### PR TITLE
docs: update release runbook and MCP registry docs

### DIFF
--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -32,13 +32,11 @@ chore(release): bump workspace versions to 0.2.0
 
 ### 1. Bump versions
 
-Update the version in all four package manifests and the MCPB `manifest.json`:
+```bash
+node scripts/bump_version.mjs <version>
+```
 
-- `packages/docx-core/package.json`
-- `packages/docx-mcp/package.json`
-- `packages/safe-docx/package.json`
-- `packages/safe-docx-mcpb/package.json`
-- `packages/safe-docx-mcpb/manifest.json`
+This script is the source of truth for which files are managed (package manifests, MCPB manifest, cross-workspace dependency ranges, and `package-lock.json`). Do not bump versions manually.
 
 Commit: `chore(release): bump workspace versions to X.Y.Z`
 
@@ -65,14 +63,27 @@ preflight → publish-suite → ensure-release → publish-mcpb-asset → update
 
 ### 4. Verify
 
+- [ ] `node scripts/bump_version.mjs --check` confirms all managed files are in sync
 - [ ] npm packages are published with provenance
 - [ ] GitHub Release exists with categorized notes
 - [ ] MCPB asset is attached to the release
 - [ ] Changelog data PR is opened (merge it to update the trust site)
 
+### 5. MCP Registry Submissions
+
+After npm publish, submit the package to each registry target:
+
+1. **Official MCP Registry** (`registry.modelcontextprotocol.io`) — Requires `packages/safe-docx/server.json` (already managed by the bump script). Submit via the [registry quickstart](https://modelcontextprotocol.io/registry/quickstart).
+2. **Anthropic Connectors Directory** — Separate from the official registry. Submit local MCP servers via the [Google Form](https://support.claude.com/en/articles/12922832-local-mcp-server-submission-guide).
+3. **mcpservers.org** — Manual web form at https://mcpservers.org/submit.
+4. **Smithery.ai** — Publish via https://smithery.ai/docs/build/publish or https://smithery.ai/new.
+5. **Glama.ai** — Auto-discovers from GitHub/registry. Verify listing after registry publish + sync window (not tied to npm timing).
+
+> **Note:** These URLs were verified as of 2026-03-17. Confirm they are still current at submission time.
+
 ## Monorepo Version Coupling
 
-All publishable packages share the same version. The preflight job verifies that the tag version matches every `package.json` and the MCPB `manifest.json`. If any mismatch exists, the release fails before publishing.
+All publishable packages share the same version. The preflight job verifies that the tag version matches all files managed by `bump_version.mjs`. If any mismatch exists, the release fails before publishing.
 
 ## Fixing Bad Release Notes
 

--- a/docs/safe-docx/mcp-docs-checklist.md
+++ b/docs/safe-docx/mcp-docs-checklist.md
@@ -47,6 +47,6 @@ Before adding more docs, trim anything that matches one of these:
 - [x] Keep tool schemas in one source of truth (`src/tool_catalog.ts` with Zod 4).
 - [x] Generate tool docs from schema source (`docs/tool-reference.generated.md`).
 - [x] Add three golden prompts.
-- [ ] Publish `.mcpb` artifact in CI release flow.
+- [x] Publish `.mcpb` artifact in CI release flow.
 - [x] List public package in MCP Registry when open-source launch is ready.
 - [ ] Add concise troubleshooting section in package README after first support feedback cycle.


### PR DESCRIPTION
## Summary

- **Release runbook**: Replace hardcoded file list with `node scripts/bump_version.mjs <version>` as the canonical version-bump command. Add `--check` to verification checklist. Fix "Monorepo Version Coupling" wording to reference the bump script instead of "every package.json".
- **MCP registry submissions**: Add new Section 5 documenting 5 distinct submission targets (Official MCP Registry, Anthropic Connectors Directory, mcpservers.org, Smithery.ai, Glama.ai) with URLs and instructions.
- **MCP docs checklist**: Check off `.mcpb` CI artifact item (working since v0.3.0).

## Test plan

- [x] `node scripts/bump_version.mjs --check` still passes (no version changes)
- [x] Runbook no longer hardcodes a file count
- [x] All 5 registry targets documented with distinct submission paths