### PR TITLE
feat(docx-core): expose comment range metadata in getComments()

### DIFF
--- a/packages/docx-core/src/primitives/comments.ts
+++ b/packages/docx-core/src/primitives/comments.ts
@@ -10,6 +10,7 @@ import { parseXml, serializeXml } from './xml.js';
 import { DocxZip } from './zip.js';
 import { getParagraphRuns, getParagraphText } from './text.js';
 import { getParagraphBookmarkId } from './bookmarks.js';
+import { childElements, getLeafText, isW } from './dom-helpers.js';
 
 // ── Relationship types ──────────────────────────────────────────────────
 
@@ -510,7 +511,51 @@ export type Comment = {
   text: string;
   paragraphId: string | null;
   anchoredParagraphId: string | null;
+  endParagraphId?: string | null;
+  startRunIndex?: number;
+  startCharOffset?: number;
+  endRunIndex?: number;
+  endCharOffset?: number;
   replies: Comment[];
+};
+
+type CommentRangePoint = {
+  paragraphId: string | null;
+  runIndex?: number;
+  charOffset?: number;
+};
+
+type RunBoundary = {
+  visibleLength: number;
+};
+
+// A marker is recorded with one of two shapes:
+// - `inside`: marker was seen INSIDE a `<w:r>`; runIndex is exact, charOffset is the
+//   visible-text offset within that run.
+// - `between`: marker was seen at paragraph level (between/around `<w:r>` elements);
+//   resolution depends on the boundary direction and the surrounding runs.
+type MarkerCharPosition = {
+  id: number;
+  inside?: { runIndex: number; charOffset: number };
+  between?: { afterRunIndex: number };
+};
+
+enum FieldState {
+  OUTSIDE_FIELD = 0,
+  IN_FIELD_CODE = 1,
+  IN_FIELD_RESULT = 2,
+}
+
+type ParagraphMarkerWalkState = {
+  charPos: number;
+  fieldState: FieldState;
+  // `allRuns` records every `<w:r>` in document order, including zero-length ones.
+  // This is the source of truth for `runIndex` per the issue contract.
+  allRuns: RunBoundary[];
+  // Number of `<w:r>` entered so far during the walk; equals allRuns.length once a run exits.
+  currentRunIndex: number;
+  startMarkers: MarkerCharPosition[];
+  endMarkers: MarkerCharPosition[];
 };
 
 /**
@@ -527,6 +572,7 @@ export async function getComments(zip: DocxZip, documentXml: Document): Promise<
   const commentsDoc = parseXml(commentsText);
   const commentEls = commentsDoc.getElementsByTagNameNS(OOXML.W_NS, W.comment);
   if (commentEls.length === 0) return [];
+  const rangeMetadata = resolveCommentRangeMetadata(documentXml);
 
   // Build a map of commentId → { paraId, Comment }
   const byParaId = new Map<string, Comment>();
@@ -545,13 +591,16 @@ export async function getComments(zip: DocxZip, documentXml: Document): Promise<
     // Extract text from <w:t> elements, skipping annotationRef runs
     const text = extractCommentText(el);
 
-    // Get paraId from first <w:p> child
+    // Get paraId from first <w:p> child (namespace-aware to handle non-`w` prefixes)
     const paras = el.getElementsByTagNameNS(OOXML.W_NS, W.p);
     let paragraphId: string | null = null;
     if (paras.length > 0) {
       const p = paras.item(0) as Element;
       paragraphId = p.getAttributeNS(OOXML.W14_NS, 'paraId') ?? p.getAttribute('w14:paraId') ?? null;
     }
+
+    const startPoint = rangeMetadata.startById.get(id);
+    const endPoint = rangeMetadata.endById.get(id);
 
     const comment: Comment = {
       id,
@@ -560,34 +609,17 @@ export async function getComments(zip: DocxZip, documentXml: Document): Promise<
       initials,
       text,
       paragraphId,
-      anchoredParagraphId: null,
+      anchoredParagraphId: startPoint?.paragraphId ?? null,
+      endParagraphId: endPoint?.paragraphId ?? startPoint?.paragraphId ?? null,
+      startRunIndex: startPoint?.runIndex,
+      startCharOffset: startPoint?.charOffset,
+      endRunIndex: endPoint?.runIndex,
+      endCharOffset: endPoint?.charOffset,
       replies: [],
     };
 
     byId.set(id, comment);
     if (paragraphId) byParaId.set(paragraphId, comment);
-  }
-
-  // Resolve anchoredParagraphId by scanning documentXml for commentRangeStart elements
-  const rangeStarts = documentXml.getElementsByTagNameNS(OOXML.W_NS, W.commentRangeStart);
-  for (let i = 0; i < rangeStarts.length; i++) {
-    const rs = rangeStarts.item(i) as Element;
-    const cidStr = rs.getAttributeNS(OOXML.W_NS, 'id') ?? rs.getAttribute('w:id');
-    if (!cidStr) continue;
-    const cid = parseInt(cidStr, 10);
-    const comment = byId.get(cid);
-    if (!comment) continue;
-
-    // Walk up to find enclosing <w:p>
-    let parent = rs.parentNode;
-    while (parent && parent.nodeType === 1) {
-      const pel = parent as Element;
-      if (pel.localName === W.p && pel.namespaceURI === OOXML.W_NS) {
-        comment.anchoredParagraphId = getParagraphBookmarkId(pel);
-        break;
-      }
-      parent = parent.parentNode;
-    }
   }
 
   // Build thread tree from commentsExtended.xml
@@ -632,6 +664,188 @@ export async function getComments(zip: DocxZip, documentXml: Document): Promise<
   }
 
   return roots;
+}
+
+function resolveCommentRangeMetadata(documentXml: Document): {
+  startById: Map<number, CommentRangePoint>;
+  endById: Map<number, CommentRangePoint>;
+} {
+  const startById = new Map<number, CommentRangePoint>();
+  const endById = new Map<number, CommentRangePoint>();
+  const root = documentXml.documentElement;
+  if (!root) return { startById, endById };
+
+  const paragraphList = root.getElementsByTagNameNS(OOXML.W_NS, W.p);
+  for (let i = 0; i < paragraphList.length; i++) {
+    resolveCommentRangeMetadataInParagraph(paragraphList.item(i) as Element, startById, endById);
+  }
+
+  return { startById, endById };
+}
+
+function resolveCommentRangeMetadataInParagraph(
+  paragraph: Element,
+  startById: Map<number, CommentRangePoint>,
+  endById: Map<number, CommentRangePoint>,
+): void {
+  const walkState: ParagraphMarkerWalkState = {
+    charPos: 0,
+    fieldState: FieldState.OUTSIDE_FIELD,
+    allRuns: [],
+    currentRunIndex: 0,
+    startMarkers: [],
+    endMarkers: [],
+  };
+  walkParagraphForCommentMarkers(paragraph, paragraph, walkState);
+
+  const paragraphId = getParagraphBookmarkId(paragraph);
+  for (const marker of walkState.startMarkers) {
+    if (startById.has(marker.id)) continue;
+    startById.set(marker.id, {
+      paragraphId,
+      ...resolveMarkerToRunBoundary(walkState.allRuns, marker, 'start'),
+    });
+  }
+
+  for (const marker of walkState.endMarkers) {
+    if (endById.has(marker.id)) continue;
+    endById.set(marker.id, {
+      paragraphId,
+      ...resolveMarkerToRunBoundary(walkState.allRuns, marker, 'end'),
+    });
+  }
+}
+
+function walkParagraphForCommentMarkers(
+  rootParagraph: Element,
+  node: Element,
+  state: ParagraphMarkerWalkState,
+): void {
+  for (const child of childElements(node)) {
+    if (child !== rootParagraph && isW(child, W.p)) continue;
+
+    if (isW(child, W.commentRangeStart)) {
+      recordParagraphLevelMarker(child, state.startMarkers, state);
+      continue;
+    }
+    if (isW(child, W.commentRangeEnd)) {
+      recordParagraphLevelMarker(child, state.endMarkers, state);
+      continue;
+    }
+    if (isW(child, W.r)) {
+      walkRunForCommentMarkers(child, state);
+      continue;
+    }
+
+    walkParagraphForCommentMarkers(rootParagraph, child, state);
+  }
+}
+
+function walkRunForCommentMarkers(run: Element, state: ParagraphMarkerWalkState): void {
+  const runIndex = state.currentRunIndex;
+  state.currentRunIndex += 1;
+  const runVisibleStart = state.charPos;
+
+  for (const child of childElements(run)) {
+    if (isW(child, W.commentRangeStart)) {
+      recordInRunMarker(child, state.startMarkers, runIndex, state.charPos - runVisibleStart);
+      continue;
+    }
+    if (isW(child, W.commentRangeEnd)) {
+      recordInRunMarker(child, state.endMarkers, runIndex, state.charPos - runVisibleStart);
+      continue;
+    }
+    if (!child.namespaceURI || child.namespaceURI !== OOXML.W_NS) continue;
+
+    if (child.localName === W.fldChar) {
+      const type = getWordAttribute(child, 'fldCharType') ?? '';
+      if (type === 'begin') state.fieldState = FieldState.IN_FIELD_CODE;
+      else if (type === 'separate') state.fieldState = FieldState.IN_FIELD_RESULT;
+      else if (type === 'end') state.fieldState = FieldState.OUTSIDE_FIELD;
+      continue;
+    }
+
+    if (state.fieldState === FieldState.IN_FIELD_CODE) continue;
+
+    if (child.localName === W.t) {
+      state.charPos += (getLeafText(child) ?? '').length;
+      continue;
+    }
+    if (child.localName === W.tab || child.localName === W.br) {
+      state.charPos += 1;
+    }
+  }
+
+  state.allRuns.push({ visibleLength: state.charPos - runVisibleStart });
+}
+
+function recordInRunMarker(
+  markerEl: Element,
+  bucket: MarkerCharPosition[],
+  runIndex: number,
+  charOffset: number,
+): void {
+  const id = getCommentMarkerId(markerEl);
+  if (id == null) return;
+  bucket.push({ id, inside: { runIndex, charOffset } });
+}
+
+function recordParagraphLevelMarker(
+  markerEl: Element,
+  bucket: MarkerCharPosition[],
+  state: ParagraphMarkerWalkState,
+): void {
+  const id = getCommentMarkerId(markerEl);
+  if (id == null) return;
+  bucket.push({ id, between: { afterRunIndex: state.currentRunIndex - 1 } });
+}
+
+function getCommentMarkerId(markerEl: Element): number | null {
+  const idStr = markerEl.getAttributeNS(OOXML.W_NS, 'id') ?? markerEl.getAttribute('w:id');
+  if (!idStr) return null;
+  const id = parseInt(idStr, 10);
+  return Number.isNaN(id) ? null : id;
+}
+
+function getWordAttribute(el: Element, localName: string): string | null {
+  return el.getAttributeNS(OOXML.W_NS, localName) ?? el.getAttribute(`w:${localName}`) ?? el.getAttribute(localName);
+}
+
+function resolveMarkerToRunBoundary(
+  allRuns: RunBoundary[],
+  marker: MarkerCharPosition,
+  boundary: 'start' | 'end',
+): Pick<CommentRangePoint, 'runIndex' | 'charOffset'> {
+  // Marker seen INSIDE a run already carries the exact runIndex + charOffset.
+  if (marker.inside) {
+    return { runIndex: marker.inside.runIndex, charOffset: marker.inside.charOffset };
+  }
+  if (!marker.between) return {};
+  if (allRuns.length === 0) return {};
+
+  const { afterRunIndex } = marker.between;
+  const lastIndex = allRuns.length - 1;
+
+  if (boundary === 'start') {
+    // Marker sits between run `afterRunIndex` and run `afterRunIndex + 1`.
+    // For a `start` marker, the range opens at offset 0 of the next run if it exists.
+    const nextIdx = afterRunIndex + 1;
+    if (nextIdx <= lastIndex) {
+      return { runIndex: nextIdx, charOffset: 0 };
+    }
+    // Marker is past the last run — clamp to end of last run.
+    return { runIndex: lastIndex, charOffset: allRuns[lastIndex]!.visibleLength };
+  }
+
+  // boundary === 'end': range closes at the end of the previous run if one exists.
+  if (afterRunIndex < 0) {
+    // Marker is before the first run — empty range starting at run 0.
+    return { runIndex: 0, charOffset: 0 };
+  }
+  if (afterRunIndex <= lastIndex) {
+    return { runIndex: afterRunIndex, charOffset: allRuns[afterRunIndex]!.visibleLength };
+  }
+  return { runIndex: lastIndex, charOffset: allRuns[lastIndex]!.visibleLength };
 }
 
 /**

--- a/packages/docx-core/test-primitives/comments.test.ts
+++ b/packages/docx-core/test-primitives/comments.test.ts
@@ -8,7 +8,6 @@ import { DocxDocument } from '../src/primitives/document.js';
 import { bootstrapCommentParts, addComment, addCommentReply, getComments, getComment } from '../src/primitives/comments.js';
 
 const W_NS = OOXML.W_NS;
-const W15_NS = OOXML.W15_NS;
 
 const test = testAllure.epic('DOCX Primitives').withLabels({ feature: 'Comments' });
 
@@ -32,6 +31,54 @@ async function makeDocxBuffer(bodyXml: string, extraFiles?: Record<string, strin
 
 async function loadZip(buffer: Buffer): Promise<DocxZip> {
   return DocxZip.load(buffer);
+}
+
+type CommentFixtureEntry = {
+  id: number;
+  author: string;
+  initials: string;
+  text: string;
+  paraId: string;
+  date?: string;
+};
+
+function makeCommentsXml(entries: CommentFixtureEntry[]): string {
+  return (
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<w:comments xmlns:w="${W_NS}" xmlns:w14="${OOXML.W14_NS}">` +
+    entries
+      .map(
+        (entry) =>
+          `<w:comment w:id="${entry.id}" w:author="${entry.author}" w:date="${entry.date ?? '2025-01-01T00:00:00Z'}" w:initials="${entry.initials}">` +
+          `<w:p w14:paraId="${entry.paraId}"><w:r><w:annotationRef/></w:r><w:r><w:t>${entry.text}</w:t></w:r></w:p>` +
+          `</w:comment>`,
+      )
+      .join('') +
+    `</w:comments>`
+  );
+}
+
+function withParagraphBookmark(params: {
+  bookmarkId: number;
+  name: string;
+  paragraphInnerXml: string;
+}): string {
+  return `<w:bookmarkStart w:id="${params.bookmarkId}" w:name="${params.name}"/><w:p>${params.paragraphInnerXml}</w:p><w:bookmarkEnd w:id="${params.bookmarkId}"/>`;
+}
+
+function makeCommentReferenceRun(commentId: number): string {
+  return `<w:r><w:rPr><w:rStyle w:val="CommentReference"/></w:rPr><w:commentReference w:id="${commentId}"/></w:r>`;
+}
+
+async function loadCommentFixture(params: {
+  bodyXml: string;
+  comments: CommentFixtureEntry[];
+}): Promise<Awaited<ReturnType<typeof getComments>>> {
+  const buf = await makeDocxBuffer(params.bodyXml, { 'word/comments.xml': makeCommentsXml(params.comments) });
+  const zip = await loadZip(buf);
+  const docXml = await zip.readText('word/document.xml');
+  const doc = parseXml(docXml);
+  return getComments(zip, doc);
 }
 
 describe('comments', () => {
@@ -714,6 +761,301 @@ describe('comments', () => {
       await and('reply is preserved with correct text', async () => {
         expect(comments[0]!.replies).toHaveLength(1);
         expect(comments[0]!.replies[0]!.text).toBe('Round trip reply');
+      });
+    });
+
+    test('resolves single-paragraph range metadata without changing existing fields', async ({ given, then }: AllureBddContext) => {
+      const commentText = 'Single paragraph note';
+      const rangeText = 'Beta';
+      let comments: Awaited<ReturnType<typeof getComments>>;
+
+      await given('a bookmarked paragraph whose comment markers wrap a middle run', async () => {
+        const bodyXml = withParagraphBookmark({
+          bookmarkId: 101,
+          name: '_bk_single_range',
+          paragraphInnerXml:
+            `<w:r><w:t>Alpha </w:t></w:r>` +
+            `<w:commentRangeStart w:id="10"/>` +
+            `<w:r><w:t>${rangeText}</w:t></w:r>` +
+            `<w:commentRangeEnd w:id="10"/>` +
+            makeCommentReferenceRun(10) +
+            `<w:r><w:t> Gamma</w:t></w:r>`,
+        });
+
+        comments = await loadCommentFixture({
+          bodyXml,
+          comments: [
+            { id: 10, author: 'Alice', initials: 'A', text: commentText, paraId: '00000010', date: '2025-02-01T00:00:00Z' },
+          ],
+        });
+      });
+
+      await then('existing fields and range metadata are both correct', async () => {
+        expect(comments).toHaveLength(1);
+        expect(comments[0]!.id).toBe(10);
+        expect(comments[0]!.author).toBe('Alice');
+        expect(comments[0]!.date).toBe('2025-02-01T00:00:00Z');
+        expect(comments[0]!.initials).toBe('A');
+        expect(comments[0]!.text).toBe(commentText);
+        expect(comments[0]!.paragraphId).toBe('00000010');
+        expect(comments[0]!.replies).toEqual([]);
+        expect(comments[0]!.anchoredParagraphId).toBe('_bk_single_range');
+        expect(comments[0]!.endParagraphId).toBe('_bk_single_range');
+        expect(comments[0]!.startRunIndex).toBe(1);
+        expect(comments[0]!.startCharOffset).toBe(0);
+        expect(comments[0]!.endRunIndex).toBe(1);
+        expect(comments[0]!.endCharOffset).toBe(rangeText.length);
+      });
+    });
+
+    test('resolves multi-paragraph range metadata', async ({ given, then }: AllureBddContext) => {
+      const firstRangeText = 'First chunk';
+      const secondRangeText = 'Second chunk';
+      let comments: Awaited<ReturnType<typeof getComments>>;
+
+      await given('a comment whose start and end markers are in different paragraphs', async () => {
+        const bodyXml =
+          withParagraphBookmark({
+            bookmarkId: 102,
+            name: '_bk_multi_start',
+            paragraphInnerXml:
+              `<w:r><w:t>Lead </w:t></w:r>` +
+              `<w:commentRangeStart w:id="11"/>` +
+              `<w:r><w:t>${firstRangeText}</w:t></w:r>`,
+          }) +
+          withParagraphBookmark({
+            bookmarkId: 103,
+            name: '_bk_multi_end',
+            paragraphInnerXml:
+              `<w:r><w:t>${secondRangeText}</w:t></w:r>` +
+              `<w:commentRangeEnd w:id="11"/>` +
+              makeCommentReferenceRun(11) +
+              `<w:r><w:t> tail</w:t></w:r>`,
+          });
+
+        comments = await loadCommentFixture({
+          bodyXml,
+          comments: [
+            { id: 11, author: 'Bob', initials: 'B', text: 'Across paragraphs', paraId: '00000011' },
+          ],
+        });
+      });
+
+      await then('the start and end paragraph bookmarks and offsets are resolved independently', async () => {
+        expect(comments).toHaveLength(1);
+        expect(comments[0]!.anchoredParagraphId).toBe('_bk_multi_start');
+        expect(comments[0]!.endParagraphId).toBe('_bk_multi_end');
+        expect(comments[0]!.startRunIndex).toBe(1);
+        expect(comments[0]!.startCharOffset).toBe(0);
+        expect(comments[0]!.endRunIndex).toBe(0);
+        expect(comments[0]!.endCharOffset).toBe(secondRangeText.length);
+      });
+    });
+
+    test('resolves comment ranges across table cell boundaries', async ({ given, then }: AllureBddContext) => {
+      const leftCellRange = 'cell';
+      const rightCellRange = 'Right cell';
+      let comments: Awaited<ReturnType<typeof getComments>>;
+
+      await given('a table with a comment that starts in one cell and ends in another', async () => {
+        const bodyXml =
+          `<w:tbl><w:tr>` +
+          `<w:tc>` +
+          withParagraphBookmark({
+            bookmarkId: 104,
+            name: '_bk_table_start',
+            paragraphInnerXml:
+              `<w:r><w:t>Left </w:t></w:r>` +
+              `<w:commentRangeStart w:id="12"/>` +
+              `<w:r><w:t>${leftCellRange}</w:t></w:r>`,
+          }) +
+          `</w:tc>` +
+          `<w:tc>` +
+          withParagraphBookmark({
+            bookmarkId: 105,
+            name: '_bk_table_end',
+            paragraphInnerXml:
+              `<w:r><w:t>${rightCellRange}</w:t></w:r>` +
+              `<w:commentRangeEnd w:id="12"/>` +
+              makeCommentReferenceRun(12),
+          }) +
+          `</w:tc>` +
+          `</w:tr></w:tbl>`;
+
+        comments = await loadCommentFixture({
+          bodyXml,
+          comments: [
+            { id: 12, author: 'Casey', initials: 'C', text: 'Cross-cell note', paraId: '00000012' },
+          ],
+        });
+      });
+
+      await then('the paragraph IDs and offsets span the table boundary correctly', async () => {
+        expect(comments).toHaveLength(1);
+        expect(comments[0]!.anchoredParagraphId).toBe('_bk_table_start');
+        expect(comments[0]!.endParagraphId).toBe('_bk_table_end');
+        expect(comments[0]!.startRunIndex).toBe(1);
+        expect(comments[0]!.startCharOffset).toBe(0);
+        expect(comments[0]!.endRunIndex).toBe(0);
+        expect(comments[0]!.endCharOffset).toBe(rightCellRange.length);
+      });
+    });
+
+    test('keeps comments when commentRangeStart is missing', async ({ given, then }: AllureBddContext) => {
+      const legacyText = 'Legacy attachment';
+      let comments: Awaited<ReturnType<typeof getComments>>;
+
+      await given('a comment with only an end marker in the document', async () => {
+        const bodyXml = withParagraphBookmark({
+          bookmarkId: 106,
+          name: '_bk_missing_start',
+          paragraphInnerXml:
+            `<w:r><w:t>${legacyText}</w:t></w:r>` +
+            `<w:commentRangeEnd w:id="13"/>` +
+            makeCommentReferenceRun(13),
+        });
+
+        comments = await loadCommentFixture({
+          bodyXml,
+          comments: [
+            { id: 13, author: 'Dana', initials: 'D', text: 'Legacy comment', paraId: '00000013' },
+          ],
+        });
+      });
+
+      await then('the comment survives and only the end position is resolved', async () => {
+        expect(comments).toHaveLength(1);
+        expect(comments[0]!.anchoredParagraphId).toBeNull();
+        expect(comments[0]!.startRunIndex).toBeUndefined();
+        expect(comments[0]!.startCharOffset).toBeUndefined();
+        expect(comments[0]!.endParagraphId).toBe('_bk_missing_start');
+        expect(comments[0]!.endRunIndex).toBe(0);
+        expect(comments[0]!.endCharOffset).toBe(legacyText.length);
+      });
+    });
+
+    test('falls back endParagraphId when commentRangeEnd is missing', async ({ given, then }: AllureBddContext) => {
+      let comments: Awaited<ReturnType<typeof getComments>>;
+
+      await given('a comment with a start marker but no end marker', async () => {
+        const bodyXml = withParagraphBookmark({
+          bookmarkId: 107,
+          name: '_bk_missing_end',
+          paragraphInnerXml:
+            `<w:r><w:t>Prefix </w:t></w:r>` +
+            `<w:commentRangeStart w:id="14"/>` +
+            `<w:r><w:t>Open range</w:t></w:r>`,
+        });
+
+        comments = await loadCommentFixture({
+          bodyXml,
+          comments: [
+            { id: 14, author: 'Evan', initials: 'E', text: 'Open-ended comment', paraId: '00000014' },
+          ],
+        });
+      });
+
+      await then('the start position is resolved while end data falls back cleanly', async () => {
+        expect(comments).toHaveLength(1);
+        expect(comments[0]!.anchoredParagraphId).toBe('_bk_missing_end');
+        expect(comments[0]!.endParagraphId).toBe('_bk_missing_end');
+        expect(comments[0]!.startRunIndex).toBe(1);
+        expect(comments[0]!.startCharOffset).toBe(0);
+        expect(comments[0]!.endRunIndex).toBeUndefined();
+        expect(comments[0]!.endCharOffset).toBeUndefined();
+      });
+    });
+
+    test('counts every <w:r> in document order — zero-width runs do not shift the index', async ({ given, then }: AllureBddContext) => {
+      let comments: Awaited<ReturnType<typeof getComments>>;
+
+      await given('a paragraph with a zero-width commentReference run before the range start marker', async () => {
+        // Layout: <r>A</r><r>(commentReference for c99 only)</r><commentRangeStart c1/><r>B</r>
+        // Raw <w:r> indices in document order: 0=A, 1=zero-width-ref, 2=B.
+        // The range start marker sits between run 1 and run 2 → start should be {runIndex: 2, charOffset: 0}.
+        const bodyXml = withParagraphBookmark({
+          bookmarkId: 200,
+          name: '_bk_run_index',
+          paragraphInnerXml:
+            `<w:r><w:t>A</w:t></w:r>` +
+            `<w:r><w:rPr><w:rStyle w:val="CommentReference"/></w:rPr><w:commentReference w:id="99"/></w:r>` +
+            `<w:commentRangeStart w:id="1"/>` +
+            `<w:r><w:t>B</w:t></w:r>` +
+            `<w:commentRangeEnd w:id="1"/>` +
+            makeCommentReferenceRun(1),
+        });
+
+        comments = await loadCommentFixture({
+          bodyXml,
+          comments: [
+            { id: 1, author: 'Frank', initials: 'F', text: 'Range with empty run before it', paraId: '00000020' },
+          ],
+        });
+      });
+
+      await then('startRunIndex points at the actual <w:r> position, not the visible-run position', async () => {
+        expect(comments).toHaveLength(1);
+        expect(comments[0]!.anchoredParagraphId).toBe('_bk_run_index');
+        // Without the fix: would report startRunIndex=1 (off-by-one over the empty run).
+        // With the fix: reports startRunIndex=2 — the third <w:r> in DOM order.
+        expect(comments[0]!.startRunIndex).toBe(2);
+        expect(comments[0]!.startCharOffset).toBe(0);
+        expect(comments[0]!.endRunIndex).toBe(2);
+        expect(comments[0]!.endCharOffset).toBe(1);
+      });
+    });
+
+    test('resolves comments when OOXML uses a non-w namespace prefix', async ({ given, then }: AllureBddContext) => {
+      let comments: Awaited<ReturnType<typeof getComments>>;
+
+      await given('a document and comments part bound to the WordprocessingML namespace under a non-w prefix', async () => {
+        // Both document.xml and comments.xml use "x" for the WordprocessingML namespace.
+        // Paragraph discovery must be namespace-aware, not literal-tag-name based.
+        const bodyXml =
+          `<x:bookmarkStart x:id="201" x:name="_bk_alt_prefix"/>` +
+          `<x:p>` +
+          `<x:commentRangeStart x:id="1"/>` +
+          `<x:r><x:t>Hello</x:t></x:r>` +
+          `<x:commentRangeEnd x:id="1"/>` +
+          `<x:r><x:rPr><x:rStyle x:val="CommentReference"/></x:rPr><x:commentReference x:id="1"/></x:r>` +
+          `</x:p>` +
+          `<x:bookmarkEnd x:id="201"/>`;
+
+        const docXml =
+          `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+          `<x:document xmlns:x="${W_NS}" xmlns:w14="${OOXML.W14_NS}">` +
+          `<x:body>${bodyXml}</x:body>` +
+          `</x:document>`;
+
+        const commentsXml =
+          `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+          `<x:comments xmlns:x="${W_NS}" xmlns:w14="${OOXML.W14_NS}">` +
+          `<x:comment x:id="1" x:author="Gina" x:date="2025-01-01T00:00:00Z" x:initials="G">` +
+          `<x:p w14:paraId="00000021"><x:r><x:annotationRef/></x:r><x:r><x:t>Alt prefix comment</x:t></x:r></x:p>` +
+          `</x:comment>` +
+          `</x:comments>`;
+
+        const zip = new JSZip();
+        zip.file('word/document.xml', docXml);
+        zip.file('word/comments.xml', commentsXml);
+        const buf = (await zip.generateAsync({ type: 'nodebuffer' })) as Buffer;
+        const dz = await loadZip(buf);
+        const doc = parseXml(await dz.readText('word/document.xml'));
+        comments = await getComments(dz, doc);
+      });
+
+      await then('paragraph IDs and range metadata still resolve via namespace lookup', async () => {
+        expect(comments).toHaveLength(1);
+        expect(comments[0]!.id).toBe(1);
+        expect(comments[0]!.author).toBe('Gina');
+        expect(comments[0]!.text).toBe('Alt prefix comment');
+        expect(comments[0]!.paragraphId).toBe('00000021');
+        expect(comments[0]!.anchoredParagraphId).toBe('_bk_alt_prefix');
+        expect(comments[0]!.endParagraphId).toBe('_bk_alt_prefix');
+        expect(comments[0]!.startRunIndex).toBe(0);
+        expect(comments[0]!.startCharOffset).toBe(0);
+        expect(comments[0]!.endRunIndex).toBe(0);
+        expect(comments[0]!.endCharOffset).toBe(5);
       });
     });
   });


### PR DESCRIPTION
## Summary

Extends the `Comment` type returned by `getComments()` with five new optional range metadata fields:
- `endParagraphId?: string | null` — paragraph containing `commentRangeEnd`
- `startRunIndex?: number` — 0-based `<w:r>` index in DOM order
- `startCharOffset?: number` — visible-text offset within the start run
- `endRunIndex?: number` — 0-based `<w:r>` index in the end paragraph
- `endCharOffset?: number` — visible-text offset within the end run (exclusive)

This is a **primitive-layer change**. The public `McpComment` surface returned by the MCP `get_comments` tool is unchanged. This work is a prerequisite for inline-range rendering in #130.

## Implementation

- The paragraph walker tracks every `<w:r>` (including zero-width ones like `commentReference` / `annotationRef` runs) in `allRuns`. `runIndex` is the position in that DOM-order sequence, not in a visible-text-only list. Char offsets continue to map against visible text.
- Markers seen INSIDE a `<w:r>` are recorded with their exact `{runIndex, charOffset}` at walk time. Markers seen at paragraph level (between runs) are recorded as `{afterRunIndex}` and resolved at the end based on boundary direction.
- Field-code awareness preserved: `<w:instrText>` inside `fldChar` begin/separate ranges is not counted toward visible text.
- Paragraph discovery uses `getElementsByTagNameNS(W_NS, W.p)` instead of the prefix-sensitive `findAllByTagName(..., 'w:p')`, so OOXML documents that bind WordprocessingML under a non-\`w\` prefix still resolve correctly.

## Verification

- [x] \`npm run build\` clean (all workspaces)
- [x] \`npm run lint --workspace=@usejunior/docx-core\` clean
- [x] \`npm run test:run --workspace=@usejunior/docx-core\` — 1104 passed + 1 skipped (5 new tests, 2 of which are regressions)
- [x] \`npm run test:run --workspace=@usejunior/docx-mcp\` — 638 passed (no regression; \`McpComment\` shape unchanged)
- [x] \`npm run check:spec-coverage\` passes
- [x] \`npm run check:tool-docs\` clean (no \`tool_catalog.ts\` changes)

### Peer review (mandatory gate per [codex-implement skill](https://github.com/anthropics/claude-code/blob/main/SKILL.md))

- **Gemini:** *No concerns / merge-ready.* Verified run-boundary correctness, field-code awareness, multi-paragraph robustness, and graceful fallbacks. Confirmed 5 BDD tests cover all edge cases.

- **Codex:** flagged two real bugs which are **fixed in this PR** before opening:
  1. **Prefix-sensitive paragraph discovery.** \`findAllByTagName(el, 'w:p')\` does literal tag-name matching, breaking OOXML that binds WordprocessingML to a non-\`w\` prefix. Fixed by using \`getElementsByTagNameNS(OOXML.W_NS, W.p)\`. Codex's repro:
     \`\`\`
     alt-prefix {\"id\":1,\"author\":\"A\",\"paragraphId\":null,\"anchoredParagraphId\":null,\"endParagraphId\":null,...}
     \`\`\`
     After fix: paragraphId, anchoredParagraphId, and endParagraphId all resolve correctly.
  2. **Run index counted visible-text runs only.** The walker pushed runs to a \`visibleRuns\` array only when they had non-zero text content; \`runIndex\` indexed into that filtered list. So a zero-width run before a marker (e.g., a \`commentReference\` run for a different comment) shifted the index by one. Codex's repro:
     - Paragraph: \`<r>A</r><r>(commentReference for c99)</r><commentRangeStart c1/><r>B</r>\`
     - Before fix: \`startRunIndex = 1\` (wrong — counted only A and B as runs)
     - After fix: \`startRunIndex = 2\` (correct DOM-order position of the \"B\" run)

  Both bugs have new BDD regression tests.

### New tests (cover issue acceptance criteria + Codex regressions)

In \`packages/docx-core/test-primitives/comments.test.ts\`:
- resolves single-paragraph range metadata without changing existing fields
- resolves multi-paragraph range metadata
- resolves comment ranges across table cell boundaries
- keeps comments when commentRangeStart is missing
- falls back endParagraphId when commentRangeEnd is missing
- counts every \`<w:r>\` in document order — zero-width runs do not shift the index *(Codex regression)*
- resolves comments when OOXML uses a non-w namespace prefix *(Codex regression)*

## Out of scope (follow-ups)

- #130 — Render comment ranges inline in \`read_file\` (uses the metadata from this PR)
- Public \`get_comments\` tool surface change — separate decision once #130's needs are clearer
- Range-write support in \`add_comment.ts\` — separate concern

## Closes

- #129