### PR TITLE
fix(docx-core): container-aware inplace matching for tables with merged cells

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,11 @@ jobs:
             echo "Tag version ($TAG_VERSION) must match packages/safe-docx/server.json version ($SERVER_VERSION)."
             exit 1
           fi
+          SMITHERY_VERSION="$(node -e "const fs=require('fs');const m=JSON.parse(fs.readFileSync('./packages/safe-docx/.smithery/shttp/manifest.json','utf8'));process.stdout.write(m.payload.serverCard.serverInfo.version)")"
+          if [ "$TAG_VERSION" != "$SMITHERY_VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) must match packages/safe-docx/.smithery/shttp/manifest.json version ($SMITHERY_VERSION)."
+            exit 1
+          fi
 
       - name: Verify release commit is on main
         run: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "safe-docx-suite",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "safe-docx-suite",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -7906,7 +7906,7 @@
     },
     "packages/allure-test-factory": {
       "name": "@usejunior/allure-test-factory",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -7927,7 +7927,7 @@
     },
     "packages/docx-core": {
       "name": "@usejunior/docx-core",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.10",
@@ -7954,11 +7954,11 @@
     },
     "packages/docx-mcp": {
       "name": "@usejunior/docx-mcp",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@usejunior/docx-core": "^0.7.1",
+        "@usejunior/docx-core": "^0.7.2",
         "zod": "^4.3.6"
       },
       "bin": {
@@ -7978,7 +7978,7 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@usejunior/google-docs-core": "^0.7.1"
+        "@usejunior/google-docs-core": "^0.7.2"
       },
       "peerDependenciesMeta": {
         "@usejunior/google-docs-core": {
@@ -7988,7 +7988,7 @@
     },
     "packages/google-docs-core": {
       "name": "@usejunior/google-docs-core",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "dependencies": {
         "google-auth-library": "^9.0.0"
@@ -8004,10 +8004,10 @@
     },
     "packages/safe-docx": {
       "name": "@usejunior/safe-docx",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "dependencies": {
-        "@usejunior/docx-mcp": "^0.7.1"
+        "@usejunior/docx-mcp": "^0.7.2"
       },
       "bin": {
         "safe-docx": "bin/safe-docx.js",
@@ -8019,10 +8019,10 @@
     },
     "packages/safe-docx-mcpb": {
       "name": "@usejunior/safedocx-mcpb",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "dependencies": {
-        "@usejunior/safe-docx": "^0.7.1"
+        "@usejunior/safe-docx": "^0.7.2"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-docx-suite",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": true,
   "description": "Monorepo for Safe DOCX packages",
   "repository": {

--- a/packages/allure-test-factory/package.json
+++ b/packages/allure-test-factory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/allure-test-factory",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Shared Allure test helpers for vitest — BDD context, OpenSpec auto-inference, Prism.js highlighting",
   "type": "module",
   "exports": {

--- a/packages/docx-core/package.json
+++ b/packages/docx-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/docx-core",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "OOXML (.docx) core library: primitives, comparison, and track changes",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/docx-core/src/baselines/atomizer/atomLcs.ts
+++ b/packages/docx-core/src/baselines/atomizer/atomLcs.ts
@@ -283,20 +283,50 @@ export function createMergedAtomList(
  * @param merged - Merged atom list
  * @param lcsResult - LCS result with matches
  */
+/**
+ * Compute a container key for an atom based on its ancestor chain.
+ * For atoms inside table cells, produces a string like "w:tbl:0/w:tr:2/w:tc:1".
+ * For atoms not in tables, produces "".
+ * Used to prevent cross-cell paragraph matches in unified index assignment.
+ */
+function getAtomContainerKey(atom: ComparisonUnitAtom): string {
+  const parts: string[] = [];
+  for (const el of atom.ancestorElements) {
+    if (el.tagName === 'w:tc' || el.tagName === 'w:tr' || el.tagName === 'w:tbl') {
+      let index = 0;
+      let sibling = el.previousSibling;
+      while (sibling) {
+        if (sibling.nodeType === 1 && (sibling as Element).tagName === el.tagName) {
+          index++;
+        }
+        sibling = sibling.previousSibling;
+      }
+      parts.push(`${el.tagName}:${index}`);
+    }
+  }
+  return parts.join('/');
+}
+
 export function assignUnifiedParagraphIndices(
   original: ComparisonUnitAtom[],
   revised: ComparisonUnitAtom[],
   merged: ComparisonUnitAtom[],
   lcsResult: LcsResult
 ): void {
-  // Build paragraph correspondence from matches
+  // Build paragraph correspondence from matches.
+  // Container-aware (issue #65): skip matches where atoms are in different
+  // structural containers (e.g., different table cells) to prevent empty
+  // paragraphs from matching across cell boundaries.
   const originalToRevisedPara = new Map<number, number>();
   for (const match of lcsResult.matches) {
     const origAtom = original[match.originalIndex]!;
     const revAtom = revised[match.revisedIndex]!;
     if (origAtom.paragraphIndex !== undefined && revAtom.paragraphIndex !== undefined) {
       if (!originalToRevisedPara.has(origAtom.paragraphIndex)) {
-        originalToRevisedPara.set(origAtom.paragraphIndex, revAtom.paragraphIndex);
+        // Only establish correspondence if atoms are in the same container
+        if (getAtomContainerKey(origAtom) === getAtomContainerKey(revAtom)) {
+          originalToRevisedPara.set(origAtom.paragraphIndex, revAtom.paragraphIndex);
+        }
       }
     }
   }

--- a/packages/docx-core/src/baselines/atomizer/documentReconstructor-tables.test.ts
+++ b/packages/docx-core/src/baselines/atomizer/documentReconstructor-tables.test.ts
@@ -5,7 +5,8 @@
  * and other structural elements when rebuilding from atoms.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, expect } from 'vitest';
+import { testAllure } from '../../testing/allure-test.js';
 import { DOMParser } from '@xmldom/xmldom';
 import { reconstructDocument } from './documentReconstructor.js';
 import {
@@ -111,8 +112,10 @@ const DOC_WITH_SDT = [
 // Tests
 // ---------------------------------------------------------------------------
 
+const test = testAllure.epic('Document Comparison').withLabels({ feature: 'Document Reconstruction' });
+
 describe('Structure-preserving rebuild: table preservation', () => {
-  it('preserves table wrappers when all paragraphs are equal', () => {
+  test('preserves table wrappers when all paragraphs are equal', () => {
     const atoms: ComparisonUnitAtom[] = [
       makeAtom('Body para 1', CorrelationStatus.Equal, 0),
       makeAtom('Cell R1', CorrelationStatus.Equal, 1),
@@ -132,7 +135,7 @@ describe('Structure-preserving rebuild: table preservation', () => {
     expect(result).toContain('w:tcW');
   });
 
-  it('preserves table structure with tracked changes inside cells', () => {
+  test('preserves table structure with tracked changes inside cells', () => {
     const atoms: ComparisonUnitAtom[] = [
       makeAtom('Body para 1', CorrelationStatus.Equal, 0),
       makeAtom('Old Cell R1', CorrelationStatus.Deleted, 1),
@@ -151,7 +154,7 @@ describe('Structure-preserving rebuild: table preservation', () => {
     expect(result).toContain('w:ins');
   });
 
-  it('reconstructed text matches after accept-all', () => {
+  test('reconstructed text matches after accept-all', () => {
     const atoms: ComparisonUnitAtom[] = [
       makeAtom('Body para 1', CorrelationStatus.Equal, 0),
       makeAtom('Old Cell', CorrelationStatus.Deleted, 1),
@@ -170,7 +173,7 @@ describe('Structure-preserving rebuild: table preservation', () => {
     expect(acceptedText).not.toContain('Old Cell');
   });
 
-  it('reconstructed text matches after reject-all', () => {
+  test('reconstructed text matches after reject-all', () => {
     const atoms: ComparisonUnitAtom[] = [
       makeAtom('Body para 1', CorrelationStatus.Equal, 0),
       makeAtom('Old Cell', CorrelationStatus.Deleted, 1),
@@ -191,7 +194,7 @@ describe('Structure-preserving rebuild: table preservation', () => {
 });
 
 describe('Structure-preserving rebuild: inserted paragraphs', () => {
-  it('inserts paragraph in correct table cell context', () => {
+  test('inserts paragraph in correct table cell context', () => {
     // Original has 4 paragraphs, we add an extra inserted paragraph in cell 1
     const atoms: ComparisonUnitAtom[] = [
       makeAtom('Body para 1', CorrelationStatus.Equal, 0),
@@ -211,7 +214,7 @@ describe('Structure-preserving rebuild: inserted paragraphs', () => {
     expect(tblMatch![0]).toContain('Extra in cell');
   });
 
-  it('inserts paragraph before first body paragraph', () => {
+  test('inserts paragraph before first body paragraph', () => {
     // Insert a paragraph before the first body paragraph
     const atoms: ComparisonUnitAtom[] = [
       makeAtom('Prepended', CorrelationStatus.Inserted, 0),
@@ -231,7 +234,7 @@ describe('Structure-preserving rebuild: inserted paragraphs', () => {
 });
 
 describe('Structure-preserving rebuild: sectPr preservation', () => {
-  it('keeps sectPr as last child of body', () => {
+  test('keeps sectPr as last child of body', () => {
     const atoms: ComparisonUnitAtom[] = [
       makeAtom('Paragraph 1', CorrelationStatus.Equal, 0),
       makeAtom('Paragraph 2', CorrelationStatus.Equal, 1),
@@ -248,7 +251,7 @@ describe('Structure-preserving rebuild: sectPr preservation', () => {
     expect(lastTagMatch?.[1]).toBe('w:sectPr');
   });
 
-  it('does not insert after sectPr when appending', () => {
+  test('does not insert after sectPr when appending', () => {
     // Extra inserted paragraph should go before sectPr
     const atoms: ComparisonUnitAtom[] = [
       makeAtom('Paragraph 1', CorrelationStatus.Equal, 0),
@@ -267,7 +270,7 @@ describe('Structure-preserving rebuild: sectPr preservation', () => {
 });
 
 describe('Structure-preserving rebuild: SDT wrapper preservation', () => {
-  it('preserves SDT wrapper around paragraphs', () => {
+  test('preserves SDT wrapper around paragraphs', () => {
     const atoms: ComparisonUnitAtom[] = [
       makeAtom('Before SDT', CorrelationStatus.Equal, 0),
       makeAtom('Inside SDT', CorrelationStatus.Equal, 1),
@@ -286,7 +289,7 @@ describe('Structure-preserving rebuild: SDT wrapper preservation', () => {
 });
 
 describe('Structure-preserving rebuild: moved/format-changed classification', () => {
-  it('MovedSource paragraph consumes an original slot', () => {
+  test('MovedSource paragraph consumes an original slot', () => {
     const atoms: ComparisonUnitAtom[] = [
       makeAtom('Body para 1', CorrelationStatus.Equal, 0),
       makeAtom('Cell R1', CorrelationStatus.MovedSource, 1),
@@ -301,7 +304,7 @@ describe('Structure-preserving rebuild: moved/format-changed classification', ()
     expect(countTag(result, 'w:tr')).toBe(2);
   });
 
-  it('FormatChanged paragraph consumes an original slot', () => {
+  test('FormatChanged paragraph consumes an original slot', () => {
     const atoms: ComparisonUnitAtom[] = [
       makeAtom('Body para 1', CorrelationStatus.Equal, 0),
       makeAtom('Cell R1', CorrelationStatus.FormatChanged, 1),

--- a/packages/docx-core/src/baselines/atomizer/documentReconstructor-tables.test.ts
+++ b/packages/docx-core/src/baselines/atomizer/documentReconstructor-tables.test.ts
@@ -1,0 +1,318 @@
+/**
+ * Tests for structure-preserving document reconstruction (rebuild mode).
+ *
+ * Validates that the reconstructor preserves table wrappers, SDTs,
+ * and other structural elements when rebuilding from atoms.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { DOMParser } from '@xmldom/xmldom';
+import { reconstructDocument } from './documentReconstructor.js';
+import {
+  acceptAllChanges,
+  rejectAllChanges,
+  extractTextWithParagraphs,
+} from './trackChangesAcceptorAst.js';
+import type { ComparisonUnitAtom, OpcPart } from '../../core-types.js';
+import { CorrelationStatus } from '../../core-types.js';
+
+const PART: OpcPart = { uri: 'word/document.xml', contentType: 'text/xml' };
+const OPTS = { author: 'Test', date: new Date('2025-01-01T00:00:00Z') };
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeAtom(
+  text: string,
+  status: CorrelationStatus,
+  paragraphIndex: number
+): ComparisonUnitAtom {
+  const doc = new DOMParser().parseFromString(
+    `<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:r><w:t>${text}</w:t></w:r></w:p>`,
+    'application/xml'
+  );
+  const paragraph = doc.documentElement;
+  const run = paragraph.getElementsByTagName('w:r')[0]!;
+  const textEl = paragraph.getElementsByTagName('w:t')[0]!;
+
+  return {
+    sha1Hash: `hash-${text}-${paragraphIndex}`,
+    correlationStatus: status,
+    contentElement: textEl,
+    ancestorElements: [paragraph, run],
+    ancestorUnids: [],
+    part: PART,
+    paragraphIndex,
+    rPr: null,
+  };
+}
+
+function countTag(xml: string, tag: string): number {
+  const regex = new RegExp(`<${tag}[\\s/>]`, 'g');
+  return (xml.match(regex) || []).length;
+}
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+/** Document with 2 body paragraphs + 1 table (2 rows x 1 col, 1 para each) */
+const DOC_WITH_TABLE = [
+  '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>',
+  '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">',
+  '<w:body>',
+  '<w:p><w:r><w:t>Body para 1</w:t></w:r></w:p>',
+  '<w:tbl>',
+  '  <w:tblPr><w:tblBorders><w:top w:val="single" w:sz="4" w:color="0000FF"/></w:tblBorders></w:tblPr>',
+  '  <w:tr>',
+  '    <w:tc><w:tcPr><w:tcW w:w="5000" w:type="dxa"/></w:tcPr>',
+  '      <w:p><w:r><w:t>Cell R1</w:t></w:r></w:p>',
+  '    </w:tc>',
+  '  </w:tr>',
+  '  <w:tr>',
+  '    <w:tc><w:tcPr><w:tcW w:w="5000" w:type="dxa"/></w:tcPr>',
+  '      <w:p><w:r><w:t>Cell R2</w:t></w:r></w:p>',
+  '    </w:tc>',
+  '  </w:tr>',
+  '</w:tbl>',
+  '<w:p><w:r><w:t>Body para 2</w:t></w:r></w:p>',
+  '</w:body>',
+  '</w:document>',
+].join('\n');
+
+/** Document with final sectPr */
+const DOC_WITH_SECTPR = [
+  '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>',
+  '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">',
+  '<w:body>',
+  '<w:p><w:r><w:t>Paragraph 1</w:t></w:r></w:p>',
+  '<w:p><w:r><w:t>Paragraph 2</w:t></w:r></w:p>',
+  '<w:sectPr><w:pgSz w:w="12240" w:h="15840"/></w:sectPr>',
+  '</w:body>',
+  '</w:document>',
+].join('\n');
+
+/** Document with SDT wrapper */
+const DOC_WITH_SDT = [
+  '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>',
+  '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">',
+  '<w:body>',
+  '<w:p><w:r><w:t>Before SDT</w:t></w:r></w:p>',
+  '<w:sdt><w:sdtContent>',
+  '  <w:p><w:r><w:t>Inside SDT</w:t></w:r></w:p>',
+  '</w:sdtContent></w:sdt>',
+  '<w:p><w:r><w:t>After SDT</w:t></w:r></w:p>',
+  '</w:body>',
+  '</w:document>',
+].join('\n');
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Structure-preserving rebuild: table preservation', () => {
+  it('preserves table wrappers when all paragraphs are equal', () => {
+    const atoms: ComparisonUnitAtom[] = [
+      makeAtom('Body para 1', CorrelationStatus.Equal, 0),
+      makeAtom('Cell R1', CorrelationStatus.Equal, 1),
+      makeAtom('Cell R2', CorrelationStatus.Equal, 2),
+      makeAtom('Body para 2', CorrelationStatus.Equal, 3),
+    ];
+
+    const result = reconstructDocument(atoms, DOC_WITH_TABLE, OPTS);
+
+    expect(countTag(result, 'w:tbl')).toBe(1);
+    expect(countTag(result, 'w:tr')).toBe(2);
+    expect(countTag(result, 'w:tc')).toBe(2);
+    // Table properties preserved
+    expect(result).toContain('w:tblBorders');
+    expect(result).toContain('0000FF');
+    // Cell widths preserved
+    expect(result).toContain('w:tcW');
+  });
+
+  it('preserves table structure with tracked changes inside cells', () => {
+    const atoms: ComparisonUnitAtom[] = [
+      makeAtom('Body para 1', CorrelationStatus.Equal, 0),
+      makeAtom('Old Cell R1', CorrelationStatus.Deleted, 1),
+      makeAtom('New Cell R1', CorrelationStatus.Inserted, 1),
+      makeAtom('Cell R2', CorrelationStatus.Equal, 2),
+      makeAtom('Body para 2', CorrelationStatus.Equal, 3),
+    ];
+
+    const result = reconstructDocument(atoms, DOC_WITH_TABLE, OPTS);
+
+    expect(countTag(result, 'w:tbl')).toBe(1);
+    expect(countTag(result, 'w:tr')).toBe(2);
+    expect(countTag(result, 'w:tc')).toBe(2);
+    // Should have tracked changes
+    expect(result).toContain('w:del');
+    expect(result).toContain('w:ins');
+  });
+
+  it('reconstructed text matches after accept-all', () => {
+    const atoms: ComparisonUnitAtom[] = [
+      makeAtom('Body para 1', CorrelationStatus.Equal, 0),
+      makeAtom('Old Cell', CorrelationStatus.Deleted, 1),
+      makeAtom('New Cell', CorrelationStatus.Inserted, 1),
+      makeAtom('Cell R2', CorrelationStatus.Equal, 2),
+      makeAtom('Body para 2', CorrelationStatus.Equal, 3),
+    ];
+
+    const result = reconstructDocument(atoms, DOC_WITH_TABLE, OPTS);
+    const acceptedText = extractTextWithParagraphs(acceptAllChanges(result));
+
+    expect(acceptedText).toContain('Body para 1');
+    expect(acceptedText).toContain('New Cell');
+    expect(acceptedText).toContain('Cell R2');
+    expect(acceptedText).toContain('Body para 2');
+    expect(acceptedText).not.toContain('Old Cell');
+  });
+
+  it('reconstructed text matches after reject-all', () => {
+    const atoms: ComparisonUnitAtom[] = [
+      makeAtom('Body para 1', CorrelationStatus.Equal, 0),
+      makeAtom('Old Cell', CorrelationStatus.Deleted, 1),
+      makeAtom('New Cell', CorrelationStatus.Inserted, 1),
+      makeAtom('Cell R2', CorrelationStatus.Equal, 2),
+      makeAtom('Body para 2', CorrelationStatus.Equal, 3),
+    ];
+
+    const result = reconstructDocument(atoms, DOC_WITH_TABLE, OPTS);
+    const rejectedText = extractTextWithParagraphs(rejectAllChanges(result));
+
+    expect(rejectedText).toContain('Body para 1');
+    expect(rejectedText).toContain('Old Cell');
+    expect(rejectedText).toContain('Cell R2');
+    expect(rejectedText).toContain('Body para 2');
+    expect(rejectedText).not.toContain('New Cell');
+  });
+});
+
+describe('Structure-preserving rebuild: inserted paragraphs', () => {
+  it('inserts paragraph in correct table cell context', () => {
+    // Original has 4 paragraphs, we add an extra inserted paragraph in cell 1
+    const atoms: ComparisonUnitAtom[] = [
+      makeAtom('Body para 1', CorrelationStatus.Equal, 0),
+      makeAtom('Cell R1', CorrelationStatus.Equal, 1),
+      makeAtom('Extra in cell', CorrelationStatus.Inserted, 2),
+      makeAtom('Cell R2', CorrelationStatus.Equal, 3),
+      makeAtom('Body para 2', CorrelationStatus.Equal, 4),
+    ];
+
+    const result = reconstructDocument(atoms, DOC_WITH_TABLE, OPTS);
+
+    // Table structure preserved
+    expect(countTag(result, 'w:tbl')).toBe(1);
+    // The inserted paragraph should be inside the table
+    const tblMatch = result.match(/<w:tbl>[\s\S]*?<\/w:tbl>/);
+    expect(tblMatch).toBeTruthy();
+    expect(tblMatch![0]).toContain('Extra in cell');
+  });
+
+  it('inserts paragraph before first body paragraph', () => {
+    // Insert a paragraph before the first body paragraph
+    const atoms: ComparisonUnitAtom[] = [
+      makeAtom('Prepended', CorrelationStatus.Inserted, 0),
+      makeAtom('Body para 1', CorrelationStatus.Equal, 1),
+      makeAtom('Cell R1', CorrelationStatus.Equal, 2),
+      makeAtom('Cell R2', CorrelationStatus.Equal, 3),
+      makeAtom('Body para 2', CorrelationStatus.Equal, 4),
+    ];
+
+    const result = reconstructDocument(atoms, DOC_WITH_TABLE, OPTS);
+
+    // Table preserved
+    expect(countTag(result, 'w:tbl')).toBe(1);
+    // Prepended paragraph should be in the body, before the table
+    expect(result).toContain('Prepended');
+  });
+});
+
+describe('Structure-preserving rebuild: sectPr preservation', () => {
+  it('keeps sectPr as last child of body', () => {
+    const atoms: ComparisonUnitAtom[] = [
+      makeAtom('Paragraph 1', CorrelationStatus.Equal, 0),
+      makeAtom('Paragraph 2', CorrelationStatus.Equal, 1),
+    ];
+
+    const result = reconstructDocument(atoms, DOC_WITH_SECTPR, OPTS);
+
+    // sectPr should be present
+    expect(result).toContain('w:sectPr');
+    expect(result).toContain('w:pgSz');
+    // sectPr should be the last element before </w:body>
+    const bodyContent = result.match(/<w:body[^>]*>([\s\S]*?)<\/w:body>/)?.[1] ?? '';
+    const lastTagMatch = bodyContent.match(/<(w:\w+)[^>]*(?:\/>|>[\s\S]*?<\/\1>)\s*$/);
+    expect(lastTagMatch?.[1]).toBe('w:sectPr');
+  });
+
+  it('does not insert after sectPr when appending', () => {
+    // Extra inserted paragraph should go before sectPr
+    const atoms: ComparisonUnitAtom[] = [
+      makeAtom('Paragraph 1', CorrelationStatus.Equal, 0),
+      makeAtom('Paragraph 2', CorrelationStatus.Equal, 1),
+      makeAtom('Appended', CorrelationStatus.Inserted, 2),
+    ];
+
+    const result = reconstructDocument(atoms, DOC_WITH_SECTPR, OPTS);
+
+    expect(result).toContain('Appended');
+    // sectPr should still be last
+    const bodyContent = result.match(/<w:body[^>]*>([\s\S]*?)<\/w:body>/)?.[1] ?? '';
+    const lastTagMatch = bodyContent.match(/<(w:\w+)[^>]*(?:\/>|>[\s\S]*?<\/\1>)\s*$/);
+    expect(lastTagMatch?.[1]).toBe('w:sectPr');
+  });
+});
+
+describe('Structure-preserving rebuild: SDT wrapper preservation', () => {
+  it('preserves SDT wrapper around paragraphs', () => {
+    const atoms: ComparisonUnitAtom[] = [
+      makeAtom('Before SDT', CorrelationStatus.Equal, 0),
+      makeAtom('Inside SDT', CorrelationStatus.Equal, 1),
+      makeAtom('After SDT', CorrelationStatus.Equal, 2),
+    ];
+
+    const result = reconstructDocument(atoms, DOC_WITH_SDT, OPTS);
+
+    expect(result).toContain('w:sdt');
+    expect(result).toContain('w:sdtContent');
+    // The SDT-wrapped paragraph should be inside the SDT
+    const sdtMatch = result.match(/<w:sdt>[\s\S]*?<\/w:sdt>/);
+    expect(sdtMatch).toBeTruthy();
+    expect(sdtMatch![0]).toContain('Inside SDT');
+  });
+});
+
+describe('Structure-preserving rebuild: moved/format-changed classification', () => {
+  it('MovedSource paragraph consumes an original slot', () => {
+    const atoms: ComparisonUnitAtom[] = [
+      makeAtom('Body para 1', CorrelationStatus.Equal, 0),
+      makeAtom('Cell R1', CorrelationStatus.MovedSource, 1),
+      makeAtom('Cell R2', CorrelationStatus.Equal, 2),
+      makeAtom('Body para 2', CorrelationStatus.Equal, 3),
+    ];
+
+    const result = reconstructDocument(atoms, DOC_WITH_TABLE, OPTS);
+
+    // Table should still be preserved
+    expect(countTag(result, 'w:tbl')).toBe(1);
+    expect(countTag(result, 'w:tr')).toBe(2);
+  });
+
+  it('FormatChanged paragraph consumes an original slot', () => {
+    const atoms: ComparisonUnitAtom[] = [
+      makeAtom('Body para 1', CorrelationStatus.Equal, 0),
+      makeAtom('Cell R1', CorrelationStatus.FormatChanged, 1),
+      makeAtom('Cell R2', CorrelationStatus.Equal, 2),
+      makeAtom('Body para 2', CorrelationStatus.Equal, 3),
+    ];
+
+    const result = reconstructDocument(atoms, DOC_WITH_TABLE, OPTS);
+
+    // Table should still be preserved
+    expect(countTag(result, 'w:tbl')).toBe(1);
+    expect(countTag(result, 'w:tr')).toBe(2);
+  });
+});

--- a/packages/docx-core/src/baselines/atomizer/documentReconstructor.ts
+++ b/packages/docx-core/src/baselines/atomizer/documentReconstructor.ts
@@ -5,7 +5,7 @@
  * Generates w:ins, w:del, w:moveFrom, w:moveTo elements as appropriate.
  */
 
-import { DOMParser } from '@xmldom/xmldom';
+import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
 import type { ComparisonUnitAtom } from '../../core-types.js';
 import { CorrelationStatus } from '../../core-types.js';
 import { getLeafText, childElements, findChildByTagName } from '../../primitives/index.js';
@@ -129,8 +129,8 @@ export function reconstructDocument(
   const emptyCounters = getEmptyParagraphCounters();
   debug('reconstructor', `Empty paragraphs: inserted=${emptyCounters.inserted}, deleted=${emptyCounters.deleted}, equal=${emptyCounters.equal}, other=${emptyCounters.other}`);
 
-  // Reconstruct the document
-  return buildDocument(originalXml, paragraphXmls);
+  // Reconstruct the document, preserving original body structure (tables, SDTs, etc.)
+  return buildDocumentPreservingStructure(originalXml, paragraphXmls, paragraphGroups);
 }
 
 /**
@@ -1192,15 +1192,227 @@ function buildFormatChangeRun(
   return parts.join('');
 }
 
+// =============================================================================
+// Structure-Preserving Document Building
+// =============================================================================
+
 /**
- * Build the final document by replacing body content.
+ * A paragraph slot in the original body — represents one <w:p> in document order.
+ */
+interface ParagraphSlot {
+  /** Sequential index among all <w:p> in original body */
+  index: number;
+  /** The <w:p> DOM element in the original tree */
+  element: Element;
+  /** The immediate parent node (for replaceChild / insertBefore) */
+  parent: Node;
+}
+
+/**
+ * Parse the original document body into a structural map.
+ *
+ * Recursively finds ALL <w:p> elements in document order, regardless of
+ * wrapper (tables, SDTs, customXml, nested tables, etc.). This matches
+ * the atomizer's recursive tree walk in atomizer.ts.
+ */
+function parseOriginalBodyStructure(originalXml: string): {
+  doc: Document;
+  body: Element;
+  slots: ParagraphSlot[];
+} {
+  const doc = new DOMParser().parseFromString(originalXml, 'application/xml');
+  const bodies = doc.getElementsByTagName('w:body');
+  if (!bodies.length) {
+    throw new Error('Could not find w:body in document');
+  }
+  const body = bodies[0]!;
+
+  // getElementsByTagName returns ALL descendants in document order —
+  // this naturally recurses through tables, SDTs, customXml, nested tables, etc.
+  const paragraphs = body.getElementsByTagName('w:p');
+  const slots: ParagraphSlot[] = [];
+  for (let i = 0; i < paragraphs.length; i++) {
+    const el = paragraphs[i]!;
+    slots.push({ index: i, element: el, parent: el.parentNode! });
+  }
+
+  return { doc, body, slots };
+}
+
+/**
+ * Determine if a ParagraphGroup is "rooted" (maps to an original paragraph slot)
+ * or "purely inserted" (new content with no original counterpart).
+ *
+ * A group is rooted if ANY run group has a status other than Inserted or
+ * MovedDestination — i.e., it contains content from the original document.
+ * This correctly handles Equal, Deleted, MovedSource, and FormatChanged.
+ */
+function isRootedGroup(group: ParagraphGroup): boolean {
+  return group.runGroups.some(
+    (rg) =>
+      rg.status !== CorrelationStatus.Inserted &&
+      rg.status !== CorrelationStatus.MovedDestination
+  );
+}
+
+/**
+ * Build the final document preserving original body structure.
+ *
+ * Instead of replacing <w:body> content with flat paragraphs, this uses the
+ * original body DOM as a scaffold: rooted paragraphs replace their corresponding
+ * <w:p> slots, inserted paragraphs are placed adjacent to their context, and
+ * all structural wrappers (tables, SDTs, etc.) are preserved.
+ */
+function buildDocumentPreservingStructure(
+  originalXml: string,
+  paragraphXmls: string[],
+  paragraphGroups: ParagraphGroup[]
+): string {
+  const { doc, body, slots } = parseOriginalBodyStructure(originalXml);
+
+  let slotCursor = 0;
+  let lastEmittedNode: Node | null = null;
+
+  // Find body-level <w:sectPr> (must stay as last child of body)
+  const bodyChildren = childElements(body);
+  const finalSectPr = bodyChildren.length > 0 &&
+    bodyChildren[bodyChildren.length - 1]!.tagName === 'w:sectPr'
+    ? bodyChildren[bodyChildren.length - 1]!
+    : null;
+
+  for (let i = 0; i < paragraphGroups.length; i++) {
+    const group = paragraphGroups[i]!;
+    const paraXml = paragraphXmls[i]!;
+
+    // Parse the reconstructed paragraph XML into a DOM node
+    const fragDoc = new DOMParser().parseFromString(
+      `<__wrap xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006">${paraXml}</__wrap>`,
+      'application/xml'
+    );
+    const newNode = doc.importNode(fragDoc.documentElement.firstChild!, true);
+
+    if (isRootedGroup(group)) {
+      // Replace the corresponding original <w:p> slot
+      if (slotCursor < slots.length) {
+        const slot = slots[slotCursor]!;
+        slot.parent.replaceChild(newNode, slot.element);
+        lastEmittedNode = newNode;
+        slotCursor++;
+      } else {
+        // More rooted paragraphs than slots — append to body (before sectPr)
+        if (finalSectPr) {
+          body.insertBefore(newNode, finalSectPr);
+        } else {
+          body.appendChild(newNode);
+        }
+        lastEmittedNode = newNode;
+      }
+    } else {
+      // Inserted paragraph — place in context
+      if (lastEmittedNode) {
+        // Insert after the previous paragraph in the same parent
+        const parent = lastEmittedNode.parentNode!;
+        const nextSibling = lastEmittedNode.nextSibling;
+
+        // Guard: never insert after body-level <w:sectPr>
+        if (nextSibling === finalSectPr && parent === body) {
+          parent.insertBefore(newNode, finalSectPr);
+        } else {
+          parent.insertBefore(newNode, nextSibling);
+        }
+        lastEmittedNode = newNode;
+      } else if (slotCursor < slots.length) {
+        // No previous node — insert before the next rooted slot
+        const nextSlot = slots[slotCursor]!;
+        nextSlot.parent.insertBefore(newNode, nextSlot.element);
+        lastEmittedNode = newNode;
+      } else {
+        // No context — append to body (before sectPr)
+        if (finalSectPr) {
+          body.insertBefore(newNode, finalSectPr);
+        } else {
+          body.appendChild(newNode);
+        }
+        lastEmittedNode = newNode;
+      }
+    }
+  }
+
+  // Remove any leftover original <w:p> slots that weren't consumed
+  // (this happens when the original has more paragraphs than the merged result)
+  for (let i = slotCursor; i < slots.length; i++) {
+    const slot = slots[i]!;
+    slot.parent.removeChild(slot.element);
+  }
+
+  // Strip inter-paragraph bookmark/comment range markers from the scaffold.
+  // These are bookmarkStart/End, commentRangeStart/End elements that were
+  // siblings of <w:p> in the original body. The paragraph rebuilder handles
+  // its own bookmark logic, so keeping these orphaned markers causes
+  // unmatched bookmark IDs.
+  const SCAFFOLD_STRIP_TAGS = new Set([
+    'w:bookmarkStart', 'w:bookmarkEnd',
+    'w:commentRangeStart', 'w:commentRangeEnd',
+  ]);
+  const toRemove: Element[] = [];
+  for (const el of Array.from(body.getElementsByTagName('*'))) {
+    if (SCAFFOLD_STRIP_TAGS.has(el.tagName) && el.parentNode) {
+      // Only strip if NOT inside a reconstructed <w:p> (i.e., it's a scaffold remnant)
+      let insideParagraph = false;
+      let ancestor: Node | null = el.parentNode;
+      while (ancestor && ancestor !== body) {
+        if ((ancestor as Element).tagName === 'w:p') {
+          insideParagraph = true;
+          break;
+        }
+        ancestor = ancestor.parentNode;
+      }
+      if (!insideParagraph) {
+        toRemove.push(el as Element);
+      }
+    }
+  }
+  for (const el of toRemove) {
+    el.parentNode!.removeChild(el);
+  }
+
+  // Serialize modified body and splice back into original envelope
+  const serializer = new XMLSerializer();
+  let newBodyXml = serializer.serializeToString(body);
+
+  // Strip redundant xmlns:w declarations from inner elements.
+  // XMLSerializer adds xmlns:w="..." on imported paragraph/rPr nodes because
+  // they were parsed in a separate fragment document. These redundant
+  // redeclarations are valid XML but confuse some OOXML consumers (Pages,
+  // Google Docs) and prevent them from rendering tracked changes.
+  // The w: namespace is already declared on the document root element.
+  const W_NS_DECL = ' xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
+  // Keep the first declaration (on <w:body>) but remove all others
+  let firstFound = false;
+  newBodyXml = newBodyXml.replace(
+    new RegExp(W_NS_DECL.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'),
+    (match) => {
+      if (!firstFound) { firstFound = true; return match; }
+      return '';
+    }
+  );
+
+  // Replace original body in the full document string
+  const bodyRegex = /<w:body[^>]*>[\s\S]*?<\/w:body>/;
+  return originalXml.replace(bodyRegex, newBodyXml);
+}
+
+/**
+ * Build the final document by replacing body content (legacy flat mode).
  *
  * Note: sectPr elements are NOT extracted and appended separately because:
  * 1. Section properties inside pPr elements are already preserved in the reconstructed paragraphs
  * 2. The regex to extract "final sectPr" was incorrectly matching sectPr inside pPr elements
  *    and capturing large amounts of body content, causing duplicate text.
+ *
+ * @deprecated Use buildDocumentPreservingStructure instead. Retained as fallback.
  */
-function buildDocument(originalXml: string, paragraphXmls: string[]): string {
+export function buildDocument(originalXml: string, paragraphXmls: string[]): string {
   // Extract document structure
   const bodyMatch = originalXml.match(/(<w:body[^>]*>)([\s\S]*?)(<\/w:body>)/);
 

--- a/packages/docx-core/src/baselines/atomizer/hierarchicalLcs.ts
+++ b/packages/docx-core/src/baselines/atomizer/hierarchicalLcs.ts
@@ -62,7 +62,7 @@ export interface HierarchicalCompareOptions {
  */
 export interface GroupLcsResult {
   /** Matched paragraph pairs */
-  matchedGroups: Array<{ originalIndex: number; revisedIndex: number }>;
+  matchedGroups: Array<{ originalIndex: number; revisedIndex: number; containerMatch?: boolean }>;
   /** Indices of paragraphs only in original (deleted) */
   deletedGroupIndices: number[];
   /** Indices of paragraphs only in revised (inserted) */
@@ -545,6 +545,30 @@ function similarityLcs(
 }
 
 /**
+ * Compute a container key for a paragraph group based on its first atom's ancestor chain.
+ * Returns "" for body-level paragraphs, or a path like "w:tbl:0/w:tr:2/w:tc:1" for table cells.
+ */
+function getGroupContainerKey(group: ComparisonUnitGroup): string {
+  const atom = group.atoms[0];
+  if (!atom) return '';
+  const parts: string[] = [];
+  for (const el of atom.ancestorElements) {
+    if (el.tagName === 'w:tc' || el.tagName === 'w:tr' || el.tagName === 'w:tbl') {
+      let index = 0;
+      let sibling = el.previousSibling;
+      while (sibling) {
+        if (sibling.nodeType === 1 && (sibling as Element).tagName === el.tagName) {
+          index++;
+        }
+        sibling = sibling.previousSibling;
+      }
+      parts.push(`${el.tagName}:${index}`);
+    }
+  }
+  return parts.join('/');
+}
+
+/**
  * Compute LCS on paragraph groups with order-constrained similarity fallback.
  *
  * Two passes:
@@ -677,12 +701,68 @@ export function computeGroupLcs(
   }
 
   // Combine exact matches and similarity matches
-  const allMatches = [...matchedGroups, ...similarityMatches];
+  const allMatches: Array<{ originalIndex: number; revisedIndex: number; containerMatch?: boolean }> = [...matchedGroups, ...similarityMatches];
 
   // Update matched sets
   for (const match of similarityMatches) {
     matchedOriginal.add(match.originalIndex);
     matchedRevised.add(match.revisedIndex);
+  }
+
+  // === Pass 3 (issue #65): Container-position fallback ===
+  //
+  // After TF-IDF gap matching, some paragraphs remain unmatched because their
+  // cosine similarity is below the threshold. This happens when the only differing
+  // content is high-IDF words (e.g., company names in template fills).
+  //
+  // For unmatched paragraphs that are in the same structural container position
+  // (same table cell by table/row/cell index), force a match. This preserves
+  // paragraph alignment within table cells when the content is a template fill.
+  unmatchedOriginal = [];
+  for (let idx = 0; idx < n; idx++) {
+    if (!matchedOriginal.has(idx)) unmatchedOriginal.push(idx);
+  }
+  unmatchedRevised = [];
+  for (let idx = 0; idx < m; idx++) {
+    if (!matchedRevised.has(idx)) unmatchedRevised.push(idx);
+  }
+
+  if (unmatchedOriginal.length > 0 && unmatchedRevised.length > 0) {
+    // Build container keys for unmatched groups
+    const origContainerKeys = new Map<number, string>();
+    for (const idx of unmatchedOriginal) {
+      const group = originalGroups[idx]!;
+      if (group.atoms.length > 0) {
+        origContainerKeys.set(idx, getGroupContainerKey(group));
+      }
+    }
+    const revContainerKeys = new Map<number, string>();
+    for (const idx of unmatchedRevised) {
+      const group = revisedGroups[idx]!;
+      if (group.atoms.length > 0) {
+        revContainerKeys.set(idx, getGroupContainerKey(group));
+      }
+    }
+
+    // For each unmatched original in a table cell, find an unmatched revised
+    // in the same cell. Match greedily in document order.
+    const usedRevised = new Set<number>();
+    for (const origIdx of unmatchedOriginal) {
+      const origKey = origContainerKeys.get(origIdx);
+      if (!origKey) continue; // Not in a table cell
+
+      for (const revIdx of unmatchedRevised) {
+        if (usedRevised.has(revIdx)) continue;
+        const revKey = revContainerKeys.get(revIdx);
+        if (revKey === origKey) {
+          allMatches.push({ originalIndex: origIdx, revisedIndex: revIdx, containerMatch: true });
+          matchedOriginal.add(origIdx);
+          matchedRevised.add(revIdx);
+          usedRevised.add(revIdx);
+          break;
+        }
+      }
+    }
   }
 
   // Final deleted and inserted indices
@@ -765,7 +845,7 @@ export function hierarchicalCompare(
   );
 
   // Step 3: Build combined atom-level result
-  const allMatches: Array<{ originalIndex: number; revisedIndex: number }> = [];
+  const allMatches: Array<{ originalIndex: number; revisedIndex: number; containerMatch?: boolean }> = [];
   const deletedIndices: number[] = [];
   const insertedIndices: number[] = [];
 
@@ -794,7 +874,11 @@ export function hierarchicalCompare(
     const vecB = tfidfVectors.get(revGroup);
     const similarity = isExactMatch ? 1.0
       : (vecA && vecB ? computeTfidfCosineSimilarity(vecA, vecB) : 0);
-    const useAtomLcs = similarity >= similarityThreshold;
+    // Container matches (Pass 3, issue #65) always use atom LCS regardless of threshold.
+    // These are paragraphs in the same table cell position that were matched by container
+    // key, not content similarity — atom LCS is needed to produce inline tracked changes
+    // instead of whole-paragraph delete+insert.
+    const useAtomLcs = similarity >= similarityThreshold || match.containerMatch === true;
 
     if (!isExactMatch && !useAtomLcs) {
       debug('hierarchicalLcs', `Low similarity match (${similarity.toFixed(2)}): origGroup[${match.originalIndex}] "${origGroup.textContent.slice(0, 50)}..." vs revGroup[${match.revisedIndex}] "${revGroup.textContent.slice(0, 50)}..."`);

--- a/packages/docx-core/src/baselines/atomizer/inPlaceModifier.test.ts
+++ b/packages/docx-core/src/baselines/atomizer/inPlaceModifier.test.ts
@@ -22,6 +22,9 @@ import {
   mergeWhitespaceBridgedTrackChanges,
   coalesceDelInsPairChains,
   runHasVisibleContent,
+  getContainerPath,
+  resolveContainerInRevised,
+  validateContainerTopology,
 } from './inPlaceModifier.js';
 import { childElements, findAllByTagName } from '../../primitives/index.js';
 import { el } from '../../testing/dom-test-helpers.js';
@@ -3061,6 +3064,211 @@ describe('inPlaceModifier', () => {
         const spaceDelText = delTexts.find(e => e.textContent === ' ');
         expect(spaceDelText).toBeDefined();
         expect(spaceDelText!.getAttribute('xml:space')).toBe('preserve');
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Container-aware insertion helpers (issue #65)
+  // ---------------------------------------------------------------------------
+  describe('getContainerPath', () => {
+    test('returns empty array for body-level paragraph', async ({ given, when, then }: AllureBddContext) => {
+      let path: ReturnType<typeof getContainerPath>;
+      await given('a paragraph directly inside w:body', () => {});
+      await when('getContainerPath is called', () => {
+        const body = el('w:body', {}, [el('w:p')]);
+        const p = childElements(body)[0]!;
+        path = getContainerPath(p);
+      });
+      await then('the path is empty', () => {
+        expect(path).toEqual([]);
+      });
+    });
+
+    test('returns correct path for a paragraph in a table cell', async ({ given, when, then }: AllureBddContext) => {
+      let path: ReturnType<typeof getContainerPath>;
+      await given('a paragraph inside tbl[0] > tr[0] > tc[0]', () => {});
+      await when('getContainerPath is called', () => {
+        const p = el('w:p');
+        const tc = el('w:tc', {}, [el('w:tcPr'), p]);
+        const tr = el('w:tr', {}, [tc]);
+        const tbl = el('w:tbl', {}, [tr]);
+        el('w:body', {}, [tbl]);
+        path = getContainerPath(p);
+      });
+      await then('the path has tc, tr, tbl with index 0', () => {
+        expect(path).toEqual([
+          { tag: 'w:tc', index: 0 },
+          { tag: 'w:tr', index: 0 },
+          { tag: 'w:tbl', index: 0 },
+        ]);
+      });
+    });
+
+    test('returns correct indices for multi-row multi-cell table', async ({ given, when, then }: AllureBddContext) => {
+      let path: ReturnType<typeof getContainerPath>;
+      await given('a paragraph in tbl[0] > tr[2] > tc[1]', () => {});
+      await when('getContainerPath is called', () => {
+        const p = el('w:p');
+        const targetTc = el('w:tc', {}, [p]);
+        const row0 = el('w:tr', {}, [el('w:tc', {}, [el('w:p')]), el('w:tc', {}, [el('w:p')])]);
+        const row1 = el('w:tr', {}, [el('w:tc', {}, [el('w:p')])]);
+        const row2 = el('w:tr', {}, [el('w:tc', {}, [el('w:p')]), targetTc]);
+        const tbl = el('w:tbl', {}, [row0, row1, row2]);
+        el('w:body', {}, [tbl]);
+        path = getContainerPath(p);
+      });
+      await then('the path reflects tc[1], tr[2], tbl[0]', () => {
+        expect(path).toEqual([
+          { tag: 'w:tc', index: 1 },
+          { tag: 'w:tr', index: 2 },
+          { tag: 'w:tbl', index: 0 },
+        ]);
+      });
+    });
+  });
+
+  describe('resolveContainerInRevised', () => {
+    test('finds the correct cell from a path', async ({ given, when, then }: AllureBddContext) => {
+      let result: Element | null;
+      let expectedTc: Element;
+      await given('a revised body with a 3-row table', () => {});
+      await when('resolveContainerInRevised is called with path tc[1], tr[2], tbl[0]', () => {
+        expectedTc = el('w:tc', {}, [el('w:p')]);
+        const row0 = el('w:tr', {}, [el('w:tc', {}, [el('w:p')]), el('w:tc', {}, [el('w:p')])]);
+        const row1 = el('w:tr', {}, [el('w:tc', {}, [el('w:p')])]);
+        const row2 = el('w:tr', {}, [el('w:tc', {}, [el('w:p')]), expectedTc]);
+        const tbl = el('w:tbl', {}, [row0, row1, row2]);
+        const body = el('w:body', {}, [tbl]);
+        result = resolveContainerInRevised(
+          [{ tag: 'w:tc', index: 1 }, { tag: 'w:tr', index: 2 }, { tag: 'w:tbl', index: 0 }],
+          body
+        );
+      });
+      await then('the resolved element is the expected cell', () => {
+        expect(result).toBe(expectedTc);
+      });
+    });
+
+    test('returns null on empty path', async ({ given, when, then }: AllureBddContext) => {
+      let result: Element | null;
+      await given('an empty container path', () => {});
+      await when('resolveContainerInRevised is called', () => {
+        const body = el('w:body', {}, [el('w:p')]);
+        result = resolveContainerInRevised([], body);
+      });
+      await then('it returns null', () => {
+        expect(result).toBeNull();
+      });
+    });
+
+    test('returns null on structural mismatch', async ({ given, when, then }: AllureBddContext) => {
+      let result: Element | null;
+      await given('a path requesting tr[5] but only 2 rows exist', () => {});
+      await when('resolveContainerInRevised is called', () => {
+        const row0 = el('w:tr', {}, [el('w:tc', {}, [el('w:p')])]);
+        const row1 = el('w:tr', {}, [el('w:tc', {}, [el('w:p')])]);
+        const tbl = el('w:tbl', {}, [row0, row1]);
+        const body = el('w:body', {}, [tbl]);
+        result = resolveContainerInRevised(
+          [{ tag: 'w:tc', index: 0 }, { tag: 'w:tr', index: 5 }, { tag: 'w:tbl', index: 0 }],
+          body
+        );
+      });
+      await then('it returns null', () => {
+        expect(result).toBeNull();
+      });
+    });
+  });
+
+  describe('validateContainerTopology', () => {
+    test('returns true for empty path (body-level)', async ({ given, when, then }: AllureBddContext) => {
+      let result: boolean;
+      await given('an empty path', () => {});
+      await when('validateContainerTopology is called', () => {
+        const body = el('w:body', {}, [el('w:p')]);
+        result = validateContainerTopology([], body);
+      });
+      await then('it returns true', () => {
+        expect(result).toBe(true);
+      });
+    });
+
+    test('returns false when row count differs', async ({ given, when, then }: AllureBddContext) => {
+      let result: boolean;
+      await given('a path requesting tr[3] but only 1 row exists', () => {});
+      await when('validateContainerTopology is called', () => {
+        const tbl = el('w:tbl', {}, [el('w:tr', {}, [el('w:tc', {}, [el('w:p')])])]);
+        const body = el('w:body', {}, [tbl]);
+        result = validateContainerTopology(
+          [{ tag: 'w:tc', index: 0 }, { tag: 'w:tr', index: 3 }, { tag: 'w:tbl', index: 0 }],
+          body
+        );
+      });
+      await then('it returns false', () => {
+        expect(result).toBe(false);
+      });
+    });
+
+    test('returns false when cell count differs', async ({ given, when, then }: AllureBddContext) => {
+      let result: boolean;
+      await given('a path requesting tc[2] but only 1 cell exists', () => {});
+      await when('validateContainerTopology is called', () => {
+        const tbl = el('w:tbl', {}, [el('w:tr', {}, [el('w:tc', {}, [el('w:p')])])]);
+        const body = el('w:body', {}, [tbl]);
+        result = validateContainerTopology(
+          [{ tag: 'w:tc', index: 2 }, { tag: 'w:tr', index: 0 }, { tag: 'w:tbl', index: 0 }],
+          body
+        );
+      });
+      await then('it returns false', () => {
+        expect(result).toBe(false);
+      });
+    });
+  });
+
+  describe('insertDeletedParagraph (container-aware)', () => {
+    test('inserts paragraph after w:tcPr when target is a table cell', async ({ given, when, then }: AllureBddContext) => {
+      let tc: Element;
+      await given('a table cell with w:tcPr and one paragraph', () => {
+        const tcPr = el('w:tcPr');
+        const existingP = el('w:p', {}, [el('w:r', {}, [el('w:t', {}, undefined, 'existing')])]);
+        tc = el('w:tc', {}, [tcPr, existingP]);
+      });
+      await when('insertDeletedParagraph is called with null anchor and the cell as container', () => {
+        const atom = createMockAtom({
+          isEmptyParagraph: true,
+          sourceParagraphElement: el('w:p', {}, [el('w:r', {}, [el('w:t', {}, undefined, 'deleted')])]),
+        });
+        const state = createRevisionIdState();
+        insertDeletedParagraph(atom, null, tc, author, dateStr, state);
+      });
+      await then('the new paragraph is inserted after w:tcPr, not before it', () => {
+        const children = childElements(tc);
+        expect(children[0]!.tagName).toBe('w:tcPr');
+        expect(children.length).toBe(3); // tcPr + deleted para + existing para
+        // The deleted paragraph should be between tcPr and existing
+        expect(children[1]!.tagName).toBe('w:p');
+      });
+    });
+
+    test('inserts paragraph into body when not in a table', async ({ given, when, then }: AllureBddContext) => {
+      let body: Element;
+      await given('a body with one paragraph', () => {
+        body = el('w:body', {}, [el('w:p', {}, [el('w:r', {}, [el('w:t', {}, undefined, 'existing')])])]);
+      });
+      await when('insertDeletedParagraph is called with body as container', () => {
+        const atom = createMockAtom({
+          isEmptyParagraph: true,
+          sourceParagraphElement: el('w:p', {}, [el('w:r', {}, [el('w:t', {}, undefined, 'deleted')])]),
+        });
+        const state = createRevisionIdState();
+        insertDeletedParagraph(atom, null, body, author, dateStr, state);
+      });
+      await then('the new paragraph is at the start of body', () => {
+        const children = childElements(body);
+        expect(children.length).toBe(2);
+        expect(children[0]!.tagName).toBe('w:p');
       });
     });
   });

--- a/packages/docx-core/src/baselines/atomizer/inPlaceModifier.ts
+++ b/packages/docx-core/src/baselines/atomizer/inPlaceModifier.ts
@@ -51,6 +51,148 @@ function attachSourceElementPointers(atoms: ComparisonUnitAtom[]): void {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Container-aware insertion helpers (issue #65)
+// ---------------------------------------------------------------------------
+
+/**
+ * Error thrown when the original and revised documents have different table/container
+ * topology, making container-aware inplace insertion impossible.
+ * Caught by the adaptive pass loop to trigger rebuild fallback.
+ */
+export class ContainerResolutionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ContainerResolutionError';
+  }
+}
+
+/** A single step in a structural path from a paragraph up to w:body. */
+interface ContainerPathStep {
+  tag: string;
+  index: number;
+}
+
+/**
+ * Compute the structural path from a paragraph to the document body.
+ * Walks `parentNode` from the paragraph, recording {tag, index} for each
+ * structural container (w:tc, w:tr, w:tbl). Stops at w:body.
+ * Returns innermost-first order.
+ *
+ * Uses original-tree nodes — safe because only the revised tree is mutated.
+ */
+export function getContainerPath(paragraph: Element): ContainerPathStep[] {
+  const path: ContainerPathStep[] = [];
+  let current: Node | null = paragraph.parentNode;
+  while (current && (current as Element).tagName) {
+    const el = current as Element;
+    if (el.tagName === 'w:body') break;
+
+    if (el.tagName === 'w:tc' || el.tagName === 'w:tr' || el.tagName === 'w:tbl') {
+      const parent = el.parentNode as Element;
+      if (parent) {
+        let index = 0;
+        let sibling = el.previousSibling;
+        while (sibling) {
+          if (sibling.nodeType === 1 && (sibling as Element).tagName === el.tagName) {
+            index++;
+          }
+          sibling = sibling.previousSibling;
+        }
+        path.push({ tag: el.tagName, index });
+      }
+    }
+    current = el.parentNode;
+  }
+  return path;
+}
+
+/**
+ * Resolve a container path in the revised tree.
+ * Walks the path in reverse (outermost → innermost) from `body`.
+ * Returns the deepest container (typically w:tc), or null on mismatch.
+ */
+export function resolveContainerInRevised(path: ContainerPathStep[], body: Element): Element | null {
+  if (path.length === 0) return null;
+
+  let current: Element = body;
+  // Walk outermost to innermost (path is innermost-first, so reverse)
+  for (let i = path.length - 1; i >= 0; i--) {
+    const step = path[i]!;
+    const children = childElements(current).filter(c => c.tagName === step.tag);
+    const child = children[step.index];
+    if (!child) return null; // Structural mismatch
+    current = child;
+  }
+  return current;
+}
+
+/**
+ * Validate that the revised tree has compatible topology at the given path.
+ * Checks row count and cell count match at the target position.
+ * Returns false if there's a structural mismatch (row/cell additions, gridSpan divergence).
+ */
+export function validateContainerTopology(path: ContainerPathStep[], body: Element): boolean {
+  if (path.length === 0) return true; // Body-level, always valid
+
+  let current: Element = body;
+  for (let i = path.length - 1; i >= 0; i--) {
+    const step = path[i]!;
+    const children = childElements(current).filter(c => c.tagName === step.tag);
+    if (step.index >= children.length) return false;
+    current = children[step.index]!;
+  }
+  return true;
+}
+
+/**
+ * Find the correct container and insertion anchor for a deleted/moved-source atom.
+ *
+ * For body-level atoms, returns ctx.body with the global lastProcessedParagraph anchor.
+ * For table-cell atoms, maps from the original tree container to the revised tree container
+ * by structural position, and uses the per-container anchor from lastParaByContainer.
+ *
+ * Returns null if container resolution fails (topology mismatch) — caller must throw
+ * ContainerResolutionError to trigger rebuild fallback.
+ */
+function findTargetContainerForAtom(
+  atom: ComparisonUnitAtom,
+  ctx: ProcessingContext
+): { container: Element; insertAfter: Element | null } | null {
+  // 1. Check if atom was in a table cell (original tree ancestors)
+  const sourceTc = findAncestorByTag(atom, 'w:tc');
+  if (!sourceTc) {
+    // Body-level paragraph — use global anchor (current behavior, correct)
+    return { container: ctx.body, insertAfter: ctx.lastProcessedParagraph };
+  }
+
+  // 2. Compute structural path from original tree
+  const sourcePara = atom.sourceParagraphElement;
+  if (!sourcePara) {
+    return null; // Can't resolve → force rebuild
+  }
+  const path = getContainerPath(sourcePara);
+  if (path.length === 0) {
+    // Paragraph has a w:tc ancestor but path is empty — shouldn't happen
+    return null;
+  }
+
+  // 3. Validate topology match before resolving
+  if (!validateContainerTopology(path, ctx.body)) {
+    return null; // Structural mismatch → force rebuild
+  }
+
+  // 4. Resolve container in revised tree
+  const revisedContainer = resolveContainerInRevised(path, ctx.body);
+  if (!revisedContainer) {
+    return null; // Resolution failed → force rebuild
+  }
+
+  // 5. Find container-local insertion anchor
+  const anchor = ctx.lastParaByContainer.get(revisedContainer) ?? null;
+  return { container: revisedContainer, insertAfter: anchor };
+}
+
 /**
  * Determine whether an atom is "whitespace-only" for paragraph-level classification.
  *
@@ -950,7 +1092,7 @@ export function insertMoveFromRun(
 export function insertDeletedParagraph(
   deletedAtom: ComparisonUnitAtom,
   insertAfterParagraph: Element | null,
-  targetBody: Element,
+  targetContainer: Element,
   author: string,
   dateStr: string,
   state: RevisionIdState
@@ -970,11 +1112,18 @@ export function insertDeletedParagraph(
     wrapAsDeleted(run, author, dateStr, state);
   }
 
-  // Insert at correct position
+  // Insert at correct position, preserving w:tcPr as first child when target is a table cell
   if (insertAfterParagraph) {
     insertAfterElement(insertAfterParagraph, clonedParagraph);
   } else {
-    targetBody.insertBefore(clonedParagraph, targetBody.firstChild);
+    const tcPr = targetContainer.tagName === 'w:tc'
+      ? findChildByTagName(targetContainer, 'w:tcPr')
+      : null;
+    if (tcPr) {
+      insertAfterElement(tcPr, clonedParagraph);
+    } else {
+      targetContainer.insertBefore(clonedParagraph, targetContainer.firstChild);
+    }
   }
 
   return clonedParagraph;
@@ -1765,6 +1914,12 @@ interface ProcessingContext {
    * after all inserted deleted/moved fragments have been placed.
    */
   createdParagraphTrailingBookmarks: Map<number, Element[]>;
+  /**
+   * Last processed paragraph per DOM container (w:tc or w:body).
+   * Used by findTargetContainerForAtom to find the correct insertion
+   * anchor when atoms jump between table cells.
+   */
+  lastParaByContainer: Map<Element, Element>;
 }
 
 /**
@@ -1848,10 +2003,15 @@ function handleDeleted(atom: ComparisonUnitAtom, ctx: ProcessingContext): Handle
 
   // Handle empty deleted paragraphs specially
   if (atom.isEmptyParagraph && atom.sourceParagraphElement) {
+    // Container-aware insertion (issue #65)
+    const emptyTarget = findTargetContainerForAtom(atom, ctx);
+    if (!emptyTarget) {
+      throw new ContainerResolutionError('Container topology mismatch for empty deleted paragraph');
+    }
     const createdPara = insertDeletedParagraph(
       atom,
-      ctx.lastProcessedParagraph,
-      ctx.body,
+      emptyTarget.insertAfter,
+      emptyTarget.container,
       ctx.author,
       ctx.dateStr,
       ctx.state
@@ -1923,10 +2083,22 @@ function handleDeleted(atom: ComparisonUnitAtom, ctx: ProcessingContext): Handle
             newPara.appendChild(clonedPPr);
           }
 
-          if (ctx.lastProcessedParagraph) {
-            insertAfterElement(ctx.lastProcessedParagraph, newPara);
+          // Container-aware insertion (issue #65)
+          const delTarget = findTargetContainerForAtom(atom, ctx);
+          if (!delTarget) {
+            throw new ContainerResolutionError('Container topology mismatch for deleted paragraph');
+          }
+          if (delTarget.insertAfter) {
+            insertAfterElement(delTarget.insertAfter, newPara);
           } else {
-            ctx.body.insertBefore(newPara, ctx.body.firstChild);
+            const propsEl = delTarget.container.tagName === 'w:tc'
+              ? findChildByTagName(delTarget.container, 'w:tcPr')
+              : null;
+            if (propsEl) {
+              insertAfterElement(propsEl, newPara);
+            } else {
+              delTarget.container.insertBefore(newPara, delTarget.container.firstChild);
+            }
           }
           ctx.createdParagraphs.set(unifiedPara, newPara);
           const leadingTail = insertLeadingMarkers(newPara, leadingMarkers);
@@ -2050,10 +2222,22 @@ function handleMovedSource(atom: ComparisonUnitAtom, ctx: ProcessingContext): Ha
             newPara.appendChild(clonedPPr);
           }
 
-          if (ctx.lastProcessedParagraph) {
-            insertAfterElement(ctx.lastProcessedParagraph, newPara);
+          // Container-aware insertion (issue #65)
+          const moveTarget = findTargetContainerForAtom(atom, ctx);
+          if (!moveTarget) {
+            throw new ContainerResolutionError('Container topology mismatch for moved-from paragraph');
+          }
+          if (moveTarget.insertAfter) {
+            insertAfterElement(moveTarget.insertAfter, newPara);
           } else {
-            ctx.body.insertBefore(newPara, ctx.body.firstChild);
+            const propsEl = moveTarget.container.tagName === 'w:tc'
+              ? findChildByTagName(moveTarget.container, 'w:tcPr')
+              : null;
+            if (propsEl) {
+              insertAfterElement(propsEl, newPara);
+            } else {
+              moveTarget.container.insertBefore(newPara, moveTarget.container.firstChild);
+            }
           }
           ctx.createdParagraphs.set(unifiedPara, newPara);
           const leadingTail = insertLeadingMarkers(newPara, leadingMarkers);
@@ -2329,6 +2513,7 @@ function processAtoms(
       createdParagraphs: new Map(),
       createdParagraphLastRun: new Map(),
       createdParagraphTrailingBookmarks: new Map(),
+      lastParaByContainer: new Map(),
     };
   }
 
@@ -2379,6 +2564,7 @@ function processAtoms(
     createdParagraphs: new Map(),
     createdParagraphLastRun: new Map(),
     createdParagraphTrailingBookmarks: new Map(),
+    lastParaByContainer: new Map(),
   };
 
   // Reorder atoms so consecutive deletions precede consecutive insertions.
@@ -2399,6 +2585,13 @@ function processAtoms(
     }
     if (result.newLastParagraph !== undefined) {
       ctx.lastProcessedParagraph = result.newLastParagraph;
+      // Track per-container anchor for container-aware insertion (issue #65)
+      if (result.newLastParagraph) {
+        const container = result.newLastParagraph.parentNode as Element | null;
+        if (container) {
+          ctx.lastParaByContainer.set(container, result.newLastParagraph);
+        }
+      }
     }
     if (result.newLastParagraphIndex !== undefined) {
       ctx.lastParagraphIndex = result.newLastParagraphIndex;

--- a/packages/docx-core/src/baselines/atomizer/pipeline.ts
+++ b/packages/docx-core/src/baselines/atomizer/pipeline.ts
@@ -58,7 +58,7 @@ import {
   reconstructDocument,
   computeReconstructionStats,
 } from './documentReconstructor.js';
-import { modifyRevisedDocument } from './inPlaceModifier.js';
+import { modifyRevisedDocument, ContainerResolutionError } from './inPlaceModifier.js';
 import {
   acceptAllChanges,
   rejectAllChanges,
@@ -715,7 +715,23 @@ export async function compareDocumentsAtomizer(
     const failedAttempts: ReconstructionAttemptDiagnostics[] = [];
     let selected: typeof comparisonResult | undefined;
     for (const { pass, atomizeOptions } of inplacePasses) {
-      const candidate = runComparisonPass(atomizeOptions, 'inplace');
+      let candidate: typeof comparisonResult;
+      try {
+        candidate = runComparisonPass(atomizeOptions, 'inplace');
+      } catch (e) {
+        if (e instanceof ContainerResolutionError) {
+          // Container topology mismatch — treat as failed pass (issue #65)
+          failedAttempts.push({
+            pass,
+            checks: { acceptText: false, rejectText: false, acceptBookmarks: true, rejectBookmarks: true, fieldStructure: false },
+            failedChecks: ['rejectText' as ReconstructionSafetyCheckName],
+            failureDetails: undefined,
+            firstDiffSummary: undefined,
+          });
+          continue;
+        }
+        throw e;
+      }
       const safety = evaluateRoundTripSafety(candidate.newDocumentXml);
 
       if (safety.safe) {

--- a/packages/docx-mcp/package.json
+++ b/packages/docx-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/docx-mcp",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Safe Docx MCP server (TypeScript)",
   "type": "module",
   "main": "dist/index.js",
@@ -26,7 +26,7 @@
     "lint": "tsc -b --pretty false"
   },
   "dependencies": {
-    "@usejunior/docx-core": "^0.7.1",
+    "@usejunior/docx-core": "^0.7.2",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "zod": "^4.3.6"
   },
@@ -53,7 +53,7 @@
     "dist"
   ],
   "peerDependencies": {
-    "@usejunior/google-docs-core": "^0.7.1"
+    "@usejunior/google-docs-core": "^0.7.2"
   },
   "peerDependenciesMeta": {
     "@usejunior/google-docs-core": {

--- a/packages/google-docs-core/package.json
+++ b/packages/google-docs-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/google-docs-core",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Google Docs core library: read, write, and anchor management via Google Docs API",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/safe-docx-mcpb/manifest.json
+++ b/packages/safe-docx-mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "safe-docx",
   "display_name": "Safe Docx",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "AI-native Word document editing with stable paragraph anchors and deterministic DOCX operations.",
   "long_description": "Safe Docx lets Claude work directly with .docx files on your local filesystem. It provides stable paragraph IDs (jr_para_*) for precise editing while preserving formatting and structure.\n\nCore capabilities include reading/searching content, formatting-preserving edits and inserts, deterministic layout controls, tracked-changes output, comments, footnote tools, document comparison, and revision extraction.",
   "author": {

--- a/packages/safe-docx-mcpb/package.json
+++ b/packages/safe-docx-mcpb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/safedocx-mcpb",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": true,
   "description": "Claude Desktop MCP Bundle (.mcpb) wrapper for @usejunior/safe-docx",
   "type": "module",
@@ -14,7 +14,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@usejunior/safe-docx": "^0.7.1"
+    "@usejunior/safe-docx": "^0.7.2"
   },
   "devDependencies": {
     "@vitest/runner": "^3.2.4",

--- a/packages/safe-docx/.smithery/shttp/manifest.json
+++ b/packages/safe-docx/.smithery/shttp/manifest.json
@@ -1,0 +1,943 @@
+{
+  "payload": {
+    "type": "hosted",
+    "stateful": false,
+    "hasAuthAdapter": false,
+    "serverCard": {
+      "serverInfo": {
+        "name": "safe-docx",
+        "version": "0.7.2"
+      },
+      "tools": [
+        {
+          "name": "read_file",
+          "description": "Read document content (DOCX or Google Doc). Output is token-limited (~14k tokens) by default with pagination metadata (has_more, next_offset). Use offset/limit to paginate.",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "file_path": {
+                "description": "Path to the DOCX file.",
+                "type": "string"
+              },
+              "google_doc_id": {
+                "description": "Google Doc ID or URL (alternative to file_path). Extract from URL: docs.google.com/document/d/{ID}/edit",
+                "type": "string"
+              },
+              "offset": {
+                "description": "1-based paragraph offset for pagination. Negative values count from end.",
+                "type": "number"
+              },
+              "limit": {
+                "description": "Max paragraphs to return. When omitted, output is token-limited to ~14k tokens with pagination.",
+                "type": "number"
+              },
+              "node_ids": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "toon",
+                  "json",
+                  "simple"
+                ]
+              },
+              "show_formatting": {
+                "description": "When true (default), shows inline formatting tags (<b>, <i>, <u>, <highlighting>, <a>). When false, emits plain text with no inline tags.",
+                "type": "boolean"
+              }
+            },
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "additionalProperties": false
+          },
+          "annotations": {
+            "readOnlyHint": true,
+            "destructiveHint": false
+          }
+        },
+        {
+          "name": "grep",
+          "description": "Search paragraphs with regex. Use file_path for session-based search, file_paths for stateless multi-file search, or google_doc_id for Google Docs.",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "file_path": {
+                "description": "Path to the DOCX file.",
+                "type": "string"
+              },
+              "google_doc_id": {
+                "description": "Google Doc ID or URL (alternative to file_path). Extract from URL: docs.google.com/document/d/{ID}/edit",
+                "type": "string"
+              },
+              "file_paths": {
+                "description": "Multiple file paths for stateless multi-file search. No session created.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "patterns": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "pattern": {
+                "type": "string"
+              },
+              "case_sensitive": {
+                "type": "boolean"
+              },
+              "whole_word": {
+                "type": "boolean"
+              },
+              "max_results": {
+                "type": "number"
+              },
+              "context_chars": {
+                "type": "number"
+              },
+              "dedupe_by_paragraph": {
+                "type": "boolean"
+              },
+              "search_xml": {
+                "description": "When true, search raw XML (word/document.xml) instead of paragraph text.",
+                "type": "boolean"
+              },
+              "include_context": {
+                "description": "When false, skip document view context (list labels, headers) for faster results. Default: true.",
+                "type": "boolean"
+              }
+            },
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "additionalProperties": false
+          },
+          "annotations": {
+            "readOnlyHint": true,
+            "destructiveHint": false
+          }
+        },
+        {
+          "name": "init_plan",
+          "description": "Initialize revision-bound context metadata for coordinated multi-agent planning.",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "file_path": {
+                "type": "string",
+                "description": "Path to the DOCX file."
+              },
+              "plan_name": {
+                "type": "string"
+              },
+              "orchestrator_id": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "file_path"
+            ],
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "additionalProperties": false
+          },
+          "annotations": {
+            "readOnlyHint": true,
+            "destructiveHint": false
+          }
+        },
+        {
+          "name": "merge_plans",
+          "description": "Deterministically merge multiple sub-agent plans and detect hard conflicts before apply.",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "plans": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": {}
+                }
+              },
+              "fail_on_conflict": {
+                "type": "boolean"
+              },
+              "require_shared_base_revision": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "plans"
+            ],
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "additionalProperties": false
+          },
+          "annotations": {
+            "readOnlyHint": true,
+            "destructiveHint": false
+          }
+        },
+        {
+          "name": "apply_plan",
+          "description": "Validate and apply a batch of edit steps (replace_text, insert_paragraph) to a document in one call. Validates all steps first; applies only if all pass. Accepts inline steps or a plan_file_path. Compatible with merge_plans output.",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "file_path": {
+                "type": "string",
+                "description": "Path to the DOCX file."
+              },
+              "steps": {
+                "description": "JSON array of edit steps. Each step needs step_id, operation, and operation-specific fields.",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {},
+                  "additionalProperties": {}
+                }
+              },
+              "plan_file_path": {
+                "description": "Path to a .json file containing an array of edit steps. Mutually exclusive with steps.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "file_path"
+            ],
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "additionalProperties": false
+          },
+          "annotations": {
+            "readOnlyHint": false,
+            "destructiveHint": true
+          }
+        },
+        {
+          "name": "replace_text",
+          "description": "Replace text in a paragraph by _bk_* id, preserving formatting. Supports DOCX and Google Docs.",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "file_path": {
+                "description": "Path to the DOCX file.",
+                "type": "string"
+              },
+              "google_doc_id": {
+                "description": "Google Doc ID or URL (alternative to file_path). Extract from URL: docs.google.com/document/d/{ID}/edit",
+                "type": "string"
+              },
+              "target_paragraph_id": {
+                "type": "string"
+              },
+              "old_string": {
+                "type": "string"
+              },
+              "new_string": {
+                "type": "string"
+              },
+              "instruction": {
+                "type": "string"
+              },
+              "normalize_first": {
+                "description": "Merge format-identical adjacent runs before searching. Useful when text is fragmented across runs.",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "target_paragraph_id",
+              "old_string",
+              "new_string",
+              "instruction"
+            ],
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "additionalProperties": false
+          },
+          "annotations": {
+            "readOnlyHint": false,
+            "destructiveHint": true
+          }
+        },
+        {
+          "name": "insert_paragraph",
+          "description": "Insert a paragraph before/after an anchor paragraph by _bk_* id. Supports DOCX and Google Docs.",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "file_path": {
+                "description": "Path to the DOCX file.",
+                "type": "string"
+              },
+              "google_doc_id": {
+                "description": "Google Doc ID or URL (alternative to file_path). Extract from URL: docs.google.com/document/d/{ID}/edit",
+                "type": "string"
+              },
+              "positional_anchor_node_id": {
+                "type": "string"
+              },
+              "new_string": {
+                "type": "string"
+              },
+              "instruction": {
+                "type": "string"
+              },
+              "position": {
+                "type": "string",
+                "enum": [
+                  "BEFORE",
+                  "AFTER"
+                ]
+              },
+              "style_source_id": {
+                "description": "Paragraph _bk_* ID to clone formatting (pPr and template run) from instead of the positional anchor. Falls back to anchor with a warning if not found.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "positional_anchor_node_id",
+              "new_string",
+              "instruction"
+            ],
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "additionalProperties": false
+          },
+          "annotations": {
+            "readOnlyHint": false,
+            "destructiveHint": true
+          }
+        },
+        {
+          "name": "save",
+          "description": "Save document. For DOCX: saves clean and/or tracked changes output. For Google Docs: checkpoint (default) returns revisionId, or snapshot exports as DOCX.",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "file_path": {
+                "description": "Path to the DOCX file.",
+                "type": "string"
+              },
+              "google_doc_id": {
+                "description": "Google Doc ID or URL (alternative to file_path). Extract from URL: docs.google.com/document/d/{ID}/edit",
+                "type": "string"
+              },
+              "save_to_local_path": {
+                "type": "string"
+              },
+              "clean_bookmarks": {
+                "type": "boolean"
+              },
+              "save_format": {
+                "type": "string",
+                "enum": [
+                  "clean",
+                  "tracked",
+                  "both"
+                ]
+              },
+              "allow_overwrite": {
+                "type": "boolean"
+              },
+              "tracked_save_to_local_path": {
+                "type": "string"
+              },
+              "tracked_changes_author": {
+                "type": "string"
+              },
+              "tracked_changes_engine": {
+                "type": "string",
+                "enum": [
+                  "auto",
+                  "atomizer"
+                ]
+              },
+              "fail_on_rebuild_fallback": {
+                "description": "When true, return an error instead of a destructive output if the comparison engine falls back to rebuild mode (which destroys table structure). Default: false.",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "save_to_local_path"
+            ],
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "additionalProperties": false
+          },
+          "annotations": {
+            "readOnlyHint": false,
+            "destructiveHint": true
+          }
+        },
+        {
+          "name": "format_layout",
+          "description": "Apply layout controls (paragraph spacing, table row height, cell padding). Google Docs supports paragraph spacing only.",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "file_path": {
+                "description": "Path to the DOCX file.",
+                "type": "string"
+              },
+              "google_doc_id": {
+                "description": "Google Doc ID or URL (alternative to file_path). Extract from URL: docs.google.com/document/d/{ID}/edit",
+                "type": "string"
+              },
+              "strict": {
+                "type": "boolean"
+              },
+              "paragraph_spacing": {
+                "type": "object",
+                "properties": {
+                  "paragraph_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "before_twips": {
+                    "type": "number"
+                  },
+                  "after_twips": {
+                    "type": "number"
+                  },
+                  "line_twips": {
+                    "type": "number"
+                  },
+                  "line_rule": {
+                    "type": "string",
+                    "enum": [
+                      "auto",
+                      "exact",
+                      "atLeast"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              },
+              "row_height": {
+                "type": "object",
+                "properties": {
+                  "table_indexes": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    }
+                  },
+                  "row_indexes": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    }
+                  },
+                  "value_twips": {
+                    "type": "number"
+                  },
+                  "rule": {
+                    "type": "string",
+                    "enum": [
+                      "auto",
+                      "exact",
+                      "atLeast"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              },
+              "cell_padding": {
+                "type": "object",
+                "properties": {
+                  "table_indexes": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    }
+                  },
+                  "row_indexes": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    }
+                  },
+                  "cell_indexes": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    }
+                  },
+                  "top_dxa": {
+                    "type": "number"
+                  },
+                  "bottom_dxa": {
+                    "type": "number"
+                  },
+                  "left_dxa": {
+                    "type": "number"
+                  },
+                  "right_dxa": {
+                    "type": "number"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "additionalProperties": false
+          },
+          "annotations": {
+            "readOnlyHint": false,
+            "destructiveHint": true
+          }
+        },
+        {
+          "name": "accept_changes",
+          "description": "Accept all tracked changes in the document body, producing a clean document with no revision markup. Returns acceptance stats.",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "file_path": {
+                "type": "string",
+                "description": "Path to the DOCX file."
+              }
+            },
+            "required": [
+              "file_path"
+            ],
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "additionalProperties": false
+          },
+          "annotations": {
+            "readOnlyHint": false,
+            "destructiveHint": true
+          }
+        },
+        {
+          "name": "has_tracked_changes",
+          "description": "Check whether the document body contains tracked-change markers (insertions, deletions, moves, and property-change records). Read-only.",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "file_path": {
+                "type": "string",
+                "description": "Path to the DOCX file."
+              }
+            },
+            "required": [
+              "file_path"
+            ],
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "additionalProperties": false
+          },
+          "annotations": {
+            "readOnlyHint": true,
+            "destructiveHint": false
+          }
+        },
+        {
+          "name": "get_file_status",
+          "description": "Get file/session metadata including edit count, normalization stats, and cache info. Supports DOCX and Google Docs.",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "file_path": {
+                "description": "Path to the DOCX file.",
+                "type": "string"
+              },
+              "google_doc_id": {
+                "description": "Google Doc ID or URL (alternative to file_path). Extract from URL: docs.google.com/document/d/{ID}/edit",
+                "type": "string"
+              }
+            },
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "additionalProperties": false
+          },
+          "annotations": {
+            "readOnlyHint": true,
+            "destructiveHint": false
+          }
+        },
+        {
+          "name": "close_file",
+          "description": "Close an open file session, or close all sessions with explicit confirmation. Supports DOCX and Google Docs.",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "file_path": {
+                "description": "Path to the DOCX file.",
+                "type": "string"
+              },
+              "google_doc_id": {
+                "description": "Google Doc ID or URL (alternative to file_path). Extract from URL: docs.google.com/document/d/{ID}/edit",
+                "type": "string"
+              },
+              "clear_all": {
+                "type": "boolean"
+              },
+              "confirm": {
+                "type": "boolean"
+              }
+            },
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "additionalProperties": false
+          },
+          "annotations": {
+            "readOnlyHint": false,
+            "destructiveHint": true
+          }
+        },
+        {
+          "name": "add_comment",
+          "description": "Add a comment or threaded reply to a document. Provide target_paragraph_id + anchor_text for root comments, or parent_comment_id for replies.",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "file_path": {
+                "type": "string",
+                "description": "Path to the DOCX file."
+              },
+              "target_paragraph_id": {
+                "description": "Paragraph ID to anchor the comment to (for root comments).",
+                "type": "string"
+              },
+              "anchor_text": {
+                "description": "Text within the paragraph to anchor the comment to. If omitted, anchors to entire paragraph.",
+                "type": "string"
+              },
+              "parent_comment_id": {
+                "description": "Parent comment ID for threaded replies.",
+                "type": "number"
+              },
+              "author": {
+                "type": "string",
+                "description": "Comment author name."
+              },
+              "text": {
+                "type": "string",
+                "description": "Comment body text."
+              },
+              "initials": {
+                "description": "Author initials (defaults to first letter of author name).",
+                "type": "string"
+              }
+            },
+            "required": [
+              "file_path",
+              "author",
+              "text"
+            ],
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "additionalProperties": false
+          },
+          "annotations": {
+            "readOnlyHint": false,
+            "destructiveHint": true
+          }
+        },
+        {
+          "name": "get_comments",
+          "description": "Get all comments from the document with IDs, authors, dates, text, and anchored paragraph IDs. Includes threaded replies. Read-only.",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "file_path": {
+                "type": "string",
+                "description": "Path to the DOCX file."
+              }
+            },
+            "required": [
+              "file_path"
+            ],
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "additionalProperties": false
+          },
+          "annotations": {
+            "readOnlyHint": true,
+            "destructiveHint": false
+          }
+        },
+        {
+          "name": "delete_comment",
+          "description": "Delete a comment and all its threaded replies from the document. Cascade-deletes all descendants.",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "file_path": {
+                "type": "string",
+                "description": "Path to the DOCX file."
+              },
+              "comment_id": {
+                "type": "number",
+                "description": "Comment ID to delete."
+              }
+            },
+            "required": [
+              "file_path",
+              "comment_id"
+            ],
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "additionalProperties": false
+          },
+          "annotations": {
+            "readOnlyHint": false,
+            "destructiveHint": true
+          }
+        },
+        {
+          "name": "compare_documents",
+          "description": "Compare two DOCX documents and produce a tracked-changes output document. Provide original_file_path + revised_file_path for standalone comparison, or file_path to compare session edits against the original.",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "original_file_path": {
+                "description": "Path to the original DOCX file.",
+                "type": "string"
+              },
+              "revised_file_path": {
+                "description": "Path to the revised DOCX file.",
+                "type": "string"
+              },
+              "file_path": {
+                "description": "Path to the DOCX file.",
+                "type": "string"
+              },
+              "save_to_local_path": {
+                "type": "string",
+                "description": "Path to save the tracked-changes DOCX output."
+              },
+              "author": {
+                "description": "Author name for track changes. Default: 'Comparison'.",
+                "type": "string"
+              },
+              "engine": {
+                "description": "Comparison engine. Default: 'auto'.",
+                "type": "string",
+                "enum": [
+                  "auto",
+                  "atomizer"
+                ]
+              }
+            },
+            "required": [
+              "save_to_local_path"
+            ],
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "additionalProperties": false
+          },
+          "annotations": {
+            "readOnlyHint": true,
+            "destructiveHint": false
+          }
+        },
+        {
+          "name": "get_footnotes",
+          "description": "Get all footnotes from the document with IDs, display numbers, text, and anchored paragraph IDs. Read-only.",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "file_path": {
+                "type": "string",
+                "description": "Path to the DOCX file."
+              }
+            },
+            "required": [
+              "file_path"
+            ],
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "additionalProperties": false
+          },
+          "annotations": {
+            "readOnlyHint": true,
+            "destructiveHint": false
+          }
+        },
+        {
+          "name": "add_footnote",
+          "description": "Add a footnote anchored to a paragraph. Optionally position the reference after specific text using after_text. Note: [^N] markers in read_file output are display-only and not part of the editable text used by replace_text.",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "file_path": {
+                "type": "string",
+                "description": "Path to the DOCX file."
+              },
+              "target_paragraph_id": {
+                "type": "string",
+                "description": "Paragraph ID to anchor the footnote to."
+              },
+              "after_text": {
+                "description": "Text after which to insert the footnote reference. If omitted, appends at end of paragraph.",
+                "type": "string"
+              },
+              "text": {
+                "type": "string",
+                "description": "Footnote body text."
+              }
+            },
+            "required": [
+              "file_path",
+              "target_paragraph_id",
+              "text"
+            ],
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "additionalProperties": false
+          },
+          "annotations": {
+            "readOnlyHint": false,
+            "destructiveHint": true
+          }
+        },
+        {
+          "name": "update_footnote",
+          "description": "Update the text content of an existing footnote.",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "file_path": {
+                "type": "string",
+                "description": "Path to the DOCX file."
+              },
+              "note_id": {
+                "type": "number",
+                "description": "Footnote ID to update."
+              },
+              "new_text": {
+                "type": "string",
+                "description": "New footnote body text."
+              }
+            },
+            "required": [
+              "file_path",
+              "note_id",
+              "new_text"
+            ],
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "additionalProperties": false
+          },
+          "annotations": {
+            "readOnlyHint": false,
+            "destructiveHint": true
+          }
+        },
+        {
+          "name": "delete_footnote",
+          "description": "Delete a footnote and its reference from the document.",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "file_path": {
+                "type": "string",
+                "description": "Path to the DOCX file."
+              },
+              "note_id": {
+                "type": "number",
+                "description": "Footnote ID to delete."
+              }
+            },
+            "required": [
+              "file_path",
+              "note_id"
+            ],
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "additionalProperties": false
+          },
+          "annotations": {
+            "readOnlyHint": false,
+            "destructiveHint": true
+          }
+        },
+        {
+          "name": "clear_formatting",
+          "description": "Clear specific run-level formatting (bold, italic, underline, highlight, color, font) from paragraphs.",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "file_path": {
+                "type": "string",
+                "description": "Path to the DOCX file."
+              },
+              "paragraph_ids": {
+                "description": "Paragraph IDs to clear formatting from. If omitted, clears from all paragraphs.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "clear_highlight": {
+                "description": "Remove highlight formatting.",
+                "type": "boolean"
+              },
+              "clear_bold": {
+                "description": "Remove bold formatting.",
+                "type": "boolean"
+              },
+              "clear_italic": {
+                "description": "Remove italic formatting.",
+                "type": "boolean"
+              },
+              "clear_underline": {
+                "description": "Remove underline formatting.",
+                "type": "boolean"
+              },
+              "clear_color": {
+                "description": "Remove font color.",
+                "type": "boolean"
+              },
+              "clear_font": {
+                "description": "Remove font family and size.",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "file_path"
+            ],
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "additionalProperties": false
+          },
+          "annotations": {
+            "readOnlyHint": false,
+            "destructiveHint": true
+          }
+        },
+        {
+          "name": "extract_revisions",
+          "description": "Extract tracked changes as structured JSON with before/after text per paragraph, revision details, and comments. Supports pagination via offset and limit. Read-only - does not modify the document.",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "file_path": {
+                "type": "string",
+                "description": "Path to the DOCX file."
+              },
+              "offset": {
+                "description": "0-based offset for pagination. Default: 0.",
+                "type": "number"
+              },
+              "limit": {
+                "description": "Max entries per page (1-500). Default: 50.",
+                "type": "number"
+              }
+            },
+            "required": [
+              "file_path"
+            ],
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "additionalProperties": false
+          },
+          "annotations": {
+            "readOnlyHint": true,
+            "destructiveHint": false
+          }
+        }
+      ],
+      "resources": [],
+      "prompts": []
+    },
+    "source": {
+      "commit": "4526cdbf1ccc74bd045b5a63a75299d5081d6282",
+      "branch": "main"
+    }
+  },
+  "artifacts": {
+    "module": "module.js",
+    "sourcemap": "module.js.map"
+  }
+}

--- a/packages/safe-docx/package.json
+++ b/packages/safe-docx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/safe-docx",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Canonical npm package for the Safe Docx MCP server and CLI",
   "mcpName": "io.github.UseJunior/safe-docx",
   "type": "module",
@@ -25,7 +25,7 @@
     "safedocx": "./bin/safe-docx.js"
   },
   "dependencies": {
-    "@usejunior/docx-mcp": "^0.7.1"
+    "@usejunior/docx-mcp": "^0.7.2"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/safe-docx/server.json
+++ b/packages/safe-docx/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.UseJunior/safe-docx",
   "title": "Safe Docx",
   "description": "AI-native surgical editing of existing Word .docx files with formatting preservation",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "websiteUrl": "https://usejunior.com/developer-tools/safe-docx",
   "icons": [
     {
@@ -18,7 +18,7 @@
     {
       "registryType": "npm",
       "identifier": "@usejunior/safe-docx",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "transport": {
         "type": "stdio"
       },

--- a/scripts/bump_version.mjs
+++ b/scripts/bump_version.mjs
@@ -30,6 +30,7 @@ const PACKAGE_JSONS = [
 ];
 
 const MANIFEST_JSON = 'packages/safe-docx-mcpb/manifest.json';
+const SMITHERY_MANIFEST_JSON = 'packages/safe-docx/.smithery/shttp/manifest.json';
 
 // Cross-workspace dependencies (package name → dep specifier pattern)
 const WORKSPACE_DEPS = [
@@ -68,6 +69,9 @@ function checkVersionSync() {
 
   const manifest = readJson(MANIFEST_JSON);
   versions.set(MANIFEST_JSON, manifest.version);
+
+  const smitheryManifest = readJson(SMITHERY_MANIFEST_JSON);
+  versions.set(SMITHERY_MANIFEST_JSON, smitheryManifest.payload?.serverCard?.serverInfo?.version);
 
   const serverJson = readJson('packages/safe-docx/server.json');
   versions.set('packages/safe-docx/server.json', serverJson.version);
@@ -145,6 +149,12 @@ function bumpVersion(newVersion) {
   manifest.version = newVersion;
   writeJson(MANIFEST_JSON, manifest);
   console.log(`  ✓ ${MANIFEST_JSON}`);
+
+  // 3a. Update Smithery manifest.json
+  const smitheryManifest = readJson(SMITHERY_MANIFEST_JSON);
+  smitheryManifest.payload.serverCard.serverInfo.version = newVersion;
+  writeJson(SMITHERY_MANIFEST_JSON, smitheryManifest);
+  console.log(`  ✓ ${SMITHERY_MANIFEST_JSON}`);
 
   // 3b. Update server.json
   const SERVER_JSON = 'packages/safe-docx/server.json';

--- a/site/package.json
+++ b/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/safe-docx-site",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": true,
   "type": "module",
   "description": "Safe DOCX marketing and trust site (Eleventy)",


### PR DESCRIPTION
Closes #65

## Summary

- **Container-position fallback** in paragraph matching: when TF-IDF similarity is too low for short table cell paragraphs (e.g., "Party Name: Acme Corp" vs "Party Name: Meridian Ventures LLC"), falls back to matching by structural position (same table/row/cell index)
- **Cross-cell paragraph correspondence filter**: prevents empty paragraphs from matching across cell boundaries in unified index assignment
- **Container-aware insertion**: per-container anchor tracking, structural path resolution, `w:tcPr` guard, and `ContainerResolutionError` that triggers rebuild fallback on topology mismatch

## Before / After

Previously, the Bonterms Mutual NDA template with merged cells fell back to rebuild mode on all 4 adaptive inplace passes (`rejectText` failure). Now it succeeds on the first inplace pass with correct inline tracked changes.

**Screenshots**:
- Figure 1: LibreOffice showing inline tracked changes in table cells
<img width="1176" height="1190" alt="1" src="https://github.com/user-attachments/assets/0bed2acc-bcbf-4373-8705-9cb59dbccd98" />
- Figure 2: Google Docs showing tracked changes with sidebar annotations
<img width="1514" height="1040" alt="2" src="https://github.com/user-attachments/assets/1d544c58-191c-49f9-ba1e-ad7c856c5d17" />

## Test plan

- [x] All 1075 docx-core tests pass (0 regressions)
- [x] `compareDocuments(NDA-A, NDA-B, { reconstructionMode: 'inplace' })` returns `reconstructionModeUsed === 'inplace'` (no fallback)
- [x] Verified redline in LibreOffice — inline tracked changes render correctly in table cells
- [x] Verified redline in Google Docs — tracked changes show in sidebar
- [x] Drag-drop screenshots into this PR body