### PR TITLE
feat(docx-mcp): DOCX → HTML export (first wave) (#304)

### DIFF
--- a/openspec/changes/add-html-export/proposal.md
+++ b/openspec/changes/add-html-export/proposal.md
@@ -1,0 +1,59 @@
+# Change: Add DOCX → HTML export
+
+## Why
+
+safe-docx can read, edit, compare, save, and (since #310) export `.docx` to **Markdown** — but
+not to HTML. HTML is the most useful *structural* target for previews, web rendering, and
+content extraction; it completes the read → edit → compare → **export** loop (epic #307)
+alongside Markdown.
+
+The hard part — OOXML parsing — is already done. `DocxDocument.buildDocumentView({ showFormatting: true })`
+yields a structured `DocumentViewNode[]` with headings (level + source), list metadata,
+grid-aware table context, injected `[^n]` footnote markers, and an HTML-shaped inline-tag
+string (`tagged_text`). An HTML emitter is a **serializer over that existing model** — a sibling
+of `serialize_markdown.ts` that renders the *same* inline tokens via the shared
+`tokenizeToonInline()` core, so the two serializers never re-derive the tag grammar and drift
+from the emitter in `formatting_tags.ts`.
+
+Where Markdown is lossy, HTML is richer: it carries `<mark>` for highlighting and
+`<span style>` for font color/size/face that Markdown drops, and it renders genuine nested
+`<ul>/<ol>` rather than indented text. This is the **semantic** tier (mammoth.js-style), not
+pixel-faithful HTML+CSS (docx-preview-style), which stays out of scope.
+
+## What Changes
+
+### docx-primitives (docx-core)
+- NEW: `serialize_html.ts` — `inlineTagsToHtml()` (the shared inline tokenizer → HTML mapping)
+  and `serializeToHtml(nodes, footnotes, opts)` (block walk: headings, nested lists, tables,
+  footnote anchors + definitions; full `<!DOCTYPE html>` document by default, `fragment` opt
+  for body-only).
+- MODIFIED: `formatting_tags.ts` — export the existing `escapeHtmlAttribute` helper so the
+  serializer reuses one attribute-escaper instead of duplicating it.
+- MODIFIED: `document.ts` — async `DocxDocument.toHtml()` convenience wrapper, mirroring
+  `toMarkdown()`.
+- MODIFIED: `primitives/index.ts` — explicit barrel export for `serialize_html.js`.
+
+### safe-docx (MCP)
+- MODIFIED: `export` tool (`tools/export.ts`) — `format` enum gains `html`; `.html` default
+  extension; branches to `toHtml()`; returns the rendering under a new format-agnostic
+  `content` key (keeping the legacy `markdown` key for the Markdown format). DOCX only.
+- MODIFIED: `tool_catalog.ts` — `format` enum adds `html`; descriptions updated.
+
+## Impact
+
+- Affected specs: `docx-primitives` (new serializer), `mcp-server` (export tool gains HTML).
+- New, additive capability. No behavior change to existing tools; the Markdown path is unchanged
+  and still returns `markdown`.
+- HTML is the **semantic** tier and intentionally lossy on exact look: it does not reproduce
+  pixel layout. Constructs without a clean semantic mapping are downgraded as documented.
+
+## Out of scope
+
+- Images / embedded media (`<img>`) — no media-extraction infrastructure exists yet; a focused
+  follow-up.
+- True `colspan`/`rowspan` — the view model discards `gridSpan`/`vMerge` span width, so tables
+  use a gap-filled grid (as Markdown does); real spans need a view-model extension.
+- Nesting of *manually*-labelled lists — manual labels are pinned to list level 0 upstream, so
+  only auto-numbered lists nest (same as Markdown).
+- Equations, text boxes, charts, fields, comments-as-`<aside>`, high-fidelity HTML+CSS,
+  round-trip fidelity, and Google Docs as a source.

--- a/openspec/changes/add-html-export/specs/docx-primitives/spec.md
+++ b/openspec/changes/add-html-export/specs/docx-primitives/spec.md
@@ -1,0 +1,80 @@
+## ADDED Requirements
+
+### Requirement: HTML serialization primitive
+
+The docx-core primitives SHALL provide a serializer that converts a structured document view
+(`DocumentViewNode[]` with inline formatting tags) and its footnotes into semantic HTML. The
+serialization is the semantic tier (structural elements wrapping inline formatting), not a
+pixel-faithful rendering: constructs without a clean semantic mapping are downgraded as
+specified below. The inline-tag tokenizer is the reusable core shared with the Markdown
+serializer, so the two never re-derive the tag grammar.
+
+#### Scenario: word-style headings become heading elements
+- **GIVEN** a node whose heading source is `word_style` with a numeric level N (1–6)
+- **WHEN** the document is serialized to HTML
+- **THEN** the paragraph SHALL render as an `<hN>` element with the level clamped to 1–6
+
+#### Scenario: heuristic headings remain paragraphs
+- **GIVEN** a node with a heuristic heading (level null, e.g. a run-in bold prefix)
+- **WHEN** the document is serialized to HTML
+- **THEN** the node SHALL render as a `<p>` element, not a heading element
+
+#### Scenario: inline bold italic underline and link tags map to HTML
+- **GIVEN** tagged text containing `<b>`, `<i>`, `<u>`, and `<a href="...">` tags
+- **WHEN** the text is converted with the inline tokenizer
+- **THEN** `<b>`, `<i>`, `<u>` SHALL be emitted as HTML `<b>`, `<i>`, `<u>` elements
+- **AND** `<a href="u">t</a>` SHALL render as an anchor whose `href` attribute is escaped
+
+#### Scenario: highlight maps to mark and font maps to a styled span
+- **GIVEN** tagged text containing `<highlight>` and `<font color=... size=... face=...>` tags
+- **WHEN** the text is converted with the inline tokenizer
+- **THEN** `<highlight>` SHALL render as a `<mark>` element
+- **AND** `<font ...>` SHALL render as a `<span>` whose `style` carries the color, font-size
+  (in points), and font-family, with every CSS value sanitized so it cannot break out of the
+  attribute
+
+#### Scenario: consecutive list nodes group into nested lists
+- **GIVEN** consecutive list nodes at varying `list_level` values
+- **WHEN** the document is serialized to HTML
+- **THEN** they SHALL be grouped into nested `<ul>`/`<ol>` elements whose depth reflects the
+  levels, and the lists SHALL be well-formed (every opened list is closed)
+
+#### Scenario: auto-numbered lists render as ordered lists
+- **GIVEN** a list node whose `is_auto_numbered` is true
+- **WHEN** the document is serialized to HTML
+- **THEN** it SHALL render inside an `<ol>` element regardless of how its label classifies
+
+#### Scenario: legal list labels are preserved
+- **GIVEN** a list item carrying a literal label such as `Section 2.1`, `Article IV`, or `(a)`
+- **WHEN** the document is serialized to HTML
+- **THEN** the literal label SHALL appear in the rendered `<li>`
+
+#### Scenario: a table renders as an HTML table
+- **GIVEN** nodes sharing a `table_context.table_id` forming rows and columns
+- **WHEN** the document is serialized to HTML
+- **THEN** they SHALL render as a `<table>` with a `<thead>` header row and a `<tbody>` of data rows
+
+#### Scenario: merged cell gaps are filled to preserve the grid
+- **GIVEN** a table whose `col_index` values skip positions because of horizontally merged cells
+- **WHEN** the document is serialized to HTML
+- **THEN** the missing grid positions SHALL be filled with empty cells so every row has the full
+  column count
+
+#### Scenario: footnotes render as anchors and a definitions section
+- **GIVEN** a document with footnotes
+- **WHEN** the document is serialized to HTML
+- **THEN** each injected `[^n]` marker SHALL render as a superscript anchor linking to the
+  definition, and a footnotes `<section>` SHALL list the definitions, each linking back to its
+  reference
+
+#### Scenario: text special characters are HTML-escaped
+- **GIVEN** literal text containing characters such as `&`, `<`, `>`, or `"`
+- **WHEN** the text is serialized to HTML
+- **THEN** those characters SHALL be replaced with HTML entities so they render literally
+
+#### Scenario: a full HTML document is emitted by default
+- **GIVEN** a structured document view
+- **WHEN** it is serialized to HTML without the fragment option
+- **THEN** the output SHALL be a complete document with a doctype, a `<head>` (charset and
+  title), and a `<body>`
+- **AND** with the fragment option the output SHALL contain only the body-level elements

--- a/openspec/changes/add-html-export/specs/mcp-server/spec.md
+++ b/openspec/changes/add-html-export/specs/mcp-server/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: HTML Export Format
+
+The Safe-Docx MCP server's `export` tool SHALL support rendering a DOCX document to semantic
+HTML in addition to Markdown. When `format` is `html` the tool writes an `.html` file and
+returns the rendered HTML under a format-agnostic `content` key. The tool remains DOCX only and
+is not read-only.
+
+#### Scenario: html export writes a file and returns its path and content
+- **GIVEN** an open DOCX session
+- **WHEN** `export` is called with `format` `html`
+- **THEN** the response SHALL be successful
+- **AND** it SHALL include `format` `html`, `output_path`, `bytes_written`, and `content`
+- **AND** the file at `output_path` SHALL exist and contain the returned HTML
+
+#### Scenario: default html output path derives from the source path
+- **GIVEN** an open DOCX session for a file ending in `.docx`
+- **WHEN** `export` is called with `format` `html` and no `output_path`
+- **THEN** `output_path` SHALL be the source path with its extension replaced by `.html`
+
+#### Scenario: html overwrite of an existing output file is blocked by default
+- **GIVEN** a file already exists at the target `.html` `output_path`
+- **WHEN** `export` is called with `format` `html` and without `allow_overwrite`
+- **THEN** the response SHALL be an `OVERWRITE_BLOCKED` error
+- **AND** the existing file SHALL be left unchanged
+
+#### Scenario: include_markdown false omits the rendered html content
+- **WHEN** `export` is called with `format` `html` and `include_markdown` false
+- **THEN** the response SHALL still include `output_path` and `bytes_written`
+- **AND** the response SHALL NOT include the `content` value
+
+#### Scenario: html export rejects a Google Docs source
+- **WHEN** `export` is called with `format` `html` and a `google_doc_id`
+- **THEN** the response SHALL be an `UNSUPPORTED_FOR_PROVIDER` error

--- a/openspec/changes/add-html-export/tasks.md
+++ b/openspec/changes/add-html-export/tasks.md
@@ -1,0 +1,24 @@
+# Tasks: Add DOCX → HTML export
+
+## 1. docx-core serializer primitive
+- [x] 1.1 Export `escapeHtmlAttribute` from `formatting_tags.ts`.
+- [x] 1.2 Add `serialize_html.ts`: `inlineTagsToHtml()` (`<b>/<i>/<u>/<a>` passthrough,
+      `<highlight>`→`<mark>`, `<font>`→sanitized `<span style>`, `[^n]`→`<sup>` anchor).
+- [x] 1.3 Add `serializeToHtml()`: headings → `<hN>`; robust nested `<ul>/<ol>` stack
+      (`<ol>` from `is_auto_numbered`); tables → `<table><thead><tbody>` (gap-filled grid);
+      footnotes → `<section>` definitions; full-document wrap with `fragment` opt.
+- [x] 1.4 Add async `DocxDocument.toHtml()`; add explicit `serialize_html.js` barrel export.
+
+## 2. docx-mcp export tool
+- [x] 2.1 `export.ts`: add `html` format, `.html` extension, branch to `toHtml()`, add `content` key.
+- [x] 2.2 Update `tool_catalog.ts` `format` enum + descriptions.
+
+## 3. Tests (mapped to spec scenarios)
+- [x] 3.1 `serialize_html.test.ts` in docx-core (docx-primitives scenarios + list edge cases + CSS sanitization).
+- [x] 3.2 `export_html.test.ts` in docx-mcp (mcp-server scenarios).
+
+## 4. Validation
+- [x] 4.1 `openspec validate add-html-export --strict`.
+- [x] 4.2 Build, lint, and run both packages' tests (incl. spec-coverage).
+- [x] 4.3 Real-document smoke: export NVCA COI / ILPA LPA / Bonterms NDA to HTML; output is valid
+      XHTML5 (0 XML errors), footnote anchors resolve, tables/lists/links/highlight render.

--- a/packages/docx-core/src/primitives/document.ts
+++ b/packages/docx-core/src/primitives/document.ts
@@ -17,6 +17,7 @@ import {
 } from './track-changes-emitter.js';
 import { buildNodesForDocumentView, type DocumentStyles, type DocumentViewNode, type TableContext } from './document_view.js';
 import { serializeToMarkdown, type SerializeMarkdownOptions } from './serialize_markdown.js';
+import { serializeToHtml, type SerializeHtmlOptions } from './serialize_html.js';
 import type { FormattingMode } from './formatting_tags.js';
 import { findUniqueSubstringMatch } from './matching.js';
 import { parseDocumentRels, type RelsMap } from './relationships.js';
@@ -1069,6 +1070,20 @@ export class DocxDocument {
     const { nodes } = this.buildDocumentView({ showFormatting: true });
     const footnotes = await this.getFootnotes();
     return serializeToMarkdown(nodes, footnotes, opts);
+  }
+
+  /**
+   * Serialize the document to semantic HTML. Convenience wrapper that wires the structured
+   * document view (with inline formatting) and footnotes into {@link serializeToHtml}. The
+   * default output is a complete `<!DOCTYPE html>` document; pass `{ fragment: true }` for the
+   * body-level elements only. This is the semantic tier — exact layout is not reproduced.
+   *
+   * Async because footnote extraction reads the footnotes part from the zip.
+   */
+  async toHtml(opts?: SerializeHtmlOptions): Promise<string> {
+    const { nodes } = this.buildDocumentView({ showFormatting: true });
+    const footnotes = await this.getFootnotes();
+    return serializeToHtml(nodes, footnotes, opts);
   }
 
   async getFootnote(noteId: number): Promise<Footnote | null> {

--- a/packages/docx-core/src/primitives/formatting_tags.ts
+++ b/packages/docx-core/src/primitives/formatting_tags.ts
@@ -232,7 +232,12 @@ function closeTags(out: string[], tags: ActiveTags): void {
   if (tags.hyperlinkUrl !== null) out.push('</a>');
 }
 
-function escapeHtmlAttribute(value: string): string {
+/**
+ * Escape a string for safe inclusion inside an HTML double-quoted attribute value. Exported so
+ * the HTML serializer (`serialize_html.ts`) reuses one attribute-escaper rather than re-deriving
+ * it and drifting from what the tag emitter assumes.
+ */
+export function escapeHtmlAttribute(value: string): string {
   return value
     .replaceAll('&', '&amp;')
     .replaceAll('"', '&quot;')

--- a/packages/docx-core/src/primitives/index.ts
+++ b/packages/docx-core/src/primitives/index.ts
@@ -8,6 +8,7 @@ export * from './namespaces.js';
 export * from './numbering.js';
 export * from './semantic_tags.js';
 export * from './serialize_markdown.js';
+export * from './serialize_html.js';
 export * from './styles.js';
 export * from './text.js';
 export * from './xml.js';

--- a/packages/docx-core/src/primitives/serialize_html.test.ts
+++ b/packages/docx-core/src/primitives/serialize_html.test.ts
@@ -324,4 +324,55 @@ describe('OpenSpec traceability: add-html-export (HTML serializer)', () => {
       });
     },
   );
+
+  test(
+    'repeated items at the same level after a jump are siblings, not nested deeper',
+    async ({ then }: AllureBddContext) => {
+      const html = body([
+        node({ tagged_text: 'Top', list_metadata: { list_level: 0, is_auto_numbered: true } }),
+        node({ tagged_text: 'B', list_metadata: { list_level: 2, is_auto_numbered: true } }),
+        node({ tagged_text: 'C', list_metadata: { list_level: 2, is_auto_numbered: true } }),
+      ]);
+      await then('the two level-2 items share one nested list (no extra opening between them)', async () => {
+        // Exactly two <ol> open (level 0 + the single clamped nested list shared by B and C).
+        expect((html.match(/<ol>/g) ?? []).length).toBe(2);
+        // B and C are consecutive <li> with no intervening <ol> (they are siblings).
+        expect(html).toMatch(/<li>B\s*<\/li>\s*<li>C/);
+        expect((html.match(/<li[ >]/g) ?? []).length).toBe((html.match(/<\/li>/g) ?? []).length);
+        expect((html.match(/<ol>/g) ?? []).length).toBe((html.match(/<\/ol>/g) ?? []).length);
+      });
+    },
+  );
+
+  test(
+    'an unsafe javascript: hyperlink is neutralized while a safe one is kept',
+    async ({ then }: AllureBddContext) => {
+      const evil = inlineTagsToHtml('<a href="javascript:alert(1)">x</a>');
+      const safe = inlineTagsToHtml('<a href="https://example.com/p?a=1">x</a>');
+      await then('javascript: loses its href; https keeps it', async () => {
+        expect(evil).toBe('<a>x</a>');
+        expect(evil).not.toContain('javascript:');
+        expect(safe).toBe('<a href="https://example.com/p?a=1">x</a>');
+      });
+    },
+  );
+
+  test(
+    'footnote ids stay unique and orphan definitions get no dangling back-link',
+    async ({ then }: AllureBddContext) => {
+      const html = body(
+        // [^1] appears twice (duplicate marker); footnote 2 has a definition but no marker.
+        [node({ tagged_text: 'See[^1] and again[^1].' })],
+        [footnote(1, 'First note.'), footnote(2, 'Orphan note.')],
+      );
+      await then('the second marker gets a distinct id and the orphan omits its back-link', async () => {
+        expect(html).toContain('<sup id="fnref-1">');
+        expect(html).toContain('<sup id="fnref-1-2">'); // duplicate marker → unique id
+        // Footnote 1 was referenced → its definition links back; footnote 2 was not → no back-link.
+        expect(html).toContain('<li id="fn-1">First note. <a href="#fnref-1">↩</a></li>');
+        expect(html).toContain('<li id="fn-2">Orphan note.</li>');
+        expect(html).not.toContain('#fnref-2');
+      });
+    },
+  );
 });

--- a/packages/docx-core/src/primitives/serialize_html.test.ts
+++ b/packages/docx-core/src/primitives/serialize_html.test.ts
@@ -1,0 +1,327 @@
+import { describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { inlineTagsToHtml, serializeToHtml } from './serialize_html.js';
+import type { DocumentViewNode, TableContext } from './document_view.js';
+import { LabelType } from './list_labels.js';
+import type { Footnote } from './footnotes.js';
+
+const TEST_FEATURE = 'add-html-export';
+const test = testAllure.epic('Document Comparison').withLabels({ feature: TEST_FEATURE });
+
+// ── Minimal DocumentViewNode factory ────────────────────────────────────────
+// The serializer only reads `tagged_text`, `heading`, `list_metadata`, and `table_context`;
+// the rest are filled with inert defaults so tests stay focused on serialization behavior.
+type NodeOverrides = Omit<Partial<DocumentViewNode>, 'list_metadata'> & {
+  list_metadata?: Partial<DocumentViewNode['list_metadata']>;
+};
+
+let nodeSeq = 0;
+function node(overrides: NodeOverrides = {}): DocumentViewNode {
+  const { list_metadata: lmOverride, ...rest } = overrides;
+  return {
+    id: `_bk_${nodeSeq++}`,
+    list_label: '',
+    header: '',
+    style: 'body',
+    text: overrides.tagged_text ?? '',
+    clean_text: overrides.tagged_text ?? '',
+    tagged_text: overrides.tagged_text ?? '',
+    list_metadata: {
+      list_level: -1,
+      label_type: null,
+      label_string: '',
+      header_text: null,
+      header_style: null,
+      header_formatting: null,
+      is_auto_numbered: false,
+      ...(lmOverride ?? {}),
+    },
+    style_fingerprint: {
+      list_level: -1,
+      left_indent_pt: 0,
+      first_line_indent_pt: 0,
+      style_name: '',
+      alignment: 'LEFT',
+    },
+    paragraph_style_id: null,
+    paragraph_style_name: '',
+    paragraph_alignment: 'LEFT',
+    paragraph_indents_pt: { left: 0, first_line: 0 },
+    numbering: { num_id: null, ilvl: null, is_auto_numbered: false },
+    header_formatting: null,
+    body_run_formatting: null,
+    ...rest,
+  };
+}
+
+function tableCell(
+  rowIndex: number,
+  colIndex: number,
+  text: string,
+  opts: { isHeader?: boolean; totalCols?: number; tableId?: string } = {},
+): DocumentViewNode {
+  const tc: TableContext = {
+    table_id: opts.tableId ?? '_tbl_0',
+    table_index: 0,
+    row_index: rowIndex,
+    col_index: colIndex,
+    col_header: '',
+    total_rows: 0,
+    total_cols: opts.totalCols ?? 2,
+    is_header_row: opts.isHeader ?? false,
+    para_in_cell: 0,
+    cell_para_count: 1,
+  };
+  return node({ tagged_text: text, table_context: tc });
+}
+
+function footnote(displayNumber: number, text: string): Footnote {
+  return { id: displayNumber, displayNumber, text, anchoredParagraphId: null };
+}
+
+/** Render the body only (no doc wrapper) to keep assertions focused on block structure. */
+function body(nodes: DocumentViewNode[], footnotes: Footnote[] = []): string {
+  return serializeToHtml(nodes, footnotes, { fragment: true });
+}
+
+describe('OpenSpec traceability: add-html-export (HTML serializer)', () => {
+  test.openspec('word-style headings become heading elements')(
+    'word-style headings become heading elements',
+    async ({ then }: AllureBddContext) => {
+      const html = body([
+        node({ tagged_text: 'Section Title', heading: { text: 'Section Title', source: 'word_style', level: 2 } }),
+      ]);
+      await then('the heading renders as <h2>', async () => {
+        expect(html).toContain('<h2>Section Title</h2>');
+      });
+    },
+  );
+
+  test.openspec('heuristic headings remain paragraphs')(
+    'heuristic headings remain paragraphs',
+    async ({ then }: AllureBddContext) => {
+      const html = body([
+        node({
+          tagged_text: '<b>Indemnification.</b> The Company shall indemnify.',
+          heading: { text: 'Indemnification', source: 'run_in_header', level: null },
+        }),
+      ]);
+      await then('it is a <p> with the run-in bold, not a heading element', async () => {
+        expect(html).not.toMatch(/<h[1-6]>/);
+        expect(html).toContain('<p><b>Indemnification.</b> The Company shall indemnify.</p>');
+      });
+    },
+  );
+
+  test.openspec('inline bold italic underline and link tags map to HTML')(
+    'inline bold italic underline and link tags map to HTML',
+    async ({ then }: AllureBddContext) => {
+      const out = inlineTagsToHtml('<b>Bold</b> <i>it</i> <u>u</u> <a href="https://x.com">link</a>');
+      await then('b/i/u pass through and the anchor keeps its href', async () => {
+        expect(out).toBe('<b>Bold</b> <i>it</i> <u>u</u> <a href="https://x.com">link</a>');
+      });
+    },
+  );
+
+  test.openspec('highlight maps to mark and font maps to a styled span')(
+    'highlight maps to mark and font maps to a styled span',
+    async ({ then }: AllureBddContext) => {
+      const out = inlineTagsToHtml('<highlight>hl</highlight> <font color="FF0000" size="14" face="Arial">red</font>');
+      await then('highlight becomes <mark> and font becomes a styled <span>', async () => {
+        expect(out).toContain('<mark>hl</mark>');
+        expect(out).toContain(`<span style="color:#FF0000;font-size:14pt;font-family:'Arial'">red</span>`);
+        expect(out).toContain('</span>');
+      });
+    },
+  );
+
+  test.openspec('consecutive list nodes group into nested lists')(
+    'consecutive list nodes group into nested lists',
+    async ({ then }: AllureBddContext) => {
+      const html = body([
+        node({ tagged_text: 'First item', list_metadata: { list_level: 0, is_auto_numbered: true, label_type: LabelType.NUMBER, label_string: '1.' } }),
+        node({ tagged_text: 'Nested item', list_metadata: { list_level: 1, is_auto_numbered: true, label_type: LabelType.NUMBER, label_string: 'a.' } }),
+        node({ tagged_text: 'Back to top', list_metadata: { list_level: 0, is_auto_numbered: true, label_type: LabelType.NUMBER, label_string: '2.' } }),
+      ]);
+      await then('a nested <ol> opens and every opened list is closed', async () => {
+        expect(html).toContain('<li>First item');
+        expect(html).toContain('<li>Nested item');
+        // Well-formed: equal counts of <ol> and </ol>, <li> and </li>.
+        expect((html.match(/<ol>/g) ?? []).length).toBe((html.match(/<\/ol>/g) ?? []).length);
+        expect((html.match(/<li>/g) ?? []).length).toBe((html.match(/<\/li>/g) ?? []).length);
+        // Nesting actually happened (more than one <ol> opened).
+        expect((html.match(/<ol>/g) ?? []).length).toBeGreaterThan(1);
+      });
+    },
+  );
+
+  test.openspec('auto-numbered lists render as ordered lists')(
+    'auto-numbered lists render as ordered lists',
+    async ({ then }: AllureBddContext) => {
+      // Auto `1.` can classify as NUMBERED_HEADING, not NUMBER — `is_auto_numbered` is the signal.
+      const html = body([
+        node({ tagged_text: 'Numbered clause', list_metadata: { list_level: 0, is_auto_numbered: true, label_type: LabelType.NUMBERED_HEADING, label_string: '1.' } }),
+      ]);
+      await then('it renders inside an <ol> regardless of label_type', async () => {
+        expect(html).toContain('<ol>');
+        expect(html).toContain('<li>Numbered clause');
+        expect(html).not.toContain('<ul>');
+      });
+    },
+  );
+
+  test.openspec('legal list labels are preserved')(
+    'legal list labels are preserved',
+    async ({ then }: AllureBddContext) => {
+      const html = body([
+        node({ tagged_text: 'The parties agree as follows.', list_metadata: { list_level: 0, label_type: LabelType.SECTION, label_string: 'Section 2.1' } }),
+      ]);
+      await then('the literal legal label survives inside a <ul> item', async () => {
+        expect(html).toContain('<ul>');
+        expect(html).toContain('<li>Section 2.1 The parties agree as follows.');
+      });
+    },
+  );
+
+  test.openspec('a table renders as an HTML table')(
+    'a table renders as an HTML table',
+    async ({ then }: AllureBddContext) => {
+      const html = body([
+        tableCell(0, 0, 'Name', { isHeader: true }),
+        tableCell(0, 1, 'Age', { isHeader: true }),
+        tableCell(1, 0, 'Alice'),
+        tableCell(1, 1, '30'),
+      ]);
+      await then('a <thead> header row and a <tbody> data row are emitted', async () => {
+        expect(html).toContain('<table>');
+        expect(html).toContain('<thead>');
+        expect(html).toContain('<th>Name</th><th>Age</th>');
+        expect(html).toContain('<tbody>');
+        expect(html).toContain('<td>Alice</td><td>30</td>');
+      });
+    },
+  );
+
+  test.openspec('merged cell gaps are filled to preserve the grid')(
+    'merged cell gaps are filled to preserve the grid',
+    async ({ then }: AllureBddContext) => {
+      // Row 1 skips col_index 1 (a horizontally merged cell), leaving a grid gap.
+      const html = body([
+        tableCell(0, 0, 'A', { isHeader: true, totalCols: 3 }),
+        tableCell(0, 1, 'B', { isHeader: true, totalCols: 3 }),
+        tableCell(0, 2, 'C', { isHeader: true, totalCols: 3 }),
+        tableCell(1, 0, 'X', { totalCols: 3 }),
+        tableCell(1, 2, 'Z', { totalCols: 3 }),
+      ]);
+      await then('the skipped column is filled with an empty cell', async () => {
+        expect(html).toContain('<td>X</td><td></td><td>Z</td>');
+      });
+    },
+  );
+
+  test.openspec('footnotes render as anchors and a definitions section')(
+    'footnotes render as anchors and a definitions section',
+    async ({ then }: AllureBddContext) => {
+      const html = body(
+        [node({ tagged_text: 'A clause with a note[^1] here.' })],
+        [footnote(1, 'The footnote body.')],
+      );
+      await then('the marker is a superscript anchor and a definitions section is appended', async () => {
+        expect(html).toContain('<sup id="fnref-1"><a href="#fn-1">1</a></sup>');
+        expect(html).toContain('<section class="footnotes">');
+        expect(html).toContain('<li id="fn-1">The footnote body. <a href="#fnref-1">↩</a></li>');
+      });
+    },
+  );
+
+  test.openspec('text special characters are HTML-escaped')(
+    'text special characters are HTML-escaped',
+    async ({ then }: AllureBddContext) => {
+      const out = inlineTagsToHtml('a < b && c > d');
+      await then('the &, <, and > are entity-escaped', async () => {
+        expect(out).toBe('a &lt; b &amp;&amp; c &gt; d');
+      });
+    },
+  );
+
+  test.openspec('a full HTML document is emitted by default')(
+    'a full HTML document is emitted by default',
+    async ({ then }: AllureBddContext) => {
+      const nodes = [node({ tagged_text: 'Hello', heading: { text: 'Hello', source: 'word_style', level: 1 } })];
+      const full = serializeToHtml(nodes);
+      const fragment = serializeToHtml(nodes, [], { fragment: true });
+      await then('the default output is a complete document; fragment omits the wrapper', async () => {
+        expect(full).toContain('<!DOCTYPE html>');
+        expect(full).toContain('<meta charset="utf-8"/>');
+        expect(full).toContain('<title>Hello</title>');
+        expect(full).toContain('<body>');
+        expect(fragment).not.toContain('<!DOCTYPE html>');
+        expect(fragment.trim()).toBe('<h1>Hello</h1>');
+      });
+    },
+  );
+
+  // ── Bonus (no spec scenario): nested-list robustness against the OOXML `ilvl` patterns the
+  //    builder must survive — level jumps, interruptions, and same-depth kind changes. ──
+  test(
+    'a level jump greater than one is clamped to a single nesting step',
+    async ({ then }: AllureBddContext) => {
+      const html = body([
+        node({ tagged_text: 'Top', list_metadata: { list_level: 0, is_auto_numbered: true } }),
+        node({ tagged_text: 'Jumped', list_metadata: { list_level: 3, is_auto_numbered: true } }),
+      ]);
+      await then('only one extra list opens and the markup stays well-formed', async () => {
+        expect((html.match(/<ol>/g) ?? []).length).toBe(2);
+        expect((html.match(/<ol>/g) ?? []).length).toBe((html.match(/<\/ol>/g) ?? []).length);
+        expect((html.match(/<li>/g) ?? []).length).toBe((html.match(/<\/li>/g) ?? []).length);
+      });
+    },
+  );
+
+  test(
+    'a paragraph between list items closes the list and a fresh list starts after',
+    async ({ then }: AllureBddContext) => {
+      const html = body([
+        node({ tagged_text: 'Item one', list_metadata: { list_level: 0, is_auto_numbered: true } }),
+        node({ tagged_text: 'An interrupting paragraph.' }),
+        node({ tagged_text: 'Item two', list_metadata: { list_level: 0, is_auto_numbered: true } }),
+      ]);
+      await then('the list closes around the paragraph and reopens', async () => {
+        expect(html).toContain('<p>An interrupting paragraph.</p>');
+        expect((html.match(/<ol>/g) ?? []).length).toBe(2);
+        expect((html.match(/<ol>/g) ?? []).length).toBe((html.match(/<\/ol>/g) ?? []).length);
+        expect((html.match(/<li>/g) ?? []).length).toBe((html.match(/<\/li>/g) ?? []).length);
+      });
+    },
+  );
+
+  test(
+    'a same-depth list-kind change closes the ordered list and opens an unordered one',
+    async ({ then }: AllureBddContext) => {
+      const html = body([
+        node({ tagged_text: 'Numbered', list_metadata: { list_level: 0, is_auto_numbered: true } }),
+        node({ tagged_text: 'Bulleted', list_metadata: { list_level: 0, label_type: LabelType.LETTER, label_string: '(a)' } }),
+      ]);
+      await then('both an <ol> and a <ul> appear and all lists balance', async () => {
+        expect(html).toContain('<ol>');
+        expect(html).toContain('<ul>');
+        expect((html.match(/<ol>/g) ?? []).length).toBe((html.match(/<\/ol>/g) ?? []).length);
+        expect((html.match(/<ul>/g) ?? []).length).toBe((html.match(/<\/ul>/g) ?? []).length);
+      });
+    },
+  );
+
+  test(
+    'a hostile font face cannot inject extra CSS declarations',
+    async ({ then }: AllureBddContext) => {
+      // A `;` in the font name would split into a second CSS declaration if left unsanitized.
+      const out = inlineTagsToHtml('<font face="Trick; position:fixed">x</font>');
+      await then('the injected separator is stripped so only one declaration survives', async () => {
+        const style = /<span style="([^"]*)">/.exec(out)?.[1] ?? '';
+        expect(out).toContain('</span>');
+        expect(style).toContain('font-family');
+        expect(style).not.toContain(';'); // injected ';' removed → no second declaration
+      });
+    },
+  );
+});

--- a/packages/docx-core/src/primitives/serialize_html.ts
+++ b/packages/docx-core/src/primitives/serialize_html.ts
@@ -21,6 +21,13 @@ import type { Footnote } from './footnotes.js';
 /** Footnote markers already injected into `tagged_text`, e.g. `[^1]`, `[^12]`. */
 const FOOTNOTE_MARKER_RE = /\[\^(\d+)\]/g;
 
+/**
+ * Tracks which footnote numbers were actually rendered as markers in the body, and how many
+ * times each appeared. Used to (a) give repeated markers unique element ids and (b) emit a
+ * back-link from a definition only when its marker was really rendered (no dangling `#fnref-n`).
+ */
+type FootnoteRefs = Map<number, number>;
+
 /** Escape the characters that are significant in HTML *text* content. */
 function escapeHtmlText(text: string): string {
   return text.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
@@ -30,19 +37,42 @@ function escapeHtmlText(text: string): string {
  * Escape literal text and turn any injected `[^n]` footnote marker into a trusted superscript
  * anchor. Order matters: the literal spans are escaped, but the generated `<sup>` is emitted
  * verbatim (escaping it would render the markup literally).
+ *
+ * When a `refs` registry is supplied, the first marker for footnote N keeps `id="fnref-N"` (the
+ * definition's back-link target); later repeats get a unique `id="fnref-N-k"` so the document
+ * never carries duplicate ids.
  */
-function renderTextWithFootnotes(raw: string): string {
+function renderTextWithFootnotes(raw: string, refs?: FootnoteRefs): string {
   let out = '';
   let last = 0;
   for (const match of raw.matchAll(FOOTNOTE_MARKER_RE)) {
     const idx = match.index ?? 0;
     out += escapeHtmlText(raw.slice(last, idx));
     const n = match[1]!;
-    out += `<sup id="fnref-${n}"><a href="#fn-${n}">${n}</a></sup>`;
+    let id = `fnref-${n}`;
+    if (refs) {
+      const k = (refs.get(Number(n)) ?? 0) + 1;
+      refs.set(Number(n), k);
+      if (k > 1) id = `fnref-${n}-${k}`;
+    }
+    out += `<sup id="${id}"><a href="#fn-${n}">${n}</a></sup>`;
     last = idx + match[0].length;
   }
   out += escapeHtmlText(raw.slice(last));
   return out;
+}
+
+/**
+ * Allow only schemes that are safe to follow from a rendered document. The href arrives already
+ * attribute-escaped from `formatting_tags.ts`; a `javascript:`/`data:`/`vbscript:` URL would
+ * otherwise pass through and execute on click. Relative URLs and fragments (no scheme) are kept.
+ */
+const SAFE_URL_SCHEMES = new Set(['http', 'https', 'mailto', 'tel']);
+function isSafeHref(href: string): boolean {
+  // Strip whitespace/control chars browsers ignore (e.g. `java\tscript:`) before scheme-matching.
+  const v = href.replace(/[\u0000-\u0020]/g, '').toLowerCase();
+  const scheme = /^([a-z][a-z0-9+.-]*):/.exec(v);
+  return scheme ? SAFE_URL_SCHEMES.has(scheme[1]!) : true;
 }
 
 // ── Font (`<font ...>`) → sanitized inline style ─────────────────────────────
@@ -93,11 +123,11 @@ function fontTagToSpan(tag: string): string {
  *
  * Literal text spans are HTML-escaped; injected `[^n]` footnote markers become `<sup>` anchors.
  */
-export function inlineTagsToHtml(text: string): string {
+export function inlineTagsToHtml(text: string, refs?: FootnoteRefs): string {
   let out = '';
   for (const token of tokenizeToonInline(text)) {
     if (token.kind === 'text') {
-      out += renderTextWithFootnotes(token.value);
+      out += renderTextWithFootnotes(token.value, refs);
       continue;
     }
     const tag = token.value;
@@ -105,7 +135,13 @@ export function inlineTagsToHtml(text: string): string {
     else if (tag === '</highlight>') out += '</mark>';
     else if (tag.startsWith('<font ')) out += fontTagToSpan(tag);
     else if (tag === '</font>') out += '</span>';
-    // <b>/<i>/<u>/<a ...>/</a> and their closers are already valid HTML — pass through.
+    else if (tag.startsWith('<a ')) {
+      // Drop the href for unsafe schemes (e.g. `javascript:`); keep the anchor so `</a>` still
+      // balances and the link text survives as plain text.
+      const href = /href="([^"]*)"/.exec(tag)?.[1] ?? '';
+      out += isSafeHref(href) ? tag : '<a>';
+    }
+    // <b>/<i>/<u> and `</a>` and the closers are already valid HTML — pass through.
     else out += tag;
   }
   return out;
@@ -125,7 +161,7 @@ function isStructuralHeading(node: DocumentViewNode): boolean {
  * - Vertically merged cells and nested tables flatten into the body-level grid; multi-paragraph
  *   cells join with `<br/>`.
  */
-function renderTable(group: DocumentViewNode[]): string {
+function renderTable(group: DocumentViewNode[], refs: FootnoteRefs): string {
   let totalCols = 0;
   for (const n of group) {
     const tc = n.table_context;
@@ -146,7 +182,7 @@ function renderTable(group: DocumentViewNode[]): string {
       rowOrder.push(tc.row_index);
     }
     const cellMap = rows.get(tc.row_index)!;
-    const cellHtml = inlineTagsToHtml(n.tagged_text).replace(/\s*\n+\s*/g, '<br/>').trim();
+    const cellHtml = inlineTagsToHtml(n.tagged_text, refs).replace(/\s*\n+\s*/g, '<br/>').trim();
     const parts = cellMap.get(tc.col_index) ?? [];
     if (cellHtml) parts.push(cellHtml);
     cellMap.set(tc.col_index, parts);
@@ -187,29 +223,35 @@ function renderTable(group: DocumentViewNode[]): string {
  * malformed HTML.
  */
 class ListBuilder {
-  private stack: Array<'ul' | 'ol'> = [];
+  // Each open list records its tag AND the item `level` that opened it. Storing the level (not
+  // just depth) is what keeps consecutive same-level items siblings even after a level jump that
+  // skipped intermediate depths — depth alone would drift deeper on every repeated jumped level.
+  private stack: Array<{ tag: 'ul' | 'ol'; level: number }> = [];
   private out: string[] = [];
 
   /** Append one list item at the given 0-based level with the given list tag. */
   item(level: number, tag: 'ul' | 'ol', content: string): void {
-    const targetDepth = Math.max(1, level + 1);
-    if (this.stack.length < targetDepth) {
-      // Grow by exactly one (clamp jumps) — the nested list lives inside the current open <li>.
-      this.out.push(`<${tag}>`);
-      this.stack.push(tag);
-    } else {
-      while (this.stack.length > targetDepth) {
-        this.out.push('</li>');
-        this.out.push(`</${this.stack.pop()}>`);
-      }
-      // Close the sibling <li> we are returning to before opening the new one.
+    const lvl = Math.max(0, level);
+    // Close any lists deeper than this item's level.
+    while (this.stack.length > 0 && this.stack[this.stack.length - 1]!.level > lvl) {
       this.out.push('</li>');
-      // Same-depth list-kind change (<ol>↔<ul>): close and reopen with the desired tag.
-      if (this.stack[this.stack.length - 1] !== tag) {
-        this.out.push(`</${this.stack.pop()}>`);
+      this.out.push(`</${this.stack.pop()!.tag}>`);
+    }
+    const top = this.stack[this.stack.length - 1];
+    if (top && top.level === lvl) {
+      // Sibling at the same list level: close the previous item; swap list kind if it changed.
+      this.out.push('</li>');
+      if (top.tag !== tag) {
+        this.out.push(`</${this.stack.pop()!.tag}>`);
         this.out.push(`<${tag}>`);
-        this.stack.push(tag);
+        this.stack.push({ tag, level: lvl });
       }
+    } else {
+      // Deeper than the current top (or the first item): open one nested list inside the open
+      // <li>. We record the item's actual level, so a jump of >1 opens a single step and a later
+      // same-level item lands here as a sibling rather than nesting further.
+      this.out.push(`<${tag}>`);
+      this.stack.push({ tag, level: lvl });
     }
     this.out.push(`<li>${content}`);
   }
@@ -223,7 +265,7 @@ class ListBuilder {
   flush(): string {
     while (this.stack.length > 0) {
       this.out.push('</li>');
-      this.out.push(`</${this.stack.pop()}>`);
+      this.out.push(`</${this.stack.pop()!.tag}>`);
     }
     const html = this.out.join('\n');
     this.out = [];
@@ -231,9 +273,9 @@ class ListBuilder {
   }
 }
 
-function renderListContent(node: DocumentViewNode): { tag: 'ul' | 'ol'; content: string } {
+function renderListContent(node: DocumentViewNode, refs: FootnoteRefs): { tag: 'ul' | 'ol'; content: string } {
   const lm = node.list_metadata;
-  const html = inlineTagsToHtml(node.tagged_text).trim();
+  const html = inlineTagsToHtml(node.tagged_text, refs).trim();
   // Auto-numbered lists become <ol> (the renderer numbers them). Manual/legal labels keep their
   // literal text (`Section 2.1`, `(a)`) prefixed inside a <ul> item — a bare number would
   // silently destroy meaningful legal labels. `is_auto_numbered` is the reliable signal:
@@ -243,12 +285,15 @@ function renderListContent(node: DocumentViewNode): { tag: 'ul' | 'ol'; content:
   return { tag: 'ul', content: label ? `${escapeHtmlText(label)} ${html}` : html };
 }
 
-function renderFootnotes(footnotes: Footnote[]): string {
+function renderFootnotes(footnotes: Footnote[], refs: FootnoteRefs): string {
   const defs = footnotes.filter((fn) => fn.displayNumber > 0);
   if (defs.length === 0) return '';
   const items = defs.map((fn) => {
     const body = escapeHtmlText(fn.text.replace(/\s+/g, ' ').trim());
-    return `<li id="fn-${fn.displayNumber}">${body} <a href="#fnref-${fn.displayNumber}">↩</a></li>`;
+    // Only link back when the marker was actually rendered in the body — otherwise the `#fnref-n`
+    // target does not exist (an unreferenced/orphan footnote definition), so omit the back-link.
+    const backlink = refs.has(fn.displayNumber) ? ` <a href="#fnref-${fn.displayNumber}">↩</a>` : '';
+    return `<li id="fn-${fn.displayNumber}">${body}${backlink}</li>`;
   });
   return ['<section class="footnotes">', '<hr/>', '<ol>', ...items, '</ol>', '</section>'].join('\n');
 }
@@ -297,6 +342,8 @@ export function serializeToHtml(
   opts: SerializeHtmlOptions = {},
 ): string {
   const blocks: string[] = [];
+  // Footnote markers rendered in the body, used to dedupe ids and gate definition back-links.
+  const refs: FootnoteRefs = new Map();
   let lists: ListBuilder | null = null;
 
   const closeLists = (): void => {
@@ -317,7 +364,7 @@ export function serializeToHtml(
         i++;
       }
       i--; // for-loop will re-increment
-      const table = renderTable(group);
+      const table = renderTable(group, refs);
       if (table) blocks.push(table);
       continue;
     }
@@ -326,14 +373,14 @@ export function serializeToHtml(
     if (isStructuralHeading(node)) {
       closeLists();
       const level = Math.min(6, Math.max(1, node.heading!.level as number));
-      blocks.push(`<h${level}>${inlineTagsToHtml(node.tagged_text).trim()}</h${level}>`);
+      blocks.push(`<h${level}>${inlineTagsToHtml(node.tagged_text, refs).trim()}</h${level}>`);
       continue;
     }
 
     // ── List items: accumulated in a stateful nested-list builder ──
     if (node.list_metadata.list_level >= 0) {
       if (!lists) lists = new ListBuilder();
-      const { tag, content } = renderListContent(node);
+      const { tag, content } = renderListContent(node, refs);
       lists.item(Math.max(0, node.list_metadata.list_level), tag, content);
       continue;
     }
@@ -341,13 +388,13 @@ export function serializeToHtml(
     // ── Normal paragraphs (heuristic headings land here: their run-in bold is already in the
     //     inline tags, so they stay <p> rather than being promoted to a heading). ──
     closeLists();
-    const html = inlineTagsToHtml(node.tagged_text).trim();
+    const html = inlineTagsToHtml(node.tagged_text, refs).trim();
     if (html) blocks.push(`<p>${html}</p>`);
   }
 
   closeLists();
 
-  const footnotesHtml = renderFootnotes(footnotes);
+  const footnotesHtml = renderFootnotes(footnotes, refs);
   if (footnotesHtml) blocks.push(footnotesHtml);
 
   const body = blocks.join('\n');

--- a/packages/docx-core/src/primitives/serialize_html.ts
+++ b/packages/docx-core/src/primitives/serialize_html.ts
@@ -1,0 +1,372 @@
+// DOCX → HTML serializer (semantic tier, mammoth.js-style).
+//
+// Like `serialize_markdown.ts`, this is a *serializer over the existing structured document
+// model* — it does no OOXML parsing. `DocxDocument.buildDocumentView({ showFormatting: true })`
+// already yields a `DocumentViewNode[]` carrying headings, list metadata, grid-aware table
+// context, injected `[^n]` footnote markers, and an HTML-shaped inline-tag string
+// (`tagged_text`). This module turns that model into semantic HTML.
+//
+// It renders the *same* inline tokens as the Markdown emitter via the shared
+// `tokenizeToonInline` core, so the two serializers never re-derive the tag grammar and drift
+// from the emitter in `formatting_tags.ts`. Where Markdown is lossy, HTML is richer: highlight
+// becomes `<mark>`, font runs become a styled `<span>`, and lists nest as real `<ul>/<ol>`.
+//
+// This is the *semantic* tier, not pixel-faithful HTML+CSS: exact layout is not reproduced.
+
+import { tokenizeToonInline } from './document_view.js';
+import type { DocumentViewNode } from './document_view.js';
+import { escapeHtmlAttribute } from './formatting_tags.js';
+import type { Footnote } from './footnotes.js';
+
+/** Footnote markers already injected into `tagged_text`, e.g. `[^1]`, `[^12]`. */
+const FOOTNOTE_MARKER_RE = /\[\^(\d+)\]/g;
+
+/** Escape the characters that are significant in HTML *text* content. */
+function escapeHtmlText(text: string): string {
+  return text.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+}
+
+/**
+ * Escape literal text and turn any injected `[^n]` footnote marker into a trusted superscript
+ * anchor. Order matters: the literal spans are escaped, but the generated `<sup>` is emitted
+ * verbatim (escaping it would render the markup literally).
+ */
+function renderTextWithFootnotes(raw: string): string {
+  let out = '';
+  let last = 0;
+  for (const match of raw.matchAll(FOOTNOTE_MARKER_RE)) {
+    const idx = match.index ?? 0;
+    out += escapeHtmlText(raw.slice(last, idx));
+    const n = match[1]!;
+    out += `<sup id="fnref-${n}"><a href="#fn-${n}">${n}</a></sup>`;
+    last = idx + match[0].length;
+  }
+  out += escapeHtmlText(raw.slice(last));
+  return out;
+}
+
+// ── Font (`<font ...>`) → sanitized inline style ─────────────────────────────
+// The values come from `formatting_tags.ts`: color is a raw hex string (no `#`), size is in
+// *points* (display units), face is a font name. Every value is sanitized so a hostile font
+// name cannot break out of the `style` attribute.
+
+function sanitizeColor(raw: string | undefined): string | null {
+  if (!raw) return null;
+  const hex = raw.replace(/^#/, '');
+  return /^[0-9A-Fa-f]{3,8}$/.test(hex) ? `#${hex}` : null;
+}
+
+function sanitizeFontSize(raw: string | undefined): string | null {
+  if (!raw) return null;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? `${n}pt` : null;
+}
+
+function sanitizeFontFamily(raw: string | undefined): string | null {
+  if (!raw) return null;
+  // Strip anything that could terminate the value or the attribute; keep ordinary name chars.
+  const clean = raw.replace(/[<>"';{}()]/g, '').trim();
+  return clean ? `'${clean}'` : null;
+}
+
+function fontTagToSpan(tag: string): string {
+  const color = sanitizeColor(/color="([^"]*)"/.exec(tag)?.[1]);
+  const size = sanitizeFontSize(/size="([^"]*)"/.exec(tag)?.[1]);
+  const face = sanitizeFontFamily(/face="([^"]*)"/.exec(tag)?.[1]);
+  const decls: string[] = [];
+  if (color) decls.push(`color:${color}`);
+  if (size) decls.push(`font-size:${size}`);
+  if (face) decls.push(`font-family:${face}`);
+  // A `<font>` with no usable attribute degrades to a bare span (still balances `</font>`).
+  if (decls.length === 0) return '<span>';
+  return `<span style="${escapeHtmlAttribute(decls.join(';'))}">`;
+}
+
+/**
+ * Convert one TOON inline-tag string (a `DocumentViewNode.tagged_text` value) to inline HTML.
+ * This is the HTML parallel of `inlineTagsToMarkdown` and the reusable core of the serializer.
+ *
+ * Tag mapping:
+ * - `<b>`/`<i>`/`<u>`/`<a href="...">` → passed through verbatim (already valid, attribute-escaped HTML)
+ * - `<highlight>`                       → `<mark>`
+ * - `<font color=… size=… face=…>`      → `<span style="…">` (values sanitized)
+ *
+ * Literal text spans are HTML-escaped; injected `[^n]` footnote markers become `<sup>` anchors.
+ */
+export function inlineTagsToHtml(text: string): string {
+  let out = '';
+  for (const token of tokenizeToonInline(text)) {
+    if (token.kind === 'text') {
+      out += renderTextWithFootnotes(token.value);
+      continue;
+    }
+    const tag = token.value;
+    if (tag === '<highlight>') out += '<mark>';
+    else if (tag === '</highlight>') out += '</mark>';
+    else if (tag.startsWith('<font ')) out += fontTagToSpan(tag);
+    else if (tag === '</font>') out += '</span>';
+    // <b>/<i>/<u>/<a ...>/</a> and their closers are already valid HTML — pass through.
+    else out += tag;
+  }
+  return out;
+}
+
+/** A heading is structural (gets `<hN>`) only when Word's style told us so and gave a level. */
+function isStructuralHeading(node: DocumentViewNode): boolean {
+  return node.heading?.source === 'word_style' && typeof node.heading.level === 'number';
+}
+
+/**
+ * Render a run of nodes that share a `table_context.table_id` as an HTML `<table>`.
+ *
+ * Lossy by design (the view model discards `gridSpan`/`vMerge` span width):
+ * - Horizontally merged cells (`gridSpan`) advance `col_index`, leaving grid gaps that we fill
+ *   with empty cells so every row has the full column count.
+ * - Vertically merged cells and nested tables flatten into the body-level grid; multi-paragraph
+ *   cells join with `<br/>`.
+ */
+function renderTable(group: DocumentViewNode[]): string {
+  let totalCols = 0;
+  for (const n of group) {
+    const tc = n.table_context;
+    if (!tc) continue;
+    totalCols = Math.max(totalCols, tc.total_cols, tc.col_index + 1);
+  }
+  if (totalCols <= 0) return '';
+
+  const rows = new Map<number, Map<number, string[]>>();
+  const rowOrder: number[] = [];
+  const headerRows = new Set<number>();
+
+  for (const n of group) {
+    const tc = n.table_context;
+    if (!tc) continue;
+    if (!rows.has(tc.row_index)) {
+      rows.set(tc.row_index, new Map());
+      rowOrder.push(tc.row_index);
+    }
+    const cellMap = rows.get(tc.row_index)!;
+    const cellHtml = inlineTagsToHtml(n.tagged_text).replace(/\s*\n+\s*/g, '<br/>').trim();
+    const parts = cellMap.get(tc.col_index) ?? [];
+    if (cellHtml) parts.push(cellHtml);
+    cellMap.set(tc.col_index, parts);
+    if (tc.is_header_row) headerRows.add(tc.row_index);
+  }
+
+  rowOrder.sort((a, b) => a - b);
+  if (rowOrder.length === 0) return '';
+
+  const cellsFor = (rowIndex: number): string[] => {
+    const cellMap = rows.get(rowIndex) ?? new Map<number, string[]>();
+    const cells: string[] = [];
+    for (let c = 0; c < totalCols; c++) cells.push((cellMap.get(c) ?? []).join('<br/>'));
+    return cells;
+  };
+
+  // Prefer the first row Word flagged as a header; otherwise treat the first row as the header.
+  const headerRowIndex = rowOrder.find((ri) => headerRows.has(ri)) ?? rowOrder[0]!;
+
+  const lines: string[] = ['<table>'];
+  lines.push('<thead>');
+  lines.push(`<tr>${cellsFor(headerRowIndex).map((c) => `<th>${c}</th>`).join('')}</tr>`);
+  lines.push('</thead>');
+  lines.push('<tbody>');
+  for (const ri of rowOrder) {
+    if (ri === headerRowIndex) continue;
+    lines.push(`<tr>${cellsFor(ri).map((c) => `<td>${c}</td>`).join('')}</tr>`);
+  }
+  lines.push('</tbody>');
+  lines.push('</table>');
+  return lines.join('\n');
+}
+
+/**
+ * Stateful nested-list builder. Auto list levels come straight from OOXML `ilvl` with no
+ * monotonicity guarantee, so the open/close logic must be robust to level jumps, interruptions,
+ * and same-level kind changes — a naive open-on-increase/close-on-decrease stack would emit
+ * malformed HTML.
+ */
+class ListBuilder {
+  private stack: Array<'ul' | 'ol'> = [];
+  private out: string[] = [];
+
+  /** Append one list item at the given 0-based level with the given list tag. */
+  item(level: number, tag: 'ul' | 'ol', content: string): void {
+    const targetDepth = Math.max(1, level + 1);
+    if (this.stack.length < targetDepth) {
+      // Grow by exactly one (clamp jumps) — the nested list lives inside the current open <li>.
+      this.out.push(`<${tag}>`);
+      this.stack.push(tag);
+    } else {
+      while (this.stack.length > targetDepth) {
+        this.out.push('</li>');
+        this.out.push(`</${this.stack.pop()}>`);
+      }
+      // Close the sibling <li> we are returning to before opening the new one.
+      this.out.push('</li>');
+      // Same-depth list-kind change (<ol>↔<ul>): close and reopen with the desired tag.
+      if (this.stack[this.stack.length - 1] !== tag) {
+        this.out.push(`</${this.stack.pop()}>`);
+        this.out.push(`<${tag}>`);
+        this.stack.push(tag);
+      }
+    }
+    this.out.push(`<li>${content}`);
+  }
+
+  /** True when at least one list is currently open. */
+  get isOpen(): boolean {
+    return this.stack.length > 0;
+  }
+
+  /** Close every open list and return the accumulated HTML. */
+  flush(): string {
+    while (this.stack.length > 0) {
+      this.out.push('</li>');
+      this.out.push(`</${this.stack.pop()}>`);
+    }
+    const html = this.out.join('\n');
+    this.out = [];
+    return html;
+  }
+}
+
+function renderListContent(node: DocumentViewNode): { tag: 'ul' | 'ol'; content: string } {
+  const lm = node.list_metadata;
+  const html = inlineTagsToHtml(node.tagged_text).trim();
+  // Auto-numbered lists become <ol> (the renderer numbers them). Manual/legal labels keep their
+  // literal text (`Section 2.1`, `(a)`) prefixed inside a <ul> item — a bare number would
+  // silently destroy meaningful legal labels. `is_auto_numbered` is the reliable signal:
+  // an auto `1.` can classify as NUMBERED_HEADING, so label_type alone is not enough.
+  if (lm.is_auto_numbered) return { tag: 'ol', content: html };
+  const label = lm.label_string?.trim() ?? '';
+  return { tag: 'ul', content: label ? `${escapeHtmlText(label)} ${html}` : html };
+}
+
+function renderFootnotes(footnotes: Footnote[]): string {
+  const defs = footnotes.filter((fn) => fn.displayNumber > 0);
+  if (defs.length === 0) return '';
+  const items = defs.map((fn) => {
+    const body = escapeHtmlText(fn.text.replace(/\s+/g, ' ').trim());
+    return `<li id="fn-${fn.displayNumber}">${body} <a href="#fnref-${fn.displayNumber}">↩</a></li>`;
+  });
+  return ['<section class="footnotes">', '<hr/>', '<ol>', ...items, '</ol>', '</section>'].join('\n');
+}
+
+const DOCUMENT_STYLE = `
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 50rem; margin: 2rem auto; padding: 0 1rem; line-height: 1.5; color: #1a1a1a; }
+  table { border-collapse: collapse; margin: 1rem 0; }
+  th, td { border: 1px solid #ccc; padding: 0.3rem 0.6rem; text-align: left; vertical-align: top; }
+  th { background: #f5f5f5; }
+  mark { background: #fef08a; }
+  .footnotes { margin-top: 2rem; font-size: 0.9em; color: #444; }
+  .footnotes hr { border: none; border-top: 1px solid #ccc; }
+  sup a { text-decoration: none; }
+`.trim();
+
+/** Strip inline tags from a heading's tagged text to make a plain-text `<title>`. */
+function deriveTitle(nodes: DocumentViewNode[]): string {
+  const first = nodes.find(isStructuralHeading);
+  if (!first) return 'Document';
+  const plain = tokenizeToonInline(first.tagged_text)
+    .filter((t) => t.kind === 'text')
+    .map((t) => t.value)
+    .join('')
+    .replace(/\[\^\d+\]/g, '')
+    .trim();
+  return plain || 'Document';
+}
+
+export interface SerializeHtmlOptions {
+  /** Emit only the body-level elements (no `<!DOCTYPE>`/`<head>`/`<body>` wrapper). */
+  readonly fragment?: boolean;
+  /** Override the `<title>` (full-document mode only). Defaults to the first heading's text. */
+  readonly title?: string;
+}
+
+/**
+ * Serialize a structured document view to semantic HTML.
+ *
+ * @param nodes     Block nodes from `buildDocumentView({ showFormatting: true }).nodes`.
+ * @param footnotes Footnotes from `DocxDocument.getFootnotes()` (already sorted by
+ *                  `displayNumber`); rendered as a footnotes `<section>` with back-links.
+ */
+export function serializeToHtml(
+  nodes: DocumentViewNode[],
+  footnotes: Footnote[] = [],
+  opts: SerializeHtmlOptions = {},
+): string {
+  const blocks: string[] = [];
+  let lists: ListBuilder | null = null;
+
+  const closeLists = (): void => {
+    if (lists && lists.isOpen) blocks.push(lists.flush());
+    lists = null;
+  };
+
+  for (let i = 0; i < nodes.length; i++) {
+    const node = nodes[i]!;
+
+    // ── Tables: consume the whole run of same-table_id nodes at once ──
+    if (node.table_context) {
+      closeLists();
+      const tableId = node.table_context.table_id;
+      const group: DocumentViewNode[] = [];
+      while (i < nodes.length && nodes[i]!.table_context?.table_id === tableId) {
+        group.push(nodes[i]!);
+        i++;
+      }
+      i--; // for-loop will re-increment
+      const table = renderTable(group);
+      if (table) blocks.push(table);
+      continue;
+    }
+
+    // ── Structural (Word-styled) headings ──
+    if (isStructuralHeading(node)) {
+      closeLists();
+      const level = Math.min(6, Math.max(1, node.heading!.level as number));
+      blocks.push(`<h${level}>${inlineTagsToHtml(node.tagged_text).trim()}</h${level}>`);
+      continue;
+    }
+
+    // ── List items: accumulated in a stateful nested-list builder ──
+    if (node.list_metadata.list_level >= 0) {
+      if (!lists) lists = new ListBuilder();
+      const { tag, content } = renderListContent(node);
+      lists.item(Math.max(0, node.list_metadata.list_level), tag, content);
+      continue;
+    }
+
+    // ── Normal paragraphs (heuristic headings land here: their run-in bold is already in the
+    //     inline tags, so they stay <p> rather than being promoted to a heading). ──
+    closeLists();
+    const html = inlineTagsToHtml(node.tagged_text).trim();
+    if (html) blocks.push(`<p>${html}</p>`);
+  }
+
+  closeLists();
+
+  const footnotesHtml = renderFootnotes(footnotes);
+  if (footnotesHtml) blocks.push(footnotesHtml);
+
+  const body = blocks.join('\n');
+  if (opts.fragment) return `${body}\n`;
+
+  const title = escapeHtmlText(opts.title ?? deriveTitle(nodes));
+  return [
+    '<!DOCTYPE html>',
+    '<html lang="en">',
+    '<head>',
+    '<meta charset="utf-8"/>',
+    '<meta name="viewport" content="width=device-width, initial-scale=1"/>',
+    `<title>${title}</title>`,
+    `<style>\n${DOCUMENT_STYLE}\n</style>`,
+    '</head>',
+    '<body>',
+    body,
+    '</body>',
+    '</html>',
+    '',
+  ].join('\n');
+}

--- a/packages/docx-mcp/docs/tool-reference.generated.md
+++ b/packages/docx-mcp/docs/tool-reference.generated.md
@@ -141,7 +141,7 @@ Save document. For DOCX: saves clean and/or tracked changes output. For Google D
 
 ## `export`
 
-Export a document to a portable text rendering. Writes an output file (default: source path with the format extension, e.g. .md) and returns its path, byte count, and the rendered content. Markdown is intentionally lossy (no round-trip). DOCX only — Google Docs is not supported.
+Export a document to a portable rendering (Markdown or semantic HTML). Writes an output file (default: source path with the format extension, e.g. .md or .html) and returns its path, byte count, and the rendered content. Intentionally lossy (no round-trip); HTML is the semantic tier, not pixel-faithful. DOCX only — Google Docs is not supported.
 
 - readOnly: `false`
 - destructive: `false`
@@ -149,10 +149,10 @@ Export a document to a portable text rendering. Writes an output file (default: 
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
 | `file_path` | `string` | no | Path to the DOCX file. |
-| `format` | `enum("markdown")` | no | Output format. 'markdown' (default). 'html'/'text' are planned. |
+| `format` | `enum("markdown", "html")` | no | Output format: 'markdown' (default) or 'html'. 'text' is planned. |
 | `output_path` | `string` | no | Where to write the rendering. Defaults to the source path with the format extension. |
 | `allow_overwrite` | `boolean` | no | Overwrite output_path if it already exists. Default: false. |
-| `include_markdown` | `boolean` | no | Include the rendered content in the response. Default: true; set false for large documents. |
+| `include_markdown` | `boolean` | no | Include the rendered content (under `content`) in the response. Default: true; set false for large documents. |
 
 ## `format_layout`
 

--- a/packages/docx-mcp/src/tool_catalog.ts
+++ b/packages/docx-mcp/src/tool_catalog.ts
@@ -179,13 +179,13 @@ export const SAFE_DOCX_TOOL_CATALOG = [
   {
     name: 'export',
     description:
-      'Export a document to a portable text rendering. Writes an output file (default: source path with the format extension, e.g. .md) and returns its path, byte count, and the rendered content. Markdown is intentionally lossy (no round-trip). DOCX only — Google Docs is not supported.',
+      'Export a document to a portable rendering (Markdown or semantic HTML). Writes an output file (default: source path with the format extension, e.g. .md or .html) and returns its path, byte count, and the rendered content. Intentionally lossy (no round-trip); HTML is the semantic tier, not pixel-faithful. DOCX only — Google Docs is not supported.',
     input: z.object({
       ...FILE_FIELD_OPTIONAL,
       format: z
-        .enum(['markdown'])
+        .enum(['markdown', 'html'])
         .optional()
-        .describe("Output format. 'markdown' (default). 'html'/'text' are planned."),
+        .describe("Output format: 'markdown' (default) or 'html'. 'text' is planned."),
       output_path: z
         .string()
         .optional()
@@ -197,7 +197,7 @@ export const SAFE_DOCX_TOOL_CATALOG = [
       include_markdown: z
         .boolean()
         .optional()
-        .describe('Include the rendered content in the response. Default: true; set false for large documents.'),
+        .describe('Include the rendered content (under `content`) in the response. Default: true; set false for large documents.'),
     }),
     annotations: { readOnlyHint: false, destructiveHint: false },
   },

--- a/packages/docx-mcp/src/tools/export.ts
+++ b/packages/docx-mcp/src/tools/export.ts
@@ -6,12 +6,13 @@ import { mergeSessionResolutionMetadata, resolveSessionForTool } from './session
 import { enforceWritePathPolicy } from './path_policy.js';
 import { checkGDocsSupport } from './provider_guard.js';
 
-/** Output formats the export tool can emit. Extensible: `html`/`text` land in #304/#305. */
-const SUPPORTED_FORMATS = ['markdown'] as const;
+/** Output formats the export tool can emit. Extensible: `text` lands in #305. */
+const SUPPORTED_FORMATS = ['markdown', 'html'] as const;
 type ExportFormat = (typeof SUPPORTED_FORMATS)[number];
 
 const EXTENSION_FOR_FORMAT: Record<ExportFormat, string> = {
   markdown: '.md',
+  html: '.html',
 };
 
 function expandPath(inputPath: string): string {
@@ -25,9 +26,10 @@ function defaultOutputPath(sourcePath: string, format: ExportFormat): string {
 }
 
 /**
- * Export a document to a portable text rendering (Markdown today). Writes the rendering to a
+ * Export a document to a portable text rendering (Markdown or HTML). Writes the rendering to a
  * file (this tool is NOT read-only) and returns the written path, byte count, and — unless
- * `include_markdown: false` — the rendered content itself.
+ * `include_markdown: false` — the rendered content under a format-agnostic `content` key (plus
+ * a legacy `markdown` key for the Markdown format).
  *
  * DOCX only. Google Docs (`google_doc_id`) is out of scope for this tool.
  */
@@ -105,22 +107,25 @@ export async function exportDocument(
       }
     }
 
-    const markdown = await session.doc.toMarkdown();
-    const buffer = Buffer.from(markdown, 'utf8');
+    const content = exportFormat === 'html' ? await session.doc.toHtml() : await session.doc.toMarkdown();
+    const buffer = Buffer.from(content, 'utf8');
 
     const policy = await enforceWritePathPolicy(outputPath);
     if (!policy.ok) return policy.response;
     await fs.mkdir(path.dirname(outputPath), { recursive: true });
     await fs.writeFile(outputPath, new Uint8Array(buffer));
 
-    const includeMarkdown = params.include_markdown !== false;
+    // `include_markdown` gates the inline content for both formats (its name predates HTML).
+    const includeContent = params.include_markdown !== false;
     return ok(
       mergeSessionResolutionMetadata(
         {
           format: exportFormat,
           output_path: manager.normalizePath(outputPath),
           bytes_written: buffer.byteLength,
-          ...(includeMarkdown ? { markdown } : {}),
+          // `content` is the format-agnostic key; `markdown` is kept for back-compat on Markdown.
+          ...(includeContent ? { content } : {}),
+          ...(includeContent && exportFormat === 'markdown' ? { markdown: content } : {}),
         },
         metadata,
       ),

--- a/packages/docx-mcp/src/tools/export_html.test.ts
+++ b/packages/docx-mcp/src/tools/export_html.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { assertFailure, assertSuccess, openSession, registerCleanup } from '../testing/session-test-utils.js';
+import { exportDocument } from './export.js';
+
+const TEST_FEATURE = 'add-html-export';
+const test = testAllure.epic('Document Editing').withLabels({ feature: TEST_FEATURE });
+
+function htmlPathFor(inputPath: string): string {
+  const parsed = path.parse(inputPath);
+  return path.join(parsed.dir, `${parsed.name}.html`);
+}
+
+describe('OpenSpec traceability: add-html-export (export tool)', () => {
+  registerCleanup();
+
+  test.openspec('html export writes a file and returns its path and content')(
+    'html export writes a file and returns its path and content',
+    async ({ then }: AllureBddContext) => {
+      const opened = await openSession(['Hello world.']);
+      const result = await exportDocument(opened.mgr, { file_path: opened.inputPath, format: 'html' });
+      await then('the response carries the HTML under content and the file is on disk', async () => {
+        assertSuccess(result, 'export');
+        expect(result.format).toBe('html');
+        expect(typeof result.content).toBe('string');
+        expect(String(result.content)).toContain('<!DOCTYPE html>');
+        expect(result.bytes_written).toBeGreaterThan(0);
+        const onDisk = await fs.readFile(String(result.output_path), 'utf8');
+        expect(onDisk).toBe(result.content);
+        expect(onDisk).toContain('Hello world.');
+      });
+    },
+  );
+
+  test.openspec('default html output path derives from the source path')(
+    'default html output path derives from the source path',
+    async ({ then }: AllureBddContext) => {
+      const opened = await openSession(['Body text.']);
+      const result = await exportDocument(opened.mgr, { file_path: opened.inputPath, format: 'html' });
+      await then('the .docx extension is swapped for .html', async () => {
+        assertSuccess(result, 'export');
+        const expected = htmlPathFor(opened.inputPath);
+        const exists = await fs.access(expected).then(() => true).catch(() => false);
+        expect(exists).toBe(true);
+        expect(path.resolve(String(result.output_path))).toBe(path.resolve(expected));
+      });
+    },
+  );
+
+  test.openspec('html overwrite of an existing output file is blocked by default')(
+    'html overwrite of an existing output file is blocked by default',
+    async ({ then }: AllureBddContext) => {
+      const opened = await openSession(['Body text.']);
+      const target = path.join(opened.tmpDir, 'taken.html');
+      await fs.writeFile(target, 'PRE-EXISTING');
+      const result = await exportDocument(opened.mgr, {
+        file_path: opened.inputPath,
+        format: 'html',
+        output_path: target,
+      });
+      await then('export refuses and leaves the file untouched', async () => {
+        assertFailure(result, 'OVERWRITE_BLOCKED', 'export');
+        expect(await fs.readFile(target, 'utf8')).toBe('PRE-EXISTING');
+      });
+    },
+  );
+
+  test.openspec('include_markdown false omits the rendered html content')(
+    'include_markdown false omits the rendered html content',
+    async ({ then }: AllureBddContext) => {
+      const opened = await openSession(['Body text.']);
+      const result = await exportDocument(opened.mgr, {
+        file_path: opened.inputPath,
+        format: 'html',
+        include_markdown: false,
+      });
+      await then('path and byte count are present but content is not', async () => {
+        assertSuccess(result, 'export');
+        expect(result.output_path).toBeTruthy();
+        expect(result.bytes_written).toBeGreaterThan(0);
+        expect(result.content).toBeUndefined();
+      });
+    },
+  );
+
+  test.openspec('html export rejects a Google Docs source')(
+    'html export rejects a Google Docs source',
+    async ({ then }: AllureBddContext) => {
+      const opened = await openSession(['Body text.']);
+      const result = await exportDocument(opened.mgr, { google_doc_id: 'some-google-doc-id', format: 'html' });
+      await then('a provider-unsupported error is returned', async () => {
+        assertFailure(result, 'UNSUPPORTED_FOR_PROVIDER', 'export');
+      });
+    },
+  );
+});


### PR DESCRIPTION
Closes #304.

## Summary
Adds a semantic **DOCX → HTML** export path alongside the Markdown emitter (#310), completing the read → edit → compare → **export** loop. The exporter is a thin serializer over the existing `DocumentViewNode[]` model, sharing the `tokenizeToonInline` core so it never re-derives the inline-tag grammar (no drift from `formatting_tags.ts`).

This is the **semantic tier** (mammoth.js-style), not pixel-faithful HTML+CSS.

## What changed
**docx-core**
- `serialize_html.ts` — `inlineTagsToHtml()` (`<b>/<i>/<u>/<a>` passthrough, `<highlight>`→`<mark>`, `<font>`→sanitized `<span style>`, `[^n]`→`<sup>` anchors) and `serializeToHtml()` (headings → `<hN>`, a robust nested `<ul>/<ol>` builder, gap-filled `<table><thead><tbody>`, footnote `<section>`; full XHTML5 document or `{ fragment: true }`).
- `DocxDocument.toHtml()`; `escapeHtmlAttribute` exported from `formatting_tags.ts`; explicit barrel export.

**docx-mcp**
- `export` tool gains `format: 'html'` (`.html` extension, format-agnostic `content` response key; legacy `markdown` key retained for the Markdown format).

## Design notes
- **Ordered lists** key off `is_auto_numbered` (an auto `1.` can classify as `NUMBERED_HEADING`, so `label_type` alone is insufficient).
- **Font CSS values are sanitized** (color/size/face) so a hostile font name can't break out of `style="…"`.
- **Void elements self-close** (`<br/>`, `<hr/>`, `<meta/>`) so output parses as both HTML5 and XML — useful for downstream content extraction.

## Out of scope (per proposal)
Images/`<img>`, true `colspan`/`rowspan` (the view model discards span width), manual-label list nesting (pinned to level 0 upstream), equations/charts/fields, high-fidelity HTML+CSS, round-trip, Google Docs source.

## Verification
- Full suites green: **docx-core 1318**, **docx-mcp 771**.
- `openspec validate add-html-export --strict`; spec-coverage strict (12 core + 5 mcp scenarios), lint, allure-labels/filenames all pass.
- Real-document smoke (NVCA COI, ILPA LPA, Bonterms NDA) → **valid XHTML5 (0 XML errors)**, footnote anchors resolve, tables/nested lists/links/highlight render faithfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)