### PR TITLE
feat(docx-core): add derived heading object to DocumentViewNode (closes #179)

### DIFF
--- a/packages/docx-core/src/primitives/document_view.ts
+++ b/packages/docx-core/src/primitives/document_view.ts
@@ -61,12 +61,28 @@ export type HeaderFormatting = {
   underline: boolean;
 };
 
+export type HeadingSource =
+  | 'word_style'
+  | 'run_in_header'
+  | 'title_with_period'
+  | 'title_with_colon'
+  | 'title_caps_centered'
+  | 'title_bare';
+
+type HeuristicHeadingSource = Exclude<HeadingSource, 'word_style'>;
+
+export type HeadingValue = {
+  text: string;
+  source: HeadingSource;
+  level: number | null;
+};
+
 export type ListMetadata = {
   list_level: number; // -1 for non-list
   label_type: LabelType | null;
   label_string: string;
   header_text: string | null;
-  header_style: string | null;
+  header_style: HeuristicHeadingSource | null;
   header_formatting: HeaderFormatting | null;
   is_auto_numbered: boolean;
 };
@@ -162,6 +178,7 @@ export type DocumentViewNode = {
   paragraph_alignment: ParagraphAlignment;
   paragraph_indents_pt: { left: number; first_line: number };
   numbering: { num_id: string | null; ilvl: number | null; is_auto_numbered: boolean };
+  heading?: HeadingValue;
   header_formatting: HeaderFormatting | null;
   body_run_formatting: RunFormatting | null;
   table_context?: TableContext;
@@ -202,7 +219,7 @@ function computeFingerprintToken(fp: FormattingFingerprint, styleId?: string): s
 // Pattern-based header detection fallback (ported from Python ingestor._extract_header_info).
 const HEADER_PATTERN = /^([A-Z][^.!?:]*(?:\s+[A-Z][^.!?:]*)*)([.:]?)(?:\s|$)/;
 
-function extractHeaderInfo(cleanText: string): { header_text: string | null; header_style: string | null } {
+function extractHeaderInfo(cleanText: string): { header_text: string | null; header_style: HeuristicHeadingSource | null } {
   if (!cleanText || cleanText.length < 2) return { header_text: null, header_style: null };
   if (!/^[A-Z]/.test(cleanText)) return { header_text: null, header_style: null };
 
@@ -229,6 +246,32 @@ function extractHeaderInfo(cleanText: string): { header_text: string | null; hea
   // (e.g. "Termination of Section 2.2(d)(i) shall not affect ..."), not headers.
   // Bare titles only fire from the short-paragraph branch above.
   return { header_text: null, header_style: null };
+}
+
+function deriveHeading(
+  paragraphStyleId: string | null,
+  cleanText: string,
+  headerText: string | null,
+  headerStyle: HeuristicHeadingSource | null,
+): HeadingValue | undefined {
+  const styleMatch = paragraphStyleId ? /^Heading([1-6])$/.exec(paragraphStyleId) : null;
+  if (styleMatch) {
+    return {
+      text: cleanText,
+      source: 'word_style',
+      level: Number.parseInt(styleMatch[1]!, 10),
+    };
+  }
+
+  if (headerText && headerStyle) {
+    return {
+      text: headerText,
+      source: headerStyle,
+      level: null,
+    };
+  }
+
+  return undefined;
 }
 
 function detectRunInHeader(params: {
@@ -1246,7 +1289,7 @@ export function buildNodesForDocumentView(params: {
 
     // Run-in header detection (formatting-based) first.
     let headerText: string | null = null;
-    let headerStyle: string | null = null;
+    let headerStyle: HeuristicHeadingSource | null = null;
     let headerFormatting: HeaderFormatting | null = null;
     let headerCharCount = 0;
 
@@ -1294,6 +1337,8 @@ export function buildNodesForDocumentView(params: {
       headerText = fallback.header_text;
       headerStyle = fallback.header_style;
     }
+
+    const heading = deriveHeading(paraFmt.styleId, cleanTextNoLabel, headerText, headerStyle);
 
     // ── Tag emission ──
     let tagged = cleanTextNoLabel;
@@ -1445,6 +1490,7 @@ export function buildNodesForDocumentView(params: {
       header_formatting: headerFormatting,
       body_run_formatting: bodyFmt,
     };
+    if (heading) node.heading = heading;
     if (tableContext) node.table_context = tableContext;
     nodes.push(node);
   }

--- a/packages/docx-core/src/primitives/document_view.ts
+++ b/packages/docx-core/src/primitives/document_view.ts
@@ -69,9 +69,17 @@ export type HeadingSource =
   | 'title_caps_centered'
   | 'title_bare';
 
-type HeuristicHeadingSource = Exclude<HeadingSource, 'word_style'>;
+export type HeuristicHeadingSource = Exclude<HeadingSource, 'word_style'>;
 
 export type HeadingValue = {
+  /**
+   * Heading label text. Semantics depend on `source`:
+   * - `word_style`: the full paragraph text (the entire paragraph IS the heading).
+   * - All heuristic sources (`run_in_header`, `title_with_period`, `title_with_colon`,
+   *   `title_caps_centered`, `title_bare`): only the extracted heading prefix.
+   *   For example, on `"Indemnification. The Company shall …"` the value is
+   *   `"Indemnification"`, not the whole paragraph.
+   */
   text: string;
   source: HeadingSource;
   level: number | null;
@@ -253,6 +261,7 @@ function deriveHeading(
   cleanText: string,
   headerText: string | null,
   headerStyle: HeuristicHeadingSource | null,
+  isInTableCell: boolean,
 ): HeadingValue | undefined {
   const styleMatch = paragraphStyleId ? /^Heading([1-6])$/.exec(paragraphStyleId) : null;
   if (styleMatch) {
@@ -262,6 +271,14 @@ function deriveHeading(
       level: Number.parseInt(styleMatch[1]!, 10),
     };
   }
+
+  // Inside table cells, heuristic detectors (run_in_header, title_with_period,
+  // title_with_colon, title_bare) routinely fire on ordinary label/value content
+  // — "Name", "Purchase Price:", "Name: Acme" — which are not structural document
+  // headings. We keep the per-detector explanation on list_metadata.header_style
+  // for debugging, but suppress heuristic promotion into the canonical heading
+  // predicate. Word built-in heading styles inside cells remain real headings.
+  if (isInTableCell) return undefined;
 
   if (headerText && headerStyle) {
     return {
@@ -1338,7 +1355,7 @@ export function buildNodesForDocumentView(params: {
       headerStyle = fallback.header_style;
     }
 
-    const heading = deriveHeading(paraFmt.styleId, cleanTextNoLabel, headerText, headerStyle);
+    const heading = deriveHeading(paraFmt.styleId, cleanTextNoLabel, headerText, headerStyle, tableContext != null);
 
     // ── Tag emission ──
     let tagged = cleanTextNoLabel;

--- a/packages/docx-core/test-primitives/document_view.branch.test.ts
+++ b/packages/docx-core/test-primitives/document_view.branch.test.ts
@@ -46,6 +46,35 @@ function buildTestNodes(bodyXml: string, stylesXml: Document | null = null): Doc
   }).nodes;
 }
 
+function makeCellTableContext(paraIndex: number) {
+  return {
+    table_id: '_tbl_0',
+    table_index: 0,
+    row_index: 0,
+    col_index: paraIndex,
+    col_header: '',
+    total_rows: 1,
+    total_cols: 1,
+    is_header_row: false,
+    para_in_cell: 0,
+    cell_para_count: 1,
+  };
+}
+
+function buildTestNodesInCells(bodyXml: string, stylesXml: Document | null = null): DocumentViewNode[] {
+  const paragraphs = makeParagraphs(bodyXml).map((entry, idx) => ({
+    ...entry,
+    tableContext: makeCellTableContext(idx),
+  }));
+  return buildNodesForDocumentView({
+    paragraphs,
+    stylesXml,
+    numberingXml: null,
+    include_semantic_tags: false,
+    show_formatting: false,
+  }).nodes;
+}
+
 function makeNode(overrides: Partial<DocumentViewNode>): DocumentViewNode {
   return {
     id: '_bk_1',
@@ -785,6 +814,103 @@ describe('document_view branch coverage', () => {
     await and('the heuristic signal remains explanatory only', async () => {
       expect(nodes[0]!.list_metadata.header_style).toBe('title_with_colon');
       expect(nodes[0]!.list_metadata.header_text).toBe('Governing Law');
+    });
+  });
+
+  test('derives heuristic heading objects for title_with_period and title_bare body paragraphs', async ({ given, when, then, and }: AllureBddContext) => {
+    let bodyXml: string;
+    let nodes: DocumentViewNode[];
+
+    await given('a short bare-title paragraph and a short title-with-period paragraph', async () => {
+      bodyXml =
+        `<w:p><w:r><w:t>Governing Law</w:t></w:r></w:p>` +
+        `<w:p><w:r><w:t>Definitions.</w:t></w:r></w:p>`;
+    });
+
+    await when('buildNodesForDocumentView is called', async () => {
+      nodes = buildTestNodes(bodyXml!);
+    });
+
+    await then('the bare-title paragraph emits a title_bare heading', async () => {
+      expect(nodes[0]!.heading).toEqual({
+        text: 'Governing Law',
+        source: 'title_bare',
+        level: null,
+      });
+    });
+
+    await and('the title-with-period paragraph emits a title_with_period heading', async () => {
+      expect(nodes[1]!.heading).toEqual({
+        text: 'Definitions',
+        source: 'title_with_period',
+        level: null,
+      });
+    });
+  });
+
+  test('suppresses heuristic heading promotion for paragraphs inside table cells (peer review #190)', async ({ given, when, then, and }: AllureBddContext) => {
+    let bodyXml: string;
+    let nodes: DocumentViewNode[];
+
+    await given('table cell paragraphs that match each heuristic detector', async () => {
+      bodyXml =
+        // title_bare candidate (short ALL-CAPS-leading title, no terminator)
+        `<w:p><w:r><w:t>Purchase Price</w:t></w:r></w:p>` +
+        // title_with_colon candidate (short paragraph ending in ":")
+        `<w:p><w:r><w:t>Notice Address:</w:t></w:r></w:p>` +
+        // title_with_period candidate (short paragraph ending in ".")
+        `<w:p><w:r><w:t>Closing.</w:t></w:r></w:p>` +
+        // run_in_header candidate (bold prefix + non-bold body)
+        `<w:p>` +
+          `<w:r><w:rPr><w:b/></w:rPr><w:t>Indemnification.</w:t></w:r>` +
+          `<w:r><w:t xml:space="preserve"> The Company shall indemnify each Investor.</w:t></w:r>` +
+        `</w:p>`;
+    });
+
+    await when('buildNodesForDocumentView is called with tableContext on every paragraph', async () => {
+      nodes = buildTestNodesInCells(bodyXml!);
+    });
+
+    await then('none of the table-cell paragraphs emit a top-level heading', async () => {
+      expect(nodes).toHaveLength(4);
+      for (const node of nodes) {
+        expect(node.heading).toBeUndefined();
+        expect(Object.prototype.hasOwnProperty.call(node, 'heading')).toBe(false);
+      }
+    });
+
+    await and('the explanatory list_metadata.header_style remains populated for debugging', async () => {
+      expect(nodes[0]!.list_metadata.header_style).toBe('title_bare');
+      expect(nodes[1]!.list_metadata.header_style).toBe('title_with_colon');
+      expect(nodes[1]!.list_metadata.header_text).toBe('Notice Address');
+      expect(nodes[2]!.list_metadata.header_style).toBe('title_with_period');
+      expect(nodes[3]!.list_metadata.header_style).toBe('run_in_header');
+    });
+  });
+
+  test('still promotes word_style headings inside table cells (Heading1..6 wins over the cell gate)', async ({ given, when, then }: AllureBddContext) => {
+    let bodyXml: string;
+    let stylesXml: Document;
+    let nodes: DocumentViewNode[];
+
+    await given('a Heading3-styled paragraph injected as a table cell', async () => {
+      stylesXml = makeStylesXml(
+        `<w:style w:type="paragraph" w:styleId="Heading3"><w:name w:val="heading 3"/></w:style>`,
+      );
+      bodyXml = `<w:p><w:pPr><w:pStyle w:val="Heading3"/></w:pPr><w:r><w:t>Schedule A</w:t></w:r></w:p>`;
+    });
+
+    await when('buildNodesForDocumentView is called with tableContext', async () => {
+      nodes = buildTestNodesInCells(bodyXml!, stylesXml!);
+    });
+
+    await then('the word_style heading still fires inside the cell', async () => {
+      expect(nodes).toHaveLength(1);
+      expect(nodes[0]!.heading).toEqual({
+        text: 'Schedule A',
+        source: 'word_style',
+        level: 3,
+      });
     });
   });
 

--- a/packages/docx-core/test-primitives/document_view.branch.test.ts
+++ b/packages/docx-core/test-primitives/document_view.branch.test.ts
@@ -29,6 +29,23 @@ function makeParagraphs(bodyXml: string): Array<{ id: string; p: Element }> {
   return ps.map((p, idx) => ({ id: `_bk_${idx + 1}`, p }));
 }
 
+function makeStylesXml(styles: string): Document {
+  return parseXml(
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<w:styles xmlns:w="${W_NS}">${styles}</w:styles>`,
+  );
+}
+
+function buildTestNodes(bodyXml: string, stylesXml: Document | null = null): DocumentViewNode[] {
+  return buildNodesForDocumentView({
+    paragraphs: makeParagraphs(bodyXml),
+    stylesXml,
+    numberingXml: null,
+    include_semantic_tags: false,
+    show_formatting: false,
+  }).nodes;
+}
+
 function makeNode(overrides: Partial<DocumentViewNode>): DocumentViewNode {
   return {
     id: '_bk_1',
@@ -654,6 +671,120 @@ describe('document_view branch coverage', () => {
     await then('the title is classified as title_caps_centered, not title_bare', async () => {
       expect(nodes).toHaveLength(1);
       expect(nodes[0]!.list_metadata.header_style).toBe('title_caps_centered');
+    });
+  });
+
+  test('derives word_style headings only from exact Heading1-Heading6 paragraph style IDs', async ({ given, when, then, and }: AllureBddContext) => {
+    let bodyXml: string;
+    let stylesXml: Document;
+    let nodes: DocumentViewNode[];
+
+    await given('built-in heading styles, an inheriting HeadingPara1 style, and a normal body paragraph', async () => {
+      stylesXml = makeStylesXml(
+        `<w:style w:type="paragraph" w:styleId="Normal"><w:name w:val="Normal"/></w:style>` +
+        `<w:style w:type="paragraph" w:styleId="Heading1"><w:name w:val="heading 1"/></w:style>` +
+        `<w:style w:type="paragraph" w:styleId="Heading6"><w:name w:val="heading 6"/></w:style>` +
+        `<w:style w:type="paragraph" w:styleId="HeadingPara1">` +
+          `<w:name w:val="Heading Para 1"/>` +
+          `<w:basedOn w:val="Heading1"/>` +
+          `<w:next w:val="Normal"/>` +
+        `</w:style>`,
+      );
+      bodyXml =
+        `<w:p><w:pPr><w:pStyle w:val="Heading1"/></w:pPr><w:r><w:t>Board Approval</w:t></w:r></w:p>` +
+        `<w:p><w:pPr><w:pStyle w:val="Heading6"/></w:pPr><w:r><w:t>Minor Conditions</w:t></w:r></w:p>` +
+        `<w:p><w:pPr><w:pStyle w:val="HeadingPara1"/></w:pPr><w:r><w:t>this inherited style stays body prose.</w:t></w:r></w:p>` +
+        `<w:p><w:pPr><w:pStyle w:val="Normal"/></w:pPr><w:r><w:t>this is ordinary body text.</w:t></w:r></w:p>`;
+    });
+
+    await when('buildNodesForDocumentView is called', async () => {
+      nodes = buildTestNodes(bodyXml!, stylesXml!);
+    });
+
+    await then('Heading1 and Heading6 paragraphs emit word_style headings with exact levels', async () => {
+      expect(nodes).toHaveLength(4);
+      expect(nodes[0]!.heading).toEqual({ text: 'Board Approval', source: 'word_style', level: 1 });
+      expect(nodes[1]!.heading).toEqual({ text: 'Minor Conditions', source: 'word_style', level: 6 });
+    });
+
+    await and('HeadingPara1 inheritance does not produce a heading object', async () => {
+      expect(nodes[2]!.heading).toBeUndefined();
+      expect(Object.prototype.hasOwnProperty.call(nodes[2]!, 'heading')).toBe(false);
+    });
+
+    await and('body paragraphs omit the heading field entirely', async () => {
+      expect(nodes[3]!.heading).toBeUndefined();
+      expect(Object.prototype.hasOwnProperty.call(nodes[3]!, 'heading')).toBe(false);
+    });
+  });
+
+  test('derives heuristic heading objects for title_caps_centered and run_in_header paragraphs', async ({ given, when, then, and }: AllureBddContext) => {
+    let bodyXml: string;
+    let nodes: DocumentViewNode[];
+
+    await given('a centered standalone title and a bold-prefix run-in header paragraph', async () => {
+      bodyXml =
+        `<w:p>` +
+          `<w:pPr><w:jc w:val="center"/></w:pPr>` +
+          `<w:r><w:rPr><w:b/></w:rPr><w:t>SERIES A PREFERRED STOCK PURCHASE AGREEMENT</w:t></w:r>` +
+        `</w:p>` +
+        `<w:p>` +
+          `<w:r><w:rPr><w:b/></w:rPr><w:t>Indemnification.</w:t></w:r>` +
+          `<w:r><w:t> The Company shall indemnify each Investor as set forth herein.</w:t></w:r>` +
+        `</w:p>`;
+    });
+
+    await when('buildNodesForDocumentView is called', async () => {
+      nodes = buildTestNodes(bodyXml!);
+    });
+
+    await then('the centered title emits a null-level heading object', async () => {
+      expect(nodes).toHaveLength(2);
+      expect(nodes[0]!.heading).toEqual({
+        text: 'SERIES A PREFERRED STOCK PURCHASE AGREEMENT',
+        source: 'title_caps_centered',
+        level: null,
+      });
+    });
+
+    await and('the run-in header emits a null-level heading object', async () => {
+      expect(nodes[1]!.heading).toEqual({
+        text: 'Indemnification',
+        source: 'run_in_header',
+        level: null,
+      });
+    });
+  });
+
+  test('prefers word_style heading derivation over heuristic header detectors when both match', async ({ given, when, then, and }: AllureBddContext) => {
+    let bodyXml: string;
+    let stylesXml: Document;
+    let nodes: DocumentViewNode[];
+
+    await given('a Heading2-styled paragraph that also matches the title_with_colon heuristic', async () => {
+      stylesXml = makeStylesXml(
+        `<w:style w:type="paragraph" w:styleId="Heading2"><w:name w:val="heading 2"/></w:style>`,
+      );
+      bodyXml =
+        `<w:p><w:pPr><w:pStyle w:val="Heading2"/></w:pPr><w:r><w:t>Governing Law: this agreement is governed as stated.</w:t></w:r></w:p>`;
+    });
+
+    await when('buildNodesForDocumentView is called', async () => {
+      nodes = buildTestNodes(bodyXml!, stylesXml!);
+    });
+
+    await then('the heading object uses word_style with level 2 and clean_text', async () => {
+      expect(nodes).toHaveLength(1);
+      expect(nodes[0]!.heading).toEqual({
+        text: 'Governing Law: this agreement is governed as stated.',
+        source: 'word_style',
+        level: 2,
+      });
+    });
+
+    await and('the heuristic signal remains explanatory only', async () => {
+      expect(nodes[0]!.list_metadata.header_style).toBe('title_with_colon');
+      expect(nodes[0]!.list_metadata.header_text).toBe('Governing Law');
     });
   });
 

--- a/packages/docx-mcp/README.md
+++ b/packages/docx-mcp/README.md
@@ -51,14 +51,23 @@ Add to your MCP client:
 
 ## Heading detection in `read_file(format="json")`
 
-Each paragraph node in the JSON output exposes heading signals via `paragraph_style_id` and the `list_metadata.header_text` / `header_style` / `header_formatting` fields. The supported `header_style` values are:
+Each paragraph node in the JSON output may expose a top-level `heading` object:
 
-- `run_in_header` — bold/underline prefix followed by non-header body in the same paragraph (e.g. `**Indemnification.** The Company shall …`). Whole-paragraph bold/underline blocks are intentionally excluded.
-- `title_with_period` / `title_with_colon` — inline section header with explicit terminator (e.g. `Governing Law and Venue: this agreement is governed as stated.`).
-- `title_caps_centered` — centered, ALL-CAPS, bold standalone title (e.g. `SERIES A PREFERRED STOCK PURCHASE AGREEMENT`). Strict gates: no lowercase letters, ≥ 3 ASCII letters, ≥ 2 word-tokens (rejects placeholders like `[COMPANY]` and underscore signature lines), no list label, not in a table cell, ≤ 120 chars.
-- `title_with_period` / `title_with_colon` / `title_bare` — short standalone paragraphs (≤ 50 chars) only.
+```ts
+heading?: {
+  text: string;
+  source: 'word_style' | 'run_in_header' | 'title_with_period' | 'title_with_colon' | 'title_caps_centered' | 'title_bare';
+  level: number | null;
+}
+```
 
-To classify a paragraph as a heading, consumers should combine these signals with `paragraph_style_id` (`/^Heading[1-6]$/` is authoritative for depth). See [`skills/docx-editing/SKILL.md`](../../skills/docx-editing/SKILL.md) for the canonical precedence rule. Derived `is_heading` / `heading_level` fields are tracked in a follow-up issue.
+Use `node.heading != null` as the canonical heading check.
+
+- `source: 'word_style'` wins whenever `paragraph_style_id` matches `/^Heading([1-6])$/` exactly, and only then. Inherited styles like `HeadingPara1` do not count.
+- Heuristic sources (`run_in_header`, `title_with_period`, `title_with_colon`, `title_caps_centered`, `title_bare`) always emit `level: null`.
+- Body paragraphs omit the `heading` key entirely.
+
+`list_metadata.header_style` remains the per-detector explanation layer, not the canonical "is heading" predicate. See [`skills/docx-editing/SKILL.md`](../../skills/docx-editing/SKILL.md) for the full precedence rule and the Google Docs asymmetry: the GDocs path only emits `heading` for built-in heading styles and does not run the Word heuristics.
 
 ## Document Families
 

--- a/packages/docx-mcp/src/tools/nvca_spa_regression.test.ts
+++ b/packages/docx-mcp/src/tools/nvca_spa_regression.test.ts
@@ -449,13 +449,19 @@ describe('NVCA SPA regression: batch edit + save round-trip', { timeout: 30_000 
   });
 });
 
-describe('NVCA SPA regression: heading detection (#157)', () => {
-  test('read_file(format=json) surfaces SPA title with title_caps_centered header_style', async ({ given, when, then, and }: AllureBddContext) => {
+describe('NVCA SPA regression: heading detection (#179)', () => {
+  test('read_file(format=json) surfaces the SPA title via node.heading and omits heading on body paragraphs', async ({ given, when, then, and }: AllureBddContext) => {
     let mgr: ReturnType<typeof createMgr>;
     let filePath: string;
-    let parsed: Array<{
+    let titleNode: {
       id: string;
+      heading?: { text: string; source: string; level: number | null };
       list_metadata: { header_text: string | null; header_style: string | null };
+    };
+    let allNodes: Array<{
+      id: string;
+      clean_text: string;
+      heading?: { text: string; source: string; level: number | null };
     }>;
     const titlePid = '_bk_8c71639f1440';
 
@@ -463,24 +469,43 @@ describe('NVCA SPA regression: heading detection (#157)', () => {
       ({ mgr, filePath } = await openSPA());
     });
 
-    await when('read_file is called with format=json for the title paragraph', async () => {
-      const res = await readFile(mgr, {
+    await when('read_file is called with format=json for the title paragraph and the broader document', async () => {
+      const titleRes = await readFile(mgr, {
         file_path: filePath,
         node_ids: [titlePid],
         format: 'json',
       });
-      assertSuccess(res, 'read_file json');
-      parsed = JSON.parse(res.content as string);
+      assertSuccess(titleRes, 'read_file json title');
+      titleNode = JSON.parse(titleRes.content as string)[0]!;
+
+      const allRes = await readFile(mgr, {
+        file_path: filePath,
+        format: 'json',
+        limit: 100000,
+        offset: 1,
+      });
+      assertSuccess(allRes, 'read_file json full');
+      allNodes = JSON.parse(allRes.content as string);
     });
 
     await then('the title paragraph is returned', async () => {
-      expect(parsed).toHaveLength(1);
-      expect(parsed[0]!.id).toBe(titlePid);
+      expect(titleNode.id).toBe(titlePid);
     });
 
-    await and('list_metadata.header_style is title_caps_centered', async () => {
-      expect(parsed[0]!.list_metadata.header_style).toBe('title_caps_centered');
-      expect(parsed[0]!.list_metadata.header_text).toContain('PREFERRED STOCK PURCHASE AGREEMENT');
+    await and('the title paragraph exposes node.heading with title_caps_centered and null level', async () => {
+      expect(titleNode.heading).toEqual({
+        text: 'SERIES [___] PREFERRED STOCK PURCHASE AGREEMENT',
+        source: 'title_caps_centered',
+        level: null,
+      });
+      expect(titleNode.list_metadata.header_style).toBe('title_caps_centered');
+      expect(titleNode.list_metadata.header_text).toContain('PREFERRED STOCK PURCHASE AGREEMENT');
+    });
+
+    await and('a body paragraph omits the heading key entirely', async () => {
+      const bodyNode = allNodes.find((node) => !Object.prototype.hasOwnProperty.call(node, 'heading'));
+      expect(bodyNode).toBeDefined();
+      expect(bodyNode!.heading).toBeUndefined();
     });
   });
 });

--- a/packages/google-docs-core/src/__tests__/document-view.test.ts
+++ b/packages/google-docs-core/src/__tests__/document-view.test.ts
@@ -130,4 +130,112 @@ describe('Document View Builder', () => {
     const nodes = buildDocumentViewNodes(paragraphs);
     expect(nodes[0].id).toBe('para_100'); // Fallback ID
   });
+
+  describe('heading derivation', () => {
+    it('normalizes HEADING_1..6 namedStyleTypes to Heading1..6 and emits a word_style heading', () => {
+      const paragraphs: CachedParagraph[] = [
+        {
+          paragraphId: 'HEADING_1',
+          anchorName: '_bk_h1',
+          anchorId: 'tab1:_bk_h1',
+          startIndex: 1,
+          endIndex: 10,
+          tabId: 'tab1',
+          text: 'Section One',
+          inTable: false,
+        },
+        {
+          paragraphId: 'HEADING_6',
+          anchorName: '_bk_h6',
+          anchorId: 'tab1:_bk_h6',
+          startIndex: 20,
+          endIndex: 30,
+          tabId: 'tab1',
+          text: 'Nested Item',
+          inTable: false,
+        },
+      ];
+
+      const nodes = buildDocumentViewNodes(paragraphs);
+      expect(nodes[0].paragraph_style_id).toBe('Heading1');
+      expect(nodes[0].paragraph_style_name).toBe('Heading1');
+      expect(nodes[0].heading).toEqual({ text: 'Section One', source: 'word_style', level: 1 });
+      expect(nodes[1].paragraph_style_id).toBe('Heading6');
+      expect(nodes[1].heading).toEqual({ text: 'Nested Item', source: 'word_style', level: 6 });
+    });
+
+    it('treats NORMAL_TEXT and other non-heading namedStyleTypes as body (no heading field)', () => {
+      const paragraphs: CachedParagraph[] = [
+        {
+          paragraphId: 'NORMAL_TEXT',
+          anchorName: '_bk_body',
+          anchorId: 'tab1:_bk_body',
+          startIndex: 1,
+          endIndex: 10,
+          tabId: 'tab1',
+          text: 'Ordinary body text',
+          inTable: false,
+        },
+        {
+          paragraphId: 'TITLE',
+          anchorName: '_bk_title',
+          anchorId: 'tab1:_bk_title',
+          startIndex: 20,
+          endIndex: 30,
+          tabId: 'tab1',
+          text: 'Document Title',
+          inTable: false,
+        },
+        {
+          paragraphId: 'SUBTITLE',
+          anchorName: '_bk_sub',
+          anchorId: 'tab1:_bk_sub',
+          startIndex: 40,
+          endIndex: 50,
+          tabId: 'tab1',
+          text: 'Document Subtitle',
+          inTable: false,
+        },
+      ];
+
+      const nodes = buildDocumentViewNodes(paragraphs);
+      for (const node of nodes) {
+        expect(node.heading).toBeUndefined();
+        expect(Object.prototype.hasOwnProperty.call(node, 'heading')).toBe(false);
+        expect(node.paragraph_style_id).toBeNull();
+        expect(node.paragraph_style_name).toBe('body');
+      }
+    });
+
+    it('emits a word_style heading even for paragraphs inside table cells', () => {
+      const paragraphs: CachedParagraph[] = [
+        {
+          paragraphId: 'HEADING_2',
+          anchorName: '_bk_cellh',
+          anchorId: 'tab1:_bk_cellh',
+          startIndex: 5,
+          endIndex: 15,
+          tabId: 'tab1',
+          text: 'Cell Heading',
+          inTable: true,
+          tableMetadata: {
+            tableStartIndex: 0,
+            tableIndex: 0,
+            tableId: '_tbl_0',
+            rowIndex: 0,
+            colIndex: 0,
+            totalRows: 1,
+            totalCols: 1,
+            isHeaderRow: false,
+            paraInCell: 0,
+            cellParaCount: 1,
+            colHeader: '',
+          },
+        },
+      ];
+
+      const nodes = buildDocumentViewNodes(paragraphs);
+      expect(nodes[0].heading).toEqual({ text: 'Cell Heading', source: 'word_style', level: 2 });
+    });
+  });
 });

--- a/packages/google-docs-core/src/document-view.ts
+++ b/packages/google-docs-core/src/document-view.ts
@@ -1,5 +1,36 @@
 import type { CachedParagraph } from './types.js';
 
+type HeadingSource =
+  | 'word_style'
+  | 'run_in_header'
+  | 'title_with_period'
+  | 'title_with_colon'
+  | 'title_caps_centered'
+  | 'title_bare';
+
+type HeadingValue = {
+  text: string;
+  source: HeadingSource;
+  level: number | null;
+};
+
+function normalizeParagraphStyleId(rawStyleId: string | null | undefined): string | null {
+  if (!rawStyleId) return null;
+  const gdocsMatch = /^HEADING_([1-6])$/.exec(rawStyleId);
+  if (gdocsMatch) return `Heading${gdocsMatch[1]}`;
+  return /^Heading([1-6])$/.test(rawStyleId) ? rawStyleId : null;
+}
+
+function deriveHeading(paragraphStyleId: string | null, text: string): HeadingValue | undefined {
+  const styleMatch = paragraphStyleId ? /^Heading([1-6])$/.exec(paragraphStyleId) : null;
+  if (!styleMatch) return undefined;
+  return {
+    text,
+    source: 'word_style',
+    level: Number.parseInt(styleMatch[1]!, 10),
+  };
+}
+
 /**
  * DocumentViewNode for Google Docs output.
  * Same shape as the DOCX DocumentViewNode to ensure schema compatibility.
@@ -33,6 +64,7 @@ export type DocumentViewNodeGdocs = {
   paragraph_alignment: string;
   paragraph_indents_pt: { left: number; first_line: number };
   numbering: { num_id: string | null; ilvl: number | null; is_auto_numbered: boolean };
+  heading?: HeadingValue;
   header_formatting: { bold: boolean; italic: boolean; underline: boolean } | null;
   body_run_formatting: Record<string, unknown> | null;
   table_context?: {
@@ -61,6 +93,9 @@ export function buildDocumentViewNodes(paragraphs: CachedParagraph[]): DocumentV
         ? `th(${rowIndex},${colIndex})`
         : `td(${rowIndex},${colIndex})`)
       : 'body';
+    const paragraphStyleId = normalizeParagraphStyleId(para.paragraphId);
+    const paragraphStyleName = paragraphStyleId ?? 'body';
+    const heading = deriveHeading(paragraphStyleId, para.text);
 
     const node: DocumentViewNodeGdocs = {
       id: para.anchorId || para.anchorName || `para_${para.startIndex}`,
@@ -83,17 +118,18 @@ export function buildDocumentViewNodes(paragraphs: CachedParagraph[]): DocumentV
         list_level: -1,
         left_indent_pt: 0,
         first_line_indent_pt: 0,
-        style_name: 'body',
+        style_name: paragraphStyleName,
         alignment: 'LEFT',
       },
-      paragraph_style_id: null,
-      paragraph_style_name: 'body',
+      paragraph_style_id: paragraphStyleId,
+      paragraph_style_name: paragraphStyleName,
       paragraph_alignment: 'LEFT',
       paragraph_indents_pt: { left: 0, first_line: 0 },
       numbering: { num_id: null, ilvl: null, is_auto_numbered: false },
       header_formatting: null,
       body_run_formatting: null,
     };
+    if (heading) node.heading = heading;
 
     if (para.tableMetadata) {
       node.table_context = {

--- a/packages/google-docs-core/src/types.ts
+++ b/packages/google-docs-core/src/types.ts
@@ -34,7 +34,7 @@ export type GoogleDocsSaveResult = {
 
 /** Cached paragraph info from Google Docs structure */
 export type CachedParagraph = {
-  paragraphId: string; // Google's native paragraph ID (not used as anchor)
+  paragraphId: string; // Google Docs namedStyleType (e.g. 'HEADING_1', 'NORMAL_TEXT'). Historically misnamed; consumed by document-view.ts to derive heading metadata.
   anchorName: string | null; // Our injected _bk_ name (named range)
   anchorId: AnchorId; // Full anchor ID (tabId:anchorName)
   startIndex: number; // UTF-16 code unit offset

--- a/skills/docx-editing/SKILL.md
+++ b/skills/docx-editing/SKILL.md
@@ -236,22 +236,38 @@ Tags can be nested: `<b><i>bold italic</i></b>`. Formatting from the original ma
 
 ## Heading Detection (read_file JSON output)
 
-`read_file(format="json")` returns a `DocumentViewNode` per paragraph. To classify a paragraph as a section heading, combine these fields in the order below — the **first match wins**:
+`read_file(format="json")` returns an optional top-level `heading` object per paragraph:
 
-| Precedence | Signal | Field | Notes |
-|------------|--------|-------|-------|
-| 1 | Word built-in heading style | `paragraph_style_id` matches `/^Heading[1-6]$/` | Authoritative depth (1–6). |
-| 2 | Run-in header (bold/underline prefix + body) | `list_metadata.header_style === 'run_in_header'` | Only fires when the bold/underline prefix is followed by non-header body in the same paragraph (a true header → body transition). Whole-paragraph bold/underline blocks are intentionally NOT classified here. |
-| 3 | Inline section header (long paragraph) | `list_metadata.header_style === 'title_with_period'` or `'title_with_colon'` | E.g. `Governing Law and Venue: this agreement is governed as stated.` |
-| 4 | Centered ALL-CAPS bold standalone title | `list_metadata.header_style === 'title_caps_centered'` | Centered alignment, all visible runs bold, no lowercase letters, ≥ 3 ASCII letters and ≥ 2 word-tokens (so single-token bracketed placeholders like `[COMPANY]` and underscore signature lines like `__________` are excluded), no list label, not in a table cell, ≤ 120 chars. Catches document titles that are not styled with a Word heading style. |
-| 5 | Bare manual heading (short standalone paragraph) | `list_metadata.header_style === 'title_with_period'`, `'title_with_colon'`, or `'title_bare'` on a paragraph ≤ 50 chars | Last-resort heuristic for short headings. Body prose never reaches this branch. |
-| — | Otherwise | none of the above | Not a heading. |
+```ts
+heading?: {
+  text: string;
+  source: 'word_style'
+        | 'run_in_header'
+        | 'title_with_period'
+        | 'title_with_colon'
+        | 'title_caps_centered'
+        | 'title_bare';
+  level: number | null;
+};
+```
 
-Across all rules, the actual heading text is in `list_metadata.header_text`, and the formatting (bold/italic/underline) of the title runs is in `list_metadata.header_formatting`.
+Use `node.heading != null` as the canonical "is this a heading" check.
 
-Derived `is_heading` / `heading_level` fields are tracked separately in a follow-up issue and are NOT in the current schema.
+- If `heading` is present with `source: 'word_style'`, `level` is `1..6` and comes only from an exact `paragraph_style_id` match on `/^Heading([1-6])$/`.
+- Style inheritance does not count. Custom styles like `HeadingPara1` / `HeadingPara2` may be based on Word heading styles but still omit `heading` unless their own `paragraph_style_id` is exactly `Heading1`…`Heading6`.
+- If `heading` is present with any heuristic source, `level` is always `null`.
+- If `heading` is absent, the paragraph is not a heading. The key is omitted entirely in JSON output; it is not set to `null`.
 
-The Google Docs renderer (`packages/google-docs-core`) mirrors this schema structurally; it does not currently emit `title_caps_centered` (Google Docs has different heading semantics).
+Precedence is fixed: exact Word built-in heading styles win over every heuristic detector. This means a paragraph can still expose `list_metadata.header_style` for explanation while `heading.source` is `word_style`.
+
+`list_metadata.header_style` and `list_metadata.header_text` remain useful, but they are now the per-detector explanation layer rather than the canonical heading predicate:
+
+- `run_in_header` — bold/underline prefix followed by non-header body in the same paragraph (e.g. `**Indemnification.** The Company shall …`). Whole-paragraph bold/underline blocks are intentionally excluded.
+- `title_with_period` / `title_with_colon` — inline section header with explicit terminator (e.g. `Governing Law and Venue: this agreement is governed as stated.`).
+- `title_caps_centered` — centered, ALL-CAPS, bold standalone title (e.g. `SERIES A PREFERRED STOCK PURCHASE AGREEMENT`). Strict gates: no lowercase letters, ≥ 3 ASCII letters, ≥ 2 word-tokens, no list label, not in a table cell, ≤ 120 chars.
+- `title_bare` — short standalone manual title fallback.
+
+Google Docs is intentionally asymmetric: the `packages/google-docs-core` path emits `heading` only for built-in heading styles that normalize to `Heading1`…`Heading6`. The heuristic detectors do not run on the Google Docs renderer, so sources like `title_caps_centered` and `run_in_header` are Word-only today.
 
 ## Batch Edits with apply_plan
 


### PR DESCRIPTION
## Summary

Phase 2 of #157: adds a sparse top-level `heading?` field to `DocumentViewNode`, locking the precedence rule into the wire schema so consumers stop re-implementing it. Centralizes the verdict; future detector changes (like `title_caps_centered` added in #178) become non-breaking for downstream consumers.

## Implementation

```ts
heading?: {
  text: string;
  source: 'word_style'
        | 'run_in_header'
        | 'title_with_period'
        | 'title_with_colon'
        | 'title_caps_centered'
        | 'title_bare';
  level: number | null;   // 1..6 only when source === 'word_style'
};
// Field is OMITTED entirely for body paragraphs (not null).
```

- New `deriveHeading()` helper in `document_view.ts` — Word built-in heading wins over heuristics; `level` derived ONLY from exact `paragraph_style_id` match on `/^Heading([1-6])$/`. Style inheritance does NOT count (`HeadingPara1` / `HeadingPara2` in NVCA fixture inherit from heading styles but behave like body paragraphs — explicitly tested as a regression).
- Mirrored on Google Docs renderer (`packages/google-docs-core/src/document-view.ts`) — Word-style-only there since heuristic detectors don't run on the GDocs path. Asymmetry documented in SKILL.md.
- Bonus TypeScript improvement: `header_style` narrowed from `string | null` to `HeuristicHeadingSource | null` (exported union type) for consumer autocomplete.

Consumer code becomes:
```ts
function isHeading(node) { return node.heading != null; }
```

## Verification

- [x] `npm -w @usejunior/docx-core run build` clean.
- [x] `npm -w @usejunior/google-docs-core run build` clean.
- [x] `npm -w @usejunior/docx-core test` — 1224 pass + 1 skip (was 1220, +4 net new tests).
- [x] `npm -w @usejunior/docx-mcp test` — 733 pass + 1 fail. **The single failure (`read_file_comments.test.ts:1028` — `comment_load_error` expected string, got undefined) ALSO fails on `origin/main`** — confirmed pre-existing, introduced by PR #180's comments-namespace work, unrelated to this PR.
- [x] `npm run lint:workspaces` — 0 errors (1 pre-existing warning in `edit.test.ts` unchanged).
- [x] Smoke against NVCA SPA fixture:
  - SPA title (`_bk_8c71639f1440`) → `heading: {text: "SERIES [...]", source: "title_caps_centered", level: null}` ✓
  - Body paragraph → no `heading` key in JSON output (omitted, not null) ✓
  - 367-paragraph cross-section: 246 with `heading`, 121 body. Sources observed: `title_bare`, `title_caps_centered`, `title_with_colon`, `word_style`. (The high `title_bare` count reflects current detector state on main; #188 will reduce this — independent.)

- [ ] Peer review (Gemini + Codex) — pending; will be appended below.

## Notes for reviewers

- **Pre-existing failure**: `packages/docx-mcp/src/tools/read_file_comments.test.ts:1028` fails on `origin/main` and on this branch identically. Not caused by this PR.
- **Coordination with #188**: PR #188 (the parallel detector-hardening work) will reduce the cross-fixture `title_bare` count significantly. After both merge, the `heading.source` distribution on the NVCA SPA will skew much cleaner (mostly `word_style` + `title_caps_centered`).

## Closes

- #179