### PR TITLE
feat(docx-core): from-scratch generation phase 5 — numbering and legal recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ safe-docx targets a defined subset of **ECMA-376 5th edition**. The full surface
 (targeted sections, Non-Goals, and verification status) lives at
 [spec-compliance/CONFORMANCE.md](spec-compliance/CONFORMANCE.md).
 
-- **43** sections claimed
+- **57** sections claimed
 - **5** sections explicitly out-of-scope (Non-Goals)
 - **0** known gaps under `@conformance-gap`
 - Vendored normative schemas: `spec-compliance/ecma-376/schemas/`

--- a/openspec/changes/add-docx-generation/tasks.md
+++ b/openspec/changes/add-docx-generation/tasks.md
@@ -32,9 +32,9 @@ and `openspec validate add-docx-generation --strict`.
 - [x] 4.2 Grid-arithmetic validation (gridSpan/vMerge); table structural checks; registry entries
 
 ## 5. Numbering + recipes (PR 5, after PR 4) — SDX-GEN-060..062, 070, 071
-- [ ] 5.1 `emit/numbering-part.ts` (abstractNum/num, numeric id assignment); `w:numPr` wiring
-- [ ] 5.2 Label round-trip against the read-side list-label computation
-- [ ] 5.3 `recipes.ts` (`coverTermsTable`, `signatureBlock`) + recipe artifacts; registry entries
+- [x] 5.1 `emit/numbering-part.ts` (abstractNum/num, numeric id assignment); `w:numPr` wiring
+- [x] 5.2 Label round-trip against the read-side list-label computation
+- [x] 5.3 `recipes.ts` (`coverTermsTable`, `signatureBlock`) + recipe artifacts; registry entries
 
 ## 6. Drafting-note layer (PR 6) — SDX-GEN-080..083
 - [ ] 6.1 `emit/comments-part.ts` + anchors + `includeDraftingNotes` switch; deterministic ids/dates

--- a/packages/docx-core/docs/generation-manual-compat-checklist.md
+++ b/packages/docx-core/docs/generation-manual-compat-checklist.md
@@ -31,6 +31,7 @@ Artifacts land under `packages/docx-core/src/testing/outputs/`.
 | `generation-phase2-styled.docx` (named style + run formatting + tabs/indent/justify) | PR 2 | — | — | — | — |
 | `generation-phase3-cover-body.docx` (titlePg cover header → body header, Page X of Y field footer, page break) | PR 3 | — | — | — | — |
 | `generation-phase4-tables.docx` (fixed-grid bordered table, shaded merged header row, repeating-header flag) | PR 4 | — | — | — | — |
+| `generation-phase5-numbering-recipes.docx` (three-level legal numbering, cover-terms recipe table, signature blocks) | PR 5 | — | — | — | — |
 
 ## Per-reader notes
 

--- a/packages/docx-core/src/generation/compile.ts
+++ b/packages/docx-core/src/generation/compile.ts
@@ -16,6 +16,7 @@ import { createZipBuffer } from '../primitives/zip.js';
 import { CompileContext } from './context.js';
 import { emitDocumentPart } from './emit/document-part.js';
 import { emitHeaderFooterParts } from './emit/header-footer-part.js';
+import { emitNumberingPartIfNeeded } from './emit/numbering-part.js';
 import { emitPackageParts } from './emit/package-parts.js';
 import { emitSettingsPartIfNeeded } from './emit/settings-part.js';
 import { emitStylesPart } from './emit/styles-part.js';
@@ -35,8 +36,9 @@ export async function generateDocx(spec: DocumentSpec, _opts?: GenerateDocxOptio
   validateSpec(spec);
 
   const ctx = new CompileContext();
-  const headerFooterRefs = emitHeaderFooterParts(spec, ctx);
-  ctx.setFileContent('word/document.xml', emitDocumentPart(spec, headerFooterRefs));
+  const numberingIds = emitNumberingPartIfNeeded(spec, ctx);
+  const headerFooterRefs = emitHeaderFooterParts(spec, ctx, numberingIds);
+  ctx.setFileContent('word/document.xml', emitDocumentPart(spec, headerFooterRefs, numberingIds));
   emitStylesPart(spec, ctx);
   emitSettingsPartIfNeeded(spec, ctx);
   emitPackageParts(spec, ctx);

--- a/packages/docx-core/src/generation/emit/document-part.ts
+++ b/packages/docx-core/src/generation/emit/document-part.ts
@@ -10,14 +10,12 @@
 
 import { createWmlElement } from '../../primitives/dom-helpers.js';
 import { OOXML, W } from '../../primitives/namespaces.js';
-import { parseXml, serializeXml } from '../../primitives/xml.js';
+import { parseXml, serializeXml, XML_DECL } from '../../primitives/xml.js';
 import { GenerationInternalError } from '../errors.js';
 import type { DocumentSpec } from '../types.js';
 import type { NumberingIdMap } from './numbering-part.js';
 import { buildSectPr, type SectionHeaderFooterRefs } from './section.js';
 import { buildBlock } from './table.js';
-
-export const XML_DECL = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
 
 const DOCUMENT_SKELETON =
   `<w:document xmlns:w="${OOXML.W_NS}" xmlns:r="${OOXML.R_NS}" xmlns:w14="${OOXML.W14_NS}">` +

--- a/packages/docx-core/src/generation/emit/document-part.ts
+++ b/packages/docx-core/src/generation/emit/document-part.ts
@@ -13,6 +13,7 @@ import { OOXML, W } from '../../primitives/namespaces.js';
 import { parseXml, serializeXml } from '../../primitives/xml.js';
 import { GenerationInternalError } from '../errors.js';
 import type { DocumentSpec } from '../types.js';
+import type { NumberingIdMap } from './numbering-part.js';
 import { buildSectPr, type SectionHeaderFooterRefs } from './section.js';
 import { buildBlock } from './table.js';
 
@@ -32,14 +33,14 @@ const DOCUMENT_SKELETON =
  * @conformance ECMA-376 edition 5, Part 1 § 17.6.18
  * @conformance ECMA-376 edition 5, Part 1 § 17.6.17
  */
-export function emitDocumentPart(spec: DocumentSpec, refs?: SectionHeaderFooterRefs[]): string {
+export function emitDocumentPart(spec: DocumentSpec, refs?: SectionHeaderFooterRefs[], numberingIds?: NumberingIdMap): string {
   const doc = parseXml(DOCUMENT_SKELETON);
   const body = doc.getElementsByTagName('w:body').item(0);
   if (!body) throw new GenerationInternalError('document skeleton lost its w:body');
 
   spec.sections.forEach((section, index) => {
     for (const block of section.blocks) {
-      body.appendChild(buildBlock(doc, block));
+      body.appendChild(buildBlock(doc, block, numberingIds));
     }
 
     const sectPr = buildSectPr(doc, section, refs?.[index]);

--- a/packages/docx-core/src/generation/emit/header-footer-part.ts
+++ b/packages/docx-core/src/generation/emit/header-footer-part.ts
@@ -16,6 +16,7 @@ import { parseXml, serializeXml } from '../../primitives/xml.js';
 import type { CompileContext } from '../context.js';
 import type { DocumentSpec, HeaderFooterSpec, SectionSpec } from '../types.js';
 import { XML_DECL } from './document-part.js';
+import type { NumberingIdMap } from './numbering-part.js';
 import { buildBlock } from './table.js';
 import type { SectionHeaderFooterRefs } from './section.js';
 
@@ -31,27 +32,27 @@ const SLOT_ORDER = ['first', 'default', 'even'] as const;
  * reference maps for the sectPr emitter. Runs before the document part so
  * relationship ids exist when sections bind their references.
  */
-export function emitHeaderFooterParts(spec: DocumentSpec, ctx: CompileContext): SectionHeaderFooterRefs[] {
-  return spec.sections.map((section) => emitForSection(section, ctx));
+export function emitHeaderFooterParts(spec: DocumentSpec, ctx: CompileContext, numberingIds?: NumberingIdMap): SectionHeaderFooterRefs[] {
+  return spec.sections.map((section) => emitForSection(section, ctx, numberingIds));
 }
 
-function emitForSection(section: SectionSpec, ctx: CompileContext): SectionHeaderFooterRefs {
+function emitForSection(section: SectionSpec, ctx: CompileContext, numberingIds?: NumberingIdMap): SectionHeaderFooterRefs {
   const refs: SectionHeaderFooterRefs = { headers: {}, footers: {} };
   for (const slot of SLOT_ORDER) {
     const header = section.headers?.[slot];
     if (header) {
-      refs.headers[slot] = emitPart(header, ctx, 'header');
+      refs.headers[slot] = emitPart(header, ctx, 'header', numberingIds);
     }
     const footer = section.footers?.[slot];
     if (footer) {
-      refs.footers[slot] = emitPart(footer, ctx, 'footer');
+      refs.footers[slot] = emitPart(footer, ctx, 'footer', numberingIds);
     }
   }
   return refs;
 }
 
 /** @conformance ECMA-376 edition 5, Part 1 § 17.10.3 */
-function emitPart(content: HeaderFooterSpec, ctx: CompileContext, kind: 'header' | 'footer'): string {
+function emitPart(content: HeaderFooterSpec, ctx: CompileContext, kind: 'header' | 'footer', numberingIds?: NumberingIdMap): string {
   const isHeader = kind === 'header';
   const partName = isHeader ? ctx.allocateHeaderPartName() : ctx.allocateFooterPartName();
   const part = ctx.registerPart(
@@ -64,7 +65,7 @@ function emitPart(content: HeaderFooterSpec, ctx: CompileContext, kind: 'header'
   const doc = parseXml(`<${rootTag} xmlns:w="${OOXML.W_NS}" xmlns:r="${OOXML.R_NS}"/>`);
   const root = doc.documentElement!;
   for (const block of content.blocks) {
-    root.appendChild(buildBlock(doc, block));
+    root.appendChild(buildBlock(doc, block, numberingIds));
   }
 
   ctx.setFileContent(partName, XML_DECL + serializeXml(doc));

--- a/packages/docx-core/src/generation/emit/header-footer-part.ts
+++ b/packages/docx-core/src/generation/emit/header-footer-part.ts
@@ -12,10 +12,9 @@
  */
 
 import { OOXML } from '../../primitives/namespaces.js';
-import { parseXml, serializeXml } from '../../primitives/xml.js';
+import { parseXml, serializeXml, XML_DECL } from '../../primitives/xml.js';
 import type { CompileContext } from '../context.js';
 import type { DocumentSpec, HeaderFooterSpec, SectionSpec } from '../types.js';
-import { XML_DECL } from './document-part.js';
 import type { NumberingIdMap } from './numbering-part.js';
 import { buildBlock } from './table.js';
 import type { SectionHeaderFooterRefs } from './section.js';

--- a/packages/docx-core/src/generation/emit/numbering-part.ts
+++ b/packages/docx-core/src/generation/emit/numbering-part.ts
@@ -19,10 +19,9 @@
 
 import { createWmlElement } from '../../primitives/dom-helpers.js';
 import { OOXML, W } from '../../primitives/namespaces.js';
-import { parseXml, serializeXml } from '../../primitives/xml.js';
+import { parseXml, serializeXml, XML_DECL } from '../../primitives/xml.js';
 import type { CompileContext } from '../context.js';
 import type { DocumentSpec, NumberingSpec } from '../types.js';
-import { XML_DECL } from './document-part.js';
 import { buildRunPropsElement } from './properties.js';
 
 export const NUMBERING_CONTENT_TYPE =

--- a/packages/docx-core/src/generation/emit/numbering-part.ts
+++ b/packages/docx-core/src/generation/emit/numbering-part.ts
@@ -1,0 +1,115 @@
+/**
+ * word/numbering.xml emitter.
+ *
+ * Each NumberingSpec compiles to one abstract definition plus one instance:
+ * the spec's string handle (`numId`) maps to sequential numeric ids assigned
+ * in declaration order, so identical specs always produce identical ids. The
+ * returned map is what lets paragraph `w:numPr` references bind to the
+ * numeric `w:numId` deterministically.
+ *
+ * Level children follow the CT_Lvl sequence (start, numFmt, suff, lvlText,
+ * lvlJc, pPr, rPr); level run properties reuse the shared rPr builder so a
+ * bullet glyph's font serializes exactly like body formatting would.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.9.16
+ * @conformance ECMA-376 edition 5, Part 1 § 17.9.1
+ * @conformance ECMA-376 edition 5, Part 1 § 17.9.15
+ * @conformance ECMA-376 edition 5, Part 1 § 17.9.2
+ */
+
+import { createWmlElement } from '../../primitives/dom-helpers.js';
+import { OOXML, W } from '../../primitives/namespaces.js';
+import { parseXml, serializeXml } from '../../primitives/xml.js';
+import type { CompileContext } from '../context.js';
+import type { DocumentSpec, NumberingSpec } from '../types.js';
+import { XML_DECL } from './document-part.js';
+import { buildRunPropsElement } from './properties.js';
+
+export const NUMBERING_CONTENT_TYPE =
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.numbering+xml';
+export const NUMBERING_REL_TYPE =
+  'http://schemas.openxmlformats.org/officeDocument/2006/relationships/numbering';
+
+/** Spec-level numbering handle → numeric w:numId value. */
+export type NumberingIdMap = ReadonlyMap<string, number>;
+
+const NUMBERING_SKELETON = `<w:numbering xmlns:w="${OOXML.W_NS}"/>`;
+
+/**
+ * Emit word/numbering.xml when the spec declares numbering definitions.
+ * Returns the handle → numeric id map (empty when no part is emitted).
+ */
+export function emitNumberingPartIfNeeded(spec: DocumentSpec, ctx: CompileContext): NumberingIdMap {
+  const ids = new Map<string, number>();
+  const definitions = spec.numbering ?? [];
+  if (definitions.length === 0) return ids;
+
+  ctx.registerPart('word/numbering.xml', NUMBERING_CONTENT_TYPE, NUMBERING_REL_TYPE);
+
+  const doc = parseXml(NUMBERING_SKELETON);
+  const root = doc.documentElement!;
+
+  definitions.forEach((definition, index) => {
+    ids.set(definition.numId, index + 1);
+  });
+  // CT_Numbering sequence: every abstractNum precedes every num.
+  definitions.forEach((definition, index) => {
+    root.appendChild(buildAbstractNum(doc, definition, index));
+  });
+  definitions.forEach((_definition, index) => {
+    const num = createWmlElement(doc, W.num, { 'w:numId': String(index + 1) });
+    num.appendChild(createWmlElement(doc, W.abstractNumId, { 'w:val': String(index) }));
+    root.appendChild(num);
+  });
+
+  ctx.setFileContent('word/numbering.xml', XML_DECL + serializeXml(doc));
+  return ids;
+}
+
+/**
+ * @conformance ECMA-376 edition 5, Part 1 § 17.9.12
+ * @conformance ECMA-376 edition 5, Part 1 § 17.9.6
+ */
+function buildAbstractNum(doc: Document, definition: NumberingSpec, abstractId: number): Element {
+  const abstractNum = createWmlElement(doc, W.abstractNum, { 'w:abstractNumId': String(abstractId) });
+  abstractNum.appendChild(
+    createWmlElement(doc, W.multiLevelType, {
+      'w:val': definition.levels.length > 1 ? 'multilevel' : 'singleLevel',
+    }),
+  );
+  for (const level of definition.levels) {
+    abstractNum.appendChild(buildLevel(doc, level));
+  }
+  return abstractNum;
+}
+
+/**
+ * @conformance ECMA-376 edition 5, Part 1 § 17.9.25
+ * @conformance ECMA-376 edition 5, Part 1 § 17.9.17
+ * @conformance ECMA-376 edition 5, Part 1 § 17.9.28
+ * @conformance ECMA-376 edition 5, Part 1 § 17.9.11
+ * @conformance ECMA-376 edition 5, Part 1 § 17.9.7
+ */
+function buildLevel(doc: Document, level: NumberingSpec['levels'][number]): Element {
+  const lvl = createWmlElement(doc, W.lvl, { 'w:ilvl': String(level.ilvl) });
+  lvl.appendChild(createWmlElement(doc, W.start, { 'w:val': String(level.start ?? 1) }));
+  lvl.appendChild(createWmlElement(doc, W.numFmt, { 'w:val': level.numFmt }));
+  if (level.suff !== undefined) {
+    lvl.appendChild(createWmlElement(doc, W.suff, { 'w:val': level.suff }));
+  }
+  lvl.appendChild(createWmlElement(doc, W.lvlText, { 'w:val': level.lvlText }));
+  lvl.appendChild(createWmlElement(doc, W.lvlJc, { 'w:val': 'left' }));
+  if (level.indentTwips !== undefined) {
+    const pPr = createWmlElement(doc, W.pPr);
+    const attrs: Record<string, string> = {};
+    if (level.indentTwips.left !== undefined) attrs['w:left'] = String(level.indentTwips.left);
+    if (level.indentTwips.hanging !== undefined) attrs['w:hanging'] = String(level.indentTwips.hanging);
+    pPr.appendChild(createWmlElement(doc, W.ind, attrs));
+    lvl.appendChild(pPr);
+  }
+  if (level.runProps !== undefined) {
+    const rPr = buildRunPropsElement(doc, level.runProps);
+    if (rPr) lvl.appendChild(rPr);
+  }
+  return lvl;
+}

--- a/packages/docx-core/src/generation/emit/package-parts.ts
+++ b/packages/docx-core/src/generation/emit/package-parts.ts
@@ -8,10 +8,9 @@
  */
 
 import { OOXML } from '../../primitives/namespaces.js';
-import { parseXml, serializeXml } from '../../primitives/xml.js';
+import { parseXml, serializeXml, XML_DECL } from '../../primitives/xml.js';
 import type { CompileContext } from '../context.js';
 import type { DocumentSpec } from '../types.js';
-import { XML_DECL } from './document-part.js';
 
 export const CONTENT_TYPES = {
   document: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml',

--- a/packages/docx-core/src/generation/emit/paragraph.ts
+++ b/packages/docx-core/src/generation/emit/paragraph.ts
@@ -9,13 +9,37 @@
 
 import { createWmlElement } from '../../primitives/dom-helpers.js';
 import { W } from '../../primitives/namespaces.js';
+import { GenerationInternalError } from '../errors.js';
 import type { ParagraphSpec } from '../types.js';
+import type { NumberingIdMap } from './numbering-part.js';
 import { buildParagraphPropsElement } from './properties.js';
 import { buildInlineRuns } from './run.js';
 
-export function buildParagraph(doc: Document, paragraph: ParagraphSpec): Element {
+/**
+ * List paragraphs reference their numbering definition through w:numPr
+ * (w:ilvl then w:numId, per CT_NumPr); the numeric id comes from the
+ * numbering part's deterministic handle map.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.3.1.19
+ * @conformance ECMA-376 edition 5, Part 1 § 17.9.3
+ * @conformance ECMA-376 edition 5, Part 1 § 17.9.18
+ */
+export function buildParagraph(doc: Document, paragraph: ParagraphSpec, numberingIds?: NumberingIdMap): Element {
   const p = createWmlElement(doc, W.p);
-  const pPr = buildParagraphPropsElement(doc, paragraph);
+  let extras: Map<string, Element> | undefined;
+  if (paragraph.list !== undefined) {
+    const numericId = numberingIds?.get(paragraph.list.numId);
+    if (numericId === undefined) {
+      throw new GenerationInternalError(
+        `List paragraph references numbering handle '${paragraph.list.numId}' with no allocated numeric id`,
+      );
+    }
+    const numPr = createWmlElement(doc, W.numPr);
+    numPr.appendChild(createWmlElement(doc, W.ilvl, { 'w:val': String(paragraph.list.ilvl) }));
+    numPr.appendChild(createWmlElement(doc, W.numId, { 'w:val': String(numericId) }));
+    extras = new Map([[W.numPr, numPr]]);
+  }
+  const pPr = buildParagraphPropsElement(doc, paragraph, extras);
   if (pPr) p.appendChild(pPr);
   for (const inline of paragraph.runs) {
     for (const run of buildInlineRuns(doc, inline)) {

--- a/packages/docx-core/src/generation/emit/settings-part.ts
+++ b/packages/docx-core/src/generation/emit/settings-part.ts
@@ -10,10 +10,9 @@
 
 import { createWmlElement } from '../../primitives/dom-helpers.js';
 import { OOXML, W } from '../../primitives/namespaces.js';
-import { parseXml, serializeXml } from '../../primitives/xml.js';
+import { parseXml, serializeXml, XML_DECL } from '../../primitives/xml.js';
 import type { CompileContext } from '../context.js';
 import type { DocumentSpec } from '../types.js';
-import { XML_DECL } from './document-part.js';
 
 const SETTINGS_CONTENT_TYPE = 'application/vnd.openxmlformats-officedocument.wordprocessingml.settings+xml';
 const SETTINGS_REL_TYPE = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/settings';

--- a/packages/docx-core/src/generation/emit/styles-part.ts
+++ b/packages/docx-core/src/generation/emit/styles-part.ts
@@ -11,10 +11,9 @@
 
 import { createWmlElement } from '../../primitives/dom-helpers.js';
 import { OOXML, W } from '../../primitives/namespaces.js';
-import { parseXml, serializeXml } from '../../primitives/xml.js';
+import { parseXml, serializeXml, XML_DECL } from '../../primitives/xml.js';
 import type { CompileContext } from '../context.js';
 import type { DocumentSpec, StyleSpec } from '../types.js';
-import { XML_DECL } from './document-part.js';
 import { buildParagraphPropsElement, buildRunPropsElement, styleParagraphProps } from './properties.js';
 
 export const STYLES_CONTENT_TYPE = 'application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml';

--- a/packages/docx-core/src/generation/emit/table.ts
+++ b/packages/docx-core/src/generation/emit/table.ts
@@ -16,6 +16,7 @@ import { createWmlElement } from '../../primitives/dom-helpers.js';
 import { W } from '../../primitives/namespaces.js';
 import { appendInOrder, TBLPR_ORDER, TCPR_ORDER, TRPR_ORDER } from '../ordering.js';
 import type { BlockSpec, BorderSpec, TableBorders, TableCellSpec, TableRowSpec, TableSpec } from '../types.js';
+import type { NumberingIdMap } from './numbering-part.js';
 import { buildParagraph } from './paragraph.js';
 
 /**
@@ -25,12 +26,12 @@ import { buildParagraph } from './paragraph.js';
  * @conformance ECMA-376 edition 5, Part 1 § 17.4.59
  * @conformance ECMA-376 edition 5, Part 1 § 17.4.48
  */
-export function buildTable(doc: Document, table: TableSpec): Element {
+export function buildTable(doc: Document, table: TableSpec, numberingIds?: NumberingIdMap): Element {
   const tbl = createWmlElement(doc, W.tbl);
   tbl.appendChild(buildTblPr(doc, table));
   tbl.appendChild(buildTblGrid(doc, table));
   for (const row of table.rows) {
-    tbl.appendChild(buildRow(doc, table, row));
+    tbl.appendChild(buildRow(doc, table, row, numberingIds));
   }
   return tbl;
 }
@@ -74,7 +75,7 @@ function buildTblGrid(doc: Document, table: TableSpec): Element {
  * @conformance ECMA-376 edition 5, Part 1 § 17.4.80
  * @conformance ECMA-376 edition 5, Part 1 § 17.4.49
  */
-function buildRow(doc: Document, table: TableSpec, row: TableRowSpec): Element {
+function buildRow(doc: Document, table: TableSpec, row: TableRowSpec, numberingIds?: NumberingIdMap): Element {
   const tr = createWmlElement(doc, W.tr);
 
   const props = new Map<string, Element | Element[]>();
@@ -99,7 +100,7 @@ function buildRow(doc: Document, table: TableSpec, row: TableRowSpec): Element {
   let gridOffset = 0;
   for (const cell of row.cells) {
     const span = cell.gridSpan ?? 1;
-    tr.appendChild(buildCell(doc, table, cell, gridOffset));
+    tr.appendChild(buildCell(doc, table, cell, gridOffset, numberingIds));
     gridOffset += span;
   }
   return tr;
@@ -119,7 +120,7 @@ function buildRow(doc: Document, table: TableSpec, row: TableRowSpec): Element {
  * @conformance ECMA-376 edition 5, Part 1 § 17.4.83
  * @conformance ECMA-376 edition 5, Part 1 § 17.4.68
  */
-function buildCell(doc: Document, table: TableSpec, cell: TableCellSpec, gridOffset: number): Element {
+function buildCell(doc: Document, table: TableSpec, cell: TableCellSpec, gridOffset: number, numberingIds?: NumberingIdMap): Element {
   const tc = createWmlElement(doc, W.tc);
   const tcPr = createWmlElement(doc, W.tcPr);
   const props = new Map<string, Element | Element[]>();
@@ -153,7 +154,7 @@ function buildCell(doc: Document, table: TableSpec, cell: TableCellSpec, gridOff
   tc.appendChild(tcPr);
 
   for (const block of cell.blocks) {
-    tc.appendChild(buildBlock(doc, block));
+    tc.appendChild(buildBlock(doc, block, numberingIds));
   }
   // A cell must end with a paragraph: readers reject a cell that is empty or
   // whose last block is a table.
@@ -165,8 +166,8 @@ function buildCell(doc: Document, table: TableSpec, cell: TableCellSpec, gridOff
 }
 
 /** Dispatch a block-level spec node to its emitter (cells hold both kinds). */
-export function buildBlock(doc: Document, block: BlockSpec): Element {
-  return block.kind === 'table' ? buildTable(doc, block) : buildParagraph(doc, block);
+export function buildBlock(doc: Document, block: BlockSpec, numberingIds?: NumberingIdMap): Element {
+  return block.kind === 'table' ? buildTable(doc, block, numberingIds) : buildParagraph(doc, block, numberingIds);
 }
 
 /**

--- a/packages/docx-core/src/generation/generation-numbering-recipes.test.ts
+++ b/packages/docx-core/src/generation/generation-numbering-recipes.test.ts
@@ -1,0 +1,307 @@
+import { describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { DocxDocument } from '../primitives/document.js';
+import {
+  computeListLabelForParagraph,
+  parseNumberingXml,
+  type NumberingCounters,
+} from '../primitives/numbering.js';
+import { readZipText } from '../primitives/zip.js';
+import { parseXml } from '../primitives/xml.js';
+import { generateDocx } from './compile.js';
+import { coverTermsTable, signatureBlock } from './recipes.js';
+import { checkGeneratedPackage } from './structural-checks.js';
+import type { DocumentSpec, NumberingSpec } from './types.js';
+
+const TEST_FEATURE = 'add-docx-generation';
+const test = testAllure.epic('Document Generation').withLabels({ feature: TEST_FEATURE });
+
+function listItem(text: string, numId: string, ilvl: number): DocumentSpec['sections'][number]['blocks'][number] {
+  return { kind: 'paragraph', list: { numId, ilvl }, runs: [{ kind: 'text', text }] };
+}
+
+/** Article/section/clause: decimal, multi-level decimal, lowerRoman. */
+function legalNumbering(): NumberingSpec {
+  return {
+    numId: 'articles',
+    levels: [
+      { ilvl: 0, numFmt: 'decimal', lvlText: '%1.', indentTwips: { left: 720, hanging: 360 } },
+      { ilvl: 1, numFmt: 'decimal', lvlText: '%1.%2', indentTwips: { left: 1440, hanging: 360 } },
+      { ilvl: 2, numFmt: 'lowerRoman', lvlText: '(%3)', indentTwips: { left: 2160, hanging: 360 } },
+    ],
+  };
+}
+
+function nestedListSpec(): DocumentSpec {
+  return {
+    meta: { title: 'Generation numbering', createdIso: '2026-06-11T00:00:00Z' },
+    numbering: [legalNumbering()],
+    sections: [
+      {
+        blocks: [
+          listItem('Definitions', 'articles', 0),
+          listItem('Confidential Information', 'articles', 1),
+          listItem('Exclusions', 'articles', 1),
+          listItem('publicly available information', 'articles', 2),
+          listItem('Obligations', 'articles', 0),
+          listItem('Standard of care', 'articles', 1),
+        ],
+      },
+    ],
+  };
+}
+
+describe('Traceability: numbering and legal-document recipes', () => {
+  test
+    .openspec('[SDX-GEN-060] numbering definitions are emitted')
+    .conformance(
+      { spec: 'ECMA-376', edition: 5, part: 1, section: '17.9.16' },
+      { spec: 'ECMA-376', edition: 5, part: 1, section: '17.9.1' },
+      { spec: 'ECMA-376', edition: 5, part: 1, section: '17.9.15' },
+      { spec: 'ECMA-376', edition: 5, part: 1, section: '17.3.1.19' },
+    )(
+    'Scenario: numbering definitions are emitted',
+    async ({ given, when, then, attachPrettyXml }: AllureBddContext) => {
+      let buffer!: Buffer;
+      await given('a spec declaring a three-level numbering definition used by list paragraphs', async () => {
+        buffer = await generateDocx(nestedListSpec());
+        expect((await checkGeneratedPackage(buffer)).ok).toBe(true);
+      });
+
+      let numberingXml!: string;
+      let documentXml!: string;
+      await when('word/numbering.xml and word/document.xml are parsed back', async () => {
+        numberingXml = (await readZipText(buffer, 'word/numbering.xml'))!;
+        documentXml = (await readZipText(buffer, 'word/document.xml'))!;
+        expect(numberingXml).toBeTruthy();
+        await attachPrettyXml('word/numbering.xml', numberingXml);
+      });
+
+      await then('the part holds a matching abstract definition and instance', async () => {
+        const numberingDoc = parseXml(numberingXml);
+        const abstract = numberingDoc.getElementsByTagName('w:abstractNum').item(0)!;
+        expect(abstract.getAttribute('w:abstractNumId')).toBe('0');
+        expect(abstract.getElementsByTagName('w:lvl')).toHaveLength(3);
+        const num = numberingDoc.getElementsByTagName('w:num').item(0)!;
+        expect(num.getAttribute('w:numId')).toBe('1');
+        expect(num.getElementsByTagName('w:abstractNumId').item(0)!.getAttribute('w:val')).toBe('0');
+      });
+
+      await then('list paragraphs reference it via w:numPr with the declared level', async () => {
+        const documentDoc = parseXml(documentXml);
+        const numPrs = Array.from(documentDoc.getElementsByTagName('w:numPr'));
+        expect(numPrs).toHaveLength(6);
+        const first = numPrs[0]!;
+        expect(first.getElementsByTagName('w:ilvl').item(0)!.getAttribute('w:val')).toBe('0');
+        expect(first.getElementsByTagName('w:numId').item(0)!.getAttribute('w:val')).toBe('1');
+        expect(numPrs[3]!.getElementsByTagName('w:ilvl').item(0)!.getAttribute('w:val')).toBe('2');
+      });
+    },
+  );
+
+  test.openspec('[SDX-GEN-061] generated labels match the read-side computation')(
+    'Scenario: generated labels match the read-side computation',
+    async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
+      let buffer!: Buffer;
+      await given('a generated document with nested numbered lists', async () => {
+        buffer = await generateDocx(nestedListSpec());
+        expect(buffer.length).toBeGreaterThan(0);
+      });
+
+      let labels!: string[];
+      await when('the read-side list-label computation runs over the loaded document', async () => {
+        const doc = await DocxDocument.load(buffer);
+        const numberingXml = (await readZipText(buffer, 'word/numbering.xml'))!;
+        const model = parseNumberingXml(parseXml(numberingXml));
+        const documentDoc = doc.getDocumentXmlClone();
+        const counters: NumberingCounters = new Map();
+        labels = [];
+        for (const numPr of Array.from(documentDoc.getElementsByTagName('w:numPr'))) {
+          const ilvl = Number(numPr.getElementsByTagName('w:ilvl').item(0)!.getAttribute('w:val'));
+          const numId = numPr.getElementsByTagName('w:numId').item(0)!.getAttribute('w:val')!;
+          labels.push(computeListLabelForParagraph(model, counters, { numId, ilvl }));
+        }
+        await attachPrettyJson('computed-labels', labels);
+      });
+
+      await then('the computed labels match the labels implied by the numbering definition', async () => {
+        expect(labels).toEqual(['1.', '1.1', '1.2', '(i)', '2.', '2.1']);
+        expect(new Set(labels).size).toBe(labels.length);
+      });
+    },
+  );
+
+  test
+    .openspec('[SDX-GEN-062] bullet and ordinal formats are both supported')
+    .conformance(
+      { spec: 'ECMA-376', edition: 5, part: 1, section: '17.9.17' },
+      { spec: 'ECMA-376', edition: 5, part: 1, section: '17.9.11' },
+      { spec: 'ECMA-376', edition: 5, part: 1, section: '17.9.25' },
+    )(
+    'Scenario: bullet and ordinal formats are both supported',
+    async ({ given, when, then, attachPrettyXml }: AllureBddContext) => {
+      let spec!: DocumentSpec;
+      await given('numbering definitions using bullet, decimal, and roman formats across levels', async () => {
+        spec = {
+          numbering: [
+            {
+              numId: 'mixed',
+              levels: [
+                { ilvl: 0, numFmt: 'bullet', lvlText: '•', suff: 'tab', runProps: { font: 'Symbol' } },
+                { ilvl: 1, numFmt: 'decimal', start: 3, lvlText: '%2)' },
+                { ilvl: 2, numFmt: 'upperRoman', lvlText: '%3.' },
+              ],
+            },
+          ],
+          sections: [
+            {
+              blocks: [
+                listItem('bullet item', 'mixed', 0),
+                listItem('decimal item', 'mixed', 1),
+                listItem('roman item', 'mixed', 2),
+              ],
+            },
+          ],
+        };
+        expect(spec.numbering![0]!.levels).toHaveLength(3);
+      });
+
+      let levels!: Element[];
+      await when('the document is generated and the levels parsed back', async () => {
+        const buffer = await generateDocx(spec);
+        const numberingXml = (await readZipText(buffer, 'word/numbering.xml'))!;
+        await attachPrettyXml('word/numbering.xml', numberingXml);
+        levels = Array.from(parseXml(numberingXml).getElementsByTagName('w:lvl'));
+        expect(levels).toHaveLength(3);
+      });
+
+      await then('each level carries the declared numFmt, level text, and start value', async () => {
+        const fmt = (lvl: Element) => lvl.getElementsByTagName('w:numFmt').item(0)!.getAttribute('w:val');
+        const text = (lvl: Element) => lvl.getElementsByTagName('w:lvlText').item(0)!.getAttribute('w:val');
+        expect(levels.map(fmt)).toEqual(['bullet', 'decimal', 'upperRoman']);
+        expect(levels.map(text)).toEqual(['•', '%2)', '%3.']);
+        expect(levels[1]!.getElementsByTagName('w:start').item(0)!.getAttribute('w:val')).toBe('3');
+        expect(levels[0]!.getElementsByTagName('w:rFonts').item(0)!.getAttribute('w:ascii')).toBe('Symbol');
+      });
+    },
+  );
+
+  test.openspec('[SDX-GEN-070] a cover-terms recipe produces a label/value table')(
+    'Scenario: a cover-terms recipe produces a label/value table',
+    async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
+      let spec!: DocumentSpec;
+      await given('a list of term labels and values handed to coverTermsTable', async () => {
+        const table = coverTermsTable({
+          title: 'Cover Terms',
+          terms: [
+            { label: 'Disclosing Party', value: 'Acme Manufacturing, Inc.' },
+            { label: 'Receiving Party', value: 'Northeast Logistics LLC' },
+            { label: 'Effective Date', value: 'June 11, 2026' },
+          ],
+        });
+        await attachPrettyJson('recipe-output', table);
+        expect(table.kind).toBe('table');
+        expect(JSON.parse(JSON.stringify(table))).toEqual(table);
+        spec = { sections: [{ blocks: [table] }] };
+      });
+
+      let documentXml!: string;
+      await when('the document is generated', async () => {
+        const buffer = await generateDocx(spec);
+        expect((await checkGeneratedPackage(buffer)).ok).toBe(true);
+        documentXml = (await readZipText(buffer, 'word/document.xml'))!;
+      });
+
+      await then('the output contains a fixed-layout two-column table pairing each label with its value', async () => {
+        const dom = parseXml(documentXml);
+        expect(dom.getElementsByTagName('w:tblLayout').item(0)!.getAttribute('w:type')).toBe('fixed');
+        expect(dom.getElementsByTagName('w:gridCol')).toHaveLength(2);
+        const rows = Array.from(dom.getElementsByTagName('w:tr'));
+        expect(rows).toHaveLength(4);
+        expect(documentXml.indexOf('Disclosing Party')).toBeLessThan(documentXml.indexOf('Acme Manufacturing, Inc.'));
+        expect(documentXml.indexOf('Receiving Party')).toBeLessThan(documentXml.indexOf('Northeast Logistics LLC'));
+      });
+    },
+  );
+
+  test.openspec('[SDX-GEN-071] a signature-block recipe renders signature lines')(
+    'Scenario: a signature-block recipe renders signature lines',
+    async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
+      let spec!: DocumentSpec;
+      await given('party names with titles and date labels handed to signatureBlock', async () => {
+        const blocks = signatureBlock({
+          parties: [
+            { party: 'Acme Manufacturing, Inc.', name: 'Jane Doe', title: 'CEO' },
+            { party: 'Northeast Logistics LLC', name: 'John Smith', title: 'Managing Member', dateLabel: 'Dated:' },
+          ],
+        });
+        await attachPrettyJson('recipe-output', blocks);
+        expect(blocks.length).toBeGreaterThan(2);
+        spec = { sections: [{ blocks: [{ kind: 'paragraph', runs: [{ kind: 'text', text: 'IN WITNESS WHEREOF' }] }, ...blocks] }] };
+      });
+
+      let documentXml!: string;
+      await when('the document is generated', async () => {
+        const buffer = await generateDocx(spec);
+        expect((await checkGeneratedPackage(buffer)).ok).toBe(true);
+        documentXml = (await readZipText(buffer, 'word/document.xml'))!;
+      });
+
+      await then('each party gets a bottom-bordered signature-line cell followed by name, title, and date rows', async () => {
+        const dom = parseXml(documentXml);
+        const lineCells = Array.from(dom.getElementsByTagName('w:tcBorders')).filter(
+          (b) => b.getElementsByTagName('w:bottom').length === 1 && b.getElementsByTagName('w:top').length === 0,
+        );
+        expect(lineCells).toHaveLength(2);
+        for (const name of ['Name: Jane Doe', 'Title: CEO', 'Date:', 'Name: John Smith', 'Title: Managing Member', 'Dated:']) {
+          expect(documentXml).toContain(name);
+        }
+      });
+
+      await then('the output contains no VML or picture markup', async () => {
+        expect(documentXml).not.toMatch(/<w:pict|<v:|<w:object|<w:drawing/);
+        expect(documentXml).toContain('w:tcBorders');
+      });
+    },
+  );
+
+  test('phase 5 numbering/recipes artifact loads through the document façade with labels intact', async () => {
+    const spec: DocumentSpec = {
+      meta: { title: 'SDX generation phase 5', author: 'safe-docx tests', createdIso: '2026-06-11T00:00:00Z' },
+      numbering: [legalNumbering()],
+      sections: [
+        {
+          blocks: [
+            coverTermsTable({
+              title: 'Cover Terms',
+              terms: [
+                { label: 'Disclosing Party', value: 'Acme Manufacturing, Inc.' },
+                { label: 'Receiving Party', value: 'Northeast Logistics LLC' },
+              ],
+            }),
+            { kind: 'paragraph', runs: [{ kind: 'text', text: '' }] },
+            listItem('Definitions', 'articles', 0),
+            listItem('Confidential Information means non-public information.', 'articles', 1),
+            listItem('Obligations', 'articles', 0),
+            { kind: 'paragraph', runs: [{ kind: 'text', text: 'IN WITNESS WHEREOF, the parties execute this Agreement.' }] },
+            ...signatureBlock({
+              parties: [
+                { party: 'Acme Manufacturing, Inc.', name: 'Jane Doe', title: 'CEO' },
+                { party: 'Northeast Logistics LLC', name: 'John Smith', title: 'Managing Member' },
+              ],
+            }),
+          ],
+        },
+      ],
+    };
+    const buffer = await generateDocx(spec);
+    const doc = await DocxDocument.load(buffer);
+    doc.insertParagraphBookmarks('sdx-gen-phase5');
+    const texts = doc.readParagraphs().paragraphs.map((p) => p.text);
+    expect(texts.join('\n')).toContain('Definitions');
+    expect(texts.join('\n')).toContain('Name: Jane Doe');
+    const { writeIntegrationArtifact } = await import('../integration/output-artifacts.js');
+    const outputPath = await writeIntegrationArtifact('generation-phase5-numbering-recipes.docx', buffer);
+    expect(outputPath).toContain('generation-phase5-numbering-recipes.docx');
+  });
+});

--- a/packages/docx-core/src/generation/generation-skeleton.test.ts
+++ b/packages/docx-core/src/generation/generation-skeleton.test.ts
@@ -85,8 +85,8 @@ describe('Traceability: from-scratch generation skeleton', () => {
     'Scenario: unimplemented spec features are rejected loudly',
     async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
       let noteSpec!: DocumentSpec;
-      let listSpec!: DocumentSpec;
-      await given('specs using declared features whose emitters have not shipped (drafting note, numbered list)', async () => {
+      let cellNoteSpec!: DocumentSpec;
+      await given('specs using the declared drafting-note feature, whose emitter has not shipped (body and table-cell anchors)', async () => {
         noteSpec = {
           sections: [
             {
@@ -96,11 +96,25 @@ describe('Traceability: from-scratch generation skeleton', () => {
             },
           ],
         };
-        listSpec = {
+        cellNoteSpec = {
           sections: [
             {
               blocks: [
-                { kind: 'paragraph', list: { numId: 'main', ilvl: 0 }, runs: [{ kind: 'text', text: 'item' }] },
+                {
+                  kind: 'table',
+                  columnWidthsTwips: [9360],
+                  rows: [
+                    {
+                      cells: [
+                        {
+                          blocks: [
+                            { kind: 'paragraph', note: { text: 'check this cell' }, runs: [{ kind: 'text', text: 'cell' }] },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
               ],
             },
           ],
@@ -108,13 +122,13 @@ describe('Traceability: from-scratch generation skeleton', () => {
       });
 
       let noteError: unknown;
-      let listError: unknown;
+      let cellNoteError: unknown;
       await when('generateDocx compiles each spec', async () => {
         noteError = await generateDocx(noteSpec).then(
           () => null,
           (err: unknown) => err,
         );
-        listError = await generateDocx(listSpec).then(
+        cellNoteError = await generateDocx(cellNoteSpec).then(
           () => null,
           (err: unknown) => err,
         );
@@ -124,11 +138,11 @@ describe('Traceability: from-scratch generation skeleton', () => {
         expect(noteError).toBeInstanceOf(GenerationSpecError);
         expect((noteError as GenerationSpecError).code).toBe('unsupported_feature');
         expect((noteError as GenerationSpecError).path).toBe('/sections/0/blocks/0/note');
-        expect(listError).toBeInstanceOf(GenerationSpecError);
-        expect((listError as GenerationSpecError).path).toBe('/sections/0/blocks/0/list');
+        expect(cellNoteError).toBeInstanceOf(GenerationSpecError);
+        expect((cellNoteError as GenerationSpecError).path).toBe('/sections/0/blocks/0/rows/0/cells/0/blocks/0/note');
         await attachPrettyJson('rejections', {
           note: { code: (noteError as GenerationSpecError).code, path: (noteError as GenerationSpecError).path },
-          list: { code: (listError as GenerationSpecError).code, path: (listError as GenerationSpecError).path },
+          cellNote: { code: (cellNoteError as GenerationSpecError).code, path: (cellNoteError as GenerationSpecError).path },
         });
       });
     },

--- a/packages/docx-core/src/generation/generation-styles-formatting.test.ts
+++ b/packages/docx-core/src/generation/generation-styles-formatting.test.ts
@@ -66,14 +66,25 @@ describe('Traceability: styles and run/paragraph formatting emission', () => {
     'Scenario: dangling references are rejected before emission',
     async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
       let spec!: DocumentSpec;
-      await given('a paragraph referencing a styleId absent from the declared styles', async () => {
+      let listSpec!: DocumentSpec;
+      await given('paragraphs referencing a styleId and a numId absent from the document-level definitions', async () => {
         spec = styledSpec();
         spec.sections[0]!.blocks.push({ kind: 'paragraph', styleId: 'GhostStyle', runs: [{ kind: 'text', text: 'x' }] });
+        listSpec = {
+          sections: [
+            { blocks: [{ kind: 'paragraph', list: { numId: 'ghostList', ilvl: 0 }, runs: [{ kind: 'text', text: 'x' }] }] },
+          ],
+        };
       });
 
       let error: unknown;
-      await when('generateDocx compiles the spec', async () => {
+      let numberingError: unknown;
+      await when('generateDocx compiles each spec', async () => {
         error = await generateDocx(spec).then(
+          () => null,
+          (err: unknown) => err,
+        );
+        numberingError = await generateDocx(listSpec).then(
           () => null,
           (err: unknown) => err,
         );
@@ -85,7 +96,14 @@ describe('Traceability: styles and run/paragraph formatting emission', () => {
         expect(specError.code).toBe('dangling_style_reference');
         expect(specError.path).toBe('/sections/0/blocks/2/styleId');
         expect(specError.message).toContain('GhostStyle');
-        await attachPrettyJson('rejection', { code: specError.code, path: specError.path });
+        expect(numberingError).toBeInstanceOf(GenerationSpecError);
+        const numError = numberingError as GenerationSpecError;
+        expect(numError.code).toBe('dangling_numbering_reference');
+        expect(numError.path).toBe('/sections/0/blocks/0/list/numId');
+        await attachPrettyJson('rejections', {
+          style: { code: specError.code, path: specError.path },
+          numbering: { code: numError.code, path: numError.path },
+        });
       });
     },
   );

--- a/packages/docx-core/src/generation/index.ts
+++ b/packages/docx-core/src/generation/index.ts
@@ -10,6 +10,7 @@
 export { generateDocx, type GenerateDocxOptions } from './compile.js';
 export { GenerationSpecError, GenerationInternalError, type GenerationSpecErrorCode } from './errors.js';
 export { checkGeneratedPackage, type StructuralCheckResult, type StructuralIssue } from './structural-checks.js';
+export { coverTermsTable, signatureBlock, type CoverTermsOptions, type SignatureBlockOptions } from './recipes.js';
 export type {
   BlockSpec,
   BorderSpec,

--- a/packages/docx-core/src/generation/recipes.ts
+++ b/packages/docx-core/src/generation/recipes.ts
@@ -1,0 +1,114 @@
+/**
+ * Legal-document recipes.
+ *
+ * Pure functions producing spec nodes from options — no own OOXML
+ * representation, no compiler hooks. Everything a recipe returns is built
+ * from the paragraph/table grammar, so its output is inlineable anywhere a
+ * BlockSpec is accepted and serializes through exactly the emitters the
+ * rest of the document uses. Signature lines are bottom-bordered cells, not
+ * VML shapes: Pages and Google Docs mangle VML, borders survive everywhere.
+ */
+
+import type { BlockSpec, BorderSpec, ParagraphSpec, TableSpec } from './types.js';
+
+const SINGLE: BorderSpec = { style: 'single' };
+
+export type CoverTermsOptions = {
+  /** Label/value pairs, rendered one row each in declaration order. */
+  terms: Array<{ label: string; value: string }>;
+  /** Two-column widths in twips; defaults to a 2880/6480 split of a 6.5" body. */
+  columnWidthsTwips?: [number, number];
+  /** Heading text for a shaded full-width header row; omitted when absent. */
+  title?: string;
+};
+
+/**
+ * A fixed-layout two-column label/value table for cover-terms blocks
+ * (scenario SDX-GEN-070).
+ */
+export function coverTermsTable(options: CoverTermsOptions): TableSpec {
+  const [labelWidth, valueWidth] = options.columnWidthsTwips ?? [2880, 6480];
+  const rows: TableSpec['rows'] = [];
+  if (options.title !== undefined) {
+    rows.push({
+      header: true,
+      cells: [
+        {
+          gridSpan: 2,
+          shadingHex: 'D9D9D9',
+          vAlign: 'center',
+          blocks: [paragraph(options.title, { bold: true, alignment: 'center' })],
+        },
+      ],
+    });
+  }
+  for (const term of options.terms) {
+    rows.push({
+      cells: [
+        { blocks: [paragraph(term.label, { bold: true })] },
+        { blocks: [paragraph(term.value)] },
+      ],
+    });
+  }
+  return {
+    kind: 'table',
+    layout: 'fixed',
+    columnWidthsTwips: [labelWidth, valueWidth],
+    borders: { top: SINGLE, bottom: SINGLE, left: SINGLE, right: SINGLE, insideH: SINGLE, insideV: SINGLE },
+    rows,
+  };
+}
+
+export type SignatureBlockOptions = {
+  parties: Array<{
+    /** Party heading above the signature line, e.g. the company name. */
+    party: string;
+    /** Signatory name printed under the line. */
+    name: string;
+    title?: string;
+    /** Label for the date row; defaults to 'Date:'. */
+    dateLabel?: string;
+  }>;
+  /** Signature-line column width in twips; defaults to 4320 (3"). */
+  lineWidthTwips?: number;
+};
+
+/**
+ * Signature blocks rendered as borderless single-column tables whose first
+ * content cell carries only a bottom border — the signature line — followed
+ * by name, title, and date rows (scenario SDX-GEN-071). No VML, no images.
+ */
+export function signatureBlock(options: SignatureBlockOptions): BlockSpec[] {
+  const width = options.lineWidthTwips ?? 4320;
+  const blocks: BlockSpec[] = [];
+  options.parties.forEach((party, index) => {
+    if (index > 0) blocks.push(paragraph(''));
+    blocks.push(paragraph(party.party, { bold: true }));
+    const rows: TableSpec['rows'] = [
+      { cells: [{ borders: { bottom: SINGLE }, blocks: [paragraph('')] }] },
+      { cells: [{ blocks: [paragraph(`Name: ${party.name}`)] }] },
+    ];
+    if (party.title !== undefined) {
+      rows.push({ cells: [{ blocks: [paragraph(`Title: ${party.title}`)] }] });
+    }
+    rows.push({ cells: [{ blocks: [paragraph(party.dateLabel ?? 'Date:')] }] });
+    blocks.push({
+      kind: 'table',
+      layout: 'fixed',
+      columnWidthsTwips: [width],
+      rows,
+    });
+  });
+  return blocks;
+}
+
+function paragraph(
+  text: string,
+  opts?: { bold?: boolean; alignment?: ParagraphSpec['alignment'] },
+): ParagraphSpec {
+  return {
+    kind: 'paragraph',
+    ...(opts?.alignment !== undefined ? { alignment: opts.alignment } : {}),
+    runs: [{ kind: 'text', text, ...(opts?.bold ? { bold: true } : {}) }],
+  };
+}

--- a/packages/docx-core/src/generation/validate-spec.ts
+++ b/packages/docx-core/src/generation/validate-spec.ts
@@ -12,9 +12,10 @@
  * Shipped so far: formatted text/tab/break runs, five-part PAGE/NUMPAGES
  * fields, paragraph formatting, named styles + styles.xml, multi-section
  * documents with per-section page setup, page numbering, break types,
- * default/first/even headers and footers, and tables (grid, spans, vertical
- * merges, cell decoration, nesting).
- * Still rejected: numbering, drafting notes.
+ * default/first/even headers and footers, tables (grid, spans, vertical
+ * merges, cell decoration, nesting), and multi-level numbering with
+ * w:numPr list references.
+ * Still rejected: drafting notes.
  */
 
 import { GenerationSpecError } from './errors.js';
@@ -23,6 +24,7 @@ import type {
   BorderSpec,
   DocumentSpec,
   InlineSpec,
+  NumberingSpec,
   ParagraphSpec,
   RunProps,
   SectionSpec,
@@ -47,13 +49,49 @@ export function validateSpec(spec: DocumentSpec): void {
     throw new GenerationSpecError('empty_sections', '/sections', 'DocumentSpec.sections must contain at least one section');
   }
 
-  if (spec.numbering && spec.numbering.length > 0) unsupported('/numbering', 'numbering');
-
   const declaredStyleIds = validateStyles(spec.styles ?? []);
+  const numbering = validateNumbering(spec.numbering ?? []);
 
   spec.sections.forEach((section, sectionIndex) => {
-    validateSection(section, `/sections/${sectionIndex}`, declaredStyleIds);
+    validateSection(section, `/sections/${sectionIndex}`, declaredStyleIds, numbering);
   });
+}
+
+/** Returns numId handle → set of declared levels, for list-reference checks. */
+function validateNumbering(definitions: NumberingSpec[]): Map<string, Set<number>> {
+  const declared = new Map<string, Set<number>>();
+  definitions.forEach((definition, index) => {
+    const path = `/numbering/${index}`;
+    if (!definition.numId) {
+      throw new GenerationSpecError('invalid_value', `${path}/numId`, 'NumberingSpec requires a numId handle');
+    }
+    if (declared.has(definition.numId)) {
+      throw new GenerationSpecError('invalid_value', `${path}/numId`, `Duplicate numbering handle '${definition.numId}'`);
+    }
+    if (!Array.isArray(definition.levels) || definition.levels.length === 0) {
+      throw new GenerationSpecError('invalid_value', `${path}/levels`, 'Numbering definitions require at least one level');
+    }
+    const levels = new Set<number>();
+    definition.levels.forEach((level, levelIndex) => {
+      const levelPath = `${path}/levels/${levelIndex}`;
+      if (!Number.isInteger(level.ilvl) || level.ilvl < 0 || level.ilvl > 8) {
+        throw new GenerationSpecError('invalid_value', `${levelPath}/ilvl`, 'ilvl must be an integer between 0 and 8');
+      }
+      if (levels.has(level.ilvl)) {
+        throw new GenerationSpecError('invalid_value', `${levelPath}/ilvl`, `Duplicate ilvl ${level.ilvl} in numbering '${definition.numId}'`);
+      }
+      levels.add(level.ilvl);
+      if (typeof level.lvlText !== 'string' || level.lvlText.length === 0) {
+        throw new GenerationSpecError('invalid_value', `${levelPath}/lvlText`, 'Numbering levels require a lvlText pattern');
+      }
+      if (level.start !== undefined && (!Number.isInteger(level.start) || level.start < 0)) {
+        throw new GenerationSpecError('invalid_value', `${levelPath}/start`, 'Level start must be a non-negative integer');
+      }
+      if (level.runProps) validateRunProps(level.runProps, `${levelPath}/runProps`);
+    });
+    declared.set(definition.numId, levels);
+  });
+  return declared;
 }
 
 /** Returns the set of resolvable style ids (declared styles + implicit Normal). */
@@ -87,7 +125,7 @@ function validateStyles(styles: StyleSpec[]): Set<string> {
   return ids;
 }
 
-function validateSection(section: SectionSpec, path: string, styleIds: Set<string>): void {
+function validateSection(section: SectionSpec, path: string, styleIds: Set<string>, numbering: Map<string, Set<number>>): void {
   if (section.pageNumbering?.start !== undefined) {
     const start = section.pageNumbering.start;
     if (!Number.isInteger(start) || start < 1) {
@@ -104,7 +142,7 @@ function validateSection(section: SectionSpec, path: string, styleIds: Set<strin
         throw new GenerationSpecError('invalid_value', `${slotPath}/blocks`, 'Header/footer blocks must be a non-empty array');
       }
       content.blocks.forEach((block, blockIndex) => {
-        validateBlock(block, `${slotPath}/blocks/${blockIndex}`, styleIds);
+        validateBlock(block, `${slotPath}/blocks/${blockIndex}`, styleIds, numbering);
       });
     }
   }
@@ -126,13 +164,13 @@ function validateSection(section: SectionSpec, path: string, styleIds: Set<strin
     throw new GenerationSpecError('invalid_value', `${path}/blocks`, 'Section blocks must be an array');
   }
   section.blocks.forEach((block, blockIndex) => {
-    validateBlock(block, `${path}/blocks/${blockIndex}`, styleIds);
+    validateBlock(block, `${path}/blocks/${blockIndex}`, styleIds, numbering);
   });
 }
 
-function validateBlock(block: BlockSpec, path: string, styleIds: Set<string>): void {
-  if (block.kind === 'table') validateTable(block, path, styleIds);
-  else validateParagraph(block, path, styleIds);
+function validateBlock(block: BlockSpec, path: string, styleIds: Set<string>, numbering: Map<string, Set<number>>): void {
+  if (block.kind === 'table') validateTable(block, path, styleIds, numbering);
+  else validateParagraph(block, path, styleIds, numbering);
 }
 
 /**
@@ -142,7 +180,7 @@ function validateBlock(block: BlockSpec, path: string, styleIds: Set<string>): v
  * span of a merge cell in the previous row — otherwise readers either show
  * a recovery dialog or silently reflow the table.
  */
-function validateTable(table: TableSpec, path: string, styleIds: Set<string>): void {
+function validateTable(table: TableSpec, path: string, styleIds: Set<string>, numbering: Map<string, Set<number>>): void {
   if (!Array.isArray(table.columnWidthsTwips) || table.columnWidthsTwips.length === 0) {
     throw new GenerationSpecError('invalid_value', `${path}/columnWidthsTwips`, 'Tables require at least one column width');
   }
@@ -207,7 +245,7 @@ function validateTable(table: TableSpec, path: string, styleIds: Set<string>): v
         throw new GenerationSpecError('invalid_value', `${cellPath}/blocks`, 'Cell blocks must be an array (empty allowed; an empty cell compiles to an empty paragraph)');
       }
       cell.blocks.forEach((block, blockIndex) => {
-        validateBlock(block, `${cellPath}/blocks/${blockIndex}`, styleIds);
+        validateBlock(block, `${cellPath}/blocks/${blockIndex}`, styleIds, numbering);
       });
       gridOffset += span;
     });
@@ -235,9 +273,26 @@ function validateBorders(borders: TableBorders, path: string): void {
   }
 }
 
-function validateParagraph(paragraph: ParagraphSpec, path: string, styleIds: Set<string>): void {
-  if (paragraph.list !== undefined) unsupported(`${path}/list`, 'numbered lists');
+function validateParagraph(paragraph: ParagraphSpec, path: string, styleIds: Set<string>, numbering: Map<string, Set<number>>): void {
   if (paragraph.note !== undefined) unsupported(`${path}/note`, 'drafting notes');
+
+  if (paragraph.list !== undefined) {
+    const levels = numbering.get(paragraph.list.numId);
+    if (!levels) {
+      throw new GenerationSpecError(
+        'dangling_numbering_reference',
+        `${path}/list/numId`,
+        `Paragraph references undeclared numbering '${paragraph.list.numId}'`,
+      );
+    }
+    if (!levels.has(paragraph.list.ilvl)) {
+      throw new GenerationSpecError(
+        'dangling_numbering_reference',
+        `${path}/list/ilvl`,
+        `Numbering '${paragraph.list.numId}' declares no level ${paragraph.list.ilvl}`,
+      );
+    }
+  }
 
   if (paragraph.styleId !== undefined && !styleIds.has(paragraph.styleId)) {
     throw new GenerationSpecError(

--- a/packages/docx-core/src/primitives/namespaces.ts
+++ b/packages/docx-core/src/primitives/namespaces.ts
@@ -70,6 +70,8 @@ export const W = {
   abstractNumId: 'abstractNumId',
   lvlOverride: 'lvlOverride',
   startOverride: 'startOverride',
+  lvlJc: 'lvlJc',
+  multiLevelType: 'multiLevelType',
 
   // Tables + layout
   tbl: 'tbl',

--- a/packages/docx-core/src/primitives/xml.ts
+++ b/packages/docx-core/src/primitives/xml.ts
@@ -2,6 +2,12 @@ import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
 
 export type XmlDoc = Document;
 
+/**
+ * Standard XML declaration for serialized OOXML parts. xmldom's serializer
+ * omits the declaration, so every emitted part prepends this manually.
+ */
+export const XML_DECL = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
+
 export function parseXml(xml: string): XmlDoc {
   // application/xml ensures XML parsing rules (vs HTML-ish parsing).
   // xmldom 0.9.x returns its own module-scoped Document type; cast to global

--- a/spec-compliance/CONFORMANCE.md
+++ b/spec-compliance/CONFORMANCE.md
@@ -56,6 +56,20 @@ Allure labels via `testAllure.conformance({…})`; source code carries
 | `ECMA-PART1-17-4-83` | w:vAlign cell vertical alignment | 5 | 1 | 17.4.83 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:vAlign` | — |
 | `ECMA-PART1-17-4-68` | w:tcMar single-cell margins | 5 | 1 | 17.4.68 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:tcMar` | — |
 | `ECMA-PART1-17-4-66` | w:tcBorders cell border collection | 5 | 1 | 17.4.66 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:tcBorders` | — |
+| `ECMA-PART1-17-9-16` | w:numbering numbering-definitions part emission | 5 | 1 | 17.9.16 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:numbering` | — |
+| `ECMA-PART1-17-9-1` | w:abstractNum abstract numbering definition | 5 | 1 | 17.9.1 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:abstractNum` | — |
+| `ECMA-PART1-17-9-2` | w:abstractNumId abstract definition reference | 5 | 1 | 17.9.2 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:abstractNumId` | — |
+| `ECMA-PART1-17-9-15` | w:num numbering definition instance | 5 | 1 | 17.9.15 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:num` | — |
+| `ECMA-PART1-17-9-18` | w:numId numbering instance reference | 5 | 1 | 17.9.18 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:numId` | — |
+| `ECMA-PART1-17-9-3` | w:ilvl numbering level reference | 5 | 1 | 17.9.3 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:ilvl` | — |
+| `ECMA-PART1-17-9-6` | w:lvl numbering level definition | 5 | 1 | 17.9.6 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:lvl` | — |
+| `ECMA-PART1-17-9-17` | w:numFmt numbering format | 5 | 1 | 17.9.17 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:numFmt` | — |
+| `ECMA-PART1-17-9-11` | w:lvlText numbering level text | 5 | 1 | 17.9.11 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:lvlText` | — |
+| `ECMA-PART1-17-9-25` | w:start numbering level starting value | 5 | 1 | 17.9.25 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:start` | — |
+| `ECMA-PART1-17-9-28` | w:suff content between numbering symbol and text | 5 | 1 | 17.9.28 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:suff` | — |
+| `ECMA-PART1-17-9-12` | w:multiLevelType abstract definition type | 5 | 1 | 17.9.12 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:multiLevelType` | — |
+| `ECMA-PART1-17-9-7` | w:lvlJc numbering level justification | 5 | 1 | 17.9.7 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:lvlJc` | — |
+| `ECMA-PART1-17-3-1-19` | w:numPr paragraph numbering reference | 5 | 1 | 17.3.1.19 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:numPr` | — |
 
 ### ECMA-PART4-17-16-5 — w:delInstrText and w:fldChar placement in tracked deletions
 
@@ -593,6 +607,159 @@ explicit `dxa` widths; only the edges the spec declares are written.
 Declared cell borders emit as a `w:tcBorders` collection in the
 `CT_TcBorders` sequence with explicit size/space/color per edge, sitting
 between `w:vMerge` and `w:shd` in the cell-property order.
+
+### ECMA-PART1-17-9-16 — w:numbering numbering-definitions part emission
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.9.16
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:numbering`
+
+Declared numbering definitions compile to a word/numbering.xml part whose
+root holds every abstract definition before every instance, per the
+CT_Numbering sequence. The emitter lives in
+`packages/docx-core/src/generation/emit/numbering-part.ts`.
+
+### ECMA-PART1-17-9-1 — w:abstractNum abstract numbering definition
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.9.1
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:abstractNum`
+
+Each NumberingSpec becomes one abstract definition with sequential
+`abstractNumId` values assigned in declaration order — ids are
+deterministic compile output, never random.
+
+### ECMA-PART1-17-9-2 — w:abstractNumId abstract definition reference
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.9.2
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:abstractNumId`
+
+Every emitted instance references its abstract definition through
+`w:abstractNumId`; the pairing is 1:1 by construction so the reference can
+never dangle.
+
+### ECMA-PART1-17-9-15 — w:num numbering definition instance
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.9.15
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:num`
+
+Instances carry sequential numeric `w:numId` values (starting at 1) in
+declaration order; the spec-level string handle → numeric id map is what
+paragraph references bind through.
+
+### ECMA-PART1-17-9-18 — w:numId numbering instance reference
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.9.18
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:numId`
+
+List paragraphs reference their instance via `w:numId` inside `w:numPr`;
+spec validation rejects handles with no declared definition
+(`dangling_numbering_reference`) before any XML is produced.
+
+### ECMA-PART1-17-9-3 — w:ilvl numbering level reference
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.9.3
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:ilvl`
+
+The paragraph's level reference is emitted before `w:numId` per the
+CT_NumPr sequence, and validation requires the referenced level to exist
+in the bound definition.
+
+### ECMA-PART1-17-9-6 — w:lvl numbering level definition
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.9.6
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:lvl`
+
+Level definitions follow the CT_Lvl child sequence (start, numFmt, suff,
+lvlText, lvlJc, pPr, rPr); level indents emit through `w:pPr`/`w:ind` and
+level run properties reuse the shared rPr builder.
+
+### ECMA-PART1-17-9-17 — w:numFmt numbering format
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.9.17
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:numFmt`
+
+Each level carries its declared format verbatim (decimal, letter, roman,
+bullet, none); the generated formats round-trip through the read-side
+label computation in `packages/docx-core/src/primitives/numbering.ts`.
+
+### ECMA-PART1-17-9-11 — w:lvlText numbering level text
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.9.11
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:lvlText`
+
+The level text pattern (e.g. `%1.` / `%1.%2` / a literal bullet glyph) is
+emitted verbatim from the spec; validation requires a non-empty pattern on
+every level.
+
+### ECMA-PART1-17-9-25 — w:start numbering level starting value
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.9.25
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:start`
+
+The starting value is always emitted explicitly (declared value or 1) so
+readers never fall back to divergent defaults.
+
+### ECMA-PART1-17-9-28 — w:suff content between numbering symbol and text
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.9.28
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:suff`
+
+A declared suffix (tab/space/nothing) emits at its CT_Lvl position; when
+absent the element is omitted and readers apply the spec default (tab),
+matching the read-side parser's assumption.
+
+### ECMA-PART1-17-9-12 — w:multiLevelType abstract definition type
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.9.12
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:multiLevelType`
+
+Abstract definitions declare `multilevel` when more than one level exists
+and `singleLevel` otherwise, so single-level bullet definitions don't
+advertise unused depth.
+
+### ECMA-PART1-17-9-7 — w:lvlJc numbering level justification
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.9.7
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:lvlJc`
+
+Level justification is always emitted (`left`) for determinism — omission
+leaves the alignment to reader defaults.
+
+### ECMA-PART1-17-3-1-19 — w:numPr paragraph numbering reference
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.3.1.19
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:numPr`
+
+List paragraphs carry `w:numPr` (ilvl then numId) at its CT_PPrBase slot
+via the PPR_ORDER table; the numeric id comes from the numbering part's
+deterministic handle map.
 
 ## Non-Goals
 

--- a/spec-compliance/registry/ecma-376.md
+++ b/spec-compliance/registry/ecma-376.md
@@ -721,6 +721,215 @@ Declared cell borders emit as a `w:tcBorders` collection in the
 `CT_TcBorders` sequence with explicit size/space/color per edge, sitting
 between `w:vMerge` and `w:shd` in the cell-property order.
 
+## [ECMA-PART1-17-9-16] w:numbering numbering-definitions part emission
+
+```yaml
+edition: 5
+part: 1
+section: "17.9.16"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:numbering
+verifiedBy:
+```
+
+Declared numbering definitions compile to a word/numbering.xml part whose
+root holds every abstract definition before every instance, per the
+CT_Numbering sequence. The emitter lives in
+`packages/docx-core/src/generation/emit/numbering-part.ts`.
+
+## [ECMA-PART1-17-9-1] w:abstractNum abstract numbering definition
+
+```yaml
+edition: 5
+part: 1
+section: "17.9.1"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:abstractNum
+verifiedBy:
+```
+
+Each NumberingSpec becomes one abstract definition with sequential
+`abstractNumId` values assigned in declaration order — ids are
+deterministic compile output, never random.
+
+## [ECMA-PART1-17-9-2] w:abstractNumId abstract definition reference
+
+```yaml
+edition: 5
+part: 1
+section: "17.9.2"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:abstractNumId
+verifiedBy:
+```
+
+Every emitted instance references its abstract definition through
+`w:abstractNumId`; the pairing is 1:1 by construction so the reference can
+never dangle.
+
+## [ECMA-PART1-17-9-15] w:num numbering definition instance
+
+```yaml
+edition: 5
+part: 1
+section: "17.9.15"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:num
+verifiedBy:
+```
+
+Instances carry sequential numeric `w:numId` values (starting at 1) in
+declaration order; the spec-level string handle → numeric id map is what
+paragraph references bind through.
+
+## [ECMA-PART1-17-9-18] w:numId numbering instance reference
+
+```yaml
+edition: 5
+part: 1
+section: "17.9.18"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:numId
+verifiedBy:
+```
+
+List paragraphs reference their instance via `w:numId` inside `w:numPr`;
+spec validation rejects handles with no declared definition
+(`dangling_numbering_reference`) before any XML is produced.
+
+## [ECMA-PART1-17-9-3] w:ilvl numbering level reference
+
+```yaml
+edition: 5
+part: 1
+section: "17.9.3"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:ilvl
+verifiedBy:
+```
+
+The paragraph's level reference is emitted before `w:numId` per the
+CT_NumPr sequence, and validation requires the referenced level to exist
+in the bound definition.
+
+## [ECMA-PART1-17-9-6] w:lvl numbering level definition
+
+```yaml
+edition: 5
+part: 1
+section: "17.9.6"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:lvl
+verifiedBy:
+```
+
+Level definitions follow the CT_Lvl child sequence (start, numFmt, suff,
+lvlText, lvlJc, pPr, rPr); level indents emit through `w:pPr`/`w:ind` and
+level run properties reuse the shared rPr builder.
+
+## [ECMA-PART1-17-9-17] w:numFmt numbering format
+
+```yaml
+edition: 5
+part: 1
+section: "17.9.17"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:numFmt
+verifiedBy:
+```
+
+Each level carries its declared format verbatim (decimal, letter, roman,
+bullet, none); the generated formats round-trip through the read-side
+label computation in `packages/docx-core/src/primitives/numbering.ts`.
+
+## [ECMA-PART1-17-9-11] w:lvlText numbering level text
+
+```yaml
+edition: 5
+part: 1
+section: "17.9.11"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:lvlText
+verifiedBy:
+```
+
+The level text pattern (e.g. `%1.` / `%1.%2` / a literal bullet glyph) is
+emitted verbatim from the spec; validation requires a non-empty pattern on
+every level.
+
+## [ECMA-PART1-17-9-25] w:start numbering level starting value
+
+```yaml
+edition: 5
+part: 1
+section: "17.9.25"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:start
+verifiedBy:
+```
+
+The starting value is always emitted explicitly (declared value or 1) so
+readers never fall back to divergent defaults.
+
+## [ECMA-PART1-17-9-28] w:suff content between numbering symbol and text
+
+```yaml
+edition: 5
+part: 1
+section: "17.9.28"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:suff
+verifiedBy:
+```
+
+A declared suffix (tab/space/nothing) emits at its CT_Lvl position; when
+absent the element is omitted and readers apply the spec default (tab),
+matching the read-side parser's assumption.
+
+## [ECMA-PART1-17-9-12] w:multiLevelType abstract definition type
+
+```yaml
+edition: 5
+part: 1
+section: "17.9.12"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:multiLevelType
+verifiedBy:
+```
+
+Abstract definitions declare `multilevel` when more than one level exists
+and `singleLevel` otherwise, so single-level bullet definitions don't
+advertise unused depth.
+
+## [ECMA-PART1-17-9-7] w:lvlJc numbering level justification
+
+```yaml
+edition: 5
+part: 1
+section: "17.9.7"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:lvlJc
+verifiedBy:
+```
+
+Level justification is always emitted (`left`) for determinism — omission
+leaves the alignment to reader defaults.
+
+## [ECMA-PART1-17-3-1-19] w:numPr paragraph numbering reference
+
+```yaml
+edition: 5
+part: 1
+section: "17.3.1.19"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:numPr
+verifiedBy:
+```
+
+List paragraphs carry `w:numPr` (ilvl then numId) at its CT_PPrBase slot
+via the PPR_ORDER table; the numeric id comes from the numbering part's
+deterministic handle map.
+
 ## Non-Goals
 
 Sections explicitly **out of scope** for safe-docx. Each entry below carries the


### PR DESCRIPTION
## Summary

Phase 5 of the `add-docx-generation` OpenSpec change (PR 5 of 7): multi-level numbering and the legal-document recipes. Implements scenarios `[SDX-GEN-060]`..`[SDX-GEN-062]`, `[SDX-GEN-070]`, `[SDX-GEN-071]`.

- **`emit/numbering-part.ts`**: each `NumberingSpec` compiles to one `w:abstractNum` + one `w:num` with deterministic sequential ids (handle → numeric map returned to the compiler); CT_Numbering sequence (all abstracts before all instances); CT_Lvl child order (`start`, `numFmt`, `suff`, `lvlText`, `lvlJc`, `pPr`/`w:ind` level indents, `rPr` bullet-glyph fonts via the shared rPr builder); `multiLevelType` reflects declared depth.
- **`w:numPr` wiring**: list paragraphs emit `ilvl` then `numId` (CT_NumPr) through the shared pPr builder at its `PPR_ORDER` slot; the id map threads through every block emitter, so lists work in body, cells, and headers/footers.
- **Validation**: numbering shape checks (unique handles, ilvl 0–8 unique per definition, non-empty `lvlText`) and dangling-reference rejection — undeclared `numId` or missing `ilvl` fail with `dangling_numbering_reference` before emission; the `[SDX-GEN-004]` scenario test now covers its numId half.
- **Label round-trip** (scenario 061): the read-side `computeListLabelForParagraph` over a generated nested list reproduces exactly the labels the definition implies (`1.`, `1.1`, `1.2`, `(i)`, `2.`, `2.1`).
- **`recipes.ts`** (scenarios 070/071): `coverTermsTable` → fixed-layout two-column label/value table (optional shaded spanning title row); `signatureBlock` → per-party bottom-bordered signature-line cell + name/title/date rows, no VML/picture markup. Pure `opts → spec-node` functions, JSON-round-trip clean, exported from the generation index.
- `[SDX-GEN-003]`'s unsupported probes move to drafting notes only (body + table-cell paths) — the last unshipped feature before phase 6.
- **Registry**: 14 new entries (§ 17.9.x + § 17.3.1.19), section numbers verified against the ECMA-376 Part 1 ToC; CONFORMANCE.md + README block regenerated.
- New review artifact `generation-phase5-numbering-recipes.docx` + manual-compat matrix row.

Spec coverage: 31/36 scenarios mapped (remaining 5 belong to phases 6–7; generation coverage validator stays `--report-only` until PR 7).

Ref: #280

## Test plan

- [x] `npm run build && npm run lint:workspaces && npm run test:run` (2563 passed)
- [x] `npm run check:spec-coverage` (incl. generation validator, report-only) + allure-labels validator
- [x] `npm run check:conformance-citations` (57 entries) / `check:conformance-doc` green at commit
- [x] `openspec validate add-docx-generation --strict`
- [x] New `generation-numbering-recipes.test.ts`: part emission + numPr binding (060), oracle label round-trip (061), bullet/decimal/roman formats (062), cover-terms recipe (070), signature-block recipe incl. no-VML assertion (071), artifact round-trip through `DocxDocument`