### PR TITLE
fix(docx-core): make Reject All paragraph removal mark-based, not content-based (closes G4)

### DIFF
--- a/openspec/changes/add-lean-ts-helper-differential-harness/specs/docx-comparison/spec.md
+++ b/openspec/changes/add-lean-ts-helper-differential-harness/specs/docx-comparison/spec.md
@@ -12,10 +12,10 @@ A TypeScript property test (`packages/docx-core/src/integration/lean-differentia
 - render each generated `Doc` both to the Lean JSON encoding and, via a **`Doc`→`document.xml` adapter**, to a real OOXML `document.xml` string parseable by the engine's `@xmldom/xmldom` path;
 - run the TS helpers in-process per case and spawn the Lean executable **once per memory-bounded chunk** of the batch;
 - compare `accept`/`reject` outputs on a **canonical token projection** that both the Lean output `Doc` and the TS output XML reduce to deterministically (paragraph/run/wrapper/atom tokens in document order), and compare `validate` as a boolean, asserting strict per-case equality;
-- assert the known out-of-subset model cases explicitly as fixed cases rather than hiding them: `fldChar` inside `del` (G1) and `delInstrText` outside `del` (G2) — now **closed** to agreement by `add-lean-deleted-field-code-constraint` — plus the two still-characterized gaps, accept of an `ins`-wrappered collapsing paragraph (G3) and reject of an `ins`-only paragraph (G4);
+- assert the known out-of-subset model cases explicitly as fixed cases rather than hiding them: `fldChar` inside `del` (G1) and `delInstrText` outside `del` (G2) — now **closed** to agreement by `add-lean-deleted-field-code-constraint` — and reject of an `ins`-only untracked-mark paragraph (G4) — now **closed** to agreement by the engine fidelity fix `make-reject-paragraph-collapse-mark-based` (mark-based reject) — plus the one still-characterized gap, accept of an `ins`-wrappered collapsing paragraph (G3);
 - **skip** with a clear message when the Lean executable is absent (so a developer without the Lean toolchain still gets a green `npm test`), while CI builds the executable so the comparison runs there.
 
-The harness SHALL assert **strict** agreement on the faithful subset by default; any in-subset divergence is a genuine finding, NOT a reason to weaken the assertion. The out-of-subset cases SHALL be asserted explicitly: G1/G2 as agreement (the DeletedFieldCode locality constraint is modeled), and the remaining gaps G3/G4 as documented divergences (characterization cases), forming the worklist for the next model-broadening increment. This requirement strengthens extensional-equivalence evidence between the existing Lean and TS helpers only; it introduces no production-engine change and modifies no proved Lean module.
+The harness SHALL assert **strict** agreement on the faithful subset by default; any in-subset divergence is a genuine finding, NOT a reason to weaken the assertion. The out-of-subset cases SHALL be asserted explicitly: G1/G2 as agreement (the DeletedFieldCode locality constraint is modeled), G4 as agreement (reject is now mark-based, an engine fidelity fix), and the remaining gap G3 as a documented divergence (a characterization case), forming the worklist for the next model-broadening increment. This requirement strengthens extensional-equivalence evidence between the existing Lean and TS helpers only; it introduces no production-engine change and modifies no proved Lean module.
 
 #### Scenario: [LEAN-HELP-01] Compiled Lean accept/reject/validate match the TS engine on generated docs in the faithful subset
 
@@ -44,10 +44,10 @@ The harness SHALL assert **strict** agreement on the faithful subset by default;
 - **WHEN** the harness runs the fixed [G3] `Doc` with a paragraph whose only content is a `w:ins` wrapping deleted/empty content
 - **THEN** the Lean `accept` drops the paragraph while the TS `acceptAllChanges` keeps an empty `<w:p>`, asserted via the token projection as a documented divergence
 
-#### Scenario: [LEAN-HELP-06] G4 — reject paragraph-collapse is a characterized divergence
+#### Scenario: [LEAN-HELP-06] G4 — reject paragraph-collapse now agrees (engine fidelity fix)
 
-- **WHEN** the harness runs the fixed [G4] `Doc` with an `ins`-only paragraph (no surviving content)
-- **THEN** the Lean `reject` keeps an empty paragraph (its reject never drops paragraphs) while the TS `rejectAllChanges` removes the paragraph, asserted via the token projection as a documented divergence (the reject-side analog of G3)
+- **WHEN** the harness runs the fixed [G4] `Doc` with an `ins`-only paragraph whose paragraph mark is untracked (no surviving content)
+- **THEN** the Lean `reject` and the TS `rejectAllChanges` both keep the collapsed paragraph as an empty `<w:p>`, asserted via the token projection as agreement — the TS engine's reject is now purely mark-based (`make-reject-paragraph-collapse-mark-based`), matching the already-faithful Lean `reject`
 
 #### Scenario: [LEAN-HELP-07] A real divergence is caught, not masked
 

--- a/openspec/changes/make-reject-paragraph-collapse-mark-based/design.md
+++ b/openspec/changes/make-reject-paragraph-collapse-mark-based/design.md
@@ -1,0 +1,45 @@
+# Design: mark-based Reject All
+
+## Context
+
+`rejectAllChanges` decided paragraph removal by two paths: (1) the paragraph mark is `PPR-INS`, or (2) a
+content heuristic — every substantive run lives inside `w:ins`/`w:moveTo`. Path (2) existed solely because
+`wrapParagraphAsInserted` *omitted* `PPR-INS` for non-empty inserted paragraphs (an uncited "Google Docs
+compat" choice), so the mark was unavailable to drop them. The primitive `rejectChanges` carried the same
+two-path logic (`paragraphHasOnlyInsertedContent`).
+
+## Decision
+
+Make insertions always carry `PPR-INS`, then drop the content heuristic from both reject paths so reject is
+purely **mark-based**. This is the rule Word, LibreOffice, and Google Docs all implement: a run-level
+insertion under an untracked paragraph mark is text added to a pre-existing paragraph and survives reject
+as an empty paragraph; only a `PPR-INS`-marked paragraph (the break itself inserted) is removed.
+
+## Why mark-based, not content-based
+
+Oracle evidence (Stage 0/1):
+
+| Fixture (mark untracked) | op | LibreOffice | Google Docs |
+| --- | --- | --- | --- |
+| `ins`-only | reject | keep empty `<w:p>` | — |
+| `moveTo`-only | reject | keep empty `<w:p>` | — |
+| `del`-only | accept | keep empty `<w:p>` | — |
+| `ins` **+ PPR-INS** | reject | **drop** | **drop, no leftover empty paragraph** |
+
+The content heuristic is XML-indistinguishable from "text into a pre-existing paragraph", so it cannot be
+correct in general; the mark is the only faithful discriminator. Always emitting `PPR-INS` is also *more*
+correct: a fully inserted paragraph's mark genuinely is inserted.
+
+## Round-trip safety
+
+safe-docx's own inserted paragraphs now always carry `PPR-INS`, so mark-based reject removes them exactly
+as before — the insert→reject round-trip is preserved (validated: full docx-core suite + round-trip-inplace
+11/11 + real-corpus regression). The only behavior change is for **foreign** documents whose inserted runs
+sit under an untracked mark, which now correctly survive reject as empty paragraphs.
+
+## Scope boundary
+
+Reject side only. The symmetric accept-side content drop (a `del`-only untracked-mark paragraph is dropped
+on accept where LibreOffice keeps it) is the same root cause but is left to a follow-up; `wrapParagraphAsDeleted`
+already always emits `PPR-DEL`, so safe-docx's own deletions are already mark-based and unaffected. The Lean
+accept-side gap `G3` (broaden Lean `accept` to keep empty-collapsing paragraphs) is its own successor change.

--- a/openspec/changes/make-reject-paragraph-collapse-mark-based/proposal.md
+++ b/openspec/changes/make-reject-paragraph-collapse-mark-based/proposal.md
@@ -1,0 +1,55 @@
+# Change: Make Reject All paragraph removal purely mark-based (closes G4, oracle-validated)
+
+## Why
+
+The Lean↔TS helper differential (`add-lean-ts-helper-differential-harness`) pinned **G4**: rejecting a
+paragraph whose only content is inside `w:ins` (with an **untracked** paragraph mark) — the Lean `reject`
+keeps an empty `<w:p>`, the TS `rejectAllChanges` drops the whole paragraph. The original framing assumed
+G4 was a Lean-model gap. A reference-implementation oracle shows the opposite: **G4 is an engine
+over-deletion.**
+
+- **LibreOffice** (driven headless, accept/reject all): an `ins`-run under an untracked paragraph mark
+  rejects to an **empty paragraph that survives** (the run-level insertion redline deletes only the text;
+  the paragraph node is never in the redline range). Confirmed for `ins`-only (keeps), `moveTo`-only
+  (keeps), and the `PPR-INS`-marked control (drops). The same is true on the accept side for `del`-only.
+- **OOXML semantics:** `<w:ins>` inside `<w:pPr><w:rPr>` (PPR-INS) marks the paragraph **mark** as
+  inserted. A run-level insertion under an *untracked* mark means text was inserted into a **pre-existing**
+  paragraph, so rejecting restores that (empty) paragraph. Only when the mark itself is `PPR-INS` should
+  reject remove the whole paragraph.
+- **Google Docs:** renders inserted runs identically with or without `PPR-INS`, and rejecting a
+  `PPR-INS`-marked inserted paragraph removes it cleanly with **no leftover empty paragraph** — i.e.
+  `PPR-INS` is strictly better there, debunking the (uncited) "Google Docs hides w:ins runs with PPR-INS"
+  rationale the engine relied on.
+
+The engine drops G4 via a content-based heuristic ("all content is inside `w:ins`/`w:moveTo`") that exists
+only to compensate for `wrapParagraphAsInserted` **omitting** `PPR-INS` for non-empty inserted paragraphs.
+That heuristic over-deletes foreign (Word/LibreOffice-authored) paragraphs whose mark is untracked. Making
+insertions always carry `PPR-INS` lets reject be purely **mark-based** — Word/LibreOffice/Google-Docs
+faithful — and closes G4 by fixing the engine, with the Lean model (keep-empty) already correct.
+
+## What Changes
+
+- `wrapParagraphAsInserted` (`packages/docx-core/src/baselines/atomizer/inPlaceModifier-wrappers.ts`)
+  SHALL **always** emit the `PPR-INS` paragraph-mark marker, including for non-empty paragraphs (drop the
+  prior "Google Docs compat" omission). `wrapParagraphAsDeleted` already always emits `PPR-DEL`.
+- `rejectAllChanges` (`trackChangesAcceptorAst.ts:533-579`) and the primitive `rejectChanges`
+  (`primitives/reject_changes.ts`, `paragraphHasOnlyInsertedContent`) SHALL remove a paragraph on reject
+  **iff its paragraph mark is `PPR-INS`** — the content-based all-`w:ins`/`w:moveTo` drop heuristic is
+  removed from **both** reject paths in lockstep (they are used by different public APIs).
+- Flip the G4 case in `lean-differential-helpers.test.ts` (`[LEAN-HELP-06]`) from *characterized
+  divergence* to *agreement*; reverse the `inPlaceModifier.test.ts` "no-op for substantive runs" assertion
+  to expect the marker; update the pending `add-lean-ts-helper-differential-harness` G4 scenario to match.
+
+## Impact
+
+- Affected specs: `docx-comparison` (ADDED: one requirement; the pending helper-differential change's G4
+  scenario is revised in place since that change is not yet archived).
+- Affected code: `packages/docx-core/src/baselines/atomizer/inPlaceModifier-wrappers.ts`,
+  `packages/docx-core/src/baselines/atomizer/trackChangesAcceptorAst.ts`,
+  `packages/docx-core/src/primitives/reject_changes.ts`, and tests
+  (`inPlaceModifier.test.ts`, `integration/lean-differential-helpers.test.ts`).
+- **Behavior change** (reject of foreign / mark-omitting documents): a paragraph whose runs are inserted
+  under an untracked mark now survives reject as an empty paragraph instead of being dropped — matching
+  Word/LibreOffice. safe-docx's own inserted paragraphs always carry `PPR-INS` now, so their insert→reject
+  round-trip is unchanged (validated: full docx-core suite + round-trip-inplace 11/11 green).
+- The Lean accept-side gap **G3** is unaffected and remains the next increment (broaden Lean `accept`).

--- a/openspec/changes/make-reject-paragraph-collapse-mark-based/specs/docx-comparison/spec.md
+++ b/openspec/changes/make-reject-paragraph-collapse-mark-based/specs/docx-comparison/spec.md
@@ -1,0 +1,51 @@
+## ADDED Requirements
+
+### Requirement: Reject All removes paragraphs by the paragraph-mark insertion marker, not by content
+
+The production Reject All SHALL remove a paragraph during reject **if and only if** its paragraph mark is a
+tracked insertion (`<w:pPr><w:rPr><w:ins/>`, "PPR-INS"). This applies to both reject entry points —
+`rejectAllChanges` (`packages/docx-core/src/baselines/atomizer/trackChangesAcceptorAst.ts`) and the
+primitive `rejectChanges` (`packages/docx-core/src/primitives/reject_changes.ts`) — which SHALL behave
+identically. Reject SHALL NOT remove a paragraph based on a content heuristic (e.g. "all runs live inside
+`w:ins`/`w:moveTo`"): a run-level insertion under an **untracked** paragraph mark denotes text inserted
+into a pre-existing paragraph, which Microsoft Word and LibreOffice both keep as an empty paragraph on
+reject; a content-based drop over-deletes it.
+
+To make every genuinely inserted paragraph removable by this mark-based rule, `wrapParagraphAsInserted`
+(`packages/docx-core/src/baselines/atomizer/inPlaceModifier-wrappers.ts`) SHALL always emit the `PPR-INS`
+marker, including for non-empty paragraphs, mirroring `wrapParagraphAsDeleted` (which already always emits
+`PPR-DEL`). The prior omission of `PPR-INS` for non-empty paragraphs (justified by an uncited claim that
+Google Docs hides `w:ins` runs coexisting with `PPR-INS`) SHALL be removed: Google Docs renders the
+inserted runs identically with `PPR-INS` present and rejects such a paragraph cleanly with no leftover
+empty paragraph.
+
+This closes the characterized reject-side divergence `G4` recorded by the Lean↔TS helper differential as an
+**engine fidelity fix** (the Lean `reject`, which keeps the empty paragraph, was already faithful): the TS
+and Lean `reject` SHALL now agree on an `ins`-only untracked-mark paragraph. The accept-side gap `G3`
+(Lean `accept` dropping empty-collapsing paragraphs) is out of scope and remains the successor increment.
+This requirement changes production reject behavior only; safe-docx's own inserted paragraphs always carry
+`PPR-INS`, so their insert→reject round-trip is preserved.
+
+#### Scenario: [REJECT-MARK-01] Ins-only paragraph with an untracked mark survives reject as an empty paragraph
+
+- **GIVEN** a paragraph whose only content is a `w:ins`-wrapped run and whose paragraph mark is NOT `PPR-INS` (text inserted into a pre-existing paragraph)
+- **WHEN** it is run through `rejectAllChanges` (and through the primitive `rejectChanges`)
+- **THEN** the inserted run is removed and the now-empty paragraph is kept, matching Word/LibreOffice and the Lean `reject` (the former `G4` divergence is now agreement)
+
+#### Scenario: [REJECT-MARK-02] PPR-INS-marked inserted paragraph is removed by reject
+
+- **GIVEN** a paragraph whose paragraph mark is a tracked insertion (`<w:pPr><w:rPr><w:ins/>`)
+- **WHEN** it is run through `rejectAllChanges` (and through the primitive `rejectChanges`)
+- **THEN** the whole paragraph is removed, including its mark, matching Word/LibreOffice/Google-Docs
+
+#### Scenario: [REJECT-MARK-03] wrapParagraphAsInserted always emits the PPR-INS marker
+
+- **GIVEN** a paragraph with substantive run content that is being marked as a tracked insertion
+- **WHEN** `wrapParagraphAsInserted` is applied
+- **THEN** a `PPR-INS` paragraph-mark marker is present in `w:pPr/w:rPr`, so mark-based reject removes the paragraph (the prior no-op-for-substantive-runs behavior is reversed)
+
+#### Scenario: [REJECT-MARK-04] safe-docx insert→reject round-trip is preserved
+
+- **GIVEN** the in-place modifier inserting paragraphs into a real document (each inserted paragraph now carrying `PPR-INS`)
+- **WHEN** the result is run through reject
+- **THEN** every inserted paragraph is removed and the document round-trips to its pre-edit paragraph structure, with the existing round-trip-inplace and real-corpus regression suites passing

--- a/openspec/changes/make-reject-paragraph-collapse-mark-based/tasks.md
+++ b/openspec/changes/make-reject-paragraph-collapse-mark-based/tasks.md
@@ -1,0 +1,36 @@
+## 1. Engine: always-mark insertions
+
+- [x] 1.1 `wrapParagraphAsInserted` (`inPlaceModifier-wrappers.ts`): always emit `PPR-INS`; remove the
+      `hasSubstantiveContent` early-return and the uncited "Google Docs compat" rationale.
+
+## 2. Engine: mark-based reject (both paths, in lockstep)
+
+- [x] 2.1 `rejectAllChanges` (`trackChangesAcceptorAst.ts:533-579`): remove the content-based
+      all-`w:ins`/`w:moveTo` paragraph-drop heuristic; keep only the `PPR-INS` mark-based drop.
+- [x] 2.2 `rejectChanges` (`primitives/reject_changes.ts`): remove `paragraphHasOnlyInsertedContent` and its
+      drop branch; keep only the `paragraphHasParaMarker(p, 'ins')` mark-based drop.
+- [x] 2.3 Remove the now-dead helpers/constants left behind (`runHasVisibleContent` +
+      `RUN_VISIBLE_CONTENT_TAGS` in `trackChangesAcceptorAst.ts`; `containsRun`, `paragraphHasOnlyInsertedContent`,
+      `INSERTED_LOCALS`/`KEPT_LOCALS`/`RANGE_MARKER_LOCALS`, `isWElement` in `reject_changes.ts`). `tsc` clean.
+
+## 3. Tests
+
+- [x] 3.1 `inPlaceModifier.test.ts`: reverse the "no-op for substantive runs" test to assert the `PPR-INS`
+      marker IS added.
+- [x] 3.2 `lean-differential-helpers.test.ts`: flip `[LEAN-HELP-06]` (G4) from documented divergence to
+      strict agreement (both keep an empty `P[ ]`); update the file header comment (G4 closed, G3 remains).
+- [x] 3.3 Full `@usejunior/docx-core` suite green (1338 passed); helper differential green 7/7 with the exe.
+
+## 4. Oracle validation (Stage 0/1 evidence)
+
+- [x] 4.1 LibreOffice headless accept/reject confirms keep-empty for `ins`-only / `del`-only / `moveTo`-only
+      untracked-mark paragraphs, and drop for the `PPR-INS`-marked control.
+- [x] 4.2 Google Docs confirms `PPR-INS` renders inserted runs and rejects cleanly (no leftover empty
+      paragraph); the "Google Docs hides w:ins runs" claim is debunked.
+
+## 5. Specs / docs
+
+- [x] 5.1 Add the `docx-comparison` ADDED requirement (this change) + scenarios `[REJECT-MARK-01..04]`.
+- [x] 5.2 Revise the pending `add-lean-ts-helper-differential-harness` G4 scenario (`[LEAN-HELP-06]`) from
+      documented divergence to agreement.
+- [ ] 5.3 Ship: peer-review (codex + agy), open PR, `/automerge-smoke`.

--- a/packages/docx-core/src/baselines/atomizer/inPlaceModifier-wrappers.ts
+++ b/packages/docx-core/src/baselines/atomizer/inPlaceModifier-wrappers.ts
@@ -528,40 +528,22 @@ export function wrapParagraphAsInserted(
   dateStr: string,
   state: RevisionIdState
 ): boolean {
-  // For paragraphs with substantive run content: skip the paragraph-mark marker.
-  // Google Docs ignores (or actively hides) w:ins-wrapped runs when they
-  // coexist with PPR-INS markers. Since individual runs are already wrapped
-  // with <w:ins>, the paragraph-level marker is redundant for non-empty
-  // paragraphs and omitting it maximises cross-application compatibility.
+  // Mark the paragraph MARK as inserted (<w:pPr><w:rPr><w:ins/>). For a genuinely
+  // inserted paragraph the paragraph break itself is a tracked insertion, so this
+  // marker is what makes Reject All remove the whole paragraph (mark + content) and
+  // Accept All keep it. The individual runs are wrapped in <w:ins> separately; this
+  // function only adds the paragraph-mark marker.
   //
-  // For empty paragraphs (no runs, or only empty w:r shells): we MUST add
-  // the PPR-INS marker so that Reject All removes the paragraph. Without it,
-  // the empty paragraph shell survives reject, causing round-trip safety failures.
-  //
-  // Important: empty <w:r> elements (no w:t, w:tab, w:br, etc.) should NOT
-  // count as substantive content. They are empty shells that don't produce
-  // visible output and should not prevent PPR-INS from being added.
-  let hasSubstantiveContent = false;
-  for (const child of childElements(paragraph)) {
-    if (child.tagName === 'w:ins') {
-      // Check if the w:ins wrapper contains runs with visible content
-      for (let i = 0; i < child.childNodes.length; i++) {
-        const insChild = child.childNodes[i]!;
-        if (insChild.nodeType === 1 && (insChild as Element).tagName === 'w:r' &&
-            runHasVisibleContent(insChild as Element)) {
-          hasSubstantiveContent = true;
-          break;
-        }
-      }
-      if (hasSubstantiveContent) break;
-    } else if (child.tagName === 'w:r' && runHasVisibleContent(child)) {
-      hasSubstantiveContent = true;
-      break;
-    }
-  }
-  if (hasSubstantiveContent) {
-    return true;
-  }
+  // We ALWAYS emit the marker, including for non-empty paragraphs. A prior heuristic
+  // omitted it when the paragraph had substantive run content, on the (uncited) belief
+  // that Google Docs hides w:ins-wrapped runs that coexist with a PPR-INS marker. That
+  // is false — Google Docs renders the inserted runs identically with or without
+  // PPR-INS, and rejecting WITH the marker is cleaner there (it leaves no empty
+  // paragraph). Omitting the marker forced Reject All to guess via a content-based
+  // "all content is inside w:ins" heuristic that over-deleted foreign paragraphs whose
+  // mark is untracked (i.e. text inserted into a pre-existing paragraph, which Word and
+  // LibreOffice keep as an empty paragraph on reject). Reject is now purely mark-based
+  // (see rejectAllChanges / rejectChanges), which requires this marker to be present.
   addParagraphMarkRevisionMarker(paragraph, 'w:ins', author, dateStr, state);
   return true;
 }

--- a/packages/docx-core/src/baselines/atomizer/inPlaceModifier.test.ts
+++ b/packages/docx-core/src/baselines/atomizer/inPlaceModifier.test.ts
@@ -782,7 +782,7 @@ describe('inPlaceModifier', () => {
       });
     });
 
-    test('should be a no-op for paragraphs with substantive runs (Google Docs compat)', async ({ given, when, then }: AllureBddContext) => {
+    test('always adds the PPR-INS marker, including for paragraphs with substantive runs', async ({ given, when, then }: AllureBddContext) => {
       let pPr: Element, p: Element;
       let state: ReturnType<typeof createRevisionIdState>;
       let result: boolean;
@@ -799,13 +799,18 @@ describe('inPlaceModifier', () => {
         result = wrapParagraphAsInserted(p, author, dateStr, state);
       });
 
-      await then('no PPR-INS marker is added — runs with visible content are wrapped by w:ins', () => {
+      await then('the PPR-INS paragraph-mark marker is added so reject stays purely mark-based', () => {
         expect(result).toBe(true);
 
-        // No PPR-INS marker — runs with visible content already wrapped by w:ins
+        // A genuinely inserted paragraph's mark is itself inserted. We always emit
+        // PPR-INS (even for non-empty paragraphs) so that mark-based Reject All removes
+        // the whole paragraph. The prior "Google Docs compat" omission was uncited and
+        // false — Google Docs renders the inserted runs identically with PPR-INS present.
         const pPrChildren = childElements(pPr);
         const rPr = pPrChildren.find((c) => c.tagName === 'w:rPr');
-        expect(rPr).toBeUndefined();
+        expect(rPr).toBeDefined();
+        const insMarker = childElements(rPr!).find((c) => c.tagName === 'w:ins');
+        expect(insMarker).toBeDefined();
       });
     });
   });

--- a/packages/docx-core/src/baselines/atomizer/trackChangesAcceptorAst.ts
+++ b/packages/docx-core/src/baselines/atomizer/trackChangesAcceptorAst.ts
@@ -28,9 +28,17 @@ function getParagraphPPr(p: Element): Element | undefined {
 }
 
 function paragraphHasParaMarker(p: Element, tagName: 'w:ins' | 'w:del'): boolean {
+  // Strict paragraph-mark marker shape: w:p > w:pPr > w:rPr > (w:ins | w:del),
+  // navigated by direct children only — NOT a descendant search. A descendant
+  // search would mistake a marker nested inside a w:pPrChange snapshot (which
+  // stores a prior w:pPr/w:rPr) for the live paragraph mark, and would diverge
+  // from the primitive rejectChanges (primitives/reject_changes.ts), which both
+  // reject paths must agree with.
   const pPr = getParagraphPPr(p);
   if (!pPr) return false;
-  return findAllByTagName(pPr, tagName).length > 0;
+  const rPr = childElements(pPr).find((c) => c.tagName === 'w:rPr');
+  if (!rPr) return false;
+  return childElements(rPr).some((c) => c.tagName === tagName);
 }
 
 function removeParaMarkers(root: Element): void {
@@ -89,29 +97,6 @@ function findNeighborParagraphOutsideRemoval(
   }
 
   return undefined;
-}
-
-/**
- * Tag names that represent visible content inside a w:r element.
- * A run containing at least one of these is considered substantive (non-empty).
- */
-const RUN_VISIBLE_CONTENT_TAGS: ReadonlySet<string> = new Set([
-  'w:t', 'w:tab', 'w:br', 'w:cr', 'w:drawing', 'w:object', 'w:pict',
-  'w:sym', 'w:fldChar', 'w:instrText',
-]);
-
-/**
- * Returns true if a w:r element contains at least one visible content child.
- * Empty runs (containing only w:rPr or nothing) return false.
- */
-function runHasVisibleContent(run: Element): boolean {
-  for (let i = 0; i < run.childNodes.length; i++) {
-    const child = run.childNodes[i]!;
-    if (child.nodeType === NODE_TYPE.ELEMENT && RUN_VISIBLE_CONTENT_TAGS.has((child as Element).tagName)) {
-      return true;
-    }
-  }
-  return false;
 }
 
 function paragraphContentStartIndex(paragraph: Element): number {
@@ -519,61 +504,20 @@ export function acceptAllChanges(documentXml: string): string {
 export function rejectAllChanges(documentXml: string): string {
   const root = parseDocumentXml(documentXml);
 
-  // Step 1: Find paragraphs where w:ins is the ONLY substantive content
-  // (no w:del, no w:r outside track changes)
+  // Step 1: Remove a paragraph on Reject All iff its paragraph MARK is a tracked
+  // insertion (<w:pPr><w:rPr><w:ins .../></w:rPr>) — i.e. the paragraph break itself
+  // was inserted, so rejecting the insertion removes the whole paragraph. This is the
+  // Word/LibreOffice-faithful, purely mark-based rule.
+  //
+  // We deliberately do NOT drop a paragraph based on content (e.g. "all runs are inside
+  // w:ins"). A run-level insertion under an UNTRACKED paragraph mark means text was
+  // inserted into a pre-existing paragraph; Word and LibreOffice both keep that
+  // paragraph (empty) on reject, and a content-based drop over-deletes it. safe-docx's
+  // own inserted paragraphs always carry the PPR-INS mark now (wrapParagraphAsInserted),
+  // so the mark-based rule covers them without the old content heuristic.
   const paragraphsToRemove = new Set<Element>();
-  // Paragraph-level insertion markers (Aspose/Word encode inserted paragraphs via <w:pPr><w:rPr><w:ins .../></w:rPr>)
-  // should remove the paragraph on Reject All.
   for (const p of findAllByTagName(root, 'w:p')) {
     if (paragraphHasParaMarker(p, 'w:ins')) {
-      paragraphsToRemove.add(p);
-    }
-  }
-
-  // Also check paragraphs where ALL substantive content is inside w:ins and/or
-  // w:moveTo wrappers (no bare w:r, no w:del, no w:moveFrom). These paragraphs
-  // should be removed on reject even without an explicit PPR-INS paragraph marker.
-  // This handles the inplace modifier's no-op wrapParagraphAsInserted (which omits
-  // PPR-INS for Google Docs compatibility).
-  for (const p of findAllByTagName(root, 'w:p')) {
-    if (paragraphsToRemove.has(p)) continue;
-
-    // Must have at least one w:ins or w:moveTo
-    const insEls = findAllByTagName(p, 'w:ins');
-    const moveToEls = findAllByTagName(p, 'w:moveTo');
-    if (insEls.length === 0 && moveToEls.length === 0) continue;
-
-    // Skip if paragraph has deleted/moveFrom content (those survive reject)
-    const dels = findAllByTagName(p, 'w:del');
-    const moveFroms = findAllByTagName(p, 'w:moveFrom');
-    if (dels.length > 0 || moveFroms.length > 0) continue;
-
-    // Check if this paragraph has any w:r elements with visible content
-    // outside of w:ins/w:moveTo. Empty w:r shells (no w:t, w:tab, w:br, etc.)
-    // should NOT count as substantive content — they are artifacts that would
-    // otherwise prevent paragraph removal, leaving ghost paragraphs after reject.
-    let hasContentOutsideRemoved = false;
-    for (const child of childElements(p)) {
-      if (child.tagName === 'w:r') {
-        if (runHasVisibleContent(child)) {
-          hasContentOutsideRemoved = true;
-          break;
-        }
-        continue;
-      }
-      if (child.tagName !== 'w:ins' && child.tagName !== 'w:moveTo' &&
-          child.tagName !== 'w:pPr' &&
-          child.tagName !== 'w:moveToRangeStart' && child.tagName !== 'w:moveToRangeEnd' &&
-          child.tagName !== 'w:bookmarkStart' && child.tagName !== 'w:bookmarkEnd') {
-        const runsInChild = findAllByTagName(child, 'w:r');
-        if (runsInChild.some(runHasVisibleContent)) {
-          hasContentOutsideRemoved = true;
-          break;
-        }
-      }
-    }
-
-    if (!hasContentOutsideRemoved) {
       paragraphsToRemove.add(p);
     }
   }
@@ -583,7 +527,7 @@ export function rejectAllChanges(documentXml: string): string {
   // Step 2: Remove w:ins elements entirely (inserted content disappears)
   removeAllByTagName(root, 'w:ins');
 
-  // Step 3: Remove paragraphs that ONLY had w:ins content
+  // Step 3: Remove the PPR-INS-marked paragraphs (their paragraph mark was inserted)
   for (const p of paragraphsToRemove) {
     if (p.parentNode) {
       p.parentNode.removeChild(p);

--- a/packages/docx-core/src/integration/lean-differential-helpers.test.ts
+++ b/packages/docx-core/src/integration/lean-differential-helpers.test.ts
@@ -30,13 +30,15 @@
  * it (`add-lean-deleted-field-code-constraint`), so the two engines AGREE:
  *   G1  fldChar inside w:del            → Lean validate=false, TS validate=false  (agree)
  *   G2  delInstrText outside w:del      → Lean validate=false, TS validate=false  (agree)
- * Two KNOWN gaps remain, pinned as characterization cases — the worklist for the next
- * model-broadening increment (slice 4b: paragraph-mark accept/reject collapse, which needs
- * an OoxmlModel paragraph-datatype extension), not harness bugs:
+ * G4 — the reject-side paragraph collapse — is now also CLOSED, but as an ENGINE fidelity fix
+ * rather than a Lean change: an ins-only paragraph whose paragraph MARK is untracked means text
+ * inserted into a pre-existing paragraph, which Word/LibreOffice keep (empty) on reject. The TS
+ * engine used to drop it via a content-based heuristic; reject is now purely mark-based, so it
+ * keeps the empty paragraph, matching Lean (which never dropped it):
+ *   G4  reject of an ins-only paragraph → Lean keeps an empty <w:p>, TS keeps empty <w:p>  (agree)
+ * One KNOWN gap remains, pinned as a characterization case (a Lean-model gap, not a harness bug):
  *   G3  accept of an ins-wrappered      → Lean drops the paragraph, TS keeps empty <w:p>
- *       paragraph that collapses to empty
- *   G4  reject of an ins-only paragraph → Lean keeps an empty <w:p>, TS drops it
- *       (Lean `reject` never drops paragraphs; the reject-side analog of G3)
+ *       paragraph that collapses to empty  (closes when Lean `accept` is broadened to keep empties)
  *
  * Gating: when the executable is absent (a developer without the Lean toolchain, or an
  * un-built `.lake`), the suite is SKIPPED with a clear message so `npm test` stays green;
@@ -598,8 +600,8 @@ describeMaybe('Lean Differential Harness - Tier 2 helper extensional equivalence
     },
   );
 
-  test.openspec('[LEAN-HELP-06] G4 — reject paragraph-collapse is a characterized divergence')(
-    'reject of an ins-only paragraph: Lean keeps an empty paragraph, TS drops it',
+  test.openspec('[LEAN-HELP-06] G4 — reject paragraph-collapse now AGREES (engine fidelity fix)')(
+    'reject of an ins-only paragraph (untracked mark): Lean and TS both keep an empty paragraph',
     async ({ given, when, then }: AllureBddContext) => {
       let lean: HelperResult;
       await given('a doc whose first paragraph is only a w:ins (no surviving content)', async () => {
@@ -611,12 +613,14 @@ describeMaybe('Lean Differential Harness - Tier 2 helper extensional equivalence
         tsReject = xmlToTokens(rejectAllChanges(renderDocToXml(G4_DOC)));
         leanReject = docToTokens(lean!.reject);
       });
-      await then('Lean keeps an empty paragraph (its reject never drops) while the TS engine removes it', async () => {
-        // Lean reject keeps every paragraph: the collapsed one becomes an empty P[ ].
+      await then('both keep the collapsed paragraph as an empty P[ ] — mark-based reject is Word-faithful', async () => {
+        // The first paragraph's mark is UNTRACKED, so reject keeps it (now empty): an
+        // ins-run under an untracked mark means text inserted into a pre-existing
+        // paragraph, which Word and LibreOffice both keep on reject. The engine's old
+        // content-based drop over-deleted it; the mark-based reject now matches Lean.
         expect(leanReject).toEqual(['P[', ']', 'P[', 'R[', 't:keep', ']', ']']);
-        // TS drops the ins-only paragraph, keeping only the survivor.
-        expect(tsReject).toEqual(['P[', 'R[', 't:keep', ']', ']']);
-        expect(key(tsReject)).not.toBe(key(leanReject));
+        expect(tsReject).toEqual(['P[', ']', 'P[', 'R[', 't:keep', ']', ']']);
+        expect(key(tsReject)).toBe(key(leanReject));
       });
     },
   );

--- a/packages/docx-core/src/integration/paragraph-level-markers.test.ts
+++ b/packages/docx-core/src/integration/paragraph-level-markers.test.ts
@@ -69,4 +69,41 @@ describe('Paragraph-Level Track Changes Markers (Aspose-Style)', () => {
       expect(countParagraphs(rejectedXml)).toBe(countParagraphs(origXml));
     });
   });
+
+  test('reject detects the paragraph mark strictly (pPr/rPr) and ignores w:ins nested in a w:pPrChange snapshot', async ({ given, when, then, and }: AllureBddContext) => {
+    // Regression: paragraphHasParaMarker must match only the live w:pPr > w:rPr > w:ins
+    // shape, not any descendant w:ins under w:pPr. A w:pPrChange snapshot stores a prior
+    // w:pPr/w:rPr that can contain a w:ins; a descendant search would mistake it for the
+    // live paragraph mark and drop a paragraph the primitive rejectChanges keeps.
+    let xml: string;
+    let rejectedXml = '';
+
+    await given('a doc with (A) a paragraph whose only w:ins under pPr is nested in a w:pPrChange + a bare run, and (B) a paragraph with a direct pPr/rPr w:ins mark', () => {
+      const ns = 'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
+      xml =
+        `<w:document ${ns}><w:body>` +
+        // (A) nested-in-pPrChange — NOT a live mark → must survive reject (its run stays)
+        '<w:p><w:pPr><w:pPrChange w:id="9" w:author="x" w:date="2024-01-01T00:00:00Z">' +
+        '<w:pPr><w:rPr><w:ins w:id="8" w:author="x" w:date="2024-01-01T00:00:00Z"/></w:rPr></w:pPr>' +
+        '</w:pPrChange></w:pPr><w:r><w:t>survives</w:t></w:r></w:p>' +
+        // (B) direct PPR-INS mark → must be dropped on reject
+        '<w:p><w:pPr><w:rPr><w:ins w:id="1" w:author="x" w:date="2024-01-01T00:00:00Z"/></w:rPr></w:pPr>' +
+        '<w:ins w:id="2" w:author="x" w:date="2024-01-01T00:00:00Z"><w:r><w:t>inserted</w:t></w:r></w:ins></w:p>' +
+        '</w:body></w:document>';
+    });
+
+    await when('rejectAllChanges is applied', () => {
+      rejectedXml = rejectAllChanges(xml);
+    });
+
+    await then('the pPrChange-nested paragraph survives (its run is kept)', () => {
+      expect(rejectedXml).toContain('survives');
+    });
+
+    await and('the directly-PPR-INS-marked paragraph is dropped', () => {
+      expect(rejectedXml).not.toContain('inserted');
+      // Exactly one paragraph remains: the pPrChange one kept, the marked one removed.
+      expect(countParagraphs(rejectedXml)).toBe(1);
+    });
+  });
 });

--- a/packages/docx-core/src/primitives/reject_changes.ts
+++ b/packages/docx-core/src/primitives/reject_changes.ts
@@ -33,10 +33,6 @@ function isW(node: Node, localName: string): node is Element {
   );
 }
 
-function isWElement(node: Node): node is Element {
-  return node.nodeType === 1 && (node as Element).namespaceURI === W_NS;
-}
-
 function getDepth(node: Node): number {
   let depth = 0;
   let cur: Node | null = node.parentNode;
@@ -95,61 +91,6 @@ function paragraphHasParaMarker(p: Element, markerLocalName: string): boolean {
         const rPrChild = pPrChild.childNodes[k]!;
         if (isW(rPrChild, markerLocalName)) return true;
       }
-    }
-  }
-  return false;
-}
-
-/**
- * Check if a node (or its descendants) contains any w:r elements.
- */
-function containsRun(node: Node): boolean {
-  if (isW(node, 'r')) return true;
-  for (let i = 0; i < node.childNodes.length; i++) {
-    if (containsRun(node.childNodes[i]!)) return true;
-  }
-  return false;
-}
-
-// Tags that are "inserted" content — removal candidates when rejecting
-const INSERTED_LOCALS = new Set(['ins', 'moveTo']);
-// Tags that are "kept" content when rejecting
-const KEPT_LOCALS = new Set(['del', 'moveFrom']);
-// Range marker tags to ignore
-const RANGE_MARKER_LOCALS = new Set([
-  'moveFromRangeStart', 'moveFromRangeEnd',
-  'moveToRangeStart', 'moveToRangeEnd',
-]);
-
-/**
- * Determine if a paragraph's only content lives inside w:ins or w:moveTo
- * (no w:r outside those wrappers, and no w:del/w:moveFrom siblings).
- * These paragraphs should be removed when rejecting changes.
- */
-function paragraphHasOnlyInsertedContent(p: Element): boolean {
-  for (let i = 0; i < p.childNodes.length; i++) {
-    const child = p.childNodes[i]!;
-    if (child.nodeType !== 1) continue;
-    const el = child as Element;
-    if (el.namespaceURI !== W_NS) continue;
-    const local = el.localName;
-
-    // If the paragraph has kept content wrappers, it stays
-    if (KEPT_LOCALS.has(local)) return false;
-
-    // Skip pPr, range markers, and inserted wrappers
-    if (local === 'pPr' || RANGE_MARKER_LOCALS.has(local) || INSERTED_LOCALS.has(local)) continue;
-
-    // A bare w:r or any other element that contains runs means live content
-    if (local === 'r' || containsRun(el)) return false;
-  }
-
-  // We passed all children without finding live content — but there must be
-  // at least one inserted wrapper for this to be an "inserted content" paragraph
-  for (let i = 0; i < p.childNodes.length; i++) {
-    const child = p.childNodes[i]!;
-    if (child.nodeType === 1 && isWElement(child) && INSERTED_LOCALS.has(child.localName)) {
-      return true;
     }
   }
   return false;
@@ -259,13 +200,14 @@ export function rejectChanges(doc: Document): RejectChangesResult {
   const allParagraphs = collectByLocalName(root, 'p');
 
   for (const p of allParagraphs) {
-    // Paragraph-level insertion marker: w:p > w:pPr > w:rPr > w:ins
+    // Remove a paragraph iff its paragraph MARK is a tracked insertion
+    // (w:p > w:pPr > w:rPr > w:ins) — the paragraph break itself was inserted.
+    // We deliberately do NOT drop a paragraph based on content ("all runs inside
+    // w:ins/w:moveTo"): a run-level insertion under an untracked mark means text was
+    // inserted into a pre-existing paragraph, which Word/LibreOffice keep (empty) on
+    // reject. safe-docx's inserted paragraphs always carry the mark now, so the
+    // mark-based rule suffices and is Word-faithful. (Mirrors rejectAllChanges.)
     if (paragraphHasParaMarker(p, 'ins')) {
-      paragraphsToRemove.add(p);
-      continue;
-    }
-    // Paragraphs whose only content is inside w:ins or w:moveTo
-    if (paragraphHasOnlyInsertedContent(p)) {
       paragraphsToRemove.add(p);
     }
   }

--- a/packages/docx-core/test-primitives/reject_changes.test.ts
+++ b/packages/docx-core/test-primitives/reject_changes.test.ts
@@ -49,6 +49,31 @@ describe('rejectChanges', () => {
     });
   });
 
+  test('detects the paragraph mark strictly (pPr/rPr) and ignores w:ins nested in a w:pPrChange snapshot', async ({ given, when, then }: AllureBddContext) => {
+    // Mirrors the AST rejectAllChanges regression: both reject entry points must keep a
+    // paragraph whose only w:ins under pPr is inside a w:pPrChange snapshot, and drop one
+    // with a direct w:pPr/w:rPr/w:ins mark — proving the two paths behave identically.
+    let doc: Document;
+
+    await given('a doc with (A) a w:pPrChange-nested w:ins + a bare run, and (B) a direct pPr/rPr w:ins mark', async () => {
+      doc = makeDoc(
+        '<w:p><w:pPr><w:pPrChange w:id="9" w:author="x" w:date="2024-01-01T00:00:00Z">' +
+          '<w:pPr><w:rPr><w:ins w:id="8" w:author="x" w:date="2024-01-01T00:00:00Z"/></w:rPr></w:pPr>' +
+          '</w:pPrChange></w:pPr><w:r><w:t>survives</w:t></w:r></w:p>' +
+        '<w:p><w:pPr><w:rPr><w:ins w:id="1" w:author="x" w:date="2024-01-01T00:00:00Z"/></w:rPr></w:pPr>' +
+          '<w:ins w:id="2" w:author="x" w:date="2024-01-01T00:00:00Z"><w:r><w:t>inserted</w:t></w:r></w:ins></w:p>',
+      );
+    });
+
+    await when('rejectChanges is called', async () => {
+      rejectChanges(doc);
+    });
+
+    await then('only the pPrChange-nested paragraph survives, matching the AST reject path', async () => {
+      expect(getAllParagraphTexts(doc)).toEqual(['survives']);
+    });
+  });
+
   test('should remove inserted content', async ({ given, when, then }: AllureBddContext) => {
     let doc: Document;
     let result: ReturnType<typeof rejectChanges>;


### PR DESCRIPTION
## What

Reject All dropped a paragraph whose runs were all inside `w:ins`/`w:moveTo` even when its paragraph **mark** was untracked. A reference-implementation oracle shows this **over-deletes**: a run-level insertion under an untracked mark is text inserted into a *pre-existing* paragraph, which Microsoft Word and LibreOffice both keep (as an empty paragraph) on reject.

This makes inserted paragraphs always carry the `PPR-INS` mark and makes both reject paths purely **mark-based** — Word/LibreOffice/Google-Docs faithful.

## Why (oracle-validated)

| Fixture (mark untracked) | op | LibreOffice | engine before |
|---|---|---|---|
| `ins`-only | reject | **keeps empty `<w:p>`** | dropped ❌ |
| `moveTo`-only | reject | **keeps empty `<w:p>`** | dropped ❌ |
| `ins` **+ PPR-INS** | reject | drops | drops ✓ |

- **OOXML:** `<w:ins>` in `<w:pPr><w:rPr>` marks the paragraph *mark* as inserted; only then should reject remove the whole paragraph.
- **Google Docs:** renders `w:ins` runs identically with `PPR-INS` present, and rejects a `PPR-INS` paragraph cleanly with **no leftover empty paragraph** — debunking the uncited "Google Docs hides w:ins runs with PPR-INS" rationale the engine relied on.

## Changes

- `wrapParagraphAsInserted`: **always** emit `PPR-INS` (mirrors `wrapParagraphAsDeleted`).
- `rejectAllChanges` + primitive `rejectChanges`: drop a paragraph **iff** its mark is `PPR-INS`; removed the content-based all-`w:ins`/`w:moveTo` heuristic from **both** paths.
- Detect the mark **strictly** (`w:pPr > w:rPr > w:ins`, direct children) in both paths so a `w:ins` nested in a `w:pPrChange` snapshot isn't mistaken for the live mark; added `pPrChange` regression tests proving both paths agree.
- Flip the G4 differential (`[LEAN-HELP-06]`) from divergence → **agreement**; reverse the `inPlaceModifier` no-op-for-substantive-runs assertion.
- OpenSpec: new change `make-reject-paragraph-collapse-mark-based`; revised the pending harness G4 scenario.

## Validation

- Full `@usejunior/docx-core` suite **1340 passed / 0 failed** (incl. round-trip-inplace 11/11, NVCA real-corpus regression, stability-invariants).
- Helper differential **7/7** with the compiled Lean exe — **G4 now agrees**; G3 still diverges (the Lean accept-side increment, next PR).
- `tsc` clean; `openspec validate --strict` ✓; `check:spec-coverage` rc=0.
- Peer-reviewed by **agy** (APPROVE) and **Codex** (APPROVE; its Medium finding — the strict `pPrChange` mark detection — is fixed here with regression coverage).

safe-docx's own inserts always carry `PPR-INS` now, so insert→reject round-trips unchanged. The Lean accept-side gap **G3** is unaffected and remains the next increment.