### PR TITLE
fix(spec-compliance): make conformance-doc generator deterministic (closes #231)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,6 @@ safe-docx targets a defined subset of **ECMA-376 5th edition**. The full surface
 - **0** sections explicitly out-of-scope (Non-Goals)
 - **0** known gaps under `@conformance-gap`
 - Vendored normative schemas: `spec-compliance/ecma-376/schemas/`
-
-Last regenerated: `86e175f` on `2026-05-25`.
 <!-- AUTO-GENERATED:conformance-summary END -->
 
 ## Trusted By

--- a/scripts/generate_conformance_doc.mjs
+++ b/scripts/generate_conformance_doc.mjs
@@ -11,7 +11,6 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { execSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
@@ -194,21 +193,10 @@ function countGaps() {
   return count;
 }
 
-function getCommitHash() {
-  try {
-    return execSync('git rev-parse --short HEAD', { cwd: REPO_ROOT }).toString().trim();
-  } catch {
-    return 'uncommitted';
-  }
-}
-
 function renderReadmeBlock(registry) {
   const N = registry.entries.length;
   const M = registry.nonGoals.length;
   const K = countGaps();
-  const commit = getCommitHash();
-  // Use a stable date format that doesn't change minute-to-minute.
-  const today = new Date().toISOString().slice(0, 10);
   const lines = [];
   lines.push(SUMMARY_START);
   lines.push('safe-docx targets a defined subset of **ECMA-376 5th edition**. The full surface');
@@ -219,8 +207,6 @@ function renderReadmeBlock(registry) {
   lines.push(`- **${M}** section${M === 1 ? '' : 's'} explicitly out-of-scope (Non-Goals)`);
   lines.push(`- **${K}** known gap${K === 1 ? '' : 's'} under \`@conformance-gap\``);
   lines.push('- Vendored normative schemas: `spec-compliance/ecma-376/schemas/`');
-  lines.push('');
-  lines.push(`Last regenerated: \`${commit}\` on \`${today}\`.`);
   lines.push(SUMMARY_END);
   return lines.join('\n');
 }


### PR DESCRIPTION
## Summary

Closes #231.

The conformance-doc generator stamped `Last regenerated: <HEAD short SHA> on <today>` into the `README.md` AUTO-GENERATED block, making the output a function of HEAD and the wall-clock rather than just the registry contents. Every merge to `main` shifts HEAD, and every midnight rollover flips the date, so the `check:conformance-doc` drift gate would fail in CI on the next push — blocking subsequent merges until someone hand-regenerated the file, then immediately starting to fail again.

Surfaced by the post-merge smoke on #230: <https://github.com/UseJunior/safe-docx/pull/230#issuecomment-4535975514>.

## Implementation

Drop both stamps from the marker block. The git history is already the authoritative record for when these files were last touched (`git log -- README.md` / `git log -- spec-compliance/CONFORMANCE.md`); the in-content stamp added drift risk without adding information.

Diff: 2 files, **16 lines removed, 0 added**.

- `scripts/generate_conformance_doc.mjs` — remove the `getCommitHash()` helper, the orphaned `execSync`/`node:child_process` import, the `const today = ...` line, and the two lines pushing `Last regenerated:` into the output.
- `README.md` — remove the now-stale stamp line from the AUTO-GENERATED block so the committed file matches the new generator output.

The `<!-- AUTO-GENERATED:conformance-summary START/END -->` markers themselves are untouched (the drift gate depends on them). Localized READMEs are unaffected (they carry hand-translated static blocks per #230's design). No OpenSpec spec text needed updating — the requirement under "CONFORMANCE.md and README marker block are generated" doesn't reference the timestamp or SHA.

## Verification

- [x] **Generator idempotent across HEAD changes**: `sha256(README.md + spec-compliance/CONFORMANCE.md)` is identical across regenerator runs at different HEADs.
- [x] **Generator idempotent across calendar days**: no date string `YYYY-MM-DD` appears in the marker block; no `Last regenerated:` line.
- [x] `npm run check:conformance-doc` → `OK` (with fix staged, simulating post-merge CI state).
- [x] `npm run check:conformance-citations` → `OK (3 registry entries, 51 XSDs)`.
- [x] `openspec validate add-ecma-376-conformance-framework --strict` → `valid`.
- [x] `npm run build` clean.
- [x] `npm run lint:workspaces` clean (one pre-existing unused `eslint-disable` warning in `packages/docx-mcp/src/cli/commands/edit.test.ts:133`, not introduced here).
- [ ] **Peer review (Gemini + Codex) — pending**; supervisor will run on this open PR before arming auto-merge.

## Closes
- #231

🤖 Generated with [Claude Code](https://claude.com/claude-code) — implementation delegated to Codex CLI via `/codex-implement`.