### PR TITLE
fix(docx-core): split runs in insertCommentMarkers for sub-paragraph anchor ranges

### DIFF
--- a/packages/docx-core/src/primitives/comments.test.ts
+++ b/packages/docx-core/src/primitives/comments.test.ts
@@ -409,6 +409,348 @@ describe('comments — edge cases and branch coverage', () => {
         ).rejects.toThrow('Invalid comment range');
       });
     });
+
+    test('splits a single run when anchor offsets fall mid-run', async ({ given, when, then, and }: AllureBddContext) => {
+      // Issue #151 reproducer: paragraph stores its visible text as one big <w:r>.
+      // The fix splits the run at exact offsets so markers wrap only the anchor span.
+      let zip: DocxZip;
+      let doc: Document;
+
+      await given('a document whose paragraph has one run with full visible text', async () => {
+        ({ zip, doc } = await setupWithComment(
+          '<w:p><w:r><w:t>The terms below are incorporated into and form part of this agreement.</w:t></w:r></w:p>',
+        ));
+      });
+
+      await when('addComment is called with offsets that bracket "incorporated"', async () => {
+        const p = doc.getElementsByTagNameNS(W_NS, W.p).item(0) as Element;
+        const fullText = 'The terms below are incorporated into and form part of this agreement.';
+        const start = fullText.indexOf('incorporated');
+        const end = start + 'incorporated'.length;
+        await addComment(doc, zip, {
+          paragraphEl: p,
+          start,
+          end,
+          author: 'Test',
+          text: 'Range comment on "incorporated"',
+        });
+      });
+
+      await then('the original run is split into pre / span / post runs', () => {
+        const p = doc.getElementsByTagNameNS(W_NS, W.p).item(0) as Element;
+        const children = Array.from(p.childNodes).filter((n) => n.nodeType === 1) as Element[];
+        // Expect: [pre-run, commentRangeStart, span-run, commentRangeEnd, commentReference-run, post-run]
+        // (commentReference is inserted between rangeEnd and the post-run, matching existing behavior.)
+        expect(children.map((c) => c.localName)).toEqual([
+          'r',
+          'commentRangeStart',
+          'r',
+          'commentRangeEnd',
+          'r',
+          'r',
+        ]);
+        expect(children[0]!.textContent).toBe('The terms below are ');
+        expect(children[2]!.textContent).toBe('incorporated');
+        expect(children[5]!.textContent).toBe(' into and form part of this agreement.');
+      });
+
+      await and('no empty <w:r> elements survived the split', () => {
+        const p = doc.getElementsByTagNameNS(W_NS, W.p).item(0) as Element;
+        const runs = Array.from(p.getElementsByTagNameNS(W_NS, W.r));
+        for (const r of runs) {
+          // An empty run has no <w:t>, <w:tab>, <w:br>, or <w:commentReference> children.
+          const meaningful = Array.from(r.childNodes).filter((c) => {
+            if (c.nodeType !== 1) return false;
+            const local = (c as Element).localName;
+            return local !== 'rPr';
+          });
+          expect(meaningful.length).toBeGreaterThan(0);
+        }
+      });
+
+      await and('getComments reports range metadata bracketing the span only', async () => {
+        const comments = await getComments(zip, doc);
+        expect(comments).toHaveLength(1);
+        // <w:r> indices in document order: 0=pre, 1=span (markers around it), 2=commentRef, 3=post.
+        // The range markers bracket run 1; getComments returns 0-based run indices.
+        expect(comments[0]!.startRunIndex).toBe(1);
+        expect(comments[0]!.startCharOffset).toBe(0);
+        expect(comments[0]!.endRunIndex).toBe(1);
+        expect(comments[0]!.endCharOffset).toBe('incorporated'.length);
+      });
+    });
+
+    test('splits boundary runs when anchor crosses multiple runs', async ({ given, when, then }: AllureBddContext) => {
+      let zip: DocxZip;
+      let doc: Document;
+
+      await given('a document with three runs', async () => {
+        ({ zip, doc } = await setupWithComment(
+          '<w:p><w:r><w:t>Hello </w:t></w:r><w:r><w:t>brave new </w:t></w:r><w:r><w:t>World!</w:t></w:r></w:p>',
+        ));
+      });
+
+      await when('addComment is called with offsets that span runs 0..2 mid-text', async () => {
+        const p = doc.getElementsByTagNameNS(W_NS, W.p).item(0) as Element;
+        // Concat: "Hello brave new World!" — anchor "lo brave new Wor"
+        const start = 'Hel'.length;
+        const end = 'Hello brave new Wor'.length;
+        await addComment(doc, zip, {
+          paragraphEl: p,
+          start,
+          end,
+          author: 'Test',
+          text: 'Cross-run anchor',
+        });
+      });
+
+      await then('start run and end run are split, middle run is untouched', async () => {
+        const p = doc.getElementsByTagNameNS(W_NS, W.p).item(0) as Element;
+        const runs = Array.from(p.getElementsByTagNameNS(W_NS, W.r));
+        const texts = runs
+          .map((r) => r.getElementsByTagNameNS(W_NS, W.t).item(0))
+          .map((t) => (t ? t.textContent : ''));
+        // After split: [Hel, lo<spc>, brave<spc>new<spc>, Wor, commentRef, ld!]
+        // commentReference run is inserted between rangeEnd and the post-run.
+        expect(texts).toEqual(['Hel', 'lo ', 'brave new ', 'Wor', '', 'ld!']);
+
+        const comments = await getComments(zip, doc);
+        expect(comments).toHaveLength(1);
+        expect(comments[0]!.startRunIndex).toBe(1);
+        expect(comments[0]!.startCharOffset).toBe(0);
+        expect(comments[0]!.endRunIndex).toBe(3);
+        expect(comments[0]!.endCharOffset).toBe('Wor'.length);
+      });
+    });
+
+    test('does not split when anchor exactly equals the only run text', async ({ given, when, then }: AllureBddContext) => {
+      let zip: DocxZip;
+      let doc: Document;
+
+      await given('a document with one run', async () => {
+        ({ zip, doc } = await setupWithComment(
+          '<w:p><w:r><w:t>Hello World</w:t></w:r></w:p>',
+        ));
+      });
+
+      await when('addComment is called with offsets covering the whole run', async () => {
+        const p = doc.getElementsByTagNameNS(W_NS, W.p).item(0) as Element;
+        await addComment(doc, zip, {
+          paragraphEl: p,
+          start: 0,
+          end: 'Hello World'.length,
+          author: 'Test',
+          text: 'Whole run',
+        });
+      });
+
+      await then('the run is not split (just one visible run + the commentReference run)', () => {
+        const p = doc.getElementsByTagNameNS(W_NS, W.p).item(0) as Element;
+        const runs = Array.from(p.getElementsByTagNameNS(W_NS, W.r));
+        // Original run + commentReference run = 2.
+        expect(runs).toHaveLength(2);
+        expect(runs[0]!.getElementsByTagNameNS(W_NS, W.t).item(0)!.textContent).toBe('Hello World');
+      });
+    });
+
+    test('preserves run formatting (rPr) on both halves of a split', async ({ given, when, then }: AllureBddContext) => {
+      let zip: DocxZip;
+      let doc: Document;
+
+      await given('a document with a single bold+italic run', async () => {
+        ({ zip, doc } = await setupWithComment(
+          '<w:p><w:r><w:rPr><w:b/><w:i/></w:rPr><w:t>Hello World</w:t></w:r></w:p>',
+        ));
+      });
+
+      await when('addComment is called with mid-run offsets', async () => {
+        const p = doc.getElementsByTagNameNS(W_NS, W.p).item(0) as Element;
+        await addComment(doc, zip, {
+          paragraphEl: p,
+          start: 'Hello '.length,
+          end: 'Hello World'.length,
+          author: 'Test',
+          text: 'Bold split',
+        });
+      });
+
+      await then('both pre-run and span-run carry bold+italic', () => {
+        const p = doc.getElementsByTagNameNS(W_NS, W.p).item(0) as Element;
+        const visibleRuns = Array.from(p.getElementsByTagNameNS(W_NS, W.r)).filter(
+          (r) => r.getElementsByTagNameNS(W_NS, W.t).length > 0,
+        );
+        expect(visibleRuns).toHaveLength(2);
+        for (const r of visibleRuns) {
+          const rPr = r.getElementsByTagNameNS(W_NS, W.rPr).item(0)!;
+          expect(rPr.getElementsByTagNameNS(W_NS, W.b).length).toBe(1);
+          expect(rPr.getElementsByTagNameNS(W_NS, W.i).length).toBe(1);
+        }
+      });
+    });
+
+    test('keeps markers inside w:hyperlink when anchor falls inside the wrapper', async ({ given, when, then }: AllureBddContext) => {
+      let zip: DocxZip;
+      let doc: Document;
+
+      await given('a paragraph whose only visible text is inside a w:hyperlink', async () => {
+        // w:anchor avoids needing the r:id namespace; semantically still a hyperlink wrapper for our test.
+        ({ zip, doc } = await setupWithComment(
+          '<w:p><w:hyperlink w:anchor="bk1"><w:r><w:t>Visit our website now</w:t></w:r></w:hyperlink></w:p>',
+        ));
+      });
+
+      await when('addComment is called with offsets that bracket "website"', async () => {
+        const p = doc.getElementsByTagNameNS(W_NS, W.p).item(0) as Element;
+        const start = 'Visit our '.length;
+        const end = start + 'website'.length;
+        await addComment(doc, zip, {
+          paragraphEl: p,
+          start,
+          end,
+          author: 'Test',
+          text: 'Hyperlink-internal anchor',
+        });
+      });
+
+      await then('the hyperlink wrapper still contains the split runs and the markers', () => {
+        const p = doc.getElementsByTagNameNS(W_NS, W.p).item(0) as Element;
+        const hyperlink = p.getElementsByTagNameNS(W_NS, 'hyperlink').item(0) as Element;
+        expect(hyperlink).toBeTruthy();
+        const childLocalNames = Array.from(hyperlink.childNodes)
+          .filter((c) => c.nodeType === 1)
+          .map((c) => (c as Element).localName);
+        // [pre-run, commentRangeStart, span-run, commentRangeEnd, post-run, commentReference-run]
+        // [pre-run, commentRangeStart, span-run, commentRangeEnd, commentReference-run, post-run]
+        expect(childLocalNames).toEqual([
+          'r',
+          'commentRangeStart',
+          'r',
+          'commentRangeEnd',
+          'r',
+          'r',
+        ]);
+      });
+    });
+
+    test('keeps markers inside w:ins (tracked-change wrapper) when anchor falls inside it', async ({ given, when, then }: AllureBddContext) => {
+      let zip: DocxZip;
+      let doc: Document;
+
+      await given('a paragraph whose only visible text is inside a w:ins', async () => {
+        ({ zip, doc } = await setupWithComment(
+          '<w:p><w:ins w:id="1" w:author="A" w:date="2025-01-01T00:00:00Z"><w:r><w:t>inserted clause text</w:t></w:r></w:ins></w:p>',
+        ));
+      });
+
+      await when('addComment is called with offsets bracketing "clause"', async () => {
+        const p = doc.getElementsByTagNameNS(W_NS, W.p).item(0) as Element;
+        const start = 'inserted '.length;
+        const end = start + 'clause'.length;
+        await addComment(doc, zip, {
+          paragraphEl: p,
+          start,
+          end,
+          author: 'Test',
+          text: 'Ins-internal anchor',
+        });
+      });
+
+      await then('the w:ins wrapper still contains the split runs and the markers', () => {
+        const p = doc.getElementsByTagNameNS(W_NS, W.p).item(0) as Element;
+        const ins = p.getElementsByTagNameNS(W_NS, 'ins').item(0) as Element;
+        expect(ins).toBeTruthy();
+        const childLocalNames = Array.from(ins.childNodes)
+          .filter((c) => c.nodeType === 1)
+          .map((c) => (c as Element).localName);
+        // [pre-run, commentRangeStart, span-run, commentRangeEnd, commentReference-run, post-run]
+        expect(childLocalNames).toEqual([
+          'r',
+          'commentRangeStart',
+          'r',
+          'commentRangeEnd',
+          'r',
+          'r',
+        ]);
+      });
+    });
+
+    test('moves a w:tab to the span when the anchor starts exactly on it', async ({ given, when, then }: AllureBddContext) => {
+      let zip: DocxZip;
+      let doc: Document;
+
+      await given('a paragraph with text-tab-text in one run', async () => {
+        ({ zip, doc } = await setupWithComment(
+          '<w:p><w:r><w:t>foo</w:t><w:tab/><w:t>bar</w:t></w:r></w:p>',
+        ));
+      });
+
+      await when('addComment anchors from the tab through the trailing text', async () => {
+        const p = doc.getElementsByTagNameNS(W_NS, W.p).item(0) as Element;
+        // Visible text = "foo\tbar" (length 7). Anchor "\tbar" → start 3, end 7.
+        await addComment(doc, zip, {
+          paragraphEl: p,
+          start: 3,
+          end: 7,
+          author: 'Test',
+          text: 'Tab-spanning anchor',
+        });
+      });
+
+      await then('the tab lands in the span run, not the pre run', () => {
+        const p = doc.getElementsByTagNameNS(W_NS, W.p).item(0) as Element;
+        const visibleRuns = Array.from(p.getElementsByTagNameNS(W_NS, W.r)).filter((r) => {
+          return Array.from(r.childNodes).some((c) => {
+            if (c.nodeType !== 1) return false;
+            const local = (c as Element).localName;
+            return local === 't' || local === 'tab' || local === 'br';
+          });
+        });
+        // Pre run has "foo" only; span run has tab+"bar"; commentReference run has nothing visible (filtered out).
+        expect(visibleRuns).toHaveLength(2);
+        const preChildren = Array.from(visibleRuns[0]!.childNodes)
+          .filter((c) => c.nodeType === 1)
+          .map((c) => (c as Element).localName);
+        expect(preChildren).toContain('t');
+        expect(preChildren).not.toContain('tab');
+        const spanChildren = Array.from(visibleRuns[1]!.childNodes)
+          .filter((c) => c.nodeType === 1)
+          .map((c) => (c as Element).localName);
+        expect(spanChildren).toContain('tab');
+        expect(spanChildren).toContain('t');
+      });
+    });
+
+    test('falls back to whole-paragraph wrap when offsets are out of range', async ({ given, when, then }: AllureBddContext) => {
+      // Defense-in-depth for direct callers of the docx-core primitive that pass
+      // offsets findOffsetInRuns cannot map (e.g., > visible length).
+      let zip: DocxZip;
+      let doc: Document;
+
+      await given('a document with a short paragraph', async () => {
+        ({ zip, doc } = await setupWithComment('<w:p><w:r><w:t>Short</w:t></w:r></w:p>'));
+      });
+
+      await when('addComment is called with offsets beyond the paragraph length', async () => {
+        const p = doc.getElementsByTagNameNS(W_NS, W.p).item(0) as Element;
+        await addComment(doc, zip, {
+          paragraphEl: p,
+          start: 100,
+          end: 200,
+          author: 'Test',
+          text: 'Out-of-range fallback',
+        });
+      });
+
+      await then('markers are inserted at run boundaries without throwing', () => {
+        const p = doc.getElementsByTagNameNS(W_NS, W.p).item(0) as Element;
+        const childLocalNames = Array.from(p.childNodes)
+          .filter((c) => c.nodeType === 1)
+          .map((c) => (c as Element).localName);
+        expect(childLocalNames).toContain('commentRangeStart');
+        expect(childLocalNames).toContain('commentRangeEnd');
+        expect(childLocalNames).toContain('r');
+      });
+    });
   });
 
   describe('addCommentReply', () => {

--- a/packages/docx-core/src/primitives/comments.ts
+++ b/packages/docx-core/src/primitives/comments.ts
@@ -8,7 +8,7 @@
 import { OOXML, W } from './namespaces.js';
 import { parseXml, serializeXml } from './xml.js';
 import { DocxZip } from './zip.js';
-import { getParagraphRuns, getParagraphText } from './text.js';
+import { findOffsetInRuns, getParagraphRuns, getParagraphText, splitRunAtVisibleOffset, type TextRun } from './text.js';
 import { getParagraphBookmarkId } from './bookmarks.js';
 import { childElements, getLeafText, isW } from './dom-helpers.js';
 
@@ -378,10 +378,8 @@ function insertCommentMarkers(
   start: number,
   end: number,
 ): void {
-  // Find the runs in the paragraph and map string offsets to DOM positions
   const runs = getParagraphRuns(paragraphEl);
 
-  // Create marker elements
   const rangeStart = documentXml.createElementNS(OOXML.W_NS, 'w:commentRangeStart');
   rangeStart.setAttribute('w:id', String(commentId));
 
@@ -398,39 +396,83 @@ function insertCommentMarkers(
   commentRef.setAttribute('w:id', String(commentId));
   refRun.appendChild(commentRef);
 
-  // Map string offsets to run positions
-  let pos = 0;
-  let startRunIdx = -1;
-  let endRunIdx = -1;
-
-  for (let i = 0; i < runs.length; i++) {
-    const runEnd = pos + runs[i]!.text.length;
-    if (startRunIdx < 0 && start < runEnd) startRunIdx = i;
-    if (endRunIdx < 0 && end <= runEnd) endRunIdx = i;
-    pos = runEnd;
-  }
-
-  // Fallback: if offsets don't map cleanly, wrap the whole paragraph
-  if (startRunIdx < 0) startRunIdx = 0;
-  if (endRunIdx < 0) endRunIdx = runs.length - 1;
-
-  // Insert commentRangeStart before the start run
-  if (runs.length > 0 && startRunIdx < runs.length) {
-    paragraphEl.insertBefore(rangeStart, runs[startRunIdx]!.r);
-  } else {
-    // No runs — insert at end of paragraph
+  if (runs.length === 0) {
     paragraphEl.appendChild(rangeStart);
-  }
-
-  // Insert commentRangeEnd and reference run after the end run
-  if (runs.length > 0 && endRunIdx < runs.length) {
-    const afterEndRun = runs[endRunIdx]!.r.nextSibling;
-    paragraphEl.insertBefore(rangeEnd, afterEndRun);
-    paragraphEl.insertBefore(refRun, afterEndRun);
-  } else {
     paragraphEl.appendChild(rangeEnd);
     paragraphEl.appendChild(refRun);
+    return;
   }
+
+  let mapping: ReturnType<typeof findOffsetInRuns>;
+  try {
+    mapping = findOffsetInRuns(runs, start, end);
+  } catch {
+    insertCommentMarkersAtRunBoundaries(runs, rangeStart, rangeEnd, refRun);
+    return;
+  }
+
+  const { startRunIdx, startOffset, endRunIdx, endOffset } = mapping;
+
+  // Split boundary runs at the exact visible-text offsets so the markers can sit
+  // on true sub-paragraph boundaries instead of being snapped to whole-run edges.
+  // Choreography mirrors replaceParagraphTextRange() in text.ts.
+  let startRunEl: Element = runs[startRunIdx]!.r;
+  let endRunEl: Element = runs[endRunIdx]!.r;
+
+  if (startRunIdx === endRunIdx) {
+    const runLen = runs[startRunIdx]!.text.length;
+    if (endOffset < runLen) {
+      const { left } = splitRunAtVisibleOffset(startRunEl, endOffset);
+      startRunEl = left;
+      endRunEl = left;
+    }
+    if (startOffset > 0) {
+      const { right } = splitRunAtVisibleOffset(startRunEl, startOffset);
+      startRunEl = right;
+      endRunEl = right;
+    }
+  } else {
+    if (startOffset > 0) {
+      const { right } = splitRunAtVisibleOffset(startRunEl, startOffset);
+      startRunEl = right;
+    }
+    const endLen = runs[endRunIdx]!.text.length;
+    if (endOffset < endLen) {
+      const { left } = splitRunAtVisibleOffset(endRunEl, endOffset);
+      endRunEl = left;
+    }
+  }
+
+  // Insert relative to each run's parent so anchors inside w:hyperlink, w:ins,
+  // w:del, w:sdtContent, etc. keep the markers inside the wrapper.
+  const startParent = startRunEl.parentNode;
+  const endParent = endRunEl.parentNode;
+  if (!startParent || !endParent) {
+    insertCommentMarkersAtRunBoundaries(runs, rangeStart, rangeEnd, refRun);
+    return;
+  }
+
+  startParent.insertBefore(rangeStart, startRunEl);
+  endParent.insertBefore(rangeEnd, endRunEl.nextSibling);
+  endParent.insertBefore(refRun, rangeEnd.nextSibling);
+}
+
+function insertCommentMarkersAtRunBoundaries(
+  runs: TextRun[],
+  rangeStart: Element,
+  rangeEnd: Element,
+  refRun: Element,
+): void {
+  const firstRun = runs[0]!.r;
+  const lastRun = runs[runs.length - 1]!.r;
+  const firstParent = firstRun.parentNode;
+  const lastParent = lastRun.parentNode;
+  if (!firstParent || !lastParent) {
+    throw new Error('Run has no parent');
+  }
+  firstParent.insertBefore(rangeStart, firstRun);
+  lastParent.insertBefore(rangeEnd, lastRun.nextSibling);
+  lastParent.insertBefore(refRun, rangeEnd.nextSibling);
 }
 
 async function linkReplyInCommentsExtended(

--- a/packages/docx-core/src/primitives/text.ts
+++ b/packages/docx-core/src/primitives/text.ts
@@ -74,7 +74,7 @@ export function getParagraphText(p: Element): string {
     .join('');
 }
 
-function findOffsetInRuns(runs: TextRun[], start: number, end: number): {
+export function findOffsetInRuns(runs: TextRun[], start: number, end: number): {
   startRunIdx: number;
   startOffset: number;
   endRunIdx: number;

--- a/packages/docx-mcp/src/tools/read_file_comments.test.ts
+++ b/packages/docx-mcp/src/tools/read_file_comments.test.ts
@@ -893,6 +893,34 @@ describe('read_file comment rendering', () => {
     expect(content).toContain(`#COMMENT ${opened.firstParaId} c${result.comment_id} Alice `);
   });
 
+  test('inline_markers renders the anchor span when add_comment(anchor_text) hits a single-run paragraph (#151)', async () => {
+    // Issue #151: paragraphs stored as one big <w:r> previously caused the writer to
+    // wrap the whole run, which inline_markers would then suppress. With run-splitting,
+    // the markers must bracket only the anchor span and inline_markers must render them.
+    const opened = await openSession([
+      'The terms below are incorporated into and form part of this agreement.',
+    ]);
+    const result = await addComment(opened.mgr, {
+      file_path: opened.inputPath,
+      target_paragraph_id: opened.firstParaId,
+      anchor_text: 'incorporated',
+      author: 'SmokeTest',
+      text: 'Range comment on "incorporated".',
+    });
+    assertSuccess(result, 'add_comment');
+
+    const read = await readFile(opened.mgr, {
+      file_path: opened.inputPath,
+      comment_rendering: 'inline_markers',
+    });
+    assertSuccess(read, 'read_file');
+    const content = String(read.content);
+    const line = findParagraphLine(toonLines(content), opened.firstParaId);
+    const id = result.comment_id as number;
+    expect(line).toContain(`[cm-start:${id}]incorporated[cm-end:${id}]`);
+    expect(content).toContain(`#COMMENT ${opened.firstParaId} c${id} SmokeTest `);
+  });
+
   test('inline_markers renders multi-paragraph ranges only at the boundary paragraphs', async () => {
     const { lines } = await renderCommentFixture({
       bodyXml:


### PR DESCRIPTION
Closes #151.

## Summary
- `insertCommentMarkers()` now splits boundary runs at exact visible-text offsets so `commentRangeStart` / `commentRangeEnd` bracket only the anchor span, instead of snapping to existing run boundaries.
- Markers are inserted relative to each run's `parentNode`, so anchors inside `w:hyperlink`, `w:ins`, `w:del`, or `w:sdtContent` keep the markers inside the wrapper.
- Same-run choreography: split at `endOffset` first, then split the resulting left half at `startOffset` → `[pre, span, post]`. Cross-run: split start, then end. Mirrors `replaceParagraphTextRange()` in `text.ts`.
- Out-of-range offsets fall back to the previous whole-paragraph wrap (preserves backward compat for direct primitive callers).
- Exports `findOffsetInRuns()` from `text.ts` for reuse.

## Why this matters
With the write-side fix, AI workflows that call `add_comment(anchor_text="…")` against single-run paragraphs (the openagreements reproducer in #151) now produce span-precise ranges. The MCP `read_file(comment_rendering: 'inline_markers')` reader no longer suppresses them as whole-paragraph — confirmed by a new E2E test that asserts `[cm-start:N]incorporated[cm-end:N]` appears inline.

## Tests
- 8 new unit tests in `packages/docx-core/src/primitives/comments.test.ts`:
  - single-run mid-anchor split + structural assertions + run-index metadata
  - cross-run anchor splits start and end runs, leaves middle untouched
  - anchor exactly equals the only run's text → no split
  - rPr (bold + italic) preserved on both halves
  - markers stay inside `w:hyperlink` wrapper when anchor falls inside it
  - markers stay inside `w:ins` (tracked-change) wrapper
  - tab handling: anchor starting on a `w:tab` keeps the tab in the span run
  - out-of-range offsets fall back to whole-paragraph wrap
- 1 new MCP E2E test in `packages/docx-mcp/src/tools/read_file_comments.test.ts` covering the user-visible regression: `add_comment(anchor_text="incorporated")` → `read_file(inline_markers)` shows `[cm-start:N]incorporated[cm-end:N]` inline.

## Test plan
- [x] `npm --workspace @usejunior/docx-core run test:run` — 1128 pass + 1 skipped (was: 1120 pass; 8 new)
- [x] `npm --workspace @usejunior/docx-mcp run test:run` — 674 pass (was: 673 pass; 1 new E2E)
- [x] `npm --workspace @usejunior/docx-core run lint` (tsc --noEmit) — clean
- [x] `npm --workspace @usejunior/docx-mcp run lint` (tsc -b) — clean

## Out of scope (flagged for follow-up)
- `packages/docx-core/src/primitives/footnotes.ts` `splitRunAndInsertReference()` (line 404) duplicates much of `splitRunAtVisibleOffset()`. Worth a small refactor in a separate ticket.
- Public-API offset validation: `addComment(documentXml, zip, params)` still permissively falls back on `< 0` or `> fullVisibleLength` rather than throwing — preserved here to avoid downstream-visible behavior change.