### PR TITLE
fix(ci): pass --repo to gh pr view in workflow_dispatch path (closes #275)

### DIFF
--- a/.github/workflows/llm-based-quality-gate.yml
+++ b/.github/workflows/llm-based-quality-gate.yml
@@ -82,7 +82,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            gh pr view "$DISPATCH_PR_NUMBER" --json headRefOid,headRefName,baseRefName,labels,headRepository,headRepositoryOwner > "$RUNNER_TEMP/pr.json"
+            gh pr view "$DISPATCH_PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json headRefOid,headRefName,baseRefName,labels,headRepository,headRepositoryOwner > "$RUNNER_TEMP/pr.json"
             # SECURITY: the job-level `if:` permits workflow_dispatch
             # unconditionally; the same-repo gate (`head.repo.full_name ==
             # github.repository`) is only enforced for pull_request events. Without


### PR DESCRIPTION
## Summary

One-line fix to make the LLM-gate's `workflow_dispatch` path work. Currently a manual re-run via `gh workflow run llm-based-quality-gate.yml -f pr_number=<N>` fails at the `Resolve PR context` step before any check runs.

## Implementation

In `.github/workflows/llm-based-quality-gate.yml`, the `Resolve PR context` step runs before any checkout. The workflow_dispatch branch calls `gh pr view "$DISPATCH_PR_NUMBER"` without `--repo`, so `gh` falls back to inferring the repo from the working-directory git remote — which doesn't exist yet, producing `fatal: not a git repository`. The `pull_request` event path is unaffected because it reads from `github.event.pull_request.*`, not `gh`.

Diff:

```diff
-            gh pr view "$DISPATCH_PR_NUMBER" --json headRefOid,headRefName,baseRefName,labels,headRepository,headRepositoryOwner > "$RUNNER_TEMP/pr.json"
+            gh pr view "$DISPATCH_PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json headRefOid,headRefName,baseRefName,labels,headRepository,headRepositoryOwner > "$RUNNER_TEMP/pr.json"
```

## Verification

- [x] `actionlint .github/workflows/llm-based-quality-gate.yml`: pass
- [x] YAML parse: pass
- [ ] Peer review (Gemini + Codex) — pending; will be appended below
- [ ] Post-merge: dispatch the workflow against a recent PR and confirm a 14-item gate comment lands

## Repro of the original bug

Run [26519152791](https://github.com/UseJunior/safe-docx/actions/runs/26519152791) — dispatched against PR #270, failed at `Resolve PR context` with:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
##[error]Process completed with exit code 1.
```

## Closes

- #275

## Related

- Surfaced during the post-merge smoke for #274.
- The same fix should be applied to `UseJunior/tests-renderer`'s analogous workflow in a separate small PR.