### PR TITLE
feat(docx-core): emit w:ins/w:del at write time in text.ts (#136)

### DIFF
--- a/packages/docx-core/src/index.ts
+++ b/packages/docx-core/src/index.ts
@@ -253,10 +253,12 @@ export {
   allocateRevisionId,
   buildPPrChangeElement,
   buildRPrChangeElement,
+  createRevisionContainer,
   createRevisionContext,
   createRevisionIdState,
   escapeXmlAttr,
   formatDate,
+  prepareElementForDeletion,
   wrapElementWithDel,
   wrapElementWithIns,
 } from './primitives/track-changes-emitter.js';

--- a/packages/docx-core/src/primitives/text.test.ts
+++ b/packages/docx-core/src/primitives/text.test.ts
@@ -1,8 +1,10 @@
+import { XMLSerializer } from '@xmldom/xmldom';
 import { describe, expect } from 'vitest';
 import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
 import { parseXml } from './xml.js';
 import { OOXML, W } from './namespaces.js';
 import { SafeDocxError } from './errors.js';
+import { createRevisionContext, createRevisionIdState } from './track-changes-emitter.js';
 import {
   getParagraphRuns,
   getParagraphText,
@@ -29,6 +31,16 @@ function firstParagraph(doc: Document): Element {
   const p = doc.getElementsByTagNameNS(W_NS, W.p).item(0);
   if (!p) throw new Error('missing paragraph');
   return p as Element;
+}
+
+function paragraphAt(doc: Document, index: number): Element {
+  const p = doc.getElementsByTagNameNS(W_NS, W.p).item(index);
+  if (!p) throw new Error(`missing paragraph at index ${index}`);
+  return p as Element;
+}
+
+function serialize(node: Node): string {
+  return new XMLSerializer().serializeToString(node);
 }
 
 // ── getParagraphRuns — field-code state machine ─────────────────────
@@ -666,6 +678,289 @@ describe('replaceParagraphTextRange', () => {
 
     await then('paragraph text reads "ABCXYZ"', () => {
       expect(getParagraphText(p)).toBe('ABCXYZ');
+    });
+  });
+});
+
+describe('replaceParagraphTextRange tracked-change emission', () => {
+  test('emits one insertion and one deletion wrapper for a tracked replacement', async ({ given, when, then }: AllureBddContext) => {
+    let p: Element;
+    let serialized: string;
+
+    await given('a paragraph and a shared revision context', () => {
+      const doc = makeDoc('<w:p><w:r><w:t>Hello world</w:t></w:r></w:p>');
+      p = firstParagraph(doc);
+    });
+
+    await when('the first word is replaced under tracked-change emission', () => {
+      replaceParagraphTextRange(
+        p,
+        0,
+        5,
+        'NEW',
+        createRevisionContext({
+          author: 'SafeDocX AI',
+          date: '2026-05-03T14:15:16Z',
+          idState: createRevisionIdState(),
+        }),
+      );
+      serialized = serialize(p);
+    });
+
+    await then('exactly one insertion and one deletion wrapper are emitted with revision metadata', () => {
+      const insertions = Array.from(p.getElementsByTagNameNS(W_NS, 'ins'));
+      const deletions = Array.from(p.getElementsByTagNameNS(W_NS, 'del'));
+      expect(insertions).toHaveLength(1);
+      expect(deletions).toHaveLength(1);
+
+      const insertion = insertions[0]!;
+      const deletion = deletions[0]!;
+      expect(insertion.getAttribute('w:id')).toBeTruthy();
+      expect(insertion.getAttribute('w:author')).toBe('SafeDocX AI');
+      expect(insertion.getAttribute('w:date')).toBe('2026-05-03T14:15:16Z');
+      expect(deletion.getAttribute('w:id')).toBeTruthy();
+      expect(deletion.getAttribute('w:author')).toBe('SafeDocX AI');
+      expect(deletion.getAttribute('w:date')).toBe('2026-05-03T14:15:16Z');
+      expect(serialized).toContain('<w:ins ');
+      expect(serialized).toContain('<w:del ');
+      expect(serialized).toContain('<w:r><w:t>NEW</w:t></w:r>');
+      expect(deletion.getElementsByTagNameNS(W_NS, 'delText')).toHaveLength(1);
+      expect(deletion.getElementsByTagNameNS(W_NS, W.t)).toHaveLength(0);
+    });
+  });
+
+  test('emits only an insertion wrapper for pure tracked insertion', async ({ given, when, then }: AllureBddContext) => {
+    let p: Element;
+
+    await given('a paragraph containing "HelloWorld"', () => {
+      const doc = makeDoc('<w:p><w:r><w:t>HelloWorld</w:t></w:r></w:p>');
+      p = firstParagraph(doc);
+    });
+
+    await when('text is inserted at a zero-length range under tracked changes', () => {
+      replaceParagraphTextRange(
+        p,
+        5,
+        5,
+        'NEW',
+        createRevisionContext({
+          author: 'SafeDocX AI',
+          date: '2026-05-03T14:15:16Z',
+          idState: createRevisionIdState(),
+        }),
+      );
+    });
+
+    await then('only one insertion wrapper is emitted', () => {
+      expect(getParagraphText(p)).toBe('HelloNEWWorld');
+      expect(p.getElementsByTagNameNS(W_NS, 'ins')).toHaveLength(1);
+      expect(p.getElementsByTagNameNS(W_NS, 'del')).toHaveLength(0);
+    });
+  });
+
+  test('emits only a deletion wrapper for pure tracked deletion', async ({ given, when, then }: AllureBddContext) => {
+    let p: Element;
+
+    await given('a paragraph containing "Hello world"', () => {
+      const doc = makeDoc('<w:p><w:r><w:t>Hello world</w:t></w:r></w:p>');
+      p = firstParagraph(doc);
+    });
+
+    await when('text is deleted with an empty replacement under tracked changes', () => {
+      replaceParagraphTextRange(
+        p,
+        0,
+        5,
+        '',
+        createRevisionContext({
+          author: 'SafeDocX AI',
+          date: '2026-05-03T14:15:16Z',
+          idState: createRevisionIdState(),
+        }),
+      );
+    });
+
+    await then('only one deletion wrapper is emitted', () => {
+      expect(getParagraphText(p)).toBe(' world');
+      expect(p.getElementsByTagNameNS(W_NS, 'ins')).toHaveLength(0);
+      expect(p.getElementsByTagNameNS(W_NS, 'del')).toHaveLength(1);
+    });
+  });
+
+  test('preserves per-run formatting inside tracked deletions spanning multiple runs', async ({ given, when, then }: AllureBddContext) => {
+    let p: Element;
+    let deletion: Element;
+
+    await given('a paragraph with bold, plain, and italic runs', () => {
+      const doc = makeDoc(
+        `<w:p>` +
+          `<w:r><w:rPr><w:b/></w:rPr><w:t>Hello</w:t></w:r>` +
+          `<w:r><w:t> </w:t></w:r>` +
+          `<w:r><w:rPr><w:i/></w:rPr><w:t>world</w:t></w:r>` +
+        `</w:p>`,
+      );
+      p = firstParagraph(doc);
+    });
+
+    await when('the full span is replaced under tracked changes', () => {
+      replaceParagraphTextRange(
+        p,
+        0,
+        11,
+        'New text',
+        createRevisionContext({
+          author: 'SafeDocX AI',
+          date: '2026-05-03T14:15:16Z',
+          idState: createRevisionIdState(),
+        }),
+      );
+      deletion = p.getElementsByTagNameNS(W_NS, 'del').item(0) as Element;
+    });
+
+    await then('the deletion wrapper keeps the original three runs and their run properties', () => {
+      const deletedRuns = Array.from(deletion.getElementsByTagNameNS(W_NS, W.r));
+      expect(deletedRuns).toHaveLength(3);
+      expect(deletedRuns[0]!.getElementsByTagNameNS(W_NS, W.b)).toHaveLength(1);
+      expect(deletedRuns[1]!.getElementsByTagNameNS(W_NS, W.rPr)).toHaveLength(0);
+      expect(deletedRuns[2]!.getElementsByTagNameNS(W_NS, W.i)).toHaveLength(1);
+      expect(Array.from(deletion.getElementsByTagNameNS(W_NS, 'delText')).map((el) => el.textContent)).toEqual([
+        'Hello',
+        ' ',
+        'world',
+      ]);
+    });
+  });
+
+  test('preserves run formatting on partial-run tracked deletion (split path)', async ({ given, when, then }: AllureBddContext) => {
+    let p: Element;
+    let deletion: Element;
+
+    await given('a paragraph with a single bold run carrying "HelloWorld"', () => {
+      const doc = makeDoc(
+        `<w:p><w:r><w:rPr><w:b/></w:rPr><w:t>HelloWorld</w:t></w:r></w:p>`,
+      );
+      p = firstParagraph(doc);
+    });
+
+    await when('a tracked replacement targets the middle slice [2, 8) — splitting the run', () => {
+      replaceParagraphTextRange(
+        p,
+        2,
+        8,
+        'X',
+        createRevisionContext({
+          author: 'SafeDocX AI',
+          date: '2026-05-03T14:15:16Z',
+          idState: createRevisionIdState(),
+        }),
+      );
+      deletion = p.getElementsByTagNameNS(W_NS, 'del').item(0) as Element;
+    });
+
+    await then('the deletion fragment retains the bold rPr from the original run', () => {
+      const deletedRuns = Array.from(deletion.getElementsByTagNameNS(W_NS, W.r));
+      expect(deletedRuns).toHaveLength(1);
+      expect(deletedRuns[0]!.getElementsByTagNameNS(W_NS, W.b)).toHaveLength(1);
+      expect(Array.from(deletion.getElementsByTagNameNS(W_NS, 'delText')).map((el) => el.textContent)).toEqual([
+        'lloWor',
+      ]);
+      expect(getParagraphText(p)).toBe('HeXld');
+    });
+  });
+
+  test('preserves legacy untracked behavior when revision context is omitted', async ({ given, when, then }: AllureBddContext) => {
+    let p: Element;
+    let serialized: string;
+
+    await given('a paragraph containing "Hello world"', () => {
+      const doc = makeDoc('<w:p><w:r><w:t>Hello world</w:t></w:r></w:p>');
+      p = firstParagraph(doc);
+    });
+
+    await when('the first word is replaced without a revision context', () => {
+      replaceParagraphTextRange(p, 0, 5, 'NEW');
+      serialized = serialize(p);
+    });
+
+    await then('the edit stays untracked and the visible text still changes', () => {
+      expect(getParagraphText(p)).toBe('NEW world');
+      expect(p.getElementsByTagNameNS(W_NS, 'ins')).toHaveLength(0);
+      expect(p.getElementsByTagNameNS(W_NS, 'del')).toHaveLength(0);
+      expect(serialized).not.toContain('<w:ins');
+      expect(serialized).not.toContain('<w:del');
+    });
+  });
+
+  test('allocates unique revision IDs across multiple tracked replacements in one document', async ({ given, when, then }: AllureBddContext) => {
+    let doc: Document;
+    let ids: number[];
+
+    await given('a document with two editable paragraphs and a shared revision state', () => {
+      doc = makeDoc(
+        `<w:p><w:r><w:t>Hello world</w:t></w:r></w:p>` +
+          `<w:p><w:r><w:t>Second line</w:t></w:r></w:p>`,
+      );
+      ids = [];
+    });
+
+    await when('two tracked replacements are applied with the same revision context', () => {
+      const ctx = createRevisionContext({
+        author: 'SafeDocX AI',
+        date: '2026-05-03T14:15:16Z',
+        idState: createRevisionIdState(),
+      });
+
+      replaceParagraphTextRange(paragraphAt(doc, 0), 0, 5, 'NEW', ctx);
+      replaceParagraphTextRange(paragraphAt(doc, 1), 0, 6, 'Other', ctx);
+
+      ids = [
+        ...Array.from(doc.getElementsByTagNameNS(W_NS, 'ins')),
+        ...Array.from(doc.getElementsByTagNameNS(W_NS, 'del')),
+      ].map((el) => Number(el.getAttribute('w:id')));
+    });
+
+    await then('all emitted insertion and deletion IDs are distinct', () => {
+      expect(ids).toHaveLength(4);
+      expect(new Set(ids).size).toBe(4);
+      expect(ids.slice().sort((a, b) => a - b)).toEqual([1, 2, 3, 4]);
+    });
+  });
+
+  test('preserves UNSAFE_CONTAINER_BOUNDARY refusal for tracked edits crossing a hyperlink boundary', async ({ given, when, then }: AllureBddContext) => {
+    let p: Element;
+
+    await given('a paragraph whose visible range spans from a hyperlink into plain paragraph content', () => {
+      const doc = makeDoc(
+        `<w:p>` +
+          `<w:hyperlink r:id="rId5"><w:r><w:t>Hello</w:t></w:r></w:hyperlink>` +
+          `<w:r><w:t> world</w:t></w:r>` +
+        `</w:p>`,
+      );
+      p = firstParagraph(doc);
+    });
+
+    await when('a tracked replacement crosses the hyperlink boundary', () => {
+      // captured for assertion
+    });
+
+    await then('the primitive throws UNSAFE_CONTAINER_BOUNDARY', () => {
+      try {
+        replaceParagraphTextRange(
+          p,
+          0,
+          6,
+          'NEW',
+          createRevisionContext({
+            author: 'SafeDocX AI',
+            date: '2026-05-03T14:15:16Z',
+            idState: createRevisionIdState(),
+          }),
+        );
+        expect.unreachable('Should have thrown');
+      } catch (e) {
+        expect(e).toBeInstanceOf(SafeDocxError);
+        expect((e as SafeDocxError).code).toBe('UNSAFE_CONTAINER_BOUNDARY');
+      }
     });
   });
 });

--- a/packages/docx-core/src/primitives/text.ts
+++ b/packages/docx-core/src/primitives/text.ts
@@ -1,5 +1,10 @@
 import { OOXML, W } from './namespaces.js';
 import { SafeDocxError } from './errors.js';
+import {
+  createRevisionContainer,
+  prepareElementForDeletion,
+  type RevisionContext,
+} from './track-changes-emitter.js';
 
 export type TextRun = {
   r: Element; // w:r
@@ -265,6 +270,10 @@ function cleanupEmptyRuns(parent: Node): void {
   }
 }
 
+function getRunVisibleLength(run: Element): number {
+  return getDirectContentElements(run).reduce((sum, child) => sum + visibleLengthForEl(child), 0);
+}
+
 export type AddRunProps = {
   // Additive or subtractive formatting.
   // Set to true to enable, false to explicitly disable/remove.
@@ -397,6 +406,7 @@ export function replaceParagraphTextRange(
   start: number,
   end: number,
   replacement: string | ReplacementPart[],
+  ctx?: RevisionContext,
 ): void {
   // Replace visible text in [start, end) in paragraph by operating on w:t nodes.
   // Strategy:
@@ -490,23 +500,53 @@ export function replaceParagraphTextRange(
   const insertBeforeNode = rangeEndRunEl.nextSibling;
 
   // Remove runs in [rangeStartRunEl, rangeEndRunEl] inclusive (only w:r elements).
+  const removedRuns: Element[] = [];
   let cur: Node | null = rangeStartRunEl;
   while (cur) {
     const nextNode: Node | null = cur.nextSibling as Node | null;
     if (cur.nodeType === 1 && isW(cur as Element, W.r)) {
-      (cur as Element).parentNode?.removeChild(cur);
+      const runEl = cur as Element;
+      runEl.parentNode?.removeChild(runEl);
+      if (getRunVisibleLength(runEl) > 0) {
+        removedRuns.push(runEl);
+      }
     }
     if (cur === rangeEndRunEl) break;
     cur = nextNode;
   }
 
-  // Insert replacement runs.
+  // Build replacement runs using the same formatting/template logic as the legacy path.
+  const replacementRuns: Element[] = [];
   for (const part of parts) {
     const tmpl = part.templateRun ?? templateRun;
     const newRun = cloneRunFormattingOnly(doc, tmpl);
     applyRunProps(doc, newRun, part.addRunProps, part.clearHighlight);
     appendTextToRun(doc, newRun, part.text);
-    parent.insertBefore(newRun, insertBeforeNode);
+    if (getRunVisibleLength(newRun) > 0) {
+      replacementRuns.push(newRun);
+    }
+  }
+
+  if (ctx) {
+    if (removedRuns.length > 0) {
+      const deletion = createRevisionContainer(doc, 'del', ctx);
+      for (const removedRun of removedRuns) {
+        deletion.appendChild(prepareElementForDeletion(removedRun));
+      }
+      parent.insertBefore(deletion, insertBeforeNode);
+    }
+
+    if (replacementRuns.length > 0) {
+      const insertion = createRevisionContainer(doc, 'ins', ctx);
+      for (const replacementRun of replacementRuns) {
+        insertion.appendChild(replacementRun);
+      }
+      parent.insertBefore(insertion, insertBeforeNode);
+    }
+  } else {
+    for (const replacementRun of replacementRuns) {
+      parent.insertBefore(replacementRun, insertBeforeNode);
+    }
   }
 
   cleanupEmptyRuns(parent);

--- a/packages/docx-core/src/primitives/track-changes-emitter.test.ts
+++ b/packages/docx-core/src/primitives/track-changes-emitter.test.ts
@@ -8,6 +8,7 @@ import {
   allocateRevisionId,
   buildPPrChangeElement,
   buildRPrChangeElement,
+  createRevisionContainer,
   createRevisionContext,
   createRevisionIdState,
   wrapElementWithDel,
@@ -92,6 +93,37 @@ describe('track-changes-emitter', () => {
       expect(serialized).toContain('<w:delInstrText>PAGE</w:delInstrText>');
       expect(serialized).not.toContain('<w:t');
       expect(serialized).not.toContain('<w:instrText');
+    });
+  });
+
+  test('createRevisionContainer allocates tracked-change metadata for caller-owned content', async ({ given, when, then }: AllureBddContext) => {
+    let doc: Document;
+    let serialized: string;
+
+    await given('a document and a shared revision context', () => {
+      doc = parseXml(`<?xml version="1.0" encoding="UTF-8"?><root xmlns:w="${OOXML.W_NS}"/>`);
+    });
+
+    await when('a deletion container is created for multi-run ownership', () => {
+      serialized = serialize(
+        createRevisionContainer(
+          doc,
+          'del',
+          createRevisionContext({
+            author: 'Comparison',
+            date: '2026-05-03T14:15:16Z',
+            idState: createRevisionIdState(),
+          }),
+        ),
+      );
+    });
+
+    await then('the wrapper includes revision metadata and no placeholder children', () => {
+      expect(serialized).toContain('<w:del ');
+      expect(serialized).toContain('w:id="1"');
+      expect(serialized).toContain('w:author="Comparison"');
+      expect(serialized).toContain('w:date="2026-05-03T14:15:16Z"');
+      expect(serialized).not.toContain('<w:r');
     });
   });
 

--- a/packages/docx-core/src/primitives/track-changes-emitter.ts
+++ b/packages/docx-core/src/primitives/track-changes-emitter.ts
@@ -87,12 +87,47 @@ export function createRevisionContext(options: RevisionContextOptions): Revision
 }
 
 /**
+ * Create a fresh tracked-change container (`<w:ins>` or `<w:del>`) into which
+ * the caller appends owned child nodes.
+ *
+ * Use this when wrapping multiple sibling elements under one revision marker.
+ * For single-element wrapping, prefer `wrapElementWithIns` / `wrapElementWithDel`.
+ */
+export function createRevisionContainer(
+  doc: Document,
+  kind: 'ins' | 'del',
+  ctx: RevisionContext,
+): Element {
+  return createRevisionWrapperElement(doc, kind, ctx);
+}
+
+/**
+ * Rewrite `<w:t>` → `<w:delText>` and `<w:instrText>` → `<w:delInstrText>`
+ * on the given element and all its descendants, for use inside a `<w:del>`
+ * container.
+ *
+ * **CALLERS MUST USE THE RETURN VALUE.** When the input element itself is a
+ * root `<w:t>` or `<w:instrText>`, this helper creates a renamed replacement
+ * node (you cannot rename a DOM element in place); the input element is
+ * detached from the tree and the new node is returned. Pattern:
+ *
+ *   const ready = prepareElementForDeletion(detachedElement);
+ *   wrapper.appendChild(ready);
+ *
+ * The element MUST already be detached from any parent. Calling on an
+ * attached element will leave the original tree in an inconsistent state.
+ */
+export function prepareElementForDeletion(element: Element): Element {
+  return normalizeDeletionElement(element);
+}
+
+/**
  * Wrap an xmldom element in `<w:ins>`.
  *
  * The source element is cloned; the original DOM node is left untouched.
  */
 export function wrapElementWithIns(element: Element, ctx: RevisionContext): Element {
-  const wrapper = createRevisionWrapperElement(getOwnerDocument(element), 'ins', ctx);
+  const wrapper = createRevisionContainer(getOwnerDocument(element), 'ins', ctx);
   wrapper.appendChild(element.cloneNode(true));
   return wrapper;
 }
@@ -104,8 +139,8 @@ export function wrapElementWithIns(element: Element, ctx: RevisionContext): Elem
  * deletion equivalents before the cloned element is appended.
  */
 export function wrapElementWithDel(element: Element, ctx: RevisionContext): Element {
-  const wrapper = createRevisionWrapperElement(getOwnerDocument(element), 'del', ctx);
-  const cloned = normalizeDeletionElement(element.cloneNode(true) as Element);
+  const wrapper = createRevisionContainer(getOwnerDocument(element), 'del', ctx);
+  const cloned = prepareElementForDeletion(element.cloneNode(true) as Element);
   wrapper.appendChild(cloned);
   return wrapper;
 }


### PR DESCRIPTION
## Summary

First per-primitive PR after the foundation #135 (#147). Migrates `packages/docx-core/src/primitives/text.ts` to optionally emit native OOXML revision markup at write time, using the helpers from #135.

`replaceParagraphTextRange` gains an optional `ctx?: RevisionContext` parameter. When provided, removed runs are wrapped in a single `<w:del>` and replacement runs in a single `<w:ins>` (one accept/reject per logical edit, matching Word's UX). When omitted, behavior is preserved.

## What changed

| File | Change |
|---|---|
| `text.ts` | `replaceParagraphTextRange` accepts optional `ctx`; emits `<w:del>` + `<w:ins>` when provided. New internal `getRunVisibleLength` helper for empty-run filtering. |
| `track-changes-emitter.ts` | Adds `createRevisionContainer(doc, kind, ctx)` for multi-element wrapping and `prepareElementForDeletion(element)` for in-place `w:t→w:delText` renaming. Strengthened JSDoc on `prepareElementForDeletion` to require callers to use the return value (renameElement creates a replacement node when input is a root `w:t`/`w:instrText`). |
| `index.ts` | Barrel re-exports both new helpers. |
| `text.test.ts` | +8 tracked-change tests. |
| `track-changes-emitter.test.ts` | +1 test for `createRevisionContainer`. |

Total: 5 files changed, 410 insertions, 6 deletions.

## Peer review

| Reviewer | Finding | Resolution |
|---|---|---|
| Gemini | Empty-run filter in no-ctx path is a slight behavior change | Codex confirmed `cleanupEmptyRuns()` already removes empty runs; final output unchanged |
| Gemini | Helpers missing from barrel export | **Fixed** — added `createRevisionContainer` + `prepareElementForDeletion` to `src/index.ts` |
| Gemini | JSDoc mutation warning could be stronger | **Fixed** — explicit "callers MUST use the return value" warning |
| Codex | `prepareElementForDeletion` is a footgun on root `<w:t>`/`<w:instrText>` (renameElement creates replacement node) | **Fixed** — JSDoc now explicitly documents the contract |
| Codex | Half-public helpers (exported from module but not barrel) | **Fixed** as above |
| Codex | Suggest partial-run-deletion test for split-path coverage | **Fixed** — added "preserves run formatting on partial-run tracked deletion (split path)" test |

Both reviewers confirmed the empty-run filter is a non-issue (no behavior change in final output), multi-run formatting preservation works correctly, the split-path through `splitRunAtVisibleOffset` cleanly hands off to the deletion wrapper, and emission order (`<w:del>` → `<w:ins>`) is correct.

## Verification

```bash
npm run build -w @usejunior/docx-core  # clean
npm run lint -w @usejunior/docx-core   # clean
npm run test:run -w @usejunior/docx-core
# Test Files  78 passed (78)
# Tests  1111 passed | 1 skipped (1112)
```

## What's not in this PR

- MCP tool `replace_text.ts` still calls `replaceParagraphTextRange` without a `ctx` — author/identity wiring lands in #142 [120.7].
- `w:rPrChange` for run formatting changes — that's a separate primitive path; this PR only covers text edits (`w:ins`/`w:del`).
- All other primitives (`document.ts`, `comments.ts`, etc.) — separate sub-issues #137–#141.

## Closes

- #136 ([120.1] of #120)