### PR TITLE
fix(docx-mcp): capture comparison baselines on auto-opened sessions

### DIFF
--- a/packages/docx-mcp/src/session/manager.ts
+++ b/packages/docx-mcp/src/session/manager.ts
@@ -132,6 +132,32 @@ export class SessionManager {
     return session;
   }
 
+  /**
+   * Finalize a newly created session by normalizing the document, inserting
+   * paragraph bookmarks, and capturing post-normalization comparison baselines.
+   *
+   * INVARIANT: All production session creation paths must call
+   * `finalizeNewSession` before returning a session. `createSession` alone
+   * leaves baselines null and is incomplete for tool use.
+   */
+  async finalizeNewSession(
+    session: Session,
+    opts?: { skipNormalization?: boolean },
+  ): Promise<{ normalizationStats: NormalizationResult | null; paragraphCount: number }> {
+    if (!opts?.skipNormalization) {
+      session.normalizationStats = session.doc.normalize();
+    }
+    const info = session.doc.insertParagraphBookmarks(`mcp_${session.sessionId}`);
+    const [cleanBaseline, bookmarkedBaseline] = await Promise.all([
+      session.doc.toBuffer({ cleanBookmarks: true }),
+      session.doc.toBuffer({ cleanBookmarks: false }),
+    ]);
+    session.comparisonBaseline = cleanBaseline.buffer;
+    session.comparisonBaselineWithBookmarks = bookmarkedBaseline.buffer;
+    this.touch(session);
+    return { normalizationStats: session.normalizationStats, paragraphCount: info.paragraphCount };
+  }
+
   getSession(sessionId: string): Session {
     if (!SessionManager.SESSION_ID_PATTERN.test(sessionId)) {
       throw new Error(`INVALID_SESSION_ID:${sessionId}`);

--- a/packages/docx-mcp/src/tools/open_document.ts
+++ b/packages/docx-mcp/src/tools/open_document.ts
@@ -72,31 +72,16 @@ export async function openDocument(
     const filename = path.basename(safePath);
     const session = await manager.createSession(content as Buffer, filename, safePath);
 
-    // Normalize: merge runs + simplify redlines BEFORE bookmark allocation.
-    if (!params.skip_normalization) {
-      session.normalizationStats = session.doc.normalize();
-    }
+    const { paragraphCount } = await manager.finalizeNewSession(session, {
+      skipNormalization: params.skip_normalization,
+    });
 
-    // Insert paragraph bookmarks for stable paragraph ids.
-    const info = session.doc.insertParagraphBookmarks(`mcp_${session.sessionId}`);
-
-    // Compute comparison baselines AFTER normalization + bookmark insertion.
-    // These baselines are used for tracked-changes comparison instead of originalBuffer,
-    // preventing normalization artifacts from appearing as false tracked changes.
-    const [cleanBaseline, bookmarkedBaseline] = await Promise.all([
-      session.doc.toBuffer({ cleanBookmarks: true }),
-      session.doc.toBuffer({ cleanBookmarks: false }),
-    ]);
-    session.comparisonBaseline = cleanBaseline.buffer;
-    session.comparisonBaselineWithBookmarks = bookmarkedBaseline.buffer;
-
-    manager.touch(session);
     return ok({
       session_id: session.sessionId,
       expires_at: session.expiresAt.toISOString(),
       document: {
         filename,
-        paragraphs: info.paragraphCount,
+        paragraphs: paragraphCount,
         size_bytes: content.length,
       },
       normalization: session.normalizationStats

--- a/packages/docx-mcp/src/tools/session_resolution.ts
+++ b/packages/docx-mcp/src/tools/session_resolution.ts
@@ -216,12 +216,7 @@ export async function resolveSessionForTool(
     loaded.normalizedPath,
   );
 
-  // Normalize: merge runs + simplify redlines BEFORE bookmark allocation.
-  session.normalizationStats = session.doc.normalize();
-
-  // Backfill missing intrinsic paragraph IDs before first read/edit.
-  session.doc.insertParagraphBookmarks(`mcp_${session.sessionId}`);
-  manager.touch(session);
+  await manager.finalizeNewSession(session);
 
   return {
     ok: true,

--- a/packages/docx-mcp/src/tools/session_resolution_baseline.test.ts
+++ b/packages/docx-mcp/src/tools/session_resolution_baseline.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect } from 'vitest';
+import { itAllure as it } from '../testing/allure-test.js';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import { resolveSessionForTool } from './session_resolution.js';
+import { save } from './save.js';
+import { compareDocuments_tool } from './compare_documents.js';
+import { createTestSessionManager, createTrackedTempDir, registerCleanup } from '../testing/session-test-utils.js';
+import { makeDocxWithDocumentXml } from '../testing/docx_test_utils.js';
+
+/**
+ * Regression tests for comparison baseline capture during auto-open
+ * (session_resolution path).
+ *
+ * Before this fix, resolveSessionForTool normalized the document and inserted
+ * bookmarks but never captured post-normalization baselines. This caused the
+ * atomizer to treat every merged run as a tracked change.
+ */
+
+const CONTENT_TYPES_XML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>`;
+
+const RELS_XML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>`;
+
+const FRAGMENTED_RUNS_XML =
+  `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+  `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
+  `<w:body>` +
+  `<w:p><w:r><w:t>By</w:t></w:r><w:r><w:t>laws</w:t></w:r></w:p>` +
+  `<w:p><w:r><w:t>Amend</w:t></w:r><w:r><w:t>ment</w:t></w:r></w:p>` +
+  `</w:body></w:document>`;
+
+async function createFragmentedDoc(dir: string, name = 'fragmented.docx'): Promise<string> {
+  const filePath = path.join(dir, name);
+  const buf = await makeDocxWithDocumentXml(FRAGMENTED_RUNS_XML, {
+    '[Content_Types].xml': CONTENT_TYPES_XML,
+    '_rels/.rels': RELS_XML,
+  });
+  await fs.writeFile(filePath, new Uint8Array(buf));
+  return filePath;
+}
+
+describe('auto-open baseline capture regression', () => {
+  registerCleanup();
+
+  it('save(tracked) produces zero changes after auto-open of fragmented-runs doc', async () => {
+    const mgr = createTestSessionManager();
+    const tmpDir = await createTrackedTempDir('safe-docx-baseline-save-');
+    const inputPath = await createFragmentedDoc(tmpDir);
+    const savePath = path.join(tmpDir, 'output.docx');
+    const trackedPath = path.join(tmpDir, 'output.tracked.docx');
+
+    // Auto-open via file_path (the session_resolution path)
+    const resolved = await resolveSessionForTool(mgr, { file_path: inputPath }, { toolName: 'save' });
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok) return;
+    expect(resolved.metadata.session_resolution).toBe('opened_new_session');
+
+    // Save with tracked changes — no edits were made
+    const result = await save(mgr, {
+      session_id: resolved.session.sessionId,
+      save_to_local_path: savePath,
+      save_format: 'tracked',
+      tracked_save_to_local_path: trackedPath,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    // The key assertion: zero tracked changes because baseline was captured
+    // post-normalization, so merged runs don't appear as diffs.
+    const stats = (result as Record<string, unknown>).tracked_changes_stats as
+      | { insertions: number; deletions: number; modifications: number }
+      | undefined;
+    if (stats) {
+      expect(stats.insertions).toBe(0);
+      expect(stats.deletions).toBe(0);
+      expect(stats.modifications).toBe(0);
+    }
+  });
+
+  it('compare_documents(session mode) produces zero changes after auto-open', async () => {
+    const mgr = createTestSessionManager();
+    const tmpDir = await createTrackedTempDir('safe-docx-baseline-compare-');
+    const inputPath = await createFragmentedDoc(tmpDir);
+    const comparePath = path.join(tmpDir, 'compared.docx');
+
+    // Auto-open via file_path
+    const resolved = await resolveSessionForTool(mgr, { file_path: inputPath }, { toolName: 'compare_documents' });
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok) return;
+
+    // Compare without edits (session mode)
+    const result = await compareDocuments_tool(mgr, {
+      session_id: resolved.session.sessionId,
+      save_to_local_path: comparePath,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    const stats = (result as Record<string, unknown>).stats as
+      | { insertions: number; deletions: number; modifications: number }
+      | undefined;
+    if (stats) {
+      expect(stats.insertions).toBe(0);
+      expect(stats.deletions).toBe(0);
+      expect(stats.modifications).toBe(0);
+    }
+  });
+
+  it('finalizeNewSession sets non-null baselines on auto-opened session', async () => {
+    const mgr = createTestSessionManager();
+    const tmpDir = await createTrackedTempDir('safe-docx-baseline-unit-');
+    const inputPath = await createFragmentedDoc(tmpDir);
+
+    const resolved = await resolveSessionForTool(mgr, { file_path: inputPath }, { toolName: 'read_file' });
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok) return;
+
+    const session = resolved.session;
+    expect(session.comparisonBaseline).not.toBeNull();
+    expect(session.comparisonBaselineWithBookmarks).not.toBeNull();
+    expect(Buffer.isBuffer(session.comparisonBaseline)).toBe(true);
+    expect(Buffer.isBuffer(session.comparisonBaselineWithBookmarks)).toBe(true);
+    expect(session.comparisonBaseline!.length).toBeGreaterThan(0);
+    expect(session.comparisonBaselineWithBookmarks!.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

- **Bug**: When a document was auto-opened via `read_file` with `file_path` (the `session_resolution.ts` path), normalization and bookmarks were applied but `comparisonBaseline` and `comparisonBaselineWithBookmarks` were never captured — both stayed `null`
- **Impact**: `save(tracked)` and `compare_documents` (session mode) fell back to the pre-normalization `originalBuffer`, causing the atomizer to treat every merged XML run as a tracked change (e.g. dozens of spurious "Bylaws" → "Bylaws" diffs from just 2 real edits)
- **Fix**: Consolidate normalization, bookmark insertion, and baseline capture into `SessionManager.finalizeNewSession()` and call it from both `open_document.ts` and `session_resolution.ts`
- Patch coverage: 92.9% statements, 92.9% branch, 96.4% functions across all 3 changed files

## Test plan

- [x] New `session_resolution_baseline.test.ts` — 3 regression tests:
  - `save(tracked)` produces 0 insertions/deletions/modifications after auto-open of fragmented-runs doc
  - `compare_documents` (session mode) produces 0 tracked changes after auto-open
  - `finalizeNewSession` sets non-null Buffer baselines on auto-opened session
- [x] All 58 tests pass across the 6 affected test files (`manager.test.ts`, `open_document.test.ts`, `session_resolution.test.ts`, `save.test.ts`, `compare_documents.test.ts`, + new baseline test)
- [ ] CI passes