### PR TITLE
feat(docx-mcp): render comments inline at paragraph level in read_file

### DIFF
--- a/packages/docx-core/src/primitives/document_view.ts
+++ b/packages/docx-core/src/primitives/document_view.ts
@@ -101,6 +101,15 @@ export type TableContext = {
   cell_para_count: number;  // Total paragraphs in this cell
 };
 
+export type DocumentViewComment = {
+  id: number;
+  author: string;
+  date: string | null;
+  initials: string;
+  text: string;
+  replies: DocumentViewComment[];
+};
+
 export type DocumentViewNode = {
   id: string; // _bk_*
   list_label: string;
@@ -121,6 +130,7 @@ export type DocumentViewNode = {
   header_formatting: HeaderFormatting | null;
   body_run_formatting: RunFormatting | null;
   table_context?: TableContext;
+  comments?: DocumentViewComment[];
 };
 
 function fingerprintKey(fp: FormattingFingerprint): string {
@@ -385,6 +395,36 @@ export function formatTableMarker(info: { id: string; totalRows: number; totalCo
   return `#TABLE ${info.id} | ${info.totalRows} rows × ${info.totalCols} cols`;
 }
 
+function escapeToonCommentField(value: string): string {
+  return value.replaceAll('|', '\\|');
+}
+
+function formatCommentDate(date: string | null): string {
+  return date ?? '-';
+}
+
+function collectToonCommentLines(
+  comment: DocumentViewComment,
+  paragraphId: string,
+  parentId?: number,
+): string[] {
+  const author = escapeToonCommentField(comment.author || '-');
+  const date = formatCommentDate(comment.date);
+  const text = escapeToonCommentField(comment.text);
+  const line = parentId == null
+    ? `#COMMENT ${paragraphId} c${comment.id} ${author} ${date} | ${text}`
+    : `#REPLY c${comment.id} -> c${parentId} ${author} ${date} | ${text}`;
+
+  return [
+    line,
+    ...comment.replies.flatMap((reply) => collectToonCommentLines(reply, paragraphId, comment.id)),
+  ];
+}
+
+export function formatToonCommentLines(node: Pick<DocumentViewNode, 'id' | 'comments'>): string[] {
+  return node.comments?.flatMap((comment) => collectToonCommentLines(comment, node.id)) ?? [];
+}
+
 export function renderToon(nodes: DocumentViewNode[], options: { compact?: boolean } = {}): string {
   const lines: string[] = ['#SCHEMA id | list_label | header | style | text'];
 
@@ -411,6 +451,7 @@ export function renderToon(nodes: DocumentViewNode[], options: { compact?: boole
     }
 
     lines.push(formatToonDataLine(n, options));
+    lines.push(...formatToonCommentLines(n));
   }
 
   // Close any open table at end

--- a/packages/docx-core/src/primitives/document_view.ts
+++ b/packages/docx-core/src/primitives/document_view.ts
@@ -396,7 +396,11 @@ export function formatTableMarker(info: { id: string; totalRows: number; totalCo
 }
 
 function escapeToonCommentField(value: string): string {
-  return value.replaceAll('|', '\\|');
+  return value
+    .replaceAll('\r\n', '\\n')
+    .replaceAll('\r', '\\r')
+    .replaceAll('\n', '\\n')
+    .replaceAll('|', '\\|');
 }
 
 function formatCommentDate(date: string | null): string {

--- a/packages/docx-core/src/primitives/document_view.ts
+++ b/packages/docx-core/src/primitives/document_view.ts
@@ -429,6 +429,37 @@ export function formatToonCommentLines(node: Pick<DocumentViewNode, 'id' | 'comm
   return node.comments?.flatMap((comment) => collectToonCommentLines(comment, node.id)) ?? [];
 }
 
+function collectToonCommentEndnoteLines(
+  comment: DocumentViewComment,
+  paragraphId: string,
+  parentId?: number,
+): string[] {
+  const author = escapeToonCommentField(comment.author || '-');
+  const date = formatCommentDate(comment.date);
+  const text = escapeToonCommentField(comment.text);
+  const line = parentId == null
+    ? `c${comment.id} @ ${paragraphId} ${author} ${date} | ${text}`
+    : `c${comment.id} -> c${parentId} ${author} ${date} | ${text}`;
+
+  return [
+    line,
+    ...comment.replies.flatMap((reply) => collectToonCommentEndnoteLines(reply, paragraphId, comment.id)),
+  ];
+}
+
+export function formatToonCommentEndnoteLines(node: Pick<DocumentViewNode, 'id' | 'comments'>): string[] {
+  return node.comments?.flatMap((comment) => collectToonCommentEndnoteLines(comment, node.id)) ?? [];
+}
+
+export function formatToonCommentsEndnotesBlock(
+  nodes: readonly Pick<DocumentViewNode, 'id' | 'comments'>[],
+): string[] {
+  const commentLines = nodes.flatMap((node) => formatToonCommentEndnoteLines(node));
+  return commentLines.length > 0
+    ? ['#COMMENTS', ...commentLines]
+    : [];
+}
+
 export function renderToon(nodes: DocumentViewNode[], options: { compact?: boolean } = {}): string {
   const lines: string[] = ['#SCHEMA id | list_label | header | style | text'];
 
@@ -462,6 +493,42 @@ export function renderToon(nodes: DocumentViewNode[], options: { compact?: boole
   if (currentTableIndex !== null) {
     lines.push('#END_TABLE');
   }
+
+  return lines.join('\n');
+}
+
+export function renderToonWithCommentEndnotes(
+  nodes: DocumentViewNode[],
+  options: { compact?: boolean } = {},
+): string {
+  const lines: string[] = ['#SCHEMA id | list_label | header | style | text'];
+  const tableInfo = collectTableMarkerInfo(nodes);
+
+  let currentTableIndex: number | null = null;
+
+  for (const n of nodes) {
+    const tc = n.table_context;
+    const nodeTableIndex = tc ? tc.table_index : null;
+
+    if (currentTableIndex !== null && nodeTableIndex !== currentTableIndex) {
+      lines.push('#END_TABLE');
+      currentTableIndex = null;
+    }
+
+    if (nodeTableIndex !== null && currentTableIndex === null) {
+      const info = tableInfo.get(nodeTableIndex);
+      if (info) lines.push(formatTableMarker(info));
+      currentTableIndex = nodeTableIndex;
+    }
+
+    lines.push(formatToonDataLine(n, options));
+  }
+
+  if (currentTableIndex !== null) {
+    lines.push('#END_TABLE');
+  }
+
+  lines.push(...formatToonCommentsEndnotesBlock(nodes));
 
   return lines.join('\n');
 }

--- a/packages/docx-core/test-primitives/document_view.test.ts
+++ b/packages/docx-core/test-primitives/document_view.test.ts
@@ -116,4 +116,68 @@ describe('document_view renderToon', () => {
       expect(toon).toContain('_bk_000000000114 |  |  | body | plain body paragraph');
     });
   });
+
+  test('emits comment and reply lines after the paragraph row', async ({ given, when, then }: AllureBddContext) => {
+    let toon: string;
+
+    await given('a node with a comment thread', async () => {});
+
+    await when('renderToon is called', async () => {
+      toon = renderToon([
+        makeNode({
+          id: '_bk_000000000115',
+          tagged_text: 'commented paragraph',
+          comments: [{
+            id: 12,
+            author: 'Alice',
+            date: '2026-04-30',
+            initials: 'AL',
+            text: 'Root note',
+            replies: [{
+              id: 13,
+              author: 'Bob',
+              date: '2026-05-01',
+              initials: 'BO',
+              text: 'Reply note',
+              replies: [],
+            }],
+          }],
+        }),
+      ]);
+    });
+
+    await then('the paragraph row is followed by #COMMENT and #REPLY lines', async () => {
+      const lines = toon.split('\n');
+      expect(lines).toContain('_bk_000000000115 |  |  | body | commented paragraph');
+      expect(lines).toContain('#COMMENT _bk_000000000115 c12 Alice 2026-04-30 | Root note');
+      expect(lines).toContain('#REPLY c13 -> c12 Bob 2026-05-01 | Reply note');
+    });
+  });
+
+  test('escapes literal pipes in rendered comment fields', async ({ given, when, then }: AllureBddContext) => {
+    let toon: string;
+
+    await given('a node with comment content containing pipe characters', async () => {});
+
+    await when('renderToon is called', async () => {
+      toon = renderToon([
+        makeNode({
+          id: '_bk_000000000116',
+          tagged_text: 'pipe paragraph',
+          comments: [{
+            id: 21,
+            author: 'A|B',
+            date: null,
+            initials: 'AB',
+            text: 'Clause | note',
+            replies: [],
+          }],
+        }),
+      ]);
+    });
+
+    await then('pipe characters are escaped on the comment line', async () => {
+      expect(toon).toContain('#COMMENT _bk_000000000116 c21 A\\|B - | Clause \\| note');
+    });
+  });
 });

--- a/packages/docx-mcp/docs/tool-reference.generated.md
+++ b/packages/docx-mcp/docs/tool-reference.generated.md
@@ -20,7 +20,7 @@ Read document content (DOCX or Google Doc). Output is token-limited (~14k tokens
 | `limit` | `number` | no | Max paragraphs to return. When omitted, output is token-limited to ~14k tokens with pagination. |
 | `node_ids` | `array<string>` | no |  |
 | `format` | `enum("toon", "json", "simple")` | no |  |
-| `comment_rendering` | `enum("none", "paragraph_notes")` | no | How to render comments in read_file output. Use "paragraph_notes" (default) to emit paragraph-local comments and replies, or "none" for the legacy output with no comment rendering. |
+| `comment_rendering` | `enum("none", "paragraph_notes", "endnotes")` | no | How to render comments in read_file output. Use "paragraph_notes" (default) to emit paragraph-local comments and replies, "endnotes" to collect threaded comments into a trailing #COMMENTS block in TOON output, or "none" for the legacy output with no comment rendering. |
 | `show_formatting` | `boolean` | no | When true (default), shows inline formatting tags (<b>, <i>, <u>, <highlighting>, <a>). When false, emits plain text with no inline tags. |
 
 ## `grep`

--- a/packages/docx-mcp/docs/tool-reference.generated.md
+++ b/packages/docx-mcp/docs/tool-reference.generated.md
@@ -20,6 +20,7 @@ Read document content (DOCX or Google Doc). Output is token-limited (~14k tokens
 | `limit` | `number` | no | Max paragraphs to return. When omitted, output is token-limited to ~14k tokens with pagination. |
 | `node_ids` | `array<string>` | no |  |
 | `format` | `enum("toon", "json", "simple")` | no |  |
+| `comment_rendering` | `enum("none", "paragraph_notes")` | no | How to render comments in read_file output. Use "paragraph_notes" (default) to emit paragraph-local comments and replies, or "none" for the legacy output with no comment rendering. |
 | `show_formatting` | `boolean` | no | When true (default), shows inline formatting tags (<b>, <i>, <u>, <highlighting>, <a>). When false, emits plain text with no inline tags. |
 
 ## `grep`

--- a/packages/docx-mcp/src/tool_catalog.ts
+++ b/packages/docx-mcp/src/tool_catalog.ts
@@ -40,6 +40,12 @@ export const SAFE_DOCX_TOOL_CATALOG = [
       limit: z.number().optional().describe('Max paragraphs to return. When omitted, output is token-limited to ~14k tokens with pagination.'),
       node_ids: z.array(z.string()).optional(),
       format: z.enum(['toon', 'json', 'simple']).optional(),
+      comment_rendering: z
+        .enum(['none', 'paragraph_notes'])
+        .optional()
+        .describe(
+          'How to render comments in read_file output. Use "paragraph_notes" (default) to emit paragraph-local comments and replies, or "none" for the legacy output with no comment rendering.',
+        ),
       show_formatting: z
         .boolean()
         .optional()

--- a/packages/docx-mcp/src/tool_catalog.ts
+++ b/packages/docx-mcp/src/tool_catalog.ts
@@ -41,10 +41,10 @@ export const SAFE_DOCX_TOOL_CATALOG = [
       node_ids: z.array(z.string()).optional(),
       format: z.enum(['toon', 'json', 'simple']).optional(),
       comment_rendering: z
-        .enum(['none', 'paragraph_notes'])
+        .enum(['none', 'paragraph_notes', 'endnotes'])
         .optional()
         .describe(
-          'How to render comments in read_file output. Use "paragraph_notes" (default) to emit paragraph-local comments and replies, or "none" for the legacy output with no comment rendering.',
+          'How to render comments in read_file output. Use "paragraph_notes" (default) to emit paragraph-local comments and replies, "endnotes" to collect threaded comments into a trailing #COMMENTS block in TOON output, or "none" for the legacy output with no comment rendering.',
         ),
       show_formatting: z
         .boolean()

--- a/packages/docx-mcp/src/tools/read_file.ts
+++ b/packages/docx-mcp/src/tools/read_file.ts
@@ -40,7 +40,11 @@ function collectFootnoteMarkerSuffix(
 }
 
 function escapeCommentSuffixText(text: string): string {
-  return text.replaceAll('|', '\\|');
+  return text
+    .replaceAll('\r\n', '\\n')
+    .replaceAll('\r', '\\r')
+    .replaceAll('\n', '\\n')
+    .replaceAll('|', '\\|');
 }
 
 function mapDocumentViewComment(comment: Comment): DocumentViewComment {

--- a/packages/docx-mcp/src/tools/read_file.ts
+++ b/packages/docx-mcp/src/tools/read_file.ts
@@ -1,7 +1,18 @@
 import { SessionManager } from '../session/manager.js';
 import { errorMessage } from "../error_utils.js";
 import { err, ok, type ToolResponse } from './types.js';
-import { OOXML, W, renderToon, formatToonDataLine, collectTableMarkerInfo, formatTableMarker, type DocumentViewNode } from '@usejunior/docx-core';
+import {
+  OOXML,
+  W,
+  renderToon,
+  formatToonDataLine,
+  formatToonCommentLines,
+  collectTableMarkerInfo,
+  formatTableMarker,
+  type Comment,
+  type DocumentViewComment,
+  type DocumentViewNode,
+} from '@usejunior/docx-core';
 import { READ_SIMPLE_PREVIEW_CHARS, previewText } from './preview.js';
 import { mergeSessionResolutionMetadata, resolveSessionForTool } from './session_resolution.js';
 import { estimateTokens, DEFAULT_CONTENT_TOKEN_BUDGET, buildPaginationMeta } from './pagination.js';
@@ -28,9 +39,75 @@ function collectFootnoteMarkerSuffix(
   return markers.join('');
 }
 
+function escapeCommentSuffixText(text: string): string {
+  return text.replaceAll('|', '\\|');
+}
+
+function mapDocumentViewComment(comment: Comment): DocumentViewComment {
+  return {
+    id: comment.id,
+    author: comment.author,
+    date: comment.date || null,
+    initials: comment.initials,
+    text: comment.text,
+    replies: comment.replies.map((reply) => mapDocumentViewComment(reply)),
+  };
+}
+
+function attachParagraphComments(
+  nodes: readonly DocumentViewNode[],
+  comments: readonly Comment[],
+): DocumentViewNode[] {
+  const commentsByParagraph = new Map<string, DocumentViewComment[]>();
+  for (const comment of comments) {
+    if (!comment.anchoredParagraphId) continue;
+    const rootComments = commentsByParagraph.get(comment.anchoredParagraphId) ?? [];
+    rootComments.push(mapDocumentViewComment(comment));
+    commentsByParagraph.set(comment.anchoredParagraphId, rootComments);
+  }
+
+  return nodes.map((node) => {
+    const nodeComments = commentsByParagraph.get(node.id);
+    return nodeComments && nodeComments.length > 0
+      ? { ...node, comments: nodeComments }
+      : node;
+  });
+}
+
+function collectSimpleCommentSuffixes(
+  comments: readonly DocumentViewComment[],
+  parentId?: number,
+): string[] {
+  const suffixes: string[] = [];
+  for (const comment of comments) {
+    const text = escapeCommentSuffixText(comment.text);
+    suffixes.push(parentId == null
+      ? `[c${comment.id}: ${text}]`
+      : `[c${comment.id}->c${parentId}: ${text}]`);
+    suffixes.push(...collectSimpleCommentSuffixes(comment.replies, comment.id));
+  }
+  return suffixes;
+}
+
+function formatSimpleTextLine(node: DocumentViewNode): string {
+  const preview = previewText(node.clean_text, READ_SIMPLE_PREVIEW_CHARS);
+  const commentSuffixes = node.comments ? collectSimpleCommentSuffixes(node.comments) : [];
+  return commentSuffixes.length > 0
+    ? `${preview} ${commentSuffixes.join(' ')}`
+    : preview;
+}
+
 export async function readFile(
   manager: SessionManager,
-  params: { file_path?: string; offset?: number; limit?: number; node_ids?: string[]; format?: string; show_formatting?: boolean },
+  params: {
+    file_path?: string;
+    offset?: number;
+    limit?: number;
+    node_ids?: string[];
+    format?: string;
+    show_formatting?: boolean;
+    comment_rendering?: string;
+  },
 ): Promise<ToolResponse> {
   try {
     const resolved = await resolveSessionForTool(manager, params, { toolName: 'read_file' });
@@ -40,6 +117,15 @@ export async function readFile(
     const format = (params.format ?? 'toon').toLowerCase();
     if (format !== 'toon' && format !== 'json' && format !== 'simple') {
       return err('INVALID_FORMAT', `Invalid format: ${params.format}`, "Use 'toon' (default), 'json', or 'simple'.");
+    }
+
+    const commentRendering = (params.comment_rendering ?? 'paragraph_notes').toLowerCase();
+    if (commentRendering !== 'none' && commentRendering !== 'paragraph_notes') {
+      return err(
+        'INVALID_COMMENT_RENDERING',
+        `Invalid comment_rendering: ${params.comment_rendering}`,
+        "Use 'paragraph_notes' (default) or 'none'.",
+      );
     }
 
     const showFormatting = params.show_formatting ?? true;
@@ -92,6 +178,14 @@ export async function readFile(
       }
     } catch {
       enriched = filtered;
+    }
+
+    if (commentRendering === 'paragraph_notes') {
+      try {
+        enriched = attachParagraphComments(enriched, await session.doc.getComments());
+      } catch {
+        // Preserve existing read_file behavior if comment parts are unavailable or malformed.
+      }
     }
 
     let content: string;
@@ -186,7 +280,9 @@ function renderToonWithBudget(
     }
 
     const dataLine = formatToonDataLine(node);
-    const candidate = accumulated + '\n' + dataLine;
+    const commentLines = formatToonCommentLines(node);
+    const nodeLines = [dataLine, ...commentLines].join('\n');
+    const candidate = accumulated + '\n' + nodeLines;
     if (count > 0 && estimateTokens(candidate) > budget) {
       // Close table before breaking
       if (currentTableIndex !== null) {
@@ -227,8 +323,7 @@ function renderSimpleWithTableMarkers(
       currentTableIndex = nodeTableIndex;
     }
 
-    const text = previewText(n.clean_text, READ_SIMPLE_PREVIEW_CHARS);
-    lines.push(`${n.id} | ${text}`);
+    lines.push(`${n.id} | ${formatSimpleTextLine(n)}`);
   }
 
   if (currentTableIndex !== null) {
@@ -268,8 +363,7 @@ function renderSimpleWithBudget(
       currentTableIndex = nodeTableIndex;
     }
 
-    const text = previewText(n.clean_text, READ_SIMPLE_PREVIEW_CHARS);
-    const dataLine = `${n.id} | ${text}`;
+    const dataLine = `${n.id} | ${formatSimpleTextLine(n)}`;
     const candidate = accumulated + '\n' + dataLine;
     if (count > 0 && estimateTokens(candidate) > budget) {
       if (currentTableIndex !== null) {

--- a/packages/docx-mcp/src/tools/read_file.ts
+++ b/packages/docx-mcp/src/tools/read_file.ts
@@ -5,8 +5,10 @@ import {
   OOXML,
   W,
   renderToon,
+  renderToonWithCommentEndnotes,
   formatToonDataLine,
   formatToonCommentLines,
+  formatToonCommentsEndnotesBlock,
   collectTableMarkerInfo,
   formatTableMarker,
   type Comment,
@@ -124,11 +126,11 @@ export async function readFile(
     }
 
     const commentRendering = (params.comment_rendering ?? 'paragraph_notes').toLowerCase();
-    if (commentRendering !== 'none' && commentRendering !== 'paragraph_notes') {
+    if (commentRendering !== 'none' && commentRendering !== 'paragraph_notes' && commentRendering !== 'endnotes') {
       return err(
         'INVALID_COMMENT_RENDERING',
         `Invalid comment_rendering: ${params.comment_rendering}`,
-        "Use 'paragraph_notes' (default) or 'none'.",
+        "Use 'paragraph_notes' (default), 'endnotes', or 'none'.",
       );
     }
 
@@ -184,7 +186,7 @@ export async function readFile(
       enriched = filtered;
     }
 
-    if (commentRendering === 'paragraph_notes') {
+    if (commentRendering !== 'none') {
       try {
         enriched = attachParagraphComments(enriched, await session.doc.getComments());
       } catch {
@@ -202,13 +204,15 @@ export async function readFile(
       } else if (format === 'simple') {
         content = renderSimpleWithTableMarkers(enriched);
       } else {
-        content = renderToon(enriched);
+        content = commentRendering === 'endnotes'
+          ? renderToonWithCommentEndnotes(enriched)
+          : renderToon(enriched);
       }
       paragraphsReturned = enriched.length;
     } else {
       // One-pass token-budget accumulation
       const budget = DEFAULT_CONTENT_TOKEN_BUDGET;
-      const result = renderWithBudget(enriched, format, budget);
+      const result = renderWithBudget(enriched, format, budget, commentRendering);
       content = result.content;
       paragraphsReturned = result.count;
     }
@@ -237,6 +241,7 @@ function renderWithBudget(
   enriched: readonly DocumentViewNode[],
   format: string,
   budget: number,
+  commentRendering: string,
 ): BudgetResult {
   if (format === 'json') {
     return renderJsonWithBudget(enriched, budget);
@@ -244,17 +249,19 @@ function renderWithBudget(
   if (format === 'simple') {
     return renderSimpleWithBudget(enriched, budget);
   }
-  return renderToonWithBudget(enriched, budget);
+  return renderToonWithBudget(enriched, budget, commentRendering);
 }
 
 function renderToonWithBudget(
   enriched: readonly DocumentViewNode[],
   budget: number,
+  commentRendering: string,
 ): BudgetResult {
   const headerLine = '#SCHEMA id | list_label | header | style | text';
   let accumulated = headerLine;
   let count = 0;
   let currentTableIndex: number | null = null;
+  const includedNodes: DocumentViewNode[] = [];
 
   // Pre-scan: collect table marker info for #TABLE lines
   const tableInfo = collectTableMarkerInfo(enriched);
@@ -284,9 +291,21 @@ function renderToonWithBudget(
     }
 
     const dataLine = formatToonDataLine(node);
-    const commentLines = formatToonCommentLines(node);
+    const commentLines = commentRendering === 'paragraph_notes'
+      ? formatToonCommentLines(node)
+      : [];
     const nodeLines = [dataLine, ...commentLines].join('\n');
-    const candidate = accumulated + '\n' + nodeLines;
+    const candidateBase = accumulated + '\n' + nodeLines;
+    let candidate = candidateBase;
+    if (commentRendering === 'endnotes') {
+      if (nodeTableIndex !== null) {
+        candidate += '\n#END_TABLE';
+      }
+      const endnotesBlock = formatToonCommentsEndnotesBlock([...includedNodes, node]);
+      if (endnotesBlock.length > 0) {
+        candidate += '\n' + endnotesBlock.join('\n');
+      }
+    }
     if (count > 0 && estimateTokens(candidate) > budget) {
       // Close table before breaking
       if (currentTableIndex !== null) {
@@ -294,13 +313,21 @@ function renderToonWithBudget(
       }
       break;
     }
-    accumulated = candidate;
+    accumulated = candidateBase;
+    includedNodes.push(node);
     count++;
   }
 
   // Close any open table at end of loop
   if (currentTableIndex !== null) {
     accumulated += '\n#END_TABLE';
+  }
+
+  if (commentRendering === 'endnotes') {
+    const endnotesBlock = formatToonCommentsEndnotesBlock(includedNodes);
+    if (endnotesBlock.length > 0) {
+      accumulated += '\n' + endnotesBlock.join('\n');
+    }
   }
 
   return { content: accumulated, count };

--- a/packages/docx-mcp/src/tools/read_file_comments.test.ts
+++ b/packages/docx-mcp/src/tools/read_file_comments.test.ts
@@ -17,6 +17,11 @@ function findParagraphLine(lines: string[], paragraphId: string): string {
   return line;
 }
 
+function commentBlockLines(lines: string[]): string[] {
+  const start = lines.indexOf('#COMMENTS');
+  return start === -1 ? [] : lines.slice(start);
+}
+
 describe('read_file comment rendering', () => {
   registerCleanup();
 
@@ -233,6 +238,271 @@ describe('read_file comment rendering', () => {
     });
   });
 
+  test('endnotes mode emits one trailing #COMMENTS block after #END_TABLE with no inline comment lines', async ({ given, when, then }: AllureBddContext) => {
+    const xml =
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+      `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
+      `<w:body>` +
+      `<w:tbl>` +
+      `<w:tr><w:tc><w:p><w:r><w:t>Table cell text.</w:t></w:r></w:p></w:tc></w:tr>` +
+      `</w:tbl>` +
+      `</w:body></w:document>`;
+    const opened = await given('a document with a one-cell table', async () => openSession([], { xml }));
+
+    const rendered = await when('a table-cell comment is read in endnotes mode', async () => {
+      const result = await addComment(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.firstParaId,
+        author: 'Alice',
+        text: 'Cell comment.',
+      });
+      assertSuccess(result, 'add_comment');
+      const read = await readFile(opened.mgr, {
+        file_path: opened.inputPath,
+        comment_rendering: 'endnotes',
+      });
+      assertSuccess(read, 'read_file');
+      return { commentId: Number(result.comment_id), read };
+    });
+
+    await then('the TOON view closes the table before a single trailing comments block', async () => {
+      const lines = toonLines(rendered.read.content);
+      const endTableIndex = lines.indexOf('#END_TABLE');
+      const commentsIndex = lines.indexOf('#COMMENTS');
+      expect(lines.filter((line) => line === '#COMMENTS')).toHaveLength(1);
+      expect(lines.some((line) => line.startsWith('#COMMENT '))).toBe(false);
+      expect(lines.some((line) => line.startsWith('#REPLY '))).toBe(false);
+      expect(endTableIndex).toBeGreaterThan(-1);
+      expect(commentsIndex).toBe(endTableIndex + 1);
+      expect(lines[commentsIndex + 1]).toContain(`c${rendered.commentId} @ ${opened.firstParaId} Alice `);
+      expect(lines[commentsIndex + 1]).toContain('| Cell comment.');
+    });
+  });
+
+  test('endnotes mode renders a single root comment as one block entry', async ({ given, when, then }: AllureBddContext) => {
+    const opened = await given('a document with one paragraph', async () => openSession(['Alpha paragraph.']));
+
+    const rendered = await when('a root comment is added and read in endnotes mode', async () => {
+      const result = await addComment(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.firstParaId,
+        author: 'Alice',
+        text: 'Please review this clause.',
+      });
+      assertSuccess(result, 'add_comment');
+      const read = await readFile(opened.mgr, {
+        file_path: opened.inputPath,
+        comment_rendering: 'endnotes',
+      });
+      assertSuccess(read, 'read_file');
+      return { commentId: Number(result.comment_id), read };
+    });
+
+    await then('the comments block contains exactly one root entry after the paragraph data', async () => {
+      const lines = toonLines(rendered.read.content);
+      const commentsBlock = commentBlockLines(lines);
+      const paragraphIndex = lines.indexOf(findParagraphLine(lines, opened.firstParaId));
+      expect(commentsBlock).toHaveLength(2);
+      expect(commentsBlock[0]).toBe('#COMMENTS');
+      expect(commentsBlock[1]).toContain(`c${rendered.commentId} @ ${opened.firstParaId} Alice `);
+      expect(commentsBlock[1]).toContain('| Please review this clause.');
+      expect(lines.indexOf('#COMMENTS')).toBe(paragraphIndex + 1);
+      expect(Number(rendered.read.paragraphs_returned)).toBe(1);
+    });
+  });
+
+  test('endnotes mode renders parent comments followed by ordered replies', async ({ given, when, then }: AllureBddContext) => {
+    const opened = await given('a document with one paragraph', async () => openSession(['Discussion paragraph.']));
+
+    const rendered = await when('a nested comment thread is added and read in endnotes mode', async () => {
+      const root = await addComment(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.firstParaId,
+        author: 'Alice',
+        text: 'Root note.',
+      });
+      assertSuccess(root, 'add_comment(root)');
+      const reply = await addComment(opened.mgr, {
+        file_path: opened.inputPath,
+        parent_comment_id: Number(root.comment_id),
+        author: 'Bob',
+        text: 'First reply.',
+      });
+      assertSuccess(reply, 'add_comment(reply)');
+      const nestedReply = await addComment(opened.mgr, {
+        file_path: opened.inputPath,
+        parent_comment_id: Number(reply.comment_id),
+        author: 'Cara',
+        text: 'Nested reply.',
+      });
+      assertSuccess(nestedReply, 'add_comment(nested reply)');
+
+      const read = await readFile(opened.mgr, {
+        file_path: opened.inputPath,
+        comment_rendering: 'endnotes',
+      });
+      assertSuccess(read, 'read_file');
+      return {
+        rootId: Number(root.comment_id),
+        replyId: Number(reply.comment_id),
+        nestedReplyId: Number(nestedReply.comment_id),
+        read,
+      };
+    });
+
+    await then('the block emits the parent entry first and each reply directly after its parent chain', async () => {
+      const commentsBlock = commentBlockLines(toonLines(rendered.read.content));
+      const rootIndex = commentsBlock.findIndex((line) => line.startsWith(`c${rendered.rootId} @ ${opened.firstParaId} Alice `));
+      const replyIndex = commentsBlock.findIndex((line) => line.startsWith(`c${rendered.replyId} -> c${rendered.rootId} Bob `));
+      const nestedReplyIndex = commentsBlock.findIndex((line) => line.startsWith(`c${rendered.nestedReplyId} -> c${rendered.replyId} Cara `));
+      expect(rootIndex).toBeGreaterThan(0);
+      expect(replyIndex).toBe(rootIndex + 1);
+      expect(nestedReplyIndex).toBe(replyIndex + 1);
+    });
+  });
+
+  test('endnotes mode lists comments in document order by anchor paragraph', async ({ given, when, then }: AllureBddContext) => {
+    const opened = await given('a document with three paragraphs', async () => openSession([
+      'First paragraph.',
+      'Second paragraph.',
+      'Third paragraph.',
+    ]));
+
+    const rendered = await when('comments are added out of paragraph order and read in endnotes mode', async () => {
+      const second = await addComment(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.paraIds[1],
+        author: 'Bob',
+        text: 'Second paragraph comment.',
+      });
+      assertSuccess(second, 'add_comment(second)');
+      const first = await addComment(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.paraIds[0],
+        author: 'Alice',
+        text: 'First paragraph comment.',
+      });
+      assertSuccess(first, 'add_comment(first)');
+      const third = await addComment(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.paraIds[2],
+        author: 'Cara',
+        text: 'Third paragraph comment.',
+      });
+      assertSuccess(third, 'add_comment(third)');
+      const read = await readFile(opened.mgr, {
+        file_path: opened.inputPath,
+        comment_rendering: 'endnotes',
+      });
+      assertSuccess(read, 'read_file');
+      return { read };
+    });
+
+    await then('the comments block follows paragraph order instead of comment creation order', async () => {
+      const commentsBlock = commentBlockLines(toonLines(rendered.read.content));
+      expect(commentsBlock[1]).toContain(`@ ${opened.paraIds[0]} `);
+      expect(commentsBlock[2]).toContain(`@ ${opened.paraIds[1]} `);
+      expect(commentsBlock[3]).toContain(`@ ${opened.paraIds[2]} `);
+    });
+  });
+
+  test('paginated endnotes reads include only in-window anchored comments', async ({ given, when, then }: AllureBddContext) => {
+    const opened = await given('a document with three paragraphs', async () => openSession([
+      'First paragraph.',
+      'Second paragraph.',
+      'Third paragraph.',
+    ]));
+
+    const rendered = await when('comments are added to multiple paragraphs and a one-paragraph endnotes window is read', async () => {
+      const first = await addComment(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.paraIds[0],
+        author: 'Alice',
+        text: 'First window comment.',
+      });
+      assertSuccess(first, 'add_comment(first)');
+      const second = await addComment(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.paraIds[1],
+        author: 'Bob',
+        text: 'Second window comment.',
+      });
+      assertSuccess(second, 'add_comment(second)');
+      const read = await readFile(opened.mgr, {
+        file_path: opened.inputPath,
+        offset: 2,
+        limit: 1,
+        comment_rendering: 'endnotes',
+      });
+      assertSuccess(read, 'read_file');
+      return read;
+    });
+
+    await then('the trailing comments block lists only the comment anchored to the returned paragraph', async () => {
+      const content = String(rendered.content);
+      const commentsBlock = commentBlockLines(toonLines(content));
+      expect(content).toContain('Second paragraph');
+      expect(commentsBlock).toHaveLength(2);
+      expect(commentsBlock[1]).toContain(`@ ${opened.paraIds[1]} `);
+      expect(commentsBlock[1]).toContain('Second window comment.');
+      expect(content).not.toContain('First paragraph.');
+      expect(content).not.toContain('First window comment.');
+      expect(Number(rendered.paragraphs_returned)).toBe(1);
+    });
+  });
+
+  test('endnotes mode and footnotes render independently in the same view', async ({ given, when, then }: AllureBddContext) => {
+    const opened = await given('a document with one paragraph', async () => openSession(['Clause text.']));
+
+    const rendered = await when('a footnote and comment are added to the same paragraph and read in endnotes mode', async () => {
+      const note = await addFootnote(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.firstParaId,
+        text: 'Footnote body',
+      });
+      assertSuccess(note, 'add_footnote');
+      const comment = await addComment(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.firstParaId,
+        author: 'Alice',
+        text: 'Comment body.',
+      });
+      assertSuccess(comment, 'add_comment');
+      const read = await readFile(opened.mgr, {
+        file_path: opened.inputPath,
+        comment_rendering: 'endnotes',
+      });
+      assertSuccess(read, 'read_file');
+      return read;
+    });
+
+    await then('the paragraph keeps the footnote marker and the trailing comments block contains the comment', async () => {
+      const lines = toonLines(rendered.content);
+      const commentsBlock = commentBlockLines(lines);
+      expect(findParagraphLine(lines, opened.firstParaId)).toContain('[^1]');
+      expect(commentsBlock).toHaveLength(2);
+      expect(commentsBlock[1]).toContain(`@ ${opened.firstParaId} `);
+      expect(commentsBlock[1]).toContain('Comment body.');
+    });
+  });
+
+  test('endnotes mode skips the #COMMENTS block when no in-window comments exist', async ({ given, when, then }: AllureBddContext) => {
+    const opened = await given('a document with one paragraph and no comments', async () => openSession(['Plain paragraph.']));
+
+    const rendered = await when('read_file is called in endnotes mode without comments', async () => {
+      const read = await readFile(opened.mgr, {
+        file_path: opened.inputPath,
+        comment_rendering: 'endnotes',
+      });
+      assertSuccess(read, 'read_file');
+      return read;
+    });
+
+    await then('the output contains no stray comments header', async () => {
+      expect(String(rendered.content)).not.toContain('#COMMENTS');
+    });
+  });
+
   test('comment_rendering none preserves the previous output exactly', async ({ given, when, then }: AllureBddContext) => {
     const opened = await given('a document with one paragraph', async () => openSession(['Regression paragraph.']));
 
@@ -317,6 +587,53 @@ describe('read_file comment rendering', () => {
       expect(node?.comments?.[0]?.replies[0]?.id).toBe(rendered.replyId);
       expect(String(rendered.simpleRead.content)).toContain(`[c${rendered.rootId}: Root json note.]`);
       expect(String(rendered.simpleRead.content)).toContain(`[c${rendered.replyId}->c${rendered.rootId}: Reply json note.]`);
+    });
+  });
+
+  test('endnotes mode keeps json node comments and paragraph-local simple suffixes', async ({ given, when, then }: AllureBddContext) => {
+    const opened = await given('a document with one paragraph', async () => openSession(['Simple endnotes paragraph.']));
+
+    const rendered = await when('a comment thread is added and json and simple reads use endnotes mode', async () => {
+      const root = await addComment(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.firstParaId,
+        author: 'Alice',
+        text: 'Root endnote note.',
+      });
+      assertSuccess(root, 'add_comment(root)');
+      const reply = await addComment(opened.mgr, {
+        file_path: opened.inputPath,
+        parent_comment_id: Number(root.comment_id),
+        author: 'Bob',
+        text: 'Reply endnote note.',
+      });
+      assertSuccess(reply, 'add_comment(reply)');
+      const jsonRead = await readFile(opened.mgr, {
+        file_path: opened.inputPath,
+        format: 'json',
+        comment_rendering: 'endnotes',
+      });
+      assertSuccess(jsonRead, 'read_file(json)');
+      const simpleRead = await readFile(opened.mgr, {
+        file_path: opened.inputPath,
+        format: 'simple',
+        comment_rendering: 'endnotes',
+      });
+      assertSuccess(simpleRead, 'read_file(simple)');
+      return { rootId: Number(root.comment_id), replyId: Number(reply.comment_id), jsonRead, simpleRead };
+    });
+
+    await then('json still includes node-attached comments and simple format keeps paragraph-style suffixes for parity', async () => {
+      const nodes = JSON.parse(String(rendered.jsonRead.content)) as Array<{
+        id: string;
+        comments?: Array<{ id: number; text: string; replies: Array<{ id: number; text: string }> }>;
+      }>;
+      const node = nodes.find((candidate) => candidate.id === opened.firstParaId);
+      expect(node?.comments).toHaveLength(1);
+      expect(node?.comments?.[0]?.id).toBe(rendered.rootId);
+      expect(node?.comments?.[0]?.replies[0]?.id).toBe(rendered.replyId);
+      expect(String(rendered.simpleRead.content)).toContain(`[c${rendered.rootId}: Root endnote note.]`);
+      expect(String(rendered.simpleRead.content)).toContain(`[c${rendered.replyId}->c${rendered.rootId}: Reply endnote note.]`);
     });
   });
 

--- a/packages/docx-mcp/src/tools/read_file_comments.test.ts
+++ b/packages/docx-mcp/src/tools/read_file_comments.test.ts
@@ -1,0 +1,344 @@
+import { describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { assertSuccess, openSession, registerCleanup } from '../testing/session-test-utils.js';
+import { addComment } from './add_comment.js';
+import { addFootnote } from './add_footnote.js';
+import { readFile } from './read_file.js';
+
+const test = testAllure.epic('Document Reading');
+
+function toonLines(content: unknown): string[] {
+  return String(content).split('\n');
+}
+
+function findParagraphLine(lines: string[], paragraphId: string): string {
+  const line = lines.find((candidate) => candidate.startsWith(`${paragraphId} | `));
+  if (!line) throw new Error(`Paragraph line not found for ${paragraphId}`);
+  return line;
+}
+
+describe('read_file comment rendering', () => {
+  registerCleanup();
+
+  test('single root comment renders one #COMMENT line', async ({ given, when, then }: AllureBddContext) => {
+    const opened = await given('a document with one paragraph', async () => openSession(['Alpha paragraph.']));
+
+    const created = await when('a root comment is added and read_file is called', async () => {
+      const result = await addComment(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.firstParaId,
+        author: 'Alice',
+        text: 'Please review this clause.',
+      });
+      assertSuccess(result, 'add_comment');
+      const read = await readFile(opened.mgr, { file_path: opened.inputPath });
+      assertSuccess(read, 'read_file');
+      return { commentId: Number(result.comment_id), read };
+    });
+
+    await then('the paragraph row is followed by one #COMMENT line and no replies', async () => {
+      const lines = toonLines(created.read.content);
+      const paragraphIndex = lines.indexOf(findParagraphLine(lines, opened.firstParaId));
+      const commentLine = lines.find((line) => line.startsWith(`#COMMENT ${opened.firstParaId} c${created.commentId} Alice `));
+      expect(commentLine).toContain('| Please review this clause.');
+      expect(lines.filter((line) => line.startsWith('#COMMENT '))).toHaveLength(1);
+      expect(lines.filter((line) => line.startsWith('#REPLY '))).toHaveLength(0);
+      expect(lines[paragraphIndex + 1]).toBe(commentLine);
+      expect(Number(created.read.paragraphs_returned)).toBe(1);
+    });
+  });
+
+  test('comment with replies renders ordered #REPLY lines', async ({ given, when, then }: AllureBddContext) => {
+    const opened = await given('a document with one paragraph', async () => openSession(['Discussion paragraph.']));
+
+    const created = await when('a nested comment thread is added', async () => {
+      const root = await addComment(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.firstParaId,
+        author: 'Alice',
+        text: 'Root note.',
+      });
+      assertSuccess(root, 'add_comment(root)');
+      const reply = await addComment(opened.mgr, {
+        file_path: opened.inputPath,
+        parent_comment_id: Number(root.comment_id),
+        author: 'Bob',
+        text: 'First reply.',
+      });
+      assertSuccess(reply, 'add_comment(reply)');
+      const nestedReply = await addComment(opened.mgr, {
+        file_path: opened.inputPath,
+        parent_comment_id: Number(reply.comment_id),
+        author: 'Cara',
+        text: 'Nested reply.',
+      });
+      assertSuccess(nestedReply, 'add_comment(nested reply)');
+
+      const read = await readFile(opened.mgr, { file_path: opened.inputPath });
+      assertSuccess(read, 'read_file');
+      return {
+        rootId: Number(root.comment_id),
+        replyId: Number(reply.comment_id),
+        nestedReplyId: Number(nestedReply.comment_id),
+        read,
+      };
+    });
+
+    await then('the thread is emitted in parent-child order', async () => {
+      const lines = toonLines(created.read.content);
+      const rootIndex = lines.findIndex((line) => line.startsWith(`#COMMENT ${opened.firstParaId} c${created.rootId} Alice `));
+      const replyIndex = lines.findIndex((line) => line.startsWith(`#REPLY c${created.replyId} -> c${created.rootId} Bob `));
+      const nestedReplyIndex = lines.findIndex((line) => line.startsWith(`#REPLY c${created.nestedReplyId} -> c${created.replyId} Cara `));
+      expect(rootIndex).toBeGreaterThan(-1);
+      expect(replyIndex).toBeGreaterThan(rootIndex);
+      expect(nestedReplyIndex).toBeGreaterThan(replyIndex);
+    });
+  });
+
+  test('multiple root comments on one paragraph all render', async ({ given, when, then }: AllureBddContext) => {
+    const opened = await given('a document with one paragraph', async () => openSession(['Shared paragraph.']));
+
+    const read = await when('two root comments are added to the same paragraph', async () => {
+      const first = await addComment(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.firstParaId,
+        author: 'Alice',
+        text: 'First root.',
+      });
+      assertSuccess(first, 'add_comment(first)');
+      const second = await addComment(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.firstParaId,
+        author: 'Bob',
+        text: 'Second root.',
+      });
+      assertSuccess(second, 'add_comment(second)');
+      const result = await readFile(opened.mgr, { file_path: opened.inputPath });
+      assertSuccess(result, 'read_file');
+      return result;
+    });
+
+    await then('both root comments appear under the paragraph', async () => {
+      const commentLines = toonLines(read.content).filter((line) => line.startsWith('#COMMENT '));
+      expect(commentLines).toHaveLength(2);
+      expect(commentLines[0]).toContain('First root.');
+      expect(commentLines[1]).toContain('Second root.');
+    });
+  });
+
+  test('comment on a table-cell paragraph renders inside the #TABLE block', async ({ given, when, then }: AllureBddContext) => {
+    const xml =
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+      `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
+      `<w:body>` +
+      `<w:tbl>` +
+      `<w:tr><w:tc><w:p><w:r><w:t>Table cell text.</w:t></w:r></w:p></w:tc></w:tr>` +
+      `</w:tbl>` +
+      `</w:body></w:document>`;
+    const opened = await given('a document with a one-cell table', async () => openSession([], { xml }));
+
+    const read = await when('a comment is added to the table cell paragraph', async () => {
+      const result = await addComment(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.firstParaId,
+        author: 'Alice',
+        text: 'Cell comment.',
+      });
+      assertSuccess(result, 'add_comment');
+      const rendered = await readFile(opened.mgr, { file_path: opened.inputPath });
+      assertSuccess(rendered, 'read_file');
+      return rendered;
+    });
+
+    await then('the comment line stays inside the table block after the cell paragraph', async () => {
+      const lines = toonLines(read.content);
+      const tableIndex = lines.indexOf('#TABLE _tbl_0 | 1 rows × 1 cols');
+      const paragraphIndex = lines.indexOf(findParagraphLine(lines, opened.firstParaId));
+      const commentIndex = lines.findIndex((line) => line.startsWith(`#COMMENT ${opened.firstParaId} `));
+      const endIndex = lines.indexOf('#END_TABLE');
+      expect(tableIndex).toBeGreaterThan(-1);
+      expect(paragraphIndex).toBeGreaterThan(tableIndex);
+      expect(commentIndex).toBe(paragraphIndex + 1);
+      expect(endIndex).toBeGreaterThan(commentIndex);
+    });
+  });
+
+  test('paragraph with footnote and comment shows both with no interaction', async ({ given, when, then }: AllureBddContext) => {
+    const opened = await given('a document with one paragraph', async () => openSession(['Clause text.']));
+
+    const read = await when('a footnote and comment are added to the same paragraph', async () => {
+      const note = await addFootnote(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.firstParaId,
+        text: 'Footnote body',
+      });
+      assertSuccess(note, 'add_footnote');
+      const comment = await addComment(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.firstParaId,
+        author: 'Alice',
+        text: 'Comment body.',
+      });
+      assertSuccess(comment, 'add_comment');
+      const result = await readFile(opened.mgr, { file_path: opened.inputPath });
+      assertSuccess(result, 'read_file');
+      return result;
+    });
+
+    await then('the paragraph retains the footnote marker and gains a comment line', async () => {
+      const lines = toonLines(read.content);
+      expect(findParagraphLine(lines, opened.firstParaId)).toContain('[^1]');
+      expect(lines.some((line) => line.startsWith(`#COMMENT ${opened.firstParaId} `) && line.includes('Comment body.'))).toBe(true);
+    });
+  });
+
+  test('paginated reads render only comments for in-window paragraphs', async ({ given, when, then }: AllureBddContext) => {
+    const opened = await given('a document with three paragraphs', async () => openSession([
+      'First paragraph.',
+      'Second paragraph.',
+      'Third paragraph.',
+    ]));
+
+    const read = await when('comments are added to two paragraphs and a windowed read is requested', async () => {
+      const first = await addComment(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.paraIds[0],
+        author: 'Alice',
+        text: 'First window comment.',
+      });
+      assertSuccess(first, 'add_comment(first)');
+      const second = await addComment(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.paraIds[1],
+        author: 'Bob',
+        text: 'Second window comment.',
+      });
+      assertSuccess(second, 'add_comment(second)');
+      const result = await readFile(opened.mgr, {
+        file_path: opened.inputPath,
+        offset: 2,
+        limit: 1,
+      });
+      assertSuccess(result, 'read_file');
+      return result;
+    });
+
+    await then('only the in-window paragraph and its comments are rendered', async () => {
+      const content = String(read.content);
+      expect(content).toContain('Second paragraph');
+      expect(content).toContain('Second window comment.');
+      expect(content).not.toContain('First paragraph.');
+      expect(content).not.toContain('First window comment.');
+      expect(Number(read.paragraphs_returned)).toBe(1);
+    });
+  });
+
+  test('comment_rendering none preserves the previous output exactly', async ({ given, when, then }: AllureBddContext) => {
+    const opened = await given('a document with one paragraph', async () => openSession(['Regression paragraph.']));
+
+    const read = await when('a comment is added but comment rendering is disabled', async () => {
+      const result = await addComment(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.firstParaId,
+        author: 'Alice',
+        text: 'Hidden comment.',
+      });
+      assertSuccess(result, 'add_comment');
+      const rendered = await readFile(opened.mgr, {
+        file_path: opened.inputPath,
+        comment_rendering: 'none',
+      });
+      assertSuccess(rendered, 'read_file');
+      return rendered;
+    });
+
+    await then('the TOON output matches the pre-comment baseline exactly', async () => {
+      expect(String(read.content)).toBe(opened.content);
+    });
+  });
+
+  test('paragraph_notes is the default comment rendering mode', async ({ given, when, then }: AllureBddContext) => {
+    const opened = await given('a document with one paragraph', async () => openSession(['Default behavior paragraph.']));
+
+    const read = await when('a comment is added and read_file is called without the option', async () => {
+      const result = await addComment(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.firstParaId,
+        author: 'Alice',
+        text: 'Default comment.',
+      });
+      assertSuccess(result, 'add_comment');
+      const rendered = await readFile(opened.mgr, { file_path: opened.inputPath });
+      assertSuccess(rendered, 'read_file');
+      return rendered;
+    });
+
+    await then('the comment line is present by default', async () => {
+      expect(String(read.content)).toContain('Default comment.');
+      expect(String(read.content)).toContain(`#COMMENT ${opened.firstParaId} `);
+    });
+  });
+
+  test('json mode populates comments and simple mode appends comment suffixes', async ({ given, when, then }: AllureBddContext) => {
+    const opened = await given('a document with one paragraph', async () => openSession(['JSON paragraph.']));
+
+    const rendered = await when('a comment thread is added and json and simple reads are requested', async () => {
+      const root = await addComment(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.firstParaId,
+        author: 'Alice',
+        text: 'Root json note.',
+      });
+      assertSuccess(root, 'add_comment(root)');
+      const reply = await addComment(opened.mgr, {
+        file_path: opened.inputPath,
+        parent_comment_id: Number(root.comment_id),
+        author: 'Bob',
+        text: 'Reply json note.',
+      });
+      assertSuccess(reply, 'add_comment(reply)');
+      const jsonRead = await readFile(opened.mgr, { file_path: opened.inputPath, format: 'json' });
+      assertSuccess(jsonRead, 'read_file(json)');
+      const simpleRead = await readFile(opened.mgr, { file_path: opened.inputPath, format: 'simple' });
+      assertSuccess(simpleRead, 'read_file(simple)');
+      return { rootId: Number(root.comment_id), replyId: Number(reply.comment_id), jsonRead, simpleRead };
+    });
+
+    await then('json nodes include comments and simple output includes flattened comment suffixes', async () => {
+      const nodes = JSON.parse(String(rendered.jsonRead.content)) as Array<{
+        id: string;
+        comments?: Array<{ id: number; text: string; replies: Array<{ id: number; text: string }> }>;
+      }>;
+      const node = nodes.find((candidate) => candidate.id === opened.firstParaId);
+      expect(node?.comments).toHaveLength(1);
+      expect(node?.comments?.[0]?.id).toBe(rendered.rootId);
+      expect(node?.comments?.[0]?.text).toBe('Root json note.');
+      expect(node?.comments?.[0]?.replies).toHaveLength(1);
+      expect(node?.comments?.[0]?.replies[0]?.id).toBe(rendered.replyId);
+      expect(String(rendered.simpleRead.content)).toContain(`[c${rendered.rootId}: Root json note.]`);
+      expect(String(rendered.simpleRead.content)).toContain(`[c${rendered.replyId}->c${rendered.rootId}: Reply json note.]`);
+    });
+  });
+
+  test('comment text containing literal pipes is escaped on TOON emit', async ({ given, when, then }: AllureBddContext) => {
+    const opened = await given('a document with one paragraph', async () => openSession(['Pipe paragraph.']));
+
+    const read = await when('a comment with pipe characters is added', async () => {
+      const result = await addComment(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.firstParaId,
+        author: 'A|B',
+        text: 'Clause | note.',
+      });
+      assertSuccess(result, 'add_comment');
+      const rendered = await readFile(opened.mgr, { file_path: opened.inputPath });
+      assertSuccess(rendered, 'read_file');
+      return rendered;
+    });
+
+    await then('the rendered comment line escapes literal pipes', async () => {
+      expect(String(read.content)).toContain('A\\|B');
+      expect(String(read.content)).toContain('Clause \\| note.');
+    });
+  });
+});

--- a/packages/docx-mcp/src/tools/read_file_comments.test.ts
+++ b/packages/docx-mcp/src/tools/read_file_comments.test.ts
@@ -341,4 +341,58 @@ describe('read_file comment rendering', () => {
       expect(String(read.content)).toContain('Clause \\| note.');
     });
   });
+
+  test('multiline comment text is escaped to a single TOON line', async ({ given, when, then }: AllureBddContext) => {
+    const opened = await given('a document with one paragraph', async () => openSession(['Multiline paragraph.']));
+
+    const read = await when('a comment containing newlines is added', async () => {
+      const result = await addComment(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.firstParaId,
+        author: 'Alice',
+        text: 'Line one.\nLine two.\r\nLine three.\rLine four.',
+      });
+      assertSuccess(result, 'add_comment');
+      const rendered = await readFile(opened.mgr, { file_path: opened.inputPath });
+      assertSuccess(rendered, 'read_file');
+      return rendered;
+    });
+
+    await then('the comment renders as exactly one #COMMENT line with literal escapes', async () => {
+      const lines = toonLines(read.content);
+      const commentLines = lines.filter((line) => line.startsWith('#COMMENT '));
+      expect(commentLines).toHaveLength(1);
+      expect(commentLines[0]).toContain('Line one.');
+      expect(commentLines[0]).toContain('Line two.');
+      expect(commentLines[0]).toContain('Line three.');
+      expect(commentLines[0]).toContain('Line four.');
+      expect(commentLines[0]).toMatch(/\\[nr]/);
+      expect(commentLines[0]).not.toContain('\n');
+      expect(commentLines[0]).not.toContain('\r');
+    });
+  });
+
+  test('multiline comment text is escaped to a single line in simple format', async ({ given, when, then }: AllureBddContext) => {
+    const opened = await given('a document with one paragraph', async () => openSession(['Multiline simple paragraph.']));
+
+    const read = await when('a comment containing newlines is added and read in simple format', async () => {
+      const result = await addComment(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.firstParaId,
+        author: 'Alice',
+        text: 'Alpha\nBeta\r\nGamma',
+      });
+      assertSuccess(result, 'add_comment');
+      const rendered = await readFile(opened.mgr, { file_path: opened.inputPath, format: 'simple' });
+      assertSuccess(rendered, 'read_file');
+      return rendered;
+    });
+
+    await then('the simple-format suffix renders on a single line with literal escapes', async () => {
+      const lines = String(read.content).split('\n');
+      const paragraphLines = lines.filter((line) => line.includes(opened.firstParaId));
+      expect(paragraphLines).toHaveLength(1);
+      expect(paragraphLines[0]).toContain('Alpha\\nBeta\\nGamma');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Adds `comment_rendering: \"none\" | \"paragraph_notes\"` to the MCP `read_file` tool, default `paragraph_notes`. In the new mode, root comments and threaded replies anchored to each paragraph are emitted as `#COMMENT`/`#REPLY` lines immediately after that paragraph's TOON data line. JSON format populates a new optional `DocumentViewNode.comments?` field. \"Simple\" format gets `[c<id>: <text>]` suffix lines parallel to the footnote suffix.

This is a renderer-only change. The `getComments()` primitive and the `get_comments` MCP tool are unchanged — this PR consumes the data they already produce.

## Implementation

- New type `DocumentViewComment` and optional field `DocumentViewNode.comments?` in `packages/docx-core/src/primitives/document_view.ts`.
- TOON helpers `escapeToonCommentField` and `collectToonCommentLines` in the same file; `\\|` escape applied to author and text fields so the conformance harness's naive `split('|')` parsing remains correct.
- `read_file` (`packages/docx-mcp/src/tools/read_file.ts`) accepts the new option, attaches matching comments to each in-window node by `anchoredParagraphId`, and dispatches per format.
- Pagination: out-of-window comments are silently dropped. Comment lines count toward the token budget but not the node-count limit.
- Table-cell paragraphs with comments render the comment lines INSIDE the `#TABLE` block.
- `tool_catalog.ts` schema entry for `read_file` lists the new option; `tool-reference.generated.md` regenerated.

## Verification

- [x] \`npm run build --workspaces\` clean
- [x] \`npm run lint --workspace=@usejunior/docx-core\` and \`-mcp\` pass
- [x] \`npm run test:run\` — docx-core: 1099 pass + 1 skip; docx-mcp: 648 pass (12 new tests added across both packages)
- [x] \`npm run check:spec-coverage\` passes
- [x] \`npm run check:tool-docs\` — generated doc included in commit, no drift

### Peer review (mandatory gate per [codex-implement skill](https://github.com/anthropics/claude-code/blob/main/SKILL.md))

- **Gemini:** *No concerns. The implementation is clean, follows all repository conventions, and correctly handles the architectural requirements for token-budgeted pagination and format-specific comment rendering. The PR is ready for merge.*
- **Codex:** caught a real CI miss — `tool_catalog.ts` changed but `tool-reference.generated.md` wasn't regenerated. Fixed in this PR (`docs:generate:tools` rerun, regenerated file committed).

### New tests (cover issue acceptance criteria)

In `packages/docx-mcp/src/tools/read_file_comments.test.ts`:
- single root comment renders one #COMMENT line
- comment with replies renders ordered #REPLY lines
- multiple root comments on one paragraph all render
- comment on a table-cell paragraph renders inside the #TABLE block
- paragraph with footnote and comment shows both with no interaction
- paginated reads render only comments for in-window paragraphs
- comment_rendering none preserves the previous output exactly
- paragraph_notes is the default
- json mode populates comments and simple mode appends comment suffixes
- comment text containing literal pipes is escaped on TOON emit

Plus 2 core renderer tests in `packages/docx-core/test-primitives/document_view.test.ts`.

## Out of scope (follow-ups already filed)

- #129 — Expose comment range metadata in \`getComments()\` (prereq for inline range rendering)
- #130 — Render comment ranges inline (\`inline_markers\` mode; depends on #127 + #129)
- #131 — Endnotes-style rendering (\`endnotes\` mode; depends on #127)

## Closes

- #127