### PR TITLE
feat(verification): extend Lean↔TS differential to Tier 2 accept/reject/validate helpers (Tier 2.5)

### DIFF
--- a/.github/workflows/lean-build.yml
+++ b/.github/workflows/lean-build.yml
@@ -11,6 +11,11 @@ on:
       # so a change to either must re-run it — not just changes to the harness.
       - 'packages/docx-core/src/baselines/atomizer/atomLcs.ts'
       - 'packages/docx-core/src/core-types.ts'
+      # Tier 2-helper differential: guards the production accept/reject/validate engine
+      # against the Lean Tier 2 model, so a change to either re-runs it.
+      - 'packages/docx-core/src/integration/lean-differential-helpers.test.ts'
+      - 'packages/docx-core/src/baselines/atomizer/trackChangesAcceptorAst.ts'
+      - 'packages/docx-core/src/baselines/atomizer/pipeline.ts'
   pull_request:
     branches: [main]
     paths:
@@ -19,6 +24,9 @@ on:
       - 'packages/docx-core/src/integration/lean-differential-lcs.test.ts'
       - 'packages/docx-core/src/baselines/atomizer/atomLcs.ts'
       - 'packages/docx-core/src/core-types.ts'
+      - 'packages/docx-core/src/integration/lean-differential-helpers.test.ts'
+      - 'packages/docx-core/src/baselines/atomizer/trackChangesAcceptorAst.ts'
+      - 'packages/docx-core/src/baselines/atomizer/pipeline.ts'
   workflow_dispatch:
 
 permissions:
@@ -141,3 +149,14 @@ jobs:
         env:
           LEAN_DIFF_EXHAUSTIVE: '1'
         run: npm run test:run -w @usejunior/docx-core -- src/integration/lean-differential-lcs.test.ts
+
+      # Lean↔TS Tier 2-helper differential harness (Tier 2.5, second increment). `lake build`
+      # above also built the `leanHelperDifferential` exe (a @[default_target] lean_exe). This
+      # step runs the genuine `Tier2.AcceptReject.accept`/`.reject` and
+      # `Tier2.FieldStructure.validateFieldStructure` against the production
+      # accept/reject/validate engine over a widened randomized sweep, reusing the Node setup
+      # and `npm ci` above. `LEAN_DIFF_EXHAUSTIVE=1` widens this harness's random sweep too.
+      - name: Lean↔TS Tier 2-helper differential harness (extended)
+        env:
+          LEAN_DIFF_EXHAUSTIVE: '1'
+        run: npm run test:run -w @usejunior/docx-core -- src/integration/lean-differential-helpers.test.ts

--- a/openspec/changes/add-lean-ts-helper-differential-harness/design.md
+++ b/openspec/changes/add-lean-ts-helper-differential-harness/design.md
@@ -1,0 +1,88 @@
+# Design: Lean↔TS Tier 2-helper differential harness
+
+## Context
+
+Second Tier 2.5 increment. Mirrors the structure of `add-lean-ts-lcs-differential-harness` (a Lean executable reading batched JSON over stdin, a TS vitest harness spawning it once per chunk and asserting equality) but for the accept/reject/validate surface, which — unlike the LCS — needs a `Doc`→`document.xml` adapter and a non-trivial output comparison.
+
+## Decision 1 — differential execution of the genuine Lean `def`s, same as LCS
+
+The Lean executable links the **proved** Tier 2 modules and calls `Tier2.FieldStructure.validateFieldStructure`, `Tier2.AcceptReject.accept`, `Tier2.AcceptReject.reject` directly — never a re-implementation. Local `FromJson`/`ToJson` instances for `OoxmlModel.Atom`/`Run`/`Block`/`Paragraph` live in `DifferentialHelpers.lean` so the proved modules stay untouched (same pattern as `Differential.lean`'s local `Atom` instances).
+
+JSON import: `import Lean.Data.Json` + `open Lean` (the form verified working in the LCS increment — it brings `Json.parse`, the deriving handlers, and the typeclasses into scope; `import Lean` / `import Lean.Data.Json.FromToJson` do not).
+
+## Decision 2 — wire protocol (`Doc` as a tagged-union JSON tree)
+
+`Tier2.OoxmlModel.Doc = List Paragraph`. The opaque `PPr`/`RPr` markers carry no cross-boundary meaning (the engine has no equivalent), so they are fixed to their defaults and not encoded. The wire `Doc` is a JSON array of paragraphs:
+
+```
+Doc       := [ Paragraph ]
+Paragraph := { "body": [ Block ] }
+Block     := { "run":      { "content": [ Atom ] } }
+           | { "ins":      [ Block ] }
+           | { "del":      [ Block ] }
+           | { "moveFrom": [ Block ] }
+           | { "moveTo":   [ Block ] }
+           | { "other":    { "tag": String, "children": [ Block ] } }
+Atom      := { "text": String } | { "delText": String }
+           | { "instrText": String } | { "delInstrText": String }
+           | { "fldChar": "begin" | "separate" | "end" }
+```
+
+Stdin: `{ "cases": [ { "doc": Doc } ] }`. Stdout: `{ "results": [ { "validate": Bool, "accept": Doc, "reject": Doc } ] }`. The single-tag-object encoding is unambiguous and round-trips through hand-written `FromJson`/`ToJson` instances (Lean's auto-derivation for recursive inductives with a structure field is finicky; explicit instances are clearer and matched to the wire grammar above).
+
+## Decision 3 — the `Doc`→`document.xml` adapter (`renderDocToXml`)
+
+The TS harness renders the same abstract `Doc` to OOXML the engine can parse via its `@xmldom/xmldom` path (`parseDocumentXml`):
+
+```
+Doc        → <w:document xmlns:w="…"><w:body>{paragraphs}</w:body></w:document>
+Paragraph  → <w:p>{blocks}</w:p>
+Block.run  → <w:r>{atoms}</w:r>
+Block.ins  → <w:ins w:id="N" w:author="t" w:date="2020-01-01T00:00:00Z">{children}</w:ins>
+Block.del  → <w:del w:id="N" …>{children}</w:del>           (moveFrom/moveTo analogous)
+Block.other→ <{tag}>{children}</{tag}>     (tag ∈ a transparent-container allowlist)
+Atom.text          s → <w:t xml:space="preserve">{esc s}</w:t>   (wrapped in its run)
+Atom.delText       s → <w:delText xml:space="preserve">{esc s}</w:delText>
+Atom.instrText     s → <w:instrText xml:space="preserve">{esc s}</w:instrText>
+Atom.delInstrText  s → <w:delInstrText xml:space="preserve">{esc s}</w:delInstrText>
+Atom.fldChar       k → <w:fldChar w:fldCharType="begin|separate|end"/>
+```
+
+Wrapper attributes (`w:id`/`w:author`/`w:date`) are present for OOXML faithfulness; the engine's accept/reject keys off tag names (`unwrapAllByTagName('w:ins')`, etc.) and the validator ignores them, so their exact values do not affect the comparison. `other` tags are drawn from an allowlist of containers the engine descends through transparently (e.g. `w:hyperlink`, `w:sdtContent`), matching the Lean `other` semantics. Strings are generated over a tiny alphabet with no XML metacharacters, but `renderDocToXml` still entity-escapes defensively.
+
+## Decision 4 — comparison on a canonical token projection
+
+Lean `accept`/`reject` return a `Doc`; TS `acceptAllChanges`/`rejectAllChanges` return an XML string. Rather than string-compare (serializer-format-fragile) or build an inverse XML→Doc parser tied to wrapper attributes, both outputs reduce to one **canonical token stream**:
+
+- `docToTokens(doc: WireDoc): string[]` — flatten the Lean output `Doc` in document order: `P[` … `]` per paragraph, `R[` … `]` per run, wrapper tokens `INS[`/`DEL[`/`MOVEFROM[`/`MOVETO[`/`OTHER:tag[` … `]`, atom tokens `t:s` / `dt:s` / `it:s` / `dit:s` / `fc:begin|separate|end`.
+- `xmlToTokens(xml: string): string[]` — parse the TS output via `@xmldom/xmldom` and walk `w:p`/`w:r`/`w:ins`/…/`w:t`/`w:fldChar` producing the **same** grammar.
+
+`validate` is a plain `Bool` and compared directly. The two token streams are compared with structural deep-equality. The projection is total and order-preserving, so equal token streams ⇔ the two engines produced the same paragraph/run/wrapper/atom structure (modulo the opaque markers and wrapper attributes the model deliberately abstracts).
+
+## Decision 5 — the faithful subset and the characterization cases
+
+The default property generates `Doc`s **inside the subset where Lean and TS provably agree**, enforced by the arbitrary:
+
+1. **`fldChar` and `instrText` appear only in top-level runs, never inside any `ins`/`del`/`moveFrom`/`moveTo` wrapper** — avoids G1 (`fldChar` in `del` → TS-only invalid).
+2. **`delInstrText` is generated only in its one OOXML-legal home — inside a `del` wrapper, in an open pre-`separate` field** (via a dedicated field fragment). Both engines agree there (Lean walks transparently through `del`; TS requires exactly insideDel + open-field). This is the in-subset counterpart of the G2 characterization, which puts `delInstrText` *outside* `del` and diverges. `delInstrText` is otherwise excluded from random generation, so generated docs never straddle the G2 boundary.
+3. **Every paragraph retains surviving top-level content** — at least one top-level `run` with ≥1 non-deleted atom — so neither an accepted body (avoids G3) nor a rejected body of an `ins`-only paragraph (avoids G4) is ever empty-but-was-wrappered. The two engines' paragraph-collapse rules differ on BOTH operations (TS `acceptAllChanges` keeps `ins`-wrappered collapsing paragraphs; TS `rejectAllChanges` drops `ins`-only paragraphs; Lean `accept` drops only truly-empty bodies and Lean `reject` never drops), so the survivor run is what keeps both out of the random subset.
+
+Four explicit **characterization cases** assert the known divergences directly (fixed inputs, not generated), so each gap is a passing test that pins the limitation:
+
+- **[G1]** a `Doc` with `fldChar` inside `del`: Lean `validate = true`, TS `validateFieldStructure = false`.
+- **[G2]** a `Doc` with `delInstrText` in an open pre-`separate` field outside `del`: Lean `true`, TS `false`.
+- **[G3]** a `Doc` with a paragraph whose only content is an `ins` wrapping deleted/empty content: Lean `accept` drops the paragraph, TS keeps an empty `<w:p>` — asserted via the token projection.
+- **[G4]** a `Doc` with an `ins`-only paragraph (no surviving content): Lean `reject` keeps an empty `<w:p>` (its reject never drops paragraphs), TS `rejectAllChanges` removes it — the reject-side analog of G3, asserted via the token projection.
+
+If a future proof increment teaches the Lean model constraint (3) and the engine's accept/reject paragraph-collapse rules, these characterization cases are where the change shows up: they flip from asserting divergence to asserting agreement, and the corresponding subset restriction is lifted.
+
+## Decision 6 — negative control
+
+A self-test perturbs one side of one helper (e.g. swaps `accept` and `reject` outputs, or flips a `validate` bool) and confirms the gate fails with a per-case diff — proving the equality assertions are load-bearing, mirroring `[LEAN-DIFF-04]`.
+
+## Rejected alternatives
+
+- **Inverse XML→`Doc` parser for comparison.** More code, and couples the comparison to wrapper-attribute serialization; the token projection is simpler and attribute-agnostic.
+- **String-compare the rendered Lean output against the TS XML.** Brittle: depends on `@xmldom/xmldom` serializer whitespace/attribute-ordering and on re-deriving the engine's exact emit shape in Lean.
+- **Generate broadly and assert a weaker invariant.** Hides G1/G2/G3 instead of pinning them; violates the asymmetry-of-rot principle that limitations must over-disclose. The subset-plus-characterization split keeps the gate strict while making every known gap a visible, tested fact.
+- **Extend the Lean model to close G1/G2/G3 now.** Touches the `inv_field_001` proof; out of scope for a differential increment. Deferred to a proof increment, for which this harness is the worklist and regression guard.

--- a/openspec/changes/add-lean-ts-helper-differential-harness/proposal.md
+++ b/openspec/changes/add-lean-ts-helper-differential-harness/proposal.md
@@ -1,0 +1,48 @@
+# Change: Lean↔TS Tier 2-helper differential harness (Tier 2.5, second increment)
+
+## Why
+
+The first Tier 2.5 increment (`add-lean-ts-lcs-differential-harness`, merged) made the Lean↔TS **LCS** equivalence a reproducible in-CI gate by running the genuine `LeanSpike.computeAtomLcs` against the production TS `computeAtomLcs`. The named successor it deferred is this change: extend the same differential-execution discipline to the **Tier 2 track-change helpers** the spike actually models — `Tier2.AcceptReject.accept` / `.reject` and `Tier2.FieldStructure.validateFieldStructure` (`verification/lean/Tier2/`) — against the production engine `acceptAllChanges` / `rejectAllChanges` / `validateFieldStructure` (`packages/docx-core/src/baselines/atomizer/trackChangesAcceptorAst.ts`, `pipeline.ts`).
+
+The Tier 2 definitions claim to "mirror the production engine structurally rather than abstractly" (`Tier2/OoxmlModel.lean:5-7`). Today nothing executes that claim: the only check is the Lean-internal `inv_field_001` proof, which says the *model* is sound, not that the *model matches the code*. The LCS harness closed that gap for one surface; this closes it for the accept/reject/validate surface — the surface the headline `inv_field_001` theorem is actually about.
+
+### What the helper surface needs that LCS did not — the `Doc`→`document.xml` adapter
+
+The TS LCS took a plain atom array, so the harness fed both sides the same JSON. The helpers take a serialized **`document.xml` string** (`acceptAllChanges(documentXml: string): string`). So this increment must add a faithful **`Doc`→`document.xml` renderer**: the same abstract `Tier2.OoxmlModel.Doc` value (paragraphs → blocks → runs → atoms, with `ins`/`del`/`moveFrom`/`moveTo`/`other` wrappers) is encoded as JSON for the Lean executable AND rendered to OOXML for the production engine. Because the Lean helpers return a structured `Doc` while the TS helpers return an XML string, the harness compares on a **canonical token projection** both outputs reduce to deterministically — not fragile string equality.
+
+### Model-vs-engine gaps this surfaced (verified against the running engine)
+
+Dynamic probes against the real engine (and the peer review of this change) confirmed four places where the Lean Tier 2 model and the production engine genuinely disagree — exactly the findings a differential exists to produce:
+
+- **G1 — `w:fldChar` inside `w:del`.** TS `validateFieldStructure` returns **false** (`pipeline.ts:542`, the `insideDelDepth > 0` guard); the Lean `validateFieldStructure` walks transparently through `del` and returns **true** (`FieldStructure.lean:82-90`). The Lean model implements constraints (1) global begin/end balance and (2) instr-inside-open-field, but **not** constraint (3) field-chars-not-inside-`del`.
+- **G2 — `w:delInstrText` outside `w:del`.** In an open pre-`separate` field but not inside a `del` wrapper, TS returns **false** (`pipeline.ts:555`); Lean returns **true** (`stepAtom` checks only the separator bit, `FieldStructure.lean:68-71`).
+- **G3 — accept paragraph collapse.** A paragraph whose accepted body is empty *but which contained a `w:ins`/`w:moveTo` wrapper* is **kept** as an empty `<w:p>` by TS (the `if (insElements.length > 0) continue` skip, `trackChangesAcceptorAst.ts:399`) but **dropped** by Lean `accept` (`AcceptReject.lean:44`). The common del-only and empty-run cases agree.
+- **G4 — reject paragraph collapse.** An `w:ins`-only paragraph is **dropped** by TS `rejectAllChanges` (`trackChangesAcceptorAst.ts:536-578`) but **kept** as an empty `<w:p>` by Lean `reject`, which never drops paragraphs (`AcceptReject.lean:83-85`). This is the reject-side analog of G3; surfaced by the peer review.
+
+These are real characterized limitations of the current Lean model, not harness bugs. This change does **not** fix them in the proved modules (that touches the `inv_field_001` proof and belongs to a later proof increment); it **pins them down**: the strict-equality gate generates within the faithful subset where Lean and TS provably agree, and dedicated **characterization cases** assert each divergence (G1/G2/G3/G4) so the gap is over-disclosed and rot-proof rather than hidden — and becomes the concrete worklist for broadening the model.
+
+## What Changes
+
+- **New Lean executable `verification/lean/DifferentialHelpers.lean`** + `@[default_target] lean_exe leanHelperDifferential` in `verification/lean/lakefile.lean`. It reads a batched JSON document `{ "cases": [ { "doc": <Doc> } ] }` from stdin, runs `Tier2.FieldStructure.validateFieldStructure`, `Tier2.AcceptReject.accept`, and `Tier2.AcceptReject.reject` on each `Doc`, and emits `{ "results": [ { "validate": Bool, "accept": <Doc>, "reject": <Doc> } ] }` to stdout — one spawn amortized over the whole batch. Local `FromJson`/`ToJson` instances for the `OoxmlModel` datatypes keep the proved Tier 2 modules pristine. Plain executable code, no `sorry`; the zero-`sorry` audit stays green.
+- **New TS harness `packages/docx-core/src/integration/lean-differential-helpers.test.ts`** (vitest, `.openspec()` tags + `TEST_FEATURE`). It contains:
+  - a `fast-check` arbitrary producing `Doc` values **within the faithful subset** (`fldChar`/`instrText` only outside track-change wrappers; `delInstrText` only in its one OOXML-legal home inside `del`, in an open pre-separate field, where both engines agree; every paragraph keeps surviving top-level content so accept-collapse cannot trigger G3);
+  - a **`renderDocToXml(doc)`** adapter emitting a real `document.xml` string (parseable by the engine's `@xmldom/xmldom` path) and a parallel JSON encoder for the Lean executable;
+  - a **canonical token projection** `docToTokens` / `xmlToTokens` so the Lean output `Doc` and the TS output XML are compared on one normal form;
+  - the gate: for each generated `Doc`, assert `validate`, `accept`, and `reject` agree between the spawned Lean exe and the in-process TS helpers;
+  - **characterization cases** [G1]/[G2]/[G3]/[G4] asserting the *known* divergences, so the limitations are tested rather than merely documented;
+  - a skip-if-exe-absent gate (dev without the Lean toolchain still gets a green `npm test`); CI builds the exe so the gate is live.
+- **CI wiring in `.github/workflows/lean-build.yml`.** Add the new harness file (and the production helper sources `trackChangesAcceptorAst.ts`, `pipeline.ts`) to the `push`/`pull_request` `paths:` triggers, and a scoped run of the new test after `lake build`, reusing the Node setup the LCS harness added.
+
+## Scope guardrails
+
+- **Modeled helpers only.** `accept` / `reject` / `validateFieldStructure` — the three the spike actually defines. `extractTextContent` / `extractTextWithParagraphs` / `normalizeText` are **not** modeled in Lean Tier 2; covering them would require new Lean definitions and is deferred to a further increment (named `add-lean-ts-text-extraction-differential`).
+- **No production-engine changes and no proof changes.** `trackChangesAcceptorAst.ts` / `pipeline.ts` are read, never edited. The Tier 2 proved modules are not modified; G1/G2/G3/G4 are characterized, not fixed.
+- **Strict equality on the faithful subset.** Divergences inside the subset are genuine findings (a real harness failure to investigate), not a reason to weaken the assertion. The four known out-of-subset gaps are asserted explicitly as characterization cases.
+
+## Impact
+
+- **Affected specs:** `docx-comparison` (one new ADDED requirement — see `specs/docx-comparison/spec.md`).
+- **Affected code:** `verification/lean/DifferentialHelpers.lean` (new), `verification/lean/lakefile.lean`, `packages/docx-core/src/integration/lean-differential-helpers.test.ts` (new), `.github/workflows/lean-build.yml`. `verification/ROADMAP.md` updated to mark the Tier 2.5 second increment in progress and record G1/G2/G3/G4 as characterized model gaps.
+- **No production-engine code changes.**
+- **CI:** the new test runs inside the `lean-build` workflow (already provisions elan + the mathlib cache + Node from the LCS increment). `npm run check:spec-coverage` must continue to pass once the new requirement's scenarios are mapped via `.openspec()` tags; the test file declares `const TEST_FEATURE` so the `allure-labels` gate is satisfied.
+- **Runtime:** default mode adds one `fast-check` property at ~2,000 random `Doc`s (plus seeds) with the Lean exe spawned once per memory-bounded chunk; `LEAN_DIFF_EXHAUSTIVE=1` widens this to ~50,000 reproducible random `Doc`s — a larger randomized sweep, NOT exhaustive enumeration (the `Doc` grammar makes true enumeration impractical, so it is deliberately not claimed).

--- a/openspec/changes/add-lean-ts-helper-differential-harness/specs/docx-comparison/spec.md
+++ b/openspec/changes/add-lean-ts-helper-differential-harness/specs/docx-comparison/spec.md
@@ -1,0 +1,55 @@
+## ADDED Requirements
+
+### Requirement: Executable differential harness establishes Lean↔TS accept/reject/validate extensional equivalence reproducibly in CI
+
+The system SHALL exercise the genuine Lean Tier 2 track-change helpers — `Tier2.AcceptReject.accept`, `Tier2.AcceptReject.reject`, and `Tier2.FieldStructure.validateFieldStructure` (`verification/lean/Tier2/`) — against the production TypeScript engine `acceptAllChanges`, `rejectAllChanges`, and `validateFieldStructure` (`packages/docx-core/src/baselines/atomizer/trackChangesAcceptorAst.ts`, `pipeline.ts`) over shared generated inputs, asserting agreement as a reproducible CI gate. This extends the LCS differential (the merged `add-lean-ts-lcs-differential-harness`) to the accept/reject/validate surface that the headline `inv_field_001` theorem is about.
+
+The harness SHALL run the **actual compiled Lean definitions**, not a re-implementation: a Lean executable (`verification/lean/DifferentialHelpers.lean`, registered as the `leanHelperDifferential` `lean_exe` target) reads a batched JSON document `{ "cases": [ { "doc": Doc } ] }` from stdin, runs the three helpers per case, and emits `{ "results": [ { "validate": Bool, "accept": Doc, "reject": Doc } ] }` to stdout, where `Doc` is a tagged-union JSON encoding of `Tier2.OoxmlModel.Doc` (paragraphs → blocks → runs → atoms, with `ins`/`del`/`moveFrom`/`moveTo`/`other` wrappers; opaque `pPr`/`rPr` markers omitted). The executable SHALL contain no `sorry` and SHALL NOT alter the spike's zero-`sorry` status.
+
+A TypeScript property test (`packages/docx-core/src/integration/lean-differential-helpers.test.ts`) SHALL:
+
+- generate `Doc` values over a small alphabet via `fast-check`, constrained to the **faithful subset** in which the Lean model and the production engine provably agree: `fldChar`/`instrText` only in top-level runs (never inside a track-change wrapper), `delInstrText` only in its one OOXML-legal home inside a `del` wrapper in an open pre-`separate` field (where both engines agree), and every paragraph retaining surviving top-level content under accept;
+- render each generated `Doc` both to the Lean JSON encoding and, via a **`Doc`→`document.xml` adapter**, to a real OOXML `document.xml` string parseable by the engine's `@xmldom/xmldom` path;
+- run the TS helpers in-process per case and spawn the Lean executable **once per memory-bounded chunk** of the batch;
+- compare `accept`/`reject` outputs on a **canonical token projection** that both the Lean output `Doc` and the TS output XML reduce to deterministically (paragraph/run/wrapper/atom tokens in document order), and compare `validate` as a boolean, asserting strict per-case equality;
+- assert the four known **characterized model gaps** explicitly as fixed cases rather than hiding them: `fldChar` inside `del` (G1), `delInstrText` outside `del` (G2), accept of an `ins`-wrappered collapsing paragraph (G3), and reject of an `ins`-only paragraph (G4);
+- **skip** with a clear message when the Lean executable is absent (so a developer without the Lean toolchain still gets a green `npm test`), while CI builds the executable so the comparison runs there.
+
+The harness SHALL assert **strict** agreement on the faithful subset by default; any in-subset divergence is a genuine finding, NOT a reason to weaken the assertion. The out-of-subset gaps G1/G2/G3/G4 SHALL be asserted as documented divergences (characterization cases), forming the worklist for a later proof increment that teaches the Lean model the missing constraints. This requirement strengthens extensional-equivalence evidence between the existing Lean and TS helpers only; it introduces no production-engine change and modifies no proved Lean module.
+
+#### Scenario: [LEAN-HELP-01] Compiled Lean accept/reject/validate match the TS engine on generated docs in the faithful subset
+
+- **GIVEN** the `leanHelperDifferential` executable built from `verification/lean/DifferentialHelpers.lean` and a `fast-check` arbitrary generating `Doc`s within the faithful subset
+- **WHEN** each `Doc` is rendered to `document.xml`, run through both the in-process TS helpers and the spawned Lean executable, and the accept/reject outputs are reduced to the canonical token projection
+- **THEN** `validate` (boolean) and the accept and reject token streams are identical between the two on every generated case, asserted strictly
+
+#### Scenario: [LEAN-HELP-02] Harness skips cleanly without the Lean toolchain and runs in CI
+
+- **WHEN** the differential test runs where the `leanHelperDifferential` executable is absent (a developer without the Lean toolchain or an un-built `.lake`)
+- **THEN** the test skips with a message explaining the executable was not found, rather than failing
+- **AND** in CI the `lean-build` workflow builds the executable and triggers on the harness file and the production helper sources, so the comparison actually runs and gates merges
+
+#### Scenario: [LEAN-HELP-03] G1 — fldChar inside w:del is a characterized validate divergence
+
+- **WHEN** the harness runs the fixed [G1] `Doc` whose field characters sit inside a `del` wrapper
+- **THEN** the Lean `validateFieldStructure` returns `true` while the TS `validateFieldStructure` returns `false`, and the test asserts exactly this documented divergence (constraint (3), field-chars-not-inside-`del`, is unmodeled in the current Lean spike)
+
+#### Scenario: [LEAN-HELP-04] G2 — delInstrText outside w:del is a characterized validate divergence
+
+- **WHEN** the harness runs the fixed [G2] `Doc` with a `delInstrText` in an open pre-`separate` field outside any `del` wrapper
+- **THEN** the Lean `validateFieldStructure` returns `true` while the TS `validateFieldStructure` returns `false`, asserted as a documented divergence
+
+#### Scenario: [LEAN-HELP-05] G3 — accept paragraph-collapse is a characterized divergence
+
+- **WHEN** the harness runs the fixed [G3] `Doc` with a paragraph whose only content is a `w:ins` wrapping deleted/empty content
+- **THEN** the Lean `accept` drops the paragraph while the TS `acceptAllChanges` keeps an empty `<w:p>`, asserted via the token projection as a documented divergence
+
+#### Scenario: [LEAN-HELP-06] G4 — reject paragraph-collapse is a characterized divergence
+
+- **WHEN** the harness runs the fixed [G4] `Doc` with an `ins`-only paragraph (no surviving content)
+- **THEN** the Lean `reject` keeps an empty paragraph (its reject never drops paragraphs) while the TS `rejectAllChanges` removes the paragraph, asserted via the token projection as a documented divergence (the reject-side analog of G3)
+
+#### Scenario: [LEAN-HELP-07] A real divergence is caught, not masked
+
+- **WHEN** one helper's output is perturbed (e.g. accept and reject token streams swapped, or a `validate` bool flipped)
+- **THEN** the harness fails with a per-case diff identifying the diverging input `Doc` and the differing `validate` / accept / reject projection, demonstrating the equality assertions are load-bearing rather than vacuous

--- a/openspec/changes/add-lean-ts-helper-differential-harness/tasks.md
+++ b/openspec/changes/add-lean-ts-helper-differential-harness/tasks.md
@@ -1,0 +1,45 @@
+# Tasks: Lean↔TS Tier 2-helper differential harness
+
+## 1. Lean executable
+
+- [x] 1.1 Add `verification/lean/DifferentialHelpers.lean`: `import Lean.Data.Json` + `import Tier2.AcceptReject` (transitively brings `FieldStructure`/`OoxmlModel`), `open Lean Tier2.OoxmlModel Tier2.FieldStructure Tier2.AcceptReject`.
+- [x] 1.2 Hand-write `FromJson`/`ToJson` instances for `FldCharKind`, `Atom`, `Run`, `Block`, `Paragraph`, and the `Doc` alias, matching the tagged-union wire grammar in `design.md` (single-tag objects). Keep them local so the proved Tier 2 modules are untouched.
+- [x] 1.3 Define `CaseIn := { doc : Doc }`, `Input := { cases : List CaseIn }`, and a result encoder `{ validate := validateFieldStructure d, accept := accept d, reject := reject d }`.
+- [x] 1.4 `main : IO Unit` reads stdin, `Json.parse`, `fromJson?`, maps each case, emits `{ "results": [...] }` via `IO.println out.compress` (mirror `Differential.lean`).
+- [x] 1.5 Register `@[default_target] lean_exe leanHelperDifferential where root := \`DifferentialHelpers` in `verification/lean/lakefile.lean`.
+- [x] 1.6 `cd verification/lean && lake build` succeeds; zero-`sorry` audit finds nothing (no proof-hole keyword in comments or code).
+- [x] 1.7 Smoke the exe: a one-case batch round-trips `validate`/`accept`/`reject` for a simple `Doc`.
+
+## 2. TS harness — adapter + projection
+
+- [x] 2.1 Add `packages/docx-core/src/integration/lean-differential-helpers.test.ts` with `const TEST_FEATURE` and `.openspec()` tags (single-line, per the coverage-parser constraint).
+- [x] 2.2 Define the TS `WireDoc` types mirroring the wire grammar and a `fast-check` arbitrary generating `Doc`s within the **faithful subset** (Decision 5: no field-context atoms inside wrappers; `delInstrText` only inside `del`; every paragraph keeps surviving top-level content).
+- [x] 2.3 Implement `renderDocToXml(doc)` → a `document.xml` string parseable by `parseDocumentXml`, entity-escaping text; `other` tags from a transparent-container allowlist.
+- [x] 2.4 Implement `docToTokens(wireDoc)` and `xmlToTokens(xml)` producing the same canonical token grammar (Decision 4).
+- [x] 2.5 Resolve the exe path (`verification/lean/.lake/build/bin/leanHelperDifferential`); if absent, `skip` with a clear message.
+- [x] 2.6 Run the TS helpers in-process per case (`validateFieldStructure(xml)`, `acceptAllChanges(xml)`, `rejectAllChanges(xml)`); spawn the Lean exe **once per memory-bounded chunk**; parse results.
+- [x] 2.7 Assert per case: `validate` booleans equal; `xmlToTokens(acceptAllChanges(xml))` deep-equals `docToTokens(leanAccept)`; same for reject. On divergence, fail with a per-case diff (input doc + both token streams).
+
+## 3. Characterization + negative control
+
+- [x] 3.1 Add fixed characterization cases [G1] (`fldChar` in `del`), [G2] (`delInstrText` outside `del`), [G3] (accept drops vs keeps empty `w:ins` paragraph) asserting the documented divergence on each.
+- [x] 3.2 Add a negative-control self-test (perturb one helper's output) confirming the gate fails with a per-case diff.
+
+## 4. CI wiring
+
+- [x] 4.1 Add `packages/docx-core/src/integration/lean-differential-helpers.test.ts`, `packages/docx-core/src/baselines/atomizer/trackChangesAcceptorAst.ts`, and `packages/docx-core/src/baselines/atomizer/pipeline.ts` to both `push` and `pull_request` `paths:` in `.github/workflows/lean-build.yml`.
+- [x] 4.2 After the build step, add a scoped run: `npm run test:run -w @usejunior/docx-core -- src/integration/lean-differential-helpers.test.ts`, reusing the Node setup the LCS increment added (extend the existing run rather than duplicating the setup-node block).
+- [x] 4.3 Leave the zero-`sorry` audit step unchanged.
+
+## 5. Docs
+
+- [x] 5.1 Update `verification/ROADMAP.md`: mark the Tier 2.5 second increment in progress; record G1/G2/G3 as characterized model gaps and the worklist for the model-broadening proof increment.
+
+## 6. Verify
+
+- [x] 6.1 `cd verification/lean && lake build` green; `leanHelperDifferential` present.
+- [x] 6.2 `npm run test:run -w @usejunior/docx-core -- src/integration/lean-differential-helpers.test.ts` green (default + characterization + negative control).
+- [x] 6.3 Negative control flips red when armed, green when reverted.
+- [x] 6.4 `npm run build && npm run lint:workspaces`.
+- [x] 6.5 `npm run check:spec-coverage` — the new scenarios map to the tagged property.
+- [x] 6.6 `openspec validate add-lean-ts-helper-differential-harness --strict`.

--- a/packages/docx-core/src/integration/lean-differential-helpers.test.ts
+++ b/packages/docx-core/src/integration/lean-differential-helpers.test.ts
@@ -1,0 +1,607 @@
+/**
+ * Lean↔TS Tier 2-helper differential harness (Tier 2.5, second increment).
+ *
+ * Runs the GENUINE Lean Tier 2 helpers — `Tier2.FieldStructure.validateFieldStructure`,
+ * `Tier2.AcceptReject.accept`, `Tier2.AcceptReject.reject` (compiled to the
+ * `leanHelperDifferential` executable from `verification/lean/DifferentialHelpers.lean`)
+ * — against the production engine `validateFieldStructure`
+ * (`packages/docx-core/src/baselines/atomizer/pipeline.ts`), `acceptAllChanges`, and
+ * `rejectAllChanges` (`trackChangesAcceptorAst.ts`) over shared generated `Doc`s,
+ * asserting agreement. This extends the LCS differential
+ * (`lean-differential-lcs.test.ts`) to the accept/reject/validate surface the headline
+ * `inv_field_001` theorem is actually about.
+ *
+ * The helpers take a serialized `document.xml` string (not a plain atom array), so this
+ * harness adds a `Doc`→`document.xml` adapter (`renderDocToXml`) and, because the Lean
+ * helpers return a structured `Doc` while the TS helpers return XML, compares
+ * accept/reject on a canonical token projection (`docToTokens` / `xmlToTokens`) both
+ * outputs reduce to. `validate` is a plain boolean.
+ *
+ * Wire protocol (one subprocess spawn amortized over the whole batch, chunked):
+ *   stdin : { "cases":   [ { "doc": Doc } ] }
+ *   stdout: { "results": [ { "validate": bool, "accept": Doc, "reject": Doc } ] }
+ *
+ * Faithful subset: the random generator stays inside the region where the Lean model and
+ * the production engine provably agree — fldChar/instrText only in top-level runs;
+ * delInstrText only in its one OOXML-legal home (inside a w:del, in an open pre-separate
+ * field), where both engines agree; and every paragraph keeps a surviving top-level run.
+ * Four KNOWN model gaps live OUTSIDE that subset and are pinned by explicit
+ * characterization cases rather than hidden:
+ *   G1  fldChar inside w:del            → Lean validate=true,  TS validate=false
+ *   G2  delInstrText outside w:del      → Lean validate=true,  TS validate=false
+ *   G3  accept of an ins-wrappered      → Lean drops the paragraph, TS keeps empty <w:p>
+ *       paragraph that collapses to empty
+ *   G4  reject of an ins-only paragraph → Lean keeps an empty <w:p>, TS drops it
+ *       (Lean `reject` never drops paragraphs; the reject-side analog of G3)
+ * These are characterized limitations of the current Lean spike (it models field-balance
+ * and instr-inside-open-field but not the del-ancestry constraint, and its accept/reject
+ * use simpler paragraph-collapse rules than the engine); they are the worklist for a later
+ * model-broadening proof increment, not harness bugs.
+ *
+ * Gating: when the executable is absent (a developer without the Lean toolchain, or an
+ * un-built `.lake`), the suite is SKIPPED with a clear message so `npm test` stays green;
+ * CI builds the exe so the comparison actually runs there.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import fc from 'fast-check';
+import { describe, expect } from 'vitest';
+import { acceptAllChanges, rejectAllChanges } from '../baselines/atomizer/trackChangesAcceptorAst.js';
+import { validateFieldStructure } from '../baselines/atomizer/pipeline.js';
+import { parseDocumentXml } from '../baselines/atomizer/xmlToWmlElement.js';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+
+// Named const (not an inline literal) so `scripts/validate_allure_test_labels.mjs` can
+// map the `.openspec([LEAN-HELP-*])` tags deterministically to a feature.
+const TEST_FEATURE = 'Lean Differential Harness (Tier 2 helpers)';
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({ feature: TEST_FEATURE })
+  .conformance({ spec: 'ECMA-376', edition: 5, part: 4, section: '17.16.5' });
+
+const INTEGRATION_DIR = dirname(import.meta.url.replace('file://', ''));
+const PROJECT_ROOT = join(INTEGRATION_DIR, '../../../..');
+const LEAN_EXE = join(PROJECT_ROOT, 'verification/lean/.lake/build/bin/leanHelperDifferential');
+
+// `LEAN_DIFF_EXHAUSTIVE=1` (the same flag the LCS harness honours, so one CI env var
+// drives both) widens this into a larger RANDOMIZED sweep — not a true enumeration. The
+// Doc grammar (wrappers, fields, nesting) makes exhaustive enumeration impractical, so we
+// deliberately do not claim it; the fixed seed keeps the wider sweep reproducible.
+const EXTENDED = process.env.LEAN_DIFF_EXHAUSTIVE === '1';
+const SAMPLE_COUNT = EXTENDED ? 50_000 : 2000;
+const LEAN_CHUNK = 10_000; // cases per subprocess spawn (memory-bounded batching)
+const SPAWN_MAX_BUFFER = 256 * 1024 * 1024;
+const TEST_TIMEOUT = EXTENDED ? 600_000 : 30_000;
+
+// ---------------------------------------------------------------------------
+// Wire types — the tagged-union JSON encoding of `Tier2.OoxmlModel.Doc`.
+// ---------------------------------------------------------------------------
+
+type WireFldChar = 'begin' | 'separate' | 'end';
+type WireAtom =
+  | { text: string }
+  | { delText: string }
+  | { instrText: string }
+  | { delInstrText: string }
+  | { fldChar: WireFldChar };
+type WireBlock =
+  | { run: { content: WireAtom[] } }
+  | { ins: WireBlock[] }
+  | { del: WireBlock[] }
+  | { moveFrom: WireBlock[] }
+  | { moveTo: WireBlock[] }
+  | { other: { tag: string; children: WireBlock[] } };
+type WireParagraph = { body: WireBlock[] };
+type WireDoc = WireParagraph[];
+
+interface HelperResult {
+  validate: boolean;
+  accept: WireDoc;
+  reject: WireDoc;
+}
+
+/** Projected comparison surface for one case. */
+interface Projection {
+  validate: boolean;
+  accept: string[];
+  reject: string[];
+}
+
+interface Divergence {
+  index: number;
+  input: WireDoc;
+  field: 'validate' | 'accept' | 'reject';
+  ts: Projection;
+  lean: Projection;
+}
+
+// Containers the engine descends through transparently — the OOXML referents of the
+// Lean `other` block (it keeps them and recursively processes their children).
+const OTHER_ALLOWLIST = ['w:hyperlink', 'w:sdtContent'] as const;
+
+// ---------------------------------------------------------------------------
+// Doc → document.xml adapter.
+// ---------------------------------------------------------------------------
+
+function esc(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function atomToXml(a: WireAtom): string {
+  if ('text' in a) return `<w:t xml:space="preserve">${esc(a.text)}</w:t>`;
+  if ('delText' in a) return `<w:delText xml:space="preserve">${esc(a.delText)}</w:delText>`;
+  if ('instrText' in a) return `<w:instrText xml:space="preserve">${esc(a.instrText)}</w:instrText>`;
+  if ('delInstrText' in a) return `<w:delInstrText xml:space="preserve">${esc(a.delInstrText)}</w:delInstrText>`;
+  return `<w:fldChar w:fldCharType="${a.fldChar}"/>`;
+}
+
+// Wrapper attributes are present for OOXML faithfulness; accept/reject key off tag names
+// and the validator ignores them, so the exact values do not affect the comparison.
+const WRAP_ATTRS = 'w:id="1" w:author="t" w:date="2020-01-01T00:00:00Z"';
+
+function blockToXml(b: WireBlock): string {
+  if ('run' in b) return `<w:r>${b.run.content.map(atomToXml).join('')}</w:r>`;
+  if ('ins' in b) return `<w:ins ${WRAP_ATTRS}>${b.ins.map(blockToXml).join('')}</w:ins>`;
+  if ('del' in b) return `<w:del ${WRAP_ATTRS}>${b.del.map(blockToXml).join('')}</w:del>`;
+  if ('moveFrom' in b) return `<w:moveFrom ${WRAP_ATTRS}>${b.moveFrom.map(blockToXml).join('')}</w:moveFrom>`;
+  if ('moveTo' in b) return `<w:moveTo ${WRAP_ATTRS}>${b.moveTo.map(blockToXml).join('')}</w:moveTo>`;
+  return `<${b.other.tag}>${b.other.children.map(blockToXml).join('')}</${b.other.tag}>`;
+}
+
+function renderDocToXml(doc: WireDoc): string {
+  const body = doc.map((p) => `<w:p>${p.body.map(blockToXml).join('')}</w:p>`).join('');
+  return `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>${body}</w:body></w:document>`;
+}
+
+// ---------------------------------------------------------------------------
+// Canonical token projection — Lean output Doc and TS output XML reduce to one
+// order-preserving token grammar. Equal token streams ⇔ same paragraph / run /
+// wrapper / atom structure (modulo the opaque markers + attributes the model abstracts).
+// ---------------------------------------------------------------------------
+
+function atomTokens(a: WireAtom): string {
+  if ('text' in a) return `t:${a.text}`;
+  if ('delText' in a) return `dt:${a.delText}`;
+  if ('instrText' in a) return `it:${a.instrText}`;
+  if ('delInstrText' in a) return `dit:${a.delInstrText}`;
+  return `fc:${a.fldChar}`;
+}
+
+function blockTokens(b: WireBlock, out: string[]): void {
+  if ('run' in b) {
+    out.push('R[');
+    for (const a of b.run.content) out.push(atomTokens(a));
+    out.push(']');
+  } else if ('ins' in b) {
+    out.push('INS[');
+    for (const c of b.ins) blockTokens(c, out);
+    out.push(']');
+  } else if ('del' in b) {
+    out.push('DEL[');
+    for (const c of b.del) blockTokens(c, out);
+    out.push(']');
+  } else if ('moveFrom' in b) {
+    out.push('MF[');
+    for (const c of b.moveFrom) blockTokens(c, out);
+    out.push(']');
+  } else if ('moveTo' in b) {
+    out.push('MT[');
+    for (const c of b.moveTo) blockTokens(c, out);
+    out.push(']');
+  } else {
+    out.push(`OTHER:${b.other.tag}[`);
+    for (const c of b.other.children) blockTokens(c, out);
+    out.push(']');
+  }
+}
+
+function docToTokens(doc: WireDoc): string[] {
+  const out: string[] = [];
+  for (const p of doc) {
+    out.push('P[');
+    for (const b of p.body) blockTokens(b, out);
+    out.push(']');
+  }
+  return out;
+}
+
+function childElements(node: Element): Element[] {
+  const result: Element[] = [];
+  for (let child = node.firstChild; child; child = child.nextSibling) {
+    if (child.nodeType === 1) result.push(child as Element);
+  }
+  return result;
+}
+
+const WRAP_TOKEN: Record<string, string> = {
+  'w:ins': 'INS',
+  'w:del': 'DEL',
+  'w:moveFrom': 'MF',
+  'w:moveTo': 'MT',
+};
+const SKIP_TAGS = new Set(['w:pPr', 'w:rPr']);
+
+function xmlRunTokens(run: Element, out: string[]): void {
+  out.push('R[');
+  for (const child of childElements(run)) {
+    const tag = child.tagName;
+    if (SKIP_TAGS.has(tag)) continue;
+    if (tag === 'w:t') out.push(`t:${child.textContent ?? ''}`);
+    else if (tag === 'w:delText') out.push(`dt:${child.textContent ?? ''}`);
+    else if (tag === 'w:instrText') out.push(`it:${child.textContent ?? ''}`);
+    else if (tag === 'w:delInstrText') out.push(`dit:${child.textContent ?? ''}`);
+    else if (tag === 'w:fldChar') out.push(`fc:${child.getAttribute('w:fldCharType') ?? ''}`);
+    else throw new Error(`unexpected run child <${tag}> in TS output`);
+  }
+  out.push(']');
+}
+
+function xmlBlockTokens(el: Element, out: string[]): void {
+  const tag = el.tagName;
+  if (SKIP_TAGS.has(tag)) return;
+  if (tag === 'w:r') {
+    xmlRunTokens(el, out);
+    return;
+  }
+  if (tag in WRAP_TOKEN) {
+    out.push(`${WRAP_TOKEN[tag]}[`);
+    for (const child of childElements(el)) xmlBlockTokens(child, out);
+    out.push(']');
+    return;
+  }
+  if ((OTHER_ALLOWLIST as readonly string[]).includes(tag)) {
+    out.push(`OTHER:${tag}[`);
+    for (const child of childElements(el)) xmlBlockTokens(child, out);
+    out.push(']');
+    return;
+  }
+  throw new Error(`unexpected block <${tag}> in TS output`);
+}
+
+function xmlToTokens(xml: string): string[] {
+  const root = parseDocumentXml(xml);
+  const bodies = root.getElementsByTagName('w:body');
+  const body = bodies.length > 0 ? (bodies[0] as Element) : root;
+  const out: string[] = [];
+  for (const p of childElements(body)) {
+    if (p.tagName !== 'w:p') continue; // ignore w:sectPr etc. (not generated)
+    out.push('P[');
+    for (const child of childElements(p)) xmlBlockTokens(child, out);
+    out.push(']');
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// TS-side and Lean-side projections.
+// ---------------------------------------------------------------------------
+
+function tsProjection(doc: WireDoc): Projection {
+  const xml = renderDocToXml(doc);
+  return {
+    validate: validateFieldStructure(xml),
+    accept: xmlToTokens(acceptAllChanges(xml)),
+    reject: xmlToTokens(rejectAllChanges(xml)),
+  };
+}
+
+function leanProjection(r: HelperResult): Projection {
+  return { validate: r.validate, accept: docToTokens(r.accept), reject: docToTokens(r.reject) };
+}
+
+/** Run the genuine Lean exe over a doc batch, spawning once per chunk. */
+function leanHelperBatch(docs: WireDoc[]): HelperResult[] {
+  const out: HelperResult[] = [];
+  for (let i = 0; i < docs.length; i += LEAN_CHUNK) {
+    const chunk = docs.slice(i, i + LEAN_CHUNK);
+    const payload = JSON.stringify({ cases: chunk.map((doc) => ({ doc })) });
+    const proc = spawnSync(LEAN_EXE, [], {
+      input: payload,
+      encoding: 'utf8',
+      maxBuffer: SPAWN_MAX_BUFFER,
+    });
+    if (proc.error) throw new Error(`leanHelperDifferential failed to spawn: ${proc.error.message}`);
+    if (proc.status !== 0) throw new Error(`leanHelperDifferential exited ${proc.status}: ${proc.stderr}`);
+    const parsed = JSON.parse(proc.stdout) as { results: HelperResult[] };
+    out.push(...parsed.results);
+  }
+  return out;
+}
+
+function key(tokens: string[]): string {
+  return JSON.stringify(tokens);
+}
+
+/** Compare TS vs Lean per case; collect divergences (empty array = full agreement). */
+function findDivergences(docs: WireDoc[], leanResults: HelperResult[]): Divergence[] {
+  const divergences: Divergence[] = [];
+  for (let i = 0; i < docs.length; i++) {
+    const ts = tsProjection(docs[i]!);
+    const lean = leanProjection(leanResults[i]!);
+    let field: Divergence['field'] | null = null;
+    if (ts.validate !== lean.validate) field = 'validate';
+    else if (key(ts.accept) !== key(lean.accept)) field = 'accept';
+    else if (key(ts.reject) !== key(lean.reject)) field = 'reject';
+    if (field !== null) divergences.push({ index: i, input: docs[i]!, field, ts, lean });
+  }
+  return divergences;
+}
+
+// ---------------------------------------------------------------------------
+// Faithful-subset generator (Decision 5).
+// ---------------------------------------------------------------------------
+
+const textAtom: fc.Arbitrary<WireAtom> = fc.constantFrom('a', 'b').map((s) => ({ text: s }));
+const delTextAtom: fc.Arbitrary<WireAtom> = fc.constantFrom('x', 'y').map((s) => ({ delText: s }));
+
+const textRun: fc.Arbitrary<WireBlock> = fc
+  .array(textAtom, { minLength: 1, maxLength: 2 })
+  .map((content) => ({ run: { content } }));
+const delRun: fc.Arbitrary<WireBlock> = fc
+  .array(delTextAtom, { minLength: 1, maxLength: 2 })
+  .map((content) => ({ run: { content } }));
+
+const insBlock: fc.Arbitrary<WireBlock> = fc
+  .array(textRun, { minLength: 1, maxLength: 2 })
+  .map((children) => ({ ins: children }));
+const delBlock: fc.Arbitrary<WireBlock> = fc
+  .array(delRun, { minLength: 1, maxLength: 2 })
+  .map((children) => ({ del: children }));
+const moveFromBlock: fc.Arbitrary<WireBlock> = fc
+  .array(delRun, { minLength: 1, maxLength: 2 })
+  .map((children) => ({ moveFrom: children }));
+const moveToBlock: fc.Arbitrary<WireBlock> = fc
+  .array(textRun, { minLength: 1, maxLength: 2 })
+  .map((children) => ({ moveTo: children }));
+const otherBlock: fc.Arbitrary<WireBlock> = fc
+  .record({ tag: fc.constantFrom(...OTHER_ALLOWLIST), children: fc.array(textRun, { minLength: 1, maxLength: 2 }) })
+  .map((other) => ({ other }));
+
+// Helpers to build top-level field fragments (always outside any wrapper, so G1/G2 cannot
+// trigger). Both well-formed (validate=true) and malformed (validate=false) variants are
+// generated; every malformed variant below is rejected by BOTH engines identically.
+const fc_begin: WireBlock = { run: { content: [{ fldChar: 'begin' }] } };
+const fc_sep: WireBlock = { run: { content: [{ fldChar: 'separate' }] } };
+const fc_end: WireBlock = { run: { content: [{ fldChar: 'end' }] } };
+const instr = (s: string): WireBlock => ({ run: { content: [{ instrText: s }] } });
+
+// A `delInstrText` in its only OOXML-legal home: inside a `w:del`, in an open pre-separate
+// field. Both engines agree here (Lean walks transparently through del; TS requires exactly
+// insideDel + open-field), so this is the in-subset counterpart of the G2 characterization
+// (which puts delInstrText OUTSIDE del and diverges). On reject it renames to instrText.
+const delInstr = (s: string): WireBlock => ({ del: [{ run: { content: [{ delInstrText: s }] } }] });
+
+// Both well-formed (validate=true) and malformed (validate=false) variants; every
+// malformed variant below is rejected by BOTH engines identically (instr/end at depth 0,
+// unbalanced begin/end, instr after separate), so they stay inside the agreeing subset.
+const fieldFragmentArb: fc.Arbitrary<WireBlock[]> = fc.constantFrom(
+  [fc_begin, instr('PAGE'), fc_sep, { run: { content: [{ text: 'a' }] } }, fc_end],
+  [fc_begin, instr('PAGE'), fc_end],
+  [fc_begin, delInstr('PAGE'), fc_sep, { run: { content: [{ text: 'a' }] } }, fc_end], // delInstrText inside del (legal)
+  [fc_begin, delInstr('PAGE'), fc_end],
+  [fc_begin, fc_sep, instr('PAGE'), fc_end],
+  [instr('PAGE')],
+  [fc_begin],
+  [fc_end],
+);
+
+// Each "segment" is a list of blocks (so a multi-block field fragment can be spliced in).
+const segment: fc.Arbitrary<WireBlock[]> = fc.oneof(
+  textRun.map((b) => [b]),
+  insBlock.map((b) => [b]),
+  delBlock.map((b) => [b]),
+  moveFromBlock.map((b) => [b]),
+  moveToBlock.map((b) => [b]),
+  otherBlock.map((b) => [b]),
+  fieldFragmentArb,
+);
+
+// Every paragraph starts with a surviving top-level run (visible text), so accept never
+// collapses it to empty and reject never treats it as ins-only — this is what keeps G3 out
+// of the random subset.
+const paragraphArb: fc.Arbitrary<WireParagraph> = fc
+  .tuple(textRun, fc.array(segment, { minLength: 0, maxLength: 3 }))
+  .map(([survivor, segs]) => ({ body: [survivor, ...segs.flat()] }));
+
+const docArb: fc.Arbitrary<WireDoc> = fc.array(paragraphArb, { minLength: 1, maxLength: 3 });
+
+const SEED_DOCS: WireDoc[] = [
+  [{ body: [{ run: { content: [{ text: 'a' }] } }] }], // plain
+  [{ body: [{ run: { content: [{ text: 'a' }] } }, { del: [{ run: { content: [{ delText: 'x' }] } }] }] }],
+  [{ body: [{ run: { content: [{ text: 'a' }] } }, { ins: [{ run: { content: [{ text: 'b' }] } }] }] }],
+  [{ body: [{ run: { content: [{ text: 'a' }] } }, { moveFrom: [{ run: { content: [{ delText: 'x' }] } }] }] }],
+  [{ body: [{ run: { content: [{ text: 'a' }] } }, { moveTo: [{ run: { content: [{ text: 'b' }] } }] }] }],
+  [{ body: [{ run: { content: [{ text: 'a' }] } }, ...[fc_begin, instr('PAGE'), fc_sep, { run: { content: [{ text: 'r' }] } }, fc_end]] }],
+  // delInstrText in its legal home (inside del, open pre-separate field) — in-subset, agrees.
+  [{ body: [{ run: { content: [{ text: 'a' }] } }, fc_begin, delInstr('PAGE'), fc_sep, { run: { content: [{ text: 'r' }] } }, fc_end] }],
+  [{ body: [{ run: { content: [{ text: 'a' }] } }, { other: { tag: 'w:hyperlink', children: [{ run: { content: [{ text: 'b' }] } }] } }] }],
+];
+
+function buildDocs(): WireDoc[] {
+  const sampled = fc.sample(docArb, { numRuns: SAMPLE_COUNT, seed: 0xf1e1d });
+  return [...SEED_DOCS, ...sampled];
+}
+
+// ---------------------------------------------------------------------------
+// Characterization fixtures (the three KNOWN out-of-subset model gaps).
+// ---------------------------------------------------------------------------
+
+/** G1: fldChar inside w:del. */
+const G1_DOC: WireDoc = [
+  { body: [{ del: [{ run: { content: [{ fldChar: 'begin' }] } }] }, { run: { content: [{ fldChar: 'end' }] } }] },
+];
+/** G2: delInstrText in an open pre-separate field, outside w:del. */
+const G2_DOC: WireDoc = [
+  {
+    body: [
+      { run: { content: [{ fldChar: 'begin' }] } },
+      { run: { content: [{ delInstrText: 'X' }] } },
+      { run: { content: [{ fldChar: 'end' }] } },
+    ],
+  },
+];
+/** G3: a paragraph whose only content is an ins wrapping deleted content (accept side). */
+const G3_DOC: WireDoc = [
+  { body: [{ ins: [{ del: [{ run: { content: [{ delText: 'x' }] } }] }] }] },
+  { body: [{ run: { content: [{ text: 'keep' }] } }] },
+];
+/** G4: an ins-only paragraph (reject side — the analog of G3 for reject). */
+const G4_DOC: WireDoc = [
+  { body: [{ ins: [{ run: { content: [{ text: 'b' }] } }] }] },
+  { body: [{ run: { content: [{ text: 'keep' }] } }] },
+];
+
+const exeExists = existsSync(LEAN_EXE);
+if (!exeExists) {
+  // eslint-disable-next-line no-console
+  console.warn(
+    `[lean-differential-helpers] SKIP: ${LEAN_EXE} not found. ` +
+      `Build it with: (cd verification/lean && lake build leanHelperDifferential)`,
+  );
+}
+const describeMaybe = exeExists ? describe : describe.skip;
+
+describeMaybe('Lean Differential Harness - Tier 2 helper extensional equivalence', () => {
+  test
+    .openspec('[LEAN-HELP-01] Compiled Lean accept/reject/validate match the TS engine on generated docs in the faithful subset')
+    .openspec('[LEAN-HELP-02] Harness skips cleanly without the Lean toolchain and runs in CI')(
+    'genuine Lean accept/reject/validate and the TS engine agree on every generated doc',
+    async ({ given, when, then }: AllureBddContext) => {
+      let docs: WireDoc[] = [];
+      let leanResults: HelperResult[] = [];
+
+      await given(
+        `${SEED_DOCS.length} seeded docs plus ${SAMPLE_COUNT} random docs within the faithful subset`,
+        async () => {
+          docs = buildDocs();
+        },
+      );
+
+      await when('each doc is rendered to document.xml, run through the TS engine and the spawned Lean exe', async () => {
+        leanResults = leanHelperBatch(docs);
+        expect(leanResults.length).toBe(docs.length);
+      });
+
+      await then('validate, and the accept/reject token projections, are identical on every case', async () => {
+        const divergences = findDivergences(docs, leanResults);
+        expect(
+          divergences.length,
+          divergences.length === 0
+            ? ''
+            : `${divergences.length}/${docs.length} cases diverged. First (${divergences[0]!.field}): ${JSON.stringify(divergences[0])}`,
+        ).toBe(0);
+      });
+    },
+    TEST_TIMEOUT,
+  );
+
+  test.openspec('[LEAN-HELP-03] G1 — fldChar inside w:del is a characterized validate divergence')(
+    'fldChar inside w:del: Lean validate=true, TS validate=false (constraint (3) unmodeled)',
+    async ({ given, when, then }: AllureBddContext) => {
+      let lean: HelperResult;
+      await given('a doc whose field characters sit inside a w:del wrapper', async () => {
+        lean = leanHelperBatch([G1_DOC])[0]!;
+      });
+      let tsValidate = false;
+      await when('both engines validate it', async () => {
+        tsValidate = validateFieldStructure(renderDocToXml(G1_DOC));
+      });
+      await then('Lean accepts it (true) while the TS engine rejects it (false)', async () => {
+        expect(lean!.validate).toBe(true);
+        expect(tsValidate).toBe(false);
+      });
+    },
+  );
+
+  test.openspec('[LEAN-HELP-04] G2 — delInstrText outside w:del is a characterized validate divergence')(
+    'delInstrText outside w:del: Lean validate=true, TS validate=false',
+    async ({ given, when, then }: AllureBddContext) => {
+      let lean: HelperResult;
+      await given('a doc with a delInstrText in an open pre-separate field outside any w:del', async () => {
+        lean = leanHelperBatch([G2_DOC])[0]!;
+      });
+      let tsValidate = false;
+      await when('both engines validate it', async () => {
+        tsValidate = validateFieldStructure(renderDocToXml(G2_DOC));
+      });
+      await then('Lean accepts it (true) while the TS engine rejects it (false)', async () => {
+        expect(lean!.validate).toBe(true);
+        expect(tsValidate).toBe(false);
+      });
+    },
+  );
+
+  test.openspec('[LEAN-HELP-05] G3 — accept paragraph-collapse is a characterized divergence')(
+    'accept of an ins-wrappered collapsing paragraph: Lean drops it, TS keeps an empty <w:p>',
+    async ({ given, when, then }: AllureBddContext) => {
+      let lean: HelperResult;
+      await given('a doc whose first paragraph is only a w:ins wrapping deleted content', async () => {
+        lean = leanHelperBatch([G3_DOC])[0]!;
+      });
+      let tsAccept: string[] = [];
+      let leanAccept: string[] = [];
+      await when('both engines accept it', async () => {
+        tsAccept = xmlToTokens(acceptAllChanges(renderDocToXml(G3_DOC)));
+        leanAccept = docToTokens(lean!.accept);
+      });
+      await then('Lean keeps one paragraph (the survivor) while the TS engine keeps two (one empty)', async () => {
+        // Lean drops the collapsing paragraph: only the "keep" paragraph remains.
+        expect(leanAccept).toEqual(['P[', 'R[', 't:keep', ']', ']']);
+        // TS keeps an empty <w:p> for the collapsed paragraph, so the streams differ.
+        expect(key(tsAccept)).not.toBe(key(leanAccept));
+        expect(tsAccept.filter((t) => t === 'P[').length).toBe(2);
+      });
+    },
+  );
+
+  test.openspec('[LEAN-HELP-06] G4 — reject paragraph-collapse is a characterized divergence')(
+    'reject of an ins-only paragraph: Lean keeps an empty paragraph, TS drops it',
+    async ({ given, when, then }: AllureBddContext) => {
+      let lean: HelperResult;
+      await given('a doc whose first paragraph is only a w:ins (no surviving content)', async () => {
+        lean = leanHelperBatch([G4_DOC])[0]!;
+      });
+      let tsReject: string[] = [];
+      let leanReject: string[] = [];
+      await when('both engines reject it', async () => {
+        tsReject = xmlToTokens(rejectAllChanges(renderDocToXml(G4_DOC)));
+        leanReject = docToTokens(lean!.reject);
+      });
+      await then('Lean keeps an empty paragraph (its reject never drops) while the TS engine removes it', async () => {
+        // Lean reject keeps every paragraph: the collapsed one becomes an empty P[ ].
+        expect(leanReject).toEqual(['P[', ']', 'P[', 'R[', 't:keep', ']', ']']);
+        // TS drops the ins-only paragraph, keeping only the survivor.
+        expect(tsReject).toEqual(['P[', 'R[', 't:keep', ']', ']']);
+        expect(key(tsReject)).not.toBe(key(leanReject));
+      });
+    },
+  );
+
+  test.openspec('[LEAN-HELP-07] A real divergence is caught, not masked')(
+    'the projection comparison flags a perturbed result rather than passing vacuously',
+    async ({ given, when, then }: AllureBddContext) => {
+      const doc: WireDoc = [
+        { body: [{ run: { content: [{ text: 'a' }] } }, { del: [{ run: { content: [{ delText: 'x' }] } }] }] },
+      ];
+      let real: HelperResult;
+      await given('a doc where the genuine Lean and TS projections agree', async () => {
+        real = leanHelperBatch([doc])[0]!;
+        expect(findDivergences([doc], [real]).length).toBe(0);
+      });
+      let perturbed: HelperResult;
+      await when('the Lean-side accept/reject outputs are swapped', async () => {
+        perturbed = { validate: real!.validate, accept: real!.reject, reject: real!.accept };
+      });
+      await then('findDivergences reports the perturbed case, proving the check is load-bearing', async () => {
+        const divergences = findDivergences([doc], [perturbed!]);
+        expect(divergences.length).toBe(1);
+        expect(divergences[0]!.field).toBe('accept');
+      });
+    },
+  );
+});

--- a/verification/ROADMAP.md
+++ b/verification/ROADMAP.md
@@ -137,14 +137,19 @@ Tier 2 is the first place where the roadmap becomes specification-heavy enough t
 
 ## Tier 2.5 — Lean ↔ TS equivalence + projection broadening
 
-**Status: IN PROGRESS** (first increment landed: reproducible LCS differential harness).
+**Status: IN PROGRESS** (two increments landed: reproducible LCS differential harness, and the Tier 2-helper accept/reject/validate differential harness).
 
 This tier sits between "the Lean model is sound" and "the Lean model is faithfully about the production code." It closes the two biggest remaining abstraction gaps from Tier 1.
 
 - **Extensional equivalence LCS Lean ↔ TS DP**: the previously un-reproducible "1.19M cases, zero divergence" brute-force is now a **reproducible, in-CI executable differential harness** (`add-lean-ts-lcs-differential-harness`). The genuine `LeanSpike.computeAtomLcs` is compiled to the `leanDifferential` exe (`verification/lean/Differential.lean`) and run against the production TS `computeAtomLcs` over shared generated inputs by `packages/docx-core/src/integration/lean-differential-lcs.test.ts`; the exhaustive length-≤6 / 3-symbol sweep (1,194,649 pairs, zero divergence) runs in the `lean-build` workflow. This grounds the empirical claim and de-risks the *formal* closure, which still **requires either a proof that the recursive Lean LCS and the iterative TS Wagner-Fischer DP produce the same output set, or a refactor of the TS** — both deferred.
 - **Broaden `Atom` projection toward the real `ComparisonUnitAtom`**: the current 3-field model is enough for Tier 1 but narrower than production. Once broadened, `atomsEqual_implies_eq` breaks and must be replaced by a weaker lemma keyed on the LCS-relevant subset; the LCS proof's equality branch then has to be rewired around that weaker result. Deferred.
 
-The Tier 2 *helper* differential (`accept` / `reject` / `validateFieldStructure` / `extractText` / `normalizeText`) is a named successor (`add-lean-ts-helper-differential-harness`); it needs a `Doc`→`document.xml` adapter to feed the TS AST path.
+- **Extensional equivalence helpers Lean ↔ TS**: the Tier 2 *helper* differential (`add-lean-ts-helper-differential-harness`) is now **landed** for the three modeled helpers. The genuine `Tier2.AcceptReject.accept`/`.reject` and `Tier2.FieldStructure.validateFieldStructure` compile to the `leanHelperDifferential` exe (`verification/lean/DifferentialHelpers.lean`) and run against the production `acceptAllChanges`/`rejectAllChanges`/`validateFieldStructure` over shared generated `Doc`s by `packages/docx-core/src/integration/lean-differential-helpers.test.ts`, via a `Doc`→`document.xml` adapter and a canonical token projection. The harness surfaced **four characterized model gaps** the current spike does not capture — its concrete worklist for the model-broadening proof increment:
+  - **G1** `w:fldChar` inside `w:del`: Lean `validateFieldStructure` returns `true`, the TS engine returns `false` (constraint (3), field-chars-not-inside-`del`, `pipeline.ts:542`, is unmodeled).
+  - **G2** `w:delInstrText` outside `w:del`: Lean `true`, TS `false` (`pipeline.ts:555`).
+  - **G3** accept of an `ins`-wrappered paragraph that collapses to empty: Lean `accept` drops it; the TS engine keeps an empty `<w:p>` (`trackChangesAcceptorAst.ts:399`).
+  - **G4** reject of an `ins`-only paragraph: Lean `reject` keeps an empty `<w:p>` (it never drops paragraphs, `AcceptReject.lean:83-85`); the TS engine drops it (`trackChangesAcceptorAst.ts:536-578`) — the reject-side analog of G3.
+  These are pinned by explicit characterization cases rather than hidden, and feed the deferred proof increment that would teach the Lean model the missing constraints. `extractText` / `normalizeText` are **not** modeled in Lean Tier 2 and are deferred to a further increment (`add-lean-ts-text-extraction-differential`).
 
 Rough effort: **2-6 months** combined (the harness above is the first slice).
 

--- a/verification/lean/DifferentialHelpers.lean
+++ b/verification/lean/DifferentialHelpers.lean
@@ -1,0 +1,167 @@
+/-
+Lean↔TS Tier 2-helper differential harness — executable entry point.
+
+Reads a batched JSON document from stdin, runs the GENUINE Tier 2 helpers
+`Tier2.FieldStructure.validateFieldStructure`, `Tier2.AcceptReject.accept`, and
+`Tier2.AcceptReject.reject` (`verification/lean/Tier2/`) on each modeled `Doc`, and
+writes the results as JSON to stdout. A TypeScript harness
+(`packages/docx-core/src/integration/lean-differential-helpers.test.ts`) renders the
+same generated `Doc`s to `document.xml`, feeds them to the production engine
+(`acceptAllChanges` / `rejectAllChanges` / `validateFieldStructure`,
+`packages/docx-core/src/baselines/atomizer/`), and asserts agreement on a canonical
+token projection — extending the Tier 2.5 differential to the accept/reject/validate
+surface (second increment; see `openspec/changes/add-lean-ts-helper-differential-harness/`).
+
+Wire protocol (one process spawn amortized over the whole batch):
+
+  stdin : { "cases":   [ { "doc": Doc } ] }
+  stdout: { "results": [ { "validate": Bool, "accept": Doc, "reject": Doc } ] }
+
+where Doc is the tagged-union encoding of `Tier2.OoxmlModel.Doc` defined below
+(paragraphs → blocks → runs → atoms, with ins/del/moveFrom/moveTo/other wrappers;
+the opaque pPr/rPr markers carry no cross-boundary meaning and are fixed to defaults).
+
+The JSON instances are defined locally here so the proved Tier 2 modules
+(`Tier2/OoxmlModel.lean`, `FieldStructure.lean`, `AcceptReject.lean`) stay pristine.
+This file is plain executable code carrying no proof placeholders, so the spike's
+zero-proof-placeholder audit (which scans `.lean` modules for the proof-hole keyword)
+is unaffected.
+
+NOTE: `import Lean.Data.Json` (not `import Lean` / `import Lean.Data.Json.FromToJson`)
+is required under the pinned toolchain — it brings `Json.parse`, the array/object
+accessors, and the `FromJson`/`ToJson` typeclasses into scope.
+-/
+import Lean.Data.Json
+import Tier2.AcceptReject
+
+open Lean Tier2.OoxmlModel Tier2.FieldStructure Tier2.AcceptReject
+
+/-! ### Encoders (`Doc` → JSON), matching the wire grammar in `design.md`. -/
+
+instance : ToJson FldCharKind where
+  toJson
+    | .begin => Json.str "begin"
+    | .separate => Json.str "separate"
+    | .endf => Json.str "end"
+
+instance : ToJson Atom where
+  toJson
+    | .text s => Json.mkObj [("text", toJson s)]
+    | .delText s => Json.mkObj [("delText", toJson s)]
+    | .instrText s => Json.mkObj [("instrText", toJson s)]
+    | .delInstrText s => Json.mkObj [("delInstrText", toJson s)]
+    | .fldChar k => Json.mkObj [("fldChar", toJson k)]
+
+/-- `Block` is recursive (`List Block` children), so the encoder is `partial`; this is
+    an executable, not a proof — no termination obligation is incurred. -/
+partial def blockToJson : Block → Json
+  | .run r => Json.mkObj [("run", Json.mkObj [("content", toJson r.content)])]
+  | .ins bs => Json.mkObj [("ins", Json.arr ((bs.map blockToJson)).toArray)]
+  | .del bs => Json.mkObj [("del", Json.arr ((bs.map blockToJson)).toArray)]
+  | .moveFrom bs => Json.mkObj [("moveFrom", Json.arr ((bs.map blockToJson)).toArray)]
+  | .moveTo bs => Json.mkObj [("moveTo", Json.arr ((bs.map blockToJson)).toArray)]
+  | .other tag bs =>
+    Json.mkObj [("other", Json.mkObj
+      [ ("tag", toJson tag)
+      , ("children", Json.arr ((bs.map blockToJson)).toArray) ])]
+
+instance : ToJson Block where toJson := blockToJson
+
+def paragraphToJson (p : Paragraph) : Json :=
+  Json.mkObj [("body", Json.arr ((p.body.map blockToJson)).toArray)]
+
+def docToJson (d : Doc) : Json :=
+  Json.arr ((d.map paragraphToJson)).toArray
+
+/-! ### Decoders (JSON → `Doc`). -/
+
+def fldCharKindFromJson (j : Json) : Except String FldCharKind :=
+  match j.getStr? with
+  | .ok "begin" => .ok .begin
+  | .ok "separate" => .ok .separate
+  | .ok "end" => .ok .endf
+  | .ok other => .error s!"unknown fldCharType: {other}"
+  | .error e => .error e
+
+instance : FromJson Atom where
+  fromJson? j :=
+    match j.getObjVal? "text" with
+    | .ok v => do return Atom.text (← fromJson? v)
+    | .error _ =>
+    match j.getObjVal? "delText" with
+    | .ok v => do return Atom.delText (← fromJson? v)
+    | .error _ =>
+    match j.getObjVal? "instrText" with
+    | .ok v => do return Atom.instrText (← fromJson? v)
+    | .error _ =>
+    match j.getObjVal? "delInstrText" with
+    | .ok v => do return Atom.delInstrText (← fromJson? v)
+    | .error _ =>
+    match j.getObjVal? "fldChar" with
+    | .ok v => do return Atom.fldChar (← fldCharKindFromJson v)
+    | .error _ => .error s!"unknown Atom: {j.compress}"
+
+/-- Recursive decoder; `partial` for the same reason as `blockToJson`. -/
+partial def blockFromJson (j : Json) : Except String Block := do
+  match j.getObjVal? "run" with
+  | .ok v => return Block.run { content := (← v.getObjValAs? (List Atom) "content") }
+  | .error _ =>
+  match j.getObjVal? "ins" with
+  | .ok v => return Block.ins (← (← v.getArr?).toList.mapM blockFromJson)
+  | .error _ =>
+  match j.getObjVal? "del" with
+  | .ok v => return Block.del (← (← v.getArr?).toList.mapM blockFromJson)
+  | .error _ =>
+  match j.getObjVal? "moveFrom" with
+  | .ok v => return Block.moveFrom (← (← v.getArr?).toList.mapM blockFromJson)
+  | .error _ =>
+  match j.getObjVal? "moveTo" with
+  | .ok v => return Block.moveTo (← (← v.getArr?).toList.mapM blockFromJson)
+  | .error _ =>
+  match j.getObjVal? "other" with
+  | .ok v => do
+    let tag ← v.getObjValAs? String "tag"
+    let children ← v.getObjVal? "children"
+    return Block.other tag (← (← children.getArr?).toList.mapM blockFromJson)
+  | .error _ => .error s!"unknown Block: {j.compress}"
+
+def paragraphFromJson (j : Json) : Except String Paragraph := do
+  let body ← j.getObjVal? "body"
+  return { body := (← (← body.getArr?).toList.mapM blockFromJson) }
+
+def docFromJson (j : Json) : Except String Doc := do
+  (← j.getArr?).toList.mapM paragraphFromJson
+
+/-! ### Batch I/O. -/
+
+structure CaseIn where
+  doc : Doc
+
+def caseFromJson (j : Json) : Except String CaseIn := do
+  return { doc := (← docFromJson (← j.getObjVal? "doc")) }
+
+/-- Run the three modeled helpers on one `Doc` and encode the results. -/
+def encodeResult (d : Doc) : Json :=
+  Json.mkObj
+    [ ("validate", toJson (validateFieldStructure d))
+    , ("accept", docToJson (accept d))
+    , ("reject", docToJson (reject d)) ]
+
+def main : IO Unit := do
+  let stdin ← IO.getStdin
+  let raw ← stdin.readToEnd
+  match Json.parse raw with
+  | .error e => throw (IO.userError s!"JSON parse error: {e}")
+  | .ok j =>
+    match j.getObjVal? "cases" with
+    | .error e => throw (IO.userError s!"missing cases: {e}")
+    | .ok casesJson =>
+      match casesJson.getArr? with
+      | .error e => throw (IO.userError s!"cases not an array: {e}")
+      | .ok arr =>
+        match arr.toList.mapM caseFromJson with
+        | .error e => throw (IO.userError s!"case parse error: {e}")
+        | .ok cases =>
+          let results := cases.map (fun c => encodeResult c.doc)
+          let out := Json.mkObj [("results", Json.arr results.toArray)]
+          IO.println out.compress

--- a/verification/lean/lakefile.lean
+++ b/verification/lean/lakefile.lean
@@ -19,3 +19,12 @@ lean_lib Tier2
 @[default_target]
 lean_exe leanDifferential where
   root := `Differential
+
+-- Tier 2-helper differential harness executable: runs the genuine
+-- `Tier2.AcceptReject.accept` / `.reject` and `Tier2.FieldStructure.validateFieldStructure`
+-- over batched JSON stdin/stdout so the TS bridge can assert Lean↔TS accept/reject/validate
+-- extensional equivalence (Tier 2.5, second increment). Plain executable code with no proof
+-- placeholders, so the zero-proof-placeholder audit is unaffected.
+@[default_target]
+lean_exe leanHelperDifferential where
+  root := `DifferentialHelpers


### PR DESCRIPTION
## Summary

Second **Tier 2.5** increment (successor to the merged LCS differential #308). Extends the differential-execution discipline from the LCS surface to the **Tier 2 track-change helpers** the headline `inv_field_001` theorem is actually about: it runs the *genuine* Lean `Tier2.AcceptReject.accept`/`.reject` and `Tier2.FieldStructure.validateFieldStructure` against the production `acceptAllChanges`/`rejectAllChanges`/`validateFieldStructure` over shared generated inputs, asserting agreement as a reproducible in-CI gate.

The helpers consume a serialized `document.xml` string (not a plain atom array), so this adds the **`Doc`→`document.xml` adapter** the prior increment deferred, plus a **canonical token projection** both the Lean output `Doc` and the TS output XML reduce to (Lean returns a structured `Doc`; TS returns XML).

## What's here

- **`verification/lean/DifferentialHelpers.lean`** + `leanHelperDifferential` `lean_exe`: batched JSON `Doc` in → `{validate, accept, reject}` out, calling the genuine proved helpers. Local `FromJson`/`ToJson` keep the proved Tier 2 modules pristine. Builds **zero-`sorry`**.
- **`lean-differential-helpers.test.ts`**: `renderDocToXml` adapter, `docToTokens`/`xmlToTokens` projection, a faithful-subset `fast-check` generator (**2000 default / 50,000 extended docs**, both green), 4 characterization cases, and a negative control.
- **CI** (`lean-build.yml`): triggers on the harness + the production helper sources (`trackChangesAcceptorAst.ts`, `pipeline.ts`) and runs the new test, reusing the LCS increment's Node setup.

## Characterized model gaps (pinned, not hidden)

The differential surfaced four real Lean↔TS divergences — its whole point. They live outside the faithful subset and are asserted as passing characterization cases, forming the worklist for a later model-broadening proof increment (they are **not** fixed here, since that touches the `inv_field_001` proof):

| | gap | Lean | TS |
|---|---|---|---|
| **G1** | `w:fldChar` inside `w:del` | `validate=true` | `validate=false` |
| **G2** | `w:delInstrText` outside `w:del` | `validate=true` | `validate=false` |
| **G3** | accept of an `ins`-wrappered collapsing paragraph | drops para | keeps empty `<w:p>` |
| **G4** | reject of an `ins`-only paragraph | keeps empty `<w:p>` | drops para |

G1–G3 were found by a dynamic probe during design; **G4 was surfaced by the peer review of this PR** (Gemini static analysis), then verified against the running engine.

## Verification

- `lake build leanHelperDifferential` green, zero-`sorry` audit clean.
- Harness green default + extended (`LEAN_DIFF_EXHAUSTIVE=1`).
- `npm run build`, `lint:workspaces` (0 errors), `check:spec-coverage`, `check:allure-labels`, `openspec validate --strict` all pass.
- Peer-reviewed (Codex executed: built + ran both modes + a widened 10k-doc + adversarial probe, **0 divergences**; two doc-accuracy findings folded in. Gemini surfaced G4).

## Scope

Modeled helpers only (`accept`/`reject`/`validateFieldStructure`). `extractText`/`normalizeText` aren't modeled in Lean Tier 2 → deferred (`add-lean-ts-text-extraction-differential`). No production-engine or proved-module changes.

OpenSpec: `add-lean-ts-helper-differential-harness`.