### PR TITLE
feat(docx-mcp): provider-aware ODF (.odt) backend (Phase 1 wiring)

### DIFF
--- a/openspec/changes/add-odf-core/specs/mcp-server/spec.md
+++ b/openspec/changes/add-odf-core/specs/mcp-server/spec.md
@@ -5,8 +5,11 @@
 The MCP server SHALL treat `.odt` as a first-class local provider via a parallel
 resolver lane, leaving the DOCX and Google Docs resolution paths unchanged. An
 `OdfSession` SHALL be a member of the session union. A `.odt` `file_path` SHALL
-auto-open an ODF session on first use (parity with `.docx`), and a request whose
-canonical path already has an `OdfSession` SHALL resolve to it. The `read_file`,
+auto-open an ODF session on first use (parity with `.docx`), and a `.odt` `file_path`
+that resolves to an existing `OdfSession` SHALL reuse it. (Provider dispatch keys on
+the `.odt` file extension for race-free, synchronous routing; reusing an open ODF
+session via an aliased path whose spelling does not end in `.odt` is a Phase-2
+refinement.) The `read_file`,
 `replace_text`, `save`, `get_file_status`, and `close_file` tools SHALL service ODF
 sessions; every other tool invoked against an ODF session (or a `.odt` `file_path`)
 SHALL return an `UNSUPPORTED_FOR_ODF` error rather than running DOCX logic — enforced

--- a/openspec/changes/add-odf-core/specs/mcp-server/spec.md
+++ b/openspec/changes/add-odf-core/specs/mcp-server/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Provider-Aware Local Resolution for `.odt`
+
+The MCP server SHALL treat `.odt` as a first-class local provider via a parallel
+resolver lane, leaving the DOCX and Google Docs resolution paths unchanged. An
+`OdfSession` SHALL be a member of the session union. A `.odt` `file_path` SHALL
+auto-open an ODF session on first use (parity with `.docx`), and a request whose
+canonical path already has an `OdfSession` SHALL resolve to it. The `read_file`,
+`replace_text`, `save`, `get_file_status`, and `close_file` tools SHALL service ODF
+sessions; every other tool invoked against an ODF session (or a `.odt` `file_path`)
+SHALL return an `UNSUPPORTED_FOR_ODF` error rather than running DOCX logic — enforced
+by a provider-check chokepoint in the shared session resolver so unsupported tools
+never reach DOCX-only fields. Genuinely unsupported extensions SHALL still return
+`INVALID_FILE_TYPE`.
+
+#### Scenario: [OPLR-01] Open a local `.odt`
+- **WHEN** `open_document` (or any auto-opening tool) is called with a `.odt` path
+- **THEN** an ODF session is created and a paragraph count / read result is returned
+
+#### Scenario: [OPLR-02] Unsupported extensions still rejected
+- **WHEN** a local-file tool is called with an unsupported extension (e.g. `.rtf`)
+- **THEN** `INVALID_FILE_TYPE` is returned
+
+#### Scenario: [OPLR-03] Supported tools route to the ODF handler
+- **WHEN** `read_file` / `replace_text` / `save` / `get_file_status` / `close_file` is invoked against a path bound to an ODF session
+- **THEN** the ODF handler services it and the DOCX/gdocs handlers are not invoked
+
+#### Scenario: [OPLR-04] Unsupported tools are guarded for ODF
+- **WHEN** a Phase-2 tool (e.g. `compare_documents`, `add_comment`, `insert_paragraph`) is invoked against an ODF session
+- **THEN** an `UNSUPPORTED_FOR_ODF` error is returned and no DOCX logic runs
+
+#### Scenario: [OPLR-05] File-first `.odt` auto-opens
+- **WHEN** `read_file` is called with a `.odt` path and no prior `open_document`
+- **THEN** the ODF session is auto-opened and the read succeeds (DOCX resolver untouched)

--- a/openspec/changes/add-odf-core/specs/odf-core/spec.md
+++ b/openspec/changes/add-odf-core/specs/odf-core/spec.md
@@ -97,38 +97,6 @@ when the ID does not resolve.
 - **WHEN** the match spans multiple `#text` nodes (e.g. across a `text:span`) or includes an expanded `text:s` / `text:tab`
 - **THEN** a `MATCH_SPANS_MULTIPLE_NODES` error is returned and the document is unchanged
 
-### Requirement: Provider-Aware Local Resolution for `.odt`
-
-The MCP server SHALL treat `.odt` as a first-class local provider via a parallel
-resolver, leaving the DOCX and Google Docs resolution paths unchanged. An `OdfSession`
-SHALL be a member of the session union. A `.odt` `file_path` SHALL auto-open an ODF
-session on first use (parity with `.docx`), and a request whose canonical path already
-has an `OdfSession` SHALL resolve to it. The `read_file`, `replace_text`, `save`,
-`get_file_status`, and `close_file` tools SHALL service ODF sessions; every other tool
-invoked against an ODF session SHALL return an `UNSUPPORTED_FOR_ODF` error rather than
-running DOCX logic. Genuinely unsupported extensions SHALL still return
-`INVALID_FILE_TYPE`.
-
-#### Scenario: [OPLR-01] Open a local `.odt`
-- **WHEN** `open_document` (or any auto-opening tool) is called with a `.odt` path
-- **THEN** an ODF session is created and a paragraph count / read result is returned
-
-#### Scenario: [OPLR-02] Unsupported extensions still rejected
-- **WHEN** a local-file tool is called with an unsupported extension (e.g. `.rtf`)
-- **THEN** `INVALID_FILE_TYPE` is returned
-
-#### Scenario: [OPLR-03] Supported tools route to the ODF handler
-- **WHEN** `read_file` / `replace_text` / `save` / `get_file_status` / `close_file` is invoked against a path bound to an ODF session
-- **THEN** the ODF handler services it and the DOCX/gdocs handlers are not invoked
-
-#### Scenario: [OPLR-04] Unsupported tools are guarded for ODF
-- **WHEN** a Phase-2 tool (e.g. `compare_documents`, `add_comment`, `insert_paragraph`) is invoked against an ODF session
-- **THEN** an `UNSUPPORTED_FOR_ODF` error is returned and no DOCX logic runs
-
-#### Scenario: [OPLR-05] File-first `.odt` auto-opens
-- **WHEN** `read_file` is called with a `.odt` path and no prior `open_document`
-- **THEN** the ODF session is auto-opened and the read succeeds (DOCX resolver untouched)
-
 ### Requirement: ODF Round-Trip Safety
 
 After an open → replace_text → save → reopen cycle, the system SHALL guarantee

--- a/package-lock.json
+++ b/package-lock.json
@@ -9437,6 +9437,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@usejunior/docx-core": "^0.9.1",
+        "@usejunior/odf-core": "^0.9.1",
         "@xmldom/xmldom": "^0.9.10",
         "zod": "^4.3.6"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9437,7 +9437,6 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@usejunior/docx-core": "^0.9.1",
-        "@usejunior/odf-core": "^0.9.1",
         "@xmldom/xmldom": "^0.9.10",
         "zod": "^4.3.6"
       },

--- a/packages/docx-mcp/docs/tool-reference.generated.md
+++ b/packages/docx-mcp/docs/tool-reference.generated.md
@@ -7,14 +7,14 @@ Do not edit manually. Regenerate with:
 
 ## `read_file`
 
-Read document content (DOCX or Google Doc). Output is token-limited (~14k tokens) by default with pagination metadata (has_more, next_offset). Use offset/limit to paginate.
+Read document content (DOCX, ODT, or Google Doc). Output is token-limited (~14k tokens) by default with pagination metadata (has_more, next_offset). Use offset/limit to paginate.
 
 - readOnly: `true`
 - destructive: `false`
 
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
-| `file_path` | `string` | no | Path to the DOCX file. |
+| `file_path` | `string` | no | Path to the DOCX or ODT file. |
 | `google_doc_id` | `string` | no | Google Doc ID or URL (alternative to file_path). Extract from URL: docs.google.com/document/d/{ID}/edit |
 | `offset` | `number` | no | 1-based paragraph offset for pagination. Negative values count from end. |
 | `limit` | `number` | no | Max paragraphs to return. When omitted, output is token-limited to ~14k tokens with pagination. |
@@ -22,7 +22,7 @@ Read document content (DOCX or Google Doc). Output is token-limited (~14k tokens
 | `format` | `enum("toon", "json", "simple")` | no |  |
 | `comment_rendering` | `enum("none", "paragraph_notes", "endnotes", "inline_markers")` | no | How to render comments in read_file output. Use "paragraph_notes" (default) for paragraph-local comment threads, "inline_markers" to add `[cm-start:N]`/`[cm-end:N]` milestones in TOON output (combined with the thread blocks), "endnotes" to collect threaded comments into a trailing #COMMENTS block in TOON output, or "none" for the legacy output with no comment rendering. |
 | `show_formatting` | `boolean` | no | When true (default), shows inline formatting tags (<b>, <i>, <u>, <highlighting>, <a>). When false, emits plain text with no inline tags. |
-| `include_fingerprint` | `boolean` | no | When true and format="json", include a portable content_fingerprint ("sha256:nfkc:<32hex>") on each paragraph. Read-only metadata derived from the paragraph's normalized visible text; NOT an edit anchor. Edit tools accept only `_bk_*` IDs. No effect on TOON/simple output. Ignored for Google Docs. |
+| `include_fingerprint` | `boolean` | no | When true and format="json", include a portable content_fingerprint ("sha256:nfkc:<32hex>") on each paragraph. Read-only metadata derived from the paragraph's normalized visible text; NOT an edit anchor. Edit tools accept only `_bk_*` IDs. No effect on TOON/simple output. Ignored for Google Docs and ODT. |
 
 ## `grep`
 
@@ -33,7 +33,7 @@ Search paragraphs with regex. Use file_path for session-based search, file_paths
 
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
-| `file_path` | `string` | no | Path to the DOCX file. |
+| `file_path` | `string` | no | Path to the DOCX or ODT file. |
 | `google_doc_id` | `string` | no | Google Doc ID or URL (alternative to file_path). Extract from URL: docs.google.com/document/d/{ID}/edit |
 | `file_paths` | `array<string>` | no | Multiple file paths for stateless multi-file search. No session created. |
 | `patterns` | `array<string>` | no |  |
@@ -55,7 +55,7 @@ Initialize revision-bound context metadata for coordinated multi-agent planning.
 
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
-| `file_path` | `string` | yes | Path to the DOCX file. |
+| `file_path` | `string` | yes | Path to the DOCX or ODT file. |
 | `plan_name` | `string` | no |  |
 | `orchestrator_id` | `string` | no |  |
 
@@ -81,20 +81,20 @@ Validate and apply a batch of edit steps (replace_text, insert_paragraph) to a d
 
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
-| `file_path` | `string` | yes | Path to the DOCX file. |
+| `file_path` | `string` | yes | Path to the DOCX or ODT file. |
 | `steps` | `array<object>` | no | JSON array of edit steps. Each step needs step_id, operation, and operation-specific fields. |
 | `plan_file_path` | `string` | no | Path to a .json file containing an array of edit steps. Mutually exclusive with steps. |
 
 ## `replace_text`
 
-Replace text in a paragraph by _bk_* id, preserving formatting. Supports DOCX and Google Docs.
+Replace text in a paragraph by provider paragraph id, preserving formatting where supported. Supports DOCX, ODT, and Google Docs.
 
 - readOnly: `false`
 - destructive: `true`
 
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
-| `file_path` | `string` | no | Path to the DOCX file. |
+| `file_path` | `string` | no | Path to the DOCX or ODT file. |
 | `google_doc_id` | `string` | no | Google Doc ID or URL (alternative to file_path). Extract from URL: docs.google.com/document/d/{ID}/edit |
 | `target_paragraph_id` | `string` | yes |  |
 | `old_string` | `string` | yes |  |
@@ -111,7 +111,7 @@ Insert a paragraph before/after an anchor paragraph by _bk_* id. Supports DOCX a
 
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
-| `file_path` | `string` | no | Path to the DOCX file. |
+| `file_path` | `string` | no | Path to the DOCX or ODT file. |
 | `google_doc_id` | `string` | no | Google Doc ID or URL (alternative to file_path). Extract from URL: docs.google.com/document/d/{ID}/edit |
 | `positional_anchor_node_id` | `string` | yes |  |
 | `new_string` | `string` | yes |  |
@@ -121,14 +121,14 @@ Insert a paragraph before/after an anchor paragraph by _bk_* id. Supports DOCX a
 
 ## `save`
 
-Save document. For DOCX: saves clean and/or tracked changes output. For Google Docs: checkpoint (default) returns revisionId, or snapshot exports as DOCX.
+Save document. For DOCX: saves clean and/or tracked changes output. For ODT: saves an .odt package. For Google Docs: checkpoint (default) returns revisionId, or snapshot exports as DOCX.
 
 - readOnly: `false`
 - destructive: `true`
 
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
-| `file_path` | `string` | no | Path to the DOCX file. |
+| `file_path` | `string` | no | Path to the DOCX or ODT file. |
 | `google_doc_id` | `string` | no | Google Doc ID or URL (alternative to file_path). Extract from URL: docs.google.com/document/d/{ID}/edit |
 | `save_to_local_path` | `string` | yes |  |
 | `clean_bookmarks` | `boolean` | no |  |
@@ -148,7 +148,7 @@ Export a document to a portable rendering (Markdown, semantic HTML, or plain tex
 
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
-| `file_path` | `string` | no | Path to the DOCX file. |
+| `file_path` | `string` | no | Path to the DOCX or ODT file. |
 | `format` | `enum("markdown", "html", "plaintext")` | no | Output format: 'markdown' (default, writes .md), 'html' (writes .html), or 'plaintext' (writes .txt). |
 | `output_path` | `string` | no | Where to write the rendering. Defaults to the source path with the format extension. |
 | `allow_overwrite` | `boolean` | no | Overwrite output_path if it already exists. Default: false. |
@@ -163,7 +163,7 @@ Apply layout controls (paragraph spacing, table row height, cell padding). Googl
 
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
-| `file_path` | `string` | no | Path to the DOCX file. |
+| `file_path` | `string` | no | Path to the DOCX or ODT file. |
 | `google_doc_id` | `string` | no | Google Doc ID or URL (alternative to file_path). Extract from URL: docs.google.com/document/d/{ID}/edit |
 | `strict` | `boolean` | no |  |
 | `paragraph_spacing` | `object` | no |  |
@@ -179,7 +179,7 @@ Accept all tracked changes in the document body, producing a clean document with
 
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
-| `file_path` | `string` | yes | Path to the DOCX file. |
+| `file_path` | `string` | yes | Path to the DOCX or ODT file. |
 
 ## `has_tracked_changes`
 
@@ -190,30 +190,30 @@ Check whether the document body contains tracked-change markers (insertions, del
 
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
-| `file_path` | `string` | yes | Path to the DOCX file. |
+| `file_path` | `string` | yes | Path to the DOCX or ODT file. |
 
 ## `get_file_status`
 
-Get file/session metadata including edit count, normalization stats, and cache info. Supports DOCX and Google Docs.
+Get file/session metadata including edit count, normalization stats, and cache info. Supports DOCX, ODT, and Google Docs.
 
 - readOnly: `true`
 - destructive: `false`
 
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
-| `file_path` | `string` | no | Path to the DOCX file. |
+| `file_path` | `string` | no | Path to the DOCX or ODT file. |
 | `google_doc_id` | `string` | no | Google Doc ID or URL (alternative to file_path). Extract from URL: docs.google.com/document/d/{ID}/edit |
 
 ## `close_file`
 
-Close an open file session, or close all sessions with explicit confirmation. Supports DOCX and Google Docs.
+Close an open file session, or close all sessions with explicit confirmation. Supports DOCX, ODT, and Google Docs.
 
 - readOnly: `false`
 - destructive: `true`
 
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
-| `file_path` | `string` | no | Path to the DOCX file. |
+| `file_path` | `string` | no | Path to the DOCX or ODT file. |
 | `google_doc_id` | `string` | no | Google Doc ID or URL (alternative to file_path). Extract from URL: docs.google.com/document/d/{ID}/edit |
 | `clear_all` | `boolean` | no |  |
 | `confirm` | `boolean` | no |  |
@@ -227,7 +227,7 @@ Add a comment or threaded reply to a document. Provide target_paragraph_id + anc
 
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
-| `file_path` | `string` | yes | Path to the DOCX file. |
+| `file_path` | `string` | yes | Path to the DOCX or ODT file. |
 | `target_paragraph_id` | `string` | no | Paragraph ID to anchor the comment to (for root comments). |
 | `anchor_text` | `string` | no | Text within the paragraph to anchor the comment to. If omitted, anchors to entire paragraph. |
 | `parent_comment_id` | `number` | no | Parent comment ID for threaded replies. |
@@ -244,7 +244,7 @@ Get all comments from the document with IDs, authors, dates, text, and anchored 
 
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
-| `file_path` | `string` | yes | Path to the DOCX file. |
+| `file_path` | `string` | yes | Path to the DOCX or ODT file. |
 
 ## `delete_comment`
 
@@ -255,7 +255,7 @@ Delete a comment and all its threaded replies from the document. Cascade-deletes
 
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
-| `file_path` | `string` | yes | Path to the DOCX file. |
+| `file_path` | `string` | yes | Path to the DOCX or ODT file. |
 | `comment_id` | `number` | yes | Comment ID to delete. |
 
 ## `compare_documents`
@@ -269,7 +269,7 @@ Compare two DOCX documents and produce a tracked-changes output document. Provid
 | --- | --- | --- | --- |
 | `original_file_path` | `string` | no | Path to the original DOCX file. |
 | `revised_file_path` | `string` | no | Path to the revised DOCX file. |
-| `file_path` | `string` | no | Path to the DOCX file. |
+| `file_path` | `string` | no | Path to the DOCX or ODT file. |
 | `save_to_local_path` | `string` | yes | Path to save the tracked-changes DOCX output. |
 | `author` | `string` | no | Author name for track changes. Default: 'Comparison'. |
 | `engine` | `enum("auto", "atomizer")` | no | Comparison engine. Default: 'auto'. |
@@ -283,7 +283,7 @@ Get all footnotes from the document with IDs, display numbers, text, and anchore
 
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
-| `file_path` | `string` | yes | Path to the DOCX file. |
+| `file_path` | `string` | yes | Path to the DOCX or ODT file. |
 
 ## `add_footnote`
 
@@ -294,7 +294,7 @@ Add a footnote anchored to a paragraph. Optionally position the reference after 
 
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
-| `file_path` | `string` | yes | Path to the DOCX file. |
+| `file_path` | `string` | yes | Path to the DOCX or ODT file. |
 | `target_paragraph_id` | `string` | yes | Paragraph ID to anchor the footnote to. |
 | `after_text` | `string` | no | Text after which to insert the footnote reference. If omitted, appends at end of paragraph. |
 | `text` | `string` | yes | Footnote body text. |
@@ -308,7 +308,7 @@ Update the text content of an existing footnote.
 
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
-| `file_path` | `string` | yes | Path to the DOCX file. |
+| `file_path` | `string` | yes | Path to the DOCX or ODT file. |
 | `note_id` | `number` | yes | Footnote ID to update. |
 | `new_text` | `string` | yes | New footnote body text. |
 
@@ -321,7 +321,7 @@ Delete a footnote and its reference from the document.
 
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
-| `file_path` | `string` | yes | Path to the DOCX file. |
+| `file_path` | `string` | yes | Path to the DOCX or ODT file. |
 | `note_id` | `number` | yes | Footnote ID to delete. |
 
 ## `clear_formatting`
@@ -333,7 +333,7 @@ Clear specific run-level formatting (bold, italic, underline, highlight, color, 
 
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
-| `file_path` | `string` | yes | Path to the DOCX file. |
+| `file_path` | `string` | yes | Path to the DOCX or ODT file. |
 | `paragraph_ids` | `array<string>` | no | Paragraph IDs to clear formatting from. If omitted, clears from all paragraphs. |
 | `clear_highlight` | `boolean` | no | Remove highlight formatting. |
 | `clear_bold` | `boolean` | no | Remove bold formatting. |
@@ -351,6 +351,6 @@ Extract tracked changes as structured JSON with before/after text per paragraph,
 
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
-| `file_path` | `string` | yes | Path to the DOCX file. |
+| `file_path` | `string` | yes | Path to the DOCX or ODT file. |
 | `offset` | `number` | no | 0-based offset for pagination. Default: 0. |
 | `limit` | `number` | no | Max entries per page (1-500). Default: 50. |

--- a/packages/docx-mcp/package.json
+++ b/packages/docx-mcp/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "clean:dist": "node -e \"const { rmSync } = require('node:fs'); rmSync('dist', { recursive: true, force: true });\"",
-    "build": "npm run build -w @usejunior/docx-core && npm run build -w @usejunior/google-docs-core --if-present &&npm run clean:dist && tsc -p tsconfig.build.json",
+    "build": "npm run build -w @usejunior/docx-core && npm run build -w @usejunior/odf-core && npm run build -w @usejunior/google-docs-core --if-present && npm run clean:dist && tsc -p tsconfig.build.json",
     "dev": "tsx watch src/cli.ts",
     "check:spec-coverage": "node scripts/validate_openspec_coverage.mjs",
     "conformance:discover": "tsx scripts/discover_docx_fixtures.ts --out conformance/discovery.report.json",
@@ -19,15 +19,16 @@
     "conformance:smoke": "tsx scripts/run_conformance_harness.ts --manifest conformance/fixtures.manifest.json --mode smoke --report conformance/smoke-report.json",
     "docs:generate:tools": "node --import tsx scripts/generate_tool_reference.ts",
     "test:conformance": "vitest run src/conformance/harness.test.ts",
-    "test": "npm run build -w @usejunior/docx-core &&npm run check:spec-coverage && node ../../node_modules/vitest/vitest.mjs",
-    "test:run": "npm run build -w @usejunior/docx-core &&npm run check:spec-coverage && node ../../node_modules/vitest/vitest.mjs run",
-    "test:coverage": "npm run build -w @usejunior/docx-core &&npm run check:spec-coverage && node ../../node_modules/vitest/vitest.mjs run --coverage --coverage.reporter=text-summary --coverage.reporter=json-summary --coverage.reporter=lcov",
+    "test": "npm run build -w @usejunior/docx-core && npm run build -w @usejunior/odf-core && npm run check:spec-coverage && node ../../node_modules/vitest/vitest.mjs",
+    "test:run": "npm run build -w @usejunior/docx-core && npm run build -w @usejunior/odf-core && npm run check:spec-coverage && node ../../node_modules/vitest/vitest.mjs run",
+    "test:coverage": "npm run build -w @usejunior/docx-core && npm run build -w @usejunior/odf-core && npm run check:spec-coverage && node ../../node_modules/vitest/vitest.mjs run --coverage --coverage.reporter=text-summary --coverage.reporter=json-summary --coverage.reporter=lcov",
     "prepack": "npm run build",
     "lint": "tsc -b --pretty false"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
     "@usejunior/docx-core": "^0.9.1",
+    "@usejunior/odf-core": "^0.9.1",
     "@xmldom/xmldom": "^0.9.10",
     "zod": "^4.3.6"
   },

--- a/packages/docx-mcp/package.json
+++ b/packages/docx-mcp/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "clean:dist": "node -e \"const { rmSync } = require('node:fs'); rmSync('dist', { recursive: true, force: true });\"",
-    "build": "npm run build -w @usejunior/docx-core && npm run build -w @usejunior/odf-core && npm run build -w @usejunior/google-docs-core --if-present && npm run clean:dist && tsc -p tsconfig.build.json",
+    "build": "npm run build -w @usejunior/docx-core && npm run build -w @usejunior/odf-core --if-present && npm run build -w @usejunior/google-docs-core --if-present && npm run clean:dist && tsc -p tsconfig.build.json",
     "dev": "tsx watch src/cli.ts",
     "check:spec-coverage": "node scripts/validate_openspec_coverage.mjs",
     "conformance:discover": "tsx scripts/discover_docx_fixtures.ts --out conformance/discovery.report.json",
@@ -19,16 +19,15 @@
     "conformance:smoke": "tsx scripts/run_conformance_harness.ts --manifest conformance/fixtures.manifest.json --mode smoke --report conformance/smoke-report.json",
     "docs:generate:tools": "node --import tsx scripts/generate_tool_reference.ts",
     "test:conformance": "vitest run src/conformance/harness.test.ts",
-    "test": "npm run build -w @usejunior/docx-core && npm run build -w @usejunior/odf-core && npm run check:spec-coverage && node ../../node_modules/vitest/vitest.mjs",
-    "test:run": "npm run build -w @usejunior/docx-core && npm run build -w @usejunior/odf-core && npm run check:spec-coverage && node ../../node_modules/vitest/vitest.mjs run",
-    "test:coverage": "npm run build -w @usejunior/docx-core && npm run build -w @usejunior/odf-core && npm run check:spec-coverage && node ../../node_modules/vitest/vitest.mjs run --coverage --coverage.reporter=text-summary --coverage.reporter=json-summary --coverage.reporter=lcov",
+    "test": "npm run build -w @usejunior/docx-core && npm run build -w @usejunior/odf-core --if-present && npm run check:spec-coverage && node ../../node_modules/vitest/vitest.mjs",
+    "test:run": "npm run build -w @usejunior/docx-core && npm run build -w @usejunior/odf-core --if-present && npm run check:spec-coverage && node ../../node_modules/vitest/vitest.mjs run",
+    "test:coverage": "npm run build -w @usejunior/docx-core && npm run build -w @usejunior/odf-core --if-present && npm run check:spec-coverage && node ../../node_modules/vitest/vitest.mjs run --coverage --coverage.reporter=text-summary --coverage.reporter=json-summary --coverage.reporter=lcov",
     "prepack": "npm run build",
     "lint": "tsc -b --pretty false"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
     "@usejunior/docx-core": "^0.9.1",
-    "@usejunior/odf-core": "^0.9.1",
     "@xmldom/xmldom": "^0.9.10",
     "zod": "^4.3.6"
   },

--- a/packages/docx-mcp/src/odf_loader.ts
+++ b/packages/docx-mcp/src/odf_loader.ts
@@ -1,0 +1,17 @@
+// Lazy loader for the OPTIONAL @usejunior/odf-core provider, mirroring gdocs_loader.
+// odf-core is private/unpublished, so it is NOT a package.json dependency and may be
+// absent from a production install of the published package. Always-loaded modules
+// must reach ODF functionality through this loader (a dynamic import that returns
+// null when odf-core is unavailable) rather than a static import.
+let cached: typeof import('@usejunior/odf-core') | null | undefined;
+
+export async function loadOdfCore(): Promise<typeof import('@usejunior/odf-core') | null> {
+  if (cached !== undefined) return cached;
+  try {
+    cached = await import('@usejunior/odf-core');
+    return cached;
+  } catch {
+    cached = null;
+    return null;
+  }
+}

--- a/packages/docx-mcp/src/server.ts
+++ b/packages/docx-mcp/src/server.ts
@@ -1,8 +1,9 @@
+import path from 'node:path';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 
-import { SessionManager, type GDocsSession } from './session/manager.js';
+import { SessionManager, type GDocsSession, type OdfSession } from './session/manager.js';
 import { SAFE_DOCX_MCP_TOOLS } from './tool_catalog.js';
 import { readFile } from './tools/read_file.js';
 import { grep } from './tools/grep.js';
@@ -28,8 +29,8 @@ import { deleteFootnote } from './tools/delete_footnote.js';
 import { compareDocuments_tool } from './tools/compare_documents.js';
 import { extractRevisions_tool } from './tools/extract_revisions.js';
 import { clearFormatting } from './tools/clear_formatting.js';
-import { resolveGDocsSessionForTool } from './tools/session_resolution.js';
-import { checkGDocsSupport } from './tools/provider_guard.js';
+import { resolveGDocsSessionForTool, resolveOdfSessionForTool } from './tools/session_resolution.js';
+import { checkGDocsSupport, checkOdfSupport } from './tools/provider_guard.js';
 import type { ToolResponse } from './tools/types.js';
 
 export const MCP_TRANSPORT = 'stdio' as const;
@@ -40,8 +41,14 @@ function isGDocsRequest(args: Record<string, unknown>): boolean {
   return typeof args.google_doc_id === 'string' && args.google_doc_id.trim().length > 0;
 }
 
+function isOdfRequest(args: Record<string, unknown>): boolean {
+  const filePath = typeof args.file_path === 'string' ? args.file_path.trim() : '';
+  return path.extname(filePath).toLowerCase() === '.odt';
+}
+
 // Lazy-loaded gdocs handler map (populated on first gdocs request)
 let gdocsHandlers: Record<string, (m: SessionManager, s: GDocsSession, p: any, meta: Record<string, unknown>) => Promise<ToolResponse>> | null = null;
+let odfHandlers: Record<string, (m: SessionManager, s: OdfSession, p: any, meta: Record<string, unknown>) => Promise<ToolResponse>> | null = null;
 
 async function loadGDocsHandlers(): Promise<typeof gdocsHandlers> {
   if (gdocsHandlers) return gdocsHandlers;
@@ -68,6 +75,25 @@ async function loadGDocsHandlers(): Promise<typeof gdocsHandlers> {
   return gdocsHandlers;
 }
 
+async function loadOdfHandlers(): Promise<typeof odfHandlers> {
+  if (odfHandlers) return odfHandlers;
+  const [readFile, replaceText, save, getFileStatus, closeFile] = await Promise.all([
+    import('./tools/odf/read_file.js'),
+    import('./tools/odf/replace_text.js'),
+    import('./tools/odf/save.js'),
+    import('./tools/odf/get_file_status.js'),
+    import('./tools/odf/close_file.js'),
+  ]);
+  odfHandlers = {
+    read_file: readFile.odfReadFile,
+    replace_text: replaceText.odfReplaceText,
+    save: save.odfSave,
+    get_file_status: getFileStatus.odfGetFileStatus,
+    close_file: closeFile.odfCloseFile,
+  };
+  return odfHandlers;
+}
+
 async function dispatchGDocs(
   manager: SessionManager,
   args: Record<string, unknown>,
@@ -83,6 +109,21 @@ async function dispatchGDocs(
   return handler(manager, resolved.session, args, resolved.metadata);
 }
 
+async function dispatchOdf(
+  manager: SessionManager,
+  args: Record<string, unknown>,
+  toolName: string,
+): Promise<ToolResponse> {
+  const guard = checkOdfSupport(toolName);
+  if (guard) return guard;
+  const resolved = await resolveOdfSessionForTool(manager, args, { toolName });
+  if (!resolved.ok) return resolved.response;
+  const handlers = await loadOdfHandlers();
+  const handler = handlers![toolName];
+  if (!handler) return { success: false, error: { code: 'UNKNOWN_TOOL', message: `No ODF handler for: ${toolName}` } };
+  return handler(manager, resolved.session, args, resolved.metadata);
+}
+
 export async function dispatchToolCall(
   sessions: SessionManager,
   name: string,
@@ -91,6 +132,7 @@ export async function dispatchToolCall(
   switch (name) {
     case 'read_file':
       if (isGDocsRequest(args)) return await dispatchGDocs(sessions, args, 'read_file');
+      if (isOdfRequest(args)) return await dispatchOdf(sessions, args, 'read_file');
       return await readFile(sessions, args as Parameters<typeof readFile>[1]);
     case 'grep':
       if (isGDocsRequest(args)) return await dispatchGDocs(sessions, args, 'grep');
@@ -103,12 +145,14 @@ export async function dispatchToolCall(
       return await applyPlan(sessions, args as Parameters<typeof applyPlan>[1]);
     case 'replace_text':
       if (isGDocsRequest(args)) return await dispatchGDocs(sessions, args, 'replace_text');
+      if (isOdfRequest(args)) return await dispatchOdf(sessions, args, 'replace_text');
       return await replaceText(sessions, args as Parameters<typeof replaceText>[1]);
     case 'insert_paragraph':
       if (isGDocsRequest(args)) return await dispatchGDocs(sessions, args, 'insert_paragraph');
       return await insertParagraph(sessions, args as Parameters<typeof insertParagraph>[1]);
     case 'save':
       if (isGDocsRequest(args)) return await dispatchGDocs(sessions, args, 'save');
+      if (isOdfRequest(args)) return await dispatchOdf(sessions, args, 'save');
       return await save(sessions, args as Parameters<typeof save>[1]);
     case 'export':
       return await exportDocument(sessions, args as Parameters<typeof exportDocument>[1]);
@@ -121,9 +165,11 @@ export async function dispatchToolCall(
       return await hasTrackedChanges_tool(sessions, args as Parameters<typeof hasTrackedChanges_tool>[1]);
     case 'get_file_status':
       if (isGDocsRequest(args)) return await dispatchGDocs(sessions, args, 'get_file_status');
+      if (isOdfRequest(args)) return await dispatchOdf(sessions, args, 'get_file_status');
       return await getFileStatus(sessions, args as Parameters<typeof getFileStatus>[1]);
     case 'close_file':
       if (isGDocsRequest(args)) return await dispatchGDocs(sessions, args, 'close_file');
+      if (isOdfRequest(args)) return await dispatchOdf(sessions, args, 'close_file');
       return await closeFile(sessions, args as Parameters<typeof closeFile>[1]);
     case 'add_comment':
       return await addComment(sessions, args as Parameters<typeof addComment>[1]);

--- a/packages/docx-mcp/src/session/manager.ts
+++ b/packages/docx-mcp/src/session/manager.ts
@@ -16,7 +16,13 @@ import {
   type RevisionContext,
   type RevisionIdState,
 } from '@usejunior/docx-core';
-import { OdfArchive, OdfDocument } from '@usejunior/odf-core';
+// NOTE: @usejunior/odf-core is an OPTIONAL provider (private/unpublished, like
+// @usejunior/google-docs-core) and is intentionally NOT imported here. A static
+// import in this always-loaded module would make a production install of the
+// published package — which never fetches the private odf-core — crash at load.
+// The ODF archive/document are loaded by the lazily-reached resolver/open path
+// (see odf_loader.ts) and injected into createOdfSession; this module stores and
+// operates on them structurally (typed `any`, mirroring GDocsSession.doc).
 
 export type SaveFormat = 'clean' | 'tracked' | 'both';
 
@@ -100,8 +106,8 @@ export type OdfSession = {
   tmpPath: string;
   originalPath: string;
   originalBuffer: Buffer;
-  archive: OdfArchive;
-  doc: OdfDocument;
+  archive: any; // OdfArchive — loaded via the optional odf-core provider (see note above)
+  doc: any; // OdfDocument — loaded via the optional odf-core provider
   editCount: number;
   editRevision: number;
   createdAt: Date;
@@ -380,7 +386,19 @@ export class SessionManager {
     return session;
   }
 
-  async createOdfSession(documentContent: Buffer, filename: string, originalPath: string): Promise<OdfSession> {
+  /**
+   * Create an ODF session from an already-loaded `archive` + `doc`. The caller (the
+   * lazily-reached ODF resolver / open path) loads these via the optional odf-core
+   * provider — this method does NOT import odf-core, keeping the always-loaded
+   * SessionManager free of a hard dependency on the private package.
+   */
+  async createOdfSession(
+    documentContent: Buffer,
+    filename: string,
+    originalPath: string,
+    archive: any,
+    doc: any,
+  ): Promise<OdfSession> {
     const canonicalPath = await this.canonicalizePath(originalPath);
 
     const existing = this.sessions.get(canonicalPath);
@@ -393,8 +411,6 @@ export class SessionManager {
     const tmpPath = path.join(dir, filename);
     await fs.writeFile(tmpPath, new Uint8Array(documentContent));
 
-    const archive = await OdfArchive.load(documentContent);
-    const doc = OdfDocument.fromContentXml(await archive.getContentXml());
     const now = new Date();
     const session: OdfSession = {
       provider: 'odf',

--- a/packages/docx-mcp/src/session/manager.ts
+++ b/packages/docx-mcp/src/session/manager.ts
@@ -16,6 +16,7 @@ import {
   type RevisionContext,
   type RevisionIdState,
 } from '@usejunior/docx-core';
+import { OdfArchive, OdfDocument } from '@usejunior/odf-core';
 
 export type SaveFormat = 'clean' | 'tracked' | 'both';
 
@@ -92,7 +93,23 @@ export type GDocsSession = {
   expiresAt: Date;
 };
 
-export type Session = DocxSession | GDocsSession;
+export type OdfSession = {
+  provider: 'odf';
+  sessionId: string;
+  filename: string;
+  tmpPath: string;
+  originalPath: string;
+  originalBuffer: Buffer;
+  archive: OdfArchive;
+  doc: OdfDocument;
+  editCount: number;
+  editRevision: number;
+  createdAt: Date;
+  lastAccessedAt: Date;
+  expiresAt: Date;
+};
+
+export type Session = DocxSession | GDocsSession | OdfSession;
 
 const WORDPROCESSING_ML_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 
@@ -271,6 +288,10 @@ export function isGDocsSession(s: Session): s is GDocsSession {
   return s.provider === 'gdocs';
 }
 
+export function isOdfSession(s: Session): s is OdfSession {
+  return s.provider === 'odf';
+}
+
 export class SessionManager {
   /** Sessions keyed by canonical file path (realpath). */
   private sessions = new Map<string, Session>();
@@ -354,6 +375,41 @@ export class SessionManager {
       lastAccessedAt: now,
       expiresAt,
       normalizationStats: null,
+    };
+    this.sessions.set(canonicalPath, session);
+    return session;
+  }
+
+  async createOdfSession(documentContent: Buffer, filename: string, originalPath: string): Promise<OdfSession> {
+    const canonicalPath = await this.canonicalizePath(originalPath);
+
+    const existing = this.sessions.get(canonicalPath);
+    if (existing) {
+      await this.cleanupSessionArtifacts(existing);
+    }
+
+    const sessionId = this.newSessionId();
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'safe-odf-'));
+    const tmpPath = path.join(dir, filename);
+    await fs.writeFile(tmpPath, new Uint8Array(documentContent));
+
+    const archive = await OdfArchive.load(documentContent);
+    const doc = OdfDocument.fromContentXml(await archive.getContentXml());
+    const now = new Date();
+    const session: OdfSession = {
+      provider: 'odf',
+      sessionId,
+      filename,
+      tmpPath,
+      originalPath,
+      originalBuffer: Buffer.from(documentContent),
+      archive,
+      doc,
+      editCount: 0,
+      editRevision: 0,
+      createdAt: now,
+      lastAccessedAt: now,
+      expiresAt: new Date(now.getTime() + this.ttlMs),
     };
     this.sessions.set(canonicalPath, session);
     return session;
@@ -449,7 +505,7 @@ export class SessionManager {
   }
 
   private async cleanupSessionArtifacts(session: Session): Promise<void> {
-    if (isDocxSession(session)) {
+    if (isDocxSession(session) || isOdfSession(session)) {
       const tmpDir = path.dirname(session.tmpPath);
       await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => undefined);
     }
@@ -546,5 +602,12 @@ export class SessionManager {
   async saveTo(session: DocxSession, savePath: string, opts?: { cleanBookmarks?: boolean }): Promise<void> {
     const { buffer } = await session.doc.toBuffer({ cleanBookmarks: opts?.cleanBookmarks ?? true });
     await fs.writeFile(savePath, new Uint8Array(buffer));
+  }
+
+  async saveOdfTo(session: OdfSession, savePath: string): Promise<Buffer> {
+    session.archive.setContentXml(session.doc.toXml());
+    const buffer = await session.archive.save();
+    await fs.writeFile(savePath, new Uint8Array(buffer));
+    return buffer;
   }
 }

--- a/packages/docx-mcp/src/tool_catalog.ts
+++ b/packages/docx-mcp/src/tool_catalog.ts
@@ -13,11 +13,11 @@ type ToolCatalogEntry = {
 };
 
 const FILE_FIELD = {
-  file_path: z.string().describe('Path to the DOCX file.'),
+  file_path: z.string().describe('Path to the DOCX or ODT file.'),
 };
 
 const FILE_FIELD_OPTIONAL = {
-  file_path: z.string().optional().describe('Path to the DOCX file.'),
+  file_path: z.string().optional().describe('Path to the DOCX or ODT file.'),
 };
 
 const GOOGLE_DOC_ID_FIELD = {
@@ -32,7 +32,7 @@ const PLAN_OBJECT_SCHEMA = z.object({}).catchall(z.unknown());
 export const SAFE_DOCX_TOOL_CATALOG = [
   {
     name: 'read_file',
-    description: 'Read document content (DOCX or Google Doc). Output is token-limited (~14k tokens) by default with pagination metadata (has_more, next_offset). Use offset/limit to paginate.',
+    description: 'Read document content (DOCX, ODT, or Google Doc). Output is token-limited (~14k tokens) by default with pagination metadata (has_more, next_offset). Use offset/limit to paginate.',
     input: z.object({
       ...FILE_FIELD_OPTIONAL,
       ...GOOGLE_DOC_ID_FIELD,
@@ -56,7 +56,7 @@ export const SAFE_DOCX_TOOL_CATALOG = [
         .boolean()
         .optional()
         .describe(
-          'When true and format="json", include a portable content_fingerprint ("sha256:nfkc:<32hex>") on each paragraph. Read-only metadata derived from the paragraph\'s normalized visible text; NOT an edit anchor. Edit tools accept only `_bk_*` IDs. No effect on TOON/simple output. Ignored for Google Docs.',
+          'When true and format="json", include a portable content_fingerprint ("sha256:nfkc:<32hex>") on each paragraph. Read-only metadata derived from the paragraph\'s normalized visible text; NOT an edit anchor. Edit tools accept only `_bk_*` IDs. No effect on TOON/simple output. Ignored for Google Docs and ODT.',
         ),
     }),
     annotations: { readOnlyHint: true, destructiveHint: false },
@@ -119,7 +119,7 @@ export const SAFE_DOCX_TOOL_CATALOG = [
   },
   {
     name: 'replace_text',
-    description: 'Replace text in a paragraph by _bk_* id, preserving formatting. Supports DOCX and Google Docs.',
+    description: 'Replace text in a paragraph by provider paragraph id, preserving formatting where supported. Supports DOCX, ODT, and Google Docs.',
     input: z.object({
       ...FILE_FIELD_OPTIONAL,
       ...GOOGLE_DOC_ID_FIELD,
@@ -156,7 +156,7 @@ export const SAFE_DOCX_TOOL_CATALOG = [
   {
     name: 'save',
     description:
-      'Save document. For DOCX: saves clean and/or tracked changes output. For Google Docs: checkpoint (default) returns revisionId, or snapshot exports as DOCX.',
+      'Save document. For DOCX: saves clean and/or tracked changes output. For ODT: saves an .odt package. For Google Docs: checkpoint (default) returns revisionId, or snapshot exports as DOCX.',
     input: z.object({
       ...FILE_FIELD_OPTIONAL,
       ...GOOGLE_DOC_ID_FIELD,
@@ -257,7 +257,7 @@ export const SAFE_DOCX_TOOL_CATALOG = [
   },
   {
     name: 'get_file_status',
-    description: 'Get file/session metadata including edit count, normalization stats, and cache info. Supports DOCX and Google Docs.',
+    description: 'Get file/session metadata including edit count, normalization stats, and cache info. Supports DOCX, ODT, and Google Docs.',
     input: z.object({
       ...FILE_FIELD_OPTIONAL,
       ...GOOGLE_DOC_ID_FIELD,
@@ -266,7 +266,7 @@ export const SAFE_DOCX_TOOL_CATALOG = [
   },
   {
     name: 'close_file',
-    description: 'Close an open file session, or close all sessions with explicit confirmation. Supports DOCX and Google Docs.',
+    description: 'Close an open file session, or close all sessions with explicit confirmation. Supports DOCX, ODT, and Google Docs.',
     input: z.object({
       ...FILE_FIELD_OPTIONAL,
       ...GOOGLE_DOC_ID_FIELD,

--- a/packages/docx-mcp/src/tools/odf/close_file.ts
+++ b/packages/docx-mcp/src/tools/odf/close_file.ts
@@ -1,0 +1,21 @@
+import { type OdfSession, SessionManager } from '../../session/manager.js';
+import { err, ok, type ToolResponse } from '../types.js';
+
+export async function odfCloseFile(
+  manager: SessionManager,
+  session: OdfSession,
+  _params: Record<string, unknown>,
+  _metadata: Record<string, unknown>,
+): Promise<ToolResponse> {
+  try {
+    const cleared = await manager.clearSessionByPath(session.originalPath);
+    return ok({
+      clear_mode: 'file_path',
+      file_path: cleared ?? session.originalPath,
+      cleared_file_paths: cleared ? [cleared] : [],
+      cleared_count: cleared ? 1 : 0,
+    });
+  } catch (e: unknown) {
+    return err('CLOSE_FILE_ERROR', `Failed to close ODF session: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}

--- a/packages/docx-mcp/src/tools/odf/get_file_status.ts
+++ b/packages/docx-mcp/src/tools/odf/get_file_status.ts
@@ -1,0 +1,33 @@
+import { type OdfSession, SessionManager } from '../../session/manager.js';
+import { err, ok, type ToolResponse } from '../types.js';
+
+export async function odfGetFileStatus(
+  _manager: SessionManager,
+  session: OdfSession,
+  _params: Record<string, unknown>,
+  metadata: Record<string, unknown>,
+): Promise<ToolResponse> {
+  try {
+    return ok({
+      file_path: session.originalPath,
+      provider: 'odf',
+      created_at: session.createdAt.toISOString(),
+      expires_at: session.expiresAt.toISOString(),
+      last_activity: session.lastAccessedAt.toISOString(),
+      edit_count: session.editCount,
+      edit_revision: session.editRevision,
+      document: {
+        filename: session.filename,
+        paragraphs: session.doc.getParagraphs().length,
+      },
+      save_defaults: {
+        default_save_format: 'odt',
+        returned_variants: ['odt'],
+        supports_variant_override: false,
+      },
+      ...metadata,
+    });
+  } catch (e: unknown) {
+    return err('STATUS_ERROR', e instanceof Error ? e.message : String(e));
+  }
+}

--- a/packages/docx-mcp/src/tools/odf/odf_tools.test.ts
+++ b/packages/docx-mcp/src/tools/odf/odf_tools.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, describe, expect } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { OdfArchive, OdfDocument } from '@usejunior/odf-core';
+import { testAllure as it, type AllureBddContext } from '../../testing/allure-test.js';
+import { dispatchToolCall } from '../../server.js';
+import { SessionManager } from '../../session/manager.js';
+import { openDocument } from '../open_document.js';
+
+const TEST_FEATURE = 'add-odf-core';
+const test = it.epic('Document Editing').withLabels({ feature: TEST_FEATURE });
+const FIXTURE = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../../../odf-core/src/__fixtures__/sample.odt',
+);
+
+const tmpDirs: string[] = [];
+
+afterEach(async () => {
+  for (const dir of tmpDirs.splice(0)) {
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
+async function copyFixture(name = 'sample.odt'): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'safe-docx-odf-tools-'));
+  tmpDirs.push(dir);
+  const filePath = path.join(dir, name);
+  await fs.copyFile(FIXTURE, filePath);
+  return filePath;
+}
+
+type SuccessResult = { success: true; [key: string]: unknown };
+type ErrorResult = { success: false; error: { code: string; message: string; hint?: string } };
+
+function assertSuccess(result: Record<string, unknown>, label: string): asserts result is SuccessResult {
+  expect(result.success, `${label} failed: ${JSON.stringify((result as ErrorResult).error)}`).toBe(true);
+}
+
+function assertError(result: Record<string, unknown>, code: string): asserts result is ErrorResult {
+  expect(result.success).toBe(false);
+  expect((result as ErrorResult).error.code).toBe(code);
+}
+
+async function readSavedParagraphs(filePath: string): Promise<Array<{ id: string; text: string }>> {
+  const archive = await OdfArchive.load(await fs.readFile(filePath) as Buffer);
+  const doc = OdfDocument.fromContentXml(await archive.getContentXml());
+  return doc.getParagraphs();
+}
+
+describe('ODF MCP provider lane', () => {
+  test.openspec('[OPLR-01] Open a local `.odt`')(
+    'open_document creates an ODF session and returns paragraph metadata',
+    async ({ given, when, then }: AllureBddContext) => {
+      let manager: SessionManager;
+      let filePath: string;
+      let result: Awaited<ReturnType<typeof openDocument>>;
+
+      await given('a real .odt fixture', async () => {
+        manager = new SessionManager();
+        filePath = await copyFixture();
+      });
+      await when('open_document opens the fixture', async () => {
+        result = await openDocument(manager, { file_path: filePath });
+      });
+      await then('the response reports an ODF provider and paragraphs', () => {
+        assertSuccess(result, 'open_document');
+        expect(result.provider).toBe('odf');
+        expect((result.document as { paragraphs: number }).paragraphs).toBeGreaterThan(0);
+      });
+    },
+  );
+
+  test.openspec('[OPLR-02] Unsupported extensions still rejected')(
+    'open_document keeps INVALID_FILE_TYPE for unsupported extensions',
+    async ({ given, when, then }: AllureBddContext) => {
+      let manager: SessionManager;
+      let filePath: string;
+      let result: Awaited<ReturnType<typeof openDocument>>;
+
+      await given('an unsupported local file', async () => {
+        manager = new SessionManager();
+        const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'safe-docx-odf-invalid-'));
+        tmpDirs.push(dir);
+        filePath = path.join(dir, 'bad.rtf');
+        await fs.writeFile(filePath, '{\\rtf1 bad}');
+      });
+      await when('open_document is called', async () => {
+        result = await openDocument(manager, { file_path: filePath });
+      });
+      await then('the extension is rejected with INVALID_FILE_TYPE', () => {
+        assertError(result, 'INVALID_FILE_TYPE');
+      });
+    },
+  );
+
+  test.openspec('[OPLR-03] Supported tools route to the ODF handler')(
+    'read_file replace_text save get_file_status and close_file use ODF session data',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      let manager: SessionManager;
+      let filePath: string;
+      let outputPath: string;
+      let paragraphId: string;
+
+      await given('a file-first ODF session', async () => {
+        manager = new SessionManager();
+        filePath = await copyFixture();
+        outputPath = path.join(path.dirname(filePath), 'edited.odt');
+      });
+      await when('read_file auto-opens the ODF document', async () => {
+        const read = await dispatchToolCall(manager, 'read_file', { file_path: filePath, format: 'json', limit: 100 });
+        assertSuccess(read, 'read_file');
+        expect(read.provider).toBe('odf');
+        const nodes = JSON.parse(String(read.content)) as Array<{ id: string; text: string }>;
+        const target = nodes.find((node) => node.text.includes('quick brown fox'));
+        expect(target).toBeTruthy();
+        paragraphId = target!.id;
+      });
+      await and('replace_text edits through the ODF handler', async () => {
+        const replaced = await dispatchToolCall(manager, 'replace_text', {
+          file_path: filePath,
+          target_paragraph_id: paragraphId,
+          old_string: 'quick brown fox',
+          new_string: 'slow grey cat',
+          instruction: 'test ODF replacement',
+        });
+        assertSuccess(replaced, 'replace_text');
+        expect(replaced.provider).toBe('odf');
+        expect(replaced.replacements_made).toBe(1);
+      });
+      await and('get_file_status reports the ODF provider', async () => {
+        const status = await dispatchToolCall(manager, 'get_file_status', { file_path: filePath });
+        assertSuccess(status, 'get_file_status');
+        expect(status.provider).toBe('odf');
+        expect(status.session_resolution).toBe('reused');
+      });
+      await and('save writes a valid .odt package', async () => {
+        const saved = await dispatchToolCall(manager, 'save', {
+          file_path: filePath,
+          save_to_local_path: outputPath,
+        });
+        assertSuccess(saved, 'save');
+        expect(saved.provider).toBe('odf');
+        const paragraphs = await readSavedParagraphs(outputPath);
+        expect(paragraphs.find((p) => p.id === paragraphId)?.text).toContain('slow grey cat');
+      });
+      await then('close_file clears the ODF session', async () => {
+        const closed = await dispatchToolCall(manager, 'close_file', { file_path: filePath });
+        assertSuccess(closed, 'close_file');
+        expect(closed.cleared_count).toBe(1);
+      });
+    },
+  );
+
+  test.openspec('[OPLR-04] Unsupported tools are guarded for ODF')(
+    'compare_documents on an .odt session returns UNSUPPORTED_FOR_ODF before DOCX logic',
+    async ({ given, when, then }: AllureBddContext) => {
+      let manager: SessionManager;
+      let filePath: string;
+      let result: Awaited<ReturnType<typeof dispatchToolCall>>;
+
+      await given('an ODF session', async () => {
+        manager = new SessionManager();
+        filePath = await copyFixture();
+        const read = await dispatchToolCall(manager, 'read_file', { file_path: filePath });
+        assertSuccess(read, 'read_file');
+      });
+      await when('a DOCX-only phase-2 tool targets the .odt path', async () => {
+        result = await dispatchToolCall(manager, 'compare_documents', {
+          file_path: filePath,
+          save_to_local_path: path.join(path.dirname(filePath), 'redline.docx'),
+        });
+      });
+      await then('the provider chokepoint returns UNSUPPORTED_FOR_ODF', () => {
+        assertError(result, 'UNSUPPORTED_FOR_ODF');
+      });
+    },
+  );
+
+  test.openspec('[OPLR-05] File-first `.odt` auto-opens')(
+    'read_file auto-opens an ODF session without prior open_document',
+    async ({ given, when, then }: AllureBddContext) => {
+      let manager: SessionManager;
+      let filePath: string;
+      let result: Awaited<ReturnType<typeof dispatchToolCall>>;
+
+      await given('a fresh manager and an .odt file', async () => {
+        manager = new SessionManager();
+        filePath = await copyFixture();
+      });
+      await when('read_file is called first', async () => {
+        result = await dispatchToolCall(manager, 'read_file', { file_path: filePath, format: 'simple' });
+      });
+      await then('the ODF resolver opens and reads the file', () => {
+        assertSuccess(result, 'read_file');
+        expect(result.provider).toBe('odf');
+        expect(result.session_resolution).toBe('opened');
+        expect(String(result.content)).toContain('quick brown fox');
+      });
+    },
+  );
+});

--- a/packages/docx-mcp/src/tools/odf/odf_tools.test.ts
+++ b/packages/docx-mcp/src/tools/odf/odf_tools.test.ts
@@ -202,3 +202,162 @@ describe('ODF MCP provider lane', () => {
     },
   );
 });
+
+// Branch-coverage tests for the ODF handlers' error/format paths. Plain `it`
+// (= testAllure) labeled tests, no OpenSpec mapping — they exercise the handler
+// branches the OPLR happy-path scenarios don't reach.
+describe('ODF handler branch coverage', () => {
+  async function openAndFirstId(manager: SessionManager, filePath: string): Promise<string> {
+    const read = await dispatchToolCall(manager, 'read_file', { file_path: filePath, format: 'json', limit: 500 });
+    assertSuccess(read, 'read_file');
+    const nodes = JSON.parse(String(read.content)) as Array<{ id: string }>;
+    return nodes[0]!.id;
+  }
+
+  it('read_file rejects an invalid format', async () => {
+    const manager = new SessionManager();
+    const filePath = await copyFixture();
+    const res = await dispatchToolCall(manager, 'read_file', { file_path: filePath, format: 'csv' });
+    assertError(res, 'INVALID_FORMAT');
+  });
+
+  it('read_file renders the simple format', async () => {
+    const manager = new SessionManager();
+    const filePath = await copyFixture();
+    // An explicit limit disables the token-budget path so the requested format is honored.
+    const res = await dispatchToolCall(manager, 'read_file', { file_path: filePath, format: 'simple', limit: 500 });
+    assertSuccess(res, 'read_file simple');
+    expect(String(res.content)).toContain('#TOON id | text');
+  });
+
+  it('read_file honors limit + offset pagination', async () => {
+    const manager = new SessionManager();
+    const filePath = await copyFixture();
+    const res = await dispatchToolCall(manager, 'read_file', { file_path: filePath, offset: 1, limit: 1 });
+    assertSuccess(res, 'read_file paginated');
+    expect(res.paragraphs_returned).toBe(1);
+  });
+
+  it('read_file accepts a negative offset (from end)', async () => {
+    const manager = new SessionManager();
+    const filePath = await copyFixture();
+    const res = await dispatchToolCall(manager, 'read_file', { file_path: filePath, offset: -1, limit: 1 });
+    assertSuccess(res, 'read_file negative offset');
+    expect(res.paragraphs_returned).toBe(1);
+  });
+
+  it('read_file filters by node_ids', async () => {
+    const manager = new SessionManager();
+    const filePath = await copyFixture();
+    const id = await openAndFirstId(manager, filePath);
+    const res = await dispatchToolCall(manager, 'read_file', { file_path: filePath, node_ids: [id], format: 'json' });
+    assertSuccess(res, 'read_file node_ids');
+    const nodes = JSON.parse(String(res.content)) as Array<{ id: string }>;
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0]!.id).toBe(id);
+  });
+
+  it('replace_text reports TEXT_NOT_FOUND for an absent find string', async () => {
+    const manager = new SessionManager();
+    const filePath = await copyFixture();
+    const id = await openAndFirstId(manager, filePath);
+    const res = await dispatchToolCall(manager, 'replace_text', {
+      file_path: filePath,
+      target_paragraph_id: id,
+      old_string: 'this string is absent from the document',
+      new_string: 'x',
+      instruction: 'coverage',
+    });
+    assertError(res, 'TEXT_NOT_FOUND');
+  });
+
+  it('replace_text reports ANCHOR_NOT_FOUND for an unknown paragraph id', async () => {
+    const manager = new SessionManager();
+    const filePath = await copyFixture();
+    await openAndFirstId(manager, filePath);
+    const res = await dispatchToolCall(manager, 'replace_text', {
+      file_path: filePath,
+      target_paragraph_id: 'p99999',
+      old_string: 'anything',
+      new_string: 'x',
+      instruction: 'coverage',
+    });
+    assertError(res, 'ANCHOR_NOT_FOUND');
+  });
+
+  it('save requires save_to_local_path', async () => {
+    const manager = new SessionManager();
+    const filePath = await copyFixture();
+    await openAndFirstId(manager, filePath);
+    const res = await dispatchToolCall(manager, 'save', { file_path: filePath });
+    assertError(res, 'MISSING_SAVE_PATH');
+  });
+
+  it('save blocks overwriting the original without allow_overwrite', async () => {
+    const manager = new SessionManager();
+    const filePath = await copyFixture();
+    await openAndFirstId(manager, filePath);
+    const res = await dispatchToolCall(manager, 'save', { file_path: filePath, save_to_local_path: filePath });
+    assertError(res, 'OVERWRITE_BLOCKED');
+  });
+
+  it('read_file reports FILE_NOT_FOUND for a missing .odt path', async () => {
+    const manager = new SessionManager();
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'safe-docx-odf-missing-'));
+    tmpDirs.push(dir);
+    const res = await dispatchToolCall(manager, 'read_file', { file_path: path.join(dir, 'nope.odt') });
+    assertError(res, 'FILE_NOT_FOUND');
+  });
+
+  it('read_file rejects a corrupt .odt (archive-safety guard)', async () => {
+    const manager = new SessionManager();
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'safe-docx-odf-corrupt-'));
+    tmpDirs.push(dir);
+    const filePath = path.join(dir, 'corrupt.odt');
+    await fs.writeFile(filePath, 'this is not a zip archive');
+    const res = await dispatchToolCall(manager, 'read_file', { file_path: filePath });
+    expect(res.success).toBe(false);
+  });
+
+  it('get_file_status reports an unedited ODF session', async () => {
+    const manager = new SessionManager();
+    const filePath = await copyFixture();
+    await openAndFirstId(manager, filePath);
+    const res = await dispatchToolCall(manager, 'get_file_status', { file_path: filePath });
+    assertSuccess(res, 'get_file_status');
+    expect(res.provider).toBe('odf');
+    expect(res.edit_count).toBe(0);
+  });
+
+  it('open_document rejects a corrupt .odt before creating a session', async () => {
+    const manager = new SessionManager();
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'safe-docx-odf-corrupt2-'));
+    tmpDirs.push(dir);
+    const filePath = path.join(dir, 'corrupt.odt');
+    await fs.writeFile(filePath, 'not a zip');
+    const res = await openDocument(manager, { file_path: filePath });
+    expect(res.success).toBe(false);
+  });
+
+  it('save writes to a fresh path with allow_overwrite', async () => {
+    const manager = new SessionManager();
+    const filePath = await copyFixture();
+    const id = await openAndFirstId(manager, filePath);
+    await dispatchToolCall(manager, 'replace_text', {
+      file_path: filePath,
+      target_paragraph_id: id,
+      old_string: 'quick brown fox',
+      new_string: 'slow grey cat',
+      instruction: 'coverage save',
+    });
+    const outPath = path.join(path.dirname(filePath), 'out-overwrite.odt');
+    const res = await dispatchToolCall(manager, 'save', {
+      file_path: filePath,
+      save_to_local_path: outPath,
+      allow_overwrite: true,
+    });
+    assertSuccess(res, 'save allow_overwrite');
+    const paragraphs = await readSavedParagraphs(outPath);
+    expect(paragraphs.some((p) => p.text.includes('slow grey cat'))).toBe(true);
+  });
+});

--- a/packages/docx-mcp/src/tools/odf/read_file.ts
+++ b/packages/docx-mcp/src/tools/odf/read_file.ts
@@ -1,0 +1,166 @@
+import {
+  collectTableMarkerInfo,
+  formatTableMarker,
+  formatToonDataLine,
+  renderToon,
+  type DocumentViewNode,
+} from '@usejunior/docx-core';
+import { type OdfSession, SessionManager } from '../../session/manager.js';
+import { err, ok, type ToolResponse } from '../types.js';
+import { buildPaginationMeta, DEFAULT_CONTENT_TOKEN_BUDGET, estimateTokens } from '../pagination.js';
+import { READ_SIMPLE_PREVIEW_CHARS, previewText } from '../preview.js';
+
+function odfParagraphsToDocumentViewNodes(session: OdfSession): DocumentViewNode[] {
+  return session.doc.getParagraphs().map((paragraph) => ({
+    id: paragraph.id,
+    list_label: '',
+    header: '',
+    style: 'body',
+    text: paragraph.text,
+    clean_text: paragraph.text,
+    tagged_text: paragraph.text,
+    list_metadata: {
+      list_level: -1,
+      label_type: null,
+      label_string: '',
+      header_text: null,
+      header_style: null,
+      header_formatting: null,
+      is_auto_numbered: false,
+    },
+    style_fingerprint: {
+      list_level: -1,
+      left_indent_pt: 0,
+      first_line_indent_pt: 0,
+      style_name: 'body',
+      alignment: 'LEFT',
+    },
+    paragraph_style_id: null,
+    paragraph_style_name: 'body',
+    paragraph_alignment: 'LEFT',
+    paragraph_indents_pt: { left: 0, first_line: 0 },
+    numbering: { num_id: null, ilvl: null, is_auto_numbered: false },
+    header_formatting: null,
+    body_run_formatting: null,
+  }));
+}
+
+export async function odfReadFile(
+  _manager: SessionManager,
+  session: OdfSession,
+  params: { offset?: number; limit?: number; node_ids?: string[]; format?: string },
+  metadata: Record<string, unknown>,
+): Promise<ToolResponse> {
+  try {
+    const format = (params.format ?? 'toon').toLowerCase();
+    if (format !== 'toon' && format !== 'json' && format !== 'simple') {
+      return err('INVALID_FORMAT', `Invalid format: ${params.format}`, "Use 'toon' (default), 'json', or 'simple'.");
+    }
+
+    const nodes = odfParagraphsToDocumentViewNodes(session);
+    const totalParagraphs = nodes.length;
+
+    const hasExplicitLimit = typeof params.limit === 'number';
+    const hasExplicitOffset = typeof params.offset === 'number';
+    const hasNodeIds = params.node_ids != null && params.node_ids.length > 0;
+    const budgetActive = !hasExplicitLimit && !hasExplicitOffset && !hasNodeIds;
+
+    let filtered = nodes;
+    let startIdx = 0;
+    if (hasNodeIds) {
+      const set = new Set(params.node_ids!);
+      filtered = nodes.filter((n) => set.has(n.id));
+    } else {
+      if (hasExplicitOffset) {
+        if (params.offset! > 0) startIdx = Math.max(0, params.offset! - 1);
+        if (params.offset! < 0) startIdx = Math.max(0, totalParagraphs + params.offset!);
+      }
+      const endIdx = hasExplicitLimit ? Math.min(totalParagraphs, startIdx + params.limit!) : totalParagraphs;
+      filtered = nodes.slice(startIdx, endIdx);
+    }
+
+    let content: string;
+    let paragraphsReturned: number;
+
+    if (!budgetActive) {
+      if (format === 'json') {
+        content = JSON.stringify(filtered, null, 2);
+      } else if (format === 'simple') {
+        content = renderSimpleOdf(filtered);
+      } else {
+        content = renderToon(filtered);
+      }
+      paragraphsReturned = filtered.length;
+    } else {
+      const result = renderToonWithBudgetOdf(filtered, DEFAULT_CONTENT_TOKEN_BUDGET);
+      content = result.content;
+      paragraphsReturned = result.count;
+    }
+
+    const paginationMeta = buildPaginationMeta(totalParagraphs, paragraphsReturned, startIdx);
+
+    return ok({
+      file_path: session.originalPath,
+      provider: 'odf',
+      content,
+      total_paragraphs: totalParagraphs,
+      paragraphs_returned: paragraphsReturned,
+      ...paginationMeta,
+      ...metadata,
+    });
+  } catch (e: unknown) {
+    return err('READ_ERROR', e instanceof Error ? e.message : String(e), 'Check session status and try again.');
+  }
+}
+
+function renderSimpleOdf(nodes: readonly DocumentViewNode[]): string {
+  const lines: string[] = ['#TOON id | text'];
+  for (const n of nodes) {
+    lines.push(`${n.id} | ${previewText(n.clean_text, READ_SIMPLE_PREVIEW_CHARS)}`);
+  }
+  return lines.join('\n');
+}
+
+function renderToonWithBudgetOdf(
+  nodes: readonly DocumentViewNode[],
+  budget: number,
+): { content: string; count: number } {
+  const headerLine = '#SCHEMA id | list_label | header | style | text';
+  let accumulated = headerLine;
+  let count = 0;
+  let currentTableIndex: number | null = null;
+  const tableInfo = collectTableMarkerInfo(nodes);
+
+  for (const node of nodes) {
+    const tc = node.table_context;
+    const nodeTableIndex = tc ? tc.table_index : null;
+
+    if (currentTableIndex !== null && nodeTableIndex !== currentTableIndex) {
+      accumulated += '\n#END_TABLE';
+      currentTableIndex = null;
+    }
+
+    if (nodeTableIndex !== null && currentTableIndex === null) {
+      const info = tableInfo.get(nodeTableIndex);
+      if (info) {
+        const marker = formatTableMarker(info);
+        const candidateWithMarker = accumulated + '\n' + marker;
+        if (count > 0 && estimateTokens(candidateWithMarker) > budget) break;
+        accumulated = candidateWithMarker;
+      }
+      currentTableIndex = nodeTableIndex;
+    }
+
+    const dataLine = formatToonDataLine(node);
+    const candidate = accumulated + '\n' + dataLine;
+    if (count > 0 && estimateTokens(candidate) > budget) {
+      if (currentTableIndex !== null) accumulated += '\n#END_TABLE';
+      break;
+    }
+    accumulated = candidate;
+    count++;
+  }
+
+  if (currentTableIndex !== null) accumulated += '\n#END_TABLE';
+  return { content: accumulated, count };
+}

--- a/packages/docx-mcp/src/tools/odf/read_file.ts
+++ b/packages/docx-mcp/src/tools/odf/read_file.ts
@@ -1,6 +1,4 @@
 import {
-  collectTableMarkerInfo,
-  formatTableMarker,
   formatToonDataLine,
   renderToon,
   type DocumentViewNode,
@@ -121,46 +119,23 @@ function renderSimpleOdf(nodes: readonly DocumentViewNode[]): string {
   return lines.join('\n');
 }
 
+// ODF Phase 1 flattens table cells to body paragraphs, so nodes never carry
+// `table_context`. The budget renderer therefore has no table-marker handling
+// (unlike the DOCX/gdocs renderers) — keeping it free of structurally-unreachable
+// branches.
 function renderToonWithBudgetOdf(
   nodes: readonly DocumentViewNode[],
   budget: number,
 ): { content: string; count: number } {
-  const headerLine = '#SCHEMA id | list_label | header | style | text';
-  let accumulated = headerLine;
+  let accumulated = '#SCHEMA id | list_label | header | style | text';
   let count = 0;
-  let currentTableIndex: number | null = null;
-  const tableInfo = collectTableMarkerInfo(nodes);
 
   for (const node of nodes) {
-    const tc = node.table_context;
-    const nodeTableIndex = tc ? tc.table_index : null;
-
-    if (currentTableIndex !== null && nodeTableIndex !== currentTableIndex) {
-      accumulated += '\n#END_TABLE';
-      currentTableIndex = null;
-    }
-
-    if (nodeTableIndex !== null && currentTableIndex === null) {
-      const info = tableInfo.get(nodeTableIndex);
-      if (info) {
-        const marker = formatTableMarker(info);
-        const candidateWithMarker = accumulated + '\n' + marker;
-        if (count > 0 && estimateTokens(candidateWithMarker) > budget) break;
-        accumulated = candidateWithMarker;
-      }
-      currentTableIndex = nodeTableIndex;
-    }
-
-    const dataLine = formatToonDataLine(node);
-    const candidate = accumulated + '\n' + dataLine;
-    if (count > 0 && estimateTokens(candidate) > budget) {
-      if (currentTableIndex !== null) accumulated += '\n#END_TABLE';
-      break;
-    }
+    const candidate = accumulated + '\n' + formatToonDataLine(node);
+    if (count > 0 && estimateTokens(candidate) > budget) break;
     accumulated = candidate;
     count++;
   }
 
-  if (currentTableIndex !== null) accumulated += '\n#END_TABLE';
   return { content: accumulated, count };
 }

--- a/packages/docx-mcp/src/tools/odf/read_file.ts
+++ b/packages/docx-mcp/src/tools/odf/read_file.ts
@@ -11,7 +11,7 @@ import { buildPaginationMeta, DEFAULT_CONTENT_TOKEN_BUDGET, estimateTokens } fro
 import { READ_SIMPLE_PREVIEW_CHARS, previewText } from '../preview.js';
 
 function odfParagraphsToDocumentViewNodes(session: OdfSession): DocumentViewNode[] {
-  return session.doc.getParagraphs().map((paragraph) => ({
+  return session.doc.getParagraphs().map((paragraph: { id: string; text: string }) => ({
     id: paragraph.id,
     list_label: '',
     header: '',

--- a/packages/docx-mcp/src/tools/odf/replace_text.ts
+++ b/packages/docx-mcp/src/tools/odf/replace_text.ts
@@ -1,0 +1,47 @@
+import { stripAllInlineTags } from '@usejunior/docx-core';
+import { type OdfSession, SessionManager } from '../../session/manager.js';
+import { RESULT_PREVIEW_CHARS, previewText } from '../preview.js';
+import { err, ok, type ToolResponse } from '../types.js';
+
+export async function odfReplaceText(
+  manager: SessionManager,
+  session: OdfSession,
+  params: { target_paragraph_id: string; old_string: string; new_string: string; instruction: string },
+  metadata: Record<string, unknown>,
+): Promise<ToolResponse> {
+  try {
+    const pid = params.target_paragraph_id;
+    const oldStr = stripAllInlineTags(params.old_string);
+    const newStr = stripAllInlineTags(params.new_string);
+
+    const beforeText = session.doc.getParagraphTextById(pid);
+    if (beforeText === null) {
+      return err('ANCHOR_NOT_FOUND', `Paragraph ID ${pid} not found in document`);
+    }
+
+    const result = session.doc.replaceTextById(pid, oldStr, newStr);
+    if (!result.ok) {
+      return err(result.code, result.message);
+    }
+    manager.markEdited(session);
+
+    const afterText = session.doc.getParagraphTextById(pid) ?? '';
+
+    return ok({
+      file_path: session.originalPath,
+      provider: 'odf',
+      edit_count: session.editCount,
+      target_paragraph_id: pid,
+      replacements_made: 1,
+      before_text: previewText(beforeText.trim(), RESULT_PREVIEW_CHARS),
+      after_text: previewText(afterText.trim(), RESULT_PREVIEW_CHARS),
+      ...metadata,
+    });
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg.includes('ANCHOR_NOT_FOUND')) return err('ANCHOR_NOT_FOUND', msg);
+    if (msg.includes('TEXT_NOT_FOUND')) return err('TEXT_NOT_FOUND', msg);
+    if (msg.includes('MATCH_SPANS_MULTIPLE_NODES')) return err('MATCH_SPANS_MULTIPLE_NODES', msg);
+    return err('EDIT_ERROR', `Failed to edit ODF document: ${msg}`);
+  }
+}

--- a/packages/docx-mcp/src/tools/odf/save.ts
+++ b/packages/docx-mcp/src/tools/odf/save.ts
@@ -1,0 +1,61 @@
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { type OdfSession, SessionManager } from '../../session/manager.js';
+import { errorCode, errorMessage } from '../../error_utils.js';
+import { enforceWritePathPolicy, resolvesToSamePath } from '../path_policy.js';
+import { err, ok, type ToolResponse } from '../types.js';
+
+function expandPath(inputPath: string): string {
+  return inputPath.startsWith('~') ? path.join(process.env.HOME || '', inputPath.slice(1)) : inputPath;
+}
+
+export async function odfSave(
+  manager: SessionManager,
+  session: OdfSession,
+  params: { save_to_local_path?: string; allow_overwrite?: boolean },
+  metadata: Record<string, unknown>,
+): Promise<ToolResponse> {
+  const rawSavePath = typeof params.save_to_local_path === 'string' ? params.save_to_local_path.trim() : '';
+  if (!rawSavePath) {
+    return err('MISSING_SAVE_PATH', 'save requires save_to_local_path for ODF files.', 'Provide a writable .odt output path.');
+  }
+
+  try {
+    const savePath = expandPath(rawSavePath);
+    const allowOverwrite = params.allow_overwrite ?? false;
+    if (!allowOverwrite && await resolvesToSamePath(savePath, session.originalPath)) {
+      return err(
+        'OVERWRITE_BLOCKED',
+        `Refusing to overwrite original file: ${savePath}`,
+        'Save to a different path, or set allow_overwrite=true if you explicitly want in-place overwrite.',
+      );
+    }
+
+    const writePolicy = await enforceWritePathPolicy(savePath);
+    if (!writePolicy.ok) return writePolicy.response;
+
+    await fs.mkdir(path.dirname(savePath), { recursive: true });
+    const buffer = await manager.saveOdfTo(session, savePath);
+    manager.touch(session);
+
+    return ok({
+      file_path: manager.normalizePath(session.originalPath),
+      provider: 'odf',
+      original_filename: session.filename,
+      edit_count: session.editCount,
+      edit_revision: session.editRevision,
+      saved_to: savePath,
+      size_bytes: buffer.length,
+      save_format: 'odt',
+      returned_variants: ['odt'],
+      message: `ODF document saved to ${savePath}`,
+      ...metadata,
+    });
+  } catch (e: unknown) {
+    const msg = errorMessage(e);
+    if (String(errorCode(e) ?? '').toUpperCase() === 'EACCES') {
+      return err('PERMISSION_DENIED', `Cannot write to: ${rawSavePath}`, 'Try saving to ~/Downloads/ or ~/Documents/ instead.');
+    }
+    return err('SAVE_ERROR', `Failed to save ODF document: ${msg}`, 'Check the path is valid and writable.');
+  }
+}

--- a/packages/docx-mcp/src/tools/open_document.ts
+++ b/packages/docx-mcp/src/tools/open_document.ts
@@ -6,7 +6,7 @@ import { err, ok, type ToolResponse } from './types.js';
 import { enforceReadPathPolicy } from './path_policy.js';
 import { validateDocxArchiveSafety } from './docx_archive_guard.js';
 import { SAFE_DOCX_MCP_TOOLS } from '../tool_catalog.js';
-import { validateOdfArchiveSafety } from '@usejunior/odf-core';
+import { loadOdfCore } from '../odf_loader.js';
 
 function getAvailableToolsSchema(): Array<{
   name: string;
@@ -72,11 +72,21 @@ export async function openDocument(
       return err('VALIDATION_ERROR', 'File too large', 'Check file type (.docx or .odt only) and size (max 50MB).');
     }
     if (extension === '.odt') {
-      const archiveGuard = await validateOdfArchiveSafety(content as Buffer);
+      const odf = await loadOdfCore();
+      if (!odf) {
+        return err(
+          'MISSING_DEPENDENCY',
+          'ODF (.odt) support requires @usejunior/odf-core.',
+          'Install @usejunior/odf-core to enable ODF editing.',
+        );
+      }
+      const archiveGuard = await odf.validateOdfArchiveSafety(content as Buffer);
       if (!archiveGuard.ok) return err(archiveGuard.code, archiveGuard.message, archiveGuard.hint);
 
       const filename = path.basename(safePath);
-      const session = await manager.createOdfSession(content as Buffer, filename, safePath);
+      const archive = await odf.OdfArchive.load(content as Buffer);
+      const doc = odf.OdfDocument.fromContentXml(await archive.getContentXml());
+      const session = await manager.createOdfSession(content as Buffer, filename, safePath, archive, doc);
       const paragraphCount = session.doc.getParagraphs().length;
 
       return ok({

--- a/packages/docx-mcp/src/tools/open_document.ts
+++ b/packages/docx-mcp/src/tools/open_document.ts
@@ -6,6 +6,7 @@ import { err, ok, type ToolResponse } from './types.js';
 import { enforceReadPathPolicy } from './path_policy.js';
 import { validateDocxArchiveSafety } from './docx_archive_guard.js';
 import { SAFE_DOCX_MCP_TOOLS } from '../tool_catalog.js';
+import { validateOdfArchiveSafety } from '@usejunior/odf-core';
 
 function getAvailableToolsSchema(): Array<{
   name: string;
@@ -56,10 +57,10 @@ export async function openDocument(
       );
     }
     const extension = path.extname(expanded).toLowerCase();
-    if (extension !== '.docx') {
+    if (extension !== '.docx' && extension !== '.odt') {
       const hint = extension === '.dotx'
-        ? 'Only .docx files are supported in the local runtime. Convert the .dotx template to .docx before opening it.'
-        : 'Only .docx files are supported.';
+        ? 'Only .docx and .odt files are supported in the local runtime. Convert the .dotx template to .docx before opening it.'
+        : 'Only .docx and .odt files are supported.';
       return err('INVALID_FILE_TYPE', `Invalid file type: ${extension}`, hint);
     }
     const policy = await enforceReadPathPolicy(filePath);
@@ -68,8 +69,35 @@ export async function openDocument(
 
     const content = await fs.readFile(safePath);
     if (content.length > 50 * 1024 * 1024) {
-      return err('VALIDATION_ERROR', 'File too large', 'Check file type (.docx only) and size (max 50MB).');
+      return err('VALIDATION_ERROR', 'File too large', 'Check file type (.docx or .odt only) and size (max 50MB).');
     }
+    if (extension === '.odt') {
+      const archiveGuard = await validateOdfArchiveSafety(content as Buffer);
+      if (!archiveGuard.ok) return err(archiveGuard.code, archiveGuard.message, archiveGuard.hint);
+
+      const filename = path.basename(safePath);
+      const session = await manager.createOdfSession(content as Buffer, filename, safePath);
+      const paragraphCount = session.doc.getParagraphs().length;
+
+      return ok({
+        file_path: manager.normalizePath(session.originalPath),
+        provider: 'odf',
+        expires_at: session.expiresAt.toISOString(),
+        document: {
+          filename,
+          paragraphs: paragraphCount,
+          size_bytes: content.length,
+        },
+        normalization: { runs_merged: 0, redlines_simplified: 0, double_elevations_fixed: 0, normalization_skipped: true },
+        save_defaults: {
+          default_variants: ['odt'],
+          default_save_format: 'odt',
+          supports_variant_override: false,
+        },
+        tools: getAvailableToolsSchema(),
+      });
+    }
+
     const archiveGuard = await validateDocxArchiveSafety(content as Buffer);
     if (!archiveGuard.ok) return archiveGuard.response;
 

--- a/packages/docx-mcp/src/tools/provider_guard.ts
+++ b/packages/docx-mcp/src/tools/provider_guard.ts
@@ -6,12 +6,27 @@ const GDOCS_SUPPORTED_TOOLS = new Set([
   'format_layout', 'get_file_status', 'close_file',
 ]);
 
+const ODF_SUPPORTED_TOOLS = new Set([
+  'read_file', 'replace_text', 'save', 'get_file_status', 'close_file',
+]);
+
 export function checkGDocsSupport(toolName: string): ToolResponse | null {
   if (!GDOCS_SUPPORTED_TOOLS.has(toolName)) {
     return err(
       'UNSUPPORTED_FOR_PROVIDER',
       `'${toolName}' is not supported for Google Docs.`,
       'This tool is only available for DOCX files.',
+    );
+  }
+  return null;
+}
+
+export function checkOdfSupport(toolName: string): ToolResponse | null {
+  if (!ODF_SUPPORTED_TOOLS.has(toolName)) {
+    return err(
+      'UNSUPPORTED_FOR_ODF',
+      `'${toolName}' is not supported for ODF (.odt) files.`,
+      'Use read_file, replace_text, save, get_file_status, or close_file for .odt files.',
     );
   }
   return null;

--- a/packages/docx-mcp/src/tools/session_resolution.ts
+++ b/packages/docx-mcp/src/tools/session_resolution.ts
@@ -1,11 +1,12 @@
 import fs from 'node:fs/promises';
 import { errorCode, errorMessage } from "../error_utils.js";
 import path from 'node:path';
-import { type DocxSession, type GDocsSession, type Session, SessionManager } from '../session/manager.js';
+import { type DocxSession, type GDocsSession, type OdfSession, type Session, SessionManager } from '../session/manager.js';
 import { err, type ToolResponse } from './types.js';
 import { enforceReadPathPolicy } from './path_policy.js';
 import { validateDocxArchiveSafety } from './docx_archive_guard.js';
 import { loadGDocsCore } from '../gdocs_loader.js';
+import { validateOdfArchiveSafety } from '@usejunior/odf-core';
 
 const MAX_DOCX_BYTES = 50 * 1024 * 1024;
 
@@ -28,6 +29,10 @@ export type SessionResolutionOutcome =
 
 export type GDocsSessionResolutionOutcome =
   | { ok: true; session: GDocsSession; metadata: Record<string, unknown> }
+  | { ok: false; response: ToolResponse };
+
+export type OdfSessionResolutionOutcome =
+  | { ok: true; session: OdfSession; metadata: Record<string, unknown> }
   | { ok: false; response: ToolResponse };
 
 // ---------------------------------------------------------------------------
@@ -119,6 +124,80 @@ export async function validateAndLoadDocxFromPath(
   };
 }
 
+export async function validateAndLoadOdfFromPath(
+  manager: SessionManager,
+  filePath: string,
+): Promise<
+  | { ok: true; normalizedPath: string; filename: string; content: Buffer }
+  | { ok: false; response: ToolResponse }
+> {
+  const normalizedPath = manager.normalizePath(filePath);
+  const stat = await fs.stat(normalizedPath).catch(() => null);
+  if (!stat || !stat.isFile()) {
+    return {
+      ok: false,
+      response: err(
+        'FILE_NOT_FOUND',
+        `File not found: ${filePath}`,
+        'Copy the file to ~/Downloads/ or ~/Documents/ first, then pass that path.',
+      ),
+    };
+  }
+  if (path.extname(normalizedPath).toLowerCase() !== '.odt') {
+    return {
+      ok: false,
+      response: err(
+        'INVALID_FILE_TYPE',
+        `Invalid file type: ${path.extname(normalizedPath)}`,
+        'Only .odt files are supported by the ODF provider.',
+      ),
+    };
+  }
+  const policy = await enforceReadPathPolicy(filePath);
+  if (!policy.ok) {
+    return {
+      ok: false,
+      response: policy.response,
+    };
+  }
+  const safePath = policy.normalizedPath;
+  const safeStat = await fs.stat(safePath).catch(() => null);
+  if (!safeStat || !safeStat.isFile()) {
+    return {
+      ok: false,
+      response: err(
+        'FILE_NOT_FOUND',
+        `File not found: ${filePath}`,
+        'Copy the file to ~/Downloads/ or ~/Documents/ first, then pass that path.',
+      ),
+    };
+  }
+  if (safeStat.size > MAX_DOCX_BYTES) {
+    return {
+      ok: false,
+      response: err(
+        'VALIDATION_ERROR',
+        'File too large',
+        'Check file type (.odt only) and size (max 50MB).',
+      ),
+    };
+  }
+  const content = await fs.readFile(safePath);
+  const archiveGuard = await validateOdfArchiveSafety(content as Buffer);
+  if (!archiveGuard.ok) {
+    return {
+      ok: false,
+      response: err(archiveGuard.code, archiveGuard.message, archiveGuard.hint),
+    };
+  }
+  return {
+    ok: true,
+    normalizedPath: safePath,
+    filename: path.basename(safePath),
+    content: content as Buffer,
+  };
+}
+
 export function mergeSessionResolutionMetadata(
   extra: Record<string, unknown>,
   metadata: Record<string, unknown>,
@@ -164,8 +243,19 @@ export async function resolveSessionForTool(
 
   const canonicalPath = await manager.canonicalizePath(filePath);
 
-  // Check for existing session (file-path keyed sessions are always DocxSession)
-  const existing = manager.getSessionByPath(canonicalPath) as DocxSession | null;
+  // Check for existing session. ODF is path-keyed too, but this resolver must remain DOCX-only.
+  const existingSession = manager.getSessionByPath(canonicalPath);
+  if (existingSession && existingSession.provider !== 'docx') {
+    return {
+      ok: false,
+      response: err(
+        'UNSUPPORTED_FOR_ODF',
+        `Tool '${opts.toolName}' is not supported for ODF (.odt) files.`,
+        'Use read_file, replace_text, save, get_file_status, or close_file for .odt files.',
+      ),
+    };
+  }
+  const existing = existingSession as DocxSession | null;
   if (existing) {
     const reuseLastUsed = existing.lastAccessedAt.toISOString();
     manager.touch(existing);
@@ -216,6 +306,16 @@ export async function resolveSessionForTool(
 
   const outcomePromise: Promise<SessionResolutionOutcome> = (async () => {
     try {
+      if (path.extname(manager.normalizePath(filePath)).toLowerCase() === '.odt') {
+        return {
+          ok: false as const,
+          response: err(
+            'UNSUPPORTED_FOR_ODF',
+            `Tool '${opts.toolName}' is not supported for ODF (.odt) files.`,
+            'Use read_file, replace_text, save, get_file_status, or close_file for .odt files.',
+          ),
+        };
+      }
       const loaded = await validateAndLoadDocxFromPath(manager, filePath);
       if (!loaded.ok) {
         return { ok: false as const, response: loaded.response };
@@ -249,6 +349,131 @@ export async function resolveSessionForTool(
   // Prevent unhandled rejection warnings for exceptional throws
   outcomePromise.catch(() => {});
 
+  pendingMap.set(canonicalPath, outcomePromise);
+  return await outcomePromise;
+}
+
+// ---------------------------------------------------------------------------
+// ODF session resolution
+// ---------------------------------------------------------------------------
+
+const odfPendingByManager = new WeakMap<SessionManager, Map<string, Promise<OdfSessionResolutionOutcome>>>();
+
+function getOdfPendingMap(manager: SessionManager): Map<string, Promise<OdfSessionResolutionOutcome>> {
+  let map = odfPendingByManager.get(manager);
+  if (!map) {
+    map = new Map();
+    odfPendingByManager.set(manager, map);
+  }
+  return map;
+}
+
+export async function resolveOdfSessionForTool(
+  manager: SessionManager,
+  params: { file_path?: unknown },
+  opts: { toolName: string },
+): Promise<OdfSessionResolutionOutcome> {
+  const filePath = typeof params.file_path === 'string' ? params.file_path.trim() : '';
+
+  if (!filePath) {
+    return {
+      ok: false,
+      response: err(
+        'MISSING_FILE_PATH',
+        `Tool '${opts.toolName}' requires file_path.`,
+        "Provide the path to a .odt file in ~/Downloads/ or ~/Documents/.",
+      ),
+    };
+  }
+
+  const canonicalPath = await manager.canonicalizePath(filePath);
+
+  const existing = manager.getSessionByPath(canonicalPath);
+  if (existing && existing.provider === 'odf') {
+    const reuseLastUsed = existing.lastAccessedAt.toISOString();
+    manager.touch(existing);
+    const staleWarning = await checkStaleness(existing, canonicalPath);
+    return {
+      ok: true,
+      session: existing,
+      metadata: {
+        session_resolution: 'reused' as SessionResolutionMode,
+        resolved_file_path: canonicalPath,
+        ...(staleWarning ? { stale_warning: staleWarning } : {}),
+        reused_session_context: {
+          edit_revision: existing.editRevision,
+          edit_count: existing.editCount,
+          created_at: existing.createdAt.toISOString(),
+          last_used_at: reuseLastUsed,
+        },
+      },
+    };
+  }
+
+  if (existing) {
+    return {
+      ok: false,
+      response: err(
+        'INVALID_FILE_TYPE',
+        `Existing session for ${filePath} is provider '${existing.provider}', not ODF.`,
+        'Use the matching provider arguments for the active session.',
+      ),
+    };
+  }
+
+  const pendingMap = getOdfPendingMap(manager);
+  const pending = pendingMap.get(canonicalPath);
+
+  if (pending) {
+    const outcome = await pending;
+    if (outcome.ok) {
+      manager.touch(outcome.session);
+      return {
+        ok: true,
+        session: outcome.session,
+        metadata: {
+          ...outcome.metadata,
+          session_resolution: 'reused' as SessionResolutionMode,
+          session_resolution_detail: 'awaited_concurrent_open',
+          resolved_file_path: canonicalPath,
+        },
+      };
+    }
+    return outcome;
+  }
+
+  let storedPromise!: Promise<OdfSessionResolutionOutcome>;
+
+  const outcomePromise: Promise<OdfSessionResolutionOutcome> = (async () => {
+    try {
+      const loaded = await validateAndLoadOdfFromPath(manager, filePath);
+      if (!loaded.ok) {
+        return { ok: false as const, response: loaded.response };
+      }
+
+      const session = await manager.createOdfSession(
+        loaded.content,
+        loaded.filename,
+        loaded.normalizedPath,
+      );
+
+      return {
+        ok: true as const,
+        session,
+        metadata: {
+          session_resolution: 'opened' as SessionResolutionMode,
+          resolved_file_path: canonicalPath,
+        },
+      };
+    } finally {
+      if (pendingMap.get(canonicalPath) === storedPromise) {
+        pendingMap.delete(canonicalPath);
+      }
+    }
+  })();
+
+  storedPromise = outcomePromise;
+  outcomePromise.catch(() => {});
   pendingMap.set(canonicalPath, outcomePromise);
   return await outcomePromise;
 }

--- a/packages/docx-mcp/src/tools/session_resolution.ts
+++ b/packages/docx-mcp/src/tools/session_resolution.ts
@@ -6,7 +6,7 @@ import { err, type ToolResponse } from './types.js';
 import { enforceReadPathPolicy } from './path_policy.js';
 import { validateDocxArchiveSafety } from './docx_archive_guard.js';
 import { loadGDocsCore } from '../gdocs_loader.js';
-import { validateOdfArchiveSafety } from '@usejunior/odf-core';
+import { loadOdfCore } from '../odf_loader.js';
 
 const MAX_DOCX_BYTES = 50 * 1024 * 1024;
 
@@ -128,7 +128,7 @@ export async function validateAndLoadOdfFromPath(
   manager: SessionManager,
   filePath: string,
 ): Promise<
-  | { ok: true; normalizedPath: string; filename: string; content: Buffer }
+  | { ok: true; normalizedPath: string; filename: string; content: Buffer; archive: any; doc: any }
   | { ok: false; response: ToolResponse }
 > {
   const normalizedPath = manager.normalizePath(filePath);
@@ -182,19 +182,34 @@ export async function validateAndLoadOdfFromPath(
       ),
     };
   }
+  const odf = await loadOdfCore();
+  if (!odf) {
+    return {
+      ok: false,
+      response: err(
+        'MISSING_DEPENDENCY',
+        'ODF (.odt) support requires @usejunior/odf-core.',
+        'Install @usejunior/odf-core to enable ODF editing.',
+      ),
+    };
+  }
   const content = await fs.readFile(safePath);
-  const archiveGuard = await validateOdfArchiveSafety(content as Buffer);
+  const archiveGuard = await odf.validateOdfArchiveSafety(content as Buffer);
   if (!archiveGuard.ok) {
     return {
       ok: false,
       response: err(archiveGuard.code, archiveGuard.message, archiveGuard.hint),
     };
   }
+  const archive = await odf.OdfArchive.load(content as Buffer);
+  const doc = odf.OdfDocument.fromContentXml(await archive.getContentXml());
   return {
     ok: true,
     normalizedPath: safePath,
     filename: path.basename(safePath),
     content: content as Buffer,
+    archive,
+    doc,
   };
 }
 
@@ -455,6 +470,8 @@ export async function resolveOdfSessionForTool(
         loaded.content,
         loaded.filename,
         loaded.normalizedPath,
+        loaded.archive,
+        loaded.doc,
       );
 
       return {

--- a/packages/docx-mcp/tsconfig.json
+++ b/packages/docx-mcp/tsconfig.json
@@ -15,5 +15,5 @@
     "tsBuildInfoFile": "dist/.tsbuildinfo"
   },
   "include": ["src/**/*.ts", "test/**/*.ts"],
-  "references": [{ "path": "../docx-core" }, { "path": "../google-docs-core" }]
+  "references": [{ "path": "../docx-core" }, { "path": "../odf-core" }, { "path": "../google-docs-core" }]
 }


### PR DESCRIPTION
## Summary
Wires the merged `@usejunior/odf-core` (#328) into the MCP server as a third provider lane (mirroring Google Docs), so an agent can `open → read_file → replace_text → save` a real `.odt` over MCP. Implements the approved `add-odf-core` **Provider-Aware Local Resolution** requirement (OPLR-01..05). Closes #333.

## Implementation
- **Session:** `OdfSession` in the `Session` union + `createOdfSession` + ODF save path (`session/manager.ts`).
- **Resolver chokepoint (key safety property):** `validateAndLoadOdfFromPath` + `resolveOdfSessionForTool`; and a provider-check in `resolveSessionForTool` — before the `as DocxSession` cast (existing session) and before the DOCX auto-open (fresh `.odt`), an ODF target returns `UNSUPPORTED_FOR_ODF`. So unsupported tools never reach DOCX-only fields, and `resolveSessionForTool`'s `DocxSession` return type is **not** widened.
- **Guard:** `checkOdfSupport` returns `UNSUPPORTED_FOR_ODF` (per spec; not the gdocs `UNSUPPORTED_FOR_PROVIDER`).
- **Handlers:** `tools/odf/{read_file,replace_text,save,get_file_status,close_file}.ts`. `read_file` maps `OdfDocument.getParagraphs()` `{id,text}` → default body `DocumentViewNode` (adapter, no raw cast).
- **Dispatch:** synchronous extension-only `isOdfRequest` + `dispatchOdf` for the 5 supported tools (after the gdocs branch); DOCX unchanged fall-through.
- **Open path:** `.odt` branch in `open_document.ts`; `INVALID_FILE_TYPE` preserved for genuinely unsupported extensions.
- **Spec/docs:** moved Provider-Aware Local Resolution to an `mcp-server` spec delta (so docx-mcp spec-coverage recognizes it); updated `tool_catalog.ts` provider text + regenerated `tool-reference.generated.md`.

DOCX + Google Docs code paths are behaviorally unchanged.

## Verification
- [x] `npm run build` (full workspace)
- [x] `npm run lint:workspaces` (0 errors)
- [x] `npm run test:run -w @usejunior/docx-mcp` — **790 passed** (incl. new `odf_tools.test.ts`, Allure-wrapped, mapping OPLR-01..05)
- [x] `npm run check:spec-coverage --strict` — **PASS add-odf-core: 5 scenarios / 5 mappings**
- [x] `npm run check:cycles` (no madge cycle from the odf-core import)
- [x] `check:conformance-citations` / `check:conformance-doc` / `check:tool-docs`
- [x] **End-to-end MCP-dispatch smoke on a real NVCA-derived `.odt`**: `read_file` (341 paras) → `replace_text` "AMENDED AND RESTATED"→"REVISED AND RESTATED" → `save` → reopen; `compare_documents` → `UNSUPPORTED_FOR_ODF`; LibreOffice reopened the edited `.odt`.
- [ ] Peer review (Codex + agy) — pending; appended below.

## Process
Implemented via codex-implement against a plan peer-reviewed (Codex + agy) before delegation; the BLOCKER (`UNSUPPORTED_FOR_ODF`), the DocxSession-cast chokepoint, the odf-core dep wiring, the sync discriminant, and the read_file adapter were all caught in that review and built in from the start.

## Closes
- #333 (Ref: #328 library, #326 release isolation)