### PR TITLE
chore(release): bump package suite to 0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-docx-suite",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "Monorepo for Safe DOCX packages",
   "repository": {

--- a/packages/allure-test-factory/package.json
+++ b/packages/allure-test-factory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/allure-test-factory",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Shared Allure test helpers for vitest — BDD context, OpenSpec auto-inference, Prism.js highlighting",
   "type": "module",
   "exports": {

--- a/packages/docx-core/package.json
+++ b/packages/docx-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/docx-core",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "OOXML (.docx) core library: primitives, comparison, and track changes",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/docx-mcp/package.json
+++ b/packages/docx-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/docx-mcp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Safe Docx MCP server (TypeScript)",
   "type": "module",
   "main": "dist/index.js",
@@ -26,7 +26,7 @@
     "lint": "tsc -b --pretty false"
   },
   "dependencies": {
-    "@usejunior/docx-core": "^0.1.0",
+    "@usejunior/docx-core": "^0.1.1",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "zod": "^4.3.6"
   },

--- a/packages/safe-docx-mcpb/manifest.json
+++ b/packages/safe-docx-mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "safe-docx",
   "display_name": "Safe Docx",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "AI-native Word document editing with stable paragraph anchors and deterministic DOCX operations.",
   "long_description": "Safe Docx lets Claude work directly with .docx files on your local filesystem. It provides stable paragraph IDs (jr_para_*) for precise editing while preserving formatting and structure.\n\nCore capabilities include reading/searching content, formatting-preserving edits and inserts, deterministic layout controls, tracked-changes output, comments, footnote tools, document comparison, and revision extraction.",
   "author": {
@@ -14,7 +14,9 @@
     "entry_point": "dist/index.js",
     "mcp_config": {
       "command": "node",
-      "args": ["${__dirname}/dist/index.js"]
+      "args": [
+        "${__dirname}/dist/index.js"
+      ]
     }
   },
   "tools": [
@@ -125,7 +127,11 @@
   "license": "MIT",
   "compatibility": {
     "claude_desktop": ">=0.10.0",
-    "platforms": ["darwin", "win32", "linux"],
+    "platforms": [
+      "darwin",
+      "win32",
+      "linux"
+    ],
     "runtimes": {
       "node": ">=18.0.0"
     }

--- a/packages/safe-docx-mcpb/package.json
+++ b/packages/safe-docx-mcpb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/safedocx-mcpb",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "Claude Desktop MCP Bundle (.mcpb) wrapper for @usejunior/safe-docx",
   "type": "module",
@@ -14,7 +14,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@usejunior/safe-docx": "^0.1.0"
+    "@usejunior/safe-docx": "^0.1.1"
   },
   "devDependencies": {
     "@vitest/runner": "^3.2.4",

--- a/packages/safe-docx/package.json
+++ b/packages/safe-docx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/safe-docx",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Canonical npm package for the Safe Docx MCP server and CLI",
   "type": "module",
   "main": "./index.js",
@@ -24,7 +24,7 @@
     "safedocx": "./bin/safe-docx.js"
   },
   "dependencies": {
-    "@usejunior/docx-mcp": "^0.1.0"
+    "@usejunior/docx-mcp": "^0.1.1"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/site/package.json
+++ b/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/safe-docx-site",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "description": "Safe DOCX marketing and trust site (Eleventy)",


### PR DESCRIPTION
Summary:\n- bump root and workspace package versions from 0.1.0 to 0.1.1\n- bump internal dependency ranges to ^0.1.1\n- bump packages/safe-docx-mcpb/manifest.json version to 0.1.1\n\nWhy:\nThe v0.1.0 tag points to an older commit where npm provenance verification fails due missing package metadata. Releasing from current main as 0.1.1 gives a clean provenance-valid target.\n\nValidation:\n- npm run build\n- npm run lint:workspaces\n- npm run test:run\n- npm run check:spec-coverage\n- npm run check:mcpb-manifest