### PR TITLE
fix(ci): harden LLM-gate against npm config-load failures (closes #273)

### DIFF
--- a/.github/actions/llm-gate-check/action.yml
+++ b/.github/actions/llm-gate-check/action.yml
@@ -60,8 +60,11 @@ runs:
         set -euo pipefail
         : > "$NPM_CONFIG_USERCONFIG"
         : > "$NPM_CONFIG_GLOBALCONFIG"
+        GEMINI_PREFIX="$RUNNER_TEMP/gemini-cli"
         cd "$RUNNER_TEMP"
-        npm install --silent --no-audit --no-fund --global "@google/gemini-cli@${GEMINI_CLI_VERSION}"
+        npm install --silent --no-audit --no-fund --global "@google/gemini-cli@${GEMINI_CLI_VERSION}" --prefix "$GEMINI_PREFIX"
+        echo "$GEMINI_PREFIX/bin" >> "$GITHUB_PATH"
+        export PATH="$GEMINI_PREFIX/bin:$PATH"
         gemini --version
 
     - name: Build settings.json (tool allowlist)
@@ -74,6 +77,9 @@ runs:
         # Top-level `coreTools` / `maxSessionTurns` is silently ignored, which
         # would leave the gate running with default (broader) tool access.
         # See: https://github.com/google-gemini/gemini-cli/blob/v0.39.1/docs/reference/configuration.md
+        # Disable auto-update in CI: the update path shells out to npm before
+        # the model runs, and npm config-load failures look like Gemini startup
+        # failures. The CLI docs define these under `general.*`.
         #
         # The allowlist is intentionally broad so the model can deterministically
         # verify lint/spec/check claims via `npm run *` rather than only
@@ -89,6 +95,10 @@ runs:
         #     by the output sanitizer below.
         cat > .gemini/settings.json <<'JSON'
         {
+          "general": {
+            "enableAutoUpdate": false,
+            "enableAutoUpdateNotification": false
+          },
           "model": {
             "maxSessionTurns": 50
           },
@@ -154,6 +164,16 @@ runs:
         PROMPT_FILE="$RUNNER_TEMP/prompt-${CHECK_ID}.txt"
         compose_prompt "$PROMPT_FILE"
 
+        # The Gemini CLI can invoke npm during startup for package-management
+        # paths such as update checks. Keep the install step's defensive npm
+        # config from leaking into runtime, where npm 11 can abort with
+        # "Exit prior to config file resolving" before Gemini writes JSON.
+        while IFS='=' read -r name _; do
+          case "$name" in
+            npm_config_*|NPM_CONFIG_*) unset "$name" ;;
+          esac
+        done < <(env)
+
         PARSED=""
         ATTEMPTS=0
         MAX_ATTEMPTS=3
@@ -183,6 +203,7 @@ runs:
             GEMINI_EXIT=$?
           fi
 
+          RETRY_REASON="malformed output"
           if [ "$GEMINI_EXIT" -eq 0 ]; then
             # The CLI returns {"response": "<model text>", "stats": {...}}.
             # Extract response, then parse it as our {status, justification} JSON.
@@ -197,25 +218,33 @@ runs:
             fi
             printf 'attempt %d: CLI exit 0 but response JSON did not match {status,justification} contract\n' "$attempt" >> "$DIAG_LOG"
           else
-            printf 'attempt %d: CLI exit %d (no parse attempted)\n' "$attempt" "$GEMINI_EXIT" >> "$DIAG_LOG"
+            if [ ! -s "$RAW" ]; then
+              RETRY_REASON="CLI startup failure before response JSON"
+              printf 'attempt %d: CLI exit %d before writing response JSON\n' "$attempt" "$GEMINI_EXIT" >> "$DIAG_LOG"
+            else
+              RETRY_REASON="CLI failure with unparseable response JSON"
+              printf 'attempt %d: CLI exit %d with non-empty response JSON (no parse attempted)\n' "$attempt" "$GEMINI_EXIT" >> "$DIAG_LOG"
+            fi
           fi
 
           if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
-            echo "::warning::Attempt $attempt for check ${CHECK_ID} produced malformed output; retrying"
-            # Append a short corrective note for the next attempt so the
-            # model knows what went wrong.
-            {
-              printf '\n\n## Note from the workflow (attempt %d failed)\n' "$attempt"
-              printf 'Your previous response did not match the required JSON contract. '
-              printf 'Respond with EXACTLY one line: {"status":"PASS or WARN","justification":"..."}. '
-              printf 'No markdown, no fences, no prose.\n'
-            } >> "$PROMPT_FILE"
+            echo "::warning::Attempt $attempt for check ${CHECK_ID} hit ${RETRY_REASON}; retrying"
+            if [ "$RETRY_REASON" = "malformed output" ]; then
+              # Append a short corrective note for the next attempt so the
+              # model knows what went wrong.
+              {
+                printf '\n\n## Note from the workflow (attempt %d failed)\n' "$attempt"
+                printf 'Your previous response did not match the required JSON contract. '
+                printf 'Respond with EXACTLY one line: {"status":"PASS or WARN","justification":"..."}. '
+                printf 'No markdown, no fences, no prose.\n'
+              } >> "$PROMPT_FILE"
+            fi
           fi
         done
 
         if [ -z "$PARSED" ]; then
-          echo "::warning::Check ${CHECK_ID} fell back to WARN after $MAX_ATTEMPTS malformed attempts"
-          PARSED=$(jq -n '{status: "WARN", justification: "Unable to verify: the LLM produced malformed output across all retry attempts. Review this question manually."}')
+          echo "::warning::Check ${CHECK_ID} fell back to WARN after $MAX_ATTEMPTS unsuccessful attempts"
+          PARSED=$(jq -n '{status: "WARN", justification: "Unable to verify: Gemini CLI failed to produce valid gate output across all retry attempts. Review this question manually."}')
 
           # Surface the last-attempt diagnostic so we can root-cause why all
           # retries failed (auth/quota, model availability, CLI/model

--- a/.github/workflows/llm-based-quality-gate.yml
+++ b/.github/workflows/llm-based-quality-gate.yml
@@ -353,6 +353,9 @@ jobs:
             await core.summary.addRaw(body).write();
 
             const blockingMode = process.env.LLM_GATE_BLOCKING === '1';
+            if (blockingMode && rows.length === 0 && !overrideActive) {
+              core.setFailed('LLM-Based Quality Gate produced no result rows. Failing closed because LLM_GATE_BLOCKING=1.');
+            }
             if (blockingMode && warns > 0 && !overrideActive) {
               core.setFailed(`LLM-Based Quality Gate found ${warns} WARN row(s). Add the \`llm-gate/override\` label to bypass (with justification in a PR comment).`);
             }


### PR DESCRIPTION
## Summary

Three-layer fix for the intermittent `Exit prior to config file resolving` failures in the LLM-Based Quality Gate, plus one defense-in-depth change closing a silent-pass hole that would have surfaced when promoting the gate to enforcing.

## Implementation

Root cause is an npm config-loader failure, not a Gemini API issue. Reproduced locally:

```
Exit prior to config file resolving
cause
double-loading config "/tmp/npmrc.thHOfb" as "global", previously loaded as "user"
```

That string is from npm 11's exit-handler ([source](https://raw.githubusercontent.com/npm/cli/v11.12.1/lib/cli/exit-handler.js)). The Gemini CLI shells out to npm at startup for its auto-update check; the install-time defensive `NPM_CONFIG_USERCONFIG` / `NPM_CONFIG_GLOBALCONFIG` env vars leak into the runtime and trip the double-load assertion on the next npm invocation.

The fix has three layers in `.github/actions/llm-gate-check/action.yml`:

1. **Isolate the install** — `npm install --prefix "$RUNNER_TEMP/gemini-cli"` instead of `--global`, with the bin dir added to `GITHUB_PATH`. Decouples CLI from npm-global config state.
2. **Disable Gemini's startup-time npm calls** — set `general.enableAutoUpdate=false` + `general.enableAutoUpdateNotification=false` in `.gemini/settings.json` per [Gemini CLI config docs](https://raw.githubusercontent.com/google-gemini/gemini-cli/v0.39.1/docs/reference/configuration.md). With auto-update off, the CLI doesn't shell out to npm before serving the model request.
3. **Defense in depth** — `unset` all inherited `npm_config_*` / `NPM_CONFIG_*` env vars before invoking `gemini`. If any future code path still shells out to npm, it loads npm's defaults instead of the install-time defensive config.

Additional hardening on a separate (but related) risk:

4. **Retry on CLI startup failure** — the retry loop previously only fired on malformed model JSON; CLI-startup failures failed the matrix job on attempt 1. Now both classes retry up to 3 times. The retry diagnostics distinguish "CLI startup failure before response JSON" from "CLI failure with unparseable response JSON" from "malformed output" for easier root-causing.
5. **Fail closed on zero results in blocking mode** — `.github/workflows/llm-based-quality-gate.yml` aggregate step now calls `core.setFailed` when `LLM_GATE_BLOCKING=1` and no result rows were produced. Closes the silent-pass hole — previously a "NO RESULTS" run with `LLM_GATE_BLOCKING=1` still let the required check pass.

## Verification

- [x] `actionlint .github/workflows/llm-based-quality-gate.yml`: pass
- [x] YAML parse on both changed files: pass
- [x] Local repro of the original `Exit prior to config file resolving` error confirmed the npm config-double-load trigger
- [ ] Peer review (Gemini + Codex) — pending; will be appended below
- [ ] CI on this PR runs the gate against the new code (the workflow checks out the PR head for the composite action; if the fix works, this PR's gate run produces 14 verdicts instead of "NO RESULTS")

## Follow-up after merge

Once this lands, re-run the gate on the ~10 most recent PRs via `workflow_dispatch` and confirm every run produces actual verdicts. Once ~10 consecutive clean runs, promote:

```bash
gh variable set LLM_GATE_BLOCKING --body 1 --repo UseJunior/safe-docx
# Then add "Aggregate and post review" to required branch-protection contexts
```

## Closes

- #273