### PR TITLE
fix(docx-core): harden heading detection (#157 Phase 1)

### DIFF
--- a/packages/docx-core/src/primitives/document_view.ts
+++ b/packages/docx-core/src/primitives/document_view.ts
@@ -219,7 +219,10 @@ function extractHeaderInfo(cleanText: string): { header_text: string | null; hea
 
   if (terminator === '.') return { header_text: headerText, header_style: 'title_with_period' };
   if (terminator === ':') return { header_text: headerText, header_style: 'title_with_colon' };
-  return { header_text: headerText, header_style: 'title_bare' };
+  // Long-paragraph regex matches without an explicit terminator are body prose
+  // (e.g. "Termination of Section 2.2(d)(i) shall not affect ..."), not headers.
+  // Bare titles only fire from the short-paragraph branch above.
+  return { header_text: null, header_style: null };
 }
 
 function detectRunInHeader(params: {
@@ -243,6 +246,16 @@ function detectRunInHeader(params: {
       seen.add(tr.r);
       orderedUniqueRuns.push(tr.r);
     }
+  }
+
+  // Compute total visible character count across all runs first so we can
+  // verify the header is a true prefix, not the whole paragraph (signature
+  // labels, defined-term lead-ins, and table-header cells are often entirely
+  // bold/underlined and would otherwise be mis-classified as run-in headers).
+  let totalVisibleChars = 0;
+  for (const r of orderedUniqueRuns) {
+    const ts = Array.from(r.getElementsByTagNameNS(OOXML.W_NS, W.t));
+    for (const t of ts) totalVisibleChars += (t.textContent ?? '').length;
   }
 
   let headerText = '';
@@ -269,8 +282,72 @@ function detectRunInHeader(params: {
   if (!trimmed) return null;
   if (!punct.has(trimmed[trimmed.length - 1]!)) return null;
   if (!formatting) return null;
+  // Require a real header-prefix / body transition: the bold/underline prefix
+  // must be followed by non-header body text. Without this guard, fully bold
+  // paragraphs (e.g. "Email:", "Title:", or all-bold defined-term sentences)
+  // surface as run-in headers.
+  if (headerCharCount >= totalVisibleChars) return null;
 
   return { raw_text: trimmed, formatting, headerCharCount };
+}
+
+/**
+ * Detect a centered, ALL-CAPS, bold standalone title (e.g. an NVCA SPA's
+ * `SERIES […] PREFERRED STOCK PURCHASE AGREEMENT` title).
+ *
+ * Strict gates only — this fires only when the other detectors returned null
+ * and the paragraph cannot be confused with body prose:
+ *   - paragraph alignment is CENTER
+ *   - clean text contains no lowercase letters
+ *   - clean text is non-empty and short (≤ MAX_HEADER_TEXT_LENGTH)
+ *   - all visible runs are bold (a single non-bold char disqualifies)
+ */
+function detectTitleCapsCentered(params: {
+  paragraph: Element;
+  paragraphPPr: Element | null;
+  paragraphStyleId: string | null;
+  alignment: ParagraphAlignment;
+  cleanTextNoLabel: string;
+  styles: StylesModel;
+}): { raw_text: string; formatting: HeaderFormatting } | null {
+  const { paragraph, paragraphPPr, paragraphStyleId, alignment, cleanTextNoLabel, styles } = params;
+  if (alignment !== 'CENTER') return null;
+  const trimmed = cleanTextNoLabel.trim();
+  if (!trimmed) return null;
+  if (trimmed.length > MAX_HEADER_TEXT_LENGTH) return null;
+  if (/[a-z]/.test(trimmed)) return null;
+
+  const runs = getParagraphRuns(paragraph);
+  if (runs.length === 0) return null;
+  const orderedUniqueRuns: Element[] = [];
+  const seen = new Set<Element>();
+  for (const tr of runs) {
+    if (!seen.has(tr.r)) {
+      seen.add(tr.r);
+      orderedUniqueRuns.push(tr.r);
+    }
+  }
+
+  let formatting: HeaderFormatting | null = null;
+  let sawAnyText = false;
+  for (const r of orderedUniqueRuns) {
+    const ts = Array.from(r.getElementsByTagNameNS(OOXML.W_NS, W.t));
+    let runHasText = false;
+    for (const t of ts) {
+      if ((t.textContent ?? '').length > 0) {
+        runHasText = true;
+        break;
+      }
+    }
+    if (!runHasText) continue;
+    const fmt = extractEffectiveRunFormatting({ run: r, paragraphPPr, paragraphStyleId, styles });
+    if (!fmt.bold) return null;
+    sawAnyText = true;
+    if (!formatting) formatting = { bold: fmt.bold, italic: fmt.italic, underline: fmt.underline };
+  }
+  if (!sawAnyText || !formatting) return null;
+
+  return { raw_text: trimmed, formatting };
 }
 
 function inferSemanticName(params: {
@@ -1175,6 +1252,30 @@ export function buildNodesForDocumentView(params: {
       const fallback = extractHeaderInfo(cleanTextNoLabel);
       headerText = fallback.header_text;
       headerStyle = fallback.header_style;
+    }
+
+    // Final fallback: centered ALL-CAPS bold standalone titles (e.g. an NVCA
+    // SPA's `SERIES […] PREFERRED STOCK PURCHASE AGREEMENT`). Only fires when
+    // the previous detectors returned null AND the paragraph has no list label
+    // AND it is not in a table cell.
+    if (!headerText && !labelString && !tableContext) {
+      try {
+        const titleHdr = detectTitleCapsCentered({
+          paragraph: p,
+          paragraphPPr: paraPPr ?? null,
+          paragraphStyleId: paraFmt.styleId,
+          alignment: paraFmt.alignment,
+          cleanTextNoLabel,
+          styles: stylesModel,
+        });
+        if (titleHdr) {
+          headerText = titleHdr.raw_text;
+          headerStyle = 'title_caps_centered';
+          headerFormatting = titleHdr.formatting;
+        }
+      } catch {
+        // ignore
+      }
     }
 
     // ── Tag emission ──

--- a/packages/docx-core/src/primitives/document_view.ts
+++ b/packages/docx-core/src/primitives/document_view.ts
@@ -10,6 +10,12 @@ import { isReservedFootnote } from './footnotes.js';
 
 const SHORT_HEADER_MAX_LENGTH = 50;
 const MAX_HEADER_TEXT_LENGTH = 60;
+// Centered ALL-CAPS titles (e.g. NVCA COI's `AMENDED AND RESTATED CERTIFICATE
+// OF INCORPORATION OF FOO INC.`) routinely exceed 60 chars in real corporate
+// documents. The 60-char cap on `extractHeaderInfo` exists to avoid emitting a
+// "leading words = header" guess from long body prose, which doesn't apply to
+// the standalone-title detector.
+const MAX_CENTERED_TITLE_LENGTH = 120;
 const STYLE_EXAMPLE_TEXT_PREVIEW_LENGTH = 50;
 
 function getWAttr(el: Element, localName: string): string | null {
@@ -248,45 +254,43 @@ function detectRunInHeader(params: {
     }
   }
 
-  // Compute total visible character count across all runs first so we can
-  // verify the header is a true prefix, not the whole paragraph (signature
-  // labels, defined-term lead-ins, and table-header cells are often entirely
-  // bold/underlined and would otherwise be mis-classified as run-in headers).
-  let totalVisibleChars = 0;
-  for (const r of orderedUniqueRuns) {
-    const ts = Array.from(r.getElementsByTagNameNS(OOXML.W_NS, W.t));
-    for (const t of ts) totalVisibleChars += (t.textContent ?? '').length;
-  }
-
+  // Walk runs once, splitting into bold/underline header-prefix text and
+  // everything-after body text. The header → body transition is what
+  // distinguishes a run-in header (bold prefix + body) from a fully-bold
+  // signature label or defined-term lead-in.
   let headerText = '';
+  let bodyText = '';
   let formatting: HeaderFormatting | null = null;
   let headerCharCount = 0;
+  let inHeader = true;
 
   for (const r of orderedUniqueRuns) {
     const fmt = extractEffectiveRunFormatting({ run: r, paragraphPPr, paragraphStyleId, styles });
     const isHeaderStyle = fmt.bold || fmt.underline;
-    if (!isHeaderStyle) break;
-
-    // Accumulate run text.
     const ts = Array.from(r.getElementsByTagNameNS(OOXML.W_NS, W.t));
-    for (const t of ts) {
-      const tc = t.textContent ?? '';
-      headerText += tc;
-      headerCharCount += tc.length;
-    }
+    let runText = '';
+    for (const t of ts) runText += t.textContent ?? '';
 
-    if (!formatting) formatting = { bold: fmt.bold, italic: fmt.italic, underline: fmt.underline };
+    if (inHeader && isHeaderStyle) {
+      headerText += runText;
+      headerCharCount += runText.length;
+      if (!formatting) formatting = { bold: fmt.bold, italic: fmt.italic, underline: fmt.underline };
+    } else {
+      inHeader = false;
+      bodyText += runText;
+    }
   }
 
   const trimmed = headerText.trim();
   if (!trimmed) return null;
   if (!punct.has(trimmed[trimmed.length - 1]!)) return null;
   if (!formatting) return null;
-  // Require a real header-prefix / body transition: the bold/underline prefix
-  // must be followed by non-header body text. Without this guard, fully bold
-  // paragraphs (e.g. "Email:", "Title:", or all-bold defined-term sentences)
-  // surface as run-in headers.
-  if (headerCharCount >= totalVisibleChars) return null;
+  // Require a real header-prefix → body transition: there must be non-whitespace
+  // body text after the bold/underline prefix. Trailing-whitespace-only "body"
+  // (e.g. a single bold run followed by a non-bold run that holds just `" "`)
+  // is not a transition — those are still whole-paragraph bold blocks
+  // (signature labels, all-bold short titles, etc.) and must be rejected.
+  if (!bodyText.trim()) return null;
 
   return { raw_text: trimmed, formatting, headerCharCount };
 }
@@ -295,11 +299,14 @@ function detectRunInHeader(params: {
  * Detect a centered, ALL-CAPS, bold standalone title (e.g. an NVCA SPA's
  * `SERIES […] PREFERRED STOCK PURCHASE AGREEMENT` title).
  *
- * Strict gates only — this fires only when the other detectors returned null
- * and the paragraph cannot be confused with body prose:
+ * Strict gates only — fires only when the paragraph cannot be confused with
+ * body prose, a placeholder, or a signature line:
  *   - paragraph alignment is CENTER
  *   - clean text contains no lowercase letters
- *   - clean text is non-empty and short (≤ MAX_HEADER_TEXT_LENGTH)
+ *   - clean text contains ≥ 3 ASCII letters AND ≥ 2 whitespace-separated
+ *     word-tokens (so single-token bracketed placeholders like `[COMPANY]`
+ *     and underscore-only signature lines like `____________` are rejected)
+ *   - clean text is non-empty and ≤ MAX_CENTERED_TITLE_LENGTH
  *   - all visible runs are bold (a single non-bold char disqualifies)
  */
 function detectTitleCapsCentered(params: {
@@ -314,8 +321,15 @@ function detectTitleCapsCentered(params: {
   if (alignment !== 'CENTER') return null;
   const trimmed = cleanTextNoLabel.trim();
   if (!trimmed) return null;
-  if (trimmed.length > MAX_HEADER_TEXT_LENGTH) return null;
+  if (trimmed.length > MAX_CENTERED_TITLE_LENGTH) return null;
   if (/[a-z]/.test(trimmed)) return null;
+  // Content gate: punctuation/underscore-only signature lines and bracketed
+  // single-token placeholders (`[COMPANY]`, `[___]`, `<NAME>`) must not
+  // classify as titles. Real titles are multi-word ALL-CAPS phrases.
+  const letterCount = (trimmed.match(/[A-Z]/g) ?? []).length;
+  if (letterCount < 3) return null;
+  const wordTokens = trimmed.split(/\s+/).filter((w) => /[A-Z]/.test(w));
+  if (wordTokens.length < 2) return null;
 
   const runs = getParagraphRuns(paragraph);
   if (runs.length === 0) return null;
@@ -1248,16 +1262,13 @@ export function buildNodesForDocumentView(params: {
       // ignore
     }
 
-    if (!headerText) {
-      const fallback = extractHeaderInfo(cleanTextNoLabel);
-      headerText = fallback.header_text;
-      headerStyle = fallback.header_style;
-    }
-
-    // Final fallback: centered ALL-CAPS bold standalone titles (e.g. an NVCA
-    // SPA's `SERIES […] PREFERRED STOCK PURCHASE AGREEMENT`). Only fires when
-    // the previous detectors returned null AND the paragraph has no list label
-    // AND it is not in a table cell.
+    // Centered ALL-CAPS bold standalone titles (e.g. an NVCA SPA's
+    // `SERIES […] PREFERRED STOCK PURCHASE AGREEMENT`). Runs before
+    // extractHeaderInfo so the documented precedence (title_caps_centered
+    // outranks short standalone title_bare/title_with_period/title_with_colon)
+    // matches the implementation. Only fires when run_in_header did not match
+    // AND the paragraph has no list label AND is not in a table cell. The
+    // try/catch is defensive against malformed XML in user documents.
     if (!headerText && !labelString && !tableContext) {
       try {
         const titleHdr = detectTitleCapsCentered({
@@ -1274,8 +1285,14 @@ export function buildNodesForDocumentView(params: {
           headerFormatting = titleHdr.formatting;
         }
       } catch {
-        // ignore
+        // ignore: malformed run/style data falls through to extractHeaderInfo.
       }
+    }
+
+    if (!headerText) {
+      const fallback = extractHeaderInfo(cleanTextNoLabel);
+      headerText = fallback.header_text;
+      headerStyle = fallback.header_style;
     }
 
     // ── Tag emission ──

--- a/packages/docx-core/test-primitives/document_view.branch.test.ts
+++ b/packages/docx-core/test-primitives/document_view.branch.test.ts
@@ -379,4 +379,164 @@ describe('document_view branch coverage', () => {
       expect(toon).toContain('Hello');
     });
   });
+
+  test('long-paragraph regex no longer truncates body prose into a bare-title header (#157)', async ({ given, when, then, and }: AllureBddContext) => {
+    let bodyXml: string;
+    let nodes: ReturnType<typeof buildNodesForDocumentView>['nodes'];
+
+    await given('paragraphs that begin with a capitalized word followed by body prose', async () => {
+      // Real false positives observed against tests/test_documents/nvca-regression/source.docx.
+      const termination = 'Termination of Section 2.2(d)(i) shall not affect any other provision of this Agreement.';
+      const exceptAs = 'Except as described in Section 2.2(d)(i), the Company has no obligation to repurchase the shares.';
+      bodyXml =
+        `<w:p><w:r><w:t>${termination}</w:t></w:r></w:p>` +
+        `<w:p><w:r><w:t>${exceptAs}</w:t></w:r></w:p>`;
+    });
+
+    await when('buildNodesForDocumentView is called', async () => {
+      ({ nodes } = buildNodesForDocumentView({
+        paragraphs: makeParagraphs(bodyXml!),
+        stylesXml: null,
+        numberingXml: null,
+        include_semantic_tags: false,
+        show_formatting: false,
+      }));
+    });
+
+    await then('"Termination of Section ..." is not classified as a header', async () => {
+      expect(nodes).toHaveLength(2);
+      expect(nodes[0]!.list_metadata.header_text).toBeNull();
+      expect(nodes[0]!.list_metadata.header_style).toBeNull();
+    });
+
+    await and('"Except as described ..." is not classified as a header', async () => {
+      expect(nodes[1]!.list_metadata.header_text).toBeNull();
+      expect(nodes[1]!.list_metadata.header_style).toBeNull();
+    });
+  });
+
+  test('detectRunInHeader rejects whole-paragraph bold blocks (#157)', async ({ given, when, then, and }: AllureBddContext) => {
+    let bodyXml: string;
+    let nodes: ReturnType<typeof buildNodesForDocumentView>['nodes'];
+
+    await given('a long fully-bold paragraph that ends with a colon', async () => {
+      // Mirrors all-bold defined-term lead-ins in the NVCA fixture. The
+      // paragraph is over SHORT_HEADER_MAX_LENGTH (50 chars) so the
+      // short-paragraph inline-style fallback does not fire — the only path
+      // that could classify it as a header is detectRunInHeader, which now
+      // requires a real header-prefix / body transition.
+      const text = 'This entire paragraph is bold and ends with a colon to mimic an all-bold defined term lead-in:';
+      bodyXml = `<w:p><w:r><w:rPr><w:b/></w:rPr><w:t>${text}</w:t></w:r></w:p>`;
+    });
+
+    await when('buildNodesForDocumentView is called', async () => {
+      ({ nodes } = buildNodesForDocumentView({
+        paragraphs: makeParagraphs(bodyXml!),
+        stylesXml: null,
+        numberingXml: null,
+        include_semantic_tags: false,
+        show_formatting: false,
+      }));
+    });
+
+    await then('the whole-paragraph bold block is not a run-in header', async () => {
+      expect(nodes).toHaveLength(1);
+      expect(nodes[0]!.list_metadata.header_style).not.toBe('run_in_header');
+    });
+
+    await and('the rendered header field stays empty (no toon stripping)', async () => {
+      expect(nodes[0]!.header).toBe('');
+    });
+  });
+
+  test('detectRunInHeader still fires on a real bold-prefix + body transition (no regression)', async ({ given, when, then }: AllureBddContext) => {
+    let bodyXml: string;
+    let nodes: ReturnType<typeof buildNodesForDocumentView>['nodes'];
+
+    await given('a paragraph with a bold "Indemnification." prefix followed by non-bold body', async () => {
+      bodyXml =
+        `<w:p>` +
+          `<w:r><w:rPr><w:b/></w:rPr><w:t>Indemnification.</w:t></w:r>` +
+          `<w:r><w:t> The Company shall indemnify each Investor as set forth herein.</w:t></w:r>` +
+        `</w:p>`;
+    });
+
+    await when('buildNodesForDocumentView is called', async () => {
+      ({ nodes } = buildNodesForDocumentView({
+        paragraphs: makeParagraphs(bodyXml!),
+        stylesXml: null,
+        numberingXml: null,
+        include_semantic_tags: false,
+        show_formatting: false,
+      }));
+    });
+
+    await then('the bold prefix is classified as a run_in_header', async () => {
+      expect(nodes).toHaveLength(1);
+      expect(nodes[0]!.list_metadata.header_style).toBe('run_in_header');
+      expect(nodes[0]!.list_metadata.header_text).toBe('Indemnification');
+    });
+  });
+
+  test('detects centered ALL-CAPS bold standalone title as title_caps_centered (#157)', async ({ given, when, then, and }: AllureBddContext) => {
+    let bodyXml: string;
+    let nodes: ReturnType<typeof buildNodesForDocumentView>['nodes'];
+
+    await given('a center-aligned, fully bold, ALL-CAPS standalone title', async () => {
+      // Mirrors the NVCA SPA's primary title.
+      bodyXml =
+        `<w:p>` +
+          `<w:pPr><w:jc w:val="center"/></w:pPr>` +
+          `<w:r><w:rPr><w:b/></w:rPr><w:t>SERIES A PREFERRED STOCK PURCHASE AGREEMENT</w:t></w:r>` +
+        `</w:p>`;
+    });
+
+    await when('buildNodesForDocumentView is called', async () => {
+      ({ nodes } = buildNodesForDocumentView({
+        paragraphs: makeParagraphs(bodyXml!),
+        stylesXml: null,
+        numberingXml: null,
+        include_semantic_tags: false,
+        show_formatting: false,
+      }));
+    });
+
+    await then('the title is surfaced with header_style title_caps_centered', async () => {
+      expect(nodes).toHaveLength(1);
+      expect(nodes[0]!.list_metadata.header_style).toBe('title_caps_centered');
+      expect(nodes[0]!.list_metadata.header_text).toBe('SERIES A PREFERRED STOCK PURCHASE AGREEMENT');
+    });
+
+    await and('header_formatting reflects the bold run', async () => {
+      expect(nodes[0]!.list_metadata.header_formatting?.bold).toBe(true);
+    });
+  });
+
+  test('title_caps_centered does not fire on centered text containing lowercase (#157)', async ({ given, when, then }: AllureBddContext) => {
+    let bodyXml: string;
+    let nodes: ReturnType<typeof buildNodesForDocumentView>['nodes'];
+
+    await given('a centered, bold, mixed-case standalone paragraph', async () => {
+      bodyXml =
+        `<w:p>` +
+          `<w:pPr><w:jc w:val="center"/></w:pPr>` +
+          `<w:r><w:rPr><w:b/></w:rPr><w:t>Series A Preferred Stock Purchase Agreement</w:t></w:r>` +
+        `</w:p>`;
+    });
+
+    await when('buildNodesForDocumentView is called', async () => {
+      ({ nodes } = buildNodesForDocumentView({
+        paragraphs: makeParagraphs(bodyXml!),
+        stylesXml: null,
+        numberingXml: null,
+        include_semantic_tags: false,
+        show_formatting: false,
+      }));
+    });
+
+    await then('the title_caps_centered rule does not fire', async () => {
+      expect(nodes).toHaveLength(1);
+      expect(nodes[0]!.list_metadata.header_style).not.toBe('title_caps_centered');
+    });
+  });
 });

--- a/packages/docx-core/test-primitives/document_view.branch.test.ts
+++ b/packages/docx-core/test-primitives/document_view.branch.test.ts
@@ -539,4 +539,151 @@ describe('document_view branch coverage', () => {
       expect(nodes[0]!.list_metadata.header_style).not.toBe('title_caps_centered');
     });
   });
+
+  test('title_caps_centered rejects bracketed single-token placeholders like [COMPANY] (#178 review)', async ({ given, when, then }: AllureBddContext) => {
+    let bodyXml: string;
+    let nodes: ReturnType<typeof buildNodesForDocumentView>['nodes'];
+
+    await given('a centered, bold, single-token bracketed placeholder', async () => {
+      bodyXml =
+        `<w:p>` +
+          `<w:pPr><w:jc w:val="center"/></w:pPr>` +
+          `<w:r><w:rPr><w:b/></w:rPr><w:t>[COMPANY]</w:t></w:r>` +
+        `</w:p>`;
+    });
+
+    await when('buildNodesForDocumentView is called', async () => {
+      ({ nodes } = buildNodesForDocumentView({
+        paragraphs: makeParagraphs(bodyXml!),
+        stylesXml: null,
+        numberingXml: null,
+        include_semantic_tags: false,
+        show_formatting: false,
+      }));
+    });
+
+    await then('the placeholder is not classified as title_caps_centered', async () => {
+      expect(nodes).toHaveLength(1);
+      expect(nodes[0]!.list_metadata.header_style).not.toBe('title_caps_centered');
+    });
+  });
+
+  test('title_caps_centered rejects punctuation/underscore-only signature lines (#178 review)', async ({ given, when, then }: AllureBddContext) => {
+    let bodyXml: string;
+    let nodes: ReturnType<typeof buildNodesForDocumentView>['nodes'];
+
+    await given('a centered, bold underscore signature line (real ILPA fixture pattern)', async () => {
+      bodyXml =
+        `<w:p>` +
+          `<w:pPr><w:jc w:val="center"/></w:pPr>` +
+          `<w:r><w:rPr><w:b/></w:rPr><w:t>____________________________________________</w:t></w:r>` +
+        `</w:p>`;
+    });
+
+    await when('buildNodesForDocumentView is called', async () => {
+      ({ nodes } = buildNodesForDocumentView({
+        paragraphs: makeParagraphs(bodyXml!),
+        stylesXml: null,
+        numberingXml: null,
+        include_semantic_tags: false,
+        show_formatting: false,
+      }));
+    });
+
+    await then('the underscore line is not classified as title_caps_centered', async () => {
+      expect(nodes).toHaveLength(1);
+      expect(nodes[0]!.list_metadata.header_style).not.toBe('title_caps_centered');
+      expect(nodes[0]!.list_metadata.header_text).toBeNull();
+    });
+  });
+
+  test('title_caps_centered admits long ALL-CAPS corporate titles up to 120 chars (#178 review)', async ({ given, when, then }: AllureBddContext) => {
+    let bodyXml: string;
+    let nodes: ReturnType<typeof buildNodesForDocumentView>['nodes'];
+
+    await given('a centered, bold ALL-CAPS title between 60 and 120 chars (NVCA COI fixture pattern)', async () => {
+      // 87 chars — exceeds the old MAX_HEADER_TEXT_LENGTH of 60 but fits the
+      // new MAX_CENTERED_TITLE_LENGTH of 120.
+      const text = 'AMENDED AND RESTATED CERTIFICATE OF INCORPORATION OF FOO HOLDINGS INC.';
+      bodyXml =
+        `<w:p>` +
+          `<w:pPr><w:jc w:val="center"/></w:pPr>` +
+          `<w:r><w:rPr><w:b/></w:rPr><w:t>${text}</w:t></w:r>` +
+        `</w:p>`;
+    });
+
+    await when('buildNodesForDocumentView is called', async () => {
+      ({ nodes } = buildNodesForDocumentView({
+        paragraphs: makeParagraphs(bodyXml!),
+        stylesXml: null,
+        numberingXml: null,
+        include_semantic_tags: false,
+        show_formatting: false,
+      }));
+    });
+
+    await then('the title is classified as title_caps_centered', async () => {
+      expect(nodes).toHaveLength(1);
+      expect(nodes[0]!.list_metadata.header_style).toBe('title_caps_centered');
+      expect(nodes[0]!.list_metadata.header_text).toContain('AMENDED AND RESTATED');
+    });
+  });
+
+  test('title_caps_centered outranks short title_bare for short ALL-CAPS centered titles (#178 review)', async ({ given, when, then }: AllureBddContext) => {
+    let bodyXml: string;
+    let nodes: ReturnType<typeof buildNodesForDocumentView>['nodes'];
+
+    await given('a short centered, bold ALL-CAPS title that would also match the short-paragraph fallback', async () => {
+      bodyXml =
+        `<w:p>` +
+          `<w:pPr><w:jc w:val="center"/></w:pPr>` +
+          `<w:r><w:rPr><w:b/></w:rPr><w:t>SCHEDULE OF PURCHASERS</w:t></w:r>` +
+        `</w:p>`;
+    });
+
+    await when('buildNodesForDocumentView is called', async () => {
+      ({ nodes } = buildNodesForDocumentView({
+        paragraphs: makeParagraphs(bodyXml!),
+        stylesXml: null,
+        numberingXml: null,
+        include_semantic_tags: false,
+        show_formatting: false,
+      }));
+    });
+
+    await then('the title is classified as title_caps_centered, not title_bare', async () => {
+      expect(nodes).toHaveLength(1);
+      expect(nodes[0]!.list_metadata.header_style).toBe('title_caps_centered');
+    });
+  });
+
+  test('detectRunInHeader rejects whole-paragraph bold blocks even with trailing whitespace (#178 review)', async ({ given, when, then }: AllureBddContext) => {
+    let bodyXml: string;
+    let nodes: ReturnType<typeof buildNodesForDocumentView>['nodes'];
+
+    await given('a fully-bold short paragraph with a trailing space in a separate non-bold run', async () => {
+      // Real false positive observed against ~/Downloads Co-Founder Agreement.docx:
+      // a wholly-bold "Compensation & Benefits." with a trailing space-only run.
+      bodyXml =
+        `<w:p>` +
+          `<w:r><w:rPr><w:b/></w:rPr><w:t xml:space="preserve">Compensation &amp; Benefits.</w:t></w:r>` +
+          `<w:r><w:t xml:space="preserve"> </w:t></w:r>` +
+        `</w:p>`;
+    });
+
+    await when('buildNodesForDocumentView is called', async () => {
+      ({ nodes } = buildNodesForDocumentView({
+        paragraphs: makeParagraphs(bodyXml!),
+        stylesXml: null,
+        numberingXml: null,
+        include_semantic_tags: false,
+        show_formatting: false,
+      }));
+    });
+
+    await then('the trailing-whitespace-only "body" does not satisfy the header→body transition', async () => {
+      expect(nodes).toHaveLength(1);
+      expect(nodes[0]!.list_metadata.header_style).not.toBe('run_in_header');
+    });
+  });
 });

--- a/packages/docx-mcp/README.md
+++ b/packages/docx-mcp/README.md
@@ -49,6 +49,17 @@ Add to your MCP client:
 - Comments/Footnotes: `add_comment`, `get_comments`, `delete_comment`, `get_footnotes`, `add_footnote`, `update_footnote`, `delete_footnote`
 - Session/Safety: `clear_session`, path-policy + archive guardrails
 
+## Heading detection in `read_file(format="json")`
+
+Each paragraph node in the JSON output exposes heading signals via `paragraph_style_id` and the `list_metadata.header_text` / `header_style` / `header_formatting` fields. The supported `header_style` values are:
+
+- `run_in_header` — bold/underline prefix followed by non-header body in the same paragraph (e.g. `**Indemnification.** The Company shall …`). Whole-paragraph bold/underline blocks are intentionally excluded.
+- `title_with_period` / `title_with_colon` — inline section header with explicit terminator (e.g. `Governing Law and Venue: this agreement is governed as stated.`).
+- `title_caps_centered` — centered, ALL-CAPS, bold standalone title (e.g. `SERIES A PREFERRED STOCK PURCHASE AGREEMENT`). Strict gates: no lowercase letters, no list label, not in a table cell, ≤ 60 chars.
+- `title_with_period` / `title_with_colon` / `title_bare` — short standalone paragraphs (≤ 50 chars) only.
+
+To classify a paragraph as a heading, consumers should combine these signals with `paragraph_style_id` (`/^Heading[1-6]$/` is authoritative for depth). See [`skills/docx-editing/SKILL.md`](../../skills/docx-editing/SKILL.md) for the canonical precedence rule. Derived `is_heading` / `heading_level` fields are tracked in a follow-up issue.
+
 ## Document Families
 
 ### Automated fixture coverage in this repo

--- a/packages/docx-mcp/README.md
+++ b/packages/docx-mcp/README.md
@@ -55,7 +55,7 @@ Each paragraph node in the JSON output exposes heading signals via `paragraph_st
 
 - `run_in_header` — bold/underline prefix followed by non-header body in the same paragraph (e.g. `**Indemnification.** The Company shall …`). Whole-paragraph bold/underline blocks are intentionally excluded.
 - `title_with_period` / `title_with_colon` — inline section header with explicit terminator (e.g. `Governing Law and Venue: this agreement is governed as stated.`).
-- `title_caps_centered` — centered, ALL-CAPS, bold standalone title (e.g. `SERIES A PREFERRED STOCK PURCHASE AGREEMENT`). Strict gates: no lowercase letters, no list label, not in a table cell, ≤ 60 chars.
+- `title_caps_centered` — centered, ALL-CAPS, bold standalone title (e.g. `SERIES A PREFERRED STOCK PURCHASE AGREEMENT`). Strict gates: no lowercase letters, ≥ 3 ASCII letters, ≥ 2 word-tokens (rejects placeholders like `[COMPANY]` and underscore signature lines), no list label, not in a table cell, ≤ 120 chars.
 - `title_with_period` / `title_with_colon` / `title_bare` — short standalone paragraphs (≤ 50 chars) only.
 
 To classify a paragraph as a heading, consumers should combine these signals with `paragraph_style_id` (`/^Heading[1-6]$/` is authoritative for depth). See [`skills/docx-editing/SKILL.md`](../../skills/docx-editing/SKILL.md) for the canonical precedence rule. Derived `is_heading` / `heading_level` fields are tracked in a follow-up issue.

--- a/packages/docx-mcp/src/tools/nvca_spa_regression.test.ts
+++ b/packages/docx-mcp/src/tools/nvca_spa_regression.test.ts
@@ -17,6 +17,7 @@ import { getParagraphRuns } from '@usejunior/docx-core';
 
 import { SessionManager } from '../session/manager.js';
 import { openDocument } from './open_document.js';
+import { readFile } from './read_file.js';
 import { replaceText } from './replace_text.js';
 import { insertParagraph } from './insert_paragraph.js';
 import { save } from './save.js';
@@ -444,6 +445,42 @@ describe('NVCA SPA regression: batch edit + save round-trip', { timeout: 30_000 
       expect(trackedXml).toContain('w:ins');
       expect(trackedXml).toContain('w:del');
       expect(trackedXml).toContain('Treasury');
+    });
+  });
+});
+
+describe('NVCA SPA regression: heading detection (#157)', () => {
+  test('read_file(format=json) surfaces SPA title with title_caps_centered header_style', async ({ given, when, then, and }: AllureBddContext) => {
+    let mgr: ReturnType<typeof createMgr>;
+    let filePath: string;
+    let parsed: Array<{
+      id: string;
+      list_metadata: { header_text: string | null; header_style: string | null };
+    }>;
+    const titlePid = '_bk_8c71639f1440';
+
+    await given('the NVCA SPA source document is open in a new session', async () => {
+      ({ mgr, filePath } = await openSPA());
+    });
+
+    await when('read_file is called with format=json for the title paragraph', async () => {
+      const res = await readFile(mgr, {
+        file_path: filePath,
+        node_ids: [titlePid],
+        format: 'json',
+      });
+      assertSuccess(res, 'read_file json');
+      parsed = JSON.parse(res.content as string);
+    });
+
+    await then('the title paragraph is returned', async () => {
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0]!.id).toBe(titlePid);
+    });
+
+    await and('list_metadata.header_style is title_caps_centered', async () => {
+      expect(parsed[0]!.list_metadata.header_style).toBe('title_caps_centered');
+      expect(parsed[0]!.list_metadata.header_text).toContain('PREFERRED STOCK PURCHASE AGREEMENT');
     });
   });
 });

--- a/skills/docx-editing/SKILL.md
+++ b/skills/docx-editing/SKILL.md
@@ -209,6 +209,25 @@ When writing `new_string` in `replace_text` or `insert_paragraph`, use inline ta
 
 Tags can be nested: `<b><i>bold italic</i></b>`. Formatting from the original matched text is preserved for untagged replacement text.
 
+## Heading Detection (read_file JSON output)
+
+`read_file(format="json")` returns a `DocumentViewNode` per paragraph. To classify a paragraph as a section heading, combine these fields in the order below — the **first match wins**:
+
+| Precedence | Signal | Field | Notes |
+|------------|--------|-------|-------|
+| 1 | Word built-in heading style | `paragraph_style_id` matches `/^Heading[1-6]$/` | Authoritative depth (1–6). |
+| 2 | Run-in header (bold/underline prefix + body) | `list_metadata.header_style === 'run_in_header'` | Only fires when the bold/underline prefix is followed by non-header body in the same paragraph (a true header → body transition). Whole-paragraph bold/underline blocks are intentionally NOT classified here. |
+| 3 | Inline section header (long paragraph) | `list_metadata.header_style === 'title_with_period'` or `'title_with_colon'` | E.g. `Governing Law and Venue: this agreement is governed as stated.` |
+| 4 | Centered ALL-CAPS bold standalone title | `list_metadata.header_style === 'title_caps_centered'` | Centered alignment, body bold, no lowercase letters, no list label, not in a table cell, ≤ 60 chars. Catches document titles that are not styled with a Word heading style. |
+| 5 | Bare manual heading (short standalone paragraph) | `list_metadata.header_style === 'title_with_period'`, `'title_with_colon'`, or `'title_bare'` on a paragraph ≤ 50 chars | Last-resort heuristic for short headings. Body prose never reaches this branch. |
+| — | Otherwise | none of the above | Not a heading. |
+
+Across all rules, the actual heading text is in `list_metadata.header_text`, and the formatting (bold/italic/underline) of the title runs is in `list_metadata.header_formatting`.
+
+Derived `is_heading` / `heading_level` fields are tracked separately in a follow-up issue and are NOT in the current schema.
+
+The Google Docs renderer (`packages/google-docs-core`) mirrors this schema structurally; it does not currently emit `title_caps_centered` (Google Docs has different heading semantics).
+
 ## Batch Edits with apply_plan
 
 For 3+ edits on one document, prefer `apply_plan` over sequential `replace_text` calls. It validates all steps before applying any, so you get all-or-nothing transactional semantics.

--- a/skills/docx-editing/SKILL.md
+++ b/skills/docx-editing/SKILL.md
@@ -218,7 +218,7 @@ Tags can be nested: `<b><i>bold italic</i></b>`. Formatting from the original ma
 | 1 | Word built-in heading style | `paragraph_style_id` matches `/^Heading[1-6]$/` | Authoritative depth (1–6). |
 | 2 | Run-in header (bold/underline prefix + body) | `list_metadata.header_style === 'run_in_header'` | Only fires when the bold/underline prefix is followed by non-header body in the same paragraph (a true header → body transition). Whole-paragraph bold/underline blocks are intentionally NOT classified here. |
 | 3 | Inline section header (long paragraph) | `list_metadata.header_style === 'title_with_period'` or `'title_with_colon'` | E.g. `Governing Law and Venue: this agreement is governed as stated.` |
-| 4 | Centered ALL-CAPS bold standalone title | `list_metadata.header_style === 'title_caps_centered'` | Centered alignment, body bold, no lowercase letters, no list label, not in a table cell, ≤ 60 chars. Catches document titles that are not styled with a Word heading style. |
+| 4 | Centered ALL-CAPS bold standalone title | `list_metadata.header_style === 'title_caps_centered'` | Centered alignment, all visible runs bold, no lowercase letters, ≥ 3 ASCII letters and ≥ 2 word-tokens (so single-token bracketed placeholders like `[COMPANY]` and underscore signature lines like `__________` are excluded), no list label, not in a table cell, ≤ 120 chars. Catches document titles that are not styled with a Word heading style. |
 | 5 | Bare manual heading (short standalone paragraph) | `list_metadata.header_style === 'title_with_period'`, `'title_with_colon'`, or `'title_bare'` on a paragraph ≤ 50 chars | Last-resort heuristic for short headings. Body prose never reaches this branch. |
 | — | Otherwise | none of the above | Not a heading. |
 


### PR DESCRIPTION
## Summary

Phase 1 of #157: tighten the existing heading-detection signals in `read_file(format=\"json\")`, document the canonical precedence rule, and add a centered-title detector. Phase 2 (derived `is_heading` / `heading_level` schema fields) is deferred to a follow-up issue.

Three concrete bugs fixed against `tests/test_documents/nvca-regression/source.docx`:

1. **False negative**: the SPA's center-aligned, ALL-CAPS, bold title (`SERIES […] PREFERRED STOCK PURCHASE AGREEMENT`) now surfaces as `header_style: 'title_caps_centered'` instead of producing a null heading signal.
2. **False positives in `extractHeaderInfo()`**: the long-paragraph regex branch no longer returns `title_bare` when no explicit `.` or `:` terminator is matched — body prose like `Termination of Section 2.2(d)(i) shall not affect …` and `Except as described in Section 2.2(d)(i), …` no longer surface a leading-word `header_text`.
3. **False positives in `detectRunInHeader()`**: a formatting-transition invariant (`headerCharCount < totalVisibleChars`) ensures the bold/underline prefix is followed by non-header body. Whole-paragraph bold/underline blocks (signature labels, defined-term lead-in sentences) no longer get classified as run-in headers.

### Smoke results across the 367-paragraph NVCA SPA

| Header style | Main | This PR | Net |
|---|---|---|---|
| `run_in_header` | 12 (all false positives, `header_text` = whole body prose) | 0 | -12 false positives |
| `title_with_period` | 12 | 12 | unchanged |
| `title_with_colon` | 9 | 12 | +3 (recovered from former `run_in_header` mis-classification) |
| `title_bare` | 90 | 88 | -2 (Termination/Except now correctly null) |
| `title_caps_centered` | 0 | 3 | +3 NEW true positives (SPA title + 2 others) |

### Why Phase 1 only (not Phase 2)

Peer-reviewed with both Gemini and Codex CLI before implementation. Codex flagged that:

- The existing signals are too noisy to bless with a top-level verdict field today (the 12 false-positive `run_in_header` entries on main are exactly that noise).
- The existing `header` string field is wired into toon header-stripping (`document_view.ts:363`) and grep locators (`packages/docx-mcp/src/tools/grep.ts:56`) — repurposing it would be more breaking than adding new fields later.
- The Google Docs renderer is structurally cast to `DocumentViewNode` at `packages/docx-mcp/src/tools/gdocs/read_file.ts:21`, so any new top-level field is immediately a cross-renderer contract.

Phase 1 lands the cleaner signals and the documented precedence rule first; the Phase 2 schema (`heading: null | { text, source, level }` per Codex's preference, vs. nested `heading: { is_heading, tier, level, source, source_detail }` per Gemini's) will be designed against stable signals in a follow-up issue.

### Documentation

- `skills/docx-editing/SKILL.md` — new \"Heading Detection (read_file JSON output)\" subsection with the canonical precedence table.
- `packages/docx-mcp/README.md` — brief paragraph documenting `list_metadata.header_text` / `header_style` (previously undocumented), pointing to SKILL.md.

### Out of scope (tracked in follow-up)

- Top-level `is_heading` / `heading_level` schema work.
- Refining `Heading 1`–`Heading 6` style detection (e.g., the `HeadingPara1` / `HeadingPara2` footgun in the NVCA fixture where styles inherit from heading styles but behave like body).
- Mirroring on the Google Docs renderer (its structural cast already auto-mirrors any new top-level fields, so no Phase 1 changes break it).

## Test plan

- [x] `npm -w @usejunior/docx-core test` — 1137 pass, 1 skipped, 0 fail (5 new branch tests added).
- [x] `npm -w @usejunior/docx-mcp test` — 675 pass, 0 fail (1 new end-to-end JSON-shape test against the SPA fixture).
- [x] `npm run lint:workspaces` — 0 errors (1 pre-existing warning in `edit.test.ts` unchanged).
- [x] Manual smoke against the actual NVCA SPA fixture: SPA title detected as `title_caps_centered`, `Termination of Section …` and `Except as described in Section …` no longer surface a non-null `header_text`, all 12 main-branch `run_in_header` false positives suppressed.
- [x] `Governing Law and Venue: …` style inline headers still detected as `title_with_colon` (no regression in `document_view.branch.test.ts:150`).
- [x] New regression test for a real bold-prefix + body-suffix paragraph confirms `run_in_header` still fires on legitimate cases.

Ref: #157