### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Safe Docx is an open-source TypeScript stack for surgical editing of existing Mi
 
 If you review contracts with AI, the slowest step is often applying accepted recommendations in Word. Safe Docx turns that into deterministic tool calls.
 
+[![safe-docx MCP server](https://glama.ai/mcp/servers/UseJunior/safe-docx/badges/card.svg)](https://glama.ai/mcp/servers/UseJunior/safe-docx)
+
 ## Why This Exists
 
 AI coding CLIs are great with code and text files but weak on brownfield `.docx` editing. Business and legal workflows still run on Word documents, so we built a native TypeScript path for:


### PR DESCRIPTION
This PR adds a badge for the [safe-docx](https://glama.ai/mcp/servers/UseJunior/safe-docx) server listing in Glama MCP server directory.

[![safe-docx MCP server](https://glama.ai/mcp/servers/UseJunior/safe-docx/badges/card.svg)](https://glama.ai/mcp/servers/UseJunior/safe-docx)

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.