### PR TITLE
fix(docx-mcp): render each footnote marker exactly once in read_file output

### DIFF
--- a/packages/docx-mcp/src/tools/nvca_spa_regression.test.ts
+++ b/packages/docx-mcp/src/tools/nvca_spa_regression.test.ts
@@ -619,9 +619,17 @@ describe('NVCA SPA regression: footnote anchor surfacing (#185)', () => {
       assertSuccess(probe, 'read_file node_ids probe');
       const probed = JSON.parse(probe.content as string) as Array<{ id: string; text: string }>;
       expect(probed).toHaveLength(1);
-      // Pure-marker node; the optional second [^46] tolerates the pre-existing
-      // marker doubling (#382) without letting zero or triple markers pass.
-      expect(probed[0]!.text).toMatch(/^\[\^46\](?:\[\^46\])?$/);
+      // Pure-marker node; exactly one [^46] — the view-level injection used to
+      // be doubled by a read_file suffix pass. @see #382
+      expect(probed[0]!.text).toBe('[^46]');
+    });
+
+    await and('no footnote marker anywhere in the walk is doubled', async () => {
+      // Adjacent same-number markers ([^45][^45], with or without intervening
+      // whitespace) are the #382 signature; distinct adjacent references
+      // ([^1][^2]) remain legal.
+      const doubled = nodes.filter((n) => /\[\^(\d+)\]\s*\[\^\1\]/.test(n.text));
+      expect(doubled.map((n) => n.id)).toEqual([]);
     });
   });
 });

--- a/packages/docx-mcp/src/tools/read_file.ts
+++ b/packages/docx-mcp/src/tools/read_file.ts
@@ -352,6 +352,12 @@ export async function readFile(
       return map;
     })();
 
+    // Footnote [^N] markers: the document view already injects them into
+    // tagged_text/text at the reference's visible offset (injectFootnoteMarkers
+    // in docx-core's document_view.ts). Only clean_text is enriched here — the
+    // view deliberately keeps it marker-free for core consumers (edit matching,
+    // signature-cluster detection), so the suffix is a read_file output concern.
+    // Appending to all three fields doubled every marker. @see #382
     let enriched = filtered;
     try {
       const footnotes = await session.doc.getFootnotes();
@@ -368,8 +374,6 @@ export async function readFile(
           return {
             ...node,
             clean_text: `${node.clean_text}${markerSuffix}`,
-            tagged_text: `${node.tagged_text}${markerSuffix}`,
-            text: `${node.text}${markerSuffix}`,
           };
         });
       }

--- a/packages/docx-mcp/src/tools/read_file.ts
+++ b/packages/docx-mcp/src/tools/read_file.ts
@@ -28,20 +28,47 @@ function getWAttr(el: Element, localName: string): string | null {
   return el.getAttributeNS(OOXML.W_NS, localName) ?? el.getAttribute(`w:${localName}`) ?? el.getAttribute(localName);
 }
 
+enum FieldState {
+  OUTSIDE_FIELD = 0,
+  IN_FIELD_CODE = 1,
+  IN_FIELD_RESULT = 2,
+}
+
 function collectFootnoteMarkerSuffix(
   paragraphEl: Element,
   displayNumberById: Map<number, number>,
 ): string {
+  // References inside field code (between fldChar begin and separate) are
+  // hidden text and must not surface a marker — the view-level injection
+  // skips them the same way, keeping clean_text and text in agreement on
+  // which footnotes exist. @see #382
   const markers: string[] = [];
-  const refs = paragraphEl.getElementsByTagNameNS(OOXML.W_NS, W.footnoteReference);
-  for (let i = 0; i < refs.length; i++) {
-    const ref = refs.item(i) as Element;
-    const rawId = getWAttr(ref, 'id');
-    if (!rawId) continue;
-    const numericId = Number.parseInt(rawId, 10);
-    if (Number.isNaN(numericId)) continue;
-    const display = displayNumberById.get(numericId) ?? numericId;
-    markers.push(`[^${display}]`);
+  let fieldState = FieldState.OUTSIDE_FIELD;
+
+  for (const runEl of Array.from(paragraphEl.getElementsByTagNameNS(OOXML.W_NS, W.r))) {
+    for (const child of Array.from(runEl.childNodes)) {
+      if (child.nodeType !== 1) continue;
+      const el = child as Element;
+      if (el.namespaceURI !== OOXML.W_NS) continue;
+
+      if (el.localName === W.fldChar) {
+        const type = getWAttr(el, 'fldCharType') ?? '';
+        if (type === 'begin') fieldState = FieldState.IN_FIELD_CODE;
+        else if (type === 'separate') fieldState = FieldState.IN_FIELD_RESULT;
+        else if (type === 'end') fieldState = FieldState.OUTSIDE_FIELD;
+        continue;
+      }
+
+      if (fieldState === FieldState.IN_FIELD_CODE) continue;
+      if (el.localName !== W.footnoteReference) continue;
+
+      const rawId = getWAttr(el, 'id');
+      if (!rawId) continue;
+      const numericId = Number.parseInt(rawId, 10);
+      if (Number.isNaN(numericId)) continue;
+      const display = displayNumberById.get(numericId) ?? numericId;
+      markers.push(`[^${display}]`);
+    }
   }
   return markers.join('');
 }
@@ -65,12 +92,6 @@ function getCommentAnchorParagraphId(comment: Comment): string | null {
 }
 
 function getParagraphRunVisibleLengths(paragraphEl: Element): number[] {
-  enum FieldState {
-    OUTSIDE_FIELD = 0,
-    IN_FIELD_CODE = 1,
-    IN_FIELD_RESULT = 2,
-  }
-
   const runLengths: number[] = [];
   const runElements = Array.from(paragraphEl.getElementsByTagNameNS(OOXML.W_NS, W.r));
   let fieldState = FieldState.OUTSIDE_FIELD;

--- a/packages/docx-mcp/src/tools/read_file_footnotes.test.ts
+++ b/packages/docx-mcp/src/tools/read_file_footnotes.test.ts
@@ -129,6 +129,68 @@ describe('read_file footnotes', () => {
     });
   });
 
+  test('a footnote reference inside field code is hidden from every text field (#382)', async ({ given, when, then }: AllureBddContext) => {
+    const W_DOC_OPEN = '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">';
+    // First paragraph: a footnoteReference between fldChar begin and separate —
+    // field-code content Word never displays. Second paragraph: an ordinary
+    // visible reference. The hidden reference still occupies display slot 1 in
+    // document order, so the visible one renders as [^2].
+    const documentXml =
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+      W_DOC_OPEN +
+      `<w:body>` +
+      `<w:p>` +
+      `<w:r><w:t>Before </w:t></w:r>` +
+      `<w:r><w:fldChar w:fldCharType="begin"/></w:r>` +
+      `<w:r><w:instrText xml:space="preserve"> NOTEREF _Ref1 </w:instrText></w:r>` +
+      `<w:r><w:footnoteReference w:id="1"/></w:r>` +
+      `<w:r><w:fldChar w:fldCharType="separate"/></w:r>` +
+      `<w:r><w:t>Visible result</w:t></w:r>` +
+      `<w:r><w:fldChar w:fldCharType="end"/></w:r>` +
+      `<w:r><w:t> After</w:t></w:r>` +
+      `</w:p>` +
+      `<w:p><w:r><w:t>Anchor sentence.</w:t></w:r><w:r><w:footnoteReference w:id="2"/></w:r></w:p>` +
+      `</w:body></w:document>`;
+    const footnotesXml =
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+      `<w:footnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
+      `<w:footnote w:type="separator" w:id="-1"><w:p><w:r><w:separator/></w:r></w:p></w:footnote>` +
+      `<w:footnote w:type="continuationSeparator" w:id="0"><w:p><w:r><w:continuationSeparator/></w:r></w:p></w:footnote>` +
+      `<w:footnote w:id="1"><w:p><w:r><w:t>Hidden field-code note.</w:t></w:r></w:p></w:footnote>` +
+      `<w:footnote w:id="2"><w:p><w:r><w:t>Visible note.</w:t></w:r></w:p></w:footnote>` +
+      `</w:footnotes>`;
+
+    let opened: Awaited<ReturnType<typeof openSession>>;
+    let nodes: Array<{ id: string; text: string; tagged_text: string; clean_text: string }>;
+
+    await given('a document with one field-code-contained and one visible footnote reference', async () => {
+      opened = await openSession([], {
+        xml: documentXml,
+        extraFiles: { 'word/footnotes.xml': footnotesXml },
+      });
+    });
+
+    await when('read_file renders the full document as JSON', async () => {
+      const read = await readFile(opened.mgr, { file_path: opened.inputPath, format: 'json' });
+      assertSuccess(read, 'read_file');
+      nodes = JSON.parse(String(read.content));
+      expect(nodes).toHaveLength(2);
+    });
+
+    await then('the hidden reference surfaces no marker in any field and the visible one exactly one', async () => {
+      // The view skips field-code references; the clean_text suffix pass must
+      // agree, or the fields disagree about whether the footnote exists (#382).
+      const fieldCodeNode = nodes[0]!;
+      expect(fieldCodeNode.text).not.toContain('[^');
+      expect(fieldCodeNode.tagged_text).not.toContain('[^');
+      expect(fieldCodeNode.clean_text).not.toContain('[^');
+
+      const visibleNode = nodes[1]!;
+      expect(visibleNode.text).toBe('Anchor sentence.[^2]');
+      expect(visibleNode.clean_text).toBe('Anchor sentence.[^2]');
+    });
+  });
+
   test('explicit limit disables the first-node overflow warning even when the paragraph has a footnote', async ({ when, then }: AllureBddContext) => {
     const rendered = await when('a caller provides an explicit limit for the oversized first-node read', async () => {
       return readWithOversizedFirstNode({ format: 'toon', limit: 1 });

--- a/packages/docx-mcp/src/tools/read_file_footnotes.test.ts
+++ b/packages/docx-mcp/src/tools/read_file_footnotes.test.ts
@@ -110,10 +110,9 @@ describe('read_file footnotes', () => {
       const anchorNode = nodes.find((n) => n.id === anchorId);
       expect(anchorNode).toBeDefined();
       // The node is pure marker: the view renders the footnote reference and
-      // nothing else. The optional second [^1] tolerates the pre-existing
-      // marker doubling (view-level injection + read_file suffix, #382)
-      // without letting zero or triple markers pass.
-      expect(anchorNode!.text).toMatch(/^\[\^1\](?:\[\^1\])?$/);
+      // nothing else. Exactly one [^1] — the view-level injection used to be
+      // doubled by a read_file suffix pass. @see #382
+      expect(anchorNode!.text).toBe('[^1]');
       expect(anchorNode!.clean_text).toBe('[^1]');
     });
 


### PR DESCRIPTION
## Problem

Every footnote-anchoring paragraph rendered its marker doubled (`[^N][^N]`) in `read_file`'s `text`/`tagged_text` fields — all 107 reachable markers on the NVCA SPA fixture. Two independent passes both injected the marker:

1. **View level** — `buildNodesForDocumentView` injects `[^N]` into `tagged_text`/`text` at the reference's visible offset (`injectFootnoteMarkers`, tag-aware via `findTaggedTextInsertionIndex`).
2. **Tool level** — `read_file`'s enrichment appended the marker again as a suffix to `clean_text`, `tagged_text`, and `text`.

`clean_text` got a single marker (the view never touches it), so the fields also disagreed on count (1 vs 2).

## Fix

The view-level injection wins for `tagged_text`/`text`: its placement is faithful and it feeds every downstream rendering (toon, json, the markdown/html/plaintext serializers, and the #185 footnote-only-paragraph surfacing). `read_file`'s suffix pass now enriches only `clean_text`, which the view deliberately keeps marker-free for core consumers (edit matching, signature-cluster detection). Every field now carries exactly one marker per reference.

**Peer-review hardening (Codex probe finding):** `collectFootnoteMarkerSuffix` collected every descendant `w:footnoteReference` indiscriminately, while the view skips references inside field code (between `fldChar begin` and `separate` — content Word never displays). That would have left `clean_text` claiming a footnote that `text` correctly omits. The suffix collector now applies the same `fldChar` state machine, so all fields agree on which footnotes exist.

## Tests

- The two #185 regression assertions that deliberately tolerated the duplicate (`/^\[\^N\](?:\[\^N\])?$/`) are tightened to exactly-one.
- The NVCA SPA full-document walk now asserts no adjacent same-number marker pair appears anywhere in the view.
- New regression test: a field-code-contained reference surfaces no marker in any field; a visible reference renders exactly one, with document-order display numbering still counting the hidden slot.

Peer-reviewed via Codex (`REQUEST-CHANGES` → addressed in second commit) and agy (`APPROVE`), both with dynamic execution traces.

Full pre-submit gate green: build, lint:workspaces, test:run, check:spec-coverage, check:conformance-citations, check:conformance-doc.

Fixes: #382