### PR TITLE
feat(docx-mcp): ODF compare_documents session mode — redline a .odt session against its original

### DIFF
--- a/openspec/changes/add-odf-compare-session/design.md
+++ b/openspec/changes/add-odf-compare-session/design.md
@@ -1,0 +1,54 @@
+# Design — ODF `compare_documents` session mode
+
+## Context
+
+The two-file ODF compare (Slice 1) is stateless: it loads both `.odt`s itself because two-file
+inputs carry no `file_path` and cannot route through `resolveOdfSessionForTool`. Session mode's
+input *is* a `file_path`, so it can — and should — use the standard ODF session lane. The engine
+(`compareOdf(originalContentXml, revisedContentXml, opts)`) is reused unchanged.
+
+## Goals / Non-Goals
+
+- Goals: session-mode `.odt` compare with response parity (`mode: 'session'` + session-resolution
+  metadata); no session-state mutation; an unedited session yields an empty redline.
+- Non-Goals: intra-paragraph granularity (#356); changing the engine; DOCX/gdocs behavior.
+
+## Decisions
+
+- **Route via the `dispatchOdf` handler map.** `compare_documents` is already in
+  `ODF_SUPPORTED_TOOLS`, so registering `odfCompareDocumentsSession` in `loadOdfHandlers` gives
+  open-or-reuse session resolution, staleness warnings, and metadata attachment for free — the same
+  shape as every other ODF session tool.
+- **Two-file precedence across all providers** (peer-review blocker). When both
+  `original_file_path` and `revised_file_path` are present, two-file mode wins even with a stray
+  `file_path` supplied — mirroring `compareDocuments_tool`'s own `twoFileMode` precedence.
+  Previously a stray `.odt` `file_path` made two-`.docx` compares fail `UNSUPPORTED_FOR_ODF`; after
+  the naive guard-swap it would instead have silently opened a session on the stray `.odt`.
+- **Baseline = raw `content.xml` from `session.originalBuffer`, no normalization.** `compareOdf`
+  diffs per-block *visible text* (`collectBlocks` + `buildSegments(...).visible`), so
+  parse→serialize differences (attribute order, whitespace-in-tags) cannot surface as phantom
+  changes. Verified by direct probe: `compareOdf(raw, serialize(parse(raw)))` over the sample
+  fixture returns `{insertions: 0, deletions: 0, modifications: 0}`. The DOCX-style normalized
+  baseline (`ensureBaselines`) is unnecessary for ODF; scenario [OPCS-02] pins this, including a
+  fixture with serialization-sensitive constructs (`text:s`, `text:tab`, `text:line-break`,
+  `text:h`, entity-escaped text, `office:annotation`).
+- **Fresh `OdfArchive` from `originalBuffer` for both baseline extraction and redline packaging.**
+  `SessionManager.saveOdfTo` stamps `session.archive` with `doc.toXml()` on every save, so the live
+  archive's `content.xml` may already be the *edited* state (unusable as a baseline), and writing
+  redline markup into it would poison the live session. Packaging the redline on the fresh original
+  archive is valid under a **current invariant**: today's ODF session edit tools mutate
+  `content.xml` only (the same premise `saveOdfTo` rests on), so the original package plus the
+  redline `content.xml` *is* the revised redline package. If a future ODF tool mutates non-content
+  parts (styles.xml, manifest, …), session compare must switch to a revised-session package
+  baseline or copy the modified parts. Scenario [OPCS-06] pins the no-mutation property.
+- **No `allow_overwrite` for the output path.** Comparison inputs are never overwritable (parity
+  with the DOCX tool and two-file mode, issue #313), even though `save` offers `allow_overwrite`.
+
+## Risks / Trade-offs
+
+- [Invariant drift: a future ODF tool touches non-content parts] → invariant stated in the handler
+  comment + here; [OPCS-06] catches session poisoning, and redline output is built from the
+  original package so such a tool's parts would be *missing* from the redline — the invariant note
+  tells the implementer where to fix it.
+- [Pending-change coupling: `add-odf-compare` not yet archived] → its delta is amended in this PR
+  (OPCD-04 re-point), following the #348 precedent for sequential slices.

--- a/openspec/changes/add-odf-compare-session/proposal.md
+++ b/openspec/changes/add-odf-compare-session/proposal.md
@@ -1,0 +1,50 @@
+# Change: ODF (.odt) `compare_documents` — session mode (redline a session's edits against its original)
+
+## Why
+
+`add-odf-compare` (Slice 1, #348) landed ODF `compare_documents` in **two-file mode** only; a
+`.odt` on `file_path` (session mode) still returns `UNSUPPORTED_FOR_ODF`. That blocks the common
+workflow of opening a `.odt`, editing it through the session tools (`replace_text`,
+`insert_paragraph`, `add_comment`, …), and producing a redline of exactly what changed — today the
+user must save a copy and run a manual two-file compare. Session mode removes that friction:
+compare the live session against the original it was opened from, in one call (issue #357).
+
+## What Changes
+
+- `@usejunior/docx-mcp`:
+  - New session-aware entry point `odfCompareDocumentsSession(manager, session, params, metadata)`
+    in `tools/odf/compare_documents.ts`, registered in the `dispatchOdf` handler map. It takes the
+    original `content.xml` from the session's immutable open-time `originalBuffer` (via a fresh
+    `OdfArchive` — the live `session.archive` is stamped with the *edited* content on every `save`,
+    so it is not a valid baseline source and must not be poisoned with redline markup), the revised
+    `content.xml` from the live `session.doc`, runs the existing `compareOdf` engine, and packages
+    the redline `content.xml` into that fresh original archive. Packaging on the original package is
+    valid under the current invariant that ODF session edit tools mutate `content.xml` only (the
+    same premise `SessionManager.saveOdfTo` rests on).
+  - `server.ts` `compare_documents` routing is restructured for **two-file precedence across all
+    providers**: when both `original_file_path` and `revised_file_path` are present, two-file mode
+    wins (ODF stateless handler for `.odt` inputs, DOCX tool otherwise) even if a stray `file_path`
+    is also supplied — previously a stray `.odt` `file_path` preempted a two-`.docx` compare with
+    `UNSUPPORTED_FOR_ODF`. Otherwise a `.odt` `file_path` now dispatches through the standard ODF
+    session lane (`dispatchOdf`) instead of returning `UNSUPPORTED_FOR_ODF`.
+  - Same output-path safety as two-file mode: refuse `save_to_local_path` resolving to the
+    session's original file (no `allow_overwrite` escape — comparison inputs are never
+    overwritable), and enforce the write-path policy.
+  - `tool_catalog.ts` `compare_documents` description updated (ODF now supports both modes);
+    `docs/tool-reference.generated.md` regenerated.
+- `openspec/changes/add-odf-compare` (pending): the "session mode SHALL return
+  `UNSUPPORTED_FOR_ODF`" clause is removed and scenario `[OPCD-04]` is re-pointed at a different
+  still-unsupported tool (`accept_changes`), mirroring how #348 re-pointed `[OPLR-08]` when
+  two-file compare became supported.
+- `@usejunior/odf-core` is **unchanged** — the paragraph-granularity engine from `add-odf-compare`
+  is reused as-is, and session mode inherits whatever granularity the engine supports.
+
+## Impact
+
+- Affected specs: `mcp-server` (ADDED requirement: ODF session-mode `compare_documents`; plus an
+  amendment inside the pending `add-odf-compare` change's delta).
+- Affected code: `packages/docx-mcp/src/server.ts`,
+  `packages/docx-mcp/src/tools/odf/compare_documents.ts`, `packages/docx-mcp/src/tool_catalog.ts`,
+  `docs/tool-reference.generated.md`; tests in
+  `packages/docx-mcp/src/tools/odf/odf_compare_session.test.ts` (new) and
+  `packages/docx-mcp/src/tools/odf/odf_compare.test.ts` (OPCD-04 re-point).

--- a/openspec/changes/add-odf-compare-session/specs/mcp-server/spec.md
+++ b/openspec/changes/add-odf-compare-session/specs/mcp-server/spec.md
@@ -1,0 +1,59 @@
+## ADDED Requirements
+
+### Requirement: ODF session-mode `compare_documents` (redline a `.odt` session against its original)
+
+The MCP server SHALL service `compare_documents` for a `.odt` `file_path` (session mode) by
+dispatching through the standard ODF session-resolution lane (`dispatchOdf`), opening or reusing
+the `.odt` session, and comparing the session's current edited state against the original document
+the session was opened from. The original SHALL be the `content.xml` extracted from the session's
+immutable open-time `originalBuffer` (via a freshly loaded archive — the live session archive is
+stamped with edited content on save and SHALL NOT be used as the baseline source or mutated by
+comparison), and the revised SHALL be the live session document's serialization. The comparison
+SHALL use the same paragraph-granularity engine as two-file mode and SHALL inherit whatever
+granularity that engine supports.
+
+Mode precedence SHALL be two-file first for ALL providers: when both `original_file_path` and
+`revised_file_path` are present, the request SHALL be handled in two-file mode (the stateless ODF
+handler when an input is `.odt`, the DOCX tool otherwise) even if a `file_path` is also supplied.
+
+The redline SHALL be packaged on the original package (valid because ODF session edit tools
+currently mutate only `content.xml`) and written to `save_to_local_path` with the same output-path
+safety as two-file mode: the server SHALL reject a `save_to_local_path` resolving to the session's
+original file with no `allow_overwrite` escape, and SHALL enforce the write-path policy before
+writing. The live session SHALL NOT be mutated: a subsequent `save` SHALL produce the edited
+document without tracked-changes markup.
+
+The response SHALL carry `mode: 'session'`, `provider: 'odf'`, `original_file_path`, `saved_to`,
+`size_bytes`, `author`, `granularity: 'paragraph'`, `stats: { insertions, deletions,
+modifications }`, a `message`, and the standard session-resolution metadata
+(`session_resolution`, `resolved_file_path`, and `reused_session_context` when reused). DOCX-only
+fields (`engine`, `reconstruction_mode`) SHALL be omitted. A session with no edits SHALL succeed
+with zero stats (an empty change set), not an error.
+
+#### Scenario: [OPCS-01] Session edits produce a tracked-changes redline
+- **WHEN** a `.odt` session has accumulated edits and `compare_documents` is invoked with that `file_path` plus `save_to_local_path`
+- **THEN** a tracked-changes `.odt` is written to `save_to_local_path` and the response reports `mode: 'session'`, `provider: 'odf'`, `granularity: 'paragraph'`, and non-zero `stats`
+
+#### Scenario: [OPCS-02] An unedited session produces an empty redline
+- **WHEN** `compare_documents` is invoked on a freshly opened, unedited `.odt` session — including one whose content uses serialization-sensitive constructs (`text:s`, `text:tab`, `text:line-break`, `text:h`, entity-escaped text, `office:annotation`)
+- **THEN** the call succeeds with `stats` of zero insertions, zero deletions, zero modifications, and no phantom changes appear in the output
+
+#### Scenario: [OPCS-03] The session redline reopens with deleted content out-of-line
+- **WHEN** the redline produced by a session-mode compare is reloaded
+- **THEN** the revised (edited) text is present in the body and the deleted original text does not leak into the visible content
+
+#### Scenario: [OPCS-04] Output path may not overwrite the session's original
+- **WHEN** session-mode `compare_documents` is invoked with a `save_to_local_path` that resolves to the session's original file
+- **THEN** an `OVERWRITE_BLOCKED` error is returned and the original file is untouched
+
+#### Scenario: [OPCS-05] Session-resolution metadata is attached
+- **WHEN** session-mode `compare_documents` opens a fresh `.odt` session, or reuses one created by a prior edit
+- **THEN** the response carries `session_resolution: 'opened'` for the fresh path, or `session_resolution: 'reused'` plus `reused_session_context` for the reused path
+
+#### Scenario: [OPCS-06] Comparison does not mutate the live session
+- **WHEN** a session-mode compare runs and the session is subsequently saved
+- **THEN** the saved document contains the session's edits and no tracked-changes markup
+
+#### Scenario: [OPCS-07] Two-file mode keeps precedence over a stray `file_path`
+- **WHEN** `compare_documents` is invoked with two `.docx` input paths and a stray `.odt` `file_path`
+- **THEN** the DOCX two-file comparison runs and no ODF session is opened

--- a/openspec/changes/add-odf-compare-session/tasks.md
+++ b/openspec/changes/add-odf-compare-session/tasks.md
@@ -1,0 +1,17 @@
+# Tasks
+
+## docx-mcp
+- [x] `tools/odf/compare_documents.ts`: add `odfCompareDocumentsSession(manager, session, params, metadata)` — baseline `content.xml` from a fresh `OdfArchive.load(session.originalBuffer)`, revised from `session.doc.toXml()`, `compareOdf`, package redline on the fresh original archive (NOT `session.archive`; state the content.xml-only invariant in the handler comment), refuse `save_to_local_path` resolving to `session.originalPath` (no `allow_overwrite`), `enforceWritePathPolicy`, `manager.touch(session)`, response `{ mode:'session', provider:'odf', original_file_path, saved_to, size_bytes, author, granularity:'paragraph', stats, message, ...metadata }`. Update the file header + two-file `MISSING_PARAMS` hint (session mode now supported)
+- [x] `server.ts`: register `compare_documents` in `loadOdfHandlers`; restructure the `compare_documents` case for two-file precedence across all providers (both input paths present → two-file even with stray `file_path`); `.odt` `file_path` → `dispatchOdf`; update the routing comment
+- [x] `tool_catalog.ts`: update `compare_documents` description (ODF supports both modes); regenerate `docs/tool-reference.generated.md`; `npm run check:tool-docs`
+
+## OpenSpec
+- [x] Amend pending `add-odf-compare` delta: drop the "session mode SHALL return UNSUPPORTED_FOR_ODF" clause; re-point `[OPCD-04]` at `accept_changes` (still-unsupported example)
+- [x] `openspec validate add-odf-compare-session --strict` and `openspec validate add-odf-compare --strict`
+
+## Tests & verification
+- [x] New `tools/odf/odf_compare_session.test.ts` (`TEST_FEATURE = 'add-odf-compare-session'`, `testAllure as it`, driven through `dispatchToolCall`, fresh `SessionManager` per test): OPCS-01..07, including the serialization-sensitive no-op fixture (OPCS-02) and the session-not-mutated save check (OPCS-06)
+- [x] Update `odf_compare.test.ts` `[OPCD-04]` test to the re-pointed scenario (`accept_changes` on an open ODF session → `UNSUPPORTED_FOR_ODF`), with a comment noting the flip
+- [x] Full CI gate locally: `npm run build && npm run lint:workspaces && npm run test:run && npm run check:spec-coverage && npm run check:conformance-citations && npm run check:conformance-doc`
+- [x] Document-shaped `.odt` smoke: open a realistic `.odt`, `replace_text` + `insert_paragraph` (+ `add_comment`), session-mode `compare_documents`; stats reflect the edits; redline reopens
+- [x] LibreOffice oracle: accept-all on the session redline reproduces the edited text; reject-all reproduces the original

--- a/openspec/changes/add-odf-compare/specs/mcp-server/spec.md
+++ b/openspec/changes/add-odf-compare/specs/mcp-server/spec.md
@@ -25,8 +25,9 @@ The ODF handler SHALL apply the same output-path safety as the DOCX tool: it SHA
 `save_to_local_path` resolves to either source file, and SHALL enforce the write-path policy
 before writing the redline.
 
-ODF **session-mode** `compare_documents` (a `.odt` on `file_path`) is not yet supported and
-SHALL return `UNSUPPORTED_FOR_ODF` rather than silently degrading.
+ODF **session-mode** `compare_documents` (a `.odt` on `file_path`) is specified by the
+`add-odf-compare-session` change; tools still outside the ODF supported set SHALL continue to
+return `UNSUPPORTED_FOR_ODF`.
 
 #### Scenario: [OPCD-01] Two-file `.odt` compare produces a redline
 - **WHEN** `compare_documents` is invoked with `.odt` `original_file_path` and `revised_file_path` that differ by whole paragraphs, plus `save_to_local_path`
@@ -40,8 +41,8 @@ SHALL return `UNSUPPORTED_FOR_ODF` rather than silently degrading.
 - **WHEN** `compare_documents` is invoked with two `.docx` paths
 - **THEN** the existing DOCX comparison runs and returns its DOCX response shape (including `engine`), and no ODF logic runs
 
-#### Scenario: [OPCD-04] ODF session-mode compare is unsupported
-- **WHEN** `compare_documents` is invoked with a `.odt` `file_path` (session mode)
+#### Scenario: [OPCD-04] Still-unsupported tools remain guarded for ODF sessions
+- **WHEN** a tool outside the ODF supported set (e.g. `accept_changes`) is invoked against an open `.odt` session
 - **THEN** an `UNSUPPORTED_FOR_ODF` error is returned and no DOCX logic runs
 
 #### Scenario: [OPCD-05] The redline reopens with the changes preserved

--- a/openspec/changes/add-odf-core/specs/mcp-server/spec.md
+++ b/openspec/changes/add-odf-core/specs/mcp-server/spec.md
@@ -30,7 +30,7 @@ never reach DOCX-only fields. Genuinely unsupported extensions SHALL still retur
 - **THEN** the ODF handler services it and the DOCX/gdocs handlers are not invoked
 
 #### Scenario: [OPLR-04] Unsupported tools are guarded for ODF
-- **WHEN** a Phase-2 tool (e.g. `compare_documents`, `add_comment`) is invoked against an ODF session
+- **WHEN** a tool outside the ODF supported set (e.g. `format_layout`) is invoked against an ODF session
 - **THEN** an `UNSUPPORTED_FOR_ODF` error is returned and no DOCX logic runs
 
 #### Scenario: [OPLR-05] File-first `.odt` auto-opens

--- a/packages/docx-mcp/docs/tool-reference.generated.md
+++ b/packages/docx-mcp/docs/tool-reference.generated.md
@@ -260,7 +260,7 @@ Delete a comment and all its threaded replies from the document. Cascade-deletes
 
 ## `compare_documents`
 
-Compare two documents and produce a tracked-changes output document. Provide original_file_path + revised_file_path for standalone comparison, or file_path to compare session edits against the original. DOCX supports both modes; ODF (.odt) supports two-file mode at paragraph granularity (a modified paragraph counts as one deletion plus one insertion).
+Compare two documents and produce a tracked-changes output document. Provide original_file_path + revised_file_path for standalone comparison, or file_path to compare session edits against the original. DOCX and ODF (.odt) support both modes; ODF compares at paragraph granularity (a modified paragraph counts as one deletion plus one insertion).
 
 - readOnly: `true`
 - destructive: `false`

--- a/packages/docx-mcp/src/server.ts
+++ b/packages/docx-mcp/src/server.ts
@@ -89,7 +89,7 @@ async function loadGDocsHandlers(): Promise<typeof gdocsHandlers> {
 
 async function loadOdfHandlers(): Promise<typeof odfHandlers> {
   if (odfHandlers) return odfHandlers;
-  const [readFile, replaceText, grep, insertParagraph, addComment, getComments, save, getFileStatus, closeFile] = await Promise.all([
+  const [readFile, replaceText, grep, insertParagraph, addComment, getComments, save, getFileStatus, closeFile, compareDocuments] = await Promise.all([
     import('./tools/odf/read_file.js'),
     import('./tools/odf/replace_text.js'),
     import('./tools/odf/grep.js'),
@@ -99,6 +99,7 @@ async function loadOdfHandlers(): Promise<typeof odfHandlers> {
     import('./tools/odf/save.js'),
     import('./tools/odf/get_file_status.js'),
     import('./tools/odf/close_file.js'),
+    import('./tools/odf/compare_documents.js'),
   ]);
   odfHandlers = {
     read_file: readFile.odfReadFile,
@@ -110,6 +111,7 @@ async function loadOdfHandlers(): Promise<typeof odfHandlers> {
     save: save.odfSave,
     get_file_status: getFileStatus.odfGetFileStatus,
     close_file: closeFile.odfCloseFile,
+    compare_documents: compareDocuments.odfCompareDocumentsSession,
   };
   return odfHandlers;
 }
@@ -201,28 +203,27 @@ export async function dispatchToolCall(
       return await getComments(sessions, args as Parameters<typeof getComments>[1]);
     case 'delete_comment':
       return await deleteComment(sessions, args as Parameters<typeof deleteComment>[1]);
-    case 'compare_documents':
-      // compare_documents resolves its inputs via original_file_path / revised_file_path
-      // (not file_path), so the shared resolver's .odt chokepoint can't see them. Route here:
-      //  - two `.odt` inputs → the stateless ODF handler directly (it loads both files itself; it
-      //    CANNOT go through dispatchOdf, whose resolveOdfSessionForTool requires a file_path);
-      //  - a `.odt` session file_path → UNSUPPORTED_FOR_ODF (session-mode compare is a later slice);
-      //  - otherwise the DOCX tool.
-      if (hasOdfInputPath(args, ['original_file_path', 'revised_file_path'])) {
-        const { odfCompareDocuments } = await import('./tools/odf/compare_documents.js');
-        return await odfCompareDocuments(sessions, args as Parameters<typeof odfCompareDocuments>[1]);
+    case 'compare_documents': {
+      // compare_documents has two modes. Two-file mode (original_file_path + revised_file_path)
+      // takes precedence for ALL providers — mirroring the DOCX tool's own twoFileMode precedence —
+      // so a stray file_path cannot preempt a two-file request (e.g. two `.docx` inputs plus a
+      // `.odt` file_path must run the DOCX comparison, not open an ODF session). Within two-file
+      // mode, `.odt` inputs route to the stateless ODF handler directly (it loads both files
+      // itself; it CANNOT go through dispatchOdf, whose resolveOdfSessionForTool requires a
+      // file_path). Session mode (file_path only) routes a `.odt` through the standard ODF session
+      // lane; otherwise the DOCX tool.
+      const hasOriginal = typeof args.original_file_path === 'string' && args.original_file_path.trim().length > 0;
+      const hasRevised = typeof args.revised_file_path === 'string' && args.revised_file_path.trim().length > 0;
+      if (hasOriginal && hasRevised) {
+        if (hasOdfInputPath(args, ['original_file_path', 'revised_file_path'])) {
+          const { odfCompareDocuments } = await import('./tools/odf/compare_documents.js');
+          return await odfCompareDocuments(sessions, args as Parameters<typeof odfCompareDocuments>[1]);
+        }
+        return await compareDocuments_tool(sessions, args as Parameters<typeof compareDocuments_tool>[1]);
       }
-      if (isOdfRequest(args)) {
-        return {
-          success: false,
-          error: {
-            code: 'UNSUPPORTED_FOR_ODF',
-            message: 'Session-mode compare_documents is not yet supported for ODF (.odt) files.',
-            hint: 'Provide original_file_path and revised_file_path to compare two .odt files.',
-          },
-        };
-      }
+      if (isOdfRequest(args)) return await dispatchOdf(sessions, args, 'compare_documents');
       return await compareDocuments_tool(sessions, args as Parameters<typeof compareDocuments_tool>[1]);
+    }
     case 'get_footnotes':
       return await getFootnotes(sessions, args as Parameters<typeof getFootnotes>[1]);
     case 'add_footnote':

--- a/packages/docx-mcp/src/tool_catalog.ts
+++ b/packages/docx-mcp/src/tool_catalog.ts
@@ -312,7 +312,7 @@ export const SAFE_DOCX_TOOL_CATALOG = [
   {
     name: 'compare_documents',
     description:
-      'Compare two documents and produce a tracked-changes output document. Provide original_file_path + revised_file_path for standalone comparison, or file_path to compare session edits against the original. DOCX supports both modes; ODF (.odt) supports two-file mode at paragraph granularity (a modified paragraph counts as one deletion plus one insertion).',
+      'Compare two documents and produce a tracked-changes output document. Provide original_file_path + revised_file_path for standalone comparison, or file_path to compare session edits against the original. DOCX and ODF (.odt) support both modes; ODF compares at paragraph granularity (a modified paragraph counts as one deletion plus one insertion).',
     input: z.object({
       original_file_path: z.string().optional().describe('Path to the original DOCX or .odt file.'),
       revised_file_path: z.string().optional().describe('Path to the revised DOCX or .odt file.'),

--- a/packages/docx-mcp/src/tools/odf/compare_documents.ts
+++ b/packages/docx-mcp/src/tools/odf/compare_documents.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import fs from 'node:fs/promises';
 
-import { SessionManager } from '../../session/manager.js';
+import { type OdfSession, SessionManager } from '../../session/manager.js';
 import { errorCode, errorMessage } from '../../error_utils.js';
 import { loadOdfCore } from '../../odf_loader.js';
 import { enforceWritePathPolicy, resolvesToSamePath } from '../path_policy.js';
@@ -21,12 +21,12 @@ function resolveAuthor(explicit?: string): string {
 }
 
 /**
- * ODF `compare_documents` — Slice 1: paragraph-granularity, TWO-FILE mode only.
+ * ODF `compare_documents` — paragraph-granularity TWO-FILE mode.
  *
  * Stateless (mirrors the DOCX `compareDocuments_tool`): it does its own loading and takes no
  * resolved session, because two-file compare carries no `file_path` and so cannot route through
- * `resolveOdfSessionForTool` (which requires one). Session-mode `.odt` compare is guarded upstream
- * in `server.ts` and is a later slice.
+ * `resolveOdfSessionForTool` (which requires one). Session-mode `.odt` compare routes through
+ * `dispatchOdf` to `odfCompareDocumentsSession` below.
  */
 export async function odfCompareDocuments(
   manager: SessionManager,
@@ -45,7 +45,7 @@ export async function odfCompareDocuments(
       return err(
         'MISSING_PARAMS',
         'ODF comparison requires both original_file_path and revised_file_path.',
-        'Session-mode compare (file_path) is not yet supported for .odt; provide two .odt files.',
+        'Provide two .odt files, or pass file_path alone to compare a session against its original.',
       );
     }
 
@@ -109,6 +109,97 @@ export async function odfCompareDocuments(
         `Redline comparing '${originalLoaded.filename}' vs '${revisedLoaded.filename}' saved to ${savePath}. ` +
         'Changes are tracked at the whole-paragraph level (a modified paragraph counts as one ' +
         'deletion plus one insertion), so insertion/deletion counts may run higher than the DOCX path.',
+    });
+  } catch (e: unknown) {
+    if (String(errorCode(e) ?? '').toUpperCase() === 'EACCES') {
+      return err('PERMISSION_DENIED', `Cannot write to: ${params.save_to_local_path}`, 'Try saving to ~/Downloads/ or ~/Documents/ instead.');
+    }
+    return err('COMPARE_ERROR', `ODF comparison failed: ${errorMessage(e)}`);
+  }
+}
+
+/**
+ * ODF `compare_documents` — SESSION mode: redline the live session's edits against the original
+ * the session was opened from.
+ *
+ * Both the baseline and the redline package come from a FRESH archive loaded off
+ * `session.originalBuffer`, never from `session.archive`: `SessionManager.saveOdfTo` stamps the
+ * live archive's `content.xml` with the edited state on every save (so it is not a valid baseline
+ * source), and writing redline markup into it would poison the session. The raw original
+ * `content.xml` needs no normalization as a baseline because `compareOdf` diffs per-block visible
+ * text, which a parse→serialize round-trip does not alter.
+ *
+ * Packaging the redline on the original package is valid under a CURRENT invariant: ODF session
+ * edit tools mutate `content.xml` only (the same premise `saveOdfTo` rests on). If a future ODF
+ * tool mutates non-content parts (styles.xml, manifest, …), session compare must switch to a
+ * revised-session package baseline or copy those modified parts.
+ */
+export async function odfCompareDocumentsSession(
+  manager: SessionManager,
+  session: OdfSession,
+  params: {
+    file_path?: string;
+    save_to_local_path?: string;
+    author?: string;
+  },
+  metadata: Record<string, unknown>,
+): Promise<ToolResponse> {
+  try {
+    const rawSavePath = typeof params.save_to_local_path === 'string' ? params.save_to_local_path.trim() : '';
+    if (!rawSavePath) {
+      return err('MISSING_SAVE_PATH', 'compare_documents requires save_to_local_path.', 'Provide a writable .odt output path.');
+    }
+
+    // Refuse to clobber the comparison input via the output path (parity with two-file mode and
+    // the DOCX tool, issue #313). No allow_overwrite escape: the original is an input here.
+    const savePath = expandPath(rawSavePath);
+    if (await resolvesToSamePath(savePath, session.originalPath)) {
+      return err(
+        'OVERWRITE_BLOCKED',
+        `Refusing to overwrite a source document: ${manager.normalizePath(session.originalPath)}`,
+        'Choose a different save_to_local_path.',
+      );
+    }
+
+    const odf = await loadOdfCore();
+    if (!odf) {
+      return err(
+        'MISSING_DEPENDENCY',
+        'ODF (.odt) support requires @usejunior/odf-core.',
+        'Install @usejunior/odf-core to enable ODF comparison.',
+      );
+    }
+
+    const author = resolveAuthor(params.author);
+    const originalArchive = await odf.OdfArchive.load(session.originalBuffer);
+    const originalXml = await originalArchive.getContentXml();
+    const revisedXml = session.doc.toXml();
+    const result = odf.compareOdf(originalXml, revisedXml, { author });
+
+    const writePolicy = await enforceWritePathPolicy(savePath);
+    if (!writePolicy.ok) return writePolicy.response;
+
+    originalArchive.setContentXml(result.contentXml);
+    const buffer: Buffer = await originalArchive.save();
+
+    await fs.mkdir(path.dirname(savePath), { recursive: true });
+    await fs.writeFile(savePath, new Uint8Array(buffer));
+    manager.touch(session);
+
+    return ok({
+      mode: 'session',
+      provider: 'odf',
+      original_file_path: manager.normalizePath(session.originalPath),
+      saved_to: savePath,
+      size_bytes: buffer.length,
+      author,
+      granularity: 'paragraph',
+      stats: result.stats,
+      message:
+        `Redline of session edits to '${session.filename}' saved to ${savePath}. ` +
+        'Changes are tracked at the whole-paragraph level (a modified paragraph counts as one ' +
+        'deletion plus one insertion), so insertion/deletion counts may run higher than the DOCX path.',
+      ...metadata,
     });
   } catch (e: unknown) {
     if (String(errorCode(e) ?? '').toUpperCase() === 'EACCES') {

--- a/packages/docx-mcp/src/tools/odf/odf_compare.test.ts
+++ b/packages/docx-mcp/src/tools/odf/odf_compare.test.ts
@@ -164,17 +164,23 @@ describe('ODF compare_documents lane (two-file, paragraph granularity)', () => {
     },
   );
 
-  test.openspec('[OPCD-04] ODF session-mode compare is unsupported')(
-    'a .odt file_path (session mode) returns UNSUPPORTED_FOR_ODF',
-    async ({ given, then }: AllureBddContext) => {
+  test.openspec('[OPCD-04] Still-unsupported tools remain guarded for ODF sessions')(
+    'accept_changes against an open .odt session returns UNSUPPORTED_FOR_ODF',
+    async ({ given, when, then }: AllureBddContext) => {
+      // Session-mode .odt compare became supported in add-odf-compare-session; this scenario was
+      // re-pointed at a still-unsupported tool (the same flip OPLR-08 got when two-file compare
+      // landed). Session-mode compare coverage lives in odf_compare_session.test.ts (OPCS-*).
       let result: Record<string, unknown> = {};
-      await given('a .odt session file_path', async () => {
+      const manager = new SessionManager();
+      let odt = '';
+      await given('an open .odt session', async () => {
         const dir = await tmpdir();
-        const odt = await copyFixtureTo(dir, 'session.odt');
-        result = await dispatchToolCall(new SessionManager(), 'compare_documents', {
-          file_path: odt,
-          save_to_local_path: path.join(dir, 'out.odt'),
-        });
+        odt = await copyFixtureTo(dir, 'session.odt');
+        const read = await dispatchToolCall(manager, 'read_file', { file_path: odt });
+        assertSuccess(read, 'read_file');
+      });
+      await when('a still-unsupported tool targets the session', async () => {
+        result = await dispatchToolCall(manager, 'accept_changes', { file_path: odt });
       });
       await then('UNSUPPORTED_FOR_ODF is returned', () => {
         assertError(result, 'UNSUPPORTED_FOR_ODF');

--- a/packages/docx-mcp/src/tools/odf/odf_compare_session.test.ts
+++ b/packages/docx-mcp/src/tools/odf/odf_compare_session.test.ts
@@ -1,0 +1,323 @@
+import { afterEach, describe, expect } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createZipBuffer } from '@usejunior/docx-core';
+import { OdfArchive } from '@usejunior/odf-core';
+
+import { testAllure as it, type AllureBddContext } from '../../testing/allure-test.js';
+import { dispatchToolCall } from '../../server.js';
+import { SessionManager } from '../../session/manager.js';
+
+const TEST_FEATURE = 'add-odf-compare-session';
+const test = it.epic('Document Editing').withLabels({ feature: TEST_FEATURE });
+
+const FIXTURE = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../../../odf-core/src/__fixtures__/sample.odt',
+);
+
+const tmpDirs: string[] = [];
+afterEach(async () => {
+  for (const dir of tmpDirs.splice(0)) {
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
+async function tmpdir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'safe-docx-odf-cmp-session-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+async function copyFixtureTo(dir: string, name: string): Promise<string> {
+  const filePath = path.join(dir, name);
+  await fs.copyFile(FIXTURE, filePath);
+  return filePath;
+}
+
+type ErrorResult = { success: false; error: { code: string; message: string; hint?: string } };
+function assertSuccess(result: Record<string, unknown>, label: string): asserts result is { success: true; [k: string]: unknown } {
+  expect(result.success, `${label} failed: ${JSON.stringify((result as ErrorResult).error)}`).toBe(true);
+}
+function assertError(result: Record<string, unknown>, code: string): asserts result is ErrorResult {
+  expect(result.success).toBe(false);
+  expect((result as ErrorResult).error.code).toBe(code);
+}
+
+/** Edit the session's third paragraph (Acme → Globex) so a compare yields one delete+insert pair. */
+async function editSession(manager: SessionManager, filePath: string): Promise<void> {
+  const edit = await dispatchToolCall(manager, 'replace_text', {
+    file_path: filePath,
+    target_paragraph_id: 'p2',
+    old_string: 'Acme Manufacturing',
+    new_string: 'Globex Corporation',
+    instruction: 'Rename the company referenced in the third paragraph.',
+  });
+  assertSuccess(edit, 'replace_text');
+}
+
+async function readContentXml(odtPath: string): Promise<string> {
+  const archive = await OdfArchive.load(await fs.readFile(odtPath));
+  return archive.getContentXml();
+}
+
+/**
+ * content.xml exercising serialization-sensitive constructs: text:s, text:tab, text:line-break,
+ * text:h, entity-escaped text, and an office:annotation. Used to pin that the raw open-time
+ * content.xml is a faithful comparison baseline (a parse→serialize round-trip must not surface
+ * phantom changes through any of these).
+ */
+const SERIALIZATION_SENSITIVE_CONTENT_XML =
+  `<?xml version="1.0" encoding="UTF-8"?>` +
+  `<office:document-content xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0"` +
+  ` xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"` +
+  ` xmlns:dc="http://purl.org/dc/elements/1.1/" office:version="1.4"><office:body><office:text>` +
+  `<text:h text:outline-level="1">Heading &amp; overview</text:h>` +
+  `<text:p>Spaced<text:s text:c="3"/>words</text:p>` +
+  `<text:p>Tabbed<text:tab/>and<text:line-break/>broken</text:p>` +
+  `<text:p>Entities &amp; angles &lt;tag&gt; stay.</text:p>` +
+  `<text:p>Annotated<office:annotation><dc:creator>Reviewer</dc:creator>` +
+  `<dc:date>2026-06-10T00:00:00</dc:date><text:p>A note.</text:p></office:annotation> body.</text:p>` +
+  `</office:text></office:body></office:document-content>`;
+
+/** Write a valid .odt whose content.xml is `contentXml`, reusing the fixture's package shell. */
+async function writeOdtWithContent(dir: string, name: string, contentXml: string): Promise<string> {
+  const archive = await OdfArchive.load(await fs.readFile(FIXTURE));
+  archive.setContentXml(contentXml);
+  const filePath = path.join(dir, name);
+  await fs.writeFile(filePath, new Uint8Array(await archive.save()));
+  return filePath;
+}
+
+const SMALL_DOCX_CONTENT_TYPES = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>`;
+const SMALL_DOCX_RELS = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>`;
+async function writeTestDocx(dir: string, name: string, paragraphs: string[]): Promise<string> {
+  const documentXml =
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>` +
+    paragraphs.map((t) => `<w:p><w:r><w:t>${t}</w:t></w:r></w:p>`).join('') +
+    `</w:body></w:document>`;
+  const buf = await createZipBuffer({
+    '[Content_Types].xml': SMALL_DOCX_CONTENT_TYPES,
+    '_rels/.rels': SMALL_DOCX_RELS,
+    'word/document.xml': documentXml,
+  });
+  const p = path.join(dir, name);
+  await fs.writeFile(p, new Uint8Array(buf));
+  return p;
+}
+
+describe('ODF compare_documents session mode', () => {
+  test.openspec('[OPCS-01] Session edits produce a tracked-changes redline')(
+    'a .odt file_path routes to the ODF session handler and writes a redline of the edits',
+    async ({ given, when, then }: AllureBddContext) => {
+      let result: Record<string, unknown> = {};
+      let out = '';
+      await given('a .odt session with one edited paragraph', async () => {
+        const dir = await tmpdir();
+        const manager = new SessionManager();
+        const filePath = await copyFixtureTo(dir, 'session.odt');
+        await editSession(manager, filePath);
+        out = path.join(dir, 'redline.odt');
+        await when('compare_documents runs with the session file_path', async () => {
+          result = await dispatchToolCall(manager, 'compare_documents', {
+            file_path: filePath,
+            save_to_local_path: out,
+          });
+        });
+      });
+      await then('a paragraph-granularity session redline is written', async () => {
+        assertSuccess(result, 'compare_documents');
+        expect(result.provider).toBe('odf');
+        expect(result.mode).toBe('session');
+        expect(result.granularity).toBe('paragraph');
+        const stats = result.stats as { insertions: number; deletions: number; modifications: number };
+        expect(stats.insertions).toBeGreaterThanOrEqual(1);
+        expect(stats.deletions).toBeGreaterThanOrEqual(1);
+        expect(stats.modifications).toBe(0);
+        const content = await readContentXml(out);
+        expect(content).toContain('tracked-changes');
+        expect(content).toContain('Globex Corporation');
+      });
+    },
+  );
+
+  test.openspec('[OPCS-02] An unedited session produces an empty redline')(
+    'no-op compares yield zero stats, including on serialization-sensitive content',
+    async ({ given, then }: AllureBddContext) => {
+      const allStats: Array<{ insertions: number; deletions: number; modifications: number }> = [];
+      await given('unedited sessions over the sample fixture and a serialization-sensitive .odt', async () => {
+        const dir = await tmpdir();
+        for (const filePath of [
+          await copyFixtureTo(dir, 'plain.odt'),
+          await writeOdtWithContent(dir, 'sensitive.odt', SERIALIZATION_SENSITIVE_CONTENT_XML),
+        ]) {
+          const result = await dispatchToolCall(new SessionManager(), 'compare_documents', {
+            file_path: filePath,
+            save_to_local_path: path.join(dir, `redline-${path.basename(filePath)}`),
+          });
+          assertSuccess(result, `compare_documents (${path.basename(filePath)})`);
+          allStats.push(result.stats as (typeof allStats)[number]);
+        }
+      });
+      await then('both compares succeed with zero insertions, deletions, and modifications', () => {
+        for (const stats of allStats) {
+          expect(stats).toEqual({ insertions: 0, deletions: 0, modifications: 0 });
+        }
+      });
+    },
+  );
+
+  test.openspec('[OPCS-03] The session redline reopens with deleted content out-of-line')(
+    'the redline shows the revised text and does not leak the deleted original text',
+    async ({ given, then }: AllureBddContext) => {
+      let content = '';
+      await given('a session redline produced from a one-paragraph modification', async () => {
+        const dir = await tmpdir();
+        const manager = new SessionManager();
+        const filePath = await copyFixtureTo(dir, 'session.odt');
+        await editSession(manager, filePath);
+        const out = path.join(dir, 'redline.odt');
+        const result = await dispatchToolCall(manager, 'compare_documents', {
+          file_path: filePath,
+          save_to_local_path: out,
+        });
+        assertSuccess(result, 'compare_documents');
+        // read_file reopens the redline through OdfDocument (which skips text:tracked-changes).
+        const reread = await dispatchToolCall(new SessionManager(), 'read_file', { file_path: out });
+        assertSuccess(reread, 'read_file');
+        content = String(reread.content ?? '');
+      });
+      await then('the body shows the revised text and the deleted original stays out-of-line', () => {
+        expect(content).toContain('quick brown fox'); // unchanged paragraph preserved
+        expect(content).toContain('Globex Corporation'); // revised paragraph
+        expect(content).not.toContain('Acme Manufacturing'); // deleted content stays out-of-line
+      });
+    },
+  );
+
+  test.openspec("[OPCS-04] Output path may not overwrite the session's original")(
+    'save_to_local_path resolving to the session original is rejected',
+    async ({ given, then }: AllureBddContext) => {
+      let result: Record<string, unknown> = {};
+      let filePath = '';
+      let originalBytes = Buffer.alloc(0);
+      await given('a session compare whose save_to_local_path equals the session original', async () => {
+        const dir = await tmpdir();
+        const manager = new SessionManager();
+        filePath = await copyFixtureTo(dir, 'session.odt');
+        originalBytes = Buffer.from(await fs.readFile(filePath));
+        await editSession(manager, filePath);
+        result = await dispatchToolCall(manager, 'compare_documents', {
+          file_path: filePath,
+          save_to_local_path: filePath,
+        });
+      });
+      await then('OVERWRITE_BLOCKED is returned and the original file is untouched', async () => {
+        assertError(result, 'OVERWRITE_BLOCKED');
+        expect(Buffer.compare(originalBytes, await fs.readFile(filePath))).toBe(0);
+      });
+    },
+  );
+
+  test.openspec('[OPCS-05] Session-resolution metadata is attached')(
+    'a fresh path reports opened; a pre-edited session reports reused with context',
+    async ({ given, when, then }: AllureBddContext) => {
+      let opened: Record<string, unknown> = {};
+      let reused: Record<string, unknown> = {};
+      const manager = new SessionManager();
+      let dir = '';
+      let filePath = '';
+      await given('a never-opened .odt path', async () => {
+        dir = await tmpdir();
+        filePath = await copyFixtureTo(dir, 'session.odt');
+        opened = await dispatchToolCall(manager, 'compare_documents', {
+          file_path: filePath,
+          save_to_local_path: path.join(dir, 'noop.odt'),
+        });
+      });
+      await when('the session is edited and compared again', async () => {
+        await editSession(manager, filePath);
+        reused = await dispatchToolCall(manager, 'compare_documents', {
+          file_path: filePath,
+          save_to_local_path: path.join(dir, 'redline.odt'),
+        });
+      });
+      await then('the first compare opened a session and the second reused it with context', () => {
+        assertSuccess(opened, 'compare_documents (opened)');
+        expect(opened.session_resolution).toBe('opened');
+        expect(opened.resolved_file_path).toBeDefined();
+        assertSuccess(reused, 'compare_documents (reused)');
+        expect(reused.session_resolution).toBe('reused');
+        const context = reused.reused_session_context as { edit_count: number } | undefined;
+        expect(context).toBeDefined();
+        expect(context!.edit_count).toBeGreaterThanOrEqual(1);
+      });
+    },
+  );
+
+  test.openspec('[OPCS-06] Comparison does not mutate the live session')(
+    'a save after compare writes the edited document without tracked-changes markup',
+    async ({ given, when, then }: AllureBddContext) => {
+      let savedContent = '';
+      await given('a .odt session with one edit that has been compared', async () => {
+        const dir = await tmpdir();
+        const manager = new SessionManager();
+        const filePath = await copyFixtureTo(dir, 'session.odt');
+        await editSession(manager, filePath);
+        const compared = await dispatchToolCall(manager, 'compare_documents', {
+          file_path: filePath,
+          save_to_local_path: path.join(dir, 'redline.odt'),
+        });
+        assertSuccess(compared, 'compare_documents');
+        await when('the session is saved', async () => {
+          const out = path.join(dir, 'saved.odt');
+          const saved = await dispatchToolCall(manager, 'save', { file_path: filePath, save_to_local_path: out });
+          assertSuccess(saved, 'save');
+          savedContent = await readContentXml(out);
+        });
+      });
+      await then('the saved document has the edits and no redline markup', () => {
+        expect(savedContent).toContain('Globex Corporation');
+        expect(savedContent).not.toContain('Acme Manufacturing');
+        expect(savedContent).not.toContain('tracked-changes');
+      });
+    },
+  );
+
+  test.openspec('[OPCS-07] Two-file mode keeps precedence over a stray `file_path`')(
+    'two .docx inputs plus a stray .odt file_path still run the DOCX two-file comparison',
+    async ({ given, then }: AllureBddContext) => {
+      let result: Record<string, unknown> = {};
+      await given('two .docx inputs and an unrelated .odt file_path', async () => {
+        const dir = await tmpdir();
+        const original = await writeTestDocx(dir, 'a.docx', ['Hello world']);
+        const revised = await writeTestDocx(dir, 'b.docx', ['Hello brave new world']);
+        const strayOdt = await copyFixtureTo(dir, 'stray.odt');
+        result = await dispatchToolCall(new SessionManager(), 'compare_documents', {
+          original_file_path: original,
+          revised_file_path: revised,
+          file_path: strayOdt,
+          save_to_local_path: path.join(dir, 'out.docx'),
+        });
+      });
+      await then('the DOCX two-file comparison runs and no ODF session logic is involved', () => {
+        assertSuccess(result, 'compare_documents');
+        expect(result.mode).toBe('two_file');
+        expect(result.engine_used).toBeDefined();
+        expect(result.provider).not.toBe('odf');
+        expect(result.session_resolution).toBeUndefined();
+      });
+    },
+  );
+});

--- a/packages/docx-mcp/src/tools/odf/odf_grep_insert.test.ts
+++ b/packages/docx-mcp/src/tools/odf/odf_grep_insert.test.ts
@@ -230,7 +230,8 @@ describe('ODF grep + insert branch coverage', () => {
 
   it('compare_documents with two .odt input paths now routes to the ODF handler (two-file form)', async () => {
     // Two-file .odt compare became supported in add-odf-compare; the prior guard was flipped.
-    // (Session-mode .odt compare remains unsupported — covered by odf_compare.test.ts OPCD-04.)
+    // (Session-mode .odt compare became supported in add-odf-compare-session — covered by
+    // odf_compare_session.test.ts OPCS-*.)
     const manager = new SessionManager();
     const original = await copyFixture('orig.odt');
     const revised = await copyFixture('rev.odt');

--- a/packages/docx-mcp/src/tools/odf/odf_tools.test.ts
+++ b/packages/docx-mcp/src/tools/odf/odf_tools.test.ts
@@ -155,8 +155,11 @@ describe('ODF MCP provider lane', () => {
   );
 
   test.openspec('[OPLR-04] Unsupported tools are guarded for ODF')(
-    'compare_documents on an .odt session returns UNSUPPORTED_FOR_ODF before DOCX logic',
+    'format_layout on an .odt session returns UNSUPPORTED_FOR_ODF before DOCX logic',
     async ({ given, when, then }: AllureBddContext) => {
+      // Originally exercised via compare_documents, then add_comment — both became supported
+      // (add-odf-compare / add-odf-compare-session / add-odf-comments), so the guard example was
+      // re-pointed at format_layout, which remains DOCX-only.
       let manager: SessionManager;
       let filePath: string;
       let result: Awaited<ReturnType<typeof dispatchToolCall>>;
@@ -167,10 +170,10 @@ describe('ODF MCP provider lane', () => {
         const read = await dispatchToolCall(manager, 'read_file', { file_path: filePath });
         assertSuccess(read, 'read_file');
       });
-      await when('a DOCX-only phase-2 tool targets the .odt path', async () => {
-        result = await dispatchToolCall(manager, 'compare_documents', {
+      await when('a DOCX-only tool targets the .odt path', async () => {
+        result = await dispatchToolCall(manager, 'format_layout', {
           file_path: filePath,
-          save_to_local_path: path.join(path.dirname(filePath), 'redline.docx'),
+          page_size: 'LETTER',
         });
       });
       await then('the provider chokepoint returns UNSUPPORTED_FOR_ODF', () => {


### PR DESCRIPTION
Fixes #357. Builds on the merged paragraph-granularity engine (#348, `add-odf-compare`); independent of the intra-paragraph follow-up (#356).

## What

`compare_documents` with a single `.odt` `file_path` (session mode) now compares the live session's edited state against the original it was opened from and writes an ODF tracked-changes redline — replacing the `UNSUPPORTED_FOR_ODF` guard. The engine is unchanged; this is routing plus a session-aware entry point (`odfCompareDocumentsSession`) registered in the standard ODF session lane (`dispatchOdf`), so the response carries the same session-resolution metadata as the other ODF session tools (`mode: 'session'`, `session_resolution`, `reused_session_context`, …).

## Key decisions

- **Fresh archive from `session.originalBuffer` for both baseline and redline packaging.** `saveOdfTo` stamps the live `session.archive` with edited content on every save, so it's not a valid baseline source, and the compare must not poison it with redline markup (pinned by OPCS-06). Packaging on the original package is valid under the current invariant that ODF session edit tools mutate `content.xml` only — stated in the handler comment for whoever breaks it.
- **No normalized baseline needed** (the issue's flagged risk): `compareOdf` diffs per-block *visible text*, which a parse→serialize round-trip doesn't alter. Pinned by OPCS-02, including a fixture with `text:s`/`text:tab`/`text:line-break`/`text:h`/entities/`office:annotation`.
- **Two-file precedence across all providers** (peer-review finding): previously a stray `.odt` `file_path` made a two-`.docx` compare fail `UNSUPPORTED_FOR_ODF`; the restructured routing mirrors the DOCX tool's own `twoFileMode` precedence (pinned by OPCS-07).
- **No `allow_overwrite` escape** for an output path resolving to the session original — comparison inputs are never overwritable (parity with #313).

## OpenSpec

- New change `add-odf-compare-session` (mcp-server, scenarios OPCS-01..07), validated `--strict`.
- Amends the pending `add-odf-compare` delta: drops the "session mode SHALL return UNSUPPORTED_FOR_ODF" clause and re-points `[OPCD-04]` at a still-unsupported tool (`accept_changes`) — the same flip `[OPLR-08]` got in #348 — so the generic guard keeps its own coverage.

## Verification

- Full local gate: build, lint, **all workspace tests**, `check:spec-coverage` (7/7 OPCS scenarios mapped), `check:tool-docs`, allure gates, conformance gates, cycles.
- **Real-document smoke** (NVCA model COI → `.odt` via LibreOffice): open session → `replace_text` + `insert_paragraph` + `add_comment` → session compare. Stats exactly match the edits (1 del + 2 ins; the comment correctly produces no text change). Redline reopens with revised text; deleted text stays out-of-line.
- **LibreOffice headless accept/reject round trip** on that redline (macro-injection oracle): accept-all ≡ edited session text, reject-all ≡ original — projection-to-projection with bookmark-ref display caches neutralized (LO re-resolves field caches at store time; all 35 bookmark targets and paragraph counts are exact).