### PR TITLE
ci: add changelog pipeline with release metadata and PR title enforcement

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,38 @@
+# GitHub Release note categories.
+# Controls how --generate-notes groups merged PRs into sections.
+# See: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+
+changelog:
+  exclude:
+    labels:
+      - skip-changelog
+    authors:
+      - dependabot
+      - dependabot[bot]
+
+  categories:
+    - title: Breaking Changes
+      labels:
+        - breaking
+    - title: Features
+      labels:
+        - feat
+    - title: Bug Fixes
+      labels:
+        - fix
+    - title: Performance
+      labels:
+        - perf
+    - title: Documentation
+      labels:
+        - docs
+    - title: CI / Infrastructure
+      labels:
+        - ci
+        - build
+    - title: Refactoring
+      labels:
+        - refactor
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,105 @@
+name: PR Title Lint
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches: [main]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  validate:
+    name: Validate conventional title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR title
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            refactor
+            test
+            docs
+            chore
+            ci
+            perf
+            style
+            revert
+            build
+          requireScope: false
+          subjectPattern: ^[a-z].+$
+          subjectPatternError: |
+            The subject must start with a lowercase letter.
+
+            Examples of valid PR titles:
+              feat(docx-core): add paragraph diffing
+              fix: correct bookmark cleanup order
+              chore(release): bump workspace versions
+              ci: add PR title validation
+
+  auto-label:
+    name: Apply type label from PR title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Parse title and set label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.pull_request.title;
+            const match = title.match(/^(\w+)(\(.+?\))?!?:/);
+            if (!match) {
+              core.info('PR title does not match conventional format — skipping label.');
+              return;
+            }
+
+            const type = match[1];
+            const typeLabels = [
+              'feat', 'fix', 'refactor', 'test', 'docs',
+              'chore', 'ci', 'perf', 'style', 'revert', 'build',
+            ];
+
+            if (!typeLabels.includes(type)) {
+              core.info(`Unknown type "${type}" — skipping label.`);
+              return;
+            }
+
+            // Remove any existing type labels, then apply the current one.
+            const current = context.payload.pull_request.labels.map(l => l.name);
+            const toRemove = current.filter(l => typeLabels.includes(l) && l !== type);
+
+            for (const label of toRemove) {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: label,
+              });
+            }
+
+            // Ensure the label exists (creates it if missing).
+            try {
+              await github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: type,
+              });
+            } catch {
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: type,
+                color: 'ededed',
+              });
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: [type],
+            });
+            core.info(`Applied label: ${type}`);

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,9 +240,29 @@ jobs:
             (cd "$PKG_DIR" && npm publish --access public --provenance)
           done
 
+  ensure-release:
+    name: Create or update GitHub Release
+    needs: publish-suite
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref }}
+
+      - name: Create GitHub Release with auto-generated notes
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.RELEASE_TAG }}
+          generate_release_notes: true
+
   publish-mcpb-asset:
     name: Publish safe-docx MCP bundle asset
-    needs: [preflight, publish-suite]
+    needs: [preflight, publish-suite, ensure-release]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -300,4 +320,3 @@ jobs:
             packages/safe-docx-mcpb/safe-docx.mcpb
             packages/safe-docx-mcpb/safe-docx.mcpb.sha256
           fail_on_unmatched_files: true
-          generate_release_notes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,9 @@
 # Changelog
 
-All notable changes to this repository will be documented in this file.
+This project uses [GitHub Releases](https://github.com/UseJunior/safe-docx/releases)
+as the canonical changelog. Each release is auto-categorized from PR labels.
 
-The format is based on Keep a Changelog and this project follows SemVer for published package versions.
+Browse the full history:
 
-## [Unreleased]
-
-### Added
-
-- OSS governance docs (`CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, `CODEOWNERS`).
+- **GitHub Releases:** <https://github.com/UseJunior/safe-docx/releases>
+- **Trust site changelog:** <https://safedocx.com/trust/changelog/>


### PR DESCRIPTION
## Summary
- Add `.github/release.yml` for categorized release notes (Breaking Changes, Features, Bug Fixes, etc.)
- Add `.github/workflows/pr-title.yml` for conventional commit PR title validation + auto-labeling
- Add dedicated `ensure-release` job to release workflow so GitHub Releases are created independently of MCPB asset publishing
- Convert `CHANGELOG.md` to a pointer file directing to GitHub Releases and the trust site

## Test plan
- [ ] Push a PR with non-conventional title — `pr-title` check fails with guidance
- [ ] Push a PR with `feat(site): test title` — check passes and `feat` label auto-applied
- [ ] Verify `.github/release.yml` renders category preview in GitHub UI
- [ ] Confirm `CHANGELOG.md` points to releases page