### PR TITLE
feat(docx-core): formatting-fidelity comparison check (#363)

### DIFF
--- a/openspec/changes/add-formatting-fidelity-comparison-check/design.md
+++ b/openspec/changes/add-formatting-fidelity-comparison-check/design.md
@@ -1,0 +1,32 @@
+## Context
+
+Issue #363. Both existing oracles are formatting-blind, so rebuild's formatting loss is invisible to every gate. The campaign needs (1) a way to quantify what rebuild currently drops on each fallback shape, and (2) a per-fix gate asserting inplace output's formatting fidelity ≥ rebuild's.
+
+## Goals / Non-Goals
+
+- Goals: deterministic in-engine comparison of two `document.xml` views; per-property divergence report; scalar score usable as a gate; insensitivity to run-split and revision-markup granularity noise.
+- Non-Goals: LibreOffice-based formatting oracling (LO rewrites formatting on load/save); style-sheet resolution (`styles.xml` cascade — compares direct formatting only); wiring the check into the pipeline's fallback decision (measurement first, gating per-fix later).
+
+## Decisions
+
+- **Content-anchored alignment, not raw XML diff.** Paragraphs are aligned by their visible text (`w:t` + `w:delText`) via LCS; only aligned pairs are compared for formatting. This compares formatting *of the same content* and keeps content divergence (the text oracle's job) out of the formatting tallies.
+- **Character-weighted run comparison.** Within an aligned paragraph each character carries the canonical key of its nearest `w:r`'s `w:rPr`. Comparing per character makes the check agnostic to run splits — rebuild and inplace legitimately split runs differently — and weights divergence by how much text it affects.
+- **Canonical property keys.** Property containers are canonicalized by deep serialization with sorted attributes and sorted children, excluding revision-tracking elements (`w:rPrChange`, `w:pPrChange`, `w:tblPrChange`, `w:trPrChange`, `w:tcPrChange`, `w:sectPrChange`, `w:ins`, `w:del`, `w:cellIns`, `w:cellDel`, `w:cellMerge`). `w:sectPr` is excluded from `w:pPr` comparison and handled by the section dimension instead.
+- **Table formatting compared per paragraph via the enclosing chain.** Each paragraph carries the `w:tblPr`/`w:trPr`/`w:tcPr` chain of its enclosing tables (outermost-first). This captures table-property loss aligned to content without a separate table-grid alignment.
+- **Score = alignment coverage × mean of defined dimension scores.** Each dimension (run chars, paragraphs, paragraphs-in-tables, section breaks) scores `(compared − divergent) / compared`, or 1 when nothing was compared. Coverage is `2·aligned / (expectedParagraphs + actualParagraphs)`. Exact preservation scores exactly 1.0, so the score works as an exact-preservation gate as well as a ranking metric.
+- **Projection wrapper for candidate-vs-candidate use.** `compareProjectedFormattingFidelity` compares accept-all projections and reject-all projections (reusing `acceptAllChanges`/`rejectAllChanges` from `trackChangesAcceptorAst`), returning both reports and `min(accept.score, reject.score)`. Mirrors the projection-to-projection oracle stance from #347.
+- **`@xmldom/xmldom` via the existing `parseDocumentXml`** — project convention; no new XML dependency.
+
+## Risks / Trade-offs
+
+- O(n·m) LCS over paragraphs on very large documents → acceptable for a measurement/gate tool; documented on the entry point.
+- Section breaks are aligned by document-order index, not content; if content alignment shifts section breaks the section dimension may misattribute a divergence. Acceptable for the prototype; coverage already degrades the score when content diverges.
+- Paragraph-mark run properties (`w:pPr > w:rPr`) are included in paragraph comparison (revision marks stripped); benign mark-formatting differences between modes will surface as signal, which is the point of a discovery tool.
+
+## Migration Plan
+
+Pure addition — no behavior change to comparison output. Follow-ups wire the check into per-fix gates as inplace shapes are fixed.
+
+## Open Questions
+
+- Whether to weight dimensions by unit counts instead of the unweighted mean once real fallback-surface measurements exist.

--- a/openspec/changes/add-formatting-fidelity-comparison-check/proposal.md
+++ b/openspec/changes/add-formatting-fidelity-comparison-check/proposal.md
@@ -1,0 +1,18 @@
+# Change: Add formatting-fidelity comparison check
+
+## Why
+
+The rebuild-elimination campaign (#347 → #358/#359) needs to *measure* formatting loss, and no current gate can: the round-trip safety oracle compares text projections only, and the LibreOffice oracle's `paragraphShape()` records only paragraph count + visible-text presence. Rebuild mode reconstructs `document.xml` from atoms and silently drops formatting that inplace mode preserves — and that loss passes every existing check.
+
+## What Changes
+
+- Add a deterministic, in-engine formatting-fidelity comparison (`compareFormattingFidelity`) that aligns two `word/document.xml` views by paragraph text content and reports per-property divergence across run (`w:rPr`), paragraph (`w:pPr`), table (`w:tblPr`/`w:trPr`/`w:tcPr`), and section (`w:sectPr`) formatting, plus a scalar fidelity score in [0, 1].
+- Run formatting is compared character-by-character so differing run splits with identical formatting (the normal inplace-vs-rebuild structural difference) score perfect fidelity.
+- Add a projection-based wrapper (`compareProjectedFormattingFidelity`) that compares accept-all and reject-all projections of two candidates, making the check insensitive to revision-markup granularity differences — the same projection-to-projection stance the round-trip oracle adopted in #347.
+- LibreOffice is deliberately NOT used: it rewrites formatting on load/save (adds default `w:pPr`/`w:rPr`), so this must be an in-engine comparison over our own emitted XML.
+
+## Impact
+
+- Affected specs: `docx-comparison`
+- Affected code: `packages/docx-core/src/baselines/atomizer/formattingFidelity.ts` (new), `packages/docx-core/src/index.ts` (export)
+- Ref: #363 (enabler for the rebuild-elimination campaign behind the preserve semantics adopted in #347)

--- a/openspec/changes/add-formatting-fidelity-comparison-check/specs/docx-comparison/spec.md
+++ b/openspec/changes/add-formatting-fidelity-comparison-check/specs/docx-comparison/spec.md
@@ -1,0 +1,54 @@
+## ADDED Requirements
+
+### Requirement: Formatting-Fidelity Comparison Check
+
+The system SHALL provide a deterministic, in-engine formatting comparison `compareFormattingFidelity(expectedDocumentXml, actualDocumentXml)` that aligns the two views by paragraph text content and reports formatting divergence across run properties (`w:rPr`), paragraph properties (`w:pPr`), table properties (`w:tblPr`/`w:trPr`/`w:tcPr`), and section properties (`w:sectPr`), producing a structured per-property divergence report and a scalar formatting-fidelity score in [0, 1] where exact preservation scores exactly 1.0.
+
+#### Scenario: identical document views score perfect formatting fidelity
+
+- **WHEN** the same document.xml view is compared against itself
+- **THEN** the score is exactly 1.0 with zero divergences and zero unaligned paragraphs
+
+#### Scenario: dropped run bold is reported as a char-weighted run divergence
+
+- **WHEN** the actual view drops `w:b` from a run whose text is preserved
+- **THEN** a run-scope divergence with property "bold" and kind "removed" is reported, the run dimension counts the affected characters as divergent, and the score is below 1.0
+
+#### Scenario: differing run splits with identical formatting do not reduce fidelity
+
+- **WHEN** the actual view carries the same paragraph text split into different `w:r` boundaries with equivalent run properties
+- **THEN** the score is exactly 1.0 with zero divergences
+
+#### Scenario: dropped paragraph alignment is reported as a paragraph divergence
+
+- **WHEN** the actual view drops `w:jc` from a paragraph's `w:pPr`
+- **THEN** a paragraph-scope divergence with property "alignment" and kind "removed" is reported and the paragraph dimension records one divergent unit
+
+#### Scenario: dropped table cell shading is reported as a table divergence
+
+- **WHEN** the actual view drops `w:shd` from a table cell's `w:tcPr` while the cell text is preserved
+- **THEN** a table-scope divergence is reported and the table dimension records the affected paragraph as divergent
+
+#### Scenario: changed page size is reported as a section divergence
+
+- **WHEN** the actual view carries a `w:sectPr` whose `w:pgSz` differs from the expected view
+- **THEN** a section-scope divergence with property `w:pgSz` and kind "changed" is reported
+
+#### Scenario: unaligned paragraph content lowers alignment coverage not formatting tallies
+
+- **WHEN** a paragraph's text differs between the two views so it cannot be content-aligned
+- **THEN** the unaligned paragraph is counted in the unaligned tallies and lowers the score through alignment coverage, while the formatting dimensions count only aligned paragraphs
+
+### Requirement: Projection-Based Candidate Formatting Comparison
+
+The system SHALL provide `compareProjectedFormattingFidelity(expectedCandidateXml, actualCandidateXml)` that compares the accept-all projections and the reject-all projections of two tracked-changes candidates and returns both formatting-fidelity reports plus an overall score equal to the minimum of the two projection scores, so that revision-markup granularity differences between reconstruction modes do not register as formatting divergence.
+
+#### Scenario: projected fidelity ignores revision markup granularity differences
+
+- **WHEN** two candidates encode the same insertion with different `w:ins` wrapper and run granularity but identical formatting
+- **THEN** the overall projected score is exactly 1.0
+
+#### Scenario: pipeline inplace and rebuild candidates are measurable end-to-end
+
+- **WHEN** the comparison pipeline produces an inplace candidate and a rebuild candidate for the same original and revised documents
+- **THEN** the projected formatting-fidelity comparison of the two candidates returns well-formed accept and reject reports with scores in [0, 1]

--- a/openspec/changes/add-formatting-fidelity-comparison-check/tasks.md
+++ b/openspec/changes/add-formatting-fidelity-comparison-check/tasks.md
@@ -1,0 +1,7 @@
+## 1. Implementation
+
+- [x] 1.1 Add `formattingFidelity.ts` to the atomizer: paragraph-unit extraction (char-level rPr keys, pPr, table chain), LCS content alignment, canonical property keys, per-dimension tallies, divergence report, scalar score
+- [x] 1.2 Add `compareProjectedFormattingFidelity` projection wrapper over accept-all / reject-all
+- [x] 1.3 Export the new API from `@usejunior/docx-core`
+- [x] 1.4 Add traceability tests covering every scenario in the delta spec
+- [x] 1.5 Run the full pre-submit gate suite

--- a/packages/docx-core/src/baselines/atomizer/formattingFidelity.test.ts
+++ b/packages/docx-core/src/baselines/atomizer/formattingFidelity.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Traceability tests for the formatting-fidelity comparison check.
+ *
+ * The check is the formatting oracle the rebuild-elimination campaign needs:
+ * both existing oracles (round-trip text projections, LibreOffice
+ * paragraphShape) are formatting-blind, so rebuild's formatting loss passes
+ * every prior gate silently.
+ *
+ * @see https://github.com/UseJunior/safe-docx/issues/363
+ */
+
+import { describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
+import { buildDocxFromBodyXml } from '../../testing/ooxml-fixtures.js';
+import { DocxArchive } from '../../shared/docx/DocxArchive.js';
+import { compareDocumentsAtomizer } from './pipeline.js';
+import {
+  compareFormattingFidelity,
+  compareProjectedFormattingFidelity,
+} from './formattingFidelity.js';
+
+const TEST_FEATURE = 'add-formatting-fidelity-comparison-check';
+const test = testAllure.epic('Document Comparison').withLabels({ feature: TEST_FEATURE });
+const humanReadableTest = test.allure({
+  tags: ['human-readable'],
+  parameters: { audience: 'developers' },
+});
+
+function docXml(bodyXml: string): string {
+  return (
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
+    `<w:body>${bodyXml}</w:body></w:document>`
+  );
+}
+
+describe('Formatting-fidelity comparison check', () => {
+  humanReadableTest.openspec('identical document views score perfect formatting fidelity')(
+    'Scenario: identical document views score perfect formatting fidelity',
+    (_: AllureBddContext) => {
+      const view = docXml(
+        `<w:p><w:pPr><w:jc w:val="center"/></w:pPr>` +
+          `<w:r><w:rPr><w:b/></w:rPr><w:t>Bold heading</w:t></w:r></w:p>` +
+          `<w:tbl><w:tblPr><w:tblW w:w="5000" w:type="pct"/></w:tblPr>` +
+          `<w:tr><w:tc><w:tcPr><w:shd w:val="clear" w:fill="DDDDDD"/></w:tcPr>` +
+          `<w:p><w:r><w:t>cell</w:t></w:r></w:p></w:tc></w:tr></w:tbl>` +
+          `<w:sectPr><w:pgSz w:w="11906" w:h="16838"/></w:sectPr>`,
+      );
+
+      const report = compareFormattingFidelity(view, view);
+
+      expect(report.score).toBe(1);
+      expect(report.divergences).toEqual([]);
+      expect(report.unalignedExpectedParagraphs).toBe(0);
+      expect(report.unalignedActualParagraphs).toBe(0);
+    },
+  );
+
+  humanReadableTest.openspec('dropped run bold is reported as a char-weighted run divergence')(
+    'Scenario: dropped run bold is reported as a char-weighted run divergence',
+    (_: AllureBddContext) => {
+      const expected = docXml(
+        `<w:p><w:r><w:rPr><w:b/></w:rPr><w:t>Bold text</w:t></w:r>` +
+          `<w:r><w:t> stays plain</w:t></w:r></w:p>`,
+      );
+      const actual = docXml(
+        `<w:p><w:r><w:t>Bold text</w:t></w:r><w:r><w:t> stays plain</w:t></w:r></w:p>`,
+      );
+
+      const report = compareFormattingFidelity(expected, actual);
+
+      expect(report.score).toBeLessThan(1);
+      expect(report.runFormatting.divergent).toBe('Bold text'.length);
+      expect(report.runFormatting.compared).toBe('Bold text stays plain'.length);
+      const bold = report.divergences.find((d) => d.property === 'bold');
+      expect(bold).toMatchObject({
+        scope: 'run',
+        kind: 'removed',
+        paragraphIndex: 0,
+        textSample: 'Bold text',
+      });
+    },
+  );
+
+  humanReadableTest.openspec('differing run splits with identical formatting do not reduce fidelity')(
+    'Scenario: differing run splits with identical formatting do not reduce fidelity',
+    (_: AllureBddContext) => {
+      const expected = docXml(
+        `<w:p><w:r><w:rPr><w:i/></w:rPr><w:t>Hello world</w:t></w:r></w:p>`,
+      );
+      // Same text and formatting, split into three runs (what rebuild vs
+      // inplace legitimately produce differently).
+      const actual = docXml(
+        `<w:p><w:r><w:rPr><w:i/></w:rPr><w:t>Hel</w:t></w:r>` +
+          `<w:r><w:rPr><w:i/></w:rPr><w:t>lo wo</w:t></w:r>` +
+          `<w:r><w:rPr><w:i/></w:rPr><w:t>rld</w:t></w:r></w:p>`,
+      );
+
+      const report = compareFormattingFidelity(expected, actual);
+
+      expect(report.score).toBe(1);
+      expect(report.divergences).toEqual([]);
+    },
+  );
+
+  humanReadableTest.openspec('dropped paragraph alignment is reported as a paragraph divergence')(
+    'Scenario: dropped paragraph alignment is reported as a paragraph divergence',
+    (_: AllureBddContext) => {
+      const expected = docXml(
+        `<w:p><w:pPr><w:jc w:val="center"/></w:pPr><w:r><w:t>Centered</w:t></w:r></w:p>`,
+      );
+      const actual = docXml(`<w:p><w:r><w:t>Centered</w:t></w:r></w:p>`);
+
+      const report = compareFormattingFidelity(expected, actual);
+
+      expect(report.paragraphFormatting.divergent).toBe(1);
+      const alignment = report.divergences.find((d) => d.property === 'alignment');
+      expect(alignment).toMatchObject({ scope: 'paragraph', kind: 'removed', paragraphIndex: 0 });
+      expect(report.score).toBeLessThan(1);
+    },
+  );
+
+  humanReadableTest.openspec('dropped table cell shading is reported as a table divergence')(
+    'Scenario: dropped table cell shading is reported as a table divergence',
+    (_: AllureBddContext) => {
+      const table = (tcPr: string): string =>
+        `<w:tbl><w:tblPr><w:tblW w:w="5000" w:type="pct"/></w:tblPr>` +
+        `<w:tr><w:tc>${tcPr}<w:p><w:r><w:t>cell text</w:t></w:r></w:p></w:tc></w:tr></w:tbl>`;
+      const expected = docXml(table(`<w:tcPr><w:shd w:val="clear" w:fill="FF0000"/></w:tcPr>`));
+      const actual = docXml(table(''));
+
+      const report = compareFormattingFidelity(expected, actual);
+
+      expect(report.tableFormatting.compared).toBe(1);
+      expect(report.tableFormatting.divergent).toBe(1);
+      const shading = report.divergences.find((d) => d.scope === 'table');
+      expect(shading).toMatchObject({ property: 'w:shd', kind: 'removed', textSample: 'cell text' });
+      expect(report.score).toBeLessThan(1);
+    },
+  );
+
+  humanReadableTest.openspec('changed page size is reported as a section divergence')(
+    'Scenario: changed page size is reported as a section divergence',
+    (_: AllureBddContext) => {
+      const body = (pgSz: string): string =>
+        `<w:p><w:r><w:t>content</w:t></w:r></w:p><w:sectPr>${pgSz}</w:sectPr>`;
+      const expected = docXml(body(`<w:pgSz w:w="11906" w:h="16838"/>`));
+      const actual = docXml(body(`<w:pgSz w:w="12240" w:h="15840"/>`));
+
+      const report = compareFormattingFidelity(expected, actual);
+
+      expect(report.sectionFormatting.divergent).toBe(1);
+      const pgSz = report.divergences.find((d) => d.scope === 'section');
+      expect(pgSz).toMatchObject({ property: 'w:pgSz', kind: 'changed', paragraphIndex: -1 });
+      expect(report.score).toBeLessThan(1);
+    },
+  );
+
+  humanReadableTest.openspec('unaligned paragraph content lowers alignment coverage not formatting tallies')(
+    'Scenario: unaligned paragraph content lowers alignment coverage not formatting tallies',
+    (_: AllureBddContext) => {
+      const expected = docXml(
+        `<w:p><w:r><w:t>Alpha</w:t></w:r></w:p><w:p><w:r><w:t>Beta</w:t></w:r></w:p>`,
+      );
+      const actual = docXml(
+        `<w:p><w:r><w:t>Alpha</w:t></w:r></w:p><w:p><w:r><w:t>Gamma</w:t></w:r></w:p>`,
+      );
+
+      const report = compareFormattingFidelity(expected, actual);
+
+      expect(report.unalignedExpectedParagraphs).toBe(1);
+      expect(report.unalignedActualParagraphs).toBe(1);
+      // Only the aligned "Alpha" paragraph enters the formatting tallies …
+      expect(report.paragraphFormatting.compared).toBe(1);
+      expect(report.paragraphFormatting.divergent).toBe(0);
+      expect(report.runFormatting.compared).toBe('Alpha'.length);
+      expect(report.divergences).toEqual([]);
+      // … while the content mismatch degrades the score through coverage.
+      expect(report.score).toBeCloseTo(0.5, 5);
+    },
+  );
+
+  humanReadableTest.openspec('projected fidelity ignores revision markup granularity differences')(
+    'Scenario: projected fidelity ignores revision markup granularity differences',
+    (_: AllureBddContext) => {
+      // The same tracked insertion, encoded as one w:ins wrapper …
+      const coarse = docXml(
+        `<w:p><w:r><w:t>Existing </w:t></w:r>` +
+          `<w:ins w:id="1" w:author="A" w:date="2026-06-01T00:00:00Z">` +
+          `<w:r><w:rPr><w:b/></w:rPr><w:t>new bold</w:t></w:r></w:ins></w:p>`,
+      );
+      // … and as two w:ins wrappers with split runs.
+      const fine = docXml(
+        `<w:p><w:r><w:t>Existing </w:t></w:r>` +
+          `<w:ins w:id="2" w:author="A" w:date="2026-06-01T00:00:00Z">` +
+          `<w:r><w:rPr><w:b/></w:rPr><w:t>new </w:t></w:r></w:ins>` +
+          `<w:ins w:id="3" w:author="A" w:date="2026-06-01T00:00:00Z">` +
+          `<w:r><w:rPr><w:b/></w:rPr><w:t>bold</w:t></w:r></w:ins></w:p>`,
+      );
+
+      const result = compareProjectedFormattingFidelity(coarse, fine);
+
+      expect(result.accept.divergences).toEqual([]);
+      expect(result.reject.divergences).toEqual([]);
+      expect(result.score).toBe(1);
+    },
+  );
+
+  humanReadableTest.openspec('pipeline inplace and rebuild candidates are measurable end-to-end')(
+    'Scenario: pipeline inplace and rebuild candidates are measurable end-to-end',
+    async (_: AllureBddContext) => {
+      const original = await buildDocxFromBodyXml(
+        `<w:p><w:pPr><w:jc w:val="center"/></w:pPr>` +
+          `<w:r><w:rPr><w:b/></w:rPr><w:t>Heading stays put</w:t></w:r></w:p>` +
+          `<w:p><w:r><w:t>The quick brown fox.</w:t></w:r></w:p>`,
+      );
+      const revised = await buildDocxFromBodyXml(
+        `<w:p><w:pPr><w:jc w:val="center"/></w:pPr>` +
+          `<w:r><w:rPr><w:b/></w:rPr><w:t>Heading stays put</w:t></w:r></w:p>` +
+          `<w:p><w:r><w:t>The quick red fox.</w:t></w:r></w:p>`,
+      );
+
+      const options = { author: 'Fidelity Test', date: new Date('2026-06-01T00:00:00Z') };
+      const inplace = await compareDocumentsAtomizer(original, revised, {
+        ...options,
+        reconstructionMode: 'inplace',
+      });
+      const rebuild = await compareDocumentsAtomizer(original, revised, {
+        ...options,
+        reconstructionMode: 'rebuild',
+      });
+      const inplaceXml = await (await DocxArchive.load(inplace.document)).getDocumentXml();
+      const rebuildXml = await (await DocxArchive.load(rebuild.document)).getDocumentXml();
+
+      const result = compareProjectedFormattingFidelity(inplaceXml, rebuildXml);
+
+      for (const report of [result.accept, result.reject]) {
+        expect(report.score).toBeGreaterThanOrEqual(0);
+        expect(report.score).toBeLessThanOrEqual(1);
+        expect(report.runFormatting.compared).toBeGreaterThan(0);
+        expect(report.paragraphFormatting.compared).toBeGreaterThan(0);
+      }
+      expect(result.score).toBe(Math.min(result.accept.score, result.reject.score));
+    },
+  );
+});

--- a/packages/docx-core/src/baselines/atomizer/formattingFidelity.ts
+++ b/packages/docx-core/src/baselines/atomizer/formattingFidelity.ts
@@ -1,0 +1,632 @@
+/**
+ * Formatting-Fidelity Comparison Check
+ *
+ * Deterministic, in-engine measurement of formatting divergence between two
+ * word/document.xml views (e.g. inplace candidate vs rebuild candidate, or
+ * candidate vs expected). Both existing safety oracles are formatting-blind:
+ * the round-trip oracle compares text projections and the LibreOffice
+ * oracle's paragraphShape() records only paragraph count + visible-text
+ * presence — so rebuild mode's formatting loss passes every current gate
+ * silently. This module quantifies that loss and gates inplace fixes.
+ *
+ * Alignment strategy: paragraphs are aligned by their visible text content
+ * (LCS over paragraph texts), then run formatting is compared character by
+ * character within each aligned pair. Comparing per character — not per run —
+ * makes the check agnostic to run splits, which rebuild and inplace
+ * legitimately produce differently. Content divergence is the text oracle's
+ * job and is reported separately as alignment coverage, not folded into the
+ * formatting tallies.
+ *
+ * LibreOffice is deliberately not involved: it rewrites formatting on
+ * load/save (adds default w:pPr/w:rPr), so it cannot serve as a formatting
+ * oracle. This comparison runs entirely over our own emitted XML.
+ *
+ * @see https://github.com/UseJunior/safe-docx/issues/363
+ */
+
+import { parseDocumentXml } from './xmlToWmlElement.js';
+import { acceptAllChanges, rejectAllChanges } from './trackChangesAcceptorAst.js';
+import { childElements, findChildByTagName } from '../../primitives/index.js';
+import { RUN_PROPERTY_FRIENDLY_NAMES } from '../../core-types.js';
+import { PARAGRAPH_PROPERTY_FRIENDLY_NAMES } from '../../format-detection.js';
+
+// =============================================================================
+// Report types
+// =============================================================================
+
+export type FormattingScope = 'run' | 'paragraph' | 'table' | 'section';
+
+export type FormattingDivergenceKind = 'added' | 'removed' | 'changed';
+
+export interface FormattingDivergence {
+  scope: FormattingScope;
+  /** Friendly property name when known (e.g. "bold"), else the OOXML tag. */
+  property: string;
+  /** "added"/"removed" are relative to the expected view. */
+  kind: FormattingDivergenceKind;
+  /** Canonical serialization of the property in the expected view. */
+  expectedValue: string | null;
+  /** Canonical serialization of the property in the actual view. */
+  actualValue: string | null;
+  /**
+   * Document-order paragraph index in the expected view, or -1 for
+   * section-scope divergences (section breaks are aligned by index, not
+   * anchored to a paragraph).
+   */
+  paragraphIndex: number;
+  /** Aligned text the divergence applies to (truncated). */
+  textSample: string;
+}
+
+export interface FormattingDimensionTally {
+  /** Units compared: chars (run), paragraphs (paragraph/table), section breaks (section). */
+  compared: number;
+  divergent: number;
+  /** (compared - divergent) / compared; 1 when nothing was compared. */
+  score: number;
+}
+
+export interface FormattingFidelityReport {
+  /**
+   * Alignment coverage × mean of the dimension scores that compared at
+   * least one unit. Exactly 1.0 iff content aligned fully and no formatting
+   * diverged, so the score doubles as an exact-preservation gate.
+   */
+  score: number;
+  /** Character-weighted w:rPr comparison over aligned paragraph text. */
+  runFormatting: FormattingDimensionTally;
+  /** Per-paragraph w:pPr comparison (w:sectPr handled by the section dimension). */
+  paragraphFormatting: FormattingDimensionTally;
+  /** Per-paragraph w:tblPr/w:trPr/w:tcPr chain comparison for paragraphs inside tables. */
+  tableFormatting: FormattingDimensionTally;
+  /** Per-section-break w:sectPr comparison, aligned by document-order index. */
+  sectionFormatting: FormattingDimensionTally;
+  /** Paragraphs whose text could not be content-aligned (content divergence, not formatting). */
+  unalignedExpectedParagraphs: number;
+  unalignedActualParagraphs: number;
+  divergences: FormattingDivergence[];
+}
+
+// =============================================================================
+// Canonical property keys
+// =============================================================================
+
+/**
+ * Revision-tracking elements excluded from canonicalization at every depth.
+ * Two views that differ only in tracked-change provenance markup carry the
+ * same formatting.
+ */
+const REVISION_PROPERTY_TAGS = new Set([
+  'w:rPrChange',
+  'w:pPrChange',
+  'w:tblPrChange',
+  'w:trPrChange',
+  'w:tcPrChange',
+  'w:sectPrChange',
+  'w:ins',
+  'w:del',
+  'w:cellIns',
+  'w:cellDel',
+  'w:cellMerge',
+]);
+
+/** w:sectPr inside w:pPr is a section break — owned by the section dimension. */
+const PPR_EXCLUDED_TAGS = new Set([...REVISION_PROPERTY_TAGS, 'w:sectPr']);
+
+/**
+ * Canonical serialization: sorted attributes, children sorted by their own
+ * canonical form, revision markup dropped. A comparison key, not output XML —
+ * sorting trades element-order semantics for emitter-order independence.
+ */
+function canonicalizeElement(el: Element): string {
+  const attrs: string[] = [];
+  for (let i = 0; i < el.attributes.length; i++) {
+    const attr = el.attributes[i]!;
+    attrs.push(`${attr.name}="${attr.value}"`);
+  }
+  attrs.sort();
+  const attrPart = attrs.length > 0 ? ` ${attrs.join(' ')}` : '';
+
+  const children = childElements(el)
+    .filter((child) => !REVISION_PROPERTY_TAGS.has(child.tagName))
+    .map(canonicalizeElement)
+    .sort();
+  if (children.length === 0) {
+    const text = (el.textContent ?? '').trim();
+    return text.length > 0
+      ? `<${el.tagName}${attrPart}>${text}</${el.tagName}>`
+      : `<${el.tagName}${attrPart}/>`;
+  }
+  return `<${el.tagName}${attrPart}>${children.join('')}</${el.tagName}>`;
+}
+
+/**
+ * Map of property tag → canonical serialization for the direct children of a
+ * property container (w:rPr, w:pPr, w:tcPr, ...). Repeated tags are merged
+ * into one sorted entry. An absent container equals an empty one.
+ */
+function propertyMap(
+  container: Element | null,
+  excludedTags: ReadonlySet<string>,
+): Map<string, string> {
+  const collected = new Map<string, string[]>();
+  if (container) {
+    for (const child of childElements(container)) {
+      if (excludedTags.has(child.tagName)) continue;
+      const existing = collected.get(child.tagName);
+      if (existing) existing.push(canonicalizeElement(child));
+      else collected.set(child.tagName, [canonicalizeElement(child)]);
+    }
+  }
+  const merged = new Map<string, string>();
+  for (const [tag, values] of collected) {
+    merged.set(tag, values.sort().join(''));
+  }
+  return merged;
+}
+
+function containerKey(props: Map<string, string>): string {
+  return [...props.keys()]
+    .sort()
+    .map((tag) => props.get(tag)!)
+    .join('');
+}
+
+interface PropertyDiff {
+  property: string;
+  kind: FormattingDivergenceKind;
+  expectedValue: string | null;
+  actualValue: string | null;
+}
+
+function diffPropertyMaps(
+  expected: Map<string, string>,
+  actual: Map<string, string>,
+  friendlyNames: Record<string, string>,
+): PropertyDiff[] {
+  const diffs: PropertyDiff[] = [];
+  const allTags = [...new Set([...expected.keys(), ...actual.keys()])].sort();
+  for (const tag of allTags) {
+    const expectedValue = expected.get(tag);
+    const actualValue = actual.get(tag);
+    if (expectedValue === actualValue) continue;
+    diffs.push({
+      property: friendlyNames[tag] ?? tag,
+      kind:
+        expectedValue === undefined
+          ? 'added'
+          : actualValue === undefined
+            ? 'removed'
+            : 'changed',
+      expectedValue: expectedValue ?? null,
+      actualValue: actualValue ?? null,
+    });
+  }
+  return diffs;
+}
+
+// =============================================================================
+// Paragraph unit extraction
+// =============================================================================
+
+interface TableChainLevel {
+  tblPr: Element | null;
+  trPr: Element | null;
+  tcPr: Element | null;
+}
+
+interface ParagraphUnit {
+  /** Document-order index of this paragraph within its view. */
+  index: number;
+  /** Visible text: concatenated w:t + w:delText character content. */
+  text: string;
+  /** Canonical w:rPr key per character of `text`. */
+  charRPrKeys: string[];
+  /** The w:rPr element each character's key was derived from (for divergence detail). */
+  charRPrElements: (Element | null)[];
+  pPrProps: Map<string, string>;
+  pPrKey: string;
+  /** Enclosing table property chain, outermost table first; empty outside tables. */
+  tableChain: TableChainLevel[];
+  tableKey: string;
+}
+
+function tableLevelKey(level: TableChainLevel): string {
+  return [
+    containerKey(propertyMap(level.tblPr, REVISION_PROPERTY_TAGS)),
+    containerKey(propertyMap(level.trPr, REVISION_PROPERTY_TAGS)),
+    containerKey(propertyMap(level.tcPr, REVISION_PROPERTY_TAGS)),
+  ].join('§');
+}
+
+function collectRunText(
+  el: Element,
+  currentRPrKey: string,
+  currentRPr: Element | null,
+  unit: ParagraphUnit,
+): void {
+  for (const child of childElements(el)) {
+    if (child.tagName === 'w:pPr') continue;
+    if (child.tagName === 'w:r') {
+      const rPr = findChildByTagName(child, 'w:rPr');
+      const key = containerKey(propertyMap(rPr, REVISION_PROPERTY_TAGS));
+      collectRunText(child, key, rPr, unit);
+      continue;
+    }
+    if (child.tagName === 'w:t' || child.tagName === 'w:delText') {
+      const text = child.textContent ?? '';
+      unit.text += text;
+      for (let i = 0; i < text.length; i++) {
+        unit.charRPrKeys.push(currentRPrKey);
+        unit.charRPrElements.push(currentRPr);
+      }
+      continue;
+    }
+    // Recurse through revision wrappers, hyperlinks, smart tags, sdt, ...
+    collectRunText(child, currentRPrKey, currentRPr, unit);
+  }
+}
+
+function buildParagraphUnit(
+  paragraph: Element,
+  chain: TableChainLevel[],
+  index: number,
+): ParagraphUnit {
+  const pPr = findChildByTagName(paragraph, 'w:pPr');
+  const pPrProps = propertyMap(pPr, PPR_EXCLUDED_TAGS);
+  const unit: ParagraphUnit = {
+    index,
+    text: '',
+    charRPrKeys: [],
+    charRPrElements: [],
+    pPrProps,
+    pPrKey: containerKey(pPrProps),
+    tableChain: chain,
+    tableKey: chain.map(tableLevelKey).join('|'),
+  };
+  collectRunText(paragraph, '', null, unit);
+  return unit;
+}
+
+function collectParagraphUnits(
+  container: Element,
+  chain: TableChainLevel[],
+  out: ParagraphUnit[],
+): void {
+  for (const child of childElements(container)) {
+    if (child.tagName === 'w:p') {
+      out.push(buildParagraphUnit(child, chain, out.length));
+      continue;
+    }
+    if (child.tagName === 'w:tbl') {
+      const tblPr = findChildByTagName(child, 'w:tblPr');
+      for (const row of childElements(child)) {
+        if (row.tagName !== 'w:tr') continue;
+        const trPr = findChildByTagName(row, 'w:trPr');
+        for (const cell of childElements(row)) {
+          if (cell.tagName !== 'w:tc') continue;
+          const tcPr = findChildByTagName(cell, 'w:tcPr');
+          collectParagraphUnits(cell, [...chain, { tblPr, trPr, tcPr }], out);
+        }
+      }
+      continue;
+    }
+    // Recurse through sdt/customXml/revision wrappers that can hold blocks.
+    collectParagraphUnits(child, chain, out);
+  }
+}
+
+function collectSectionProperties(root: Element): Element[] {
+  const out: Element[] = [];
+  const walk = (el: Element): void => {
+    for (const child of childElements(el)) {
+      if (child.tagName === 'w:sectPr') {
+        out.push(child);
+        continue;
+      }
+      walk(child);
+    }
+  };
+  walk(root);
+  return out;
+}
+
+// =============================================================================
+// Content alignment
+// =============================================================================
+
+/**
+ * LCS over paragraph texts. O(n·m) — fine for a measurement/gate tool, not
+ * intended for hot paths.
+ */
+function alignParagraphsByText(
+  expected: ParagraphUnit[],
+  actual: ParagraphUnit[],
+): Array<[ParagraphUnit, ParagraphUnit]> {
+  if (
+    expected.length === actual.length &&
+    expected.every((unit, i) => unit.text === actual[i]!.text)
+  ) {
+    return expected.map((unit, i) => [unit, actual[i]!]);
+  }
+
+  const n = expected.length;
+  const m = actual.length;
+  const table: number[] = new Array((n + 1) * (m + 1)).fill(0);
+  const at = (i: number, j: number): number => i * (m + 1) + j;
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      table[at(i, j)] =
+        expected[i]!.text === actual[j]!.text
+          ? table[at(i + 1, j + 1)]! + 1
+          : Math.max(table[at(i + 1, j)]!, table[at(i, j + 1)]!);
+    }
+  }
+
+  const pairs: Array<[ParagraphUnit, ParagraphUnit]> = [];
+  let i = 0;
+  let j = 0;
+  while (i < n && j < m) {
+    if (expected[i]!.text === actual[j]!.text) {
+      pairs.push([expected[i]!, actual[j]!]);
+      i++;
+      j++;
+    } else if (table[at(i + 1, j)]! >= table[at(i, j + 1)]!) {
+      i++;
+    } else {
+      j++;
+    }
+  }
+  return pairs;
+}
+
+// =============================================================================
+// Comparison
+// =============================================================================
+
+const TEXT_SAMPLE_LIMIT = 80;
+
+function sampleText(text: string): string {
+  return text.length > TEXT_SAMPLE_LIMIT ? `${text.slice(0, TEXT_SAMPLE_LIMIT)}…` : text;
+}
+
+function makeTally(compared: number, divergent: number): FormattingDimensionTally {
+  return {
+    compared,
+    divergent,
+    score: compared === 0 ? 1 : (compared - divergent) / compared,
+  };
+}
+
+function compareRunFormatting(
+  pairs: Array<[ParagraphUnit, ParagraphUnit]>,
+  divergences: FormattingDivergence[],
+): FormattingDimensionTally {
+  let compared = 0;
+  let divergent = 0;
+  for (const [expected, actual] of pairs) {
+    compared += expected.text.length;
+    let rangeStart = -1;
+    const flushRange = (end: number): void => {
+      if (rangeStart < 0) return;
+      const diffs = diffPropertyMaps(
+        propertyMap(expected.charRPrElements[rangeStart] ?? null, REVISION_PROPERTY_TAGS),
+        propertyMap(actual.charRPrElements[rangeStart] ?? null, REVISION_PROPERTY_TAGS),
+        RUN_PROPERTY_FRIENDLY_NAMES,
+      );
+      const textSample = sampleText(expected.text.slice(rangeStart, end));
+      for (const diff of diffs) {
+        divergences.push({
+          scope: 'run',
+          paragraphIndex: expected.index,
+          textSample,
+          ...diff,
+        });
+      }
+      rangeStart = -1;
+    };
+    for (let i = 0; i < expected.text.length; i++) {
+      if (expected.charRPrKeys[i] === actual.charRPrKeys[i]) {
+        flushRange(i);
+        continue;
+      }
+      divergent++;
+      // Coalesce contiguous chars with the same key pair into one report range.
+      if (
+        rangeStart >= 0 &&
+        (expected.charRPrKeys[i] !== expected.charRPrKeys[rangeStart] ||
+          actual.charRPrKeys[i] !== actual.charRPrKeys[rangeStart])
+      ) {
+        flushRange(i);
+      }
+      if (rangeStart < 0) rangeStart = i;
+    }
+    flushRange(expected.text.length);
+  }
+  return makeTally(compared, divergent);
+}
+
+function compareParagraphFormatting(
+  pairs: Array<[ParagraphUnit, ParagraphUnit]>,
+  divergences: FormattingDivergence[],
+): FormattingDimensionTally {
+  let divergent = 0;
+  for (const [expected, actual] of pairs) {
+    if (expected.pPrKey === actual.pPrKey) continue;
+    divergent++;
+    for (const diff of diffPropertyMaps(
+      expected.pPrProps,
+      actual.pPrProps,
+      PARAGRAPH_PROPERTY_FRIENDLY_NAMES,
+    )) {
+      divergences.push({
+        scope: 'paragraph',
+        paragraphIndex: expected.index,
+        textSample: sampleText(expected.text),
+        ...diff,
+      });
+    }
+  }
+  return makeTally(pairs.length, divergent);
+}
+
+function compareTableFormatting(
+  pairs: Array<[ParagraphUnit, ParagraphUnit]>,
+  divergences: FormattingDivergence[],
+): FormattingDimensionTally {
+  let compared = 0;
+  let divergent = 0;
+  for (const [expected, actual] of pairs) {
+    if (expected.tableChain.length === 0 && actual.tableChain.length === 0) continue;
+    compared++;
+    if (expected.tableKey === actual.tableKey) continue;
+    divergent++;
+    if (expected.tableChain.length !== actual.tableChain.length) {
+      divergences.push({
+        scope: 'table',
+        property: 'tableNesting',
+        kind: 'changed',
+        expectedValue: String(expected.tableChain.length),
+        actualValue: String(actual.tableChain.length),
+        paragraphIndex: expected.index,
+        textSample: sampleText(expected.text),
+      });
+      continue;
+    }
+    for (let level = 0; level < expected.tableChain.length; level++) {
+      const expectedLevel = expected.tableChain[level]!;
+      const actualLevel = actual.tableChain[level]!;
+      const containers: Array<[Element | null, Element | null]> = [
+        [expectedLevel.tblPr, actualLevel.tblPr],
+        [expectedLevel.trPr, actualLevel.trPr],
+        [expectedLevel.tcPr, actualLevel.tcPr],
+      ];
+      for (const [expectedContainer, actualContainer] of containers) {
+        for (const diff of diffPropertyMaps(
+          propertyMap(expectedContainer, REVISION_PROPERTY_TAGS),
+          propertyMap(actualContainer, REVISION_PROPERTY_TAGS),
+          {},
+        )) {
+          divergences.push({
+            scope: 'table',
+            paragraphIndex: expected.index,
+            textSample: sampleText(expected.text),
+            ...diff,
+          });
+        }
+      }
+    }
+  }
+  return makeTally(compared, divergent);
+}
+
+function compareSectionFormatting(
+  expectedRoot: Element,
+  actualRoot: Element,
+  divergences: FormattingDivergence[],
+): FormattingDimensionTally {
+  const expectedSections = collectSectionProperties(expectedRoot);
+  const actualSections = collectSectionProperties(actualRoot);
+  const compared = Math.max(expectedSections.length, actualSections.length);
+  let divergent = 0;
+  for (let i = 0; i < compared; i++) {
+    const expectedProps = propertyMap(expectedSections[i] ?? null, REVISION_PROPERTY_TAGS);
+    const actualProps = propertyMap(actualSections[i] ?? null, REVISION_PROPERTY_TAGS);
+    if (containerKey(expectedProps) === containerKey(actualProps)) continue;
+    divergent++;
+    for (const diff of diffPropertyMaps(expectedProps, actualProps, {})) {
+      divergences.push({
+        scope: 'section',
+        paragraphIndex: -1,
+        textSample: '',
+        ...diff,
+      });
+    }
+  }
+  return makeTally(compared, divergent);
+}
+
+/**
+ * Compare the formatting carried by two word/document.xml views.
+ *
+ * The views are expected to hold comparable content (e.g. two reconstruction
+ * candidates for the same comparison, or the same projection of each); use
+ * compareProjectedFormattingFidelity to compare tracked-changes candidates
+ * whose revision-markup granularity may differ.
+ */
+export function compareFormattingFidelity(
+  expectedDocumentXml: string,
+  actualDocumentXml: string,
+): FormattingFidelityReport {
+  const expectedRoot = parseDocumentXml(expectedDocumentXml);
+  const actualRoot = parseDocumentXml(actualDocumentXml);
+
+  const expectedUnits: ParagraphUnit[] = [];
+  const actualUnits: ParagraphUnit[] = [];
+  collectParagraphUnits(expectedRoot, [], expectedUnits);
+  collectParagraphUnits(actualRoot, [], actualUnits);
+
+  const pairs = alignParagraphsByText(expectedUnits, actualUnits);
+
+  const divergences: FormattingDivergence[] = [];
+  const runFormatting = compareRunFormatting(pairs, divergences);
+  const paragraphFormatting = compareParagraphFormatting(pairs, divergences);
+  const tableFormatting = compareTableFormatting(pairs, divergences);
+  const sectionFormatting = compareSectionFormatting(expectedRoot, actualRoot, divergences);
+
+  const totalParagraphs = expectedUnits.length + actualUnits.length;
+  const alignmentCoverage = totalParagraphs === 0 ? 1 : (2 * pairs.length) / totalParagraphs;
+  const dimensions = [runFormatting, paragraphFormatting, tableFormatting, sectionFormatting].filter(
+    (dimension) => dimension.compared > 0,
+  );
+  const dimensionScore =
+    dimensions.length === 0
+      ? 1
+      : dimensions.reduce((sum, dimension) => sum + dimension.score, 0) / dimensions.length;
+
+  return {
+    score: alignmentCoverage * dimensionScore,
+    runFormatting,
+    paragraphFormatting,
+    tableFormatting,
+    sectionFormatting,
+    unalignedExpectedParagraphs: expectedUnits.length - pairs.length,
+    unalignedActualParagraphs: actualUnits.length - pairs.length,
+    divergences,
+  };
+}
+
+// =============================================================================
+// Projection-based candidate comparison
+// =============================================================================
+
+export interface ProjectedFormattingFidelity {
+  /** Fidelity of accept-all(actual) measured against accept-all(expected). */
+  accept: FormattingFidelityReport;
+  /** Fidelity of reject-all(actual) measured against reject-all(expected). */
+  reject: FormattingFidelityReport;
+  /** min(accept.score, reject.score) — a candidate must preserve both projections. */
+  score: number;
+}
+
+/**
+ * Compare two tracked-changes candidates projection-to-projection, the same
+ * stance the round-trip text oracle adopted in #347: accept-all and
+ * reject-all projections strip revision markup, so candidates that encode
+ * the same result with different w:ins/w:del granularity score 1.0 unless
+ * their formatting actually diverges.
+ */
+export function compareProjectedFormattingFidelity(
+  expectedCandidateXml: string,
+  actualCandidateXml: string,
+): ProjectedFormattingFidelity {
+  const accept = compareFormattingFidelity(
+    acceptAllChanges(expectedCandidateXml),
+    acceptAllChanges(actualCandidateXml),
+  );
+  const reject = compareFormattingFidelity(
+    rejectAllChanges(expectedCandidateXml),
+    rejectAllChanges(actualCandidateXml),
+  );
+  return { accept, reject, score: Math.min(accept.score, reject.score) };
+}

--- a/packages/docx-core/src/index.ts
+++ b/packages/docx-core/src/index.ts
@@ -86,6 +86,9 @@ export * from './move-detection.js';
 // Re-export format detection
 export * from './format-detection.js';
 
+// Re-export the formatting-fidelity comparison check
+export * from './baselines/atomizer/formattingFidelity.js';
+
 // Re-export numbering utilities
 export * from './numbering.js';
 


### PR DESCRIPTION
## Why

Closes #363.

The rebuild-elimination campaign (#347 → #358/#359) needs to *measure* formatting loss, and no current gate can: the round-trip safety oracle compares text projections only, and the LibreOffice oracle's `paragraphShape()` records only paragraph count + visible-text presence. Rebuild reconstructs `document.xml` from atoms and silently drops formatting that inplace preserves — and that loss passes every existing check.

## What

**`compareFormattingFidelity(expectedXml, actualXml)`** — deterministic, in-engine comparison of two `word/document.xml` views:

- **Content-anchored alignment**: paragraphs aligned by visible text (LCS), so it compares formatting *of the same content*, not raw XML diff noise. Content divergence is reported as alignment coverage, separately from the formatting tallies.
- **Char-weighted run comparison**: each character carries the canonical key of its nearest `w:rPr`; differing run splits with identical formatting (the normal inplace-vs-rebuild structural difference) register as zero divergence.
- **Four dimensions**: run (`w:rPr`), paragraph (`w:pPr`), table (`w:tblPr`/`w:trPr`/`w:tcPr` chain per paragraph-in-table), section (`w:sectPr`).
- **Output**: structured per-property divergence report (scope, friendly property name, added/removed/changed, canonical values, paragraph index, text sample) + a scalar score in [0,1] where **exact preservation scores exactly 1.0** — usable both as a ranking metric and an exact-preservation gate.

**`compareProjectedFormattingFidelity(expectedCandidate, actualCandidate)`** — compares accept-all and reject-all projections of two tracked-changes candidates (the projection-to-projection stance from #347), returning both reports plus `min(accept.score, reject.score)`. This is the entry point for "assert inplace fidelity ≥ rebuild's" per-fix gates.

Per the issue's note, LibreOffice is deliberately **not** used: it rewrites formatting on load/save, so the check is in-engine over our own emitted XML. Parsing reuses the existing `parseDocumentXml` (`@xmldom/xmldom`).

## Sanity measurement (use-case wiring)

Ran the check over real pipeline outputs (inplace vs rebuild candidates for the same edit on a doc with centered bold heading, indentation, italic span, shaded table cell): both modes measurable end-to-end; on this rebuild-safe shape the score is exactly 1.0 across both projections (`run 0/96+, para 0/3, table 0/1, sect 0/1`), confirming the gate property that identical formatting scores perfect fidelity. Quantifying the currently-failing fallback surface is the campaign follow-up this check enables.

## OpenSpec

Change `add-formatting-fidelity-comparison-check`: two ADDED requirements on `docx-comparison`, validated `--strict`; every delta scenario is covered by a `.openspec()`-tagged test in the new traceability test file (`TEST_FEATURE = 'add-formatting-fidelity-comparison-check'`).

## Testing

- 9 new scenario tests, including run-split noise immunity, revision-markup-granularity immunity via projections, and an end-to-end pipeline test (inplace + rebuild candidates).
- Full pre-submit suite green locally: build, lint:workspaces, test:run, check:spec-coverage, check:allure-labels, check:allure-quality, check:allure-filenames, check:conformance-citations, check:conformance-doc.