### PR TITLE
ci(release): fix shellcheck SC2005 in mcp-publisher download step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -298,7 +298,7 @@ jobs:
           echo "Downloading mcp-publisher from: $URL"
           curl -fsSL "$URL" | tar xz mcp-publisher
           chmod +x mcp-publisher
-          echo "$(pwd)" >> "$GITHUB_PATH"
+          pwd >> "$GITHUB_PATH"
 
       - name: Authenticate with GitHub OIDC
         run: mcp-publisher login github-oidc


### PR DESCRIPTION
One-liner: replace `echo "$(pwd)"` with `pwd` in GITHUB_PATH append. Fixes actionlint on main.