### PR TITLE
feat(docx-core): emit pPrChange/trPrChange/tcPrChange from layout setters (#140)

### DIFF
--- a/packages/docx-core/src/index.ts
+++ b/packages/docx-core/src/index.ts
@@ -252,6 +252,8 @@ export * from './primitives/index.js';
 export {
   allocateRevisionId,
   buildPPrChangeElement,
+  buildTcPrChangeElement,
+  buildTrPrChangeElement,
   buildRPrChangeElement,
   createRevisionContainer,
   createRevisionContext,

--- a/packages/docx-core/src/primitives/document.ts
+++ b/packages/docx-core/src/primitives/document.ts
@@ -755,8 +755,11 @@ export class DocxDocument {
     return result;
   }
 
-  setParagraphSpacing(mutation: ParagraphSpacingMutation): ParagraphSpacingMutationResult {
-    const result = setParagraphSpacing(this.documentXml, mutation);
+  setParagraphSpacing(
+    mutation: ParagraphSpacingMutation,
+    ctx?: RevisionContext,
+  ): ParagraphSpacingMutationResult {
+    const result = setParagraphSpacing(this.documentXml, mutation, ctx);
     if (result.affectedParagraphs > 0) {
       this.dirty = true;
       this.documentViewCache = null;
@@ -764,8 +767,11 @@ export class DocxDocument {
     return result;
   }
 
-  setTableRowHeight(mutation: TableRowHeightMutation): TableRowHeightMutationResult {
-    const result = setTableRowHeight(this.documentXml, mutation);
+  setTableRowHeight(
+    mutation: TableRowHeightMutation,
+    ctx?: RevisionContext,
+  ): TableRowHeightMutationResult {
+    const result = setTableRowHeight(this.documentXml, mutation, ctx);
     if (result.affectedRows > 0) {
       this.dirty = true;
       this.documentViewCache = null;
@@ -773,8 +779,11 @@ export class DocxDocument {
     return result;
   }
 
-  setTableCellPadding(mutation: TableCellPaddingMutation): TableCellPaddingMutationResult {
-    const result = setTableCellPadding(this.documentXml, mutation);
+  setTableCellPadding(
+    mutation: TableCellPaddingMutation,
+    ctx?: RevisionContext,
+  ): TableCellPaddingMutationResult {
+    const result = setTableCellPadding(this.documentXml, mutation, ctx);
     if (result.affectedCells > 0) {
       this.dirty = true;
       this.documentViewCache = null;

--- a/packages/docx-core/src/primitives/layout.test.ts
+++ b/packages/docx-core/src/primitives/layout.test.ts
@@ -1,0 +1,470 @@
+import { describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { getParagraphBookmarkId, insertParagraphBookmarks } from './bookmarks.js';
+import { getDirectChildrenByName } from './dom-helpers.js';
+import { setParagraphSpacing, setTableCellPadding, setTableRowHeight } from './layout.js';
+import { OOXML, W } from './namespaces.js';
+import { createRevisionContext, createRevisionIdState } from './track-changes-emitter.js';
+import { parseXml } from './xml.js';
+
+const test = testAllure.epic('Document Comparison').withLabels({ feature: 'Layout Primitives' });
+
+const W_NS = OOXML.W_NS;
+
+function makeDocument(bodyXml: string): Document {
+  return parseXml(
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+      `<w:document xmlns:w="${OOXML.W_NS}" xmlns:r="${OOXML.R_NS}">` +
+      `<w:body>${bodyXml}</w:body>` +
+      `</w:document>`,
+  );
+}
+
+function createIndexedDocument(bodyXml: string): { doc: Document; paragraphIds: string[] } {
+  const doc = makeDocument(bodyXml);
+  insertParagraphBookmarks(doc, 'attachment-1');
+  const paragraphIds = Array.from(doc.getElementsByTagNameNS(W_NS, W.p)).map((paragraph) => {
+    const paragraphId = getParagraphBookmarkId(paragraph as Element);
+    if (!paragraphId) throw new Error('Expected paragraph bookmark');
+    return paragraphId;
+  });
+  return { doc, paragraphIds };
+}
+
+function firstDirectChild(parent: Element, localName: string): Element {
+  const child = getDirectChildrenByName(parent, localName)[0];
+  if (!child) throw new Error(`Expected ${localName} under ${parent.localName}`);
+  return child;
+}
+
+function wordAttr(element: Element, localName: string): string | null {
+  return (
+    element.getAttributeNS(W_NS, localName) ??
+    element.getAttribute(`w:${localName}`) ??
+    element.getAttribute(localName)
+  );
+}
+
+function revisionId(element: Element): number {
+  const raw = wordAttr(element, 'id');
+  if (!raw) throw new Error('Expected revision ID');
+  return Number(raw);
+}
+
+describe('layout tracked-change emission', () => {
+  test('setParagraphSpacing emits pPrChange with the prior paragraph properties snapshot', async ({ given, when, then }: AllureBddContext) => {
+    let doc: Document;
+    let paragraphId: string;
+    let paragraph: Element;
+    let pPr: Element;
+    let spacing: Element;
+    let pPrChange: Element;
+    let previousSpacing: Element;
+
+    await given('a bookmarked paragraph that already has spacing properties', () => {
+      const indexed = createIndexedDocument(
+        `<w:p><w:pPr><w:spacing w:after="120"/></w:pPr><w:r><w:t>Alpha</w:t></w:r></w:p>`,
+      );
+      doc = indexed.doc;
+      [paragraphId] = indexed.paragraphIds as [string];
+    });
+
+    await when('tracked paragraph spacing is updated', () => {
+      const result = setParagraphSpacing(
+        doc,
+        { paragraphIds: [paragraphId], beforeTwips: 240 },
+        createRevisionContext({
+          author: 'SafeDocX AI',
+          date: '2026-05-03T14:15:16Z',
+          idState: createRevisionIdState(),
+        }),
+      );
+      expect(result).toEqual({ affectedParagraphs: 1, missingParagraphIds: [] });
+
+      paragraph = doc.getElementsByTagNameNS(W_NS, W.p).item(0) as Element;
+      pPr = firstDirectChild(paragraph, W.pPr);
+      spacing = firstDirectChild(pPr, W.spacing);
+      pPrChange = firstDirectChild(pPr, 'pPrChange');
+      previousSpacing = firstDirectChild(firstDirectChild(pPrChange, W.pPr), W.spacing);
+    });
+
+    await then('the outer spacing is updated while the inner pPr snapshot preserves the old state', () => {
+      expect(wordAttr(pPrChange, 'author')).toBe('SafeDocX AI');
+      expect(wordAttr(pPrChange, 'date')).toBe('2026-05-03T14:15:16Z');
+      expect(revisionId(pPrChange)).toBe(1);
+      expect(wordAttr(spacing, 'before')).toBe('240');
+      expect(wordAttr(spacing, 'after')).toBe('120');
+      expect(wordAttr(previousSpacing, 'before')).toBeNull();
+      expect(wordAttr(previousSpacing, 'after')).toBe('120');
+    });
+  });
+
+  test('setTableRowHeight emits trPrChange with the prior row properties snapshot', async ({ given, when, then }: AllureBddContext) => {
+    let doc: Document;
+    let trPr: Element;
+    let trHeight: Element;
+    let trPrChange: Element;
+    let previousTrHeight: Element;
+
+    await given('a table row that already has a height definition', () => {
+      doc = makeDocument(
+        `<w:tbl><w:tr><w:trPr><w:trHeight w:val="360" w:hRule="atLeast"/></w:trPr><w:tc><w:p><w:r><w:t>Cell</w:t></w:r></w:p></w:tc></w:tr></w:tbl>`,
+      );
+    });
+
+    await when('tracked row height is updated', () => {
+      const result = setTableRowHeight(
+        doc,
+        { tableIndexes: [0], valueTwips: 480, rule: 'exact' },
+        createRevisionContext({
+          author: 'SafeDocX AI',
+          date: '2026-05-03T14:15:16Z',
+          idState: createRevisionIdState(),
+        }),
+      );
+      expect(result).toEqual({ affectedRows: 1, missingTableIndexes: [], missingRowIndexes: [] });
+
+      const table = doc.getElementsByTagNameNS(W_NS, W.tbl).item(0) as Element;
+      const row = firstDirectChild(table, W.tr);
+      trPr = firstDirectChild(row, W.trPr);
+      trHeight = firstDirectChild(trPr, W.trHeight);
+      trPrChange = firstDirectChild(trPr, 'trPrChange');
+      previousTrHeight = firstDirectChild(firstDirectChild(trPrChange, W.trPr), W.trHeight);
+    });
+
+    await then('the outer row properties are updated while the inner trPr snapshot preserves the old height', () => {
+      expect(wordAttr(trPrChange, 'author')).toBe('SafeDocX AI');
+      expect(wordAttr(trPrChange, 'date')).toBe('2026-05-03T14:15:16Z');
+      expect(revisionId(trPrChange)).toBe(1);
+      expect(wordAttr(trHeight, 'val')).toBe('480');
+      expect(wordAttr(trHeight, 'hRule')).toBe('exact');
+      expect(wordAttr(previousTrHeight, 'val')).toBe('360');
+      expect(wordAttr(previousTrHeight, 'hRule')).toBe('atLeast');
+    });
+  });
+
+  test('setTableCellPadding emits tcPrChange with the prior cell properties snapshot', async ({ given, when, then }: AllureBddContext) => {
+    let doc: Document;
+    let tcMar: Element;
+    let left: Element;
+    let tcPrChange: Element;
+    let previousTcMar: Element;
+
+    await given('a table cell that already has top padding', () => {
+      doc = makeDocument(
+        `<w:tbl><w:tr><w:tc><w:tcPr><w:tcMar><w:top w:w="100" w:type="dxa"/></w:tcMar></w:tcPr><w:p><w:r><w:t>Cell</w:t></w:r></w:p></w:tc></w:tr></w:tbl>`,
+      );
+    });
+
+    await when('tracked left padding is added', () => {
+      const result = setTableCellPadding(
+        doc,
+        { tableIndexes: [0], leftDxa: 240 },
+        createRevisionContext({
+          author: 'SafeDocX AI',
+          date: '2026-05-03T14:15:16Z',
+          idState: createRevisionIdState(),
+        }),
+      );
+      expect(result).toEqual({
+        affectedCells: 1,
+        missingTableIndexes: [],
+        missingRowIndexes: [],
+        missingCellIndexes: [],
+      });
+
+      const table = doc.getElementsByTagNameNS(W_NS, W.tbl).item(0) as Element;
+      const row = firstDirectChild(table, W.tr);
+      const cell = firstDirectChild(row, W.tc);
+      const tcPr = firstDirectChild(cell, W.tcPr);
+      tcMar = firstDirectChild(tcPr, W.tcMar);
+      left = firstDirectChild(tcMar, W.left);
+      tcPrChange = firstDirectChild(tcPr, 'tcPrChange');
+      previousTcMar = firstDirectChild(firstDirectChild(tcPrChange, W.tcPr), W.tcMar);
+    });
+
+    await then('the outer cell properties are updated while the inner tcPr snapshot preserves the old padding', () => {
+      expect(wordAttr(tcPrChange, 'author')).toBe('SafeDocX AI');
+      expect(wordAttr(tcPrChange, 'date')).toBe('2026-05-03T14:15:16Z');
+      expect(revisionId(tcPrChange)).toBe(1);
+      expect(wordAttr(left, 'w')).toBe('240');
+      expect(wordAttr(left, 'type')).toBe('dxa');
+      expect(getDirectChildrenByName(previousTcMar, W.left)).toHaveLength(0);
+      expect(firstDirectChild(previousTcMar, W.top)).toBeDefined();
+    });
+  });
+
+  test('layout primitives preserve legacy mutation behavior when revision context is omitted', async ({ given, when, then }: AllureBddContext) => {
+    let doc: Document;
+    let paragraphId: string;
+
+    await given('a document with paragraph, row, and cell layout properties', () => {
+      const indexed = createIndexedDocument(
+        `<w:p><w:r><w:t>Alpha</w:t></w:r></w:p>` +
+          `<w:tbl><w:tr><w:tc><w:p><w:r><w:t>Cell</w:t></w:r></w:p></w:tc></w:tr></w:tbl>`,
+      );
+      doc = indexed.doc;
+      [paragraphId] = indexed.paragraphIds as [string];
+    });
+
+    await when('the layout primitives run without tracked-change context', () => {
+      setParagraphSpacing(doc, { paragraphIds: [paragraphId], beforeTwips: 240 });
+      setTableRowHeight(doc, { tableIndexes: [0], valueTwips: 480, rule: 'exact' });
+      setTableCellPadding(doc, { tableIndexes: [0], leftDxa: 240 });
+    });
+
+    await then('no property-change wrappers are emitted while the direct properties are still updated', () => {
+      const paragraph = doc.getElementsByTagNameNS(W_NS, W.p).item(0) as Element;
+      const pPr = firstDirectChild(paragraph, W.pPr);
+      expect(getDirectChildrenByName(pPr, 'pPrChange')).toHaveLength(0);
+      expect(wordAttr(firstDirectChild(pPr, W.spacing), 'before')).toBe('240');
+
+      const table = doc.getElementsByTagNameNS(W_NS, W.tbl).item(0) as Element;
+      const row = firstDirectChild(table, W.tr);
+      const trPr = firstDirectChild(row, W.trPr);
+      expect(getDirectChildrenByName(trPr, 'trPrChange')).toHaveLength(0);
+      expect(wordAttr(firstDirectChild(trPr, W.trHeight), 'val')).toBe('480');
+
+      const cell = firstDirectChild(row, W.tc);
+      const tcPr = firstDirectChild(cell, W.tcPr);
+      expect(getDirectChildrenByName(tcPr, 'tcPrChange')).toHaveLength(0);
+      expect(wordAttr(firstDirectChild(firstDirectChild(tcPr, W.tcMar), W.left), 'w')).toBe('240');
+    });
+  });
+
+  test('layout primitives emit empty prior snapshots and unique IDs when tracked properties are created from scratch', async ({ given, when, then }: AllureBddContext) => {
+    let doc: Document;
+    let paragraphId: string;
+    let emittedIds: number[];
+    let previousPPr: Element;
+    let previousTrPr: Element;
+    let previousTcPr: Element;
+
+    await given('a document whose targeted paragraph, row, and cell have no prior property blocks', () => {
+      const indexed = createIndexedDocument(
+        `<w:p><w:r><w:t>Alpha</w:t></w:r></w:p>` +
+          `<w:tbl><w:tr><w:tc><w:p><w:r><w:t>Cell</w:t></w:r></w:p></w:tc></w:tr></w:tbl>`,
+      );
+      doc = indexed.doc;
+      [paragraphId] = indexed.paragraphIds as [string];
+    });
+
+    await when('the three tracked layout primitives share one revision context', () => {
+      const ctx = createRevisionContext({
+        author: 'SafeDocX AI',
+        date: '2026-05-03T14:15:16Z',
+        idState: createRevisionIdState(),
+      });
+
+      setParagraphSpacing(doc, { paragraphIds: [paragraphId], beforeTwips: 240 }, ctx);
+      setTableRowHeight(doc, { tableIndexes: [0], valueTwips: 480, rule: 'exact' }, ctx);
+      setTableCellPadding(doc, { tableIndexes: [0], leftDxa: 120 }, ctx);
+
+      const paragraph = doc.getElementsByTagNameNS(W_NS, W.p).item(0) as Element;
+      const pPr = firstDirectChild(paragraph, W.pPr);
+      const table = doc.getElementsByTagNameNS(W_NS, W.tbl).item(0) as Element;
+      const row = firstDirectChild(table, W.tr);
+      const trPr = firstDirectChild(row, W.trPr);
+      const cell = firstDirectChild(row, W.tc);
+      const tcPr = firstDirectChild(cell, W.tcPr);
+
+      const pPrChange = firstDirectChild(pPr, 'pPrChange');
+      const trPrChange = firstDirectChild(trPr, 'trPrChange');
+      const tcPrChange = firstDirectChild(tcPr, 'tcPrChange');
+      emittedIds = [revisionId(pPrChange), revisionId(trPrChange), revisionId(tcPrChange)];
+      previousPPr = firstDirectChild(pPrChange, W.pPr);
+      previousTrPr = firstDirectChild(trPrChange, W.trPr);
+      previousTcPr = firstDirectChild(tcPrChange, W.tcPr);
+    });
+
+    await then('each new change wrapper gets a unique ID and carries an empty prior-properties element', () => {
+      expect(emittedIds).toEqual([1, 2, 3]);
+      expect(new Set(emittedIds).size).toBe(3);
+      expect(previousPPr.childNodes.length).toBe(0);
+      expect(previousTrPr.childNodes.length).toBe(0);
+      expect(previousTcPr.childNodes.length).toBe(0);
+    });
+  });
+
+  test('a second tracked layout mutation replaces the existing pPrChange instead of stacking siblings', async ({ given, when, then }: AllureBddContext) => {
+    let doc: Document;
+    let paragraphId: string;
+    let pPr: Element;
+    let pPrChanges: Element[];
+
+    await given('a paragraph that already carries a pPrChange from a prior tracked spacing edit', () => {
+      const indexed = createIndexedDocument(`<w:p><w:r><w:t>Hello</w:t></w:r></w:p>`);
+      doc = indexed.doc;
+      paragraphId = indexed.paragraphIds[0]!;
+
+      setParagraphSpacing(
+        doc,
+        { paragraphIds: [paragraphId], beforeTwips: 120 },
+        createRevisionContext({
+          author: 'AuthorA',
+          date: '2026-01-01T00:00:00Z',
+          idState: createRevisionIdState(),
+        }),
+      );
+
+      pPr = firstDirectChild(
+        Array.from(doc.getElementsByTagNameNS(W_NS, W.p)).find((p) =>
+          getParagraphBookmarkId(p as Element) === paragraphId,
+        ) as Element,
+        W.pPr,
+      );
+      expect(getDirectChildrenByName(pPr, 'pPrChange')).toHaveLength(1);
+    });
+
+    await when('a second tracked spacing edit is applied with a fresh revision context', () => {
+      setParagraphSpacing(
+        doc,
+        { paragraphIds: [paragraphId], beforeTwips: 240 },
+        createRevisionContext({
+          author: 'SafeDocX AI',
+          date: '2026-05-06T15:30:00Z',
+          idState: createRevisionIdState(),
+        }),
+      );
+      pPrChanges = getDirectChildrenByName(pPr, 'pPrChange');
+    });
+
+    await then('exactly one pPrChange remains under the pPr, attributed to the latest author', () => {
+      expect(pPrChanges).toHaveLength(1);
+      expect(pPrChanges[0]!.getAttribute('w:author')).toBe('SafeDocX AI');
+    });
+  });
+
+  test('a second tracked row-height mutation replaces the existing trPrChange', async ({ given, when, then }: AllureBddContext) => {
+    let doc: Document;
+    let trPr: Element;
+    let trPrChanges: Element[];
+
+    await given('a row that already carries a trPrChange from a prior tracked row-height edit', () => {
+      doc = makeDocument(`<w:tbl><w:tr><w:tc><w:p/></w:tc></w:tr></w:tbl>`);
+      setTableRowHeight(
+        doc,
+        { tableIndexes: [0], rowIndexes: [0], valueTwips: 360, rule: 'atLeast' },
+        createRevisionContext({
+          author: 'AuthorA',
+          date: '2026-01-01T00:00:00Z',
+          idState: createRevisionIdState(),
+        }),
+      );
+      const row = doc.getElementsByTagNameNS(W_NS, W.tr).item(0) as Element;
+      trPr = firstDirectChild(row, W.trPr);
+      expect(getDirectChildrenByName(trPr, 'trPrChange')).toHaveLength(1);
+    });
+
+    await when('a second tracked row-height edit is applied', () => {
+      setTableRowHeight(
+        doc,
+        { tableIndexes: [0], rowIndexes: [0], valueTwips: 720, rule: 'exact' },
+        createRevisionContext({
+          author: 'SafeDocX AI',
+          date: '2026-05-06T15:30:00Z',
+          idState: createRevisionIdState(),
+        }),
+      );
+      trPrChanges = getDirectChildrenByName(trPr, 'trPrChange');
+    });
+
+    await then('exactly one trPrChange remains under the trPr, attributed to the latest author', () => {
+      expect(trPrChanges).toHaveLength(1);
+      expect(trPrChanges[0]!.getAttribute('w:author')).toBe('SafeDocX AI');
+    });
+  });
+
+  test('a second tracked cell-padding mutation replaces the existing tcPrChange', async ({ given, when, then }: AllureBddContext) => {
+    let doc: Document;
+    let tcPr: Element;
+    let tcPrChanges: Element[];
+
+    await given('a cell that already carries a tcPrChange from a prior tracked padding edit', () => {
+      doc = makeDocument(`<w:tbl><w:tr><w:tc><w:p/></w:tc></w:tr></w:tbl>`);
+      setTableCellPadding(
+        doc,
+        { tableIndexes: [0], rowIndexes: [0], cellIndexes: [0], topDxa: 100 },
+        createRevisionContext({
+          author: 'AuthorA',
+          date: '2026-01-01T00:00:00Z',
+          idState: createRevisionIdState(),
+        }),
+      );
+      const cell = doc.getElementsByTagNameNS(W_NS, W.tc).item(0) as Element;
+      tcPr = firstDirectChild(cell, W.tcPr);
+      expect(getDirectChildrenByName(tcPr, 'tcPrChange')).toHaveLength(1);
+    });
+
+    await when('a second tracked padding edit is applied', () => {
+      setTableCellPadding(
+        doc,
+        { tableIndexes: [0], rowIndexes: [0], cellIndexes: [0], topDxa: 200 },
+        createRevisionContext({
+          author: 'SafeDocX AI',
+          date: '2026-05-06T15:30:00Z',
+          idState: createRevisionIdState(),
+        }),
+      );
+      tcPrChanges = getDirectChildrenByName(tcPr, 'tcPrChange');
+    });
+
+    await then('exactly one tcPrChange remains under the tcPr, attributed to the latest author', () => {
+      expect(tcPrChanges).toHaveLength(1);
+      expect(tcPrChanges[0]!.getAttribute('w:author')).toBe('SafeDocX AI');
+    });
+  });
+
+  test('tracked cell-padding edit on a cell with cellIns history preserves the topology revision in the snapshot', async ({ given, when, then }: AllureBddContext) => {
+    let doc: Document;
+    let tcPr: Element;
+    let tcPrChange: Element;
+    let snapshotTcPr: Element;
+
+    await given('a cell with a pre-existing cellIns marker (cell-topology revision history)', () => {
+      doc = makeDocument(
+        `<w:tbl>` +
+          `<w:tr>` +
+            `<w:tc>` +
+              `<w:tcPr>` +
+                `<w:cellIns w:id="50" w:author="OldAuthor" w:date="2024-01-01T00:00:00Z"/>` +
+                `<w:tcMar><w:top w:w="80" w:type="dxa"/></w:tcMar>` +
+              `</w:tcPr>` +
+              `<w:p/>` +
+            `</w:tc>` +
+          `</w:tr>` +
+        `</w:tbl>`,
+      );
+    });
+
+    await when('a tracked padding edit is applied', () => {
+      setTableCellPadding(
+        doc,
+        { tableIndexes: [0], rowIndexes: [0], cellIndexes: [0], topDxa: 200 },
+        createRevisionContext({
+          author: 'SafeDocX AI',
+          date: '2026-05-06T15:30:00Z',
+          idState: createRevisionIdState(),
+        }),
+      );
+      const cell = doc.getElementsByTagNameNS(W_NS, W.tc).item(0) as Element;
+      tcPr = firstDirectChild(cell, W.tcPr);
+      tcPrChange = firstDirectChild(tcPr, 'tcPrChange');
+      snapshotTcPr = firstDirectChild(tcPrChange, W.tcPr);
+    });
+
+    await then('the snapshot inside tcPrChange preserves the prior cellIns and tcMar (CT_TcPrInner allows them)', () => {
+      // The snapshot must retain cell-topology revision children.
+      expect(getDirectChildrenByName(snapshotTcPr, 'cellIns')).toHaveLength(1);
+      expect(getDirectChildrenByName(snapshotTcPr, 'cellIns')[0]!.getAttribute('w:author')).toBe('OldAuthor');
+      // tcMar with the OLD top value also survives.
+      const snapshotTcMar = firstDirectChild(snapshotTcPr, 'tcMar');
+      const snapshotTop = firstDirectChild(snapshotTcMar, 'top');
+      expect(snapshotTop.getAttribute('w:w')).toBe('80');
+      // The OUTER tcPr has the NEW top value.
+      const newTcMar = firstDirectChild(tcPr, 'tcMar');
+      const newTop = firstDirectChild(newTcMar, 'top');
+      expect(newTop.getAttribute('w:w')).toBe('200');
+    });
+  });
+});

--- a/packages/docx-core/src/primitives/layout.ts
+++ b/packages/docx-core/src/primitives/layout.ts
@@ -1,5 +1,11 @@
 import { findParagraphByBookmarkId } from './bookmarks.js';
 import { OOXML, W } from './namespaces.js';
+import {
+  buildPPrChangeElement,
+  buildTcPrChangeElement,
+  buildTrPrChangeElement,
+  type RevisionContext,
+} from './track-changes-emitter.js';
 
 export type SpacingLineRule = 'auto' | 'exact' | 'atLeast';
 export type RowHeightRule = 'auto' | 'exact' | 'atLeast';
@@ -127,6 +133,7 @@ function getTables(doc: Document): Element[] {
 export function setParagraphSpacing(
   doc: Document,
   mutation: ParagraphSpacingMutation,
+  ctx?: RevisionContext,
 ): ParagraphSpacingMutationResult {
   const paragraphIds = [...new Set(mutation.paragraphIds)];
   const missingParagraphIds: string[] = [];
@@ -139,6 +146,8 @@ export function setParagraphSpacing(
       continue;
     }
 
+    const currentPPr = getDirectChildrenByName(paragraph, W.pPr)[0] ?? null;
+    const oldPPr = currentPPr ? (currentPPr.cloneNode(true) as Element) : null;
     const pPr = ensureFirstChild(paragraph, W.pPr);
     const spacing = ensureChild(pPr, W.spacing);
 
@@ -146,6 +155,14 @@ export function setParagraphSpacing(
     if (typeof mutation.afterTwips === 'number') setWAttr(spacing, W.after, String(mutation.afterTwips));
     if (typeof mutation.lineTwips === 'number') setWAttr(spacing, W.line, String(mutation.lineTwips));
     if (typeof mutation.lineRule === 'string') setWAttr(spacing, W.lineRule, mutation.lineRule);
+    if (ctx) {
+      // CT_PPr permits at most one <w:pPrChange> child. Strip any stale
+      // wrapper from prior history before appending the new one.
+      for (const stale of getDirectChildrenByName(pPr, 'pPrChange')) {
+        pPr.removeChild(stale);
+      }
+      pPr.appendChild(buildPPrChangeElement(oldPPr, ctx));
+    }
 
     affectedParagraphs += 1;
   }
@@ -156,6 +173,7 @@ export function setParagraphSpacing(
 export function setTableRowHeight(
   doc: Document,
   mutation: TableRowHeightMutation,
+  ctx?: RevisionContext,
 ): TableRowHeightMutationResult {
   const tables = getTables(doc);
   const missingTableIndexes: number[] = [];
@@ -177,10 +195,19 @@ export function setTableRowHeight(
 
     for (const rowIndex of rowSelection.indexes) {
       const row = rows[rowIndex]!;
+      const currentTrPr = getDirectChildrenByName(row, W.trPr)[0] ?? null;
+      const oldTrPr = currentTrPr ? (currentTrPr.cloneNode(true) as Element) : null;
       const trPr = ensureFirstChild(row, W.trPr);
       const trHeight = ensureChild(trPr, W.trHeight);
       setWAttr(trHeight, W.val, String(mutation.valueTwips));
       setWAttr(trHeight, W.hRule, mutation.rule);
+      if (ctx) {
+        // CT_TrPr permits at most one <w:trPrChange> child.
+        for (const stale of getDirectChildrenByName(trPr, 'trPrChange')) {
+          trPr.removeChild(stale);
+        }
+        trPr.appendChild(buildTrPrChangeElement(oldTrPr, ctx));
+      }
       affectedRows += 1;
     }
   }
@@ -191,6 +218,7 @@ export function setTableRowHeight(
 export function setTableCellPadding(
   doc: Document,
   mutation: TableCellPaddingMutation,
+  ctx?: RevisionContext,
 ): TableCellPaddingMutationResult {
   const tables = getTables(doc);
   const missingTableIndexes: number[] = [];
@@ -221,6 +249,8 @@ export function setTableCellPadding(
 
       for (const cellIndex of cellSelection.indexes) {
         const cell = cells[cellIndex]!;
+        const currentTcPr = getDirectChildrenByName(cell, W.tcPr)[0] ?? null;
+        const oldTcPr = currentTcPr ? (currentTcPr.cloneNode(true) as Element) : null;
         const tcPr = ensureFirstChild(cell, W.tcPr);
         const tcMar = ensureChild(tcPr, W.tcMar);
 
@@ -243,6 +273,13 @@ export function setTableCellPadding(
           const right = ensureChild(tcMar, W.right);
           setWAttr(right, W.w, String(mutation.rightDxa));
           setWAttr(right, W.type, 'dxa');
+        }
+        if (ctx) {
+          // CT_TcPr permits at most one <w:tcPrChange> child.
+          for (const stale of getDirectChildrenByName(tcPr, 'tcPrChange')) {
+            tcPr.removeChild(stale);
+          }
+          tcPr.appendChild(buildTcPrChangeElement(oldTcPr, ctx));
         }
 
         affectedCells += 1;

--- a/packages/docx-core/src/primitives/track-changes-emitter.test.ts
+++ b/packages/docx-core/src/primitives/track-changes-emitter.test.ts
@@ -8,6 +8,8 @@ import {
   allocateRevisionId,
   buildPPrChangeElement,
   buildRPrChangeElement,
+  buildTcPrChangeElement,
+  buildTrPrChangeElement,
   createRevisionContainer,
   createRevisionContext,
   createRevisionIdState,
@@ -173,6 +175,74 @@ describe('track-changes-emitter', () => {
       expect(serialized).toContain('<w:pPr><w:spacing w:before="120"/></w:pPr>');
       expect(serialized).not.toContain('<w:rPr>');
       expect(serialized).not.toContain('<w:sectPr');
+    });
+  });
+
+  test('buildTrPrChangeElement snapshots prior row properties without nested trPrChange or row revision markers', async ({ given, when, then }: AllureBddContext) => {
+    let trPr: Element;
+    let serialized: string;
+
+    await given('a row properties element that already contains tracked-change children', () => {
+      trPr = parseFragment(
+        '<w:trPr><w:trHeight w:val="360" w:hRule="atLeast"/><w:ins w:id="50"/><w:del w:id="51"/><w:trPrChange w:id="99"/></w:trPr>',
+      );
+    });
+
+    await when('buildTrPrChangeElement snapshots the previous state', () => {
+      serialized = serialize(
+        buildTrPrChangeElement(
+          trPr,
+          createRevisionContext({
+            author: 'Comparison',
+            date: '2026-05-03T14:15:16Z',
+            idState: createRevisionIdState(),
+          }),
+        ),
+      );
+    });
+
+    await then('the generated wrapper contains only CT_TrPrBase-compatible children', () => {
+      expect(serialized).toContain('<w:trPrChange ');
+      expect(serialized).toContain('<w:trPr><w:trHeight w:val="360" w:hRule="atLeast"/></w:trPr>');
+      expect(serialized).not.toContain('w:trPrChange w:id="99"');
+      expect(serialized).not.toContain('<w:ins ');
+      expect(serialized).not.toContain('<w:del ');
+    });
+  });
+
+  test('buildTcPrChangeElement snapshots prior cell properties preserving cell-topology revision children but stripping nested tcPrChange', async ({ given, when, then }: AllureBddContext) => {
+    let tcPr: Element;
+    let serialized: string;
+
+    await given('a cell properties element that already contains cell-topology revision markers and a stale tcPrChange', () => {
+      tcPr = parseFragment(
+        '<w:tcPr><w:tcMar><w:top w:w="100" w:type="dxa"/></w:tcMar><w:cellIns w:id="40"/><w:cellDel w:id="41"/><w:cellMerge w:id="42"/><w:tcPrChange w:id="99"/></w:tcPr>',
+      );
+    });
+
+    await when('buildTcPrChangeElement snapshots the previous state', () => {
+      serialized = serialize(
+        buildTcPrChangeElement(
+          tcPr,
+          createRevisionContext({
+            author: 'Comparison',
+            date: '2026-05-03T14:15:16Z',
+            idState: createRevisionIdState(),
+          }),
+        ),
+      );
+    });
+
+    await then('CT_TcPrInner preserves cellIns/cellDel/cellMerge but excludes the stale tcPrChange', () => {
+      expect(serialized).toContain('<w:tcPrChange ');
+      // The stale change-of-a-change marker is dropped.
+      expect(serialized).not.toContain('w:tcPrChange w:id="99"');
+      // Cell-topology revisions are part of CT_TcPrInner and must be preserved.
+      expect(serialized).toContain('<w:cellIns w:id="40"/>');
+      expect(serialized).toContain('<w:cellDel w:id="41"/>');
+      expect(serialized).toContain('<w:cellMerge w:id="42"/>');
+      // tcMar is also part of CT_TcPrInner and must be preserved.
+      expect(serialized).toContain('<w:tcMar><w:top w:w="100" w:type="dxa"/></w:tcMar>');
     });
   });
 

--- a/packages/docx-core/src/primitives/track-changes-emitter.ts
+++ b/packages/docx-core/src/primitives/track-changes-emitter.ts
@@ -6,6 +6,12 @@ const SYNTHETIC_DOC = parseXml(
 );
 
 const EXCLUDED_PPR_CHANGE_CHILDREN = new Set(['w:rPr', 'w:rPrChange', 'w:pPrChange', 'w:sectPr']);
+const EXCLUDED_TRPR_CHANGE_CHILDREN = new Set(['w:trPrChange', 'w:ins', 'w:del']);
+// CT_TcPrInner (the inner pPr under <w:tcPrChange>) preserves cell-topology
+// revision children (w:cellIns, w:cellDel, w:cellMerge). Only the
+// change-of-a-change marker w:tcPrChange itself is excluded. See:
+// https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.wordprocessing.previoustablecellproperties
+const EXCLUDED_TCPR_CHANGE_CHILDREN = new Set(['w:tcPrChange']);
 const EXCLUDED_RPR_CHANGE_CHILDREN = new Set(['w:rPrChange']);
 
 /**
@@ -168,6 +174,56 @@ export function buildPPrChangeElement(oldPPr: Element | null, ctx: RevisionConte
 
   pPrChange.appendChild(previousPPr);
   return pPrChange;
+}
+
+/**
+ * Build a `<w:trPrChange>` wrapper containing the previous row properties.
+ *
+ * The nested snapshot excludes children that are not valid in `CT_TrPrBase`.
+ */
+export function buildTrPrChangeElement(oldTrPr: Element | null, ctx: RevisionContext): Element {
+  const trPrChange = createWmlElement(
+    getOwnerDocument(oldTrPr),
+    'trPrChange',
+    revisionAttributes(ctx),
+  );
+  const previousTrPr = createWmlElement(getOwnerDocument(oldTrPr), 'trPr');
+
+  if (oldTrPr) {
+    for (const child of childElements(oldTrPr)) {
+      if (!EXCLUDED_TRPR_CHANGE_CHILDREN.has(child.tagName)) {
+        previousTrPr.appendChild(child.cloneNode(true));
+      }
+    }
+  }
+
+  trPrChange.appendChild(previousTrPr);
+  return trPrChange;
+}
+
+/**
+ * Build a `<w:tcPrChange>` wrapper containing the previous cell properties.
+ *
+ * The nested snapshot excludes children that are not valid in `CT_TcPrBase`.
+ */
+export function buildTcPrChangeElement(oldTcPr: Element | null, ctx: RevisionContext): Element {
+  const tcPrChange = createWmlElement(
+    getOwnerDocument(oldTcPr),
+    'tcPrChange',
+    revisionAttributes(ctx),
+  );
+  const previousTcPr = createWmlElement(getOwnerDocument(oldTcPr), 'tcPr');
+
+  if (oldTcPr) {
+    for (const child of childElements(oldTcPr)) {
+      if (!EXCLUDED_TCPR_CHANGE_CHILDREN.has(child.tagName)) {
+        previousTcPr.appendChild(child.cloneNode(true));
+      }
+    }
+  }
+
+  tcPrChange.appendChild(previousTcPr);
+  return tcPrChange;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fifth per-primitive PR after #136/#137/#138/#139. Migrates the three layout setters in `packages/docx-core/src/primitives/layout.ts` to optionally accept `ctx?: RevisionContext` and emit native OOXML property-change revisions:

- `setParagraphSpacing` → `<w:pPrChange>`
- `setTableRowHeight` → `<w:trPrChange>`
- `setTableCellPadding` → `<w:tcPrChange>`

The pattern is the cleanest of the per-primitive PRs: capture a clone of the existing `pPr`/`trPr`/`tcPr` BEFORE mutation, apply the mutation, append the `*PrChange` wrapper to the modified element. No run-level wrapping, no DOM splitting.

## What's new in `track-changes-emitter.ts`

Two helpers (re-exported from the package barrel):

- **`buildTrPrChangeElement(oldTrPr, ctx)`** — snapshots prior `trPr` per `CT_TrPrBase`, excluding nested `trPrChange`/`ins`/`del`.
- **`buildTcPrChangeElement(oldTcPr, ctx)`** — snapshots prior `tcPr` per `CT_TcPrInner`. **Preserves** `cellIns`/`cellDel`/`cellMerge` children (cell-topology revisions are valid inside the snapshot per ECMA-376; only the change-of-a-change marker `tcPrChange` itself is excluded).

## Peer review fixes (both High severity)

| Reviewer | Finding | Resolution |
|---|---|---|
| Codex (with Microsoft Learn citation) | Initial `EXCLUDED_TCPR_CHANGE_CHILDREN` incorrectly stripped `cellIns`/`cellDel`/`cellMerge`. Per `CT_TcPrInner` spec, those ARE valid in the snapshot. Stripping them loses prior cell-topology state. | **Fixed** — exclusion list shrunk to just `['w:tcPrChange']`. Test updated to assert preservation. |
| Both | OOXML permits at most one `*PrChange` per `pPr`/`trPr`/`tcPr`. The initial implementation always appended, so a second tracked layout mutation on a previously-reviewed document produced duplicate sibling change wrappers (invalid OOXML). | **Fixed** — each setter strips any stale `*PrChange` direct child before appending the new one. Three new tests lock in one-wrapper-only across consecutive edits. |

Both reviewers also confirmed:
- `pPrChange` and `trPrChange` exclusion sets are correct
- Placement (`appendChild`) is canonical (`*PrChange` must be last child per ECMA-376)
- Empty-prior-state semantics match `buildPPrChangeElement(null, ...)` behavior
- DocxDocument wrappers correctly forward `ctx`, `dirty`, and cache invalidation

## Test coverage

11 new tests:

1. `setParagraphSpacing` emits `pPrChange` with prior pPr snapshot
2. `setTableRowHeight` emits `trPrChange` with prior trPr snapshot
3. `setTableCellPadding` emits `tcPrChange` with prior tcPr snapshot
4. Layout primitives preserve legacy mutation behavior when `ctx` is omitted
5. Layout primitives emit empty prior snapshots and unique IDs when tracked properties are created from scratch
6. **(new)** A second tracked layout mutation replaces the existing `pPrChange` instead of stacking siblings
7. **(new)** A second tracked row-height mutation replaces the existing `trPrChange`
8. **(new)** A second tracked cell-padding mutation replaces the existing `tcPrChange`
9. **(new)** Tracked cell-padding edit on a cell with `cellIns` history preserves the topology revision in the snapshot
10. `buildTrPrChangeElement` snapshots prior row properties without nested `trPrChange` or row revision markers
11. `buildTcPrChangeElement` snapshots prior cell properties **preserving** cell-topology revision children but stripping nested `tcPrChange`

## Verification

```bash
npm run build -w @usejunior/docx-core   # clean
npm run lint -w @usejunior/docx-core    # clean
npm run test:run -w @usejunior/docx-core
# Test Files  80 passed (80)
# Tests  1166 passed | 1 skipped (1167)
```

## What's not in this PR

- MCP `format_layout` tool still calls without `ctx` — author identity wiring lands in #142.
- `sectPrChange` (section property changes) — no current primitive surfaces this; deferred.
- `tblPrChange`/`tblGridChange` (table-wide property/grid changes) — same.

## Closes

- #140 ([120.5] of #120)