### PR TITLE
Add translated READMEs (zh, es, pt-br, de)

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -1,0 +1,156 @@
+# Safe DOCX Suite
+
+[![CI](https://github.com/usejunior/safe-docx/actions/workflows/ci.yml/badge.svg)](https://github.com/usejunior/safe-docx/actions/workflows/ci.yml)
+[![codecov](https://img.shields.io/codecov/c/github/usejunior/safe-docx/main)](https://app.codecov.io/gh/usejunior/safe-docx)
+
+[English](./README.md) | [Español](./README.es.md) | [简体中文](./README.zh.md) | [Português (Brasil)](./README.pt-br.md) | [Deutsch](./README.de.md)
+
+> **Übersetzungshinweis:** Die englische Version `README.md` ist die kanonische Quelle der Wahrheit. Diese Übersetzung kann einen kurzen Rückstand haben. Wesentliche Aktualisierungen des englischen READMEs sollten innerhalb von 72 Stunden in diese Datei übernommen werden.
+
+**safe-docx** von [UseJunior](https://usejunior.com) — nutze Programmier-Agenten auch für Papierkram.
+
+Teil der [UseJunior-Entwicklertools](https://usejunior.com/developer-tools/safe-docx).
+
+Safe Docx ist ein Open-Source-TypeScript-Stack für die chirurgische Bearbeitung bestehender Microsoft Word `.docx`-Dateien. Es wurde für Workflows entwickelt, in denen ein Agent Änderungen vorschlägt und ein Mensch weiterhin zuverlässige, formatierungserhaltende Dokumentenbearbeitungen benötigt.
+
+Wenn du Verträge mit KI prüfst, ist der langsamste Schritt oft das Anwenden akzeptierter Empfehlungen in Word. Safe Docx verwandelt das in deterministische Tool-Aufrufe.
+
+## Warum dieses Projekt existiert
+
+KI-Programmier-CLIs sind großartig bei Code und Textdateien, aber schwach bei der Bearbeitung bestehender `.docx`-Dateien. Geschäfts- und Rechts-Workflows laufen immer noch über Word-Dokumente, daher haben wir einen nativen TypeScript-Pfad gebaut für:
+
+- Lesen und Durchsuchen bestehender Dokumente in token-effizienten Formaten
+- Chirurgische Bearbeitungen ohne Zerstörung der Formatierung
+- Saubere/nachverfolgte Ausgaben und Revisionsextraktions-Artefakte
+
+Mission: Programmier-Agenten auch für Papierkram befähigen. Safe Docx konzentriert sich auf deterministische Bearbeitungen bestehender Word-Dateien, bei denen Formatierung und Review-Semantik die Automatisierung überleben müssen.
+
+## Positionierung
+
+Safe Docx ist optimiert für Agenten-Workflows, die deterministische, lokale Bearbeitungen bestehender `.docx`-Dateien benötigen:
+
+- Typisierte MCP-Tools für Bearbeitung, Vergleich, Revisionsextraktion, Kommentare, Fußnoten und Layout
+- Auditierbares Verhalten mit Testbelegen und Nachverfolgbarkeits-Artefakten
+- TypeScript-Laufzeitverteilung ohne Python oder LibreOffice für unterstützte Nutzung
+
+Safe Docx ist nicht dazu gedacht, generierungsorientierte `.docx`-Bibliotheken zu ersetzen.
+
+## Hier starten
+
+Für Einrichtung und tägliche Nutzung siehe:
+
+- `packages/docx-mcp/README.md`
+
+Schnellstart:
+
+```bash
+npx -y @usejunior/safe-docx
+```
+
+## Wofür Safe Docx optimiert ist
+
+- Brownfield-Bearbeitung bestehender `.docx`-Dateien
+- Formatierungserhaltende Textersetzung und Absatzeinfügung
+- Kommentar- und Fußnoten-Workflows
+- Nachverfolgte Ausgaben zur Überprüfung (`download`, `compare_documents`)
+- Revisionsextraktion als strukturiertes JSON (`extract_revisions`)
+
+## Wofür Safe Docx nicht optimiert ist
+
+Safe Docx ist kein Toolkit zur Dokumentenerstellung von Grund auf.
+
+Wenn dein Hauptbedarf die Erstellung neuer `.docx`-Dateien aus Vorlagen oder programmatischem Layout ist, verwende Pakete wie [`docx`](https://www.npmjs.com/package/docx).
+
+## Dokumentenfamilien
+
+### Automatisierte Fixture-Abdeckung in diesem Repository
+
+- Common-Paper-Stil gegenseitige NDA-Fixtures
+- Bonterms gegenseitiges NDA-Fixture
+- Letter-of-Intent-Fixture
+- ILPA Limited-Partnership-Agreement-Redline-Fixtures
+
+### Für komplexe juristische und geschäftliche `.docx`-Klassen konzipiert
+
+- NVCA-Finanzierungsformulare
+- YC SAFEs
+- Angebotsmemoranden
+- Bestellformulare und Dienstleistungsvereinbarungen
+- Limited-Partnership-Agreements
+
+## Pakete
+
+- `@usejunior/docx-core`: Primitive und Vergleichs-Engine für bestehende `.docx`-Dokumente
+- `@usejunior/docx-mcp`: MCP-Server-Implementierung und Tool-Oberfläche
+- `@usejunior/safe-docx`: Kanonischer Installationsname für Endbenutzer (`npx -y @usejunior/safe-docx`)
+- `@usejunior/safedocx-mcpb`: Privater MCP-Bundle-Wrapper
+
+## Zuverlässigkeit und Vertrauensoberfläche
+
+- Tool-Schemas werden aus `packages/docx-mcp/src/tool_catalog.ts` generiert.
+- OpenSpec-Nachverfolgbarkeitsmatrix: `packages/docx-mcp/src/testing/SAFE_DOCX_OPENSPEC_TRACEABILITY.md`
+- Annahmenmatrix: `packages/docx-mcp/assumptions.md`
+- Konformitätsleitfaden: `docs/safe-docx/sprint-3-conformance.md`
+
+## Häufig gestellte Fragen
+
+### Was ist Safe Docx?
+
+Ein TypeScript-first DOCX-Bearbeitungs-Stack für Programmier-Agenten-Workflows, die deterministische, formatierungserhaltende Bearbeitungen bestehender Word-Dokumente benötigen.
+
+### Wird die Formatierung bei Bearbeitungen beibehalten?
+
+Das ist ein zentrales Designziel. Die Tool-Oberfläche basiert auf chirurgischen Operationen (`replace_text`, `insert_paragraph`, Layout-Steuerung), die Dokumentstruktur und Formatierungssemantik so weit wie möglich erhalten.
+
+### Wird .NET, Python oder LibreOffice im normalen Laufzeitbetrieb benötigt?
+
+Nein. Die unterstützte Laufzeitnutzung ist JavaScript/TypeScript mit `jszip` + `@xmldom/xmldom`.
+
+### Kann man damit Verträge von Grund auf erstellen?
+
+Nicht der Hauptfokus. Für die Erstellung von Grund auf verwende Pakete wie [`docx`](https://www.npmjs.com/package/docx).
+
+### Welche Dokumenttypen wurden in den Repository-Fixtures getestet?
+
+Gegenseitige NDAs (einschließlich Common-Paper/Bonterms-Stil-Fixtures), Letter of Intent und ILPA Limited-Partnership-Agreement-Redline-Fixtures.
+
+### Ist das nur für Anwälte?
+
+Nein. Die gleichen Bearbeitungsprobleme bei bestehenden `.docx`-Dateien treten in HR, Beschaffung, Finanzen, Vertrieb und anderen papierkramintensiven Workflows auf.
+
+### Wo sollte ich als MCP-Benutzer anfangen?
+
+Verwende `@usejunior/safe-docx` über `npx`, dann folge den Einrichtungsbeispielen in `packages/docx-mcp/README.md`.
+
+### Wo kann ich die Tool-Schemas einsehen?
+
+Siehe die generierte Referenz unter `packages/docx-mcp/docs/tool-reference.generated.md`.
+
+## Entwicklung
+
+```bash
+npm ci
+npm run build
+npm run lint --workspaces --if-present
+npm run test:run
+npm run check:spec-coverage
+npm run test:coverage:packages
+npm run coverage:packages:check
+npm run coverage:matrix
+```
+
+## Siehe auch
+
+- [Open Agreements](https://github.com/open-agreements/open-agreements) — Standardmäßige Rechtsvorlagen mit Programmier-Agenten ausfüllen (NDAs, SAFEs, NVCA)
+- [UseJunior-Entwicklertools](https://usejunior.com/developer-tools/safe-docx) — Produktseite mit Installationsoptionen und Tool-Katalog
+
+## Datenschutz
+
+Safe Docx läuft vollständig auf deinem lokalen Rechner. Es werden keine Dokumenteninhalte an externe Server gesendet. Siehe unsere [Datenschutzrichtlinie](https://usejunior.com/privacy_policy) für Details.
+
+## Governance
+
+- [Beitragsleitfaden](CONTRIBUTING.md)
+- [Verhaltenskodex](CODE_OF_CONDUCT.md)
+- [Sicherheitsrichtlinie](SECURITY.md)
+- [Änderungsprotokoll](CHANGELOG.md)

--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,156 @@
+# Safe DOCX Suite
+
+[![CI](https://github.com/usejunior/safe-docx/actions/workflows/ci.yml/badge.svg)](https://github.com/usejunior/safe-docx/actions/workflows/ci.yml)
+[![codecov](https://img.shields.io/codecov/c/github/usejunior/safe-docx/main)](https://app.codecov.io/gh/usejunior/safe-docx)
+
+[English](./README.md) | [Español](./README.es.md) | [简体中文](./README.zh.md) | [Português (Brasil)](./README.pt-br.md) | [Deutsch](./README.de.md)
+
+> **Nota de traducción:** La versión en inglés `README.md` es la fuente canónica de la verdad. Esta traducción puede tener un breve retraso. Las actualizaciones importantes del README en inglés deben sincronizarse con este archivo en un plazo de 72 horas.
+
+**safe-docx** por [UseJunior](https://usejunior.com) — usa agentes de programación también para el papeleo.
+
+Parte de las [herramientas para desarrolladores de UseJunior](https://usejunior.com/developer-tools/safe-docx).
+
+Safe Docx es un stack de TypeScript de código abierto para la edición quirúrgica de archivos Microsoft Word `.docx` existentes. Está diseñado para flujos de trabajo donde un agente propone cambios y un humano aún necesita ediciones de documentos confiables que preserven el formato.
+
+Si revisas contratos con IA, el paso más lento suele ser aplicar las recomendaciones aceptadas en Word. Safe Docx convierte eso en llamadas de herramientas deterministas.
+
+## Por qué existe este proyecto
+
+Los CLIs de programación con IA son excelentes con código y archivos de texto, pero débiles en la edición de archivos `.docx` existentes. Los flujos de trabajo empresariales y legales aún funcionan con documentos de Word, así que construimos una ruta nativa en TypeScript para:
+
+- leer y buscar documentos existentes en formatos eficientes en tokens
+- realizar ediciones quirúrgicas sin destruir el formato
+- producir salidas limpias/con control de cambios y artefactos de extracción de revisiones
+
+Misión: permitir que los agentes de programación también hagan papeleo. Safe Docx se enfoca en ediciones deterministas de archivos Word existentes donde el formato y la semántica de revisión deben sobrevivir a la automatización.
+
+## Posicionamiento
+
+Safe Docx está optimizado para flujos de trabajo de agentes que necesitan ediciones deterministas y locales de archivos `.docx` existentes:
+
+- herramientas MCP tipadas para edición, comparación, extracción de revisiones, comentarios, notas al pie y diseño
+- comportamiento auditable con evidencia de pruebas y artefactos de trazabilidad
+- distribución en tiempo de ejecución TypeScript sin requerir Python o LibreOffice para el uso soportado
+
+Safe Docx no pretende reemplazar bibliotecas de `.docx` orientadas a la generación.
+
+## Comienza aquí
+
+Para configuración y uso diario, ve a:
+
+- `packages/docx-mcp/README.md`
+
+Ejecución rápida:
+
+```bash
+npx -y @usejunior/safe-docx
+```
+
+## Para qué está optimizado Safe Docx
+
+- Edición brownfield de archivos `.docx` existentes
+- Reemplazo de texto e inserción de párrafos que preservan el formato
+- Flujos de trabajo de comentarios y notas al pie
+- Salidas con control de cambios para revisión (`download`, `compare_documents`)
+- Extracción de revisiones como JSON estructurado (`extract_revisions`)
+
+## Para qué no está optimizado Safe Docx
+
+Safe Docx no es un toolkit de generación de documentos desde cero.
+
+Si tu necesidad principal es generar nuevos archivos `.docx` desde plantillas o diseño programático, usa paquetes como [`docx`](https://www.npmjs.com/package/docx).
+
+## Familias de documentos
+
+### Cobertura automatizada de fixtures en este repositorio
+
+- Fixtures de NDA mutuo estilo Common Paper
+- Fixture de NDA mutuo Bonterms
+- Fixture de Carta de Intención
+- Fixtures de redline de acuerdo de sociedad limitada ILPA
+
+### Diseñado para clases complejas de `.docx` legales y empresariales
+
+- Formularios de financiamiento NVCA
+- SAFEs de YC
+- Memorandos de oferta
+- Formularios de pedido y acuerdos de servicios
+- Acuerdos de sociedad limitada
+
+## Paquetes
+
+- `@usejunior/docx-core`: primitivas y motor de comparación para documentos `.docx` existentes
+- `@usejunior/docx-mcp`: implementación del servidor MCP y superficie de herramientas
+- `@usejunior/safe-docx`: nombre canónico de instalación para el usuario final (`npx -y @usejunior/safe-docx`)
+- `@usejunior/safedocx-mcpb`: wrapper privado de bundle MCP
+
+## Confiabilidad y superficie de confianza
+
+- Los esquemas de herramientas se generan desde `packages/docx-mcp/src/tool_catalog.ts`.
+- Matriz de trazabilidad OpenSpec: `packages/docx-mcp/src/testing/SAFE_DOCX_OPENSPEC_TRACEABILITY.md`
+- Matriz de supuestos: `packages/docx-mcp/assumptions.md`
+- Guía de conformidad: `docs/safe-docx/sprint-3-conformance.md`
+
+## Preguntas frecuentes
+
+### ¿Qué es Safe Docx?
+
+Un stack de edición DOCX con TypeScript como prioridad para flujos de trabajo de agentes de programación que necesitan ediciones deterministas y que preservan el formato en documentos Word existentes.
+
+### ¿Preserva el formato durante las ediciones?
+
+Ese es un objetivo central de diseño. La superficie de herramientas está construida alrededor de operaciones quirúrgicas (`replace_text`, `insert_paragraph`, controles de diseño) que preservan la estructura del documento y la semántica de formato tanto como sea posible.
+
+### ¿Requiere .NET, Python o LibreOffice en uso normal?
+
+No. El uso soportado en tiempo de ejecución es JavaScript/TypeScript con `jszip` + `@xmldom/xmldom`.
+
+### ¿Puede generar contratos desde cero?
+
+No es el enfoque principal. Para generación desde cero, usa paquetes como [`docx`](https://www.npmjs.com/package/docx).
+
+### ¿Qué tipos de documentos se han probado en los fixtures del repositorio?
+
+NDAs mutuos (incluyendo fixtures estilo Common Paper/Bonterms), Carta de Intención y fixtures de redline de acuerdo de sociedad limitada ILPA.
+
+### ¿Esto es solo para abogados?
+
+No. Los mismos problemas de edición de archivos `.docx` existentes aparecen en recursos humanos, adquisiciones, finanzas, operaciones de ventas y otros flujos de trabajo con mucho papeleo.
+
+### ¿Por dónde debería empezar como usuario de MCP?
+
+Usa `@usejunior/safe-docx` vía `npx`, luego sigue los ejemplos de configuración en `packages/docx-mcp/README.md`.
+
+### ¿Dónde puedo inspeccionar los esquemas de herramientas?
+
+Consulta la referencia generada en `packages/docx-mcp/docs/tool-reference.generated.md`.
+
+## Desarrollo
+
+```bash
+npm ci
+npm run build
+npm run lint --workspaces --if-present
+npm run test:run
+npm run check:spec-coverage
+npm run test:coverage:packages
+npm run coverage:packages:check
+npm run coverage:matrix
+```
+
+## Ver también
+
+- [Open Agreements](https://github.com/open-agreements/open-agreements) — llena plantillas legales estándar con agentes de programación (NDAs, SAFEs, NVCA)
+- [Herramientas para desarrolladores UseJunior](https://usejunior.com/developer-tools/safe-docx) — página del producto con opciones de instalación y catálogo de herramientas
+
+## Privacidad
+
+Safe Docx se ejecuta completamente en tu máquina local. No se envía contenido de documentos a servidores externos. Consulta nuestra [Política de Privacidad](https://usejunior.com/privacy_policy) para más detalles.
+
+## Gobernanza
+
+- [Guía de contribución](CONTRIBUTING.md)
+- [Código de conducta](CODE_OF_CONDUCT.md)
+- [Política de seguridad](SECURITY.md)
+- [Registro de cambios](CHANGELOG.md)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![CI](https://github.com/usejunior/safe-docx/actions/workflows/ci.yml/badge.svg)](https://github.com/usejunior/safe-docx/actions/workflows/ci.yml)
 [![codecov](https://img.shields.io/codecov/c/github/usejunior/safe-docx/main)](https://app.codecov.io/gh/usejunior/safe-docx)
 
+[English](./README.md) | [Español](./README.es.md) | [简体中文](./README.zh.md) | [Português (Brasil)](./README.pt-br.md) | [Deutsch](./README.de.md)
+
 **safe-docx** by [UseJunior](https://usejunior.com) — use coding agents for paperwork too.
 
 Part of the [UseJunior developer tools](https://usejunior.com/developer-tools/safe-docx).

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -1,0 +1,156 @@
+# Safe DOCX Suite
+
+[![CI](https://github.com/usejunior/safe-docx/actions/workflows/ci.yml/badge.svg)](https://github.com/usejunior/safe-docx/actions/workflows/ci.yml)
+[![codecov](https://img.shields.io/codecov/c/github/usejunior/safe-docx/main)](https://app.codecov.io/gh/usejunior/safe-docx)
+
+[English](./README.md) | [Español](./README.es.md) | [简体中文](./README.zh.md) | [Português (Brasil)](./README.pt-br.md) | [Deutsch](./README.de.md)
+
+> **Nota de tradução:** A versão em inglês `README.md` é a fonte canônica da verdade. Esta tradução pode ter um breve atraso. Atualizações importantes do README em inglês devem ser sincronizadas com este arquivo em até 72 horas.
+
+**safe-docx** por [UseJunior](https://usejunior.com) — use agentes de programação também para a burocracia.
+
+Parte das [ferramentas para desenvolvedores da UseJunior](https://usejunior.com/developer-tools/safe-docx).
+
+Safe Docx é um stack TypeScript de código aberto para edição cirúrgica de arquivos Microsoft Word `.docx` existentes. Foi construído para fluxos de trabalho onde um agente propõe alterações e um humano ainda precisa de edições de documentos confiáveis que preservem a formatação.
+
+Se você revisa contratos com IA, a etapa mais lenta geralmente é aplicar as recomendações aceitas no Word. Safe Docx transforma isso em chamadas de ferramentas determinísticas.
+
+## Por que este projeto existe
+
+CLIs de programação com IA são ótimos com código e arquivos de texto, mas fracos na edição de arquivos `.docx` existentes. Fluxos de trabalho empresariais e jurídicos ainda funcionam com documentos Word, então construímos um caminho nativo em TypeScript para:
+
+- ler e pesquisar documentos existentes em formatos eficientes em tokens
+- fazer edições cirúrgicas sem destruir a formatação
+- produzir saídas limpas/com controle de alterações e artefatos de extração de revisões
+
+Missão: permitir que agentes de programação também façam burocracia. Safe Docx foca em edições determinísticas de arquivos Word existentes onde a formatação e a semântica de revisão devem sobreviver à automação.
+
+## Posicionamento
+
+Safe Docx é otimizado para fluxos de trabalho de agentes que precisam de edições determinísticas e locais em arquivos `.docx` existentes:
+
+- ferramentas MCP tipadas para edição, comparação, extração de revisões, comentários, notas de rodapé e layout
+- comportamento auditável com evidências de teste e artefatos de rastreabilidade
+- distribuição em tempo de execução TypeScript sem necessidade de Python ou LibreOffice para uso suportado
+
+Safe Docx não pretende substituir bibliotecas de `.docx` orientadas à geração.
+
+## Comece aqui
+
+Para configuração e uso diário, acesse:
+
+- `packages/docx-mcp/README.md`
+
+Execução rápida:
+
+```bash
+npx -y @usejunior/safe-docx
+```
+
+## Para que o Safe Docx é otimizado
+
+- Edição brownfield de arquivos `.docx` existentes
+- Substituição de texto e inserção de parágrafos que preservam a formatação
+- Fluxos de trabalho de comentários e notas de rodapé
+- Saídas com controle de alterações para revisão (`download`, `compare_documents`)
+- Extração de revisões como JSON estruturado (`extract_revisions`)
+
+## Para que o Safe Docx não é otimizado
+
+Safe Docx não é um toolkit de geração de documentos do zero.
+
+Se sua necessidade principal é gerar novos arquivos `.docx` a partir de templates ou layout programático, use pacotes como [`docx`](https://www.npmjs.com/package/docx).
+
+## Famílias de documentos
+
+### Cobertura automatizada de fixtures neste repositório
+
+- Fixtures de NDA mútuo estilo Common Paper
+- Fixture de NDA mútuo Bonterms
+- Fixture de Carta de Intenção
+- Fixtures de redline de acordo de sociedade limitada ILPA
+
+### Projetado para classes complexas de `.docx` jurídicos e empresariais
+
+- Formulários de financiamento NVCA
+- SAFEs do YC
+- Memorandos de oferta
+- Formulários de pedido e acordos de serviços
+- Acordos de sociedade limitada
+
+## Pacotes
+
+- `@usejunior/docx-core`: primitivas e motor de comparação para documentos `.docx` existentes
+- `@usejunior/docx-mcp`: implementação do servidor MCP e superfície de ferramentas
+- `@usejunior/safe-docx`: nome canônico de instalação para o usuário final (`npx -y @usejunior/safe-docx`)
+- `@usejunior/safedocx-mcpb`: wrapper privado de bundle MCP
+
+## Confiabilidade e superfície de confiança
+
+- Os esquemas de ferramentas são gerados a partir de `packages/docx-mcp/src/tool_catalog.ts`.
+- Matriz de rastreabilidade OpenSpec: `packages/docx-mcp/src/testing/SAFE_DOCX_OPENSPEC_TRACEABILITY.md`
+- Matriz de premissas: `packages/docx-mcp/assumptions.md`
+- Guia de conformidade: `docs/safe-docx/sprint-3-conformance.md`
+
+## Perguntas frequentes
+
+### O que é Safe Docx?
+
+Um stack de edição DOCX com TypeScript como prioridade para fluxos de trabalho de agentes de programação que precisam de edições determinísticas e que preservam a formatação em documentos Word existentes.
+
+### Preserva a formatação durante as edições?
+
+Esse é um objetivo central de design. A superfície de ferramentas é construída em torno de operações cirúrgicas (`replace_text`, `insert_paragraph`, controles de layout) que preservam a estrutura do documento e a semântica de formatação o máximo possível.
+
+### Requer .NET, Python ou LibreOffice em uso normal?
+
+Não. O uso suportado em tempo de execução é JavaScript/TypeScript com `jszip` + `@xmldom/xmldom`.
+
+### Pode gerar contratos do zero?
+
+Não é o foco principal. Para geração do zero, use pacotes como [`docx`](https://www.npmjs.com/package/docx).
+
+### Quais tipos de documentos foram testados nos fixtures do repositório?
+
+NDAs mútuos (incluindo fixtures estilo Common Paper/Bonterms), Carta de Intenção e fixtures de redline de acordo de sociedade limitada ILPA.
+
+### Isso é só para advogados?
+
+Não. Os mesmos problemas de edição de arquivos `.docx` existentes aparecem em recursos humanos, compras, finanças, operações de vendas e outros fluxos de trabalho com muita burocracia.
+
+### Por onde devo começar como usuário de MCP?
+
+Use `@usejunior/safe-docx` via `npx`, depois siga os exemplos de configuração em `packages/docx-mcp/README.md`.
+
+### Onde posso inspecionar os esquemas de ferramentas?
+
+Consulte a referência gerada em `packages/docx-mcp/docs/tool-reference.generated.md`.
+
+## Desenvolvimento
+
+```bash
+npm ci
+npm run build
+npm run lint --workspaces --if-present
+npm run test:run
+npm run check:spec-coverage
+npm run test:coverage:packages
+npm run coverage:packages:check
+npm run coverage:matrix
+```
+
+## Veja também
+
+- [Open Agreements](https://github.com/open-agreements/open-agreements) — preencha templates jurídicos padrão com agentes de programação (NDAs, SAFEs, NVCA)
+- [Ferramentas para desenvolvedores UseJunior](https://usejunior.com/developer-tools/safe-docx) — página do produto com opções de instalação e catálogo de ferramentas
+
+## Privacidade
+
+Safe Docx é executado inteiramente na sua máquina local. Nenhum conteúdo de documento é enviado para servidores externos. Consulte nossa [Política de Privacidade](https://usejunior.com/privacy_policy) para detalhes.
+
+## Governança
+
+- [Guia de contribuição](CONTRIBUTING.md)
+- [Código de conduta](CODE_OF_CONDUCT.md)
+- [Política de segurança](SECURITY.md)
+- [Registro de alterações](CHANGELOG.md)

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,0 +1,156 @@
+# Safe DOCX Suite
+
+[![CI](https://github.com/usejunior/safe-docx/actions/workflows/ci.yml/badge.svg)](https://github.com/usejunior/safe-docx/actions/workflows/ci.yml)
+[![codecov](https://img.shields.io/codecov/c/github/usejunior/safe-docx/main)](https://app.codecov.io/gh/usejunior/safe-docx)
+
+[English](./README.md) | [Español](./README.es.md) | [简体中文](./README.zh.md) | [Português (Brasil)](./README.pt-br.md) | [Deutsch](./README.de.md)
+
+> **翻译说明：** 英文版 `README.md` 是规范的事实来源。此翻译可能会有短暂滞后。英文 README 的重大更新应在 72 小时内同步到本文件。
+
+**safe-docx** 由 [UseJunior](https://usejunior.com) 开发 — 让编程代理也能处理文书工作。
+
+隶属于 [UseJunior 开发者工具](https://usejunior.com/developer-tools/safe-docx)。
+
+Safe Docx 是一套开源 TypeScript 技术栈，用于对现有 Microsoft Word `.docx` 文件进行精确编辑。它专为代理提出更改建议、人工仍需可靠且保留格式的文档编辑场景而构建。
+
+如果你使用 AI 审阅合同，最慢的步骤往往是在 Word 中应用已接受的建议。Safe Docx 将其转化为确定性工具调用。
+
+## 为什么需要这个项目
+
+AI 编程 CLI 在处理代码和文本文件方面表现出色，但在编辑已有 `.docx` 文件时能力不足。商业和法律工作流仍然依赖 Word 文档，因此我们构建了原生 TypeScript 路径：
+
+- 以 token 高效的格式读取和搜索现有文档
+- 在不破坏格式的前提下进行精确编辑
+- 生成干净的/带修订标记的输出和修订提取产物
+
+使命：让编程代理也能处理文书工作。Safe Docx 专注于对现有 Word 文件的确定性编辑，确保格式和审阅语义在自动化过程中得以保留。
+
+## 定位
+
+Safe Docx 针对需要确定性、本地优先编辑现有 `.docx` 文件的代理工作流进行了优化：
+
+- 用于编辑、比较、修订提取、批注、脚注和布局的类型化 MCP 工具
+- 具备测试证据和可追溯性产物的可审计行为
+- TypeScript 运行时分发，支持的使用场景无需 Python 或 LibreOffice
+
+Safe Docx 不旨在替代以生成为主的 `.docx` 库。
+
+## 从这里开始
+
+设置和日常使用请参阅：
+
+- `packages/docx-mcp/README.md`
+
+快速运行：
+
+```bash
+npx -y @usejunior/safe-docx
+```
+
+## Safe Docx 擅长什么
+
+- 对现有 `.docx` 文件的棕地编辑
+- 保留格式的文本替换和段落插入
+- 批注和脚注工作流
+- 带修订标记的输出供审阅（`download`、`compare_documents`）
+- 将修订提取为结构化 JSON（`extract_revisions`）
+
+## Safe Docx 不擅长什么
+
+Safe Docx 不是从零开始的文档生成工具包。
+
+如果你的主要需求是从模板或程序化布局生成新 `.docx` 文件，请使用 [`docx`](https://www.npmjs.com/package/docx) 等包。
+
+## 文档类别
+
+### 本仓库中的自动化测试覆盖
+
+- Common Paper 风格双向 NDA 测试文件
+- Bonterms 双向 NDA 测试文件
+- 意向书测试文件
+- ILPA 有限合伙协议红线标注测试文件
+
+### 为复杂法律和商业 `.docx` 类别设计
+
+- NVCA 融资表格
+- YC SAFE 协议
+- 发行备忘录
+- 订单和服务协议
+- 有限合伙协议
+
+## 包
+
+- `@usejunior/docx-core`：现有 `.docx` 文档的原语和比较引擎
+- `@usejunior/docx-mcp`：MCP 服务器实现和工具表面
+- `@usejunior/safe-docx`：规范的终端用户安装名（`npx -y @usejunior/safe-docx`）
+- `@usejunior/safedocx-mcpb`：私有 MCP 打包封装
+
+## 可靠性与信任表面
+
+- 工具模式从 `packages/docx-mcp/src/tool_catalog.ts` 生成。
+- OpenSpec 可追溯性矩阵：`packages/docx-mcp/src/testing/SAFE_DOCX_OPENSPEC_TRACEABILITY.md`
+- 假设矩阵：`packages/docx-mcp/assumptions.md`
+- 一致性指南：`docs/safe-docx/sprint-3-conformance.md`
+
+## 常见问题
+
+### Safe Docx 是什么？
+
+一个 TypeScript 优先的 DOCX 编辑技术栈，面向需要对现有 Word 文档进行确定性、保留格式编辑的编程代理工作流。
+
+### 编辑时是否保留格式？
+
+这是核心设计目标。工具表面围绕精确操作（`replace_text`、`insert_paragraph`、布局控制）构建，尽可能保留文档结构和格式语义。
+
+### 正常运行时是否需要 .NET、Python 或 LibreOffice？
+
+不需要。支持的运行时使用 JavaScript/TypeScript 配合 `jszip` + `@xmldom/xmldom`。
+
+### 能从零开始生成合同吗？
+
+这不是主要关注点。从零生成请使用 [`docx`](https://www.npmjs.com/package/docx) 等包。
+
+### 本仓库测试文件中测试了哪些文档类型？
+
+双向 NDA（包括 Common Paper/Bonterms 风格测试文件）、意向书和 ILPA 有限合伙协议红线标注测试文件。
+
+### 这只是给律师用的吗？
+
+不是。同样的已有 `.docx` 文件编辑问题也出现在人力资源、采购、财务、销售运营和其他文书密集型工作流中。
+
+### 作为 MCP 用户，我应该从哪里开始？
+
+通过 `npx` 使用 `@usejunior/safe-docx`，然后参照 `packages/docx-mcp/README.md` 中的设置示例。
+
+### 在哪里可以查看工具模式？
+
+请参阅 `packages/docx-mcp/docs/tool-reference.generated.md` 中的生成参考。
+
+## 开发
+
+```bash
+npm ci
+npm run build
+npm run lint --workspaces --if-present
+npm run test:run
+npm run check:spec-coverage
+npm run test:coverage:packages
+npm run coverage:packages:check
+npm run coverage:matrix
+```
+
+## 另请参阅
+
+- [Open Agreements](https://github.com/open-agreements/open-agreements) — 使用编程代理填写标准法律模板（NDA、SAFE、NVCA）
+- [UseJunior 开发者工具](https://usejunior.com/developer-tools/safe-docx) — 产品页面，包含安装选项和工具目录
+
+## 隐私
+
+Safe Docx 完全在你的本地机器上运行。不会向外部服务器发送任何文档内容。详见我们的[隐私政策](https://usejunior.com/privacy_policy)。
+
+## 治理
+
+- [贡献指南](CONTRIBUTING.md)
+- [行为准则](CODE_OF_CONDUCT.md)
+- [安全政策](SECURITY.md)
+- [更新日志](CHANGELOG.md)


### PR DESCRIPTION
## Summary
- Add full README translations: Chinese (Simplified), Spanish, Portuguese (Brazil), German
- Each translation includes a 72-hour sync note pointing to English README as canonical source
- Add language selector line to main README matching the pattern used in open-agreements

## Languages
| File | Language |
|------|----------|
| `README.zh.md` | 简体中文 (Chinese Simplified) |
| `README.es.md` | Español (Spanish) |
| `README.pt-br.md` | Português (Brasil) |
| `README.de.md` | Deutsch (German) |

## Test plan
- [ ] Verify language selector links in main README resolve to correct files
- [ ] Spot-check translation accuracy in each file
- [ ] Confirm badge URLs and external links are unchanged