### PR TITLE
feat(docx-core): make start/end optional in addComment()

### DIFF
--- a/packages/docx-core/src/primitives/comments.test.ts
+++ b/packages/docx-core/src/primitives/comments.test.ts
@@ -280,6 +280,135 @@ describe('comments — edge cases and branch coverage', () => {
         expect(commentsXml).toContain('xml:space="preserve"');
       });
     });
+
+    test('defaults to full paragraph when start and end are omitted', async ({ given, when, then, and }: AllureBddContext) => {
+      let zip: DocxZip;
+      let doc: Document;
+      let result: Awaited<ReturnType<typeof addComment>>;
+
+      await given('a document with a multi-run paragraph', async () => {
+        ({ zip, doc } = await setupWithComment(
+          '<w:p><w:r><w:t>Hello </w:t></w:r><w:r><w:t>World</w:t></w:r></w:p>',
+        ));
+      });
+
+      await when('addComment is called without start and end', async () => {
+        const p = doc.getElementsByTagNameNS(W_NS, W.p).item(0) as Element;
+        result = await addComment(doc, zip, {
+          paragraphEl: p,
+          author: 'Test Author',
+          text: 'Whole paragraph comment',
+        });
+      });
+
+      await then('a comment ID is allocated', () => {
+        expect(result.commentId).toBeGreaterThanOrEqual(0);
+      });
+
+      await and('range markers and reference span the entire paragraph', () => {
+        const serialized = serializeXml(doc);
+        expect(serialized).toContain('commentRangeStart');
+        expect(serialized).toContain('commentRangeEnd');
+        expect(serialized).toContain('commentReference');
+      });
+    });
+
+    test('handles empty paragraph when start and end are omitted', async ({ given, when, then }: AllureBddContext) => {
+      let zip: DocxZip;
+      let doc: Document;
+      let result: Awaited<ReturnType<typeof addComment>>;
+
+      await given('a document with an empty paragraph containing pPr', async () => {
+        ({ zip, doc } = await setupWithComment('<w:p><w:pPr/></w:p>'));
+      });
+
+      await when('addComment is called without start and end', async () => {
+        const p = doc.getElementsByTagNameNS(W_NS, W.p).item(0) as Element;
+        result = await addComment(doc, zip, {
+          paragraphEl: p,
+          author: 'Test',
+          text: 'Comment on empty paragraph',
+        });
+      });
+
+      await then('comment is created and pPr stays first with markers appended after', () => {
+        expect(result.commentId).toBeGreaterThanOrEqual(0);
+        const p = doc.getElementsByTagNameNS(W_NS, W.p).item(0) as Element;
+        const children = Array.from(p.childNodes).filter(
+          (n) => n.nodeType === 1,
+        ) as Element[];
+        expect(children[0]!.localName).toBe('pPr');
+        expect(children[1]!.localName).toBe('commentRangeStart');
+        expect(children[2]!.localName).toBe('commentRangeEnd');
+        // commentReference is inside a w:r
+        expect(children[3]!.localName).toBe('r');
+      });
+    });
+
+    test('handles paragraph with field result when start and end are omitted', async ({ given, when, then }: AllureBddContext) => {
+      let zip: DocxZip;
+      let doc: Document;
+      let result: Awaited<ReturnType<typeof addComment>>;
+
+      const fieldParaXml = [
+        '<w:p>',
+        '<w:r><w:t>Before </w:t></w:r>',
+        '<w:r><w:fldChar w:fldCharType="begin"/></w:r>',
+        '<w:r><w:instrText> PAGEREF _bk1 </w:instrText></w:r>',
+        '<w:r><w:fldChar w:fldCharType="separate"/></w:r>',
+        '<w:r><w:t>42</w:t></w:r>',
+        '<w:r><w:fldChar w:fldCharType="end"/></w:r>',
+        '<w:r><w:t> After</w:t></w:r>',
+        '</w:p>',
+      ].join('');
+
+      await given('a document with a paragraph containing a field result', async () => {
+        ({ zip, doc } = await setupWithComment(fieldParaXml));
+      });
+
+      await when('addComment is called without start and end', async () => {
+        const p = doc.getElementsByTagNameNS(W_NS, W.p).item(0) as Element;
+        result = await addComment(doc, zip, {
+          paragraphEl: p,
+          author: 'Test',
+          text: 'Comment on field paragraph',
+        });
+      });
+
+      await then('comment is created with markers present', () => {
+        expect(result.commentId).toBeGreaterThanOrEqual(0);
+        const serialized = serializeXml(doc);
+        expect(serialized).toContain('commentRangeStart');
+        expect(serialized).toContain('commentRangeEnd');
+        expect(serialized).toContain('commentReference');
+      });
+    });
+
+    test('throws when start > end', async ({ given, when, then }: AllureBddContext) => {
+      let zip: DocxZip;
+      let doc: Document;
+      let p: Element;
+
+      await given('a document with a paragraph', async () => {
+        ({ zip, doc, p } = await setupWithComment());
+      });
+
+      await when('addComment is called with start > end', async () => {
+        // no-op, assertion is in then
+      });
+
+      await then('an error is thrown', async () => {
+        await expect(
+          addComment(doc, zip, {
+            paragraphEl: p,
+            start: 5,
+            end: 2,
+            author: 'Test',
+            text: 'Invalid range',
+          }),
+        ).rejects.toThrow('Invalid comment range');
+      });
+    });
   });
 
   describe('addCommentReply', () => {

--- a/packages/docx-core/src/primitives/comments.ts
+++ b/packages/docx-core/src/primitives/comments.ts
@@ -8,7 +8,7 @@
 import { OOXML, W } from './namespaces.js';
 import { parseXml, serializeXml } from './xml.js';
 import { DocxZip } from './zip.js';
-import { getParagraphRuns } from './text.js';
+import { getParagraphRuns, getParagraphText } from './text.js';
 import { getParagraphBookmarkId } from './bookmarks.js';
 
 // ── Relationship types ──────────────────────────────────────────────────
@@ -181,8 +181,8 @@ async function ensureRelationships(zip: DocxZip, newParts: string[]): Promise<vo
 
 export type AddCommentParams = {
   paragraphEl: Element;
-  start: number;
-  end: number;
+  start?: number;
+  end?: number;
   author: string;
   text: string;
   initials?: string;
@@ -206,7 +206,12 @@ export async function addComment(
   zip: DocxZip,
   params: AddCommentParams,
 ): Promise<AddCommentResult> {
-  const { paragraphEl, start, end, author, text, initials } = params;
+  const { paragraphEl, author, text, initials } = params;
+  const start = params.start ?? 0;
+  const end = params.end ?? getParagraphText(paragraphEl).length;
+  if (start > end) {
+    throw new Error(`Invalid comment range: start (${start}) must be <= end (${end})`);
+  }
 
   // Load comments.xml
   const commentsXml = await zip.readText('word/comments.xml');

--- a/packages/docx-core/src/primitives/document.ts
+++ b/packages/docx-core/src/primitives/document.ts
@@ -720,8 +720,8 @@ export class DocxDocument {
    */
   async addComment(params: {
     paragraphId: string;
-    start: number;
-    end: number;
+    start?: number;
+    end?: number;
     author: string;
     text: string;
     initials?: string;

--- a/packages/docx-core/test-primitives/comments.test.ts
+++ b/packages/docx-core/test-primitives/comments.test.ts
@@ -482,6 +482,40 @@ describe('comments', () => {
         expect(commentsXml).toContain('Round Trip');
       });
     });
+
+    test('DocxDocument.addComment wraps entire paragraph when start and end are omitted', async ({ given, when, then }: AllureBddContext) => {
+      let doc: InstanceType<typeof DocxDocument>;
+      let result: Awaited<ReturnType<typeof doc.addComment>>;
+
+      await given('a document with bookmarked paragraphs', async () => {
+        const bodyXml = '<w:p><w:r><w:t>Full paragraph comment</w:t></w:r></w:p>';
+        const buf = await makeDocxBuffer(bodyXml);
+        doc = await DocxDocument.load(buf);
+        doc.insertParagraphBookmarks('test_attachment');
+      });
+
+      await when('addComment is called without start and end', async () => {
+        const { paragraphs } = doc.readParagraphs();
+        const paraId = paragraphs[0]!.id;
+        result = await doc.addComment({
+          paragraphId: paraId,
+          author: 'Wrapper Test',
+          text: 'No offsets provided',
+        });
+      });
+
+      await then('a comment is created wrapping the entire paragraph', async () => {
+        expect(result.commentId).toBeGreaterThanOrEqual(0);
+        const { buffer } = await doc.toBuffer();
+        const reloadedZip = await DocxZip.load(buffer);
+        const docXml = await reloadedZip.readText('word/document.xml');
+        expect(docXml).toContain('commentRangeStart');
+        expect(docXml).toContain('commentRangeEnd');
+        const commentsXml = await reloadedZip.readText('word/comments.xml');
+        expect(commentsXml).toContain('No offsets provided');
+        expect(commentsXml).toContain('Wrapper Test');
+      });
+    });
   });
 
   describe('getComments', () => {


### PR DESCRIPTION
## Summary

- Make `start` and `end` optional in `AddCommentParams` and `DocxDocument.addComment()`
- When omitted, `start` defaults to `0` and `end` defaults to `getParagraphText(paragraphEl).length`, anchoring the comment to the full visible paragraph
- Add `start <= end` validation (throws on invalid ranges)
- No changes to MCP layer — it already handles whole-paragraph comments via `anchor_text`

**Motivation**: AI agents identifying issues in a document know *which* paragraph has a problem but can't reliably specify exact character offsets. This removes the friction.

## Test plan

- [x] 4 new primitive-level tests: full paragraph default, empty paragraph, field-result paragraph, `start > end` validation
- [x] 1 new wrapper-level test: `DocxDocument.addComment()` round-trip without offsets
- [x] All 1058 existing tests pass (1 skipped, pre-existing)
- [x] TypeScript compiles clean (`tsc --noEmit`)

## Peer review

Plan reviewed by **Codex CLI** and **Gemini CLI** before implementation.