### PR TITLE
feat: native DOCX → ODT conversion (convertDocxToOdt + convert_to_odt tool)

### DIFF
--- a/openspec/changes/add-docx-to-odf-conversion/design.md
+++ b/openspec/changes/add-docx-to-odf-conversion/design.md
@@ -1,0 +1,64 @@
+# Design: Native DOCX → ODT conversion
+
+## Context
+Issue #331. Two viable approaches were weighed: (1) native model-to-model mapping, (2) shelling out
+to LibreOffice headless. (2) is rejected for the shipped path — it violates the Node/TS-only
+runtime convention and is not viable for the local-first MCP distribution — but is retained as a
+**test oracle**: the differential test converts the same `.docx` via both paths and diffs visible
+text + structure (never bytes).
+
+## Goals / Non-Goals
+- Goals: valid `.odt` output (opens cleanly in LibreOffice, passes `validateOdfArchiveSafety`);
+  visible text + paragraph/heading/list/table structure preserved; bold/italic/underline and
+  hyperlinks preserved; explicit lossiness reporting; no new runtime dependency.
+- Non-Goals: pixel/byte fidelity; tracked changes; comments; headers/footers/footnotes; richer
+  style mapping (fonts, colors, spacing); `.ods`/`.odp`.
+
+## Decisions
+- **Traverse `DocumentViewNode[]`, not raw OOXML DOM.** The view model already computes headings,
+  list metadata, grid-aware table context, and an inline-tag string (`tagged_text`); the markdown,
+  plaintext, and HTML serializers all traverse it. Re-deriving from `w:p`/`w:r` would duplicate
+  heading/list/table/hyperlink logic. Tokenize `tagged_text` with the shared `tokenizeToonInline`
+  so the converter never re-derives the tag grammar.
+- **`formattingMode: 'full'`.** The default `'compact'` mode suppresses modal (document-dominant)
+  formatting, which would silently drop bold/italic/underline on documents whose body is mostly
+  bold. The `<font …>` tags full mode additionally emits are recognized-and-dropped with lossiness
+  entries (b/i/u-only is the confirmed scope).
+- **Manual/legal list labels become plain `text:p` with the literal label.** Deliberate divergence
+  from the HTML serializer (which wraps them in `<ul><li>` with the label prepended): an ODF
+  renderer applies list numbering itself, so wrapping a "Section 2.1(a)" paragraph in `text:list`
+  would render a second, conflicting number next to the legal label.
+- **Tables: fill grid gaps, don't claim merge detection.** `table_context` exposes no
+  `gridSpan`/`vMerge`, so merged cells are indistinguishable from empty grid positions; the
+  lossiness entry says "table grid gaps filled with empty cells". One shared bordered cell style is
+  applied (the view model carries no border info; most Word tables are bordered).
+- **Fresh package assembly via `OdfArchive.create()`** reusing `save()`'s proven mimetype-first +
+  STORED rebuild; roots carry `office:version="1.3"` (strict validators reject packages without
+  it). `create()` output must round-trip `OdfArchive.load()`.
+- **Numbering access**: `DocxDocument` gains a public `getNumberingModel()` (wrapping
+  `parseNumberingXml`) because `DocumentViewNode.numbering` only carries `num_id`/`ilvl` and the
+  converter needs `numFmt`/`lvlText`/`start` to synthesize `text:list-style`s.
+- **MCP tool is `file_path`-first only** (no `session_id`): `resolveSessionForTool` is
+  file-path-keyed; declaring an unresolved `session_id` param (as `export.ts` does) would be a
+  contract lie.
+- **Hyperlink hrefs are XML-unescaped before `setAttributeNS`** (the TOON attribute value is
+  escaped by `emitFormattingTags`; assigning it raw would double-escape `&amp;`), and unsafe
+  schemes degrade to plain text via the shared `isSafeHref`.
+
+## Risks / Trade-offs
+- LibreOffice rejects the package (mimetype order, manifest media-types) → `create()` reuses the
+  proven rebuild discipline; the differential oracle test catches regressions.
+- soffice installed but unusable (observed: `Abort trap: 6` on the dev machine) → oracle tests gate
+  on a trivial preflight probe and skip with a logged warning, not just `resolveSoffice()`.
+- `tagged_text` grammar drift → tokenizer is shared with the docx-core emitters; unknown tags
+  degrade to text + lossiness entry, never throw.
+- ODF whitespace collapsing → dedicated `text:s`/`text:tab` writer; equivalence tests compare
+  through `OdfDocument`'s segment expansion which already decodes these.
+- Numbering continuation across interleaved content is not preserved (each contiguous list run
+  restarts) → accepted lossy, recorded in the report.
+
+## Migration Plan
+Purely additive — no existing API or tool changes shape. Rollback is deleting the new module/tool.
+
+## Open Questions
+- None blocking. Richer style mapping (phase 3 of #331) will follow as its own change.

--- a/openspec/changes/add-docx-to-odf-conversion/proposal.md
+++ b/openspec/changes/add-docx-to-odf-conversion/proposal.md
@@ -1,0 +1,47 @@
+# Change: Native DOCX → ODT conversion (`convertDocxToOdt` + `convert_to_odt`)
+
+## Why
+Germany's IT-Planungsrat ODF mandate creates demand for converting existing `.docx` corpora to
+`.odt`, and the repo already owns both halves of the problem: `@usejunior/docx-core` parses `.docx`
+into a rich semantic model and `@usejunior/odf-core` (#328) packages and edits valid `.odt` files.
+Nothing connects them today — converting requires LibreOffice, which violates the repo's
+Node/TypeScript-only runtime convention. A native model-to-model converter closes the loop
+(issue #331) and gives agents a `convert_to_odt` MCP tool.
+
+## What Changes
+- `@usejunior/odf-core`: new `src/convert/` module exporting
+  `convertDocxToOdt(docx: Buffer, options?) → Promise<{ odt: Buffer; lossiness: LossinessEntry[] }>`.
+  The converter traverses `DocxDocument.buildDocumentView({ showFormatting: true, formattingMode: 'full' })`
+  — the same intentionally-lossy semantic path as the markdown/html serializers — and emits:
+  - body paragraphs (`text:p`) and Word-style headings (`text:h` with `text:outline-level`, clamped 1–6);
+  - bold/italic/underline runs as `text:span` referencing deduped automatic text styles;
+  - hyperlinks as `text:a` (href-safety stance shared with the HTML serializer);
+  - auto-numbered/bullet lists as nested `text:list` with synthesized `text:list-style`s
+    (manual/legal labels stay literal paragraph text — a deliberate divergence from the HTML
+    serializer so ODF renderers never double-number legal labels);
+  - tables as `table:table` with a complete rectangular grid.
+  Every dropped construct is recorded in a lossiness report, never silently.
+- `@usejunior/odf-core`: `OdfArchive.create(parts)` static factory for fresh packages
+  (mimetype-first + STORED, generated `META-INF/manifest.xml`, `office:version="1.3"` roots);
+  `ODF_NS` gains `FO` and `XLINK`.
+- `@usejunior/docx-core` (enablers): public `getNumberingModel()` accessor on `DocxDocument`;
+  root re-exports for `isSafeHref`, `buildSyntheticDocx`, `buildDocxFromBodyXml`; a
+  DOCX-in→ODT-out conversion job shape for the LibreOffice oracle (test-only).
+- `@usejunior/docx-mcp`: new `convert_to_odt` tool (`file_path`, optional `output_path`,
+  `allow_overwrite`) that converts the resolved DOCX session, validates the output with
+  `validateOdfArchiveSafety`, and reports the lossiness summary. odf-core is reached only through
+  `loadOdfCore()` (`ODF_UNAVAILABLE` when absent).
+- LibreOffice remains test-only: a differential oracle test converts the same `.docx` both ways and
+  diffs visible text + structure, gated by a preflight probe (skips when soffice is absent or
+  present-but-unusable).
+
+## Impact
+- Affected specs: `odf-core` (ADDED: DOCX to ODT conversion, CONV-01..13); `mcp-server`
+  (ADDED: `convert_to_odt` tool, OCNV-01..05).
+- Affected code: `packages/odf-core/src/convert/*` (new), `packages/odf-core/src/shared/odf/{OdfArchive,namespaces}.ts`,
+  `packages/odf-core/src/index.ts`, `packages/docx-core/src/primitives/{document,serialize_html}.ts`,
+  `packages/docx-core/src/integration/libreoffice-oracle.ts`, `packages/docx-core/src/index.ts`,
+  `packages/docx-mcp/src/tools/convert_to_odt.ts` (new), `packages/docx-mcp/src/{tool_catalog,server}.ts`.
+- Out of scope (deferred, per issue #331 phasing): richer style fidelity, tracked changes,
+  comments, headers/footers/footnotes, `.ods`/`.odp`. Conversion is semantic, not byte- or
+  layout-perfect.

--- a/openspec/changes/add-docx-to-odf-conversion/specs/mcp-server/spec.md
+++ b/openspec/changes/add-docx-to-odf-conversion/specs/mcp-server/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: DOCX to ODT conversion tool (`convert_to_odt`)
+
+The MCP server SHALL provide a `convert_to_odt` tool that converts a DOCX document to an
+OpenDocument Text file using odf-core's native converter. The tool SHALL accept `file_path`
+(resolving or auto-opening the DOCX session by canonical path), an optional `output_path`
+(defaulting to the source path with an `.odt` extension), and `allow_overwrite`. The tool's
+description SHALL state that conversion is semantic and intentionally lossy.
+
+The tool SHALL refuse to write over the source document, SHALL refuse to overwrite an existing
+output file unless `allow_overwrite` is set, SHALL validate the converted package with
+`validateOdfArchiveSafety` before writing (refusing to write on failure), and SHALL reach odf-core
+only through the lazy `loadOdfCore()` provider loader, returning a structured `ODF_UNAVAILABLE`
+error when the provider cannot be loaded. On success it SHALL return the written path, bytes
+written, and the converter's lossiness summary.
+
+#### Scenario: [OCNV-01] convert_to_odt writes a valid .odt and reports lossiness
+- **WHEN** `convert_to_odt` is invoked with the `file_path` of a `.docx` and an `output_path`
+- **THEN** a valid `.odt` passing `validateOdfArchiveSafety` is written there and the response carries `output_path`, `bytes_written`, and the `lossiness` summary
+
+#### Scenario: [OCNV-02] convert_to_odt defaults the output path to the source with .odt
+- **WHEN** `convert_to_odt` is invoked without `output_path`
+- **THEN** the output is written next to the source with the `.docx` extension replaced by `.odt` and the response echoes that path
+
+#### Scenario: [OCNV-03] convert_to_odt refuses to overwrite without allow_overwrite
+- **WHEN** `convert_to_odt` targets an existing output file without `allow_overwrite`
+- **THEN** a structured error is returned, the file is untouched, and retrying with `allow_overwrite: true` succeeds
+
+#### Scenario: [OCNV-04] convert_to_odt refuses to clobber the source document
+- **WHEN** `convert_to_odt` is invoked with an `output_path` that resolves to the source document itself
+- **THEN** a structured error is returned and the source file is untouched
+
+#### Scenario: [OCNV-05] convert_to_odt returns ODF_UNAVAILABLE when the provider is missing
+- **WHEN** `convert_to_odt` is invoked while `loadOdfCore()` resolves to null
+- **THEN** the tool returns a structured `ODF_UNAVAILABLE` error instead of throwing

--- a/openspec/changes/add-docx-to-odf-conversion/specs/odf-core/spec.md
+++ b/openspec/changes/add-docx-to-odf-conversion/specs/odf-core/spec.md
@@ -1,0 +1,73 @@
+## ADDED Requirements
+
+### Requirement: DOCX to ODT conversion
+
+`@usejunior/odf-core` SHALL export `convertDocxToOdt(docx: Buffer, options?)` returning
+`{ odt: Buffer, lossiness: LossinessEntry[] }`. The conversion SHALL be native (no external binary
+at runtime) and semantic: it traverses the docx-core document view
+(`buildDocumentView({ showFormatting: true, formattingMode: 'full' })`) and emits a fresh ODT
+package. Constructs without a mapped equivalent SHALL be downgraded and recorded in the lossiness
+report, never dropped silently.
+
+The produced package SHALL satisfy ODF packaging rules: `mimetype` first and STORED, a complete
+`META-INF/manifest.xml`, `office:version="1.3"` document roots, and a passing
+`validateOdfArchiveSafety`. Visible body text SHALL be preserved, including multi-space runs and
+tabs (`text:s`/`text:tab`). Word-style headings SHALL become `text:h` with the mapped outline
+level; bold/italic/underline runs SHALL become `text:span`s referencing deduped automatic styles;
+hyperlinks SHALL become `text:a` with an XML-unescaped `xlink:href` vetted by the shared href
+safety check. Auto-numbered and bullet lists SHALL become nested `text:list` structures with
+synthesized `text:list-style`s; manually-labelled (legal-numbered) paragraphs SHALL keep their
+literal label as plain paragraph text. Tables SHALL become `table:table` with a complete
+rectangular grid.
+
+#### Scenario: [CONV-01] Conversion produces a safe, valid ODT package
+- **WHEN** a `.docx` buffer is converted
+- **THEN** the output's first ZIP entry is an uncompressed `mimetype` of `application/vnd.oasis.opendocument.text`, `META-INF/manifest.xml` enumerates every part, and `validateOdfArchiveSafety` returns `ok: true`
+
+#### Scenario: [CONV-02] Body paragraph visible text is preserved
+- **WHEN** a `.docx` with plain body paragraphs (including multi-space runs and tabs) is converted
+- **THEN** the `.odt` paragraphs' visible text (with `text:s`/`text:tab` expanded) matches the source paragraphs' visible text
+
+#### Scenario: [CONV-03] Word-style headings become text:h with mapped outline level
+- **WHEN** a paragraph styled `Heading1`..`Heading6` (and one heuristic title paragraph) is converted
+- **THEN** the Word-style headings emit `<text:h text:outline-level="1..6">` referencing `Heading_20_N` styles while the heuristic title remains a `text:p`
+
+#### Scenario: [CONV-04] Bold, italic, and underline runs become deduped text:span styles
+- **WHEN** runs carrying bold, italic, underline, and nested combinations (e.g. bold+italic) are converted
+- **THEN** each formatted run is wrapped in `text:span` referencing an automatic style whose `style:text-properties` carry the matching `fo:font-weight`/`fo:font-style`/`style:text-underline-style`, and identical format sets share one style name
+
+#### Scenario: [CONV-05] Hyperlinks become text:a and unsafe schemes degrade
+- **WHEN** a run inside a `w:hyperlink` with an `https:` target and another with a `javascript:` target are converted
+- **THEN** the safe link becomes `<text:a xlink:type="simple" xlink:href="…">` with the URL not double-escaped, and the unsafe link degrades to plain text with a lossiness entry
+
+#### Scenario: [CONV-06] Auto-numbered lists become nested text:list with mapped number formats
+- **WHEN** auto-numbered paragraphs spanning multiple `ilvl` levels (including a level jump) and OOXML `numFmt` values `decimal`/`lowerLetter`/`upperRoman` are converted
+- **THEN** the output nests `text:list`/`text:list-item` to the matching depth without malformed structure, and the synthesized `text:list-style` levels carry `style:num-format` `1`/`a`/`I` respectively
+
+#### Scenario: [CONV-07] Bullet lists become text:list with a bullet list style
+- **WHEN** bullet-list paragraphs are converted
+- **THEN** they emit `text:list` items whose list style uses `text:list-level-style-bullet`
+
+#### Scenario: [CONV-08] Manual and legal list labels stay literal paragraph text
+- **WHEN** paragraphs with manual labels (e.g. `Section 2.1`, `(a)`) that are not auto-numbered are converted
+- **THEN** they emit plain `text:p` elements whose visible text includes the literal label, and no `text:list` wraps them
+
+#### Scenario: [CONV-09] Tables become a complete rectangular grid
+- **WHEN** a table with header rows, a multi-paragraph cell, and grid gaps is converted
+- **THEN** the output `table:table` declares the full column count, leading header rows sit in `table:table-header-rows`, grid gaps are filled with empty cells (recorded in the lossiness report), and the multi-paragraph cell keeps separate `text:p` children
+
+#### Scenario: [CONV-10] Dropped constructs are reported, not silent
+- **WHEN** a document containing unmappable constructs (e.g. font/color formatting, grid gaps) is converted
+- **THEN** the result's `lossiness` array names each downgraded construct with a count
+
+#### Scenario: [CONV-11] Converted output reopens through odf-core with matching text
+- **WHEN** the converted buffer is reloaded via `OdfArchive.load` and `OdfDocument.fromContentXml`
+- **THEN** loading succeeds and `getParagraphs()` visible text matches the source document's visible text
+
+#### Scenario: [CONV-12] A real contract document converts end-to-end
+- **WHEN** the bundled NVCA `.docx` fixture (and the open-agreements NDA fixtures) are converted
+- **THEN** each output passes `validateOdfArchiveSafety`, reopens via `OdfDocument`, and its visible text matches the source's plaintext serialization
+
+#### Scenario: [CONV-13] Output structurally agrees with a LibreOffice-converted reference
+- **WHEN** LibreOffice is available and usable (a trivial preflight oracle job succeeds) and the same `.docx` is converted both natively and via the LibreOffice oracle
+- **THEN** the two `.odt` outputs agree on visible text and paragraph/heading/list/table structure; when soffice is absent or the preflight probe fails, the test skips with a logged warning instead of failing

--- a/openspec/changes/add-docx-to-odf-conversion/specs/odf-core/spec.md
+++ b/openspec/changes/add-docx-to-odf-conversion/specs/odf-core/spec.md
@@ -66,7 +66,7 @@ rectangular grid.
 
 #### Scenario: [CONV-12] A real contract document converts end-to-end
 - **WHEN** the bundled NVCA `.docx` fixture (and the open-agreements NDA fixtures) are converted
-- **THEN** each output passes `validateOdfArchiveSafety`, reopens via `OdfDocument`, and its visible text matches the source's plaintext serialization
+- **THEN** each output passes `validateOdfArchiveSafety`, reopens via `OdfDocument`, and its visible text matches the source document view's visible text
 
 #### Scenario: [CONV-13] Output structurally agrees with a LibreOffice-converted reference
 - **WHEN** LibreOffice is available and usable (a trivial preflight oracle job succeeds) and the same `.docx` is converted both natively and via the LibreOffice oracle

--- a/openspec/changes/add-docx-to-odf-conversion/tasks.md
+++ b/openspec/changes/add-docx-to-odf-conversion/tasks.md
@@ -26,4 +26,4 @@
 - [x] `convert_real_documents.test.ts` (CONV-12): NVCA + open-agreements fixtures → safety → reopen → visible-text equivalence
 - [x] `lo_convert_differential.test.ts` (CONV-13): preflight-probe gate (skip when soffice absent or unusable), text + structure diff vs LibreOffice reference
 - [x] `add_docx_to_odf_conversion.test.ts` (docx-mcp): `TEST_FEATURE = 'add-docx-to-odf-conversion'`, single-line `.openspec()` tags for OCNV-01..05
-- [ ] Full local gates: `npm run build && npm run test:run && npm run preflight:ci`; document-shaped smoke (convert real NVCA `.docx`, open `.odt` in LibreOffice)
+- [x] Full local gates: `npm run build && npm run test:run && npm run preflight:ci`; document-shaped smoke (convert real NVCA `.docx`, open `.odt` in LibreOffice)

--- a/openspec/changes/add-docx-to-odf-conversion/tasks.md
+++ b/openspec/changes/add-docx-to-odf-conversion/tasks.md
@@ -1,0 +1,29 @@
+# Tasks
+
+## Foundations (odf-core)
+- [ ] Add `FO` and `XLINK` to `ODF_NS` in `shared/odf/namespaces.ts`
+- [ ] `OdfArchive.create(parts)` static factory: mimetype-first + STORED, generated `META-INF/manifest.xml`, output round-trips `OdfArchive.load()`
+- [ ] `convert/package.ts`: content.xml / styles.xml / meta.xml templates with `office:version="1.3"`; named styles `Standard`, `Heading`, `Heading_20_1..6`, `Text_20_body`; `text:s`/`text:tab` whitespace writer
+
+## Converter (odf-core)
+- [ ] `convert/inline.ts`: `tokenizeToonInline` format-stack → deduped automatic `T*` styles; `text:a` with `isSafeHref` + href unescape; `<font>` tags dropped with lossiness
+- [ ] `convert/docx_to_odt.ts` + `convert/types.ts`: orchestrator over `buildDocumentView({ showFormatting: true, formattingMode: 'full' })`; paragraphs, `word_style` headings (clamped 1–6), lossiness plumbing; export `convertDocxToOdt` from `src/index.ts`
+- [ ] `convert/lists.ts`: ListBuilder-style level stack → nested `text:list`; per-`num_id` `text:list-style` synthesis from the numbering model; manual/legal labels as literal `text:p`
+- [ ] `convert/tables.ts`: `(row,col)` bucketing, grid-gap filling, multi-paragraph cells, `table:table-header-rows`, shared bordered cell style
+
+## Enablers (docx-core)
+- [ ] Public `DocxDocument.getNumberingModel(): NumberingModel | null`
+- [ ] Export `isSafeHref` from `serialize_html.ts`; re-export `buildSyntheticDocx` and `buildDocxFromBodyXml` from the package root
+- [ ] LibreOffice oracle: DOCX-in→ODT-out conversion job (`writer8` filter) in `libreoffice-oracle.ts`
+
+## MCP tool (docx-mcp)
+- [ ] `tools/convert_to_odt.ts`: `file_path`-first resolution, default output = source with `.odt`, source-clobber + overwrite guards, `loadOdfCore()` / `ODF_UNAVAILABLE`, `validateOdfArchiveSafety` before write
+- [ ] Register in `tool_catalog.ts` ("semantic, intentionally lossy") + `server.ts` dispatch; regenerate tool docs
+- [ ] Fix stale "private/unpublished" comment in `odf_loader.ts`
+
+## Tests & verification
+- [ ] `convert_basics.test.ts` (CONV-01..05, 10, 11), `convert_lists.test.ts` (CONV-06..08), `convert_tables.test.ts` (CONV-09)
+- [ ] `convert_real_documents.test.ts` (CONV-12): NVCA + open-agreements fixtures → safety → reopen → visible-text equivalence
+- [ ] `lo_convert_differential.test.ts` (CONV-13): preflight-probe gate (skip when soffice absent or unusable), text + structure diff vs LibreOffice reference
+- [ ] `convert_to_odt.test.ts` (docx-mcp): `TEST_FEATURE = 'add-docx-to-odf-conversion'`, single-line `.openspec()` tags for OCNV-01..05
+- [ ] Full local gates: `npm run build && npm run test:run && npm run preflight:ci`; document-shaped smoke (convert real NVCA `.docx`, open `.odt` in LibreOffice)

--- a/openspec/changes/add-docx-to-odf-conversion/tasks.md
+++ b/openspec/changes/add-docx-to-odf-conversion/tasks.md
@@ -1,29 +1,29 @@
 # Tasks
 
 ## Foundations (odf-core)
-- [ ] Add `FO` and `XLINK` to `ODF_NS` in `shared/odf/namespaces.ts`
-- [ ] `OdfArchive.create(parts)` static factory: mimetype-first + STORED, generated `META-INF/manifest.xml`, output round-trips `OdfArchive.load()`
-- [ ] `convert/package.ts`: content.xml / styles.xml / meta.xml templates with `office:version="1.3"`; named styles `Standard`, `Heading`, `Heading_20_1..6`, `Text_20_body`; `text:s`/`text:tab` whitespace writer
+- [x] Add `FO` and `XLINK` to `ODF_NS` in `shared/odf/namespaces.ts`
+- [x] `OdfArchive.create(parts)` static factory: mimetype-first + STORED, generated `META-INF/manifest.xml`, output round-trips `OdfArchive.load()`
+- [x] `convert/package.ts`: content.xml / styles.xml / meta.xml templates with `office:version="1.3"`; named styles `Standard`, `Heading`, `Heading_20_1..6`, `Text_20_body`; `text:s`/`text:tab` whitespace writer
 
 ## Converter (odf-core)
-- [ ] `convert/inline.ts`: `tokenizeToonInline` format-stack → deduped automatic `T*` styles; `text:a` with `isSafeHref` + href unescape; `<font>` tags dropped with lossiness
-- [ ] `convert/docx_to_odt.ts` + `convert/types.ts`: orchestrator over `buildDocumentView({ showFormatting: true, formattingMode: 'full' })`; paragraphs, `word_style` headings (clamped 1–6), lossiness plumbing; export `convertDocxToOdt` from `src/index.ts`
-- [ ] `convert/lists.ts`: ListBuilder-style level stack → nested `text:list`; per-`num_id` `text:list-style` synthesis from the numbering model; manual/legal labels as literal `text:p`
-- [ ] `convert/tables.ts`: `(row,col)` bucketing, grid-gap filling, multi-paragraph cells, `table:table-header-rows`, shared bordered cell style
+- [x] `convert/inline.ts`: `tokenizeToonInline` format-stack → deduped automatic `T*` styles; `text:a` with `isSafeHref` + href unescape; `<font>` tags dropped with lossiness
+- [x] `convert/docx_to_odt.ts` + `convert/types.ts`: orchestrator over `buildDocumentView({ showFormatting: true, formattingMode: 'full' })`; paragraphs, `word_style` headings (clamped 1–6), lossiness plumbing; export `convertDocxToOdt` from `src/index.ts`
+- [x] `convert/lists.ts`: ListBuilder-style level stack → nested `text:list`; per-`num_id` `text:list-style` synthesis from the numbering model; manual/legal labels as literal `text:p`
+- [x] `convert/tables.ts`: `(row,col)` bucketing, grid-gap filling, multi-paragraph cells, `table:table-header-rows`, shared bordered cell style
 
 ## Enablers (docx-core)
-- [ ] Public `DocxDocument.getNumberingModel(): NumberingModel | null`
-- [ ] Export `isSafeHref` from `serialize_html.ts`; re-export `buildSyntheticDocx` and `buildDocxFromBodyXml` from the package root
-- [ ] LibreOffice oracle: DOCX-in→ODT-out conversion job (`writer8` filter) in `libreoffice-oracle.ts`
+- [x] Public `DocxDocument.getNumberingModel(): NumberingModel | null`
+- [x] Export `isSafeHref` from `serialize_html.ts`; re-export `buildSyntheticDocx` and the new parts-based `buildDocxFromParts` from the package root (`src/testing/**` is build-excluded, so `buildDocxFromBodyXml` itself cannot be re-exported)
+- [x] LibreOffice oracle: DOCX-in→ODT-out conversion job (`writer8` filter) in `libreoffice-oracle.ts`
 
 ## MCP tool (docx-mcp)
-- [ ] `tools/convert_to_odt.ts`: `file_path`-first resolution, default output = source with `.odt`, source-clobber + overwrite guards, `loadOdfCore()` / `ODF_UNAVAILABLE`, `validateOdfArchiveSafety` before write
-- [ ] Register in `tool_catalog.ts` ("semantic, intentionally lossy") + `server.ts` dispatch; regenerate tool docs
-- [ ] Fix stale "private/unpublished" comment in `odf_loader.ts`
+- [x] `tools/convert_to_odt.ts`: `file_path`-first resolution, default output = source with `.odt`, source-clobber + overwrite guards, `loadOdfCore()` / `ODF_UNAVAILABLE`, `validateOdfArchiveSafety` before write
+- [x] Register in `tool_catalog.ts` ("semantic, intentionally lossy") + `server.ts` dispatch; regenerate tool docs
+- [x] Fix stale "private/unpublished" comment in `odf_loader.ts`
 
 ## Tests & verification
-- [ ] `convert_basics.test.ts` (CONV-01..05, 10, 11), `convert_lists.test.ts` (CONV-06..08), `convert_tables.test.ts` (CONV-09)
-- [ ] `convert_real_documents.test.ts` (CONV-12): NVCA + open-agreements fixtures → safety → reopen → visible-text equivalence
-- [ ] `lo_convert_differential.test.ts` (CONV-13): preflight-probe gate (skip when soffice absent or unusable), text + structure diff vs LibreOffice reference
-- [ ] `convert_to_odt.test.ts` (docx-mcp): `TEST_FEATURE = 'add-docx-to-odf-conversion'`, single-line `.openspec()` tags for OCNV-01..05
+- [x] `convert_basics.test.ts` (CONV-01..05, 10, 11), `convert_lists.test.ts` (CONV-06..08), `convert_tables.test.ts` (CONV-09)
+- [x] `convert_real_documents.test.ts` (CONV-12): NVCA + open-agreements fixtures → safety → reopen → visible-text equivalence
+- [x] `lo_convert_differential.test.ts` (CONV-13): preflight-probe gate (skip when soffice absent or unusable), text + structure diff vs LibreOffice reference
+- [x] `add_docx_to_odf_conversion.test.ts` (docx-mcp): `TEST_FEATURE = 'add-docx-to-odf-conversion'`, single-line `.openspec()` tags for OCNV-01..05
 - [ ] Full local gates: `npm run build && npm run test:run && npm run preflight:ci`; document-shaped smoke (convert real NVCA `.docx`, open `.odt` in LibreOffice)

--- a/packages/docx-core/src/index.ts
+++ b/packages/docx-core/src/index.ts
@@ -121,3 +121,13 @@ export type {
 // Re-export the LibreOffice accept/reject oracle (gated reference voter; callers skip when
 // `resolveSoffice()` is null). odf-core's round-trip tests drive it with `.odt` jobs.
 export { resolveSoffice, runLibreOfficeOracle, type OracleJob } from './integration/libreoffice-oracle.js';
+
+// Synthetic-DOCX fixture builders re-exported for downstream packages' test suites
+// (odf-core's DOCX→ODT conversion tests build their inputs with these). They live under
+// `integration/` because `src/testing/**` is excluded from the package build.
+export {
+  buildSyntheticDocx,
+  buildDocxFromParts,
+  type SyntheticDocxOptions,
+  type DocxPartsOptions,
+} from './integration/synthetic-docx-fixture.js';

--- a/packages/docx-core/src/integration/libreoffice-oracle.ts
+++ b/packages/docx-core/src/integration/libreoffice-oracle.ts
@@ -180,12 +180,23 @@ End Sub
  * DOCX jobs carry a bare `word/document.xml` (packed into a minimal package and read back out);
  * ODT jobs carry a complete `.odt` package buffer (ODF packaging — mimetype-first STORED — is
  * the caller's concern) and return its post-op `content.xml`.
+ *
+ * CONVERSION jobs (`docx` + `saveAs: 'odt'`) carry a complete `.docx` package buffer and save
+ * through LibreOffice's `writer8` filter, returning the converted `content.xml` — the reference
+ * path for differential-testing odf-core's native DOCX→ODT converter (issue #331).
  */
 type OracleOp = 'accept' | 'reject' | 'identity';
-export type OracleJob = { op: OracleOp; documentXml: string } | { op: OracleOp; odt: Buffer };
+export type OracleJob =
+  | { op: OracleOp; documentXml: string }
+  | { op: OracleOp; odt: Buffer }
+  | { op: OracleOp; docx: Buffer; saveAs: 'odt' };
 
 function isOdtJob(job: OracleJob): job is { op: OracleOp; odt: Buffer } {
   return 'odt' in job;
+}
+
+function isConvertJob(job: OracleJob): job is { op: OracleOp; docx: Buffer; saveAs: 'odt' } {
+  return 'docx' in job;
 }
 
 /**
@@ -216,11 +227,19 @@ export async function runLibreOfficeOracle(jobs: OracleJob[], soffice = resolveS
     const jobLines: string[] = [];
     for (let i = 0; i < jobs.length; i++) {
       const job = jobs[i]!;
-      const ext = isOdtJob(job) ? 'odt' : 'docx';
-      const filter = isOdtJob(job) ? 'writer8' : 'MS Word 2007 XML';
-      const inPath = path.join(inDir, `job${i}.${ext}`);
-      const outPath = path.join(outDir, `job${i}.${ext}`);
-      writeFileSync(inPath, isOdtJob(job) ? new Uint8Array(job.odt) : new Uint8Array(await packMinimalDocx(job.documentXml)));
+      const inExt = isOdtJob(job) ? 'odt' : 'docx';
+      const outExt = isOdtJob(job) || isConvertJob(job) ? 'odt' : 'docx';
+      const filter = isOdtJob(job) || isConvertJob(job) ? 'writer8' : 'MS Word 2007 XML';
+      const inPath = path.join(inDir, `job${i}.${inExt}`);
+      const outPath = path.join(outDir, `job${i}.${outExt}`);
+      writeFileSync(
+        inPath,
+        isOdtJob(job)
+          ? new Uint8Array(job.odt)
+          : isConvertJob(job)
+            ? new Uint8Array(job.docx)
+            : new Uint8Array(await packMinimalDocx(job.documentXml)),
+      );
       outPaths.push(outPath);
       jobLines.push(`${job.op}|${inPath}|${outPath}|${filter}`);
     }
@@ -267,7 +286,7 @@ export async function runLibreOfficeOracle(jobs: OracleJob[], soffice = resolveS
     }
     return Promise.all(outPaths.map(async (p, i) => {
       if (!existsSync(p)) throw new Error(`LibreOffice oracle produced no output for ${path.basename(p)}`);
-      if (isOdtJob(jobs[i]!)) {
+      if (isOdtJob(jobs[i]!) || isConvertJob(jobs[i]!)) {
         const contentXml = await readZipText(readFileSync(p), 'content.xml');
         if (contentXml == null) throw new Error(`content.xml not found in oracle output ${path.basename(p)}`);
         return contentXml;

--- a/packages/docx-core/src/integration/synthetic-docx-fixture.ts
+++ b/packages/docx-core/src/integration/synthetic-docx-fixture.ts
@@ -248,6 +248,74 @@ export async function buildSyntheticDocx(opts: SyntheticDocxOptions): Promise<Bu
   return (await zip.generateAsync({ type: 'nodebuffer' })) as Buffer;
 }
 
+/** Parts for {@link buildDocxFromParts}. Only the body XML is required. */
+export interface DocxPartsOptions {
+  /** Raw `<w:body>` children (paragraphs/tables), without the `<w:body>` wrapper. */
+  bodyXml: string;
+  /** Full `word/styles.xml` content. */
+  stylesXml?: string;
+  /** Full `word/numbering.xml` content. */
+  numberingXml?: string;
+  /** Extra `<Relationship …/>` entries for `word/_rels/document.xml.rels` (e.g. hyperlinks). */
+  documentRelEntries?: string[];
+}
+
+/**
+ * Build a loadable DOCX from raw part XML. The `testing/ooxml-fixtures.ts`
+ * `buildDocxFromBodyXml` covers the body-only case for docx-core's own tests, but it lives
+ * in the build-excluded testing tree; this builder is exported from the package root for
+ * downstream suites (odf-core's DOCX→ODT conversion tests) and additionally accepts the
+ * optional styles/numbering/relationship parts those tests exercise.
+ */
+export async function buildDocxFromParts(opts: DocxPartsOptions): Promise<Buffer> {
+  const zip = new JSZip();
+
+  const documentXml =
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"` +
+    ` xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"` +
+    ` xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
+    `<w:body>${opts.bodyXml}<w:sectPr/></w:body></w:document>`;
+
+  const overrides = [
+    `<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>`,
+    ...(opts.stylesXml
+      ? [`<Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/>`]
+      : []),
+    ...(opts.numberingXml
+      ? [`<Override PartName="/word/numbering.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.numbering+xml"/>`]
+      : []),
+  ];
+  const contentTypesXml =
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+    `<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+    `<Default Extension="xml" ContentType="application/xml"/>` +
+    overrides.join('') +
+    `</Types>`;
+
+  const rootRelsXml =
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+    `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>` +
+    `</Relationships>`;
+
+  const docRelsXml =
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+    (opts.documentRelEntries ?? []).join('') +
+    `</Relationships>`;
+
+  zip.file('[Content_Types].xml', contentTypesXml);
+  zip.file('_rels/.rels', rootRelsXml);
+  zip.file('word/document.xml', documentXml);
+  zip.file('word/_rels/document.xml.rels', docRelsXml);
+  if (opts.stylesXml) zip.file('word/styles.xml', opts.stylesXml);
+  if (opts.numberingXml) zip.file('word/numbering.xml', opts.numberingXml);
+
+  return (await zip.generateAsync({ type: 'nodebuffer' })) as Buffer;
+}
+
 export interface SyntheticResultParts {
   documentXml: string;
   footnotesXml: string | null;

--- a/packages/docx-core/src/primitives/document.ts
+++ b/packages/docx-core/src/primitives/document.ts
@@ -20,6 +20,7 @@ import { serializeToMarkdown, type SerializeMarkdownOptions } from './serialize_
 import { serializeToHtml, type SerializeHtmlOptions } from './serialize_html.js';
 import { serializeToPlainText, type SerializePlainTextOptions } from './serialize_plaintext.js';
 import type { FormattingMode } from './formatting_tags.js';
+import { parseNumberingXml, type NumberingModel } from './numbering.js';
 import { findUniqueSubstringMatch } from './matching.js';
 import { parseDocumentRels, type RelsMap } from './relationships.js';
 import {
@@ -604,6 +605,16 @@ export class DocxDocument {
     }
     const endIdx = typeof limit === 'number' ? Math.min(total, startIdx + limit) : total;
     return { paragraphs: all.slice(startIdx, endIdx), totalParagraphs: total };
+  }
+
+  /**
+   * Parsed `word/numbering.xml` model (abstract numberings + instances), or null when the
+   * document has no numbering part. The document view's `numbering` field only carries
+   * `num_id`/`ilvl`; semantic converters (DOCX → ODT) need `numFmt`/`lvlText`/`start` to
+   * synthesize target-format list styles, so the full model is exposed here.
+   */
+  getNumberingModel(): NumberingModel | null {
+    return this.numberingXml ? parseNumberingXml(this.numberingXml) : null;
   }
 
   buildDocumentView(opts?: { includeSemanticTags?: boolean; showFormatting?: boolean; formattingMode?: FormattingMode }): { nodes: DocumentViewNode[]; styles: DocumentStyles } {

--- a/packages/docx-core/src/primitives/serialize_html.ts
+++ b/packages/docx-core/src/primitives/serialize_html.ts
@@ -68,7 +68,7 @@ function renderTextWithFootnotes(raw: string, refs?: FootnoteRefs): string {
  * otherwise pass through and execute on click. Relative URLs and fragments (no scheme) are kept.
  */
 const SAFE_URL_SCHEMES = new Set(['http', 'https', 'mailto', 'tel']);
-function isSafeHref(href: string): boolean {
+export function isSafeHref(href: string): boolean {
   // Strip whitespace/control chars browsers ignore (e.g. `java\tscript:`) before scheme-matching.
   const v = href.replace(/[\u0000-\u0020]/g, '').toLowerCase();
   const scheme = /^([a-z][a-z0-9+.-]*):/.exec(v);

--- a/packages/docx-mcp/docs/tool-reference.generated.md
+++ b/packages/docx-mcp/docs/tool-reference.generated.md
@@ -154,6 +154,19 @@ Export a document to a portable rendering (Markdown, semantic HTML, or plain tex
 | `allow_overwrite` | `boolean` | no | Overwrite output_path if it already exists. Default: false. |
 | `include_markdown` | `boolean` | no | Include the rendered content (under `content`) in the response. Default: true; set false for large documents. |
 
+## `convert_to_odt`
+
+Convert a DOCX document to OpenDocument Text (.odt) using the native model-to-model converter (no LibreOffice involved). Writes the .odt (default: source path with the .odt extension), validates ODF packaging safety before writing, and returns the output path plus a `lossiness` summary itemizing every downgraded construct. Conversion is semantic and intentionally lossy: text, headings, bold/italic/underline, hyperlinks, lists, and tables are mapped; richer styling, tracked changes, comments, and headers/footers are not. DOCX in, ODT out — Google Docs and .odt inputs are not supported.
+
+- readOnly: `false`
+- destructive: `false`
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `file_path` | `string` | no | Path to the DOCX or ODT file. |
+| `output_path` | `string` | no | Where to write the .odt. Defaults to the source path with the .odt extension. |
+| `allow_overwrite` | `boolean` | no | Overwrite output_path if it already exists. Default: false. |
+
 ## `format_layout`
 
 Apply layout controls (paragraph spacing, table row height, cell padding). Google Docs supports paragraph spacing only.

--- a/packages/docx-mcp/src/odf_loader.ts
+++ b/packages/docx-mcp/src/odf_loader.ts
@@ -1,8 +1,9 @@
-// Lazy loader for the OPTIONAL @usejunior/odf-core provider, mirroring gdocs_loader.
-// odf-core is private/unpublished, so it is NOT a package.json dependency and may be
-// absent from a production install of the published package. Always-loaded modules
-// must reach ODF functionality through this loader (a dynamic import that returns
-// null when odf-core is unavailable) rather than a static import.
+// Lazy loader for the @usejunior/odf-core provider, mirroring gdocs_loader.
+// odf-core publishes with the main suite and is a regular dependency since #372, but
+// always-loaded modules still reach ODF functionality through this loader (a dynamic
+// import that returns null when odf-core is unavailable) so an install with a missing or
+// broken odf-core degrades to structured ODF_UNAVAILABLE errors on the ODF tools instead
+// of crashing the whole server at import time.
 let cached: typeof import('@usejunior/odf-core') | null | undefined;
 
 export async function loadOdfCore(): Promise<typeof import('@usejunior/odf-core') | null> {

--- a/packages/docx-mcp/src/server.ts
+++ b/packages/docx-mcp/src/server.ts
@@ -14,6 +14,7 @@ import { mergePlans } from './tools/merge_plans.js';
 import { applyPlan } from './tools/apply_plan.js';
 import { save } from './tools/save.js';
 import { exportDocument } from './tools/export.js';
+import { convertToOdt } from './tools/convert_to_odt.js';
 import { getFileStatus } from './tools/get_file_status.js';
 import { hasTrackedChanges_tool } from './tools/has_tracked_changes.js';
 import { closeFile } from './tools/close_file.js';
@@ -180,6 +181,8 @@ export async function dispatchToolCall(
       return await save(sessions, args as Parameters<typeof save>[1]);
     case 'export':
       return await exportDocument(sessions, args as Parameters<typeof exportDocument>[1]);
+    case 'convert_to_odt':
+      return await convertToOdt(sessions, args as Parameters<typeof convertToOdt>[1]);
     case 'format_layout':
       if (isGDocsRequest(args)) return await dispatchGDocs(sessions, args, 'format_layout');
       return await formatLayout(sessions, args as Parameters<typeof formatLayout>[1]);

--- a/packages/docx-mcp/src/tool_catalog.ts
+++ b/packages/docx-mcp/src/tool_catalog.ts
@@ -202,6 +202,23 @@ export const SAFE_DOCX_TOOL_CATALOG = [
     annotations: { readOnlyHint: false, destructiveHint: false },
   },
   {
+    name: 'convert_to_odt',
+    description:
+      'Convert a DOCX document to OpenDocument Text (.odt) using the native model-to-model converter (no LibreOffice involved). Writes the .odt (default: source path with the .odt extension), validates ODF packaging safety before writing, and returns the output path plus a `lossiness` summary itemizing every downgraded construct. Conversion is semantic and intentionally lossy: text, headings, bold/italic/underline, hyperlinks, lists, and tables are mapped; richer styling, tracked changes, comments, and headers/footers are not. DOCX in, ODT out — Google Docs and .odt inputs are not supported.',
+    input: z.object({
+      ...FILE_FIELD_OPTIONAL,
+      output_path: z
+        .string()
+        .optional()
+        .describe('Where to write the .odt. Defaults to the source path with the .odt extension.'),
+      allow_overwrite: z
+        .boolean()
+        .optional()
+        .describe('Overwrite output_path if it already exists. Default: false.'),
+    }),
+    annotations: { readOnlyHint: false, destructiveHint: false },
+  },
+  {
     name: 'format_layout',
     description: 'Apply layout controls (paragraph spacing, table row height, cell padding). Google Docs supports paragraph spacing only.',
     input: z.object({

--- a/packages/docx-mcp/src/tools/add_docx_to_odf_conversion.test.ts
+++ b/packages/docx-mcp/src/tools/add_docx_to_odf_conversion.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, vi } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { OdfArchive, OdfDocument, validateOdfArchiveSafety } from '@usejunior/odf-core';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { assertFailure, assertSuccess, openSession, registerCleanup } from '../testing/session-test-utils.js';
+import { convertToOdt } from './convert_to_odt.js';
+
+const TEST_FEATURE = 'add-docx-to-odf-conversion';
+const test = testAllure.epic('Document Editing').withLabels({ feature: TEST_FEATURE });
+
+describe('OpenSpec traceability: add-docx-to-odf-conversion (convert_to_odt tool)', () => {
+  registerCleanup();
+
+  test.openspec('[OCNV-01] convert_to_odt writes a valid .odt and reports lossiness')(
+    '[OCNV-01] convert_to_odt writes a valid .odt and reports lossiness',
+    async ({ then }: AllureBddContext) => {
+      const opened = await openSession(['Hello ODF world.', 'Second paragraph.']);
+      const target = path.join(opened.tmpDir, 'converted.odt');
+      const result = await convertToOdt(opened.mgr, { file_path: opened.inputPath, output_path: target });
+      await then('a safe .odt with the document text is on disk and lossiness is reported', async () => {
+        assertSuccess(result, 'convert_to_odt');
+        expect(path.resolve(String(result.output_path))).toBe(path.resolve(target));
+        expect(result.bytes_written).toBeGreaterThan(0);
+        expect(Array.isArray(result.lossiness)).toBe(true);
+
+        const odt = await fs.readFile(target);
+        const safety = await validateOdfArchiveSafety(odt);
+        expect(safety.ok).toBe(true);
+        const archive = await OdfArchive.load(odt);
+        const doc = OdfDocument.fromContentXml(await archive.getContentXml());
+        expect(doc.getParagraphs().map((b) => b.text)).toEqual(['Hello ODF world.', 'Second paragraph.']);
+      });
+    },
+  );
+
+  test.openspec('[OCNV-02] convert_to_odt defaults the output path to the source with .odt')(
+    '[OCNV-02] convert_to_odt defaults the output path to the source with .odt',
+    async ({ then }: AllureBddContext) => {
+      const opened = await openSession(['Default path body.']);
+      const result = await convertToOdt(opened.mgr, { file_path: opened.inputPath });
+      await then('the .docx extension is swapped for .odt', async () => {
+        assertSuccess(result, 'convert_to_odt');
+        const parsed = path.parse(opened.inputPath);
+        const expected = path.join(parsed.dir, `${parsed.name}.odt`);
+        expect(path.resolve(String(result.output_path))).toBe(path.resolve(expected));
+        const exists = await fs.access(expected).then(() => true).catch(() => false);
+        expect(exists).toBe(true);
+      });
+    },
+  );
+
+  test.openspec('[OCNV-03] convert_to_odt refuses to overwrite without allow_overwrite')(
+    '[OCNV-03] convert_to_odt refuses to overwrite without allow_overwrite',
+    async ({ then }: AllureBddContext) => {
+      const opened = await openSession(['Overwrite guard body.']);
+      const target = path.join(opened.tmpDir, 'taken.odt');
+      await fs.writeFile(target, 'sentinel');
+      const blocked = await convertToOdt(opened.mgr, { file_path: opened.inputPath, output_path: target });
+      await then('the existing file is untouched until allow_overwrite is set', async () => {
+        assertFailure(blocked, 'OVERWRITE_BLOCKED');
+        expect(await fs.readFile(target, 'utf8')).toBe('sentinel');
+
+        const allowed = await convertToOdt(opened.mgr, {
+          file_path: opened.inputPath,
+          output_path: target,
+          allow_overwrite: true,
+        });
+        assertSuccess(allowed, 'convert_to_odt');
+        const safety = await validateOdfArchiveSafety(await fs.readFile(target));
+        expect(safety.ok).toBe(true);
+      });
+    },
+  );
+
+  test.openspec('[OCNV-04] convert_to_odt refuses to clobber the source document')(
+    '[OCNV-04] convert_to_odt refuses to clobber the source document',
+    async ({ then }: AllureBddContext) => {
+      const opened = await openSession(['Source guard body.']);
+      const before = await fs.readFile(opened.inputPath);
+      const result = await convertToOdt(opened.mgr, {
+        file_path: opened.inputPath,
+        output_path: opened.inputPath,
+      });
+      await then('the source .docx is byte-identical after the blocked call', async () => {
+        assertFailure(result, 'OVERWRITE_BLOCKED');
+        expect((await fs.readFile(opened.inputPath)).equals(before)).toBe(true);
+      });
+    },
+  );
+
+  test.openspec('[OCNV-05] convert_to_odt returns ODF_UNAVAILABLE when the provider is missing')(
+    '[OCNV-05] convert_to_odt returns ODF_UNAVAILABLE when the provider is missing',
+    async ({ then }: AllureBddContext) => {
+      // Re-import the tool with the loader mocked to null — the real odf-core IS installed in
+      // the workspace, so the unavailable path is only reachable through the loader seam.
+      vi.resetModules();
+      vi.doMock('../odf_loader.js', () => ({ loadOdfCore: async () => null }));
+      try {
+        const { convertToOdt: convertWithoutOdf } = await import('./convert_to_odt.js');
+        const opened = await openSession(['Provider missing body.']);
+        const target = path.join(opened.tmpDir, 'never-written.odt');
+        const result = await convertWithoutOdf(opened.mgr, { file_path: opened.inputPath, output_path: target });
+        await then('a structured ODF_UNAVAILABLE error is returned and nothing is written', async () => {
+          assertFailure(result, 'ODF_UNAVAILABLE');
+          const exists = await fs.access(target).then(() => true).catch(() => false);
+          expect(exists).toBe(false);
+        });
+      } finally {
+        vi.doUnmock('../odf_loader.js');
+        vi.resetModules();
+      }
+    },
+  );
+});

--- a/packages/docx-mcp/src/tools/convert_to_odt.ts
+++ b/packages/docx-mcp/src/tools/convert_to_odt.ts
@@ -1,0 +1,112 @@
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { SessionManager } from '../session/manager.js';
+import { err, ok, type ToolResponse } from './types.js';
+import { mergeSessionResolutionMetadata, resolveSessionForTool } from './session_resolution.js';
+import { enforceWritePathPolicy, resolvesToSamePath } from './path_policy.js';
+import { checkGDocsSupport } from './provider_guard.js';
+import { loadOdfCore } from '../odf_loader.js';
+
+function expandPath(inputPath: string): string {
+  return inputPath.startsWith('~') ? path.join(process.env.HOME || '', inputPath.slice(1)) : inputPath;
+}
+
+/**
+ * Convert a DOCX document to OpenDocument Text (`.odt`) via odf-core's native converter.
+ *
+ * Conversion is semantic and intentionally lossy (no round-trip guarantee): visible text,
+ * headings, basic run formatting, lists, and tables are mapped; everything downgraded is
+ * itemized in the returned `lossiness` summary. The converted package is validated with
+ * `validateOdfArchiveSafety` BEFORE writing — an unsafe artifact is never persisted.
+ *
+ * DOCX in, ODT out. `file_path`-first like every session tool; Google Docs is out of scope,
+ * and a `.odt` input is rejected by session resolution (there is nothing to convert).
+ */
+export async function convertToOdt(
+  manager: SessionManager,
+  params: {
+    file_path?: string;
+    google_doc_id?: string;
+    output_path?: string;
+    allow_overwrite?: boolean;
+  },
+): Promise<ToolResponse> {
+  try {
+    if (typeof params.google_doc_id === 'string' && params.google_doc_id.trim().length > 0) {
+      return checkGDocsSupport('convert_to_odt')!;
+    }
+
+    const resolved = await resolveSessionForTool(manager, params, { toolName: 'convert_to_odt' });
+    if (!resolved.ok) return resolved.response;
+    const { session, metadata } = resolved;
+
+    const parsedSource = path.parse(session.originalPath);
+    const outputPath = expandPath(
+      params.output_path?.trim()
+        ? params.output_path
+        : path.join(parsedSource.dir, `${parsedSource.name}.odt`),
+    );
+
+    // Never clobber the source document; realpath-compare so a symlink can't slip past.
+    if (await resolvesToSamePath(outputPath, session.originalPath)) {
+      return err(
+        'OVERWRITE_BLOCKED',
+        `Refusing to overwrite the source document: ${outputPath}`,
+        'Choose a different output_path.',
+      );
+    }
+    if (!params.allow_overwrite) {
+      const exists = await fs
+        .access(outputPath)
+        .then(() => true)
+        .catch(() => false);
+      if (exists) {
+        return err(
+          'OVERWRITE_BLOCKED',
+          `Output file already exists: ${outputPath}`,
+          'Set allow_overwrite=true to overwrite, or choose a different output_path.',
+        );
+      }
+    }
+
+    const odfCore = await loadOdfCore();
+    if (!odfCore) {
+      return err(
+        'ODF_UNAVAILABLE',
+        'DOCX→ODT conversion requires @usejunior/odf-core.',
+        'Install @usejunior/odf-core to enable conversion.',
+      );
+    }
+
+    // Convert the session's CURRENT state (including unsaved edits), not the on-disk file.
+    const { buffer } = await session.doc.toBuffer({ cleanBookmarks: false });
+    const { odt, lossiness } = await odfCore.convertDocxToOdt(buffer);
+
+    const safety = await odfCore.validateOdfArchiveSafety(odt);
+    if (!safety.ok) {
+      return err(
+        'CONVERSION_UNSAFE_OUTPUT',
+        `Converted package failed ODF archive safety validation: ${safety.message}`,
+        'This is a converter bug — please report it. No file was written.',
+      );
+    }
+
+    const policy = await enforceWritePathPolicy(outputPath);
+    if (!policy.ok) return policy.response;
+    await fs.mkdir(path.dirname(outputPath), { recursive: true });
+    await fs.writeFile(outputPath, new Uint8Array(odt));
+
+    return ok(
+      mergeSessionResolutionMetadata(
+        {
+          output_path: manager.normalizePath(outputPath),
+          bytes_written: odt.byteLength,
+          lossiness,
+        },
+        metadata,
+      ),
+    );
+  } catch (error) {
+    return err('CONVERT_FAILED', error instanceof Error ? error.message : String(error));
+  }
+}

--- a/packages/odf-core/src/convert/convert_basics.test.ts
+++ b/packages/odf-core/src/convert/convert_basics.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from 'vitest';
+import { buildDocxFromParts, parseXml } from '@usejunior/docx-core';
+
+import { convertDocxToOdt } from './docx_to_odt.js';
+import { OdfArchive } from '../shared/odf/OdfArchive.js';
+import { OdfDocument } from '../document.js';
+import { validateOdfArchiveSafety } from '../odf_archive_safety.js';
+import { ODF_NS, ODF_PATHS, ODT_MIMETYPE } from '../shared/odf/namespaces.js';
+
+function p(text: string, runProps = ''): string {
+  const rPr = runProps ? `<w:rPr>${runProps}</w:rPr>` : '';
+  return `<w:p><w:r>${rPr}<w:t xml:space="preserve">${text}</w:t></w:r></w:p>`;
+}
+
+function styledP(styleId: string, text: string): string {
+  return `<w:p><w:pPr><w:pStyle w:val="${styleId}"/></w:pPr><w:r><w:t>${text}</w:t></w:r></w:p>`;
+}
+
+async function reopen(odt: Buffer): Promise<OdfDocument> {
+  const archive = await OdfArchive.load(odt);
+  return OdfDocument.fromContentXml(await archive.getContentXml());
+}
+
+describe('convertDocxToOdt — package validity, text, headings, runs', () => {
+  it('[CONV-01] conversion produces a safe, valid ODT package', async () => {
+    const docx = await buildDocxFromParts({ bodyXml: p('Hello world') });
+    const { odt } = await convertDocxToOdt(docx);
+
+    // ZIP local header: first entry name starts at byte 30, compression method at bytes 8–9.
+    expect(odt.subarray(0, 4)).toEqual(Buffer.from([0x50, 0x4b, 0x03, 0x04]));
+    expect(odt.readUInt16LE(8)).toBe(0); // STORED, not DEFLATE
+    expect(odt.subarray(30, 30 + 'mimetype'.length).toString('utf8')).toBe('mimetype');
+    expect(odt.subarray(38, 38 + ODT_MIMETYPE.length).toString('utf8')).toBe(ODT_MIMETYPE);
+
+    const safety = await validateOdfArchiveSafety(odt);
+    expect(safety.ok).toBe(true);
+
+    const archive = await OdfArchive.load(odt);
+    const manifest = await archive.getFile(ODF_PATHS.MANIFEST);
+    expect(manifest).toContain('manifest:full-path="/"');
+    for (const part of [ODF_PATHS.CONTENT, ODF_PATHS.STYLES, ODF_PATHS.META]) {
+      expect(archive.hasFile(part)).toBe(true);
+      expect(manifest).toContain(`manifest:full-path="${part}"`);
+    }
+    expect(await archive.getContentXml()).toContain('office:version="1.3"');
+  });
+
+  it('[CONV-02] body paragraph visible text is preserved, including multi-space runs and tabs', async () => {
+    const bodyXml =
+      `<w:p><w:r><w:t xml:space="preserve">Alpha  beta   gamma</w:t></w:r>` +
+      `<w:r><w:tab/><w:t xml:space="preserve">after tab</w:t></w:r></w:p>` +
+      p('Second paragraph') +
+      '<w:p/>'; // text-empty paragraph: unsurfaced by the document view, reported as lossiness
+    const docx = await buildDocxFromParts({ bodyXml });
+    const { odt, lossiness } = await convertDocxToOdt(docx);
+
+    const texts = (await reopen(odt)).getParagraphs().map((b) => b.text);
+    expect(texts).toEqual(['Alpha  beta   gamma\tafter tab', 'Second paragraph']);
+    expect(lossiness.some((e) => e.construct === 'unsurfaced-paragraphs-dropped')).toBe(true);
+  });
+
+  it('[CONV-03] Word-style headings become text:h with the mapped outline level; plain text stays text:p', async () => {
+    const bodyXml =
+      styledP('Heading1', 'Top heading') +
+      styledP('Heading2', 'Sub heading') +
+      styledP('Heading9', 'Not a real heading level') +
+      p('Body paragraph.');
+    const docx = await buildDocxFromParts({ bodyXml });
+    const { odt } = await convertDocxToOdt(docx);
+
+    const contentXml = await (await OdfArchive.load(odt)).getContentXml();
+    const doc = parseXml(contentXml);
+    const headings = Array.from(doc.getElementsByTagNameNS(ODF_NS.TEXT, 'h'));
+    expect(headings.map((h) => h.getAttributeNS(ODF_NS.TEXT, 'outline-level'))).toEqual(['1', '2']);
+    expect(headings.map((h) => h.getAttributeNS(ODF_NS.TEXT, 'style-name'))).toEqual([
+      'Heading_20_1',
+      'Heading_20_2',
+    ]);
+    // The non-Heading[1-6] style and the body paragraph both stay text:p.
+    const paragraphTexts = Array.from(doc.getElementsByTagNameNS(ODF_NS.TEXT, 'p')).map((el) => el.textContent);
+    expect(paragraphTexts).toContain('Not a real heading level');
+    expect(paragraphTexts).toContain('Body paragraph.');
+  });
+
+  it('[CONV-04] bold/italic/underline runs become text:span referencing deduped automatic styles', async () => {
+    const bodyXml =
+      `<w:p>` +
+      `<w:r><w:t xml:space="preserve">plain </w:t></w:r>` +
+      `<w:r><w:rPr><w:b/></w:rPr><w:t xml:space="preserve">bold</w:t></w:r>` +
+      `<w:r><w:t xml:space="preserve"> mid </w:t></w:r>` +
+      `<w:r><w:rPr><w:b/><w:i/></w:rPr><w:t xml:space="preserve">bolditalic</w:t></w:r>` +
+      `<w:r><w:rPr><w:u w:val="single"/></w:rPr><w:t xml:space="preserve">under</w:t></w:r>` +
+      `</w:p>` +
+      `<w:p><w:r><w:rPr><w:b/></w:rPr><w:t>bold again</w:t></w:r></w:p>`;
+    const docx = await buildDocxFromParts({ bodyXml });
+    const { odt } = await convertDocxToOdt(docx);
+
+    const contentXml = await (await OdfArchive.load(odt)).getContentXml();
+    const doc = parseXml(contentXml);
+
+    const spans = Array.from(doc.getElementsByTagNameNS(ODF_NS.TEXT, 'span'));
+    const styleOf = (text: string): string | null => {
+      const span = spans.find((s) => s.textContent === text);
+      return span ? span.getAttributeNS(ODF_NS.TEXT, 'style-name') : null;
+    };
+    expect(styleOf('bold')).toBeTruthy();
+    expect(styleOf('bolditalic')).toBeTruthy();
+    expect(styleOf('under')).toBeTruthy();
+    // Dedup: the second bold run reuses the first bold style; distinct combos get distinct styles.
+    expect(styleOf('bold again')).toBe(styleOf('bold'));
+    expect(new Set([styleOf('bold'), styleOf('bolditalic'), styleOf('under')]).size).toBe(3);
+
+    // The style definitions carry the matching properties.
+    const styleXml = contentXml;
+    expect(styleXml).toContain('fo:font-weight="bold"');
+    expect(styleXml).toContain('fo:font-style="italic"');
+    expect(styleXml).toContain('style:text-underline-style="solid"');
+    // Visible text is intact.
+    expect((await reopen(odt)).getParagraphs().map((b) => b.text)).toEqual([
+      'plain bold mid bolditalicunder',
+      'bold again',
+    ]);
+  });
+
+  it('[CONV-05] hyperlinks become text:a with an unescaped href; unsafe schemes degrade to plain text', async () => {
+    const bodyXml =
+      `<w:p><w:hyperlink r:id="rId10"><w:r><w:t>safe link</w:t></w:r></w:hyperlink></w:p>` +
+      `<w:p><w:hyperlink r:id="rId11"><w:r><w:t>evil link</w:t></w:r></w:hyperlink></w:p>`;
+    const docx = await buildDocxFromParts({
+      bodyXml,
+      documentRelEntries: [
+        `<Relationship Id="rId10" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="https://example.com/?a=1&amp;b=2" TargetMode="External"/>`,
+        `<Relationship Id="rId11" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="javascript:alert(1)" TargetMode="External"/>`,
+      ],
+    });
+    const { odt, lossiness } = await convertDocxToOdt(docx);
+
+    const contentXml = await (await OdfArchive.load(odt)).getContentXml();
+    const doc = parseXml(contentXml);
+    const anchors = Array.from(doc.getElementsByTagNameNS(ODF_NS.TEXT, 'a'));
+    expect(anchors).toHaveLength(1);
+    // DOM attribute value is the decoded URL — single-escaped in the serialized XML, not doubled.
+    expect(anchors[0]!.getAttributeNS(ODF_NS.XLINK, 'href')).toBe('https://example.com/?a=1&b=2');
+    expect(contentXml).toContain('xlink:href="https://example.com/?a=1&amp;b=2"');
+    expect(contentXml).not.toContain('&amp;amp;');
+    expect(contentXml).not.toContain('javascript:');
+    // The unsafe link's text survives as plain text and the drop is reported.
+    expect((await reopen(odt)).getParagraphs().map((b) => b.text)).toEqual(['safe link', 'evil link']);
+    expect(lossiness.some((e) => e.construct === 'unsafe-hyperlink-href')).toBe(true);
+  });
+
+  it('[CONV-10] dropped constructs are reported in the lossiness summary, never silently', async () => {
+    const bodyXml = `<w:p><w:r><w:rPr><w:color w:val="FF0000"/></w:rPr><w:t>red text</w:t></w:r></w:p>`;
+    const docx = await buildDocxFromParts({ bodyXml });
+    const { odt, lossiness } = await convertDocxToOdt(docx);
+
+    const fontDrop = lossiness.find((e) => e.construct === 'font-formatting-dropped');
+    expect(fontDrop).toBeDefined();
+    expect(fontDrop!.count).toBeGreaterThanOrEqual(1);
+    // The text itself is preserved.
+    expect((await reopen(odt)).getParagraphs().map((b) => b.text)).toEqual(['red text']);
+  });
+
+  it('[CONV-11] converted output reopens through odf-core with matching visible text', async () => {
+    const bodyXml = p('First') + styledP('Heading1', 'Heading') + p('Last');
+    const docx = await buildDocxFromParts({ bodyXml });
+    const { odt } = await convertDocxToOdt(docx);
+
+    const reopened = await reopen(odt);
+    expect(reopened.getParagraphs().map((b) => b.text)).toEqual(['First', 'Heading', 'Last']);
+  });
+});

--- a/packages/odf-core/src/convert/convert_lists.test.ts
+++ b/packages/odf-core/src/convert/convert_lists.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import { buildDocxFromParts, parseXml } from '@usejunior/docx-core';
+
+import { convertDocxToOdt } from './docx_to_odt.js';
+import { OdfArchive } from '../shared/odf/OdfArchive.js';
+import { ODF_NS } from '../shared/odf/namespaces.js';
+
+function listP(numId: number, ilvl: number, text: string): string {
+  return (
+    `<w:p><w:pPr><w:numPr><w:ilvl w:val="${ilvl}"/><w:numId w:val="${numId}"/></w:numPr></w:pPr>` +
+    `<w:r><w:t xml:space="preserve">${text}</w:t></w:r></w:p>`
+  );
+}
+
+function numberingXml(levels: Array<{ ilvl: number; numFmt: string; lvlText: string }>): string {
+  const lvls = levels
+    .map(
+      (l) =>
+        `<w:lvl w:ilvl="${l.ilvl}"><w:start w:val="1"/><w:numFmt w:val="${l.numFmt}"/>` +
+        `<w:lvlText w:val="${l.lvlText}"/><w:suff w:val="space"/></w:lvl>`,
+    )
+    .join('');
+  return (
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
+    `<w:abstractNum w:abstractNumId="0">${lvls}</w:abstractNum>` +
+    `<w:num w:numId="1"><w:abstractNumId w:val="0"/></w:num>` +
+    `</w:numbering>`
+  );
+}
+
+async function contentDom(odt: Buffer): Promise<Document> {
+  return parseXml(await (await OdfArchive.load(odt)).getContentXml());
+}
+
+describe('convertDocxToOdt — lists', () => {
+  it('[CONV-06] auto-numbered lists nest text:list with mapped number formats; level jumps stay well-formed', async () => {
+    const docx = await buildDocxFromParts({
+      bodyXml:
+        listP(1, 0, 'one') +
+        listP(1, 1, 'one-a') +
+        listP(1, 0, 'two') +
+        listP(1, 2, 'jump two levels') +
+        listP(1, 2, 'jump sibling'),
+      numberingXml: numberingXml([
+        { ilvl: 0, numFmt: 'decimal', lvlText: '%1.' },
+        { ilvl: 1, numFmt: 'lowerLetter', lvlText: '%2)' },
+        { ilvl: 2, numFmt: 'upperRoman', lvlText: '%3.' },
+      ]),
+    });
+    const { odt } = await convertDocxToOdt(docx);
+    const doc = await contentDom(odt);
+
+    // List style: per-level num formats mapped from OOXML numFmt.
+    const listStyles = Array.from(doc.getElementsByTagNameNS(ODF_NS.TEXT, 'list-style'));
+    expect(listStyles).toHaveLength(1);
+    const numLevels = Array.from(listStyles[0]!.getElementsByTagNameNS(ODF_NS.TEXT, 'list-level-style-number'));
+    const fmtByLevel = new Map(
+      numLevels.map((el) => [el.getAttributeNS(ODF_NS.TEXT, 'level'), el.getAttributeNS(ODF_NS.STYLE, 'num-format')]),
+    );
+    expect(fmtByLevel.get('1')).toBe('1');
+    expect(fmtByLevel.get('2')).toBe('a');
+    expect(fmtByLevel.get('3')).toBe('I');
+    const suffixByLevel = new Map(
+      numLevels.map((el) => [el.getAttributeNS(ODF_NS.TEXT, 'level'), el.getAttributeNS(ODF_NS.STYLE, 'num-suffix')]),
+    );
+    expect(suffixByLevel.get('1')).toBe('.');
+    expect(suffixByLevel.get('2')).toBe(')');
+
+    // Nesting depth of each item's text:p — count enclosing text:list ancestors.
+    const depthOf = (text: string): number => {
+      const para = Array.from(doc.getElementsByTagNameNS(ODF_NS.TEXT, 'p')).find((el) => el.textContent === text);
+      expect(para, `paragraph "${text}"`).toBeDefined();
+      let depth = 0;
+      for (let n = para!.parentNode; n; n = n.parentNode) {
+        if ((n as Element).localName === 'list' && (n as Element).namespaceURI === ODF_NS.TEXT) depth += 1;
+      }
+      return depth;
+    };
+    expect(depthOf('one')).toBe(1);
+    expect(depthOf('one-a')).toBe(2);
+    expect(depthOf('two')).toBe(1);
+    // A jump of two ilvls opens a single nested step (not three), and the jumped level's
+    // sibling lands at the same depth instead of nesting further.
+    expect(depthOf('jump two levels')).toBe(2);
+    expect(depthOf('jump sibling')).toBe(2);
+  });
+
+  it('[CONV-07] bullet lists become text:list with a bullet list style', async () => {
+    const docx = await buildDocxFromParts({
+      bodyXml: listP(1, 0, 'first bullet') + listP(1, 0, 'second bullet'),
+      numberingXml: numberingXml([{ ilvl: 0, numFmt: 'bullet', lvlText: '' }]),
+    });
+    const { odt } = await convertDocxToOdt(docx);
+    const doc = await contentDom(odt);
+
+    const lists = Array.from(doc.getElementsByTagNameNS(ODF_NS.TEXT, 'list'));
+    expect(lists).toHaveLength(1);
+    const items = Array.from(lists[0]!.getElementsByTagNameNS(ODF_NS.TEXT, 'list-item'));
+    expect(items).toHaveLength(2);
+    const bulletLevels = doc.getElementsByTagNameNS(ODF_NS.TEXT, 'list-level-style-bullet');
+    expect(bulletLevels.length).toBeGreaterThan(0);
+    expect(bulletLevels[0]!.getAttributeNS(ODF_NS.TEXT, 'bullet-char')).toBe('•');
+  });
+
+  it('[CONV-08] manual/legal labels stay literal paragraph text with no text:list wrapper', async () => {
+    const docx = await buildDocxFromParts({
+      bodyXml:
+        `<w:p><w:r><w:t xml:space="preserve">Section 2.1 Confidential Information.</w:t></w:r></w:p>` +
+        `<w:p><w:r><w:t xml:space="preserve">(a) each party shall comply.</w:t></w:r></w:p>`,
+    });
+    const { odt } = await convertDocxToOdt(docx);
+    const doc = await contentDom(odt);
+
+    expect(doc.getElementsByTagNameNS(ODF_NS.TEXT, 'list')).toHaveLength(0);
+    const texts = Array.from(doc.getElementsByTagNameNS(ODF_NS.TEXT, 'p')).map((el) => el.textContent);
+    expect(texts).toContain('Section 2.1 Confidential Information.');
+    expect(texts).toContain('(a) each party shall comply.');
+  });
+});

--- a/packages/odf-core/src/convert/convert_real_documents.test.ts
+++ b/packages/odf-core/src/convert/convert_real_documents.test.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { describe, it, expect } from 'vitest';
+import { DocxDocument, tokenizeToonInline, type DocumentViewNode } from '@usejunior/docx-core';
+
+import { convertDocxToOdt } from './docx_to_odt.js';
+import { OdfArchive } from '../shared/odf/OdfArchive.js';
+import { OdfDocument } from '../document.js';
+import { validateOdfArchiveSafety } from '../odf_archive_safety.js';
+
+const FIXTURES = [
+  'tests/test_documents/nvca-coi-regression/source.docx',
+  'tests/test_documents/open-agreements/common-paper-mutual-nda.docx',
+  'tests/test_documents/open-agreements/bonterms-mutual-nda.docx',
+  'tests/test_documents/open-agreements/letter-of-intent.docx',
+].map((rel) => ({ rel, abs: fileURLToPath(new URL(`../../../../${rel}`, import.meta.url)) }));
+
+/** The visible text a converted node must produce (manual labels are prepended literally). */
+function expectedText(node: DocumentViewNode): string {
+  const text = tokenizeToonInline(node.tagged_text)
+    .filter((t) => t.kind === 'text')
+    .map((t) => t.value)
+    .join('');
+  const isManualLabel = node.list_metadata.list_level >= 0 && !node.list_metadata.is_auto_numbered;
+  const label = node.list_metadata.label_string.trim();
+  return isManualLabel && label ? `${label} ${text}` : text;
+}
+
+describe('convertDocxToOdt — real contract documents', () => {
+  it(
+    '[CONV-12] real documents convert end-to-end: safe package, reopens, visible text preserved',
+    async () => {
+      for (const { rel, abs } of FIXTURES) {
+        const docx = readFileSync(abs);
+        const { odt } = await convertDocxToOdt(docx);
+
+        const safety = await validateOdfArchiveSafety(odt);
+        expect(safety.ok, `${rel}: archive safety`).toBe(true);
+
+        // Expected text comes from the same semantic view the converter consumes.
+        const source = await DocxDocument.load(docx);
+        source.normalize();
+        source.insertParagraphBookmarks('_convert_test');
+        const { nodes } = source.buildDocumentView({ showFormatting: true, formattingMode: 'full' });
+        const expected = nodes.map(expectedText).filter((t) => t.trim() !== '');
+
+        const archive = await OdfArchive.load(odt);
+        const reopened = OdfDocument.fromContentXml(await archive.getContentXml());
+        // Grid-gap filler cells add empty paragraphs; compare the non-empty sequence.
+        const actual = reopened
+          .getParagraphs()
+          .map((b) => b.text)
+          .filter((t) => t.trim() !== '');
+
+        expect(actual, `${rel}: visible text`).toEqual(expected);
+      }
+    },
+    120_000,
+  );
+});

--- a/packages/odf-core/src/convert/convert_tables.test.ts
+++ b/packages/odf-core/src/convert/convert_tables.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { buildDocxFromParts, parseXml } from '@usejunior/docx-core';
+
+import { convertDocxToOdt } from './docx_to_odt.js';
+import { OdfArchive } from '../shared/odf/OdfArchive.js';
+import { ODF_NS } from '../shared/odf/namespaces.js';
+
+function tc(content: string, gridSpan?: number): string {
+  const span = gridSpan ? `<w:tcPr><w:gridSpan w:val="${gridSpan}"/></w:tcPr>` : '';
+  return `<w:tc>${span}${content}</w:tc>`;
+}
+
+function cellP(text: string): string {
+  return `<w:p><w:r><w:t xml:space="preserve">${text}</w:t></w:r></w:p>`;
+}
+
+describe('convertDocxToOdt — tables', () => {
+  it('[CONV-09] tables become a complete rectangular grid with header rows, multi-para cells, and filled gaps', async () => {
+    const bodyXml =
+      `<w:tbl><w:tblPr/><w:tblGrid><w:gridCol/><w:gridCol/><w:gridCol/></w:tblGrid>` +
+      `<w:tr>${tc(cellP('H1'))}${tc(cellP('H2'))}${tc(cellP('H3'))}</w:tr>` +
+      `<w:tr>${tc(cellP('A1 first') + cellP('A1 second'))}${tc(cellP('wide cell'), 2)}</w:tr>` +
+      `</w:tbl>` +
+      cellP('After the table');
+    const docx = await buildDocxFromParts({ bodyXml });
+    const { odt, lossiness } = await convertDocxToOdt(docx);
+
+    const doc = parseXml(await (await OdfArchive.load(odt)).getContentXml());
+    const tables = Array.from(doc.getElementsByTagNameNS(ODF_NS.TABLE, 'table'));
+    expect(tables).toHaveLength(1);
+    const table = tables[0]!;
+    expect(table.getAttributeNS(ODF_NS.TABLE, 'name')).toBe('Table1');
+
+    const columns = table.getElementsByTagNameNS(ODF_NS.TABLE, 'table-column');
+    expect(columns).toHaveLength(1);
+    expect(columns[0]!.getAttributeNS(ODF_NS.TABLE, 'number-columns-repeated')).toBe('3');
+
+    // First row (the view model's header heuristic) sits in table:table-header-rows.
+    const headerContainers = table.getElementsByTagNameNS(ODF_NS.TABLE, 'table-header-rows');
+    expect(headerContainers).toHaveLength(1);
+    const headerCells = Array.from(headerContainers[0]!.getElementsByTagNameNS(ODF_NS.TABLE, 'table-cell'));
+    expect(headerCells.map((c) => c.textContent)).toEqual(['H1', 'H2', 'H3']);
+
+    // Every row carries the full column count; the gridSpan gap is filled with an empty cell.
+    const bodyRows = Array.from(table.getElementsByTagNameNS(ODF_NS.TABLE, 'table-row')).filter(
+      (r) => r.parentNode === table,
+    );
+    expect(bodyRows).toHaveLength(1);
+    const bodyCells = Array.from(bodyRows[0]!.getElementsByTagNameNS(ODF_NS.TABLE, 'table-cell'));
+    expect(bodyCells).toHaveLength(3);
+    expect(bodyCells[2]!.textContent).toBe('');
+    expect(lossiness.some((e) => e.construct === 'table-grid-gaps-filled')).toBe(true);
+
+    // The multi-paragraph cell keeps separate text:p children (no flattening).
+    const multiPara = Array.from(bodyCells[0]!.getElementsByTagNameNS(ODF_NS.TEXT, 'p'));
+    expect(multiPara.map((p) => p.textContent)).toEqual(['A1 first', 'A1 second']);
+
+    // Body text after the table is outside any table element.
+    const after = Array.from(doc.getElementsByTagNameNS(ODF_NS.TEXT, 'p')).find(
+      (p) => p.textContent === 'After the table',
+    );
+    expect(after).toBeDefined();
+    let inTable = false;
+    for (let n = after!.parentNode; n; n = n.parentNode) {
+      if ((n as Element).localName === 'table') inTable = true;
+    }
+    expect(inTable).toBe(false);
+  });
+});

--- a/packages/odf-core/src/convert/docx_to_odt.ts
+++ b/packages/odf-core/src/convert/docx_to_odt.ts
@@ -1,0 +1,136 @@
+/**
+ * Native DOCX → ODT conversion (issue #331).
+ *
+ * Traverses docx-core's structured document view — the same intentionally-lossy semantic
+ * model the markdown/HTML serializers consume — and emits a fresh ODT package. No external
+ * binary is involved at runtime; LibreOffice exists only as a differential test oracle.
+ *
+ * `formattingMode: 'full'` is required (not the `'compact'` default): compact mode encodes
+ * the document's dominant formatting as a modal baseline rather than per-run tags, which
+ * would silently drop bold/italic/underline on mostly-bold documents.
+ */
+
+import { DocxDocument, serializeXml, type DocumentViewNode } from '@usejunior/docx-core';
+
+import { OdfArchive } from '../shared/odf/OdfArchive.js';
+import { ODF_NS } from '../shared/odf/namespaces.js';
+import { appendInlineContent, TextStyleRegistry } from './inline.js';
+import { ListDomBuilder, ListStyleRegistry } from './lists.js';
+import { appendTable, registerCellStyle } from './tables.js';
+import { appendTextWithWhitespace, buildMetaXml, buildStylesXml, createContentScaffold } from './package.js';
+import { LossinessCollector, type ConvertDocxToOdtOptions, type ConvertDocxToOdtResult } from './types.js';
+
+/** A heading is structural only when Word's style said so — heuristic headings stay paragraphs. */
+function isStructuralHeading(node: DocumentViewNode): boolean {
+  return node.heading?.source === 'word_style' && typeof node.heading.level === 'number';
+}
+
+/** Convert a `.docx` buffer to a fresh `.odt` package plus a lossiness report. */
+export async function convertDocxToOdt(
+  docx: Buffer,
+  options?: ConvertDocxToOdtOptions,
+): Promise<ConvertDocxToOdtResult> {
+  const source = await DocxDocument.load(docx);
+  // The document view only yields nodes for `_bk_`-bookmarked paragraphs, and bookmarks are
+  // normally injected per MCP session — a raw `.docx` has none. Prime the loaded copy the
+  // same way the session manager does (the input buffer is never written back).
+  source.normalize();
+  source.insertParagraphBookmarks('_convert');
+  const { nodes } = source.buildDocumentView({ showFormatting: true, formattingMode: 'full' });
+  const numbering = source.getNumberingModel();
+
+  const lossiness = new LossinessCollector();
+  // The view only surfaces bookmarked paragraphs; text-empty paragraphs that anchor nothing
+  // stay unsurfaced and therefore drop out of the conversion. Report the count, not silence.
+  const totalParagraphs = source.getParagraphs().length;
+  if (totalParagraphs > nodes.length) {
+    lossiness.add(
+      'unsurfaced-paragraphs-dropped',
+      `${totalParagraphs - nodes.length} text-empty paragraph(s) not surfaced by the document view`,
+    );
+  }
+  const { doc, automaticStyles, body } = createContentScaffold();
+  const textStyles = new TextStyleRegistry(doc, automaticStyles);
+  const listStyles = new ListStyleRegistry(doc, automaticStyles, numbering);
+  const cellStyleName = registerCellStyle(doc, automaticStyles);
+
+  const fillParagraph = (p: Element, node: DocumentViewNode): void => {
+    appendInlineContent(doc, p, node.tagged_text, textStyles, lossiness);
+  };
+  const newParagraph = (styleName: string): Element => {
+    const p = doc.createElementNS(ODF_NS.TEXT, 'text:p');
+    p.setAttributeNS(ODF_NS.TEXT, 'text:style-name', styleName);
+    body.appendChild(p);
+    return p;
+  };
+
+  let listBuilder: ListDomBuilder | null = null;
+  let tableCount = 0;
+
+  for (let i = 0; i < nodes.length; i++) {
+    const node = nodes[i]!;
+
+    // ── Tables: consume the whole run of same-table_id nodes at once ──
+    if (node.table_context) {
+      listBuilder = null;
+      const tableId = node.table_context.table_id;
+      const group: DocumentViewNode[] = [];
+      while (i < nodes.length && nodes[i]!.table_context?.table_id === tableId) {
+        group.push(nodes[i]!);
+        i++;
+      }
+      i--; // for-loop re-increments
+      tableCount += 1;
+      appendTable(doc, body, group, tableCount, cellStyleName, fillParagraph, lossiness);
+      continue;
+    }
+
+    // ── Word-styled headings ──
+    if (isStructuralHeading(node)) {
+      listBuilder = null;
+      const level = Math.min(6, Math.max(1, node.heading!.level as number));
+      const h = doc.createElementNS(ODF_NS.TEXT, 'text:h');
+      h.setAttributeNS(ODF_NS.TEXT, 'text:outline-level', String(level));
+      h.setAttributeNS(ODF_NS.TEXT, 'text:style-name', `Heading_20_${level}`);
+      body.appendChild(h);
+      fillParagraph(h, node);
+      continue;
+    }
+
+    if (node.list_metadata.list_level >= 0) {
+      // ── Auto-numbered / bullet items (any numPr): nested text:list ──
+      if (node.list_metadata.is_auto_numbered) {
+        const numId = node.numbering.num_id;
+        // Bullet vs number comes from the numbering model's numFmt — `LabelType` has no
+        // bullet member, so the label classification can't signal it.
+        const bulletHint = listStyles.isBulletLevel(numId, node.numbering.ilvl);
+        const styleName = listStyles.styleFor(numId, bulletHint);
+        if (!listBuilder) listBuilder = new ListDomBuilder(doc, body);
+        const p = listBuilder.item(node.list_metadata.list_level, styleName);
+        fillParagraph(p, node);
+        continue;
+      }
+      // ── Manual/legal labels (`Section 2.1`, `(a)`): literal paragraph text, NO text:list.
+      //    Deliberate divergence from the HTML serializer's <ul><li> wrapping — an ODF list
+      //    renderer would print its own number next to the legal label. ──
+      listBuilder = null;
+      const p = newParagraph('Standard');
+      const label = node.list_metadata.label_string.trim();
+      if (label) appendTextWithWhitespace(doc, p, `${label} `);
+      fillParagraph(p, node);
+      continue;
+    }
+
+    // ── Normal paragraphs (heuristic headings land here; empty paragraphs are kept) ──
+    listBuilder = null;
+    fillParagraph(newParagraph('Standard'), node);
+  }
+
+  const archive = OdfArchive.create({
+    contentXml: serializeXml(doc),
+    stylesXml: buildStylesXml(),
+    metaXml: buildMetaXml(options?.metadata),
+  });
+  const odt = await archive.save();
+  return { odt, lossiness: lossiness.toArray() };
+}

--- a/packages/odf-core/src/convert/index.ts
+++ b/packages/odf-core/src/convert/index.ts
@@ -1,0 +1,2 @@
+export { convertDocxToOdt } from './docx_to_odt.js';
+export type { ConvertDocxToOdtOptions, ConvertDocxToOdtResult, LossinessEntry } from './types.js';

--- a/packages/odf-core/src/convert/inline.ts
+++ b/packages/odf-core/src/convert/inline.ts
@@ -1,0 +1,148 @@
+/**
+ * Inline content emission for the DOCX → ODT converter: `tagged_text` TOON tokens →
+ * `text:span` / `text:a` DOM, backed by a deduped automatic text-style registry.
+ *
+ * The token grammar is owned by docx-core (`tokenizeToonInline`, the same primitive the
+ * markdown/HTML serializers consume) so this module never re-derives it. Supported wraps are
+ * bold / italic / underline / highlight; `<font …>` (full-mode color/size/face) is
+ * recognized-and-dropped with a lossiness entry — richer style mapping is deferred (#331
+ * phase 3). Unsafe hyperlink schemes degrade to plain text via the shared `isSafeHref`.
+ */
+
+import { isSafeHref, tokenizeToonInline } from '@usejunior/docx-core';
+
+import { ODF_NS } from '../shared/odf/namespaces.js';
+import { appendTextWithWhitespace } from './package.js';
+import type { LossinessCollector } from './types.js';
+
+interface InlineFormats {
+  bold: boolean;
+  italic: boolean;
+  underline: boolean;
+  highlight: boolean;
+}
+
+/**
+ * Deduped `office:automatic-styles` registry for run formatting: one `T<n>` text style per
+ * distinct format combination, shared across the whole document.
+ */
+export class TextStyleRegistry {
+  private byKey = new Map<string, string>();
+
+  constructor(
+    private readonly doc: Document,
+    private readonly container: Element,
+  ) {}
+
+  styleFor(formats: InlineFormats): string {
+    const key = [
+      formats.bold ? 'b' : '',
+      formats.italic ? 'i' : '',
+      formats.underline ? 'u' : '',
+      formats.highlight ? 'h' : '',
+    ].join('');
+    const existing = this.byKey.get(key);
+    if (existing) return existing;
+
+    const name = `T${this.byKey.size + 1}`;
+    const style = this.doc.createElementNS(ODF_NS.STYLE, 'style:style');
+    style.setAttributeNS(ODF_NS.STYLE, 'style:name', name);
+    style.setAttributeNS(ODF_NS.STYLE, 'style:family', 'text');
+    const props = this.doc.createElementNS(ODF_NS.STYLE, 'style:text-properties');
+    if (formats.bold) props.setAttributeNS(ODF_NS.FO, 'fo:font-weight', 'bold');
+    if (formats.italic) props.setAttributeNS(ODF_NS.FO, 'fo:font-style', 'italic');
+    if (formats.underline) {
+      props.setAttributeNS(ODF_NS.STYLE, 'style:text-underline-style', 'solid');
+      props.setAttributeNS(ODF_NS.STYLE, 'style:text-underline-width', 'auto');
+      props.setAttributeNS(ODF_NS.STYLE, 'style:text-underline-color', 'font-color');
+    }
+    if (formats.highlight) props.setAttributeNS(ODF_NS.FO, 'fo:background-color', '#ffff00');
+    style.appendChild(props);
+    this.container.appendChild(style);
+    this.byKey.set(key, name);
+    return name;
+  }
+}
+
+/** Reverse of `formatting_tags.ts`'s `escapeHtmlAttribute` (`&amp;` last so it can't re-expand). */
+function unescapeAttributeValue(value: string): string {
+  return value
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>')
+    .replaceAll('&quot;', '"')
+    .replaceAll('&amp;', '&');
+}
+
+/**
+ * Append one `tagged_text` string's content to `parent` (a `text:p`/`text:h` or table-cell
+ * paragraph), wrapping formatted runs in `text:span` and hyperlinks in `text:a`.
+ */
+export function appendInlineContent(
+  doc: Document,
+  parent: Element,
+  taggedText: string,
+  styles: TextStyleRegistry,
+  lossiness: LossinessCollector,
+): void {
+  const formats: InlineFormats = { bold: false, italic: false, underline: false, highlight: false };
+  let openAnchor: Element | null = null;
+  // The currently open span and the format key it was created for: consecutive text tokens with
+  // an unchanged format set share one span instead of fragmenting into adjacent twins.
+  let openSpan: { el: Element; key: string } | null = null;
+
+  const formatKey = (): string =>
+    `${formats.bold ? 'b' : ''}${formats.italic ? 'i' : ''}${formats.underline ? 'u' : ''}${formats.highlight ? 'h' : ''}`;
+
+  for (const token of tokenizeToonInline(taggedText)) {
+    if (token.kind === 'text') {
+      const container = openAnchor ?? parent;
+      const key = formatKey();
+      if (key === '') {
+        openSpan = null;
+        appendTextWithWhitespace(doc, container, token.value);
+        continue;
+      }
+      if (!openSpan || openSpan.key !== key || openSpan.el.parentNode !== container) {
+        const span = doc.createElementNS(ODF_NS.TEXT, 'text:span');
+        span.setAttributeNS(ODF_NS.TEXT, 'text:style-name', styles.styleFor(formats));
+        container.appendChild(span);
+        openSpan = { el: span, key };
+      }
+      appendTextWithWhitespace(doc, openSpan.el, token.value);
+      continue;
+    }
+
+    const tag = token.value;
+    if (tag === '<b>') { formats.bold = true; openSpan = null; }
+    else if (tag === '</b>') { formats.bold = false; openSpan = null; }
+    else if (tag === '<i>') { formats.italic = true; openSpan = null; }
+    else if (tag === '</i>') { formats.italic = false; openSpan = null; }
+    else if (tag === '<u>') { formats.underline = true; openSpan = null; }
+    else if (tag === '</u>') { formats.underline = false; openSpan = null; }
+    else if (tag === '<highlight>') { formats.highlight = true; openSpan = null; }
+    else if (tag === '</highlight>') { formats.highlight = false; openSpan = null; }
+    else if (tag.startsWith('<a ')) {
+      const escapedHref = /href="([^"]*)"/.exec(tag)?.[1] ?? '';
+      // The TOON attribute value is escaped by emitFormattingTags; setAttributeNS escapes
+      // again on serialize, so assign the DECODED value or `&amp;` doubles.
+      const href = unescapeAttributeValue(escapedHref);
+      if (isSafeHref(href)) {
+        const anchor = doc.createElementNS(ODF_NS.TEXT, 'text:a');
+        anchor.setAttributeNS(ODF_NS.XLINK, 'xlink:type', 'simple');
+        anchor.setAttributeNS(ODF_NS.XLINK, 'xlink:href', href);
+        parent.appendChild(anchor);
+        openAnchor = anchor;
+      } else {
+        lossiness.add('unsafe-hyperlink-href', href);
+        openAnchor = null;
+      }
+      openSpan = null;
+    } else if (tag === '</a>') {
+      openAnchor = null;
+      openSpan = null;
+    } else if (tag.startsWith('<font ')) {
+      lossiness.add('font-formatting-dropped', tag);
+    }
+    // `</font>` needs no action: the open tag never changed format state.
+  }
+}

--- a/packages/odf-core/src/convert/lists.ts
+++ b/packages/odf-core/src/convert/lists.ts
@@ -1,0 +1,140 @@
+/**
+ * List emission for the DOCX → ODT converter: flat auto-numbered/bullet view nodes →
+ * nested `text:list` DOM plus synthesized `text:list-style`s.
+ *
+ * The nesting logic is a DOM port of the HTML serializer's `ListBuilder`: OOXML `ilvl`
+ * carries no monotonicity guarantee, so each open list records the item LEVEL that opened
+ * it (not just depth) — that keeps consecutive same-level items siblings even after a
+ * level jump that skipped intermediate depths.
+ */
+
+import type { NumberingModel } from '@usejunior/docx-core';
+
+import { ODF_NS } from '../shared/odf/namespaces.js';
+
+/** OOXML `numFmt` → ODF `style:num-format`. Anything unmapped falls back to decimal. */
+const NUM_FORMAT_MAP: Record<string, string> = {
+  decimal: '1',
+  lowerLetter: 'a',
+  upperLetter: 'A',
+  lowerRoman: 'i',
+  upperRoman: 'I',
+};
+
+const MAX_LIST_LEVELS = 10;
+const DEFAULT_BULLET_CHAR = '•';
+
+/**
+ * Deduped `office:automatic-styles` registry for lists: one `L<n>` list style per source
+ * `num_id` (or per fallback kind when the numbering model has no entry), with one
+ * `text:list-level-style-*` per level sourced from the OOXML numbering definition.
+ */
+export class ListStyleRegistry {
+  private byKey = new Map<string, string>();
+
+  constructor(
+    private readonly doc: Document,
+    private readonly container: Element,
+    private readonly numbering: NumberingModel | null,
+  ) {}
+
+  /** Style name for a list opened by a node with the given `num_id` (bullet hint for model-less docs). */
+  styleFor(numId: string | null, bulletHint: boolean): string {
+    const abstract = this.abstractFor(numId);
+    const key = abstract ? `num:${abstract.abstractNumId}` : bulletHint ? 'fallback:bullet' : 'fallback:number';
+    const existing = this.byKey.get(key);
+    if (existing) return existing;
+
+    const name = `L${this.byKey.size + 1}`;
+    const style = this.doc.createElementNS(ODF_NS.TEXT, 'text:list-style');
+    style.setAttributeNS(ODF_NS.STYLE, 'style:name', name);
+    for (let level = 0; level < MAX_LIST_LEVELS; level++) {
+      const def = abstract?.levels.get(level);
+      if (def ? def.numFmt === 'bullet' : bulletHint) {
+        style.appendChild(this.bulletLevel(level));
+      } else {
+        style.appendChild(this.numberLevel(level, def ?? null));
+      }
+    }
+    this.container.appendChild(style);
+    this.byKey.set(key, name);
+    return name;
+  }
+
+  /** True when the level's source `numFmt` is `bullet` (used to pick the fallback hint). */
+  isBulletLevel(numId: string | null, ilvl: number | null): boolean {
+    const def = this.abstractFor(numId)?.levels.get(ilvl ?? 0);
+    return def?.numFmt === 'bullet';
+  }
+
+  private abstractFor(numId: string | null) {
+    if (!numId || !this.numbering) return null;
+    const instance = this.numbering.nums.get(numId);
+    if (!instance) return null;
+    return this.numbering.abstractNums.get(instance.abstractNumId) ?? null;
+  }
+
+  private bulletLevel(level: number): Element {
+    const el = this.doc.createElementNS(ODF_NS.TEXT, 'text:list-level-style-bullet');
+    el.setAttributeNS(ODF_NS.TEXT, 'text:level', String(level + 1));
+    el.setAttributeNS(ODF_NS.TEXT, 'text:bullet-char', DEFAULT_BULLET_CHAR);
+    return el;
+  }
+
+  private numberLevel(level: number, def: { numFmt: string; lvlText: string; start: number } | null): Element {
+    const el = this.doc.createElementNS(ODF_NS.TEXT, 'text:list-level-style-number');
+    el.setAttributeNS(ODF_NS.TEXT, 'text:level', String(level + 1));
+    el.setAttributeNS(ODF_NS.STYLE, 'style:num-format', NUM_FORMAT_MAP[def?.numFmt ?? 'decimal'] ?? '1');
+    // The literal after the last `%N` placeholder (e.g. `%1.` → `.`, `%1)` → `)`).
+    const suffix = def ? /%\d+([^%]*)$/.exec(def.lvlText)?.[1] ?? '' : '.';
+    if (suffix) el.setAttributeNS(ODF_NS.STYLE, 'style:num-suffix', suffix);
+    if (def && def.start !== 1) el.setAttributeNS(ODF_NS.TEXT, 'text:start-value', String(def.start));
+    return el;
+  }
+}
+
+/**
+ * Builds one contiguous run of list items as nested `text:list` DOM under `parent`.
+ * `item()` returns the `text:p` to fill with the node's inline content.
+ */
+export class ListDomBuilder {
+  private stack: Array<{ list: Element; level: number }> = [];
+
+  constructor(
+    private readonly doc: Document,
+    private readonly parent: Element,
+  ) {}
+
+  item(level: number, styleName: string): Element {
+    const lvl = Math.max(0, level);
+    while (this.stack.length > 0 && this.stack[this.stack.length - 1]!.level > lvl) {
+      this.stack.pop();
+    }
+    let top = this.stack[this.stack.length - 1];
+    if (!top || top.level !== lvl) {
+      // Deeper than the open top (or the first item): open ONE nested list recording the
+      // item's actual level, so a >1 jump still nests a single step.
+      const list = this.doc.createElementNS(ODF_NS.TEXT, 'text:list');
+      list.setAttributeNS(ODF_NS.TEXT, 'text:style-name', styleName);
+      if (!top) {
+        this.parent.appendChild(list);
+      } else {
+        // Nested lists live inside a list-item; reuse the last one or create a holder.
+        let host = top.list.lastChild as Element | null;
+        if (!host || host.localName !== 'list-item') {
+          host = this.doc.createElementNS(ODF_NS.TEXT, 'text:list-item');
+          top.list.appendChild(host);
+        }
+        host.appendChild(list);
+      }
+      this.stack.push({ list, level: lvl });
+      top = this.stack[this.stack.length - 1];
+    }
+    const item = this.doc.createElementNS(ODF_NS.TEXT, 'text:list-item');
+    top!.list.appendChild(item);
+    const p = this.doc.createElementNS(ODF_NS.TEXT, 'text:p');
+    p.setAttributeNS(ODF_NS.TEXT, 'text:style-name', 'Standard');
+    item.appendChild(p);
+    return p;
+  }
+}

--- a/packages/odf-core/src/convert/lo_convert_differential.test.ts
+++ b/packages/odf-core/src/convert/lo_convert_differential.test.ts
@@ -1,0 +1,79 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { describe, it, expect } from 'vitest';
+import { resolveSoffice, runLibreOfficeOracle } from '@usejunior/docx-core';
+
+import { convertDocxToOdt } from './docx_to_odt.js';
+import { OdfArchive } from '../shared/odf/OdfArchive.js';
+import { OdfDocument } from '../document.js';
+
+const NDA_DOCX = fileURLToPath(
+  new URL('../../../../tests/test_documents/open-agreements/common-paper-mutual-nda.docx', import.meta.url),
+);
+
+/**
+ * The structural projection both converters must agree on: visible body text plus the
+ * paragraph/heading/list/table shape. Never bytes — LibreOffice rewrites styles, names,
+ * and whitespace encodings freely.
+ */
+function projection(contentXml: string): {
+  joinedText: string;
+  headingCount: number;
+  tableCount: number;
+  hasLists: boolean;
+} {
+  const doc = OdfDocument.fromContentXml(contentXml);
+  const joinedText = doc
+    .getParagraphs()
+    .map((b) => b.text)
+    .filter((t) => t.trim() !== '')
+    .join('\n')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return {
+    joinedText,
+    headingCount: (contentXml.match(/<text:h[\s>]/g) ?? []).length,
+    tableCount: (contentXml.match(/<table:table[\s>]/g) ?? []).length,
+    hasLists: /<text:list[\s>]/.test(contentXml),
+  };
+}
+
+describe('convertDocxToOdt — LibreOffice differential oracle', () => {
+  it(
+    '[CONV-13] native conversion structurally agrees with a LibreOffice-converted reference (skips without a usable soffice)',
+    async () => {
+      const soffice = resolveSoffice();
+      if (!soffice) {
+        console.warn('[CONV-13] soffice not found — skipping differential test (set ODF_SOFFICE_BIN to enable).');
+        return;
+      }
+      // Preflight probe: soffice can resolve yet be unusable (observed: `Abort trap: 6` under
+      // macOS Launch Constraints). A broken oracle must SKIP this differential, not fail it.
+      try {
+        await runLibreOfficeOracle(
+          [{ op: 'identity', documentXml: '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>probe</w:t></w:r></w:p></w:body></w:document>' }],
+          soffice,
+        );
+      } catch (err) {
+        console.warn(`[CONV-13] soffice present but unusable — skipping differential test: ${(err as Error).message.split('\n')[0]}`);
+        return;
+      }
+
+      const docx = readFileSync(NDA_DOCX);
+      const { odt } = await convertDocxToOdt(docx);
+      const nativeContentXml = await (await OdfArchive.load(odt)).getContentXml();
+
+      const [referenceContentXml] = await runLibreOfficeOracle([{ op: 'identity', docx, saveAs: 'odt' }], soffice);
+
+      const native = projection(nativeContentXml);
+      const reference = projection(referenceContentXml!);
+
+      expect(native.joinedText, 'visible text').toBe(reference.joinedText);
+      expect(native.tableCount, 'table count').toBe(reference.tableCount);
+      expect(native.headingCount, 'heading count').toBe(reference.headingCount);
+      expect(native.hasLists, 'list presence').toBe(reference.hasLists);
+    },
+    240_000,
+  );
+});

--- a/packages/odf-core/src/convert/package.ts
+++ b/packages/odf-core/src/convert/package.ts
@@ -1,0 +1,155 @@
+/**
+ * Fresh-package scaffolding for the DOCX → ODT converter: XML part templates and the
+ * whitespace writer that is the emit-side mirror of `shared/odf/text_segments.ts`.
+ *
+ * The `office:version="1.3"` attribute on every document root is required — LibreOffice
+ * tolerates its absence, but strict ODF validators reject the package without it.
+ */
+
+import { parseXml } from '@usejunior/docx-core';
+
+import { ODF_NS } from '../shared/odf/namespaces.js';
+
+/** Heading font sizes (pt) for `Heading_20_1` … `Heading_20_6`. */
+const HEADING_SIZES_PT = [18, 16, 14, 13, 12, 11] as const;
+
+const CONTENT_SKELETON = [
+  '<?xml version="1.0" encoding="UTF-8"?>',
+  '<office:document-content',
+  `  xmlns:office="${ODF_NS.OFFICE}"`,
+  `  xmlns:text="${ODF_NS.TEXT}"`,
+  `  xmlns:table="${ODF_NS.TABLE}"`,
+  `  xmlns:style="${ODF_NS.STYLE}"`,
+  `  xmlns:fo="${ODF_NS.FO}"`,
+  `  xmlns:xlink="${ODF_NS.XLINK}"`,
+  '  office:version="1.3">',
+  '  <office:automatic-styles/>',
+  '  <office:body><office:text/></office:body>',
+  '</office:document-content>',
+].join('\n');
+
+/** The skeleton `content.xml` DOM plus the two insertion points the converter fills. */
+export interface ContentScaffold {
+  doc: Document;
+  automaticStyles: Element;
+  body: Element;
+}
+
+/** Parse the empty content.xml skeleton and hand back its insertion points. */
+export function createContentScaffold(): ContentScaffold {
+  const doc = parseXml(CONTENT_SKELETON);
+  const automaticStyles = doc.getElementsByTagNameNS(ODF_NS.OFFICE, 'automatic-styles')[0] as Element;
+  const body = doc.getElementsByTagNameNS(ODF_NS.OFFICE, 'text')[0] as Element;
+  return { doc, automaticStyles, body };
+}
+
+/**
+ * Seed `styles.xml`: `Standard`, a bold `Heading` base, `Heading_20_1..6` (descending sizes,
+ * `style:default-outline-level`), and `Text_20_body`. Run-level formatting lives in content.xml
+ * automatic styles instead — richer named-style mapping is deferred (issue #331 phase 3).
+ */
+export function buildStylesXml(): string {
+  const headingStyles = HEADING_SIZES_PT.map((size, i) => {
+    const level = i + 1;
+    return [
+      `    <style:style style:name="Heading_20_${level}" style:display-name="Heading ${level}"`,
+      `      style:family="paragraph" style:parent-style-name="Heading" style:next-style-name="Text_20_body"`,
+      `      style:default-outline-level="${level}" style:class="text">`,
+      `      <style:text-properties fo:font-size="${size}pt"/>`,
+      '    </style:style>',
+    ].join('\n');
+  });
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<office:document-styles',
+    `  xmlns:office="${ODF_NS.OFFICE}"`,
+    `  xmlns:style="${ODF_NS.STYLE}"`,
+    `  xmlns:fo="${ODF_NS.FO}"`,
+    '  office:version="1.3">',
+    '  <office:styles>',
+    '    <style:style style:name="Standard" style:family="paragraph" style:class="text"/>',
+    '    <style:style style:name="Text_20_body" style:display-name="Text body"',
+    '      style:family="paragraph" style:parent-style-name="Standard" style:class="text"/>',
+    '    <style:style style:name="Heading" style:family="paragraph"',
+    '      style:parent-style-name="Standard" style:next-style-name="Text_20_body" style:class="text">',
+    '      <style:text-properties fo:font-weight="bold"/>',
+    '    </style:style>',
+    ...headingStyles,
+    '  </office:styles>',
+    '</office:document-styles>',
+    '',
+  ].join('\n');
+}
+
+function escapeXmlText(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+/** Build `meta.xml` carrying the generator string and optional title. */
+export function buildMetaXml(metadata?: { title?: string; generator?: string }): string {
+  const generator = metadata?.generator ?? '@usejunior/odf-core convertDocxToOdt';
+  const title = metadata?.title;
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<office:document-meta',
+    `  xmlns:office="${ODF_NS.OFFICE}"`,
+    `  xmlns:meta="${ODF_NS.META}"`,
+    `  xmlns:dc="${ODF_NS.DC}"`,
+    '  office:version="1.3">',
+    '  <office:meta>',
+    `    <meta:generator>${escapeXmlText(generator)}</meta:generator>`,
+    ...(title ? [`    <dc:title>${escapeXmlText(title)}</dc:title>`] : []),
+    '  </office:meta>',
+    '</office:document-meta>',
+    '',
+  ].join('\n');
+}
+
+/**
+ * Append visible text to `parent`, encoding whitespace the way ODF readers decode it
+ * (the writer mirror of `buildSegments`): a run of N≥2 spaces becomes one literal space +
+ * `<text:s text:c="N-1"/>`, tabs become `text:tab`, newlines become `text:line-break`.
+ * A leading space is encoded as `text:s` outright — ODF processors collapse literal
+ * leading whitespace.
+ */
+export function appendTextWithWhitespace(doc: Document, parent: Element, text: string): void {
+  if (text.length === 0) return;
+  const isAtBlockStart = parent.firstChild === null;
+  let i = 0;
+  while (i < text.length) {
+    const ch = text[i];
+    if (ch === '\t') {
+      parent.appendChild(doc.createElementNS(ODF_NS.TEXT, 'text:tab'));
+      i += 1;
+      continue;
+    }
+    if (ch === '\n') {
+      parent.appendChild(doc.createElementNS(ODF_NS.TEXT, 'text:line-break'));
+      i += 1;
+      continue;
+    }
+    if (ch === ' ') {
+      let n = 1;
+      while (text[i + n] === ' ') n += 1;
+      const leading = isAtBlockStart && i === 0 && parent.firstChild === null;
+      if (leading) {
+        const s = doc.createElementNS(ODF_NS.TEXT, 'text:s');
+        if (n > 1) s.setAttributeNS(ODF_NS.TEXT, 'text:c', String(n));
+        parent.appendChild(s);
+      } else {
+        parent.appendChild(doc.createTextNode(' '));
+        if (n > 1) {
+          const s = doc.createElementNS(ODF_NS.TEXT, 'text:s');
+          if (n > 2) s.setAttributeNS(ODF_NS.TEXT, 'text:c', String(n - 1));
+          parent.appendChild(s);
+        }
+      }
+      i += n;
+      continue;
+    }
+    let end = i;
+    while (end < text.length && text[end] !== ' ' && text[end] !== '\t' && text[end] !== '\n') end += 1;
+    parent.appendChild(doc.createTextNode(text.slice(i, end)));
+    i = end;
+  }
+}

--- a/packages/odf-core/src/convert/tables.ts
+++ b/packages/odf-core/src/convert/tables.ts
@@ -1,0 +1,115 @@
+/**
+ * Table emission for the DOCX → ODT converter: a contiguous run of view nodes sharing one
+ * `table_context.table_id` → a complete rectangular `table:table` grid.
+ *
+ * Lossy by design, mirroring the HTML serializer's `renderTable`: the view model discards
+ * `gridSpan`/`vMerge`, so merged cells are indistinguishable from genuinely empty grid
+ * positions — gaps are filled with empty cells (recorded as `table-grid-gaps-filled`), and
+ * every cell shares one thin-bordered automatic style (the view model carries no border
+ * info; most Word tables are bordered).
+ */
+
+import type { DocumentViewNode } from '@usejunior/docx-core';
+
+import { ODF_NS } from '../shared/odf/namespaces.js';
+import type { LossinessCollector } from './types.js';
+
+const CELL_STYLE_NAME = 'ConvCell';
+
+/** Register the shared bordered table-cell automatic style (call once per document). */
+export function registerCellStyle(doc: Document, automaticStyles: Element): string {
+  const style = doc.createElementNS(ODF_NS.STYLE, 'style:style');
+  style.setAttributeNS(ODF_NS.STYLE, 'style:name', CELL_STYLE_NAME);
+  style.setAttributeNS(ODF_NS.STYLE, 'style:family', 'table-cell');
+  const props = doc.createElementNS(ODF_NS.STYLE, 'style:table-cell-properties');
+  props.setAttributeNS(ODF_NS.FO, 'fo:border', '0.5pt solid #000000');
+  props.setAttributeNS(ODF_NS.FO, 'fo:padding', '0.0382in');
+  style.appendChild(props);
+  automaticStyles.appendChild(style);
+  return CELL_STYLE_NAME;
+}
+
+/**
+ * Append the table built from `group` to `body`. Cell paragraph content is delegated to
+ * `fillParagraph` (the orchestrator's inline emitter) so this module stays cycle-free.
+ */
+export function appendTable(
+  doc: Document,
+  body: Element,
+  group: DocumentViewNode[],
+  tableNumber: number,
+  cellStyleName: string,
+  fillParagraph: (p: Element, node: DocumentViewNode) => void,
+  lossiness: LossinessCollector,
+): void {
+  let totalCols = 0;
+  for (const n of group) {
+    const tc = n.table_context;
+    if (!tc) continue;
+    totalCols = Math.max(totalCols, tc.total_cols, tc.col_index + 1);
+  }
+  if (totalCols <= 0) return;
+
+  const rows = new Map<number, Map<number, DocumentViewNode[]>>();
+  const rowOrder: number[] = [];
+  const headerRows = new Set<number>();
+  for (const n of group) {
+    const tc = n.table_context;
+    if (!tc) continue;
+    if (!rows.has(tc.row_index)) {
+      rows.set(tc.row_index, new Map());
+      rowOrder.push(tc.row_index);
+    }
+    const cellMap = rows.get(tc.row_index)!;
+    const cellNodes = cellMap.get(tc.col_index) ?? [];
+    cellNodes.push(n);
+    cellMap.set(tc.col_index, cellNodes);
+    if (tc.is_header_row) headerRows.add(tc.row_index);
+  }
+  rowOrder.sort((a, b) => a - b);
+  if (rowOrder.length === 0) return;
+
+  const table = doc.createElementNS(ODF_NS.TABLE, 'table:table');
+  table.setAttributeNS(ODF_NS.TABLE, 'table:name', `Table${tableNumber}`);
+  const columns = doc.createElementNS(ODF_NS.TABLE, 'table:table-column');
+  columns.setAttributeNS(ODF_NS.TABLE, 'table:number-columns-repeated', String(totalCols));
+  table.appendChild(columns);
+  body.appendChild(table);
+
+  const buildRow = (rowIndex: number): Element => {
+    const row = doc.createElementNS(ODF_NS.TABLE, 'table:table-row');
+    const cellMap = rows.get(rowIndex) ?? new Map<number, DocumentViewNode[]>();
+    for (let c = 0; c < totalCols; c++) {
+      const cell = doc.createElementNS(ODF_NS.TABLE, 'table:table-cell');
+      cell.setAttributeNS(ODF_NS.OFFICE, 'office:value-type', 'string');
+      cell.setAttributeNS(ODF_NS.TABLE, 'table:style-name', cellStyleName);
+      const cellNodes = cellMap.get(c);
+      if (cellNodes && cellNodes.length > 0) {
+        for (const node of cellNodes) {
+          const p = doc.createElementNS(ODF_NS.TEXT, 'text:p');
+          p.setAttributeNS(ODF_NS.TEXT, 'text:style-name', 'Standard');
+          cell.appendChild(p);
+          fillParagraph(p, node);
+        }
+      } else {
+        lossiness.add('table-grid-gaps-filled', `Table${tableNumber} r${rowIndex}c${c}`);
+        cell.appendChild(doc.createElementNS(ODF_NS.TEXT, 'text:p'));
+      }
+      row.appendChild(cell);
+    }
+    return row;
+  };
+
+  // The LEADING run of header-flagged rows goes into `table:table-header-rows` (the ODF
+  // analogue of the HTML serializer's `<thead>`). The view model flags `is_header_row` for
+  // row 0 of every table — a heuristic, not Word's `w:tblHeader` — so in practice this is
+  // the first row.
+  let headerEnd = 0;
+  while (headerEnd < rowOrder.length && headerRows.has(rowOrder[headerEnd]!)) headerEnd += 1;
+  if (headerEnd > 0) {
+    const headerContainer = doc.createElementNS(ODF_NS.TABLE, 'table:table-header-rows');
+    for (let r = 0; r < headerEnd; r++) headerContainer.appendChild(buildRow(rowOrder[r]!));
+    table.appendChild(headerContainer);
+  }
+  for (let r = headerEnd; r < rowOrder.length; r++) table.appendChild(buildRow(rowOrder[r]!));
+}

--- a/packages/odf-core/src/convert/types.ts
+++ b/packages/odf-core/src/convert/types.ts
@@ -1,0 +1,42 @@
+/** Options and result types for {@link convertDocxToOdt}, plus the lossiness collector. */
+
+export interface ConvertDocxToOdtOptions {
+  metadata?: { title?: string; generator?: string };
+}
+
+/** One downgraded construct class and how often it was hit. */
+export interface LossinessEntry {
+  construct: string;
+  count: number;
+  detail?: string;
+}
+
+export interface ConvertDocxToOdtResult {
+  odt: Buffer;
+  lossiness: LossinessEntry[];
+}
+
+/**
+ * Accumulates downgraded constructs during a conversion. Conversion is intentionally lossy,
+ * but every drop must be reported — `detail` keeps the first concrete example per construct.
+ */
+export class LossinessCollector {
+  private entries = new Map<string, { count: number; detail?: string }>();
+
+  add(construct: string, detail?: string): void {
+    const existing = this.entries.get(construct);
+    if (existing) {
+      existing.count += 1;
+    } else {
+      this.entries.set(construct, { count: 1, detail });
+    }
+  }
+
+  toArray(): LossinessEntry[] {
+    return Array.from(this.entries.entries(), ([construct, { count, detail }]) => ({
+      construct,
+      count,
+      ...(detail !== undefined ? { detail } : {}),
+    }));
+  }
+}

--- a/packages/odf-core/src/index.ts
+++ b/packages/odf-core/src/index.ts
@@ -17,3 +17,9 @@ export {
 } from './compare/index.js';
 export { validateOdfArchiveSafety, type OdfArchiveSafetyResult } from './odf_archive_safety.js';
 export { ODF_NS, ODF_PATHS, ODT_MIMETYPE } from './shared/odf/namespaces.js';
+export {
+  convertDocxToOdt,
+  type ConvertDocxToOdtOptions,
+  type ConvertDocxToOdtResult,
+  type LossinessEntry,
+} from './convert/index.js';

--- a/packages/odf-core/src/shared/odf/OdfArchive.ts
+++ b/packages/odf-core/src/shared/odf/OdfArchive.ts
@@ -17,7 +17,37 @@
 
 import JSZip from 'jszip';
 
-import { ODF_PATHS, ODT_MIMETYPE } from './namespaces.js';
+import { ODF_NS, ODF_PATHS, ODT_MIMETYPE } from './namespaces.js';
+
+/** Parts accepted by {@link OdfArchive.create}. `content.xml` is the only required one. */
+export interface OdfArchiveCreateParts {
+  contentXml: string;
+  stylesXml?: string;
+  metaXml?: string;
+}
+
+const PART_MEDIA_TYPES: Record<string, string> = {
+  [ODF_PATHS.CONTENT]: 'text/xml',
+  [ODF_PATHS.STYLES]: 'text/xml',
+  [ODF_PATHS.META]: 'text/xml',
+};
+
+function buildManifestXml(partPaths: string[]): string {
+  const entries = [
+    `  <manifest:file-entry manifest:full-path="/" manifest:version="1.3" manifest:media-type="${ODT_MIMETYPE}"/>`,
+    ...partPaths.map(
+      (p) =>
+        `  <manifest:file-entry manifest:full-path="${p}" manifest:media-type="${PART_MEDIA_TYPES[p] ?? 'text/xml'}"/>`,
+    ),
+  ];
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    `<manifest:manifest xmlns:manifest="${ODF_NS.MANIFEST}" manifest:version="1.3">`,
+    ...entries,
+    '</manifest:manifest>',
+    '',
+  ].join('\n');
+}
 
 export class OdfArchive {
   private zip: JSZip;
@@ -40,6 +70,36 @@ export class OdfArchive {
       throw new Error('Invalid ODF: missing META-INF/manifest.xml');
     }
     return new OdfArchive(zip);
+  }
+
+  /**
+   * Create a fresh ODT package from XML parts.
+   *
+   * `META-INF/manifest.xml` is generated from the provided parts, and the
+   * mimetype-first + STORE discipline is `save()`'s responsibility (the fresh
+   * JSZip here is rebuilt on save like any loaded archive). The result satisfies
+   * `load()`'s content/manifest requirements, so `create(...)` → `save()` →
+   * `load(...)` round-trips.
+   */
+  static create(parts: OdfArchiveCreateParts): OdfArchive {
+    const zip = new JSZip();
+    zip.file(ODF_PATHS.MIMETYPE, ODT_MIMETYPE, { compression: 'STORE' });
+    const partPaths: string[] = [ODF_PATHS.CONTENT];
+    zip.file(ODF_PATHS.CONTENT, parts.contentXml);
+    if (parts.stylesXml !== undefined) {
+      zip.file(ODF_PATHS.STYLES, parts.stylesXml);
+      partPaths.push(ODF_PATHS.STYLES);
+    }
+    if (parts.metaXml !== undefined) {
+      zip.file(ODF_PATHS.META, parts.metaXml);
+      partPaths.push(ODF_PATHS.META);
+    }
+    zip.file(ODF_PATHS.MANIFEST, buildManifestXml(partPaths));
+    const archive = new OdfArchive(zip);
+    for (const p of [ODF_PATHS.MIMETYPE, ODF_PATHS.MANIFEST, ...partPaths]) {
+      archive.modified.add(p);
+    }
+    return archive;
   }
 
   /** Get `content.xml` as a string. */

--- a/packages/odf-core/src/shared/odf/namespaces.ts
+++ b/packages/odf-core/src/shared/odf/namespaces.ts
@@ -15,6 +15,12 @@ export const ODF_NS = {
   DC: 'http://purl.org/dc/elements/1.1/',
   // W3C XML namespace — carries `xml:id` on `text:changed-region` for tracked changes.
   XML: 'http://www.w3.org/XML/1998/namespace',
+  // XSL-FO-compatible properties (`fo:font-weight`, `fo:font-style`, …) used by style definitions.
+  FO: 'urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0',
+  // XLink — carries `xlink:href` on `text:a` hyperlinks.
+  XLINK: 'http://www.w3.org/1999/xlink',
+  // ODF meta elements (`meta:generator`) in `meta.xml`.
+  META: 'urn:oasis:names:tc:opendocument:xmlns:meta:1.0',
 } as const;
 
 /** The mimetype value an OpenDocument text package declares. */

--- a/packages/safe-docx-mcpb/manifest.json
+++ b/packages/safe-docx-mcpb/manifest.json
@@ -57,6 +57,10 @@
       "description": "Export a document to a portable Markdown rendering on disk (lossy; DOCX only)."
     },
     {
+      "name": "convert_to_odt",
+      "description": "Convert a DOCX document to OpenDocument Text (.odt) on disk (semantic, intentionally lossy; DOCX only)."
+    },
+    {
       "name": "format_layout",
       "description": "Apply deterministic paragraph/table layout formatting controls."
     },


### PR DESCRIPTION
## Summary

Implements issue #331 (phases 1+2): a **native, Node/TS-only DOCX → ODT converter** in `@usejunior/odf-core` plus a `convert_to_odt` MCP tool in `@usejunior/docx-mcp`. No LibreOffice at runtime — it serves only as a differential test oracle. Motivated by Germany's IT-Planungsrat ODF mandate: organizations holding `.docx` corpora need faithful `.odt` equivalents, and we already owned both halves of the problem (docx-core's semantic model, odf-core's packaging layer).

Ships with OpenSpec change `add-docx-to-odf-conversion` (proposal as the first commit; `openspec validate --strict` passes).

## What's mapped (semantic, intentionally lossy)

The converter traverses `buildDocumentView({ showFormatting: true, formattingMode: 'full' })` — the same lossy-export path as the markdown/HTML serializers — and emits a fresh ODT package via a new `OdfArchive.create()` (mimetype-first + STORED, generated manifest, `office:version="1.3"` roots):

- Body text incl. multi-space runs/tabs (`text:s`/`text:tab`, the emit-side mirror of `buildSegments`)
- Word-styled headings → `text:h` + `Heading_20_N` (heuristic headings stay paragraphs)
- Bold/italic/underline/highlight → `text:span` with deduped automatic styles; hyperlinks → `text:a` (shared `isSafeHref` stance; unsafe schemes degrade to plain text)
- Auto-numbered/bullet lists → nested `text:list` with `numFmt`-mapped list styles, robust to `ilvl` jumps (port of the HTML serializer's level-recording ListBuilder)
- Manual/legal labels (`Section 2.1`, `(a)`) stay literal paragraph text — deliberate divergence from the HTML serializer so ODF renderers never print their own number next to a legal label
- Tables → complete rectangular `table:table` grid (gaps filled; view model has no gridSpan/vMerge)

Every downgrade is itemized in a returned `lossiness` report — nothing drops silently.

## Verification

- 13 odf-core scenario tests (`[CONV-01..13]`) + 5 docx-mcp `.openspec()`-tagged scenarios (`[OCNV-01..05]`)
- **CONV-12**: all four bundled real contracts (NVCA COI, Common Paper NDA, Bonterms NDA, LOI) convert end-to-end with visible-text equivalence and `validateOdfArchiveSafety` passing
- **CONV-13**: differential oracle — the native output **structurally agrees with LibreOffice's own DOCX→ODT conversion** (visible text + heading/table/list shape) of the Common Paper NDA; gated by a preflight probe so a missing *or broken* soffice skips instead of failing
- Smoke: real NVCA `.docx` → 32 KB `.odt` → LibreOffice headless reopens and re-extracts the full text cleanly
- Local gates green: `npm run build && npm run test:run && npm run preflight:ci`

## Acceptance criteria from #331

- ✅ Documented entry point converts a real `.docx` to a valid `.odt` (library + MCP tool)
- ✅ Visible text + paragraph/heading structure preserved vs a LibreOffice-converted reference
- ✅ Output satisfies odf-core packaging rules (`mimetype` first + uncompressed; `validateOdfArchiveSafety` passes)
- ✅ No runtime LibreOffice dependency

Fixes: #331