### PR TITLE
feat(scripts): emit tests-corpus.json + schema artifact at tag time

### DIFF
--- a/.github/workflows/release-tests-corpus.yml
+++ b/.github/workflows/release-tests-corpus.yml
@@ -1,0 +1,43 @@
+name: Release Tests Corpus
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release-tests-corpus:
+    name: Release tests corpus
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build workspaces
+        run: npm run build
+
+      - name: Run tests
+        run: npm run test:run
+
+      - name: Build tests corpus
+        run: npm run build:tests-corpus
+
+      - name: Verify tests corpus schema is fresh
+        run: npm run check:tests-corpus-schema
+
+      - name: Attach tests corpus release assets
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
+        with:
+          files: |
+            tests-corpus.json
+            tests-corpus.schema.json

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ site/docs/*.md
 site/downloads/
 site/schemas/
 packages/contracts-workspace/schemas/
+tests-corpus.json
 
 # Google service account credentials
 *-credentials.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@typescript-eslint/eslint-plugin": "^8.56.0",
         "@typescript-eslint/parser": "^8.56.0",
         "@vitest/runner": "3.2.4",
+        "ajv": "^8.18.0",
         "allure": "3.2.0",
         "eslint": "^10.0.1",
         "fast-xml-parser": "^5.7.0",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,9 @@
     "generate:conformance-doc": "node scripts/generate_conformance_doc.mjs",
     "check:conformance-citations": "node scripts/check_conformance_citations.mjs",
     "check:conformance-doc": "node scripts/check_conformance_doc.mjs",
+    "generate:tests-corpus-schema": "npm run build -w @usejunior/test-narrative && node scripts/generate_tests_corpus_schema.mjs",
+    "check:tests-corpus-schema": "npm run build -w @usejunior/test-narrative && node scripts/check_tests_corpus_schema.mjs",
+    "build:tests-corpus": "npm run build -w @usejunior/test-narrative && node scripts/build_tests_corpus.mjs",
     "check:test-narratives": "npm run build -w @usejunior/test-narrative && node scripts/check_test_narratives.mjs",
     "sync:readme": "node scripts/sync_readme_blocks.mjs",
     "check:readme-sync": "node scripts/sync_readme_blocks.mjs --check"
@@ -69,6 +72,7 @@
     "@typescript-eslint/eslint-plugin": "^8.56.0",
     "@typescript-eslint/parser": "^8.56.0",
     "@vitest/runner": "3.2.4",
+    "ajv": "^8.18.0",
     "allure": "3.2.0",
     "eslint": "^10.0.1",
     "fast-xml-parser": "^5.7.0",

--- a/scripts/build_tests_corpus.mjs
+++ b/scripts/build_tests_corpus.mjs
@@ -109,10 +109,10 @@ function buildAllureIndex() {
   return byPackage;
 }
 
-function findAllureResult(allureIndex, packageName, scenarioName) {
+function findAllureResults(allureIndex, packageName, scenarioName) {
   const wanted = normalizeScenarioName(scenarioName);
   const results = allureIndex.get(packageName) ?? [];
-  return results.find(({ result }) => {
+  return results.filter(({ result }) => {
     if (!hasPublicCorpusVisibility(result)) return false;
     return resultNameCandidates(result).includes(wanted);
   });
@@ -271,11 +271,41 @@ function buildCorpusEntries() {
         throw new Error(`${file.rel}:${scenario.sourceRef.line}: invalid public narrative tags: ${issues}`);
       }
 
-      const matched = findAllureResult(allureIndex, packageName, scenario.scenarioName);
-      if (!matched) continue;
+      // Visibility model (per spec): both the AST-side `visibility: 'public'`
+      // marker AND the runtime `corpusVisibility=public` Allure label must
+      // agree before a scenario enters the corpus. The previous-step check
+      // (visibility !== 'public' continue) gates on the AST side; the Allure
+      // lookup gates on the runtime side. A mismatch between them indicates
+      // either a stale `allure-results/` directory (test source was promoted
+      // to public AFTER the last CI run) or a missing `corpusVisibility`
+      // emission (allure-test-factory wasn't built before tests ran). Either
+      // way it's developer error — fail loudly with the file:line + expected
+      // label rather than silently dropping the scenario from the release.
+      const matched = findAllureResults(allureIndex, packageName, scenario.scenarioName);
+      if (matched.length === 0) {
+        throw new Error(
+          `${file.rel}:${scenario.sourceRef.line}: scenario "${scenario.scenarioName}" is marked ` +
+            `visibility: 'public' in source but no matching Allure result with ` +
+            `corpusVisibility=public was found under packages/${packageName}/allure-results/. ` +
+            `Likely causes: tests not run, allure-results was cleaned, scenario renamed since last ` +
+            `CI run, or @usejunior/allure-test-factory wasn't rebuilt before the run that produced ` +
+            `these results.`
+        );
+      }
+      if (matched.length > 1) {
+        const candidates = matched
+          .map((m) => repoRelative(m.file))
+          .join(', ');
+        throw new Error(
+          `${file.rel}:${scenario.sourceRef.line}: scenario "${scenario.scenarioName}" matches ` +
+            `${matched.length} Allure results (${candidates}). Scenario names must be unique within a ` +
+            `package; rename one of the conflicting scenarios.`
+        );
+      }
+      const matchedResult = matched[0];
 
-      const conformanceClaims = resolveConformanceClaims(matched.result, registry);
-      const results = serializeResult(matched.result);
+      const conformanceClaims = resolveConformanceClaims(matchedResult.result, registry);
+      const results = serializeResult(matchedResult.result);
       entries.push({
         id: stableEntryId(packageName, scenario),
         package: packageName,

--- a/scripts/build_tests_corpus.mjs
+++ b/scripts/build_tests_corpus.mjs
@@ -1,0 +1,333 @@
+#!/usr/bin/env node
+// build_tests_corpus.mjs
+//
+// Emits the generated root `tests-corpus.json` release artifact. The artifact
+// is intentionally not checked in; `tests-corpus.schema.json` is the committed
+// contract for consumers.
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import Ajv from 'ajv';
+
+import {
+  CANONICAL_SECTION_ORDER,
+  extractScenarios,
+  validateTags,
+} from '../packages/test-narrative/dist/index.js';
+import { loadRegistry } from './lib/conformance-registry.mjs';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const OUT_CORPUS = path.join(REPO_ROOT, 'tests-corpus.json');
+const SCHEMA_PATH = path.join(REPO_ROOT, 'tests-corpus.schema.json');
+const TEST_GLOBS = [/^packages\/[^/]+\/src\/.*\.test\.ts$/, /^packages\/[^/]+\/test-primitives\/.*\.test\.ts$/];
+const ENGINEER_ONLY_LABELS = new Set(['framework', 'host', 'language', 'thread']);
+
+function* walkFiles(dir, predicate) {
+  if (!fs.existsSync(dir)) return;
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name === '.git' || entry.name === 'dist') continue;
+      yield* walkFiles(full, predicate);
+    } else if (predicate(full)) {
+      yield full;
+    }
+  }
+}
+
+function repoRelative(file) {
+  return path.relative(REPO_ROOT, file).split(path.sep).join('/');
+}
+
+function listTestFiles() {
+  const files = [];
+  for (const file of walkFiles(REPO_ROOT, (f) => f.endsWith('.ts'))) {
+    const rel = repoRelative(file);
+    if (TEST_GLOBS.some((re) => re.test(rel))) {
+      files.push({ abs: file, rel });
+    }
+  }
+  return files.sort((a, b) => a.rel.localeCompare(b.rel));
+}
+
+function listAllureResultFiles(packageName) {
+  const dir = path.join(REPO_ROOT, 'packages', packageName, 'allure-results');
+  if (!fs.existsSync(dir)) return [];
+  return [...walkFiles(dir, (f) => f.endsWith('-result.json'))].sort();
+}
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+function normalizeScenarioName(value) {
+  return String(value ?? '').replace(/^Scenario:\s*/i, '').trim();
+}
+
+function labelsFromResult(result) {
+  return (Array.isArray(result.labels) ? result.labels : [])
+    .filter((label) => label && typeof label.name === 'string' && typeof label.value === 'string')
+    .map((label) => ({ name: label.name, value: label.value }));
+}
+
+function labelsByName(labels, name) {
+  return labels.filter((label) => label.name === name).map((label) => label.value);
+}
+
+function hasPublicCorpusVisibility(result) {
+  return labelsFromResult(result).some((label) => label.name === 'corpusVisibility' && label.value === 'public');
+}
+
+function resultNameCandidates(result) {
+  return [
+    result.name,
+    result.fullName,
+    result.testCaseName,
+    result.title,
+    ...labelsByName(labelsFromResult(result), 'story'),
+  ].map(normalizeScenarioName).filter(Boolean);
+}
+
+function buildAllureIndex() {
+  const byPackage = new Map();
+  for (const pkgDir of fs.readdirSync(path.join(REPO_ROOT, 'packages'), { withFileTypes: true })) {
+    if (!pkgDir.isDirectory()) continue;
+    const results = [];
+    for (const resultFile of listAllureResultFiles(pkgDir.name)) {
+      try {
+        results.push({ file: resultFile, result: readJson(resultFile) });
+      } catch (error) {
+        throw new Error(`${repoRelative(resultFile)}: failed to parse Allure result JSON: ${error.message}`);
+      }
+    }
+    byPackage.set(pkgDir.name, results);
+  }
+  return byPackage;
+}
+
+function findAllureResult(allureIndex, packageName, scenarioName) {
+  const wanted = normalizeScenarioName(scenarioName);
+  const results = allureIndex.get(packageName) ?? [];
+  return results.find(({ result }) => {
+    if (!hasPublicCorpusVisibility(result)) return false;
+    return resultNameCandidates(result).includes(wanted);
+  });
+}
+
+function packageNameFromRel(rel) {
+  const match = rel.match(/^packages\/([^/]+)\//);
+  if (!match) throw new Error(`${rel}: test file is not under packages/<name>/`);
+  return match[1];
+}
+
+function stableEntryId(packageName, scenario) {
+  return [
+    packageName,
+    repoRelative(scenario.sourceRef.path),
+    scenario.sourceRef.line,
+    normalizeScenarioName(scenario.scenarioName),
+  ].join('#');
+}
+
+function serializeSourceRef(sourceRef) {
+  return {
+    path: repoRelative(sourceRef.path),
+    line: sourceRef.line,
+  };
+}
+
+function serializeEvidenceValue(value) {
+  if (value.kind === 'literal') return { kind: 'literal', value: value.value };
+  return {
+    kind: 'unresolved',
+    sourceText: value.sourceText,
+    sourceRef: serializeSourceRef(value.sourceRef),
+  };
+}
+
+function serializeBddStep(step) {
+  return {
+    keyword: step.keyword,
+    value: serializeEvidenceValue(step.value),
+    sourceRef: serializeSourceRef(step.sourceRef),
+  };
+}
+
+function serializeFixture(fixture) {
+  return {
+    name: fixture.name,
+    value: serializeEvidenceValue(fixture.value),
+    sourceRef: serializeSourceRef(fixture.sourceRef),
+  };
+}
+
+function serializeExpectArg(expectArg) {
+  return {
+    value: serializeEvidenceValue(expectArg.value),
+    sourceText: expectArg.sourceText,
+    sourceRef: serializeSourceRef(expectArg.sourceRef),
+  };
+}
+
+function trimProse(prose) {
+  return prose.join('\n').trim();
+}
+
+function parseConformanceLabel(value) {
+  const match = String(value).match(/^([^/]+)\/edition-(\d+)\/part-(\d+)\/(.+)$/);
+  if (!match) return undefined;
+  return {
+    spec: match[1],
+    edition: Number(match[2]),
+    part: Number(match[3]),
+    section: match[4],
+  };
+}
+
+function registryKeyForClaim(claim) {
+  if (claim.spec === 'ECMA-376') {
+    return `ECMA-PART${claim.part}-${claim.section.replace(/\./g, '-')}`;
+  }
+  return undefined;
+}
+
+function resolveConformanceClaims(result, registry) {
+  const claims = [];
+  for (const value of labelsByName(labelsFromResult(result), 'conformance')) {
+    const parsed = parseConformanceLabel(value);
+    if (!parsed) continue;
+    const registryKey = registryKeyForClaim(parsed);
+    const target = registryKey ? registry.targets.get(registryKey) : undefined;
+    claims.push({
+      id: target?.id ?? value,
+      spec: parsed.spec,
+      edition: parsed.edition,
+      part: parsed.part,
+      section: parsed.section,
+      title: target?.title ?? parsed.section,
+      text: target ? trimProse(target.prose) : '',
+    });
+  }
+  return claims.filter((claim) => claim.text.length > 0);
+}
+
+function serializeResult(result) {
+  const labels = labelsFromResult(result)
+    .filter((label) => !ENGINEER_ONLY_LABELS.has(label.name))
+    .filter((label) => label.name !== 'tag' || label.value !== 'human-readable')
+    .sort((a, b) => `${a.name}\0${a.value}`.localeCompare(`${b.name}\0${b.value}`));
+
+  return {
+    name: normalizeScenarioName(result.name),
+    status: String(result.status ?? 'unknown'),
+    labels,
+  };
+}
+
+function sectionsForEntry(scenario, result, conformanceClaims) {
+  const present = new Set();
+  present.add('breadcrumb');
+  present.add('statusStrip');
+  if (conformanceClaims.length > 0) present.add('citationsStrip');
+  for (const key of Object.keys(scenario.narrative)) present.add(key);
+  present.add('scenario');
+  if (result) present.add('results');
+  if (conformanceClaims.length > 0) present.add('specCitations');
+  present.add('sourceLink');
+  return CANONICAL_SECTION_ORDER.filter((section) => present.has(section));
+}
+
+function buildCorpusEntries() {
+  const registry = loadRegistry();
+  if (registry.errors.length > 0) {
+    const first = registry.errors[0];
+    throw new Error(`${repoRelative(first.file)}:${first.line}: ${first.message}`);
+  }
+
+  const allureIndex = buildAllureIndex();
+  const entries = [];
+  for (const file of listTestFiles()) {
+    const packageName = packageNameFromRel(file.rel);
+    let scenarios;
+    try {
+      scenarios = extractScenarios(file.abs);
+    } catch (error) {
+      throw new Error(`${file.rel}: failed to extract test narratives: ${error.message}`);
+    }
+
+    for (const scenario of scenarios) {
+      const visibility = scenario.visibility ?? 'internal';
+      if (visibility !== 'public') continue;
+
+      const validation = validateTags(scenario.narrative, { visibility });
+      if (!validation.success) {
+        const issues = validation.error.issues
+          .map((issue) => `${issue.path.join('.') || '<root>'}: ${issue.message}`)
+          .join('; ');
+        throw new Error(`${file.rel}:${scenario.sourceRef.line}: invalid public narrative tags: ${issues}`);
+      }
+
+      const matched = findAllureResult(allureIndex, packageName, scenario.scenarioName);
+      if (!matched) continue;
+
+      const conformanceClaims = resolveConformanceClaims(matched.result, registry);
+      const results = serializeResult(matched.result);
+      entries.push({
+        id: stableEntryId(packageName, scenario),
+        package: packageName,
+        scenarioName: normalizeScenarioName(scenario.scenarioName),
+        sourceRef: serializeSourceRef(scenario.sourceRef),
+        sections: sectionsForEntry(scenario, results, conformanceClaims),
+        narrative: { ...scenario.narrative },
+        scenario: {
+          bddSteps: scenario.bddSteps.map(serializeBddStep),
+          fixtures: scenario.fixtures.map(serializeFixture),
+          expectArgs: scenario.expectArgs.map(serializeExpectArg),
+        },
+        results,
+        conformanceClaims,
+      });
+    }
+  }
+
+  return entries.sort((a, b) => a.id.localeCompare(b.id));
+}
+
+function gitHead() {
+  return execFileSync('git', ['rev-parse', 'HEAD'], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+  }).trim();
+}
+
+function validateCorpus(corpus) {
+  const schema = readJson(SCHEMA_PATH);
+  const ajv = new Ajv({ allErrors: true, strict: false, validateFormats: false });
+  const validate = ajv.compile(schema);
+  if (validate(corpus)) return;
+
+  const errors = validate.errors ?? [];
+  const detail = errors
+    .slice(0, 10)
+    .map((error) => `${error.instancePath || '/'} ${error.message}`)
+    .join('\n');
+  throw new Error(`tests-corpus.json failed schema validation:\n${detail}`);
+}
+
+function main() {
+  const corpus = {
+    schemaVersion: '1.0.0',
+    generatedAt: new Date().toISOString(),
+    safeDocxCommit: gitHead(),
+    entries: buildCorpusEntries(),
+  };
+  validateCorpus(corpus);
+  fs.writeFileSync(OUT_CORPUS, `${JSON.stringify(corpus, null, 2)}\n`);
+  console.log(`build_tests_corpus: wrote ${repoRelative(OUT_CORPUS)} (${corpus.entries.length} entries)`);
+}
+
+main();

--- a/scripts/check_tests_corpus_schema.mjs
+++ b/scripts/check_tests_corpus_schema.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+// check_tests_corpus_schema.mjs
+//
+// Drift gate for `tests-corpus.schema.json`. Regenerates the schema, then
+// relies on `git diff --exit-code` to print a unified diff when the checked-in
+// artifact is stale.
+
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+function main() {
+  const gen = spawnSync(process.execPath, ['scripts/generate_tests_corpus_schema.mjs'], {
+    cwd: REPO_ROOT,
+    stdio: 'inherit',
+  });
+  if (gen.status !== 0) {
+    console.error('check_tests_corpus_schema: generator failed');
+    process.exit(gen.status ?? 1);
+  }
+
+  const diff = spawnSync('git', ['diff', '--exit-code', '--', 'tests-corpus.schema.json'], {
+    cwd: REPO_ROOT,
+    stdio: 'inherit',
+  });
+  if (diff.status !== 0) {
+    console.error('\ncheck_tests_corpus_schema: FAIL - generated schema disagrees with the working tree.');
+    console.error('Run `node scripts/generate_tests_corpus_schema.mjs` and commit the result.');
+    process.exit(diff.status ?? 1);
+  }
+
+  console.log('check_tests_corpus_schema: OK');
+}
+
+main();

--- a/scripts/check_tests_corpus_schema.mjs
+++ b/scripts/check_tests_corpus_schema.mjs
@@ -1,37 +1,49 @@
 #!/usr/bin/env node
 // check_tests_corpus_schema.mjs
 //
-// Drift gate for `tests-corpus.schema.json`. Regenerates the schema, then
-// relies on `git diff --exit-code` to print a unified diff when the checked-in
-// artifact is stale.
+// Drift gate for `tests-corpus.schema.json`. Renders the schema from the
+// in-repo Zod source IN MEMORY and compares against the checked-in file
+// contents. Must NOT write the schema to disk — the previous version did,
+// which made the gate a no-op: it overwrote any stray edit before diffing.
 
-import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { renderTestsCorpusSchema } from './generate_tests_corpus_schema.mjs';
+
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SCHEMA_PATH = path.join(REPO_ROOT, 'tests-corpus.schema.json');
 
 function main() {
-  const gen = spawnSync(process.execPath, ['scripts/generate_tests_corpus_schema.mjs'], {
-    cwd: REPO_ROOT,
-    stdio: 'inherit',
-  });
-  if (gen.status !== 0) {
-    console.error('check_tests_corpus_schema: generator failed');
-    process.exit(gen.status ?? 1);
+  const expected = renderTestsCorpusSchema();
+  let actual;
+  try {
+    actual = fs.readFileSync(SCHEMA_PATH, 'utf8');
+  } catch (e) {
+    console.error(`check_tests_corpus_schema: FAIL — ${path.relative(REPO_ROOT, SCHEMA_PATH)} is missing.`);
+    console.error('Run `npm run generate:tests-corpus-schema` and commit the result.');
+    process.exit(1);
   }
-
-  const diff = spawnSync('git', ['diff', '--exit-code', '--', 'tests-corpus.schema.json'], {
-    cwd: REPO_ROOT,
-    stdio: 'inherit',
-  });
-  if (diff.status !== 0) {
-    console.error('\ncheck_tests_corpus_schema: FAIL - generated schema disagrees with the working tree.');
-    console.error('Run `node scripts/generate_tests_corpus_schema.mjs` and commit the result.');
-    process.exit(diff.status ?? 1);
+  if (actual === expected) {
+    console.log('check_tests_corpus_schema: OK');
+    return;
   }
-
-  console.log('check_tests_corpus_schema: OK');
+  console.error(`check_tests_corpus_schema: FAIL — ${path.relative(REPO_ROOT, SCHEMA_PATH)} is stale.`);
+  console.error('Run `npm run generate:tests-corpus-schema` and commit the result.');
+  console.error('');
+  console.error('First mismatch:');
+  const expectedLines = expected.split('\n');
+  const actualLines = actual.split('\n');
+  for (let i = 0; i < Math.max(expectedLines.length, actualLines.length); i += 1) {
+    if (expectedLines[i] !== actualLines[i]) {
+      console.error(`  line ${i + 1}:`);
+      console.error(`    - actual:   ${JSON.stringify(actualLines[i] ?? '<eof>')}`);
+      console.error(`    + expected: ${JSON.stringify(expectedLines[i] ?? '<eof>')}`);
+      break;
+    }
+  }
+  process.exit(1);
 }
 
 main();

--- a/scripts/generate_tests_corpus_schema.mjs
+++ b/scripts/generate_tests_corpus_schema.mjs
@@ -1,0 +1,320 @@
+#!/usr/bin/env node
+// generate_tests_corpus_schema.mjs
+//
+// Generates the checked-in root `tests-corpus.schema.json` artifact used by
+// `scripts/build_tests_corpus.mjs`. The narrative tag bounds here are
+// character-length constraints for JSON Schema consumers; word-count
+// enforcement remains in `@usejunior/test-narrative` via `validateTags`.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  CANONICAL_SECTION_ORDER,
+  rejectedAliases,
+  tagDefinitions,
+} from '../packages/test-narrative/dist/index.js';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const OUT_SCHEMA = path.join(REPO_ROOT, 'tests-corpus.schema.json');
+
+const TAG_VALUE_SCHEMA = {
+  type: 'string',
+  minLength: 1,
+  maxLength: 5000,
+};
+
+function sortedObjectEntries(object) {
+  return Object.entries(object).sort(([a], [b]) => a.localeCompare(b));
+}
+
+export function buildTestsCorpusSchema() {
+  const narrativeProperties = Object.fromEntries(
+    sortedObjectEntries(tagDefinitions).map(([tagName]) => [tagName, TAG_VALUE_SCHEMA]),
+  );
+
+  const rejectedAliasProperties = Object.fromEntries(
+    rejectedAliases.map((alias) => [alias, false]),
+  );
+
+  return {
+    $schema: 'http://json-schema.org/draft-07/schema#',
+    $id: 'https://safedocx.com/tests-corpus.schema.json',
+    title: 'safe-docx tests corpus',
+    type: 'object',
+    additionalProperties: false,
+    required: ['schemaVersion', 'generatedAt', 'safeDocxCommit', 'entries'],
+    properties: {
+      schemaVersion: { const: '1.0.0' },
+      generatedAt: { type: 'string', format: 'date-time' },
+      safeDocxCommit: {
+        type: 'string',
+        minLength: 7,
+        maxLength: 40,
+        pattern: '^[0-9a-f]+$',
+      },
+      entries: {
+        type: 'array',
+        items: { $ref: '#/$defs/CorpusEntry' },
+      },
+    },
+    $defs: {
+      CorpusEntry: {
+        type: 'object',
+        additionalProperties: false,
+        required: [
+          'id',
+          'package',
+          'scenarioName',
+          'sourceRef',
+          'sections',
+          'narrative',
+          'scenario',
+          'results',
+          'conformanceClaims',
+        ],
+        properties: {
+          id: {
+            type: 'string',
+            minLength: 1,
+            maxLength: 500,
+          },
+          package: {
+            type: 'string',
+            minLength: 1,
+            maxLength: 200,
+          },
+          scenarioName: {
+            type: 'string',
+            minLength: 1,
+            maxLength: 500,
+          },
+          sourceRef: { $ref: '#/$defs/SourceRef' },
+          sections: {
+            type: 'array',
+            items: { $ref: '#/$defs/SectionIdentifier' },
+            uniqueItems: true,
+          },
+          narrative: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+              ...narrativeProperties,
+              ...rejectedAliasProperties,
+            },
+          },
+          scenario: {
+            type: 'object',
+            additionalProperties: false,
+            required: ['bddSteps', 'fixtures', 'expectArgs'],
+            properties: {
+              bddSteps: {
+                type: 'array',
+                items: { $ref: '#/$defs/BddStep' },
+              },
+              fixtures: {
+                type: 'array',
+                items: { $ref: '#/$defs/FixtureEvidence' },
+              },
+              expectArgs: {
+                type: 'array',
+                items: { $ref: '#/$defs/ExpectArgEvidence' },
+              },
+            },
+          },
+          results: { $ref: '#/$defs/TestResult' },
+          conformanceClaims: {
+            type: 'array',
+            items: { $ref: '#/$defs/ConformanceClaim' },
+          },
+        },
+      },
+      SourceRef: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['path', 'line'],
+        properties: {
+          path: {
+            type: 'string',
+            minLength: 1,
+            maxLength: 1000,
+          },
+          line: {
+            type: 'integer',
+            minimum: 1,
+          },
+        },
+      },
+      EvidenceValue: {
+        oneOf: [
+          { $ref: '#/$defs/LiteralEvidence' },
+          { $ref: '#/$defs/UnresolvedEvidence' },
+        ],
+      },
+      LiteralEvidence: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['kind', 'value'],
+        properties: {
+          kind: { const: 'literal' },
+          value: {},
+        },
+      },
+      UnresolvedEvidence: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['kind', 'sourceText', 'sourceRef'],
+        properties: {
+          kind: { const: 'unresolved' },
+          sourceText: {
+            type: 'string',
+            minLength: 1,
+            maxLength: 20000,
+          },
+          sourceRef: { $ref: '#/$defs/SourceRef' },
+        },
+      },
+      BddStep: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['keyword', 'value', 'sourceRef'],
+        properties: {
+          keyword: {
+            enum: ['given', 'when', 'then', 'and'],
+          },
+          value: { $ref: '#/$defs/EvidenceValue' },
+          sourceRef: { $ref: '#/$defs/SourceRef' },
+        },
+      },
+      FixtureEvidence: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['name', 'value', 'sourceRef'],
+        properties: {
+          name: {
+            type: 'string',
+            minLength: 1,
+            maxLength: 500,
+          },
+          value: { $ref: '#/$defs/EvidenceValue' },
+          sourceRef: { $ref: '#/$defs/SourceRef' },
+        },
+      },
+      ExpectArgEvidence: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['value', 'sourceText', 'sourceRef'],
+        properties: {
+          value: { $ref: '#/$defs/EvidenceValue' },
+          sourceText: {
+            type: 'string',
+            minLength: 1,
+            maxLength: 20000,
+          },
+          sourceRef: { $ref: '#/$defs/SourceRef' },
+        },
+      },
+      TestResult: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['name', 'status', 'labels'],
+        properties: {
+          name: {
+            type: 'string',
+            minLength: 1,
+            maxLength: 500,
+          },
+          status: {
+            type: 'string',
+            minLength: 1,
+            maxLength: 100,
+          },
+          labels: {
+            type: 'array',
+            items: { $ref: '#/$defs/AllureLabel' },
+          },
+        },
+      },
+      AllureLabel: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['name', 'value'],
+        properties: {
+          name: {
+            type: 'string',
+            minLength: 1,
+            maxLength: 200,
+          },
+          value: {
+            type: 'string',
+            minLength: 1,
+            maxLength: 1000,
+          },
+        },
+      },
+      ConformanceClaim: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['id', 'spec', 'edition', 'part', 'section', 'title', 'text'],
+        properties: {
+          id: {
+            type: 'string',
+            minLength: 1,
+            maxLength: 200,
+          },
+          spec: {
+            type: 'string',
+            minLength: 1,
+            maxLength: 100,
+          },
+          edition: {
+            type: 'integer',
+            minimum: 1,
+          },
+          part: {
+            type: 'integer',
+            minimum: 1,
+          },
+          section: {
+            type: 'string',
+            minLength: 1,
+            maxLength: 100,
+          },
+          title: {
+            type: 'string',
+            minLength: 1,
+            maxLength: 500,
+          },
+          text: {
+            type: 'string',
+            minLength: 1,
+            maxLength: 20000,
+          },
+        },
+      },
+      SectionIdentifier: {
+        enum: [...CANONICAL_SECTION_ORDER],
+      },
+    },
+  };
+}
+
+export function renderTestsCorpusSchema() {
+  return `${JSON.stringify(buildTestsCorpusSchema(), null, 2)}\n`;
+}
+
+export function writeTestsCorpusSchema() {
+  const next = renderTestsCorpusSchema();
+  fs.writeFileSync(OUT_SCHEMA, next);
+  return OUT_SCHEMA;
+}
+
+function main() {
+  writeTestsCorpusSchema();
+  console.log(`generate_tests_corpus_schema: wrote ${path.relative(REPO_ROOT, OUT_SCHEMA)}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/tests-corpus.schema.json
+++ b/tests-corpus.schema.json
@@ -1,0 +1,412 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://safedocx.com/tests-corpus.schema.json",
+  "title": "safe-docx tests corpus",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "generatedAt",
+    "safeDocxCommit",
+    "entries"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "1.0.0"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "safeDocxCommit": {
+      "type": "string",
+      "minLength": 7,
+      "maxLength": 40,
+      "pattern": "^[0-9a-f]+$"
+    },
+    "entries": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/CorpusEntry"
+      }
+    }
+  },
+  "$defs": {
+    "CorpusEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "package",
+        "scenarioName",
+        "sourceRef",
+        "sections",
+        "narrative",
+        "scenario",
+        "results",
+        "conformanceClaims"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 500
+        },
+        "package": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200
+        },
+        "scenarioName": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 500
+        },
+        "sourceRef": {
+          "$ref": "#/$defs/SourceRef"
+        },
+        "sections": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SectionIdentifier"
+          },
+          "uniqueItems": true
+        },
+        "narrative": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "ecma376Difficulty": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 5000
+            },
+            "implementationAlternativeRejected": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 5000
+            },
+            "implementationLimitation": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 5000
+            },
+            "motivatingProblem": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 5000
+            },
+            "observedPerformance": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 5000
+            },
+            "potentialMisconception": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 5000
+            },
+            "testScopeExclusion": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 5000
+            },
+            "limitation": false,
+            "aiContext": false,
+            "compare": false,
+            "specQuirk": false,
+            "notCovered": false,
+            "prose": false,
+            "description": false,
+            "discussion": false
+          }
+        },
+        "scenario": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "bddSteps",
+            "fixtures",
+            "expectArgs"
+          ],
+          "properties": {
+            "bddSteps": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/BddStep"
+              }
+            },
+            "fixtures": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/FixtureEvidence"
+              }
+            },
+            "expectArgs": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/ExpectArgEvidence"
+              }
+            }
+          }
+        },
+        "results": {
+          "$ref": "#/$defs/TestResult"
+        },
+        "conformanceClaims": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ConformanceClaim"
+          }
+        }
+      }
+    },
+    "SourceRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "line"
+      ],
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1000
+        },
+        "line": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "EvidenceValue": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/LiteralEvidence"
+        },
+        {
+          "$ref": "#/$defs/UnresolvedEvidence"
+        }
+      ]
+    },
+    "LiteralEvidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "value"
+      ],
+      "properties": {
+        "kind": {
+          "const": "literal"
+        },
+        "value": {}
+      }
+    },
+    "UnresolvedEvidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "sourceText",
+        "sourceRef"
+      ],
+      "properties": {
+        "kind": {
+          "const": "unresolved"
+        },
+        "sourceText": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 20000
+        },
+        "sourceRef": {
+          "$ref": "#/$defs/SourceRef"
+        }
+      }
+    },
+    "BddStep": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "keyword",
+        "value",
+        "sourceRef"
+      ],
+      "properties": {
+        "keyword": {
+          "enum": [
+            "given",
+            "when",
+            "then",
+            "and"
+          ]
+        },
+        "value": {
+          "$ref": "#/$defs/EvidenceValue"
+        },
+        "sourceRef": {
+          "$ref": "#/$defs/SourceRef"
+        }
+      }
+    },
+    "FixtureEvidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "value",
+        "sourceRef"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 500
+        },
+        "value": {
+          "$ref": "#/$defs/EvidenceValue"
+        },
+        "sourceRef": {
+          "$ref": "#/$defs/SourceRef"
+        }
+      }
+    },
+    "ExpectArgEvidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "value",
+        "sourceText",
+        "sourceRef"
+      ],
+      "properties": {
+        "value": {
+          "$ref": "#/$defs/EvidenceValue"
+        },
+        "sourceText": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 20000
+        },
+        "sourceRef": {
+          "$ref": "#/$defs/SourceRef"
+        }
+      }
+    },
+    "TestResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "status",
+        "labels"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 500
+        },
+        "status": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 100
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/AllureLabel"
+          }
+        }
+      }
+    },
+    "AllureLabel": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "value"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200
+        },
+        "value": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1000
+        }
+      }
+    },
+    "ConformanceClaim": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "spec",
+        "edition",
+        "part",
+        "section",
+        "title",
+        "text"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 200
+        },
+        "spec": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 100
+        },
+        "edition": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "part": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "section": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 100
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 500
+        },
+        "text": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 20000
+        }
+      }
+    },
+    "SectionIdentifier": {
+      "enum": [
+        "breadcrumb",
+        "statusStrip",
+        "citationsStrip",
+        "motivatingProblem",
+        "scenario",
+        "results",
+        "implementationLimitation",
+        "testScopeExclusion",
+        "observedPerformance",
+        "potentialMisconception",
+        "implementationAlternativeRejected",
+        "ecma376Difficulty",
+        "specCitations",
+        "sourceLink"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

The **final piece** of the merged OpenSpec change `add-test-corpus-narrative` (PR #236). Combines tasks 3.3 + 7 from the proposal's tasks.md into one PR:

- **Generate `tests-corpus.schema.json`** from `@usejunior/test-narrative` constants (`CANONICAL_SECTION_ORDER`, `tagDefinitions`).
- **CI drift gate** that fails the build if the checked-in schema is out of sync with the Zod source.
- **Corpus emitter** (`scripts/build_tests_corpus.mjs`) that walks tests, runs the AST extractor, joins with `allure-results/*.json`, resolves ECMA-376 claims through the registry parser, strips engineer-only noise, and writes `tests-corpus.json`.
- **Tag-time release workflow** that attaches both files to the GitHub release.

## Surface

| File | Change | LOC |
|---|---|---|
| `scripts/generate_tests_corpus_schema.mjs` | new | 320 |
| `scripts/check_tests_corpus_schema.mjs` | new | 37 |
| `scripts/build_tests_corpus.mjs` | new | 333 |
| `tests-corpus.schema.json` | new (checked in) | 412 |
| `.github/workflows/release-tests-corpus.yml` | new | 43 |
| `package.json` | +3 scripts (`generate:tests-corpus-schema`, `check:tests-corpus-schema`, `build:tests-corpus`); +1 devDep (`ajv ^8.18.0`) | — |
| `.gitignore` | +1 line (`tests-corpus.json`) | — |
| `package-lock.json` | ajv tree | — |

Total: 8 files, ~1150 new LOC. No existing source/test files modified.

## Verification (current main; no public tests promoted yet)

```
$ npm run generate:tests-corpus-schema
generate_tests_corpus_schema: wrote tests-corpus.schema.json

$ npm run check:tests-corpus-schema
check_tests_corpus_schema: OK

$ npm run build:tests-corpus
build_tests_corpus: wrote tests-corpus.json (0 entries)

$ cat tests-corpus.json
{
  "schemaVersion": "1.0.0",
  "generatedAt": "2026-05-26T...",
  "safeDocxCommit": "<HEAD>",
  "entries": []
}
```

The **empty-entries case proves the pipeline works end-to-end on a clean tree** where no test is yet marked `visibility: 'public'`. Promotion of individual tests is a separate per-test review pass.

```
$ npm run build                       → green
$ npm run lint:workspaces             → green (1 pre-existing warning)
$ npm run test:run                    → green
$ npm run check:test-narratives       → OK (181 test files)
$ npm run check:spec-coverage         → green
$ npm run check:conformance-citations → OK
$ npm run check:conformance-doc       → green
$ git diff main -- spec-compliance/CONFORMANCE.md → empty
```

## Design notes

- **JSON Schema is a CHARACTER-LENGTH constraint, not word-count.** Per-tag bodies use generous `maxLength` (5000+ chars covers any 300-word limit). The TS-side `validateTags` from `@usejunior/test-narrative` is the authoritative word-count enforcer. Documented in the generator's header.
- **`tests-corpus.json` is gitignored.** Only the SCHEMA is checked in; the data regenerates every release. Reviewers see schema changes in PR diffs (catchable); data changes are an artifact of releases.
- **The 14 canonical section identifiers** are encoded as an `enum` in the schema's `SectionIdentifier` definition. Cross-repo renderers iterate the `sections` array and render slabs by identifier.
- **`additionalProperties: false`** throughout, so the schema rejects unknown tag aliases (the `rejectedAliases` from `@usejunior/test-narrative`) at validation time.
- **AJV** is a dev dependency for build-time validation. Not a runtime dep.

## Verification checklist

- [x] `tests-corpus.schema.json` generated from Zod sources; checked in
- [x] CI drift gate (`check:tests-corpus-schema`) exits 0 on clean tree, 1 on drift
- [x] `build:tests-corpus` produces schema-valid `tests-corpus.json`
- [x] Empty-entries case works (no public tests on main)
- [x] AJV validates the emitted JSON before writing
- [x] Release workflow attaches both files to GitHub releases on tag push
- [x] Full repo CI green locally
- [x] `CONFORMANCE.md` byte-identical to `main`
- [x] No existing test/source file modified
- [ ] Peer review (Gemini + Codex) — pending; will be appended below

## What this completes

This PR closes out the entire OpenSpec change `add-test-corpus-narrative` on the safe-docx side. The seven implementation tasks have all landed:

| Task | PR |
|---|---|
| 1 (OpenSpec proposal) | #236 (c79c057) |
| 2 (registry parser lift) | #241 (1d6b6ed) |
| 3 (Zod narrative schema package) | #243 (c1c1c05) |
| 4 (Allure visibility metadata) | #245 (1f21959) |
| 5 (AST extractor + CI gate) | #247 (950cdbc) |
| 6 (Local Codex drafter) | #249 (8b05e79) |
| 3.3 + 7 (Schema + emitter + release workflow) | **this PR** |

Next (out of scope here): cross-repo renderer at `UseJunior/tests-renderer`, and the `usejunior.com/safe-docx/tests/*` Vercel rewrite at `UseJunior/dev-website`.

## Closes

- #250