### PR TITLE
feat(docx-core): from-scratch generation phase 6 — drafting notes as anchored comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ safe-docx targets a defined subset of **ECMA-376 5th edition**. The full surface
 (targeted sections, Non-Goals, and verification status) lives at
 [spec-compliance/CONFORMANCE.md](spec-compliance/CONFORMANCE.md).
 
-- **57** sections claimed
+- **62** sections claimed
 - **5** sections explicitly out-of-scope (Non-Goals)
 - **0** known gaps under `@conformance-gap`
 - Vendored normative schemas: `spec-compliance/ecma-376/schemas/`

--- a/openspec/changes/add-docx-generation/specs/docx-generation/spec.md
+++ b/openspec/changes/add-docx-generation/specs/docx-generation/spec.md
@@ -22,7 +22,7 @@ ignored.
 - **THEN** the output SHALL be byte-identical to compiling the original spec
 
 #### Scenario: [SDX-GEN-003] unimplemented spec features are rejected loudly
-- **GIVEN** a `DocumentSpec` using a declared spec feature whose emitter has not shipped
+- **GIVEN** a `DocumentSpec` using a spec feature without a shipped emitter — a declared feature whose phase has not landed yet, or an unrecognized block/inline kind arriving from a JSON caller
 - **WHEN** `generateDocx(spec)` is called
 - **THEN** compilation SHALL fail with a typed error naming the unsupported feature and its path in the spec
 

--- a/openspec/changes/add-docx-generation/tasks.md
+++ b/openspec/changes/add-docx-generation/tasks.md
@@ -37,9 +37,9 @@ and `openspec validate add-docx-generation --strict`.
 - [x] 5.3 `recipes.ts` (`coverTermsTable`, `signatureBlock`) + recipe artifacts; registry entries
 
 ## 6. Drafting-note layer (PR 6) — SDX-GEN-080..083
-- [ ] 6.1 `emit/comments-part.ts` + anchors + `includeDraftingNotes` switch; deterministic ids/dates
-- [ ] 6.2 Resolve ancillary-part and content-type sub-decisions against a Word-authored document
-- [ ] 6.3 Body-identical-with/without test; post-hoc strip test via `deleteComment`
+- [x] 6.1 `emit/comments-part.ts` + anchors + `includeDraftingNotes` switch; deterministic ids/dates
+- [x] 6.2 Resolve ancillary-part and content-type sub-decisions against a Word-authored document
+- [x] 6.3 Body-identical-with/without test; post-hoc strip test via `deleteComment`
 
 ## 7. Compatibility sign-off + repositioning (PR 7, closes #280) — SDX-GEN-092
 - [ ] 7.1 Full manual matrix recorded for all artifact classes; public export from `src/index.ts`

--- a/packages/docx-core/docs/generation-manual-compat-checklist.md
+++ b/packages/docx-core/docs/generation-manual-compat-checklist.md
@@ -32,6 +32,7 @@ Artifacts land under `packages/docx-core/src/testing/outputs/`.
 | `generation-phase3-cover-body.docx` (titlePg cover header → body header, Page X of Y field footer, page break) | PR 3 | — | — | — | — |
 | `generation-phase4-tables.docx` (fixed-grid bordered table, shaded merged header row, repeating-header flag) | PR 4 | — | — | — | — |
 | `generation-phase5-numbering-recipes.docx` (three-level legal numbering, cover-terms recipe table, signature blocks) | PR 5 | — | — | — | — |
+| `generation-phase6-drafting-notes.docx` (anchored comments with commentsExtended/people ancillary parts) | PR 6 | — | — | — | — |
 
 ## Per-reader notes
 

--- a/packages/docx-core/src/generation/compile.ts
+++ b/packages/docx-core/src/generation/compile.ts
@@ -14,6 +14,8 @@
 
 import { createZipBuffer } from '../primitives/zip.js';
 import { CompileContext } from './context.js';
+import { emitCommentsPartsIfNeeded } from './emit/comments-part.js';
+import { DraftingNoteCollector } from './emit/emit-context.js';
 import { emitDocumentPart } from './emit/document-part.js';
 import { emitHeaderFooterParts } from './emit/header-footer-part.js';
 import { emitNumberingPartIfNeeded } from './emit/numbering-part.js';
@@ -32,13 +34,16 @@ export type GenerateDocxOptions = {
 };
 
 /** Compile a DocumentSpec into a complete DOCX package. */
-export async function generateDocx(spec: DocumentSpec, _opts?: GenerateDocxOptions): Promise<Buffer> {
+export async function generateDocx(spec: DocumentSpec, opts?: GenerateDocxOptions): Promise<Buffer> {
   validateSpec(spec);
 
+  const notesEnabled = opts?.includeDraftingNotes ?? spec.options?.includeDraftingNotes ?? true;
   const ctx = new CompileContext();
   const numberingIds = emitNumberingPartIfNeeded(spec, ctx);
-  const headerFooterRefs = emitHeaderFooterParts(spec, ctx, numberingIds);
-  ctx.setFileContent('word/document.xml', emitDocumentPart(spec, headerFooterRefs, numberingIds));
+  const headerFooterRefs = emitHeaderFooterParts(spec, ctx, { numberingIds });
+  const notes = notesEnabled ? new DraftingNoteCollector() : undefined;
+  ctx.setFileContent('word/document.xml', emitDocumentPart(spec, headerFooterRefs, { numberingIds, notes }));
+  if (notes) emitCommentsPartsIfNeeded(spec, ctx, notes);
   emitStylesPart(spec, ctx);
   emitSettingsPartIfNeeded(spec, ctx);
   emitPackageParts(spec, ctx);

--- a/packages/docx-core/src/generation/emit/comments-part.ts
+++ b/packages/docx-core/src/generation/emit/comments-part.ts
@@ -1,0 +1,134 @@
+/**
+ * Drafting-note comment parts: word/comments.xml plus the Word-extension
+ * ancillary parts word/commentsExtended.xml and word/people.xml.
+ *
+ * All three are always emitted together when notes are enabled. The
+ * ancillary pair is deliberately on by default: plain comments.xml loads in
+ * every reader we test, but Word 2013+ writes the trio and its own comment
+ * UI degrades (no resolve state, no people presence) without them. Content
+ * and relationship types match what Word itself writes — verified against
+ * the Open XML SDK's WordprocessingCommentsExPart/WordprocessingPeoplePart
+ * constants (the `application/vnd.ms-word.commentsExtended+xml` variant
+ * found in some third-party packages is NOT what Word emits). They also
+ * match the editing path in primitives/comments.ts, so a generated document
+ * is indistinguishable from an edited one to the comment APIs.
+ *
+ * Determinism: comment ids are allocated in document order by the
+ * DraftingNoteCollector; w14:paraId values derive from those ids; dates come
+ * only from DraftingNoteSpec.dateIso (falling back to meta.createdIso);
+ * authors fall back note.author → meta.author → 'safe-docx'. No clock, no
+ * randomness — identical specs produce byte-identical comment parts.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.4.6
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.4.2
+ */
+
+import { createWmlElement, createWmlTextElement } from '../../primitives/dom-helpers.js';
+import { OOXML, W } from '../../primitives/namespaces.js';
+import { parseXml, serializeXml, XML_DECL } from '../../primitives/xml.js';
+import type { CompileContext } from '../context.js';
+import type { DocumentSpec, DraftingNoteSpec } from '../types.js';
+import type { DraftingNoteCollector } from './emit-context.js';
+
+export const COMMENTS_CONTENT_TYPE = 'application/vnd.openxmlformats-officedocument.wordprocessingml.comments+xml';
+export const COMMENTS_REL_TYPE = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/comments';
+export const COMMENTS_EXTENDED_CONTENT_TYPE =
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.commentsExtended+xml';
+export const COMMENTS_EXTENDED_REL_TYPE = 'http://schemas.microsoft.com/office/2011/relationships/commentsExtended';
+export const PEOPLE_CONTENT_TYPE = 'application/vnd.openxmlformats-officedocument.wordprocessingml.people+xml';
+export const PEOPLE_REL_TYPE = 'http://schemas.microsoft.com/office/2011/relationships/people';
+
+const COMMENTS_SKELETON = `<w:comments xmlns:w="${OOXML.W_NS}" xmlns:w14="${OOXML.W14_NS}"/>`;
+
+const DEFAULT_AUTHOR = 'safe-docx';
+
+/** Deterministic w14:paraId for a comment id: zero-padded uppercase hex. */
+function paraIdFor(id: number): string {
+  return id.toString(16).toUpperCase().padStart(8, '0');
+}
+
+function authorFor(spec: DocumentSpec, note: DraftingNoteSpec): string {
+  return note.author ?? spec.meta?.author ?? DEFAULT_AUTHOR;
+}
+
+/** Up-to-three-letter initials from the author's words, deterministic. */
+function initialsFor(author: string): string {
+  const letters = author
+    .split(/\s+/)
+    .map((word) => word.replace(/[^\p{L}\p{N}]/gu, '').charAt(0))
+    .filter((c) => c.length > 0);
+  const initials = letters.slice(0, 3).join('').toUpperCase();
+  return initials.length > 0 ? initials : 'SD';
+}
+
+/** Emit the comment trio from the notes collected during body emission. */
+export function emitCommentsPartsIfNeeded(
+  spec: DocumentSpec,
+  ctx: CompileContext,
+  collector: DraftingNoteCollector,
+): void {
+  if (collector.collected.length === 0) return;
+
+  ctx.registerPart('word/comments.xml', COMMENTS_CONTENT_TYPE, COMMENTS_REL_TYPE);
+  ctx.registerPart('word/commentsExtended.xml', COMMENTS_EXTENDED_CONTENT_TYPE, COMMENTS_EXTENDED_REL_TYPE);
+  ctx.registerPart('word/people.xml', PEOPLE_CONTENT_TYPE, PEOPLE_REL_TYPE);
+
+  ctx.setFileContent('word/comments.xml', emitCommentsXml(spec, collector));
+  ctx.setFileContent('word/commentsExtended.xml', emitCommentsExtendedXml(collector));
+  ctx.setFileContent('word/people.xml', emitPeopleXml(spec, collector));
+}
+
+function emitCommentsXml(spec: DocumentSpec, collector: DraftingNoteCollector): string {
+  const doc = parseXml(COMMENTS_SKELETON);
+  const root = doc.documentElement!;
+  for (const { id, note } of collector.collected) {
+    const attrs: Record<string, string> = {
+      'w:id': String(id),
+      'w:author': authorFor(spec, note),
+      'w:initials': initialsFor(authorFor(spec, note)),
+    };
+    const dateIso = note.dateIso ?? spec.meta?.createdIso;
+    if (dateIso !== undefined) attrs['w:date'] = dateIso;
+    const comment = createWmlElement(doc, W.comment, attrs);
+
+    const p = createWmlElement(doc, W.p);
+    p.setAttributeNS(OOXML.W14_NS, 'w14:paraId', paraIdFor(id));
+    const run = createWmlElement(doc, W.r);
+    run.appendChild(createWmlTextElement(doc, note.text));
+    p.appendChild(run);
+    comment.appendChild(p);
+    root.appendChild(comment);
+  }
+  return XML_DECL + serializeXml(doc);
+}
+
+function emitCommentsExtendedXml(collector: DraftingNoteCollector): string {
+  const doc = parseXml(`<w15:commentsEx xmlns:w15="${OOXML.W15_NS}"/>`);
+  const root = doc.documentElement!;
+  for (const { id } of collector.collected) {
+    const commentEx = doc.createElementNS(OOXML.W15_NS, 'w15:commentEx');
+    commentEx.setAttributeNS(OOXML.W15_NS, 'w15:paraId', paraIdFor(id));
+    commentEx.setAttributeNS(OOXML.W15_NS, 'w15:done', '0');
+    root.appendChild(commentEx);
+  }
+  return XML_DECL + serializeXml(doc);
+}
+
+function emitPeopleXml(spec: DocumentSpec, collector: DraftingNoteCollector): string {
+  const doc = parseXml(`<w15:people xmlns:w15="${OOXML.W15_NS}"/>`);
+  const root = doc.documentElement!;
+  const seen = new Set<string>();
+  for (const { note } of collector.collected) {
+    const author = authorFor(spec, note);
+    if (seen.has(author)) continue;
+    seen.add(author);
+    const person = doc.createElementNS(OOXML.W15_NS, 'w15:person');
+    person.setAttributeNS(OOXML.W15_NS, 'w15:author', author);
+    const presence = doc.createElementNS(OOXML.W15_NS, 'w15:presenceInfo');
+    presence.setAttributeNS(OOXML.W15_NS, 'w15:providerId', 'None');
+    presence.setAttributeNS(OOXML.W15_NS, 'w15:userId', author);
+    person.appendChild(presence);
+    root.appendChild(person);
+  }
+  return XML_DECL + serializeXml(doc);
+}

--- a/packages/docx-core/src/generation/emit/document-part.ts
+++ b/packages/docx-core/src/generation/emit/document-part.ts
@@ -13,7 +13,7 @@ import { OOXML, W } from '../../primitives/namespaces.js';
 import { parseXml, serializeXml, XML_DECL } from '../../primitives/xml.js';
 import { GenerationInternalError } from '../errors.js';
 import type { DocumentSpec } from '../types.js';
-import type { NumberingIdMap } from './numbering-part.js';
+import type { BlockEmitContext } from './emit-context.js';
 import { buildSectPr, type SectionHeaderFooterRefs } from './section.js';
 import { buildBlock } from './table.js';
 
@@ -31,14 +31,14 @@ const DOCUMENT_SKELETON =
  * @conformance ECMA-376 edition 5, Part 1 § 17.6.18
  * @conformance ECMA-376 edition 5, Part 1 § 17.6.17
  */
-export function emitDocumentPart(spec: DocumentSpec, refs?: SectionHeaderFooterRefs[], numberingIds?: NumberingIdMap): string {
+export function emitDocumentPart(spec: DocumentSpec, refs?: SectionHeaderFooterRefs[], ctx?: BlockEmitContext): string {
   const doc = parseXml(DOCUMENT_SKELETON);
   const body = doc.getElementsByTagName('w:body').item(0);
   if (!body) throw new GenerationInternalError('document skeleton lost its w:body');
 
   spec.sections.forEach((section, index) => {
     for (const block of section.blocks) {
-      body.appendChild(buildBlock(doc, block, numberingIds));
+      body.appendChild(buildBlock(doc, block, ctx));
     }
 
     const sectPr = buildSectPr(doc, section, refs?.[index]);

--- a/packages/docx-core/src/generation/emit/emit-context.ts
+++ b/packages/docx-core/src/generation/emit/emit-context.ts
@@ -1,0 +1,31 @@
+/**
+ * Shared state the block emitters thread through paragraph/table recursion.
+ *
+ * Bundling it in one object keeps emitter signatures stable as features
+ * land: numbering binds spec handles to numeric ids, and the drafting-note
+ * collector allocates comment ids in document order (absent in stories that
+ * cannot carry notes, e.g. headers/footers, and when notes are disabled).
+ */
+
+import type { DraftingNoteSpec } from '../types.js';
+
+/** Spec-level numbering handle → numeric w:numId value. */
+export type NumberingIdMap = ReadonlyMap<string, number>;
+
+/** Allocates deterministic comment ids and records notes in document order. */
+export class DraftingNoteCollector {
+  readonly collected: Array<{ id: number; note: DraftingNoteSpec }> = [];
+  private nextId = 1;
+
+  allocate(note: DraftingNoteSpec): number {
+    const id = this.nextId++;
+    this.collected.push({ id, note });
+    return id;
+  }
+}
+
+export type BlockEmitContext = {
+  numberingIds?: NumberingIdMap;
+  /** Present only where drafting notes may anchor (body story, notes enabled). */
+  notes?: DraftingNoteCollector;
+};

--- a/packages/docx-core/src/generation/emit/header-footer-part.ts
+++ b/packages/docx-core/src/generation/emit/header-footer-part.ts
@@ -15,7 +15,7 @@ import { OOXML } from '../../primitives/namespaces.js';
 import { parseXml, serializeXml, XML_DECL } from '../../primitives/xml.js';
 import type { CompileContext } from '../context.js';
 import type { DocumentSpec, HeaderFooterSpec, SectionSpec } from '../types.js';
-import type { NumberingIdMap } from './numbering-part.js';
+import type { BlockEmitContext } from './emit-context.js';
 import { buildBlock } from './table.js';
 import type { SectionHeaderFooterRefs } from './section.js';
 
@@ -31,27 +31,27 @@ const SLOT_ORDER = ['first', 'default', 'even'] as const;
  * reference maps for the sectPr emitter. Runs before the document part so
  * relationship ids exist when sections bind their references.
  */
-export function emitHeaderFooterParts(spec: DocumentSpec, ctx: CompileContext, numberingIds?: NumberingIdMap): SectionHeaderFooterRefs[] {
-  return spec.sections.map((section) => emitForSection(section, ctx, numberingIds));
+export function emitHeaderFooterParts(spec: DocumentSpec, ctx: CompileContext, blockCtx?: BlockEmitContext): SectionHeaderFooterRefs[] {
+  return spec.sections.map((section) => emitForSection(section, ctx, blockCtx));
 }
 
-function emitForSection(section: SectionSpec, ctx: CompileContext, numberingIds?: NumberingIdMap): SectionHeaderFooterRefs {
+function emitForSection(section: SectionSpec, ctx: CompileContext, blockCtx?: BlockEmitContext): SectionHeaderFooterRefs {
   const refs: SectionHeaderFooterRefs = { headers: {}, footers: {} };
   for (const slot of SLOT_ORDER) {
     const header = section.headers?.[slot];
     if (header) {
-      refs.headers[slot] = emitPart(header, ctx, 'header', numberingIds);
+      refs.headers[slot] = emitPart(header, ctx, 'header', blockCtx);
     }
     const footer = section.footers?.[slot];
     if (footer) {
-      refs.footers[slot] = emitPart(footer, ctx, 'footer', numberingIds);
+      refs.footers[slot] = emitPart(footer, ctx, 'footer', blockCtx);
     }
   }
   return refs;
 }
 
 /** @conformance ECMA-376 edition 5, Part 1 § 17.10.3 */
-function emitPart(content: HeaderFooterSpec, ctx: CompileContext, kind: 'header' | 'footer', numberingIds?: NumberingIdMap): string {
+function emitPart(content: HeaderFooterSpec, ctx: CompileContext, kind: 'header' | 'footer', blockCtx?: BlockEmitContext): string {
   const isHeader = kind === 'header';
   const partName = isHeader ? ctx.allocateHeaderPartName() : ctx.allocateFooterPartName();
   const part = ctx.registerPart(
@@ -64,7 +64,7 @@ function emitPart(content: HeaderFooterSpec, ctx: CompileContext, kind: 'header'
   const doc = parseXml(`<${rootTag} xmlns:w="${OOXML.W_NS}" xmlns:r="${OOXML.R_NS}"/>`);
   const root = doc.documentElement!;
   for (const block of content.blocks) {
-    root.appendChild(buildBlock(doc, block, numberingIds));
+    root.appendChild(buildBlock(doc, block, blockCtx));
   }
 
   ctx.setFileContent(partName, XML_DECL + serializeXml(doc));

--- a/packages/docx-core/src/generation/emit/numbering-part.ts
+++ b/packages/docx-core/src/generation/emit/numbering-part.ts
@@ -22,15 +22,13 @@ import { OOXML, W } from '../../primitives/namespaces.js';
 import { parseXml, serializeXml, XML_DECL } from '../../primitives/xml.js';
 import type { CompileContext } from '../context.js';
 import type { DocumentSpec, NumberingSpec } from '../types.js';
+import type { NumberingIdMap } from './emit-context.js';
 import { buildRunPropsElement } from './properties.js';
 
 export const NUMBERING_CONTENT_TYPE =
   'application/vnd.openxmlformats-officedocument.wordprocessingml.numbering+xml';
 export const NUMBERING_REL_TYPE =
   'http://schemas.openxmlformats.org/officeDocument/2006/relationships/numbering';
-
-/** Spec-level numbering handle → numeric w:numId value. */
-export type NumberingIdMap = ReadonlyMap<string, number>;
 
 const NUMBERING_SKELETON = `<w:numbering xmlns:w="${OOXML.W_NS}"/>`;
 

--- a/packages/docx-core/src/generation/emit/paragraph.ts
+++ b/packages/docx-core/src/generation/emit/paragraph.ts
@@ -11,7 +11,7 @@ import { createWmlElement } from '../../primitives/dom-helpers.js';
 import { W } from '../../primitives/namespaces.js';
 import { GenerationInternalError } from '../errors.js';
 import type { ParagraphSpec } from '../types.js';
-import type { NumberingIdMap } from './numbering-part.js';
+import type { BlockEmitContext } from './emit-context.js';
 import { buildParagraphPropsElement } from './properties.js';
 import { buildInlineRuns } from './run.js';
 
@@ -23,12 +23,15 @@ import { buildInlineRuns } from './run.js';
  * @conformance ECMA-376 edition 5, Part 1 § 17.3.1.19
  * @conformance ECMA-376 edition 5, Part 1 § 17.9.3
  * @conformance ECMA-376 edition 5, Part 1 § 17.9.18
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.4.4
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.4.3
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.4.5
  */
-export function buildParagraph(doc: Document, paragraph: ParagraphSpec, numberingIds?: NumberingIdMap): Element {
+export function buildParagraph(doc: Document, paragraph: ParagraphSpec, ctx?: BlockEmitContext): Element {
   const p = createWmlElement(doc, W.p);
   let extras: Map<string, Element> | undefined;
   if (paragraph.list !== undefined) {
-    const numericId = numberingIds?.get(paragraph.list.numId);
+    const numericId = ctx?.numberingIds?.get(paragraph.list.numId);
     if (numericId === undefined) {
       throw new GenerationInternalError(
         `List paragraph references numbering handle '${paragraph.list.numId}' with no allocated numeric id`,
@@ -41,10 +44,25 @@ export function buildParagraph(doc: Document, paragraph: ParagraphSpec, numberin
   }
   const pPr = buildParagraphPropsElement(doc, paragraph, extras);
   if (pPr) p.appendChild(pPr);
+
+  // Drafting-note anchors: range markers bracket the paragraph's content and
+  // the reference run trails it (§ 17.13.4.4 / .3 / .5). Absent a collector
+  // (notes disabled, or a story that cannot carry them) the paragraph
+  // serializes without any trace of the note.
+  const noteId = paragraph.note !== undefined && ctx?.notes ? ctx.notes.allocate(paragraph.note) : undefined;
+  if (noteId !== undefined) {
+    p.appendChild(createWmlElement(doc, W.commentRangeStart, { 'w:id': String(noteId) }));
+  }
   for (const inline of paragraph.runs) {
     for (const run of buildInlineRuns(doc, inline)) {
       p.appendChild(run);
     }
+  }
+  if (noteId !== undefined) {
+    p.appendChild(createWmlElement(doc, W.commentRangeEnd, { 'w:id': String(noteId) }));
+    const referenceRun = createWmlElement(doc, W.r);
+    referenceRun.appendChild(createWmlElement(doc, W.commentReference, { 'w:id': String(noteId) }));
+    p.appendChild(referenceRun);
   }
   return p;
 }

--- a/packages/docx-core/src/generation/emit/table.ts
+++ b/packages/docx-core/src/generation/emit/table.ts
@@ -16,7 +16,7 @@ import { createWmlElement } from '../../primitives/dom-helpers.js';
 import { W } from '../../primitives/namespaces.js';
 import { appendInOrder, TBLPR_ORDER, TCPR_ORDER, TRPR_ORDER } from '../ordering.js';
 import type { BlockSpec, BorderSpec, TableBorders, TableCellSpec, TableRowSpec, TableSpec } from '../types.js';
-import type { NumberingIdMap } from './numbering-part.js';
+import type { BlockEmitContext } from './emit-context.js';
 import { buildParagraph } from './paragraph.js';
 
 /**
@@ -26,12 +26,12 @@ import { buildParagraph } from './paragraph.js';
  * @conformance ECMA-376 edition 5, Part 1 § 17.4.59
  * @conformance ECMA-376 edition 5, Part 1 § 17.4.48
  */
-export function buildTable(doc: Document, table: TableSpec, numberingIds?: NumberingIdMap): Element {
+export function buildTable(doc: Document, table: TableSpec, ctx?: BlockEmitContext): Element {
   const tbl = createWmlElement(doc, W.tbl);
   tbl.appendChild(buildTblPr(doc, table));
   tbl.appendChild(buildTblGrid(doc, table));
   for (const row of table.rows) {
-    tbl.appendChild(buildRow(doc, table, row, numberingIds));
+    tbl.appendChild(buildRow(doc, table, row, ctx));
   }
   return tbl;
 }
@@ -75,7 +75,7 @@ function buildTblGrid(doc: Document, table: TableSpec): Element {
  * @conformance ECMA-376 edition 5, Part 1 § 17.4.80
  * @conformance ECMA-376 edition 5, Part 1 § 17.4.49
  */
-function buildRow(doc: Document, table: TableSpec, row: TableRowSpec, numberingIds?: NumberingIdMap): Element {
+function buildRow(doc: Document, table: TableSpec, row: TableRowSpec, ctx?: BlockEmitContext): Element {
   const tr = createWmlElement(doc, W.tr);
 
   const props = new Map<string, Element | Element[]>();
@@ -100,7 +100,7 @@ function buildRow(doc: Document, table: TableSpec, row: TableRowSpec, numberingI
   let gridOffset = 0;
   for (const cell of row.cells) {
     const span = cell.gridSpan ?? 1;
-    tr.appendChild(buildCell(doc, table, cell, gridOffset, numberingIds));
+    tr.appendChild(buildCell(doc, table, cell, gridOffset, ctx));
     gridOffset += span;
   }
   return tr;
@@ -120,7 +120,7 @@ function buildRow(doc: Document, table: TableSpec, row: TableRowSpec, numberingI
  * @conformance ECMA-376 edition 5, Part 1 § 17.4.83
  * @conformance ECMA-376 edition 5, Part 1 § 17.4.68
  */
-function buildCell(doc: Document, table: TableSpec, cell: TableCellSpec, gridOffset: number, numberingIds?: NumberingIdMap): Element {
+function buildCell(doc: Document, table: TableSpec, cell: TableCellSpec, gridOffset: number, ctx?: BlockEmitContext): Element {
   const tc = createWmlElement(doc, W.tc);
   const tcPr = createWmlElement(doc, W.tcPr);
   const props = new Map<string, Element | Element[]>();
@@ -154,7 +154,7 @@ function buildCell(doc: Document, table: TableSpec, cell: TableCellSpec, gridOff
   tc.appendChild(tcPr);
 
   for (const block of cell.blocks) {
-    tc.appendChild(buildBlock(doc, block, numberingIds));
+    tc.appendChild(buildBlock(doc, block, ctx));
   }
   // A cell must end with a paragraph: readers reject a cell that is empty or
   // whose last block is a table.
@@ -166,8 +166,8 @@ function buildCell(doc: Document, table: TableSpec, cell: TableCellSpec, gridOff
 }
 
 /** Dispatch a block-level spec node to its emitter (cells hold both kinds). */
-export function buildBlock(doc: Document, block: BlockSpec, numberingIds?: NumberingIdMap): Element {
-  return block.kind === 'table' ? buildTable(doc, block, numberingIds) : buildParagraph(doc, block, numberingIds);
+export function buildBlock(doc: Document, block: BlockSpec, ctx?: BlockEmitContext): Element {
+  return block.kind === 'table' ? buildTable(doc, block, ctx) : buildParagraph(doc, block, ctx);
 }
 
 /**

--- a/packages/docx-core/src/generation/generation-drafting-notes.test.ts
+++ b/packages/docx-core/src/generation/generation-drafting-notes.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { DocxDocument } from '../primitives/document.js';
+import { readZipText } from '../primitives/zip.js';
+import { parseXml } from '../primitives/xml.js';
+import { generateDocx } from './compile.js';
+import { checkGeneratedPackage } from './structural-checks.js';
+import type { DocumentSpec } from './types.js';
+
+const TEST_FEATURE = 'add-docx-generation';
+const test = testAllure.epic('Document Generation').withLabels({ feature: TEST_FEATURE });
+
+const COMMENT_PARTS = ['word/comments.xml', 'word/commentsExtended.xml', 'word/people.xml'] as const;
+
+function notedSpec(): DocumentSpec {
+  return {
+    meta: { title: 'Drafting notes', author: 'Jane Doe', createdIso: '2026-06-11T00:00:00Z' },
+    sections: [
+      {
+        blocks: [
+          { kind: 'paragraph', runs: [{ kind: 'text', text: 'Recitals.' }] },
+          {
+            kind: 'paragraph',
+            note: { text: 'Confirm the survival period with the client.', author: 'John Smith', dateIso: '2026-06-10T12:00:00Z' },
+            runs: [{ kind: 'text', text: 'Confidentiality survives three years.' }],
+          },
+          {
+            kind: 'paragraph',
+            note: { text: 'Mirror the governing-law choice from the MSA.' },
+            runs: [{ kind: 'text', text: 'Governing law: Delaware.' }],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+/** The same content with no notes declared at all. */
+function bareSpec(): DocumentSpec {
+  const spec = notedSpec();
+  for (const block of spec.sections[0]!.blocks) {
+    if (block.kind === 'paragraph') delete block.note;
+  }
+  return spec;
+}
+
+describe('Traceability: separable drafting-note layer', () => {
+  test
+    .openspec('[SDX-GEN-080] a drafting note becomes an anchored comment')
+    .conformance(
+      { spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.4.6' },
+      { spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.4.4' },
+      { spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.4.3' },
+      { spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.4.5' },
+    )(
+    'Scenario: a drafting note becomes an anchored comment',
+    async ({ given, when, then, attachPrettyXml }: AllureBddContext) => {
+      let buffer!: Buffer;
+      await given('paragraphs carrying drafting notes, compiled with notes enabled (the default)', async () => {
+        buffer = await generateDocx(notedSpec());
+        expect((await checkGeneratedPackage(buffer)).issues).toEqual([]);
+      });
+
+      let documentXml!: string;
+      let commentsXml!: string;
+      await when('the document and comments parts are parsed back', async () => {
+        documentXml = (await readZipText(buffer, 'word/document.xml'))!;
+        commentsXml = (await readZipText(buffer, 'word/comments.xml'))!;
+        expect(commentsXml).toBeTruthy();
+        await attachPrettyXml('word/comments.xml', commentsXml);
+      });
+
+      await then('the package contains the comment trio with the note text and metadata', async () => {
+        for (const part of ['word/commentsExtended.xml', 'word/people.xml']) {
+          expect(await readZipText(buffer, part)).toBeTruthy();
+        }
+        const comments = Array.from(parseXml(commentsXml).getElementsByTagName('w:comment'));
+        expect(comments).toHaveLength(2);
+        expect(comments[0]!.getAttribute('w:author')).toBe('John Smith');
+        expect(comments[0]!.getAttribute('w:date')).toBe('2026-06-10T12:00:00Z');
+        // Authorless note falls back to the document author; dateless to createdIso.
+        expect(comments[1]!.getAttribute('w:author')).toBe('Jane Doe');
+        expect(comments[1]!.getAttribute('w:date')).toBe('2026-06-11T00:00:00Z');
+        expect(commentsXml).toContain('Confirm the survival period with the client.');
+      });
+
+      await then('each noted paragraph carries range anchors and a reference with matching ids', async () => {
+        const dom = parseXml(documentXml);
+        const starts = Array.from(dom.getElementsByTagName('w:commentRangeStart'));
+        const ends = Array.from(dom.getElementsByTagName('w:commentRangeEnd'));
+        const refs = Array.from(dom.getElementsByTagName('w:commentReference'));
+        expect(starts.map((el) => el.getAttribute('w:id'))).toEqual(['1', '2']);
+        expect(ends.map((el) => el.getAttribute('w:id'))).toEqual(['1', '2']);
+        expect(refs.map((el) => el.getAttribute('w:id'))).toEqual(['1', '2']);
+      });
+    },
+  );
+
+  test.openspec('[SDX-GEN-081] compile-time omission leaves the body identical')(
+    'Scenario: compile-time omission leaves the body identical',
+    async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
+      let withNotes!: Buffer;
+      let disabledViaSpec!: Buffer;
+      let disabledViaOpts!: Buffer;
+      let bare!: Buffer;
+      await given('the same noted spec compiled with notes enabled and disabled, plus a never-noted control', async () => {
+        withNotes = await generateDocx(notedSpec());
+        disabledViaSpec = await generateDocx({ ...notedSpec(), options: { includeDraftingNotes: false } });
+        disabledViaOpts = await generateDocx(notedSpec(), { includeDraftingNotes: false });
+        bare = await generateDocx(bareSpec());
+      });
+
+      let disabledDocumentXml!: string;
+      await when('the body text layers are extracted', async () => {
+        disabledDocumentXml = (await readZipText(disabledViaSpec, 'word/document.xml'))!;
+        expect(disabledDocumentXml).toBeTruthy();
+      });
+
+      await then('the disabled outputs are byte-identical to the never-noted control', async () => {
+        expect(disabledViaSpec.equals(bare)).toBe(true);
+        expect(disabledViaOpts.equals(bare)).toBe(true);
+        await attachPrettyJson('byte-comparison', {
+          disabledViaSpecEqualsBare: disabledViaSpec.equals(bare),
+          disabledViaOptsEqualsBare: disabledViaOpts.equals(bare),
+        });
+      });
+
+      await then('the disabled output contains no comment parts or anchors, while the enabled one does', async () => {
+        for (const part of COMMENT_PARTS) {
+          expect(await readZipText(disabledViaSpec, part)).toBeNull();
+          expect(await readZipText(withNotes, part)).toBeTruthy();
+        }
+        expect(disabledDocumentXml).not.toMatch(/commentRangeStart|commentRangeEnd|commentReference/);
+      });
+    },
+  );
+
+  test.openspec('[SDX-GEN-082] notes can be stripped after generation')(
+    'Scenario: notes can be stripped after generation',
+    async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
+      let doc!: DocxDocument;
+      await given('a generated document with drafting notes', async () => {
+        const buffer = await generateDocx(notedSpec());
+        doc = await DocxDocument.load(buffer);
+        expect((await readZipText(buffer, 'word/comments.xml'))!).toContain('Mirror the governing-law');
+      });
+
+      let stripped!: Buffer;
+      await when('each comment is deleted through the existing comment-deletion path', async () => {
+        await doc.deleteComment({ commentId: 1 });
+        await doc.deleteComment({ commentId: 2 });
+        stripped = (await doc.toBuffer()).buffer;
+        await attachPrettyJson('stripped-size', { bytes: stripped.length });
+      });
+
+      await then('the result contains no comment anchors or references and the comments part is empty', async () => {
+        const documentXml = (await readZipText(stripped, 'word/document.xml'))!;
+        expect(documentXml).not.toMatch(/commentRangeStart|commentRangeEnd|commentReference/);
+        const commentsXml = await readZipText(stripped, 'word/comments.xml');
+        if (commentsXml !== null) {
+          expect(parseXml(commentsXml).getElementsByTagName('w:comment')).toHaveLength(0);
+        }
+      });
+
+      await then('the stripped document still passes structural validation and loads', async () => {
+        const result = await checkGeneratedPackage(stripped);
+        expect(result.issues).toEqual([]);
+        const reloaded = await DocxDocument.load(stripped);
+        reloaded.insertParagraphBookmarks('sdx-gen-082');
+        const texts = reloaded.readParagraphs().paragraphs.map((p) => p.text);
+        expect(texts.join('\n')).toContain('Confidentiality survives three years.');
+      });
+    },
+  );
+
+  test.openspec('[SDX-GEN-083] comment metadata is deterministic')(
+    'Scenario: comment metadata is deterministic',
+    async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
+      let spec!: DocumentSpec;
+      await given('a spec with drafting notes carrying explicit ISO dates', async () => {
+        spec = notedSpec();
+        expect(spec.sections[0]!.blocks.some((b) => b.kind === 'paragraph' && b.note?.dateIso)).toBe(true);
+      });
+
+      let first!: Buffer;
+      let second!: Buffer;
+      await when('it is compiled twice', async () => {
+        first = await generateDocx(spec);
+        second = await generateDocx(spec);
+      });
+
+      await then('the outputs are byte-identical', async () => {
+        expect(second.equals(first)).toBe(true);
+        expect(first.length).toBeGreaterThan(0);
+      });
+
+      await then('ids, paraIds, and dates derive only from the spec and compile context', async () => {
+        const commentsXml = (await readZipText(first, 'word/comments.xml'))!;
+        const comments = Array.from(parseXml(commentsXml).getElementsByTagName('w:comment'));
+        expect(comments.map((c) => c.getAttribute('w:id'))).toEqual(['1', '2']);
+        const extendedXml = (await readZipText(first, 'word/commentsExtended.xml'))!;
+        const paraIds = Array.from(parseXml(extendedXml).getElementsByTagName('w15:commentEx')).map((el) =>
+          el.getAttribute('w15:paraId'),
+        );
+        expect(paraIds).toEqual(['00000001', '00000002']);
+        expect(commentsXml).toContain('w14:paraId="00000001"');
+        await attachPrettyJson('deterministic-metadata', { paraIds });
+      });
+    },
+  );
+
+  test('phase 6 drafting-notes artifact loads with comments visible to the comment APIs', async () => {
+    const buffer = await generateDocx(notedSpec());
+    const doc = await DocxDocument.load(buffer);
+    doc.insertParagraphBookmarks('sdx-gen-phase6');
+    const texts = doc.readParagraphs().paragraphs.map((p) => p.text);
+    expect(texts.join('\n')).toContain('Governing law: Delaware.');
+    const commentsXml = (await readZipText(buffer, 'word/comments.xml'))!;
+    expect(commentsXml).toContain('Mirror the governing-law choice from the MSA.');
+    const { writeIntegrationArtifact } = await import('../integration/output-artifacts.js');
+    const outputPath = await writeIntegrationArtifact('generation-phase6-drafting-notes.docx', buffer);
+    expect(outputPath).toContain('generation-phase6-drafting-notes.docx');
+  });
+});

--- a/packages/docx-core/src/generation/generation-skeleton.test.ts
+++ b/packages/docx-core/src/generation/generation-skeleton.test.ts
@@ -84,65 +84,40 @@ describe('Traceability: from-scratch generation skeleton', () => {
   test.openspec('[SDX-GEN-003] unimplemented spec features are rejected loudly')(
     'Scenario: unimplemented spec features are rejected loudly',
     async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
-      let noteSpec!: DocumentSpec;
-      let cellNoteSpec!: DocumentSpec;
-      await given('specs using the declared drafting-note feature, whose emitter has not shipped (body and table-cell anchors)', async () => {
-        noteSpec = {
-          sections: [
-            {
-              blocks: [
-                { kind: 'paragraph', note: { text: 'flag this clause' }, runs: [{ kind: 'text', text: 'clause' }] },
-              ],
-            },
-          ],
-        };
-        cellNoteSpec = {
-          sections: [
-            {
-              blocks: [
-                {
-                  kind: 'table',
-                  columnWidthsTwips: [9360],
-                  rows: [
-                    {
-                      cells: [
-                        {
-                          blocks: [
-                            { kind: 'paragraph', note: { text: 'check this cell' }, runs: [{ kind: 'text', text: 'cell' }] },
-                          ],
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        };
+      let unknownBlockSpec!: DocumentSpec;
+      let unknownInlineSpec!: DocumentSpec;
+      await given('specs using kinds without a shipped emitter (an unrecognized block kind and inline kind, as a JSON caller could send)', async () => {
+        unknownBlockSpec = JSON.parse(
+          '{"sections":[{"blocks":[{"kind":"contentControl","runs":[]}]}]}',
+        ) as DocumentSpec;
+        unknownInlineSpec = JSON.parse(
+          '{"sections":[{"blocks":[{"kind":"paragraph","runs":[{"kind":"footnote","text":"x"}]}]}]}',
+        ) as DocumentSpec;
       });
 
-      let noteError: unknown;
-      let cellNoteError: unknown;
+      let blockError: unknown;
+      let inlineError: unknown;
       await when('generateDocx compiles each spec', async () => {
-        noteError = await generateDocx(noteSpec).then(
+        blockError = await generateDocx(unknownBlockSpec).then(
           () => null,
           (err: unknown) => err,
         );
-        cellNoteError = await generateDocx(cellNoteSpec).then(
+        inlineError = await generateDocx(unknownInlineSpec).then(
           () => null,
           (err: unknown) => err,
         );
       });
 
       await then('each compilation fails with a typed error naming the feature and its spec path', async () => {
-        expect(noteError).toBeInstanceOf(GenerationSpecError);
-        expect((noteError as GenerationSpecError).code).toBe('unsupported_feature');
-        expect((noteError as GenerationSpecError).path).toBe('/sections/0/blocks/0/note');
-        expect(cellNoteError).toBeInstanceOf(GenerationSpecError);
-        expect((cellNoteError as GenerationSpecError).path).toBe('/sections/0/blocks/0/rows/0/cells/0/blocks/0/note');
+        expect(blockError).toBeInstanceOf(GenerationSpecError);
+        expect((blockError as GenerationSpecError).code).toBe('unsupported_feature');
+        expect((blockError as GenerationSpecError).path).toBe('/sections/0/blocks/0');
+        expect(inlineError).toBeInstanceOf(GenerationSpecError);
+        expect((inlineError as GenerationSpecError).code).toBe('unsupported_feature');
+        expect((inlineError as GenerationSpecError).path).toBe('/sections/0/blocks/0/runs/0');
         await attachPrettyJson('rejections', {
-          note: { code: (noteError as GenerationSpecError).code, path: (noteError as GenerationSpecError).path },
-          cellNote: { code: (cellNoteError as GenerationSpecError).code, path: (cellNoteError as GenerationSpecError).path },
+          block: { code: (blockError as GenerationSpecError).code, path: (blockError as GenerationSpecError).path },
+          inline: { code: (inlineError as GenerationSpecError).code, path: (inlineError as GenerationSpecError).path },
         });
       });
     },

--- a/packages/docx-core/src/generation/validate-spec.ts
+++ b/packages/docx-core/src/generation/validate-spec.ts
@@ -13,9 +13,14 @@
  * fields, paragraph formatting, named styles + styles.xml, multi-section
  * documents with per-section page setup, page numbering, break types,
  * default/first/even headers and footers, tables (grid, spans, vertical
- * merges, cell decoration, nesting), and multi-level numbering with
- * w:numPr list references.
- * Still rejected: drafting notes.
+ * merges, cell decoration, nesting), multi-level numbering with w:numPr
+ * list references, and drafting notes compiled to anchored comments (body
+ * story only — header/footer paragraphs cannot carry notes).
+ *
+ * Every declared feature now has an emitter; the loud-rejection contract
+ * (SDX-GEN-003) lives on as runtime guards against unrecognized block and
+ * inline kinds, which protect callers handing in JSON that the TypeScript
+ * surface never saw.
  */
 
 import { GenerationSpecError } from './errors.js';
@@ -142,7 +147,7 @@ function validateSection(section: SectionSpec, path: string, styleIds: Set<strin
         throw new GenerationSpecError('invalid_value', `${slotPath}/blocks`, 'Header/footer blocks must be a non-empty array');
       }
       content.blocks.forEach((block, blockIndex) => {
-        validateBlock(block, `${slotPath}/blocks/${blockIndex}`, styleIds, numbering);
+        validateBlock(block, `${slotPath}/blocks/${blockIndex}`, styleIds, numbering, 'headerFooter');
       });
     }
   }
@@ -164,13 +169,23 @@ function validateSection(section: SectionSpec, path: string, styleIds: Set<strin
     throw new GenerationSpecError('invalid_value', `${path}/blocks`, 'Section blocks must be an array');
   }
   section.blocks.forEach((block, blockIndex) => {
-    validateBlock(block, `${path}/blocks/${blockIndex}`, styleIds, numbering);
+    validateBlock(block, `${path}/blocks/${blockIndex}`, styleIds, numbering, 'body');
   });
 }
 
-function validateBlock(block: BlockSpec, path: string, styleIds: Set<string>, numbering: Map<string, Set<number>>): void {
-  if (block.kind === 'table') validateTable(block, path, styleIds, numbering);
-  else validateParagraph(block, path, styleIds, numbering);
+/** Story kind: drafting notes may only anchor in the body story. */
+type StoryContext = 'body' | 'headerFooter';
+
+function validateBlock(
+  block: BlockSpec,
+  path: string,
+  styleIds: Set<string>,
+  numbering: Map<string, Set<number>>,
+  story: StoryContext,
+): void {
+  if (block.kind === 'table') validateTable(block, path, styleIds, numbering, story);
+  else if (block.kind === 'paragraph') validateParagraph(block, path, styleIds, numbering, story);
+  else unsupported(path, `block kind '${(block as { kind: string }).kind}'`);
 }
 
 /**
@@ -180,7 +195,7 @@ function validateBlock(block: BlockSpec, path: string, styleIds: Set<string>, nu
  * span of a merge cell in the previous row — otherwise readers either show
  * a recovery dialog or silently reflow the table.
  */
-function validateTable(table: TableSpec, path: string, styleIds: Set<string>, numbering: Map<string, Set<number>>): void {
+function validateTable(table: TableSpec, path: string, styleIds: Set<string>, numbering: Map<string, Set<number>>, story: StoryContext): void {
   if (!Array.isArray(table.columnWidthsTwips) || table.columnWidthsTwips.length === 0) {
     throw new GenerationSpecError('invalid_value', `${path}/columnWidthsTwips`, 'Tables require at least one column width');
   }
@@ -245,7 +260,7 @@ function validateTable(table: TableSpec, path: string, styleIds: Set<string>, nu
         throw new GenerationSpecError('invalid_value', `${cellPath}/blocks`, 'Cell blocks must be an array (empty allowed; an empty cell compiles to an empty paragraph)');
       }
       cell.blocks.forEach((block, blockIndex) => {
-        validateBlock(block, `${cellPath}/blocks/${blockIndex}`, styleIds, numbering);
+        validateBlock(block, `${cellPath}/blocks/${blockIndex}`, styleIds, numbering, story);
       });
       gridOffset += span;
     });
@@ -273,8 +288,25 @@ function validateBorders(borders: TableBorders, path: string): void {
   }
 }
 
-function validateParagraph(paragraph: ParagraphSpec, path: string, styleIds: Set<string>, numbering: Map<string, Set<number>>): void {
-  if (paragraph.note !== undefined) unsupported(`${path}/note`, 'drafting notes');
+function validateParagraph(
+  paragraph: ParagraphSpec,
+  path: string,
+  styleIds: Set<string>,
+  numbering: Map<string, Set<number>>,
+  story: StoryContext,
+): void {
+  if (paragraph.note !== undefined) {
+    if (story === 'headerFooter') {
+      throw new GenerationSpecError(
+        'invalid_value',
+        `${path}/note`,
+        'Drafting notes anchor as document-story comments and cannot live in headers or footers',
+      );
+    }
+    if (typeof paragraph.note.text !== 'string' || paragraph.note.text.length === 0) {
+      throw new GenerationSpecError('invalid_value', `${path}/note/text`, 'Drafting notes require non-empty text');
+    }
+  }
 
   if (paragraph.list !== undefined) {
     const levels = numbering.get(paragraph.list.numId);
@@ -318,6 +350,9 @@ function validateParagraph(paragraph: ParagraphSpec, path: string, styleIds: Set
 }
 
 function validateInline(run: InlineSpec, path: string): void {
+  if (run.kind !== 'tab' && run.kind !== 'break' && run.kind !== 'field' && run.kind !== 'text') {
+    unsupported(path, `inline kind '${(run as { kind: string }).kind}'`);
+  }
   if (run.kind === 'tab' || run.kind === 'break') return;
   if (run.kind === 'field') {
     if (typeof run.cachedResult !== 'string' || run.cachedResult.length === 0) {

--- a/spec-compliance/CONFORMANCE.md
+++ b/spec-compliance/CONFORMANCE.md
@@ -70,6 +70,11 @@ Allure labels via `testAllure.conformance({…})`; source code carries
 | `ECMA-PART1-17-9-12` | w:multiLevelType abstract definition type | 5 | 1 | 17.9.12 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:multiLevelType` | — |
 | `ECMA-PART1-17-9-7` | w:lvlJc numbering level justification | 5 | 1 | 17.9.7 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:lvlJc` | — |
 | `ECMA-PART1-17-3-1-19` | w:numPr paragraph numbering reference | 5 | 1 | 17.3.1.19 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:numPr` | — |
+| `ECMA-PART1-17-13-4-6` | w:comments comment-collection part emission | 5 | 1 | 17.13.4.6 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:comments` | — |
+| `ECMA-PART1-17-13-4-2` | w:comment comment content emission | 5 | 1 | 17.13.4.2 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:comment` | — |
+| `ECMA-PART1-17-13-4-4` | w:commentRangeStart comment anchor opening | 5 | 1 | 17.13.4.4 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:commentRangeStart` | — |
+| `ECMA-PART1-17-13-4-3` | w:commentRangeEnd comment anchor closing | 5 | 1 | 17.13.4.3 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:commentRangeEnd` | — |
+| `ECMA-PART1-17-13-4-5` | w:commentReference comment reference mark | 5 | 1 | 17.13.4.5 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:commentReference` | — |
 
 ### ECMA-PART4-17-16-5 — w:delInstrText and w:fldChar placement in tracked deletions
 
@@ -760,6 +765,64 @@ leaves the alignment to reader defaults.
 List paragraphs carry `w:numPr` (ilvl then numId) at its CT_PPrBase slot
 via the PPR_ORDER table; the numeric id comes from the numbering part's
 deterministic handle map.
+
+### ECMA-PART1-17-13-4-6 — w:comments comment-collection part emission
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.13.4.6
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:comments`
+
+Drafting notes compile to a word/comments.xml part holding one
+`w:comment` per note, alongside the Word-extension commentsExtended and
+people parts (content/relationship types matching what Word itself
+writes, cross-checked against the Open XML SDK part constants). The
+emitter lives in `packages/docx-core/src/generation/emit/comments-part.ts`.
+
+### ECMA-PART1-17-13-4-2 — w:comment comment content emission
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.13.4.2
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:comment`
+
+Each comment carries deterministic metadata: sequential ids in document
+order, author falling back note.author → meta.author → 'safe-docx' with
+derived initials, dates only from DraftingNoteSpec.dateIso or
+meta.createdIso (never the clock), and a `w14:paraId` derived from the
+comment id so commentsExtended entries pair up by construction.
+
+### ECMA-PART1-17-13-4-4 — w:commentRangeStart comment anchor opening
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.13.4.4
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:commentRangeStart`
+
+A noted paragraph opens its comment range before its first run; range
+ids always match an emitted comment, and the disabled-notes compile emits
+no anchors at all, keeping the body byte-identical to a never-noted spec.
+
+### ECMA-PART1-17-13-4-3 — w:commentRangeEnd comment anchor closing
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.13.4.3
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:commentRangeEnd`
+
+The comment range closes after the paragraph's last run, before the
+reference run, so the anchored extent is exactly the paragraph content.
+
+### ECMA-PART1-17-13-4-5 — w:commentReference comment reference mark
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.13.4.5
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:commentReference`
+
+The trailing reference run carries `w:commentReference` with the same id
+as its range anchors; the existing deleteComment editing path removes the
+trio cleanly, which the strip scenario verifies on generated output.
 
 ## Non-Goals
 

--- a/spec-compliance/registry/ecma-376.md
+++ b/spec-compliance/registry/ecma-376.md
@@ -930,6 +930,84 @@ List paragraphs carry `w:numPr` (ilvl then numId) at its CT_PPrBase slot
 via the PPR_ORDER table; the numeric id comes from the numbering part's
 deterministic handle map.
 
+## [ECMA-PART1-17-13-4-6] w:comments comment-collection part emission
+
+```yaml
+edition: 5
+part: 1
+section: "17.13.4.6"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:comments
+verifiedBy:
+```
+
+Drafting notes compile to a word/comments.xml part holding one
+`w:comment` per note, alongside the Word-extension commentsExtended and
+people parts (content/relationship types matching what Word itself
+writes, cross-checked against the Open XML SDK part constants). The
+emitter lives in `packages/docx-core/src/generation/emit/comments-part.ts`.
+
+## [ECMA-PART1-17-13-4-2] w:comment comment content emission
+
+```yaml
+edition: 5
+part: 1
+section: "17.13.4.2"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:comment
+verifiedBy:
+```
+
+Each comment carries deterministic metadata: sequential ids in document
+order, author falling back note.author → meta.author → 'safe-docx' with
+derived initials, dates only from DraftingNoteSpec.dateIso or
+meta.createdIso (never the clock), and a `w14:paraId` derived from the
+comment id so commentsExtended entries pair up by construction.
+
+## [ECMA-PART1-17-13-4-4] w:commentRangeStart comment anchor opening
+
+```yaml
+edition: 5
+part: 1
+section: "17.13.4.4"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:commentRangeStart
+verifiedBy:
+```
+
+A noted paragraph opens its comment range before its first run; range
+ids always match an emitted comment, and the disabled-notes compile emits
+no anchors at all, keeping the body byte-identical to a never-noted spec.
+
+## [ECMA-PART1-17-13-4-3] w:commentRangeEnd comment anchor closing
+
+```yaml
+edition: 5
+part: 1
+section: "17.13.4.3"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:commentRangeEnd
+verifiedBy:
+```
+
+The comment range closes after the paragraph's last run, before the
+reference run, so the anchored extent is exactly the paragraph content.
+
+## [ECMA-PART1-17-13-4-5] w:commentReference comment reference mark
+
+```yaml
+edition: 5
+part: 1
+section: "17.13.4.5"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:commentReference
+verifiedBy:
+```
+
+The trailing reference run carries `w:commentReference` with the same id
+as its range anchors; the existing deleteComment editing path removes the
+trio cleanly, which the strip scenario verifies on generated output.
+
 ## Non-Goals
 
 Sections explicitly **out of scope** for safe-docx. Each entry below carries the


### PR DESCRIPTION
## Summary

Phase 6 of the `add-docx-generation` OpenSpec change (PR 6 of 7): the separable drafting-note layer. Implements scenarios `[SDX-GEN-080]`..`[SDX-GEN-083]`.

- **`emit/comments-part.ts`**: `ParagraphSpec.note` compiles to an anchored OOXML comment — `w:commentRangeStart`/`End` bracket the paragraph content, a trailing run carries `w:commentReference`. The comment trio (comments.xml + commentsExtended.xml + people.xml) is always emitted together when notes are enabled.
- **Content-type decision (task 6.2)**: the repo had two competing commentsExtended content types. Resolved against Microsoft's own Open XML SDK (`WordprocessingCommentsExPart.ContentTypeConstant`): Word writes `application/vnd.openxmlformats-officedocument.wordprocessingml.commentsExtended+xml` with rel type `http://schemas.microsoft.com/office/2011/relationships/commentsExtended` — matching `primitives/comments.ts`; the `vnd.ms-word.*` variant in `synthetic-docx-fixture.ts` is the outlier and was not adopted. Decision documented in the module doc comment.
- **Separability both ways** (scenarios 081/082): `includeDraftingNotes: false` (spec option or `generateDocx` override) produces a package **byte-identical** to compiling a never-noted spec — no parts, no anchors; and the existing `deleteComment` editing path strips generated comments cleanly (verified: no anchors/references remain, structural checks still pass).
- **Deterministic metadata** (scenario 083): sequential ids in document order; `w14:paraId` = zero-padded hex of the id (pairs comments.xml with commentsExtended.xml by construction); dates only from `DraftingNoteSpec.dateIso` → `meta.createdIso`; author fallback `note.author` → `meta.author` → `safe-docx` with derived initials. Byte-identical recompiles.
- **Scope rule**: notes are body-story only; header/footer notes rejected at validation (`invalid_value`).
- **`BlockEmitContext` refactor**: block emitters now thread one context object (numbering ids + note collector) instead of growing positional params.
- **`[SDX-GEN-003]` amended** (spec delta + test): with every declared feature now shipped, the loud-rejection contract covers unrecognized block/inline kinds arriving from JSON callers, enforced by new runtime guards in validate-spec.
- **Registry**: 5 new `§ 17.13.4.x` entries verified against the ECMA-376 Part 1 ToC; CONFORMANCE.md + README block regenerated.
- New review artifact `generation-phase6-drafting-notes.docx` + manual-compat matrix row.

Spec coverage: 35/36 scenarios mapped (the last one is PR 7's manual-matrix scenario; validator stays `--report-only` until PR 7 flips it).

Ref: #280

## Test plan

- [x] `npm run build && npm run lint:workspaces && npm run test:run` (2568 passed) + `npx madge --circular` clean
- [x] `npm run check:spec-coverage` (incl. generation validator, report-only) + allure-labels validator
- [x] `npm run check:conformance-citations` (62 entries) / `check:conformance-doc` green at commit
- [x] `openspec validate add-docx-generation --strict` (incl. the amended SDX-GEN-003 delta)
- [x] New `generation-drafting-notes.test.ts`: anchored trio + metadata fallbacks (080), byte-identical disabled output both ways (081), deleteComment strip (082), deterministic ids/paraIds/dates (083), artifact round-trip