### PR TITLE
fix(ci): restore registry-url in release trusted-publish workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          registry-url: https://registry.npmjs.org
           cache: npm
 
       - name: Use npm 11.5.1+ for OIDC trusted publishing compatibility
@@ -163,6 +164,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          registry-url: https://registry.npmjs.org
           cache: npm
 
       - name: Use npm 11.5.1+ for OIDC trusted publishing compatibility
@@ -227,6 +229,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          registry-url: https://registry.npmjs.org
           cache: npm
 
       - name: Use npm 11.5.1+ for OIDC trusted publishing compatibility


### PR DESCRIPTION
Summary: restore registry-url in setup-node for all release jobs. Why: release publish still fails with ENEEDAUTH, indicating trusted publishing is not being engaged; this aligns with npm's documented setup while keeping token cleanup and Node 22. Ref: #9.