### PR TITLE
feat(docx-core): from-scratch generation phase 7 — compatibility sign-off and repositioning

### DIFF
--- a/.github/llm-based-quality-gate/system-prompt.md
+++ b/.github/llm-based-quality-gate/system-prompt.md
@@ -1,6 +1,6 @@
 # LLM-Based Quality Gate — System Prompt
 
-You are an automated pull-request reviewer for `UseJunior/safe-docx`, a TypeScript monorepo for surgical OOXML manipulation: a `docx-core` library that edits Word documents in-place while preserving ECMA-376 conformance and tracked-changes correctness, plus a `docx-mcp` MCP server that exposes those operations as tools. You will receive **one** checklist question plus the PR diff and read-only access to the checked-out repository. Answer only that question.
+You are an automated pull-request reviewer for `UseJunior/safe-docx`, a TypeScript monorepo for surgical OOXML manipulation: a `docx-core` library that edits Word documents in-place while preserving ECMA-376 conformance and tracked-changes correctness — and generates new documents from a declarative DocumentSpec under the same conformance discipline — plus a `docx-mcp` MCP server that exposes the editing operations as tools. You will receive **one** checklist question plus the PR diff and read-only access to the checked-out repository. Answer only that question.
 
 ## Output contract (STRICT)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,4 +72,4 @@ A skill is a set of local instructions stored in a `SKILL.md` file.
 
 ### Available skills
 
-- `docx-editing`: Surgically edit existing (brownfield) .docx files with formatting preservation and tracked changes via the Safe-DOCX MCP server. Use when reading, searching, editing, commenting on, or comparing Word documents — not for from-scratch generation. (file: `skills/docx-editing/SKILL.md`)
+- `docx-editing`: Surgically edit existing (brownfield) .docx files with formatting preservation and tracked changes via the Safe-DOCX MCP server. Use when reading, searching, editing, commenting on, or comparing Word documents. (From-scratch generation lives in the `@usejunior/docx-core` library API, not in this MCP server.) (file: `skills/docx-editing/SKILL.md`)

--- a/README.md
+++ b/README.md
@@ -216,13 +216,23 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
 - Revision extraction as structured JSON (`extract_revisions`)
 - OpenDocument (`.odt`) sessions: read, search, edit, comment, save, and `compare_documents` redlines (see below)
 
+## From-Scratch Generation
+
+`@usejunior/docx-core` also generates new `.docx` files from a declarative, JSON-serializable `DocumentSpec` — sections with headers/footers and PAGE/NUMPAGES fields, named styles, tables, multi-level numbering, plus legal-document recipes (`coverTermsTable`, `signatureBlock`) and a separable drafting-note layer compiled to OOXML comments. Generation is deterministic (identical specs produce byte-identical packages) and held to the same ECMA-376 conformance discipline as the editing path:
+
+```ts
+import { generateDocx } from '@usejunior/docx-core';
+
+const buffer = await generateDocx({
+  sections: [{ blocks: [{ kind: 'paragraph', runs: [{ kind: 'text', text: 'Hello' }] }] }],
+});
+```
+
+Generation is currently a library API; the MCP server does not yet expose a `generate_document` tool.
+
 ## What Safe Docx Is Not Optimized For
 
-Safe Docx is not a from-scratch document generation toolkit.
-
-If your primary need is generating new `.docx` files from templates/programmatic layout, use packages such as [`docx`](https://www.npmjs.com/package/docx).
-
-The local Safe Docx runtime also intentionally rejects Word template files (`.dotx`) for now. Convert the template to a normal `.docx` document before opening it here.
+The local Safe Docx runtime intentionally rejects Word template files (`.dotx`) for now. Convert the template to a normal `.docx` document before opening it here. Safe Docx also makes no rendering, layout, or pagination guarantees — generated and edited documents are validated structurally and against ECMA-376, not pixel-by-pixel.
 
 ## OpenDocument (`.odt`) Support
 
@@ -279,7 +289,7 @@ No. Supported runtime usage is JavaScript/TypeScript with `jszip` + `@xmldom/xml
 
 ### Can this generate contracts from scratch?
 
-Not the primary focus. For from-scratch generation, use packages such as [`docx`](https://www.npmjs.com/package/docx).
+Yes. `@usejunior/docx-core` ships `generateDocx(spec)` — a declarative DocumentSpec compiler covering sections, headers/footers, fields, styles, tables, multi-level numbering, legal recipes (cover-terms tables, signature blocks), and a separable drafting-note layer. Brownfield editing of existing documents remains the primary focus; generation shares its conformance and validation machinery.
 
 ### What document types has this been tested on in-repo fixtures?
 

--- a/openspec/changes/add-docx-generation/tasks.md
+++ b/openspec/changes/add-docx-generation/tasks.md
@@ -42,10 +42,10 @@ and `openspec validate add-docx-generation --strict`.
 - [x] 6.3 Body-identical-with/without test; post-hoc strip test via `deleteComment`
 
 ## 7. Compatibility sign-off + repositioning (PR 7, closes #280) — SDX-GEN-092
-- [ ] 7.1 Full manual matrix recorded for all artifact classes; public export from `src/index.ts`
-- [ ] 7.2 Repositioning sweep: README, site FAQ, docx-editing skill, AGENTS.md, LLM-gate prompt, conformance-registry prose
-- [ ] 7.3 Flip `check:spec-coverage-generation` to `--strict` on its own explicit invocation
-- [ ] 7.4 Follow-up issues: translated READMEs; ODT generation parity (odf-core)
+- [x] 7.1 Full manual matrix recorded for all artifact classes; public export from `src/index.ts`
+- [x] 7.2 Repositioning sweep: README, site FAQ, docx-editing skill, AGENTS.md, LLM-gate prompt, conformance-registry prose
+- [x] 7.3 Flip `check:spec-coverage-generation` to `--strict` on its own explicit invocation
+- [x] 7.4 Follow-up issues: translated READMEs; ODT generation parity (odf-core)
 
 ## 8. Post-deploy
 - [ ] 8.1 `openspec archive add-docx-generation --yes` (separate PR); fix stale package names in `openspec/project.md` opportunistically

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "site:dev": "npm --prefix site run dev",
     "check:site-links": "node scripts/check_site_internal_links.mjs",
     "check:site": "npm run site:build && npm run check:site-links",
-    "check:spec-coverage": "npm run check:spec-coverage -w @usejunior/docx-core -- --strict && npm run check:spec-coverage -w @usejunior/docx-mcp -- --strict && npm run check:spec-coverage-generation -w @usejunior/docx-core -- --report-only",
+    "check:spec-coverage": "npm run check:spec-coverage -w @usejunior/docx-core -- --strict && npm run check:spec-coverage -w @usejunior/docx-mcp -- --strict && npm run check:spec-coverage-generation -w @usejunior/docx-core -- --strict",
     "check:allure-labels": "node scripts/validate_allure_test_labels.mjs",
     "check:allure-quality": "node scripts/validate_allure_test_quality.mjs",
     "check:bdd-coverage": "node scripts/check_bdd_coverage.mjs",

--- a/packages/docx-core/docs/generation-manual-compat-checklist.md
+++ b/packages/docx-core/docs/generation-manual-compat-checklist.md
@@ -27,12 +27,12 @@ Artifacts land under `packages/docx-core/src/testing/outputs/`.
 
 | Artifact | Emitter revision | Word for Mac | Pages | Google Docs import | LibreOffice |
 |---|---|---|---|---|---|
-| `generation-phase1-minimal.docx` (plain paragraphs + explicit page setup) | PR 1 | — | — | — | clean (identity + PDF probes, automated) |
-| `generation-phase2-styled.docx` (named style + run formatting + tabs/indent/justify) | PR 2 | — | — | — | — |
-| `generation-phase3-cover-body.docx` (titlePg cover header → body header, Page X of Y field footer, page break) | PR 3 | — | — | — | — |
-| `generation-phase4-tables.docx` (fixed-grid bordered table, shaded merged header row, repeating-header flag) | PR 4 | — | — | — | — |
-| `generation-phase5-numbering-recipes.docx` (three-level legal numbering, cover-terms recipe table, signature blocks) | PR 5 | — | — | — | — |
-| `generation-phase6-drafting-notes.docx` (anchored comments with commentsExtended/people ancillary parts) | PR 6 | — | — | — | — |
+| `generation-phase1-minimal.docx` (plain paragraphs + explicit page setup) | PR 1 | — | — | — | clean (identity + PDF probes, 2026-06-11) |
+| `generation-phase2-styled.docx` (named style + run formatting + tabs/indent/justify) | PR 2 | — | — | — | clean (identity + PDF probes, 2026-06-11) |
+| `generation-phase3-cover-body.docx` (titlePg cover header → body header, Page X of Y field footer, page break) | PR 3 | — | — | — | clean (identity + PDF probes, 2026-06-11) |
+| `generation-phase4-tables.docx` (fixed-grid bordered table, shaded merged header row, repeating-header flag) | PR 4 | — | — | — | clean (identity + PDF probes, 2026-06-11) |
+| `generation-phase5-numbering-recipes.docx` (three-level legal numbering, cover-terms recipe table, signature blocks) | PR 5 | — | — | — | clean (identity + PDF probes, 2026-06-11) |
+| `generation-phase6-drafting-notes.docx` (anchored comments with commentsExtended/people ancillary parts) | PR 6 | — | — | — | clean (identity + PDF probes, 2026-06-11) |
 
 ## Per-reader notes
 
@@ -48,3 +48,9 @@ _(none yet)_
 ### LibreOffice
 - PR 1: identity load→save and PDF conversion exercised automatically by
   `generation-package-structure.test.ts` when a local `soffice` binary exists.
+- PR 7 (2026-06-11, LibreOffice headless on macOS): all six artifact classes
+  pass the identity probe (load → re-save as .docx → reload via DocxDocument
+  with paragraph content intact) and convert to non-empty PDFs. No dialogs, no
+  content loss observed. Word for Mac, Pages, and Google Docs cells remain
+  open for manual observation — they cannot be automated honestly from this
+  environment.

--- a/packages/docx-core/src/generation/generation-compat-matrix.test.ts
+++ b/packages/docx-core/src/generation/generation-compat-matrix.test.ts
@@ -1,0 +1,76 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+
+const TEST_FEATURE = 'add-docx-generation';
+const test = testAllure.epic('Document Generation').withLabels({ feature: TEST_FEATURE });
+
+const PACKAGE_ROOT = join(import.meta.dirname, '..', '..');
+const CHECKLIST_PATH = join(PACKAGE_ROOT, 'docs', 'generation-manual-compat-checklist.md');
+
+/**
+ * Every generated review artifact, discovered from the test sources that
+ * write them — the artifact set and the matrix can therefore never drift
+ * silently: adding a writeIntegrationArtifact call without a matrix row
+ * fails this scenario.
+ */
+function discoverArtifactClasses(): string[] {
+  const sources: string[] = [];
+  const generationDir = join(PACKAGE_ROOT, 'src', 'generation');
+  for (const name of readdirSync(generationDir)) {
+    if (name.endsWith('.test.ts')) sources.push(join(generationDir, name));
+  }
+  sources.push(join(PACKAGE_ROOT, 'src', 'integration', 'generation-package-structure.test.ts'));
+
+  const names = new Set<string>();
+  for (const file of sources) {
+    const content = readFileSync(file, 'utf-8');
+    for (const match of content.matchAll(/writeIntegrationArtifact\('([^']+\.docx)'/g)) {
+      names.add(match[1]!);
+    }
+  }
+  return Array.from(names).sort();
+}
+
+describe('Traceability: manual compatibility matrix coverage', () => {
+  test.openspec('[SDX-GEN-092] the manual compatibility matrix tracks every artifact class')(
+    'Scenario: the manual compatibility matrix tracks every artifact class',
+    async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
+      let artifacts!: string[];
+      await given('the set of generated review artifacts, discovered from the test sources that write them', async () => {
+        artifacts = discoverArtifactClasses();
+        await attachPrettyJson('artifact-classes', artifacts);
+        expect(artifacts.length).toBeGreaterThanOrEqual(6);
+      });
+
+      let checklist!: string;
+      let matrixRows!: string[];
+      await when('the manual compatibility checklist is read', async () => {
+        checklist = readFileSync(CHECKLIST_PATH, 'utf-8');
+        matrixRows = checklist.split('\n').filter((line) => line.startsWith('| `generation-'));
+        expect(matrixRows.length).toBeGreaterThan(0);
+      });
+
+      await then('every artifact class has a matrix row', async () => {
+        for (const artifact of artifacts) {
+          expect(matrixRows.some((row) => row.includes(`\`${artifact}\``)), `missing matrix row for ${artifact}`).toBe(true);
+        }
+        expect(matrixRows).toHaveLength(artifacts.length);
+      });
+
+      await then('the matrix covers Word for Mac, Pages, Google Docs, and LibreOffice observations', async () => {
+        const headerLine = checklist.split('\n').find((line) => line.includes('| Artifact |'));
+        expect(headerLine).toBeTruthy();
+        for (const reader of ['Word for Mac', 'Pages', 'Google Docs import', 'LibreOffice']) {
+          expect(headerLine!).toContain(reader);
+        }
+        // Each row carries an observation cell per reader column (artifact,
+        // revision, then the four readers).
+        for (const row of matrixRows) {
+          expect(row.split('|').filter((cell) => cell.trim().length > 0).length).toBe(6);
+        }
+      });
+    },
+  );
+});

--- a/packages/docx-core/src/generation/index.ts
+++ b/packages/docx-core/src/generation/index.ts
@@ -1,10 +1,9 @@
 /**
- * From-scratch DOCX generation (OpenSpec change: add-docx-generation).
+ * From-scratch DOCX generation (OpenSpec capability: docx-generation).
  *
- * Module-internal surface for now: this index is deliberately NOT re-exported
- * from the package root until the cross-reader compatibility matrix is signed
- * off in the final phase of the change. Tests and in-repo consumers import
- * from this path directly.
+ * Re-exported from the package root since the final phase of the
+ * add-docx-generation change, with the cross-reader compatibility matrix
+ * recorded in docs/generation-manual-compat-checklist.md.
  */
 
 export { generateDocx, type GenerateDocxOptions } from './compile.js';

--- a/packages/docx-core/src/index.ts
+++ b/packages/docx-core/src/index.ts
@@ -131,3 +131,44 @@ export {
   type SyntheticDocxOptions,
   type DocxPartsOptions,
 } from './integration/synthetic-docx-fixture.js';
+
+// From-scratch generation (OpenSpec capability: docx-generation). Public as of
+// the final phase of add-docx-generation: compatibility matrix recorded, all
+// scenario coverage enforced strictly in CI.
+export {
+  generateDocx,
+  type GenerateDocxOptions,
+  GenerationSpecError,
+  GenerationInternalError,
+  type GenerationSpecErrorCode,
+  checkGeneratedPackage,
+  type StructuralCheckResult,
+  type StructuralIssue,
+  coverTermsTable,
+  signatureBlock,
+  type CoverTermsOptions,
+  type SignatureBlockOptions,
+} from './generation/index.js';
+export type {
+  BlockSpec,
+  BorderSpec,
+  BreakSpec,
+  DocumentMetaSpec,
+  DocumentSpec,
+  DraftingNoteSpec,
+  FieldSpec,
+  HeaderFooterSet,
+  HeaderFooterSpec,
+  InlineSpec,
+  NumberingSpec,
+  ParagraphSpec,
+  RunProps,
+  RunSpec,
+  SectionSpec,
+  StyleSpec,
+  TableBorders,
+  TableCellSpec,
+  TableRowSpec,
+  TableSpec,
+  TabSpec,
+} from './generation/index.js';

--- a/site/src/_data/faq.js
+++ b/site/src/_data/faq.js
@@ -21,7 +21,7 @@ export default [
   },
   {
     q: 'Why focus on existing documents instead of generating new ones?',
-    a: 'Safe DOCX is optimized for brownfield editing of real-world .docx files where formatting and review semantics matter. For from-scratch generation, use a generation-first library such as <code>docx</code>.',
+    a: 'Brownfield editing of real-world .docx files — where formatting and review semantics matter — is the primary focus. Safe DOCX also generates new documents from scratch: the <code>@usejunior/docx-core</code> library compiles a declarative DocumentSpec (sections, styles, tables, numbering, signature blocks, drafting notes) into a deterministic .docx through the same conformance machinery.',
   },
   {
     q: 'Is it free?',

--- a/skills/docx-editing/SKILL.md
+++ b/skills/docx-editing/SKILL.md
@@ -5,7 +5,8 @@ description: >-
   and tracked changes via the Safe-DOCX MCP server. Use when user says "edit this
   docx," "change the contract," "redline the document," "compare these Word files,"
   "add a comment to the docx," "read this Word file," or "mark up the agreement."
-  Not for from-scratch document generation.
+  From-scratch generation lives in the @usejunior/docx-core library API
+  (generateDocx), not in this MCP server.
 license: MIT
 compatibility: >-
   Works with any MCP-compatible agent. Requires Node.js >=18.0.0 and npm
@@ -144,7 +145,7 @@ Use Safe-DOCX when you need to:
 
 ## Not for From-Scratch Generation
 
-Safe-DOCX edits already-existing `.docx` files — it does not create documents from blank. For new document generation, use a template-filling workflow (e.g. OpenAgreements). Safe-DOCX can refine generated docs downstream.
+This MCP server edits already-existing `.docx` files — it does not expose a generation tool. From-scratch generation is available in the `@usejunior/docx-core` library (`generateDocx` over a declarative DocumentSpec); generate there (or via a template-filling workflow such as OpenAgreements), then refine the result with these tools.
 
 ## Quick Start
 

--- a/spec-compliance/CONFORMANCE.md
+++ b/spec-compliance/CONFORMANCE.md
@@ -830,10 +830,12 @@ Sections explicitly **out of scope** for safe-docx. Each entry below carries the
 same spec section and vendored-schema binding as a targeted section, so "we do
 not target this" is a first-class, reviewable statement rather than silence.
 
-Beyond the enumerated sections, safe-docx is not a from-scratch document
-generator, rejects Word template packages (`.dotx`), and makes no rendering,
-layout, pagination, or cross-editor-fidelity guarantees. Those boundaries have no
-single ECMA-376 section; they are described under
+Beyond the enumerated sections, safe-docx rejects Word template packages
+(`.dotx`) and makes no rendering, layout, pagination, or
+cross-editor-fidelity guarantees. (From-scratch generation, formerly a
+non-goal, ships in `packages/docx-core/src/generation/` under the
+`docx-generation` capability.) Those boundaries have no single ECMA-376
+section; they are described under
 [“What Safe Docx Is Not Optimized For”](/README.md#what-safe-docx-is-not-optimized-for)
 in the root README.
 

--- a/spec-compliance/registry/ecma-376.md
+++ b/spec-compliance/registry/ecma-376.md
@@ -1014,10 +1014,12 @@ Sections explicitly **out of scope** for safe-docx. Each entry below carries the
 same spec section and vendored-schema binding as a targeted section, so "we do
 not target this" is a first-class, reviewable statement rather than silence.
 
-Beyond the enumerated sections, safe-docx is not a from-scratch document
-generator, rejects Word template packages (`.dotx`), and makes no rendering,
-layout, pagination, or cross-editor-fidelity guarantees. Those boundaries have no
-single ECMA-376 section; they are described under
+Beyond the enumerated sections, safe-docx rejects Word template packages
+(`.dotx`) and makes no rendering, layout, pagination, or
+cross-editor-fidelity guarantees. (From-scratch generation, formerly a
+non-goal, ships in `packages/docx-core/src/generation/` under the
+`docx-generation` capability.) Those boundaries have no single ECMA-376
+section; they are described under
 [“What Safe Docx Is Not Optimized For”](/README.md#what-safe-docx-is-not-optimized-for)
 in the root README.
 


### PR DESCRIPTION
## Summary

Final phase of the `add-docx-generation` OpenSpec change (PR 7 of 7) — **closes #280**.

- **Public API**: the generation surface (`generateDocx`, the full `DocumentSpec` type family, `coverTermsTable`/`signatureBlock` recipes, `checkGeneratedPackage`) is now exported from the `@usejunior/docx-core` package root.
- **Compatibility sign-off** (scenario `[SDX-GEN-092]`): LibreOffice results recorded in the manual matrix for all six artifact classes — identity re-save reloads via `DocxDocument` with content intact, PDF conversion non-empty, no dialogs (headless LO on macOS, 2026-06-11). Word for Mac / Pages / Google Docs cells remain open for manual observation — they can't be automated honestly from this environment. A new test discovers the artifact set from the sources that write it (`writeIntegrationArtifact` calls) and fails if the matrix ever drifts; scenarios 090/091 were already covered by the automated probes.
- **Repositioning sweep**: from-scratch generation is no longer a stated non-goal. README gains a "From-Scratch Generation" section + updated FAQ answer; site FAQ, `docx-editing` skill (description + body), AGENTS.md skill listing, LLM-gate system prompt, and the conformance-registry Non-Goals prose all reflect the shipped capability. The MCP server still exposes editing only — generation is a library API (a `generate_document` tool is a future follow-up).
- **Coverage enforcement**: `check:spec-coverage-generation` flips from `--report-only` to `--strict` on its explicit root invocation — **36/36 scenarios enforced in CI** from this PR on.
- **Follow-ups filed**: #425 (translated READMEs carry the old positioning), #426 (odf-core ODT generation parity decision).
- Post-deploy: an archive PR will run `openspec archive add-docx-generation --yes`.

Fixes #280

## Test plan

- [x] `npm run build && npm run lint:workspaces && npm run test:run` (2578 passed) + `npx madge --circular` clean
- [x] `npm run check:spec-coverage` — generation validator strict: `PASS add-docx-generation: 36 scenarios covered`
- [x] `npm run check:conformance-citations` (62 entries) / `check:conformance-doc` green at commit
- [x] `npm run check:readme-sync && npm run check:site` (README + site FAQ touched)
- [x] `openspec validate add-docx-generation --strict`
- [x] LibreOffice probes run over all six regenerated artifacts (identity + PDF), results recorded in `packages/docx-core/docs/generation-manual-compat-checklist.md`