### PR TITLE
fix(docx-core): handle collapsed ranges and validate offsets in addComment

### DIFF
--- a/packages/docx-core/src/primitives/comments.test.ts
+++ b/packages/docx-core/src/primitives/comments.test.ts
@@ -720,35 +720,177 @@ describe('comments — edge cases and branch coverage', () => {
       });
     });
 
-    test('falls back to whole-paragraph wrap when offsets are out of range', async ({ given, when, then }: AllureBddContext) => {
-      // Defense-in-depth for direct callers of the docx-core primitive that pass
-      // offsets findOffsetInRuns cannot map (e.g., > visible length).
+    test('throws when offsets exceed paragraph visible length', async ({ given, when, then }: AllureBddContext) => {
+      // Anchoring on unrelated text would be worse than a clear error, so
+      // out-of-range offsets must fail loudly. Direct callers of the docx-core
+      // primitive should validate offsets against getParagraphText() themselves.
       let zip: DocxZip;
       let doc: Document;
+      let p: Element;
 
       await given('a document with a short paragraph', async () => {
-        ({ zip, doc } = await setupWithComment('<w:p><w:r><w:t>Short</w:t></w:r></w:p>'));
+        ({ zip, doc, p } = await setupWithComment('<w:p><w:r><w:t>Short</w:t></w:r></w:p>'));
       });
 
       await when('addComment is called with offsets beyond the paragraph length', async () => {
+        // assertion in then
+      });
+
+      await then('an error is thrown', async () => {
+        await expect(
+          addComment(doc, zip, {
+            paragraphEl: p,
+            start: 100,
+            end: 200,
+            author: 'Test',
+            text: 'Out-of-range',
+          }),
+        ).rejects.toThrow(/outside paragraph visible text/);
+      });
+    });
+
+    test('throws when start is negative', async ({ given, when, then }: AllureBddContext) => {
+      let zip: DocxZip;
+      let doc: Document;
+      let p: Element;
+
+      await given('a document with a paragraph', async () => {
+        ({ zip, doc, p } = await setupWithComment());
+      });
+
+      await when('addComment is called with a negative start', async () => {
+        // assertion in then
+      });
+
+      await then('an error is thrown', async () => {
+        await expect(
+          addComment(doc, zip, {
+            paragraphEl: p,
+            start: -1,
+            end: 5,
+            author: 'Test',
+            text: 'Negative start',
+          }),
+        ).rejects.toThrow(/outside paragraph visible text/);
+      });
+    });
+
+    test('handles a collapsed range (start === end) in the middle of a run', async ({ given, when, then, and }: AllureBddContext) => {
+      let zip: DocxZip;
+      let doc: Document;
+
+      await given('a document with one run', async () => {
+        ({ zip, doc } = await setupWithComment('<w:p><w:r><w:t>Hello World</w:t></w:r></w:p>'));
+      });
+
+      await when('addComment is called with a zero-width range mid-run', async () => {
         const p = doc.getElementsByTagNameNS(W_NS, W.p).item(0) as Element;
         await addComment(doc, zip, {
           paragraphEl: p,
-          start: 100,
-          end: 200,
+          start: 5,
+          end: 5,
           author: 'Test',
-          text: 'Out-of-range fallback',
+          text: 'Insertion-point comment',
         });
       });
 
-      await then('markers are inserted at run boundaries without throwing', () => {
+      await then('the run is split once and the markers sit between the two halves', () => {
         const p = doc.getElementsByTagNameNS(W_NS, W.p).item(0) as Element;
-        const childLocalNames = Array.from(p.childNodes)
-          .filter((c) => c.nodeType === 1)
-          .map((c) => (c as Element).localName);
-        expect(childLocalNames).toContain('commentRangeStart');
-        expect(childLocalNames).toContain('commentRangeEnd');
-        expect(childLocalNames).toContain('r');
+        const children = Array.from(p.childNodes).filter((n) => n.nodeType === 1) as Element[];
+        // Layout: [pre-run "Hello", commentRangeStart, commentRangeEnd, commentReference-run, post-run " World"]
+        expect(children.map((c) => c.localName)).toEqual([
+          'r',
+          'commentRangeStart',
+          'commentRangeEnd',
+          'r',
+          'r',
+        ]);
+        expect(children[0]!.textContent).toBe('Hello');
+        expect(children[4]!.textContent).toBe(' World');
+      });
+
+      await and('no empty <w:r> survived the split', () => {
+        const p = doc.getElementsByTagNameNS(W_NS, W.p).item(0) as Element;
+        const visibleRuns = Array.from(p.getElementsByTagNameNS(W_NS, W.r)).filter((r) => {
+          return Array.from(r.childNodes).some((c) => {
+            if (c.nodeType !== 1) return false;
+            const local = (c as Element).localName;
+            return local === 't' || local === 'tab' || local === 'br' || local === 'commentReference';
+          });
+        });
+        // Pre-run, post-run, and commentReference run all have meaningful content; no empty <w:r>.
+        expect(visibleRuns).toHaveLength(3);
+      });
+    });
+
+    test('handles a collapsed range at the very start of a paragraph', async ({ given, when, then }: AllureBddContext) => {
+      let zip: DocxZip;
+      let doc: Document;
+
+      await given('a document with one run', async () => {
+        ({ zip, doc } = await setupWithComment('<w:p><w:r><w:t>Hello World</w:t></w:r></w:p>'));
+      });
+
+      await when('addComment is called with start === end === 0', async () => {
+        const p = doc.getElementsByTagNameNS(W_NS, W.p).item(0) as Element;
+        await addComment(doc, zip, {
+          paragraphEl: p,
+          start: 0,
+          end: 0,
+          author: 'Test',
+          text: 'At paragraph start',
+        });
+      });
+
+      await then('markers go before the run, no split occurs', () => {
+        const p = doc.getElementsByTagNameNS(W_NS, W.p).item(0) as Element;
+        const children = Array.from(p.childNodes).filter((n) => n.nodeType === 1) as Element[];
+        expect(children.map((c) => c.localName)).toEqual([
+          'commentRangeStart',
+          'commentRangeEnd',
+          'r',
+          'r',
+        ]);
+        // commentReference run is at index 2; original run with full text is at index 3.
+        expect(children[3]!.textContent).toBe('Hello World');
+      });
+    });
+
+    test('handles a collapsed range at an existing run boundary', async ({ given, when, then }: AllureBddContext) => {
+      let zip: DocxZip;
+      let doc: Document;
+
+      await given('a document with two runs', async () => {
+        ({ zip, doc } = await setupWithComment(
+          '<w:p><w:r><w:t>Hello </w:t></w:r><w:r><w:t>World</w:t></w:r></w:p>',
+        ));
+      });
+
+      await when('addComment is called with start === end at the boundary between them', async () => {
+        const p = doc.getElementsByTagNameNS(W_NS, W.p).item(0) as Element;
+        // Visible "Hello " is 6 chars; boundary at offset 6 sits between the two runs.
+        await addComment(doc, zip, {
+          paragraphEl: p,
+          start: 6,
+          end: 6,
+          author: 'Test',
+          text: 'At run boundary',
+        });
+      });
+
+      await then('markers go between the two existing runs, no split occurs', () => {
+        const p = doc.getElementsByTagNameNS(W_NS, W.p).item(0) as Element;
+        const children = Array.from(p.childNodes).filter((n) => n.nodeType === 1) as Element[];
+        // Layout: ["Hello ", commentRangeStart, commentRangeEnd, commentReference-run, "World"]
+        expect(children.map((c) => c.localName)).toEqual([
+          'r',
+          'commentRangeStart',
+          'commentRangeEnd',
+          'r',
+          'r',
+        ]);
+        expect(children[0]!.textContent).toBe('Hello ');
+        expect(children[4]!.textContent).toBe('World');
       });
     });
   });

--- a/packages/docx-core/src/primitives/comments.ts
+++ b/packages/docx-core/src/primitives/comments.ts
@@ -8,7 +8,7 @@
 import { OOXML, W } from './namespaces.js';
 import { parseXml, serializeXml } from './xml.js';
 import { DocxZip } from './zip.js';
-import { findOffsetInRuns, getParagraphRuns, getParagraphText, splitRunAtVisibleOffset, type TextRun } from './text.js';
+import { getParagraphRuns, getParagraphText, splitRunAtVisibleOffset, type TextRun } from './text.js';
 import { getParagraphBookmarkId } from './bookmarks.js';
 import { childElements, getLeafText, isW } from './dom-helpers.js';
 
@@ -208,10 +208,16 @@ export async function addComment(
   params: AddCommentParams,
 ): Promise<AddCommentResult> {
   const { paragraphEl, author, text, initials } = params;
+  const visibleLen = getParagraphText(paragraphEl).length;
   const start = params.start ?? 0;
-  const end = params.end ?? getParagraphText(paragraphEl).length;
+  const end = params.end ?? visibleLen;
   if (start > end) {
     throw new Error(`Invalid comment range: start (${start}) must be <= end (${end})`);
+  }
+  if (start < 0 || end > visibleLen) {
+    throw new Error(
+      `Invalid comment range: [${start}, ${end}) is outside paragraph visible text [0, ${visibleLen})`,
+    );
   }
 
   // Load comments.xml
@@ -403,19 +409,27 @@ function insertCommentMarkers(
     return;
   }
 
-  let mapping: ReturnType<typeof findOffsetInRuns>;
-  try {
-    mapping = findOffsetInRuns(runs, start, end);
-  } catch {
-    insertCommentMarkersAtRunBoundaries(runs, rangeStart, rangeEnd, refRun);
+  const mapping = mapOffsetsToRuns(runs, start, end);
+  const { startRunIdx, startOffset, endRunIdx, endOffset } = mapping;
+
+  // Collapsed range (start === end): insert both markers at the same boundary.
+  // Splitting again here would create an empty <w:r> inside the marker pair —
+  // replaceParagraphTextRange() avoids this by deleting the temporary run, which
+  // we can't do for comments. Handle the boundary directly.
+  if (startRunIdx === endRunIdx && startOffset === endOffset) {
+    insertCollapsedRangeMarkers(
+      runs[startRunIdx]!,
+      startOffset,
+      rangeStart,
+      rangeEnd,
+      refRun,
+    );
     return;
   }
 
-  const { startRunIdx, startOffset, endRunIdx, endOffset } = mapping;
-
   // Split boundary runs at the exact visible-text offsets so the markers can sit
   // on true sub-paragraph boundaries instead of being snapped to whole-run edges.
-  // Choreography mirrors replaceParagraphTextRange() in text.ts.
+  // Choreography mirrors replaceParagraphTextRange() in text.ts:404.
   let startRunEl: Element = runs[startRunIdx]!.r;
   let endRunEl: Element = runs[endRunIdx]!.r;
 
@@ -448,8 +462,7 @@ function insertCommentMarkers(
   const startParent = startRunEl.parentNode;
   const endParent = endRunEl.parentNode;
   if (!startParent || !endParent) {
-    insertCommentMarkersAtRunBoundaries(runs, rangeStart, rangeEnd, refRun);
-    return;
+    throw new Error('Split run has no parent');
   }
 
   startParent.insertBefore(rangeStart, startRunEl);
@@ -457,22 +470,70 @@ function insertCommentMarkers(
   endParent.insertBefore(refRun, rangeEnd.nextSibling);
 }
 
-function insertCommentMarkersAtRunBoundaries(
+function mapOffsetsToRuns(
   runs: TextRun[],
+  start: number,
+  end: number,
+): { startRunIdx: number; startOffset: number; endRunIdx: number; endOffset: number } {
+  // Map visible-text offsets to (runIndex, offsetInRun). Caller validates that
+  // 0 <= start <= end <= sum(runs[i].text.length).
+  let pos = 0;
+  let startRunIdx = -1;
+  let endRunIdx = -1;
+  let startOffset = 0;
+  let endOffset = 0;
+  for (let i = 0; i < runs.length; i++) {
+    const len = runs[i]!.text.length;
+    if (startRunIdx === -1 && start >= pos && start <= pos + len) {
+      startRunIdx = i;
+      startOffset = start - pos;
+    }
+    if (endRunIdx === -1 && end >= pos && end <= pos + len) {
+      endRunIdx = i;
+      endOffset = end - pos;
+      break;
+    }
+    pos += len;
+  }
+  if (startRunIdx === -1 || endRunIdx === -1) {
+    throw new Error(`Could not map offsets [${start}, ${end}) to runs`);
+  }
+  return { startRunIdx, startOffset, endRunIdx, endOffset };
+}
+
+function insertCollapsedRangeMarkers(
+  run: TextRun,
+  offsetInRun: number,
   rangeStart: Element,
   rangeEnd: Element,
   refRun: Element,
 ): void {
-  const firstRun = runs[0]!.r;
-  const lastRun = runs[runs.length - 1]!.r;
-  const firstParent = firstRun.parentNode;
-  const lastParent = lastRun.parentNode;
-  if (!firstParent || !lastParent) {
-    throw new Error('Run has no parent');
+  const runEl = run.r;
+  const parent = runEl.parentNode;
+  if (!parent) throw new Error('Run has no parent');
+  const runLen = run.text.length;
+
+  if (offsetInRun === 0) {
+    // Insert before the run.
+    parent.insertBefore(rangeStart, runEl);
+    parent.insertBefore(rangeEnd, runEl);
+    parent.insertBefore(refRun, runEl);
+    return;
   }
-  firstParent.insertBefore(rangeStart, firstRun);
-  lastParent.insertBefore(rangeEnd, lastRun.nextSibling);
-  lastParent.insertBefore(refRun, rangeEnd.nextSibling);
+  if (offsetInRun === runLen) {
+    // Insert after the run. Capture nextSibling once because insertBefore
+    // shifts it (rangeStart would otherwise land last instead of first).
+    const ref = runEl.nextSibling;
+    parent.insertBefore(rangeStart, ref);
+    parent.insertBefore(rangeEnd, ref);
+    parent.insertBefore(refRun, ref);
+    return;
+  }
+  // Mid-run: split once so the markers sit between the two halves.
+  const { right } = splitRunAtVisibleOffset(runEl, offsetInRun);
+  parent.insertBefore(rangeStart, right);
+  parent.insertBefore(rangeEnd, right);
+  parent.insertBefore(refRun, right);
 }
 
 async function linkReplyInCommentsExtended(

--- a/packages/docx-core/src/primitives/text.ts
+++ b/packages/docx-core/src/primitives/text.ts
@@ -74,7 +74,7 @@ export function getParagraphText(p: Element): string {
     .join('');
 }
 
-export function findOffsetInRuns(runs: TextRun[], start: number, end: number): {
+function findOffsetInRuns(runs: TextRun[], start: number, end: number): {
   startRunIdx: number;
   startOffset: number;
   endRunIdx: number;


### PR DESCRIPTION
Follow-up to #151 / #153 addressing three concrete issues raised in the post-merge peer review (Codex):

## Summary
1. **Collapsed-range bug.** When `start === end > 0` on a non-empty paragraph, the same-run double-split path in #153 could leave an empty `<w:r>` inside the marker pair. `replaceParagraphTextRange()` avoids this by deleting its temporary run; `insertCommentMarkers()` couldn't. New code detects collapsed ranges up front and uses a dedicated path that splits at most once and inserts both markers at the same boundary.
2. **Validate offsets up front.** Previously, out-of-range offsets silently fell back to a whole-paragraph wrap — anchoring a comment on unrelated text rather than failing loudly. `addComment()` now validates `0 <= start <= end <= getParagraphText(paragraphEl).length` and throws on out-of-range. The locked-in fallback test is replaced with a throw-on-out-of-range test plus a negative-start test.
3. **Revert public export of `findOffsetInRuns`.** #153 inadvertently expanded the `@usejunior/docx-core` surface (via the `primitives/index.ts` barrel re-export of `text.ts`). The offset-mapping logic is now inlined as a private helper in `comments.ts`, so the public API is unchanged.

## Tests
- 3 new collapsed-range tests (mid-run, paragraph start, run boundary).
- Replaced the silent-fallback test with `throws when offsets exceed paragraph visible length` + `throws when start is negative`.

| Suite | Before | After |
|---|---|---|
| docx-core | 1128 + 1 skipped | 1132 + 1 skipped |
| docx-mcp | 674 | 674 |

Both lint runs (`tsc --noEmit`, `tsc -b`) clean.

## Smoke
Re-ran the three-real-doc smoke (`bonterms-mutual-nda.docx`, `Balanced_Employee_IP_Agreement.docx`, `Co-Founder Agreement.docx`) on this branch: 3/3 produce span-precise saved XML, same as #153.

## Test plan
- [x] All existing tests still pass
- [x] New collapsed-range tests cover mid-run, paragraph-start, and run-boundary cases
- [x] Out-of-range offsets now throw with a clear message
- [x] `findOffsetInRuns` is no longer publicly exported
- [x] Smoke against three real legal docs still produces span-precise saved XML

## Why a separate PR

#153 was already merged when these issues surfaced. Splitting them out makes the diff smaller, the bisect history cleaner, and lets reviewers focus on the three specific corrections.

## Related
- Original fix: #151 / PR #153
- Reader-side follow-up (separate concern, unrelated): #154