### PR TITLE
docs(spec): add openspec change add-test-corpus-narrative

### DIFF
--- a/openspec/changes/add-test-corpus-narrative/design.md
+++ b/openspec/changes/add-test-corpus-narrative/design.md
@@ -73,9 +73,13 @@ defines exactly these tags:
 | `implementationAlternativeRejected` | optional | 40-250 | Implementation alternatives considered and rejected |
 | `ecma376Difficulty` | optional | 40-250 | What makes this hard in ECMA-376 |
 
-The schema is the only place these strings and ranges live. The drafter,
-AST extractor, CI validator, corpus emitter, and any renderer import from
-it instead of copying constants.
+The schema is the only place these strings and ranges live. In-repo
+consumers (the drafter, AST extractor, CI validator, and corpus emitter)
+import from it directly. Cross-repo consumers (notably the downstream
+renderer that lives in another repository) consume the emitted
+`tests-corpus.schema.json` artifact instead — they do not import the
+TypeScript package. See D6c and the spec's "Corpus artifact is the
+renderer-facing contract" requirement.
 
 The rejected names `limitation`, `aiContext`, `compare`, `specQuirk`,
 `notCovered`, `prose`, `description`, and `discussion` are intentionally

--- a/openspec/changes/add-test-corpus-narrative/design.md
+++ b/openspec/changes/add-test-corpus-narrative/design.md
@@ -1,0 +1,174 @@
+# Design: Test corpus narrative
+
+## Context
+
+Issue #235 asks for an OpenSpec proposal only. The desired system makes the
+test itself the source of truth for public corpus narrative while retaining
+Allure as the source for test identity, status, labels, links, and step
+execution data.
+
+No deployed OpenSpec capability currently owns a test-corpus narrative
+concept. `website-trust-surface` consumes Allure artifacts for the public
+site trust surface, and the active `add-ecma-376-conformance-framework`
+change adds `testAllure.conformance(...)` under a proposed
+`spec-compliance` capability, but neither owns `AllureLabelDefaults` or a
+publishable test corpus. This proposal therefore introduces
+`test-corpus-narrative` and documents the `AllureLabelDefaults.visibility`
+addition there as an added requirement.
+
+## Goals / Non-Goals
+
+**Goals**
+- Put public test rationale in JSDoc directly above the
+  `test.openspec(...)(...)` call.
+- Keep tag names, word-count ranges, and rendered section titles in one
+  Zod schema under a future `packages/test-narrative/` package.
+- Add one runtime metadata field, `visibility`, to classify tests as
+  `public` or `internal`.
+- Emit a stable `tests-corpus.json` plus `tests-corpus.schema.json`
+  artifact suitable for downstream rendering.
+- Let developers use a local Codex drafter while keeping CI deterministic
+  and LLM-free.
+- Coordinate ECMA-376 citation resolution with the active conformance
+  framework and a prerequisite registry-parser lift.
+
+**Non-Goals**
+- Implementing `packages/test-narrative/`, AST extraction, drafter, CI
+  check, corpus emitter, or workflow in this PR.
+- Creating an external renderer or website page.
+- Adding cross-linking between scenarios. Rendered test pages are
+  self-contained.
+- Adding a staleness hash gate for narrative prose.
+
+## Decisions
+
+### D1. New capability: `test-corpus-narrative`
+
+The existing capabilities cover DOCX behavior, MCP behavior, website trust
+summary generation, and open-agreements functionality. The test-corpus
+narrative system is cross-cutting but has a distinct contract: schema,
+authoring loop, validation, artifact shape, and release behavior. A new
+capability avoids overloading unrelated specs.
+
+### D2. JSDoc carries prose; Allure carries visibility
+
+Narrative prose lives in JSDoc above the `test.openspec(...)(...)` call so
+it can be reviewed with the test body and extracted through AST context.
+Runtime metadata is limited to `visibility?: 'public' | 'internal'` on
+`AllureLabelDefaults`, defaulting to `internal`. This avoids adding a
+runtime narrative API and keeps prose out of Allure labels.
+
+### D3. Schema-owned names, ranges, and section titles
+
+The future `packages/test-narrative/` package owns a Zod schema that
+defines exactly these tags:
+
+| Tag | Required | Words | Section title |
+| --- | --- | --- | --- |
+| `motivatingProblem` | when `visibility` is `public` | 60-150 | Motivating problem |
+| `implementationLimitation` | optional | 40-300 | Implementation limitations |
+| `testScopeExclusion` | optional | 40-300 | Test-scope exclusions |
+| `observedPerformance` | optional | 40-200 | Observed performance characteristics |
+| `potentialMisconception` | optional | 40-250 | Potential misconceptions |
+| `implementationAlternativeRejected` | optional | 40-250 | Implementation alternatives considered and rejected |
+| `ecma376Difficulty` | optional | 40-250 | What makes this hard in ECMA-376 |
+
+The schema is the only place these strings and ranges live. The drafter,
+AST extractor, CI validator, corpus emitter, and any renderer import from
+it instead of copying constants.
+
+The rejected names `limitation`, `aiContext`, `compare`, `specQuirk`,
+`notCovered`, `prose`, `description`, and `discussion` are intentionally
+not aliases because they are ambiguous or encourage undifferentiated prose.
+
+### D4. Public tests require `motivatingProblem`; structural tests stay internal
+
+`motivatingProblem` frames the problem in the world that motivates the
+scenario and may be capability-shaped only where the issue allows it. Tests
+whose value is purely structural, such as checking that a parser does not
+crash on empty input, remain `visibility: internal`; there is no escape
+hatch that allows a public test to omit `motivatingProblem`.
+
+### D5. Asymmetry-of-rot replaces hash staleness gates
+
+The validator fails on missing required tags and present tags that do not
+parse against the schema. It does not compare hashes of test bodies to
+narrative prose. Hash gates are noisy for cosmetic edits and can miss
+semantic changes that preserve token order. The accepted trade-off is that
+capability rot oversells and breaks trust, while limitation rot usually
+undersells what the implementation can do.
+
+### D6. Corpus artifact joins Allure and AST evidence
+
+`tests-corpus.json` is produced from Allure result JSON joined with
+AST-extracted evidence. Allure contributes identity, status, labels, links,
+and step names. AST extraction contributes JSDoc narrative tags, verbatim
+BDD `given`/`when`/`then` strings, local fixture literals, `expect()`
+arguments, and test source coordinates. ECMA-376 citations come from
+`ConformanceClaim[]` labels resolved through the conformance registry.
+
+The artifact strips engineer-only noise such as host runner IDs, Vitest
+framework name, millisecond durations, language tags, and other fields that
+do not help downstream corpus readers.
+
+### D7. Rendering order is deterministic and self-contained
+
+The rendered page order is:
+
+1. Breadcrumb, status strip, and citations strip.
+2. Motivating problem.
+3. Scenario from AST-extracted BDD strings.
+4. Results, including conclusion, expected, actual, evaluation,
+   performance, and cross-library subsections when present.
+5. Implementation limitations.
+6. Test-scope exclusions.
+7. Observed performance characteristics.
+8. Potential misconceptions.
+9. Implementation alternatives considered and rejected.
+10. What makes this hard in ECMA-376.
+11. Spec citations and source link.
+
+Optional sections render only when their source tag is present. There is no
+"Discussion" umbrella and no "Related scenarios" requirement.
+
+### D8. Conformance-registry parser lift is a prerequisite
+
+The active `add-ecma-376-conformance-framework` change currently keeps
+registry parsing private to `scripts/check_conformance_citations.mjs` and
+`scripts/generate_conformance_doc.mjs`. The corpus emitter must not
+duplicate that grammar. A separate follow-up PR must lift
+`parseRegistryFile` and `loadRegistry` into
+`scripts/lib/conformance-registry.mjs` before `scripts/build_tests_corpus.mjs`
+consumes resolved `ConformanceClaim[]`.
+
+## Risks / Trade-offs
+
+- **Authoring friction for public tests.** Mitigation: provide a local
+  drafter, keep the required set to `motivatingProblem`, and validate only
+  schema shape in CI.
+- **Schema constants copied into prompts or renderers.** Mitigation: make
+  `packages/test-narrative/` the import source for every consumer.
+- **Corpus emitter depends on test AST shape.** Mitigation: scope the
+  extractor to the existing Allure/OpenSpec BDD pattern and add targeted
+  fixture tests before broad rollout.
+- **Conformance framework landing order.** Mitigation: list the registry
+  parser lift as a prerequisite follow-up and keep this proposal
+  implementation-free.
+
+## Migration Plan
+
+This proposal does not change runtime code. Follow-up implementation PRs
+should land in this order: registry-parser lift, narrative schema package,
+Allure visibility metadata, AST extractor and CI validator, local drafter,
+corpus emitter, then tag-time release workflow.
+
+Existing tests default to `visibility: internal` until explicitly marked
+public and given valid JSDoc narrative tags.
+
+## Open Questions
+
+- Should `tests-corpus.schema.json` be checked in, generated during release,
+  or both? The requirement only needs a stable emitted schema artifact.
+- Should the corpus emitter include source ranges for every extracted
+  literal or only a source link for the owning test? The current contract
+  requires enough identity for a source link, not full range provenance.

--- a/openspec/changes/add-test-corpus-narrative/design.md
+++ b/openspec/changes/add-test-corpus-narrative/design.md
@@ -84,10 +84,18 @@ not aliases because they are ambiguous or encourage undifferentiated prose.
 ### D4. Public tests require `motivatingProblem`; structural tests stay internal
 
 `motivatingProblem` frames the problem in the world that motivates the
-scenario and may be capability-shaped only where the issue allows it. Tests
-whose value is purely structural, such as checking that a parser does not
-crash on empty input, remain `visibility: internal`; there is no escape
-hatch that allows a public test to omit `motivatingProblem`.
+scenario. The framing is "the problem we are solving" even when the
+sentence necessarily describes a capability deficiency the test catches —
+the writer leans on the problem rather than the capability so the text
+stays true if the solution improves.
+
+The normative mechanical contract is narrow: `visibility: 'public'`
+requires a valid `@motivatingProblem`; `visibility: 'internal'` (or
+omitted) does not. The authoring policy that tests with no honest problem
+statement should stay internal lives here, in design, because no automated
+check can decide whether a candidate `@motivatingProblem` is honest — only
+a human reviewer can. There is no escape-hatch tag that satisfies the
+public-narrative requirement in place of `@motivatingProblem`.
 
 ### D5. Asymmetry-of-rot replaces hash staleness gates
 
@@ -111,25 +119,76 @@ The artifact strips engineer-only noise such as host runner IDs, Vitest
 framework name, millisecond durations, language tags, and other fields that
 do not help downstream corpus readers.
 
-### D7. Rendering order is deterministic and self-contained
+### D6a. AST extractor is purely static; unresolved values become evidence markers
 
-The rendered page order is:
+The AST extractor will encounter many tests whose given/when/then
+arguments are not raw literals — they're imported constants, factory
+calls, destructured fixtures, or template literals with runtime
+expressions (the existing `merge_runs.test.ts`, `accept_changes.test.ts`,
+and most integration tests are in this shape). A spec that required the
+extractor to resolve these would force it to evaluate code, which we
+explicitly reject (slow, unsafe, defeats the purpose of static
+extraction).
 
-1. Breadcrumb, status strip, and citations strip.
-2. Motivating problem.
-3. Scenario from AST-extracted BDD strings.
-4. Results, including conclusion, expected, actual, evaluation,
-   performance, and cross-library subsections when present.
-5. Implementation limitations.
-6. Test-scope exclusions.
-7. Observed performance characteristics.
-8. Potential misconceptions.
-9. Implementation alternatives considered and rejected.
-10. What makes this hard in ECMA-376.
-11. Spec citations and source link.
+The contract is: extract what is syntactically a literal directly; for
+everything else, emit an unresolved-evidence marker with the source-text
+of the expression plus a `path:line` source reference. The downstream
+renderer can show "this fixture is `SHARED_PARAGRAPH_FIXTURE` — see
+[source link]" instead of pretending to show the value. The marker
+shape is normative — see spec.md Requirement: "AST extractor falls back
+on non-literal evidence".
 
-Optional sections render only when their source tag is present. There is no
-"Discussion" umbrella and no "Related scenarios" requirement.
+### D6b. Visibility emitted as `corpusVisibility` Allure label
+
+`AllureLabelDefaults.visibility` is the authoring surface; the runtime
+emission is a label with name `corpusVisibility` and value `public`
+when (and only when) `visibility: 'public'`. The label name avoids the
+bare `visibility` namespace because that conflicts with other Allure
+conventions and is too generic for downstream filters. Internal/omitted
+visibility emits no label; the corpus builder reads the absence as
+`internal`. This makes the Allure JSON the canonical signal — the
+corpus builder does not need to read the test source to classify
+visibility.
+
+### D6c. JSON Schema is generated and checked in; CI fails on drift
+
+`tests-corpus.schema.json` is generated from the Zod schema in
+`packages/test-narrative/` and checked into the repository. A CI step
+regenerates and compares; drift fails the build. The release workflow
+attaches the same file as a release artifact so external consumers
+(particularly the cross-repo renderer) can pin to a stable URL without
+importing this repo's TypeScript package.
+
+This pattern mirrors `scripts/generate_conformance_doc.mjs` (commit
+`9aac629` and the broader spec-compliance directory) — generated file
+checked in, `git diff --exit-code` drift gate. The trade-off vs.
+release-time-only generation: checking in costs almost nothing because
+the schema is small and changes rarely, and it gives PR reviewers a
+visible diff when the schema evolves, which catches accidents the
+generate-at-release flow would only surface after the change ships.
+
+### D7. Rendering order is a corpus-artifact contract, not a renderer-side rule
+
+Each corpus entry carries a `sections` array of stable section identifiers
+in the canonical order. Sections whose source content is absent are
+omitted from the array — the renderer iterates the array and emits one
+slab per identifier. The full identifier set, in canonical order:
+`breadcrumb`, `statusStrip`, `citationsStrip`, `motivatingProblem`,
+`scenario`, `results`, `implementationLimitation`, `testScopeExclusion`,
+`observedPerformance`, `potentialMisconception`,
+`implementationAlternativeRejected`, `ecma376Difficulty`,
+`specCitations`, `sourceLink`.
+
+This shape makes the renderer obligation enforceable from this repo: the
+corpus emitter's tests assert section ordering and omission rules, which
+is mechanical. A spec that put SHALLs on the cross-repo renderer would
+be a contract we cannot test from here.
+
+There is no "Discussion" umbrella and no "Related scenarios" identifier
+in the set; both were rejected during plan iteration (the former as too
+vague to be useful, the latter as a publish-gate that rotted 10× faster
+than other content because editing one scenario forced edits on N
+sibling pages).
 
 ### D8. Conformance-registry parser lift is a prerequisite
 
@@ -167,8 +226,27 @@ public and given valid JSDoc narrative tags.
 
 ## Open Questions
 
-- Should `tests-corpus.schema.json` be checked in, generated during release,
-  or both? The requirement only needs a stable emitted schema artifact.
 - Should the corpus emitter include source ranges for every extracted
   literal or only a source link for the owning test? The current contract
   requires enough identity for a source link, not full range provenance.
+- Should `corpusVisibility` Allure-label emission live inside the
+  `allure-test-factory` runtime, or in a setup-allure-labels helper that
+  callers already wire in? Either works; the implementation PR for Allure
+  visibility metadata will choose.
+
+## Closed Questions
+
+- **Where does `tests-corpus.schema.json` live?** Decided in D6c:
+  generated from the Zod schema, checked into the repo, CI fails on
+  drift, release attaches the same file.
+- **How does a cross-repo renderer consume the schema?** Decided in
+  spec.md Requirement: "Corpus artifact is the renderer-facing
+  contract": through the emitted JSON Schema artifact, not by importing
+  the TypeScript workspace package.
+- **How is `visibility` emitted as Allure metadata?** Decided in D6b:
+  label name `corpusVisibility`, value `public` when public, no label
+  when internal or omitted.
+- **What does the AST extractor do with non-literal fixture values?**
+  Decided in D6a and spec.md Requirement: "AST extractor falls back on
+  non-literal evidence": emit an unresolved-evidence marker with source
+  text and a `path:line` reference; never evaluate code.

--- a/openspec/changes/add-test-corpus-narrative/proposal.md
+++ b/openspec/changes/add-test-corpus-narrative/proposal.md
@@ -1,0 +1,44 @@
+# Change: Add test corpus narrative
+
+## Why
+
+BDD tests carry context that is currently trapped in commit messages,
+review discussion, and local maintainer memory. Public corpus consumers
+need a machine-readable, test-local source of truth that explains why a
+scenario exists, what it proves, what it deliberately excludes, and how it
+relates to ECMA-376 conformance evidence.
+
+## What Changes
+
+- Add a new OpenSpec capability, `test-corpus-narrative`, for per-test
+  narrative metadata and the publishable tests-corpus artifact.
+- Define a JSDoc narrative tag schema owned by a future
+  `packages/test-narrative/` package. The schema is the only source for
+  tag names, word ranges, and rendered section titles.
+- Add `visibility?: 'public' | 'internal'` to `AllureLabelDefaults`, with
+  a default of `internal`, as the only new runtime metadata needed to
+  decide whether narrative tags are required.
+- Define `tests-corpus.json` and `tests-corpus.schema.json`, emitted from
+  Allure result JSON joined with AST-extracted JSDoc narrative tags, BDD
+  strings, local fixture literals, `expect()` arguments, and resolved
+  ECMA-376 conformance claims.
+- Define the authoring and maintenance loop: a local Codex drafter may
+  propose JSDoc tags, CI validates required-tag presence and schema
+  conformance, and CI does not run an LLM or hash-based staleness gate.
+- Coordinate the corpus emitter with the active
+  `add-ecma-376-conformance-framework` change by listing the
+  conformance-registry parser lift as a prerequisite follow-up task.
+
+## Impact
+
+- Affected specs: `test-corpus-narrative` (new capability)
+- Affected code in follow-up PRs only:
+  - `packages/test-narrative/**`
+  - `packages/allure-test-factory/src/index.{js,d.ts}`
+  - `scripts/draft-narrative-jsdoc.mjs`
+  - `scripts/check_test_narratives.mjs`
+  - `scripts/build_tests_corpus.mjs`
+  - `scripts/lib/conformance-registry.mjs`
+  - tag-time GitHub Actions release workflow
+
+Ref: #235.

--- a/openspec/changes/add-test-corpus-narrative/specs/test-corpus-narrative/spec.md
+++ b/openspec/changes/add-test-corpus-narrative/specs/test-corpus-narrative/spec.md
@@ -1,0 +1,278 @@
+# test-corpus-narrative Specification (delta)
+
+## ADDED Requirements
+
+### Requirement: Narrative schema owns public test prose tags
+
+The repository SHALL define a Zod-backed narrative schema in
+`packages/test-narrative/` that is the only source of truth for narrative
+JSDoc tag names, required-vs-optional rules, word-count ranges, and
+rendered section titles. The drafter prompt, AST extractor, CI validator,
+corpus emitter, and downstream renderers MUST import those definitions
+instead of duplicating constants.
+
+The schema SHALL define these tags and no aliases:
+
+| Tag | Required | Words | Rendered section title |
+| --- | --- | --- | --- |
+| `motivatingProblem` | required when `visibility` is `public` | 60-150 | Motivating problem |
+| `implementationLimitation` | optional | 40-300 | Implementation limitations |
+| `testScopeExclusion` | optional | 40-300 | Test-scope exclusions |
+| `observedPerformance` | optional | 40-200 | Observed performance characteristics |
+| `potentialMisconception` | optional | 40-250 | Potential misconceptions |
+| `implementationAlternativeRejected` | optional | 40-250 | Implementation alternatives considered and rejected |
+| `ecma376Difficulty` | optional | 40-250 | What makes this hard in ECMA-376 |
+
+The names `limitation`, `aiContext`, `compare`, `specQuirk`,
+`notCovered`, `prose`, `description`, and `discussion` MUST NOT be
+accepted as aliases.
+
+#### Scenario: public test requires motivating problem
+
+- **GIVEN** a test with `visibility: 'public'`
+- **WHEN** the test has no `@motivatingProblem` JSDoc tag above its
+  `test.openspec(...)(...)` call
+- **THEN** `scripts/check_test_narratives.mjs` SHALL fail the test file
+  with a missing-required-tag error
+
+#### Scenario: internal test does not require narrative
+
+- **GIVEN** a structural test with omitted visibility or
+  `visibility: 'internal'`
+- **WHEN** it has no narrative JSDoc tags
+- **THEN** `scripts/check_test_narratives.mjs` SHALL accept the test
+
+#### Scenario: rejected tag alias fails
+
+- **GIVEN** a test JSDoc block containing `@limitation`
+- **WHEN** `scripts/check_test_narratives.mjs` parses the block
+- **THEN** the check SHALL fail because `limitation` is not a schema tag
+
+#### Scenario: tag word count is enforced
+
+- **GIVEN** a public test with `@motivatingProblem`
+- **WHEN** the tag body has fewer than 60 words or more than 150 words
+- **THEN** the check SHALL fail with a schema validation error
+
+### Requirement: Narrative tags describe distinct rendering sections
+
+Each present optional narrative tag SHALL render as its own self-titled
+section using the title provided by the schema. The renderer MUST NOT
+group optional tag bodies under a generic "Discussion" section.
+
+`motivatingProblem` SHALL describe the problem in the world that motivates
+the scenario, framed as a problem statement rather than a capability claim.
+`implementationLimitation` SHALL describe constraints of the code under
+test and bias toward underselling on rot. `testScopeExclusion` SHALL
+describe input shapes the test itself does not exercise, independent of
+whether the implementation handles them. `observedPerformance` SHALL
+describe applicable Big-O, memory complexity, observed runtime range, or
+scaling caveats without requiring every category. `potentialMisconception`
+SHALL include both the misconception and corrective claim in one block.
+`implementationAlternativeRejected` SHALL describe implementation designs
+considered and rejected, not test-design alternatives. `ecma376Difficulty`
+SHALL describe ECMA-376 idiosyncrasies that motivated the test.
+
+#### Scenario: optional tags render independently
+
+- **GIVEN** a public test with `@implementationLimitation` and
+  `@potentialMisconception`
+- **WHEN** the corpus is rendered
+- **THEN** the page SHALL include separate sections titled
+  "Implementation limitations" and "Potential misconceptions"
+- **AND** it SHALL NOT include a generic "Discussion" wrapper section
+
+#### Scenario: test-scope exclusions do not describe implementation support
+
+- **GIVEN** a JSDoc block with `@testScopeExclusion`
+- **WHEN** the schema validates the tag
+- **THEN** the tag SHALL be treated as prose about shapes unexercised by
+  that test, not as a claim that the implementation cannot handle them
+
+### Requirement: Allure label defaults include corpus visibility
+
+`packages/allure-test-factory` SHALL add
+`visibility?: 'public' | 'internal'` to `AllureLabelDefaults`. Omitted
+visibility SHALL be treated as `internal`. This field SHALL be the only
+new runtime metadata for test narrative; narrative content MUST remain in
+JSDoc above the `test.openspec(...)(...)` call and MUST NOT be passed
+through a runtime narrative API.
+
+#### Scenario: omitted visibility defaults internal
+
+- **GIVEN** a test whose Allure defaults omit `visibility`
+- **WHEN** the narrative validator classifies the test
+- **THEN** it SHALL treat the test as `internal`
+- **AND** it SHALL NOT require `@motivatingProblem`
+
+#### Scenario: public visibility activates required narrative
+
+- **GIVEN** a test whose Allure defaults include `visibility: 'public'`
+- **WHEN** the narrative validator classifies the test
+- **THEN** it SHALL require a valid `@motivatingProblem` tag
+
+#### Scenario: runtime API does not carry narrative prose
+
+- **GIVEN** a public test with narrative JSDoc
+- **WHEN** the test calls `test.openspec(...)(...)`
+- **THEN** the runtime Allure metadata SHALL include visibility but SHALL
+  NOT include the narrative tag bodies
+
+### Requirement: Structural tests remain internal
+
+The system SHALL keep tests whose value is purely structural and has no
+natural problem-in-the-world narrative at `visibility: 'internal'`.
+The system MUST NOT provide an escape hatch that allows a public test to
+omit `@motivatingProblem`.
+
+#### Scenario: parser empty-input guard stays internal
+
+- **GIVEN** a parser test that only verifies empty input does not crash
+- **WHEN** no meaningful public `@motivatingProblem` can be written
+- **THEN** the test SHALL remain `visibility: 'internal'`
+
+#### Scenario: no public escape hatch exists
+
+- **GIVEN** a test marked `visibility: 'public'`
+- **WHEN** it tries to bypass `@motivatingProblem` with any alternate flag
+  or tag
+- **THEN** `scripts/check_test_narratives.mjs` SHALL fail the test
+
+### Requirement: Narrative authoring is local and review-driven
+
+The repository SHALL provide `scripts/draft-narrative-jsdoc.mjs` as a
+local authoring helper that can invoke `codex exec` to draft narrative
+JSDoc tags for a developer to review, edit, and commit. CI MUST NOT run
+an LLM and MUST NOT create automatic narrative PRs.
+
+#### Scenario: developer drafts narrative locally
+
+- **GIVEN** a developer has added or updated a public test
+- **WHEN** the developer runs `scripts/draft-narrative-jsdoc.mjs`
+- **THEN** the script MAY invoke `codex exec` locally to draft candidate
+  narrative JSDoc tags
+- **AND** the developer SHALL review and edit the tags before committing
+
+#### Scenario: CI does not invoke LLM
+
+- **GIVEN** a pull request with public tests
+- **WHEN** CI runs narrative checks
+- **THEN** CI SHALL validate committed tags only
+- **AND** CI SHALL NOT invoke Codex, another LLM, or an automatic PR author
+
+### Requirement: Narrative CI gate validates presence and schema only
+
+`scripts/check_test_narratives.mjs` SHALL hard-fail when a public test is
+missing required `@motivatingProblem` or any present narrative tag fails
+the schema. The gate MUST NOT use hash-based staleness checks over test
+body text or narrative text.
+
+#### Scenario: invalid optional tag fails
+
+- **GIVEN** an internal or public test with `@observedPerformance`
+- **WHEN** the tag body fails the schema word-count range
+- **THEN** `scripts/check_test_narratives.mjs` SHALL fail even though the
+  tag is optional
+
+#### Scenario: cosmetic test edit does not trigger staleness failure
+
+- **GIVEN** a public test with valid narrative tags
+- **WHEN** a contributor changes indentation, renames a local variable, or
+  fixes a typo in the test body
+- **THEN** `scripts/check_test_narratives.mjs` SHALL NOT fail because of
+  a stale body hash
+
+### Requirement: Tests corpus artifact combines Allure and AST evidence
+
+`scripts/build_tests_corpus.mjs` SHALL emit `tests-corpus.json` and
+`tests-corpus.schema.json`. The corpus JSON SHALL combine Allure result
+JSON identity, status, labels, links, and step names with AST-extracted
+JSDoc narrative tags, verbatim BDD `given`/`when`/`then` strings, local
+fixture literals, `expect()` arguments, source links, and ECMA-376
+`ConformanceClaim[]` values resolved through the conformance registry.
+
+#### Scenario: corpus includes public narrative and BDD steps
+
+- **GIVEN** a public OpenSpec-mapped test with valid narrative JSDoc and
+  BDD `given`/`when`/`then` calls
+- **WHEN** `scripts/build_tests_corpus.mjs` runs after tests have emitted
+  Allure JSON
+- **THEN** `tests-corpus.json` SHALL include the test identity, status,
+  labels, links, narrative tag values, and verbatim BDD strings
+
+#### Scenario: corpus resolves ECMA-376 conformance claims
+
+- **GIVEN** a test with `ConformanceClaim[]` labels for ECMA-376 sections
+- **WHEN** `scripts/build_tests_corpus.mjs` loads the conformance registry
+- **THEN** the corpus entry SHALL include the scenario's resolved
+  conformance claims rather than only raw label strings
+
+#### Scenario: corpus includes local test evidence
+
+- **GIVEN** a test with local fixture literals and `expect()` calls
+- **WHEN** the AST extractor processes the test
+- **THEN** the corpus entry SHALL include the relevant fixture literals
+  and `expect()` arguments without executing the test body
+
+### Requirement: Tests corpus artifact strips engineer-only noise
+
+The corpus emitter SHALL normalize output for downstream corpus readers by
+excluding engineer-only or unstable runner details, including host runner
+IDs, Vitest framework names, millisecond durations, language tags, and
+other fields that do not describe the scenario, evidence, result, links,
+labels, citations, or source.
+
+#### Scenario: unstable runner fields are omitted
+
+- **GIVEN** an Allure result JSON file containing host runner IDs, Vitest
+  framework metadata, millisecond durations, and language tags
+- **WHEN** `scripts/build_tests_corpus.mjs` emits `tests-corpus.json`
+- **THEN** those fields SHALL be absent from the corpus entry
+
+#### Scenario: stable scenario fields remain
+
+- **GIVEN** the same Allure result JSON file contains test identity,
+  status, labels, links, and step names
+- **WHEN** `scripts/build_tests_corpus.mjs` emits `tests-corpus.json`
+- **THEN** those stable fields SHALL remain available in normalized form
+
+### Requirement: Tests corpus artifact is released at tag time
+
+The repository SHALL publish `tests-corpus.json` and
+`tests-corpus.schema.json` as tag-time release artifacts from a GitHub
+Actions workflow.
+
+#### Scenario: tag release publishes corpus artifacts
+
+- **GIVEN** a release tag is pushed
+- **WHEN** the tag-time release workflow runs
+- **THEN** the workflow SHALL build `tests-corpus.json` and
+  `tests-corpus.schema.json`
+- **AND** it SHALL attach both files to the release artifacts
+
+### Requirement: Rendered corpus pages follow fixed section ordering
+
+Downstream renderers of `tests-corpus.json` SHALL render each public test
+as a self-contained page in this order: breadcrumb/status/citations strip,
+Motivating problem, Scenario, Results, Implementation limitations,
+Test-scope exclusions, Observed performance characteristics, Potential
+misconceptions, Implementation alternatives considered and rejected, What
+makes this hard in ECMA-376, then Spec citations and Source link. Optional
+sections SHALL render only when their source tags are present. Renderers
+MUST NOT require a "Related scenarios" section.
+
+#### Scenario: optional section is omitted when tag is absent
+
+- **GIVEN** a corpus entry with `@motivatingProblem` but no
+  `@implementationAlternativeRejected`
+- **WHEN** the entry is rendered
+- **THEN** the page SHALL include "Motivating problem"
+- **AND** it SHALL NOT include "Implementation alternatives considered
+  and rejected"
+
+#### Scenario: source and citations remain final
+
+- **GIVEN** a corpus entry with ECMA-376 citations and a source link
+- **WHEN** the entry is rendered
+- **THEN** the final page section SHALL expose spec citations and the
+  source link after all present narrative sections

--- a/openspec/changes/add-test-corpus-narrative/specs/test-corpus-narrative/spec.md
+++ b/openspec/changes/add-test-corpus-narrative/specs/test-corpus-narrative/spec.md
@@ -59,22 +59,28 @@ accepted as aliases.
 
 ### Requirement: Narrative tags describe distinct rendering sections
 
-Each present optional narrative tag SHALL render as its own self-titled
-section using the title provided by the schema. The renderer MUST NOT
-group optional tag bodies under a generic "Discussion" section.
+Each narrative tag SHALL carry its own distinct section identifier and
+title from the schema, so the corpus emitter emits a separate entry in
+the `sections` array per present tag. The corpus emitter MUST NOT emit
+a generic `discussion` (or equivalent umbrella) section identifier that
+groups multiple tag bodies; the schema also MUST NOT define one. (Cross-
+repo renderers consume the resulting sections array — see the "Corpus
+artifact is the renderer-facing contract" requirement.)
 
-`motivatingProblem` SHALL describe the problem in the world that motivates
-the scenario, framed as a problem statement rather than a capability claim.
-`implementationLimitation` SHALL describe constraints of the code under
-test and bias toward underselling on rot. `testScopeExclusion` SHALL
-describe input shapes the test itself does not exercise, independent of
-whether the implementation handles them. `observedPerformance` SHALL
-describe applicable Big-O, memory complexity, observed runtime range, or
-scaling caveats without requiring every category. `potentialMisconception`
-SHALL include both the misconception and corrective claim in one block.
-`implementationAlternativeRejected` SHALL describe implementation designs
-considered and rejected, not test-design alternatives. `ecma376Difficulty`
-SHALL describe ECMA-376 idiosyncrasies that motivated the test.
+The schema's tag definitions SHALL constrain content as follows:
+`motivatingProblem` describes the problem in the world that motivates
+the scenario, framed as a problem statement rather than a capability
+claim. `implementationLimitation` describes constraints of the code
+under test and biases toward underselling on rot. `testScopeExclusion`
+describes input shapes the test itself does not exercise, independent
+of whether the implementation handles them. `observedPerformance`
+describes applicable Big-O, memory complexity, observed runtime range,
+or scaling caveats without requiring every category.
+`potentialMisconception` includes both the misconception and corrective
+claim in one block. `implementationAlternativeRejected` describes
+implementation designs considered and rejected, not test-design
+alternatives. `ecma376Difficulty` describes ECMA-376 idiosyncrasies that
+motivated the test.
 
 #### Scenario: optional tags render independently
 
@@ -351,10 +357,12 @@ identifiers in their canonical rendering order: `breadcrumb`,
 `specCitations`, `sourceLink`. Sections whose backing content is absent
 (e.g., the entry has no `@implementationLimitation` tag) SHALL be
 omitted from the array, not emitted with empty content. The schema
-SHALL document each section identifier's human-readable title. Renderers
-in any repository SHALL render the sections in array order; they SHALL
-NOT introduce a "Related scenarios" section as a structural element of
-the page.
+SHALL document each section identifier's human-readable title. The
+emitted `sections` array MUST NOT contain a `relatedScenarios`,
+`discussion`, or other umbrella identifier — the canonical list above is
+exhaustive. (Cross-repo renderers iterate the array in order and emit
+one slab per identifier; this proposal places no further normative
+requirement on those renderers because they live outside this repo.)
 
 #### Scenario: schema is checked in and CI fails on drift
 

--- a/openspec/changes/add-test-corpus-narrative/specs/test-corpus-narrative/spec.md
+++ b/openspec/changes/add-test-corpus-narrative/specs/test-corpus-narrative/spec.md
@@ -7,9 +7,12 @@
 The repository SHALL define a Zod-backed narrative schema in
 `packages/test-narrative/` that is the only source of truth for narrative
 JSDoc tag names, required-vs-optional rules, word-count ranges, and
-rendered section titles. The drafter prompt, AST extractor, CI validator,
-corpus emitter, and downstream renderers MUST import those definitions
-instead of duplicating constants.
+rendered section titles. The in-repo drafter prompt, AST extractor, CI
+validator, and corpus emitter MUST import those definitions instead of
+duplicating constants. Downstream renderers in other repositories MUST
+consume the emitted `tests-corpus.schema.json` artifact (see Requirement:
+Corpus artifact is the renderer-facing contract) rather than importing
+the TypeScript package directly.
 
 The schema SHALL define these tags and no aliases:
 
@@ -98,6 +101,15 @@ new runtime metadata for test narrative; narrative content MUST remain in
 JSDoc above the `test.openspec(...)(...)` call and MUST NOT be passed
 through a runtime narrative API.
 
+When `visibility` is `'public'`, the Allure runtime SHALL emit it as a
+label with name `corpusVisibility` and value `public` on each test
+result. When `visibility` is `'internal'` or omitted, the Allure runtime
+SHALL NOT emit a `corpusVisibility` label; the corpus builder normalizes
+the absent value to `internal`. The label name `corpusVisibility` is the
+hard contract — corpus builders, downstream tooling, and future renderers
+key off it; the alternate name `visibility` MUST NOT be used because it
+collides with the conventional Allure label namespace.
+
 #### Scenario: omitted visibility defaults internal
 
 - **GIVEN** a test whose Allure defaults omit `visibility`
@@ -115,21 +127,37 @@ through a runtime narrative API.
 
 - **GIVEN** a public test with narrative JSDoc
 - **WHEN** the test calls `test.openspec(...)(...)`
-- **THEN** the runtime Allure metadata SHALL include visibility but SHALL
-  NOT include the narrative tag bodies
+- **THEN** the runtime Allure metadata SHALL include the
+  `corpusVisibility` label but SHALL NOT include the narrative tag bodies
 
-### Requirement: Structural tests remain internal
+#### Scenario: public visibility emits stable Allure label
 
-The system SHALL keep tests whose value is purely structural and has no
-natural problem-in-the-world narrative at `visibility: 'internal'`.
-The system MUST NOT provide an escape hatch that allows a public test to
-omit `@motivatingProblem`.
+- **GIVEN** a test with `visibility: 'public'`
+- **WHEN** the Allure runtime emits the test result JSON
+- **THEN** the result's `labels` array SHALL include an entry with
+  `name: 'corpusVisibility'` and `value: 'public'`
 
-#### Scenario: parser empty-input guard stays internal
+#### Scenario: internal visibility omits the label
 
-- **GIVEN** a parser test that only verifies empty input does not crash
-- **WHEN** no meaningful public `@motivatingProblem` can be written
-- **THEN** the test SHALL remain `visibility: 'internal'`
+- **GIVEN** a test with `visibility: 'internal'` or with `visibility`
+  omitted
+- **WHEN** the Allure runtime emits the test result JSON
+- **THEN** the result's `labels` array SHALL NOT include any entry whose
+  `name` is `corpusVisibility`
+- **AND** the corpus builder SHALL classify the test as `internal` when
+  it consumes the result
+
+### Requirement: No public escape hatch for missing narrative
+
+The system MUST NOT provide an escape hatch that allows a `visibility:
+'public'` test to omit `@motivatingProblem`. No alternate tag, label, or
+flag (for example, a hypothetical `@structuralGuarantee` tag) SHALL
+satisfy the public-narrative requirement in place of `@motivatingProblem`.
+
+Authoring policy (non-normative; see `design.md` D4): tests whose value
+is purely structural and for which no useful `@motivatingProblem` can
+honestly be written should stay `visibility: 'internal'`. The mechanical
+contract above is the only normative gate.
 
 #### Scenario: no public escape hatch exists
 
@@ -137,6 +165,13 @@ omit `@motivatingProblem`.
 - **WHEN** it tries to bypass `@motivatingProblem` with any alternate flag
   or tag
 - **THEN** `scripts/check_test_narratives.mjs` SHALL fail the test
+
+#### Scenario: internal structural test passes the gate
+
+- **GIVEN** a structural parser test marked `visibility: 'internal'`
+- **WHEN** it has no `@motivatingProblem` tag
+- **THEN** `scripts/check_test_narratives.mjs` SHALL accept the test
+  without checking for narrative content
 
 ### Requirement: Narrative authoring is local and review-driven
 
@@ -191,6 +226,12 @@ JSDoc narrative tags, verbatim BDD `given`/`when`/`then` strings, local
 fixture literals, `expect()` arguments, source links, and ECMA-376
 `ConformanceClaim[]` values resolved through the conformance registry.
 
+The AST extractor SHALL be purely static. It MUST NOT evaluate test
+code, resolve runtime imports, follow factory function calls, or attempt
+to compute non-literal values. The contract is "extract what is
+syntactically present in the test source; for everything else, point at
+it." See the fallback requirement below.
+
 #### Scenario: corpus includes public narrative and BDD steps
 
 - **GIVEN** a public OpenSpec-mapped test with valid narrative JSDoc and
@@ -209,10 +250,50 @@ fixture literals, `expect()` arguments, source links, and ECMA-376
 
 #### Scenario: corpus includes local test evidence
 
-- **GIVEN** a test with local fixture literals and `expect()` calls
+- **GIVEN** a test whose given/when/then bodies contain only
+  syntactically-local string literals, number literals, and object/array
+  literals (no imports, no factory calls, no computed expressions)
 - **WHEN** the AST extractor processes the test
-- **THEN** the corpus entry SHALL include the relevant fixture literals
-  and `expect()` arguments without executing the test body
+- **THEN** the corpus entry SHALL include those literals verbatim and the
+  exact `expect()` argument expressions without executing the test body
+
+### Requirement: AST extractor falls back on non-literal evidence
+
+The corpus emitter SHALL record an unresolved-evidence marker in place
+of any value the AST extractor cannot statically resolve. The unresolved
+case includes imported bindings, factory function calls, template
+literals with runtime expressions, destructured fixtures, and any
+non-literal expression. The marker SHALL include the source-text of the
+unresolved expression and a stable source reference (file path plus
+line number) so a downstream reader can follow the link. The emitter
+MUST NOT fail the build, MUST NOT execute the test, and MUST NOT
+silently drop the field.
+
+#### Scenario: imported fixture is recorded as unresolved with source link
+
+- **GIVEN** a test whose `given(...)` argument is an imported constant
+  (for example, `given(SHARED_PARAGRAPH_FIXTURE, ...)` where
+  `SHARED_PARAGRAPH_FIXTURE` is imported from another module)
+- **WHEN** `scripts/build_tests_corpus.mjs` runs the AST extractor
+- **THEN** the corpus entry for that step SHALL contain a value object
+  whose `kind` is `unresolved`, whose `sourceText` is the literal
+  expression (`SHARED_PARAGRAPH_FIXTURE`), and whose `sourceRef` is the
+  `path:line` of the call site
+
+#### Scenario: factory call is recorded as unresolved
+
+- **GIVEN** an `expect()` whose argument is a function call (for example,
+  `expect(buildFixture('case-A')).toBe(...)`)
+- **WHEN** the AST extractor processes it
+- **THEN** the corpus entry SHALL record the call as an unresolved
+  evidence marker rather than evaluating the function
+
+#### Scenario: static literal is fully resolved
+
+- **GIVEN** a `given(...)` with a string-literal argument
+- **WHEN** the AST extractor processes it
+- **THEN** the corpus entry SHALL include the literal value directly,
+  without any unresolved-evidence marker
 
 ### Requirement: Tests corpus artifact strips engineer-only noise
 
@@ -250,29 +331,51 @@ Actions workflow.
   `tests-corpus.schema.json`
 - **AND** it SHALL attach both files to the release artifacts
 
-### Requirement: Rendered corpus pages follow fixed section ordering
+### Requirement: Corpus artifact is the renderer-facing contract
 
-Downstream renderers of `tests-corpus.json` SHALL render each public test
-as a self-contained page in this order: breadcrumb/status/citations strip,
-Motivating problem, Scenario, Results, Implementation limitations,
-Test-scope exclusions, Observed performance characteristics, Potential
-misconceptions, Implementation alternatives considered and rejected, What
-makes this hard in ECMA-376, then Spec citations and Source link. Optional
-sections SHALL render only when their source tags are present. Renderers
-MUST NOT require a "Related scenarios" section.
+`scripts/build_tests_corpus.mjs` SHALL generate `tests-corpus.schema.json`
+from the in-repo Zod schema and check it into the repository alongside
+the source schema, so the renderer contract lives in the emitted
+artifact rather than in source-code imports across repositories. A CI
+step SHALL regenerate the JSON Schema and fail the build if it drifts
+from the checked-in copy. The release workflow SHALL publish the same
+generated file as a release artifact so external consumers can pin to
+a stable URL.
 
-#### Scenario: optional section is omitted when tag is absent
+Each corpus entry SHALL carry a `sections` array of stable section
+identifiers in their canonical rendering order: `breadcrumb`,
+`statusStrip`, `citationsStrip`, `motivatingProblem`, `scenario`,
+`results`, `implementationLimitation`, `testScopeExclusion`,
+`observedPerformance`, `potentialMisconception`,
+`implementationAlternativeRejected`, `ecma376Difficulty`,
+`specCitations`, `sourceLink`. Sections whose backing content is absent
+(e.g., the entry has no `@implementationLimitation` tag) SHALL be
+omitted from the array, not emitted with empty content. The schema
+SHALL document each section identifier's human-readable title. Renderers
+in any repository SHALL render the sections in array order; they SHALL
+NOT introduce a "Related scenarios" section as a structural element of
+the page.
 
-- **GIVEN** a corpus entry with `@motivatingProblem` but no
-  `@implementationAlternativeRejected`
-- **WHEN** the entry is rendered
-- **THEN** the page SHALL include "Motivating problem"
-- **AND** it SHALL NOT include "Implementation alternatives considered
-  and rejected"
+#### Scenario: schema is checked in and CI fails on drift
 
-#### Scenario: source and citations remain final
+- **GIVEN** a developer modifies the Zod schema in
+  `packages/test-narrative/` without regenerating
+  `tests-corpus.schema.json`
+- **WHEN** CI runs the schema-drift check
+- **THEN** the check SHALL fail with a message identifying the drift
 
-- **GIVEN** a corpus entry with ECMA-376 citations and a source link
-- **WHEN** the entry is rendered
-- **THEN** the final page section SHALL expose spec citations and the
-  source link after all present narrative sections
+#### Scenario: omitted optional section is not present in sections array
+
+- **GIVEN** a corpus entry derived from a test with `@motivatingProblem`
+  but no `@implementationAlternativeRejected`
+- **WHEN** the entry is emitted
+- **THEN** the entry's `sections` array SHALL contain
+  `motivatingProblem`
+- **AND** SHALL NOT contain `implementationAlternativeRejected`
+
+#### Scenario: spec citations and source link are last
+
+- **GIVEN** any corpus entry with ECMA-376 citations and a source link
+- **WHEN** the entry is emitted
+- **THEN** the last two elements of its `sections` array SHALL be
+  `specCitations` followed by `sourceLink`, in that order

--- a/openspec/changes/add-test-corpus-narrative/tasks.md
+++ b/openspec/changes/add-test-corpus-narrative/tasks.md
@@ -4,15 +4,23 @@
 
 - [ ] 1.1 Review and approve this OpenSpec change.
 - [ ] 1.2 Coordinate landing order with
-      `add-ecma-376-conformance-framework`, because corpus conformance
-      resolution depends on that framework's registry and Allure labels.
+      `add-ecma-376-conformance-framework`. Implementation of
+      `scripts/build_tests_corpus.mjs` (task 7.1) is **blocked** until
+      the registry-parser lift (task 2) lands, which itself MUST follow
+      `add-ecma-376-conformance-framework` reaching a stable registry
+      grammar (either fully archived or at a commit a maintainer
+      explicitly pins as stable for downstream consumers). OpenSpec has
+      no native cross-change dependency mechanism; this dependency is
+      tracked here.
 
 ## 2. Conformance registry prerequisite
 
 - [ ] 2.1 Lift the private registry parsers from
       `scripts/check_conformance_citations.mjs` and
       `scripts/generate_conformance_doc.mjs` into
-      `scripts/lib/conformance-registry.mjs`.
+      `scripts/lib/conformance-registry.mjs`. Do NOT begin this task
+      until `add-ecma-376-conformance-framework` has reached a stable
+      registry grammar (see task 1.2).
 - [ ] 2.2 Export parser/load helpers that the conformance lint, generated
       docs, and future corpus emitter can share without duplicating
       registry grammar.
@@ -24,10 +32,15 @@
 - [ ] 3.1 Create `packages/test-narrative/` with a Zod schema for the
       narrative tags, word-count ranges, rendered section titles, and
       required-vs-optional visibility rules.
-- [ ] 3.2 Make the schema the only source of truth imported by the drafter,
-      AST extractor, CI validator, corpus emitter, and downstream
-      renderers.
-- [ ] 3.3 Add package tests that cover valid tags, invalid tag names,
+- [ ] 3.2 Make the schema the only source of truth imported by in-repo
+      consumers (drafter, AST extractor, CI validator, corpus emitter).
+      Cross-repo renderers MUST consume the emitted JSON Schema artifact
+      instead — they MUST NOT import the TypeScript package directly.
+- [ ] 3.3 Generate `tests-corpus.schema.json` from the Zod schema, check
+      it into the repository, and add a CI step that regenerates it and
+      fails on drift (mirroring the existing
+      `scripts/generate_conformance_doc.mjs` idiom).
+- [ ] 3.4 Add package tests that cover valid tags, invalid tag names,
       out-of-range prose, required public `motivatingProblem`, and
       internal structural tests with no narrative requirement.
 
@@ -37,17 +50,28 @@
       `AllureLabelDefaults` in `packages/allure-test-factory/src/index.d.ts`
       and the runtime merge/emission surface.
 - [ ] 4.2 Default omitted visibility to `internal`.
-- [ ] 4.3 Ensure this remains the only runtime metadata added for test
+- [ ] 4.3 Emit `visibility: 'public'` as an Allure label with name
+      `corpusVisibility` and value `public` on the test result.
+      `visibility: 'internal'` (or omitted) MUST NOT emit a
+      `corpusVisibility` label; the corpus builder reads the absence as
+      internal. Do NOT reuse the bare `visibility` label name — it
+      collides with the conventional Allure label namespace.
+- [ ] 4.4 Ensure this remains the only runtime metadata added for test
       narrative; narrative prose stays in JSDoc above the
       `test.openspec(...)(...)` call.
 
 ## 5. AST extraction and validation
 
-- [ ] 5.1 Implement an AST extractor that joins a test call to its leading
-      JSDoc narrative tags and extracts verbatim BDD `given`/`when`/`then`
-      step strings.
-- [ ] 5.2 Extract local fixture literals and `expect()` arguments needed by
-      the corpus artifact without evaluating tests.
+- [ ] 5.1 Implement a purely-static AST extractor that joins a test call
+      to its leading JSDoc narrative tags and extracts verbatim BDD
+      `given`/`when`/`then` step strings. The extractor MUST NOT
+      evaluate test code, follow imports, or resolve function calls.
+- [ ] 5.2 Extract syntactically-local fixture literals and `expect()`
+      arguments. For any value that is not statically resolvable
+      (imported binding, factory call, computed expression, destructured
+      fixture), emit an unresolved-evidence marker carrying the source
+      text of the expression plus a `path:line` reference. The extractor
+      MUST NOT fail the build and MUST NOT silently drop the field.
 - [ ] 5.3 Implement `scripts/check_test_narratives.mjs` so CI hard-fails
       when public tests lack `@motivatingProblem` or any present tag fails
       schema parsing.
@@ -65,16 +89,26 @@
 ## 7. Corpus artifact
 
 - [ ] 7.1 Implement `scripts/build_tests_corpus.mjs` to emit
-      `tests-corpus.json` and `tests-corpus.schema.json`.
-- [ ] 7.2 Populate the corpus from Allure JSON identity, status, labels,
-      links, and step names joined with AST-extracted narrative tags, BDD
-      steps, fixture literals, `expect()` arguments, and resolved
-      `ConformanceClaim[]`.
+      `tests-corpus.json` (using the schema generated in task 3.3).
+- [ ] 7.2 Populate the corpus from Allure JSON identity, status, labels
+      (including the `corpusVisibility` label from task 4.3), links, and
+      step names joined with AST-extracted narrative tags, BDD steps,
+      fixture literals (or unresolved-evidence markers per task 5.2),
+      `expect()` arguments, and resolved `ConformanceClaim[]`.
 - [ ] 7.3 Normalize the artifact by stripping host runner IDs, Vitest
       framework names, millisecond durations, language tags, and other
       engineer-only noise.
-- [ ] 7.4 Add a tag-time GitHub Actions workflow that publishes the corpus
-      files as release artifacts.
+- [ ] 7.4 For each entry, emit a `sections` array of stable section
+      identifiers in canonical order: `breadcrumb`, `statusStrip`,
+      `citationsStrip`, `motivatingProblem`, `scenario`, `results`,
+      `implementationLimitation`, `testScopeExclusion`,
+      `observedPerformance`, `potentialMisconception`,
+      `implementationAlternativeRejected`, `ecma376Difficulty`,
+      `specCitations`, `sourceLink`. Omit any section whose backing
+      content is absent.
+- [ ] 7.5 Add a tag-time GitHub Actions workflow that publishes
+      `tests-corpus.json` and the checked-in `tests-corpus.schema.json`
+      as release artifacts.
 
 ## 8. Verification
 

--- a/openspec/changes/add-test-corpus-narrative/tasks.md
+++ b/openspec/changes/add-test-corpus-narrative/tasks.md
@@ -1,0 +1,83 @@
+# Tasks: add-test-corpus-narrative
+
+## 1. Proposal
+
+- [ ] 1.1 Review and approve this OpenSpec change.
+- [ ] 1.2 Coordinate landing order with
+      `add-ecma-376-conformance-framework`, because corpus conformance
+      resolution depends on that framework's registry and Allure labels.
+
+## 2. Conformance registry prerequisite
+
+- [ ] 2.1 Lift the private registry parsers from
+      `scripts/check_conformance_citations.mjs` and
+      `scripts/generate_conformance_doc.mjs` into
+      `scripts/lib/conformance-registry.mjs`.
+- [ ] 2.2 Export parser/load helpers that the conformance lint, generated
+      docs, and future corpus emitter can share without duplicating
+      registry grammar.
+- [ ] 2.3 Keep the lift as a separate follow-up PR before implementing
+      `scripts/build_tests_corpus.mjs`.
+
+## 3. Narrative schema package
+
+- [ ] 3.1 Create `packages/test-narrative/` with a Zod schema for the
+      narrative tags, word-count ranges, rendered section titles, and
+      required-vs-optional visibility rules.
+- [ ] 3.2 Make the schema the only source of truth imported by the drafter,
+      AST extractor, CI validator, corpus emitter, and downstream
+      renderers.
+- [ ] 3.3 Add package tests that cover valid tags, invalid tag names,
+      out-of-range prose, required public `motivatingProblem`, and
+      internal structural tests with no narrative requirement.
+
+## 4. Allure visibility metadata
+
+- [ ] 4.1 Add `visibility?: 'public' | 'internal'` to
+      `AllureLabelDefaults` in `packages/allure-test-factory/src/index.d.ts`
+      and the runtime merge/emission surface.
+- [ ] 4.2 Default omitted visibility to `internal`.
+- [ ] 4.3 Ensure this remains the only runtime metadata added for test
+      narrative; narrative prose stays in JSDoc above the
+      `test.openspec(...)(...)` call.
+
+## 5. AST extraction and validation
+
+- [ ] 5.1 Implement an AST extractor that joins a test call to its leading
+      JSDoc narrative tags and extracts verbatim BDD `given`/`when`/`then`
+      step strings.
+- [ ] 5.2 Extract local fixture literals and `expect()` arguments needed by
+      the corpus artifact without evaluating tests.
+- [ ] 5.3 Implement `scripts/check_test_narratives.mjs` so CI hard-fails
+      when public tests lack `@motivatingProblem` or any present tag fails
+      schema parsing.
+- [ ] 5.4 Do not add hash-based staleness gates.
+
+## 6. Authoring loop
+
+- [ ] 6.1 Implement `scripts/draft-narrative-jsdoc.mjs` as a local-only
+      helper that shells to `codex exec` to draft narrative tags.
+- [ ] 6.2 Document that developers must review, edit, and commit the
+      drafted tags manually.
+- [ ] 6.3 Ensure CI never runs an LLM and never opens automatic narrative
+      PRs.
+
+## 7. Corpus artifact
+
+- [ ] 7.1 Implement `scripts/build_tests_corpus.mjs` to emit
+      `tests-corpus.json` and `tests-corpus.schema.json`.
+- [ ] 7.2 Populate the corpus from Allure JSON identity, status, labels,
+      links, and step names joined with AST-extracted narrative tags, BDD
+      steps, fixture literals, `expect()` arguments, and resolved
+      `ConformanceClaim[]`.
+- [ ] 7.3 Normalize the artifact by stripping host runner IDs, Vitest
+      framework names, millisecond durations, language tags, and other
+      engineer-only noise.
+- [ ] 7.4 Add a tag-time GitHub Actions workflow that publishes the corpus
+      files as release artifacts.
+
+## 8. Verification
+
+- [ ] 8.1 `openspec validate add-test-corpus-narrative --strict` passes.
+- [ ] 8.2 Future implementation PRs add targeted package tests and wire the
+      narrative check into CI.


### PR DESCRIPTION
## Summary

Scaffolds the OpenSpec proposal `add-test-corpus-narrative` (proposal/tasks/design + spec delta under a new `test-corpus-narrative` capability). Proposal-only PR — no code changes; the implementation lands in follow-up PRs per `tasks.md`.

## What this proposes

- **JSDoc narrative-tag schema** (Zod, owned by a future `packages/test-narrative/`) — 7 tags total, all 3–4 word camelCase, self-disambiguating without relying on section titles. Required when `visibility: 'public'`: `@motivatingProblem`. Optional: `@implementationLimitation`, `@testScopeExclusion`, `@observedPerformance`, `@potentialMisconception`, `@implementationAlternativeRejected`, `@ecma376Difficulty`. Ambiguous names (`@limitation`, `@aiContext`, `@compare`, `@specQuirk`, `@notCovered`, `@prose`, `@description`, `@discussion`) are explicitly rejected as aliases.
- **`visibility?: 'public' | 'internal'` on `AllureLabelDefaults`** (default `internal`). The only new runtime metadata. Narrative content does NOT live on a runtime API; it lives in JSDoc above the `test.openspec(...)(...)` call.
- **`tests-corpus.json` + `tests-corpus.schema.json` artifact** emitted by a future `scripts/build_tests_corpus.mjs`. Allure JSON contributes identity/status/labels/links/step names; AST extraction contributes JSDoc tags + verbatim BDD strings + local fixture literals + `expect()` arguments; the existing ECMA-376 registry resolves `ConformanceClaim[]`. Engineer-only noise (host runner IDs, vitest framework name, ms durations, language tags) is stripped. Released as a tag-time GitHub Actions artifact.
- **Authoring + CI loop**: developer runs a local `scripts/draft-narrative-jsdoc.mjs` (Codex via `codex exec`); CI never calls an LLM and never opens automatic PRs. The CI gate (`scripts/check_test_narratives.mjs`) hard-fails on missing required tag or schema-invalid present tag. **No hash-based staleness gate** — false-positives on cosmetic edits and false-negatives on semantic changes that preserve token order; trust + the asymmetry-of-rot principle replace it.
- **Structural-only tests** (parser-doesn't-crash-on-empty-input class) stay `visibility: 'internal'`. No escape hatch.

## Coordination

The corpus emitter depends on the active `add-ecma-376-conformance-framework` change (8/35 tasks). The conformance-registry parsers (`parseRegistryFile` / `loadRegistry`, private to `scripts/check_conformance_citations.mjs:63` and `scripts/generate_conformance_doc.mjs:41`) must be lifted into `scripts/lib/conformance-registry.mjs` first. `tasks.md` lists that lift as a prerequisite follow-up — it doesn't live in this PR.

## Verification

```text
$ openspec validate add-test-corpus-narrative --strict
Change 'add-test-corpus-narrative' is valid
```

Diff is confined to `openspec/changes/add-test-corpus-narrative/` — no code edits, no changes to existing specs (no MODIFIED deltas; the `AllureLabelDefaults` addition is captured as a new ADDED requirement under the new capability, per the design.md rationale).

## Verification checklist

- [x] `openspec validate add-test-corpus-narrative --strict` exits 0
- [x] `proposal.md`, `tasks.md`, `design.md` present
- [x] Spec delta under `specs/test-corpus-narrative/spec.md` with `## ADDED Requirements`
- [x] Every requirement has at least one `#### Scenario:`
- [x] No code changes outside `openspec/changes/add-test-corpus-narrative/`
- [ ] Peer review (Gemini + Codex) — pending; will be appended as a PR comment

## Closes

- #235