### PR TITLE
feat(docx-core): from-scratch generation phase 2 — styles.xml + run/paragraph formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ safe-docx targets a defined subset of **ECMA-376 5th edition**. The full surface
 (targeted sections, Non-Goals, and verification status) lives at
 [spec-compliance/CONFORMANCE.md](spec-compliance/CONFORMANCE.md).
 
-- **9** sections claimed
+- **12** sections claimed
 - **5** sections explicitly out-of-scope (Non-Goals)
 - **0** known gaps under `@conformance-gap`
 - Vendored normative schemas: `spec-compliance/ecma-376/schemas/`

--- a/openspec/changes/add-docx-generation/tasks.md
+++ b/openspec/changes/add-docx-generation/tasks.md
@@ -17,9 +17,9 @@ and `openspec validate add-docx-generation --strict`.
 - [x] 1.9 PR 1 tests (`TEST_FEATURE = 'add-docx-generation'`) + `docs/generation-manual-compat-checklist.md` + review artifacts
 
 ## 2. Run/paragraph formatting + styles emission (PR 2) — SDX-GEN-004, 040..043
-- [ ] 2.1 `emit/styles-part.ts` (docDefaults, Normal, StyleSpec[])
-- [ ] 2.2 Full RunProps via `RPR_ORDER`; paragraph pPr (alignment/spacing/indent/tabs) via `PPR_ORDER`
-- [ ] 2.3 XSD relative-order cross-check test; registry entries for styles/rPr/pPr sections
+- [x] 2.1 `emit/styles-part.ts` (docDefaults, Normal, StyleSpec[])
+- [x] 2.2 Full RunProps via `RPR_ORDER`; paragraph pPr (alignment/spacing/indent/tabs) via `PPR_ORDER`
+- [x] 2.3 XSD relative-order cross-check test; registry entries for styles/rPr/pPr sections
 
 ## 3. Sections, headers/footers, fields, page numbering (PR 3) — SDX-GEN-021..024, 030..032
 - [ ] 3.1 `emit/header-footer-part.ts` + reference wiring + content types + `w:titlePg`

--- a/packages/docx-core/docs/generation-manual-compat-checklist.md
+++ b/packages/docx-core/docs/generation-manual-compat-checklist.md
@@ -28,6 +28,7 @@ Artifacts land under `packages/docx-core/src/testing/outputs/`.
 | Artifact | Emitter revision | Word for Mac | Pages | Google Docs import | LibreOffice |
 |---|---|---|---|---|---|
 | `generation-phase1-minimal.docx` (plain paragraphs + explicit page setup) | PR 1 | — | — | — | clean (identity + PDF probes, automated) |
+| `generation-phase2-styled.docx` (named style + run formatting + tabs/indent/justify) | PR 2 | — | — | — | — |
 
 ## Per-reader notes
 

--- a/packages/docx-core/src/generation/compile.ts
+++ b/packages/docx-core/src/generation/compile.ts
@@ -11,6 +11,7 @@ import { createZipBuffer } from '../primitives/zip.js';
 import { CompileContext } from './context.js';
 import { emitDocumentPart } from './emit/document-part.js';
 import { emitPackageParts } from './emit/package-parts.js';
+import { emitStylesPart } from './emit/styles-part.js';
 import type { DocumentSpec } from './types.js';
 import { validateSpec } from './validate-spec.js';
 
@@ -28,6 +29,7 @@ export async function generateDocx(spec: DocumentSpec, _opts?: GenerateDocxOptio
 
   const ctx = new CompileContext();
   ctx.setFileContent('word/document.xml', emitDocumentPart(spec));
+  emitStylesPart(spec, ctx);
   emitPackageParts(spec, ctx);
 
   return createZipBuffer(ctx.toFileRecord(), { fileDate: ZIP_EPOCH });

--- a/packages/docx-core/src/generation/emit/paragraph.ts
+++ b/packages/docx-core/src/generation/emit/paragraph.ts
@@ -1,19 +1,22 @@
 /**
  * Paragraph emitter.
  *
- * PR 1 scope: paragraphs of plain text runs with no paragraph properties.
- * pPr emission (style references, alignment, spacing, numbering, and the
- * section-break injection hook) arrives with the formatting and
- * multi-section phases, always routed through PPR_ORDER.
+ * Shipped: paragraphs with style references and direct formatting
+ * (alignment, spacing, indentation, tabs, keepNext, pageBreakBefore), all
+ * routed through the shared pPr builder and PPR_ORDER. The section-break
+ * injection hook (a pPr-only sectPr) arrives with the multi-section phase.
  */
 
 import { createWmlElement } from '../../primitives/dom-helpers.js';
 import { W } from '../../primitives/namespaces.js';
 import type { ParagraphSpec } from '../types.js';
+import { buildParagraphPropsElement } from './properties.js';
 import { buildInlineRuns } from './run.js';
 
 export function buildParagraph(doc: Document, paragraph: ParagraphSpec): Element {
   const p = createWmlElement(doc, W.p);
+  const pPr = buildParagraphPropsElement(doc, paragraph);
+  if (pPr) p.appendChild(pPr);
   for (const inline of paragraph.runs) {
     for (const run of buildInlineRuns(doc, inline)) {
       p.appendChild(run);

--- a/packages/docx-core/src/generation/emit/properties.ts
+++ b/packages/docx-core/src/generation/emit/properties.ts
@@ -1,0 +1,145 @@
+/**
+ * Shared property builders: RunProps → w:rPr and paragraph formatting → w:pPr
+ * child maps, used by both the body emitters (run.ts / paragraph.ts) and the
+ * styles-part emitter so direct formatting and style definitions can never
+ * drift apart. All children are routed through the ordering tables.
+ */
+
+import { createWmlElement } from '../../primitives/dom-helpers.js';
+import { W } from '../../primitives/namespaces.js';
+import { appendInOrder, PPR_ORDER, RPR_ORDER } from '../ordering.js';
+import type { ParagraphSpec, RunProps, StyleSpec } from '../types.js';
+
+/** Paragraph-formatting subset shared by ParagraphSpec and StyleSpec.paragraph. */
+export type ParagraphProps = Pick<
+  ParagraphSpec,
+  'alignment' | 'spacing' | 'indent' | 'tabs' | 'pageBreakBefore' | 'keepNext'
+> & { styleId?: string };
+
+const ALIGNMENT_TO_JC: Record<NonNullable<ParagraphProps['alignment']>, string> = {
+  left: 'left',
+  center: 'center',
+  right: 'right',
+  justify: 'both',
+};
+
+/**
+ * Build the ordered rPr children for a RunProps value. Returns null when no
+ * property is set so callers can omit the rPr container entirely.
+ *
+ * Complex-script twins (bCs/iCs/szCs) and the full rFonts script coverage
+ * (ascii + hAnsi + cs) are always emitted alongside their base properties so
+ * all script ranges agree.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.3.2.28
+ */
+export function buildRunPropsElement(doc: Document, props: RunProps): Element | null {
+  const children = new Map<string, Element | Element[]>();
+
+  if (props.font !== undefined) {
+    children.set(W.rFonts, createWmlElement(doc, W.rFonts, {
+      'w:ascii': props.font,
+      'w:hAnsi': props.font,
+      'w:cs': props.font,
+    }));
+  }
+  if (props.bold !== undefined) {
+    children.set(W.b, createWmlElement(doc, W.b, props.bold ? undefined : { 'w:val': '0' }));
+    children.set(W.bCs, createWmlElement(doc, W.bCs, props.bold ? undefined : { 'w:val': '0' }));
+  }
+  if (props.italic !== undefined) {
+    children.set(W.i, createWmlElement(doc, W.i, props.italic ? undefined : { 'w:val': '0' }));
+    children.set(W.iCs, createWmlElement(doc, W.iCs, props.italic ? undefined : { 'w:val': '0' }));
+  }
+  if (props.caps !== undefined) {
+    children.set(W.caps, createWmlElement(doc, W.caps, props.caps ? undefined : { 'w:val': '0' }));
+  }
+  if (props.smallCaps !== undefined) {
+    children.set(W.smallCaps, createWmlElement(doc, W.smallCaps, props.smallCaps ? undefined : { 'w:val': '0' }));
+  }
+  if (props.colorHex !== undefined) {
+    children.set(W.color, createWmlElement(doc, W.color, { 'w:val': props.colorHex }));
+  }
+  if (props.sizePt !== undefined) {
+    const halfPoints = String(Math.round(props.sizePt * 2));
+    children.set(W.sz, createWmlElement(doc, W.sz, { 'w:val': halfPoints }));
+    children.set(W.szCs, createWmlElement(doc, W.szCs, { 'w:val': halfPoints }));
+  }
+  if (props.underline !== undefined) {
+    children.set(W.u, createWmlElement(doc, W.u, { 'w:val': props.underline }));
+  }
+
+  if (children.size === 0) return null;
+  const rPr = createWmlElement(doc, W.rPr);
+  appendInOrder(rPr, children, RPR_ORDER);
+  return rPr;
+}
+
+/**
+ * Build the ordered pPr children for a paragraph-formatting subset. Returns
+ * null when nothing is set. The optional extras hook lets phase-specific
+ * callers add already-built children (e.g. a section break sectPr) that
+ * still go through the same ordering discipline.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.3.1.26
+ */
+export function buildParagraphPropsElement(
+  doc: Document,
+  props: ParagraphProps,
+  extras?: ReadonlyMap<string, Element | Element[]>,
+): Element | null {
+  const children = new Map<string, Element | Element[]>();
+
+  if (props.styleId !== undefined) {
+    children.set(W.pStyle, createWmlElement(doc, W.pStyle, { 'w:val': props.styleId }));
+  }
+  if (props.keepNext) {
+    children.set(W.keepNext, createWmlElement(doc, W.keepNext));
+  }
+  if (props.pageBreakBefore) {
+    children.set(W.pageBreakBefore, createWmlElement(doc, W.pageBreakBefore));
+  }
+  if (props.tabs && props.tabs.length > 0) {
+    const tabs = createWmlElement(doc, W.tabs);
+    for (const stop of props.tabs) {
+      const attrs: Record<string, string> = { 'w:val': stop.align, 'w:pos': String(stop.posTwips) };
+      if (stop.leader && stop.leader !== 'none') attrs['w:leader'] = stop.leader;
+      tabs.appendChild(createWmlElement(doc, W.tab, attrs));
+    }
+    children.set(W.tabs, tabs);
+  }
+  if (props.spacing) {
+    const attrs: Record<string, string> = {};
+    if (props.spacing.beforeTwips !== undefined) attrs['w:before'] = String(props.spacing.beforeTwips);
+    if (props.spacing.afterTwips !== undefined) attrs['w:after'] = String(props.spacing.afterTwips);
+    if (props.spacing.lineTwips !== undefined) {
+      attrs['w:line'] = String(props.spacing.lineTwips);
+      attrs['w:lineRule'] = props.spacing.lineRule ?? 'auto';
+    }
+    if (Object.keys(attrs).length > 0) children.set(W.spacing, createWmlElement(doc, W.spacing, attrs));
+  }
+  if (props.indent) {
+    const attrs: Record<string, string> = {};
+    if (props.indent.leftTwips !== undefined) attrs['w:left'] = String(props.indent.leftTwips);
+    if (props.indent.rightTwips !== undefined) attrs['w:right'] = String(props.indent.rightTwips);
+    if (props.indent.firstLineTwips !== undefined) attrs['w:firstLine'] = String(props.indent.firstLineTwips);
+    if (props.indent.hangingTwips !== undefined) attrs['w:hanging'] = String(props.indent.hangingTwips);
+    if (Object.keys(attrs).length > 0) children.set(W.ind, createWmlElement(doc, W.ind, attrs));
+  }
+  if (props.alignment !== undefined) {
+    children.set(W.jc, createWmlElement(doc, W.jc, { 'w:val': ALIGNMENT_TO_JC[props.alignment] }));
+  }
+  if (extras) {
+    for (const [name, value] of extras) children.set(name, value);
+  }
+
+  if (children.size === 0) return null;
+  const pPr = createWmlElement(doc, W.pPr);
+  appendInOrder(pPr, children, PPR_ORDER);
+  return pPr;
+}
+
+/** Paragraph-formatting subset of a StyleSpec, normalized for the builder. */
+export function styleParagraphProps(style: StyleSpec): ParagraphProps {
+  return { ...style.paragraph };
+}

--- a/packages/docx-core/src/generation/emit/run.ts
+++ b/packages/docx-core/src/generation/emit/run.ts
@@ -1,21 +1,25 @@
 /**
  * Inline-run emitter.
  *
- * PR 1 scope: plain text runs. Run formatting, fields (with their five-part
- * begin/instrText/separate/result/end state machine), tabs, and breaks land
- * in later phases; validate-spec rejects them before emission, so reaching
- * this dispatcher with an unshipped kind is a compiler bug.
+ * Shipped: text runs with full RunProps formatting (via the shared property
+ * builders). Fields (with their five-part begin/instrText/separate/result/end
+ * state machine), tabs, and breaks land in later phases; validate-spec rejects
+ * them before emission, so reaching this dispatcher with an unshipped kind is
+ * a compiler bug.
  */
 
 import { createWmlElement, createWmlTextElement } from '../../primitives/dom-helpers.js';
 import { W } from '../../primitives/namespaces.js';
 import { GenerationInternalError } from '../errors.js';
 import type { InlineSpec } from '../types.js';
+import { buildRunPropsElement } from './properties.js';
 
 /** Build the w:r element(s) for one inline spec node. */
 export function buildInlineRuns(doc: Document, inline: InlineSpec): Element[] {
   if (inline.kind === 'text') {
     const run = createWmlElement(doc, W.r);
+    const rPr = buildRunPropsElement(doc, inline);
+    if (rPr) run.appendChild(rPr);
     run.appendChild(createWmlTextElement(doc, inline.text));
     return [run];
   }

--- a/packages/docx-core/src/generation/emit/styles-part.ts
+++ b/packages/docx-core/src/generation/emit/styles-part.ts
@@ -1,0 +1,95 @@
+/**
+ * word/styles.xml emitter.
+ *
+ * Always emitted: document defaults, the Normal paragraph style, and every
+ * declared StyleSpec. Style pPr/rPr go through the same shared property
+ * builders as direct formatting (emit/properties.ts), so a style definition
+ * and an inline run can never disagree on how a property serializes.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.7.4.18
+ */
+
+import { createWmlElement } from '../../primitives/dom-helpers.js';
+import { OOXML, W } from '../../primitives/namespaces.js';
+import { parseXml, serializeXml } from '../../primitives/xml.js';
+import type { CompileContext } from '../context.js';
+import type { DocumentSpec, StyleSpec } from '../types.js';
+import { XML_DECL } from './document-part.js';
+import { buildParagraphPropsElement, buildRunPropsElement, styleParagraphProps } from './properties.js';
+
+export const STYLES_CONTENT_TYPE = 'application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml';
+export const STYLES_REL_TYPE = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles';
+
+const STYLES_SKELETON = `<w:styles xmlns:w="${OOXML.W_NS}"/>`;
+
+/** Default run properties for docDefaults: Calibri 11pt, matching Word's baseline. */
+const DEFAULT_FONT = 'Calibri';
+const DEFAULT_SIZE_HALF_POINTS = '22';
+
+export function emitStylesPart(spec: DocumentSpec, ctx: CompileContext): void {
+  ctx.registerPart('word/styles.xml', STYLES_CONTENT_TYPE, STYLES_REL_TYPE);
+
+  const doc = parseXml(STYLES_SKELETON);
+  const root = doc.documentElement!;
+
+  root.appendChild(buildDocDefaults(doc));
+  root.appendChild(buildNormalStyle(doc));
+  for (const style of spec.styles ?? []) {
+    root.appendChild(buildStyle(doc, style));
+  }
+
+  ctx.setFileContent('word/styles.xml', XML_DECL + serializeXml(doc));
+}
+
+/** @conformance ECMA-376 edition 5, Part 1 § 17.7.5.1 */
+function buildDocDefaults(doc: Document): Element {
+  const docDefaults = createWmlElement(doc, W.docDefaults);
+
+  const rPrDefault = createWmlElement(doc, W.rPrDefault);
+  const rPr = createWmlElement(doc, W.rPr);
+  rPr.appendChild(createWmlElement(doc, W.rFonts, {
+    'w:ascii': DEFAULT_FONT,
+    'w:hAnsi': DEFAULT_FONT,
+    'w:cs': DEFAULT_FONT,
+  }));
+  rPr.appendChild(createWmlElement(doc, W.sz, { 'w:val': DEFAULT_SIZE_HALF_POINTS }));
+  rPr.appendChild(createWmlElement(doc, W.szCs, { 'w:val': DEFAULT_SIZE_HALF_POINTS }));
+  rPrDefault.appendChild(rPr);
+  docDefaults.appendChild(rPrDefault);
+
+  const pPrDefault = createWmlElement(doc, W.pPrDefault);
+  docDefaults.appendChild(pPrDefault);
+
+  return docDefaults;
+}
+
+function buildNormalStyle(doc: Document): Element {
+  const style = createWmlElement(doc, W.style, { 'w:type': 'paragraph', 'w:styleId': 'Normal', 'w:default': '1' });
+  style.appendChild(createWmlElement(doc, W.name, { 'w:val': 'Normal' }));
+  style.appendChild(createWmlElement(doc, W.qFormat));
+  return style;
+}
+
+/** @conformance ECMA-376 edition 5, Part 1 § 17.7.4.17 */
+function buildStyle(doc: Document, spec: StyleSpec): Element {
+  const style = createWmlElement(doc, W.style, { 'w:type': spec.type, 'w:styleId': spec.styleId });
+  style.appendChild(createWmlElement(doc, W.name, { 'w:val': spec.name }));
+  if (spec.basedOn !== undefined) {
+    style.appendChild(createWmlElement(doc, W.basedOn, { 'w:val': spec.basedOn }));
+  }
+  if (spec.next !== undefined) {
+    style.appendChild(createWmlElement(doc, W.next, { 'w:val': spec.next }));
+  }
+  style.appendChild(createWmlElement(doc, W.qFormat));
+
+  // CT_Style declares pPr before rPr.
+  if (spec.paragraph) {
+    const pPr = buildParagraphPropsElement(doc, styleParagraphProps(spec));
+    if (pPr) style.appendChild(pPr);
+  }
+  if (spec.run) {
+    const rPr = buildRunPropsElement(doc, spec.run);
+    if (rPr) style.appendChild(rPr);
+  }
+  return style;
+}

--- a/packages/docx-core/src/generation/generation-styles-formatting.test.ts
+++ b/packages/docx-core/src/generation/generation-styles-formatting.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { DocxDocument } from '../primitives/document.js';
+import { parseStylesXml, extractEffectiveRunFormatting } from '../primitives/styles.js';
+import { getDirectChildrenByName, childElements } from '../primitives/dom-helpers.js';
+import { readZipText } from '../primitives/zip.js';
+import { parseXml } from '../primitives/xml.js';
+import { OOXML } from '../primitives/namespaces.js';
+import { generateDocx } from './compile.js';
+import { GenerationSpecError } from './errors.js';
+import { checkGeneratedPackage } from './structural-checks.js';
+import type { DocumentSpec } from './types.js';
+
+const TEST_FEATURE = 'add-docx-generation';
+const test = testAllure.epic('Document Generation').withLabels({ feature: TEST_FEATURE });
+
+function styledSpec(): DocumentSpec {
+  return {
+    meta: { title: 'Styled generation', createdIso: '2026-06-10T00:00:00Z' },
+    styles: [
+      {
+        styleId: 'SectionHeading',
+        name: 'Section Heading',
+        type: 'paragraph',
+        basedOn: 'Normal',
+        next: 'Normal',
+        paragraph: { alignment: 'center', spacing: { beforeTwips: 240, afterTwips: 120 }, keepNext: true },
+        run: { bold: true, sizePt: 14, font: 'Georgia' },
+      },
+    ],
+    sections: [
+      {
+        blocks: [
+          { kind: 'paragraph', styleId: 'SectionHeading', runs: [{ kind: 'text', text: 'ARTICLE I — DEFINITIONS' }] },
+          {
+            kind: 'paragraph',
+            alignment: 'justify',
+            spacing: { beforeTwips: 0, afterTwips: 200, lineTwips: 276, lineRule: 'auto' },
+            indent: { leftTwips: 720, hangingTwips: 360 },
+            tabs: [{ posTwips: 4320, align: 'center', leader: 'dot' }],
+            runs: [
+              { kind: 'text', text: 'Confidential Information', bold: true, italic: true },
+              { kind: 'text', text: ' means information disclosed by either party, marked ' },
+              { kind: 'text', text: 'confidential', underline: 'single', colorHex: 'C00000', font: 'Georgia', sizePt: 11.5 },
+              { kind: 'text', text: '.' },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+async function loadPart(buffer: Buffer, part: string): Promise<Document> {
+  const xml = await readZipText(buffer, part);
+  expect(xml, `${part} missing from package`).not.toBeNull();
+  return parseXml(xml!);
+}
+
+function wChildNames(el: Element): string[] {
+  return childElements(el).filter((c) => c.namespaceURI === OOXML.W_NS).map((c) => c.localName);
+}
+
+describe('Traceability: styles and run/paragraph formatting emission', () => {
+  test.openspec('[SDX-GEN-004] dangling references are rejected before emission')(
+    'Scenario: dangling references are rejected before emission',
+    async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
+      let spec!: DocumentSpec;
+      await given('a paragraph referencing a styleId absent from the declared styles', async () => {
+        spec = styledSpec();
+        spec.sections[0]!.blocks.push({ kind: 'paragraph', styleId: 'GhostStyle', runs: [{ kind: 'text', text: 'x' }] });
+      });
+
+      let error: unknown;
+      await when('generateDocx compiles the spec', async () => {
+        error = await generateDocx(spec).then(
+          () => null,
+          (err: unknown) => err,
+        );
+      });
+
+      await then('compilation fails with a typed error identifying the dangling reference and its path', async () => {
+        expect(error).toBeInstanceOf(GenerationSpecError);
+        const specError = error as GenerationSpecError;
+        expect(specError.code).toBe('dangling_style_reference');
+        expect(specError.path).toBe('/sections/0/blocks/2/styleId');
+        expect(specError.message).toContain('GhostStyle');
+        await attachPrettyJson('rejection', { code: specError.code, path: specError.path });
+      });
+    },
+  );
+
+  test
+    .openspec('[SDX-GEN-040] declared styles are emitted into the style table')
+    .conformance(
+      { spec: 'ECMA-376', edition: 5, part: 1, section: '17.7.4.18' },
+      { spec: 'ECMA-376', edition: 5, part: 1, section: '17.7.5.1' },
+    )(
+    'Scenario: declared styles are emitted into the style table',
+    async ({ given, when, then, attachPrettyXml }: AllureBddContext) => {
+      let buffer!: Buffer;
+      await given('a spec declaring a named paragraph style based on Normal', async () => {
+        buffer = await generateDocx(styledSpec());
+        expect((await checkGeneratedPackage(buffer)).ok).toBe(true);
+      });
+
+      let stylesDoc!: Document;
+      await when('word/styles.xml is parsed back', async () => {
+        stylesDoc = await loadPart(buffer, 'word/styles.xml');
+        await attachPrettyXml('word/styles.xml', (await readZipText(buffer, 'word/styles.xml'))!);
+      });
+
+      await then('it contains docDefaults, Normal, and the declared style with its basedOn link', async () => {
+        const model = parseStylesXml(stylesDoc);
+        expect(model.byId.has('Normal')).toBe(true);
+        const declared = model.byId.get('SectionHeading');
+        expect(declared?.basedOn).toBe('Normal');
+        expect(stylesDoc.getElementsByTagName('w:docDefaults')).toHaveLength(1);
+      });
+
+      await then('paragraphs referencing the style carry the matching w:pStyle', async () => {
+        const documentDoc = await loadPart(buffer, 'word/document.xml');
+        const firstParagraph = documentDoc.getElementsByTagName('w:p').item(0)!;
+        const pStyle = firstParagraph.getElementsByTagName('w:pStyle').item(0);
+        expect(pStyle?.getAttribute('w:val')).toBe('SectionHeading');
+      });
+    },
+  );
+
+  test
+    .openspec('[SDX-GEN-041] run properties are emitted in schema order')
+    .conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.3.2.28' })(
+    'Scenario: run properties are emitted in schema order',
+    async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
+      let buffer!: Buffer;
+      await given('a run specifying bold, italic, underline, color, font, and size', async () => {
+        const spec = styledSpec();
+        spec.sections[0]!.blocks = [
+          {
+            kind: 'paragraph',
+            runs: [{ kind: 'text', text: 'kitchen sink', bold: true, italic: true, underline: 'single', colorHex: '1F4E79', font: 'Georgia', sizePt: 12 }],
+          },
+        ];
+        buffer = await generateDocx(spec);
+      });
+
+      let rPr!: Element;
+      let documentDoc!: Document;
+      await when('the run properties are parsed back', async () => {
+        documentDoc = await loadPart(buffer, 'word/document.xml');
+        rPr = documentDoc.getElementsByTagName('w:rPr').item(0)!;
+        expect(rPr).toBeTruthy();
+      });
+
+      await then('the rPr children appear in the WML schema sequence', async () => {
+        const names = wChildNames(rPr);
+        await attachPrettyJson('rpr-child-order', names);
+        expect(names).toEqual(['rFonts', 'b', 'bCs', 'i', 'iCs', 'color', 'sz', 'szCs', 'u']);
+      });
+
+      await then('the formatting survives a round-trip through the run-formatting reader', async () => {
+        const run = documentDoc.getElementsByTagName('w:r').item(0)!;
+        const stylesDoc = await loadPart(buffer, 'word/styles.xml');
+        const formatting = extractEffectiveRunFormatting({
+          run,
+          paragraphPPr: null,
+          paragraphStyleId: null,
+          styles: parseStylesXml(stylesDoc),
+        });
+        expect(formatting).toMatchObject({
+          bold: true,
+          italic: true,
+          underline: true,
+          colorHex: '1F4E79',
+          fontName: 'Georgia',
+          fontSizePt: 12,
+        });
+      });
+    },
+  );
+
+  test
+    .openspec('[SDX-GEN-042] paragraph properties are emitted in schema order')
+    .conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.3.1.26' })(
+    'Scenario: paragraph properties are emitted in schema order',
+    async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
+      let buffer!: Buffer;
+      await given('a paragraph specifying alignment, spacing, indentation, and tab stops', async () => {
+        buffer = await generateDocx(styledSpec());
+      });
+
+      let pPr!: Element;
+      await when('the second paragraph’s properties are parsed back', async () => {
+        const documentDoc = await loadPart(buffer, 'word/document.xml');
+        const paragraph = documentDoc.getElementsByTagName('w:p').item(1)!;
+        pPr = getDirectChildrenByName(paragraph, 'pPr')[0]!;
+        expect(pPr).toBeTruthy();
+      });
+
+      await then('the pPr children appear in the WML schema sequence with the requested values', async () => {
+        const names = wChildNames(pPr);
+        await attachPrettyJson('ppr-child-order', names);
+        expect(names).toEqual(['tabs', 'spacing', 'ind', 'jc']);
+        const jc = pPr.getElementsByTagName('w:jc').item(0)!;
+        expect(jc.getAttribute('w:val')).toBe('both');
+        const tab = pPr.getElementsByTagName('w:tab').item(0)!;
+        expect(tab.getAttribute('w:pos')).toBe('4320');
+        expect(tab.getAttribute('w:leader')).toBe('dot');
+      });
+    },
+  );
+
+  test('phase 2 styled artifact loads through the document façade with formatting intact', async () => {
+    const buffer = await generateDocx(styledSpec());
+    const doc = await DocxDocument.load(buffer);
+    doc.insertParagraphBookmarks('sdx-gen-phase2');
+    const texts = doc.readParagraphs().paragraphs.map((p) => p.text);
+    expect(texts[0]).toContain('ARTICLE I');
+    expect(texts[1]).toContain('Confidential Information');
+    const { writeIntegrationArtifact } = await import('../integration/output-artifacts.js');
+    const outputPath = await writeIntegrationArtifact('generation-phase2-styled.docx', buffer);
+    expect(outputPath).toContain('generation-phase2-styled.docx');
+  });
+});

--- a/packages/docx-core/src/generation/ordering-schema.test.ts
+++ b/packages/docx-core/src/generation/ordering-schema.test.ts
@@ -1,0 +1,87 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { PPR_ORDER, RPR_ORDER, SECTPR_ORDER, TBLPR_ORDER, TCPR_ORDER } from './ordering.js';
+
+const TEST_FEATURE = 'add-docx-generation';
+const test = testAllure.epic('Document Generation').withLabels({ feature: TEST_FEATURE });
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const WML_XSD_PATH = path.resolve(__dirname, '../../../../spec-compliance/ecma-376/schemas/transitional/wml.xsd');
+
+/**
+ * Extract child element local names, in declaration order, from a named
+ * complexType or group in the vendored WML schema. Declaration order inside
+ * the type body is the schema's canonical property order (sequences enforce
+ * it outright; the transitional EG_RPrBase choice still lists members in
+ * canonical order).
+ */
+function schemaChildOrder(xsd: string, kind: 'complexType' | 'group', name: string): string[] {
+  const open = new RegExp(`<xsd:${kind} name="${name}">`);
+  const startMatch = open.exec(xsd);
+  if (!startMatch) throw new Error(`schema ${kind} '${name}' not found`);
+  const close = `</xsd:${kind}>`;
+  const end = xsd.indexOf(close, startMatch.index);
+  if (end < 0) throw new Error(`schema ${kind} '${name}' has no close tag`);
+  const body = xsd.slice(startMatch.index, end);
+
+  const names: string[] = [];
+  const elementRe = /<xsd:element (?:name|ref)="(?:w:)?([A-Za-z0-9_]+)"/g;
+  let m;
+  while ((m = elementRe.exec(body))) {
+    if (!names.includes(m[1]!)) names.push(m[1]!);
+  }
+  // Inline groups referenced from the body (e.g. CT_PPrBase pulls EG_RPrBase? no,
+  // but CT_PPr extends CT_PPrBase) are resolved by callers via concatenation.
+  return names;
+}
+
+function expectSubsequence(table: readonly string[], schemaOrder: string[], label: string): void {
+  const filtered = schemaOrder.filter((name) => table.includes(name));
+  const missing = table.filter((name) => !schemaOrder.includes(name));
+  expect(missing, `${label}: ordering-table entries missing from schema declaration: ${missing.join(', ')}`).toEqual([]);
+  expect(filtered, `${label}: table order must match schema declaration order`).toEqual([...table]);
+}
+
+describe('Traceability: property-order tables vs vendored schema', () => {
+  test
+    .openspec('[SDX-GEN-043] property-order tables match the vendored schema')
+    .conformance(
+      { spec: 'ECMA-376', edition: 5, part: 1, section: '17.3.1.26' },
+      { spec: 'ECMA-376', edition: 5, part: 1, section: '17.3.2.28' },
+    )(
+    'Scenario: property-order tables match the vendored schema',
+    async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
+      let xsd!: string;
+      await given('the vendored transitional WML schema', async () => {
+        xsd = readFileSync(WML_XSD_PATH, 'utf-8');
+        expect(xsd.length).toBeGreaterThan(100_000);
+      });
+
+      let orders!: Record<string, string[]>;
+      await when('the declared child order is extracted for each property container', async () => {
+        orders = {
+          // CT_PPr extends CT_PPrBase with rPr + sectPr (+ pPrChange) at the end.
+          pPr: [...schemaChildOrder(xsd, 'complexType', 'CT_PPrBase'), ...schemaChildOrder(xsd, 'complexType', 'CT_PPr')],
+          rPr: schemaChildOrder(xsd, 'group', 'EG_RPrBase'),
+          // CT_SectPr pulls EG_HdrFtrReferences first, then the shared
+          // EG_SectPrContents group that holds the property sequence.
+          sectPr: ['headerReference', 'footerReference', ...schemaChildOrder(xsd, 'group', 'EG_SectPrContents')],
+          tblPr: schemaChildOrder(xsd, 'complexType', 'CT_TblPrBase'),
+          tcPr: schemaChildOrder(xsd, 'complexType', 'CT_TcPrBase'),
+        };
+        await attachPrettyJson('schema-declared-orders', orders);
+      });
+
+      await then('every ordering table is a subsequence of the schema order', async () => {
+        expectSubsequence(PPR_ORDER, orders.pPr!, 'PPR_ORDER');
+        expectSubsequence(RPR_ORDER, orders.rPr!, 'RPR_ORDER');
+        expectSubsequence(SECTPR_ORDER, orders.sectPr!, 'SECTPR_ORDER');
+        expectSubsequence(TBLPR_ORDER, orders.tblPr!, 'TBLPR_ORDER');
+        expectSubsequence(TCPR_ORDER, orders.tcPr!, 'TCPR_ORDER');
+      });
+    },
+  );
+});

--- a/packages/docx-core/src/generation/validate-spec.ts
+++ b/packages/docx-core/src/generation/validate-spec.ts
@@ -9,23 +9,17 @@
  *     with a typed error naming the feature and its path — never be silently
  *     dropped (scenario SDX-GEN-003).
  *
- * As phase PRs land emitters, their features move from the rejection list to
- * the supported set in the same PR.
+ * Shipped so far: plain/formatted text runs (RunProps), paragraph formatting
+ * (style references, alignment, spacing, indentation, tabs, keepNext,
+ * pageBreakBefore), named styles + styles.xml, single-section page setup.
+ * Still rejected: numbering, multi-section, headers/footers, fields,
+ * tab/break runs, tables, drafting notes.
  */
 
 import { GenerationSpecError } from './errors.js';
-import type { DocumentSpec, InlineSpec, ParagraphSpec, RunProps, SectionSpec } from './types.js';
+import type { DocumentSpec, InlineSpec, ParagraphSpec, RunProps, SectionSpec, StyleSpec } from './types.js';
 
-const RUN_PROP_KEYS: ReadonlyArray<keyof RunProps> = [
-  'bold',
-  'italic',
-  'underline',
-  'colorHex',
-  'font',
-  'sizePt',
-  'caps',
-  'smallCaps',
-];
+const COLOR_HEX_RE = /^[0-9A-Fa-f]{6}$/;
 
 function unsupported(path: string, feature: string): never {
   throw new GenerationSpecError(
@@ -41,16 +35,48 @@ export function validateSpec(spec: DocumentSpec): void {
     throw new GenerationSpecError('empty_sections', '/sections', 'DocumentSpec.sections must contain at least one section');
   }
 
-  if (spec.styles && spec.styles.length > 0) unsupported('/styles', 'styles');
   if (spec.numbering && spec.numbering.length > 0) unsupported('/numbering', 'numbering');
   if (spec.sections.length > 1) unsupported('/sections', 'multiple sections');
 
+  const declaredStyleIds = validateStyles(spec.styles ?? []);
+
   spec.sections.forEach((section, sectionIndex) => {
-    validateSection(section, `/sections/${sectionIndex}`);
+    validateSection(section, `/sections/${sectionIndex}`, declaredStyleIds);
   });
 }
 
-function validateSection(section: SectionSpec, path: string): void {
+/** Returns the set of resolvable style ids (declared styles + implicit Normal). */
+function validateStyles(styles: StyleSpec[]): Set<string> {
+  const ids = new Set<string>(['Normal']);
+  styles.forEach((style, index) => {
+    const path = `/styles/${index}`;
+    if (!style.styleId || !style.name) {
+      throw new GenerationSpecError('invalid_value', path, 'StyleSpec requires styleId and name');
+    }
+    if (ids.has(style.styleId)) {
+      throw new GenerationSpecError('invalid_value', `${path}/styleId`, `Duplicate styleId '${style.styleId}'`);
+    }
+    ids.add(style.styleId);
+    if (style.run) validateRunProps(style.run, `${path}/run`);
+  });
+  // basedOn / next must resolve against the full declared set (forward refs allowed).
+  styles.forEach((style, index) => {
+    const path = `/styles/${index}`;
+    for (const key of ['basedOn', 'next'] as const) {
+      const ref = style[key];
+      if (ref !== undefined && !ids.has(ref)) {
+        throw new GenerationSpecError(
+          'dangling_style_reference',
+          `${path}/${key}`,
+          `Style '${style.styleId}' references undeclared style '${ref}' via ${key}`,
+        );
+      }
+    }
+  });
+  return ids;
+}
+
+function validateSection(section: SectionSpec, path: string, styleIds: Set<string>): void {
   if (section.breakType) unsupported(`${path}/breakType`, 'section break type');
   if (section.pageNumbering) unsupported(`${path}/pageNumbering`, 'page numbering');
   if (section.titlePg) unsupported(`${path}/titlePg`, 'title page header/footer');
@@ -76,20 +102,28 @@ function validateSection(section: SectionSpec, path: string): void {
   section.blocks.forEach((block, blockIndex) => {
     const blockPath = `${path}/blocks/${blockIndex}`;
     if (block.kind === 'table') unsupported(blockPath, 'tables');
-    validateParagraph(block, blockPath);
+    validateParagraph(block, blockPath, styleIds);
   });
 }
 
-function validateParagraph(paragraph: ParagraphSpec, path: string): void {
-  if (paragraph.styleId !== undefined) unsupported(`${path}/styleId`, 'named paragraph styles');
-  if (paragraph.alignment !== undefined) unsupported(`${path}/alignment`, 'paragraph alignment');
-  if (paragraph.spacing !== undefined) unsupported(`${path}/spacing`, 'paragraph spacing');
-  if (paragraph.indent !== undefined) unsupported(`${path}/indent`, 'paragraph indentation');
+function validateParagraph(paragraph: ParagraphSpec, path: string, styleIds: Set<string>): void {
   if (paragraph.list !== undefined) unsupported(`${path}/list`, 'numbered lists');
-  if (paragraph.pageBreakBefore !== undefined) unsupported(`${path}/pageBreakBefore`, 'page break before');
-  if (paragraph.keepNext !== undefined) unsupported(`${path}/keepNext`, 'keep with next');
-  if (paragraph.tabs !== undefined) unsupported(`${path}/tabs`, 'tab stops');
   if (paragraph.note !== undefined) unsupported(`${path}/note`, 'drafting notes');
+
+  if (paragraph.styleId !== undefined && !styleIds.has(paragraph.styleId)) {
+    throw new GenerationSpecError(
+      'dangling_style_reference',
+      `${path}/styleId`,
+      `Paragraph references undeclared style '${paragraph.styleId}'`,
+    );
+  }
+  if (paragraph.tabs) {
+    paragraph.tabs.forEach((stop, i) => {
+      if (!(stop.posTwips >= 0) || !Number.isFinite(stop.posTwips)) {
+        throw new GenerationSpecError('invalid_value', `${path}/tabs/${i}/posTwips`, 'Tab stop position must be a non-negative finite twips value');
+      }
+    });
+  }
 
   if (!Array.isArray(paragraph.runs)) {
     throw new GenerationSpecError('invalid_value', `${path}/runs`, 'Paragraph runs must be an array');
@@ -107,7 +141,14 @@ function validateInline(run: InlineSpec, path: string): void {
   if (typeof run.text !== 'string') {
     throw new GenerationSpecError('invalid_value', `${path}/text`, 'Text runs must carry a string');
   }
-  for (const key of RUN_PROP_KEYS) {
-    if (run[key] !== undefined) unsupported(`${path}/${key}`, `run formatting '${key}'`);
+  validateRunProps(run, path);
+}
+
+function validateRunProps(props: RunProps, path: string): void {
+  if (props.colorHex !== undefined && !COLOR_HEX_RE.test(props.colorHex)) {
+    throw new GenerationSpecError('invalid_value', `${path}/colorHex`, `colorHex must be six hex digits without '#', got '${props.colorHex}'`);
+  }
+  if (props.sizePt !== undefined && (!(props.sizePt > 0) || !Number.isFinite(props.sizePt))) {
+    throw new GenerationSpecError('invalid_value', `${path}/sizePt`, 'sizePt must be a positive finite number');
   }
 }

--- a/packages/docx-core/src/primitives/namespaces.ts
+++ b/packages/docx-core/src/primitives/namespaces.ts
@@ -93,6 +93,20 @@ export const W = {
   pgSz: 'pgSz',
   pgMar: 'pgMar',
 
+  // Styles part + paragraph/run formatting (generation emitters)
+  docDefaults: 'docDefaults',
+  pPrDefault: 'pPrDefault',
+  rPrDefault: 'rPrDefault',
+  next: 'next',
+  qFormat: 'qFormat',
+  bCs: 'bCs',
+  iCs: 'iCs',
+  caps: 'caps',
+  smallCaps: 'smallCaps',
+  keepNext: 'keepNext',
+  pageBreakBefore: 'pageBreakBefore',
+  tabs: 'tabs',
+
   // Fields + special runs
   fldChar: 'fldChar',
   instrText: 'instrText',

--- a/spec-compliance/CONFORMANCE.md
+++ b/spec-compliance/CONFORMANCE.md
@@ -22,6 +22,9 @@ Allure labels via `testAllure.conformance({…})`; source code carries
 | `ECMA-PART1-17-6-11` | w:pgMar page margin emission | 5 | 1 | 17.6.11 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:pgMar` | — |
 | `ECMA-PART1-17-3-1-26` | w:pPr child-element ordering | 5 | 1 | 17.3.1.26 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:pPr` | — |
 | `ECMA-PART1-17-3-2-28` | w:rPr child-element ordering | 5 | 1 | 17.3.2.28 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:rPr` | — |
+| `ECMA-PART1-17-7-4-18` | w:styles style-definitions part emission | 5 | 1 | 17.7.4.18 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:styles` | — |
+| `ECMA-PART1-17-7-4-17` | w:style style-definition emission | 5 | 1 | 17.7.4.17 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:style` | — |
+| `ECMA-PART1-17-7-5-1` | w:docDefaults document-default properties | 5 | 1 | 17.7.5.1 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:docDefaults` | — |
 
 ### ECMA-PART4-17-16-5 — w:delInstrText and w:fldChar placement in tracked deletions
 
@@ -165,6 +168,47 @@ decision.
 generation discipline encodes the emitted subset as `RPR_ORDER` in
 `packages/docx-core/src/generation/ordering.ts`, enforced through the
 same `appendInOrder` mechanism as paragraph properties.
+
+### ECMA-PART1-17-7-4-18 — w:styles style-definitions part emission
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.7.4.18
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:styles`
+
+`w:styles` is the root of the style-definitions part. From-scratch
+generation always emits `word/styles.xml` — document defaults, a default
+`Normal` paragraph style, and every declared named style — wired through a
+content-type override and a styles relationship from the main document
+part. The emitter lives at
+`packages/docx-core/src/generation/emit/styles-part.ts`.
+
+### ECMA-PART1-17-7-4-17 — w:style style-definition emission
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.7.4.17
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:style`
+
+Each declared `StyleSpec` becomes a `w:style` carrying `w:type`,
+`w:styleId`, `w:name`, optional `w:basedOn`/`w:next` links, and `w:pPr` /
+`w:rPr` built by the same shared property builders the body emitters use —
+so a style definition and direct formatting can never serialize a property
+differently. Dangling `basedOn`/`next`/paragraph references are rejected
+at spec validation, before any XML is built.
+
+### ECMA-PART1-17-7-5-1 — w:docDefaults document-default properties
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.7.5.1
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:docDefaults`
+
+`w:docDefaults` carries the document-wide default run and paragraph
+properties that styles and direct formatting layer over. Generation emits
+explicit defaults (font bound across ascii/hAnsi/cs script ranges plus an
+explicit size) rather than relying on reader fallbacks, which diverge
+between Word, LibreOffice, and Google Docs import.
 
 ## Non-Goals
 

--- a/spec-compliance/registry/ecma-376.md
+++ b/spec-compliance/registry/ecma-376.md
@@ -191,6 +191,59 @@ generation discipline encodes the emitted subset as `RPR_ORDER` in
 `packages/docx-core/src/generation/ordering.ts`, enforced through the
 same `appendInOrder` mechanism as paragraph properties.
 
+## [ECMA-PART1-17-7-4-18] w:styles style-definitions part emission
+
+```yaml
+edition: 5
+part: 1
+section: "17.7.4.18"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:styles
+verifiedBy:
+```
+
+`w:styles` is the root of the style-definitions part. From-scratch
+generation always emits `word/styles.xml` — document defaults, a default
+`Normal` paragraph style, and every declared named style — wired through a
+content-type override and a styles relationship from the main document
+part. The emitter lives at
+`packages/docx-core/src/generation/emit/styles-part.ts`.
+
+## [ECMA-PART1-17-7-4-17] w:style style-definition emission
+
+```yaml
+edition: 5
+part: 1
+section: "17.7.4.17"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:style
+verifiedBy:
+```
+
+Each declared `StyleSpec` becomes a `w:style` carrying `w:type`,
+`w:styleId`, `w:name`, optional `w:basedOn`/`w:next` links, and `w:pPr` /
+`w:rPr` built by the same shared property builders the body emitters use —
+so a style definition and direct formatting can never serialize a property
+differently. Dangling `basedOn`/`next`/paragraph references are rejected
+at spec validation, before any XML is built.
+
+## [ECMA-PART1-17-7-5-1] w:docDefaults document-default properties
+
+```yaml
+edition: 5
+part: 1
+section: "17.7.5.1"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:docDefaults
+verifiedBy:
+```
+
+`w:docDefaults` carries the document-wide default run and paragraph
+properties that styles and direct formatting layer over. Generation emits
+explicit defaults (font bound across ascii/hAnsi/cs script ranges plus an
+explicit size) rather than relying on reader fallbacks, which diverge
+between Word, LibreOffice, and Google Docs import.
+
 ## Non-Goals
 
 Sections explicitly **out of scope** for safe-docx. Each entry below carries the


### PR DESCRIPTION
## Summary

Phase 2 of the `add-docx-generation` OpenSpec change (#280, follows #397).

- `word/styles.xml` always emitted: explicit `docDefaults` (cross-script font binding + explicit size — reader fallbacks diverge), default `Normal`, and every declared `StyleSpec` with `basedOn`/`next` links.
- Full run formatting (`bold`/`italic`/`underline`/`colorHex`/`font`/`sizePt`/`caps`/`smallCaps`, with `bCs`/`iCs`/`szCs` complex-script twins) and paragraph formatting (`styleId`, `alignment`, `spacing`, `indent`, `tabs`, `keepNext`, `pageBreakBefore`).
- One shared pair of property builders (`emit/properties.ts`) serves both style definitions and direct formatting — they cannot drift apart; everything still routes through the ordering tables.
- **New schema cross-check** (`ordering-schema.test.ts`): extracts each property container's declared child order from the vendored transitional `wml.xsd` and asserts every ordering table is a subsequence — the ordering discipline is now a checked invariant (SDX-GEN-043).
- Dangling `styleId`/`basedOn`/`next` references rejected at spec validation with typed path-bearing errors (SDX-GEN-004).
- Registry +3 verified sections (styles §17.7.4.18, style §17.7.4.17, docDefaults §17.7.5.1).

Scenarios covered this phase: SDX-GEN-004, 040–043 (15/36 mapped, validator report-only by design until the final phase).

## Verification

- build / lint:workspaces / full `test:run` green (17 generation tests incl. the schema cross-check)
- `check:spec-coverage`, `check:allure-labels`, `check:allure-quality`, `check:allure-filenames`, `check:conformance-citations` green; `check:conformance-doc` green at commit
- `openspec validate add-docx-generation --strict` green

Ref: #280