### PR TITLE
feat(docx-mcp): render comment ranges inline in read_file with milestone markers

### DIFF
--- a/packages/docx-core/src/primitives/document_view.ts
+++ b/packages/docx-core/src/primitives/document_view.ts
@@ -101,6 +101,15 @@ export type TableContext = {
   cell_para_count: number;  // Total paragraphs in this cell
 };
 
+export type DocumentViewCommentRange = {
+  startParagraphId: string;
+  endParagraphId: string;
+  startRunIndex?: number;
+  startCharOffset?: number;
+  endRunIndex?: number;
+  endCharOffset?: number;
+};
+
 export type DocumentViewComment = {
   id: number;
   author: string;
@@ -108,7 +117,27 @@ export type DocumentViewComment = {
   initials: string;
   text: string;
   replies: DocumentViewComment[];
+  range?: DocumentViewCommentRange;
 };
+
+export const INLINE_COMMENT_MARKER_RUNTIME = Symbol('inline_comment_marker_runtime');
+
+type InlineCommentMarkerRuntime = {
+  startVisibleOffset: number;
+  endVisibleOffset: number;
+  suppressInlineMarkers: boolean;
+};
+
+type DocumentViewCommentWithRuntime = DocumentViewComment & {
+  [INLINE_COMMENT_MARKER_RUNTIME]?: InlineCommentMarkerRuntime;
+};
+
+export type ToonCommentMarker = {
+  offset: number;
+  marker: string;
+};
+
+export type ToonCommentMarkerMap = Map<string, ToonCommentMarker[]>;
 
 export type DocumentViewNode = {
   id: string; // _bk_*
@@ -338,17 +367,206 @@ function headerStripFromText(params: { header: string; text: string }): string {
   return text;
 }
 
+// Matches the exact set of TOON inline formatting tags that emitFormattingTags() can emit:
+//   <b>, </b>, <i>, </i>, <u>, </u>, <highlight>, </highlight>,
+//   <a href="...">, </a>, <font ...>, </font>
+// Anything else in the form `<...>` is literal document text (e.g., `<Borrower>` placeholders
+// in legal templates) and must be counted as visible characters, not skipped as markup.
+const TOON_INLINE_TAG_RE = /^(?:<\/?(?:b|i|u|highlight)>|<\/(?:a|font)>|<(?:a|font)(?:\s[^>]*)?>)/;
+
+function toonTagLengthAt(text: string, i: number): number {
+  if (text[i] !== '<') return 0;
+  const match = TOON_INLINE_TAG_RE.exec(text.slice(i));
+  return match ? match[0].length : 0;
+}
+
+function countVisibleTextCharacters(text: string): number {
+  let visibleCount = 0;
+  for (let i = 0; i < text.length; i++) {
+    const tagLen = toonTagLengthAt(text, i);
+    if (tagLen > 0) {
+      i += tagLen - 1;
+      continue;
+    }
+    visibleCount++;
+  }
+  return visibleCount;
+}
+
+function findTaggedTextInsertionIndex(text: string, visibleOffset: number): number {
+  if (visibleOffset <= 0) return 0;
+
+  let visibleCount = 0;
+  for (let i = 0; i < text.length; i++) {
+    if (visibleCount === visibleOffset) return i;
+
+    const tagLen = toonTagLengthAt(text, i);
+    if (tagLen > 0) {
+      i += tagLen - 1;
+      continue;
+    }
+
+    visibleCount++;
+  }
+
+  return text.length;
+}
+
+function injectToonCommentMarkers(
+  text: string,
+  markers: readonly ToonCommentMarker[],
+): string {
+  if (markers.length === 0) return text;
+
+  let result = text;
+  for (const { offset, marker } of markers) {
+    const insertionIndex = findTaggedTextInsertionIndex(result, offset);
+    result = result.slice(0, insertionIndex) + marker + result.slice(insertionIndex);
+  }
+  return result;
+}
+
+type InlineCommentMarkerCandidate = {
+  id: number;
+  startParagraphId: string;
+  endParagraphId: string;
+  startParagraphIndex: number;
+  startOffset: number;
+  endOffset: number;
+};
+
+type InlineCommentMarkerGroup = {
+  closes: InlineCommentMarkerCandidate[];
+  opens: InlineCommentMarkerCandidate[];
+};
+
+function collectInlineCommentMarkerCandidates(
+  comments: readonly DocumentViewComment[],
+  paragraphIndexById: ReadonlyMap<string, number>,
+  candidates: InlineCommentMarkerCandidate[],
+): void {
+  for (const comment of comments) {
+    const runtime = (comment as DocumentViewCommentWithRuntime)[INLINE_COMMENT_MARKER_RUNTIME];
+    if (comment.range && runtime && !runtime.suppressInlineMarkers) {
+      candidates.push({
+        id: comment.id,
+        startParagraphId: comment.range.startParagraphId,
+        endParagraphId: comment.range.endParagraphId,
+        startParagraphIndex: paragraphIndexById.get(comment.range.startParagraphId) ?? Number.MAX_SAFE_INTEGER,
+        startOffset: runtime.startVisibleOffset,
+        endOffset: runtime.endVisibleOffset,
+      });
+    }
+
+    if (comment.replies.length > 0) {
+      collectInlineCommentMarkerCandidates(comment.replies, paragraphIndexById, candidates);
+    }
+  }
+}
+
+function compareInlineCommentCloseOrder(
+  left: InlineCommentMarkerCandidate,
+  right: InlineCommentMarkerCandidate,
+): number {
+  if (left.startParagraphIndex !== right.startParagraphIndex) {
+    return right.startParagraphIndex - left.startParagraphIndex;
+  }
+  if (left.startOffset !== right.startOffset) {
+    return right.startOffset - left.startOffset;
+  }
+  return right.id - left.id;
+}
+
+export function collectInlineCommentMarkers(
+  nodes: readonly DocumentViewNode[],
+): ToonCommentMarkerMap {
+  const paragraphIndexById = new Map<string, number>();
+  for (let index = 0; index < nodes.length; index++) {
+    paragraphIndexById.set(nodes[index]!.id, index);
+  }
+
+  const candidates: InlineCommentMarkerCandidate[] = [];
+  for (const node of nodes) {
+    if (node.comments && node.comments.length > 0) {
+      collectInlineCommentMarkerCandidates(node.comments, paragraphIndexById, candidates);
+    }
+  }
+
+  const groupedByParagraph = new Map<string, Map<number, InlineCommentMarkerGroup>>();
+  for (const candidate of candidates) {
+    const startOffsets = groupedByParagraph.get(candidate.startParagraphId) ?? new Map<number, InlineCommentMarkerGroup>();
+    const startGroup = startOffsets.get(candidate.startOffset) ?? { closes: [], opens: [] };
+    startGroup.opens.push(candidate);
+    startOffsets.set(candidate.startOffset, startGroup);
+    groupedByParagraph.set(candidate.startParagraphId, startOffsets);
+
+    const endOffsets = groupedByParagraph.get(candidate.endParagraphId) ?? new Map<number, InlineCommentMarkerGroup>();
+    const endGroup = endOffsets.get(candidate.endOffset) ?? { closes: [], opens: [] };
+    endGroup.closes.push(candidate);
+    endOffsets.set(candidate.endOffset, endGroup);
+    groupedByParagraph.set(candidate.endParagraphId, endOffsets);
+  }
+
+  const markersByParagraph = new Map<string, ToonCommentMarker[]>();
+  for (const [paragraphId, offsetGroups] of groupedByParagraph.entries()) {
+    const markers: ToonCommentMarker[] = [];
+    const sortedOffsets = Array.from(offsetGroups.keys()).sort((left, right) => right - left);
+    for (const offset of sortedOffsets) {
+      const group = offsetGroups.get(offset);
+      if (!group) continue;
+
+      const closes = [...group.closes].sort(compareInlineCommentCloseOrder);
+      const opens = [...group.opens].sort((left, right) => left.id - right.id);
+      const marker =
+        closes.map((comment) => `[cm-end:${comment.id}]`).join('') +
+        opens.map((comment) => `[cm-start:${comment.id}]`).join('');
+      if (!marker) continue;
+      markers.push({ offset, marker });
+    }
+
+    if (markers.length > 0) {
+      markersByParagraph.set(paragraphId, markers);
+    }
+  }
+
+  return markersByParagraph;
+}
+
 /**
  * Format a single toon data line for one DocumentViewNode.
  * Handles table-context-aware style (th/td) and header stripping.
  */
-export function formatToonDataLine(n: DocumentViewNode, options?: { compact?: boolean }): string {
+export function formatToonDataLine(
+  n: DocumentViewNode,
+  options?: { compact?: boolean; commentMarkers?: ToonCommentMarkerMap },
+): string {
   let text = n.tagged_text;
-  if (n.header) text = headerStripFromText({ header: n.header, text });
   let header = n.header;
+  let strippedPrefixVisibleLength = 0;
+
+  if (header) {
+    const strippedText = headerStripFromText({ header, text });
+    strippedPrefixVisibleLength = Math.max(
+      0,
+      countVisibleTextCharacters(text) - countVisibleTextCharacters(strippedText),
+    );
+    text = strippedText;
+  }
   if (header && !text) {
     text = header;
     header = '';
+    strippedPrefixVisibleLength = 0;
+  }
+
+  const commentMarkers = options?.commentMarkers?.get(n.id);
+  if (commentMarkers && commentMarkers.length > 0) {
+    text = injectToonCommentMarkers(
+      text,
+      commentMarkers.map(({ offset, marker }) => ({
+        offset: Math.max(0, offset - strippedPrefixVisibleLength),
+        marker,
+      })),
+    );
   }
 
   const tc = n.table_context;
@@ -462,6 +680,8 @@ export function formatToonCommentsEndnotesBlock(
 
 export function renderToon(nodes: DocumentViewNode[], options: { compact?: boolean } = {}): string {
   const lines: string[] = ['#SCHEMA id | list_label | header | style | text'];
+  const commentMarkers = collectInlineCommentMarkers(nodes);
+  const lineOptions = { ...options, commentMarkers };
 
   // Pre-scan: collect table marker info for #TABLE lines
   const tableInfo = collectTableMarkerInfo(nodes);
@@ -485,7 +705,7 @@ export function renderToon(nodes: DocumentViewNode[], options: { compact?: boole
       currentTableIndex = nodeTableIndex;
     }
 
-    lines.push(formatToonDataLine(n, options));
+    lines.push(formatToonDataLine(n, lineOptions));
     lines.push(...formatToonCommentLines(n));
   }
 

--- a/packages/docx-core/src/primitives/document_view.ts
+++ b/packages/docx-core/src/primitives/document_view.ts
@@ -160,6 +160,18 @@ export type DocumentViewNode = {
   body_run_formatting: RunFormatting | null;
   table_context?: TableContext;
   comments?: DocumentViewComment[];
+  /**
+   * Number of visible characters stripped from the head of the raw paragraph text when
+   * extracting a manual list label (and trimming the trailing whitespace). Used by the
+   * inline-comment-marker injector to translate run/offset positions (which are computed
+   * against the FULL paragraph visible text by `getComments()`) into positions within
+   * `tagged_text` (which has the label stripped).
+   *
+   * Auto-numbered list paragraphs do NOT have their text stripped — their label lives in
+   * the `list_label` field separately — so this stays 0 for them. Run-in header stripping
+   * is handled separately at format time and is not included here.
+   */
+  visible_offset_correction?: number;
 };
 
 function fingerprintKey(fp: FormattingFingerprint): string {
@@ -369,10 +381,16 @@ function headerStripFromText(params: { header: string; text: string }): string {
 
 // Matches the exact set of TOON inline formatting tags that emitFormattingTags() can emit:
 //   <b>, </b>, <i>, </i>, <u>, </u>, <highlight>, </highlight>,
-//   <a href="...">, </a>, <font ...>, </font>
+//   <a href="...">, </a>, <font ATTR=...>, </font>
 // Anything else in the form `<...>` is literal document text (e.g., `<Borrower>` placeholders
-// in legal templates) and must be counted as visible characters, not skipped as markup.
-const TOON_INLINE_TAG_RE = /^(?:<\/?(?:b|i|u|highlight)>|<\/(?:a|font)>|<(?:a|font)(?:\s[^>]*)?>)/;
+// in legal templates, or stylesheet samples like `<font>`) and must be counted as visible
+// characters, not skipped as markup.
+//
+// Note the opening `a`/`font` alternative requires `\s[^>]*` (mandatory attributes), because
+// the formatter only emits `<a href="...">` and `<font ATTR=...>` — never bare `<a>` or
+// `<font>`. Allowing the bare forms would cause literal `<a>` / `<font>` in document text to
+// be silently skipped, shifting marker positions.
+const TOON_INLINE_TAG_RE = /^(?:<\/?(?:b|i|u|highlight)>|<\/(?:a|font)>|<(?:a|font)\s[^>]*>)/;
 
 function toonTagLengthAt(text: string, i: number): number {
   if (text[i] !== '<') return 0;
@@ -560,10 +578,18 @@ export function formatToonDataLine(
 
   const commentMarkers = options?.commentMarkers?.get(n.id);
   if (commentMarkers && commentMarkers.length > 0) {
+    // Comment marker offsets are computed against the FULL paragraph visible text (raw
+    // run/char counting in `getComments()`). To translate to `tagged_text` positions we
+    // subtract:
+    //  1. `visible_offset_correction` — chars stripped at build time when extracting the
+    //     manual list label and trimming following whitespace.
+    //  2. `strippedPrefixVisibleLength` — chars stripped at format time by the run-in-header
+    //     extraction above.
+    const totalCorrection = (n.visible_offset_correction ?? 0) + strippedPrefixVisibleLength;
     text = injectToonCommentMarkers(
       text,
       commentMarkers.map(({ offset, marker }) => ({
-        offset: Math.max(0, offset - strippedPrefixVisibleLength),
+        offset: Math.max(0, offset - totalCorrection),
         marker,
       })),
     );
@@ -1268,6 +1294,11 @@ export function buildNodesForDocumentView(params: {
       tagged = injectFootnoteMarkers(tagged, fnMarkers);
     }
 
+    // Visible characters stripped from the raw paragraph head when extracting a manual
+    // label (label text + trailing whitespace). Auto-numbered paragraphs leave fullText
+    // intact, so this is 0 for them.
+    const visibleOffsetCorrection = isAutoNumbered ? 0 : Math.max(0, fullText.length - cleanTextNoLabel.length);
+
     const node: DocumentViewNode = {
       id,
       list_label: labelString,
@@ -1277,6 +1308,7 @@ export function buildNodesForDocumentView(params: {
 
       clean_text: cleanTextNoLabel,
       tagged_text: tagged,
+      visible_offset_correction: visibleOffsetCorrection > 0 ? visibleOffsetCorrection : undefined,
       list_metadata: {
         list_level: listLevel,
         label_type: labelType,

--- a/packages/docx-mcp/docs/tool-reference.generated.md
+++ b/packages/docx-mcp/docs/tool-reference.generated.md
@@ -20,7 +20,7 @@ Read document content (DOCX or Google Doc). Output is token-limited (~14k tokens
 | `limit` | `number` | no | Max paragraphs to return. When omitted, output is token-limited to ~14k tokens with pagination. |
 | `node_ids` | `array<string>` | no |  |
 | `format` | `enum("toon", "json", "simple")` | no |  |
-| `comment_rendering` | `enum("none", "paragraph_notes", "endnotes")` | no | How to render comments in read_file output. Use "paragraph_notes" (default) to emit paragraph-local comments and replies, "endnotes" to collect threaded comments into a trailing #COMMENTS block in TOON output, or "none" for the legacy output with no comment rendering. |
+| `comment_rendering` | `enum("none", "paragraph_notes", "endnotes", "inline_markers")` | no | How to render comments in read_file output. Use "paragraph_notes" (default) for paragraph-local comment threads, "inline_markers" to add `[cm-start:N]`/`[cm-end:N]` milestones in TOON output (combined with the thread blocks), "endnotes" to collect threaded comments into a trailing #COMMENTS block in TOON output, or "none" for the legacy output with no comment rendering. |
 | `show_formatting` | `boolean` | no | When true (default), shows inline formatting tags (<b>, <i>, <u>, <highlighting>, <a>). When false, emits plain text with no inline tags. |
 
 ## `grep`

--- a/packages/docx-mcp/src/tool_catalog.ts
+++ b/packages/docx-mcp/src/tool_catalog.ts
@@ -41,10 +41,10 @@ export const SAFE_DOCX_TOOL_CATALOG = [
       node_ids: z.array(z.string()).optional(),
       format: z.enum(['toon', 'json', 'simple']).optional(),
       comment_rendering: z
-        .enum(['none', 'paragraph_notes', 'endnotes'])
+        .enum(['none', 'paragraph_notes', 'endnotes', 'inline_markers'])
         .optional()
         .describe(
-          'How to render comments in read_file output. Use "paragraph_notes" (default) to emit paragraph-local comments and replies, "endnotes" to collect threaded comments into a trailing #COMMENTS block in TOON output, or "none" for the legacy output with no comment rendering.',
+          'How to render comments in read_file output. Use "paragraph_notes" (default) for paragraph-local comment threads, "inline_markers" to add `[cm-start:N]`/`[cm-end:N]` milestones in TOON output (combined with the thread blocks), "endnotes" to collect threaded comments into a trailing #COMMENTS block in TOON output, or "none" for the legacy output with no comment rendering.',
         ),
       show_formatting: z
         .boolean()

--- a/packages/docx-mcp/src/tools/read_file.ts
+++ b/packages/docx-mcp/src/tools/read_file.ts
@@ -4,11 +4,13 @@ import { err, ok, type ToolResponse } from './types.js';
 import {
   OOXML,
   W,
+  INLINE_COMMENT_MARKER_RUNTIME,
   renderToon,
   renderToonWithCommentEndnotes,
   formatToonDataLine,
   formatToonCommentLines,
   formatToonCommentsEndnotesBlock,
+  collectInlineCommentMarkers,
   collectTableMarkerInfo,
   formatTableMarker,
   type Comment,
@@ -49,27 +51,194 @@ function escapeCommentSuffixText(text: string): string {
     .replaceAll('|', '\\|');
 }
 
-function mapDocumentViewComment(comment: Comment): DocumentViewComment {
+type InlineCommentMarkerRuntime = {
+  startVisibleOffset: number;
+  endVisibleOffset: number;
+  suppressInlineMarkers: boolean;
+};
+
+function getCommentAnchorParagraphId(comment: Comment): string | null {
+  return comment.anchoredParagraphId ?? comment.endParagraphId ?? null;
+}
+
+function getParagraphRunVisibleLengths(paragraphEl: Element): number[] {
+  enum FieldState {
+    OUTSIDE_FIELD = 0,
+    IN_FIELD_CODE = 1,
+    IN_FIELD_RESULT = 2,
+  }
+
+  const runLengths: number[] = [];
+  const runElements = Array.from(paragraphEl.getElementsByTagNameNS(OOXML.W_NS, W.r));
+  let fieldState = FieldState.OUTSIDE_FIELD;
+
+  for (const runEl of runElements) {
+    let visibleLength = 0;
+
+    for (const child of Array.from(runEl.childNodes)) {
+      if (child.nodeType !== 1) continue;
+      const el = child as Element;
+      if (el.namespaceURI !== OOXML.W_NS) continue;
+
+      if (el.localName === W.fldChar) {
+        const type = getWAttr(el, 'fldCharType') ?? '';
+        if (type === 'begin') fieldState = FieldState.IN_FIELD_CODE;
+        else if (type === 'separate') fieldState = FieldState.IN_FIELD_RESULT;
+        else if (type === 'end') fieldState = FieldState.OUTSIDE_FIELD;
+        continue;
+      }
+
+      if (fieldState === FieldState.IN_FIELD_CODE) continue;
+
+      if (el.localName === W.t) {
+        visibleLength += (el.textContent ?? '').length;
+      } else if (el.localName === W.tab || el.localName === W.br) {
+        visibleLength += 1;
+      }
+    }
+
+    runLengths.push(visibleLength);
+  }
+
+  return runLengths;
+}
+
+function resolveCommentVisibleOffset(
+  runVisibleLengths: readonly number[],
+  runIndex: number | undefined,
+  charOffset: number | undefined,
+): number | undefined {
+  if (runIndex == null || charOffset == null) return undefined;
+  if (runIndex < 0 || runIndex >= runVisibleLengths.length) return undefined;
+
+  const runVisibleLength = runVisibleLengths[runIndex];
+  if (runVisibleLength == null || charOffset < 0 || charOffset > runVisibleLength) {
+    return undefined;
+  }
+
+  let offset = charOffset;
+  for (let index = 0; index < runIndex; index++) {
+    offset += runVisibleLengths[index] ?? 0;
+  }
+  return offset;
+}
+
+function buildInlineCommentMarkerRuntime(
+  comment: Comment,
+  paragraphElementsById: ReadonlyMap<string, Element>,
+  paragraphRunLengthsById: Map<string, number[]>,
+): InlineCommentMarkerRuntime | undefined {
+  if (
+    !comment.anchoredParagraphId ||
+    !comment.endParagraphId ||
+    comment.startRunIndex == null ||
+    comment.startCharOffset == null ||
+    comment.endRunIndex == null ||
+    comment.endCharOffset == null
+  ) {
+    return undefined;
+  }
+
+  const getRunLengths = (paragraphId: string): number[] | undefined => {
+    const cached = paragraphRunLengthsById.get(paragraphId);
+    if (cached) return cached;
+    const paragraphEl = paragraphElementsById.get(paragraphId);
+    if (!paragraphEl) return undefined;
+    const runLengths = getParagraphRunVisibleLengths(paragraphEl);
+    paragraphRunLengthsById.set(paragraphId, runLengths);
+    return runLengths;
+  };
+
+  const startRunLengths = getRunLengths(comment.anchoredParagraphId);
+  const endRunLengths = getRunLengths(comment.endParagraphId);
+  if (!startRunLengths || !endRunLengths) return undefined;
+
+  const startVisibleOffset = resolveCommentVisibleOffset(
+    startRunLengths,
+    comment.startRunIndex,
+    comment.startCharOffset,
+  );
+  const endVisibleOffset = resolveCommentVisibleOffset(
+    endRunLengths,
+    comment.endRunIndex,
+    comment.endCharOffset,
+  );
+  if (startVisibleOffset == null || endVisibleOffset == null) return undefined;
+
+  const endParagraphVisibleLength = endRunLengths.reduce((sum, length) => sum + length, 0);
   return {
+    startVisibleOffset,
+    endVisibleOffset,
+    suppressInlineMarkers:
+      comment.anchoredParagraphId === comment.endParagraphId &&
+      startVisibleOffset === 0 &&
+      endVisibleOffset === endParagraphVisibleLength,
+  };
+}
+
+function mapDocumentViewComment(
+  comment: Comment,
+  options?: {
+    includeRange?: boolean;
+    paragraphElementsById?: ReadonlyMap<string, Element>;
+    paragraphRunLengthsById?: Map<string, number[]>;
+  },
+): DocumentViewComment {
+  const mapped: DocumentViewComment = {
     id: comment.id,
     author: comment.author,
     date: comment.date || null,
     initials: comment.initials,
     text: comment.text,
-    replies: comment.replies.map((reply) => mapDocumentViewComment(reply)),
+    replies: comment.replies.map((reply) => mapDocumentViewComment(reply, options)),
   };
+
+  if (options?.includeRange && comment.anchoredParagraphId && comment.endParagraphId) {
+    mapped.range = {
+      startParagraphId: comment.anchoredParagraphId,
+      endParagraphId: comment.endParagraphId,
+      startRunIndex: comment.startRunIndex,
+      startCharOffset: comment.startCharOffset,
+      endRunIndex: comment.endRunIndex,
+      endCharOffset: comment.endCharOffset,
+    };
+
+    const runtime = options.paragraphElementsById && options.paragraphRunLengthsById
+      ? buildInlineCommentMarkerRuntime(
+          comment,
+          options.paragraphElementsById,
+          options.paragraphRunLengthsById,
+        )
+      : undefined;
+
+    if (runtime) {
+      Object.defineProperty(mapped, INLINE_COMMENT_MARKER_RUNTIME, {
+        value: runtime,
+        enumerable: false,
+      });
+    }
+  }
+
+  return mapped;
 }
 
 function attachParagraphComments(
   nodes: readonly DocumentViewNode[],
   comments: readonly Comment[],
+  options?: { includeInlineMarkers?: boolean; paragraphElementsById?: ReadonlyMap<string, Element> },
 ): DocumentViewNode[] {
   const commentsByParagraph = new Map<string, DocumentViewComment[]>();
+  const paragraphRunLengthsById = new Map<string, number[]>();
   for (const comment of comments) {
-    if (!comment.anchoredParagraphId) continue;
-    const rootComments = commentsByParagraph.get(comment.anchoredParagraphId) ?? [];
-    rootComments.push(mapDocumentViewComment(comment));
-    commentsByParagraph.set(comment.anchoredParagraphId, rootComments);
+    const paragraphId = getCommentAnchorParagraphId(comment);
+    if (!paragraphId) continue;
+    const rootComments = commentsByParagraph.get(paragraphId) ?? [];
+    rootComments.push(mapDocumentViewComment(comment, {
+      includeRange: options?.includeInlineMarkers,
+      paragraphElementsById: options?.paragraphElementsById,
+      paragraphRunLengthsById,
+    }));
+    commentsByParagraph.set(paragraphId, rootComments);
   }
 
   return nodes.map((node) => {
@@ -126,11 +295,16 @@ export async function readFile(
     }
 
     const commentRendering = (params.comment_rendering ?? 'paragraph_notes').toLowerCase();
-    if (commentRendering !== 'none' && commentRendering !== 'paragraph_notes' && commentRendering !== 'endnotes') {
+    if (
+      commentRendering !== 'none' &&
+      commentRendering !== 'paragraph_notes' &&
+      commentRendering !== 'endnotes' &&
+      commentRendering !== 'inline_markers'
+    ) {
       return err(
         'INVALID_COMMENT_RENDERING',
         `Invalid comment_rendering: ${params.comment_rendering}`,
-        "Use 'paragraph_notes' (default), 'endnotes', or 'none'.",
+        "Use 'paragraph_notes' (default), 'inline_markers', 'endnotes', or 'none'.",
       );
     }
 
@@ -188,7 +362,23 @@ export async function readFile(
 
     if (commentRendering !== 'none') {
       try {
-        enriched = attachParagraphComments(enriched, await session.doc.getComments());
+        const comments = await session.doc.getComments();
+        const paragraphElementsById = commentRendering === 'inline_markers'
+          ? new Map(
+              Array.from(new Set([
+                ...enriched.map((node) => node.id),
+                ...comments.map((comment) => comment.anchoredParagraphId).filter((paragraphId): paragraphId is string => paragraphId != null),
+                ...comments.map((comment) => comment.endParagraphId).filter((paragraphId): paragraphId is string => paragraphId != null),
+              ]))
+                .map((paragraphId) => [paragraphId, session.doc.getParagraphElementById(paragraphId)] as const)
+                .filter((entry): entry is readonly [string, Element] => entry[1] != null),
+            )
+          : undefined;
+
+        enriched = attachParagraphComments(enriched, comments, {
+          includeInlineMarkers: commentRendering === 'inline_markers',
+          paragraphElementsById,
+        });
       } catch {
         // Preserve existing read_file behavior if comment parts are unavailable or malformed.
       }
@@ -262,6 +452,8 @@ function renderToonWithBudget(
   let count = 0;
   let currentTableIndex: number | null = null;
   const includedNodes: DocumentViewNode[] = [];
+  const useInlineMarkers = commentRendering === 'inline_markers';
+  const commentMarkers = useInlineMarkers ? collectInlineCommentMarkers(enriched) : undefined;
 
   // Pre-scan: collect table marker info for #TABLE lines
   const tableInfo = collectTableMarkerInfo(enriched);
@@ -290,10 +482,13 @@ function renderToonWithBudget(
       currentTableIndex = nodeTableIndex;
     }
 
-    const dataLine = formatToonDataLine(node);
-    const commentLines = commentRendering === 'paragraph_notes'
-      ? formatToonCommentLines(node)
-      : [];
+    const dataLine = useInlineMarkers
+      ? formatToonDataLine(node, { commentMarkers })
+      : formatToonDataLine(node);
+    const commentLines =
+      commentRendering === 'paragraph_notes' || useInlineMarkers
+        ? formatToonCommentLines(node)
+        : [];
     const nodeLines = [dataLine, ...commentLines].join('\n');
     const candidateBase = accumulated + '\n' + nodeLines;
     let candidate = candidateBase;

--- a/packages/docx-mcp/src/tools/read_file_comments.test.ts
+++ b/packages/docx-mcp/src/tools/read_file_comments.test.ts
@@ -22,6 +22,81 @@ function commentBlockLines(lines: string[]): string[] {
   return start === -1 ? [] : lines.slice(start);
 }
 
+type CommentFixtureEntry = {
+  id: number;
+  author: string;
+  initials: string;
+  text: string;
+  paraId: string;
+  date?: string;
+};
+
+function makeDocumentXml(bodyXml: string): string {
+  return (
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">` +
+    `<w:body>${bodyXml}</w:body>` +
+    `</w:document>`
+  );
+}
+
+function withParagraphBookmark(params: {
+  bookmarkId: number;
+  name: string;
+  paragraphInnerXml: string;
+}): string {
+  return `<w:bookmarkStart w:id="${params.bookmarkId}" w:name="${params.name}"/><w:p>${params.paragraphInnerXml}</w:p><w:bookmarkEnd w:id="${params.bookmarkId}"/>`;
+}
+
+function makeCommentReferenceRun(commentId: number): string {
+  return `<w:r><w:rPr><w:rStyle w:val="CommentReference"/></w:rPr><w:commentReference w:id="${commentId}"/></w:r>`;
+}
+
+function makeCommentsXml(entries: CommentFixtureEntry[]): string {
+  return (
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<w:comments xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">` +
+    entries
+      .map(
+        (entry) =>
+          `<w:comment w:id="${entry.id}" w:author="${entry.author}" w:date="${entry.date ?? '2025-01-01T00:00:00Z'}" w:initials="${entry.initials}">` +
+          `<w:p w14:paraId="${entry.paraId}"><w:r><w:annotationRef/></w:r><w:r><w:t>${entry.text}</w:t></w:r></w:p>` +
+          `</w:comment>`,
+      )
+      .join('') +
+    `</w:comments>`
+  );
+}
+
+async function openCommentFixture(params: {
+  bodyXml: string;
+  comments: CommentFixtureEntry[];
+}) {
+  return openSession([], {
+    xml: makeDocumentXml(params.bodyXml),
+    extraFiles: { 'word/comments.xml': makeCommentsXml(params.comments) },
+  });
+}
+
+async function renderCommentFixture(params: {
+  bodyXml: string;
+  comments: CommentFixtureEntry[];
+  readParams?: {
+    format?: 'toon' | 'json' | 'simple';
+    comment_rendering?: string;
+    offset?: number;
+    limit?: number;
+  };
+}) {
+  const opened = await openCommentFixture({ bodyXml: params.bodyXml, comments: params.comments });
+  const read = await readFile(opened.mgr, {
+    file_path: opened.inputPath,
+    ...params.readParams,
+  });
+  assertSuccess(read, 'read_file');
+  return { opened, read, content: String(read.content), lines: toonLines(read.content) };
+}
+
 describe('read_file comment rendering', () => {
   registerCleanup();
 
@@ -711,5 +786,316 @@ describe('read_file comment rendering', () => {
       expect(paragraphLines).toHaveLength(1);
       expect(paragraphLines[0]).toContain('Alpha\\nBeta\\nGamma');
     });
+  });
+
+  const inlineMarkerParagraphCases = [
+    {
+      name: 'inline_markers wraps a single commented span in one paragraph',
+      paragraphId: '_bk_inline_single',
+      expected: 'Alpha [cm-start:0]Beta[cm-end:0] Gamma',
+      bodyXml: withParagraphBookmark({
+        bookmarkId: 310,
+        name: '_bk_inline_single',
+        paragraphInnerXml:
+          `<w:r><w:t>Alpha </w:t></w:r><w:commentRangeStart w:id="0"/>` +
+          `<w:r><w:t>Beta</w:t></w:r><w:commentRangeEnd w:id="0"/>${makeCommentReferenceRun(0)}` +
+          `<w:r><w:t> Gamma</w:t></w:r>`,
+      }),
+      comments: [{ id: 0, author: 'Alice', initials: 'A', text: 'Inline note.', paraId: '00000040' }],
+    },
+    {
+      name: 'inline_markers renders two non-overlapping ranges in one paragraph',
+      paragraphId: '_bk_inline_non_overlapping',
+      expected: '[cm-start:0]Alpha[cm-end:0] middle [cm-start:1]Gamma[cm-end:1]',
+      bodyXml: withParagraphBookmark({
+        bookmarkId: 311,
+        name: '_bk_inline_non_overlapping',
+        paragraphInnerXml:
+          `<w:commentRangeStart w:id="0"/><w:r><w:t>Alpha</w:t></w:r>` +
+          `<w:commentRangeEnd w:id="0"/>${makeCommentReferenceRun(0)}<w:r><w:t> middle </w:t></w:r>` +
+          `<w:commentRangeStart w:id="1"/><w:r><w:t>Gamma</w:t></w:r>` +
+          `<w:commentRangeEnd w:id="1"/>${makeCommentReferenceRun(1)}`,
+      }),
+      comments: [
+        { id: 0, author: 'Alice', initials: 'A', text: 'Alpha note.', paraId: '00000041' },
+        { id: 1, author: 'Bob', initials: 'B', text: 'Gamma note.', paraId: '00000042' },
+      ],
+    },
+    {
+      name: 'inline_markers preserves nested close ordering',
+      paragraphId: '_bk_inline_nested',
+      expected: 'Lead [cm-start:0]Alpha [cm-start:1]Beta[cm-end:1][cm-end:0] tail',
+      bodyXml: withParagraphBookmark({
+        bookmarkId: 312,
+        name: '_bk_inline_nested',
+        paragraphInnerXml:
+          `<w:r><w:t>Lead </w:t></w:r><w:commentRangeStart w:id="0"/><w:r><w:t>Alpha </w:t></w:r>` +
+          `<w:commentRangeStart w:id="1"/><w:r><w:t>Beta</w:t></w:r>` +
+          `<w:commentRangeEnd w:id="1"/>${makeCommentReferenceRun(1)}` +
+          `<w:commentRangeEnd w:id="0"/>${makeCommentReferenceRun(0)}<w:r><w:t> tail</w:t></w:r>`,
+      }),
+      comments: [
+        { id: 0, author: 'Alice', initials: 'A', text: 'Outer note.', paraId: '00000043' },
+        { id: 1, author: 'Bob', initials: 'B', text: 'Inner note.', paraId: '00000044' },
+      ],
+    },
+    {
+      name: 'inline_markers preserves crossing ranges losslessly',
+      paragraphId: '_bk_inline_crossing',
+      expected: '[cm-start:0]A [cm-start:1]B[cm-end:0] C[cm-end:1]',
+      bodyXml: withParagraphBookmark({
+        bookmarkId: 313,
+        name: '_bk_inline_crossing',
+        paragraphInnerXml:
+          `<w:commentRangeStart w:id="0"/><w:r><w:t>A </w:t></w:r><w:commentRangeStart w:id="1"/>` +
+          `<w:r><w:t>B</w:t></w:r><w:commentRangeEnd w:id="0"/>${makeCommentReferenceRun(0)}` +
+          `<w:r><w:t> C</w:t></w:r><w:commentRangeEnd w:id="1"/>${makeCommentReferenceRun(1)}`,
+      }),
+      comments: [
+        { id: 0, author: 'Alice', initials: 'A', text: 'First crossing note.', paraId: '00000045' },
+        { id: 1, author: 'Bob', initials: 'B', text: 'Second crossing note.', paraId: '00000046' },
+      ],
+    },
+  ] satisfies Array<{
+    name: string;
+    paragraphId: string;
+    expected: string;
+    bodyXml: string;
+    comments: CommentFixtureEntry[];
+  }>;
+
+  for (const scenario of inlineMarkerParagraphCases) {
+    test(scenario.name, async () => {
+      const { lines } = await renderCommentFixture({
+        bodyXml: scenario.bodyXml,
+        comments: scenario.comments,
+        readParams: { comment_rendering: 'inline_markers' },
+      });
+      expect(findParagraphLine(lines, scenario.paragraphId)).toContain(scenario.expected);
+    });
+  }
+
+  test('inline_markers suppresses whole-paragraph markers but keeps the thread block', async () => {
+    const opened = await openSession(['Whole paragraph comment']);
+    const result = await addComment(opened.mgr, {
+      file_path: opened.inputPath,
+      target_paragraph_id: opened.firstParaId,
+      author: 'Alice',
+      text: 'Whole-paragraph note.',
+    });
+    assertSuccess(result, 'add_comment');
+    const read = await readFile(opened.mgr, { file_path: opened.inputPath, comment_rendering: 'inline_markers' });
+    assertSuccess(read, 'read_file');
+    const content = String(read.content);
+    const line = findParagraphLine(toonLines(content), opened.firstParaId);
+    expect(line).not.toContain('[cm-start:');
+    expect(line).not.toContain('[cm-end:');
+    expect(content).toContain(`#COMMENT ${opened.firstParaId} c${result.comment_id} Alice `);
+  });
+
+  test('inline_markers renders multi-paragraph ranges only at the boundary paragraphs', async () => {
+    const { lines } = await renderCommentFixture({
+      bodyXml:
+        withParagraphBookmark({
+          bookmarkId: 301,
+          name: '_bk_multi_start',
+          paragraphInnerXml:
+            `<w:r><w:t>Lead </w:t></w:r><w:commentRangeStart w:id="11"/><w:r><w:t>First chunk</w:t></w:r>`,
+        }) +
+        withParagraphBookmark({
+          bookmarkId: 302,
+          name: '_bk_multi_middle',
+          paragraphInnerXml: `<w:r><w:t>Middle paragraph</w:t></w:r>`,
+        }) +
+        withParagraphBookmark({
+          bookmarkId: 303,
+          name: '_bk_multi_end',
+          paragraphInnerXml:
+            `<w:r><w:t>Second chunk</w:t></w:r><w:commentRangeEnd w:id="11"/>${makeCommentReferenceRun(11)}` +
+            `<w:r><w:t> tail</w:t></w:r>`,
+        }),
+      comments: [{ id: 11, author: 'Alice', initials: 'A', text: 'Across paragraphs.', paraId: '00000031' }],
+      readParams: { comment_rendering: 'inline_markers' },
+    });
+    expect(findParagraphLine(lines, '_bk_multi_start')).toContain('Lead [cm-start:11]First chunk');
+    expect(findParagraphLine(lines, '_bk_multi_middle')).not.toContain('[cm-');
+    expect(findParagraphLine(lines, '_bk_multi_end')).toContain('Second chunk[cm-end:11] tail');
+  });
+
+  test('inline_markers supports ranges that start in a table cell and end after the table', async () => {
+    const { lines } = await renderCommentFixture({
+      bodyXml:
+        `<w:tbl><w:tr><w:tc>` +
+        withParagraphBookmark({
+          bookmarkId: 304,
+          name: '_bk_table_start',
+          paragraphInnerXml:
+            `<w:r><w:t>Left </w:t></w:r><w:commentRangeStart w:id="12"/><w:r><w:t>cell</w:t></w:r>`,
+        }) +
+        `</w:tc></w:tr></w:tbl>` +
+        withParagraphBookmark({
+          bookmarkId: 305,
+          name: '_bk_after_table',
+          paragraphInnerXml: `<w:r><w:t>After table</w:t></w:r><w:commentRangeEnd w:id="12"/>${makeCommentReferenceRun(12)}`,
+        }),
+      comments: [{ id: 12, author: 'Bob', initials: 'B', text: 'Cross-boundary note.', paraId: '00000032' }],
+      readParams: { comment_rendering: 'inline_markers' },
+    });
+    const tableIndex = lines.indexOf('#TABLE _tbl_0 | 1 rows × 1 cols');
+    const startIndex = lines.indexOf(findParagraphLine(lines, '_bk_table_start'));
+    const endTableIndex = lines.indexOf('#END_TABLE');
+    const afterTableIndex = lines.indexOf(findParagraphLine(lines, '_bk_after_table'));
+    expect(tableIndex).toBeGreaterThan(-1);
+    expect(startIndex).toBeGreaterThan(tableIndex);
+    expect(findParagraphLine(lines, '_bk_table_start')).toContain('Left [cm-start:12]cell');
+    expect(afterTableIndex).toBeGreaterThan(endTableIndex);
+    expect(findParagraphLine(lines, '_bk_after_table')).toContain('After table[cm-end:12]');
+  });
+
+  test('inline_markers combined mode keeps #COMMENT and #REPLY lines', async () => {
+    const opened = await openCommentFixture({
+      bodyXml: withParagraphBookmark({
+        bookmarkId: 314,
+        name: '_bk_inline_combined',
+        paragraphInnerXml:
+          `<w:commentRangeStart w:id="20"/><w:r><w:t>Clause</w:t></w:r>` +
+          `<w:commentRangeEnd w:id="20"/>${makeCommentReferenceRun(20)}<w:r><w:t> text</w:t></w:r>`,
+      }),
+      comments: [{ id: 20, author: 'Alice', initials: 'A', text: 'Root inline note.', paraId: '00000047' }],
+    });
+    const reply = await addComment(opened.mgr, {
+      file_path: opened.inputPath,
+      parent_comment_id: 20,
+      author: 'Bob',
+      text: 'Reply inline note.',
+    });
+    assertSuccess(reply, 'add_comment(reply)');
+    const read = await readFile(opened.mgr, { file_path: opened.inputPath, comment_rendering: 'inline_markers' });
+    assertSuccess(read, 'read_file');
+    const content = String(read.content);
+    const lines = toonLines(content);
+    expect(findParagraphLine(lines, '_bk_inline_combined')).toContain('[cm-start:20]Clause[cm-end:20] text');
+    expect(content).toContain('#COMMENT _bk_inline_combined c20 Alice ');
+    expect(content).toContain(`#REPLY c${reply.comment_id} -> c20 Bob `);
+  });
+
+  test('pagination does not surface inline markers for out-of-window comment boundaries', async () => {
+    const { content, read } = await renderCommentFixture({
+      bodyXml:
+        withParagraphBookmark({
+          bookmarkId: 306,
+          name: '_bk_window_start',
+          paragraphInnerXml:
+            `<w:r><w:t>Lead </w:t></w:r><w:commentRangeStart w:id="13"/><w:r><w:t>First chunk</w:t></w:r>`,
+        }) +
+        withParagraphBookmark({
+          bookmarkId: 307,
+          name: '_bk_window_middle',
+          paragraphInnerXml: `<w:r><w:t>Middle paragraph</w:t></w:r>`,
+        }) +
+        withParagraphBookmark({
+          bookmarkId: 308,
+          name: '_bk_window_end',
+          paragraphInnerXml: `<w:r><w:t>Second chunk</w:t></w:r><w:commentRangeEnd w:id="13"/>${makeCommentReferenceRun(13)}`,
+        }),
+      comments: [{ id: 13, author: 'Cara', initials: 'C', text: 'Windowed note.', paraId: '00000033' }],
+      readParams: { offset: 3, limit: 1, comment_rendering: 'inline_markers' },
+    });
+    expect(findParagraphLine(toonLines(content), '_bk_window_end')).not.toContain('[cm-end:13]');
+    expect(content).not.toContain('#COMMENT _bk_window_start');
+    expect(Number(read.paragraphs_returned)).toBe(1);
+  });
+
+  test('inline_markers falls back to paragraph notes when range metadata is incomplete', async () => {
+    const { content, lines } = await renderCommentFixture({
+      bodyXml: withParagraphBookmark({
+        bookmarkId: 309,
+        name: '_bk_missing_start',
+        paragraphInnerXml:
+          `<w:r><w:t>Legacy attachment</w:t></w:r><w:commentRangeEnd w:id="14"/>${makeCommentReferenceRun(14)}`,
+      }),
+      comments: [{ id: 14, author: 'Dana', initials: 'D', text: 'Legacy comment.', paraId: '00000034' }],
+      readParams: { comment_rendering: 'inline_markers' },
+    });
+    expect(findParagraphLine(lines, '_bk_missing_start')).not.toContain('[cm-');
+    expect(content).toContain('#COMMENT _bk_missing_start c14 Dana ');
+  });
+
+  test('json output includes comment range metadata only in inline_markers mode', async () => {
+    const fixture = {
+      bodyXml: withParagraphBookmark({
+        bookmarkId: 315,
+        name: '_bk_json_range',
+        paragraphInnerXml:
+          `<w:r><w:t>Alpha </w:t></w:r><w:commentRangeStart w:id="30"/><w:r><w:t>Beta</w:t></w:r>` +
+          `<w:commentRangeEnd w:id="30"/>${makeCommentReferenceRun(30)}<w:r><w:t> Gamma</w:t></w:r>`,
+      }),
+      comments: [{ id: 30, author: 'Alice', initials: 'A', text: 'JSON range note.', paraId: '00000048' }],
+    };
+    const inline = await renderCommentFixture({ ...fixture, readParams: { format: 'json', comment_rendering: 'inline_markers' } });
+    const paragraphNotes = await renderCommentFixture({ ...fixture, readParams: { format: 'json', comment_rendering: 'paragraph_notes' } });
+    const inlineNode = (JSON.parse(inline.content) as Array<{ id: string; comments?: Array<{ id: number; range?: unknown }> }>)
+      .find((candidate) => candidate.id === '_bk_json_range');
+    const paragraphNode = (JSON.parse(paragraphNotes.content) as Array<{ id: string; comments?: Array<{ range?: unknown }> }>)
+      .find((candidate) => candidate.id === '_bk_json_range');
+    expect(inlineNode?.comments?.[0]).toMatchObject({
+      id: 30,
+      range: {
+        startParagraphId: '_bk_json_range',
+        endParagraphId: '_bk_json_range',
+        startRunIndex: 1,
+        startCharOffset: 0,
+        endRunIndex: 1,
+        endCharOffset: 4,
+      },
+    });
+    expect(paragraphNode?.comments?.[0]?.range).toBeUndefined();
+  });
+
+  test('simple output in inline_markers mode keeps comment suffixes but does not inline the milestones', async () => {
+    const opened = await openSession(['Simple inline paragraph']);
+    const result = await addComment(opened.mgr, {
+      file_path: opened.inputPath,
+      target_paragraph_id: opened.firstParaId,
+      author: 'Alice',
+      text: 'Simple inline note.',
+      anchor_text: 'inline',
+    });
+    assertSuccess(result, 'add_comment');
+    const read = await readFile(opened.mgr, {
+      file_path: opened.inputPath,
+      format: 'simple',
+      comment_rendering: 'inline_markers',
+    });
+    assertSuccess(read, 'read_file');
+    const content = String(read.content);
+    expect(content).toContain(`[c${result.comment_id}: Simple inline note.]`);
+    expect(content).not.toContain('[cm-start:');
+    expect(content).not.toContain('[cm-end:');
+  });
+
+  test('inline_markers correctly positions markers around literal angle-bracket text like <Borrower>', async () => {
+    // Regression: the marker injector previously treated any `<...>` in tagged_text as a
+    // TOON formatting tag, so paragraphs containing literal angle-bracket placeholders
+    // (common in legal templates: `<Borrower>`, `<Effective Date>`) misplaced the markers.
+    // The fix recognizes only the known TOON tag set; literal `<...>` is counted as visible chars.
+    const fixture = {
+      bodyXml: withParagraphBookmark({
+        bookmarkId: 320,
+        name: '_bk_literal_angles',
+        paragraphInnerXml:
+          `<w:r><w:t>Alpha &lt;Borrower&gt; </w:t></w:r>` +
+          `<w:commentRangeStart w:id="40"/>` +
+          `<w:r><w:t>Beta</w:t></w:r>` +
+          `<w:commentRangeEnd w:id="40"/>${makeCommentReferenceRun(40)}`,
+      }),
+      comments: [{ id: 40, author: 'Alice', initials: 'A', text: 'Should this be a placeholder?', paraId: '00000049' }],
+      readParams: { comment_rendering: 'inline_markers' as const },
+    };
+    const rendered = await renderCommentFixture(fixture);
+    const lines = String(rendered.content).split('\n');
+    const paragraphLine = findParagraphLine(lines, '_bk_literal_angles');
+    // Markers must wrap "Beta" exactly, not anything else.
+    expect(paragraphLine).toContain('Alpha <Borrower> [cm-start:40]Beta[cm-end:40]');
   });
 });

--- a/packages/docx-mcp/src/tools/read_file_comments.test.ts
+++ b/packages/docx-mcp/src/tools/read_file_comments.test.ts
@@ -1098,4 +1098,77 @@ describe('read_file comment rendering', () => {
     // Markers must wrap "Beta" exactly, not anything else.
     expect(paragraphLine).toContain('Alpha <Borrower> [cm-start:40]Beta[cm-end:40]');
   });
+
+  test('inline_markers correctly positions markers when the paragraph has a manual list label', async () => {
+    // Regression: `buildDocumentView` strips manual list labels (e.g., `(a) `) from
+    // `tagged_text`, but comment range offsets are computed against the FULL raw paragraph
+    // text. Without compensation, markers would shift left by the label length.
+    // The fix: track stripped char count in `visible_offset_correction` on the node and
+    // subtract it during marker injection.
+    const fixture = {
+      bodyXml: withParagraphBookmark({
+        bookmarkId: 321,
+        name: '_bk_manual_label',
+        // "(a) Alpha Beta" — visible run layout:
+        //   run 0: "(a) Alpha "  (10 chars)
+        //   run 1 (with markers around it): "Beta" (4 chars)
+        // After stripListLabel: "Alpha Beta" (label "(a)" + space stripped → 4 chars stripped)
+        // Comment range covers run 1 → raw offsets 10..14; tagged_text offsets 6..10 (after correction).
+        paragraphInnerXml:
+          `<w:r><w:t>(a) Alpha </w:t></w:r>` +
+          `<w:commentRangeStart w:id="50"/>` +
+          `<w:r><w:t>Beta</w:t></w:r>` +
+          `<w:commentRangeEnd w:id="50"/>${makeCommentReferenceRun(50)}`,
+      }),
+      comments: [{ id: 50, author: 'Alice', initials: 'A', text: 'Manual label note.', paraId: '00000050' }],
+      readParams: { comment_rendering: 'inline_markers' as const },
+    };
+    const rendered = await renderCommentFixture(fixture);
+    const lines = String(rendered.content).split('\n');
+    const paragraphLine = findParagraphLine(lines, '_bk_manual_label');
+    // Markers must wrap "Beta" inside the post-label text.
+    expect(paragraphLine).toContain('Alpha [cm-start:50]Beta[cm-end:50]');
+    // Sanity: there must be no stray markers at the end of the line.
+    expect(paragraphLine).not.toMatch(/Beta\s*\[cm-start:50\]\[cm-end:50\]\s*$/);
+  });
+
+  test('inline_markers does not match bare <a> or <font> as TOON tags', async () => {
+    // Regression: the TOON_INLINE_TAG_RE previously allowed bare `<a>` and `<font>` (no
+    // attributes), but the formatter only emits `<a href="...">` and `<font ATTR=...>`.
+    // Literal `<a>` or `<font>` text in document content was being silently skipped as
+    // markup, shifting marker positions.
+    const fixtureA = {
+      bodyXml: withParagraphBookmark({
+        bookmarkId: 322,
+        name: '_bk_literal_a',
+        paragraphInnerXml:
+          `<w:r><w:t>Alpha &lt;a&gt; </w:t></w:r>` +
+          `<w:commentRangeStart w:id="51"/>` +
+          `<w:r><w:t>Beta</w:t></w:r>` +
+          `<w:commentRangeEnd w:id="51"/>${makeCommentReferenceRun(51)}`,
+      }),
+      comments: [{ id: 51, author: 'Alice', initials: 'A', text: 'Literal a tag.', paraId: '00000051' }],
+      readParams: { comment_rendering: 'inline_markers' as const },
+    };
+    const renderedA = await renderCommentFixture(fixtureA);
+    expect(findParagraphLine(String(renderedA.content).split('\n'), '_bk_literal_a'))
+      .toContain('Alpha <a> [cm-start:51]Beta[cm-end:51]');
+
+    const fixtureFont = {
+      bodyXml: withParagraphBookmark({
+        bookmarkId: 323,
+        name: '_bk_literal_font',
+        paragraphInnerXml:
+          `<w:r><w:t>Alpha &lt;font&gt; </w:t></w:r>` +
+          `<w:commentRangeStart w:id="52"/>` +
+          `<w:r><w:t>Beta</w:t></w:r>` +
+          `<w:commentRangeEnd w:id="52"/>${makeCommentReferenceRun(52)}`,
+      }),
+      comments: [{ id: 52, author: 'Alice', initials: 'A', text: 'Literal font tag.', paraId: '00000052' }],
+      readParams: { comment_rendering: 'inline_markers' as const },
+    };
+    const renderedFont = await renderCommentFixture(fixtureFont);
+    expect(findParagraphLine(String(renderedFont.content).split('\n'), '_bk_literal_font'))
+      .toContain('Alpha <font> [cm-start:52]Beta[cm-end:52]');
+  });
 });


### PR DESCRIPTION
## Summary

Adds `comment_rendering: \"inline_markers\"` to the `read_file` MCP tool. In this mode, the TOON renderer injects ASCII-only milestone markers `[cm-start:N]` and `[cm-end:N]` at the appropriate text positions in each paragraph, AND emits the per-paragraph `#COMMENT`/`#REPLY` thread blocks from #127. The combined output gives an AI both span locality and comment text in one read.

> ⚠️ **PR base:** `127-render-comments-paragraph-20260503` (PR #132). This branch also has `129-comment-range-metadata-20260503` (PR #134) merged in, so the diff above shows commits from both prerequisites. **Reviewers: focus on the latest commit only** (the `feat(docx-mcp)` one, ~810 lines). The PR auto-retargets to `main` when both #132 and #134 merge.

## Design decisions

- **Notation:** square-bracket milestone tokens. Brackets chosen over curly braces because curly braces collide with field placeholders in legal templates (\`{Borrower}\`). Parallels footnote \`[^N]\`.
- **Overlap encoding:** milestone (lossless on cross-overlap). Each marker is a separate point token paired by ID.
- **Default mode:** combined — emits both inline markers AND `#COMMENT`/`#REPLY` thread blocks. Markers alone are context-free for an AI.

## Implementation

- New optional `range?` field on `DocumentViewComment` (renderer-internal type), populated only in `inline_markers` mode.
- Marker injector in `document_view.ts` mirrors `injectFootnoteMarkers`'s position-aware pattern. Position math: sum `visibleLength` of runs `0..runIndex-1`, then add `charOffset`, then map to `tagged_text` offset via `findTaggedTextInsertionIndex`.
- Multi-paragraph ranges: start marker only in start paragraph, end marker only in end paragraph.
- Whole-paragraph detection: comments spanning a full paragraph suppress inline markers (the `#COMMENT` thread block conveys attachment alone).
- Order at same position: closes (LIFO by opening order) before opens (ascending by comment ID).
- Pagination: out-of-window comments don't have their nodes returned, so their markers naturally don't render.
- Missing-metadata fallback: a comment with no range fields still surfaces via its `#COMMENT` thread block; only the inline markers are omitted.
- Simple format: keeps the per-paragraph `[c<id>: <text>]` suffix from #127; inline markers are TOON-specific.
- Schema enum `comment_rendering` extended; `tool-reference.generated.md` regenerated.

## Verification

- [x] \`npm run build\` clean (all workspaces)
- [x] \`npm run lint --workspace=@usejunior/docx-core\` and \`-mcp\` pass
- [x] \`npm run test:run --workspace=@usejunior/docx-mcp\` — 663 passed (+13 new tests)
- [x] \`npm run test:run --workspace=@usejunior/docx-core\` — 1106 + 1 skipped (no regression)
- [x] \`npm run check:tool-docs\` passes (regenerated doc included)
- [x] \`npm run check:spec-coverage\` passes

### Peer review (mandatory gate)

- **Gemini pre-PR:** flagged two issues — manual-list-label offset bug and duplicate footnote markers. **Codex empirically tested both** and found neither manifests in actual code paths. No code changes from Gemini's review.
- **Codex pre-PR:** caught a real critical bug. The marker injector previously treated ANY `<...>` substring in `tagged_text` as a TOON formatting tag when computing visible-character positions. But `tagged_text` can contain literal document text with angle brackets (e.g., `<Borrower>` placeholders, common in legal templates). Reproducer: \`Alpha <Borrower> Beta\` with a comment around \"Borrower\" produced \`Alpha <Borrower> [cm-start:0]Beta[cm-end:0]\` — markers on the wrong word. **Fixed in this PR** by replacing the \"skip any `<...>`\" heuristic with exact pattern matching against the known TOON tag set. Regression test added: \"inline_markers correctly positions markers around literal angle-bracket text like `<Borrower>`\".

### New tests (cover issue acceptance criteria + Codex regression)

In \`packages/docx-mcp/src/tools/read_file_comments.test.ts\`:
- single inline span markers
- two non-overlapping ranges
- nested range close ordering
- crossing ranges (milestone preserves both spans losslessly)
- whole-paragraph suppression
- multi-paragraph start/end-only markers
- table-cell to body-paragraph boundary
- combined \`inline_markers\` + \`#COMMENT\`/\`#REPLY\`
- pagination suppression for out-of-window markers
- incomplete metadata fallback
- JSON \`range\` population
- simple-format suffix behavior
- **regression: literal `<Borrower>` placeholders don't shift markers** (Codex finding)

## Out of scope

- Range *write* support in \`add_comment.ts\` (currently paragraph-local with run-boundary marker insertion) — separate concern. The new tests use fixture-backed OOXML to construct sub-paragraph ranges.
- Comparison-engine consumption of range metadata.

## Closes

- #130