### PR TITLE
fix(docx-core): preserve spaces in deleted text for inplace mode

### DIFF
--- a/packages/docx-core/src/atomizer-rpr.test.ts
+++ b/packages/docx-core/src/atomizer-rpr.test.ts
@@ -116,4 +116,40 @@ describe('ComparisonUnitAtom.rPr', () => {
       }
     });
   });
+
+  test('word-split whitespace atoms have xml:space="preserve"', async ({ given, when, then, and }: AllureBddContext) => {
+    let textEl: Element;
+    let run: Element;
+    let paragraph: Element;
+    let wordAtoms: ReturnType<typeof splitAtomsIntoWords>;
+
+    await given('a run with multi-word text "a b"', () => {
+      textEl = el('w:t', {}, undefined, 'a b');
+      run = el('w:r', {}, [textEl]);
+      paragraph = el('w:p', {}, [run]);
+    });
+
+    await when('the atom is word-split', () => {
+      const atom = createComparisonUnitAtom({
+        contentElement: textEl,
+        ancestors: [paragraph, run],
+        part: PART,
+      });
+      wordAtoms = splitAtomsIntoWords([atom]);
+    });
+
+    await then('3 atoms are produced: "a", " ", "b"', () => {
+      expect(wordAtoms.length).toBe(3);
+    });
+
+    await and('the whitespace atom has xml:space="preserve"', () => {
+      const spaceAtom = wordAtoms[1]!;
+      expect(spaceAtom.contentElement.getAttribute('xml:space')).toBe('preserve');
+    });
+
+    await and('the whitespace atom contentElement is namespace-aware', () => {
+      const spaceEl = wordAtoms[1]!.contentElement;
+      expect(spaceEl.namespaceURI).toBe('http://schemas.openxmlformats.org/wordprocessingml/2006/main');
+    });
+  });
 });

--- a/packages/docx-core/src/atomizer.ts
+++ b/packages/docx-core/src/atomizer.ts
@@ -21,6 +21,7 @@ import {
   childElements,
   findChildByTagName,
 } from './primitives/index.js';
+import { OOXML } from './primitives/namespaces.js';
 
 // =============================================================================
 // Shared synthetic document for creating virtual elements
@@ -701,8 +702,11 @@ export function collapseFieldSequences(
       // Create a collapsed field atom with the visible text
       const firstAtom = fieldAtoms[0]!;
       // Use w:t so it can merge with adjacent text
-      const virtualElement = SYNTHETIC_DOC.createElement('w:t');
+      const virtualElement = SYNTHETIC_DOC.createElementNS(OOXML.W_NS, 'w:t');
       setLeafText(virtualElement, visibleText);
+      if (/\s/.test(visibleText)) {
+        virtualElement.setAttributeNS('http://www.w3.org/XML/1998/namespace', 'xml:space', 'preserve');
+      }
 
       const collapsedAtom: ComparisonUnitAtom = {
         contentElement: virtualElement,
@@ -775,13 +779,17 @@ function splitAtomIntoWords(atom: ComparisonUnitAtom): ComparisonUnitAtom[] {
     if (part === '') continue;
 
     // Create a new element for this word/whitespace
-    const wordElement = SYNTHETIC_DOC.createElement('w:t');
+    const wordElement = SYNTHETIC_DOC.createElementNS(OOXML.W_NS, 'w:t');
     // Copy attributes from the original content element
     for (let i = 0; i < atom.contentElement.attributes.length; i++) {
       const attr = atom.contentElement.attributes[i]!;
       wordElement.setAttribute(attr.name, attr.value);
     }
     setLeafText(wordElement, part);
+    // Ensure OOXML renderers preserve whitespace in this fragment
+    if (/\s/.test(part)) {
+      wordElement.setAttributeNS('http://www.w3.org/XML/1998/namespace', 'xml:space', 'preserve');
+    }
 
     // Create atom for this word
     const wordAtom: ComparisonUnitAtom = {

--- a/packages/docx-core/src/integration/round-trip-inplace.test.ts
+++ b/packages/docx-core/src/integration/round-trip-inplace.test.ts
@@ -97,6 +97,45 @@ describe('Round-Trip Tests - Inplace Reconstruction', () => {
   }
 });
 
+test('multiple-changes inplace: deleted text preserves xml:space on whitespace fragments', async ({ given, when, then }: AllureBddContext) => {
+  let original: Buffer;
+  let revised: Buffer;
+  let resultXml: string;
+
+  await given('multiple-changes original and revised documents are loaded', async () => {
+    original = await readFile(join(fixturesPath, 'multiple-changes', 'original.docx'));
+    revised = await readFile(join(fixturesPath, 'multiple-changes', 'revised.docx'));
+  });
+
+  await when('documents are compared in inplace mode', async () => {
+    const result = await compareDocuments(original, revised, {
+      engine: 'atomizer',
+      reconstructionMode: 'inplace',
+    });
+    const resultArchive = await DocxArchive.load(result.document);
+    resultXml = await resultArchive.getDocumentXml();
+  });
+
+  await then('all w:delText elements containing whitespace have xml:space="preserve"', () => {
+    // Parse the result XML and check every w:delText element
+    const { DOMParser } = require('@xmldom/xmldom');
+    const doc = new DOMParser().parseFromString(resultXml, 'application/xml');
+    const delTexts = doc.getElementsByTagName('w:delText');
+    for (let i = 0; i < delTexts.length; i++) {
+      const el = delTexts[i]!;
+      const text = el.textContent ?? '';
+      if (/\s/.test(text)) {
+        expect(
+          el.getAttribute('xml:space'),
+          `w:delText with whitespace "${text}" must have xml:space="preserve"`,
+        ).toBe('preserve');
+      }
+    }
+    // Sanity check: there should be at least one deleted whitespace fragment
+    expect(delTexts.length).toBeGreaterThan(0);
+  });
+});
+
 test('split-run-boundary-change: reject changes should match original', async ({ given, when, then }: AllureBddContext) => {
   const makeDocxWithRuns = async (runs: string[]): Promise<Buffer> => {
     const contentTypes = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>


### PR DESCRIPTION
## Summary
Fixes #76 — inplace mode was stripping all spaces from deleted text in tracked changes output.

- `splitAtomIntoWords()` in `atomizer.ts` creates word-level `<w:t>` elements but was missing `xml:space="preserve"` on whitespace fragments
- Without this attribute, Word/LibreOffice silently collapse whitespace in `<w:delText>` elements
- Also fixed `collapseFieldSequences()` which had the same `createElement` (non-namespaced) issue

## Root Cause
The regex `text.split(/(\s+)/)` produces separate atoms for words and whitespace (e.g., `["The", " ", "Company", " ", "shall"]`). Each gets a new `<w:t>` element, but whitespace-only parts like `" "` need `xml:space="preserve"` to render correctly in OOXML. This attribute was never set.

## Before / After

### Before
<img width="893" height="1000" alt="pr77-before-spaces-stripped" src="https://github.com/user-attachments/assets/711df274-4739-4835-91df-3be92293deb9" />

### After
<img width="927" height="913" alt="pr77-after-spaces-preserved" src="https://github.com/user-attachments/assets/ad9483ea-0d55-4704-a9fd-a19db90687e5" />

## Test plan
- [x] `tsc --noEmit` passes
- [x] 1082/1082 tests pass (74/74 test files)
- [x] New XML-level regression test: asserts `<w:delText xml:space="preserve">` on whitespace fragments
- [x] New atomizer unit test: validates word-split atoms get `xml:space="preserve"`
- [x] Manual CLI test with `--mode inplace` on `multiple-changes` fixture, confirmed in LibreOffice