### PR TITLE
fix(ci): npm 11 rejects double-loaded user/global config — split paths

### DIFF
--- a/.github/actions/llm-gate-check/action.yml
+++ b/.github/actions/llm-gate-check/action.yml
@@ -45,15 +45,21 @@ runs:
       # runs `gemini` with GEMINI_API_KEY in env — the output sanitizer can't
       # defend against a malicious binary (it can exfil over network or stderr).
       # Install from $RUNNER_TEMP (no .npmrc), force per-user and global config
-      # to a forced-empty file, pin the registry explicitly.
+      # to forced-empty files, pin the registry explicitly.
+      #
+      # NOTE: the user-config and global-config paths must be DIFFERENT files.
+      # npm 11+ rejects loading the same file in both roles with:
+      #   "double-loading config '<path>' as 'global', previously loaded as 'user'"
+      # (See PR comment on safe-docx#269 for the failing CI log.)
       env:
         GEMINI_CLI_VERSION: ${{ inputs.gemini-cli-version }}
-        NPM_CONFIG_USERCONFIG: ${{ runner.temp }}/llm-gate-empty-npmrc
-        NPM_CONFIG_GLOBALCONFIG: ${{ runner.temp }}/llm-gate-empty-npmrc
+        NPM_CONFIG_USERCONFIG: ${{ runner.temp }}/llm-gate-empty-userconfig
+        NPM_CONFIG_GLOBALCONFIG: ${{ runner.temp }}/llm-gate-empty-globalconfig
         NPM_CONFIG_REGISTRY: https://registry.npmjs.org/
       run: |
         set -euo pipefail
         : > "$NPM_CONFIG_USERCONFIG"
+        : > "$NPM_CONFIG_GLOBALCONFIG"
         cd "$RUNNER_TEMP"
         npm install --silent --no-audit --no-fund --global "@google/gemini-cli@${GEMINI_CLI_VERSION}"
         gemini --version


### PR DESCRIPTION
## Summary

One-line fix to the `.npmrc`-poisoning hardening from #253. That hardening set both `NPM_CONFIG_USERCONFIG` and `NPM_CONFIG_GLOBALCONFIG` to the same path:

```yaml
NPM_CONFIG_USERCONFIG: ${{ runner.temp }}/llm-gate-empty-npmrc
NPM_CONFIG_GLOBALCONFIG: ${{ runner.temp }}/llm-gate-empty-npmrc
```

npm 11+ refuses to load one file in both roles and exits with:

```
Exit prior to config file resolving
cause
double-loading config "/home/runner/work/_temp/llm-gate-empty-npmrc" as "global", previously loaded as "user"
##[error]Process completed with exit code 1.
```

This caused every LLM gate matrix job on PR #268 and #269 (the first PRs to trigger the gate after #253 merged) to fail at the "Install Gemini CLI" step. Phase 1 advisory mode meant the gate's `Aggregate and post review` check is not in required status checks, so those PRs merged anyway — but the gate itself has been unable to produce a verdict for any PR since #253 landed.

## Fix

Use two separate empty-file paths so neither role is double-loaded:

```yaml
NPM_CONFIG_USERCONFIG: ${{ runner.temp }}/llm-gate-empty-userconfig
NPM_CONFIG_GLOBALCONFIG: ${{ runner.temp }}/llm-gate-empty-globalconfig
```

Touch both files before the install. The security property is unchanged — both files are still forced-empty, registry is still pinned, install still runs from `\$RUNNER_TEMP`. Same fix lands in parallel on [open-agreements](https://github.com/open-agreements/open-agreements) (which inherited the bug via the original port direction).

## Verification

- [x] `actionlint .github/workflows/llm-based-quality-gate.yml` clean
- [x] Embedded `settings.json` still parses
- [ ] Next PR after merge: gate should run cleanly through the install step and produce verdicts (this is the actual end-to-end test)

## Test plan

When this PR opens, the gate workflow on the PR will hit the same broken install (because workflows use base-ref source). Expected: same `double-loading` failure as #268/#269. **After merge**, future PRs should see the gate install Gemini cleanly and produce per-item verdicts.