### PR TITLE
ci: fix PR title check for acronyms and fork PRs

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,7 +1,7 @@
 name: PR Title Lint
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, synchronize, reopened]
     branches: [main]
 
@@ -31,15 +31,18 @@ jobs:
             revert
             build
           requireScope: false
-          subjectPattern: ^[a-z].+$
+          subjectPattern: ^(?![A-Z][a-z]).+$
           subjectPatternError: |
-            The subject must start with a lowercase letter.
+            The subject must not start with a Title Case word (e.g. "Add", "Update").
+            Acronyms like SHA, API, URL are fine. Lowercase starts are fine.
 
             Examples of valid PR titles:
               feat(docx-core): add paragraph diffing
               fix: correct bookmark cleanup order
               chore(release): bump workspace versions
               ci: add PR title validation
+              ci: SHA-pin all GitHub Actions
+              feat: API migration to v2
 
   auto-label:
     name: Apply type label from PR title

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ Longer is better — think essay, not tweet.
 Fixes: #42
 ```
 
-**Valid types:** `feat`, `fix`, `refactor`, `test`, `docs`, `chore`, `ci`, `perf`, `style`
+**Valid types:** `feat`, `fix`, `refactor`, `test`, `docs`, `chore`, `ci`, `perf`, `style`, `revert`, `build`
 
 **Scopes** should match the package or area you're changing:
 - `fix(docx-core):` — bug fix in the core OOXML library
@@ -56,9 +56,13 @@ Fixes: #42
 
 Scope your commits to one package when possible. Cross-package changes should use the primary package as scope.
 
+**Subject casing:** The subject (the part after the colon) must not start with a Title Case word like "Add" or "Update". Lowercase starts and all-caps acronyms (SHA, API, URL) are fine.
+
 **Reference issues** in the commit body: `Fixes: #N` (closes the issue) or `Ref: #N` (related but doesn't close).
 
 ## Pull Request Guidelines
+
+Pull request titles follow the same Conventional Commits format as commit messages. A CI check (`Validate conventional title`) enforces this on every PR.
 
 - **Keep PRs small and focused.** 10 small PRs are better than 1 monolithic one.
 - **A PR doesn't have to be done** — or even work — but it should represent clean progress in one direction.


### PR DESCRIPTION
## Summary
- Switch `pr-title.yml` trigger from `pull_request` to `pull_request_target` so the check works on fork PRs (safe — only reads PR title, no code checkout)
- Relax `subjectPattern` to allow all-caps acronyms (`SHA`, `API`, `URL`) while still blocking Title Case (`Add`, `Update`)
- Add `revert` and `build` to CONTRIBUTING.md valid types list
- Document subject casing rule and PR title enforcement

## Test plan
- [ ] PR with `ci: SHA-pin something` passes validation
- [ ] PR with `ci: Add something` is blocked (Title Case)
- [ ] PR with `ci: API migration` passes (acronym OK)
- [ ] Fork-originated PR gets labels applied correctly