### PR TITLE
fix(docx-core): partition field-closure validation by ECMA-376 story (#212)

### DIFF
--- a/packages/docx-core/src/baselines/atomizer/pipeline.field-validation.test.ts
+++ b/packages/docx-core/src/baselines/atomizer/pipeline.field-validation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect } from 'vitest';
 import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
-import { validateFieldStructure } from './pipeline.js';
+import { splitStories, validateFieldStructure } from './pipeline.js';
 
 const test = testAllure
   .epic('Document Comparison')
@@ -247,6 +247,224 @@ describe('validateFieldStructure', () => {
       });
       await then('it passes', () => {
         expect(ok).toBe(true);
+      });
+    },
+  );
+});
+
+// =============================================================================
+// Per-story validation (issue #212)
+//
+// ECMA-376 Part 4 (fldChar topic) treats each footnote and endnote entry as
+// its own document story. A complex field whose begin/end markers straddle a
+// story boundary breaks Word's field state machine even when global counts
+// balance — the renderer discards the field characters and emits the runs as
+// literal text. These tests exercise the per-story partitioning provided by
+// `splitStories` + the array-input form of `validateFieldStructure`.
+// =============================================================================
+
+function buildFootnotes(entries: Array<{ id: string; content: string; type?: string }>): string {
+  const body = entries
+    .map(
+      (e) =>
+        `<w:footnote w:id="${e.id}"${e.type ? ` w:type="${e.type}"` : ''}>${e.content}</w:footnote>`,
+    )
+    .join('');
+  return (
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<w:footnotes ${NS}>${body}</w:footnotes>`
+  );
+}
+
+function buildEndnotes(entries: Array<{ id: string; content: string; type?: string }>): string {
+  const body = entries
+    .map(
+      (e) =>
+        `<w:endnote w:id="${e.id}"${e.type ? ` w:type="${e.type}"` : ''}>${e.content}</w:endnote>`,
+    )
+    .join('');
+  return (
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<w:endnotes ${NS}>${body}</w:endnotes>`
+  );
+}
+
+const DOC_WITH_FOOTNOTE_REF = buildDoc(
+  `<w:p><w:r><w:footnoteReference w:id="1"/></w:r></w:p>`,
+);
+
+const DOC_WITH_OPEN_FIELD_AND_FOOTNOTE_REF = buildDoc(
+  `<w:p>` +
+    `<w:r><w:fldChar w:fldCharType="begin"/></w:r>` +
+    `<w:r><w:instrText xml:space="preserve"> PAGE </w:instrText></w:r>` +
+    `<w:r><w:footnoteReference w:id="1"/></w:r>` +
+    `</w:p>`,
+);
+
+describe('validateFieldStructure: per-story (issue #212)', () => {
+  test(
+    'balanced field inside a footnote entry is valid',
+    async ({ given, when, then }: AllureBddContext) => {
+      let stories: ReturnType<typeof splitStories> = [];
+      let ok = false;
+
+      await given('a footnote entry containing a complete NUMPAGES field', () => {
+        const footnotesXml = buildFootnotes([
+          { id: '1', content: `<w:p>${COMPLETE_FIELD}</w:p>` },
+        ]);
+        stories = splitStories(DOC_WITH_FOOTNOTE_REF, [footnotesXml], [null]);
+      });
+      await when('the multi-story input is validated', () => {
+        ok = validateFieldStructure(stories);
+      });
+      await then('it passes', () => {
+        expect(ok).toBe(true);
+      });
+    },
+  );
+
+  test(
+    'field that opens in the main body and "ends" in a footnote is rejected',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      let stories: ReturnType<typeof splitStories> = [];
+      let ok = true;
+      let globalCountsBalance = false;
+
+      await given(
+        'a body with an unclosed fldChar[begin] and a footnote whose only fldChar is an unbalanced end',
+        () => {
+          const footnotesXml = buildFootnotes([
+            {
+              id: '1',
+              content:
+                `<w:p>` +
+                `<w:r><w:fldChar w:fldCharType="separate"/></w:r>` +
+                `<w:r><w:t>x</w:t></w:r>` +
+                `<w:r><w:fldChar w:fldCharType="end"/></w:r>` +
+                `</w:p>`,
+            },
+          ]);
+          stories = splitStories(DOC_WITH_OPEN_FIELD_AND_FOOTNOTE_REF, [footnotesXml], [null]);
+          const allXml = stories.map((s) => s.xml).join('');
+          const begins = (allXml.match(/w:fldCharType="begin"/g) ?? []).length;
+          const ends = (allXml.match(/w:fldCharType="end"/g) ?? []).length;
+          globalCountsBalance = begins === ends;
+        },
+      );
+      await and('global fldChar begin/end counts across all stories happen to balance', () => {
+        expect(globalCountsBalance).toBe(true);
+      });
+      await when('the multi-story input is validated', () => {
+        ok = validateFieldStructure(stories);
+      });
+      await then('it is rejected — the unbalanced body story trips the per-story check', () => {
+        expect(ok).toBe(false);
+      });
+    },
+  );
+
+  test(
+    'a footnote with an unclosed field is rejected',
+    async ({ given, when, then }: AllureBddContext) => {
+      let stories: ReturnType<typeof splitStories> = [];
+      let ok = true;
+
+      await given('a body without fields and a footnote whose field begin has no matching end', () => {
+        const footnotesXml = buildFootnotes([
+          {
+            id: '1',
+            content:
+              `<w:p>` +
+              `<w:r><w:fldChar w:fldCharType="begin"/></w:r>` +
+              `<w:r><w:instrText xml:space="preserve"> PAGE </w:instrText></w:r>` +
+              `<w:r><w:fldChar w:fldCharType="separate"/></w:r>` +
+              `<w:r><w:t>3</w:t></w:r>` +
+              `</w:p>`,
+          },
+        ]);
+        stories = splitStories(DOC_WITH_FOOTNOTE_REF, [footnotesXml], [null]);
+      });
+      await when('the multi-story input is validated', () => {
+        ok = validateFieldStructure(stories);
+      });
+      await then('it is rejected', () => {
+        expect(ok).toBe(false);
+      });
+    },
+  );
+
+  test(
+    'separator footnote entries with no field content pass',
+    async ({ given, when, then }: AllureBddContext) => {
+      let stories: ReturnType<typeof splitStories> = [];
+      let ok = false;
+
+      await given('a footnotes sidecar containing only the standard separator entries', () => {
+        const footnotesXml = buildFootnotes([
+          { id: '-1', type: 'separator', content: `<w:p><w:r><w:separator/></w:r></w:p>` },
+          {
+            id: '0',
+            type: 'continuationSeparator',
+            content: `<w:p><w:r><w:continuationSeparator/></w:r></w:p>`,
+          },
+        ]);
+        stories = splitStories(
+          buildDoc(`<w:p><w:r><w:t>hi</w:t></w:r></w:p>`),
+          [footnotesXml],
+          [null],
+        );
+      });
+      await when('the multi-story input is validated', () => {
+        ok = validateFieldStructure(stories);
+      });
+      await then('it passes', () => {
+        expect(ok).toBe(true);
+      });
+    },
+  );
+
+  test(
+    'a balanced field inside an endnote entry is valid',
+    async ({ given, when, then }: AllureBddContext) => {
+      let stories: ReturnType<typeof splitStories> = [];
+      let ok = false;
+
+      await given('an endnotes sidecar with one entry containing a complete field', () => {
+        const endnotesXml = buildEndnotes([
+          { id: '1', content: `<w:p>${COMPLETE_FIELD}</w:p>` },
+        ]);
+        stories = splitStories(
+          buildDoc(`<w:p><w:r><w:endnoteReference w:id="1"/></w:r></w:p>`),
+          [null],
+          [endnotesXml],
+        );
+      });
+      await when('the multi-story input is validated', () => {
+        ok = validateFieldStructure(stories);
+      });
+      await then('it passes', () => {
+        expect(ok).toBe(true);
+      });
+    },
+  );
+
+  test(
+    'missing footnote/endnote sidecars yield a single document story',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      let stories: ReturnType<typeof splitStories> = [];
+
+      await given('a document with no footnote or endnote sidecars', () => {
+        stories = splitStories(buildDoc(`<w:p><w:r><w:t>hi</w:t></w:r></w:p>`), [null], [null]);
+      });
+      await when('split into stories', () => {
+        // no-op; splitStories already ran
+      });
+      await then('only the document story is emitted', () => {
+        expect(stories).toHaveLength(1);
+        expect(stories[0]?.label).toBe('document');
+      });
+      await and('validation still succeeds via the array path', () => {
+        expect(validateFieldStructure(stories)).toBe(true);
       });
     },
   );

--- a/packages/docx-core/src/baselines/atomizer/pipeline.ts
+++ b/packages/docx-core/src/baselines/atomizer/pipeline.ts
@@ -342,11 +342,81 @@ function buildFailureSummary(
   return Object.keys(summary).length > 0 ? summary : undefined;
 }
 
+// Declared above splitStories so the function body never observes an
+// uninitialized binding under circular imports.
+const serializer = new XMLSerializer();
+
 /**
- * Validate field structure integrity in document XML.
+ * One story (a self-contained complex-field state machine per ECMA-376 Part 4):
+ * the main document body, an individual footnote entry, or an individual
+ * endnote entry. `label` is for diagnostics only; `xml` is the serialized
+ * fragment that gets parsed and walked.
+ */
+export interface FieldStory {
+  label: string;
+  xml: string;
+}
+
+/**
+ * Split a docx into per-story XML fragments for field-closure validation.
  *
- * Enforces three ECMA-376 Part 4 constraints on complex fields:
- *   1. Global `w:fldChar` begin/end count balance.
+ * ECMA-376 Part 4 treats each footnote/endnote entry as an isolated story:
+ * a complex field whose `begin` and `end` markers straddle stories breaks
+ * Word's field state machine. We therefore validate each `<w:footnote>` and
+ * `<w:endnote>` entry independently rather than treating the whole
+ * `footnotes.xml`/`endnotes.xml` as one stream.
+ *
+ * Accepts arrays of sidecar XMLs (one per source archive) so callers can
+ * validate the union of entries from every archive that may contribute to the
+ * final result. Step 12 of `compareDocumentsAtomizer` merges entries from a
+ * mode-dependent source archive into the base archive; passing both archives'
+ * sidecars guarantees that whichever path the merge takes, the entries it
+ * could publish have already been screened. Duplicates (same `w:id` in both
+ * archives) yield redundant but harmless validation work.
+ *
+ * Header/footer stories are not yet covered — they require relationship
+ * walking to enumerate `headerN.xml`/`footerN.xml` and are tracked in a
+ * follow-up to issue #212.
+ */
+export function splitStories(
+  documentXml: string,
+  footnotesXmls: ReadonlyArray<string | null>,
+  endnotesXmls: ReadonlyArray<string | null>,
+): FieldStory[] {
+  const stories: FieldStory[] = [{ label: 'document', xml: documentXml }];
+
+  const collectEntries = (
+    sidecars: ReadonlyArray<string | null>,
+    entryTag: string,
+    labelPrefix: string,
+  ): void => {
+    for (let s = 0; s < sidecars.length; s++) {
+      const sidecarXml = sidecars[s];
+      if (!sidecarXml) continue;
+      const doc = parseXml(sidecarXml);
+      const entries = doc.getElementsByTagName(entryTag);
+      for (let i = 0; i < entries.length; i++) {
+        const entry = entries[i] as Element;
+        const id = entry.getAttribute('w:id') ?? String(i);
+        stories.push({
+          label: `${labelPrefix}[${s}]:${id}`,
+          xml: serializer.serializeToString(entry),
+        });
+      }
+    }
+  };
+
+  collectEntries(footnotesXmls, 'w:footnote', 'footnote');
+  collectEntries(endnotesXmls, 'w:endnote', 'endnote');
+
+  return stories;
+}
+
+/**
+ * Validate field structure integrity across one or more document stories.
+ *
+ * Enforces three ECMA-376 Part 4 constraints on complex fields **per story**:
+ *   1. `w:fldChar` begin/end count balance within the story.
  *   2. Every `w:instrText` AND `w:delInstrText` sits inside an open field body
  *      (between `begin` and `separate`). Orphaned instruction text renders as
  *      literal text in Word.
@@ -357,8 +427,22 @@ function buildFailureSummary(
  * Called on both pre-accept/reject combined XML (with track-change wrappers)
  * and on post-accept/reject XML (wrappers removed). Both cases must satisfy the
  * field placement check; constraint (3) is vacuous post-accept/reject.
+ *
+ * Accepts either a single XML string (legacy single-story call) or an array of
+ * `FieldStory` fragments. Stories are validated independently and short-circuit
+ * on the first failure.
  */
-export function validateFieldStructure(documentXml: string): boolean {
+export function validateFieldStructure(input: string | FieldStory[]): boolean {
+  if (typeof input === 'string') {
+    return validateFieldStructureForStory(input);
+  }
+  for (const story of input) {
+    if (!validateFieldStructureForStory(story.xml)) return false;
+  }
+  return true;
+}
+
+function validateFieldStructureForStory(documentXml: string): boolean {
   const root = parseDocumentXml(documentXml);
 
   const allFldChars = findAllByTagName(root, 'w:fldChar');
@@ -434,7 +518,11 @@ function evaluateSafetyChecks(
   revisedTextForRoundTrip: string,
   originalBookmarkDiagnostics: BookmarkDiagnostics,
   revisedBookmarkDiagnostics: BookmarkDiagnostics,
-  candidateXml: string
+  candidateXml: string,
+  auxiliarySidecars: {
+    footnotesXmls: ReadonlyArray<string | null>;
+    endnotesXmls: ReadonlyArray<string | null>;
+  },
 ): {
   safe: boolean;
   checks: ReconstructionSafetyChecks;
@@ -460,12 +548,27 @@ function evaluateSafetyChecks(
     rejectedBookmarkDiagnostics
   );
 
-  // Validate field structure: after accept-all and reject-all, every
-  // w:instrText must be inside a proper field sequence (between fldChar
-  // begin and fldChar separate). Orphaned instrText renders as visible
-  // text in Word.
+  // Validate field structure per-story. Each footnote/endnote entry is its own
+  // ECMA-376 story; a complex field that crosses a story boundary breaks
+  // Word's field state machine even when global begin/end counts balance.
+  // Sidecars from BOTH archives are validated because Step 12's auxiliary-part
+  // merge picks its base and source archives by reconstruction mode (inplace
+  // base = revised; rebuild base = original) and validating only one side
+  // would miss field issues that would still ship in the merged result.
+  // `acceptAllChanges` / `rejectAllChanges` only transform document.xml, so
+  // the sidecar set is identical for both transforms.
+  const acceptedStories = splitStories(
+    acceptedXml,
+    auxiliarySidecars.footnotesXmls,
+    auxiliarySidecars.endnotesXmls,
+  );
+  const rejectedStories = splitStories(
+    rejectedXml,
+    auxiliarySidecars.footnotesXmls,
+    auxiliarySidecars.endnotesXmls,
+  );
   const fieldStructureOk =
-    validateFieldStructure(acceptedXml) && validateFieldStructure(rejectedXml);
+    validateFieldStructure(acceptedStories) && validateFieldStructure(rejectedStories);
 
   const checks: ReconstructionSafetyChecks = {
     acceptText: acceptTextComparison.normalizedIdentical,
@@ -579,6 +682,28 @@ export async function compareDocumentsAtomizer(
   const originalNumberingXml = await originalArchive.getNumberingXml() ?? undefined;
   const revisedNumberingXml = await revisedArchive.getNumberingXml() ?? undefined;
 
+  // Extract footnote/endnote sidecars from BOTH archives for per-story
+  // field-closure validation (issue #212). Step 12 picks the base archive by
+  // reconstruction mode (inplace = revised, rebuild = original) and merges
+  // missing referenced entries from the opposite archive. Validating both
+  // archives' sidecars covers the union of entries that could ship without
+  // having to duplicate the merge logic at safety-check time.
+  const [
+    originalFootnotesXml,
+    originalEndnotesXml,
+    revisedFootnotesXml,
+    revisedEndnotesXml,
+  ] = await Promise.all([
+    originalArchive.getFile('word/footnotes.xml'),
+    originalArchive.getFile('word/endnotes.xml'),
+    revisedArchive.getFile('word/footnotes.xml'),
+    revisedArchive.getFile('word/endnotes.xml'),
+  ]);
+  const auxiliarySidecars = {
+    footnotesXmls: [originalFootnotesXml, revisedFootnotesXml] as const,
+    endnotesXmls: [originalEndnotesXml, revisedEndnotesXml] as const,
+  };
+
   const originalPart: OpcPart = {
     uri: 'word/document.xml',
     contentType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml',
@@ -684,7 +809,8 @@ export async function compareDocumentsAtomizer(
       revisedTextForRoundTrip,
       originalBookmarkDiagnostics,
       revisedBookmarkDiagnostics,
-      candidateXml
+      candidateXml,
+      auxiliarySidecars,
     );
 
   let comparisonResult: {
@@ -925,8 +1051,6 @@ function parseEntries(xml: string, entryTag: string): { doc: Document; entries: 
   }
   return { doc, entries };
 }
-
-const serializer = new XMLSerializer();
 
 /**
  * Merge auxiliary part definitions (footnotes, endnotes, comments) from the

--- a/packages/docx-core/src/integration/field-cross-story-pipeline.test.ts
+++ b/packages/docx-core/src/integration/field-cross-story-pipeline.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Integration Tests — Cross-story field-closure check at the pipeline level (#212)
+ *
+ * Verifies that `compareDocumentsAtomizer`'s round-trip safety evaluation
+ * runs `validateFieldStructure` per ECMA-376 story (document body + each
+ * footnote/endnote entry) using sidecars from BOTH archives. A cross-story
+ * unbalanced field — one whose `fldChar begin`/`end` markers straddle the
+ * body and a footnote — must be detected even when global fldChar counts
+ * across all stories balance.
+ */
+
+import { describe, expect } from 'vitest';
+import JSZip from 'jszip';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { compareDocuments } from '../index.js';
+
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({ feature: 'Cross-story Field Closure (#212)' });
+
+const NS = 'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
+const NS14 = 'xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"';
+
+interface DocxParts {
+  bodyXml: string;
+  footnotesXml: string | null;
+}
+
+async function buildDocxWithFootnotes(parts: DocxParts): Promise<Buffer> {
+  const documentXml =
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<w:document ${NS} ${NS14}>` +
+    `<w:body>${parts.bodyXml}<w:sectPr/></w:body></w:document>`;
+
+  const contentTypeOverrides = [
+    `<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>`,
+  ];
+  const docRelEntries: string[] = [];
+
+  const zip = new JSZip();
+  if (parts.footnotesXml) {
+    zip.file('word/footnotes.xml', parts.footnotesXml);
+    contentTypeOverrides.push(
+      `<Override PartName="/word/footnotes.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footnotes+xml"/>`,
+    );
+    docRelEntries.push(
+      `<Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/footnotes" Target="footnotes.xml"/>`,
+    );
+  }
+
+  const contentTypesXml =
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+    `<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+    `<Default Extension="xml" ContentType="application/xml"/>` +
+    contentTypeOverrides.join('') +
+    `</Types>`;
+
+  const rootRelsXml =
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+    `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>` +
+    `</Relationships>`;
+
+  const docRelsXml =
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+    docRelEntries.join('') +
+    `</Relationships>`;
+
+  zip.file('[Content_Types].xml', contentTypesXml);
+  zip.file('_rels/.rels', rootRelsXml);
+  zip.file('word/document.xml', documentXml);
+  zip.file('word/_rels/document.xml.rels', docRelsXml);
+
+  return (await zip.generateAsync({ type: 'nodebuffer' })) as Buffer;
+}
+
+const BODY_WITH_FOOTNOTE_REF = (text: string): string =>
+  `<w:p>` +
+  `<w:r><w:t xml:space="preserve">${text} </w:t></w:r>` +
+  `<w:r><w:rPr><w:rStyle w:val="FootnoteReference"/></w:rPr><w:footnoteReference w:id="1"/></w:r>` +
+  `</w:p>`;
+
+const VALID_FOOTNOTES = (footnoteContent: string): string =>
+  `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+  `<w:footnotes ${NS}>` +
+  `<w:footnote w:type="separator" w:id="-1"><w:p><w:r><w:separator/></w:r></w:p></w:footnote>` +
+  `<w:footnote w:type="continuationSeparator" w:id="0"><w:p><w:r><w:continuationSeparator/></w:r></w:p></w:footnote>` +
+  `<w:footnote w:id="1">${footnoteContent}</w:footnote>` +
+  `</w:footnotes>`;
+
+const PLAIN_FOOTNOTE_BODY = `<w:p><w:r><w:t>see source</w:t></w:r></w:p>`;
+
+// Field begin with no matching end inside the footnote story. Note: with no
+// field characters in the body, global counts across all stories are 1:0 —
+// this case would also be caught by the legacy global-balance check. Useful
+// for verifying the sidecar plumbing works end-to-end.
+const UNCLOSED_FIELD_FOOTNOTE_BODY =
+  `<w:p>` +
+  `<w:r><w:fldChar w:fldCharType="begin"/></w:r>` +
+  `<w:r><w:instrText xml:space="preserve"> PAGE </w:instrText></w:r>` +
+  `<w:r><w:fldChar w:fldCharType="separate"/></w:r>` +
+  `<w:r><w:t>3</w:t></w:r>` +
+  `</w:p>`;
+
+// Body opens a field (begin + instrText) but never closes it. The footnote
+// has a stray separate + end with no matching begin. GLOBAL counts:
+// 1 begin / 1 end → balanced. PER-STORY counts: body 1:0, footnote 0:1 →
+// both unbalanced. Only a per-story partitioning check catches this; the
+// legacy global counter would have passed it. This is the fixture that
+// actually proves the per-story refactor is doing the work.
+const BODY_WITH_OPEN_FIELD_AND_FOOTNOTE_REF = (text: string): string =>
+  `<w:p>` +
+  `<w:r><w:t xml:space="preserve">${text} </w:t></w:r>` +
+  `<w:r><w:fldChar w:fldCharType="begin"/></w:r>` +
+  `<w:r><w:instrText xml:space="preserve"> PAGE </w:instrText></w:r>` +
+  `<w:r><w:rPr><w:rStyle w:val="FootnoteReference"/></w:rPr><w:footnoteReference w:id="1"/></w:r>` +
+  `</w:p>`;
+
+const END_ONLY_FIELD_FOOTNOTE_BODY =
+  `<w:p>` +
+  `<w:r><w:fldChar w:fldCharType="separate"/></w:r>` +
+  `<w:r><w:t>3</w:t></w:r>` +
+  `<w:r><w:fldChar w:fldCharType="end"/></w:r>` +
+  `</w:p>`;
+
+describe('Cross-story field-closure check (issue #212) — pipeline-level', () => {
+  test(
+    'inplace comparison with a malformed field inside a footnote falls back to rebuild via fieldStructure failure',
+    async ({ given, when, then, and, attachPrettyJson }: AllureBddContext) => {
+      let original: Buffer = Buffer.alloc(0);
+      let revised: Buffer = Buffer.alloc(0);
+      let result: Awaited<ReturnType<typeof compareDocuments>>;
+
+      await given(
+        'original/revised pair whose footnotes sidecar contains a fldChar begin with no matching end',
+        async () => {
+          const malformedFootnotes = VALID_FOOTNOTES(UNCLOSED_FIELD_FOOTNOTE_BODY);
+          original = await buildDocxWithFootnotes({
+            bodyXml: BODY_WITH_FOOTNOTE_REF('Hello'),
+            footnotesXml: malformedFootnotes,
+          });
+          revised = await buildDocxWithFootnotes({
+            bodyXml: BODY_WITH_FOOTNOTE_REF('Hello world'),
+            footnotesXml: malformedFootnotes,
+          });
+        },
+      );
+
+      await when('compared in inplace mode', async () => {
+        result = await compareDocuments(original, revised, {
+          engine: 'atomizer',
+          reconstructionMode: 'inplace',
+        });
+        await attachPrettyJson('comparison-metadata.json', {
+          reconstructionModeUsed: result.reconstructionModeUsed,
+          fallbackReason: result.fallbackReason,
+          fallbackDiagnostics: result.fallbackDiagnostics,
+        });
+      });
+
+      await then('every inplace attempt records fieldStructure as failed', () => {
+        const attempts = result.fallbackDiagnostics?.attempts ?? [];
+        expect(attempts.length, 'at least one inplace attempt should be diagnosed').toBeGreaterThan(0);
+        for (const attempt of attempts) {
+          const failed = attempt.failedChecks ?? [];
+          expect(
+            failed.includes('fieldStructure'),
+            `attempt ${attempt.pass} should report fieldStructure failure but failed=${JSON.stringify(failed)}`,
+          ).toBe(true);
+        }
+      });
+
+      await and('the pipeline falls back to rebuild output', () => {
+        expect(result.reconstructionModeUsed).toBe('rebuild');
+        expect(result.fallbackReason).toBe('round_trip_safety_check_failed');
+      });
+    },
+  );
+
+  test(
+    'globally-balanced but per-story-unbalanced field across body and footnote is rejected',
+    async ({ given, when, then, and, attachPrettyJson }: AllureBddContext) => {
+      let original: Buffer = Buffer.alloc(0);
+      let revised: Buffer = Buffer.alloc(0);
+      let result: Awaited<ReturnType<typeof compareDocuments>>;
+
+      await given(
+        'a docx whose body opens a field that never closes and ONE archive has a footnote with a stray end',
+        async () => {
+          // The safety check validates sidecars from BOTH original and revised
+          // archives. Putting the malformed footnote in only ONE archive
+          // ensures the safety stream contains exactly one stray `end`. The
+          // OTHER archive has a well-formed footnote at the same w:id so the
+          // body's footnoteReference resolves and the comparison runs normally.
+          //
+          // Global safety-stream counts (across body + both archives' sidecar
+          // entries): 1 begin (body) + 1 end (original footnote, stray) +
+          // 0 (revised footnote, well-formed) = 1:1 — BALANCED. The legacy
+          // global counter would accept this. Per-story counts: body 1:0,
+          // original footnote 0:1, revised footnote 0:0 — only the per-story
+          // partitioning catches the cross-story imbalance.
+          const malformedFootnotes = VALID_FOOTNOTES(END_ONLY_FIELD_FOOTNOTE_BODY);
+          const cleanFootnotes = VALID_FOOTNOTES(PLAIN_FOOTNOTE_BODY);
+          original = await buildDocxWithFootnotes({
+            bodyXml: BODY_WITH_OPEN_FIELD_AND_FOOTNOTE_REF('Hello'),
+            footnotesXml: malformedFootnotes,
+          });
+          revised = await buildDocxWithFootnotes({
+            bodyXml: BODY_WITH_OPEN_FIELD_AND_FOOTNOTE_REF('Hello world'),
+            footnotesXml: cleanFootnotes,
+          });
+        },
+      );
+
+      await when('compared in inplace mode', async () => {
+        result = await compareDocuments(original, revised, {
+          engine: 'atomizer',
+          reconstructionMode: 'inplace',
+        });
+        await attachPrettyJson('comparison-metadata.json', {
+          reconstructionModeUsed: result.reconstructionModeUsed,
+          fallbackReason: result.fallbackReason,
+          fallbackDiagnostics: result.fallbackDiagnostics,
+        });
+      });
+
+      await then('every inplace attempt records fieldStructure as failed', () => {
+        const attempts = result.fallbackDiagnostics?.attempts ?? [];
+        expect(attempts.length, 'at least one inplace attempt should be diagnosed').toBeGreaterThan(0);
+        for (const attempt of attempts) {
+          const failed = attempt.failedChecks ?? [];
+          expect(
+            failed.includes('fieldStructure'),
+            `attempt ${attempt.pass} should report fieldStructure failure but failed=${JSON.stringify(failed)}`,
+          ).toBe(true);
+        }
+      });
+
+      await and('the pipeline falls back to rebuild output', () => {
+        expect(result.reconstructionModeUsed).toBe('rebuild');
+        expect(result.fallbackReason).toBe('round_trip_safety_check_failed');
+      });
+    },
+  );
+
+  test(
+    'inplace comparison with valid footnote fields succeeds without a safety fallback',
+    async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
+      let original: Buffer = Buffer.alloc(0);
+      let revised: Buffer = Buffer.alloc(0);
+      let result: Awaited<ReturnType<typeof compareDocuments>>;
+
+      await given('original/revised pair whose footnote is a plain non-field paragraph', async () => {
+        const footnotesXml = VALID_FOOTNOTES(PLAIN_FOOTNOTE_BODY);
+        original = await buildDocxWithFootnotes({
+          bodyXml: BODY_WITH_FOOTNOTE_REF('Hello'),
+          footnotesXml,
+        });
+        revised = await buildDocxWithFootnotes({
+          bodyXml: BODY_WITH_FOOTNOTE_REF('Hello world'),
+          footnotesXml,
+        });
+      });
+
+      await when('compared in inplace mode', async () => {
+        result = await compareDocuments(original, revised, {
+          engine: 'atomizer',
+          reconstructionMode: 'inplace',
+        });
+        await attachPrettyJson('comparison-metadata.json', {
+          reconstructionModeUsed: result.reconstructionModeUsed,
+          fallbackReason: result.fallbackReason,
+        });
+      });
+
+      await then('no field-structure failure is recorded and inplace output is used', () => {
+        expect(result.reconstructionModeUsed).toBe('inplace');
+        expect(result.fallbackReason).toBeUndefined();
+        const attempts = result.fallbackDiagnostics?.attempts ?? [];
+        for (const attempt of attempts) {
+          const failed = attempt.failedChecks ?? [];
+          expect(failed.includes('fieldStructure')).toBe(false);
+        }
+      });
+    },
+  );
+});


### PR DESCRIPTION
## Summary

Per ECMA-376 Part 4, the main body and each footnote/endnote entry are isolated complex-field state machines — a `w:fldChar begin` whose matching `end` lives in a different story breaks Word's field state machine. The existing `validateFieldStructure` only ran a global begin/end counter, so a cross-story unbalanced field could pass undetected once reconstruction starts emitting footnote XML (forthcoming via the `add-footnote-support` change).

This PR:
- Partitions validation by story (`document` + one story per `<w:footnote>` / `<w:endnote>` entry) before running the existing balance + instrText scan.
- Threads footnote/endnote sidecars through `evaluateSafetyChecks` from **both** `originalArchive` and `revisedArchive`, since Step 12's auxiliary merge picks its base by reconstruction mode (inplace = revised, rebuild = original). Validating both sidecars covers the union of entries that could ship after the merge without duplicating the merge logic.
- Moves the module-level `XMLSerializer` instance above `splitStories` to eliminate any TDZ risk under hypothetical circular imports.

## Adversarial test fixture

`field-cross-story-pipeline.test.ts` includes a fixture engineered to be **globally balanced** (1 `begin` / 1 `end` across all stories) but **per-story unbalanced**: malformed end-only footnote in the original archive only, well-formed footnote at the same `w:id` in the revised archive. Self-administered mutation test: replacing the per-story scan with a legacy global counter causes this test to fail with `expected 0 to be greater than 0` (safety passes → no fallback → no attempts recorded). Restoring the per-story scan makes the test pass. The test is provably adversarial.

## Out of scope (deferred)

- **Header/footer stories.** Cover only main + footnotes + endnotes in this PR. Headers/footers require relationship walking to enumerate `headerN.xml` / `footerN.xml`, which aren't currently loaded by the pipeline. Filing a follow-up issue.
- **Direct `rebuild` mode bypasses `evaluateRoundTripSafety` entirely.** The safety check only runs in `inplace` (or its rebuild fallback). When a caller explicitly requests `rebuild`, the field-structure check — old or new — never executes. Out of scope for #212's per-story partitioning. Filing a follow-up issue.

## Conservative tradeoff documented in code

`splitStories` validates every entry in both archives' sidecars, not only the entries that will actually be referenced from the candidate `document.xml`. This is intentional: deriving the precise effective sidecar requires running the Step 12 merge logic at safety-check time. A malformed unreferenced entry in either source archive currently triggers a fallback. We judged this acceptable — surfacing the latent bug is better than silently shipping a broken sidecar that a future change might begin referencing.

## Test plan

- [x] `npm run build` — clean
- [x] `npm run lint:workspaces` — clean (one unrelated pre-existing warning in `docx-mcp/edit.test.ts`)
- [x] `npm run test:run -w @usejunior/docx-core` — 86 files / 1262 passed / 1 skipped
- [x] `npm run test:run -w @usejunior/docx-mcp` — 73 files / 744 passed
- [x] `npm run check:spec-coverage` — all PASS
- [x] New: `pipeline.field-validation.test.ts` — 16 tests (10 original + 6 per-story unit tests)
- [x] New: `field-cross-story-pipeline.test.ts` — 3 pipeline-level tests including the **provably adversarial** globally-balanced-but-per-story-unbalanced case
- [x] Mutation test: confirmed the new fixture fails under a legacy global-count mutation of `validateFieldStructure`

Fixes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)