### PR TITLE
ci(release): auto-tag version-bump merges so releases cannot strand untagged

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -1,0 +1,95 @@
+# Auto-tag version-bump merges so a release can never strand untagged again.
+#
+# When a `chore(release): bump workspace versions` PR merges to main, this
+# workflow creates and pushes the matching `v<version>` tag. The tag push then
+# triggers release.yml exactly as a manually pushed tag does today.
+#
+# Two constraints shape this file:
+#
+# - The tag is pushed with the release-bot GitHub App token, NOT the
+#   workflow-scoped GITHUB_TOKEN: events created by GITHUB_TOKEN do not start
+#   downstream workflow runs, so a GITHUB_TOKEN-pushed tag would never fire
+#   release.yml.
+# - This workflow must only ever create the tag. npm trusted publishing (OIDC)
+#   is pinned to the release.yml workflow filename; running `npm publish` or
+#   `mcp-publisher publish` from any other workflow file fails the
+#   trusted-publisher claim match and the publish is rejected.
+name: Auto-tag release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: auto-tag-release
+  cancel-in-progress: false
+
+jobs:
+  auto-tag:
+    name: Tag version-bump merges
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Detect a merged version bump without a tag
+        id: detect
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          VERSION="$(node -p "require('./package.json').version")"
+          TAG="v${VERSION}"
+
+          # Only act when this push actually changed the version field, so
+          # reverts and cherry-picks of unrelated work cannot mint accidental
+          # releases. The before-sha can be missing locally after a force
+          # push; fall back to the parent commit.
+          if [ -z "$BEFORE_SHA" ] || ! git cat-file -e "${BEFORE_SHA}^{commit}" 2>/dev/null; then
+            BEFORE_SHA="$(git rev-parse HEAD~1)"
+          fi
+          git show "${BEFORE_SHA}:package.json" > /tmp/package.before.json
+          PREVIOUS_VERSION="$(node -p "require('/tmp/package.before.json').version")"
+
+          if [ "$VERSION" = "$PREVIOUS_VERSION" ]; then
+            echo "Root package.json version unchanged by this push (${VERSION}) — not a version-bump merge."
+            echo "release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists — nothing to do."
+            echo "release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Refuse to tag a half-bumped commit. Release preflight would catch
+          # the mismatch anyway, but failing here keeps the bad tag from ever
+          # existing.
+          node scripts/bump_version.mjs --check
+
+          echo "Version bump ${PREVIOUS_VERSION} -> ${VERSION} merged with no ${TAG} tag — tagging."
+          echo "release=true" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Generate GitHub App token
+        if: steps.detect.outputs.release == 'true'
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
+      - name: Create and push tag (triggers release.yml)
+        if: steps.detect.outputs.release == 'true'
+        env:
+          TAG: ${{ steps.detect.outputs.tag }}
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          git tag "${TAG}" "${GITHUB_SHA}"
+          git push "https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "refs/tags/${TAG}"
+          echo "Pushed ${TAG} at ${GITHUB_SHA} — release.yml takes it from here."

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -40,12 +40,29 @@ This script is the source of truth for which files are managed (package manifest
 
 Commit: `chore(release): bump workspace versions to X.Y.Z`
 
-### 2. Tag and push
+### 2. Tag (automated)
+
+Merging the bump PR is the release trigger. The `Auto-tag release` workflow
+(`.github/workflows/auto-tag-release.yml`) runs on every push to `main`; when the
+push changed the root `package.json` version and no `v<version>` tag exists yet,
+it pushes the tag with the release-bot App token, and the tag push triggers the
+release workflow below.
+
+Manual fallback (auto-tag failed, or releasing a commit other than the current
+`main` tip):
 
 ```bash
-git tag vX.Y.Z
-git push origin main --tags
+git tag vX.Y.Z <commit-sha>
+git push origin vX.Y.Z
 ```
+
+Two constraints to preserve when touching this machinery:
+
+- The tag must be pushed with a GitHub App or PAT credential. Tags created with
+  the workflow-scoped `GITHUB_TOKEN` do not trigger `release.yml`.
+- npm trusted publishing (OIDC) is pinned to the `release.yml` workflow filename.
+  Never move `npm publish` or `mcp-publisher publish` into another workflow file —
+  the trusted-publisher claim match would fail and the publish would be rejected.
 
 ### 3. Monitor the release workflow
 

--- a/scripts/bump_version.mjs
+++ b/scripts/bump_version.mjs
@@ -8,7 +8,9 @@
 //
 // Updates: root + all workspace package.json files, mcpb manifest.json,
 // cross-workspace dep ranges, and package-lock.json.
-// After running, commit the changes and merge before tagging.
+// After running, commit the changes and merge to main. The Auto-tag release
+// workflow (.github/workflows/auto-tag-release.yml) then pushes the v<version>
+// tag, and the tag push triggers the release workflow.
 
 import { readFileSync, writeFileSync } from 'node:fs';
 import { resolve, join, basename } from 'node:path';
@@ -195,7 +197,8 @@ function bumpVersion(newVersion) {
     console.log('\nNext steps:');
     console.log(`  1. git add -A && git commit -m "chore(release): bump workspace versions to ${newVersion}"`);
     console.log('  2. Open PR, merge to main');
-    console.log(`  3. git tag v${newVersion} && git push origin v${newVersion}`);
+    console.log(`  3. On merge, auto-tag-release.yml pushes v${newVersion}, which triggers release.yml.`);
+    console.log(`     Manual fallback: git tag v${newVersion} && git push origin v${newVersion}`);
   } else {
     console.error('\nVersion sync check failed after bump — investigate manually.');
     process.exit(1);


### PR DESCRIPTION
## Why

v0.10.0 merged in #375 but the tag was never pushed, so `release.yml` never fired — npm and the official MCP registry silently stranded at 0.9.1 while main advertised 0.10.0 (#381). The release train was fully automated except for its trigger.

## What

Implements the **durable fix (option 1, recommended)** from #381:

- **`.github/workflows/auto-tag-release.yml`** — on push to `main`: if the push changed the root `package.json` version and no `v<version>` tag exists, verify the commit is fully bumped (`bump_version.mjs --check`) and push the tag with the release-bot App token. The tag push triggers `release.yml` exactly as a manual push does today.
- **`scripts/bump_version.mjs`** — header + next-steps now describe the automated trigger; manual tag push demoted to a fallback.
- **`docs/release-runbook.md`** — step 2 rewritten: merging the bump PR *is* the release trigger; documents the two machinery constraints.

## Design constraints honored (from #381)

- **App token, not `GITHUB_TOKEN`**: tags created with the workflow-scoped `GITHUB_TOKEN` don't trigger downstream workflows, so `release.yml` would never fire. Reuses the existing `RELEASE_BOT_APP_ID` / `RELEASE_BOT_PRIVATE_KEY` App already trusted by `release.yml`'s changelog job.
- **No publishing moves into this file**: npm trusted publishing (OIDC) is pinned to the `release.yml` workflow filename; this workflow only creates the tag.
- **Guarded on the actual version-field change** between the push's before/after shas (not commit-message matching), so reverts and unrelated merges can't mint accidental releases; the tag-exists check makes re-runs idempotent. Merging *this* PR is therefore a no-op for the workflow.

## Immediate remediation (separate from this PR)

The stranded 0.10.0 release still needs its tag pushed manually (`git tag v0.10.0 && git push origin v0.10.0` at current main HEAD) — by design this PR's guard won't retroactively tag it.

Verified: `actionlint` clean; `node scripts/bump_version.mjs --check` passes (all 13 files at 0.10.0).

Ref: #381