### PR TITLE
chore(release): fold @usejunior/odf-core into the suite release train

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,6 +307,7 @@ jobs:
           pack_dir="$(mktemp -d)"
           run_dir="$(mktemp -d)"
           core_tgz="$(cd packages/docx-core && npm pack --silent --pack-destination "$pack_dir")"
+          odf_tgz="$(cd packages/odf-core && npm pack --silent --pack-destination "$pack_dir")"
           mcp_tgz="$(cd packages/docx-mcp && npm pack --silent --pack-destination "$pack_dir")"
           safe_tgz="$(cd packages/safe-docx && npm pack --silent --pack-destination "$pack_dir")"
           pushd "$run_dir"
@@ -314,7 +315,7 @@ jobs:
           for attempt in 1 2 3; do
             echo "runtime smoke attempt ${attempt}/3"
             rm -rf node_modules package-lock.json
-            if npm install --no-audit --no-fund "$pack_dir/$core_tgz" "$pack_dir/$mcp_tgz" "$pack_dir/$safe_tgz" >/dev/null \
+            if npm install --no-audit --no-fund "$pack_dir/$core_tgz" "$pack_dir/$odf_tgz" "$pack_dir/$mcp_tgz" "$pack_dir/$safe_tgz" >/dev/null \
               && ./node_modules/.bin/safe-docx --help; then
               popd
               rm -rf "$pack_dir" "$run_dir"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           TAG_REF="${RELEASE_TAG:-$GITHUB_REF_NAME}"
           TAG_VERSION="${TAG_REF#v}"
-          for pkg in packages/docx-core packages/docx-mcp packages/google-docs-core packages/safe-docx packages/safe-docx-mcpb; do
+          for pkg in packages/docx-core packages/odf-core packages/docx-mcp packages/google-docs-core packages/safe-docx packages/safe-docx-mcpb; do
             PKG_VERSION="$(node -p "require('./${pkg}/package.json').version")"
             if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
               echo "Tag version ($TAG_VERSION) must match ${pkg}/package.json version ($PKG_VERSION)."
@@ -121,7 +121,7 @@ jobs:
         run: |
           TAG_REF="${RELEASE_TAG:-$GITHUB_REF_NAME}"
           VERSION="${TAG_REF#v}"
-          for pkg in @usejunior/docx-core @usejunior/docx-mcp @usejunior/google-docs-core @usejunior/safe-docx; do
+          for pkg in @usejunior/docx-core @usejunior/odf-core @usejunior/docx-mcp @usejunior/google-docs-core @usejunior/safe-docx; do
             if npm view "$pkg@$VERSION" version >/dev/null 2>&1; then
               echo "$pkg@$VERSION already exists on npm."
               exit 1
@@ -156,7 +156,7 @@ jobs:
 
       - name: Verify package contents (dry-run)
         run: |
-          for pkg in packages/docx-core packages/docx-mcp packages/google-docs-core packages/safe-docx; do
+          for pkg in packages/docx-core packages/odf-core packages/docx-mcp packages/google-docs-core packages/safe-docx; do
             echo "Dry-run pack: $pkg"
             (cd "$pkg" && npm pack --dry-run)
           done
@@ -252,7 +252,7 @@ jobs:
           npm config delete //registry.npmjs.org/:_authToken || true
 
           # Publish in dependency order.
-          for entry in "@usejunior/docx-core:packages/docx-core" "@usejunior/docx-mcp:packages/docx-mcp" "@usejunior/google-docs-core:packages/google-docs-core" "@usejunior/safe-docx:packages/safe-docx"; do
+          for entry in "@usejunior/docx-core:packages/docx-core" "@usejunior/odf-core:packages/odf-core" "@usejunior/docx-mcp:packages/docx-mcp" "@usejunior/google-docs-core:packages/google-docs-core" "@usejunior/safe-docx:packages/safe-docx"; do
             PKG_NAME="${entry%%:*}"
             PKG_DIR="${entry##*:}"
             if npm view "$PKG_NAME@$VERSION" version >/dev/null 2>&1; then

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Edit Word documents (.docx) with coding agents via MCP
+# Edit Word documents (.docx) with coding agents via MCP — with OpenDocument (.odt) support
 
 <!-- SYNC:badges BEGIN -->
 [![CI](https://github.com/usejunior/safe-docx/actions/workflows/ci.yml/badge.svg)](https://github.com/usejunior/safe-docx/actions/workflows/ci.yml)
@@ -75,7 +75,7 @@ flowchart LR
 ```
 <!-- SYNC:architecture-diagram END -->
 
-Safe Docx is an open-source TypeScript stack for surgical editing of existing Microsoft Word `.docx` files. It is built for workflows where an agent proposes changes and a human still needs reliable, formatting-preserving document edits.
+Safe Docx is an open-source TypeScript stack for surgical editing of existing Microsoft Word `.docx` files — and, through the same tool surface, OpenDocument `.odt` files. It is built for workflows where an agent proposes changes and a human still needs reliable, formatting-preserving document edits.
 
 If you review contracts with AI, the slowest step is often applying accepted recommendations in Word. Safe Docx turns that into deterministic tool calls.
 
@@ -214,6 +214,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
 - Comment and footnote workflows
 - Tracked-changes outputs for review (`download`, `compare_documents`)
 - Revision extraction as structured JSON (`extract_revisions`)
+- OpenDocument (`.odt`) sessions: read, search, edit, comment, save, and `compare_documents` redlines (see below)
 
 ## What Safe Docx Is Not Optimized For
 
@@ -222,6 +223,12 @@ Safe Docx is not a from-scratch document generation toolkit.
 If your primary need is generating new `.docx` files from templates/programmatic layout, use packages such as [`docx`](https://www.npmjs.com/package/docx).
 
 The local Safe Docx runtime also intentionally rejects Word template files (`.dotx`) for now. Convert the template to a normal `.docx` document before opening it here.
+
+## OpenDocument (`.odt`) Support
+
+Teams on LibreOffice have the same problem as teams on Word: edits without a record. The core session tools — `read_file`, `grep`, `replace_text`, `insert_paragraph`, `add_comment`, `get_comments`, `save` — work directly on `.odt` files, and `compare_documents` writes a native ODF tracked-changes redline: compare two files, or a live editing session against the original it was opened from.
+
+ODF changes are tracked at the whole-paragraph level (a modified paragraph appears as one deletion plus one insertion). The redline round-trips in LibreOffice: accepting all changes reproduces the edited document, rejecting all restores the original. See the [tool reference](packages/docx-mcp/docs/tool-reference.generated.md) for per-tool format support.
 
 ## Document Families
 
@@ -243,6 +250,7 @@ The local Safe Docx runtime also intentionally rejects Word template files (`.do
 ## Packages
 
 - `@usejunior/docx-core`: primitives + comparison engine for existing `.docx` documents
+- `@usejunior/odf-core`: OpenDocument (`.odt`) primitives + tracked-changes comparison engine
 - `@usejunior/docx-mcp`: MCP server implementation and tool surface
 - `@usejunior/safe-docx`: canonical end-user install name (`npx -y @usejunior/safe-docx`)
 - `@usejunior/safedocx-mcpb`: private MCP bundle wrapper

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "safe-docx",
   "version": "0.9.1",
-  "description": "AI-powered DOCX editing with tracked changes, redlining, and formatting preservation",
+  "description": "AI-powered DOCX and ODT editing with tracked changes, redlining, and formatting preservation",
   "contextFileName": "GEMINI.md",
   "entrypoint": "GEMINI.md",
   "mcpServers": {

--- a/openspec/changes/add-odf-release-isolation/proposal.md
+++ b/openspec/changes/add-odf-release-isolation/proposal.md
@@ -75,3 +75,37 @@ break.
   this change does not mark it private or otherwise touch it.
 - Unblocks the ODF workstream: odf-core can be built and merged without any risk
   of coupling to — or churn on — the stable DOCX release.
+
+## Revision (2026-06-10, issue #372)
+
+The deferred independent ODF release track is **not being built**; `@usejunior/odf-core`
+joins the main suite release train instead. The original isolation premise — a rapidly
+churning experimental lane that must not force suite republishes — no longer holds:
+
+- The ODF lane shipped end-to-end (#328, #335, #336, #341, #348, #366): the published
+  `docx-mcp` server loads `odf-core` at runtime for every `.odt` tool call, so the two
+  packages are version-coupled de facto. An independent track would add a cross-track
+  compatibility range to manage while delivering nothing (suite republishes are fully
+  automated and effectively free).
+- Keeping odf-core private makes the shipped ODF features unreachable for npm users:
+  `loadOdfCore()` returns null in a production install and every `.odt` call fails with
+  `MISSING_DEPENDENCY`.
+
+What changes relative to the original proposal:
+
+- `odf-core` drops `private: true`, gains publish metadata, and is added to all four
+  `release.yml` loops (publish ordered after `docx-core`, before `docx-mcp`).
+- `docx-mcp` declares `@usejunior/odf-core` as a regular dependency — ODF works out of
+  the box. (Google Docs stays an optional peer because it needs external OAuth setup;
+  ODF needs nothing.)
+- The guard (`scripts/check-release-isolation.mjs`) keeps assertion A (workflow
+  snapshot, now including odf-core) and replaces the ODF-must-be-private assertion with
+  its inverse for the publish surface: any `private: true` package on the publish list
+  fails CI (it would otherwise fail the release at tag time).
+- The `odf-v*` tag namespace is retired unused; no `release-odf.yml` will be built.
+- Bootstrap: npm trusted publishing can only be configured for an existing package, so
+  the first `@usejunior/odf-core` publish is manual (interactive, at the current suite
+  version), then the package's trusted publisher is configured to mirror the other four
+  and the next suite tag publishes it via OIDC.
+
+The spec delta below reflects the revised policy.

--- a/openspec/changes/add-odf-release-isolation/specs/release-publishing/spec.md
+++ b/openspec/changes/add-odf-release-isolation/specs/release-publishing/spec.md
@@ -1,66 +1,62 @@
 ## ADDED Requirements
 
-### Requirement: ODF packages release independently of the DOCX suite
+### Requirement: ODF core publishes with the DOCX suite release
 
-The system SHALL version and publish ODF packages (`@usejunior/odf-core` and any
-future ODF package) on a release track that is decoupled from the DOCX suite
-release tag. ODF versions SHALL NOT be required to match the DOCX suite version,
-and an ODF version change SHALL NOT force a version bump or re-publish of any
-DOCX suite package (`docx-core`, `docx-mcp`, `google-docs-core`, `safe-docx`,
-`safe-docx-mcpb`).
+The system SHALL version and publish `@usejunior/odf-core` as part of the suite release:
+its version SHALL match the suite lockstep version (and therefore the `v*.*.*` release
+tag), and `release.yml` SHALL include it in the version-pin, duplicate-publish, dry-run
+pack, and publish lists, publishing in dependency order (after `@usejunior/docx-core`,
+before `@usejunior/docx-mcp`).
 
-This isolation guarantee covers the **version-pin and publish** behavior of the
-DOCX release. It does NOT cover ordinary monorepo CI: the DOCX release preflight
-runs all-workspace build/test/lint, so an ODF package must keep CI green like any
-other workspace member. That is build health, not version/publish coupling.
+`@usejunior/docx-mcp` SHALL declare `@usejunior/odf-core` as a regular dependency so a
+production install resolves it and `.odt` tools work out of the box; the dynamic
+`loadOdfCore()` loader remains as defense in depth and degrades to a clear
+`MISSING_DEPENDENCY` error if the package is somehow absent.
 
-The DOCX suite release SHALL continue to trigger on `v*.*.*` push tags. The
-future independent ODF release track SHALL own the `odf-v*` tag namespace, which
-does not match the DOCX `v*.*.*` push trigger.
+*(Revision note: this replaces the original independent-track design — `odf-v*` tags and
+`release-odf.yml` are retired unused. See the proposal's 2026-06-10 revision for why.)*
 
-#### Scenario: [ORP-01] ODF version bump does not bump or republish the DOCX suite
-- **WHEN** an ODF package version is changed
-- **THEN** no DOCX suite package version changes and the DOCX version-pin/publish preflight does not require any ODF package to match the tag
+#### Scenario: [ORP-01] Suite tag publishes odf-core with the suite
+- **WHEN** a `v*.*.*` release tag is pushed
+- **THEN** the preflight requires `packages/odf-core` to match the tag version and the publish step publishes `@usejunior/odf-core` after `docx-core` and before `docx-mcp`
 
-#### Scenario: [ORP-02] DOCX release tag ignores ODF packages
-- **WHEN** a `v*.*.*` DOCX release tag is pushed
-- **THEN** the suite-version preflight checks only the DOCX list and does not require any ODF package to match the tag
+#### Scenario: [ORP-02] Production installs get ODF support out of the box
+- **WHEN** the published `@usejunior/docx-mcp` (or the `@usejunior/safe-docx` wrapper) is installed from npm
+- **THEN** `@usejunior/odf-core` is installed as a dependency and `.odt` tool calls do not fail with `MISSING_DEPENDENCY`
 
-#### Scenario: [ORP-03] ODF push tag does not trigger the DOCX release
-- **WHEN** a future `odf-v*` tag is pushed for an ODF release
-- **THEN** it does not match the `v*.*.*` push trigger and does not start the DOCX `release.yml` workflow
+### Requirement: Release lists are snapshot-guarded against surface drift
 
-#### Scenario: [ORP-04] Manual dispatch of an ODF tag fails safely
-- **WHEN** the DOCX `release.yml` is manually dispatched with an `odf-v*` tag
-- **THEN** preflight fails the suite-version check (the tag matches no DOCX package version) before anything is published
+The system SHALL enforce, in CI, that the hardcoded suite package lists in
+`release.yml` (the version-pin list, the duplicate-publish guard list, the dry-run pack
+list, and the publish list) each equal a fixed expected set that includes
+`odf-core`. If any list gains or loses a package, the guard SHALL fail until the
+expected snapshot is deliberately updated alongside `release.yml`. This protects the
+actual release mechanism (membership in a release list) so the publish surface can only
+change on purpose.
 
-### Requirement: ODF packages must be private until their release track exists
+#### Scenario: [ORP-03] Changing a release list fails the guard until the snapshot is updated
+- **WHEN** a package name is added to or removed from any of the hardcoded suite lists in `release.yml` without updating the guard's expected snapshot
+- **THEN** the guard exits non-zero, naming the list and the unexpected or missing package
 
-The system SHALL require every workspace package whose name matches `odf` to be
-marked `private: true`. ODF packages SHALL remain `private: true` until the
-independent ODF release track (`release-odf.yml`) exists and passes its own
-preflight; only that future change may set an ODF package `private: false`. A
-`private: true` package builds, tests, and is consumed across the workspace
-normally; npm refuses to publish it.
+### Requirement: Publish-list packages must be publishable
 
-#### Scenario: [ORP-05] ODF core is private until its own publish gate
-- **WHEN** `packages/odf-core` exists before the ODF release track is built
-- **THEN** its `package.json` has `"private": true` and it is not published by the DOCX release
+The system SHALL require every package on the npm publish list to NOT be marked
+`private: true`. A private package on the publish surface would fail the release at tag
+time; the guard SHALL catch it at PR time with the offending package path and remedy.
 
-#### Scenario: [ORP-06] A non-private ODF package fails CI
-- **WHEN** a workspace package whose name matches `odf` is not marked `private: true`
-- **THEN** the release-isolation guard exits non-zero and the PR check fails with the offending package name
+#### Scenario: [ORP-04] A private package on the publish list fails CI
+- **WHEN** a package on the publish list sets `"private": true`
+- **THEN** the release-surface guard exits non-zero, naming the package and the remedy
 
-### Requirement: Release lists are snapshot-guarded against new packages
+### Requirement: First publish of a new suite package is a manual bootstrap
 
-The system SHALL enforce, in CI, that the hardcoded DOCX package lists in
-`release.yml` (the version-pin list, the duplicate-publish guard list, the
-dry-run pack list, and the publish list) each equal a fixed expected DOCX set.
-If any list gains an unexpected package — ODF or otherwise — the guard SHALL
-fail. This protects the actual coupling mechanism (membership in a release list)
-directly, rather than inferring it from a package's `private` flag, and so does
-not depend on the private-ness of packages that are on no release list.
+The system SHALL bootstrap a newly added suite package by a one-time manual publish at
+the current suite version (npm trusted publishing can only be configured for an
+already-existing package), followed by configuring the package's trusted publisher to
+match the existing suite packages; subsequent suite tags publish it via OIDC like the
+rest. The duplicate-publish guard SHALL treat the manually published version as already
+released and skip it without failing.
 
-#### Scenario: [ORP-07] Adding a package to a DOCX release list fails the guard
-- **WHEN** a package name is added to any of the four hardcoded DOCX lists in `release.yml`
-- **THEN** the guard exits non-zero, naming the list and the unexpected package
+#### Scenario: [ORP-05] Manual bootstrap version is skipped, next tag publishes via OIDC
+- **WHEN** a new suite package was manually published at version X and a suite tag for version Y > X is later pushed
+- **THEN** the duplicate-publish guard passes (Y is unpublished) and the workflow publishes version Y via trusted publishing

--- a/openspec/changes/add-odf-release-isolation/tasks.md
+++ b/openspec/changes/add-odf-release-isolation/tasks.md
@@ -23,3 +23,11 @@
 - [x] 5.2 Create design with the three options and recommendation
 - [x] 5.3 Create `release-publishing` capability spec with scenarios
 - [x] 5.4 `openspec validate add-odf-release-isolation --strict` passes
+
+## 6. Revision (2026-06-10, issue #372): fold odf-core into the suite train
+- [x] 6.1 Drop `private: true` from `packages/odf-core` and add `publishConfig.access: public` (other publish metadata already present)
+- [x] 6.2 Add `@usejunior/odf-core` to `docx-mcp` `dependencies` (ODF works out of the box; gdocs stays optional-peer)
+- [x] 6.3 Add odf-core to all four `release.yml` loops, publish ordered after docx-core / before docx-mcp
+- [x] 6.4 Guard: include odf-core in `EXPECTED_LOOPS`; replace the ODF-private assertion with the publish-list-publishable assertion; update tests
+- [x] 6.5 Rewrite the `release-publishing` delta to the revised policy (ORP-01..05); proposal addendum records the reversal rationale
+- [x] 6.6 Sync human-facing format claims: npm descriptions/keywords (`odt`, `opendocument`, `libreoffice`), `server.json`, MCPB manifest, `gemini-extension.json`, root + docx-mcp READMEs

--- a/package-lock.json
+++ b/package-lock.json
@@ -9437,6 +9437,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@usejunior/docx-core": "^0.9.1",
+        "@usejunior/odf-core": "^0.9.1",
         "@xmldom/xmldom": "^0.9.10",
         "zod": "^4.3.6"
       },

--- a/packages/docx-mcp/README.md
+++ b/packages/docx-mcp/README.md
@@ -6,7 +6,7 @@
 
 **Install via the canonical package:** `npx -y @usejunior/safe-docx` — [see setup guide](../../README.md)
 
-Local MCP server for surgical editing of existing Microsoft Word `.docx` files with coding agents.
+Local MCP server for surgical editing of existing Microsoft Word `.docx` files with coding agents. The same tool surface also services OpenDocument `.odt` files — including `compare_documents` redlines (two files, or a live session against its original) written as native ODF tracked changes at paragraph granularity.
 
 Safe Docx is built for brownfield paperwork workflows: apply accepted AI edits to real Word documents while preserving formatting and review semantics.
 

--- a/packages/docx-mcp/package.json
+++ b/packages/docx-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@usejunior/docx-mcp",
   "version": "0.9.1",
-  "description": "MCP server for reading, editing, and comparing Word documents with tracked changes. For Claude, Gemini CLI, Cursor, and any MCP client. MIT licensed.",
+  "description": "MCP server for reading, editing, and comparing Word (.docx) and OpenDocument (.odt) files with tracked changes. For Claude, Gemini CLI, Cursor, and any MCP client. MIT licensed.",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -28,6 +28,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
     "@usejunior/docx-core": "^0.9.1",
+    "@usejunior/odf-core": "^0.9.1",
     "@xmldom/xmldom": "^0.9.10",
     "zod": "^4.3.6"
   },
@@ -99,7 +100,10 @@
     "local-first",
     "offline",
     "diff",
-    "safedocx"
+    "safedocx",
+    "odt",
+    "opendocument",
+    "libreoffice"
   ],
   "homepage": "https://github.com/UseJunior/safe-docx/tree/main/packages/docx-mcp",
   "bugs": {

--- a/packages/odf-core/package.json
+++ b/packages/odf-core/package.json
@@ -1,8 +1,7 @@
 {
   "name": "@usejunior/odf-core",
   "version": "0.9.1",
-  "private": true,
-  "description": "OpenDocument Format (.odt) core library: archive packaging, document view, and surgical text replacement",
+  "description": "OpenDocument Format (.odt) core library: archive packaging, document view, surgical text replacement, and tracked-changes comparison",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -35,6 +34,9 @@
   "bugs": {
     "url": "https://github.com/UseJunior/safe-docx/issues"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "files": [
     "dist"
   ],
@@ -42,6 +44,9 @@
     "odf",
     "opendocument",
     "odt",
+    "libreoffice",
+    "track-changes",
+    "comparison",
     "document-editing",
     "mcp"
   ],

--- a/packages/safe-docx-mcpb/manifest.json
+++ b/packages/safe-docx-mcpb/manifest.json
@@ -3,7 +3,7 @@
   "name": "safe-docx",
   "display_name": "Safe Docx",
   "version": "0.9.1",
-  "description": "AI-native Word document editing with stable paragraph anchors and deterministic DOCX operations.",
+  "description": "AI-native Word (.docx) and OpenDocument (.odt) editing with stable paragraph anchors and deterministic document operations.",
   "long_description": "Safe Docx lets Claude work directly with .docx files on your local filesystem. It provides stable paragraph IDs (_bk_*) for precise editing while preserving formatting and structure.\n\nCore capabilities include reading/searching content, formatting-preserving edits and inserts, deterministic layout controls, tracked-changes output, comments, footnote tools, document comparison, and revision extraction.",
   "author": {
     "name": "OpenAgreements",

--- a/packages/safe-docx/package.json
+++ b/packages/safe-docx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@usejunior/safe-docx",
   "version": "0.9.1",
-  "description": "Edit Word (.docx) documents with tracked changes, redlines, and formatting preservation. Built for AI coding agents. MIT licensed, 100% local processing.",
+  "description": "Edit Word (.docx) and OpenDocument (.odt) files with tracked changes, redlines, and formatting preservation. Built for AI coding agents. MIT licensed, 100% local processing.",
   "mcpName": "io.github.UseJunior/safe-docx",
   "type": "module",
   "main": "./index.js",
@@ -84,7 +84,10 @@
     "local-first",
     "offline",
     "diff",
-    "safedocx"
+    "safedocx",
+    "odt",
+    "opendocument",
+    "libreoffice"
   ],
   "homepage": "https://usejunior.com/developer-tools/safe-docx",
   "bugs": {

--- a/packages/safe-docx/server.json
+++ b/packages/safe-docx/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.UseJunior/safe-docx",
   "title": "Safe Docx",
-  "description": "AI-native surgical editing of existing Word .docx files with formatting preservation",
+  "description": "AI-native surgical editing of existing Word .docx and OpenDocument .odt files with formatting preservation",
   "version": "0.9.1",
   "websiteUrl": "https://usejunior.com/developer-tools/safe-docx",
   "icons": [

--- a/scripts/check-release-isolation.mjs
+++ b/scripts/check-release-isolation.mjs
@@ -1,21 +1,25 @@
 #!/usr/bin/env node
-// Release-isolation guard (OpenSpec change: add-odf-release-isolation).
+// Release-surface guard (OpenSpec change: add-odf-release-isolation, revised
+// 2026-06-10: odf-core now publishes WITH the suite — see the change's
+// proposal addendum and issue #372).
 //
-// Keeps ODF (and any future non-DOCX) packages from being coupled to — or
-// churning — the stable DOCX suite release. Two assertions:
+// Keeps the suite release surface deliberate. The original ODF-must-stay-
+// private assertion was retired when @usejunior/odf-core joined the suite
+// release train (docx-mcp depends on it at runtime, so the two are version-
+// coupled de facto). Two assertions remain:
 //
-//   A. Workflow-snapshot: the hardcoded DOCX package lists in
+//   A. Workflow-snapshot: the hardcoded suite package lists in
 //      .github/workflows/release.yml must equal a fixed expected set. Adding
-//      ANY package (ODF or otherwise) to a release `for` loop fails the guard.
-//      This guards the actual coupling mechanism (membership in a release list)
-//      rather than inferring it from a package's `private` flag, so it is robust
-//      to packages that are non-private yet on no release list (e.g.
-//      allure-test-factory).
+//      or removing ANY package in a release `for` loop fails the guard until
+//      EXPECTED_LOOPS is deliberately updated. This guards the actual release
+//      mechanism (membership in a release list) so the surface can only change
+//      on purpose.
 //
-//   B. ODF-private: every workspace package whose name matches /odf/ must be
-//      `private: true`. ODF packages stay private until the independent ODF
-//      release track (release-odf.yml) exists and passes its own preflight;
-//      only that future change may flip an ODF package to `private: false`.
+//   B. Publish-list-publishable: every `packages/<dir>` on the npm publish
+//      surface must NOT be `private: true` — a private package on the publish
+//      list would fail the release at tag time; catch it at PR time instead.
+//      (This is the inverse of the retired assertion, and is exactly the
+//      bootstrap mistake folding a new package into the train can make.)
 //
 // Pure JSON/text inspection — no network, no build. Wired into the
 // workspace-lint required check. Exits non-zero with an actionable message.
@@ -28,15 +32,15 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..');
 const RELEASE_YML = path.join(REPO_ROOT, '.github', 'workflows', 'release.yml');
 
-// ── Expected snapshot of release.yml's DOCX package loops ──────────────────
+// ── Expected snapshot of release.yml's suite package loops ─────────────────
 // Each entry is the set of package tokens (`@usejunior/*` and/or `packages/*`)
 // that a `for pkg in ...` / `for entry in ...` loop in release.yml may contain.
-// Update this ONLY when intentionally changing the DOCX release surface — never
-// to admit an ODF package (ODF publishes on its own track, not these loops).
+// Update this ONLY when intentionally changing the suite release surface.
 export const EXPECTED_LOOPS = [
   // "Verify tag matches package suite versions" (version-pin)
   [
     'packages/docx-core',
+    'packages/odf-core',
     'packages/docx-mcp',
     'packages/google-docs-core',
     'packages/safe-docx',
@@ -45,6 +49,7 @@ export const EXPECTED_LOOPS = [
   // "Guard against duplicate publish"
   [
     '@usejunior/docx-core',
+    '@usejunior/odf-core',
     '@usejunior/docx-mcp',
     '@usejunior/google-docs-core',
     '@usejunior/safe-docx',
@@ -52,6 +57,7 @@ export const EXPECTED_LOOPS = [
   // "Verify package contents (dry-run)"
   [
     'packages/docx-core',
+    'packages/odf-core',
     'packages/docx-mcp',
     'packages/google-docs-core',
     'packages/safe-docx',
@@ -59,14 +65,27 @@ export const EXPECTED_LOOPS = [
   // "Publish to npm (trusted publishing)" — name:dir pairs
   [
     '@usejunior/docx-core',
+    '@usejunior/odf-core',
     '@usejunior/docx-mcp',
     '@usejunior/google-docs-core',
     '@usejunior/safe-docx',
     'packages/docx-core',
+    'packages/odf-core',
     'packages/docx-mcp',
     'packages/google-docs-core',
     'packages/safe-docx',
   ],
+];
+
+// Suite packages on the npm publish surface (the publish loop's `packages/*`
+// dirs). These must be publishable: `private: true` here would fail the
+// release at tag time.
+export const PUBLISH_DIRS = [
+  'packages/docx-core',
+  'packages/odf-core',
+  'packages/docx-mcp',
+  'packages/google-docs-core',
+  'packages/safe-docx',
 ];
 
 const PKG_TOKEN_RE = /(?:@usejunior\/[a-z0-9.-]+|packages\/[a-z0-9.-]+)/g;
@@ -107,19 +126,19 @@ export function diffWorkflowSnapshot(found, expected = EXPECTED_LOOPS) {
     if (unexpected.length) {
       errors.push(
         `release.yml release loops contain unexpected package(s): ${unexpected.join(', ')}. ` +
-          `ODF and other non-DOCX packages must NOT be added to the DOCX release lists — they publish on their own track.`,
+          `Changing the suite release surface must be deliberate — update EXPECTED_LOOPS (and PUBLISH_DIRS) in this guard alongside release.yml.`,
       );
     }
     if (missing.length) {
       errors.push(
-        `release.yml release loops are missing expected DOCX package(s): ${missing.join(', ')}. ` +
-          `If this is an intentional change to the DOCX surface, update EXPECTED_LOOPS in this guard.`,
+        `release.yml release loops are missing expected suite package(s): ${missing.join(', ')}. ` +
+          `If this is an intentional change to the suite surface, update EXPECTED_LOOPS in this guard.`,
       );
     }
     if (!unexpected.length && !missing.length) {
       errors.push(
         `release.yml package-loop membership drifted from EXPECTED_LOOPS (a token moved between loops). ` +
-          `Re-verify the DOCX release surface and update the guard.`,
+          `Re-verify the suite release surface and update the guard.`,
       );
     }
   }
@@ -135,67 +154,40 @@ function checkWorkflowSnapshot() {
   return diffWorkflowSnapshot(extractReleaseLoops(yml));
 }
 
-// ── Assertion B: ODF packages must be private ─────────────────────────────
-function readWorkspaceGlobs() {
-  const rootPkg = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, 'package.json'), 'utf8'));
-  const ws = rootPkg.workspaces;
-  if (Array.isArray(ws)) return ws;
-  if (ws && Array.isArray(ws.packages)) return ws.packages;
-  return [];
-}
-
-function expandWorkspacePackages() {
-  const dirs = [];
-  for (const glob of readWorkspaceGlobs()) {
-    if (glob.endsWith('/*')) {
-      const base = path.join(REPO_ROOT, glob.slice(0, -2));
-      if (!fs.existsSync(base)) continue;
-      for (const entry of fs.readdirSync(base, { withFileTypes: true })) {
-        if (!entry.isDirectory()) continue;
-        const pkgJson = path.join(base, entry.name, 'package.json');
-        if (fs.existsSync(pkgJson)) dirs.push(pkgJson);
-      }
-    } else {
-      const pkgJson = path.join(REPO_ROOT, glob, 'package.json');
-      if (fs.existsSync(pkgJson)) dirs.push(pkgJson);
-    }
-  }
-  return dirs;
-}
-
-// Pure: given [{name, private, rel}], return errors for non-private ODF pkgs.
-export function diffOdfPrivate(packages) {
+// ── Assertion B: publish-list packages must be publishable ─────────────────
+// Pure: given [{dir, private, rel}], return errors for private publish-list pkgs.
+export function diffPublishListPrivate(packages) {
   const errors = [];
   for (const pkg of packages) {
-    const name = pkg.name ?? '';
-    if (/odf/i.test(name) && pkg.private !== true) {
+    if (pkg.private === true) {
       errors.push(
-        `${pkg.rel} (${name}) must set "private": true. ` +
-          `ODF packages stay private until release-odf.yml exists and passes its own preflight.`,
+        `${pkg.rel} is on the npm publish list but sets "private": true — npm will refuse to publish it ` +
+          `and the release will fail at tag time. Drop "private" (and add publish metadata) or remove it from PUBLISH_DIRS + release.yml.`,
       );
     }
   }
   return errors;
 }
 
-function checkOdfPrivate() {
-  const packages = expandWorkspacePackages().map((pkgJsonPath) => {
+function checkPublishListPrivate() {
+  const packages = PUBLISH_DIRS.map((dir) => {
+    const pkgJsonPath = path.join(REPO_ROOT, dir, 'package.json');
     const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
-    return { name: pkg.name, private: pkg.private, rel: path.relative(REPO_ROOT, pkgJsonPath) };
+    return { dir, private: pkg.private, rel: path.relative(REPO_ROOT, pkgJsonPath) };
   });
-  return diffOdfPrivate(packages);
+  return diffPublishListPrivate(packages);
 }
 
 // ── Run (only when invoked directly, not when imported by the test) ─────────
 function main() {
-  const errors = [...checkWorkflowSnapshot(), ...checkOdfPrivate()];
+  const errors = [...checkWorkflowSnapshot(), ...checkPublishListPrivate()];
   if (errors.length) {
-    console.error('Release-isolation guard FAILED:\n');
+    console.error('Release-surface guard FAILED:\n');
     for (const e of errors) console.error(`  - ${e}`);
-    console.error('\nSee openspec/changes/add-odf-release-isolation for the rationale.');
+    console.error('\nSee openspec/changes/add-odf-release-isolation (revised) for the rationale.');
     process.exit(1);
   }
-  console.log('Release-isolation guard passed: DOCX release lists match snapshot; no non-private ODF package.');
+  console.log('Release-surface guard passed: suite release lists match snapshot; all publish-list packages are publishable.');
 }
 
 if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {

--- a/scripts/check-release-isolation.test.mjs
+++ b/scripts/check-release-isolation.test.mjs
@@ -3,8 +3,9 @@ import test from 'node:test';
 
 import {
   EXPECTED_LOOPS,
+  PUBLISH_DIRS,
   canonical,
-  diffOdfPrivate,
+  diffPublishListPrivate,
   diffWorkflowSnapshot,
   extractReleaseLoops,
 } from './check-release-isolation.mjs';
@@ -29,19 +30,30 @@ test('snapshot passes when found loops equal expected (order-independent)', () =
   assert.deepEqual(diffWorkflowSnapshot(found), []);
 });
 
-test('snapshot flags an unexpected ODF package added to a release loop', () => {
+test('snapshot flags an unexpected package added to a release loop', () => {
   const found = EXPECTED_LOOPS.map((l) => [...l]);
-  found[1] = [...found[1], '@usejunior/odf-core'];
+  found[1] = [...found[1], '@usejunior/allure-test-factory'];
   const errors = diffWorkflowSnapshot(found);
   assert.equal(errors.length, 1);
-  assert.match(errors[0], /unexpected package\(s\): @usejunior\/odf-core/);
+  assert.match(errors[0], /unexpected package\(s\): @usejunior\/allure-test-factory/);
 });
 
-test('snapshot flags a missing DOCX package', () => {
+test('snapshot flags a missing suite package', () => {
   const found = EXPECTED_LOOPS.map((l) => [...l]);
   found[0] = found[0].filter((t) => t !== 'packages/safe-docx-mcpb');
   const errors = diffWorkflowSnapshot(found);
-  assert.ok(errors.some((e) => /missing expected DOCX package\(s\): packages\/safe-docx-mcpb/.test(e)));
+  assert.ok(errors.some((e) => /missing expected suite package\(s\): packages\/safe-docx-mcpb/.test(e)));
+});
+
+test('odf-core is on every release loop and the publish surface', () => {
+  // The 2026-06 revision folded odf-core into the suite train; regression-pin it.
+  for (const loop of EXPECTED_LOOPS) {
+    assert.ok(
+      loop.includes('packages/odf-core') || loop.includes('@usejunior/odf-core'),
+      `expected odf-core in loop: ${loop.join(', ')}`,
+    );
+  }
+  assert.ok(PUBLISH_DIRS.includes('packages/odf-core'));
 });
 
 test('snapshot flags a wrong loop count', () => {
@@ -49,28 +61,21 @@ test('snapshot flags a wrong loop count', () => {
   assert.ok(errors.some((e) => /package loop\(s\); expected 4/.test(e)));
 });
 
-// ── diffOdfPrivate ──────────────────────────────────────────────────────────
-test('odf-private passes for a private ODF package and ignores non-ODF', () => {
-  const errors = diffOdfPrivate([
-    { name: '@usejunior/odf-core', private: true, rel: 'packages/odf-core/package.json' },
-    { name: '@usejunior/allure-test-factory', private: false, rel: 'packages/allure-test-factory/package.json' },
+// ── diffPublishListPrivate ──────────────────────────────────────────────────
+test('publish-list check passes when all packages are publishable', () => {
+  const errors = diffPublishListPrivate([
+    { dir: 'packages/odf-core', private: undefined, rel: 'packages/odf-core/package.json' },
+    { dir: 'packages/docx-core', private: false, rel: 'packages/docx-core/package.json' },
   ]);
   assert.deepEqual(errors, []);
 });
 
-test('odf-private flags a non-private ODF package', () => {
-  const errors = diffOdfPrivate([
-    { name: '@usejunior/odf-mcp', private: false, rel: 'packages/odf-mcp/package.json' },
+test('publish-list check flags a private package on the publish surface', () => {
+  const errors = diffPublishListPrivate([
+    { dir: 'packages/odf-core', private: true, rel: 'packages/odf-core/package.json' },
   ]);
   assert.equal(errors.length, 1);
-  assert.match(errors[0], /odf-mcp.*must set "private": true/);
-});
-
-test('odf-private treats missing private flag as non-private', () => {
-  const errors = diffOdfPrivate([
-    { name: '@usejunior/odf-core', rel: 'packages/odf-core/package.json' },
-  ]);
-  assert.equal(errors.length, 1);
+  assert.match(errors[0], /odf-core.*"private": true.*release will fail at tag time/);
 });
 
 // ── canonical ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #372.

## What

Makes the merged ODF lane (#328–#366) actually reachable for published users. Today `@usejunior/odf-core` is `private: true` and absent from `docx-mcp`'s dependencies, so a production install's `loadOdfCore()` returns null and every `.odt` call fails with `MISSING_DEPENDENCY`. This PR retires the deferred independent-track design (`odf-v*` / `release-odf.yml`) and folds odf-core into the main lockstep suite release.

- **`packages/odf-core`**: drops `private`, adds `publishConfig` (publish metadata was already in place); description/keywords now cover the comparison engine.
- **`packages/docx-mcp`**: `@usejunior/odf-core` becomes a regular dependency — ODF works out of the box. Google Docs stays an optional peer because it needs external OAuth setup; ODF needs nothing.
- **`release.yml`**: odf-core added to all four hardcoded loops; publish ordered after `docx-core`, before `docx-mcp`.
- **Guard** (`check-release-isolation.mjs`) becomes a release-surface guard: the workflow snapshot now includes odf-core, and the ODF-must-be-private assertion is replaced by its inverse — a `private: true` package on the publish list fails at PR time instead of at tag time. Tests updated, plus a regression pin that odf-core is on every loop.
- **OpenSpec**: `add-odf-release-isolation` revised in place (proposal addendum + rewritten `release-publishing` delta, ORP-01..05), including the manual-bootstrap requirement.
- **Docs/manifest sync**: root + docx-mcp READMEs, npm descriptions and `odt`/`opendocument`/`libreoffice` keywords, `server.json`, MCPB manifest, `gemini-extension.json` now state OpenDocument (.odt) support.

## Why fold instead of building the separate track

The isolation premise — a rapidly churning experimental lane that must not force suite republishes — no longer holds. The published server is runtime-coupled to odf-core for every `.odt` tool call, so independent versioning would just add a cross-track compatibility range to manage, while suite republishes are automated and effectively free.

## Bootstrap (after merge, before tagging v0.10.0)

npm trusted publishing can only be configured for an already-existing package, so the first odf-core publish is manual: `npm publish --access public` from `packages/odf-core` at **0.9.1** (current version, avoiding any collision with the CI-published 0.10.0), then configure the package's trusted publisher on npmjs.com to mirror the other four. The next suite tag publishes it via OIDC like the rest.

## Verification

- Full preflight green post-commit (`preflight:ci` + all workspace tests + guard tests, exit codes checked explicitly).
- `npm pack --dry-run -w @usejunior/odf-core`: 46 files, dist included, publishable.
- **Production-install smoke**: packed docx-core + odf-core + docx-mcp tarballs, installed them in a clean temp project, and drove the *installed* `safe-docx` stdio binary as a real MCP client — `replace_text` + session-mode `compare_documents` on a real `.odt` (NVCA model COI) returned `mode: 'session'`, `provider: 'odf'`, `stats: {insertions: 1, deletions: 1, modifications: 0}`. This is exactly the path that fails with `MISSING_DEPENDENCY` on current main.