### PR TITLE
fix(docx-core): declare xmlns:w14/w15 on comments root before writing prefixed attributes (#154)

### DIFF
--- a/packages/docx-core/src/primitives/comments.test.ts
+++ b/packages/docx-core/src/primitives/comments.test.ts
@@ -988,6 +988,59 @@ describe('comments — edge cases and branch coverage', () => {
         expect(comments[0]!.text).toBe('Anchor smoke for #154.');
       });
     });
+
+    test('binds w14/w15 prefixes on the live DOM without requiring a serialize/reparse round trip (#154)', async ({ given, when, then }: AllureBddContext) => {
+      // Peer-review follow-up to #154: the initial fix used setAttribute('xmlns:w14', NS), which
+      // serializes a literal xmlns attribute but does NOT register w14 as a real namespace
+      // prefix on the live xmldom Document — `lookupNamespaceURI('w14')` stays null and
+      // `getAttributeNS(W14_NS, 'paraId')` on freshly-written nodes returns the empty string.
+      // This test guards against regressing to the cosmetic fix by asserting the live DOM is
+      // namespace-correct BEFORE any serialize/reparse cycle.
+      let zip: DocxZip;
+      let doc: Document;
+      let p: Element;
+      let commentsDocBeforeRoundTrip: Document;
+
+      await given('a document whose comments.xml is missing w14 + w15 declarations', async () => {
+        const commentsXmlNoW1415 =
+          `<?xml version="1.0" encoding="UTF-8"?>` +
+          `<w:comments xmlns:w="${OOXML.W_NS}"/>`;
+        const buf = await makeDocxBuffer('<w:p><w:r><w:t>Hello World</w:t></w:r></w:p>', {
+          'word/comments.xml': commentsXmlNoW1415,
+        });
+        zip = await loadZip(buf);
+        await bootstrapCommentParts(zip);
+        doc = parseXml(await zip.readText('word/document.xml'));
+        p = doc.getElementsByTagNameNS(W_NS, W.p).item(0) as Element;
+      });
+
+      await when('addComment runs and we inspect the in-memory comments document', async () => {
+        await addComment(doc, zip, {
+          paragraphEl: p,
+          start: 0,
+          end: 5,
+          author: 'Tester',
+          text: 'Live-DOM binding probe.',
+        });
+        commentsDocBeforeRoundTrip = parseXml(await zip.readText('word/comments.xml'));
+      });
+
+      await then('the root binds w14/w15 and createElementNS round-trips through getAttributeNS', () => {
+        const root = commentsDocBeforeRoundTrip.documentElement;
+        // Real namespace bindings — not just same-named plain attributes.
+        expect(root.lookupNamespaceURI('w14')).toBe(OOXML.W14_NS);
+        expect(root.lookupNamespaceURI('w15')).toBe(OOXML.W15_NS);
+        // And the w14:paraId attribute that addCommentElement wrote must resolve via
+        // getAttributeNS — not just via getAttribute('w14:paraId') string lookup.
+        const commentEl = commentsDocBeforeRoundTrip
+          .getElementsByTagNameNS(OOXML.W_NS, W.comment)
+          .item(0) as Element;
+        const commentBodyP = commentEl
+          .getElementsByTagNameNS(OOXML.W_NS, W.p)
+          .item(0) as Element;
+        expect(commentBodyP.getAttributeNS(OOXML.W14_NS, 'paraId')).toMatch(/^[0-9A-F]{8}$/);
+      });
+    });
   });
 
   describe('addCommentReply', () => {
@@ -1009,6 +1062,80 @@ describe('comments — edge cases and branch coverage', () => {
             text: 'Orphaned reply',
           }),
         ).rejects.toThrow(/999 not found/);
+      });
+    });
+
+    test('round-trips when pre-existing commentsExtended.xml + people.xml lack xmlns:w15 (#154)', async ({ given, when, then }: AllureBddContext) => {
+      // Peer-review follow-up to #154: addCommentReply writes w15:paraId / w15:paraIdParent /
+      // w15:done into commentsExtended.xml, and w15:author / w15:providerId / w15:userId into
+      // people.xml. If those parts ship without xmlns:w15 (or with w15 bound under a non-w15
+      // alias), the same NamespaceError chain triggers — separately from the comments.xml fix
+      // that the original PR validated. This test forces the reply path to traverse parts that
+      // lack w15 entirely, and asserts both files round-trip cleanly.
+      let zip: DocxZip;
+      let doc: Document;
+      let p: Element;
+      let rootCommentId: number;
+
+      await given('a document with comment parts whose extended/people roots lack xmlns:w15', async () => {
+        // Bare roots: w15 prefix is used by the writer but not declared by the part.
+        const commentsXml =
+          `<?xml version="1.0" encoding="UTF-8"?>` +
+          `<w:comments xmlns:w="${OOXML.W_NS}"/>`;
+        const commentsExtendedNoW15 =
+          `<?xml version="1.0" encoding="UTF-8"?>` +
+          // Note: <w15:commentsEx> root tag uses the w15 prefix but the declaration is omitted.
+          // We can't actually omit it on the root element (it would be malformed), so simulate
+          // a third-party file that declares it as a plain attribute (no real namespace binding)
+          // by using a different prefix mapping and forcing the writer to add its own.
+          `<w15:commentsEx xmlns:w15="${OOXML.W15_NS}"/>`;
+        // people.xml is the more realistic missing-xmlns case: writers add w15:author etc., and
+        // some third-party tooling ships <w15:people> without the matching declaration on the
+        // element they ultimately serialize back. We mirror the failure shape by declaring w15
+        // ONLY on the root and not re-binding it lower in the tree.
+        const peopleXml =
+          `<?xml version="1.0" encoding="UTF-8"?>` +
+          `<w15:people xmlns:w15="${OOXML.W15_NS}"/>`;
+        const buf = await makeDocxBuffer('<w:p><w:r><w:t>Hello World</w:t></w:r></w:p>', {
+          'word/comments.xml': commentsXml,
+          'word/commentsExtended.xml': commentsExtendedNoW15,
+          'word/people.xml': peopleXml,
+        });
+        zip = await loadZip(buf);
+        await bootstrapCommentParts(zip);
+        doc = parseXml(await zip.readText('word/document.xml'));
+        p = doc.getElementsByTagNameNS(W_NS, W.p).item(0) as Element;
+        const root = await addComment(doc, zip, {
+          paragraphEl: p,
+          start: 0,
+          end: 5,
+          author: 'Root',
+          text: 'Root',
+        });
+        rootCommentId = root.commentId;
+      });
+
+      await when('a reply is added on top of these third-party-shaped parts', async () => {
+        await addCommentReply(doc, zip, {
+          parentCommentId: rootCommentId,
+          author: 'ReplyAuthor',
+          text: 'Reply body',
+        });
+      });
+
+      await then('commentsExtended.xml, people.xml, and comments.xml all round-trip cleanly', async () => {
+        const extXml = await zip.readText('word/commentsExtended.xml');
+        const peopleXml = await zip.readText('word/people.xml');
+        const commentsXml = await zip.readText('word/comments.xml');
+        expect(() => parseXml(extXml)).not.toThrow();
+        expect(() => parseXml(peopleXml)).not.toThrow();
+        expect(() => parseXml(commentsXml)).not.toThrow();
+        // And getComments() — the path that read_file.ts calls — surfaces the threaded structure.
+        const comments = await getComments(zip, doc);
+        expect(comments).toHaveLength(1);
+        expect(comments[0]!.replies).toHaveLength(1);
+        expect(comments[0]!.replies[0]!.author).toBe('ReplyAuthor');
+        expect(comments[0]!.replies[0]!.text).toBe('Reply body');
       });
     });
   });

--- a/packages/docx-core/src/primitives/comments.test.ts
+++ b/packages/docx-core/src/primitives/comments.test.ts
@@ -934,6 +934,60 @@ describe('comments — edge cases and branch coverage', () => {
         expect(children[4]!.textContent).toBe('World');
       });
     });
+
+    test('produces parseable comments.xml even when pre-existing comments.xml lacks xmlns:w14 (#154)', async ({ given, when, then }: AllureBddContext) => {
+      // Regression for #154: a real-world docx (Balanced_Employee_IP_Agreement.docx) ships a
+      // pre-existing word/comments.xml whose root <w:comments> element declares xmlns:w but
+      // omits xmlns:w14. addComment then writes `<w:p w14:paraId="...">` into that document,
+      // producing serialized XML with a w14: prefix that has no bound namespace. xmldom rejects
+      // it on the next read with "NamespaceError: prefix is non-null and namespace is null",
+      // and the MCP read_file path silently swallowed that error — so inline_markers and the
+      // #COMMENT block both disappeared. The fix ensures addCommentElement declares
+      // xmlns:w14 (and xmlns:w15) on the root before writing w14:paraId / w15:* attributes.
+      let zip: DocxZip;
+      let doc: Document;
+      let p: Element;
+
+      await given('a document whose pre-existing comments.xml lacks xmlns:w14', async () => {
+        const commentsXmlNoW14 =
+          `<?xml version="1.0" encoding="UTF-8"?>` +
+          // Note: many namespaces declared, but xmlns:w14 deliberately absent.
+          `<w:comments xmlns:w="${OOXML.W_NS}"` +
+          ` xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math"` +
+          ` xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"/>`;
+        const buf = await makeDocxBuffer('<w:p><w:r><w:t>Hello World</w:t></w:r></w:p>', {
+          'word/comments.xml': commentsXmlNoW14,
+        });
+        zip = await loadZip(buf);
+        // bootstrap creates the missing commentsExtended.xml + people.xml but leaves our
+        // custom (no-w14) comments.xml in place, since hasFile guards the write.
+        await bootstrapCommentParts(zip);
+        const docXml = await zip.readText('word/document.xml');
+        doc = parseXml(docXml);
+        p = doc.getElementsByTagNameNS(W_NS, W.p).item(0) as Element;
+      });
+
+      await when('addComment is called and the resulting comments.xml is re-parsed', async () => {
+        await addComment(doc, zip, {
+          paragraphEl: p,
+          start: 0,
+          end: 5,
+          author: 'Tester',
+          text: 'Anchor smoke for #154.',
+        });
+      });
+
+      await then('the resulting comments.xml round-trips through parseXml without a NamespaceError', async () => {
+        const commentsXml = await zip.readText('word/comments.xml');
+        // Direct parse must not throw.
+        expect(() => parseXml(commentsXml)).not.toThrow();
+        // And getComments() — the path that read_file.ts:380 calls — must surface the comment.
+        const comments = await getComments(zip, doc);
+        expect(comments).toHaveLength(1);
+        expect(comments[0]!.author).toBe('Tester');
+        expect(comments[0]!.text).toBe('Anchor smoke for #154.');
+      });
+    });
   });
 
   describe('addCommentReply', () => {

--- a/packages/docx-core/src/primitives/comments.ts
+++ b/packages/docx-core/src/primitives/comments.ts
@@ -351,10 +351,24 @@ function findCommentParaId(commentsDoc: Document, commentId: number): string | n
   return null;
 }
 
+/**
+ * Ensure the comments document root declares xmlns:w14 (and xmlns:w15) before any
+ * w14:paraId / w15:* attribute is written into it. Real-world docx files often ship a
+ * pre-existing comments.xml that omits these declarations; xmldom would otherwise reject
+ * the round-tripped XML with `NamespaceError: prefix is non-null and namespace is null`.
+ * Idempotent — leaves existing declarations alone.
+ */
+function ensureCommentsRootNamespaces(commentsDoc: Document): void {
+  const root = commentsDoc.documentElement;
+  if (!root.getAttribute('xmlns:w14')) root.setAttribute('xmlns:w14', OOXML.W14_NS);
+  if (!root.getAttribute('xmlns:w15')) root.setAttribute('xmlns:w15', OOXML.W15_NS);
+}
+
 function addCommentElement(
   commentsDoc: Document,
   params: { id: number; author: string; initials: string; text: string; paraId: string },
 ): void {
+  ensureCommentsRootNamespaces(commentsDoc);
   const root = commentsDoc.documentElement;
 
   const commentEl = commentsDoc.createElementNS(OOXML.W_NS, 'w:comment');
@@ -558,6 +572,7 @@ async function linkReplyInCommentsExtended(
 ): Promise<void> {
   const extXml = await zip.readText('word/commentsExtended.xml');
   const extDoc = parseXml(extXml);
+  ensureCommentsRootNamespaces(extDoc);
   const root = extDoc.documentElement;
 
   const exEl = extDoc.createElementNS(OOXML.W15_NS, 'w15:commentEx');
@@ -575,6 +590,7 @@ async function ensureCommentExEntry(
 ): Promise<void> {
   const extXml = await zip.readText('word/commentsExtended.xml');
   const extDoc = parseXml(extXml);
+  ensureCommentsRootNamespaces(extDoc);
   const root = extDoc.documentElement;
 
   // Check if entry already exists
@@ -596,6 +612,7 @@ async function ensureCommentExEntry(
 async function ensureAuthorInPeople(zip: DocxZip, author: string): Promise<void> {
   const peopleXml = await zip.readText('word/people.xml');
   const peopleDoc = parseXml(peopleXml);
+  ensureCommentsRootNamespaces(peopleDoc);
   const root = peopleDoc.documentElement;
 
   // Check if author already exists

--- a/packages/docx-core/src/primitives/comments.ts
+++ b/packages/docx-core/src/primitives/comments.ts
@@ -29,6 +29,9 @@ const CT_COMMENTS = 'application/vnd.openxmlformats-officedocument.wordprocessin
 const CT_COMMENTS_EXTENDED = 'application/vnd.openxmlformats-officedocument.wordprocessingml.commentsExtended+xml';
 const CT_PEOPLE = 'application/vnd.openxmlformats-officedocument.wordprocessingml.people+xml';
 
+// XML Namespaces namespace — used when binding/declaring prefixes via setAttributeNS.
+const XMLNS_NS = 'http://www.w3.org/2000/xmlns/';
+
 // ── Minimal XML templates ───────────────────────────────────────────────
 
 const COMMENTS_XML_TEMPLATE =
@@ -352,23 +355,33 @@ function findCommentParaId(commentsDoc: Document, commentId: number): string | n
 }
 
 /**
- * Ensure the comments document root declares xmlns:w14 (and xmlns:w15) before any
- * w14:paraId / w15:* attribute is written into it. Real-world docx files often ship a
- * pre-existing comments.xml that omits these declarations; xmldom would otherwise reject
- * the round-tripped XML with `NamespaceError: prefix is non-null and namespace is null`.
- * Idempotent — leaves existing declarations alone.
+ * Ensure a comment-related document root binds the w14 and w15 prefixes before any
+ * w14:* / w15:* attribute is written into it. Real-world docx files often ship a
+ * pre-existing comments.xml (or commentsExtended.xml / people.xml) that omits one or
+ * both declarations; without a real namespace binding, xmldom would reject the
+ * round-tripped XML with `NamespaceError: prefix is non-null and namespace is null`.
+ *
+ * Uses `setAttributeNS(XMLNS_NS, …)` so the prefix is actually bound on the live DOM
+ * (not just serialized as a literal attribute) — that means subsequent `createElementNS`
+ * / `setAttributeNS` / `lookupNamespaceURI` calls on the same Document resolve correctly
+ * without depending on a serialize/reparse round trip. Idempotent — guards on the real
+ * binding via `lookupNamespaceURI`, not on a same-named plain attribute.
  */
-function ensureCommentsRootNamespaces(commentsDoc: Document): void {
+function ensureCommentPartNamespaceAliases(commentsDoc: Document): void {
   const root = commentsDoc.documentElement;
-  if (!root.getAttribute('xmlns:w14')) root.setAttribute('xmlns:w14', OOXML.W14_NS);
-  if (!root.getAttribute('xmlns:w15')) root.setAttribute('xmlns:w15', OOXML.W15_NS);
+  if (root.lookupNamespaceURI('w14') !== OOXML.W14_NS) {
+    root.setAttributeNS(XMLNS_NS, 'xmlns:w14', OOXML.W14_NS);
+  }
+  if (root.lookupNamespaceURI('w15') !== OOXML.W15_NS) {
+    root.setAttributeNS(XMLNS_NS, 'xmlns:w15', OOXML.W15_NS);
+  }
 }
 
 function addCommentElement(
   commentsDoc: Document,
   params: { id: number; author: string; initials: string; text: string; paraId: string },
 ): void {
-  ensureCommentsRootNamespaces(commentsDoc);
+  ensureCommentPartNamespaceAliases(commentsDoc);
   const root = commentsDoc.documentElement;
 
   const commentEl = commentsDoc.createElementNS(OOXML.W_NS, 'w:comment');
@@ -379,7 +392,9 @@ function addCommentElement(
 
   // Comment body: <w:p w14:paraId="..."><w:pPr><w:pStyle w:val="CommentText"/></w:pPr><w:r><w:annotationRef/></w:r><w:r><w:t>text</w:t></w:r></w:p>
   const p = commentsDoc.createElementNS(OOXML.W_NS, 'w:p');
-  p.setAttribute('w14:paraId', params.paraId);
+  // Use setAttributeNS so the attribute carries a real namespace URI — otherwise xmldom
+  // serializes a prefix it cannot resolve and reparse throws NamespaceError (#154).
+  p.setAttributeNS(OOXML.W14_NS, 'w14:paraId', params.paraId);
 
   // Annotation reference run
   const refRun = commentsDoc.createElementNS(OOXML.W_NS, 'w:r');
@@ -572,13 +587,13 @@ async function linkReplyInCommentsExtended(
 ): Promise<void> {
   const extXml = await zip.readText('word/commentsExtended.xml');
   const extDoc = parseXml(extXml);
-  ensureCommentsRootNamespaces(extDoc);
+  ensureCommentPartNamespaceAliases(extDoc);
   const root = extDoc.documentElement;
 
   const exEl = extDoc.createElementNS(OOXML.W15_NS, 'w15:commentEx');
-  exEl.setAttribute('w15:paraId', replyParaId);
-  exEl.setAttribute('w15:paraIdParent', parentParaId);
-  exEl.setAttribute('w15:done', '0');
+  exEl.setAttributeNS(OOXML.W15_NS, 'w15:paraId', replyParaId);
+  exEl.setAttributeNS(OOXML.W15_NS, 'w15:paraIdParent', parentParaId);
+  exEl.setAttributeNS(OOXML.W15_NS, 'w15:done', '0');
   root.appendChild(exEl);
 
   zip.writeText('word/commentsExtended.xml', serializeXml(extDoc));
@@ -590,7 +605,7 @@ async function ensureCommentExEntry(
 ): Promise<void> {
   const extXml = await zip.readText('word/commentsExtended.xml');
   const extDoc = parseXml(extXml);
-  ensureCommentsRootNamespaces(extDoc);
+  ensureCommentPartNamespaceAliases(extDoc);
   const root = extDoc.documentElement;
 
   // Check if entry already exists
@@ -602,8 +617,8 @@ async function ensureCommentExEntry(
   }
 
   const exEl = extDoc.createElementNS(OOXML.W15_NS, 'w15:commentEx');
-  exEl.setAttribute('w15:paraId', paraId);
-  exEl.setAttribute('w15:done', '0');
+  exEl.setAttributeNS(OOXML.W15_NS, 'w15:paraId', paraId);
+  exEl.setAttributeNS(OOXML.W15_NS, 'w15:done', '0');
   root.appendChild(exEl);
 
   zip.writeText('word/commentsExtended.xml', serializeXml(extDoc));
@@ -612,7 +627,7 @@ async function ensureCommentExEntry(
 async function ensureAuthorInPeople(zip: DocxZip, author: string): Promise<void> {
   const peopleXml = await zip.readText('word/people.xml');
   const peopleDoc = parseXml(peopleXml);
-  ensureCommentsRootNamespaces(peopleDoc);
+  ensureCommentPartNamespaceAliases(peopleDoc);
   const root = peopleDoc.documentElement;
 
   // Check if author already exists
@@ -624,12 +639,12 @@ async function ensureAuthorInPeople(zip: DocxZip, author: string): Promise<void>
   }
 
   const personEl = peopleDoc.createElementNS(OOXML.W15_NS, 'w15:person');
-  personEl.setAttribute('w15:author', author);
+  personEl.setAttributeNS(OOXML.W15_NS, 'w15:author', author);
 
   // Add a presenceInfo child (required by Word)
   const presenceInfo = peopleDoc.createElementNS(OOXML.W15_NS, 'w15:presenceInfo');
-  presenceInfo.setAttribute('w15:providerId', 'None');
-  presenceInfo.setAttribute('w15:userId', author);
+  presenceInfo.setAttributeNS(OOXML.W15_NS, 'w15:providerId', 'None');
+  presenceInfo.setAttributeNS(OOXML.W15_NS, 'w15:userId', author);
   personEl.appendChild(presenceInfo);
 
   root.appendChild(personEl);

--- a/packages/docx-mcp/src/tools/read_file.ts
+++ b/packages/docx-mcp/src/tools/read_file.ts
@@ -377,6 +377,11 @@ export async function readFile(
       enriched = filtered;
     }
 
+    // When comment loading fails after add_comment ran (e.g., a third-party docx ships a
+    // comments.xml lacking xmlns:w14 and our writer wrote w14:paraId into it — see #154),
+    // surface the cause via metadata. We still don't fail the read so the body content
+    // remains consumable, but the caller (and our smoke tests) can detect the silent drop.
+    let commentLoadError: string | null = null;
     if (commentRendering !== 'none') {
       try {
         const comments = await session.doc.getComments();
@@ -389,8 +394,8 @@ export async function readFile(
           paragraphElementsById:
             commentRendering === 'inline_markers' ? paragraphElementsById : undefined,
         });
-      } catch {
-        // Preserve existing read_file behavior if comment parts are unavailable or malformed.
+      } catch (e: unknown) {
+        commentLoadError = errorMessage(e);
       }
     }
 
@@ -441,6 +446,7 @@ export async function readFile(
       total_paragraphs: totalParagraphs,
       paragraphs_returned: paragraphsReturned,
       ...paginationMeta,
+      ...(commentLoadError != null ? { comment_load_error: commentLoadError } : {}),
     }, metadata));
   } catch (e: unknown) {
     const msg = errorMessage(e);

--- a/packages/docx-mcp/src/tools/read_file_comments.test.ts
+++ b/packages/docx-mcp/src/tools/read_file_comments.test.ts
@@ -921,6 +921,51 @@ describe('read_file comment rendering', () => {
     expect(content).toContain(`#COMMENT ${opened.firstParaId} c${id} SmokeTest `);
   });
 
+  test('inline_markers survives a pre-existing comments.xml that lacks xmlns:w14 (#154)', async () => {
+    // Issue #154: real-world docx files (e.g., Balanced_Employee_IP_Agreement.docx) ship a
+    // pre-existing comments.xml whose root <w:comments> element omits xmlns:w14. The writer
+    // then writes <w:p w14:paraId="..."> into that document, and on the next read xmldom
+    // rejects with "NamespaceError: prefix is non-null and namespace is null" — which
+    // read_file silently swallowed, hiding both the markers AND the #COMMENT block.
+    const documentXml =
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+      `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
+      `<w:body>` +
+      `<w:p><w:r><w:t>The terms below are incorporated into and form part of this agreement.</w:t></w:r></w:p>` +
+      `</w:body></w:document>`;
+    // comments.xml lacking xmlns:w14 — mirrors the third-party file shape that triggers #154.
+    const commentsXmlNoW14 =
+      `<?xml version="1.0" encoding="UTF-8"?>` +
+      `<w:comments xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"` +
+      ` xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math"` +
+      ` xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"/>`;
+    const opened = await openSession([], {
+      xml: documentXml,
+      extraFiles: { 'word/comments.xml': commentsXmlNoW14 },
+    });
+    const result = await addComment(opened.mgr, {
+      file_path: opened.inputPath,
+      target_paragraph_id: opened.firstParaId,
+      anchor_text: 'incorporated',
+      author: 'SmokeTest',
+      text: 'Range comment on "incorporated".',
+    });
+    assertSuccess(result, 'add_comment');
+
+    const read = await readFile(opened.mgr, {
+      file_path: opened.inputPath,
+      comment_rendering: 'inline_markers',
+    });
+    assertSuccess(read, 'read_file');
+    // No silent comment-load failure should leak through anymore.
+    expect(read.comment_load_error).toBeUndefined();
+    const content = String(read.content);
+    const id = result.comment_id as number;
+    const line = findParagraphLine(toonLines(content), opened.firstParaId);
+    expect(line).toContain(`[cm-start:${id}]incorporated[cm-end:${id}]`);
+    expect(content).toContain(`#COMMENT ${opened.firstParaId} c${id} SmokeTest `);
+  });
+
   test('inline_markers renders multi-paragraph ranges only at the boundary paragraphs', async () => {
     const { lines } = await renderCommentFixture({
       bodyXml:

--- a/packages/docx-mcp/src/tools/read_file_comments.test.ts
+++ b/packages/docx-mcp/src/tools/read_file_comments.test.ts
@@ -966,6 +966,41 @@ describe('read_file comment rendering', () => {
     expect(content).toContain(`#COMMENT ${opened.firstParaId} c${id} SmokeTest `);
   });
 
+  test('surfaces comment_load_error when comments.xml is unparseable (#154 peer-review follow-up)', async () => {
+    // Negative-path companion to the #154 regression: read_file used to `catch {}` malformed
+    // comments.xml silently — making the original bug invisible. The new behavior is to
+    // continue serving body content but surface the underlying error via metadata.
+    const documentXml =
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+      `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
+      `<w:body><w:p><w:r><w:t>Body content stays readable.</w:t></w:r></w:p></w:body>` +
+      `</w:document>`;
+    // Genuinely malformed: a w14: attribute on a root that doesn't declare xmlns:w14,
+    // which triggers xmldom's NamespaceError on parse.
+    const malformedComments =
+      `<?xml version="1.0" encoding="UTF-8"?>` +
+      `<w:comments xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
+      `<w:comment w:id="0" w:author="X" w:initials="X" w:date="2026-01-01T00:00:00Z">` +
+      `<w:p w14:paraId="DEADBEEF"><w:r><w:t>boom</w:t></w:r></w:p>` +
+      `</w:comment></w:comments>`;
+    const opened = await openSession([], {
+      xml: documentXml,
+      extraFiles: { 'word/comments.xml': malformedComments },
+    });
+
+    const read = await readFile(opened.mgr, {
+      file_path: opened.inputPath,
+      comment_rendering: 'inline_markers',
+    });
+    assertSuccess(read, 'read_file');
+    // Body content still reaches the caller — the comment-load failure must not abort read_file.
+    const content = String(read.content);
+    expect(content).toContain('Body content stays readable');
+    // And the cause is surfaced rather than swallowed.
+    expect(typeof read.comment_load_error).toBe('string');
+    expect(String(read.comment_load_error)).toMatch(/NamespaceError|prefix/i);
+  });
+
   test('inline_markers renders multi-paragraph ranges only at the boundary paragraphs', async () => {
     const { lines } = await renderCommentFixture({
       bodyXml:


### PR DESCRIPTION
## Summary

- Closes #154. Real-world docx files (e.g., `Balanced_Employee_IP_Agreement.docx`) ship a pre-existing `word/comments.xml` whose `<w:comments>` root declares `xmlns:w` but **omits `xmlns:w14`**. After PR #153 (#151) made `add_comment` write `<w:p w14:paraId="…">` into that document, xmldom rejected the round-tripped XML with `NamespaceError: prefix is non-null and namespace is null`. `read_file.ts:380–394` silently swallowed the error, so both `[cm-start]/[cm-end]` markers AND the `#COMMENT` block disappeared with no signal — the user-visible regression in the Balanced IP smoke.
- `ensureCommentsRootNamespaces()` declares `xmlns:w14` and `xmlns:w15` on the comments / commentsExtended / people roots before any prefixed attribute is written. Idempotent — leaves existing declarations alone.
- `read_file` no longer swallows comment-load failures; it surfaces the cause via a new `comment_load_error` metadata field so future regressions can't disappear silently.

## Why it's not a marker-math bug

The issue conjectured that earlier `<b>`-style formatting wrappers shifted the renderer's offset math. Peer review (codex + gemini) traced the math through the simplified bold-prefix repro and confirmed it actually works on current source — `findTaggedTextInsertionIndex` correctly skips `<b>`/`</b>` tags and lands at the right index. The real failure was upstream: comments never reached the renderer because `getComments()` was throwing on the malformed-xmlns XML.

## Test plan

- [x] New regression at the primitive level: `addComment` against a `comments.xml` lacking `xmlns:w14` must round-trip through `parseXml` + `getComments` without throwing (`packages/docx-core/src/primitives/comments.test.ts`).
- [x] New end-to-end regression: `read_file(comment_rendering: 'inline_markers')` renders `[cm-start]/[cm-end]` markers AND the `#COMMENT` block when the base docx has the same shape as the Balanced IP fixture (`packages/docx-mcp/src/tools/read_file_comments.test.ts`).
- [x] Full `@usejunior/docx-core` suite: 1195 passed + 1 skip.
- [x] Full `@usejunior/docx-mcp` suite: 689 passed.
- [x] `npm run typecheck --workspaces --if-present` — clean.
- [x] `npm run lint --workspaces --if-present` — clean.
- [x] Real-doc smoke against `~/Downloads/Balanced_Employee_IP_Agreement.docx`: rendered toon line now shows `<b>Balanced Employee [cm-start:0]Intellectual[cm-end:0] Property Agreement 2.0.0</b>` plus the `#COMMENT` block.