### PR TITLE
fix(ci): install site deps in release preflight

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,9 @@ jobs:
       - name: Regenerate and verify tool reference docs are committed
         run: npm run check:tool-docs
 
+      - name: Install site dependencies
+        run: npm --prefix site ci
+
       - name: Build site and validate internal links
         run: npm run check:site
 


### PR DESCRIPTION
Summary:\n- install site dependencies in release preflight before check:site\n\nWhy:\nRelease preflight runs npm run check:site, which calls the Eleventy build in site/. Root npm ci does not install site/package.json dependencies, so preflight failed with eleventy not found (exit 127).\n\nValidation:\n- npm run check:site\n