### PR TITLE
chore(release): bump to 0.7.1 — fix paragraph similarity alignment (#61)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "safe-docx-suite",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "safe-docx-suite",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -7906,7 +7906,7 @@
     },
     "packages/allure-test-factory": {
       "name": "@usejunior/allure-test-factory",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -7927,7 +7927,7 @@
     },
     "packages/docx-core": {
       "name": "@usejunior/docx-core",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.10",
@@ -7954,11 +7954,11 @@
     },
     "packages/docx-mcp": {
       "name": "@usejunior/docx-mcp",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@usejunior/docx-core": "^0.7.0",
+        "@usejunior/docx-core": "^0.7.1",
         "zod": "^4.3.6"
       },
       "bin": {
@@ -7978,7 +7978,7 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@usejunior/google-docs-core": "^0.7.0"
+        "@usejunior/google-docs-core": "^0.7.1"
       },
       "peerDependenciesMeta": {
         "@usejunior/google-docs-core": {
@@ -7988,7 +7988,7 @@
     },
     "packages/google-docs-core": {
       "name": "@usejunior/google-docs-core",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
         "google-auth-library": "^9.0.0"
@@ -8004,10 +8004,10 @@
     },
     "packages/safe-docx": {
       "name": "@usejunior/safe-docx",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
-        "@usejunior/docx-mcp": "^0.7.0"
+        "@usejunior/docx-mcp": "^0.7.1"
       },
       "bin": {
         "safe-docx": "bin/safe-docx.js",
@@ -8019,10 +8019,10 @@
     },
     "packages/safe-docx-mcpb": {
       "name": "@usejunior/safedocx-mcpb",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
-        "@usejunior/safe-docx": "^0.7.0"
+        "@usejunior/safe-docx": "^0.7.1"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-docx-suite",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": true,
   "description": "Monorepo for Safe DOCX packages",
   "repository": {

--- a/packages/allure-test-factory/package.json
+++ b/packages/allure-test-factory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/allure-test-factory",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Shared Allure test helpers for vitest — BDD context, OpenSpec auto-inference, Prism.js highlighting",
   "type": "module",
   "exports": {

--- a/packages/docx-core/package.json
+++ b/packages/docx-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/docx-core",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "OOXML (.docx) core library: primitives, comparison, and track changes",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/docx-mcp/package.json
+++ b/packages/docx-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/docx-mcp",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Safe Docx MCP server (TypeScript)",
   "type": "module",
   "main": "dist/index.js",
@@ -26,7 +26,7 @@
     "lint": "tsc -b --pretty false"
   },
   "dependencies": {
-    "@usejunior/docx-core": "^0.7.0",
+    "@usejunior/docx-core": "^0.7.1",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "zod": "^4.3.6"
   },
@@ -53,7 +53,7 @@
     "dist"
   ],
   "peerDependencies": {
-    "@usejunior/google-docs-core": "^0.7.0"
+    "@usejunior/google-docs-core": "^0.7.1"
   },
   "peerDependenciesMeta": {
     "@usejunior/google-docs-core": {

--- a/packages/google-docs-core/package.json
+++ b/packages/google-docs-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/google-docs-core",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Google Docs core library: read, write, and anchor management via Google Docs API",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/safe-docx-mcpb/manifest.json
+++ b/packages/safe-docx-mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "safe-docx",
   "display_name": "Safe Docx",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "AI-native Word document editing with stable paragraph anchors and deterministic DOCX operations.",
   "long_description": "Safe Docx lets Claude work directly with .docx files on your local filesystem. It provides stable paragraph IDs (jr_para_*) for precise editing while preserving formatting and structure.\n\nCore capabilities include reading/searching content, formatting-preserving edits and inserts, deterministic layout controls, tracked-changes output, comments, footnote tools, document comparison, and revision extraction.",
   "author": {

--- a/packages/safe-docx-mcpb/package.json
+++ b/packages/safe-docx-mcpb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/safedocx-mcpb",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": true,
   "description": "Claude Desktop MCP Bundle (.mcpb) wrapper for @usejunior/safe-docx",
   "type": "module",
@@ -14,7 +14,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@usejunior/safe-docx": "^0.7.0"
+    "@usejunior/safe-docx": "^0.7.1"
   },
   "devDependencies": {
     "@vitest/runner": "^3.2.4",

--- a/packages/safe-docx/package.json
+++ b/packages/safe-docx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/safe-docx",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Canonical npm package for the Safe Docx MCP server and CLI",
   "mcpName": "io.github.UseJunior/safe-docx",
   "type": "module",
@@ -25,7 +25,7 @@
     "safedocx": "./bin/safe-docx.js"
   },
   "dependencies": {
-    "@usejunior/docx-mcp": "^0.7.0"
+    "@usejunior/docx-mcp": "^0.7.1"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/safe-docx/server.json
+++ b/packages/safe-docx/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.UseJunior/safe-docx",
   "title": "Safe Docx",
   "description": "AI-native surgical editing of existing Word .docx files with formatting preservation",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "websiteUrl": "https://usejunior.com/developer-tools/safe-docx",
   "icons": [
     {
@@ -18,7 +18,7 @@
     {
       "registryType": "npm",
       "identifier": "@usejunior/safe-docx",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "transport": {
         "type": "stdio"
       },

--- a/site/package.json
+++ b/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/safe-docx-site",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": true,
   "type": "module",
   "description": "Safe DOCX marketing and trust site (Eleventy)",


### PR DESCRIPTION
## Summary

Patch release for the paragraph similarity alignment fix merged in #62.

- Bumps all workspace versions from 0.7.0 → 0.7.1
- Updates cross-workspace dependency ranges and package-lock.json

### What's in 0.7.1

- **fix(docx-core):** Order-constrained TF-IDF paragraph matching prevents phantom redlines on legal boilerplate documents (#62, fixes #61)

## Test plan

- [x] Version sync verified by bump script (`--check`)
- [x] All docx-core tests pass (1053 passed)
- [x] All docx-mcp tests pass (636 passed)