### PR TITLE
fix(docx-core): emit paragraph-level markers outside <w:r> on rebuild

### DIFF
--- a/packages/docx-core/src/atomizer.ts
+++ b/packages/docx-core/src/atomizer.ts
@@ -201,12 +201,11 @@ const LEAF_NODE_TAGS = new Set([
   'w:footnoteReference', // Footnote reference
   'w:endnoteReference', // Endnote reference
   'w:commentReference', // Comment reference anchor (run-level child).
-  // w:commentRangeStart / w:commentRangeEnd are paragraph-level markers, not
-  // run-level leaves; treating them as leaves makes the rebuild reconstructor
-  // wrap them in a synthetic <w:r>, which is non-conformant. Trade-off: comment
-  // ranges (the highlighted span) are lost on rebuild, but the comment itself
-  // still anchors at commentReference. Restoring ranges requires reconstructor
-  // changes to emit paragraph-level atoms outside <w:r> wrappers.
+  // Note: w:commentRangeStart / w:commentRangeEnd / w:bookmarkStart / w:bookmarkEnd
+  // are paragraph-level markers (siblings of <w:r>, not children). They are
+  // tracked in PARAGRAPH_LEVEL_TAGS below and atomized via a separate branch in
+  // atomizeTreeInternal so the reconstructor can emit them outside synthetic
+  // <w:r> wrappers.
   'w:separator', // Separator
   'w:continuationSeparator', // Continuation separator
   'w:pgNum', // Page number
@@ -214,6 +213,26 @@ const LEAF_NODE_TAGS = new Set([
   'w:pict', // Picture (VML)
   'w:object', // Embedded object
   'mc:AlternateContent', // Alternate content
+]);
+
+/**
+ * Tag names that are paragraph-level OOXML markers per ECMA-376 §17.13.5.
+ *
+ * These elements are valid as direct children of <w:p> (and revision wrappers
+ * like <w:ins>/<w:del>/<w:moveFrom>/<w:moveTo>) but never inside <w:r>. The
+ * rebuild reconstructor emits them as siblings of <w:r>, not leaves wrapped in
+ * a synthetic run.
+ *
+ * Scope: commentRange and bookmark only. moveFromRange / moveToRange and
+ * permStart / permEnd are deferred to follow-up issues — moveRange collides
+ * with the synthetic emission in wrapWithMoveFrom and wrapWithMoveTo, and
+ * permStart / permEnd needs fixture coverage.
+ */
+export const PARAGRAPH_LEVEL_TAGS = new Set([
+  'w:commentRangeStart',
+  'w:commentRangeEnd',
+  'w:bookmarkStart',
+  'w:bookmarkEnd',
 ]);
 
 /**
@@ -253,6 +272,18 @@ export interface AtomizeTreeOptions {
    * Default: true.
    */
   splitTextIntoWords?: boolean;
+  /**
+   * Atomize paragraph-level markers (commentRangeStart/End, bookmarkStart/End)
+   * so the rebuild reconstructor can re-emit them as siblings of <w:r>.
+   *
+   * MUST be false for inplace mode. Inplace handlers are run-anchored and
+   * silently no-op on atoms with no sourceRunElement, but inplace's bookmark
+   * reconciliation breaks if bookmarkStart/End atoms enter the stream
+   * (orphaned bookmark warnings, round-trip safety check fails).
+   *
+   * Default: false.
+   */
+  atomizeParagraphLevelMarkers?: boolean;
 }
 
 /**
@@ -265,6 +296,18 @@ export interface AtomizeTreeOptions {
  */
 export function isLeafNode(element: WmlElement): boolean {
   return LEAF_NODE_TAGS.has(element.tagName);
+}
+
+/**
+ * Check if an element is a paragraph-level OOXML marker.
+ *
+ * Paragraph-level markers (commentRangeStart/End, bookmarkStart/End) are
+ * atomized only when they sit inside a <w:p> ancestor — body/table-sibling
+ * placements stay out of the atom stream and are handled by the scaffold-strip
+ * block in the reconstructor.
+ */
+export function isParagraphLevelLeaf(element: WmlElement): boolean {
+  return PARAGRAPH_LEVEL_TAGS.has(element.tagName);
 }
 
 // =============================================================================
@@ -423,7 +466,7 @@ function atomizeTreeInternal(
   ancestors: WmlElement[],
   part: OpcPart,
   state: AtomizationState,
-  options: Required<Pick<AtomizeTreeOptions, 'cloneLeafNodes'>>
+  options: Required<Pick<AtomizeTreeOptions, 'cloneLeafNodes' | 'atomizeParagraphLevelMarkers'>>
 ): ComparisonUnitAtom[] {
   const atoms: ComparisonUnitAtom[] = [];
 
@@ -435,6 +478,24 @@ function atomizeTreeInternal(
     });
     atoms.push(atom);
     // Update last content hash for context-aware empty paragraph matching
+    state.lastContentHash = atom.sha1Hash;
+  } else if (
+    options.atomizeParagraphLevelMarkers &&
+    isParagraphLevelLeaf(node) &&
+    ancestors.some((a) => a.tagName === 'w:p')
+  ) {
+    // Paragraph-level markers (commentRange*, bookmark*) inside a <w:p> become
+    // atoms so the rebuild reconstructor can re-emit them as siblings of <w:r>.
+    // Body/table-sibling placements are intentionally skipped — they are
+    // already handled by the scaffold-strip block in the reconstructor and
+    // would otherwise misattach to the previous paragraph in
+    // assignParagraphIndices().
+    const atom = createComparisonUnitAtom({
+      contentElement: options.cloneLeafNodes ? (node.cloneNode(true) as Element) : node,
+      ancestors,
+      part,
+    });
+    atoms.push(atom);
     state.lastContentHash = atom.sha1Hash;
   } else if (isEmptyParagraph(node)) {
     // Create empty paragraph atom with context-aware hash
@@ -471,6 +532,7 @@ export function atomizeTree(
     mergeAcrossRuns: options.mergeAcrossRuns ?? true,
     mergePunctuationAcrossRuns: options.mergePunctuationAcrossRuns ?? true,
     splitTextIntoWords: options.splitTextIntoWords ?? true,
+    atomizeParagraphLevelMarkers: options.atomizeParagraphLevelMarkers ?? false,
   };
 
   const state: AtomizationState = {

--- a/packages/docx-core/src/baselines/atomizer/documentReconstructor.ts
+++ b/packages/docx-core/src/baselines/atomizer/documentReconstructor.ts
@@ -11,7 +11,8 @@ import type { ComparisonUnitAtom } from '../../core-types.js';
 import { CorrelationStatus } from '../../core-types.js';
 import { getLeafText, childElements, findChildByTagName } from '../../primitives/index.js';
 import { serializeToXml, cloneElement } from './xmlToWmlElement.js';
-import { EMPTY_PARAGRAPH_TAG } from '../../atomizer.js';
+import { EMPTY_PARAGRAPH_TAG, isParagraphLevelLeaf } from '../../atomizer.js';
+import { enforceConsumerCompatibility } from './consumerCompatibility.js';
 import { areRunPropertiesEqual } from '../../format-detection.js';
 import { debug } from './debug.js';
 
@@ -128,7 +129,12 @@ export function reconstructDocument(
   debug('reconstructor', `Empty paragraphs: inserted=${emptyCounters.inserted}, deleted=${emptyCounters.deleted}, equal=${emptyCounters.equal}, other=${emptyCounters.other}`);
 
   // Reconstruct the document, preserving original body structure (tables, SDTs, etc.)
-  return buildDocumentPreservingStructure(originalXml, paragraphXmls, paragraphGroups);
+  return buildDocumentPreservingStructure(
+    originalXml,
+    paragraphXmls,
+    paragraphGroups,
+    () => allocateRevisionId(revState)
+  );
 }
 
 /**
@@ -816,6 +822,12 @@ function buildRunContentAsPlainRun(group: RunGroup): string {
   );
   if (contentAtoms.length === 0) return '';
 
+  // Paragraph-level markers must sit outside <w:r>; route through the
+  // marker-aware helper which buffers run atoms and flushes on each marker.
+  if (groupHasParagraphLevelAtoms(group)) {
+    return buildRunContentWithParagraphMarkers(group);
+  }
+
   // If group has explicit rPr, emit a single run
   if (group.rPr !== null) {
     return buildSingleRun(group.atoms, group.rPr);
@@ -937,6 +949,57 @@ function subGroupByRPr(atoms: ComparisonUnitAtom[]): { rPr: Element | null; atom
 }
 
 /**
+ * Returns true when any atom in the group is a paragraph-level marker
+ * (commentRange / bookmark) that must be emitted outside <w:r>.
+ */
+function groupHasParagraphLevelAtoms(group: RunGroup): boolean {
+  for (const atom of group.atoms) {
+    if (isParagraphLevelLeaf(atom.contentElement)) return true;
+  }
+  return false;
+}
+
+/**
+ * Marker-aware emission for run groups containing paragraph-level atoms.
+ *
+ * Walks atoms left-to-right. Run-level atoms accumulate in a buffer; on
+ * encountering a paragraph-level atom (or end of group) the buffer is flushed
+ * via subGroupByRPr + buildSingleRun (one <w:r> per contiguous rPr) and the
+ * marker is emitted as a bare element.
+ *
+ * group.rPr is intentionally ignored here — RunGroup.rPr is captured from the
+ * first atom in groupAtomsByParagraph(), and for moved groups
+ * shouldStartNewRunGroup() suppresses rPr-based splitting. Always re-deriving
+ * rPr per atom prevents formatting bleed and bogus rPr inheritance from
+ * illegally nested markers.
+ */
+function buildRunContentWithParagraphMarkers(group: RunGroup): string {
+  const parts: string[] = [];
+  let runBuffer: ComparisonUnitAtom[] = [];
+
+  const flush = () => {
+    if (runBuffer.length === 0) return;
+    for (const sg of subGroupByRPr(runBuffer)) {
+      const run = buildSingleRun(sg.atoms, sg.rPr);
+      if (run) parts.push(run);
+    }
+    runBuffer = [];
+  };
+
+  for (const atom of group.atoms) {
+    if (atom.contentElement.tagName === EMPTY_PARAGRAPH_TAG) continue;
+    if (isParagraphLevelLeaf(atom.contentElement)) {
+      flush();
+      parts.push(serializeAtomElement(atom.contentElement));
+    } else {
+      runBuffer.push(atom);
+    }
+  }
+  flush();
+  return parts.join('');
+}
+
+/**
  * Build a single <w:r> element from a set of atoms with the given rPr.
  * Preserves pendingText coalescing, collapsedFieldAtoms expansion,
  * and debug counter increments.
@@ -1038,6 +1101,12 @@ function buildRunContent(group: RunGroup): string {
   // If no content atoms, return empty string (don't generate empty run)
   if (contentAtoms.length === 0) {
     return '';
+  }
+
+  // Paragraph-level markers must sit outside <w:r>; route through the
+  // marker-aware helper which buffers run atoms and flushes on each marker.
+  if (groupHasParagraphLevelAtoms(group)) {
+    return buildRunContentWithParagraphMarkers(group);
   }
 
   // If group has explicit rPr, emit a single run
@@ -1264,7 +1333,8 @@ function isRootedGroup(group: ParagraphGroup): boolean {
 function buildDocumentPreservingStructure(
   originalXml: string,
   paragraphXmls: string[],
-  paragraphGroups: ParagraphGroup[]
+  paragraphGroups: ParagraphGroup[],
+  allocateRevisionId: () => number
 ): string {
   const { doc, body, slots } = parseOriginalBodyStructure(originalXml);
 
@@ -1372,6 +1442,13 @@ function buildDocumentPreservingStructure(
   for (const el of toRemove) {
     el.parentNode!.removeChild(el);
   }
+
+  // Balance bookmarks and enforce consumer-compatibility invariants on the
+  // rebuilt body. This dedupes bookmark Names/IDs, hoists bookmarkStart/End
+  // out of <w:ins>/<w:del> wrappers (so they survive accept/reject), and
+  // synthesizes recovery markers for orphaned starts/ends. Mirrors the
+  // post-processing applied in inplace mode (inPlaceModifier.ts).
+  enforceConsumerCompatibility(body, allocateRevisionId);
 
   // Serialize modified body and splice back into original envelope
   const serializer = new XMLSerializer();

--- a/packages/docx-core/src/baselines/atomizer/pipeline.ts
+++ b/packages/docx-core/src/baselines/atomizer/pipeline.ts
@@ -752,14 +752,20 @@ export async function compareDocumentsAtomizer(
     if (selected) {
       comparisonResult = selected;
     } else {
-      comparisonResult = runComparisonPass(undefined, 'rebuild');
+      comparisonResult = runComparisonPass(
+        { atomizeParagraphLevelMarkers: true },
+        'rebuild'
+      );
       fallbackReason = 'round_trip_safety_check_failed';
       fallbackDiagnostics = {
         attempts: failedAttempts,
       };
     }
   } else {
-    comparisonResult = runComparisonPass(undefined, 'rebuild');
+    comparisonResult = runComparisonPass(
+      { atomizeParagraphLevelMarkers: true },
+      'rebuild'
+    );
   }
 
   const { mergedAtoms, newDocumentXml } = comparisonResult;

--- a/packages/docx-core/src/integration/rebuild-auxiliary-merge.test.ts
+++ b/packages/docx-core/src/integration/rebuild-auxiliary-merge.test.ts
@@ -16,6 +16,30 @@ import { describe, expect } from 'vitest';
 import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
 import { compareDocuments } from '../index.js';
 import { buildSyntheticDocx, getResultParts } from './synthetic-docx-fixture.js';
+import { parseXml } from '../primitives/xml.js';
+
+/**
+ * Find every element with the given local name and report its immediate-parent
+ * tag and the chain of ancestor tags. Used by the marker-position assertions
+ * below.
+ */
+function inspectElements(xml: string, localName: string): Array<{ parent: string; ancestors: string[]; idAttr: string | null }> {
+  const doc = parseXml(xml);
+  const found: Array<{ parent: string; ancestors: string[]; idAttr: string | null }> = [];
+  const all = doc.getElementsByTagName(localName);
+  for (let i = 0; i < all.length; i++) {
+    const el = all[i]!;
+    const parent = (el.parentNode as Element | null)?.tagName ?? '';
+    const ancestors: string[] = [];
+    let cur: Element | null = el.parentNode as Element | null;
+    while (cur) {
+      ancestors.push(cur.tagName);
+      cur = cur.parentNode as Element | null;
+    }
+    found.push({ parent, ancestors, idAttr: el.getAttribute('w:id') });
+  }
+  return found;
+}
 
 const test = testAllure
   .epic('Document Comparison')
@@ -119,6 +143,19 @@ describe('Rebuild Auxiliary Part Merging (issue #94)', () => {
         expect(parts.documentXml).not.toMatch(/<w:r\b[^>]*>\s*<w:commentRangeStart\b/);
         expect(parts.documentXml).not.toMatch(/<w:r\b[^>]*>\s*<w:commentRangeEnd\b/);
 
+        // Issue #106: range markers must be present and at paragraph-level
+        // position — direct children of w:p (consumerCompatibility hoists them
+        // out of revision wrappers so they survive accept/reject).
+        const starts = inspectElements(parts.documentXml, 'w:commentRangeStart');
+        const ends = inspectElements(parts.documentXml, 'w:commentRangeEnd');
+        expect(starts.length).toBeGreaterThan(0);
+        expect(ends.length).toBeGreaterThan(0);
+        const validParents = new Set(['w:p', 'w:ins', 'w:del', 'w:moveFrom', 'w:moveTo']);
+        for (const m of [...starts, ...ends]) {
+          expect(m.ancestors).not.toContain('w:r');
+          expect(validParents.has(m.parent)).toBe(true);
+        }
+
         expect(parts.contentTypesXml!).toContain('word/comments.xml');
         expect(parts.contentTypesXml!).toContain(
           'application/vnd.openxmlformats-officedocument.wordprocessingml.comments+xml'
@@ -216,6 +253,121 @@ describe('Rebuild Auxiliary Part Merging (issue #94)', () => {
 
         const userFootnoteCount = (parts.footnotesXml!.match(/<w:footnote w:id="1"/g) ?? []).length;
         expect(userFootnoteCount).toBe(1);
+      });
+    });
+  });
+});
+
+describe('Paragraph-level marker reconstruction on rebuild (issue #106)', () => {
+  describe('Cross-paragraph comment span', () => {
+    test('rebuild keeps commentRangeStart and commentRangeEnd in their respective paragraphs', async ({ given, when, then }: AllureBddContext) => {
+      let original: Buffer, revised: Buffer;
+      await given('original has two plain paragraphs and revised adds a comment spanning both', async () => {
+        original = await buildSyntheticDocx({
+          paragraphs: ['First paragraph', 'Second paragraph'],
+        });
+        revised = await buildSyntheticDocx({
+          paragraphs: ['First paragraph', 'Second paragraph'],
+          commentSpanParagraphs: { start: 0, end: 1 },
+          commentText: 'Spanning comment',
+          commentAuthor: 'Reviewer',
+        });
+      });
+
+      let result: Awaited<ReturnType<typeof compareDocuments>>;
+      await when('documents are compared in rebuild mode', async () => {
+        result = await compareDocuments(original, revised, {
+          engine: 'atomizer',
+          reconstructionMode: 'rebuild',
+        });
+      });
+
+      await then('start and end markers survive rebuild at paragraph level with matching ids', async () => {
+        expect(result.reconstructionModeUsed).toBe('rebuild');
+        const parts = await getResultParts(result.document);
+
+        const starts = inspectElements(parts.documentXml, 'w:commentRangeStart');
+        const ends = inspectElements(parts.documentXml, 'w:commentRangeEnd');
+        expect(starts.length).toBe(1);
+        expect(ends.length).toBe(1);
+        expect(starts[0]!.idAttr).toBe(ends[0]!.idAttr);
+
+        const validParents = new Set(['w:p', 'w:ins', 'w:del', 'w:moveFrom', 'w:moveTo']);
+        for (const m of [...starts, ...ends]) {
+          expect(m.ancestors).not.toContain('w:r');
+          expect(validParents.has(m.parent)).toBe(true);
+        }
+      });
+    });
+  });
+
+  describe('Sibling-style scaffold markers', () => {
+    test('body-level bookmarks are stripped on rebuild and do not leak into reconstructed paragraphs', async ({ given, when, then }: AllureBddContext) => {
+      let original: Buffer, revised: Buffer;
+      await given('original has a sibling-style bookmark between two paragraphs', async () => {
+        original = await buildSyntheticDocx({
+          paragraphs: ['Para A', 'Para B'],
+          siblingBookmarkBefore: { index: 1, name: '_scaffold_bookmark', id: 999 },
+        });
+        revised = await buildSyntheticDocx({
+          paragraphs: ['Para A revised', 'Para B'],
+          siblingBookmarkBefore: { index: 1, name: '_scaffold_bookmark', id: 999 },
+        });
+      });
+
+      let result: Awaited<ReturnType<typeof compareDocuments>>;
+      await when('documents are compared in rebuild mode', async () => {
+        result = await compareDocuments(original, revised, {
+          engine: 'atomizer',
+          reconstructionMode: 'rebuild',
+        });
+      });
+
+      await then('the body-level bookmark does not appear inside any reconstructed <w:p>', async () => {
+        expect(result.reconstructionModeUsed).toBe('rebuild');
+        const parts = await getResultParts(result.document);
+
+        // Scaffold-strip removes body-level scaffold bookmarks. After
+        // strip+balance, any surviving start must not be inside a <w:p>.
+        const starts = inspectElements(parts.documentXml, 'w:bookmarkStart').filter(
+          (m) => m.idAttr === '999'
+        );
+        for (const m of starts) {
+          expect(m.ancestors).not.toContain('w:p');
+        }
+      });
+    });
+  });
+
+  describe('Inplace regression — comment span', () => {
+    test('inplace mode succeeds with a cross-paragraph comment span on the revised side', async ({ given, when, then }: AllureBddContext) => {
+      let original: Buffer, revised: Buffer;
+      await given('original has plain paragraphs and revised adds a spanning comment', async () => {
+        original = await buildSyntheticDocx({
+          paragraphs: ['First paragraph', 'Second paragraph'],
+        });
+        revised = await buildSyntheticDocx({
+          paragraphs: ['First paragraph', 'Second paragraph'],
+          commentSpanParagraphs: { start: 0, end: 1 },
+          commentText: 'Spanning comment',
+          commentAuthor: 'Reviewer',
+        });
+      });
+
+      let result: Awaited<ReturnType<typeof compareDocuments>>;
+      await when('documents are compared in inplace mode', async () => {
+        result = await compareDocuments(original, revised, {
+          engine: 'atomizer',
+          reconstructionMode: 'inplace',
+        });
+      });
+
+      await then('inplace mode is used (no fallback) and output is structurally valid', async () => {
+        expect(result.reconstructionModeUsed).toBe('inplace');
+        const parts = await getResultParts(result.document);
+        // inplace output must contain the comment anchor; the full span survives
+        // because the markers are already present in the revised archive.
+        expect(parts.documentXml).toContain('w:commentReference');
       });
     });
   });

--- a/packages/docx-core/src/integration/synthetic-docx-fixture.ts
+++ b/packages/docx-core/src/integration/synthetic-docx-fixture.ts
@@ -11,13 +11,44 @@ export interface SyntheticDocxOptions {
   // When true, the comment scenario also emits commentsExtended.xml + people.xml
   // with matching paraId / author entries. Used to test ancillary-part bootstrap.
   commentAncillaryParts?: boolean;
+  /**
+   * Cross-paragraph comment span. The comment opens at the start of
+   * paragraphs[start] and closes at the end of paragraphs[end]. The
+   * commentReference run is appended to paragraphs[end].
+   *
+   * Mutually exclusive with commentOnParagraph.
+   */
+  commentSpanParagraphs?: { start: number; end: number };
+  /**
+   * Bookmark spanning a single paragraph (start and end inside the same w:p).
+   * Used to verify paragraph-internal bookmark preservation through rebuild.
+   */
+  bookmarkOnParagraph?: { paragraph: number; name: string; id?: number };
+  /**
+   * Body-level (sibling of <w:p>) bookmark inserted between
+   * paragraphs[index - 1] and paragraphs[index]. Used to verify scaffold
+   * markers do not leak into reconstructed paragraphs.
+   */
+  siblingBookmarkBefore?: { index: number; name: string; id?: number };
 }
 
 export async function buildSyntheticDocx(opts: SyntheticDocxOptions): Promise<Buffer> {
   const hasFootnote = opts.footnoteOnParagraph != null;
   const hasComment = opts.commentOnParagraph != null;
+  const hasCommentSpan = opts.commentSpanParagraphs != null;
+  const hasBookmark = opts.bookmarkOnParagraph != null;
+  const hasSiblingBookmark = opts.siblingBookmarkBefore != null;
 
-  const paragraphsXml = opts.paragraphs.map((text, idx) => {
+  if (hasComment && hasCommentSpan) {
+    throw new Error('commentOnParagraph and commentSpanParagraphs are mutually exclusive');
+  }
+
+  const bookmarkId = opts.bookmarkOnParagraph?.id ?? 100;
+  const siblingBookmarkId = opts.siblingBookmarkBefore?.id ?? 200;
+  const spanStart = opts.commentSpanParagraphs?.start;
+  const spanEnd = opts.commentSpanParagraphs?.end;
+
+  const paragraphParts: string[] = opts.paragraphs.map((text, idx) => {
     const escaped = text
       .replaceAll('&', '&amp;')
       .replaceAll('<', '&lt;')
@@ -37,8 +68,41 @@ export async function buildSyntheticDocx(opts: SyntheticDocxOptions): Promise<Bu
       return `<w:p>${extra}</w:p>`;
     }
 
+    if (hasCommentSpan && (idx === spanStart || idx === spanEnd)) {
+      const before = idx === spanStart ? `<w:commentRangeStart w:id="1"/>` : '';
+      const after = idx === spanEnd
+        ? `<w:commentRangeEnd w:id="1"/>` +
+          `<w:r><w:rPr><w:rStyle w:val="CommentReference"/></w:rPr><w:commentReference w:id="1"/></w:r>`
+        : '';
+      return `<w:p>${before}<w:r><w:t>${escaped}</w:t></w:r>${after}${extra}</w:p>`;
+    }
+
+    if (hasBookmark && idx === opts.bookmarkOnParagraph!.paragraph) {
+      const name = opts.bookmarkOnParagraph!.name;
+      return (
+        `<w:p>` +
+        `<w:bookmarkStart w:id="${bookmarkId}" w:name="${name}"/>` +
+        `<w:r><w:t>${escaped}</w:t></w:r>` +
+        `<w:bookmarkEnd w:id="${bookmarkId}"/>` +
+        extra +
+        `</w:p>`
+      );
+    }
+
     return `<w:p><w:r><w:t>${escaped}</w:t></w:r>${extra}</w:p>`;
-  }).join('\n    ');
+  });
+
+  // Inject a body-level (sibling of <w:p>) bookmark before paragraphs[index].
+  // Bookmark*Start*/End placed as sibling of <w:p> per ECMA-376 §17.13.5.
+  if (hasSiblingBookmark) {
+    const { index, name } = opts.siblingBookmarkBefore!;
+    const sibling =
+      `<w:bookmarkStart w:id="${siblingBookmarkId}" w:name="${name}"/>` +
+      `<w:bookmarkEnd w:id="${siblingBookmarkId}"/>`;
+    paragraphParts.splice(index, 0, sibling);
+  }
+
+  const paragraphsXml = paragraphParts.join('\n    ');
 
   const documentXml =
     `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
@@ -74,7 +138,7 @@ export async function buildSyntheticDocx(opts: SyntheticDocxOptions): Promise<Bu
     );
   }
 
-  if (hasComment) {
+  if (hasComment || hasCommentSpan) {
     const cText = opts.commentText ?? 'Test comment';
     const cAuthor = opts.commentAuthor ?? 'Author';
     const commentsXml =


### PR DESCRIPTION
## Summary

Fixes #106. Restores `w:commentRangeStart` / `w:commentRangeEnd` and `w:bookmarkStart` / `w:bookmarkEnd` on rebuild output by atomizing paragraph-internal markers and routing them outside the synthetic `<w:r>` wrapper that `buildSingleRun` emits for run-level leaves.

PR #101 traded these markers away to fix a "Word can't open" regression (issue #94), accepting that comment ranges (the highlighted span) and paragraph-internal bookmark spans were lost on rebuild output. This PR puts them back — at the schema-correct position (siblings of `<w:r>`, not children) — so Word still opens the file and the spans survive.

## Mechanics

- New `PARAGRAPH_LEVEL_TAGS` set + `isParagraphLevelLeaf()` predicate in `atomizer.ts`.
- **Ancestry-sensitive atomization**: only emit a marker atom when the element sits inside a `<w:p>`. Body/table-sibling placements stay out of the atom stream and are still handled by the existing scaffold-strip block (avoids misattachment via `assignParagraphIndices`, which only assigns indices to atoms with a `w:p` ancestor).
- **Rebuild-only gate**: new `atomizeParagraphLevelMarkers` flag on `AtomizeTreeOptions`, set true only on the rebuild path. The inplace path's bookmark reconciliation breaks if `bookmarkStart`/`End` atoms enter the stream (orphaned-bookmark warnings, round-trip safety failures).
- **`buildRunContentWithParagraphMarkers()`**: walks a `RunGroup` left to right, buffers run-level atoms, flushes the buffer to `<w:r>` blocks via `subGroupByRPr` + `buildSingleRun` on each marker, and emits markers as bare elements. Always sub-groups by per-atom rPr — `group.rPr` is captured from the first atom and is intentionally suppressed for moved groups, so trusting it would bleed formatting across segments.
- **Bookmark integrity**: applies `enforceConsumerCompatibility` on the rebuilt body (mirrors inplace mode) to dedupe bookmark names/IDs and synthesize recovery starts/ends for orphans. Required because cross-context bookmark pairs (one half paragraph-internal, other body-level) appear unbalanced after rebuild.

## Tests

- Strengthen "Comment added on revised side" in `rebuild-auxiliary-merge.test.ts` to verify markers are present and that their immediate parent is one of `w:p` / `w:ins` / `w:del` / `w:moveFrom` / `w:moveTo` (DOM-based, not regex). Original "must NOT appear inside `<w:r>`" regex regression stays as a floor.
- New "Cross-paragraph comment span" — markers preserved across paragraph boundary with matching `w:id`.
- New "Sibling-style scaffold markers" — body-level bookmarks don't leak into reconstructed paragraphs.
- New "Inplace regression — comment span" — verifies inplace mode still succeeds without falling back to rebuild when revised has a spanning comment.
- Extend `synthetic-docx-fixture.ts` with `commentSpanParagraphs`, `bookmarkOnParagraph`, `siblingBookmarkBefore`.

Counts: docx-core 1094 pass (was 1091, +3 new), docx-mcp 638 pass, full lint clean.

## Out of scope (follow-ups will be filed)

- `moveFromRange*` / `moveToRange*` — collides with synthetic emission in `wrapWithMoveFrom`/`To`; needs scaffold-cleanup + dedup work.
- `permStart` / `permEnd` — same placement rule per ECMA-376; mechanical extension once helper exists, but lacks fixture coverage.
- `buildDocumentPreservingStructure` cross-paragraph comment-range stripping in inplace mode — separate code path; explicitly deferred by issue #106 itself.

## Peer review

Reviewed by **Codex CLI** (with repo access) and **Gemini CLI** in parallel before implementation; both reviews informed the final design — particularly Codex's catches on:
- ancestry-sensitive atomization (vs naive tag-only)
- gating to rebuild-only via options flag (`shouldStartNewParagraph` keeps `paragraphIndex === undefined` atoms in the current paragraph, so body-level markers would otherwise misattach)
- always sub-grouping by rPr in the marker-aware helper (overriding `group.rPr` because moved groups suppress rPr-splitting)
- DOM-based test assertions (the existing "comment added" scenario produces an `Inserted` range, so the marker's parent is `<w:ins>` — not raw `<w:p>`)

## Test plan

- [x] `npm run build`
- [x] `npm run lint:workspaces`
- [x] `npm run test:run` (1094/1095 across docx-core, +638 docx-mcp, +113 third workspace)
- [x] `npm run check:spec-coverage`
- [ ] Reviewer: confirm acceptance criteria from issue #106 are met
- [ ] Reviewer: verify no regressions in inplace-mode bookmark/comment tests

Fixes: #106
Ref: #101