### PR TITLE
test(docx-comparison): field-bearing fast-check arbitrary for the Lean spec bridge

### DIFF
--- a/openspec/changes/add-field-bearing-bridge-arbitrary/design.md
+++ b/openspec/changes/add-field-bearing-bridge-arbitrary/design.md
@@ -1,0 +1,63 @@
+# Design — field-bearing fast-check arbitrary for the Lean spec bridge
+
+## Context
+
+`lean-spec-bridge.test.ts` empirically falsifies two named residual axioms about this repo's inplace `compareDocumentXml` output:
+
+- `compareDocumentXml_output_preservation_friendly` — INV-FIELD-001: field structure survives accept-all / reject-all on the combined output.
+- `compareDocumentXml_output_text_roundtrip` — INV-RT-001: `accept(combined)` text-equals the revised input and `reject(combined)` text-equals the original, under `normalizeText`.
+
+Property coverage (`pairArb`, `trackedPairArb`, 100 runs each) is field-free by design; field-bearing coverage is three hand-written fixtures over one `COMPLETE_NUMPAGES_FIELD`. This change adds a field-bearing fast-check arbitrary so both axioms are exercised over field type × operation × placement rather than three fixed XML strings.
+
+The two existing field fixtures already establish the engine facts this design leans on:
+
+- The **insert** fixture (`:893`) stays inplace and passes the *strong* `assertRecursivelyWellformed`.
+- The **delete** fixture (`:924`) stays inplace but can pass only the *weak* `assertFieldInvariant`, because post-#217 the inplace atomizer fragments deleted fields (fldChars unwrapped at sibling level, `<w:del>` wrapping only the `delInstrText` / `delText` payload), so the `<w:del>` subtree has an empty *local* field stack and is not `fieldContextNeutral` under `∀ ctx`.
+
+## Decision 1: per-operation assertion strength is load-bearing, not a workaround
+
+`assertRecursivelyWellformed` checks the **stronger** per-subtree `fieldContextNeutral ∀ ctx` property; `assertFieldInvariant` checks the **weaker** document-level `validateFieldStructure(accept)` ∧ `validateFieldStructure(reject)`. The post-#220 residual axiom `compareDocumentXml_output_preservation_friendly` was deliberately weakened to the document-level property precisely because fragmented deletes do not satisfy the per-subtree one (`lean-spec-bridge.test.ts:937-951` documents this on the delete fixture).
+
+Therefore the field-bearing property must dispatch by operation:
+
+- `field-insert` / `field-stable` / `text-only` (no field deletion) → assert **both** `assertRecursivelyWellformed` (strong audit gate) **and** `assertFieldInvariant`.
+- `field-delete` → assert **only** `assertFieldInvariant` (document-level), matching the axiom's actual post-#220 strength.
+
+Applying the strong check uniformly would make the arbitrary fail on legitimate engine output (a false positive on every deletion) — it would be testing the pre-#217 engine, not the current one. Applying only the weak check uniformly would silently lose the audit-gate signal on inserts (the "engine has not regressed into emitting partial-wrapper fragments unexpectedly" guard, `:699-707`). The split preserves both: maximum strength where the engine supports it, axiom-faithful strength where it does not. The operation tag the arbitrary already carries (to realize the insert/delete/stable difference) is exactly the discriminator, so no extra XML inspection is needed.
+
+**Alternative considered — infer strength from the output XML** (e.g. "if any `<w:del>` contains `delInstrText`, use the weak check"). Rejected: it couples the test to the engine's current fragmentation representation (the thing under test), and re-derives a fact the generator already knows. The operation tag is the honest discriminator.
+
+## Decision 2: fallback is falsification + coverage floor, not `fc.pre` filtering
+
+The two theorems are premised on `compareDocumentXml a b = some combined`; pairs where inplace mode fails are out of the spec's scope. The file currently treats fallback as falsification (`assertInplaceResult` throws `triage=inplace-fallback`) and justifies it by the generators being "paragraph-only, table-free, and field-free, so [`ContainerResolutionError`] is not expected to fire" (`:30-35`). A field-bearing arbitrary changes that premise.
+
+**Options.**
+
+- **A — `fc.pre(result.modeUsed === 'inplace')`.** Filter out any pair that falls back, formally honoring the `some combined` precondition. Risk: a generator that *always* falls back would make the property pass **vacuously** — a silent coverage hole. fast-check's `fc.pre` rejections are invisible unless the discard rate is asserted. This is exactly the "silent cap" the repo's `feedback_asymmetry_of_rot` / "no silent caps" discipline rejects.
+- **B — keep fallback as falsification, constrain the generator to inplace-safe operation shapes, add an operation-coverage floor.** (Recommended.) The existing insert/delete fixtures prove the engine handles whole-field-at-run-boundary insert and delete inplace (both `assertInplaceResult` and pass). The arbitrary generates only those proven-inplace operation shapes (complete fields as atomic units at run boundaries; no fragmented modification, no nesting, no paragraph-spanning fields). Any fallback then signals a real regression and should fail loudly. The operation/field-type coverage assertion (`assertTrackedScenarioCoverage` analogue) doubles as the floor: if the generator degenerated such that an operation family never ran, the coverage assertion fails instead of the property passing on a shrunken input space.
+
+**Choice: B.** It keeps the falsifiability strong (fallback = failure, with `triage` diagnostics) and makes coverage gaps loud, at the cost of a deliberately narrower operation set than "any field-bearing document." That narrowing is correct for this change: the broader, harder surfaces (fragmented field modification, nested fields, paragraph-spanning fields) are explicitly out of scope and are where fallback is *expected*, not a regression. Mixing them in would force option A and reintroduce the silent-hole risk.
+
+**Residual risk acknowledged:** option B asserts the engine *stays* inplace on a wider input space than the two fixtures. If some complete-field placement the arbitrary can reach (but the fixtures did not) legitimately falls back, the property will fail with `triage=inplace-fallback` and we will either (a) discover a real inplace regression, or (b) discover the operation shape is not as inplace-safe as assumed and tighten the generator. Either outcome is informative; neither is a silent pass. This is the intended forcing function, not a flake to suppress — the triage diagnostics distinguish the two.
+
+## Decision 3: clean inputs, no pre-tracking (field-bearing analogue of `pairArb`, not `trackedPairArb`)
+
+`trackedPairArb` feeds **pre-tracked** documents (the input already carries `w:ins` / `w:del`), which is why it needs the `w:del`-on-`a` / `w:ins`-on-`b` guard (`:270-271`) to avoid falsifying INV-RT-001 *by construction*. This arbitrary generates **clean** original/revised documents and lets the engine produce all tracking — the same shape as `pairArb` and the three field fixtures. Consequences:
+
+- No by-construction INV-RT-001 risk; no `w:del`/`w:ins` side guard needed.
+- The field operation is realized by the **difference** between two clean sides (field present on one side, absent/identical on the other), not by emitting tracked markup into the input.
+- `extractTextWithParagraphs` over a clean field-bearing input counts the field **result** text (`<w:t>` payload, e.g. NUMPAGES `"3"`) and ignores `instrText` / `fldChar`; so `field-stable` and `text-only` round-trips include the result text on both sides, and `field-insert` / `field-delete` round-trips add/remove exactly that result text — which is what the engine's accept/reject must reproduce.
+
+## Decision 4: reuse the three existing complete-field constants; add a builder helper only if needed
+
+The arbitrary draws fields from `COMPLETE_NUMPAGES_FIELD` / `COMPLETE_PAGE_FIELD` / `COMPLETE_PAGEREF_FIELD` (`ooxml-fixtures.ts:47-66`) rather than minting new field XML — re-deriving field shapes inline is the cross-file drift issue #221 was filed to prevent (`ooxml-fixtures.ts:1-19`, AGENTS.md "Test Fixtures"). If a `paragraphWithField(text, field)` body-XML helper is needed, it lands in `ooxml-fixtures.ts`, not inline. The arbitrary itself (operation selection, coverage tracking) is test-specific orchestration and stays in `lean-spec-bridge.test.ts`, like the existing `trackedScenario*Arb` arbitraries.
+
+## What stays out of scope
+
+- Fragmented field modification (`FRAGMENTED_NUMPAGES_MODIFICATION`), nested fields, paragraph-spanning fields — harder surfaces where inplace fallback is expected; a separate follow-up.
+- Field bodies inside comment/footnote parts (the file already scopes comment/footnote coverage to `document.xml` anchors only, `:50-51`).
+- Any Lean change or discharge of the residual axioms (Tier 3).
+
+## Residual obligations after this change
+
+Unchanged from `add-inv-rt-001-proof`: both residual axioms remain Tier-3-owned; this change only widens their empirical falsifiability over field-bearing inputs. No `sorry` is introduced (no Lean change). The Lean↔TS extensional-equivalence gap (Tier 2.5) is unaffected.

--- a/openspec/changes/add-field-bearing-bridge-arbitrary/proposal.md
+++ b/openspec/changes/add-field-bearing-bridge-arbitrary/proposal.md
@@ -1,0 +1,64 @@
+# Change: Field-bearing fast-check arbitrary for the Lean spec bridge
+
+## Why
+
+The Lean spike is now zero-`sorry` (closed by `add-inv-rt-001-proof`, PR #293) and carries exactly two named residual axioms about this repo's inplace `compareDocumentXml` output:
+
+- `compareDocumentXml_output_preservation_friendly` (Tier 2, `add-ooxml-doc-subset-and-inv-field-001-proof`) — the INV-FIELD-001 obligation.
+- `compareDocumentXml_output_text_roundtrip` (Tier 2, `add-inv-rt-001-proof`) — the INV-RT-001 obligation.
+
+`packages/docx-core/src/integration/lean-spec-bridge.test.ts` is the falsifiability layer for both axioms: it fails if either invariant breaks on real engine output. But its **property-based** coverage (the `pairArb` and `trackedPairArb` fast-check arbitraries, 100 runs each) is entirely **field-free** — the file header records this as an intentional spike limitation ("Field-bearing input families still live in `collapsed-field-inplace.test.ts`"). The only field-bearing coverage in the bridge file is **three hand-written single fixtures**, all over one `COMPLETE_NUMPAGES_FIELD` shape:
+
+- INV-FIELD-001 field-insert (`lean-spec-bridge.test.ts:893`) — asserts the strong `assertRecursivelyWellformed`.
+- INV-FIELD-001 field-delete (`lean-spec-bridge.test.ts:924`) — asserts only the document-level `assertFieldInvariant` (the `<w:del>` subtrees are not context-neutral post-#217).
+- INV-RT-001 field-insert round-trip (`lean-spec-bridge.test.ts:971`).
+
+A single fixture per operation falsifies an axiom only on that exact XML. The residual axioms are stated **universally** over `(a, b)`; the field-bearing surface — where `w:fldChar` / `w:instrText` / `w:delInstrText` atoms exercise the field-walk in `pipeline.ts` and the `delInstrText → instrText` rename in `trackChangesAcceptorAst.ts` — is the **riskiest** part of that surface and the one with the weakest empirical grounding. Both the Tier 2 and the INV-RT-001 changes explicitly deferred a full field-bearing fast-check arbitrary to this successor change, by name:
+
+> "The full arbitrary is a separate follow-up." — `add-ooxml-doc-subset-and-inv-field-001-proof/tasks.md`, naming `add-field-bearing-bridge-arbitrary`.
+> "the full field-bearing fast-check arbitrary stays a separate follow-up, consistent with how `add-field-bearing-bridge-arbitrary` was split out of Tier 2." — `add-inv-rt-001-proof/design.md`
+> "the arbitrary opens as `add-field-bearing-bridge-arbitrary`." — `verification/ROADMAP.md:128-129`
+
+This change is that successor. It adds a field-bearing fast-check arbitrary that drives randomly-generated complete-field documents through the live inplace engine and asserts INV-FIELD-001 and INV-RT-001 across many runs — lifting field-bearing coverage from three fixed XML strings to a property over field type × field operation × placement.
+
+Tracking: no dedicated GitHub issue; the follow-up is named in `verification/ROADMAP.md`, `add-ooxml-doc-subset-and-inv-field-001-proof/tasks.md`, and `add-inv-rt-001-proof/{proposal,design}.md`. This change carries **no Lean changes and no production-engine changes** — it is test-layer only.
+
+## What Changes
+
+All changes are inside `packages/docx-core/src/integration/lean-spec-bridge.test.ts` and (if new primitives are needed) `packages/docx-core/src/testing/ooxml-fixtures.ts`. No Lean files, no production engine code.
+
+- **New `fieldBearingPairArb` arbitrary.** Generates a clean (non-pre-tracked) `(original, revised)` body-XML pair built with `buildDocxFromBodyXml`, mirroring the existing field fixtures' construction. Each side is a small paragraph array; selected paragraphs carry a **complete, self-contained field** drawn from the three existing constants `COMPLETE_NUMPAGES_FIELD` / `COMPLETE_PAGE_FIELD` / `COMPLETE_PAGEREF_FIELD` (`ooxml-fixtures.ts:47-66`), surrounded by ordinary `<w:t>` runs. The difference between the two sides realizes one of a fixed set of **field operations**:
+  - `field-insert` — field absent on the original side, present on the revised side.
+  - `field-delete` — field present on the original side, absent on the revised side.
+  - `field-stable` — identical complete field present on both sides (pure field context; the surrounding text may still change).
+  - `text-only` — a field present-and-unchanged on both sides, with a tracked text edit in a *different* paragraph (guards that a nearby field does not perturb a plain-text round-trip).
+
+  Inputs are clean documents (the engine generates all tracking), so — unlike `trackedPairArb` — there is **no by-construction INV-RT-001 falsification risk** and no need for the `w:del`-on-`a` / `w:ins`-on-`b` guard. This arbitrary is the field-bearing analogue of `pairArb`, not of `trackedPairArb`.
+
+- **Two (or three) new property tests** over `fieldBearingPairArb`, mirroring the existing INV-FIELD-001 / INV-RT-001 property tests:
+  - `INV-FIELD-001: field structure preserved on field-bearing inplace comparison output` — asserts `assertInplaceResult` + `assertFieldInvariant` on every run; additionally asserts the **stronger** `assertRecursivelyWellformed` **only on runs whose operation is `field-insert` / `field-stable` / `text-only`** (no field deletion), matching the existing fixtures' split. `field-delete` runs assert the document-level `assertFieldInvariant` only — see `design.md` for why the per-operation assertion strength is load-bearing, not a workaround.
+  - `INV-RT-001: paired round-trip text equality on field-bearing inplace comparison output` — asserts `assertInplaceResult` + `assertRoundTripInvariant` on every run, exercising the live `extractTextWithParagraphs` / `normalizeText` over field result text (`<w:t>` payloads) while `instrText` / `delInstrText` / `fldChar` atoms contribute none.
+
+- **Operation/field-type coverage assertion.** Mirroring `assertTrackedScenarioCoverage` (`lean-spec-bridge.test.ts:382`), each property records a coverage map over `{field-insert, field-delete, field-stable, text-only}` (and field type) and asserts every family was exercised, so a generator that silently stopped producing one operation fails loudly rather than passing vacuously.
+
+- **Fallback is treated as falsification, with a coverage floor (no silent `fc.pre` filtering).** The file header currently states the generators are "paragraph-only, table-free, and field-free, so [`ContainerResolutionError`] is not expected to fire," and treats any inplace fallback as falsification via `assertInplaceResult`. This change's arbitrary is **field-bearing**, so that premise no longer holds verbatim. The arbitrary is therefore **constrained to the whole-field-at-run-boundary operation shapes the existing fixtures already prove the engine handles inplace** (the insert/delete fixtures both `assertInplaceResult` and pass). Fallback remains falsification (`assertInplaceResult` throws with `triage=inplace-fallback`); the operation-coverage assertion doubles as the floor that detects a degenerate all-fallback run. The header comment is updated to scope the "field-free" claim to the two original generators and document the field-bearing arbitrary's narrower inplace-safe operation set. See `design.md` for the rejected `fc.pre`-filter alternative.
+
+- **Header / coverage-surface comment update.** The "Coverage surfaces" and "Fallback semantics" comment blocks (`lean-spec-bridge.test.ts:8-52`) are extended to list the field-bearing arbitrary and its operation families, so the file's self-description stays accurate (asymmetry-of-rot: the comment must not oversell field-free-ness once a field-bearing generator exists).
+
+- **`ooxml-fixtures.ts` additions only if needed.** If the arbitrary needs a field-bearing paragraph builder beyond the existing `COMPLETE_*` constants (e.g. a `paragraphWithField(text, field)` helper), it is added to `ooxml-fixtures.ts` per the AGENTS.md fixture-home rule, not inlined in the test.
+
+## Scope guardrails
+
+- **Inplace-mode comparison output only.** Matches the `Spec.lean` precondition and the existing bridge tests.
+- **Whole, self-contained fields at run boundaries only.** The arbitrary generates only complete `begin … (instrText) … separate … result … end` sequences as atomic units inserted/deleted/kept — the operation shapes the existing fixtures prove are inplace-safe. It does **not** generate fragmented field modifications (changing instruction text under track changes — `FRAGMENTED_NUMPAGES_MODIFICATION`), nested fields, or fields spanning paragraph boundaries. Those are separate, harder surfaces.
+- **No new residual-axiom claims and no Lean changes.** This change only strengthens empirical falsifiability of the two existing axioms; it does not discharge them (Tier 3) and adds no Lean code.
+- **No production-engine code changes.** Test layer only.
+- **No change to the existing field-free property tests or the three field fixtures.** They stay as-is; this change is additive.
+
+## Impact
+
+- **Affected specs:** `docx-comparison` (one new requirement — see `specs/docx-comparison/spec.md`).
+- **Affected code:** `packages/docx-core/src/integration/lean-spec-bridge.test.ts` (new arbitrary + property tests + header comment), `packages/docx-core/src/testing/ooxml-fixtures.ts` (new field-bearing paragraph helper only if required).
+- **No Lean changes. No production-engine code changes.**
+- **CI:** the new property tests run in the standard `@usejunior/docx-core` workspace test job alongside the existing bridge properties; no new CI wiring. `npm run check:spec-coverage` must continue to pass for the new `docx-comparison` requirement once its scenarios are mapped per repo convention.
+- **Runtime:** adds two (or three) `fc.assert` properties at `numRuns: 100` each, each building and comparing real DOCX buffers — comparable to the existing field-free properties; the `{ timeout: 60_000 }` describe budget already in the file covers them.

--- a/openspec/changes/add-field-bearing-bridge-arbitrary/specs/docx-comparison/spec.md
+++ b/openspec/changes/add-field-bearing-bridge-arbitrary/specs/docx-comparison/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: Field-bearing property coverage falsifies the inplace residual axioms over generated field documents
+
+The system SHALL exercise the two named residual axioms about this repo's inplace `compareDocumentXml` output — `compareDocumentXml_output_preservation_friendly` (INV-FIELD-001) and `compareDocumentXml_output_text_roundtrip` (INV-RT-001), declared in `verification/lean/LeanSpike/Spec.lean` — against the live TypeScript comparison engine over a **fast-check arbitrary that generates field-bearing documents**, not only over hand-written single fixtures.
+
+The arbitrary SHALL generate clean (non-pre-tracked) `(original, revised)` document pairs in which selected paragraphs carry a complete, self-contained field drawn from the shared constants `COMPLETE_NUMPAGES_FIELD` / `COMPLETE_PAGE_FIELD` / `COMPLETE_PAGEREF_FIELD` (`packages/docx-core/src/testing/ooxml-fixtures.ts`), and the difference between the two sides SHALL realize one of a fixed set of field operations: field-insert, field-delete, field-stable (field present and identical on both sides), and text-only (field unchanged on both sides with a tracked text edit in a different paragraph). The arbitrary SHALL NOT generate fragmented field modifications, nested fields, or fields spanning paragraph boundaries; those surfaces are out of scope.
+
+The property tests SHALL run through the inplace reconstruction path and:
+
+- treat any inplace fallback as falsification (via the existing `assertInplaceResult`, emitting `triage=inplace-fallback`), NOT silently filter it with `fc.pre`;
+- assert an operation-family (and field-type) coverage floor so a generator that stopped producing an operation fails loudly rather than passing vacuously;
+- for INV-FIELD-001, assert the document-level field-structure invariant (`assertFieldInvariant`) on every run, and additionally assert the stronger per-subtree `recursivelyWellformed` / `fieldContextNeutral ∀ ctx` invariant (`assertRecursivelyWellformed`) only on runs whose operation is not field-delete, because post-#217 the inplace atomizer fragments deleted fields and the resulting `<w:del>` subtrees are not field-context-neutral — the same per-operation assertion-strength split the existing field-delete fixture documents;
+- for INV-RT-001, assert that the normalized text of `acceptAllChanges(combined)` equals the revised input's normalized text and the normalized text of `rejectAllChanges(combined)` equals the original's, using the live `extractTextWithParagraphs` / `normalizeText`, with field result text (`<w:t>` payloads) counted and `instrText` / `delInstrText` / `fldChar` atoms contributing no text.
+
+This requirement strengthens empirical falsifiability only; it introduces no Lean change and does not discharge either residual axiom (Tier 3 owns that). The existing field-free property tests and the three single field fixtures SHALL remain.
+
+#### Scenario: [LEAN-FBA-01] Field-bearing arbitrary drives INV-FIELD-001 across operations
+
+- **GIVEN** the `fieldBearingPairArb` fast-check arbitrary generating clean field-bearing `(original, revised)` pairs over field-insert / field-delete / field-stable / text-only operations and the NUMPAGES / PAGE / PAGEREF field types
+- **WHEN** each generated pair is compared through the live inplace engine and the combined output is accepted and rejected
+- **THEN** `assertFieldInvariant` holds on every run and `assertInplaceResult` confirms inplace mode was used, with the property executing at `numRuns: 100`
+
+#### Scenario: [LEAN-FBA-02] Per-operation assertion strength matches the post-#217 engine
+
+- **WHEN** a generated run's operation is field-insert, field-stable, or text-only
+- **THEN** the stronger `assertRecursivelyWellformed` (per-subtree `fieldContextNeutral ∀ ctx`) is asserted in addition to `assertFieldInvariant`
+- **AND** when the operation is field-delete, only the document-level `assertFieldInvariant` is asserted, because the fragmented `<w:del>` subtrees are not field-context-neutral — matching the strength of the `compareDocumentXml_output_preservation_friendly` axiom
+
+#### Scenario: [LEAN-FBA-03] Field-bearing arbitrary drives INV-RT-001 round-trip
+
+- **WHEN** each generated field-bearing pair is compared and the combined output is projected through accept-all and reject-all
+- **THEN** the normalized accepted text equals the revised input's normalized text and the normalized rejected text equals the original's, via the live `extractTextWithParagraphs` / `normalizeText`, with field result text counted and field instruction / fldChar atoms contributing none
+
+#### Scenario: [LEAN-FBA-04] Fallback is falsification and coverage is floored, not silently filtered
+
+- **WHEN** the field-bearing properties run
+- **THEN** any inplace fallback fails the property with `triage=inplace-fallback` diagnostics rather than being discarded by `fc.pre`
+- **AND** a coverage assertion requires every field operation family (and field type) to have been exercised, so a degenerate generator that drops an operation fails loudly instead of passing vacuously
+
+#### Scenario: [LEAN-FBA-05] Bridge file self-description stays accurate
+
+- **WHEN** a reader inspects the header comment blocks of `packages/docx-core/src/integration/lean-spec-bridge.test.ts`
+- **THEN** the "Coverage surfaces" block lists the field-bearing arbitrary and its operation families, the "Fallback semantics" block scopes the "field-free ⇒ no `ContainerResolutionError`" claim to the two original generators and documents the field-bearing arbitrary's narrower inplace-safe operation set, and the "Coverage limitations" note no longer implies all field-bearing input families live only in `collapsed-field-inplace.test.ts`

--- a/openspec/changes/add-field-bearing-bridge-arbitrary/tasks.md
+++ b/openspec/changes/add-field-bearing-bridge-arbitrary/tasks.md
@@ -1,0 +1,40 @@
+# Tasks — field-bearing fast-check arbitrary for the Lean spec bridge
+
+## 1. Field-bearing arbitrary (`lean-spec-bridge.test.ts`, with `ooxml-fixtures.ts` helpers)
+
+- [ ] 1.1 Add a `paragraphWithField(text, field)` body-XML helper to `ooxml-fixtures.ts` (only if the arbitrary needs more than the existing `COMPLETE_*` constants); otherwise compose inline from the constants. Do not re-derive field XML inline in the test (issue #221 drift rule).
+- [ ] 1.2 Define a `FieldOperation` union `{ field-insert, field-delete, field-stable, text-only }` and a `FieldType` over the three constants `COMPLETE_NUMPAGES_FIELD` / `COMPLETE_PAGE_FIELD` / `COMPLETE_PAGEREF_FIELD`.
+- [ ] 1.3 Define `fieldBearingPairArb`: generates a clean `(originalBodyXml, revisedBodyXml)` pair (via `buildDocxFromBodyXml`) realizing one `FieldOperation` with one `FieldType`, with ordinary `<w:t>` runs around the field. Clean inputs only (no pre-tracked markup) — the engine generates all tracking. Carry the `operation` and `fieldType` on the generated value for per-run dispatch and coverage.
+- [ ] 1.4 Add a `FieldBearingCoverage` map + `createFieldBearingCoverage` / `recordFieldBearingHit` / `assertFieldBearingCoverage` mirroring the `TrackedScenarioCoverage` helpers (`:364-393`), keyed by operation (and field type).
+
+## 2. Property tests
+
+- [ ] 2.1 `INV-FIELD-001: field structure preserved on field-bearing inplace comparison output` — `fc.assert(fc.asyncProperty(fieldBearingPairArb, …), { numRuns: NUM_RUNS })`: build + compare buffers, `assertInplaceResult`, `assertFieldInvariant`; additionally `assertRecursivelyWellformed` **iff** `operation !== 'field-delete'`. Record coverage; assert full coverage in `finally`.
+- [ ] 2.2 `INV-RT-001: paired round-trip text equality on field-bearing inplace comparison output` — `assertInplaceResult` + `assertRoundTripInvariant` on every run; record + assert coverage. Confirm the round-trip accounts for field **result** text (`<w:t>`) on both sides and that `instrText` / `fldChar` contribute none.
+- [ ] 2.3 (Optional) Allure JSON attachment of the coverage map per property, mirroring `allureJsonAttachment('tracked-input-family-hits-…', coverage)` (`:849`, `:886`).
+
+## 3. Header / comment accuracy (asymmetry-of-rot)
+
+- [ ] 3.1 Extend the "Coverage surfaces" comment (`:8-21`) to list the field-bearing arbitrary and its operation families.
+- [ ] 3.2 Scope the "Fallback semantics" comment (`:23-44`): the "field-free ⇒ no `ContainerResolutionError`" claim now applies to the two original generators; document the field-bearing arbitrary's narrower inplace-safe operation set and that fallback there is still treated as falsification.
+- [ ] 3.3 Update the "Coverage limitations" note (`:46-52`) so it no longer implies *all* field-bearing input families live only in `collapsed-field-inplace.test.ts`.
+
+## 4. Verify locally (AGENTS.md pre-submit)
+
+- [ ] 4.1 `npm run build`
+- [ ] 4.2 `npm run lint:workspaces`
+- [ ] 4.3 `npm run test:run` (confirm the new properties pass at `numRuns: 100`, full operation/field-type coverage reported, no inplace fallback observed; if any run falls back, triage `engine-bug` vs. generator-shape before suppressing).
+- [ ] 4.4 `npm run check:spec-coverage`
+- [ ] 4.5 `npm run check:conformance-citations && npm run check:conformance-doc`
+
+## 5. Spec coverage mapping
+
+- [ ] 5.1 Map the new `docx-comparison` requirement's `[LEAN-FBA-*]` scenarios to the new bridge property tests in `packages/docx-core/src/testing/DOCX_COMPARISON_OPENSPEC_TRACEABILITY.md` per repo convention, so `check:spec-coverage` passes for them once the change is applied.
+
+## 6. Validate
+
+- [ ] 6.1 `openspec validate add-field-bearing-bridge-arbitrary --strict` passes.
+
+## 7. Documentation follow-through
+
+- [ ] 7.1 Update `verification/ROADMAP.md` to mark the `add-field-bearing-bridge-arbitrary` follow-up as delivered (it is currently listed as an open follow-up at `:128-129`).

--- a/openspec/changes/add-field-bearing-bridge-arbitrary/tasks.md
+++ b/openspec/changes/add-field-bearing-bridge-arbitrary/tasks.md
@@ -2,39 +2,39 @@
 
 ## 1. Field-bearing arbitrary (`lean-spec-bridge.test.ts`, with `ooxml-fixtures.ts` helpers)
 
-- [ ] 1.1 Add a `paragraphWithField(text, field)` body-XML helper to `ooxml-fixtures.ts` (only if the arbitrary needs more than the existing `COMPLETE_*` constants); otherwise compose inline from the constants. Do not re-derive field XML inline in the test (issue #221 drift rule).
-- [ ] 1.2 Define a `FieldOperation` union `{ field-insert, field-delete, field-stable, text-only }` and a `FieldType` over the three constants `COMPLETE_NUMPAGES_FIELD` / `COMPLETE_PAGE_FIELD` / `COMPLETE_PAGEREF_FIELD`.
-- [ ] 1.3 Define `fieldBearingPairArb`: generates a clean `(originalBodyXml, revisedBodyXml)` pair (via `buildDocxFromBodyXml`) realizing one `FieldOperation` with one `FieldType`, with ordinary `<w:t>` runs around the field. Clean inputs only (no pre-tracked markup) — the engine generates all tracking. Carry the `operation` and `fieldType` on the generated value for per-run dispatch and coverage.
-- [ ] 1.4 Add a `FieldBearingCoverage` map + `createFieldBearingCoverage` / `recordFieldBearingHit` / `assertFieldBearingCoverage` mirroring the `TrackedScenarioCoverage` helpers (`:364-393`), keyed by operation (and field type).
+- [x] 1.1 Added `paragraphWithText` + `paragraphWithField(prefix, field, suffix)` body-XML helpers (with `escapeXmlText`) to `ooxml-fixtures.ts`; the arbitrary sources field XML from the `COMPLETE_*` constants via these helpers — no inline re-derivation (issue #221 drift rule).
+- [x] 1.2 Defined `FieldOperation` union `{ field-insert, field-delete, field-stable, text-only }` and `FieldType` over `COMPLETE_NUMPAGES_FIELD` / `COMPLETE_PAGE_FIELD` / `COMPLETE_PAGEREF_FIELD` (`FIELD_FIXTURES`).
+- [x] 1.3 Defined `fieldBearingPairArb` (+ `buildFieldBearingPair`, `compareFieldBearingPair`): clean `(originalBodyXml, revisedBodyXml)` pairs realizing one operation × field type, ordinary `<w:t>` runs around the field, engine generates all tracking. Carries `operation` / `fieldType` for per-run dispatch and coverage.
+- [x] 1.4 Added `FieldBearingCoverage` map + `createFieldBearingCoverage` / `recordFieldBearingHit` / `assertFieldBearingCoverage`, keyed by operation × field type.
 
 ## 2. Property tests
 
-- [ ] 2.1 `INV-FIELD-001: field structure preserved on field-bearing inplace comparison output` — `fc.assert(fc.asyncProperty(fieldBearingPairArb, …), { numRuns: NUM_RUNS })`: build + compare buffers, `assertInplaceResult`, `assertFieldInvariant`; additionally `assertRecursivelyWellformed` **iff** `operation !== 'field-delete'`. Record coverage; assert full coverage in `finally`.
-- [ ] 2.2 `INV-RT-001: paired round-trip text equality on field-bearing inplace comparison output` — `assertInplaceResult` + `assertRoundTripInvariant` on every run; record + assert coverage. Confirm the round-trip accounts for field **result** text (`<w:t>`) on both sides and that `instrText` / `fldChar` contribute none.
-- [ ] 2.3 (Optional) Allure JSON attachment of the coverage map per property, mirroring `allureJsonAttachment('tracked-input-family-hits-…', coverage)` (`:849`, `:886`).
+- [x] 2.1 `INV-FIELD-001: field structure preserved on field-bearing inplace comparison output` at `numRuns: NUM_RUNS`: `assertInplaceResult` + `assertFieldInvariant`; `assertRecursivelyWellformed` **iff** `operation !== 'field-delete'`. Coverage recorded; full coverage asserted in `finally`. Seeded with all 12 operation×type combos via `examples` so the coverage floor is deterministic on top of the 100 random runs.
+- [x] 2.2 `INV-RT-001: paired round-trip text equality on field-bearing inplace comparison output`: `assertInplaceResult` + `await assertRoundTripInvariant` per run; coverage recorded + asserted. Round-trip exercises the live `extractTextWithParagraphs` / `normalizeText` (field result `<w:t>` counted; `instrText` / `fldChar` contribute none).
+- [x] 2.3 Allure JSON coverage attachment per property (`field-bearing-operation-type-hits-inv-field-001` / `…-inv-rt-001`).
 
 ## 3. Header / comment accuracy (asymmetry-of-rot)
 
-- [ ] 3.1 Extend the "Coverage surfaces" comment (`:8-21`) to list the field-bearing arbitrary and its operation families.
-- [ ] 3.2 Scope the "Fallback semantics" comment (`:23-44`): the "field-free ⇒ no `ContainerResolutionError`" claim now applies to the two original generators; document the field-bearing arbitrary's narrower inplace-safe operation set and that fallback there is still treated as falsification.
-- [ ] 3.3 Update the "Coverage limitations" note (`:46-52`) so it no longer implies *all* field-bearing input families live only in `collapsed-field-inplace.test.ts`.
+- [x] 3.1 Extended the "Coverage surfaces" comment to list the field-bearing arbitrary and its four operation families.
+- [x] 3.2 Scoped the "Fallback semantics" comment: the "field-free ⇒ no `ContainerResolutionError`" claim now applies to the two original generators (`pairArb`, `trackedPairArb`); documented the field-bearing arbitrary's narrower complete-field-at-run-boundary operation set and that fallback there is still falsification. Also de-scoped the `fallbackError` message ("under the bridge generator").
+- [x] 3.3 Updated the "Coverage limitations" note so it no longer implies all field-bearing input families live only in `collapsed-field-inplace.test.ts` (fragmented/nested/paragraph-spanning families are what remain outside this surface).
 
 ## 4. Verify locally (AGENTS.md pre-submit)
 
-- [ ] 4.1 `npm run build`
-- [ ] 4.2 `npm run lint:workspaces`
-- [ ] 4.3 `npm run test:run` (confirm the new properties pass at `numRuns: 100`, full operation/field-type coverage reported, no inplace fallback observed; if any run falls back, triage `engine-bug` vs. generator-shape before suppressing).
-- [ ] 4.4 `npm run check:spec-coverage`
-- [ ] 4.5 `npm run check:conformance-citations && npm run check:conformance-doc`
+- [x] 4.1 `npm run build -w @usejunior/docx-core` — clean.
+- [x] 4.2 `npm run lint -w @usejunior/docx-core` (`tsc --noEmit`, typechecks tests incl. `.openspec()` tags) — clean.
+- [x] 4.3 Full docx-core suite (`npm run test:run -w @usejunior/docx-core`) — 1290 passed, 3 skipped, 87 files. Both new properties pass at `numRuns: 100` with full operation×type coverage and no inplace fallback.
+- [x] 4.4 `npm run check:spec-coverage` — PASS (both workspaces).
+- [x] 4.5 `npm run check:conformance-citations && npm run check:conformance-doc` — OK.
 
 ## 5. Spec coverage mapping
 
-- [ ] 5.1 Map the new `docx-comparison` requirement's `[LEAN-FBA-*]` scenarios to the new bridge property tests in `packages/docx-core/src/testing/DOCX_COMPARISON_OPENSPEC_TRACEABILITY.md` per repo convention, so `check:spec-coverage` passes for them once the change is applied.
+- [x] 5.1 Mapped via `.openspec('[LEAN-FBA-NN] …')` tags on the two new property tests. The traceability matrix `DOCX_COMPARISON_OPENSPEC_TRACEABILITY.md` is **auto-generated** by `validate_openspec_coverage.mjs` from canonical-spec scenarios + these tags — the rows for `[LEAN-FBA-*]` populate automatically when the delta is applied to the canonical spec on archive. No hand-edit of the matrix (a manual edit is overwritten by the generator).
 
 ## 6. Validate
 
-- [ ] 6.1 `openspec validate add-field-bearing-bridge-arbitrary --strict` passes.
+- [x] 6.1 `openspec validate add-field-bearing-bridge-arbitrary --strict` passes.
 
 ## 7. Documentation follow-through
 
-- [ ] 7.1 Update `verification/ROADMAP.md` to mark the `add-field-bearing-bridge-arbitrary` follow-up as delivered (it is currently listed as an open follow-up at `:128-129`).
+- [x] 7.1 Updated `verification/ROADMAP.md`: moved the field-bearing arbitrary from "still open / deferred" to a new "Delivered follow-ups" section.

--- a/openspec/changes/add-field-bearing-bridge-arbitrary/tasks.md
+++ b/openspec/changes/add-field-bearing-bridge-arbitrary/tasks.md
@@ -9,7 +9,7 @@
 
 ## 2. Property tests
 
-- [x] 2.1 `INV-FIELD-001: field structure preserved on field-bearing inplace comparison output` at `numRuns: NUM_RUNS`: `assertInplaceResult` + `assertFieldInvariant`; `assertRecursivelyWellformed` **iff** `operation !== 'field-delete'`. Coverage recorded; full coverage asserted in `finally`. Seeded with all 12 operation×type combos via `examples` so the coverage floor is deterministic on top of the 100 random runs.
+- [x] 2.1 `INV-FIELD-001: field structure preserved on field-bearing inplace comparison output` at `numRuns: NUM_RUNS`: `assertInplaceResult` + `assertFieldInvariant`; `assertRecursivelyWellformed` **iff** `operation !== 'field-delete'`. Coverage recorded; full coverage asserted in `finally`. Seeded with all 12 operation×type combos via `examples` so the coverage floor is deterministic; the budget is `NUM_RUNS + fieldBearingExampleArgs.length` because fast-check consumes `examples` from within `numRuns`, so this keeps a full `NUM_RUNS` random cases on top of the 12 deterministic examples.
 - [x] 2.2 `INV-RT-001: paired round-trip text equality on field-bearing inplace comparison output`: `assertInplaceResult` + `await assertRoundTripInvariant` per run; coverage recorded + asserted. Round-trip exercises the live `extractTextWithParagraphs` / `normalizeText` (field result `<w:t>` counted; `instrText` / `fldChar` contribute none).
 - [x] 2.3 Allure JSON coverage attachment per property (`field-bearing-operation-type-hits-inv-field-001` / `…-inv-rt-001`).
 

--- a/packages/docx-core/src/integration/lean-spec-bridge.test.ts
+++ b/packages/docx-core/src/integration/lean-spec-bridge.test.ts
@@ -11,6 +11,9 @@
  *     carries one focused tracked-change family:
  *       `w:ins`, `w:del`, paragraph-insert, `pPrChange`, comment-anchor,
  *       footnote-anchor.
+ *   - Tier 2 field-bearing clean pairs whose `document.xml` carries a complete
+ *     NUMPAGES / PAGE / PAGEREF field and realizes one focused operation:
+ *       field-insert, field-delete, field-stable, text-only.
  *
  * These are empirical bridge tests, not the proofs themselves. As of the
  * `inv_rt_001` closure both theorems are closed (zero `sorry`) but each rests on a
@@ -20,7 +23,7 @@
  * layer for those axioms — it fails if either invariant breaks on real engine
  * output.
  *
- * Fallback semantics — scoped to both bridge generators in this file:
+ * Fallback semantics:
  *
  *   `Spec.lean` models `compareDocumentXml : OoxmlDoc → OoxmlDoc → Option OoxmlDoc`
  *   and both theorems are premised on `compareDocumentXml a b = some combined`,
@@ -29,10 +32,13 @@
  *     (a) `evaluateSafetyChecks` rejecting every inplace pass — i.e. an internal
  *         INV-FIELD-001 / INV-RT-001 falsification on the candidate XML;
  *     (b) `ContainerResolutionError` from container-topology mismatch.
- *   Every generator here is paragraph-only, table-free, and field-free, so (b)
- *   is not expected to fire. We therefore treat fallback as falsification and
- *   throw with `triage=inplace-fallback` diagnostics rather than filtering with
- *   `fc.pre`.
+ *   The two original generators (`pairArb`, `trackedPairArb`) are
+ *   paragraph-only, table-free, and field-free, so (b) is not expected to fire
+ *   there. The field-bearing arbitrary is narrower instead: it uses only
+ *   complete fields at run boundaries and the inplace-safe operation families
+ *   already covered by the fixed fixtures. We therefore treat fallback as
+ *   falsification for all bridge properties and throw with
+ *   `triage=inplace-fallback` diagnostics rather than filtering with `fc.pre`.
  *
  * INV-RT-001 tracked-input triage:
  *   - `triage=engine-bug`: accept/reject of `combined` disagrees with the fully
@@ -44,7 +50,9 @@
  *   - `triage=inplace-fallback`: the inplace candidate was never emitted.
  *
  * Coverage limitations (intentional for the spike — not bugs):
- *   - Field-bearing input families still live in `collapsed-field-inplace.test.ts`.
+ *   - Fragmented, nested, and paragraph-spanning field input families still live
+ *     outside this bridge property surface (for example in
+ *     `collapsed-field-inplace.test.ts` / field-fragmentation fixtures).
  *   - Small-edit/run-boundary regression coverage still lives in the fixture
  *     tests (`round-trip-inplace.test.ts`, `nvca-coi-regression.test.ts`).
  *   - Comment and footnote coverage here is limited to `document.xml` anchors;
@@ -57,9 +65,13 @@ import { describe } from 'vitest';
 import { compareDocuments, type ReconstructionMode } from '../index.js';
 import { validateFieldStructure } from '../baselines/atomizer/pipeline.js';
 import {
+  COMPLETE_PAGE_FIELD,
+  COMPLETE_PAGEREF_FIELD,
   COMPLETE_NUMPAGES_FIELD,
   WHOLE_FIELD_IN_INS,
   buildDocxFromBodyXml,
+  paragraphWithField,
+  paragraphWithText,
 } from '../testing/ooxml-fixtures.js';
 import {
   acceptAllChanges,
@@ -117,6 +129,25 @@ const TRACKED_SCENARIO_FAMILIES = [
 ] as const;
 
 type TrackedScenarioFamily = (typeof TRACKED_SCENARIO_FAMILIES)[number];
+
+const FIELD_OPERATIONS = [
+  'field-insert',
+  'field-delete',
+  'field-stable',
+  'text-only',
+] as const;
+
+type FieldOperation = (typeof FIELD_OPERATIONS)[number];
+
+const FIELD_FIXTURES = {
+  NUMPAGES: COMPLETE_NUMPAGES_FIELD,
+  PAGE: COMPLETE_PAGE_FIELD,
+  PAGEREF: COMPLETE_PAGEREF_FIELD,
+} as const;
+
+type FieldType = keyof typeof FIELD_FIXTURES;
+
+const FIELD_TYPES = Object.keys(FIELD_FIXTURES) as FieldType[];
 
 interface InsertScenario {
   family: 'w:ins';
@@ -176,6 +207,21 @@ interface TrackedScenarioPair {
   revisedScenario: TrackedScenario;
 }
 
+interface FieldBearingPair {
+  operation: FieldOperation;
+  fieldType: FieldType;
+  originalBodyXml: string;
+  revisedBodyXml: string;
+}
+
+interface FieldTextShape {
+  prefix: string;
+  suffix: string;
+  revisedSuffix: string;
+  originalPlainText: string;
+  revisedPlainText: string;
+}
+
 interface MaterializedTrackedScenario {
   scenario: TrackedScenario;
   document: Buffer;
@@ -183,6 +229,7 @@ interface MaterializedTrackedScenario {
 }
 
 type TrackedScenarioCoverage = Record<TrackedScenarioFamily, number>;
+type FieldBearingCoverage = Record<FieldOperation, Record<FieldType, number>>;
 
 const NUM_RUNS = 100;
 
@@ -289,6 +336,75 @@ const trackedPairArb: fc.Arbitrary<TrackedScenarioPair> = fc.record({
   revisedScenario: trackedRevisedScenarioArb,
 });
 
+const fieldTextShapeArb = fc.record({
+  prefix: fc.constantFrom('Total pages ', 'Field value ', 'Reference '),
+  suffix: fc.constantFrom(' here.', ' done.', ' end.'),
+  revisedSuffix: fc.constantFrom(' updated.', ' complete.', ' final.'),
+  originalPlainText: fc.constantFrom('Plain edit before field.', 'Separate original text.'),
+  revisedPlainText: fc.constantFrom('Plain edit after field.', 'Separate revised text.'),
+});
+
+function buildFieldBearingPair(
+  operation: FieldOperation,
+  fieldType: FieldType,
+  shape: FieldTextShape,
+): FieldBearingPair {
+  const field = FIELD_FIXTURES[fieldType];
+  const stableFieldParagraph = paragraphWithField(shape.prefix, field, shape.suffix);
+
+  switch (operation) {
+    case 'field-insert':
+      return {
+        operation,
+        fieldType,
+        originalBodyXml: paragraphWithText(`${shape.prefix}${shape.suffix}`),
+        revisedBodyXml: paragraphWithField(shape.prefix, field, shape.suffix),
+      };
+    case 'field-delete':
+      return {
+        operation,
+        fieldType,
+        originalBodyXml: paragraphWithField(shape.prefix, field, shape.suffix),
+        revisedBodyXml: paragraphWithText(`${shape.prefix}${shape.suffix}`),
+      };
+    case 'field-stable':
+      return {
+        operation,
+        fieldType,
+        originalBodyXml: stableFieldParagraph,
+        revisedBodyXml: paragraphWithField(shape.prefix, field, shape.revisedSuffix),
+      };
+    case 'text-only':
+      return {
+        operation,
+        fieldType,
+        originalBodyXml: stableFieldParagraph + paragraphWithText(shape.originalPlainText),
+        revisedBodyXml: stableFieldParagraph + paragraphWithText(shape.revisedPlainText),
+      };
+  }
+}
+
+const fieldBearingExamples: FieldBearingPair[] = FIELD_OPERATIONS.flatMap((operation) =>
+  FIELD_TYPES.map((fieldType) =>
+    buildFieldBearingPair(operation, fieldType, {
+      prefix: 'Total pages ',
+      suffix: ' here.',
+      revisedSuffix: ' updated.',
+      originalPlainText: 'Plain edit before field.',
+      revisedPlainText: 'Plain edit after field.',
+    }),
+  ),
+);
+const fieldBearingExampleArgs = fieldBearingExamples.map((pair) => [pair] as [FieldBearingPair]);
+
+const fieldBearingPairArb: fc.Arbitrary<FieldBearingPair> = fc
+  .record({
+    operation: fc.constantFrom(...FIELD_OPERATIONS),
+    fieldType: fc.constantFrom(...FIELD_TYPES),
+    shape: fieldTextShapeArb,
+  })
+  .map(({ operation, fieldType, shape }) => buildFieldBearingPair(operation, fieldType, shape));
+
 async function getDocumentXml(document: Buffer): Promise<string> {
   const archive = await DocxArchive.load(document);
   return await archive.getDocumentXml();
@@ -351,6 +467,15 @@ async function compareSyntheticDocuments(
   return compareDocumentBuffers(original, revised);
 }
 
+async function compareFieldBearingPair(pair: FieldBearingPair): Promise<CompareBridgeResult> {
+  const [original, revised] = await Promise.all([
+    buildDocxFromBodyXml(pair.originalBodyXml),
+    buildDocxFromBodyXml(pair.revisedBodyXml),
+  ]);
+
+  return compareDocumentBuffers(original, revised);
+}
+
 async function getDocumentTextViews(document: Buffer): Promise<DocumentTextViews> {
   const rawXml = await getDocumentXml(document);
   return {
@@ -387,6 +512,33 @@ function assertTrackedScenarioCoverage(
   if (missing.length > 0) {
     throw new Error(
       `${invariant}: tracked-input family coverage incomplete. ` +
+        `missing=${missing.join(', ')} hits=${JSON.stringify(coverage)}`,
+    );
+  }
+}
+
+function createFieldBearingCoverage(): FieldBearingCoverage {
+  return Object.fromEntries(
+    FIELD_OPERATIONS.map((operation) => [
+      operation,
+      Object.fromEntries(FIELD_TYPES.map((fieldType) => [fieldType, 0])),
+    ]),
+  ) as FieldBearingCoverage;
+}
+
+function recordFieldBearingHit(coverage: FieldBearingCoverage, pair: FieldBearingPair): void {
+  coverage[pair.operation][pair.fieldType] += 1;
+}
+
+function assertFieldBearingCoverage(invariant: string, coverage: FieldBearingCoverage): void {
+  const missing = FIELD_OPERATIONS.flatMap((operation) =>
+    FIELD_TYPES.filter((fieldType) => coverage[operation][fieldType] === 0).map(
+      (fieldType) => `${operation}/${fieldType}`,
+    ),
+  );
+  if (missing.length > 0) {
+    throw new Error(
+      `${invariant}: field-bearing operation/type coverage incomplete. ` +
         `missing=${missing.join(', ')} hits=${JSON.stringify(coverage)}`,
     );
   }
@@ -586,7 +738,7 @@ function fallbackError(
 ): Error {
   return new Error(
     `${invariant}: triage=inplace-fallback inplace mode fell back to ${result.modeUsed ?? 'unknown'} ` +
-      `under the paragraph-only, table-free bridge generator. ` +
+      `under the bridge generator. ` +
       `fallbackReason=${result.fallbackReason ?? '(none)'} ` +
       `failedChecks=${JSON.stringify(result.failedChecks)} ` +
       `context=${JSON.stringify(context)}`,
@@ -887,6 +1039,113 @@ describe('Lean Spec Bridge - Inplace Reconstruction', { timeout: 60_000 }, () =>
         }
         assertTrackedScenarioCoverage('INV-RT-001 tracked', coverage);
       });
+    },
+  );
+
+  test
+    .openspec(
+      '[LEAN-FBA-01] Field-bearing arbitrary drives INV-FIELD-001 across operations',
+    )
+    .openspec('[LEAN-FBA-02] Per-operation assertion strength matches the post-#217 engine')
+    .openspec('[LEAN-FBA-04] Fallback is falsification and coverage is floored, not silently filtered')
+    .openspec('[LEAN-FBA-05] Bridge file self-description stays accurate')(
+    'INV-FIELD-001: field structure preserved on field-bearing inplace comparison output',
+    async ({ given, when, then }: AllureBddContext) => {
+      const coverage = createFieldBearingCoverage();
+
+      await given(
+        'clean original and revised document pairs are generated with complete NUMPAGES, PAGE, or PAGEREF fields',
+        async () => {},
+      );
+
+      await when('the live inplace comparison output is accepted and rejected across field-bearing pairs', async () => {});
+
+      await then(
+        'field structure remains valid, delete runs use document-level strength, and every operation/type family is exercised',
+        async () => {
+          try {
+            await fc.assert(
+              fc.asyncProperty(fieldBearingPairArb, async (pair) => {
+                recordFieldBearingHit(coverage, pair);
+
+                const result = await compareFieldBearingPair(pair);
+                const context = {
+                  operation: pair.operation,
+                  fieldType: pair.fieldType,
+                  originalBodyXml: pair.originalBodyXml,
+                  revisedBodyXml: pair.revisedBodyXml,
+                };
+
+                assertInplaceResult('INV-FIELD-001 field-bearing property', context, result);
+                assertFieldInvariant(
+                  'INV-FIELD-001 field-bearing property',
+                  context,
+                  result.combined,
+                );
+                if (pair.operation !== 'field-delete') {
+                  assertRecursivelyWellformed(
+                    'INV-FIELD-001 field-bearing property',
+                    context,
+                    result.combined,
+                  );
+                }
+              }),
+              { numRuns: NUM_RUNS, examples: fieldBearingExampleArgs },
+            );
+          } finally {
+            await allureJsonAttachment('field-bearing-operation-type-hits-inv-field-001', coverage);
+          }
+          assertFieldBearingCoverage('INV-FIELD-001 field-bearing property', coverage);
+        },
+      );
+    },
+  );
+
+  test
+    .openspec('[LEAN-FBA-03] Field-bearing arbitrary drives INV-RT-001 round-trip')
+    .openspec('[LEAN-FBA-04] Fallback is falsification and coverage is floored, not silently filtered')(
+    'INV-RT-001: paired round-trip text equality on field-bearing inplace comparison output',
+    async ({ given, when, then }: AllureBddContext) => {
+      const coverage = createFieldBearingCoverage();
+
+      await given(
+        'clean original and revised document pairs are generated with complete fields and field result text',
+        async () => {},
+      );
+
+      await when('the live inplace comparison output is projected through accept-all and reject-all', async () => {});
+
+      await then(
+        'normalized text round-trips and every field operation/type family is exercised',
+        async () => {
+          try {
+            await fc.assert(
+              fc.asyncProperty(fieldBearingPairArb, async (pair) => {
+                recordFieldBearingHit(coverage, pair);
+
+                const result = await compareFieldBearingPair(pair);
+                const context = {
+                  operation: pair.operation,
+                  fieldType: pair.fieldType,
+                  originalBodyXml: pair.originalBodyXml,
+                  revisedBodyXml: pair.revisedBodyXml,
+                };
+
+                assertInplaceResult('INV-RT-001 field-bearing property', context, result);
+                await assertRoundTripInvariant(
+                  'INV-RT-001 field-bearing property',
+                  context,
+                  result,
+                );
+              }),
+              { numRuns: NUM_RUNS, examples: fieldBearingExampleArgs },
+            );
+          } finally {
+            await allureJsonAttachment('field-bearing-operation-type-hits-inv-rt-001', coverage);
+          }
+          assertFieldBearingCoverage('INV-RT-001 field-bearing property', coverage);
+        },
+      );
     },
   );
 

--- a/packages/docx-core/src/integration/lean-spec-bridge.test.ts
+++ b/packages/docx-core/src/integration/lean-spec-bridge.test.ts
@@ -94,9 +94,14 @@ import {
   type AllureBddContext,
 } from '../testing/allure-test.js';
 
+// Declared as a named const (not an inline literal) because this file now
+// carries OpenSpec `.openspec([LEAN-FBA-*])` traceability tags, which
+// `scripts/validate_allure_test_labels.mjs` requires to map deterministically
+// to a `TEST_FEATURE`.
+const TEST_FEATURE = 'Lean Spec Bridge (fast-check)';
 const test = testAllure
   .epic('Document Comparison')
-  .withLabels({ feature: 'Lean Spec Bridge (fast-check)' })
+  .withLabels({ feature: TEST_FEATURE })
   .conformance({ spec: 'ECMA-376', edition: 5, part: 4, section: '17.16.5' });
 
 const TRACKED_REVISION_AUTHOR = 'Lean Bridge';

--- a/packages/docx-core/src/integration/lean-spec-bridge.test.ts
+++ b/packages/docx-core/src/integration/lean-spec-bridge.test.ts
@@ -384,6 +384,12 @@ function buildFieldBearingPair(
   }
 }
 
+// One deterministic example per (operation, fieldType) combo. Seeded via
+// fast-check `examples` so the coverage floor (`assertFieldBearingCoverage`) is
+// guaranteed to be satisfied every run rather than relying on the random
+// generator happening to hit all 12 combos. NOTE: fast-check consumes examples
+// from within the `numRuns` budget, so both properties run at
+// `NUM_RUNS + fieldBearingExampleArgs.length` to keep NUM_RUNS *random* cases.
 const fieldBearingExamples: FieldBearingPair[] = FIELD_OPERATIONS.flatMap((operation) =>
   FIELD_TYPES.map((fieldType) =>
     buildFieldBearingPair(operation, fieldType, {
@@ -1090,7 +1096,13 @@ describe('Lean Spec Bridge - Inplace Reconstruction', { timeout: 60_000 }, () =>
                   );
                 }
               }),
-              { numRuns: NUM_RUNS, examples: fieldBearingExampleArgs },
+              // fast-check runs `examples` from WITHIN the numRuns budget, not in
+              // addition to it, so bump the budget by the example count to get the
+              // full 12 deterministic operation×type combos AND NUM_RUNS random cases.
+              {
+                numRuns: NUM_RUNS + fieldBearingExampleArgs.length,
+                examples: fieldBearingExampleArgs,
+              },
             );
           } finally {
             await allureJsonAttachment('field-bearing-operation-type-hits-inv-field-001', coverage);
@@ -1138,7 +1150,13 @@ describe('Lean Spec Bridge - Inplace Reconstruction', { timeout: 60_000 }, () =>
                   result,
                 );
               }),
-              { numRuns: NUM_RUNS, examples: fieldBearingExampleArgs },
+              // fast-check runs `examples` from WITHIN the numRuns budget, not in
+              // addition to it, so bump the budget by the example count to get the
+              // full 12 deterministic operation×type combos AND NUM_RUNS random cases.
+              {
+                numRuns: NUM_RUNS + fieldBearingExampleArgs.length,
+                examples: fieldBearingExampleArgs,
+              },
             );
           } finally {
             await allureJsonAttachment('field-bearing-operation-type-hits-inv-rt-001', coverage);

--- a/packages/docx-core/src/testing/ooxml-fixtures.ts
+++ b/packages/docx-core/src/testing/ooxml-fixtures.ts
@@ -44,6 +44,21 @@ export function resultText(text: string): string {
   return `<w:r><w:t>${text}</w:t></w:r>`;
 }
 
+function escapeXmlText(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+export function paragraphWithText(text: string): string {
+  return `<w:p>${resultText(escapeXmlText(text))}</w:p>`;
+}
+
+export function paragraphWithField(prefixText: string, field: string, suffixText: string): string {
+  return `<w:p>${resultText(escapeXmlText(prefixText))}${field}${resultText(escapeXmlText(suffixText))}</w:p>`;
+}
+
 export const COMPLETE_NUMPAGES_FIELD =
   fldChar('begin') +
   instrText(' NUMPAGES ', { preserve: true }) +

--- a/verification/ROADMAP.md
+++ b/verification/ROADMAP.md
@@ -123,10 +123,13 @@ The spike is now zero-`sorry`. Two named residual axioms remain, both Tier 3:
 `compareDocumentXml_output_preservation_friendly` and
 `compareDocumentXml_output_text_roundtrip`.
 
+Delivered follow-ups:
+
+- A full field-bearing fast-check arbitrary for the bridge test shipped in
+  `add-field-bearing-bridge-arbitrary`.
+
 Still open / deferred:
 
-- A full field-bearing fast-check arbitrary for the bridge test — only fixture
-  cases ship here; the arbitrary opens as `add-field-bearing-bridge-arbitrary`.
 - Intra-line whitespace-collapse fidelity and Lean↔TS extensional equivalence of
   the text helpers — Tier 2.5.
 


### PR DESCRIPTION
## Summary

Generalizes the three single NUMPAGES field fixtures in `lean-spec-bridge.test.ts` into a **fast-check arbitrary** that drives randomly-generated clean field-bearing document pairs through the live inplace comparison engine, falsifying both residual axioms over field type × operation × placement instead of three fixed XML strings.

Implements the approved OpenSpec change `add-field-bearing-bridge-arbitrary` — the follow-up deferred by name from Tier 2 (`add-ooxml-doc-subset-and-inv-field-001-proof`) and from `add-inv-rt-001-proof`.

**Test-layer only: no Lean changes, no production-engine changes.**

## Why

The field-bearing surface — `w:fldChar` / `w:instrText` / `w:delInstrText` atoms exercising the field-walk and the `delInstrText → instrText` rename — is the riskiest part of the two axioms' domain (`compareDocumentXml_output_preservation_friendly` / `compareDocumentXml_output_text_roundtrip`), and previously had only single-fixture empirical grounding. The two field-free arbitraries (`pairArb`, `trackedPairArb`) never touch it.

## Implementation

- `fieldBearingPairArb` over `{field-insert, field-delete, field-stable, text-only}` × `{NUMPAGES, PAGE, PAGEREF}`, clean inputs (engine generates all tracking — the analogue of `pairArb`, not `trackedPairArb`).
- Two property tests at `numRuns: 100`, plus all 12 operation×type combos seeded via fast-check `examples` so the coverage floor is deterministic.
- Field XML sourced from the shared `COMPLETE_*` constants via new `paragraphWithField` / `paragraphWithText` helpers in `ooxml-fixtures.ts` (issue #221 drift rule).
- Header comment blocks updated (asymmetry-of-rot); ROADMAP follow-up flipped to delivered; traceability via `.openspec([LEAN-FBA-NN])` tags.

### Two load-bearing design decisions (design.md)

1. **Per-operation assertion strength.** `field-insert`/`stable`/`text-only` runs assert the stronger `assertRecursivelyWellformed` *and* `assertFieldInvariant`; `field-delete` runs assert `assertFieldInvariant` only — post-#217 fragmentation makes deleted `<w:del>` subtrees non-context-neutral. The generator's operation tag is the discriminator (not output-XML inspection).
2. **Fallback = falsification + coverage floor, not `fc.pre`.** The arbitrary is constrained to whole-field-at-run-boundary shapes the existing fixtures prove are inplace-safe; `assertInplaceResult` keeps throwing on fallback; the operation×type coverage assertion is the floor against a degenerate all-fallback run.

## Verification (local)

- [x] `npm run build -w @usejunior/docx-core` — clean
- [x] `npm run lint -w @usejunior/docx-core` (`tsc --noEmit`, typechecks tests) — clean
- [x] Full docx-core suite — **1290 passed, 3 skipped, 87 files**; both new properties green, full operation×type coverage, no inplace fallback
- [x] `npm run check:spec-coverage` — PASS (both workspaces)
- [x] `npm run check:conformance-citations && check:conformance-doc` — OK
- [ ] Peer review (Gemini + Codex) — pending; appended below

## OpenSpec

- `openspec/changes/add-field-bearing-bridge-arbitrary/` (proposal, design, tasks, `docx-comparison` delta with `[LEAN-FBA-01..05]`)
- `openspec validate add-field-bearing-bridge-arbitrary --strict` passes