### PR TITLE
chore(release): bump workspace versions to 0.9.1

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-docx",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "AI-powered DOCX editing with tracked changes, redlining, and formatting preservation",
   "contextFileName": "GEMINI.md",
   "entrypoint": "GEMINI.md",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "safe-docx-suite",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "safe-docx-suite",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -2847,15 +2847,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/abort-controller": {
@@ -7906,7 +7897,7 @@
     },
     "packages/allure-test-factory": {
       "name": "@usejunior/allure-test-factory",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -7927,7 +7918,7 @@
     },
     "packages/docx-core": {
       "name": "@usejunior/docx-core",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "^0.9.9",
@@ -7963,11 +7954,11 @@
     },
     "packages/docx-mcp": {
       "name": "@usejunior/docx-mcp",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@usejunior/docx-core": "^0.9.0",
+        "@usejunior/docx-core": "^0.9.1",
         "zod": "^4.3.6"
       },
       "bin": {
@@ -7987,7 +7978,7 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@usejunior/google-docs-core": "^0.9.0"
+        "@usejunior/google-docs-core": "^0.9.1"
       },
       "peerDependenciesMeta": {
         "@usejunior/google-docs-core": {
@@ -7997,7 +7988,7 @@
     },
     "packages/google-docs-core": {
       "name": "@usejunior/google-docs-core",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "google-auth-library": "^9.0.0"
@@ -8013,10 +8004,10 @@
     },
     "packages/safe-docx": {
       "name": "@usejunior/safe-docx",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
-        "@usejunior/docx-mcp": "^0.9.0"
+        "@usejunior/docx-mcp": "^0.9.1"
       },
       "bin": {
         "safe-docx": "bin/safe-docx.js",
@@ -8028,10 +8019,10 @@
     },
     "packages/safe-docx-mcpb": {
       "name": "@usejunior/safedocx-mcpb",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
-        "@usejunior/safe-docx": "^0.9.0"
+        "@usejunior/safe-docx": "^0.9.1"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7959,6 +7959,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@usejunior/docx-core": "^0.9.1",
+        "@xmldom/xmldom": "^0.8.11",
         "zod": "^4.3.6"
       },
       "bin": {
@@ -7984,6 +7985,15 @@
         "@usejunior/google-docs-core": {
           "optional": true
         }
+      }
+    },
+    "packages/docx-mcp/node_modules/@xmldom/xmldom": {
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "packages/google-docs-core": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-docx-suite",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "description": "Monorepo for Safe DOCX packages",
   "repository": {

--- a/packages/allure-test-factory/package.json
+++ b/packages/allure-test-factory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/allure-test-factory",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Shared Allure test helpers for vitest — BDD context, OpenSpec auto-inference, Prism.js highlighting",
   "type": "module",
   "exports": {

--- a/packages/docx-core/package.json
+++ b/packages/docx-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/docx-core",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "OOXML (.docx) core library: primitives, comparison, and track changes",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/docx-mcp/package.json
+++ b/packages/docx-mcp/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@usejunior/docx-core": "^0.9.1",
     "@modelcontextprotocol/sdk": "^1.0.0",
+    "@xmldom/xmldom": "^0.8.11",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/packages/docx-mcp/package.json
+++ b/packages/docx-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/docx-mcp",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "MCP server for reading, editing, and comparing Word documents with tracked changes. For Claude, Gemini CLI, Cursor, and any MCP client. MIT licensed.",
   "type": "module",
   "main": "dist/index.js",
@@ -26,7 +26,7 @@
     "lint": "tsc -b --pretty false"
   },
   "dependencies": {
-    "@usejunior/docx-core": "^0.9.0",
+    "@usejunior/docx-core": "^0.9.1",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "zod": "^4.3.6"
   },
@@ -53,7 +53,7 @@
     "dist"
   ],
   "peerDependencies": {
-    "@usejunior/google-docs-core": "^0.9.0"
+    "@usejunior/google-docs-core": "^0.9.1"
   },
   "peerDependenciesMeta": {
     "@usejunior/google-docs-core": {

--- a/packages/google-docs-core/package.json
+++ b/packages/google-docs-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/google-docs-core",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Google Docs core library: read, write, and anchor management via Google Docs API",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/safe-docx-mcpb/manifest.json
+++ b/packages/safe-docx-mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "safe-docx",
   "display_name": "Safe Docx",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "AI-native Word document editing with stable paragraph anchors and deterministic DOCX operations.",
   "long_description": "Safe Docx lets Claude work directly with .docx files on your local filesystem. It provides stable paragraph IDs (jr_para_*) for precise editing while preserving formatting and structure.\n\nCore capabilities include reading/searching content, formatting-preserving edits and inserts, deterministic layout controls, tracked-changes output, comments, footnote tools, document comparison, and revision extraction.",
   "author": {

--- a/packages/safe-docx-mcpb/package.json
+++ b/packages/safe-docx-mcpb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/safedocx-mcpb",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "description": "Claude Desktop MCP Bundle (.mcpb) wrapper for @usejunior/safe-docx",
   "type": "module",
@@ -14,7 +14,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@usejunior/safe-docx": "^0.9.0"
+    "@usejunior/safe-docx": "^0.9.1"
   },
   "devDependencies": {
     "@vitest/runner": "^3.2.4",

--- a/packages/safe-docx/.smithery/shttp/manifest.json
+++ b/packages/safe-docx/.smithery/shttp/manifest.json
@@ -6,7 +6,7 @@
     "serverCard": {
       "serverInfo": {
         "name": "safe-docx",
-        "version": "0.9.0"
+        "version": "0.9.1"
       },
       "tools": [
         {

--- a/packages/safe-docx/package.json
+++ b/packages/safe-docx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/safe-docx",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Edit Word (.docx) documents with tracked changes, redlines, and formatting preservation. Built for AI coding agents. MIT licensed, 100% local processing.",
   "mcpName": "io.github.UseJunior/safe-docx",
   "type": "module",
@@ -25,7 +25,7 @@
     "safedocx": "./bin/safe-docx.js"
   },
   "dependencies": {
-    "@usejunior/docx-mcp": "^0.9.0"
+    "@usejunior/docx-mcp": "^0.9.1"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/safe-docx/server.json
+++ b/packages/safe-docx/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.UseJunior/safe-docx",
   "title": "Safe Docx",
   "description": "AI-native surgical editing of existing Word .docx files with formatting preservation",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "websiteUrl": "https://usejunior.com/developer-tools/safe-docx",
   "icons": [
     {
@@ -18,7 +18,7 @@
     {
       "registryType": "npm",
       "identifier": "@usejunior/safe-docx",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "transport": {
         "type": "stdio"
       },

--- a/site/package.json
+++ b/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/safe-docx-site",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "type": "module",
   "description": "Safe DOCX marketing and trust site (Eleventy)",


### PR DESCRIPTION
## Summary

Patch release covering bug fixes accumulated since v0.9.0.

### Included fixes
- `fix(docx-core)`: merge auxiliary parts in rebuild mode — #94 (PR #101)
- `fix(docx-core)`: emit paragraph-level markers outside `<w:r>` on rebuild — #109
- `fix(docx-core)`: preserve reply comments in rebuild mode — #108 (PR #112)
- `test(docx-mcp)`: harden vitest path allowlist against /tmp symlink topology — #105
- `ci`: SHA-pin all GitHub Actions, add dependency review and Dependabot
- `ci`: fix PR title check for acronyms and fork PRs — #88
- `chore(skills)`: sync docx-editing to 0.3.0 — #95

Generated via `scripts/bump_version.mjs`.

## Test plan
- [x] `node scripts/bump_version.mjs --check` reports all 12 files at 0.9.1
- [ ] CI green (build, lint, test, spec-coverage)
- [ ] After merge: tag `v0.9.1` on main → release workflow auto-publishes