### PR TITLE
fix(allure-test-factory): restore Allure tree grouping under allure-vitest ≥3.6 project-scoped labels

### DIFF
--- a/packages/allure-test-factory/package.json
+++ b/packages/allure-test-factory/package.json
@@ -20,6 +20,7 @@
   "main": "./src/index.js",
   "types": "./src/index.d.ts",
   "scripts": {
+    "test": "vitest",
     "test:run": "vitest run"
   },
   "files": [

--- a/packages/allure-test-factory/src/compat-reporter.js
+++ b/packages/allure-test-factory/src/compat-reporter.js
@@ -22,6 +22,59 @@ function resolvePrefix(prefix, overrides, packageName) {
   return null;
 }
 
+/**
+ * Rewrite an ordered path (the dot-split `package` label or the `titlePath`
+ * array) so the Allure tree groups by display name.
+ *
+ * allure-vitest >=3.6 prepends a project-scope segment — the nearest
+ * package.json `name`, e.g. `@usejunior/docx-core` — ahead of the source
+ * directory, so the source-root anchor (`src`/`test`/an override key) is no
+ * longer at index 0. Find that anchor wherever it now sits, drop everything
+ * before it (the project scope), and replace it with its display name. Pre-3.6
+ * shapes have the anchor at index 0, so this is a no-op-equivalent rewrite for
+ * them and stays backward compatible.
+ *
+ * @param {string[]} segments - Ordered path segments.
+ * @param {Record<string, string> | undefined} overrides
+ * @param {string | undefined} packageName
+ * @returns {string[] | null} - Rewritten segments, or null if no anchor resolves.
+ */
+function rewritePathSegments(segments, overrides, packageName) {
+  for (let i = 0; i < segments.length; i++) {
+    const resolved = resolvePrefix(segments[i], overrides, packageName);
+    if (resolved !== null) {
+      return [resolved, ...segments.slice(i + 1)];
+    }
+  }
+  return null;
+}
+
+/**
+ * Rewrite an allure-vitest `fullName`. The shape is `<project>:<specPath>#<test>`
+ * in >=3.6 (e.g. `@usejunior/docx-core:src/foo.test.ts#suite test`) and just
+ * `<specPath>#<test>` before that. Drop the leading `<project>:` scope (package
+ * names never contain `:`), then replace the spec path's source-root directory
+ * with its display name.
+ *
+ * @returns {string | null} - Rewritten fullName, or null if the prefix doesn't resolve.
+ */
+function rewriteFullName(fullName, overrides, packageName) {
+  const hashIdx = fullName.indexOf('#');
+  const locator = hashIdx === -1 ? fullName : fullName.slice(0, hashIdx);
+  const testPart = hashIdx === -1 ? '' : fullName.slice(hashIdx);
+
+  const colonIdx = locator.indexOf(':');
+  const specPath = colonIdx === -1 ? locator : locator.slice(colonIdx + 1);
+
+  const slashIdx = specPath.indexOf('/');
+  const prefix = slashIdx === -1 ? specPath : specPath.slice(0, slashIdx);
+  const resolved = resolvePrefix(prefix, overrides, packageName);
+  if (resolved === null) return null;
+
+  const rewrittenPath = slashIdx === -1 ? resolved : resolved + specPath.slice(slashIdx);
+  return rewrittenPath + testPart;
+}
+
 export default class AllureVitestCompatReporter {
   /** @type {unknown} */
   ctx;
@@ -120,40 +173,34 @@ export default class AllureVitestCompatReporter {
           }
         }
 
-        // 2. Rewrite `package` label: replace leading directory with resolved name.
+        // 2. Rewrite `package` label so the Packages tab groups by display name.
+        //    Anchor on the source-root segment (`src`/override key), dropping any
+        //    leading project-scope segment that allure-vitest >=3.6 prepends.
         if (packageName) {
           for (const label of data.labels) {
             if (label.name === 'package' && typeof label.value === 'string') {
-              const parts = label.value.split('.');
-              if (parts.length > 0) {
-                const resolved = resolvePrefix(parts[0], overrides, packageName);
-                if (resolved !== null) {
-                  parts[0] = resolved;
-                  label.value = parts.join('.');
-                  changed = true;
-                }
+              const rewritten = rewritePathSegments(label.value.split('.'), overrides, packageName);
+              if (rewritten !== null) {
+                label.value = rewritten.join('.');
+                changed = true;
               }
             }
           }
 
           // 3. Rewrite `fullName`: controls the Results page tree hierarchy.
           if (typeof data.fullName === 'string') {
-            const slashIdx = data.fullName.indexOf('/');
-            if (slashIdx !== -1) {
-              const prefix = data.fullName.slice(0, slashIdx);
-              const resolved = resolvePrefix(prefix, overrides, packageName);
-              if (resolved !== null) {
-                data.fullName = resolved + data.fullName.slice(slashIdx);
-                changed = true;
-              }
+            const rewritten = rewriteFullName(data.fullName, overrides, packageName);
+            if (rewritten !== null && rewritten !== data.fullName) {
+              data.fullName = rewritten;
+              changed = true;
             }
           }
 
-          // 4. Rewrite `titlePath[0]`.
+          // 4. Rewrite `titlePath`: drop the project scope and map the source root.
           if (Array.isArray(data.titlePath) && data.titlePath.length > 0) {
-            const resolved = resolvePrefix(data.titlePath[0], overrides, packageName);
-            if (resolved !== null) {
-              data.titlePath[0] = resolved;
+            const rewritten = rewritePathSegments(data.titlePath, overrides, packageName);
+            if (rewritten !== null) {
+              data.titlePath = rewritten;
               changed = true;
             }
           }

--- a/packages/allure-test-factory/src/compat-reporter.test.js
+++ b/packages/allure-test-factory/src/compat-reporter.test.js
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtemp, readFile, readdir, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import Reporter from './compat-reporter.js';
+
+/**
+ * Regression coverage for the Allure tree-grouping normalization in
+ * `normalizeResultLabels`. The exercised shapes are the *raw* labels
+ * allure-vitest emits; the assertions are the rewritten display-name tree.
+ *
+ * allure-vitest >=3.6 prepends a project-scope segment (the nearest
+ * package.json `name`) ahead of the source directory — `package` becomes
+ * `@scope/pkg.src.foo.test.ts` and `fullName` becomes
+ * `@scope/pkg:src/foo.test.ts#test`. The pre-3.6 shape had the source root at
+ * index 0. Both must normalize to the same `<display>.<file>` tree so the
+ * report grouping is stable across the version bump.
+ */
+
+const DOCX_CORE_OPTS = {
+  innerReporterPath: '',
+  packageName: 'DOCX Comparison',
+  packageNameOverrides: { 'test-primitives': 'DOCX Primitives' },
+};
+
+let resultsDir;
+
+beforeEach(async () => {
+  resultsDir = await mkdtemp(join(tmpdir(), 'allure-compat-'));
+});
+
+afterEach(async () => {
+  await rm(resultsDir, { recursive: true, force: true });
+});
+
+async function writeResult(name, result) {
+  await writeFile(join(resultsDir, name), JSON.stringify(result));
+}
+
+async function normalize(opts = DOCX_CORE_OPTS) {
+  const reporter = new Reporter({ ...opts, resultsDir });
+  await reporter.normalizeResultLabels();
+  const entries = (await readdir(resultsDir)).filter((e) => e.endsWith('-result.json'));
+  const out = {};
+  for (const entry of entries) {
+    out[entry] = JSON.parse(await readFile(join(resultsDir, entry), 'utf-8'));
+  }
+  return out;
+}
+
+describe('compat-reporter normalizeResultLabels', () => {
+  it('rewrites the allure-vitest >=3.6 project-scoped shape to the display-name tree', async () => {
+    await writeResult('a-result.json', {
+      labels: [{ name: 'package', value: '@usejunior/docx-core.src.atomizer-rpr.test.ts' }],
+      fullName: '@usejunior/docx-core:src/atomizer-rpr.test.ts#ComparisonUnitAtom.rPr sets rPr',
+      titlePath: ['@usejunior/docx-core', 'src', 'atomizer-rpr.test.ts', 'ComparisonUnitAtom.rPr'],
+    });
+
+    const { 'a-result.json': r } = await normalize();
+
+    expect(r.labels.find((l) => l.name === 'package').value).toBe('DOCX Comparison.atomizer-rpr.test.ts');
+    expect(r.fullName).toBe('DOCX Comparison/atomizer-rpr.test.ts#ComparisonUnitAtom.rPr sets rPr');
+    // Source file is stripped from titlePath so the tree matches the breadcrumb.
+    expect(r.titlePath).toEqual(['DOCX Comparison', 'ComparisonUnitAtom.rPr']);
+  });
+
+  it('applies packageNameOverrides to the source-root segment (test-primitives)', async () => {
+    await writeResult('b-result.json', {
+      labels: [{ name: 'package', value: '@usejunior/docx-core.test-primitives.bookmarks.test.ts' }],
+      fullName: '@usejunior/docx-core:test-primitives/bookmarks.test.ts#Paragraph Bookmarks mints IDs',
+      titlePath: ['@usejunior/docx-core', 'test-primitives', 'bookmarks.test.ts', 'Paragraph Bookmarks'],
+    });
+
+    const { 'b-result.json': r } = await normalize();
+
+    expect(r.labels.find((l) => l.name === 'package').value).toBe('DOCX Primitives.bookmarks.test.ts');
+    expect(r.fullName).toBe('DOCX Primitives/bookmarks.test.ts#Paragraph Bookmarks mints IDs');
+    expect(r.titlePath).toEqual(['DOCX Primitives', 'Paragraph Bookmarks']);
+  });
+
+  it('keeps nested source directories below the source root', async () => {
+    await writeResult('c-result.json', {
+      labels: [
+        {
+          name: 'package',
+          value: '@usejunior/docx-core.src.baselines.atomizer.pipeline.field-validation.test.ts',
+        },
+      ],
+      fullName:
+        '@usejunior/docx-core:src/baselines/atomizer/pipeline.field-validation.test.ts#validateFieldStructure rejects',
+      titlePath: [
+        '@usejunior/docx-core',
+        'src',
+        'baselines',
+        'atomizer',
+        'pipeline.field-validation.test.ts',
+        'validateFieldStructure',
+      ],
+    });
+
+    const { 'c-result.json': r } = await normalize();
+
+    expect(r.labels.find((l) => l.name === 'package').value).toBe(
+      'DOCX Comparison.baselines.atomizer.pipeline.field-validation.test.ts',
+    );
+    expect(r.fullName).toBe(
+      'DOCX Comparison/baselines/atomizer/pipeline.field-validation.test.ts#validateFieldStructure rejects',
+    );
+    // Only a top-level source file (index 1) is stripped; nested dirs are kept.
+    expect(r.titlePath).toEqual([
+      'DOCX Comparison',
+      'baselines',
+      'atomizer',
+      'pipeline.field-validation.test.ts',
+      'validateFieldStructure',
+    ]);
+  });
+
+  it('stays backward compatible with the pre-3.6 unscoped shape', async () => {
+    await writeResult('d-result.json', {
+      labels: [{ name: 'package', value: 'src.atomizer-rpr.test.ts' }],
+      fullName: 'src/atomizer-rpr.test.ts#ComparisonUnitAtom.rPr sets rPr',
+      titlePath: ['src', 'atomizer-rpr.test.ts', 'ComparisonUnitAtom.rPr'],
+    });
+
+    const { 'd-result.json': r } = await normalize();
+
+    expect(r.labels.find((l) => l.name === 'package').value).toBe('DOCX Comparison.atomizer-rpr.test.ts');
+    expect(r.fullName).toBe('DOCX Comparison/atomizer-rpr.test.ts#ComparisonUnitAtom.rPr sets rPr');
+    expect(r.titlePath).toEqual(['DOCX Comparison', 'ComparisonUnitAtom.rPr']);
+  });
+
+  it('de-duplicates suite labels, keeping the last value', async () => {
+    await writeResult('e-result.json', {
+      labels: [
+        { name: 'parentSuite', value: 'auto-derived' },
+        { name: 'parentSuite', value: 'from-setup' },
+        { name: 'suite', value: 'auto' },
+        { name: 'suite', value: 'final' },
+        { name: 'package', value: '@usejunior/docx-core.src.foo.test.ts' },
+      ],
+      fullName: '@usejunior/docx-core:src/foo.test.ts#t',
+      titlePath: ['@usejunior/docx-core', 'src', 'foo.test.ts', 'suite'],
+    });
+
+    const { 'e-result.json': r } = await normalize();
+
+    expect(r.labels.filter((l) => l.name === 'parentSuite').map((l) => l.value)).toEqual(['from-setup']);
+    expect(r.labels.filter((l) => l.name === 'suite').map((l) => l.value)).toEqual(['final']);
+  });
+
+  it('leaves labels untouched when no packageName is configured', async () => {
+    await writeResult('f-result.json', {
+      labels: [{ name: 'package', value: '@usejunior/docx-core.src.foo.test.ts' }],
+      fullName: '@usejunior/docx-core:src/foo.test.ts#t',
+      titlePath: ['@usejunior/docx-core', 'src', 'foo.test.ts', 'suite'],
+    });
+
+    const { 'f-result.json': r } = await normalize({ innerReporterPath: '' });
+
+    expect(r.labels.find((l) => l.name === 'package').value).toBe('@usejunior/docx-core.src.foo.test.ts');
+    expect(r.titlePath).toEqual(['@usejunior/docx-core', 'src', 'foo.test.ts', 'suite']);
+  });
+});


### PR DESCRIPTION
## What

allure-vitest 3.6 (pulled in by the vitest 3→4 bump in #291) began prefixing every emitted label with a **project-scope segment** derived from the nearest `package.json` `name` (e.g. `@usejunior/docx-core`). That pushed the source-root anchor (`src` / a `packageNameOverrides` key like `test-primitives`) off index 0, so all three rewrites in `compat-reporter.js` silently no-op'd:

| field | raw ≥3.6 shape | old code anchored on | result |
|---|---|---|---|
| `package` | `@usejunior/docx-core.src.foo.test.ts` | `parts[0]` = `@usejunior/docx-core` | no-op |
| `fullName` | `@usejunior/docx-core:src/foo.test.ts#…` | first `/` (inside the scope) | no-op |
| `titlePath` | `["@usejunior/docx-core","src",…]` | `[0]` = `@usejunior/docx-core` | no-op |

So the Allure report tree regressed to grouping by raw scope/directory instead of the configured display names (`DOCX Comparison`, `DOCX Primitives`, `Safe DOCX MCP Server`, …).

**This is cosmetic** — it never affected CI pass/fail, nor the `.test.ts`-scoped allure/OpenSpec traceability gates.

## Fix

Make the rewrites **scope-aware**: locate the source-root anchor wherever it now sits, drop the leading project-scope segment(s), and map the anchor to its display name.

- `rewritePathSegments` — handles the dot-joined `package` label and the `titlePath` array.
- `rewriteFullName` — handles the `<project>:<spec>#<test>` shape (splits the `:` scope prefix before mapping the spec path).
- Both stay backward compatible with the pre-3.6 unscoped shape.

## Tests

Adds `compat-reporter.test.js` (6 cases): the ≥3.6 shape, the `packageNameOverrides` path, nested source dirs, the pre-3.6 shape, suite-label dedup, and the no-`packageName` passthrough — so a future allure-vitest shape change fails loudly rather than silently no-op'ing again. It is intentionally `.test.js` so the reporter plumbing test stays out of the `.test.ts`-scoped conformance-traceability gates.

Also adds a `test` script to the package (matching `safedocx-mcpb`) so CI's catch-all `npm run test` actually runs this package — previously **neither** the new test nor the existing `visibility.test.ts` ran in the PR gate.

## Verification (local, allure-vitest 3.9.0)

- `docx-core`: `DOCX Comparison.atomizer-rpr.test.ts`, titlePath `["DOCX Comparison","ComparisonUnitAtom.rPr"]`
- `test-primitives` override: `DOCX Primitives.bookmarks.test.ts`
- `docx-mcp` (no overrides, different scope): `Safe DOCX MCP Server.…`

All restore the exact pre-3.6 tree. Lint clean (0 errors); 6 new + existing tests pass.

Ref: #291