### PR TITLE
feat(docx-mcp): add MCP Apps preview with zero-residue isolation

### DIFF
--- a/packages/docx-mcp/package.json
+++ b/packages/docx-mcp/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "clean:dist": "node -e \"const { rmSync } = require('node:fs'); rmSync('dist', { recursive: true, force: true });\"",
-    "build": "npm run build -w @usejunior/docx-core &&npm run clean:dist && tsc -p tsconfig.build.json",
+    "build": "npm run build -w @usejunior/docx-core &&npm run clean:dist && tsc -p tsconfig.build.json && if [ -d src/app ]; then mkdir -p dist/app && cp src/app/*.html dist/app/; fi",
     "dev": "tsx watch src/cli.ts",
     "check:spec-coverage": "node scripts/validate_openspec_coverage.mjs",
     "conformance:discover": "tsx scripts/discover_docx_fixtures.ts --out conformance/discovery.report.json",

--- a/packages/docx-mcp/src/app/app_tools.ts
+++ b/packages/docx-mcp/src/app/app_tools.ts
@@ -1,0 +1,45 @@
+import { z } from 'zod';
+
+type ToolMeta = {
+  ui?: {
+    resourceUri: string;
+    visibility?: Array<'model' | 'app'>;
+  };
+};
+
+const SESSION_OR_FILE_FIELDS = {
+  session_id: z.string().optional(),
+  file_path: z.string().optional(),
+};
+
+const GET_DOCUMENT_VIEW_ENTRY = {
+  name: 'get_document_view' as const,
+  description:
+    'Get full document view as structured nodes with styles, formatting, and metadata. Returns DocumentViewNode[] for the interactive preview app. Hidden from LLM — only callable by the preview app.',
+  input: z.object({
+    ...SESSION_OR_FILE_FIELDS,
+  }),
+  annotations: { readOnlyHint: true, destructiveHint: false },
+  _meta: {
+    ui: {
+      resourceUri: 'ui://safe-docx/preview',
+      visibility: ['app'],
+    },
+  } satisfies ToolMeta,
+};
+
+function toJsonObjectSchema(schema: z.ZodTypeAny, name: string): Record<string, unknown> {
+  const jsonSchema = z.toJSONSchema(schema);
+  if (typeof jsonSchema !== 'object' || Array.isArray(jsonSchema) || jsonSchema === null) {
+    throw new Error(`Expected JSON schema object for tool '${name}'.`);
+  }
+  return jsonSchema as Record<string, unknown>;
+}
+
+export const GET_DOCUMENT_VIEW_TOOL = {
+  name: GET_DOCUMENT_VIEW_ENTRY.name,
+  description: GET_DOCUMENT_VIEW_ENTRY.description,
+  inputSchema: toJsonObjectSchema(GET_DOCUMENT_VIEW_ENTRY.input, GET_DOCUMENT_VIEW_ENTRY.name),
+  annotations: GET_DOCUMENT_VIEW_ENTRY.annotations,
+  _meta: GET_DOCUMENT_VIEW_ENTRY._meta,
+};

--- a/packages/docx-mcp/src/app/get_document_view.ts
+++ b/packages/docx-mcp/src/app/get_document_view.ts
@@ -1,0 +1,46 @@
+import { SessionManager } from '../session/manager.js';
+import { errorMessage } from '../error_utils.js';
+import { err, ok, type ToolResponse } from '../tools/types.js';
+import { mergeSessionResolutionMetadata, resolveSessionForTool } from '../tools/session_resolution.js';
+
+export async function getDocumentView(
+  manager: SessionManager,
+  params: { session_id?: string; file_path?: string },
+): Promise<ToolResponse> {
+  try {
+    const resolved = await resolveSessionForTool(manager, params, { toolName: 'get_document_view' });
+    if (!resolved.ok) return resolved.response;
+    const { session, metadata } = resolved;
+
+    const { nodes, styles } = session.doc.buildDocumentView({
+      includeSemanticTags: true,
+      showFormatting: true,
+    });
+
+    const stylesObj: Record<string, unknown> = {};
+    for (const [id, info] of styles.styles) {
+      stylesObj[id] = {
+        style_id: info.style_id,
+        display_name: info.display_name,
+        fingerprint: info.fingerprint,
+        count: info.count,
+        dominant_alignment: info.dominant_alignment,
+      };
+    }
+
+    return ok(
+      mergeSessionResolutionMetadata(
+        {
+          session_id: session.sessionId,
+          edit_revision: session.editRevision,
+          nodes,
+          styles: stylesObj,
+        },
+        metadata,
+      ),
+    );
+  } catch (e: unknown) {
+    const msg = errorMessage(e);
+    return err('VIEW_ERROR', msg, 'Check session status and try again.');
+  }
+}

--- a/packages/docx-mcp/src/app/mcp-app-resources.ts
+++ b/packages/docx-mcp/src/app/mcp-app-resources.ts
@@ -20,12 +20,19 @@ type DispatchFn = (
   args: Record<string, unknown>,
 ) => Promise<Record<string, unknown>>;
 
-export function registerPreviewApp(
-  server: Server,
-  sessions: SessionManager,
-  coreTools: ReadonlyArray<Record<string, unknown>>,
-  coreDispatch: DispatchFn,
-): void {
+type RegisterPreviewAppOptions = {
+  server: Server;
+  sessions: SessionManager;
+  coreTools: ReadonlyArray<Record<string, unknown>>;
+  coreDispatch: DispatchFn;
+};
+
+export function registerPreviewApp({
+  server,
+  sessions,
+  coreTools,
+  coreDispatch,
+}: RegisterPreviewAppOptions): void {
   // Register resource capability (removed when this module is removed)
   server.registerCapabilities({ resources: {} });
 
@@ -40,7 +47,7 @@ export function registerPreviewApp(
     const args = (req.params.arguments ?? {}) as Record<string, unknown>;
 
     const result =
-      name === 'get_document_view'
+      name === GET_DOCUMENT_VIEW_TOOL.name
         ? await getDocumentView(sessions, args as Parameters<typeof getDocumentView>[1])
         : await coreDispatch(sessions, name, args);
 

--- a/packages/docx-mcp/src/app/mcp-app-resources.ts
+++ b/packages/docx-mcp/src/app/mcp-app-resources.ts
@@ -1,0 +1,80 @@
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  ListResourcesRequestSchema,
+  ReadResourceRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+
+import { SessionManager } from '../session/manager.js';
+import { getPreviewHtml } from './preview-html.js';
+import { getDocumentView } from './get_document_view.js';
+import { GET_DOCUMENT_VIEW_TOOL } from './app_tools.js';
+
+export const PREVIEW_RESOURCE_URI = 'ui://safe-docx/preview';
+export const PREVIEW_MIME_TYPE = 'text/html;profile=mcp-app';
+
+type DispatchFn = (
+  sessions: SessionManager,
+  name: string,
+  args: Record<string, unknown>,
+) => Promise<Record<string, unknown>>;
+
+export function registerPreviewApp(
+  server: Server,
+  sessions: SessionManager,
+  coreTools: ReadonlyArray<Record<string, unknown>>,
+  coreDispatch: DispatchFn,
+): void {
+  // Register resource capability (removed when this module is removed)
+  server.registerCapabilities({ resources: {} });
+
+  // Override ListTools to include the preview-only tool
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: [...coreTools, GET_DOCUMENT_VIEW_TOOL],
+  }));
+
+  // Override CallTool to handle get_document_view, delegating everything else
+  server.setRequestHandler(CallToolRequestSchema, async (req) => {
+    const { name } = req.params;
+    const args = (req.params.arguments ?? {}) as Record<string, unknown>;
+
+    const result =
+      name === 'get_document_view'
+        ? await getDocumentView(sessions, args as Parameters<typeof getDocumentView>[1])
+        : await coreDispatch(sessions, name, args);
+
+    return {
+      content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+    };
+  });
+
+  // ListResources handler
+  server.setRequestHandler(ListResourcesRequestSchema, async () => ({
+    resources: [
+      {
+        uri: PREVIEW_RESOURCE_URI,
+        name: 'Document Preview',
+        description: 'Interactive Word-like document preview with inline editing',
+        mimeType: PREVIEW_MIME_TYPE,
+      },
+    ],
+  }));
+
+  // ReadResource handler
+  server.setRequestHandler(ReadResourceRequestSchema, async (req) => {
+    const { uri } = req.params;
+    if (uri !== PREVIEW_RESOURCE_URI) {
+      throw new Error(`Unknown resource: ${uri}`);
+    }
+    return {
+      contents: [
+        {
+          uri: PREVIEW_RESOURCE_URI,
+          mimeType: PREVIEW_MIME_TYPE,
+          text: getPreviewHtml(),
+        },
+      ],
+    };
+  });
+}

--- a/packages/docx-mcp/src/app/preview-html.ts
+++ b/packages/docx-mcp/src/app/preview-html.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+let _cached: string | null = null;
+
+export function getPreviewHtml(): string {
+  if (_cached) return _cached;
+  _cached = readFileSync(join(__dirname, 'preview.html'), 'utf-8');
+  return _cached;
+}

--- a/packages/docx-mcp/src/app/preview.html
+++ b/packages/docx-mcp/src/app/preview.html
@@ -1,0 +1,501 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Document Preview</title>
+<style>
+  :root {
+    --bg: #f0f0f0;
+    --page-bg: #fff;
+    --text: #1a1a1a;
+    --border: #d0d0d0;
+    --shadow: rgba(0,0,0,0.12);
+    --accent: #2563eb;
+    --error-bg: #fef2f2;
+    --error-text: #dc2626;
+    --insert-bg: #dcfce7;
+    --delete-bg: #fce7e7;
+    --heading1-size: 24pt;
+    --heading2-size: 18pt;
+    --heading3-size: 14pt;
+    --body-size: 11pt;
+  }
+
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+
+  body {
+    font-family: 'Calibri', 'Segoe UI', system-ui, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.5;
+  }
+
+  .toolbar {
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    background: var(--page-bg);
+    border-bottom: 1px solid var(--border);
+    padding: 8px 16px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    font-size: 13px;
+  }
+
+  .toolbar-title {
+    font-weight: 600;
+    flex: 1;
+  }
+
+  .toolbar button {
+    background: var(--accent);
+    color: #fff;
+    border: none;
+    padding: 4px 12px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 12px;
+  }
+
+  .toolbar button:hover { opacity: 0.9; }
+
+  .toolbar .status {
+    font-size: 11px;
+    color: #666;
+  }
+
+  .page {
+    max-width: 8.5in;
+    margin: 24px auto;
+    padding: 1in;
+    background: var(--page-bg);
+    box-shadow: 0 1px 4px var(--shadow);
+    min-height: 11in;
+  }
+
+  .para {
+    outline: none;
+    padding: 2px 4px;
+    border-radius: 2px;
+    transition: background 0.15s;
+    margin-bottom: 0;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+  }
+
+  .para:focus {
+    background: #f8fafc;
+    box-shadow: inset 0 0 0 1px var(--accent);
+  }
+
+  .para.error {
+    background: var(--error-bg);
+  }
+
+  .para .list-label {
+    font-weight: 600;
+    margin-right: 0.5em;
+    user-select: none;
+  }
+
+  .para .header-text {
+    font-weight: 700;
+  }
+
+  /* Style mappings */
+  .style-heading, .style-Heading1 { font-size: var(--heading1-size); font-weight: 700; margin-top: 16pt; margin-bottom: 8pt; }
+  .style-heading_1, .style-Heading2 { font-size: var(--heading2-size); font-weight: 700; margin-top: 14pt; margin-bottom: 6pt; }
+  .style-heading_2, .style-Heading3 { font-size: var(--heading3-size); font-weight: 700; margin-top: 12pt; margin-bottom: 4pt; }
+  .style-body, .style-Normal { font-size: var(--body-size); margin-top: 0; margin-bottom: 6pt; }
+
+  .align-LEFT { text-align: left; }
+  .align-CENTER { text-align: center; }
+  .align-RIGHT { text-align: right; }
+  .align-JUSTIFY { text-align: justify; }
+
+  mark, highlighting { background: #fef08a; }
+
+  .error-badge {
+    display: inline-block;
+    background: var(--error-text);
+    color: #fff;
+    font-size: 10px;
+    padding: 1px 6px;
+    border-radius: 8px;
+    margin-left: 8px;
+    cursor: pointer;
+  }
+
+  .loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 200px;
+    color: #666;
+    font-size: 14px;
+  }
+</style>
+</head>
+<body>
+
+<div class="toolbar">
+  <span class="toolbar-title">Document Preview</span>
+  <span class="status" id="status">Loading...</span>
+  <button id="refreshBtn" title="Refresh document view">Refresh</button>
+</div>
+
+<div class="page" id="page">
+  <div class="loading" id="loading">Loading document...</div>
+</div>
+
+<script type="module">
+// ── App initialization ──────────────────────────────────────────────
+
+let app;
+let sessionId = null;
+let filePath = null;
+let editRevision = 0;
+const originalTexts = new Map();
+let nodes = [];
+
+async function initApp() {
+  try {
+    const mod = await import('https://esm.sh/@modelcontextprotocol/ext-apps@1.2.0/app-with-deps');
+    const App = mod.App || mod.default;
+    app = new App(
+      { name: 'safe-docx-preview', version: '0.3.0' },
+      {},
+    );
+
+    app.ontoolinput = (input) => {
+      const args = input?.arguments || input?.args || input || {};
+      if (args.session_id) sessionId = args.session_id;
+      if (args.file_path) filePath = args.file_path;
+      // Auto-fetch as soon as we have either identifier
+      if (sessionId || filePath) fetchDocumentView();
+    };
+
+    app.ontoolresult = (result) => {
+      try {
+        const data = typeof result === 'string' ? JSON.parse(result) : result;
+        if (data?.nodes) {
+          handleViewData(data);
+        }
+      } catch { /* ignore parse errors */ }
+    };
+
+    app.onhostcontextchanged = () => {
+      if (typeof app.applyHostStyleVariables === 'function') {
+        app.applyHostStyleVariables();
+      }
+    };
+
+    await app.connect();
+    setStatus('Connected');
+
+    // If we got session_id or file_path from tool input, fetch view data
+    if (sessionId || filePath) {
+      await fetchDocumentView();
+    } else {
+      // Wait a moment for tool input notification, then show status
+      setTimeout(async () => {
+        if (nodes.length === 0) {
+          setStatus('No session — waiting for tool input...');
+        }
+      }, 3000);
+    }
+  } catch (e) {
+    console.error('App init error:', e);
+    setStatus('Error: ' + e.message);
+    showError('Failed to initialize MCP App connection. ' + e.message);
+  }
+}
+
+async function fetchDocumentView() {
+  if (!app) return;
+  setStatus('Fetching...');
+  try {
+    const args = {};
+    if (sessionId) args.session_id = sessionId;
+    else if (filePath) args.file_path = filePath;
+    const result = await app.callServerTool({
+      name: 'get_document_view',
+      arguments: args,
+    });
+    const data = parseToolResult(result);
+    if (data?.nodes) {
+      handleViewData(data);
+    } else if (data?.error) {
+      showError(data.error.message || 'Failed to fetch document view');
+    }
+  } catch (e) {
+    console.error('Fetch error:', e);
+    setStatus('Fetch error');
+    showError('Failed to fetch: ' + e.message);
+  }
+}
+
+function parseToolResult(result) {
+  if (!result) return null;
+  // Tool results come as content blocks
+  if (result.content) {
+    for (const block of result.content) {
+      if (block.type === 'text' && block.text) {
+        try { return JSON.parse(block.text); } catch { /* continue */ }
+      }
+    }
+  }
+  // Direct object
+  if (result.nodes) return result;
+  if (typeof result === 'string') {
+    try { return JSON.parse(result); } catch { return null; }
+  }
+  return result;
+}
+
+function handleViewData(data) {
+  if (data.session_id) sessionId = data.session_id;
+  if (data.edit_revision != null) editRevision = data.edit_revision;
+  nodes = data.nodes || [];
+  renderDocument(nodes);
+  setStatus(`${nodes.length} paragraphs — rev ${editRevision}`);
+}
+
+// ── Rendering ───────────────────────────────────────────────────────
+
+function renderDocument(viewNodes) {
+  const page = document.getElementById('page');
+  const loading = document.getElementById('loading');
+  if (loading) loading.remove();
+
+  // Preserve focused element ID
+  const focusedId = document.activeElement?.dataset?.id;
+
+  page.innerHTML = '';
+  originalTexts.clear();
+
+  for (const node of viewNodes) {
+    const el = createParagraphElement(node);
+    page.appendChild(el);
+  }
+
+  // Restore focus
+  if (focusedId) {
+    const target = page.querySelector(`[data-id="${CSS.escape(focusedId)}"]`);
+    if (target) target.focus();
+  }
+}
+
+function createParagraphElement(node) {
+  const div = document.createElement('div');
+  div.className = buildClassList(node);
+  div.dataset.id = node.id;
+  div.contentEditable = 'true';
+  div.spellcheck = false;
+
+  // Indentation
+  const leftPt = node.paragraph_indents_pt?.left || 0;
+  if (leftPt > 0) {
+    div.style.marginLeft = leftPt + 'pt';
+  }
+  const firstLine = node.paragraph_indents_pt?.first_line || 0;
+  if (firstLine !== 0) {
+    div.style.textIndent = firstLine + 'pt';
+  }
+
+  // Build content
+  let html = '';
+
+  // List label (non-editable)
+  if (node.list_label) {
+    html += `<span class="list-label" contenteditable="false">${escapeHtml(node.list_label)}</span>`;
+  }
+
+  // Tagged text with formatting
+  html += convertTaggedText(node.tagged_text);
+
+  div.innerHTML = html;
+
+  // Event handlers
+  div.addEventListener('focus', () => onParaFocus(div, node));
+  div.addEventListener('blur', () => onParaBlur(div, node));
+  div.addEventListener('paste', onPaste);
+  div.addEventListener('keydown', onKeydown);
+
+  return div;
+}
+
+function buildClassList(node) {
+  const classes = ['para'];
+
+  // Style class
+  const style = node.style || node.paragraph_style_name || 'body';
+  classes.push('style-' + style.replace(/\s+/g, '_'));
+
+  // Alignment
+  const align = node.paragraph_alignment || 'LEFT';
+  classes.push('align-' + align);
+
+  return classes.join(' ');
+}
+
+function convertTaggedText(tagged) {
+  if (!tagged) return '';
+  // Sanitize: convert tagged_text formatting tags to HTML
+  let html = escapeHtml(tagged);
+
+  // Convert formatting tags (they're already escaped, unescape known tags)
+  const tagMap = [
+    [/&lt;b&gt;/g, '<b>'], [/&lt;\/b&gt;/g, '</b>'],
+    [/&lt;i&gt;/g, '<i>'], [/&lt;\/i&gt;/g, '</i>'],
+    [/&lt;u&gt;/g, '<u>'], [/&lt;\/u&gt;/g, '</u>'],
+    [/&lt;highlighting&gt;/g, '<mark>'], [/&lt;\/highlighting&gt;/g, '</mark>'],
+    [/&lt;highlight&gt;/g, '<mark>'], [/&lt;\/highlight&gt;/g, '</mark>'],
+  ];
+
+  for (const [pattern, replacement] of tagMap) {
+    html = html.replace(pattern, replacement);
+  }
+
+  // Handle <a href="...">...</a> links
+  html = html.replace(
+    /&lt;a href=&quot;([^&]*)&quot;&gt;(.*?)&lt;\/a&gt;/g,
+    '<a href="$1" target="_blank" rel="noopener" contenteditable="false">$2</a>'
+  );
+
+  return html;
+}
+
+function escapeHtml(text) {
+  const div = document.createElement('div');
+  div.textContent = text;
+  return div.innerHTML;
+}
+
+// ── Edit flow ───────────────────────────────────────────────────────
+
+function onParaFocus(el, node) {
+  // Store original clean text for diff on blur
+  const cleanText = getCleanText(el);
+  originalTexts.set(node.id, cleanText);
+}
+
+async function onParaBlur(el, node) {
+  const original = originalTexts.get(node.id);
+  if (original == null) return;
+
+  const current = getCleanText(el);
+  if (current === original) {
+    originalTexts.delete(node.id);
+    return;
+  }
+
+  // Text changed — persist via replace_text
+  el.classList.remove('error');
+  setStatus('Saving...');
+
+  try {
+    const result = await app.callServerTool({
+      name: 'replace_text',
+      arguments: {
+        session_id: sessionId,
+        target_paragraph_id: node.id,
+        old_string: original,
+        new_string: current,
+        instruction: 'User edit from preview app',
+      },
+    });
+
+    const data = parseToolResult(result);
+    if (data?.success) {
+      originalTexts.set(node.id, current);
+      editRevision++;
+      setStatus(`Saved — rev ${editRevision}`);
+
+      // Notify Claude of the edit
+      try {
+        const preview = current.length > 80 ? current.slice(0, 80) + '...' : current;
+        await app.updateModelContext({
+          content: [{
+            type: 'text',
+            text: `[User Edit] Paragraph ${node.id}: text changed to "${preview}"`,
+          }],
+        });
+      } catch { /* context update is best-effort */ }
+    } else {
+      const errMsg = data?.error?.message || 'Save failed';
+      showParaError(el, errMsg);
+      setStatus('Save error — try refresh');
+      // Re-fetch on stale text error
+      if (data?.error?.code === 'TEXT_NOT_FOUND') {
+        setTimeout(() => fetchDocumentView(), 500);
+      }
+    }
+  } catch (e) {
+    console.error('Save error:', e);
+    showParaError(el, e.message);
+    setStatus('Save error');
+  }
+}
+
+function getCleanText(el) {
+  // Get text content, excluding list labels
+  const clone = el.cloneNode(true);
+  const labels = clone.querySelectorAll('.list-label');
+  for (const l of labels) l.remove();
+  return clone.textContent || '';
+}
+
+function showParaError(el, msg) {
+  el.classList.add('error');
+  // Remove existing badges
+  const existing = el.querySelector('.error-badge');
+  if (existing) existing.remove();
+  const badge = document.createElement('span');
+  badge.className = 'error-badge';
+  badge.textContent = 'Error';
+  badge.title = msg;
+  badge.onclick = (e) => { e.stopPropagation(); badge.remove(); el.classList.remove('error'); };
+  el.appendChild(badge);
+}
+
+// ── Input handling ──────────────────────────────────────────────────
+
+function onPaste(e) {
+  e.preventDefault();
+  const text = e.clipboardData?.getData('text/plain') || '';
+  document.execCommand('insertText', false, text);
+}
+
+function onKeydown(e) {
+  if (e.key === 'Enter') {
+    e.preventDefault(); // No paragraph splitting in prototype
+  }
+}
+
+// ── Utilities ───────────────────────────────────────────────────────
+
+function setStatus(msg) {
+  const el = document.getElementById('status');
+  if (el) el.textContent = msg;
+}
+
+function showError(msg) {
+  const page = document.getElementById('page');
+  page.innerHTML = `<div class="loading" style="color:var(--error-text)">${escapeHtml(msg)}</div>`;
+}
+
+// ── Refresh ─────────────────────────────────────────────────────────
+
+document.getElementById('refreshBtn').addEventListener('click', () => {
+  fetchDocumentView();
+});
+
+// ── Start ───────────────────────────────────────────────────────────
+
+initApp();
+</script>
+</body>
+</html>

--- a/packages/docx-mcp/src/app/preview.registration.test.ts
+++ b/packages/docx-mcp/src/app/preview.registration.test.ts
@@ -50,7 +50,7 @@ async function createConnectedPair(opts: { withPreview: boolean }) {
 }
 
 describe('registerPreviewApp integration', () => {
-  const test = testAllure.epic('MCP Apps').withLabels({ feature: 'Preview Registration' });
+  const test = testAllure.epic('Document Reading').withLabels({ feature: 'Preview Registration' });
   registerCleanup();
 
   test('tools/list includes get_document_view when preview is registered', async () => {
@@ -126,8 +126,9 @@ describe('registerPreviewApp integration', () => {
       const content = result.contents[0]!;
       expect(content.uri).toBe(PREVIEW_RESOURCE_URI);
       expect(content.mimeType).toBe(PREVIEW_MIME_TYPE);
-      expect(typeof content.text).toBe('string');
-      expect((content.text as string)).toContain('<!DOCTYPE html>');
+      expect('text' in content).toBe(true);
+      const text = (content as { text: string }).text;
+      expect(text).toContain('<!DOCTYPE html>');
     });
   });
 });

--- a/packages/docx-mcp/src/app/preview.registration.test.ts
+++ b/packages/docx-mcp/src/app/preview.registration.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect } from 'vitest';
+
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+
+import { SessionManager } from '../session/manager.js';
+import { SAFE_DOCX_MCP_TOOLS } from '../tool_catalog.js';
+import { dispatchToolCall } from '../server.js';
+import { registerPreviewApp, PREVIEW_RESOURCE_URI, PREVIEW_MIME_TYPE } from './mcp-app-resources.js';
+import { testAllure, allureStep } from '../testing/allure-test.js';
+import { registerCleanup, openSession } from '../testing/session-test-utils.js';
+
+async function createConnectedPair(opts: { withPreview: boolean }) {
+  const server = new Server(
+    { name: 'test-preview', version: '1.0.0' },
+    { capabilities: { tools: {} } },
+  );
+  const sessions = new SessionManager();
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: SAFE_DOCX_MCP_TOOLS,
+  }));
+
+  server.setRequestHandler(CallToolRequestSchema, async (req) => {
+    const { name } = req.params;
+    const args = (req.params.arguments ?? {}) as Record<string, unknown>;
+    const result = await dispatchToolCall(sessions, name, args);
+    return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+  });
+
+  if (opts.withPreview) {
+    registerPreviewApp({
+      server,
+      sessions,
+      coreTools: SAFE_DOCX_MCP_TOOLS,
+      coreDispatch: dispatchToolCall,
+    });
+  }
+
+  const client = new Client({ name: 'test-client', version: '1.0.0' });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+
+  return { server, client, sessions };
+}
+
+describe('registerPreviewApp integration', () => {
+  const test = testAllure.epic('MCP Apps').withLabels({ feature: 'Preview Registration' });
+  registerCleanup();
+
+  test('tools/list includes get_document_view when preview is registered', async () => {
+    const { client } = await createConnectedPair({ withPreview: true });
+
+    const { tools } = await allureStep('When listing tools via client', () =>
+      client.listTools(),
+    );
+
+    await allureStep('Then get_document_view is present with _meta.ui', () => {
+      const names = tools.map((t) => t.name);
+      expect(names).toContain('get_document_view');
+
+      const tool = tools.find((t) => t.name === 'get_document_view')!;
+      expect(tool.annotations?.readOnlyHint).toBe(true);
+    });
+  });
+
+  test('tools/list excludes get_document_view without preview', async () => {
+    const { client } = await createConnectedPair({ withPreview: false });
+
+    const { tools } = await allureStep('When listing tools via client', () =>
+      client.listTools(),
+    );
+
+    await allureStep('Then get_document_view is absent', () => {
+      const names = tools.map((t) => t.name);
+      expect(names).not.toContain('get_document_view');
+    });
+  });
+
+  test('tools/call get_document_view succeeds for a real session', async () => {
+    const { client, sessions } = await createConnectedPair({ withPreview: true });
+    const { sessionId } = await openSession(['Hello integration'], { mgr: sessions });
+
+    const result = await allureStep('When calling get_document_view via client', () =>
+      client.callTool({ name: 'get_document_view', arguments: { session_id: sessionId } }),
+    );
+
+    await allureStep('Then result contains document nodes', () => {
+      const text = (result.content as Array<{ type: string; text: string }>)[0]!.text;
+      const parsed = JSON.parse(text);
+      expect(parsed.success).toBe(true);
+      expect(Array.isArray(parsed.nodes)).toBe(true);
+      expect(parsed.nodes.length).toBe(1);
+      expect(parsed.nodes[0].clean_text).toBe('Hello integration');
+    });
+  });
+
+  test('resources/list includes preview resource', async () => {
+    const { client } = await createConnectedPair({ withPreview: true });
+
+    const { resources } = await allureStep('When listing resources via client', () =>
+      client.listResources(),
+    );
+
+    await allureStep('Then preview resource is present', () => {
+      expect(resources.length).toBe(1);
+      expect(resources[0]!.uri).toBe(PREVIEW_RESOURCE_URI);
+      expect(resources[0]!.mimeType).toBe(PREVIEW_MIME_TYPE);
+    });
+  });
+
+  test('resources/read returns preview HTML', async () => {
+    const { client } = await createConnectedPair({ withPreview: true });
+
+    const result = await allureStep('When reading preview resource via client', () =>
+      client.readResource({ uri: PREVIEW_RESOURCE_URI }),
+    );
+
+    await allureStep('Then HTML content is returned', () => {
+      expect(result.contents.length).toBe(1);
+      const content = result.contents[0]!;
+      expect(content.uri).toBe(PREVIEW_RESOURCE_URI);
+      expect(content.mimeType).toBe(PREVIEW_MIME_TYPE);
+      expect(typeof content.text).toBe('string');
+      expect((content.text as string)).toContain('<!DOCTYPE html>');
+    });
+  });
+});

--- a/packages/docx-mcp/src/app/preview.test.ts
+++ b/packages/docx-mcp/src/app/preview.test.ts
@@ -12,7 +12,7 @@ import {
 import { getPreviewHtml } from './preview-html.js';
 
 describe('MCP App Preview', () => {
-  const test = testAllure.epic('MCP Apps').withLabels({ feature: 'Document Preview' });
+  const test = testAllure.epic('Document Reading').withLabels({ feature: 'Document Preview' });
   registerCleanup();
 
   test('get_document_view returns nodes, styles, session_id, and edit_revision', async () => {

--- a/packages/docx-mcp/src/app/preview.test.ts
+++ b/packages/docx-mcp/src/app/preview.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect } from 'vitest';
+
+import { getDocumentView } from './get_document_view.js';
+import { PREVIEW_RESOURCE_URI, PREVIEW_MIME_TYPE } from './mcp-app-resources.js';
+import { GET_DOCUMENT_VIEW_TOOL } from './app_tools.js';
+import { testAllure, allureStep, allureJsonAttachment } from '../testing/allure-test.js';
+import {
+  assertSuccess,
+  openSession,
+  registerCleanup,
+} from '../testing/session-test-utils.js';
+import { getPreviewHtml } from './preview-html.js';
+
+describe('MCP App Preview', () => {
+  const test = testAllure.epic('MCP Apps').withLabels({ feature: 'Document Preview' });
+  registerCleanup();
+
+  test('get_document_view returns nodes, styles, session_id, and edit_revision', async () => {
+    const { mgr, sessionId } = await openSession(['Hello World', 'Second paragraph']);
+
+    const result = await allureStep('When get_document_view is called', () =>
+      getDocumentView(mgr, { session_id: sessionId }),
+    );
+    assertSuccess(result, 'get_document_view');
+    await allureJsonAttachment('result', result);
+
+    await allureStep('Then response contains structured document view data', () => {
+      expect(result.session_id).toBe(sessionId);
+      expect(result.edit_revision).toBe(0);
+      expect(Array.isArray(result.nodes)).toBe(true);
+      expect(typeof result.styles).toBe('object');
+
+      const nodes = result.nodes as Array<Record<string, unknown>>;
+      expect(nodes.length).toBe(2);
+      expect(nodes[0]!.id).toBeTruthy();
+      expect(nodes[0]!.clean_text).toBe('Hello World');
+      expect(nodes[0]!.tagged_text).toBeTruthy();
+      expect(nodes[1]!.clean_text).toBe('Second paragraph');
+    });
+  });
+
+  test('get_document_view works with file_path (auto-open)', async () => {
+    const { mgr, inputPath } = await openSession(['Test content']);
+
+    const result = await allureStep('When get_document_view is called with file_path', () =>
+      getDocumentView(mgr, { file_path: inputPath }),
+    );
+    assertSuccess(result, 'get_document_view');
+
+    await allureStep('Then nodes contain the document content', () => {
+      const nodes = result.nodes as Array<Record<string, unknown>>;
+      expect(nodes.length).toBeGreaterThan(0);
+      expect(result.session_id).toBeTruthy();
+    });
+  });
+
+  test('get_document_view tool is registered with _meta.ui', async () => {
+    await allureStep('Then get_document_view tool has _meta.ui in catalog', () => {
+      expect(GET_DOCUMENT_VIEW_TOOL).toBeTruthy();
+      expect(GET_DOCUMENT_VIEW_TOOL.annotations.readOnlyHint).toBe(true);
+
+      const meta = GET_DOCUMENT_VIEW_TOOL._meta;
+      expect(meta).toBeTruthy();
+      expect(meta.ui).toBeTruthy();
+      expect(meta.ui.resourceUri).toBe('ui://safe-docx/preview');
+      expect(meta.ui.visibility).toEqual(['app']);
+    });
+  });
+
+  test('ListResources includes preview resource with correct URI and MIME type', async () => {
+    await allureStep('Then preview resource constants are correctly defined', () => {
+      expect(PREVIEW_RESOURCE_URI).toBe('ui://safe-docx/preview');
+      expect(PREVIEW_MIME_TYPE).toBe('text/html;profile=mcp-app');
+    });
+  });
+
+  test('preview HTML resource returns valid HTML with mcp-app content', async () => {
+    const html = await allureStep('When getPreviewHtml is called', () => getPreviewHtml());
+
+    await allureStep('Then returned HTML is valid', () => {
+      expect(html).toBeTruthy();
+      expect(html).toContain('<!DOCTYPE html>');
+      expect(html).toContain('Document Preview');
+      expect(html).toContain('contentEditable');
+      expect(html).toContain('callServerTool');
+      expect(html).toContain('get_document_view');
+      expect(html).toContain('replace_text');
+    });
+  });
+});

--- a/packages/docx-mcp/src/server.ts
+++ b/packages/docx-mcp/src/server.ts
@@ -27,6 +27,7 @@ import { deleteFootnote } from './tools/delete_footnote.js';
 import { compareDocuments_tool } from './tools/compare_documents.js';
 import { extractRevisions_tool } from './tools/extract_revisions.js';
 import { clearFormatting } from './tools/clear_formatting.js';
+import { registerPreviewApp } from './app/mcp-app-resources.js';
 
 export const MCP_TRANSPORT = 'stdio' as const;
 
@@ -98,7 +99,7 @@ export async function dispatchToolCall(
 
 export async function runServer(): Promise<void> {
   const server = new Server(
-    { name: 'safe-docx', version: '0.2.0' },
+    { name: 'safe-docx', version: '0.3.0' },
     {
       capabilities: {
         tools: {},
@@ -122,6 +123,9 @@ export async function runServer(): Promise<void> {
       content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
     };
   });
+
+  // MCP Apps: preview app (delete src/app/ + these 2 lines to remove)
+  registerPreviewApp(server, sessions, MCP_TOOLS, dispatchToolCall);
 
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/packages/docx-mcp/src/server.ts
+++ b/packages/docx-mcp/src/server.ts
@@ -125,7 +125,7 @@ export async function runServer(): Promise<void> {
   });
 
   // MCP Apps: preview app (delete src/app/ + these 2 lines to remove)
-  registerPreviewApp(server, sessions, MCP_TOOLS, dispatchToolCall);
+  registerPreviewApp({ server, sessions, coreTools: MCP_TOOLS, coreDispatch: dispatchToolCall });
 
   const transport = new StdioServerTransport();
   await server.connect(transport);


### PR DESCRIPTION
## Summary
- Self-contained MCP Apps preview in `src/app/` — interactive document preview with `get_document_view` tool, resource handlers, and HTML preview app
- **Zero-residue removal**: delete `src/app/` + remove 3 lines from `server.ts` to fully remove the feature
- `registerPreviewApp()` owns all preview concerns: capabilities, ListTools/CallTool overrides, ListResources/ReadResource handlers
- No `@modelcontextprotocol/ext-apps` dependency (CDN-only in HTML)
- Build copy step no-ops when `src/app/` is absent

## Peer review
Reviewed by Codex (gpt-5.3) and Gemini with full repo access. Findings addressed:
- Options object signature (was 4 positional args)
- String literal dedup via `GET_DOCUMENT_VIEW_TOOL.name`
- Integration tests via InMemoryTransport + Client

## Test plan
- [x] `npm run build -w @usejunior/docx-mcp` passes
- [x] 621/621 tests pass (5 unit + 5 integration tests added)
- [x] Removal simulation: delete `src/app/` + remove lines → build passes
- [ ] MCP Inspector: Resources tab lists `ui://safe-docx/preview`, Apps tab renders preview