### PR TITLE
chore(release): bump workspace versions to 0.11.0

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-docx",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "AI-powered DOCX and ODT editing with tracked changes, redlining, and formatting preservation",
   "contextFileName": "GEMINI.md",
   "entrypoint": "GEMINI.md",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "safe-docx-suite",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "safe-docx-suite",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -9383,7 +9383,7 @@
     },
     "packages/allure-test-factory": {
       "name": "@usejunior/allure-test-factory",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -9404,7 +9404,7 @@
     },
     "packages/docx-core": {
       "name": "@usejunior/docx-core",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "^0.9.10",
@@ -9412,7 +9412,8 @@
       },
       "bin": {
         "docx-comparison": "dist/cli/index.js",
-        "safe-docx-compare": "dist/cli/index.js"
+        "safe-docx-compare": "dist/cli/index.js",
+        "safe-docx-conformance-adapter": "dist/cli/conformance-adapter.js"
       },
       "devDependencies": {
         "@types/diff-match-patch": "^1.0.36",
@@ -9432,12 +9433,12 @@
     },
     "packages/docx-mcp": {
       "name": "@usejunior/docx-mcp",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@usejunior/docx-core": "^0.10.0",
-        "@usejunior/odf-core": "^0.10.0",
+        "@usejunior/docx-core": "^0.11.0",
+        "@usejunior/odf-core": "^0.11.0",
         "@xmldom/xmldom": "^0.9.10",
         "zod": "^4.3.6"
       },
@@ -9458,7 +9459,7 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@usejunior/google-docs-core": "^0.10.0"
+        "@usejunior/google-docs-core": "^0.11.0"
       },
       "peerDependenciesMeta": {
         "@usejunior/google-docs-core": {
@@ -9468,7 +9469,7 @@
     },
     "packages/google-docs-core": {
       "name": "@usejunior/google-docs-core",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "google-auth-library": "^9.0.0"
@@ -9484,10 +9485,10 @@
     },
     "packages/odf-core": {
       "name": "@usejunior/odf-core",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
-        "@usejunior/docx-core": "^0.10.0",
+        "@usejunior/docx-core": "^0.11.0",
         "@xmldom/xmldom": "^0.9.10",
         "jszip": "^3.10.1"
       },
@@ -9502,10 +9503,10 @@
     },
     "packages/safe-docx": {
       "name": "@usejunior/safe-docx",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
-        "@usejunior/docx-mcp": "^0.10.0"
+        "@usejunior/docx-mcp": "^0.11.0"
       },
       "bin": {
         "safe-docx": "bin/safe-docx.js",
@@ -9517,10 +9518,10 @@
     },
     "packages/safe-docx-mcpb": {
       "name": "@usejunior/safedocx-mcpb",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
-        "@usejunior/safe-docx": "^0.10.0"
+        "@usejunior/safe-docx": "^0.11.0"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-docx-suite",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": true,
   "description": "Monorepo for Safe DOCX packages",
   "repository": {

--- a/packages/allure-test-factory/package.json
+++ b/packages/allure-test-factory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/allure-test-factory",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Shared Allure test helpers for vitest — BDD context, OpenSpec auto-inference, Prism.js highlighting",
   "type": "module",
   "exports": {

--- a/packages/docx-core/package.json
+++ b/packages/docx-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/docx-core",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "OOXML (.docx) core library: primitives, comparison, and track changes",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/docx-mcp/package.json
+++ b/packages/docx-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/docx-mcp",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "MCP server for reading, editing, and comparing Word (.docx) and OpenDocument (.odt) files with tracked changes. For Claude, Gemini CLI, Cursor, and any MCP client. MIT licensed.",
   "type": "module",
   "main": "dist/index.js",
@@ -27,8 +27,8 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@usejunior/docx-core": "^0.10.0",
-    "@usejunior/odf-core": "^0.10.0",
+    "@usejunior/docx-core": "^0.11.0",
+    "@usejunior/odf-core": "^0.11.0",
     "@xmldom/xmldom": "^0.9.10",
     "zod": "^4.3.6"
   },
@@ -55,7 +55,7 @@
     "dist"
   ],
   "peerDependencies": {
-    "@usejunior/google-docs-core": "^0.10.0"
+    "@usejunior/google-docs-core": "^0.11.0"
   },
   "peerDependenciesMeta": {
     "@usejunior/google-docs-core": {

--- a/packages/google-docs-core/package.json
+++ b/packages/google-docs-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/google-docs-core",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Google Docs core library: read, write, and anchor management via Google Docs API",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/odf-core/package.json
+++ b/packages/odf-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/odf-core",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "OpenDocument Format (.odt) core library: archive packaging, document view, surgical text replacement, and tracked-changes comparison",
   "type": "module",
   "main": "dist/index.js",
@@ -14,7 +14,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@usejunior/docx-core": "^0.10.0",
+    "@usejunior/docx-core": "^0.11.0",
     "@xmldom/xmldom": "^0.9.10",
     "jszip": "^3.10.1"
   },

--- a/packages/safe-docx-mcpb/manifest.json
+++ b/packages/safe-docx-mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "safe-docx",
   "display_name": "Safe Docx",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "AI-native Word (.docx) and OpenDocument (.odt) editing with stable paragraph anchors and deterministic document operations.",
   "long_description": "Safe Docx lets Claude work directly with .docx files on your local filesystem. It provides stable paragraph IDs (_bk_*) for precise editing while preserving formatting and structure.\n\nCore capabilities include reading/searching content, formatting-preserving edits and inserts, deterministic layout controls, tracked-changes output, comments, footnote tools, document comparison, and revision extraction.",
   "author": {

--- a/packages/safe-docx-mcpb/package.json
+++ b/packages/safe-docx-mcpb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/safedocx-mcpb",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": true,
   "description": "Claude Desktop MCP Bundle (.mcpb) wrapper for @usejunior/safe-docx",
   "type": "module",
@@ -14,7 +14,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@usejunior/safe-docx": "^0.10.0"
+    "@usejunior/safe-docx": "^0.11.0"
   },
   "devDependencies": {
     "@vitest/runner": "^4.1.8",

--- a/packages/safe-docx/.smithery/shttp/manifest.json
+++ b/packages/safe-docx/.smithery/shttp/manifest.json
@@ -6,7 +6,7 @@
     "serverCard": {
       "serverInfo": {
         "name": "safe-docx",
-        "version": "0.10.0"
+        "version": "0.11.0"
       },
       "tools": [
         {

--- a/packages/safe-docx/package.json
+++ b/packages/safe-docx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/safe-docx",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Edit Word (.docx) and OpenDocument (.odt) files with tracked changes, redlines, and formatting preservation. Built for AI coding agents. MIT licensed, 100% local processing.",
   "mcpName": "io.github.UseJunior/safe-docx",
   "type": "module",
@@ -25,7 +25,7 @@
     "safedocx": "./bin/safe-docx.js"
   },
   "dependencies": {
-    "@usejunior/docx-mcp": "^0.10.0"
+    "@usejunior/docx-mcp": "^0.11.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/safe-docx/server.json
+++ b/packages/safe-docx/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.UseJunior/safe-docx",
   "title": "Safe Docx",
   "description": "AI-native surgical editing of Word .docx and OpenDocument .odt files with formatting preservation",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "websiteUrl": "https://usejunior.com/developer-tools/safe-docx",
   "icons": [
     {
@@ -18,7 +18,7 @@
     {
       "registryType": "npm",
       "identifier": "@usejunior/safe-docx",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "transport": {
         "type": "stdio"
       },

--- a/site/package.json
+++ b/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/safe-docx-site",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": true,
   "type": "module",
   "description": "Safe DOCX marketing and trust site (Eleventy)",


### PR DESCRIPTION
Lockstep bump 0.10.0 → 0.11.0 across all 13 version-bearing files, via `scripts/bump_version.mjs` (`--check` green; build green).

First minor since v0.10.0. Headlines:

- **From-scratch DOCX generation, phases 1–6** (#397, #402, #407, #414, #417, #422): DocumentSpec skeleton → styles/formatting → sections, headers/footers, PAGE/NUMPAGES fields → tables → numbering + legal recipes → drafting notes as anchored comments.
- **Native DOCX → ODT conversion** (#401, #406, #415): `convertDocxToOdt` + the `convert_to_odt` MCP tool, with richer style fidelity in phase 3.
- **Cross-implementation conformance adapter** (#394, M2 of #283): new `safe-docx-conformance-adapter` bin implementing the docx-platform-tests adapter protocol v1, plus the skip-gated suite self-check. Publishing this bin unblocks open-agreements/docx-platform-tests#3 (registry install for the suite's safe-docx column).
- **Footnote refs as document-view metadata** (#413).

Fixes worth shipping promptly:

- **`.bin`-symlink silent no-op** (#404): 0.10.0's *published* `docx-comparison`/`safe-docx-compare` bins exit 0 without doing anything when invoked through `node_modules/.bin` — every npm user of the CLIs is affected today. This release gets the fix into the registry.
- `server.json` description within the MCP registry's 100-char cap (#400).

After merge: `auto-tag-release.yml` pushes `v0.11.0`, which triggers `release.yml` (npm publish ×5 via OIDC, MCP registry, GitHub release + MCPB bundle, changelog-data PR). Manual fallback: `git tag v0.11.0 && git push origin v0.11.0`.