### PR TITLE
feat(docx-mcp): add endnotes rendering mode for comments in read_file

### DIFF
--- a/packages/docx-core/src/primitives/document_view.ts
+++ b/packages/docx-core/src/primitives/document_view.ts
@@ -429,6 +429,37 @@ export function formatToonCommentLines(node: Pick<DocumentViewNode, 'id' | 'comm
   return node.comments?.flatMap((comment) => collectToonCommentLines(comment, node.id)) ?? [];
 }
 
+function collectToonCommentEndnoteLines(
+  comment: DocumentViewComment,
+  paragraphId: string,
+  parentId?: number,
+): string[] {
+  const author = escapeToonCommentField(comment.author || '-');
+  const date = formatCommentDate(comment.date);
+  const text = escapeToonCommentField(comment.text);
+  const line = parentId == null
+    ? `c${comment.id} @ ${paragraphId} ${author} ${date} | ${text}`
+    : `c${comment.id} -> c${parentId} ${author} ${date} | ${text}`;
+
+  return [
+    line,
+    ...comment.replies.flatMap((reply) => collectToonCommentEndnoteLines(reply, paragraphId, comment.id)),
+  ];
+}
+
+export function formatToonCommentEndnoteLines(node: Pick<DocumentViewNode, 'id' | 'comments'>): string[] {
+  return node.comments?.flatMap((comment) => collectToonCommentEndnoteLines(comment, node.id)) ?? [];
+}
+
+export function formatToonCommentsEndnotesBlock(
+  nodes: readonly Pick<DocumentViewNode, 'id' | 'comments'>[],
+): string[] {
+  const commentLines = nodes.flatMap((node) => formatToonCommentEndnoteLines(node));
+  return commentLines.length > 0
+    ? ['#COMMENTS', ...commentLines]
+    : [];
+}
+
 export function renderToon(nodes: DocumentViewNode[], options: { compact?: boolean } = {}): string {
   const lines: string[] = ['#SCHEMA id | list_label | header | style | text'];
 
@@ -462,6 +493,42 @@ export function renderToon(nodes: DocumentViewNode[], options: { compact?: boole
   if (currentTableIndex !== null) {
     lines.push('#END_TABLE');
   }
+
+  return lines.join('\n');
+}
+
+export function renderToonWithCommentEndnotes(
+  nodes: DocumentViewNode[],
+  options: { compact?: boolean } = {},
+): string {
+  const lines: string[] = ['#SCHEMA id | list_label | header | style | text'];
+  const tableInfo = collectTableMarkerInfo(nodes);
+
+  let currentTableIndex: number | null = null;
+
+  for (const n of nodes) {
+    const tc = n.table_context;
+    const nodeTableIndex = tc ? tc.table_index : null;
+
+    if (currentTableIndex !== null && nodeTableIndex !== currentTableIndex) {
+      lines.push('#END_TABLE');
+      currentTableIndex = null;
+    }
+
+    if (nodeTableIndex !== null && currentTableIndex === null) {
+      const info = tableInfo.get(nodeTableIndex);
+      if (info) lines.push(formatTableMarker(info));
+      currentTableIndex = nodeTableIndex;
+    }
+
+    lines.push(formatToonDataLine(n, options));
+  }
+
+  if (currentTableIndex !== null) {
+    lines.push('#END_TABLE');
+  }
+
+  lines.push(...formatToonCommentsEndnotesBlock(nodes));
 
   return lines.join('\n');
 }

--- a/packages/docx-mcp/docs/tool-reference.generated.md
+++ b/packages/docx-mcp/docs/tool-reference.generated.md
@@ -20,7 +20,7 @@ Read document content (DOCX or Google Doc). Output is token-limited (~14k tokens
 | `limit` | `number` | no | Max paragraphs to return. When omitted, output is token-limited to ~14k tokens with pagination. |
 | `node_ids` | `array<string>` | no |  |
 | `format` | `enum("toon", "json", "simple")` | no |  |
-| `comment_rendering` | `enum("none", "paragraph_notes")` | no | How to render comments in read_file output. Use "paragraph_notes" (default) to emit paragraph-local comments and replies, or "none" for the legacy output with no comment rendering. |
+| `comment_rendering` | `enum("none", "paragraph_notes", "endnotes")` | no | How to render comments in read_file output. Use "paragraph_notes" (default) to emit paragraph-local comments and replies, "endnotes" to collect threaded comments into a trailing #COMMENTS block in TOON output, or "none" for the legacy output with no comment rendering. |
 | `show_formatting` | `boolean` | no | When true (default), shows inline formatting tags (<b>, <i>, <u>, <highlighting>, <a>). When false, emits plain text with no inline tags. |
 
 ## `grep`

--- a/packages/docx-mcp/src/tool_catalog.ts
+++ b/packages/docx-mcp/src/tool_catalog.ts
@@ -41,10 +41,10 @@ export const SAFE_DOCX_TOOL_CATALOG = [
       node_ids: z.array(z.string()).optional(),
       format: z.enum(['toon', 'json', 'simple']).optional(),
       comment_rendering: z
-        .enum(['none', 'paragraph_notes'])
+        .enum(['none', 'paragraph_notes', 'endnotes'])
         .optional()
         .describe(
-          'How to render comments in read_file output. Use "paragraph_notes" (default) to emit paragraph-local comments and replies, or "none" for the legacy output with no comment rendering.',
+          'How to render comments in read_file output. Use "paragraph_notes" (default) to emit paragraph-local comments and replies, "endnotes" to collect threaded comments into a trailing #COMMENTS block in TOON output, or "none" for the legacy output with no comment rendering.',
         ),
       show_formatting: z
         .boolean()

--- a/packages/docx-mcp/src/tools/read_file.ts
+++ b/packages/docx-mcp/src/tools/read_file.ts
@@ -5,8 +5,10 @@ import {
   OOXML,
   W,
   renderToon,
+  renderToonWithCommentEndnotes,
   formatToonDataLine,
   formatToonCommentLines,
+  formatToonCommentsEndnotesBlock,
   collectTableMarkerInfo,
   formatTableMarker,
   type Comment,
@@ -124,11 +126,11 @@ export async function readFile(
     }
 
     const commentRendering = (params.comment_rendering ?? 'paragraph_notes').toLowerCase();
-    if (commentRendering !== 'none' && commentRendering !== 'paragraph_notes') {
+    if (commentRendering !== 'none' && commentRendering !== 'paragraph_notes' && commentRendering !== 'endnotes') {
       return err(
         'INVALID_COMMENT_RENDERING',
         `Invalid comment_rendering: ${params.comment_rendering}`,
-        "Use 'paragraph_notes' (default) or 'none'.",
+        "Use 'paragraph_notes' (default), 'endnotes', or 'none'.",
       );
     }
 
@@ -184,7 +186,7 @@ export async function readFile(
       enriched = filtered;
     }
 
-    if (commentRendering === 'paragraph_notes') {
+    if (commentRendering !== 'none') {
       try {
         enriched = attachParagraphComments(enriched, await session.doc.getComments());
       } catch {
@@ -202,13 +204,15 @@ export async function readFile(
       } else if (format === 'simple') {
         content = renderSimpleWithTableMarkers(enriched);
       } else {
-        content = renderToon(enriched);
+        content = commentRendering === 'endnotes'
+          ? renderToonWithCommentEndnotes(enriched)
+          : renderToon(enriched);
       }
       paragraphsReturned = enriched.length;
     } else {
       // One-pass token-budget accumulation
       const budget = DEFAULT_CONTENT_TOKEN_BUDGET;
-      const result = renderWithBudget(enriched, format, budget);
+      const result = renderWithBudget(enriched, format, budget, commentRendering);
       content = result.content;
       paragraphsReturned = result.count;
     }
@@ -237,6 +241,7 @@ function renderWithBudget(
   enriched: readonly DocumentViewNode[],
   format: string,
   budget: number,
+  commentRendering: string,
 ): BudgetResult {
   if (format === 'json') {
     return renderJsonWithBudget(enriched, budget);
@@ -244,17 +249,19 @@ function renderWithBudget(
   if (format === 'simple') {
     return renderSimpleWithBudget(enriched, budget);
   }
-  return renderToonWithBudget(enriched, budget);
+  return renderToonWithBudget(enriched, budget, commentRendering);
 }
 
 function renderToonWithBudget(
   enriched: readonly DocumentViewNode[],
   budget: number,
+  commentRendering: string,
 ): BudgetResult {
   const headerLine = '#SCHEMA id | list_label | header | style | text';
   let accumulated = headerLine;
   let count = 0;
   let currentTableIndex: number | null = null;
+  const includedNodes: DocumentViewNode[] = [];
 
   // Pre-scan: collect table marker info for #TABLE lines
   const tableInfo = collectTableMarkerInfo(enriched);
@@ -284,9 +291,21 @@ function renderToonWithBudget(
     }
 
     const dataLine = formatToonDataLine(node);
-    const commentLines = formatToonCommentLines(node);
+    const commentLines = commentRendering === 'paragraph_notes'
+      ? formatToonCommentLines(node)
+      : [];
     const nodeLines = [dataLine, ...commentLines].join('\n');
-    const candidate = accumulated + '\n' + nodeLines;
+    const candidateBase = accumulated + '\n' + nodeLines;
+    let candidate = candidateBase;
+    if (commentRendering === 'endnotes') {
+      if (nodeTableIndex !== null) {
+        candidate += '\n#END_TABLE';
+      }
+      const endnotesBlock = formatToonCommentsEndnotesBlock([...includedNodes, node]);
+      if (endnotesBlock.length > 0) {
+        candidate += '\n' + endnotesBlock.join('\n');
+      }
+    }
     if (count > 0 && estimateTokens(candidate) > budget) {
       // Close table before breaking
       if (currentTableIndex !== null) {
@@ -294,13 +313,21 @@ function renderToonWithBudget(
       }
       break;
     }
-    accumulated = candidate;
+    accumulated = candidateBase;
+    includedNodes.push(node);
     count++;
   }
 
   // Close any open table at end of loop
   if (currentTableIndex !== null) {
     accumulated += '\n#END_TABLE';
+  }
+
+  if (commentRendering === 'endnotes') {
+    const endnotesBlock = formatToonCommentsEndnotesBlock(includedNodes);
+    if (endnotesBlock.length > 0) {
+      accumulated += '\n' + endnotesBlock.join('\n');
+    }
   }
 
   return { content: accumulated, count };

--- a/packages/docx-mcp/src/tools/read_file_comments.test.ts
+++ b/packages/docx-mcp/src/tools/read_file_comments.test.ts
@@ -17,6 +17,11 @@ function findParagraphLine(lines: string[], paragraphId: string): string {
   return line;
 }
 
+function commentBlockLines(lines: string[]): string[] {
+  const start = lines.indexOf('#COMMENTS');
+  return start === -1 ? [] : lines.slice(start);
+}
+
 describe('read_file comment rendering', () => {
   registerCleanup();
 
@@ -233,6 +238,271 @@ describe('read_file comment rendering', () => {
     });
   });
 
+  test('endnotes mode emits one trailing #COMMENTS block after #END_TABLE with no inline comment lines', async ({ given, when, then }: AllureBddContext) => {
+    const xml =
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+      `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
+      `<w:body>` +
+      `<w:tbl>` +
+      `<w:tr><w:tc><w:p><w:r><w:t>Table cell text.</w:t></w:r></w:p></w:tc></w:tr>` +
+      `</w:tbl>` +
+      `</w:body></w:document>`;
+    const opened = await given('a document with a one-cell table', async () => openSession([], { xml }));
+
+    const rendered = await when('a table-cell comment is read in endnotes mode', async () => {
+      const result = await addComment(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.firstParaId,
+        author: 'Alice',
+        text: 'Cell comment.',
+      });
+      assertSuccess(result, 'add_comment');
+      const read = await readFile(opened.mgr, {
+        file_path: opened.inputPath,
+        comment_rendering: 'endnotes',
+      });
+      assertSuccess(read, 'read_file');
+      return { commentId: Number(result.comment_id), read };
+    });
+
+    await then('the TOON view closes the table before a single trailing comments block', async () => {
+      const lines = toonLines(rendered.read.content);
+      const endTableIndex = lines.indexOf('#END_TABLE');
+      const commentsIndex = lines.indexOf('#COMMENTS');
+      expect(lines.filter((line) => line === '#COMMENTS')).toHaveLength(1);
+      expect(lines.some((line) => line.startsWith('#COMMENT '))).toBe(false);
+      expect(lines.some((line) => line.startsWith('#REPLY '))).toBe(false);
+      expect(endTableIndex).toBeGreaterThan(-1);
+      expect(commentsIndex).toBe(endTableIndex + 1);
+      expect(lines[commentsIndex + 1]).toContain(`c${rendered.commentId} @ ${opened.firstParaId} Alice `);
+      expect(lines[commentsIndex + 1]).toContain('| Cell comment.');
+    });
+  });
+
+  test('endnotes mode renders a single root comment as one block entry', async ({ given, when, then }: AllureBddContext) => {
+    const opened = await given('a document with one paragraph', async () => openSession(['Alpha paragraph.']));
+
+    const rendered = await when('a root comment is added and read in endnotes mode', async () => {
+      const result = await addComment(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.firstParaId,
+        author: 'Alice',
+        text: 'Please review this clause.',
+      });
+      assertSuccess(result, 'add_comment');
+      const read = await readFile(opened.mgr, {
+        file_path: opened.inputPath,
+        comment_rendering: 'endnotes',
+      });
+      assertSuccess(read, 'read_file');
+      return { commentId: Number(result.comment_id), read };
+    });
+
+    await then('the comments block contains exactly one root entry after the paragraph data', async () => {
+      const lines = toonLines(rendered.read.content);
+      const commentsBlock = commentBlockLines(lines);
+      const paragraphIndex = lines.indexOf(findParagraphLine(lines, opened.firstParaId));
+      expect(commentsBlock).toHaveLength(2);
+      expect(commentsBlock[0]).toBe('#COMMENTS');
+      expect(commentsBlock[1]).toContain(`c${rendered.commentId} @ ${opened.firstParaId} Alice `);
+      expect(commentsBlock[1]).toContain('| Please review this clause.');
+      expect(lines.indexOf('#COMMENTS')).toBe(paragraphIndex + 1);
+      expect(Number(rendered.read.paragraphs_returned)).toBe(1);
+    });
+  });
+
+  test('endnotes mode renders parent comments followed by ordered replies', async ({ given, when, then }: AllureBddContext) => {
+    const opened = await given('a document with one paragraph', async () => openSession(['Discussion paragraph.']));
+
+    const rendered = await when('a nested comment thread is added and read in endnotes mode', async () => {
+      const root = await addComment(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.firstParaId,
+        author: 'Alice',
+        text: 'Root note.',
+      });
+      assertSuccess(root, 'add_comment(root)');
+      const reply = await addComment(opened.mgr, {
+        file_path: opened.inputPath,
+        parent_comment_id: Number(root.comment_id),
+        author: 'Bob',
+        text: 'First reply.',
+      });
+      assertSuccess(reply, 'add_comment(reply)');
+      const nestedReply = await addComment(opened.mgr, {
+        file_path: opened.inputPath,
+        parent_comment_id: Number(reply.comment_id),
+        author: 'Cara',
+        text: 'Nested reply.',
+      });
+      assertSuccess(nestedReply, 'add_comment(nested reply)');
+
+      const read = await readFile(opened.mgr, {
+        file_path: opened.inputPath,
+        comment_rendering: 'endnotes',
+      });
+      assertSuccess(read, 'read_file');
+      return {
+        rootId: Number(root.comment_id),
+        replyId: Number(reply.comment_id),
+        nestedReplyId: Number(nestedReply.comment_id),
+        read,
+      };
+    });
+
+    await then('the block emits the parent entry first and each reply directly after its parent chain', async () => {
+      const commentsBlock = commentBlockLines(toonLines(rendered.read.content));
+      const rootIndex = commentsBlock.findIndex((line) => line.startsWith(`c${rendered.rootId} @ ${opened.firstParaId} Alice `));
+      const replyIndex = commentsBlock.findIndex((line) => line.startsWith(`c${rendered.replyId} -> c${rendered.rootId} Bob `));
+      const nestedReplyIndex = commentsBlock.findIndex((line) => line.startsWith(`c${rendered.nestedReplyId} -> c${rendered.replyId} Cara `));
+      expect(rootIndex).toBeGreaterThan(0);
+      expect(replyIndex).toBe(rootIndex + 1);
+      expect(nestedReplyIndex).toBe(replyIndex + 1);
+    });
+  });
+
+  test('endnotes mode lists comments in document order by anchor paragraph', async ({ given, when, then }: AllureBddContext) => {
+    const opened = await given('a document with three paragraphs', async () => openSession([
+      'First paragraph.',
+      'Second paragraph.',
+      'Third paragraph.',
+    ]));
+
+    const rendered = await when('comments are added out of paragraph order and read in endnotes mode', async () => {
+      const second = await addComment(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.paraIds[1],
+        author: 'Bob',
+        text: 'Second paragraph comment.',
+      });
+      assertSuccess(second, 'add_comment(second)');
+      const first = await addComment(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.paraIds[0],
+        author: 'Alice',
+        text: 'First paragraph comment.',
+      });
+      assertSuccess(first, 'add_comment(first)');
+      const third = await addComment(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.paraIds[2],
+        author: 'Cara',
+        text: 'Third paragraph comment.',
+      });
+      assertSuccess(third, 'add_comment(third)');
+      const read = await readFile(opened.mgr, {
+        file_path: opened.inputPath,
+        comment_rendering: 'endnotes',
+      });
+      assertSuccess(read, 'read_file');
+      return { read };
+    });
+
+    await then('the comments block follows paragraph order instead of comment creation order', async () => {
+      const commentsBlock = commentBlockLines(toonLines(rendered.read.content));
+      expect(commentsBlock[1]).toContain(`@ ${opened.paraIds[0]} `);
+      expect(commentsBlock[2]).toContain(`@ ${opened.paraIds[1]} `);
+      expect(commentsBlock[3]).toContain(`@ ${opened.paraIds[2]} `);
+    });
+  });
+
+  test('paginated endnotes reads include only in-window anchored comments', async ({ given, when, then }: AllureBddContext) => {
+    const opened = await given('a document with three paragraphs', async () => openSession([
+      'First paragraph.',
+      'Second paragraph.',
+      'Third paragraph.',
+    ]));
+
+    const rendered = await when('comments are added to multiple paragraphs and a one-paragraph endnotes window is read', async () => {
+      const first = await addComment(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.paraIds[0],
+        author: 'Alice',
+        text: 'First window comment.',
+      });
+      assertSuccess(first, 'add_comment(first)');
+      const second = await addComment(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.paraIds[1],
+        author: 'Bob',
+        text: 'Second window comment.',
+      });
+      assertSuccess(second, 'add_comment(second)');
+      const read = await readFile(opened.mgr, {
+        file_path: opened.inputPath,
+        offset: 2,
+        limit: 1,
+        comment_rendering: 'endnotes',
+      });
+      assertSuccess(read, 'read_file');
+      return read;
+    });
+
+    await then('the trailing comments block lists only the comment anchored to the returned paragraph', async () => {
+      const content = String(rendered.content);
+      const commentsBlock = commentBlockLines(toonLines(content));
+      expect(content).toContain('Second paragraph');
+      expect(commentsBlock).toHaveLength(2);
+      expect(commentsBlock[1]).toContain(`@ ${opened.paraIds[1]} `);
+      expect(commentsBlock[1]).toContain('Second window comment.');
+      expect(content).not.toContain('First paragraph.');
+      expect(content).not.toContain('First window comment.');
+      expect(Number(rendered.paragraphs_returned)).toBe(1);
+    });
+  });
+
+  test('endnotes mode and footnotes render independently in the same view', async ({ given, when, then }: AllureBddContext) => {
+    const opened = await given('a document with one paragraph', async () => openSession(['Clause text.']));
+
+    const rendered = await when('a footnote and comment are added to the same paragraph and read in endnotes mode', async () => {
+      const note = await addFootnote(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.firstParaId,
+        text: 'Footnote body',
+      });
+      assertSuccess(note, 'add_footnote');
+      const comment = await addComment(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.firstParaId,
+        author: 'Alice',
+        text: 'Comment body.',
+      });
+      assertSuccess(comment, 'add_comment');
+      const read = await readFile(opened.mgr, {
+        file_path: opened.inputPath,
+        comment_rendering: 'endnotes',
+      });
+      assertSuccess(read, 'read_file');
+      return read;
+    });
+
+    await then('the paragraph keeps the footnote marker and the trailing comments block contains the comment', async () => {
+      const lines = toonLines(rendered.content);
+      const commentsBlock = commentBlockLines(lines);
+      expect(findParagraphLine(lines, opened.firstParaId)).toContain('[^1]');
+      expect(commentsBlock).toHaveLength(2);
+      expect(commentsBlock[1]).toContain(`@ ${opened.firstParaId} `);
+      expect(commentsBlock[1]).toContain('Comment body.');
+    });
+  });
+
+  test('endnotes mode skips the #COMMENTS block when no in-window comments exist', async ({ given, when, then }: AllureBddContext) => {
+    const opened = await given('a document with one paragraph and no comments', async () => openSession(['Plain paragraph.']));
+
+    const rendered = await when('read_file is called in endnotes mode without comments', async () => {
+      const read = await readFile(opened.mgr, {
+        file_path: opened.inputPath,
+        comment_rendering: 'endnotes',
+      });
+      assertSuccess(read, 'read_file');
+      return read;
+    });
+
+    await then('the output contains no stray comments header', async () => {
+      expect(String(rendered.content)).not.toContain('#COMMENTS');
+    });
+  });
+
   test('comment_rendering none preserves the previous output exactly', async ({ given, when, then }: AllureBddContext) => {
     const opened = await given('a document with one paragraph', async () => openSession(['Regression paragraph.']));
 
@@ -317,6 +587,53 @@ describe('read_file comment rendering', () => {
       expect(node?.comments?.[0]?.replies[0]?.id).toBe(rendered.replyId);
       expect(String(rendered.simpleRead.content)).toContain(`[c${rendered.rootId}: Root json note.]`);
       expect(String(rendered.simpleRead.content)).toContain(`[c${rendered.replyId}->c${rendered.rootId}: Reply json note.]`);
+    });
+  });
+
+  test('endnotes mode keeps json node comments and paragraph-local simple suffixes', async ({ given, when, then }: AllureBddContext) => {
+    const opened = await given('a document with one paragraph', async () => openSession(['Simple endnotes paragraph.']));
+
+    const rendered = await when('a comment thread is added and json and simple reads use endnotes mode', async () => {
+      const root = await addComment(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.firstParaId,
+        author: 'Alice',
+        text: 'Root endnote note.',
+      });
+      assertSuccess(root, 'add_comment(root)');
+      const reply = await addComment(opened.mgr, {
+        file_path: opened.inputPath,
+        parent_comment_id: Number(root.comment_id),
+        author: 'Bob',
+        text: 'Reply endnote note.',
+      });
+      assertSuccess(reply, 'add_comment(reply)');
+      const jsonRead = await readFile(opened.mgr, {
+        file_path: opened.inputPath,
+        format: 'json',
+        comment_rendering: 'endnotes',
+      });
+      assertSuccess(jsonRead, 'read_file(json)');
+      const simpleRead = await readFile(opened.mgr, {
+        file_path: opened.inputPath,
+        format: 'simple',
+        comment_rendering: 'endnotes',
+      });
+      assertSuccess(simpleRead, 'read_file(simple)');
+      return { rootId: Number(root.comment_id), replyId: Number(reply.comment_id), jsonRead, simpleRead };
+    });
+
+    await then('json still includes node-attached comments and simple format keeps paragraph-style suffixes for parity', async () => {
+      const nodes = JSON.parse(String(rendered.jsonRead.content)) as Array<{
+        id: string;
+        comments?: Array<{ id: number; text: string; replies: Array<{ id: number; text: string }> }>;
+      }>;
+      const node = nodes.find((candidate) => candidate.id === opened.firstParaId);
+      expect(node?.comments).toHaveLength(1);
+      expect(node?.comments?.[0]?.id).toBe(rendered.rootId);
+      expect(node?.comments?.[0]?.replies[0]?.id).toBe(rendered.replyId);
+      expect(String(rendered.simpleRead.content)).toContain(`[c${rendered.rootId}: Root endnote note.]`);
+      expect(String(rendered.simpleRead.content)).toContain(`[c${rendered.replyId}->c${rendered.rootId}: Reply endnote note.]`);
     });
   });
 


### PR DESCRIPTION
## Summary

Extends `read_file`'s `comment_rendering` enum with a third value: `\"endnotes\"`. In this mode, the TOON renderer emits a single `#COMMENTS` block at the end of the returned view (after any `#END_TABLE`), listing every in-window-anchored root comment plus its threaded replies in document order by anchor paragraph. Per-paragraph `#COMMENT`/`#REPLY` lines are NOT emitted in this mode.

> ⚠️ **PR base:** `127-render-comments-paragraph-20260503` (PR #132). This PR auto-retargets to `main` when #127 merges. Do not merge this PR before #127.

## Implementation

- `\"endnotes\"` is mutually exclusive with `\"paragraph_notes\"` in TOON. Same `node.comments?` data populates JSON; only the TOON dispatch differs.
- Block placement: AFTER the last paragraph data line AND AFTER any closing `#END_TABLE`.
- Empty case: zero in-window-anchored comments → no stray `#COMMENTS` header.
- Pagination: only comments anchored to in-window paragraphs are listed (parallel to #127).
- Simple format keeps the per-paragraph `[c<id>: <text>]` suffix for parity with the footnote suffix.
- Author/text fields reuse the existing `escapeToonCommentField` helper (handles `|`, `\\r`, `\\n`).
- `tool_catalog.ts` schema updated; `tool-reference.generated.md` regenerated.

## Verification

- [x] \`npm run build\` clean (all workspaces)
- [x] \`npm run lint --workspace=@usejunior/docx-core\` and \`-mcp\` pass
- [x] \`npm run test:run --workspace=@usejunior/docx-mcp\` — 658 passed (+8 new endnote tests)
- [x] \`npm run test:run --workspace=@usejunior/docx-core\` — 1099 + 1 skipped (no regression; this PR doesn't touch core primitive logic)
- [x] \`npm run check:tool-docs\` passes (regenerated doc included in commit)
- [x] \`npm run check:spec-coverage\` passes

### Peer review (mandatory gate)

- **Gemini:** *No concerns; the PR is merge-ready.* Verified `#COMMENTS` block placement, mutual exclusion with inline notes, empty-case handling, and documentation update.
- **Codex:** *No concerns from review. Merge-ready.* Cited specific file:line references confirming the implementation matches the stated assumptions. Re-ran the docx-mcp test suite from the worktree (66 files / 658 tests passed).

### New tests (cover issue acceptance criteria)

In \`packages/docx-mcp/src/tools/read_file_comments.test.ts\`:
- endnotes mode emits one trailing `#COMMENTS` block after `#END_TABLE` with no inline comment lines
- endnotes mode renders a single root comment as one block entry
- endnotes mode renders parent comments followed by ordered replies
- endnotes mode lists comments in document order by anchor paragraph
- paginated endnotes reads include only in-window anchored comments
- endnotes mode and footnotes render independently in the same view
- endnotes mode skips the `#COMMENTS` block when no in-window comments exist
- endnotes mode keeps json node comments and paragraph-local simple suffixes

## Out of scope

- Inline range markers (`inline_markers` mode) — that's #130, blocked on #129
- Global \"all comments across whole document\" mode — separate API surface
- Endnotes for footnotes (the OOXML kind) — separate concern

## Closes

- #131