### PR TITLE
feat(docx-mcp): ODF grep + insert_paragraph (Phase 2a)

### DIFF
--- a/openspec/changes/add-odf-core/specs/mcp-server/spec.md
+++ b/openspec/changes/add-odf-core/specs/mcp-server/spec.md
@@ -30,7 +30,7 @@ never reach DOCX-only fields. Genuinely unsupported extensions SHALL still retur
 - **THEN** the ODF handler services it and the DOCX/gdocs handlers are not invoked
 
 #### Scenario: [OPLR-04] Unsupported tools are guarded for ODF
-- **WHEN** a Phase-2 tool (e.g. `compare_documents`, `add_comment`, `insert_paragraph`) is invoked against an ODF session
+- **WHEN** a Phase-2 tool (e.g. `compare_documents`, `add_comment`) is invoked against an ODF session
 - **THEN** an `UNSUPPORTED_FOR_ODF` error is returned and no DOCX logic runs
 
 #### Scenario: [OPLR-05] File-first `.odt` auto-opens

--- a/openspec/changes/add-odf-grep-insert/design.md
+++ b/openspec/changes/add-odf-grep-insert/design.md
@@ -1,0 +1,35 @@
+# Design notes — ODF `grep` + `insert_paragraph`
+
+## Positional ID shift (key decision)
+ODF paragraph IDs are document-order ordinals (`p0,p1,…`); there are no durable anchors yet
+(deferred). Inserting shifts every ID at/after the insertion point. Two peer reviewers (Codex,
+agy) agreed this is acceptable for Phase 2a **provided** the contract is machine-actionable:
+- `insertParagraph` returns the inserted blocks' freshly recomputed IDs.
+- The tool response includes `invalidates_paragraph_ids_after`, `requires_reread_before_next_edit`,
+  and a human `ids_note`.
+- `replaceTextById` already fails closed with `TEXT_NOT_FOUND` on a stale ID (verified), so a
+  mis-targeted edit errors rather than silently corrupting the wrong paragraph.
+Durable injected `xml:id` anchors remain out of scope.
+
+## grep core extraction
+The DOCX grep search loop is pure over `{id,text}[]` + an optional locator map. Extracted to
+`tools/grep_core.ts` (`searchParagraphsCore` / `searchRawXmlCore`) so the ODF lane reuses it
+without duplicating the dedupe / truncation / context logic. Behavior-preserving — covered by
+the existing `grep.test.ts` (agy ran it green). ODF passes `locatorById = null` (no list-label /
+header in the ODF view).
+
+## Style inheritance heading guard
+Copying `text:style-name` blindly from a `text:h` anchor would make an inserted body paragraph
+render as a heading. Guard: inherit only when `anchor.localName === 'p'`.
+
+## `\n\n` parity
+DOCX `insert_paragraph` splits `new_string` on blank lines into multiple paragraphs. ODF matches
+this (blank line → separate `text:p`; single `\n` → `text:line-break`) so agents get consistent
+multi-paragraph behavior across providers.
+
+## Dispatch safety
+`isGDocsRequest` keys on `google_doc_id`; `isOdfRequest` keys on the `.odt` extension and is
+checked after the gdocs branch. Multi-file grep uses `file_paths` (not `file_path`), so
+`isOdfRequest` is false there and it stays on the DOCX lane (which rejects `.odt` gracefully).
+No session-key collision: gdocs sessions are keyed `gdocs:<id>`, docx/odf by canonical path, and
+the `resolveSessionForTool` chokepoint returns `UNSUPPORTED_FOR_ODF` before any DocxSession cast.

--- a/openspec/changes/add-odf-grep-insert/proposal.md
+++ b/openspec/changes/add-odf-grep-insert/proposal.md
@@ -1,0 +1,37 @@
+# Change: Extend the ODF (.odt) lane with `grep` and `insert_paragraph`
+
+## Why
+Phase 1 (`add-odf-core`) wired a provider-aware ODF lane so an agent can
+`open → read_file → replace_text → save` a real `.odt`. The next two tools an editing
+agent reaches for are `grep` (locate text before editing) and `insert_paragraph` (add
+content). Both extend the existing five-tool ODF lane and the `OdfDocument` view without
+the heavy machinery that `compare_documents` / comments require (a tracked-changes
+atomizer + `office:annotation`), which stay deferred to a later phase.
+
+## What Changes
+- `@usejunior/odf-core`: add `OdfDocument.insertParagraph(id, text, BEFORE|AFTER)` — creates
+  one or more `text:p` blocks (blank lines split into separate paragraphs; single newlines
+  become `text:line-break`), inheriting the anchor's `text:style-name` only when the anchor
+  is a body paragraph (never propagating a heading style), and returns the inserted blocks'
+  freshly recomputed positional IDs.
+- `@usejunior/docx-mcp`: add `grep` and `insert_paragraph` to the ODF supported-tool set;
+  add `tools/odf/{grep,insert_paragraph}.ts` handlers; add `isOdfRequest` dispatch branches;
+  extract a shared, pure `tools/grep_core.ts` (behavior-preserving refactor of the DOCX grep
+  search core) reused by both lanes.
+- ODF `grep` is session-mode (`file_path`) only; multi-file `file_paths` stays on the DOCX
+  lane. ODF paragraphs carry no list-label / header context, so those fields are empty.
+- `insert_paragraph` responses carry machine-actionable ID-invalidation fields
+  (`invalidates_paragraph_ids_after`, `requires_reread_before_next_edit`) because ODF
+  paragraph IDs are positional and shift on insertion.
+
+## Impact
+- Affected specs: `mcp-server` (ADDED: extended ODF tool support, OPLR-06/OPLR-07);
+  `odf-core` (ADDED: paragraph insertion).
+- Affected code: `packages/odf-core/src/{document,index}.ts`;
+  `packages/docx-mcp/src/tools/{grep.ts, grep_core.ts, provider_guard.ts, session_resolution.ts,
+  odf/grep.ts, odf/insert_paragraph.ts}`; `packages/docx-mcp/src/server.ts`;
+  `tool_catalog.ts` + regenerated tool docs. DOCX and Google Docs paths unchanged.
+- `odf-core` stays `private: true` (no name-squatting; optional-lazy provider, not a
+  published dependency of docx-mcp).
+- Out of scope: `compare_documents`, comments, durable injected `xml:id` anchors,
+  cross-span `replace_text`, multi-file ODF grep, `.ods`/`.odp`.

--- a/openspec/changes/add-odf-grep-insert/specs/mcp-server/spec.md
+++ b/openspec/changes/add-odf-grep-insert/specs/mcp-server/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Extended ODF Tool Support (`grep`, `insert_paragraph`)
+
+The MCP server SHALL service `grep` and `insert_paragraph` for ODF sessions via the
+provider-aware `.odt` lane, in addition to the Phase-1 tools (`read_file`, `replace_text`,
+`save`, `get_file_status`, `close_file`). Both SHALL route to the ODF handler when the
+`file_path` ends in `.odt` (or resolves to an existing `OdfSession`); the DOCX and Google
+Docs paths SHALL remain unchanged, and every still-unsupported tool SHALL continue to return
+`UNSUPPORTED_FOR_ODF`.
+
+ODF `grep` SHALL operate in single-file session mode (a `.odt` `file_path`); multi-file
+`file_paths` search remains a DOCX-lane capability. ODF paragraphs carry no list-label /
+header context, so those fields SHALL be empty strings.
+
+ODF `insert_paragraph` SHALL insert one or more `text:p` blocks before or after the anchor
+paragraph (blank lines splitting `new_string` into separate paragraphs; single newlines
+mapping to `text:line-break`), inheriting the anchor's paragraph style only when the anchor
+is a body paragraph (never propagating a heading style). Because ODF paragraph IDs are
+positional ordinals, the response SHALL return the inserted blocks' freshly recomputed IDs
+and SHALL carry machine-actionable invalidation signals
+(`invalidates_paragraph_ids_after`, `requires_reread_before_next_edit`) so the agent
+re-reads before its next edit.
+
+#### Scenario: [OPLR-06] `grep` searches an ODF session
+- **WHEN** `grep` is invoked with a `.odt` `file_path` and a pattern
+- **THEN** the ODF handler returns matches with paragraph IDs, 1-based indices, and context, and the DOCX/gdocs handlers are not invoked
+
+#### Scenario: [OPLR-07] `insert_paragraph` inserts into an ODF session
+- **WHEN** `insert_paragraph` is invoked with a `.odt` `file_path`, an anchor paragraph ID, and `new_string`
+- **THEN** a new paragraph is inserted before/after the anchor, the response returns the new positional paragraph ID(s) and ID-invalidation fields, and re-reading reflects the inserted text
+
+#### Scenario: [OPLR-08] Still-unsupported tools remain guarded
+- **WHEN** a tool outside the ODF supported set (e.g. `compare_documents`, `add_comment`) is invoked against a `.odt` path or ODF session
+- **THEN** an `UNSUPPORTED_FOR_ODF` error is returned and no DOCX logic runs

--- a/openspec/changes/add-odf-grep-insert/specs/odf-core/spec.md
+++ b/openspec/changes/add-odf-grep-insert/specs/odf-core/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: ODF Paragraph Insertion
+
+`OdfDocument` SHALL provide `insertParagraph(id, text, position)` that inserts one or more
+block-level paragraphs (`text:p`) before or after the paragraph identified by `id`. The
+method SHALL split `text` on blank lines (`\n{2,}`) into separate paragraphs and map a single
+newline within a block to a `text:line-break`. It SHALL inherit the anchor paragraph's
+`text:style-name` only when the anchor is itself a `text:p`; when the anchor is a heading
+(`text:h`), the inserted blocks SHALL be default body paragraphs without the heading style.
+
+Because paragraph IDs are positional ordinals, insertion SHALL rebuild the structural block
+index and SHALL return the inserted blocks' freshly recomputed IDs in document order. A
+non-resolving anchor `id` SHALL return an `ANCHOR_NOT_FOUND` result rather than throwing.
+
+#### Scenario: [OINS-01] Insert after a body paragraph
+- **WHEN** `insertParagraph(id, "New text", "AFTER")` is called for a `text:p` anchor
+- **THEN** a new `text:p` carrying the anchor's style is inserted immediately after it, and its new positional ID is returned
+
+#### Scenario: [OINS-02] Insert before, heading anchor does not propagate heading style
+- **WHEN** `insertParagraph(id, "Body", "BEFORE")` is called for a `text:h` anchor
+- **THEN** a default body `text:p` (no heading style) is inserted immediately before it
+
+#### Scenario: [OINS-03] Blank lines split into multiple paragraphs
+- **WHEN** `text` contains a blank line (`\n\n`)
+- **THEN** multiple `text:p` blocks are created and all of their new IDs are returned
+
+#### Scenario: [OINS-04] Unknown anchor returns ANCHOR_NOT_FOUND
+- **WHEN** `insertParagraph` is called with an id that does not resolve to a block
+- **THEN** an `{ ok: false, code: 'ANCHOR_NOT_FOUND' }` result is returned (no throw)

--- a/openspec/changes/add-odf-grep-insert/tasks.md
+++ b/openspec/changes/add-odf-grep-insert/tasks.md
@@ -17,7 +17,8 @@
 - [x] Update `tool_catalog.ts` provider text + regenerate `tool-reference.generated.md`
 
 ## Tests & verification
-- [ ] odf-core `document.test.ts`: insert BEFORE/AFTER, style inherit + heading guard, ID shift, line-break, ANCHOR_NOT_FOUND
-- [ ] docx-mcp ODF grep + insert scenarios (OPLR-06/07) + branch tests (MISSING_PATTERN, INVALID_POSITION, dedupe, search_xml), `TEST_FEATURE='add-odf-grep-insert'`
-- [ ] Full CI gate locally + document-shaped `.odt` smoke (grep + insert on real NVCA .odt, reopen in LibreOffice)
-- [ ] Coverage ratchet not regressed
+- [x] odf-core `document.test.ts`: insert BEFORE/AFTER, style inherit + heading guard, ID shift, line-break, ANCHOR_NOT_FOUND
+- [x] docx-mcp ODF grep + insert scenarios (OPLR-06/07/08) + branch tests (MISSING_PATTERN, INVALID_POSITION, dedupe, search_xml), `TEST_FEATURE='add-odf-grep-insert'`
+- [x] Peer-review fixes: compare_documents two-file `.odt` guard (UNSUPPORTED_FOR_ODF); hoist `.odt` early-return before pending-map (correct tool name) — both with regression tests
+- [x] Full CI gate locally + document-shaped `.odt` smoke (grep + insert on real NVCA .odt, reopen in LibreOffice)
+- [x] Coverage ratchet not regressed

--- a/openspec/changes/add-odf-grep-insert/tasks.md
+++ b/openspec/changes/add-odf-grep-insert/tasks.md
@@ -1,0 +1,23 @@
+# Tasks
+
+## odf-core
+- [x] Add `OdfDocument.insertParagraph(id, text, BEFORE|AFTER)` + `InsertResult` type
+- [x] Heading-aware style inheritance (inherit `text:style-name` only from `text:p` anchors)
+- [x] Blank-line → multiple `text:p`; single `\n` → `text:line-break`
+- [x] Rebuild positional block index; return freshly recomputed new IDs
+- [x] Export `InsertResult` from package index
+
+## docx-mcp
+- [x] Extract pure `tools/grep_core.ts` (searchParagraphsCore / searchRawXmlCore)
+- [x] Refactor `tools/grep.ts` to delegate to the core (no behavior change)
+- [x] Add `tools/odf/grep.ts` (session-mode, no locator context)
+- [x] Add `tools/odf/insert_paragraph.ts` (ID-invalidation fields in response)
+- [x] Add `grep`, `insert_paragraph` to `ODF_SUPPORTED_TOOLS`; update both ODF hint strings
+- [x] Register handlers in `loadOdfHandlers`; add `isOdfRequest` dispatch branches
+- [x] Update `tool_catalog.ts` provider text + regenerate `tool-reference.generated.md`
+
+## Tests & verification
+- [ ] odf-core `document.test.ts`: insert BEFORE/AFTER, style inherit + heading guard, ID shift, line-break, ANCHOR_NOT_FOUND
+- [ ] docx-mcp ODF grep + insert scenarios (OPLR-06/07) + branch tests (MISSING_PATTERN, INVALID_POSITION, dedupe, search_xml), `TEST_FEATURE='add-odf-grep-insert'`
+- [ ] Full CI gate locally + document-shaped `.odt` smoke (grep + insert on real NVCA .odt, reopen in LibreOffice)
+- [ ] Coverage ratchet not regressed

--- a/packages/docx-mcp/docs/tool-reference.generated.md
+++ b/packages/docx-mcp/docs/tool-reference.generated.md
@@ -26,7 +26,7 @@ Read document content (DOCX, ODT, or Google Doc). Output is token-limited (~14k 
 
 ## `grep`
 
-Search paragraphs with regex. Use file_path for session-based search, file_paths for stateless multi-file search, or google_doc_id for Google Docs.
+Search paragraphs with regex. Use file_path for session-based search, file_paths for stateless multi-file search, or google_doc_id for Google Docs. ODT supported via file_path (single-file) only.
 
 - readOnly: `true`
 - destructive: `false`
@@ -104,7 +104,7 @@ Replace text in a paragraph by provider paragraph id, preserving formatting wher
 
 ## `insert_paragraph`
 
-Insert a paragraph before/after an anchor paragraph by _bk_* id. Supports DOCX and Google Docs.
+Insert a paragraph before/after an anchor paragraph by paragraph id. Supports DOCX, ODT, and Google Docs. (ODT paragraph ids are positional and shift after insertion — re-read before further edits.)
 
 - readOnly: `false`
 - destructive: `true`

--- a/packages/docx-mcp/src/server.ts
+++ b/packages/docx-mcp/src/server.ts
@@ -77,9 +77,11 @@ async function loadGDocsHandlers(): Promise<typeof gdocsHandlers> {
 
 async function loadOdfHandlers(): Promise<typeof odfHandlers> {
   if (odfHandlers) return odfHandlers;
-  const [readFile, replaceText, save, getFileStatus, closeFile] = await Promise.all([
+  const [readFile, replaceText, grep, insertParagraph, save, getFileStatus, closeFile] = await Promise.all([
     import('./tools/odf/read_file.js'),
     import('./tools/odf/replace_text.js'),
+    import('./tools/odf/grep.js'),
+    import('./tools/odf/insert_paragraph.js'),
     import('./tools/odf/save.js'),
     import('./tools/odf/get_file_status.js'),
     import('./tools/odf/close_file.js'),
@@ -87,6 +89,8 @@ async function loadOdfHandlers(): Promise<typeof odfHandlers> {
   odfHandlers = {
     read_file: readFile.odfReadFile,
     replace_text: replaceText.odfReplaceText,
+    grep: grep.odfGrep,
+    insert_paragraph: insertParagraph.odfInsertParagraph,
     save: save.odfSave,
     get_file_status: getFileStatus.odfGetFileStatus,
     close_file: closeFile.odfCloseFile,
@@ -136,6 +140,7 @@ export async function dispatchToolCall(
       return await readFile(sessions, args as Parameters<typeof readFile>[1]);
     case 'grep':
       if (isGDocsRequest(args)) return await dispatchGDocs(sessions, args, 'grep');
+      if (isOdfRequest(args)) return await dispatchOdf(sessions, args, 'grep');
       return await grep(sessions, args as Parameters<typeof grep>[1]);
     case 'init_plan':
       return await initPlan(sessions, args as Parameters<typeof initPlan>[1]);
@@ -149,6 +154,7 @@ export async function dispatchToolCall(
       return await replaceText(sessions, args as Parameters<typeof replaceText>[1]);
     case 'insert_paragraph':
       if (isGDocsRequest(args)) return await dispatchGDocs(sessions, args, 'insert_paragraph');
+      if (isOdfRequest(args)) return await dispatchOdf(sessions, args, 'insert_paragraph');
       return await insertParagraph(sessions, args as Parameters<typeof insertParagraph>[1]);
     case 'save':
       if (isGDocsRequest(args)) return await dispatchGDocs(sessions, args, 'save');

--- a/packages/docx-mcp/src/server.ts
+++ b/packages/docx-mcp/src/server.ts
@@ -46,6 +46,18 @@ function isOdfRequest(args: Record<string, unknown>): boolean {
   return path.extname(filePath).toLowerCase() === '.odt';
 }
 
+/**
+ * True when any input-path field on the args points at a `.odt`. Used to guard tools
+ * that take path fields other than `file_path` (e.g. `compare_documents`'s two-file
+ * `original_file_path` / `revised_file_path`), which `isOdfRequest` does not cover.
+ */
+function hasOdfInputPath(args: Record<string, unknown>, fields: string[]): boolean {
+  return fields.some((f) => {
+    const v = args[f];
+    return typeof v === 'string' && path.extname(v.trim()).toLowerCase() === '.odt';
+  });
+}
+
 // Lazy-loaded gdocs handler map (populated on first gdocs request)
 let gdocsHandlers: Record<string, (m: SessionManager, s: GDocsSession, p: any, meta: Record<string, unknown>) => Promise<ToolResponse>> | null = null;
 let odfHandlers: Record<string, (m: SessionManager, s: OdfSession, p: any, meta: Record<string, unknown>) => Promise<ToolResponse>> | null = null;
@@ -184,6 +196,12 @@ export async function dispatchToolCall(
     case 'delete_comment':
       return await deleteComment(sessions, args as Parameters<typeof deleteComment>[1]);
     case 'compare_documents':
+      // compare_documents resolves its inputs via original_file_path / revised_file_path
+      // (not file_path), so the shared resolver's .odt chokepoint can't see them. Guard
+      // here: a .odt on any input path is UNSUPPORTED_FOR_ODF (compare is Phase-2b ODF work).
+      if (isOdfRequest(args) || hasOdfInputPath(args, ['original_file_path', 'revised_file_path'])) {
+        return checkOdfSupport('compare_documents')!;
+      }
       return await compareDocuments_tool(sessions, args as Parameters<typeof compareDocuments_tool>[1]);
     case 'get_footnotes':
       return await getFootnotes(sessions, args as Parameters<typeof getFootnotes>[1]);

--- a/packages/docx-mcp/src/tool_catalog.ts
+++ b/packages/docx-mcp/src/tool_catalog.ts
@@ -63,7 +63,7 @@ export const SAFE_DOCX_TOOL_CATALOG = [
   },
   {
     name: 'grep',
-    description: 'Search paragraphs with regex. Use file_path for session-based search, file_paths for stateless multi-file search, or google_doc_id for Google Docs.',
+    description: 'Search paragraphs with regex. Use file_path for session-based search, file_paths for stateless multi-file search, or google_doc_id for Google Docs. ODT supported via file_path (single-file) only.',
     input: z.object({
       ...FILE_FIELD_OPTIONAL,
       ...GOOGLE_DOC_ID_FIELD,
@@ -136,7 +136,7 @@ export const SAFE_DOCX_TOOL_CATALOG = [
   },
   {
     name: 'insert_paragraph',
-    description: 'Insert a paragraph before/after an anchor paragraph by _bk_* id. Supports DOCX and Google Docs.',
+    description: 'Insert a paragraph before/after an anchor paragraph by paragraph id. Supports DOCX, ODT, and Google Docs. (ODT paragraph ids are positional and shift after insertion — re-read before further edits.)',
     input: z.object({
       ...FILE_FIELD_OPTIONAL,
       ...GOOGLE_DOC_ID_FIELD,

--- a/packages/docx-mcp/src/tools/grep.ts
+++ b/packages/docx-mcp/src/tools/grep.ts
@@ -3,38 +3,15 @@ import { SessionManager } from '../session/manager.js';
 import { errorCode, errorMessage } from "../error_utils.js";
 import { err, ok, type ToolResponse } from './types.js';
 import { mergeSessionResolutionMetadata, resolveSessionForTool, validateAndLoadDocxFromPath } from './session_resolution.js';
+import {
+  searchParagraphsCore,
+  searchRawXmlCore,
+  type Locator,
+  type SearchParagraphsResult,
+} from './grep_core.js';
 
 // ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-type ParagraphMatch = {
-  para_id: string;
-  para_index_1based: number;
-  list_label: string;
-  header: string;
-  match_count_in_paragraph: number;
-  match_text: string;
-  context: string;
-};
-
-type XmlMatch = {
-  char_start: number;
-  char_end: number;
-  line: number;
-  match_text: string;
-  context: string;
-};
-
-type SearchParagraphsResult = {
-  matches: ParagraphMatch[];
-  totalMatches: number;
-  paragraphsWithMatches: number;
-  matchesTruncated: boolean;
-};
-
-// ---------------------------------------------------------------------------
-// Pure search core — extracted for reuse across session and stateless paths
+// DOCX-specific search wrappers over the shared pure core (grep_core.ts).
 // ---------------------------------------------------------------------------
 
 function searchParagraphs(
@@ -47,13 +24,12 @@ function searchParagraphs(
     includeContext?: boolean;
   },
 ): SearchParagraphsResult {
-  const { maxResults, contextChars, dedupeByParagraph } = opts;
   const includeCtx = opts.includeContext ?? true;
 
   const { paragraphs } = doc.readParagraphs();
   const typed = paragraphs as Array<{ id: string; text: string }>;
 
-  let locatorById: Map<string, { list_label: string; header: string }> | null = null;
+  let locatorById: Map<string, Locator> | null = null;
   if (includeCtx) {
     const { nodes } = doc.buildDocumentView({ includeSemanticTags: true });
     locatorById = new Map(
@@ -61,125 +37,15 @@ function searchParagraphs(
     );
   }
 
-  const matches: ParagraphMatch[] = [];
-  const paragraphsWithMatchesSet = new Set<string>();
-  let totalMatches = 0;
-  let matchesTruncated = false;
-
-  for (let paraIndex = 0; paraIndex < typed.length; paraIndex += 1) {
-    const p = typed[paraIndex]!;
-    re.lastIndex = 0;
-    const text = p.text;
-    let m: RegExpExecArray | null;
-    let paragraphMatchCount = 0;
-    let firstMatchText = '';
-    let firstMatchIndex = -1;
-    // eslint-disable-next-line no-cond-assign
-    while ((m = re.exec(text)) !== null) {
-      totalMatches += 1;
-      paragraphMatchCount += 1;
-      if (firstMatchIndex === -1) {
-        firstMatchText = m[0];
-        firstMatchIndex = m.index;
-      }
-      if (!dedupeByParagraph) {
-        if (matches.length < maxResults) {
-          const start = Math.max(0, m.index - contextChars);
-          const end = Math.min(text.length, m.index + m[0].length + contextChars);
-          const before = text.slice(start, m.index);
-          const after = text.slice(m.index + m[0].length, end);
-          const locator = locatorById?.get(p.id) ?? { list_label: '', header: '' };
-          matches.push({
-            para_id: p.id,
-            para_index_1based: paraIndex + 1,
-            list_label: locator.list_label,
-            header: locator.header,
-            match_count_in_paragraph: 1,
-            match_text: m[0],
-            context: `...${before}>>>${m[0]}<<<${after}...`,
-          });
-        } else {
-          matchesTruncated = true;
-        }
-      }
-      if (m[0].length === 0) break; // safety for zero-length regex
-    }
-    if (paragraphMatchCount > 0) {
-      paragraphsWithMatchesSet.add(p.id);
-      if (dedupeByParagraph) {
-        if (matches.length < maxResults) {
-          const start = Math.max(0, firstMatchIndex - contextChars);
-          const end = Math.min(text.length, firstMatchIndex + firstMatchText.length + contextChars);
-          const before = text.slice(start, firstMatchIndex);
-          const after = text.slice(firstMatchIndex + firstMatchText.length, end);
-          const locator = locatorById?.get(p.id) ?? { list_label: '', header: '' };
-          matches.push({
-            para_id: p.id,
-            para_index_1based: paraIndex + 1,
-            list_label: locator.list_label,
-            header: locator.header,
-            match_count_in_paragraph: paragraphMatchCount,
-            match_text: firstMatchText,
-            context: `...${before}>>>${firstMatchText}<<<${after}...`,
-          });
-        } else {
-          matchesTruncated = true;
-        }
-      }
-    }
-  }
-
-  return {
-    matches,
-    totalMatches,
-    paragraphsWithMatches: paragraphsWithMatchesSet.size,
-    matchesTruncated,
-  };
+  return searchParagraphsCore(typed, re, opts, locatorById);
 }
-
-// ---------------------------------------------------------------------------
-// Raw XML search
-// ---------------------------------------------------------------------------
 
 function searchRawXml(
   doc: DocxDocument,
   re: RegExp,
   opts: { maxResults: number; contextChars: number },
-): { matches: XmlMatch[]; totalMatches: number; matchesTruncated: boolean } {
-  const xml = serializeXml(doc.getDocumentXmlClone());
-  const matches: XmlMatch[] = [];
-  let totalMatches = 0;
-  let matchesTruncated = false;
-
-  re.lastIndex = 0;
-  let m: RegExpExecArray | null;
-  // eslint-disable-next-line no-cond-assign
-  while ((m = re.exec(xml)) !== null) {
-    totalMatches += 1;
-    if (matches.length < opts.maxResults) {
-      const charStart = m.index;
-      const charEnd = m.index + m[0].length;
-      // Count newlines up to match start for approximate line number
-      let line = 1;
-      for (let i = 0; i < charStart; i++) {
-        if (xml[i] === '\n') line++;
-      }
-      const ctxStart = Math.max(0, charStart - opts.contextChars);
-      const ctxEnd = Math.min(xml.length, charEnd + opts.contextChars);
-      matches.push({
-        char_start: charStart,
-        char_end: charEnd,
-        line,
-        match_text: m[0],
-        context: xml.slice(ctxStart, ctxEnd),
-      });
-    } else {
-      matchesTruncated = true;
-    }
-    if (m[0].length === 0) break;
-  }
-
-  return { matches, totalMatches, matchesTruncated };
+): ReturnType<typeof searchRawXmlCore> {
+  return searchRawXmlCore(serializeXml(doc.getDocumentXmlClone()), re, opts);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/docx-mcp/src/tools/grep_core.ts
+++ b/packages/docx-mcp/src/tools/grep_core.ts
@@ -1,0 +1,163 @@
+// ---------------------------------------------------------------------------
+// Pure regex search core — shared by the DOCX grep tool (tools/grep.ts) and the
+// ODF grep handler (tools/odf/grep.ts). Operates on a plain {id, text}[] paragraph
+// list plus an optional locator map, so it has no dependency on any document model.
+// Extracted from grep.ts with no behavior change (covered by grep.test.ts).
+// ---------------------------------------------------------------------------
+
+export type ParagraphMatch = {
+  para_id: string;
+  para_index_1based: number;
+  list_label: string;
+  header: string;
+  match_count_in_paragraph: number;
+  match_text: string;
+  context: string;
+};
+
+export type XmlMatch = {
+  char_start: number;
+  char_end: number;
+  line: number;
+  match_text: string;
+  context: string;
+};
+
+export type SearchParagraphsResult = {
+  matches: ParagraphMatch[];
+  totalMatches: number;
+  paragraphsWithMatches: number;
+  matchesTruncated: boolean;
+};
+
+/** A paragraph's locator context (DOCX-only; ODF passes empty strings). */
+export type Locator = { list_label: string; header: string };
+
+/**
+ * Search a paragraph list with `re`. `locatorById` supplies optional list-label /
+ * header context per paragraph id (DOCX); pass `null` when unavailable (ODF).
+ */
+export function searchParagraphsCore(
+  paragraphs: Array<{ id: string; text: string }>,
+  re: RegExp,
+  opts: { maxResults: number; contextChars: number; dedupeByParagraph: boolean },
+  locatorById: Map<string, Locator> | null,
+): SearchParagraphsResult {
+  const { maxResults, contextChars, dedupeByParagraph } = opts;
+
+  const matches: ParagraphMatch[] = [];
+  const paragraphsWithMatchesSet = new Set<string>();
+  let totalMatches = 0;
+  let matchesTruncated = false;
+
+  for (let paraIndex = 0; paraIndex < paragraphs.length; paraIndex += 1) {
+    const p = paragraphs[paraIndex]!;
+    re.lastIndex = 0;
+    const text = p.text;
+    let m: RegExpExecArray | null;
+    let paragraphMatchCount = 0;
+    let firstMatchText = '';
+    let firstMatchIndex = -1;
+    // eslint-disable-next-line no-cond-assign
+    while ((m = re.exec(text)) !== null) {
+      totalMatches += 1;
+      paragraphMatchCount += 1;
+      if (firstMatchIndex === -1) {
+        firstMatchText = m[0];
+        firstMatchIndex = m.index;
+      }
+      if (!dedupeByParagraph) {
+        if (matches.length < maxResults) {
+          const start = Math.max(0, m.index - contextChars);
+          const end = Math.min(text.length, m.index + m[0].length + contextChars);
+          const before = text.slice(start, m.index);
+          const after = text.slice(m.index + m[0].length, end);
+          const locator = locatorById?.get(p.id) ?? { list_label: '', header: '' };
+          matches.push({
+            para_id: p.id,
+            para_index_1based: paraIndex + 1,
+            list_label: locator.list_label,
+            header: locator.header,
+            match_count_in_paragraph: 1,
+            match_text: m[0],
+            context: `...${before}>>>${m[0]}<<<${after}...`,
+          });
+        } else {
+          matchesTruncated = true;
+        }
+      }
+      if (m[0].length === 0) break; // safety for zero-length regex
+    }
+    if (paragraphMatchCount > 0) {
+      paragraphsWithMatchesSet.add(p.id);
+      if (dedupeByParagraph) {
+        if (matches.length < maxResults) {
+          const start = Math.max(0, firstMatchIndex - contextChars);
+          const end = Math.min(text.length, firstMatchIndex + firstMatchText.length + contextChars);
+          const before = text.slice(start, firstMatchIndex);
+          const after = text.slice(firstMatchIndex + firstMatchText.length, end);
+          const locator = locatorById?.get(p.id) ?? { list_label: '', header: '' };
+          matches.push({
+            para_id: p.id,
+            para_index_1based: paraIndex + 1,
+            list_label: locator.list_label,
+            header: locator.header,
+            match_count_in_paragraph: paragraphMatchCount,
+            match_text: firstMatchText,
+            context: `...${before}>>>${firstMatchText}<<<${after}...`,
+          });
+        } else {
+          matchesTruncated = true;
+        }
+      }
+    }
+  }
+
+  return {
+    matches,
+    totalMatches,
+    paragraphsWithMatches: paragraphsWithMatchesSet.size,
+    matchesTruncated,
+  };
+}
+
+/** Search a raw XML string with `re`, returning matches with approximate line numbers. */
+export function searchRawXmlCore(
+  xml: string,
+  re: RegExp,
+  opts: { maxResults: number; contextChars: number },
+): { matches: XmlMatch[]; totalMatches: number; matchesTruncated: boolean } {
+  const matches: XmlMatch[] = [];
+  let totalMatches = 0;
+  let matchesTruncated = false;
+
+  re.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  // eslint-disable-next-line no-cond-assign
+  while ((m = re.exec(xml)) !== null) {
+    totalMatches += 1;
+    if (matches.length < opts.maxResults) {
+      const charStart = m.index;
+      const charEnd = m.index + m[0].length;
+      // Count newlines up to match start for approximate line number
+      let line = 1;
+      for (let i = 0; i < charStart; i++) {
+        if (xml[i] === '\n') line++;
+      }
+      const ctxStart = Math.max(0, charStart - opts.contextChars);
+      const ctxEnd = Math.min(xml.length, charEnd + opts.contextChars);
+      matches.push({
+        char_start: charStart,
+        char_end: charEnd,
+        line,
+        match_text: m[0],
+        context: xml.slice(ctxStart, ctxEnd),
+      });
+    } else {
+      matchesTruncated = true;
+    }
+    if (m[0].length === 0) break;
+  }
+
+  return { matches, totalMatches, matchesTruncated };
+}

--- a/packages/docx-mcp/src/tools/odf/grep.ts
+++ b/packages/docx-mcp/src/tools/odf/grep.ts
@@ -1,0 +1,108 @@
+import { type OdfSession, SessionManager } from '../../session/manager.js';
+import { errorMessage } from '../../error_utils.js';
+import { err, ok, type ToolResponse } from '../types.js';
+import { searchParagraphsCore, searchRawXmlCore } from '../grep_core.js';
+
+/**
+ * ODF (.odt) `grep`. Session-mode only — the dispatcher resolves the ODF session by
+ * `.odt` `file_path` before calling here (multi-file `file_paths` stays on the DOCX
+ * lane). ODF paragraphs carry no list-label / header context, so those fields are
+ * empty. Output shape mirrors the DOCX grep session response.
+ */
+export async function odfGrep(
+  manager: SessionManager,
+  session: OdfSession,
+  params: {
+    patterns?: string[];
+    pattern?: string;
+    case_sensitive?: boolean;
+    whole_word?: boolean;
+    max_results?: number;
+    context_chars?: number;
+    dedupe_by_paragraph?: boolean;
+    search_xml?: boolean;
+  },
+  metadata: Record<string, unknown>,
+): Promise<ToolResponse> {
+  try {
+    let patterns = params.patterns ?? [];
+    if (patterns.length === 0 && typeof params.pattern === 'string') {
+      patterns = [params.pattern];
+    }
+    if (patterns.length === 0) {
+      return err(
+        'MISSING_PATTERN',
+        'No search patterns provided.',
+        'Pass patterns: ["your search term"] (array of regex strings).',
+      );
+    }
+
+    const caseSensitive = params.case_sensitive ?? false;
+    const wholeWord = params.whole_word ?? false;
+    const maxResults = params.max_results ?? 100;
+    const contextChars = params.context_chars ?? 50;
+    const dedupeByParagraph = params.dedupe_by_paragraph ?? true;
+    const searchXml = params.search_xml ?? false;
+
+    const patternStr = wholeWord ? `\\b(${patterns.join('|')})\\b` : `(${patterns.join('|')})`;
+    let re: RegExp;
+    try {
+      re = new RegExp(patternStr, caseSensitive ? 'g' : 'gi');
+    } catch (e: unknown) {
+      return ok({
+        file_path: session.originalPath,
+        provider: 'odf',
+        patterns,
+        total_matches: 0,
+        matches: [],
+        error: `Invalid regex pattern: ${errorMessage(e)}`,
+        ...metadata,
+      });
+    }
+
+    if (searchXml) {
+      const xmlResult = searchRawXmlCore(session.doc.toXml(), re, { maxResults, contextChars });
+      return ok({
+        file_path: session.originalPath,
+        provider: 'odf',
+        patterns,
+        search_xml: true,
+        total_matches: xmlResult.totalMatches,
+        matches: xmlResult.matches,
+        matches_returned: xmlResult.matches.length,
+        matches_truncated: xmlResult.matchesTruncated,
+        ...metadata,
+      });
+    }
+
+    const paragraphs = session.doc.getParagraphs();
+    const result = searchParagraphsCore(
+      paragraphs,
+      re,
+      { maxResults, contextChars, dedupeByParagraph },
+      null,
+    );
+
+    const response: Record<string, unknown> = {
+      file_path: session.originalPath,
+      provider: 'odf',
+      patterns,
+      dedupe_by_paragraph: dedupeByParagraph,
+      total_matches: result.totalMatches,
+      paragraphs_with_matches: result.paragraphsWithMatches,
+      matches: result.matches,
+      matches_returned: result.matches.length,
+      max_results_applied: maxResults,
+      matches_truncated: result.matchesTruncated,
+      ...metadata,
+    };
+    if (result.matchesTruncated) {
+      response.truncation_note = dedupeByParagraph
+        ? 'max_results limits returned rows to matching paragraphs while total_matches counts all regex hits. Increase max_results or set dedupe_by_paragraph=false for per-match rows.'
+        : 'max_results limits returned rows to individual matches while total_matches counts all regex hits. Increase max_results to see more matches.';
+    }
+    return ok(response);
+  } catch (e: unknown) {
+    return err('SEARCH_ERROR', `Failed to search ODF document: ${errorMessage(e)}`, 'Check patterns are valid regex and try again.');
+  }
+}

--- a/packages/docx-mcp/src/tools/odf/insert_paragraph.ts
+++ b/packages/docx-mcp/src/tools/odf/insert_paragraph.ts
@@ -1,0 +1,59 @@
+import { stripAllInlineTags } from '@usejunior/docx-core';
+import { type OdfSession, SessionManager } from '../../session/manager.js';
+import { errorMessage } from '../../error_utils.js';
+import { RESULT_PREVIEW_CHARS, previewText } from '../preview.js';
+import { err, ok, type ToolResponse } from '../types.js';
+
+/**
+ * ODF (.odt) `insert_paragraph`. Inserts plain-text paragraph(s) BEFORE/AFTER an anchor.
+ * `new_string` is split on blank lines into separate paragraphs; single newlines become
+ * line breaks (parity with the DOCX tool). DOCX run-formatting tags are not yet supported
+ * for ODF and are stripped.
+ *
+ * IMPORTANT: ODF paragraph IDs are positional ordinals, so inserting shifts every ID at or
+ * after the insertion point. The response carries machine-actionable invalidation fields so
+ * the agent re-reads before its next edit.
+ */
+export async function odfInsertParagraph(
+  manager: SessionManager,
+  session: OdfSession,
+  params: { positional_anchor_node_id: string; new_string: string; instruction: string; position?: string },
+  metadata: Record<string, unknown>,
+): Promise<ToolResponse> {
+  try {
+    const anchorId = params.positional_anchor_node_id;
+    const positionUpper = (params.position ?? 'AFTER').toUpperCase();
+    if (positionUpper !== 'BEFORE' && positionUpper !== 'AFTER') {
+      return err('INVALID_POSITION', `Invalid position: ${params.position}. Must be 'BEFORE' or 'AFTER'.`);
+    }
+
+    const text = stripAllInlineTags(params.new_string ?? '');
+
+    const result = session.doc.insertParagraph(anchorId, text, positionUpper as 'BEFORE' | 'AFTER');
+    if (!result.ok) {
+      return err(result.code, result.message);
+    }
+    manager.markEdited(session);
+
+    const newIds = result.newIds;
+    return ok({
+      success: true,
+      file_path: session.originalPath,
+      provider: 'odf',
+      edit_count: session.editCount,
+      anchor_paragraph_id: anchorId,
+      new_paragraph_id: newIds[0] ?? null,
+      new_paragraph_ids: newIds,
+      position: positionUpper,
+      inserted_text: previewText(text, RESULT_PREVIEW_CHARS),
+      // ODF IDs are positional; everything at/after the insertion point has shifted.
+      invalidates_paragraph_ids_after: anchorId,
+      requires_reread_before_next_edit: true,
+      ids_note:
+        'ODF paragraph IDs are positional and have shifted after this insertion. Call read_file or grep again to get current IDs before your next edit.',
+      ...metadata,
+    });
+  } catch (e: unknown) {
+    return err('INSERT_ERROR', `Failed to insert paragraph into ODF document: ${errorMessage(e)}`);
+  }
+}

--- a/packages/docx-mcp/src/tools/odf/odf_grep_insert.test.ts
+++ b/packages/docx-mcp/src/tools/odf/odf_grep_insert.test.ts
@@ -231,6 +231,35 @@ describe('ODF grep + insert branch coverage', () => {
     expect((res.new_paragraph_ids as string[]).length).toBe(2);
   });
 
+  it('compare_documents with .odt input paths returns UNSUPPORTED_FOR_ODF (two-file form)', async () => {
+    const manager = new SessionManager();
+    const original = await copyFixture('orig.odt');
+    const revised = await copyFixture('rev.odt');
+    const res = await dispatchToolCall(manager, 'compare_documents', {
+      original_file_path: original,
+      revised_file_path: revised,
+      save_to_local_path: path.join(path.dirname(original), 'redline.docx'),
+    });
+    assertError(res, 'UNSUPPORTED_FOR_ODF');
+  });
+
+  it('two unsupported tools on the same .odt path name the correct tool (no stale pending replay)', async () => {
+    const manager = new SessionManager();
+    const filePath = await copyFixture();
+    const one = await dispatchToolCall(manager, 'add_comment', {
+      file_path: filePath, target_paragraph_id: 'p0', comment_text: 'x', author: 'Jane Doe',
+    });
+    const two = await dispatchToolCall(manager, 'delete_comment', { file_path: filePath, comment_id: 'c1' });
+    assertError(one, 'UNSUPPORTED_FOR_ODF');
+    assertError(two, 'UNSUPPORTED_FOR_ODF');
+    expect(one.error.message).toContain("'add_comment'");
+    expect(two.error.message).toContain("'delete_comment'");
+    // A supported tool on the same path must still work (pending map not poisoned).
+    const read = await dispatchToolCall(manager, 'read_file', { file_path: filePath, format: 'simple', limit: 50 });
+    assertSuccess(read, 'read_file after unsupported');
+    expect(read.provider).toBe('odf');
+  });
+
   it('insert_paragraph defaults to AFTER and round-trips through save', async () => {
     const manager = new SessionManager();
     const filePath = await copyFixture();

--- a/packages/docx-mcp/src/tools/odf/odf_grep_insert.test.ts
+++ b/packages/docx-mcp/src/tools/odf/odf_grep_insert.test.ts
@@ -1,0 +1,253 @@
+import { afterEach, describe, expect } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { testAllure as it, type AllureBddContext } from '../../testing/allure-test.js';
+import { dispatchToolCall } from '../../server.js';
+import { SessionManager } from '../../session/manager.js';
+
+const TEST_FEATURE = 'add-odf-grep-insert';
+const test = it.epic('Document Editing').withLabels({ feature: TEST_FEATURE });
+const FIXTURE = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../../../odf-core/src/__fixtures__/sample.odt',
+);
+
+const tmpDirs: string[] = [];
+
+afterEach(async () => {
+  for (const dir of tmpDirs.splice(0)) {
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
+async function copyFixture(name = 'sample.odt'): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'safe-docx-odf-gi-'));
+  tmpDirs.push(dir);
+  const filePath = path.join(dir, name);
+  await fs.copyFile(FIXTURE, filePath);
+  return filePath;
+}
+
+type ErrorResult = { success: false; error: { code: string; message: string; hint?: string } };
+
+function assertSuccess(result: Record<string, unknown>, label: string): asserts result is { success: true; [k: string]: unknown } {
+  expect(result.success, `${label} failed: ${JSON.stringify((result as ErrorResult).error)}`).toBe(true);
+}
+function assertError(result: Record<string, unknown>, code: string): asserts result is ErrorResult {
+  expect(result.success).toBe(false);
+  expect((result as ErrorResult).error.code).toBe(code);
+}
+
+async function firstId(manager: SessionManager, filePath: string): Promise<string> {
+  const read = await dispatchToolCall(manager, 'read_file', { file_path: filePath, format: 'json', limit: 500 });
+  assertSuccess(read, 'read_file');
+  const nodes = JSON.parse(String(read.content)) as Array<{ id: string }>;
+  return nodes[0]!.id;
+}
+
+describe('ODF grep + insert_paragraph lane', () => {
+  test.openspec('[OPLR-06] `grep` searches an ODF session')(
+    'grep routes to the ODF handler and returns matches with paragraph IDs',
+    async ({ given, when, then }: AllureBddContext) => {
+      let manager: SessionManager;
+      let filePath: string;
+      let result: Awaited<ReturnType<typeof dispatchToolCall>>;
+
+      await given('a file-first ODF session', async () => {
+        manager = new SessionManager();
+        filePath = await copyFixture();
+      });
+      await when('grep is called with a pattern on the .odt path', async () => {
+        result = await dispatchToolCall(manager, 'grep', { file_path: filePath, pattern: 'quick brown fox' });
+      });
+      await then('the ODF handler returns matches with a paragraph id and context', () => {
+        assertSuccess(result, 'grep');
+        expect(result.provider).toBe('odf');
+        expect(result.total_matches as number).toBeGreaterThan(0);
+        const matches = result.matches as Array<{ para_id: string; context: string; list_label: string; header: string }>;
+        expect(matches[0]!.para_id).toMatch(/^p\d+$/);
+        expect(matches[0]!.context).toContain('quick brown fox');
+        // ODF carries no list-label / header context.
+        expect(matches[0]!.list_label).toBe('');
+        expect(matches[0]!.header).toBe('');
+      });
+    },
+  );
+
+  test.openspec('[OPLR-07] `insert_paragraph` inserts into an ODF session')(
+    'insert_paragraph adds a paragraph and returns ID-invalidation fields',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      let manager: SessionManager;
+      let filePath: string;
+      let anchorId: string;
+      let result: Awaited<ReturnType<typeof dispatchToolCall>>;
+
+      await given('an ODF session with a known anchor paragraph', async () => {
+        manager = new SessionManager();
+        filePath = await copyFixture();
+        anchorId = await firstId(manager, filePath);
+      });
+      await when('insert_paragraph inserts AFTER the anchor', async () => {
+        result = await dispatchToolCall(manager, 'insert_paragraph', {
+          file_path: filePath,
+          positional_anchor_node_id: anchorId,
+          new_string: 'Inserted clause from the agent.',
+          instruction: 'add a clause',
+          position: 'AFTER',
+        });
+      });
+      await then('the response reports the new positional id and ID-invalidation contract', () => {
+        assertSuccess(result, 'insert_paragraph');
+        expect(result.provider).toBe('odf');
+        expect(result.new_paragraph_id as string).toMatch(/^p\d+$/);
+        expect(result.invalidates_paragraph_ids_after).toBe(anchorId);
+        expect(result.requires_reread_before_next_edit).toBe(true);
+      });
+      await and('re-reading the document reflects the inserted text', async () => {
+        const read = await dispatchToolCall(manager, 'read_file', { file_path: filePath, format: 'json', limit: 500 });
+        assertSuccess(read, 'read_file');
+        expect(String(read.content)).toContain('Inserted clause from the agent.');
+      });
+    },
+  );
+
+  test.openspec('[OPLR-08] Still-unsupported tools remain guarded')(
+    'a tool outside the ODF supported set still returns UNSUPPORTED_FOR_ODF after grep/insert are added',
+    async ({ given, when, then }: AllureBddContext) => {
+      let manager: SessionManager;
+      let filePath: string;
+      let result: Awaited<ReturnType<typeof dispatchToolCall>>;
+
+      await given('an ODF session', async () => {
+        manager = new SessionManager();
+        filePath = await copyFixture();
+        await firstId(manager, filePath);
+      });
+      await when('a still-unsupported tool targets the .odt path', async () => {
+        result = await dispatchToolCall(manager, 'add_comment', {
+          file_path: filePath,
+          target_paragraph_id: 'p0',
+          comment_text: 'should be rejected',
+          author: 'Jane Doe',
+        });
+      });
+      await then('the provider guard returns UNSUPPORTED_FOR_ODF', () => {
+        assertError(result, 'UNSUPPORTED_FOR_ODF');
+      });
+    },
+  );
+});
+
+// Branch-coverage tests for the ODF grep + insert handlers.
+describe('ODF grep + insert branch coverage', () => {
+  it('grep requires a pattern', async () => {
+    const manager = new SessionManager();
+    const filePath = await copyFixture();
+    const res = await dispatchToolCall(manager, 'grep', { file_path: filePath });
+    assertError(res, 'MISSING_PATTERN');
+  });
+
+  it('grep returns zero matches for an absent pattern', async () => {
+    const manager = new SessionManager();
+    const filePath = await copyFixture();
+    const res = await dispatchToolCall(manager, 'grep', { file_path: filePath, pattern: 'zzz-not-present-zzz' });
+    assertSuccess(res, 'grep');
+    expect(res.total_matches).toBe(0);
+    expect((res.matches as unknown[]).length).toBe(0);
+  });
+
+  it('grep honors dedupe_by_paragraph=false (per-match rows)', async () => {
+    const manager = new SessionManager();
+    const filePath = await copyFixture();
+    const res = await dispatchToolCall(manager, 'grep', {
+      file_path: filePath,
+      pattern: 'o',
+      dedupe_by_paragraph: false,
+      max_results: 5,
+    });
+    assertSuccess(res, 'grep per-match');
+    expect(res.provider).toBe('odf');
+    expect((res.matches as unknown[]).length).toBeLessThanOrEqual(5);
+  });
+
+  it('grep supports search_xml over content.xml', async () => {
+    const manager = new SessionManager();
+    const filePath = await copyFixture();
+    const res = await dispatchToolCall(manager, 'grep', { file_path: filePath, pattern: 'text:p', search_xml: true });
+    assertSuccess(res, 'grep xml');
+    expect(res.search_xml).toBe(true);
+    expect(res.total_matches as number).toBeGreaterThan(0);
+  });
+
+  it('grep supports whole_word matching', async () => {
+    const manager = new SessionManager();
+    const filePath = await copyFixture();
+    const res = await dispatchToolCall(manager, 'grep', { file_path: filePath, pattern: 'fox', whole_word: true });
+    assertSuccess(res, 'grep whole_word');
+    expect(res.total_matches as number).toBeGreaterThan(0);
+  });
+
+  it('insert_paragraph rejects an invalid position', async () => {
+    const manager = new SessionManager();
+    const filePath = await copyFixture();
+    const id = await firstId(manager, filePath);
+    const res = await dispatchToolCall(manager, 'insert_paragraph', {
+      file_path: filePath,
+      positional_anchor_node_id: id,
+      new_string: 'x',
+      instruction: 'bad position',
+      position: 'SIDEWAYS',
+    });
+    assertError(res, 'INVALID_POSITION');
+  });
+
+  it('insert_paragraph reports ANCHOR_NOT_FOUND for an unknown id', async () => {
+    const manager = new SessionManager();
+    const filePath = await copyFixture();
+    await firstId(manager, filePath);
+    const res = await dispatchToolCall(manager, 'insert_paragraph', {
+      file_path: filePath,
+      positional_anchor_node_id: 'p99999',
+      new_string: 'x',
+      instruction: 'bad anchor',
+    });
+    assertError(res, 'ANCHOR_NOT_FOUND');
+  });
+
+  it('insert_paragraph splits blank lines into multiple paragraphs', async () => {
+    const manager = new SessionManager();
+    const filePath = await copyFixture();
+    const id = await firstId(manager, filePath);
+    const res = await dispatchToolCall(manager, 'insert_paragraph', {
+      file_path: filePath,
+      positional_anchor_node_id: id,
+      new_string: 'First inserted.\n\nSecond inserted.',
+      instruction: 'two paragraphs',
+      position: 'AFTER',
+    });
+    assertSuccess(res, 'insert multi');
+    expect((res.new_paragraph_ids as string[]).length).toBe(2);
+  });
+
+  it('insert_paragraph defaults to AFTER and round-trips through save', async () => {
+    const manager = new SessionManager();
+    const filePath = await copyFixture();
+    const id = await firstId(manager, filePath);
+    const ins = await dispatchToolCall(manager, 'insert_paragraph', {
+      file_path: filePath,
+      positional_anchor_node_id: id,
+      new_string: 'Persisted paragraph.',
+      instruction: 'default position',
+    });
+    assertSuccess(ins, 'insert default');
+    expect(ins.position).toBe('AFTER');
+    const outPath = path.join(path.dirname(filePath), 'inserted.odt');
+    const saved = await dispatchToolCall(manager, 'save', { file_path: filePath, save_to_local_path: outPath });
+    assertSuccess(saved, 'save inserted');
+    const reread = await dispatchToolCall(manager, 'read_file', { file_path: outPath, format: 'json', limit: 500 });
+    assertSuccess(reread, 'reread inserted');
+    expect(String(reread.content)).toContain('Persisted paragraph.');
+  });
+});

--- a/packages/docx-mcp/src/tools/provider_guard.ts
+++ b/packages/docx-mcp/src/tools/provider_guard.ts
@@ -7,7 +7,7 @@ const GDOCS_SUPPORTED_TOOLS = new Set([
 ]);
 
 const ODF_SUPPORTED_TOOLS = new Set([
-  'read_file', 'replace_text', 'save', 'get_file_status', 'close_file',
+  'read_file', 'replace_text', 'grep', 'insert_paragraph', 'save', 'get_file_status', 'close_file',
 ]);
 
 export function checkGDocsSupport(toolName: string): ToolResponse | null {
@@ -26,7 +26,7 @@ export function checkOdfSupport(toolName: string): ToolResponse | null {
     return err(
       'UNSUPPORTED_FOR_ODF',
       `'${toolName}' is not supported for ODF (.odt) files.`,
-      'Use read_file, replace_text, save, get_file_status, or close_file for .odt files.',
+      'Use read_file, replace_text, grep, insert_paragraph, save, get_file_status, or close_file for .odt files.',
     );
   }
   return null;

--- a/packages/docx-mcp/src/tools/session_resolution.ts
+++ b/packages/docx-mcp/src/tools/session_resolution.ts
@@ -266,7 +266,7 @@ export async function resolveSessionForTool(
       response: err(
         'UNSUPPORTED_FOR_ODF',
         `Tool '${opts.toolName}' is not supported for ODF (.odt) files.`,
-        'Use read_file, replace_text, save, get_file_status, or close_file for .odt files.',
+        'Use read_file, replace_text, grep, insert_paragraph, save, get_file_status, or close_file for .odt files.',
       ),
     };
   }
@@ -327,7 +327,7 @@ export async function resolveSessionForTool(
           response: err(
             'UNSUPPORTED_FOR_ODF',
             `Tool '${opts.toolName}' is not supported for ODF (.odt) files.`,
-            'Use read_file, replace_text, save, get_file_status, or close_file for .odt files.',
+            'Use read_file, replace_text, grep, insert_paragraph, save, get_file_status, or close_file for .odt files.',
           ),
         };
       }

--- a/packages/docx-mcp/src/tools/session_resolution.ts
+++ b/packages/docx-mcp/src/tools/session_resolution.ts
@@ -292,6 +292,21 @@ export async function resolveSessionForTool(
     };
   }
 
+  // Fail fast for unsupported tools on a `.odt` path BEFORE touching the pending map.
+  // This must be a synchronous early return: registering it as a leader promise would
+  // resolve before `pendingMap.set` runs, leaving a stale entry that replays THIS tool's
+  // error (and tool name) for the next unsupported tool on the same path.
+  if (path.extname(manager.normalizePath(filePath)).toLowerCase() === '.odt') {
+    return {
+      ok: false,
+      response: err(
+        'UNSUPPORTED_FOR_ODF',
+        `Tool '${opts.toolName}' is not supported for ODF (.odt) files.`,
+        'Use read_file, replace_text, grep, insert_paragraph, save, get_file_status, or close_file for .odt files.',
+      ),
+    };
+  }
+
   // --- Concurrent auto-open deduplication ---
   const pendingMap = getPendingMap(manager);
   const pending = pendingMap.get(canonicalPath);
@@ -321,16 +336,8 @@ export async function resolveSessionForTool(
 
   const outcomePromise: Promise<SessionResolutionOutcome> = (async () => {
     try {
-      if (path.extname(manager.normalizePath(filePath)).toLowerCase() === '.odt') {
-        return {
-          ok: false as const,
-          response: err(
-            'UNSUPPORTED_FOR_ODF',
-            `Tool '${opts.toolName}' is not supported for ODF (.odt) files.`,
-            'Use read_file, replace_text, grep, insert_paragraph, save, get_file_status, or close_file for .odt files.',
-          ),
-        };
-      }
+      // `.odt` is already handled by the synchronous early return above, so by here
+      // the path is a non-`.odt` DOCX candidate.
       const loaded = await validateAndLoadDocxFromPath(manager, filePath);
       if (!loaded.ok) {
         return { ok: false as const, response: loaded.response };

--- a/packages/odf-core/src/document.test.ts
+++ b/packages/odf-core/src/document.test.ts
@@ -125,3 +125,67 @@ describe('OdfDocument — replaceTextById', () => {
     expect(doc.getParagraphTextById('p0')).toBe('Hello planet today');
   });
 });
+
+describe('OdfDocument — insertParagraph', () => {
+  it('[OINS-01] inserts a body paragraph AFTER the anchor, inheriting its style', () => {
+    const doc = OdfDocument.fromContentXml(
+      contentXml('<text:p text:style-name="Standard">First</text:p><text:p>Second</text:p>'),
+    );
+    const res = doc.insertParagraph('p0', 'Inserted', 'AFTER');
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.newIds).toEqual(['p1']);
+    expect(doc.getParagraphs().map((p) => p.text)).toEqual(['First', 'Inserted', 'Second']);
+    // Inherited the anchor's body-paragraph style.
+    expect(doc.toXml()).toContain('text:style-name="Standard">Inserted');
+  });
+
+  it('inserts BEFORE the anchor', () => {
+    const doc = OdfDocument.fromContentXml(contentXml('<text:p>Only</text:p>'));
+    const res = doc.insertParagraph('p0', 'New first', 'BEFORE');
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.newIds).toEqual(['p0']);
+    expect(doc.getParagraphs().map((p) => p.text)).toEqual(['New first', 'Only']);
+  });
+
+  it('[OINS-02] does NOT propagate heading style when the anchor is a text:h', () => {
+    const doc = OdfDocument.fromContentXml(
+      contentXml('<text:h text:style-name="Heading_2">Title</text:h>'),
+    );
+    const res = doc.insertParagraph('p0', 'Body text', 'AFTER');
+    expect(res.ok).toBe(true);
+    const xml = doc.toXml();
+    // The inserted body paragraph must not carry the heading style.
+    expect(xml).toContain('<text:p>Body text</text:p>');
+    expect(xml).not.toContain('text:style-name="Heading_2">Body text');
+  });
+
+  it('[OINS-03] splits blank lines into multiple paragraphs; single newline is a line break', () => {
+    const doc = OdfDocument.fromContentXml(contentXml('<text:p>Anchor</text:p>'));
+    const res = doc.insertParagraph('p0', 'Para one\n\nPara two\nstill two', 'AFTER');
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.newIds).toEqual(['p1', 'p2']);
+    const texts = doc.getParagraphs().map((p) => p.text);
+    expect(texts[0]).toBe('Anchor');
+    expect(texts[1]).toBe('Para one');
+    expect(texts[2]).toBe('Para two\nstill two'); // line-break preserved as \n in visible text
+    expect(doc.toXml()).toContain('<text:line-break/>');
+  });
+
+  it('[OINS-04] returns ANCHOR_NOT_FOUND for an unknown id without throwing', () => {
+    const doc = OdfDocument.fromContentXml(contentXml('<text:p>Only</text:p>'));
+    const res = doc.insertParagraph('p9', 'X', 'AFTER');
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.code).toBe('ANCHOR_NOT_FOUND');
+    expect(doc.getParagraphs()).toHaveLength(1);
+  });
+
+  it('shifts positional IDs after the insertion point', () => {
+    const doc = OdfDocument.fromContentXml(
+      contentXml('<text:p>A</text:p><text:p>B</text:p><text:p>C</text:p>'),
+    );
+    // Insert after p0 — old p1/p2 (B/C) shift to p2/p3.
+    doc.insertParagraph('p0', 'NEW', 'AFTER');
+    const paras = doc.getParagraphs();
+    expect(paras.map((p) => `${p.id}:${p.text}`)).toEqual(['p0:A', 'p1:NEW', 'p2:B', 'p3:C']);
+  });
+});

--- a/packages/odf-core/src/document.ts
+++ b/packages/odf-core/src/document.ts
@@ -29,6 +29,10 @@ export type ReplaceResult =
   | { ok: true }
   | { ok: false; code: 'ANCHOR_NOT_FOUND' | 'TEXT_NOT_FOUND' | 'MATCH_SPANS_MULTIPLE_NODES'; message: string };
 
+export type InsertResult =
+  | { ok: true; newIds: string[] }
+  | { ok: false; code: 'ANCHOR_NOT_FOUND'; message: string };
+
 /** A contiguous slice of a paragraph's visible text and where it came from. */
 type Segment =
   | { kind: 'text'; node: { data: string }; visStart: number; length: number }
@@ -179,6 +183,64 @@ export class OdfDocument {
     const localEnd = matchEnd - host.visStart;
     host.node.data = host.node.data.slice(0, localStart) + replaceWith + host.node.data.slice(localEnd);
     return { ok: true };
+  }
+
+  /**
+   * Insert one or more paragraphs relative to the anchor paragraph identified by `id`.
+   *
+   * `text` is split on blank lines (`\n{2,}`) into separate `text:p` blocks (parity with
+   * the DOCX `insert_paragraph` tool); a single `\n` within a block becomes a
+   * `text:line-break`. Inserted blocks inherit the anchor's `text:style-name` ONLY when
+   * the anchor is itself a `text:p` — inserting after a heading (`text:h`) produces
+   * default body paragraphs, never more headings.
+   *
+   * Paragraph IDs are positional ordinals, so every ID at or after the insertion point
+   * shifts by the number of inserted blocks. Returns the inserted blocks' freshly
+   * recomputed IDs in document order; callers must re-read before issuing further edits
+   * that target IDs near or after the insertion point.
+   */
+  insertParagraph(id: string, text: string, position: 'BEFORE' | 'AFTER'): InsertResult {
+    const anchor = this.blockForId(id);
+    if (!anchor) {
+      return { ok: false, code: 'ANCHOR_NOT_FOUND', message: `Paragraph not found: ${id}` };
+    }
+    const parent = anchor.parentNode;
+    if (!parent) {
+      return { ok: false, code: 'ANCHOR_NOT_FOUND', message: `Paragraph ${id} has no parent element` };
+    }
+
+    // Inherit the anchor's paragraph style only when the anchor is a body paragraph.
+    // Inserting relative to a heading must not produce another heading.
+    const inheritStyle =
+      anchor.localName === 'p'
+        ? anchor.getAttributeNS(ODF_NS.TEXT, 'style-name') ?? anchor.getAttribute('text:style-name')
+        : null;
+
+    const blockTexts = text.replace(/\r\n/g, '\n').split(/\n{2,}/);
+    const newEls: Element[] = blockTexts.map((blockText) => {
+      const p = this.doc.createElementNS(ODF_NS.TEXT, 'text:p');
+      if (inheritStyle) p.setAttributeNS(ODF_NS.TEXT, 'text:style-name', inheritStyle);
+      const lines = blockText.split('\n');
+      lines.forEach((line, i) => {
+        if (i > 0) p.appendChild(this.doc.createElementNS(ODF_NS.TEXT, 'text:line-break'));
+        if (line.length > 0) p.appendChild(this.doc.createTextNode(line));
+      });
+      return p;
+    });
+
+    // `insertBefore(el, null)` appends, so AFTER on the last child appends correctly.
+    const refNode = position === 'AFTER' ? anchor.nextSibling : anchor;
+    for (const el of newEls) {
+      parent.insertBefore(el, refNode);
+    }
+
+    // Rebuild the structural block index; positional IDs shift accordingly.
+    const blocks: Element[] = [];
+    OdfDocument.collectBlocks(this.doc.documentElement, blocks);
+    this.blocks = blocks;
+
+    const newIds = newEls.map((el) => this.idForIndex(blocks.indexOf(el)));
+    return { ok: true, newIds };
   }
 
   /** Serialize the (possibly edited) document back to a `content.xml` string. */

--- a/packages/odf-core/src/index.ts
+++ b/packages/odf-core/src/index.ts
@@ -1,4 +1,4 @@
 export { OdfArchive } from './shared/odf/OdfArchive.js';
-export { OdfDocument, type OdfParagraph, type ReplaceResult } from './document.js';
+export { OdfDocument, type OdfParagraph, type ReplaceResult, type InsertResult } from './document.js';
 export { validateOdfArchiveSafety, type OdfArchiveSafetyResult } from './odf_archive_safety.js';
 export { ODF_NS, ODF_PATHS, ODT_MIMETYPE } from './shared/odf/namespaces.js';


### PR DESCRIPTION
## Summary
Phase 2a of ODF support: extends the Phase 1 provider-aware `.odt` lane (#335) with the next two editing-loop tools — **`grep`** (locate) and **`insert_paragraph`** (add content). The heavier `compare_documents` + comments (which need a fresh ODF tracked-changes atomizer + `office:annotation`) are deferred to a separate Phase 2b PR, per the tightly-scoped phasing plan.

## Implementation
**odf-core**
- `OdfDocument.insertParagraph(id, text, BEFORE|AFTER)` + `InsertResult`. Blank lines split into separate `text:p`; single newlines become `text:line-break`. Inherits the anchor's `text:style-name` **only when the anchor is a body paragraph** (never propagates a heading style). Rebuilds the positional block index and returns the inserted blocks' freshly recomputed IDs.

**docx-mcp**
- Extract pure `tools/grep_core.ts` (`searchParagraphsCore` / `searchRawXmlCore`); `grep.ts` delegates to it — behavior-preserving, covered by the existing `grep.test.ts`.
- `tools/odf/grep.ts` (session-mode `file_path` only; ODF has no list-label/header context) and `tools/odf/insert_paragraph.ts`.
- Insert responses carry machine-actionable ID-invalidation fields (`invalidates_paragraph_ids_after`, `requires_reread_before_next_edit`) because ODF paragraph IDs are positional and shift on insertion. `replaceTextById` already fails closed with `TEXT_NOT_FOUND` on a stale ID, so a mis-targeted edit errors rather than corrupting.
- Added `grep` + `insert_paragraph` to `ODF_SUPPORTED_TOOLS`; updated **both** `UNSUPPORTED_FOR_ODF` hint strings (`provider_guard.ts` + `session_resolution.ts`).
- Registered handlers in `loadOdfHandlers`; added `isOdfRequest` dispatch branches. `tool_catalog` + regenerated tool-reference docs.

## Peer review
Design peer-reviewed by **Codex + agy** before implementation (both executed: agy ran the 816-test suite + an xmldom serialization probe; Codex ran `openspec validate` + its own xmldom probe). No disagreements. Their three refinements — heading-style guard, `\n\n` paragraph parity, and the machine-actionable ID-shift contract — are all folded in.

## OpenSpec
New change `add-odf-grep-insert` (`mcp-server` OPLR-06/07/08; `odf-core` OINS-01..04). Fixed the now-stale `insert_paragraph` example in `add-odf-core` OPLR-04. ADDED-only (no `MODIFIED` against the unarchived `add-odf-core` base).

## Verification
- [x] build, lint:workspaces (0 errors), check:cycles, check:release-isolation
- [x] allure labels / filenames / quality (0 errors)
- [x] `openspec validate add-odf-grep-insert --strict`; `check:spec-coverage -w @usejunior/docx-mcp -- --strict` (add-odf-grep-insert 3/3); check:tool-docs
- [x] docx-mcp **816 tests** + odf-core **29 tests**
- [x] coverage ratchet improved (docx-mcp lines +1.11% / branches +0.73%; docx-core +0.53% / +0.76%)
- [x] **Document-shaped smoke** on the real NVCA certificate (DOCX→ODT via soffice): `read_file` (341 paras, provider=odf) → `grep` (located "CERTIFICATE OF INCORPORATION") → `insert_paragraph` (new id, ID-invalidation fields) → `compare_documents` guarded `UNSUPPORTED_FOR_ODF` → `save` → reread confirms the insertion; LibreOffice reopens the edited `.odt` cleanly.

## Out of scope
`compare_documents`, comments, durable injected `xml:id` anchors, cross-span `replace_text`, multi-file ODF grep, `.ods`/`.odp`.