### PR TITLE
chore(release): bump workspace versions to 0.5.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           TAG_REF="${RELEASE_TAG:-$GITHUB_REF_NAME}"
           TAG_VERSION="${TAG_REF#v}"
-          for pkg in packages/docx-core packages/docx-mcp packages/safe-docx packages/safe-docx-mcpb; do
+          for pkg in packages/docx-core packages/docx-mcp packages/google-docs-core packages/safe-docx packages/safe-docx-mcpb; do
             PKG_VERSION="$(node -p "require('./${pkg}/package.json').version")"
             if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
               echo "Tag version ($TAG_VERSION) must match ${pkg}/package.json version ($PKG_VERSION)."
@@ -104,7 +104,7 @@ jobs:
         run: |
           TAG_REF="${RELEASE_TAG:-$GITHUB_REF_NAME}"
           VERSION="${TAG_REF#v}"
-          for pkg in @usejunior/docx-core @usejunior/docx-mcp @usejunior/safe-docx; do
+          for pkg in @usejunior/docx-core @usejunior/docx-mcp @usejunior/google-docs-core @usejunior/safe-docx; do
             if npm view "$pkg@$VERSION" version >/dev/null 2>&1; then
               echo "$pkg@$VERSION already exists on npm."
               exit 1
@@ -139,7 +139,7 @@ jobs:
 
       - name: Verify package contents (dry-run)
         run: |
-          for pkg in packages/docx-core packages/docx-mcp packages/safe-docx; do
+          for pkg in packages/docx-core packages/docx-mcp packages/google-docs-core packages/safe-docx; do
             echo "Dry-run pack: $pkg"
             (cd "$pkg" && npm pack --dry-run)
           done
@@ -224,6 +224,7 @@ jobs:
         run: |
           npm run build -w @usejunior/docx-core
           npm run build -w @usejunior/docx-mcp
+          npm run build -w @usejunior/google-docs-core
           npm run build -w @usejunior/safe-docx
 
       - name: Publish to npm (trusted publishing)
@@ -234,7 +235,7 @@ jobs:
           npm config delete //registry.npmjs.org/:_authToken || true
 
           # Publish in dependency order.
-          for entry in "@usejunior/docx-core:packages/docx-core" "@usejunior/docx-mcp:packages/docx-mcp" "@usejunior/safe-docx:packages/safe-docx"; do
+          for entry in "@usejunior/docx-core:packages/docx-core" "@usejunior/docx-mcp:packages/docx-mcp" "@usejunior/google-docs-core:packages/google-docs-core" "@usejunior/safe-docx:packages/safe-docx"; do
             PKG_NAME="${entry%%:*}"
             PKG_DIR="${entry##*:}"
             if npm view "$PKG_NAME@$VERSION" version >/dev/null 2>&1; then

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "safe-docx-suite",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "safe-docx-suite",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -5026,36 +5026,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/googleapis": {
-      "version": "140.0.1",
-      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-140.0.1.tgz",
-      "integrity": "sha512-ZGvBX4mQcFXO9ACnVNg6Aqy3KtBPB5zTuue43YVLxwn8HSv8jB7w+uDKoIPSoWuxGROgnj2kbng6acXncOQRNA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "google-auth-library": "^9.0.0",
-        "googleapis-common": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/googleapis-common": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.2.0.tgz",
-      "integrity": "sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "extend": "^3.0.2",
-        "gaxios": "^6.0.3",
-        "google-auth-library": "^9.7.0",
-        "qs": "^6.7.0",
-        "url-template": "^2.0.8",
-        "uuid": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -7466,12 +7436,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/url-template": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
-      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
-      "license": "BSD"
-    },
     "node_modules/use-debounce": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-10.1.0.tgz",
@@ -7942,7 +7906,7 @@
     },
     "packages/allure-test-factory": {
       "name": "@usejunior/allure-test-factory",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -7963,7 +7927,7 @@
     },
     "packages/docx-core": {
       "name": "@usejunior/docx-core",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.10",
@@ -7990,11 +7954,11 @@
     },
     "packages/docx-mcp": {
       "name": "@usejunior/docx-mcp",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@usejunior/docx-core": "^0.4.0",
+        "@usejunior/docx-core": "^0.5.0",
         "zod": "^4.3.6"
       },
       "bin": {
@@ -8027,7 +7991,7 @@
       "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
-        "googleapis": "^140.0.1"
+        "google-auth-library": "^9.0.0"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
@@ -8040,10 +8004,10 @@
     },
     "packages/safe-docx": {
       "name": "@usejunior/safe-docx",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
-        "@usejunior/docx-mcp": "^0.4.0"
+        "@usejunior/docx-mcp": "^0.5.0"
       },
       "bin": {
         "safe-docx": "bin/safe-docx.js",
@@ -8055,10 +8019,10 @@
     },
     "packages/safe-docx-mcpb": {
       "name": "@usejunior/safedocx-mcpb",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
-        "@usejunior/safe-docx": "^0.4.0"
+        "@usejunior/safe-docx": "^0.5.0"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7978,7 +7978,7 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@usejunior/google-docs-core": "^0.3.1"
+        "@usejunior/google-docs-core": "^0.5.0"
       },
       "peerDependenciesMeta": {
         "@usejunior/google-docs-core": {
@@ -7988,7 +7988,7 @@
     },
     "packages/google-docs-core": {
       "name": "@usejunior/google-docs-core",
-      "version": "0.3.1",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "google-auth-library": "^9.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-docx-suite",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "description": "Monorepo for Safe DOCX packages",
   "repository": {

--- a/packages/allure-test-factory/package.json
+++ b/packages/allure-test-factory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/allure-test-factory",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Shared Allure test helpers for vitest — BDD context, OpenSpec auto-inference, Prism.js highlighting",
   "type": "module",
   "exports": {

--- a/packages/docx-core/package.json
+++ b/packages/docx-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/docx-core",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "OOXML (.docx) core library: primitives, comparison, and track changes",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/docx-mcp/package.json
+++ b/packages/docx-mcp/package.json
@@ -53,7 +53,7 @@
     "dist"
   ],
   "peerDependencies": {
-    "@usejunior/google-docs-core": "^0.3.1"
+    "@usejunior/google-docs-core": "^0.5.0"
   },
   "peerDependenciesMeta": {
     "@usejunior/google-docs-core": {

--- a/packages/docx-mcp/package.json
+++ b/packages/docx-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/docx-mcp",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Safe Docx MCP server (TypeScript)",
   "type": "module",
   "main": "dist/index.js",
@@ -26,7 +26,7 @@
     "lint": "tsc -b --pretty false"
   },
   "dependencies": {
-    "@usejunior/docx-core": "^0.4.0",
+    "@usejunior/docx-core": "^0.5.0",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "zod": "^4.3.6"
   },

--- a/packages/google-docs-core/package.json
+++ b/packages/google-docs-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/google-docs-core",
-  "version": "0.3.1",
+  "version": "0.5.0",
   "description": "Google Docs core library: read, write, and anchor management via Google Docs API",
   "type": "module",
   "main": "dist/index.js",
@@ -32,6 +32,9 @@
   "homepage": "https://github.com/UseJunior/safe-docx/tree/main/packages/google-docs-core",
   "bugs": {
     "url": "https://github.com/UseJunior/safe-docx/issues"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "files": [
     "dist"

--- a/packages/safe-docx-mcpb/manifest.json
+++ b/packages/safe-docx-mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "safe-docx",
   "display_name": "Safe Docx",
-  "version": "0.3.1",
+  "version": "0.5.0",
   "description": "AI-native Word document editing with stable paragraph anchors and deterministic DOCX operations.",
   "long_description": "Safe Docx lets Claude work directly with .docx files on your local filesystem. It provides stable paragraph IDs (jr_para_*) for precise editing while preserving formatting and structure.\n\nCore capabilities include reading/searching content, formatting-preserving edits and inserts, deterministic layout controls, tracked-changes output, comments, footnote tools, document comparison, and revision extraction.",
   "author": {

--- a/packages/safe-docx-mcpb/package.json
+++ b/packages/safe-docx-mcpb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/safedocx-mcpb",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "description": "Claude Desktop MCP Bundle (.mcpb) wrapper for @usejunior/safe-docx",
   "type": "module",
@@ -14,7 +14,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@usejunior/safe-docx": "^0.4.0"
+    "@usejunior/safe-docx": "^0.5.0"
   },
   "devDependencies": {
     "@vitest/runner": "^3.2.4",

--- a/packages/safe-docx/package.json
+++ b/packages/safe-docx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/safe-docx",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Canonical npm package for the Safe Docx MCP server and CLI",
   "mcpName": "io.github.usejunior/safe-docx",
   "type": "module",
@@ -25,7 +25,7 @@
     "safedocx": "./bin/safe-docx.js"
   },
   "dependencies": {
-    "@usejunior/docx-mcp": "^0.4.0"
+    "@usejunior/docx-mcp": "^0.5.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/safe-docx/server.json
+++ b/packages/safe-docx/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.usejunior/safe-docx",
   "title": "Safe Docx",
   "description": "AI-native surgical editing of existing Word .docx files with formatting preservation",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "websiteUrl": "https://usejunior.com/developer-tools/safe-docx",
   "icons": [
     {
@@ -18,7 +18,7 @@
     {
       "registryType": "npm",
       "identifier": "@usejunior/safe-docx",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "transport": {
         "type": "stdio"
       },

--- a/scripts/bump_version.mjs
+++ b/scripts/bump_version.mjs
@@ -23,6 +23,7 @@ const PACKAGE_JSONS = [
   'packages/allure-test-factory/package.json',
   'packages/docx-core/package.json',
   'packages/docx-mcp/package.json',
+  'packages/google-docs-core/package.json',
   'packages/safe-docx-mcpb/package.json',
   'packages/safe-docx/package.json',
   'site/package.json',

--- a/site/package.json
+++ b/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/safe-docx-site",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "description": "Safe DOCX marketing and trust site (Eleventy)",


### PR DESCRIPTION
## Summary

Version bump to 0.5.0 for all workspace packages.

**Breaking changes:**
- `session_id` removed from all 21 tool input schemas and responses
- `get_session_status` renamed to `get_file_status`
- `clear_session` renamed to `close_file`
- `file_path` is now the sole document identifier

**New features:**
- `@usejunior/google-docs-core` package (first publish)
- 8 Google Docs MCP tool handlers
- Multi-file stateless grep, raw XML search, CLI grep command
- Lazy baseline generation, staleness detection

## Test plan
- [x] `node scripts/bump_version.mjs --check` — all 10 files at 0.5.0
- [x] E2E smoke test: DOCX (11 steps) + Google Docs (8 tools) both pass on main