### PR TITLE
fix(docx-mcp): warn when read_file budget is exceeded by a single node (closes #184)

### DIFF
--- a/packages/docx-mcp/src/tools/read_file.ts
+++ b/packages/docx-mcp/src/tools/read_file.ts
@@ -559,7 +559,11 @@ function renderToonWithBudget(
       break;
     }
     accumulated = candidateBase;
-    if (count === 0 && estimateTokens(accumulated) > budget) {
+    if (count === 0 && estimateTokens(candidate) > budget) {
+      // Use `candidate` (not `accumulated`) so endnotes-mode counts the
+      // endnotes block that's already part of node 1's first-page payload.
+      // This is substantive content, unlike the post-loop `#END_TABLE`
+      // structural closure that we deliberately exclude.
       firstNodeOverflow = true;
     }
     includedNodes.push(node);
@@ -691,8 +695,14 @@ function renderJsonWithBudget(
     if (count > 0 && Math.ceil(candidateChars / 4) > budget) break;
     items.push(serialized);
     totalChars = candidateChars;
-    if (count === 0 && Math.ceil(candidateChars / 4) > budget) {
-      firstNodeOverflow = true;
+    if (count === 0) {
+      // Final render is `[\n${items.join(',\n')}\n]` — 4 chars of framing,
+      // not 2. The pagination break check uses the same approximation as
+      // the loop, but the warning needs to reflect the true final length.
+      const finalChars = candidateChars + 2; // closing `\n]`
+      if (Math.ceil(finalChars / 4) > budget) {
+        firstNodeOverflow = true;
+      }
     }
     count++;
   }

--- a/packages/docx-mcp/src/tools/read_file.ts
+++ b/packages/docx-mcp/src/tools/read_file.ts
@@ -467,14 +467,8 @@ interface BudgetResult {
 
 const BUDGET_EXCEEDED_BY_FIRST_NODE_WARNING = 'budget_exceeded_by_first_node';
 
-function getBudgetWarnings(
-  content: string,
-  count: number,
-  budget: number,
-): string[] | undefined {
-  if (count !== 1) return undefined;
-  if (estimateTokens(content) <= budget) return undefined;
-  return [BUDGET_EXCEEDED_BY_FIRST_NODE_WARNING];
+function firstNodeOverflowWarnings(firstNodeOverflow: boolean): string[] | undefined {
+  return firstNodeOverflow ? [BUDGET_EXCEEDED_BY_FIRST_NODE_WARNING] : undefined;
 }
 
 function renderWithBudget(
@@ -504,6 +498,12 @@ function renderToonWithBudget(
   const includedNodes: DocumentViewNode[] = [];
   const useInlineMarkers = commentRendering === 'inline_markers';
   const commentMarkers = useInlineMarkers ? collectInlineCommentMarkers(enriched) : undefined;
+  // Captured the moment node 0 is admitted, BEFORE post-loop closures
+  // (#END_TABLE, endnotes block) inflate `accumulated`. Computing this
+  // after the loop produces false positives when row 1 of a table fits but
+  // we break at row 2 — the closing #END_TABLE bumps the final size over
+  // budget, but node 1 itself was fine.
+  let firstNodeOverflow = false;
 
   // Pre-scan: collect table marker info for #TABLE lines
   const tableInfo = collectTableMarkerInfo(enriched);
@@ -559,6 +559,9 @@ function renderToonWithBudget(
       break;
     }
     accumulated = candidateBase;
+    if (count === 0 && estimateTokens(accumulated) > budget) {
+      firstNodeOverflow = true;
+    }
     includedNodes.push(node);
     count++;
   }
@@ -578,7 +581,7 @@ function renderToonWithBudget(
   return {
     content: accumulated,
     count,
-    warnings: getBudgetWarnings(accumulated, count, budget),
+    warnings: firstNodeOverflowWarnings(firstNodeOverflow),
   };
 }
 
@@ -621,6 +624,8 @@ function renderSimpleWithBudget(
   let accumulated = headerLine;
   let count = 0;
   let currentTableIndex: number | null = null;
+  // Captured at admission of node 0; see comment in renderToonWithBudget.
+  let firstNodeOverflow = false;
 
   const tableInfo = collectTableMarkerInfo(enriched);
 
@@ -652,6 +657,9 @@ function renderSimpleWithBudget(
       break;
     }
     accumulated = candidate;
+    if (count === 0 && estimateTokens(accumulated) > budget) {
+      firstNodeOverflow = true;
+    }
     count++;
   }
 
@@ -662,7 +670,7 @@ function renderSimpleWithBudget(
   return {
     content: accumulated,
     count,
-    warnings: getBudgetWarnings(accumulated, count, budget),
+    warnings: firstNodeOverflowWarnings(firstNodeOverflow),
   };
 }
 
@@ -673,6 +681,8 @@ function renderJsonWithBudget(
   const items: string[] = [];
   let totalChars = 2; // for "[\n" and "]"
   let count = 0;
+  // Captured at admission of node 0; see comment in renderToonWithBudget.
+  let firstNodeOverflow = false;
 
   for (const node of enriched) {
     const serialized = JSON.stringify(node, null, 2);
@@ -681,6 +691,9 @@ function renderJsonWithBudget(
     if (count > 0 && Math.ceil(candidateChars / 4) > budget) break;
     items.push(serialized);
     totalChars = candidateChars;
+    if (count === 0 && Math.ceil(candidateChars / 4) > budget) {
+      firstNodeOverflow = true;
+    }
     count++;
   }
 
@@ -688,6 +701,6 @@ function renderJsonWithBudget(
   return {
     content,
     count,
-    warnings: getBudgetWarnings(content, count, budget),
+    warnings: firstNodeOverflowWarnings(firstNodeOverflow),
   };
 }

--- a/packages/docx-mcp/src/tools/read_file.ts
+++ b/packages/docx-mcp/src/tools/read_file.ts
@@ -427,10 +427,21 @@ export async function readFile(
       const budget = DEFAULT_CONTENT_TOKEN_BUDGET;
       const result =
         format === 'json'
-          ? renderJsonWithBudget(jsonNodes, DEFAULT_CONTENT_TOKEN_BUDGET)
+          ? renderJsonWithBudget(jsonNodes, budget)
           : renderWithBudget(enriched, format, budget, commentRendering);
       content = result.content;
       paragraphsReturned = result.count;
+
+      const paginationMeta = buildPaginationMeta(totalParagraphs, paragraphsReturned, startIdx);
+
+      return ok(mergeSessionResolutionMetadata({
+        file_path: manager.normalizePath(session.originalPath),
+        content,
+        total_paragraphs: totalParagraphs,
+        paragraphs_returned: paragraphsReturned,
+        ...(result.warnings ? { warnings: result.warnings } : {}),
+        ...paginationMeta,
+      }, metadata));
     }
 
     const paginationMeta = buildPaginationMeta(totalParagraphs, paragraphsReturned, startIdx);
@@ -451,6 +462,19 @@ export async function readFile(
 interface BudgetResult {
   content: string;
   count: number;
+  warnings?: string[];
+}
+
+const BUDGET_EXCEEDED_BY_FIRST_NODE_WARNING = 'budget_exceeded_by_first_node';
+
+function getBudgetWarnings(
+  content: string,
+  count: number,
+  budget: number,
+): string[] | undefined {
+  if (count !== 1) return undefined;
+  if (estimateTokens(content) <= budget) return undefined;
+  return [BUDGET_EXCEEDED_BY_FIRST_NODE_WARNING];
 }
 
 function renderWithBudget(
@@ -551,7 +575,11 @@ function renderToonWithBudget(
     }
   }
 
-  return { content: accumulated, count };
+  return {
+    content: accumulated,
+    count,
+    warnings: getBudgetWarnings(accumulated, count, budget),
+  };
 }
 
 function renderSimpleWithTableMarkers(
@@ -631,7 +659,11 @@ function renderSimpleWithBudget(
     accumulated += '\n#END_TABLE';
   }
 
-  return { content: accumulated, count };
+  return {
+    content: accumulated,
+    count,
+    warnings: getBudgetWarnings(accumulated, count, budget),
+  };
 }
 
 function renderJsonWithBudget(
@@ -653,5 +685,9 @@ function renderJsonWithBudget(
   }
 
   const content = '[\n' + items.join(',\n') + '\n]';
-  return { content, count };
+  return {
+    content,
+    count,
+    warnings: getBudgetWarnings(content, count, budget),
+  };
 }

--- a/packages/docx-mcp/src/tools/read_file_comments.test.ts
+++ b/packages/docx-mcp/src/tools/read_file_comments.test.ts
@@ -3,6 +3,7 @@ import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
 import { assertSuccess, openSession, registerCleanup } from '../testing/session-test-utils.js';
 import { addComment } from './add_comment.js';
 import { addFootnote } from './add_footnote.js';
+import { DEFAULT_CONTENT_TOKEN_BUDGET, estimateTokens } from './pagination.js';
 import { readFile } from './read_file.js';
 
 const test = testAllure.epic('Document Reading');
@@ -269,6 +270,33 @@ describe('read_file comment rendering', () => {
       const lines = toonLines(read.content);
       expect(findParagraphLine(lines, opened.firstParaId)).toContain('[^1]');
       expect(lines.some((line) => line.startsWith(`#COMMENT ${opened.firstParaId} `) && line.includes('Comment body.'))).toBe(true);
+    });
+  });
+
+  test('simple format warns when a single commented paragraph exceeds the budget', async ({ given, when, then }: AllureBddContext) => {
+    const oversizedComment = 'Comment payload '.repeat(6_000);
+    const opened = await given('a document with one paragraph', async () => openSession(['Clause text.']));
+
+    const read = await when('a very large comment is added and read_file renders simple format', async () => {
+      const comment = await addComment(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.firstParaId,
+        author: 'Alice',
+        text: oversizedComment,
+      });
+      assertSuccess(comment, 'add_comment');
+      const result = await readFile(opened.mgr, {
+        file_path: opened.inputPath,
+        format: 'simple',
+      });
+      assertSuccess(result, 'read_file');
+      return result;
+    });
+
+    await then('the response keeps the full comment payload and surfaces the first-node overflow warning', async () => {
+      expect(Number(read.paragraphs_returned)).toBe(1);
+      expect(estimateTokens(String(read.content))).toBeGreaterThan(DEFAULT_CONTENT_TOKEN_BUDGET);
+      expect(read.warnings).toEqual(['budget_exceeded_by_first_node']);
     });
   });
 

--- a/packages/docx-mcp/src/tools/read_file_footnotes.test.ts
+++ b/packages/docx-mcp/src/tools/read_file_footnotes.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { assertSuccess, openSession, registerCleanup } from '../testing/session-test-utils.js';
+import { addFootnote } from './add_footnote.js';
+import { DEFAULT_CONTENT_TOKEN_BUDGET, estimateTokens } from './pagination.js';
+import { readFile } from './read_file.js';
+
+const test = testAllure.epic('Document Reading');
+const FIRST_NODE_BUDGET_WARNING = 'budget_exceeded_by_first_node';
+
+describe('read_file footnotes', () => {
+  registerCleanup();
+
+  async function readWithOversizedFirstNode(params: {
+    format?: 'toon' | 'json';
+    limit?: number;
+  }) {
+    const opened = await openSession(['P'.repeat(80_000)]);
+
+    const note = await addFootnote(opened.mgr, {
+      file_path: opened.inputPath,
+      target_paragraph_id: opened.firstParaId,
+      text: 'Footnote body',
+    });
+    assertSuccess(note, 'add_footnote');
+
+    const read = await readFile(opened.mgr, {
+      file_path: opened.inputPath,
+      format: params.format,
+      limit: params.limit,
+    });
+    assertSuccess(read, 'read_file');
+
+    return { opened, read };
+  }
+
+  test('oversized first paragraph with a footnote emits a budget warning in toon format', async ({ when, then }: AllureBddContext) => {
+    const rendered = await when('read_file returns an oversized first paragraph that also carries a footnote marker in toon format', async () => {
+      return readWithOversizedFirstNode({ format: 'toon' });
+    });
+
+    await then('the response preserves the content and surfaces the structured warning', async () => {
+      expect(Number(rendered.read.paragraphs_returned)).toBe(1);
+      expect(estimateTokens(String(rendered.read.content))).toBeGreaterThan(DEFAULT_CONTENT_TOKEN_BUDGET);
+      expect(rendered.read.warnings).toEqual([FIRST_NODE_BUDGET_WARNING]);
+      expect(String(rendered.read.content)).toContain(rendered.opened.firstParaId);
+      expect(String(rendered.read.content)).toContain('[^1]');
+    });
+  });
+
+  test('oversized first paragraph with a footnote emits a budget warning in json format', async ({ when, then }: AllureBddContext) => {
+    const rendered = await when('read_file returns an oversized first paragraph that also carries a footnote marker in json format', async () => {
+      return readWithOversizedFirstNode({ format: 'json' });
+    });
+
+    await then('the JSON response remains intact and carries the warning', async () => {
+      expect(Number(rendered.read.paragraphs_returned)).toBe(1);
+      expect(estimateTokens(String(rendered.read.content))).toBeGreaterThan(DEFAULT_CONTENT_TOKEN_BUDGET);
+      expect(rendered.read.warnings).toEqual([FIRST_NODE_BUDGET_WARNING]);
+      const parsed = JSON.parse(String(rendered.read.content));
+      expect(parsed).toHaveLength(1);
+      expect(String(parsed[0].text)).toContain('[^1]');
+    });
+  });
+
+  test('explicit limit disables the first-node overflow warning even when the paragraph has a footnote', async ({ when, then }: AllureBddContext) => {
+    const rendered = await when('a caller provides an explicit limit for the oversized first-node read', async () => {
+      return readWithOversizedFirstNode({ format: 'toon', limit: 1 });
+    });
+
+    await then('the oversized content is returned without the budget warning', async () => {
+      expect(Number(rendered.read.paragraphs_returned)).toBe(1);
+      expect(estimateTokens(String(rendered.read.content))).toBeGreaterThan(DEFAULT_CONTENT_TOKEN_BUDGET);
+      expect(rendered.read.warnings).toBeUndefined();
+    });
+  });
+});

--- a/packages/docx-mcp/src/tools/read_file_pagination.test.ts
+++ b/packages/docx-mcp/src/tools/read_file_pagination.test.ts
@@ -485,6 +485,42 @@ describe('read_file pagination', () => {
     });
   });
 
+  test('count=1 + has_more table truncation does not falsely emit first-node warning', async ({ when, then }: AllureBddContext) => {
+    // Regression for a false-positive in the warning logic: when a multi-row
+    // table breaks at row N>1, the loop emits row 1 and then appends
+    // `#END_TABLE`, which can push the final accumulated content over the
+    // budget even though row 1 itself fit. The warning must reflect node 1's
+    // own size at admission time, not the post-loop closed-out content.
+    const cellLen = 55_864; // tuned to put row 1 just under, row 2 over (Codex repro)
+    const cellText = 'X'.repeat(cellLen);
+    const tableXml =
+      `<w:tbl>` +
+      `<w:tr><w:tc><w:p><w:r><w:t>${cellText}</w:t></w:r></w:p></w:tc></w:tr>` +
+      `<w:tr><w:tc><w:p><w:r><w:t>${cellText}</w:t></w:r></w:p></w:tc></w:tr>` +
+      `</w:tbl>`;
+    const xml =
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+      `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
+      `<w:body>${tableXml}</w:body></w:document>`;
+
+    const read = await when('a two-row table is read where row 1 fits but row 2 forces truncation', async () => {
+      const mgr = createTestSessionManager();
+      const { filePath } = await openSession([], { mgr, xml, trackOpenStep: false });
+      const result = await readFile(mgr, { file_path: filePath, format: 'toon' });
+      assertSuccess(result, 'read');
+      return result;
+    });
+
+    await then('exactly one row is returned, has_more=true, and no first-node warning fires', async () => {
+      expect(Number(read.paragraphs_returned)).toBe(1);
+      expect(read.has_more).toBe(true);
+      // Final content (with #END_TABLE) may exceed budget; that's the bug we're guarding against.
+      expect(estimateTokens(String(read.content))).toBeGreaterThan(DEFAULT_CONTENT_TOKEN_BUDGET);
+      // Node 1's admission size was UNDER budget, so the warning must not fire.
+      expect(read.warnings).toBeUndefined();
+    });
+  });
+
   // ── Table coverage: renderToonWithBudget with body text after table ───
 
   test('renderToonWithBudget handles transition from table to body text within budget', async ({ given, when, then }: AllureBddContext) => {

--- a/packages/docx-mcp/src/tools/read_file_pagination.test.ts
+++ b/packages/docx-mcp/src/tools/read_file_pagination.test.ts
@@ -521,6 +521,62 @@ describe('read_file pagination', () => {
     });
   });
 
+  test('endnotes-mode overflow on the first node fires the warning (substantive payload)', async ({ given, when, then }: AllureBddContext) => {
+    // Companion to the table false-positive guard: the endnotes block IS
+    // substantive payload (unlike the post-loop `#END_TABLE` structural
+    // closure), so when the first node's own comments push the page over
+    // budget, the warning must fire.
+    const opened = await given('a session with one short anchor paragraph', async () => {
+      const mgr = createTestSessionManager();
+      const result = await openSession(['Anchor.'], { mgr });
+      return result;
+    });
+
+    const read = await when('a huge comment is added and read in endnotes mode', async () => {
+      const { addComment } = await import('./add_comment.js');
+      const huge = 'Comment payload '.repeat(6000);
+      const c = await addComment(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.firstParaId,
+        author: 'Reviewer',
+        text: huge,
+      });
+      assertSuccess(c, 'add_comment');
+      const r = await readFile(opened.mgr, {
+        file_path: opened.inputPath,
+        comment_rendering: 'endnotes',
+      });
+      assertSuccess(r, 'read');
+      return r;
+    });
+
+    await then('the warning fires because endnotes content blew the budget', async () => {
+      expect(Number(read.paragraphs_returned)).toBe(1);
+      expect(estimateTokens(String(read.content))).toBeGreaterThan(DEFAULT_CONTENT_TOKEN_BUDGET);
+      expect(read.warnings).toEqual(['budget_exceeded_by_first_node']);
+    });
+  });
+
+  test('json single-paragraph at exact budget cutoff fires the warning (framing accounted for)', async ({ when, then }: AllureBddContext) => {
+    // The JSON budget check undercounted final framing by the closing `\n]`
+    // (2 chars). At an exact-boundary input the warning could be missed.
+    // Codex repro: paragraph length 18344 → 14001 tokens, no warning under
+    // the old check. Final fix accounts for the 4 chars of framing.
+    const read = await when('a single paragraph sized to land exactly at the budget cutoff is JSON-read', async () => {
+      const mgr = createTestSessionManager();
+      const { filePath } = await openSession(['P'.repeat(18344)], { mgr });
+      const r = await readFile(mgr, { file_path: filePath, format: 'json' });
+      assertSuccess(r, 'read');
+      return r;
+    });
+
+    await then('the warning fires because the rendered JSON exceeds the budget', async () => {
+      expect(Number(read.paragraphs_returned)).toBe(1);
+      expect(estimateTokens(String(read.content))).toBeGreaterThan(DEFAULT_CONTENT_TOKEN_BUDGET);
+      expect(read.warnings).toEqual(['budget_exceeded_by_first_node']);
+    });
+  });
+
   // ── Table coverage: renderToonWithBudget with body text after table ───
 
   test('renderToonWithBudget handles transition from table to body text within budget', async ({ given, when, then }: AllureBddContext) => {

--- a/packages/docx-mcp/src/tools/read_file_pagination.test.ts
+++ b/packages/docx-mcp/src/tools/read_file_pagination.test.ts
@@ -433,6 +433,58 @@ describe('read_file pagination', () => {
     });
   });
 
+  test('multi-node toon overflow does not emit the first-node budget warning', async ({ when, then }: AllureBddContext) => {
+    const readTwoRowTable = async (cellTextLength: number) => {
+      const cellText = 'X'.repeat(cellTextLength);
+      const tableXml =
+        `<w:tbl>` +
+        `<w:tr><w:tc><w:p><w:r><w:t>${cellText}</w:t></w:r></w:p></w:tc></w:tr>` +
+        `<w:tr><w:tc><w:p><w:r><w:t>${cellText}</w:t></w:r></w:p></w:tc></w:tr>` +
+        `</w:tbl>`;
+      const xml =
+        `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+        `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
+        `<w:body>${tableXml}</w:body></w:document>`;
+      const mgr = createTestSessionManager();
+      const { filePath } = await openSession([], { mgr, xml, trackOpenStep: false });
+      const result = await readFile(mgr, { file_path: filePath, format: 'toon' });
+      assertSuccess(result, 'read');
+      return result;
+    };
+
+    const read = await when('the largest two-row table that still emits both rows is read under the budgeted toon path', async () => {
+      let low = 25_000;
+      let high = 30_000;
+      let bestLength: number | undefined;
+      let bestRead: Awaited<ReturnType<typeof readTwoRowTable>> | undefined;
+
+      while (low <= high) {
+        const mid = Math.floor((low + high) / 2);
+        const current = await readTwoRowTable(mid);
+        if (Number(current.paragraphs_returned) === 2) {
+          bestLength = mid;
+          bestRead = current;
+          low = mid + 1;
+        } else {
+          high = mid - 1;
+        }
+      }
+
+      if (!bestRead || bestLength == null) {
+        throw new Error('Failed to find a two-row table budget boundary for read_file.');
+      }
+
+      return { bestLength, bestRead };
+    });
+
+    await then('the multi-node overflow stays unlabeled even when the final content ends slightly above budget', async () => {
+      expect(Number(read.bestRead.paragraphs_returned)).toBe(2);
+      expect(estimateTokens(String(read.bestRead.content))).toBeGreaterThan(DEFAULT_CONTENT_TOKEN_BUDGET);
+      expect(read.bestRead.warnings).toBeUndefined();
+      expect(read.bestLength).toBeGreaterThan(25_000);
+    });
+  });
+
   // ── Table coverage: renderToonWithBudget with body text after table ───
 
   test('renderToonWithBudget handles transition from table to body text within budget', async ({ given, when, then }: AllureBddContext) => {


### PR DESCRIPTION
## Summary

`read_file` silently returned oversized responses when a single paragraph (or its inline footnote body, post-#158) was big enough to blow the ~14k token budget on its own. This adds a structured `warnings: ['budget_exceeded_by_first_node']` field so callers can detect the overflow and react.

## Implementation

- New `getBudgetWarnings(content, count, budget)` helper applied uniformly across the three budget renderers (`renderJsonWithBudget`, `renderToonWithBudget`, `renderSimpleWithBudget`).
- Warning fires only when exactly one node was emitted AND its rendered content exceeds the budget. Multi-node overflow during normal pagination does NOT trigger the warning — that's expected behavior, not a single-node overflow.
- Warning does NOT fire when explicit `limit`/`offset`/`node_ids` deactivate the budget (the user opted out of pagination semantics).
- Response shape change is additive: `warnings?: string[]`. Existing consumers that don't read the field are unaffected.

## Verification

- [x] `npm run build -w @usejunior/docx-mcp` — clean
- [x] `npm run test -w @usejunior/docx-mcp` — 728 tests pass (73 files)
- [x] `read_file_footnotes.test.ts`, `read_file_pagination.test.ts`, `read_file_comments.test.ts` — 57 tests pass
- [x] `npm run check:tool-docs` — clean (no schema changes; response-shape only)
- [ ] Peer review (Gemini + Codex) — pending; will be appended below

## Out of scope (deferred)

- **Option 1 (truncation)** rejected: silent content loss is the failure mode this work addresses, not the cure.
- **Option 3 (`max_tokens` parameter)** deferred: nice-to-have, but adding the warning gives callers enough signal without a new knob. Can layer in later.

## Notes

- The Codex implementer noted that the issue text references inline footnote bodies (#158) which haven't merged to `main` yet. The warning contract is exercised against giant paragraphs instead — same code path, same outcome, since the budget renderers don't care what's filling the bytes.

## Closes

- #184