### PR TITLE
fix(ci): build before lint in release preflight

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,9 @@ jobs:
           echo "npm ci failed after 3 attempts"
           exit 1
 
+      - name: Build workspaces
+        run: npm run build
+
       - name: Lint/typecheck workspaces
         run: npm run lint:workspaces
 
@@ -100,9 +103,6 @@ jobs:
             fi
             echo "$pkg@$VERSION not yet published."
           done
-
-      - name: Build workspaces
-        run: npm run build
 
       - name: Test workspaces
         run: npm run test


### PR DESCRIPTION
## Summary\n- run workspace build before lint/typecheck in release preflight\n- remove the duplicate later preflight build step\n\n## Why\nRelease preflight lint was running on a clean checkout before declarations existed for workspace packages, causing false-negative type resolution failures even when main CI was green. This aligns release ordering with CI workspace-lint behavior.\n\n## Validation\n- npm run build\n- npm run lint:workspaces\n