### PR TITLE
ci(release): pack all publishable packages into the preflight runtime smoke

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,15 +170,21 @@ jobs:
         run: |
           pack_dir="$(mktemp -d)"
           run_dir="$(mktemp -d)"
-          core_tgz="$(cd packages/docx-core && npm pack --silent --pack-destination "$pack_dir")"
-          mcp_tgz="$(cd packages/docx-mcp && npm pack --silent --pack-destination "$pack_dir")"
-          safe_tgz="$(cd packages/safe-docx && npm pack --silent --pack-destination "$pack_dir")"
+          # Pack ALL publishable packages (same list as publish-suite): any
+          # same-version workspace dep must resolve from a local tarball, not
+          # the registry — at preflight time this run's versions aren't on npm
+          # yet, so a registry fallback always ETARGETs (issue #395).
+          tarballs=()
+          for pkg in packages/docx-core packages/odf-core packages/docx-mcp packages/google-docs-core packages/safe-docx; do
+            tgz="$(cd "$pkg" && npm pack --silent --pack-destination "$pack_dir")"
+            tarballs+=("$pack_dir/$tgz")
+          done
           pushd "$run_dir"
           npm init -y >/dev/null
           for attempt in 1 2 3; do
             echo "runtime smoke attempt ${attempt}/3"
             rm -rf node_modules package-lock.json
-            if npm install --no-audit --no-fund "$pack_dir/$core_tgz" "$pack_dir/$mcp_tgz" "$pack_dir/$safe_tgz" >/dev/null \
+            if npm install --no-audit --no-fund "${tarballs[@]}" >/dev/null \
               && ./node_modules/.bin/safe-docx --help; then
               popd
               rm -rf "$pack_dir" "$run_dir"

--- a/scripts/check-release-isolation.mjs
+++ b/scripts/check-release-isolation.mjs
@@ -62,6 +62,15 @@ export const EXPECTED_LOOPS = [
     'packages/google-docs-core',
     'packages/safe-docx',
   ],
+  // "Isolated package runtime smoke test" — pack every publishable so
+  // same-version workspace deps resolve from local tarballs (issue #395)
+  [
+    'packages/docx-core',
+    'packages/odf-core',
+    'packages/docx-mcp',
+    'packages/google-docs-core',
+    'packages/safe-docx',
+  ],
   // "Publish to npm (trusted publishing)" — name:dir pairs
   [
     '@usejunior/docx-core',

--- a/scripts/check-release-isolation.test.mjs
+++ b/scripts/check-release-isolation.test.mjs
@@ -58,7 +58,7 @@ test('odf-core is on every release loop and the publish surface', () => {
 
 test('snapshot flags a wrong loop count', () => {
   const errors = diffWorkflowSnapshot(EXPECTED_LOOPS.slice(0, 3));
-  assert.ok(errors.some((e) => /package loop\(s\); expected 4/.test(e)));
+  assert.ok(errors.some((e) => /package loop\(s\); expected 5/.test(e)));
 });
 
 // ── diffPublishListPrivate ──────────────────────────────────────────────────


### PR DESCRIPTION
## Why

The v0.10.0 release (run 27315171055, tag pushed per #381) died in preflight's **Isolated package runtime smoke test**: `npm error notarget No matching version found for @usejunior/odf-core@^0.10.0`. All publish jobs skipped — nothing partial shipped.

The smoke packs only `docx-core` + `docx-mcp` + `safe-docx` into a clean temp install. `docx-mcp@0.10.0` gained an `@usejunior/odf-core@^0.10.0` dependency during 0.10.0 development, so npm fell through to the public registry for it — which can never have this run's version, because `publish-suite` publishes it later in the same workflow. Chicken-and-egg: preflight can't see the version it gates (#395).

## What

Pack the same five packages `publish-suite` publishes (`docx-core`, `odf-core`, `docx-mcp`, `google-docs-core`, `safe-docx`) so every same-version workspace dep resolves from a local tarball, never the registry. The list now mirrors the publish list instead of a hand-picked subset, so a future workspace-dep addition can't recreate this failure.

## Verification

- `actionlint` clean.
- Replicated the fixed smoke locally at 0.10.0: five-tarball isolated install succeeds, `safe-docx --help` runs. The three-tarball form reproduces the CI ETARGET exactly.

## After merge

Re-dispatch the stranded release (workflow definition from main, code from the tag):

```
gh workflow run release.yml -f release_tag=v0.10.0
```

Fixes #395
Ref: #381