### PR TITLE
fix(docx-core): preserve w:hyperlink wrappers in rebuild reconstruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ safe-docx targets a defined subset of **ECMA-376 5th edition**. The full surface
 (targeted sections, Non-Goals, and verification status) lives at
 [spec-compliance/CONFORMANCE.md](spec-compliance/CONFORMANCE.md).
 
-- **3** sections claimed
+- **4** sections claimed
 - **5** sections explicitly out-of-scope (Non-Goals)
 - **0** known gaps under `@conformance-gap`
 - Vendored normative schemas: `spec-compliance/ecma-376/schemas/`

--- a/packages/docx-core/src/atomizer.ts
+++ b/packages/docx-core/src/atomizer.ts
@@ -963,12 +963,35 @@ function runPropertiesEqual(
 }
 
 /**
+ * Find the nearest `w:hyperlink` ancestor of an atom, or null.
+ *
+ * Boundary normalization must never merge text atoms across a hyperlink
+ * boundary: the surviving atom keeps a single ancestor chain, so a
+ * cross-boundary merge either absorbs adjacent plain text into the link
+ * (formatting bleed) or detaches link text from its wrapper.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.22
+ * @see https://github.com/UseJunior/safe-docx/issues/368
+ */
+export function nearestHyperlinkAncestor(atom: ComparisonUnitAtom): WmlElement | null {
+  for (let i = atom.ancestorElements.length - 1; i >= 0; i--) {
+    const ancestor = atom.ancestorElements[i]!;
+    if (ancestor.tagName === 'w:hyperlink') return ancestor;
+    // w:hyperlink always sits between the run and its paragraph; once the
+    // walk reaches w:p there is no hyperlink wrapper.
+    if (ancestor.tagName === 'w:p') break;
+  }
+  return null;
+}
+
+/**
  * Check if two atoms can be merged into one.
  *
  * Atoms can be merged if they:
  * - Are both w:t (text) elements
  * - Neither is a collapsed field (fields should stay as separate atoms for finer diff)
  * - Are in the same paragraph
+ * - Are inside the same w:hyperlink wrapper (or both outside one)
  * - Have the same run formatting (w:rPr) OR are in the same run
  * - Have the same revision tracking status
  *
@@ -1006,6 +1029,11 @@ function canMergeAtoms(
   // Different runs - allow cross-run merge only if enabled.
   // (In inplace mode we disable this so each atom stays anchored to a real run.)
   if (!options.mergeAcrossRuns) return false;
+
+  // Never merge across a w:hyperlink boundary — the merged atom keeps only
+  // one side's ancestry, so link text would detach from (or plain text be
+  // absorbed into) the hyperlink wrapper.
+  if (nearestHyperlinkAncestor(a) !== nearestHyperlinkAncestor(b)) return false;
 
   // Different runs - check if they have equivalent formatting
   const aRPr = getRunProperties(a);
@@ -1077,6 +1105,11 @@ function canMergePunctuation(
   // A must end with a word character (not whitespace or punctuation)
   const aText = getLeafText(a.contentElement) ?? '';
   if (!/\w$/.test(aText)) return false;
+
+  // Never merge across a w:hyperlink boundary: punctuation that follows a
+  // link must not inherit the link run's ancestry/formatting (e.g. the
+  // sentence period after a URL turning underlined).
+  if (nearestHyperlinkAncestor(a) !== nearestHyperlinkAncestor(b)) return false;
 
   // If cross-run punctuation merge is disabled, require same run.
   if (!options.mergePunctuationAcrossRuns) {

--- a/packages/docx-core/src/baselines/atomizer/documentReconstructor-hyperlinks.test.ts
+++ b/packages/docx-core/src/baselines/atomizer/documentReconstructor-hyperlinks.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Regression tests for w:hyperlink preservation in rebuild reconstruction.
+ *
+ * Rebuild used to drop `<w:hyperlink>` wrappers entirely (link + r:id lost)
+ * and the cross-run punctuation merge absorbed adjacent plain text into the
+ * underlined link run. First caught on a real document by the
+ * formatting-fidelity check; pinned here with the issue's fixture shape
+ * (Common Paper Mutual NDA cover page: `…posted at <hyperlink>URL</hyperlink>.`).
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.22
+ * @see https://github.com/UseJunior/safe-docx/issues/368
+ */
+
+import { describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
+import { buildDocxFromBodyXml } from '../../testing/ooxml-fixtures.js';
+import { DocxArchive } from '../../shared/docx/DocxArchive.js';
+import { compareDocumentsAtomizer } from './pipeline.js';
+import { compareProjectedFormattingFidelity } from './formattingFidelity.js';
+import { acceptAllChanges, rejectAllChanges } from './trackChangesAcceptorAst.js';
+
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({
+    feature: 'Document Reconstructor Hyperlinks',
+    story: 'Hyperlink Wrapper Preservation In Rebuild',
+    severity: 'critical',
+  })
+  .conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.16.22' });
+
+const R_NS = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+
+/** Hyperlink-bearing paragraph in the issue-#368 fixture shape. */
+function linkParagraph(urlText: string): string {
+  return (
+    `<w:p><w:r><w:t xml:space="preserve">License terms are posted at </w:t></w:r>` +
+    `<w:hyperlink xmlns:r="${R_NS}" r:id="rId7" w:history="1">` +
+    `<w:r><w:rPr><w:u w:val="single"/></w:rPr><w:t>${urlText}</w:t></w:r>` +
+    `</w:hyperlink>` +
+    `<w:r><w:t>.</w:t></w:r></w:p>`
+  );
+}
+
+function countMatches(xml: string, re: RegExp): number {
+  return (xml.match(re) ?? []).length;
+}
+
+async function rebuildCompare(originalBody: string, revisedBody: string) {
+  const original = await buildDocxFromBodyXml(originalBody);
+  const revised = await buildDocxFromBodyXml(revisedBody);
+  const result = await compareDocumentsAtomizer(original, revised, {
+    author: 'Hyperlink Test',
+    date: new Date('2026-06-10T00:00:00Z'),
+    reconstructionMode: 'rebuild',
+  });
+  expect(result.reconstructionModeUsed).toBe('rebuild');
+  return (await DocxArchive.load(result.document)).getDocumentXml();
+}
+
+describe('Rebuild reconstruction preserves w:hyperlink wrappers', () => {
+  test('edit inside the link text keeps the wrapper, r:id, and revision nesting', async ({ given, when, then, and }: AllureBddContext) => {
+    let rebuildXml: string;
+
+    await given('original and revised docs whose only change is inside the hyperlink URL', () => {});
+
+    await when('compared with reconstructionMode rebuild', async () => {
+      rebuildXml = await rebuildCompare(
+        linkParagraph('commonpaper.com/standards/mutual-nda/1.0'),
+        linkParagraph('commonpaper.com/standards/reciprocal-nda/1.0'),
+      );
+    });
+
+    await then('exactly one w:hyperlink with the original r:id survives', () => {
+      expect(countMatches(rebuildXml, /<w:hyperlink[\s>]/g)).toBe(1);
+      expect(rebuildXml).toContain('r:id="rId7"');
+    });
+
+    await and('revision wrappers nest inside the hyperlink, never around it', () => {
+      expect(rebuildXml).not.toMatch(/<w:ins[^>]*>\s*<w:hyperlink/);
+      expect(rebuildXml).not.toMatch(/<w:del[^>]*>\s*<w:hyperlink/);
+      const wrapperInner = /<w:hyperlink[^>]*>([\s\S]*?)<\/w:hyperlink>/.exec(rebuildXml)![1]!;
+      expect(wrapperInner).toContain('<w:del');
+      expect(wrapperInner).toContain('<w:ins');
+    });
+
+    await and('both projections resolve the edit while keeping the link text inside the wrapper', () => {
+      const accepted = acceptAllChanges(rebuildXml);
+      const rejected = rejectAllChanges(rebuildXml);
+      expect(/<w:hyperlink[^>]*>[\s\S]*?reciprocal-nda[\s\S]*?<\/w:hyperlink>/.test(accepted)).toBe(true);
+      expect(/<w:hyperlink[^>]*>[\s\S]*?mutual-nda[\s\S]*?<\/w:hyperlink>/.test(rejected)).toBe(true);
+    });
+  });
+
+  test('the sentence period after the link does not inherit the underline', async ({ given, when, then }: AllureBddContext) => {
+    let inplaceXml: string;
+    let rebuildXml: string;
+
+    await given('the issue-368 fixture shape with a plain "." run after the underlined URL', () => {});
+
+    await when('inplace and rebuild candidates are produced for the same revision', async () => {
+      const original = await buildDocxFromBodyXml(
+        linkParagraph('commonpaper.com/standards/mutual-nda/1.0'),
+      );
+      const revised = await buildDocxFromBodyXml(
+        linkParagraph('commonpaper.com/standards/reciprocal-nda/1.0'),
+      );
+      const options = { author: 'Hyperlink Test', date: new Date('2026-06-10T00:00:00Z') };
+      const inplace = await compareDocumentsAtomizer(original, revised, {
+        ...options, reconstructionMode: 'inplace',
+      });
+      const rebuild = await compareDocumentsAtomizer(original, revised, {
+        ...options, reconstructionMode: 'rebuild',
+      });
+      inplaceXml = await (await DocxArchive.load(inplace.document)).getDocumentXml();
+      rebuildXml = await (await DocxArchive.load(rebuild.document)).getDocumentXml();
+    });
+
+    await then('the fidelity check reports no underline divergence in either projection', () => {
+      const result = compareProjectedFormattingFidelity(inplaceXml, rebuildXml);
+      const underline = [...result.accept.divergences, ...result.reject.divergences]
+        .filter((d) => d.property === 'underline');
+      expect(underline).toEqual([]);
+    });
+  });
+
+  test('an edit elsewhere in the paragraph leaves the untouched link intact', async ({ given, when, then }: AllureBddContext) => {
+    let rebuildXml: string;
+
+    await given('a revision that only rewords the plain text before the link', () => {});
+
+    await when('compared with reconstructionMode rebuild', async () => {
+      rebuildXml = await rebuildCompare(
+        linkParagraph('commonpaper.com/standards/mutual-nda/1.0').replace(
+          'License terms are posted at ', 'License terms are published at '),
+        linkParagraph('commonpaper.com/standards/mutual-nda/1.0'),
+      );
+    });
+
+    await then('the hyperlink survives whole with its r:id and full URL inside', () => {
+      expect(countMatches(rebuildXml, /<w:hyperlink[\s>]/g)).toBe(1);
+      expect(
+        /<w:hyperlink[^>]*r:id="rId7"[^>]*>[\s\S]*?mutual-nda[\s\S]*?<\/w:hyperlink>/.test(rebuildXml),
+      ).toBe(true);
+    });
+  });
+
+  test('a deleted paragraph keeps its hyperlink with w:del nested inside', async ({ given, when, then }: AllureBddContext) => {
+    let rebuildXml: string;
+
+    await given('a revision that removes the entire hyperlink-bearing paragraph', () => {});
+
+    await when('compared with reconstructionMode rebuild', async () => {
+      rebuildXml = await rebuildCompare(
+        `<w:p><w:r><w:t>Kept paragraph</w:t></w:r></w:p>` +
+          linkParagraph('commonpaper.com/standards/mutual-nda/1.0'),
+        `<w:p><w:r><w:t>Kept paragraph</w:t></w:r></w:p>`,
+      );
+    });
+
+    await then('the deletion nests inside the wrapper and rejecting restores the link', () => {
+      expect(rebuildXml).toMatch(/<w:hyperlink[^>]*r:id="rId7"[^>]*><w:del/);
+      expect(rebuildXml).not.toMatch(/<w:del[^>]*>\s*<w:hyperlink/);
+      const rejected = rejectAllChanges(rebuildXml);
+      expect(/<w:hyperlink[^>]*>[\s\S]*?mutual-nda[\s\S]*?<\/w:hyperlink>/.test(rejected)).toBe(true);
+    });
+  });
+
+  test('a retargeted link never leaves accepted text on the stale original target', async ({ given, when, then, and }: AllureBddContext) => {
+    let rebuildXml: string;
+
+    await given('a revision that changes the link target (r:id) and part of the link text, keeping a text suffix equal', () => {});
+
+    await when('compared with reconstructionMode rebuild', async () => {
+      const para = (id: string, text: string) =>
+        `<w:p><w:r><w:t xml:space="preserve">See </w:t></w:r>` +
+        `<w:hyperlink xmlns:r="${R_NS}" r:id="${id}"><w:r><w:t>${text}</w:t></w:r></w:hyperlink></w:p>`;
+      rebuildXml = await rebuildCompare(
+        para('rId7', 'alpha target'),
+        para('rId99', 'beta target'),
+      );
+    });
+
+    await then('the accepted projection carries neither the stale rId7 nor the unresolvable rId99', () => {
+      const accepted = acceptAllChanges(rebuildXml);
+      expect(accepted).not.toContain('rId7');
+      expect(accepted).not.toContain('rId99');
+      expect(accepted).toContain('beta');
+      expect(accepted).toContain('target');
+    });
+
+    await and('the rejected projection keeps deleted link text under the original r:id', () => {
+      const rejected = rejectAllChanges(rebuildXml);
+      expect(/<w:hyperlink[^>]*r:id="rId7"[^>]*>[\s\S]*?alpha[\s\S]*?<\/w:hyperlink>/.test(rejected)).toBe(true);
+      expect(rejected).not.toContain('rId99');
+    });
+  });
+
+  test('an inserted anchor-only hyperlink is wrapped; an inserted r:id hyperlink stays unwrapped', async ({ given, when, then, and }: AllureBddContext) => {
+    let anchorXml: string;
+    let relIdXml: string;
+
+    await given('revisions that add a new hyperlink paragraph (anchor-only vs r:id)', () => {});
+
+    await when('compared with reconstructionMode rebuild', async () => {
+      const base = `<w:p><w:r><w:t>Existing text</w:t></w:r></w:p>`;
+      anchorXml = await rebuildCompare(
+        base,
+        base +
+          `<w:p><w:hyperlink w:anchor="definitions">` +
+          `<w:r><w:t>See definitions</w:t></w:r></w:hyperlink></w:p>`,
+      );
+      relIdXml = await rebuildCompare(
+        base,
+        base +
+          `<w:p><w:hyperlink xmlns:r="${R_NS}" r:id="rId99">` +
+          `<w:r><w:t>brand-new.example.com</w:t></w:r></w:hyperlink></w:p>`,
+      );
+    });
+
+    await then('the anchor-only insertion re-emits the wrapper with w:ins inside', () => {
+      expect(anchorXml).toMatch(/<w:hyperlink[^>]*w:anchor="definitions"[^>]*><w:ins/);
+      expect(anchorXml).not.toMatch(/<w:ins[^>]*>\s*<w:hyperlink/);
+    });
+
+    await and('the r:id insertion is NOT wrapped — rId99 has no relationship in the original-based package, and a dangling r:id corrupts the document (known boundary, content preserved as plain inserted runs)', () => {
+      expect(relIdXml).not.toContain('rId99');
+      expect(relIdXml).toContain('brand-new.example.com');
+    });
+  });
+});

--- a/packages/docx-core/src/baselines/atomizer/documentReconstructor.ts
+++ b/packages/docx-core/src/baselines/atomizer/documentReconstructor.ts
@@ -23,7 +23,7 @@ import {
   wrapSerializedContentWithIns,
 } from '../../primitives/track-changes-emitter.js';
 import { serializeToXml, cloneElement } from './xmlToWmlElement.js';
-import { EMPTY_PARAGRAPH_TAG, isParagraphLevelLeaf } from '../../atomizer.js';
+import { EMPTY_PARAGRAPH_TAG, isParagraphLevelLeaf, nearestHyperlinkAncestor } from '../../atomizer.js';
 import { enforceConsumerCompatibility } from './consumerCompatibility.js';
 import { areRunPropertiesEqual } from '../../format-detection.js';
 import { debug } from './debug.js';
@@ -588,10 +588,13 @@ function buildParagraphXml(
   // entirely (instead of leaving behind a stub <w:p> break).
   if (isEntireParagraphWithStatus(group, CorrelationStatus.Inserted)) {
     const paraId = allocateRevisionId(revState);
-    const insertedRunXml = wrapSerializedContentWithIns(
-      group.runGroups.map((runGroup) => buildRunContentAsPlainRun(runGroup)).join(''),
-      revisionCtx,
-    );
+    const insertedRunXml = paragraphHasHyperlinkAtoms(group)
+      ? buildWholeParagraphRevisionContent(group, (runs) =>
+          wrapSerializedContentWithIns(runs, revisionCtx))
+      : wrapSerializedContentWithIns(
+          group.runGroups.map((runGroup) => buildRunContentAsPlainRun(runGroup)).join(''),
+          revisionCtx,
+        );
     const pPrChangeEl = buildPPrChangeElement(group.pPr, revisionCtx);
     const parts: string[] = [];
     parts.push('<w:p>');
@@ -610,10 +613,15 @@ function buildParagraphXml(
     parts.push(serializePPrWithParaRevisionMarker(
       group.pPr, 'w:del', paraId, author, dateStr
     ));
-    parts.push(wrapSerializedContentWithDel(
-      group.runGroups.map((runGroup) => buildRunContentAsPlainRun(runGroup)).join(''),
-      revisionCtx,
-    ));
+    parts.push(
+      paragraphHasHyperlinkAtoms(group)
+        ? buildWholeParagraphRevisionContent(group, (runs) =>
+            wrapSerializedContentWithDel(runs, revisionCtx))
+        : wrapSerializedContentWithDel(
+            group.runGroups.map((runGroup) => buildRunContentAsPlainRun(runGroup)).join(''),
+            revisionCtx,
+          )
+    );
     parts.push('</w:p>');
     return parts.join('');
   }
@@ -648,10 +656,16 @@ function buildParagraphXml(
     parts.push(serializeToXml(group.pPr));
   }
 
-  // Add run groups with track changes
-  for (const runGroup of group.runGroups) {
-    const runXml = buildRunGroupXml(runGroup, author, dateStr, revState);
-    parts.push(runXml);
+  // Add run groups with track changes, restoring w:hyperlink wrappers when
+  // the paragraph contains hyperlink atoms (issue #368). Hyperlink-free
+  // paragraphs keep the legacy per-group emission byte-identical.
+  if (paragraphHasHyperlinkAtoms(group)) {
+    parts.push(buildRunGroupsWithHyperlinks(group.runGroups, author, dateStr, revState));
+  } else {
+    for (const runGroup of group.runGroups) {
+      const runXml = buildRunGroupXml(runGroup, author, dateStr, revState);
+      parts.push(runXml);
+    }
   }
 
   parts.push('</w:p>');
@@ -887,6 +901,249 @@ function subGroupByRPr(atoms: ComparisonUnitAtom[]): { rPr: Element | null; atom
 
   result.push({ rPr: currentRPr, atoms: currentAtoms });
   return result;
+}
+
+// =============================================================================
+// Hyperlink Wrapper Re-emission
+// =============================================================================
+
+/**
+ * A resolved hyperlink wrapper for a contiguous segment of atoms.
+ *
+ * `element` is the w:hyperlink whose attributes get re-emitted. `fromOriginal`
+ * records whether that element comes from the original document tree — the
+ * rebuild output package is cloned from the original archive, so only
+ * original-tree `r:id` values are guaranteed to resolve against the shipped
+ * relationships part.
+ */
+interface ResolvedHyperlink {
+  element: Element;
+  key: string;
+  fromOriginal: boolean;
+}
+
+/**
+ * Attribute fingerprint of a w:hyperlink element, used to recognize "the
+ * same" hyperlink across the original and revised trees (equal/deleted atoms
+ * reference the original tree's element, inserted atoms the revised tree's).
+ */
+function hyperlinkKey(el: Element): string {
+  const parts: string[] = [];
+  for (let i = 0; i < el.attributes.length; i++) {
+    const attr = el.attributes.item(i)!;
+    if (attr.name.startsWith('xmlns')) continue;
+    parts.push(`${attr.name}=${attr.value}`);
+  }
+  return parts.sort().join(' ');
+}
+
+/**
+ * Resolve the hyperlink wrapper an atom belongs to, preferring the
+ * original-tree element so the re-emitted r:id resolves against the
+ * original-based rebuild package: deleted atoms carry original ancestry
+ * directly; equal atoms (revised tree) reach it via comparisonUnitAtomBefore.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.22
+ * @see https://github.com/UseJunior/safe-docx/issues/368
+ */
+function resolveHyperlinkForAtom(atom: ComparisonUnitAtom): ResolvedHyperlink | null {
+  const own = nearestHyperlinkAncestor(atom);
+  if (!own) return null;
+  if (atom.sourceDocument === 'original') {
+    return { element: own, key: hyperlinkKey(own), fromOriginal: true };
+  }
+  const before = atom.comparisonUnitAtomBefore;
+  const beforeHyperlink = before ? nearestHyperlinkAncestor(before) : null;
+  // Attribute to the original wrapper only when both trees agree on the
+  // hyperlink's attributes. When they differ (e.g. the revision retargeted
+  // the link to a new r:id), emitting the original wrapper would pin the
+  // still-equal link text to the STALE target in the accepted document —
+  // worse than dropping the wrapper. Such atoms fall through to the
+  // revised-only policy below instead.
+  // TODO(#376): the faithful tracked representation of a retargeted link
+  // is delete-old-link + insert-new-link (what Word emits), which needs the
+  // hyperlink fingerprint in atom identity so the LCS stops matching text
+  // across different link targets.
+  if (beforeHyperlink && hyperlinkKey(beforeHyperlink) === hyperlinkKey(own)) {
+    return { element: beforeHyperlink, key: hyperlinkKey(beforeHyperlink), fromOriginal: true };
+  }
+  // Revised-only attribution (purely inserted hyperlink). Emitting its r:id
+  // would dangle against the original-based package, so the caller only
+  // wraps when the hyperlink carries no relationship reference (anchor-only).
+  return { element: own, key: hyperlinkKey(own), fromOriginal: false };
+}
+
+/**
+ * Whether a resolved hyperlink is safe to re-emit. Original-attributed
+ * wrappers always are; revised-only wrappers are safe only without an r:id
+ * (internal anchor links), because the rebuild package ships the ORIGINAL
+ * document.xml.rels and a revised-only r:id would be a dangling reference
+ * (Word treats those as a corrupt package). Revised-only r:id hyperlinks
+ * keep today's behavior — content emitted unwrapped.
+ */
+function isEmittableHyperlink(resolved: ResolvedHyperlink): boolean {
+  return resolved.fromOriginal || resolved.element.getAttribute('r:id') === null;
+}
+
+/**
+ * True when any atom in the paragraph sits inside a w:hyperlink. Gates the
+ * hyperlink-aware emission paths so hyperlink-free paragraphs keep the
+ * byte-identical legacy output.
+ */
+function paragraphHasHyperlinkAtoms(group: ParagraphGroup): boolean {
+  return group.runGroups.some((rg) =>
+    rg.atoms.some((atom) => nearestHyperlinkAncestor(atom) !== null)
+  );
+}
+
+/**
+ * A hyperlink-pure slice of a RunGroup: every atom resolves to the same
+ * emittable hyperlink wrapper (or to none).
+ */
+interface HyperlinkSegment {
+  group: RunGroup;
+  hyperlink: ResolvedHyperlink | null;
+}
+
+/**
+ * Split a RunGroup into contiguous hyperlink-pure sub-groups.
+ *
+ * Moved groups are returned whole: splitting them would emit
+ * moveFromRangeStart/End once per slice, corrupting the move ranges. A move
+ * spanning a hyperlink keeps today's unwrapped emission.
+ */
+function splitRunGroupByHyperlink(group: RunGroup): HyperlinkSegment[] {
+  if (
+    group.status === CorrelationStatus.MovedSource ||
+    group.status === CorrelationStatus.MovedDestination
+  ) {
+    return [{ group, hyperlink: null }];
+  }
+
+  const segments: HyperlinkSegment[] = [];
+  let current: HyperlinkSegment | null = null;
+
+  for (const atom of group.atoms) {
+    // Emit-ability is decided per merged bucket, not per atom: an inserted
+    // atom inside an otherwise-original hyperlink folds into the adjacent
+    // original-attributed bucket via the shared key.
+    const resolved = resolveHyperlinkForAtom(atom);
+    const key = resolved?.key ?? null;
+
+    if (current && (current.hyperlink?.key ?? null) === key) {
+      current.group.atoms.push(atom);
+      // Prefer an original-attributed representative within the segment.
+      if (resolved?.fromOriginal && current.hyperlink && !current.hyperlink.fromOriginal) {
+        current.hyperlink = resolved;
+      }
+    } else {
+      current = {
+        group: { ...group, atoms: [atom] },
+        hyperlink: resolved,
+      };
+      segments.push(current);
+    }
+  }
+
+  return segments;
+}
+
+/**
+ * Serialize the opening tag of a re-emitted w:hyperlink wrapper, copying the
+ * source element's attributes verbatim (r:id, w:anchor, w:history, ...).
+ */
+function serializeHyperlinkOpenTag(el: Element): string {
+  const attrs: string[] = [];
+  for (let i = 0; i < el.attributes.length; i++) {
+    const attr = el.attributes.item(i)!;
+    if (attr.name.startsWith('xmlns')) continue;
+    attrs.push(` ${attr.name}="${escapeXmlAttr(attr.value)}"`);
+  }
+  return `<w:hyperlink${attrs.join('')}>`;
+}
+
+/**
+ * Merge adjacent segments that resolve to the same hyperlink fingerprint, so
+ * an equal/deleted/inserted sequence inside one link shares one wrapper.
+ */
+function mergeAdjacentHyperlinkSegments(
+  segments: HyperlinkSegment[]
+): Array<{ hyperlink: ResolvedHyperlink | null; groups: RunGroup[] }> {
+  const buckets: Array<{ hyperlink: ResolvedHyperlink | null; groups: RunGroup[] }> = [];
+  for (const segment of segments) {
+    const last = buckets[buckets.length - 1];
+    if (last && (last.hyperlink?.key ?? null) === (segment.hyperlink?.key ?? null)) {
+      last.groups.push(segment.group);
+      if (segment.hyperlink?.fromOriginal && last.hyperlink && !last.hyperlink.fromOriginal) {
+        last.hyperlink = segment.hyperlink;
+      }
+    } else {
+      buckets.push({ hyperlink: segment.hyperlink, groups: [segment.group] });
+    }
+  }
+  return buckets;
+}
+
+/**
+ * Emit a paragraph's run groups with w:hyperlink wrappers restored around the
+ * runs whose atoms came from inside a hyperlink. Track-change wrappers nest
+ * INSIDE the hyperlink (`<w:hyperlink><w:ins>…`): CT_Hyperlink admits
+ * EG_RunLevelElts (w:ins / w:del / range markers), while CT_RunTrackChange
+ * does not admit w:hyperlink.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.22
+ * @see https://github.com/UseJunior/safe-docx/issues/368
+ */
+function buildRunGroupsWithHyperlinks(
+  runGroups: RunGroup[],
+  author: string,
+  dateStr: string,
+  revState: RevisionIdState
+): string {
+  const buckets = mergeAdjacentHyperlinkSegments(
+    runGroups.flatMap(splitRunGroupByHyperlink)
+  );
+
+  const parts: string[] = [];
+  for (const bucket of buckets) {
+    const content = bucket.groups
+      .map((g) => buildRunGroupXml(g, author, dateStr, revState))
+      .join('');
+    if (!content) continue;
+    parts.push(
+      bucket.hyperlink && isEmittableHyperlink(bucket.hyperlink)
+        ? `${serializeHyperlinkOpenTag(bucket.hyperlink.element)}${content}</w:hyperlink>`
+        : content
+    );
+  }
+  return parts.join('');
+}
+
+/**
+ * Whole-paragraph insert/delete emission with hyperlink wrappers restored.
+ * Each bucket gets its own revision wrapper so the hyperlink can stay
+ * OUTSIDE the w:ins / w:del (see buildRunGroupsWithHyperlinks).
+ */
+function buildWholeParagraphRevisionContent(
+  group: ParagraphGroup,
+  wrap: (content: string) => string
+): string {
+  const buckets = mergeAdjacentHyperlinkSegments(
+    group.runGroups.flatMap(splitRunGroupByHyperlink)
+  );
+
+  const parts: string[] = [];
+  for (const bucket of buckets) {
+    const runs = bucket.groups.map((g) => buildRunContentAsPlainRun(g)).join('');
+    if (!runs) continue;
+    const wrapped = wrap(runs);
+    parts.push(
+      bucket.hyperlink && isEmittableHyperlink(bucket.hyperlink)
+        ? `${serializeHyperlinkOpenTag(bucket.hyperlink.element)}${wrapped}</w:hyperlink>`
+        : wrapped
+    );
+  }
+  return parts.join('');
 }
 
 /**

--- a/packages/docx-core/src/baselines/atomizer/trackChangesAcceptorAst.ts
+++ b/packages/docx-core/src/baselines/atomizer/trackChangesAcceptorAst.ts
@@ -17,6 +17,25 @@ import {
   NODE_TYPE,
 } from '../../primitives/index.js';
 
+/**
+ * Remove w:hyperlink elements left with no element children after change
+ * resolution. Word drops a hyperlink whose entire content was a resolved
+ * tracked change (all link text deleted + accepted, or all link text
+ * inserted + rejected); keeping the empty wrapper would ship a contentless
+ * `<w:hyperlink r:id=".."/>` husk. Hyperlinks that still hold any element
+ * (runs, bookmarks, range markers) are kept.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.22
+ * @see https://github.com/UseJunior/safe-docx/issues/368
+ */
+function removeEmptyHyperlinks(root: Element): void {
+  for (const hyperlink of findAllByTagName(root, 'w:hyperlink')) {
+    if (childElements(hyperlink).length === 0 && hyperlink.parentNode) {
+      hyperlink.parentNode.removeChild(hyperlink);
+    }
+  }
+}
+
 /** xmldom does not implement parentElement; use parentNode with an Element guard. */
 function parentElement(node: Node): Element | undefined {
   const p = node.parentNode;
@@ -403,6 +422,9 @@ export function acceptAllChanges(documentXml: string): string {
     }
   }
 
+  // Drop hyperlink wrappers emptied by the accepted deletions above.
+  removeEmptyHyperlinks(root);
+
   return serializeToXml(root);
 }
 
@@ -481,6 +503,9 @@ export function rejectAllChanges(documentXml: string): string {
 
   // Strip paragraph-level markers now that changes are rejected.
   removeParaMarkers(root);
+
+  // Drop hyperlink wrappers emptied by the rejected insertions above.
+  removeEmptyHyperlinks(root);
 
   return serializeToXml(root);
 }

--- a/spec-compliance/CONFORMANCE.md
+++ b/spec-compliance/CONFORMANCE.md
@@ -16,6 +16,7 @@ Allure labels via `testAllure.conformance({…})`; source code carries
 | `ECMA-PART4-17-16-5` | w:delInstrText and w:fldChar placement in tracked deletions | 5 | 4 | 17.16.5 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:delInstrText` | — |
 | `ECMA-PART1-17-13-5` | Paragraph-level OOXML markers | 5 | 1 | 17.13.5 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:pPrChange` | — |
 | `ECMA-PART1-17-11-14` | w:footnoteReference identifier vs display number | 5 | 1 | 17.11.14 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:footnoteReference` | — |
+| `ECMA-PART1-17-16-22` | w:hyperlink container preservation under tracked changes | 5 | 1 | 17.16.22 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:hyperlink` | — |
 
 ### ECMA-PART4-17-16-5 — w:delInstrText and w:fldChar placement in tracked deletions
 
@@ -66,6 +67,27 @@ as conventional reserved values via `RESERVED_FOOTNOTE_IDS` in
 `packages/docx-core/src/footnotes.ts`. The runtime ordering logic
 (`findReferencesInOrder`, also in `footnotes.ts`) implements the
 reference-vs-display distinction this section establishes.
+
+### ECMA-PART1-17-16-22 — w:hyperlink container preservation under tracked changes
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.16.22
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:hyperlink`
+
+`w:hyperlink` (CT_Hyperlink) is a run container inside `<w:p>` whose
+`r:id` attribute carries the relationship reference to the link target.
+Its content model (EG_PContent) admits run-level revision wrappers, so
+tracked edits to link text nest as `<w:hyperlink><w:ins>…` /
+`<w:hyperlink><w:del>…`; the reverse nesting is invalid because
+CT_RunTrackChange (the `w:ins` / `w:del` content model) does not admit
+`w:hyperlink`. safe-docx's comparison engine preserves the wrapper and
+its attributes when reconstructing paragraphs that contain hyperlinks,
+and never merges text atoms across a hyperlink boundary. The enforcement
+lives in `packages/docx-core/src/atomizer.ts`
+(`nearestHyperlinkAncestor`) and
+`packages/docx-core/src/baselines/atomizer/documentReconstructor.ts`
+(hyperlink wrapper re-emission).
 
 ## Non-Goals
 

--- a/spec-compliance/registry/ecma-376.md
+++ b/spec-compliance/registry/ecma-376.md
@@ -74,6 +74,31 @@ as conventional reserved values via `RESERVED_FOOTNOTE_IDS` in
 (`findReferencesInOrder`, also in `footnotes.ts`) implements the
 reference-vs-display distinction this section establishes.
 
+## [ECMA-PART1-17-16-22] w:hyperlink container preservation under tracked changes
+
+```yaml
+edition: 5
+part: 1
+section: "17.16.22"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:hyperlink
+verifiedBy:
+```
+
+`w:hyperlink` (CT_Hyperlink) is a run container inside `<w:p>` whose
+`r:id` attribute carries the relationship reference to the link target.
+Its content model (EG_PContent) admits run-level revision wrappers, so
+tracked edits to link text nest as `<w:hyperlink><w:ins>…` /
+`<w:hyperlink><w:del>…`; the reverse nesting is invalid because
+CT_RunTrackChange (the `w:ins` / `w:del` content model) does not admit
+`w:hyperlink`. safe-docx's comparison engine preserves the wrapper and
+its attributes when reconstructing paragraphs that contain hyperlinks,
+and never merges text atoms across a hyperlink boundary. The enforcement
+lives in `packages/docx-core/src/atomizer.ts`
+(`nearestHyperlinkAncestor`) and
+`packages/docx-core/src/baselines/atomizer/documentReconstructor.ts`
+(hyperlink wrapper re-emission).
+
 ## Non-Goals
 
 Sections explicitly **out of scope** for safe-docx. Each entry below carries the


### PR DESCRIPTION
Fixes #368.

## What

Rebuild reconstruction dropped `<w:hyperlink>` wrappers entirely (link + `r:id` lost) and the cross-run punctuation merge absorbed the sentence period after a URL into the underlined link run. Three changes, one per layer:

- **Atomizer** — cross-run text/punctuation merges stop at `w:hyperlink` boundaries (`nearestHyperlinkAncestor`). This is the underline-bleed root cause: the merged atom kept only the link run's ancestry, so the "." inherited underline + hyperlink membership.
- **Reconstructor** — run groups are split into hyperlink-pure segments; adjacent segments with the same attribute fingerprint share one re-emitted `<w:hyperlink>` wrapper. Revision wrappers nest **inside** the hyperlink: `CT_Hyperlink → EG_PContent → EG_ContentRunContent → EG_RunLevelElts` admits `w:ins`/`w:del`, while `CT_RunTrackChange` does not admit `w:hyperlink` (verified against the vendored `wml.xsd`). Applies to the whole-paragraph insert/delete branches too. Wrapper attribution prefers the **original** tree's element (deleted atoms directly, equal atoms via `comparisonUnitAtomBefore`) because rebuild output clones the original archive — only original-tree `r:id` values resolve against the shipped rels.
- **Acceptor** — accept/reject prune `w:hyperlink` elements emptied by change resolution, matching Word (no contentless `<w:hyperlink r:id=".."/>` husks).

Hyperlink-free paragraphs take the unchanged legacy emission path (byte-identical output).

## Known boundaries (deliberate, pinned by tests)

- A **purely-inserted hyperlink with `r:id`** stays unwrapped (pre-fix behavior): its relationship exists only in the revised package, and a dangling `r:id` reads as a corrupt package in Word. Anchor-only inserted hyperlinks are wrapped. Relationship merging is tracked in #376.
- A **retargeted link** (`r:id` change with equal text) emits the equal text unwrapped rather than pinned to the stale original target. Caught in peer review (Codex executed probe — the first iteration attributed equal text to the old `r:id`, silently mislinking accepted content). The faithful delete-old-link + insert-new-link representation is #376.

## Evidence

Real-fixture repro from the issue (Common Paper Mutual NDA, `Confidential Information`→`Proprietary Information` + `mutual`→`reciprocal`):

| view | `<w:hyperlink>` | `rId7` refs |
|---|---|---|
| original | 1 | 1 |
| inplace candidate | 1 | 1 |
| rebuild candidate (before) | **0** | **0** |
| rebuild candidate (after) | **1** | **1** |

`compareProjectedFormattingFidelity(inplace, rebuild)` on that fixture: **1.0000** with zero divergences (issue measured 0.7498; the `[run] underline added @p2 "."` finding is gone, and the section noise was #371).

## Verification

- 6 new regression tests in `documentReconstructor-hyperlinks.test.ts` (issue fixture shape, punctuation no-bleed via fidelity check, untouched-link preservation, deleted-paragraph nesting, inserted anchor/r:id boundary, retargeted-link no-stale-target).
- Full pre-submit gate green: build, lint, all workspace tests, spec-coverage, conformance citations/doc, allure label/filename/quality checks.
- Peer-reviewed (Codex + agy, both dynamic with executed verification); the one SHOULD-FIX both raised (stale-target attribution) is fixed and pinned here, with the deeper representation tracked in #376.
- New conformance registry entry `ECMA-PART1-17-16-22`; `CONFORMANCE.md`/README regenerated.