### PR TITLE
docs(scripts): align conformance script headers with canonical-README contract

### DIFF
--- a/scripts/check_conformance_doc.mjs
+++ b/scripts/check_conformance_doc.mjs
@@ -5,8 +5,11 @@
 // `generate_conformance_doc.mjs`, then verifies that the generated outputs
 // match the committed working tree. Fails if either:
 //   - `spec-compliance/CONFORMANCE.md` differs from generator output, or
-//   - any `README*.md` AUTO-GENERATED marker block differs from generator
-//     output.
+//   - the canonical `README.md` AUTO-GENERATED marker block differs from
+//     generator output.
+// Localized READMEs (`README.es.md`, `README.zh.md`, etc.) carry
+// hand-translated static content and are NOT verified by this gate — see
+// `generate_conformance_doc.mjs` for the rationale.
 // Mirrors the package-script pattern used by `check:tool-docs` and
 // `check:trust-metrics`.
 

--- a/scripts/generate_conformance_doc.mjs
+++ b/scripts/generate_conformance_doc.mjs
@@ -4,7 +4,10 @@
 // Generates two outputs from `spec-compliance/registry/*.md`:
 //   1. `spec-compliance/CONFORMANCE.md` — the full normative-claims summary.
 //   2. The `<!-- AUTO-GENERATED:conformance-summary START -->` … `END` block
-//      inside every `README*.md` at the repo root.
+//      inside the canonical `README.md` at the repo root. Localized READMEs
+//      (`README.es.md`, `README.zh.md`, etc.) carry hand-translated static
+//      content and are deliberately excluded — see the README_FILES const
+//      comment below for the rationale.
 //
 // The drift gate `scripts/check_conformance_doc.mjs` runs this script and
 // then `git diff --exit-code` to catch hand edits to either output.


### PR DESCRIPTION
## Summary

Non-blocking follow-up from Codex peer-review on #268 ([review comment](https://github.com/UseJunior/safe-docx/pull/268)): the spec text and implementation constants were aligned to the canonical `README.md` only, but both script-file header comments still mentioned `README*.md`. This PR cleans up those headers and explicitly notes that localized READMEs are excluded by design.

## Changes

- `scripts/generate_conformance_doc.mjs` — header now reads "inside the canonical `README.md` at the repo root. Localized READMEs (`README.es.md`, `README.zh.md`, etc.) carry hand-translated static content and are deliberately excluded — see the `README_FILES` const comment below for the rationale."
- `scripts/check_conformance_doc.mjs` — header now reads "the canonical `README.md` AUTO-GENERATED marker block" plus an explicit sentence: "Localized READMEs ... carry hand-translated static content and are NOT verified by this gate."

No behavior change — these are doc-comment edits only.

## Why this PR exists

Doubles as the **post-merge verification PR for #270** ([npm config double-load fix](https://github.com/UseJunior/safe-docx/pull/270)). When this PR opens, the LLM gate workflow on safe-docx main should now install Gemini cleanly (the `NPM_CONFIG_USERCONFIG`/`NPM_CONFIG_GLOBALCONFIG` paths are no longer the same file) and produce per-item verdicts. If the gate posts a comment with PASS/WARN verdicts, the npm-config fix is confirmed working in production.

Predicted gate behavior:
- All 14 checklist items should run
- Most should return PASS quickly (this PR is docs-only, no OOXML/MCP code touched)
- Item #10 (`SUPPORT.md` Table A drift) might fire substantively since the change touches `spec-compliance/`-adjacent scripts — but should still PASS (this PR doesn't alter SUPPORT.md)
- Total cost target: ~$0.03–$0.05 per the predictions in the Phase 1 PR body

## Verification

- [x] `npm run check:conformance-doc` passes (no drift introduced)
- [ ] LLM gate produces verdict comment on this PR (the real validation we're after)