### PR TITLE
feat(odf-core): DOCX → ODT phase 3 — richer style fidelity

### DIFF
--- a/openspec/changes/update-docx-to-odf-style-fidelity/design.md
+++ b/openspec/changes/update-docx-to-odf-style-fidelity/design.md
@@ -1,0 +1,80 @@
+## Context
+
+Phase 1+2 of DOCX → ODT conversion (#401) deliberately downgraded several style classes and
+recorded each in the `lossiness` report. The post-merge smoke telemetry on the bundled real
+fixtures prioritizes phase 3 (#406): font runs dominate (185 drops on the NVCA COI, 32 on the
+Common Paper NDA); everything else is single-digit. The converter consumes the docx-core
+document view (`formattingMode: 'full'`) — the same intentionally-lossy semantic model the
+markdown/HTML serializers use — so each fidelity class must either come from data the view
+already carries, an enrichment of the view, or a narrow raw-DOM supplement.
+
+## Goals / Non-Goals
+
+- Goals: near-zero lossiness on the bundled real fixtures for the six in-scope classes;
+  CONV-13 LibreOffice differential stays green; conversion stays native and semantic.
+- Non-Goals (unchanged from #331): tracked changes, comments, headers/footers/footnote
+  fidelity, `.ods`/`.odp`, pixel-faithful layout.
+
+## Decisions
+
+- **Font runs come from the TOON `<font>` tag, not a raw-DOM pass.** The full-mode tag already
+  carries `color` (hex, no `#`), `size` (points), and `face`; the converter's inline emitter
+  tracks them as state alongside b/i/u and the `TextStyleRegistry` key grows to include them.
+  Used font faces are declared in `office:font-face-decls` (new `svg` namespace) because ODF
+  resolves `style:font-name` against declared faces.
+- **Highlight color rides the existing TOON tag, full mode only.** `RunFormatting.highlightVal`
+  already holds the `w:highlight` enum; `emitFormattingTags` now keeps the value in its active
+  tag state and emits `<highlight color="green">` when `formattingMode: 'full'`. Compact mode
+  emits the value-less `<highlight>` exactly as before (adjacent different-color runs still
+  collapse via `mergeAdjacentTags`, preserving today's compact output byte-for-byte). The
+  tokenizer grammar (`TOON_INLINE_TAG_RE`) and the strip helpers accept the attributed form.
+  The ECMA-376 ST_HighlightColor palette maps to fixed hex values in odf-core.
+- **Paragraph alignment/indents use view data only.** A `ParagraphStyleRegistry` creates deduped
+  automatic paragraph styles keyed by (parent style, alignment, left indent, first-line indent),
+  created only when something deviates (non-LEFT alignment or non-zero indent). List items get
+  alignment only: `text:list` nesting already supplies indentation, and re-applying
+  `fo:margin-left` would double-indent.
+- **Named styles resolve via the style chain with tri-state semantics.** A new
+  `extractStyleRunFormatting(styles, styleId)` returns `null` for properties the chain never
+  specifies (unlike `extractEffectiveRunFormatting`, which collapses to defaults) so the ODF
+  template only overrides what the source actually declares — e.g. a non-bold source Heading2
+  emits `fo:font-weight="normal"`, an unspecified one inherits the template's bold `Heading`
+  base. Heading styles are matched by styleId `Heading[1-6]` or name `heading [1-6]`; `Normal`
+  seeds `Standard`.
+- **Table borders/widths read the raw `w:tbl` directly, not a view enrichment.** The view's
+  `table_context.table_index` indexes direct `w:tbl` children of `w:body` — the converter
+  resolves the same elements from the already-loaded source and reads `w:tblPr/w:tblBorders`
+  (explicitly-none → borderless cell style; declared size/color honored, eighths-of-a-point →
+  pt) and `w:tblGrid/w:gridCol` (twips → pt column widths). Borders inherited from a
+  `w:tblStyle` chain are out of scope (StyleDef carries no tblPr); such tables keep the
+  0.5pt default that matches Word's bordered-by-default reality. Per-cell `w:tcBorders`
+  overrides also stay out of scope.
+- **Empty paragraphs are a raw-DOM supplement keyed by bookmark identity.** Every paragraph
+  (including text-empty ones) gets a `_bk_*` bookmark before view construction;
+  `getParagraphBookmarkId` correlates `getParagraphs()` order with surfaced view nodes. Each
+  unsurfaced, text-empty, body-level (not inside `w:tc`) paragraph emits an empty `text:p`
+  before its nearest following surfaced node (or trailing). Table-cell paragraphs — including
+  empty ones — are already surfaced by the view and flow through the grid emitter, so only
+  defensive lossiness branches remain for exotic unsurfaced shapes.
+
+## Risks / Trade-offs
+
+- Changing full-mode TOON output could affect other full-mode consumers → the converter is the
+  only production consumer (verified by grep); compact mode is bit-identical.
+- `</highlight><highlight color="…">` adjacency in full mode no longer merges when colors
+  differ — that is the point; identical-format adjacent runs are already merged by
+  `normalize()` before tagging.
+- LibreOffice differential (CONV-13) projection compares text/headings/tables/lists only, so
+  the new styles cannot break it; empty-paragraph preservation is filtered out by the
+  projection's empty-text filter.
+
+## Migration Plan
+
+Pure addition behind the existing `convertDocxToOdt` API; the lossiness report shrinks. No
+rollback steps beyond reverting the PR.
+
+## Open Questions
+
+- Extending the CONV-13 projection to font/alignment attributes is deferred until the
+  LibreOffice oracle's style normalization is characterized (#406 acceptance notes it as
+  optional).

--- a/openspec/changes/update-docx-to-odf-style-fidelity/proposal.md
+++ b/openspec/changes/update-docx-to-odf-style-fidelity/proposal.md
@@ -1,0 +1,40 @@
+# Change: DOCX → ODT conversion phase 3 — richer style fidelity
+
+## Why
+
+The lossiness telemetry from the phase 1+2 converter (#401) shows font face/size/color runs are
+by far the dominant fidelity gap on real documents: converting the NVCA COI drops 185 `<font …>`
+runs and the Common Paper NDA drops 32. Paragraph alignment/indents are already carried by the
+document view but unused by the converter; heading styles use generic template sizes instead of
+the source's; non-yellow highlights normalize to yellow; tables get a uniform invented border;
+and text-empty spacing paragraphs are dropped. Issue #406 covers all six classes.
+
+## What Changes
+
+- Map full-mode `<font color size face>` TOON tags to ODF automatic text styles
+  (`fo:color`, `fo:font-size`, `style:font-name`) with `office:font-face-decls` entries,
+  removing the `font-formatting-dropped` lossiness class.
+- Emit automatic paragraph styles carrying `fo:text-align` / `fo:margin-left` / `fo:text-indent`
+  from the view's `paragraph_alignment` + `paragraph_indents_pt` (alignment only on list items,
+  where the list nesting already supplies indentation).
+- Seed `styles.xml` named styles (`Heading_20_1..6`, `Standard`) from the source document's
+  style definitions instead of the fixed template.
+- Enrich full-mode TOON highlight tags with the source `w:highlight` value
+  (`<highlight color="green">`) and map the ECMA-376 highlight palette to ODF
+  `fo:background-color` hex values. Compact-mode TOON output is unchanged.
+- Read `w:tblBorders` / `w:tblGrid` from the source table directly: borderless tables stay
+  borderless, declared border size/color is honored, and `table:table-column` widths follow
+  the source grid.
+- Preserve text-empty body-level paragraphs (vertical spacing) as empty `text:p` elements
+  instead of reporting them dropped; anything else the view fails to surface stays reported.
+- docx-core additions in service of the above: `DocxDocument.getStylesModel()`,
+  `extractStyleRunFormatting` (tri-state style-chain run formatting), and the full-mode
+  highlight value plumbing.
+
+## Impact
+
+- Affected specs: `odf-core` (conversion fidelity scenarios CONV-14..CONV-19),
+  `docx-primitives` (full-mode highlight tag value, style-chain formatting extraction)
+- Affected code: `packages/odf-core/src/convert/**`,
+  `packages/docx-core/src/primitives/{formatting_tags,semantic_tags,styles,document,document_view-comments,serialize_html}.ts`
+- Ref: #406 (phase 3), #331 (phasing), #401 (phases 1+2)

--- a/openspec/changes/update-docx-to-odf-style-fidelity/specs/docx-primitives/spec.md
+++ b/openspec/changes/update-docx-to-odf-style-fidelity/specs/docx-primitives/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Full-Mode Highlight Color Tags
+
+When the document view is built with `formattingMode: 'full'`, TOON highlight tags SHALL carry
+the source `w:highlight` value as a `color` attribute (`<highlight color="green">`), and the
+shared tokenizer grammar (`TOON_INLINE_TAG_RE`) and highlight strip helpers SHALL accept the
+attributed form. Compact-mode output SHALL remain byte-identical to the value-less form,
+including the merging of adjacent highlight runs whose colors differ.
+
+#### Scenario: [HLCOLOR-01] Full mode emits the highlight value, compact mode does not
+- **WHEN** a paragraph with a `green`-highlighted run is rendered with `formattingMode: 'full'` and again with the default compact mode
+- **THEN** the full-mode `tagged_text` contains `<highlight color="green">…</highlight>` while compact mode contains the value-less `<highlight>…</highlight>`, and `tokenizeToonInline` yields the attributed open tag as a single `tag` token
+
+#### Scenario: [HLCOLOR-02] Adjacent different-color highlights stay merged in compact mode
+- **WHEN** two adjacent runs highlighted with different colors are rendered in compact mode
+- **THEN** the emitted tags collapse to one `<highlight>…</highlight>` span exactly as before the value plumbing existed
+
+### Requirement: Style-Chain Run Formatting Extraction
+
+`@usejunior/docx-core` SHALL export `extractStyleRunFormatting(styles, styleId)` resolving a
+style's `basedOn` chain into tri-state run formatting (`bold`/`italic` as `boolean | null`,
+`fontName`/`colorHex` as `string | null`, `fontSizePt` as `number | null`) where `null` means
+the chain never specifies the property, and `DocxDocument` SHALL expose `getStylesModel()`
+returning the parsed styles model of the loaded document.
+
+#### Scenario: [STYLEFMT-01] Chain resolution distinguishes unspecified from false
+- **WHEN** formatting is extracted for a style chain where `Heading1` is based on a `Heading` base that sets bold and a 20pt size, and `Heading1` itself sets only a color
+- **THEN** the result carries `bold: true` and `fontSizePt: 20` from the base, the color from `Heading1`, and `italic: null` because no chain member specifies italics

--- a/openspec/changes/update-docx-to-odf-style-fidelity/specs/odf-core/spec.md
+++ b/openspec/changes/update-docx-to-odf-style-fidelity/specs/odf-core/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: DOCX to ODT conversion style fidelity
+
+`convertDocxToOdt` SHALL map the style classes the phase 1+2 converter downgraded, removing
+their lossiness entries on documents where the source data is available. Font face, size, and
+color runs SHALL become deduped automatic text styles (`style:font-name`, `fo:font-size`,
+`fo:color`) with every used font face declared in `office:font-face-decls`. Paragraph alignment
+and indentation from the document view SHALL become deduped automatic paragraph styles
+(`fo:text-align`, `fo:margin-left`, `fo:text-indent`); list-item paragraphs receive alignment
+only. Named heading styles and `Standard` in `styles.xml` SHALL be seeded from the source
+document's style definitions when present. Highlight runs SHALL carry the source highlight
+color mapped from the ECMA-376 palette rather than normalizing to yellow. Table cell borders
+SHALL honor an explicit `w:tblBorders` (including explicitly borderless tables) and
+`table:table-column` widths SHALL follow `w:tblGrid`. Text-empty body-level paragraphs SHALL be
+preserved as empty `text:p` elements; any paragraph the view fails to surface that is not a
+text-empty body paragraph remains reported in the lossiness report.
+
+#### Scenario: [CONV-14] Font face, size, and color runs become automatic text styles
+- **WHEN** runs carrying `w:rFonts`/`w:sz`/`w:color` (e.g. 22pt Georgia, red text) are converted in full formatting mode
+- **THEN** each run is wrapped in a `text:span` whose automatic style carries the matching `style:font-name`, `fo:font-size` (points), and `fo:color` (`#RRGGBB`), every used face is declared in `office:font-face-decls`, identical font tuples share one style, and no `font-formatting-dropped` lossiness entry is reported
+
+#### Scenario: [CONV-15] Paragraph alignment and indentation become automatic paragraph styles
+- **WHEN** paragraphs with center/right/justify alignment and left or first-line indents are converted
+- **THEN** each emits a `text:p` referencing an automatic paragraph style with the mapped `fo:text-align` (`center`/`end`/`justify`) and `fo:margin-left`/`fo:text-indent` in points, deviating-format paragraphs share deduped styles, and default left-aligned unindented paragraphs keep the plain named style
+
+#### Scenario: [CONV-16] Named styles are seeded from the source document
+- **WHEN** a source whose `styles.xml` defines `Heading1` (e.g. 20pt, non-bold, colored) and `Normal` (e.g. 11pt Georgia) is converted
+- **THEN** the output `styles.xml` `Heading_20_1` carries the source font size, weight, and color, `Standard` carries the source body font, and properties the source style chain does not specify fall back to the template defaults
+
+#### Scenario: [CONV-17] Highlight colors are preserved
+- **WHEN** runs highlighted `green` and `cyan` are converted
+- **THEN** their `text:span` automatic styles carry `fo:background-color` `#00ff00` and `#00ffff` respectively instead of normalizing to yellow
+
+#### Scenario: [CONV-18] Table borders and column widths follow the source
+- **WHEN** a table with explicit `w:tblBorders` set to `none` and a `w:tblGrid` with unequal column widths is converted alongside a table with a declared 1pt border
+- **THEN** the borderless table's cell style carries `fo:border="none"`, the bordered table's cell style carries the declared width and color, and `table:table-column` elements reference automatic styles whose `style:column-width` matches the source grid proportions in points
+
+#### Scenario: [CONV-19] Text-empty body paragraphs are preserved as spacing
+- **WHEN** a document with text-empty paragraphs between body paragraphs (leading, mid-document, and trailing) is converted
+- **THEN** each body-level empty paragraph emits an empty `text:p` at its source position and no `unsurfaced-paragraphs-dropped` entry is reported

--- a/openspec/changes/update-docx-to-odf-style-fidelity/tasks.md
+++ b/openspec/changes/update-docx-to-odf-style-fidelity/tasks.md
@@ -1,0 +1,23 @@
+## 1. docx-core enrichments
+
+- [x] 1.1 `formatting_tags.ts`: carry `highlightVal` in active tag state; emit `<highlight color="…">` in full mode only; keep compact-mode merge behavior
+- [x] 1.2 `document_view-comments.ts`: extend `TOON_INLINE_TAG_RE` to accept attributed highlight opens
+- [x] 1.3 `semantic_tags.ts`: `hasHighlightTags`/`stripHighlightTags` accept the attributed form; `serialize_html.ts` tolerates it
+- [x] 1.4 `styles.ts`: export `extractStyleRunFormatting` (tri-state chain resolution); `document.ts`: add `DocxDocument.getStylesModel()`
+- [x] 1.5 docx-core tests for 1.1–1.4
+
+## 2. odf-core converter
+
+- [x] 2.1 `inline.ts`: font color/size/face + highlight color state from TOON tags; extended `TextStyleRegistry`; ECMA-376 highlight palette map
+- [x] 2.2 `package.ts`: `office:font-face-decls` in content skeleton; `FontFaceRegistry`; `svg` namespace
+- [x] 2.3 New `paragraph_styles.ts`: `ParagraphStyleRegistry`; wire into `docx_to_odt.ts` for body/heading/cell/manual-label paragraphs (alignment-only for list items)
+- [x] 2.4 `package.ts`: `buildStylesXml` seeded from source `Heading1..6`/`Normal` via `extractStyleRunFormatting`; styles.xml font-face decls
+- [x] 2.5 `tables.ts`: per-table cell border style from `w:tblBorders`; column-width styles from `w:tblGrid`
+- [x] 2.6 `docx_to_odt.ts`: preserve text-empty body-level paragraphs via bookmark correlation; keep in-table drops reported
+
+## 3. Tests and acceptance
+
+- [x] 3.1 `convert_style_fidelity.test.ts` covering CONV-14..CONV-19
+- [x] 3.2 Update CONV-02/CONV-04/CONV-10 expectations for preserved empty paragraphs and removed font lossiness
+- [x] 3.3 `convert_real_documents.test.ts`: assert in-scope lossiness classes are absent on the bundled real fixtures
+- [x] 3.4 Full local gate: build, lint, tests, spec-coverage, conformance checks

--- a/packages/docx-core/src/primitives/document.ts
+++ b/packages/docx-core/src/primitives/document.ts
@@ -20,6 +20,7 @@ import { serializeToMarkdown, type SerializeMarkdownOptions } from './serialize_
 import { serializeToHtml, type SerializeHtmlOptions } from './serialize_html.js';
 import { serializeToPlainText, type SerializePlainTextOptions } from './serialize_plaintext.js';
 import type { FormattingMode } from './formatting_tags.js';
+import { parseStylesXml, type StylesModel } from './styles.js';
 import { parseNumberingXml, type NumberingModel } from './numbering.js';
 import { findUniqueSubstringMatch } from './matching.js';
 import { parseDocumentRels, type RelsMap } from './relationships.js';
@@ -615,6 +616,15 @@ export class DocxDocument {
    */
   getNumberingModel(): NumberingModel | null {
     return this.numberingXml ? parseNumberingXml(this.numberingXml) : null;
+  }
+
+  /**
+   * Parsed named-style model of the loaded document (empty when the package has no
+   * `word/styles.xml`). Semantic converters (DOCX → ODT) resolve heading/body style chains
+   * through it to seed their own style templates from the source's definitions.
+   */
+  getStylesModel(): StylesModel {
+    return parseStylesXml(this.stylesXml);
   }
 
   buildDocumentView(opts?: { includeSemanticTags?: boolean; showFormatting?: boolean; formattingMode?: FormattingMode }): { nodes: DocumentViewNode[]; styles: DocumentStyles } {

--- a/packages/docx-core/src/primitives/document_view-comments.ts
+++ b/packages/docx-core/src/primitives/document_view-comments.ts
@@ -15,7 +15,7 @@ type DocumentViewCommentWithRuntime = DocumentViewComment & {
 };
 
 // Matches the exact set of TOON inline formatting tags that emitFormattingTags() can emit:
-//   <b>, </b>, <i>, </i>, <u>, </u>, <highlight>, </highlight>,
+//   <b>, </b>, <i>, </i>, <u>, </u>, <highlight>, <highlight color="...">, </highlight>,
 //   <a href="...">, </a>, <font ATTR=...>, </font>
 // Anything else in the form `<...>` is literal document text (e.g., `<Borrower>` placeholders
 // in legal templates, or stylesheet samples like `<font>`) and must be counted as visible
@@ -24,8 +24,9 @@ type DocumentViewCommentWithRuntime = DocumentViewComment & {
 // Note the opening `a`/`font` alternative requires `\s[^>]*` (mandatory attributes), because
 // the formatter only emits `<a href="...">` and `<font ATTR=...>` — never bare `<a>` or
 // `<font>`. Allowing the bare forms would cause literal `<a>` / `<font>` in document text to
-// be silently skipped, shifting marker positions.
-export const TOON_INLINE_TAG_RE = /^(?:<\/?(?:b|i|u|highlight)>|<\/(?:a|font)>|<(?:a|font)\s[^>]*>)/;
+// be silently skipped, shifting marker positions. `<highlight>` appears both bare (compact
+// mode) and attributed (full mode carries the source w:highlight value).
+export const TOON_INLINE_TAG_RE = /^(?:<\/?(?:b|i|u|highlight)>|<\/(?:a|font)>|<(?:a|font|highlight)\s[^>]*>)/;
 
 /**
  * Split a TOON inline-tag string (`DocumentViewNode.tagged_text` produced with

--- a/packages/docx-core/src/primitives/document_view.ts
+++ b/packages/docx-core/src/primitives/document_view.ts
@@ -636,7 +636,7 @@ export function buildNodesForDocumentView(params: {
 
       // Emit formatting tags from run-level metadata.
       const paraFontBaseline = computeParagraphFontBaseline(bodyRuns, { formattingMode });
-      tagged = emitFormattingTags({ runs: bodyRuns, baseline: docBaseline, fontBaseline: paraFontBaseline });
+      tagged = emitFormattingTags({ runs: bodyRuns, baseline: docBaseline, fontBaseline: paraFontBaseline, formattingMode });
       tagged = mergeAdjacentTags(tagged);
 
     } else if (includeSemantic) {

--- a/packages/docx-core/src/primitives/formatting_tags.ts
+++ b/packages/docx-core/src/primitives/formatting_tags.ts
@@ -192,7 +192,9 @@ type ActiveTags = {
   bold: boolean;
   italic: boolean;
   underline: boolean;
-  highlighting: boolean;
+  // The source w:highlight value (e.g. "green"), or null when unhighlighted. Compact mode
+  // emits the value-less <highlight> regardless; full mode carries it as a color attribute.
+  highlightVal: string | null;
   color: string | null;
   fontSize: number | null; // points (display units)
   fontName: string | null;
@@ -204,7 +206,7 @@ function tagsEqual(a: ActiveTags, b: ActiveTags): boolean {
     a.bold === b.bold &&
     a.italic === b.italic &&
     a.underline === b.underline &&
-    a.highlighting === b.highlighting &&
+    a.highlightVal === b.highlightVal &&
     a.color === b.color &&
     a.fontSize === b.fontSize &&
     a.fontName === b.fontName
@@ -224,7 +226,7 @@ function hasFontAttrs(tags: ActiveTags): boolean {
 }
 
 function closeTags(out: string[], tags: ActiveTags): void {
-  if (tags.highlighting) out.push(`</${HIGHLIGHT_TAG}>`);
+  if (tags.highlightVal !== null) out.push(`</${HIGHLIGHT_TAG}>`);
   if (tags.underline) out.push('</u>');
   if (tags.italic) out.push('</i>');
   if (tags.bold) out.push('</b>');
@@ -245,7 +247,7 @@ export function escapeHtmlAttribute(value: string): string {
     .replaceAll('>', '&gt;');
 }
 
-function openTags(out: string[], tags: ActiveTags): void {
+function openTags(out: string[], tags: ActiveTags, mode: FormattingMode): void {
   if (tags.hyperlinkUrl !== null) {
     out.push(`<a href="${escapeHtmlAttribute(tags.hyperlinkUrl)}">`);
   }
@@ -254,7 +256,15 @@ function openTags(out: string[], tags: ActiveTags): void {
   if (tags.bold) out.push('<b>');
   if (tags.italic) out.push('<i>');
   if (tags.underline) out.push('<u>');
-  if (tags.highlighting) out.push(`<${HIGHLIGHT_TAG}>`);
+  if (tags.highlightVal !== null) {
+    // Only full mode carries the source w:highlight value; compact mode stays byte-identical
+    // to the historical value-less form (mergeAdjacentTags collapses adjacent pairs there).
+    out.push(
+      mode === 'full'
+        ? `<${HIGHLIGHT_TAG} color="${escapeHtmlAttribute(tags.highlightVal)}">`
+        : `<${HIGHLIGHT_TAG}>`,
+    );
+  }
 }
 
 function desiredTagsForRun(
@@ -265,12 +275,12 @@ function desiredTagsForRun(
   if (run.isHeaderRun) {
     return {
       hyperlinkUrl: null,
-      bold: false, italic: false, underline: false, highlighting: false,
+      bold: false, italic: false, underline: false, highlightVal: null,
       color: null, fontSize: null, fontName: null,
     };
   }
 
-  const highlighting = !!run.formatting.highlightVal;
+  const highlightVal = run.formatting.highlightVal;
 
   // BIU
   let bold: boolean;
@@ -322,7 +332,7 @@ function desiredTagsForRun(
 
   return {
     hyperlinkUrl: run.hyperlinkUrl,
-    bold, italic, underline, highlighting,
+    bold, italic, underline, highlightVal,
     color, fontSize, fontName,
   };
 }
@@ -331,14 +341,16 @@ export function emitFormattingTags(params: {
   runs: AnnotatedRun[];
   baseline: FormattingBaseline;
   fontBaseline?: FontBaseline | null;
+  formattingMode?: FormattingMode;
 }): string {
   const { runs, baseline, fontBaseline } = params;
+  const mode = params.formattingMode ?? 'compact';
   if (runs.length === 0) return '';
 
   const out: string[] = [];
   let active: ActiveTags = {
     hyperlinkUrl: null,
-    bold: false, italic: false, underline: false, highlighting: false,
+    bold: false, italic: false, underline: false, highlightVal: null,
     color: null, fontSize: null, fontName: null,
   };
 
@@ -347,7 +359,7 @@ export function emitFormattingTags(params: {
     const desired = desiredTagsForRun(run, baseline, fontBaseline ?? null);
     if (!tagsEqual(active, desired)) {
       closeTags(out, active);
-      openTags(out, desired);
+      openTags(out, desired, mode);
       active = desired;
     }
     out.push(run.text);

--- a/packages/docx-core/src/primitives/semantic_tags.ts
+++ b/packages/docx-core/src/primitives/semantic_tags.ts
@@ -31,6 +31,7 @@ export function stripHyperlinkTags(text: string): string {
 export function hasHighlightTags(text: string): boolean {
   return (
     text.includes(`<${HIGHLIGHT_TAG}>`) ||
+    text.includes(`<${HIGHLIGHT_TAG} `) || // full-mode attributed form: <highlight color="...">
     text.includes(`</${HIGHLIGHT_TAG}>`) ||
     text.includes('<highlighting>') ||
     text.includes('</highlighting>')
@@ -39,7 +40,7 @@ export function hasHighlightTags(text: string): boolean {
 
 export function stripHighlightTags(text: string): string {
   return text
-    .replaceAll(new RegExp(`<${HIGHLIGHT_TAG}>`, 'g'), '')
+    .replaceAll(new RegExp(`<${HIGHLIGHT_TAG}\\b[^>]*>`, 'g'), '')
     .replaceAll(new RegExp(`</${HIGHLIGHT_TAG}>`, 'g'), '')
     .replaceAll(/<highlighting>/g, '')
     .replaceAll(/<\/highlighting>/g, '');

--- a/packages/docx-core/src/primitives/serialize_html.ts
+++ b/packages/docx-core/src/primitives/serialize_html.ts
@@ -131,7 +131,9 @@ export function inlineTagsToHtml(text: string, refs?: FootnoteRefs): string {
       continue;
     }
     const tag = token.value;
-    if (tag === '<highlight>') out += '<mark>';
+    // The serializer renders compact-mode views, but tolerate the full-mode attributed form
+    // (<highlight color="...">) so a full-mode tagged_text can't leak raw markup into HTML.
+    if (tag === '<highlight>' || tag.startsWith('<highlight ')) out += '<mark>';
     else if (tag === '</highlight>') out += '</mark>';
     else if (tag.startsWith('<font ')) out += fontTagToSpan(tag);
     else if (tag === '</font>') out += '</span>';

--- a/packages/docx-core/src/primitives/styles.ts
+++ b/packages/docx-core/src/primitives/styles.ts
@@ -148,6 +148,35 @@ export type RunFormatting = {
   colorHex: string | null;
 };
 
+/**
+ * Tri-state run formatting resolved from a named style's `basedOn` chain: `null` means no
+ * chain member specifies the property (distinct from an explicit `w:val="0"` → `false`).
+ * Consumers seeding their own style templates (e.g. the DOCX → ODT converter's `styles.xml`)
+ * use `null` to fall back to template defaults instead of overriding them.
+ */
+export type StyleRunFormatting = {
+  bold: boolean | null;
+  italic: boolean | null;
+  fontName: string | null;
+  fontSizePt: number | null;
+  colorHex: string | null;
+};
+
+/** Resolve a named style's effective run formatting through its `basedOn` chain. */
+export function extractStyleRunFormatting(
+  styles: StylesModel,
+  styleId: string | null,
+): StyleRunFormatting {
+  const rPrs = resolveStyleChain(styles, styleId).map((s) => s.rPr);
+  return {
+    bold: firstNonNull(rPrs.map((rPr) => parseBoolProp(rPr, W.b))),
+    italic: firstNonNull(rPrs.map((rPr) => parseBoolProp(rPr, W.i))),
+    fontName: firstNonNull(rPrs.map(parseFontName)),
+    fontSizePt: firstNonNull(rPrs.map(parseFontSizePt)),
+    colorHex: firstNonNull(rPrs.map(parseColorHex)),
+  };
+}
+
 function parseBoolProp(parent: Element | null, tagLocal: string): boolean | null {
   if (!parent) return null;
   const el = getFirstChild(parent, OOXML.W_NS, tagLocal);

--- a/packages/docx-core/test-primitives/odf_style_fidelity.traceability.test.ts
+++ b/packages/docx-core/test-primitives/odf_style_fidelity.traceability.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from './helpers/allure-test.js';
+
+import {
+  emitFormattingTags,
+  mergeAdjacentTags,
+  type AnnotatedRun,
+  type FormattingBaseline,
+} from '../src/primitives/formatting_tags.js';
+import { tokenizeToonInline } from '../src/primitives/document_view-comments.js';
+import { parseXml } from '../src/primitives/xml.js';
+import {
+  extractStyleRunFormatting,
+  parseStylesXml,
+  type RunFormatting,
+  type StyleRunFormatting,
+  type StylesModel,
+} from '../src/primitives/styles.js';
+
+const TEST_FEATURE = 'update-docx-to-odf-style-fidelity';
+const test = testAllure.epic('DOCX Primitives').withLabels({ feature: TEST_FEATURE });
+
+const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+const BASELINE: FormattingBaseline = { bold: false, italic: false, underline: false, suppressed: false };
+
+function annotatedRun(text: string, formatting: Partial<RunFormatting> = {}): AnnotatedRun {
+  return {
+    text,
+    formatting: {
+      bold: false,
+      italic: false,
+      underline: false,
+      highlightVal: null,
+      fontName: '',
+      fontSizePt: 0,
+      colorHex: null,
+      ...formatting,
+    },
+    hyperlinkUrl: null,
+    charCount: text.length,
+    isHeaderRun: false,
+  };
+}
+
+function stylesModelFrom(stylesBodyXml: string): StylesModel {
+  return parseStylesXml(parseXml(`<w:styles xmlns:w="${W_NS}">${stylesBodyXml}</w:styles>`));
+}
+
+describe('full-mode highlight color tags', () => {
+  test.openspec('[HLCOLOR-01] Full mode emits the highlight value, compact mode does not')(
+    'full mode carries the w:highlight value as a color attribute; compact mode stays value-less',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      let runs: AnnotatedRun[];
+      let full: string;
+      let compact: string;
+
+      await given('a plain run followed by a green-highlighted run', async () => {
+        runs = [annotatedRun('plain '), annotatedRun('lit', { highlightVal: 'green' })];
+      });
+
+      await when('tags are emitted in full and compact modes', async () => {
+        full = emitFormattingTags({ runs, baseline: BASELINE, formattingMode: 'full' });
+        compact = emitFormattingTags({ runs, baseline: BASELINE });
+      });
+
+      await then('full mode carries the color attribute', async () => {
+        expect(full!).toContain('<highlight color="green">lit</highlight>');
+      });
+
+      await and('compact mode emits the value-less historical form', async () => {
+        expect(compact!).toContain('<highlight>lit</highlight>');
+        expect(compact!).not.toContain('color=');
+      });
+
+      await and('the tokenizer yields the attributed open tag as one tag token', async () => {
+        const tokens = tokenizeToonInline(full!);
+        expect(tokens).toContainEqual({ kind: 'tag', value: '<highlight color="green">' });
+        expect(tokens.filter((t) => t.kind === 'text').map((t) => t.value).join('')).toBe('plain lit');
+      });
+    },
+  );
+
+  test.openspec('[HLCOLOR-02] Adjacent different-color highlights stay merged in compact mode')(
+    'adjacent different-color highlights collapse in compact mode and stay distinct in full mode',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      let runs: AnnotatedRun[];
+      let compact: string;
+      let full: string;
+
+      await given('adjacent runs highlighted green and cyan', async () => {
+        runs = [annotatedRun('one', { highlightVal: 'green' }), annotatedRun('two', { highlightVal: 'cyan' })];
+      });
+
+      await when('tags are emitted and adjacent tags merged in both modes', async () => {
+        compact = mergeAdjacentTags(emitFormattingTags({ runs, baseline: BASELINE }));
+        full = mergeAdjacentTags(emitFormattingTags({ runs, baseline: BASELINE, formattingMode: 'full' }));
+      });
+
+      await then('compact mode collapses to one value-less span (historical behavior)', async () => {
+        expect(compact!).toBe('<highlight>onetwo</highlight>');
+      });
+
+      await and('full mode keeps the two color spans distinct', async () => {
+        expect(full!).toBe('<highlight color="green">one</highlight><highlight color="cyan">two</highlight>');
+      });
+    },
+  );
+});
+
+describe('style-chain run formatting extraction', () => {
+  test.openspec('[STYLEFMT-01] Chain resolution distinguishes unspecified from false')(
+    'extractStyleRunFormatting resolves the basedOn chain with tri-state semantics',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      let model: StylesModel;
+      let resolved: StyleRunFormatting;
+
+      await given('Heading1 based on a bold 20pt Heading base, itself adding only a color', async () => {
+        model = stylesModelFrom(
+          `<w:style w:type="paragraph" w:styleId="Heading">` +
+            `<w:name w:val="Heading"/>` +
+            `<w:rPr><w:b/><w:sz w:val="40"/></w:rPr>` +
+            `</w:style>` +
+            `<w:style w:type="paragraph" w:styleId="Heading1">` +
+            `<w:name w:val="heading 1"/>` +
+            `<w:basedOn w:val="Heading"/>` +
+            `<w:rPr><w:color w:val="2E74B5"/></w:rPr>` +
+            `</w:style>`,
+        );
+      });
+
+      await when('formatting is extracted for Heading1', async () => {
+        resolved = extractStyleRunFormatting(model!, 'Heading1');
+      });
+
+      await then('inherited and own properties resolve through the chain', async () => {
+        expect(resolved!.bold).toBe(true);
+        expect(resolved!.fontSizePt).toBe(20); // w:sz is half-points
+        expect(resolved!.colorHex).toBe('2E74B5');
+      });
+
+      await and('properties no chain member specifies stay null (not false)', async () => {
+        expect(resolved!.italic).toBeNull();
+        expect(resolved!.fontName).toBeNull();
+      });
+
+      await and('an explicit w:val="0" override resolves to false, and unknown ids to all-null', async () => {
+        const overrideModel = stylesModelFrom(
+          `<w:style w:type="paragraph" w:styleId="Base"><w:rPr><w:b/></w:rPr></w:style>` +
+            `<w:style w:type="paragraph" w:styleId="Quiet"><w:basedOn w:val="Base"/><w:rPr><w:b w:val="0"/></w:rPr></w:style>`,
+        );
+        expect(extractStyleRunFormatting(overrideModel, 'Quiet').bold).toBe(false);
+        expect(extractStyleRunFormatting(overrideModel, 'Nope')).toEqual({
+          bold: null,
+          italic: null,
+          fontName: null,
+          fontSizePt: null,
+          colorHex: null,
+        });
+      });
+    },
+  );
+});

--- a/packages/docx-core/test-primitives/semantic_tags.test.ts
+++ b/packages/docx-core/test-primitives/semantic_tags.test.ts
@@ -123,3 +123,24 @@ describe('hasHighlightTags', () => {
     });
   });
 });
+
+describe('attributed highlight form (full-mode TOON)', () => {
+  test('hasHighlightTags and stripHighlightTags accept <highlight color="...">', async ({ given, when, then, and }: AllureBddContext) => {
+    let input: string;
+    let stripped: string;
+    await given('full-mode text with an attributed highlight open tag', async () => {
+      input = `some <${HIGHLIGHT_TAG} color="green">highlighted</${HIGHLIGHT_TAG}> text`;
+    });
+    await when('the highlight helpers run', async () => {
+      stripped = stripHighlightTags(input);
+    });
+    await then('the attributed form is detected and stripped', async () => {
+      expect(hasHighlightTags(input!)).toBe(true);
+      expect(stripped!).toBe('some highlighted text');
+    });
+    await and('literal <highlighting...> words like "highlighting" in prose stay intact', async () => {
+      // \b in the stripper must not let <highlight...> eat <highlighting> differently than before.
+      expect(stripHighlightTags('keep <highlighting>x</highlighting> y')).toBe('keep x y');
+    });
+  });
+});

--- a/packages/odf-core/src/convert/convert_basics.test.ts
+++ b/packages/odf-core/src/convert/convert_basics.test.ts
@@ -50,13 +50,13 @@ describe('convertDocxToOdt — package validity, text, headings, runs', () => {
       `<w:p><w:r><w:t xml:space="preserve">Alpha  beta   gamma</w:t></w:r>` +
       `<w:r><w:tab/><w:t xml:space="preserve">after tab</w:t></w:r></w:p>` +
       p('Second paragraph') +
-      '<w:p/>'; // text-empty paragraph: unsurfaced by the document view, reported as lossiness
+      '<w:p/>'; // text-empty paragraph: unsurfaced by the document view, preserved as spacing (CONV-19)
     const docx = await buildDocxFromParts({ bodyXml });
     const { odt, lossiness } = await convertDocxToOdt(docx);
 
     const texts = (await reopen(odt)).getParagraphs().map((b) => b.text);
-    expect(texts).toEqual(['Alpha  beta   gamma\tafter tab', 'Second paragraph']);
-    expect(lossiness.some((e) => e.construct === 'unsurfaced-paragraphs-dropped')).toBe(true);
+    expect(texts).toEqual(['Alpha  beta   gamma\tafter tab', 'Second paragraph', '']);
+    expect(lossiness.some((e) => e.construct === 'unsurfaced-paragraphs-dropped')).toBe(false);
   });
 
   it('[CONV-03] Word-style headings become text:h with the mapped outline level; plain text stays text:p', async () => {
@@ -150,15 +150,27 @@ describe('convertDocxToOdt — package validity, text, headings, runs', () => {
   });
 
   it('[CONV-10] dropped constructs are reported in the lossiness summary, never silently', async () => {
-    const bodyXml = `<w:p><w:r><w:rPr><w:color w:val="FF0000"/></w:rPr><w:t>red text</w:t></w:r></w:p>`;
+    // Font/color runs map since phase 3 (CONV-14); grid gaps remain a genuinely
+    // unmappable downgrade and must be reported.
+    const bodyXml =
+      `<w:tbl><w:tblGrid><w:gridCol w:w="2000"/><w:gridCol w:w="2000"/></w:tblGrid>` +
+      `<w:tr><w:tc><w:p><w:r><w:t>A1</w:t></w:r></w:p><w:p/></w:tc>` +
+      `<w:tc><w:p><w:r><w:t>A2</w:t></w:r></w:p></w:tc></w:tr>` +
+      `<w:tr><w:tc><w:p><w:r><w:t>B1</w:t></w:r></w:p></w:tc></w:tr>` +
+      `</w:tbl>` +
+      `<w:p><w:r><w:rPr><w:color w:val="FF0000"/></w:rPr><w:t>red text</w:t></w:r></w:p>`;
     const docx = await buildDocxFromParts({ bodyXml });
     const { odt, lossiness } = await convertDocxToOdt(docx);
 
-    const fontDrop = lossiness.find((e) => e.construct === 'font-formatting-dropped');
-    expect(fontDrop).toBeDefined();
-    expect(fontDrop!.count).toBeGreaterThanOrEqual(1);
+    // Each one-cell row leaves the second grid column empty — filled and reported.
+    const gridGaps = lossiness.find((e) => e.construct === 'table-grid-gaps-filled');
+    expect(gridGaps).toBeDefined();
+    expect(gridGaps!.count).toBeGreaterThanOrEqual(1);
+    // Font formatting is mapped now, never reported as dropped.
+    expect(lossiness.some((e) => e.construct === 'font-formatting-dropped')).toBe(false);
     // The text itself is preserved.
-    expect((await reopen(odt)).getParagraphs().map((b) => b.text)).toEqual(['red text']);
+    const texts = (await reopen(odt)).getParagraphs().map((b) => b.text).filter((t) => t !== '');
+    expect(texts).toEqual(['A1', 'A2', 'B1', 'red text']);
   });
 
   it('[CONV-11] converted output reopens through odf-core with matching visible text', async () => {

--- a/packages/odf-core/src/convert/convert_real_documents.test.ts
+++ b/packages/odf-core/src/convert/convert_real_documents.test.ts
@@ -33,10 +33,21 @@ describe('convertDocxToOdt — real contract documents', () => {
     async () => {
       for (const { rel, abs } of FIXTURES) {
         const docx = readFileSync(abs);
-        const { odt } = await convertDocxToOdt(docx);
+        const { odt, lossiness } = await convertDocxToOdt(docx);
 
         const safety = await validateOdfArchiveSafety(odt);
         expect(safety.ok, `${rel}: archive safety`).toBe(true);
+
+        // Phase 3 acceptance (#406): the in-scope style classes report zero loss on the
+        // bundled real fixtures. Only merged-cell grid gaps (out of scope) may remain.
+        const inScope = [
+          'font-formatting-dropped',
+          'unsurfaced-paragraphs-dropped',
+          'unknown-highlight-color',
+          'unmappable-font-color',
+        ];
+        const offending = lossiness.filter((e) => inScope.includes(e.construct));
+        expect(offending, `${rel}: in-scope lossiness`).toEqual([]);
 
         // Expected text comes from the same semantic view the converter consumes.
         const source = await DocxDocument.load(docx);

--- a/packages/odf-core/src/convert/convert_style_fidelity.test.ts
+++ b/packages/odf-core/src/convert/convert_style_fidelity.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect } from 'vitest';
+import { buildDocxFromParts, parseXml } from '@usejunior/docx-core';
+
+import { convertDocxToOdt } from './docx_to_odt.js';
+import { OdfArchive } from '../shared/odf/OdfArchive.js';
+import { ODF_NS } from '../shared/odf/namespaces.js';
+
+const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+function r(text: string, runProps = ''): string {
+  const rPr = runProps ? `<w:rPr>${runProps}</w:rPr>` : '';
+  return `<w:r>${rPr}<w:t xml:space="preserve">${text}</w:t></w:r>`;
+}
+
+function stylesXmlWith(stylesBody: string): string {
+  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:styles xmlns:w="${W_NS}">${stylesBody}</w:styles>`;
+}
+
+async function contentDocOf(odt: Buffer): Promise<{ contentXml: string; doc: Document }> {
+  const contentXml = await (await OdfArchive.load(odt)).getContentXml();
+  return { contentXml, doc: parseXml(contentXml) };
+}
+
+/** Map text:span content → its automatic style's style:text-properties element. */
+function spanProperties(doc: Document): Map<string, Element> {
+  const stylesByName = new Map<string, Element>();
+  for (const style of Array.from(doc.getElementsByTagNameNS(ODF_NS.STYLE, 'style'))) {
+    const name = style.getAttributeNS(ODF_NS.STYLE, 'name');
+    const props = style.getElementsByTagNameNS(ODF_NS.STYLE, 'text-properties')[0];
+    if (name && props) stylesByName.set(name, props as Element);
+  }
+  const result = new Map<string, Element>();
+  for (const span of Array.from(doc.getElementsByTagNameNS(ODF_NS.TEXT, 'span'))) {
+    const styleName = span.getAttributeNS(ODF_NS.TEXT, 'style-name');
+    const props = styleName ? stylesByName.get(styleName) : undefined;
+    if (props) result.set(span.textContent ?? '', props);
+  }
+  return result;
+}
+
+/** Map paragraph visible text → the style:paragraph-properties of its (automatic) style. */
+function paragraphProperties(doc: Document): Map<string, { styleName: string; props: Element | null }> {
+  const stylesByName = new Map<string, Element>();
+  for (const style of Array.from(doc.getElementsByTagNameNS(ODF_NS.STYLE, 'style'))) {
+    const name = style.getAttributeNS(ODF_NS.STYLE, 'name');
+    const props = style.getElementsByTagNameNS(ODF_NS.STYLE, 'paragraph-properties')[0];
+    if (name) stylesByName.set(name, props as Element);
+  }
+  const result = new Map<string, { styleName: string; props: Element | null }>();
+  const blocks = [
+    ...Array.from(doc.getElementsByTagNameNS(ODF_NS.TEXT, 'p')),
+    ...Array.from(doc.getElementsByTagNameNS(ODF_NS.TEXT, 'h')),
+  ];
+  for (const p of blocks) {
+    const styleName = p.getAttributeNS(ODF_NS.TEXT, 'style-name') ?? '';
+    result.set(p.textContent ?? '', { styleName, props: stylesByName.get(styleName) ?? null });
+  }
+  return result;
+}
+
+describe('convertDocxToOdt — style fidelity (phase 3, #406)', () => {
+  it('[CONV-14] font face/size/color runs become automatic text styles with declared font faces', async () => {
+    const bodyXml =
+      `<w:p>${r('Big Georgia title', '<w:sz w:val="44"/><w:rFonts w:ascii="Georgia"/>')}</w:p>` +
+      `<w:p>${r('red ', '<w:color w:val="FF0000"/>')}${r('plain ')}${r('red again', '<w:color w:val="FF0000"/>')}</w:p>`;
+    const docx = await buildDocxFromParts({ bodyXml });
+    const { odt, lossiness } = await convertDocxToOdt(docx);
+    const { doc } = await contentDocOf(odt);
+
+    const spans = spanProperties(doc);
+    const title = spans.get('Big Georgia title');
+    expect(title).toBeDefined();
+    expect(title!.getAttributeNS(ODF_NS.FO, 'font-size')).toBe('22pt'); // w:sz is half-points
+    expect(title!.getAttributeNS(ODF_NS.STYLE, 'font-name')).toBe('Georgia');
+
+    const red = spans.get('red ');
+    expect(red).toBeDefined();
+    expect(red!.getAttributeNS(ODF_NS.FO, 'color')).toBe('#ff0000');
+
+    // Identical font tuples share one deduped automatic style.
+    const redSpans = Array.from(doc.getElementsByTagNameNS(ODF_NS.TEXT, 'span'))
+      .filter((s) => s.textContent?.startsWith('red'));
+    expect(redSpans).toHaveLength(2);
+    expect(redSpans[0]!.getAttributeNS(ODF_NS.TEXT, 'style-name'))
+      .toBe(redSpans[1]!.getAttributeNS(ODF_NS.TEXT, 'style-name'));
+
+    // The used face is declared for ODF style:font-name resolution.
+    const decls = Array.from(doc.getElementsByTagNameNS(ODF_NS.STYLE, 'font-face'));
+    expect(decls.map((d) => d.getAttributeNS(ODF_NS.STYLE, 'name'))).toContain('Georgia');
+
+    expect(lossiness.some((e) => e.construct === 'font-formatting-dropped')).toBe(false);
+  });
+
+  it('[CONV-15] paragraph alignment and indents become deduped automatic paragraph styles', async () => {
+    const bodyXml =
+      `<w:p><w:pPr><w:jc w:val="center"/></w:pPr>${r('Centered')}</w:p>` +
+      `<w:p><w:pPr><w:jc w:val="center"/></w:pPr>${r('Centered too')}</w:p>` +
+      `<w:p><w:pPr><w:jc w:val="both"/><w:ind w:left="720" w:firstLine="360"/></w:pPr>${r('Justified indented')}</w:p>` +
+      `<w:p>${r('Plain')}</w:p>`;
+    const docx = await buildDocxFromParts({ bodyXml });
+    const { odt } = await convertDocxToOdt(docx);
+    const { doc } = await contentDocOf(odt);
+
+    const paras = paragraphProperties(doc);
+    const centered = paras.get('Centered')!;
+    expect(centered.props).not.toBeNull();
+    expect(centered.props!.getAttributeNS(ODF_NS.FO, 'text-align')).toBe('center');
+    // Identical deviating formats share one deduped style.
+    expect(paras.get('Centered too')!.styleName).toBe(centered.styleName);
+
+    const justified = paras.get('Justified indented')!;
+    expect(justified.props!.getAttributeNS(ODF_NS.FO, 'text-align')).toBe('justify');
+    expect(justified.props!.getAttributeNS(ODF_NS.FO, 'margin-left')).toBe('36pt'); // 720 twips
+    expect(justified.props!.getAttributeNS(ODF_NS.FO, 'text-indent')).toBe('18pt'); // 360 twips
+
+    // Default left-aligned unindented paragraphs keep the plain named style.
+    expect(paras.get('Plain')!.styleName).toBe('Standard');
+  });
+
+  it('[CONV-16] named styles are seeded from the source document styles', async () => {
+    const stylesXml = stylesXmlWith(
+      `<w:style w:type="paragraph" w:styleId="Normal"><w:name w:val="Normal"/>` +
+        `<w:rPr><w:rFonts w:ascii="Georgia"/><w:sz w:val="22"/></w:rPr></w:style>` +
+        `<w:style w:type="paragraph" w:styleId="Heading1"><w:name w:val="heading 1"/>` +
+        `<w:rPr><w:b w:val="0"/><w:sz w:val="40"/><w:color w:val="2E74B5"/></w:rPr></w:style>`,
+    );
+    const bodyXml =
+      `<w:p><w:pPr><w:pStyle w:val="Heading1"/></w:pPr>${r('The Heading')}</w:p>` +
+      `<w:p>${r('Body text')}</w:p>`;
+    const docx = await buildDocxFromParts({ bodyXml, stylesXml });
+    const { odt } = await convertDocxToOdt(docx);
+    const odtStylesXml = await (await OdfArchive.load(odt)).getFile('styles.xml');
+    const stylesDoc = parseXml(odtStylesXml!);
+
+    const byName = new Map<string, Element>();
+    for (const style of Array.from(stylesDoc.getElementsByTagNameNS(ODF_NS.STYLE, 'style'))) {
+      byName.set(style.getAttributeNS(ODF_NS.STYLE, 'name') ?? '', style);
+    }
+
+    const h1Props = byName.get('Heading_20_1')!.getElementsByTagNameNS(ODF_NS.STYLE, 'text-properties')[0] as Element;
+    expect(h1Props.getAttributeNS(ODF_NS.FO, 'font-size')).toBe('20pt'); // source 40 half-points, not template 18pt
+    expect(h1Props.getAttributeNS(ODF_NS.FO, 'font-weight')).toBe('normal'); // explicit w:b w:val="0"
+    expect(h1Props.getAttributeNS(ODF_NS.FO, 'color')).toBe('#2e74b5');
+
+    const standardProps = byName.get('Standard')!.getElementsByTagNameNS(ODF_NS.STYLE, 'text-properties')[0] as Element;
+    expect(standardProps.getAttributeNS(ODF_NS.STYLE, 'font-name')).toBe('Georgia');
+    expect(standardProps.getAttributeNS(ODF_NS.FO, 'font-size')).toBe('11pt');
+
+    // Unspecified properties keep template defaults: Heading_20_2 still carries its template size.
+    const h2Props = byName.get('Heading_20_2')!.getElementsByTagNameNS(ODF_NS.STYLE, 'text-properties')[0] as Element;
+    expect(h2Props.getAttributeNS(ODF_NS.FO, 'font-size')).toBe('16pt');
+  });
+
+  it('[CONV-17] highlight colors are preserved instead of normalizing to yellow', async () => {
+    const bodyXml =
+      `<w:p>${r('green bit', '<w:highlight w:val="green"/>')}${r(' and ')}${r('cyan bit', '<w:highlight w:val="cyan"/>')}</w:p>`;
+    const docx = await buildDocxFromParts({ bodyXml });
+    const { odt, lossiness } = await convertDocxToOdt(docx);
+    const { doc } = await contentDocOf(odt);
+
+    const spans = spanProperties(doc);
+    expect(spans.get('green bit')!.getAttributeNS(ODF_NS.FO, 'background-color')).toBe('#00ff00');
+    expect(spans.get('cyan bit')!.getAttributeNS(ODF_NS.FO, 'background-color')).toBe('#00ffff');
+    expect(lossiness.some((e) => e.construct === 'unknown-highlight-color')).toBe(false);
+  });
+
+  it('[CONV-18] table borders and column widths follow the source table', async () => {
+    const borderlessTable =
+      `<w:tbl><w:tblPr><w:tblBorders>` +
+      `<w:top w:val="none"/><w:left w:val="none"/><w:bottom w:val="none"/><w:right w:val="none"/>` +
+      `<w:insideH w:val="none"/><w:insideV w:val="none"/>` +
+      `</w:tblBorders></w:tblPr>` +
+      `<w:tblGrid><w:gridCol w:w="2880"/><w:gridCol w:w="1440"/></w:tblGrid>` +
+      `<w:tr><w:tc><w:p>${r('L1')}</w:p></w:tc><w:tc><w:p>${r('R1')}</w:p></w:tc></w:tr>` +
+      `</w:tbl>`;
+    const borderedTable =
+      `<w:tbl><w:tblPr><w:tblBorders>` +
+      `<w:top w:val="single" w:sz="8" w:color="FF0000"/><w:insideH w:val="single" w:sz="8" w:color="FF0000"/>` +
+      `</w:tblBorders></w:tblPr>` +
+      `<w:tblGrid><w:gridCol w:w="1440"/><w:gridCol w:w="1440"/></w:tblGrid>` +
+      `<w:tr><w:tc><w:p>${r('A')}</w:p></w:tc><w:tc><w:p>${r('B')}</w:p></w:tc></w:tr>` +
+      `</w:tbl>`;
+    const docx = await buildDocxFromParts({
+      bodyXml: borderlessTable + `<w:p>${r('between')}</w:p>` + borderedTable,
+    });
+    const { odt } = await convertDocxToOdt(docx);
+    const { doc } = await contentDocOf(odt);
+
+    const tables = Array.from(doc.getElementsByTagNameNS(ODF_NS.TABLE, 'table'));
+    expect(tables).toHaveLength(2);
+
+    const cellBorderOf = (table: Element): string => {
+      const cell = table.getElementsByTagNameNS(ODF_NS.TABLE, 'table-cell')[0] as Element;
+      const styleName = cell.getAttributeNS(ODF_NS.TABLE, 'style-name')!;
+      const style = Array.from(doc.getElementsByTagNameNS(ODF_NS.STYLE, 'style'))
+        .find((s) => s.getAttributeNS(ODF_NS.STYLE, 'name') === styleName)!;
+      const props = style.getElementsByTagNameNS(ODF_NS.STYLE, 'table-cell-properties')[0] as Element;
+      return props.getAttributeNS(ODF_NS.FO, 'border')!;
+    };
+    expect(cellBorderOf(tables[0]!)).toBe('none');
+    expect(cellBorderOf(tables[1]!)).toBe('1pt solid #ff0000'); // w:sz=8 eighths-of-a-point
+
+    // Column widths follow w:tblGrid (twips → pt): 2880 → 144pt, 1440 → 72pt.
+    const columnWidthOf = (column: Element): string => {
+      const styleName = column.getAttributeNS(ODF_NS.TABLE, 'style-name')!;
+      const style = Array.from(doc.getElementsByTagNameNS(ODF_NS.STYLE, 'style'))
+        .find((s) => s.getAttributeNS(ODF_NS.STYLE, 'name') === styleName)!;
+      const props = style.getElementsByTagNameNS(ODF_NS.STYLE, 'table-column-properties')[0] as Element;
+      return props.getAttributeNS(ODF_NS.STYLE, 'column-width')!;
+    };
+    const firstTableColumns = Array.from(tables[0]!.getElementsByTagNameNS(ODF_NS.TABLE, 'table-column'));
+    expect(firstTableColumns).toHaveLength(2);
+    expect(columnWidthOf(firstTableColumns[0]!)).toBe('144pt');
+    expect(columnWidthOf(firstTableColumns[1]!)).toBe('72pt');
+  });
+
+  it('[CONV-19] text-empty body paragraphs are preserved as spacing at their source positions', async () => {
+    const bodyXml =
+      `<w:p/>` +
+      `<w:p>${r('First')}</w:p>` +
+      `<w:p/><w:p/>` +
+      `<w:p>${r('Second')}</w:p>` +
+      `<w:p/>`;
+    const docx = await buildDocxFromParts({ bodyXml });
+    const { odt, lossiness } = await convertDocxToOdt(docx);
+    const { doc } = await contentDocOf(odt);
+
+    const texts = Array.from(doc.getElementsByTagNameNS(ODF_NS.TEXT, 'p')).map((p) => p.textContent ?? '');
+    expect(texts).toEqual(['', 'First', '', '', 'Second', '']);
+    expect(lossiness.some((e) => e.construct === 'unsurfaced-paragraphs-dropped')).toBe(false);
+  });
+});

--- a/packages/odf-core/src/convert/docx_to_odt.ts
+++ b/packages/odf-core/src/convert/docx_to_odt.ts
@@ -1,5 +1,5 @@
 /**
- * Native DOCX → ODT conversion (issue #331).
+ * Native DOCX → ODT conversion (issues #331, #406).
  *
  * Traverses docx-core's structured document view — the same intentionally-lossy semantic
  * model the markdown/HTML serializers consume — and emits a fresh ODT package. No external
@@ -8,21 +8,102 @@
  * `formattingMode: 'full'` is required (not the `'compact'` default): compact mode encodes
  * the document's dominant formatting as a modal baseline rather than per-run tags, which
  * would silently drop bold/italic/underline on mostly-bold documents.
+ *
+ * Two narrow raw-DOM supplements cover what the view cannot carry: table borders/grid widths
+ * (read from the source `w:tbl` by the view's `table_index`) and text-empty body paragraphs
+ * (vertical spacing the view never surfaces, preserved as empty `text:p` by bookmark
+ * correlation).
  */
 
-import { DocxDocument, serializeXml, type DocumentViewNode } from '@usejunior/docx-core';
+import {
+  DocxDocument,
+  getParagraphBookmarkId,
+  getParagraphText,
+  serializeXml,
+  W_NS,
+  type DocumentViewNode,
+} from '@usejunior/docx-core';
 
 import { OdfArchive } from '../shared/odf/OdfArchive.js';
 import { ODF_NS } from '../shared/odf/namespaces.js';
-import { appendInlineContent, TextStyleRegistry } from './inline.js';
+import { appendInlineContent, FontFaceRegistry, TextStyleRegistry } from './inline.js';
 import { ListDomBuilder, ListStyleRegistry } from './lists.js';
-import { appendTable, registerCellStyle } from './tables.js';
-import { appendTextWithWhitespace, buildMetaXml, buildStylesXml, createContentScaffold } from './package.js';
+import { appendTable, TableStyleRegistry } from './tables.js';
+import { ParagraphStyleRegistry } from './paragraph_styles.js';
+import {
+  appendTextWithWhitespace,
+  buildMetaXml,
+  buildStylesXml,
+  createContentScaffold,
+  deriveSourceNamedStyles,
+} from './package.js';
 import { LossinessCollector, type ConvertDocxToOdtOptions, type ConvertDocxToOdtResult } from './types.js';
 
 /** A heading is structural only when Word's style said so — heuristic headings stay paragraphs. */
 function isStructuralHeading(node: DocumentViewNode): boolean {
   return node.heading?.source === 'word_style' && typeof node.heading.level === 'number';
+}
+
+/** True when the paragraph element sits inside a table cell (any depth up to the body). */
+function isInsideTableCell(p: Element): boolean {
+  let current: Node | null = p.parentNode;
+  while (current && current.nodeType === 1) {
+    const el = current as Element;
+    if (el.namespaceURI === W_NS && el.localName === 'body') return false;
+    if (el.namespaceURI === W_NS && el.localName === 'tc') return true;
+    current = el.parentNode;
+  }
+  return false;
+}
+
+/**
+ * Text-empty body-level paragraphs are never surfaced by the document view (it only yields
+ * bookmarked paragraphs with content) but they are vertical spacing in the source. Correlate
+ * `getParagraphs()` order with surfaced node ids via the bookmarks `normalize()` installed:
+ * each unsurfaced empty body paragraph is preserved before its nearest following surfaced
+ * node (`emptyBefore`) or at the end (`trailingEmpty`); in-table ones stay reported.
+ */
+function planUnsurfacedParagraphs(
+  source: DocxDocument,
+  nodes: DocumentViewNode[],
+  lossiness: LossinessCollector,
+): { emptyBefore: Map<string, number>; trailingEmpty: number } {
+  const surfacedIds = new Set(nodes.map((n) => n.id));
+  const emptyBefore = new Map<string, number>();
+  let pending = 0;
+  for (const p of source.getParagraphs()) {
+    const id = getParagraphBookmarkId(p);
+    if (id && surfacedIds.has(id)) {
+      if (pending > 0) emptyBefore.set(id, pending);
+      pending = 0;
+      continue;
+    }
+    if (getParagraphText(p).trim() !== '') {
+      // Unsurfaced despite content (e.g. exotic containers) — same drop as before, reported.
+      lossiness.add('unsurfaced-paragraphs-dropped', 'non-empty paragraph not surfaced by the document view');
+    } else if (isInsideTableCell(p)) {
+      // Cell-internal spacing needs cell-level positioning the grid emitter does not model.
+      lossiness.add('unsurfaced-table-paragraphs-dropped', 'text-empty paragraph inside a table cell');
+    } else {
+      pending += 1;
+    }
+  }
+  return { emptyBefore, trailingEmpty: pending };
+}
+
+/** The direct `w:tbl` children of `w:body`, in order — the view's `table_index` space. */
+function bodyLevelTables(source: DocxDocument): Element[] {
+  const docXml = source.getDocumentXmlClone();
+  const body = docXml.getElementsByTagNameNS(W_NS, 'body').item(0);
+  if (!body) return [];
+  const tables: Element[] = [];
+  for (let i = 0; i < body.childNodes.length; i++) {
+    const child = body.childNodes[i]!;
+    if (child.nodeType === 1 && (child as Element).localName === 'tbl' && (child as Element).namespaceURI === W_NS) {
+      tables.push(child as Element);
+    }
+  }
+  return tables;
 }
 
 /** Convert a `.docx` buffer to a fresh `.odt` package plus a lossiness report. */
@@ -40,19 +121,15 @@ export async function convertDocxToOdt(
   const numbering = source.getNumberingModel();
 
   const lossiness = new LossinessCollector();
-  // The view only surfaces bookmarked paragraphs; text-empty paragraphs that anchor nothing
-  // stay unsurfaced and therefore drop out of the conversion. Report the count, not silence.
-  const totalParagraphs = source.getParagraphs().length;
-  if (totalParagraphs > nodes.length) {
-    lossiness.add(
-      'unsurfaced-paragraphs-dropped',
-      `${totalParagraphs - nodes.length} text-empty paragraph(s) not surfaced by the document view`,
-    );
-  }
-  const { doc, automaticStyles, body } = createContentScaffold();
-  const textStyles = new TextStyleRegistry(doc, automaticStyles);
+  const { emptyBefore, trailingEmpty } = planUnsurfacedParagraphs(source, nodes, lossiness);
+  const sourceTables = bodyLevelTables(source);
+
+  const { doc, fontFaceDecls, automaticStyles, body } = createContentScaffold();
+  const fontFaces = new FontFaceRegistry(doc, fontFaceDecls);
+  const textStyles = new TextStyleRegistry(doc, automaticStyles, fontFaces);
+  const paragraphStyles = new ParagraphStyleRegistry(doc, automaticStyles);
   const listStyles = new ListStyleRegistry(doc, automaticStyles, numbering);
-  const cellStyleName = registerCellStyle(doc, automaticStyles);
+  const tableStyles = new TableStyleRegistry(doc, automaticStyles);
 
   const fillParagraph = (p: Element, node: DocumentViewNode): void => {
     appendInlineContent(doc, p, node.tagged_text, textStyles, lossiness);
@@ -63,6 +140,9 @@ export async function convertDocxToOdt(
     body.appendChild(p);
     return p;
   };
+  const appendEmptyParagraphs = (count: number): void => {
+    for (let n = 0; n < count; n++) newParagraph('Standard');
+  };
 
   let listBuilder: ListDomBuilder | null = null;
   let tableCount = 0;
@@ -70,10 +150,18 @@ export async function convertDocxToOdt(
   for (let i = 0; i < nodes.length; i++) {
     const node = nodes[i]!;
 
+    // ── Preserved vertical spacing: unsurfaced empty body paragraphs before this node ──
+    const emptyCount = emptyBefore.get(node.id) ?? 0;
+    if (emptyCount > 0) {
+      listBuilder = null;
+      appendEmptyParagraphs(emptyCount);
+    }
+
     // ── Tables: consume the whole run of same-table_id nodes at once ──
     if (node.table_context) {
       listBuilder = null;
       const tableId = node.table_context.table_id;
+      const sourceTbl = sourceTables[node.table_context.table_index] ?? null;
       const group: DocumentViewNode[] = [];
       while (i < nodes.length && nodes[i]!.table_context?.table_id === tableId) {
         group.push(nodes[i]!);
@@ -81,7 +169,17 @@ export async function convertDocxToOdt(
       }
       i--; // for-loop re-increments
       tableCount += 1;
-      appendTable(doc, body, group, tableCount, cellStyleName, fillParagraph, lossiness);
+      appendTable(
+        doc,
+        body,
+        group,
+        tableCount,
+        sourceTbl,
+        tableStyles,
+        fillParagraph,
+        (n) => paragraphStyles.styleFor('Standard', n),
+        lossiness,
+      );
       continue;
     }
 
@@ -91,7 +189,7 @@ export async function convertDocxToOdt(
       const level = Math.min(6, Math.max(1, node.heading!.level as number));
       const h = doc.createElementNS(ODF_NS.TEXT, 'text:h');
       h.setAttributeNS(ODF_NS.TEXT, 'text:outline-level', String(level));
-      h.setAttributeNS(ODF_NS.TEXT, 'text:style-name', `Heading_20_${level}`);
+      h.setAttributeNS(ODF_NS.TEXT, 'text:style-name', paragraphStyles.styleFor(`Heading_20_${level}`, node));
       body.appendChild(h);
       fillParagraph(h, node);
       continue;
@@ -106,7 +204,13 @@ export async function convertDocxToOdt(
         const bulletHint = listStyles.isBulletLevel(numId, node.numbering.ilvl);
         const styleName = listStyles.styleFor(numId, bulletHint);
         if (!listBuilder) listBuilder = new ListDomBuilder(doc, body);
-        const p = listBuilder.item(node.list_metadata.list_level, styleName);
+        // Alignment only: the nested text:list supplies indentation, and re-applying the
+        // source margins would double-indent the item.
+        const p = listBuilder.item(
+          node.list_metadata.list_level,
+          styleName,
+          paragraphStyles.styleFor('Standard', node, { indents: false }),
+        );
         fillParagraph(p, node);
         continue;
       }
@@ -114,7 +218,7 @@ export async function convertDocxToOdt(
       //    Deliberate divergence from the HTML serializer's <ul><li> wrapping — an ODF list
       //    renderer would print its own number next to the legal label. ──
       listBuilder = null;
-      const p = newParagraph('Standard');
+      const p = newParagraph(paragraphStyles.styleFor('Standard', node));
       const label = node.list_metadata.label_string.trim();
       if (label) appendTextWithWhitespace(doc, p, `${label} `);
       fillParagraph(p, node);
@@ -123,12 +227,14 @@ export async function convertDocxToOdt(
 
     // ── Normal paragraphs (heuristic headings land here; empty paragraphs are kept) ──
     listBuilder = null;
-    fillParagraph(newParagraph('Standard'), node);
+    fillParagraph(newParagraph(paragraphStyles.styleFor('Standard', node)), node);
   }
+
+  appendEmptyParagraphs(trailingEmpty);
 
   const archive = OdfArchive.create({
     contentXml: serializeXml(doc),
-    stylesXml: buildStylesXml(),
+    stylesXml: buildStylesXml(deriveSourceNamedStyles(source.getStylesModel())),
     metaXml: buildMetaXml(options?.metadata),
   });
   const odt = await archive.save();

--- a/packages/odf-core/src/convert/inline.ts
+++ b/packages/odf-core/src/convert/inline.ts
@@ -4,22 +4,78 @@
  *
  * The token grammar is owned by docx-core (`tokenizeToonInline`, the same primitive the
  * markdown/HTML serializers consume) so this module never re-derives it. Supported wraps are
- * bold / italic / underline / highlight; `<font …>` (full-mode color/size/face) is
- * recognized-and-dropped with a lossiness entry — richer style mapping is deferred (#331
- * phase 3). Unsafe hyperlink schemes degrade to plain text via the shared `isSafeHref`.
+ * bold / italic / underline / highlight (with its full-mode source color) and the full-mode
+ * `<font color size face>` tag, mapped to `fo:color` / `fo:font-size` / `style:font-name`
+ * automatic styles (#406 phase 3). Unsafe hyperlink schemes degrade to plain text via the
+ * shared `isSafeHref`.
  */
 
 import { isSafeHref, tokenizeToonInline } from '@usejunior/docx-core';
 
 import { ODF_NS } from '../shared/odf/namespaces.js';
-import { appendTextWithWhitespace } from './package.js';
+import { appendTextWithWhitespace, quoteFontFamily } from './package.js';
 import type { LossinessCollector } from './types.js';
+
+/**
+ * OOXML `ST_HighlightColor` enum values (`w:highlight`) → the hex Word renders them as.
+ * The TOON highlight tag carries the source enum value in full mode; anything unknown
+ * degrades to yellow with a lossiness entry rather than dropping the highlight.
+ */
+const HIGHLIGHT_COLOR_HEX: Record<string, string> = {
+  yellow: '#ffff00',
+  green: '#00ff00',
+  cyan: '#00ffff',
+  magenta: '#ff00ff',
+  blue: '#0000ff',
+  red: '#ff0000',
+  darkBlue: '#00008b',
+  darkCyan: '#008b8b',
+  darkGreen: '#006400',
+  darkMagenta: '#8b008b',
+  darkRed: '#8b0000',
+  darkYellow: '#808000',
+  darkGray: '#a9a9a9',
+  lightGray: '#d3d3d3',
+  black: '#000000',
+  white: '#ffffff',
+};
+
+const DEFAULT_HIGHLIGHT_HEX = HIGHLIGHT_COLOR_HEX['yellow']!;
 
 interface InlineFormats {
   bold: boolean;
   italic: boolean;
   underline: boolean;
-  highlight: boolean;
+  /** ODF `fo:background-color` hex (e.g. `#00ff00`), or null when unhighlighted. */
+  highlight: string | null;
+  /** ODF `fo:color` hex (e.g. `#ff0000`), or null for the default color. */
+  fontColor: string | null;
+  /** Font size in points as carried by the TOON tag (may be fractional), or null. */
+  fontSizePt: number | null;
+  /** Font face name, or null for the default face. */
+  fontFace: string | null;
+}
+
+/**
+ * Deduped `office:font-face-decls` registry: one `style:font-face` per distinct face name
+ * used anywhere in the document (ODF resolves `style:font-name` against declared faces).
+ */
+export class FontFaceRegistry {
+  private declared = new Set<string>();
+
+  constructor(
+    private readonly doc: Document,
+    private readonly container: Element,
+  ) {}
+
+  ensure(face: string): void {
+    if (this.declared.has(face)) return;
+    this.declared.add(face);
+    const decl = this.doc.createElementNS(ODF_NS.STYLE, 'style:font-face');
+    decl.setAttributeNS(ODF_NS.STYLE, 'style:name', face);
+    decl.setAttributeNS(ODF_NS.SVG, 'svg:font-family', quoteFontFamily(face));
+    this.container.appendChild(decl);
+  }
 }
 
 /**
@@ -32,6 +88,7 @@ export class TextStyleRegistry {
   constructor(
     private readonly doc: Document,
     private readonly container: Element,
+    private readonly fontFaces: FontFaceRegistry,
   ) {}
 
   styleFor(formats: InlineFormats): string {
@@ -39,8 +96,11 @@ export class TextStyleRegistry {
       formats.bold ? 'b' : '',
       formats.italic ? 'i' : '',
       formats.underline ? 'u' : '',
-      formats.highlight ? 'h' : '',
-    ].join('');
+      formats.highlight ?? '',
+      formats.fontColor ?? '',
+      formats.fontSizePt ?? '',
+      formats.fontFace ?? '',
+    ].join('|');
     const existing = this.byKey.get(key);
     if (existing) return existing;
 
@@ -56,7 +116,13 @@ export class TextStyleRegistry {
       props.setAttributeNS(ODF_NS.STYLE, 'style:text-underline-width', 'auto');
       props.setAttributeNS(ODF_NS.STYLE, 'style:text-underline-color', 'font-color');
     }
-    if (formats.highlight) props.setAttributeNS(ODF_NS.FO, 'fo:background-color', '#ffff00');
+    if (formats.highlight) props.setAttributeNS(ODF_NS.FO, 'fo:background-color', formats.highlight);
+    if (formats.fontColor) props.setAttributeNS(ODF_NS.FO, 'fo:color', formats.fontColor);
+    if (formats.fontSizePt !== null) props.setAttributeNS(ODF_NS.FO, 'fo:font-size', `${formats.fontSizePt}pt`);
+    if (formats.fontFace) {
+      this.fontFaces.ensure(formats.fontFace);
+      props.setAttributeNS(ODF_NS.STYLE, 'style:font-name', formats.fontFace);
+    }
     style.appendChild(props);
     this.container.appendChild(style);
     this.byKey.set(key, name);
@@ -73,6 +139,22 @@ function unescapeAttributeValue(value: string): string {
     .replaceAll('&amp;', '&');
 }
 
+function attributeValue(tag: string, name: string): string | null {
+  const match = new RegExp(`\\b${name}="([^"]*)"`).exec(tag);
+  return match ? unescapeAttributeValue(match[1]!) : null;
+}
+
+/** Map a TOON highlight open tag to its ODF background hex. */
+function highlightHexFor(tag: string, lossiness: LossinessCollector): string {
+  const val = attributeValue(tag, 'color');
+  // Compact mode emits the value-less form; the historical normalization to yellow applies.
+  if (val === null) return DEFAULT_HIGHLIGHT_HEX;
+  const hex = HIGHLIGHT_COLOR_HEX[val];
+  if (hex) return hex;
+  lossiness.add('unknown-highlight-color', val);
+  return DEFAULT_HIGHLIGHT_HEX;
+}
+
 /**
  * Append one `tagged_text` string's content to `parent` (a `text:p`/`text:h` or table-cell
  * paragraph), wrapping formatted runs in `text:span` and hyperlinks in `text:a`.
@@ -84,20 +166,38 @@ export function appendInlineContent(
   styles: TextStyleRegistry,
   lossiness: LossinessCollector,
 ): void {
-  const formats: InlineFormats = { bold: false, italic: false, underline: false, highlight: false };
+  const formats: InlineFormats = {
+    bold: false,
+    italic: false,
+    underline: false,
+    highlight: null,
+    fontColor: null,
+    fontSizePt: null,
+    fontFace: null,
+  };
   let openAnchor: Element | null = null;
   // The currently open span and the format key it was created for: consecutive text tokens with
   // an unchanged format set share one span instead of fragmenting into adjacent twins.
   let openSpan: { el: Element; key: string } | null = null;
 
   const formatKey = (): string =>
-    `${formats.bold ? 'b' : ''}${formats.italic ? 'i' : ''}${formats.underline ? 'u' : ''}${formats.highlight ? 'h' : ''}`;
+    [
+      formats.bold ? 'b' : '',
+      formats.italic ? 'i' : '',
+      formats.underline ? 'u' : '',
+      formats.highlight ?? '',
+      formats.fontColor ?? '',
+      formats.fontSizePt ?? '',
+      formats.fontFace ?? '',
+    ].join('|');
+
+  const EMPTY_KEY = '||||||';
 
   for (const token of tokenizeToonInline(taggedText)) {
     if (token.kind === 'text') {
       const container = openAnchor ?? parent;
       const key = formatKey();
-      if (key === '') {
+      if (key === EMPTY_KEY) {
         openSpan = null;
         appendTextWithWhitespace(doc, container, token.value);
         continue;
@@ -119,8 +219,10 @@ export function appendInlineContent(
     else if (tag === '</i>') { formats.italic = false; openSpan = null; }
     else if (tag === '<u>') { formats.underline = true; openSpan = null; }
     else if (tag === '</u>') { formats.underline = false; openSpan = null; }
-    else if (tag === '<highlight>') { formats.highlight = true; openSpan = null; }
-    else if (tag === '</highlight>') { formats.highlight = false; openSpan = null; }
+    else if (tag === '<highlight>' || tag.startsWith('<highlight ')) {
+      formats.highlight = highlightHexFor(tag, lossiness);
+      openSpan = null;
+    } else if (tag === '</highlight>') { formats.highlight = null; openSpan = null; }
     else if (tag.startsWith('<a ')) {
       const escapedHref = /href="([^"]*)"/.exec(tag)?.[1] ?? '';
       // The TOON attribute value is escaped by emitFormattingTags; setAttributeNS escapes
@@ -141,8 +243,30 @@ export function appendInlineContent(
       openAnchor = null;
       openSpan = null;
     } else if (tag.startsWith('<font ')) {
-      lossiness.add('font-formatting-dropped', tag);
+      // Full-mode font runs: color is the raw w:color hex (no '#'), size is points, face is
+      // the font name. A malformed color degrades to the default color, reported.
+      const color = attributeValue(tag, 'color');
+      if (color !== null) {
+        if (/^[0-9A-Fa-f]{6}$/.test(color)) {
+          formats.fontColor = `#${color.toLowerCase()}`;
+        } else {
+          lossiness.add('unmappable-font-color', color);
+          formats.fontColor = null;
+        }
+      } else {
+        formats.fontColor = null;
+      }
+      const size = attributeValue(tag, 'size');
+      const sizePt = size !== null ? Number(size) : NaN;
+      formats.fontSizePt = Number.isFinite(sizePt) && sizePt > 0 ? sizePt : null;
+      const face = attributeValue(tag, 'face');
+      formats.fontFace = face !== null && face.trim() !== '' ? face : null;
+      openSpan = null;
+    } else if (tag === '</font>') {
+      formats.fontColor = null;
+      formats.fontSizePt = null;
+      formats.fontFace = null;
+      openSpan = null;
     }
-    // `</font>` needs no action: the open tag never changed format state.
   }
 }

--- a/packages/odf-core/src/convert/lists.ts
+++ b/packages/odf-core/src/convert/lists.ts
@@ -105,7 +105,7 @@ export class ListDomBuilder {
     private readonly parent: Element,
   ) {}
 
-  item(level: number, styleName: string): Element {
+  item(level: number, styleName: string, paragraphStyleName = 'Standard'): Element {
     const lvl = Math.max(0, level);
     while (this.stack.length > 0 && this.stack[this.stack.length - 1]!.level > lvl) {
       this.stack.pop();
@@ -133,7 +133,7 @@ export class ListDomBuilder {
     const item = this.doc.createElementNS(ODF_NS.TEXT, 'text:list-item');
     top!.list.appendChild(item);
     const p = this.doc.createElementNS(ODF_NS.TEXT, 'text:p');
-    p.setAttributeNS(ODF_NS.TEXT, 'text:style-name', 'Standard');
+    p.setAttributeNS(ODF_NS.TEXT, 'text:style-name', paragraphStyleName);
     item.appendChild(p);
     return p;
   }

--- a/packages/odf-core/src/convert/package.ts
+++ b/packages/odf-core/src/convert/package.ts
@@ -6,11 +6,16 @@
  * tolerates its absence, but strict ODF validators reject the package without it.
  */
 
-import { parseXml } from '@usejunior/docx-core';
+import { parseXml, extractStyleRunFormatting, type StyleRunFormatting, type StylesModel } from '@usejunior/docx-core';
 
 import { ODF_NS } from '../shared/odf/namespaces.js';
 
-/** Heading font sizes (pt) for `Heading_20_1` … `Heading_20_6`. */
+/** Quote a font family for `svg:font-family` when it contains non-name characters (spaces). */
+export function quoteFontFamily(face: string): string {
+  return /^[A-Za-z0-9-]+$/.test(face) ? face : `'${face.replaceAll("'", '')}'`;
+}
+
+/** Template heading font sizes (pt) for `Heading_20_1` … `Heading_20_6` (source may override). */
 const HEADING_SIZES_PT = [18, 16, 14, 13, 12, 11] as const;
 
 const CONTENT_SKELETON = [
@@ -22,15 +27,18 @@ const CONTENT_SKELETON = [
   `  xmlns:style="${ODF_NS.STYLE}"`,
   `  xmlns:fo="${ODF_NS.FO}"`,
   `  xmlns:xlink="${ODF_NS.XLINK}"`,
+  `  xmlns:svg="${ODF_NS.SVG}"`,
   '  office:version="1.3">',
+  '  <office:font-face-decls/>',
   '  <office:automatic-styles/>',
   '  <office:body><office:text/></office:body>',
   '</office:document-content>',
 ].join('\n');
 
-/** The skeleton `content.xml` DOM plus the two insertion points the converter fills. */
+/** The skeleton `content.xml` DOM plus the insertion points the converter fills. */
 export interface ContentScaffold {
   doc: Document;
+  fontFaceDecls: Element;
   automaticStyles: Element;
   body: Element;
 }
@@ -38,36 +46,126 @@ export interface ContentScaffold {
 /** Parse the empty content.xml skeleton and hand back its insertion points. */
 export function createContentScaffold(): ContentScaffold {
   const doc = parseXml(CONTENT_SKELETON);
+  const fontFaceDecls = doc.getElementsByTagNameNS(ODF_NS.OFFICE, 'font-face-decls')[0] as Element;
   const automaticStyles = doc.getElementsByTagNameNS(ODF_NS.OFFICE, 'automatic-styles')[0] as Element;
   const body = doc.getElementsByTagNameNS(ODF_NS.OFFICE, 'text')[0] as Element;
-  return { doc, automaticStyles, body };
+  return { doc, fontFaceDecls, automaticStyles, body };
+}
+
+/** Source-derived named-style formatting feeding {@link buildStylesXml}. */
+export interface SourceNamedStyles {
+  /** Resolved run formatting per heading level 1..6 (absent levels keep template defaults). */
+  headings: Map<number, StyleRunFormatting>;
+  /** Resolved run formatting of the source `Normal` style, or null when undefined. */
+  normal: StyleRunFormatting | null;
+}
+
+/**
+ * Resolve the source styles the converted `styles.xml` is seeded from: `Heading1..6` (matched
+ * by styleId or by the canonical `heading N` style name) and `Normal`. Properties a chain
+ * never specifies stay `null` so the template defaults survive.
+ */
+export function deriveSourceNamedStyles(styles: StylesModel): SourceNamedStyles {
+  const headingIdByLevel = new Map<number, string>();
+  let normalId: string | null = null;
+  for (const [id, def] of styles.byId) {
+    const byId = /^Heading([1-6])$/.exec(id);
+    const byName = /^heading ([1-6])$/i.exec(def.name);
+    const level = byId ? Number(byId[1]) : byName ? Number(byName[1]) : null;
+    if (level !== null && !headingIdByLevel.has(level)) headingIdByLevel.set(level, id);
+    if (normalId === null && (id === 'Normal' || /^normal$/i.test(def.name))) normalId = id;
+  }
+  const headings = new Map<number, StyleRunFormatting>();
+  for (const [level, id] of headingIdByLevel) {
+    headings.set(level, extractStyleRunFormatting(styles, id));
+  }
+  return { headings, normal: normalId ? extractStyleRunFormatting(styles, normalId) : null };
+}
+
+function escapeXmlAttr(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/**
+ * `style:text-properties` attributes for a source-derived named style. Only properties the
+ * source chain specifies are emitted; `null` lets the template's own defaults (or the parent
+ * style) win. `collectFace` records faces needing a `style:font-face` declaration.
+ */
+function textPropertiesAttrs(fmt: StyleRunFormatting | null, collectFace: (face: string) => void): string[] {
+  if (!fmt) return [];
+  const attrs: string[] = [];
+  if (fmt.fontSizePt !== null && fmt.fontSizePt > 0) attrs.push(`fo:font-size="${fmt.fontSizePt}pt"`);
+  if (fmt.bold !== null) attrs.push(`fo:font-weight="${fmt.bold ? 'bold' : 'normal'}"`);
+  if (fmt.italic !== null) attrs.push(`fo:font-style="${fmt.italic ? 'italic' : 'normal'}"`);
+  if (fmt.colorHex !== null && /^[0-9A-Fa-f]{6}$/.test(fmt.colorHex)) {
+    attrs.push(`fo:color="#${fmt.colorHex.toLowerCase()}"`);
+  }
+  if (fmt.fontName !== null && fmt.fontName.trim() !== '') {
+    collectFace(fmt.fontName);
+    attrs.push(`style:font-name="${escapeXmlAttr(fmt.fontName)}"`);
+  }
+  return attrs;
 }
 
 /**
  * Seed `styles.xml`: `Standard`, a bold `Heading` base, `Heading_20_1..6` (descending sizes,
- * `style:default-outline-level`), and `Text_20_body`. Run-level formatting lives in content.xml
- * automatic styles instead — richer named-style mapping is deferred (issue #331 phase 3).
+ * `style:default-outline-level`), and `Text_20_body`. When `source` carries the document's
+ * resolved style-chain formatting, heading sizes/weights/colors/fonts and the `Standard` body
+ * font come from the source instead of the fixed template (#406 phase 3); properties the
+ * source never specifies keep the template defaults.
  */
-export function buildStylesXml(): string {
-  const headingStyles = HEADING_SIZES_PT.map((size, i) => {
+export function buildStylesXml(source?: SourceNamedStyles): string {
+  const faces = new Set<string>();
+  const collectFace = (face: string): void => { faces.add(face); };
+
+  const headingStyles = HEADING_SIZES_PT.map((templateSize, i) => {
     const level = i + 1;
+    const sourceAttrs = textPropertiesAttrs(source?.headings.get(level) ?? null, collectFace);
+    const attrs = sourceAttrs.some((a) => a.startsWith('fo:font-size='))
+      ? sourceAttrs
+      : [`fo:font-size="${templateSize}pt"`, ...sourceAttrs];
     return [
       `    <style:style style:name="Heading_20_${level}" style:display-name="Heading ${level}"`,
       `      style:family="paragraph" style:parent-style-name="Heading" style:next-style-name="Text_20_body"`,
       `      style:default-outline-level="${level}" style:class="text">`,
-      `      <style:text-properties fo:font-size="${size}pt"/>`,
+      `      <style:text-properties ${attrs.join(' ')}/>`,
       '    </style:style>',
     ].join('\n');
   });
+
+  const standardAttrs = textPropertiesAttrs(source?.normal ?? null, collectFace);
+  const standardStyle = standardAttrs.length > 0
+    ? [
+        '    <style:style style:name="Standard" style:family="paragraph" style:class="text">',
+        `      <style:text-properties ${standardAttrs.join(' ')}/>`,
+        '    </style:style>',
+      ].join('\n')
+    : '    <style:style style:name="Standard" style:family="paragraph" style:class="text"/>';
+
+  const fontFaceDecls = faces.size > 0
+    ? [
+        '  <office:font-face-decls>',
+        ...Array.from(faces, (face) =>
+          `    <style:font-face style:name="${escapeXmlAttr(face)}" svg:font-family="${escapeXmlAttr(quoteFontFamily(face))}"/>`),
+        '  </office:font-face-decls>',
+      ]
+    : [];
+
   return [
     '<?xml version="1.0" encoding="UTF-8"?>',
     '<office:document-styles',
     `  xmlns:office="${ODF_NS.OFFICE}"`,
     `  xmlns:style="${ODF_NS.STYLE}"`,
     `  xmlns:fo="${ODF_NS.FO}"`,
+    `  xmlns:svg="${ODF_NS.SVG}"`,
     '  office:version="1.3">',
+    ...fontFaceDecls,
     '  <office:styles>',
-    '    <style:style style:name="Standard" style:family="paragraph" style:class="text"/>',
+    standardStyle,
     '    <style:style style:name="Text_20_body" style:display-name="Text body"',
     '      style:family="paragraph" style:parent-style-name="Standard" style:class="text"/>',
     '    <style:style style:name="Heading" style:family="paragraph"',

--- a/packages/odf-core/src/convert/paragraph_styles.ts
+++ b/packages/odf-core/src/convert/paragraph_styles.ts
@@ -1,0 +1,65 @@
+/**
+ * Paragraph-level automatic styles for the DOCX → ODT converter: the view's
+ * `paragraph_alignment` + `paragraph_indents_pt` → deduped `P<n>` styles carrying
+ * `fo:text-align` / `fo:margin-left` / `fo:text-indent` (#406 phase 3).
+ *
+ * Styles are only created when something deviates from the named parent's defaults
+ * (non-LEFT alignment or a non-zero indent); plain paragraphs keep the parent name directly.
+ * List items request alignment only — `text:list` nesting already supplies indentation, and
+ * re-applying `fo:margin-left` would double-indent.
+ */
+
+import type { DocumentViewNode } from '@usejunior/docx-core';
+
+import { ODF_NS } from '../shared/odf/namespaces.js';
+
+/** OOXML `ParagraphAlignment` → ODF `fo:text-align`. LEFT is the default and emits nothing. */
+const TEXT_ALIGN_MAP: Record<string, string> = {
+  CENTER: 'center',
+  RIGHT: 'end',
+  JUSTIFY: 'justify',
+};
+
+/** Format points for style attributes: round to 2 decimals, trim trailing zeros. */
+function fmtPt(v: number): string {
+  return `${Number(v.toFixed(2))}pt`;
+}
+
+export class ParagraphStyleRegistry {
+  private byKey = new Map<string, string>();
+
+  constructor(
+    private readonly doc: Document,
+    private readonly container: Element,
+  ) {}
+
+  /**
+   * Style name for a paragraph with `parentStyle` and the node's alignment/indents.
+   * Returns `parentStyle` itself when nothing deviates.
+   */
+  styleFor(parentStyle: string, node: DocumentViewNode, opts?: { indents?: boolean }): string {
+    const includeIndents = opts?.indents ?? true;
+    const align = TEXT_ALIGN_MAP[node.paragraph_alignment] ?? null;
+    const left = includeIndents ? node.paragraph_indents_pt.left : 0;
+    const firstLine = includeIndents ? node.paragraph_indents_pt.first_line : 0;
+    if (align === null && left === 0 && firstLine === 0) return parentStyle;
+
+    const key = `${parentStyle}|${align ?? ''}|${left}|${firstLine}`;
+    const existing = this.byKey.get(key);
+    if (existing) return existing;
+
+    const name = `P${this.byKey.size + 1}`;
+    const style = this.doc.createElementNS(ODF_NS.STYLE, 'style:style');
+    style.setAttributeNS(ODF_NS.STYLE, 'style:name', name);
+    style.setAttributeNS(ODF_NS.STYLE, 'style:family', 'paragraph');
+    style.setAttributeNS(ODF_NS.STYLE, 'style:parent-style-name', parentStyle);
+    const props = this.doc.createElementNS(ODF_NS.STYLE, 'style:paragraph-properties');
+    if (align !== null) props.setAttributeNS(ODF_NS.FO, 'fo:text-align', align);
+    if (left !== 0) props.setAttributeNS(ODF_NS.FO, 'fo:margin-left', fmtPt(left));
+    if (firstLine !== 0) props.setAttributeNS(ODF_NS.FO, 'fo:text-indent', fmtPt(firstLine));
+    style.appendChild(props);
+    this.container.appendChild(style);
+    this.byKey.set(key, name);
+    return name;
+  }
+}

--- a/packages/odf-core/src/convert/tables.ts
+++ b/packages/odf-core/src/convert/tables.ts
@@ -4,42 +4,149 @@
  *
  * Lossy by design, mirroring the HTML serializer's `renderTable`: the view model discards
  * `gridSpan`/`vMerge`, so merged cells are indistinguishable from genuinely empty grid
- * positions — gaps are filled with empty cells (recorded as `table-grid-gaps-filled`), and
- * every cell shares one thin-bordered automatic style (the view model carries no border
- * info; most Word tables are bordered).
+ * positions — gaps are filled with empty cells (recorded as `table-grid-gaps-filled`).
+ * Borders and column widths come from the raw source `w:tbl` (#406 phase 3): an explicit
+ * `w:tblBorders` is honored uniformly per table (including explicitly borderless tables) and
+ * `w:tblGrid` widths become `table:table-column` styles. Tables without explicit borders keep
+ * the 0.5pt default (most Word tables are bordered via their table style, whose `w:tblPr`
+ * the styles model does not carry). Per-cell `w:tcBorders` overrides are out of scope.
  */
 
-import type { DocumentViewNode } from '@usejunior/docx-core';
+import { W_NS, type DocumentViewNode } from '@usejunior/docx-core';
 
 import { ODF_NS } from '../shared/odf/namespaces.js';
 import type { LossinessCollector } from './types.js';
 
-const CELL_STYLE_NAME = 'ConvCell';
+/** The `fo:border` applied when the source declares no explicit `w:tblBorders`. */
+const DEFAULT_BORDER_SPEC = '0.5pt solid #000000';
 
-/** Register the shared bordered table-cell automatic style (call once per document). */
-export function registerCellStyle(doc: Document, automaticStyles: Element): string {
-  const style = doc.createElementNS(ODF_NS.STYLE, 'style:style');
-  style.setAttributeNS(ODF_NS.STYLE, 'style:name', CELL_STYLE_NAME);
-  style.setAttributeNS(ODF_NS.STYLE, 'style:family', 'table-cell');
-  const props = doc.createElementNS(ODF_NS.STYLE, 'style:table-cell-properties');
-  props.setAttributeNS(ODF_NS.FO, 'fo:border', '0.5pt solid #000000');
-  props.setAttributeNS(ODF_NS.FO, 'fo:padding', '0.0382in');
-  style.appendChild(props);
-  automaticStyles.appendChild(style);
-  return CELL_STYLE_NAME;
+/** OOXML `ST_Border` → ODF border line style (anything unmapped degrades to solid). */
+const BORDER_STYLE_MAP: Record<string, string> = {
+  single: 'solid',
+  double: 'double',
+  dotted: 'dotted',
+  dashed: 'dashed',
+};
+
+function firstChildNS(parent: Element | null, localName: string): Element | null {
+  if (!parent) return null;
+  for (let i = 0; i < parent.childNodes.length; i++) {
+    const child = parent.childNodes[i]!;
+    if (child.nodeType === 1 && (child as Element).localName === localName && (child as Element).namespaceURI === W_NS) {
+      return child as Element;
+    }
+  }
+  return null;
+}
+
+function wAttr(el: Element, localName: string): string | null {
+  return el.getAttributeNS(W_NS, localName) || el.getAttribute(`w:${localName}`) || null;
+}
+
+/**
+ * Resolve the uniform `fo:border` for a table from its explicit `w:tblBorders`, preferring
+ * inside edges (what most cells show). Explicitly border-free tables return `'none'`; tables
+ * without a `w:tblBorders` at all return the bordered default.
+ */
+export function resolveTableBorderSpec(tbl: Element | null): string {
+  const tblPr = firstChildNS(tbl, 'tblPr');
+  const borders = firstChildNS(tblPr, 'tblBorders');
+  if (!borders) return DEFAULT_BORDER_SPEC;
+
+  const candidates = ['insideH', 'insideV', 'top', 'bottom', 'left', 'right']
+    .map((edge) => firstChildNS(borders, edge))
+    .filter((el): el is Element => el !== null);
+  if (candidates.length === 0) return DEFAULT_BORDER_SPEC;
+
+  for (const edge of candidates) {
+    const val = wAttr(edge, 'val') ?? 'none';
+    if (val === 'none' || val === 'nil') continue;
+    // w:sz is eighths of a point; absent → Word's hairline default (≈0.5pt).
+    const szRaw = Number(wAttr(edge, 'sz') ?? NaN);
+    const widthPt = Number.isFinite(szRaw) && szRaw > 0 ? Number((szRaw / 8).toFixed(2)) : 0.5;
+    const colorRaw = wAttr(edge, 'color');
+    const color = colorRaw && /^[0-9A-Fa-f]{6}$/.test(colorRaw) ? `#${colorRaw.toLowerCase()}` : '#000000';
+    return `${widthPt}pt ${BORDER_STYLE_MAP[val] ?? 'solid'} ${color}`;
+  }
+  return 'none'; // every declared edge was explicitly none/nil
+}
+
+/** Column widths in points from `w:tblGrid/w:gridCol` (`w:w` is twips); empty when absent. */
+export function readGridColWidthsPt(tbl: Element | null): number[] {
+  const grid = firstChildNS(tbl, 'tblGrid');
+  if (!grid) return [];
+  const widths: number[] = [];
+  for (let i = 0; i < grid.childNodes.length; i++) {
+    const child = grid.childNodes[i]!;
+    if (child.nodeType !== 1 || (child as Element).localName !== 'gridCol') continue;
+    const w = Number(wAttr(child as Element, 'w') ?? NaN);
+    if (!Number.isFinite(w) || w <= 0) return []; // a single unusable column invalidates the grid
+    widths.push(w / 20);
+  }
+  return widths;
+}
+
+/**
+ * Deduped automatic styles for table emission: one `table-cell` style per distinct border
+ * spec and one `table-column` style per distinct width, shared across tables.
+ */
+export class TableStyleRegistry {
+  private cellByBorder = new Map<string, string>();
+  private columnByWidth = new Map<string, string>();
+
+  constructor(
+    private readonly doc: Document,
+    private readonly container: Element,
+  ) {}
+
+  cellStyleFor(borderSpec: string): string {
+    const existing = this.cellByBorder.get(borderSpec);
+    if (existing) return existing;
+    const name = `ConvCell${this.cellByBorder.size + 1}`;
+    const style = this.doc.createElementNS(ODF_NS.STYLE, 'style:style');
+    style.setAttributeNS(ODF_NS.STYLE, 'style:name', name);
+    style.setAttributeNS(ODF_NS.STYLE, 'style:family', 'table-cell');
+    const props = this.doc.createElementNS(ODF_NS.STYLE, 'style:table-cell-properties');
+    props.setAttributeNS(ODF_NS.FO, 'fo:border', borderSpec);
+    props.setAttributeNS(ODF_NS.FO, 'fo:padding', '0.0382in');
+    style.appendChild(props);
+    this.container.appendChild(style);
+    this.cellByBorder.set(borderSpec, name);
+    return name;
+  }
+
+  columnStyleFor(widthPt: number): string {
+    const key = String(widthPt);
+    const existing = this.columnByWidth.get(key);
+    if (existing) return existing;
+    const name = `ConvCol${this.columnByWidth.size + 1}`;
+    const style = this.doc.createElementNS(ODF_NS.STYLE, 'style:style');
+    style.setAttributeNS(ODF_NS.STYLE, 'style:name', name);
+    style.setAttributeNS(ODF_NS.STYLE, 'style:family', 'table-column');
+    const props = this.doc.createElementNS(ODF_NS.STYLE, 'style:table-column-properties');
+    props.setAttributeNS(ODF_NS.STYLE, 'style:column-width', `${Number(widthPt.toFixed(2))}pt`);
+    style.appendChild(props);
+    this.container.appendChild(style);
+    this.columnByWidth.set(key, name);
+    return name;
+  }
 }
 
 /**
  * Append the table built from `group` to `body`. Cell paragraph content is delegated to
- * `fillParagraph` (the orchestrator's inline emitter) so this module stays cycle-free.
+ * `fillParagraph` (the orchestrator's inline emitter) and cell paragraph styles to
+ * `paragraphStyleFor` so this module stays cycle-free. `sourceTbl` is the raw `w:tbl` this
+ * group was derived from (null when unavailable — defaults apply).
  */
 export function appendTable(
   doc: Document,
   body: Element,
   group: DocumentViewNode[],
   tableNumber: number,
-  cellStyleName: string,
+  sourceTbl: Element | null,
+  tableStyles: TableStyleRegistry,
   fillParagraph: (p: Element, node: DocumentViewNode) => void,
+  paragraphStyleFor: (node: DocumentViewNode) => string,
   lossiness: LossinessCollector,
 ): void {
   let totalCols = 0;
@@ -69,11 +176,24 @@ export function appendTable(
   rowOrder.sort((a, b) => a - b);
   if (rowOrder.length === 0) return;
 
+  const cellStyleName = tableStyles.cellStyleFor(resolveTableBorderSpec(sourceTbl));
+
   const table = doc.createElementNS(ODF_NS.TABLE, 'table:table');
   table.setAttributeNS(ODF_NS.TABLE, 'table:name', `Table${tableNumber}`);
-  const columns = doc.createElementNS(ODF_NS.TABLE, 'table:table-column');
-  columns.setAttributeNS(ODF_NS.TABLE, 'table:number-columns-repeated', String(totalCols));
-  table.appendChild(columns);
+  // Source grid widths drive per-column styles; a grid that does not match the view's
+  // column count (gridSpan merges can desync them) falls back to unstyled repeated columns.
+  const gridWidths = readGridColWidthsPt(sourceTbl);
+  if (gridWidths.length === totalCols) {
+    for (const widthPt of gridWidths) {
+      const column = doc.createElementNS(ODF_NS.TABLE, 'table:table-column');
+      column.setAttributeNS(ODF_NS.TABLE, 'table:style-name', tableStyles.columnStyleFor(widthPt));
+      table.appendChild(column);
+    }
+  } else {
+    const columns = doc.createElementNS(ODF_NS.TABLE, 'table:table-column');
+    columns.setAttributeNS(ODF_NS.TABLE, 'table:number-columns-repeated', String(totalCols));
+    table.appendChild(columns);
+  }
   body.appendChild(table);
 
   const buildRow = (rowIndex: number): Element => {
@@ -87,7 +207,7 @@ export function appendTable(
       if (cellNodes && cellNodes.length > 0) {
         for (const node of cellNodes) {
           const p = doc.createElementNS(ODF_NS.TEXT, 'text:p');
-          p.setAttributeNS(ODF_NS.TEXT, 'text:style-name', 'Standard');
+          p.setAttributeNS(ODF_NS.TEXT, 'text:style-name', paragraphStyleFor(node));
           cell.appendChild(p);
           fillParagraph(p, node);
         }

--- a/packages/odf-core/src/shared/odf/namespaces.ts
+++ b/packages/odf-core/src/shared/odf/namespaces.ts
@@ -19,6 +19,8 @@ export const ODF_NS = {
   FO: 'urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0',
   // XLink — carries `xlink:href` on `text:a` hyperlinks.
   XLINK: 'http://www.w3.org/1999/xlink',
+  // SVG-compatible properties (`svg:font-family` on `style:font-face` declarations).
+  SVG: 'urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0',
   // ODF meta elements (`meta:generator`) in `meta.xml`.
   META: 'urn:oasis:names:tc:opendocument:xmlns:meta:1.0',
 } as const;


### PR DESCRIPTION
## Summary

Phase 3 of DOCX → ODT conversion (#406, phasing from #331, phases 1+2 in #401). The smoke telemetry made font face/size/color runs the priority — 185 dropped `<font>` runs on the NVCA COI, 32 on the Common Paper NDA — followed by paragraph alignment/indents, source-derived named styles, highlight colors, table borders/widths, and empty-paragraph preservation. All six classes land here.

**Acceptance signal (from #406):** in-scope lossiness on the bundled real fixtures is now zero:

| Fixture | Before | After |
|---|---|---|
| NVCA COI | 185 font drops + 6 unsurfaced paragraphs | _none_ |
| Common Paper NDA | 32 font drops | _none_ |
| Bonterms NDA | font drops + grid gaps | only `table-grid-gaps-filled` ×5 (merged cells, out of scope) |
| Letter of Intent | font drops | _none_ |

The CONV-13 LibreOffice differential oracle still passes against a real soffice run, and CONV-12 visible-text equality holds on all four fixtures.

## How

- **Font runs (CONV-14):** the full-mode `<font color size face>` TOON tag maps to deduped automatic text styles (`fo:color`/`fo:font-size`/`style:font-name`) with `office:font-face-decls` entries.
- **Alignment/indents (CONV-15):** the view's `paragraph_alignment`/`paragraph_indents_pt` become deduped automatic paragraph styles; list items get alignment only (list nesting already indents).
- **Named styles (CONV-16):** `styles.xml` `Heading_20_1..6`/`Standard` seed from the source style chains via a new tri-state `extractStyleRunFormatting` (docx-core), so unspecified properties keep template defaults.
- **Highlight colors (CONV-17):** full-mode TOON highlight tags now carry the source `w:highlight` value (docx-core); the converter maps the Word palette to hex. Compact-mode TOON output is byte-identical to before.
- **Table borders/widths (CONV-18):** explicit `w:tblBorders` is honored uniformly per table (explicitly borderless stays borderless); `w:tblGrid` widths become `table:table-column` styles. Borders inherited via `w:tblStyle` chains stay out of scope (recorded in design.md).
- **Empty paragraphs (CONV-19):** text-empty body paragraphs are preserved as empty `text:p` at their source position via bookmark correlation; in-cell empties were already surfaced by the view and flow through the grid emitter.

## Spec

New OpenSpec change `update-docx-to-odf-style-fidelity` (validates `--strict`): CONV-14..19 under `odf-core`, HLCOLOR-01/02 + STYLEFMT-01 under `docx-primitives` with a tagged traceability test file. CONV-02/CONV-10 expectations updated for the behavior changes (empty paragraph preserved; font runs no longer reported dropped).

## Testing

- Full pre-submit gate green locally: build, lint:workspaces, test:run (all workspaces), check:spec-coverage, check:conformance-citations, check:conformance-doc.
- `convert_style_fidelity.test.ts` covers CONV-14..19; `odf_style_fidelity.traceability.test.ts` covers the docx-core enrichments; real-fixture test now asserts the in-scope lossiness classes are absent.

Fixes #406