### PR TITLE
chore(release): bump workspace versions to 0.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ The local Safe Docx runtime also intentionally rejects Word template files (`.do
 
 Teams on LibreOffice have the same problem as teams on Word: edits without a record. The core session tools — `read_file`, `grep`, `replace_text`, `insert_paragraph`, `add_comment`, `get_comments`, `save` — work directly on `.odt` files, and `compare_documents` writes a native ODF tracked-changes redline: compare two files, or a live editing session against the original it was opened from.
 
-ODF changes are tracked at the whole-paragraph level (a modified paragraph appears as one deletion plus one insertion). The redline round-trips in LibreOffice: accepting all changes reproduces the edited document, rejecting all restores the original. See the [tool reference](packages/docx-mcp/docs/tool-reference.generated.md) for per-tool format support.
+ODF changes are tracked inline at run level: edits within a paragraph appear as word-level insertions and deletions rather than whole-paragraph replacements. The redline round-trips in LibreOffice: accepting all changes reproduces the edited document, rejecting all restores the original. See the [tool reference](packages/docx-mcp/docs/tool-reference.generated.md) for per-tool format support.
 
 ## Document Families
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-docx",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "AI-powered DOCX and ODT editing with tracked changes, redlining, and formatting preservation",
   "contextFileName": "GEMINI.md",
   "entrypoint": "GEMINI.md",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "safe-docx-suite",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "safe-docx-suite",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -9383,7 +9383,7 @@
     },
     "packages/allure-test-factory": {
       "name": "@usejunior/allure-test-factory",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -9404,7 +9404,7 @@
     },
     "packages/docx-core": {
       "name": "@usejunior/docx-core",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "^0.9.10",
@@ -9432,12 +9432,12 @@
     },
     "packages/docx-mcp": {
       "name": "@usejunior/docx-mcp",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@usejunior/docx-core": "^0.9.1",
-        "@usejunior/odf-core": "^0.9.1",
+        "@usejunior/docx-core": "^0.10.0",
+        "@usejunior/odf-core": "^0.10.0",
         "@xmldom/xmldom": "^0.9.10",
         "zod": "^4.3.6"
       },
@@ -9458,7 +9458,7 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@usejunior/google-docs-core": "^0.9.1"
+        "@usejunior/google-docs-core": "^0.10.0"
       },
       "peerDependenciesMeta": {
         "@usejunior/google-docs-core": {
@@ -9468,7 +9468,7 @@
     },
     "packages/google-docs-core": {
       "name": "@usejunior/google-docs-core",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "google-auth-library": "^9.0.0"
@@ -9484,10 +9484,10 @@
     },
     "packages/odf-core": {
       "name": "@usejunior/odf-core",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
-        "@usejunior/docx-core": "^0.9.1",
+        "@usejunior/docx-core": "^0.10.0",
         "@xmldom/xmldom": "^0.9.10",
         "jszip": "^3.10.1"
       },
@@ -9502,10 +9502,10 @@
     },
     "packages/safe-docx": {
       "name": "@usejunior/safe-docx",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
-        "@usejunior/docx-mcp": "^0.9.1"
+        "@usejunior/docx-mcp": "^0.10.0"
       },
       "bin": {
         "safe-docx": "bin/safe-docx.js",
@@ -9517,10 +9517,10 @@
     },
     "packages/safe-docx-mcpb": {
       "name": "@usejunior/safedocx-mcpb",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
-        "@usejunior/safe-docx": "^0.9.1"
+        "@usejunior/safe-docx": "^0.10.0"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-docx-suite",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "private": true,
   "description": "Monorepo for Safe DOCX packages",
   "repository": {

--- a/packages/allure-test-factory/package.json
+++ b/packages/allure-test-factory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/allure-test-factory",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Shared Allure test helpers for vitest — BDD context, OpenSpec auto-inference, Prism.js highlighting",
   "type": "module",
   "exports": {

--- a/packages/docx-core/package.json
+++ b/packages/docx-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/docx-core",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "OOXML (.docx) core library: primitives, comparison, and track changes",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/docx-mcp/README.md
+++ b/packages/docx-mcp/README.md
@@ -6,7 +6,7 @@
 
 **Install via the canonical package:** `npx -y @usejunior/safe-docx` — [see setup guide](../../README.md)
 
-Local MCP server for surgical editing of existing Microsoft Word `.docx` files with coding agents. The same tool surface also services OpenDocument `.odt` files — including `compare_documents` redlines (two files, or a live session against its original) written as native ODF tracked changes at paragraph granularity.
+Local MCP server for surgical editing of existing Microsoft Word `.docx` files with coding agents. The same tool surface also services OpenDocument `.odt` files — including `compare_documents` redlines (two files, or a live session against its original) written as native ODF tracked changes with inline (run-level) granularity.
 
 Safe Docx is built for brownfield paperwork workflows: apply accepted AI edits to real Word documents while preserving formatting and review semantics.
 

--- a/packages/docx-mcp/package.json
+++ b/packages/docx-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/docx-mcp",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "MCP server for reading, editing, and comparing Word (.docx) and OpenDocument (.odt) files with tracked changes. For Claude, Gemini CLI, Cursor, and any MCP client. MIT licensed.",
   "type": "module",
   "main": "dist/index.js",
@@ -27,8 +27,8 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@usejunior/docx-core": "^0.9.1",
-    "@usejunior/odf-core": "^0.9.1",
+    "@usejunior/docx-core": "^0.10.0",
+    "@usejunior/odf-core": "^0.10.0",
     "@xmldom/xmldom": "^0.9.10",
     "zod": "^4.3.6"
   },
@@ -55,7 +55,7 @@
     "dist"
   ],
   "peerDependencies": {
-    "@usejunior/google-docs-core": "^0.9.1"
+    "@usejunior/google-docs-core": "^0.10.0"
   },
   "peerDependenciesMeta": {
     "@usejunior/google-docs-core": {

--- a/packages/google-docs-core/package.json
+++ b/packages/google-docs-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/google-docs-core",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Google Docs core library: read, write, and anchor management via Google Docs API",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/odf-core/package.json
+++ b/packages/odf-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/odf-core",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "OpenDocument Format (.odt) core library: archive packaging, document view, surgical text replacement, and tracked-changes comparison",
   "type": "module",
   "main": "dist/index.js",
@@ -14,7 +14,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@usejunior/docx-core": "^0.9.1",
+    "@usejunior/docx-core": "^0.10.0",
     "@xmldom/xmldom": "^0.9.10",
     "jszip": "^3.10.1"
   },

--- a/packages/safe-docx-mcpb/manifest.json
+++ b/packages/safe-docx-mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "safe-docx",
   "display_name": "Safe Docx",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "AI-native Word (.docx) and OpenDocument (.odt) editing with stable paragraph anchors and deterministic document operations.",
   "long_description": "Safe Docx lets Claude work directly with .docx files on your local filesystem. It provides stable paragraph IDs (_bk_*) for precise editing while preserving formatting and structure.\n\nCore capabilities include reading/searching content, formatting-preserving edits and inserts, deterministic layout controls, tracked-changes output, comments, footnote tools, document comparison, and revision extraction.",
   "author": {

--- a/packages/safe-docx-mcpb/package.json
+++ b/packages/safe-docx-mcpb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/safedocx-mcpb",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "private": true,
   "description": "Claude Desktop MCP Bundle (.mcpb) wrapper for @usejunior/safe-docx",
   "type": "module",
@@ -14,7 +14,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@usejunior/safe-docx": "^0.9.1"
+    "@usejunior/safe-docx": "^0.10.0"
   },
   "devDependencies": {
     "@vitest/runner": "^4.1.8",

--- a/packages/safe-docx/.smithery/shttp/manifest.json
+++ b/packages/safe-docx/.smithery/shttp/manifest.json
@@ -6,7 +6,7 @@
     "serverCard": {
       "serverInfo": {
         "name": "safe-docx",
-        "version": "0.9.1"
+        "version": "0.10.0"
       },
       "tools": [
         {

--- a/packages/safe-docx/package.json
+++ b/packages/safe-docx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/safe-docx",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Edit Word (.docx) and OpenDocument (.odt) files with tracked changes, redlines, and formatting preservation. Built for AI coding agents. MIT licensed, 100% local processing.",
   "mcpName": "io.github.UseJunior/safe-docx",
   "type": "module",
@@ -25,7 +25,7 @@
     "safedocx": "./bin/safe-docx.js"
   },
   "dependencies": {
-    "@usejunior/docx-mcp": "^0.9.1"
+    "@usejunior/docx-mcp": "^0.10.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/safe-docx/server.json
+++ b/packages/safe-docx/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.UseJunior/safe-docx",
   "title": "Safe Docx",
   "description": "AI-native surgical editing of existing Word .docx and OpenDocument .odt files with formatting preservation",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "websiteUrl": "https://usejunior.com/developer-tools/safe-docx",
   "icons": [
     {
@@ -18,7 +18,7 @@
     {
       "registryType": "npm",
       "identifier": "@usejunior/safe-docx",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "transport": {
         "type": "stdio"
       },

--- a/scripts/bump_version.mjs
+++ b/scripts/bump_version.mjs
@@ -23,6 +23,7 @@ const PACKAGE_JSONS = [
   'packages/allure-test-factory/package.json',
   'packages/docx-core/package.json',
   'packages/docx-mcp/package.json',
+  'packages/odf-core/package.json',
   'packages/google-docs-core/package.json',
   'packages/safe-docx-mcpb/package.json',
   'packages/safe-docx/package.json',
@@ -35,6 +36,7 @@ const SMITHERY_MANIFEST_JSON = 'packages/safe-docx/.smithery/shttp/manifest.json
 // Cross-workspace dependencies (package name → dep specifier pattern)
 const WORKSPACE_DEPS = [
   '@usejunior/docx-core',
+  '@usejunior/odf-core',
   '@usejunior/docx-mcp',
   '@usejunior/google-docs-core',
   '@usejunior/safe-docx',

--- a/site/package.json
+++ b/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/safe-docx-site",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "private": true,
   "type": "module",
   "description": "Safe DOCX marketing and trust site (Eleventy)",


### PR DESCRIPTION
Ref #372. Lockstep bump 0.9.1 → 0.10.0 across all 13 version-bearing files, via `scripts/bump_version.mjs`.

First minor since v0.9.1 — headline: **OpenDocument (.odt) support becomes installable**. The tag that follows this merge publishes the full suite including `@usejunior/odf-core@0.10.0` (first publish was bootstrapped manually at 0.9.1; the trusted publisher is configured, so this release goes via OIDC like the other packages).

Also in this PR:
- `scripts/bump_version.mjs`: add odf-core to `PACKAGE_JSONS` + `WORKSPACE_DEPS` (the script predated the package) — this bump is the first produced with it included; cross-workspace ranges land at `^0.10.0`.
- README granularity refresh: #370 upgraded ODF compare from whole-paragraph to inline (run-level) tracked changes; the README copy added in #373 said "whole-paragraph level" and now undersells — updated to inline.

After merge: `git tag v0.10.0 && git push origin v0.10.0` triggers `release.yml` (npm publish ×5 incl. odf-core, MCP registry, GitHub release + MCPB bundle, changelog-data PR).