### PR TITLE
ci(release): add ODF release-isolation guard and OpenSpec proposal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,10 @@ jobs:
         run: npm run lint:workspaces
       - name: Check for import cycles
         run: npm run check:cycles
+      - name: Check release isolation (ODF decoupling guard)
+        run: npm run check:release-isolation
+      - name: Test release-isolation guard
+        run: npm run test:release-isolation
 
   spec-coverage:
     runs-on: ubuntu-latest

--- a/openspec/changes/add-odf-release-isolation/design.md
+++ b/openspec/changes/add-odf-release-isolation/design.md
@@ -1,0 +1,176 @@
+# Design: Isolate ODF package releases from the DOCX suite
+
+## Context
+
+`release.yml` is suite-versioned. The preflight job's
+"Verify tag matches package suite versions" step iterates a hardcoded list:
+
+```
+packages/docx-core packages/docx-mcp packages/google-docs-core \
+packages/safe-docx packages/safe-docx-mcpb
+```
+
+and additionally pins `safe-docx-mcpb/manifest.json`, `safe-docx/server.json`,
+`safe-docx/.smithery/shttp/manifest.json`, and `gemini-extension.json` to the
+tag version (all currently `0.9.1`). The `publish-suite` job publishes a
+hardcoded four-package list (`docx-core`, `docx-mcp`, `google-docs-core`,
+`safe-docx`). The workflow triggers on `push: tags: ["v*.*.*"]` and a
+`workflow_dispatch` taking an existing `v*.*.*` tag.
+
+Two facts, both verified against the current workflow, shape this design:
+
+1. **`odf-v*.*.*` tags do not match the `v*.*.*` push trigger.** GitHub Actions
+   tag globs are evaluated against the ref name and anchor at its start;
+   `odf-v1.0.0` does not begin with `v`, so a future ODF release workflow can own
+   the `odf-v*` namespace with zero overlap on the **push** trigger.
+   `workflow_dispatch` is a separate matter — see "The dispatch input" below.
+2. **The suite check and publish job are allowlist-driven, not
+   discover-all.** A new `packages/odf-core` is not seen by either until it is
+   explicitly added. So nothing is broken today — the exposure is a *latent*
+   coupling a future contributor could introduce by "finishing the list."
+
+`check:spec-coverage` (the traceability gate that `release.yml` runs) is scoped
+only to the `docx-comparison` and `docx-primitives` specs, so introducing a new
+`release-publishing` capability spec does not require test-traceability wiring.
+
+## Goals / Non-Goals
+
+**Goals**
+- Guarantee ODF packages version and publish independently of the DOCX suite
+  tag, decided and enforced *before* any ODF package is published.
+- Make the rejected "add ODF to the suite lockstep" option fail CI rather than
+  rely on reviewer vigilance.
+- Choose a non-colliding `odf-v*` git-tag prefix for the future independent
+  track (our own repo's tags — not an external name reservation) without
+  building that track now. No placeholder publish to claim any npm name.
+
+**Non-Goals**
+- Building `release-odf.yml` (the independent publish pipeline). Deferred until
+  ODF has a real published shape — see "Decisions / Staging".
+- Creating `packages/odf-core` or any ODF code (Phase 1).
+- Changing any DOCX package version or the DOCX release pipeline.
+
+## Decision
+
+### The three options, weighed
+
+| Option | Clears the blocker? | Cost now | Risk |
+| --- | --- | --- | --- |
+| **A. Independent release track now** (`odf-v*` + full `release-odf.yml`) | Yes | High — a full parallel preflight/publish/provenance/MCP-registry pipeline | Pipeline is built against a *guessed* package shape (no odf-core exists), bitrots until Phase 2 actually publishes |
+| **B. ODF-private + workflow-snapshot guard now; build the track at publish-time** (recommended) | Yes | Low — one guard script + a spec | None to the DOCX suite; the independent track is built later when the shape is known |
+| **C. Suite-wide lockstep** (add ODF to the hardcoded lists) | No | Low | Rejected — forces churn/re-publish of the stable DOCX suite on every ODF `0.x` bump |
+
+**Recommendation: Option B.** The plan's stated preference was Option A
+("independent release track"), and B reaches the *same end state* — an
+`odf-v*`-tagged independent pipeline — but sequences it correctly. Building a
+publish pipeline before the package it publishes exists means guessing the
+`server.json` / smithery / provenance / MCP-registry surface for odf-core and
+maintaining dead YAML across all of Phase 1. Option B clears the blocker today
+with a guard that is a few dozen lines, and defers the pipeline to the moment we
+actually know odf-core's published shape. The `odf-v*` namespace reservation in
+this spec means the deferred track slots in without ever editing `release.yml`.
+
+This is a sequencing disagreement with the plan, not a destination
+disagreement — surfaced deliberately rather than averaged away.
+
+### Staging
+
+- **Now (this change):** spec + `private: true` convention + allowlist guard.
+- **Phase 1:** `packages/odf-core` is created with `"private": true`; the guard
+  keeps it off the DOCX release automatically.
+- **Pre-publish (post Phase 1, separate change):** build `release-odf.yml` on
+  the `odf-v*` trigger with its own preflight/publish, flip odf packages to
+  publishable, and add them to an **ODF** allowlist (never the DOCX one).
+
+### The dispatch input
+
+`release.yml`'s `workflow_dispatch` takes a **free-string** `release_tag` input
+(with `v0.1.1` only as an example), not a `v*.*.*`-constrained value. So a
+maintainer *could* manually dispatch with `odf-v1.0.0`. That is safe by failure,
+not by trigger: preflight computes `TAG_VERSION="${TAG_REF#v}"`, which leaves
+`odf-v1.0.0` unchanged (it has no leading `v`), and the suite-version check then
+fails because `odf-v1.0.0` matches no DOCX package version. The non-overlap
+guarantee is therefore: **push** never fires DOCX release on an `odf-v*` tag, and
+a **manual dispatch** of one fails preflight before publishing anything. An
+optional belt-and-suspenders hardening — an explicit
+`^v[0-9]+\.[0-9]+\.[0-9]+` assertion in preflight — is listed in Open Questions;
+it edits `release.yml`, so it is not part of this change's required scope.
+
+### The guard
+
+`scripts/check-release-isolation.mjs`. Two assertions, both pure JSON/text
+inspection (no network, no build), wired into the existing workspace-lint
+required check:
+
+**A. Workflow-snapshot check (the real anti-coupling enforcement).** The guard
+holds the four expected DOCX package lists as the single source of truth and
+asserts each matches the corresponding hardcoded list in `release.yml`:
+- version-pin list (`release.yml` preflight),
+- duplicate-publish guard list,
+- dry-run pack list,
+- publish list.
+Adding *any* package — ODF or otherwise — to one of these lists changes the
+snapshot and fails the guard, with the offending list + package named. This
+guards the coupling mechanism directly (membership in a release list), so it is
+robust to packages like `allure-test-factory` that are non-private but on no
+release list. To keep the comparison robust rather than parsing shell `for`
+loops with a regex, the guard reads the workflow text and asserts each expected
+package name is present in the relevant step *and* that no unexpected
+`@usejunior/*` / `packages/*` token appears in those steps; the exact extraction
+is an implementation detail to be covered by the guard's own unit test.
+
+**B. ODF-private check.** Enumerate workspace packages by reading the root
+`package.json` `workspaces` globs and expanding them (e.g. `packages/*` →
+`packages/*/package.json`). **Do not** use `npm query .workspace` — verified
+against npm 11.12.1 it returns `[]` and `npm query ':workspace'` errors
+`EQUERYNOPSEUDO`. For each package whose name matches `/odf/`, assert
+`private: true`; otherwise fail with the package name and the remedy. This is
+narrow (touches only ODF packages) and forward-looking (no ODF package exists
+yet, so it is a no-op on the current tree).
+
+Lifting condition (from review): no ODF package may set `private: false` until
+the independent `release-odf.yml` track exists and passes its own preflight. The
+ODF-private check enforces the "stays private" half; the spec records the
+lifting condition so the future ODF-release change is the only place that
+flips it.
+
+## Risks / Trade-offs
+
+- **Guard/workflow drift.** If `release.yml`'s hardcoded list changes and the
+  guard's constant does not, the cross-check assertion fails — by design, that
+  is the signal, not a bug. Accepted.
+- **`private: true` blocks nothing developers need.** Workspaces build, test,
+  typecheck, and cross-import private packages normally; only `npm publish`
+  refuses. No DX cost.
+- **Deferring the track means a second change later.** Accepted — that change is
+  cheap *because* it is written against a real package, and it never touches the
+  DOCX pipeline.
+- **Residual monorepo CI coupling (named, not eliminated).** `release.yml`
+  preflight runs `npm run build`, `npm run test`, and `npm run lint:workspaces`
+  across *all* workspaces, so once `packages/odf-core` exists its build and tests
+  must stay green for a DOCX release to proceed (same as `ci.yml`). This is
+  *build/test* coupling, not *version/publish* coupling — odf-core never gets a
+  version bump or a publish from the DOCX tag. It is the normal cost of a
+  monorepo and is acceptable: odf-core must keep CI green regardless. The guard
+  and `private: true` close the version/publish coupling, which is the one that
+  forces churn; this build coupling does not force any DOCX version change.
+
+## Migration Plan
+
+Additive. New spec + new guard script + one wire-up line. No version bumps, no
+`release.yml` edits, no ODF code. Rollback = delete the guard + spec; the repo
+returns to its current allowlist-only (latent-coupling) state.
+
+## Open Questions
+
+- Optional preflight hardening: add `^v[0-9]+\.[0-9]+\.[0-9]+` validation on the
+  `workflow_dispatch` `release_tag` input so a manual `odf-v*` dispatch fails
+  with a clear message instead of incidentally via the version-mismatch check.
+  Deferred — it edits `release.yml` and the safe-by-failure behavior already
+  protects against publishing; fold it into the future `release-odf.yml` change.
+- Whether the future `release-odf.yml` should be a sibling workflow or a
+  parameterized reuse of `release.yml` via a matrix — decide when building it,
+  against the real odf-core shape. Not in scope here.
+- Whether the unscoped `odf-mcp` thin entrypoint publishes on the same
+  `odf-v*` track or its own — revisit at publish-time (it depends on whether its
+  version tracks odf-core).

--- a/openspec/changes/add-odf-release-isolation/proposal.md
+++ b/openspec/changes/add-odf-release-isolation/proposal.md
@@ -1,0 +1,77 @@
+# Change: Isolate ODF package releases from the DOCX suite
+
+## Why
+
+The repo will gain `@usejunior/odf-core` and an `odf` MCP backend (see the ODF
+support roadmap). Those packages will start at `0.x` and churn rapidly while the
+DOCX suite (`docx-core`, `docx-mcp`, `google-docs-core`, `safe-docx`,
+`safe-docx-mcpb`) is stable at `0.9.1`.
+
+`release.yml` enforces **suite-wide version lockstep**: the preflight
+"Verify tag matches package suite versions" step fails the release unless the
+`v*.*.*` tag equals every suite package's `version` *and* the
+`safe-docx-mcpb/manifest.json`, `safe-docx/server.json`,
+`safe-docx/.smithery/shttp/manifest.json`, and `gemini-extension.json` versions.
+
+If ODF packages were added to that lockstep, every ODF `0.x` bump would force a
+version bump (and a full re-publish + provenance + MCP-registry round) of the
+stable DOCX suite. That is the rejected option. We need ODF to version
+independently **before any ODF package is published**, so this is a blocker for
+the ODF workstream.
+
+The good news, established by reading the current pipeline: the suite-version
+check and the publish job both iterate **hardcoded allowlists** of the five
+DOCX packages, and the release workflow triggers only on `v*.*.*` tags. A new
+`packages/odf-core` is therefore invisible to the DOCX release today — the
+coupling only appears if someone *adds* ODF to those hardcoded lists. The risk
+is silent regression (a future contributor "completes the set"), not a current
+break.
+
+## What Changes
+
+- Add a **release-isolation capability spec** stating that ODF packages version
+  and publish on their own track, decoupled from the DOCX suite tag.
+- Establish the **`private: true` convention for ODF packages**: every ODF
+  package is born `private` and stays private until the independent ODF release
+  track exists and passes its own preflight. `private` packages build, test, and
+  develop normally in the workspace; npm simply refuses to publish them.
+- Add a **CI guard** (`scripts/check-release-isolation.mjs`, wired into an
+  existing required check) with two assertions:
+  1. **Workflow-snapshot check** — the DOCX package lists hardcoded in
+     `release.yml` (version-pin, duplicate-publish, dry-run pack, and publish)
+     each equal a fixed expected DOCX set. Adding *any* new package (ODF or
+     otherwise) to those lists fails the guard. This directly protects the
+     coupling mechanism — being on a release list — rather than inferring it
+     from a package's `private` flag.
+  2. **ODF-private check** — any workspace package whose name matches `odf` must
+     be `private: true`.
+  Together these make the lockstep coupling impossible to reintroduce by
+  accident without touching `release.yml`'s lists or un-privating an ODF
+  package, both of which now fail CI.
+- **Defer** building the independent ODF release pipeline (`release-odf.yml`)
+  until ODF is a real, functioning package at a genuine publish-readiness gate
+  (post Phase 1). This proposal does **not** build that pipeline and does **not**
+  publish anything; it records the decision and notes that the future track will
+  use a non-colliding `odf-v*` git-tag prefix so it slots in without touching
+  `release.yml`.
+- **No name-squatting.** We do **not** publish a thin/placeholder `odf-mcp`
+  (unscoped) entrypoint to reserve the npm name. ODF packages publish only when
+  they are real, functioning artifacts. This drops the earlier "claim the
+  `odf-mcp` name early" goal — reserve-only publishing is against npm policy and
+  not how we want to claim the brand.
+
+## Impact
+
+- Affected specs: new `release-publishing` capability (additive).
+- Affected code: `scripts/check-release-allowlist.mjs` (new), one wire-up line
+  in the package-level `package.json`/CI lint step that runs it; no change to
+  `release.yml` and no change to any DOCX package version.
+- No ODF package exists yet, so the ODF-private rule is forward-looking policy
+  enforced by the guard rather than an edit to an existing manifest.
+- Out of scope (named, not fixed): `@usejunior/allure-test-factory` is
+  `private: false` yet unpublished (npm 404) and absent from every release list
+  — a pre-existing inconsistency. The guard's workflow-snapshot design tolerates
+  it deliberately (it is not on any release list, so it is not coupling risk);
+  this change does not mark it private or otherwise touch it.
+- Unblocks the ODF workstream: odf-core can be built and merged without any risk
+  of coupling to — or churn on — the stable DOCX release.

--- a/openspec/changes/add-odf-release-isolation/specs/release-publishing/spec.md
+++ b/openspec/changes/add-odf-release-isolation/specs/release-publishing/spec.md
@@ -1,0 +1,66 @@
+## ADDED Requirements
+
+### Requirement: ODF packages release independently of the DOCX suite
+
+The system SHALL version and publish ODF packages (`@usejunior/odf-core` and any
+future ODF package) on a release track that is decoupled from the DOCX suite
+release tag. ODF versions SHALL NOT be required to match the DOCX suite version,
+and an ODF version change SHALL NOT force a version bump or re-publish of any
+DOCX suite package (`docx-core`, `docx-mcp`, `google-docs-core`, `safe-docx`,
+`safe-docx-mcpb`).
+
+This isolation guarantee covers the **version-pin and publish** behavior of the
+DOCX release. It does NOT cover ordinary monorepo CI: the DOCX release preflight
+runs all-workspace build/test/lint, so an ODF package must keep CI green like any
+other workspace member. That is build health, not version/publish coupling.
+
+The DOCX suite release SHALL continue to trigger on `v*.*.*` push tags. The
+future independent ODF release track SHALL own the `odf-v*` tag namespace, which
+does not match the DOCX `v*.*.*` push trigger.
+
+#### Scenario: [ORP-01] ODF version bump does not bump or republish the DOCX suite
+- **WHEN** an ODF package version is changed
+- **THEN** no DOCX suite package version changes and the DOCX version-pin/publish preflight does not require any ODF package to match the tag
+
+#### Scenario: [ORP-02] DOCX release tag ignores ODF packages
+- **WHEN** a `v*.*.*` DOCX release tag is pushed
+- **THEN** the suite-version preflight checks only the DOCX list and does not require any ODF package to match the tag
+
+#### Scenario: [ORP-03] ODF push tag does not trigger the DOCX release
+- **WHEN** a future `odf-v*` tag is pushed for an ODF release
+- **THEN** it does not match the `v*.*.*` push trigger and does not start the DOCX `release.yml` workflow
+
+#### Scenario: [ORP-04] Manual dispatch of an ODF tag fails safely
+- **WHEN** the DOCX `release.yml` is manually dispatched with an `odf-v*` tag
+- **THEN** preflight fails the suite-version check (the tag matches no DOCX package version) before anything is published
+
+### Requirement: ODF packages must be private until their release track exists
+
+The system SHALL require every workspace package whose name matches `odf` to be
+marked `private: true`. ODF packages SHALL remain `private: true` until the
+independent ODF release track (`release-odf.yml`) exists and passes its own
+preflight; only that future change may set an ODF package `private: false`. A
+`private: true` package builds, tests, and is consumed across the workspace
+normally; npm refuses to publish it.
+
+#### Scenario: [ORP-05] ODF core is private until its own publish gate
+- **WHEN** `packages/odf-core` exists before the ODF release track is built
+- **THEN** its `package.json` has `"private": true` and it is not published by the DOCX release
+
+#### Scenario: [ORP-06] A non-private ODF package fails CI
+- **WHEN** a workspace package whose name matches `odf` is not marked `private: true`
+- **THEN** the release-isolation guard exits non-zero and the PR check fails with the offending package name
+
+### Requirement: Release lists are snapshot-guarded against new packages
+
+The system SHALL enforce, in CI, that the hardcoded DOCX package lists in
+`release.yml` (the version-pin list, the duplicate-publish guard list, the
+dry-run pack list, and the publish list) each equal a fixed expected DOCX set.
+If any list gains an unexpected package — ODF or otherwise — the guard SHALL
+fail. This protects the actual coupling mechanism (membership in a release list)
+directly, rather than inferring it from a package's `private` flag, and so does
+not depend on the private-ness of packages that are on no release list.
+
+#### Scenario: [ORP-07] Adding a package to a DOCX release list fails the guard
+- **WHEN** a package name is added to any of the four hardcoded DOCX lists in `release.yml`
+- **THEN** the guard exits non-zero, naming the list and the unexpected package

--- a/openspec/changes/add-odf-release-isolation/tasks.md
+++ b/openspec/changes/add-odf-release-isolation/tasks.md
@@ -1,0 +1,25 @@
+## 1. Release-isolation guard
+- [x] 1.1 Add `scripts/check-release-isolation.mjs`
+- [x] 1.2 Assertion A (workflow-snapshot): encode the four expected DOCX lists (version-pin, duplicate-publish, dry-run pack, publish) as named constants and assert each matches the corresponding hardcoded list in `release.yml`; fail if any new/unexpected package appears in those steps
+- [x] 1.3 Assertion B (ODF-private): enumerate workspace packages by reading root `package.json` `workspaces` globs and expanding them (NOT `npm query .workspace` — returns `[]` on npm 11.12); assert every package whose name matches `/odf/` is `private: true`
+- [x] 1.4 Emit actionable failure output (offending list/package + remedy) and exit non-zero
+
+## 2. CI wire-up
+- [x] 2.1 Add a `check:release-isolation` script to the root `package.json`
+- [x] 2.2 Run it from the existing workspace-lint required check so it gates every PR
+- [x] 2.3 Confirm it passes on the current tree (workflow lists match snapshot; no `odf`-named package exists yet; `allure-test-factory` is intentionally not in scope)
+
+## 3. Convention documentation
+- [x] 3.1 Document the ODF `private: true` rule and its lifting condition (stays private until `release-odf.yml` exists and passes preflight) in the guard's header and/or `openspec/project.md` conventions
+- [x] 3.2 Note the non-colliding `odf-v*` git-tag prefix for the future independent ODF release track (spec note; no workflow built, no placeholder publish to claim any npm name)
+
+## 4. Verification
+- [x] 4.1 Negative test: a temporary `odf`-named non-private fixture package makes Assertion B fail (then remove the fixture)
+- [x] 4.2 Negative test: adding a fake package to a `release.yml` DOCX list makes Assertion A fail (then restore)
+- [x] 4.3 `release.yml` is unchanged and no DOCX package version is touched (diff review)
+
+## 5. OpenSpec
+- [x] 5.1 Create change proposal
+- [x] 5.2 Create design with the three options and recommendation
+- [x] 5.3 Create `release-publishing` capability spec with scenarios
+- [x] 5.4 `openspec validate add-odf-release-isolation --strict` passes

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
     "check:allure-filenames": "node scripts/check_allure_test_filename_policy.mjs --baseline coverage/allure-test-filename-baseline.json",
     "check:mcpb-manifest": "npm run check:manifest-contract -w @usejunior/safedocx-mcpb",
     "check:gemini-extension-manifest": "node scripts/check_gemini_extension_manifest.mjs",
+    "check:release-isolation": "node scripts/check-release-isolation.mjs",
+    "test:release-isolation": "node --test scripts/check-release-isolation.test.mjs",
     "preflight:ci": "npm run lint:workspaces && npm run check:spec-coverage && npm run check:tool-docs && npm run check:mcpb-manifest && npm run check:gemini-extension-manifest && npm run check:allure-labels && npm run check:allure-filenames && npm run check:allure-quality && npm run check:conformance-citations && npm run check:conformance-doc && npm run check:site && npm run check:cycles",
     "test:coverage:packages": "npm run test:coverage -w @usejunior/docx-core && npm run test:coverage -w @usejunior/docx-mcp",
     "coverage:matrix": "node scripts/print_coverage_matrix.mjs",

--- a/scripts/check-release-isolation.mjs
+++ b/scripts/check-release-isolation.mjs
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+// Release-isolation guard (OpenSpec change: add-odf-release-isolation).
+//
+// Keeps ODF (and any future non-DOCX) packages from being coupled to — or
+// churning — the stable DOCX suite release. Two assertions:
+//
+//   A. Workflow-snapshot: the hardcoded DOCX package lists in
+//      .github/workflows/release.yml must equal a fixed expected set. Adding
+//      ANY package (ODF or otherwise) to a release `for` loop fails the guard.
+//      This guards the actual coupling mechanism (membership in a release list)
+//      rather than inferring it from a package's `private` flag, so it is robust
+//      to packages that are non-private yet on no release list (e.g.
+//      allure-test-factory).
+//
+//   B. ODF-private: every workspace package whose name matches /odf/ must be
+//      `private: true`. ODF packages stay private until the independent ODF
+//      release track (release-odf.yml) exists and passes its own preflight;
+//      only that future change may flip an ODF package to `private: false`.
+//
+// Pure JSON/text inspection — no network, no build. Wired into the
+// workspace-lint required check. Exits non-zero with an actionable message.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..');
+const RELEASE_YML = path.join(REPO_ROOT, '.github', 'workflows', 'release.yml');
+
+// ── Expected snapshot of release.yml's DOCX package loops ──────────────────
+// Each entry is the set of package tokens (`@usejunior/*` and/or `packages/*`)
+// that a `for pkg in ...` / `for entry in ...` loop in release.yml may contain.
+// Update this ONLY when intentionally changing the DOCX release surface — never
+// to admit an ODF package (ODF publishes on its own track, not these loops).
+export const EXPECTED_LOOPS = [
+  // "Verify tag matches package suite versions" (version-pin)
+  [
+    'packages/docx-core',
+    'packages/docx-mcp',
+    'packages/google-docs-core',
+    'packages/safe-docx',
+    'packages/safe-docx-mcpb',
+  ],
+  // "Guard against duplicate publish"
+  [
+    '@usejunior/docx-core',
+    '@usejunior/docx-mcp',
+    '@usejunior/google-docs-core',
+    '@usejunior/safe-docx',
+  ],
+  // "Verify package contents (dry-run)"
+  [
+    'packages/docx-core',
+    'packages/docx-mcp',
+    'packages/google-docs-core',
+    'packages/safe-docx',
+  ],
+  // "Publish to npm (trusted publishing)" — name:dir pairs
+  [
+    '@usejunior/docx-core',
+    '@usejunior/docx-mcp',
+    '@usejunior/google-docs-core',
+    '@usejunior/safe-docx',
+    'packages/docx-core',
+    'packages/docx-mcp',
+    'packages/google-docs-core',
+    'packages/safe-docx',
+  ],
+];
+
+const PKG_TOKEN_RE = /(?:@usejunior\/[a-z0-9.-]+|packages\/[a-z0-9.-]+)/g;
+
+export function canonical(tokens) {
+  return JSON.stringify([...new Set(tokens)].sort());
+}
+
+export function extractReleaseLoops(yml) {
+  // Match the body of every `for pkg in ...; do` / `for entry in ...; do` loop.
+  const loopRe = /for\s+(?:pkg|entry)\s+in\s+([\s\S]*?);\s*do/g;
+  const loops = [];
+  let m;
+  while ((m = loopRe.exec(yml)) !== null) {
+    const tokens = m[1].match(PKG_TOKEN_RE) ?? [];
+    if (tokens.length > 0) loops.push(tokens);
+  }
+  return loops;
+}
+
+// Pure: compare extracted loops against an expected snapshot. Returns string[].
+export function diffWorkflowSnapshot(found, expected = EXPECTED_LOOPS) {
+  const errors = [];
+  if (found.length !== expected.length) {
+    errors.push(
+      `release.yml has ${found.length} package loop(s); expected ${expected.length}. ` +
+        `The release structure changed — re-verify the DOCX surface and update EXPECTED_LOOPS in this guard.`,
+    );
+  }
+
+  const expectedSigs = expected.map(canonical).sort();
+  const foundSigs = found.map(canonical).sort();
+  if (JSON.stringify(expectedSigs) !== JSON.stringify(foundSigs)) {
+    const expectedTokens = new Set(expected.flat());
+    const foundTokens = new Set(found.flat());
+    const unexpected = [...foundTokens].filter((t) => !expectedTokens.has(t)).sort();
+    const missing = [...expectedTokens].filter((t) => !foundTokens.has(t)).sort();
+    if (unexpected.length) {
+      errors.push(
+        `release.yml release loops contain unexpected package(s): ${unexpected.join(', ')}. ` +
+          `ODF and other non-DOCX packages must NOT be added to the DOCX release lists — they publish on their own track.`,
+      );
+    }
+    if (missing.length) {
+      errors.push(
+        `release.yml release loops are missing expected DOCX package(s): ${missing.join(', ')}. ` +
+          `If this is an intentional change to the DOCX surface, update EXPECTED_LOOPS in this guard.`,
+      );
+    }
+    if (!unexpected.length && !missing.length) {
+      errors.push(
+        `release.yml package-loop membership drifted from EXPECTED_LOOPS (a token moved between loops). ` +
+          `Re-verify the DOCX release surface and update the guard.`,
+      );
+    }
+  }
+  return errors;
+}
+
+// fs wrapper around the pure snapshot diff.
+function checkWorkflowSnapshot() {
+  if (!fs.existsSync(RELEASE_YML)) {
+    return [`release.yml not found at ${path.relative(REPO_ROOT, RELEASE_YML)}`];
+  }
+  const yml = fs.readFileSync(RELEASE_YML, 'utf8');
+  return diffWorkflowSnapshot(extractReleaseLoops(yml));
+}
+
+// ── Assertion B: ODF packages must be private ─────────────────────────────
+function readWorkspaceGlobs() {
+  const rootPkg = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, 'package.json'), 'utf8'));
+  const ws = rootPkg.workspaces;
+  if (Array.isArray(ws)) return ws;
+  if (ws && Array.isArray(ws.packages)) return ws.packages;
+  return [];
+}
+
+function expandWorkspacePackages() {
+  const dirs = [];
+  for (const glob of readWorkspaceGlobs()) {
+    if (glob.endsWith('/*')) {
+      const base = path.join(REPO_ROOT, glob.slice(0, -2));
+      if (!fs.existsSync(base)) continue;
+      for (const entry of fs.readdirSync(base, { withFileTypes: true })) {
+        if (!entry.isDirectory()) continue;
+        const pkgJson = path.join(base, entry.name, 'package.json');
+        if (fs.existsSync(pkgJson)) dirs.push(pkgJson);
+      }
+    } else {
+      const pkgJson = path.join(REPO_ROOT, glob, 'package.json');
+      if (fs.existsSync(pkgJson)) dirs.push(pkgJson);
+    }
+  }
+  return dirs;
+}
+
+// Pure: given [{name, private, rel}], return errors for non-private ODF pkgs.
+export function diffOdfPrivate(packages) {
+  const errors = [];
+  for (const pkg of packages) {
+    const name = pkg.name ?? '';
+    if (/odf/i.test(name) && pkg.private !== true) {
+      errors.push(
+        `${pkg.rel} (${name}) must set "private": true. ` +
+          `ODF packages stay private until release-odf.yml exists and passes its own preflight.`,
+      );
+    }
+  }
+  return errors;
+}
+
+function checkOdfPrivate() {
+  const packages = expandWorkspacePackages().map((pkgJsonPath) => {
+    const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
+    return { name: pkg.name, private: pkg.private, rel: path.relative(REPO_ROOT, pkgJsonPath) };
+  });
+  return diffOdfPrivate(packages);
+}
+
+// ── Run (only when invoked directly, not when imported by the test) ─────────
+function main() {
+  const errors = [...checkWorkflowSnapshot(), ...checkOdfPrivate()];
+  if (errors.length) {
+    console.error('Release-isolation guard FAILED:\n');
+    for (const e of errors) console.error(`  - ${e}`);
+    console.error('\nSee openspec/changes/add-odf-release-isolation for the rationale.');
+    process.exit(1);
+  }
+  console.log('Release-isolation guard passed: DOCX release lists match snapshot; no non-private ODF package.');
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/check-release-isolation.test.mjs
+++ b/scripts/check-release-isolation.test.mjs
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  EXPECTED_LOOPS,
+  canonical,
+  diffOdfPrivate,
+  diffWorkflowSnapshot,
+  extractReleaseLoops,
+} from './check-release-isolation.mjs';
+
+// ── extractReleaseLoops ─────────────────────────────────────────────────────
+test('extractReleaseLoops pulls package tokens from for-loops', () => {
+  const yml = [
+    '          for pkg in packages/docx-core packages/safe-docx; do',
+    '          for entry in "@usejunior/docx-core:packages/docx-core"; do',
+    '          for attempt in 1 2 3; do', // not a package loop — yields no tokens
+  ].join('\n');
+  const loops = extractReleaseLoops(yml);
+  assert.deepEqual(loops, [
+    ['packages/docx-core', 'packages/safe-docx'],
+    ['@usejunior/docx-core', 'packages/docx-core'],
+  ]);
+});
+
+// ── diffWorkflowSnapshot ────────────────────────────────────────────────────
+test('snapshot passes when found loops equal expected (order-independent)', () => {
+  const found = [...EXPECTED_LOOPS].reverse().map((l) => [...l].reverse());
+  assert.deepEqual(diffWorkflowSnapshot(found), []);
+});
+
+test('snapshot flags an unexpected ODF package added to a release loop', () => {
+  const found = EXPECTED_LOOPS.map((l) => [...l]);
+  found[1] = [...found[1], '@usejunior/odf-core'];
+  const errors = diffWorkflowSnapshot(found);
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /unexpected package\(s\): @usejunior\/odf-core/);
+});
+
+test('snapshot flags a missing DOCX package', () => {
+  const found = EXPECTED_LOOPS.map((l) => [...l]);
+  found[0] = found[0].filter((t) => t !== 'packages/safe-docx-mcpb');
+  const errors = diffWorkflowSnapshot(found);
+  assert.ok(errors.some((e) => /missing expected DOCX package\(s\): packages\/safe-docx-mcpb/.test(e)));
+});
+
+test('snapshot flags a wrong loop count', () => {
+  const errors = diffWorkflowSnapshot(EXPECTED_LOOPS.slice(0, 3));
+  assert.ok(errors.some((e) => /package loop\(s\); expected 4/.test(e)));
+});
+
+// ── diffOdfPrivate ──────────────────────────────────────────────────────────
+test('odf-private passes for a private ODF package and ignores non-ODF', () => {
+  const errors = diffOdfPrivate([
+    { name: '@usejunior/odf-core', private: true, rel: 'packages/odf-core/package.json' },
+    { name: '@usejunior/allure-test-factory', private: false, rel: 'packages/allure-test-factory/package.json' },
+  ]);
+  assert.deepEqual(errors, []);
+});
+
+test('odf-private flags a non-private ODF package', () => {
+  const errors = diffOdfPrivate([
+    { name: '@usejunior/odf-mcp', private: false, rel: 'packages/odf-mcp/package.json' },
+  ]);
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /odf-mcp.*must set "private": true/);
+});
+
+test('odf-private treats missing private flag as non-private', () => {
+  const errors = diffOdfPrivate([
+    { name: '@usejunior/odf-core', rel: 'packages/odf-core/package.json' },
+  ]);
+  assert.equal(errors.length, 1);
+});
+
+// ── canonical ───────────────────────────────────────────────────────────────
+test('canonical dedupes and sorts', () => {
+  assert.equal(canonical(['b', 'a', 'b']), JSON.stringify(['a', 'b']));
+});


### PR DESCRIPTION
## Summary

ODF packages (`@usejunior/odf-core` + an `odf` MCP backend) are coming and will churn at `0.x` while the DOCX suite stays at `0.9.1`. `release.yml` pins versions and publishes via **four hardcoded DOCX package lists**; if ODF were added to them, every ODF `0.x` bump would force a version bump + re-publish of the stable DOCX suite. **This PR is the blocker-clearing decision before any ODF code lands** (Workstream B, Phase 0).

It does **not** build the independent ODF release pipeline (that's deferred to publish-time, when `odf-core`'s real shape is known). Instead it makes the coupling impossible to reintroduce by accident, with the minimum footprint.

## What's here

- **`scripts/check-release-isolation.mjs`** — wired into the `workspace-lint` required check. Two assertions:
  - **A. Workflow-snapshot** — `release.yml`'s four DOCX package loops (version-pin, duplicate-publish, dry-run pack, publish) must equal a fixed expected set. Adding **any** package (ODF or otherwise) to a release list fails CI. This guards the *actual* coupling mechanism (membership in a release list), so it's robust to packages that are non-private yet on no release list (e.g. `allure-test-factory`).
  - **B. ODF-private** — every workspace package whose name matches `/odf/` must be `private: true`, and stays private until `release-odf.yml` exists and passes its own preflight.
- **`scripts/check-release-isolation.test.mjs`** — unit tests for the guard logic (9 tests, `node:test`).
- **OpenSpec change `add-odf-release-isolation`** — proposal / design (three options weighed) / tasks / `release-publishing` capability spec.

## What's deliberately NOT here

- **No `release.yml` edits, no version bumps, nothing published.**
- The future independent ODF release track will use a non-colliding `odf-v*` git-tag prefix (our own repo's tags — not an external name reservation).
- **No name-squatting** — no placeholder `odf-mcp` publish to reserve the npm name; ODF publishes only when it's a real, functioning package.

## Verification

- [x] Build clean, `lint:workspaces`, `check:spec-coverage`, `check:conformance-citations`, `check:conformance-doc` — all green locally
- [x] Guard passes on the current tree; 9/9 unit tests pass
- [x] Negative tests: an `odf`-named non-private fixture fails assertion B; adding a package to a `release.yml` DOCX list fails assertion A
- [x] `openspec validate add-odf-release-isolation --strict` passes
- [x] `release.yml` unchanged; no DOCX package version touched

## Review notes

Peer-reviewed with Codex (dynamic execution). Four findings incorporated — most notably reframing the guard off an "allowlist-or-private" model that **fails on the current tree** (`allure-test-factory` is non-private but on no release list), and dropping a bogus `npm query .workspace` enumeration (returns `[]` on npm 11.12) in favor of expanding the root `workspaces` glob.