### PR TITLE
refactor(docx-core): extract shared xml-helpers (dedupe defensive XML access) (closes #311)

### DIFF
--- a/packages/docx-core/src/baselines/atomizer/inPlaceModifier.ts
+++ b/packages/docx-core/src/baselines/atomizer/inPlaceModifier.ts
@@ -22,6 +22,7 @@ import { areRunPropertiesEqual } from '../../format-detection.js';
 import { enforceConsumerCompatibility } from './consumerCompatibility.js';
 import { XMLSerializer } from '@xmldom/xmldom';
 import { parseXml } from '../../primitives/xml.js';
+import { findChild } from '../../primitives/xml-helpers.js';
 import { warn } from './debug.js';
 
 const SYNTHETIC_DOC = parseXml('<root xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"/>');
@@ -2616,8 +2617,7 @@ function processAtoms(
   state: RevisionIdState,
   revisedRoot: Element
 ): ProcessingContext {
-  const bodyElements = Array.from(revisedRoot.getElementsByTagName('w:body')) as Element[];
-  const body = bodyElements[0];
+  const body = findChild(revisedRoot, 'w:body');
   if (!body) {
     warn('inPlaceModifier', 'Cannot process atoms: no w:body element found');
     // Return a minimal context to avoid callers having to handle undefined.

--- a/packages/docx-core/src/primitives/comments.ts
+++ b/packages/docx-core/src/primitives/comments.ts
@@ -11,6 +11,7 @@ import { DocxZip } from './zip.js';
 import { getParagraphRuns, getParagraphText, splitRunAtVisibleOffset, type TextRun } from './text.js';
 import { getParagraphBookmarkId } from './bookmarks.js';
 import { childElements, getLeafText, isW } from './dom-helpers.js';
+import { getAttributeSafe } from './xml-helpers.js';
 import {
   createRevisionContainer,
   prepareElementForDeletion,
@@ -328,7 +329,7 @@ function allocateNextCommentId(commentsDoc: Document): number {
   let maxId = -1;
   for (let i = 0; i < commentEls.length; i++) {
     const el = commentEls.item(i) as Element;
-    const idStr = el.getAttributeNS(OOXML.W_NS, 'id') ?? el.getAttribute('w:id');
+    const idStr = getAttributeSafe(el, OOXML.W_NS, 'id', 'w', { bareFallback: false });
     if (idStr) {
       const id = parseInt(idStr, 10);
       if (id > maxId) maxId = id;
@@ -341,13 +342,13 @@ function findCommentParaId(commentsDoc: Document, commentId: number): string | n
   const commentEls = commentsDoc.getElementsByTagNameNS(OOXML.W_NS, W.comment);
   for (let i = 0; i < commentEls.length; i++) {
     const el = commentEls.item(i) as Element;
-    const idStr = el.getAttributeNS(OOXML.W_NS, 'id') ?? el.getAttribute('w:id');
+    const idStr = getAttributeSafe(el, OOXML.W_NS, 'id', 'w', { bareFallback: false });
     if (idStr && parseInt(idStr, 10) === commentId) {
       // paraId is on the w:p child inside the comment
       const paras = el.getElementsByTagNameNS(OOXML.W_NS, W.p);
       if (paras.length > 0) {
         const p = paras.item(0) as Element;
-        return p.getAttributeNS(OOXML.W14_NS, 'paraId') ?? p.getAttribute('w14:paraId') ?? null;
+        return getAttributeSafe(p, OOXML.W14_NS, 'paraId', 'w14', { bareFallback: false });
       }
     }
   }
@@ -612,7 +613,7 @@ async function ensureCommentExEntry(
   const existing = root.getElementsByTagNameNS(OOXML.W15_NS, 'commentEx');
   for (let i = 0; i < existing.length; i++) {
     const el = existing.item(i) as Element;
-    const pid = el.getAttributeNS(OOXML.W15_NS, 'paraId') ?? el.getAttribute('w15:paraId');
+    const pid = getAttributeSafe(el, OOXML.W15_NS, 'paraId', 'w15', { bareFallback: false });
     if (pid === paraId) return; // Already present
   }
 
@@ -634,7 +635,7 @@ async function ensureAuthorInPeople(zip: DocxZip, author: string): Promise<void>
   const persons = root.getElementsByTagNameNS(OOXML.W15_NS, 'person');
   for (let i = 0; i < persons.length; i++) {
     const el = persons.item(i) as Element;
-    const name = el.getAttributeNS(OOXML.W15_NS, 'author') ?? el.getAttribute('w15:author');
+    const name = getAttributeSafe(el, OOXML.W15_NS, 'author', 'w15', { bareFallback: false });
     if (name === author) return; // Already present
   }
 
@@ -730,13 +731,13 @@ export async function getComments(zip: DocxZip, documentXml: Document): Promise<
 
   for (let i = 0; i < commentEls.length; i++) {
     const el = commentEls.item(i) as Element;
-    const idStr = el.getAttributeNS(OOXML.W_NS, 'id') ?? el.getAttribute('w:id');
+    const idStr = getAttributeSafe(el, OOXML.W_NS, 'id', 'w', { bareFallback: false });
     const id = idStr ? parseInt(idStr, 10) : -1;
     if (id < 0) continue;
 
-    const author = el.getAttributeNS(OOXML.W_NS, 'author') ?? el.getAttribute('w:author') ?? '';
-    const date = el.getAttributeNS(OOXML.W_NS, 'date') ?? el.getAttribute('w:date') ?? '';
-    const initials = el.getAttributeNS(OOXML.W_NS, 'initials') ?? el.getAttribute('w:initials') ?? '';
+    const author = getAttributeSafe(el, OOXML.W_NS, 'author', 'w', { bareFallback: false }) ?? '';
+    const date = getAttributeSafe(el, OOXML.W_NS, 'date', 'w', { bareFallback: false }) ?? '';
+    const initials = getAttributeSafe(el, OOXML.W_NS, 'initials', 'w', { bareFallback: false }) ?? '';
 
     // Extract text from <w:t> elements, skipping annotationRef runs
     const text = extractCommentText(el);
@@ -746,7 +747,7 @@ export async function getComments(zip: DocxZip, documentXml: Document): Promise<
     let paragraphId: string | null = null;
     if (paras.length > 0) {
       const p = paras.item(0) as Element;
-      paragraphId = p.getAttributeNS(OOXML.W14_NS, 'paraId') ?? p.getAttribute('w14:paraId') ?? null;
+      paragraphId = getAttributeSafe(p, OOXML.W14_NS, 'paraId', 'w14', { bareFallback: false });
     }
 
     const startPoint = rangeMetadata.startById.get(id);
@@ -779,8 +780,8 @@ export async function getComments(zip: DocxZip, documentXml: Document): Promise<
     const exEls = extDoc.getElementsByTagNameNS(OOXML.W15_NS, 'commentEx');
     for (let i = 0; i < exEls.length; i++) {
       const ex = exEls.item(i) as Element;
-      const childParaId = ex.getAttributeNS(OOXML.W15_NS, 'paraId') ?? ex.getAttribute('w15:paraId');
-      const parentParaId = ex.getAttributeNS(OOXML.W15_NS, 'paraIdParent') ?? ex.getAttribute('w15:paraIdParent');
+      const childParaId = getAttributeSafe(ex, OOXML.W15_NS, 'paraId', 'w15', { bareFallback: false });
+      const parentParaId = getAttributeSafe(ex, OOXML.W15_NS, 'paraIdParent', 'w15', { bareFallback: false });
       if (!childParaId || !parentParaId) continue;
 
       const child = byParaId.get(childParaId);
@@ -798,8 +799,8 @@ export async function getComments(zip: DocxZip, documentXml: Document): Promise<
     const exEls = extDoc.getElementsByTagNameNS(OOXML.W15_NS, 'commentEx');
     for (let i = 0; i < exEls.length; i++) {
       const ex = exEls.item(i) as Element;
-      const childParaId = ex.getAttributeNS(OOXML.W15_NS, 'paraId') ?? ex.getAttribute('w15:paraId');
-      const parentParaId = ex.getAttributeNS(OOXML.W15_NS, 'paraIdParent') ?? ex.getAttribute('w15:paraIdParent');
+      const childParaId = getAttributeSafe(ex, OOXML.W15_NS, 'paraId', 'w15', { bareFallback: false });
+      const parentParaId = getAttributeSafe(ex, OOXML.W15_NS, 'paraIdParent', 'w15', { bareFallback: false });
       if (childParaId && parentParaId) {
         replyParaIds.add(childParaId);
       }
@@ -951,14 +952,14 @@ function recordParagraphLevelMarker(
 }
 
 function getCommentMarkerId(markerEl: Element): number | null {
-  const idStr = markerEl.getAttributeNS(OOXML.W_NS, 'id') ?? markerEl.getAttribute('w:id');
+  const idStr = getAttributeSafe(markerEl, OOXML.W_NS, 'id', 'w', { bareFallback: false });
   if (!idStr) return null;
   const id = parseInt(idStr, 10);
   return Number.isNaN(id) ? null : id;
 }
 
 function getWordAttribute(el: Element, localName: string): string | null {
-  return el.getAttributeNS(OOXML.W_NS, localName) ?? el.getAttribute(`w:${localName}`) ?? el.getAttribute(localName);
+  return getAttributeSafe(el, OOXML.W_NS, localName, 'w');
 }
 
 function resolveMarkerToRunBoundary(
@@ -1055,7 +1056,7 @@ export async function deleteComment(
   const allCommentEls = commentsDoc.getElementsByTagNameNS(OOXML.W_NS, W.comment);
   for (let i = 0; i < allCommentEls.length; i++) {
     const el = allCommentEls.item(i) as Element;
-    const idStr = el.getAttributeNS(OOXML.W_NS, 'id') ?? el.getAttribute('w:id');
+    const idStr = getAttributeSafe(el, OOXML.W_NS, 'id', 'w', { bareFallback: false });
     const id = idStr ? parseInt(idStr, 10) : -1;
     if (id < 0) continue;
     const pid = getCommentElParaId(el);
@@ -1072,8 +1073,8 @@ export async function deleteComment(
     const childrenOf = new Map<string, string[]>();
     for (let i = 0; i < exEls.length; i++) {
       const ex = exEls.item(i) as Element;
-      const childPid = ex.getAttributeNS(OOXML.W15_NS, 'paraId') ?? ex.getAttribute('w15:paraId');
-      const parentPid = ex.getAttributeNS(OOXML.W15_NS, 'paraIdParent') ?? ex.getAttribute('w15:paraIdParent');
+      const childPid = getAttributeSafe(ex, OOXML.W15_NS, 'paraId', 'w15', { bareFallback: false });
+      const parentPid = getAttributeSafe(ex, OOXML.W15_NS, 'paraIdParent', 'w15', { bareFallback: false });
       if (childPid && parentPid) {
         const arr = childrenOf.get(parentPid);
         if (arr) arr.push(childPid);
@@ -1102,7 +1103,7 @@ export async function deleteComment(
   const elsToRemove: Element[] = [];
   for (let i = 0; i < allCommentEls.length; i++) {
     const el = allCommentEls.item(i) as Element;
-    const idStr = el.getAttributeNS(OOXML.W_NS, 'id') ?? el.getAttribute('w:id');
+    const idStr = getAttributeSafe(el, OOXML.W_NS, 'id', 'w', { bareFallback: false });
     const id = idStr ? parseInt(idStr, 10) : -1;
     if (idsToDelete.has(id)) elsToRemove.push(el);
   }
@@ -1118,7 +1119,7 @@ export async function deleteComment(
     const exToRemove: Element[] = [];
     for (let i = 0; i < exEls.length; i++) {
       const ex = exEls.item(i) as Element;
-      const pid = ex.getAttributeNS(OOXML.W15_NS, 'paraId') ?? ex.getAttribute('w15:paraId');
+      const pid = getAttributeSafe(ex, OOXML.W15_NS, 'paraId', 'w15', { bareFallback: false });
       if (pid && paraIdsToDelete.has(pid)) exToRemove.push(ex);
     }
     for (const ex of exToRemove) {
@@ -1137,7 +1138,7 @@ function findCommentElementById(commentsDoc: Document, commentId: number): Eleme
   const commentEls = commentsDoc.getElementsByTagNameNS(OOXML.W_NS, W.comment);
   for (let i = 0; i < commentEls.length; i++) {
     const el = commentEls.item(i) as Element;
-    const idStr = el.getAttributeNS(OOXML.W_NS, 'id') ?? el.getAttribute('w:id');
+    const idStr = getAttributeSafe(el, OOXML.W_NS, 'id', 'w', { bareFallback: false });
     if (idStr && parseInt(idStr, 10) === commentId) return el;
   }
   return null;
@@ -1147,7 +1148,7 @@ function getCommentElParaId(commentEl: Element): string | null {
   const paras = commentEl.getElementsByTagNameNS(OOXML.W_NS, W.p);
   if (paras.length === 0) return null;
   const p = paras.item(0) as Element;
-  return p.getAttributeNS(OOXML.W14_NS, 'paraId') ?? p.getAttribute('w14:paraId') ?? null;
+  return getAttributeSafe(p, OOXML.W14_NS, 'paraId', 'w14', { bareFallback: false });
 }
 
 function removeCommentMarkersFromDocument(
@@ -1162,7 +1163,7 @@ function removeCommentMarkersFromDocument(
   const startsToRemove: Element[] = [];
   for (let i = 0; i < rangeStarts.length; i++) {
     const el = rangeStarts.item(i) as Element;
-    const id = el.getAttributeNS(OOXML.W_NS, 'id') ?? el.getAttribute('w:id');
+    const id = getAttributeSafe(el, OOXML.W_NS, 'id', 'w', { bareFallback: false });
     if (id === cidStr) startsToRemove.push(el);
   }
   for (const el of startsToRemove) el.parentNode?.removeChild(el);
@@ -1172,7 +1173,7 @@ function removeCommentMarkersFromDocument(
   const endsToRemove: Element[] = [];
   for (let i = 0; i < rangeEnds.length; i++) {
     const el = rangeEnds.item(i) as Element;
-    const id = el.getAttributeNS(OOXML.W_NS, 'id') ?? el.getAttribute('w:id');
+    const id = getAttributeSafe(el, OOXML.W_NS, 'id', 'w', { bareFallback: false });
     if (id === cidStr) endsToRemove.push(el);
   }
   for (const el of endsToRemove) el.parentNode?.removeChild(el);
@@ -1183,7 +1184,7 @@ function removeCommentMarkersFromDocument(
   const refsToRemove: Element[] = [];
   for (let i = 0; i < refs.length; i++) {
     const el = refs.item(i) as Element;
-    const id = el.getAttributeNS(OOXML.W_NS, 'id') ?? el.getAttribute('w:id');
+    const id = getAttributeSafe(el, OOXML.W_NS, 'id', 'w', { bareFallback: false });
     if (id === cidStr) refsToRemove.push(el);
   }
   for (const ref of refsToRemove) {

--- a/packages/docx-core/src/primitives/document_view.ts
+++ b/packages/docx-core/src/primitives/document_view.ts
@@ -1,4 +1,5 @@
 import { OOXML, W } from './namespaces.js';
+import { getAttributeSafe, getFirstChild } from './xml-helpers.js';
 import { getParagraphText, getParagraphRuns } from './text.js';
 import { extractListLabel, stripListLabel, LabelType } from './list_labels.js';
 import { parseNumberingXml, type NumberingCounters, computeListLabelForParagraph } from './numbering.js';
@@ -19,13 +20,13 @@ const MAX_CENTERED_TITLE_LENGTH = 120;
 const STYLE_EXAMPLE_TEXT_PREVIEW_LENGTH = 50;
 
 function getWAttr(el: Element, localName: string): string | null {
-  return el.getAttributeNS(OOXML.W_NS, localName) ?? el.getAttribute(`w:${localName}`) ?? el.getAttribute(localName);
+  return getAttributeSafe(el, OOXML.W_NS, localName, 'w');
 }
 
 function runHighlightVal(run: Element): string | null {
-  const rPr = run.getElementsByTagNameNS(OOXML.W_NS, W.rPr).item(0);
+  const rPr = getFirstChild(run, OOXML.W_NS, W.rPr);
   if (!rPr) return null;
-  const h = rPr.getElementsByTagNameNS(OOXML.W_NS, W.highlight).item(0);
+  const h = getFirstChild(rPr, OOXML.W_NS, W.highlight);
   if (!h) return null;
   const v = getWAttr(h, 'val');
   if (!v || v === 'none') return null;
@@ -999,7 +1000,7 @@ export function buildDocumentView(params: {
   const counters: NumberingCounters = new Map();
   void counters;
 
-  const body = documentXml.getElementsByTagNameNS(OOXML.W_NS, W.body).item(0);
+  const body = getFirstChild(documentXml, OOXML.W_NS, W.body);
   if (!body) return { nodes: [], styles: { styles: new Map(), fingerprint_to_style: new Map() } };
 
   const paragraphs = Array.from(body.getElementsByTagNameNS(OOXML.W_NS, W.p));
@@ -1024,10 +1025,7 @@ function resolveRunHyperlinkUrl(runEl: Element, relsMap: RelsMap | undefined): s
   const parent = runEl.parentNode as Element | null;
   if (!parent || parent.localName !== W.hyperlink) return null;
   // r:id attribute can be namespaced or prefixed.
-  const rId =
-    parent.getAttributeNS(OOXML.R_NS, 'id') ??
-    parent.getAttribute('r:id') ??
-    null;
+  const rId = getAttributeSafe(parent, OOXML.R_NS, 'id', 'r', { bareFallback: false });
   if (!rId) return null;
   return relsMap.get(rId) ?? null;
 }
@@ -1248,7 +1246,7 @@ export function buildNodesForDocumentView(params: {
 
   if (showFormatting) {
     for (const { p } of paragraphs) {
-      const paraPPr = p.getElementsByTagNameNS(OOXML.W_NS, W.pPr).item(0);
+      const paraPPr = getFirstChild(p, OOXML.W_NS, W.pPr);
       const paraFmt = extractParagraphFormatting(paraPPr ?? null, stylesModel);
       const runs = buildAnnotatedRuns({
         p,
@@ -1301,7 +1299,7 @@ export function buildNodesForDocumentView(params: {
   for (let idx = 0; idx < paragraphs.length; idx++) {
     const { id, p, tableContext } = paragraphs[idx]!;
 
-    const paraPPr = p.getElementsByTagNameNS(OOXML.W_NS, W.pPr).item(0);
+    const paraPPr = getFirstChild(p, OOXML.W_NS, W.pPr);
     const paraFmt = extractParagraphFormatting(paraPPr ?? null, stylesModel);
 
     // Visible clean text (field codes stripped).
@@ -1312,10 +1310,10 @@ export function buildNodesForDocumentView(params: {
     // Numbering (auto-numbered) info from numPr.
     let numId: string | null = null;
     let ilvl: number | null = null;
-    const numPr = paraPPr ? paraPPr.getElementsByTagNameNS(OOXML.W_NS, W.numPr).item(0) : null;
+    const numPr = paraPPr ? getFirstChild(paraPPr, OOXML.W_NS, W.numPr) : null;
     if (numPr) {
-      const numIdEl = numPr.getElementsByTagNameNS(OOXML.W_NS, W.numId).item(0);
-      const ilvlEl = numPr.getElementsByTagNameNS(OOXML.W_NS, W.ilvl).item(0);
+      const numIdEl = getFirstChild(numPr, OOXML.W_NS, W.numId);
+      const ilvlEl = getFirstChild(numPr, OOXML.W_NS, W.ilvl);
       const numIdVal = numIdEl ? getWAttr(numIdEl, 'val') : null;
       const ilvlVal = ilvlEl ? getWAttr(ilvlEl, 'val') : null;
       if (numIdVal) numId = numIdVal;

--- a/packages/docx-core/src/primitives/styles.ts
+++ b/packages/docx-core/src/primitives/styles.ts
@@ -1,10 +1,10 @@
 import { OOXML, W } from './namespaces.js';
+import { getAttributeSafe, getFirstChild } from './xml-helpers.js';
 
 function getWAttr(el: Element, localName: string): string | null {
-  // Use || instead of ?? — getAttributeNS returns "" (not null) when the
-  // attribute exists without proper NS binding (e.g. set via setAttribute
-  // instead of setAttributeNS).
-  return el.getAttributeNS(OOXML.W_NS, localName) || el.getAttribute(`w:${localName}`) || el.getAttribute(localName) || null;
+  // Preserve legacy truthy fallback for empty strings from namespace-bound reads
+  // when attributes were written without a real namespace binding.
+  return getAttributeSafe(el, OOXML.W_NS, localName, 'w', { emptyIsMissing: true });
 }
 
 export type StyleDef = {
@@ -27,10 +27,10 @@ export function parseStylesXml(stylesDoc: Document | null): StylesModel {
   for (const st of styles) {
     const id = getWAttr(st, 'styleId');
     if (!id) continue;
-    const nameEl = st.getElementsByTagNameNS(OOXML.W_NS, W.name).item(0);
-    const basedOnEl = st.getElementsByTagNameNS(OOXML.W_NS, W.basedOn).item(0);
-    const pPr = st.getElementsByTagNameNS(OOXML.W_NS, W.pPr).item(0);
-    const rPr = st.getElementsByTagNameNS(OOXML.W_NS, W.rPr).item(0);
+    const nameEl = getFirstChild(st, OOXML.W_NS, W.name);
+    const basedOnEl = getFirstChild(st, OOXML.W_NS, W.basedOn);
+    const pPr = getFirstChild(st, OOXML.W_NS, W.pPr);
+    const rPr = getFirstChild(st, OOXML.W_NS, W.rPr);
 
     const name = nameEl ? (getWAttr(nameEl, 'val') ?? id) : id;
     const basedOn = basedOnEl ? (getWAttr(basedOnEl, 'val') ?? null) : null;
@@ -113,18 +113,18 @@ export function extractParagraphFormatting(
   pPr: Element | null,
   styles: StylesModel,
 ): ParagraphFormatting {
-  const pStyleEl = pPr ? pPr.getElementsByTagNameNS(OOXML.W_NS, W.pStyle).item(0) : null;
+  const pStyleEl = pPr ? getFirstChild(pPr, OOXML.W_NS, W.pStyle) : null;
   const styleId = pStyleEl ? (getWAttr(pStyleEl, 'val') ?? null) : null;
 
   const chain = resolveStyleChain(styles, styleId);
   const styleName = (styleId && styles.byId.get(styleId)?.name) || styleId || '';
 
   // Resolve alignment and indents: direct pPr overrides style chain.
-  const directJc = pPr ? pPr.getElementsByTagNameNS(OOXML.W_NS, W.jc).item(0) : null;
-  const directInd = pPr ? pPr.getElementsByTagNameNS(OOXML.W_NS, W.ind).item(0) : null;
+  const directJc = pPr ? getFirstChild(pPr, OOXML.W_NS, W.jc) : null;
+  const directInd = pPr ? getFirstChild(pPr, OOXML.W_NS, W.ind) : null;
 
-  const styleJc = firstNonNull(chain.map((s) => (s.pPr ? s.pPr.getElementsByTagNameNS(OOXML.W_NS, W.jc).item(0) : null)));
-  const styleInd = firstNonNull(chain.map((s) => (s.pPr ? s.pPr.getElementsByTagNameNS(OOXML.W_NS, W.ind).item(0) : null)));
+  const styleJc = firstNonNull(chain.map((s) => (s.pPr ? getFirstChild(s.pPr, OOXML.W_NS, W.jc) : null)));
+  const styleInd = firstNonNull(chain.map((s) => (s.pPr ? getFirstChild(s.pPr, OOXML.W_NS, W.ind) : null)));
 
   const alignment = parseAlignment(directJc ?? styleJc);
   const ind = parseIndentPt(directInd ?? styleInd);
@@ -150,7 +150,7 @@ export type RunFormatting = {
 
 function parseBoolProp(parent: Element | null, tagLocal: string): boolean | null {
   if (!parent) return null;
-  const el = parent.getElementsByTagNameNS(OOXML.W_NS, tagLocal).item(0);
+  const el = getFirstChild(parent, OOXML.W_NS, tagLocal);
   if (!el) return null;
   // <w:b/> implies true. <w:b w:val="0"/> implies false.
   const v = getWAttr(el, 'val');
@@ -160,7 +160,7 @@ function parseBoolProp(parent: Element | null, tagLocal: string): boolean | null
 
 function parseUnderline(parent: Element | null): boolean | null {
   if (!parent) return null;
-  const el = parent.getElementsByTagNameNS(OOXML.W_NS, W.u).item(0);
+  const el = getFirstChild(parent, OOXML.W_NS, W.u);
   if (!el) return null;
   const v = getWAttr(el, 'val');
   if (!v) return true;
@@ -169,14 +169,14 @@ function parseUnderline(parent: Element | null): boolean | null {
 
 function parseFontName(parent: Element | null): string | null {
   if (!parent) return null;
-  const el = parent.getElementsByTagNameNS(OOXML.W_NS, W.rFonts).item(0);
+  const el = getFirstChild(parent, OOXML.W_NS, W.rFonts);
   if (!el) return null;
   return getWAttr(el, 'ascii') ?? getWAttr(el, 'hAnsi') ?? getWAttr(el, 'cs') ?? getWAttr(el, 'val') ?? null;
 }
 
 function parseFontSizePt(parent: Element | null): number | null {
   if (!parent) return null;
-  const el = parent.getElementsByTagNameNS(OOXML.W_NS, W.sz).item(0);
+  const el = getFirstChild(parent, OOXML.W_NS, W.sz);
   if (!el) return null;
   const valStr = getWAttr(el, 'val') || el.getAttribute('val');
   if (!valStr) return null;
@@ -188,7 +188,7 @@ function parseFontSizePt(parent: Element | null): number | null {
 
 function parseColorHex(parent: Element | null): string | null {
   if (!parent) return null;
-  const el = parent.getElementsByTagNameNS(OOXML.W_NS, W.color).item(0);
+  const el = getFirstChild(parent, OOXML.W_NS, W.color);
   if (!el) return null;
   const v = getWAttr(el, 'val') || el.getAttribute('val');
   if (!v || v === 'auto') return null;
@@ -197,7 +197,7 @@ function parseColorHex(parent: Element | null): string | null {
 
 function parseHighlightVal(parent: Element | null): string | null {
   if (!parent) return null;
-  const el = parent.getElementsByTagNameNS(OOXML.W_NS, W.highlight).item(0);
+  const el = getFirstChild(parent, OOXML.W_NS, W.highlight);
   if (!el) return null;
   const v = getWAttr(el, 'val');
   if (!v || v === 'none') return null;
@@ -212,11 +212,11 @@ export function extractEffectiveRunFormatting(params: {
 }): RunFormatting {
   const { run, paragraphPPr, paragraphStyleId, styles } = params;
   const isRun = run.localName === W.r || run.localName === 'r';
-  const rPr = isRun ? run.getElementsByTagNameNS(OOXML.W_NS, W.rPr).item(0) : null;
-  const pRPr = paragraphPPr ? paragraphPPr.getElementsByTagNameNS(OOXML.W_NS, W.rPr).item(0) : null;
+  const rPr = isRun ? getFirstChild(run, OOXML.W_NS, W.rPr) : null;
+  const pRPr = paragraphPPr ? getFirstChild(paragraphPPr, OOXML.W_NS, W.rPr) : null;
 
   // Resolve w:rStyle character style chain (e.g. "Strong" → bold via style definition).
-  const rStyleEl = rPr?.getElementsByTagNameNS(OOXML.W_NS, W.rStyle).item(0);
+  const rStyleEl = rPr ? getFirstChild(rPr, OOXML.W_NS, W.rStyle) : null;
   const rStyleId = rStyleEl ? (getWAttr(rStyleEl, 'val') ?? null) : null;
   const rStyleChain = resolveStyleChain(styles, rStyleId);
   const rStyleRPr = firstNonNull(rStyleChain.map((s) => s.rPr));

--- a/packages/docx-core/src/primitives/tables.ts
+++ b/packages/docx-core/src/primitives/tables.ts
@@ -8,6 +8,7 @@
 
 import { OOXML, W } from './namespaces.js';
 import { isW, getDirectChildrenByName } from './dom-helpers.js';
+import { getAttributeSafe, getFirstChild } from './xml-helpers.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -118,7 +119,7 @@ function detectMerge(tc: Element): 'hMerge' | 'vMerge' | 'gridSpan' | null {
     if (child.nodeType !== 1) continue;
     const el = child as Element;
     if (isW(el, 'gridSpan')) {
-      const val = el.getAttributeNS(OOXML.W_NS, W.val) ?? el.getAttribute('w:val');
+      const val = getAttributeSafe(el, OOXML.W_NS, W.val, 'w', { bareFallback: false });
       if (val && parseInt(val, 10) > 1) return 'gridSpan';
     }
   }
@@ -128,7 +129,7 @@ function detectMerge(tc: Element): 'hMerge' | 'vMerge' | 'gridSpan' | null {
 
 /** Get top-level tables from w:body only (not nested tables). */
 function getBodyTables(doc: Document): Element[] {
-  const body = doc.getElementsByTagNameNS(OOXML.W_NS, W.body).item(0);
+  const body = getFirstChild(doc, OOXML.W_NS, W.body);
   if (!body) return [];
   return getDirectChildrenByName(body as Element, W.tbl);
 }

--- a/packages/docx-core/src/primitives/text.ts
+++ b/packages/docx-core/src/primitives/text.ts
@@ -1,5 +1,6 @@
 import { OOXML, W } from './namespaces.js';
 import { SafeDocxError } from './errors.js';
+import { getAttributeSafe, getFirstChild } from './xml-helpers.js';
 import {
   buildRPrChangeElement,
   createRevisionContainer,
@@ -21,7 +22,7 @@ export function getParagraphRuns(p: Element): TextRun[] {
   }
 
   function getWAttr(el: Element, localName: string): string | null {
-    return el.getAttributeNS(OOXML.W_NS, localName) ?? el.getAttribute(`w:${localName}`) ?? el.getAttribute(localName);
+    return getAttributeSafe(el, OOXML.W_NS, localName, 'w');
   }
 
   const runs: TextRun[] = [];
@@ -382,7 +383,7 @@ function ensureRPr(doc: Document, run: Element): Element {
 }
 
 function ensureBoolProp(doc: Document, rPr: Element, localName: string, val: boolean): void {
-  let el = rPr.getElementsByTagNameNS(OOXML.W_NS, localName).item(0) as Element | null;
+  let el = getFirstChild(rPr, OOXML.W_NS, localName);
   if (val) {
     if (!el) {
       el = doc.createElementNS(OOXML.W_NS, `w:${localName}`);
@@ -395,7 +396,7 @@ function ensureBoolProp(doc: Document, rPr: Element, localName: string, val: boo
 }
 
 function ensureUnderline(doc: Document, rPr: Element, val: boolean | string): void {
-  let el = rPr.getElementsByTagNameNS(OOXML.W_NS, W.u).item(0) as Element | null;
+  let el = getFirstChild(rPr, OOXML.W_NS, W.u);
   if (val === false) {
     if (el) el.parentNode?.removeChild(el);
     return;
@@ -418,7 +419,7 @@ function ensureHighlight(doc: Document, rPr: Element, val: boolean | string): vo
     clearHighlightProp(rPr);
     return;
   }
-  let el = rPr.getElementsByTagNameNS(OOXML.W_NS, W.highlight).item(0) as Element | null;
+  let el = getFirstChild(rPr, OOXML.W_NS, W.highlight);
   if (!el) {
     el = doc.createElementNS(OOXML.W_NS, `w:${W.highlight}`);
     rPr.insertBefore(el, rPr.firstChild);
@@ -428,7 +429,7 @@ function ensureHighlight(doc: Document, rPr: Element, val: boolean | string): vo
 
 function ensureSz(doc: Document, rPr: Element, halfPoints: number): void {
   for (const localName of [W.sz, W.szCs]) {
-    let el = rPr.getElementsByTagNameNS(OOXML.W_NS, localName).item(0) as Element | null;
+    let el = getFirstChild(rPr, OOXML.W_NS, localName);
     if (!el) {
       el = doc.createElementNS(OOXML.W_NS, `w:${localName}`);
       rPr.insertBefore(el, rPr.firstChild);
@@ -438,7 +439,7 @@ function ensureSz(doc: Document, rPr: Element, halfPoints: number): void {
 }
 
 function ensureColor(doc: Document, rPr: Element, hex: string): void {
-  let el = rPr.getElementsByTagNameNS(OOXML.W_NS, W.color).item(0) as Element | null;
+  let el = getFirstChild(rPr, OOXML.W_NS, W.color);
   if (!el) {
     el = doc.createElementNS(OOXML.W_NS, `w:${W.color}`);
     rPr.insertBefore(el, rPr.firstChild);
@@ -447,7 +448,7 @@ function ensureColor(doc: Document, rPr: Element, hex: string): void {
 }
 
 function ensureFont(doc: Document, rPr: Element, name: string): void {
-  let el = rPr.getElementsByTagNameNS(OOXML.W_NS, W.rFonts).item(0) as Element | null;
+  let el = getFirstChild(rPr, OOXML.W_NS, W.rFonts);
   if (!el) {
     el = doc.createElementNS(OOXML.W_NS, `w:${W.rFonts}`);
     rPr.insertBefore(el, rPr.firstChild);

--- a/packages/docx-core/src/primitives/xml-helpers.ts
+++ b/packages/docx-core/src/primitives/xml-helpers.ts
@@ -1,0 +1,59 @@
+/**
+ * Defensive XML access helpers for OOXML-style DOMs.
+ *
+ * DOCX parts in the wild may mix namespace-bound attributes/elements with
+ * prefixed or bare names. These helpers centralize the fallback order without
+ * changing each caller's null handling.
+ */
+
+export type AttributeSafeOptions = {
+  /**
+   * Treat empty strings as missing and continue through fallbacks.
+   * Leave false for the canonical DOM getAttributeNS/getAttribute semantics.
+   */
+  emptyIsMissing?: boolean;
+  /** Include a final bare local-name lookup after namespace/prefix fallbacks. */
+  bareFallback?: boolean;
+};
+
+/**
+ * Read an attribute by namespace, then optional prefix, then bare local name.
+ */
+export function getAttributeSafe(
+  el: Element,
+  ns: string,
+  localName: string,
+  prefix?: string,
+  options?: AttributeSafeOptions,
+): string | null {
+  const useBareFallback = options?.bareFallback ?? true;
+
+  if (options?.emptyIsMissing) {
+    return (
+      el.getAttributeNS(ns, localName) ||
+      (prefix ? el.getAttribute(`${prefix}:${localName}`) : null) ||
+      (useBareFallback ? el.getAttribute(localName) : null) ||
+      null
+    );
+  }
+
+  return (
+    el.getAttributeNS(ns, localName) ??
+    (prefix ? el.getAttribute(`${prefix}:${localName}`) : null) ??
+    (useBareFallback ? el.getAttribute(localName) : null)
+  );
+}
+
+/**
+ * Return the first descendant element matching namespace/local-name, or null.
+ */
+export function getFirstChild(parent: Element | Document, ns: string, localName: string): Element | null {
+  return parent.getElementsByTagNameNS(ns, localName).item(0) as Element | null;
+}
+
+/**
+ * Return the first descendant element matching tag name, or null.
+ */
+export function findChild(parent: Element | Document, tagName: string): Element | null {
+  return parent.getElementsByTagName(tagName).item(0) as Element | null;
+}


### PR DESCRIPTION
## Summary
Consolidates the duplicated defensive XML-access idioms in `docx-core` into a single `primitives/xml-helpers.ts` (`getAttributeSafe` / `getFirstChild` / `findChild`), and applies them across the primitives + the inplace modifier. Pure behavior-preserving refactor; also seeds the upcoming `odf-core` package.

## Implementation
- New `packages/docx-core/src/primitives/xml-helpers.ts`.
- `getWAttr` and ~50 `getAttributeNS`/`getElementsByTagName(...).item(0)` call sites now route through the helpers.
- Fallback semantics preserved exactly: default 3-level (ns → prefix → bare); call sites that omitted the bare-name fallback pass `{ bareFallback: false }`.
- Dedup: `getAttributeNS` occurrences in primitives 50 → 21; first-child idiom in target files 33 → 0.

## Verification
- [x] Build clean (workspace)
- [x] `npm run test:run` — 1291 passed / 11 skipped (skips are the Lean differential tests, which need the local Lean binary)
- [x] Full pre-submit chain green: `lint:workspaces`, `check:spec-coverage`, `check:conformance-citations`, `check:conformance-doc`
- [x] `verification/lean` untouched
- [ ] Peer review (Gemini + Codex) — pending; will be appended below

## Closes
- #311