### PR TITLE
feat(docx-core): publish DOM-aware tracked-change emitter helpers (#135)

### DIFF
--- a/packages/docx-core/src/baselines/atomizer/documentReconstructor.ts
+++ b/packages/docx-core/src/baselines/atomizer/documentReconstructor.ts
@@ -10,6 +10,18 @@ import { parseXml } from '../../primitives/xml.js';
 import type { ComparisonUnitAtom } from '../../core-types.js';
 import { CorrelationStatus } from '../../core-types.js';
 import { getLeafText, childElements, findChildByTagName } from '../../primitives/index.js';
+import {
+  type RevisionIdState,
+  allocateRevisionId,
+  buildPPrChangeElement,
+  convertSerializedDeletionContent,
+  createRevisionContext,
+  createRevisionIdState,
+  escapeXmlAttr,
+  formatDate,
+  wrapSerializedContentWithDel,
+  wrapSerializedContentWithIns,
+} from '../../primitives/track-changes-emitter.js';
 import { serializeToXml, cloneElement } from './xmlToWmlElement.js';
 import { EMPTY_PARAGRAPH_TAG, isParagraphLevelLeaf } from '../../atomizer.js';
 import { enforceConsumerCompatibility } from './consumerCompatibility.js';
@@ -36,31 +48,6 @@ export interface ReconstructorOptions {
 }
 
 /**
- * State for tracking revision IDs during reconstruction.
- */
-interface RevisionIdState {
-  nextId: number;
-  moveRangeIds: Map<string, { sourceRangeId: number; destRangeId: number }>;
-}
-
-/**
- * Create initial revision ID state.
- */
-function createRevisionIdState(): RevisionIdState {
-  return {
-    nextId: 1,
-    moveRangeIds: new Map(),
-  };
-}
-
-/**
- * Allocate a new revision ID.
- */
-function allocateRevisionId(state: RevisionIdState): number {
-  return state.nextId++;
-}
-
-/**
  * Get or allocate move range IDs for a move name.
  */
 function getMoveRangeIds(
@@ -76,13 +63,6 @@ function getMoveRangeIds(
     state.moveRangeIds.set(moveName, ids);
   }
   return ids;
-}
-
-/**
- * Format date for OOXML (ISO 8601).
- */
-function formatDate(date: Date): string {
-  return date.toISOString().replace(/\.\d{3}Z$/, 'Z');
 }
 
 /**
@@ -570,6 +550,8 @@ function buildParagraphXml(
   dateStr: string,
   revState: RevisionIdState
 ): string {
+  const revisionCtx = createRevisionContext({ author, date: dateStr, idState: revState });
+
   // Track empty paragraph statuses for debugging
   if (isEmptyParagraphGroup(group)) {
     const status = group.runGroups[0]?.atoms[0]?.correlationStatus;
@@ -606,44 +588,32 @@ function buildParagraphXml(
   // entirely (instead of leaving behind a stub <w:p> break).
   if (isEntireParagraphWithStatus(group, CorrelationStatus.Inserted)) {
     const paraId = allocateRevisionId(revState);
-    const runId = allocateRevisionId(revState);
-    const pPrChangeEl = buildPPrChangeElement(group.pPr, author, dateStr, revState);
+    const insertedRunXml = wrapSerializedContentWithIns(
+      group.runGroups.map((runGroup) => buildRunContentAsPlainRun(runGroup)).join(''),
+      revisionCtx,
+    );
+    const pPrChangeEl = buildPPrChangeElement(group.pPr, revisionCtx);
     const parts: string[] = [];
     parts.push('<w:p>');
     parts.push(serializePPrWithParaRevisionMarker(
       group.pPr, 'w:ins', paraId, author, dateStr, pPrChangeEl
     ));
-    parts.push(
-      `<w:ins w:id="${runId}" w:author="${escapeXmlAttr(author)}" w:date="${dateStr}">`
-    );
-    for (const runGroup of group.runGroups) {
-      parts.push(buildRunContentAsPlainRun(runGroup));
-    }
-    parts.push('</w:ins>');
+    parts.push(insertedRunXml);
     parts.push('</w:p>');
     return parts.join('');
   }
 
   if (isEntireParagraphWithStatus(group, CorrelationStatus.Deleted)) {
     const paraId = allocateRevisionId(revState);
-    const runId = allocateRevisionId(revState);
     const parts: string[] = [];
     parts.push('<w:p>');
     parts.push(serializePPrWithParaRevisionMarker(
       group.pPr, 'w:del', paraId, author, dateStr
     ));
-    parts.push(
-      `<w:del w:id="${runId}" w:author="${escapeXmlAttr(author)}" w:date="${dateStr}">`
-    );
-    for (const runGroup of group.runGroups) {
-      const plainRun = buildRunContentAsPlainRun(runGroup);
-      parts.push(
-        plainRun
-          .replace(/<w:t([^>]*)>([^<]*)<\/w:t>/g, '<w:delText$1>$2</w:delText>')
-          .replace(/<w:instrText([^>]*)>([^<]*)<\/w:instrText>/g, '<w:delInstrText$1>$2</w:delInstrText>')
-      );
-    }
-    parts.push('</w:del>');
+    parts.push(wrapSerializedContentWithDel(
+      group.runGroups.map((runGroup) => buildRunContentAsPlainRun(runGroup)).join(''),
+      revisionCtx,
+    ));
     parts.push('</w:p>');
     return parts.join('');
   }
@@ -653,7 +623,7 @@ function buildParagraphXml(
   // marker inside w:pPr > w:rPr.
   if (isEmptyParagraphWithStatus(group, CorrelationStatus.Inserted)) {
     const paraId = allocateRevisionId(revState);
-    const pPrChangeEl = buildPPrChangeElement(group.pPr, author, dateStr, revState);
+    const pPrChangeEl = buildPPrChangeElement(group.pPr, revisionCtx);
     const pPrXml = serializePPrWithParaRevisionMarker(
       group.pPr, 'w:ins', paraId, author, dateStr, pPrChangeEl
     );
@@ -734,35 +704,6 @@ function serializePPrWithParaRevisionMarker(
   }
 
   return serializeToXml(effectivePPr);
-}
-
-/**
- * Build a `<w:pPrChange>` Element from a pPr DOM element.
- *
- * The child `<w:pPr>` conforms to CT_PPrBase — it excludes w:rPr, w:sectPr,
- * w:rPrChange, and w:pPrChange.
- */
-function buildPPrChangeElement(
-  pPr: Element | null,
-  author: string,
-  dateStr: string,
-  revState: RevisionIdState
-): Element {
-  const id = allocateRevisionId(revState);
-  const EXCLUDED = new Set(['w:rPr', 'w:rPrChange', 'w:pPrChange', 'w:sectPr']);
-  const pPrChange = createEl('w:pPrChange', {
-    'w:id': String(id),
-    'w:author': author,
-    'w:date': dateStr,
-  });
-  const oldPPr = createEl('w:pPr');
-  if (pPr) {
-    for (const child of childElements(pPr)) {
-      if (!EXCLUDED.has(child.tagName)) oldPPr.appendChild(child.cloneNode(true) as Element);
-    }
-  }
-  pPrChange.appendChild(oldPPr);
-  return pPrChange;
 }
 
 /**
@@ -1128,8 +1069,10 @@ function wrapWithIns(
   dateStr: string,
   revState: RevisionIdState
 ): string {
-  const id = allocateRevisionId(revState);
-  return `<w:ins w:id="${id}" w:author="${escapeXmlAttr(author)}" w:date="${dateStr}">${content}</w:ins>`;
+  return wrapSerializedContentWithIns(
+    content,
+    createRevisionContext({ author, date: dateStr, idState: revState }),
+  );
 }
 
 /**
@@ -1141,12 +1084,10 @@ function wrapWithDel(
   dateStr: string,
   revState: RevisionIdState
 ): string {
-  const id = allocateRevisionId(revState);
-  // For deletions, convert w:t to w:delText and w:instrText to w:delInstrText
-  const delContent = content
-    .replace(/<w:t([^>]*)>([^<]*)<\/w:t>/g, '<w:delText$1>$2</w:delText>')
-    .replace(/<w:instrText([^>]*)>([^<]*)<\/w:instrText>/g, '<w:delInstrText$1>$2</w:delInstrText>');
-  return `<w:del w:id="${id}" w:author="${escapeXmlAttr(author)}" w:date="${dateStr}">${delContent}</w:del>`;
+  return wrapSerializedContentWithDel(
+    content,
+    createRevisionContext({ author, date: dateStr, idState: revState }),
+  );
 }
 
 /**
@@ -1162,10 +1103,7 @@ function wrapWithMoveFrom(
   const ids = getMoveRangeIds(revState, moveName);
   const moveId = allocateRevisionId(revState);
 
-  // Convert w:t to w:delText and w:instrText to w:delInstrText for moved-from content
-  const delContent = content
-    .replace(/<w:t([^>]*)>([^<]*)<\/w:t>/g, '<w:delText$1>$2</w:delText>')
-    .replace(/<w:instrText([^>]*)>([^<]*)<\/w:instrText>/g, '<w:delInstrText$1>$2</w:delInstrText>');
+  const delContent = convertSerializedDeletionContent(content);
 
   return (
     `<w:moveFromRangeStart w:id="${ids.sourceRangeId}" w:name="${moveName}" w:author="${escapeXmlAttr(author)}" w:date="${dateStr}"/>` +
@@ -1221,7 +1159,13 @@ function buildFormatChangeRun(
       }
     }
 
-    // Add rPrChange with old properties (wrapped in w:rPr per OOXML spec)
+    // Add rPrChange with old properties (wrapped in w:rPr per OOXML spec).
+    // Kept as the original per-child serialization (NOT delegated to
+    // buildRPrChangeElement) to preserve byte-identical output: xmldom emits
+    // inline `xmlns:w="..."` declarations when serializing detached children,
+    // and downstream consumers may pin on that exact serialized form. The
+    // DOM-aware buildRPrChangeElement helper exists for new primitive code
+    // paths (#136 onward).
     const formatChange = group.atoms[0]?.formatChange;
     if (formatChange?.oldRunProperties) {
       const id = allocateRevisionId(revState);
@@ -1229,7 +1173,7 @@ function buildFormatChangeRun(
         `<w:rPrChange w:id="${id}" w:author="${escapeXmlAttr(author)}" w:date="${dateStr}">`
       );
       parts.push('<w:rPr>');
-      for (const child of childElements(formatChange.oldRunProperties!)) {
+      for (const child of childElements(formatChange.oldRunProperties)) {
         parts.push(serializeToXml(child));
       }
       parts.push('</w:rPr>');
@@ -1515,17 +1459,6 @@ function escapeXmlText(text: string): string {
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;');
-}
-
-/**
- * Escape XML attribute value.
- */
-function escapeXmlAttr(text: string): string {
-  return text
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
 }
 
 /**

--- a/packages/docx-core/src/index.ts
+++ b/packages/docx-core/src/index.ts
@@ -249,3 +249,19 @@ export * from './footnotes.js';
 
 // Re-export primitives (editing, DOM helpers, document operations)
 export * from './primitives/index.js';
+export {
+  allocateRevisionId,
+  buildPPrChangeElement,
+  buildRPrChangeElement,
+  createRevisionContext,
+  createRevisionIdState,
+  escapeXmlAttr,
+  formatDate,
+  wrapElementWithDel,
+  wrapElementWithIns,
+} from './primitives/track-changes-emitter.js';
+export type {
+  RevisionContext,
+  RevisionContextOptions,
+  RevisionIdState,
+} from './primitives/track-changes-emitter.js';

--- a/packages/docx-core/src/primitives/track-changes-emitter.test.ts
+++ b/packages/docx-core/src/primitives/track-changes-emitter.test.ts
@@ -1,0 +1,174 @@
+import { XMLSerializer } from '@xmldom/xmldom';
+import { describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { childElements } from './dom-helpers.js';
+import { OOXML } from './namespaces.js';
+import { parseXml } from './xml.js';
+import {
+  allocateRevisionId,
+  buildPPrChangeElement,
+  buildRPrChangeElement,
+  createRevisionContext,
+  createRevisionIdState,
+  wrapElementWithDel,
+  wrapElementWithIns,
+} from './track-changes-emitter.js';
+
+const test = testAllure.epic('Document Comparison').withLabels({
+  feature: 'Track Changes Emitter',
+});
+
+function parseFragment(fragment: string): Element {
+  const doc = parseXml(
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+      `<root xmlns:w="${OOXML.W_NS}">${fragment}</root>`,
+  );
+  const element = childElements(doc.documentElement)[0];
+  if (!element) throw new Error('missing fragment root');
+  return element;
+}
+
+function serialize(element: Element): string {
+  return new XMLSerializer().serializeToString(element);
+}
+
+describe('track-changes-emitter', () => {
+  test('wrapElementWithIns emits a valid w:ins wrapper', async ({ given, when, then }: AllureBddContext) => {
+    let run: Element;
+    let serialized: string;
+
+    await given('a run element and a shared revision context', () => {
+      run = parseFragment('<w:r><w:t>Hello</w:t></w:r>');
+    });
+
+    await when('wrapElementWithIns wraps the run', () => {
+      serialized = serialize(
+        wrapElementWithIns(
+          run,
+          createRevisionContext({
+            author: 'Comparison',
+            date: '2026-05-03T14:15:16Z',
+            idState: createRevisionIdState(),
+          }),
+        ),
+      );
+    });
+
+    await then('the serialized wrapper includes the tracked-change metadata and content', () => {
+      expect(serialized).toContain('<w:ins ');
+      expect(serialized).toContain('w:id="1"');
+      expect(serialized).toContain('w:author="Comparison"');
+      expect(serialized).toContain('w:date="2026-05-03T14:15:16Z"');
+      expect(serialized).toContain('<w:r><w:t>Hello</w:t></w:r>');
+    });
+  });
+
+  test('wrapElementWithDel converts text and field instruction descendants', async ({ given, when, then }: AllureBddContext) => {
+    let run: Element;
+    let serialized: string;
+
+    await given('a run containing both visible text and field instructions', () => {
+      run = parseFragment(
+        '<w:r><w:t xml:space="preserve"> Hello </w:t><w:instrText>PAGE</w:instrText></w:r>',
+      );
+    });
+
+    await when('wrapElementWithDel wraps the run', () => {
+      serialized = serialize(
+        wrapElementWithDel(
+          run,
+          createRevisionContext({
+            author: 'Comparison',
+            date: '2026-05-03T14:15:16Z',
+            idState: createRevisionIdState(),
+          }),
+        ),
+      );
+    });
+
+    await then('deletion-specific text tags are emitted', () => {
+      expect(serialized).toContain('<w:del ');
+      expect(serialized).toContain('<w:delText xml:space="preserve"> Hello </w:delText>');
+      expect(serialized).toContain('<w:delInstrText>PAGE</w:delInstrText>');
+      expect(serialized).not.toContain('<w:t');
+      expect(serialized).not.toContain('<w:instrText');
+    });
+  });
+
+  test('RevisionIdState allocates monotonically increasing unique IDs', async ({ given, when, then }: AllureBddContext) => {
+    let ids: number[];
+
+    await given('a fresh revision ID state', () => {
+      ids = [];
+    });
+
+    await when('multiple IDs are allocated from the shared state', () => {
+      const state = createRevisionIdState();
+      ids = [allocateRevisionId(state), allocateRevisionId(state), allocateRevisionId(state)];
+    });
+
+    await then('each allocated ID is unique and increasing', () => {
+      expect(ids).toEqual([1, 2, 3]);
+      expect(new Set(ids).size).toBe(3);
+    });
+  });
+
+  test('buildPPrChangeElement snapshots prior paragraph properties in CT_PPrBase form', async ({ given, when, then }: AllureBddContext) => {
+    let pPr: Element;
+    let serialized: string;
+
+    await given('a paragraph properties element with paragraph and run properties', () => {
+      pPr = parseFragment(
+        '<w:pPr><w:spacing w:before="120"/><w:rPr><w:b/></w:rPr><w:sectPr/></w:pPr>',
+      );
+    });
+
+    await when('buildPPrChangeElement snapshots the previous state', () => {
+      serialized = serialize(
+        buildPPrChangeElement(
+          pPr,
+          createRevisionContext({
+            author: 'Comparison',
+            date: '2026-05-03T14:15:16Z',
+            idState: createRevisionIdState(),
+          }),
+        ),
+      );
+    });
+
+    await then('the change element contains only valid prior paragraph property children', () => {
+      expect(serialized).toContain('<w:pPrChange ');
+      expect(serialized).toContain('<w:pPr><w:spacing w:before="120"/></w:pPr>');
+      expect(serialized).not.toContain('<w:rPr>');
+      expect(serialized).not.toContain('<w:sectPr');
+    });
+  });
+
+  test('buildRPrChangeElement snapshots prior run properties without nested rPrChange', async ({ given, when, then }: AllureBddContext) => {
+    let rPr: Element;
+    let serialized: string;
+
+    await given('a run properties element that already contains a nested rPrChange', () => {
+      rPr = parseFragment('<w:rPr><w:b/><w:rPrChange w:id="99"/></w:rPr>');
+    });
+
+    await when('buildRPrChangeElement snapshots the previous state', () => {
+      serialized = serialize(
+        buildRPrChangeElement(
+          rPr,
+          createRevisionContext({
+            author: 'Comparison',
+            date: '2026-05-03T14:15:16Z',
+            idState: createRevisionIdState(),
+          }),
+        ),
+      );
+    });
+
+    await then('the generated wrapper contains the old run properties inside a single w:rPr', () => {
+      expect(serialized).toContain('<w:rPrChange ');
+      expect(serialized).toContain('<w:rPr><w:b/></w:rPr>');
+      expect(serialized).not.toContain('w:rPrChange w:id="99"');
+    });
+  });
+});

--- a/packages/docx-core/src/primitives/track-changes-emitter.ts
+++ b/packages/docx-core/src/primitives/track-changes-emitter.ts
@@ -1,0 +1,240 @@
+import { parseXml } from './xml.js';
+import { childElements, createWmlElement, renameElement } from './dom-helpers.js';
+
+const SYNTHETIC_DOC = parseXml(
+  '<root xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"/>',
+);
+
+const EXCLUDED_PPR_CHANGE_CHILDREN = new Set(['w:rPr', 'w:rPrChange', 'w:pPrChange', 'w:sectPr']);
+const EXCLUDED_RPR_CHANGE_CHILDREN = new Set(['w:rPrChange']);
+
+/**
+ * State for allocating monotonically increasing revision IDs.
+ *
+ * `moveRangeIds` exists so comparison-time emitters can reserve paired source
+ * and destination IDs for move ranges while sharing the same counter.
+ */
+export interface RevisionIdState {
+  nextId: number;
+  moveRangeIds: Map<string, { sourceRangeId: number; destRangeId: number }>;
+}
+
+/**
+ * Create a revision ID allocator.
+ *
+ * @param startId - First ID to allocate. Defaults to `1`.
+ */
+export function createRevisionIdState(startId: number = 1): RevisionIdState {
+  return {
+    nextId: startId,
+    moveRangeIds: new Map(),
+  };
+}
+
+/**
+ * Allocate the next revision ID from a shared state object.
+ */
+export function allocateRevisionId(state: RevisionIdState): number {
+  return state.nextId++;
+}
+
+/**
+ * Serialized metadata shared by tracked-change emitters.
+ */
+export interface RevisionContext {
+  author: string;
+  date: string;
+  idState: RevisionIdState;
+}
+
+/**
+ * Options for constructing a revision context.
+ */
+export interface RevisionContextOptions {
+  author: string;
+  date?: Date | string;
+  idState?: RevisionIdState;
+}
+
+/**
+ * Format a revision timestamp as OOXML-friendly ISO 8601.
+ */
+export function formatDate(date: Date): string {
+  return date.toISOString().replace(/\.\d{3}Z$/, 'Z');
+}
+
+/**
+ * Escape XML attribute text used in serialized revision markup.
+ */
+export function escapeXmlAttr(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/**
+ * Create a reusable revision context for tracked-change emission.
+ */
+export function createRevisionContext(options: RevisionContextOptions): RevisionContext {
+  const { author, date, idState = createRevisionIdState() } = options;
+  return {
+    author,
+    date: typeof date === 'string' ? date : formatDate(date ?? new Date()),
+    idState,
+  };
+}
+
+/**
+ * Wrap an xmldom element in `<w:ins>`.
+ *
+ * The source element is cloned; the original DOM node is left untouched.
+ */
+export function wrapElementWithIns(element: Element, ctx: RevisionContext): Element {
+  const wrapper = createRevisionWrapperElement(getOwnerDocument(element), 'ins', ctx);
+  wrapper.appendChild(element.cloneNode(true));
+  return wrapper;
+}
+
+/**
+ * Wrap an xmldom element in `<w:del>`.
+ *
+ * Any descendant `<w:t>` and `<w:instrText>` nodes are converted to the OOXML
+ * deletion equivalents before the cloned element is appended.
+ */
+export function wrapElementWithDel(element: Element, ctx: RevisionContext): Element {
+  const wrapper = createRevisionWrapperElement(getOwnerDocument(element), 'del', ctx);
+  const cloned = normalizeDeletionElement(element.cloneNode(true) as Element);
+  wrapper.appendChild(cloned);
+  return wrapper;
+}
+
+/**
+ * Build a `<w:pPrChange>` wrapper containing the previous paragraph properties.
+ *
+ * The nested snapshot excludes children that are not valid in `CT_PPrBase`.
+ */
+export function buildPPrChangeElement(oldPPr: Element | null, ctx: RevisionContext): Element {
+  const pPrChange = createWmlElement(
+    getOwnerDocument(oldPPr),
+    'pPrChange',
+    revisionAttributes(ctx),
+  );
+  const previousPPr = createWmlElement(getOwnerDocument(oldPPr), 'pPr');
+
+  if (oldPPr) {
+    for (const child of childElements(oldPPr)) {
+      if (!EXCLUDED_PPR_CHANGE_CHILDREN.has(child.tagName)) {
+        previousPPr.appendChild(child.cloneNode(true));
+      }
+    }
+  }
+
+  pPrChange.appendChild(previousPPr);
+  return pPrChange;
+}
+
+/**
+ * Build a `<w:rPrChange>` wrapper containing the previous run properties.
+ *
+ * The nested snapshot excludes any existing `w:rPrChange` child. This filtering
+ * is intentional: OOXML does not permit recursively nested `w:rPrChange` (a
+ * change-of-a-change is undefined), so the helper drops it. Note this is a
+ * stricter contract than the legacy reconstructor's per-child loop, which
+ * would have passed a nested `w:rPrChange` through verbatim. The reconstructor
+ * still uses its own per-child path; this helper is for new primitive code
+ * (#136 onward).
+ */
+export function buildRPrChangeElement(oldRPr: Element | null, ctx: RevisionContext): Element {
+  const rPrChange = createWmlElement(
+    getOwnerDocument(oldRPr),
+    'rPrChange',
+    revisionAttributes(ctx),
+  );
+  const previousRPr = createWmlElement(getOwnerDocument(oldRPr), 'rPr');
+
+  if (oldRPr) {
+    for (const child of childElements(oldRPr)) {
+      if (!EXCLUDED_RPR_CHANGE_CHILDREN.has(child.tagName)) {
+        previousRPr.appendChild(child.cloneNode(true));
+      }
+    }
+  }
+
+  rPrChange.appendChild(previousRPr);
+  return rPrChange;
+}
+
+/**
+ * Wrap serialized OOXML content in a `<w:ins>` element.
+ *
+ * This keeps the reconstructor on its string-based emission path while sharing
+ * revision metadata handling with the DOM-aware helpers above.
+ */
+export function wrapSerializedContentWithIns(content: string, ctx: RevisionContext): string {
+  return `${createSerializedRevisionOpenTag('w:ins', ctx)}${content}</w:ins>`;
+}
+
+/**
+ * Wrap serialized OOXML content in a `<w:del>` element.
+ *
+ * Visible text nodes are rewritten to their deletion-tag equivalents before
+ * the wrapper is serialized.
+ */
+export function wrapSerializedContentWithDel(content: string, ctx: RevisionContext): string {
+  return `${createSerializedRevisionOpenTag('w:del', ctx)}${convertSerializedDeletionContent(content)}</w:del>`;
+}
+
+/**
+ * Convert serialized run content from insertion-style text tags to deletion
+ * equivalents (`w:t` -> `w:delText`, `w:instrText` -> `w:delInstrText`).
+ */
+export function convertSerializedDeletionContent(content: string): string {
+  return content
+    .replace(/<w:t([^>]*)>([^<]*)<\/w:t>/g, '<w:delText$1>$2</w:delText>')
+    .replace(/<w:instrText([^>]*)>([^<]*)<\/w:instrText>/g, '<w:delInstrText$1>$2</w:delInstrText>');
+}
+
+function getOwnerDocument(element: Element | null): Document {
+  return element?.ownerDocument ?? SYNTHETIC_DOC;
+}
+
+function revisionAttributes(ctx: RevisionContext): Record<string, string> {
+  return {
+    'w:id': String(allocateRevisionId(ctx.idState)),
+    'w:author': ctx.author,
+    'w:date': ctx.date,
+  };
+}
+
+function createRevisionWrapperElement(
+  doc: Document,
+  tag: 'ins' | 'del',
+  ctx: RevisionContext,
+): Element {
+  return createWmlElement(doc, tag, revisionAttributes(ctx));
+}
+
+function createSerializedRevisionOpenTag(
+  tagName: 'w:ins' | 'w:del',
+  ctx: RevisionContext,
+): string {
+  const id = allocateRevisionId(ctx.idState);
+  return `<${tagName} w:id="${id}" w:author="${escapeXmlAttr(ctx.author)}" w:date="${ctx.date}">`;
+}
+
+function normalizeDeletionElement(element: Element): Element {
+  for (const child of childElements(element)) {
+    normalizeDeletionElement(child);
+  }
+
+  if (element.tagName === 'w:t') {
+    return renameElement(element, 'w:delText');
+  }
+  if (element.tagName === 'w:instrText') {
+    return renameElement(element, 'w:delInstrText');
+  }
+
+  return element;
+}


### PR DESCRIPTION
## Summary

Foundation PR for #120. Publishes `packages/docx-core/src/primitives/track-changes-emitter.ts` — a DOM-aware tracked-change emitter module that primitives in #136–#143 will import.

Until now, tracked-change emission lived exclusively inside `documentReconstructor.ts` and operated on serialized strings. Primitives that work with xmldom Element nodes had no API to call. This PR adds DOM-aware variants and exposes them via `@usejunior/docx-core`'s public surface, while leaving the reconstructor's serialized output **byte-identical** to pre-PR.

## What's in the new module

| Export | Purpose |
|---|---|
| `wrapElementWithIns(el, ctx)` | DOM-aware `<w:ins>` wrapper; clones input |
| `wrapElementWithDel(el, ctx)` | DOM-aware `<w:del>` wrapper; performs `w:t→w:delText`, `w:instrText→w:delInstrText` conversion via `renameElement` (preserves `xml:space="preserve"` and all attributes) |
| `buildPPrChangeElement(oldPPr, ctx)` | `<w:pPrChange>` with prior-pPr snapshot, filtered to ECMA-376 CT_PPrBase |
| `buildRPrChangeElement(oldRPr, ctx)` | `<w:rPrChange>` with prior-rPr snapshot, filtered to drop nested rPrChange |
| `createRevisionContext({ author, date?, idState? })` | Factory for the value passed to all emitters |
| `RevisionIdState`, `createRevisionIdState`, `allocateRevisionId` | Shared monotonic ID counter |
| `wrapSerializedContentWithIns/Del`, `convertSerializedDeletionContent` | String-based variants the reconstructor delegates to |
| `escapeXmlAttr`, `formatDate` | Re-exported from the new module (moved from reconstructor) |

5 BDD tests (testAllure framework) in `track-changes-emitter.test.ts`.

## Critical correctness property — byte-identical reconstructor output

The reconstructor's serialized output must not change in this PR; existing golden tests + 1102 unit tests stay green.

Initial implementation routed the rPrChange emission path through `buildRPrChangeElement`, which broke byte-identity. **Codex peer review caught this with a concrete repro:**

```
pre-PR:  <w:rPrChange...><w:rPr><w:i xmlns:w="..."/></w:rPr></w:rPrChange>
draft:   <w:rPrChange...><w:rPr><w:i/></w:rPr></w:rPrChange>
```

xmldom emits inline `xmlns:w` declarations when serializing detached children, but not when those children are inside a parent context that already declares the namespace. The fix: revert the reconstructor's rPrChange path to its original per-child loop. The DOM-aware `buildRPrChangeElement` stays in the new module for new primitive code (#136+) but is not used by the reconstructor.

Additionally, `buildRPrChangeElement` filters nested `w:rPrChange` (per OOXML — change-of-a-change is undefined). The legacy per-child loop in the reconstructor would have passed nested rPrChange through verbatim. This stricter contract is documented in the helper's JSDoc as intentional. The reconstructor is unaffected because it doesn't call the helper for this case.

## Peer review

| Reviewer | Finding | Resolution |
|---|---|---|
| Gemini | LGTM. Validated serialization fidelity, `renameElement` attribute preservation, CT_PPrBase exclusion set, `cloneNode(true)` non-mutation, `SYNTHETIC_DOC` namespace safety | None required |
| Codex | **HIGH**: rPrChange refactor not byte-identical (xmlns:w drop) | Reverted reconstructor's rPrChange path to original per-child loop |
| Codex | **HIGH**: `buildRPrChangeElement` filters nested rPrChange — behavior change vs legacy | Documented as intentional in JSDoc; reconstructor's behavior unaffected |
| Codex | LGTM on `wrapElementWithDel` cloning, `renameElement`, pPrChange exclusion set, public API surface | — |

## Verification

```bash
npm run build -w @usejunior/docx-core    # clean
npm run lint -w @usejunior/docx-core     # clean
npm run test:run -w @usejunior/docx-core # 1102 passed, 1 skipped — no regressions
```

## What's not in this PR (sub-issues that depend on this one)

- #136 [120.1] text.ts run edits — uses `wrapElementWithIns/Del`
- #137 [120.2] document.ts paragraph insertion — uses `wrapElementWithIns` + paragraph-mark marker
- #138 [120.3] comments.ts body anchors
- #139 [120.4] footnotes.ts reference + text
- #140 [120.5] layout.ts property changes — uses `buildPPrChangeElement` and analogues
- #141 [120.6] clear_formatting MCP tool — uses `buildRPrChangeElement`
- #142 [120.7] AI author config wiring
- #143 [120.8] regression suite

Per the local plan, these are sequential after this PR merges.

## Closes

- #135
