### PR TITLE
ci(verification): fix actionlint SC2086 in lean-build zero-sorry audit

### DIFF
--- a/.github/workflows/lean-build.yml
+++ b/.github/workflows/lean-build.yml
@@ -93,9 +93,11 @@ jobs:
         run: |
           # All LeanSpike modules except Spec.lean (which intentionally holds
           # exactly two sorries — the deferred specification targets).
-          files=$(find LeanSpike -name '*.lean' ! -name 'Spec.lean')
-          files="LeanSpike.lean $files"
-          if grep -nw "sorry" $files; then
+          # `find -print0 | xargs -0 grep` avoids the SC2086 word-splitting
+          # foot-gun on an unquoted variable while still letting future modules
+          # under LeanSpike/ get picked up automatically.
+          if find LeanSpike.lean LeanSpike -name '*.lean' ! -name 'Spec.lean' -print0 \
+               | xargs -0 grep -nwH "sorry"; then
             echo "ERROR: sorry found in non-Spec Lean modules. They must remain zero-sorry."
             exit 1
           fi


### PR DESCRIPTION
## Summary

Fixes the `actionlint` CI check that has been failing since PR #164 merged.

The zero-sorry audit step in `.github/workflows/lean-build.yml` assembled a list of `.lean` files into a string variable and then passed it unquoted to `grep`, relying on shell word-splitting:

```yaml
files=$(find LeanSpike -name '*.lean' ! -name 'Spec.lean')
files="LeanSpike.lean $files"
if grep -nw "sorry" $files; then    # SC2086
```

shellcheck/SC2086 flags this — a real footgun if any future filename contains whitespace. actionlint propagated that as a job failure on every push touching the workflow.

Switched to the NUL-delimited pipeline:

```yaml
if find LeanSpike.lean LeanSpike -name '*.lean' ! -name 'Spec.lean' -print0 \
     | xargs -0 grep -nwH "sorry"; then
```

Same future-proof glob over all LeanSpike modules except `Spec.lean`, but correct under any filename.

## Test plan

- [x] `actionlint .github/workflows/lean-build.yml` exits clean locally
- [x] Positive case: current zero-sorry repo state → audit exits 1 (audit passes — no forbidden sorries found)
- [x] Negative case: synthetic `sorry` injected into a non-Spec module → audit exits 0 with file:line:match printed (audit fails as intended)
- [ ] `actionlint` CI check passes on this PR

Workflow trigger paths include `.github/workflows/lean-build.yml` itself, so the `lean-build` job will also re-run on this PR.