### PR TITLE
fix(site): trailing slashes, feedback link, Gemini CLI install

### DIFF
--- a/site/src/_includes/layouts/base.njk
+++ b/site/src/_includes/layouts/base.njk
@@ -63,6 +63,7 @@
       </nav>
       <div class="topbar-actions">
         <a class="gh-link" href="https://github.com/usejunior/safe-docx" target="_blank" rel="noopener">GitHub</a>
+        <a class="gh-link" href="https://github.com/usejunior/safe-docx/issues/new" target="_blank" rel="noopener">Feedback</a>
       </div>
     </header>
     <div class="shell">

--- a/site/src/assets/site.css
+++ b/site/src/assets/site.css
@@ -583,7 +583,7 @@ a {
 
 .install-cards {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: 1rem;
   margin-top: 1rem;
 }

--- a/site/src/index.njk
+++ b/site/src/index.njk
@@ -109,6 +109,16 @@ description: Deterministic DOCX operations for AI systems. Fast, safe, composabl
       </div>
     </div>
     <div class="card">
+      <h3>Gemini CLI Extension</h3>
+      <p>Install as a Gemini CLI extension:</p>
+      <div class="install-pre-wrap">
+        <pre><code>gemini extensions install https://github.com/UseJunior/safe-docx</code></pre>
+        <button class="copy-btn" data-copy="gemini extensions install https://github.com/UseJunior/safe-docx" aria-label="Copy Gemini CLI command">
+          <span class="copy-label">Copy</span>
+        </button>
+      </div>
+    </div>
+    <div class="card">
       <h3>npm</h3>
       <p>Install as a dependency:</p>
       <div class="install-pre-wrap">

--- a/site/vercel.json
+++ b/site/vercel.json
@@ -4,7 +4,7 @@
   "buildCommand": "npm run build",
   "outputDirectory": "_site",
   "cleanUrls": true,
-  "trailingSlash": false,
+  "trailingSlash": true,
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## Summary
- Enable `trailingSlash: true` in `vercel.json` — fixes broken relative links on `/trust` page (traceability, changelog links were resolving against root instead of `/trust/`)
- Add Feedback link to topbar (→ GitHub Issues), matching open-agreements site
- Add Gemini CLI extension install card: `gemini extensions install https://github.com/UseJunior/safe-docx`
- Update install grid to responsive 3-column layout

## Test plan
- [x] Site builds cleanly
- [x] Internal link check passes (72 refs, 5 files)
- [x] Trust page links resolve correctly with trailing slash