### PR TITLE
fix(odf-core): anchor EOF-replacement deletion backward so reject-all restores the original (#367)

### DIFF
--- a/openspec/changes/add-odf-compare/specs/odf-core/spec.md
+++ b/openspec/changes/add-odf-compare/specs/odf-core/spec.md
@@ -39,6 +39,15 @@ scanning existing ids; `office:change-info` carrying `dc:creator` from `opts.aut
   marker and the insertion's `text:change-start` target the same position (the start of the
   inserted replacement paragraph), the `text:change` (deletion) marker SHALL be emitted BEFORE
   the `text:change-start` (insertion) marker.
+- A deletion run whose following paragraph belongs to an inserted run that itself reaches
+  **end of document** (a whole-paragraph replacement of the LAST paragraph) SHALL anchor
+  **backward** — empty merge artifact first, inline `text:change` marker at the end of the
+  preceding surviving paragraph, BEFORE the insertion's end-anchored `text:change-start` — so
+  the marker stays outside the insertion span and rejecting the insertion cannot remove the
+  deletion's restore point. (A forward marker would sit inside the inserted paragraph, and
+  reject-all would merge the preceding paragraph with the restored one and leave a trailing
+  empty paragraph.) When no preceding paragraph exists (`revisedCursor` 0), the forward
+  placement stands.
 
 `compareOdf` SHALL preserve the unchanged paragraphs' visible text and the rest of the revised
 document (styles, manifest, untouched parts) so the redline round-trips.
@@ -85,3 +94,7 @@ and the visible-text walk SHALL skip the `text:tracked-changes` subtree.
 #### Scenario: [OCMP-10] Modified paragraph orders deletion before insertion markers
 - **WHEN** `compareOdf` emits a modified paragraph whose deletion `text:change` and insertion `text:change-start` target the start of the same replacement paragraph
 - **THEN** the `text:change` (deletion) marker precedes the `text:change-start` (insertion) marker in that paragraph
+
+#### Scenario: [OCMP-11] Replaced last paragraph anchors the deletion backward, outside the insertion bracket
+- **WHEN** `compareOdf` emits a whole-paragraph replacement of the LAST paragraph (a deletion run immediately followed by an inserted run reaching end-of-document)
+- **THEN** the deletion stores the empty merge artifact first and its inline `text:change` marker sits at the end of the preceding surviving paragraph, BEFORE the insertion's end-anchored `text:change-start` (never inside the inserted replacement paragraph), so LibreOffice's reject-all restores the original paragraphs without merging or leaving a trailing empty paragraph

--- a/packages/odf-core/src/compare/emit.test.ts
+++ b/packages/odf-core/src/compare/emit.test.ts
@@ -139,6 +139,25 @@ describe('compareOdf — ODF tracked-changes emission', () => {
     expect(firstTwo).toEqual(['change', 'change-start']); // deletion point BEFORE insertion start
   });
 
+  it('[OCMP-11] replaced LAST paragraph: deletion anchors backward, outside the insertion bracket', () => {
+    // Whole-paragraph replacement at end-of-document (issue #367): the insertion bracket is
+    // end-anchored, so the deletion marker must move to the end of the preceding kept paragraph
+    // (before the change-start) instead of the start of the inserted replacement paragraph.
+    const { contentXml: out, stats } = compareOdf(contentXml(['A', 'B']), contentXml(['A', 'X']));
+    expect(stats).toEqual({ insertions: 1, deletions: 1, modifications: 0 });
+    const ot = officeText(out);
+    const regions = trackedRegions(ot);
+    expect(regions).toHaveLength(2);
+    const delRegion = regions.find((r) => childByName(r, ODF_NS.TEXT, 'deletion'))!;
+    expect(deletionStored(delRegion)).toEqual(['', 'B']); // backward merge: empty artifact first
+    const [pa, px] = bodyParagraphs(ot);
+    // End of kept "A": deletion point marker BEFORE the insertion's change-start.
+    const lastTwo = elementChildren(pa!).slice(-2).map((e) => e.localName);
+    expect(lastTwo).toEqual(['change', 'change-start']);
+    expect(lastElLocal(px!)).toBe('change-end'); // insertion bracket itself is unchanged
+    expect(firstElLocal(px!)).not.toBe('change'); // nothing anchored inside the inserted paragraph
+  });
+
   it('[OCMP-05] change ids are unique across regions', () => {
     const out = compareOdf(contentXml(['A', 'B', 'C']), contentXml(['A', 'X', 'C'])).contentXml;
     const ids = [...out.matchAll(/xml:id="(ct\d+)"/g)].map((m) => m[1]);

--- a/packages/odf-core/src/compare/emit.ts
+++ b/packages/odf-core/src/compare/emit.ts
@@ -15,9 +15,14 @@
  *  - Deletion (paragraph-break merge): the deleted paragraphs live out-of-line in a `text:deletion`
  *    region; an inline `text:change` point marker sits in the nearest SURVIVING paragraph — at the
  *    start of the following one (forward) or the end of the preceding one (backward, for a run
- *    reaching end-of-document). Consecutive deletions coalesce into ONE region with all deleted
- *    paragraphs plus one empty merge-artifact paragraph (artifact last for forward, first for
- *    backward). `text:change` is inline and is never a direct block child of `office:text`.
+ *    reaching end-of-document). A run whose following paragraph belongs to an inserted run that
+ *    itself reaches end-of-document (a dissimilar whole-paragraph replacement of the LAST
+ *    paragraph) also anchors BACKWARD: the insertion's bracket is end-anchored there, so a forward
+ *    marker would sit inside the insertion span and rejecting the insertion would remove the
+ *    deletion's restore point (issue #367). Consecutive deletions coalesce into ONE region with
+ *    all deleted paragraphs plus one empty merge-artifact paragraph (artifact last for forward,
+ *    first for backward). `text:change` is inline and is never a direct block child of
+ *    `office:text`.
  *  - Modify pair (intra-paragraph): the revised paragraph stays in place. An inserted span keeps
  *    its content inline bracketed by `text:change-start`/`text:change-end`; a deleted span leaves
  *    one `text:change` point marker and its content is stored out-of-line in a `text:deletion`
@@ -216,7 +221,7 @@ export function emitTrackedChanges(params: EmitParams): EmitResult {
     ...deleteRuns.map((dr) => ({
       id: dr.id,
       build: () => {
-        const forward = dr.revisedCursor < m;
+        const forward = !anchorsBackward(dr, insertRuns, m);
         const deletedPs = dr.originalIndices.map((i) => revisedDoc.importNode(originalBlocks[i]!, true) as Element);
         const artifact = makeEmptyParagraph(revisedDoc, originalBlocks[dr.originalIndices[0]!]!);
         const stored = forward ? [...deletedPs, artifact] : [artifact, ...deletedPs];
@@ -249,12 +254,11 @@ export function emitTrackedChanges(params: EmitParams): EmitResult {
   }
   // --- Place whole-paragraph deletion point markers.
   for (const run of deleteRuns) {
-    const forward = run.revisedCursor < m;
     const marker = makeMarker(revisedDoc, 'change', run.id);
-    if (forward) {
+    if (!anchorsBackward(run, insertRuns, m)) {
       prepend(revisedBlocks[run.revisedCursor]!, marker);
     } else {
-      revisedBlocks[m - 1]!.appendChild(marker);
+      appendOutsideInsertionStart(revisedBlocks[Math.min(run.revisedCursor, m) - 1]!, marker);
     }
   }
   return result;
@@ -317,6 +321,35 @@ function placeModifyMarkers(doc: Document, block: Element, placements: MarkerPla
       point.parent.insertBefore(makeMarker(doc, p.type, p.id), point.before);
     }
   }
+}
+
+/**
+ * Whether a deletion run anchors its point marker BACKWARD (end of the preceding surviving
+ * paragraph). True when the run reaches end-of-document, and ALSO when its forward anchor would
+ * be the first paragraph of an insert run that itself reaches end-of-document: that insertion's
+ * bracket is end-anchored (`text:change-start` at the end of the preceding kept paragraph), so a
+ * forward marker would sit INSIDE the insertion span and rejecting the insertion would remove
+ * the deletion's restore point (issue #367). With no preceding paragraph (`revisedCursor` 0)
+ * there is nothing to anchor backward to, so the forward placement stands.
+ */
+function anchorsBackward(run: DeleteRun, insertRuns: InsertRun[], m: number): boolean {
+  if (run.revisedCursor >= m) return true;
+  if (run.revisedCursor === 0) return false;
+  return insertRuns.some((ins) => ins.a === run.revisedCursor && ins.b === m - 1);
+}
+
+/**
+ * Append `marker` at the end of `anchor`, but BEFORE a co-located end-of-document insertion
+ * `text:change-start` (insertion markers are placed first), keeping the deletion marker outside
+ * the insertion span.
+ */
+function appendOutsideInsertionStart(anchor: Element, marker: Element): void {
+  const last = anchor.lastChild;
+  const ref =
+    last && last.nodeType === 1 && (last as Element).namespaceURI === ODF_NS.TEXT && (last as Element).localName === 'change-start'
+      ? last
+      : null;
+  anchor.insertBefore(marker, ref);
 }
 
 function placeInsertionMarkers(doc: Document, revisedBlocks: Element[], run: InsertRun, m: number): void {

--- a/packages/odf-core/src/compare/lo_inline_roundtrip.test.ts
+++ b/packages/odf-core/src/compare/lo_inline_roundtrip.test.ts
@@ -85,18 +85,21 @@ describe('LibreOffice accept/reject round-trip of the inline redline', () => {
   );
 
   it(
-    'characterization (issue #367): reject-all of an END-OF-DOCUMENT whole-paragraph replacement merges paragraphs',
+    'issue #367 (fixed): an END-OF-DOCUMENT whole-paragraph replacement round-trips on accept AND reject',
     async () => {
       const soffice = resolveSoffice();
       if (!soffice) {
-        console.warn('[issue #367] soffice not found — skipping characterization (set ODF_SOFFICE_BIN to enable).');
+        console.warn('[issue #367] soffice not found — skipping LibreOffice round-trip (set ODF_SOFFICE_BIN to enable).');
         return;
       }
 
-      // Pre-existing Slice-1 defect: the deletion marker anchors inside the inserted replacement
-      // paragraph while the end-of-document insertion bracket starts in the preceding paragraph;
-      // rejecting both restores the deleted text into the preceding paragraph and leaves an empty
-      // trailing paragraph. Pinned here so a fix for #367 flips this test on purpose.
+      // Formerly a characterization of the pre-existing Slice-1 defect: the deletion marker
+      // anchored inside the inserted replacement paragraph while the end-of-document insertion
+      // bracket started in the preceding paragraph, so reject-all merged the preceding paragraph
+      // with the restored one (and left a trailing empty paragraph). Fixed by anchoring the
+      // deletion BACKWARD — marker at the end of the preceding kept paragraph, before the
+      // insertion's change-start — so this now asserts the true round-trip (see also
+      // lo_paragraph_roundtrip.test.ts, which covers the neighboring EOF compositions).
       const original = ['Stable one.', 'Entirely different clause about apples.'];
       const revised = ['Stable one.', 'Zebras graze quietly under moonlight.'];
       const { contentXml: redline } = compareOdf(await contentXml(original), await contentXml(revised), {
@@ -111,8 +114,8 @@ describe('LibreOffice accept/reject round-trip of the inline redline', () => {
         soffice,
       );
 
-      expect(paragraphTexts(accepted!)).toEqual(revised); // accept-all is correct
-      expect(paragraphTexts(rejected!)).toEqual(['Stable one.Entirely different clause about apples.', '']);
+      expect(paragraphTexts(accepted!)).toEqual(revised);
+      expect(paragraphTexts(rejected!)).toEqual(original);
     },
     180_000,
   );

--- a/packages/odf-core/src/compare/lo_paragraph_roundtrip.test.ts
+++ b/packages/odf-core/src/compare/lo_paragraph_roundtrip.test.ts
@@ -1,0 +1,109 @@
+/**
+ * LibreOffice accept/reject round-trip of the paragraph-granularity (Slice 1) redline.
+ *
+ * Gated reference-oracle test (skipped when no soffice binary is available — CI does not install
+ * LibreOffice). Drives LibreOffice's native .uno:AcceptAllTrackedChanges /
+ * .uno:RejectAllTrackedChanges over `compareOdf` output packaged as a real `.odt`, asserting
+ * accept-all reproduces the revised text and reject-all the original.
+ *
+ * Compositions covered, all batched into ONE headless launch:
+ *  - dissimilar whole-paragraph replacement of the LAST paragraph (issue #367 — the deletion
+ *    must anchor backward, outside the end-of-document insertion bracket, or reject-all merges
+ *    the preceding paragraph with the restored one and leaves a trailing empty paragraph)
+ *  - dissimilar mid-document whole-paragraph replacement (round-tripped cleanly before #367's
+ *    fix; guards that the anchoring change did not regress it)
+ *  - pure end-of-document deletion and pure end-of-document insertion (the two halves of the
+ *    failing composition, each clean in isolation)
+ */
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, it, expect } from 'vitest';
+import { resolveSoffice, runLibreOfficeOracle, type OracleJob } from '@usejunior/docx-core';
+
+import { compareOdf } from './index.js';
+import { OdfArchive } from '../shared/odf/OdfArchive.js';
+import { OdfDocument } from '../document.js';
+
+const FIXTURE = path.join(path.dirname(fileURLToPath(import.meta.url)), '../__fixtures__/sample.odt');
+
+/**
+ * Splice test paragraphs into the FIXTURE's own content.xml (keeping its LibreOffice-authored
+ * root element). A from-scratch minimal `office:document-content` is rejected by LibreOffice's
+ * loader even when schema-plausible — the production flow always reuses a real document's root,
+ * so the test does too.
+ */
+async function contentXml(paras: string[]): Promise<string> {
+  const base = await (await OdfArchive.load(readFileSync(FIXTURE))).getContentXml();
+  const body = paras.map((t) => `<text:p text:style-name="Standard">${t}</text:p>`).join('');
+  return base.replace(/<office:text\b[^>]*>[\s\S]*<\/office:text>/, `<office:text>${body}</office:text>`);
+}
+
+/** Package a content.xml into a complete .odt (mimetype-first STORED) on the fixture shell. */
+async function packageOdt(content: string): Promise<Buffer> {
+  const archive = await OdfArchive.load(readFileSync(FIXTURE));
+  archive.setContentXml(content);
+  return archive.save();
+}
+
+function paragraphTexts(content: string): string[] {
+  return OdfDocument.fromContentXml(content)
+    .getParagraphs()
+    .map((p) => p.text);
+}
+
+type Composition = { name: string; original: string[]; revised: string[] };
+
+const COMPOSITIONS: Composition[] = [
+  {
+    name: 'end-of-document whole-paragraph replacement (issue #367)',
+    original: ['Stable one.', 'Entirely different clause about apples.'],
+    revised: ['Stable one.', 'Zebras graze quietly under moonlight.'],
+  },
+  {
+    name: 'mid-document whole-paragraph replacement',
+    original: ['Stable one.', 'Entirely different clause about apples.', 'Trailing stable paragraph.'],
+    revised: ['Stable one.', 'Zebras graze quietly under moonlight.', 'Trailing stable paragraph.'],
+  },
+  {
+    name: 'pure end-of-document deletion',
+    original: ['Stable one.', 'Drop this final paragraph entirely.'],
+    revised: ['Stable one.'],
+  },
+  {
+    name: 'pure end-of-document insertion',
+    original: ['Stable one.'],
+    revised: ['Stable one.', 'Appended fresh paragraph at the end.'],
+  },
+];
+
+describe('LibreOffice accept/reject round-trip of the paragraph-granularity redline', () => {
+  it(
+    'accept-all reproduces the revised text; reject-all the original (skipped without soffice)',
+    async () => {
+      const soffice = resolveSoffice();
+      if (!soffice) {
+        console.warn('[issue #367] soffice not found — skipping LibreOffice round-trip (set ODF_SOFFICE_BIN to enable).');
+        return;
+      }
+
+      const jobs: OracleJob[] = [];
+      for (const c of COMPOSITIONS) {
+        const { contentXml: redline } = compareOdf(await contentXml(c.original), await contentXml(c.revised), {
+          author: 'RoundTrip',
+        });
+        const redlineOdt = await packageOdt(redline);
+        jobs.push({ op: 'accept', odt: redlineOdt }, { op: 'reject', odt: redlineOdt });
+      }
+
+      const results = await runLibreOfficeOracle(jobs, soffice);
+      for (let i = 0; i < COMPOSITIONS.length; i++) {
+        const c = COMPOSITIONS[i]!;
+        expect(paragraphTexts(results[2 * i]!), `${c.name}: accept-all`).toEqual(c.revised);
+        expect(paragraphTexts(results[2 * i + 1]!), `${c.name}: reject-all`).toEqual(c.original);
+      }
+    },
+    240_000,
+  );
+});


### PR DESCRIPTION
Fixes #367.

## Problem

For a **dissimilar whole-paragraph replacement of the LAST paragraph** (Slice-1 shape: whole-paragraph deletion + end-of-document insertion), LibreOffice's Reject All did not reproduce the original: the preceding paragraph and the restored deleted paragraph merged, and a trailing empty paragraph was left behind.

The deletion's inline `text:change` point marker anchored **forward** — at the start of the *inserted* replacement paragraph — while the insertion used the end-of-document bracket (`text:change-start` at the end of the preceding kept paragraph). The deletion marker therefore sat **inside** the insertion span; rejecting the insertion removed the span the marker lived in, and the restore went to the wrong place.

## Fix

In `emitTrackedChanges`, a deletion run whose forward anchor would be the first paragraph of an insert run that itself reaches end-of-document now anchors **backward**:

- empty merge artifact stored **first** in the `text:deletion` region (the backward shape, matching pure EOF deletion);
- inline `text:change` marker at the **end of the preceding kept paragraph**, placed **before** the insertion's end-anchored `text:change-start`, so it stays outside the insertion span.

With no preceding paragraph (`revisedCursor` 0, whole-document replacement) the forward placement stands — there is nothing to anchor backward to.

Rebased onto #370 (intra-paragraph compare): the rule lives in the lane-1 whole-paragraph path, so it covers both a plain delete+insert from the paragraph diff and a **degraded modify pair** at end-of-document (both re-route through the same delete-run/insert-run shape). Similar replacements that survive as inline modify pairs are untouched.

## Oracle confirmation (G-case style)

- #370's gated characterization test (`lo_inline_roundtrip.test.ts`) pinned the broken reject output for exactly this composition, with the comment "flip when fixing #367" — **flipped here** to assert the true round-trip, and it passes against live LibreOffice.
- New gated `lo_paragraph_roundtrip.test.ts` batches four compositions into one headless launch and asserts accept-all → revised, reject-all → original for each:

| Composition | Before fix | After fix |
|---|---|---|
| EOF whole-paragraph replacement (#367 repro) | reject-all → `["Stable one.Entirely different…", ""]` ❌ | ✅ |
| mid-document whole-paragraph replacement | ✅ | ✅ (guards the anchoring change) |
| pure EOF deletion | ✅ | ✅ |
| pure EOF insertion | ✅ | ✅ |

Verified locally that the round-trip test **fails without the emitter change** with exactly the issue's failure shape, and passes with it (LibreOffice 25.8, macOS).

Unit test `[OCMP-11]` pins the markup shape without LibreOffice (backward artifact-first storage, marker before `change-start` at the shared anchor, nothing anchored inside the inserted paragraph), and the `add-odf-compare` spec delta gains the matching scenario (validated `--strict`).

The `.odt` oracle-job support and `@usejunior/docx-core` re-export this PR originally carried were absorbed by #370's merge — the diff is now odf-core-only.

## Pre-submit

`npm run build && npm run lint:workspaces && npm run test:run && npm run check:spec-coverage && npm run check:conformance-citations && npm run check:conformance-doc` — all green locally after the rebase (including the LibreOffice-gated suites).