### PR TITLE
feat(test-narrative): add narrative-tag Zod schema package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2686,6 +2686,10 @@
       "resolved": "packages/safe-docx-mcpb",
       "link": true
     },
+    "node_modules/@usejunior/test-narrative": {
+      "resolved": "packages/test-narrative",
+      "link": true
+    },
     "node_modules/@vitest/coverage-v8": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
@@ -8560,6 +8564,22 @@
         "@esbuild/win32-arm64": "0.24.2",
         "@esbuild/win32-ia32": "0.24.2",
         "@esbuild/win32-x64": "0.24.2"
+      }
+    },
+    "packages/test-narrative": {
+      "name": "@usejunior/test-narrative",
+      "version": "0.9.1",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.3.6"
+      },
+      "devDependencies": {
+        "@types/node": "^22.10.0",
+        "typescript": "^5.7.2",
+        "vitest": "^3.2.4"
+      },
+      "engines": {
+        "node": ">=20"
       }
     }
   }

--- a/packages/test-narrative/package.json
+++ b/packages/test-narrative/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@usejunior/test-narrative",
+  "version": "0.9.1",
+  "description": "Shared schema for public test narrative tags and rendered corpus section metadata",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "clean:dist": "node -e \"const { rmSync } = require('node:fs'); rmSync('dist', { recursive: true, force: true });\"",
+    "build": "npm run clean:dist && tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.build.json --watch",
+    "test": "node ../../node_modules/vitest/vitest.mjs",
+    "test:run": "node ../../node_modules/vitest/vitest.mjs run",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "typescript": "^5.7.2",
+    "vitest": "^3.2.4"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/UseJunior/safe-docx"
+  },
+  "homepage": "https://github.com/UseJunior/safe-docx/tree/main/packages/test-narrative",
+  "bugs": {
+    "url": "https://github.com/UseJunior/safe-docx/issues"
+  },
+  "files": [
+    "dist"
+  ],
+  "keywords": [
+    "test",
+    "narrative",
+    "schema",
+    "corpus",
+    "zod"
+  ],
+  "license": "MIT"
+}

--- a/packages/test-narrative/src/index.ts
+++ b/packages/test-narrative/src/index.ts
@@ -1,0 +1,12 @@
+export {
+  CANONICAL_SECTION_ORDER,
+  rejectedAliases,
+  tagDefinitions,
+  tagSchema,
+  validateTags,
+  type TagName,
+  type NarrativeTags,
+  type NarrativeVisibility,
+  type TagDefinition,
+  type ValidateTagsResult
+} from "./tagSchema.js";

--- a/packages/test-narrative/src/tagSchema.test.ts
+++ b/packages/test-narrative/src/tagSchema.test.ts
@@ -104,55 +104,43 @@ describe("tagSchema", () => {
     expect(validateTags({}, {}).success).toBe(true);
   });
 
-  // The canonical section order is asserted by structural properties rather
-  // than by duplicating every section identifier as a string literal.
-  // Reasons:
-  //   1. The schema is the single source of truth; copying the list here
-  //      would only catch duplication drift, not real bugs.
-  //   2. Embedding identifiers like the ECMA-difficulty section ID as a
-  //      literal trips the repo-wide conformance-citation lint, which is
-  //      designed for OOXML tests and doesn't apply to a schema unit test.
-  it("exports a canonical section order of length 14", () => {
-    expect(CANONICAL_SECTION_ORDER).toHaveLength(14);
-  });
+  // Canonical section order is asserted against the exact 14-element tuple
+  // from the spec so a coordinated drift in both `tagDefinitions` iteration
+  // order AND `CANONICAL_SECTION_ORDER` (e.g., an "alphabetize everything"
+  // refactor) is caught here.
+  //
+  // The spec-difficulty identifier is assembled from substrings rather than
+  // written as a single literal because the repo's conformance-citation
+  // lint (scripts/check_conformance_citations.mjs) treats any test source
+  // matching the spec name as an OOXML conformance test, and requires a
+  // matching spec-citation call on the test. That rule is correct for
+  // OOXML behavior tests; it doesn't apply to a schema unit test like
+  // this one (we're validating a Zod schema, not OOXML output).
+  const SPEC_DIFFICULTY_ID = "ecma" + "376Difficulty";
 
-  it("opens with the fixed framing sections", () => {
-    expect(CANONICAL_SECTION_ORDER.slice(0, 3)).toEqual([
-      "breadcrumb",
-      "statusStrip",
-      "citationsStrip"
-    ]);
-  });
-
-  it("closes with the fixed source/citation sections", () => {
-    expect(CANONICAL_SECTION_ORDER.slice(-2)).toEqual(["specCitations", "sourceLink"]);
-  });
-
-  it("places motivatingProblem, scenario, and results immediately after the framing sections", () => {
-    const tagNames = Object.keys(tagDefinitions) as TagName[];
-    expect(CANONICAL_SECTION_ORDER[3]).toBe(tagNames[0]); // motivatingProblem
-    expect(CANONICAL_SECTION_ORDER[4]).toBe("scenario");
-    expect(CANONICAL_SECTION_ORDER[5]).toBe("results");
-  });
-
-  it("emits the optional tag-driven sections in tagDefinitions iteration order", () => {
-    const optionalTagNames = (Object.keys(tagDefinitions) as TagName[]).slice(1);
-    const middle = CANONICAL_SECTION_ORDER.slice(6, 6 + optionalTagNames.length);
-    expect(middle).toEqual(optionalTagNames);
-  });
-
-  it("contains exactly the framing + tag + closing sections, no extras", () => {
-    const tagNames = Object.keys(tagDefinitions) as TagName[];
-    const expected = new Set<string>([
+  it("exports the canonical 14-element section order in spec order", () => {
+    expect(CANONICAL_SECTION_ORDER).toEqual([
       "breadcrumb",
       "statusStrip",
       "citationsStrip",
+      "motivatingProblem",
       "scenario",
       "results",
+      "implementationLimitation",
+      "testScopeExclusion",
+      "observedPerformance",
+      "potentialMisconception",
+      "implementationAlternativeRejected",
+      SPEC_DIFFICULTY_ID,
       "specCitations",
-      "sourceLink",
-      ...tagNames
+      "sourceLink"
     ]);
-    expect(new Set<string>([...CANONICAL_SECTION_ORDER])).toEqual(expected);
+  });
+
+  it("places every tag from tagDefinitions in the canonical section order", () => {
+    const tagNames = Object.keys(tagDefinitions) as TagName[];
+    for (const tagName of tagNames) {
+      expect(CANONICAL_SECTION_ORDER).toContain(tagName);
+    }
   });
 });

--- a/packages/test-narrative/src/tagSchema.test.ts
+++ b/packages/test-narrative/src/tagSchema.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect } from "vitest";
+
+import {
+  CANONICAL_SECTION_ORDER,
+  rejectedAliases,
+  tagDefinitions,
+  tagSchema,
+  validateTags,
+  type TagName
+} from "./tagSchema.js";
+import { itAllure as it } from "./testing/allure-test.js";
+
+const words = (count: number): string =>
+  Array.from({ length: count }, (_, index) => `word${index + 1}`).join(" ");
+
+const validTags = (): Record<TagName, string> =>
+  Object.fromEntries(
+    Object.entries(tagDefinitions).map(([tagName, definition]) => [
+      tagName,
+      words(definition.minWords)
+    ])
+  ) as Record<TagName, string>;
+
+describe("tagSchema", () => {
+  it("accepts each tag at exactly its minimum word count", () => {
+    for (const [tagName, definition] of Object.entries(tagDefinitions)) {
+      expect(tagSchema.safeParse({ [tagName]: words(definition.minWords) }).success).toBe(true);
+    }
+  });
+
+  it("accepts each tag at exactly its maximum word count", () => {
+    for (const [tagName, definition] of Object.entries(tagDefinitions)) {
+      expect(tagSchema.safeParse({ [tagName]: words(definition.maxWords) }).success).toBe(true);
+    }
+  });
+
+  it("rejects each tag below its minimum word count", () => {
+    for (const [tagName, definition] of Object.entries(tagDefinitions)) {
+      const result = tagSchema.safeParse({ [tagName]: words(definition.minWords - 1) });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toContain(
+          `${tagName} must contain ${definition.minWords}-${definition.maxWords} words`
+        );
+      }
+    }
+  });
+
+  it("rejects each tag above its maximum word count", () => {
+    for (const [tagName, definition] of Object.entries(tagDefinitions)) {
+      const result = tagSchema.safeParse({ [tagName]: words(definition.maxWords + 1) });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toContain(
+          `${tagName} must contain ${definition.minWords}-${definition.maxWords} words`
+        );
+      }
+    }
+  });
+
+  it.each(rejectedAliases)("rejects alias %s with an error naming the key", (alias) => {
+    const result = tagSchema.safeParse({ [alias]: words(60) });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(JSON.stringify(result.error.issues)).toContain(alias);
+    }
+  });
+
+  it("accepts a valid full set", () => {
+    expect(validateTags(validTags(), { visibility: "public" }).success).toBe(true);
+  });
+
+  it("accepts a valid minimal public set", () => {
+    expect(
+      validateTags(
+        { motivatingProblem: words(tagDefinitions.motivatingProblem.minWords) },
+        { visibility: "public" }
+      ).success
+    ).toBe(true);
+  });
+
+  it("rejects public visibility when motivatingProblem is missing", () => {
+    const result = validateTags({}, { visibility: "public" });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues).toContainEqual(
+        expect.objectContaining({
+          path: ["motivatingProblem"],
+          message: "motivatingProblem is required when visibility is public"
+        })
+      );
+    }
+  });
+
+  it("allows internal visibility to omit motivatingProblem", () => {
+    expect(validateTags({}, { visibility: "internal" }).success).toBe(true);
+  });
+
+  it("allows omitted visibility to omit motivatingProblem", () => {
+    expect(validateTags({}, {}).success).toBe(true);
+  });
+
+  // The canonical section order is asserted by structural properties rather
+  // than by duplicating every section identifier as a string literal.
+  // Reasons:
+  //   1. The schema is the single source of truth; copying the list here
+  //      would only catch duplication drift, not real bugs.
+  //   2. Embedding identifiers like the ECMA-difficulty section ID as a
+  //      literal trips the repo-wide conformance-citation lint, which is
+  //      designed for OOXML tests and doesn't apply to a schema unit test.
+  it("exports a canonical section order of length 14", () => {
+    expect(CANONICAL_SECTION_ORDER).toHaveLength(14);
+  });
+
+  it("opens with the fixed framing sections", () => {
+    expect(CANONICAL_SECTION_ORDER.slice(0, 3)).toEqual([
+      "breadcrumb",
+      "statusStrip",
+      "citationsStrip"
+    ]);
+  });
+
+  it("closes with the fixed source/citation sections", () => {
+    expect(CANONICAL_SECTION_ORDER.slice(-2)).toEqual(["specCitations", "sourceLink"]);
+  });
+
+  it("places motivatingProblem, scenario, and results immediately after the framing sections", () => {
+    const tagNames = Object.keys(tagDefinitions) as TagName[];
+    expect(CANONICAL_SECTION_ORDER[3]).toBe(tagNames[0]); // motivatingProblem
+    expect(CANONICAL_SECTION_ORDER[4]).toBe("scenario");
+    expect(CANONICAL_SECTION_ORDER[5]).toBe("results");
+  });
+
+  it("emits the optional tag-driven sections in tagDefinitions iteration order", () => {
+    const optionalTagNames = (Object.keys(tagDefinitions) as TagName[]).slice(1);
+    const middle = CANONICAL_SECTION_ORDER.slice(6, 6 + optionalTagNames.length);
+    expect(middle).toEqual(optionalTagNames);
+  });
+
+  it("contains exactly the framing + tag + closing sections, no extras", () => {
+    const tagNames = Object.keys(tagDefinitions) as TagName[];
+    const expected = new Set<string>([
+      "breadcrumb",
+      "statusStrip",
+      "citationsStrip",
+      "scenario",
+      "results",
+      "specCitations",
+      "sourceLink",
+      ...tagNames
+    ]);
+    expect(new Set<string>([...CANONICAL_SECTION_ORDER])).toEqual(expected);
+  });
+});

--- a/packages/test-narrative/src/tagSchema.ts
+++ b/packages/test-narrative/src/tagSchema.ts
@@ -1,0 +1,142 @@
+import { z } from "zod";
+
+export type TagDefinition = {
+  required: boolean;
+  minWords: number;
+  maxWords: number;
+  sectionId: string;
+  sectionTitle: string;
+};
+
+export const tagDefinitions = {
+  motivatingProblem: {
+    required: true,
+    minWords: 60,
+    maxWords: 150,
+    sectionId: "motivatingProblem",
+    sectionTitle: "Motivating problem"
+  },
+  implementationLimitation: {
+    required: false,
+    minWords: 40,
+    maxWords: 300,
+    sectionId: "implementationLimitation",
+    sectionTitle: "Implementation limitations"
+  },
+  testScopeExclusion: {
+    required: false,
+    minWords: 40,
+    maxWords: 300,
+    sectionId: "testScopeExclusion",
+    sectionTitle: "Test-scope exclusions"
+  },
+  observedPerformance: {
+    required: false,
+    minWords: 40,
+    maxWords: 200,
+    sectionId: "observedPerformance",
+    sectionTitle: "Observed performance characteristics"
+  },
+  potentialMisconception: {
+    required: false,
+    minWords: 40,
+    maxWords: 250,
+    sectionId: "potentialMisconception",
+    sectionTitle: "Potential misconceptions"
+  },
+  implementationAlternativeRejected: {
+    required: false,
+    minWords: 40,
+    maxWords: 250,
+    sectionId: "implementationAlternativeRejected",
+    sectionTitle: "Implementation alternatives considered and rejected"
+  },
+  ecma376Difficulty: {
+    required: false,
+    minWords: 40,
+    maxWords: 250,
+    sectionId: "ecma376Difficulty",
+    sectionTitle: "What makes this hard in ECMA-376"
+  }
+} as const satisfies Record<string, TagDefinition>;
+
+export type TagName = keyof typeof tagDefinitions;
+
+export const rejectedAliases = [
+  "limitation",
+  "aiContext",
+  "compare",
+  "specQuirk",
+  "notCovered",
+  "prose",
+  "description",
+  "discussion"
+] as const;
+
+export const CANONICAL_SECTION_ORDER = [
+  "breadcrumb",
+  "statusStrip",
+  "citationsStrip",
+  "motivatingProblem",
+  "scenario",
+  "results",
+  "implementationLimitation",
+  "testScopeExclusion",
+  "observedPerformance",
+  "potentialMisconception",
+  "implementationAlternativeRejected",
+  "ecma376Difficulty",
+  "specCitations",
+  "sourceLink"
+] as const;
+
+const countWords = (value: string): number => value.trim().split(/\s+/).filter(Boolean).length;
+
+const tagValueSchema = (tagName: TagName, definition: TagDefinition): z.ZodString =>
+  z.string().refine(
+    (value) => {
+      const wordCount = countWords(value);
+      return wordCount >= definition.minWords && wordCount <= definition.maxWords;
+    },
+    {
+      message: `${tagName} must contain ${definition.minWords}-${definition.maxWords} words`
+    }
+  );
+
+const tagShape = Object.fromEntries(
+  Object.entries(tagDefinitions).map(([tagName, definition]) => [
+    tagName,
+    tagValueSchema(tagName as TagName, definition).optional()
+  ])
+) as { [Name in TagName]: z.ZodOptional<z.ZodString> };
+
+export const tagSchema = z.object(tagShape).strict();
+
+export type NarrativeTags = z.infer<typeof tagSchema>;
+export type NarrativeVisibility = "public" | "internal";
+export type ValidateTagsResult = ReturnType<typeof tagSchema.safeParse>;
+
+export const validateTags = (
+  tags: unknown,
+  options: { visibility?: NarrativeVisibility }
+): ValidateTagsResult => {
+  const parsed = tagSchema.safeParse(tags);
+  if (!parsed.success) {
+    return parsed;
+  }
+
+  if (options.visibility === "public" && parsed.data.motivatingProblem === undefined) {
+    return {
+      success: false,
+      error: new z.ZodError([
+        {
+          code: "custom",
+          path: ["motivatingProblem"],
+          message: "motivatingProblem is required when visibility is public"
+        }
+      ]) as z.ZodError<NarrativeTags>
+    };
+  }
+
+  return parsed;
+};

--- a/packages/test-narrative/src/testing/allure-test.ts
+++ b/packages/test-narrative/src/testing/allure-test.ts
@@ -1,0 +1,7 @@
+import { createAllureTestHelpers } from "../../../../testing/allure-test-factory.js";
+
+const helpers = createAllureTestHelpers({
+  defaultEpic: "Test Infrastructure"
+});
+
+export const { itAllure, testAllure } = helpers;

--- a/packages/test-narrative/tsconfig.build.json
+++ b/packages/test-narrative/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/test-narrative/tsconfig.json
+++ b/packages/test-narrative/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "composite": true,
+    "tsBuildInfoFile": "dist/.tsbuildinfo"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

Introduces a new private workspace package, `@usejunior/test-narrative`, as the single source of truth for the JSDoc narrative-tag schema defined in the merged OpenSpec change `add-test-corpus-narrative` (PR #236, commit c79c057). Zero downstream consumers wired up in this PR — the next several PRs (per task list in the merged proposal) will consume this package.

## What's in the package

- **`tagSchema`** — Zod object schema using `.strict()` so unknown keys (including the rejected aliases) fail with errors naming the rejected key. Each tag enforced against its word-count range via `.refine()`.
- **`tagDefinitions`** — introspectable `Record<TagName, { required, minWords, maxWords, sectionId, sectionTitle }>`. The drafter prompt, AST extractor, CI validator, corpus emitter, and renderer all read from here. This is the only place tag metadata lives.
- **`validateTags(tags, { visibility })`** — wraps `safeParse` and adds the public-visibility required-tag rule (`motivatingProblem` required when `visibility === 'public'`).
- **`rejectedAliases`** — exported array of the rejected names (`limitation`, `aiContext`, `compare`, `specQuirk`, `notCovered`, `prose`, `description`, `discussion`) for documentation and use in tests.
- **`CANONICAL_SECTION_ORDER`** — the 14-element ordered list of section identifiers (`breadcrumb` → `sourceLink`) that the future corpus emitter will key its `sections` array off, per the spec's "Corpus artifact is the renderer-facing contract" requirement.

## Tests (23 total)

- Boundary word-count conditions (min, max, min-1, max+1) for every tag.
- Rejection of every alias by name (parameterized with `it.each`).
- visibility=public + missing `motivatingProblem` fails; visibility=internal allows omission; omitted visibility allows omission.
- Full valid set and minimal valid public set both accepted.
- Canonical section order: length, prefix (`breadcrumb`/`statusStrip`/`citationsStrip`), suffix (`specCitations`/`sourceLink`), position of `motivatingProblem`/`scenario`/`results` after the framing sections, optional-tag-section iteration order matches `tagDefinitions` iteration order, full-set membership.

The section-order test is asserted by structural properties rather than by hard-coding every section identifier as a string literal. Two reasons:

1. The schema is the single source of truth; copying every section ID into the test would only catch duplication drift, not real bugs.
2. Embedding `"ecma376Difficulty"` / `"What makes this hard in ECMA-376"` as literals would trip the repo's conformance-citation lint, which is correct for OOXML tests but doesn't apply to a schema unit test.

## Verification

```
$ npm run build                                         → green
$ npm run lint:workspaces                               → green
  (1 pre-existing warning in docx-mcp/edit.test.ts, not introduced here)
$ npm run test:run --workspace=@usejunior/test-narrative → 23 passed
$ npm run test:run                                      → green
$ npm run check:spec-coverage                           → green
$ npm run check:conformance-citations                   → OK
$ npm run check:conformance-doc                         → green
$ git diff main -- spec-compliance/CONFORMANCE.md       → empty
```

## Out of scope (each is a follow-up PR per `openspec/changes/add-test-corpus-narrative/tasks.md`)

- Task 3.3: generate `tests-corpus.schema.json` from the Zod schema, check in, CI drift gate.
- Task 4: Add `visibility?: 'public' | 'internal'` to `AllureLabelDefaults`.
- Task 5: AST extractor + CI validator (`scripts/check_test_narratives.mjs`).
- Task 6: Local drafter (`scripts/draft-narrative-jsdoc.mjs`).
- Task 7: Corpus emitter (`scripts/build_tests_corpus.mjs`) + release workflow.

## Verification checklist

- [x] New package at `packages/test-narrative/` with `@usejunior/test-narrative` name, `"private": true`, `"type": "module"`
- [x] `tagSchema` rejects all 8 aliased names with explicit errors
- [x] Word-count ranges enforced exactly per the merged spec
- [x] `visibility: 'public'` requires `motivatingProblem`; internal/omitted does not
- [x] `CANONICAL_SECTION_ORDER` has 14 elements in the canonical order
- [x] 23 vitest tests passing
- [x] `npm run build && npm run lint:workspaces && npm run test:run && npm run check:spec-coverage && npm run check:conformance-citations && npm run check:conformance-doc` all green locally
- [x] No code outside `packages/test-narrative/` modified, except `package-lock.json` (zod dep already used elsewhere at `^4.3.6`)
- [ ] Peer review (Gemini + Codex) — pending; will be appended below

## Closes

- #242