### PR TITLE
chore(deps): declare @xmldom/xmldom + jszip as explicit root devDeps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,10 +15,12 @@
         "@typescript-eslint/eslint-plugin": "^8.56.0",
         "@typescript-eslint/parser": "^8.56.0",
         "@vitest/runner": "4.1.8",
+        "@xmldom/xmldom": "^0.9.10",
         "ajv": "^8.18.0",
         "allure": "3.8.2",
         "eslint": "^10.0.1",
         "fast-xml-parser": "^5.7.0",
+        "jszip": "^3.10.1",
         "madge": "8.0.0",
         "prismjs": "^1.30.0"
       },

--- a/package.json
+++ b/package.json
@@ -75,10 +75,12 @@
     "@typescript-eslint/eslint-plugin": "^8.56.0",
     "@typescript-eslint/parser": "^8.56.0",
     "@vitest/runner": "4.1.8",
+    "@xmldom/xmldom": "^0.9.10",
     "ajv": "^8.18.0",
     "allure": "3.8.2",
     "eslint": "^10.0.1",
     "fast-xml-parser": "^5.7.0",
+    "jszip": "^3.10.1",
     "madge": "8.0.0",
     "prismjs": "^1.30.0"
   },


### PR DESCRIPTION
## What

Adds `@xmldom/xmldom` and `jszip` to the **root** `devDependencies`.

## Why

The spec-traceability PoC scripts landed in #329 (`scripts/spec-traceability/build-wiki.mjs`, `extract-element-definition.mjs`) `import` both packages but resolved them only via workspace hoisting from `@usejunior/docx-core`. A future docx-core dependency change could remove that hoist and silently break the root scripts. Declaring them at the root makes the dependency explicit and self-owned.

## Scope

Both packages already exist in the dependency tree, so the lockfile delta is just the two added **root** references — no new package installs:

```
       "@vitest/runner": "4.1.8",
+      "@xmldom/xmldom": "^0.9.10",
       ...
       "fast-xml-parser": "^5.7.0",
+      "jszip": "^3.10.1",
```

## Verification

- `npm install` → clean; lockfile diff is the two references only.
- `@xmldom/xmldom` + `jszip` resolve from repo root (`DOMParser`/`JSZip` import OK).
- Both scripts pass `node --check`.

Ref: #227