### PR TITLE
feat(docx-mcp): ODF compare_documents — paragraph-granularity redline for .odt (Slice 1)

### DIFF
--- a/openspec/changes/add-odf-compare/design.md
+++ b/openspec/changes/add-odf-compare/design.md
@@ -1,0 +1,171 @@
+# Design notes — ODF `compare_documents` (Slice 1: paragraph granularity, two-file mode)
+
+## Markup shapes (oracle-confirmed)
+The exact tracked-changes markup below was obtained by driving LibreOffice to AUTHOR the
+changes (a Basic macro: create doc, `RecordChanges = True`, mutate, store `writer8`) and
+inspecting the resulting `content.xml`. It is what LibreOffice writes AND accepts, so the
+emitter reproduces it verbatim. (Recipe + findings: user memory
+`project_odf_tracked_deletion_shape`.)
+
+The `text:tracked-changes` container is the **first child of `office:text`** and holds the
+change definitions; the body carries lightweight markers referencing them by id.
+
+### Insertion of a whole paragraph
+`text:change-start` is inline at the **start of the inserted `text:p`**; `text:change-end` is
+inline at the **start of the following kept paragraph** (the change spans the inserted content
++ its paragraph break). The `text:insertion` region carries ONLY `office:change-info` —
+inserted content stays inline in the body.
+```xml
+<text:tracked-changes>
+  <text:changed-region xml:id="ct1" text:id="ct1">
+    <text:insertion><office:change-info><dc:creator>SafeDocX</dc:creator><dc:date>…</dc:date></office:change-info></text:insertion>
+  </text:changed-region>
+</text:tracked-changes>
+…
+<text:p>Alpha</text:p>
+<text:p><text:change-start text:change-id="ct1"/>Beta</text:p>
+<text:p><text:change-end text:change-id="ct1"/>Gamma</text:p>
+```
+
+### Insertion of a paragraph at END of document (oracle-confirmed)
+There is no following kept paragraph, so LibreOffice brackets backward: `text:change-start` at
+the **end of the preceding kept paragraph**, `text:change-end` at the **end of the inserted
+paragraph**.
+```xml
+<text:p>Alpha</text:p>
+<text:p>Beta<text:change-start text:change-id="ct1"/></text:p>
+<text:p>Gamma<text:change-end text:change-id="ct1"/></text:p>
+```
+
+### Deletion of a whole paragraph (paragraph-break MERGE)
+`text:change` is an **inline** element — schema-PROHIBITED as a direct child of `office:text`
+(peer-review BLOCKER, agy). It is placed inline inside an **adjacent kept paragraph**, and the
+deleted content lives out-of-line in `text:deletion`:
+- **Forward merge** (first/middle paragraph deleted): marker at the **start of the following
+  kept paragraph**; `text:deletion` holds `[<text:p>deletedContent</text:p>, <text:p/>]`.
+- **Backward merge** (last paragraph deleted): marker at the **end of the preceding kept
+  paragraph**; `text:deletion` holds `[<text:p/>, <text:p>deletedContent</text:p>]`.
+
+The empty `<text:p/>` is the merge artifact (the surviving paragraph's mark).
+```xml
+<text:changed-region xml:id="ct2" text:id="ct2">
+  <text:deletion>
+    <office:change-info>…</office:change-info>
+    <text:p>Beta</text:p><text:p/>
+  </text:deletion>
+</text:changed-region>
+…
+<text:p>Alpha</text:p>
+<text:p><text:change text:change-id="ct2"/>Gamma</text:p>
+```
+
+### Consecutive deletions COALESCE into one region (oracle-confirmed)
+Deleting two adjacent paragraphs (Beta + Gamma, with Alpha/Delta kept) — even as two separate
+tracked operations — yields a **single** `text:changed-region` whose `text:deletion` holds
+`[<text:p>Beta</text:p>, <text:p>Gamma</text:p>, <text:p/>]` and a **single** inline
+`text:change` marker at the start of Delta (the next *surviving* paragraph). So the emitter
+MUST:
+- group **runs of consecutive deleted paragraphs** into one `text:deletion` region (all deleted
+  `text:p`s in document order, then one empty merge artifact for forward merge / the empty
+  artifact first for a run that reaches end-of-doc), with ONE marker; and
+- anchor the marker to the next *surviving* (kept) paragraph for a forward run (or the previous
+  surviving paragraph for a run that reaches end-of-doc), **skipping over the other deleted
+  paragraphs** — never anchor to a paragraph that is itself deleted.
+```xml
+<text:changed-region xml:id="ct3" text:id="ct3">
+  <text:deletion><office:change-info>…</office:change-info>
+    <text:p>Beta</text:p><text:p>Gamma</text:p><text:p/>
+  </text:deletion>
+</text:changed-region>
+…
+<text:p>Alpha</text:p>
+<text:p><text:change text:change-id="ct3"/>Delta</text:p>
+```
+A backward consecutive run (delete the last two paragraphs Gamma+Delta) yields the empty
+artifact **first**, then the deleted paras, with the marker at the **end of the preceding
+surviving paragraph**:
+```xml
+<text:deletion>…<text:p/><text:p>Gamma</text:p><text:p>Delta</text:p></text:deletion>
+…
+<text:p>Beta<text:change text:change-id="ct3"/></text:p>
+```
+
+### Modified paragraph = delete + insert at the same slot (oracle-confirmed; markers CO-EXIST)
+A paragraph "modified" Beta → Beta' is diffed as `delete Beta` + `insert Beta'`. The deletion's
+inline `text:change` marker and the insertion's `text:change-start` BOTH land at the start of
+the inserted replacement paragraph, and LibreOffice accepts them — ordered **deletion
+`text:change` FIRST, then insertion `text:change-start`** (so the emitter must emit the deletion
+anchor before the insertion start when both target the same position). This means modified
+paragraphs do NOT need to fail closed in Slice 1.
+```xml
+<text:p><text:change text:change-id="DEL"/><text:change-start text:change-id="INS"/>Beta2</text:p>
+<text:p><text:change-end text:change-id="INS"/>Gamma</text:p>
+```
+(The deletion region for Beta holds `[<text:p>Beta</text:p>, <text:p/>]` as a normal forward
+merge; the insertion region holds only change-info.) A modified LAST paragraph composes the
+backward-delete anchor with the EOF-insert bracket by the same first-deletion-then-insertion
+ordering rule.
+
+## Existing `text:tracked-changes` in the revised doc (Codex MAJOR)
+The emitter writes into the revised content.xml. If `office:text` already has a
+`text:tracked-changes` first child, the emitter SHALL **reuse/append** new `text:changed-region`s
+to that existing container (never create a second container) and allocate `ctN` ids past the
+existing ones. (For Slice 1's two-file inputs this is rare, but the emitter must not assume the
+container is absent.)
+`OdfDocument.doc`/`blocks` are `private` and there is no public DOM accessor. So
+`compareOdf(originalContentXml, revisedContentXml, opts)` takes content.xml **strings** and
+parses each exactly once internally (via the `parseXml` odf-core already depends on from
+docx-core); `diff.ts` and `emit.ts` operate on those local `Document`s. No Element crosses the
+package boundary and NO public DOM getter is added (keeps the surface minimal; avoids the
+"redundant parse" concern by parsing once in `compareOdf`, not once per `OdfDocument`). To
+avoid duplicating the walk, `collectBlocks` + the skip predicates move into `shared/odf/`
+(the same extraction pattern 2b-1 used for `text_segments.ts`), reused by `OdfDocument` and
+`compare/index.ts` without a cycle.
+
+## Dispatch (peer-review BLOCKER — Codex)
+Two-file compare CANNOT route through the generic `dispatchOdf()`: it always calls
+`resolveOdfSessionForTool()`, which requires `file_path` and returns `MISSING_FILE_PATH` for
+two-file input (`original_file_path`/`revised_file_path`) before any handler runs. So
+`odfCompareDocuments` is **stateless** — signature `(manager, args, metadata)`, mirroring the
+DOCX `compareDocuments_tool(sessions, args)` — and `server.ts` dispatches to it directly for
+`.odt` two-file input. A `.odt` session `file_path` returns `UNSUPPORTED_FOR_ODF` in Slice 1
+(session mode is a follow-up change); it does NOT silently degrade.
+
+The handler MUST match the DOCX compare's write-path safety (Codex MAJOR): reject when
+`save_to_local_path` resolves to either source file (`resolvesToSamePath`) and run
+`enforceWritePathPolicy(savePath)` before writing. The output path should be `.odt`.
+
+## Diff (paragraph LCS)
+`compare/diff.ts` runs a generic O(N·M) LCS over the two `getParagraphs()` text arrays
+(conceptually mirroring docx-core `atomLcs.ts::computeAtomLcs`) and returns a structured edit
+script `{kind:'equal'|'insert'|'delete', originalIndex?, revisedIndex?}[]`. No DOM, unit-tested
+in isolation.
+
+## Stats semantics (both reviewers)
+At paragraph granularity a "modified" paragraph is represented as a **delete of the old +
+insert of the new** (no run-level merge yet), so `modifications` is always `0` in Slice 1 and
+those edits land in `insertions`/`deletions`. A single changed word therefore reads as 1
+deletion + 1 insertion. The handler `message` states that changes are tracked at the
+whole-paragraph level so the counts are expected to run higher than the DOCX (atom-level) path.
+
+## `ctN` id allocation
+`xml:id` + `text:id` per `text:changed-region` are allocated `ct1, ct2, …` by scanning all
+existing ids in both docs, mirroring the `office:name` allocator in `comments.ts`. The reader
+and the writer reserve the same id space (reviewer bug class from 2b-1).
+
+## Degenerate cases (fail closed, never emit invalid markup)
+A deleted paragraph with no adjacent kept paragraph (all paragraphs deleted; single-paragraph
+doc) has no inline anchor available. The emitter MUST fail closed / log rather than place a
+`text:change` as an invalid block child of `office:text`. Covered by an explicit test.
+
+## No-leak invariant (peer-review scrutiny carried from 2b-1)
+`collectBlocks` and `buildSegments` recurse into every child; the deleted `text:p`s inside
+`text:tracked-changes` would otherwise inflate `getParagraphs()` and register phantom blocks.
+Both traversals skip the `text:tracked-changes` subtree via `isTrackedChangesSubtree`, with an
+explicit no-leak regression test (mirrors OANN-05).
+
+## LibreOffice is the authoritative compatibility check
+The produced redline `.odt` must open in LibreOffice with the changes visible/acceptable
+(Edit ▸ Track Changes ▸ Manage). Local checks are semantic/structural (tracked-changes regions
++ in-body markers present, untouched paragraphs' visible text preserved, mimetype-first
+STORED); the document-shaped smoke reopens the redline in LibreOffice.

--- a/openspec/changes/add-odf-compare/proposal.md
+++ b/openspec/changes/add-odf-compare/proposal.md
@@ -1,0 +1,61 @@
+# Change: ODF (.odt) `compare_documents` — paragraph-granularity tracked-changes redline (Slice 1)
+
+## Why
+Phases 1/2a/2b-1 (`add-odf-core`, `add-odf-grep-insert`, `add-odf-comments`) wired a
+provider-aware ODF lane covering `read_file → grep → replace_text → insert_paragraph →
+add_comment → get_comments → save`. The one Phase-2 tool still returning
+`UNSUPPORTED_FOR_ODF` is `compare_documents` — the tracked-changes redline. The DOCX path
+produces a `w:ins`/`w:del` redline via docx-core's atomizer; the ODF analogue needs a fresh
+emitter because ODF stores deletions **out-of-line** in a `text:tracked-changes` /
+`text:changed-region` container (with only lightweight in-body markers) rather than inline.
+
+This change lands the first, shippable slice: **paragraph-granularity, two-file mode**. It
+diffs two `.odt` files at the whole-paragraph level (LCS keyed on paragraph text) and emits a
+valid redline `.odt` that LibreOffice opens with the insertions/deletions visible and
+acceptable. Intra-paragraph (run-level) diffs and session-mode comparison are deliberately
+deferred to follow-up changes so each PR stays reviewable.
+
+## What Changes
+- `@usejunior/odf-core`:
+  - New `compare/` module — `compare/diff.ts` (pure paragraph-level LCS over `{id,text}[]`,
+    no DOM), `compare/emit.ts` (ODF tracked-changes emitter), `compare/index.ts`
+    (`compareOdf(originalContentXml, revisedContentXml, opts)` orchestrating diff → emit).
+    The diff stays separable from emission (own module, own unit tests), mirroring docx-core's
+    `atomLcs.ts` ↔ `documentReconstructor.ts` split.
+  - `compareOdf` takes `content.xml` **strings** and parses each exactly once internally; no
+    DOM Element crosses the package boundary and no public DOM getter is added to
+    `OdfDocument`. To avoid duplicating the block walk, `collectBlocks` (and a new
+    `isTrackedChangesSubtree` predicate) are extracted into `shared/odf/` and reused by both
+    `OdfDocument` and `compare/index.ts`.
+  - `collectBlocks` and the visible-text walk SHALL skip the `text:tracked-changes` container
+    (its `text:p`s are deleted-content storage, not body paragraphs) so deleted content never
+    leaks into `getParagraphs()`.
+  - Add `XML` (`http://www.w3.org/XML/1998/namespace`, for `xml:id`) to `ODF_NS`.
+  - Export `compareOdf` + its result type from `index.ts`.
+- `@usejunior/docx-mcp`:
+  - New `tools/odf/compare_documents.ts` — a **stateless** handler
+    `odfCompareDocuments(manager, args, metadata)` (NOT the `(manager, session, …)` shape):
+    two-file compare cannot route through `dispatchOdf`, because the shared
+    `resolveOdfSessionForTool` requires `file_path` and returns `MISSING_FILE_PATH` before any
+    handler runs. It loads both `.odt`s via `validateAndLoadOdfFromPath`, calls `compareOdf`,
+    writes the redline, and returns the DOCX-parallel response shape with ODF-appropriate
+    fields (`granularity: 'paragraph'`, `stats`, no `engine`/`reconstruction_mode`).
+  - `server.ts` replaces the `compare_documents` guard: a `.odt` two-file input dispatches to
+    `odfCompareDocuments` directly; a `.odt` session `file_path` returns `UNSUPPORTED_FOR_ODF`
+    ("session-mode compare for .odt not yet supported"); otherwise the DOCX tool runs.
+  - Add `compare_documents` to `ODF_SUPPORTED_TOOLS`; update the guard hint + the two
+    `session_resolution.ts` hints; update `tool_catalog.ts` provider text + regenerate docs.
+
+## Impact
+- Affected specs: `mcp-server` (ADDED: ODF two-file `compare_documents`, OPCD-01..05);
+  `odf-core` (ADDED: ODF paragraph comparison + tracked-changes emission + no-leak, OCMP-01..06).
+- Affected code: `packages/odf-core/src/{document,index}.ts`,
+  `packages/odf-core/src/shared/odf/{namespaces,text_segments,*block-walk*}.ts`,
+  `packages/odf-core/src/compare/{diff,emit,index}.ts`;
+  `packages/docx-mcp/src/tools/{provider_guard,session_resolution}.ts`,
+  `packages/docx-mcp/src/tools/odf/compare_documents.ts`, `packages/docx-mcp/src/server.ts`,
+  `tool_catalog.ts` + regenerated tool docs. DOCX and Google Docs paths unchanged.
+- `odf-core` stays `private: true` (optional-lazy provider, not a published dependency of docx-mcp).
+- Out of scope (separate changes): intra-paragraph (run-level) diffs; session-mode compare;
+  `.ods`/`.odp`; accepting/rejecting ODF tracked changes; docx→odf conversion; durable injected
+  `xml:id` paragraph anchors.

--- a/openspec/changes/add-odf-compare/specs/mcp-server/spec.md
+++ b/openspec/changes/add-odf-compare/specs/mcp-server/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: ODF two-file `compare_documents` (paragraph-granularity redline)
+
+The MCP server SHALL service `compare_documents` for ODF inputs in **two-file mode**
+(`original_file_path` + `revised_file_path` both ending in `.odt`) via the provider-aware lane,
+in addition to the existing ODF tools. The DOCX and Google Docs paths SHALL remain unchanged,
+and every still-unsupported tool SHALL continue to return `UNSUPPORTED_FOR_ODF`.
+
+Because two-file `compare_documents` carries no `file_path`, it SHALL dispatch to a stateless
+ODF compare handler directly (NOT through the session-resolution chokepoint, which requires
+`file_path`). The handler SHALL load both `.odt`s, produce a paragraph-granularity
+tracked-changes redline `.odt`, write it to `save_to_local_path`, and return a response of the
+same shape as the DOCX tool with ODF-appropriate fields: `mode: 'two_file'`,
+`original_file_path`, `revised_file_path`, `saved_to`, `size_bytes`, `author`,
+`granularity: 'paragraph'`, `stats: { insertions, deletions, modifications }`, and a `message`.
+DOCX-only fields (`engine`, `reconstruction_mode`) SHALL be omitted.
+
+At paragraph granularity a modified paragraph SHALL be represented as a deletion of the old
+paragraph plus an insertion of the new one, so `modifications` SHALL be `0` and the `message`
+SHALL note that changes are tracked at the whole-paragraph level (so insertion/deletion counts
+run higher than the DOCX atom-level path).
+
+The ODF handler SHALL apply the same output-path safety as the DOCX tool: it SHALL reject when
+`save_to_local_path` resolves to either source file, and SHALL enforce the write-path policy
+before writing the redline.
+
+ODF **session-mode** `compare_documents` (a `.odt` on `file_path`) is not yet supported and
+SHALL return `UNSUPPORTED_FOR_ODF` rather than silently degrading.
+
+#### Scenario: [OPCD-01] Two-file `.odt` compare produces a redline
+- **WHEN** `compare_documents` is invoked with `.odt` `original_file_path` and `revised_file_path` that differ by whole paragraphs, plus `save_to_local_path`
+- **THEN** the ODF handler writes a tracked-changes `.odt` to `save_to_local_path` and returns `mode: 'two_file'`, `granularity: 'paragraph'`, and non-zero `stats`, and the DOCX/gdocs handlers are not invoked
+
+#### Scenario: [OPCD-02] Inserted and deleted paragraphs are counted
+- **WHEN** the revised `.odt` adds one paragraph and removes another relative to the original
+- **THEN** `stats.insertions` and `stats.deletions` are each at least 1 and `stats.modifications` is 0
+
+#### Scenario: [OPCD-03] DOCX two-file compare is unchanged
+- **WHEN** `compare_documents` is invoked with two `.docx` paths
+- **THEN** the existing DOCX comparison runs and returns its DOCX response shape (including `engine`), and no ODF logic runs
+
+#### Scenario: [OPCD-04] ODF session-mode compare is unsupported
+- **WHEN** `compare_documents` is invoked with a `.odt` `file_path` (session mode)
+- **THEN** an `UNSUPPORTED_FOR_ODF` error is returned and no DOCX logic runs
+
+#### Scenario: [OPCD-05] The redline reopens with the changes preserved
+- **WHEN** the redline `.odt` produced by a two-file compare is reloaded
+- **THEN** its `text:tracked-changes` regions and in-body change markers are present, the unchanged paragraphs' visible text is preserved, and the package is mimetype-first STORED
+
+#### Scenario: [OPCD-06] Output path may not overwrite a source
+- **WHEN** `compare_documents` is invoked with `.odt` sources and a `save_to_local_path` that resolves to one of the source files
+- **THEN** an error is returned and neither source file is overwritten

--- a/openspec/changes/add-odf-compare/specs/odf-core/spec.md
+++ b/openspec/changes/add-odf-compare/specs/odf-core/spec.md
@@ -1,0 +1,87 @@
+## ADDED Requirements
+
+### Requirement: ODF paragraph comparison + tracked-changes emission (`compareOdf`)
+
+`@usejunior/odf-core` SHALL provide `compareOdf(originalContentXml, revisedContentXml, opts)`
+returning `{ contentXml, stats: { insertions, deletions, modifications } }`, where `contentXml`
+is a redline `content.xml` carrying ODF tracked-changes markup and `stats` counts the
+whole-paragraph edits. `compareOdf` SHALL take `content.xml` **strings** and parse each exactly
+once internally; it SHALL NOT require any DOM Element to cross the package boundary and SHALL
+NOT add a public DOM accessor to `OdfDocument`.
+
+The diff SHALL be a pure paragraph-level LCS over the two documents' block text (the same block
+set `getParagraphs()` enumerates), kept in a separate module from emission and unit-tested in
+isolation. A modified paragraph SHALL be emitted as a deletion plus an insertion, so
+`modifications` SHALL be `0` at this granularity.
+
+The emitter SHALL write a `text:tracked-changes` container as the first child of `office:text`,
+with one `text:changed-region` per change (unique `xml:id` + `text:id` allocated `ctN` by
+scanning existing ids; `office:change-info` carrying `dc:creator` from `opts.author` and a
+`dc:date`):
+- An **inserted** paragraph with a following kept paragraph SHALL be bracketed by
+  `text:change-start` (inline at the start of the inserted `text:p`) and `text:change-end`
+  (inline at the start of the following kept paragraph), referencing a `text:insertion` region;
+  the inserted content SHALL remain inline. An inserted paragraph at **end of document** (no
+  following kept paragraph) SHALL instead place `text:change-start` at the **end of the
+  preceding kept paragraph** and `text:change-end` at the **end of the inserted paragraph**.
+- A **run of one or more consecutive deleted** paragraphs SHALL be stored as a single
+  `text:deletion` region (the deleted `text:p`s in document order plus one empty merge-artifact
+  `text:p`) with a single inline `text:change` marker. The marker SHALL be placed in the nearest
+  *surviving* (kept) paragraph — at the start of the following surviving paragraph (forward
+  merge) or the end of the preceding surviving paragraph (backward merge for a run reaching
+  end-of-document) — **skipping over other deleted paragraphs**; it SHALL NEVER anchor to a
+  paragraph that is itself deleted. `text:change` SHALL NOT be emitted as a direct block child
+  of `office:text` (it is an inline element). When a deletion run has no surviving paragraph to
+  anchor to (every paragraph deleted), the emitter SHALL fail closed rather than emit
+  schema-invalid markup.
+- A **modified** paragraph (matched position, changed text) SHALL be emitted as a deletion of
+  the old paragraph plus an insertion of the new one. When the deletion's inline `text:change`
+  marker and the insertion's `text:change-start` target the same position (the start of the
+  inserted replacement paragraph), the `text:change` (deletion) marker SHALL be emitted BEFORE
+  the `text:change-start` (insertion) marker.
+
+`compareOdf` SHALL preserve the unchanged paragraphs' visible text and the rest of the revised
+document (styles, manifest, untouched parts) so the redline round-trips.
+
+An emitted redline's deleted content SHALL NOT appear in `getParagraphs()`: both `collectBlocks`
+and the visible-text walk SHALL skip the `text:tracked-changes` subtree.
+
+#### Scenario: [OCMP-01] Paragraph LCS yields an insert/delete/equal edit script
+- **WHEN** the diff runs over an original and a revised paragraph-text array that differ by one added and one removed paragraph
+- **THEN** the edit script marks the added paragraph `insert`, the removed paragraph `delete`, and the common paragraphs `equal`
+
+#### Scenario: [OCMP-02] Inserted paragraph is bracketed by change-start/-end
+- **WHEN** `compareOdf` emits an inserted paragraph
+- **THEN** a `text:change-start` sits at the start of the inserted `text:p`, a `text:change-end` with the same `text:change-id` sits at the start of the following kept paragraph, and a matching `text:changed-region`/`text:insertion` exists
+
+#### Scenario: [OCMP-03] Deleted middle paragraph uses a forward-merge anchor
+- **WHEN** `compareOdf` deletes a paragraph that has a following kept paragraph
+- **THEN** an inline `text:change` marker sits at the start of the following kept paragraph and the deleted content is stored in a `text:deletion` region (no `text:change` is a block child of `office:text`)
+
+#### Scenario: [OCMP-04] Deleted last paragraph uses a backward-merge anchor
+- **WHEN** `compareOdf` deletes the last paragraph (no following kept paragraph)
+- **THEN** an inline `text:change` marker sits at the end of the preceding kept paragraph and the deleted content is stored in a `text:deletion` region
+
+#### Scenario: [OCMP-05] Change ids are unique and reserve the reader's id space
+- **WHEN** `compareOdf` emits multiple changes
+- **THEN** each `text:changed-region` carries a unique `xml:id`/`text:id` allocated by scanning existing ids, with no collisions
+
+#### Scenario: [OCMP-06] Deleted content does not leak into the paragraph stream
+- **WHEN** `getParagraphs()` is called on a redline document containing a `text:tracked-changes` container
+- **THEN** it returns only the body paragraphs (with their visible text) and creates no phantom block for the deleted `text:p`s stored in `text:deletion`
+
+#### Scenario: [OCMP-07] Consecutive deletions coalesce into one region
+- **WHEN** `compareOdf` deletes two or more consecutive paragraphs that have a following surviving paragraph
+- **THEN** a single `text:changed-region`/`text:deletion` stores all the deleted `text:p`s in order with one empty merge artifact, and a single inline `text:change` marker sits in the following surviving paragraph (none of the deleted paragraphs is used as an anchor)
+
+#### Scenario: [OCMP-08] Consecutive deletion run at end of document
+- **WHEN** `compareOdf` deletes the final two or more paragraphs (no following surviving paragraph)
+- **THEN** a single `text:deletion` region stores the empty merge artifact first then the deleted `text:p`s, and a single inline `text:change` marker sits at the end of the preceding surviving paragraph
+
+#### Scenario: [OCMP-09] Insertion at end of document brackets backward
+- **WHEN** `compareOdf` inserts a paragraph after the last paragraph of the document
+- **THEN** `text:change-start` sits at the end of the preceding kept paragraph and `text:change-end` sits at the end of the inserted paragraph
+
+#### Scenario: [OCMP-10] Modified paragraph orders deletion before insertion markers
+- **WHEN** `compareOdf` emits a modified paragraph whose deletion `text:change` and insertion `text:change-start` target the start of the same replacement paragraph
+- **THEN** the `text:change` (deletion) marker precedes the `text:change-start` (insertion) marker in that paragraph

--- a/openspec/changes/add-odf-compare/tasks.md
+++ b/openspec/changes/add-odf-compare/tasks.md
@@ -1,0 +1,22 @@
+# Tasks
+
+## odf-core
+- [ ] Add `XML` namespace (`http://www.w3.org/XML/1998/namespace`) to `ODF_NS`
+- [ ] Extract `collectBlocks` + an `isTrackedChangesSubtree` predicate into `shared/odf/` (block-walk helper); `document.ts` reuses it. Both the block walk and `buildSegments` skip the `text:tracked-changes` subtree (no deleted-content leak)
+- [ ] New `compare/diff.ts`: pure paragraph-level LCS over `{id,text}[]` → edit script (`equal`/`insert`/`delete`); no DOM
+- [ ] New `compare/emit.ts`: ODF tracked-changes emitter (insertion: `change-start`/`-end` + `text:insertion` region; deletion: coalesce consecutive deleted paragraphs into ONE `text:deletion` region + ONE inline `text:change` anchor in the nearest SURVIVING paragraph, skipping deleted ones, forward/backward merge); `ctN` id allocation scanning existing ids; `office:change-info` author/date; degenerate all-deleted case fails closed
+- [ ] New `compare/index.ts`: `compareOdf(originalContentXml, revisedContentXml, opts)` — parse each string once, diff → emit, return `{ contentXml, stats }`; export `compareOdf` + result type from `index.ts`
+- [ ] odf-core `compare/diff.test.ts`: insert-only, delete-only, identical, empty doc, multi-paragraph, reordering (assert edit script)
+- [ ] odf-core `compare/emit.test.ts`: insertion (mid + EOF backward bracket), deletion forward (start anchor) + backward (end anchor) + consecutive-coalesce forward & backward (one region, anchor skips deleted) + modified-paragraph marker order (deletion before insertion) + table-cell + degenerate all-deleted; existing-tracked-changes-container reuse; `ctN` allocation; no-leak regression (`getParagraphs()` ignores `text:tracked-changes`)
+
+## docx-mcp
+- [ ] `tools/odf/compare_documents.ts`: stateless `odfCompareDocuments(manager, args, metadata)` — two-file load via `validateAndLoadOdfFromPath`, `archive.getContentXml()` → `compareOdf`, build redline from revised buffer (`setContentXml` + `save`), write to `save_to_local_path`; response `{ mode:'two_file', original_file_path, revised_file_path, saved_to, size_bytes, author, granularity:'paragraph', stats, message }`. Reject `save_to_local_path` resolving to either source + run `enforceWritePathPolicy` (match DOCX compare)
+- [ ] Add `compare_documents` to `ODF_SUPPORTED_TOOLS`; update guard hint + both `session_resolution.ts` hints
+- [ ] `server.ts`: replace the `compare_documents` case — `.odt` two-file → `odfCompareDocuments` (stateless, lazy-load odf-core); `.odt` session `file_path` → `UNSUPPORTED_FOR_ODF` (session mode deferred); else DOCX tool. Update comment
+- [ ] Update `tool_catalog.ts` provider text (now includes `.odt` two-file) + regenerate `tool-reference.generated.md`
+
+## Tests & verification
+- [ ] docx-mcp `tools/odf/odf_compare.test.ts`: OPCD-01..05 scenarios + branch tests; `TEST_FEATURE='add-odf-compare'`; `import { testAllure as it }`; driven through `dispatchToolCall`
+- [ ] Full CI gate locally (build, lint, cycles, release-isolation, allure-*, openspec validate --strict, spec-coverage --strict, tool-docs) + coverage ratchet not regressed
+- [ ] Document-shaped `.odt` smoke: NVCA source → `.odt`, derive an edited revision, two-file `compare_documents` through `dispatchToolCall`; confirm non-trivial stats, redline parses back (regions + markers, untouched preserved, mimetype-first STORED), reopen in LibreOffice
+- [ ] Regression: two-`.docx` compare unchanged; still-unsupported tool on `.odt` returns `UNSUPPORTED_FOR_ODF`; `.odt` session compare returns `UNSUPPORTED_FOR_ODF`

--- a/openspec/changes/add-odf-grep-insert/specs/mcp-server/spec.md
+++ b/openspec/changes/add-odf-grep-insert/specs/mcp-server/spec.md
@@ -31,5 +31,5 @@ re-reads before its next edit.
 - **THEN** a new paragraph is inserted before/after the anchor, the response returns the new positional paragraph ID(s) and ID-invalidation fields, and re-reading reflects the inserted text
 
 #### Scenario: [OPLR-08] Still-unsupported tools remain guarded
-- **WHEN** a tool outside the ODF supported set (e.g. `compare_documents`) is invoked against a `.odt` path or ODF session
+- **WHEN** a tool outside the ODF supported set (e.g. `extract_revisions`) is invoked against a `.odt` path or ODF session
 - **THEN** an `UNSUPPORTED_FOR_ODF` error is returned and no DOCX logic runs

--- a/packages/docx-mcp/docs/tool-reference.generated.md
+++ b/packages/docx-mcp/docs/tool-reference.generated.md
@@ -260,19 +260,19 @@ Delete a comment and all its threaded replies from the document. Cascade-deletes
 
 ## `compare_documents`
 
-Compare two DOCX documents and produce a tracked-changes output document. Provide original_file_path + revised_file_path for standalone comparison, or file_path to compare session edits against the original.
+Compare two documents and produce a tracked-changes output document. Provide original_file_path + revised_file_path for standalone comparison, or file_path to compare session edits against the original. DOCX supports both modes; ODF (.odt) supports two-file mode at paragraph granularity (a modified paragraph counts as one deletion plus one insertion).
 
 - readOnly: `true`
 - destructive: `false`
 
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
-| `original_file_path` | `string` | no | Path to the original DOCX file. |
-| `revised_file_path` | `string` | no | Path to the revised DOCX file. |
+| `original_file_path` | `string` | no | Path to the original DOCX or .odt file. |
+| `revised_file_path` | `string` | no | Path to the revised DOCX or .odt file. |
 | `file_path` | `string` | no | Path to the DOCX or ODT file. |
-| `save_to_local_path` | `string` | yes | Path to save the tracked-changes DOCX output. |
-| `author` | `string` | no | Author name for track changes. Default: 'Comparison'. |
-| `engine` | `enum("auto", "atomizer")` | no | Comparison engine. Default: 'auto'. |
+| `save_to_local_path` | `string` | yes | Path to save the tracked-changes output (DOCX or .odt). |
+| `author` | `string` | no | Author name for track changes. Default: 'Comparison' (DOCX) or the configured AI author (ODF). |
+| `engine` | `enum("auto", "atomizer")` | no | Comparison engine (DOCX only). Default: 'auto'. |
 
 ## `get_footnotes`
 

--- a/packages/docx-mcp/src/server.ts
+++ b/packages/docx-mcp/src/server.ts
@@ -203,10 +203,24 @@ export async function dispatchToolCall(
       return await deleteComment(sessions, args as Parameters<typeof deleteComment>[1]);
     case 'compare_documents':
       // compare_documents resolves its inputs via original_file_path / revised_file_path
-      // (not file_path), so the shared resolver's .odt chokepoint can't see them. Guard
-      // here: a .odt on any input path is UNSUPPORTED_FOR_ODF (compare is Phase-2b ODF work).
-      if (isOdfRequest(args) || hasOdfInputPath(args, ['original_file_path', 'revised_file_path'])) {
-        return checkOdfSupport('compare_documents')!;
+      // (not file_path), so the shared resolver's .odt chokepoint can't see them. Route here:
+      //  - two `.odt` inputs → the stateless ODF handler directly (it loads both files itself; it
+      //    CANNOT go through dispatchOdf, whose resolveOdfSessionForTool requires a file_path);
+      //  - a `.odt` session file_path → UNSUPPORTED_FOR_ODF (session-mode compare is a later slice);
+      //  - otherwise the DOCX tool.
+      if (hasOdfInputPath(args, ['original_file_path', 'revised_file_path'])) {
+        const { odfCompareDocuments } = await import('./tools/odf/compare_documents.js');
+        return await odfCompareDocuments(sessions, args as Parameters<typeof odfCompareDocuments>[1]);
+      }
+      if (isOdfRequest(args)) {
+        return {
+          success: false,
+          error: {
+            code: 'UNSUPPORTED_FOR_ODF',
+            message: 'Session-mode compare_documents is not yet supported for ODF (.odt) files.',
+            hint: 'Provide original_file_path and revised_file_path to compare two .odt files.',
+          },
+        };
       }
       return await compareDocuments_tool(sessions, args as Parameters<typeof compareDocuments_tool>[1]);
     case 'get_footnotes':

--- a/packages/docx-mcp/src/tool_catalog.ts
+++ b/packages/docx-mcp/src/tool_catalog.ts
@@ -312,14 +312,14 @@ export const SAFE_DOCX_TOOL_CATALOG = [
   {
     name: 'compare_documents',
     description:
-      'Compare two DOCX documents and produce a tracked-changes output document. Provide original_file_path + revised_file_path for standalone comparison, or file_path to compare session edits against the original.',
+      'Compare two documents and produce a tracked-changes output document. Provide original_file_path + revised_file_path for standalone comparison, or file_path to compare session edits against the original. DOCX supports both modes; ODF (.odt) supports two-file mode at paragraph granularity (a modified paragraph counts as one deletion plus one insertion).',
     input: z.object({
-      original_file_path: z.string().optional().describe('Path to the original DOCX file.'),
-      revised_file_path: z.string().optional().describe('Path to the revised DOCX file.'),
+      original_file_path: z.string().optional().describe('Path to the original DOCX or .odt file.'),
+      revised_file_path: z.string().optional().describe('Path to the revised DOCX or .odt file.'),
       ...FILE_FIELD_OPTIONAL,
-      save_to_local_path: z.string().describe('Path to save the tracked-changes DOCX output.'),
-      author: z.string().optional().describe("Author name for track changes. Default: 'Comparison'."),
-      engine: z.enum(['auto', 'atomizer']).optional().describe("Comparison engine. Default: 'auto'."),
+      save_to_local_path: z.string().describe('Path to save the tracked-changes output (DOCX or .odt).'),
+      author: z.string().optional().describe("Author name for track changes. Default: 'Comparison' (DOCX) or the configured AI author (ODF)."),
+      engine: z.enum(['auto', 'atomizer']).optional().describe("Comparison engine (DOCX only). Default: 'auto'."),
     }),
     annotations: { readOnlyHint: true, destructiveHint: false },
   },

--- a/packages/docx-mcp/src/tools/odf/compare_documents.ts
+++ b/packages/docx-mcp/src/tools/odf/compare_documents.ts
@@ -1,0 +1,119 @@
+import path from 'node:path';
+import fs from 'node:fs/promises';
+
+import { SessionManager } from '../../session/manager.js';
+import { errorCode, errorMessage } from '../../error_utils.js';
+import { loadOdfCore } from '../../odf_loader.js';
+import { enforceWritePathPolicy, resolvesToSamePath } from '../path_policy.js';
+import { validateAndLoadOdfFromPath } from '../session_resolution.js';
+import { err, ok, type ToolResponse } from '../types.js';
+
+function expandPath(inputPath: string): string {
+  return inputPath.startsWith('~') ? path.join(process.env.HOME || '', inputPath.slice(1)) : inputPath;
+}
+
+/** Default change author for ODF comparison: the env-configured AI author, else `SafeDocX`. */
+function resolveAuthor(explicit?: string): string {
+  const trimmed = typeof explicit === 'string' ? explicit.trim() : '';
+  if (trimmed) return trimmed;
+  const env = process.env.SAFE_DOCX_AI_AUTHOR;
+  return env && env.trim() ? env.trim() : 'SafeDocX';
+}
+
+/**
+ * ODF `compare_documents` — Slice 1: paragraph-granularity, TWO-FILE mode only.
+ *
+ * Stateless (mirrors the DOCX `compareDocuments_tool`): it does its own loading and takes no
+ * resolved session, because two-file compare carries no `file_path` and so cannot route through
+ * `resolveOdfSessionForTool` (which requires one). Session-mode `.odt` compare is guarded upstream
+ * in `server.ts` and is a later slice.
+ */
+export async function odfCompareDocuments(
+  manager: SessionManager,
+  params: {
+    original_file_path?: string;
+    revised_file_path?: string;
+    file_path?: string;
+    save_to_local_path?: string;
+    author?: string;
+  },
+): Promise<ToolResponse> {
+  try {
+    const hasOriginal = typeof params.original_file_path === 'string' && params.original_file_path.trim().length > 0;
+    const hasRevised = typeof params.revised_file_path === 'string' && params.revised_file_path.trim().length > 0;
+    if (!hasOriginal || !hasRevised) {
+      return err(
+        'MISSING_PARAMS',
+        'ODF comparison requires both original_file_path and revised_file_path.',
+        'Session-mode compare (file_path) is not yet supported for .odt; provide two .odt files.',
+      );
+    }
+
+    const rawSavePath = typeof params.save_to_local_path === 'string' ? params.save_to_local_path.trim() : '';
+    if (!rawSavePath) {
+      return err('MISSING_SAVE_PATH', 'compare_documents requires save_to_local_path.', 'Provide a writable .odt output path.');
+    }
+
+    const originalLoaded = await validateAndLoadOdfFromPath(manager, params.original_file_path!);
+    if (!originalLoaded.ok) return originalLoaded.response;
+    const revisedLoaded = await validateAndLoadOdfFromPath(manager, params.revised_file_path!);
+    if (!revisedLoaded.ok) return revisedLoaded.response;
+
+    // Refuse to clobber either source via the output path (parity with the DOCX tool, issue #313).
+    const savePath = expandPath(rawSavePath);
+    for (const source of [originalLoaded.normalizedPath, revisedLoaded.normalizedPath]) {
+      if (await resolvesToSamePath(savePath, source)) {
+        return err(
+          'OVERWRITE_BLOCKED',
+          `Refusing to overwrite a source document: ${source}`,
+          'Choose a different save_to_local_path.',
+        );
+      }
+    }
+
+    const odf = await loadOdfCore();
+    if (!odf) {
+      return err(
+        'MISSING_DEPENDENCY',
+        'ODF (.odt) support requires @usejunior/odf-core.',
+        'Install @usejunior/odf-core to enable ODF comparison.',
+      );
+    }
+
+    const author = resolveAuthor(params.author);
+    const originalXml = await originalLoaded.archive.getContentXml();
+    const revisedXml = await revisedLoaded.archive.getContentXml();
+    const result = odf.compareOdf(originalXml, revisedXml, { author });
+
+    // Build the redline on the revised package (its styles/manifest/untouched parts are preserved).
+    const writePolicy = await enforceWritePathPolicy(savePath);
+    if (!writePolicy.ok) return writePolicy.response;
+
+    revisedLoaded.archive.setContentXml(result.contentXml);
+    const buffer: Buffer = await revisedLoaded.archive.save();
+
+    await fs.mkdir(path.dirname(savePath), { recursive: true });
+    await fs.writeFile(savePath, new Uint8Array(buffer));
+
+    return ok({
+      mode: 'two_file',
+      provider: 'odf',
+      original_file_path: originalLoaded.normalizedPath,
+      revised_file_path: revisedLoaded.normalizedPath,
+      saved_to: savePath,
+      size_bytes: buffer.length,
+      author,
+      granularity: 'paragraph',
+      stats: result.stats,
+      message:
+        `Redline comparing '${originalLoaded.filename}' vs '${revisedLoaded.filename}' saved to ${savePath}. ` +
+        'Changes are tracked at the whole-paragraph level (a modified paragraph counts as one ' +
+        'deletion plus one insertion), so insertion/deletion counts may run higher than the DOCX path.',
+    });
+  } catch (e: unknown) {
+    if (String(errorCode(e) ?? '').toUpperCase() === 'EACCES') {
+      return err('PERMISSION_DENIED', `Cannot write to: ${params.save_to_local_path}`, 'Try saving to ~/Downloads/ or ~/Documents/ instead.');
+    }
+    return err('COMPARE_ERROR', `ODF comparison failed: ${errorMessage(e)}`);
+  }
+}

--- a/packages/docx-mcp/src/tools/odf/odf_compare.test.ts
+++ b/packages/docx-mcp/src/tools/odf/odf_compare.test.ts
@@ -1,0 +1,232 @@
+import { afterEach, describe, expect } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createZipBuffer } from '@usejunior/docx-core';
+
+import { testAllure as it, type AllureBddContext } from '../../testing/allure-test.js';
+import { dispatchToolCall } from '../../server.js';
+import { SessionManager } from '../../session/manager.js';
+
+const TEST_FEATURE = 'add-odf-compare';
+const test = it.epic('Document Editing').withLabels({ feature: TEST_FEATURE });
+
+const FIXTURE = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../../../odf-core/src/__fixtures__/sample.odt',
+);
+
+const tmpDirs: string[] = [];
+afterEach(async () => {
+  for (const dir of tmpDirs.splice(0)) {
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
+async function tmpdir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'safe-docx-odf-cmp-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+async function copyFixtureTo(dir: string, name: string): Promise<string> {
+  const filePath = path.join(dir, name);
+  await fs.copyFile(FIXTURE, filePath);
+  return filePath;
+}
+
+type ErrorResult = { success: false; error: { code: string; message: string; hint?: string } };
+function assertSuccess(result: Record<string, unknown>, label: string): asserts result is { success: true; [k: string]: unknown } {
+  expect(result.success, `${label} failed: ${JSON.stringify((result as ErrorResult).error)}`).toBe(true);
+}
+function assertError(result: Record<string, unknown>, code: string): asserts result is ErrorResult {
+  expect(result.success).toBe(false);
+  expect((result as ErrorResult).error.code).toBe(code);
+}
+
+const SMALL_DOCX_CONTENT_TYPES = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>`;
+const SMALL_DOCX_RELS = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>`;
+async function writeTestDocx(dir: string, name: string, paragraphs: string[]): Promise<string> {
+  const documentXml =
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>` +
+    paragraphs.map((t) => `<w:p><w:r><w:t>${t}</w:t></w:r></w:p>`).join('') +
+    `</w:body></w:document>`;
+  const buf = await createZipBuffer({
+    '[Content_Types].xml': SMALL_DOCX_CONTENT_TYPES,
+    '_rels/.rels': SMALL_DOCX_RELS,
+    'word/document.xml': documentXml,
+  });
+  const p = path.join(dir, name);
+  await fs.writeFile(p, new Uint8Array(buf));
+  return p;
+}
+
+/** Make a revised .odt using a single manager (edits persist to the saved file). */
+async function buildOriginalAndRevised(dir: string): Promise<{ original: string; revised: string }> {
+  const original = await copyFixtureTo(dir, 'original.odt');
+  const revised = await copyFixtureTo(dir, 'revised.odt');
+  const mgr = new SessionManager();
+  const edit = await dispatchToolCall(mgr, 'replace_text', {
+    file_path: revised,
+    target_paragraph_id: 'p2',
+    old_string: 'Acme Manufacturing',
+    new_string: 'Globex Corporation',
+    instruction: 'Rename the company referenced in the third paragraph.',
+  });
+  assertSuccess(edit, 'replace_text');
+  const saved = await dispatchToolCall(mgr, 'save', { file_path: revised, save_to_local_path: revised, allow_overwrite: true });
+  assertSuccess(saved, 'save');
+  return { original, revised };
+}
+
+describe('ODF compare_documents lane (two-file, paragraph granularity)', () => {
+  test.openspec('[OPCD-01] Two-file `.odt` compare produces a redline')(
+    'compare_documents routes to the ODF handler and writes a tracked-changes .odt',
+    async ({ given, when, then }: AllureBddContext) => {
+      let dir = '';
+      let result: Record<string, unknown> = {};
+      let out = '';
+      await given('an original and a revised .odt that differ by one paragraph', async () => {
+        dir = await tmpdir();
+        const { original, revised } = await buildOriginalAndRevised(dir);
+        out = path.join(dir, 'redline.odt');
+        result = await dispatchToolCall(new SessionManager(), 'compare_documents', {
+          original_file_path: original,
+          revised_file_path: revised,
+          save_to_local_path: out,
+        });
+      });
+      await when('the comparison runs', () => {});
+      await then('the ODF handler writes a paragraph-granularity redline .odt', async () => {
+        assertSuccess(result, 'compare_documents');
+        expect(result.provider).toBe('odf');
+        expect(result.mode).toBe('two_file');
+        expect(result.granularity).toBe('paragraph');
+        const stat = await fs.stat(out);
+        expect(stat.size).toBeGreaterThan(0);
+      });
+    },
+  );
+
+  test.openspec('[OPCD-02] Inserted and deleted paragraphs are counted')(
+    'a modified paragraph counts as one deletion and one insertion (modifications 0)',
+    async ({ given, then }: AllureBddContext) => {
+      let stats: { insertions: number; deletions: number; modifications: number } = { insertions: 0, deletions: 0, modifications: 0 };
+      await given('a compare of an original vs a one-paragraph-modified revision', async () => {
+        const dir = await tmpdir();
+        const { original, revised } = await buildOriginalAndRevised(dir);
+        const result = await dispatchToolCall(new SessionManager(), 'compare_documents', {
+          original_file_path: original,
+          revised_file_path: revised,
+          save_to_local_path: path.join(dir, 'redline.odt'),
+        });
+        assertSuccess(result, 'compare_documents');
+        stats = result.stats as typeof stats;
+      });
+      await then('insertions and deletions are each at least 1 and modifications is 0', () => {
+        expect(stats.insertions).toBeGreaterThanOrEqual(1);
+        expect(stats.deletions).toBeGreaterThanOrEqual(1);
+        expect(stats.modifications).toBe(0);
+      });
+    },
+  );
+
+  test.openspec('[OPCD-03] DOCX two-file compare is unchanged')(
+    'two .docx inputs run the DOCX comparison and return the DOCX response shape',
+    async ({ given, then }: AllureBddContext) => {
+      let result: Record<string, unknown> = {};
+      await given('two .docx files', async () => {
+        const dir = await tmpdir();
+        const original = await writeTestDocx(dir, 'a.docx', ['Hello world']);
+        const revised = await writeTestDocx(dir, 'b.docx', ['Hello brave new world']);
+        result = await dispatchToolCall(new SessionManager(), 'compare_documents', {
+          original_file_path: original,
+          revised_file_path: revised,
+          save_to_local_path: path.join(dir, 'out.docx'),
+        });
+      });
+      await then('the DOCX engine runs (engine_used present) and no ODF granularity is set', () => {
+        assertSuccess(result, 'compare_documents');
+        expect(result.engine_used).toBeDefined();
+        expect(result.granularity).toBeUndefined();
+        expect(result.provider).not.toBe('odf');
+      });
+    },
+  );
+
+  test.openspec('[OPCD-04] ODF session-mode compare is unsupported')(
+    'a .odt file_path (session mode) returns UNSUPPORTED_FOR_ODF',
+    async ({ given, then }: AllureBddContext) => {
+      let result: Record<string, unknown> = {};
+      await given('a .odt session file_path', async () => {
+        const dir = await tmpdir();
+        const odt = await copyFixtureTo(dir, 'session.odt');
+        result = await dispatchToolCall(new SessionManager(), 'compare_documents', {
+          file_path: odt,
+          save_to_local_path: path.join(dir, 'out.odt'),
+        });
+      });
+      await then('UNSUPPORTED_FOR_ODF is returned', () => {
+        assertError(result, 'UNSUPPORTED_FOR_ODF');
+      });
+    },
+  );
+
+  test.openspec('[OPCD-05] The redline reopens with the changes preserved')(
+    'the redline parses back: unchanged paragraphs preserved, deleted content does not leak',
+    async ({ given, then }: AllureBddContext) => {
+      let content = '';
+      await given('a redline produced from a one-paragraph modification', async () => {
+        const dir = await tmpdir();
+        const { original, revised } = await buildOriginalAndRevised(dir);
+        const out = path.join(dir, 'redline.odt');
+        const result = await dispatchToolCall(new SessionManager(), 'compare_documents', {
+          original_file_path: original,
+          revised_file_path: revised,
+          save_to_local_path: out,
+        });
+        assertSuccess(result, 'compare_documents');
+        // read_file reopens the redline through OdfDocument (which skips text:tracked-changes).
+        const reread = await dispatchToolCall(new SessionManager(), 'read_file', { file_path: out });
+        assertSuccess(reread, 'read_file');
+        content = String(reread.content ?? '');
+      });
+      await then('the body shows the revised text and the deleted original text does not leak', () => {
+        expect(content).toContain('quick brown fox'); // unchanged paragraph preserved
+        expect(content).toContain('Globex Corporation'); // revised paragraph
+        expect(content).not.toContain('Acme Manufacturing'); // deleted content stays out-of-line
+      });
+    },
+  );
+
+  test.openspec('[OPCD-06] Output path may not overwrite a source')(
+    'save_to_local_path resolving to a source file is rejected',
+    async ({ given, then }: AllureBddContext) => {
+      let result: Record<string, unknown> = {};
+      let original = '';
+      await given('a compare whose save_to_local_path equals the original source', async () => {
+        const dir = await tmpdir();
+        const built = await buildOriginalAndRevised(dir);
+        original = built.original;
+        result = await dispatchToolCall(new SessionManager(), 'compare_documents', {
+          original_file_path: original,
+          revised_file_path: built.revised,
+          save_to_local_path: original,
+        });
+      });
+      await then('OVERWRITE_BLOCKED is returned and the source is untouched', () => {
+        assertError(result, 'OVERWRITE_BLOCKED');
+      });
+    },
+  );
+});

--- a/packages/docx-mcp/src/tools/odf/odf_grep_insert.test.ts
+++ b/packages/docx-mcp/src/tools/odf/odf_grep_insert.test.ts
@@ -126,9 +126,8 @@ describe('ODF grep + insert_paragraph lane', () => {
         await firstId(manager, filePath);
       });
       await when('a still-unsupported tool targets the .odt path', async () => {
-        result = await dispatchToolCall(manager, 'compare_documents', {
+        result = await dispatchToolCall(manager, 'extract_revisions', {
           file_path: filePath,
-          save_to_local_path: '/tmp/should-be-rejected.odt',
         });
       });
       await then('the provider guard returns UNSUPPORTED_FOR_ODF', () => {
@@ -229,16 +228,19 @@ describe('ODF grep + insert branch coverage', () => {
     expect((res.new_paragraph_ids as string[]).length).toBe(2);
   });
 
-  it('compare_documents with .odt input paths returns UNSUPPORTED_FOR_ODF (two-file form)', async () => {
+  it('compare_documents with two .odt input paths now routes to the ODF handler (two-file form)', async () => {
+    // Two-file .odt compare became supported in add-odf-compare; the prior guard was flipped.
+    // (Session-mode .odt compare remains unsupported — covered by odf_compare.test.ts OPCD-04.)
     const manager = new SessionManager();
     const original = await copyFixture('orig.odt');
     const revised = await copyFixture('rev.odt');
     const res = await dispatchToolCall(manager, 'compare_documents', {
       original_file_path: original,
       revised_file_path: revised,
-      save_to_local_path: path.join(path.dirname(original), 'redline.docx'),
+      save_to_local_path: path.join(path.dirname(original), 'redline.odt'),
     });
-    assertError(res, 'UNSUPPORTED_FOR_ODF');
+    assertSuccess(res, 'compare_documents (two .odt)');
+    expect(res.provider).toBe('odf');
   });
 
   it('two unsupported tools on the same .odt path name the correct tool (no stale pending replay)', async () => {

--- a/packages/docx-mcp/src/tools/provider_guard.ts
+++ b/packages/docx-mcp/src/tools/provider_guard.ts
@@ -8,7 +8,7 @@ const GDOCS_SUPPORTED_TOOLS = new Set([
 
 const ODF_SUPPORTED_TOOLS = new Set([
   'read_file', 'replace_text', 'grep', 'insert_paragraph', 'add_comment', 'get_comments',
-  'save', 'get_file_status', 'close_file',
+  'compare_documents', 'save', 'get_file_status', 'close_file',
 ]);
 
 export function checkGDocsSupport(toolName: string): ToolResponse | null {
@@ -27,7 +27,7 @@ export function checkOdfSupport(toolName: string): ToolResponse | null {
     return err(
       'UNSUPPORTED_FOR_ODF',
       `'${toolName}' is not supported for ODF (.odt) files.`,
-      'Use read_file, replace_text, grep, insert_paragraph, add_comment, get_comments, save, get_file_status, or close_file for .odt files.',
+      'Use read_file, replace_text, grep, insert_paragraph, add_comment, get_comments, compare_documents, save, get_file_status, or close_file for .odt files.',
     );
   }
   return null;

--- a/packages/docx-mcp/src/tools/session_resolution.ts
+++ b/packages/docx-mcp/src/tools/session_resolution.ts
@@ -266,7 +266,7 @@ export async function resolveSessionForTool(
       response: err(
         'UNSUPPORTED_FOR_ODF',
         `Tool '${opts.toolName}' is not supported for ODF (.odt) files.`,
-        'Use read_file, replace_text, grep, insert_paragraph, add_comment, get_comments, save, get_file_status, or close_file for .odt files.',
+        'Use read_file, replace_text, grep, insert_paragraph, add_comment, get_comments, compare_documents, save, get_file_status, or close_file for .odt files.',
       ),
     };
   }
@@ -302,7 +302,7 @@ export async function resolveSessionForTool(
       response: err(
         'UNSUPPORTED_FOR_ODF',
         `Tool '${opts.toolName}' is not supported for ODF (.odt) files.`,
-        'Use read_file, replace_text, grep, insert_paragraph, add_comment, get_comments, save, get_file_status, or close_file for .odt files.',
+        'Use read_file, replace_text, grep, insert_paragraph, add_comment, get_comments, compare_documents, save, get_file_status, or close_file for .odt files.',
       ),
     };
   }

--- a/packages/odf-core/src/compare/diff.test.ts
+++ b/packages/odf-core/src/compare/diff.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+
+import { diffParagraphs, type EditOp } from './diff.js';
+
+/** Compact an edit script to readable tokens for assertions. */
+function tokens(ops: EditOp[]): string[] {
+  return ops.map((op) => {
+    if (op.kind === 'equal') return `=${op.originalIndex}:${op.revisedIndex}`;
+    if (op.kind === 'insert') return `+${op.revisedIndex}`;
+    return `-${op.originalIndex}`;
+  });
+}
+
+describe('diffParagraphs — paragraph-level LCS', () => {
+  it('[OCMP-01] marks added/removed/common paragraphs', () => {
+    // original: A B C ; revised: A X C  (B removed, X added, A/C common)
+    const ops = diffParagraphs(['A', 'B', 'C'], ['A', 'X', 'C']);
+    expect(tokens(ops)).toEqual(['=0:0', '-1', '+1', '=2:2']);
+  });
+
+  it('identical documents are all equal', () => {
+    const ops = diffParagraphs(['A', 'B'], ['A', 'B']);
+    expect(ops.every((o) => o.kind === 'equal')).toBe(true);
+    expect(tokens(ops)).toEqual(['=0:0', '=1:1']);
+  });
+
+  it('insert-only against an empty original', () => {
+    expect(tokens(diffParagraphs([], ['A', 'B']))).toEqual(['+0', '+1']);
+  });
+
+  it('delete-only against an empty revised', () => {
+    expect(tokens(diffParagraphs(['A', 'B'], []))).toEqual(['-0', '-1']);
+  });
+
+  it('two empty arrays produce no ops', () => {
+    expect(diffParagraphs([], [])).toEqual([]);
+  });
+
+  it('a pure insertion in the middle keeps surrounding paragraphs equal', () => {
+    expect(tokens(diffParagraphs(['A', 'C'], ['A', 'B', 'C']))).toEqual(['=0:0', '+1', '=1:2']);
+  });
+
+  it('consecutive deletions are emitted in order', () => {
+    expect(tokens(diffParagraphs(['A', 'B', 'C', 'D'], ['A', 'D']))).toEqual(['=0:0', '-1', '-2', '=3:1']);
+  });
+
+  it('a replace surfaces as delete-before-insert at the same slot', () => {
+    expect(tokens(diffParagraphs(['B'], ['X']))).toEqual(['-0', '+0']);
+  });
+
+  it('reordering is handled by the LCS (no spurious equals)', () => {
+    // original A B ; revised B A — LCS length 1; one of A/B is delete+insert.
+    const ops = diffParagraphs(['A', 'B'], ['B', 'A']);
+    const ins = ops.filter((o) => o.kind === 'insert').length;
+    const del = ops.filter((o) => o.kind === 'delete').length;
+    const eq = ops.filter((o) => o.kind === 'equal').length;
+    expect(eq).toBe(1);
+    expect(ins).toBe(1);
+    expect(del).toBe(1);
+  });
+});

--- a/packages/odf-core/src/compare/diff.ts
+++ b/packages/odf-core/src/compare/diff.ts
@@ -1,0 +1,59 @@
+/**
+ * Pure paragraph-level diff for ODF comparison (Slice 1).
+ *
+ * A language-agnostic O(N·M) LCS over two arrays of paragraph visible-text strings, returning a
+ * structured edit script in standard diff order. No DOM — this mirrors docx-core's `atomLcs.ts`
+ * (kept separate from emission so it is testable in isolation).
+ *
+ * Order convention: a paragraph "replaced" in place (text differs at a matched slot) surfaces as
+ * a `delete` of the original immediately followed by an `insert` of the revised, because at a
+ * mismatch we prefer the deletion branch. The emitter relies on this delete-before-insert order
+ * when both anchor at the same position.
+ */
+
+/** One step of the edit script, in merged document order. */
+export type EditOp =
+  | { kind: 'equal'; originalIndex: number; revisedIndex: number }
+  | { kind: 'insert'; revisedIndex: number }
+  | { kind: 'delete'; originalIndex: number };
+
+/**
+ * Diff two paragraph-text arrays into an ordered edit script.
+ * `equal` ops carry both indices; `insert` carries the revised index; `delete` the original index.
+ */
+export function diffParagraphs(original: string[], revised: string[]): EditOp[] {
+  const n = original.length;
+  const m = revised.length;
+
+  // dp[i][j] = LCS length of original[i..] and revised[j..].
+  const dp: number[][] = Array.from({ length: n + 1 }, () => new Array<number>(m + 1).fill(0));
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      dp[i]![j] =
+        original[i] === revised[j]
+          ? dp[i + 1]![j + 1]! + 1
+          : Math.max(dp[i + 1]![j]!, dp[i]![j + 1]!);
+    }
+  }
+
+  const ops: EditOp[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < n && j < m) {
+    if (original[i] === revised[j]) {
+      ops.push({ kind: 'equal', originalIndex: i, revisedIndex: j });
+      i++;
+      j++;
+    } else if (dp[i + 1]![j]! >= dp[i]![j + 1]!) {
+      // Prefer deletion at a tie so a replace surfaces as delete-then-insert.
+      ops.push({ kind: 'delete', originalIndex: i });
+      i++;
+    } else {
+      ops.push({ kind: 'insert', revisedIndex: j });
+      j++;
+    }
+  }
+  while (i < n) ops.push({ kind: 'delete', originalIndex: i++ });
+  while (j < m) ops.push({ kind: 'insert', revisedIndex: j++ });
+  return ops;
+}

--- a/packages/odf-core/src/compare/emit.test.ts
+++ b/packages/odf-core/src/compare/emit.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from 'vitest';
+import { parseXml } from '@usejunior/docx-core';
+
+import { compareOdf, OdfEmitError } from './index.js';
+import { OdfDocument } from '../document.js';
+import { ODF_NS } from '../shared/odf/namespaces.js';
+
+/** Wrap paragraphs in a minimal, namespace-complete content.xml (incl. xml: for xml:id). */
+function contentXml(paras: string[]): string {
+  const body = paras.map((t) => `<text:p>${t}</text:p>`).join('');
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<office:document-content
+  xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0"
+  xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"
+  xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0"
+  xmlns:dc="http://purl.org/dc/elements/1.1/"
+  xmlns:xml="http://www.w3.org/XML/1998/namespace">
+  <office:body><office:text>${body}</office:text></office:body>
+</office:document-content>`;
+}
+
+function officeText(xml: string): Element {
+  const doc = parseXml(xml);
+  return doc.getElementsByTagNameNS(ODF_NS.OFFICE, 'text').item(0) as Element;
+}
+
+function trackedRegions(ot: Element): Element[] {
+  const tracked = childByName(ot, ODF_NS.TEXT, 'tracked-changes');
+  if (!tracked) return [];
+  return elementChildren(tracked).filter((e) => e.localName === 'changed-region' && e.namespaceURI === ODF_NS.TEXT);
+}
+
+/** Direct body `text:p` children of office:text (excludes the tracked-changes container). */
+function bodyParagraphs(ot: Element): Element[] {
+  return elementChildren(ot).filter((e) => e.namespaceURI === ODF_NS.TEXT && e.localName === 'p');
+}
+
+function elementChildren(el: Element): Element[] {
+  const out: Element[] = [];
+  for (let c = el.firstChild; c; c = c.nextSibling) if (c.nodeType === 1) out.push(c as Element);
+  return out;
+}
+
+function childByName(el: Element, ns: string, local: string): Element | null {
+  return elementChildren(el).find((e) => e.namespaceURI === ns && e.localName === local) ?? null;
+}
+
+/** localName of a paragraph's first element child, or null. */
+function firstElLocal(p: Element): string | null {
+  const first = elementChildren(p)[0];
+  return first ? first.localName : null;
+}
+
+function lastElLocal(p: Element): string | null {
+  const els = elementChildren(p);
+  return els.length ? els[els.length - 1]!.localName! : null;
+}
+
+/** The stored `text:p` localNames inside a region's text:deletion (after change-info). */
+function deletionStored(region: Element): string[] {
+  const del = childByName(region, ODF_NS.TEXT, 'deletion');
+  if (!del) return [];
+  return elementChildren(del)
+    .filter((e) => e.localName === 'p' && e.namespaceURI === ODF_NS.TEXT)
+    .map((p) => p.textContent ?? '');
+}
+
+describe('compareOdf — ODF tracked-changes emission', () => {
+  it('[OCMP-02] inserts a paragraph: change-start in the new para, change-end in the following', () => {
+    const { contentXml: out, stats } = compareOdf(contentXml(['A', 'C']), contentXml(['A', 'B', 'C']));
+    const ot = officeText(out);
+    expect(stats).toEqual({ insertions: 1, deletions: 0, modifications: 0 });
+    const regions = trackedRegions(ot);
+    expect(regions).toHaveLength(1);
+    expect(childByName(regions[0]!, ODF_NS.TEXT, 'insertion')).not.toBeNull();
+    const [pa, pb, pc] = bodyParagraphs(ot);
+    expect(pa!.textContent).toBe('A');
+    expect(firstElLocal(pb!)).toBe('change-start'); // inserted "B"
+    expect(firstElLocal(pc!)).toBe('change-end'); // following kept "C"
+  });
+
+  it('[OCMP-09] inserts at end-of-document: change-start at end of prev, change-end at end of new', () => {
+    const out = compareOdf(contentXml(['A', 'B']), contentXml(['A', 'B', 'C'])).contentXml;
+    const ps = bodyParagraphs(officeText(out));
+    expect(lastElLocal(ps[1]!)).toBe('change-start'); // end of preceding kept "B"
+    expect(lastElLocal(ps[2]!)).toBe('change-end'); // end of inserted "C"
+  });
+
+  it('[OCMP-03] deletes a middle paragraph: forward anchor + out-of-line content', () => {
+    const { contentXml: out, stats } = compareOdf(contentXml(['A', 'B', 'C']), contentXml(['A', 'C']));
+    const ot = officeText(out);
+    expect(stats).toEqual({ insertions: 0, deletions: 1, modifications: 0 });
+    const regions = trackedRegions(ot);
+    expect(regions).toHaveLength(1);
+    expect(deletionStored(regions[0]!)).toEqual(['B', '']); // deleted content, then empty merge artifact
+    const [, pc] = bodyParagraphs(ot);
+    expect(firstElLocal(pc!)).toBe('change'); // inline point marker at start of following "C"
+  });
+
+  it('[OCMP-04] deletes the last paragraph: backward anchor + empty-artifact-first', () => {
+    const out = compareOdf(contentXml(['A', 'B', 'C']), contentXml(['A', 'B'])).contentXml;
+    const ot = officeText(out);
+    expect(deletionStored(trackedRegions(ot)[0]!)).toEqual(['', 'C']);
+    const [, pb] = bodyParagraphs(ot);
+    expect(lastElLocal(pb!)).toBe('change'); // marker at end of preceding "B"
+  });
+
+  it('[OCMP-07] consecutive deletions coalesce into one region with one marker', () => {
+    const out = compareOdf(contentXml(['A', 'B', 'C', 'D']), contentXml(['A', 'D'])).contentXml;
+    const ot = officeText(out);
+    const regions = trackedRegions(ot);
+    expect(regions).toHaveLength(1);
+    expect(deletionStored(regions[0]!)).toEqual(['B', 'C', '']);
+    const [, pd] = bodyParagraphs(ot);
+    expect(firstElLocal(pd!)).toBe('change');
+    // exactly one in-body change marker
+    expect(out.match(/<text:change /g) ?? []).toHaveLength(1);
+  });
+
+  it('[OCMP-08] consecutive deletion run at end: one region, empty artifact first, end anchor', () => {
+    const out = compareOdf(contentXml(['A', 'B', 'C', 'D']), contentXml(['A', 'B'])).contentXml;
+    const ot = officeText(out);
+    const regions = trackedRegions(ot);
+    expect(regions).toHaveLength(1);
+    expect(deletionStored(regions[0]!)).toEqual(['', 'C', 'D']);
+    const [, pb] = bodyParagraphs(ot);
+    expect(lastElLocal(pb!)).toBe('change');
+  });
+
+  it('[OCMP-10] modified paragraph orders deletion marker before insertion change-start', () => {
+    const { contentXml: out, stats } = compareOdf(contentXml(['A', 'B', 'C']), contentXml(['A', 'X', 'C']));
+    expect(stats).toEqual({ insertions: 1, deletions: 1, modifications: 0 });
+    const ot = officeText(out);
+    expect(trackedRegions(ot)).toHaveLength(2); // one deletion + one insertion
+    const px = bodyParagraphs(ot)[1]!; // the replacement paragraph "X"
+    const firstTwo = elementChildren(px)
+      .slice(0, 2)
+      .map((e) => e.localName);
+    expect(firstTwo).toEqual(['change', 'change-start']); // deletion point BEFORE insertion start
+  });
+
+  it('[OCMP-05] change ids are unique across regions', () => {
+    const out = compareOdf(contentXml(['A', 'B', 'C']), contentXml(['A', 'X', 'C'])).contentXml;
+    const ids = [...out.matchAll(/xml:id="(ct\d+)"/g)].map((m) => m[1]);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids.length).toBe(2);
+  });
+
+  it('[OCMP-06] deleted content does not leak into getParagraphs()', () => {
+    const out = compareOdf(contentXml(['A', 'B', 'C']), contentXml(['A', 'C'])).contentXml;
+    const paras = OdfDocument.fromContentXml(out).getParagraphs();
+    expect(paras.map((p) => p.text)).toEqual(['A', 'C']); // "B" stays out-of-line, no phantom block
+  });
+
+  it('preserves unchanged paragraphs and reuses a single tracked-changes container', () => {
+    const out = compareOdf(contentXml(['A', 'B', 'C']), contentXml(['A', 'X', 'C'])).contentXml;
+    const ot = officeText(out);
+    // one container, first child of office:text
+    expect(firstElLocal(ot)).toBe('tracked-changes');
+    expect(elementChildren(ot).filter((e) => e.localName === 'tracked-changes')).toHaveLength(1);
+  });
+
+  it('places a deletion marker inside a table cell', () => {
+    const orig = `<?xml version="1.0" encoding="UTF-8"?>
+<office:document-content xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xml="http://www.w3.org/XML/1998/namespace">
+  <office:body><office:text><table:table><table:table-row><table:table-cell><text:p>Cell1</text:p><text:p>Cell2</text:p></table:table-cell></table:table-row></table:table></office:text></office:body>
+</office:document-content>`;
+    const rev = orig.replace('<text:p>Cell1</text:p>', '');
+    const out = compareOdf(orig, rev).contentXml;
+    // The kept cell paragraph "Cell2" carries the inline deletion marker at its start.
+    expect(out).toMatch(/<table:table-cell><text:p><text:change [^>]*\/>Cell2<\/text:p>/);
+    expect(OdfDocument.fromContentXml(out).getParagraphs().map((p) => p.text)).toEqual(['Cell2']);
+  });
+
+  it('fails closed when every paragraph is deleted (no anchor)', () => {
+    expect(() => compareOdf(contentXml(['A', 'B']), contentXml([]))).toThrow(OdfEmitError);
+  });
+
+  it('inserts into a previously-empty document by bracketing the whole run', () => {
+    const out = compareOdf(contentXml([]), contentXml(['A', 'B'])).contentXml;
+    const ps = bodyParagraphs(officeText(out));
+    expect(firstElLocal(ps[0]!)).toBe('change-start'); // start of first inserted
+    expect(lastElLocal(ps[1]!)).toBe('change-end'); // end of last inserted
+  });
+});

--- a/packages/odf-core/src/compare/emit.ts
+++ b/packages/odf-core/src/compare/emit.ts
@@ -1,0 +1,261 @@
+/**
+ * ODF tracked-changes emitter for paragraph-granularity comparison (Slice 1).
+ *
+ * Mutates the REVISED `content.xml` DOM in place, adding a `text:tracked-changes` container (first
+ * child of `office:text`) plus the lightweight in-body markers that reference it. The exact markup
+ * shapes were confirmed by driving LibreOffice to author each change and inspecting its output
+ * (see the `add-odf-compare` design notes):
+ *
+ *  - Insertion: `text:change-start` / `text:change-end` brackets the inserted run, referencing a
+ *    `text:insertion` region; inserted content stays inline. Forward (a following kept paragraph
+ *    exists): start at the inserted run's first paragraph, end at the following paragraph's start.
+ *    End-of-document: start at the preceding paragraph's end, end at the inserted run's last
+ *    paragraph's end.
+ *  - Deletion (paragraph-break merge): the deleted paragraphs live out-of-line in a `text:deletion`
+ *    region; an inline `text:change` point marker sits in the nearest SURVIVING paragraph — at the
+ *    start of the following one (forward) or the end of the preceding one (backward, for a run
+ *    reaching end-of-document). Consecutive deletions coalesce into ONE region with all deleted
+ *    paragraphs plus one empty merge-artifact paragraph (artifact last for forward, first for
+ *    backward). `text:change` is inline and is never a direct block child of `office:text`.
+ *  - A run with no surviving paragraph to anchor to (every paragraph deleted) fails closed.
+ *
+ * All element creation/matching is by `namespaceURI` + `localName` (ODF prefixes are not guaranteed).
+ */
+
+import { ODF_NS } from '../shared/odf/namespaces.js';
+import type { EditOp } from './diff.js';
+
+export type EmitParams = {
+  /** The revised `content.xml` DOM; mutated in place. */
+  revisedDoc: Document;
+  /** Revised body paragraphs in document order (excludes `text:tracked-changes`). */
+  revisedBlocks: Element[];
+  /** Original body paragraphs in document order (source of deleted content). */
+  originalBlocks: Element[];
+  /** The edit script from `diffParagraphs(original, revised)`. */
+  ops: EditOp[];
+  /** Change author for `dc:creator`. */
+  author: string;
+  /** Change date for `dc:date` (ODF 8601, no fractional seconds). */
+  date: string;
+};
+
+export class OdfEmitError extends Error {}
+
+type InsertRun = { a: number; b: number; id: string };
+type DeleteRun = { originalIndices: number[]; revisedCursor: number; id: string };
+
+/** Apply the tracked-changes markup for `ops` to `revisedDoc`. */
+export function emitTrackedChanges(params: EmitParams): void {
+  const { revisedDoc, revisedBlocks, originalBlocks, ops, author, date } = params;
+  const m = revisedBlocks.length;
+
+  const officeText = firstElementNS(revisedDoc, ODF_NS.OFFICE, 'text');
+  if (!officeText) throw new OdfEmitError('No office:text element in revised content.xml.');
+
+  // --- Plan: group consecutive same-kind change ops into runs, allocating ids in document order.
+  const alloc = makeIdAllocator(revisedDoc);
+  const insertRuns: InsertRun[] = [];
+  const deleteRuns: DeleteRun[] = [];
+  let revisedCursor = 0;
+  let k = 0;
+  while (k < ops.length) {
+    const op = ops[k]!;
+    if (op.kind === 'equal') {
+      revisedCursor = op.revisedIndex + 1;
+      k++;
+    } else if (op.kind === 'insert') {
+      const a = op.revisedIndex;
+      let b = a;
+      while (k + 1 < ops.length && ops[k + 1]!.kind === 'insert') {
+        k++;
+        b = (ops[k] as { revisedIndex: number }).revisedIndex;
+      }
+      insertRuns.push({ a, b, id: alloc() });
+      revisedCursor = b + 1;
+      k++;
+    } else {
+      const originalIndices = [op.originalIndex];
+      while (k + 1 < ops.length && ops[k + 1]!.kind === 'delete') {
+        k++;
+        originalIndices.push((ops[k] as { originalIndex: number }).originalIndex);
+      }
+      // A deletion run with no surviving revised paragraph anywhere cannot be anchored inline.
+      if (m === 0) {
+        throw new OdfEmitError(
+          'Cannot emit a deletion when the revised document has no paragraphs to anchor the change marker to.',
+        );
+      }
+      deleteRuns.push({ originalIndices, revisedCursor, id: alloc() });
+      k++;
+    }
+  }
+
+  // Identical documents: emit nothing (no empty container).
+  if (insertRuns.length === 0 && deleteRuns.length === 0) return;
+
+  // --- Create the changed-region definitions, in ascending id (document) order.
+  const tracked = ensureTrackedChanges(revisedDoc, officeText);
+  const allRuns: Array<{ kind: 'insert' | 'delete'; id: string; run: InsertRun | DeleteRun }> = [
+    ...insertRuns.map((run) => ({ kind: 'insert' as const, id: run.id, run })),
+    ...deleteRuns.map((run) => ({ kind: 'delete' as const, id: run.id, run })),
+  ].sort((x, y) => idNum(x.id) - idNum(y.id));
+  for (const entry of allRuns) {
+    if (entry.kind === 'insert') {
+      tracked.appendChild(makeInsertionRegion(revisedDoc, entry.id, author, date));
+    } else {
+      const dr = entry.run as DeleteRun;
+      const forward = dr.revisedCursor < m;
+      const deletedPs = dr.originalIndices.map((i) => revisedDoc.importNode(originalBlocks[i]!, true) as Element);
+      const artifact = makeEmptyParagraph(revisedDoc, originalBlocks[dr.originalIndices[0]!]!);
+      const stored = forward ? [...deletedPs, artifact] : [artifact, ...deletedPs];
+      tracked.appendChild(makeDeletionRegion(revisedDoc, entry.id, author, date, stored));
+    }
+  }
+
+  // --- Place insertion markers FIRST so a co-located deletion marker can be prepended before them.
+  for (const run of insertRuns) {
+    placeInsertionMarkers(revisedDoc, revisedBlocks, run, m);
+  }
+  // --- Place deletion point markers.
+  for (const run of deleteRuns) {
+    const forward = run.revisedCursor < m;
+    const marker = makeMarker(revisedDoc, 'change', run.id);
+    if (forward) {
+      prepend(revisedBlocks[run.revisedCursor]!, marker);
+    } else {
+      revisedBlocks[m - 1]!.appendChild(marker);
+    }
+  }
+}
+
+function placeInsertionMarkers(doc: Document, revisedBlocks: Element[], run: InsertRun, m: number): void {
+  const start = makeMarker(doc, 'change-start', run.id);
+  const end = makeMarker(doc, 'change-end', run.id);
+  const hasFollowing = run.b + 1 < m;
+  const hasPreceding = run.a - 1 >= 0;
+  if (hasFollowing) {
+    // Forward bracket: start of inserted run … start of following paragraph.
+    prepend(revisedBlocks[run.a]!, start);
+    prepend(revisedBlocks[run.b + 1]!, end);
+  } else if (hasPreceding) {
+    // End-of-document: end of preceding paragraph … end of inserted run.
+    revisedBlocks[run.a - 1]!.appendChild(start);
+    revisedBlocks[run.b]!.appendChild(end);
+  } else {
+    // Entire revised document is inserted: bracket from the first paragraph's start to the last's end.
+    prepend(revisedBlocks[run.a]!, start);
+    revisedBlocks[run.b]!.appendChild(end);
+  }
+}
+
+// --- DOM helpers -------------------------------------------------------------------------------
+
+function firstElementNS(doc: Document, ns: string, local: string): Element | null {
+  const els = doc.getElementsByTagNameNS(ns, local);
+  return (els.item(0) as Element | null) ?? null;
+}
+
+function prepend(block: Element, node: Node): void {
+  block.insertBefore(node, block.firstChild);
+}
+
+/** Get the `text:tracked-changes` first child of `officeText`, creating it if absent. */
+function ensureTrackedChanges(doc: Document, officeText: Element): Element {
+  for (let child = officeText.firstChild; child; child = child.nextSibling) {
+    if (
+      child.nodeType === 1 &&
+      (child as Element).namespaceURI === ODF_NS.TEXT &&
+      (child as Element).localName === 'tracked-changes'
+    ) {
+      return child as Element;
+    }
+  }
+  const tracked = doc.createElementNS(ODF_NS.TEXT, 'text:tracked-changes');
+  officeText.insertBefore(tracked, officeText.firstChild);
+  return tracked;
+}
+
+function makeChangeInfo(doc: Document, author: string, date: string): Element {
+  const info = doc.createElementNS(ODF_NS.OFFICE, 'office:change-info');
+  const creator = doc.createElementNS(ODF_NS.DC, 'dc:creator');
+  creator.appendChild(doc.createTextNode(author));
+  info.appendChild(creator);
+  const d = doc.createElementNS(ODF_NS.DC, 'dc:date');
+  d.appendChild(doc.createTextNode(date));
+  info.appendChild(d);
+  return info;
+}
+
+function makeChangedRegion(doc: Document, id: string): Element {
+  const region = doc.createElementNS(ODF_NS.TEXT, 'text:changed-region');
+  region.setAttributeNS(ODF_NS.XML, 'xml:id', id);
+  region.setAttributeNS(ODF_NS.TEXT, 'text:id', id);
+  return region;
+}
+
+function makeInsertionRegion(doc: Document, id: string, author: string, date: string): Element {
+  const region = makeChangedRegion(doc, id);
+  const insertion = doc.createElementNS(ODF_NS.TEXT, 'text:insertion');
+  insertion.appendChild(makeChangeInfo(doc, author, date));
+  region.appendChild(insertion);
+  return region;
+}
+
+function makeDeletionRegion(doc: Document, id: string, author: string, date: string, stored: Element[]): Element {
+  const region = makeChangedRegion(doc, id);
+  const deletion = doc.createElementNS(ODF_NS.TEXT, 'text:deletion');
+  deletion.appendChild(makeChangeInfo(doc, author, date));
+  for (const p of stored) deletion.appendChild(p);
+  region.appendChild(deletion);
+  return region;
+}
+
+/** An empty `text:p` merge artifact, inheriting the deleted paragraph's style when present. */
+function makeEmptyParagraph(doc: Document, modelBlock: Element): Element {
+  const p = doc.createElementNS(ODF_NS.TEXT, 'text:p');
+  const style = modelBlock.getAttributeNS(ODF_NS.TEXT, 'style-name') ?? modelBlock.getAttribute('text:style-name');
+  if (style) p.setAttributeNS(ODF_NS.TEXT, 'text:style-name', style);
+  return p;
+}
+
+function makeMarker(doc: Document, local: 'change' | 'change-start' | 'change-end', id: string): Element {
+  const el = doc.createElementNS(ODF_NS.TEXT, `text:${local}`);
+  el.setAttributeNS(ODF_NS.TEXT, 'text:change-id', id);
+  return el;
+}
+
+const CT_ID_RE = /^ct(\d+)$/;
+function idNum(id: string): number {
+  const m = CT_ID_RE.exec(id);
+  return m ? Number.parseInt(m[1]!, 10) : 0;
+}
+
+/**
+ * Allocate fresh `ct<n>` change ids that collide with no existing `xml:id` / `text:id` on the
+ * revised document's `text:changed-region`s (so reused/pre-existing tracked-changes are preserved).
+ */
+function makeIdAllocator(doc: Document): () => string {
+  const used = new Set<string>();
+  const regions = doc.getElementsByTagNameNS(ODF_NS.TEXT, 'changed-region');
+  let max = 0;
+  for (let i = 0; i < regions.length; i++) {
+    const r = regions.item(i) as Element;
+    for (const id of [
+      r.getAttributeNS(ODF_NS.XML, 'id') ?? r.getAttribute('xml:id'),
+      r.getAttributeNS(ODF_NS.TEXT, 'id') ?? r.getAttribute('text:id'),
+    ]) {
+      if (!id) continue;
+      used.add(id);
+      const mm = CT_ID_RE.exec(id);
+      if (mm) max = Math.max(max, Number.parseInt(mm[1]!, 10));
+    }
+  }
+  let next = max + 1;
+  return () => {
+    let id = `ct${next++}`;
+    while (used.has(id)) id = `ct${next++}`;
+    used.add(id);
+    return id;
+  };
+}

--- a/packages/odf-core/src/compare/index.ts
+++ b/packages/odf-core/src/compare/index.ts
@@ -1,0 +1,88 @@
+/**
+ * ODF document comparison — paragraph-granularity tracked-changes redline (Slice 1).
+ *
+ * `compareOdf` is the public entry: it takes two `content.xml` STRINGS, parses each exactly once
+ * internally (no DOM Element crosses the package boundary, no public DOM accessor on
+ * `OdfDocument`), diffs the body paragraphs, emits ODF tracked-changes into the revised DOM, and
+ * returns the redline `content.xml` plus edit stats. Diff and emit live in separate modules so the
+ * diff is testable without round-tripping a `.odt`.
+ *
+ * Granularity: whole-paragraph. A "modified" paragraph surfaces as a deletion of the old plus an
+ * insertion of the new, so `modifications` is always 0 at this granularity; intra-paragraph
+ * (run-level) diffs are a later slice.
+ */
+
+import { parseXml, serializeXml } from '@usejunior/docx-core';
+
+import { collectBlocks } from '../shared/odf/blocks.js';
+import { buildSegments } from '../shared/odf/text_segments.js';
+import { diffParagraphs } from './diff.js';
+import { emitTrackedChanges } from './emit.js';
+
+export { OdfEmitError } from './emit.js';
+
+/** Counts of whole-paragraph edits. `modifications` is always 0 at paragraph granularity. */
+export type OdfCompareStats = {
+  insertions: number;
+  deletions: number;
+  modifications: number;
+};
+
+export type OdfCompareResult = {
+  /** The redline `content.xml` (revised document + tracked-changes markup). */
+  contentXml: string;
+  stats: OdfCompareStats;
+};
+
+export type OdfCompareOptions = {
+  /** Change author for `dc:creator`. Defaults to `SafeDocX`. */
+  author?: string;
+  /** Change date; defaults to now. */
+  date?: Date;
+};
+
+/** ODF `dc:date` value: ISO 8601, no fractional seconds or trailing `Z` (matches comments.ts). */
+function odfDate(date: Date): string {
+  return date.toISOString().replace(/\.\d{3}Z$/, '');
+}
+
+/**
+ * Compare two `content.xml` strings and produce a paragraph-granularity tracked-changes redline.
+ * The redline is built on the REVISED document (so its styles, manifest, and untouched paragraphs
+ * are preserved); deleted paragraphs are stored out-of-line in the tracked-changes container.
+ */
+export function compareOdf(
+  originalContentXml: string,
+  revisedContentXml: string,
+  options: OdfCompareOptions = {},
+): OdfCompareResult {
+  const author = options.author ?? 'SafeDocX';
+  const date = odfDate(options.date ?? new Date());
+
+  const originalDoc = parseXml(originalContentXml);
+  const revisedDoc = parseXml(revisedContentXml);
+
+  const originalBlocks: Element[] = [];
+  collectBlocks(originalDoc.documentElement, originalBlocks);
+  const revisedBlocks: Element[] = [];
+  collectBlocks(revisedDoc.documentElement, revisedBlocks);
+
+  const ops = diffParagraphs(
+    originalBlocks.map((b) => buildSegments(b).visible),
+    revisedBlocks.map((b) => buildSegments(b).visible),
+  );
+
+  emitTrackedChanges({ revisedDoc, revisedBlocks, originalBlocks, ops, author, date });
+
+  let insertions = 0;
+  let deletions = 0;
+  for (const op of ops) {
+    if (op.kind === 'insert') insertions++;
+    else if (op.kind === 'delete') deletions++;
+  }
+
+  return {
+    contentXml: serializeXml(revisedDoc),
+    stats: { insertions, deletions, modifications: 0 },
+  };
+}

--- a/packages/odf-core/src/document.ts
+++ b/packages/odf-core/src/document.ts
@@ -14,7 +14,8 @@
 import { parseXml, serializeXml } from '@usejunior/docx-core';
 
 import { ODF_NS } from './shared/odf/namespaces.js';
-import { ELEMENT_NODE, buildSegments, isAnnotationSubtree, isTextBlock } from './shared/odf/text_segments.js';
+import { buildSegments } from './shared/odf/text_segments.js';
+import { collectBlocks } from './shared/odf/blocks.js';
 import { addAnnotation, readAnnotations, type AddAnnotationResult, type OdfComment } from './comments.js';
 
 export type OdfParagraph = {
@@ -60,25 +61,8 @@ export class OdfDocument {
   static fromContentXml(contentXml: string): OdfDocument {
     const doc = parseXml(contentXml);
     const blocks: Element[] = [];
-    OdfDocument.collectBlocks(doc.documentElement, blocks);
+    collectBlocks(doc.documentElement, blocks);
     return new OdfDocument(doc, blocks);
-  }
-
-  /** Depth-first, document-order collection of `text:p` / `text:h` blocks. */
-  private static collectBlocks(node: Node | null, out: Element[]): void {
-    if (!node) return;
-    for (let child = node.firstChild; child; child = child.nextSibling) {
-      if (child.nodeType !== ELEMENT_NODE) continue;
-      const el = child as Element;
-      // An annotation carries its own `text:p` comment body; never enumerate it as a block.
-      if (isAnnotationSubtree(el)) continue;
-      if (isTextBlock(el)) {
-        out.push(el);
-        // Block-level text elements are not nested inside one another in ODF, but
-        // continue traversal in case of unusual structures (cost is negligible).
-      }
-      OdfDocument.collectBlocks(el, out);
-    }
   }
 
   private idForIndex(index: number): string {
@@ -193,7 +177,7 @@ export class OdfDocument {
 
     // Rebuild the structural block index; positional IDs shift accordingly.
     const blocks: Element[] = [];
-    OdfDocument.collectBlocks(this.doc.documentElement, blocks);
+    collectBlocks(this.doc.documentElement, blocks);
     this.blocks = blocks;
 
     const newIds = newEls.map((el) => this.idForIndex(blocks.indexOf(el)));

--- a/packages/odf-core/src/index.ts
+++ b/packages/odf-core/src/index.ts
@@ -8,5 +8,12 @@ export {
   type AddCommentResult,
 } from './document.js';
 export { type OdfComment } from './comments.js';
+export {
+  compareOdf,
+  OdfEmitError,
+  type OdfCompareResult,
+  type OdfCompareStats,
+  type OdfCompareOptions,
+} from './compare/index.js';
 export { validateOdfArchiveSafety, type OdfArchiveSafetyResult } from './odf_archive_safety.js';
 export { ODF_NS, ODF_PATHS, ODT_MIMETYPE } from './shared/odf/namespaces.js';

--- a/packages/odf-core/src/shared/odf/blocks.ts
+++ b/packages/odf-core/src/shared/odf/blocks.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared block-level paragraph enumeration for ODF `content.xml`.
+ *
+ * Extracted from `document.ts` so both the document view and the comparison engine
+ * (`compare/index.ts`) enumerate body paragraphs identically without an import cycle.
+ *
+ * A "block" is a `text:p` / `text:h` carrying visible content, in document order — including
+ * those nested in `table:table-cell`. Two subtrees are skipped because their `text:p`s are not
+ * body content: `office:annotation` / `office:annotation-end` (comment bodies) and
+ * `text:tracked-changes` (deleted content stored out-of-line). All matching is by
+ * `namespaceURI` + `localName` (ODF prefixes are not guaranteed).
+ */
+
+import {
+  ELEMENT_NODE,
+  isAnnotationSubtree,
+  isTextBlock,
+  isTrackedChangesSubtree,
+} from './text_segments.js';
+
+/** Depth-first, document-order collection of `text:p` / `text:h` blocks into `out`. */
+export function collectBlocks(node: Node | null, out: Element[]): void {
+  if (!node) return;
+  for (let child = node.firstChild; child; child = child.nextSibling) {
+    if (child.nodeType !== ELEMENT_NODE) continue;
+    const el = child as Element;
+    // An annotation carries its own `text:p` comment body; never enumerate it as a block.
+    if (isAnnotationSubtree(el)) continue;
+    // `text:tracked-changes` stores deleted paragraphs out-of-line; they are not body blocks.
+    if (isTrackedChangesSubtree(el)) continue;
+    if (isTextBlock(el)) {
+      out.push(el);
+      // Block-level text elements are not nested inside one another in ODF, but
+      // continue traversal in case of unusual structures (cost is negligible).
+    }
+    collectBlocks(el, out);
+  }
+}

--- a/packages/odf-core/src/shared/odf/namespaces.ts
+++ b/packages/odf-core/src/shared/odf/namespaces.ts
@@ -13,6 +13,8 @@ export const ODF_NS = {
   MANIFEST: 'urn:oasis:names:tc:opendocument:xmlns:manifest:1.0',
   // Dublin Core — carries annotation/change author (`dc:creator`) and date (`dc:date`).
   DC: 'http://purl.org/dc/elements/1.1/',
+  // W3C XML namespace — carries `xml:id` on `text:changed-region` for tracked changes.
+  XML: 'http://www.w3.org/XML/1998/namespace',
 } as const;
 
 /** The mimetype value an OpenDocument text package declares. */

--- a/packages/odf-core/src/shared/odf/text_segments.ts
+++ b/packages/odf-core/src/shared/odf/text_segments.ts
@@ -26,6 +26,16 @@ export function isAnnotationSubtree(el: { namespaceURI?: string | null; localNam
   return el.namespaceURI === ODF_NS.OFFICE && (el.localName === 'annotation' || el.localName === 'annotation-end');
 }
 
+/**
+ * True for a `text:tracked-changes` container. It holds change DEFINITIONS — including deleted
+ * paragraphs stored out-of-line inside `text:deletion` — which are NOT body content: they must
+ * not be walked as a host paragraph's visible text nor enumerated as paragraph blocks. Callers
+ * skip this subtree (the deletion-storage analogue of `isAnnotationSubtree`).
+ */
+export function isTrackedChangesSubtree(el: { namespaceURI?: string | null; localName?: string | null }): boolean {
+  return el.namespaceURI === ODF_NS.TEXT && el.localName === 'tracked-changes';
+}
+
 /** A contiguous slice of a paragraph's visible text and where it came from. */
 export type Segment =
   | { kind: 'text'; node: { data: string }; visStart: number; length: number }
@@ -55,6 +65,8 @@ export function buildSegments(block: Element): { segments: Segment[]; visible: s
       const el = child as Element;
       // Skip annotation subtrees: their body text is a comment, not the host paragraph's content.
       if (isAnnotationSubtree(el)) continue;
+      // Skip tracked-changes storage: deleted paragraphs live out-of-line here, not in the body.
+      if (isTrackedChangesSubtree(el)) continue;
       if (el.namespaceURI === ODF_NS.TEXT && el.localName === 's') {
         const countRaw = el.getAttributeNS(ODF_NS.TEXT, 'c') ?? el.getAttribute('text:c');
         const count = Math.max(1, Number.parseInt(countRaw ?? '1', 10) || 1);


### PR DESCRIPTION
Closes #343 (Slice 1 of 3).

## What
Adds two-file ODF (`.odt`) support for `compare_documents`: redline two `.odt` files into ODF tracked-changes markup (`text:tracked-changes` / `text:changed-region` / `text:insertion` / `text:deletion` / `text:change-start` / `-end` / `text:change`). This is the ODF analogue of docx-core's `w:ins`/`w:del` atomizer — same LCS *algorithm*, a fresh *emitter* (ODF stores deletions out-of-line, not inline).

**Scope (Slice 1):** paragraph granularity, two-file mode. Intra-paragraph (run-level) diffs and session-mode compare are deferred to follow-up slices.

## How it works
- **odf-core `compare/`**: `diff.ts` (pure paragraph LCS, no DOM) → `emit.ts` (ODF tracked-changes emitter) → `index.ts` (`compareOdf(originalContentXml, revisedContentXml)`). Diff is separable and unit-tested in isolation.
- **Markup shapes were confirmed empirically** by driving LibreOffice to *author* each change and inspecting its `content.xml`:
  - Insertion brackets `change-start`/`-end` (EOF brackets backward); content stays inline.
  - Deletion stores paragraphs out-of-line in `text:deletion` and anchors an inline `text:change` in the nearest **surviving** paragraph (forward start / backward end). Consecutive deletions **coalesce** into one region. `text:change` is inline — never a block child of `office:text`.
  - A modified paragraph = delete + insert (so `modifications` is always 0 at this granularity); when both markers share a position, the deletion marker precedes the insertion `change-start`.
  - All-deleted (no anchor) fails closed.
- **No-leak**: `collectBlocks` (extracted to `shared/odf/blocks.ts`) and `buildSegments` skip the `text:tracked-changes` subtree, so deleted content never appears in `getParagraphs()`.
- **docx-mcp**: a stateless `tools/odf/compare_documents.ts` handler (two-file compare carries no `file_path`, so it cannot use the session-keyed resolver); `server.ts` routes two `.odt` inputs to it, guards `.odt` session-mode as `UNSUPPORTED_FOR_ODF`, and leaves the DOCX path untouched. Output-path clobber + write-policy match the DOCX tool.

## Optional-provider isolation
odf-core stays `private: true` and is reached only via the lazy `loadOdfCore()` dynamic import. `check:release-isolation` passes.

## Verification
- `build`, `lint:workspaces` (0 errors), `check:cycles`, `check:release-isolation`, `check:allure-{labels,filenames,quality}` — all green.
- `openspec validate add-odf-compare --strict` ✓; `check:spec-coverage --strict` ✓ (OPCD-01..06, 6/6).
- Suites: odf-core 62 passed; docx-mcp 833 passed. Coverage ratchet passed (improved: docx-mcp +1.24% lines).
- **Document-shaped smoke on a real 341-paragraph NVCA `.odt`** (converted from `nvca-coi-regression/source.docx`), driven through `dispatchToolCall`: produced a redline with 2 insertions + 1 deletion; **reopened in LibreOffice** — accept-all yields the revised text, reject-all yields the original. The sample-fixture redline round-trips identically.

## OpenSpec
New `add-odf-compare` change (mcp-server `OPCD-01..06`, odf-core `OCMP-01..10`). Amends `add-odf-grep-insert` `OPLR-08` example (compare_documents is now supported).