### PR TITLE
docs(readme): add architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,66 @@
 
 Part of the [UseJunior developer tools](https://usejunior.com/developer-tools/safe-docx).
 
+```mermaid
+%%{init: {"flowchart": {"htmlLabels": true, "curve": "basis", "nodeSpacing": 30, "rankSpacing": 50}, "themeVariables": {"fontSize": "14px"}} }%%
+flowchart LR
+    DocInLeft["<b>Existing .docx</b><br/>on disk"]
+
+    subgraph Server["@usejunior/safe-docx — local MCP server"]
+        direction LR
+
+        subgraph ReadParse["<b>1. Read</b>"]
+            direction TB
+            RPTool["<code>read_file(file_path,<br/>&nbsp;&nbsp;format)</code>"]
+        end
+
+        subgraph Locate["<b>2. Locate</b>"]
+            direction TB
+            LocTool["<code>grep(file_path,<br/>&nbsp;&nbsp;pattern)</code>"]
+        end
+
+        subgraph Edit["<b>3. Edit</b>"]
+            direction TB
+            EditTool["<code>replace_text(<br/>&nbsp;&nbsp;target_paragraph_id,<br/>&nbsp;&nbsp;old_string, new_string,<br/>&nbsp;&nbsp;instruction)</code>"]
+        end
+
+        subgraph Save["<b>4. Save</b>"]
+            direction TB
+            SaveTool["<code>save(save_to_local_path,<br/>&nbsp;&nbsp;save_format)</code>"]
+        end
+
+        ReadParse --> Locate
+        Locate --> Edit
+        Edit --> Save
+    end
+
+    DocInRight["<b>Saved .docx output</b><br/>on disk"]
+
+    subgraph Client [" "]
+        direction TB
+        Prompt["<b>Prompt</b><br/>'Change NDA governing law to Delaware'"]
+        Agent["<b>Coding agent / MCP client</b><br/>Claude Code · Cursor · Gemini CLI"]
+        Prompt --> Agent
+    end
+
+    DocInLeft --> RPTool
+    SaveTool --> DocInRight
+    Agent <-->|tool call / tool result| Server
+
+    classDef io fill:#f5f5f5,stroke:#888,color:#222
+    classDef server fill:#eff6ff,stroke:#3b82f6,color:#1e3a8a
+    classDef stage fill:#eef2ff,stroke:#6366f1,color:#1e1b4b
+    classDef tools fill:#ecfdf5,stroke:#10b981,color:#064e3b
+    classDef ext fill:#ddd6fe,stroke:#7c3aed,color:#3b0764
+    classDef hidden fill:none,stroke:none
+    class DocInLeft,DocInRight io
+    class Server server
+    class ReadParse,Locate,Edit,Save stage
+    class RPTool,LocTool,EditTool,SaveTool tools
+    class Prompt,Agent ext
+    class Client hidden
+```
+
 Safe Docx is an open-source TypeScript stack for surgical editing of existing Microsoft Word `.docx` files. It is built for workflows where an agent proposes changes and a human still needs reliable, formatting-preserving document edits.
 
 If you review contracts with AI, the slowest step is often applying accepted recommendations in Word. Safe Docx turns that into deterministic tool calls.


### PR DESCRIPTION
## Summary

Adds a Mermaid hero diagram at the top of the README showing the agent-led editing workflow: a coding agent makes MCP tool calls to the local safe-docx server, which runs the read → locate → edit → save pipeline against an existing .docx and writes a new output file.

## Why

New contributors and prospective users currently have to read several paragraphs of prose before understanding the basic shape of a safe-docx session. A diagram at the top makes the agent ↔ MCP server relationship and the four-stage edit lifecycle legible at a glance.

## Design decisions (after peer review by Codex + Gemini)

- **Function signatures match real tool params** — verified against `packages/docx-mcp/src/tools/save.ts`, `replace_text.ts`, and `packages/docx-mcp/src/tool_catalog.ts`. `save(save_to_local_path, save_format)` and `replace_text(target_paragraph_id, old_string, new_string, instruction)` are the correct shapes.
- **Output node labeled "Saved .docx output"** (not "Updated .docx") — `save` writes a NEW file at `save_to_local_path` and does not modify the original unless `allow_overwrite=true`.
- **Two `.docx` nodes** (Existing left, Saved output right) instead of one with a cycle — avoids dagre layout collapse and reads more clearly as input → output than a self-loop.
- **Hidden client wrapper uses `fill:none,stroke:none`** instead of `#ffffff` — survives GitHub's dark-mode rendering.
- **`<-->` bidirectional arrow** (not `<==>`) — matches the visual weight of the pipeline arrows and reduces GitHub-renderer risk.

## Test plan

- [x] Local mmdc render of the Mermaid source produced a clean horizontal layout (verified at multiple resolutions).
- [ ] Open the PR and visually inspect the rendered diagram on github.com (light + dark mode) to confirm GitHub's native Mermaid renderer matches the local render.
- [ ] Verify no existing CI checks regress (this is a docs-only change; no code touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)