### PR TITLE
fix(skills): add trigger phrases and CONNECTORS.md link

### DIFF
--- a/skills/docx-editing/SKILL.md
+++ b/skills/docx-editing/SKILL.md
@@ -2,8 +2,10 @@
 name: docx-editing
 description: >-
   Surgically edit existing (brownfield) .docx files with formatting preservation
-  and tracked changes via the Safe-DOCX MCP server. Use when reading, searching,
-  editing, commenting on, or comparing Word documents — not for from-scratch generation.
+  and tracked changes via the Safe-DOCX MCP server. Use when user says "edit this
+  docx," "change the contract," "redline the document," "compare these Word files,"
+  "add a comment to the docx," "read this Word file," or "mark up the agreement."
+  Not for from-scratch document generation.
 ---
 
 # Editing .docx Files with Safe-DOCX
@@ -149,3 +151,7 @@ Call `accept_changes(session_id)` to flatten all tracked changes into a clean do
 ## Path Restrictions
 
 By default, only files under `~/` (home directory) and system temp directories are accessible. Symlinks must resolve to allowed roots.
+
+## Connectors
+
+For MCP server setup instructions (Claude Desktop, Cursor, Claude Code), see [CONNECTORS.md](./CONNECTORS.md).


### PR DESCRIPTION
## Summary

- **P0**: Add `Use when user says "..."` trigger phrases to `docx-editing` skill frontmatter description for better routing — the description is the only thing used for skill activation decisions
- **P1**: Add `## Connectors` section linking `CONNECTORS.md` from the SKILL.md body so it's discoverable

Part of a cross-repo skills compliance audit against Anthropic's official skills guide.

## Test plan

- [ ] Verify SKILL.md YAML frontmatter parses correctly (no syntax errors)
- [ ] Confirm trigger phrases in description match the skill's intended activation scenarios
- [ ] Verify CONNECTORS.md link resolves correctly from the skill directory