### PR TITLE
fix(docx-core): run docx-comparison bin when invoked via node_modules/.bin symlink

### DIFF
--- a/packages/docx-core/src/cli/index.test.ts
+++ b/packages/docx-core/src/cli/index.test.ts
@@ -1,0 +1,71 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterAll, describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+
+const test = testAllure.epic('Document Comparison').withLabels({ feature: 'CLI Bin Symlink Entrypoint' });
+
+const CLI_SOURCE_PATH = join(dirname(fileURLToPath(import.meta.url)), 'index.ts');
+const PACKAGE_DIR = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+const tempDirs: string[] = [];
+
+function runCliEntry(entryPath: string, args: string[]) {
+  // --import tsx lets the spawned node execute the TypeScript source directly,
+  // so the test exercises the entry guard without depending on a prior build.
+  return spawnSync(process.execPath, ['--import', 'tsx', entryPath, ...args], {
+    cwd: PACKAGE_DIR,
+    encoding: 'utf8',
+  });
+}
+
+afterAll(() => {
+  for (const dir of tempDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('docx-comparison bin entry guard', () => {
+  test('executes the CLI when invoked through a node_modules/.bin-style symlink', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    let symlinkPath!: string;
+    let result!: ReturnType<typeof runCliEntry>;
+
+    await given('a symlink to the CLI entrypoint, as npm creates in node_modules/.bin', () => {
+      const binDir = mkdtempSync(join(tmpdir(), 'docx-comparison-bin-'));
+      tempDirs.push(binDir);
+      symlinkPath = join(binDir, 'docx-comparison');
+      symlinkSync(CLI_SOURCE_PATH, symlinkPath);
+    });
+
+    await when('the bin is invoked through the symlink with --help', () => {
+      result = runCliEntry(symlinkPath, ['--help']);
+    });
+
+    await then('the CLI runs and prints usage instead of silently exiting 0', () => {
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('Usage: docx-comparison');
+    });
+  });
+
+  test('still executes the CLI when invoked by direct file path', async ({ when, then }: AllureBddContext) => {
+    let result!: ReturnType<typeof runCliEntry>;
+
+    await when('the entrypoint is invoked by its real path with --help', () => {
+      result = runCliEntry(CLI_SOURCE_PATH, ['--help']);
+    });
+
+    await then('the CLI prints usage', () => {
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('Usage: docx-comparison');
+    });
+  });
+});

--- a/packages/docx-core/src/cli/index.ts
+++ b/packages/docx-core/src/cli/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { realpathSync } from 'node:fs';
 import { pathToFileURL } from 'node:url';
 import { runCompareCli } from './compare-two.js';
 
@@ -14,7 +15,10 @@ export async function runCli(argv = process.argv): Promise<void> {
   console.log(JSON.stringify(result));
 }
 
-if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) {
+// npm installs bins as node_modules/.bin symlinks, so argv[1] must be
+// realpath-resolved before comparing against import.meta.url (which node
+// always resolves to the real dist file). See #398.
+if (process.argv[1] && pathToFileURL(realpathSync(process.argv[1])).href === import.meta.url) {
   runCli(process.argv).catch((err) => {
     // eslint-disable-next-line no-console
     console.error(err?.message ?? String(err));


### PR DESCRIPTION
## Problem

The entry guard in `packages/docx-core/src/cli/index.ts` compared `pathToFileURL(process.argv[1])` against `import.meta.url`. When the published bins (`docx-comparison`, `safe-docx-compare`) are invoked through the `node_modules/.bin` symlink — the normal path for any npm-installed consumer — `argv[1]` is the symlink while `import.meta.url` is the realpath of `dist/cli/index.js`, so the guard never matched and the process exited 0 having done nothing. Invisible in-repo (`npm run cli` runs the dist file directly), broken for every external consumer.

## Fix

Resolve the symlink before comparing — `pathToFileURL(realpathSync(process.argv[1])).href === import.meta.url` — the same form the conformance adapter uses (#394).

## Hardening (per the issue)

- **Pattern sweep:** `pathToFileURL(process.argv[1])` existed nowhere else. The `docx-mcp` and `safe-docx` bin entrypoints call `runCli` unconditionally (no guard to break). `benchmark/runner.ts` has a similar-looking guard but is internal-only (`npm run benchmark` → direct `tsx` invocation), not a published bin.
- **Symlink regression test:** `src/cli/index.test.ts` executes the entrypoint through an actual symlink (the shape npm creates in `node_modules/.bin`) plus the direct path, asserting usage output and exit 0. Verified red against the unfixed guard, green with the fix. Also smoke-tested the built `dist/cli/index.js` through a symlink manually.

Full pre-submit gate (build, lint, tests, spec-coverage, conformance checks) passed locally.

Fixes: #398
Ref: #394
Ref: #283