### PR TITLE
feat(seo): activate 301 redirects to usejunior.com

### DIFF
--- a/site/vercel.json
+++ b/site/vercel.json
@@ -1,10 +1,17 @@
 {
   "framework": null,
   "installCommand": "npm install",
-  "buildCommand": "npm run build",
+  "buildCommand": "mkdir -p _site && echo 'redirect-only' > _site/.keep",
   "outputDirectory": "_site",
   "cleanUrls": true,
-  "trailingSlash": true,
+  "trailingSlash": false,
+  "redirects": [
+    { "source": "/", "destination": "https://usejunior.com/developer-tools/safe-docx", "statusCode": 301 },
+    { "source": "/about", "destination": "https://usejunior.com/developer-tools/safe-docx", "statusCode": 301 },
+    { "source": "/trust", "destination": "https://usejunior.com/developer-tools/safe-docx#trust", "statusCode": 301 },
+    { "source": "/trust/:path*", "destination": "https://usejunior.com/developer-tools/safe-docx#trust", "statusCode": 301 },
+    { "source": "/:path*", "destination": "https://usejunior.com/developer-tools/safe-docx", "statusCode": 301 }
+  ],
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## Summary
- Skip build (empty `_site/`) so Vercel redirects fire instead of static HTML
- Use `statusCode: 301` instead of `"permanent": true` (308) for GSC compatibility
- No APIs or static assets to preserve — safedocx.com becomes a pure redirect domain

## Test plan
- [ ] Verify `curl -sI https://safedocx.com/` returns 301 → usejunior.com
- [ ] Verify `curl -sI https://safedocx.com/trust/system-card` returns 301
- [ ] Run GSC Change of Address for safedocx.com