### PR TITLE
fix(scripts): allure-labels validator false positives on factory self-test and fixture sources

### DIFF
--- a/scripts/validate_allure_test_labels.mjs
+++ b/scripts/validate_allure_test_labels.mjs
@@ -9,6 +9,10 @@ const TEST_PATH_RE = /^packages\/[^/]+\/(src|test)\/.+\.test\.ts$/;
 const ALLURE_EXEMPT_PACKAGES = new Set(['google-docs-core']);
 
 const helperImportRe = /from\s+['"][^'"]*allure-test\.(?:js|ts)['"]/;
+// The allure-test-factory package is the source of the shared helpers; its
+// self-tests construct the wrappers in-process via createAllureTestHelpers,
+// so they satisfy the "use the shared wrappers" rule without an import.
+const factoryConstructorRe = /\bcreateAllureTestHelpers\s*\(/;
 const wrapperReferenceRe = /\b(itAllure|testAllure)\b/;
 const epicWrapperAssignmentRe =
   /(?:const|let|var)\s+\w+\s*=\s*(?:itAllure|testAllure)\.(?:epic\(\s*['"`][^'"`]+['"`]\s*\)|withLabels\(\s*\{[\s\S]*?\bepic\s*:)/m;
@@ -119,14 +123,26 @@ function findSlugFeatureLiteralValues(body) {
 
   return [...values].sort();
 }
+// Strip string-literal contents (backticks, single, double) so that
+// regex-based checks below don't false-positive on fixture source code
+// embedded as strings — e.g., AST-extractor tests that pass synthetic
+// `.openspec(...)` snippets as template-literal inputs.
+function stripStringLiterals(body) {
+  return body
+    .replace(/`(?:\\[\s\S]|[^`\\])*`/g, '``')
+    .replace(/'(?:\\.|[^'\\\n])*'/g, "''")
+    .replace(/"(?:\\.|[^"\\\n])*"/g, '""');
+}
+
 function validateFile(relativePath) {
   const absolutePath = join(ROOT, relativePath);
   const body = readFileSync(absolutePath, 'utf-8');
+  const codeOnlyBody = stripStringLiterals(body);
   const errors = [];
   const isAllureFile = relativePath.endsWith('.allure.test.ts');
-  const isOpenSpecTraceabilityFile = /\.openspec\(/.test(body);
+  const isOpenSpecTraceabilityFile = /\.openspec\(/.test(codeOnlyBody);
 
-  if (!helperImportRe.test(body)) {
+  if (!helperImportRe.test(body) && !factoryConstructorRe.test(body)) {
     errors.push('must import the shared Allure helper (`allure-test`).');
   }
 


### PR DESCRIPTION
## Summary

Main has been red on `allure-labels` since before #254. Two false positives in `scripts/validate_allure_test_labels.mjs`:

- **`packages/allure-test-factory/src/visibility.test.ts`** is the factory's own self-test. It constructs `testAllure` via `createAllureTestHelpers` (the factory's public API) rather than importing a separate `allure-test` helper — which would mean importing the package from itself. The validator's helper-import regex rejected it.

- **`packages/test-narrative/src/astExtractor.test.ts`** writes synthetic `.openspec(...)` snippets to disk as template-literal fixtures so the AST extractor can parse them. The OpenSpec-traceability detector (`/\.openspec\(/`) matched those string-embedded calls and demanded `const TEST_FEATURE = ...` from a file with no real OpenSpec usage.

## Fix

1. Accept `createAllureTestHelpers(` as satisfying the helper-source rule, alongside the existing import check.
2. Strip string-literal contents (backticks, single, double) before applying the `.openspec(` detector so it only sees real code, not fixture source.

## Test plan

- [x] `node scripts/validate_allure_test_labels.mjs` passes locally
- [x] `vitest run` on both affected test files still passes
- [ ] CI green on this PR