### PR TITLE
fix(docx-core): strip sectPr from cloned paragraph shell in insert_paragraph

### DIFF
--- a/packages/docx-core/src/primitives/document.ts
+++ b/packages/docx-core/src/primitives/document.ts
@@ -762,6 +762,13 @@ export class DocxDocument {
         if (child.nodeType === 1 && isWTag(child as Element, W.pPr)) continue;
         newP.removeChild(child);
       }
+      // sectPr is the section terminator — must stay on the anchor, not propagate to the new paragraph.
+      const clonedPPr = getDirectChildrenByName(newP, W.pPr)[0];
+      if (clonedPPr) {
+        for (const sectPr of getDirectChildrenByName(clonedPPr, 'sectPr')) {
+          clonedPPr.removeChild(sectPr);
+        }
+      }
       return newP;
     }
 

--- a/packages/docx-mcp/src/integration/preservation_invariants.test.ts
+++ b/packages/docx-mcp/src/integration/preservation_invariants.test.ts
@@ -191,15 +191,9 @@ describe('OOXML preservation invariants: brownfield mutations preserve what the 
 
   // B.2 Mid-document section break: inserting AFTER a paragraph that carries
   // <w:sectPr> in its <w:pPr> must NOT clone the sectPr into the new paragraph.
-  //
-  // This assertion exercises the documented risk in insert_paragraph's
-  // cloneParagraphShell path (document.ts ~757): the anchor paragraph is deep-
-  // cloned to seed the new <w:p>, which means its <w:sectPr> child rides along.
-  //
-  // Marked test.fails because the bug is real and tracked in issue #285. When
-  // that issue is fixed, this test will start "failing" (the assertion will
-  // pass); flip test.fails back to test at that point.
-  test.fails('inserting after a sectPr-carrying paragraph does not clone the section break onto the new paragraph (pins #285)', async ({
+  // sectPr is a section terminator, so propagating it would fragment the
+  // document's section model.
+  test('inserting after a sectPr-carrying paragraph does not clone the section break onto the new paragraph', async ({
     given,
     when,
     then,
@@ -263,9 +257,6 @@ describe('OOXML preservation invariants: brownfield mutations preserve what the 
 
       const insertedPPr = directChildren(inserted, 'pPr')[0];
       if (insertedPPr) {
-        // The known failure mode: cloneParagraphShell deep-clones the anchor's
-        // pPr, which carries sectPr along. Asserting zero here pins the
-        // invariant — see test comment above for remediation pointer.
         expect(directChildren(insertedPPr, 'sectPr').length).toBe(0);
       }
     });


### PR DESCRIPTION
## Summary

Fixes #285. `insert_paragraph` was deep-cloning the anchor paragraph's `<w:pPr>` wholesale via `cloneParagraphShell`, which carried any inline `<w:sectPr>` (section terminator) onto the newly-inserted paragraph. The result: a single section in the input became two sections in the output — a silent fragmentation of Word's section model.

This change strips direct-child `<w:sectPr>` from the cloned `<w:pPr>` before returning the new paragraph shell. The anchor keeps its section terminator; the inserted paragraph joins the existing section, matching what Word does when you press Enter at the end of a section-terminating paragraph.

PR #287 already pinned this bug with `test.fails(...)` in B.2 of `preservation_invariants.test.ts`. This change flips that test back to a passing `test(...)` and rewrites the surrounding comment as an invariant description rather than a bug-pin. The F test (#286, run-level rsid stripping) is intentionally untouched.

## Diff shape

- `packages/docx-core/src/primitives/document.ts` — 7 lines added inside `cloneParagraphShell` after the existing pPr-preservation loop. Uses the existing `getDirectChildrenByName` helper; no new imports.
- `packages/docx-mcp/src/integration/preservation_invariants.test.ts` — `test.fails(...)` → `test(...)`, ` (pins #285)` stripped from the test name, comment block rewritten as invariant.

## Peer review

Reviewed via `/peer-review` with both Codex (dynamic, executed tests) and Gemini (static, explicitly flagged unverified execution claims).

- **Codex**: "No merge-blocking findings." Verified the fix is in the right place (`cloneParagraphShell` has exactly one caller — `insertParagraph` at `document.ts:883`), confirmed `getDirectChildrenByName` is direct-child + W-namespace filtered and accepts bare local names, and confirmed B.2 setup exercises the fix correctly.
- **Gemini**: APPROVED on code correctness. Verified the helper, namespace constants, empty-pPr legality, and `ensureParagraphRunProperties` `insertBefore` ordering (falls back to `pPrChange` or `null`/appendChild when no sectPr).

## Test results (worktree, pre-push)

| Suite | Result |
|---|---|
| `preservation_invariants.test.ts` | 6/6 pass; only F still `.fails` for #286 |
| 25 `insert_paragraph`-touching test files (Codex `rg` selection) | 267/267 pass |
| 14 `sectPr`-touching test files (Codex `rg` selection) | 245/245 pass |
| `npm run build`, `lint:workspaces`, `check:spec-coverage`, `check:conformance-citations`, `check:conformance-doc` | all OK |
| Full `npx vitest run` | 2272 pass, 38 skipped (2 pre-existing `scripts/*.test.mjs` suite-load failures unrelated to this change) |

Rebased onto current `origin/main` (`fb9b2f9`) before pushing.

## Test plan

- [ ] CI passes
- [ ] Post-merge smoke against real Bonterms NDA confirms `insert_paragraph` adjacent to a Word-authored section break leaves only one sectPr per section