### PR TITLE
chore(gitignore): ignore Office lock files (~$*)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ node_modules/
 dist/
 *.tgz
 .DS_Store
+# Office lock files (Word/Excel/PowerPoint create these while a file is open)
+~$*
 .mcpregistry_*
 # Allure report artifacts (any depth)
 allure-results/


### PR DESCRIPTION
## Summary
- Add `~$*` to `.gitignore` so Office lock files don't show up in `git status` during DOCX fixture or template work.

## Why
Word/Excel/PowerPoint create lock files like `~$test-doc.docx` next to the open document. When testing or authoring DOCX fixtures locally with the document open in Word, these land in `git status` and can be accidentally staged.

## Test plan
- [ ] CI green.
- [ ] `git check-ignore -v ~\$foo.docx` prints the new rule.