### PR TITLE
docs(readme): replace branding header with action-led title and autosync translations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,16 @@ jobs:
       - name: Validate Gemini extension manifest
         run: node scripts/check_gemini_extension_manifest.mjs
 
+  readme-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+      - name: Verify README translations are in sync with English source
+        run: node scripts/sync_readme_blocks.mjs --check
+
   workspace-lint:
     runs-on: ubuntu-latest
     steps:

--- a/README.de.md
+++ b/README.de.md
@@ -1,19 +1,81 @@
-# Safe DOCX Suite
+# Word-Dokumente (.docx) mit Programmier-Agenten via MCP bearbeiten
 
+<!-- SYNC:badges BEGIN -->
 [![CI](https://github.com/usejunior/safe-docx/actions/workflows/ci.yml/badge.svg)](https://github.com/usejunior/safe-docx/actions/workflows/ci.yml)
 [![codecov](https://img.shields.io/codecov/c/github/usejunior/safe-docx/main)](https://app.codecov.io/gh/usejunior/safe-docx)
 [![npm version](https://img.shields.io/npm/v/@usejunior/safe-docx)](https://www.npmjs.com/package/@usejunior/safe-docx)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/UseJunior/safe-docx/blob/main/LICENSE)
 [![GitHub last commit](https://img.shields.io/github/last-commit/UseJunior/safe-docx)](https://github.com/UseJunior/safe-docx/commits/main)
 [![GitHub issues closed](https://img.shields.io/github/issues-closed/UseJunior/safe-docx)](https://github.com/UseJunior/safe-docx/issues?q=is%3Aissue+is%3Aclosed)
+<!-- SYNC:badges END -->
 
+<!-- SYNC:lang-nav BEGIN -->
 [English](./README.md) | [Español](./README.es.md) | [简体中文](./README.zh.md) | [Português (Brasil)](./README.pt-br.md) | [Deutsch](./README.de.md)
+<!-- SYNC:lang-nav END -->
 
 > **Übersetzungshinweis:** Die englische Version `README.md` ist die kanonische Quelle der Wahrheit. Diese Übersetzung kann einen kurzen Rückstand haben. Wesentliche Aktualisierungen des englischen READMEs sollten innerhalb von 72 Stunden in diese Datei übernommen werden.
 
-**safe-docx** von [UseJunior](https://usejunior.com) — nutze Programmier-Agenten auch für Papierkram.
+<!-- SYNC:architecture-diagram BEGIN -->
+```mermaid
+%%{init: {"flowchart": {"htmlLabels": true, "curve": "basis", "nodeSpacing": 30, "rankSpacing": 50}, "themeVariables": {"fontSize": "14px"}} }%%
+flowchart LR
+    DocInLeft["<b>Existing .docx</b><br/>on disk"]
 
-Teil der [UseJunior-Entwicklertools](https://usejunior.com/developer-tools/safe-docx).
+    subgraph Server["@usejunior/safe-docx — local MCP server"]
+        direction LR
+
+        subgraph ReadParse["<b>1. Read</b>"]
+            direction TB
+            RPTool["<code>read_file(file_path,<br/>&nbsp;&nbsp;format)</code>"]
+        end
+
+        subgraph Locate["<b>2. Locate</b>"]
+            direction TB
+            LocTool["<code>grep(file_path,<br/>&nbsp;&nbsp;pattern)</code>"]
+        end
+
+        subgraph Edit["<b>3. Edit</b>"]
+            direction TB
+            EditTool["<code>replace_text(<br/>&nbsp;&nbsp;target_paragraph_id,<br/>&nbsp;&nbsp;old_string, new_string,<br/>&nbsp;&nbsp;instruction)</code>"]
+        end
+
+        subgraph Save["<b>4. Save</b>"]
+            direction TB
+            SaveTool["<code>save(save_to_local_path,<br/>&nbsp;&nbsp;save_format)</code>"]
+        end
+
+        ReadParse --> Locate
+        Locate --> Edit
+        Edit --> Save
+    end
+
+    DocInRight["<b>Saved .docx output</b><br/>on disk"]
+
+    subgraph Client [" "]
+        direction TB
+        Prompt["<b>Prompt</b><br/>'Change NDA governing law to Delaware'"]
+        Agent["<b>Coding agent / MCP client</b><br/>Claude Code · Cursor · Gemini CLI"]
+        Prompt --> Agent
+    end
+
+    DocInLeft --> RPTool
+    SaveTool --> DocInRight
+    Agent <-->|tool call / tool result| Server
+
+    classDef io fill:#f5f5f5,stroke:#888,color:#222
+    classDef server fill:#eff6ff,stroke:#3b82f6,color:#1e3a8a
+    classDef stage fill:#eef2ff,stroke:#6366f1,color:#1e1b4b
+    classDef tools fill:#ecfdf5,stroke:#10b981,color:#064e3b
+    classDef ext fill:#ddd6fe,stroke:#7c3aed,color:#3b0764
+    classDef hidden fill:none,stroke:none
+    class DocInLeft,DocInRight io
+    class Server server
+    class ReadParse,Locate,Edit,Save stage
+    class RPTool,LocTool,EditTool,SaveTool tools
+    class Prompt,Agent ext
+    class Client hidden
+```
+<!-- SYNC:architecture-diagram END -->
 
 Safe Docx ist ein Open-Source-TypeScript-Stack für die chirurgische Bearbeitung bestehender Microsoft Word `.docx`-Dateien. Es wurde für Workflows entwickelt, in denen ein Agent Änderungen vorschlägt und ein Mensch weiterhin zuverlässige, formatierungserhaltende Dokumentenbearbeitungen benötigt.
 
@@ -235,7 +297,6 @@ npm run coverage:matrix
 ## Siehe auch
 
 - [Open Agreements](https://github.com/open-agreements/open-agreements) — Standardmäßige Rechtsvorlagen mit Programmier-Agenten ausfüllen (NDAs, SAFEs, NVCA)
-- [UseJunior-Entwicklertools](https://usejunior.com/developer-tools/safe-docx) — Produktseite mit Installationsoptionen und Tool-Katalog
 
 ## Datenschutz
 

--- a/README.es.md
+++ b/README.es.md
@@ -1,19 +1,81 @@
-# Safe DOCX Suite
+# Edita documentos de Word (.docx) con agentes de programación vía MCP
 
+<!-- SYNC:badges BEGIN -->
 [![CI](https://github.com/usejunior/safe-docx/actions/workflows/ci.yml/badge.svg)](https://github.com/usejunior/safe-docx/actions/workflows/ci.yml)
 [![codecov](https://img.shields.io/codecov/c/github/usejunior/safe-docx/main)](https://app.codecov.io/gh/usejunior/safe-docx)
 [![npm version](https://img.shields.io/npm/v/@usejunior/safe-docx)](https://www.npmjs.com/package/@usejunior/safe-docx)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/UseJunior/safe-docx/blob/main/LICENSE)
 [![GitHub last commit](https://img.shields.io/github/last-commit/UseJunior/safe-docx)](https://github.com/UseJunior/safe-docx/commits/main)
 [![GitHub issues closed](https://img.shields.io/github/issues-closed/UseJunior/safe-docx)](https://github.com/UseJunior/safe-docx/issues?q=is%3Aissue+is%3Aclosed)
+<!-- SYNC:badges END -->
 
+<!-- SYNC:lang-nav BEGIN -->
 [English](./README.md) | [Español](./README.es.md) | [简体中文](./README.zh.md) | [Português (Brasil)](./README.pt-br.md) | [Deutsch](./README.de.md)
+<!-- SYNC:lang-nav END -->
 
 > **Nota de traducción:** La versión en inglés `README.md` es la fuente canónica de la verdad. Esta traducción puede tener un breve retraso. Las actualizaciones importantes del README en inglés deben sincronizarse con este archivo en un plazo de 72 horas.
 
-**safe-docx** por [UseJunior](https://usejunior.com) — usa agentes de programación también para el papeleo.
+<!-- SYNC:architecture-diagram BEGIN -->
+```mermaid
+%%{init: {"flowchart": {"htmlLabels": true, "curve": "basis", "nodeSpacing": 30, "rankSpacing": 50}, "themeVariables": {"fontSize": "14px"}} }%%
+flowchart LR
+    DocInLeft["<b>Existing .docx</b><br/>on disk"]
 
-Parte de las [herramientas para desarrolladores de UseJunior](https://usejunior.com/developer-tools/safe-docx).
+    subgraph Server["@usejunior/safe-docx — local MCP server"]
+        direction LR
+
+        subgraph ReadParse["<b>1. Read</b>"]
+            direction TB
+            RPTool["<code>read_file(file_path,<br/>&nbsp;&nbsp;format)</code>"]
+        end
+
+        subgraph Locate["<b>2. Locate</b>"]
+            direction TB
+            LocTool["<code>grep(file_path,<br/>&nbsp;&nbsp;pattern)</code>"]
+        end
+
+        subgraph Edit["<b>3. Edit</b>"]
+            direction TB
+            EditTool["<code>replace_text(<br/>&nbsp;&nbsp;target_paragraph_id,<br/>&nbsp;&nbsp;old_string, new_string,<br/>&nbsp;&nbsp;instruction)</code>"]
+        end
+
+        subgraph Save["<b>4. Save</b>"]
+            direction TB
+            SaveTool["<code>save(save_to_local_path,<br/>&nbsp;&nbsp;save_format)</code>"]
+        end
+
+        ReadParse --> Locate
+        Locate --> Edit
+        Edit --> Save
+    end
+
+    DocInRight["<b>Saved .docx output</b><br/>on disk"]
+
+    subgraph Client [" "]
+        direction TB
+        Prompt["<b>Prompt</b><br/>'Change NDA governing law to Delaware'"]
+        Agent["<b>Coding agent / MCP client</b><br/>Claude Code · Cursor · Gemini CLI"]
+        Prompt --> Agent
+    end
+
+    DocInLeft --> RPTool
+    SaveTool --> DocInRight
+    Agent <-->|tool call / tool result| Server
+
+    classDef io fill:#f5f5f5,stroke:#888,color:#222
+    classDef server fill:#eff6ff,stroke:#3b82f6,color:#1e3a8a
+    classDef stage fill:#eef2ff,stroke:#6366f1,color:#1e1b4b
+    classDef tools fill:#ecfdf5,stroke:#10b981,color:#064e3b
+    classDef ext fill:#ddd6fe,stroke:#7c3aed,color:#3b0764
+    classDef hidden fill:none,stroke:none
+    class DocInLeft,DocInRight io
+    class Server server
+    class ReadParse,Locate,Edit,Save stage
+    class RPTool,LocTool,EditTool,SaveTool tools
+    class Prompt,Agent ext
+    class Client hidden
+```
+<!-- SYNC:architecture-diagram END -->
 
 Safe Docx es un stack de TypeScript de código abierto para la edición quirúrgica de archivos Microsoft Word `.docx` existentes. Está diseñado para flujos de trabajo donde un agente propone cambios y un humano aún necesita ediciones de documentos confiables que preserven el formato.
 
@@ -234,7 +296,6 @@ npm run coverage:matrix
 ## Ver también
 
 - [Open Agreements](https://github.com/open-agreements/open-agreements) — llena plantillas legales estándar con agentes de programación (NDAs, SAFEs, NVCA)
-- [Herramientas para desarrolladores UseJunior](https://usejunior.com/developer-tools/safe-docx) — página del producto con opciones de instalación y catálogo de herramientas
 
 ## Privacidad
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,19 @@
-# Safe DOCX Suite
+# Edit Word documents (.docx) with coding agents via MCP
 
+<!-- SYNC:badges BEGIN -->
 [![CI](https://github.com/usejunior/safe-docx/actions/workflows/ci.yml/badge.svg)](https://github.com/usejunior/safe-docx/actions/workflows/ci.yml)
 [![codecov](https://img.shields.io/codecov/c/github/usejunior/safe-docx/main)](https://app.codecov.io/gh/usejunior/safe-docx)
 [![npm version](https://img.shields.io/npm/v/@usejunior/safe-docx)](https://www.npmjs.com/package/@usejunior/safe-docx)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/UseJunior/safe-docx/blob/main/LICENSE)
 [![GitHub last commit](https://img.shields.io/github/last-commit/UseJunior/safe-docx)](https://github.com/UseJunior/safe-docx/commits/main)
 [![GitHub issues closed](https://img.shields.io/github/issues-closed/UseJunior/safe-docx)](https://github.com/UseJunior/safe-docx/issues?q=is%3Aissue+is%3Aclosed)
+<!-- SYNC:badges END -->
 
+<!-- SYNC:lang-nav BEGIN -->
 [English](./README.md) | [Español](./README.es.md) | [简体中文](./README.zh.md) | [Português (Brasil)](./README.pt-br.md) | [Deutsch](./README.de.md)
+<!-- SYNC:lang-nav END -->
 
-**safe-docx** by [UseJunior](https://usejunior.com) — use coding agents for paperwork too.
-
-Part of the [UseJunior developer tools](https://usejunior.com/developer-tools/safe-docx).
-
+<!-- SYNC:architecture-diagram BEGIN -->
 ```mermaid
 %%{init: {"flowchart": {"htmlLabels": true, "curve": "basis", "nodeSpacing": 30, "rankSpacing": 50}, "themeVariables": {"fontSize": "14px"}} }%%
 flowchart LR
@@ -72,6 +73,7 @@ flowchart LR
     class Prompt,Agent ext
     class Client hidden
 ```
+<!-- SYNC:architecture-diagram END -->
 
 Safe Docx is an open-source TypeScript stack for surgical editing of existing Microsoft Word `.docx` files. It is built for workflows where an agent proposes changes and a human still needs reliable, formatting-preserving document edits.
 
@@ -303,7 +305,6 @@ npm run coverage:matrix
 ## See Also
 
 - [Open Agreements](https://github.com/open-agreements/open-agreements) — fill standard legal templates with coding agents (NDAs, SAFEs, NVCA)
-- [UseJunior Developer Tools](https://usejunior.com/developer-tools/safe-docx) — product page with install options and tool catalog
 
 ## Privacy
 

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -1,19 +1,81 @@
-# Safe DOCX Suite
+# Edite documentos do Word (.docx) com agentes de programação via MCP
 
+<!-- SYNC:badges BEGIN -->
 [![CI](https://github.com/usejunior/safe-docx/actions/workflows/ci.yml/badge.svg)](https://github.com/usejunior/safe-docx/actions/workflows/ci.yml)
 [![codecov](https://img.shields.io/codecov/c/github/usejunior/safe-docx/main)](https://app.codecov.io/gh/usejunior/safe-docx)
 [![npm version](https://img.shields.io/npm/v/@usejunior/safe-docx)](https://www.npmjs.com/package/@usejunior/safe-docx)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/UseJunior/safe-docx/blob/main/LICENSE)
 [![GitHub last commit](https://img.shields.io/github/last-commit/UseJunior/safe-docx)](https://github.com/UseJunior/safe-docx/commits/main)
 [![GitHub issues closed](https://img.shields.io/github/issues-closed/UseJunior/safe-docx)](https://github.com/UseJunior/safe-docx/issues?q=is%3Aissue+is%3Aclosed)
+<!-- SYNC:badges END -->
 
+<!-- SYNC:lang-nav BEGIN -->
 [English](./README.md) | [Español](./README.es.md) | [简体中文](./README.zh.md) | [Português (Brasil)](./README.pt-br.md) | [Deutsch](./README.de.md)
+<!-- SYNC:lang-nav END -->
 
 > **Nota de tradução:** A versão em inglês `README.md` é a fonte canônica da verdade. Esta tradução pode ter um breve atraso. Atualizações importantes do README em inglês devem ser sincronizadas com este arquivo em até 72 horas.
 
-**safe-docx** por [UseJunior](https://usejunior.com) — use agentes de programação também para a burocracia.
+<!-- SYNC:architecture-diagram BEGIN -->
+```mermaid
+%%{init: {"flowchart": {"htmlLabels": true, "curve": "basis", "nodeSpacing": 30, "rankSpacing": 50}, "themeVariables": {"fontSize": "14px"}} }%%
+flowchart LR
+    DocInLeft["<b>Existing .docx</b><br/>on disk"]
 
-Parte das [ferramentas para desenvolvedores da UseJunior](https://usejunior.com/developer-tools/safe-docx).
+    subgraph Server["@usejunior/safe-docx — local MCP server"]
+        direction LR
+
+        subgraph ReadParse["<b>1. Read</b>"]
+            direction TB
+            RPTool["<code>read_file(file_path,<br/>&nbsp;&nbsp;format)</code>"]
+        end
+
+        subgraph Locate["<b>2. Locate</b>"]
+            direction TB
+            LocTool["<code>grep(file_path,<br/>&nbsp;&nbsp;pattern)</code>"]
+        end
+
+        subgraph Edit["<b>3. Edit</b>"]
+            direction TB
+            EditTool["<code>replace_text(<br/>&nbsp;&nbsp;target_paragraph_id,<br/>&nbsp;&nbsp;old_string, new_string,<br/>&nbsp;&nbsp;instruction)</code>"]
+        end
+
+        subgraph Save["<b>4. Save</b>"]
+            direction TB
+            SaveTool["<code>save(save_to_local_path,<br/>&nbsp;&nbsp;save_format)</code>"]
+        end
+
+        ReadParse --> Locate
+        Locate --> Edit
+        Edit --> Save
+    end
+
+    DocInRight["<b>Saved .docx output</b><br/>on disk"]
+
+    subgraph Client [" "]
+        direction TB
+        Prompt["<b>Prompt</b><br/>'Change NDA governing law to Delaware'"]
+        Agent["<b>Coding agent / MCP client</b><br/>Claude Code · Cursor · Gemini CLI"]
+        Prompt --> Agent
+    end
+
+    DocInLeft --> RPTool
+    SaveTool --> DocInRight
+    Agent <-->|tool call / tool result| Server
+
+    classDef io fill:#f5f5f5,stroke:#888,color:#222
+    classDef server fill:#eff6ff,stroke:#3b82f6,color:#1e3a8a
+    classDef stage fill:#eef2ff,stroke:#6366f1,color:#1e1b4b
+    classDef tools fill:#ecfdf5,stroke:#10b981,color:#064e3b
+    classDef ext fill:#ddd6fe,stroke:#7c3aed,color:#3b0764
+    classDef hidden fill:none,stroke:none
+    class DocInLeft,DocInRight io
+    class Server server
+    class ReadParse,Locate,Edit,Save stage
+    class RPTool,LocTool,EditTool,SaveTool tools
+    class Prompt,Agent ext
+    class Client hidden
+```
+<!-- SYNC:architecture-diagram END -->
 
 Safe Docx é um stack TypeScript de código aberto para edição cirúrgica de arquivos Microsoft Word `.docx` existentes. Foi construído para fluxos de trabalho onde um agente propõe alterações e um humano ainda precisa de edições de documentos confiáveis que preservem a formatação.
 
@@ -234,7 +296,6 @@ npm run coverage:matrix
 ## Veja também
 
 - [Open Agreements](https://github.com/open-agreements/open-agreements) — preencha templates jurídicos padrão com agentes de programação (NDAs, SAFEs, NVCA)
-- [Ferramentas para desenvolvedores UseJunior](https://usejunior.com/developer-tools/safe-docx) — página do produto com opções de instalação e catálogo de ferramentas
 
 ## Privacidade
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,19 +1,81 @@
-# Safe DOCX Suite
+# 使用编程代理通过 MCP 编辑 Word 文档 (.docx)
 
+<!-- SYNC:badges BEGIN -->
 [![CI](https://github.com/usejunior/safe-docx/actions/workflows/ci.yml/badge.svg)](https://github.com/usejunior/safe-docx/actions/workflows/ci.yml)
 [![codecov](https://img.shields.io/codecov/c/github/usejunior/safe-docx/main)](https://app.codecov.io/gh/usejunior/safe-docx)
 [![npm version](https://img.shields.io/npm/v/@usejunior/safe-docx)](https://www.npmjs.com/package/@usejunior/safe-docx)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/UseJunior/safe-docx/blob/main/LICENSE)
 [![GitHub last commit](https://img.shields.io/github/last-commit/UseJunior/safe-docx)](https://github.com/UseJunior/safe-docx/commits/main)
 [![GitHub issues closed](https://img.shields.io/github/issues-closed/UseJunior/safe-docx)](https://github.com/UseJunior/safe-docx/issues?q=is%3Aissue+is%3Aclosed)
+<!-- SYNC:badges END -->
 
+<!-- SYNC:lang-nav BEGIN -->
 [English](./README.md) | [Español](./README.es.md) | [简体中文](./README.zh.md) | [Português (Brasil)](./README.pt-br.md) | [Deutsch](./README.de.md)
+<!-- SYNC:lang-nav END -->
 
 > **翻译说明：** 英文版 `README.md` 是规范的事实来源。此翻译可能会有短暂滞后。英文 README 的重大更新应在 72 小时内同步到本文件。
 
-**safe-docx** 由 [UseJunior](https://usejunior.com) 开发 — 让编程代理也能处理文书工作。
+<!-- SYNC:architecture-diagram BEGIN -->
+```mermaid
+%%{init: {"flowchart": {"htmlLabels": true, "curve": "basis", "nodeSpacing": 30, "rankSpacing": 50}, "themeVariables": {"fontSize": "14px"}} }%%
+flowchart LR
+    DocInLeft["<b>Existing .docx</b><br/>on disk"]
 
-隶属于 [UseJunior 开发者工具](https://usejunior.com/developer-tools/safe-docx)。
+    subgraph Server["@usejunior/safe-docx — local MCP server"]
+        direction LR
+
+        subgraph ReadParse["<b>1. Read</b>"]
+            direction TB
+            RPTool["<code>read_file(file_path,<br/>&nbsp;&nbsp;format)</code>"]
+        end
+
+        subgraph Locate["<b>2. Locate</b>"]
+            direction TB
+            LocTool["<code>grep(file_path,<br/>&nbsp;&nbsp;pattern)</code>"]
+        end
+
+        subgraph Edit["<b>3. Edit</b>"]
+            direction TB
+            EditTool["<code>replace_text(<br/>&nbsp;&nbsp;target_paragraph_id,<br/>&nbsp;&nbsp;old_string, new_string,<br/>&nbsp;&nbsp;instruction)</code>"]
+        end
+
+        subgraph Save["<b>4. Save</b>"]
+            direction TB
+            SaveTool["<code>save(save_to_local_path,<br/>&nbsp;&nbsp;save_format)</code>"]
+        end
+
+        ReadParse --> Locate
+        Locate --> Edit
+        Edit --> Save
+    end
+
+    DocInRight["<b>Saved .docx output</b><br/>on disk"]
+
+    subgraph Client [" "]
+        direction TB
+        Prompt["<b>Prompt</b><br/>'Change NDA governing law to Delaware'"]
+        Agent["<b>Coding agent / MCP client</b><br/>Claude Code · Cursor · Gemini CLI"]
+        Prompt --> Agent
+    end
+
+    DocInLeft --> RPTool
+    SaveTool --> DocInRight
+    Agent <-->|tool call / tool result| Server
+
+    classDef io fill:#f5f5f5,stroke:#888,color:#222
+    classDef server fill:#eff6ff,stroke:#3b82f6,color:#1e3a8a
+    classDef stage fill:#eef2ff,stroke:#6366f1,color:#1e1b4b
+    classDef tools fill:#ecfdf5,stroke:#10b981,color:#064e3b
+    classDef ext fill:#ddd6fe,stroke:#7c3aed,color:#3b0764
+    classDef hidden fill:none,stroke:none
+    class DocInLeft,DocInRight io
+    class Server server
+    class ReadParse,Locate,Edit,Save stage
+    class RPTool,LocTool,EditTool,SaveTool tools
+    class Prompt,Agent ext
+    class Client hidden
+```
+<!-- SYNC:architecture-diagram END -->
 
 Safe Docx 是一套开源 TypeScript 技术栈，用于对现有 Microsoft Word `.docx` 文件进行精确编辑。它专为代理提出更改建议、人工仍需可靠且保留格式的文档编辑场景而构建。
 
@@ -232,7 +294,6 @@ npm run coverage:matrix
 ## 另请参阅
 
 - [Open Agreements](https://github.com/open-agreements/open-agreements) — 使用编程代理填写标准法律模板（NDA、SAFE、NVCA）
-- [UseJunior 开发者工具](https://usejunior.com/developer-tools/safe-docx) — 产品页面，包含安装选项和工具目录
 
 ## 隐私
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,9 @@
     "trust:check": "npm run check:trust-metrics",
     "generate:conformance-doc": "node scripts/generate_conformance_doc.mjs",
     "check:conformance-citations": "node scripts/check_conformance_citations.mjs",
-    "check:conformance-doc": "node scripts/check_conformance_doc.mjs"
+    "check:conformance-doc": "node scripts/check_conformance_doc.mjs",
+    "sync:readme": "node scripts/sync_readme_blocks.mjs",
+    "check:readme-sync": "node scripts/sync_readme_blocks.mjs --check"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.56.0",

--- a/scripts/sync_readme_blocks.mjs
+++ b/scripts/sync_readme_blocks.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+
+const SOURCE = 'README.md';
+const TARGETS = ['README.es.md', 'README.zh.md', 'README.de.md', 'README.pt-br.md'];
+const BLOCKS = ['badges', 'lang-nav', 'architecture-diagram'];
+
+const BEGIN = (name) => `<!-- SYNC:${name} BEGIN -->`;
+const END = (name) => `<!-- SYNC:${name} END -->`;
+
+function extractBlock(text, name, fileLabel) {
+  const begin = BEGIN(name);
+  const end = END(name);
+  const beginIdx = text.indexOf(begin);
+  const endIdx = text.indexOf(end);
+  if (beginIdx === -1 || endIdx === -1 || endIdx < beginIdx) {
+    throw new Error(
+      `${fileLabel}: missing or malformed marker pair for SYNC:${name} ` +
+        `(begin=${beginIdx}, end=${endIdx}). Insert ${begin} and ${end} on their own lines.`,
+    );
+  }
+  return { begin: beginIdx, end: endIdx, body: text.slice(beginIdx + begin.length, endIdx) };
+}
+
+function replaceBlock(text, name, newBody, fileLabel) {
+  const { begin, end } = extractBlock(text, name, fileLabel);
+  return text.slice(0, begin + BEGIN(name).length) + newBody + text.slice(end);
+}
+
+async function main() {
+  const argv = new Set(process.argv.slice(2));
+  const checkOnly = argv.has('--check');
+
+  const sourcePath = path.join(repoRoot, SOURCE);
+  const sourceText = await fs.readFile(sourcePath, 'utf8');
+  const sourceBlocks = Object.fromEntries(
+    BLOCKS.map((name) => [name, extractBlock(sourceText, name, SOURCE).body]),
+  );
+
+  let drifted = 0;
+  const driftDetails = [];
+
+  for (const rel of TARGETS) {
+    const filePath = path.join(repoRoot, rel);
+    const original = await fs.readFile(filePath, 'utf8');
+    let updated = original;
+    for (const name of BLOCKS) {
+      updated = replaceBlock(updated, name, sourceBlocks[name], rel);
+    }
+    if (updated !== original) {
+      drifted++;
+      driftDetails.push(rel);
+      if (!checkOnly) {
+        await fs.writeFile(filePath, updated);
+      }
+    }
+  }
+
+  if (checkOnly) {
+    if (drifted > 0) {
+      console.error(
+        `[sync-readme-blocks] DRIFT detected in ${drifted} file(s):\n` +
+          driftDetails.map((f) => `  - ${f}`).join('\n') +
+          `\n\nRun \`npm run sync:readme\` and commit the result.`,
+      );
+      process.exit(1);
+    }
+    console.log('[sync-readme-blocks] all translations in sync with README.md');
+    return;
+  }
+
+  if (drifted === 0) {
+    console.log('[sync-readme-blocks] no changes — all translations already in sync');
+    return;
+  }
+  console.log(
+    `[sync-readme-blocks] synced ${drifted} file(s):\n` + driftDetails.map((f) => `  - ${f}`).join('\n'),
+  );
+}
+
+main().catch((err) => {
+  console.error(`[sync-readme-blocks] ${err.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Replace `# Safe DOCX Suite` with `# Edit Word documents (.docx) with coding agents via MCP` (and localized equivalents in es/zh/de/pt-br). Visitors now see what the project does before any branding.
- Drop the `**safe-docx** by [UseJunior]…` tagline, the header `Part of the [UseJunior developer tools]…` link, and the matching `See Also` footer bullet from all 5 READMEs.
- Introduce a marker-based autosync (`SYNC:badges`, `SYNC:lang-nav`, `SYNC:architecture-diagram`) so duplicated blocks stay in lockstep across languages without manual copy-paste.
  - `scripts/sync_readme_blocks.mjs` copies the English source into each translation; `--check` mode exits non-zero on drift.
  - `npm run sync:readme` and `npm run check:readme-sync` wrap the script.
  - New `readme-sync` CI job hard-fails the PR when translations drift, prompting the dev to run `npm run sync:readme` and re-push.
- First-run effect: the mermaid architecture diagram now appears in all 4 translated READMEs (previously English-only).

## Why

The previous header introduced three concepts (Safe DOCX Suite, UseJunior, UseJunior developer tools) before a visitor knew what the project was — weak for GitHub-search and Google. The new action-led title leads with the keywords developers actually search for (`Word`, `.docx`, `coding agents`, `MCP`).

## Test plan

- [x] `node scripts/sync_readme_blocks.mjs` synced all 4 translations cleanly.
- [x] `node scripts/sync_readme_blocks.mjs --check` exits 0 on the synced tree.
- [x] `rg "by \[UseJunior\]|Part of the \[UseJunior|Safe DOCX Suite|developer-tools/safe-docx" README*.md` returns empty.
- [x] `npm run build` passes.
- [x] `npm run lint:workspaces` passes.
- [x] `npm run test:run` passes.
- [ ] Reviewer: confirm GitHub renders each language tab correctly (title, badges, lang nav, translation notice, architecture diagram in all 5).
- [ ] Reviewer: optionally test drift detection by tweaking one badge in a translation and running `npm run check:readme-sync` — should exit non-zero with a clear message.