### PR TITLE
fix: minimal edit saves — preserve untouched paragraphs, DEFLATE re-pack (#408)

### DIFF
--- a/packages/docx-core/src/primitives/document.ts
+++ b/packages/docx-core/src/primitives/document.ts
@@ -41,6 +41,7 @@ import {
   type ExtractTablesResult,
 } from './tables.js';
 import { mergeRuns, type MergeRunsOptions, type MergeRunsResult } from './merge_runs.js';
+import { restoreUntouchedBlocks } from './minimal_save.js';
 import { simplifyRedlines } from './simplify_redlines.js';
 import { preventDoubleElevation } from './prevent_double_elevation.js';
 import { validateDocument, type ValidateDocumentResult } from './validate_document.js';
@@ -388,8 +389,14 @@ export class DocxDocument {
   private relsMap: RelsMap;
   private dirty: boolean;
   private documentViewCache: { includeSemanticTags: boolean; showFormatting: boolean; formattingMode: FormattingMode; nodes: DocumentViewNode[]; styles: DocumentStyles } | null;
+  /**
+   * Raw document.xml text as loaded, before normalize()/edits mutate the DOM.
+   * Reference for minimal re-serialization in toBuffer(); null for instances
+   * not created via load().
+   */
+  private originalDocumentXmlText: string | null;
 
-  private constructor(zip: DocxZip, documentXml: Document, stylesXml: Document | null, numberingXml: Document | null, footnotesXml: Document | null, relsMap: RelsMap) {
+  private constructor(zip: DocxZip, documentXml: Document, stylesXml: Document | null, numberingXml: Document | null, footnotesXml: Document | null, relsMap: RelsMap, originalDocumentXmlText: string | null = null) {
     this.zip = zip;
     this.documentXml = documentXml;
     this.stylesXml = stylesXml;
@@ -398,6 +405,7 @@ export class DocxDocument {
     this.relsMap = relsMap;
     this.dirty = false;
     this.documentViewCache = null;
+    this.originalDocumentXmlText = originalDocumentXmlText;
   }
 
   static async load(buffer: Buffer): Promise<DocxDocument> {
@@ -419,7 +427,7 @@ export class DocxDocument {
     const relsText = await zip.readTextOrNull('word/_rels/document.xml.rels');
     const relsMap = relsText ? parseDocumentRels(parseXml(relsText)) : new Map<string, string>();
 
-    return new DocxDocument(zip, doc, stylesXml, numberingXml, footnotesXml, relsMap);
+    return new DocxDocument(zip, doc, stylesXml, numberingXml, footnotesXml, relsMap, xml);
   }
 
   getParagraphs(): Element[] {
@@ -1195,7 +1203,20 @@ export class DocxDocument {
     return parseXml(commentsText);
   }
 
-  async toBuffer(opts?: { cleanBookmarks?: boolean }): Promise<{ buffer: Buffer; bookmarksRemoved: number }> {
+  /**
+   * Serialize the document to a .docx buffer.
+   *
+   * With `minimalReserialization` (requires `cleanBookmarks`), top-level body
+   * blocks that no edit touched are restored element-for-element from the
+   * original document.xml instead of carrying the open-time normalization
+   * (proofErr stripping, run merging) to disk — so output diffs reflect the
+   * actual edit blast radius. Edited/inserted blocks are emitted as-is.
+   * Falls back to full re-serialization (blocksRestored: 0) when no original
+   * text was captured or reconciliation fails.
+   *
+   * @see https://github.com/UseJunior/safe-docx/issues/408
+   */
+  async toBuffer(opts?: { cleanBookmarks?: boolean; minimalReserialization?: boolean }): Promise<{ buffer: Buffer; bookmarksRemoved: number; blocksRestored: number }> {
     // Always write the latest document.xml when saving.
     // Important: when cleanBookmarks=true (download), we must NOT mutate session state.
     const xmlWithBookmarks = serializeXml(this.documentXml);
@@ -1204,16 +1225,26 @@ export class DocxDocument {
     if (opts?.cleanBookmarks) {
       const cloned = parseXml(xmlWithBookmarks);
       const bookmarksRemoved = cleanupInternalBookmarks(cloned);
+      let blocksRestored = 0;
+      if (opts.minimalReserialization && this.originalDocumentXmlText !== null) {
+        try {
+          blocksRestored = restoreUntouchedBlocks(cloned, this.originalDocumentXmlText);
+        } catch {
+          // Reconciliation is best-effort; the fully re-serialized DOM is
+          // always a correct (if non-minimal) save.
+          blocksRestored = 0;
+        }
+      }
       const cleanedXml = serializeXml(cloned);
 
       // Temporarily swap document.xml in the zip for output, then restore.
       this.zip.writeText('word/document.xml', cleanedXml);
       const buffer = await this.zip.toBuffer();
       this.zip.writeText('word/document.xml', xmlWithBookmarks);
-      return { buffer, bookmarksRemoved };
+      return { buffer, bookmarksRemoved, blocksRestored };
     }
 
     const buffer = await this.zip.toBuffer();
-    return { buffer, bookmarksRemoved: 0 };
+    return { buffer, bookmarksRemoved: 0, blocksRestored: 0 };
   }
 }

--- a/packages/docx-core/src/primitives/index.ts
+++ b/packages/docx-core/src/primitives/index.ts
@@ -16,6 +16,7 @@ export * from './xml.js';
 export * from './dom-helpers.js';
 export * from './zip.js';
 export * from './merge_runs.js';
+export * from './minimal_save.js';
 export * from './simplify_redlines.js';
 export * from './validate_document.js';
 export * from './accept_changes.js';

--- a/packages/docx-core/src/primitives/minimal_save.test.ts
+++ b/packages/docx-core/src/primitives/minimal_save.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Regression tests for issue #408: a one-paragraph edit must not persist
+ * open-time normalization (proofErr stripping, run merging) to untouched
+ * paragraphs, so on-disk diffs reflect the edit's actual blast radius.
+ */
+
+import { XMLSerializer } from '@xmldom/xmldom';
+import { describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { buildDocxFromBodyXml } from '../testing/ooxml-fixtures.js';
+import { DocxDocument } from './document.js';
+import { restoreUntouchedBlocks } from './minimal_save.js';
+import { OOXML, W } from './namespaces.js';
+import { parseXml } from './xml.js';
+import { readZipText } from './zip.js';
+
+const test = testAllure.epic('Document Comparison').withLabels({ feature: 'Document Primitives' });
+
+const serializer = new XMLSerializer();
+
+/** Serialized element children of the document's w:body. */
+function bodyBlocks(xml: string): string[] {
+  const doc = parseXml(xml);
+  const body = doc.getElementsByTagNameNS(OOXML.W_NS, W.body).item(0);
+  if (!body) return [];
+  const out: string[] = [];
+  let child = body.firstChild;
+  while (child) {
+    if (child.nodeType === 1) out.push(serializer.serializeToString(child as Element));
+    child = child.nextSibling;
+  }
+  return out;
+}
+
+function firstTextNode(paragraph: Element): Element {
+  const t = paragraph.getElementsByTagNameNS(OOXML.W_NS, W.t).item(0);
+  if (!t) throw new Error('Expected a w:t in paragraph');
+  return t as Element;
+}
+
+// Three Word-shaped paragraphs: P1 and P3 carry volatile proofing markup and
+// rsid-fragmented same-format runs (what normalize() rewrites); P2 is the
+// edit target.
+const P1 =
+  `<w:p w14:paraId="0000AAAA"><w:proofErr w:type="spellStart"/><w:r w:rsidR="00AA0001"><w:t>Lorem</w:t></w:r>` +
+  `<w:proofErr w:type="spellEnd"/><w:r w:rsidR="00AA0002"><w:t xml:space="preserve"> ipsum</w:t></w:r></w:p>`;
+const P2 = `<w:p w14:paraId="0000BBBB"><w:r w:rsidR="00BB0001"><w:t>{placeholder}</w:t></w:r></w:p>`;
+const P3 =
+  `<w:p w14:paraId="0000CCCC"><w:proofErr w:type="gramStart"/><w:r><w:t>dolor</w:t></w:r>` +
+  `<w:proofErr w:type="gramEnd"/><w:r><w:t xml:space="preserve"> sit</w:t></w:r></w:p>`;
+
+async function openLikeASession(bodyXml: string): Promise<{ doc: DocxDocument; originalXml: string }> {
+  const buffer = await buildDocxFromBodyXml(bodyXml);
+  const originalXml = (await readZipText(buffer, 'word/document.xml'))!;
+  const doc = await DocxDocument.load(buffer);
+  doc.normalize();
+  doc.insertParagraphBookmarks('mcp_test');
+  return { doc, originalXml };
+}
+
+describe('minimal re-serialization on save (issue #408)', () => {
+  test('a single-paragraph edit leaves untouched paragraphs element-identical to the original', async ({ given, when, then }: AllureBddContext) => {
+    let doc: DocxDocument;
+    let originalXml = '';
+    let savedXml = '';
+    let blocksRestored = 0;
+
+    await given('a normalized session over a document with proofErr and fragmented runs', async () => {
+      ({ doc, originalXml } = await openLikeASession(P1 + P2 + P3));
+    });
+
+    await when('one paragraph is edited and the document is saved minimally', async () => {
+      const target = doc.getParagraphs()[1]!;
+      firstTextNode(target).textContent = 'two (2) years';
+      const saved = await doc.toBuffer({ cleanBookmarks: true, minimalReserialization: true });
+      blocksRestored = saved.blocksRestored;
+      savedXml = (await readZipText(saved.buffer, 'word/document.xml'))!;
+    });
+
+    await then('untouched paragraphs keep their original XML and only the edit shows', () => {
+      const original = bodyBlocks(originalXml);
+      const saved = bodyBlocks(savedXml);
+      expect(saved).toHaveLength(original.length);
+
+      // P1 and P3 regain proofErr + separate rsid runs; sectPr untouched.
+      expect(saved[0]).toBe(original[0]);
+      expect(saved[2]).toBe(original[2]);
+      expect(saved[3]).toBe(original[3]);
+      // The edited paragraph carries the new text and stays normalized.
+      expect(saved[1]).toContain('two (2) years');
+      expect(saved[1]).not.toBe(original[1]);
+      expect(blocksRestored).toBe(3);
+
+      // The original's volatile markup really was at stake: the normalized
+      // session DOM had stripped it.
+      expect(original[0]).toContain('proofErr');
+      expect(saved[0]).toContain('proofErr');
+    });
+  });
+
+  test('a zero-edit save round-trips document.xml element-identically', async ({ given, when, then }: AllureBddContext) => {
+    let doc: DocxDocument;
+    let originalXml = '';
+    let savedXml = '';
+    let blocksRestored = 0;
+
+    await given('a normalized session with no edits', async () => {
+      ({ doc, originalXml } = await openLikeASession(P1 + P2 + P3));
+    });
+
+    await when('the document is saved minimally', async () => {
+      const saved = await doc.toBuffer({ cleanBookmarks: true, minimalReserialization: true });
+      blocksRestored = saved.blocksRestored;
+      savedXml = (await readZipText(saved.buffer, 'word/document.xml'))!;
+    });
+
+    await then('every block is restored and the document matches the original', () => {
+      expect(blocksRestored).toBe(4);
+      // Element-identical: both sides pass once through the same serializer.
+      expect(savedXml).toBe(serializer.serializeToString(parseXml(originalXml) as never));
+    });
+  });
+
+  test('an inserted paragraph does not disturb restoration of its neighbors', async ({ given, when, then }: AllureBddContext) => {
+    let doc: DocxDocument;
+    let originalXml = '';
+    let savedXml = '';
+
+    await given('a normalized session', async () => {
+      ({ doc, originalXml } = await openLikeASession(P1 + P2 + P3));
+    });
+
+    await when('a paragraph is inserted and the document is saved minimally', async () => {
+      const body = doc.getParagraphs()[0]!.parentNode!;
+      const inserted = parseXml(
+        `<w:p xmlns:w="${OOXML.W_NS}"><w:r><w:t>brand new</w:t></w:r></w:p>`,
+      ).documentElement!;
+      body.insertBefore(doc.getParagraphs()[0]!.ownerDocument!.importNode(inserted, true), doc.getParagraphs()[1]!);
+      const saved = await doc.toBuffer({ cleanBookmarks: true, minimalReserialization: true });
+      savedXml = (await readZipText(saved.buffer, 'word/document.xml'))!;
+    });
+
+    await then('untouched blocks are restored around the insertion', () => {
+      const original = bodyBlocks(originalXml);
+      const saved = bodyBlocks(savedXml);
+      expect(saved).toHaveLength(original.length + 1);
+      expect(saved[0]).toBe(original[0]);
+      expect(saved[1]).toContain('brand new');
+      expect(saved[2]).toBe(original[1]);
+      expect(saved[3]).toBe(original[2]);
+      expect(saved[4]).toBe(original[3]);
+    });
+  });
+
+  test('duplicate-normalizing paragraphs realign to their own originals when the earlier one is edited', async ({ given, when, then }: AllureBddContext) => {
+    // Two paragraphs that normalize to IDENTICAL serializations (no paraId,
+    // same shape, different run-level rsids). A serialization-keyed FIFO
+    // would hand the untouched SECOND paragraph the FIRST's original.
+    const originalXmlText =
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+      `<w:document xmlns:w="${OOXML.W_NS}"><w:body>` +
+      `<w:p><w:r w:rsidR="00000001"><w:t>same</w:t></w:r></w:p>` +
+      `<w:p><w:r w:rsidR="00000002"><w:t>same</w:t></w:r></w:p>` +
+      `</w:body></w:document>`;
+    let currentDoc: Document;
+    let restored = 0;
+
+    await given('a session DOM where the first duplicate was edited', () => {
+      currentDoc = parseXml(
+        `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+        `<w:document xmlns:w="${OOXML.W_NS}"><w:body>` +
+        `<w:p><w:r><w:t>changed</w:t></w:r></w:p>` +
+        `<w:p><w:r><w:t>same</w:t></w:r></w:p>` +
+        `</w:body></w:document>`,
+      );
+    });
+
+    await when('untouched blocks are restored', () => {
+      restored = restoreUntouchedBlocks(currentDoc, originalXmlText);
+    });
+
+    await then('the untouched second paragraph regains its own rsid identity', () => {
+      const blocks = bodyBlocks(serializer.serializeToString(currentDoc as never));
+      expect(restored).toBe(1);
+      expect(blocks[0]).toContain('changed');
+      expect(blocks[0]).not.toContain('rsidR');
+      expect(blocks[1]).toContain('w:rsidR="00000002"');
+    });
+  });
+
+  test('an untouched table restores while a modified table keeps its edit', async ({ given, when, then }: AllureBddContext) => {
+    const CELL_P =
+      `<w:p><w:proofErr w:type="spellStart"/><w:r w:rsidR="00CC0001"><w:t>cell</w:t></w:r>` +
+      `<w:proofErr w:type="spellEnd"/><w:r w:rsidR="00CC0002"><w:t xml:space="preserve"> text</w:t></w:r></w:p>`;
+    const TBL = (cellP: string) =>
+      `<w:tbl><w:tr><w:tc>${cellP}</w:tc></w:tr></w:tbl>`;
+    let untouched: { originalXml: string; savedXml: string };
+    let modified: { originalXml: string; savedXml: string };
+
+    await given('two sessions over a document containing a table', async () => {
+      untouched = { originalXml: '', savedXml: '' };
+      modified = { originalXml: '', savedXml: '' };
+    });
+
+    await when('one session edits a paragraph outside the table, the other a cell inside it', async () => {
+      {
+        const { doc, originalXml } = await openLikeASession(TBL(CELL_P) + P2);
+        const outside = doc.getParagraphs().find((p) => firstTextNode(p).textContent === '{placeholder}')!;
+        firstTextNode(outside).textContent = 'edited outside';
+        const saved = await doc.toBuffer({ cleanBookmarks: true, minimalReserialization: true });
+        untouched = { originalXml, savedXml: (await readZipText(saved.buffer, 'word/document.xml'))! };
+      }
+      {
+        const { doc, originalXml } = await openLikeASession(TBL(CELL_P) + P2);
+        const inside = doc.getParagraphs().find((p) => firstTextNode(p).textContent?.startsWith('cell'))!;
+        firstTextNode(inside).textContent = 'edited inside';
+        const saved = await doc.toBuffer({ cleanBookmarks: true, minimalReserialization: true });
+        modified = { originalXml, savedXml: (await readZipText(saved.buffer, 'word/document.xml'))! };
+      }
+    });
+
+    await then('the untouched table is element-identical and the edited table is not reverted', () => {
+      const untouchedOriginal = bodyBlocks(untouched.originalXml);
+      const untouchedSaved = bodyBlocks(untouched.savedXml);
+      expect(untouchedSaved[0]).toBe(untouchedOriginal[0]);
+      expect(untouchedSaved[0]).toContain('proofErr');
+      expect(untouchedSaved[1]).toContain('edited outside');
+
+      const modifiedSaved = bodyBlocks(modified.savedXml);
+      const modifiedOriginal = bodyBlocks(modified.originalXml);
+      expect(modifiedSaved[0]).toContain('edited inside');
+      expect(modifiedSaved[0]).not.toBe(modifiedOriginal[0]);
+      // The paragraph outside the table is untouched in this session.
+      expect(modifiedSaved[1]).toBe(modifiedOriginal[1]);
+    });
+  });
+
+  test('untouched paragraphs inside an edited table are restored individually', async ({ given, when, then }: AllureBddContext) => {
+    // Two rows; the edit touches one paragraph in one cell. Every other
+    // proofErr/rsid-bearing paragraph in the table must keep its original
+    // XML — issue #408's repro document is almost entirely tables.
+    const cellP = (id: string, marker: string) =>
+      `<w:p w14:paraId="${id}"><w:proofErr w:type="spellStart"/><w:r w:rsidR="00${marker}01"><w:t>${marker}</w:t></w:r>` +
+      `<w:proofErr w:type="spellEnd"/><w:r w:rsidR="00${marker}02"><w:t xml:space="preserve"> tail</w:t></w:r></w:p>`;
+    const tableBody =
+      `<w:tbl><w:tblPr><w:tblW w:w="0" w:type="auto"/></w:tblPr>` +
+      `<w:tr><w:tc>${cellP('00000A01', 'AA')}${cellP('00000A02', 'AB')}</w:tc><w:tc>${cellP('00000B01', 'BA')}</w:tc></w:tr>` +
+      `<w:tr><w:tc>${cellP('00000C01', 'CA')}</w:tc><w:tc>${cellP('00000D01', 'DA')}</w:tc></w:tr>` +
+      `</w:tbl>`;
+    let doc: DocxDocument;
+    let originalXml = '';
+    let savedXml = '';
+
+    await given('a normalized session over a two-row table', async () => {
+      ({ doc, originalXml } = await openLikeASession(tableBody + P2));
+    });
+
+    await when('one paragraph in one cell is edited and the document saved minimally', async () => {
+      const target = doc.getParagraphs().find((p) => firstTextNode(p).textContent?.startsWith('AB'))!;
+      firstTextNode(target).textContent = 'edited in cell';
+      const saved = await doc.toBuffer({ cleanBookmarks: true, minimalReserialization: true });
+      savedXml = (await readZipText(saved.buffer, 'word/document.xml'))!;
+    });
+
+    await then('only that paragraph differs across the whole document', () => {
+      const collectParagraphs = (xml: string) =>
+        Array.from(parseXml(xml).getElementsByTagNameNS(OOXML.W_NS, W.p))
+          .map((p) => serializer.serializeToString(p as never));
+      const original = collectParagraphs(originalXml);
+      const saved = collectParagraphs(savedXml);
+      expect(saved).toHaveLength(original.length);
+      const changed = original
+        .map((p, i) => (p === saved[i] ? null : i))
+        .filter((i) => i !== null);
+      expect(changed).toHaveLength(1);
+      expect(saved[changed[0]!]).toContain('edited in cell');
+      // Its same-cell sibling kept its proofing markup and rsids.
+      expect(saved[0]).toBe(original[0]);
+      expect(saved[0]).toContain('proofErr');
+    });
+  });
+
+  test('falls back to full re-serialization when no original text was captured', async ({ given, when, then }: AllureBddContext) => {
+    let restored = -1;
+    let savedXml = '';
+
+    await given('a document instance whose original XML cannot be aligned', () => {
+      // restoreUntouchedBlocks with an original that has no w:body restores
+      // nothing rather than guessing.
+    });
+
+    await when('restoration runs against a body-less original', () => {
+      const currentDoc = parseXml(
+        `<w:document xmlns:w="${OOXML.W_NS}"><w:body><w:p><w:r><w:t>x</w:t></w:r></w:p></w:body></w:document>`,
+      );
+      restored = restoreUntouchedBlocks(currentDoc, `<w:document xmlns:w="${OOXML.W_NS}"/>`);
+      savedXml = serializer.serializeToString(currentDoc as never);
+    });
+
+    await then('nothing is restored and the document is left as-is', () => {
+      expect(restored).toBe(0);
+      expect(savedXml).toContain('<w:t>x</w:t>');
+    });
+  });
+});

--- a/packages/docx-core/src/primitives/minimal_save.ts
+++ b/packages/docx-core/src/primitives/minimal_save.ts
@@ -1,0 +1,239 @@
+/**
+ * minimal_save — restore untouched top-level body blocks from the original
+ * document.xml at save time.
+ *
+ * The in-memory session DOM is normalized at open (`mergeRuns` +
+ * `simplifyRedlines`) because text addressing, bookmarks, and comparison
+ * baselines all assume the normalized shape. Serializing that DOM wholesale
+ * persists the normalization for every paragraph, so a one-paragraph edit
+ * rewrites the whole document on disk (proofErr stripped, runs merged) and
+ * downstream diffs lie about the edit's blast radius.
+ *
+ * This module reconciles at save time instead: any body block (w:p, w:tbl,
+ * w:sectPr, ...) whose serialization equals the corresponding block of a
+ * freshly-normalized re-parse of the original XML was, by construction,
+ * untouched by edits — so it is replaced with the pristine original block.
+ * Edited blocks that are tables are descended into (rows → cells →
+ * paragraphs) so a one-cell edit doesn't churn the rest of the table.
+ * Edited or inserted leaves have no equal counterpart and are kept as-is.
+ * The output contract is element-for-element preservation of untouched
+ * blocks (the XML still passes through the serializer, so byte-identity
+ * with the original file is not guaranteed).
+ *
+ * @see https://github.com/UseJunior/safe-docx/issues/408
+ */
+
+import { XMLSerializer } from '@xmldom/xmldom';
+import { parseXml } from './xml.js';
+import { OOXML, W } from './namespaces.js';
+import { mergeRuns } from './merge_runs.js';
+import { simplifyRedlines } from './simplify_redlines.js';
+
+/**
+ * Containers whose ELEMENT-CHILD structure normalization provably preserves
+ * (mergeRuns/simplifyRedlines mutate inside paragraphs only): an edited
+ * table can be descended into so its untouched rows/cells/paragraphs still
+ * restore. Paragraphs are deliberately absent — normalization adds/removes
+ * their children, so the original↔normalized index lockstep breaks there.
+ */
+const RECURSABLE_CONTAINER_LOCALS = new Set<string>([W.tbl, W.tr, W.tc]);
+
+/** Element children of a node (whitespace text nodes skipped). */
+function elementChildren(parent: Node): Element[] {
+  const out: Element[] = [];
+  let child = parent.firstChild;
+  while (child) {
+    if (child.nodeType === 1) out.push(child as Element);
+    child = child.nextSibling;
+  }
+  return out;
+}
+
+function bodyElement(doc: Document): Element | null {
+  return doc.getElementsByTagNameNS(OOXML.W_NS, W.body).item(0) as Element | null;
+}
+
+/**
+ * Order-preserving alignment of two sequences by longest common subsequence,
+ * returning matched index pairs `[i, j]` with `a[i] === b[j]`.
+ *
+ * An LCS (rather than a serialization-keyed FIFO map) is required for
+ * correctness when two blocks normalize to identical serializations: if the
+ * earlier duplicate is edited, a FIFO would hand the untouched later block
+ * the earlier block's original (swapping rsid/paraId provenance). The
+ * backtrack below matches from the tail, so untouched trailing duplicates
+ * pair with their own originals.
+ */
+/**
+ * DP cell budget (~16 MB of Int32). Edits touch few blocks, so the common
+ * prefix/suffix trim below collapses the DP to roughly the edited span;
+ * only a document with massive scattered edits exceeds this, and those
+ * blocks then simply stay normalized (conservative, never wrong).
+ */
+const MAX_LCS_DP_CELLS = 4_000_000;
+
+function lcsPairs(a: string[], b: string[]): Array<[number, number]> {
+  if (a.length === 0 || b.length === 0) return [];
+
+  // Identical leading/trailing runs are LCS matches by construction; pairing
+  // them up front shrinks the DP to the edited middle span.
+  let start = 0;
+  while (start < a.length && start < b.length && a[start] === b[start]) start++;
+  let endA = a.length;
+  let endB = b.length;
+  while (endA > start && endB > start && a[endA - 1] === b[endB - 1]) {
+    endA--;
+    endB--;
+  }
+
+  const pairs: Array<[number, number]> = [];
+  for (let k = 0; k < start; k++) pairs.push([k, k]);
+
+  const n = endA - start;
+  const m = endB - start;
+  if (n > 0 && m > 0 && n * m <= MAX_LCS_DP_CELLS) {
+    // Intern strings to integers so DP comparisons don't re-compare long XML.
+    const ids = new Map<string, number>();
+    const intern = (s: string): number => {
+      let id = ids.get(s);
+      if (id === undefined) {
+        id = ids.size;
+        ids.set(s, id);
+      }
+      return id;
+    };
+    const ai = a.slice(start, endA).map(intern);
+    const bi = b.slice(start, endB).map(intern);
+
+    // dp[(i, j)] = LCS length of ai[0..i) and bi[0..j), row-major stride m+1.
+    const stride = m + 1;
+    const dp = new Int32Array((n + 1) * stride);
+    for (let i = 1; i <= n; i++) {
+      for (let j = 1; j <= m; j++) {
+        dp[i * stride + j] =
+          ai[i - 1] === bi[j - 1]
+            ? dp[(i - 1) * stride + (j - 1)]! + 1
+            : Math.max(dp[(i - 1) * stride + j]!, dp[i * stride + (j - 1)]!);
+      }
+    }
+
+    const middle: Array<[number, number]> = [];
+    let i = n;
+    let j = m;
+    while (i > 0 && j > 0) {
+      if (
+        ai[i - 1] === bi[j - 1] &&
+        dp[i * stride + j] === dp[(i - 1) * stride + (j - 1)]! + 1
+      ) {
+        middle.push([start + i - 1, start + j - 1]);
+        i--;
+        j--;
+      } else if (dp[(i - 1) * stride + j]! >= dp[i * stride + (j - 1)]!) {
+        i--;
+      } else {
+        j--;
+      }
+    }
+    pairs.push(...middle.reverse());
+  }
+
+  for (let k = 0; endA + k < a.length; k++) pairs.push([endA + k, endB + k]);
+  return pairs;
+}
+
+const serializer = new XMLSerializer();
+
+function sameQualifiedName(a: Element, b: Element): boolean {
+  return a.namespaceURI === b.namespaceURI && a.localName === b.localName;
+}
+
+/**
+ * Reconcile the element children of one container: LCS-matched (untouched)
+ * children of `cur` are replaced with the corresponding pristine `orig`
+ * child; unmatched (edited) children that pair 1:1 with a same-named
+ * recursable container across an LCS gap are descended into, so e.g. the
+ * untouched cells and paragraphs of an edited table still restore.
+ *
+ * `orig` and `norm` children are index-lockstep (norm is orig with
+ * normalization applied, which never adds/removes container children);
+ * a count mismatch abandons this subtree.
+ */
+function reconcileChildren(
+  orig: Element,
+  norm: Element,
+  cur: Element,
+  ownerDoc: Document,
+): number {
+  const origChildren = elementChildren(orig);
+  const normChildren = elementChildren(norm);
+  const curChildren = elementChildren(cur);
+  if (origChildren.length !== normChildren.length) return 0;
+  if (origChildren.length === 0 || curChildren.length === 0) return 0;
+
+  const normKeys = normChildren.map((el) => serializer.serializeToString(el));
+  const curKeys = curChildren.map((el) => serializer.serializeToString(el));
+  const pairs = lcsPairs(normKeys, curKeys);
+
+  let restored = 0;
+  for (const [i, j] of pairs) {
+    const pristine = ownerDoc.importNode(origChildren[i]!, true);
+    cur.replaceChild(pristine, curChildren[j]!);
+    restored++;
+  }
+
+  // Between consecutive LCS anchors, the leftovers on each side are the
+  // edited children. When they pair 1:1 in order and both sides are the
+  // same recursable container, descend — only serialization-equal
+  // descendants will restore, so a mispairing cannot corrupt content.
+  let prevI = -1;
+  let prevJ = -1;
+  for (const [ai, aj] of [...pairs, [normChildren.length, curChildren.length] as [number, number]]) {
+    const gapLen = ai - prevI - 1;
+    if (gapLen > 0 && gapLen === aj - prevJ - 1) {
+      for (let k = 1; k <= gapLen; k++) {
+        const normEl = normChildren[prevI + k]!;
+        const curEl = curChildren[prevJ + k]!;
+        if (
+          sameQualifiedName(normEl, curEl) &&
+          normEl.namespaceURI === OOXML.W_NS &&
+          RECURSABLE_CONTAINER_LOCALS.has(normEl.localName)
+        ) {
+          restored += reconcileChildren(origChildren[prevI + k]!, normEl, curEl, ownerDoc);
+        }
+      }
+    }
+    prevI = ai;
+    prevJ = aj;
+  }
+  return restored;
+}
+
+/**
+ * Replace every block of `currentDoc` that is untouched — i.e.
+ * serialization-equal to the same block of the original document.xml after
+ * open-time normalization — with the pristine original block, descending
+ * into edited tables so their untouched rows/cells/paragraphs restore too.
+ *
+ * `currentDoc` must already have internal bookmarks removed (untouched
+ * blocks otherwise never match the bookmark-free reference). Returns the
+ * number of elements restored; 0 means the document is fully edited or the
+ * reference could not be aligned (output then matches today's full
+ * re-serialization, never anything worse).
+ */
+export function restoreUntouchedBlocks(
+  currentDoc: Document,
+  originalXmlText: string,
+): number {
+  const original = parseXml(originalXmlText);
+  const normRef = parseXml(originalXmlText);
+  // Mirror DocxDocument.normalize()'s document.xml steps, in order.
+  mergeRuns(normRef);
+  simplifyRedlines(normRef);
+
+  const originalBody = bodyElement(original);
+  const normRefBody = bodyElement(normRef);
+  const currentBody = bodyElement(currentDoc);
+  if (!originalBody || !normRefBody || !currentBody) return 0;
+
+  return reconcileChildren(originalBody, normRefBody, currentBody, currentDoc);
+}

--- a/packages/docx-core/src/primitives/minimal_save.ts
+++ b/packages/docx-core/src/primitives/minimal_save.ts
@@ -26,6 +26,7 @@
 import { XMLSerializer } from '@xmldom/xmldom';
 import { parseXml } from './xml.js';
 import { OOXML, W } from './namespaces.js';
+import { childElements } from './dom-helpers.js';
 import { mergeRuns } from './merge_runs.js';
 import { simplifyRedlines } from './simplify_redlines.js';
 
@@ -38,20 +39,17 @@ import { simplifyRedlines } from './simplify_redlines.js';
  */
 const RECURSABLE_CONTAINER_LOCALS = new Set<string>([W.tbl, W.tr, W.tc]);
 
-/** Element children of a node (whitespace text nodes skipped). */
-function elementChildren(parent: Node): Element[] {
-  const out: Element[] = [];
-  let child = parent.firstChild;
-  while (child) {
-    if (child.nodeType === 1) out.push(child as Element);
-    child = child.nextSibling;
-  }
-  return out;
-}
-
 function bodyElement(doc: Document): Element | null {
   return doc.getElementsByTagNameNS(OOXML.W_NS, W.body).item(0) as Element | null;
 }
+
+/**
+ * DP cell budget (~16 MB of Int32). Edits touch few blocks, so the common
+ * prefix/suffix trim below collapses the DP to roughly the edited span;
+ * only a document with massive scattered edits exceeds this, and those
+ * blocks then simply stay normalized (conservative, never wrong).
+ */
+const MAX_LCS_DP_CELLS = 4_000_000;
 
 /**
  * Order-preserving alignment of two sequences by longest common subsequence,
@@ -64,14 +62,6 @@ function bodyElement(doc: Document): Element | null {
  * backtrack below matches from the tail, so untouched trailing duplicates
  * pair with their own originals.
  */
-/**
- * DP cell budget (~16 MB of Int32). Edits touch few blocks, so the common
- * prefix/suffix trim below collapses the DP to roughly the edited span;
- * only a document with massive scattered edits exceeds this, and those
- * blocks then simply stay normalized (conservative, never wrong).
- */
-const MAX_LCS_DP_CELLS = 4_000_000;
-
 function lcsPairs(a: string[], b: string[]): Array<[number, number]> {
   if (a.length === 0 || b.length === 0) return [];
 
@@ -164,9 +154,9 @@ function reconcileChildren(
   cur: Element,
   ownerDoc: Document,
 ): number {
-  const origChildren = elementChildren(orig);
-  const normChildren = elementChildren(norm);
-  const curChildren = elementChildren(cur);
+  const origChildren = childElements(orig);
+  const normChildren = childElements(norm);
+  const curChildren = childElements(cur);
   if (origChildren.length !== normChildren.length) return 0;
   if (origChildren.length === 0 || curChildren.length === 0) return 0;
 

--- a/packages/docx-core/src/primitives/zip.test.ts
+++ b/packages/docx-core/src/primitives/zip.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Regression tests for issue #408's archive symptoms: saves came back with
+ * STORED (uncompressed) entries — ~6x on-disk inflation — plus a stray
+ * `word/` directory entry the Word-authored input never had.
+ */
+
+import JSZip from 'jszip';
+import { describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { DocxZip, inspectZipEntries, readZipText } from './zip.js';
+
+const test = testAllure.epic('Document Comparison').withLabels({ feature: 'Document Primitives' });
+
+const COMPRESSIBLE_XML =
+  `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:document>` +
+  `<w:p><w:r><w:t>repeat me </w:t></w:r></w:p>`.repeat(200) +
+  `</w:document>`;
+
+/** Source archive that, like fixture-built packages, carries directory entries. */
+async function buildArchiveWithDirectoryEntries(): Promise<Buffer> {
+  const zip = new JSZip();
+  // createFolders defaults to true: this adds `word/` and `_rels/` entries.
+  zip.file('word/document.xml', COMPRESSIBLE_XML);
+  zip.file('_rels/.rels', '<Relationships/>');
+  zip.file('[Content_Types].xml', '<Types/>');
+  return (await zip.generateAsync({ type: 'nodebuffer' })) as Buffer;
+}
+
+describe('DocxZip archive packing (issue #408)', () => {
+  test('saves entries DEFLATE-compressed', async ({ given, when, then }: AllureBddContext) => {
+    let source: Buffer;
+    let output: Buffer;
+
+    await given('a loaded archive with a highly compressible document.xml', async () => {
+      source = await buildArchiveWithDirectoryEntries();
+    });
+
+    await when('the archive is written back', async () => {
+      const zip = await DocxZip.load(source);
+      zip.writeText('word/document.xml', COMPRESSIBLE_XML);
+      output = await zip.toBuffer();
+    });
+
+    await then('document.xml is smaller on disk than its content', async () => {
+      const entries = await inspectZipEntries(output);
+      const doc = entries.find((e) => e.name === 'word/document.xml')!;
+      expect(doc.compressedSize).toBeGreaterThan(0);
+      expect(doc.compressedSize).toBeLessThan(doc.uncompressedSize);
+      expect(await readZipText(output, 'word/document.xml')).toBe(COMPRESSIBLE_XML);
+    });
+  });
+
+  test('emits zero directory entries, including ones inherited from the source archive', async ({ given, when, then }: AllureBddContext) => {
+    let source: Buffer;
+    let output: Buffer;
+
+    await given('a source archive that already contains directory entries', async () => {
+      source = await buildArchiveWithDirectoryEntries();
+      const sourceEntries = await inspectZipEntries(source);
+      expect(sourceEntries.some((e) => e.isDirectory)).toBe(true);
+    });
+
+    await when('a nested path is written and the archive is saved', async () => {
+      const zip = await DocxZip.load(source);
+      zip.writeText('word/settings.xml', '<w:settings/>');
+      output = await zip.toBuffer();
+    });
+
+    await then('the output has every file but no directory entries', async () => {
+      const entries = await inspectZipEntries(output);
+      expect(entries.some((e) => e.isDirectory)).toBe(false);
+      const names = entries.map((e) => e.name).sort();
+      expect(names).toEqual(['[Content_Types].xml', '_rels/.rels', 'word/document.xml', 'word/settings.xml']);
+    });
+  });
+});

--- a/packages/docx-core/src/primitives/zip.ts
+++ b/packages/docx-core/src/primitives/zip.ts
@@ -45,7 +45,9 @@ export class DocxZip {
   }
 
   writeText(path: string, text: string): void {
-    this.zip.file(path, text);
+    // createFolders defaults to true and would add a directory entry (e.g.
+    // `word/`) absent from the Word-authored input archive.
+    this.zip.file(path, text, { createFolders: false });
   }
 
   hasFile(path: string): boolean {
@@ -61,7 +63,19 @@ export class DocxZip {
   }
 
   async toBuffer(): Promise<Buffer> {
-    const out = await this.zip.generateAsync({ type: 'nodebuffer' });
+    // OPC packages never need directory entries (Word does not emit them);
+    // drop any that came in via the source archive or earlier writes so the
+    // output contract is simply "zero directory entries". NOT zip.remove():
+    // that deletes a folder's contents recursively.
+    for (const file of Object.values(this.zip.files)) {
+      if (file.dir) delete this.zip.files[file.name];
+    }
+    // jszip defaults to STORE, which inflated saves ~6x.
+    const out = await this.zip.generateAsync({
+      type: 'nodebuffer',
+      compression: 'DEFLATE',
+      compressionOptions: { level: 6 },
+    });
     return out as Buffer;
   }
 }

--- a/packages/docx-mcp/src/cli/commands/edit.test.ts
+++ b/packages/docx-mcp/src/cli/commands/edit.test.ts
@@ -1,9 +1,11 @@
+import { XMLSerializer } from '@xmldom/xmldom';
 import { describe, expect } from 'vitest';
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { inspectZipEntries, parseXml } from '@usejunior/docx-core';
 import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
 import { parseEditArgs, runEditCommand } from './edit.js';
-import { makeMinimalDocx, extractParaIdsFromToon } from '../../testing/docx_test_utils.js';
+import { makeMinimalDocx, extractParaIdsFromToon, readDocumentXmlFromPath } from '../../testing/docx_test_utils.js';
 import { createTrackedTempDir, registerCleanup, openSession } from '../../testing/session-test-utils.js';
 
 registerCleanup();
@@ -147,6 +149,86 @@ describe('runEditCommand E2E', () => {
       const result = JSON.parse(output[0]!) as { apply: { success: boolean }; save: { success: boolean } };
       expect(result.apply.success).toBe(true);
       expect(result.save.success).toBe(true);
+    });
+  });
+
+  test('a single replace does not rewrite untouched paragraphs or inflate the archive (issue #408)', async ({ given, when, then }: AllureBddContext) => {
+    // Word-shaped fixture: untouched paragraphs carry volatile proofErr
+    // markup and rsid-fragmented same-format runs — exactly what open-time
+    // normalization rewrites in memory and must NOT persist to disk.
+    const BLAST_XML =
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+      `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>` +
+      `<w:p><w:proofErr w:type="spellStart"/><w:r w:rsidR="00AA0001"><w:t>Lorem</w:t></w:r>` +
+      `<w:proofErr w:type="spellEnd"/><w:r w:rsidR="00AA0002"><w:t xml:space="preserve"> ipsum intro</w:t></w:r></w:p>` +
+      `<w:p><w:r><w:t>{mnda_term}</w:t></w:r></w:p>` +
+      `<w:p><w:proofErr w:type="gramStart"/><w:r><w:t>dolor</w:t></w:r>` +
+      `<w:proofErr w:type="gramEnd"/><w:r><w:t xml:space="preserve"> sit outro</w:t></w:r></w:p>` +
+      `</w:body></w:document>`;
+
+    const serializer = new XMLSerializer();
+    const bodyBlocks = (xml: string): string[] => {
+      const doc = parseXml(xml);
+      const body = doc.getElementsByTagName('w:body').item(0)!;
+      const out: string[] = [];
+      let child = body.firstChild;
+      while (child) {
+        if (child.nodeType === 1) out.push(serializer.serializeToString(child as never));
+        child = child.nextSibling;
+      }
+      return out;
+    };
+
+    let inputPath = '';
+    let outPath = '';
+    let targetParaId = '';
+    let saveJson: { blocks_restored?: number } = {};
+
+    await given('a session over a proofErr-bearing three-paragraph document', async () => {
+      const session = await openSession([], { xml: BLAST_XML });
+      inputPath = session.inputPath;
+      targetParaId = session.paraIds[1]!;
+      outPath = path.join(await createTrackedTempDir(), 'revised.docx');
+    });
+
+    await when('one paragraph is replaced and the result saved', async () => {
+      const output: string[] = [];
+      const errors: string[] = [];
+      await runEditCommand(
+        {
+          file_path: inputPath,
+          replaces: [{ paragraph_id: targetParaId, old_string: '{mnda_term}', new_string: 'two (2) years' }],
+          inserts: [],
+          output_path: outPath,
+        },
+        { write: (l) => output.push(l), writeError: (l) => errors.push(l) },
+      );
+      expect(errors).toHaveLength(0);
+      saveJson = (JSON.parse(output[0]!) as { save: { blocks_restored?: number } }).save;
+    });
+
+    await then('only the edited paragraph differs from the input', async () => {
+      const inputBlocks = bodyBlocks(await readDocumentXmlFromPath(inputPath));
+      const outputBlocks = bodyBlocks(await readDocumentXmlFromPath(outPath));
+      expect(outputBlocks).toHaveLength(inputBlocks.length);
+
+      const changed = inputBlocks
+        .map((block, i) => (block === outputBlocks[i] ? null : i))
+        .filter((i) => i !== null);
+      expect(changed).toEqual([1]);
+      expect(outputBlocks[1]).toContain('two (2) years');
+      // Untouched paragraphs keep their proofing markup and split runs.
+      expect(outputBlocks[0]).toContain('proofErr');
+      expect(outputBlocks[0]).toContain('w:rsidR="00AA0001"');
+      expect(outputBlocks[2]).toContain('proofErr');
+      expect(saveJson.blocks_restored).toBe(2);
+    });
+
+    await then('the archive is deflate-compressed with no directory entries', async () => {
+      const entries = await inspectZipEntries(await fs.readFile(outPath));
+      expect(entries.some((e) => e.isDirectory)).toBe(false);
+      const doc = entries.find((e) => e.name === 'word/document.xml')!;
+      expect(doc.compressedSize).toBeLessThan(doc.uncompressedSize);
     });
   });
 });

--- a/packages/docx-mcp/src/session/manager.test.ts
+++ b/packages/docx-mcp/src/session/manager.test.ts
@@ -465,6 +465,7 @@ describe('SessionManager.markEdited', () => {
       trackedBuffer: null,
       trackedStats: null,
       bookmarksRemoved: 0,
+      blocksRestored: 0,
       exportedAtUtc: new Date().toISOString(),
       cachedAtIso: new Date().toISOString(),
     });
@@ -565,6 +566,7 @@ describe('SessionManager save cache', () => {
       trackedBuffer: null,
       trackedStats: null,
       bookmarksRemoved: 0,
+      blocksRestored: 0,
       exportedAtUtc: new Date().toISOString(),
       cachedAtIso: new Date().toISOString(),
     };

--- a/packages/docx-mcp/src/session/manager.ts
+++ b/packages/docx-mcp/src/session/manager.ts
@@ -46,6 +46,7 @@ export type SaveCacheEntry = {
   trackedFallbackReason?: ReconstructionFallbackReason;
   trackedFallbackDiagnostics?: ReconstructionFallbackDiagnostics;
   bookmarksRemoved: number;
+  blocksRestored: number;
   exportedAtUtc: string;
   cachedAtIso: string;
 };
@@ -476,10 +477,12 @@ export class SessionManager {
     const doc = await DocxDocument.load(session.originalBuffer);
     doc.normalize();
     doc.insertParagraphBookmarks('_baseline');
-    const [clean, bookmarked] = await Promise.all([
-      doc.toBuffer({ cleanBookmarks: true }),
-      doc.toBuffer({ cleanBookmarks: false }),
-    ]);
+    // Sequential on purpose: toBuffer() temporarily swaps document.xml inside
+    // the shared zip, so concurrent calls on one document race on that state.
+    // Baselines stay fully normalized (no minimalReserialization) — the
+    // comparison pipeline expects normalized-vs-normalized inputs.
+    const clean = await doc.toBuffer({ cleanBookmarks: true });
+    const bookmarked = await doc.toBuffer({ cleanBookmarks: false });
     session.comparisonBaseline = clean.buffer;
     session.comparisonBaselineWithBookmarks = bookmarked.buffer;
   }
@@ -616,7 +619,8 @@ export class SessionManager {
   }
 
   async saveTo(session: DocxSession, savePath: string, opts?: { cleanBookmarks?: boolean }): Promise<void> {
-    const { buffer } = await session.doc.toBuffer({ cleanBookmarks: opts?.cleanBookmarks ?? true });
+    const cleanBookmarks = opts?.cleanBookmarks ?? true;
+    const { buffer } = await session.doc.toBuffer({ cleanBookmarks, minimalReserialization: cleanBookmarks });
     await fs.writeFile(savePath, new Uint8Array(buffer));
   }
 

--- a/packages/docx-mcp/src/tools/save.ts
+++ b/packages/docx-mcp/src/tools/save.ts
@@ -184,6 +184,7 @@ export async function save(
     let trackedFallbackReason: CompareResult['fallbackReason'];
     let trackedFallbackDiagnostics: CompareResult['fallbackDiagnostics'];
     let bookmarksRemoved: number;
+    let blocksRestored: number;
     let exportTimestamp: string;
 
     // Run implicit validation before producing save artifacts.
@@ -197,11 +198,16 @@ export async function save(
       trackedFallbackReason = cached.trackedFallbackReason;
       trackedFallbackDiagnostics = cached.trackedFallbackDiagnostics;
       bookmarksRemoved = cached.bookmarksRemoved;
+      blocksRestored = cached.blocksRestored;
       exportTimestamp = cached.exportedAtUtc;
     } else {
-      const revised = await session.doc.toBuffer({ cleanBookmarks: clean });
+      // The clean artifact is the minimal one: untouched body blocks are
+      // restored element-for-element from the original document.xml so the
+      // on-disk diff matches the edit's actual blast radius.
+      const revised = await session.doc.toBuffer({ cleanBookmarks: clean, minimalReserialization: clean });
       revisedBuffer = revised.buffer;
       bookmarksRemoved = revised.bookmarksRemoved;
+      blocksRestored = revised.blocksRestored;
       trackedBuffer = null;
       trackedStats = null;
       trackedReconstructionMode = undefined;
@@ -213,8 +219,15 @@ export async function save(
         // Lazily generate comparison baselines if not yet available.
         await manager.ensureBaselines(session);
         const baselineBuffer = session.comparisonBaseline ?? session.originalBuffer;
+        // The comparison input must stay fully normalized: the baseline is
+        // normalized, and the atomizer compares normalized-vs-normalized.
+        // Generated sequentially — toBuffer() swaps shared zip state, so
+        // concurrent calls on one document are unsafe.
+        const comparisonRevisedBuffer = clean
+          ? (await session.doc.toBuffer({ cleanBookmarks: clean })).buffer
+          : revisedBuffer;
         const trackedRes = await runWithoutConsoleLog(() =>
-          compareDocuments(baselineBuffer, revisedBuffer, {
+          compareDocuments(baselineBuffer, comparisonRevisedBuffer, {
             author,
             engine: trackedEngine,
             reconstructionMode: DEFAULT_RECONSTRUCTION_MODE,
@@ -250,6 +263,7 @@ export async function save(
         trackedFallbackReason,
         trackedFallbackDiagnostics,
         bookmarksRemoved: clean ? bookmarksRemoved : 0,
+        blocksRestored,
         exportedAtUtc: exportTimestamp,
         cachedAtIso: new Date().toISOString(),
       });
@@ -330,6 +344,7 @@ export async function save(
       revisions,
       exported_at_utc: exportTimestamp,
       bookmarks_removed: clean ? bookmarksRemoved : 0,
+      blocks_restored: blocksRestored,
       returned_variants: returnedVariants,
       available_variants: ['clean', 'redline'],
       cache_hit: cacheHit,


### PR DESCRIPTION
Fixes #408. Ref #409.

## Problem

A single one-paragraph `replace_text` via `safedocx edit` rewrote 8 untouched paragraphs (`w:proofErr` stripped, runs merged), shrank `document.xml` ~5 KB through normalization, and re-packed the archive with STORED entries (19.5 KB → 118 KB) plus a stray `word/` directory entry. Diffs of safe-docx output lied about edit blast radius — feeding the output back into `docx-comparison` produced phantom tracked changes (#409).

## Fix

**Commit 1 — archive packing (`DocxZip`):** `toBuffer()` now generates with DEFLATE level 6 (matching `DocxArchive.save()`) and drops all directory entries; `writeText()` passes `createFolders: false`. Output contract: zero directory entries, deflated entries.

**Commit 2 — minimal re-serialization:** open-time `normalize()` is load-bearing (addressing, bookmarks, baselines) and stays in memory. At save time, a new `restoreUntouchedBlocks` primitive aligns the bookmark-cleaned output DOM against a freshly-normalized re-parse of the original `document.xml` (positional LCS over serialized body blocks) and replaces every aligned block with its pristine original. Edited tables are descended into (`tbl → tr → tc`) so a one-cell edit doesn't churn the rest of the table. Any alignment failure falls back to today's full re-serialization.

## Contract

- Untouched blocks are preserved **element-for-element** (output still passes through the XML serializer, so byte-identity with Word's original bytes is not guaranteed; a zero-step edit round-trips `document.xml` element-identically).
- Enabled only for the **clean** save artifact (`toBuffer({ minimalReserialization })`, opt-in). The buffer fed to `compareDocuments` stays fully normalized — the atomizer keeps comparing normalized-vs-normalized, byte-for-byte unchanged behavior.
- **Stated limitation:** the tracked/redline artifact is rebuilt by the comparison pipeline from normalized inputs and remains non-minimal.
- `save` responses now report `blocks_restored` for observability of silent fallback.

## Repro before/after (Common Paper MNDA template, single replace at `_bk_0922ea572bbe`)

| Metric | Before (issue) | After |
|---|---|---|
| Changed paragraphs (of 56) | 9 (8 untouched) | **1** (the edit) |
| Output size on disk | 118 KB | **19,567 B** (input: 19,548 B) |
| Directory entries | stray `word/` | **0** |
| Redline of original vs output | 3 change regions / phantom pairs | **1 revision-bearing paragraph** |

Output validated by LibreOffice headless PDF conversion.

## Tests

- `minimal_save.test.ts`: untouched-paragraph identity, zero-edit element-identical round-trip, insertion, duplicate-alignment regression (FIFO mis-pairing case), intra-table restoration, table-edit non-revert, missing-capture fallback.
- `zip.test.ts`: DEFLATE compression, zero directory entries (including ones inherited from the source archive).
- `edit.test.ts` e2e: single replace → exactly one changed paragraph, deflated archive, `blocks_restored` surfaced; tracked save (`both`) regression-covered.

Full pre-submit gate green: build, lint:workspaces, test:run, check:spec-coverage, check:conformance-citations, check:conformance-doc, check:allure-labels.

Plan peer-reviewed pre-implementation (Codex + agy); all five Codex findings incorporated (directory-entry stripping, positional LCS, rsid-invariant correction, sequential baseline buffers, table coverage).