### PR TITLE
refactor: expose footnote refs as document-view node metadata — one derivation, not five fldChar walks

### DIFF
--- a/packages/docx-core/src/primitives/document_view-types.ts
+++ b/packages/docx-core/src/primitives/document_view-types.ts
@@ -126,6 +126,18 @@ export type DocumentViewNode = {
   paragraph_indents_pt: { left: number; first_line: number };
   numbering: { num_id: string | null; ilvl: number | null; is_auto_numbered: boolean };
   heading?: HeadingValue;
+  /**
+   * Footnote references this paragraph visibly anchors, in document order, each
+   * with the display number assigned by the view's numbering authority (the
+   * sequential scan of `document.xml` references, reserved separator IDs
+   * skipped). References inside field code (between `w:fldChar` begin and
+   * separate) are hidden text and excluded. This is the single derivation of
+   * "which footnotes does this paragraph reference" — consumers render from it
+   * instead of re-walking the paragraph DOM. Omitted when empty, matching the
+   * `heading` convention.
+   * @see #393
+   */
+  footnote_refs?: Array<{ id: number; display: number }>;
   header_formatting: HeaderFormatting | null;
   body_run_formatting: RunFormatting | null;
   table_context?: TableContext;

--- a/packages/docx-core/src/primitives/document_view.ts
+++ b/packages/docx-core/src/primitives/document_view.ts
@@ -217,9 +217,18 @@ function buildFootnoteDisplayMap(documentXml: Document, footnotesXml: Document |
 }
 
 /**
- * Compute footnote marker insertion points for a paragraph.
- * Returns an array of { offset, marker } sorted by offset descending
- * for safe right-to-left insertion into the text string.
+ * A footnote reference a paragraph visibly anchors: the referenced footnote's
+ * numeric ID, its display number, and the reference's visible-character offset
+ * within the paragraph text.
+ */
+type ParagraphFootnoteRef = { offset: number; id: number; display: number };
+
+/**
+ * Compute the footnote references a paragraph visibly anchors, in document
+ * order. This is the single derivation of "which footnotes does this paragraph
+ * reference, and with what display number" — the view injects [^N] markers
+ * from it AND exposes it as DocumentViewNode.footnote_refs so consumers
+ * (read_file's clean_text suffix) never re-walk the DOM. @see #393
  *
  * Self-contained: only inspects the paragraph DOM for w:footnoteReference
  * elements. Does NOT modify getParagraphRuns or getParagraphText.
@@ -227,13 +236,13 @@ function buildFootnoteDisplayMap(documentXml: Document, footnotesXml: Document |
 function getFootnoteMarkersForParagraph(
   p: Element,
   displayMap: Map<number, number>,
-): Array<{ offset: number; marker: string }> {
+): ParagraphFootnoteRef[] {
   if (displayMap.size === 0) return [];
 
   // Walk through direct children (and hyperlink children) to find w:r elements
   // and their visible text, tracking position. When we find a footnoteReference,
   // record its position.
-  const markers: Array<{ offset: number; marker: string }> = [];
+  const markers: ParagraphFootnoteRef[] = [];
   let visibleOffset = 0;
 
   // We need to iterate runs in paragraph order. Use the same approach as getParagraphRuns
@@ -280,7 +289,8 @@ function getFootnoteMarkersForParagraph(
       if (displayNum != null) {
         markers.push({
           offset: visibleOffset + runVisibleLen,
-          marker: `[^${displayNum}]`,
+          id: footnoteId,
+          display: displayNum,
         });
       }
     }
@@ -288,8 +298,6 @@ function getFootnoteMarkersForParagraph(
     visibleOffset += runVisibleLen;
   }
 
-  // Sort descending by offset for safe right-to-left insertion
-  markers.sort((a, b) => b.offset - a.offset);
   return markers;
 }
 
@@ -347,8 +355,9 @@ function paragraphHasAnchoringContent(p: Element): boolean {
 }
 
 /**
- * Inject footnote markers into a text string at the given offsets.
- * Markers must be sorted descending by offset.
+ * Inject [^N] footnote markers into a text string at the given offsets.
+ * Markers arrive in document order; insertion happens right-to-left (offset
+ * descending) so earlier offsets stay valid as text grows.
  *
  * Offsets are *visible*-character offsets (they count document text, not the inline
  * formatting tags emitted by `emitFormattingTags`). When `text` carries formatting tags
@@ -358,13 +367,14 @@ function paragraphHasAnchoringContent(p: Element): boolean {
  */
 function injectFootnoteMarkers(
   text: string,
-  markers: Array<{ offset: number; marker: string }>,
+  markers: ParagraphFootnoteRef[],
 ): string {
   if (markers.length === 0) return text;
+  const descending = [...markers].sort((a, b) => b.offset - a.offset);
   let result = text;
-  for (const { offset, marker } of markers) {
+  for (const { offset, display } of descending) {
     const insertionIndex = findTaggedTextInsertionIndex(result, offset);
-    result = result.slice(0, insertionIndex) + marker + result.slice(insertionIndex);
+    result = result.slice(0, insertionIndex) + `[^${display}]` + result.slice(insertionIndex);
   }
   return result;
 }
@@ -460,6 +470,9 @@ export function buildNodesForDocumentView(params: {
 
     // Visible clean text (field codes stripped).
     const fullText = getParagraphText(p).replace(/\r/g, '').replace(/\n/g, '').trim();
+    // Computed once per paragraph: gates the empty-paragraph skip below, drives
+    // the [^N] marker injection, and is exposed as node.footnote_refs.
+    const fnMarkers = getFootnoteMarkersForParagraph(p, footnoteDisplayMap);
     // Preserve empty table cell paragraphs for structural completeness, and
     // text-empty paragraphs that carry anchoring content — a visible footnote
     // reference (its [^N] marker renders via the injection pass below), an
@@ -472,7 +485,7 @@ export function buildNodesForDocumentView(params: {
     if (
       !fullText &&
       !tableContext &&
-      getFootnoteMarkersForParagraph(p, footnoteDisplayMap).length === 0 &&
+      fnMarkers.length === 0 &&
       !paragraphHasAnchoringContent(p)
     ) continue;
 
@@ -690,7 +703,6 @@ export function buildNodesForDocumentView(params: {
     }
 
     // Inject footnote [^N] markers into view text (view-only, not shared text primitives)
-    const fnMarkers = getFootnoteMarkersForParagraph(p, footnoteDisplayMap);
     if (fnMarkers.length > 0) {
       tagged = injectFootnoteMarkers(tagged, fnMarkers);
     }
@@ -729,6 +741,9 @@ export function buildNodesForDocumentView(params: {
       body_run_formatting: bodyFmt,
     };
     if (heading) node.heading = heading;
+    if (fnMarkers.length > 0) {
+      node.footnote_refs = fnMarkers.map(({ id: fnId, display }) => ({ id: fnId, display }));
+    }
     if (tableContext) node.table_context = tableContext;
     nodes.push(node);
   }

--- a/packages/docx-mcp/src/tools/read_file.ts
+++ b/packages/docx-mcp/src/tools/read_file.ts
@@ -34,45 +34,6 @@ enum FieldState {
   IN_FIELD_RESULT = 2,
 }
 
-function collectFootnoteMarkerSuffix(
-  paragraphEl: Element,
-  displayNumberById: Map<number, number>,
-): string {
-  // References inside field code (between fldChar begin and separate) are
-  // hidden text and must not surface a marker — the view-level injection
-  // skips them the same way, keeping clean_text and text in agreement on
-  // which footnotes exist. @see #382
-  const markers: string[] = [];
-  let fieldState = FieldState.OUTSIDE_FIELD;
-
-  for (const runEl of Array.from(paragraphEl.getElementsByTagNameNS(OOXML.W_NS, W.r))) {
-    for (const child of Array.from(runEl.childNodes)) {
-      if (child.nodeType !== 1) continue;
-      const el = child as Element;
-      if (el.namespaceURI !== OOXML.W_NS) continue;
-
-      if (el.localName === W.fldChar) {
-        const type = getWAttr(el, 'fldCharType') ?? '';
-        if (type === 'begin') fieldState = FieldState.IN_FIELD_CODE;
-        else if (type === 'separate') fieldState = FieldState.IN_FIELD_RESULT;
-        else if (type === 'end') fieldState = FieldState.OUTSIDE_FIELD;
-        continue;
-      }
-
-      if (fieldState === FieldState.IN_FIELD_CODE) continue;
-      if (el.localName !== W.footnoteReference) continue;
-
-      const rawId = getWAttr(el, 'id');
-      if (!rawId) continue;
-      const numericId = Number.parseInt(rawId, 10);
-      if (Number.isNaN(numericId)) continue;
-      const display = displayNumberById.get(numericId) ?? numericId;
-      markers.push(`[^${display}]`);
-    }
-  }
-  return markers.join('');
-}
-
 function escapeCommentSuffixText(text: string): string {
   return text
     .replaceAll('\r\n', '\\n')
@@ -361,8 +322,8 @@ export async function readFile(
     }
 
     // Build a single paragraph-element index up front. All downstream enrichment
-    // passes (footnote markers, comment inline markers, content_fingerprint) consult
-    // this map instead of calling getParagraphElementById() per node, which would be
+    // passes (comment inline markers, content_fingerprint) consult this map
+    // instead of calling getParagraphElementById() per node, which would be
     // a linear scan and turn the read into O(N^2) on large documents.
     const paragraphElementsById = (() => {
       const map = new Map<string, Element>();
@@ -374,33 +335,22 @@ export async function readFile(
     })();
 
     // Footnote [^N] markers: the document view already injects them into
-    // tagged_text/text at the reference's visible offset (injectFootnoteMarkers
-    // in docx-core's document_view.ts). Only clean_text is enriched here — the
-    // view deliberately keeps it marker-free for core consumers (edit matching,
-    // signature-cluster detection), so the suffix is a read_file output concern.
-    // Appending to all three fields doubled every marker. @see #382
-    let enriched = filtered;
-    try {
-      const footnotes = await session.doc.getFootnotes();
-      if (footnotes.length > 0) {
-        const displayById = new Map<number, number>();
-        for (const note of footnotes) {
-          displayById.set(note.id, note.displayNumber > 0 ? note.displayNumber : note.id);
-        }
-        enriched = filtered.map((node) => {
-          const paragraphEl = paragraphElementsById.get(node.id);
-          if (!paragraphEl) return node;
-          const markerSuffix = collectFootnoteMarkerSuffix(paragraphEl, displayById);
-          if (!markerSuffix) return node;
-          return {
-            ...node,
-            clean_text: `${node.clean_text}${markerSuffix}`,
-          };
-        });
-      }
-    } catch {
-      enriched = filtered;
-    }
+    // tagged_text/text at the reference's visible offset AND exposes the same
+    // derivation as node.footnote_refs — one fldChar walk, one numbering
+    // authority, so the fields cannot disagree about which footnotes exist
+    // (#382's failure shape). @see #393. Only clean_text is enriched here —
+    // the view deliberately keeps it marker-free for core consumers (edit
+    // matching, signature-cluster detection), so the suffix is a read_file
+    // output concern. Appending to all three fields doubled every marker.
+    // @see #382
+    let enriched = filtered.map((node) => {
+      if (!node.footnote_refs || node.footnote_refs.length === 0) return node;
+      const markerSuffix = node.footnote_refs.map(({ display }) => `[^${display}]`).join('');
+      return {
+        ...node,
+        clean_text: `${node.clean_text}${markerSuffix}`,
+      };
+    });
 
     // When comment loading fails after add_comment ran (e.g., a third-party docx ships a
     // comments.xml lacking xmlns:w14 and our writer wrote w14:paraId into it — see #154),

--- a/packages/docx-mcp/src/tools/read_file_footnotes.test.ts
+++ b/packages/docx-mcp/src/tools/read_file_footnotes.test.ts
@@ -84,7 +84,7 @@ describe('read_file footnotes', () => {
 
     let opened: Awaited<ReturnType<typeof openSession>>;
     let anchorId: string;
-    let nodes: Array<{ id: string; text: string; clean_text: string }>;
+    let nodes: Array<{ id: string; text: string; clean_text: string; footnote_refs?: Array<{ id: number; display: number }> }>;
 
     await given('a document whose middle paragraph contains only a footnote reference run', async () => {
       opened = await openSession([], {
@@ -114,6 +114,9 @@ describe('read_file footnotes', () => {
       // doubled by a read_file suffix pass. @see #382
       expect(anchorNode!.text).toBe('[^1]');
       expect(anchorNode!.clean_text).toBe('[^1]');
+      // The marker and the metadata come from the same derivation, so the
+      // node also carries the reference it anchors. @see #393
+      expect(anchorNode!.footnote_refs).toEqual([{ id: 1, display: 1 }]);
     });
 
     await and('a node_ids probe for the anchor paragraph resolves it', async () => {
@@ -161,7 +164,7 @@ describe('read_file footnotes', () => {
       `</w:footnotes>`;
 
     let opened: Awaited<ReturnType<typeof openSession>>;
-    let nodes: Array<{ id: string; text: string; tagged_text: string; clean_text: string }>;
+    let nodes: Array<{ id: string; text: string; tagged_text: string; clean_text: string; footnote_refs?: Array<{ id: number; display: number }> }>;
 
     await given('a document with one field-code-contained and one visible footnote reference', async () => {
       opened = await openSession([], {
@@ -184,10 +187,17 @@ describe('read_file footnotes', () => {
       expect(fieldCodeNode.text).not.toContain('[^');
       expect(fieldCodeNode.tagged_text).not.toContain('[^');
       expect(fieldCodeNode.clean_text).not.toContain('[^');
+      // footnote_refs is the derivation the rendered fields come from, so the
+      // hidden reference must be absent there too (omitted-when-empty). @see #393
+      expect(fieldCodeNode.footnote_refs).toBeUndefined();
 
       const visibleNode = nodes[1]!;
       expect(visibleNode.text).toBe('Anchor sentence.[^2]');
       expect(visibleNode.clean_text).toBe('Anchor sentence.[^2]');
+      // The hidden reference still occupies display slot 1, so the metadata
+      // reports display 2 for footnote id 2 — same numbering authority as the
+      // injected marker. @see #393
+      expect(visibleNode.footnote_refs).toEqual([{ id: 2, display: 2 }]);
     });
   });
 


### PR DESCRIPTION
Fixes #393. Refs #382, #386.

## Why

The package answered "which footnotes does this paragraph visibly reference, and with what display number" in multiple independent places, and #382 was the direct cost: two derivations disagreed and every reachable marker rendered doubled. The #386 fix closed that instance but (knowingly, per its peer-review trade-off) added a fifth copy of the `fldChar` begin/separate/end state machine and a second display-number map. Identical today — enforced by nothing.

## What

- **`DocumentViewNode.footnote_refs?: Array<{ id, display }>`** — the result of `getFootnoteMarkersForParagraph` (which already drives the view's `[^N]` injection and the empty-paragraph skip gate) is now surfaced on the node, in document order, omitted when empty (matching the `heading` convention).
- **`read_file`** renders its `clean_text` marker suffix from `node.footnote_refs`. `collectFootnoteMarkerSuffix`, its `fldChar` state machine, and the `getFootnotes()`-based `displayById` map are deleted — one derivation, one numbering authority.
- The per-paragraph walk is hoisted to run once (was computed twice: skip gate + injection).

The #386 invariant — a reference inside field code surfaces no marker in **any** field — now holds by construction, because only one place decides visibility.

## Acceptance criteria (from #393)

- [x] `DocumentViewNode` carries `footnote_refs` computed in exactly one place
- [x] `collectFootnoteMarkerSuffix` and the `read_file`-local display-number map are deleted
- [x] `grep -c fldCharType packages/docx-mcp/src/tools/read_file.ts` → **1** (was 2; remainder is the comment-offset walk, pending the shared visible-run iterator follow-up)
- [x] #386's regression tests pass unchanged (exactly-one marker; field-code reference hidden in every field; NVCA full-walk no-doubling) — extended with `footnote_refs` assertions locking the new contract
- [x] No behavior change in `read_file` rendered output; JSON format additionally carries the new `footnote_refs` metadata key on footnote-bearing nodes (the exposure #393 asks for)

## Out of scope

Consolidating the remaining walkers (copies 2–4) onto a shared visible-run iterator in `text.ts` — #393's optional follow-up, kept separate per one-fix-per-PR.

## Verification

`npm run build && npm run lint:workspaces && npm run test:run && npm run check:spec-coverage && npm run check:conformance-citations && npm run check:conformance-doc` — all exit 0 (gated on explicit exit codes).