### PR TITLE
docs: improve package discoverability for AI agents + bump to 0.8.1

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -2,6 +2,10 @@
 
 [![CI](https://github.com/usejunior/safe-docx/actions/workflows/ci.yml/badge.svg)](https://github.com/usejunior/safe-docx/actions/workflows/ci.yml)
 [![codecov](https://img.shields.io/codecov/c/github/usejunior/safe-docx/main)](https://app.codecov.io/gh/usejunior/safe-docx)
+[![npm version](https://img.shields.io/npm/v/@usejunior/safe-docx)](https://www.npmjs.com/package/@usejunior/safe-docx)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/UseJunior/safe-docx/blob/main/LICENSE)
+[![GitHub last commit](https://img.shields.io/github/last-commit/UseJunior/safe-docx)](https://github.com/UseJunior/safe-docx/commits/main)
+[![GitHub issues closed](https://img.shields.io/github/issues-closed/UseJunior/safe-docx)](https://github.com/UseJunior/safe-docx/issues?q=is%3Aissue+is%3Aclosed)
 
 [English](./README.md) | [Español](./README.es.md) | [简体中文](./README.zh.md) | [Português (Brasil)](./README.pt-br.md) | [Deutsch](./README.de.md)
 
@@ -35,17 +39,97 @@ Safe Docx ist optimiert für Agenten-Workflows, die deterministische, lokale Bea
 
 Safe Docx ist nicht dazu gedacht, generierungsorientierte `.docx`-Bibliotheken zu ersetzen.
 
+## Vertraut von
+
+- **Am Law Top-10-Kanzlei** — mehrstufige Vertragsübersetzungs-Pipeline
+- **Regionalkanzlei mit 150 Anwälten** — 22M+ Tokens an Vertragskorrekturen verarbeitet
+- **Gemini CLI** — kompatible Word-Bearbeitungs-MCP-Erweiterung
+
 ## Hier starten
-
-Für Einrichtung und tägliche Nutzung siehe:
-
-- `packages/docx-mcp/README.md`
-
-Schnellstart:
 
 ```bash
 npx -y @usejunior/safe-docx
 ```
+
+Für detaillierte Einrichtung und Tool-Referenz siehe `packages/docx-mcp/README.md`.
+
+### Beispiel: Agent bearbeitet einen Vertrag
+
+Wenn du einem Programmier-Agenten (Claude Code, Cursor, Gemini CLI) mit installiertem Safe Docx einen Prompt gibst, führt der Agent MCP-Tool-Aufrufe wie diese aus:
+
+```text
+Benutzer: Bearbeite die NDA unter ~/docs/NDA.docx — ändere das
+          anwendbare Recht von "State of New York" zu
+          "State of Delaware" und speichere sowohl eine saubere
+          Kopie als auch eine Kopie mit Änderungsnachverfolgung.
+
+Agent-Aufrufe:
+
+  1. read_file(file_path="~/docs/NDA.docx", format="toon")
+     → Gibt Absätze mit stabilen IDs zurück: _bk_1, _bk_2, ...
+
+  2. grep(file_path="~/docs/NDA.docx", pattern="State of New York")
+     → Treffer in Absatz _bk_47
+
+  3. replace_text(
+       file_path="~/docs/NDA.docx",
+       target_paragraph_id="_bk_47",
+       old_string="State of New York",
+       new_string="State of Delaware",
+       instruction="Change governing law to Delaware"
+     )
+
+  4. save(
+       file_path="~/docs/NDA.docx",
+       save_to_local_path="~/docs/NDA-clean.docx",
+       tracked_save_to_local_path="~/docs/NDA-tracked.docx",
+       save_format="both"
+     )
+```
+
+Der Agent verarbeitet die Tool-Aufrufe automatisch. Du erhältst eine saubere Datei und eine Datei mit Änderungsnachverfolgung zur menschlichen Überprüfung.
+
+## MCP-Schnellstart
+
+### Claude Code
+
+```bash
+claude mcp add safe-docx -- npx -y @usejunior/safe-docx
+```
+
+### Claude Desktop
+
+Füge zu `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) oder `%APPDATA%\Claude\claude_desktop_config.json` (Windows) hinzu:
+
+```json
+{
+  "mcpServers": {
+    "safe-docx": {
+      "command": "npx",
+      "args": ["-y", "@usejunior/safe-docx"]
+    }
+  }
+}
+```
+
+### Gemini CLI
+
+```json
+{
+  "mcpServers": {
+    "safe-docx": {
+      "command": "npx",
+      "args": ["-y", "@usejunior/safe-docx"]
+    }
+  }
+}
+```
+
+### Beliebiger MCP-Client
+
+- **Befehl:** `npx`
+- **Args:** `["-y", "@usejunior/safe-docx"]`
+- **Transport:** stdio
 
 ## Wofür Safe Docx optimiert ist
 

--- a/README.es.md
+++ b/README.es.md
@@ -2,6 +2,10 @@
 
 [![CI](https://github.com/usejunior/safe-docx/actions/workflows/ci.yml/badge.svg)](https://github.com/usejunior/safe-docx/actions/workflows/ci.yml)
 [![codecov](https://img.shields.io/codecov/c/github/usejunior/safe-docx/main)](https://app.codecov.io/gh/usejunior/safe-docx)
+[![npm version](https://img.shields.io/npm/v/@usejunior/safe-docx)](https://www.npmjs.com/package/@usejunior/safe-docx)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/UseJunior/safe-docx/blob/main/LICENSE)
+[![GitHub last commit](https://img.shields.io/github/last-commit/UseJunior/safe-docx)](https://github.com/UseJunior/safe-docx/commits/main)
+[![GitHub issues closed](https://img.shields.io/github/issues-closed/UseJunior/safe-docx)](https://github.com/UseJunior/safe-docx/issues?q=is%3Aissue+is%3Aclosed)
 
 [English](./README.md) | [Español](./README.es.md) | [简体中文](./README.zh.md) | [Português (Brasil)](./README.pt-br.md) | [Deutsch](./README.de.md)
 
@@ -35,17 +39,96 @@ Safe Docx está optimizado para flujos de trabajo de agentes que necesitan edici
 
 Safe Docx no pretende reemplazar bibliotecas de `.docx` orientadas a la generación.
 
+## Confían en nosotros
+
+- **Firma Am Law top-10** — pipeline de traducción de contratos multietapa
+- **Firma regional de 150 abogados** — 22M+ tokens de marcado de contratos procesados
+- **Gemini CLI** — extensión MCP compatible para edición de Word
+
 ## Comienza aquí
-
-Para configuración y uso diario, ve a:
-
-- `packages/docx-mcp/README.md`
-
-Ejecución rápida:
 
 ```bash
 npx -y @usejunior/safe-docx
 ```
+
+Para configuración detallada y referencia de herramientas, consulta `packages/docx-mcp/README.md`.
+
+### Ejemplo: Agente editando un contrato
+
+Cuando le das un prompt a un agente de programación (Claude Code, Cursor, Gemini CLI) con Safe Docx instalado, el agente realiza llamadas de herramientas MCP como estas:
+
+```text
+Usuario: Edita el NDA en ~/docs/NDA.docx — cambia la ley aplicable
+         de "State of New York" a "State of Delaware" y guarda tanto
+         una copia limpia como una copia con control de cambios.
+
+Llamadas del agente:
+
+  1. read_file(file_path="~/docs/NDA.docx", format="toon")
+     → Retorna párrafos con IDs estables: _bk_1, _bk_2, ...
+
+  2. grep(file_path="~/docs/NDA.docx", pattern="State of New York")
+     → Coincidencia en párrafo _bk_47
+
+  3. replace_text(
+       file_path="~/docs/NDA.docx",
+       target_paragraph_id="_bk_47",
+       old_string="State of New York",
+       new_string="State of Delaware",
+       instruction="Change governing law to Delaware"
+     )
+
+  4. save(
+       file_path="~/docs/NDA.docx",
+       save_to_local_path="~/docs/NDA-clean.docx",
+       tracked_save_to_local_path="~/docs/NDA-tracked.docx",
+       save_format="both"
+     )
+```
+
+El agente maneja las llamadas de herramientas automáticamente. Obtienes un archivo limpio y un archivo con control de cambios para revisión humana.
+
+## Inicio rápido MCP
+
+### Claude Code
+
+```bash
+claude mcp add safe-docx -- npx -y @usejunior/safe-docx
+```
+
+### Claude Desktop
+
+Añade a `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) o `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+
+```json
+{
+  "mcpServers": {
+    "safe-docx": {
+      "command": "npx",
+      "args": ["-y", "@usejunior/safe-docx"]
+    }
+  }
+}
+```
+
+### Gemini CLI
+
+```json
+{
+  "mcpServers": {
+    "safe-docx": {
+      "command": "npx",
+      "args": ["-y", "@usejunior/safe-docx"]
+    }
+  }
+}
+```
+
+### Cualquier cliente MCP
+
+- **Comando:** `npx`
+- **Args:** `["-y", "@usejunior/safe-docx"]`
+- **Transporte:** stdio
 
 ## Para qué está optimizado Safe Docx
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 [![CI](https://github.com/usejunior/safe-docx/actions/workflows/ci.yml/badge.svg)](https://github.com/usejunior/safe-docx/actions/workflows/ci.yml)
 [![codecov](https://img.shields.io/codecov/c/github/usejunior/safe-docx/main)](https://app.codecov.io/gh/usejunior/safe-docx)
+[![npm version](https://img.shields.io/npm/v/@usejunior/safe-docx)](https://www.npmjs.com/package/@usejunior/safe-docx)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/UseJunior/safe-docx/blob/main/LICENSE)
+[![GitHub last commit](https://img.shields.io/github/last-commit/UseJunior/safe-docx)](https://github.com/UseJunior/safe-docx/commits/main)
+[![GitHub issues closed](https://img.shields.io/github/issues-closed/UseJunior/safe-docx)](https://github.com/UseJunior/safe-docx/issues?q=is%3Aissue+is%3Aclosed)
 
 [English](./README.md) | [Español](./README.es.md) | [简体中文](./README.zh.md) | [Português (Brasil)](./README.pt-br.md) | [Deutsch](./README.de.md)
 
@@ -33,17 +37,96 @@ Safe Docx is optimized for agent workflows that need deterministic, local-first 
 
 Safe Docx is not intended to replace generation-first `.docx` libraries.
 
+## Trusted By
+
+- **Am Law top-10 firm** — multistep contract translation pipeline
+- **150-lawyer regional firm** — 22M+ tokens of contract markup processed
+- **Gemini CLI** — compatible Word editing MCP extension
+
 ## Start Here
-
-For setup and daily usage, go to:
-
-- `packages/docx-mcp/README.md`
-
-Quick run:
 
 ```bash
 npx -y @usejunior/safe-docx
 ```
+
+For detailed setup and tool reference, see `packages/docx-mcp/README.md`.
+
+### Example: Agent Editing a Contract
+
+When you prompt a coding agent (Claude Code, Cursor, Gemini CLI) with Safe Docx installed, the agent makes MCP tool calls like these:
+
+```text
+User: Edit the NDA at ~/docs/NDA.docx — change the governing law
+      from "State of New York" to "State of Delaware" and save both
+      a clean copy and a tracked-changes copy.
+
+Agent calls:
+
+  1. read_file(file_path="~/docs/NDA.docx", format="toon")
+     → Returns paragraphs with stable IDs: _bk_1, _bk_2, ...
+
+  2. grep(file_path="~/docs/NDA.docx", pattern="State of New York")
+     → Match in paragraph _bk_47
+
+  3. replace_text(
+       file_path="~/docs/NDA.docx",
+       target_paragraph_id="_bk_47",
+       old_string="State of New York",
+       new_string="State of Delaware",
+       instruction="Change governing law to Delaware"
+     )
+
+  4. save(
+       file_path="~/docs/NDA.docx",
+       save_to_local_path="~/docs/NDA-clean.docx",
+       tracked_save_to_local_path="~/docs/NDA-tracked.docx",
+       save_format="both"
+     )
+```
+
+The agent handles the tool calls automatically. You get a clean file and a tracked-changes file for human review.
+
+## MCP Quickstart
+
+### Claude Code
+
+```bash
+claude mcp add safe-docx -- npx -y @usejunior/safe-docx
+```
+
+### Claude Desktop
+
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+
+```json
+{
+  "mcpServers": {
+    "safe-docx": {
+      "command": "npx",
+      "args": ["-y", "@usejunior/safe-docx"]
+    }
+  }
+}
+```
+
+### Gemini CLI
+
+```json
+{
+  "mcpServers": {
+    "safe-docx": {
+      "command": "npx",
+      "args": ["-y", "@usejunior/safe-docx"]
+    }
+  }
+}
+```
+
+### Any MCP Client
+
+- **Command:** `npx`
+- **Args:** `["-y", "@usejunior/safe-docx"]`
+- **Transport:** stdio
 
 ## What Safe Docx Is Optimized For
 

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -2,6 +2,10 @@
 
 [![CI](https://github.com/usejunior/safe-docx/actions/workflows/ci.yml/badge.svg)](https://github.com/usejunior/safe-docx/actions/workflows/ci.yml)
 [![codecov](https://img.shields.io/codecov/c/github/usejunior/safe-docx/main)](https://app.codecov.io/gh/usejunior/safe-docx)
+[![npm version](https://img.shields.io/npm/v/@usejunior/safe-docx)](https://www.npmjs.com/package/@usejunior/safe-docx)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/UseJunior/safe-docx/blob/main/LICENSE)
+[![GitHub last commit](https://img.shields.io/github/last-commit/UseJunior/safe-docx)](https://github.com/UseJunior/safe-docx/commits/main)
+[![GitHub issues closed](https://img.shields.io/github/issues-closed/UseJunior/safe-docx)](https://github.com/UseJunior/safe-docx/issues?q=is%3Aissue+is%3Aclosed)
 
 [English](./README.md) | [Español](./README.es.md) | [简体中文](./README.zh.md) | [Português (Brasil)](./README.pt-br.md) | [Deutsch](./README.de.md)
 
@@ -35,17 +39,96 @@ Safe Docx é otimizado para fluxos de trabalho de agentes que precisam de ediç�
 
 Safe Docx não pretende substituir bibliotecas de `.docx` orientadas à geração.
 
+## Confiam em nós
+
+- **Escritório Am Law top-10** — pipeline de tradução de contratos em múltiplas etapas
+- **Escritório regional de 150 advogados** — 22M+ tokens de marcação de contratos processados
+- **Gemini CLI** — extensão MCP compatível para edição de Word
+
 ## Comece aqui
-
-Para configuração e uso diário, acesse:
-
-- `packages/docx-mcp/README.md`
-
-Execução rápida:
 
 ```bash
 npx -y @usejunior/safe-docx
 ```
+
+Para configuração detalhada e referência de ferramentas, consulte `packages/docx-mcp/README.md`.
+
+### Exemplo: Agente editando um contrato
+
+Quando você dá um prompt a um agente de programação (Claude Code, Cursor, Gemini CLI) com Safe Docx instalado, o agente faz chamadas de ferramentas MCP como estas:
+
+```text
+Usuário: Edite o NDA em ~/docs/NDA.docx — altere a lei aplicável
+         de "State of New York" para "State of Delaware" e salve tanto
+         uma cópia limpa quanto uma cópia com controle de alterações.
+
+Chamadas do agente:
+
+  1. read_file(file_path="~/docs/NDA.docx", format="toon")
+     → Retorna parágrafos com IDs estáveis: _bk_1, _bk_2, ...
+
+  2. grep(file_path="~/docs/NDA.docx", pattern="State of New York")
+     → Correspondência no parágrafo _bk_47
+
+  3. replace_text(
+       file_path="~/docs/NDA.docx",
+       target_paragraph_id="_bk_47",
+       old_string="State of New York",
+       new_string="State of Delaware",
+       instruction="Change governing law to Delaware"
+     )
+
+  4. save(
+       file_path="~/docs/NDA.docx",
+       save_to_local_path="~/docs/NDA-clean.docx",
+       tracked_save_to_local_path="~/docs/NDA-tracked.docx",
+       save_format="both"
+     )
+```
+
+O agente lida com as chamadas de ferramentas automaticamente. Você recebe um arquivo limpo e um arquivo com controle de alterações para revisão humana.
+
+## Início rápido MCP
+
+### Claude Code
+
+```bash
+claude mcp add safe-docx -- npx -y @usejunior/safe-docx
+```
+
+### Claude Desktop
+
+Adicione a `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) ou `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+
+```json
+{
+  "mcpServers": {
+    "safe-docx": {
+      "command": "npx",
+      "args": ["-y", "@usejunior/safe-docx"]
+    }
+  }
+}
+```
+
+### Gemini CLI
+
+```json
+{
+  "mcpServers": {
+    "safe-docx": {
+      "command": "npx",
+      "args": ["-y", "@usejunior/safe-docx"]
+    }
+  }
+}
+```
+
+### Qualquer cliente MCP
+
+- **Comando:** `npx`
+- **Args:** `["-y", "@usejunior/safe-docx"]`
+- **Transporte:** stdio
 
 ## Para que o Safe Docx é otimizado
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -2,6 +2,10 @@
 
 [![CI](https://github.com/usejunior/safe-docx/actions/workflows/ci.yml/badge.svg)](https://github.com/usejunior/safe-docx/actions/workflows/ci.yml)
 [![codecov](https://img.shields.io/codecov/c/github/usejunior/safe-docx/main)](https://app.codecov.io/gh/usejunior/safe-docx)
+[![npm version](https://img.shields.io/npm/v/@usejunior/safe-docx)](https://www.npmjs.com/package/@usejunior/safe-docx)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/UseJunior/safe-docx/blob/main/LICENSE)
+[![GitHub last commit](https://img.shields.io/github/last-commit/UseJunior/safe-docx)](https://github.com/UseJunior/safe-docx/commits/main)
+[![GitHub issues closed](https://img.shields.io/github/issues-closed/UseJunior/safe-docx)](https://github.com/UseJunior/safe-docx/issues?q=is%3Aissue+is%3Aclosed)
 
 [English](./README.md) | [Español](./README.es.md) | [简体中文](./README.zh.md) | [Português (Brasil)](./README.pt-br.md) | [Deutsch](./README.de.md)
 
@@ -35,17 +39,96 @@ Safe Docx 针对需要确定性、本地优先编辑现有 `.docx` 文件的代�
 
 Safe Docx 不旨在替代以生成为主的 `.docx` 库。
 
+## 信赖我们的用户
+
+- **Am Law 十强律所** — 多步骤合同翻译流水线
+- **150人规模区域律所** — 处理超过2200万 tokens 的合同标注
+- **Gemini CLI** — 兼容的 Word 编辑 MCP 扩展
+
 ## 从这里开始
-
-设置和日常使用请参阅：
-
-- `packages/docx-mcp/README.md`
-
-快速运行：
 
 ```bash
 npx -y @usejunior/safe-docx
 ```
+
+详细设置和工具参考请参阅 `packages/docx-mcp/README.md`。
+
+### 示例：代理编辑合同
+
+当你向已安装 Safe Docx 的编程代理（Claude Code、Cursor、Gemini CLI）发出提示时，代理会执行如下 MCP 工具调用：
+
+```text
+用户：编辑 ~/docs/NDA.docx 中的保密协议 — 将准据法从
+      "State of New York" 改为 "State of Delaware"，
+      同时保存一份干净副本和一份带修订标记的副本。
+
+代理调用：
+
+  1. read_file(file_path="~/docs/NDA.docx", format="toon")
+     → 返回带有稳定 ID 的段落：_bk_1、_bk_2 ...
+
+  2. grep(file_path="~/docs/NDA.docx", pattern="State of New York")
+     → 在段落 _bk_47 中找到匹配
+
+  3. replace_text(
+       file_path="~/docs/NDA.docx",
+       target_paragraph_id="_bk_47",
+       old_string="State of New York",
+       new_string="State of Delaware",
+       instruction="Change governing law to Delaware"
+     )
+
+  4. save(
+       file_path="~/docs/NDA.docx",
+       save_to_local_path="~/docs/NDA-clean.docx",
+       tracked_save_to_local_path="~/docs/NDA-tracked.docx",
+       save_format="both"
+     )
+```
+
+代理自动处理工具调用。你会得到一份干净文件和一份带修订标记的文件供人工审阅。
+
+## MCP 快速开始
+
+### Claude Code
+
+```bash
+claude mcp add safe-docx -- npx -y @usejunior/safe-docx
+```
+
+### Claude Desktop
+
+添加到 `~/Library/Application Support/Claude/claude_desktop_config.json`（macOS）或 `%APPDATA%\Claude\claude_desktop_config.json`（Windows）：
+
+```json
+{
+  "mcpServers": {
+    "safe-docx": {
+      "command": "npx",
+      "args": ["-y", "@usejunior/safe-docx"]
+    }
+  }
+}
+```
+
+### Gemini CLI
+
+```json
+{
+  "mcpServers": {
+    "safe-docx": {
+      "command": "npx",
+      "args": ["-y", "@usejunior/safe-docx"]
+    }
+  }
+}
+```
+
+### 任意 MCP 客户端
+
+- **命令：** `npx`
+- **参数：** `["-y", "@usejunior/safe-docx"]`
+- **传输协议：** stdio
 
 ## Safe Docx 擅长什么
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,9 +4,11 @@
 
 Security fixes are prioritized for the latest published `0.x` release line and `main`.
 
+This policy covers the published npm packages (`@usejunior/safe-docx`, `@usejunior/docx-mcp`, `@usejunior/docx-core`), the MCP server, and the CLI entrypoint.
+
 ## Reporting a Vulnerability
 
-Please report vulnerabilities privately to `steven@usejunior.com`.
+Please report vulnerabilities privately to `security@usejunior.com`.
 
 Include:
 
@@ -23,7 +25,12 @@ Do not open a public issue for an unpatched vulnerability.
 - Triage and severity assessment target: within 7 business days.
 - Fix timeline depends on severity and complexity.
 
+## Disclosure Policy
+
+We follow coordinated disclosure. Reporters will be credited in the release notes accompanying the fix unless they prefer anonymity. We will coordinate with reporters on disclosure timing.
+
 ## Scope Notes
 
 - `safe-docx` is intended for local execution and local file editing workflows.
+- All document processing runs locally. No document content is transmitted to external servers.
 - External dependencies are monitored through normal dependency updates and CI.

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -78,8 +78,11 @@ After npm publish, submit the package to each registry target:
 3. **mcpservers.org** — Manual web form at https://mcpservers.org/submit.
 4. **Smithery.ai** — Publish via https://smithery.ai/docs/build/publish or https://smithery.ai/new.
 5. **Glama.ai** — Auto-discovers from GitHub/registry. Verify listing after registry publish + sync window (not tied to npm timing).
+6. **PulseMCP** (`pulsemcp.com`) — Submit via web form.
+7. **mcp.so** — Submit via directory form.
+8. **mcpmarket.com** — Submit via listing form.
 
-> **Note:** These URLs were verified as of 2026-03-17. Confirm they are still current at submission time.
+> **Note:** These URLs were verified as of 2026-04-02. Confirm they are still current at submission time.
 
 ## Monorepo Version Coupling
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "safe-docx-suite",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "safe-docx-suite",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -7906,7 +7906,7 @@
     },
     "packages/allure-test-factory": {
       "name": "@usejunior/allure-test-factory",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -7927,7 +7927,7 @@
     },
     "packages/docx-core": {
       "name": "@usejunior/docx-core",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.10",
@@ -7954,11 +7954,11 @@
     },
     "packages/docx-mcp": {
       "name": "@usejunior/docx-mcp",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@usejunior/docx-core": "^0.8.0",
+        "@usejunior/docx-core": "^0.8.1",
         "zod": "^4.3.6"
       },
       "bin": {
@@ -7978,7 +7978,7 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@usejunior/google-docs-core": "^0.8.0"
+        "@usejunior/google-docs-core": "^0.8.1"
       },
       "peerDependenciesMeta": {
         "@usejunior/google-docs-core": {
@@ -7988,7 +7988,7 @@
     },
     "packages/google-docs-core": {
       "name": "@usejunior/google-docs-core",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
         "google-auth-library": "^9.0.0"
@@ -8004,10 +8004,10 @@
     },
     "packages/safe-docx": {
       "name": "@usejunior/safe-docx",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
-        "@usejunior/docx-mcp": "^0.8.0"
+        "@usejunior/docx-mcp": "^0.8.1"
       },
       "bin": {
         "safe-docx": "bin/safe-docx.js",
@@ -8019,10 +8019,10 @@
     },
     "packages/safe-docx-mcpb": {
       "name": "@usejunior/safedocx-mcpb",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
-        "@usejunior/safe-docx": "^0.8.0"
+        "@usejunior/safe-docx": "^0.8.1"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-docx-suite",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "description": "Monorepo for Safe DOCX packages",
   "repository": {

--- a/packages/allure-test-factory/package.json
+++ b/packages/allure-test-factory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/allure-test-factory",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Shared Allure test helpers for vitest — BDD context, OpenSpec auto-inference, Prism.js highlighting",
   "type": "module",
   "exports": {

--- a/packages/docx-core/package.json
+++ b/packages/docx-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/docx-core",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "OOXML (.docx) core library: primitives, comparison, and track changes",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/docx-mcp/README.md
+++ b/packages/docx-mcp/README.md
@@ -4,6 +4,8 @@
 [![CI](https://github.com/UseJunior/safe-docx/actions/workflows/ci.yml/badge.svg)](https://github.com/UseJunior/safe-docx/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/UseJunior/safe-docx/blob/main/LICENSE)
 
+**Install via the canonical package:** `npx -y @usejunior/safe-docx` — [see setup guide](../../README.md)
+
 Local MCP server for surgical editing of existing Microsoft Word `.docx` files with coding agents.
 
 Safe Docx is built for brownfield paperwork workflows: apply accepted AI edits to real Word documents while preserving formatting and review semantics.

--- a/packages/docx-mcp/package.json
+++ b/packages/docx-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@usejunior/docx-mcp",
-  "version": "0.8.0",
-  "description": "Safe Docx MCP server (TypeScript)",
+  "version": "0.8.1",
+  "description": "MCP server for reading, editing, and comparing Word documents with tracked changes. For Claude, Gemini CLI, Cursor, and any MCP client. MIT licensed.",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -26,7 +26,7 @@
     "lint": "tsc -b --pretty false"
   },
   "dependencies": {
-    "@usejunior/docx-core": "^0.8.0",
+    "@usejunior/docx-core": "^0.8.1",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "zod": "^4.3.6"
   },
@@ -53,7 +53,7 @@
     "dist"
   ],
   "peerDependencies": {
-    "@usejunior/google-docs-core": "^0.8.0"
+    "@usejunior/google-docs-core": "^0.8.1"
   },
   "peerDependenciesMeta": {
     "@usejunior/google-docs-core": {
@@ -77,7 +77,28 @@
     "serverless",
     "cloudflare-workers",
     "edge",
-    "vercel"
+    "vercel",
+    "microsoft-word",
+    "contract-review",
+    "legal-tech",
+    "document-automation",
+    "coding-agent",
+    "claude-code",
+    "cursor",
+    "windsurf",
+    "redline",
+    "redlining",
+    "contract",
+    "legal",
+    "markup",
+    "mark-up",
+    "word-editing",
+    "word-document",
+    "ai-agent",
+    "local-first",
+    "offline",
+    "diff",
+    "safedocx"
   ],
   "homepage": "https://github.com/UseJunior/safe-docx/tree/main/packages/docx-mcp",
   "bugs": {

--- a/packages/google-docs-core/package.json
+++ b/packages/google-docs-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/google-docs-core",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Google Docs core library: read, write, and anchor management via Google Docs API",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/safe-docx-mcpb/manifest.json
+++ b/packages/safe-docx-mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "safe-docx",
   "display_name": "Safe Docx",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "AI-native Word document editing with stable paragraph anchors and deterministic DOCX operations.",
   "long_description": "Safe Docx lets Claude work directly with .docx files on your local filesystem. It provides stable paragraph IDs (jr_para_*) for precise editing while preserving formatting and structure.\n\nCore capabilities include reading/searching content, formatting-preserving edits and inserts, deterministic layout controls, tracked-changes output, comments, footnote tools, document comparison, and revision extraction.",
   "author": {

--- a/packages/safe-docx-mcpb/package.json
+++ b/packages/safe-docx-mcpb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/safedocx-mcpb",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "description": "Claude Desktop MCP Bundle (.mcpb) wrapper for @usejunior/safe-docx",
   "type": "module",
@@ -14,7 +14,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@usejunior/safe-docx": "^0.8.0"
+    "@usejunior/safe-docx": "^0.8.1"
   },
   "devDependencies": {
     "@vitest/runner": "^3.2.4",

--- a/packages/safe-docx/.smithery/shttp/manifest.json
+++ b/packages/safe-docx/.smithery/shttp/manifest.json
@@ -6,7 +6,7 @@
     "serverCard": {
       "serverInfo": {
         "name": "safe-docx",
-        "version": "0.8.0"
+        "version": "0.8.1"
       },
       "tools": [
         {

--- a/packages/safe-docx/package.json
+++ b/packages/safe-docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@usejunior/safe-docx",
-  "version": "0.8.0",
-  "description": "Canonical npm package for the Safe Docx MCP server and CLI",
+  "version": "0.8.1",
+  "description": "Edit Word (.docx) documents with tracked changes, redlines, and formatting preservation. Built for AI coding agents. MIT licensed, 100% local processing.",
   "mcpName": "io.github.UseJunior/safe-docx",
   "type": "module",
   "main": "./index.js",
@@ -25,7 +25,7 @@
     "safedocx": "./bin/safe-docx.js"
   },
   "dependencies": {
-    "@usejunior/docx-mcp": "^0.8.0"
+    "@usejunior/docx-mcp": "^0.8.1"
   },
   "engines": {
     "node": ">=18.0.0"
@@ -69,7 +69,20 @@
     "coding-agent",
     "claude-code",
     "cursor",
-    "windsurf"
+    "windsurf",
+    "redline",
+    "redlining",
+    "contract",
+    "legal",
+    "markup",
+    "mark-up",
+    "word-editing",
+    "word-document",
+    "ai-agent",
+    "local-first",
+    "offline",
+    "diff",
+    "safedocx"
   ],
   "homepage": "https://usejunior.com/developer-tools/safe-docx",
   "bugs": {

--- a/packages/safe-docx/server.json
+++ b/packages/safe-docx/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.UseJunior/safe-docx",
   "title": "Safe Docx",
   "description": "AI-native surgical editing of existing Word .docx files with formatting preservation",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "websiteUrl": "https://usejunior.com/developer-tools/safe-docx",
   "icons": [
     {
@@ -18,7 +18,7 @@
     {
       "registryType": "npm",
       "identifier": "@usejunior/safe-docx",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "transport": {
         "type": "stdio"
       },

--- a/site/package.json
+++ b/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/safe-docx-site",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "type": "module",
   "description": "Safe DOCX marketing and trust site (Eleventy)",


### PR DESCRIPTION
## Summary

- **SECURITY.md**: updated email to `security@usejunior.com`, expanded scope, added disclosure policy and local-first note
- **package.json keywords + descriptions**: 37 intent-based keywords on both `safe-docx` and `docx-mcp` (redline, contract, legal, markup, ai-agent, local-first, safedocx, etc.) plus search-optimized descriptions
- **README.md**: Trusted By section (anonymized), MCP tool-call agent example, MCP Quickstart, live maintenance + MIT license badges
- **Localized READMEs** (es/zh/pt-br/de): same new sections with translated prose
- **docx-mcp README**: one-line pointer to canonical `@usejunior/safe-docx` install
- **Release runbook**: added PulseMCP, mcp.so, mcpmarket.com as registry targets
- **Version bump**: 0.8.0 → 0.8.1

Ref: `proposals/trust-surface/improve-safedocx-package-discoverability/`

## Test plan

- [ ] `node scripts/bump_version.mjs --check` confirms version sync
- [ ] `npm run lint --workspaces --if-present` passes
- [ ] Badges render correctly on GitHub README preview
- [ ] npm description fields render correctly after publish