### PR TITLE
test(docx-core): fix intermittent lean-spec-bridge whitespace failure (#203)

### DIFF
--- a/packages/docx-core/src/integration/lean-spec-bridge.test.ts
+++ b/packages/docx-core/src/integration/lean-spec-bridge.test.ts
@@ -410,7 +410,7 @@ function assertTrackedScenarioMarkup(
     case 'w:ins':
       if (
         !documentXml.includes('<w:ins') ||
-        !normalizeDocumentXmlText(documentXml).includes(scenario.insertedText)
+        !normalizeDocumentXmlText(documentXml).includes(normalizeText(scenario.insertedText))
       ) {
         throw new Error(
           `w:ins scenario failed to emit tracked insertion markup: ${JSON.stringify(scenario)}`,
@@ -427,7 +427,7 @@ function assertTrackedScenarioMarkup(
     case 'paragraph-insert':
       if (
         countTagMatches(documentXml, 'w:ins') < 2 ||
-        !normalizeDocumentXmlText(documentXml).includes(scenario.newParagraphText)
+        !normalizeDocumentXmlText(documentXml).includes(normalizeText(scenario.newParagraphText))
       ) {
         throw new Error(
           `paragraph-insert scenario failed to emit paragraph-mark + run-level insertion markup: ${JSON.stringify(scenario)}`,


### PR DESCRIPTION
## Summary

Fixes the intermittent `main` CI failure in `packages/docx-core/src/integration/lean-spec-bridge.test.ts` (`INV-RT-001` / `INV-FIELD-001`).

## Root cause

`assertTrackedScenarioMarkup` compared the **normalized** document text against the **raw** scenario string:

```ts
!normalizeDocumentXmlText(documentXml).includes(scenario.newParagraphText)
```

`normalizeDocumentXmlText` runs `normalizeText`, which collapses runs of spaces (`/ +/g` → `' '`). `scenario.insertedText` / `scenario.newParagraphText` kept their original whitespace. `paragraphArb` permits interior whitespace, so when fast-check generated multi-space text (it shrank to `"!  !"` in the observed failures) the document side became `"! !"` and `.includes()` returned `false` — a spurious assertion failure that surfaced depending on the random seed.

## Fix

Wrap the scenario text in `normalizeText` so both sides of the `.includes()` comparison are normalized identically. Applies to both the `w:ins` and `paragraph-insert` branches.

## Testing

- Ran `lean-spec-bridge.test.ts` 3× with fresh random seeds (100 runs each) — all pass.

Fixes: #203