### PR TITLE
fix(docx-core): skip xmlns declarations in formatting-fidelity canonicalization

### DIFF
--- a/openspec/changes/add-formatting-fidelity-comparison-check/specs/docx-comparison/spec.md
+++ b/openspec/changes/add-formatting-fidelity-comparison-check/specs/docx-comparison/spec.md
@@ -34,6 +34,11 @@ The system SHALL provide a deterministic, in-engine formatting comparison `compa
 - **WHEN** the actual view carries a `w:sectPr` whose `w:pgSz` differs from the expected view
 - **THEN** a section-scope divergence with property `w:pgSz` and kind "changed" is reported
 
+#### Scenario: namespace declaration placement does not register as formatting divergence
+
+- **WHEN** the actual view serializes a property element with an inline `xmlns:*` declaration while the expected view inherits the same namespace binding from an ancestor, all other attributes being identical
+- **THEN** the score is exactly 1.0 with zero divergences, because namespace declarations record where a prefix is bound rather than formatting
+
 #### Scenario: unaligned paragraph content lowers alignment coverage not formatting tallies
 
 - **WHEN** a paragraph's text differs between the two views so it cannot be content-aligned

--- a/packages/docx-core/src/baselines/atomizer/formattingFidelity.test.ts
+++ b/packages/docx-core/src/baselines/atomizer/formattingFidelity.test.ts
@@ -156,6 +156,33 @@ describe('Formatting-fidelity comparison check', () => {
     },
   );
 
+  humanReadableTest.openspec('namespace declaration placement does not register as formatting divergence')(
+    'Scenario: namespace declaration placement does not register as formatting divergence',
+    (_: AllureBddContext) => {
+      const R_NS = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+      // inplace-style: r: bound once on the root, inherited by w:headerReference.
+      const expected =
+        `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+        `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"` +
+        ` xmlns:r="${R_NS}"><w:body>` +
+        `<w:p><w:r><w:t>content</w:t></w:r></w:p>` +
+        `<w:sectPr><w:headerReference r:id="rId8" w:type="default"/></w:sectPr>` +
+        `</w:body></w:document>`;
+      // rebuild-style: the same binding declared inline on the element itself,
+      // with an identical r:id (the false "changed" divergence from #369).
+      const actual = docXml(
+        `<w:p><w:r><w:t>content</w:t></w:r></w:p>` +
+          `<w:sectPr><w:headerReference r:id="rId8" w:type="default" xmlns:r="${R_NS}"/></w:sectPr>`,
+      );
+
+      const report = compareFormattingFidelity(expected, actual);
+
+      expect(report.sectionFormatting.divergent).toBe(0);
+      expect(report.divergences).toEqual([]);
+      expect(report.score).toBe(1);
+    },
+  );
+
   humanReadableTest.openspec('unaligned paragraph content lowers alignment coverage not formatting tallies')(
     'Scenario: unaligned paragraph content lowers alignment coverage not formatting tallies',
     (_: AllureBddContext) => {

--- a/packages/docx-core/src/baselines/atomizer/formattingFidelity.ts
+++ b/packages/docx-core/src/baselines/atomizer/formattingFidelity.ts
@@ -117,11 +117,15 @@ const PPR_EXCLUDED_TAGS = new Set([...REVISION_PROPERTY_TAGS, 'w:sectPr']);
  * Canonical serialization: sorted attributes, children sorted by their own
  * canonical form, revision markup dropped. A comparison key, not output XML —
  * sorting trades element-order semantics for emitter-order independence.
+ * Namespace declarations (`xmlns`, `xmlns:*`) are skipped: they record where
+ * a prefix is bound, not formatting, and emitters legitimately declare the
+ * same binding at different depths (inline vs inherited from the root).
  */
 function canonicalizeElement(el: Element): string {
   const attrs: string[] = [];
   for (let i = 0; i < el.attributes.length; i++) {
     const attr = el.attributes[i]!;
+    if (attr.name === 'xmlns' || attr.name.startsWith('xmlns:')) continue;
     attrs.push(`${attr.name}="${attr.value}"`);
   }
   attrs.sort();


### PR DESCRIPTION
## Summary

`canonicalizeElement` in the formatting-fidelity check (#363/#365) serialized **all** attributes into the canonical property key, including namespace declarations. `xmlns`/`xmlns:*` attributes record where a prefix is bound, not formatting — and the two reconstruction modes legitimately bind the same prefix at different depths: rebuild serializes `w:headerReference`/`w:footerReference` with an inline `xmlns:r` declaration while inplace inherits it from the document root.

On the first real-document run (Common Paper Mutual NDA) this produced a false `changed` section divergence with **identical** `r:id` values, zeroing the section dimension (1/1 divergent) and dragging the overall score from ~0.83 to 0.7498 on pure serialization noise.

Fixes #369.

## Changes

- **`formattingFidelity.ts`** — filter `xmlns` / `xmlns:*` attributes out of the canonical key (one-line guard), with the rationale added to the `canonicalizeElement` doc comment.
- **`formattingFidelity.test.ts`** — pinning scenario reproducing the observed shape: `w:headerReference r:id="rId8"` with the `r` binding root-inherited on one side and declared inline on the other; asserts score 1.0, zero divergences. Verified red without the fix (1 failed / 9 passed), green with it (10/10).
- **OpenSpec delta spec** (`add-formatting-fidelity-comparison-check`, still active) — matching `namespace declaration placement does not register as formatting divergence` scenario.

## Decision on the issue's open question

The issue asked whether `w:rsid*` / `w14:paraId` revision-save attributes should also be excluded. **Deferred**: they sit on `w:p`/`w:r` elements, which the check never canonicalizes — only children of property containers enter the key — so there is no observable false positive to pin today. If they ever surface inside a property container, that's a new pinning scenario.

## Testing

Full pre-submit gate green in the worktree: `npm run build && npm run lint:workspaces && npm run test:run && npm run check:spec-coverage && npm run check:conformance-citations && npm run check:conformance-doc` (exit 0, gated on explicit exit codes).