### PR TITLE
fix(safe-docx): keep server.json description within the MCP registry's 100-char cap

### DIFF
--- a/packages/safe-docx/server.json
+++ b/packages/safe-docx/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.UseJunior/safe-docx",
   "title": "Safe Docx",
-  "description": "AI-native surgical editing of existing Word .docx and OpenDocument .odt files with formatting preservation",
+  "description": "AI-native surgical editing of Word .docx and OpenDocument .odt files with formatting preservation",
   "version": "0.10.0",
   "websiteUrl": "https://usejunior.com/developer-tools/safe-docx",
   "icons": [

--- a/scripts/bump_version.mjs
+++ b/scripts/bump_version.mjs
@@ -86,6 +86,18 @@ function checkVersionSync() {
     console.error('  server.json packages[0].version mismatch');
     ok = false;
   }
+  // The official MCP registry rejects publishes whose description exceeds
+  // 100 chars (422 at publish time, after npm has already shipped). Gate it
+  // here: --check runs at bump time and in the auto-tag workflow, before the
+  // release tag exists.
+  const REGISTRY_DESCRIPTION_MAX = 100;
+  if ((serverJson.description ?? '').length > REGISTRY_DESCRIPTION_MAX) {
+    console.error(
+      `  server.json description is ${serverJson.description.length} chars; ` +
+        `the MCP registry caps it at ${REGISTRY_DESCRIPTION_MAX}`,
+    );
+    ok = false;
+  }
 
   const uniqueVersions = new Set(versions.values());
   if (uniqueVersions.size === 1) {


### PR DESCRIPTION
## Why

The v0.10.0 release (run 27320528842) published npm fine but the MCP registry rejected `server.json` with `422 expected length <= 100` on `description` (ours: 106 chars, grown post-0.9.1). Registry `isLatest` is stranded at 0.9.1 while npm is at 0.10.0 — the exact partial-publish drift #381 anticipated. Nothing validated the registry's schema limit before publish time. (#399)

## What

- `packages/safe-docx/server.json`: description shortened 106 → 97 chars (drops "existing"; keeps Word/.docx + OpenDocument/.odt naming).
- `scripts/bump_version.mjs --check`: new assertion fails when the description exceeds 100 chars. `--check` gates the auto-tag workflow (#385) and runs at bump time, so this now fails before a release tag exists, never mid-release.

## Verification

- `node scripts/bump_version.mjs --check` passes at 97 chars.
- Negative test: with a 101-char description the check prints `server.json description is 101 chars; the MCP registry caps it at 100` and exits 1.

## After merge

Manual registry remediation for the stranded 0.10.0 entry (re-dispatching release.yml would trip the duplicate-publish guard), per `docs/release-runbook.md`:

```
mcp-publisher login github
mcp-publisher publish packages/safe-docx/server.json
```

Fixes #399
Ref: #381