### PR TITLE
Add license and compatibility metadata to docx-editing SKILL.md

### DIFF
--- a/skills/docx-editing/SKILL.md
+++ b/skills/docx-editing/SKILL.md
@@ -6,6 +6,13 @@ description: >-
   docx," "change the contract," "redline the document," "compare these Word files,"
   "add a comment to the docx," "read this Word file," or "mark up the agreement."
   Not for from-scratch document generation.
+license: MIT
+compatibility: >-
+  Works with any agent. Local MCP server requires Node.js >=20
+  and runs entirely on the local filesystem.
+metadata:
+  author: safe-docx
+  version: "0.1.0"
 ---
 
 # Editing .docx Files with Safe-DOCX


### PR DESCRIPTION
## Summary

- Adds `license: MIT` and `compatibility` frontmatter fields to `skills/docx-editing/SKILL.md`
- Adds `metadata` block with author and version
- Aligns docx-editing skill frontmatter with the format used by open-agreements skills for consistent Smithery directory listings

## Test plan

- [ ] Verify YAML frontmatter parses correctly (no syntax errors)
- [ ] Confirm Smithery listing renders the new license and compatibility fields