### PR TITLE
test(docx-comparison): fragmented-field fast-check arbitrary for the Lean spec bridge

### DIFF
--- a/openspec/changes/add-fragmented-field-bridge-arbitrary/design.md
+++ b/openspec/changes/add-fragmented-field-bridge-arbitrary/design.md
@@ -1,0 +1,55 @@
+# Design: Fragmented-field fast-check arbitrary
+
+## Context
+
+The bridge file already has three property arbitraries (`pairArb`, `trackedPairArb`, `fieldBearingPairArb`) and a settled assertion vocabulary (`assertInplaceResult`, `assertFieldInvariant`, `assertRecursivelyWellformed`, `assertRoundTripInvariant`, `assertFieldBearingCoverage`). The predecessor established that for **whole, self-contained fields**, the inplace engine always stays inplace and the raw combined output is field-structure-valid, so `assertInplaceResult` (fallback ⇒ failure) and an operation-coverage floor were the right shape.
+
+The fragmented-field surface breaks both of those premises. This design records why, and why that forces a **separate** arbitrary with a **mode-independent** assertion model rather than a fourth operation on `fieldBearingPairArb`.
+
+## The empirical characterization (reproduced)
+
+A standalone probe (clean source/revised pairs built with `buildDocxFromBodyXml`, compared with `engine: 'atomizer', reconstructionMode: 'inplace'`) established the table in `proposal.md`. The four observations that matter:
+
+1. **Instruction-only diffs field-collapse to nothing.** Changing only `w:instrText` between two clean sides (` NUMPAGES ` → ` SECTIONPAGES `) yields `ins=0, del=0` — the atomizer field-collapses the field to a single atom and the instruction text never reaches text extraction, so there is no tracked change and nothing to fragment. An instruction-only operation would therefore be a **vacuous** test (it asserts invariants on an untracked document). It is intentionally **not** one of the operations; the operations that actually fragment are result-text edits and pre-tracked fragmented input.
+2. **Result-text edits fragment and stay inplace.** Changing the field **result** run (`1` → `2`) produces `del=2, delInstrText=1, fldChar=6` (the field duplicates across the del/ins sides) and stays inplace; accept, reject, combined all field-validate; round-trip holds.
+3. **Direction *and* a result change together trigger fallback.** Feeding a pre-tracked fragmented field as the *original* side and a clean field as the *revised* side stays inplace and validates everywhere. Feeding it as the *revised* side **with the field result also changed** (e.g. clean result `1` → fragmented result `3`) drives the engine to **rebuild** (`round_trip_safety_check_failed`); the raw combined output then fails `validateFieldStructure` even though accept and reject each pass and round-trip holds. Same-result clean→fragmented stays inplace. The fallback diagnostics confirm all four inplace passes fail **only** the `fieldStructure` check (`acceptText`/`rejectText` pass on every pass) — i.e. the inplace candidate is non-conformant (the #217 `fldChar`-in-`del` class), not a text/round-trip failure, so rebuild is the engine's correct defensive choice, not an over-strict check.
+
+## Decision 1 — mode-independent invariants, not `assertInplaceResult`
+
+The residual axioms are statements about `compareDocumentXml` *output*, quantified over inputs — they say nothing about which reconstruction strategy produced that output. On the whole-field surface the engine happens to always pick inplace, so the predecessor could fold "inplace was used" into the assertion for free. On the fragmented surface the engine **correctly** picks rebuild for some inputs (observation 3). Asserting `assertInplaceResult` there would fail a run the engine handled correctly — a false falsification.
+
+So the new property asserts only what the axioms actually claim, on whichever output the engine produced:
+
+- `validateFieldStructure(acceptAllChanges(combined))` and `validateFieldStructure(rejectAllChanges(combined))` (the INV-FIELD-001 obligation, on the resolved projections);
+- normalized `accept` text == normalized revised, normalized `reject` text == normalized original (the INV-RT-001 obligation).
+
+It does **not** assert `assertInplaceResult` and does **not** assert `validateFieldStructure(combined)` (observation 3 shows the raw mixed-revision combined output legitimately fails the latter under fallback).
+
+### Why not assert on `combined`?
+
+`validateFieldStructure(combined)` over a raw mixed `<w:ins>`+`<w:del>` field is the wrong obligation: a fragmented field mid-revision is *expected* to have both a deleted and an inserted field skeleton interleaved, which is not a single well-formed field until a side is chosen. The axioms are about the *resolved* (accepted / rejected) documents; that is exactly `acceptAllChanges` / `rejectAllChanges`. Asserting on `combined` would encode a stronger claim than the axioms make and would fail correct fallback output.
+
+## Decision 2 — a mode-distribution coverage floor (the safety valve for dropping `assertInplaceResult`)
+
+Dropping `assertInplaceResult` removes the signal that would otherwise catch the engine silently degrading to all-fallback (a real regression risk: if a refactor made the engine rebuild *everything*, every invariant would still pass and the inplace path would be silently untested). The replacement is a **mode-distribution floor**: the property records `(operation, reconstructionModeUsed-or-fallback)` per run and asserts that the run set contained **both** an inplace outcome **and** a fallback outcome, **and** every operation family. This converts "the engine still both stays-inplace and falls-back across this surface" into a checked invariant rather than an unstated assumption. If a future engine change makes the surface all-inplace or all-fallback, the floor fails loudly and a human re-characterizes — which is the correct response, not a silent green.
+
+The seeded `examples` (one deterministic pair per operation, as `fieldBearingPairArb` does) guarantee the operation floor every run; the `clean-to-pretracked-fragmented` example guarantees the fallback outcome and a `result-edit` / `pretracked-fragmented-to-clean` example guarantees the inplace outcome, so the mode floor is satisfied deterministically rather than relying on the random generator.
+
+## Decision 3 — sibling arbitrary, not a fourth operation on `fieldBearingPairArb`
+
+`fieldBearingPairArb`'s property asserts `assertInplaceResult` and (for non-delete operations) `assertRecursivelyWellformed` on every run. The fragmented operations violate both contracts (fallback is allowed; combined is not recursively well-formed under fallback). Bolting them onto the same arbitrary would force per-operation branching that splits the assertion model down the middle of one property — exactly the kind of "the assertion strength depends on a hidden operation tag" complexity the predecessor already had to document carefully for field-delete. A separate arbitrary with a uniformly mode-independent property keeps each property's contract single and legible, and keeps the predecessor's requirement (which states its arbitrary "SHALL NOT generate fragmented field modifications") literally true.
+
+## Decision 4 — spec shape: ADD, not MODIFY
+
+The predecessor's requirement scopes **its** arbitrary (`fieldBearingPairArb`) and its "SHALL NOT generate fragmented…" sentence remains a true statement about that arbitrary. The new requirement governs a **new** arbitrary. They do not conflict, so this delta is **ADD-only**; the new requirement text explicitly states it extends the sibling requirement to the fragmented surface the sibling deferred, and that nested / paragraph-spanning remain deferred. This avoids a verbose full-requirement MODIFIED restatement whose only change would be one clause.
+
+## Rejected alternatives
+
+- **`fc.pre`-filter out the fallback runs.** Rejected for the same reason the predecessor rejected it for `ContainerResolutionError`: silently discarding inputs hides whether the surface is being exercised and can let the property pass vacuously. Recording mode in the coverage floor is the asymmetry-of-rot-correct inverse — it makes a dropped surface fail loudly.
+- **Assert `assertInplaceResult` and mark `clean-to-pretracked-fragmented` as a known-fallback exception with `fc.pre`/skip.** Rejected: it re-introduces the silent-filter problem and encodes "inplace is the expectation" for a surface where rebuild is correct. Mode-independence is the honest model.
+- **Assert `validateFieldStructure(combined)`.** Rejected per Decision 1 — stronger than the axioms and false under correct fallback.
+- **Include nested / paragraph-spanning in this change.** Rejected on minimal-scope grounds: they need new fixture primitives and their own probing (not done here), and the fragmented surface is a complete, shippable, independently valuable unit. Deferred to a named successor, mirroring how the predecessor split this surface out of Tier 2.
+
+## Tags
+
+New scenarios use the `[LEAN-FRAG-NN]` tag family (Fragmented-field aRbitrary for the lean briDGe — `FRAG`), deliberately distinct from the predecessor's `[LEAN-FBA-NN]` so a matrix reader never confuses whole-field-bearing coverage with fragmented coverage. The file's existing `const TEST_FEATURE` already satisfies the `allure-labels` gate.

--- a/openspec/changes/add-fragmented-field-bridge-arbitrary/proposal.md
+++ b/openspec/changes/add-fragmented-field-bridge-arbitrary/proposal.md
@@ -1,0 +1,68 @@
+# Change: Fragmented-field fast-check arbitrary for the Lean spec bridge
+
+## Why
+
+The Lean spike is zero-`sorry`, carrying exactly two named residual axioms about this repo's inplace `compareDocumentXml` output — `compareDocumentXml_output_preservation_friendly` (INV-FIELD-001) and `compareDocumentXml_output_text_roundtrip` (INV-RT-001). `packages/docx-core/src/integration/lean-spec-bridge.test.ts` is the falsifiability layer for both axioms.
+
+The predecessor change `add-field-bearing-bridge-arbitrary` (PR #294) lifted field-bearing coverage from three hand-written fixtures to the `fieldBearingPairArb` arbitrary — but only over **whole, self-contained fields at run boundaries** (field-insert / field-delete / field-stable / text-only). It explicitly deferred three "separate, harder surfaces" by name:
+
+> "It does **not** generate fragmented field modifications (changing instruction text under track changes — `FRAGMENTED_NUMPAGES_MODIFICATION`), nested fields, or fields spanning paragraph boundaries. Those are separate, harder surfaces." — `add-field-bearing-bridge-arbitrary/proposal.md`, Scope guardrails.
+
+This change takes up the **first and highest-leverage** of those three: the **fragmented-field surface**, where the field's instruction or result text is edited under track changes so the field's internal atoms (`w:instrText` / `w:delInstrText`) fragment into `<w:ins>`/`<w:del>` wrappers while the `w:fldChar` markers stay sibling-level-unwrapped. This is the surface that exercises the `delInstrText → instrText` rename in `trackChangesAcceptorAst.ts` and the field-walk in `pipeline.ts` under tracking — the riskiest part of the field surface and the one with the weakest empirical grounding (one pre-tracked fixture, `FRAGMENTED_NUMPAGES_MODIFICATION`).
+
+Nested fields and fields spanning paragraph boundaries remain deferred to a named successor (`add-nested-and-spanning-field-bridge-arbitrary`); they need new fixture primitives and their own empirical characterization, and behave differently enough to warrant separate scoping.
+
+### What the empirical probe established (load-bearing for the design)
+
+Driving fragmented-field pairs through the live inplace engine (`engine: 'atomizer', reconstructionMode: 'inplace'`) shows the surface does **not** behave like the whole-field surface — and in particular **inplace fallback is a correct, expected outcome here, not a falsification**:
+
+| Generated pair | mode used | `validate(combined)` | `validate(accept)` / `validate(reject)` | round-trip |
+| --- | --- | --- | --- | --- |
+| instruction-only change (clean → clean) | inplace | ✅ | ✅ / ✅ | ✅ (the engine **field-collapses** instruction-only diffs, emitting **zero** tracked changes; instruction text is invisible to text extraction) |
+| field **result**-text change (clean → clean, `1`→`2`) | inplace | ✅ | ✅ / ✅ | ✅ |
+| pre-tracked fragmented field → clean field | inplace | ✅ | ✅ / ✅ | ✅ |
+| clean field → pre-tracked fragmented field, **result unchanged** | inplace | ✅ | ✅ / ✅ | ✅ |
+| clean field → pre-tracked fragmented field, **result changed** (`1`→`3`) | **rebuild (fallback)**, `round_trip_safety_check_failed` | **❌** | ✅ / ✅ | ✅ |
+
+The fallback is precisely triggered by the **combination** of the clean→pre-tracked-fragmented *direction* and a *result-text change*; same-result or the reverse direction stays inplace. All four inplace passes fail **only** the `fieldStructure` safety check (`acceptText`/`rejectText` pass on every pass), so the engine rebuilds and produces conformant accept/reject output. The arbitrary's `clean-to-pretracked-fragmented` operation always changes the result (its result pools are disjoint), so it deterministically realizes the fallback row.
+
+Two findings drive the design:
+
+1. **Inplace fallback is the engine's correct defensive behavior on part of this surface** (last row). The predecessor's rule — "treat any inplace fallback as falsification via `assertInplaceResult`" — is **wrong here**: forcing inplace would fail a run the engine correctly handled by rebuilding. The widened arbitrary therefore asserts **mode-independent** invariants and records the **mode distribution** as a coverage floor (both inplace and rebuild must be exercised), instead of asserting inplace mode.
+2. **The raw `combined` (mixed `<w:ins>`+`<w:del>`) output does not always pass `validateFieldStructure`** (last row, `validate(combined)` ❌), but the **accepted** and **rejected** projections each do, and round-trip holds across both modes. So the invariants asserted are on `accept` / `reject` and on round-trip text — never on the raw combined field structure for this surface.
+
+This is the genuine departure from the predecessor and the reason the surface deserves its own arbitrary and requirement rather than an extra operation on `fieldBearingPairArb`.
+
+Tracking: no dedicated GitHub issue; the follow-up is named in the predecessor's scope guardrails and in `verification/ROADMAP.md`. This change carries **no Lean changes and no production-engine changes** — it is test-layer only.
+
+## What Changes
+
+All changes are inside `packages/docx-core/src/integration/lean-spec-bridge.test.ts` and (if new primitives are needed) `packages/docx-core/src/testing/ooxml-fixtures.ts`. No Lean files, no production engine code.
+
+- **New `fragmentedFieldPairArb` arbitrary.** A *sibling* of `fieldBearingPairArb`, not an extra operation on it (its assertion model differs — see below). It generates `(original, revised)` body-XML pairs built with `buildDocxFromBodyXml` whose difference fragments a field's internal atoms under track changes, over a fixed set of **fragmented-field operations**:
+  - `result-edit` — clean → clean; identical complete field on both sides except the field **result** run text differs (e.g. `1` → `2`). The engine tracks the result-text change inside the field (probe: inplace, all invariants hold).
+  - `pretracked-fragmented-to-clean` — side `a` carries a pre-tracked fragmented field (`FRAGMENTED_NUMPAGES_MODIFICATION`-shaped: `instrText` already wrapped in `<w:ins>`/`<w:del>`, `fldChar` markers sibling-level), side `b` carries the clean complete field (probe: inplace, all invariants hold).
+  - `clean-to-pretracked-fragmented` — the reverse; side `a` clean, side `b` pre-tracked fragmented, with the field **result changed** between the sides (probe: **rebuild fallback**, `combined` field-validate false, accept/reject validate, round-trip holds — the mode-independence-critical case). The result change is guaranteed by construction (disjoint result pools), so this operation deterministically realizes the fallback outcome that floors the mode distribution.
+- **One new property test** over `fragmentedFieldPairArb` asserting, on **every** run regardless of reconstruction mode:
+  - `validateFieldStructure(acceptAllChanges(combined)) === true` and `validateFieldStructure(rejectAllChanges(combined)) === true` (INV-FIELD-001, on the projections — *not* on the raw combined output);
+  - normalized accepted text equals the revised input's normalized text, and normalized rejected text equals the original's, via the live `extractTextWithParagraphs` / `normalizeText` (INV-RT-001);
+  - it does **not** assert inplace mode and does **not** assert `validateFieldStructure(combined)`, because the engine correctly rebuilds part of this surface.
+- **Mode-distribution coverage floor.** The property records the reconstruction mode (`inplace` vs `rebuild`/fallback) and the operation per run, and asserts that **both** modes and **every** operation family were exercised — so the test fails loudly if the engine silently stops falling back (or stops staying inplace), or if a generator drops an operation, rather than passing vacuously. This mirrors `assertFieldBearingCoverage`, adapted to record mode instead of forcing it.
+- **Header / coverage-surface comment update.** The "Coverage surfaces" and "Fallback semantics" comment blocks are extended to (a) list the fragmented-field arbitrary and its operation families, and (b) record that for this arbitrary, **fallback is a legitimate, coverage-floored outcome, not falsification** — distinguishing it from the two whole-field/field-free arbitraries where fallback remains falsification. Asymmetry-of-rot: the comment must not let the reader assume "all bridge properties treat fallback as falsification" once one provably does not.
+- **`ooxml-fixtures.ts` additions only if needed.** If a parameterized fragmented-field builder beyond the existing `FRAGMENTED_NUMPAGES_MODIFICATION` constant is required (e.g. `fragmentedFieldModification(instr, result)`), it is added to `ooxml-fixtures.ts` per the AGENTS.md fixture-home rule, not inlined in the test.
+
+## Scope guardrails
+
+- **Fragmented-field surface only.** Whole-field operations stay owned by `fieldBearingPairArb`; this change does not touch it or the three single field fixtures.
+- **Nested fields and paragraph-spanning fields remain out of scope** and are deferred to a named successor (`add-nested-and-spanning-field-bridge-arbitrary`). They require new fixture primitives and separate empirical characterization.
+- **Inplace-mode comparison input only** (the comparison is invoked with `reconstructionMode: 'inplace'`); the engine's own fallback to `rebuild` is permitted and recorded, not suppressed.
+- **No new residual-axiom claims and no Lean changes.** This change strengthens empirical falsifiability of the two existing axioms over a harder surface; it does not discharge them (Tier 3 owns that) and adds no Lean code.
+- **No production-engine code changes.** Test layer only. In particular, the `round_trip_safety_check_failed` fallback observed on the `clean-to-pretracked-fragmented` operation is treated as correct engine behavior to be characterized, not a bug to fix in this change.
+
+## Impact
+
+- **Affected specs:** `docx-comparison` (one new ADDED requirement — see `specs/docx-comparison/spec.md`).
+- **Affected code:** `packages/docx-core/src/integration/lean-spec-bridge.test.ts` (new arbitrary + property test + coverage floor + header comment), `packages/docx-core/src/testing/ooxml-fixtures.ts` (parameterized fragmented-field builder only if required).
+- **No Lean changes. No production-engine code changes.**
+- **CI:** the new property runs in the standard `@usejunior/docx-core` workspace test job alongside the existing bridge properties; no new CI wiring. `npm run check:spec-coverage` must continue to pass once the new requirement's scenarios are mapped via `.openspec()` tags. The file already declares `const TEST_FEATURE`, so the `allure-labels` gate is satisfied.
+- **Runtime:** adds one `fc.assert` property at `numRuns: 100`, building and comparing real DOCX buffers — comparable to the existing field-bearing properties; the existing `{ timeout: 60_000 }` describe budget covers it.

--- a/openspec/changes/add-fragmented-field-bridge-arbitrary/specs/docx-comparison/spec.md
+++ b/openspec/changes/add-fragmented-field-bridge-arbitrary/specs/docx-comparison/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Fragmented-field property coverage falsifies the inplace residual axioms over generated fragmented-field documents
+
+The system SHALL exercise the two named residual axioms about this repo's inplace `compareDocumentXml` output — `compareDocumentXml_output_preservation_friendly` (INV-FIELD-001) and `compareDocumentXml_output_text_roundtrip` (INV-RT-001), declared in `verification/lean/LeanSpike/Spec.lean` — against the live TypeScript comparison engine over a **fast-check arbitrary that generates fragmented-field documents**: documents whose difference fragments a field's internal atoms (`w:instrText` / `w:delInstrText` / field result runs) into `<w:ins>` / `<w:del>` wrappers under track changes while the `w:fldChar` markers remain sibling-run-level and unwrapped.
+
+This requirement extends the field-bearing coverage added by "Field-bearing property coverage falsifies the inplace residual axioms over generated field documents" to the fragmented-field surface that requirement explicitly deferred. Nested fields and fields spanning paragraph boundaries remain out of scope and deferred to a named successor.
+
+The arbitrary (`fragmentedFieldPairArb`) SHALL be a sibling of `fieldBearingPairArb`, NOT a fourth operation on it, and SHALL generate `(original, revised)` body-XML pairs realizing one of a fixed set of fragmented-field operations:
+
+- `result-edit` — a complete, identical field on both clean sides except the field **result** run text differs, so the engine tracks a change inside the field;
+- `pretracked-fragmented-to-clean` — the original side carries a pre-tracked fragmented field (instruction text already wrapped in `<w:ins>`/`<w:del>`, `fldChar` markers sibling-level), the revised side carries the clean complete field;
+- `clean-to-pretracked-fragmented` — the reverse direction.
+
+Because the engine **correctly falls back to a non-inplace reconstruction** for part of this surface (empirically, `clean-to-pretracked-fragmented` drives a `rebuild` with `round_trip_safety_check_failed`), the property tests over this arbitrary SHALL assert **mode-independent** invariants and SHALL NOT treat inplace fallback as falsification. Specifically, on every run regardless of the reconstruction mode the engine selected, the property SHALL:
+
+- assert `validateFieldStructure(acceptAllChanges(combined))` and `validateFieldStructure(rejectAllChanges(combined))` — the INV-FIELD-001 obligation on the **resolved** projections, NOT on the raw mixed-revision `combined` output (which legitimately fails field-structure validation mid-revision under fallback);
+- assert that the normalized text of `acceptAllChanges(combined)` equals the revised input's normalized text and the normalized text of `rejectAllChanges(combined)` equals the original's, using the live `extractTextWithParagraphs` / `normalizeText`, with field result text counted and `instrText` / `delInstrText` / `fldChar` atoms contributing no text — the INV-RT-001 obligation;
+- NOT assert `assertInplaceResult` and NOT assert `validateFieldStructure(combined)`.
+
+The property SHALL record the `(operation, reconstruction-mode-or-fallback)` of each run and assert a coverage floor requiring that **both** an inplace outcome **and** a fallback outcome were observed **and** every operation family was exercised, so the engine silently degrading to all-inplace or all-fallback, or a generator dropping an operation, fails the property loudly rather than passing vacuously. The floor SHALL be satisfied deterministically via seeded `examples` rather than relying on the random generator.
+
+This requirement strengthens empirical falsifiability only; it introduces no Lean change and does not discharge either residual axiom (Tier 3 owns that). The existing field-free and field-bearing property tests and the single field fixtures SHALL remain unchanged.
+
+#### Scenario: [LEAN-FRAG-01] Fragmented-field arbitrary drives both residual axioms across operations
+
+- **GIVEN** the `fragmentedFieldPairArb` fast-check arbitrary generating `(original, revised)` pairs over the `result-edit`, `pretracked-fragmented-to-clean`, and `clean-to-pretracked-fragmented` operations
+- **WHEN** each generated pair is compared through the live engine with `reconstructionMode: 'inplace'` and the combined output is accepted and rejected
+- **THEN** `validateFieldStructure(acceptAllChanges(combined))` and `validateFieldStructure(rejectAllChanges(combined))` hold on every run, and the normalized accepted text equals the revised input's normalized text and the normalized rejected text equals the original's, with the property executing at `numRuns: 100`
+
+#### Scenario: [LEAN-FRAG-02] Inplace fallback is a legitimate, mode-independent outcome, not falsification
+
+- **WHEN** a generated run (e.g. `clean-to-pretracked-fragmented`) drives the engine to fall back from inplace to a `rebuild` reconstruction with `round_trip_safety_check_failed`
+- **THEN** the property still passes that run, asserting the INV-FIELD-001 and INV-RT-001 obligations on the resolved accept / reject projections rather than failing via `assertInplaceResult`
+- **AND** the property does not assert `validateFieldStructure(combined)` on the raw mixed-revision output, because a field mid-revision is not a single well-formed field until a side is chosen
+
+#### Scenario: [LEAN-FRAG-03] Mode-distribution and operation coverage are floored, not silently filtered
+
+- **WHEN** the fragmented-field property runs
+- **THEN** a coverage assertion requires that both an inplace outcome and a fallback outcome were observed across the run set, and that every fragmented-field operation family was exercised
+- **AND** the floor is satisfied deterministically via seeded `examples`, so the engine silently degrading to all-inplace or all-fallback — or a generator dropping an operation — fails the property loudly rather than being discarded by `fc.pre`
+
+#### Scenario: [LEAN-FRAG-04] Bridge file self-description distinguishes fallback-is-falsification from fallback-is-legitimate
+
+- **WHEN** a reader inspects the header comment blocks of `packages/docx-core/src/integration/lean-spec-bridge.test.ts`
+- **THEN** the "Coverage surfaces" block lists the fragmented-field arbitrary and its operation families
+- **AND** the "Fallback semantics" block records that the fragmented-field arbitrary treats inplace fallback as a legitimate, coverage-floored outcome (not falsification), distinguishing it from the field-free and whole-field arbitraries where fallback remains falsification

--- a/openspec/changes/add-fragmented-field-bridge-arbitrary/tasks.md
+++ b/openspec/changes/add-fragmented-field-bridge-arbitrary/tasks.md
@@ -1,0 +1,30 @@
+# Tasks: Fragmented-field fast-check arbitrary
+
+## 1. Fixture primitives (only if needed)
+
+- [x] 1.1 Confirm `FRAGMENTED_NUMPAGES_MODIFICATION` and `paragraphWithField` in `packages/docx-core/src/testing/ooxml-fixtures.ts` cover the three operations; if a parameterized builder is needed (e.g. `fragmentedFieldModification(instr, result)` or a `fieldWithResult(result)` helper), add it to `ooxml-fixtures.ts` per the AGENTS.md fixture-home rule — do NOT inline OOXML in the test.
+
+## 2. Arbitrary
+
+- [x] 2.1 Add `FragmentedFieldOperation` union (`result-edit` | `pretracked-fragmented-to-clean` | `clean-to-pretracked-fragmented`) and `FragmentedFieldPair` type.
+- [x] 2.2 Add `buildFragmentedFieldPair(operation, fieldType, shape)` mirroring `buildFieldBearingPair`, producing `{ operation, fieldType, originalBodyXml, revisedBodyXml }`.
+- [x] 2.3 Add seeded `fragmentedFieldExamples` (one deterministic pair per operation) and `fragmentedFieldPairArb` (`fc.record(...).map(buildFragmentedFieldPair)`), matching the `fieldBearingPairArb` construction.
+
+## 3. Property test + coverage floor
+
+- [x] 3.1 Add `assertFragmentedFieldCoverage` recording `(operation, mode-or-fallback)` and asserting both modes + every operation observed.
+- [x] 3.2 Add the INV-FIELD-001 + INV-RT-001 mode-independent property over `fragmentedFieldPairArb`: assert `validateFieldStructure` on accept and reject, and normalized accept==revised / reject==original; do NOT assert `assertInplaceResult` or `validateFieldStructure(combined)`. Run at `numRuns: NUM_RUNS + fragmentedFieldExampleArgs.length` with seeded `examples`.
+- [x] 3.3 Tag the property with `.openspec('[LEAN-FRAG-01] ...')`, `[LEAN-FRAG-02]`, `[LEAN-FRAG-03]` per the existing chained-`testAllure` idiom (file already declares `const TEST_FEATURE`).
+
+## 4. Header comment
+
+- [x] 4.1 Extend the "Coverage surfaces" block to list `fragmentedFieldPairArb` and its operations.
+- [x] 4.2 Extend the "Fallback semantics" block to record that the fragmented-field arbitrary treats fallback as a legitimate, coverage-floored outcome (not falsification), distinguishing it from the other arbitraries — and reference `[LEAN-FRAG-04]`.
+
+## 5. Validate
+
+- [x] 5.1 `npm run test:run --workspace=@usejunior/docx-core` (or the bridge test alone) — new property passes, no regression in existing bridge properties.
+- [x] 5.2 `npm run build && npm run lint:workspaces`.
+- [x] 5.3 `npm run check:spec-coverage` — the new `[LEAN-FRAG-*]` scenarios map to the tagged property; matrix regenerates clean.
+- [x] 5.4 `npm run check:conformance-citations && npm run check:conformance-doc`.
+- [x] 5.5 `openspec validate add-fragmented-field-bridge-arbitrary --strict`.

--- a/packages/docx-core/src/integration/lean-spec-bridge.test.ts
+++ b/packages/docx-core/src/integration/lean-spec-bridge.test.ts
@@ -14,6 +14,11 @@
  *   - Tier 2 field-bearing clean pairs whose `document.xml` carries a complete
  *     NUMPAGES / PAGE / PAGEREF field and realizes one focused operation:
  *       field-insert, field-delete, field-stable, text-only.
+ *   - Tier 2 fragmented-field pairs (`fragmentedFieldPairArb`) whose difference
+ *     fragments a field's internal atoms under track changes — a changed result
+ *     run and/or a pre-tracked field whose instruction code is already split
+ *     into `<w:ins>`/`<w:del>` — over the operations:
+ *       result-edit, pretracked-fragmented-to-clean, clean-to-pretracked-fragmented.
  *
  * These are empirical bridge tests, not the proofs themselves. As of the
  * `inv_rt_001` closure both theorems are closed (zero `sorry`) but each rests on a
@@ -34,11 +39,25 @@
  *     (b) `ContainerResolutionError` from container-topology mismatch.
  *   The two original generators (`pairArb`, `trackedPairArb`) are
  *   paragraph-only, table-free, and field-free, so (b) is not expected to fire
- *   there. The field-bearing arbitrary is narrower instead: it uses only
- *   complete fields at run boundaries and the inplace-safe operation families
- *   already covered by the fixed fixtures. We therefore treat fallback as
- *   falsification for all bridge properties and throw with
- *   `triage=inplace-fallback` diagnostics rather than filtering with `fc.pre`.
+ *   there. The whole-field arbitrary (`fieldBearingPairArb`) is narrower
+ *   instead: it uses only complete fields at run boundaries and the
+ *   inplace-safe operation families already covered by the fixed fixtures. For
+ *   all of these — `pairArb`, `trackedPairArb`, `fieldBearingPairArb` — we treat
+ *   fallback as falsification and throw with `triage=inplace-fallback`
+ *   diagnostics rather than filtering with `fc.pre`.
+ *
+ *   The fragmented-field arbitrary (`fragmentedFieldPairArb`) is the deliberate
+ *   EXCEPTION: on the clean→pretracked-fragmented operation with a result-text
+ *   change, the engine's inplace candidate fails the fieldStructure safety
+ *   check (it would place a `w:fldChar` in a `<w:del>`-adjacent context / break
+ *   per-story field validity), so the engine CORRECTLY falls back to rebuild and
+ *   still produces conformant accept/reject output. The residual axioms
+ *   constrain the comparison OUTPUT, not the reconstruction strategy, so for
+ *   this arbitrary fallback is a LEGITIMATE outcome: its property asserts the
+ *   invariants mode-independently (on the resolved accept/reject projections,
+ *   never on the raw combined output) and a mode-distribution coverage floor
+ *   requires both inplace and fallback outcomes to be observed, so a silent
+ *   all-inplace or all-fallback regression fails loudly rather than via `fc.pre`.
  *
  * INV-RT-001 tracked-input triage:
  *   - `triage=engine-bug`: accept/reject of `combined` disagrees with the fully
@@ -50,9 +69,10 @@
  *   - `triage=inplace-fallback`: the inplace candidate was never emitted.
  *
  * Coverage limitations (intentional for the spike — not bugs):
- *   - Fragmented, nested, and paragraph-spanning field input families still live
- *     outside this bridge property surface (for example in
- *     `collapsed-field-inplace.test.ts` / field-fragmentation fixtures).
+ *   - Nested fields and fields spanning paragraph boundaries still live outside
+ *     this bridge property surface (deferred to a named successor); the
+ *     fragmented (single-field, instruction/result fragmentation) surface IS now
+ *     covered by `fragmentedFieldPairArb`.
  *   - Small-edit/run-boundary regression coverage still lives in the fixture
  *     tests (`round-trip-inplace.test.ts`, `nvca-coi-regression.test.ts`).
  *   - Comment and footnote coverage here is limited to `document.xml` anchors;
@@ -69,6 +89,9 @@ import {
   COMPLETE_PAGEREF_FIELD,
   COMPLETE_NUMPAGES_FIELD,
   WHOLE_FIELD_IN_INS,
+  FIELD_INSTRUCTIONS,
+  completeField,
+  fragmentedFieldModification,
   buildDocxFromBodyXml,
   paragraphWithField,
   paragraphWithText,
@@ -416,6 +439,135 @@ const fieldBearingPairArb: fc.Arbitrary<FieldBearingPair> = fc
   })
   .map(({ operation, fieldType, shape }) => buildFieldBearingPair(operation, fieldType, shape));
 
+// ---------------------------------------------------------------------------
+// Fragmented-field arbitrary (sibling of fieldBearingPairArb)
+//
+// Where fieldBearingPairArb covers WHOLE, self-contained fields at run
+// boundaries, this arbitrary covers the harder fragmented surface: a field
+// whose result run changes under track changes, and/or a pre-tracked field
+// whose instruction code is already split into <w:ins>/<w:del> wrappers.
+//
+// Its property is MODE-INDEPENDENT: the residual axioms constrain the
+// comparison OUTPUT, not the reconstruction strategy. The engine correctly
+// falls back from inplace to a rebuild reconstruction for one operation of
+// this surface (clean → pretracked-fragmented with a result-text change, which
+// fails the inplace fieldStructure safety check), so — unlike the field-free /
+// whole-field arbitraries — fallback here is a LEGITIMATE outcome, not
+// falsification. The mode-distribution coverage floor (below) requires both an
+// inplace and a fallback outcome to be observed, so a silent all-inplace or
+// all-fallback regression fails loudly.
+// ---------------------------------------------------------------------------
+
+const FRAGMENTED_FIELD_OPERATIONS = [
+  'result-edit',
+  'pretracked-fragmented-to-clean',
+  'clean-to-pretracked-fragmented',
+] as const;
+
+type FragmentedFieldOperation = (typeof FRAGMENTED_FIELD_OPERATIONS)[number];
+
+// The instruction code that the pre-tracked fragmented field deletes (the "old"
+// code under <w:del>), distinct from the field type's own (the "new" code under
+// <w:ins>), so the modification is non-trivial.
+const FIELD_ALT_INSTRUCTIONS: Record<FieldType, string> = {
+  NUMPAGES: FIELD_INSTRUCTIONS.PAGE,
+  PAGE: FIELD_INSTRUCTIONS.NUMPAGES,
+  PAGEREF: FIELD_INSTRUCTIONS.PAGE,
+};
+
+interface FragmentedFieldPair {
+  operation: FragmentedFieldOperation;
+  fieldType: FieldType;
+  originalBodyXml: string;
+  revisedBodyXml: string;
+}
+
+interface FragmentedFieldShape {
+  prefix: string;
+  suffix: string;
+  originalResult: string;
+  revisedResult: string;
+}
+
+// originalResult and revisedResult are drawn from DISJOINT pools so they always
+// differ — guaranteeing a tracked result-text change, which (together with the
+// clean→pretracked-fragmented direction) is what deterministically drives the
+// engine's correct rebuild fallback and thus satisfies the mode floor.
+const fragmentedFieldShapeArb: fc.Arbitrary<FragmentedFieldShape> = fc.record({
+  prefix: fc.constantFrom('Total pages ', 'Page count ', 'See section '),
+  suffix: fc.constantFrom(' total.', ' here.', ' end.'),
+  originalResult: fc.constantFrom('1', '2', '3'),
+  revisedResult: fc.constantFrom('7', '8', '9'),
+});
+
+function buildFragmentedFieldPair(
+  operation: FragmentedFieldOperation,
+  fieldType: FieldType,
+  shape: FragmentedFieldShape,
+): FragmentedFieldPair {
+  const instruction = FIELD_INSTRUCTIONS[fieldType];
+  const altInstruction = FIELD_ALT_INSTRUCTIONS[fieldType];
+  const clean = (result: string) =>
+    paragraphWithField(shape.prefix, completeField(instruction, result), shape.suffix);
+  const fragmented = (result: string) =>
+    paragraphWithField(
+      shape.prefix,
+      fragmentedFieldModification(instruction, altInstruction, result),
+      shape.suffix,
+    );
+
+  switch (operation) {
+    case 'result-edit':
+      return {
+        operation,
+        fieldType,
+        originalBodyXml: clean(shape.originalResult),
+        revisedBodyXml: clean(shape.revisedResult),
+      };
+    case 'pretracked-fragmented-to-clean':
+      return {
+        operation,
+        fieldType,
+        originalBodyXml: fragmented(shape.originalResult),
+        revisedBodyXml: clean(shape.revisedResult),
+      };
+    case 'clean-to-pretracked-fragmented':
+      return {
+        operation,
+        fieldType,
+        originalBodyXml: clean(shape.originalResult),
+        revisedBodyXml: fragmented(shape.revisedResult),
+      };
+  }
+}
+
+// One deterministic example per (operation, fieldType). Seeded via fast-check
+// `examples` so the coverage floor is guaranteed every run: the
+// clean-to-pretracked-fragmented examples (result 3 → 7) deterministically
+// produce the fallback outcome and the other operations the inplace outcome.
+const fragmentedFieldExamples: FragmentedFieldPair[] = FRAGMENTED_FIELD_OPERATIONS.flatMap(
+  (operation) =>
+    FIELD_TYPES.map((fieldType) =>
+      buildFragmentedFieldPair(operation, fieldType, {
+        prefix: 'Total pages ',
+        suffix: ' end.',
+        originalResult: '3',
+        revisedResult: '7',
+      }),
+    ),
+);
+const fragmentedFieldExampleArgs = fragmentedFieldExamples.map(
+  (pair) => [pair] as [FragmentedFieldPair],
+);
+
+const fragmentedFieldPairArb: fc.Arbitrary<FragmentedFieldPair> = fc
+  .record({
+    operation: fc.constantFrom(...FRAGMENTED_FIELD_OPERATIONS),
+    fieldType: fc.constantFrom(...FIELD_TYPES),
+    shape: fragmentedFieldShapeArb,
+  })
+  .map(({ operation, fieldType, shape }) => buildFragmentedFieldPair(operation, fieldType, shape));
+
 async function getDocumentXml(document: Buffer): Promise<string> {
   const archive = await DocxArchive.load(document);
   return await archive.getDocumentXml();
@@ -479,6 +631,17 @@ async function compareSyntheticDocuments(
 }
 
 async function compareFieldBearingPair(pair: FieldBearingPair): Promise<CompareBridgeResult> {
+  const [original, revised] = await Promise.all([
+    buildDocxFromBodyXml(pair.originalBodyXml),
+    buildDocxFromBodyXml(pair.revisedBodyXml),
+  ]);
+
+  return compareDocumentBuffers(original, revised);
+}
+
+async function compareFragmentedFieldPair(
+  pair: FragmentedFieldPair,
+): Promise<CompareBridgeResult> {
   const [original, revised] = await Promise.all([
     buildDocxFromBodyXml(pair.originalBodyXml),
     buildDocxFromBodyXml(pair.revisedBodyXml),
@@ -551,6 +714,65 @@ function assertFieldBearingCoverage(invariant: string, coverage: FieldBearingCov
     throw new Error(
       `${invariant}: field-bearing operation/type coverage incomplete. ` +
         `missing=${missing.join(', ')} hits=${JSON.stringify(coverage)}`,
+    );
+  }
+}
+
+// Fragmented-field coverage is floored over TWO axes: the operation family, and
+// the reconstruction OUTCOME (inplace vs fallback). Recording the outcome — and
+// requiring both to appear — is the safety valve for not asserting
+// `assertInplaceResult` on this surface: it converts "the engine still both
+// stays-inplace and falls-back here" from an unstated assumption into a checked
+// invariant, so a regression that makes the surface all-inplace or all-fallback
+// fails loudly instead of passing vacuously.
+type ReconstructionOutcome = 'inplace' | 'fallback';
+const RECONSTRUCTION_OUTCOMES: readonly ReconstructionOutcome[] = ['inplace', 'fallback'];
+
+interface FragmentedFieldCoverage {
+  operations: Record<FragmentedFieldOperation, number>;
+  outcomes: Record<ReconstructionOutcome, number>;
+}
+
+function createFragmentedFieldCoverage(): FragmentedFieldCoverage {
+  return {
+    operations: Object.fromEntries(
+      FRAGMENTED_FIELD_OPERATIONS.map((operation) => [operation, 0]),
+    ) as Record<FragmentedFieldOperation, number>,
+    outcomes: { inplace: 0, fallback: 0 },
+  };
+}
+
+function reconstructionOutcome(result: CompareBridgeResult): ReconstructionOutcome {
+  // The comparison is always requested in inplace mode, so any non-inplace
+  // result is the engine's own fallback to rebuild.
+  return result.modeUsed === 'inplace' ? 'inplace' : 'fallback';
+}
+
+function recordFragmentedFieldHit(
+  coverage: FragmentedFieldCoverage,
+  pair: FragmentedFieldPair,
+  result: CompareBridgeResult,
+): void {
+  coverage.operations[pair.operation] += 1;
+  coverage.outcomes[reconstructionOutcome(result)] += 1;
+}
+
+function assertFragmentedFieldCoverage(
+  invariant: string,
+  coverage: FragmentedFieldCoverage,
+): void {
+  const missingOperations = FRAGMENTED_FIELD_OPERATIONS.filter(
+    (operation) => coverage.operations[operation] === 0,
+  );
+  const missingOutcomes = RECONSTRUCTION_OUTCOMES.filter(
+    (outcome) => coverage.outcomes[outcome] === 0,
+  );
+  if (missingOperations.length > 0 || missingOutcomes.length > 0) {
+    throw new Error(
+      `${invariant}: fragmented-field coverage incomplete. ` +
+        `missingOperations=${missingOperations.join(', ') || '(none)'} ` +
+        `missingOutcomes=${missingOutcomes.join(', ') || '(none)'} ` +
+        `hits=${JSON.stringify(coverage)}`,
     );
   }
 }
@@ -1167,6 +1389,89 @@ describe('Lean Spec Bridge - Inplace Reconstruction', { timeout: 60_000 }, () =>
             await allureJsonAttachment('field-bearing-operation-type-hits-inv-rt-001', coverage);
           }
           assertFieldBearingCoverage('INV-RT-001 field-bearing property', coverage);
+        },
+      );
+    },
+  );
+
+  test
+    .openspec(
+      '[LEAN-FRAG-01] Fragmented-field arbitrary drives both residual axioms across operations',
+    )
+    .openspec(
+      '[LEAN-FRAG-02] Inplace fallback is a legitimate, mode-independent outcome, not falsification',
+    )
+    .openspec(
+      '[LEAN-FRAG-03] Mode-distribution and operation coverage are floored, not silently filtered',
+    )
+    .openspec(
+      '[LEAN-FRAG-04] Bridge file self-description distinguishes fallback-is-falsification from fallback-is-legitimate',
+    )(
+    'INV-FIELD-001 + INV-RT-001: mode-independent invariants on fragmented-field comparison output',
+    async ({ given, when, then }: AllureBddContext) => {
+      const coverage = createFragmentedFieldCoverage();
+
+      await given(
+        'fragmented-field pairs are generated over result-edit, pretracked-fragmented-to-clean, and clean-to-pretracked-fragmented',
+        async () => {},
+      );
+
+      await when(
+        'each pair is compared through the live engine and the combined output is accepted and rejected, regardless of the reconstruction mode the engine selected',
+        async () => {},
+      );
+
+      await then(
+        'field structure holds on accept and reject, text round-trips, and both reconstruction modes plus every operation are exercised',
+        async () => {
+          try {
+            await fc.assert(
+              fc.asyncProperty(fragmentedFieldPairArb, async (pair) => {
+                const result = await compareFragmentedFieldPair(pair);
+                recordFragmentedFieldHit(coverage, pair, result);
+
+                const context = {
+                  operation: pair.operation,
+                  fieldType: pair.fieldType,
+                  modeUsed: result.modeUsed,
+                  fallbackReason: result.fallbackReason,
+                  originalBodyXml: pair.originalBodyXml,
+                  revisedBodyXml: pair.revisedBodyXml,
+                };
+
+                // Mode-independent: the residual axioms constrain the OUTPUT,
+                // not the reconstruction strategy. The engine correctly rebuilds
+                // the clean→pretracked-fragmented + result-change case (its
+                // inplace candidate fails the fieldStructure safety check), so we
+                // assert the INV-FIELD-001 and INV-RT-001 obligations on whatever
+                // output it produced — on the resolved accept/reject projections,
+                // NOT on the raw mixed-revision combined output — and we do NOT
+                // call assertInplaceResult or assertRecursivelyWellformed here.
+                assertFieldInvariant(
+                  'INV-FIELD-001 fragmented-field property',
+                  context,
+                  result.combined,
+                );
+                await assertRoundTripInvariant(
+                  'INV-RT-001 fragmented-field property',
+                  context,
+                  result,
+                );
+              }),
+              // fast-check runs `examples` from WITHIN the numRuns budget, so bump
+              // the budget by the example count to keep NUM_RUNS random cases on
+              // top of the deterministic operation×type seeds (which also floor
+              // the mode distribution: the clean→pretracked-fragmented seeds force
+              // the fallback outcome, the rest force inplace).
+              {
+                numRuns: NUM_RUNS + fragmentedFieldExampleArgs.length,
+                examples: fragmentedFieldExampleArgs,
+              },
+            );
+          } finally {
+            await allureJsonAttachment('fragmented-field-operation-and-mode-hits', coverage);
+          }
+          assertFragmentedFieldCoverage('fragmented-field property', coverage);
         },
       );
     },

--- a/packages/docx-core/src/integration/lean-spec-bridge.test.ts
+++ b/packages/docx-core/src/integration/lean-spec-bridge.test.ts
@@ -1395,18 +1395,10 @@ describe('Lean Spec Bridge - Inplace Reconstruction', { timeout: 60_000 }, () =>
   );
 
   test
-    .openspec(
-      '[LEAN-FRAG-01] Fragmented-field arbitrary drives both residual axioms across operations',
-    )
-    .openspec(
-      '[LEAN-FRAG-02] Inplace fallback is a legitimate, mode-independent outcome, not falsification',
-    )
-    .openspec(
-      '[LEAN-FRAG-03] Mode-distribution and operation coverage are floored, not silently filtered',
-    )
-    .openspec(
-      '[LEAN-FRAG-04] Bridge file self-description distinguishes fallback-is-falsification from fallback-is-legitimate',
-    )(
+    .openspec('[LEAN-FRAG-01] Fragmented-field arbitrary drives both residual axioms across operations')
+    .openspec('[LEAN-FRAG-02] Inplace fallback is a legitimate, mode-independent outcome, not falsification')
+    .openspec('[LEAN-FRAG-03] Mode-distribution and operation coverage are floored, not silently filtered')
+    .openspec('[LEAN-FRAG-04] Bridge file self-description distinguishes fallback-is-falsification from fallback-is-legitimate')(
     'INV-FIELD-001 + INV-RT-001: mode-independent invariants on fragmented-field comparison output',
     async ({ given, when, then }: AllureBddContext) => {
       const coverage = createFragmentedFieldCoverage();

--- a/packages/docx-core/src/testing/ooxml-fixtures.ts
+++ b/packages/docx-core/src/testing/ooxml-fixtures.ts
@@ -59,39 +59,59 @@ export function paragraphWithField(prefixText: string, field: string, suffixText
   return `<w:p>${resultText(escapeXmlText(prefixText))}${field}${resultText(escapeXmlText(suffixText))}</w:p>`;
 }
 
-export const COMPLETE_NUMPAGES_FIELD =
-  fldChar('begin') +
-  instrText(' NUMPAGES ', { preserve: true }) +
-  fldChar('separate') +
-  resultText('3') +
-  fldChar('end');
+// Field instruction-code strings, keyed by field type. Single source of truth so
+// the complete-field constants and the fragmented-field builder agree on the
+// exact instruction text per type.
+export const FIELD_INSTRUCTIONS = {
+  NUMPAGES: ' NUMPAGES ',
+  PAGE: ' PAGE ',
+  PAGEREF: ' PAGEREF _Toc123 \\h ',
+} as const;
 
-export const COMPLETE_PAGE_FIELD =
-  fldChar('begin') +
-  instrText(' PAGE ', { preserve: true }) +
-  fldChar('separate') +
-  resultText('1') +
-  fldChar('end');
+// A complete, self-contained simple field: begin → instrText → separate →
+// result → end. Generalizes the COMPLETE_* constants over instruction and
+// result text.
+export function completeField(instruction: string, result: string): string {
+  return (
+    fldChar('begin') +
+    instrText(instruction, { preserve: true }) +
+    fldChar('separate') +
+    resultText(result) +
+    fldChar('end')
+  );
+}
 
-export const COMPLETE_PAGEREF_FIELD =
-  fldChar('begin') +
-  instrText(' PAGEREF _Toc123 \\h ', { preserve: true }) +
-  fldChar('separate') +
-  resultText('42') +
-  fldChar('end');
+export const COMPLETE_NUMPAGES_FIELD = completeField(FIELD_INSTRUCTIONS.NUMPAGES, '3');
+
+export const COMPLETE_PAGE_FIELD = completeField(FIELD_INSTRUCTIONS.PAGE, '1');
+
+export const COMPLETE_PAGEREF_FIELD = completeField(FIELD_INSTRUCTIONS.PAGEREF, '42');
 
 // ECMA-376 conformant field-modification pattern: a field whose instruction
 // text is changing under track changes. The fldChars remain UNWRAPPED at the
 // sibling-run level (they cannot enter <w:del>), while the changed instrText
 // fragments into <w:ins>/<w:del> wrappers. See c-rex ECMA-376 Part 4 fldChar
 // topic + DeletedFieldCode placement constraint.
-export const FRAGMENTED_NUMPAGES_MODIFICATION =
-  fldChar('begin') +
-  `<w:ins>${instrText(' NUMPAGES ', { preserve: true })}</w:ins>` +
-  `<w:del>${delInstrText(' PAGE ', { preserve: true })}</w:del>` +
-  fldChar('separate') +
-  resultText('3') +
-  fldChar('end');
+export function fragmentedFieldModification(
+  newInstruction: string,
+  oldInstruction: string,
+  result: string,
+): string {
+  return (
+    fldChar('begin') +
+    `<w:ins>${instrText(newInstruction, { preserve: true })}</w:ins>` +
+    `<w:del>${delInstrText(oldInstruction, { preserve: true })}</w:del>` +
+    fldChar('separate') +
+    resultText(result) +
+    fldChar('end')
+  );
+}
+
+export const FRAGMENTED_NUMPAGES_MODIFICATION = fragmentedFieldModification(
+  FIELD_INSTRUCTIONS.NUMPAGES,
+  FIELD_INSTRUCTIONS.PAGE,
+  '3',
+);
 
 const W_NS_ATTR = ' xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
 


### PR DESCRIPTION
## Summary

Widens the Lean-spec-bridge field-bearing falsifiability layer (for the two residual axioms `compareDocumentXml_output_preservation_friendly` / INV-FIELD-001 and `compareDocumentXml_output_text_roundtrip` / INV-RT-001) to the **fragmented-field surface** that the predecessor `add-field-bearing-bridge-arbitrary` (#294) explicitly deferred. Test-layer only — **no Lean changes, no production-engine changes**.

## The design pivot (empirically grounded)

Probing the live engine on this surface overturned the predecessor's "fallback = falsification" assumption:

| fragmented pair | mode | `validate(combined)` | `validate(accept/reject)` | round-trip |
|---|---|---|---|---|
| result-text edit (clean→clean) | inplace | ✅ | ✅/✅ | ✅ |
| pre-tracked fragmented → clean | inplace | ✅ | ✅/✅ | ✅ |
| clean → pre-tracked fragmented, **result changed** | **rebuild (fallback)** | ❌ | ✅/✅ | ✅ |

The fallback diagnostics show all four inplace passes fail **only** the `fieldStructure` safety check (`acceptText`/`rejectText` pass) — the inplace candidate is non-conformant (#217 `fldChar`-in-`del` class), so the engine **correctly** rebuilds and produces conformant accept/reject output. The fallback is the engine defending itself, **not a bug to fix**.

So the new `fragmentedFieldPairArb` property asserts the axioms **mode-independently** — on the resolved accept/reject projections, never the raw combined output — and a **mode-distribution coverage floor** requires both an inplace *and* a fallback outcome to be observed, replacing `assertInplaceResult` so a silent all-inplace/all-fallback regression still fails loudly.

## Implementation

- `ooxml-fixtures.ts`: add `completeField` / `fragmentedFieldModification` / `FIELD_INSTRUCTIONS`; refactor `COMPLETE_*` and `FRAGMENTED_NUMPAGES_MODIFICATION` onto them (byte-identical values, existing tests guard drift).
- `lean-spec-bridge.test.ts`: `fragmentedFieldPairArb` (3 operations × 3 field types) + the mode-independent property + mode-distribution floor; header Coverage/Fallback comment blocks updated (asymmetry-of-rot: the file no longer claims "fallback = falsification for all bridge properties").
- OpenSpec change `add-fragmented-field-bridge-arbitrary` — ADD-only delta, scenarios `[LEAN-FRAG-01..04]`. Nested + paragraph-spanning fields deferred to a named successor.

## Verification

- [x] `npm run build` (clean)
- [x] `npm run lint:workspaces` (0 errors; 1 pre-existing warning in `docx-mcp/.../edit.test.ts`, unrelated)
- [x] `npm run test:run` (all workspaces pass; bridge file 60 tests, new property's coverage floor confirms both modes observed)
- [x] `npm run check:spec-coverage` (PASS)
- [x] `npm run check:conformance-citations` / `check:conformance-doc` (OK)
- [x] `openspec validate add-fragmented-field-bridge-arbitrary --strict` (valid)
- [ ] Peer review (Gemini + Codex) — pending; will be appended

## Scope

Test/falsifiability layer only. The `clean → pre-tracked fragmented` fallback is correct engine behavior; making inplace handle it would be a separate, larger reconstruction-path change for an artificial input and is **not** in scope here.