### PR TITLE
feat(docx-mcp): wire configurable AI author through MCP layer (#142)

### DIFF
--- a/packages/docx-mcp/src/server.ts
+++ b/packages/docx-mcp/src/server.ts
@@ -164,7 +164,13 @@ export async function runServer(): Promise<void> {
     },
   );
 
-  const sessions = new SessionManager();
+  // Default AI author for tracked-change emission at primitive write time.
+  // Configurable via SAFE_DOCX_AI_AUTHOR env var; defaults to "SafeDocX".
+  // Set to empty string explicitly to disable tracked emission and fall back
+  // to legacy untracked behavior.
+  const aiAuthorEnv = process.env.SAFE_DOCX_AI_AUTHOR;
+  const defaultAiAuthor = aiAuthorEnv === '' ? null : (aiAuthorEnv ?? 'SafeDocX');
+  const sessions = new SessionManager({ defaultAiAuthor });
 
   server.setRequestHandler(ListToolsRequestSchema, async () => {
     return { tools: MCP_TOOLS };

--- a/packages/docx-mcp/src/session/manager.test.ts
+++ b/packages/docx-mcp/src/session/manager.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, afterEach } from 'vitest';
 import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
-import { SessionManager } from './manager.js';
-import { makeMinimalDocx } from '../testing/docx_test_utils.js';
+import { SessionManager, getRevisionContextForSession } from './manager.js';
+import { makeDocxWithDocumentXml, makeMinimalDocx } from '../testing/docx_test_utils.js';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import os from 'node:os';
@@ -71,6 +71,17 @@ describe('SessionManager.createSession', () => {
     tmpDirs.push(path.dirname(session.tmpPath));
   });
 
+  test('seeds aiAuthor from the manager default and leaves revisionIdState unset', async () => {
+    const mgr = new SessionManager({ defaultAiAuthor: 'SafeDocX' });
+    const filePath = await createTestFile();
+    const buf = await fs.readFile(filePath);
+    const session = await mgr.createSession(Buffer.from(buf), 'test.docx', filePath);
+
+    expect(session.aiAuthor).toBe('SafeDocX');
+    expect(session.revisionIdState).toBeNull();
+    tmpDirs.push(path.dirname(session.tmpPath));
+  });
+
   test('replaces existing session for same file path', async () => {
     const mgr = new SessionManager();
     const filePath = await createTestFile();
@@ -86,6 +97,30 @@ describe('SessionManager.createSession', () => {
     expect(exists).toBe(false);
 
     tmpDirs.push(path.dirname(s2.tmpPath));
+  });
+});
+
+describe('revision context helpers', () => {
+  test('initializes revision ids above the highest pre-existing w:id value', async () => {
+    const mgr = new SessionManager({ defaultAiAuthor: 'SafeDocX' });
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'mgr-revision-test-'));
+    tmpDirs.push(dir);
+    const filePath = path.join(dir, 'tracked.docx');
+    const documentXml =
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+      `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
+      `<w:body>` +
+      `<w:p><w:r><w:t>Alpha</w:t></w:r></w:p>` +
+      `<w:p><w:ins w:id="42" w:author="Existing" w:date="2026-01-01T00:00:00Z"><w:r><w:t>Prior</w:t></w:r></w:ins></w:p>` +
+      `</w:body></w:document>`;
+    const buf = await makeDocxWithDocumentXml(documentXml);
+    await fs.writeFile(filePath, new Uint8Array(buf));
+
+    const session = await mgr.createSession(buf, 'tracked.docx', filePath);
+    const ctx = getRevisionContextForSession(session);
+
+    expect(ctx).toBeDefined();
+    expect(session.revisionIdState?.nextId).toBe(43);
   });
 });
 

--- a/packages/docx-mcp/src/session/manager.ts
+++ b/packages/docx-mcp/src/session/manager.ts
@@ -4,11 +4,15 @@ import os from 'node:os';
 import fs from 'node:fs/promises';
 import {
   DocxDocument,
+  createRevisionContext,
+  createRevisionIdState,
   type NormalizationResult,
   type ParagraphRevision,
   type ReconstructionMode,
   type ReconstructionFallbackReason,
   type ReconstructionFallbackDiagnostics,
+  type RevisionContext,
+  type RevisionIdState,
 } from '@usejunior/docx-core';
 
 export type SaveFormat = 'clean' | 'tracked' | 'both';
@@ -62,6 +66,8 @@ export type DocxSession = {
    */
   comparisonBaselineWithBookmarks: Buffer | null;
   doc: DocxDocument;
+  aiAuthor: string | null;
+  revisionIdState: RevisionIdState | null;
   editCount: number;
   editRevision: number;
   saveCache: Map<string, SaveCacheEntry>;
@@ -86,6 +92,70 @@ export type GDocsSession = {
 
 export type Session = DocxSession | GDocsSession;
 
+const WORDPROCESSING_ML_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+function normalizeAiAuthor(author: string | null | undefined): string | null {
+  if (typeof author !== 'string') return null;
+  const trimmed = author.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function getWordIdValue(element: Element): number | null {
+  const raw =
+    element.getAttributeNS(WORDPROCESSING_ML_NS, 'id')
+    ?? element.getAttribute('w:id')
+    ?? element.getAttribute('id');
+  if (raw === null) return null;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/**
+ * Compute a starting `RevisionIdState` whose first allocated `w:id` is
+ * higher than any existing revision id found in the supplied documents.
+ *
+ * **Known limitation (see follow-up to #165):** this scans only the
+ * documents passed in. Today's caller passes `documentXml` only, so any
+ * pre-existing revision in side parts (`comments.xml`, `footnotesXml`,
+ * `endnotes.xml`) is invisible to the seed scan. For typical sessions
+ * with <100 AI edits this never collides in practice; for long-running
+ * sessions on heavily-reviewed third-party documents the AI counter
+ * could eventually cross a pre-existing side-part revision id.
+ *
+ * To close the gap, future work should pre-load side parts via
+ * `zip.readText('word/comments.xml')` etc. and pass them all here.
+ * That cascade requires `getRevisionContextForSession` to become async,
+ * which is deferred to follow-up.
+ */
+export function inferStartingRevisionIdState(...docs: Document[]): RevisionIdState {
+  let maxId = 0;
+
+  for (const doc of docs) {
+    for (const node of Array.from(doc.getElementsByTagName('*'))) {
+      const value = getWordIdValue(node);
+      if (value !== null && value > maxId) {
+        maxId = value;
+      }
+    }
+  }
+
+  return createRevisionIdState(maxId + 1);
+}
+
+export function getRevisionContextForSession(session: DocxSession): RevisionContext | undefined {
+  if (!session.aiAuthor) return undefined;
+
+  if (!session.revisionIdState) {
+    session.revisionIdState = inferStartingRevisionIdState(session.doc.getDocumentXmlClone());
+  }
+
+  return createRevisionContext({
+    author: session.aiAuthor,
+    date: new Date(),
+    idState: session.revisionIdState,
+  });
+}
+
 export function isDocxSession(s: Session): s is DocxSession {
   return s.provider === 'docx';
 }
@@ -98,12 +168,14 @@ export class SessionManager {
   /** Sessions keyed by canonical file path (realpath). */
   private sessions = new Map<string, Session>();
   private ttlMs: number;
+  private defaultAiAuthor: string | null;
 
   /** Concurrency guard: prevents double-generation of baselines for the same session. */
   private baselinePromises = new WeakMap<DocxSession, Promise<void>>();
 
-  constructor(opts?: { ttlMs?: number }) {
+  constructor(opts?: { ttlMs?: number; defaultAiAuthor?: string | null }) {
     this.ttlMs = opts?.ttlMs ?? 60 * 60 * 1000;
+    this.defaultAiAuthor = normalizeAiAuthor(opts?.defaultAiAuthor);
   }
 
   private expandPath(inputPath: string): string {
@@ -165,6 +237,8 @@ export class SessionManager {
       comparisonBaseline: null,
       comparisonBaselineWithBookmarks: null,
       doc,
+      aiAuthor: this.defaultAiAuthor,
+      revisionIdState: null,
       editCount: 0,
       editRevision: 0,
       saveCache: new Map<string, SaveCacheEntry>(),

--- a/packages/docx-mcp/src/tools/add_comment.ts
+++ b/packages/docx-mcp/src/tools/add_comment.ts
@@ -1,4 +1,4 @@
-import { SessionManager } from '../session/manager.js';
+import { SessionManager, getRevisionContextForSession } from '../session/manager.js';
 import { errorCode, errorMessage } from "../error_utils.js";
 import { resolveSessionForTool, mergeSessionResolutionMetadata } from './session_resolution.js';
 import { ok, err, type ToolResponse } from './types.js';
@@ -19,6 +19,7 @@ export async function addComment(
   const resolved = await resolveSessionForTool(manager, params, { toolName: 'add_comment' });
   if (!resolved.ok) return resolved.response;
   const { session, metadata } = resolved;
+  const ctx = getRevisionContextForSession(session);
 
   try {
     // Reply mode: parent_comment_id provided
@@ -28,7 +29,7 @@ export async function addComment(
         author: params.author,
         text: params.text,
         initials: params.initials,
-      });
+      }, ctx);
       manager.markEdited(session);
       return ok(mergeSessionResolutionMetadata({
         comment_id: result.commentId,
@@ -95,7 +96,7 @@ export async function addComment(
       author: params.author,
       text: params.text,
       initials: params.initials,
-    });
+    }, ctx);
 
     manager.markEdited(session);
     return ok(mergeSessionResolutionMetadata({

--- a/packages/docx-mcp/src/tools/add_footnote.ts
+++ b/packages/docx-mcp/src/tools/add_footnote.ts
@@ -1,4 +1,4 @@
-import { SessionManager } from '../session/manager.js';
+import { SessionManager, getRevisionContextForSession } from '../session/manager.js';
 import { errorCode, errorMessage } from "../error_utils.js";
 import { resolveSessionForTool, mergeSessionResolutionMetadata } from './session_resolution.js';
 import { ok, err, type ToolResponse } from './types.js';
@@ -15,6 +15,7 @@ export async function addFootnote(
   const resolved = await resolveSessionForTool(manager, params, { toolName: 'add_footnote' });
   if (!resolved.ok) return resolved.response;
   const { session, metadata } = resolved;
+  const ctx = getRevisionContextForSession(session);
 
   if (!params.target_paragraph_id) {
     return err('MISSING_PARAMETER', 'target_paragraph_id is required.', 'Provide the _bk_* ID of the paragraph to anchor the footnote to.');
@@ -34,7 +35,7 @@ export async function addFootnote(
       paragraphId: pid,
       afterText: params.after_text,
       text: params.text,
-    });
+    }, ctx);
 
     manager.markEdited(session);
     return ok(mergeSessionResolutionMetadata({

--- a/packages/docx-mcp/src/tools/ai_revision_context.test.ts
+++ b/packages/docx-mcp/src/tools/ai_revision_context.test.ts
@@ -1,0 +1,275 @@
+import path from 'node:path';
+import { describe, expect } from 'vitest';
+import { parseXml } from '@usejunior/docx-core';
+import { SessionManager } from '../session/manager.js';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { readDocumentXmlFromPath } from '../testing/docx_test_utils.js';
+import { assertSuccess, openSession, registerCleanup } from '../testing/session-test-utils.js';
+import { formatLayout } from './format_layout.js';
+import { insertParagraph } from './insert_paragraph.js';
+import { replaceText } from './replace_text.js';
+import { save } from './save.js';
+
+const WORDPROCESSING_ML_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const AI_AUTHOR = 'SafeDocX';
+const test = testAllure.epic('Document Editing').withLabels({ feature: 'AI Revision Context' });
+
+function createManager(aiAuthor: string | null = AI_AUTHOR): SessionManager {
+  return new SessionManager({ ttlMs: 60_000, defaultAiAuthor: aiAuthor });
+}
+
+function wordAttr(element: Element, localName: string): string | null {
+  return (
+    element.getAttributeNS(WORDPROCESSING_ML_NS, localName)
+    ?? element.getAttribute(`w:${localName}`)
+    ?? element.getAttribute(localName)
+  );
+}
+
+function findRevisionElements(doc: Document, localName: string, author: string): Element[] {
+  return Array.from(doc.getElementsByTagNameNS(WORDPROCESSING_ML_NS, localName)).filter(
+    (node) => wordAttr(node, 'author') === author,
+  );
+}
+
+function visibleDocumentText(doc: Document): string {
+  return Array.from(doc.getElementsByTagNameNS(WORDPROCESSING_ML_NS, 't'))
+    .map((node) => node.textContent ?? '')
+    .join('');
+}
+
+async function saveCleanAndReadXml(
+  mgr: SessionManager,
+  inputPath: string,
+  outputPath: string,
+): Promise<{ result: Awaited<ReturnType<typeof save>>; xml: string; doc: Document }> {
+  const result = await save(mgr, {
+    file_path: inputPath,
+    save_to_local_path: outputPath,
+    save_format: 'clean',
+  });
+  assertSuccess(result, 'save');
+
+  const xml = await readDocumentXmlFromPath(outputPath);
+  return { result, xml, doc: parseXml(xml) };
+}
+
+describe('tracked AI revisions through MCP tools', () => {
+  registerCleanup();
+
+  test('replace_text emits insertion and deletion wrappers with the configured author', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    const opened = await given('a tracked session with one paragraph', () =>
+      openSession(['Alpha Beta'], { mgr: createManager() }),
+    );
+
+    const edited = await when('replace_text edits the paragraph', () =>
+      replaceText(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.firstParaId,
+        old_string: 'Alpha',
+        new_string: 'Gamma',
+        instruction: 'Replace Alpha with Gamma.',
+      }),
+    );
+    assertSuccess(edited, 'replace_text');
+
+    const saved = await then('the clean save contains AI-authored insertion and deletion markup', () =>
+      saveCleanAndReadXml(opened.mgr, opened.inputPath, path.join(opened.tmpDir, 'replace-text.docx')),
+    );
+
+    expect(findRevisionElements(saved.doc, 'ins', AI_AUTHOR)).toHaveLength(1);
+    expect(findRevisionElements(saved.doc, 'del', AI_AUTHOR)).toHaveLength(1);
+    expect(visibleDocumentText(saved.doc)).toContain('Gamma Beta');
+  });
+
+  test('insert_paragraph emits paragraph-mark and run-level insertions with the configured author', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    const opened = await given('a tracked session with an anchor paragraph', () =>
+      openSession(['Anchor paragraph.'], { mgr: createManager() }),
+    );
+
+    const inserted = await when('insert_paragraph adds a paragraph after the anchor', () =>
+      insertParagraph(opened.mgr, {
+        file_path: opened.inputPath,
+        positional_anchor_node_id: opened.firstParaId,
+        new_string: 'Inserted paragraph.',
+        instruction: 'Insert a paragraph after the anchor.',
+      }),
+    );
+    assertSuccess(inserted, 'insert_paragraph');
+
+    const saved = await then('the saved document preserves both insertion markers with the AI author', () =>
+      saveCleanAndReadXml(opened.mgr, opened.inputPath, path.join(opened.tmpDir, 'insert-paragraph.docx')),
+    );
+
+    const insertions = findRevisionElements(saved.doc, 'ins', AI_AUTHOR);
+    const paragraphMarkInsertion = insertions.find(
+      (element) => (element.parentNode as Element | null)?.localName === 'rPr',
+    );
+    const runLevelInsertion = insertions.find(
+      (element) => element.textContent?.includes('Inserted paragraph.') === true,
+    );
+
+    expect(paragraphMarkInsertion).toBeDefined();
+    expect(runLevelInsertion).toBeDefined();
+  });
+
+  test('format_layout emits pPrChange with the configured author', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    const opened = await given('a tracked session with a paragraph to reformat', () =>
+      openSession(['Spacing paragraph.'], { mgr: createManager() }),
+    );
+
+    const formatted = await when('format_layout applies paragraph spacing', () =>
+      formatLayout(opened.mgr, {
+        file_path: opened.inputPath,
+        paragraph_spacing: {
+          paragraph_ids: [opened.firstParaId],
+          before_twips: 240,
+        },
+      }),
+    );
+    assertSuccess(formatted, 'format_layout');
+
+    const saved = await then('the saved document contains a tracked paragraph property change', () =>
+      saveCleanAndReadXml(opened.mgr, opened.inputPath, path.join(opened.tmpDir, 'format-layout.docx')),
+    );
+
+    expect(findRevisionElements(saved.doc, 'pPrChange', AI_AUTHOR)).toHaveLength(1);
+  });
+
+  test('replace_text stays byte-compatible with untracked mode when aiAuthor is null', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    const opened = await given('an untracked session', () =>
+      openSession(['Alpha Beta'], { mgr: createManager(null) }),
+    );
+
+    const edited = await when('replace_text edits the paragraph', () =>
+      replaceText(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.firstParaId,
+        old_string: 'Alpha',
+        new_string: 'Gamma',
+        instruction: 'Replace Alpha with Gamma.',
+      }),
+    );
+    assertSuccess(edited, 'replace_text');
+
+    const saved = await then('the clean save contains no tracked insertion or deletion markup', () =>
+      saveCleanAndReadXml(opened.mgr, opened.inputPath, path.join(opened.tmpDir, 'untracked.docx')),
+    );
+
+    expect(saved.xml).not.toContain('<w:ins');
+    expect(saved.xml).not.toContain('<w:del');
+  });
+
+  test('new revision ids start after the highest pre-existing w:id in the document', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    const xml =
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+      `<w:document xmlns:w="${WORDPROCESSING_ML_NS}">` +
+      `<w:body>` +
+      `<w:p><w:r><w:t>Alpha Beta</w:t></w:r></w:p>` +
+      `<w:p><w:ins w:id="42" w:author="Existing" w:date="2026-01-01T00:00:00Z"><w:r><w:t>Prior revision</w:t></w:r></w:ins></w:p>` +
+      `</w:body></w:document>`;
+
+    const opened = await given('a tracked session whose source document already contains revision id 42', () =>
+      openSession([], { mgr: createManager(), xml }),
+    );
+
+    const edited = await when('replace_text emits a new tracked revision', () =>
+      replaceText(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.paraIds[0]!,
+        old_string: 'Alpha',
+        new_string: 'Gamma',
+        instruction: 'Replace Alpha with Gamma.',
+      }),
+    );
+    assertSuccess(edited, 'replace_text');
+
+    const saved = await then('the new AI-authored revision ids avoid the existing id range', () =>
+      saveCleanAndReadXml(opened.mgr, opened.inputPath, path.join(opened.tmpDir, 'collision.docx')),
+    );
+
+    const ids = [
+      ...findRevisionElements(saved.doc, 'ins', AI_AUTHOR),
+      ...findRevisionElements(saved.doc, 'del', AI_AUTHOR),
+    ]
+      .map((element) => Number.parseInt(wordAttr(element, 'id') ?? '', 10))
+      .filter((id) => Number.isFinite(id));
+
+    expect(ids.length).toBeGreaterThan(0);
+    expect(ids.every((id) => id >= 43)).toBe(true);
+  });
+
+  test('save reports AI-emitted revisions after multiple tracked MCP edits', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    const opened = await given('a tracked session with two paragraphs', () =>
+      openSession(['Alpha Beta', 'Spacing paragraph.'], { mgr: createManager() }),
+    );
+
+    const replaced = await when('replace_text edits the first paragraph', () =>
+      replaceText(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.paraIds[0]!,
+        old_string: 'Alpha',
+        new_string: 'Gamma',
+        instruction: 'Replace Alpha with Gamma.',
+      }),
+    );
+    assertSuccess(replaced, 'replace_text');
+
+    const inserted = await when('insert_paragraph adds a new paragraph', () =>
+      insertParagraph(opened.mgr, {
+        file_path: opened.inputPath,
+        positional_anchor_node_id: opened.paraIds[1]!,
+        new_string: 'Inserted paragraph.',
+        instruction: 'Insert a paragraph after the spacing paragraph.',
+      }),
+    );
+    assertSuccess(inserted, 'insert_paragraph');
+
+    const formatted = await when('format_layout applies spacing to the second paragraph', () =>
+      formatLayout(opened.mgr, {
+        file_path: opened.inputPath,
+        paragraph_spacing: {
+          paragraph_ids: [opened.paraIds[1]!],
+          before_twips: 240,
+        },
+      }),
+    );
+    assertSuccess(formatted, 'format_layout');
+
+    const saved = await then('save returns a revision summary for the emitted AI changes', () =>
+      saveCleanAndReadXml(opened.mgr, opened.inputPath, path.join(opened.tmpDir, 'summary.docx')),
+    );
+
+    const revisions = saved.result.revisions as { count: number; author: string; ids?: number[] } | undefined;
+    expect(revisions).toBeDefined();
+    expect(revisions?.author).toBe(AI_AUTHOR);
+    expect(revisions?.count).toBeGreaterThanOrEqual(5);
+    expect(Array.isArray(revisions?.ids)).toBe(true);
+    expect(revisions?.ids?.length).toBeGreaterThanOrEqual(5);
+    expect(saved.xml).toContain('w:pPrChange');
+  });
+});

--- a/packages/docx-mcp/src/tools/apply_plan.ts
+++ b/packages/docx-mcp/src/tools/apply_plan.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs/promises';
-import { findUniqueSubstringMatch } from '@usejunior/docx-core';
-import { SessionManager } from '../session/manager.js';
+import { findUniqueSubstringMatch, type RevisionContext } from '@usejunior/docx-core';
+import { SessionManager, getRevisionContextForSession } from '../session/manager.js';
 import { errorMessage } from '../error_utils.js';
 import { err, ok, type ToolResponse } from './types.js';
 import { enforceReadPathPolicy } from './path_policy.js';
@@ -277,6 +277,7 @@ async function executeSteps(
   manager: SessionManager,
   filePath: string,
   steps: NormalizedStep[],
+  ctx?: RevisionContext,
 ): Promise<{
   completed_step_ids: string[];
   failed_step_id?: string;
@@ -299,7 +300,7 @@ async function executeSteps(
         new_string: step.fields.new_string as string,
         instruction: step.fields.instruction as string,
         normalize_first: step.fields.normalize_first as boolean | undefined,
-      });
+      }, ctx);
     } else {
       result = await insertParagraph(manager, {
         file_path: filePath,
@@ -308,7 +309,7 @@ async function executeSteps(
         instruction: step.fields.instruction as string,
         position: step.fields.position as string | undefined,
         style_source_id: step.fields.style_source_id as string | undefined,
-      });
+      }, ctx);
     }
 
     if (!result.success) {
@@ -406,7 +407,8 @@ export async function applyPlan(
     const allWarnings = validations.flatMap((v) => v.warnings.map((w) => ({ step_id: v.step_id, warning: w })));
 
     // Apply phase — execute steps sequentially
-    const result = await executeSteps(manager, manager.normalizePath(session.originalPath), steps);
+    const ctx = getRevisionContextForSession(session);
+    const result = await executeSteps(manager, manager.normalizePath(session.originalPath), steps, ctx);
 
     if (result.failed_step_id !== undefined) {
       return {

--- a/packages/docx-mcp/src/tools/clear_formatting.ts
+++ b/packages/docx-mcp/src/tools/clear_formatting.ts
@@ -1,4 +1,4 @@
-import { SessionManager } from '../session/manager.js';
+import { SessionManager, getRevisionContextForSession } from '../session/manager.js';
 import { ok, err, type ToolResponse } from './types.js';
 import { resolveSessionForTool, mergeSessionResolutionMetadata } from './session_resolution.js';
 import {
@@ -47,6 +47,12 @@ function removeDirectChildrenByName(parent: Element, localNames: readonly string
   return matches.length > 0;
 }
 
+function invalidateDocumentCaches(doc: unknown): void {
+  const mutableDoc = doc as { dirty?: boolean; documentViewCache?: unknown };
+  mutableDoc.dirty = true;
+  mutableDoc.documentViewCache = null;
+}
+
 export async function clearFormatting(
   manager: SessionManager,
   params: {
@@ -65,6 +71,7 @@ export async function clearFormatting(
     const resolved = await resolveSessionForTool(manager, params, { toolName: 'clear_formatting' });
     if (!resolved.ok) return resolved.response;
     const { session, metadata } = resolved;
+    const revisionCtx = ctx ?? getRevisionContextForSession(session);
 
     const { nodes } = session.doc.buildDocumentView({ includeSemanticTags: false });
     const pids = params.paragraph_ids ?? nodes.map((n) => n.id);
@@ -81,8 +88,8 @@ export async function clearFormatting(
         const rPr = r.getElementsByTagNameNS(OOXML.W_NS, W.rPr).item(0);
         if (!rPr) continue;
 
-        const oldRPrClone = ctx ? (rPr.cloneNode(true) as Element) : null;
-        const removeRunProps = ctx ? removeDirectChildrenByName : removeDescendantsByName;
+        const oldRPrClone = revisionCtx ? (rPr.cloneNode(true) as Element) : null;
+        const removeRunProps = revisionCtx ? removeDirectChildrenByName : removeDescendantsByName;
         let rModified = false;
 
         if (params.clear_highlight && removeRunProps(rPr, [W.highlight])) {
@@ -109,11 +116,11 @@ export async function clearFormatting(
           rModified = true;
         }
 
-        if (ctx && rModified) {
+        if (revisionCtx && rModified) {
           for (const stale of getDirectChildrenByName(rPr, 'rPrChange')) {
             rPr.removeChild(stale);
           }
-          rPr.appendChild(buildRPrChangeElement(oldRPrClone, ctx));
+          rPr.appendChild(buildRPrChangeElement(oldRPrClone, revisionCtx));
         }
 
         if (rModified) {
@@ -124,6 +131,7 @@ export async function clearFormatting(
     }
 
     if (modifiedCount > 0) {
+      invalidateDocumentCaches(session.doc);
       manager.markEdited(session);
     }
 

--- a/packages/docx-mcp/src/tools/delete_comment.ts
+++ b/packages/docx-mcp/src/tools/delete_comment.ts
@@ -1,4 +1,4 @@
-import { SessionManager } from '../session/manager.js';
+import { SessionManager, getRevisionContextForSession } from '../session/manager.js';
 import { errorCode, errorMessage } from "../error_utils.js";
 import { resolveSessionForTool, mergeSessionResolutionMetadata } from './session_resolution.js';
 import { ok, err, type ToolResponse } from './types.js';
@@ -13,13 +13,14 @@ export async function deleteComment(
   const resolved = await resolveSessionForTool(manager, params, { toolName: 'delete_comment' });
   if (!resolved.ok) return resolved.response;
   const { session, metadata } = resolved;
+  const ctx = getRevisionContextForSession(session);
 
   if (params.comment_id == null) {
     return err('MISSING_PARAMETER', 'comment_id is required.', 'Provide the comment ID to delete.');
   }
 
   try {
-    await session.doc.deleteComment({ commentId: params.comment_id });
+    await session.doc.deleteComment({ commentId: params.comment_id }, ctx);
 
     manager.markEdited(session);
     return ok(mergeSessionResolutionMetadata({

--- a/packages/docx-mcp/src/tools/delete_footnote.ts
+++ b/packages/docx-mcp/src/tools/delete_footnote.ts
@@ -1,4 +1,4 @@
-import { SessionManager } from '../session/manager.js';
+import { SessionManager, getRevisionContextForSession } from '../session/manager.js';
 import { errorCode, errorMessage } from "../error_utils.js";
 import { resolveSessionForTool, mergeSessionResolutionMetadata } from './session_resolution.js';
 import { ok, err, type ToolResponse } from './types.js';
@@ -13,13 +13,14 @@ export async function deleteFootnote(
   const resolved = await resolveSessionForTool(manager, params, { toolName: 'delete_footnote' });
   if (!resolved.ok) return resolved.response;
   const { session, metadata } = resolved;
+  const ctx = getRevisionContextForSession(session);
 
   if (params.note_id == null) {
     return err('MISSING_PARAMETER', 'note_id is required.', 'Provide the footnote ID to delete.');
   }
 
   try {
-    await session.doc.deleteFootnote({ noteId: params.note_id });
+    await session.doc.deleteFootnote({ noteId: params.note_id }, ctx);
 
     manager.markEdited(session);
     return ok(mergeSessionResolutionMetadata({

--- a/packages/docx-mcp/src/tools/format_layout.ts
+++ b/packages/docx-mcp/src/tools/format_layout.ts
@@ -1,4 +1,4 @@
-import { SessionManager } from '../session/manager.js';
+import { SessionManager, getRevisionContextForSession } from '../session/manager.js';
 import { errorCode, errorMessage } from "../error_utils.js";
 import { err, ok, type ToolResponse } from './types.js';
 import { mergeSessionResolutionMetadata, resolveSessionForTool } from './session_resolution.js';
@@ -255,6 +255,7 @@ export async function formatLayout(
     const resolved = await resolveSessionForTool(manager, params, { toolName: 'format_layout' });
     if (!resolved.ok) return resolved.response;
     const { session, metadata } = resolved;
+    const ctx = getRevisionContextForSession(session);
 
     const strict = params.strict ?? true;
     if (typeof strict !== 'boolean') {
@@ -354,9 +355,9 @@ export async function formatLayout(
     const paragraphCountBefore = session.doc.getParagraphs().length;
     const warnings: string[] = [];
 
-    const paragraphSpacingResult = paragraphSpacing ? session.doc.setParagraphSpacing(paragraphSpacing) : null;
-    const rowHeightResult = rowHeight ? session.doc.setTableRowHeight(rowHeight) : null;
-    const cellPaddingResult = cellPadding ? session.doc.setTableCellPadding(cellPadding) : null;
+    const paragraphSpacingResult = paragraphSpacing ? session.doc.setParagraphSpacing(paragraphSpacing, ctx) : null;
+    const rowHeightResult = rowHeight ? session.doc.setTableRowHeight(rowHeight, ctx) : null;
+    const cellPaddingResult = cellPadding ? session.doc.setTableCellPadding(cellPadding, ctx) : null;
 
     const paragraphCountAfter = session.doc.getParagraphs().length;
     if (paragraphCountAfter !== paragraphCountBefore) {

--- a/packages/docx-mcp/src/tools/insert_paragraph.ts
+++ b/packages/docx-mcp/src/tools/insert_paragraph.ts
@@ -1,11 +1,12 @@
 import {
   getParagraphRuns,
   hasHyperlinkTags,
+  type RevisionContext,
   stripHyperlinkTags,
   stripAllInlineTags,
   type ReplacementPart,
 } from '@usejunior/docx-core';
-import { SessionManager, type DocxSession } from '../session/manager.js';
+import { SessionManager, getRevisionContextForSession, type DocxSession } from '../session/manager.js';
 import { errorMessage } from "../error_utils.js";
 import { err, ok, type ToolResponse } from './types.js';
 import { RESULT_PREVIEW_CHARS, previewText } from './preview.js';
@@ -120,11 +121,13 @@ export async function insertParagraph(
     style_source_id?: string;
     target_style?: string;
   },
+  ctx?: RevisionContext,
 ): Promise<ToolResponse> {
   try {
     const resolved = await resolveSessionForTool(manager, params, { toolName: 'insert_paragraph' });
     if (!resolved.ok) return resolved.response;
     const { session, metadata } = resolved;
+    const revisionCtx = ctx ?? getRevisionContextForSession(session);
 
     const positionUpper = (params.position ?? 'AFTER').toUpperCase();
     if (positionUpper !== 'BEFORE' && positionUpper !== 'AFTER') {
@@ -173,7 +176,7 @@ export async function insertParagraph(
       relativePosition: positionUpper as 'BEFORE' | 'AFTER',
       newText: plainParagraphs.join('\n\n'),
       styleSourceId: styleSourceId,
-    });
+    }, revisionCtx);
 
     const needsHeaderRoleModel = parsedParagraphs.some((segs) => segs.some((s) => s.header));
     const headerAddProps = needsHeaderRoleModel

--- a/packages/docx-mcp/src/tools/replace_text.ts
+++ b/packages/docx-mcp/src/tools/replace_text.ts
@@ -1,4 +1,4 @@
-import { SessionManager, type DocxSession } from '../session/manager.js';
+import { SessionManager, getRevisionContextForSession, type DocxSession } from '../session/manager.js';
 import { errorMessage } from "../error_utils.js";
 import { err, ok, type ToolResponse } from './types.js';
 import { ERROR_PREVIEW_CHARS, RESULT_PREVIEW_CHARS, previewText } from './preview.js';
@@ -11,9 +11,11 @@ import {
   getParagraphRuns,
   hasHighlightTags,
   hasHyperlinkTags,
+  replaceParagraphTextRange,
   stripHyperlinkTags,
   stripAllInlineTags,
   type ReplacementPart,
+  type RevisionContext,
 } from '@usejunior/docx-core';
 import {
   splitTaggedText,
@@ -141,6 +143,12 @@ function isLikelyFieldPlaceholder(text: string): boolean {
   return (t.startsWith('[') && t.endsWith(']')) || (t.startsWith('«') && t.endsWith('»'));
 }
 
+function invalidateDocumentCaches(doc: unknown): void {
+  const mutableDoc = doc as { dirty?: boolean; documentViewCache?: unknown };
+  mutableDoc.dirty = true;
+  mutableDoc.documentViewCache = null;
+}
+
 export async function replaceText(
   manager: SessionManager,
   params: {
@@ -160,11 +168,13 @@ export async function replaceText(
     font_name?: string;
     color?: string;
   },
+  ctx?: RevisionContext,
 ): Promise<ToolResponse> {
   try {
     const resolved = await resolveSessionForTool(manager, params, { toolName: 'replace_text' });
     if (!resolved.ok) return resolved.response;
     const { session, metadata } = resolved;
+    const revisionCtx = ctx ?? getRevisionContextForSession(session);
 
     if (params.normalize_first) {
       session.doc.mergeRunsOnly();
@@ -233,7 +243,12 @@ export async function replaceText(
         parts.push({ text: s.text, templateRun: contextTemplateRun ?? undefined, addRunProps: segAddProps, clearHighlight });
       }
       replaceText = parts;
-      session.doc.replaceText({ targetParagraphId: pid, findText: matchedOldStr, replaceText });
+      if (revisionCtx) {
+        replaceParagraphTextRange(pEl, matchStart, matchEnd, replaceText, revisionCtx);
+        invalidateDocumentCaches(session.doc);
+      } else {
+        session.doc.replaceText({ targetParagraphId: pid, findText: matchedOldStr, replaceText });
+      }
     } else {
       // Fix 2: Transfer document quote style to new_string for non-exact matches.
       if (textMatch.mode !== 'exact' && textMatch.mode !== 'clean') {
@@ -260,7 +275,12 @@ export async function replaceText(
           trimmedReplace = trimmedNewStr;
         }
 
-        session.doc.replaceTextAtRange({ targetParagraphId: pid, start: trimmedStart, end: trimmedEnd, replaceText: trimmedReplace });
+        if (revisionCtx) {
+          replaceParagraphTextRange(pEl, trimmedStart, trimmedEnd, trimmedReplace, revisionCtx);
+          invalidateDocumentCaches(session.doc);
+        } else {
+          session.doc.replaceTextAtRange({ targetParagraphId: pid, start: trimmedStart, end: trimmedEnd, replaceText: trimmedReplace });
+        }
         // Range trimming splits the original run at prefix/suffix boundaries, producing
         // adjacent runs with identical formatting. Merge them back to keep output clean.
         session.doc.mergeRunsOnly();

--- a/packages/docx-mcp/src/tools/save.ts
+++ b/packages/docx-mcp/src/tools/save.ts
@@ -3,12 +3,16 @@ import { errorCode, errorMessage } from "../error_utils.js";
 import fs from 'node:fs/promises';
 import { SessionManager } from '../session/manager.js';
 import { err, ok, type ToolResponse } from './types.js';
-import { compareDocuments, type CompareOptions, type CompareResult } from '@usejunior/docx-core';
+import { DocxZip, compareDocuments, parseXml, type CompareOptions, type CompareResult } from '@usejunior/docx-core';
 import { mergeSessionResolutionMetadata, resolveSessionForTool } from './session_resolution.js';
 import { enforceWritePathPolicy } from './path_policy.js';
 import { DEFAULT_RECONSTRUCTION_MODE } from './comparison_defaults.js';
 
 type SaveFormat = 'clean' | 'tracked' | 'both';
+type SaveRevisionSummary = { count: number; author: string; ids?: number[] };
+
+const WORDPROCESSING_ML_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const REVISION_ELEMENT_NAMES = new Set(['ins', 'del', 'pPrChange', 'rPrChange', 'trPrChange', 'tcPrChange']);
 
 function expandPath(inputPath: string): string {
   return inputPath.startsWith('~') ? path.join(process.env.HOME || '', inputPath.slice(1)) : inputPath;
@@ -44,6 +48,56 @@ async function runWithoutConsoleLog<T>(fn: () => Promise<T>): Promise<T> {
   } finally {
     console.log = originalLog;
   }
+}
+
+function getWordAttr(element: Element, localName: string): string | null {
+  return (
+    element.getAttributeNS(WORDPROCESSING_ML_NS, localName)
+    ?? element.getAttribute(`w:${localName}`)
+    ?? element.getAttribute(localName)
+  );
+}
+
+async function collectAiRevisionSummary(
+  buffer: Buffer,
+  author: string | null,
+): Promise<SaveRevisionSummary | undefined> {
+  if (!author) return undefined;
+
+  const zip = await DocxZip.load(buffer);
+  const revisionIds = new Set<number>();
+  let count = 0;
+
+  for (const fileName of zip.listFiles()) {
+    if (!fileName.startsWith('word/') || !fileName.endsWith('.xml')) continue;
+    const xml = await zip.readTextOrNull(fileName);
+    if (!xml) continue;
+
+    const doc = parseXml(xml);
+    for (const node of Array.from(doc.getElementsByTagName('*'))) {
+      if (node.namespaceURI !== WORDPROCESSING_ML_NS || !REVISION_ELEMENT_NAMES.has(node.localName)) {
+        continue;
+      }
+      if (getWordAttr(node, 'author') !== author) continue;
+
+      count += 1;
+      const id = getWordAttr(node, 'id');
+      if (!id) continue;
+
+      const parsed = Number.parseInt(id, 10);
+      if (Number.isFinite(parsed)) {
+        revisionIds.add(parsed);
+      }
+    }
+  }
+
+  if (count === 0) return undefined;
+
+  return {
+    count,
+    author,
+    ...(revisionIds.size > 0 ? { ids: [...revisionIds].sort((a, b) => a - b) } : {}),
+  };
 }
 
 export async function save(
@@ -110,7 +164,7 @@ export async function save(
     const trackedEngine: CompareOptions['engine'] = engine;
 
     const clean = params.clean_bookmarks ?? true;
-    const author = params.tracked_changes_author ?? params.author ?? 'Safe-Docx';
+    const author = params.tracked_changes_author ?? params.author ?? 'SafeDocX';
     const allowOverwrite = params.allow_overwrite ?? false;
     const cacheKey = JSON.stringify({
       revision: session.editRevision,
@@ -243,6 +297,10 @@ export async function save(
       await fs.writeFile(trackedPath, new Uint8Array(trackedBuffer));
     }
 
+    const revisions = format === 'tracked'
+      ? undefined
+      : await collectAiRevisionSummary(revisedBuffer, session.aiAuthor);
+
     const returnedVariants =
       format === 'clean'
         ? ['clean']
@@ -270,6 +328,7 @@ export async function save(
       tracked_rebuild_warning: trackedReconstructionMode === 'rebuild'
         ? 'Rebuild mode was used which may alter document structure (tables, fonts, etc.)'
         : undefined,
+      revisions,
       exported_at_utc: exportTimestamp,
       bookmarks_removed: clean ? bookmarksRemoved : 0,
       returned_variants: returnedVariants,

--- a/packages/docx-mcp/src/tools/update_footnote.ts
+++ b/packages/docx-mcp/src/tools/update_footnote.ts
@@ -1,4 +1,4 @@
-import { SessionManager } from '../session/manager.js';
+import { SessionManager, getRevisionContextForSession } from '../session/manager.js';
 import { errorCode, errorMessage } from "../error_utils.js";
 import { resolveSessionForTool, mergeSessionResolutionMetadata } from './session_resolution.js';
 import { ok, err, type ToolResponse } from './types.js';
@@ -14,6 +14,7 @@ export async function updateFootnote(
   const resolved = await resolveSessionForTool(manager, params, { toolName: 'update_footnote' });
   if (!resolved.ok) return resolved.response;
   const { session, metadata } = resolved;
+  const ctx = getRevisionContextForSession(session);
 
   if (params.note_id == null) {
     return err('MISSING_PARAMETER', 'note_id is required.', 'Provide the footnote ID to update.');
@@ -32,7 +33,7 @@ export async function updateFootnote(
     await session.doc.updateFootnoteText({
       noteId: params.note_id,
       newText: params.new_text,
-    });
+    }, ctx);
 
     manager.markEdited(session);
     return ok(mergeSessionResolutionMetadata({


### PR DESCRIPTION
## Summary

**Integration PR for #120.** Threads `RevisionContext` from session config through every Table A MCP tool, replacing the hardcoded `"Comparison"` default with `"SafeDocX"`, and lighting up tracked emission end-to-end through the MCP entry path. Largest of the per-PR scopes (15 files, ~524 insertions).

After this lands, AI revisions flow end-to-end through the MCP layer with `<w:author="SafeDocX">` attribution on every emitted revision element.

## What changed

### Session model

| Field | Purpose |
|---|---|
| `aiAuthor: string \| null` | Session's configured AI author. `null` = untracked legacy mode. |
| `revisionIdState: RevisionIdState \| null` | Shared monotonic ID counter across all edits in the session. Lazily seeded above max pre-existing `w:id`. |

### New helpers

- `getRevisionContextForSession(session)` — returns a fresh `RevisionContext` with current Date, or `undefined` if aiAuthor is null.
- `inferStartingRevisionIdState(...docs)` — scans for max `w:id` and returns a state starting at `max+1`. Variadic so future side-part scanning is a 1-line update.

### Production server wiring

`server.ts` now constructs `SessionManager` with `defaultAiAuthor` sourced from `SAFE_DOCX_AI_AUTHOR` env var, defaulting to `'SafeDocX'`. Setting the env var to empty string explicitly disables tracked emission.

**This is the critical fix from peer review** — without it, the entire tracked-emission chain (#136–#141) would have shipped to production with `aiAuthor: null` and never invoked the ctx-aware paths.

### MCP tool dispatcher

All 10 Table A MCP tools now forward ctx to the underlying primitive:

`replace_text`, `insert_paragraph`, `apply_plan`, `add_comment`, `delete_comment`, `add_footnote`, `update_footnote`, `delete_footnote`, `format_layout`, `clear_formatting`.

`apply_plan` constructs ctx **once per call** so all delegated steps share the same `idState` (no ID gaps within a batch).

### Save report

`save.ts` response gains a `revisions: { count, author, ids }` field when AI revisions are detected. The detector walks every `word/*.xml` part — catches revisions in `document.xml` AND side parts (`footnotes.xml`, `comments.xml`). Default save author renamed from `'Safe-Docx'` to `'SafeDocX'` for consistency.

## Peer review

| Reviewer | Severity | Finding | Resolution |
|---|---|---|---|
| Codex | **Critical** | Production MCP server doesn't pass `defaultAiAuthor` — tracked-emission chain was dark in real usage; tests masked the bug by injecting `SessionManager` directly with `defaultAiAuthor` set | **Fixed** — server.ts wires from `SAFE_DOCX_AI_AUTHOR` env var, defaults to `'SafeDocX'` |
| Codex + Gemini | Normal | `inferStartingRevisionIdState` scans only `document.xml`, missing side-part revision IDs; could collide on long-running sessions on heavily-reviewed docs | **Documented in JSDoc** + filed as **#171** for follow-up. Helper made variadic to ease future fix. |
| Gemini | Normal | Save report re-parses every `word/*.xml` for the revisions count | Acceptable for typical docs; could be optimized in a follow-up |
| Gemini | Minor | `'Safe-Docx'` → `'SafeDocX'` rename impact on stale tests | Codex confirmed no stale references in functional save-path tests |
| Codex | Normal | Tests are tool-integration coverage, not MCP-dispatch end-to-end | Acceptable; future MCP-dispatch tests can be added in #143 regression suite |
| Gemini | Minor | Redundant local `invalidateDocumentCaches` in two tools | Deferred (minor refactor) |

## Tests

8 new BDD tests in `ai_revision_context.test.ts` + `manager.test.ts`:

1. Seeds aiAuthor from the manager default and leaves revisionIdState unset
2. Initializes revision IDs above the highest pre-existing w:id value
3. `replace_text` emits insertion and deletion wrappers with the configured author
4. `insert_paragraph` emits paragraph-mark and run-level insertions with the configured author
5. `format_layout` emits pPrChange with the configured author
6. `replace_text` stays byte-compatible with untracked mode when aiAuthor is null
7. New revision ids start after the highest pre-existing w:id in the document
8. `save` reports AI-emitted revisions after multiple tracked MCP edits

## Verification

```bash
npm run build -w @usejunior/docx-mcp   # clean
npm run lint -w @usejunior/docx-mcp    # clean (1 pre-existing warning)
npm run test:run -w @usejunior/docx-mcp
# Test Files  70 passed (70)
# Tests  710 passed (710)
```

## Known limitations (filed as follow-ups)

- **#171** — `inferStartingRevisionIdState` should scan side parts (comments.xml, footnotes.xml) to fully avoid ID collisions
- **#165** — `accept_changes` should process side-part revisions, not just `document.xml`

## What's not in this PR

- Per-session client-controlled aiAuthor (e.g., via an `open_document` parameter or a new `configure_session` MCP tool). Today the author comes from the env-var default; future work can extend this.

## Closes

- #142 ([120.7] of #120)