### PR TITLE
feat(site): format release notes with grouped conventional commit categories

### DIFF
--- a/site/.eleventy.js
+++ b/site/.eleventy.js
@@ -1,6 +1,7 @@
 import MarkdownIt from 'markdown-it';
 
 const md = new MarkdownIt({ html: true, linkify: true });
+const mdSafe = new MarkdownIt({ html: false, linkify: false });
 
 function normalizePageUrl(value) {
   if (!value || value === '/') {
@@ -30,6 +31,126 @@ function rootPrefixForUrl(value) {
   return depth === 0 ? './' : '../'.repeat(depth);
 }
 
+// Matches a conventional-commit PR line from GitHub release notes:
+//   * type(scope): title by @author in https://...
+const PR_LINE_RE =
+  /^\*\s+(?<type>[a-z]+)(?:\((?<scope>[^)]+)\))?!?:\s+(?<title>.+?)\s+by\s+@\S+\s+in\s+https?:\/\/\S+\/pull\/(?<num>\d+)\s*$/;
+
+const TYPE_LABELS = {
+  feat: 'Features',
+  fix: 'Bug Fixes',
+  chore: 'Chores',
+  refactor: 'Refactoring',
+  ci: 'CI / Infrastructure',
+  docs: 'Documentation',
+  test: 'Tests',
+  perf: 'Performance',
+  style: 'Style',
+  build: 'Build',
+};
+
+function formatReleaseNotes(content) {
+  if (!content) return '';
+  const lines = String(content).split('\n');
+
+  // Grouped entries: Map<label, [{scope, title, num}]>
+  const groups = new Map();
+  // Lines that don't fit the structured format
+  const customSections = [];
+
+  let inWhatsChanged = false;
+  let skipSection = false; // true while inside a ### sub-heading of What's Changed
+  let inCustomSection = false; // true while collecting custom (non-### inside What's Changed) lines
+  let hasUnrecognised = false;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    // Skip full-changelog footer
+    if (trimmed.startsWith('**Full Changelog**')) continue;
+
+    // Top-level ## heading
+    if (trimmed.startsWith('## ')) {
+      if (trimmed === '## What\'s Changed') {
+        inWhatsChanged = true;
+        skipSection = false;
+        inCustomSection = false;
+      } else {
+        inWhatsChanged = false;
+        skipSection = false;
+        inCustomSection = true;
+        customSections.push(line);
+      }
+      continue;
+    }
+
+    if (inWhatsChanged) {
+      // ### sub-headings inside What's Changed are redundant once we group
+      if (trimmed.startsWith('### ')) {
+        skipSection = false; // reset per-subsection
+        continue;
+      }
+
+      if (skipSection) continue;
+
+      if (!trimmed) continue; // blank line
+
+      const m = PR_LINE_RE.exec(trimmed);
+      if (m) {
+        const { type, scope, title, num } = m.groups;
+        const label = TYPE_LABELS[type] ?? (type.charAt(0).toUpperCase() + type.slice(1));
+        if (!groups.has(label)) groups.set(label, []);
+        groups.get(label).push({ scope: scope ?? null, title, num });
+      } else {
+        // Unrecognised line inside What's Changed — treat as custom
+        customSections.push(line);
+        hasUnrecognised = true;
+      }
+      continue;
+    }
+
+    if (inCustomSection) {
+      customSections.push(line);
+    }
+  }
+
+  const parts = [];
+
+  if (hasUnrecognised) {
+    parts.push('<div class="cl-warning">Some entries could not be parsed and are shown below.</div>');
+  }
+
+  for (const [label, entries] of groups) {
+    const items = entries
+      .map(({ scope, title, num }) => {
+        const scopeHtml = scope ? ` <span class="cl-scope">${escHtml(scope)}</span>` : '';
+        const safeTitle = mdSafe.renderInline(title);
+        return `<li>${safeTitle}${scopeHtml} <span class="cl-pr">#${num}</span></li>`;
+      })
+      .join('\n');
+    parts.push(
+      `<div class="cl-group"><span class="cl-type-label">${escHtml(label)}</span><ul class="cl-entries">${items}</ul></div>`
+    );
+  }
+
+  if (customSections.length) {
+    const customMd = customSections.join('\n').trim();
+    if (customMd) {
+      parts.push(md.render(customMd));
+    }
+  }
+
+  return parts.join('\n');
+}
+
+function escHtml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
 export default function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy({ 'src/assets': 'assets' });
   eleventyConfig.addFilter('rootPrefix', (pageUrl) => rootPrefixForUrl(pageUrl));
@@ -42,6 +163,7 @@ export default function (eleventyConfig) {
     if (!content) return '';
     return md.render(String(content));
   });
+  eleventyConfig.addFilter('formatReleaseNotes', formatReleaseNotes);
 
   return {
     dir: {

--- a/site/src/_raw/changelog.json
+++ b/site/src/_raw/changelog.json
@@ -1,6 +1,15 @@
 {
-  "generated_at_utc": "2026-03-04T07:48:07.783Z",
+  "generated_at_utc": "2026-03-06T22:28:30.153Z",
   "releases": [
+    {
+      "version": "0.1.0",
+      "tag": "v0.1.0",
+      "title": "v0.1.0",
+      "published_at": "2026-03-06T20:27:07Z",
+      "url": "https://github.com/UseJunior/safe-docx/releases/tag/v0.1.0",
+      "body_md": "## What's Changed\n* feat!: merge docx-primitives + docx-comparison into @usejunior/docx-core by @stevenobiajulu in https://github.com/UseJunior/safe-docx/pull/2\n* fix(docx-core): pre-split mixed-status inplace runs + publish wiring by @stevenobiajulu in https://github.com/UseJunior/safe-docx/pull/3\n* ci(safe-docx): harden npm installs with retry backoff by @stevenobiajulu in https://github.com/UseJunior/safe-docx/pull/4\n* fix(ci): restore deploy-allure artifact download path by @stevenobiajulu in https://github.com/UseJunior/safe-docx/pull/5\n\n\n**Full Changelog**: https://github.com/UseJunior/safe-docx/commits/v0.1.0",
+      "assets": []
+    },
     {
       "version": "0.3.0",
       "tag": "v0.3.0",

--- a/site/src/trust/changelog.njk
+++ b/site/src/trust/changelog.njk
@@ -72,6 +72,60 @@ description: Release history for Safe DOCX, auto-generated from GitHub Releases.
     margin-top: 1.6rem;
     font-size: 0.92rem;
   }
+
+  /* Grouped release notes */
+  .cl-warning {
+    background: color-mix(in srgb, var(--accent-soft) 12%, white);
+    border-left: 3px solid var(--accent);
+    padding: 10px 14px;
+    margin: 0 0 16px;
+    font-size: 0.88rem;
+    color: var(--ink);
+  }
+  .cl-group {
+    display: grid;
+    grid-template-columns: 130px 1fr;
+    gap: 4px 12px;
+    align-items: start;
+    margin: 5px 0;
+  }
+  .cl-type-label {
+    color: var(--ink-soft);
+    font-size: 0.76rem;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    padding-top: 3px;
+    white-space: nowrap;
+  }
+  .cl-entries {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+  .cl-entries li {
+    margin: 2px 0;
+    font-size: 0.9rem;
+    padding-left: 14px;
+    position: relative;
+  }
+  .cl-entries li::before {
+    content: "•";
+    position: absolute;
+    left: 0;
+    color: var(--ink-soft);
+  }
+  .cl-scope {
+    color: var(--ink-soft);
+    font-size: 0.84rem;
+  }
+  .cl-scope::before { content: "("; }
+  .cl-scope::after  { content: ")"; }
+  .cl-pr {
+    color: var(--ink-soft);
+    font-size: 0.82rem;
+    font-family: monospace;
+  }
 </style>
 
 <section class="hero">
@@ -91,7 +145,7 @@ description: Release history for Safe DOCX, auto-generated from GitHub Releases.
       <time datetime="{{ release.published_at }}">{{ release.published_display }}</time>
     </div>
     <div class="changelog-body">
-      {{ release.body_md | renderMarkdown | safe }}
+      {{ release.body_md | formatReleaseNotes | safe }}
     </div>
     {% if release.assets.length %}
     <div class="changelog-assets">


### PR DESCRIPTION
Ports the `formatReleaseNotes` Eleventy filter from open-agreements (PR #92) to safe-docx.

- Strips `## What's Changed`, `**Full Changelog**`, author handles, full PR URLs, and `### Features`/`### Bug Fixes` subheadings
- Groups entries by conventional commit type with `.cl-*` CSS (two-column grid, type labels, scopes, short #N PR refs)
- CSS uses existing site palette tokens — no new variables introduced
- Creates missing v0.1.0 GitHub Release and commits refreshed `_raw/changelog.json` (5 releases total)
- Build verified locally; pre-submit checks (build, lint, test, spec-coverage) all pass