### PR TITLE
fix(odf-core): group adjacent word replacements in ODF inline compare

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ The local Safe Docx runtime also intentionally rejects Word template files (`.do
 
 Teams on LibreOffice have the same problem as teams on Word: edits without a record. The core session tools — `read_file`, `grep`, `replace_text`, `insert_paragraph`, `add_comment`, `get_comments`, `save` — work directly on `.odt` files, and `compare_documents` writes a native ODF tracked-changes redline: compare two files, or a live editing session against the original it was opened from.
 
-ODF changes are tracked at the whole-paragraph level (a modified paragraph appears as one deletion plus one insertion). The redline round-trips in LibreOffice: accepting all changes reproduces the edited document, rejecting all restores the original. See the [tool reference](packages/docx-mcp/docs/tool-reference.generated.md) for per-tool format support.
+ODF changes are tracked inline at run level: edits within a paragraph appear as word-level insertions and deletions rather than whole-paragraph replacements. The redline round-trips in LibreOffice: accepting all changes reproduces the edited document, rejecting all restores the original. See the [tool reference](packages/docx-mcp/docs/tool-reference.generated.md) for per-tool format support.
 
 ## Document Families
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-docx",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "AI-powered DOCX and ODT editing with tracked changes, redlining, and formatting preservation",
   "contextFileName": "GEMINI.md",
   "entrypoint": "GEMINI.md",

--- a/openspec/changes/add-odf-intra-paragraph-compare/specs/odf-core/spec.md
+++ b/openspec/changes/add-odf-intra-paragraph-compare/specs/odf-core/spec.md
@@ -101,3 +101,7 @@ SHALL NOT appear in `getParagraphs()` or any visible-text walk.
 #### Scenario: [OCMPI-13] LibreOffice accept/reject round-trips the inline redline
 - **WHEN** LibreOffice (when available) runs accept-all and reject-all over a generated redline containing a modify pair plus whole-paragraph changes
 - **THEN** accept-all reproduces the revised document's visible paragraph texts and reject-all reproduces the original's
+
+#### Scenario: [OCMPI-14] Adjacent word replacements group into one deletion and one insertion
+- **WHEN** the intra-paragraph diff processes adjacent replaced words separated only by whitespace that the token LCS matches as equal (e.g. "Zephyr BioSystems" → "Acme Manufacturing")
+- **THEN** the span script contains a single delete+insert pair covering the whole replacement (bridge whitespace absorbed into both sides) rather than interleaved per-word pairs, while delete-only and insert-only runs keep their bridging whitespace as equal

--- a/openspec/changes/add-odf-intra-paragraph-compare/tasks.md
+++ b/openspec/changes/add-odf-intra-paragraph-compare/tasks.md
@@ -5,6 +5,7 @@
 
 ## odf-core
 - [x] `compare/inline_diff.ts`: token-level LCS (`diffInline`) with prefix/suffix trim, char-offset `SpanOp`s, delete-before-insert at ties, coalescing; `inline_diff.test.ts` incl. reconstruction property invariant
+- [x] `compare/inline_diff.ts`: group adjacent replacements bridged by whitespace-only equal spans into one delete+insert pair (issue #378, OCMPI-14); diff-level + emit-level tests
 - [x] `compare/diff.ts`: `modify` EditOp variant + `pairModifications` (order-constrained DP: max pair count then total Jaccard; threshold 0.25 default; deterministic tie-breaks; deletes-then-inserts segment order); extend `diff.test.ts` (threshold pass/fail, 2-deletes+1-insert, empties)
 - [x] `shared/odf/text_segments.ts`: virtual `Segment` gains `node: Element` + `virtual: 'space' | 'tab' | 'line-break'` (additive; `rg buildSegments` confirms no caller breaks)
 - [x] `compare/inline_map.ts`: `resolveOffset` (manual `#text` split, `text:s` rebalance, block-edge points, re-segment per call) + `extractVisibleRange` (clone inline content preserving spans/links, edge trims, whole tab/line-break); `inline_map.test.ts` with serialized-XML assertions

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "safe-docx-suite",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "safe-docx-suite",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -9383,7 +9383,7 @@
     },
     "packages/allure-test-factory": {
       "name": "@usejunior/allure-test-factory",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -9404,7 +9404,7 @@
     },
     "packages/docx-core": {
       "name": "@usejunior/docx-core",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "^0.9.10",
@@ -9432,12 +9432,12 @@
     },
     "packages/docx-mcp": {
       "name": "@usejunior/docx-mcp",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@usejunior/docx-core": "^0.9.1",
-        "@usejunior/odf-core": "^0.9.1",
+        "@usejunior/docx-core": "^0.10.0",
+        "@usejunior/odf-core": "^0.10.0",
         "@xmldom/xmldom": "^0.9.10",
         "zod": "^4.3.6"
       },
@@ -9458,7 +9458,7 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@usejunior/google-docs-core": "^0.9.1"
+        "@usejunior/google-docs-core": "^0.10.0"
       },
       "peerDependenciesMeta": {
         "@usejunior/google-docs-core": {
@@ -9468,7 +9468,7 @@
     },
     "packages/google-docs-core": {
       "name": "@usejunior/google-docs-core",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "google-auth-library": "^9.0.0"
@@ -9484,10 +9484,10 @@
     },
     "packages/odf-core": {
       "name": "@usejunior/odf-core",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
-        "@usejunior/docx-core": "^0.9.1",
+        "@usejunior/docx-core": "^0.10.0",
         "@xmldom/xmldom": "^0.9.10",
         "jszip": "^3.10.1"
       },
@@ -9502,10 +9502,10 @@
     },
     "packages/safe-docx": {
       "name": "@usejunior/safe-docx",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
-        "@usejunior/docx-mcp": "^0.9.1"
+        "@usejunior/docx-mcp": "^0.10.0"
       },
       "bin": {
         "safe-docx": "bin/safe-docx.js",
@@ -9517,10 +9517,10 @@
     },
     "packages/safe-docx-mcpb": {
       "name": "@usejunior/safedocx-mcpb",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
-        "@usejunior/safe-docx": "^0.9.1"
+        "@usejunior/safe-docx": "^0.10.0"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-docx-suite",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "private": true,
   "description": "Monorepo for Safe DOCX packages",
   "repository": {

--- a/packages/allure-test-factory/package.json
+++ b/packages/allure-test-factory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/allure-test-factory",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Shared Allure test helpers for vitest — BDD context, OpenSpec auto-inference, Prism.js highlighting",
   "type": "module",
   "exports": {

--- a/packages/docx-core/package.json
+++ b/packages/docx-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/docx-core",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "OOXML (.docx) core library: primitives, comparison, and track changes",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/docx-mcp/README.md
+++ b/packages/docx-mcp/README.md
@@ -6,7 +6,7 @@
 
 **Install via the canonical package:** `npx -y @usejunior/safe-docx` — [see setup guide](../../README.md)
 
-Local MCP server for surgical editing of existing Microsoft Word `.docx` files with coding agents. The same tool surface also services OpenDocument `.odt` files — including `compare_documents` redlines (two files, or a live session against its original) written as native ODF tracked changes at paragraph granularity.
+Local MCP server for surgical editing of existing Microsoft Word `.docx` files with coding agents. The same tool surface also services OpenDocument `.odt` files — including `compare_documents` redlines (two files, or a live session against its original) written as native ODF tracked changes with inline (run-level) granularity.
 
 Safe Docx is built for brownfield paperwork workflows: apply accepted AI edits to real Word documents while preserving formatting and review semantics.
 

--- a/packages/docx-mcp/package.json
+++ b/packages/docx-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/docx-mcp",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "MCP server for reading, editing, and comparing Word (.docx) and OpenDocument (.odt) files with tracked changes. For Claude, Gemini CLI, Cursor, and any MCP client. MIT licensed.",
   "type": "module",
   "main": "dist/index.js",
@@ -27,8 +27,8 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@usejunior/docx-core": "^0.9.1",
-    "@usejunior/odf-core": "^0.9.1",
+    "@usejunior/docx-core": "^0.10.0",
+    "@usejunior/odf-core": "^0.10.0",
     "@xmldom/xmldom": "^0.9.10",
     "zod": "^4.3.6"
   },
@@ -55,7 +55,7 @@
     "dist"
   ],
   "peerDependencies": {
-    "@usejunior/google-docs-core": "^0.9.1"
+    "@usejunior/google-docs-core": "^0.10.0"
   },
   "peerDependenciesMeta": {
     "@usejunior/google-docs-core": {

--- a/packages/google-docs-core/package.json
+++ b/packages/google-docs-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/google-docs-core",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Google Docs core library: read, write, and anchor management via Google Docs API",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/odf-core/package.json
+++ b/packages/odf-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/odf-core",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "OpenDocument Format (.odt) core library: archive packaging, document view, surgical text replacement, and tracked-changes comparison",
   "type": "module",
   "main": "dist/index.js",
@@ -14,7 +14,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@usejunior/docx-core": "^0.9.1",
+    "@usejunior/docx-core": "^0.10.0",
     "@xmldom/xmldom": "^0.9.10",
     "jszip": "^3.10.1"
   },

--- a/packages/odf-core/src/compare/emit_inline.test.ts
+++ b/packages/odf-core/src/compare/emit_inline.test.ts
@@ -245,6 +245,27 @@ describe('compareOdf — intra-paragraph modify pairs', () => {
     expect(kinds).toEqual(['deletion', 'deletion', 'insertion', 'insertion']);
   });
 
+  it('[OCMPI-14] adjacent word replacements emit one grouped deletion + insertion, not per-word pairs', () => {
+    const original = contentXml(['made by and among Zephyr BioSystems, Inc., a Delaware corporation']);
+    const revised = contentXml(['made by and among Acme Manufacturing, Inc., a Delaware corporation']);
+    const { contentXml: out, stats } = compareOdf(original, revised, OPTS);
+    const ot = officeText(out);
+
+    // One pair of changed-regions covers the whole replacement (issue #378).
+    expect(stats).toEqual({ insertions: 1, deletions: 1, modifications: 1 });
+    const regions = trackedRegions(ot);
+    expect(regions.map((r) => regionInfo(r).kind).sort()).toEqual(['deletion', 'insertion']);
+    const stored = regions.map((r) => regionInfo(r).stored).find((s) => s.length > 0)!;
+    expect(stored.map((b) => buildSegments(b).visible).join('')).toBe('Zephyr BioSystems,');
+
+    // The revised paragraph brackets the full inserted phrase; accept/reject still round-trip.
+    const block = bodyBlocks(ot)[0]!;
+    expect(buildSegments(block).visible).toBe('made by and among Acme Manufacturing, Inc., a Delaware corporation');
+    const markers = flatten(block).filter((e) => e.kind === 'marker');
+    expect(markers.map((m) => (m as { type: string }).type)).toEqual(['change-start', 'change-end', 'change']);
+    expect(rejectText(block, ot)).toBe('made by and among Zephyr BioSystems, Inc., a Delaware corporation');
+  });
+
   it('[OCMPI-10] whitespace-run edits map onto text:s (O6 shape)', () => {
     const original = contentXmlRaw(['<text:p>Word<text:s text:c="5"/>tail</text:p>']);
     const revised = contentXmlRaw(['<text:p>Word<text:s text:c="3"/>tail</text:p>']);

--- a/packages/odf-core/src/compare/inline_diff.test.ts
+++ b/packages/odf-core/src/compare/inline_diff.test.ts
@@ -122,6 +122,51 @@ describe('diffInline', () => {
     expect(revised.slice(ins.revStart, ins.revEnd)).toBe('garment');
   });
 
+  it('[OCMPI-14] adjacent replaced words group into one delete+insert pair across the bridging space', () => {
+    const original = 'made by and among Zephyr BioSystems, Inc., a Delaware corporation';
+    const revised = 'made by and among Acme Manufacturing, Inc., a Delaware corporation';
+    const ops = diffInline(original, revised);
+    assertInvariants(ops, original, revised);
+    // One grouped pair, not interleaved per-word pairs around the kept space.
+    expect(ops.map((o) => o.kind)).toEqual(['equal', 'delete', 'insert', 'equal']);
+    const del = ops[1]!;
+    const ins = ops[2]!;
+    expect(original.slice(del.origStart, del.origEnd)).toBe('Zephyr BioSystems,');
+    expect(revised.slice(ins.revStart, ins.revEnd)).toBe('Acme Manufacturing,');
+    expect(del.revStart).toBe(ins.revStart);
+  });
+
+  it('[OCMPI-14] a chain of three replaced words collapses into a single pair', () => {
+    const original = 'start aa bb cc end';
+    const revised = 'start xx yy zz end';
+    const ops = diffInline(original, revised);
+    assertInvariants(ops, original, revised);
+    expect(ops.map((o) => o.kind)).toEqual(['equal', 'delete', 'insert', 'equal']);
+    expect(original.slice(ops[1]!.origStart, ops[1]!.origEnd)).toBe('aa bb cc');
+    expect(revised.slice(ops[2]!.revStart, ops[2]!.revEnd)).toBe('xx yy zz');
+  });
+
+  it('[OCMPI-14] a kept word between two replacements is never absorbed into a window', () => {
+    const original = 'alpha keeps bravo';
+    const revised = 'delta keeps echo';
+    const ops = diffInline(original, revised);
+    assertInvariants(ops, original, revised);
+    // The non-whitespace equal " keeps " separates two independent replacement pairs.
+    expect(ops.map((o) => o.kind)).toEqual(['delete', 'insert', 'equal', 'delete', 'insert']);
+    expect(original.slice(ops[0]!.origStart, ops[0]!.origEnd)).toBe('alpha');
+    expect(original.slice(ops[3]!.origStart, ops[3]!.origEnd)).toBe('bravo');
+  });
+
+  it('[OCMPI-14] delete-only and insert-only windows keep their bridging space as equal', () => {
+    const delOps = diffInline('xx yy', ' ');
+    assertInvariants(delOps, 'xx yy', ' ');
+    expect(delOps.map((o) => o.kind)).toEqual(['delete', 'equal', 'delete']);
+
+    const insOps = diffInline(' ', 'xx yy');
+    assertInvariants(insOps, ' ', 'xx yy');
+    expect(insOps.map((o) => o.kind)).toEqual(['insert', 'equal', 'insert']);
+  });
+
   it('[OCMPI-01] property sweep: random word edits always satisfy the reconstruction invariants', () => {
     const words = ['alpha', 'bravo', 'charlie', 'delta', 'echo', 'fox', 'golf'];
     // Deterministic pseudo-random walk (no Date/Math.random in tests for reproducibility).

--- a/packages/odf-core/src/compare/inline_diff.ts
+++ b/packages/odf-core/src/compare/inline_diff.ts
@@ -11,6 +11,11 @@
  * Order convention mirrors `diffParagraphs`: at a mismatch the deletion branch wins, so a
  * replaced word surfaces as a `delete` immediately followed by an `insert` sharing `revStart`.
  * The emitter relies on that ordering when both anchor at the same offset.
+ *
+ * A grouping post-pass keeps multi-word replacements readable (issue #378): the LCS matches the
+ * space between two replaced words as `equal`, which would otherwise split one logical
+ * replacement into per-word delete/insert pairs. Change windows bridged by whitespace-only
+ * equal spans collapse into a single delete+insert pair whenever both kinds are present.
  */
 
 /**
@@ -114,5 +119,70 @@ export function diffInline(original: string, revised: string): SpanOp[] {
     push('equal', origTokens[origTokens.length - k]!.length, revTokens[revTokens.length - k]!.length);
   }
 
-  return ops;
+  return groupBridgedReplacements(ops, original);
+}
+
+/**
+ * Collapse change windows bridged by whitespace-only `equal` spans into one delete+insert pair.
+ *
+ * Replacing two adjacent words ("Zephyr BioSystems" → "Acme Manufacturing") leaves the space
+ * between them `equal`, splitting the replacement into interleaved per-word pairs — a redline
+ * that reads `Acme ~~Zephyr~~ Manufacturing ~~BioSystems~~`. A window of change spans may absorb
+ * an equal span only when it is whitespace-only AND has change spans on BOTH sides (kept words
+ * never join a window). A window containing at least one delete and one insert is rewritten as a
+ * single pair: the delete covers every original char in the window (bridge whitespace included),
+ * the insert every revised char, preserving the delete-before-insert / shared-`revStart`
+ * convention and the lockstep-offset invariant. Delete-only and insert-only windows are left
+ * alone — striking a kept space just to reinsert it would be noise, not grouping.
+ */
+function groupBridgedReplacements(ops: SpanOp[], original: string): SpanOp[] {
+  const out: SpanOp[] = [];
+  let i = 0;
+  while (i < ops.length) {
+    if (ops[i]!.kind === 'equal') {
+      out.push(ops[i]!);
+      i++;
+      continue;
+    }
+    let end = i + 1;
+    while (end < ops.length) {
+      const op = ops[end]!;
+      if (op.kind !== 'equal') {
+        end++;
+        continue;
+      }
+      const next = ops[end + 1];
+      const bridge = original.slice(op.origStart, op.origEnd);
+      if (/^\s+$/.test(bridge) && next && next.kind !== 'equal') {
+        end += 2;
+        continue;
+      }
+      break;
+    }
+    const window = ops.slice(i, end);
+    const hasDelete = window.some((o) => o.kind === 'delete');
+    const hasInsert = window.some((o) => o.kind === 'insert');
+    if (hasDelete && hasInsert) {
+      const first = window[0]!;
+      const last = window[window.length - 1]!;
+      out.push({
+        kind: 'delete',
+        origStart: first.origStart,
+        origEnd: last.origEnd,
+        revStart: first.revStart,
+        revEnd: first.revStart,
+      });
+      out.push({
+        kind: 'insert',
+        origStart: last.origEnd,
+        origEnd: last.origEnd,
+        revStart: first.revStart,
+        revEnd: last.revEnd,
+      });
+    } else {
+      out.push(...window);
+    }
+    i = end;
+  }
+  return out;
 }

--- a/packages/safe-docx-mcpb/manifest.json
+++ b/packages/safe-docx-mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "safe-docx",
   "display_name": "Safe Docx",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "AI-native Word (.docx) and OpenDocument (.odt) editing with stable paragraph anchors and deterministic document operations.",
   "long_description": "Safe Docx lets Claude work directly with .docx files on your local filesystem. It provides stable paragraph IDs (_bk_*) for precise editing while preserving formatting and structure.\n\nCore capabilities include reading/searching content, formatting-preserving edits and inserts, deterministic layout controls, tracked-changes output, comments, footnote tools, document comparison, and revision extraction.",
   "author": {

--- a/packages/safe-docx-mcpb/package.json
+++ b/packages/safe-docx-mcpb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/safedocx-mcpb",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "private": true,
   "description": "Claude Desktop MCP Bundle (.mcpb) wrapper for @usejunior/safe-docx",
   "type": "module",
@@ -14,7 +14,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@usejunior/safe-docx": "^0.9.1"
+    "@usejunior/safe-docx": "^0.10.0"
   },
   "devDependencies": {
     "@vitest/runner": "^4.1.8",

--- a/packages/safe-docx/.smithery/shttp/manifest.json
+++ b/packages/safe-docx/.smithery/shttp/manifest.json
@@ -6,7 +6,7 @@
     "serverCard": {
       "serverInfo": {
         "name": "safe-docx",
-        "version": "0.9.1"
+        "version": "0.10.0"
       },
       "tools": [
         {

--- a/packages/safe-docx/package.json
+++ b/packages/safe-docx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/safe-docx",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Edit Word (.docx) and OpenDocument (.odt) files with tracked changes, redlines, and formatting preservation. Built for AI coding agents. MIT licensed, 100% local processing.",
   "mcpName": "io.github.UseJunior/safe-docx",
   "type": "module",
@@ -25,7 +25,7 @@
     "safedocx": "./bin/safe-docx.js"
   },
   "dependencies": {
-    "@usejunior/docx-mcp": "^0.9.1"
+    "@usejunior/docx-mcp": "^0.10.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/safe-docx/server.json
+++ b/packages/safe-docx/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.UseJunior/safe-docx",
   "title": "Safe Docx",
   "description": "AI-native surgical editing of existing Word .docx and OpenDocument .odt files with formatting preservation",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "websiteUrl": "https://usejunior.com/developer-tools/safe-docx",
   "icons": [
     {
@@ -18,7 +18,7 @@
     {
       "registryType": "npm",
       "identifier": "@usejunior/safe-docx",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "transport": {
         "type": "stdio"
       },

--- a/scripts/bump_version.mjs
+++ b/scripts/bump_version.mjs
@@ -23,6 +23,7 @@ const PACKAGE_JSONS = [
   'packages/allure-test-factory/package.json',
   'packages/docx-core/package.json',
   'packages/docx-mcp/package.json',
+  'packages/odf-core/package.json',
   'packages/google-docs-core/package.json',
   'packages/safe-docx-mcpb/package.json',
   'packages/safe-docx/package.json',
@@ -35,6 +36,7 @@ const SMITHERY_MANIFEST_JSON = 'packages/safe-docx/.smithery/shttp/manifest.json
 // Cross-workspace dependencies (package name → dep specifier pattern)
 const WORKSPACE_DEPS = [
   '@usejunior/docx-core',
+  '@usejunior/odf-core',
   '@usejunior/docx-mcp',
   '@usejunior/google-docs-core',
   '@usejunior/safe-docx',

--- a/site/package.json
+++ b/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/safe-docx-site",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "private": true,
   "type": "module",
   "description": "Safe DOCX marketing and trust site (Eleventy)",


### PR DESCRIPTION
Fixes #378

## Problem

Comparing two `.odt` documents where adjacent words are replaced — e.g. the NVCA preamble `… by and among Zephyr BioSystems, Inc., …` → `… by and among Acme Manufacturing, Inc., …` — rendered as an interleaved per-word redline:

> Acme~~Zephyr~~ Manufacturing,~~BioSystems,~~

instead of the grouped shape every mainstream redliner (and our own DOCX pipeline) produces:

> Acme Manufacturing,~~Zephyr BioSystems,~~

`diffInline`'s token LCS matches the space between the two replaced words as `equal`, splitting one logical replacement into two delete/insert pairs. The DOCX pipeline bridges exactly this with `reorderChangeBlocks` / `coalesceDelInsPairChains`; the ODF inline diff had no equivalent. (Verified the DOCX path does **not** replicate on main — both `rebuild` and `inplace` group correctly over the same paragraph.)

## Fix

Post-pass in `diffInline` (`groupBridgedReplacements`): a maximal window of change spans absorbs an equal span only when it is whitespace-only and has change spans on both sides; a window containing both a delete and an insert is rewritten as one delete+insert pair (delete covers all original chars in the window, bridge whitespace included; insert covers all revised chars). Delete-only / insert-only windows keep their bridges as `equal`, so a kept space is never struck and reinserted as noise. The delete-before-insert / shared-`revStart` convention and the lockstep-offset reconstruction invariant are preserved.

## Spec

Scenario `[OCMPI-14]` added to the active `add-odf-intra-paragraph-compare` change, with diff-level tests (grouping, three-word chain, kept-word non-absorption, delete-only/insert-only bridges) and an emit-level test (one deletion region storing `Zephyr BioSystems,`, one insertion bracket, accept/reject round-trip).

## Verification

- `compareOdf` on the Series B preamble now emits `stats: { insertions: 1, deletions: 1, modifications: 1 }` with a single grouped pair (was 2/2/1 interleaved)
- Full local gate: build, lint:workspaces, test:run (0 failures), check:spec-coverage, conformance checks, `openspec validate --strict`