### PR TITLE
refactor(docx-core): extract shared OOXML test fixtures (#221)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,16 @@ Follow all conventions in [CONTRIBUTING.md](CONTRIBUTING.md). The rules below ar
 ### Pre-submit
 - All CI checks must pass locally before pushing: `npm run build && npm run lint:workspaces && npm run test:run && npm run check:spec-coverage`
 
+### Test Fixtures
+
+Before adding OOXML / DOCX test fixtures, check `packages/docx-core/src/testing/` first.
+
+- **Field XML primitives and complete-field constants** (`<w:fldChar>`, `<w:instrText>`, NUMPAGES / PAGE / PAGEREF sequences, fragmented modification patterns, whole-field `<w:ins>`/`<w:del>` wrappers): use `packages/docx-core/src/testing/ooxml-fixtures.ts`. Add new constants and helpers there rather than inline in a test file.
+- **Minimal DOCX package from raw body XML**: use `buildDocxFromBodyXml(bodyXml)` from `ooxml-fixtures.ts`. Do not copy-paste a local `JSZip` builder unless the test needs a deliberately different package shape (e.g., to test how the engine handles a missing `_rels/.rels`).
+- **Paragraph-array DOCX with optional footnote/comment/bookmark scaffolding**: use `buildSyntheticDocx` from `packages/docx-core/src/integration/synthetic-docx-fixture.ts`.
+
+Inline OOXML literals are acceptable for scenario fixtures that are *the subject* of a test (e.g., a deliberately malformed standalone-`<w:fldChar>` regression guard). They are not acceptable for re-deriving shapes that already live in the fixtures module — that produces the kind of cross-file drift issue #221 was filed to fix.
+
 ## Skills
 
 A skill is a set of local instructions stored in a `SKILL.md` file.

--- a/packages/docx-core/src/baselines/atomizer/pipeline.field-validation.test.ts
+++ b/packages/docx-core/src/baselines/atomizer/pipeline.field-validation.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect } from 'vitest';
 import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
+import {
+  COMPLETE_NUMPAGES_FIELD as COMPLETE_FIELD,
+  FRAGMENTED_NUMPAGES_MODIFICATION as MODIFIED_FIELD_FRAGMENTED,
+} from '../../testing/ooxml-fixtures.js';
 import { hasFldCharInsideDel, splitStories, validateFieldStructure } from './pipeline.js';
 
 const test = testAllure
@@ -15,26 +19,6 @@ function buildDoc(bodyXml: string): string {
     `<w:body>${bodyXml}<w:sectPr/></w:body></w:document>`
   );
 }
-
-const COMPLETE_FIELD =
-  `<w:r><w:fldChar w:fldCharType="begin"/></w:r>` +
-  `<w:r><w:instrText xml:space="preserve"> NUMPAGES </w:instrText></w:r>` +
-  `<w:r><w:fldChar w:fldCharType="separate"/></w:r>` +
-  `<w:r><w:t>3</w:t></w:r>` +
-  `<w:r><w:fldChar w:fldCharType="end"/></w:r>`;
-
-// ECMA-376 conformant field-modification pattern: a field whose instruction
-// text is changing under track changes. The fldChars remain UNWRAPPED at the
-// sibling-run level (they cannot enter <w:del>), while the changed instrText
-// fragments into <w:ins>/<w:del> wrappers. Research summary: c-rex ECMA-376
-// Part 4 fldChar topic + DeletedFieldCode placement constraint.
-const MODIFIED_FIELD_FRAGMENTED =
-  `<w:r><w:fldChar w:fldCharType="begin"/></w:r>` +
-  `<w:ins><w:r><w:instrText xml:space="preserve"> NUMPAGES </w:instrText></w:r></w:ins>` +
-  `<w:del><w:r><w:delInstrText xml:space="preserve"> PAGE </w:delInstrText></w:r></w:del>` +
-  `<w:r><w:fldChar w:fldCharType="separate"/></w:r>` +
-  `<w:r><w:t>3</w:t></w:r>` +
-  `<w:r><w:fldChar w:fldCharType="end"/></w:r>`;
 
 describe('validateFieldStructure', () => {
   test(

--- a/packages/docx-core/src/integration/collapsed-field-inplace.test.ts
+++ b/packages/docx-core/src/integration/collapsed-field-inplace.test.ts
@@ -14,7 +14,7 @@
 
 import { describe, expect } from 'vitest';
 import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
-import JSZip from 'jszip';
+import { buildDocxFromBodyXml } from '../testing/ooxml-fixtures.js';
 import { compareDocuments } from '../index.js';
 import { DocxArchive } from '../shared/docx/DocxArchive.js';
 import {
@@ -22,45 +22,6 @@ import {
   extractTextWithParagraphs,
   rejectAllChanges,
 } from '../baselines/atomizer/trackChangesAcceptorAst.js';
-
-// =============================================================================
-// Synthetic DOCX builder (field-aware)
-// =============================================================================
-
-async function createDocxWithFieldXml(bodyXml: string): Promise<Buffer> {
-  const documentXml =
-    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
-    `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"` +
-    ` xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">` +
-    `<w:body>${bodyXml}<w:sectPr/></w:body></w:document>`;
-
-  const contentTypesXml =
-    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
-    `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
-    `<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
-    `<Default Extension="xml" ContentType="application/xml"/>` +
-    `<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>` +
-    `</Types>`;
-
-  const rootRelsXml =
-    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
-    `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
-    `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>` +
-    `</Relationships>`;
-
-  const docRelsXml =
-    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
-    `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
-    `</Relationships>`;
-
-  const zip = new JSZip();
-  zip.file('[Content_Types].xml', contentTypesXml);
-  zip.file('_rels/.rels', rootRelsXml);
-  zip.file('word/document.xml', documentXml);
-  zip.file('word/_rels/document.xml.rels', docRelsXml);
-
-  return (await zip.generateAsync({ type: 'nodebuffer' })) as Buffer;
-}
 
 // =============================================================================
 // Fixture: Dedicated-run PAGEREF field (field chars in separate runs)
@@ -190,8 +151,8 @@ describe('Collapsed field inplace reconstruction', () => {
       });
 
       const [original, revised] = await Promise.all([
-        createDocxWithFieldXml(DEDICATED_RUN_FIELD_ORIGINAL),
-        createDocxWithFieldXml(DEDICATED_RUN_FIELD_REVISED),
+        buildDocxFromBodyXml(DEDICATED_RUN_FIELD_ORIGINAL),
+        buildDocxFromBodyXml(DEDICATED_RUN_FIELD_REVISED),
       ]);
 
       let result: Awaited<ReturnType<typeof compareDocuments>>;
@@ -246,8 +207,8 @@ describe('Collapsed field inplace reconstruction', () => {
       let xml: string;
       await given('original and revised dedicated-run PAGEREF fixture documents', async () => {
         const [original, revised] = await Promise.all([
-          createDocxWithFieldXml(DEDICATED_RUN_FIELD_ORIGINAL),
-          createDocxWithFieldXml(DEDICATED_RUN_FIELD_REVISED),
+          buildDocxFromBodyXml(DEDICATED_RUN_FIELD_ORIGINAL),
+          buildDocxFromBodyXml(DEDICATED_RUN_FIELD_REVISED),
         ]);
         const result = await compareDocuments(original, revised, {
           engine: 'atomizer',
@@ -271,8 +232,8 @@ describe('Collapsed field inplace reconstruction', () => {
       let xml: string;
       await given('inplace comparison result of dedicated-run PAGEREF fixtures', async () => {
         const [original, revised] = await Promise.all([
-          createDocxWithFieldXml(DEDICATED_RUN_FIELD_ORIGINAL),
-          createDocxWithFieldXml(DEDICATED_RUN_FIELD_REVISED),
+          buildDocxFromBodyXml(DEDICATED_RUN_FIELD_ORIGINAL),
+          buildDocxFromBodyXml(DEDICATED_RUN_FIELD_REVISED),
         ]);
         const result = await compareDocuments(original, revised, {
           engine: 'atomizer',
@@ -290,8 +251,8 @@ describe('Collapsed field inplace reconstruction', () => {
       let xml: string;
       await given('inplace comparison result of dedicated-run PAGEREF fixtures', async () => {
         const [original, revised] = await Promise.all([
-          createDocxWithFieldXml(DEDICATED_RUN_FIELD_ORIGINAL),
-          createDocxWithFieldXml(DEDICATED_RUN_FIELD_REVISED),
+          buildDocxFromBodyXml(DEDICATED_RUN_FIELD_ORIGINAL),
+          buildDocxFromBodyXml(DEDICATED_RUN_FIELD_REVISED),
         ]);
         const result = await compareDocuments(original, revised, {
           engine: 'atomizer',
@@ -311,8 +272,8 @@ describe('Collapsed field inplace reconstruction', () => {
       let xml: string;
       await given('inplace comparison result of dedicated-run PAGEREF fixtures', async () => {
         const [original, revised] = await Promise.all([
-          createDocxWithFieldXml(DEDICATED_RUN_FIELD_ORIGINAL),
-          createDocxWithFieldXml(DEDICATED_RUN_FIELD_REVISED),
+          buildDocxFromBodyXml(DEDICATED_RUN_FIELD_ORIGINAL),
+          buildDocxFromBodyXml(DEDICATED_RUN_FIELD_REVISED),
         ]);
         const result = await compareDocuments(original, revised, {
           engine: 'atomizer',
@@ -332,8 +293,8 @@ describe('Collapsed field inplace reconstruction', () => {
       let result: Awaited<ReturnType<typeof compareDocuments>>;
       await given('original and revised dedicated-run PAGEREF fixture documents', async () => {
         const [original, revised] = await Promise.all([
-          createDocxWithFieldXml(DEDICATED_RUN_FIELD_ORIGINAL),
-          createDocxWithFieldXml(DEDICATED_RUN_FIELD_REVISED),
+          buildDocxFromBodyXml(DEDICATED_RUN_FIELD_ORIGINAL),
+          buildDocxFromBodyXml(DEDICATED_RUN_FIELD_REVISED),
         ]);
         result = await compareDocuments(original, revised, {
           engine: 'atomizer',
@@ -359,8 +320,8 @@ describe('Collapsed field inplace reconstruction', () => {
       let xml: string;
       await when('documents are compared in inplace mode', async () => {
         const [original, revised] = await Promise.all([
-          createDocxWithFieldXml(MIXED_RUN_FIELD_ORIGINAL),
-          createDocxWithFieldXml(MIXED_RUN_FIELD_REVISED),
+          buildDocxFromBodyXml(MIXED_RUN_FIELD_ORIGINAL),
+          buildDocxFromBodyXml(MIXED_RUN_FIELD_REVISED),
         ]);
         const result = await compareDocuments(original, revised, {
           engine: 'atomizer',
@@ -387,8 +348,8 @@ describe('Collapsed field inplace reconstruction', () => {
       let xml: string;
       await given('inplace comparison result of mixed-run REF fixtures', async () => {
         const [original, revised] = await Promise.all([
-          createDocxWithFieldXml(MIXED_RUN_FIELD_ORIGINAL),
-          createDocxWithFieldXml(MIXED_RUN_FIELD_REVISED),
+          buildDocxFromBodyXml(MIXED_RUN_FIELD_ORIGINAL),
+          buildDocxFromBodyXml(MIXED_RUN_FIELD_REVISED),
         ]);
         const result = await compareDocuments(original, revised, {
           engine: 'atomizer',
@@ -408,8 +369,8 @@ describe('Collapsed field inplace reconstruction', () => {
       let xml: string;
       await given('inplace comparison result of mixed-run REF fixtures', async () => {
         const [original, revised] = await Promise.all([
-          createDocxWithFieldXml(MIXED_RUN_FIELD_ORIGINAL),
-          createDocxWithFieldXml(MIXED_RUN_FIELD_REVISED),
+          buildDocxFromBodyXml(MIXED_RUN_FIELD_ORIGINAL),
+          buildDocxFromBodyXml(MIXED_RUN_FIELD_REVISED),
         ]);
         const result = await compareDocuments(original, revised, {
           engine: 'atomizer',
@@ -429,8 +390,8 @@ describe('Collapsed field inplace reconstruction', () => {
       let xml: string;
       await given('inplace comparison result of mixed-run REF fixtures', async () => {
         const [original, revised] = await Promise.all([
-          createDocxWithFieldXml(MIXED_RUN_FIELD_ORIGINAL),
-          createDocxWithFieldXml(MIXED_RUN_FIELD_REVISED),
+          buildDocxFromBodyXml(MIXED_RUN_FIELD_ORIGINAL),
+          buildDocxFromBodyXml(MIXED_RUN_FIELD_REVISED),
         ]);
         const result = await compareDocuments(original, revised, {
           engine: 'atomizer',
@@ -456,8 +417,8 @@ describe('Collapsed field inplace reconstruction', () => {
       let xml: string;
       await given('inplace comparison result of dedicated-run PAGEREF fixtures', async () => {
         const [original, revised] = await Promise.all([
-          createDocxWithFieldXml(DEDICATED_RUN_FIELD_ORIGINAL),
-          createDocxWithFieldXml(DEDICATED_RUN_FIELD_REVISED),
+          buildDocxFromBodyXml(DEDICATED_RUN_FIELD_ORIGINAL),
+          buildDocxFromBodyXml(DEDICATED_RUN_FIELD_REVISED),
         ]);
         const result = await compareDocuments(original, revised, {
           engine: 'atomizer',
@@ -498,8 +459,8 @@ describe('Collapsed field inplace reconstruction', () => {
 </w:p>`;
 
         const [original, revised] = await Promise.all([
-          createDocxWithFieldXml(noFieldOriginal),
-          createDocxWithFieldXml(DEDICATED_RUN_FIELD_REVISED),
+          buildDocxFromBodyXml(noFieldOriginal),
+          buildDocxFromBodyXml(DEDICATED_RUN_FIELD_REVISED),
         ]);
 
         const result = await compareDocuments(original, revised, {

--- a/packages/docx-core/src/integration/field-fragmentation.test.ts
+++ b/packages/docx-core/src/integration/field-fragmentation.test.ts
@@ -24,7 +24,6 @@
  */
 
 import { describe, expect } from 'vitest';
-import JSZip from 'jszip';
 import { DOMParser } from '@xmldom/xmldom';
 import { compareDocuments } from '../index.js';
 import { DocxArchive } from '../shared/docx/DocxArchive.js';
@@ -34,6 +33,12 @@ import {
   rejectAllChanges,
 } from '../baselines/atomizer/trackChangesAcceptorAst.js';
 import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import {
+  buildDocxFromBodyXml,
+  fldChar,
+  instrText,
+  resultText,
+} from '../testing/ooxml-fixtures.js';
 
 const test = testAllure.epic('Document Comparison').withLabels({
   feature: 'Field Fragmentation (ECMA-376)',
@@ -44,30 +49,6 @@ const test = testAllure.epic('Document Comparison').withLabels({
 // =============================================================================
 // Helpers
 // =============================================================================
-
-async function buildFieldDocx(bodyXml: string): Promise<Buffer> {
-  const documentXml =
-    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
-    `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
-    `<w:body>${bodyXml}<w:sectPr/></w:body></w:document>`;
-  const contentTypesXml =
-    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
-    `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
-    `<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
-    `<Default Extension="xml" ContentType="application/xml"/>` +
-    `<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>` +
-    `</Types>`;
-  const rootRelsXml =
-    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
-    `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
-    `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>` +
-    `</Relationships>`;
-  const zip = new JSZip();
-  zip.file('[Content_Types].xml', contentTypesXml);
-  zip.file('_rels/.rels', rootRelsXml);
-  zip.file('word/document.xml', documentXml);
-  return (await zip.generateAsync({ type: 'nodebuffer' })) as Buffer;
-}
 
 async function compareInplace(original: Buffer, revised: Buffer): Promise<string> {
   const result = await compareDocuments(original, revised, {
@@ -125,11 +106,11 @@ function assertFieldStructureSurvives(combined: string): void {
 
 function makeField(instr: string, result: string): string {
   return (
-    `<w:r><w:fldChar w:fldCharType="begin"/></w:r>` +
-    `<w:r><w:instrText xml:space="preserve">${instr}</w:instrText></w:r>` +
-    `<w:r><w:fldChar w:fldCharType="separate"/></w:r>` +
-    `<w:r><w:t>${result}</w:t></w:r>` +
-    `<w:r><w:fldChar w:fldCharType="end"/></w:r>`
+    fldChar('begin') +
+    instrText(instr, { preserve: true }) +
+    fldChar('separate') +
+    resultText(result) +
+    fldChar('end')
   );
 }
 
@@ -156,10 +137,10 @@ describe('Field fragmentation — modification scenarios', () => {
       await given(
         'an original FORMCHECKBOX field (result "☐") and a revised FORMTEXT field (result "answer")',
         async () => {
-          const original = await buildFieldDocx(
+          const original = await buildDocxFromBodyXml(
             `<w:p><w:r><w:t>Status: </w:t></w:r>${makeField(' FORMCHECKBOX ', '☐')}</w:p>`,
           );
-          const revised = await buildFieldDocx(
+          const revised = await buildDocxFromBodyXml(
             `<w:p><w:r><w:t>Status: </w:t></w:r>${makeField(' FORMTEXT ', 'answer')}</w:p>`,
           );
           combined = await compareInplace(original, revised);
@@ -183,10 +164,10 @@ describe('Field fragmentation — modification scenarios', () => {
       await given(
         'an original HYPERLINK "https://a.example" (text "old link") and a revised HYPERLINK "https://b.example" (text "new link")',
         async () => {
-          const original = await buildFieldDocx(
+          const original = await buildDocxFromBodyXml(
             `<w:p>${makeField(' HYPERLINK "https://a.example" ', 'old link')}</w:p>`,
           );
-          const revised = await buildFieldDocx(
+          const revised = await buildDocxFromBodyXml(
             `<w:p>${makeField(' HYPERLINK "https://b.example" ', 'new link')}</w:p>`,
           );
           combined = await compareInplace(original, revised);
@@ -210,10 +191,10 @@ describe('Field fragmentation — modification scenarios', () => {
       await given(
         'an original PAGEREF _Toc-A (result "12") and a revised PAGEREF _Toc-B (result "15")',
         async () => {
-          const original = await buildFieldDocx(
+          const original = await buildDocxFromBodyXml(
             `<w:p><w:r><w:t>See page </w:t></w:r>${makeField(' PAGEREF _Toc-A \\h ', '12')}</w:p>`,
           );
-          const revised = await buildFieldDocx(
+          const revised = await buildDocxFromBodyXml(
             `<w:p><w:r><w:t>See page </w:t></w:r>${makeField(' PAGEREF _Toc-B \\h ', '15')}</w:p>`,
           );
           combined = await compareInplace(original, revised);
@@ -239,10 +220,10 @@ describe('Field fragmentation — modification scenarios', () => {
         async () => {
           const wrapBookmark = (inner: string) =>
             `<w:bookmarkStart w:id="1" w:name="fld"/>${inner}<w:bookmarkEnd w:id="1"/>`;
-          const original = await buildFieldDocx(
+          const original = await buildDocxFromBodyXml(
             `<w:p>${wrapBookmark(makeField(' NUMPAGES ', '3'))}</w:p>`,
           );
-          const revised = await buildFieldDocx(
+          const revised = await buildDocxFromBodyXml(
             `<w:p>${wrapBookmark(makeField(' SECTIONPAGES ', '1'))}</w:p>`,
           );
           combined = await compareInplace(original, revised);
@@ -274,10 +255,10 @@ describe('Field fragmentation — modification scenarios', () => {
             `<w:r><w:t>3</w:t></w:r>` +
             `<w:r><w:fldChar w:fldCharType="end"/></w:r>` +
             `<w:bookmarkEnd w:id="9"/>`;
-          const original = await buildFieldDocx(
+          const original = await buildDocxFromBodyXml(
             `<w:p><w:r><w:t>Pages </w:t></w:r>${fieldWithInternalBookmark}<w:r><w:t> total.</w:t></w:r></w:p>`,
           );
-          const revised = await buildFieldDocx(
+          const revised = await buildDocxFromBodyXml(
             `<w:p><w:r><w:t>Pages total.</w:t></w:r></w:p>`,
           );
           combined = await compareInplace(original, revised);
@@ -314,10 +295,10 @@ describe('Field fragmentation — modification scenarios', () => {
       await given(
         'an original NUMPAGES with result "3" and a revised with result "4" (instr unchanged)',
         async () => {
-          const original = await buildFieldDocx(
+          const original = await buildDocxFromBodyXml(
             `<w:p><w:r><w:t>Pages: </w:t></w:r>${makeField(' NUMPAGES ', '3')}</w:p>`,
           );
-          const revised = await buildFieldDocx(
+          const revised = await buildDocxFromBodyXml(
             `<w:p><w:r><w:t>Pages: </w:t></w:r>${makeField(' NUMPAGES ', '4')}</w:p>`,
           );
           combined = await compareInplace(original, revised);
@@ -347,10 +328,10 @@ describe('Field fragmentation — whole-field deletion', () => {
       await given(
         'an original document containing a NUMPAGES field and a revised document with the field removed',
         async () => {
-          const original = await buildFieldDocx(
+          const original = await buildDocxFromBodyXml(
             `<w:p><w:r><w:t>Total pages </w:t></w:r>${makeField(' NUMPAGES ', '3')}<w:r><w:t> here.</w:t></w:r></w:p>`,
           );
-          const revised = await buildFieldDocx(
+          const revised = await buildDocxFromBodyXml(
             `<w:p><w:r><w:t>Total pages here.</w:t></w:r></w:p>`,
           );
           combined = await compareInplace(original, revised);

--- a/packages/docx-core/src/integration/lean-spec-bridge.test.ts
+++ b/packages/docx-core/src/integration/lean-spec-bridge.test.ts
@@ -47,11 +47,15 @@
  */
 
 import fc from 'fast-check';
-import JSZip from 'jszip';
 import { DOMParser } from '@xmldom/xmldom';
 import { describe } from 'vitest';
 import { compareDocuments, type ReconstructionMode } from '../index.js';
 import { validateFieldStructure } from '../baselines/atomizer/pipeline.js';
+import {
+  COMPLETE_NUMPAGES_FIELD,
+  WHOLE_FIELD_IN_INS,
+  buildDocxFromBodyXml,
+} from '../testing/ooxml-fixtures.js';
 import {
   acceptAllChanges,
   rejectAllChanges,
@@ -697,30 +701,6 @@ async function assertRoundTripInvariant(
 // fragments unexpectedly.
 // =============================================================================
 
-async function buildFieldDocx(bodyXml: string): Promise<Buffer> {
-  const documentXml =
-    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
-    `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
-    `<w:body>${bodyXml}<w:sectPr/></w:body></w:document>`;
-  const contentTypesXml =
-    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
-    `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
-    `<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
-    `<Default Extension="xml" ContentType="application/xml"/>` +
-    `<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>` +
-    `</Types>`;
-  const rootRelsXml =
-    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
-    `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
-    `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>` +
-    `</Relationships>`;
-  const zip = new JSZip();
-  zip.file('[Content_Types].xml', contentTypesXml);
-  zip.file('_rels/.rels', rootRelsXml);
-  zip.file('word/document.xml', documentXml);
-  return await zip.generateAsync({ type: 'nodebuffer' });
-}
-
 /**
  * TS-side analogue of `Tier2.FieldStructure.fieldContextNeutral` for one wrapper
  * subtree. Walks every descendant `w:fldChar` / `w:instrText` / `w:delInstrText`
@@ -914,16 +894,11 @@ describe('Lean Spec Bridge - Inplace Reconstruction', { timeout: 60_000 }, () =>
       await then(
         'the combined document validates and every wrapper subtree is field-context-neutral',
         async () => {
-          const field =
-            `<w:r><w:fldChar w:fldCharType="begin"/></w:r>` +
-            `<w:r><w:instrText xml:space="preserve"> NUMPAGES </w:instrText></w:r>` +
-            `<w:r><w:fldChar w:fldCharType="separate"/></w:r>` +
-            `<w:r><w:t>3</w:t></w:r>` +
-            `<w:r><w:fldChar w:fldCharType="end"/></w:r>`;
-          const original = await buildFieldDocx(
+          const field = COMPLETE_NUMPAGES_FIELD;
+          const original = await buildDocxFromBodyXml(
             `<w:p><w:r><w:t>Total pages here.</w:t></w:r></w:p>`,
           );
-          const revised = await buildFieldDocx(
+          const revised = await buildDocxFromBodyXml(
             `<w:p><w:r><w:t>Total pages </w:t></w:r>${field}<w:r><w:t> here.</w:t></w:r></w:p>`,
           );
 
@@ -968,16 +943,11 @@ describe('Lean Spec Bridge - Inplace Reconstruction', { timeout: 60_000 }, () =>
           // engine output satisfies the document-level `preservationFriendly`
           // property but not per-subtree `recursivelyWellformed`.
           // `assertFieldInvariant` is the right document-level check.
-          const field =
-            `<w:r><w:fldChar w:fldCharType="begin"/></w:r>` +
-            `<w:r><w:instrText xml:space="preserve"> NUMPAGES </w:instrText></w:r>` +
-            `<w:r><w:fldChar w:fldCharType="separate"/></w:r>` +
-            `<w:r><w:t>3</w:t></w:r>` +
-            `<w:r><w:fldChar w:fldCharType="end"/></w:r>`;
-          const original = await buildFieldDocx(
+          const field = COMPLETE_NUMPAGES_FIELD;
+          const original = await buildDocxFromBodyXml(
             `<w:p><w:r><w:t>Total pages </w:t></w:r>${field}<w:r><w:t> here.</w:t></w:r></w:p>`,
           );
-          const revised = await buildFieldDocx(
+          const revised = await buildDocxFromBodyXml(
             `<w:p><w:r><w:t>Total pages here.</w:t></w:r></w:p>`,
           );
 
@@ -1053,14 +1023,7 @@ describe('Lean Spec Bridge - Inplace Reconstruction', { timeout: 60_000 }, () =>
       await given(
         'a <w:ins> wrapping a complete NUMPAGES begin/instrText/separate/result/end sequence',
         () => {
-          const xml =
-            `<w:ins xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
-            `<w:r><w:fldChar w:fldCharType="begin"/></w:r>` +
-            `<w:r><w:instrText xml:space="preserve"> NUMPAGES </w:instrText></w:r>` +
-            `<w:r><w:fldChar w:fldCharType="separate"/></w:r>` +
-            `<w:r><w:t>3</w:t></w:r>` +
-            `<w:r><w:fldChar w:fldCharType="end"/></w:r>` +
-            `</w:ins>`;
+          const xml = WHOLE_FIELD_IN_INS(COMPLETE_NUMPAGES_FIELD, { standalone: true });
           wrapper = new DOMParser().parseFromString(xml, 'application/xml')
             .documentElement as unknown as Element;
         },

--- a/packages/docx-core/src/testing/ooxml-fixtures.ts
+++ b/packages/docx-core/src/testing/ooxml-fixtures.ts
@@ -1,0 +1,157 @@
+/**
+ * Shared OOXML test fixtures.
+ *
+ * Single source of truth for the field-XML primitives, complete-field
+ * sequences, tracked-change variants, and minimal DOCX-package builder used
+ * across the docx-core test suite. Consolidates patterns previously
+ * re-derived inline in `lean-spec-bridge.test.ts`,
+ * `pipeline.field-validation.test.ts`, and `collapsed-field-inplace.test.ts`.
+ *
+ * The Lean Tier 2 model in `verification/lean/...` does NOT import this
+ * module — it operates on inductive `Doc`/`Block`/`Atom` constructors, not
+ * XML strings. The three independent walk semantics
+ * (`pipeline.ts:fieldContextNeutral`, `Tier2/FieldStructure.fieldContextNeutral`,
+ * `lean-spec-bridge.test.ts:isFieldContextNeutral`) are deliberately
+ * re-derived — that triple is the falsifiability layer of the field-structure
+ * proof and must not be collapsed.
+ *
+ * Ref: issue #221.
+ */
+
+import JSZip from 'jszip';
+
+export type FldCharKind = 'begin' | 'separate' | 'end';
+
+export function fldChar(kind: FldCharKind): string {
+  return `<w:r><w:fldChar w:fldCharType="${kind}"/></w:r>`;
+}
+
+export interface InstrTextOptions {
+  preserve?: boolean;
+}
+
+export function instrText(text: string, opts: InstrTextOptions = {}): string {
+  const space = opts.preserve ? ' xml:space="preserve"' : '';
+  return `<w:r><w:instrText${space}>${text}</w:instrText></w:r>`;
+}
+
+export function delInstrText(text: string, opts: InstrTextOptions = {}): string {
+  const space = opts.preserve ? ' xml:space="preserve"' : '';
+  return `<w:r><w:delInstrText${space}>${text}</w:delInstrText></w:r>`;
+}
+
+export function resultText(text: string): string {
+  return `<w:r><w:t>${text}</w:t></w:r>`;
+}
+
+export const COMPLETE_NUMPAGES_FIELD =
+  fldChar('begin') +
+  instrText(' NUMPAGES ', { preserve: true }) +
+  fldChar('separate') +
+  resultText('3') +
+  fldChar('end');
+
+export const COMPLETE_PAGE_FIELD =
+  fldChar('begin') +
+  instrText(' PAGE ', { preserve: true }) +
+  fldChar('separate') +
+  resultText('1') +
+  fldChar('end');
+
+export const COMPLETE_PAGEREF_FIELD =
+  fldChar('begin') +
+  instrText(' PAGEREF _Toc123 \\h ', { preserve: true }) +
+  fldChar('separate') +
+  resultText('42') +
+  fldChar('end');
+
+// ECMA-376 conformant field-modification pattern: a field whose instruction
+// text is changing under track changes. The fldChars remain UNWRAPPED at the
+// sibling-run level (they cannot enter <w:del>), while the changed instrText
+// fragments into <w:ins>/<w:del> wrappers. See c-rex ECMA-376 Part 4 fldChar
+// topic + DeletedFieldCode placement constraint.
+export const FRAGMENTED_NUMPAGES_MODIFICATION =
+  fldChar('begin') +
+  `<w:ins>${instrText(' NUMPAGES ', { preserve: true })}</w:ins>` +
+  `<w:del>${delInstrText(' PAGE ', { preserve: true })}</w:del>` +
+  fldChar('separate') +
+  resultText('3') +
+  fldChar('end');
+
+const W_NS_ATTR = ' xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
+
+export interface WrapOptions {
+  /**
+   * When true, emits `xmlns:w="…"` on the wrapper element so the result
+   * can be parsed as a standalone document root by `@xmldom/xmldom`'s
+   * `DOMParser.parseFromString(xml, 'application/xml')` without throwing
+   * `NamespaceError: prefix is non-null and namespace is null`.
+   *
+   * Default false (the wrapper is assumed to live inside a `<w:document>`
+   * that already declares the namespace).
+   */
+  standalone?: boolean;
+}
+
+export function WHOLE_FIELD_IN_INS(
+  field: string = COMPLETE_NUMPAGES_FIELD,
+  opts: WrapOptions = {},
+): string {
+  const ns = opts.standalone ? W_NS_ATTR : '';
+  return `<w:ins${ns}>${field}</w:ins>`;
+}
+
+export function WHOLE_FIELD_IN_DEL(
+  field: string = COMPLETE_NUMPAGES_FIELD,
+  opts: WrapOptions = {},
+): string {
+  const ns = opts.standalone ? W_NS_ATTR : '';
+  return `<w:del${ns}>${field}</w:del>`;
+}
+
+/**
+ * Build a minimal DOCX package buffer from raw `<w:body>` inner XML.
+ *
+ * Emits `[Content_Types].xml`, `_rels/.rels`, `word/document.xml`, and an
+ * empty `word/_rels/document.xml.rels`. The `<w:document>` root declares
+ * both `xmlns:w` and `xmlns:w14`. Suitable for any test that needs a
+ * loadable DOCX with a custom body but no styles/footnotes/comments/etc.
+ *
+ * Use `buildSyntheticDocx` (in `../integration/synthetic-docx-fixture.ts`)
+ * instead when you need paragraph-array input with optional
+ * footnote/comment/bookmark scaffolding.
+ */
+export async function buildDocxFromBodyXml(bodyXml: string): Promise<Buffer> {
+  const documentXml =
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"` +
+    ` xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">` +
+    `<w:body>${bodyXml}<w:sectPr/></w:body></w:document>`;
+
+  const contentTypesXml =
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+    `<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+    `<Default Extension="xml" ContentType="application/xml"/>` +
+    `<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>` +
+    `</Types>`;
+
+  const rootRelsXml =
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+    `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>` +
+    `</Relationships>`;
+
+  const docRelsXml =
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+    `</Relationships>`;
+
+  const zip = new JSZip();
+  zip.file('[Content_Types].xml', contentTypesXml);
+  zip.file('_rels/.rels', rootRelsXml);
+  zip.file('word/document.xml', documentXml);
+  zip.file('word/_rels/document.xml.rels', docRelsXml);
+
+  return (await zip.generateAsync({ type: 'nodebuffer' })) as Buffer;
+}


### PR DESCRIPTION
## Summary

- Centralizes field-XML constants, run-wrapped primitives, and the minimal DOCX-package builder into `packages/docx-core/src/testing/ooxml-fixtures.ts`.
- Migrates `lean-spec-bridge.test.ts`, `pipeline.field-validation.test.ts`, and `collapsed-field-inplace.test.ts` to import from the shared module; removes their local `buildFieldDocx` / `createDocxWithFieldXml` and inline `COMPLETE_FIELD` / `MODIFIED_FIELD_FRAGMENTED` constants.
- After this change, a shape tweak for #217 (ECMA-376 fragmentation conformance) edits one file, not six.

## Module surface

- `fldChar(kind)`, `instrText(text, {preserve})`, `delInstrText(text, {preserve})`, `resultText(text)` — typed primitive builders.
- `COMPLETE_NUMPAGES_FIELD`, `COMPLETE_PAGE_FIELD`, `COMPLETE_PAGEREF_FIELD` — canonical complete-field sequences.
- `FRAGMENTED_NUMPAGES_MODIFICATION` — ECMA-376 conformant fragmented modification pattern.
- `WHOLE_FIELD_IN_INS(field?, {standalone?})`, `WHOLE_FIELD_IN_DEL(...)` — whole-field-wrap helpers. The `{standalone: true}` option emits `xmlns:w` on the wrapper so `@xmldom/xmldom`'s `DOMParser.parseFromString(xml, 'application/xml')` does not throw `NamespaceError: prefix is non-null and namespace is null`.
- `buildDocxFromBodyXml(bodyXml): Promise<Buffer>` — minimal DOCX-package builder from raw `<w:body>` inner XML; emits the strictly-superset shape (xmlns:w + xmlns:w14 + empty `word/_rels/document.xml.rels`).

## Out of scope (deliberately)

- **Lean does NOT import.** Tier 2 (`verification/lean/...`) operates on inductive `Doc`/`Block`/`Atom` constructors, not XML strings.
- **Three independent walk semantics stay separately derived** — `pipeline.ts` `fieldContextNeutral`, `Tier2/FieldStructure.lean`, and `lean-spec-bridge.test.ts` `isFieldContextNeutral` are the falsifiability layer of the field-structure proof and must not be collapsed.
- **`text.test.ts` / `comments.test.ts` / `allure-preview-helpers.test.ts`** use varied `REF` / `PAGE` / `PAGEREF` payloads rather than the NUMPAGES duplication — not in the issue's acceptance list.
- **`field-fragmentation.test.ts`** is part of the in-progress #217 branch and not on `origin/main`. Whichever PR lands second rebases and adopts the shared module.

## Pre-merge review

Plan reviewed in parallel by **Gemini CLI** and **Codex CLI**. Both confirmed the constants are byte-exact identical across the three migrated files. Codex empirically reproduced the `NamespaceError` for bare `<w:ins>…</w:ins>` parsed as a document root (drove the `{standalone}` option). Codex also showed `compareDocuments` runs in `inplace` mode with no fallback on both the old minimal and new superset builder shapes — semantically (not byte-identically) equivalent.

## Test plan

- [x] `npm run build` — pass.
- [x] `npm run lint:workspaces` — pass (one unrelated pre-existing warning in `docx-mcp`).
- [x] Targeted `npm run test:run -w @usejunior/docx-core -- src/baselines/atomizer/pipeline.field-validation.test.ts src/integration/lean-spec-bridge.test.ts src/integration/collapsed-field-inplace.test.ts` — 36 tests pass.
- [x] `npm run test:run` (full suite, all workspaces) — 2126 tests pass.
- [x] `npm run check:spec-coverage` — all PASS.

Fixes: #221
Ref: #208, #211, #220, #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)