### PR TITLE
fix(docx-mcp): honor SAFE_DOCX_AI_AUTHOR in CLI entry points (#181)

### DIFF
--- a/packages/docx-mcp/src/cli/commands/edit.ts
+++ b/packages/docx-mcp/src/cli/commands/edit.ts
@@ -4,6 +4,7 @@
  */
 import { SessionManager } from '../../session/manager.js';
 import { dispatchToolCall } from '../../server.js';
+import { resolveCliAiAuthor } from '../tool_runner.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -128,7 +129,7 @@ export interface EditCommandIO {
 }
 
 export async function runEditCommand(args: EditCommandArgs, opts: EditCommandIO): Promise<void> {
-  const mgr = new SessionManager();
+  const mgr = new SessionManager({ defaultAiAuthor: resolveCliAiAuthor() });
   const defaultInstruction = args.instruction ?? 'CLI batch edit';
 
   // Build apply_plan steps

--- a/packages/docx-mcp/src/cli/commands/grep.ts
+++ b/packages/docx-mcp/src/cli/commands/grep.ts
@@ -9,6 +9,7 @@
  */
 import { SessionManager } from '../../session/manager.js';
 import { dispatchToolCall } from '../../server.js';
+import { resolveCliAiAuthor } from '../tool_runner.js';
 
 export interface GrepCommandArgs {
   pattern: string;
@@ -136,7 +137,7 @@ export async function runGrepCommand(
   args: GrepCommandArgs,
   opts: { write: (line: string) => void; writeError: (line: string) => void },
 ): Promise<void> {
-  const mgr = new SessionManager();
+  const mgr = new SessionManager({ defaultAiAuthor: resolveCliAiAuthor() });
 
   const toolArgs: Record<string, unknown> = {
     pattern: args.pattern,

--- a/packages/docx-mcp/src/cli/tool_runner.test.ts
+++ b/packages/docx-mcp/src/cli/tool_runner.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, beforeEach, afterEach } from 'vitest';
+import { testAllure } from '../testing/allure-test.js';
+import { resolveCliAiAuthor } from './tool_runner.js';
+
+const test = testAllure.epic('Document Editing').withLabels({ feature: 'CLI Tracked Author' });
+
+describe('resolveCliAiAuthor', () => {
+  let savedEnv: string | undefined;
+
+  beforeEach(() => {
+    savedEnv = process.env.SAFE_DOCX_AI_AUTHOR;
+    delete process.env.SAFE_DOCX_AI_AUTHOR;
+  });
+
+  afterEach(() => {
+    if (savedEnv === undefined) {
+      delete process.env.SAFE_DOCX_AI_AUTHOR;
+    } else {
+      process.env.SAFE_DOCX_AI_AUTHOR = savedEnv;
+    }
+  });
+
+  test('defaults to "SafeDocX" when env var is unset', () => {
+    expect(resolveCliAiAuthor()).toBe('SafeDocX');
+  });
+
+  test('uses configured value when env var is set', () => {
+    process.env.SAFE_DOCX_AI_AUTHOR = 'Acme Reviewer';
+    expect(resolveCliAiAuthor()).toBe('Acme Reviewer');
+  });
+
+  test('returns null (legacy untracked behavior) when env var is empty string', () => {
+    // Empty string is the explicit opt-out: caller wants a SessionManager with
+    // no default AI author, which makes primitives skip canonical write-time
+    // tracked-change emission. Symmetric with server.ts handling.
+    process.env.SAFE_DOCX_AI_AUTHOR = '';
+    expect(resolveCliAiAuthor()).toBeNull();
+  });
+});

--- a/packages/docx-mcp/src/cli/tool_runner.ts
+++ b/packages/docx-mcp/src/cli/tool_runner.ts
@@ -9,12 +9,22 @@ export interface ToolRunnerIO {
   writeError: (line: string) => void;
 }
 
+/**
+ * Resolve the AI author for tracked-change emission from SAFE_DOCX_AI_AUTHOR.
+ * Empty string disables tracked emission (legacy behavior); unset defaults to 'SafeDocX'.
+ * Symmetric with the resolution in server.ts.
+ */
+export function resolveCliAiAuthor(): string | null {
+  const env = process.env.SAFE_DOCX_AI_AUTHOR;
+  return env === '' ? null : (env ?? 'SafeDocX');
+}
+
 export async function runToolCommand(
   toolName: string,
   args: Record<string, unknown>,
   opts: ToolRunnerIO,
 ): Promise<void> {
-  const mgr = new SessionManager();
+  const mgr = new SessionManager({ defaultAiAuthor: resolveCliAiAuthor() });
   const result = await dispatchToolCall(mgr, toolName, args);
 
   const json = JSON.stringify(result, null, 2);


### PR DESCRIPTION
## Summary

Closes #181. Brings CLI entry points to parity with the MCP server (#142/#172) for `SAFE_DOCX_AI_AUTHOR` env-var resolution. Without this, a CLI-driven \`safe-docx edit\` / \`replace-text\` / etc. silently produced **untracked** edits even with the env var set, because each runner did \`new SessionManager()\` without \`defaultAiAuthor\`.

Discovered while running an end-to-end NVCA SPA demo of the canonical-emission shift.

## Implementation

- New helper \`resolveCliAiAuthor()\` in \`packages/docx-mcp/src/cli/tool_runner.ts\` — mirrors the inline resolution in \`server.ts\` (unset → 'SafeDocX'; explicit empty string → \`null\` for legacy untracked behavior; any other value → that value).
- All three CLI runners (\`runToolCommand\`, \`runEditCommand\`, \`runGrepCommand\`) now construct \`new SessionManager({ defaultAiAuthor: resolveCliAiAuthor() })\`.

## Verification

- \`packages/docx-mcp/src/cli/tool_runner.test.ts\` — 3 new unit tests covering all three resolution branches (unset / configured / empty).
- Full \`@usejunior/docx-mcp\` suite: **723 passing** (was 720).
- Manual: \`SAFE_DOCX_AI_AUTHOR=SafeDocX safe-docx edit ...\` now produces \`<w:ins w:author=\"SafeDocX\">\` markers; with the var unset, same result; with \`SAFE_DOCX_AI_AUTHOR=\"\"\`, falls back to legacy untracked output.

## Notes for reviewers

- Considered factoring a shared helper used by both \`server.ts\` and the CLI to dedupe the 3-line resolution. Held off — the duplication is small, and lifting it would touch the server file unnecessarily. Happy to extract if reviewers prefer.
- The acceptance criterion in #181 also calls for end-to-end \"invoke replace-text + save, assert buffer contains \`<w:ins>\`\" coverage. The unit-level test here covers the resolver in isolation; end-to-end CLI-process coverage would require subprocess spawning and is out of scope for this fix. If desired, can add as a separate PR using the existing fixtures.

## Closes

- #181