### PR TITLE
fix(docx-core): suppress non-sectional false-positive headings (closes #187)

### DIFF
--- a/packages/docx-core/src/primitives/document_view.ts
+++ b/packages/docx-core/src/primitives/document_view.ts
@@ -364,6 +364,48 @@ function detectTitleCapsCentered(params: {
   return { raw_text: trimmed, formatting };
 }
 
+const SIGNATURE_LABEL_LINE_RE = /^[A-Z][a-zA-Z ]{0,28}:\s*$/;
+const SIGNATURE_LABEL_PREFIX_RE = /^[A-Z]+(?::\s|$)/;
+
+function isSignatureClusterLabel(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed) return false;
+  return SIGNATURE_LABEL_LINE_RE.test(trimmed) || SIGNATURE_LABEL_PREFIX_RE.test(trimmed);
+}
+
+function suppressSignatureClusters(nodes: DocumentViewNode[]): void {
+  if (nodes.length < 4) return;
+
+  const prefixMatches = new Array<number>(nodes.length + 1).fill(0);
+  for (let idx = 0; idx < nodes.length; idx++) {
+    prefixMatches[idx + 1] = prefixMatches[idx]! + (isSignatureClusterLabel(nodes[idx]!.clean_text) ? 1 : 0);
+  }
+
+  const coverage = new Array<number>(nodes.length + 1).fill(0);
+  for (let start = 0; start <= nodes.length - 4; start++) {
+    for (let end = start + 3; end < nodes.length; end++) {
+      const runLength = end - start + 1;
+      const matchCount = prefixMatches[end + 1]! - prefixMatches[start]!;
+      if ((matchCount * 4) < (runLength * 3)) continue;
+      coverage[start]! += 1;
+      coverage[end + 1]! -= 1;
+    }
+  }
+
+  let activeClusters = 0;
+  for (let idx = 0; idx < nodes.length; idx++) {
+    activeClusters += coverage[idx]!;
+    if (activeClusters <= 0) continue;
+
+    const node = nodes[idx]!;
+    node.header = '';
+    node.header_formatting = null;
+    node.list_metadata.header_text = null;
+    node.list_metadata.header_style = null;
+    node.list_metadata.header_formatting = null;
+  }
+}
+
 function inferSemanticName(params: {
   fp: FormattingFingerprint;
   nodes: DocumentViewNode[];
@@ -1289,7 +1331,7 @@ export function buildNodesForDocumentView(params: {
       }
     }
 
-    if (!headerText) {
+    if (!headerText && !tableContext) {
       const fallback = extractHeaderInfo(cleanTextNoLabel);
       headerText = fallback.header_text;
       headerStyle = fallback.header_style;
@@ -1448,6 +1490,8 @@ export function buildNodesForDocumentView(params: {
     if (tableContext) node.table_context = tableContext;
     nodes.push(node);
   }
+
+  suppressSignatureClusters(nodes);
 
   const styles = discoverStyles(nodes);
   for (const n of nodes) {

--- a/packages/docx-core/src/primitives/document_view.ts
+++ b/packages/docx-core/src/primitives/document_view.ts
@@ -398,6 +398,11 @@ function suppressSignatureClusters(nodes: DocumentViewNode[]): void {
     if (activeClusters <= 0) continue;
 
     const node = nodes[idx]!;
+    // Only suppress nodes that themselves match a signature-label regex.
+    // The cluster window is the density signal that authorizes suppression;
+    // a real Heading1 paragraph immediately adjacent to a signature block
+    // (covered by the same window) must not be erased.
+    if (!isSignatureClusterLabel(node.clean_text)) continue;
     node.header = '';
     node.header_formatting = null;
     node.list_metadata.header_text = null;
@@ -1293,7 +1298,13 @@ export function buildNodesForDocumentView(params: {
     let headerCharCount = 0;
 
     try {
-      const hdr = detectRunInHeader({ paragraph: p, paragraphPPr: paraPPr ?? null, paragraphStyleId: paraFmt.styleId, styles: stylesModel });
+      // Skip in-table run-in header detection — table cells are key/value
+      // layout and a bold prefix is a label, not a section heading.
+      // Mirrors the !tableContext gates on detectTitleCapsCentered and
+      // extractHeaderInfo below.
+      const hdr = tableContext
+        ? null
+        : detectRunInHeader({ paragraph: p, paragraphPPr: paraPPr ?? null, paragraphStyleId: paraFmt.styleId, styles: stylesModel });
       if (hdr) {
         headerText = hdr.raw_text.replace(/[.:\-]+$/g, '');
         headerStyle = 'run_in_header';

--- a/packages/docx-core/src/primitives/document_view.ts
+++ b/packages/docx-core/src/primitives/document_view.ts
@@ -398,16 +398,12 @@ function suppressSignatureClusters(nodes: DocumentViewNode[]): void {
     if (activeClusters <= 0) continue;
 
     const node = nodes[idx]!;
-    // Inside a cluster window, suppress every node EXCEPT real Word-styled
-    // headings (Heading1-6). The density signal authorizes suppression of
-    // everything in the window; only an explicit Heading style is strong
-    // enough to overrule it. This handles both:
-    //   - Adjacent real heading: `By:`/`Name:`/`Title:`/`Address:`/`Product[Heading1]`
-    //     → labels suppressed, Heading1 preserved.
-    //   - Dense signature block: `ACME CORP`/`By:`/`Name:`/`Title:`
-    //     → ACME CORP suppressed (only heuristic title_bare, no Word style).
-    const styleId = node.paragraph_style_id ?? '';
-    if (/^Heading[1-6]$/.test(styleId)) continue;
+    // The density gate authorizes us to clear *labels* inside the window;
+    // non-label neighbors (real headings, body text) keep their detected
+    // heading metadata regardless of paragraph style. This avoids erasing
+    // an adjacent section heading or body line that happens to fall inside
+    // a window meeting the density threshold.
+    if (!isSignatureClusterLabel(node.clean_text)) continue;
     node.header = '';
     node.header_formatting = null;
     node.list_metadata.header_text = null;

--- a/packages/docx-core/src/primitives/document_view.ts
+++ b/packages/docx-core/src/primitives/document_view.ts
@@ -398,11 +398,16 @@ function suppressSignatureClusters(nodes: DocumentViewNode[]): void {
     if (activeClusters <= 0) continue;
 
     const node = nodes[idx]!;
-    // Only suppress nodes that themselves match a signature-label regex.
-    // The cluster window is the density signal that authorizes suppression;
-    // a real Heading1 paragraph immediately adjacent to a signature block
-    // (covered by the same window) must not be erased.
-    if (!isSignatureClusterLabel(node.clean_text)) continue;
+    // Inside a cluster window, suppress every node EXCEPT real Word-styled
+    // headings (Heading1-6). The density signal authorizes suppression of
+    // everything in the window; only an explicit Heading style is strong
+    // enough to overrule it. This handles both:
+    //   - Adjacent real heading: `By:`/`Name:`/`Title:`/`Address:`/`Product[Heading1]`
+    //     → labels suppressed, Heading1 preserved.
+    //   - Dense signature block: `ACME CORP`/`By:`/`Name:`/`Title:`
+    //     → ACME CORP suppressed (only heuristic title_bare, no Word style).
+    const styleId = node.paragraph_style_id ?? '';
+    if (/^Heading[1-6]$/.test(styleId)) continue;
     node.header = '';
     node.header_formatting = null;
     node.list_metadata.header_text = null;

--- a/packages/docx-core/test-primitives/document_view.branch.test.ts
+++ b/packages/docx-core/test-primitives/document_view.branch.test.ts
@@ -415,6 +415,99 @@ describe('document_view branch coverage', () => {
     });
   });
 
+  test('short standalone table-cell paragraphs do not classify as bare headers (#187)', async ({ given, when, then, and }: AllureBddContext) => {
+    let bodyXml: string;
+    let paragraphs: Array<{ id: string; p: Element; tableContext?: {
+      table_id: string;
+      table_index: number;
+      row_index: number;
+      col_index: number;
+      col_header: string;
+      total_rows: number;
+      total_cols: number;
+      is_header_row: boolean;
+      para_in_cell: number;
+      cell_para_count: number;
+    } }>;
+    let nodes: ReturnType<typeof buildNodesForDocumentView>['nodes'];
+
+    await given('a short standalone paragraph in a table cell context', async () => {
+      bodyXml = `<w:p><w:r><w:t>Purpose</w:t></w:r></w:p>`;
+      const [paragraph] = makeParagraphs(bodyXml!);
+      paragraphs = [{
+        ...paragraph!,
+        tableContext: {
+          table_id: '_tbl_0',
+          table_index: 0,
+          row_index: 1,
+          col_index: 0,
+          col_header: 'Section',
+          total_rows: 2,
+          total_cols: 1,
+          is_header_row: false,
+          para_in_cell: 0,
+          cell_para_count: 1,
+        },
+      }];
+    });
+
+    await when('buildNodesForDocumentView is called', async () => {
+      ({ nodes } = buildNodesForDocumentView({
+        paragraphs: paragraphs!,
+        stylesXml: null,
+        numberingXml: null,
+        include_semantic_tags: false,
+        show_formatting: false,
+      }));
+    });
+
+    await then('the table-cell paragraph does not emit header metadata', async () => {
+      expect(nodes).toHaveLength(1);
+      expect(nodes[0]!.list_metadata.header_text).toBeNull();
+      expect(nodes[0]!.list_metadata.header_style).toBeNull();
+    });
+
+    await and('table_context is preserved on the node', async () => {
+      expect(nodes[0]!.table_context?.table_id).toBe('_tbl_0');
+    });
+  });
+
+  test('signature-label clusters are suppressed in a post-pass (#187)', async ({ given, when, then, and }: AllureBddContext) => {
+    let bodyXml: string;
+    let nodes: ReturnType<typeof buildNodesForDocumentView>['nodes'];
+
+    await given('five consecutive signature-label paragraphs', async () => {
+      const labels = ['By:', 'Name:', 'Title:', 'Address:', 'Email:'];
+      bodyXml = labels.map((label) => `<w:p><w:r><w:t>${label}</w:t></w:r></w:p>`).join('');
+    });
+
+    await when('buildNodesForDocumentView is called', async () => {
+      ({ nodes } = buildNodesForDocumentView({
+        paragraphs: makeParagraphs(bodyXml!),
+        stylesXml: null,
+        numberingXml: null,
+        include_semantic_tags: false,
+        show_formatting: false,
+      }));
+    });
+
+    await then('every paragraph in the cluster has null header metadata', async () => {
+      expect(nodes).toHaveLength(5);
+      for (const node of nodes) {
+        expect(node.list_metadata.header_text).toBeNull();
+        expect(node.list_metadata.header_style).toBeNull();
+        expect(node.list_metadata.header_formatting).toBeNull();
+      }
+    });
+
+    await and('the duplicated header fields are cleared for rendering consistency', async () => {
+      for (const node of nodes) {
+        expect(node.header).toBe('');
+        expect(node.header_formatting).toBeNull();
+      }
+    });
+  });
+
   test('detectRunInHeader rejects whole-paragraph bold blocks (#157)', async ({ given, when, then, and }: AllureBddContext) => {
     let bodyXml: string;
     let nodes: ReturnType<typeof buildNodesForDocumentView>['nodes'];

--- a/packages/docx-core/test-primitives/document_view.branch.test.ts
+++ b/packages/docx-core/test-primitives/document_view.branch.test.ts
@@ -548,6 +548,41 @@ describe('document_view branch coverage', () => {
     });
   });
 
+  test('dense signature block with company-name lead-in is fully suppressed (#187)', async ({ given, when, then }: AllureBddContext) => {
+    let bodyXml: string;
+    let nodes: ReturnType<typeof buildNodesForDocumentView>['nodes'];
+
+    await given('a company-name paragraph followed by signature-label paragraphs', async () => {
+      // Common shape in NVCA-style fixtures: `ACME CORP` (no Word heading
+      // style — only the heuristic title_bare from the short-paragraph
+      // fallback) leads a signature block. Everything in the window without
+      // a real Heading1-6 style should be suppressed.
+      bodyXml =
+        `<w:p><w:r><w:t>ACME CORP</w:t></w:r></w:p>` +
+        `<w:p><w:r><w:t>By:</w:t></w:r></w:p>` +
+        `<w:p><w:r><w:t>Name:</w:t></w:r></w:p>` +
+        `<w:p><w:r><w:t>Title:</w:t></w:r></w:p>`;
+    });
+
+    await when('buildNodesForDocumentView is called', async () => {
+      ({ nodes } = buildNodesForDocumentView({
+        paragraphs: makeParagraphs(bodyXml!),
+        stylesXml: null,
+        numberingXml: null,
+        include_semantic_tags: false,
+        show_formatting: false,
+      }));
+    });
+
+    await then('every paragraph in the block has null header metadata', async () => {
+      expect(nodes).toHaveLength(4);
+      for (const node of nodes) {
+        expect(node.list_metadata.header_style).toBeNull();
+        expect(node.list_metadata.header_text).toBeNull();
+      }
+    });
+  });
+
   test('real heading immediately after a signature cluster is preserved (#187)', async ({ given, when, then, and }: AllureBddContext) => {
     let bodyXml: string;
     let nodes: ReturnType<typeof buildNodesForDocumentView>['nodes'];

--- a/packages/docx-core/test-primitives/document_view.branch.test.ts
+++ b/packages/docx-core/test-primitives/document_view.branch.test.ts
@@ -548,15 +548,16 @@ describe('document_view branch coverage', () => {
     });
   });
 
-  test('dense signature block with company-name lead-in is fully suppressed (#187)', async ({ given, when, then }: AllureBddContext) => {
+  test('signature cluster does not erase a non-label company-name lead-in (#187)', async ({ given, when, then, and }: AllureBddContext) => {
     let bodyXml: string;
     let nodes: ReturnType<typeof buildNodesForDocumentView>['nodes'];
 
-    await given('a company-name paragraph followed by signature-label paragraphs', async () => {
-      // Common shape in NVCA-style fixtures: `ACME CORP` (no Word heading
-      // style — only the heuristic title_bare from the short-paragraph
-      // fallback) leads a signature block. Everything in the window without
-      // a real Heading1-6 style should be suppressed.
+    await given('a non-label company-name paragraph followed by signature-label paragraphs', async () => {
+      // `ACME CORP` does not match either signature-label regex (no trailing
+      // colon, multi-word all-caps). The density gate fires for the
+      // window, but suppression must NOT mutate non-label paragraphs.
+      // The real NVCA shape `COMPANY: [Insert Company Name]` matches the
+      // prefix regex and is exercised by the test above.
       bodyXml =
         `<w:p><w:r><w:t>ACME CORP</w:t></w:r></w:p>` +
         `<w:p><w:r><w:t>By:</w:t></w:r></w:p>` +
@@ -574,7 +575,132 @@ describe('document_view branch coverage', () => {
       }));
     });
 
-    await then('every paragraph in the block has null header metadata', async () => {
+    await then('the three label paragraphs are suppressed', async () => {
+      expect(nodes).toHaveLength(4);
+      for (let i = 1; i < 4; i++) {
+        expect(nodes[i]!.list_metadata.header_style).toBeNull();
+        expect(nodes[i]!.list_metadata.header_text).toBeNull();
+      }
+    });
+
+    await and('the non-label lead-in keeps its heuristic classification', async () => {
+      expect(nodes[0]!.clean_text).toBe('ACME CORP');
+      expect(nodes[0]!.list_metadata.header_text).not.toBeNull();
+    });
+  });
+
+  test('signature cluster preserves a non-label body neighbor (#187, regression for over-suppression)', async ({ given, when, then, and }: AllureBddContext) => {
+    let bodyXml: string;
+    let nodes: ReturnType<typeof buildNodesForDocumentView>['nodes'];
+
+    await given('four signature labels followed by an unstyled short paragraph', async () => {
+      // `Product` would independently classify as title_bare via the
+      // short-paragraph fallback. Earlier revisions of suppressSignatureClusters
+      // erased every paragraph inside a qualifying window, which would have
+      // cleared `Product` here. The fix narrows suppression to label
+      // paragraphs only.
+      bodyXml =
+        `<w:p><w:r><w:t>By:</w:t></w:r></w:p>` +
+        `<w:p><w:r><w:t>Name:</w:t></w:r></w:p>` +
+        `<w:p><w:r><w:t>Title:</w:t></w:r></w:p>` +
+        `<w:p><w:r><w:t>Address:</w:t></w:r></w:p>` +
+        `<w:p><w:r><w:t>Product</w:t></w:r></w:p>`;
+    });
+
+    await when('buildNodesForDocumentView is called', async () => {
+      ({ nodes } = buildNodesForDocumentView({
+        paragraphs: makeParagraphs(bodyXml!),
+        stylesXml: null,
+        numberingXml: null,
+        include_semantic_tags: false,
+        show_formatting: false,
+      }));
+    });
+
+    await then('the four signature labels are suppressed', async () => {
+      expect(nodes).toHaveLength(5);
+      for (let i = 0; i < 4; i++) {
+        expect(nodes[i]!.list_metadata.header_style).toBeNull();
+      }
+    });
+
+    await and('the non-label neighbor keeps its heuristic header_text', async () => {
+      expect(nodes[4]!.clean_text).toBe('Product');
+      expect(nodes[4]!.list_metadata.header_text).not.toBeNull();
+    });
+  });
+
+  test('signature cluster preserves custom-style headings (Heading7 / Title / Subtitle / Article5L1) (#187)', async ({ given, when, then, and }: AllureBddContext) => {
+    let bodyXml: string;
+    let nodes: ReturnType<typeof buildNodesForDocumentView>['nodes'];
+
+    await given('four signature labels followed by four non-Heading1-6 styled headings', async () => {
+      // The fixture corpus uses heading-ish styles beyond Heading1-6
+      // (Heading7-9, Title, Subtitle, Article5L1-8). They are not signature
+      // labels, so they must survive suppression even though they sit
+      // adjacent to a label-dense window.
+      bodyXml =
+        `<w:p><w:r><w:t>By:</w:t></w:r></w:p>` +
+        `<w:p><w:r><w:t>Name:</w:t></w:r></w:p>` +
+        `<w:p><w:r><w:t>Title:</w:t></w:r></w:p>` +
+        `<w:p><w:r><w:t>Address:</w:t></w:r></w:p>` +
+        `<w:p><w:pPr><w:pStyle w:val="Heading7"/></w:pPr><w:r><w:t>Execution</w:t></w:r></w:p>` +
+        `<w:p><w:pPr><w:pStyle w:val="Title"/></w:pPr><w:r><w:t>Schedule A</w:t></w:r></w:p>` +
+        `<w:p><w:pPr><w:pStyle w:val="Subtitle"/></w:pPr><w:r><w:t>Preliminary</w:t></w:r></w:p>` +
+        `<w:p><w:pPr><w:pStyle w:val="Article5L1"/></w:pPr><w:r><w:t>Definitions</w:t></w:r></w:p>`;
+    });
+
+    await when('buildNodesForDocumentView is called', async () => {
+      ({ nodes } = buildNodesForDocumentView({
+        paragraphs: makeParagraphs(bodyXml!),
+        stylesXml: null,
+        numberingXml: null,
+        include_semantic_tags: false,
+        show_formatting: false,
+      }));
+    });
+
+    await then('the four signature labels are suppressed', async () => {
+      expect(nodes).toHaveLength(8);
+      for (let i = 0; i < 4; i++) {
+        expect(nodes[i]!.list_metadata.header_style).toBeNull();
+      }
+    });
+
+    await and('each custom-styled heading keeps its detected header_text', async () => {
+      for (let i = 4; i < 8; i++) {
+        expect(nodes[i]!.list_metadata.header_text).not.toBeNull();
+      }
+    });
+  });
+
+  test('consecutive WHEREAS recitals are not classified as signature-cluster labels (#187 regression)', async ({ given, when, then }: AllureBddContext) => {
+    let bodyXml: string;
+    let nodes: ReturnType<typeof buildNodesForDocumentView>['nodes'];
+
+    await given('four consecutive WHEREAS recital paragraphs', async () => {
+      // WHEREAS clauses use a comma after the lead-in word, not a colon,
+      // so they do not match SIGNATURE_LABEL_PREFIX_RE. They are also
+      // long, so they do not pick up title_bare/title_with_colon. Lock
+      // in that suppression does not touch them.
+      bodyXml =
+        `<w:p><w:r><w:t>WHEREAS, the parties desire to enter into this Agreement on the terms set forth herein.</w:t></w:r></w:p>` +
+        `<w:p><w:r><w:t>WHEREAS, each party has the requisite authority to execute and deliver this Agreement.</w:t></w:r></w:p>` +
+        `<w:p><w:r><w:t>WHEREAS, the parties acknowledge the mutual covenants and agreements stated below.</w:t></w:r></w:p>` +
+        `<w:p><w:r><w:t>WHEREAS, this Agreement is intended to be legally binding and enforceable.</w:t></w:r></w:p>`;
+    });
+
+    await when('buildNodesForDocumentView is called', async () => {
+      ({ nodes } = buildNodesForDocumentView({
+        paragraphs: makeParagraphs(bodyXml!),
+        stylesXml: null,
+        numberingXml: null,
+        include_semantic_tags: false,
+        show_formatting: false,
+      }));
+    });
+
+    await then('no WHEREAS recital is mutated by signature-cluster suppression', async () => {
       expect(nodes).toHaveLength(4);
       for (const node of nodes) {
         expect(node.list_metadata.header_style).toBeNull();

--- a/packages/docx-core/test-primitives/document_view.branch.test.ts
+++ b/packages/docx-core/test-primitives/document_view.branch.test.ts
@@ -508,6 +508,87 @@ describe('document_view branch coverage', () => {
     });
   });
 
+  test('all-caps signature-label cluster (COMPANY: / PURCHASER:) is suppressed (#187)', async ({ given, when, then }: AllureBddContext) => {
+    let bodyXml: string;
+    let nodes: ReturnType<typeof buildNodesForDocumentView>['nodes'];
+
+    await given('an NVCA-style all-caps signature cluster', async () => {
+      // Mirrors the NVCA SPA paragraphs 312-321 shape: alternating
+      // PARTY-name lines with COMPANY:/PURCHASER: prefix and By:/Name:/Title: rows.
+      const labels = [
+        'COMPANY: [Insert Company Name]',
+        'By:',
+        'Name:',
+        'Title:',
+        'Address:',
+        'PURCHASER: [Insert Investor Name]',
+        'By:',
+        'Name:',
+        'Title:',
+      ];
+      bodyXml = labels.map((label) => `<w:p><w:r><w:t>${label}</w:t></w:r></w:p>`).join('');
+    });
+
+    await when('buildNodesForDocumentView is called', async () => {
+      ({ nodes } = buildNodesForDocumentView({
+        paragraphs: makeParagraphs(bodyXml!),
+        stylesXml: null,
+        numberingXml: null,
+        include_semantic_tags: false,
+        show_formatting: false,
+      }));
+    });
+
+    await then('every paragraph in the all-caps cluster has null header metadata', async () => {
+      expect(nodes).toHaveLength(9);
+      for (const node of nodes) {
+        expect(node.list_metadata.header_style).toBeNull();
+        expect(node.list_metadata.header_text).toBeNull();
+      }
+    });
+  });
+
+  test('real heading immediately after a signature cluster is preserved (#187)', async ({ given, when, then, and }: AllureBddContext) => {
+    let bodyXml: string;
+    let nodes: ReturnType<typeof buildNodesForDocumentView>['nodes'];
+
+    await given('four signature labels followed by a Heading1-styled section title', async () => {
+      // Boundary case: signature page followed by the next section heading.
+      // The cluster window covering all 5 paragraphs has 4/5 = 80% match,
+      // which would have erased the Heading1 paragraph under the original
+      // "any covering window" semantics.
+      bodyXml =
+        `<w:p><w:r><w:t>By:</w:t></w:r></w:p>` +
+        `<w:p><w:r><w:t>Name:</w:t></w:r></w:p>` +
+        `<w:p><w:r><w:t>Title:</w:t></w:r></w:p>` +
+        `<w:p><w:r><w:t>Address:</w:t></w:r></w:p>` +
+        `<w:p><w:pPr><w:pStyle w:val="Heading1"/></w:pPr><w:r><w:t>Product</w:t></w:r></w:p>`;
+    });
+
+    await when('buildNodesForDocumentView is called', async () => {
+      ({ nodes } = buildNodesForDocumentView({
+        paragraphs: makeParagraphs(bodyXml!),
+        stylesXml: null,
+        numberingXml: null,
+        include_semantic_tags: false,
+        show_formatting: false,
+      }));
+    });
+
+    await then('the four signature labels are suppressed', async () => {
+      expect(nodes).toHaveLength(5);
+      for (let i = 0; i < 4; i++) {
+        expect(nodes[i]!.list_metadata.header_style).toBeNull();
+      }
+    });
+
+    await and('the adjacent Heading1 paragraph still emits a header_text', async () => {
+      const heading = nodes[4]!;
+      expect(heading.clean_text).toBe('Product');
+      expect(heading.list_metadata.header_text).not.toBeNull();
+    });
+  });
+
   test('detectRunInHeader rejects whole-paragraph bold blocks (#157)', async ({ given, when, then, and }: AllureBddContext) => {
     let bodyXml: string;
     let nodes: ReturnType<typeof buildNodesForDocumentView>['nodes'];

--- a/packages/docx-mcp/src/tools/nvca_spa_regression.test.ts
+++ b/packages/docx-mcp/src/tools/nvca_spa_regression.test.ts
@@ -30,6 +30,7 @@ import { parseOutputXml } from '../testing/session-test-utils.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const SOURCE = path.resolve(__dirname, '../../../../tests/test_documents/nvca-regression/source.docx');
+const BONTERMS_NDA_SOURCE = path.resolve(__dirname, '../../../../tests/test_documents/open-agreements/bonterms-mutual-nda.docx');
 
 const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 
@@ -51,12 +52,16 @@ async function makeTempDir(prefix = 'nvca-spa-'): Promise<string> {
   return dir;
 }
 
-async function openSPA(): Promise<{ mgr: SessionManager; sid: string; filePath: string }> {
+async function openFixture(source: string): Promise<{ mgr: SessionManager; sid: string; filePath: string }> {
   const mgr = createMgr();
-  const openRes = await openDocument(mgr, { file_path: SOURCE });
+  const openRes = await openDocument(mgr, { file_path: source });
   expect(openRes.success).toBe(true);
-  const filePath = (openRes.file_path as string) ?? SOURCE;
+  const filePath = (openRes.file_path as string) ?? source;
   return { mgr, sid: filePath, filePath };
+}
+
+async function openSPA(): Promise<{ mgr: SessionManager; sid: string; filePath: string }> {
+  return openFixture(SOURCE);
 }
 
 function assertSuccess(result: { success: boolean }, label: string): void {
@@ -481,6 +486,70 @@ describe('NVCA SPA regression: heading detection (#157)', () => {
     await and('list_metadata.header_style is title_caps_centered', async () => {
       expect(parsed[0]!.list_metadata.header_style).toBe('title_caps_centered');
       expect(parsed[0]!.list_metadata.header_text).toContain('PREFERRED STOCK PURCHASE AGREEMENT');
+    });
+  });
+
+  test('Bonterms NDA table-cell paragraphs do not emit heading styles (#187)', async ({ given, when, then, and }: AllureBddContext) => {
+    let mgr: ReturnType<typeof createMgr>;
+    let filePath: string;
+    let parsed: Array<{
+      id: string;
+      table_context?: Record<string, unknown>;
+      list_metadata: { header_style: string | null };
+    }>;
+
+    await given('the Bonterms NDA fixture is open in a new session', async () => {
+      ({ mgr, filePath } = await openFixture(BONTERMS_NDA_SOURCE));
+    });
+
+    await when('read_file is called with format=json for the full document', async () => {
+      const res = await readFile(mgr, {
+        file_path: filePath,
+        format: 'json',
+      });
+      assertSuccess(res, 'read_file bonterms json');
+      parsed = JSON.parse(res.content as string);
+    });
+
+    await then('the fixture includes table-context paragraphs', async () => {
+      expect(parsed.some((node) => Boolean(node.table_context))).toBe(true);
+    });
+
+    await and('every table-context paragraph has a null header style', async () => {
+      const tableNodes = parsed.filter((node) => Boolean(node.table_context));
+      expect(tableNodes.every((node) => node.list_metadata.header_style === null)).toBe(true);
+    });
+  });
+
+  test('NVCA SPA signature-block paragraphs 312-321 have null header styles (#187)', async ({ given, when, then, and }: AllureBddContext) => {
+    let mgr: ReturnType<typeof createMgr>;
+    let filePath: string;
+    let parsed: Array<{
+      clean_text: string;
+      list_metadata: { header_style: string | null };
+    }>;
+
+    await given('the NVCA SPA source document is open in a new session', async () => {
+      ({ mgr, filePath } = await openSPA());
+    });
+
+    await when('read_file is called for paragraphs 312 through 321', async () => {
+      const res = await readFile(mgr, {
+        file_path: filePath,
+        format: 'json',
+        offset: 312,
+        limit: 10,
+      });
+      assertSuccess(res, 'read_file spa signature block');
+      parsed = JSON.parse(res.content as string);
+    });
+
+    await then('the signature-block window is returned', async () => {
+      expect(parsed).toHaveLength(10);
+    });
+
+    await and('every paragraph in the window has a null header style', async () => {
+      expect(parsed.every((node) => node.list_metadata.header_style === null)).toBe(true);
     });
   });
 });

--- a/skills/docx-editing/SKILL.md
+++ b/skills/docx-editing/SKILL.md
@@ -249,6 +249,8 @@ Tags can be nested: `<b><i>bold italic</i></b>`. Formatting from the original ma
 
 Across all rules, the actual heading text is in `list_metadata.header_text`, and the formatting (bold/italic/underline) of the title runs is in `list_metadata.header_formatting`.
 
+Detection is suppressed inside table cells; use `table_context` when you need cell context instead of heading metadata. Consecutive label-style cluster paragraphs (for example signature blocks) are also suppressed in a post-pass.
+
 Derived `is_heading` / `heading_level` fields are tracked separately in a follow-up issue and are NOT in the current schema.
 
 The Google Docs renderer (`packages/google-docs-core`) mirrors this schema structurally; it does not currently emit `title_caps_centered` (Google Docs has different heading semantics).


### PR DESCRIPTION
## Summary

Two cross-fixture residual heading-detection error classes after PR #178 are eliminated: (1) table-cell labels misclassified as `title_bare` / `title_with_colon`, and (2) signature/field-label clusters (`By:` / `Name:` / `Title:` / `COMPANY: [Insert ...]`) misclassified individually as inline headers.

## Implementation

- **One-line table-context gate** added to `extractHeaderInfo()` call site in `buildDocumentView()`, mirroring the existing gate on `detectTitleCapsCentered()`.
- **`suppressSignatureClusters()` post-pass** scans the assembled `nodes` array for runs of ≥4 consecutive paragraphs where ≥75% match a signature-label regex (mixed-case `Name:` form OR all-caps `COMPANY: …` form). Mutates matched nodes to clear `header_text` / `header_style` / `header_formatting`.
- 4 new tests: 2 branch-coverage (synthetic XML) + 2 end-to-end MCP JSON-shape against actual fixtures.
- SKILL.md updated with a brief note about the new gates.

## Verification

- [x] `npm -w @usejunior/docx-core run build` clean.
- [x] `npm -w @usejunior/docx-core test` — 1220 pass + 1 skip (no regression in `document_view.branch.test.ts:150` `Governing Law and Venue: …` inline-style test).
- [x] `npm -w @usejunior/docx-mcp test` — 726 pass.
- [x] `npm run lint:workspaces` — 0 errors (1 pre-existing warning in `edit.test.ts` unchanged).
- [x] Cross-fixture smoke (8 fixtures):

| Fixture | Before (`title_bare`/`title_with_colon`, total/in-table) | After |
|---|---|---|
| NVCA SPA | 1/0 + 1/0 | 1/0 + 1/0 (post-1672f55 baseline already low) |
| NVCA COI | 1/0 + 0/0 | 1/0 + 0/0 |
| Mutual NDA | 16/15 + 0/0 | 1/0 + 0/0 |
| Bonterms NDA | 13/13 + 7/7 | 0/0 + 0/0 |
| Letter of Intent | 12/6 + 5/0 | 6/0 + 5/0 |
| Common Paper NDA | 15/14 + 0/0 | 1/0 + 0/0 |
| ILPA LPA WOF | 20/0 + 0/0 | 20/0 + 0/0 (real section headings, unchanged) |
| ILPA LPA Deal-By-Deal | 21/0 + 0/0 | 21/0 + 0/0 (real section headings, unchanged) |
| **TOTAL** | **99/48 + 13/7** | **51/0 + 6/0** |

In-table false positives drop to 0 across all 8 fixtures. Real section headings (ILPA LPAs) preserved unchanged.

- [x] NVCA SPA paragraphs 312–321 (signature block) all `list_metadata.header_style === null`.
- [ ] Peer review (Gemini + Codex) — pending; will be appended below.

## Closes

- #187