### PR TITLE
fix(docx-mcp): allow system temp roots in path policy

### DIFF
--- a/packages/docx-mcp/src/tools/path_policy.test.ts
+++ b/packages/docx-mcp/src/tools/path_policy.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, afterEach } from 'vitest';
 import { testAllure } from '../testing/allure-test.js';
-import { enforceReadPathPolicy, enforceWritePathPolicy } from './path_policy.js';
+import {
+  enforceReadPathPolicy,
+  enforceWritePathPolicy,
+  getPlatformTempDefaults,
+} from './path_policy.js';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import os from 'node:os';
@@ -110,6 +114,28 @@ describe('enforceReadPathPolicy', () => {
       expect(result.response.success).toBe(false);
       if (!result.response.success) {
         expect(result.response.error.code).toBe('PATH_NOT_ALLOWED');
+      }
+    }
+  });
+
+  test('PATH_NOT_ALLOWED hint omits the $VAR prefix when SAFE_DOCX_ALLOWED_ROOTS is unset', async () => {
+    delete process.env.SAFE_DOCX_ALLOWED_ROOTS;
+
+    // Reject by pointing at a path under the root which is outside every default
+    // root (HOME, os.tmpdir(), platform temp). On macOS '/private/etc' is real
+    // but not a default; on Linux '/etc' suffices. realpath must succeed for
+    // the read path policy to reach the policy-error branch.
+    const candidate = process.platform === 'darwin' ? '/private/etc/hosts' : '/etc/hosts';
+
+    const result = await enforceReadPathPolicy(candidate);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.success).toBe(false);
+      if (!result.response.success) {
+        expect(result.response.error.code).toBe('PATH_NOT_ALLOWED');
+        const hint = result.response.error.hint ?? '';
+        expect(hint).toContain('SAFE_DOCX_ALLOWED_ROOTS=');
+        expect(hint).not.toContain('$SAFE_DOCX_ALLOWED_ROOTS');
       }
     }
   });
@@ -238,5 +264,19 @@ describe('enforceWritePathPolicy', () => {
 
     const result = await enforceWritePathPolicy(filePath);
     expect(result.ok).toBe(true);
+  });
+});
+
+describe('getPlatformTempDefaults', () => {
+  test('darwin includes /tmp and /private/tmp (canonical form of /tmp on macOS)', () => {
+    expect(getPlatformTempDefaults('darwin')).toEqual(['/tmp', '/private/tmp']);
+  });
+
+  test('linux includes /tmp only — /private/tmp is not a real Linux path and would leave a ghost root', () => {
+    expect(getPlatformTempDefaults('linux')).toEqual(['/tmp']);
+  });
+
+  test('win32 is empty — os.tmpdir() already covers %TEMP%/%TMP%', () => {
+    expect(getPlatformTempDefaults('win32')).toEqual([]);
   });
 });

--- a/packages/docx-mcp/src/tools/path_policy.test.ts
+++ b/packages/docx-mcp/src/tools/path_policy.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, afterEach } from 'vitest';
-import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { testAllure } from '../testing/allure-test.js';
 import { enforceReadPathPolicy, enforceWritePathPolicy } from './path_policy.js';
 import fs from 'node:fs/promises';
 import path from 'node:path';
@@ -77,6 +77,66 @@ describe('enforceReadPathPolicy', () => {
     }
   });
 
+  test('allows paths under the common POSIX /tmp directory by default', async () => {
+    if (process.platform === 'win32') return;
+
+    const tmpDir = await fs.mkdtemp(path.join('/tmp', 'policy-system-tmp-'));
+    tmpDirs.push(tmpDir);
+    const filePath = path.join(tmpDir, 'test.docx');
+    await fs.writeFile(filePath, 'data');
+
+    const result = await enforceReadPathPolicy(filePath);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.allowedRoots).toContain(await fs.realpath('/tmp'));
+    }
+  });
+
+  test('explicit allowed roots override the default POSIX /tmp allowance', async () => {
+    if (process.platform === 'win32') return;
+
+    const allowedDir = await fs.mkdtemp(path.join(os.tmpdir(), 'policy-explicit-allowed-'));
+    tmpDirs.push(allowedDir);
+    process.env.SAFE_DOCX_ALLOWED_ROOTS = allowedDir;
+
+    const tmpDir = await fs.mkdtemp(path.join('/tmp', 'policy-explicit-tmp-'));
+    tmpDirs.push(tmpDir);
+    const filePath = path.join(tmpDir, 'test.docx');
+    await fs.writeFile(filePath, 'data');
+
+    const result = await enforceReadPathPolicy(filePath);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.success).toBe(false);
+      if (!result.response.success) {
+        expect(result.response.error.code).toBe('PATH_NOT_ALLOWED');
+      }
+    }
+  });
+
+  test('PATH_NOT_ALLOWED hint includes a delimiter-aware SAFE_DOCX_ALLOWED_ROOTS fix', async () => {
+    const allowedDir = await fs.mkdtemp(path.join(os.tmpdir(), 'policy-hint-allowed-'));
+    tmpDirs.push(allowedDir);
+    process.env.SAFE_DOCX_ALLOWED_ROOTS = allowedDir;
+
+    const otherDir = await fs.mkdtemp(path.join(os.tmpdir(), 'policy-hint-other-'));
+    tmpDirs.push(otherDir);
+    const filePath = path.join(otherDir, 'test.docx');
+    await fs.writeFile(filePath, 'test');
+
+    const result = await enforceReadPathPolicy(filePath);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.success).toBe(false);
+      if (!result.response.success) {
+        const realOtherDir = await fs.realpath(otherDir);
+        expect(result.response.error.code).toBe('PATH_NOT_ALLOWED');
+        expect(result.response.error.hint).toContain('SAFE_DOCX_ALLOWED_ROOTS=');
+        expect(result.response.error.hint).toContain(`$SAFE_DOCX_ALLOWED_ROOTS${path.delimiter}${realOtherDir}`);
+      }
+    }
+  });
+
   test('expands tilde in path', async () => {
     // This test verifies tilde expansion works; the actual resolution
     // may fail if file doesn't exist, but the normalization should work
@@ -126,6 +186,20 @@ describe('enforceWritePathPolicy', () => {
 
     const result = await enforceWritePathPolicy(filePath);
     expect(result.ok).toBe(true);
+  });
+
+  test('allows write paths under the common POSIX /tmp directory by default', async () => {
+    if (process.platform === 'win32') return;
+
+    const tmpDir = await fs.mkdtemp(path.join('/tmp', 'policy-system-write-'));
+    tmpDirs.push(tmpDir);
+    const filePath = path.join(tmpDir, 'output.docx');
+
+    const result = await enforceWritePathPolicy(filePath);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.allowedRoots).toContain(await fs.realpath('/tmp'));
+    }
   });
 
   test('allows write to non-existent file in existing directory', async () => {

--- a/packages/docx-mcp/src/tools/path_policy.ts
+++ b/packages/docx-mcp/src/tools/path_policy.ts
@@ -33,6 +33,18 @@ async function canonicalizePath(inputPath: string): Promise<string> {
   }
 }
 
+// On Linux `/private/tmp` does not exist by default. If we listed it as a root,
+// `canonicalizePath`'s realpath-fallback would leave it as a ghost entry whose
+// subpaths `resolveWritePathWithExistingAncestor` would still match (walking up
+// to `/` as the existing ancestor), silently allowing writes the user never
+// opted into. Restrict `/private/tmp` to darwin where it is the canonical form
+// of `/tmp`. Windows already covers `%TEMP%/%TMP%` via `os.tmpdir()`.
+export function getPlatformTempDefaults(platform: NodeJS.Platform = process.platform): string[] {
+  if (platform === 'darwin') return ['/tmp', '/private/tmp'];
+  if (platform === 'win32') return [];
+  return ['/tmp'];
+}
+
 async function resolveAllowedRoots(): Promise<string[]> {
   const configured = process.env.SAFE_DOCX_ALLOWED_ROOTS;
   const fromEnv = configured
@@ -41,10 +53,9 @@ async function resolveAllowedRoots(): Promise<string[]> {
       .map((entry) => entry.trim())
       .filter((entry) => entry.length > 0)
     : [];
-  const platformTempDefaults = process.platform === 'win32' ? [] : ['/tmp', '/private/tmp'];
   const defaults = fromEnv.length > 0
     ? fromEnv
-    : [process.env.HOME ?? '', os.tmpdir(), ...platformTempDefaults].filter((entry) => entry.length > 0);
+    : [process.env.HOME ?? '', os.tmpdir(), ...getPlatformTempDefaults()].filter((entry) => entry.length > 0);
 
   const out: string[] = [];
   const seen = new Set<string>();
@@ -70,12 +81,15 @@ function policyError(
   allowedRoots: string[],
 ): ToolResponse {
   const suggestedRoot = path.dirname(resolvedPath);
+  const exampleEnv = process.env.SAFE_DOCX_ALLOWED_ROOTS
+    ? `SAFE_DOCX_ALLOWED_ROOTS="$SAFE_DOCX_ALLOWED_ROOTS${path.delimiter}${suggestedRoot}"`
+    : `SAFE_DOCX_ALLOWED_ROOTS="${suggestedRoot}"`;
   return err(
     'PATH_NOT_ALLOWED',
     `Refusing to ${type} path outside allowed roots: ${inputPath} -> ${resolvedPath}`,
     [
       `Allowed roots: ${allowedRoots.join(', ')}.`,
-      `To allow this path, restart the MCP server with SAFE_DOCX_ALLOWED_ROOTS="$SAFE_DOCX_ALLOWED_ROOTS${path.delimiter}${suggestedRoot}".`,
+      `To allow this path, restart the MCP server with ${exampleEnv}.`,
     ].join(' '),
   );
 }

--- a/packages/docx-mcp/src/tools/path_policy.ts
+++ b/packages/docx-mcp/src/tools/path_policy.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs/promises';
-import { errorCode, errorMessage } from "../error_utils.js";
+import { errorMessage } from "../error_utils.js";
 import os from 'node:os';
 import path from 'node:path';
 import { err, type ToolResponse } from './types.js';
@@ -41,9 +41,10 @@ async function resolveAllowedRoots(): Promise<string[]> {
       .map((entry) => entry.trim())
       .filter((entry) => entry.length > 0)
     : [];
+  const platformTempDefaults = process.platform === 'win32' ? [] : ['/tmp', '/private/tmp'];
   const defaults = fromEnv.length > 0
     ? fromEnv
-    : [process.env.HOME ?? '', os.tmpdir()].filter((entry) => entry.length > 0);
+    : [process.env.HOME ?? '', os.tmpdir(), ...platformTempDefaults].filter((entry) => entry.length > 0);
 
   const out: string[] = [];
   const seen = new Set<string>();
@@ -68,10 +69,14 @@ function policyError(
   resolvedPath: string,
   allowedRoots: string[],
 ): ToolResponse {
+  const suggestedRoot = path.dirname(resolvedPath);
   return err(
     'PATH_NOT_ALLOWED',
     `Refusing to ${type} path outside allowed roots: ${inputPath} -> ${resolvedPath}`,
-    `Allowed roots: ${allowedRoots.join(', ')}. Configure SAFE_DOCX_ALLOWED_ROOTS if needed.`,
+    [
+      `Allowed roots: ${allowedRoots.join(', ')}.`,
+      `To allow this path, restart the MCP server with SAFE_DOCX_ALLOWED_ROOTS="$SAFE_DOCX_ALLOWED_ROOTS${path.delimiter}${suggestedRoot}".`,
+    ].join(' '),
   );
 }
 


### PR DESCRIPTION
## Summary

Fixes #192.

This updates the docx-mcp path policy so the default allowed roots include common POSIX system temp directories (`/tmp` and `/private/tmp`) alongside `$HOME` and `os.tmpdir()`. Explicit `SAFE_DOCX_ALLOWED_ROOTS` configuration remains a full override for hardened deployments.

The `PATH_NOT_ALLOWED` hint now includes a pasteable, delimiter-aware `SAFE_DOCX_ALLOWED_ROOTS` example using the rejected path's resolved directory.

## Why

On macOS, `os.tmpdir()` resolves to a per-user `/var/folders/.../T` path, while `/tmp` canonicalizes to `/private/tmp`. That meant files staged in `/tmp` were rejected by default even though `/tmp` is the common system scratch directory users and agents expect to work.

## Validation

- `npm run test:run -w @usejunior/docx-mcp -- src/tools/path_policy.test.ts`
- `npm run lint -w @usejunior/docx-mcp`