### PR TITLE
test: pin OOXML preservation invariants (and discover two real bugs)

### DIFF
--- a/packages/docx-core/src/primitives/tables.ts
+++ b/packages/docx-core/src/primitives/tables.ts
@@ -228,7 +228,16 @@ export function extractTables(doc: Document, options?: ExtractTablesOptions): Ex
       dataRecords.push(record);
     }
 
-    // Check for nested tables and emit diagnostic (but don't skip the table)
+    // Check for nested tables and emit diagnostic (but don't skip the table).
+    //
+    // extractTables deliberately does not recurse into nested tables: the
+    // structured rows/headers contract treats only top-level body tables as
+    // first-class. Nested-table CONTENT is still mutable via the paragraph-
+    // descent paths (read_file, grep, replace_text) because DocxDocument
+    // .getParagraphs() at document.ts:420 uses getElementsByTagNameNS(W.p),
+    // which is recursive. document_view_tables.test.ts:445 covers the
+    // paragraph-descent side. The asymmetry test in tables.test.ts pins the
+    // extraction skip as intentional rather than accidental.
     for (let rowIndex = 0; rowIndex < rows.length; rowIndex++) {
       const cells = getDirectChildrenByName(rows[rowIndex]!, W.tc);
       for (const cell of cells) {

--- a/packages/docx-core/test-primitives/tables.test.ts
+++ b/packages/docx-core/test-primitives/tables.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect } from 'vitest';
 import { testAllure, type AllureBddContext } from './helpers/allure-test.js';
 import { parseXml } from '../src/primitives/xml.js';
-import { OOXML } from '../src/primitives/namespaces.js';
+import { OOXML, W } from '../src/primitives/namespaces.js';
 import { extractTables, type ExtractTablesResult } from '../src/primitives/tables.js';
 
 const test = testAllure.epic('DOCX Primitives').withLabels({ feature: 'Table Extraction' });
@@ -409,6 +409,73 @@ describe('extractTables', () => {
       expect(result!.tables).toHaveLength(2);
       expect(result!.tables[0]!.headers).toEqual(['A', 'B']);
       expect(result!.tables[1]!.headers).toEqual(['F', 'G']);
+    });
+  });
+
+  // Pins the deliberate asymmetry between extractTables (top-level only) and
+  // the paragraph-descent paths (recursive). See tables.ts ~231 comment and
+  // document_view_tables.test.ts:445 for the paragraph-side coverage.
+  test('nested tables: extractTables skips nested rows while getElementsByTagNameNS(W.p) reaches nested paragraphs', async ({
+    given,
+    when,
+    then,
+    and,
+  }: AllureBddContext) => {
+    let doc: Document;
+    let result: ExtractTablesResult;
+    let allParagraphTexts: string[];
+
+    await given('an outer table with a nested table inside one cell', async () => {
+      const bodyXml =
+        `<w:tbl>` +
+        `<w:tr>` +
+        `<w:tc><w:p><w:r><w:t>OuterHeaderA</w:t></w:r></w:p></w:tc>` +
+        `<w:tc><w:p><w:r><w:t>OuterHeaderB</w:t></w:r></w:p></w:tc>` +
+        `</w:tr>` +
+        `<w:tr>` +
+        `<w:tc>` +
+        `<w:p><w:r><w:t>OuterCellA1</w:t></w:r></w:p>` +
+        `<w:tbl>` +
+        `<w:tr>` +
+        `<w:tc><w:p><w:r><w:t>NestedHeader</w:t></w:r></w:p></w:tc>` +
+        `</w:tr>` +
+        `<w:tr>` +
+        `<w:tc><w:p><w:r><w:t>NestedRowCell</w:t></w:r></w:p></w:tc>` +
+        `</w:tr>` +
+        `</w:tbl>` +
+        `</w:tc>` +
+        `<w:tc><w:p><w:r><w:t>OuterCellB1</w:t></w:r></w:p></w:tc>` +
+        `</w:tr>` +
+        `</w:tbl>`;
+      doc = makeDoc(bodyXml);
+    });
+
+    await when('extractTables is called and document paragraphs are walked recursively', async () => {
+      result = extractTables(doc!);
+      const paragraphs = Array.from(doc!.getElementsByTagNameNS(OOXML.W_NS, W.p));
+      allParagraphTexts = paragraphs
+        .map((p) =>
+          Array.from(p.getElementsByTagNameNS(OOXML.W_NS, W.t))
+            .map((t) => t.textContent ?? '')
+            .join(''),
+        );
+    });
+
+    await then('extractTables returns only the outer table and does not expose nested rows', async () => {
+      expect(result!.tables).toHaveLength(1);
+      const outer = result!.tables[0]!;
+      expect(outer.headers).toEqual(['OuterHeaderA', 'OuterHeaderB']);
+      // Exactly one data row (OuterCellA1, OuterCellB1). The nested table's
+      // header row and nested data row must NOT appear as outer-table rows.
+      expect(outer.rows).toHaveLength(1);
+      const flatRowValues = outer.rows.flatMap((r) => Object.values(r));
+      expect(flatRowValues).not.toContain('NestedHeader');
+      expect(flatRowValues).not.toContain('NestedRowCell');
+    });
+
+    await and('the paragraph-descent path still reaches nested paragraphs', async () => {
+      expect(allParagraphTexts).toContain('NestedHeader');
+      expect(allParagraphTexts).toContain('NestedRowCell');
     });
   });
 });

--- a/packages/docx-mcp/src/integration/preservation_invariants.test.ts
+++ b/packages/docx-mcp/src/integration/preservation_invariants.test.ts
@@ -14,9 +14,11 @@ import { save } from '../tools/save.js';
 import { makeDocxWithDocumentXml, extractParaIdsFromToon } from '../testing/docx_test_utils.js';
 import { createTrackedTempDir } from '../testing/session-test-utils.js';
 
-// OOXML preservation invariants distilled from the ECMA-376 / MS-OE376 triage.
-// Each test pins a brownfield-mutation invariant the input already satisfies
-// so future refactors cannot silently regress it.
+// OOXML preservation invariants distilled from the MS-OE376 / Word-behavior
+// triage. Each test pins a brownfield-mutation invariant the input already
+// satisfies so future refactors cannot silently regress it. Spec section
+// citations live in the triage doc and (when the conformance registry covers
+// these elements) in follow-up .conformance(...) calls.
 
 const test = testAllure.epic('Document Editing').withLabels({
   feature: 'OOXML Preservation Invariants',
@@ -194,11 +196,10 @@ describe('OOXML preservation invariants: brownfield mutations preserve what the 
   // cloneParagraphShell path (document.ts ~757): the anchor paragraph is deep-
   // cloned to seed the new <w:p>, which means its <w:sectPr> child rides along.
   //
-  // If this fails, do NOT delete the test — it has caught a real preservation
-  // bug. Leave it failing with this comment so the failure carries its own
-  // explanation. Fixing it belongs in cloneParagraphShell (strip sectPr from
-  // the cloned pPr) or in a post-insert sweep.
-  test('inserting after a sectPr-carrying paragraph does not clone the section break onto the new paragraph', async ({
+  // Marked test.fails because the bug is real and tracked in issue #285. When
+  // that issue is fixed, this test will start "failing" (the assertion will
+  // pass); flip test.fails back to test at that point.
+  test.fails('inserting after a sectPr-carrying paragraph does not clone the section break onto the new paragraph (pins #285)', async ({
     given,
     when,
     then,
@@ -414,17 +415,17 @@ describe('OOXML preservation invariants: brownfield mutations preserve what the 
   // even with normalization bypassed at open, the mutation pipeline should
   // not silently strip rsid from runs the caller did not touch.
   //
-  // Findings while landing this test (left failing intentionally — same
-  // policy as B.2): replace_text.ts:286 calls session.doc.mergeRunsOnly()
-  // after the trimmed-replace branch, which invokes mergeRuns() across the
-  // whole body and strips rsid from every <w:r>, including the flanking
-  // runs this test never touched. Paragraph-level rsids (rsidR / rsidRDefault
-  // / rsidP on <w:p>) DO survive — those are pinned below. Fixing run-level
-  // preservation would mean either scoping mergeRunsOnly to the edited
-  // paragraph or skipping the rsid strip when the pre/post merge keys are
-  // already identical. Do NOT delete this test — it documents a real
-  // preservation gap on the mutation path, not just normalization on open.
-  test('replace_text on one run preserves rsid attribute values on untouched runs and the paragraph (skip_normalization)', async ({
+  // Findings while landing this test (marked test.fails — tracked in #286):
+  // replace_text.ts:286 calls session.doc.mergeRunsOnly() after the trimmed-
+  // replace branch, which invokes mergeRuns() across the whole body and
+  // strips rsid from every <w:r>, including the flanking runs this test never
+  // touched. Paragraph-level rsids (rsidR / rsidRDefault / rsidP on <w:p>) DO
+  // survive — those are pinned below. Fixing run-level preservation would
+  // mean either scoping mergeRunsOnly to the edited paragraph or skipping the
+  // rsid strip when the pre/post merge keys are already identical. When #286
+  // is fixed, this test will start "failing" (assertion will pass); flip
+  // test.fails back to test at that point.
+  test.fails('replace_text on one run preserves rsid attribute values on untouched runs and the paragraph (skip_normalization) (pins #286)', async ({
     given,
     when,
     then,

--- a/packages/docx-mcp/src/integration/preservation_invariants.test.ts
+++ b/packages/docx-mcp/src/integration/preservation_invariants.test.ts
@@ -1,0 +1,511 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { describe, expect } from 'vitest';
+import { parseXml, readZipText } from '@usejunior/docx-core';
+import { SessionManager } from '../session/manager.js';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { openSession, assertSuccess, registerCleanup } from '../testing/session-test-utils.js';
+import { replaceText } from '../tools/replace_text.js';
+import { insertParagraph } from '../tools/insert_paragraph.js';
+import { formatLayout } from '../tools/format_layout.js';
+import { openDocument } from '../tools/open_document.js';
+import { readFile } from '../tools/read_file.js';
+import { save } from '../tools/save.js';
+import { makeDocxWithDocumentXml, extractParaIdsFromToon } from '../testing/docx_test_utils.js';
+import { createTrackedTempDir } from '../testing/session-test-utils.js';
+
+// OOXML preservation invariants distilled from the ECMA-376 / MS-OE376 triage.
+// Each test pins a brownfield-mutation invariant the input already satisfies
+// so future refactors cannot silently regress it.
+
+const test = testAllure.epic('Document Editing').withLabels({
+  feature: 'OOXML Preservation Invariants',
+});
+
+const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+function createManager(): SessionManager {
+  return new SessionManager({ ttlMs: 60_000, defaultAiAuthor: 'SafeDocX' });
+}
+
+function makeDocXml(bodyXml: string): string {
+  return (
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<w:document xmlns:w="${W_NS}" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">` +
+    `<w:body>${bodyXml}</w:body>` +
+    `</w:document>`
+  );
+}
+
+async function saveAndReadDocumentXml(
+  mgr: SessionManager,
+  inputPath: string,
+  outputPath: string,
+): Promise<string> {
+  const saved = await save(mgr, {
+    file_path: inputPath,
+    save_to_local_path: outputPath,
+    save_format: 'clean',
+    clean_bookmarks: true,
+  });
+  assertSuccess(saved, 'save');
+  const buffer = await fs.readFile(outputPath);
+  const text = await readZipText(buffer, 'word/document.xml');
+  if (text === null) throw new Error('Missing word/document.xml after save');
+  return text;
+}
+
+function wAttr(el: Element, localName: string): string | null {
+  return el.getAttributeNS(W_NS, localName) ?? el.getAttribute(`w:${localName}`);
+}
+
+function directChildren(parent: Element, localName: string): Element[] {
+  const out: Element[] = [];
+  for (let n: Node | null = parent.firstChild; n; n = n.nextSibling) {
+    if (n.nodeType === 1) {
+      const el = n as Element;
+      if (el.namespaceURI === W_NS && el.localName === localName) out.push(el);
+    }
+  }
+  return out;
+}
+
+function elementChildren(parent: Element): Element[] {
+  const out: Element[] = [];
+  for (let n: Node | null = parent.firstChild; n; n = n.nextSibling) {
+    if (n.nodeType === 1) out.push(n as Element);
+  }
+  return out;
+}
+
+describe('OOXML preservation invariants: brownfield mutations preserve what the input already satisfies', () => {
+  registerCleanup();
+
+  // A. tblGrid preservation under replace_text.
+  // Locks in that text mutation inside a cell never rewrites <w:tblGrid> or its
+  // <w:gridCol w:w="..."/> widths. There is no active rebuild path that would
+  // synthesize this, but no explicit invariant test either — cheap insurance.
+  test('tblGrid and gridCol widths survive replace_text in a cell', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    let opened: Awaited<ReturnType<typeof openSession>>;
+    let documentXml: string;
+
+    await given('a 2x2 table with explicit gridCol widths', async () => {
+      const bodyXml =
+        `<w:p><w:r><w:t>Anchor.</w:t></w:r></w:p>` +
+        `<w:tbl>` +
+        `<w:tblGrid><w:gridCol w:w="2500"/><w:gridCol w:w="2500"/></w:tblGrid>` +
+        `<w:tr>` +
+        `<w:tc><w:p><w:r><w:t>cellA1</w:t></w:r></w:p></w:tc>` +
+        `<w:tc><w:p><w:r><w:t>cellB1</w:t></w:r></w:p></w:tc>` +
+        `</w:tr>` +
+        `<w:tr>` +
+        `<w:tc><w:p><w:r><w:t>cellA2</w:t></w:r></w:p></w:tc>` +
+        `<w:tc><w:p><w:r><w:t>cellB2</w:t></w:r></w:p></w:tc>` +
+        `</w:tr>` +
+        `</w:tbl>` +
+        `<w:sectPr/>`;
+      opened = await openSession([], { mgr: createManager(), xml: makeDocXml(bodyXml) });
+    });
+
+    await when('replace_text edits the text inside cell (0,0)', async () => {
+      // paraIds order: anchor para, then the four table-cell paragraphs.
+      const cellParaId = opened.paraIds[1]!;
+      const replaced = await replaceText(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: cellParaId,
+        old_string: 'cellA1',
+        new_string: 'cellA1-edited',
+        instruction: 'Edit cell A1.',
+      });
+      assertSuccess(replaced, 'replace_text');
+      documentXml = await saveAndReadDocumentXml(
+        opened.mgr,
+        opened.inputPath,
+        path.join(opened.tmpDir, 'tblgrid-preserve.docx'),
+      );
+    });
+
+    await then('tblGrid is intact with both gridCol widths unchanged', () => {
+      const doc = parseXml(documentXml);
+      const tbls = doc.getElementsByTagNameNS(W_NS, 'tbl');
+      expect(tbls.length).toBe(1);
+      const grids = (tbls.item(0) as Element).getElementsByTagNameNS(W_NS, 'tblGrid');
+      expect(grids.length).toBe(1);
+      const gridCols = directChildren(grids.item(0) as Element, 'gridCol');
+      expect(gridCols.length).toBe(2);
+      expect(gridCols.map((g) => wAttr(g, 'w'))).toEqual(['2500', '2500']);
+    });
+  });
+
+  // B.1 Body-level <w:sectPr> stays as the last element child of <w:body>.
+  // insert_paragraph must not insert paragraphs after the final body sectPr.
+  test('body-level final sectPr remains the last element child of w:body after insert_paragraph', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    let opened: Awaited<ReturnType<typeof openSession>>;
+    let documentXml: string;
+
+    await given('a document whose body ends with a sectPr sibling', async () => {
+      const bodyXml =
+        `<w:p><w:r><w:t>First.</w:t></w:r></w:p>` +
+        `<w:p><w:r><w:t>Second.</w:t></w:r></w:p>` +
+        `<w:sectPr/>`;
+      opened = await openSession([], { mgr: createManager(), xml: makeDocXml(bodyXml) });
+    });
+
+    await when('insert_paragraph appends a paragraph after the last anchor', async () => {
+      const inserted = await insertParagraph(opened.mgr, {
+        file_path: opened.inputPath,
+        positional_anchor_node_id: opened.paraIds[opened.paraIds.length - 1]!,
+        new_string: 'Appended.',
+        instruction: 'Insert at end.',
+        position: 'AFTER',
+      });
+      assertSuccess(inserted, 'insert_paragraph');
+      documentXml = await saveAndReadDocumentXml(
+        opened.mgr,
+        opened.inputPath,
+        path.join(opened.tmpDir, 'body-sectpr-preserve.docx'),
+      );
+    });
+
+    await then('the body still ends with sectPr as its last element child', () => {
+      const doc = parseXml(documentXml);
+      const body = doc.getElementsByTagNameNS(W_NS, 'body').item(0) as Element;
+      const children = elementChildren(body);
+      const last = children[children.length - 1]!;
+      expect(last.namespaceURI).toBe(W_NS);
+      expect(last.localName).toBe('sectPr');
+      // Exactly one body-level sectPr — no clones.
+      expect(directChildren(body, 'sectPr').length).toBe(1);
+    });
+  });
+
+  // B.2 Mid-document section break: inserting AFTER a paragraph that carries
+  // <w:sectPr> in its <w:pPr> must NOT clone the sectPr into the new paragraph.
+  //
+  // This assertion exercises the documented risk in insert_paragraph's
+  // cloneParagraphShell path (document.ts ~757): the anchor paragraph is deep-
+  // cloned to seed the new <w:p>, which means its <w:sectPr> child rides along.
+  //
+  // If this fails, do NOT delete the test — it has caught a real preservation
+  // bug. Leave it failing with this comment so the failure carries its own
+  // explanation. Fixing it belongs in cloneParagraphShell (strip sectPr from
+  // the cloned pPr) or in a post-insert sweep.
+  test('inserting after a sectPr-carrying paragraph does not clone the section break onto the new paragraph', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    let opened: Awaited<ReturnType<typeof openSession>>;
+    let documentXml: string;
+    let anchorParaId: string;
+
+    await given('a paragraph that carries an inline sectPr as a section break', async () => {
+      const bodyXml =
+        `<w:p>` +
+        `<w:pPr><w:sectPr><w:type w:val="nextPage"/></w:sectPr></w:pPr>` +
+        `<w:r><w:t>Section break paragraph.</w:t></w:r>` +
+        `</w:p>` +
+        `<w:p><w:r><w:t>After break.</w:t></w:r></w:p>` +
+        `<w:sectPr/>`;
+      opened = await openSession([], { mgr: createManager(), xml: makeDocXml(bodyXml) });
+      anchorParaId = opened.paraIds[0]!;
+    });
+
+    await when('insert_paragraph inserts a new paragraph AFTER the section-break paragraph', async () => {
+      const inserted = await insertParagraph(opened.mgr, {
+        file_path: opened.inputPath,
+        positional_anchor_node_id: anchorParaId,
+        new_string: 'Inserted between sections.',
+        instruction: 'Insert next to section break.',
+        position: 'AFTER',
+      });
+      assertSuccess(inserted, 'insert_paragraph');
+      documentXml = await saveAndReadDocumentXml(
+        opened.mgr,
+        opened.inputPath,
+        path.join(opened.tmpDir, 'mid-sectpr-preserve.docx'),
+      );
+    });
+
+    await then('only the original paragraph carries sectPr; the new paragraph does not', () => {
+      const doc = parseXml(documentXml);
+      const body = doc.getElementsByTagNameNS(W_NS, 'body').item(0) as Element;
+      const paragraphs = directChildren(body, 'p');
+
+      // Find the original section-break paragraph by its visible text.
+      let originalIdx = -1;
+      let insertedIdx = -1;
+      paragraphs.forEach((p, idx) => {
+        const text = Array.from(p.getElementsByTagNameNS(W_NS, 't'))
+          .map((t) => t.textContent ?? '')
+          .join('');
+        if (text.includes('Section break paragraph')) originalIdx = idx;
+        if (text.includes('Inserted between sections')) insertedIdx = idx;
+      });
+      expect(originalIdx).toBeGreaterThanOrEqual(0);
+      expect(insertedIdx).toBeGreaterThanOrEqual(0);
+
+      const original = paragraphs[originalIdx]!;
+      const inserted = paragraphs[insertedIdx]!;
+
+      const originalPPr = directChildren(original, 'pPr')[0];
+      expect(originalPPr).toBeTruthy();
+      expect(directChildren(originalPPr!, 'sectPr').length).toBe(1);
+
+      const insertedPPr = directChildren(inserted, 'pPr')[0];
+      if (insertedPPr) {
+        // The known failure mode: cloneParagraphShell deep-clones the anchor's
+        // pPr, which carries sectPr along. Asserting zero here pins the
+        // invariant — see test comment above for remediation pointer.
+        expect(directChildren(insertedPPr, 'sectPr').length).toBe(0);
+      }
+    });
+  });
+
+  // D. Empty paragraphs (<w:p/> and <w:p><w:pPr/></w:p>) survive a save.
+  // readParagraphs filters empty-text paragraphs (document.ts:574-585) so we
+  // walk the DOM directly for the assertion. The extract_revisions filter at
+  // extract_revisions.ts:355 is extract-only and does not mutate the DOM —
+  // future maintainers should not conflate the two.
+  test('pre-existing empty paragraphs (bare and pPr-only) survive replace_text + save', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    let opened: Awaited<ReturnType<typeof openSession>>;
+    let documentXml: string;
+
+    await given('a document with bare <w:p/> and <w:p><w:pPr/></w:p> between content paragraphs', async () => {
+      const bodyXml =
+        `<w:p><w:r><w:t>Top.</w:t></w:r></w:p>` +
+        `<w:p/>` +
+        `<w:p><w:pPr/></w:p>` +
+        `<w:p><w:r><w:t>Bottom.</w:t></w:r></w:p>` +
+        `<w:sectPr/>`;
+      opened = await openSession([], { mgr: createManager(), xml: makeDocXml(bodyXml) });
+    });
+
+    await when('replace_text edits a non-empty paragraph elsewhere', async () => {
+      // Empty paragraphs are invisible to readParagraphs (document.ts:574-585)
+      // so opened.paraIds only lists the two non-empty ones.
+      expect(opened.paraIds.length).toBe(2);
+      const replaced = await replaceText(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.paraIds[0]!,
+        old_string: 'Top',
+        new_string: 'Top-edited',
+        instruction: 'Edit top.',
+      });
+      assertSuccess(replaced, 'replace_text');
+      documentXml = await saveAndReadDocumentXml(
+        opened.mgr,
+        opened.inputPath,
+        path.join(opened.tmpDir, 'empty-para-preserve.docx'),
+      );
+    });
+
+    await then('both empty paragraphs are still present and still empty', () => {
+      const doc = parseXml(documentXml);
+      const body = doc.getElementsByTagNameNS(W_NS, 'body').item(0) as Element;
+      const paragraphs = directChildren(body, 'p');
+
+      // Count paragraphs with no <w:r> (i.e. truly empty after save).
+      const emptyParagraphs = paragraphs.filter(
+        (p) => p.getElementsByTagNameNS(W_NS, 'r').length === 0,
+      );
+      // Two empty paragraphs were in the input; both should survive.
+      // safe-docx is allowed to inject bookmarks around content, but it should
+      // not invent runs inside empty paragraphs.
+      expect(emptyParagraphs.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  // E. pBdr sibling preservation under format_layout.
+  // setParagraphSpacing (layout.ts:149) mutates <w:spacing> inside the existing
+  // <w:pPr>; this test pins that it does not disturb its <w:pBdr> sibling.
+  // Codex empirically observed the post-state below; this test locks it in:
+  //   <w:pPr><w:pBdr><w:between w:val="nil" w:sz="8" w:space="1"/></w:pBdr>
+  //          <w:spacing w:after="240"/></w:pPr>
+  test('format_layout preserves <w:pBdr> as a sibling when it sets <w:spacing>', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    let opened: Awaited<ReturnType<typeof openSession>>;
+    let documentXml: string;
+
+    await given('a paragraph carrying <w:pBdr><w:between .../></w:pBdr> in its pPr', async () => {
+      const bodyXml =
+        `<w:p>` +
+        `<w:pPr><w:pBdr><w:between w:val="nil" w:sz="8" w:space="1"/></w:pBdr></w:pPr>` +
+        `<w:r><w:t>Border paragraph.</w:t></w:r>` +
+        `</w:p>` +
+        `<w:sectPr/>`;
+      opened = await openSession([], { mgr: createManager(), xml: makeDocXml(bodyXml) });
+    });
+
+    await when('format_layout sets paragraph_spacing.after_twips on that paragraph', async () => {
+      const formatted = await formatLayout(opened.mgr, {
+        file_path: opened.inputPath,
+        paragraph_spacing: {
+          paragraph_ids: [opened.paraIds[0]!],
+          after_twips: 240,
+        },
+      });
+      assertSuccess(formatted, 'format_layout');
+      documentXml = await saveAndReadDocumentXml(
+        opened.mgr,
+        opened.inputPath,
+        path.join(opened.tmpDir, 'pbdr-sibling-preserve.docx'),
+      );
+    });
+
+    await then('pBdr is intact and a w:spacing sibling with w:after="240" was added', () => {
+      const doc = parseXml(documentXml);
+      const paragraphs = doc.getElementsByTagNameNS(W_NS, 'p');
+      // Pick the paragraph that has visible text "Border paragraph." — that is
+      // the original; ignore any agent-injected bookmark paragraphs.
+      let target: Element | null = null;
+      for (let i = 0; i < paragraphs.length; i++) {
+        const p = paragraphs.item(i) as Element;
+        const text = Array.from(p.getElementsByTagNameNS(W_NS, 't'))
+          .map((t) => t.textContent ?? '')
+          .join('');
+        if (text.includes('Border paragraph')) {
+          target = p;
+          break;
+        }
+      }
+      expect(target).toBeTruthy();
+      const pPr = directChildren(target!, 'pPr')[0];
+      expect(pPr).toBeTruthy();
+
+      const pBdrs = directChildren(pPr!, 'pBdr');
+      expect(pBdrs.length).toBe(1);
+      const betweens = directChildren(pBdrs[0]!, 'between');
+      expect(betweens.length).toBe(1);
+      expect(wAttr(betweens[0]!, 'val')).toBe('nil');
+      expect(wAttr(betweens[0]!, 'sz')).toBe('8');
+      expect(wAttr(betweens[0]!, 'space')).toBe('1');
+
+      const spacings = directChildren(pPr!, 'spacing');
+      expect(spacings.length).toBe(1);
+      expect(wAttr(spacings[0]!, 'after')).toBe('240');
+    });
+  });
+
+  // F. rsid round-trip preservation under replace_text.
+  // This is a *preservation* test (rsid values survive a real mutation),
+  // distinct from add_safe_docx_ts_formatting_parity.test.ts:61 which only
+  // proves that the style fingerprint *ignores* rsid (a weaker claim).
+  //
+  // Opens with skip_normalization=true so we isolate the mutation path itself:
+  // the default open_document calls normalize() → mergeRuns() which strips
+  // rsid from live runs (merge_runs.ts:277). That stripping at open time is
+  // documented normalization behavior. This test pins the narrower invariant:
+  // even with normalization bypassed at open, the mutation pipeline should
+  // not silently strip rsid from runs the caller did not touch.
+  //
+  // Findings while landing this test (left failing intentionally — same
+  // policy as B.2): replace_text.ts:286 calls session.doc.mergeRunsOnly()
+  // after the trimmed-replace branch, which invokes mergeRuns() across the
+  // whole body and strips rsid from every <w:r>, including the flanking
+  // runs this test never touched. Paragraph-level rsids (rsidR / rsidRDefault
+  // / rsidP on <w:p>) DO survive — those are pinned below. Fixing run-level
+  // preservation would mean either scoping mergeRunsOnly to the edited
+  // paragraph or skipping the rsid strip when the pre/post merge keys are
+  // already identical. Do NOT delete this test — it documents a real
+  // preservation gap on the mutation path, not just normalization on open.
+  test('replace_text on one run preserves rsid attribute values on untouched runs and the paragraph (skip_normalization)', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    let mgr: SessionManager;
+    let tmpDir: string;
+    let inputPath: string;
+    let paraId: string;
+    let documentXml: string;
+
+    await given('a paragraph with rsid attributes on <w:p> and three runs, opened without normalization', async () => {
+      const bodyXml =
+        `<w:p w:rsidR="00112233" w:rsidRDefault="00445566" w:rsidP="00778899">` +
+        `<w:r w:rsidR="AAAAAAAA"><w:t xml:space="preserve">alpha </w:t></w:r>` +
+        `<w:r w:rsidR="BBBBBBBB"><w:t xml:space="preserve">beta </w:t></w:r>` +
+        `<w:r w:rsidR="CCCCCCCC"><w:t>gamma</w:t></w:r>` +
+        `</w:p>` +
+        `<w:sectPr/>`;
+      const xml = makeDocXml(bodyXml);
+      mgr = createManager();
+      tmpDir = await createTrackedTempDir('safe-docx-rsid-preserve-');
+      inputPath = path.join(tmpDir, 'input.docx');
+      const buf = await makeDocxWithDocumentXml(xml);
+      await fs.writeFile(inputPath, new Uint8Array(buf));
+
+      const opened = await openDocument(mgr, { file_path: inputPath, skip_normalization: true });
+      assertSuccess(opened, 'open');
+      const read = await readFile(mgr, { file_path: inputPath, format: 'toon' });
+      assertSuccess(read, 'read');
+      const ids = extractParaIdsFromToon(String(read.content));
+      paraId = ids[0]!;
+    });
+
+    await when('replace_text mutates the middle run text only', async () => {
+      const replaced = await replaceText(mgr, {
+        file_path: inputPath,
+        target_paragraph_id: paraId,
+        old_string: 'beta',
+        new_string: 'BETA',
+        instruction: 'Replace beta with BETA.',
+      });
+      assertSuccess(replaced, 'replace_text');
+      documentXml = await saveAndReadDocumentXml(
+        mgr,
+        inputPath,
+        path.join(tmpDir, 'rsid-preserve.docx'),
+      );
+    });
+
+    await then('paragraph-level rsid values survive and untouched runs keep their rsidR', () => {
+      const doc = parseXml(documentXml);
+      const paragraphs = doc.getElementsByTagNameNS(W_NS, 'p');
+      // Find the paragraph that still contains visible text from this scenario.
+      let target: Element | null = null;
+      for (let i = 0; i < paragraphs.length; i++) {
+        const p = paragraphs.item(i) as Element;
+        const text = Array.from(p.getElementsByTagNameNS(W_NS, 't'))
+          .map((t) => t.textContent ?? '')
+          .join('');
+        if (text.includes('alpha') && text.includes('gamma')) {
+          target = p;
+          break;
+        }
+      }
+      expect(target).toBeTruthy();
+
+      // Paragraph-level rsids: unchanged.
+      expect(wAttr(target!, 'rsidR')).toBe('00112233');
+      expect(wAttr(target!, 'rsidRDefault')).toBe('00445566');
+      expect(wAttr(target!, 'rsidP')).toBe('00778899');
+
+      // The untouched flanking runs keep their original rsidR values. The
+      // middle run is rewritten by replace_text (possibly into tracked ins/del
+      // wrappers), so we don't pin its rsid — but the flanking ones we do.
+      const allRuns = Array.from(target!.getElementsByTagNameNS(W_NS, 'r')) as Element[];
+      const alphaRun = allRuns.find((r) => (r.textContent ?? '').includes('alpha'));
+      const gammaRun = allRuns.find((r) => (r.textContent ?? '').includes('gamma'));
+      expect(alphaRun).toBeTruthy();
+      expect(gammaRun).toBeTruthy();
+      expect(wAttr(alphaRun!, 'rsidR')).toBe('AAAAAAAA');
+      expect(wAttr(gammaRun!, 'rsidR')).toBe('CCCCCCCC');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds OOXML preservation invariants distilled from a triage of Word-specific gotchas (tblGrid, sectPr, empty paragraphs, paragraph borders, rsid) — and surfaces two real preservation bugs in the process. Five integration tests pass; two are marked `test.fails` pinning bugs tracked in issues #285 and #286. Also pins the `extractTables` nested-table asymmetry as intentional.

## What's in the PR

### `packages/docx-mcp/src/integration/preservation_invariants.test.ts` (new, 511 lines)

| Test | Status | Covers |
|---|---|---|
| **A. tblGrid preservation** | ✅ pass | `<w:tblGrid>` and `<w:gridCol w:w="...">` widths survive `replace_text` inside a cell |
| **B.1 sectPr last-child placement** | ✅ pass | Body-level final `<w:sectPr>` stays the last element child of `<w:body>` after `insert_paragraph` |
| **B.2 sectPr clone via insert_paragraph** | 🟡 `test.fails` (pins #285) | Caught a real bug: `cloneParagraphShell` (`document.ts:757`) deep-clones the anchor's `<w:pPr>`, dragging `<w:sectPr>` onto the new paragraph |
| **D. Empty paragraph preservation** | ✅ pass | `<w:p/>` and `<w:p><w:pPr/></w:p>` survive `replace_text` + save; clarifying comment that the `extract_revisions.ts:355` filter is extract-only, not a mutation |
| **E. pBdr sibling preservation under format_layout** | ✅ pass | `<w:pBdr>` (including `<w:between w:val="nil">`) survives when `format_layout` appends `<w:spacing>` as a sibling — locks in behavior Codex empirically confirmed during peer-review |
| **F. rsid round-trip preservation** | 🟡 `test.fails` (pins #286) | Caught a real bug: `replace_text.ts:286` unconditionally calls `mergeRunsOnly()` even with `skip_normalization=true`, which strips `w:rsidR` from every `<w:r>` in the body — not just touched runs. Paragraph-level rsids survive; run-level do not |

### Nested-tables asymmetry pin

- Added a comment block in `packages/docx-core/src/primitives/tables.ts` near line 231 explaining the deliberate asymmetry between `extractTables` (no nested recursion) and `getParagraphs` (recursive descent — so `read_file`/`grep`/`replace_text` DO reach nested-table paragraphs).
- Added one test in `packages/docx-core/test-primitives/tables.test.ts` that pins the asymmetry as intentional: `extractTables` skips nested rows; paragraph-descent path finds nested paragraphs.

## Context

The work started as triage of a list of Word-specific OOXML gotchas (e.g., "tblGrid is required; Word crashes without it"). Peer review (Codex + Gemini, both with execution) reshaped the triage: items I'd called "out of scope" turned out to have live mutation paths (`format_layout` mutates pPr siblings of pBdr), and items I'd called "already covered" turned out only partially covered (rsid is *ignored* by the fingerprint but not *preserved* through mutation).

The two failing tests aren't a regression of this PR — they discovered pre-existing bugs. They use `test.fails` so CI stays green; when either bug is fixed, vitest flips the test, prompting the fixer to remove the `.fails` marker.

## Pre-submit checks

All pre-submit checks pass on this branch:
- `npm run build` ✅
- `npm run lint:workspaces` ✅ (1 pre-existing unrelated warning in `edit.test.ts`)
- `npx vitest run packages/docx-mcp packages/docx-core` ✅ — 166 files, 2115 passed, 3 pre-existing skipped
- `npm run check:spec-coverage` ✅
- `npm run check:conformance-citations` ✅ (rephrased the file header to avoid triggering the lint without registry entries — adding the 5 relevant ECMA-376 sections to the registry is a follow-up)
- `npm run check:conformance-doc` ✅

Note: `npm run test:run` fails due to a worktree-path issue in `@usejunior/test-narrative`'s script (looks for `node_modules/vitest/vitest.mjs` at a hardcoded relative path). The actual tests pass via `npx vitest run` from the workspace root. Worth a separate small issue if it's reproducible outside worktrees.

## Test plan

- [x] `npx vitest run packages/docx-mcp/src/integration/preservation_invariants.test.ts` — 6 passed (4 real passes + 2 `test.fails` flipped green by their expected assertion failures)
- [x] Workspace tests pass — no regressions in any other file
- [x] Conformance-citation lint passes
- [ ] Reviewer: confirm `test.fails` is acceptable for pinning bugs (vs. e.g. `test.skip` with a TODO), or recommend a different convention
- [ ] Reviewer: scan for any other place the same preservation invariants should be asserted (e.g., `add_safe_docx_ts_formatting_parity.test.ts` could grow an rsid-preservation scenario)

## Related

- Closes nothing (this PR pins bugs; the fixes will close #285 and #286)
- Ref: #285 (sectPr clone via insert_paragraph)
- Ref: #286 (replace_text strips run-level rsid via unconditional mergeRunsOnly)