### PR TITLE
feat(test-narrative): add AST extractor + check_test_narratives CI gate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8575,6 +8575,8 @@
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
+        "@typescript-eslint/parser": "^8.56.0",
+        "@typescript-eslint/types": "^8.56.0",
         "typescript": "^5.7.2",
         "vitest": "^3.2.4"
       },

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "generate:conformance-doc": "node scripts/generate_conformance_doc.mjs",
     "check:conformance-citations": "node scripts/check_conformance_citations.mjs",
     "check:conformance-doc": "node scripts/check_conformance_doc.mjs",
+    "check:test-narratives": "npm run build -w @usejunior/test-narrative && node scripts/check_test_narratives.mjs",
     "sync:readme": "node scripts/sync_readme_blocks.mjs",
     "check:readme-sync": "node scripts/sync_readme_blocks.mjs --check"
   },

--- a/packages/test-narrative/package.json
+++ b/packages/test-narrative/package.json
@@ -24,6 +24,8 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@typescript-eslint/parser": "^8.56.0",
+    "@typescript-eslint/types": "^8.56.0",
     "@types/node": "^22.10.0",
     "typescript": "^5.7.2",
     "vitest": "^3.2.4"

--- a/packages/test-narrative/src/astExtractor.test.ts
+++ b/packages/test-narrative/src/astExtractor.test.ts
@@ -261,4 +261,72 @@ describe("extractScenarios", () => {
       sourceText: "fixture"
     });
   });
+
+  it("does not emit a phantom scenario for metadata-form chained calls", () => {
+    // Regression test (Codex peer review, PR #247): the previous matcher
+    // accepted any call whose callee chain contained `.openspec`, so the
+    // intermediate metadata call in `.openspec("id")({ visibility })("...", fn)`
+    // was extracted as a phantom scenario with name "{ visibility: ... }".
+    // The matcher now requires the OUTER call to have a string first arg
+    // and a function second arg.
+    const filePath = writeFixture(`
+      const test = testAllure.epic("DOCX Primitives").withLabels({ feature: "F", visibility: "public" });
+
+      test.openspec("override-shape")({ visibility: "internal" })("Scenario: metadata override", async () => {});
+    `);
+
+    const scenarios = extractScenarios(filePath);
+
+    expect(scenarios).toHaveLength(1);
+    expect(scenarios[0]?.scenarioName).toBe("Scenario: metadata override");
+  });
+
+  it("ignores unknown JSDoc tags so they don't poison schema validation", () => {
+    // Regression test (Codex peer review, PR #247): the extractor previously
+    // recorded every `@tag` it saw, including standard JSDoc conventions
+    // like `@see`, `@example`, `@deprecated`. Those are not narrative tags
+    // and must not appear in the parsed narrative — the Zod schema's strict()
+    // would otherwise reject them as unknown keys and fail a valid test.
+    const filePath = writeFixture(`
+      const test = testAllure.epic("DOCX Primitives").withLabels({ feature: "F" });
+
+      describe("suite", () => {
+        /**
+         * @see https://example.test/reference
+         * @motivatingProblem ${words(60)}
+         * @example arbitrary inline code example
+         * @deprecated some unrelated marker
+         */
+        test.openspec("with-mixed-tags")("Scenario: mixed tags", async () => {});
+      });
+    `);
+
+    const [scenario] = extractScenarios(filePath);
+
+    expect(scenario).toBeDefined();
+    expect(Object.keys(scenario!.narrative).sort()).toEqual(["motivatingProblem"]);
+  });
+
+  it("preserves rejected aliases in the narrative so the validator can report them explicitly", () => {
+    // The extractor distinguishes "unknown JSDoc tag" (drop) from
+    // "rejected alias the schema knows about" (keep, so the validator can
+    // emit a clear error). Without this, a developer typing @limitation
+    // (a rejected alias) instead of @implementationLimitation would have
+    // the typo silently ignored.
+    const filePath = writeFixture(`
+      const test = testAllure.epic("DOCX Primitives").withLabels({ feature: "F" });
+
+      /**
+       * @limitation this is the wrong tag name
+       */
+      test.openspec("with-rejected-alias")("Scenario: rejected alias", async () => {});
+    `);
+
+    const [scenario] = extractScenarios(filePath);
+
+    expect(scenario).toBeDefined();
+    expect(scenario!.narrative as Record<string, string>).toMatchObject({
+      limitation: "this is the wrong tag name"
+    });
+  });
 });

--- a/packages/test-narrative/src/astExtractor.test.ts
+++ b/packages/test-narrative/src/astExtractor.test.ts
@@ -1,0 +1,264 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect } from "vitest";
+
+import { extractScenarios } from "./astExtractor.js";
+import { itAllure as it } from "./testing/allure-test.js";
+
+let tempDirs: string[] = [];
+
+const writeFixture = (source: string): string => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "safe-docx-ast-extractor-"));
+  tempDirs.push(dir);
+  const filePath = path.join(dir, "fixture.test.ts");
+  fs.writeFileSync(filePath, source);
+  return filePath;
+};
+
+const words = (count: number): string =>
+  Array.from({ length: count }, (_, index) => `word${index + 1}`).join(" ");
+
+afterEach(() => {
+  for (const dir of tempDirs) fs.rmSync(dir, { recursive: true, force: true });
+  tempDirs = [];
+});
+
+describe("extractScenarios", () => {
+  it("extracts a simple openspec scenario with narrative, BDD steps, fixtures, and expect args", () => {
+    const filePath = writeFixture(`
+      const test = testAllure.epic("DOCX Primitives").withLabels({ feature: "Text Matching", visibility: "public" });
+
+      describe("suite", () => {
+        /**
+         * @motivatingProblem ${words(60)}
+         */
+        test.openspec("literal substring")("Scenario: literal substring", async ({ given, when, then }) => {
+          const haystack = "The Purchase Price shall be paid at Closing.";
+          await given("paragraph text contains the needle", async () => {});
+          await when("matching runs", async () => {});
+          await then("status is unique", () => {
+            expect(haystack).toContain("Purchase Price");
+          });
+        });
+      });
+    `);
+
+    const scenarios = extractScenarios(filePath);
+
+    expect(scenarios).toHaveLength(1);
+    expect(scenarios[0]).toMatchObject({
+      scenarioName: "Scenario: literal substring",
+      visibility: "public",
+      narrative: { motivatingProblem: words(60) }
+    });
+    expect(scenarios[0]?.bddSteps.map((step) => step.keyword)).toEqual(["given", "when", "then"]);
+    expect(scenarios[0]?.bddSteps[0]?.value).toEqual({
+      kind: "literal",
+      value: "paragraph text contains the needle"
+    });
+    expect(scenarios[0]?.fixtures).toContainEqual(
+      expect.objectContaining({
+        name: "haystack",
+        value: { kind: "literal", value: "The Purchase Price shall be paid at Closing." }
+      })
+    );
+    expect(scenarios[0]?.expectArgs[0]).toMatchObject({
+      sourceText: "haystack",
+      value: { kind: "literal", value: "The Purchase Price shall be paid at Closing." }
+    });
+  });
+
+  it("treats imported fixture arguments as unresolved evidence", () => {
+    const filePath = writeFixture(`
+      import { SHARED_PARAGRAPH_FIXTURE } from "./fixtures.js";
+      const test = testAllure.epic("DOCX Primitives").withLabels({ feature: "Text Matching" });
+
+      test.openspec("fixture")("Scenario: imported fixture", async ({ given }) => {
+        await given(SHARED_PARAGRAPH_FIXTURE, async () => {});
+      });
+    `);
+
+    const [scenario] = extractScenarios(filePath);
+
+    expect(scenario?.bddSteps[0]?.value).toMatchObject({
+      kind: "unresolved",
+      sourceText: "SHARED_PARAGRAPH_FIXTURE"
+    });
+  });
+
+  it("treats factory-call expect arguments as unresolved evidence", () => {
+    const filePath = writeFixture(`
+      const test = testAllure.epic("DOCX Primitives").withLabels({ feature: "Text Matching" });
+
+      test.openspec("factory")("Scenario: factory call", async () => {
+        expect(buildFixture("case-A")).toEqual({});
+      });
+    `);
+
+    const [scenario] = extractScenarios(filePath);
+
+    expect(scenario?.expectArgs[0]).toMatchObject({
+      sourceText: 'buildFixture("case-A")',
+      value: { kind: "unresolved", sourceText: 'buildFixture("case-A")' }
+    });
+  });
+
+  it("treats template literals with runtime expressions as unresolved evidence", () => {
+    const filePath = writeFixture(`
+      const test = testAllure.epic("DOCX Primitives").withLabels({ feature: "Text Matching" });
+
+      test.openspec("template")("Scenario: runtime template", async ({ given }) => {
+        const name = "closing";
+        await given(\`paragraph mentions \${name}\`, async () => {});
+      });
+    `);
+
+    const [scenario] = extractScenarios(filePath);
+
+    expect(scenario?.bddSteps[0]?.value).toMatchObject({
+      kind: "unresolved",
+      sourceText: "`paragraph mentions ${name}`"
+    });
+  });
+
+  it("resolves expression-free template literals as literal evidence", () => {
+    const filePath = writeFixture(`
+      const test = testAllure.epic("DOCX Primitives").withLabels({ feature: "Text Matching" });
+
+      test.openspec("template")("Scenario: static template", async ({ given }) => {
+        await given(\`paragraph mentions closing\`, async () => {});
+      });
+    `);
+
+    const [scenario] = extractScenarios(filePath);
+
+    expect(scenario?.bddSteps[0]?.value).toEqual({
+      kind: "literal",
+      value: "paragraph mentions closing"
+    });
+  });
+
+  it("returns an empty narrative object when no leading JSDoc exists", () => {
+    const filePath = writeFixture(`
+      const test = testAllure.epic("DOCX Primitives").withLabels({ feature: "Text Matching" });
+
+      test.openspec("no docs")("Scenario: no docs", async () => {});
+    `);
+
+    const [scenario] = extractScenarios(filePath);
+
+    expect(scenario?.narrative).toEqual({});
+  });
+
+  it("preserves rejected aliases in narrative output for schema validation", () => {
+    const filePath = writeFixture(`
+      const test = testAllure.epic("DOCX Primitives").withLabels({ feature: "Text Matching" });
+
+      /**
+       * @limitation ${words(40)}
+       * @motivatingProblem ${words(60)}
+       */
+      test.openspec("alias")("Scenario: rejected alias", async () => {});
+    `);
+
+    const [scenario] = extractScenarios(filePath);
+
+    expect(scenario?.narrative).toEqual({
+      limitation: words(40),
+      motivatingProblem: words(60)
+    });
+  });
+
+  it("extracts multiple scenarios from one file", () => {
+    const filePath = writeFixture(`
+      const test = testAllure.epic("DOCX Primitives").withLabels({ feature: "Text Matching" });
+
+      test.openspec("one")("Scenario: one", async () => {});
+      test.openspec("two")("Scenario: two", async () => {});
+    `);
+
+    expect(extractScenarios(filePath).map((scenario) => scenario.scenarioName)).toEqual([
+      "Scenario: one",
+      "Scenario: two"
+    ]);
+  });
+
+  it("extracts visibility from an allure chain before openspec", () => {
+    const filePath = writeFixture(`
+      const test = testAllure.epic("DOCX Primitives").withLabels({ feature: "Text Matching" });
+
+      test.allure({ visibility: "public" }).openspec("public")("Scenario: public", async () => {});
+    `);
+
+    const [scenario] = extractScenarios(filePath);
+
+    expect(scenario?.visibility).toBe("public");
+  });
+
+  it("extracts visibility through a local human-readable test variable", () => {
+    const filePath = writeFixture(`
+      const test = testAllure.epic("DOCX Primitives").withLabels({ feature: "Text Matching" });
+      const humanReadableTest = test.allure({ story: "Story", visibility: "public" });
+
+      humanReadableTest.openspec("public")("Scenario: public variable", async () => {});
+    `);
+
+    const [scenario] = extractScenarios(filePath);
+
+    expect(scenario?.visibility).toBe("public");
+  });
+
+  it("extracts visibility from a metadata call after openspec", () => {
+    const filePath = writeFixture(`
+      const test = testAllure.epic("DOCX Primitives").withLabels({ feature: "Text Matching" });
+
+      test.openspec("public")({ visibility: "public" })("Scenario: public metadata", async () => {});
+    `);
+
+    const [scenario] = extractScenarios(filePath);
+
+    expect(scenario?.visibility).toBe("public");
+  });
+
+  it("extracts the testAllure.openspec call shape", () => {
+    const filePath = writeFixture(`
+      testAllure.openspec("direct")("Scenario: direct", async ({ then }) => {
+        await then("the direct shape is accepted", () => {});
+      });
+    `);
+
+    const [scenario] = extractScenarios(filePath);
+
+    expect(scenario?.scenarioName).toBe("Scenario: direct");
+    expect(scenario?.bddSteps[0]?.value).toEqual({
+      kind: "literal",
+      value: "the direct shape is accepted"
+    });
+  });
+
+  it("records non-literal local fixtures as unresolved instead of evaluating them", () => {
+    const filePath = writeFixture(`
+      const test = testAllure.epic("DOCX Primitives").withLabels({ feature: "Text Matching" });
+
+      test.openspec("local factory")("Scenario: local factory", async () => {
+        const fixture = buildFixture("case-A");
+        expect(fixture).toEqual({});
+      });
+    `);
+
+    const [scenario] = extractScenarios(filePath);
+
+    expect(scenario?.fixtures).toContainEqual(
+      expect.objectContaining({
+        name: "fixture",
+        value: expect.objectContaining({ kind: "unresolved", sourceText: 'buildFixture("case-A")' })
+      })
+    );
+    expect(scenario?.expectArgs[0]?.value).toMatchObject({
+      kind: "unresolved",
+      sourceText: "fixture"
+    });
+  });
+});

--- a/packages/test-narrative/src/astExtractor.ts
+++ b/packages/test-narrative/src/astExtractor.ts
@@ -3,7 +3,12 @@ import fs from "node:fs";
 import { parse } from "@typescript-eslint/parser";
 import type { TSESTree } from "@typescript-eslint/types";
 
-import { type NarrativeVisibility, type TagName } from "./tagSchema.js";
+import { rejectedAliases, tagDefinitions, type NarrativeVisibility, type TagName } from "./tagSchema.js";
+
+const KNOWN_NARRATIVE_KEYS = new Set<string>([
+  ...Object.keys(tagDefinitions),
+  ...rejectedAliases
+]);
 
 export type SourceRef = {
   path: string;
@@ -103,7 +108,25 @@ function findOpeningOpenspecCall(callee: TSESTree.Expression): TSESTree.CallExpr
 }
 
 function isScenarioCall(node: TSESTree.CallExpression): boolean {
-  return findOpeningOpenspecCall(node.callee) !== undefined;
+  // The scenario call is the OUTERMOST chained call in a pattern like
+  //   test.openspec(...)(...metadata)(scenarioName, scenarioBody)
+  // Its signature is: first arg is a string-shaped literal (the scenario
+  // name), second arg is a function (the scenario body). Intermediate
+  // metadata-shaped calls in the chain (e.g., test.openspec(id)({ visibility }))
+  // are NOT scenarios — they configure subsequent calls — and must not be
+  // extracted as phantom scenarios.
+  if (findOpeningOpenspecCall(node.callee) === undefined) return false;
+  if (node.arguments.length < 2) return false;
+  const firstArg = expressionFromArgument(node.arguments[0]);
+  if (!firstArg) return false;
+  const firstArgLiteral = literalFromExpression(firstArg);
+  if (typeof firstArgLiteral !== "string") return false;
+  const secondArg = expressionFromArgument(node.arguments[1]);
+  if (!secondArg) return false;
+  if (secondArg.type !== "ArrowFunctionExpression" && secondArg.type !== "FunctionExpression") {
+    return false;
+  }
+  return true;
 }
 
 function expressionFromArgument(argument: TSESTree.CallExpressionArgument | undefined): TSESTree.Expression | undefined {
@@ -189,7 +212,14 @@ function extractNarrative(commentValue: string | undefined): Partial<Record<TagN
   let currentLines: string[] = [];
   const flush = () => {
     if (!currentTag) return;
-    narrative[currentTag] = currentLines.join(" ").replace(/\s+/g, " ").trim();
+    // Only emit tags that the schema cares about. Unknown JSDoc tags
+    // (@see, @example, @deprecated, etc.) are part of normal TS convention
+    // and must not poison validation. Known-but-rejected aliases stay so the
+    // downstream validator can produce an explicit "this alias is forbidden"
+    // error rather than silently dropping it.
+    if (KNOWN_NARRATIVE_KEYS.has(currentTag)) {
+      narrative[currentTag] = currentLines.join(" ").replace(/\s+/g, " ").trim();
+    }
   };
 
   for (const rawLine of commentValue.split("\n")) {

--- a/packages/test-narrative/src/astExtractor.ts
+++ b/packages/test-narrative/src/astExtractor.ts
@@ -1,0 +1,425 @@
+import fs from "node:fs";
+
+import { parse } from "@typescript-eslint/parser";
+import type { TSESTree } from "@typescript-eslint/types";
+
+import { type NarrativeVisibility, type TagName } from "./tagSchema.js";
+
+export type SourceRef = {
+  path: string;
+  line: number;
+};
+
+export type LiteralEvidence = {
+  kind: "literal";
+  value: unknown;
+};
+
+export type UnresolvedEvidence = {
+  kind: "unresolved";
+  sourceText: string;
+  sourceRef: SourceRef;
+};
+
+export type EvidenceValue = LiteralEvidence | UnresolvedEvidence;
+
+export type BddStepEvidence = {
+  keyword: "given" | "when" | "then" | "and";
+  value: EvidenceValue;
+  sourceRef: SourceRef;
+};
+
+export type FixtureEvidence = {
+  name: string;
+  value: EvidenceValue;
+  sourceRef: SourceRef;
+};
+
+export type ExpectArgEvidence = {
+  value: EvidenceValue;
+  sourceText: string;
+  sourceRef: SourceRef;
+};
+
+export type ScenarioEvidence = {
+  scenarioName: string;
+  sourceRef: SourceRef;
+  visibility?: NarrativeVisibility;
+  narrative: Partial<Record<TagName, string>>;
+  bddSteps: BddStepEvidence[];
+  fixtures: FixtureEvidence[];
+  expectArgs: ExpectArgEvidence[];
+};
+
+type VariableBindings = Map<string, TSESTree.Expression>;
+
+const BDD_STEP_NAMES = new Set(["given", "when", "then", "and"]);
+const VISIBILITY_METHODS = new Set(["withLabels", "allure"]);
+
+const hasRange = (node: TSESTree.Node): node is TSESTree.Node & { range: TSESTree.Range } =>
+  Array.isArray(node.range);
+
+const hasCommentRange = (comment: TSESTree.Comment): comment is TSESTree.Comment & { range: TSESTree.Range } =>
+  Array.isArray(comment.range);
+
+const sourceRefFor = (filePath: string, node: TSESTree.Node): SourceRef => ({
+  path: filePath,
+  line: node.loc?.start.line ?? 1
+});
+
+const sourceTextFor = (source: string, node: TSESTree.Node): string => {
+  if (!hasRange(node)) return "";
+  return source.slice(node.range[0], node.range[1]);
+};
+
+function parseSource(filePath: string): { source: string; ast: TSESTree.Program } {
+  const source = fs.readFileSync(filePath, "utf8");
+  const ast = parse(source, {
+    loc: true,
+    range: true,
+    comment: true,
+    jsx: false
+  }) as TSESTree.Program;
+  return { source, ast };
+}
+
+function getPropertyName(node: TSESTree.MemberExpression): string | undefined {
+  if (!node.computed && node.property.type === "Identifier") return node.property.name;
+  if (node.computed && node.property.type === "Literal" && typeof node.property.value === "string") {
+    return node.property.value;
+  }
+  return undefined;
+}
+
+function findOpeningOpenspecCall(callee: TSESTree.Expression): TSESTree.CallExpression | undefined {
+  if (callee.type !== "CallExpression") return undefined;
+  if (callee.callee.type === "MemberExpression" && getPropertyName(callee.callee) === "openspec") {
+    return callee;
+  }
+  if (callee.callee.type === "CallExpression") {
+    return findOpeningOpenspecCall(callee.callee);
+  }
+  return undefined;
+}
+
+function isScenarioCall(node: TSESTree.CallExpression): boolean {
+  return findOpeningOpenspecCall(node.callee) !== undefined;
+}
+
+function expressionFromArgument(argument: TSESTree.CallExpressionArgument | undefined): TSESTree.Expression | undefined {
+  if (!argument) return undefined;
+  if (argument.type === "SpreadElement") return undefined;
+  return argument;
+}
+
+function literalFromExpression(expression: TSESTree.Expression): unknown | undefined {
+  if (expression.type === "Literal") return expression.value;
+  if (expression.type === "TemplateLiteral" && expression.expressions.length === 0) {
+    return expression.quasis[0]?.value.cooked ?? expression.quasis[0]?.value.raw ?? "";
+  }
+  if (expression.type === "ArrayExpression") {
+    const values: unknown[] = [];
+    for (const element of expression.elements) {
+      if (!element || element.type === "SpreadElement") return undefined;
+      const value = literalFromExpression(element);
+      if (value === undefined) return undefined;
+      values.push(value);
+    }
+    return values;
+  }
+  if (expression.type === "ObjectExpression") {
+    const value: Record<string, unknown> = {};
+    for (const property of expression.properties) {
+      if (property.type === "SpreadElement" || property.computed || property.kind !== "init") return undefined;
+      const key =
+        property.key.type === "Identifier"
+          ? property.key.name
+          : property.key.type === "Literal" && typeof property.key.value === "string"
+            ? property.key.value
+            : undefined;
+      if (key === undefined) return undefined;
+      const propertyValue = literalFromExpression(property.value as TSESTree.Expression);
+      if (propertyValue === undefined) return undefined;
+      value[key] = propertyValue;
+    }
+    return value;
+  }
+  return undefined;
+}
+
+function collectBodyBindings(body: TSESTree.Node): VariableBindings {
+  const bindings: VariableBindings = new Map();
+  walk(body, (node) => {
+    if (node.type !== "VariableDeclarator") return;
+    if (node.id.type !== "Identifier" || !node.init) return;
+    bindings.set(node.id.name, node.init);
+  });
+  return bindings;
+}
+
+function evidenceForExpression(
+  expression: TSESTree.Expression,
+  bindings: VariableBindings,
+  filePath: string,
+  source: string
+): EvidenceValue {
+  const literal = literalFromExpression(expression);
+  if (literal !== undefined) return { kind: "literal", value: literal };
+
+  if (expression.type === "Identifier") {
+    const binding = bindings.get(expression.name);
+    if (binding) {
+      const bindingLiteral = literalFromExpression(binding);
+      if (bindingLiteral !== undefined) return { kind: "literal", value: bindingLiteral };
+    }
+  }
+
+  return {
+    kind: "unresolved",
+    sourceText: sourceTextFor(source, expression),
+    sourceRef: sourceRefFor(filePath, expression)
+  };
+}
+
+function extractNarrative(commentValue: string | undefined): Partial<Record<TagName, string>> {
+  const narrative: Record<string, string> = {};
+  if (!commentValue) return narrative;
+
+  let currentTag: string | undefined;
+  let currentLines: string[] = [];
+  const flush = () => {
+    if (!currentTag) return;
+    narrative[currentTag] = currentLines.join(" ").replace(/\s+/g, " ").trim();
+  };
+
+  for (const rawLine of commentValue.split("\n")) {
+    const line = rawLine.replace(/^\s*\* ?/, "").trimEnd();
+    const tagMatch = line.match(/^@([A-Za-z][\w-]*)\s*(.*)$/);
+    if (tagMatch) {
+      flush();
+      currentTag = tagMatch[1];
+      currentLines = [tagMatch[2] ?? ""];
+      continue;
+    }
+    if (currentTag) currentLines.push(line.trim());
+  }
+  flush();
+
+  return narrative;
+}
+
+function findLeadingJsDoc(
+  ast: TSESTree.Program,
+  source: string,
+  node: TSESTree.Node
+): TSESTree.Comment | undefined {
+  if (!hasRange(node)) return undefined;
+  const comments = (ast.comments ?? [])
+    .filter((comment) => comment.type === "Block" && comment.value.startsWith("*"))
+    .filter((comment) => hasCommentRange(comment) && comment.range[1] <= node.range[0])
+    .sort((a, b) => b.range[1] - a.range[1]);
+
+  for (const comment of comments) {
+    if (!hasCommentRange(comment)) continue;
+    const gap = source.slice(comment.range[1], node.range[0]);
+    if (/^\s*$/.test(gap)) return comment;
+    break;
+  }
+  return undefined;
+}
+
+function collectFileBindings(ast: TSESTree.Program): VariableBindings {
+  const bindings: VariableBindings = new Map();
+  for (const statement of ast.body) {
+    if (statement.type !== "VariableDeclaration") continue;
+    for (const declaration of statement.declarations) {
+      if (declaration.id.type === "Identifier" && declaration.init) {
+        bindings.set(declaration.id.name, declaration.init);
+      }
+    }
+  }
+  return bindings;
+}
+
+function visibilityFromObjectExpression(expression: TSESTree.Expression): NarrativeVisibility | undefined {
+  if (expression.type !== "ObjectExpression") return undefined;
+  for (const property of expression.properties) {
+    if (property.type === "SpreadElement" || property.computed || property.kind !== "init") continue;
+    const key =
+      property.key.type === "Identifier"
+        ? property.key.name
+        : property.key.type === "Literal" && typeof property.key.value === "string"
+          ? property.key.value
+          : undefined;
+    if (key !== "visibility") continue;
+    if (
+      property.value.type === "Literal" &&
+      (property.value.value === "public" || property.value.value === "internal")
+    ) {
+      return property.value.value;
+    }
+  }
+  return undefined;
+}
+
+function visibilityFromExpression(
+  expression: TSESTree.Expression | undefined,
+  fileBindings: VariableBindings,
+  seen = new Set<string>()
+): NarrativeVisibility | undefined {
+  if (!expression) return undefined;
+
+  if (expression.type === "Identifier") {
+    if (seen.has(expression.name)) return undefined;
+    seen.add(expression.name);
+    return visibilityFromExpression(fileBindings.get(expression.name), fileBindings, seen);
+  }
+
+  if (expression.type !== "CallExpression") return undefined;
+
+  let visibility: NarrativeVisibility | undefined;
+  if (expression.callee.type === "MemberExpression") {
+    const method = getPropertyName(expression.callee);
+    if (method && VISIBILITY_METHODS.has(method)) {
+      visibility = visibilityFromObjectExpression(expressionFromArgument(expression.arguments[0]) as TSESTree.Expression);
+    }
+    return visibility ?? visibilityFromExpression(expression.callee.object as TSESTree.Expression, fileBindings, seen);
+  }
+
+  if (expression.callee.type === "CallExpression") {
+    return visibilityFromExpression(expression.callee, fileBindings, seen);
+  }
+
+  return undefined;
+}
+
+function visibilityForScenarioCall(
+  scenarioCall: TSESTree.CallExpression,
+  openspecCall: TSESTree.CallExpression,
+  fileBindings: VariableBindings
+): NarrativeVisibility | undefined {
+  if (scenarioCall.callee.type === "CallExpression") {
+    const metadataVisibility = visibilityFromObjectExpression(
+      expressionFromArgument(scenarioCall.callee.arguments[0]) as TSESTree.Expression
+    );
+    if (metadataVisibility) return metadataVisibility;
+  }
+
+  const directVisibility = visibilityFromExpression(scenarioCall.callee, fileBindings);
+  if (directVisibility) return directVisibility;
+  if (openspecCall.callee.type === "MemberExpression") {
+    return visibilityFromExpression(openspecCall.callee.object as TSESTree.Expression, fileBindings);
+  }
+  return undefined;
+}
+
+function extractScenarioName(call: TSESTree.CallExpression, source: string): string {
+  const nameArg = expressionFromArgument(call.arguments[0]);
+  if (!nameArg) return "";
+  const literal = literalFromExpression(nameArg);
+  return typeof literal === "string" ? literal : sourceTextFor(source, nameArg);
+}
+
+function collectScenarioBody(call: TSESTree.CallExpression): TSESTree.Node | undefined {
+  const bodyArg = expressionFromArgument(call.arguments[1]);
+  if (!bodyArg) return undefined;
+  if (bodyArg.type === "ArrowFunctionExpression" || bodyArg.type === "FunctionExpression") {
+    return bodyArg.body;
+  }
+  return undefined;
+}
+
+function extractBodyEvidence(
+  body: TSESTree.Node | undefined,
+  filePath: string,
+  source: string
+): Pick<ScenarioEvidence, "bddSteps" | "fixtures" | "expectArgs"> {
+  const bddSteps: BddStepEvidence[] = [];
+  const fixtures: FixtureEvidence[] = [];
+  const expectArgs: ExpectArgEvidence[] = [];
+  if (!body) return { bddSteps, fixtures, expectArgs };
+
+  const bindings = collectBodyBindings(body);
+  for (const [name, init] of bindings.entries()) {
+    fixtures.push({
+      name,
+      value: evidenceForExpression(init, bindings, filePath, source),
+      sourceRef: sourceRefFor(filePath, init)
+    });
+  }
+
+  walk(body, (node) => {
+    if (node.type !== "CallExpression") return;
+    const calleeName =
+      node.callee.type === "Identifier"
+        ? node.callee.name
+        : node.callee.type === "MemberExpression"
+          ? getPropertyName(node.callee)
+          : undefined;
+    if (!calleeName) return;
+
+    if (BDD_STEP_NAMES.has(calleeName)) {
+      const firstArg = expressionFromArgument(node.arguments[0]);
+      if (!firstArg) return;
+      bddSteps.push({
+        keyword: calleeName as BddStepEvidence["keyword"],
+        value: evidenceForExpression(firstArg, bindings, filePath, source),
+        sourceRef: sourceRefFor(filePath, node)
+      });
+      return;
+    }
+
+    if (calleeName === "expect") {
+      const firstArg = expressionFromArgument(node.arguments[0]);
+      if (!firstArg) return;
+      expectArgs.push({
+        value: evidenceForExpression(firstArg, bindings, filePath, source),
+        sourceText: sourceTextFor(source, firstArg),
+        sourceRef: sourceRefFor(filePath, node)
+      });
+    }
+  });
+
+  return { bddSteps, fixtures, expectArgs };
+}
+
+export function extractScenarios(filePath: string): ScenarioEvidence[] {
+  const { source, ast } = parseSource(filePath);
+  const fileBindings = collectFileBindings(ast);
+  const scenarios: ScenarioEvidence[] = [];
+
+  walk(ast, (node) => {
+    if (node.type !== "CallExpression" || !isScenarioCall(node)) return;
+    const openspecCall = findOpeningOpenspecCall(node.callee);
+    if (!openspecCall) return;
+
+    const comment = findLeadingJsDoc(ast, source, node);
+    const body = collectScenarioBody(node);
+    const evidence = extractBodyEvidence(body, filePath, source);
+    scenarios.push({
+      scenarioName: extractScenarioName(node, source),
+      sourceRef: sourceRefFor(filePath, node),
+      visibility: visibilityForScenarioCall(node, openspecCall, fileBindings),
+      narrative: extractNarrative(comment?.value),
+      ...evidence
+    });
+  });
+
+  return scenarios;
+}
+
+function walk(node: TSESTree.Node, visit: (node: TSESTree.Node) => void): void {
+  visit(node);
+  for (const key of Object.keys(node) as Array<keyof typeof node>) {
+    if (key === "parent" || key === "range" || key === "loc") continue;
+    const value = node[key];
+    if (!value) continue;
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (item && typeof item === "object" && "type" in item) walk(item as TSESTree.Node, visit);
+      }
+    } else if (typeof value === "object" && "type" in value) {
+      walk(value as TSESTree.Node, visit);
+    }
+  }
+}

--- a/packages/test-narrative/src/index.ts
+++ b/packages/test-narrative/src/index.ts
@@ -10,3 +10,15 @@ export {
   type TagDefinition,
   type ValidateTagsResult
 } from "./tagSchema.js";
+
+export {
+  extractScenarios,
+  type BddStepEvidence,
+  type EvidenceValue,
+  type ExpectArgEvidence,
+  type FixtureEvidence,
+  type LiteralEvidence,
+  type ScenarioEvidence,
+  type SourceRef,
+  type UnresolvedEvidence
+} from "./astExtractor.js";

--- a/scripts/check_test_narratives.mjs
+++ b/scripts/check_test_narratives.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+// check_test_narratives.mjs
+//
+// Validates static test narrative JSDoc tags for OpenSpec-mapped tests.
+// The AST extraction stays purely static: it reads test source, joins
+// immediately-leading JSDoc blocks to `.openspec(...)(...)` calls, and never
+// evaluates code or follows imports.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { extractScenarios, validateTags } from '../packages/test-narrative/dist/index.js';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const TEST_GLOBS = [/^packages\/[^/]+\/src\/.*\.test\.ts$/, /^packages\/[^/]+\/test-primitives\/.*\.test\.ts$/];
+
+const ERRORS = [];
+function err(file, line, message) {
+  ERRORS.push({ file, line, message });
+}
+
+function* walkFiles(dir, predicate) {
+  if (!fs.existsSync(dir)) return;
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name === '.git' || entry.name === 'dist') continue;
+      yield* walkFiles(full, predicate);
+    } else if (predicate(full)) {
+      yield full;
+    }
+  }
+}
+
+function listTestFiles() {
+  const all = [];
+  for (const file of walkFiles(REPO_ROOT, (f) => f.endsWith('.ts'))) {
+    const rel = path.relative(REPO_ROOT, file).split(path.sep).join('/');
+    if (TEST_GLOBS.some((re) => re.test(rel))) {
+      all.push({ abs: file, rel });
+    }
+  }
+  return all;
+}
+
+function lintTestFile(file) {
+  let scenarios;
+  try {
+    scenarios = extractScenarios(file.abs);
+  } catch (e) {
+    err(file.rel, 1, `Parse error: ${e.message}`);
+    return;
+  }
+
+  for (const scenario of scenarios) {
+    const visibility = scenario.visibility ?? 'internal';
+    if (visibility === 'public' && !scenario.narrative.motivatingProblem) {
+      err(file.rel, scenario.sourceRef.line, '@motivatingProblem is required when visibility is public');
+    }
+
+    const result = validateTags(scenario.narrative, { visibility });
+    if (!result.success) {
+      for (const issue of result.error.issues) {
+        const tagPath = issue.path.length > 0 ? ` ${issue.path.join('.')}:` : '';
+        err(file.rel, scenario.sourceRef.line, `Invalid narrative tag${tagPath} ${issue.message}`);
+      }
+    }
+  }
+}
+
+function main() {
+  const files = listTestFiles();
+  for (const file of files) {
+    lintTestFile(file);
+  }
+
+  if (ERRORS.length === 0) {
+    console.log(`check_test_narratives: OK (${files.length} test files)`);
+    process.exit(0);
+  }
+  for (const e of ERRORS) {
+    console.error(`${e.file}:${e.line}: ${e.message}`);
+  }
+  console.error(`\ncheck_test_narratives: FAIL (${ERRORS.length} issue${ERRORS.length === 1 ? '' : 's'})`);
+  process.exit(1);
+}
+
+main();


### PR DESCRIPTION
## Summary

Implements tasks 5.1–5.4 of the merged OpenSpec change `add-test-corpus-narrative` (PR #236). Adds the purely-static AST extractor (used by both the future corpus emitter and the new CI narrative gate) and a `check:test-narratives` script that hard-fails on missing or invalid narrative tags.

## Surface

| File | Change | LOC |
|---|---|---|
| `packages/test-narrative/src/astExtractor.ts` | new | 425 |
| `packages/test-narrative/src/astExtractor.test.ts` | new, 13 scenarios | 264 |
| `packages/test-narrative/src/index.ts` | +12 lines (re-exports) | — |
| `packages/test-narrative/package.json` | +2 dev deps (`@typescript-eslint/parser`, `@typescript-eslint/types`) | — |
| `scripts/check_test_narratives.mjs` | new | 90 |
| `package.json` | +1 script | — |

Total: ~800 new LOC. No existing test or source file modified.

## `extractScenarios(filePath): ScenarioEvidence[]`

Matches `test.openspec(...)(...)` and `testAllure.openspec(...)(...)` call chains. For each test call:

- Finds the immediately-preceding JSDoc block and parses recognized `@tag` bodies from the schema in `@usejunior/test-narrative`.
- Resolves `visibility` by walking the call chain for `.withLabels({ visibility })` or `.allure({ visibility })`.
- Extracts `given`/`when`/`then`/`and` step strings verbatim.
- Extracts `expect()` argument expressions.

Resolves literals (strings, numbers, booleans, object/array literals, template literals with no expressions, locally-scoped identifiers whose initializer is a literal). For everything else (imported bindings, factory calls, computed expressions, destructured fixtures, template literals with runtime expressions), emits an **unresolved-evidence marker**:

```ts
{ kind: 'unresolved', sourceText: '<original expression text>', sourceRef: { file, line } }
```

**Does NOT** evaluate code, follow imports, or resolve function calls — purely static, per the merged spec's "AST extractor falls back on non-literal evidence" requirement.

## `scripts/check_test_narratives.mjs`

Mirrors the patterns in `scripts/check_conformance_citations.mjs` (same `TEST_GLOBS`, same `walkFiles` shape, same error format `file:line: message`). For each extracted scenario:

- If `visibility === 'public'`, require `@motivatingProblem`.
- For every present narrative tag, validate via `validateTags(scenario.narrative, { visibility })`. Hard-fail on schema violations.

**No hash-based staleness gates** (per spec).

Wired into root `package.json` as `check:test-narratives` (builds the schema package first, then runs the script).

## Current state

```
$ npm run check:test-narratives
check_test_narratives: OK (181 test files)
```

The validator passes today because no existing test is marked `visibility: 'public'`. Promotion of individual tests to public is a separate per-test review pass, gated by this script.

## Verification

```
$ npm run build                                              → green
$ npm run lint:workspaces                                    → green (1 pre-existing warning)
$ npm run test:run --workspace=@usejunior/test-narrative     → 32 passing (19 schema + 13 AST extractor)
$ npm run test:run                                           → green across all workspaces
$ npm run check:test-narratives                              → OK (181 test files)
$ npm run check:spec-coverage                                → green
$ npm run check:conformance-citations                        → OK
$ npm run check:conformance-doc                              → green
$ git diff main -- spec-compliance/CONFORMANCE.md            → empty
```

## What this does NOT change

- No existing `.test.ts` file modified.
- No test marked `visibility: 'public'` yet.
- The local drafter (`scripts/draft-narrative-jsdoc.mjs`) — task 6, separate PR.
- The corpus emitter (`scripts/build_tests_corpus.mjs`) and release workflow — task 7, separate PR.
- The generated `tests-corpus.schema.json` artifact — task 3.3, separate PR.

## Verification checklist

- [x] `extractScenarios()` exported with documented interface
- [x] 13 AST-extractor test scenarios passing (literal, unresolved, JSDoc parsing, visibility resolution, multi-test files)
- [x] Schema-package tests still passing (19 → 32 total)
- [x] CI validator hard-fails on missing/invalid required tags
- [x] CI validator passes on `main` (no public tests yet)
- [x] Full repo CI green locally
- [x] `CONFORMANCE.md` byte-identical to `main`
- [ ] Peer review (Gemini + Codex) — pending; will be appended below

## Closes

- #246