### PR TITLE
docs(openspec): propose cross-implementation conformance suite (M0 of #283)

### DIFF
--- a/openspec/changes/add-cross-implementation-conformance-suite/design.md
+++ b/openspec/changes/add-cross-implementation-conformance-suite/design.md
@@ -1,0 +1,41 @@
+# Design: cross-implementation OOXML conformance suite
+
+## Context
+
+Issue #283 scoped a wpt.fyi-style comparison for the spec-anchored subset of our scenarios and left five open questions (scenario expression, adapter shape, spec anchor, results UI, maintenance). This design resolves them. The plan was peer-reviewed pre-approval (codex + agy); their blockers — npm-bin sequencing, OpenSpec delta format, find-replace match-scope ambiguity — are folded in below.
+
+## Goals / Non-Goals
+
+- Goals: a neutral forkable suite repo; a language-neutral scenario DSL with ECMA-376 citations on every scenario; honest `unsupported` semantics so library gaps render as matrix asymmetry, not failure noise; safe-docx self-check wired into CI; a published results JSON any renderer can consume.
+- Non-Goals: schema validation (deferred assertion kind; see #214), tracked moves/table revisions (future scenarios), porting safe-docx algorithms to other libraries, LibreOffice adapter (named stretch), per-test-page renderer joins (#391).
+
+## Decisions
+
+- **Suite home `open-agreements/docx-platform-tests`, BSD-3-Clause.** Separate repo because neutrality is critical — researchers fork the suite without forking safe-docx; wpt's license maximizes reuse. ECMA-376 is cited by section number only, never reproduced.
+- **Scenario DSL: XML pairs + assertions.** Per-scenario directory: `scenario.json` (self-disambiguating 3–4-word camelCase keys: `operationDescriptor`, `assertionList`, `specCitation` with edition/part/section mirroring `spec-compliance/registry/ecma-376.md`, optional `wordBehaviorNote` for MS-OE376 deviations), `input/document.xml` (reviewable source of truth), committed generated `input.docx` (interchange — python-docx/LibreOffice/Word only open full packages; CI verifies fragment↔package sync).
+- **Operations v1 (closed enum):** `acceptAllTrackedChanges`, `rejectAllTrackedChanges`, `replaceFirstTextOccurrence {findText, replaceText}`. Match semantics pinned: first *paragraph-local* occurrence in document order; cross-paragraph matches out of scope in v1 (paragraph-scoped primitives would otherwise legitimately diverge).
+- **Assertions v1:** `xpathQueryCount`, `xpathQueryExists`, `documentTextContainsAtOffset` (projection pinned: body `w:t` only, `w:delText` excluded, paragraphs joined with `\n`), `canonicalXmlEquals`, `schemaValidAgainstWml` (defined-but-deferred; runner reports `unimplemented-assertion`). Authoring rule: prefer the weakest assertion that captures the conformance claim; every `canonicalXmlEquals` is paired with xpath assertions because run merge/split is legal post-accept — the canonicalizer additionally applies `mergeAdjacentIdenticalRuns` for tracked-change scenarios.
+- **Canonicalization:** normalize inter-element whitespace, attribute order, namespace-prefix spelling; strip the rsid attribute family and revision-wrapper `w:id` (implementation-chosen identifiers, not conformance signals). Never normalize text content or element order.
+- **Adapter protocol v1 (file-based CLI):** `<adapter-cmd> --protocol-version 1 --operation operation.json --input input.docx --output output.docx`. The runner extracts `operationDescriptor` to a temp `operation.json`; adapters never see assertions. Exit codes: 0 success, 2 unsupported (one-line reason to stdout), 1 error, 3 protocol-mismatch. One process per scenario (isolation over batching at this scale; the Lean harness's batch-stdin pattern is the fallback at ~100+ scenarios). `registry/adapters.json` records invocation commands; runtime exit codes outrank static declarations.
+- **M1 scenarios:** `acceptInsertionsUnwrapsInsWrappers` (ECMA-376 edition 5, Part 1 § 17.13.5.18; fixture mirrors `packages/docx-core/test-primitives/accept_changes.test.ts:32`), `acceptDeletionsRemovesDelContent` (§ 17.13.5.14; mirrors `accept_changes.test.ts:60`), `replaceFirstOccurrencePreservesOffsets` (single-run paragraph fixture, modeled on `packages/docx-core/src/primitives/text.test.ts` offset cases). The single-run constraint keeps the python-docx adapter an intra-run replace — testing the library, not the adapter author; a future run-spanning scenario may legitimately show python-docx `unsupported`.
+- **safe-docx adapter is a docx-core bin**, not a new package (a package would only re-import docx-core). New compiled entrypoint with shebang + explicit `"safe-docx-conformance-adapter": "dist/cli/conformance-adapter.js"` bin (existing bins both point at `dist/cli/index.js`, so this is a new bin file, not a dispatch case).
+- **Self-check gating:** `DOCX_PLATFORM_TESTS_DIR` env var + `existsSync`, `describeMaybe = available ? describe : describe.skip` (pattern: `lean-differential-lcs.test.ts:256`). Suite SHA pinned in `docx-platform-tests.pin.json`; mismatch warns, absence skips, disagreement fails. Test carries `TEST_FEATURE`, single-line `.openspec()` tags, and `.conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '…' })` (citation lint fails any ECMA-376 mention without it).
+- **Results publishing:** suite CI (push + weekly cron, so upstream library releases get re-tested) publishes `results/latest.json` to gh-pages + artifact; snapshot committed on tagged releases. Statuses: `pass | fail | unsupported | error | protocol-mismatch`, with per-assertion detail.
+- **npm sequencing:** the suite's safe-docx adapter installs from a pinned-SHA `npm pack` tarball until the next safe-docx release publishes the bin, then flips to npm in a follow-up suite commit.
+
+## Risks / Trade-offs
+
+- Canonical equality across implementations is brittle (legal run merging/splitting) → `mergeAdjacentIdenticalRuns` + paired xpath assertions + "weakest assertion" authoring rule.
+- Adapter upkeep when upstream libraries change → weekly cron surfaces breakage as `error` cells, not silent rot; per-adapter README states maintenance policy (best-effort, matrix shows staleness honestly).
+- New-capability scenarios are not machine-enforced by existing coverage validators (only `docx-primitives`/`mcp-server` spec paths are discovered) → over-disclosure accepted for M0; extending a validator rides with the archive PR (#390).
+- Self-check is vacuous on dev machines without the suite checkout → CI clones the suite at the pinned SHA so the gate is live where it matters (Lean-harness precedent).
+
+## Migration Plan
+
+M0 (this change, PR 1) → suite repo scaffold + M1 scenarios → M2 adapter + self-check (safe-docx PR 2, #389) → suite registers safe-docx (tarball) + python-docx adapters (M3) → tests-renderer matrix page (M4, UseJunior/tests-renderer#62) → archive (#390). Rollback: the adapter bin and self-check are additive; deleting them restores the status quo. The suite repo stands alone regardless.
+
+## Open Questions
+
+- LibreOffice headless as the third adapter (it genuinely implements accept/reject; recipe in `openspec/changes/add-libreoffice-accept-reject-oracle/`) — when, and macOS-vs-CI hosting.
+- Whether `documentTextContainsAtOffset` should ever include footnote/endnote stories (v1: body only).
+- Coverage-validator extension for the `cross-implementation-conformance` capability (tracked in #390).

--- a/openspec/changes/add-cross-implementation-conformance-suite/proposal.md
+++ b/openspec/changes/add-cross-implementation-conformance-suite/proposal.md
@@ -1,0 +1,26 @@
+# Change: Cross-implementation OOXML conformance suite (wpt-analog) and safe-docx adapter
+
+## Why
+
+Our traceability tests verify safe-docx's own behavior; they cannot show whether another OOXML library (python-docx, docx4j, LibreOffice) implements the same ECMA-376-anchored behavior the same way (issue #283). For the subset of scenarios whose assertions derive from the spec — not from our algorithm — a neutral, forkable, wpt.fyi-style comparison suite makes safe-docx defensible-by-spec rather than defensible-by-tests, and gives the wider ecosystem a shared conformance artifact.
+
+## What Changes
+
+- **New external repository `open-agreements/docx-platform-tests`** (public, BSD-3-Clause): the neutral suite. Holds the scenario DSL (`scenario.json` + `input/document.xml` + packed `input.docx`), the language-neutral adapter protocol (file-based CLI, exit code 2 = unsupported, the wpt-NOTRUN analog), a Node/TS runner (`@xmldom/xmldom` + `xpath`, no `@usejunior` dependency — the oracle stays neutral), and CI that publishes a wpt.fyi-shaped `results/latest.json`. Neutrality is the point: researchers fork the suite, not safe-docx.
+- **New docx-core bin `safe-docx-conformance-adapter`** (`packages/docx-core/src/cli/conformance-adapter.ts` + `package.json` bin entry): implements adapter protocol v1 over existing primitives (`acceptChanges`, `rejectChanges`, `getParagraphText`/`replaceParagraphTextRange`, `DocxDocument.load`/`toBuffer`). No engine-behavior changes; the adapter only wires existing exports.
+- **New skip-gated self-check test** `packages/docx-core/src/integration/cross-implementation-suite.test.ts`: runs the adapter against the suite's scenarios when `DOCX_PLATFORM_TESTS_DIR` is set (Lean-differential-harness gating pattern), pinned to a recorded suite SHA. safe-docx disagreeing with the suite's expected output fails CI.
+- **Cross-repo (informational, lands outside this repo):** a comparison-matrix page in `UseJunior/tests-renderer` consuming the suite's published results JSON (UseJunior/tests-renderer#62), and a `python-docx` adapter inside the suite repo demonstrating the asymmetric matrix row (find-replace pass; accept/reject honestly `unsupported`).
+
+## Scope guardrails
+
+- Only spec-anchored scenarios enter the suite (assertion derivable from ECMA-376, with MS-OE376/Word behavior canonical where they diverge). Algorithm-anchored behavior (`_bk_*` identifier stability, determinism guarantees, safe-docx-specific primitives) stays out, per #283.
+- `schemaValidAgainstWml` is a defined-but-deferred assertion kind: there is no viable pure-JS XSD validator for the full transitional schema and our own #214 is unimplemented; M1 ships two tracked-changes scenarios + one find-replace scenario instead.
+- One adapter per follow-up milestone; LibreOffice headless is a named stretch adapter, explicitly not in scope here.
+
+## Impact
+
+- Affected specs: new capability `cross-implementation-conformance` (ADDED requirements only — deliberately not a `docx-primitives`/`mcp-server` delta, whose coverage validators strict-fail unmapped scenarios in in-flight change deltas).
+- Affected code: `packages/docx-core/src/cli/conformance-adapter.ts` (new), `packages/docx-core/package.json` (bin entry), `packages/docx-core/src/integration/cross-implementation-suite.test.ts` (new), `packages/docx-core/src/integration/docx-platform-tests.pin.json` (new).
+- External: `open-agreements/docx-platform-tests` (new repo), `UseJunior/tests-renderer` (matrix page).
+- Sequencing note: the suite's safe-docx adapter installs from a pinned-SHA `npm pack` tarball until the first release after the bin lands publishes it to npm.
+- Milestone issues: #388 (M0, this change), #389 (M2 adapter + self-check), #390 (archive), #391 (optional corpus join field), UseJunior/tests-renderer#62 (M4). Tracking: #283.

--- a/openspec/changes/add-cross-implementation-conformance-suite/specs/cross-implementation-conformance/spec.md
+++ b/openspec/changes/add-cross-implementation-conformance-suite/specs/cross-implementation-conformance/spec.md
@@ -1,0 +1,40 @@
+# Cross-Implementation Conformance Delta
+
+## ADDED Requirements
+
+### Requirement: Conformance Adapter CLI
+
+docx-core SHALL ship a `safe-docx-conformance-adapter` executable implementing the docx-platform-tests adapter protocol v1: it MUST read an operation descriptor (`--operation operation.json`) and an input package (`--input input.docx`), apply the operation with existing docx-core primitives, and write the mutated package (`--output output.docx`), exiting 0. For an operation it does not implement, it MUST exit with code 2 and print a one-line reason — never fabricate output. Protocol-version mismatches MUST exit with code 3.
+
+#### Scenario: acceptAllTrackedChanges round-trip through the adapter
+
+- **WHEN** the adapter is invoked with protocol v1, an `acceptAllTrackedChanges` operation descriptor, and an input .docx whose body contains `w:ins`-wrapped runs
+- **THEN** it exits 0 and the output package's `word/document.xml` contains the formerly wrapped run content with no remaining `w:ins` wrappers, matching `acceptChanges` semantics (ECMA-376 edition 5, Part 1 § 17.13.5.18)
+
+#### Scenario: Unknown operation declined honestly
+
+- **WHEN** the adapter receives an operation descriptor whose `operationName` is outside its implemented set
+- **THEN** it exits with code 2, prints a one-line reason to stdout, and writes no output package
+
+### Requirement: Suite Self-Check Test
+
+docx-core SHALL include an integration test that executes the conformance adapter against every scenario in a local docx-platform-tests checkout (located via the `DOCX_PLATFORM_TESTS_DIR` environment variable) and fails if safe-docx's output violates any scenario assertion. When the checkout is absent the test MUST skip with a logged warning rather than fail, so developer machines without the suite stay green while CI — which provisions the checkout — keeps the gate live.
+
+#### Scenario: Suite checkout present and safe-docx agrees
+
+- **WHEN** `DOCX_PLATFORM_TESTS_DIR` points at a valid suite checkout and the adapter's outputs satisfy all scenario assertions
+- **THEN** the self-check test passes
+
+#### Scenario: Suite checkout absent
+
+- **WHEN** `DOCX_PLATFORM_TESTS_DIR` is unset or names a missing directory
+- **THEN** the self-check suite is skipped and a warning identifying the skip reason is logged
+
+### Requirement: Pinned Suite Revision
+
+The self-check SHALL record the docx-platform-tests revision it was validated against in a committed pin file (`docx-platform-tests.pin.json`). A checkout whose HEAD differs from the pin MUST produce a warning naming both SHAs while the test still runs, and CI MUST clone the suite at the pinned revision so gate results are reproducible.
+
+#### Scenario: Checkout ahead of the pin
+
+- **WHEN** the self-check runs against a suite checkout whose HEAD SHA differs from the pinned SHA
+- **THEN** the test logs a warning naming the pinned and actual SHAs and still executes the scenarios

--- a/openspec/changes/add-cross-implementation-conformance-suite/tasks.md
+++ b/openspec/changes/add-cross-implementation-conformance-suite/tasks.md
@@ -1,0 +1,29 @@
+## 1. Suite repository (open-agreements/docx-platform-tests — M1)
+
+- [ ] 1.1 Create public repo with BSD-3-Clause LICENSE, README (WordprocessingML conformance scope), CONTRIBUTING
+- [ ] 1.2 Write `docs/scenario-dsl.md` (DSL v1.0: operations enum, assertion kinds incl. deferred `schemaValidAgainstWml`, text-projection and match-scope rules, weakest-assertion authoring rule) and `docs/adapter-protocol.md` (protocol v1, exit codes)
+- [ ] 1.3 Author the 3 M1 scenarios (`acceptInsertionsUnwrapsInsWrappers`, `acceptDeletionsRemovesDelContent`, `replaceFirstOccurrencePreservesOffsets`) with `scenario.json`, `input/document.xml`, packed `input.docx`, expected outputs
+- [ ] 1.4 Build the runner (`@xmldom/xmldom` + `xpath` + zip; canonicalizer with rsid-stripping and `mergeAdjacentIdenticalRuns`; results JSON writer) and the fixture-sync check
+- [ ] 1.5 CI workflow `run-suite.yml` (push + weekly cron) publishing `results/latest.json` to gh-pages
+- [ ] 1.6 File the suite repo's M1/M3 issues; `registry/adapters.json` scaffold
+
+## 2. safe-docx adapter + self-check (M2, issue #389)
+
+- [ ] 2.1 `packages/docx-core/src/cli/conformance-adapter.ts` (shebang entrypoint; protocol v1; wires `acceptChanges`, `rejectChanges`, `getParagraphText`/`replaceParagraphTextRange`, `DocxDocument.load`/`toBuffer`; exit 2 for unknown operations)
+- [ ] 2.2 `"safe-docx-conformance-adapter"` bin entry in `packages/docx-core/package.json`
+- [ ] 2.3 Self-check test `packages/docx-core/src/integration/cross-implementation-suite.test.ts` with `DOCX_PLATFORM_TESTS_DIR` skip-gate, `docx-platform-tests.pin.json`, `TEST_FEATURE`, single-line `.openspec()` tags, `.conformance()` citations
+- [ ] 2.4 Pre-submit gates green: build, lint:workspaces, test:run, check:spec-coverage, check:conformance-citations, check:conformance-doc
+
+## 3. Suite adapters (M2/M3)
+
+- [ ] 3.1 `adapters/safe-docx/` wrapper installing the pinned-SHA `npm pack` tarball; all 3 scenarios `pass` (self-check: safe-docx vs suite expected)
+- [ ] 3.2 `adapters/python-docx/` (pip-installable; intra-run find-replace; accept/reject exit 2 `unsupported`)
+- [ ] 3.3 Flip the safe-docx adapter to the published npm bin after the next release train
+
+## 4. Renderer (M4, UseJunior/tests-renderer#62)
+
+- [ ] 4.1 Standalone Starlight matrix page consuming the suite's gh-pages `results/latest.json`, keyed by suite scenario id
+
+## 5. Archive (issue #390)
+
+- [ ] 5.1 `openspec archive add-cross-implementation-conformance-suite --yes` in its own PR after deployment; consider coverage-validator extension for the new capability


### PR DESCRIPTION
## Why

Our traceability tests certify safe-docx only. Issue #283 scoped a wpt.fyi-style cross-implementation comparison for the ECMA-376-anchored subset of our scenarios; this PR is its M0 deliverable — the OpenSpec proposal resolving the open questions. Spec/docs only, no code.

## What

OpenSpec change `add-cross-implementation-conformance-suite`:

- **proposal.md / design.md** — decisions: neutral suite repo `open-agreements/docx-platform-tests` (BSD-3, forkable without forking safe-docx); scenario DSL = XML pairs + assertion language (`xpathQueryCount`, `documentTextContainsAtOffset` with a pinned text projection, `canonicalXmlEquals` with `mergeAdjacentIdenticalRuns`, deferred `schemaValidAgainstWml`); file-based adapter protocol v1 with exit-code-2 `unsupported` (wpt-NOTRUN analog); M1 swaps the schema-validation scenario for a second tracked-changes scenario (no viable pure-JS XSD validator; #214 still open); npm sequencing via pinned-SHA tarball until the adapter bin is released.
- **specs/cross-implementation-conformance/spec.md** — new capability (deliberately not a `docx-primitives`/`mcp-server` delta: those coverage validators strict-fail unmapped scenarios in in-flight deltas). Requirements: Conformance Adapter CLI, Suite Self-Check Test, Pinned Suite Revision.
- **tasks.md** — M1–M4 + archive checklist mapped to the milestone issues.

The plan behind this was peer-reviewed pre-approval (codex + agy); their blockers (npm-bin sequencing, delta format, find-replace match-scope ambiguity) are folded in.

## Verification

- `openspec validate add-cross-implementation-conformance-suite --strict` ✅
- `npm run check:spec-coverage` / `check:conformance-citations` / `check:conformance-doc` all exit 0 ✅

Ref: #283
Closes: #388

## Milestones

M0: this PR · M1/M3: suite repo · M2: #389 · M4: UseJunior/tests-renderer#62 · archive: #390