### PR TITLE
ci(llm-gate): mirror conclusion to PR head SHA on workflow_dispatch

### DIFF
--- a/.github/workflows/llm-based-quality-gate.yml
+++ b/.github/workflows/llm-based-quality-gate.yml
@@ -261,6 +261,11 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      # `checks: write` lets the workflow_dispatch mirror step POST an
+      # explicit check_run to /repos/.../check-runs. Without it, the mirror
+      # POST returns 403 and PRs re-fired via workflow_dispatch stay
+      # `mergeStateStatus: BLOCKED` (the bug this whole step exists to fix).
+      checks: write
     steps:
       - name: Download all per-item results
         if: ${{ needs.parse-checklist.outputs.skip_gate != 'true' && needs.parse-checklist.outputs.count != '0' }}
@@ -275,6 +280,7 @@ jobs:
         run: ls -la results/ || echo "no results downloaded"
 
       - name: Compose and post checklist comment
+        id: compose
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           MODEL: ${{ env.GEMINI_MODEL }}
@@ -401,3 +407,41 @@ jobs:
             if (blockingMode && warns > 0 && !overrideActive) {
               core.setFailed(`LLM-Based Quality Gate found ${warns} WARN row(s). Add the \`llm-gate/override\` label to bypass (with justification in a PR comment).`);
             }
+
+      # When this workflow is re-fired via `workflow_dispatch` (e.g. after a
+      # push that bypassed the `synchronize`-blind PR trigger), the auto-
+      # generated check_run for this job IS attached to the PR's head SHA,
+      # but GitHub's PR `statusCheckRollup` (which branch protection
+      # consults) does NOT include workflow_dispatch-triggered check_runs.
+      # The required check appears green via the Checks API but the PR stays
+      # `mergeStateStatus: BLOCKED`. POST an explicit check_run mirror so
+      # the rollup picks it up.
+      #
+      # `always()` is critical: when the gate finds WARN rows and the
+      # github-script step calls core.setFailed(), the default `if: success()`
+      # would skip this mirror. The mirror's own conclusion is derived from
+      # the prior step's outcome, so a failed gate produces a failed mirror.
+      - name: Mirror conclusion to PR head SHA (workflow_dispatch)
+        if: always() && github.event_name == 'workflow_dispatch' && needs.parse-checklist.outputs.head_sha != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ needs.parse-checklist.outputs.head_sha }}
+          COMPOSE_OUTCOME: ${{ steps.compose.outcome }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          if [ "$COMPOSE_OUTCOME" = "success" ]; then
+            CONCLUSION="success"
+            TITLE="LLM gate passed (re-fired via workflow_dispatch)"
+          else
+            CONCLUSION="failure"
+            TITLE="LLM gate FAILED (re-fired via workflow_dispatch)"
+          fi
+          gh api -X POST "repos/$GITHUB_REPOSITORY/check-runs" \
+            -f "name=Aggregate and post review" \
+            -f "head_sha=$HEAD_SHA" \
+            -f "status=completed" \
+            -f "conclusion=$CONCLUSION" \
+            -f "details_url=$RUN_URL" \
+            -f "output[title]=$TITLE" \
+            -f "output[summary]=Mirrored from workflow_dispatch run. Full output: $RUN_URL"


### PR DESCRIPTION
## Summary

Ports the LLM-gate check-mirror fix from open-agreements ([open-agreements/open-agreements#393](https://github.com/open-agreements/open-agreements/pull/393), commit `60582ad`) to safe-docx. Three surgical edits to `.github/workflows/llm-based-quality-gate.yml`:

1. Add `checks: write` to the aggregate job's `permissions:` block.
2. Add `id: compose` to the "Compose and post checklist comment" step.
3. Append a "Mirror conclusion to PR head SHA (workflow_dispatch)" step that POSTs an explicit `check_run` to `/repos/.../check-runs`.

## Why

When the LLM gate is re-fired via `workflow_dispatch` (the documented manual re-trigger after pushing fixes for a WARN), GitHub's PR `statusCheckRollup` — which branch protection consults — does **not** include `workflow_dispatch`-triggered check_runs. The check appears green in the Checks API but the PR stays `mergeStateStatus: BLOCKED`. The only workaround today is toggling PR draft status (or the `llm-gate/override` label) to force a `pull_request` event.

The explicit check_run POST DOES appear in `statusCheckRollup`, so branch protection sees it.

## Living evidence in open-agreements

PR [open-agreements/open-agreements#360](https://github.com/open-agreements/open-agreements/pull/360) has two "Aggregate and post review" entries on its head SHA — one auto-generated, one mirrored. That's the in-the-wild proof the same fix works.

## Behavior under existing knobs

- **Normal PR triggers** (`opened`, `ready_for_review`, label toggle): mirror step is skipped by its `github.event_name == 'workflow_dispatch'` guard — single check entry, unchanged behavior.
- **`skip_gate` (package-lock-only PRs)**: the compose step still succeeds with a SKIPPED comment, so the mirror posts a passing check_run — same semantics branch protection would see from a normal skip_gate PR-triggered run.
- **WARN rows in blocking mode**: compose calls `core.setFailed()`, mirror's `always()` guard runs it anyway, and `COMPOSE_OUTCOME != "success"` produces a failing check_run — fails closed on WARN.

## Test plan

- [ ] Wait for CI on this PR to confirm no regression on the `pull_request` path (single "Aggregate and post review" check as today).
- [ ] After merge, on any open safe-docx PR, run `gh workflow run llm-based-quality-gate.yml -R UseJunior/safe-docx -f pr_number=<N>` and verify:
  - [ ] Two "Aggregate and post review" check_runs appear on the PR head SHA (one auto, one mirrored).
  - [ ] `gh pr view <N> --json statusCheckRollup` shows the mirrored check (the auto-generated one will not appear in the rollup — that's the bug being worked around).
  - [ ] `mergeStateStatus` is `CLEAN` (assuming other required checks pass), not `BLOCKED`.
- [ ] Negative test on a future WARN: confirm the mirrored check is a `failure` (not `success`) when the gate finds WARN rows in blocking mode.