### PR TITLE
docs(openspec): align spec text with impl — only canonical README.md is auto-generated

### DIFF
--- a/openspec/changes/add-ecma-376-conformance-framework/design.md
+++ b/openspec/changes/add-ecma-376-conformance-framework/design.md
@@ -109,7 +109,10 @@ expected outputs. (Note: these are package scripts, not standalone
 two outputs from one registry pass:
 
 1. `spec-compliance/CONFORMANCE.md` (full doc).
-2. The HTML-comment-delimited auto-section in every `README*.md`.
+2. The HTML-comment-delimited auto-section in the canonical `README.md`.
+   Localized READMEs are deliberately excluded — see `tasks.md` task 8
+   and #233 for the rationale (hand-translated static content vs. dynamic
+   English marker block).
 
 The drift check runs the generator and fails if either output disagrees
 with the committed version, catching both "I edited the registry but

--- a/openspec/changes/add-ecma-376-conformance-framework/specs/spec-compliance/spec.md
+++ b/openspec/changes/add-ecma-376-conformance-framework/specs/spec-compliance/spec.md
@@ -148,8 +148,8 @@ grammar, and the lint SHALL reject any annotation pointing at a Non-Goal.
 ### Requirement: CONFORMANCE.md and README marker block are generated
 
 The repository SHALL generate `spec-compliance/CONFORMANCE.md` and the
-`<!-- AUTO-GENERATED:conformance-summary -->` marker blocks in every
-`README*.md` from the registry, and the drift check
+`<!-- AUTO-GENERATED:conformance-summary -->` marker block in the canonical
+`README.md` from the registry, and the drift check
 `npm run check:conformance-doc` SHALL fail if either output disagrees
 with the committed version.
 
@@ -165,15 +165,27 @@ with the committed version.
 - **WHEN** a contributor adds a new section to `registry/ecma-376.md`
   but does not run the generator
 - **THEN** `npm run check:conformance-doc` SHALL fail because the
-  generated `CONFORMANCE.md` and README marker blocks are out of date
+  generated `CONFORMANCE.md` and canonical `README.md` marker block are out
+  of date
 
-#### Scenario: missing marker block in README fails drift
+#### Scenario: missing marker block in canonical README fails drift
 
 - **WHEN** a contributor accidentally removes the
   `<!-- AUTO-GENERATED:conformance-summary START -->` …
-  `END` markers from a `README*.md`
+  `END` markers from `README.md`
 - **THEN** `npm run check:conformance-doc` SHALL fail with a clear
   "marker block missing" error
+
+#### Scenario: localized READMEs carry static translated conformance links
+
+- **GIVEN** localized READMEs such as `README.es.md`, `README.zh.md`,
+  `README.pt-br.md`, and `README.de.md`
+- **WHEN** `npm run check:conformance-doc` verifies generated conformance
+  documentation
+- **THEN** the drift gate SHALL NOT verify those localized README files
+- **AND** localized READMEs SHALL carry hand-translated static content that
+  links to `spec-compliance/CONFORMANCE.md` instead of the dynamic
+  `<!-- AUTO-GENERATED:conformance-summary -->` marker block
 
 ### Requirement: `testAllure.conformance({…})` helper
 

--- a/openspec/changes/add-ecma-376-conformance-framework/tasks.md
+++ b/openspec/changes/add-ecma-376-conformance-framework/tasks.md
@@ -54,7 +54,10 @@
   - [ ] `spec-compliance/CONFORMANCE.md` (full doc, includes section table
         with `verifiedBy:` column).
   - [ ] Replaces the `<!-- AUTO-GENERATED:conformance-summary START -->` …
-        `END` block in every `README*.md`.
+        `END` block in the canonical `README.md`. Localized READMEs
+        (`README.es.md`, `README.zh.md`, `README.pt-br.md`, `README.de.md`)
+        carry hand-translated static content and are not touched by the
+        generator (see Task 8 below for the rationale).
 - [ ] `scripts/check_conformance_doc.mjs` (new) — runs the generator then
       `git diff --exit-code` on both files. Mirrors the
       `check:tool-docs` / `check:trust-metrics` package-script pattern.
@@ -72,9 +75,15 @@
 - [ ] Add `## Standards Conformance` section to `README.md` (between
       `## Positioning` and `## Trusted By`) containing the
       `<!-- AUTO-GENERATED:conformance-summary -->` marker block.
-- [ ] Same marker block to `README.es.md`, `README.zh.md`, `README.pt-br.md`,
-      `README.de.md` (English content in phase 1; full localization is a
-      follow-up).
+- [ ] Localized READMEs (`README.es.md`, `README.zh.md`, `README.pt-br.md`,
+      `README.de.md`) carry a **hand-translated static block** with a
+      localized link to `spec-compliance/CONFORMANCE.md`. They do **not**
+      receive the dynamic `<!-- AUTO-GENERATED:conformance-summary -->`
+      marker block, and the drift gate does **not** verify them. Rationale:
+      injecting English content into the middle of a translated file
+      violates the localization contract and risks translators silently
+      breaking the AUTO-GENERATED markers (round-2 peer-review decision
+      on #230; see also #233).
 
 ## 9. Annotate seeds
 - [ ] `packages/docx-core/src/baselines/atomizer/pipeline.ts:418` — add


### PR DESCRIPTION
## Summary

Resolves a documented-vs-actual divergence in the `spec-compliance` capability spec (surfaced by #231 peer review).

The OpenSpec requirement at `openspec/changes/add-ecma-376-conformance-framework/specs/spec-compliance/spec.md` said the auto-generated marker block lives in *every* `README*.md` from the registry, but the implementation (`scripts/generate_conformance_doc.mjs`, `scripts/check_conformance_doc.mjs`) deliberately targets only `README.md`. Localized READMEs carry hand-translated static content per the #230 round-2 peer-review decision.

## Changes

- **Requirement statement**: `every README*.md` → `the canonical README.md`.
- **Scenario** "missing marker block in README fails drift" → renamed to "missing marker block in **canonical** README fails drift" and the body clarifies it targets `README.md` specifically.
- **New scenario** "localized READMEs carry static translated conformance links" documents that the drift gate does NOT verify `README.es.md` / `README.zh.md` / etc., and that those files carry hand-translated content linking to `spec-compliance/CONFORMANCE.md` instead of the dynamic marker block.

## Verification

- [x] `npx openspec validate add-ecma-376-conformance-framework --strict` passes
- [x] No code changes — only `openspec/changes/.../spec-compliance/spec.md` modified

## Closes

- #233