### PR TITLE
fix(docx-core): surface text-empty paragraphs anchoring endnotes, comments, or drawings

### DIFF
--- a/packages/docx-core/src/primitives/document_view.ts
+++ b/packages/docx-core/src/primitives/document_view.ts
@@ -294,6 +294,59 @@ function getFootnoteMarkersForParagraph(
 }
 
 /**
+ * Paragraph content that makes a text-empty paragraph meaningful on its own:
+ * an endnote or comment anchored to the paragraph (the comment range markers
+ * are what `getComments` resolves `anchored_paragraph_id`/`end_paragraph_id`
+ * from, so dropping their paragraph leaves a dangling anchor ID no node_ids
+ * probe can resolve), or embedded visual content (DrawingML drawing, VML
+ * picture, embedded object). Dropping such a paragraph from the document view
+ * severs the anchored note/comment from every read surface and silently
+ * hides images.
+ *
+ * Footnote references are handled separately via the display map so their
+ * [^N] markers render; the shapes here only need the node to exist.
+ * @see #383
+ */
+const ANCHORING_CONTENT = [
+  W.endnoteReference,
+  W.commentReference,
+  W.commentRangeStart,
+  W.commentRangeEnd,
+  W.drawing,
+  W.pict,
+  W.object,
+] as const;
+
+/**
+ * True when `el` sits inside a `w:del` or `w:moveFrom` revision wrapper below
+ * the paragraph. Deleted/moved-from content is invisible to the view's text
+ * extraction (`getParagraphText` reads `w:t`, never `w:delText`), so an
+ * anchor that only survives inside a tracked deletion — e.g. the
+ * `w:commentReference` a tracked comment-delete leaves under `w:del` — must
+ * not resurrect its paragraph as a blank visible node.
+ */
+function isInsideRemovedRevisionWrapper(el: Element, paragraph: Element): boolean {
+  let cur = el.parentNode as Element | null;
+  while (cur && cur !== paragraph) {
+    if (cur.namespaceURI === OOXML.W_NS && (cur.localName === W.del || cur.localName === W.moveFrom)) {
+      return true;
+    }
+    cur = cur.parentNode as Element | null;
+  }
+  return false;
+}
+
+function paragraphHasAnchoringContent(p: Element): boolean {
+  return ANCHORING_CONTENT.some((localName) => {
+    const els = p.getElementsByTagNameNS(OOXML.W_NS, localName);
+    for (let i = 0; i < els.length; i++) {
+      if (!isInsideRemovedRevisionWrapper(els.item(i) as Element, p)) return true;
+    }
+    return false;
+  });
+}
+
+/**
  * Inject footnote markers into a text string at the given offsets.
  * Markers must be sorted descending by offset.
  *
@@ -408,13 +461,19 @@ export function buildNodesForDocumentView(params: {
     // Visible clean text (field codes stripped).
     const fullText = getParagraphText(p).replace(/\r/g, '').replace(/\n/g, '').trim();
     // Preserve empty table cell paragraphs for structural completeness, and
-    // text-empty paragraphs that anchor a visible footnote reference — dropping
-    // those loses the footnote from every rendering of the document view.
-    // @see #185
+    // text-empty paragraphs that carry anchoring content — a visible footnote
+    // reference (its [^N] marker renders via the injection pass below), an
+    // endnote reference, a comment reference or comment range marker, or an
+    // embedded drawing/picture/object. Dropping those loses the anchored
+    // note/comment/image from every rendering of the document view. Anchors
+    // that survive only inside a tracked deletion don't count, and paragraphs
+    // that are empty for spacing only are still skipped.
+    // @see #185, #383
     if (
       !fullText &&
       !tableContext &&
-      getFootnoteMarkersForParagraph(p, footnoteDisplayMap).length === 0
+      getFootnoteMarkersForParagraph(p, footnoteDisplayMap).length === 0 &&
+      !paragraphHasAnchoringContent(p)
     ) continue;
 
     // Numbering (auto-numbered) info from numPr.

--- a/packages/docx-core/src/primitives/namespaces.ts
+++ b/packages/docx-core/src/primitives/namespaces.ts
@@ -114,4 +114,16 @@ export const W = {
   footnoteRef: 'footnoteRef',
   separator: 'separator',
   continuationSeparator: 'continuationSeparator',
+
+  // Endnotes
+  endnoteReference: 'endnoteReference',
+
+  // Embedded visual content (run-level children)
+  drawing: 'drawing',
+  pict: 'pict',
+  object: 'object',
+
+  // Revision wrappers
+  del: 'del',
+  moveFrom: 'moveFrom',
 } as const;

--- a/packages/docx-mcp/src/tools/read_file_anchor_only_paragraphs.test.ts
+++ b/packages/docx-mcp/src/tools/read_file_anchor_only_paragraphs.test.ts
@@ -1,0 +1,288 @@
+import { describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { assertSuccess, openSession, registerCleanup } from '../testing/session-test-utils.js';
+import { getComments } from './get_comments.js';
+import { readFile } from './read_file.js';
+
+const test = testAllure.epic('Document Reading');
+
+const W_DOC_OPEN =
+  '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">';
+
+function makeDocumentXml(bodyXml: string): string {
+  return (
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    W_DOC_OPEN +
+    `<w:body>${bodyXml}</w:body></w:document>`
+  );
+}
+
+type ViewNode = { id: string; text: string; clean_text: string };
+
+async function readJsonNodes(opened: Awaited<ReturnType<typeof openSession>>): Promise<ViewNode[]> {
+  const read = await readFile(opened.mgr, { file_path: opened.inputPath, format: 'json' });
+  assertSuccess(read, 'read_file');
+  return JSON.parse(String(read.content)) as ViewNode[];
+}
+
+async function probeNodeId(
+  opened: Awaited<ReturnType<typeof openSession>>,
+  nodeId: string,
+): Promise<ViewNode[]> {
+  const probe = await readFile(opened.mgr, {
+    file_path: opened.inputPath,
+    format: 'json',
+    node_ids: [nodeId],
+  });
+  assertSuccess(probe, 'read_file node_ids probe');
+  return JSON.parse(String(probe.content)) as ViewNode[];
+}
+
+describe('read_file text-empty paragraphs with anchoring content (#383)', () => {
+  registerCleanup();
+
+  test('a paragraph whose only content is an endnote reference is surfaced in the document view', async ({ given, when, then, and }: AllureBddContext) => {
+    const documentXml = makeDocumentXml(
+      `<w:p><w:r><w:t>Body before the endnote.</w:t></w:r></w:p>` +
+        `<w:p><w:r><w:rPr><w:rStyle w:val="EndnoteReference"/></w:rPr><w:endnoteReference w:id="1"/></w:r></w:p>` +
+        `<w:p><w:r><w:t>Body after the endnote.</w:t></w:r></w:p>`,
+    );
+    // The endnotes part exists for package realism only: this fix surfaces the
+    // anchor node; endnote marker/body rendering is a separate read surface
+    // that does not exist yet (the opt-in inlining follow-on alongside #207).
+    const endnotesXml =
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+      `<w:endnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
+      `<w:endnote w:type="separator" w:id="-1"><w:p><w:r><w:separator/></w:r></w:p></w:endnote>` +
+      `<w:endnote w:type="continuationSeparator" w:id="0"><w:p><w:r><w:continuationSeparator/></w:r></w:p></w:endnote>` +
+      `<w:endnote w:id="1"><w:p><w:r><w:t>Endnote body lives here.</w:t></w:r></w:p></w:endnote>` +
+      `</w:endnotes>`;
+
+    let opened: Awaited<ReturnType<typeof openSession>>;
+    let nodes: ViewNode[];
+
+    await given('a document whose middle paragraph contains only an endnote reference run', async () => {
+      opened = await openSession([], {
+        xml: documentXml,
+        extraFiles: { 'word/endnotes.xml': endnotesXml },
+      });
+    });
+
+    await when('read_file renders the full document as JSON', async () => {
+      nodes = await readJsonNodes(opened);
+    });
+
+    await then('the endnote-only paragraph appears in the view between its neighbors', async () => {
+      expect(nodes).toHaveLength(3);
+      expect(nodes[0]!.clean_text).toBe('Body before the endnote.');
+      expect(nodes[1]!.clean_text).toBe('');
+      expect(nodes[2]!.clean_text).toBe('Body after the endnote.');
+    });
+
+    await and('a node_ids probe for the anchor paragraph resolves it', async () => {
+      const probed = await probeNodeId(opened, nodes[1]!.id);
+      expect(probed).toHaveLength(1);
+      expect(probed[0]!.id).toBe(nodes[1]!.id);
+    });
+  });
+
+  test('a paragraph whose only content is a comment anchor is surfaced and the comment attaches to it', async ({ given, when, then, and }: AllureBddContext) => {
+    const documentXml = makeDocumentXml(
+      `<w:p><w:r><w:t>Body before the comment.</w:t></w:r></w:p>` +
+        `<w:p>` +
+        `<w:commentRangeStart w:id="1"/>` +
+        `<w:commentRangeEnd w:id="1"/>` +
+        `<w:r><w:rPr><w:rStyle w:val="CommentReference"/></w:rPr><w:commentReference w:id="1"/></w:r>` +
+        `</w:p>` +
+        `<w:p><w:r><w:t>Body after the comment.</w:t></w:r></w:p>`,
+    );
+    const commentsXml =
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+      `<w:comments xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">` +
+      `<w:comment w:id="1" w:author="Reviewer" w:date="2025-01-01T00:00:00Z" w:initials="RV">` +
+      `<w:p w14:paraId="11111111"><w:r><w:annotationRef/></w:r><w:r><w:t>Comment on an otherwise empty paragraph.</w:t></w:r></w:p>` +
+      `</w:comment>` +
+      `</w:comments>`;
+
+    let opened: Awaited<ReturnType<typeof openSession>>;
+    let anchorId: string;
+    let nodes: ViewNode[];
+
+    await given('a document whose middle paragraph contains only a comment range and reference run', async () => {
+      opened = await openSession([], {
+        xml: documentXml,
+        extraFiles: { 'word/comments.xml': commentsXml },
+      });
+      const comments = await getComments(opened.mgr, { file_path: opened.inputPath });
+      assertSuccess(comments, 'get_comments');
+      const all = comments.comments as Array<{ id: number; anchored_paragraph_id: string | null }>;
+      expect(all).toHaveLength(1);
+      expect(all[0]!.anchored_paragraph_id).not.toBeNull();
+      anchorId = all[0]!.anchored_paragraph_id!;
+    });
+
+    await when('read_file renders the full document as JSON', async () => {
+      nodes = await readJsonNodes(opened);
+    });
+
+    await then('the comment-anchor paragraph appears in the view', async () => {
+      expect(nodes).toHaveLength(3);
+      const anchorNode = nodes.find((n) => n.id === anchorId);
+      expect(anchorNode).toBeDefined();
+      expect(anchorNode!.clean_text).toBe('');
+    });
+
+    await and('a node_ids probe for the anchor paragraph resolves it and the comment thread renders against it', async () => {
+      const probed = await probeNodeId(opened, anchorId);
+      expect(probed).toHaveLength(1);
+      expect(probed[0]!.id).toBe(anchorId);
+
+      const rendered = await readFile(opened.mgr, { file_path: opened.inputPath });
+      assertSuccess(rendered, 'read_file with default comment rendering');
+      expect(String(rendered.content)).toContain('Comment on an otherwise empty paragraph.');
+    });
+  });
+
+  test('a comment range starting in an otherwise-empty paragraph keeps its anchor paragraph in the view', async ({ given, when, then, and }: AllureBddContext) => {
+    // The dangling-anchor shape: getComments resolves anchored_paragraph_id
+    // from where w:commentRangeStart sits, so if that paragraph is dropped the
+    // reported anchor ID is unreachable by any node_ids probe — even though
+    // the commentReference run lives in a later, visible paragraph.
+    const documentXml = makeDocumentXml(
+      `<w:p><w:r><w:t>Body before the comment.</w:t></w:r></w:p>` +
+        `<w:p><w:commentRangeStart w:id="1"/></w:p>` +
+        `<w:p>` +
+        `<w:r><w:t>Commented text continues here.</w:t></w:r>` +
+        `<w:commentRangeEnd w:id="1"/>` +
+        `<w:r><w:rPr><w:rStyle w:val="CommentReference"/></w:rPr><w:commentReference w:id="1"/></w:r>` +
+        `</w:p>`,
+    );
+    const commentsXml =
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+      `<w:comments xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">` +
+      `<w:comment w:id="1" w:author="Reviewer" w:date="2025-01-01T00:00:00Z" w:initials="RV">` +
+      `<w:p w14:paraId="22222222"><w:r><w:annotationRef/></w:r><w:r><w:t>Range starts on an empty paragraph.</w:t></w:r></w:p>` +
+      `</w:comment>` +
+      `</w:comments>`;
+
+    let opened: Awaited<ReturnType<typeof openSession>>;
+    let anchorId: string;
+    let nodes: ViewNode[];
+
+    await given('a document whose comment range starts in an empty paragraph and ends in the next one', async () => {
+      opened = await openSession([], {
+        xml: documentXml,
+        extraFiles: { 'word/comments.xml': commentsXml },
+      });
+      const comments = await getComments(opened.mgr, { file_path: opened.inputPath });
+      assertSuccess(comments, 'get_comments');
+      const all = comments.comments as Array<{ id: number; anchored_paragraph_id: string | null }>;
+      expect(all).toHaveLength(1);
+      expect(all[0]!.anchored_paragraph_id).not.toBeNull();
+      anchorId = all[0]!.anchored_paragraph_id!;
+    });
+
+    await when('read_file renders the full document as JSON', async () => {
+      nodes = await readJsonNodes(opened);
+    });
+
+    await then('the reported anchor paragraph is a real view node, not a dangling ID', async () => {
+      expect(nodes).toHaveLength(3);
+      const anchorNode = nodes.find((n) => n.id === anchorId);
+      expect(anchorNode).toBeDefined();
+      expect(anchorNode!.clean_text).toBe('');
+    });
+
+    await and('a node_ids probe for the anchor paragraph resolves it', async () => {
+      const probed = await probeNodeId(opened, anchorId);
+      expect(probed).toHaveLength(1);
+      expect(probed[0]!.id).toBe(anchorId);
+    });
+  });
+
+  test('anchoring content that survives only inside a tracked deletion does not resurrect its paragraph', async ({ given, when, then }: AllureBddContext) => {
+    // A tracked comment-delete leaves the w:commentReference run under w:del
+    // (with comments.xml untouched until the revision is accepted), and a
+    // tracked image-delete wraps the w:drawing the same way. Deleted content
+    // is invisible to the view's text extraction, so these paragraphs must
+    // stay hidden exactly like fully-deleted text paragraphs.
+    const minimalDrawing =
+      `<w:drawing><wp:inline xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing">` +
+      `<wp:extent cx="914400" cy="914400"/></wp:inline></w:drawing>`;
+    const documentXml = makeDocumentXml(
+      `<w:p><w:r><w:t>Body before the deletions.</w:t></w:r></w:p>` +
+        `<w:p><w:del w:id="9" w:author="A" w:date="2025-01-01T00:00:00Z">` +
+        `<w:r><w:rPr><w:rStyle w:val="CommentReference"/></w:rPr><w:commentReference w:id="1"/></w:r>` +
+        `</w:del></w:p>` +
+        `<w:p><w:del w:id="10" w:author="A" w:date="2025-01-01T00:00:00Z"><w:r>${minimalDrawing}</w:r></w:del></w:p>` +
+        `<w:p><w:r><w:t>Body after the deletions.</w:t></w:r></w:p>`,
+    );
+    const commentsXml =
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+      `<w:comments xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">` +
+      `<w:comment w:id="1" w:author="Reviewer" w:date="2025-01-01T00:00:00Z" w:initials="RV">` +
+      `<w:p w14:paraId="33333333"><w:r><w:annotationRef/></w:r><w:r><w:t>Pending tracked delete.</w:t></w:r></w:p>` +
+      `</w:comment>` +
+      `</w:comments>`;
+
+    let opened: Awaited<ReturnType<typeof openSession>>;
+    let nodes: ViewNode[];
+
+    await given('a document whose anchor-bearing paragraphs are wholly inside w:del wrappers', async () => {
+      opened = await openSession([], {
+        xml: documentXml,
+        extraFiles: { 'word/comments.xml': commentsXml },
+      });
+    });
+
+    await when('read_file renders the full document as JSON', async () => {
+      nodes = await readJsonNodes(opened);
+    });
+
+    await then('only the two visible text paragraphs appear in the view', async () => {
+      expect(nodes).toHaveLength(2);
+      expect(nodes[0]!.clean_text).toBe('Body before the deletions.');
+      expect(nodes[1]!.clean_text).toBe('Body after the deletions.');
+    });
+  });
+
+  test('paragraphs whose only content is a drawing, picture, or embedded object are surfaced; spacing-only paragraphs stay hidden', async ({ given, when, then, and }: AllureBddContext) => {
+    const minimalDrawing =
+      `<w:drawing><wp:inline xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing">` +
+      `<wp:extent cx="914400" cy="914400"/></wp:inline></w:drawing>`;
+    const documentXml = makeDocumentXml(
+      `<w:p><w:r><w:t>Body before the images.</w:t></w:r></w:p>` +
+        `<w:p><w:r>${minimalDrawing}</w:r></w:p>` +
+        `<w:p><w:r><w:pict><v:shape xmlns:v="urn:schemas-microsoft-com:vml"/></w:pict></w:r></w:p>` +
+        `<w:p><w:r><w:object><v:shape xmlns:v="urn:schemas-microsoft-com:vml"/></w:object></w:r></w:p>` +
+        `<w:p/>` +
+        `<w:p><w:r><w:t>Body after the images.</w:t></w:r></w:p>`,
+    );
+
+    let opened: Awaited<ReturnType<typeof openSession>>;
+    let nodes: ViewNode[];
+
+    await given('a document with drawing-only, pict-only, object-only, and spacing-only paragraphs', async () => {
+      opened = await openSession([], { xml: documentXml });
+    });
+
+    await when('read_file renders the full document as JSON', async () => {
+      nodes = await readJsonNodes(opened);
+    });
+
+    await then('the three embedded-content paragraphs appear in the view and the spacing-only paragraph does not', async () => {
+      expect(nodes).toHaveLength(5);
+      expect(nodes[0]!.clean_text).toBe('Body before the images.');
+      expect(nodes[1]!.clean_text).toBe('');
+      expect(nodes[2]!.clean_text).toBe('');
+      expect(nodes[3]!.clean_text).toBe('');
+      expect(nodes[4]!.clean_text).toBe('Body after the images.');
+    });
+
+    await and('a node_ids probe for the drawing paragraph resolves it', async () => {
+      const probed = await probeNodeId(opened, nodes[1]!.id);
+      expect(probed).toHaveLength(1);
+      expect(probed[0]!.id).toBe(nodes[1]!.id);
+    });
+  });
+});


### PR DESCRIPTION
## Problem

#384 (issue #185) taught `buildNodesForDocumentView` to keep a text-empty paragraph when it carries a visible **footnote** reference. Issue #383 covers the remaining silent-drop shapes, which were still removed from the document view entirely:

- **Endnote-reference-only paragraphs** — the anchored endnote was invisible to the view and to any future endnote read surface.
- **Comment-reference-only paragraphs** — the comment could not be reached via `node_ids`, and comment-rendering passes had no node to attach the thread to.
- **Drawing-only paragraphs** (`w:drawing`, plus `w:pict`/`w:object`, the same run-level atoms the atomizer treats as atomic) — dropped wholesale.

## Fix

The keep-predicate generalizes from "has footnote markers" to "has anchoring content" via a new `paragraphHasAnchoringContent` helper, with two refinements out of peer review (Codex + agy, both dynamic):

- **Comment range markers count as anchors** (agy, SHOULD-FIX): `getComments` resolves `anchored_paragraph_id`/`end_paragraph_id` from where `w:commentRangeStart`/`End` sit (`comments.ts` `resolveCommentRangeMetadataInParagraph`), so a range starting in an otherwise-empty paragraph would otherwise report a dangling anchor ID that no `node_ids` probe can resolve.
- **Anchors inside `w:del`/`w:moveFrom` do not count** (Codex, SHOULD-FIX): deleted content is invisible to the view's text extraction (`getParagraphText` reads `w:t`, never `w:delText`), and a tracked comment-delete deliberately leaves the `commentReference` run under `w:del` — resurrecting that paragraph as a blank node would contradict how fully-deleted text paragraphs render.

Kept nodes render with **empty text** — the shape already established by empty table-cell paragraphs — so no placeholder text is invented. Footnote references keep their existing display-map path so `[^N]` markers still render, and spacing-only empty paragraphs are still skipped (view shapes unchanged for documents without these constructs).

## Scope notes

- Endnote marker/body rendering is a separate read surface that does not exist yet; the natural follow-on is opt-in endnote inlining alongside #207.
- `mc:AlternateContent` blocks are covered indirectly: both the `mc:Choice` `w:drawing` and the `mc:Fallback` `w:pict` match the namespace-aware descendant scan.

## Testing

- New `read_file_anchor_only_paragraphs.test.ts` (5 MCP-level end-to-end tests): endnote-only, comment-anchor-only, and dangling-range-start paragraphs surface and resolve via `node_ids` (comment threads attach to the kept nodes); the drawing/pict/object trio surfaces while a spacing-only sibling stays hidden; `w:del`-wrapped commentReference/drawing paragraphs stay hidden.
- Red→green verified both ways by rebuilding docx-core at each state: the three surfacing tests fail without the keep-predicate change, and the two peer-review-driven tests fail against the pre-review predicate.
- Full pre-submit suite green locally: build, lint:workspaces, test:run, check:spec-coverage, check:conformance-citations, check:conformance-doc.

Fixes: #383
Ref: #185