### PR TITLE
fix(docx-core): surface text-empty paragraphs that anchor a footnote reference

### DIFF
--- a/packages/docx-core/src/primitives/document_view.ts
+++ b/packages/docx-core/src/primitives/document_view.ts
@@ -407,8 +407,15 @@ export function buildNodesForDocumentView(params: {
 
     // Visible clean text (field codes stripped).
     const fullText = getParagraphText(p).replace(/\r/g, '').replace(/\n/g, '').trim();
-    // Preserve empty table cell paragraphs for structural completeness.
-    if (!fullText && !tableContext) continue;
+    // Preserve empty table cell paragraphs for structural completeness, and
+    // text-empty paragraphs that anchor a visible footnote reference — dropping
+    // those loses the footnote from every rendering of the document view.
+    // @see #185
+    if (
+      !fullText &&
+      !tableContext &&
+      getFootnoteMarkersForParagraph(p, footnoteDisplayMap).length === 0
+    ) continue;
 
     // Numbering (auto-numbered) info from numPr.
     let numId: string | null = null;

--- a/packages/docx-mcp/src/tools/nvca_spa_regression.test.ts
+++ b/packages/docx-mcp/src/tools/nvca_spa_regression.test.ts
@@ -17,6 +17,7 @@ import { getParagraphRuns } from '@usejunior/docx-core';
 
 import { SessionManager } from '../session/manager.js';
 import { openDocument } from './open_document.js';
+import { getFootnotes } from './get_footnotes.js';
 import { readFile } from './read_file.js';
 import { replaceText } from './replace_text.js';
 import { insertParagraph } from './insert_paragraph.js';
@@ -575,6 +576,52 @@ describe('NVCA SPA regression: heading detection (#179)', () => {
 
     await and('every paragraph in the window has a null header style', async () => {
       expect(parsed.every((node) => node.list_metadata.header_style === null)).toBe(true);
+    });
+  });
+});
+
+describe('NVCA SPA regression: footnote anchor surfacing (#185)', () => {
+  test('every anchored NVCA SPA footnote is reachable through the document view', async ({ given, when, then, and }: AllureBddContext) => {
+    let mgr: ReturnType<typeof createMgr>;
+    let filePath: string;
+    let eligible: Array<{ id: number; display_number: number; anchored_paragraph_id: string }>;
+    let nodes: Array<{ id: string; text: string }>;
+
+    await given('the NVCA SPA source document is open and its 109 footnotes are listed', async () => {
+      ({ mgr, filePath } = await openSPA());
+      const notes = await getFootnotes(mgr, { file_path: filePath });
+      assertSuccess(notes, 'get_footnotes');
+      const all = notes.footnotes as Array<{ id: number; display_number: number; text: string; anchored_paragraph_id: string | null }>;
+      expect(all).toHaveLength(109);
+      eligible = all.filter(
+        (n): n is typeof n & { anchored_paragraph_id: string } =>
+          n.display_number > 0 && n.text.trim().length > 0 && n.anchored_paragraph_id !== null,
+      );
+      expect(eligible).toHaveLength(108);
+    });
+
+    await when('read_file renders the full document view as JSON', async () => {
+      const res = await readFile(mgr, { file_path: filePath, format: 'json', offset: 1, limit: 100000 });
+      assertSuccess(res, 'read_file full json walk');
+      nodes = JSON.parse(res.content as string);
+    });
+
+    await then('every eligible footnote anchor paragraph is present in the view', async () => {
+      const viewIds = new Set(nodes.map((n) => n.id));
+      const unsurfaced = eligible.filter((n) => !viewIds.has(n.anchored_paragraph_id));
+      expect(unsurfaced, `footnotes whose anchor paragraph is missing from the view: ${JSON.stringify(unsurfaced.map((n) => ({ id: n.id, display: n.display_number })))}`).toHaveLength(0);
+    });
+
+    await and('the footnote-only paragraph anchoring note 47 renders its [^46] marker', async () => {
+      // Footnote id=47 (display 46) anchors to a paragraph whose only content
+      // is the footnote-reference run; before the #185 fix the view dropped it.
+      const probe = await readFile(mgr, { file_path: filePath, format: 'json', node_ids: ['_bk_6d177a97f7e6'] });
+      assertSuccess(probe, 'read_file node_ids probe');
+      const probed = JSON.parse(probe.content as string) as Array<{ id: string; text: string }>;
+      expect(probed).toHaveLength(1);
+      // Pure-marker node; the optional second [^46] tolerates the pre-existing
+      // marker doubling (#382) without letting zero or triple markers pass.
+      expect(probed[0]!.text).toMatch(/^\[\^46\](?:\[\^46\])?$/);
     });
   });
 });

--- a/packages/docx-mcp/src/tools/read_file_footnotes.test.ts
+++ b/packages/docx-mcp/src/tools/read_file_footnotes.test.ts
@@ -2,6 +2,7 @@ import { describe, expect } from 'vitest';
 import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
 import { assertSuccess, openSession, registerCleanup } from '../testing/session-test-utils.js';
 import { addFootnote } from './add_footnote.js';
+import { getFootnotes } from './get_footnotes.js';
 import { DEFAULT_CONTENT_TOKEN_BUDGET, estimateTokens } from './pagination.js';
 import { readFile } from './read_file.js';
 
@@ -60,6 +61,72 @@ describe('read_file footnotes', () => {
       const parsed = JSON.parse(String(rendered.read.content));
       expect(parsed).toHaveLength(1);
       expect(String(parsed[0].text)).toContain('[^1]');
+    });
+  });
+
+  test('a paragraph whose only content is a footnote reference is surfaced in the document view (#185)', async ({ given, when, then, and }: AllureBddContext) => {
+    const W_DOC_OPEN = '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">';
+    const documentXml =
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+      W_DOC_OPEN +
+      `<w:body>` +
+      `<w:p><w:r><w:t>Body before the note.</w:t></w:r></w:p>` +
+      `<w:p><w:r><w:rPr><w:rStyle w:val="FootnoteReference"/></w:rPr><w:footnoteReference w:id="1"/></w:r></w:p>` +
+      `<w:p><w:r><w:t>Body after the note.</w:t></w:r></w:p>` +
+      `</w:body></w:document>`;
+    const footnotesXml =
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+      `<w:footnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
+      `<w:footnote w:type="separator" w:id="-1"><w:p><w:r><w:separator/></w:r></w:p></w:footnote>` +
+      `<w:footnote w:type="continuationSeparator" w:id="0"><w:p><w:r><w:continuationSeparator/></w:r></w:p></w:footnote>` +
+      `<w:footnote w:id="1"><w:p><w:r><w:t>Drafting guidance lives here.</w:t></w:r></w:p></w:footnote>` +
+      `</w:footnotes>`;
+
+    let opened: Awaited<ReturnType<typeof openSession>>;
+    let anchorId: string;
+    let nodes: Array<{ id: string; text: string; clean_text: string }>;
+
+    await given('a document whose middle paragraph contains only a footnote reference run', async () => {
+      opened = await openSession([], {
+        xml: documentXml,
+        extraFiles: { 'word/footnotes.xml': footnotesXml },
+      });
+      const notes = await getFootnotes(opened.mgr, { file_path: opened.inputPath });
+      assertSuccess(notes, 'get_footnotes');
+      const all = notes.footnotes as Array<{ id: number; anchored_paragraph_id: string | null }>;
+      expect(all).toHaveLength(1);
+      expect(all[0]!.anchored_paragraph_id).not.toBeNull();
+      anchorId = all[0]!.anchored_paragraph_id!;
+    });
+
+    await when('read_file renders the full document as JSON', async () => {
+      const read = await readFile(opened.mgr, { file_path: opened.inputPath, format: 'json' });
+      assertSuccess(read, 'read_file');
+      nodes = JSON.parse(String(read.content));
+    });
+
+    await then('the footnote-only paragraph appears in the view with its marker', async () => {
+      expect(nodes).toHaveLength(3);
+      const anchorNode = nodes.find((n) => n.id === anchorId);
+      expect(anchorNode).toBeDefined();
+      // The node is pure marker: the view renders the footnote reference and
+      // nothing else. The optional second [^1] tolerates the pre-existing
+      // marker doubling (view-level injection + read_file suffix, #382)
+      // without letting zero or triple markers pass.
+      expect(anchorNode!.text).toMatch(/^\[\^1\](?:\[\^1\])?$/);
+      expect(anchorNode!.clean_text).toBe('[^1]');
+    });
+
+    await and('a node_ids probe for the anchor paragraph resolves it', async () => {
+      const probe = await readFile(opened.mgr, {
+        file_path: opened.inputPath,
+        format: 'json',
+        node_ids: [anchorId],
+      });
+      assertSuccess(probe, 'read_file node_ids probe');
+      const probed = JSON.parse(String(probe.content));
+      expect(probed).toHaveLength(1);
+      expect(probed[0].id).toBe(anchorId);
     });
   });
 


### PR DESCRIPTION
Fixes #185

## Problem

`buildNodesForDocumentView` skipped any paragraph with no visible text unless it sat inside a table. A body paragraph whose only content is a footnote-reference run — a real shape: the NVCA SPA fixture anchors footnote id=47 (display 46) to exactly such a paragraph — was therefore dropped from the document view entirely. That made the loss silent in the most-used read path: `get_footnotes` reported the note as anchored, but `read_file` could never render the anchor paragraph or its `[^N]` marker in any format, and `node_ids` probes for the anchor returned zero nodes. On the NVCA fixture only 107 of 108 eligible footnotes were reachable through the view.

## Fix

Keep a text-empty paragraph when it carries a visible (non-reserved) footnote reference — the keep-predicate is `getFootnoteMarkersForParagraph(...)`, the same predicate the later marker-injection pass uses, so a kept paragraph always renders at least its `[^N]` marker and never a truly blank node. No changes to the pagination, marker, or rendering pipelines. Paragraphs that are empty for spacing only are still skipped; view shapes for footnote-free documents are unchanged. The extra check only runs for text-empty non-table paragraphs and short-circuits when the document has no footnotes.

## Behavior change to be aware of

The NVCA document view gains one node (367 → 368, at 1-based position 94), so later 1-based `offset` windows on footnote-bearing documents shift by one. No repo test pinned the old offsets (full pre-submit gate is green), but external consumers that hard-code numeric offsets into such documents may observe drift — that drift is the fix working: the document was always 368 anchorable paragraphs; one was silently hidden.

## Out of scope (filed as follow-ups)

- #382 — footnote markers render doubled (`[^N][^N]`) in `text`/`tagged_text` because both the view-level injection and `read_file`'s suffix pass fire. Pre-existing on main for **all** footnote paragraphs (verified: 107/107 doubled before this fix); orthogonal to the drop fixed here. The new tests assert `/^\[\^N\](?:\[\^N\])?$/` so they tolerate the current duplicate and a future single-marker fix, but fail on zero or triple markers.
- #383 — endnote-reference-only, comment-reference-only, and drawing-only paragraphs are still dropped by the same skip. This PR is deliberately bounded to the footnote read path per one-fix-per-PR.

## Tests

- `read_file_footnotes.test.ts`: synthetic document whose middle paragraph contains only a footnote reference — asserts the node appears in the full JSON view, renders its marker, and resolves via a `node_ids` probe.
- `nvca_spa_regression.test.ts`: NVCA SPA sweep — 109 footnotes listed, 108 eligible (display > 0, non-empty, anchored), **0** unsurfaced anchors; the issue's exact repro probe (`node_ids: ['_bk_6d177a97f7e6']`) returns the paragraph rendering `[^46]`.
- Both tests fail with the one-line guard reverted (verified via stash/rebuild/run).

Full pre-submit gate green: build, lint:workspaces, test:run (docx-core 1368 + docx-mcp 842 + rest of workspace), check:spec-coverage, check:conformance-citations, check:conformance-doc.

Peer-reviewed (dynamic) by Codex and agy before opening; both verified the fix, test failures-on-revert, offset-shift blast radius, and that the doubled-marker artifact predates this change.