### PR TITLE
fix(docx-core): preserve reply comments in rebuild mode (#108)

### DIFF
--- a/packages/docx-core/src/baselines/atomizer/pipeline.ts
+++ b/packages/docx-core/src/baselines/atomizer/pipeline.ts
@@ -785,19 +785,18 @@ export async function compareDocumentsAtomizer(
   // Step 12b: Merge auxiliary part definitions (footnotes, endnotes, comments).
   // Reconstruction may insert content (deleted in inplace, added in rebuild)
   // whose definitions are missing from the base archive.
-  const mergeResults = new Map<string, AuxiliaryMergeResult>();
   for (const descriptor of AUXILIARY_PARTS) {
-    const result = await mergeAuxiliaryPartDefinitions(
+    await mergeAuxiliaryPartDefinitions(
       mergeSourceArchive, resultArchive, newDocumentXml, descriptor
     );
-    if (result.mergedIds.size > 0) {
-      mergeResults.set(descriptor.label, result);
-    }
   }
-  if (mergeResults.has('comment')) {
-    await mergeCommentAncillaryParts(
-      mergeSourceArchive, resultArchive, mergeResults.get('comment')!
-    );
+  // Comment-specific post-pass: walk reply threads via commentsExtended.xml.
+  // Gated on root comment IDs in the *result* document (not on what the
+  // generic merge appended), so the pass runs even when the original already
+  // contains the root and revised only adds replies under it (issue #108).
+  const rootCommentIds = collectReferenceIds(newDocumentXml, 'w:commentReference');
+  if (rootCommentIds.size > 0) {
+    await mergeCommentAncillaryParts(mergeSourceArchive, resultArchive, rootCommentIds);
   }
 
   // Step 13: Save result and compute stats
@@ -1061,45 +1060,143 @@ async function ensureOpcMetadata(
 // =============================================================================
 
 /**
- * After merging comment definitions, copy related entries from
- * commentsExtended.xml and people.xml for author fidelity and reply threading.
+ * Walk the comment reply graph from each root referenced in the result
+ * document, merging reply <w:comment> entries, their commentsExtended.xml
+ * threading entries, and people.xml authors. Replies have no
+ * <w:commentReference> in document.xml — they're discoverable only via
+ * w15:paraIdParent in commentsExtended.xml. Without this expansion, rebuild
+ * mode silently drops reply threads (issue #108).
  */
 async function mergeCommentAncillaryParts(
   sourceArchive: DocxArchive,
   resultArchive: DocxArchive,
-  commentMergeResult: AuxiliaryMergeResult,
+  rootCommentIds: Set<string>,
 ): Promise<void> {
-  // Collect authors and paraIds from the merged comment entries
   const sourceCommentsXml = await sourceArchive.getFile('word/comments.xml');
   if (!sourceCommentsXml) return;
 
   const sourceDoc = parseXml(sourceCommentsXml);
-  const mergedAuthors = new Set<string>();
-  const mergedParaIds = new Set<string>();
 
-  const commentEls = sourceDoc.getElementsByTagName('w:comment');
-  for (let i = 0; i < commentEls.length; i++) {
-    const el = commentEls[i] as Element;
+  // Build full source comment maps. Canonical paraId is the first <w:p>
+  // child's w14:paraId, matching getCommentElParaId() in primitives/comments.ts.
+  const commentById = new Map<string, Element>();
+  const paraIdByCommentId = new Map<string, string>();
+  const commentIdByParaId = new Map<string, string>();
+  const authorByCommentId = new Map<string, string>();
+  const allCommentEls = sourceDoc.getElementsByTagName('w:comment');
+  for (let i = 0; i < allCommentEls.length; i++) {
+    const el = allCommentEls[i] as Element;
     const id = el.getAttribute('w:id');
-    if (!id || !commentMergeResult.mergedIds.has(id)) continue;
-
+    if (!id) continue;
+    commentById.set(id, el);
     const author = el.getAttribute('w:author');
-    if (author) mergedAuthors.add(author);
-
-    // Collect paraIds from <w:p> children inside the comment
-    const paras = el.getElementsByTagName('w:p');
-    for (let j = 0; j < paras.length; j++) {
-      const p = paras[j] as Element;
-      const paraId = p.getAttribute('w14:paraId');
-      if (paraId) mergedParaIds.add(paraId);
+    if (author) authorByCommentId.set(id, author);
+    const firstP = el.getElementsByTagName('w:p')[0] as Element | undefined;
+    const paraId = firstP?.getAttribute('w14:paraId');
+    if (paraId) {
+      paraIdByCommentId.set(id, paraId);
+      commentIdByParaId.set(paraId, id);
     }
   }
 
-  // Merge commentsExtended.xml entries matching merged paraIds
-  await mergeCommentsExtended(sourceArchive, resultArchive, mergedParaIds);
+  // Seed inclusion sets from the root IDs that appear in the result document.
+  const includedCommentIds = new Set<string>();
+  const includedParaIds = new Set<string>();
+  const includedAuthors = new Set<string>();
+  for (const id of rootCommentIds) {
+    if (!commentById.has(id)) continue;
+    includedCommentIds.add(id);
+    const pid = paraIdByCommentId.get(id);
+    if (pid) includedParaIds.add(pid);
+    const author = authorByCommentId.get(id);
+    if (author) includedAuthors.add(author);
+  }
 
-  // Merge people.xml entries matching merged authors
-  await mergePeople(sourceArchive, resultArchive, mergedAuthors);
+  // BFS over commentsExtended.xml's paraIdParent graph from each included
+  // root paraId. Skip entries that don't resolve to a real source comment so
+  // we never pull in dangling commentEx/people without a backing definition.
+  const sourceExtendedXml = await sourceArchive.getFile('word/commentsExtended.xml');
+  if (sourceExtendedXml) {
+    const exDoc = parseXml(sourceExtendedXml);
+    const exEls = exDoc.getElementsByTagName('w15:commentEx');
+    const childrenOf = new Map<string, string[]>();
+    for (let i = 0; i < exEls.length; i++) {
+      const ex = exEls[i] as Element;
+      const childPid = ex.getAttribute('w15:paraId');
+      const parentPid = ex.getAttribute('w15:paraIdParent');
+      if (!childPid || !parentPid) continue;
+      const arr = childrenOf.get(parentPid);
+      if (arr) arr.push(childPid);
+      else childrenOf.set(parentPid, [childPid]);
+    }
+
+    const queue: string[] = [...includedParaIds];
+    while (queue.length > 0) {
+      const pid = queue.shift()!;
+      const children = childrenOf.get(pid);
+      if (!children) continue;
+      for (const childPid of children) {
+        if (includedParaIds.has(childPid)) continue;
+        const childCommentId = commentIdByParaId.get(childPid);
+        if (!childCommentId) continue;
+        includedParaIds.add(childPid);
+        includedCommentIds.add(childCommentId);
+        const author = authorByCommentId.get(childCommentId);
+        if (author) includedAuthors.add(author);
+        queue.push(childPid);
+      }
+    }
+  }
+
+  // Append any reply <w:comment> definitions still missing from result.
+  // The generic merge already added roots when needed; we add the replies
+  // (and any roots not yet present in the result, defensively).
+  await mergeMissingCommentDefinitions(resultArchive, commentById, includedCommentIds);
+
+  // Merge commentsExtended and people for the expanded set.
+  await mergeCommentsExtended(sourceArchive, resultArchive, includedParaIds);
+  await mergePeople(sourceArchive, resultArchive, includedAuthors);
+}
+
+/**
+ * Append any source <w:comment> definitions in `includedCommentIds` that
+ * aren't already in result/word/comments.xml. Mirrors the append-with-importNode
+ * pattern used by mergeCommentsExtended below.
+ */
+async function mergeMissingCommentDefinitions(
+  resultArchive: DocxArchive,
+  commentById: Map<string, Element>,
+  includedCommentIds: Set<string>,
+): Promise<void> {
+  if (includedCommentIds.size === 0) return;
+  const resultXml = await resultArchive.getFile('word/comments.xml');
+  if (!resultXml) {
+    // If result has no comments.xml at all, the generic merge would have
+    // bootstrapped it for any included root. Nothing to do here.
+    return;
+  }
+  const resultDoc = parseXml(resultXml);
+  const rootEl = resultDoc.documentElement;
+
+  const existingIds = new Set<string>();
+  const existing = rootEl.getElementsByTagName('w:comment');
+  for (let i = 0; i < existing.length; i++) {
+    const id = (existing[i] as Element).getAttribute('w:id');
+    if (id) existingIds.add(id);
+  }
+
+  let appended = false;
+  for (const id of includedCommentIds) {
+    if (existingIds.has(id)) continue;
+    const sourceEl = commentById.get(id);
+    if (!sourceEl) continue;
+    rootEl.appendChild(resultDoc.importNode(sourceEl, true));
+    appended = true;
+  }
+
+  if (appended) {
+    resultArchive.setFile('word/comments.xml', serializer.serializeToString(resultDoc));
+  }
 }
 
 async function mergeCommentsExtended(

--- a/packages/docx-core/src/integration/rebuild-auxiliary-merge.test.ts
+++ b/packages/docx-core/src/integration/rebuild-auxiliary-merge.test.ts
@@ -221,6 +221,215 @@ describe('Rebuild Auxiliary Part Merging (issue #94)', () => {
     });
   });
 
+  // ---------------------------------------------------------------------------
+  // Issue #108: Reply comments dropped in rebuild mode
+  //
+  // Root comments have a <w:commentReference> in document.xml; replies do not.
+  // Replies thread through commentsExtended.xml via w15:paraIdParent. Before
+  // the fix, the comment-merge post-pass only walked root comments referenced
+  // in document.xml, so replies, their commentEx linkage, and the reply
+  // author's people.xml entry were silently dropped from rebuild output.
+  // ---------------------------------------------------------------------------
+  describe('Reply comment added to existing root (issue #108, primary case)', () => {
+    test('rebuild preserves reply when root already exists in original', async ({ given, when, then }: AllureBddContext) => {
+      let original: Buffer, revised: Buffer;
+      await given('original has root comment + ancillary parts; revised adds a reply', async () => {
+        original = await buildSyntheticDocx({
+          paragraphs: ['First paragraph', 'Commented paragraph', 'Third paragraph'],
+          commentOnParagraph: 1,
+          commentText: 'Root question',
+          commentAuthor: 'Alice',
+          commentAncillaryParts: true,
+        });
+        revised = await buildSyntheticDocx({
+          paragraphs: ['First paragraph', 'Commented paragraph', 'Third paragraph'],
+          commentOnParagraph: 1,
+          commentText: 'Root question',
+          commentAuthor: 'Alice',
+          commentAncillaryParts: true,
+          replyText: 'Reply text',
+          replyAuthor: 'Bob',
+        });
+      });
+
+      let result: Awaited<ReturnType<typeof compareDocuments>>;
+      await when('documents are compared in rebuild mode', async () => {
+        result = await compareDocuments(original, revised, {
+          engine: 'atomizer',
+          reconstructionMode: 'rebuild',
+        });
+      });
+
+      await then('reply comment, paraIdParent linkage, and reply author all survive', async () => {
+        expect(result.reconstructionModeUsed).toBe('rebuild');
+
+        const parts = await getResultParts(result.document);
+
+        // Both comments present
+        expect(parts.commentsXml).not.toBeNull();
+        expect(parts.commentsXml!).toContain('w:id="1"');
+        expect(parts.commentsXml!).toContain('w:id="2"');
+        expect(parts.commentsXml!).toContain('Root question');
+        expect(parts.commentsXml!).toContain('Reply text');
+        expect(parts.commentsXml!).toContain('w:author="Alice"');
+        expect(parts.commentsXml!).toContain('w:author="Bob"');
+
+        // Threading preserved in commentsExtended.xml
+        expect(parts.commentsExtendedXml).not.toBeNull();
+        expect(parts.commentsExtendedXml!).toContain('w15:paraId="00000001"');
+        expect(parts.commentsExtendedXml!).toContain('w15:paraId="00000002"');
+        expect(parts.commentsExtendedXml!).toContain('w15:paraIdParent="00000001"');
+
+        // Reply author present in people.xml
+        expect(parts.peopleXml).not.toBeNull();
+        expect(parts.peopleXml!).toContain('w15:author="Alice"');
+        expect(parts.peopleXml!).toContain('w15:author="Bob"');
+      });
+    });
+  });
+
+  describe('Reply comment added on revised side (bootstrap case)', () => {
+    test('rebuild bootstraps comments + ancillary parts including reply', async ({ given, when, then }: AllureBddContext) => {
+      let original: Buffer, revised: Buffer;
+      await given('original has no comments; revised adds root + reply with ancillary parts', async () => {
+        original = await buildSyntheticDocx({
+          paragraphs: ['First paragraph', 'Commented paragraph', 'Third paragraph'],
+        });
+        revised = await buildSyntheticDocx({
+          paragraphs: ['First paragraph', 'Commented paragraph', 'Third paragraph'],
+          commentOnParagraph: 1,
+          commentText: 'Root question',
+          commentAuthor: 'Alice',
+          commentAncillaryParts: true,
+          replyText: 'Reply text',
+          replyAuthor: 'Bob',
+        });
+      });
+
+      let result: Awaited<ReturnType<typeof compareDocuments>>;
+      await when('documents are compared in rebuild mode', async () => {
+        result = await compareDocuments(original, revised, {
+          engine: 'atomizer',
+          reconstructionMode: 'rebuild',
+        });
+      });
+
+      await then('both comments and the threaded commentEx + people entries are bootstrapped', async () => {
+        expect(result.reconstructionModeUsed).toBe('rebuild');
+
+        const parts = await getResultParts(result.document);
+
+        expect(parts.commentsXml).not.toBeNull();
+        expect(parts.commentsXml!).toContain('w:id="1"');
+        expect(parts.commentsXml!).toContain('w:id="2"');
+        expect(parts.commentsXml!).toContain('Reply text');
+
+        expect(parts.commentsExtendedXml).not.toBeNull();
+        expect(parts.commentsExtendedXml!).toContain('w15:paraId="00000002"');
+        expect(parts.commentsExtendedXml!).toContain('w15:paraIdParent="00000001"');
+
+        expect(parts.peopleXml).not.toBeNull();
+        expect(parts.peopleXml!).toContain('w15:author="Alice"');
+        expect(parts.peopleXml!).toContain('w15:author="Bob"');
+      });
+    });
+  });
+
+  describe('Deep reply chain preserved in rebuild (issue #108)', () => {
+    test('rebuild preserves a 3-level reply chain (root -> reply -> grandchild)', async ({ given, when, then }: AllureBddContext) => {
+      let original: Buffer, revised: Buffer;
+      await given('revised carries a 3-level threaded chain via inline archive mutation', async () => {
+        original = await buildSyntheticDocx({
+          paragraphs: ['First paragraph', 'Commented paragraph', 'Third paragraph'],
+        });
+
+        // Build a single-comment fixture, then splice in two more sibling
+        // <w:comment> entries plus their commentEx and people entries.
+        // We avoid extending SyntheticDocxOptions into a chain DSL — this
+        // depth is an issue-#108 BFS regression check, not a recurring need.
+        const baseRevised = await buildSyntheticDocx({
+          paragraphs: ['First paragraph', 'Commented paragraph', 'Third paragraph'],
+          commentOnParagraph: 1,
+          commentText: 'Root',
+          commentAuthor: 'Alice',
+          commentAncillaryParts: true,
+        });
+
+        // Re-pack the archive with extra comment / commentEx / person entries.
+        const JSZip = (await import('jszip')).default;
+        const zip = await JSZip.loadAsync(baseRevised);
+
+        const commentsXml = await zip.file('word/comments.xml')!.async('string');
+        const replyAndGrandchild =
+          `<w:comment w:id="2" w:author="Bob" w:date="2025-01-02T00:00:00Z">` +
+          `<w:p w14:paraId="00000002"><w:r><w:t>Reply</w:t></w:r></w:p>` +
+          `</w:comment>` +
+          `<w:comment w:id="3" w:author="Carol" w:date="2025-01-03T00:00:00Z">` +
+          `<w:p w14:paraId="00000003"><w:r><w:t>Grandchild</w:t></w:r></w:p>` +
+          `</w:comment>`;
+        zip.file(
+          'word/comments.xml',
+          commentsXml.replace('</w:comments>', `${replyAndGrandchild}</w:comments>`)
+        );
+
+        const exXml = await zip.file('word/commentsExtended.xml')!.async('string');
+        const exExtra =
+          `<w15:commentEx w15:paraId="00000002" w15:paraIdParent="00000001" w15:done="0"/>` +
+          `<w15:commentEx w15:paraId="00000003" w15:paraIdParent="00000002" w15:done="0"/>`;
+        zip.file(
+          'word/commentsExtended.xml',
+          exXml.replace('</w15:commentsEx>', `${exExtra}</w15:commentsEx>`)
+        );
+
+        const peopleXml = await zip.file('word/people.xml')!.async('string');
+        const peopleExtra =
+          `<w15:person w15:author="Bob"><w15:presenceInfo w15:providerId="None" w15:userId="bob@example.com"/></w15:person>` +
+          `<w15:person w15:author="Carol"><w15:presenceInfo w15:providerId="None" w15:userId="carol@example.com"/></w15:person>`;
+        zip.file(
+          'word/people.xml',
+          peopleXml.replace('</w15:people>', `${peopleExtra}</w15:people>`)
+        );
+
+        revised = (await zip.generateAsync({ type: 'nodebuffer' })) as Buffer;
+      });
+
+      let result: Awaited<ReturnType<typeof compareDocuments>>;
+      await when('documents are compared in rebuild mode', async () => {
+        result = await compareDocuments(original, revised, {
+          engine: 'atomizer',
+          reconstructionMode: 'rebuild',
+        });
+      });
+
+      await then('all three comments + both linkages survive the BFS expansion', async () => {
+        expect(result.reconstructionModeUsed).toBe('rebuild');
+
+        const parts = await getResultParts(result.document);
+
+        // All three comments present
+        expect(parts.commentsXml!).toContain('w:id="1"');
+        expect(parts.commentsXml!).toContain('w:id="2"');
+        expect(parts.commentsXml!).toContain('w:id="3"');
+        expect(parts.commentsXml!).toContain('Reply');
+        expect(parts.commentsXml!).toContain('Grandchild');
+
+        // Both linkages preserved
+        expect(parts.commentsExtendedXml!).toContain('w15:paraId="00000003"');
+        expect(parts.commentsExtendedXml!).toMatch(
+          /w15:paraId="00000002"\s+w15:paraIdParent="00000001"/
+        );
+        expect(parts.commentsExtendedXml!).toMatch(
+          /w15:paraId="00000003"\s+w15:paraIdParent="00000002"/
+        );
+
+        // All three authors in people.xml
+        expect(parts.peopleXml!).toContain('w15:author="Alice"');
+        expect(parts.peopleXml!).toContain('w15:author="Bob"');
+        expect(parts.peopleXml!).toContain('w15:author="Carol"');
+      });
+    });
+  });
+
   describe('Footnote present on both sides', () => {
     test('rebuild does not duplicate footnote definitions', async ({ given, when, then }: AllureBddContext) => {
       let original: Buffer, revised: Buffer;

--- a/packages/docx-core/src/integration/synthetic-docx-fixture.ts
+++ b/packages/docx-core/src/integration/synthetic-docx-fixture.ts
@@ -12,6 +12,16 @@ export interface SyntheticDocxOptions {
   // with matching paraId / author entries. Used to test ancillary-part bootstrap.
   commentAncillaryParts?: boolean;
   /**
+   * Threaded reply to the root comment (w:id="1"). Emits a second
+   * <w:comment w:id="2"> with paraId 00000002 and, when commentAncillaryParts
+   * is also set, a <w15:commentEx w15:paraIdParent="00000001"> linkage and a
+   * second <w15:person> for the reply author. Reply comments deliberately
+   * have NO <w:commentReference> in document.xml — that's the issue #108
+   * shape: replies are discoverable only via paraIdParent threading.
+   */
+  replyText?: string;
+  replyAuthor?: string;
+  /**
    * Cross-paragraph comment span. The comment opens at the start of
    * paragraphs[start] and closes at the end of paragraphs[end]. The
    * commentReference run is appended to paragraphs[end].
@@ -141,13 +151,22 @@ export async function buildSyntheticDocx(opts: SyntheticDocxOptions): Promise<Bu
   if (hasComment || hasCommentSpan) {
     const cText = opts.commentText ?? 'Test comment';
     const cAuthor = opts.commentAuthor ?? 'Author';
+    const hasReply = opts.replyText != null;
+    const replyAuthor = opts.replyAuthor ?? 'Replier';
+    const replyEntry = hasReply
+      ? `<w:comment w:id="2" w:author="${replyAuthor}" w:date="2025-01-02T00:00:00Z">` +
+        `<w:p w14:paraId="00000002"><w:r><w:t>${opts.replyText}</w:t></w:r></w:p>` +
+        `</w:comment>`
+      : '';
     const commentsXml =
       `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
       `<w:comments xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"` +
       ` xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">` +
       `<w:comment w:id="1" w:author="${cAuthor}" w:date="2025-01-01T00:00:00Z">` +
       `<w:p w14:paraId="00000001"><w:r><w:t>${cText}</w:t></w:r></w:p>` +
-      `</w:comment></w:comments>`;
+      `</w:comment>` +
+      replyEntry +
+      `</w:comments>`;
     zip.file('word/comments.xml', commentsXml);
     contentTypeParts.push(
       `<Override PartName="/word/comments.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.comments+xml"/>`
@@ -158,10 +177,14 @@ export async function buildSyntheticDocx(opts: SyntheticDocxOptions): Promise<Bu
     );
 
     if (opts.commentAncillaryParts) {
+      const replyExEntry = hasReply
+        ? `<w15:commentEx w15:paraId="00000002" w15:paraIdParent="00000001" w15:done="0"/>`
+        : '';
       const commentsExtendedXml =
         `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
         `<w15:commentsEx xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml">` +
         `<w15:commentEx w15:paraId="00000001" w15:done="0"/>` +
+        replyExEntry +
         `</w15:commentsEx>`;
       zip.file('word/commentsExtended.xml', commentsExtendedXml);
       contentTypeParts.push(
@@ -172,13 +195,20 @@ export async function buildSyntheticDocx(opts: SyntheticDocxOptions): Promise<Bu
         `<Relationship Id="rId${rIdCounter}" Type="http://schemas.microsoft.com/office/2011/relationships/commentsExtended" Target="commentsExtended.xml"/>`
       );
 
+      const replyPersonEntry = hasReply
+        ? `<w15:person w15:author="${replyAuthor}">` +
+          `<w15:presenceInfo w15:providerId="None" w15:userId="${replyAuthor}@example.com"/>` +
+          `</w15:person>`
+        : '';
       const peopleXml =
         `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
         `<w15:people xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml"` +
         ` xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
         `<w15:person w15:author="${cAuthor}">` +
         `<w15:presenceInfo w15:providerId="None" w15:userId="${cAuthor}@example.com"/>` +
-        `</w15:person></w15:people>`;
+        `</w15:person>` +
+        replyPersonEntry +
+        `</w15:people>`;
       zip.file('word/people.xml', peopleXml);
       contentTypeParts.push(
         `<Override PartName="/word/people.xml" ContentType="application/vnd.ms-word.people+xml"/>`


### PR DESCRIPTION
## Summary

Fix issue #108: in rebuild mode, threaded reply comments — and their `commentsExtended.xml` / `people.xml` entries — were silently dropped from output.

Reply `<w:comment>` entries do not have their own `<w:commentReference>` in `document.xml`; they thread through `commentsExtended.xml` via `w15:paraIdParent`. Two compounding bugs caused the drop:

1. The comment-merge post-pass walked only the directly-merged root comment IDs. Replies are flat siblings, never inspected.
2. The post-pass call site was gated on `mergeResults.has('comment')`, so it didn't even run when the original already contained the root and the revised side only added replies under it. Surfaced by peer review of the initial plan.

### Fix shape

- Drive the post-pass off `<w:commentReference>` IDs in the result `document.xml`, so it runs whenever any comment is anchored — regardless of what the generic auxiliary merge appended.
- Build full source-comment maps (`id ↔ paraId ↔ author`) once.
- BFS the `w15:paraIdParent` graph from each root paraId, only including children that resolve to a real source `<w:comment>` (so orphaned `commentEx` entries can't drag in dangling ancillary XML).
- Append any included `<w:comment>` definitions still missing from the result `comments.xml` (replies — and defensively, any roots).
- Call the existing `mergeCommentsExtended` / `mergePeople` with the expanded paraId / author sets.

The generic `mergeAuxiliaryPartDefinitions` helper stays generic — `paraIdParent` is a comment-only concern.

### Regression coverage (3 new tests in `rebuild-auxiliary-merge.test.ts`)

- **Reply added to existing root** — catches the gating bug specifically (without it, replies are dropped even when the BFS expansion is correct).
- **Bootstrap with reply** — root and reply both new on the revised side.
- **Deep reply chain (root → reply → grandchild)** — justifies the BFS by behavior, not by implementation detail.

Fixes: #108
Ref: #94, #101

## Test plan
- [x] Targeted regression tests are RED before fix, GREEN after (verified locally — 3 added)
- [x] Full `@usejunior/docx-core` suite — 1097 passed | 1 skipped
- [x] `npm run build` — clean
- [x] `npm run lint:workspaces` — clean (1 pre-existing warning in unrelated file)
- [x] `npm run test:run` — full suite green
- [x] `npm run check:spec-coverage` — all PASS
- [ ] Verify CI pipeline green