### PR TITLE
fix(docx-mcp): eliminate flaky MRU session test

### DIFF
--- a/packages/docx-mcp/src/session/manager.test.ts
+++ b/packages/docx-mcp/src/session/manager.test.ts
@@ -126,8 +126,8 @@ describe('SessionManager.getMostRecentlyUsedSessionForPath', () => {
     const s1 = await mgr.createSession(buf, 'test.docx', '/tmp/test.docx');
     const s2 = await mgr.createSession(buf, 'test.docx', '/tmp/test.docx');
 
-    // Touch s2 to make it most recent
-    mgr.touch(s2);
+    // Guarantee s2 has a strictly later timestamp (wall clock may not advance between calls)
+    s2.lastAccessedAt = new Date(s1.lastAccessedAt.getTime() + 1);
 
     const normalized = mgr.normalizePath('/tmp/test.docx');
     const found = mgr.getMostRecentlyUsedSessionForPath(normalized);


### PR DESCRIPTION
## Summary

- Fix flaky `selects most recently accessed among multiple sessions` test in `manager.test.ts`
- Root cause: `mgr.touch(s2)` could execute in the same millisecond as `createSession(s2)`, leaving both sessions with identical `lastAccessedAt` timestamps and non-deterministic sort order
- Fix: directly set `s2.lastAccessedAt` to `s1.lastAccessedAt + 1ms` instead of relying on wall-clock advancement
- Verified with 5 consecutive runs locally

## Test plan

- [ ] `workspace-test (20)` passes (the matrix entry that was failing)
- [ ] `workspace-test (22)` passes