### PR TITLE
fix(docx-mcp): surface comment_load_error on the default budgeted read path (closes #189)

### DIFF
--- a/packages/docx-mcp/src/tools/read_file.ts
+++ b/packages/docx-mcp/src/tools/read_file.ts
@@ -446,6 +446,7 @@ export async function readFile(
         paragraphs_returned: paragraphsReturned,
         ...(result.warnings ? { warnings: result.warnings } : {}),
         ...paginationMeta,
+        ...(commentLoadError != null ? { comment_load_error: commentLoadError } : {}),
       }, metadata));
     }
 


### PR DESCRIPTION
## Summary

`read_file`'s default budgeted-path return dropped the `comment_load_error` diagnostic metadata that #154/#180 introduced, so malformed `comments.xml` files remained body-readable but the silent-comment-drop signal never reached the caller. One-line fix: spread the field into the early budgeted return so it matches the shared fallthrough.

## Why this regressed

`read_file.ts` has two success returns in the budgeted-pagination region:

- **Early return** in the `budgetActive` branch (line ~442) — introduced by #186 alongside the new `warnings` field. Missing the `comment_load_error` spread.
- **Shared fallthrough** (line ~454) — modified by #180 to spread `comment_load_error`. Has it.

The default no-`limit`/no-`offset`/no-`node_ids` path is the budgeted path, so the common read shape lost the diagnostic. PR #180's worktree branched before #186 merged, so its CI never exercised the post-merge interaction. The negative test added in #180's hardening commit (`862edb0`) — `surfaces comment_load_error when comments.xml is unparseable` — fails on main today and passes with this fix.

## Implementation

```ts
return ok(mergeSessionResolutionMetadata({
  file_path: manager.normalizePath(session.originalPath),
  content,
  total_paragraphs: totalParagraphs,
  paragraphs_returned: paragraphsReturned,
  ...(result.warnings ? { warnings: result.warnings } : {}),
  ...paginationMeta,
+ ...(commentLoadError != null ? { comment_load_error: commentLoadError } : {}),
}, metadata));
```

`warnings` and `comment_load_error` are independent additive metadata fields — no reason for them to be mutually exclusive. No refactor of the response-assembly helpers in this PR; an optional consolidation was suggested in the issue but is explicitly out of scope here.

## Verification

- [x] Build clean — `npm run build`
- [x] Lint clean — `npm run lint:workspaces` (one pre-existing warning in `edit.test.ts` unrelated to this PR)
- [x] Tests pass — `npm run test:run` (734 passed in docx-mcp; the previously-failing `comment_load_error` regression now passes)
- [x] Spec coverage — `npm run check:spec-coverage` clean
- [ ] Peer review (Gemini + Codex) — pending; will be appended below

## Closes

- #189