### PR TITLE
chore(release): bump mcpb manifest version to 0.3.0

### DIFF
--- a/packages/safe-docx-mcpb/manifest.json
+++ b/packages/safe-docx-mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "safe-docx",
   "display_name": "Safe Docx",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "AI-native Word document editing with stable paragraph anchors and deterministic DOCX operations.",
   "long_description": "Safe Docx lets Claude work directly with .docx files on your local filesystem. It provides stable paragraph IDs (jr_para_*) for precise editing while preserving formatting and structure.\n\nCore capabilities include reading/searching content, formatting-preserving edits and inserts, deterministic layout controls, tracked-changes output, comments, footnote tools, document comparison, and revision extraction.",
   "author": {


### PR DESCRIPTION
## Summary
- Bump `packages/safe-docx-mcpb/manifest.json` version from `0.2.0` to `0.3.0`
- Required for release workflow tag-version validation

## Test plan
- [ ] Release workflow `Verify tag matches package suite versions` step passes