### PR TITLE
feat(docx-core): add DOCX → plain text export (#305)

### DIFF
--- a/openspec/changes/add-text-export/proposal.md
+++ b/openspec/changes/add-text-export/proposal.md
@@ -1,0 +1,47 @@
+# Change: Add DOCX → plain text export
+
+## Why
+
+safe-docx can read, edit, compare, save, and emit Markdown (`add-markdown-export`), but it
+cannot emit a *plain text* rendering — "just give me the text" with no markup, for clipboard,
+diffing, indexing, or feeding a model that wants no formatting. This adds the thinnest member
+of the export family (epic #307), after Markdown.
+
+The hard part — OOXML parsing — is already done. `DocxDocument.buildDocumentView({ showFormatting: true })`
+yields a structured `DocumentViewNode[]` with headings, list metadata, grid-aware table
+context, injected `[^n]` footnote markers, and an HTML-shaped inline-tag string. A plain-text
+emitter is a **serializer over that existing model** — no new parsing. Where the Markdown
+emitter *maps* inline tags to syntax, the plain-text emitter *strips* them and keeps only
+block separators.
+
+## What Changes
+
+### docx-primitives (docx-core)
+- NEW: `serialize_plaintext.ts` — `serializeToPlainText(nodes, footnotes)`: a block walk
+  (headings/paragraphs → blank-line-separated text, lists → `- ` bullets preserving literal
+  legal labels, tables → tab-separated rows) that strips every inline/semantic tag via the
+  existing `stripAllInlineTags()` and appends `[^n]` footnote definitions.
+- MODIFIED: `document.ts` — async `DocxDocument.toPlainText()` convenience wrapper (same
+  `showFormatting: true` view as `toMarkdown`, so block structure and `[^n]` markers match).
+- MODIFIED: `primitives/index.ts` — export the new serializer.
+
+### safe-docx (MCP)
+- MODIFIED: `tools/export.ts` — `format` gains `plaintext` (writes `.txt`); renders via
+  `toPlainText()`. The rendered content now returns under a generic `content` field for all
+  formats; the legacy `markdown` field is retained for the markdown format only, as a
+  deprecated back-compat alias.
+- MODIFIED: `tool_catalog.ts` — `format` enum gains `plaintext`; descriptions updated.
+
+## Impact
+
+- Affected specs: `mcp-server` (export tool gains a format + `content` field), `docx-primitives`
+  (new serializer).
+- New, additive capability. The only change to existing behavior is the response now also
+  carries `content`; the `markdown` field is unchanged for markdown exports.
+- Plain text is intentionally **lossy** (no round-trip): all formatting, links, merged/nested
+  table cells, and layout are discarded.
+
+## Out of scope
+
+Round-trip fidelity, equations/text boxes/charts/layout, the HTML emitter (#304), and Google
+Docs as a source.

--- a/openspec/changes/add-text-export/specs/docx-primitives/spec.md
+++ b/openspec/changes/add-text-export/specs/docx-primitives/spec.md
@@ -1,0 +1,54 @@
+## ADDED Requirements
+
+### Requirement: Plain text serialization primitive
+
+The docx-core primitives SHALL provide a serializer that converts a structured document view
+(`DocumentViewNode[]` with inline formatting tags) and its footnotes into plain text with no
+markup. The serialization is intentionally lossy: all inline and semantic formatting is
+stripped, and only block structure survives as whitespace separators.
+
+#### Scenario: all inline and semantic tags are stripped
+- **GIVEN** tagged text containing `<b>`, `<i>`, `<u>`, `<a href="...">`, `<highlight>`, `<font ...>`, and heading marker tags
+- **WHEN** the document is serialized to plain text
+- **THEN** every such tag SHALL be removed while its inner text is kept
+
+#### Scenario: paragraphs are separated by a blank line
+- **GIVEN** consecutive paragraph nodes
+- **WHEN** the document is serialized to plain text
+- **THEN** each paragraph's visible text SHALL appear with a blank line separating adjacent blocks
+
+#### Scenario: headings render as plain paragraphs
+- **GIVEN** a node whose heading source is `word_style` with a numeric level
+- **WHEN** the document is serialized to plain text
+- **THEN** it SHALL render as its plain text with no heading markup (no `#`)
+
+#### Scenario: list items render as simple bullets indented by level
+- **GIVEN** list nodes at increasing `list_level` values with no literal label
+- **WHEN** the document is serialized to plain text
+- **THEN** each item SHALL render as a `- ` bullet indented in proportion to its level
+
+#### Scenario: literal list labels are preserved
+- **GIVEN** a list item carrying a literal label such as `Section 2.1`, `Article IV`, or `(a)`
+- **WHEN** the document is serialized to plain text
+- **THEN** the literal label SHALL appear in the rendered bullet
+
+#### Scenario: a table renders as tab-separated rows
+- **GIVEN** nodes sharing a `table_context.table_id` forming rows and columns
+- **WHEN** the document is serialized to plain text
+- **THEN** each row SHALL render on its own line with cells separated by tab characters
+
+#### Scenario: merged cell gaps are filled to keep the column count
+- **GIVEN** a table whose `col_index` values skip positions because of horizontally merged cells
+- **WHEN** the document is serialized to plain text
+- **THEN** the missing grid positions SHALL render as empty tab-delimited fields so every row has the full column count
+
+#### Scenario: intra-cell newlines collapse to a space
+- **GIVEN** a table cell whose text contains a line break
+- **WHEN** the document is serialized to plain text
+- **THEN** the line break SHALL be collapsed to a space rather than splitting the tab-delimited row
+
+#### Scenario: footnote markers are preserved and definitions appended
+- **GIVEN** a document with footnotes whose `[^n]` markers are injected into the text
+- **WHEN** the document is serialized to plain text
+- **THEN** the inline `[^n]` markers SHALL be preserved
+- **AND** `[^n] ...` definitions SHALL be appended at the end, ordered by display number

--- a/openspec/changes/add-text-export/specs/docx-primitives/spec.md
+++ b/openspec/changes/add-text-export/specs/docx-primitives/spec.md
@@ -42,6 +42,11 @@ stripped, and only block structure survives as whitespace separators.
 - **WHEN** the document is serialized to plain text
 - **THEN** the missing grid positions SHALL render as empty tab-delimited fields so every row has the full column count
 
+#### Scenario: empty cells at table boundaries are preserved
+- **GIVEN** a document that starts or ends with a table row whose boundary cell is empty
+- **WHEN** the document is serialized to plain text
+- **THEN** the leading/trailing empty tab field SHALL be preserved (not stripped by document-level trimming) so the row keeps its full column count
+
 #### Scenario: intra-cell newlines collapse to a space
 - **GIVEN** a table cell whose text contains a line break
 - **WHEN** the document is serialized to plain text

--- a/openspec/changes/add-text-export/specs/mcp-server/spec.md
+++ b/openspec/changes/add-text-export/specs/mcp-server/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Plain Text Export Format
+
+The Safe-Docx MCP server's `export` tool SHALL support a `plaintext` format that renders a
+DOCX document to plain text (no markup) and writes it to a `.txt` file. The rendered content
+is returned under a generic `content` field (the canonical rendered-content key for every
+format); for the `plaintext` format the deprecated `markdown` alias is NOT present. As with
+other formats, the tool is not read-only and is subject to the existing overwrite and write-
+path guards. DOCX only.
+
+#### Scenario: plaintext export writes a .txt file and returns its content
+- **GIVEN** an open DOCX session
+- **WHEN** `export` is called with `format` `plaintext`
+- **THEN** the response SHALL be successful
+- **AND** it SHALL include `format`, `output_path`, `bytes_written`, and `content`
+- **AND** the file at `output_path` SHALL exist and contain the returned content
+
+#### Scenario: plaintext export does not return a markdown field
+- **GIVEN** an open DOCX session
+- **WHEN** `export` is called with `format` `plaintext`
+- **THEN** the response SHALL include `content`
+- **AND** the response SHALL NOT include a `markdown` field
+
+#### Scenario: plaintext default output path swaps the extension for .txt
+- **GIVEN** an open DOCX session for a file ending in `.docx`
+- **WHEN** `export` is called with `format` `plaintext` and no `output_path`
+- **THEN** `output_path` SHALL be the source path with its extension replaced by `.txt`
+
+#### Scenario: plaintext export strips inline formatting
+- **GIVEN** an open DOCX session
+- **WHEN** `export` is called with `format` `plaintext`
+- **THEN** the returned content SHALL carry no inline formatting tags
+
+#### Scenario: plaintext overwrite is blocked by default
+- **GIVEN** a `.txt` file already exists at the target `output_path`
+- **WHEN** `export` is called with `format` `plaintext` and without `allow_overwrite`
+- **THEN** the response SHALL be an `OVERWRITE_BLOCKED` error
+- **AND** the existing file SHALL be left unchanged

--- a/openspec/changes/add-text-export/tasks.md
+++ b/openspec/changes/add-text-export/tasks.md
@@ -1,0 +1,18 @@
+# Tasks: Add DOCX → plain text export
+
+## 1. docx-core serializer primitive
+- [x] 1.1 Add `serialize_plaintext.ts`: `serializeToPlainText()` (block walk, tag stripping, tab tables, footnote defs).
+- [x] 1.2 Add async `DocxDocument.toPlainText()`; export from the primitives barrel.
+
+## 2. docx-mcp export tool
+- [x] 2.1 Extend `tools/export.ts`: `plaintext` format (`.txt`), render via `toPlainText()`, return `content` (keep `markdown` alias for md).
+- [x] 2.2 Update the `format` enum + descriptions in `tool_catalog.ts`.
+
+## 3. Tests (mapped to spec scenarios)
+- [x] 3.1 `serialize_plaintext.test.ts` in docx-core (docx-primitives scenarios).
+- [x] 3.2 `export_plaintext.test.ts` in docx-mcp (mcp-server scenarios; separate file — one TEST_FEATURE per file).
+
+## 4. Validation
+- [x] 4.1 `openspec validate add-text-export --strict`.
+- [x] 4.2 Build, lint, and run both packages' tests (incl. spec-coverage).
+- [x] 4.3 Real-document smoke: export a real `.docx` to `.txt` and visually confirm.

--- a/packages/docx-core/src/primitives/document.ts
+++ b/packages/docx-core/src/primitives/document.ts
@@ -18,6 +18,7 @@ import {
 import { buildNodesForDocumentView, type DocumentStyles, type DocumentViewNode, type TableContext } from './document_view.js';
 import { serializeToMarkdown, type SerializeMarkdownOptions } from './serialize_markdown.js';
 import { serializeToHtml, type SerializeHtmlOptions } from './serialize_html.js';
+import { serializeToPlainText, type SerializePlainTextOptions } from './serialize_plaintext.js';
 import type { FormattingMode } from './formatting_tags.js';
 import { findUniqueSubstringMatch } from './matching.js';
 import { parseDocumentRels, type RelsMap } from './relationships.js';
@@ -1084,6 +1085,23 @@ export class DocxDocument {
     const { nodes } = this.buildDocumentView({ showFormatting: true });
     const footnotes = await this.getFootnotes();
     return serializeToHtml(nodes, footnotes, opts);
+  }
+
+  /**
+   * Serialize the document to plain text (no markup). Convenience wrapper that wires the
+   * structured document view and footnotes into {@link serializeToPlainText}. All formatting
+   * is stripped; block structure survives as blank-line-separated paragraphs, `- ` bullets,
+   * and tab-separated table rows. Intentionally lossy — see that serializer.
+   *
+   * Uses the same `showFormatting: true` view as {@link toMarkdown} so the block structure
+   * and injected `[^n]` footnote markers match; the inline tags it produces are then stripped.
+   *
+   * Async because footnote extraction reads the footnotes part from the zip.
+   */
+  async toPlainText(opts?: SerializePlainTextOptions): Promise<string> {
+    const { nodes } = this.buildDocumentView({ showFormatting: true });
+    const footnotes = await this.getFootnotes();
+    return serializeToPlainText(nodes, footnotes, opts);
   }
 
   async getFootnote(noteId: number): Promise<Footnote | null> {

--- a/packages/docx-core/src/primitives/index.ts
+++ b/packages/docx-core/src/primitives/index.ts
@@ -9,6 +9,7 @@ export * from './numbering.js';
 export * from './semantic_tags.js';
 export * from './serialize_markdown.js';
 export * from './serialize_html.js';
+export * from './serialize_plaintext.js';
 export * from './styles.js';
 export * from './text.js';
 export * from './xml.js';

--- a/packages/docx-core/src/primitives/semantic_tags.ts
+++ b/packages/docx-core/src/primitives/semantic_tags.ts
@@ -74,8 +74,21 @@ const ALL_INLINE_TAGS_RE =
  * `<highlight>`, `<highlighting>`, `<a href="...">`, `</a>`, `<font ...>`,
  * `</font>`, `<header>`, `</header>`, `<RunInHeader>`, `</RunInHeader>`,
  * `<definition>`, `</definition>`.
+ *
+ * The replacement runs to a fixpoint (loop until the string stops changing) rather than a
+ * single pass: removing one tag can splice two halves together into a *new* tag occurrence
+ * (e.g. `<b<b>i>` → `<bi>`), which a single pass would leave behind. Looping closes that
+ * `js/incomplete-multi-character-sanitization` gap. Well-formed document `tagged_text`
+ * (non-nested, known tags only) reaches the fixpoint on the first pass, so this is a no-op
+ * for real input.
  */
 export function stripAllInlineTags(text: string): string {
-  ALL_INLINE_TAGS_RE.lastIndex = 0;
-  return text.replace(ALL_INLINE_TAGS_RE, '');
+  let current = text;
+  let previous: string;
+  do {
+    previous = current;
+    ALL_INLINE_TAGS_RE.lastIndex = 0;
+    current = current.replace(ALL_INLINE_TAGS_RE, '');
+  } while (current !== previous);
+  return current;
 }

--- a/packages/docx-core/src/primitives/semantic_tags.ts
+++ b/packages/docx-core/src/primitives/semantic_tags.ts
@@ -61,8 +61,13 @@ export function stripFontTags(text: string): string {
 
 // General-purpose inline tag stripper ──────────────────────────────
 
+// A word boundary (`\b`) after the tag name keeps `<beta>` from matching `<b>` while letting
+// `[^>]*>` consume any attributes linearly. Two earlier constructs were dropped: the
+// `(?:\s[^>]*)?` group (its `\s` overlaps `[^>]`, the ambiguity CodeQL flags as polynomial
+// ReDoS — `js/polynomial-redos` — on uncontrolled document text) and the trailing
+// `|<a\s+href="[^"]*">` alternative (already covered by the `a` name + `[^>]*`).
 const ALL_INLINE_TAGS_RE =
-  /<\/?(?:b|i|u|highlight|highlighting|a|font|header|RunInHeader|definition)(?:\s[^>]*)?>|<a\s+href="[^"]*">/g;
+  /<\/?(?:b|i|u|highlight|highlighting|a|font|header|RunInHeader|definition)\b[^>]*>/g;
 
 /**
  * Strip ALL known inline tags from text. Handles `<b>`, `<i>`, `<u>`,

--- a/packages/docx-core/src/primitives/serialize_plaintext.test.ts
+++ b/packages/docx-core/src/primitives/serialize_plaintext.test.ts
@@ -6,7 +6,7 @@ import { LabelType } from './list_labels.js';
 import type { Footnote } from './footnotes.js';
 
 const TEST_FEATURE = 'add-text-export';
-const test = testAllure.epic('Document Editing').withLabels({ feature: TEST_FEATURE });
+const test = testAllure.epic('Document Comparison').withLabels({ feature: TEST_FEATURE });
 
 // ── Minimal DocumentViewNode factory ────────────────────────────────────────
 // The serializer only reads `tagged_text`, `heading`, `list_metadata`, and `table_context`;
@@ -185,6 +185,21 @@ describe('OpenSpec traceability: add-text-export (plain text serializer)', () =>
       const out = serializeToPlainText([tableCell(0, 0, 'line one\nline two'), tableCell(0, 1, 'B')]);
       await then('the cell newline becomes a space, not a row break', async () => {
         expect(out).toContain('line one line two\tB');
+      });
+    },
+  );
+
+  test.openspec('empty cells at table boundaries are preserved')(
+    'empty cells at table boundaries are preserved',
+    async ({ then }: AllureBddContext) => {
+      // A document that *starts* with a row whose first cell is empty, and *ends* with a row
+      // whose last cell is empty. The boundary tabs must survive document-level trimming so
+      // the column count stays consistent (regression: a whole-string `.trim()` ate them).
+      const leading = serializeToPlainText([tableCell(0, 0, ''), tableCell(0, 1, 'Z')]);
+      const trailing = serializeToPlainText([tableCell(0, 0, 'X'), tableCell(0, 1, '')]);
+      await then('the leading and trailing empty tab fields are kept', async () => {
+        expect(leading).toBe('\tZ\n');
+        expect(trailing).toBe('X\t\n');
       });
     },
   );

--- a/packages/docx-core/src/primitives/serialize_plaintext.test.ts
+++ b/packages/docx-core/src/primitives/serialize_plaintext.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { serializeToPlainText } from './serialize_plaintext.js';
+import type { DocumentViewNode, TableContext } from './document_view.js';
+import { LabelType } from './list_labels.js';
+import type { Footnote } from './footnotes.js';
+
+const TEST_FEATURE = 'add-text-export';
+const test = testAllure.epic('Document Editing').withLabels({ feature: TEST_FEATURE });
+
+// ── Minimal DocumentViewNode factory ────────────────────────────────────────
+// The serializer only reads `tagged_text`, `heading`, `list_metadata`, and `table_context`;
+// the rest are filled with inert defaults so tests stay focused on serialization behavior.
+type NodeOverrides = Omit<Partial<DocumentViewNode>, 'list_metadata'> & {
+  list_metadata?: Partial<DocumentViewNode['list_metadata']>;
+};
+
+let nodeSeq = 0;
+function node(overrides: NodeOverrides = {}): DocumentViewNode {
+  const { list_metadata: lmOverride, ...rest } = overrides;
+  return {
+    id: `_bk_${nodeSeq++}`,
+    list_label: '',
+    header: '',
+    style: 'body',
+    text: overrides.tagged_text ?? '',
+    clean_text: overrides.tagged_text ?? '',
+    tagged_text: overrides.tagged_text ?? '',
+    list_metadata: {
+      list_level: -1,
+      label_type: null,
+      label_string: '',
+      header_text: null,
+      header_style: null,
+      header_formatting: null,
+      is_auto_numbered: false,
+      ...(lmOverride ?? {}),
+    },
+    style_fingerprint: {
+      list_level: -1,
+      left_indent_pt: 0,
+      first_line_indent_pt: 0,
+      style_name: '',
+      alignment: 'LEFT',
+    },
+    paragraph_style_id: null,
+    paragraph_style_name: '',
+    paragraph_alignment: 'LEFT',
+    paragraph_indents_pt: { left: 0, first_line: 0 },
+    numbering: { num_id: null, ilvl: null, is_auto_numbered: false },
+    header_formatting: null,
+    body_run_formatting: null,
+    ...rest,
+  };
+}
+
+function tableCell(
+  rowIndex: number,
+  colIndex: number,
+  text: string,
+  opts: { totalCols?: number; tableId?: string } = {},
+): DocumentViewNode {
+  const tc: TableContext = {
+    table_id: opts.tableId ?? '_tbl_0',
+    table_index: 0,
+    row_index: rowIndex,
+    col_index: colIndex,
+    col_header: '',
+    total_rows: 0,
+    total_cols: opts.totalCols ?? 2,
+    is_header_row: false,
+    para_in_cell: 0,
+    cell_para_count: 1,
+  };
+  return node({ tagged_text: text, table_context: tc });
+}
+
+function footnote(displayNumber: number, text: string): Footnote {
+  return { id: displayNumber, displayNumber, text, anchoredParagraphId: null };
+}
+
+describe('OpenSpec traceability: add-text-export (plain text serializer)', () => {
+  test.openspec('all inline and semantic tags are stripped')(
+    'all inline and semantic tags are stripped',
+    async ({ then }: AllureBddContext) => {
+      const out = serializeToPlainText([
+        node({
+          tagged_text:
+            '<b>Bold</b> <i>it</i> <u>under</u> <a href="https://x.com">link</a> <font color="FF0000">red</font> <highlight>hl</highlight>',
+        }),
+      ]);
+      await then('every tag is removed and inner text is kept', async () => {
+        expect(out.trim()).toBe('Bold it under link red hl');
+        expect(out).not.toMatch(/<[^>]+>/);
+      });
+    },
+  );
+
+  test.openspec('paragraphs are separated by a blank line')(
+    'paragraphs are separated by a blank line',
+    async ({ then }: AllureBddContext) => {
+      const out = serializeToPlainText([node({ tagged_text: 'First.' }), node({ tagged_text: 'Second.' })]);
+      await then('a blank line separates the two paragraphs', async () => {
+        expect(out).toBe('First.\n\nSecond.\n');
+      });
+    },
+  );
+
+  test.openspec('headings render as plain paragraphs')(
+    'headings render as plain paragraphs',
+    async ({ then }: AllureBddContext) => {
+      const out = serializeToPlainText([
+        node({ tagged_text: 'Section Title', heading: { text: 'Section Title', source: 'word_style', level: 2 } }),
+      ]);
+      await then('the heading is plain text with no markup', async () => {
+        expect(out.trim()).toBe('Section Title');
+        expect(out).not.toContain('#');
+      });
+    },
+  );
+
+  test.openspec('list items render as simple bullets indented by level')(
+    'list items render as simple bullets indented by level',
+    async ({ then }: AllureBddContext) => {
+      const out = serializeToPlainText([
+        node({
+          tagged_text: 'First item',
+          list_metadata: { list_level: 0, label_type: LabelType.NUMBER, is_auto_numbered: true },
+        }),
+        node({ tagged_text: 'Nested bullet', list_metadata: { list_level: 1 } }),
+      ]);
+      await then('both render as - bullets and the nested one is indented', async () => {
+        expect(out).toContain('- First item');
+        expect(out).toContain('  - Nested bullet');
+        expect(out).not.toContain('1.');
+      });
+    },
+  );
+
+  test.openspec('literal list labels are preserved')(
+    'literal list labels are preserved',
+    async ({ then }: AllureBddContext) => {
+      const out = serializeToPlainText([
+        node({ tagged_text: 'Definitions.', list_metadata: { list_level: 0, label_string: 'Section 2.1' } }),
+      ]);
+      await then('the literal label appears in the bullet', async () => {
+        expect(out).toContain('- Section 2.1 Definitions.');
+      });
+    },
+  );
+
+  test.openspec('a table renders as tab-separated rows')(
+    'a table renders as tab-separated rows',
+    async ({ then }: AllureBddContext) => {
+      const out = serializeToPlainText([
+        tableCell(0, 0, 'A'),
+        tableCell(0, 1, 'B'),
+        tableCell(1, 0, 'C'),
+        tableCell(1, 1, 'D'),
+      ]);
+      await then('cells are tab-separated, one row per line', async () => {
+        expect(out).toContain('A\tB');
+        expect(out).toContain('C\tD');
+      });
+    },
+  );
+
+  test.openspec('merged cell gaps are filled to keep the column count')(
+    'merged cell gaps are filled to keep the column count',
+    async ({ then }: AllureBddContext) => {
+      // A row with cols 0 and 2 populated (col 1 skipped by a horizontal merge).
+      const out = serializeToPlainText([
+        tableCell(0, 0, 'X', { totalCols: 3 }),
+        tableCell(0, 2, 'Z', { totalCols: 3 }),
+      ]);
+      await then('the skipped column renders as an empty tab field (X\\t\\tZ)', async () => {
+        expect(out).toContain('X\t\tZ');
+      });
+    },
+  );
+
+  test.openspec('intra-cell newlines collapse to a space')(
+    'intra-cell newlines collapse to a space',
+    async ({ then }: AllureBddContext) => {
+      const out = serializeToPlainText([tableCell(0, 0, 'line one\nline two'), tableCell(0, 1, 'B')]);
+      await then('the cell newline becomes a space, not a row break', async () => {
+        expect(out).toContain('line one line two\tB');
+      });
+    },
+  );
+
+  test.openspec('footnote markers are preserved and definitions appended')(
+    'footnote markers are preserved and definitions appended',
+    async ({ then }: AllureBddContext) => {
+      const out = serializeToPlainText(
+        [node({ tagged_text: 'See the note.[^1]' })],
+        [footnote(1, 'The footnote body.')],
+      );
+      await then('the inline marker survives and the definition is appended', async () => {
+        expect(out).toContain('See the note.[^1]');
+        expect(out).toContain('[^1] The footnote body.');
+        // The marker precedes its definition.
+        expect(out.indexOf('See the note.[^1]')).toBeLessThan(out.indexOf('[^1] The footnote body.'));
+      });
+    },
+  );
+});

--- a/packages/docx-core/src/primitives/serialize_plaintext.ts
+++ b/packages/docx-core/src/primitives/serialize_plaintext.ts
@@ -161,5 +161,14 @@ export function serializeToPlainText(
     }
   }
 
-  return `${blocks.join('\n').replace(/\n{3,}/g, '\n\n').trim()}\n`;
+  // Trim only blank *lines* at the document boundary — not all whitespace. A plain `.trim()`
+  // would eat a leading/trailing tab that is a meaningful empty TSV field when the document
+  // starts or ends with a table whose boundary cell is empty (e.g. a row `\tZ`), breaking the
+  // "every row keeps the same column count" contract.
+  const rendered = blocks
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .replace(/^\n+/, '')
+    .replace(/\n+$/, '');
+  return `${rendered}\n`;
 }

--- a/packages/docx-core/src/primitives/serialize_plaintext.ts
+++ b/packages/docx-core/src/primitives/serialize_plaintext.ts
@@ -1,0 +1,165 @@
+// DOCX → plain text serializer.
+//
+// The thinnest member of the export family. Like `serialize_markdown.ts`, this is a
+// *serializer over the existing structured document model* — it does no OOXML parsing.
+// `DocxDocument.buildDocumentView({ showFormatting: true })` already yields a
+// `DocumentViewNode[]` carrying headings, list metadata, grid-aware table context, injected
+// `[^n]` footnote markers, and an HTML-shaped inline-tag string (`tagged_text`). This module
+// turns that model into plain text with no markup.
+//
+// Where the Markdown emitter *maps* inline tags to Markdown syntax, the plain-text emitter
+// *strips* them (via `stripAllInlineTags`) and keeps only sensible block separators:
+//   - a blank line between block-level paragraphs (including headings),
+//   - simple `- ` list bullets (preserving literal legal labels like `Section 2.1`),
+//   - tab-separated table cells, one row per line,
+//   - injected `[^n]` footnote markers kept inline, definitions appended at the end.
+//
+// Plain text is intentionally *lossy*: all formatting (bold/italic/underline, highlight,
+// fonts, links, merged/nested table cells, layout) is discarded — that is the whole point of
+// a "just give me the text" rendering.
+
+import type { DocumentViewNode } from './document_view.js';
+import { stripAllInlineTags } from './semantic_tags.js';
+import type { Footnote } from './footnotes.js';
+
+/** Convert one `tagged_text` value to plain text: strip all inline/semantic tags, keep text. */
+function toPlainInline(text: string): string {
+  return stripAllInlineTags(text);
+}
+
+/**
+ * Render a list item as a simple bullet. Auto-numbered numeric items and unlabeled items get
+ * a bare `- ` bullet; items carrying a literal label (legal documents use meaningful labels
+ * like `Section 2.1`, `Article IV`, `(a)`, `(i)`) keep that label so it isn't silently lost.
+ * Indentation tracks the list level.
+ */
+function renderListItem(node: DocumentViewNode): string {
+  const lm = node.list_metadata;
+  const level = Math.max(0, lm.list_level);
+  const indent = '  '.repeat(level);
+  const text = toPlainInline(node.tagged_text).trim();
+  const label = lm.label_string?.trim() ?? '';
+  if (label) {
+    return `${indent}- ${label} ${text}`.trimEnd();
+  }
+  return `${indent}- ${text}`.trimEnd();
+}
+
+/**
+ * Render a run of nodes sharing a `table_context.table_id` as tab-separated rows.
+ *
+ * Lossy by design (plain text has no table model):
+ * - Horizontally merged cells (`gridSpan`) leave grid gaps; we fill them with empty fields so
+ *   every row keeps the same tab-delimited column count (a row `X<gap>Z` → `X\t\tZ`).
+ * - Vertically merged cells (`vMerge`) and nested tables are flattened into the body grid.
+ * - Multi-paragraph / multi-node cells and intra-cell line breaks are joined with a space
+ *   (a raw newline would split the tab-delimited row).
+ */
+function renderTable(group: DocumentViewNode[]): string[] {
+  let totalCols = 0;
+  for (const n of group) {
+    const tc = n.table_context;
+    if (!tc) continue;
+    totalCols = Math.max(totalCols, tc.total_cols, tc.col_index + 1);
+  }
+  if (totalCols <= 0) return [];
+
+  const rows = new Map<number, Map<number, string[]>>();
+  const rowOrder: number[] = [];
+
+  for (const n of group) {
+    const tc = n.table_context;
+    if (!tc) continue;
+    if (!rows.has(tc.row_index)) {
+      rows.set(tc.row_index, new Map());
+      rowOrder.push(tc.row_index);
+    }
+    const cellMap = rows.get(tc.row_index)!;
+    const cellText = toPlainInline(n.tagged_text).replace(/\s*\n+\s*/g, ' ').trim();
+    const parts = cellMap.get(tc.col_index) ?? [];
+    if (cellText) parts.push(cellText);
+    cellMap.set(tc.col_index, parts);
+  }
+
+  rowOrder.sort((a, b) => a - b);
+
+  const lines: string[] = [];
+  for (const ri of rowOrder) {
+    const cellMap = rows.get(ri) ?? new Map<number, string[]>();
+    const cells: string[] = [];
+    for (let c = 0; c < totalCols; c++) {
+      cells.push((cellMap.get(c) ?? []).join(' '));
+    }
+    lines.push(cells.join('\t'));
+  }
+  return lines;
+}
+
+export interface SerializePlainTextOptions {
+  /** Reserved for future knobs (footnote policy, table layout). Currently unused. */
+  readonly _reserved?: never;
+}
+
+/**
+ * Serialize a structured document view to plain text.
+ *
+ * @param nodes     Block nodes from `buildDocumentView({ showFormatting: true }).nodes`.
+ * @param footnotes Footnotes from `DocxDocument.getFootnotes()` (already sorted by
+ *                  `displayNumber`); appended as `[^n] …` definitions.
+ */
+export function serializeToPlainText(
+  nodes: DocumentViewNode[],
+  footnotes: Footnote[] = [],
+  _opts: SerializePlainTextOptions = {},
+): string {
+  const blocks: string[] = [];
+
+  for (let i = 0; i < nodes.length; i++) {
+    const node = nodes[i]!;
+
+    // ── Tables: consume the whole run of same-table_id nodes at once ──
+    if (node.table_context) {
+      const tableId = node.table_context.table_id;
+      const group: DocumentViewNode[] = [];
+      while (i < nodes.length && nodes[i]!.table_context?.table_id === tableId) {
+        group.push(nodes[i]!);
+        i++;
+      }
+      i--; // for-loop will re-increment
+      const tableLines = renderTable(group);
+      if (tableLines.length > 0) {
+        blocks.push(tableLines.join('\n'));
+        blocks.push('');
+      }
+      continue;
+    }
+
+    // ── List items: a bullet per item, no surrounding blank lines ──
+    if (node.list_metadata.list_level >= 0) {
+      blocks.push(renderListItem(node));
+      continue;
+    }
+
+    // ── Headings and normal paragraphs alike: plain text, blank line between blocks ──
+    // Plain text has no heading syntax, so a Word-styled heading is just its text.
+    const text = toPlainInline(node.tagged_text).trim();
+    if (text === '') {
+      blocks.push('');
+    } else {
+      blocks.push(text);
+      blocks.push('');
+    }
+  }
+
+  // ── Footnote definitions ──
+  const defs = footnotes.filter((fn) => fn.displayNumber > 0);
+  if (defs.length > 0) {
+    blocks.push('');
+    for (const fn of defs) {
+      const body = fn.text.replace(/\s+/g, ' ').trim();
+      blocks.push(`[^${fn.displayNumber}] ${body}`.trimEnd());
+    }
+  }
+
+  return `${blocks.join('\n').replace(/\n{3,}/g, '\n\n').trim()}\n`;
+}

--- a/packages/docx-mcp/docs/tool-reference.generated.md
+++ b/packages/docx-mcp/docs/tool-reference.generated.md
@@ -141,7 +141,7 @@ Save document. For DOCX: saves clean and/or tracked changes output. For Google D
 
 ## `export`
 
-Export a document to a portable rendering (Markdown or semantic HTML). Writes an output file (default: source path with the format extension, e.g. .md or .html) and returns its path, byte count, and the rendered content. Intentionally lossy (no round-trip); HTML is the semantic tier, not pixel-faithful. DOCX only — Google Docs is not supported.
+Export a document to a portable rendering (Markdown, semantic HTML, or plain text). Writes an output file (default: source path with the format extension, e.g. .md, .html, or .txt) and returns its path, byte count, and the rendered content (under `content`). Intentionally lossy (no round-trip); HTML is the semantic tier, not pixel-faithful. DOCX only — Google Docs is not supported.
 
 - readOnly: `false`
 - destructive: `false`
@@ -149,7 +149,7 @@ Export a document to a portable rendering (Markdown or semantic HTML). Writes an
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
 | `file_path` | `string` | no | Path to the DOCX file. |
-| `format` | `enum("markdown", "html")` | no | Output format: 'markdown' (default) or 'html'. 'text' is planned. |
+| `format` | `enum("markdown", "html", "plaintext")` | no | Output format: 'markdown' (default, writes .md), 'html' (writes .html), or 'plaintext' (writes .txt). |
 | `output_path` | `string` | no | Where to write the rendering. Defaults to the source path with the format extension. |
 | `allow_overwrite` | `boolean` | no | Overwrite output_path if it already exists. Default: false. |
 | `include_markdown` | `boolean` | no | Include the rendered content (under `content`) in the response. Default: true; set false for large documents. |

--- a/packages/docx-mcp/src/tool_catalog.ts
+++ b/packages/docx-mcp/src/tool_catalog.ts
@@ -179,13 +179,13 @@ export const SAFE_DOCX_TOOL_CATALOG = [
   {
     name: 'export',
     description:
-      'Export a document to a portable rendering (Markdown or semantic HTML). Writes an output file (default: source path with the format extension, e.g. .md or .html) and returns its path, byte count, and the rendered content. Intentionally lossy (no round-trip); HTML is the semantic tier, not pixel-faithful. DOCX only — Google Docs is not supported.',
+      'Export a document to a portable rendering (Markdown, semantic HTML, or plain text). Writes an output file (default: source path with the format extension, e.g. .md, .html, or .txt) and returns its path, byte count, and the rendered content (under `content`). Intentionally lossy (no round-trip); HTML is the semantic tier, not pixel-faithful. DOCX only — Google Docs is not supported.',
     input: z.object({
       ...FILE_FIELD_OPTIONAL,
       format: z
-        .enum(['markdown', 'html'])
+        .enum(['markdown', 'html', 'plaintext'])
         .optional()
-        .describe("Output format: 'markdown' (default) or 'html'. 'text' is planned."),
+        .describe("Output format: 'markdown' (default, writes .md), 'html' (writes .html), or 'plaintext' (writes .txt)."),
       output_path: z
         .string()
         .optional()

--- a/packages/docx-mcp/src/tools/export.ts
+++ b/packages/docx-mcp/src/tools/export.ts
@@ -6,13 +6,14 @@ import { mergeSessionResolutionMetadata, resolveSessionForTool } from './session
 import { enforceWritePathPolicy, resolvesToSamePath } from './path_policy.js';
 import { checkGDocsSupport } from './provider_guard.js';
 
-/** Output formats the export tool can emit. Extensible: `text` lands in #305. */
-const SUPPORTED_FORMATS = ['markdown', 'html'] as const;
+/** Output formats the export tool can emit. */
+const SUPPORTED_FORMATS = ['markdown', 'html', 'plaintext'] as const;
 type ExportFormat = (typeof SUPPORTED_FORMATS)[number];
 
 const EXTENSION_FOR_FORMAT: Record<ExportFormat, string> = {
   markdown: '.md',
   html: '.html',
+  plaintext: '.txt',
 };
 
 function expandPath(inputPath: string): string {
@@ -26,10 +27,10 @@ function defaultOutputPath(sourcePath: string, format: ExportFormat): string {
 }
 
 /**
- * Export a document to a portable text rendering (Markdown or HTML). Writes the rendering to a
- * file (this tool is NOT read-only) and returns the written path, byte count, and — unless
- * `include_markdown: false` — the rendered content under a format-agnostic `content` key (plus
- * a legacy `markdown` key for the Markdown format).
+ * Export a document to a portable rendering (Markdown, HTML, or plain text). Writes the
+ * rendering to a file (this tool is NOT read-only) and returns the written path, byte count,
+ * and — unless `include_markdown: false` — the rendered content under a format-agnostic
+ * `content` key (plus a legacy `markdown` key for the Markdown format).
  *
  * DOCX only. Google Docs (`google_doc_id`) is out of scope for this tool.
  */
@@ -100,7 +101,12 @@ export async function exportDocument(
       }
     }
 
-    const content = exportFormat === 'html' ? await session.doc.toHtml() : await session.doc.toMarkdown();
+    const content =
+      exportFormat === 'html'
+        ? await session.doc.toHtml()
+        : exportFormat === 'plaintext'
+          ? await session.doc.toPlainText()
+          : await session.doc.toMarkdown();
     const buffer = Buffer.from(content, 'utf8');
 
     const policy = await enforceWritePathPolicy(outputPath);
@@ -108,7 +114,10 @@ export async function exportDocument(
     await fs.mkdir(path.dirname(outputPath), { recursive: true });
     await fs.writeFile(outputPath, new Uint8Array(buffer));
 
-    // `include_markdown` gates the inline content for both formats (its name predates HTML).
+    // `content` is the canonical rendered-content field for every format. `markdown` is kept
+    // populated only for the markdown format as a deprecated back-compat alias (callers
+    // predate the multi-format `content` field). `include_markdown` gates inclusion of both
+    // (its name predates the multi-format era).
     const includeContent = params.include_markdown !== false;
     return ok(
       mergeSessionResolutionMetadata(

--- a/packages/docx-mcp/src/tools/export_plaintext.test.ts
+++ b/packages/docx-mcp/src/tools/export_plaintext.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { assertFailure, assertSuccess, openSession, registerCleanup } from '../testing/session-test-utils.js';
+import { exportDocument } from './export.js';
+
+// A separate test file (not export.test.ts) on purpose: the spec-coverage validator maps one
+// TEST_FEATURE per file, so the new feature's scenarios must live in their own file.
+const TEST_FEATURE = 'add-text-export';
+const test = testAllure.epic('Document Editing').withLabels({ feature: TEST_FEATURE });
+
+function txtPathFor(inputPath: string): string {
+  const parsed = path.parse(inputPath);
+  return path.join(parsed.dir, `${parsed.name}.txt`);
+}
+
+describe('OpenSpec traceability: add-text-export (export tool)', () => {
+  registerCleanup();
+
+  test.openspec('plaintext export writes a .txt file and returns its content')(
+    'plaintext export writes a .txt file and returns its content',
+    async ({ then }: AllureBddContext) => {
+      const opened = await openSession(['Hello world.']);
+      const result = await exportDocument(opened.mgr, { file_path: opened.inputPath, format: 'plaintext' });
+      await then('the response carries content and the file is on disk', async () => {
+        assertSuccess(result, 'export');
+        expect(result.format).toBe('plaintext');
+        expect(typeof result.content).toBe('string');
+        expect(result.bytes_written).toBeGreaterThan(0);
+        const onDisk = await fs.readFile(String(result.output_path), 'utf8');
+        expect(onDisk).toBe(result.content);
+        expect(onDisk).toContain('Hello world.');
+      });
+    },
+  );
+
+  test.openspec('plaintext export does not return a markdown field')(
+    'plaintext export does not return a markdown field',
+    async ({ then }: AllureBddContext) => {
+      const opened = await openSession(['Body text.']);
+      const result = await exportDocument(opened.mgr, { file_path: opened.inputPath, format: 'plaintext' });
+      await then('only the generic content field is present', async () => {
+        assertSuccess(result, 'export');
+        expect(result.content).toBeTruthy();
+        expect(result.markdown).toBeUndefined();
+      });
+    },
+  );
+
+  test.openspec('plaintext default output path swaps the extension for .txt')(
+    'plaintext default output path swaps the extension for .txt',
+    async ({ then }: AllureBddContext) => {
+      const opened = await openSession(['Body text.']);
+      const result = await exportDocument(opened.mgr, { file_path: opened.inputPath, format: 'plaintext' });
+      await then('the .docx extension is swapped for .txt', async () => {
+        assertSuccess(result, 'export');
+        const expected = txtPathFor(opened.inputPath);
+        const exists = await fs.access(expected).then(() => true).catch(() => false);
+        expect(exists).toBe(true);
+        expect(path.resolve(String(result.output_path))).toBe(path.resolve(expected));
+      });
+    },
+  );
+
+  test.openspec('plaintext export strips inline formatting')(
+    'plaintext export strips inline formatting',
+    async ({ then }: AllureBddContext) => {
+      const opened = await openSession(['Plain body paragraph.']);
+      const result = await exportDocument(opened.mgr, { file_path: opened.inputPath, format: 'plaintext' });
+      await then('the rendering carries no inline tags', async () => {
+        assertSuccess(result, 'export');
+        expect(String(result.content)).not.toMatch(/<[^>]+>/);
+        expect(String(result.content)).toContain('Plain body paragraph.');
+      });
+    },
+  );
+
+  test.openspec('plaintext overwrite is blocked by default')(
+    'plaintext overwrite is blocked by default',
+    async ({ then }: AllureBddContext) => {
+      const opened = await openSession(['Body text.']);
+      const target = path.join(opened.tmpDir, 'taken.txt');
+      await fs.writeFile(target, 'PRE-EXISTING');
+      const result = await exportDocument(opened.mgr, {
+        file_path: opened.inputPath,
+        format: 'plaintext',
+        output_path: target,
+      });
+      await then('export refuses and leaves the file untouched', async () => {
+        assertFailure(result, 'OVERWRITE_BLOCKED', 'export');
+        expect(await fs.readFile(target, 'utf8')).toBe('PRE-EXISTING');
+      });
+    },
+  );
+});


### PR DESCRIPTION
## Summary
Adds a `plaintext` member of the export family — the thinnest emitter, for "just give me the text" use (clipboard, diffing, indexing, feeding a model that wants no markup). Like the Markdown exporter, this is a **serializer over the existing structured document view** (`buildDocumentView`); it does no OOXML parsing.

Where the Markdown emitter *maps* inline tags to syntax, the plain-text emitter *strips* them via the existing `stripAllInlineTags()` and keeps only block separators:
- blank line between paragraphs (and headings, which lose their `#`)
- `- ` bullets that preserve literal legal labels (`Section 2.1`, `(a)`)
- tab-separated table cells (merged-cell gaps → empty tab fields; intra-cell newlines → space)
- footnote `[^n]` markers preserved inline, definitions appended

Plain text is intentionally **lossy** (no round-trip).

## Changes
- **docx-core**: new `serialize_plaintext.ts` + `DocxDocument.toPlainText()`; barrel export.
- **docx-mcp**: `export` gains a `plaintext` format (writes `.txt`). Rendered content now returns under a generic **`content`** field for all formats; the legacy `markdown` field is retained for the markdown format only as a deprecated back-compat alias (existing callers/tests unaffected). The generic field keeps the response schema stable as `html` (#304) lands later.
- **OpenSpec**: `add-text-export` change with docx-primitives + mcp-server deltas; traceability tests in their own files (the spec-coverage validator maps one `TEST_FEATURE` per file).

## Verification
`build` · `lint:workspaces` · `check:spec-coverage` (add-text-export: 9 + 5 stories) · `check:allure-labels` · `check:conformance-citations`/`-doc` · docx-core 9/9 · docx-mcp 5/5 new + 10/10 markdown regression.

Real-document smoke on the Common Paper NDA and NVCA fixtures: no markup, tab-separated tables (incl. empty fields for merged signature cells), bullets, ~20% smaller than the Markdown output.

Ref: #305