### PR TITLE
feat(docx-core): emit tracked-change markup for footnote body + note text (#139)

### DIFF
--- a/packages/docx-core/src/primitives/document.ts
+++ b/packages/docx-core/src/primitives/document.ts
@@ -899,7 +899,7 @@ export class DocxDocument {
     paragraphId: string;
     afterText?: string;
     text: string;
-  }): Promise<AddFootnoteResult> {
+  }, ctx?: RevisionContext): Promise<AddFootnoteResult> {
     const p = findParagraphByBookmarkId(this.documentXml, params.paragraphId);
     if (!p) throw new Error(`Paragraph not found: ${params.paragraphId}`);
 
@@ -908,7 +908,7 @@ export class DocxDocument {
       paragraphEl: p,
       afterText: params.afterText,
       text: params.text,
-    });
+    }, ctx);
 
     await this.refreshFootnotesXml();
     this.dirty = true;
@@ -919,8 +919,8 @@ export class DocxDocument {
   /**
    * Update the text content of an existing footnote.
    */
-  async updateFootnoteText(params: { noteId: number; newText: string }): Promise<void> {
-    await updateFootnoteTextImpl(this.zip, params);
+  async updateFootnoteText(params: { noteId: number; newText: string }, ctx?: RevisionContext): Promise<void> {
+    await updateFootnoteTextImpl(this.zip, params, ctx);
     await this.refreshFootnotesXml();
     this.dirty = true;
     this.documentViewCache = null;
@@ -929,8 +929,8 @@ export class DocxDocument {
   /**
    * Delete a footnote and its references from the document.
    */
-  async deleteFootnote(params: { noteId: number }): Promise<void> {
-    await deleteFootnoteImpl(this.documentXml, this.zip, params);
+  async deleteFootnote(params: { noteId: number }, ctx?: RevisionContext): Promise<void> {
+    await deleteFootnoteImpl(this.documentXml, this.zip, params, ctx);
     await this.refreshFootnotesXml();
     this.dirty = true;
     this.documentViewCache = null;

--- a/packages/docx-core/src/primitives/footnotes.ts
+++ b/packages/docx-core/src/primitives/footnotes.ts
@@ -11,6 +11,12 @@ import { DocxZip } from './zip.js';
 import { getParagraphRuns } from './text.js';
 import { getParagraphBookmarkId } from './bookmarks.js';
 import { findUniqueSubstringMatch } from './matching.js';
+import { childElements, isW } from './dom-helpers.js';
+import {
+  createRevisionContainer,
+  prepareElementForDeletion,
+  type RevisionContext,
+} from './track-changes-emitter.js';
 
 // ── Relationship & content types ────────────────────────────────────────
 
@@ -309,6 +315,7 @@ export async function addFootnote(
   documentXml: Document,
   zip: DocxZip,
   params: AddFootnoteParams,
+  ctx?: RevisionContext,
 ): Promise<AddFootnoteResult> {
   const { paragraphEl, afterText, text } = params;
 
@@ -320,10 +327,13 @@ export async function addFootnote(
   const noteId = allocateNextFootnoteId(footnotesDoc);
 
   // Insert footnoteReference run in document body
-  insertFootnoteReference(documentXml, paragraphEl, noteId, afterText);
+  insertFootnoteReference(documentXml, paragraphEl, noteId, afterText, ctx);
 
   // Add footnote body to footnotes.xml
-  addFootnoteElement(footnotesDoc, noteId, text);
+  const footnoteEl = addFootnoteElement(footnotesDoc, noteId, text);
+  if (ctx) {
+    wrapFootnoteParagraphTextRuns(getFirstFootnoteParagraph(footnoteEl), 'ins', ctx);
+  }
   zip.writeText('word/footnotes.xml', serializeXml(footnotesDoc));
 
   return { noteId };
@@ -334,6 +344,7 @@ function insertFootnoteReference(
   paragraphEl: Element,
   noteId: number,
   afterText?: string,
+  ctx?: RevisionContext,
 ): void {
   // Create the reference run
   const refRun = documentXml.createElementNS(OOXML.W_NS, 'w:r');
@@ -345,10 +356,14 @@ function insertFootnoteReference(
   const fnRef = documentXml.createElementNS(OOXML.W_NS, 'w:footnoteReference');
   fnRef.setAttributeNS(OOXML.W_NS, 'w:id', String(noteId));
   refRun.appendChild(fnRef);
+  const refAnchor = ctx ? createRevisionContainer(documentXml, 'ins', ctx) : refRun;
+  if (ctx) {
+    refAnchor.appendChild(refRun);
+  }
 
   if (!afterText) {
     // Default: append at end of paragraph
-    paragraphEl.appendChild(refRun);
+    paragraphEl.appendChild(refAnchor);
     return;
   }
 
@@ -376,21 +391,21 @@ function insertFootnoteReference(
     if (insertOffset <= pos) {
       // Insert before this run
       const parent = run.r.parentNode!;
-      parent.insertBefore(refRun, run.r);
+      parent.insertBefore(refAnchor, run.r);
       return;
     }
 
     if (insertOffset > pos && insertOffset < runEnd) {
       // Need to split this run at the offset
       const splitOffset = insertOffset - pos;
-      splitRunAndInsertReference(run.r, splitOffset, refRun);
+      splitRunAndInsertReference(run.r, splitOffset, refAnchor);
       return;
     }
 
     if (insertOffset === runEnd) {
       // Insert after this run
       const parent = run.r.parentNode!;
-      parent.insertBefore(refRun, run.r.nextSibling);
+      parent.insertBefore(refAnchor, run.r.nextSibling);
       return;
     }
 
@@ -398,13 +413,13 @@ function insertFootnoteReference(
   }
 
   // Fallback: append at end
-  paragraphEl.appendChild(refRun);
+  paragraphEl.appendChild(refAnchor);
 }
 
 function splitRunAndInsertReference(
   run: Element,
   visibleOffset: number,
-  refRun: Element,
+  referenceNode: Element,
 ): void {
   const doc = run.ownerDocument;
   if (!doc) throw new Error('Run has no ownerDocument');
@@ -473,7 +488,7 @@ function splitRunAndInsertReference(
   }
 
   // Insert the reference run between left and right
-  parent.insertBefore(refRun, rightRun);
+  parent.insertBefore(referenceNode, rightRun);
 
   // Clean up empty runs
   if (!hasVisibleContent(run)) run.parentNode?.removeChild(run);
@@ -507,7 +522,7 @@ function setXmlSpacePreserve(t: Element, text: string): void {
   }
 }
 
-function addFootnoteElement(footnotesDoc: Document, noteId: number, text: string): void {
+function addFootnoteElement(footnotesDoc: Document, noteId: number, text: string): Element {
   const root = footnotesDoc.documentElement;
 
   const footnoteEl = footnotesDoc.createElementNS(OOXML.W_NS, 'w:footnote');
@@ -554,6 +569,7 @@ function addFootnoteElement(footnotesDoc: Document, noteId: number, text: string
 
   footnoteEl.appendChild(p);
   root.appendChild(footnoteEl);
+  return footnoteEl;
 }
 
 // ── Update ──────────────────────────────────────────────────────────────
@@ -561,6 +577,7 @@ function addFootnoteElement(footnotesDoc: Document, noteId: number, text: string
 export async function updateFootnoteText(
   zip: DocxZip,
   params: { noteId: number; newText: string },
+  ctx?: RevisionContext,
 ): Promise<void> {
   const { noteId, newText } = params;
 
@@ -577,39 +594,24 @@ export async function updateFootnoteText(
 
   const firstP = paragraphs.item(0) as Element;
 
-  // Replace text runs in first paragraph (preserve footnoteRef run)
-  const runs = firstP.getElementsByTagNameNS(OOXML.W_NS, W.r);
-  const runsToRemove: Element[] = [];
-
-  for (let i = 0; i < runs.length; i++) {
-    const run = runs.item(i) as Element;
-    // Keep runs that contain footnoteRef
-    const fnRefs = run.getElementsByTagNameNS(OOXML.W_NS, W.footnoteRef);
-    if (fnRefs.length > 0) continue;
-    runsToRemove.push(run);
+  if (ctx) {
+    // The deletion wrapper may land inside an existing revision container if
+    // the prior text already carried a tracked-change wrapper (e.g., another
+    // author had inserted that text). Always hoist the AI's replacement
+    // insertion to the paragraph level so its w:author attribution is not
+    // nested inside the prior author's wrapper.
+    wrapFootnoteParagraphTextRuns(firstP, 'del', ctx);
+    const insertion = createRevisionContainer(footnotesDoc, 'ins', ctx);
+    const [spaceRun, textRun] = buildFootnoteTextRuns(footnotesDoc, newText);
+    insertion.appendChild(spaceRun);
+    insertion.appendChild(textRun);
+    firstP.appendChild(insertion);
+  } else {
+    removeFootnoteParagraphTextRuns(firstP);
+    const [spaceRun, textRun] = buildFootnoteTextRuns(footnotesDoc, newText);
+    firstP.appendChild(spaceRun);
+    firstP.appendChild(textRun);
   }
-
-  for (const run of runsToRemove) {
-    run.parentNode?.removeChild(run);
-  }
-
-  // Add space separator run after footnoteRef
-  const spaceRun = footnotesDoc.createElementNS(OOXML.W_NS, 'w:r');
-  const spaceT = footnotesDoc.createElementNS(OOXML.W_NS, 'w:t');
-  spaceT.setAttributeNS('http://www.w3.org/XML/1998/namespace', 'xml:space', 'preserve');
-  spaceT.appendChild(footnotesDoc.createTextNode(' '));
-  spaceRun.appendChild(spaceT);
-  firstP.appendChild(spaceRun);
-
-  // Add new text run
-  const textRun = footnotesDoc.createElementNS(OOXML.W_NS, 'w:r');
-  const t = footnotesDoc.createElementNS(OOXML.W_NS, 'w:t');
-  if (newText.startsWith(' ') || newText.endsWith(' ')) {
-    t.setAttributeNS('http://www.w3.org/XML/1998/namespace', 'xml:space', 'preserve');
-  }
-  t.appendChild(footnotesDoc.createTextNode(newText));
-  textRun.appendChild(t);
-  firstP.appendChild(textRun);
 
   zip.writeText('word/footnotes.xml', serializeXml(footnotesDoc));
 }
@@ -620,6 +622,7 @@ export async function deleteFootnote(
   documentXml: Document,
   zip: DocxZip,
   params: { noteId: number },
+  ctx?: RevisionContext,
 ): Promise<void> {
   const { noteId } = params;
 
@@ -630,11 +633,21 @@ export async function deleteFootnote(
   if (!fnEl) throw new Error(`Footnote ID ${noteId} not found`);
   if (isReservedFootnote(fnEl)) throw new Error(`Cannot delete reserved footnote ID ${noteId}`);
 
-  // Remove from footnotes.xml
-  fnEl.parentNode?.removeChild(fnEl);
+  if (ctx) {
+    // Wrap text runs across ALL paragraphs in the footnote, not just the first.
+    // A multi-paragraph footnote with only the first paragraph wrapped would
+    // leave a "zombie" footnote where paragraphs 2+ still appear active under
+    // accept-all. Iterate every paragraph in the footnote element.
+    const paragraphs = fnEl.getElementsByTagNameNS(OOXML.W_NS, W.p);
+    for (let i = 0; i < paragraphs.length; i++) {
+      wrapFootnoteParagraphTextRuns(paragraphs.item(i) as Element, 'del', ctx);
+    }
+  } else {
+    fnEl.parentNode?.removeChild(fnEl);
+  }
   zip.writeText('word/footnotes.xml', serializeXml(footnotesDoc));
 
-  // Remove footnoteReference elements from document.xml
+  // Remove or track-delete footnoteReference elements from document.xml
   const refs = documentXml.getElementsByTagNameNS(OOXML.W_NS, W.footnoteReference);
   const refsToRemove: Element[] = [];
 
@@ -649,6 +662,17 @@ export async function deleteFootnote(
   for (const ref of refsToRemove) {
     const run = ref.parentNode as Element | null;
     if (!run) continue;
+
+    if (ctx) {
+      const isolatedRun = isolateReferenceRun(run, ref);
+      const parent = isolatedRun.parentNode;
+      if (!parent) continue;
+
+      const deletion = createRevisionContainer(documentXml, 'del', ctx);
+      parent.replaceChild(deletion, isolatedRun);
+      deletion.appendChild(prepareElementForDeletion(isolatedRun));
+      continue;
+    }
 
     // Remove only the footnoteReference element, not the entire run
     run.removeChild(ref);
@@ -670,4 +694,203 @@ function findFootnoteById(footnotesDoc: Document, noteId: number): Element | nul
     if (idStr && parseInt(idStr, 10) === noteId) return el;
   }
   return null;
+}
+
+function getFirstFootnoteParagraph(footnoteEl: Element): Element {
+  const paragraphs = footnoteEl.getElementsByTagNameNS(OOXML.W_NS, W.p);
+  if (paragraphs.length === 0) {
+    throw new Error(`Footnote ID ${getWAttr(footnoteEl, 'id') ?? '(unknown)'} has no paragraphs`);
+  }
+  return paragraphs.item(0) as Element;
+}
+
+function buildFootnoteTextRuns(doc: Document, text: string): [Element, Element] {
+  const spaceRun = doc.createElementNS(OOXML.W_NS, 'w:r');
+  const spaceT = doc.createElementNS(OOXML.W_NS, 'w:t');
+  spaceT.setAttributeNS('http://www.w3.org/XML/1998/namespace', 'xml:space', 'preserve');
+  spaceT.appendChild(doc.createTextNode(' '));
+  spaceRun.appendChild(spaceT);
+
+  const textRun = doc.createElementNS(OOXML.W_NS, 'w:r');
+  const t = doc.createElementNS(OOXML.W_NS, 'w:t');
+  if (text.startsWith(' ') || text.endsWith(' ')) {
+    t.setAttributeNS('http://www.w3.org/XML/1998/namespace', 'xml:space', 'preserve');
+  }
+  t.appendChild(doc.createTextNode(text));
+  textRun.appendChild(t);
+
+  return [spaceRun, textRun];
+}
+
+function removeFootnoteParagraphTextRuns(paragraph: Element): void {
+  const collected = collectFootnoteTextRuns(paragraph);
+  if (!collected) return;
+
+  for (const run of collected.runs) {
+    run.parentNode?.removeChild(run);
+  }
+
+  cleanupEmptyRevisionWrappers(paragraph);
+}
+
+function wrapFootnoteParagraphTextRuns(
+  paragraph: Element,
+  kind: 'ins' | 'del',
+  ctx: RevisionContext,
+): Element | null {
+  const collected = collectFootnoteTextRuns(paragraph);
+  if (!collected) return null;
+
+  const doc = paragraph.ownerDocument;
+  if (!doc) throw new Error('Paragraph has no ownerDocument');
+
+  const { parent: anchorParent, before: anchorBefore } = collected.insertionAnchor;
+  const wrapper = createRevisionContainer(doc, kind, ctx);
+  anchorParent.insertBefore(wrapper, anchorBefore);
+
+  for (const run of collected.runs) {
+    run.parentNode?.removeChild(run);
+    wrapper.appendChild(kind === 'del' ? prepareElementForDeletion(run) : run);
+  }
+
+  cleanupEmptyRevisionWrappers(paragraph);
+
+  return wrapper;
+}
+
+/**
+ * Collect every `<w:r>` descendant of the paragraph that does NOT contain a
+ * `footnoteRef` marker. This intentionally crosses into `<w:ins>` / `<w:del>`
+ * wrappers so that footnote text already carrying revision history (e.g.,
+ * third-party documents or prior tracked edits in the same session) is still
+ * captured by `updateFootnoteText` and `deleteFootnote`. The first-found
+ * insertion-anchor (the parent of the first match) is returned so callers
+ * can place a new wrapper at the same structural position.
+ */
+function collectFootnoteTextRuns(paragraph: Element): {
+  insertionAnchor: { parent: Element; before: Node | null };
+  runs: Element[];
+} | null {
+  const collected: Array<{ parent: Element; run: Element }> = [];
+
+  function visit(parent: Element): void {
+    for (const child of childElements(parent)) {
+      if (isW(child, W.r)) {
+        if (!runContainsFootnoteRef(child)) {
+          collected.push({ parent, run: child });
+        }
+        continue;
+      }
+      if (isW(child, 'ins') || isW(child, 'del')) {
+        visit(child);
+      }
+    }
+  }
+
+  visit(paragraph);
+
+  if (collected.length === 0) return null;
+
+  const first = collected[0]!;
+  return {
+    insertionAnchor: { parent: first.parent, before: first.run },
+    runs: collected.map((entry) => entry.run),
+  };
+}
+
+function runContainsFootnoteRef(run: Element): boolean {
+  return run.getElementsByTagNameNS(OOXML.W_NS, W.footnoteRef).length > 0;
+}
+
+/**
+ * After detaching runs from their parents, sweep up any now-empty
+ * `<w:ins>`/`<w:del>` siblings of the paragraph so we do not leave orphan
+ * revision wrappers behind. This pairs with `collectFootnoteTextRuns`'s
+ * cross-wrapper traversal.
+ */
+function cleanupEmptyRevisionWrappers(paragraph: Element): void {
+  for (const child of Array.from(childElements(paragraph))) {
+    if ((isW(child, 'ins') || isW(child, 'del')) && childElements(child).length === 0) {
+      paragraph.removeChild(child);
+    }
+  }
+}
+
+function isolateReferenceRun(run: Element, ref: Element): Element {
+  if (canWrapRunAsIs(run, ref)) {
+    return run;
+  }
+
+  const parent = run.parentNode;
+  const doc = run.ownerDocument;
+  if (!parent || !doc) {
+    throw new Error('Footnote reference run is detached');
+  }
+
+  const beforeNodes: Node[] = [];
+  const afterNodes: Node[] = [];
+  let seenRef = false;
+
+  for (const child of Array.from(run.childNodes)) {
+    if (child === ref) {
+      seenRef = true;
+      continue;
+    }
+    if (child.nodeType === 1 && isW(child as Element, W.rPr)) {
+      continue;
+    }
+    if (seenRef) {
+      afterNodes.push(child);
+    } else {
+      beforeNodes.push(child);
+    }
+  }
+
+  const beforeRun = beforeNodes.length > 0 ? cloneRunShell(run) : null;
+  const referenceRun = cloneRunShell(run);
+  const afterRun = afterNodes.length > 0 ? cloneRunShell(run) : null;
+
+  if (beforeRun) {
+    parent.insertBefore(beforeRun, run);
+    for (const child of beforeNodes) {
+      beforeRun.appendChild(child);
+    }
+  }
+
+  parent.insertBefore(referenceRun, run);
+  run.removeChild(ref);
+  referenceRun.appendChild(ref);
+
+  if (afterRun) {
+    parent.insertBefore(afterRun, run);
+    for (const child of afterNodes) {
+      afterRun.appendChild(child);
+    }
+  }
+
+  parent.removeChild(run);
+  return referenceRun;
+}
+
+function canWrapRunAsIs(run: Element, ref: Element): boolean {
+  for (const child of childElements(run)) {
+    if (child === ref) continue;
+    if (isW(child, W.rPr)) continue;
+    return false;
+  }
+  return true;
+}
+
+function cloneRunShell(run: Element): Element {
+  const doc = run.ownerDocument;
+  if (!doc) throw new Error('Run has no ownerDocument');
+
+  const clone = doc.createElementNS(OOXML.W_NS, 'w:r');
+  for (const child of childElements(run)) {
+    if (isW(child, W.rPr)) {
+      clone.appendChild(child.cloneNode(true));
+      break;
+    }
+  }
+  return clone;
 }

--- a/packages/docx-core/test-primitives/footnotes.test.ts
+++ b/packages/docx-core/test-primitives/footnotes.test.ts
@@ -14,6 +14,7 @@ import {
 import { DocxZip } from '../src/primitives/zip.js';
 import { getParagraphBookmarkId, insertParagraphBookmarks } from '../src/primitives/bookmarks.js';
 import { getParagraphText } from '../src/primitives/text.js';
+import { createRevisionContext, createRevisionIdState } from '../src/primitives/track-changes-emitter.js';
 import { testAllure, type AllureBddContext } from './helpers/allure-test.js';
 
 const TEST_FEATURE = 'add-footnote-support';
@@ -112,6 +113,39 @@ function findFootnoteById(doc: Document, id: number): Element | null {
     if (raw && Number.parseInt(raw, 10) === id) return node;
   }
   return null;
+}
+
+function getFirstParagraph(footnoteEl: Element): Element {
+  const paragraphs = footnoteEl.getElementsByTagNameNS(OOXML.W_NS, W.p);
+  if (paragraphs.length === 0) throw new Error('Expected footnote paragraph');
+  return paragraphs.item(0) as Element;
+}
+
+function directChildLocalNames(parent: Element): string[] {
+  return Array.from(parent.childNodes)
+    .filter((node) => node.nodeType === 1)
+    .map((node) => (node as Element).localName);
+}
+
+function getDirectChildByLocalName(parent: Element, localName: string): Element | null {
+  for (const child of Array.from(parent.childNodes)) {
+    if (child.nodeType !== 1) continue;
+    const element = child as Element;
+    if (element.namespaceURI === OOXML.W_NS && element.localName === localName) {
+      return element;
+    }
+  }
+  return null;
+}
+
+function revisionId(element: Element): number {
+  const raw = element.getAttributeNS(OOXML.W_NS, 'id') ?? element.getAttribute('w:id');
+  if (!raw) throw new Error('Expected revision ID');
+  return Number(raw);
+}
+
+function normalizeXml(xml: string): string {
+  return serializeXml(parseXml(xml));
 }
 
 describe('footnotes', () => {
@@ -891,6 +925,554 @@ describe('footnotes', () => {
         await expect(deleteFootnote(doc, zip, { noteId: 1000 })).rejects.toThrow(
           'Footnote ID 1000 not found',
         );
+      });
+    });
+  });
+
+  describe('tracked-change emission', () => {
+    test('addFootnote with ctx wraps the body reference and note text in distinct w:ins containers', async ({ given, when, then }: AllureBddContext) => {
+      let doc: Document;
+      let zip: DocxZip;
+      let paragraph: Element;
+      let noteId: number;
+      let bodyInsertion: Element;
+      let noteParagraph: Element;
+      let noteInsertion: Element;
+
+      const ctx = createRevisionContext({
+        author: 'SafeDocX AI',
+        date: '2026-05-06T14:15:16Z',
+        idState: createRevisionIdState(),
+      });
+
+      await given('a document with one paragraph and bootstrapped footnotes', async () => {
+        doc = makeDocument('<w:p><w:r><w:t>Hello world</w:t></w:r></w:p>');
+        zip = await makeZipFromDocument(doc, { 'word/footnotes.xml': RESERVED_FOOTNOTES_XML });
+        paragraph = getParagraphs(doc)[0]!;
+      });
+
+      await when('addFootnote is called with a revision context', async () => {
+        const result = await addFootnote(doc, zip, {
+          paragraphEl: paragraph,
+          text: 'Tracked footnote',
+        }, ctx);
+        noteId = result.noteId;
+
+        bodyInsertion = paragraph.getElementsByTagNameNS(OOXML.W_NS, 'ins').item(0) as Element;
+        const footnotesDoc = await readFootnotesXml(zip);
+        const footnoteEl = findFootnoteById(footnotesDoc, noteId);
+        if (!footnoteEl) throw new Error('Expected tracked footnote entry');
+        noteParagraph = getFirstParagraph(footnoteEl);
+        noteInsertion = getDirectChildByLocalName(noteParagraph, 'ins')!;
+      });
+
+      await then('document.xml and footnotes.xml each receive one insertion wrapper with distinct revision IDs', async () => {
+        expect(directChildLocalNames(paragraph)).toEqual(['r', 'ins']);
+        expect(bodyInsertion.getAttribute('w:author')).toBe('SafeDocX AI');
+        expect(bodyInsertion.getAttribute('w:date')).toBe('2026-05-06T14:15:16Z');
+        expect(bodyInsertion.getElementsByTagNameNS(OOXML.W_NS, W.r)).toHaveLength(1);
+        expect(bodyInsertion.getElementsByTagNameNS(OOXML.W_NS, W.footnoteReference)).toHaveLength(1);
+
+        expect(directChildLocalNames(noteParagraph)).toEqual(['pPr', 'r', 'ins']);
+        expect(noteInsertion.getAttribute('w:author')).toBe('SafeDocX AI');
+        expect(noteInsertion.getAttribute('w:date')).toBe('2026-05-06T14:15:16Z');
+        expect(noteInsertion.getElementsByTagNameNS(OOXML.W_NS, W.r)).toHaveLength(2);
+        expect(noteInsertion.getElementsByTagNameNS(OOXML.W_NS, W.footnoteRef)).toHaveLength(0);
+        expect(noteInsertion.contains(getDirectChildByLocalName(noteParagraph, W.r)!)).toBe(false);
+        expect(revisionId(bodyInsertion)).not.toBe(revisionId(noteInsertion));
+      });
+    });
+
+    test('updateFootnoteText with ctx keeps the body untouched and emits w:delText plus one replacement w:ins in footnotes.xml', async ({ given, when, then }: AllureBddContext) => {
+      let doc: Document;
+      let zip: DocxZip;
+      let documentBefore: string;
+      let noteParagraph: Element;
+      let deletion: Element;
+      let insertion: Element;
+
+      const ctx = createRevisionContext({
+        author: 'SafeDocX AI',
+        date: '2026-05-06T14:15:16Z',
+        idState: createRevisionIdState(),
+      });
+
+      await given('a document whose body already references the target footnote', async () => {
+        doc = makeDocument('<w:p><w:r><w:footnoteReference w:id="3"/></w:r><w:r><w:t>Body</w:t></w:r></w:p>');
+        documentBefore = serializeXml(doc);
+        zip = await makeZipFromDocument(doc, {
+          'word/footnotes.xml': makeFootnotesXml([
+            { id: -1, type: 'separator', paragraphXml: '<w:p><w:r><w:separator/></w:r></w:p>' },
+            {
+              id: 3,
+              paragraphXml:
+                '<w:p>' +
+                '<w:r><w:rPr><w:rStyle w:val="FootnoteReference"/></w:rPr><w:footnoteRef/></w:r>' +
+                '<w:r><w:t xml:space="preserve"> old</w:t></w:r>' +
+                '<w:r><w:t> text</w:t></w:r>' +
+                '</w:p>',
+            },
+          ]),
+        });
+      });
+
+      await when('the footnote text is updated with tracked changes enabled', async () => {
+        await updateFootnoteText(zip, { noteId: 3, newText: ' new text ' }, ctx);
+
+        const footnotesDoc = await readFootnotesXml(zip);
+        const footnoteEl = findFootnoteById(footnotesDoc, 3);
+        if (!footnoteEl) throw new Error('Expected updated footnote');
+        noteParagraph = getFirstParagraph(footnoteEl);
+        deletion = getDirectChildByLocalName(noteParagraph, 'del')!;
+        insertion = getDirectChildByLocalName(noteParagraph, 'ins')!;
+      });
+
+      await then('the previous runs stay in place under w:del and the replacement space-plus-text is emitted under one w:ins', async () => {
+        expect(serializeXml(doc)).toBe(documentBefore);
+        expect(directChildLocalNames(noteParagraph)).toEqual(['r', 'del', 'ins']);
+        expect(getDirectChildByLocalName(noteParagraph, W.r)!.getElementsByTagNameNS(OOXML.W_NS, W.footnoteRef)).toHaveLength(1);
+
+        expect(deletion.getAttribute('w:author')).toBe('SafeDocX AI');
+        expect(deletion.getAttribute('w:date')).toBe('2026-05-06T14:15:16Z');
+        expect(deletion.getElementsByTagNameNS(OOXML.W_NS, 'delText')).toHaveLength(2);
+        expect(deletion.getElementsByTagNameNS(OOXML.W_NS, W.t)).toHaveLength(0);
+
+        expect(insertion.getAttribute('w:author')).toBe('SafeDocX AI');
+        expect(insertion.getAttribute('w:date')).toBe('2026-05-06T14:15:16Z');
+        expect(insertion.getElementsByTagNameNS(OOXML.W_NS, W.r)).toHaveLength(2);
+        expect(insertion.getElementsByTagNameNS(OOXML.W_NS, W.footnoteRef)).toHaveLength(0);
+        expect(revisionId(deletion)).not.toBe(revisionId(insertion));
+      });
+    });
+
+    test('deleteFootnote with ctx wraps the body reference and note text in w:del while preserving the footnote entry', async ({ given, when, then }: AllureBddContext) => {
+      let doc: Document;
+      let zip: DocxZip;
+      let paragraph: Element;
+      let bodyDeletion: Element;
+      let noteParagraph: Element;
+      let noteDeletion: Element;
+
+      const ctx = createRevisionContext({
+        author: 'SafeDocX AI',
+        date: '2026-05-06T14:15:16Z',
+        idState: createRevisionIdState(),
+      });
+
+      await given('a document with a dedicated footnote reference run and a matching footnote entry', async () => {
+        doc = makeDocument(
+          '<w:p>' +
+            '<w:r><w:t>Lead</w:t></w:r>' +
+            '<w:r><w:footnoteReference w:id="12"/></w:r>' +
+            '<w:r><w:t>Tail</w:t></w:r>' +
+            '</w:p>',
+        );
+        paragraph = getParagraphs(doc)[0]!;
+        zip = await makeZipFromDocument(doc, {
+          'word/footnotes.xml': makeFootnotesXml([
+            { id: -1, type: 'separator', paragraphXml: '<w:p><w:r><w:separator/></w:r></w:p>' },
+            {
+              id: 12,
+              paragraphXml:
+                '<w:p>' +
+                '<w:r><w:rPr><w:rStyle w:val="FootnoteReference"/></w:rPr><w:footnoteRef/></w:r>' +
+                '<w:r><w:t xml:space="preserve"> </w:t></w:r>' +
+                '<w:r><w:t>Delete me</w:t></w:r>' +
+                '</w:p>',
+            },
+          ]),
+        });
+      });
+
+      await when('the footnote is deleted with a revision context', async () => {
+        await deleteFootnote(doc, zip, { noteId: 12 }, ctx);
+
+        bodyDeletion = getDirectChildByLocalName(paragraph, 'del')!;
+        const footnotesDoc = await readFootnotesXml(zip);
+        const footnoteEl = findFootnoteById(footnotesDoc, 12);
+        if (!footnoteEl) throw new Error('Expected deleted footnote entry to remain');
+        noteParagraph = getFirstParagraph(footnoteEl);
+        noteDeletion = getDirectChildByLocalName(noteParagraph, 'del')!;
+      });
+
+      await then('the body keeps the reference under w:del and footnotes.xml keeps the note with deleted text content', async () => {
+        expect(directChildLocalNames(paragraph)).toEqual(['r', 'del', 'r']);
+        expect(getParagraphText(paragraph)).toBe('LeadTail');
+        expect(bodyDeletion.getAttribute('w:author')).toBe('SafeDocX AI');
+        expect(bodyDeletion.getAttribute('w:date')).toBe('2026-05-06T14:15:16Z');
+        expect(bodyDeletion.getElementsByTagNameNS(OOXML.W_NS, W.footnoteReference)).toHaveLength(1);
+
+        expect(directChildLocalNames(noteParagraph)).toEqual(['r', 'del']);
+        expect(noteDeletion.getAttribute('w:author')).toBe('SafeDocX AI');
+        expect(noteDeletion.getAttribute('w:date')).toBe('2026-05-06T14:15:16Z');
+        expect(noteDeletion.getElementsByTagNameNS(OOXML.W_NS, 'delText')).toHaveLength(2);
+        expect(noteDeletion.getElementsByTagNameNS(OOXML.W_NS, W.t)).toHaveLength(0);
+        expect(noteDeletion.getElementsByTagNameNS(OOXML.W_NS, W.footnoteRef)).toHaveLength(0);
+        expect(revisionId(bodyDeletion)).not.toBe(revisionId(noteDeletion));
+      });
+    });
+
+    test('preserves byte-identical legacy output when ctx is omitted for addFootnote, updateFootnoteText, and deleteFootnote', async ({ given, when, then }: AllureBddContext) => {
+      let addDoc: Document;
+      let addZip: DocxZip;
+      let addDocumentXml: string;
+      let addFootnotesXml: string;
+
+      let updateZip: DocxZip;
+      let updateFootnotesXml: string;
+
+      let deleteDoc: Document;
+      let deleteZip: DocxZip;
+      let deleteDocumentXml: string;
+      let deleteFootnotesXml: string;
+
+      await given('three legacy footnote mutation scenarios with no revision context', async () => {
+        addDoc = makeDocument('<w:p><w:r><w:t>Hello</w:t></w:r></w:p>');
+        addZip = await makeZipFromDocument(addDoc, { 'word/footnotes.xml': RESERVED_FOOTNOTES_XML });
+
+        const updateDoc = makeDocument('<w:p><w:r><w:t>Body</w:t></w:r></w:p>');
+        updateZip = await makeZipFromDocument(updateDoc, {
+          'word/footnotes.xml': makeFootnotesXml([
+            { id: -1, type: 'separator', paragraphXml: '<w:p><w:r><w:separator/></w:r></w:p>' },
+            {
+              id: 3,
+              paragraphXml:
+                '<w:p>' +
+                '<w:r><w:rPr><w:rStyle w:val="FootnoteReference"/></w:rPr><w:footnoteRef/></w:r>' +
+                '<w:r><w:t>old text</w:t></w:r>' +
+                '</w:p>',
+            },
+          ]),
+        });
+
+        deleteDoc = makeDocument(
+          '<w:p>' +
+            '<w:r><w:footnoteReference w:id="12"/></w:r>' +
+            '<w:r><w:t>Tail</w:t></w:r>' +
+            '</w:p>',
+        );
+        deleteZip = await makeZipFromDocument(deleteDoc, {
+          'word/footnotes.xml': makeFootnotesXml([
+            { id: -1, type: 'separator', paragraphXml: '<w:p><w:r><w:separator/></w:r></w:p>' },
+            { id: 12, text: 'Delete dedicated run' },
+          ]),
+        });
+      });
+
+      await when('the legacy add, update, and delete flows run without ctx', async () => {
+        await addFootnote(addDoc, addZip, {
+          paragraphEl: getParagraphs(addDoc)[0]!,
+          text: 'Legacy note',
+        });
+        addDocumentXml = serializeXml(addDoc);
+        addFootnotesXml = await addZip.readText('word/footnotes.xml');
+
+        await updateFootnoteText(updateZip, { noteId: 3, newText: ' new text ' });
+        updateFootnotesXml = await updateZip.readText('word/footnotes.xml');
+
+        await deleteFootnote(deleteDoc, deleteZip, { noteId: 12 });
+        deleteDocumentXml = serializeXml(deleteDoc);
+        deleteFootnotesXml = await deleteZip.readText('word/footnotes.xml');
+      });
+
+      await then('all three outputs remain byte-identical to the pre-tracked-change behavior', async () => {
+        expect(addDocumentXml).toBe(
+          serializeXml(
+            makeDocument(
+              '<w:p>' +
+                '<w:r><w:t>Hello</w:t></w:r>' +
+                '<w:r><w:rPr><w:rStyle w:val="FootnoteReference"/></w:rPr><w:footnoteReference w:id="1"/></w:r>' +
+                '</w:p>',
+            ),
+          ),
+        );
+        expect(addFootnotesXml).toBe(
+          normalizeXml(
+            makeFootnotesXml([
+              { id: -1, type: 'separator', paragraphXml: '<w:p><w:r><w:separator/></w:r></w:p>' },
+              { id: 0, type: 'continuationSeparator', paragraphXml: '<w:p><w:r><w:continuationSeparator/></w:r></w:p>' },
+              {
+                id: 1,
+                paragraphXml:
+                  '<w:p>' +
+                  '<w:pPr><w:pStyle w:val="FootnoteText"/></w:pPr>' +
+                  '<w:r><w:rPr><w:rStyle w:val="FootnoteReference"/></w:rPr><w:footnoteRef/></w:r>' +
+                  '<w:r><w:t xml:space="preserve"> </w:t></w:r>' +
+                  '<w:r><w:t>Legacy note</w:t></w:r>' +
+                  '</w:p>',
+              },
+            ]),
+          ),
+        );
+
+        expect(updateFootnotesXml).toBe(
+          normalizeXml(
+            makeFootnotesXml([
+              { id: -1, type: 'separator', paragraphXml: '<w:p><w:r><w:separator/></w:r></w:p>' },
+              {
+                id: 3,
+                paragraphXml:
+                  '<w:p>' +
+                  '<w:r><w:rPr><w:rStyle w:val="FootnoteReference"/></w:rPr><w:footnoteRef/></w:r>' +
+                  '<w:r><w:t xml:space="preserve"> </w:t></w:r>' +
+                  '<w:r><w:t xml:space="preserve"> new text </w:t></w:r>' +
+                  '</w:p>',
+              },
+            ]),
+          ),
+        );
+
+        expect(deleteDocumentXml).toBe(
+          serializeXml(
+            makeDocument(
+              '<w:p><w:r><w:t>Tail</w:t></w:r></w:p>',
+            ),
+          ),
+        );
+        expect(deleteFootnotesXml).toBe(
+          normalizeXml(
+            makeFootnotesXml([
+              { id: -1, type: 'separator', paragraphXml: '<w:p><w:r><w:separator/></w:r></w:p>' },
+            ]),
+          ),
+        );
+      });
+    });
+
+    test('allocates unique revision IDs across tracked addFootnote and deleteFootnote operations sharing one context', async ({ given, when, then }: AllureBddContext) => {
+      let doc: Document;
+      let zip: DocxZip;
+      let emittedIds: number[];
+
+      const ctx = createRevisionContext({
+        author: 'SafeDocX AI',
+        date: '2026-05-06T14:15:16Z',
+        idState: createRevisionIdState(),
+      });
+
+      await given('a document with one existing footnote to delete and one paragraph for a new footnote', async () => {
+        doc = makeDocument(
+          '<w:p><w:r><w:footnoteReference w:id="7"/></w:r></w:p>' +
+          '<w:p><w:r><w:t>Insert here</w:t></w:r></w:p>',
+        );
+        zip = await makeZipFromDocument(doc, {
+          'word/footnotes.xml': makeFootnotesXml([
+            { id: -1, type: 'separator', paragraphXml: '<w:p><w:r><w:separator/></w:r></w:p>' },
+            {
+              id: 7,
+              paragraphXml:
+                '<w:p>' +
+                '<w:r><w:rPr><w:rStyle w:val="FootnoteReference"/></w:rPr><w:footnoteRef/></w:r>' +
+                '<w:r><w:t xml:space="preserve"> </w:t></w:r>' +
+                '<w:r><w:t>Existing note</w:t></w:r>' +
+                '</w:p>',
+            },
+          ]),
+        });
+      });
+
+      await when('tracked addFootnote and tracked deleteFootnote share the same revision context', async () => {
+        await addFootnote(doc, zip, {
+          paragraphEl: getParagraphs(doc)[1]!,
+          text: 'Fresh note',
+        }, ctx);
+        await deleteFootnote(doc, zip, { noteId: 7 }, ctx);
+
+        const footnotesDoc = await readFootnotesXml(zip);
+        emittedIds = [
+          ...Array.from(doc.getElementsByTagNameNS(OOXML.W_NS, 'ins')),
+          ...Array.from(doc.getElementsByTagNameNS(OOXML.W_NS, 'del')),
+          ...Array.from(footnotesDoc.getElementsByTagNameNS(OOXML.W_NS, 'ins')),
+          ...Array.from(footnotesDoc.getElementsByTagNameNS(OOXML.W_NS, 'del')),
+        ].map((element) => revisionId(element as Element));
+      });
+
+      await then('the shared allocator produces one distinct ID for each body-side and footnote-side wrapper', async () => {
+        expect(new Set(emittedIds).size).toBe(4);
+        expect(emittedIds.slice().sort((left, right) => left - right)).toEqual([1, 2, 3, 4]);
+      });
+    });
+
+    test('deleteFootnote with ctx isolates the reference run when it shares a run with sibling text', async ({ given, when, then }: AllureBddContext) => {
+      let doc: Document;
+      let zip: DocxZip;
+      let bodyParagraph: Element;
+      let deletion: Element;
+
+      const ctx = createRevisionContext({
+        author: 'SafeDocX AI',
+        date: '2026-05-06T14:15:16Z',
+        idState: createRevisionIdState(),
+      });
+
+      await given('a document whose footnoteReference shares a run with leading and trailing text under <w:rPr>', async () => {
+        doc = makeDocument(
+          '<w:p>' +
+            '<w:r>' +
+              '<w:rPr><w:b/></w:rPr>' +
+              '<w:t>before</w:t>' +
+              '<w:footnoteReference w:id="11"/>' +
+              '<w:t>after</w:t>' +
+            '</w:r>' +
+          '</w:p>',
+        );
+        zip = await makeZipFromDocument(doc, {
+          'word/footnotes.xml': makeFootnotesXml([
+            { id: -1, type: 'separator', paragraphXml: '<w:p><w:r><w:separator/></w:r></w:p>' },
+            { id: 11, text: 'Shared-run note' },
+          ]),
+        });
+        bodyParagraph = getParagraphs(doc)[0]!;
+      });
+
+      await when('the footnote is deleted under tracked changes', async () => {
+        await deleteFootnote(doc, zip, { noteId: 11 }, ctx);
+        deletion = bodyParagraph.getElementsByTagNameNS(OOXML.W_NS, 'del').item(0) as Element;
+      });
+
+      await then('the reference is isolated into its own run inside w:del while the surrounding text remains as plain runs with rPr preserved', async () => {
+        expect(deletion).toBeTruthy();
+        const deletedRuns = Array.from(deletion.getElementsByTagNameNS(OOXML.W_NS, W.r));
+        expect(deletedRuns).toHaveLength(1);
+        expect(deletedRuns[0]!.getElementsByTagNameNS(OOXML.W_NS, W.footnoteReference)).toHaveLength(1);
+        expect(deletedRuns[0]!.getElementsByTagNameNS(OOXML.W_NS, W.b)).toHaveLength(1);
+
+        // The "before" and "after" text survives outside the deletion wrapper, with rPr preserved.
+        const directRuns = Array.from(bodyParagraph.childNodes)
+          .filter((n) => n.nodeType === 1)
+          .filter((n) => (n as Element).localName === W.r) as Element[];
+        const directTexts = directRuns
+          .flatMap((r) => Array.from(r.getElementsByTagNameNS(OOXML.W_NS, W.t)))
+          .map((t) => t.textContent ?? '');
+        expect(directTexts).toEqual(['before', 'after']);
+        for (const run of directRuns) {
+          expect(run.getElementsByTagNameNS(OOXML.W_NS, W.b)).toHaveLength(1);
+        }
+      });
+    });
+
+    test('deleteFootnote with ctx wraps text runs across every paragraph of a multi-paragraph footnote', async ({ given, when, then }: AllureBddContext) => {
+      let doc: Document;
+      let zip: DocxZip;
+      let footnoteEl: Element;
+
+      const ctx = createRevisionContext({
+        author: 'SafeDocX AI',
+        date: '2026-05-06T14:15:16Z',
+        idState: createRevisionIdState(),
+      });
+
+      await given('a document referencing a multi-paragraph footnote', async () => {
+        doc = makeDocument('<w:p><w:r><w:footnoteReference w:id="9"/></w:r></w:p>');
+        zip = await makeZipFromDocument(doc, {
+          'word/footnotes.xml': makeFootnotesXml([
+            { id: -1, type: 'separator', paragraphXml: '<w:p><w:r><w:separator/></w:r></w:p>' },
+            {
+              id: 9,
+              paragraphXml:
+                '<w:p>' +
+                  '<w:r><w:rPr><w:rStyle w:val="FootnoteReference"/></w:rPr><w:footnoteRef/></w:r>' +
+                  '<w:r><w:t xml:space="preserve"> first paragraph</w:t></w:r>' +
+                '</w:p>' +
+                '<w:p><w:r><w:t>second paragraph</w:t></w:r></w:p>' +
+                '<w:p><w:r><w:t>third paragraph</w:t></w:r></w:p>',
+            },
+          ]),
+        });
+      });
+
+      await when('the footnote is deleted under tracked changes', async () => {
+        await deleteFootnote(doc, zip, { noteId: 9 }, ctx);
+        const footnotesDoc = await readFootnotesXml(zip);
+        footnoteEl = findFootnoteById(footnotesDoc, 9)!;
+      });
+
+      await then('every paragraph in the footnote has its text runs wrapped in w:del while footnoteRef stays untouched', async () => {
+        const paragraphs = Array.from(footnoteEl.getElementsByTagNameNS(OOXML.W_NS, W.p));
+        expect(paragraphs).toHaveLength(3);
+
+        const firstP = paragraphs[0]!;
+        const firstDel = getDirectChildByLocalName(firstP, 'del');
+        expect(firstDel).toBeTruthy();
+        // footnoteRef run is preserved as a direct child, not wrapped.
+        const firstRefRuns = Array.from(firstP.childNodes)
+          .filter((n) => n.nodeType === 1)
+          .filter((n) => (n as Element).localName === W.r);
+        expect(firstRefRuns).toHaveLength(1);
+        expect(firstRefRuns[0]!.getElementsByTagNameNS(OOXML.W_NS, W.footnoteRef)).toHaveLength(1);
+        // The text " first paragraph" is wrapped as <w:delText> inside the deletion.
+        expect(firstDel!.getElementsByTagNameNS(OOXML.W_NS, 'delText')).toHaveLength(1);
+
+        const secondDel = getDirectChildByLocalName(paragraphs[1]!, 'del');
+        expect(secondDel).toBeTruthy();
+        expect(secondDel!.getElementsByTagNameNS(OOXML.W_NS, 'delText')).toHaveLength(1);
+
+        const thirdDel = getDirectChildByLocalName(paragraphs[2]!, 'del');
+        expect(thirdDel).toBeTruthy();
+        expect(thirdDel!.getElementsByTagNameNS(OOXML.W_NS, 'delText')).toHaveLength(1);
+      });
+    });
+
+    test('updateFootnoteText with ctx captures both direct and pre-existing-w:ins-wrapped text runs in the deletion', async ({ given, when, then }: AllureBddContext) => {
+      let zip: DocxZip;
+      let noteParagraph: Element;
+      let deletion: Element;
+
+      const ctx = createRevisionContext({
+        author: 'SafeDocX AI',
+        date: '2026-05-06T14:15:16Z',
+        idState: createRevisionIdState(),
+      });
+
+      await given('a footnote whose text already mixes direct runs and a pre-existing tracked w:ins wrapper', async () => {
+        const doc = makeDocument('<w:p><w:r><w:footnoteReference w:id="5"/></w:r></w:p>');
+        zip = await makeZipFromDocument(doc, {
+          'word/footnotes.xml': makeFootnotesXml([
+            { id: -1, type: 'separator', paragraphXml: '<w:p><w:r><w:separator/></w:r></w:p>' },
+            {
+              id: 5,
+              paragraphXml:
+                '<w:p>' +
+                  '<w:r><w:rPr><w:rStyle w:val="FootnoteReference"/></w:rPr><w:footnoteRef/></w:r>' +
+                  '<w:ins w:id="500" w:author="OldAuthor" w:date="2020-01-01T00:00:00Z"><w:r><w:t>wrapped</w:t></w:r></w:ins>' +
+                  '<w:r><w:t xml:space="preserve"> direct</w:t></w:r>' +
+                '</w:p>',
+            },
+          ]),
+        });
+      });
+
+      await when('the footnote text is updated under tracked changes', async () => {
+        await updateFootnoteText(zip, { noteId: 5, newText: 'new text' }, ctx);
+        const footnotesDoc = await readFootnotesXml(zip);
+        const footnoteEl = findFootnoteById(footnotesDoc, 5)!;
+        noteParagraph = getFirstParagraph(footnoteEl);
+        deletion = noteParagraph.getElementsByTagNameNS(OOXML.W_NS, 'del').item(0) as Element;
+      });
+
+      await then('the deletion captures both wrapped and direct text content; the new replacement w:ins is hoisted to the paragraph level under SafeDocX AI authorship', async () => {
+        expect(deletion).toBeTruthy();
+        const delTexts = Array.from(deletion.getElementsByTagNameNS(OOXML.W_NS, 'delText')).map(
+          (t) => t.textContent ?? '',
+        );
+        // Both "wrapped" and " direct" text appear inside the new <w:del>.
+        expect(delTexts).toEqual(expect.arrayContaining(['wrapped', ' direct']));
+
+        // The new replacement <w:ins> is hoisted to the paragraph level so its
+        // SafeDocX AI authorship is not nested inside the prior author's wrapper.
+        const directIns = Array.from(noteParagraph.childNodes)
+          .filter((n) => n.nodeType === 1)
+          .filter((n) => (n as Element).localName === 'ins') as Element[];
+        // There may be multiple ins wrappers at the paragraph level (the old
+        // OldAuthor wrapper which now hosts the deletion, plus the new SafeDocX
+        // AI replacement). Verify the SafeDocX AI one is the new replacement.
+        const safeDocxAiIns = directIns.filter((el) => el.getAttribute('w:author') === 'SafeDocX AI');
+        expect(safeDocxAiIns).toHaveLength(1);
+        // And confirm the new wrapper actually contains the new text (not the old).
+        const newTextRuns = Array.from(safeDocxAiIns[0]!.getElementsByTagNameNS(OOXML.W_NS, W.t)).map(
+          (t) => t.textContent ?? '',
+        );
+        expect(newTextRuns).toEqual([' ', 'new text']);
       });
     });
   });


### PR DESCRIPTION
## Summary

Fourth per-primitive PR after #136/#137/#138 merged. Migrates `addFootnote` / `updateFootnoteText` / `deleteFootnote` (and the `DocxDocument` wrappers) to optionally accept `ctx?: RevisionContext`.

Footnotes touch BOTH `document.xml` (the body `<w:footnoteReference>` run) AND `footnotes.xml` (the note text content). Both are revisionable surface (Table A). The footnote-part bootstrap is Table B and unchanged.

## Behavior with ctx

| Function | Body (document.xml) | Side part (footnotes.xml) |
|---|---|---|
| `addFootnote` | Wrap reference run in `<w:ins>` | Wrap note paragraph's text runs (NOT footnoteRef) in `<w:ins>` |
| `updateFootnoteText` | Untouched | Wrap removed text runs in `<w:del>` (w:t → w:delText); new space + text runs in single `<w:ins>` hoisted to paragraph level |
| `deleteFootnote` | Wrap reference run in `<w:del>` | Wrap text runs across EVERY paragraph in the footnote in `<w:del>` (footnote element stays so body ref resolves) |

Without ctx: byte-identical to pre-PR.

## What's defensive

| Helper | Purpose |
|---|---|
| `isolateReferenceRun` | When the body footnoteReference shares a run with sibling text, splits into before-ref / ref / after-ref (preserving rPr) so `<w:del>` captures only the reference, not unrelated content |
| `collectFootnoteTextRuns` | Depth-first traversal across `<w:ins>`/`<w:del>` wrappers so footnote text already carrying revision history (third-party docs) is captured |
| `cleanupEmptyRevisionWrappers` | Sweeps now-empty `<w:ins>`/`<w:del>` children of the paragraph to prevent orphan-wrapper pollution |

## Peer review

Two **High** severity findings, both addressed:

| Reviewer | Finding | Resolution |
|---|---|---|
| Codex | `getFootnoteTextRunGroup` only handled one bucket (direct OR wrapped runs). Third-party docs with revisions in footnotes had content silently left behind. Reproducer: `<w:ins>wrapped</w:ins><w:r> direct</w:r>` → `updateFootnoteText` only removed ` direct`. | **Fixed** — replaced with `collectFootnoteTextRuns` depth-first walk |
| Gemini | Multi-paragraph footnote delete only wrapped the first paragraph, leaving paragraphs 2+ active under accept-all (zombie footnote) | **Fixed** — `deleteFootnote` iterates every paragraph |
| Both | `isolateReferenceRun` correctness was unproven (no test for shared-run case) | **Fixed** — explicit shared-run delete test |
| Both | `updateFootnoteText` mixed direct + wrapped run case unproven | **Fixed** — explicit test exercising mixed input |
| Codex | `accept_changes` only mutates `document.xml`, not `footnotes.xml` — revisions emitted into side parts won't be cleaned up | **Filed as #165** as a separate follow-up |

Implementation pivot during peer review: when the deletion lands inside an existing tracked wrapper (because the prior text had revision history), the new replacement `<w:ins>` is now hoisted to the paragraph level so the AI's authorship is not nested inside the prior author's wrapper.

## Tests

8 new BDD tests:
1. addFootnote with ctx wraps body reference and note text in distinct `<w:ins>` containers
2. updateFootnoteText with ctx keeps body untouched, emits w:delText + replacement `<w:ins>` in footnotes.xml
3. deleteFootnote with ctx wraps body reference and note text in `<w:del>` while preserving the footnote entry
4. Preserves byte-identical legacy output when ctx is omitted
5. Allocates unique revision IDs across tracked addFootnote and deleteFootnote operations sharing one context
6. **(new)** deleteFootnote with ctx isolates the reference run when it shares a run with sibling text
7. **(new)** deleteFootnote with ctx wraps text runs across every paragraph of a multi-paragraph footnote
8. **(new)** updateFootnoteText with ctx captures both direct and pre-existing-w:ins-wrapped text runs in the deletion

## Verification

```bash
npm run build -w @usejunior/docx-core   # clean
npm run lint -w @usejunior/docx-core    # clean
npm run test:run -w @usejunior/docx-core
# Test Files  79 passed (79)
# Tests  1155 passed | 1 skipped (1156)
```

## What's not in this PR

- `accept_changes` / `reject_changes` extension to handle `footnotes.xml` revisions — filed as **#165**.
- MCP tools (`add_footnote.ts`, `update_footnote.ts`, `delete_footnote.ts`) still call without ctx — author identity wiring lands in #142.
- `endnotes.xml` — separate sub-issue if/when an endnote primitive ships.

## Closes

- #139 ([120.4] of #120)