### PR TITLE
feat(odf-core,docx-mcp): ODF compare_documents — intra-paragraph (run-level) tracked changes (#356)

### DIFF
--- a/openspec/changes/add-odf-intra-paragraph-compare/design.md
+++ b/openspec/changes/add-odf-intra-paragraph-compare/design.md
@@ -1,0 +1,97 @@
+# Design — ODF intra-paragraph tracked changes
+
+## Oracle decision log (LibreOffice 25.x authoring, 2026-06-10)
+
+Method: `.tmp/odf-inline-oracle/run_author_oracle.sh` — a throwaway clone of the
+`reference_libreoffice_macos_oracle` recipe. Each scenario loads a flat-ODF fixture headlessly,
+sets `RecordChanges = True`, performs cursor edits (`createTextCursorByRange` + `goRight` +
+`setString`), stores as `writer8`, and the script dumps `content.xml`. Each scenario below is a
+decision gate; the recorded shape is what LibreOffice itself authors and is therefore the
+emitter's target markup. (Basic gotcha for future runs: `BASE` is a reserved word in StarBasic
+— a `Const BASE` silently kills module compilation and soffice hangs without running the macro.)
+
+- **O1 — delete one word mid-paragraph.** Kept paragraph keeps the surrounding text with a
+  single point marker at the deletion offset: `Alpha <text:change/>charlie delta.`. The
+  `text:deletion` region stores ONE `text:p` (host paragraph's `text:style-name`) containing
+  exactly the deleted content (`bravo `). **No empty merge-artifact paragraph** — that artifact
+  belongs only to whole-paragraph deletion (a deleted paragraph break).
+- **O2 — insert one word mid-paragraph.** Inserted content stays inline, bracketed:
+  `Alpha bravo <text:change-start/>inserted <text:change-end/>charlie delta.`; the
+  `text:insertion` region holds only `office:change-info`.
+- **O3 — replace a word.** ORDER CORRECTION vs the original plan: LibreOffice emits the
+  insertion bracket FIRST and the deletion point marker AFTER it:
+  `charlie <text:change-start/>echo<text:change-end/><text:change/>.` — i.e. the replace's
+  deletion anchor sits after the replacement's `text:change-end`, not before its
+  `text:change-start`. (Slice 1's whole-paragraph OCMP-10 deletion-first rule does NOT carry
+  over to inline replaces.) Emitter rule: a delete span anchors at its revised offset, bumped
+  past a co-located insertion's bracket; at one offset the document order is `text:change-end`,
+  then `text:change`, then `text:change-start`.
+- **O4 — edits at paragraph start/end.** Point markers sit as the first / last inline child of
+  the paragraph: `<text:p><text:change/>bravo …` and `…paragraph <text:change/></text:p>`.
+- **O5 — delete crossing a bold `text:span` boundary.** One point marker at the span's start
+  offset, at the depth where the deletion begins (block level here): `Lea<text:change/>
+  <text:span>word</text:span> tail.`. The stored deletion preserves the inline structure of the
+  covered fragments: `<text:p>d <text:span T1>bold</text:span></text:p>`. No
+  `change-start`/`change-end` depth-mismatch question arises for deletions — they are point
+  markers; brackets only wrap insertions, whose content we control.
+- **O6 — partial delete of `text:s text:c="5"` (2 of 5).** Kept paragraph rebalances the run
+  (LO chose plain-space + `text:s text:c="2"`; count arithmetic is what matters). Stored
+  content is `<text:p><text:s text:c="2"/></text:p>` — the deleted spaces as a `text:s`.
+- **O7 — delete across `text:tab` / `text:line-break`.** Virtual elements are copied whole
+  into the stored content (`t<text:tab/>R`, `p<text:line-break/>D`); the kept paragraph joins
+  the remainders around a single point marker.
+- **O8 — whole-paragraph delete + inline delete at the next paragraph's start.** LibreOffice
+  COALESCES both into one `text:deletion` region: stored = full deleted paragraph + a second
+  `text:p` holding the inline-deleted prefix (`Second `), one marker at the kept paragraph's
+  start. (Slice 1's empty merge artifact is the special case of this where the deleted prefix
+  is empty.) Our emitter keeps them as SEPARATE regions (whole-paragraph run + inline modify) —
+  the composed two-marker shape is not LO-authorable, so it is verified by the accept/reject
+  round-trip oracle instead (accept-all → revised text, reject-all → original text).
+- **O9 — whole bold word deleted.** Stored content is the full `text:span`. The kept paragraph
+  shows LO's ODF whitespace normalization (second adjacent space became `<text:s/>`). Our
+  emitter does not edit kept text (the revised paragraph's encoding is kept verbatim; deleted
+  text was never in it), so this normalization concern applies only to LO-authored docs, not to
+  our output.
+- **O10 — inline delete inside a heading.** Fully supported by LO: the kept `text:h` carries
+  the point marker, and the deletion region stores a **`text:h`** mirroring the source block
+  (`text:style-name`, `text:outline-level`). PLAN CORRECTION: heading modify pairs do NOT
+  degrade; the stored block mirrors the host block's element name and attributes.
+
+## Emitter structure (three lanes)
+
+`emitTrackedChanges` plans purely, then mutates:
+1. **Whole-paragraph runs** (`insert`/`delete` ops) — unchanged Slice-1 shapes. A `modify`
+   paragraph is a survivor for anchoring: it advances the revised cursor like `equal` and
+   terminates any open run.
+2. **Inline modify plans** — per pair: `diffInline` over the two visible texts → marker
+   placements (descending revised offset; each offset group resolved once via `resolveOffset`,
+   markers inserted at that point in the O3 document order) + one changed-region per span.
+   Deleted-span content comes from `extractVisibleRange(originalBlock, …)` imported into the
+   revised doc, wrapped in a block mirroring the host (O10).
+3. **Degrade valve** — a pair whose planning throws (`OdfMapError` or any span anomaly)
+   re-routes to lane 1 as a whole-paragraph delete+insert at the same slot, decided before any
+   markup is written; counted in `EmitResult.degradedModifications`.
+
+Stats count changed-regions (one per inline span, one per whole-paragraph op, `modifications`
+per surviving pair) so reported stats always match emitted markup.
+
+## Round-trip oracle findings (gated `runLibreOfficeOracle`, `.odt` jobs)
+
+Accept-all/reject-all through real LibreOffice round-trips the inline shapes exactly: a redline
+mixing a modify pair, a mid-document dissimilar replacement, and an end-of-document insertion
+accepts to the revised texts and rejects to the originals (`lo_inline_roundtrip.test.ts`,
+[OCMPI-13]). One PRE-EXISTING Slice-1 defect surfaced: reject-all of a dissimilar
+whole-paragraph replacement of the LAST paragraph merges the preceding paragraph with the
+restored deletion and leaves a trailing empty paragraph (the deletion marker anchors inside the
+inserted replacement paragraph while the end-of-document insertion bracket starts in the
+preceding one). Filed as issue #367 and pinned as a gated characterization test; not fixed here
+(one fix per PR), and #356 narrows its exposure since similar replacements now become inline
+modify pairs.
+
+## Similarity pairing
+
+Order-constrained DP per gap (deletes-then-inserts, a shape verified exhaustively over 14,641
+LCS cases): maximize pair count, then total Jaccard word-overlap (lowercase, punctuation
+stripped); admissible at `similarityThreshold` (default 0.25 — docx-core's reference point).
+Ties: pairing > skip-delete > skip-insert. TF-IDF (docx-core's main path) is a future upgrade —
+it needs corpus-wide IDF and exists to handle boilerplate-heavy corpora.

--- a/openspec/changes/add-odf-intra-paragraph-compare/proposal.md
+++ b/openspec/changes/add-odf-intra-paragraph-compare/proposal.md
@@ -1,0 +1,61 @@
+# Change: ODF `compare_documents` — intra-paragraph (run-level) tracked changes (Slice 2)
+
+## Why
+Slice 1 (`add-odf-compare`, issue #348) made two-file `.odt` `compare_documents` work at
+**whole-paragraph** granularity: any paragraph whose text changed at all is emitted as a delete
+of the entire old paragraph plus an insert of the entire new one. For real review work —
+especially legal prose, where paragraphs are long — that is coarse and noisy: a one-word edit
+shows the whole clause struck through and re-inserted, and `stats.modifications` is hard-wired
+to `0` because there is no notion of an in-place modification. The DOCX path already diffs down
+to the run/atom level within a matched paragraph; this change brings the ODF lane to parity
+(issue #356).
+
+## What Changes
+- `@usejunior/odf-core`:
+  - `compare/diff.ts`: new `modify` EditOp variant plus `pairModifications(ops, original,
+    revised, similarityThreshold)` — a post-pass over the Slice-1 LCS that converts similar
+    delete/insert pairs inside each gap into `modify` ops via an order-constrained,
+    deterministic DP (maximize pair count, then total Jaccard word-overlap; pairs admissible at
+    `similarityThreshold`, default 0.25 mirroring docx-core's reference point).
+  - New `compare/inline_diff.ts`: pure token-level LCS over a modify pair's visible text
+    (tokens = maximal whitespace / non-whitespace runs; common token prefix/suffix trimmed),
+    returning char-offset `SpanOp`s on clean word boundaries.
+  - New `compare/inline_map.ts`: visible-offset → DOM mapping that splits `#text` nodes and
+    `text:s` runs at span boundaries (`resolveOffset`) and clones a visible range's inline
+    content for out-of-line deletion storage (`extractVisibleRange`).
+  - `shared/odf/text_segments.ts`: the `virtual` Segment variant additionally carries its host
+    `Element` and a `virtual: 'space' | 'tab' | 'line-break'` discriminator (additive).
+  - `compare/emit.ts`: explicit `equal | insert | delete | modify` planning lanes. A modify
+    pair's revised paragraph stays in place; inserted spans are bracketed inline by
+    `text:change-start`/`text:change-end`, deleted spans leave an inline `text:change` point
+    marker and move their content into the `text:deletion` changed-region (no merge-artifact
+    paragraph — no paragraph break died). Pairs that cannot be mapped cleanly degrade to the
+    Slice-1 whole-paragraph delete+insert (correctness valve).
+  - `compare/index.ts`: `OdfCompareOptions.similarityThreshold`; meaningful stats (see spec
+    delta): one `modifications` per successful pair, inner spans counted toward
+    `insertions`/`deletions` (one per changed-region, keeping rough parity with the DOCX
+    atom-level counts).
+- `@usejunior/docx-core`: `integration/libreoffice-oracle.ts` gains an `.odt` format dimension
+  (FilterName `writer8`, `content.xml` extraction) so a soffice-gated round-trip test can
+  assert accept-all reproduces the revised text and reject-all the original.
+- `@usejunior/docx-mcp`: ODF `compare_documents` reports `granularity: 'inline'` with an
+  updated message; tool catalog + generated docs updated.
+
+## Supersedes (archive-time resolution)
+`add-odf-compare` is merged but not yet archived. This change supersedes two of its clauses:
+- odf-core: "A modified paragraph SHALL be emitted as a deletion plus an insertion, so
+  `modifications` SHALL be `0`" — now only the below-threshold fallback behaves that way.
+- mcp-server: `granularity: 'paragraph'` and the "counts run higher than the DOCX atom-level
+  path" message — now `granularity: 'inline'`.
+When both changes archive, the requirements in THIS change's deltas are the surviving text for
+those clauses.
+
+## Impact
+- Affected specs: `odf-core` (intra-paragraph comparison requirement), `mcp-server` (inline
+  granularity surface).
+- Affected code: `packages/odf-core/src/compare/*`, `packages/odf-core/src/shared/odf/
+  text_segments.ts`, `packages/docx-core/src/integration/libreoffice-oracle.ts`,
+  `packages/docx-mcp/src/tools/odf/compare_documents.ts`, `packages/docx-mcp/src/
+  tool_catalog.ts` + regenerated tool reference.
+- Out of scope (unchanged from Slice 1's deferrals): session-mode ODF compare, `.ods`/`.odp`,
+  accept/reject of ODF tracked changes, DOCX↔ODF conversion.

--- a/openspec/changes/add-odf-intra-paragraph-compare/specs/mcp-server/spec.md
+++ b/openspec/changes/add-odf-intra-paragraph-compare/specs/mcp-server/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: ODF two-file `compare_documents` reports inline granularity
+
+The ODF two-file `compare_documents` handler SHALL report `granularity: 'inline'`
+(superseding the Slice-1 `'paragraph'` value) once intra-paragraph comparison lands in
+`@usejunior/odf-core`, and its `message` SHALL describe the stats unit — changed-regions:
+modified paragraphs count once in `modifications` with their inner inserted/deleted spans
+counted in `insertions`/`deletions`; whole-paragraph changes count one each. The message SHALL
+no longer claim that a modified paragraph counts as one deletion plus one insertion or that
+counts run higher than the DOCX path.
+
+All other Slice-1 surface behavior (two-file dispatch, output-path safety, session-mode
+`UNSUPPORTED_FOR_ODF`, DOCX path untouched) SHALL be unchanged.
+
+#### Scenario: [OPDI-01] Two-file `.odt` compare reports inline granularity and meaningful modifications
+- **WHEN** `compare_documents` runs on two `.odt`s where one paragraph has a one-word edit
+- **THEN** the response carries `granularity: 'inline'` and `stats.modifications` of at least 1
+
+#### Scenario: [OPDI-02] Whole-paragraph-only diffs still report zero modifications
+- **WHEN** `compare_documents` runs on two `.odt`s that differ only by added and removed paragraphs (no similar pair)
+- **THEN** `stats.modifications` is 0 while `stats.insertions`/`stats.deletions` count the changed paragraphs

--- a/openspec/changes/add-odf-intra-paragraph-compare/specs/odf-core/spec.md
+++ b/openspec/changes/add-odf-intra-paragraph-compare/specs/odf-core/spec.md
@@ -1,0 +1,103 @@
+## ADDED Requirements
+
+### Requirement: ODF intra-paragraph comparison (modify pairs + inline tracked changes)
+
+`compareOdf` SHALL detect **modify pairs**: an aligned-but-differing original/revised paragraph
+pair whose Jaccard word-overlap (lowercased, punctuation-stripped word sets) is at least
+`opts.similarityThreshold` (default `0.25`). Pairing SHALL run as a post-pass over the
+paragraph-level LCS, inside each gap (a run of deletes followed by a run of inserts between two
+anchors), using an order-constrained, deterministic DP that maximizes the pair count and then
+the total similarity; at ties, pairing beats skipping and skipping a delete beats skipping an
+insert. Empty paragraphs SHALL never pair. Below-threshold pairs SHALL keep the Slice-1
+whole-paragraph delete+insert representation.
+
+For a modify pair, the engine SHALL diff **within** the paragraph using a pure token-level LCS
+over the two visible-text strings (tokens are maximal whitespace or non-whitespace runs — a
+partition, so spans land on word boundaries and map losslessly to char offsets), with the
+common token prefix/suffix trimmed before the DP. A replaced word SHALL surface as a `delete`
+span immediately followed by an `insert` span sharing the same revised offset.
+
+The emitter SHALL keep the modify pair's revised paragraph in place and emit inline markup:
+- An **inserted span** SHALL remain inline, bracketed by `text:change-start` and
+  `text:change-end` markers referencing a `text:insertion` changed-region.
+- A **deleted span** SHALL leave a single inline `text:change` point marker at the deletion
+  offset; its content SHALL move out-of-line into a `text:deletion` changed-region holding one
+  block element **mirroring the host block** (`text:p` or `text:h`, carrying its
+  `text:style-name` and, for headings, `text:outline-level`) with the deleted inline content —
+  and NO empty merge-artifact paragraph, since no paragraph break was deleted. Inline
+  formatting (`text:span`, hyperlinks) of the deleted content SHALL be preserved in the stored
+  copy.
+- Span boundaries SHALL be mapped onto the revised paragraph's DOM by splitting `#text` nodes
+  and `text:s` runs (rebalancing `text:c`) at the visible offsets; `text:tab` and
+  `text:line-break` are length-1 and SHALL only ever be covered whole. Markers SHALL sit at the
+  split point's natural nesting depth.
+- When a deleted span and an inserted span share an offset (a replacement), the insertion
+  bracket SHALL come first and the `text:change` point marker SHALL follow the
+  `text:change-end` — the LibreOffice-authored order. At a single offset the document order
+  SHALL be `text:change-end`, then `text:change`, then `text:change-start`. When
+  intra-paragraph markers and a whole-paragraph deletion marker share a paragraph start, the
+  whole-paragraph `text:change` SHALL precede the intra-paragraph markers.
+
+A modify pair whose spans cannot be mapped cleanly onto the DOM SHALL **degrade** to the
+Slice-1 whole-paragraph delete+insert for that pair, decided before any of its markup is
+written.
+
+Stats SHALL count changed-regions: each successful modify pair adds 1 to `modifications`, each
+of its inserted spans adds 1 to `insertions`, and each of its deleted spans adds 1 to
+`deletions`; whole-paragraph ops keep their Slice-1 counting (1 per paragraph); a degraded pair
+counts 1 insertion + 1 deletion and no modification.
+
+The Slice-1 no-leak invariant SHALL hold unchanged: content stored in `text:tracked-changes`
+SHALL NOT appear in `getParagraphs()` or any visible-text walk.
+
+#### Scenario: [OCMPI-01] Inner token diff yields word-boundary spans that reconstruct both strings
+- **WHEN** the intra-paragraph diff runs over two visible-text strings differing by one word
+- **THEN** it returns equal/delete/insert spans on word boundaries whose equal+delete spans concatenate to the original and equal+insert spans to the revised, with the delete ordered before the insert at the shared offset
+
+#### Scenario: [OCMPI-02] Similar aligned paragraphs pair as modify; dissimilar fall back
+- **WHEN** the post-pass examines a gap whose delete/insert pair shares at least the similarity threshold of words (and another whose pair shares almost none)
+- **THEN** the similar pair becomes a single `modify` op and the dissimilar pair stays a whole-paragraph delete plus insert
+
+#### Scenario: [OCMPI-03] Inline insertion is bracketed in the kept paragraph
+- **WHEN** `compareOdf` processes a modify pair whose revised text adds a word mid-paragraph
+- **THEN** the kept paragraph contains `text:change-start` and `text:change-end` around exactly the inserted word, referencing a `text:insertion` region, and the rest of the paragraph is untouched
+
+#### Scenario: [OCMPI-04] Inline deletion leaves a point marker and stores content without a merge artifact
+- **WHEN** `compareOdf` processes a modify pair whose revised text removes a word
+- **THEN** the kept paragraph contains a single `text:change` point marker at the deletion offset, the `text:deletion` region stores one `text:p` containing exactly the deleted content, and no empty merge-artifact paragraph is added
+
+#### Scenario: [OCMPI-05] A replaced word orders the insertion bracket before the deletion marker
+- **WHEN** a modify pair replaces one word (delete span and insert span share an offset)
+- **THEN** the `text:change` point marker appears immediately after the insertion's `text:change-end`, matching the LibreOffice-authored replace shape
+
+#### Scenario: [OCMPI-06] Stored inline deletion content does not leak into the paragraph stream
+- **WHEN** `getParagraphs()` runs over a redline containing inline modify markup
+- **THEN** each modified paragraph's visible text is exactly the revised text and the deleted spans appear nowhere in the paragraph stream
+
+#### Scenario: [OCMPI-07] Intra-paragraph markers compose with whole-paragraph changes at a shared anchor
+- **WHEN** a document deletes paragraph N−1 entirely and also has a modify pair at paragraph N with an edit at offset 0
+- **THEN** the whole-paragraph deletion's `text:change` marker precedes the intra-paragraph markers at the start of paragraph N and both changes accept/reject independently
+
+#### Scenario: [OCMPI-08] Unmappable modify pairs degrade to whole-paragraph delete+insert
+- **WHEN** a modify pair's span mapping fails
+- **THEN** that pair is emitted as a Slice-1 whole-paragraph deletion plus insertion with no partial inline markup, and stats count it as one insertion plus one deletion
+
+#### Scenario: [OCMPI-09] Stats count changed-regions
+- **WHEN** a compare produces one modify pair containing two deleted spans and one inserted span plus one whole-paragraph insertion
+- **THEN** stats report `modifications: 1`, `deletions: 2`, `insertions: 2`
+
+#### Scenario: [OCMPI-10] Edits touching virtual segments map onto the DOM correctly
+- **WHEN** a deleted span covers part of a `text:s` run (or a whole `text:tab`/`text:line-break`)
+- **THEN** the `text:s` count is rebalanced at the boundary (tab/line-break copied whole into the stored content) and the redline's visible text equals the revised text
+
+#### Scenario: [OCMPI-11] Formatting spans are preserved in stored deletion content
+- **WHEN** a deleted span covers text inside a `text:span` (or crosses its boundary)
+- **THEN** the stored deletion content keeps the `text:span` structure for the covered portion and the kept paragraph's remaining formatting is unchanged
+
+#### Scenario: [OCMPI-12] Heading modify pairs store a mirrored `text:h`
+- **WHEN** a modify pair's host block is a `text:h` with a deleted span
+- **THEN** the `text:deletion` region stores a `text:h` carrying the host's `text:style-name` and `text:outline-level`, and the kept heading carries the point marker inline
+
+#### Scenario: [OCMPI-13] LibreOffice accept/reject round-trips the inline redline
+- **WHEN** LibreOffice (when available) runs accept-all and reject-all over a generated redline containing a modify pair plus whole-paragraph changes
+- **THEN** accept-all reproduces the revised document's visible paragraph texts and reject-all reproduces the original's

--- a/openspec/changes/add-odf-intra-paragraph-compare/tasks.md
+++ b/openspec/changes/add-odf-intra-paragraph-compare/tasks.md
@@ -1,0 +1,27 @@
+# Tasks
+
+## Phase 0 — oracle confirmation (gate: emitter shapes settled before emitter code)
+- [x] LibreOffice authoring oracle (throwaway, `.tmp/odf-inline-oracle/`): author O1–O10 intra-paragraph tracked changes (`RecordChanges` + cursor edits, store `writer8`), inspect each `content.xml`, record the confirmed shapes as a decision log in `design.md`
+
+## odf-core
+- [x] `compare/inline_diff.ts`: token-level LCS (`diffInline`) with prefix/suffix trim, char-offset `SpanOp`s, delete-before-insert at ties, coalescing; `inline_diff.test.ts` incl. reconstruction property invariant
+- [x] `compare/diff.ts`: `modify` EditOp variant + `pairModifications` (order-constrained DP: max pair count then total Jaccard; threshold 0.25 default; deterministic tie-breaks; deletes-then-inserts segment order); extend `diff.test.ts` (threshold pass/fail, 2-deletes+1-insert, empties)
+- [x] `shared/odf/text_segments.ts`: virtual `Segment` gains `node: Element` + `virtual: 'space' | 'tab' | 'line-break'` (additive; `rg buildSegments` confirms no caller breaks)
+- [x] `compare/inline_map.ts`: `resolveOffset` (manual `#text` split, `text:s` rebalance, block-edge points, re-segment per call) + `extractVisibleRange` (clone inline content preserving spans/links, edge trims, whole tab/line-break); `inline_map.test.ts` with serialized-XML assertions
+- [x] `compare/emit.ts`: explicit `equal | insert | delete | modify` planning lanes; `ModifyPlan` built purely before mutation; degrade valve (incl. `text:h` pending oracle); inline-deletion region stores one styled `text:p`, no merge artifact; descending-offset marker placement; whole-paragraph markers placed after intra markers; `emitTrackedChanges` returns `EmitResult` counts
+- [x] `compare/emit_inline.test.ts`: OCMPI-03..11 shapes per oracle log; no-leak; structural round-trip (revised minus insert spans plus spliced deletions = original)
+- [x] `compare/index.ts`: `similarityThreshold` option; pipeline `diffParagraphs → pairModifications → emit`; changed-region stats rule; fix the "modifications is always 0" doc comment
+
+## docx-core
+- [x] `integration/libreoffice-oracle.ts`: `.odt` format dimension (FilterName `writer8`, `content.xml` extraction, pre-packed buffer input); keep `.docx` default path identical
+- [x] Gated round-trip vitest (skips when `resolveSoffice()` is null): accept-all on a generated inline redline reproduces the revised visible text; reject-all reproduces the original
+
+## docx-mcp
+- [x] `tools/odf/compare_documents.ts`: `granularity: 'inline'`, rewritten message (stats unit), stats passthrough
+- [x] Update `odf_compare.test.ts` granularity assertions/describe text; new test file `TEST_FEATURE='add-odf-intra-paragraph-compare'` covering OPDI-01..02
+- [x] `tool_catalog.ts` ODF compare description; regenerate `tool-reference.generated.md`
+
+## Verification
+- [x] `openspec validate add-odf-intra-paragraph-compare --strict`; spec-coverage maps every OCMPI/OPDI scenario
+- [x] Full local CI gate (build, lint:workspaces, test:run, check:spec-coverage, conformance checks)
+- [x] Document-shaped `.odt` smoke: real document with sub-paragraph edits through `compare_documents`; redline opens in LibreOffice with inline changes visible and acceptable

--- a/packages/docx-core/src/index.ts
+++ b/packages/docx-core/src/index.ts
@@ -117,3 +117,7 @@ export type {
   RevisionContextOptions,
   RevisionIdState,
 } from './primitives/track-changes-emitter.js';
+
+// Re-export the LibreOffice accept/reject oracle (gated reference voter; callers skip when
+// `resolveSoffice()` is null). odf-core's round-trip tests drive it with `.odt` jobs.
+export { resolveSoffice, runLibreOfficeOracle, type OracleJob } from './integration/libreoffice-oracle.js';

--- a/packages/docx-core/src/integration/libreoffice-oracle.ts
+++ b/packages/docx-core/src/integration/libreoffice-oracle.ts
@@ -126,7 +126,7 @@ const REGMOD = `<?xml version="1.0" encoding="UTF-8"?>
 </oor:items>`;
 
 /** The Basic macro: load each doc Hidden, dispatch accept/reject-all (or, for `identity`,
- *  dispatch nothing at all), save as MS Word 2007 XML. */
+ *  dispatch nothing at all), save with the job's filter. */
 function module1Xba(jobsPath: string, markerPath: string): string {
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE script:module PUBLIC "-//OpenOffice.org//DTD OfficeDocument 1.0//EN" "module.dtd">
@@ -140,14 +140,14 @@ Sub RunOracle
     Line Input #iFile, sLine
     If Len(Trim(sLine)) &gt; 0 Then
       parts = Split(sLine, "|")
-      ProcessOne(parts(0), ConvertToURL(parts(1)), ConvertToURL(parts(2)))
+      ProcessOne(parts(0), ConvertToURL(parts(1)), ConvertToURL(parts(2)), parts(3))
     End If
   Loop
   Close #iFile
   StarDesktop.terminate()
 End Sub
 
-Sub ProcessOne(op As String, inUrl As String, outUrl As String)
+Sub ProcessOne(op As String, inUrl As String, outUrl As String, filterName As String)
   Dim oDoc As Object, oFrame As Object, oDisp As Object
   Dim loadArgs(0) As New com.sun.star.beans.PropertyValue
   loadArgs(0).Name = "Hidden" : loadArgs(0).Value = True
@@ -163,7 +163,7 @@ Sub ProcessOne(op As String, inUrl As String, outUrl As String)
   ' op = "identity": no dispatch — a plain load-&gt;save, exposing LibreOffice's own DOCX
   ' import/export of UNRESOLVED tracked changes (the oracle trust-boundary check).
   Dim saveArgs(0) As New com.sun.star.beans.PropertyValue
-  saveArgs(0).Name = "FilterName" : saveArgs(0).Value = "MS Word 2007 XML"
+  saveArgs(0).Name = "FilterName" : saveArgs(0).Value = filterName
   oDoc.storeToURL(outUrl, saveArgs())
   oDoc.close(False)
 End Sub
@@ -173,15 +173,25 @@ End Sub
 /**
  * `accept` / `reject` dispatch the corresponding resolve-all command before saving — the oracle's
  * normal voting mode. `identity` loads and saves WITHOUT any dispatch, so unresolved tracked
- * changes flow through LibreOffice's DOCX import/export: it exists to characterize the oracle's
+ * changes flow through LibreOffice's import/export: it exists to characterize the oracle's
  * trust boundary (LibreOffice's save round-trip mangles some unresolved revision shapes — see
  * libreoffice-oracle-trust-boundary.test.ts), NOT to vote on engine behavior.
+ *
+ * DOCX jobs carry a bare `word/document.xml` (packed into a minimal package and read back out);
+ * ODT jobs carry a complete `.odt` package buffer (ODF packaging — mimetype-first STORED — is
+ * the caller's concern) and return its post-op `content.xml`.
  */
-export type OracleJob = { op: 'accept' | 'reject' | 'identity'; documentXml: string };
+type OracleOp = 'accept' | 'reject' | 'identity';
+export type OracleJob = { op: OracleOp; documentXml: string } | { op: OracleOp; odt: Buffer };
+
+function isOdtJob(job: OracleJob): job is { op: OracleOp; odt: Buffer } {
+  return 'odt' in job;
+}
 
 /**
- * Run LibreOffice over a batch of jobs in ONE headless launch and return the resulting
- * `word/document.xml` of each. Throws if the binary is missing or the macro did not run.
+ * Run LibreOffice over a batch of jobs in ONE headless launch and return each job's resulting
+ * main XML part — `word/document.xml` for DOCX jobs, `content.xml` for ODT jobs. Throws if the
+ * binary is missing or the macro did not run.
  */
 export async function runLibreOfficeOracle(jobs: OracleJob[], soffice = resolveSoffice()): Promise<string[]> {
   if (!soffice) throw new Error('runLibreOfficeOracle: no soffice binary (call resolveSoffice() and skip)');
@@ -201,15 +211,18 @@ export async function runLibreOfficeOracle(jobs: OracleJob[], soffice = resolveS
   try {
     for (const d of [userDir, basicDir, inDir, outDir]) mkdirSync(d, { recursive: true });
 
-    // Pack each job's input .docx and build the jobs file (op|inPath|outPath).
+    // Write each job's input package and build the jobs file (op|inPath|outPath|filter).
     const outPaths: string[] = [];
     const jobLines: string[] = [];
     for (let i = 0; i < jobs.length; i++) {
-      const inPath = path.join(inDir, `job${i}.docx`);
-      const outPath = path.join(outDir, `job${i}.docx`);
-      writeFileSync(inPath, await packMinimalDocx(jobs[i]!.documentXml));
+      const job = jobs[i]!;
+      const ext = isOdtJob(job) ? 'odt' : 'docx';
+      const filter = isOdtJob(job) ? 'writer8' : 'MS Word 2007 XML';
+      const inPath = path.join(inDir, `job${i}.${ext}`);
+      const outPath = path.join(outDir, `job${i}.${ext}`);
+      writeFileSync(inPath, isOdtJob(job) ? new Uint8Array(job.odt) : new Uint8Array(await packMinimalDocx(job.documentXml)));
       outPaths.push(outPath);
-      jobLines.push(`${jobs[i]!.op}|${inPath}|${outPath}`);
+      jobLines.push(`${job.op}|${inPath}|${outPath}|${filter}`);
     }
     writeFileSync(jobsPath, jobLines.join('\n') + '\n');
 
@@ -252,8 +265,13 @@ export async function runLibreOfficeOracle(jobs: OracleJob[], soffice = resolveS
           (keepWork ? `\n(profile kept for debugging at ${work})` : ' (set SAFE_DOCX_ORACLE_DEBUG=1 to keep the profile)'),
       );
     }
-    return Promise.all(outPaths.map(async (p) => {
+    return Promise.all(outPaths.map(async (p, i) => {
       if (!existsSync(p)) throw new Error(`LibreOffice oracle produced no output for ${path.basename(p)}`);
+      if (isOdtJob(jobs[i]!)) {
+        const contentXml = await readZipText(readFileSync(p), 'content.xml');
+        if (contentXml == null) throw new Error(`content.xml not found in oracle output ${path.basename(p)}`);
+        return contentXml;
+      }
       return extractDocumentXml(readFileSync(p));
     }));
   } finally {

--- a/packages/docx-mcp/docs/tool-reference.generated.md
+++ b/packages/docx-mcp/docs/tool-reference.generated.md
@@ -260,7 +260,7 @@ Delete a comment and all its threaded replies from the document. Cascade-deletes
 
 ## `compare_documents`
 
-Compare two documents and produce a tracked-changes output document. Provide original_file_path + revised_file_path for standalone comparison, or file_path to compare session edits against the original. DOCX and ODF (.odt) support both modes; ODF compares at paragraph granularity (a modified paragraph counts as one deletion plus one insertion).
+Compare two documents and produce a tracked-changes output document. Provide original_file_path + revised_file_path for standalone comparison, or file_path to compare session edits against the original. DOCX and ODF (.odt) support both modes; ODF compares at inline granularity (a modified paragraph is marked up in place — only the changed spans are struck or inserted).
 
 - readOnly: `true`
 - destructive: `false`

--- a/packages/docx-mcp/src/tool_catalog.ts
+++ b/packages/docx-mcp/src/tool_catalog.ts
@@ -312,7 +312,7 @@ export const SAFE_DOCX_TOOL_CATALOG = [
   {
     name: 'compare_documents',
     description:
-      'Compare two documents and produce a tracked-changes output document. Provide original_file_path + revised_file_path for standalone comparison, or file_path to compare session edits against the original. DOCX and ODF (.odt) support both modes; ODF compares at paragraph granularity (a modified paragraph counts as one deletion plus one insertion).',
+      'Compare two documents and produce a tracked-changes output document. Provide original_file_path + revised_file_path for standalone comparison, or file_path to compare session edits against the original. DOCX and ODF (.odt) support both modes; ODF compares at inline granularity (a modified paragraph is marked up in place — only the changed spans are struck or inserted).',
     input: z.object({
       original_file_path: z.string().optional().describe('Path to the original DOCX or .odt file.'),
       revised_file_path: z.string().optional().describe('Path to the revised DOCX or .odt file.'),

--- a/packages/docx-mcp/src/tools/odf/compare_documents.ts
+++ b/packages/docx-mcp/src/tools/odf/compare_documents.ts
@@ -21,7 +21,7 @@ function resolveAuthor(explicit?: string): string {
 }
 
 /**
- * ODF `compare_documents` — paragraph-granularity TWO-FILE mode.
+ * ODF `compare_documents` — inline granularity (issue #356), TWO-FILE mode.
  *
  * Stateless (mirrors the DOCX `compareDocuments_tool`): it does its own loading and takes no
  * resolved session, because two-file compare carries no `file_path` and so cannot route through
@@ -103,12 +103,12 @@ export async function odfCompareDocuments(
       saved_to: savePath,
       size_bytes: buffer.length,
       author,
-      granularity: 'paragraph',
+      granularity: 'inline',
       stats: result.stats,
       message:
         `Redline comparing '${originalLoaded.filename}' vs '${revisedLoaded.filename}' saved to ${savePath}. ` +
-        'Changes are tracked at the whole-paragraph level (a modified paragraph counts as one ' +
-        'deletion plus one insertion), so insertion/deletion counts may run higher than the DOCX path.',
+        'Stats count changed-regions: a modified paragraph counts once in modifications with each ' +
+        'changed span inside it counted in insertions/deletions; added or removed paragraphs count one each.',
     });
   } catch (e: unknown) {
     if (String(errorCode(e) ?? '').toUpperCase() === 'EACCES') {
@@ -193,12 +193,12 @@ export async function odfCompareDocumentsSession(
       saved_to: savePath,
       size_bytes: buffer.length,
       author,
-      granularity: 'paragraph',
+      granularity: 'inline',
       stats: result.stats,
       message:
         `Redline of session edits to '${session.filename}' saved to ${savePath}. ` +
-        'Changes are tracked at the whole-paragraph level (a modified paragraph counts as one ' +
-        'deletion plus one insertion), so insertion/deletion counts may run higher than the DOCX path.',
+        'Stats count changed-regions: a modified paragraph counts once in modifications with each ' +
+        'changed span inside it counted in insertions/deletions; added or removed paragraphs count one each.',
       ...metadata,
     });
   } catch (e: unknown) {

--- a/packages/docx-mcp/src/tools/odf/odf_compare.test.ts
+++ b/packages/docx-mcp/src/tools/odf/odf_compare.test.ts
@@ -89,7 +89,7 @@ async function buildOriginalAndRevised(dir: string): Promise<{ original: string;
   return { original, revised };
 }
 
-describe('ODF compare_documents lane (two-file, paragraph granularity)', () => {
+describe('ODF compare_documents lane (two-file)', () => {
   test.openspec('[OPCD-01] Two-file `.odt` compare produces a redline')(
     'compare_documents routes to the ODF handler and writes a tracked-changes .odt',
     async ({ given, when, then }: AllureBddContext) => {
@@ -107,11 +107,11 @@ describe('ODF compare_documents lane (two-file, paragraph granularity)', () => {
         });
       });
       await when('the comparison runs', () => {});
-      await then('the ODF handler writes a paragraph-granularity redline .odt', async () => {
+      await then('the ODF handler writes an inline-granularity redline .odt', async () => {
         assertSuccess(result, 'compare_documents');
         expect(result.provider).toBe('odf');
         expect(result.mode).toBe('two_file');
-        expect(result.granularity).toBe('paragraph');
+        expect(result.granularity).toBe('inline');
         const stat = await fs.stat(out);
         expect(stat.size).toBeGreaterThan(0);
       });
@@ -119,12 +119,26 @@ describe('ODF compare_documents lane (two-file, paragraph granularity)', () => {
   );
 
   test.openspec('[OPCD-02] Inserted and deleted paragraphs are counted')(
-    'a modified paragraph counts as one deletion and one insertion (modifications 0)',
+    'a wholly-replaced (dissimilar) paragraph counts as one deletion and one insertion (modifications 0)',
     async ({ given, then }: AllureBddContext) => {
       let stats: { insertions: number; deletions: number; modifications: number } = { insertions: 0, deletions: 0, modifications: 0 };
-      await given('a compare of an original vs a one-paragraph-modified revision', async () => {
+      await given('a compare of an original vs a revision whose paragraph was replaced wholesale', async () => {
         const dir = await tmpdir();
-        const { original, revised } = await buildOriginalAndRevised(dir);
+        // A replacement sharing no words stays below the similarity threshold, so it keeps the
+        // whole-paragraph delete+insert shape (similar edits now pair as `modifications`).
+        const original = await copyFixtureTo(dir, 'original.odt');
+        const revised = await copyFixtureTo(dir, 'revised.odt');
+        const mgr = new SessionManager();
+        const edit = await dispatchToolCall(mgr, 'replace_text', {
+          file_path: revised,
+          target_paragraph_id: 'p2',
+          old_string: 'Third paragraph mentions Acme Manufacturing.',
+          new_string: 'Zebras graze quietly under moonlit skies tonight.',
+          instruction: 'Replace the third paragraph wholesale.',
+        });
+        assertSuccess(edit, 'replace_text');
+        const saved = await dispatchToolCall(mgr, 'save', { file_path: revised, save_to_local_path: revised, allow_overwrite: true });
+        assertSuccess(saved, 'save');
         const result = await dispatchToolCall(new SessionManager(), 'compare_documents', {
           original_file_path: original,
           revised_file_path: revised,

--- a/packages/docx-mcp/src/tools/odf/odf_compare_inline.test.ts
+++ b/packages/docx-mcp/src/tools/odf/odf_compare_inline.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { testAllure as it, type AllureBddContext } from '../../testing/allure-test.js';
+import { dispatchToolCall } from '../../server.js';
+import { SessionManager } from '../../session/manager.js';
+
+const TEST_FEATURE = 'add-odf-intra-paragraph-compare';
+const test = it.epic('Document Editing').withLabels({ feature: TEST_FEATURE });
+
+const FIXTURE = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../../../odf-core/src/__fixtures__/sample.odt',
+);
+
+const tmpDirs: string[] = [];
+afterEach(async () => {
+  for (const dir of tmpDirs.splice(0)) {
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
+async function tmpdir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'safe-docx-odf-inline-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+type Stats = { insertions: number; deletions: number; modifications: number };
+type ErrorResult = { success: false; error: { code: string; message: string; hint?: string } };
+function assertSuccess(result: Record<string, unknown>, label: string): asserts result is { success: true; [k: string]: unknown } {
+  expect(result.success, `${label} failed: ${JSON.stringify((result as ErrorResult).error)}`).toBe(true);
+}
+
+/** Copy the fixture twice and apply one in-paragraph replacement to the revised copy. */
+async function buildPair(dir: string, oldString: string, newString: string): Promise<{ original: string; revised: string }> {
+  const original = path.join(dir, 'original.odt');
+  const revised = path.join(dir, 'revised.odt');
+  await fs.copyFile(FIXTURE, original);
+  await fs.copyFile(FIXTURE, revised);
+  const mgr = new SessionManager();
+  const edit = await dispatchToolCall(mgr, 'replace_text', {
+    file_path: revised,
+    target_paragraph_id: 'p2',
+    old_string: oldString,
+    new_string: newString,
+    instruction: 'Apply the revision under test.',
+  });
+  assertSuccess(edit, 'replace_text');
+  const saved = await dispatchToolCall(mgr, 'save', { file_path: revised, save_to_local_path: revised, allow_overwrite: true });
+  assertSuccess(saved, 'save');
+  return { original, revised };
+}
+
+describe('ODF compare_documents — inline granularity surface', () => {
+  test.openspec('[OPDI-01] Two-file `.odt` compare reports inline granularity and meaningful modifications')(
+    'a one-phrase in-paragraph edit reports granularity inline and modifications >= 1',
+    async ({ given, when, then }: AllureBddContext) => {
+      let result: Record<string, unknown> = {};
+      await given('an original and a revision differing by one phrase inside a paragraph', async () => {
+        const dir = await tmpdir();
+        const { original, revised } = await buildPair(dir, 'Acme Manufacturing', 'Globex Corporation');
+        result = await dispatchToolCall(new SessionManager(), 'compare_documents', {
+          original_file_path: original,
+          revised_file_path: revised,
+          save_to_local_path: path.join(dir, 'redline.odt'),
+        });
+      });
+      await when('the comparison runs', () => {});
+      await then('the response reports inline granularity with the pair counted as a modification', () => {
+        assertSuccess(result, 'compare_documents');
+        expect(result.granularity).toBe('inline');
+        const stats = result.stats as Stats;
+        expect(stats.modifications).toBeGreaterThanOrEqual(1);
+        expect(stats.insertions).toBeGreaterThanOrEqual(1);
+        expect(stats.deletions).toBeGreaterThanOrEqual(1);
+      });
+    },
+  );
+
+  test.openspec('[OPDI-02] Whole-paragraph-only diffs still report zero modifications')(
+    'a wholesale (dissimilar) paragraph replacement keeps modifications 0',
+    async ({ given, then }: AllureBddContext) => {
+      let stats: Stats = { insertions: 0, deletions: 0, modifications: 0 };
+      await given('a revision whose paragraph shares no words with the original', async () => {
+        const dir = await tmpdir();
+        const { original, revised } = await buildPair(
+          dir,
+          'Third paragraph mentions Acme Manufacturing.',
+          'Zebras graze quietly under moonlit skies tonight.',
+        );
+        const result = await dispatchToolCall(new SessionManager(), 'compare_documents', {
+          original_file_path: original,
+          revised_file_path: revised,
+          save_to_local_path: path.join(dir, 'redline.odt'),
+        });
+        assertSuccess(result, 'compare_documents');
+        stats = result.stats as Stats;
+      });
+      await then('the pair stays a whole-paragraph delete+insert', () => {
+        expect(stats.modifications).toBe(0);
+        expect(stats.insertions).toBe(1);
+        expect(stats.deletions).toBe(1);
+      });
+    },
+  );
+});

--- a/packages/docx-mcp/src/tools/odf/odf_compare_session.test.ts
+++ b/packages/docx-mcp/src/tools/odf/odf_compare_session.test.ts
@@ -136,18 +136,23 @@ describe('ODF compare_documents session mode', () => {
           });
         });
       });
-      await then('a paragraph-granularity session redline is written', async () => {
+      await then('an inline-granularity session redline is written', async () => {
         assertSuccess(result, 'compare_documents');
         expect(result.provider).toBe('odf');
         expect(result.mode).toBe('session');
-        expect(result.granularity).toBe('paragraph');
+        expect(result.granularity).toBe('inline');
         const stats = result.stats as { insertions: number; deletions: number; modifications: number };
+        // The edited paragraph is similar to its original, so it pairs as one modification with
+        // its changed spans counted in insertions/deletions (inline granularity, issue #356).
         expect(stats.insertions).toBeGreaterThanOrEqual(1);
         expect(stats.deletions).toBeGreaterThanOrEqual(1);
-        expect(stats.modifications).toBe(0);
+        expect(stats.modifications).toBe(1);
         const content = await readContentXml(out);
         expect(content).toContain('tracked-changes');
-        expect(content).toContain('Globex Corporation');
+        // Inline granularity brackets each replaced word, so change markers sit between the two
+        // inserted words in the raw XML — assert them individually, not as one substring.
+        expect(content).toContain('Globex');
+        expect(content).toContain('Corporation');
       });
     },
   );

--- a/packages/odf-core/src/compare/diff.test.ts
+++ b/packages/odf-core/src/compare/diff.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect } from 'vitest';
 
-import { diffParagraphs, type EditOp } from './diff.js';
+import { diffParagraphs, pairModifications, type EditOp } from './diff.js';
 
 /** Compact an edit script to readable tokens for assertions. */
 function tokens(ops: EditOp[]): string[] {
   return ops.map((op) => {
     if (op.kind === 'equal') return `=${op.originalIndex}:${op.revisedIndex}`;
     if (op.kind === 'insert') return `+${op.revisedIndex}`;
+    if (op.kind === 'modify') return `~${op.originalIndex}:${op.revisedIndex}`;
     return `-${op.originalIndex}`;
   });
 }
@@ -57,5 +58,84 @@ describe('diffParagraphs — paragraph-level LCS', () => {
     expect(eq).toBe(1);
     expect(ins).toBe(1);
     expect(del).toBe(1);
+  });
+});
+
+describe('pairModifications — modify-pair detection', () => {
+  const pair = (original: string[], revised: string[], threshold?: number): string[] =>
+    tokens(pairModifications(diffParagraphs(original, revised), original, revised, threshold));
+
+  it('[OCMPI-02] a similar replaced paragraph becomes a modify op', () => {
+    const original = ['Common intro.', 'The quick brown fox jumps over the lazy dog.', 'Common outro.'];
+    const revised = ['Common intro.', 'The quick red fox jumps over the lazy dog.', 'Common outro.'];
+    expect(pair(original, revised)).toEqual(['=0:0', '~1:1', '=2:2']);
+  });
+
+  it('[OCMPI-02] a dissimilar replacement stays delete+insert', () => {
+    const original = ['Common.', 'Entirely different sentence about apples.', 'Common two.'];
+    const revised = ['Common.', 'Nothing shared here whatsoever, zebras graze.', 'Common two.'];
+    expect(pair(original, revised)).toEqual(['=0:0', '-1', '+1', '=2:2']);
+  });
+
+  it('[OCMPI-02] threshold is honored (low threshold pairs, high threshold does not)', () => {
+    const original = ['alpha bravo charlie delta'];
+    const revised = ['alpha xx yy zz'];
+    // Jaccard = |{alpha}| / |{alpha bravo charlie delta xx yy zz}| = 1/7 ≈ 0.14
+    expect(pair(original, revised, 0.1)).toEqual(['~0:0']);
+    expect(pair(original, revised, 0.25)).toEqual(['-0', '+0']);
+  });
+
+  it('[OCMPI-02] gap of 2 deletes + 1 insert pairs the best match deterministically', () => {
+    const original = [
+      'Anchor before.',
+      'First clause about indemnification of officers.',
+      'Second clause about termination for convenience.',
+      'Anchor after.',
+    ];
+    const revised = [
+      'Anchor before.',
+      'Second clause about termination for cause.',
+      'Anchor after.',
+    ];
+    // Both deletes share words with the insert; the second shares far more — DP must pick it
+    // (maximize total similarity at equal pair count) and leave the first a pure delete.
+    expect(pair(original, revised)).toEqual(['=0:0', '-1', '~2:1', '=3:2']);
+  });
+
+  it('[OCMPI-02] both-above-threshold candidates resolve by total similarity, not first-wins', () => {
+    const original = ['Anchor.', 'shared words one extra', 'shared words two almost all same', 'End.'];
+    const revised = ['Anchor.', 'shared words two almost all same exactly', 'End.'];
+    const result = pair(original, revised);
+    expect(result).toEqual(['=0:0', '-1', '~2:1', '=3:2']);
+  });
+
+  it('[OCMPI-02] a gap with more inserts than deletes pairs in order and keeps the rest inserts', () => {
+    const original = ['Anchor.', 'The payment terms shall be net thirty days.', 'End.'];
+    const revised = [
+      'Anchor.',
+      'A brand new unrelated recital appears first, fully distinct wording.',
+      'The payment terms shall be net sixty days.',
+      'End.',
+    ];
+    expect(pair(original, revised)).toEqual(['=0:0', '+1', '~1:2', '=2:3']);
+  });
+
+  it('[OCMPI-02] empty paragraphs never pair as modify', () => {
+    expect(pair([''], ['Some new text'])).toEqual(['-0', '+0']);
+    expect(pair(['Some old text'], [''])).toEqual(['-0', '+0']);
+    // Two empty paragraphs are equal, not a gap at all.
+    expect(pair([''], [''])).toEqual(['=0:0']);
+  });
+
+  it('[OCMPI-02] punctuation and case differences do not block pairing', () => {
+    const original = ['The Quick BROWN fox, jumps; over the lazy dog.'];
+    const revised = ['the quick brown fox jumps over the lazy dog'];
+    expect(pair(original, revised)).toEqual(['~0:0']);
+  });
+
+  it('scripts without gaps pass through unchanged', () => {
+    const original = ['A', 'B'];
+    const revised = ['A', 'B'];
+    expect(pair(original, revised)).toEqual(['=0:0', '=1:1']);
   });
 });

--- a/packages/odf-core/src/compare/diff.ts
+++ b/packages/odf-core/src/compare/diff.ts
@@ -15,7 +15,8 @@
 export type EditOp =
   | { kind: 'equal'; originalIndex: number; revisedIndex: number }
   | { kind: 'insert'; revisedIndex: number }
-  | { kind: 'delete'; originalIndex: number };
+  | { kind: 'delete'; originalIndex: number }
+  | { kind: 'modify'; originalIndex: number; revisedIndex: number };
 
 /**
  * Diff two paragraph-text arrays into an ordered edit script.
@@ -56,4 +57,141 @@ export function diffParagraphs(original: string[], revised: string[]): EditOp[] 
   while (i < n) ops.push({ kind: 'delete', originalIndex: i++ });
   while (j < m) ops.push({ kind: 'insert', revisedIndex: j++ });
   return ops;
+}
+
+/**
+ * Below this Jaccard word-overlap, an aligned delete/insert pair is a replacement, not an
+ * in-place edit. Matches docx-core's `DEFAULT_PARAGRAPH_SIMILARITY_THRESHOLD` reference point.
+ */
+export const DEFAULT_ODF_SIMILARITY_THRESHOLD = 0.25;
+
+/** Normalized word set for similarity: lowercase, punctuation stripped, whitespace collapsed. */
+function similarityWords(text: string): Set<string> {
+  return new Set(
+    text
+      .replace(/[^\w\s]/g, ' ')
+      .toLowerCase()
+      .split(/\s+/)
+      .filter((w) => w.length > 0),
+  );
+}
+
+/** Jaccard word overlap; 0 when either side has no words (empty paragraphs never pair). */
+function jaccard(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 || b.size === 0) return 0;
+  let intersection = 0;
+  for (const w of a) if (b.has(w)) intersection++;
+  return intersection / (a.size + b.size - intersection);
+}
+
+/**
+ * Post-pass over a `diffParagraphs` script: inside each gap (a run of deletes followed by a run
+ * of inserts between two anchors — the order `diffParagraphs`'s tie-break guarantees), convert
+ * similar delete/insert pairs into `modify` ops.
+ *
+ * Pairing is an order-constrained DP, deterministic by construction: maximize the pair count,
+ * then the total Jaccard similarity; a pair is admissible only when similarity ≥
+ * `similarityThreshold`. At ties, pairing beats skipping, and skipping a delete beats skipping
+ * an insert (keeps the delete-first convention). Output preserves merged document order:
+ * between pairs, unpaired deletes precede unpaired inserts, exactly as Slice 1 emitted them.
+ */
+export function pairModifications(
+  ops: EditOp[],
+  original: string[],
+  revised: string[],
+  similarityThreshold: number = DEFAULT_ODF_SIMILARITY_THRESHOLD,
+): EditOp[] {
+  const out: EditOp[] = [];
+  let gapDeletes: number[] = [];
+  let gapInserts: number[] = [];
+
+  const flushGap = (): void => {
+    if (gapDeletes.length === 0 || gapInserts.length === 0) {
+      for (const d of gapDeletes) out.push({ kind: 'delete', originalIndex: d });
+      for (const ins of gapInserts) out.push({ kind: 'insert', revisedIndex: ins });
+      gapDeletes = [];
+      gapInserts = [];
+      return;
+    }
+
+    const delWords = gapDeletes.map((d) => similarityWords(original[d] ?? ''));
+    const insWords = gapInserts.map((ins) => similarityWords(revised[ins] ?? ''));
+    const sim = (a: number, b: number): number => jaccard(delWords[a]!, insWords[b]!);
+
+    // dp[a][b] = best (pairCount, simSum) over gapDeletes[a..] × gapInserts[b..].
+    const d = gapDeletes.length;
+    const m2 = gapInserts.length;
+    const count: number[][] = Array.from({ length: d + 1 }, () => new Array<number>(m2 + 1).fill(0));
+    const sum: number[][] = Array.from({ length: d + 1 }, () => new Array<number>(m2 + 1).fill(0));
+    for (let a = d - 1; a >= 0; a--) {
+      for (let b = m2 - 1; b >= 0; b--) {
+        let bestCount = count[a + 1]![b]!;
+        let bestSum = sum[a + 1]![b]!;
+        if (count[a]![b + 1]! > bestCount || (count[a]![b + 1]! === bestCount && sum[a]![b + 1]! > bestSum)) {
+          bestCount = count[a]![b + 1]!;
+          bestSum = sum[a]![b + 1]!;
+        }
+        const s = sim(a, b);
+        if (s >= similarityThreshold) {
+          const pairCount = count[a + 1]![b + 1]! + 1;
+          const pairSum = sum[a + 1]![b + 1]! + s;
+          if (pairCount > bestCount || (pairCount === bestCount && pairSum > bestSum)) {
+            bestCount = pairCount;
+            bestSum = pairSum;
+          }
+        }
+        count[a]![b] = bestCount;
+        sum[a]![b] = bestSum;
+      }
+    }
+
+    // Backtrack with the stated preference order: pair > skip-delete > skip-insert. Skipped ops
+    // buffer until the next pair (or the end) so each segment emits deletes-then-inserts, the
+    // same per-gap order Slice 1 produced.
+    let a = 0;
+    let b = 0;
+    let pendingDeletes: number[] = [];
+    let pendingInserts: number[] = [];
+    const flushPending = (): void => {
+      for (const pd of pendingDeletes) out.push({ kind: 'delete', originalIndex: pd });
+      for (const pi of pendingInserts) out.push({ kind: 'insert', revisedIndex: pi });
+      pendingDeletes = [];
+      pendingInserts = [];
+    };
+    while (a < d && b < m2) {
+      const s = sim(a, b);
+      const pairCount = s >= similarityThreshold ? count[a + 1]![b + 1]! + 1 : -1;
+      const pairSum = s >= similarityThreshold ? sum[a + 1]![b + 1]! + s : 0;
+      if (pairCount === count[a]![b]! && pairSum === sum[a]![b]!) {
+        flushPending();
+        out.push({ kind: 'modify', originalIndex: gapDeletes[a]!, revisedIndex: gapInserts[b]! });
+        a++;
+        b++;
+      } else if (count[a + 1]![b]! === count[a]![b]! && sum[a + 1]![b]! === sum[a]![b]!) {
+        pendingDeletes.push(gapDeletes[a]!);
+        a++;
+      } else {
+        pendingInserts.push(gapInserts[b]!);
+        b++;
+      }
+    }
+    while (a < d) pendingDeletes.push(gapDeletes[a++]!);
+    while (b < m2) pendingInserts.push(gapInserts[b++]!);
+    flushPending();
+    gapDeletes = [];
+    gapInserts = [];
+  };
+
+  for (const op of ops) {
+    if (op.kind === 'delete') {
+      gapDeletes.push(op.originalIndex);
+    } else if (op.kind === 'insert') {
+      gapInserts.push(op.revisedIndex);
+    } else {
+      flushGap();
+      out.push(op);
+    }
+  }
+  flushGap();
+  return out;
 }

--- a/packages/odf-core/src/compare/emit.ts
+++ b/packages/odf-core/src/compare/emit.ts
@@ -1,10 +1,11 @@
 /**
- * ODF tracked-changes emitter for paragraph-granularity comparison (Slice 1).
+ * ODF tracked-changes emitter: paragraph-granularity (Slice 1) + intra-paragraph modify pairs
+ * (issue #356).
  *
  * Mutates the REVISED `content.xml` DOM in place, adding a `text:tracked-changes` container (first
  * child of `office:text`) plus the lightweight in-body markers that reference it. The exact markup
  * shapes were confirmed by driving LibreOffice to author each change and inspecting its output
- * (see the `add-odf-compare` design notes):
+ * (see the `add-odf-compare` and `add-odf-intra-paragraph-compare` design notes):
  *
  *  - Insertion: `text:change-start` / `text:change-end` brackets the inserted run, referencing a
  *    `text:insertion` region; inserted content stays inline. Forward (a following kept paragraph
@@ -17,13 +18,25 @@
  *    reaching end-of-document). Consecutive deletions coalesce into ONE region with all deleted
  *    paragraphs plus one empty merge-artifact paragraph (artifact last for forward, first for
  *    backward). `text:change` is inline and is never a direct block child of `office:text`.
+ *  - Modify pair (intra-paragraph): the revised paragraph stays in place. An inserted span keeps
+ *    its content inline bracketed by `text:change-start`/`text:change-end`; a deleted span leaves
+ *    one `text:change` point marker and its content is stored out-of-line in a `text:deletion`
+ *    region holding ONE block mirroring the host (`text:p`/`text:h` + style/outline-level) — no
+ *    merge-artifact paragraph (no paragraph break died). A replace orders the insertion bracket
+ *    first and the deletion point after its `text:change-end` (LibreOffice's authored order); at
+ *    one offset the document order is `change-end`, `change`, `change-start`. A pair whose spans
+ *    cannot be mapped degrades to the Slice-1 whole-paragraph delete+insert, decided before any
+ *    markup is written.
  *  - A run with no surviving paragraph to anchor to (every paragraph deleted) fails closed.
  *
  * All element creation/matching is by `namespaceURI` + `localName` (ODF prefixes are not guaranteed).
  */
 
 import { ODF_NS } from '../shared/odf/namespaces.js';
+import { buildSegments } from '../shared/odf/text_segments.js';
 import type { EditOp } from './diff.js';
+import { diffInline, type SpanOp } from './inline_diff.js';
+import { OdfMapError, extractVisibleRange, resolveOffset } from './inline_map.js';
 
 export type EmitParams = {
   /** The revised `content.xml` DOM; mutated in place. */
@@ -42,21 +55,99 @@ export type EmitParams = {
 
 export class OdfEmitError extends Error {}
 
+/** Per-emission accounting so reported stats always match the emitted markup. */
+export type EmitResult = {
+  /** Modify pairs that survived as inline markup. */
+  modifications: number;
+  /** Modify pairs that fell back to whole-paragraph delete+insert. */
+  degradedModifications: number;
+  /** Inserted spans inside surviving modify pairs (one `text:insertion` region each). */
+  inlineInsertions: number;
+  /** Deleted spans inside surviving modify pairs (one `text:deletion` region each). */
+  inlineDeletions: number;
+};
+
 type InsertRun = { a: number; b: number; id: string };
 type DeleteRun = { originalIndices: number[]; revisedCursor: number; id: string };
 
+/** One in-body marker to place inside a modify pair's revised paragraph. */
+type MarkerPlacement = { offset: number; type: 'change' | 'change-start' | 'change-end'; id: string };
+/** One changed-region a modify pair contributes (delete regions carry their stored content). */
+type InlineRegion =
+  | { kind: 'insert'; id: string }
+  | { kind: 'delete'; id: string; content: Node[] };
+
+type ModifyPlan = {
+  revisedIndex: number;
+  originalIndex: number;
+  placements: MarkerPlacement[];
+  regions: InlineRegion[];
+};
+
+/** Pre-id draft: the pure planning result for one modify pair (extraction already executed). */
+type ModifyDraft = {
+  spans: SpanOp[];
+  deleteContents: Map<number, Node[]>; // span index -> extracted nodes
+};
+
 /** Apply the tracked-changes markup for `ops` to `revisedDoc`. */
-export function emitTrackedChanges(params: EmitParams): void {
+export function emitTrackedChanges(params: EmitParams): EmitResult {
   const { revisedDoc, revisedBlocks, originalBlocks, ops, author, date } = params;
   const m = revisedBlocks.length;
 
   const officeText = firstElementNS(revisedDoc, ODF_NS.OFFICE, 'text');
   if (!officeText) throw new OdfEmitError('No office:text element in revised content.xml.');
 
-  // --- Plan: group consecutive same-kind change ops into runs, allocating ids in document order.
+  // --- Lane 2/3 pre-pass: plan every modify pair PURELY (diff + content extraction, no DOM
+  // mutation of the body). A pair that cannot be planned degrades to whole-paragraph
+  // delete+insert here, BEFORE any markup exists — no partial inline state is possible. The
+  // mutating half of placement (`resolveOffset`) is deferred to the marker phase: it is total
+  // for in-range offsets, and every placement offset comes from `diffInline` over the same
+  // visible string it will be resolved against.
+  const drafts = new Map<number, ModifyDraft>();
+  const degraded = new Set<number>();
+  for (let k = 0; k < ops.length; k++) {
+    const op = ops[k]!;
+    if (op.kind !== 'modify') continue;
+    try {
+      const originalBlock = originalBlocks[op.originalIndex];
+      const revisedBlock = revisedBlocks[op.revisedIndex];
+      // Out-of-range indices are an engine bug, not a mapping limitation: fail closed (degrading
+      // would just crash later when lane 1 dereferences the same missing block).
+      if (!originalBlock || !revisedBlock) throw new OdfEmitError(`modify pair indices out of range at op ${k}`);
+      const origVisible = buildSegments(originalBlock).visible;
+      const revVisible = buildSegments(revisedBlock).visible;
+      const spans = diffInline(origVisible, revVisible);
+      const deleteContents = new Map<number, Node[]>();
+      let changed = 0;
+      for (let s = 0; s < spans.length; s++) {
+        const span = spans[s]!;
+        if (span.kind === 'equal') continue;
+        changed++;
+        if (span.kind === 'delete') {
+          deleteContents.set(s, extractVisibleRange(originalBlock, span.origStart, span.origEnd, revisedDoc));
+        }
+      }
+      // A pair with identical visible text gets no draft: nothing to mark up, nothing to count.
+      if (changed > 0) drafts.set(k, { spans, deleteContents });
+    } catch (err) {
+      if (err instanceof OdfMapError) {
+        degraded.add(k);
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  // --- Lane 1: group whole-paragraph ops into runs, allocating ids in document order. A modify
+  // paragraph is a SURVIVOR for anchoring: it advances the revised cursor exactly like `equal`
+  // (so a preceding delete run anchors its point marker at the modified paragraph's start) and
+  // terminates any open run. Degraded pairs re-route here as a delete run + insert run at the
+  // same slot (the Slice-1 replacement shape).
   const alloc = makeIdAllocator(revisedDoc);
   const insertRuns: InsertRun[] = [];
   const deleteRuns: DeleteRun[] = [];
+  const modifyPlans: ModifyPlan[] = [];
   let revisedCursor = 0;
   let k = 0;
   while (k < ops.length) {
@@ -74,7 +165,7 @@ export function emitTrackedChanges(params: EmitParams): void {
       insertRuns.push({ a, b, id: alloc() });
       revisedCursor = b + 1;
       k++;
-    } else {
+    } else if (op.kind === 'delete') {
       const originalIndices = [op.originalIndex];
       while (k + 1 < ops.length && ops[k + 1]!.kind === 'delete') {
         k++;
@@ -88,36 +179,75 @@ export function emitTrackedChanges(params: EmitParams): void {
       }
       deleteRuns.push({ originalIndices, revisedCursor, id: alloc() });
       k++;
+    } else if (op.kind === 'modify') {
+      if (degraded.has(k)) {
+        if (m === 0) {
+          throw new OdfEmitError(
+            'Cannot emit a deletion when the revised document has no paragraphs to anchor the change marker to.',
+          );
+        }
+        deleteRuns.push({ originalIndices: [op.originalIndex], revisedCursor, id: alloc() });
+        insertRuns.push({ a: op.revisedIndex, b: op.revisedIndex, id: alloc() });
+      } else if (drafts.has(k)) {
+        modifyPlans.push(finalizeModifyPlan(op.originalIndex, op.revisedIndex, drafts.get(k)!, alloc));
+      }
+      // No-op pairs (identical visible text) emit nothing.
+      revisedCursor = op.revisedIndex + 1;
+      k++;
+    } else {
+      throw new OdfEmitError(`Unknown edit op kind at index ${k}.`);
     }
   }
 
+  const result: EmitResult = {
+    modifications: modifyPlans.length,
+    degradedModifications: degraded.size,
+    inlineInsertions: modifyPlans.reduce((n, p) => n + p.regions.filter((r) => r.kind === 'insert').length, 0),
+    inlineDeletions: modifyPlans.reduce((n, p) => n + p.regions.filter((r) => r.kind === 'delete').length, 0),
+  };
+
   // Identical documents: emit nothing (no empty container).
-  if (insertRuns.length === 0 && deleteRuns.length === 0) return;
+  if (insertRuns.length === 0 && deleteRuns.length === 0 && modifyPlans.length === 0) return result;
 
   // --- Create the changed-region definitions, in ascending id (document) order.
   const tracked = ensureTrackedChanges(revisedDoc, officeText);
-  const allRuns: Array<{ kind: 'insert' | 'delete'; id: string; run: InsertRun | DeleteRun }> = [
-    ...insertRuns.map((run) => ({ kind: 'insert' as const, id: run.id, run })),
-    ...deleteRuns.map((run) => ({ kind: 'delete' as const, id: run.id, run })),
+  const allRegions: Array<{ id: string; build: () => Element }> = [
+    ...insertRuns.map((run) => ({ id: run.id, build: () => makeInsertionRegion(revisedDoc, run.id, author, date) })),
+    ...deleteRuns.map((dr) => ({
+      id: dr.id,
+      build: () => {
+        const forward = dr.revisedCursor < m;
+        const deletedPs = dr.originalIndices.map((i) => revisedDoc.importNode(originalBlocks[i]!, true) as Element);
+        const artifact = makeEmptyParagraph(revisedDoc, originalBlocks[dr.originalIndices[0]!]!);
+        const stored = forward ? [...deletedPs, artifact] : [artifact, ...deletedPs];
+        return makeDeletionRegion(revisedDoc, dr.id, author, date, stored);
+      },
+    })),
+    ...modifyPlans.flatMap((plan) =>
+      plan.regions.map((region) => ({
+        id: region.id,
+        build: () =>
+          region.kind === 'insert'
+            ? makeInsertionRegion(revisedDoc, region.id, author, date)
+            : makeDeletionRegion(revisedDoc, region.id, author, date, [
+                makeBlockMirror(revisedDoc, originalBlocks[plan.originalIndex]!, region.content),
+              ]),
+      })),
+    ),
   ].sort((x, y) => idNum(x.id) - idNum(y.id));
-  for (const entry of allRuns) {
-    if (entry.kind === 'insert') {
-      tracked.appendChild(makeInsertionRegion(revisedDoc, entry.id, author, date));
-    } else {
-      const dr = entry.run as DeleteRun;
-      const forward = dr.revisedCursor < m;
-      const deletedPs = dr.originalIndices.map((i) => revisedDoc.importNode(originalBlocks[i]!, true) as Element);
-      const artifact = makeEmptyParagraph(revisedDoc, originalBlocks[dr.originalIndices[0]!]!);
-      const stored = forward ? [...deletedPs, artifact] : [artifact, ...deletedPs];
-      tracked.appendChild(makeDeletionRegion(revisedDoc, entry.id, author, date, stored));
-    }
-  }
+  for (const entry of allRegions) tracked.appendChild(entry.build());
 
-  // --- Place insertion markers FIRST so a co-located deletion marker can be prepended before them.
+  // --- Place intra-paragraph markers FIRST: whole-paragraph markers are prepended afterwards, so
+  // at a shared paragraph start the whole-paragraph `text:change` serializes BEFORE intra markers.
+  for (const plan of modifyPlans) {
+    placeModifyMarkers(revisedDoc, revisedBlocks[plan.revisedIndex]!, plan.placements);
+  }
+  // --- Place whole-paragraph insertion markers (before deletion markers, as in Slice 1, so a
+  // co-located deletion marker can be prepended before them).
   for (const run of insertRuns) {
     placeInsertionMarkers(revisedDoc, revisedBlocks, run, m);
   }
-  // --- Place deletion point markers.
+  // --- Place whole-paragraph deletion point markers.
   for (const run of deleteRuns) {
     const forward = run.revisedCursor < m;
     const marker = makeMarker(revisedDoc, 'change', run.id);
@@ -125,6 +255,66 @@ export function emitTrackedChanges(params: EmitParams): void {
       prepend(revisedBlocks[run.revisedCursor]!, marker);
     } else {
       revisedBlocks[m - 1]!.appendChild(marker);
+    }
+  }
+  return result;
+}
+
+/**
+ * Turn a draft into a concrete plan: allocate one region id per changed span in offset order and
+ * compute marker placements. A delete span anchors at its revised offset; when it is immediately
+ * followed by an insert span (a replacement — both sit at the same revised offset), the point
+ * marker bumps past the insertion to its `change-end` offset, matching LibreOffice's authored
+ * replace shape (insertion bracket first, deletion point after).
+ */
+function finalizeModifyPlan(
+  originalIndex: number,
+  revisedIndex: number,
+  draft: ModifyDraft,
+  alloc: () => string,
+): ModifyPlan {
+  const placements: MarkerPlacement[] = [];
+  const regions: InlineRegion[] = [];
+  for (let s = 0; s < draft.spans.length; s++) {
+    const span = draft.spans[s]!;
+    if (span.kind === 'equal') continue;
+    const id = alloc();
+    if (span.kind === 'insert') {
+      regions.push({ kind: 'insert', id });
+      placements.push({ offset: span.revStart, type: 'change-start', id });
+      placements.push({ offset: span.revEnd, type: 'change-end', id });
+    } else {
+      regions.push({ kind: 'delete', id, content: draft.deleteContents.get(s)! });
+      const next = draft.spans[s + 1];
+      const anchor = next && next.kind === 'insert' ? next.revEnd : span.revStart;
+      placements.push({ offset: anchor, type: 'change', id });
+    }
+  }
+  return { originalIndex, revisedIndex, placements, regions };
+}
+
+/** Document order of co-located markers: `change-end`, then `change`, then `change-start`. */
+const MARKER_RANK: Record<MarkerPlacement['type'], number> = { 'change-end': 0, change: 1, 'change-start': 2 };
+
+/**
+ * Insert a modify pair's markers into its revised paragraph. Offset groups are processed in
+ * DESCENDING offset order — marker insertion is zero visible width and `resolveOffset`
+ * re-segments per call, so placements at lower offsets stay valid across splits made at higher
+ * ones. Each offset group is resolved once and its markers inserted sequentially at that point.
+ */
+function placeModifyMarkers(doc: Document, block: Element, placements: MarkerPlacement[]): void {
+  const groups = new Map<number, MarkerPlacement[]>();
+  for (const p of placements) {
+    const group = groups.get(p.offset) ?? [];
+    group.push(p);
+    groups.set(p.offset, group);
+  }
+  const offsets = [...groups.keys()].sort((a, b) => b - a);
+  for (const offset of offsets) {
+    const group = groups.get(offset)!.sort((a, b) => MARKER_RANK[a.type] - MARKER_RANK[b.type]);
+    const point = resolveOffset(block, offset);
+    for (const p of group) {
+      point.parent.insertBefore(makeMarker(doc, p.type, p.id), point.before);
     }
   }
 }
@@ -217,6 +407,23 @@ function makeEmptyParagraph(doc: Document, modelBlock: Element): Element {
   const style = modelBlock.getAttributeNS(ODF_NS.TEXT, 'style-name') ?? modelBlock.getAttribute('text:style-name');
   if (style) p.setAttributeNS(ODF_NS.TEXT, 'text:style-name', style);
   return p;
+}
+
+/**
+ * The storage block for an inline deletion: mirrors the host block's element name and identity
+ * attributes (`text:style-name`; `text:outline-level` for headings — the LibreOffice-authored
+ * O10 shape), holding the extracted deleted content.
+ */
+function makeBlockMirror(doc: Document, hostBlock: Element, content: Node[]): Element {
+  const local = hostBlock.localName === 'h' ? 'text:h' : 'text:p';
+  const block = doc.createElementNS(ODF_NS.TEXT, local);
+  const style = hostBlock.getAttributeNS(ODF_NS.TEXT, 'style-name') ?? hostBlock.getAttribute('text:style-name');
+  if (style) block.setAttributeNS(ODF_NS.TEXT, 'text:style-name', style);
+  const outline =
+    hostBlock.getAttributeNS(ODF_NS.TEXT, 'outline-level') ?? hostBlock.getAttribute('text:outline-level');
+  if (outline) block.setAttributeNS(ODF_NS.TEXT, 'text:outline-level', outline);
+  for (const n of content) block.appendChild(n);
+  return block;
 }
 
 function makeMarker(doc: Document, local: 'change' | 'change-start' | 'change-end', id: string): Element {

--- a/packages/odf-core/src/compare/emit_degrade.test.ts
+++ b/packages/odf-core/src/compare/emit_degrade.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from 'vitest';
+import { parseXml } from '@usejunior/docx-core';
+
+import { ODF_NS } from '../shared/odf/namespaces.js';
+import { buildSegments } from '../shared/odf/text_segments.js';
+
+// The degrade valve guards mapping failures that valid `compareOdf` inputs cannot produce today
+// (diffInline offsets are always consistent with the segments they were computed from), so the
+// valve is exercised by forcing `extractVisibleRange` to fail — the real failure channel.
+vi.mock('./inline_map.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./inline_map.js')>();
+  return {
+    ...actual,
+    extractVisibleRange: vi.fn(() => {
+      throw new actual.OdfMapError('forced mapping failure (test)');
+    }),
+  };
+});
+
+const { compareOdf } = await import('./index.js');
+
+function contentXml(paras: string[]): string {
+  const body = paras.map((t) => `<text:p text:style-name="Standard">${t}</text:p>`).join('');
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<office:document-content
+  xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0"
+  xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"
+  xmlns:dc="http://purl.org/dc/elements/1.1/"
+  xmlns:xml="http://www.w3.org/XML/1998/namespace">
+  <office:body><office:text>${body}</office:text></office:body>
+</office:document-content>`;
+}
+
+describe('compareOdf — degrade valve', () => {
+  it('[OCMPI-08] an unmappable modify pair degrades to the Slice-1 whole-paragraph shape', () => {
+    const original = contentXml(['Alpha bravo charlie delta.', 'Stable.']);
+    const revised = contentXml(['Alpha charlie delta.', 'Stable.']);
+    const { contentXml: out, stats } = compareOdf(original, revised, {
+      author: 'Tester',
+      date: new Date('2026-06-10T12:00:00Z'),
+    });
+
+    // Degraded: one whole-paragraph deletion + one whole-paragraph insertion, no modification.
+    expect(stats).toEqual({ insertions: 1, deletions: 1, modifications: 0 });
+
+    const doc = parseXml(out);
+    const ot = doc.getElementsByTagNameNS(ODF_NS.OFFICE, 'text').item(0) as Element;
+    const tracked = Array.from({ length: ot.childNodes.length }, (_, i) => ot.childNodes.item(i))
+      .filter((n): n is Element => n!.nodeType === 1)
+      .map((n) => n as Element)
+      .find((e) => e.localName === 'tracked-changes');
+    expect(tracked).toBeDefined();
+    const regions = Array.from({ length: tracked!.childNodes.length }, (_, i) => tracked!.childNodes.item(i)).filter(
+      (n): n is Element => n!.nodeType === 1,
+    );
+    expect(regions).toHaveLength(2);
+    const kinds = regions.map((r) => (r.firstChild as Element).localName).sort();
+    expect(kinds).toEqual(['deletion', 'insertion']);
+
+    // The deletion region stores the full original paragraph plus the merge artifact — no
+    // partial inline markup survives a degraded pair.
+    const deletion = regions.map((r) => r.firstChild as Element).find((e) => e.localName === 'deletion')!;
+    const stored = [];
+    for (let c = deletion.firstChild; c; c = c.nextSibling) {
+      if (c.nodeType === 1 && (c as Element).localName === 'p') stored.push(c as Element);
+    }
+    expect(stored).toHaveLength(2);
+    expect(buildSegments(stored[0]!).visible).toBe('Alpha bravo charlie delta.');
+
+    // Slice-1 replacement shape: the deletion marker precedes the insertion's change-start at
+    // the replacement paragraph's start, and the bracket wraps the WHOLE paragraph (the
+    // change-end sits at the following paragraph's start) — no mid-paragraph markers.
+    const paras = Array.from({ length: ot.childNodes.length }, (_, i) => ot.childNodes.item(i))
+      .filter((n): n is Element => n!.nodeType === 1)
+      .map((n) => n as Element)
+      .filter((e) => e.localName === 'p');
+    const first = paras[0]!;
+    expect((first.childNodes.item(0) as Element).localName).toBe('change');
+    expect((first.childNodes.item(1) as Element).localName).toBe('change-start');
+    expect((paras[1]!.childNodes.item(0) as Element).localName).toBe('change-end');
+  });
+});

--- a/packages/odf-core/src/compare/emit_inline.test.ts
+++ b/packages/odf-core/src/compare/emit_inline.test.ts
@@ -1,0 +1,352 @@
+import { describe, it, expect } from 'vitest';
+import { parseXml } from '@usejunior/docx-core';
+
+import { compareOdf } from './index.js';
+import { OdfDocument } from '../document.js';
+import { ODF_NS } from '../shared/odf/namespaces.js';
+import { buildSegments } from '../shared/odf/text_segments.js';
+
+/** Wrap raw block XML (text:p / text:h) in a minimal, namespace-complete content.xml. */
+function contentXmlRaw(blocks: string[]): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<office:document-content
+  xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0"
+  xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"
+  xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0"
+  xmlns:dc="http://purl.org/dc/elements/1.1/"
+  xmlns:xml="http://www.w3.org/XML/1998/namespace">
+  <office:body><office:text>${blocks.join('')}</office:text></office:body>
+</office:document-content>`;
+}
+
+function contentXml(paras: string[]): string {
+  return contentXmlRaw(paras.map((t) => `<text:p text:style-name="Standard">${t}</text:p>`));
+}
+
+function officeText(xml: string): Element {
+  const doc = parseXml(xml);
+  return doc.getElementsByTagNameNS(ODF_NS.OFFICE, 'text').item(0) as Element;
+}
+
+function elementChildren(el: Element): Element[] {
+  const out: Element[] = [];
+  for (let c = el.firstChild; c; c = c.nextSibling) if (c.nodeType === 1) out.push(c as Element);
+  return out;
+}
+
+function childByName(el: Element, ns: string, local: string): Element | null {
+  return elementChildren(el).find((e) => e.namespaceURI === ns && e.localName === local) ?? null;
+}
+
+function trackedRegions(ot: Element): Element[] {
+  const tracked = childByName(ot, ODF_NS.TEXT, 'tracked-changes');
+  if (!tracked) return [];
+  return elementChildren(tracked).filter((e) => e.localName === 'changed-region' && e.namespaceURI === ODF_NS.TEXT);
+}
+
+/** Direct body blocks (text:p/text:h) of office:text (excludes the tracked-changes container). */
+function bodyBlocks(ot: Element): Element[] {
+  return elementChildren(ot).filter(
+    (e) => e.namespaceURI === ODF_NS.TEXT && (e.localName === 'p' || e.localName === 'h'),
+  );
+}
+
+/** The region's change kind ('insertion' | 'deletion') and its stored blocks. */
+function regionInfo(region: Element): { kind: string; stored: Element[] } {
+  const child = elementChildren(region)[0]!;
+  return {
+    kind: child.localName!,
+    stored: elementChildren(child).filter((e) => e.localName === 'p' || e.localName === 'h'),
+  };
+}
+
+function regionById(ot: Element, id: string): Element {
+  const r = trackedRegions(ot).find((x) => x.getAttributeNS(ODF_NS.TEXT, 'id') === id);
+  expect(r, `changed-region ${id}`).toBeDefined();
+  return r!;
+}
+
+/** Flat document-order event stream of a block: text chunks and change markers. */
+type FlowEvent = { kind: 'text'; text: string } | { kind: 'marker'; type: string; id: string };
+function flatten(block: Element): FlowEvent[] {
+  const events: FlowEvent[] = [];
+  const walk = (node: Node): void => {
+    for (let child = node.firstChild; child; child = child.nextSibling) {
+      if (child.nodeType === 3) {
+        events.push({ kind: 'text', text: (child as unknown as { data: string }).data });
+        continue;
+      }
+      if (child.nodeType !== 1) continue;
+      const el = child as Element;
+      if (el.namespaceURI !== ODF_NS.TEXT) {
+        walk(el);
+        continue;
+      }
+      if (el.localName === 'change' || el.localName === 'change-start' || el.localName === 'change-end') {
+        events.push({
+          kind: 'marker',
+          type: el.localName,
+          id: el.getAttributeNS(ODF_NS.TEXT, 'change-id') ?? el.getAttribute('text:change-id') ?? '',
+        });
+        continue;
+      }
+      if (el.localName === 's') {
+        const c = el.getAttributeNS(ODF_NS.TEXT, 'c') ?? el.getAttribute('text:c');
+        events.push({ kind: 'text', text: ' '.repeat(Math.max(1, Number.parseInt(c ?? '1', 10) || 1)) });
+        continue;
+      }
+      if (el.localName === 'tab') {
+        events.push({ kind: 'text', text: '\t' });
+        continue;
+      }
+      if (el.localName === 'line-break') {
+        events.push({ kind: 'text', text: '\n' });
+        continue;
+      }
+      walk(el);
+    }
+  };
+  walk(block);
+  return events;
+}
+
+/**
+ * Reject-projection of a modified paragraph: drop bracketed insertions, splice each deletion
+ * marker's stored content back in. Accept-projection is simply the visible text. Together these
+ * are the structural round-trip invariant.
+ */
+function rejectText(block: Element, ot: Element): string {
+  const events = flatten(block);
+  let out = '';
+  let skipDepth = 0;
+  for (const ev of events) {
+    if (ev.kind === 'marker') {
+      if (ev.type === 'change-start') skipDepth++;
+      else if (ev.type === 'change-end') skipDepth--;
+      else if (skipDepth === 0) {
+        const { stored } = regionInfo(regionById(ot, ev.id));
+        out += stored.map((b) => buildSegments(b).visible).join('');
+      }
+      continue;
+    }
+    if (skipDepth === 0) out += ev.text;
+  }
+  return out;
+}
+
+const OPTS = { author: 'Tester', date: new Date('2026-06-10T12:00:00Z') };
+
+describe('compareOdf — intra-paragraph modify pairs', () => {
+  it('[OCMPI-03] an inserted word is bracketed inline in the kept paragraph', () => {
+    const original = contentXml(['Alpha bravo charlie delta.', 'Stable.']);
+    const revised = contentXml(['Alpha bravo inserted charlie delta.', 'Stable.']);
+    const { contentXml: out, stats } = compareOdf(original, revised, OPTS);
+    const ot = officeText(out);
+
+    expect(stats).toEqual({ insertions: 1, deletions: 0, modifications: 1 });
+    const regions = trackedRegions(ot);
+    expect(regions).toHaveLength(1);
+    expect(regionInfo(regions[0]!).kind).toBe('insertion');
+
+    const para = bodyBlocks(ot)[0]!;
+    const events = flatten(para);
+    expect(events).toEqual([
+      { kind: 'text', text: 'Alpha bravo ' },
+      { kind: 'marker', type: 'change-start', id: expect.any(String) },
+      { kind: 'text', text: 'inserted ' },
+      { kind: 'marker', type: 'change-end', id: expect.any(String) },
+      { kind: 'text', text: 'charlie delta.' },
+    ]);
+  });
+
+  it('[OCMPI-04] a deleted word leaves a point marker; storage is one styled block, no artifact', () => {
+    const original = contentXml(['Alpha bravo charlie delta.', 'Stable.']);
+    const revised = contentXml(['Alpha charlie delta.', 'Stable.']);
+    const { contentXml: out, stats } = compareOdf(original, revised, OPTS);
+    const ot = officeText(out);
+
+    expect(stats).toEqual({ insertions: 0, deletions: 1, modifications: 1 });
+    const regions = trackedRegions(ot);
+    expect(regions).toHaveLength(1);
+    const info = regionInfo(regions[0]!);
+    expect(info.kind).toBe('deletion');
+    // Exactly one stored block (no merge artifact) carrying the deleted span and the host style.
+    expect(info.stored).toHaveLength(1);
+    expect(buildSegments(info.stored[0]!).visible).toBe('bravo ');
+    expect(info.stored[0]!.getAttributeNS(ODF_NS.TEXT, 'style-name')).toBe('Standard');
+
+    const para = bodyBlocks(ot)[0]!;
+    expect(flatten(para)).toEqual([
+      { kind: 'text', text: 'Alpha ' },
+      { kind: 'marker', type: 'change', id: expect.any(String) },
+      { kind: 'text', text: 'charlie delta.' },
+    ]);
+  });
+
+  it('[OCMPI-05] a replaced word orders the insertion bracket before the deletion marker (O3 shape)', () => {
+    const original = contentXml(['Alpha bravo charlie delta.']);
+    const revised = contentXml(['Alpha bravo charlie echo.']);
+    const { contentXml: out, stats } = compareOdf(original, revised, OPTS);
+    const ot = officeText(out);
+
+    expect(stats).toEqual({ insertions: 1, deletions: 1, modifications: 1 });
+    const para = bodyBlocks(ot)[0]!;
+    const events = flatten(para);
+    expect(events).toEqual([
+      { kind: 'text', text: 'Alpha bravo charlie ' },
+      { kind: 'marker', type: 'change-start', id: expect.any(String) },
+      { kind: 'text', text: 'echo.' },
+      { kind: 'marker', type: 'change-end', id: expect.any(String) },
+      { kind: 'marker', type: 'change', id: expect.any(String) },
+    ]);
+  });
+
+  it('[OCMPI-06] deleted spans do not leak into the paragraph stream', () => {
+    const original = contentXml(['Alpha bravo charlie delta.', 'Stable.']);
+    const revised = contentXml(['Alpha charlie delta.', 'Stable.']);
+    const { contentXml: out } = compareOdf(original, revised, OPTS);
+    const paras = OdfDocument.fromContentXml(out).getParagraphs();
+    expect(paras.map((p) => p.text)).toEqual(['Alpha charlie delta.', 'Stable.']);
+  });
+
+  it('[OCMPI-07] a whole-paragraph deletion marker precedes intra markers at a shared start', () => {
+    const original = contentXml(['Doomed paragraph.', 'Alpha bravo charlie delta.']);
+    const revised = contentXml(['bravo charlie delta.']);
+    const { contentXml: out, stats } = compareOdf(original, revised, OPTS);
+    const ot = officeText(out);
+
+    // One whole-paragraph deletion + one inline deletion ("Alpha ") on the modify pair.
+    expect(stats).toEqual({ insertions: 0, deletions: 2, modifications: 1 });
+    const para = bodyBlocks(ot)[0]!;
+    const events = flatten(para);
+    expect(events[0]!.kind).toBe('marker');
+    expect(events[1]!.kind).toBe('marker');
+    const first = regionInfo(regionById(ot, (events[0] as { id: string }).id));
+    const second = regionInfo(regionById(ot, (events[1] as { id: string }).id));
+    // First marker: the whole-paragraph deletion (stores the doomed paragraph + artifact).
+    expect(first.kind).toBe('deletion');
+    expect(first.stored.length).toBe(2);
+    expect(buildSegments(first.stored[0]!).visible).toBe('Doomed paragraph.');
+    // Second marker: the inline deletion (single stored block, no artifact).
+    expect(second.kind).toBe('deletion');
+    expect(second.stored.length).toBe(1);
+    expect(buildSegments(second.stored[0]!).visible).toBe('Alpha ');
+  });
+
+  it('[OCMPI-09] stats count changed-regions (2 inline deletes + 1 inline insert + 1 paragraph insert)', () => {
+    const original = contentXml(['aa bb cc dd ee']);
+    const revised = contentXml(['aa cc ff ee', 'Brand new unrelated paragraph wording.']);
+    const { contentXml: out, stats } = compareOdf(original, revised, OPTS);
+    const ot = officeText(out);
+
+    expect(stats).toEqual({ insertions: 2, deletions: 2, modifications: 1 });
+    // One region per counted unit: 2 deletions + 1 insertion inline, 1 whole-paragraph insertion.
+    const kinds = trackedRegions(ot).map((r) => regionInfo(r).kind).sort();
+    expect(kinds).toEqual(['deletion', 'deletion', 'insertion', 'insertion']);
+  });
+
+  it('[OCMPI-10] whitespace-run edits map onto text:s (O6 shape)', () => {
+    const original = contentXmlRaw(['<text:p>Word<text:s text:c="5"/>tail</text:p>']);
+    const revised = contentXmlRaw(['<text:p>Word<text:s text:c="3"/>tail</text:p>']);
+    const { contentXml: out, stats } = compareOdf(original, revised, OPTS);
+    const ot = officeText(out);
+
+    expect(stats.modifications).toBe(1);
+    const para = bodyBlocks(ot)[0]!;
+    expect(buildSegments(para).visible).toBe('Word   tail');
+    // The deleted five-space run is stored as a text:s carrying its count.
+    const deletion = trackedRegions(ot)
+      .map((r) => regionInfo(r))
+      .find((i) => i.kind === 'deletion')!;
+    expect(buildSegments(deletion.stored[0]!).visible).toBe('     ');
+  });
+
+  it('[OCMPI-11] formatting structure is preserved in stored deletion content (O9 shape)', () => {
+    const original = contentXmlRaw([
+      '<text:p text:style-name="Standard">Lead <text:span text:style-name="T1">boldword</text:span> tail stays here.</text:p>',
+    ]);
+    const revised = contentXml(['Lead tail stays here.']);
+    const { contentXml: out, stats } = compareOdf(original, revised, OPTS);
+    const ot = officeText(out);
+
+    expect(stats).toEqual({ insertions: 0, deletions: 1, modifications: 1 });
+    const deletion = trackedRegions(ot).map((r) => regionInfo(r))[0]!;
+    const storedSpan = childByName(deletion.stored[0]!, ODF_NS.TEXT, 'span');
+    expect(storedSpan).not.toBeNull();
+    expect(storedSpan!.getAttributeNS(ODF_NS.TEXT, 'style-name')).toBe('T1');
+    expect(buildSegments(deletion.stored[0]!).visible).toBe('boldword ');
+  });
+
+  it('[OCMPI-12] heading modify pairs store a mirrored text:h (O10 shape)', () => {
+    const original = contentXmlRaw([
+      '<text:h text:style-name="Heading_20_1" text:outline-level="1">Heading text here</text:h>',
+    ]);
+    const revised = contentXmlRaw([
+      '<text:h text:style-name="Heading_20_1" text:outline-level="1">Heading here</text:h>',
+    ]);
+    const { contentXml: out, stats } = compareOdf(original, revised, OPTS);
+    const ot = officeText(out);
+
+    expect(stats).toEqual({ insertions: 0, deletions: 1, modifications: 1 });
+    const deletion = trackedRegions(ot).map((r) => regionInfo(r))[0]!;
+    expect(deletion.kind).toBe('deletion');
+    const stored = deletion.stored[0]!;
+    expect(stored.localName).toBe('h');
+    expect(stored.getAttributeNS(ODF_NS.TEXT, 'style-name')).toBe('Heading_20_1');
+    expect(stored.getAttributeNS(ODF_NS.TEXT, 'outline-level')).toBe('1');
+    expect(buildSegments(stored).visible).toBe('text ');
+    // The kept heading carries the marker inline.
+    const heading = bodyBlocks(ot)[0]!;
+    expect(heading.localName).toBe('h');
+    expect(flatten(heading).some((e) => e.kind === 'marker' && e.type === 'change')).toBe(true);
+  });
+
+  it('change ids are unique across whole-paragraph and inline regions, and every marker resolves', () => {
+    const original = contentXml(['Doomed.', 'aa bb cc dd ee', 'Stable.']);
+    const revised = contentXml(['aa bb ff dd ee', 'Stable.', 'Appended paragraph at the end.']);
+    const { contentXml: out } = compareOdf(original, revised, OPTS);
+    const ot = officeText(out);
+
+    const ids = trackedRegions(ot).map((r) => r.getAttributeNS(ODF_NS.TEXT, 'id'));
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const block of bodyBlocks(ot)) {
+      for (const ev of flatten(block)) {
+        if (ev.kind === 'marker') expect(ids).toContain(ev.id);
+      }
+    }
+  });
+
+  it('structural round-trip: accept-projection is the revised text, reject-projection the original', () => {
+    const original = contentXmlRaw([
+      '<text:p text:style-name="Standard">The quick brown fox jumps over the lazy dog.</text:p>',
+      '<text:p text:style-name="Standard">Second paragraph with <text:span text:style-name="T1">formatting</text:span> inside.</text:p>',
+      '<text:p text:style-name="Standard">Word<text:s text:c="5"/>tail</text:p>',
+    ]);
+    const revised = contentXmlRaw([
+      '<text:p text:style-name="Standard">The quick red fox leaps over the lazy dog.</text:p>',
+      '<text:p text:style-name="Standard">Second paragraph with <text:span text:style-name="T1">formatting</text:span> kept inside.</text:p>',
+      '<text:p text:style-name="Standard">Word<text:s text:c="2"/>tail extended</text:p>',
+    ]);
+    const { contentXml: out, stats } = compareOdf(original, revised, OPTS);
+    const ot = officeText(out);
+
+    expect(stats.modifications).toBe(3);
+    const originalTexts = ['The quick brown fox jumps over the lazy dog.', 'Second paragraph with formatting inside.', 'Word     tail'];
+    const revisedTexts = ['The quick red fox leaps over the lazy dog.', 'Second paragraph with formatting kept inside.', 'Word  tail extended'];
+    const blocks = bodyBlocks(ot);
+    expect(blocks.map((b) => buildSegments(b).visible)).toEqual(revisedTexts);
+    expect(blocks.map((b) => rejectText(b, ot))).toEqual(originalTexts);
+  });
+
+  it('below-threshold replacements keep the Slice-1 whole-paragraph shape', () => {
+    const original = contentXml(['Entirely different sentence about apples.']);
+    const revised = contentXml(['Nothing shared here whatsoever, zebras graze.']);
+    const { contentXml: out, stats } = compareOdf(original, revised, OPTS);
+    const ot = officeText(out);
+
+    expect(stats).toEqual({ insertions: 1, deletions: 1, modifications: 0 });
+    // Whole-paragraph deletion region stores the deleted paragraph plus the merge artifact.
+    const deletion = trackedRegions(ot).map((r) => regionInfo(r)).find((i) => i.kind === 'deletion')!;
+    expect(deletion.stored.length).toBe(2);
+  });
+});

--- a/packages/odf-core/src/compare/index.ts
+++ b/packages/odf-core/src/compare/index.ts
@@ -1,5 +1,5 @@
 /**
- * ODF document comparison — paragraph-granularity tracked-changes redline (Slice 1).
+ * ODF document comparison — tracked-changes redline at inline granularity.
  *
  * `compareOdf` is the public entry: it takes two `content.xml` STRINGS, parses each exactly once
  * internally (no DOM Element crosses the package boundary, no public DOM accessor on
@@ -7,21 +7,25 @@
  * returns the redline `content.xml` plus edit stats. Diff and emit live in separate modules so the
  * diff is testable without round-tripping a `.odt`.
  *
- * Granularity: whole-paragraph. A "modified" paragraph surfaces as a deletion of the old plus an
- * insertion of the new, so `modifications` is always 0 at this granularity; intra-paragraph
- * (run-level) diffs are a later slice.
+ * Granularity: aligned-but-differing paragraph pairs above `similarityThreshold` are diffed
+ * WITHIN the paragraph (token-level) and emitted as inline tracked changes; below-threshold
+ * replacements and pure adds/removes keep the Slice-1 whole-paragraph shapes.
  */
 
 import { parseXml, serializeXml } from '@usejunior/docx-core';
 
 import { collectBlocks } from '../shared/odf/blocks.js';
 import { buildSegments } from '../shared/odf/text_segments.js';
-import { diffParagraphs } from './diff.js';
+import { DEFAULT_ODF_SIMILARITY_THRESHOLD, diffParagraphs, pairModifications } from './diff.js';
 import { emitTrackedChanges } from './emit.js';
 
 export { OdfEmitError } from './emit.js';
 
-/** Counts of whole-paragraph edits. `modifications` is always 0 at paragraph granularity. */
+/**
+ * Counts of changed-regions in the redline: whole-paragraph inserts/deletes count one per
+ * paragraph; a modified paragraph counts one `modifications` plus one insertion/deletion per
+ * inline span inside it; a degraded modify pair counts one insertion plus one deletion.
+ */
 export type OdfCompareStats = {
   insertions: number;
   deletions: number;
@@ -39,6 +43,12 @@ export type OdfCompareOptions = {
   author?: string;
   /** Change date; defaults to now. */
   date?: Date;
+  /**
+   * Minimum Jaccard word-overlap for an aligned delete/insert pair to be treated as an
+   * in-place modification (intra-paragraph diff) instead of a whole-paragraph replacement.
+   * Defaults to `DEFAULT_ODF_SIMILARITY_THRESHOLD` (0.25).
+   */
+  similarityThreshold?: number;
 };
 
 /** ODF `dc:date` value: ISO 8601, no fractional seconds or trailing `Z` (matches comments.ts). */
@@ -47,9 +57,10 @@ function odfDate(date: Date): string {
 }
 
 /**
- * Compare two `content.xml` strings and produce a paragraph-granularity tracked-changes redline.
- * The redline is built on the REVISED document (so its styles, manifest, and untouched paragraphs
- * are preserved); deleted paragraphs are stored out-of-line in the tracked-changes container.
+ * Compare two `content.xml` strings and produce a tracked-changes redline. The redline is built
+ * on the REVISED document (so its styles, manifest, and untouched paragraphs are preserved);
+ * deleted content — whole paragraphs and inline spans alike — is stored out-of-line in the
+ * tracked-changes container.
  */
 export function compareOdf(
   originalContentXml: string,
@@ -58,6 +69,7 @@ export function compareOdf(
 ): OdfCompareResult {
   const author = options.author ?? 'SafeDocX';
   const date = odfDate(options.date ?? new Date());
+  const similarityThreshold = options.similarityThreshold ?? DEFAULT_ODF_SIMILARITY_THRESHOLD;
 
   const originalDoc = parseXml(originalContentXml);
   const revisedDoc = parseXml(revisedContentXml);
@@ -67,15 +79,21 @@ export function compareOdf(
   const revisedBlocks: Element[] = [];
   collectBlocks(revisedDoc.documentElement, revisedBlocks);
 
-  const ops = diffParagraphs(
-    originalBlocks.map((b) => buildSegments(b).visible),
-    revisedBlocks.map((b) => buildSegments(b).visible),
+  const originalTexts = originalBlocks.map((b) => buildSegments(b).visible);
+  const revisedTexts = revisedBlocks.map((b) => buildSegments(b).visible);
+  const ops = pairModifications(
+    diffParagraphs(originalTexts, revisedTexts),
+    originalTexts,
+    revisedTexts,
+    similarityThreshold,
   );
 
-  emitTrackedChanges({ revisedDoc, revisedBlocks, originalBlocks, ops, author, date });
+  const emitted = emitTrackedChanges({ revisedDoc, revisedBlocks, originalBlocks, ops, author, date });
 
-  let insertions = 0;
-  let deletions = 0;
+  // Whole-paragraph ops count one each; inline spans and degradations come from the emitter so
+  // the stats always describe the markup actually written.
+  let insertions = emitted.inlineInsertions + emitted.degradedModifications;
+  let deletions = emitted.inlineDeletions + emitted.degradedModifications;
   for (const op of ops) {
     if (op.kind === 'insert') insertions++;
     else if (op.kind === 'delete') deletions++;
@@ -83,6 +101,6 @@ export function compareOdf(
 
   return {
     contentXml: serializeXml(revisedDoc),
-    stats: { insertions, deletions, modifications: 0 },
+    stats: { insertions, deletions, modifications: emitted.modifications },
   };
 }

--- a/packages/odf-core/src/compare/inline_diff.test.ts
+++ b/packages/odf-core/src/compare/inline_diff.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+
+import { diffInline, type SpanOp } from './inline_diff.js';
+
+/** Reapply the span script: equal+delete spans must reconstruct the original, equal+insert the revised. */
+function reconstruct(ops: SpanOp[], original: string, revised: string): { orig: string; rev: string } {
+  let orig = '';
+  let rev = '';
+  for (const op of ops) {
+    if (op.kind === 'equal' || op.kind === 'delete') orig += original.slice(op.origStart, op.origEnd);
+    if (op.kind === 'equal' || op.kind === 'insert') rev += revised.slice(op.revStart, op.revEnd);
+  }
+  return { orig, rev };
+}
+
+/** Structural invariants every script must satisfy, regardless of content. */
+function assertInvariants(ops: SpanOp[], original: string, revised: string): void {
+  const { orig, rev } = reconstruct(ops, original, revised);
+  expect(orig).toBe(original);
+  expect(rev).toBe(revised);
+  let origPos = 0;
+  let revPos = 0;
+  for (const op of ops) {
+    expect(op.origStart).toBe(origPos);
+    expect(op.revStart).toBe(revPos);
+    expect(op.origEnd).toBeGreaterThanOrEqual(op.origStart);
+    expect(op.revEnd).toBeGreaterThanOrEqual(op.revStart);
+    if (op.kind === 'insert') expect(op.origEnd).toBe(op.origStart);
+    if (op.kind === 'delete') expect(op.revEnd).toBe(op.revStart);
+    if (op.kind === 'equal') {
+      expect(op.origEnd - op.origStart).toBe(op.revEnd - op.revStart);
+      expect(original.slice(op.origStart, op.origEnd)).toBe(revised.slice(op.revStart, op.revEnd));
+    }
+    // No zero-length spans, no two adjacent same-kind spans (coalesced).
+    expect(op.origEnd - op.origStart + (op.revEnd - op.revStart)).toBeGreaterThan(0);
+    origPos = op.origEnd;
+    revPos = op.revEnd;
+  }
+  expect(origPos).toBe(original.length);
+  expect(revPos).toBe(revised.length);
+  for (let k = 1; k < ops.length; k++) expect(ops[k]!.kind).not.toBe(ops[k - 1]!.kind);
+}
+
+describe('diffInline', () => {
+  it('[OCMPI-01] a one-word replacement yields delete+insert sharing revStart, surroundings equal', () => {
+    const original = 'The quick brown fox jumps over the lazy dog.';
+    const revised = 'The quick red fox jumps over the lazy dog.';
+    const ops = diffInline(original, revised);
+    assertInvariants(ops, original, revised);
+    const del = ops.find((o) => o.kind === 'delete');
+    const ins = ops.find((o) => o.kind === 'insert');
+    expect(del).toBeDefined();
+    expect(ins).toBeDefined();
+    expect(original.slice(del!.origStart, del!.origEnd)).toBe('brown');
+    expect(revised.slice(ins!.revStart, ins!.revEnd)).toBe('red');
+    // Delete-before-insert at the shared anchor.
+    expect(ops.indexOf(del!)).toBeLessThan(ops.indexOf(ins!));
+    expect(del!.revStart).toBe(ins!.revStart);
+    // Only the changed word moved: exactly equal, delete, insert, equal.
+    expect(ops.map((o) => o.kind)).toEqual(['equal', 'delete', 'insert', 'equal']);
+  });
+
+  it('[OCMPI-01] insert-only and delete-only edits produce a single changed span', () => {
+    const base = 'Alpha bravo charlie.';
+    const inserted = 'Alpha bravo extra charlie.';
+    const insOps = diffInline(base, inserted);
+    assertInvariants(insOps, base, inserted);
+    expect(insOps.filter((o) => o.kind === 'insert')).toHaveLength(1);
+    expect(insOps.filter((o) => o.kind === 'delete')).toHaveLength(0);
+    expect(inserted.slice(insOps.find((o) => o.kind === 'insert')!.revStart, insOps.find((o) => o.kind === 'insert')!.revEnd)).toBe('extra ');
+
+    const delOps = diffInline(inserted, base);
+    assertInvariants(delOps, inserted, base);
+    expect(delOps.filter((o) => o.kind === 'delete')).toHaveLength(1);
+    expect(delOps.filter((o) => o.kind === 'insert')).toHaveLength(0);
+  });
+
+  it('[OCMPI-01] edits at string start and string end keep offsets exact', () => {
+    const original = 'Alpha bravo charlie';
+    const atStart = diffInline(original, 'bravo charlie');
+    assertInvariants(atStart, original, 'bravo charlie');
+    expect(atStart[0]!.kind).toBe('delete');
+    expect(atStart[0]!.origStart).toBe(0);
+
+    const atEnd = diffInline(original, 'Alpha bravo');
+    assertInvariants(atEnd, original, 'Alpha bravo');
+    expect(atEnd[atEnd.length - 1]!.kind).toBe('delete');
+    expect(atEnd[atEnd.length - 1]!.origEnd).toBe(original.length);
+  });
+
+  it('[OCMPI-01] whitespace-run changes are their own spans (tokens partition the string)', () => {
+    const original = 'word  tail'; // two spaces
+    const revised = 'word tail'; // one space
+    const ops = diffInline(original, revised);
+    assertInvariants(ops, original, revised);
+    // The whitespace run differs, so it is replaced as a unit; the words stay equal.
+    const del = ops.find((o) => o.kind === 'delete');
+    const ins = ops.find((o) => o.kind === 'insert');
+    expect(original.slice(del!.origStart, del!.origEnd)).toBe('  ');
+    expect(revised.slice(ins!.revStart, ins!.revEnd)).toBe(' ');
+  });
+
+  it('[OCMPI-01] identical strings yield one equal span; empty strings yield an empty script', () => {
+    const same = diffInline('Same text.', 'Same text.');
+    expect(same).toEqual([{ kind: 'equal', origStart: 0, origEnd: 10, revStart: 0, revEnd: 10 }]);
+    expect(diffInline('', '')).toEqual([]);
+    const fromEmpty = diffInline('', 'New text');
+    assertInvariants(fromEmpty, '', 'New text');
+    expect(fromEmpty).toEqual([{ kind: 'insert', origStart: 0, origEnd: 0, revStart: 0, revEnd: 8 }]);
+    const toEmpty = diffInline('Old text', '');
+    assertInvariants(toEmpty, 'Old text', '');
+  });
+
+  it('[OCMPI-01] no mid-word matching: distinct words sharing prefix/suffix chars replace whole', () => {
+    const original = 'the government acted';
+    const revised = 'the garment acted';
+    const ops = diffInline(original, revised);
+    assertInvariants(ops, original, revised);
+    const del = ops.find((o) => o.kind === 'delete')!;
+    const ins = ops.find((o) => o.kind === 'insert')!;
+    expect(original.slice(del.origStart, del.origEnd)).toBe('government');
+    expect(revised.slice(ins.revStart, ins.revEnd)).toBe('garment');
+  });
+
+  it('[OCMPI-01] property sweep: random word edits always satisfy the reconstruction invariants', () => {
+    const words = ['alpha', 'bravo', 'charlie', 'delta', 'echo', 'fox', 'golf'];
+    // Deterministic pseudo-random walk (no Date/Math.random in tests for reproducibility).
+    let seed = 42;
+    const next = (): number => {
+      seed = (seed * 1103515245 + 12345) % 2147483648;
+      return seed;
+    };
+    for (let trial = 0; trial < 200; trial++) {
+      const len = next() % 8;
+      const orig: string[] = [];
+      for (let k = 0; k < len; k++) orig.push(words[next() % words.length]!);
+      const rev = [...orig];
+      const edits = next() % 3;
+      for (let e = 0; e < edits && rev.length > 0; e++) {
+        const pos = next() % rev.length;
+        const action = next() % 3;
+        if (action === 0) rev.splice(pos, 1);
+        else if (action === 1) rev.splice(pos, 0, words[next() % words.length]!);
+        else rev[pos] = words[next() % words.length]!;
+      }
+      const a = orig.join(' ');
+      const b = rev.join(' ');
+      assertInvariants(diffInline(a, b), a, b);
+    }
+  });
+});

--- a/packages/odf-core/src/compare/inline_diff.ts
+++ b/packages/odf-core/src/compare/inline_diff.ts
@@ -1,0 +1,118 @@
+/**
+ * Pure intra-paragraph diff for ODF comparison (issue #356).
+ *
+ * Token-level LCS over a single paragraph pair's visible text, returning char-offset spans.
+ * Tokens are maximal runs of whitespace or non-whitespace — a partition of the string — so
+ * every token boundary maps losslessly back to a character offset and the emitted spans land
+ * on clean word boundaries (no ragged mid-word matches). Common token prefix/suffix are
+ * trimmed before the O(N·M) DP, so the dominant case — one edited word in a long clause —
+ * costs close to the edit size, not the paragraph size.
+ *
+ * Order convention mirrors `diffParagraphs`: at a mismatch the deletion branch wins, so a
+ * replaced word surfaces as a `delete` immediately followed by an `insert` sharing `revStart`.
+ * The emitter relies on that ordering when both anchor at the same offset.
+ */
+
+/**
+ * One span of the intra-paragraph edit script, as half-open char offsets into the two visible
+ * strings. `insert` spans have `origStart === origEnd`; `delete` spans have
+ * `revStart === revEnd`; `equal` spans have the same length on both sides.
+ */
+export type SpanOp = {
+  kind: 'equal' | 'insert' | 'delete';
+  origStart: number;
+  origEnd: number;
+  revStart: number;
+  revEnd: number;
+};
+
+/** Split into maximal whitespace / non-whitespace runs (a partition: tokens concat to the input). */
+function tokenizeRuns(text: string): string[] {
+  return text.match(/\s+|\S+/g) ?? [];
+}
+
+/**
+ * Diff two visible-text strings into an ordered span script.
+ * Adjacent same-kind spans are coalesced; zero-length spans are never emitted.
+ */
+export function diffInline(original: string, revised: string): SpanOp[] {
+  const origTokens = tokenizeRuns(original);
+  const revTokens = tokenizeRuns(revised);
+
+  // Trim the common token prefix/suffix; the DP only sees the differing middle window.
+  let prefix = 0;
+  const maxPrefix = Math.min(origTokens.length, revTokens.length);
+  while (prefix < maxPrefix && origTokens[prefix] === revTokens[prefix]) prefix++;
+  let suffix = 0;
+  const maxSuffix = Math.min(origTokens.length, revTokens.length) - prefix;
+  while (
+    suffix < maxSuffix &&
+    origTokens[origTokens.length - 1 - suffix] === revTokens[revTokens.length - 1 - suffix]
+  ) {
+    suffix++;
+  }
+
+  const midOrig = origTokens.slice(prefix, origTokens.length - suffix);
+  const midRev = revTokens.slice(prefix, revTokens.length - suffix);
+
+  // dp[i][j] = LCS length of midOrig[i..] and midRev[j..] (same shape as diffParagraphs).
+  const n = midOrig.length;
+  const m = midRev.length;
+  const dp: number[][] = Array.from({ length: n + 1 }, () => new Array<number>(m + 1).fill(0));
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      dp[i]![j] =
+        midOrig[i] === midRev[j] ? dp[i + 1]![j + 1]! + 1 : Math.max(dp[i + 1]![j]!, dp[i]![j + 1]!);
+    }
+  }
+
+  // Walk tokens emitting per-token kinds, tracking char cursors in both strings.
+  const ops: SpanOp[] = [];
+  let origPos = 0;
+  let revPos = 0;
+  const push = (kind: SpanOp['kind'], origLen: number, revLen: number): void => {
+    if (origLen === 0 && revLen === 0) return;
+    const last = ops[ops.length - 1];
+    if (last && last.kind === kind) {
+      last.origEnd += origLen;
+      last.revEnd += revLen;
+    } else {
+      ops.push({
+        kind,
+        origStart: origPos,
+        origEnd: origPos + origLen,
+        revStart: revPos,
+        revEnd: revPos + revLen,
+      });
+    }
+    origPos += origLen;
+    revPos += revLen;
+  };
+
+  for (let k = 0; k < prefix; k++) push('equal', origTokens[k]!.length, revTokens[k]!.length);
+
+  let i = 0;
+  let j = 0;
+  while (i < n && j < m) {
+    if (midOrig[i] === midRev[j]) {
+      push('equal', midOrig[i]!.length, midRev[j]!.length);
+      i++;
+      j++;
+    } else if (dp[i + 1]![j]! >= dp[i]![j + 1]!) {
+      // Prefer deletion at a tie so a replaced word surfaces as delete-then-insert.
+      push('delete', midOrig[i]!.length, 0);
+      i++;
+    } else {
+      push('insert', 0, midRev[j]!.length);
+      j++;
+    }
+  }
+  while (i < n) push('delete', midOrig[i++]!.length, 0);
+  while (j < m) push('insert', 0, midRev[j++]!.length);
+
+  for (let k = suffix; k > 0; k--) {
+    push('equal', origTokens[origTokens.length - k]!.length, revTokens[revTokens.length - k]!.length);
+  }
+
+  return ops;
+}

--- a/packages/odf-core/src/compare/inline_map.test.ts
+++ b/packages/odf-core/src/compare/inline_map.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+import { parseXml, serializeXml } from '@usejunior/docx-core';
+
+import { OdfMapError, resolveOffset, extractVisibleRange } from './inline_map.js';
+import { buildSegments } from '../shared/odf/text_segments.js';
+import { ODF_NS } from '../shared/odf/namespaces.js';
+
+/** Wrap paragraph-content XML in a minimal namespace-complete document and return the block. */
+function blockOf(paraInnerXml: string): { doc: Document; block: Element } {
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<office:document-content
+  xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0"
+  xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0">
+  <office:body><office:text><text:p>${paraInnerXml}</text:p></office:text></office:body>
+</office:document-content>`;
+  const doc = parseXml(xml);
+  const block = doc.getElementsByTagNameNS(ODF_NS.TEXT, 'p').item(0) as Element;
+  return { doc, block };
+}
+
+/** Serialize just the paragraph element for shape assertions. */
+function paraXml(block: Element): string {
+  return serializeXml(block.ownerDocument as Document)
+    .replace(/^[\s\S]*?(<text:p[\s\S]*?<\/text:p>|<text:p[^>]*\/>)[\s\S]*$/, '$1');
+}
+
+/** Insert a text:change marker at a DomPoint (mirrors what the emitter does). */
+function insertMarker(block: Element, vis: number): void {
+  const point = resolveOffset(block, vis);
+  const doc = block.ownerDocument as Document;
+  const marker = doc.createElementNS(ODF_NS.TEXT, 'text:change');
+  marker.setAttributeNS(ODF_NS.TEXT, 'text:change-id', 'ct1');
+  point.parent.insertBefore(marker, point.before);
+}
+
+describe('resolveOffset', () => {
+  it('[OCMPI-10] splits a #text node mid-word and serializes the marker between the halves', () => {
+    const { block } = blockOf('HelloWorld');
+    insertMarker(block, 5);
+    expect(paraXml(block)).toBe('<text:p>Hello<text:change text:change-id="ct1"/>World</text:p>');
+  });
+
+  it('[OCMPI-10] offsets 0 and length resolve to block-level prepend/append', () => {
+    const { block } = blockOf('Alpha');
+    insertMarker(block, 0);
+    expect(paraXml(block)).toBe('<text:p><text:change text:change-id="ct1"/>Alpha</text:p>');
+
+    const { block: block2 } = blockOf('Alpha');
+    insertMarker(block2, 5);
+    expect(paraXml(block2)).toBe('<text:p>Alpha<text:change text:change-id="ct1"/></text:p>');
+  });
+
+  it('[OCMPI-10] an offset inside a text:span splits at the natural depth (inside the span)', () => {
+    const { block } = blockOf('Lead <text:span text:style-name="T1">boldword</text:span> tail.');
+    insertMarker(block, 9); // "Lead bold|word"
+    expect(paraXml(block)).toBe(
+      '<text:p>Lead <text:span text:style-name="T1">bold<text:change text:change-id="ct1"/>word</text:span> tail.</text:p>',
+    );
+  });
+
+  it('[OCMPI-10] a boundary between segments inserts before the following node without splitting', () => {
+    const { block } = blockOf('Lead <text:span text:style-name="T1">bold</text:span> tail.');
+    insertMarker(block, 5); // boundary before the span's inner text
+    expect(paraXml(block)).toBe(
+      '<text:p>Lead <text:span text:style-name="T1"><text:change text:change-id="ct1"/>bold</text:span> tail.</text:p>',
+    );
+  });
+
+  it('[OCMPI-10] splits a text:s run rebalancing text:c (and omits text:c at count 1)', () => {
+    const { block } = blockOf('Word<text:s text:c="5"/>tail');
+    insertMarker(block, 6); // 2 spaces kept left, 3 right
+    expect(paraXml(block)).toBe(
+      '<text:p>Word<text:s text:c="2"/><text:change text:change-id="ct1"/><text:s text:c="3"/>tail</text:p>',
+    );
+
+    const { block: block2 } = blockOf('Word<text:s text:c="2"/>tail');
+    insertMarker(block2, 5); // 1 and 1: both sides omit text:c
+    expect(paraXml(block2)).toBe(
+      '<text:p>Word<text:s/><text:change text:change-id="ct1"/><text:s/>tail</text:p>',
+    );
+    expect(buildSegments(block2).visible).toBe('Word  tail');
+  });
+
+  it('[OCMPI-10] out-of-range offsets throw OdfMapError', () => {
+    const { block } = blockOf('abc');
+    expect(() => resolveOffset(block, -1)).toThrow(OdfMapError);
+    expect(() => resolveOffset(block, 4)).toThrow(OdfMapError);
+  });
+
+  it('splitting preserves the visible text exactly', () => {
+    const { block } = blockOf('Word<text:s text:c="5"/>middle<text:tab/>end');
+    const before = buildSegments(block).visible;
+    insertMarker(block, 7);
+    insertMarker(block, 11);
+    expect(buildSegments(block).visible).toBe(before);
+  });
+});
+
+describe('extractVisibleRange', () => {
+  const targetDoc = (): Document => blockOf('').doc;
+
+  /** Append extracted nodes to an empty text:p in a fresh target doc and serialize it. */
+  function extractedXml(srcInner: string, start: number, end: number): string {
+    const { block } = blockOf(srcInner);
+    const { doc: tdoc, block: holder } = blockOf('');
+    const nodes = extractVisibleRange(block, start, end, tdoc);
+    for (const n of nodes) holder.appendChild(n);
+    return paraXml(holder);
+  }
+
+  it('[OCMPI-11] a mid-text range extracts trimmed plain text', () => {
+    expect(extractedXml('Alpha bravo charlie delta.', 6, 12)).toBe('<text:p>bravo </text:p>');
+  });
+
+  it('[OCMPI-11] a range crossing a span boundary preserves the span structure (O5 shape)', () => {
+    expect(extractedXml('Lead <text:span text:style-name="T1">boldword</text:span> tail.', 3, 9)).toBe(
+      '<text:p>d <text:span text:style-name="T1">bold</text:span></text:p>',
+    );
+  });
+
+  it('[OCMPI-11] a whole formatted word extracts the full span (O9 shape)', () => {
+    expect(extractedXml('Lead <text:span text:style-name="T1">boldword</text:span> tail.', 5, 13)).toBe(
+      '<text:p><text:span text:style-name="T1">boldword</text:span></text:p>',
+    );
+  });
+
+  it('[OCMPI-10] a partially covered text:s is rebalanced to the covered count (O6 shape)', () => {
+    expect(extractedXml('Word<text:s text:c="5"/>tail', 5, 7)).toBe('<text:p><text:s text:c="2"/></text:p>');
+    expect(extractedXml('Word<text:s text:c="5"/>tail', 4, 5)).toBe('<text:p><text:s/></text:p>');
+  });
+
+  it('[OCMPI-10] tab and line-break are copied whole (O7 shape)', () => {
+    expect(extractedXml('Left<text:tab/>Right', 3, 6)).toBe('<text:p>t<text:tab/>R</text:p>');
+    expect(extractedXml('Up<text:line-break/>Down', 1, 4)).toBe('<text:p>p<text:line-break/>D</text:p>');
+  });
+
+  it('extraction is pure with respect to the source block', () => {
+    const { block } = blockOf('Lead <text:span text:style-name="T1">boldword</text:span> tail.');
+    const before = paraXml(block);
+    extractVisibleRange(block, 3, 9, targetDoc());
+    expect(paraXml(block)).toBe(before);
+  });
+
+  it('empty or out-of-range spans throw OdfMapError', () => {
+    const { block } = blockOf('abc');
+    const tdoc = targetDoc();
+    expect(() => extractVisibleRange(block, 1, 1, tdoc)).toThrow(OdfMapError);
+    expect(() => extractVisibleRange(block, 2, 5, tdoc)).toThrow(OdfMapError);
+    expect(() => extractVisibleRange(block, -1, 2, tdoc)).toThrow(OdfMapError);
+  });
+});

--- a/packages/odf-core/src/compare/inline_map.ts
+++ b/packages/odf-core/src/compare/inline_map.ts
@@ -1,0 +1,160 @@
+/**
+ * Visible-offset → DOM mapping for the intra-paragraph compare emitter (issue #356).
+ *
+ * `resolveOffset` turns a visible-text offset in a block into a concrete DOM insertion point,
+ * splitting a `#text` node or a `text:s` run when the offset falls strictly inside one.
+ * `extractVisibleRange` clones a visible range's inline content (preserving `text:span` /
+ * hyperlink structure) for out-of-line storage in a `text:deletion` changed-region.
+ *
+ * Contract for callers that mutate: `resolveOffset` re-segments the block on every call and
+ * never trusts a previously computed `Segment[]`. Marker insertion (zero visible width) at an
+ * offset never changes the visible offsets BELOW it, so emitters processing offsets in
+ * DESCENDING order stay correct across splits. `#text` splits are done manually (truncate
+ * `.data` + insert a sibling) — `Text.splitText` is not assumed to exist in xmldom.
+ */
+
+import { ODF_NS } from '../shared/odf/namespaces.js';
+import {
+  ELEMENT_NODE,
+  TEXT_NODE,
+  buildSegments,
+  isAnnotationSubtree,
+  isTrackedChangesSubtree,
+} from '../shared/odf/text_segments.js';
+
+/** A visible offset could not be mapped onto the block's DOM. The emitter degrades the pair. */
+export class OdfMapError extends Error {}
+
+/** A DOM insertion point: `parent.insertBefore(node, before)`. */
+export type DomPoint = { parent: Node; before: Node | null };
+
+/** Read a `text:s` run length the way `buildSegments` does. */
+function spaceCount(el: Element): number {
+  const countRaw = el.getAttributeNS(ODF_NS.TEXT, 'c') ?? el.getAttribute('text:c');
+  return Math.max(1, Number.parseInt(countRaw ?? '1', 10) || 1);
+}
+
+/** Set a `text:s` run length, omitting the attribute for the default count of 1. */
+function setSpaceCount(el: Element, count: number): void {
+  if (count === 1) {
+    el.removeAttributeNS(ODF_NS.TEXT, 'c');
+    el.removeAttribute('text:c');
+  } else {
+    el.setAttributeNS(ODF_NS.TEXT, 'text:c', String(count));
+  }
+}
+
+/**
+ * Resolve visible offset `vis` in `block` to a DOM insertion point at the offset's natural
+ * nesting depth (inside a `text:span` when the offset is inside one — the LibreOffice-authored
+ * placement). Offsets 0 and `visible.length` resolve to block-level prepend/append. An offset
+ * strictly inside a `#text` node splits it; strictly inside a `text:s` run splits the run,
+ * rebalancing `text:c`. Throws `OdfMapError` when `vis` is out of range.
+ */
+export function resolveOffset(block: Element, vis: number): DomPoint {
+  const { segments, visible } = buildSegments(block);
+  if (vis < 0 || vis > visible.length) {
+    throw new OdfMapError(`offset ${vis} outside visible range 0..${visible.length}`);
+  }
+  if (vis === 0) return { parent: block, before: block.firstChild };
+  if (vis === visible.length) return { parent: block, before: null };
+
+  // A boundary between segments: insert before the segment that starts at `vis`, at its depth.
+  const startingHere = segments.find((s) => s.visStart === vis);
+  if (startingHere) {
+    const host = startingHere.kind === 'text' ? (startingHere.node as unknown as Node) : startingHere.node;
+    const parent = host.parentNode;
+    if (!parent) throw new OdfMapError(`segment host at offset ${vis} has no parent`);
+    return { parent, before: host };
+  }
+
+  const seg = segments.find((s) => s.visStart < vis && vis < s.visStart + s.length);
+  if (!seg) throw new OdfMapError(`offset ${vis} maps to no segment`);
+  const off = vis - seg.visStart;
+
+  if (seg.kind === 'text') {
+    const textNode = seg.node as unknown as { data: string } & Node;
+    const parent = textNode.parentNode;
+    const doc = (textNode as Node).ownerDocument;
+    if (!parent || !doc) throw new OdfMapError(`text node at offset ${vis} is detached`);
+    const tail = doc.createTextNode(textNode.data.slice(off));
+    textNode.data = textNode.data.slice(0, off);
+    parent.insertBefore(tail, textNode.nextSibling);
+    return { parent, before: tail };
+  }
+
+  if (seg.virtual === 'space') {
+    const run = seg.node;
+    const parent = run.parentNode;
+    const doc = run.ownerDocument;
+    if (!parent || !doc) throw new OdfMapError(`text:s at offset ${vis} is detached`);
+    const tail = doc.importNode(run, false) as Element;
+    setSpaceCount(run, off);
+    setSpaceCount(tail, seg.length - off);
+    parent.insertBefore(tail, run.nextSibling);
+    return { parent, before: tail };
+  }
+
+  // tab / line-break are length 1 — an offset strictly inside one cannot exist.
+  throw new OdfMapError(`offset ${vis} falls inside an atomic ${seg.virtual} element`);
+}
+
+/**
+ * Clone the inline content of `block`'s visible range [start, end) as nodes owned by
+ * `targetDoc`, for storage inside a `text:deletion` changed-region. Ancestor inline elements
+ * (`text:span`, hyperlinks) of covered content are shallow-cloned with their attributes;
+ * `#text` is trimmed at the edges; a partially covered `text:s` is rebalanced to the covered
+ * count; `text:tab` / `text:line-break` are copied whole (length 1 — never split). Pure with
+ * respect to `block`. Throws `OdfMapError` on an empty or out-of-range span.
+ */
+export function extractVisibleRange(block: Element, start: number, end: number, targetDoc: Document): Node[] {
+  const { visible } = buildSegments(block);
+  if (!(start >= 0 && start < end && end <= visible.length)) {
+    throw new OdfMapError(`range [${start}, ${end}) invalid for visible length ${visible.length}`);
+  }
+
+  let pos = 0;
+  const out: Node[] = [];
+  const walk = (node: Node, sink: Node[]): void => {
+    for (let child = node.firstChild; child; child = child.nextSibling) {
+      if (child.nodeType === TEXT_NODE) {
+        const data = (child as unknown as { data: string }).data ?? '';
+        const from = Math.max(start, pos);
+        const to = Math.min(end, pos + data.length);
+        if (to > from) sink.push(targetDoc.createTextNode(data.slice(from - pos, to - pos)));
+        pos += data.length;
+        continue;
+      }
+      if (child.nodeType !== ELEMENT_NODE) continue;
+      const el = child as Element;
+      if (isAnnotationSubtree(el) || isTrackedChangesSubtree(el)) continue;
+      if (el.namespaceURI === ODF_NS.TEXT && el.localName === 's') {
+        const count = spaceCount(el);
+        const covered = Math.min(end, pos + count) - Math.max(start, pos);
+        if (covered > 0) {
+          const clone = targetDoc.importNode(el, false) as Element;
+          setSpaceCount(clone, covered);
+          sink.push(clone);
+        }
+        pos += count;
+        continue;
+      }
+      if (el.namespaceURI === ODF_NS.TEXT && (el.localName === 'tab' || el.localName === 'line-break')) {
+        if (start <= pos && pos < end) sink.push(targetDoc.importNode(el, false));
+        pos += 1;
+        continue;
+      }
+      // Container element (text:span, text:a, …): recurse; shallow-clone it only when it
+      // actually contributes covered content, so uncovered formatting never leaks into storage.
+      const sub: Node[] = [];
+      walk(el, sub);
+      if (sub.length > 0) {
+        const clone = targetDoc.importNode(el, false) as Element;
+        for (const n of sub) clone.appendChild(n);
+        sink.push(clone);
+      }
+    }
+  };
+  walk(block, out);
+  return out;
+}

--- a/packages/odf-core/src/compare/lo_inline_roundtrip.test.ts
+++ b/packages/odf-core/src/compare/lo_inline_roundtrip.test.ts
@@ -1,0 +1,119 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, it, expect } from 'vitest';
+import { resolveSoffice, runLibreOfficeOracle } from '@usejunior/docx-core';
+
+import { compareOdf } from './index.js';
+import { OdfArchive } from '../shared/odf/OdfArchive.js';
+import { OdfDocument } from '../document.js';
+
+const FIXTURE = path.join(path.dirname(fileURLToPath(import.meta.url)), '../__fixtures__/sample.odt');
+
+/**
+ * Splice test paragraphs into the FIXTURE's own content.xml (keeping its LibreOffice-authored
+ * root element). A from-scratch minimal `office:document-content` is rejected by LibreOffice's
+ * loader even when schema-plausible — the production flow always reuses a real document's root,
+ * so the test does too.
+ */
+async function contentXml(paras: string[]): Promise<string> {
+  const base = await (await OdfArchive.load(readFileSync(FIXTURE))).getContentXml();
+  const body = paras.map((t) => `<text:p text:style-name="Standard">${t}</text:p>`).join('');
+  return base.replace(/<office:text\b[^>]*>[\s\S]*<\/office:text>/, `<office:text>${body}</office:text>`);
+}
+
+/** Package a content.xml into a complete .odt (mimetype-first STORED) on the fixture shell. */
+async function packageOdt(content: string): Promise<Buffer> {
+  const archive = await OdfArchive.load(readFileSync(FIXTURE));
+  archive.setContentXml(content);
+  return archive.save();
+}
+
+function paragraphTexts(content: string): string[] {
+  return OdfDocument.fromContentXml(content)
+    .getParagraphs()
+    .map((p) => p.text);
+}
+
+// A modify pair (two replaced words), an equal paragraph, a dissimilar MID-document
+// whole-paragraph replacement, a trailing equal paragraph, and a pure end-of-document
+// insertion. (A dissimilar replacement of the LAST paragraph is deliberately absent: that
+// pre-existing Slice-1 composition fails reject-all — characterized below, issue #367.)
+const ORIGINAL = [
+  'The quick brown fox jumps over the lazy dog.',
+  'Second paragraph stays unchanged.',
+  'Entirely different clause about apples.',
+  'Trailing stable paragraph.',
+];
+const REVISED = [
+  'The quick red fox leaps over the lazy dog.',
+  'Second paragraph stays unchanged.',
+  'Zebras graze quietly under moonlight.',
+  'Trailing stable paragraph.',
+  'Appended fresh paragraph at the end.',
+];
+
+describe('LibreOffice accept/reject round-trip of the inline redline', () => {
+  it(
+    '[OCMPI-13] accept-all reproduces the revised text; reject-all the original (skipped without soffice)',
+    async () => {
+      const soffice = resolveSoffice();
+      if (!soffice) {
+        console.warn('[OCMPI-13] soffice not found — skipping LibreOffice round-trip (set ODF_SOFFICE_BIN to enable).');
+        return;
+      }
+
+      const { contentXml: redline, stats } = compareOdf(await contentXml(ORIGINAL), await contentXml(REVISED), {
+        author: 'RoundTrip',
+      });
+      expect(stats).toEqual({ insertions: 4, deletions: 3, modifications: 1 });
+
+      const redlineOdt = await packageOdt(redline);
+      const [accepted, rejected] = await runLibreOfficeOracle(
+        [
+          { op: 'accept', odt: redlineOdt },
+          { op: 'reject', odt: redlineOdt },
+        ],
+        soffice,
+      );
+
+      expect(paragraphTexts(accepted!)).toEqual(REVISED);
+      expect(paragraphTexts(rejected!)).toEqual(ORIGINAL);
+    },
+    180_000,
+  );
+
+  it(
+    'characterization (issue #367): reject-all of an END-OF-DOCUMENT whole-paragraph replacement merges paragraphs',
+    async () => {
+      const soffice = resolveSoffice();
+      if (!soffice) {
+        console.warn('[issue #367] soffice not found — skipping characterization (set ODF_SOFFICE_BIN to enable).');
+        return;
+      }
+
+      // Pre-existing Slice-1 defect: the deletion marker anchors inside the inserted replacement
+      // paragraph while the end-of-document insertion bracket starts in the preceding paragraph;
+      // rejecting both restores the deleted text into the preceding paragraph and leaves an empty
+      // trailing paragraph. Pinned here so a fix for #367 flips this test on purpose.
+      const original = ['Stable one.', 'Entirely different clause about apples.'];
+      const revised = ['Stable one.', 'Zebras graze quietly under moonlight.'];
+      const { contentXml: redline } = compareOdf(await contentXml(original), await contentXml(revised), {
+        author: 'RoundTrip',
+      });
+      const redlineOdt = await packageOdt(redline);
+      const [accepted, rejected] = await runLibreOfficeOracle(
+        [
+          { op: 'accept', odt: redlineOdt },
+          { op: 'reject', odt: redlineOdt },
+        ],
+        soffice,
+      );
+
+      expect(paragraphTexts(accepted!)).toEqual(revised); // accept-all is correct
+      expect(paragraphTexts(rejected!)).toEqual(['Stable one.Entirely different clause about apples.', '']);
+    },
+    180_000,
+  );
+});

--- a/packages/odf-core/src/shared/odf/text_segments.ts
+++ b/packages/odf-core/src/shared/odf/text_segments.ts
@@ -39,14 +39,16 @@ export function isTrackedChangesSubtree(el: { namespaceURI?: string | null; loca
 /** A contiguous slice of a paragraph's visible text and where it came from. */
 export type Segment =
   | { kind: 'text'; node: { data: string }; visStart: number; length: number }
-  | { kind: 'virtual'; visStart: number; length: number };
+  | { kind: 'virtual'; node: Element; virtual: 'space' | 'tab' | 'line-break'; visStart: number; length: number };
 
 /**
  * Build the ordered segment list and concatenated visible string for a block.
  * `text:s` (count via `text:c`) expands to spaces, `text:tab` to a tab, and
- * `text:line-break` to a newline — each a "virtual" segment with no single host
- * `#text` node (so a match landing on one cannot be edited in place in Phase 1).
- * `office:annotation` / `office:annotation-end` subtrees are skipped entirely.
+ * `text:line-break` to a newline — each a "virtual" segment whose visible text has no host
+ * `#text` node (so a match landing on one cannot be edited in place via `replaceTextById`);
+ * the generating element itself is carried as `node` so offset-mapping consumers (the compare
+ * emitter) can split or copy it. `office:annotation` / `office:annotation-end` subtrees are
+ * skipped entirely.
  */
 export function buildSegments(block: Element): { segments: Segment[]; visible: string } {
   const segments: Segment[] = [];
@@ -71,17 +73,17 @@ export function buildSegments(block: Element): { segments: Segment[]; visible: s
         const countRaw = el.getAttributeNS(ODF_NS.TEXT, 'c') ?? el.getAttribute('text:c');
         const count = Math.max(1, Number.parseInt(countRaw ?? '1', 10) || 1);
         const spaces = ' '.repeat(count);
-        segments.push({ kind: 'virtual', visStart: visible.length, length: spaces.length });
+        segments.push({ kind: 'virtual', node: el, virtual: 'space', visStart: visible.length, length: spaces.length });
         visible += spaces;
         continue;
       }
       if (el.namespaceURI === ODF_NS.TEXT && el.localName === 'tab') {
-        segments.push({ kind: 'virtual', visStart: visible.length, length: 1 });
+        segments.push({ kind: 'virtual', node: el, virtual: 'tab', visStart: visible.length, length: 1 });
         visible += '\t';
         continue;
       }
       if (el.namespaceURI === ODF_NS.TEXT && el.localName === 'line-break') {
-        segments.push({ kind: 'virtual', visStart: visible.length, length: 1 });
+        segments.push({ kind: 'virtual', node: el, virtual: 'line-break', visStart: visible.length, length: 1 });
         visible += '\n';
         continue;
       }


### PR DESCRIPTION
## Why

ODF `compare_documents` (Slice 1, #348) diffed at whole-paragraph granularity: any edited paragraph became a full-paragraph delete + insert — noisy for long legal prose — and `stats.modifications` was hard-wired to `0`. The DOCX path already marks up only the changed spans inside a matched paragraph. Fixes #356.

## What

**OpenSpec change `add-odf-intra-paragraph-compare`** (proposal + design + spec deltas, `openspec validate --strict` green). The design.md carries the LibreOffice **authoring-oracle decision log** (O1–O10): every inline markup shape was settled by having LO author the same edit and inspecting its `content.xml` *before* emitter code was written. Two plan corrections came out of it: a replace orders the insertion bracket BEFORE the deletion point marker (O3), and `text:h` modify pairs are fully supported via a mirrored heading storage block (O10 — no degrade needed).

- **odf-core**
  - `pairModifications` post-pass: aligned delete/insert pairs with Jaccard word-overlap ≥ 0.25 (`OdfCompareOptions.similarityThreshold`) become `modify` ops via a deterministic order-constrained DP (max pair count, then total similarity).
  - `inline_diff.ts`: token-level LCS (whitespace/non-whitespace run partition → word-boundary spans, lossless char offsets), prefix/suffix trimmed.
  - `inline_map.ts`: visible-offset → DOM mapping (`resolveOffset` splits `#text` and rebalances `text:s`; `extractVisibleRange` clones deleted content preserving `text:span`/link structure). The virtual `Segment` variant now carries its host element (additive).
  - `emit.ts`: explicit `equal | insert | delete | modify` planning lanes; modify pairs plan purely before any mutation; inserted spans stay inline bracketed; deleted spans leave a `text:change` point marker with content stored out-of-line in a block mirroring the host — **no merge artifact**; markers placed at descending offsets, LO's replace order at shared offsets; unmappable pairs **degrade** to the Slice-1 whole-paragraph shape before any markup exists.
  - Stats count changed-regions (modify pair = 1 modification + its spans in insertions/deletions), so stats always match the emitted markup.
- **docx-core**: `runLibreOfficeOracle` gains `.odt` jobs (writer8 filter, `content.xml` result); oracle entry points exported from the index.
- **docx-mcp**: `granularity: 'inline'`, rewritten stats message, catalog + regenerated tool reference, OPDI scenario tests (`TEST_FEATURE='add-odf-intra-paragraph-compare'`).

## Verification

- 105 odf-core tests (incl. structural round-trip invariants: accept-projection = revised text, reject-projection = original text, no-leak into `getParagraphs()`); docx-mcp ODF tool tests green; full local gate green (build, lint, test:run, spec-coverage, conformance checks, `openspec validate --strict`).
- **Gated LibreOffice round-trip** (`lo_inline_roundtrip.test.ts`, skips without soffice): a redline mixing a modify pair, a mid-document dissimilar replacement, and an EOF insertion **accepts to the revised texts and rejects to the originals through real LibreOffice**.
- **Document-shaped smoke** on a real NVCA stock purchase agreement (398 paragraphs, DOCX→ODT): `grep` → `replace_text` → `compare_documents` through `dispatchToolCall`; redline = exactly 4 changed-regions, opens in LO; accept-all reproduces the revision **exactly**; reject-all restores the edited paragraph exactly (residual diffs are LO re-evaluating cross-reference fields left dangling by the fixture's DOCX→ODT conversion, in untouched paragraphs only — change-free baseline shows zero diffs).

## Discovered (not fixed here)

The new oracle surfaced a **pre-existing Slice-1 defect**: reject-all of a dissimilar whole-paragraph replacement of the **last** paragraph merges paragraphs (deletion marker anchors inside the inserted paragraph whose EOF bracket is also rejected). Filed as #367 with a gated characterization test pinning the behavior; this PR narrows its exposure since similar replacements now become inline modify pairs.