### PR TITLE
fix(ci): run release workflow on Node 22 for trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Use npm 11.5.1+ for OIDC trusted publishing compatibility
@@ -162,7 +162,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Use npm 11.5.1+ for OIDC trusted publishing compatibility
@@ -226,7 +226,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Use npm 11.5.1+ for OIDC trusted publishing compatibility


### PR DESCRIPTION
Summary: switch release workflow jobs from Node 20 to Node 22. Why: npm trusted publishing requires Node 22.14+; Node 20 caused publish to fail with ENEEDAUTH instead of using OIDC. Ref: #9.