### PR TITLE
feat(docx-mcp): DOCX → Markdown export via shared serializer core

### DIFF
--- a/openspec/changes/add-markdown-export/proposal.md
+++ b/openspec/changes/add-markdown-export/proposal.md
@@ -1,0 +1,51 @@
+# Change: Add DOCX → Markdown export
+
+## Why
+
+The safe-docx suite can read, grep, edit, compare, and save `.docx`, but it cannot emit a
+portable text rendering. Agents and downstream tooling routinely need a document's content
+as Markdown — to summarize, diff, feed another model, or hand to a human. This adds the
+**export** leg of the read → edit → compare → export loop (epic #307).
+
+The hard part — OOXML parsing — is already done. `DocxDocument.buildDocumentView({ showFormatting: true })`
+yields a structured `DocumentViewNode[]` with headings (level + source), list metadata,
+grid-aware table context, injected `[^n]` footnote markers, and an HTML-shaped inline-tag
+string. A Markdown emitter is a **serializer over that existing model** — no new parsing.
+
+Per the epic, Markdown/HTML/text are "thin emitters over a shared structured-export core."
+This change builds the Markdown emitter and factors the **inline-tag tokenizer** as the
+reusable core piece (HTML #304 will render the same tokens).
+
+## What Changes
+
+### docx-primitives (docx-core)
+- NEW: `serialize_markdown.ts` — `inlineTagsToMarkdown()` (the reusable inline tokenizer →
+  Markdown mapping) and `serializeToMarkdown(nodes, footnotes)` (block walk: headings, lists,
+  GFM tables, footnote definitions).
+- NEW: `tokenizeToonInline()` + exported `TOON_INLINE_TAG_RE` in `document_view.ts` — the
+  shared inline-tag tokenizer, so serializers never re-derive the tag grammar.
+- MODIFIED: `document.ts` — async `DocxDocument.toMarkdown()` convenience wrapper.
+- FIXED: `injectFootnoteMarkers` in `document_view.ts` is now tag-aware (uses
+  `findTaggedTextInsertionIndex`, like the comment-marker path). Previously a visible-offset
+  marker was spliced into the *tagged* string by raw index, so `[^n]` could land inside a
+  formatting tag once `show_formatting` was on. This corrects `read_file` output too.
+
+### safe-docx (MCP)
+- NEW: `export` tool (`tools/export.ts`) — `format` enum (`markdown` now), writes an output
+  file (default: source path with `.md`), guards overwrite, returns path + byte count +
+  rendered Markdown (suppressible via `include_markdown: false`). DOCX only.
+- MODIFIED: `tool_catalog.ts` — add `export` catalog entry.
+- MODIFIED: `server.ts` — add import + dispatch case.
+
+## Impact
+
+- Affected specs: `mcp-server` (new export tool), `docx-primitives` (new serializer).
+- New, additive capability. No behavior change to existing tools except the footnote-marker
+  placement fix, which makes `read_file` output more correct for formatted footnoted text.
+- Markdown is intentionally **lossy** (no round-trip): highlighting, font runs, merged/nested
+  table cells, and pixel layout are downgraded as documented.
+
+## Out of scope
+
+Round-trip fidelity, equations/text boxes/charts/layout, HTML/text/PDF emitters
+(#304/#305/#306), and Google Docs as a source.

--- a/openspec/changes/add-markdown-export/specs/docx-primitives/spec.md
+++ b/openspec/changes/add-markdown-export/specs/docx-primitives/spec.md
@@ -1,0 +1,66 @@
+## ADDED Requirements
+
+### Requirement: Markdown serialization primitive
+
+The docx-core primitives SHALL provide a serializer that converts a structured document view
+(`DocumentViewNode[]` with inline formatting tags) and its footnotes into GitHub-Flavored
+Markdown. The serialization is intentionally lossy: constructs without a Markdown equivalent
+are downgraded as specified below rather than preserved for round-tripping. The inline-tag
+tokenizer is the reusable core shared with future serializers (HTML, text).
+
+#### Scenario: word-style headings become ATX headings
+- **GIVEN** a node whose heading source is `word_style` with a numeric level N (1–6)
+- **WHEN** the document is serialized to Markdown
+- **THEN** the paragraph SHALL render as an ATX heading with N leading `#` characters
+
+#### Scenario: heuristic headings remain paragraphs
+- **GIVEN** a node with a heuristic heading (level null, e.g. a run-in bold prefix)
+- **WHEN** the document is serialized to Markdown
+- **THEN** the node SHALL render as a normal paragraph, not an ATX heading
+
+#### Scenario: inline bold italic and link tags map to Markdown
+- **GIVEN** tagged text containing `<b>`, `<i>`, and `<a href="...">` tags
+- **WHEN** the text is converted with the inline tokenizer
+- **THEN** `<b>` SHALL map to `**`, `<i>` to `*`, and `<a href="u">t</a>` to `[t](u)`
+
+#### Scenario: underline passes through as raw HTML and font and highlight tags are stripped
+- **GIVEN** tagged text containing `<u>`, `<font ...>`, and `<highlight>` tags
+- **WHEN** the text is converted with the inline tokenizer
+- **THEN** `<u>` SHALL be emitted verbatim as raw HTML
+- **AND** `<font ...>` and `<highlight>` tags SHALL be removed while their inner text is kept
+
+#### Scenario: nested ordered and bullet lists are indented by level
+- **GIVEN** list nodes at increasing `list_level` values
+- **WHEN** the document is serialized to Markdown
+- **THEN** each item SHALL be indented in proportion to its level
+- **AND** auto-numbered numeric items SHALL render as `1.` ordered items and unlabeled items as `-` bullets
+
+#### Scenario: legal list labels are preserved
+- **GIVEN** a list item carrying a literal label such as `Section 2.1`, `Article IV`, or `(a)`
+- **WHEN** the document is serialized to Markdown
+- **THEN** the literal label SHALL appear in the rendered item rather than being replaced by a bare `1.`
+
+#### Scenario: a table renders as a GFM table
+- **GIVEN** nodes sharing a `table_context.table_id` forming rows and columns
+- **WHEN** the document is serialized to Markdown
+- **THEN** they SHALL render as a GFM pipe table with a header separator row
+
+#### Scenario: merged cell gaps are filled to preserve the grid
+- **GIVEN** a table whose `col_index` values skip positions because of horizontally merged cells
+- **WHEN** the document is serialized to Markdown
+- **THEN** the missing grid positions SHALL be filled with empty cells so every row has the full column count
+
+#### Scenario: footnote definitions are appended
+- **GIVEN** a document with footnotes
+- **WHEN** the document is serialized to Markdown
+- **THEN** `[^n]: ...` definitions SHALL be appended, ordered by display number
+
+#### Scenario: footnote markers are preserved when escaping text
+- **GIVEN** text containing an injected `[^1]` footnote marker
+- **WHEN** the text is escaped for Markdown
+- **THEN** the `[^1]` marker SHALL remain intact and match its appended definition
+
+#### Scenario: Markdown-significant characters in text are escaped
+- **GIVEN** literal text containing characters such as `*`, `_`, `[`, or a leading `#`
+- **WHEN** the text is serialized to Markdown
+- **THEN** those characters SHALL be backslash-escaped so they render literally

--- a/openspec/changes/add-markdown-export/specs/mcp-server/spec.md
+++ b/openspec/changes/add-markdown-export/specs/mcp-server/spec.md
@@ -1,0 +1,54 @@
+## ADDED Requirements
+
+### Requirement: Document Export
+
+The Safe-Docx MCP server SHALL provide an `export` tool that renders a DOCX document to a
+portable text format (Markdown initially) and writes the result to a file. The tool is not
+read-only: it writes an output file and returns the written path, the byte count, and — by
+default — the rendered content.
+
+#### Scenario: markdown export writes a file and returns its path and content
+- **GIVEN** an open DOCX session
+- **WHEN** `export` is called with `format` `markdown`
+- **THEN** the response SHALL be successful
+- **AND** it SHALL include `format`, `output_path`, `bytes_written`, and `markdown`
+- **AND** the file at `output_path` SHALL exist and contain the returned Markdown
+
+#### Scenario: default output path derives from the source path
+- **GIVEN** an open DOCX session for a file ending in `.docx`
+- **WHEN** `export` is called without `output_path`
+- **THEN** `output_path` SHALL be the source path with its extension replaced by `.md`
+
+#### Scenario: explicit output_path is honored
+- **WHEN** `export` is called with an `output_path`
+- **THEN** the Markdown SHALL be written to that path
+- **AND** `output_path` in the response SHALL reflect it
+
+#### Scenario: overwrite of an existing output file is blocked by default
+- **GIVEN** a file already exists at the target `output_path`
+- **WHEN** `export` is called without `allow_overwrite`
+- **THEN** the response SHALL be an `OVERWRITE_BLOCKED` error
+- **AND** the existing file SHALL be left unchanged
+
+#### Scenario: allow_overwrite permits replacing an existing output file
+- **GIVEN** a file already exists at the target `output_path`
+- **WHEN** `export` is called with `allow_overwrite` true
+- **THEN** the response SHALL be successful
+- **AND** the file SHALL contain the freshly rendered Markdown
+
+#### Scenario: unknown export format is rejected
+- **WHEN** `export` is called with a `format` other than a supported value
+- **THEN** the response SHALL be an `INVALID_FORMAT` error
+
+#### Scenario: include_markdown false omits the rendered content
+- **WHEN** `export` is called with `include_markdown` false
+- **THEN** the response SHALL still include `output_path` and `bytes_written`
+- **AND** the response SHALL NOT include the `markdown` content
+
+#### Scenario: export resolves a session from file_path
+- **WHEN** `export` is called with `file_path` and no `session_id`
+- **THEN** the server SHALL resolve a session per standard resolution rules and export it
+
+#### Scenario: export rejects a Google Docs source
+- **WHEN** `export` is called with a `google_doc_id`
+- **THEN** the response SHALL be an `UNSUPPORTED_FOR_PROVIDER` error

--- a/openspec/changes/add-markdown-export/tasks.md
+++ b/openspec/changes/add-markdown-export/tasks.md
@@ -1,0 +1,20 @@
+# Tasks: Add DOCX → Markdown export
+
+## 1. docx-core serializer primitive
+- [x] 1.1 Export `TOON_INLINE_TAG_RE` and add `tokenizeToonInline()` in `document_view.ts`.
+- [x] 1.2 Make `injectFootnoteMarkers` tag-aware (reuse `findTaggedTextInsertionIndex`).
+- [x] 1.3 Add `serialize_markdown.ts`: `inlineTagsToMarkdown()` + `serializeToMarkdown()`.
+- [x] 1.4 Add async `DocxDocument.toMarkdown()`; export from the primitives barrel.
+
+## 2. docx-mcp export tool
+- [x] 2.1 Add `tools/export.ts` (session resolution, path policy, overwrite guard, default `.md`).
+- [x] 2.2 Register in `tool_catalog.ts` and `server.ts`.
+
+## 3. Tests (mapped to spec scenarios)
+- [x] 3.1 `serialize_markdown.test.ts` in docx-core (docx-primitives scenarios).
+- [x] 3.2 `export.test.ts` in docx-mcp (mcp-server scenarios).
+
+## 4. Validation
+- [x] 4.1 `openspec validate add-markdown-export --strict`.
+- [x] 4.2 Build, lint, and run both packages' tests (incl. spec-coverage).
+- [x] 4.3 Real-document smoke: export a real `.docx` and visually confirm the `.md`.

--- a/packages/docx-core/src/primitives/document.ts
+++ b/packages/docx-core/src/primitives/document.ts
@@ -16,6 +16,7 @@ import {
   type RevisionContext,
 } from './track-changes-emitter.js';
 import { buildNodesForDocumentView, type DocumentStyles, type DocumentViewNode, type TableContext } from './document_view.js';
+import { serializeToMarkdown, type SerializeMarkdownOptions } from './serialize_markdown.js';
 import type { FormattingMode } from './formatting_tags.js';
 import { findUniqueSubstringMatch } from './matching.js';
 import { parseDocumentRels, type RelsMap } from './relationships.js';
@@ -1055,6 +1056,19 @@ export class DocxDocument {
 
   async getFootnotes(): Promise<Footnote[]> {
     return getFootnotesImpl(this.zip, this.documentXml);
+  }
+
+  /**
+   * Serialize the document to GitHub-Flavored Markdown. Convenience wrapper that wires the
+   * structured document view (with inline formatting) and footnotes into
+   * {@link serializeToMarkdown}. Markdown is intentionally lossy — see that serializer.
+   *
+   * Async because footnote extraction reads the footnotes part from the zip.
+   */
+  async toMarkdown(opts?: SerializeMarkdownOptions): Promise<string> {
+    const { nodes } = this.buildDocumentView({ showFormatting: true });
+    const footnotes = await this.getFootnotes();
+    return serializeToMarkdown(nodes, footnotes, opts);
   }
 
   async getFootnote(noteId: number): Promise<Footnote | null> {

--- a/packages/docx-core/src/primitives/document_view.ts
+++ b/packages/docx-core/src/primitives/document_view.ts
@@ -589,7 +589,40 @@ function headerStripFromText(params: { header: string; text: string }): string {
 // the formatter only emits `<a href="...">` and `<font ATTR=...>` — never bare `<a>` or
 // `<font>`. Allowing the bare forms would cause literal `<a>` / `<font>` in document text to
 // be silently skipped, shifting marker positions.
-const TOON_INLINE_TAG_RE = /^(?:<\/?(?:b|i|u|highlight)>|<\/(?:a|font)>|<(?:a|font)\s[^>]*>)/;
+export const TOON_INLINE_TAG_RE = /^(?:<\/?(?:b|i|u|highlight)>|<\/(?:a|font)>|<(?:a|font)\s[^>]*>)/;
+
+/** A single token produced by {@link tokenizeToonInline}. */
+export type ToonInlineToken =
+  | { kind: 'tag'; value: string }
+  | { kind: 'text'; value: string };
+
+/**
+ * Split a TOON inline-tag string (`DocumentViewNode.tagged_text` produced with
+ * `show_formatting`) into an ordered list of `tag` and `text` tokens, using the exact same
+ * grammar (`TOON_INLINE_TAG_RE`) the formatter emits. Consecutive literal characters are
+ * coalesced into one `text` token. This is the shared tokenization primitive used by
+ * downstream serializers (Markdown today, HTML next) so they never reason about the tag
+ * grammar independently and drift from the emitter.
+ */
+export function tokenizeToonInline(text: string): ToonInlineToken[] {
+  const tokens: ToonInlineToken[] = [];
+  let buffer = '';
+  for (let i = 0; i < text.length; i++) {
+    const tagLen = toonTagLengthAt(text, i);
+    if (tagLen > 0) {
+      if (buffer) {
+        tokens.push({ kind: 'text', value: buffer });
+        buffer = '';
+      }
+      tokens.push({ kind: 'tag', value: text.slice(i, i + tagLen) });
+      i += tagLen - 1;
+      continue;
+    }
+    buffer += text[i];
+  }
+  if (buffer) tokens.push({ kind: 'text', value: buffer });
+  return tokens;
+}
 
 function toonTagLengthAt(text: string, i: number): number {
   if (text[i] !== '<') return 0;
@@ -1200,6 +1233,12 @@ function getFootnoteMarkersForParagraph(
 /**
  * Inject footnote markers into a text string at the given offsets.
  * Markers must be sorted descending by offset.
+ *
+ * Offsets are *visible*-character offsets (they count document text, not the inline
+ * formatting tags emitted by `emitFormattingTags`). When `text` carries formatting tags
+ * we therefore map each visible offset to a tag-aware insertion index, exactly as the
+ * comment-marker path does (`findTaggedTextInsertionIndex`). A naive `slice(offset)` would
+ * land the `[^n]` marker inside a tag or mid-word once formatting is present.
  */
 function injectFootnoteMarkers(
   text: string,
@@ -1208,9 +1247,8 @@ function injectFootnoteMarkers(
   if (markers.length === 0) return text;
   let result = text;
   for (const { offset, marker } of markers) {
-    // Clamp offset to text length
-    const pos = Math.min(offset, result.length);
-    result = result.slice(0, pos) + marker + result.slice(pos);
+    const insertionIndex = findTaggedTextInsertionIndex(result, offset);
+    result = result.slice(0, insertionIndex) + marker + result.slice(insertionIndex);
   }
   return result;
 }

--- a/packages/docx-core/src/primitives/index.ts
+++ b/packages/docx-core/src/primitives/index.ts
@@ -7,6 +7,7 @@ export * from './matching.js';
 export * from './namespaces.js';
 export * from './numbering.js';
 export * from './semantic_tags.js';
+export * from './serialize_markdown.js';
 export * from './styles.js';
 export * from './text.js';
 export * from './xml.js';

--- a/packages/docx-core/src/primitives/serialize_markdown.test.ts
+++ b/packages/docx-core/src/primitives/serialize_markdown.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { inlineTagsToMarkdown, serializeToMarkdown } from './serialize_markdown.js';
+import type { DocumentViewNode, TableContext } from './document_view.js';
+import { LabelType } from './list_labels.js';
+import type { Footnote } from './footnotes.js';
+
+const TEST_FEATURE = 'add-markdown-export';
+const test = testAllure.epic('Document Comparison').withLabels({ feature: TEST_FEATURE });
+
+// ── Minimal DocumentViewNode factory ────────────────────────────────────────
+// The serializer only reads `tagged_text`, `heading`, `list_metadata`, and `table_context`;
+// the rest are filled with inert defaults so tests stay focused on serialization behavior.
+type NodeOverrides = Omit<Partial<DocumentViewNode>, 'list_metadata'> & {
+  list_metadata?: Partial<DocumentViewNode['list_metadata']>;
+};
+
+let nodeSeq = 0;
+function node(overrides: NodeOverrides = {}): DocumentViewNode {
+  const { list_metadata: lmOverride, ...rest } = overrides;
+  return {
+    id: `_bk_${nodeSeq++}`,
+    list_label: '',
+    header: '',
+    style: 'body',
+    text: overrides.tagged_text ?? '',
+    clean_text: overrides.tagged_text ?? '',
+    tagged_text: overrides.tagged_text ?? '',
+    list_metadata: {
+      list_level: -1,
+      label_type: null,
+      label_string: '',
+      header_text: null,
+      header_style: null,
+      header_formatting: null,
+      is_auto_numbered: false,
+      ...(lmOverride ?? {}),
+    },
+    style_fingerprint: {
+      list_level: -1,
+      left_indent_pt: 0,
+      first_line_indent_pt: 0,
+      style_name: '',
+      alignment: 'LEFT',
+    },
+    paragraph_style_id: null,
+    paragraph_style_name: '',
+    paragraph_alignment: 'LEFT',
+    paragraph_indents_pt: { left: 0, first_line: 0 },
+    numbering: { num_id: null, ilvl: null, is_auto_numbered: false },
+    header_formatting: null,
+    body_run_formatting: null,
+    ...rest,
+  };
+}
+
+function tableCell(
+  rowIndex: number,
+  colIndex: number,
+  text: string,
+  opts: { isHeader?: boolean; totalCols?: number; tableId?: string } = {},
+): DocumentViewNode {
+  const tc: TableContext = {
+    table_id: opts.tableId ?? '_tbl_0',
+    table_index: 0,
+    row_index: rowIndex,
+    col_index: colIndex,
+    col_header: '',
+    total_rows: 0,
+    total_cols: opts.totalCols ?? 2,
+    is_header_row: opts.isHeader ?? false,
+    para_in_cell: 0,
+    cell_para_count: 1,
+  };
+  return node({ tagged_text: text, table_context: tc });
+}
+
+function footnote(displayNumber: number, text: string): Footnote {
+  return { id: displayNumber, displayNumber, text, anchoredParagraphId: null };
+}
+
+describe('OpenSpec traceability: add-markdown-export (Markdown serializer)', () => {
+  test.openspec('word-style headings become ATX headings')(
+    'word-style headings become ATX headings',
+    async ({ then }: AllureBddContext) => {
+      const md = serializeToMarkdown([
+        node({ tagged_text: 'Section Title', heading: { text: 'Section Title', source: 'word_style', level: 2 } }),
+      ]);
+      await then('the heading renders with two leading #', async () => {
+        expect(md).toContain('## Section Title');
+      });
+    },
+  );
+
+  test.openspec('heuristic headings remain paragraphs')(
+    'heuristic headings remain paragraphs',
+    async ({ then }: AllureBddContext) => {
+      const md = serializeToMarkdown([
+        node({
+          tagged_text: '<b>Indemnification.</b> The Company shall indemnify.',
+          heading: { text: 'Indemnification', source: 'run_in_header', level: null },
+        }),
+      ]);
+      await then('it is a bold paragraph, not an ATX heading', async () => {
+        expect(md).not.toMatch(/^#/m);
+        expect(md).toContain('**Indemnification.**');
+      });
+    },
+  );
+
+  test.openspec('inline bold italic and link tags map to Markdown')(
+    'inline bold italic and link tags map to Markdown',
+    async ({ then }: AllureBddContext) => {
+      const out = inlineTagsToMarkdown('<b>Bold</b> and <i>it</i> and <a href="https://x.com">link</a>');
+      await then('tags map to **, *, and [text](url)', async () => {
+        expect(out).toBe('**Bold** and *it* and [link](https://x.com)');
+      });
+      // Run-split phrases must not produce stray `******`: adjacent close→open emphasis
+      // toggles are coalesced back into a single span.
+      const split = inlineTagsToMarkdown('<b><i>2 years</i></b><b><i> total</i></b>');
+      await then('run-split emphasis coalesces instead of emitting ******', async () => {
+        expect(split).toBe('***2 years total***');
+        expect(split).not.toContain('******');
+      });
+    },
+  );
+
+  test.openspec('underline passes through as raw HTML and font and highlight tags are stripped')(
+    'underline passes through as raw HTML and font and highlight tags are stripped',
+    async ({ then }: AllureBddContext) => {
+      const out = inlineTagsToMarkdown('<u>under</u> <font color="FF0000">red</font> <highlight>hl</highlight>');
+      await then('underline is raw HTML; font/highlight drop their tags', async () => {
+        expect(out).toBe('<u>under</u> red hl');
+      });
+    },
+  );
+
+  test.openspec('nested ordered and bullet lists are indented by level')(
+    'nested ordered and bullet lists are indented by level',
+    async ({ then }: AllureBddContext) => {
+      const md = serializeToMarkdown([
+        node({
+          tagged_text: 'First item',
+          list_metadata: { list_level: 0, label_type: LabelType.NUMBER, label_string: '1.', is_auto_numbered: true },
+        }),
+        node({
+          tagged_text: 'Nested bullet',
+          list_metadata: { list_level: 1 },
+        }),
+      ]);
+      await then('ordered item uses 1. and the nested bullet is indented', async () => {
+        expect(md).toContain('1. First item');
+        expect(md).toContain('  - Nested bullet');
+      });
+    },
+  );
+
+  test.openspec('legal list labels are preserved')(
+    'legal list labels are preserved',
+    async ({ then }: AllureBddContext) => {
+      const md = serializeToMarkdown([
+        node({
+          tagged_text: 'The parties agree as follows.',
+          list_metadata: { list_level: 0, label_type: LabelType.SECTION, label_string: 'Section 2.1' },
+        }),
+      ]);
+      await then('the literal legal label survives', async () => {
+        expect(md).toContain('Section 2.1 The parties agree as follows.');
+        expect(md).not.toContain('1. The parties agree');
+      });
+    },
+  );
+
+  test.openspec('a table renders as a GFM table')(
+    'a table renders as a GFM table',
+    async ({ then }: AllureBddContext) => {
+      const md = serializeToMarkdown([
+        tableCell(0, 0, 'Name', { isHeader: true }),
+        tableCell(0, 1, 'Age', { isHeader: true }),
+        tableCell(1, 0, 'Alice'),
+        tableCell(1, 1, '30'),
+      ]);
+      await then('a header row, separator, and body row are emitted', async () => {
+        expect(md).toContain('| Name | Age |');
+        expect(md).toContain('| --- | --- |');
+        expect(md).toContain('| Alice | 30 |');
+      });
+      // A line break inside a cell must not split the GFM row.
+      const withBreak = serializeToMarkdown([
+        tableCell(0, 0, 'H', { isHeader: true, totalCols: 1 }),
+        tableCell(1, 0, 'Line1\nLine2', { totalCols: 1 }),
+      ]);
+      await then('intra-cell newlines become <br> rather than breaking the row', async () => {
+        expect(withBreak).toContain('| Line1<br>Line2 |');
+        expect(withBreak).not.toContain('Line1\nLine2');
+      });
+    },
+  );
+
+  test.openspec('merged cell gaps are filled to preserve the grid')(
+    'merged cell gaps are filled to preserve the grid',
+    async ({ then }: AllureBddContext) => {
+      // Row 1 skips col_index 1 (a horizontally merged cell), leaving a grid gap.
+      const md = serializeToMarkdown([
+        tableCell(0, 0, 'A', { isHeader: true, totalCols: 3 }),
+        tableCell(0, 1, 'B', { isHeader: true, totalCols: 3 }),
+        tableCell(0, 2, 'C', { isHeader: true, totalCols: 3 }),
+        tableCell(1, 0, 'X', { totalCols: 3 }),
+        tableCell(1, 2, 'Z', { totalCols: 3 }),
+      ]);
+      await then('the skipped column is filled with an empty cell', async () => {
+        expect(md).toContain('| X |  | Z |');
+      });
+    },
+  );
+
+  test.openspec('footnote definitions are appended')(
+    'footnote definitions are appended',
+    async ({ then }: AllureBddContext) => {
+      const md = serializeToMarkdown(
+        [node({ tagged_text: 'A clause with a note[^1] here.' })],
+        [footnote(1, 'The footnote body.')],
+      );
+      await then('the [^1] definition is appended', async () => {
+        expect(md).toContain('A clause with a note[^1] here.');
+        expect(md).toContain('[^1]: The footnote body.');
+      });
+    },
+  );
+
+  test.openspec('footnote markers are preserved when escaping text')(
+    'footnote markers are preserved when escaping text',
+    async ({ then }: AllureBddContext) => {
+      const out = inlineTagsToMarkdown('a*b[^2] tail');
+      await then('the marker stays intact while the * is escaped', async () => {
+        expect(out).toContain('[^2]');
+        expect(out).toContain('a\\*b');
+      });
+    },
+  );
+
+  test.openspec('Markdown-significant characters in text are escaped')(
+    'Markdown-significant characters in text are escaped',
+    async ({ then }: AllureBddContext) => {
+      const inline = inlineTagsToMarkdown('use *stars* and _under_');
+      const leading = serializeToMarkdown([node({ tagged_text: '# not a heading' })]);
+      await then('inline emphasis chars and a leading # are escaped', async () => {
+        expect(inline).toBe('use \\*stars\\* and \\_under\\_');
+        expect(leading).toContain('\\# not a heading');
+      });
+    },
+  );
+});

--- a/packages/docx-core/src/primitives/serialize_markdown.test.ts
+++ b/packages/docx-core/src/primitives/serialize_markdown.test.ts
@@ -122,6 +122,14 @@ describe('OpenSpec traceability: add-markdown-export (Markdown serializer)', () 
         expect(split).toBe('***2 years total***');
         expect(split).not.toContain('******');
       });
+      // A run-split where the second run re-opens emphasis in the *opposite* order
+      // (`<i><b>` vs `<b><i>`) leaves no adjacent same-kind toggle to cancel pairwise; the
+      // state-machine reconciliation must still collapse it rather than emit `******`.
+      const reordered = inlineTagsToMarkdown('<b><i>A</i></b><i><b>B</b></i>');
+      await then('opposite-order run-split also coalesces', async () => {
+        expect(reordered).toBe('***AB***');
+        expect(reordered).not.toContain('******');
+      });
     },
   );
 

--- a/packages/docx-core/src/primitives/serialize_markdown.ts
+++ b/packages/docx-core/src/primitives/serialize_markdown.ts
@@ -1,0 +1,319 @@
+// DOCX → Markdown serializer.
+//
+// This is a *serializer over the existing structured document model* — it does no OOXML
+// parsing. `DocxDocument.buildDocumentView({ showFormatting: true })` already yields a
+// `DocumentViewNode[]` carrying headings, list metadata, grid-aware table context, injected
+// `[^n]` footnote markers, and an HTML-shaped inline-tag string (`tagged_text`). This module
+// turns that model into GitHub-Flavored Markdown.
+//
+// Markdown is intentionally *lossy*: there is no round-trip guarantee. Constructs without a
+// Markdown equivalent (highlighting, font runs, merged/nested table cells, layout) are
+// downgraded as documented below rather than preserved.
+//
+// The inline tokenizer (`inlineTagsToMarkdown`) is the reusable core; the planned HTML
+// emitter (#304) renders the same tokens, so neither serializer reasons about the tag
+// grammar independently and drifts from the emitter in `formatting_tags.ts`.
+
+import { tokenizeToonInline } from './document_view.js';
+import type { DocumentViewNode } from './document_view.js';
+import { LabelType } from './list_labels.js';
+import type { Footnote } from './footnotes.js';
+
+/** Footnote markers already injected into `tagged_text`, e.g. `[^1]`, `[^12]`. */
+const FOOTNOTE_MARKER_RE = /\[\^\d+\]/g;
+
+/**
+ * Backslash-escape the inline Markdown-significant characters that would otherwise be
+ * interpreted mid-line. GFM honours backslash escapes for ASCII punctuation, so `\*`
+ * renders a literal `*`. We escape only the characters that trigger *inline* constructs
+ * (emphasis, code, links, raw HTML, table pipes); block-level triggers (`#`, `-`, `>`, …)
+ * are handled per-line by {@link escapeLeadingBlockSyntax} so we don't litter prose with
+ * `\.` and `\-` on every sentence.
+ *
+ * Already-present `[^n]` footnote markers are protected: escaping their `[`/`]`/`^` would
+ * sever them from the appended `[^n]: …` definitions.
+ */
+function escapeInlineText(text: string): string {
+  const escapeSpan = (s: string): string => s.replace(/[\\`*_[\]<|]/g, (c) => `\\${c}`);
+
+  let out = '';
+  let lastIndex = 0;
+  for (const match of text.matchAll(FOOTNOTE_MARKER_RE)) {
+    const idx = match.index ?? 0;
+    out += escapeSpan(text.slice(lastIndex, idx));
+    out += match[0]; // leave the footnote marker untouched
+    lastIndex = idx + match[0].length;
+  }
+  out += escapeSpan(text.slice(lastIndex));
+  return out;
+}
+
+/**
+ * Escape a leading block-level trigger so a normal paragraph whose visible text begins with
+ * `#`, `>`, `-`, `+`, `* `, or `N.`/`N)` is not mis-read as a heading, quote, or list.
+ * Block triggers always require a trailing space, whereas the emphasis we emit (`**`, `*`)
+ * never does — so matching the space-terminated forms cannot corrupt generated Markdown.
+ */
+function escapeLeadingBlockSyntax(line: string): string {
+  return line.replace(/^(\s*)(#{1,6}(?= )|>(?= )|[-+*](?= )|\d+[.)](?= ))/, (_m, ws: string, trig: string) => {
+    if (/^\d/.test(trig)) {
+      // ordered-list trigger: escape the delimiter (the `.` or `)`), keep the digits
+      return `${ws}${trig.slice(0, -1)}\\${trig.slice(-1)}`;
+    }
+    return `${ws}\\${trig[0]}${trig.slice(1)}`;
+  });
+}
+
+/**
+ * Convert one TOON inline-tag string (a `DocumentViewNode.tagged_text` value) to inline
+ * Markdown. This is the reusable core of the serializer.
+ *
+ * Tag mapping:
+ * - `<b>`/`</b>`            → `**`
+ * - `<i>`/`</i>`            → `*`
+ * - `<u>`/`</u>`            → passed through verbatim (Markdown has no underline; raw `<u>`
+ *                             is valid GFM HTML)
+ * - `<a href="u">…</a>`     → `[…](u)`
+ * - `<highlight>`/`<font …>` → tags stripped, inner text kept (no Markdown equivalent — lossy)
+ *
+ * Literal text spans are Markdown-escaped; injected `[^n]` footnote markers are preserved.
+ */
+type InlineOp =
+  | { t: 'md'; v: string } // already-final Markdown/raw text (escaped text, links, raw <u>)
+  | { t: 'emph'; kind: 'b' | 'i'; dir: 1 | -1 }; // emphasis open (+1) / close (-1)
+
+export function inlineTagsToMarkdown(text: string): string {
+  const ops: InlineOp[] = [];
+  const linkUrls: string[] = []; // stack of open <a> hrefs (links don't nest meaningfully)
+
+  for (const token of tokenizeToonInline(text)) {
+    if (token.kind === 'text') {
+      ops.push({ t: 'md', v: escapeInlineText(token.value) });
+      continue;
+    }
+    const tag = token.value;
+    if (tag === '<b>') ops.push({ t: 'emph', kind: 'b', dir: 1 });
+    else if (tag === '</b>') ops.push({ t: 'emph', kind: 'b', dir: -1 });
+    else if (tag === '<i>') ops.push({ t: 'emph', kind: 'i', dir: 1 });
+    else if (tag === '</i>') ops.push({ t: 'emph', kind: 'i', dir: -1 });
+    else if (tag === '<u>' || tag === '</u>') ops.push({ t: 'md', v: tag }); // raw HTML passthrough
+    else if (tag.startsWith('<a ')) {
+      linkUrls.push(/href="([^"]*)"/.exec(tag)?.[1] ?? '');
+      ops.push({ t: 'md', v: '[' });
+    } else if (tag === '</a>') {
+      ops.push({ t: 'md', v: `](${linkUrls.pop() ?? ''})` });
+    }
+    // <highlight>, </highlight>, <font …>, </font> → strip (emit nothing, keep inner text)
+  }
+
+  // Defensive: an unbalanced <a> (no closing tag) would leave a dangling "["; close it.
+  while (linkUrls.length > 0) {
+    ops.push({ t: 'md', v: `](${linkUrls.pop()})` });
+  }
+
+  // Collapse redundant *adjacent* emphasis toggles (nothing between them). Word splits a
+  // single formatted phrase into multiple runs, so `tagged_text` often holds
+  // `</b></i><b><i>` or empty `<b></b>` pairs. Mapped naively these become `******` or
+  // `****`, which render as literal asterisks. Removing the adjacent close→open (and empty
+  // open→close) pairs re-fuses the phrase into one clean emphasis span.
+  for (let changed = true; changed; ) {
+    changed = false;
+    for (let i = 0; i < ops.length - 1; i++) {
+      const a = ops[i]!;
+      const b = ops[i + 1]!;
+      if (a.t === 'emph' && b.t === 'emph' && a.kind === b.kind && a.dir === -b.dir) {
+        ops.splice(i, 2);
+        changed = true;
+        break;
+      }
+    }
+  }
+
+  let out = '';
+  for (const op of ops) {
+    out += op.t === 'md' ? op.v : op.kind === 'b' ? '**' : '*';
+  }
+  return out;
+}
+
+/** A heading is structural (gets `#`) only when Word's style told us so and gave a level. */
+function isStructuralHeading(node: DocumentViewNode): boolean {
+  return node.heading?.source === 'word_style' && typeof node.heading.level === 'number';
+}
+
+function renderListItem(node: DocumentViewNode): string {
+  const lm = node.list_metadata;
+  const level = Math.max(0, lm.list_level);
+  const indent = '  '.repeat(level);
+  const text = inlineTagsToMarkdown(node.tagged_text).trim();
+  const label = lm.label_string?.trim() ?? '';
+
+  // True auto-numbered numeric lists render as a Markdown ordered list (let the renderer
+  // number them). Everything else preserves the *literal* label — legal documents carry
+  // meaningful labels like `Section 2.1`, `Article IV`, `(a)`, `(i)` that a bare `1.` would
+  // silently destroy.
+  if (lm.label_type === LabelType.NUMBER && lm.is_auto_numbered) {
+    return `${indent}1. ${text}`.trimEnd();
+  }
+  if (label) {
+    return `${indent}- ${label} ${text}`.trimEnd();
+  }
+  return `${indent}- ${text}`.trimEnd();
+}
+
+/**
+ * Render a run of nodes that share a `table_context.table_id` as a GFM table.
+ *
+ * Lossy by design (GFM has no merged/nested-cell support):
+ * - Horizontally merged cells (`gridSpan`) advance `col_index`, leaving grid gaps that we
+ *   fill with empty cells so the column count stays consistent and viewers don't break.
+ * - Vertically merged cells (`vMerge`) and nested tables are flattened into the body-level
+ *   grid; multi-paragraph cells are joined with `<br>`.
+ */
+function renderTable(group: DocumentViewNode[]): string[] {
+  let totalCols = 0;
+  for (const n of group) {
+    const tc = n.table_context;
+    if (!tc) continue;
+    totalCols = Math.max(totalCols, tc.total_cols, tc.col_index + 1);
+  }
+  if (totalCols <= 0) return [];
+
+  const rows = new Map<number, Map<number, string[]>>();
+  const rowOrder: number[] = [];
+  const headerRows = new Set<number>();
+
+  for (const n of group) {
+    const tc = n.table_context;
+    if (!tc) continue;
+    if (!rows.has(tc.row_index)) {
+      rows.set(tc.row_index, new Map());
+      rowOrder.push(tc.row_index);
+    }
+    const cellMap = rows.get(tc.row_index)!;
+    // A raw newline inside a cell (from a line break) would split the GFM table row and
+    // break the whole table, so collapse intra-cell newlines to `<br>`.
+    const cellText = inlineTagsToMarkdown(n.tagged_text).replace(/\s*\n+\s*/g, '<br>').trim();
+    const parts = cellMap.get(tc.col_index) ?? [];
+    if (cellText) parts.push(cellText);
+    cellMap.set(tc.col_index, parts);
+    if (tc.is_header_row) headerRows.add(tc.row_index);
+  }
+
+  rowOrder.sort((a, b) => a - b);
+  if (rowOrder.length === 0) return [];
+
+  const cellsFor = (rowIndex: number): string[] => {
+    const cellMap = rows.get(rowIndex) ?? new Map<number, string[]>();
+    const cells: string[] = [];
+    for (let c = 0; c < totalCols; c++) {
+      cells.push((cellMap.get(c) ?? []).join('<br>'));
+    }
+    return cells;
+  };
+
+  // GFM requires exactly one header row. Prefer the first row Word flagged as a header;
+  // otherwise treat the first row as the header (the common case).
+  const headerRowIndex = rowOrder.find((ri) => headerRows.has(ri)) ?? rowOrder[0]!;
+
+  const lines: string[] = [];
+  lines.push(`| ${cellsFor(headerRowIndex).join(' | ')} |`);
+  lines.push(`| ${Array.from({ length: totalCols }, () => '---').join(' | ')} |`);
+  for (const ri of rowOrder) {
+    if (ri === headerRowIndex) continue;
+    lines.push(`| ${cellsFor(ri).join(' | ')} |`);
+  }
+  return lines;
+}
+
+export interface SerializeMarkdownOptions {
+  /** Reserved for future knobs (heading promotion, table policy). Currently unused. */
+  readonly _reserved?: never;
+}
+
+/**
+ * Serialize a structured document view to GitHub-Flavored Markdown.
+ *
+ * @param nodes     Block nodes from `buildDocumentView({ showFormatting: true }).nodes`.
+ * @param footnotes Footnotes from `DocxDocument.getFootnotes()` (already sorted by
+ *                  `displayNumber`); appended as `[^n]: …` definitions.
+ */
+export function serializeToMarkdown(
+  nodes: DocumentViewNode[],
+  footnotes: Footnote[] = [],
+  _opts: SerializeMarkdownOptions = {},
+): string {
+  const blocks: string[] = [];
+  let inList = false;
+
+  const closeList = (): void => {
+    if (inList) {
+      blocks.push('');
+      inList = false;
+    }
+  };
+
+  for (let i = 0; i < nodes.length; i++) {
+    const node = nodes[i]!;
+
+    // ── Tables: consume the whole run of same-table_id nodes at once ──
+    if (node.table_context) {
+      closeList();
+      const tableId = node.table_context.table_id;
+      const group: DocumentViewNode[] = [];
+      while (i < nodes.length && nodes[i]!.table_context?.table_id === tableId) {
+        group.push(nodes[i]!);
+        i++;
+      }
+      i--; // for-loop will re-increment
+      const tableLines = renderTable(group);
+      if (tableLines.length > 0) {
+        blocks.push(tableLines.join('\n'));
+        blocks.push('');
+      }
+      continue;
+    }
+
+    // ── Structural (Word-styled) headings ──
+    if (isStructuralHeading(node)) {
+      closeList();
+      const level = Math.min(6, Math.max(1, node.heading!.level as number));
+      const text = inlineTagsToMarkdown(node.tagged_text).trim();
+      blocks.push(`${'#'.repeat(level)} ${text}`.trimEnd());
+      blocks.push('');
+      continue;
+    }
+
+    // ── List items ──
+    if (node.list_metadata.list_level >= 0) {
+      inList = true;
+      blocks.push(renderListItem(node));
+      continue;
+    }
+
+    // ── Normal paragraphs (heuristic headings land here: their run-in bold already lives
+    //     in the inline tags, so we keep them as paragraphs rather than inventing a `#`). ──
+    closeList();
+    const text = escapeLeadingBlockSyntax(inlineTagsToMarkdown(node.tagged_text));
+    if (text.trim() === '') {
+      blocks.push('');
+    } else {
+      blocks.push(text);
+      blocks.push('');
+    }
+  }
+
+  closeList();
+
+  // ── Footnote definitions ──
+  const defs = footnotes.filter((fn) => fn.displayNumber > 0);
+  if (defs.length > 0) {
+    blocks.push('');
+    for (const fn of defs) {
+      const body = escapeInlineText(fn.text.replace(/\s+/g, ' ').trim());
+      blocks.push(`[^${fn.displayNumber}]: ${body}`);
+    }
+  }
+
+  return `${blocks.join('\n').replace(/\n{3,}/g, '\n\n').trim()}\n`;
+}

--- a/packages/docx-core/src/primitives/serialize_markdown.ts
+++ b/packages/docx-core/src/primitives/serialize_markdown.ts
@@ -111,28 +111,50 @@ export function inlineTagsToMarkdown(text: string): string {
     ops.push({ t: 'md', v: `](${linkUrls.pop()})` });
   }
 
-  // Collapse redundant *adjacent* emphasis toggles (nothing between them). Word splits a
-  // single formatted phrase into multiple runs, so `tagged_text` often holds
-  // `</b></i><b><i>` or empty `<b></b>` pairs. Mapped naively these become `******` or
-  // `****`, which render as literal asterisks. Removing the adjacent close→open (and empty
-  // open→close) pairs re-fuses the phrase into one clean emphasis span.
-  for (let changed = true; changed; ) {
-    changed = false;
-    for (let i = 0; i < ops.length - 1; i++) {
-      const a = ops[i]!;
-      const b = ops[i + 1]!;
-      if (a.t === 'emph' && b.t === 'emph' && a.kind === b.kind && a.dir === -b.dir) {
-        ops.splice(i, 2);
-        changed = true;
-        break;
-      }
-    }
-  }
-
+  // Emit emphasis delimiters only where the *active* emphasis state actually changes
+  // between two text spans. Word splits a single formatted phrase into many runs, so
+  // `tagged_text` carries boundary noise: `</b></i><b><i>` (state unchanged across the
+  // boundary), interleaved different-kind toggles `</b></i><i><b>`, or empty `<b></b>`
+  // pairs. Mapping each toggle naively yields runs like `******` / `****` that render as
+  // literal asterisks. Tracking the state and reconciling on a stack collapses all of that
+  // to the minimal delimiters while keeping nesting well-formed (`**a*b*c**`).
+  const DELIM: Record<'b' | 'i', string> = { b: '**', i: '*' };
   let out = '';
+  const activeStack: ('b' | 'i')[] = []; // emphasis kinds currently open, in open order
+  const desired = new Set<'b' | 'i'>(); // running target state as we scan emph ops
+
+  const reconcile = (): void => {
+    // Close from the top until every still-open kind is wanted, remembering any wanted
+    // kinds we had to close (because they sat above an unwanted one) so we can reopen them.
+    const reopen: ('b' | 'i')[] = [];
+    while (activeStack.length > 0 && !activeStack.every((k) => desired.has(k))) {
+      const k = activeStack.pop()!;
+      out += DELIM[k];
+      if (desired.has(k)) reopen.push(k);
+    }
+    // Open the kinds that are wanted but not currently open: the reopened ones first (in
+    // their original open order), then any brand-new kinds in a stable order (b before i).
+    const active = new Set(activeStack);
+    const toOpen = [...reopen.reverse(), ...(['b', 'i'] as const).filter((k) => desired.has(k))];
+    for (const k of toOpen) {
+      if (active.has(k)) continue;
+      active.add(k);
+      activeStack.push(k);
+      out += DELIM[k];
+    }
+  };
+
   for (const op of ops) {
-    out += op.t === 'md' ? op.v : op.kind === 'b' ? '**' : '*';
+    if (op.t === 'emph') {
+      if (op.dir === 1) desired.add(op.kind);
+      else desired.delete(op.kind);
+      continue;
+    }
+    reconcile(); // realize pending state changes before emitting literal text/Markdown
+    out += op.v;
   }
+  desired.clear();
+  reconcile(); // close any still-open emphasis at end of string
   return out;
 }
 

--- a/packages/docx-mcp/docs/tool-reference.generated.md
+++ b/packages/docx-mcp/docs/tool-reference.generated.md
@@ -139,6 +139,21 @@ Save document. For DOCX: saves clean and/or tracked changes output. For Google D
 | `tracked_changes_engine` | `enum("auto", "atomizer")` | no |  |
 | `fail_on_rebuild_fallback` | `boolean` | no | When true, return an error instead of a destructive output if the comparison engine falls back to rebuild mode (which destroys table structure). Default: false. |
 
+## `export`
+
+Export a document to a portable text rendering. Writes an output file (default: source path with the format extension, e.g. .md) and returns its path, byte count, and the rendered content. Markdown is intentionally lossy (no round-trip). DOCX only — Google Docs is not supported.
+
+- readOnly: `false`
+- destructive: `false`
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `file_path` | `string` | no | Path to the DOCX file. |
+| `format` | `enum("markdown")` | no | Output format. 'markdown' (default). 'html'/'text' are planned. |
+| `output_path` | `string` | no | Where to write the rendering. Defaults to the source path with the format extension. |
+| `allow_overwrite` | `boolean` | no | Overwrite output_path if it already exists. Default: false. |
+| `include_markdown` | `boolean` | no | Include the rendered content in the response. Default: true; set false for large documents. |
+
 ## `format_layout`
 
 Apply layout controls (paragraph spacing, table row height, cell padding). Google Docs supports paragraph spacing only.

--- a/packages/docx-mcp/src/server.ts
+++ b/packages/docx-mcp/src/server.ts
@@ -12,6 +12,7 @@ import { insertParagraph } from './tools/insert_paragraph.js';
 import { mergePlans } from './tools/merge_plans.js';
 import { applyPlan } from './tools/apply_plan.js';
 import { save } from './tools/save.js';
+import { exportDocument } from './tools/export.js';
 import { getFileStatus } from './tools/get_file_status.js';
 import { hasTrackedChanges_tool } from './tools/has_tracked_changes.js';
 import { closeFile } from './tools/close_file.js';
@@ -109,6 +110,8 @@ export async function dispatchToolCall(
     case 'save':
       if (isGDocsRequest(args)) return await dispatchGDocs(sessions, args, 'save');
       return await save(sessions, args as Parameters<typeof save>[1]);
+    case 'export':
+      return await exportDocument(sessions, args as Parameters<typeof exportDocument>[1]);
     case 'format_layout':
       if (isGDocsRequest(args)) return await dispatchGDocs(sessions, args, 'format_layout');
       return await formatLayout(sessions, args as Parameters<typeof formatLayout>[1]);

--- a/packages/docx-mcp/src/tool_catalog.ts
+++ b/packages/docx-mcp/src/tool_catalog.ts
@@ -177,6 +177,31 @@ export const SAFE_DOCX_TOOL_CATALOG = [
     annotations: { readOnlyHint: false, destructiveHint: true },
   },
   {
+    name: 'export',
+    description:
+      'Export a document to a portable text rendering. Writes an output file (default: source path with the format extension, e.g. .md) and returns its path, byte count, and the rendered content. Markdown is intentionally lossy (no round-trip). DOCX only — Google Docs is not supported.',
+    input: z.object({
+      ...FILE_FIELD_OPTIONAL,
+      format: z
+        .enum(['markdown'])
+        .optional()
+        .describe("Output format. 'markdown' (default). 'html'/'text' are planned."),
+      output_path: z
+        .string()
+        .optional()
+        .describe('Where to write the rendering. Defaults to the source path with the format extension.'),
+      allow_overwrite: z
+        .boolean()
+        .optional()
+        .describe('Overwrite output_path if it already exists. Default: false.'),
+      include_markdown: z
+        .boolean()
+        .optional()
+        .describe('Include the rendered content in the response. Default: true; set false for large documents.'),
+    }),
+    annotations: { readOnlyHint: false, destructiveHint: false },
+  },
+  {
     name: 'format_layout',
     description: 'Apply layout controls (paragraph spacing, table row height, cell padding). Google Docs supports paragraph spacing only.',
     input: z.object({

--- a/packages/docx-mcp/src/tools/export.test.ts
+++ b/packages/docx-mcp/src/tools/export.test.ts
@@ -151,4 +151,26 @@ describe('OpenSpec traceability: add-markdown-export (export tool)', () => {
       });
     },
   );
+
+  // Bonus (security regression, no spec scenario): the source-clobber guard must canonicalize
+  // both paths so a symlink output (`link.md` -> the source .docx) cannot slip past a purely
+  // lexical comparison and destroy the source document through the link.
+  test(
+    'a symlink output_path pointing back at the source is refused',
+    async ({ then }: AllureBddContext) => {
+      const opened = await openSession(['Original document body.']);
+      const sourceBefore = await fs.readFile(opened.inputPath);
+      const linkPath = path.join(opened.tmpDir, 'link.md');
+      await fs.symlink(opened.inputPath, linkPath);
+      const result = await exportDocument(opened.mgr, {
+        file_path: opened.inputPath,
+        output_path: linkPath,
+        allow_overwrite: true,
+      });
+      await then('export refuses and the source .docx is byte-for-byte intact', async () => {
+        assertFailure(result, 'OVERWRITE_BLOCKED', 'export');
+        expect(Buffer.compare(await fs.readFile(opened.inputPath), sourceBefore)).toBe(0);
+      });
+    },
+  );
 });

--- a/packages/docx-mcp/src/tools/export.test.ts
+++ b/packages/docx-mcp/src/tools/export.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { assertFailure, assertSuccess, openSession, registerCleanup } from '../testing/session-test-utils.js';
+import { exportDocument } from './export.js';
+
+const TEST_FEATURE = 'add-markdown-export';
+const test = testAllure.epic('Document Editing').withLabels({ feature: TEST_FEATURE });
+
+function mdPathFor(inputPath: string): string {
+  const parsed = path.parse(inputPath);
+  return path.join(parsed.dir, `${parsed.name}.md`);
+}
+
+describe('OpenSpec traceability: add-markdown-export (export tool)', () => {
+  registerCleanup();
+
+  test.openspec('markdown export writes a file and returns its path and content')(
+    'markdown export writes a file and returns its path and content',
+    async ({ then }: AllureBddContext) => {
+      const opened = await openSession(['Hello world.']);
+      const result = await exportDocument(opened.mgr, { file_path: opened.inputPath });
+      await then('the response carries the rendering and the file is on disk', async () => {
+        assertSuccess(result, 'export');
+        expect(result.format).toBe('markdown');
+        expect(typeof result.markdown).toBe('string');
+        expect(result.bytes_written).toBeGreaterThan(0);
+        const onDisk = await fs.readFile(String(result.output_path), 'utf8');
+        expect(onDisk).toBe(result.markdown);
+        expect(onDisk).toContain('Hello world.');
+      });
+    },
+  );
+
+  test.openspec('default output path derives from the source path')(
+    'default output path derives from the source path',
+    async ({ then }: AllureBddContext) => {
+      const opened = await openSession(['Body text.']);
+      const result = await exportDocument(opened.mgr, { file_path: opened.inputPath });
+      await then('the .docx extension is swapped for .md', async () => {
+        assertSuccess(result, 'export');
+        const expected = mdPathFor(opened.inputPath);
+        const exists = await fs.access(expected).then(() => true).catch(() => false);
+        expect(exists).toBe(true);
+        expect(path.resolve(String(result.output_path))).toBe(path.resolve(expected));
+      });
+    },
+  );
+
+  test.openspec('explicit output_path is honored')(
+    'explicit output_path is honored',
+    async ({ then }: AllureBddContext) => {
+      const opened = await openSession(['Body text.']);
+      const target = path.join(opened.tmpDir, 'custom-name.md');
+      const result = await exportDocument(opened.mgr, { file_path: opened.inputPath, output_path: target });
+      await then('the Markdown is written to the explicit path', async () => {
+        assertSuccess(result, 'export');
+        const exists = await fs.access(target).then(() => true).catch(() => false);
+        expect(exists).toBe(true);
+        expect(path.resolve(String(result.output_path))).toBe(path.resolve(target));
+      });
+    },
+  );
+
+  test.openspec('overwrite of an existing output file is blocked by default')(
+    'overwrite of an existing output file is blocked by default',
+    async ({ then }: AllureBddContext) => {
+      const opened = await openSession(['Body text.']);
+      const target = path.join(opened.tmpDir, 'taken.md');
+      await fs.writeFile(target, 'PRE-EXISTING');
+      const result = await exportDocument(opened.mgr, { file_path: opened.inputPath, output_path: target });
+      await then('export refuses and leaves the file untouched', async () => {
+        assertFailure(result, 'OVERWRITE_BLOCKED', 'export');
+        expect(await fs.readFile(target, 'utf8')).toBe('PRE-EXISTING');
+      });
+    },
+  );
+
+  test.openspec('allow_overwrite permits replacing an existing output file')(
+    'allow_overwrite permits replacing an existing output file',
+    async ({ then }: AllureBddContext) => {
+      const opened = await openSession(['Fresh body.']);
+      const target = path.join(opened.tmpDir, 'taken.md');
+      await fs.writeFile(target, 'PRE-EXISTING');
+      const result = await exportDocument(opened.mgr, {
+        file_path: opened.inputPath,
+        output_path: target,
+        allow_overwrite: true,
+      });
+      await then('the file is replaced with the rendering', async () => {
+        assertSuccess(result, 'export');
+        const onDisk = await fs.readFile(target, 'utf8');
+        expect(onDisk).not.toBe('PRE-EXISTING');
+        expect(onDisk).toContain('Fresh body.');
+      });
+    },
+  );
+
+  test.openspec('unknown export format is rejected')(
+    'unknown export format is rejected',
+    async ({ then }: AllureBddContext) => {
+      const opened = await openSession(['Body text.']);
+      const result = await exportDocument(opened.mgr, {
+        file_path: opened.inputPath,
+        format: 'pdf',
+      });
+      await then('an INVALID_FORMAT error is returned', async () => {
+        assertFailure(result, 'INVALID_FORMAT', 'export');
+      });
+    },
+  );
+
+  test.openspec('include_markdown false omits the rendered content')(
+    'include_markdown false omits the rendered content',
+    async ({ then }: AllureBddContext) => {
+      const opened = await openSession(['Body text.']);
+      const result = await exportDocument(opened.mgr, {
+        file_path: opened.inputPath,
+        include_markdown: false,
+      });
+      await then('path and byte count are present but markdown is not', async () => {
+        assertSuccess(result, 'export');
+        expect(result.output_path).toBeTruthy();
+        expect(result.bytes_written).toBeGreaterThan(0);
+        expect(result.markdown).toBeUndefined();
+      });
+    },
+  );
+
+  test.openspec('export resolves a session from file_path')(
+    'export resolves a session from file_path',
+    async ({ then }: AllureBddContext) => {
+      const opened = await openSession(['Resolvable.']);
+      // Call with file_path only (no session_id); resolution should still find the session.
+      const result = await exportDocument(opened.mgr, { file_path: opened.inputPath });
+      await then('the export succeeds via file-path resolution', async () => {
+        assertSuccess(result, 'export');
+        expect(String(result.markdown)).toContain('Resolvable.');
+      });
+    },
+  );
+
+  test.openspec('export rejects a Google Docs source')(
+    'export rejects a Google Docs source',
+    async ({ then }: AllureBddContext) => {
+      const opened = await openSession(['Body text.']);
+      const result = await exportDocument(opened.mgr, { google_doc_id: 'some-google-doc-id' });
+      await then('a provider-unsupported error is returned', async () => {
+        assertFailure(result, 'UNSUPPORTED_FOR_PROVIDER', 'export');
+      });
+    },
+  );
+});

--- a/packages/docx-mcp/src/tools/export.ts
+++ b/packages/docx-mcp/src/tools/export.ts
@@ -73,7 +73,16 @@ export async function exportDocument(
 
     // Never let the export clobber the source DOCX (e.g. a stray output_path pointing back
     // at it). The default path always differs by extension, but an explicit one might not.
-    if (path.resolve(outputPath) === path.resolve(session.originalPath)) {
+    // Compare via realpath so a symlink output (`foo.md` -> `foo.docx`) can't slip past a
+    // purely lexical check and overwrite the source through the link.
+    const canonical = async (p: string): Promise<string> => {
+      try {
+        return await fs.realpath(p);
+      } catch {
+        return path.resolve(p);
+      }
+    };
+    if ((await canonical(outputPath)) === (await canonical(session.originalPath))) {
       return err(
         'OVERWRITE_BLOCKED',
         `Refusing to overwrite the source document: ${outputPath}`,

--- a/packages/docx-mcp/src/tools/export.ts
+++ b/packages/docx-mcp/src/tools/export.ts
@@ -1,0 +1,122 @@
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { SessionManager } from '../session/manager.js';
+import { err, ok, type ToolResponse } from './types.js';
+import { mergeSessionResolutionMetadata, resolveSessionForTool } from './session_resolution.js';
+import { enforceWritePathPolicy } from './path_policy.js';
+import { checkGDocsSupport } from './provider_guard.js';
+
+/** Output formats the export tool can emit. Extensible: `html`/`text` land in #304/#305. */
+const SUPPORTED_FORMATS = ['markdown'] as const;
+type ExportFormat = (typeof SUPPORTED_FORMATS)[number];
+
+const EXTENSION_FOR_FORMAT: Record<ExportFormat, string> = {
+  markdown: '.md',
+};
+
+function expandPath(inputPath: string): string {
+  return inputPath.startsWith('~') ? path.join(process.env.HOME || '', inputPath.slice(1)) : inputPath;
+}
+
+/** Default output path: the source path with its extension swapped for the format's. */
+function defaultOutputPath(sourcePath: string, format: ExportFormat): string {
+  const parsed = path.parse(sourcePath);
+  return path.join(parsed.dir, `${parsed.name}${EXTENSION_FOR_FORMAT[format]}`);
+}
+
+/**
+ * Export a document to a portable text rendering (Markdown today). Writes the rendering to a
+ * file (this tool is NOT read-only) and returns the written path, byte count, and — unless
+ * `include_markdown: false` — the rendered content itself.
+ *
+ * DOCX only. Google Docs (`google_doc_id`) is out of scope for this tool.
+ */
+export async function exportDocument(
+  manager: SessionManager,
+  params: {
+    file_path?: string;
+    session_id?: string;
+    google_doc_id?: string;
+    format?: string;
+    output_path?: string;
+    allow_overwrite?: boolean;
+    include_markdown?: boolean;
+  },
+): Promise<ToolResponse> {
+  try {
+    // DOCX-only guard: reject Google Docs requests explicitly rather than silently degrading.
+    if (typeof params.google_doc_id === 'string' && params.google_doc_id.trim().length > 0) {
+      return checkGDocsSupport('export')!;
+    }
+
+    // Validate the requested format up front with a clear error (mirrors read_file), even
+    // though the catalog Zod enum also constrains it.
+    const format = (params.format ?? 'markdown').toLowerCase();
+    if (!SUPPORTED_FORMATS.includes(format as ExportFormat)) {
+      return err(
+        'INVALID_FORMAT',
+        `Invalid export format: ${params.format}`,
+        `Supported formats: ${SUPPORTED_FORMATS.join(', ')}.`,
+      );
+    }
+    const exportFormat = format as ExportFormat;
+
+    const resolved = await resolveSessionForTool(manager, params, { toolName: 'export' });
+    if (!resolved.ok) return resolved.response;
+    const { session, metadata } = resolved;
+
+    const outputPath = expandPath(
+      params.output_path?.trim()
+        ? params.output_path
+        : defaultOutputPath(session.originalPath, exportFormat),
+    );
+
+    // Never let the export clobber the source DOCX (e.g. a stray output_path pointing back
+    // at it). The default path always differs by extension, but an explicit one might not.
+    if (path.resolve(outputPath) === path.resolve(session.originalPath)) {
+      return err(
+        'OVERWRITE_BLOCKED',
+        `Refusing to overwrite the source document: ${outputPath}`,
+        'Choose a different output_path.',
+      );
+    }
+
+    // Guard against clobbering an existing output file unless explicitly allowed.
+    if (!params.allow_overwrite) {
+      const exists = await fs
+        .access(outputPath)
+        .then(() => true)
+        .catch(() => false);
+      if (exists) {
+        return err(
+          'OVERWRITE_BLOCKED',
+          `Output file already exists: ${outputPath}`,
+          'Set allow_overwrite=true to overwrite, or choose a different output_path.',
+        );
+      }
+    }
+
+    const markdown = await session.doc.toMarkdown();
+    const buffer = Buffer.from(markdown, 'utf8');
+
+    const policy = await enforceWritePathPolicy(outputPath);
+    if (!policy.ok) return policy.response;
+    await fs.mkdir(path.dirname(outputPath), { recursive: true });
+    await fs.writeFile(outputPath, new Uint8Array(buffer));
+
+    const includeMarkdown = params.include_markdown !== false;
+    return ok(
+      mergeSessionResolutionMetadata(
+        {
+          format: exportFormat,
+          output_path: manager.normalizePath(outputPath),
+          bytes_written: buffer.byteLength,
+          ...(includeMarkdown ? { markdown } : {}),
+        },
+        metadata,
+      ),
+    );
+  } catch (error) {
+    return err('EXPORT_FAILED', error instanceof Error ? error.message : String(error));
+  }
+}

--- a/packages/safe-docx-mcpb/manifest.json
+++ b/packages/safe-docx-mcpb/manifest.json
@@ -53,6 +53,10 @@
       "description": "Save clean/tracked output document variants to disk."
     },
     {
+      "name": "export",
+      "description": "Export a document to a portable Markdown rendering on disk (lossy; DOCX only)."
+    },
+    {
       "name": "format_layout",
       "description": "Apply deterministic paragraph/table layout formatting controls."
     },


### PR DESCRIPTION
## What

Adds the **export** leg of the read → edit → compare → export loop (Fixes: #303, epic #307). safe-docx can now emit a portable Markdown rendering of a DOCX.

Per the epic, Markdown/HTML/text are *thin emitters over a shared structured-export core*. This PR builds the Markdown emitter and factors the **inline-tag tokenizer** as the reusable core (HTML #304 will render the same tokens). It is a serializer over the existing `buildDocumentView()` model — **no new OOXML parsing**.

### docx-core
- `serialize_markdown.ts` — `inlineTagsToMarkdown()` (reusable tokenizer → Markdown) and `serializeToMarkdown()` (headings → ATX, nested lists, GFM tables, footnote definitions).
- `document_view.ts` — export `TOON_INLINE_TAG_RE` + new `tokenizeToonInline()`; **make `injectFootnoteMarkers` tag-aware** (reuse `findTaggedTextInsertionIndex`, as the comment-marker path already did). Previously a visible-offset `[^n]` marker was spliced into the *tagged* string by raw index, so it could land inside a formatting tag once `show_formatting` was on. This also corrects `read_file` output for formatted footnoted text.
- `document.ts` — async `DocxDocument.toMarkdown()`.

### docx-mcp
- `export` tool — `format` enum (`markdown`), writes an output file (default: source path with `.md`), overwrite guard + `enforceWritePathPolicy`, returns `output_path` + `bytes_written` + `markdown` (suppressible via `include_markdown:false`). DOCX only. Registered in `tool_catalog.ts` + `server.ts`.

## Design notes (lossy by intent)
- No round-trip guarantee. Highlighting and font runs drop their tags (inner text kept); `<u>` passes through as raw GFM HTML.
- GFM has no colspan/rowspan: horizontally-merged cells leave grid gaps that are filled with empty cells; vertically-merged/nested cells are flattened; multi-line cells use `<br>`.
- **Legal list labels** (`Section 2.1`, `Article IV`, `(a)`) are preserved rather than flattened to a bare `1.`.
- Only Word-styled headings (numeric level) become `#`; heuristic run-in headings stay paragraphs (their bold already lives in the inline tags).
- Tokenize → escape only text spans (footnote markers protected) → map tags, so escaping never corrupts generated Markdown or `[^n]` markers. Adjacent run-split emphasis toggles are coalesced (no stray `******`).

## OpenSpec
`add-markdown-export` with `mcp-server` + `docx-primitives` deltas; `openspec validate --strict` clean.

## Testing
- `serialize_markdown.test.ts` (docx-core) + `export.test.ts` (docx-mcp), mapped to spec scenarios (both coverage gates pass).
- Build, lint, conformance-citations: clean. docx-core 1302 passed; docx-mcp 765 passed.
- **Real-document smoke**: exported a Bonterms Mutual NDA, an NVCA SPA (200+ footnotes), and the ILPA Model LPA. Confirmed 5 levels of headings, correctly-placed footnote markers + ordered definitions, GFM tables with `<br>`/gap handling, and Markdown escaping.

### Sample (NVCA SPA)
```markdown
# <u>Purchase and Sale of Preferred Stock</u>.
## <u>Sale and Issuance of Preferred Stock</u>.
### The Company shall have adopted and filed ... the Initial Closing[^1] ...
...
[^1]: If only one closing is contemplated, references to "Initial Closing," ... should be modified.
```

## Out of scope
Round-trip fidelity, equations/text boxes/charts/layout, HTML/text/PDF emitters (#304/#305/#306), Google Docs source.

🤖 Peer-reviewed by Codex + Gemini before implementation (caught the `<highlight>` tag mismatch, the non-tag-aware footnote injection, path-policy omission, and async `getFootnotes`).