### PR TITLE
fix(ci): restore deploy-allure artifact download path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,6 +289,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: allure-results
+          path: packages
       - name: Generate Allure report
         run: npm run allure:generate
       - name: Brand Allure report


### PR DESCRIPTION
## Summary
- set `deploy-allure` artifact download path to `packages`
- preserve expected directory layout for `allure:generate`

## Why
`workspace-test (20)` uploads the `allure-results` artifact with root `packages`, but `deploy-allure` was downloading to repo root. That left results under `./docx-core/...` instead of `./packages/docx-core/...`, causing `generate_allure_report.mjs` to throw `No non-empty allure-results directories found under packages/.`

## Result
`deploy-allure` can discover non-empty results and generate the report again.

Ref: #4
