### PR TITLE
feat(docx-core): from-scratch generation phase 3 — sections, headers/footers, PAGE/NUMPAGES fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ safe-docx targets a defined subset of **ECMA-376 5th edition**. The full surface
 (targeted sections, Non-Goals, and verification status) lives at
 [spec-compliance/CONFORMANCE.md](spec-compliance/CONFORMANCE.md).
 
-- **12** sections claimed
+- **23** sections claimed
 - **5** sections explicitly out-of-scope (Non-Goals)
 - **0** known gaps under `@conformance-gap`
 - Vendored normative schemas: `spec-compliance/ecma-376/schemas/`

--- a/openspec/changes/add-docx-generation/tasks.md
+++ b/openspec/changes/add-docx-generation/tasks.md
@@ -22,10 +22,10 @@ and `openspec validate add-docx-generation --strict`.
 - [x] 2.3 XSD relative-order cross-check test; registry entries for styles/rPr/pPr sections
 
 ## 3. Sections, headers/footers, fields, page numbering (PR 3) — SDX-GEN-021..024, 030..032
-- [ ] 3.1 `emit/header-footer-part.ts` + reference wiring + content types + `w:titlePg`
-- [ ] 3.2 Mid-document section-break paragraphs; `w:pgNumType`; settings.xml for even headers
-- [ ] 3.3 `FieldSpec` (PAGE/NUMPAGES, required cachedResult); cross-story field-pairing structural check
-- [ ] 3.4 Cover→body acceptance fixture; registry entries for sectPr/header/field sections
+- [x] 3.1 `emit/header-footer-part.ts` + reference wiring + content types + `w:titlePg`
+- [x] 3.2 Mid-document section-break paragraphs; `w:pgNumType`; settings.xml for even headers
+- [x] 3.3 `FieldSpec` (PAGE/NUMPAGES, required cachedResult); cross-story field-pairing structural check
+- [x] 3.4 Cover→body acceptance fixture; registry entries for sectPr/header/field sections
 
 ## 4. Tables (PR 4) — SDX-GEN-050..053
 - [ ] 4.1 `emit/table.ts`: tblPr/tblGrid/trPr/tcPr per schema order; blocks-in-cells with trailing `w:p`

--- a/packages/docx-core/docs/generation-manual-compat-checklist.md
+++ b/packages/docx-core/docs/generation-manual-compat-checklist.md
@@ -29,6 +29,7 @@ Artifacts land under `packages/docx-core/src/testing/outputs/`.
 |---|---|---|---|---|---|
 | `generation-phase1-minimal.docx` (plain paragraphs + explicit page setup) | PR 1 | — | — | — | clean (identity + PDF probes, automated) |
 | `generation-phase2-styled.docx` (named style + run formatting + tabs/indent/justify) | PR 2 | — | — | — | — |
+| `generation-phase3-cover-body.docx` (titlePg cover header → body header, Page X of Y field footer, page break) | PR 3 | — | — | — | — |
 
 ## Per-reader notes
 

--- a/packages/docx-core/src/generation/compile.ts
+++ b/packages/docx-core/src/generation/compile.ts
@@ -5,12 +5,19 @@
  * Determinism contract: identical specs compile to byte-identical buffers.
  * No emitter reads the clock or randomness; zip entry dates are pinned to a
  * fixed epoch (document-facing dates come from spec.meta.createdIso).
+ *
+ * Ordering: header/footer parts are allocated first so their relationship
+ * ids exist when the document part binds section references; the package
+ * plumbing runs last because [Content_Types].xml is assembled from the part
+ * registry.
  */
 
 import { createZipBuffer } from '../primitives/zip.js';
 import { CompileContext } from './context.js';
 import { emitDocumentPart } from './emit/document-part.js';
+import { emitHeaderFooterParts } from './emit/header-footer-part.js';
 import { emitPackageParts } from './emit/package-parts.js';
+import { emitSettingsPartIfNeeded } from './emit/settings-part.js';
 import { emitStylesPart } from './emit/styles-part.js';
 import type { DocumentSpec } from './types.js';
 import { validateSpec } from './validate-spec.js';
@@ -28,8 +35,10 @@ export async function generateDocx(spec: DocumentSpec, _opts?: GenerateDocxOptio
   validateSpec(spec);
 
   const ctx = new CompileContext();
-  ctx.setFileContent('word/document.xml', emitDocumentPart(spec));
+  const headerFooterRefs = emitHeaderFooterParts(spec, ctx);
+  ctx.setFileContent('word/document.xml', emitDocumentPart(spec, headerFooterRefs));
   emitStylesPart(spec, ctx);
+  emitSettingsPartIfNeeded(spec, ctx);
   emitPackageParts(spec, ctx);
 
   return createZipBuffer(ctx.toFileRecord(), { fileDate: ZIP_EPOCH });

--- a/packages/docx-core/src/generation/emit/document-part.ts
+++ b/packages/docx-core/src/generation/emit/document-part.ts
@@ -8,12 +8,13 @@
  * the structural validator asserts every part starts with one.
  */
 
-import { OOXML } from '../../primitives/namespaces.js';
+import { createWmlElement } from '../../primitives/dom-helpers.js';
+import { OOXML, W } from '../../primitives/namespaces.js';
 import { parseXml, serializeXml } from '../../primitives/xml.js';
 import { GenerationInternalError } from '../errors.js';
 import type { DocumentSpec } from '../types.js';
 import { buildParagraph } from './paragraph.js';
-import { buildSectPr } from './section.js';
+import { buildSectPr, type SectionHeaderFooterRefs } from './section.js';
 
 export const XML_DECL = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
 
@@ -22,19 +23,21 @@ const DOCUMENT_SKELETON =
   `<w:body/></w:document>`;
 
 /**
- * Compile the body: each section's blocks in order, with the final section's
- * properties bound as the body's last child. Multi-section emission (a
- * dedicated break paragraph whose pPr holds the ending section's sectPr)
- * lands in the multi-section phase.
+ * Compile the body: each section's blocks in order. Every non-final section
+ * ends with a dedicated break paragraph whose pPr contains only that
+ * section's sectPr (what Word itself emits on Insert → Section Break; it
+ * also sidesteps the trailing-table case), and the final section's
+ * properties bind as the body's last child.
  *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.6.18
  * @conformance ECMA-376 edition 5, Part 1 § 17.6.17
  */
-export function emitDocumentPart(spec: DocumentSpec): string {
+export function emitDocumentPart(spec: DocumentSpec, refs?: SectionHeaderFooterRefs[]): string {
   const doc = parseXml(DOCUMENT_SKELETON);
   const body = doc.getElementsByTagName('w:body').item(0);
   if (!body) throw new GenerationInternalError('document skeleton lost its w:body');
 
-  for (const section of spec.sections) {
+  spec.sections.forEach((section, index) => {
     for (const block of section.blocks) {
       if (block.kind !== 'paragraph') {
         throw new GenerationInternalError(
@@ -43,10 +46,19 @@ export function emitDocumentPart(spec: DocumentSpec): string {
       }
       body.appendChild(buildParagraph(doc, block));
     }
-  }
 
-  const finalSection = spec.sections[spec.sections.length - 1]!;
-  body.appendChild(buildSectPr(doc, finalSection));
+    const sectPr = buildSectPr(doc, section, refs?.[index]);
+    const isFinal = index === spec.sections.length - 1;
+    if (isFinal) {
+      body.appendChild(sectPr);
+    } else {
+      const breakParagraph = createWmlElement(doc, W.p);
+      const pPr = createWmlElement(doc, W.pPr);
+      pPr.appendChild(sectPr);
+      breakParagraph.appendChild(pPr);
+      body.appendChild(breakParagraph);
+    }
+  });
 
   return XML_DECL + serializeXml(doc);
 }

--- a/packages/docx-core/src/generation/emit/header-footer-part.ts
+++ b/packages/docx-core/src/generation/emit/header-footer-part.ts
@@ -1,0 +1,78 @@
+/**
+ * Header and footer part emitters.
+ *
+ * Each declared header/footer slot (default / first / even) becomes its own
+ * part — word/headerN.xml or word/footerN.xml — registered with a
+ * content-type override and a relationship from the main document part. The
+ * block content reuses the same paragraph/run emitters as the body, so a
+ * footer's "Page X of Y" field compiles through exactly the same five-part
+ * field machinery.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.10.4
+ */
+
+import { OOXML } from '../../primitives/namespaces.js';
+import { parseXml, serializeXml } from '../../primitives/xml.js';
+import { GenerationInternalError } from '../errors.js';
+import type { CompileContext } from '../context.js';
+import type { DocumentSpec, HeaderFooterSpec, SectionSpec } from '../types.js';
+import { XML_DECL } from './document-part.js';
+import { buildParagraph } from './paragraph.js';
+import type { SectionHeaderFooterRefs } from './section.js';
+
+const HEADER_CONTENT_TYPE = 'application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml';
+const FOOTER_CONTENT_TYPE = 'application/vnd.openxmlformats-officedocument.wordprocessingml.footer+xml';
+const HEADER_REL_TYPE = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/header';
+const FOOTER_REL_TYPE = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/footer';
+
+const SLOT_ORDER = ['first', 'default', 'even'] as const;
+
+/**
+ * Allocate and emit every header/footer part, returning per-section
+ * reference maps for the sectPr emitter. Runs before the document part so
+ * relationship ids exist when sections bind their references.
+ */
+export function emitHeaderFooterParts(spec: DocumentSpec, ctx: CompileContext): SectionHeaderFooterRefs[] {
+  return spec.sections.map((section) => emitForSection(section, ctx));
+}
+
+function emitForSection(section: SectionSpec, ctx: CompileContext): SectionHeaderFooterRefs {
+  const refs: SectionHeaderFooterRefs = { headers: {}, footers: {} };
+  for (const slot of SLOT_ORDER) {
+    const header = section.headers?.[slot];
+    if (header) {
+      refs.headers[slot] = emitPart(header, ctx, 'header');
+    }
+    const footer = section.footers?.[slot];
+    if (footer) {
+      refs.footers[slot] = emitPart(footer, ctx, 'footer');
+    }
+  }
+  return refs;
+}
+
+/** @conformance ECMA-376 edition 5, Part 1 § 17.10.3 */
+function emitPart(content: HeaderFooterSpec, ctx: CompileContext, kind: 'header' | 'footer'): string {
+  const isHeader = kind === 'header';
+  const partName = isHeader ? ctx.allocateHeaderPartName() : ctx.allocateFooterPartName();
+  const part = ctx.registerPart(
+    partName,
+    isHeader ? HEADER_CONTENT_TYPE : FOOTER_CONTENT_TYPE,
+    isHeader ? HEADER_REL_TYPE : FOOTER_REL_TYPE,
+  );
+
+  const rootTag = isHeader ? 'w:hdr' : 'w:ftr';
+  const doc = parseXml(`<${rootTag} xmlns:w="${OOXML.W_NS}" xmlns:r="${OOXML.R_NS}"/>`);
+  const root = doc.documentElement!;
+  for (const block of content.blocks) {
+    if (block.kind !== 'paragraph') {
+      throw new GenerationInternalError(
+        `Header/footer block kind '${block.kind}' reached the emitter without a shipped emitter`,
+      );
+    }
+    root.appendChild(buildParagraph(doc, block));
+  }
+
+  ctx.setFileContent(partName, XML_DECL + serializeXml(doc));
+  return part.documentRel!.rId;
+}

--- a/packages/docx-core/src/generation/emit/run.ts
+++ b/packages/docx-core/src/generation/emit/run.ts
@@ -1,30 +1,76 @@
 /**
  * Inline-run emitter.
  *
- * Shipped: text runs with full RunProps formatting (via the shared property
- * builders). Fields (with their five-part begin/instrText/separate/result/end
- * state machine), tabs, and breaks land in later phases; validate-spec rejects
- * them before emission, so reaching this dispatcher with an unshipped kind is
- * a compiler bug.
+ * Shipped: text runs with full RunProps formatting, tab and break runs, and
+ * complete five-part complex fields. A FieldSpec compiles to
+ * begin → instruction text → separate → cached result → end so reading
+ * applications always display a value without recomputation prompts — the
+ * required `cachedResult` makes the no-recovery-dialog property
+ * unrepresentable-by-omission. `w:dirty` is never set (it triggers
+ * update-fields prompts in some readers).
  */
 
 import { createWmlElement, createWmlTextElement } from '../../primitives/dom-helpers.js';
 import { W } from '../../primitives/namespaces.js';
 import { GenerationInternalError } from '../errors.js';
-import type { InlineSpec } from '../types.js';
+import type { FieldSpec, InlineSpec, RunProps } from '../types.js';
 import { buildRunPropsElement } from './properties.js';
+
+/** Instruction text per field, with the canonical surrounding spaces. */
+const FIELD_INSTRUCTION_TEXT: Record<FieldSpec['field'], string> = {
+  PAGE: ' PAGE ',
+  NUMPAGES: ' NUMPAGES ',
+};
+
+function makeRun(doc: Document, props: RunProps, ...children: Element[]): Element {
+  const run = createWmlElement(doc, W.r);
+  const rPr = buildRunPropsElement(doc, props);
+  if (rPr) run.appendChild(rPr);
+  for (const child of children) run.appendChild(child);
+  return run;
+}
+
+/**
+ * Five sibling runs per field: fldChar begin, preserved-space instruction
+ * text, fldChar separate, the cached result, fldChar end.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.18
+ */
+function buildFieldRuns(doc: Document, field: FieldSpec): Element[] {
+  const instr = createWmlElement(doc, W.instrText);
+  instr.setAttribute('xml:space', 'preserve');
+  instr.appendChild(doc.createTextNode(FIELD_INSTRUCTION_TEXT[field.field]));
+
+  return [
+    makeRun(doc, field, createWmlElement(doc, W.fldChar, { 'w:fldCharType': 'begin' })),
+    makeRun(doc, field, instr),
+    makeRun(doc, field, createWmlElement(doc, W.fldChar, { 'w:fldCharType': 'separate' })),
+    makeRun(doc, field, createWmlTextElement(doc, field.cachedResult)),
+    makeRun(doc, field, createWmlElement(doc, W.fldChar, { 'w:fldCharType': 'end' })),
+  ];
+}
 
 /** Build the w:r element(s) for one inline spec node. */
 export function buildInlineRuns(doc: Document, inline: InlineSpec): Element[] {
-  if (inline.kind === 'text') {
-    const run = createWmlElement(doc, W.r);
-    const rPr = buildRunPropsElement(doc, inline);
-    if (rPr) run.appendChild(rPr);
-    run.appendChild(createWmlTextElement(doc, inline.text));
-    return [run];
+  switch (inline.kind) {
+    case 'text': {
+      const run = createWmlElement(doc, W.r);
+      const rPr = buildRunPropsElement(doc, inline);
+      if (rPr) run.appendChild(rPr);
+      run.appendChild(createWmlTextElement(doc, inline.text));
+      return [run];
+    }
+    case 'field':
+      return buildFieldRuns(doc, inline);
+    case 'tab':
+      return [makeRun(doc, {}, createWmlElement(doc, W.tab))];
+    case 'break': {
+      const attrs = inline.breakType === 'page' ? { 'w:type': 'page' } : undefined;
+      return [makeRun(doc, {}, createWmlElement(doc, W.br, attrs))];
+    }
+    default:
+      throw new GenerationInternalError(
+        `Inline kind '${(inline as { kind: string }).kind}' reached the run emitter without a shipped emitter`,
+      );
   }
-  throw new GenerationInternalError(
-    `Inline kind '${inline.kind}' reached the run emitter without a shipped emitter; ` +
-      'validate-spec should have rejected it',
-  );
 }

--- a/packages/docx-core/src/generation/emit/section.ts
+++ b/packages/docx-core/src/generation/emit/section.ts
@@ -1,13 +1,14 @@
 /**
  * Section-properties emitter.
  *
- * PR 1 scope: page size and margins for the document-final section. Header /
- * footer references, break types, page numbering, and title-page switches land
- * with the multi-section phase.
+ * Shipped: page size/margins, page numbering, section break type, title-page
+ * switch, and header/footer references. The reference rIds come from the
+ * header/footer part allocation pass (emit/header-footer-part.ts), which runs
+ * before the document part so the sectPr can bind them.
  */
 
 import { createWmlElement } from '../../primitives/dom-helpers.js';
-import { W } from '../../primitives/namespaces.js';
+import { OOXML, W } from '../../primitives/namespaces.js';
 import { appendInOrder, SECTPR_ORDER } from '../ordering.js';
 import type { SectionSpec } from '../types.js';
 
@@ -25,21 +26,79 @@ const DEFAULT_MARGINS = {
   gutter: 0,
 } as const;
 
+/** Header/footer part references for one section, allocated by the parts pass. */
+export type SectionHeaderFooterRefs = {
+  headers: Partial<Record<'default' | 'first' | 'even', string>>;
+  footers: Partial<Record<'default' | 'first' | 'even', string>>;
+};
+
 /**
  * Build the w:sectPr element for a section.
  *
  * Width/height are always emitted explicitly (never reader defaults); a
- * landscape request swaps the dimensions and sets w:orient.
+ * landscape request swaps the dimensions and sets w:orient. Header/footer
+ * references lead the child sequence; w:titlePg is implied whenever a
+ * first-page header or footer is present.
  *
  * @conformance ECMA-376 edition 5, Part 1 § 17.6.13
+ * @conformance ECMA-376 edition 5, Part 1 § 17.6.12
+ * @conformance ECMA-376 edition 5, Part 1 § 17.10.6
  */
-export function buildSectPr(doc: Document, section: SectionSpec): Element {
+export function buildSectPr(doc: Document, section: SectionSpec, refs?: SectionHeaderFooterRefs): Element {
   const sectPr = createWmlElement(doc, W.sectPr);
   const props = new Map<string, Element | Element[]>();
+
+  if (refs) {
+    const headerRefs = buildReferences(doc, W.headerReference, refs.headers);
+    const footerRefs = buildReferences(doc, W.footerReference, refs.footers);
+    if (headerRefs.length > 0) props.set(W.headerReference, headerRefs);
+    if (footerRefs.length > 0) props.set(W.footerReference, footerRefs);
+  }
+
+  if (section.breakType !== undefined) {
+    props.set(W.type, createWmlElement(doc, W.type, { 'w:val': section.breakType }));
+  }
   props.set(W.pgSz, buildPgSz(doc, section));
   props.set(W.pgMar, buildPgMar(doc, section));
+  if (section.pageNumbering) {
+    const attrs: Record<string, string> = {};
+    if (section.pageNumbering.start !== undefined) attrs['w:start'] = String(section.pageNumbering.start);
+    if (section.pageNumbering.format !== undefined) attrs['w:fmt'] = section.pageNumbering.format;
+    props.set(W.pgNumType, createWmlElement(doc, W.pgNumType, attrs));
+  }
+  if (titlePgImplied(section)) {
+    props.set(W.titlePg, createWmlElement(doc, W.titlePg));
+  }
+
   appendInOrder(sectPr, props, SECTPR_ORDER);
   return sectPr;
+}
+
+export function titlePgImplied(section: SectionSpec): boolean {
+  return Boolean(section.titlePg || section.headers?.first || section.footers?.first);
+}
+
+/**
+ * One reference element per declared header/footer slot, in a fixed
+ * first/default/even emission order so output is deterministic.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.10.5
+ * @conformance ECMA-376 edition 5, Part 1 § 17.10.2
+ */
+function buildReferences(
+  doc: Document,
+  localName: string,
+  slots: Partial<Record<'default' | 'first' | 'even', string>>,
+): Element[] {
+  const out: Element[] = [];
+  for (const type of ['first', 'default', 'even'] as const) {
+    const rId = slots[type];
+    if (!rId) continue;
+    const el = createWmlElement(doc, localName, { 'w:type': type });
+    el.setAttributeNS(OOXML.R_NS, 'r:id', rId);
+    out.push(el);
+  }
+  return out;
 }
 
 function buildPgSz(doc: Document, section: SectionSpec): Element {

--- a/packages/docx-core/src/generation/emit/settings-part.ts
+++ b/packages/docx-core/src/generation/emit/settings-part.ts
@@ -1,0 +1,29 @@
+/**
+ * word/settings.xml emitter.
+ *
+ * Only emitted when the document actually needs a setting — today that is
+ * `w:evenAndOddHeaders`, required for any section declaring an even-page
+ * header or footer (without it readers ignore the even-page parts entirely).
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.10.1
+ */
+
+import { createWmlElement } from '../../primitives/dom-helpers.js';
+import { OOXML, W } from '../../primitives/namespaces.js';
+import { parseXml, serializeXml } from '../../primitives/xml.js';
+import type { CompileContext } from '../context.js';
+import type { DocumentSpec } from '../types.js';
+import { XML_DECL } from './document-part.js';
+
+const SETTINGS_CONTENT_TYPE = 'application/vnd.openxmlformats-officedocument.wordprocessingml.settings+xml';
+const SETTINGS_REL_TYPE = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/settings';
+
+export function emitSettingsPartIfNeeded(spec: DocumentSpec, ctx: CompileContext): void {
+  const needsEvenOdd = spec.sections.some((s) => s.headers?.even || s.footers?.even);
+  if (!needsEvenOdd) return;
+
+  ctx.registerPart('word/settings.xml', SETTINGS_CONTENT_TYPE, SETTINGS_REL_TYPE);
+  const doc = parseXml(`<w:settings xmlns:w="${OOXML.W_NS}"/>`);
+  doc.documentElement!.appendChild(createWmlElement(doc, W.evenAndOddHeaders));
+  ctx.setFileContent('word/settings.xml', XML_DECL + serializeXml(doc));
+}

--- a/packages/docx-core/src/generation/generation-sections-fields.test.ts
+++ b/packages/docx-core/src/generation/generation-sections-fields.test.ts
@@ -1,0 +1,309 @@
+import JSZip from 'jszip';
+import { describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { childElements } from '../primitives/dom-helpers.js';
+import { readZipText } from '../primitives/zip.js';
+import { parseXml } from '../primitives/xml.js';
+import { generateDocx } from './compile.js';
+import { checkGeneratedPackage } from './structural-checks.js';
+import type { DocumentSpec, HeaderFooterSpec } from './types.js';
+
+const TEST_FEATURE = 'add-docx-generation';
+const test = testAllure.epic('Document Generation').withLabels({ feature: TEST_FEATURE });
+
+function header(text: string): HeaderFooterSpec {
+  return { blocks: [{ kind: 'paragraph', alignment: 'center', runs: [{ kind: 'text', text }] }] };
+}
+
+function pageXofYFooter(): HeaderFooterSpec {
+  return {
+    blocks: [
+      {
+        kind: 'paragraph',
+        alignment: 'center',
+        runs: [
+          { kind: 'text', text: 'Page ' },
+          { kind: 'field', field: 'PAGE', cachedResult: '1' },
+          { kind: 'text', text: ' of ' },
+          { kind: 'field', field: 'NUMPAGES', cachedResult: '2' },
+        ],
+      },
+    ],
+  };
+}
+
+/** Cover page (distinct first header, no footer) flowing into body pages. */
+function coverBodySpec(): DocumentSpec {
+  return {
+    meta: { title: 'Cover-body acceptance', createdIso: '2026-06-10T00:00:00Z' },
+    sections: [
+      {
+        headers: { first: header('CONFIDENTIAL — DRAFT'), default: header('Acme / Northeast — Mutual NDA') },
+        footers: { default: pageXofYFooter() },
+        pageNumbering: { start: 1, format: 'decimal' },
+        blocks: [
+          { kind: 'paragraph', alignment: 'center', runs: [{ kind: 'text', text: 'MUTUAL NONDISCLOSURE AGREEMENT', bold: true, sizePt: 16 }] },
+          { kind: 'paragraph', runs: [{ kind: 'break', breakType: 'page' }, { kind: 'text', text: 'Body text after the cover page.' }] },
+        ],
+      },
+    ],
+  };
+}
+
+function twoSectionSpec(): DocumentSpec {
+  return {
+    sections: [
+      {
+        page: { sizeTwips: { w: 12240, h: 15840 } },
+        blocks: [{ kind: 'paragraph', runs: [{ kind: 'text', text: 'Portrait section.' }] }],
+      },
+      {
+        breakType: 'nextPage',
+        page: { sizeTwips: { w: 12240, h: 15840 }, orientation: 'landscape' },
+        blocks: [{ kind: 'paragraph', runs: [{ kind: 'text', text: 'Landscape section.' }] }],
+      },
+    ],
+  };
+}
+
+async function loadPart(buffer: Buffer, part: string): Promise<Document> {
+  const xml = await readZipText(buffer, part);
+  expect(xml, `${part} missing from package`).not.toBeNull();
+  return parseXml(xml!);
+}
+
+describe('Traceability: multi-section documents, headers/footers, and fields', () => {
+  test
+    .openspec('[SDX-GEN-021] non-final sections end with a dedicated break paragraph')
+    .conformance(
+      { spec: 'ECMA-376', edition: 5, part: 1, section: '17.6.18' },
+      { spec: 'ECMA-376', edition: 5, part: 1, section: '17.6.17' },
+    )(
+    'Scenario: non-final sections end with a dedicated break paragraph',
+    async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
+      let buffer!: Buffer;
+      await given('a spec with two sections', async () => {
+        buffer = await generateDocx(twoSectionSpec());
+        expect((await checkGeneratedPackage(buffer)).ok).toBe(true);
+      });
+
+      let bodyKids!: Element[];
+      await when('the document body is parsed', async () => {
+        const doc = await loadPart(buffer, 'word/document.xml');
+        bodyKids = childElements(doc.getElementsByTagName('w:body').item(0)!);
+      });
+
+      await then('the first section ends with a paragraph whose pPr contains only its sectPr', async () => {
+        const breakParagraph = bodyKids[1]!;
+        expect(breakParagraph.tagName).toBe('w:p');
+        const pPrKids = childElements(childElements(breakParagraph)[0]!);
+        await attachPrettyJson('break-paragraph-ppr-children', pPrKids.map((k) => k.tagName));
+        expect(childElements(breakParagraph)).toHaveLength(1);
+        expect(pPrKids.map((k) => k.tagName)).toEqual(['w:sectPr']);
+        const pgSz = pPrKids[0]!.getElementsByTagName('w:pgSz').item(0)!;
+        expect(pgSz.getAttribute('w:orient')).toBeNull();
+      });
+
+      await then('the final section keeps its sectPr as the body last child, carrying the landscape setup', async () => {
+        const last = bodyKids[bodyKids.length - 1]!;
+        expect(last.tagName).toBe('w:sectPr');
+        const pgSz = last.getElementsByTagName('w:pgSz').item(0)!;
+        expect(pgSz.getAttribute('w:orient')).toBe('landscape');
+        const type = last.getElementsByTagName('w:type').item(0)!;
+        expect(type.getAttribute('w:val')).toBe('nextPage');
+      });
+    },
+  );
+
+  test
+    .openspec('[SDX-GEN-022] a distinct cover-page header uses the title-page switch')
+    .conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.10.6' })(
+    'Scenario: a distinct cover-page header uses the title-page switch',
+    async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
+      let buffer!: Buffer;
+      await given('a section with a first header differing from its default header', async () => {
+        buffer = await generateDocx(coverBodySpec());
+      });
+
+      let sectPr!: Element;
+      await when('the section properties are parsed', async () => {
+        const doc = await loadPart(buffer, 'word/document.xml');
+        sectPr = doc.getElementsByTagName('w:sectPr').item(0)!;
+      });
+
+      await then('w:titlePg is present alongside first and default header references', async () => {
+        expect(sectPr.getElementsByTagName('w:titlePg')).toHaveLength(1);
+        const refs = Array.from(sectPr.getElementsByTagName('w:headerReference')).map((r) => r.getAttribute('w:type'));
+        await attachPrettyJson('header-reference-types', refs);
+        expect(refs).toContain('first');
+        expect(refs).toContain('default');
+      });
+    },
+  );
+
+  test
+    .openspec('[SDX-GEN-023] header and footer parts are fully wired')
+    .conformance(
+      { spec: 'ECMA-376', edition: 5, part: 1, section: '17.10.4' },
+      { spec: 'ECMA-376', edition: 5, part: 1, section: '17.10.3' },
+      { spec: 'ECMA-376', edition: 5, part: 1, section: '17.10.5' },
+      { spec: 'ECMA-376', edition: 5, part: 1, section: '17.10.2' },
+    )(
+    'Scenario: header and footer parts are fully wired',
+    async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
+      let buffer!: Buffer;
+      await given('a section declaring headers and a footer', async () => {
+        buffer = await generateDocx(coverBodySpec());
+      });
+
+      let zipNames!: string[];
+      await when('the package contents are listed', async () => {
+        const zip = await JSZip.loadAsync(buffer);
+        zipNames = Object.keys(zip.files);
+        await attachPrettyJson('package-parts', zipNames.sort());
+      });
+
+      await then('each declared header/footer exists as its own part with a content-type override', async () => {
+        expect(zipNames).toContain('word/header1.xml');
+        expect(zipNames).toContain('word/header2.xml');
+        expect(zipNames).toContain('word/footer1.xml');
+        const contentTypes = (await readZipText(buffer, '[Content_Types].xml'))!;
+        expect(contentTypes).toContain('/word/header1.xml');
+        expect(contentTypes).toContain('wordprocessingml.footer+xml');
+      });
+
+      await then('every reference r:id resolves and the structural checks pass', async () => {
+        const result = await checkGeneratedPackage(buffer);
+        expect(result.ok, JSON.stringify(result.issues)).toBe(true);
+      });
+    },
+  );
+
+  test
+    .openspec('[SDX-GEN-024] page numbering format and start are honored')
+    .conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.6.12' })(
+    'Scenario: page numbering format and start are honored',
+    async ({ given, when, then }: AllureBddContext) => {
+      let buffer!: Buffer;
+      await given('a section specifying a page-number format and start value', async () => {
+        const spec = twoSectionSpec();
+        spec.sections[1]!.pageNumbering = { start: 5, format: 'lowerRoman' };
+        buffer = await generateDocx(spec);
+      });
+
+      let finalSectPr!: Element;
+      await when('the final section properties are parsed', async () => {
+        const doc = await loadPart(buffer, 'word/document.xml');
+        const body = doc.getElementsByTagName('w:body').item(0)!;
+        const kids = childElements(body);
+        finalSectPr = kids[kids.length - 1]!;
+      });
+
+      await then('w:pgNumType carries the requested start and format', async () => {
+        const pgNumType = finalSectPr.getElementsByTagName('w:pgNumType').item(0)!;
+        expect(pgNumType.getAttribute('w:start')).toBe('5');
+        expect(pgNumType.getAttribute('w:fmt')).toBe('lowerRoman');
+      });
+    },
+  );
+
+  test
+    .openspec('[SDX-GEN-030] a PAGE field is structurally complete')
+    .conformance(
+      { spec: 'ECMA-376', edition: 5, part: 1, section: '17.16.18' },
+      { spec: 'ECMA-376', edition: 5, part: 1, section: '17.16.5.44' },
+    )(
+    'Scenario: a PAGE field is structurally complete',
+    async ({ given, when, then, attachPrettyXml }: AllureBddContext) => {
+      let footerXml!: string;
+      await given('a footer paragraph containing a PAGE field with cached result "1"', async () => {
+        const buffer = await generateDocx(coverBodySpec());
+        footerXml = (await readZipText(buffer, 'word/footer1.xml'))!;
+        await attachPrettyXml('word/footer1.xml', footerXml);
+      });
+
+      let sequence!: string[];
+      await when('the footer run sequence is flattened', async () => {
+        const doc = parseXml(footerXml);
+        sequence = Array.from(doc.getElementsByTagName('*'))
+          .filter((el) => el.tagName === 'w:fldChar' || el.tagName === 'w:instrText' || el.tagName === 'w:t')
+          .map((el) =>
+            el.tagName === 'w:fldChar' ? `fldChar:${el.getAttribute('w:fldCharType')}` : `${el.tagName}:${el.textContent}`,
+          );
+      });
+
+      await then('the PAGE field appears as begin → instruction → separate → cached result → end', async () => {
+        const pageStart = sequence.indexOf('w:instrText: PAGE ');
+        expect(pageStart).toBeGreaterThan(0);
+        expect(sequence[pageStart - 1]).toBe('fldChar:begin');
+        expect(sequence.slice(pageStart + 1, pageStart + 4)).toEqual(['fldChar:separate', 'w:t:1', 'fldChar:end']);
+      });
+    },
+  );
+
+  test
+    .openspec('[SDX-GEN-031] a NUMPAGES field carries its cached result')
+    .conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.16.5.42' })(
+    'Scenario: a NUMPAGES field carries its cached result',
+    async ({ given, when, then }: AllureBddContext) => {
+      let sequence!: string[];
+      await given('a footer composed of PAGE and NUMPAGES fields with cached results', async () => {
+        const buffer = await generateDocx(coverBodySpec());
+        const doc = parseXml((await readZipText(buffer, 'word/footer1.xml'))!);
+        sequence = Array.from(doc.getElementsByTagName('*'))
+          .filter((el) => el.tagName === 'w:fldChar' || el.tagName === 'w:instrText' || el.tagName === 'w:t')
+          .map((el) =>
+            el.tagName === 'w:fldChar' ? `fldChar:${el.getAttribute('w:fldCharType')}` : `${el.tagName}:${el.textContent}`,
+          );
+      });
+
+      let numpagesStart!: number;
+      await when('the NUMPAGES instruction is located', async () => {
+        numpagesStart = sequence.indexOf('w:instrText: NUMPAGES ');
+        expect(numpagesStart).toBeGreaterThan(0);
+      });
+
+      await then('both fields are complete five-part sequences rendering the cached text', async () => {
+        expect(sequence[numpagesStart - 1]).toBe('fldChar:begin');
+        expect(sequence.slice(numpagesStart + 1, numpagesStart + 4)).toEqual(['fldChar:separate', 'w:t:2', 'fldChar:end']);
+        expect(sequence.filter((s) => s === 'fldChar:begin')).toHaveLength(2);
+        expect(sequence.filter((s) => s === 'fldChar:end')).toHaveLength(2);
+      });
+    },
+  );
+
+  test.openspec('[SDX-GEN-032] field pairing holds in every story part')(
+    'Scenario: field pairing holds in every story part',
+    async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
+      let buffer!: Buffer;
+      await given('a generated package with fields in its footer story', async () => {
+        buffer = await generateDocx(coverBodySpec());
+      });
+
+      await when('the structural field-pairing check scans every story part', async () => {
+        const result = await checkGeneratedPackage(buffer);
+        expect(result.ok, JSON.stringify(result.issues)).toBe(true);
+      });
+
+      await then('removing a fldChar end from the footer is detected as an unclosed field', async () => {
+        const zip = await JSZip.loadAsync(buffer);
+        const footer = await zip.file('word/footer1.xml')!.async('text');
+        const tampered = footer.replace(/<w:r><w:fldChar w:fldCharType="end"\/><\/w:r>/, '');
+        expect(tampered).not.toBe(footer);
+        zip.file('word/footer1.xml', tampered);
+        const result = await checkGeneratedPackage((await zip.generateAsync({ type: 'nodebuffer' })) as Buffer);
+        await attachPrettyJson('tampered-field-result', result);
+        expect(result.ok).toBe(false);
+        expect(result.issues.some((i) => i.check === 'field_pairing' && i.part === 'word/footer1.xml')).toBe(true);
+      });
+    },
+  );
+
+  test('cover→body acceptance artifact is written for the manual compatibility matrix', async () => {
+    const buffer = await generateDocx(coverBodySpec());
+    expect((await checkGeneratedPackage(buffer)).ok).toBe(true);
+    const { writeIntegrationArtifact } = await import('../integration/output-artifacts.js');
+    const outputPath = await writeIntegrationArtifact('generation-phase3-cover-body.docx', buffer);
+    expect(outputPath).toContain('generation-phase3-cover-body.docx');
+  });
+});

--- a/packages/docx-core/src/generation/generation-skeleton.test.ts
+++ b/packages/docx-core/src/generation/generation-skeleton.test.ts
@@ -85,8 +85,8 @@ describe('Traceability: from-scratch generation skeleton', () => {
     'Scenario: unimplemented spec features are rejected loudly',
     async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
       let tableSpec!: DocumentSpec;
-      let fieldSpec!: DocumentSpec;
-      await given('specs using declared features whose emitters have not shipped (table block, field run)', async () => {
+      let listSpec!: DocumentSpec;
+      await given('specs using declared features whose emitters have not shipped (table block, numbered list)', async () => {
         tableSpec = {
           sections: [
             {
@@ -94,11 +94,11 @@ describe('Traceability: from-scratch generation skeleton', () => {
             },
           ],
         };
-        fieldSpec = {
+        listSpec = {
           sections: [
             {
               blocks: [
-                { kind: 'paragraph', runs: [{ kind: 'field', field: 'PAGE', cachedResult: '1' }] },
+                { kind: 'paragraph', list: { numId: 'main', ilvl: 0 }, runs: [{ kind: 'text', text: 'item' }] },
               ],
             },
           ],
@@ -106,13 +106,13 @@ describe('Traceability: from-scratch generation skeleton', () => {
       });
 
       let tableError: unknown;
-      let fieldError: unknown;
+      let listError: unknown;
       await when('generateDocx compiles each spec', async () => {
         tableError = await generateDocx(tableSpec).then(
           () => null,
           (err: unknown) => err,
         );
-        fieldError = await generateDocx(fieldSpec).then(
+        listError = await generateDocx(listSpec).then(
           () => null,
           (err: unknown) => err,
         );
@@ -122,11 +122,11 @@ describe('Traceability: from-scratch generation skeleton', () => {
         expect(tableError).toBeInstanceOf(GenerationSpecError);
         expect((tableError as GenerationSpecError).code).toBe('unsupported_feature');
         expect((tableError as GenerationSpecError).path).toBe('/sections/0/blocks/0');
-        expect(fieldError).toBeInstanceOf(GenerationSpecError);
-        expect((fieldError as GenerationSpecError).path).toBe('/sections/0/blocks/0/runs/0');
+        expect(listError).toBeInstanceOf(GenerationSpecError);
+        expect((listError as GenerationSpecError).path).toBe('/sections/0/blocks/0/list');
         await attachPrettyJson('rejections', {
           table: { code: (tableError as GenerationSpecError).code, path: (tableError as GenerationSpecError).path },
-          field: { code: (fieldError as GenerationSpecError).code, path: (fieldError as GenerationSpecError).path },
+          list: { code: (listError as GenerationSpecError).code, path: (listError as GenerationSpecError).path },
         });
       });
     },

--- a/packages/docx-core/src/generation/validate-spec.ts
+++ b/packages/docx-core/src/generation/validate-spec.ts
@@ -9,11 +9,11 @@
  *     with a typed error naming the feature and its path — never be silently
  *     dropped (scenario SDX-GEN-003).
  *
- * Shipped so far: plain/formatted text runs (RunProps), paragraph formatting
- * (style references, alignment, spacing, indentation, tabs, keepNext,
- * pageBreakBefore), named styles + styles.xml, single-section page setup.
- * Still rejected: numbering, multi-section, headers/footers, fields,
- * tab/break runs, tables, drafting notes.
+ * Shipped so far: formatted text/tab/break runs, five-part PAGE/NUMPAGES
+ * fields, paragraph formatting, named styles + styles.xml, multi-section
+ * documents with per-section page setup, page numbering, break types, and
+ * default/first/even headers and footers.
+ * Still rejected: numbering, tables, drafting notes.
  */
 
 import { GenerationSpecError } from './errors.js';
@@ -36,7 +36,6 @@ export function validateSpec(spec: DocumentSpec): void {
   }
 
   if (spec.numbering && spec.numbering.length > 0) unsupported('/numbering', 'numbering');
-  if (spec.sections.length > 1) unsupported('/sections', 'multiple sections');
 
   const declaredStyleIds = validateStyles(spec.styles ?? []);
 
@@ -77,11 +76,28 @@ function validateStyles(styles: StyleSpec[]): Set<string> {
 }
 
 function validateSection(section: SectionSpec, path: string, styleIds: Set<string>): void {
-  if (section.breakType) unsupported(`${path}/breakType`, 'section break type');
-  if (section.pageNumbering) unsupported(`${path}/pageNumbering`, 'page numbering');
-  if (section.titlePg) unsupported(`${path}/titlePg`, 'title page header/footer');
-  if (section.headers) unsupported(`${path}/headers`, 'headers');
-  if (section.footers) unsupported(`${path}/footers`, 'footers');
+  if (section.pageNumbering?.start !== undefined) {
+    const start = section.pageNumbering.start;
+    if (!Number.isInteger(start) || start < 1) {
+      throw new GenerationSpecError('invalid_value', `${path}/pageNumbering/start`, 'Page numbering start must be a positive integer');
+    }
+  }
+  for (const [kind, set] of [['headers', section.headers], ['footers', section.footers]] as const) {
+    if (!set) continue;
+    for (const slot of ['default', 'first', 'even'] as const) {
+      const content = set[slot];
+      if (!content) continue;
+      const slotPath = `${path}/${kind}/${slot}`;
+      if (!Array.isArray(content.blocks) || content.blocks.length === 0) {
+        throw new GenerationSpecError('invalid_value', `${slotPath}/blocks`, 'Header/footer blocks must be a non-empty array');
+      }
+      content.blocks.forEach((block, blockIndex) => {
+        const blockPath = `${slotPath}/blocks/${blockIndex}`;
+        if (block.kind === 'table') unsupported(blockPath, 'tables');
+        validateParagraph(block, blockPath, styleIds);
+      });
+    }
+  }
 
   const size = section.page?.sizeTwips;
   if (size && (!(size.w > 0) || !(size.h > 0))) {
@@ -134,9 +150,18 @@ function validateParagraph(paragraph: ParagraphSpec, path: string, styleIds: Set
 }
 
 function validateInline(run: InlineSpec, path: string): void {
-  if (run.kind === 'field') unsupported(path, 'field codes');
-  if (run.kind === 'tab') unsupported(path, 'tab runs');
-  if (run.kind === 'break') unsupported(path, 'break runs');
+  if (run.kind === 'tab' || run.kind === 'break') return;
+  if (run.kind === 'field') {
+    if (typeof run.cachedResult !== 'string' || run.cachedResult.length === 0) {
+      throw new GenerationSpecError(
+        'invalid_value',
+        `${path}/cachedResult`,
+        'Fields require a non-empty cachedResult — the no-recovery-dialog guarantee is unrepresentable-by-omission',
+      );
+    }
+    validateRunProps(run, path);
+    return;
+  }
 
   if (typeof run.text !== 'string') {
     throw new GenerationSpecError('invalid_value', `${path}/text`, 'Text runs must carry a string');

--- a/packages/docx-core/src/primitives/namespaces.ts
+++ b/packages/docx-core/src/primitives/namespaces.ts
@@ -92,6 +92,14 @@ export const W = {
   sectPr: 'sectPr',
   pgSz: 'pgSz',
   pgMar: 'pgMar',
+  pgNumType: 'pgNumType',
+  headerReference: 'headerReference',
+  footerReference: 'footerReference',
+  titlePg: 'titlePg',
+  hdr: 'hdr',
+  ftr: 'ftr',
+  settings: 'settings',
+  evenAndOddHeaders: 'evenAndOddHeaders',
 
   // Styles part + paragraph/run formatting (generation emitters)
   docDefaults: 'docDefaults',

--- a/spec-compliance/CONFORMANCE.md
+++ b/spec-compliance/CONFORMANCE.md
@@ -25,6 +25,17 @@ Allure labels via `testAllure.conformance({…})`; source code carries
 | `ECMA-PART1-17-7-4-18` | w:styles style-definitions part emission | 5 | 1 | 17.7.4.18 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:styles` | — |
 | `ECMA-PART1-17-7-4-17` | w:style style-definition emission | 5 | 1 | 17.7.4.17 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:style` | — |
 | `ECMA-PART1-17-7-5-1` | w:docDefaults document-default properties | 5 | 1 | 17.7.5.1 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:docDefaults` | — |
+| `ECMA-PART1-17-6-18` | w:sectPr paragraph-level section break emission | 5 | 1 | 17.6.18 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:sectPr` | — |
+| `ECMA-PART1-17-6-12` | w:pgNumType page-numbering settings emission | 5 | 1 | 17.6.12 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:pgNumType` | — |
+| `ECMA-PART1-17-10-5` | w:headerReference binding | 5 | 1 | 17.10.5 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:headerReference` | — |
+| `ECMA-PART1-17-10-2` | w:footerReference binding | 5 | 1 | 17.10.2 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:footerReference` | — |
+| `ECMA-PART1-17-10-6` | w:titlePg first-page header/footer switch | 5 | 1 | 17.10.6 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:titlePg` | — |
+| `ECMA-PART1-17-10-4` | w:hdr header part emission | 5 | 1 | 17.10.4 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:hdr` | — |
+| `ECMA-PART1-17-10-3` | w:ftr footer part emission | 5 | 1 | 17.10.3 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:ftr` | — |
+| `ECMA-PART1-17-10-1` | w:evenAndOddHeaders setting | 5 | 1 | 17.10.1 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:evenAndOddHeaders` | — |
+| `ECMA-PART1-17-16-18` | w:fldChar five-part complex-field emission | 5 | 1 | 17.16.18 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:fldChar` | — |
+| `ECMA-PART1-17-16-5-44` | PAGE field instruction emission | 5 | 1 | 17.16.5.44 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:instrText` | — |
+| `ECMA-PART1-17-16-5-42` | NUMPAGES field instruction emission | 5 | 1 | 17.16.5.42 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:instrText` | — |
 
 ### ECMA-PART4-17-16-5 — w:delInstrText and w:fldChar placement in tracked deletions
 
@@ -209,6 +220,138 @@ properties that styles and direct formatting layer over. Generation emits
 explicit defaults (font bound across ascii/hAnsi/cs script ranges plus an
 explicit size) rather than relying on reader fallbacks, which diverge
 between Word, LibreOffice, and Google Docs import.
+
+### ECMA-PART1-17-6-18 — w:sectPr paragraph-level section break emission
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.6.18
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:sectPr`
+
+A non-final section's properties bind through a `w:sectPr` inside the
+`w:pPr` of a dedicated break paragraph — the shape Word itself produces on
+Insert → Section Break, and the one that sidesteps the trailing-table case
+(a table cannot carry section properties). The generation document emitter
+appends such a break paragraph after every non-final section's blocks;
+`auditSectPr` verifies the pPr-only placement on the way back out.
+
+### ECMA-PART1-17-6-12 — w:pgNumType page-numbering settings emission
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.6.12
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:pgNumType`
+
+`w:pgNumType` declares a section's page-number format and restart value.
+Generation emits `w:start`/`w:fmt` only when the spec requests them, so
+sections without explicit numbering inherit continuous decimal numbering.
+
+### ECMA-PART1-17-10-5 — w:headerReference binding
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.10.5
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:headerReference`
+
+Each declared header slot (first/default/even) becomes its own part bound
+through a typed `w:headerReference` whose `r:id` (written namespace-aware
+via `setAttributeNS`) resolves in the document's relationships. References
+lead the `w:sectPr` child sequence; the structural validator rejects
+dangling or missing ids.
+
+### ECMA-PART1-17-10-2 — w:footerReference binding
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.10.2
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:footerReference`
+
+Footer references follow the same typed-binding discipline as header
+references, emitted in a fixed first/default/even order for deterministic
+output.
+
+### ECMA-PART1-17-10-6 — w:titlePg first-page header/footer switch
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.10.6
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:titlePg`
+
+`w:titlePg` activates a section's first-page header/footer. Generation
+implies it whenever a `first` header or footer is declared (and honors an
+explicit `titlePg: true`), so a declared cover-page header can never be
+silently ignored by readers.
+
+### ECMA-PART1-17-10-4 — w:hdr header part emission
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.10.4
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:hdr`
+
+Header parts are emitted as standalone `w:hdr` documents
+(word/headerN.xml) with content-type overrides, sharing the body's
+paragraph/run emitters so header content compiles through the same
+formatting and field machinery as body content.
+
+### ECMA-PART1-17-10-3 — w:ftr footer part emission
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.10.3
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:ftr`
+
+Footer parts mirror header parts as `w:ftr` documents (word/footerN.xml);
+"Page X of Y" footers carry complete five-part PAGE/NUMPAGES fields with
+cached results.
+
+### ECMA-PART1-17-10-1 — w:evenAndOddHeaders setting
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.10.1
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:evenAndOddHeaders`
+
+Even-page headers/footers are only honored when `w:evenAndOddHeaders` is
+set in word/settings.xml. Generation emits the settings part exactly when
+some section declares an `even` slot, so the declared content and the
+document-level switch can never drift apart.
+
+### ECMA-PART1-17-16-18 — w:fldChar five-part complex-field emission
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.16.18
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:fldChar`
+
+Every generated field is a complete five-run sequence — `fldChar begin`,
+preserved-space `w:instrText`, `fldChar separate`, a cached-result run,
+`fldChar end` — and `w:dirty` is never set. The cached result is a
+required spec property, making the no-recovery-dialog guarantee
+unrepresentable-by-omission; the structural validator runs a begin →
+separate → end state machine over every story part.
+
+### ECMA-PART1-17-16-5-44 — PAGE field instruction emission
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.16.5.44
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:instrText`
+
+The PAGE instruction is emitted with canonical surrounding spaces
+(` PAGE `) inside a preserved-space `w:instrText`, matching the shape of
+the committed field fixtures used by the comparison pipeline.
+
+### ECMA-PART1-17-16-5-42 — NUMPAGES field instruction emission
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.16.5.42
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:instrText`
+
+The NUMPAGES instruction follows the same emission discipline as PAGE
+(` NUMPAGES `, preserved spacing, cached result required), giving
+"Page X of Y" footers structurally correct field pairs.
 
 ## Non-Goals
 

--- a/spec-compliance/registry/ecma-376.md
+++ b/spec-compliance/registry/ecma-376.md
@@ -244,6 +244,182 @@ explicit defaults (font bound across ascii/hAnsi/cs script ranges plus an
 explicit size) rather than relying on reader fallbacks, which diverge
 between Word, LibreOffice, and Google Docs import.
 
+## [ECMA-PART1-17-6-18] w:sectPr paragraph-level section break emission
+
+```yaml
+edition: 5
+part: 1
+section: "17.6.18"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:sectPr
+verifiedBy:
+```
+
+A non-final section's properties bind through a `w:sectPr` inside the
+`w:pPr` of a dedicated break paragraph — the shape Word itself produces on
+Insert → Section Break, and the one that sidesteps the trailing-table case
+(a table cannot carry section properties). The generation document emitter
+appends such a break paragraph after every non-final section's blocks;
+`auditSectPr` verifies the pPr-only placement on the way back out.
+
+## [ECMA-PART1-17-6-12] w:pgNumType page-numbering settings emission
+
+```yaml
+edition: 5
+part: 1
+section: "17.6.12"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:pgNumType
+verifiedBy:
+```
+
+`w:pgNumType` declares a section's page-number format and restart value.
+Generation emits `w:start`/`w:fmt` only when the spec requests them, so
+sections without explicit numbering inherit continuous decimal numbering.
+
+## [ECMA-PART1-17-10-5] w:headerReference binding
+
+```yaml
+edition: 5
+part: 1
+section: "17.10.5"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:headerReference
+verifiedBy:
+```
+
+Each declared header slot (first/default/even) becomes its own part bound
+through a typed `w:headerReference` whose `r:id` (written namespace-aware
+via `setAttributeNS`) resolves in the document's relationships. References
+lead the `w:sectPr` child sequence; the structural validator rejects
+dangling or missing ids.
+
+## [ECMA-PART1-17-10-2] w:footerReference binding
+
+```yaml
+edition: 5
+part: 1
+section: "17.10.2"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:footerReference
+verifiedBy:
+```
+
+Footer references follow the same typed-binding discipline as header
+references, emitted in a fixed first/default/even order for deterministic
+output.
+
+## [ECMA-PART1-17-10-6] w:titlePg first-page header/footer switch
+
+```yaml
+edition: 5
+part: 1
+section: "17.10.6"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:titlePg
+verifiedBy:
+```
+
+`w:titlePg` activates a section's first-page header/footer. Generation
+implies it whenever a `first` header or footer is declared (and honors an
+explicit `titlePg: true`), so a declared cover-page header can never be
+silently ignored by readers.
+
+## [ECMA-PART1-17-10-4] w:hdr header part emission
+
+```yaml
+edition: 5
+part: 1
+section: "17.10.4"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:hdr
+verifiedBy:
+```
+
+Header parts are emitted as standalone `w:hdr` documents
+(word/headerN.xml) with content-type overrides, sharing the body's
+paragraph/run emitters so header content compiles through the same
+formatting and field machinery as body content.
+
+## [ECMA-PART1-17-10-3] w:ftr footer part emission
+
+```yaml
+edition: 5
+part: 1
+section: "17.10.3"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:ftr
+verifiedBy:
+```
+
+Footer parts mirror header parts as `w:ftr` documents (word/footerN.xml);
+"Page X of Y" footers carry complete five-part PAGE/NUMPAGES fields with
+cached results.
+
+## [ECMA-PART1-17-10-1] w:evenAndOddHeaders setting
+
+```yaml
+edition: 5
+part: 1
+section: "17.10.1"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:evenAndOddHeaders
+verifiedBy:
+```
+
+Even-page headers/footers are only honored when `w:evenAndOddHeaders` is
+set in word/settings.xml. Generation emits the settings part exactly when
+some section declares an `even` slot, so the declared content and the
+document-level switch can never drift apart.
+
+## [ECMA-PART1-17-16-18] w:fldChar five-part complex-field emission
+
+```yaml
+edition: 5
+part: 1
+section: "17.16.18"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:fldChar
+verifiedBy:
+```
+
+Every generated field is a complete five-run sequence — `fldChar begin`,
+preserved-space `w:instrText`, `fldChar separate`, a cached-result run,
+`fldChar end` — and `w:dirty` is never set. The cached result is a
+required spec property, making the no-recovery-dialog guarantee
+unrepresentable-by-omission; the structural validator runs a begin →
+separate → end state machine over every story part.
+
+## [ECMA-PART1-17-16-5-44] PAGE field instruction emission
+
+```yaml
+edition: 5
+part: 1
+section: "17.16.5.44"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:instrText
+verifiedBy:
+```
+
+The PAGE instruction is emitted with canonical surrounding spaces
+(` PAGE `) inside a preserved-space `w:instrText`, matching the shape of
+the committed field fixtures used by the comparison pipeline.
+
+## [ECMA-PART1-17-16-5-42] NUMPAGES field instruction emission
+
+```yaml
+edition: 5
+part: 1
+section: "17.16.5.42"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:instrText
+verifiedBy:
+```
+
+The NUMPAGES instruction follows the same emission discipline as PAGE
+(` NUMPAGES `, preserved spacing, cached result required), giving
+"Page X of Y" footers structurally correct field pairs.
+
 ## Non-Goals
 
 Sections explicitly **out of scope** for safe-docx. Each entry below carries the


### PR DESCRIPTION
## Summary

Phase 3 of the `add-docx-generation` OpenSpec change (#280; follows #397, #402).

- **Multi-section emission** per ECMA-376 sectPr semantics: non-final sections end with a dedicated break paragraph whose `pPr` contains only that section's `sectPr` (what Word emits; sidesteps the trailing-table case); the final section's `sectPr` stays the body's last child. Break types and `w:pgNumType` (start/format) supported.
- **Headers/footers**: each declared slot (`first`/`default`/`even`) is its own part (`word/headerN.xml`/`word/footerN.xml`) with content-type overrides and typed `w:headerReference`/`w:footerReference` bindings (`r:id` written via `setAttributeNS`). `w:titlePg` is implied whenever a first-page slot exists; `word/settings.xml` gains `w:evenAndOddHeaders` exactly when an even slot is declared. Header/footer content compiles through the same paragraph/run emitters as the body.
- **Fields**: `FieldSpec` (PAGE/NUMPAGES) compiles to the complete five-run sequence — begin → preserved-space instruction → separate → **required cached result** → end, never `w:dirty` — matching the committed `completeField()` fixture shape. Tab and break runs ship alongside for realistic "Page X of Y" footers.
- The cross-story field-pairing structural check now exercises real header/footer stories; the tampering test proves an unclosed footer field is caught.
- Registry +11 verified sections (17.6.18, 17.6.12, 17.10.1–17.10.6 subset, 17.16.18, 17.16.5.42/.44).
- New `generation-phase3-cover-body.docx` artifact (cover header → body header, field footer) added to the manual compatibility matrix.

Scenarios covered this phase: SDX-GEN-021–024, 030–032 (22/36 mapped; validator report-only by design until the final phase).

## Verification

- build / lint:workspaces / full `test:run` green (25 generation tests)
- `check:spec-coverage`, `check:allure-labels`, `check:allure-quality`, `check:allure-filenames`, `check:conformance-citations` green; `check:conformance-doc` green at commit
- `openspec validate add-docx-generation --strict` green

Ref: #280