### PR TITLE
chore(readme): UTM-tag usejunior.com privacy link across all 5 READMEs

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -300,7 +300,7 @@ npm run coverage:matrix
 
 ## Datenschutz
 
-Safe Docx läuft vollständig auf deinem lokalen Rechner. Es werden keine Dokumenteninhalte an externe Server gesendet. Siehe unsere [Datenschutzrichtlinie](https://usejunior.com/privacy_policy) für Details.
+Safe Docx läuft vollständig auf deinem lokalen Rechner. Es werden keine Dokumenteninhalte an externe Server gesendet. Siehe unsere [Datenschutzrichtlinie](https://usejunior.com/privacy_policy?utm_source=github&utm_medium=readme&utm_campaign=safe-docx) für Details.
 
 ## Governance
 

--- a/README.es.md
+++ b/README.es.md
@@ -299,7 +299,7 @@ npm run coverage:matrix
 
 ## Privacidad
 
-Safe Docx se ejecuta completamente en tu máquina local. No se envía contenido de documentos a servidores externos. Consulta nuestra [Política de Privacidad](https://usejunior.com/privacy_policy) para más detalles.
+Safe Docx se ejecuta completamente en tu máquina local. No se envía contenido de documentos a servidores externos. Consulta nuestra [Política de Privacidad](https://usejunior.com/privacy_policy?utm_source=github&utm_medium=readme&utm_campaign=safe-docx) para más detalles.
 
 ## Gobernanza
 

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ npm run coverage:matrix
 
 ## Privacy
 
-Safe Docx runs entirely on your local machine. No document content is sent to external servers. See our [Privacy Policy](https://usejunior.com/privacy_policy) for details.
+Safe Docx runs entirely on your local machine. No document content is sent to external servers. See our [Privacy Policy](https://usejunior.com/privacy_policy?utm_source=github&utm_medium=readme&utm_campaign=safe-docx) for details.
 
 ## Governance
 

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -299,7 +299,7 @@ npm run coverage:matrix
 
 ## Privacidade
 
-Safe Docx é executado inteiramente na sua máquina local. Nenhum conteúdo de documento é enviado para servidores externos. Consulte nossa [Política de Privacidade](https://usejunior.com/privacy_policy) para detalhes.
+Safe Docx é executado inteiramente na sua máquina local. Nenhum conteúdo de documento é enviado para servidores externos. Consulte nossa [Política de Privacidade](https://usejunior.com/privacy_policy?utm_source=github&utm_medium=readme&utm_campaign=safe-docx) para detalhes.
 
 ## Governança
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -297,7 +297,7 @@ npm run coverage:matrix
 
 ## 隐私
 
-Safe Docx 完全在你的本地机器上运行。不会向外部服务器发送任何文档内容。详见我们的[隐私政策](https://usejunior.com/privacy_policy)。
+Safe Docx 完全在你的本地机器上运行。不会向外部服务器发送任何文档内容。详见我们的[隐私政策](https://usejunior.com/privacy_policy?utm_source=github&utm_medium=readme&utm_campaign=safe-docx)。
 
 ## 治理
 


### PR DESCRIPTION
## Summary

Single change applied across all five language READMEs (en, es, zh, de, pt-br): append \`?utm_source=github&utm_medium=readme&utm_campaign=safe-docx\` to the \`https://usejunior.com/privacy_policy\` link.

## Why

GA4 on usejunior.com shows 68% of homepage sessions as "Direct" with poor engagement, and the site owner doesn't currently know where Direct traffic comes from. Some of it is README clicks from this repo — those strip the referrer header when navigating cross-origin, so without UTM they collapse into Direct. Tagging the link makes GitHub-driven traffic surface as \`session_source=github\` in GA4.

Same campaign treatment landing in parallel on \`open-agreements/open-agreements\` and \`UseJunior/email-agent-mcp\`.

## Test plan

- [x] All 5 READMEs updated, one URL each
- [x] No other links touched (CC, GitHub, etc.)
- [x] \`sync_readme_blocks.mjs\` doesn't sync the privacy block, so translations stay correct after a future sync