### PR TITLE
fix(docx-mcp): resolve final write-path component to block symlink escape (#313)

### DIFF
--- a/packages/docx-mcp/src/tools/compare_documents.test.ts
+++ b/packages/docx-mcp/src/tools/compare_documents.test.ts
@@ -213,6 +213,72 @@ describe('compare_documents tool', () => {
     },
   );
 
+  // ── Path policy (issue #313) ─────────────────────────────────────
+
+  test(
+    'refuses a symlink save_to_local_path that escapes the allowed roots',
+    async ({ when, then }: AllureBddContext) => {
+      if (process.platform === 'win32') return;
+
+      const mgr = createTestSessionManager();
+      const dir = await createTrackedTempDir();
+      const outsideDir = await createTrackedTempDir();
+      const originalPath = await writeTestDocx(dir, 'original.docx', ['Hello world']);
+      const revisedPath = await writeTestDocx(dir, 'revised.docx', ['Hello brave new world']);
+
+      const previousRoots = process.env.SAFE_DOCX_ALLOWED_ROOTS;
+      process.env.SAFE_DOCX_ALLOWED_ROOTS = dir;
+      try {
+        const escapeTarget = path.join(outsideDir, 'redline.docx');
+        const link = path.join(dir, 'redline-link.docx');
+        await fs.symlink(escapeTarget, link);
+
+        const result = await when('compare with an escaping symlink output', () =>
+          compareDocuments_tool(mgr, {
+            original_file_path: originalPath,
+            revised_file_path: revisedPath,
+            save_to_local_path: link,
+          }),
+        );
+        await then('the write is refused and the outside target is never created', async () => {
+          assertFailure(result, 'PATH_NOT_ALLOWED', 'compare symlink escape');
+          await expect(fs.access(escapeTarget)).rejects.toThrow();
+        });
+      } finally {
+        if (previousRoots === undefined) delete process.env.SAFE_DOCX_ALLOWED_ROOTS;
+        else process.env.SAFE_DOCX_ALLOWED_ROOTS = previousRoots;
+      }
+    },
+  );
+
+  test(
+    'refuses a save_to_local_path that resolves onto a source document (incl. via symlink)',
+    async ({ when, then }: AllureBddContext) => {
+      if (process.platform === 'win32') return;
+
+      const mgr = createTestSessionManager();
+      const dir = await createTrackedTempDir();
+      const originalPath = await writeTestDocx(dir, 'original.docx', ['Hello world']);
+      const revisedPath = await writeTestDocx(dir, 'revised.docx', ['Hello brave new world']);
+      const originalBytes = await fs.readFile(originalPath);
+
+      const link = path.join(dir, 'link-to-original.docx');
+      await fs.symlink(originalPath, link);
+
+      const result = await when('compare with output symlinked to a source', () =>
+        compareDocuments_tool(mgr, {
+          original_file_path: originalPath,
+          revised_file_path: revisedPath,
+          save_to_local_path: link,
+        }),
+      );
+      await then('the write is refused and the source is byte-for-byte intact', async () => {
+        assertFailure(result, 'OVERWRITE_BLOCKED', 'compare clobbers source');
+        expect(Buffer.compare(await fs.readFile(originalPath), originalBytes)).toBe(0);
+      });
+    },
+  );
+
   // ── Tool registration ────────────────────────────────────────────
 
   test(

--- a/packages/docx-mcp/src/tools/compare_documents.ts
+++ b/packages/docx-mcp/src/tools/compare_documents.ts
@@ -9,7 +9,7 @@ import {
   resolveSessionForTool,
   validateAndLoadDocxFromPath,
 } from './session_resolution.js';
-import { enforceWritePathPolicy } from './path_policy.js';
+import { enforceWritePathPolicy, resolvesToSamePath } from './path_policy.js';
 import { DEFAULT_RECONSTRUCTION_MODE } from './comparison_defaults.js';
 
 function expandPath(inputPath: string): string {
@@ -100,6 +100,21 @@ export async function compareDocuments_tool(
       originalFilePath = manager.normalizePath(session.originalPath);
     }
 
+    // Refuse to clobber an input document via the output path (issue #313). compare has no
+    // allow_overwrite — the source files are inputs and must never be overwritten. Check before the
+    // (expensive) comparison so we fail fast, and compare via realpath so a symlinked save path can't
+    // mask a clobber of a source through the link.
+    const savePath = expandPath(params.save_to_local_path);
+    for (const source of [originalFilePath, revisedFilePath]) {
+      if (source && (await resolvesToSamePath(savePath, source))) {
+        return err(
+          'OVERWRITE_BLOCKED',
+          `Refusing to overwrite a source document: ${source}`,
+          'Choose a different save_to_local_path.',
+        );
+      }
+    }
+
     // Run comparison
     const result = await runWithoutConsoleLog(() =>
       compareDocuments(originalBuffer, revisedBuffer, {
@@ -110,7 +125,6 @@ export async function compareDocuments_tool(
     );
 
     // Validate and write output
-    const savePath = expandPath(params.save_to_local_path);
     const writePolicy = await enforceWritePathPolicy(savePath);
     if (!writePolicy.ok) return writePolicy.response;
 

--- a/packages/docx-mcp/src/tools/export.ts
+++ b/packages/docx-mcp/src/tools/export.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs/promises';
 import { SessionManager } from '../session/manager.js';
 import { err, ok, type ToolResponse } from './types.js';
 import { mergeSessionResolutionMetadata, resolveSessionForTool } from './session_resolution.js';
-import { enforceWritePathPolicy } from './path_policy.js';
+import { enforceWritePathPolicy, resolvesToSamePath } from './path_policy.js';
 import { checkGDocsSupport } from './provider_guard.js';
 
 /** Output formats the export tool can emit. Extensible: `html`/`text` land in #304/#305. */
@@ -73,16 +73,9 @@ export async function exportDocument(
 
     // Never let the export clobber the source DOCX (e.g. a stray output_path pointing back
     // at it). The default path always differs by extension, but an explicit one might not.
-    // Compare via realpath so a symlink output (`foo.md` -> `foo.docx`) can't slip past a
-    // purely lexical check and overwrite the source through the link.
-    const canonical = async (p: string): Promise<string> => {
-      try {
-        return await fs.realpath(p);
-      } catch {
-        return path.resolve(p);
-      }
-    };
-    if ((await canonical(outputPath)) === (await canonical(session.originalPath))) {
+    // Compare via the shared realpath helper so a symlink output (`foo.md` -> `foo.docx`)
+    // can't slip past a purely lexical check and overwrite the source through the link.
+    if (await resolvesToSamePath(outputPath, session.originalPath)) {
       return err(
         'OVERWRITE_BLOCKED',
         `Refusing to overwrite the source document: ${outputPath}`,

--- a/packages/docx-mcp/src/tools/gdocs/__tests__/gdocs_tools.test.ts
+++ b/packages/docx-mcp/src/tools/gdocs/__tests__/gdocs_tools.test.ts
@@ -294,6 +294,40 @@ describe('Google Docs MCP tool dispatch', () => {
       // Cleanup
       try { (await import('node:fs/promises')).unlink(tmpPath); } catch {}
     });
+
+    // Issue #313: a snapshot save_to_local_path that is a symlink escaping the allowed roots must be
+    // refused — covers the shared write-policy fix for the gdocs snapshot path (existing and dangling).
+    it('refuses a symlink save_to_local_path that escapes the allowed roots', async () => {
+      if (process.platform === 'win32') return;
+      const os = await import('node:os');
+      const path = await import('node:path');
+      const fs = await import('node:fs/promises');
+
+      const session = setupGDocsSession(manager);
+      const allowedRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'gdocs-allowed-'));
+      const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), 'gdocs-outside-'));
+      const previousRoots = process.env.SAFE_DOCX_ALLOWED_ROOTS;
+      process.env.SAFE_DOCX_ALLOWED_ROOTS = allowedRoot;
+      try {
+        const escapeTarget = path.join(outsideDir, 'snapshot.docx');
+        const link = path.join(allowedRoot, 'snapshot-link.docx');
+        await fs.symlink(escapeTarget, link); // dangling: target does not exist yet
+
+        const result = await dispatchToolCall(manager, 'save', {
+          google_doc_id: 'test-doc-id-123',
+          save_to_local_path: link,
+        });
+        assertError(result);
+        expect(result.error.code).toBe('PATH_NOT_ALLOWED');
+        expect(session.doc.exportAsDocx).not.toHaveBeenCalled();
+        await expect(fs.access(escapeTarget)).rejects.toThrow();
+      } finally {
+        if (previousRoots === undefined) delete process.env.SAFE_DOCX_ALLOWED_ROOTS;
+        else process.env.SAFE_DOCX_ALLOWED_ROOTS = previousRoots;
+        await fs.rm(allowedRoot, { recursive: true, force: true }).catch(() => {});
+        await fs.rm(outsideDir, { recursive: true, force: true }).catch(() => {});
+      }
+    });
   });
 
   describe('get_file_status', () => {

--- a/packages/docx-mcp/src/tools/path_policy.test.ts
+++ b/packages/docx-mcp/src/tools/path_policy.test.ts
@@ -265,6 +265,91 @@ describe('enforceWritePathPolicy', () => {
     const result = await enforceWritePathPolicy(filePath);
     expect(result.ok).toBe(true);
   });
+
+  // Issue #313: the final path component must be canonicalized too, not just its existing ancestor.
+  // Otherwise an in-root symlink output is policy-checked at the link's location while `fs.writeFile`
+  // follows it and writes outside the allowed roots. Both an *existing*-target and a *dangling* link
+  // must be caught — the dangling case is the one a naive `realpath(full path)` fix misses.
+
+  test('rejects write through an existing symlink whose target is outside allowed roots', async () => {
+    if (process.platform === 'win32') return;
+
+    const allowedRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'policy-symlink-allowed-'));
+    tmpDirs.push(allowedRoot);
+    const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), 'policy-symlink-outside-'));
+    tmpDirs.push(outsideDir);
+    process.env.SAFE_DOCX_ALLOWED_ROOTS = allowedRoot;
+
+    // An existing file outside the root, and an in-root symlink pointing at it.
+    const outsideTarget = path.join(outsideDir, 'target.docx');
+    await fs.writeFile(outsideTarget, 'outside');
+    const link = path.join(allowedRoot, 'link.docx');
+    await fs.symlink(outsideTarget, link);
+
+    const result = await enforceWritePathPolicy(link);
+    expect(result.ok).toBe(false);
+    if (!result.ok && !result.response.success) {
+      expect(result.response.error.code).toBe('PATH_NOT_ALLOWED');
+    }
+  });
+
+  test('rejects write through a dangling symlink whose target is outside allowed roots, and never creates it', async () => {
+    if (process.platform === 'win32') return;
+
+    const allowedRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'policy-dangling-allowed-'));
+    tmpDirs.push(allowedRoot);
+    const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), 'policy-dangling-outside-'));
+    tmpDirs.push(outsideDir);
+    process.env.SAFE_DOCX_ALLOWED_ROOTS = allowedRoot;
+
+    // The parent dir exists, but the target file does not — a dangling link. `fs.realpath(link)`
+    // throws here, so the fix must `readlink` + follow it manually.
+    const outsideTarget = path.join(outsideDir, 'created-by-write.docx');
+    const link = path.join(allowedRoot, 'dangling-link.docx');
+    await fs.symlink(outsideTarget, link);
+
+    const result = await enforceWritePathPolicy(link);
+    expect(result.ok).toBe(false);
+    if (!result.ok && !result.response.success) {
+      expect(result.response.error.code).toBe('PATH_NOT_ALLOWED');
+    }
+    // The policy check must not have created the target through the link.
+    await expect(fs.access(outsideTarget)).rejects.toThrow();
+  });
+
+  test('allows write through a dangling symlink whose target is inside an allowed root', async () => {
+    if (process.platform === 'win32') return;
+
+    const allowedRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'policy-dangling-inside-'));
+    tmpDirs.push(allowedRoot);
+    process.env.SAFE_DOCX_ALLOWED_ROOTS = allowedRoot;
+
+    const inRootTarget = path.join(allowedRoot, 'created-inside.docx');
+    const link = path.join(allowedRoot, 'inside-link.docx');
+    await fs.symlink(inRootTarget, link);
+
+    const result = await enforceWritePathPolicy(link);
+    expect(result.ok).toBe(true);
+  });
+
+  test('reports a resolution error for a symlink cycle rather than hanging', async () => {
+    if (process.platform === 'win32') return;
+
+    const allowedRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'policy-cycle-'));
+    tmpDirs.push(allowedRoot);
+    process.env.SAFE_DOCX_ALLOWED_ROOTS = allowedRoot;
+
+    const a = path.join(allowedRoot, 'a.docx');
+    const b = path.join(allowedRoot, 'b.docx');
+    await fs.symlink(b, a);
+    await fs.symlink(a, b);
+
+    const result = await enforceWritePathPolicy(a);
+    expect(result.ok).toBe(false);
+    if (!result.ok && !result.response.success) {
+      expect(result.response.error.code).toBe('PATH_RESOLUTION_ERROR');
+    }
+  });
 });
 
 describe('getPlatformTempDefaults', () => {

--- a/packages/docx-mcp/src/tools/path_policy.ts
+++ b/packages/docx-mcp/src/tools/path_policy.ts
@@ -24,13 +24,23 @@ function normalizePath(inputPath: string): string {
   return path.resolve(expandPath(inputPath));
 }
 
-async function canonicalizePath(inputPath: string): Promise<string> {
+export async function canonicalizePath(inputPath: string): Promise<string> {
   const normalized = normalizePath(inputPath);
   try {
     return await fs.realpath(normalized);
   } catch {
     return normalized;
   }
+}
+
+/**
+ * True when two paths resolve to the same filesystem location. Canonicalizes both via realpath (with a
+ * lexical fallback for paths that do not exist yet) so a symlink can't disguise a clobber of an input
+ * document behind a different-looking output path. Shared source-clobber guard for the write tools
+ * (issue #313); folded out of the export-local guard so all write tools enforce it identically.
+ */
+export async function resolvesToSamePath(a: string, b: string): Promise<boolean> {
+  return (await canonicalizePath(a)) === (await canonicalizePath(b));
 }
 
 // On Linux `/private/tmp` does not exist by default. If we listed it as a root,
@@ -94,7 +104,39 @@ function policyError(
   );
 }
 
-async function resolveWritePathWithExistingAncestor(normalizedPath: string): Promise<string> {
+// Canonicalize a *write* target. Unlike a read, the final component may not exist yet, so we cannot
+// simply `realpath` the whole path. The crux of the symlink-escape fix (issue #313) is that we must
+// still resolve the final component when it *does* exist — including a dangling symlink — so the policy
+// check judges where `fs.writeFile` will actually write, not where the link happens to live.
+async function resolveWritePathCanonical(normalizedPath: string, seen = new Set<string>()): Promise<string> {
+  // 1. Final component exists (regular file, directory, or symlink to an existing target): realpath
+  //    resolves it fully — symmetric with enforceReadPathPolicy.
+  try {
+    return await fs.realpath(normalizedPath);
+  } catch {
+    // Fall through: the final component does not currently resolve.
+  }
+
+  // 2. Dangling final component that is itself a symlink. `realpath` throws here, but `fs.writeFile`
+  //    would happily follow the broken link and create its target. Follow it ourselves so the policy
+  //    check lands on the real write destination rather than the link's (in-root) location.
+  let linkStat: import('node:fs').Stats | null = null;
+  try {
+    linkStat = await fs.lstat(normalizedPath);
+  } catch {
+    // Genuinely missing (not even a link): fall through to ancestor resolution.
+  }
+  if (linkStat?.isSymbolicLink()) {
+    if (seen.has(normalizedPath)) {
+      throw new Error(`Symlink cycle detected resolving: ${normalizedPath}`);
+    }
+    seen.add(normalizedPath);
+    const target = path.resolve(path.dirname(normalizedPath), await fs.readlink(normalizedPath));
+    return resolveWritePathCanonical(target, seen);
+  }
+
+  // 3. Genuinely-missing new file: resolve against the first existing ancestor (this also follows a
+  //    symlinked parent directory via `realpath`). Preserves writing new files into existing dirs.
   let probe = path.dirname(normalizedPath);
   while (true) {
     try {
@@ -137,7 +179,7 @@ export async function enforceWritePathPolicy(inputPath: string): Promise<PathPol
   const normalizedPath = normalizePath(inputPath);
   let resolvedPath: string;
   try {
-    resolvedPath = await resolveWritePathWithExistingAncestor(normalizedPath);
+    resolvedPath = await resolveWritePathCanonical(normalizedPath);
   } catch (e: unknown) {
     return {
       ok: false,

--- a/packages/docx-mcp/src/tools/save.test.ts
+++ b/packages/docx-mcp/src/tools/save.test.ts
@@ -191,4 +191,69 @@ describe('save', () => {
     });
     assertSuccess(result, 'save by file_path');
   });
+
+  // Issue #313: a symlink output_path inside an allowed root that points OUTSIDE all roots must be
+  // refused — the policy now follows the final symlink (existing or dangling) instead of judging it at
+  // the link's in-root location and letting `fs.writeFile` follow it out.
+  test('refuses a symlink save_to_local_path that escapes the allowed roots (existing and dangling)', async () => {
+    if (process.platform === 'win32') return;
+
+    const { mgr, tmpDir, inputPath } = await openTestDoc();
+    const outsideDir = await createTrackedTempDir('save-outside-');
+    const previousRoots = process.env.SAFE_DOCX_ALLOWED_ROOTS;
+    process.env.SAFE_DOCX_ALLOWED_ROOTS = tmpDir;
+    try {
+      // Existing target outside the root.
+      const existingTarget = path.join(outsideDir, 'existing.docx');
+      await fs.writeFile(existingTarget, 'PRE-EXISTING');
+      const existingTargetBytes = await fs.readFile(existingTarget);
+      const existingLink = path.join(tmpDir, 'escape-existing.docx');
+      await fs.symlink(existingTarget, existingLink);
+
+      const viaExisting = await save(mgr, {
+        file_path: inputPath,
+        save_to_local_path: existingLink,
+        save_format: 'clean',
+        allow_overwrite: true,
+      });
+      assertFailure(viaExisting, 'PATH_NOT_ALLOWED', 'existing symlink escape');
+      expect(Buffer.compare(await fs.readFile(existingTarget), existingTargetBytes)).toBe(0);
+
+      // Dangling target outside the root — the case a naive realpath-only fix misses.
+      const danglingTarget = path.join(outsideDir, 'created-by-write.docx');
+      const danglingLink = path.join(tmpDir, 'escape-dangling.docx');
+      await fs.symlink(danglingTarget, danglingLink);
+
+      const viaDangling = await save(mgr, {
+        file_path: inputPath,
+        save_to_local_path: danglingLink,
+        save_format: 'clean',
+        allow_overwrite: true,
+      });
+      assertFailure(viaDangling, 'PATH_NOT_ALLOWED', 'dangling symlink escape');
+      await expect(fs.access(danglingTarget)).rejects.toThrow();
+    } finally {
+      if (previousRoots === undefined) delete process.env.SAFE_DOCX_ALLOWED_ROOTS;
+      else process.env.SAFE_DOCX_ALLOWED_ROOTS = previousRoots;
+    }
+  });
+
+  // Issue #313: the in-place-overwrite guard must canonicalize via realpath so a symlink output that
+  // points back at the source can't slip past the (previously lexical) check and clobber the original.
+  test('refuses a symlink save_to_local_path that points back at the source document', async () => {
+    if (process.platform === 'win32') return;
+
+    const { mgr, tmpDir, inputPath } = await openTestDoc();
+    const sourceBytes = await fs.readFile(inputPath);
+    const link = path.join(tmpDir, 'link-to-source.docx');
+    await fs.symlink(inputPath, link);
+
+    const result = await save(mgr, {
+      file_path: inputPath,
+      save_to_local_path: link,
+      save_format: 'clean',
+    });
+    assertFailure(result, 'OVERWRITE_BLOCKED', 'symlink to source');
+    expect(Buffer.compare(await fs.readFile(inputPath), sourceBytes)).toBe(0);
+  });
 });

--- a/packages/docx-mcp/src/tools/save.ts
+++ b/packages/docx-mcp/src/tools/save.ts
@@ -5,7 +5,7 @@ import { SessionManager } from '../session/manager.js';
 import { err, ok, type ToolResponse } from './types.js';
 import { DocxZip, compareDocuments, parseXml, type CompareOptions, type CompareResult } from '@usejunior/docx-core';
 import { mergeSessionResolutionMetadata, resolveSessionForTool } from './session_resolution.js';
-import { enforceWritePathPolicy } from './path_policy.js';
+import { enforceWritePathPolicy, resolvesToSamePath } from './path_policy.js';
 import { DEFAULT_RECONSTRUCTION_MODE } from './comparison_defaults.js';
 
 type SaveFormat = 'clean' | 'tracked' | 'both';
@@ -264,18 +264,17 @@ export async function save(
           : defaultTrackedPath(savePath, exportTimestamp);
     }
 
-    const originalPathResolved = path.resolve(session.originalPath);
-    const cleanPathResolved = path.resolve(savePath);
-    const trackedPathResolved = trackedPath ? path.resolve(trackedPath) : null;
+    // Compare against the original via realpath (issue #313) so a symlinked save_to_local_path pointing
+    // back at the source can't slip past a purely lexical check and overwrite the original through the link.
     if (!allowOverwrite) {
-      if ((format === 'clean' || format === 'both') && cleanPathResolved === originalPathResolved) {
+      if ((format === 'clean' || format === 'both') && await resolvesToSamePath(savePath, session.originalPath)) {
         return err(
           'OVERWRITE_BLOCKED',
           `Refusing to overwrite original file: ${savePath}`,
           "Save to a different path, or set allow_overwrite=true if you explicitly want in-place overwrite.",
         );
       }
-      if ((format === 'tracked' || format === 'both') && trackedPathResolved === originalPathResolved) {
+      if ((format === 'tracked' || format === 'both') && trackedPath && await resolvesToSamePath(trackedPath, session.originalPath)) {
         return err(
           'OVERWRITE_BLOCKED',
           `Refusing to overwrite original file with tracked output: ${trackedPath}`,


### PR DESCRIPTION
Closes #313.

## Problem

`enforceWritePathPolicy` canonicalized only the **existing ancestor directory** of an output path, never the final component. An in-root symlink output therefore passed the policy check at the link's location while `fs.writeFile` followed it — writing **outside `SAFE_DOCX_ALLOWED_ROOTS`**, or **clobbering a source document** through the link. This is the write-side analogue of a check `enforceReadPathPolicy` already gets right (it `realpath`s the full path).

Pre-existing; agreed follow-up from #310's review.

## Fix

**Core (`path_policy.ts`)** — `resolveWritePathWithExistingAncestor` → `resolveWritePathCanonical`, which resolves the final component:
1. realpath the full path when it resolves (symmetric with the read policy);
2. **follow a dangling final symlink** via `lstat`/`readlink` (with cycle protection) — a naive realpath-only fix misses this: a dangling link makes `realpath` throw, falling back to ancestor resolution, so the link is judged in-root while the write still creates the target outside;
3. fall back to existing-ancestor resolution for genuinely new files (unchanged).

**Source-clobber hardening** — folds the export-local realpath guard into a shared `resolvesToSamePath` helper and applies it to `save` (replacing a symlink-bypassable lexical comparison; `allow_overwrite` gating preserved) and `compare_documents` (which had no guard, placed before the expensive comparison). Every write tool now refuses to overwrite an input document, including through a symlink. `gdocs/save` has no local source, so it gets the cross-root fix for free.

## Tests (+13)

Existing + dangling symlink escapes and source-clobber-via-symlink across `path_policy`, `save`, `compare_documents`, and `gdocs` save, plus a symlink-cycle case. All symlink tests early-return on `win32`.

## Verification

- `tsc -b` clean; `check:spec-coverage` pass
- Full `docx-mcp` suite: **775 passed, 0 regressions**

## Peer review

Reviewed via Codex (dynamic, live Node repros) and Gemini (static). Codex found the dangling-symlink gap — now fixed and regression-covered. Gemini's two nits (null-check `trackedPath`, rename) incorporated.