### PR TITLE
feat(docx-core): conformance adapter bin + docx-platform-tests self-check (M2 of #283)

### DIFF
--- a/packages/docx-core/package.json
+++ b/packages/docx-core/package.json
@@ -63,6 +63,7 @@
   "license": "MIT",
   "bin": {
     "docx-comparison": "dist/cli/index.js",
-    "safe-docx-compare": "dist/cli/index.js"
+    "safe-docx-compare": "dist/cli/index.js",
+    "safe-docx-conformance-adapter": "dist/cli/conformance-adapter.js"
   }
 }

--- a/packages/docx-core/src/cli/conformance-adapter.ts
+++ b/packages/docx-core/src/cli/conformance-adapter.ts
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+/**
+ * docx-platform-tests adapter protocol v1 entrypoint.
+ *
+ * Invoked by the suite runner as:
+ *   safe-docx-conformance-adapter --protocol-version 1 \
+ *     --operation operation.json --input input.docx --output output.docx
+ *
+ * Exit codes (per the suite's docs/adapter-protocol.md):
+ *   0 success, 1 error, 2 unsupported operation, 3 protocol mismatch.
+ * Declining with 2 is mandatory for operations outside the implemented
+ * set — the suite's design treats honest gaps as data, never approximate.
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+import { DocxDocument } from '../primitives/document.js';
+import { getParagraphText, replaceParagraphTextRange } from '../primitives/text.js';
+
+const SUPPORTED_PROTOCOL_VERSION = '1';
+const SUPPORTED_OPERATIONS = new Set([
+  'acceptAllTrackedChanges',
+  'rejectAllTrackedChanges',
+  'replaceFirstTextOccurrence',
+]);
+
+interface OperationDescriptor {
+  operationName: string;
+  findText?: string;
+  replaceText?: string;
+}
+
+function argValue(argv: string[], flag: string): string | undefined {
+  const idx = argv.indexOf(flag);
+  return idx !== -1 ? argv[idx + 1] : undefined;
+}
+
+export async function runConformanceAdapter(argv: string[]): Promise<number> {
+  const protocolVersion = argValue(argv, '--protocol-version');
+  const operationPath = argValue(argv, '--operation');
+  const inputPath = argValue(argv, '--input');
+  const outputPath = argValue(argv, '--output');
+
+  if (protocolVersion !== SUPPORTED_PROTOCOL_VERSION) {
+    console.log(
+      `safe-docx-conformance-adapter speaks protocol v${SUPPORTED_PROTOCOL_VERSION}, got ${protocolVersion ?? 'none'}`
+    );
+    return 3;
+  }
+  if (!operationPath || !inputPath || !outputPath) {
+    console.error('usage: --protocol-version 1 --operation <json> --input <docx> --output <docx>');
+    return 1;
+  }
+
+  const operation = JSON.parse(readFileSync(operationPath, 'utf8')) as OperationDescriptor;
+  // Decline before touching the input: unsupported must not depend on the
+  // document being readable.
+  if (!SUPPORTED_OPERATIONS.has(operation.operationName)) {
+    console.log(`safe-docx adapter does not implement operation '${operation.operationName}'`);
+    return 2;
+  }
+  const doc = await DocxDocument.load(readFileSync(inputPath));
+
+  switch (operation.operationName) {
+    case 'acceptAllTrackedChanges':
+      await doc.acceptChanges();
+      break;
+    case 'rejectAllTrackedChanges':
+      await doc.rejectChanges();
+      break;
+    case 'replaceFirstTextOccurrence': {
+      const { findText, replaceText } = operation;
+      if (typeof findText !== 'string' || typeof replaceText !== 'string') {
+        console.error('replaceFirstTextOccurrence requires findText and replaceText');
+        return 1;
+      }
+      // DSL 1.0 match scope: first paragraph-local occurrence in document
+      // order; the replacement is a plain edit, not a tracked change.
+      const paragraph = doc
+        .getParagraphs()
+        .find((p) => getParagraphText(p).includes(findText));
+      if (!paragraph) {
+        console.error(`findText not present in any paragraph: ${JSON.stringify(findText)}`);
+        return 1;
+      }
+      const start = getParagraphText(paragraph).indexOf(findText);
+      replaceParagraphTextRange(paragraph, start, start + findText.length, replaceText);
+      break;
+    }
+    default:
+      // Unreachable: membership was checked above.
+      return 2;
+  }
+
+  const { buffer } = await doc.toBuffer();
+  writeFileSync(outputPath, buffer);
+  return 0;
+}
+
+if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) {
+  runConformanceAdapter(process.argv.slice(2))
+    .then((code) => process.exit(code))
+    .catch((err) => {
+      console.error(err?.message ?? String(err));
+      process.exit(1);
+    });
+}

--- a/packages/docx-core/src/cli/conformance-adapter.ts
+++ b/packages/docx-core/src/cli/conformance-adapter.ts
@@ -11,7 +11,7 @@
  * Declining with 2 is mandatory for operations outside the implemented
  * set — the suite's design treats honest gaps as data, never approximate.
  */
-import { readFileSync, writeFileSync } from 'node:fs';
+import { readFileSync, realpathSync, writeFileSync } from 'node:fs';
 import { pathToFileURL } from 'node:url';
 import { DocxDocument } from '../primitives/document.js';
 import { getParagraphText, replaceParagraphTextRange } from '../primitives/text.js';
@@ -96,7 +96,9 @@ export async function runConformanceAdapter(argv: string[]): Promise<number> {
   return 0;
 }
 
-if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) {
+// realpathSync: when invoked through the node_modules/.bin symlink,
+// process.argv[1] is the symlink while import.meta.url is the real file.
+if (process.argv[1] && pathToFileURL(realpathSync(process.argv[1])).href === import.meta.url) {
   runConformanceAdapter(process.argv.slice(2))
     .then((code) => process.exit(code))
     .catch((err) => {

--- a/packages/docx-core/src/integration/cross-implementation-suite.test.ts
+++ b/packages/docx-core/src/integration/cross-implementation-suite.test.ts
@@ -1,0 +1,223 @@
+/**
+ * docx-platform-tests self-check (cross-implementation conformance suite).
+ *
+ * Drives the REAL suite runner (open-agreements/docx-platform-tests) against
+ * the safe-docx conformance adapter (`src/cli/conformance-adapter.ts`) via a
+ * temporary adapter registry, and asserts every suite scenario reports
+ * `pass`. safe-docx disagreeing with a suite expectation fails this test —
+ * the suite's assertions derive from cited ECMA-376 clauses, so a failure
+ * here is a conformance finding, not a flake.
+ *
+ * Gating (Lean-differential-harness pattern): the suite checkout is located
+ * via the DOCX_PLATFORM_TESTS_DIR environment variable; when it is unset,
+ * missing, or its runner dependencies are not installed, the gated suite is
+ * SKIPPED with a clear message so `npm test` stays green on machines without
+ * the checkout. CI clones the suite at the SHA recorded in
+ * `docx-platform-tests.pin.json`; a checkout at a different SHA warns (both
+ * SHAs named) but still runs.
+ *
+ * The protocol-behavior tests (unsupported operation → exit 2, protocol
+ * mismatch → exit 3) need no suite checkout and always run.
+ */
+
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+
+// Named const (not an inline literal) so `scripts/validate_allure_test_labels.mjs`
+// can map the `.openspec([XIMPL-*])` tags deterministically to a feature.
+const TEST_FEATURE = 'Cross-Implementation Conformance Suite';
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({ feature: TEST_FEATURE })
+  .conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.5' });
+
+const INTEGRATION_DIR = dirname(import.meta.url.replace('file://', ''));
+const PROJECT_ROOT = join(INTEGRATION_DIR, '../../../..');
+const ADAPTER_ENTRY = join(INTEGRATION_DIR, '../cli/conformance-adapter.ts');
+const TSX_BIN = join(PROJECT_ROOT, 'node_modules/.bin/tsx');
+const PIN_FILE = join(INTEGRATION_DIR, 'docx-platform-tests.pin.json');
+
+const SUITE_DIR = process.env.DOCX_PLATFORM_TESTS_DIR ?? '';
+const RUNNER_TSX = SUITE_DIR ? join(SUITE_DIR, 'runner/node_modules/.bin/tsx') : '';
+
+interface SuiteResults {
+  results: Array<{
+    scenarioId: string;
+    outcomes: Record<
+      string,
+      {
+        status: string;
+        reason?: string;
+        assertionResults?: Array<{ assertionKind: string; passed: boolean; detail: string }>;
+      }
+    >;
+  }>;
+}
+
+const suiteAvailable =
+  SUITE_DIR !== '' && existsSync(SUITE_DIR) && existsSync(RUNNER_TSX);
+if (!suiteAvailable) {
+  console.warn(
+    '[cross-implementation-suite] SKIP: set DOCX_PLATFORM_TESTS_DIR to a ' +
+      'docx-platform-tests checkout with runner dependencies installed ' +
+      '(git clone open-agreements/docx-platform-tests && cd runner && npm ci).',
+  );
+}
+const describeMaybe = suiteAvailable ? describe : describe.skip;
+
+function warnOnPinMismatch(): void {
+  const pin = JSON.parse(readFileSync(PIN_FILE, 'utf8')) as { pinnedCommitSha: string };
+  const head = spawnSync('git', ['-C', SUITE_DIR, 'rev-parse', 'HEAD'], { encoding: 'utf8' });
+  const actualSha = head.status === 0 ? head.stdout.trim() : 'unknown';
+  if (actualSha !== pin.pinnedCommitSha) {
+    console.warn(
+      `[cross-implementation-suite] suite checkout is at ${actualSha}, pinned ${pin.pinnedCommitSha}; running anyway`,
+    );
+  }
+}
+
+describeMaybe('Cross-implementation conformance suite self-check', () => {
+  test
+    .openspec('[XIMPL-01] Suite checkout present and safe-docx agrees')
+    .openspec('[XIMPL-02] Suite checkout absent skips with a logged warning')
+    .openspec('[XIMPL-03] Checkout ahead of the pin warns and still runs')
+    .openspec('[XIMPL-04] acceptAllTrackedChanges round-trip through the adapter')(
+    'safe-docx adapter passes every docx-platform-tests scenario',
+    async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
+      const workDir = mkdtempSync(join(tmpdir(), 'ximpl-'));
+      try {
+        const registryPath = join(workDir, 'adapters.json');
+        const resultsPath = join(workDir, 'results.json');
+        let results: SuiteResults = { results: [] };
+
+        await given('a temp registry pointing the suite runner at the safe-docx adapter', async () => {
+          warnOnPinMismatch();
+          writeFileSync(
+            registryPath,
+            JSON.stringify({
+              protocolVersion: 1,
+              adapters: [
+                { adapterName: 'safe-docx', adapterCommand: [TSX_BIN, ADAPTER_ENTRY] },
+              ],
+            }),
+          );
+        });
+
+        await when('the real suite runner executes every scenario through the adapter', async () => {
+          const run = spawnSync(
+            RUNNER_TSX,
+            ['src/run.ts', '--registry', registryPath, '--results', resultsPath],
+            { cwd: join(SUITE_DIR, 'runner'), encoding: 'utf8', timeout: 120_000 },
+          );
+          expect(run.status, `runner failed:\n${run.stdout}\n${run.stderr}`).toBe(0);
+          results = JSON.parse(readFileSync(resultsPath, 'utf8')) as SuiteResults;
+          await attachPrettyJson('suite-results', results);
+        });
+
+        await then('every scenario outcome for safe-docx is pass', async () => {
+          expect(results.results.length).toBeGreaterThan(0);
+          const failures = results.results
+            .map((scenario) => ({ scenario, outcome: scenario.outcomes['safe-docx'] }))
+            .filter(({ outcome }) => outcome?.status !== 'pass');
+          const detail = failures
+            .map(
+              ({ scenario, outcome }) =>
+                `${scenario.scenarioId}: ${outcome?.status ?? 'missing'} ` +
+                (outcome?.reason ?? '') +
+                (outcome?.assertionResults ?? [])
+                  .filter((a) => !a.passed)
+                  .map((a) => `\n  ${a.assertionKind}: ${a.detail}`)
+                  .join(''),
+            )
+            .join('\n');
+          expect(failures.length, detail).toBe(0);
+        });
+      } finally {
+        rmSync(workDir, { recursive: true, force: true });
+      }
+    },
+    180_000,
+  );
+});
+
+describe('Conformance adapter protocol behavior', () => {
+  test.openspec('[XIMPL-05] Unknown operation declined honestly with exit code 2')(
+    'unknown operations exit 2 with a one-line reason and no output',
+    async ({ given, when, then }: AllureBddContext) => {
+      const workDir = mkdtempSync(join(tmpdir(), 'ximpl-proto-'));
+      try {
+        const operationPath = join(workDir, 'operation.json');
+        const outputPath = join(workDir, 'output.docx');
+        let result: SpawnSyncReturns<string>;
+
+        await given('an operation descriptor outside the implemented set', async () => {
+          writeFileSync(operationPath, JSON.stringify({ operationName: 'rewriteEntireDocumentInLatin' }));
+        });
+
+        await when('the adapter is invoked with protocol v1', async () => {
+          result = spawnSync(
+            TSX_BIN,
+            [
+              ADAPTER_ENTRY,
+              '--protocol-version', '1',
+              '--operation', operationPath,
+              '--input', join(workDir, 'does-not-exist.docx'),
+              '--output', outputPath,
+            ],
+            { encoding: 'utf8', timeout: 60_000 },
+          );
+        });
+
+        await then('it exits 2, explains itself on stdout, and writes nothing', async () => {
+          expect(result!.status, result!.stderr).toBe(2);
+          expect(result!.stdout.trim()).toContain('does not implement');
+          expect(existsSync(outputPath)).toBe(false);
+        });
+      } finally {
+        rmSync(workDir, { recursive: true, force: true });
+      }
+    },
+    60_000,
+  );
+
+  test.openspec('[XIMPL-06] Protocol version mismatch exits with code 3')(
+    'an unknown protocol version exits 3',
+    async ({ given, when, then }: AllureBddContext) => {
+      const workDir = mkdtempSync(join(tmpdir(), 'ximpl-ver-'));
+      try {
+        const operationPath = join(workDir, 'operation.json');
+        let result: SpawnSyncReturns<string>;
+
+        await given('a valid operation descriptor', async () => {
+          writeFileSync(operationPath, JSON.stringify({ operationName: 'acceptAllTrackedChanges' }));
+        });
+
+        await when('the adapter is invoked with protocol v999', async () => {
+          result = spawnSync(
+            TSX_BIN,
+            [
+              ADAPTER_ENTRY,
+              '--protocol-version', '999',
+              '--operation', operationPath,
+              '--input', join(workDir, 'unused.docx'),
+              '--output', join(workDir, 'unused-out.docx'),
+            ],
+            { encoding: 'utf8', timeout: 60_000 },
+          );
+        });
+
+        await then('it exits 3 and names the protocol it speaks', async () => {
+          expect(result!.status, result!.stderr).toBe(3);
+          expect(result!.stdout).toContain('protocol v1');
+        });
+      } finally {
+        rmSync(workDir, { recursive: true, force: true });
+      }
+    },
+    60_000,
+  );
+});

--- a/packages/docx-core/src/integration/docx-platform-tests.pin.json
+++ b/packages/docx-core/src/integration/docx-platform-tests.pin.json
@@ -1,4 +1,4 @@
 {
   "repository": "open-agreements/docx-platform-tests",
-  "pinnedCommitSha": "ed93596e05d8ea0fe66d371b64ba6bb8cf8d6a43"
+  "pinnedCommitSha": "bbf891847fdad142737346eabfb530694e530187"
 }

--- a/packages/docx-core/src/integration/docx-platform-tests.pin.json
+++ b/packages/docx-core/src/integration/docx-platform-tests.pin.json
@@ -1,0 +1,4 @@
+{
+  "repository": "open-agreements/docx-platform-tests",
+  "pinnedCommitSha": "ed93596e05d8ea0fe66d371b64ba6bb8cf8d6a43"
+}


### PR DESCRIPTION
## Why

M2 of #283: safe-docx participates in the cross-implementation conformance suite ([open-agreements/docx-platform-tests](https://github.com/open-agreements/docx-platform-tests)) as one implementation among several. Design in the M0 OpenSpec change (#392).

## What

- **`safe-docx-conformance-adapter` bin** (`packages/docx-core/src/cli/conformance-adapter.ts` + bin entry): adapter protocol v1. Wires existing exports only — `DocxDocument.load/acceptChanges/rejectChanges/getParagraphs/toBuffer`, `getParagraphText` + `replaceParagraphTextRange` (paragraph-local first occurrence, plain edit). Exit codes: 0 success / 1 error / **2 unsupported** (declined before touching the input) / 3 protocol mismatch.
- **Self-check test** (`src/integration/cross-implementation-suite.test.ts`): spawns the suite's real runner with a temp registry pointing at the adapter; asserts every scenario outcome is `pass`. Skip-gated on `DOCX_PLATFORM_TESTS_DIR` exactly like the Lean differential harness; suite SHA pinned in `docx-platform-tests.pin.json` (mismatch warns, absence skips, disagreement fails). Two ungated protocol tests cover exit codes 2 and 3.

## Verification

- Self-check against the suite checkout: **3/3 scenarios pass** through the real runner (acceptInsertionsUnwrapsInsWrappers § 17.13.5.18, acceptDeletionsRemovesDelContent § 17.13.5.14, replaceFirstOccurrencePreservesOffsets).
- Without the checkout: gated suite skips with a logged warning; 2 protocol tests still pass.
- Gates: build ✅ lint:workspaces ✅ (0 errors) test:run ✅ (all workspaces) check:spec-coverage ✅ check:conformance-citations ✅ check:conformance-doc ✅ validate_allure_test_labels ✅

## Notes

- The suite's `adapters/safe-docx/` registration consumes this bin from a pinned-SHA `npm pack` tarball until the next release publishes it (open-agreements/docx-platform-tests#1, #3).

Ref: #283
Fixes: #389