### PR TITLE
fix(docx-core): write hyperlinkKey NUL separator as an escape; guard source against raw control bytes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,8 @@ jobs:
         run: npm run lint:workspaces
       - name: Check for import cycles
         run: npm run check:cycles
+      - name: Check for raw control bytes in source
+        run: npm run check:control-bytes
       - name: Check release isolation (ODF decoupling guard)
         run: npm run check:release-isolation
       - name: Test release-isolation guard

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "lint:workspaces": "npm run lint --workspaces --if-present && npm run lint:allure-imports",
     "lint:allure-imports": "eslint \"packages/**/*.test.ts\" --ignore-pattern \"packages/google-docs-core/**\" --ignore-pattern \"packages/odf-core/**\"",
     "check:cycles": "madge --circular --extensions ts packages/*/src",
+    "check:control-bytes": "node scripts/check_control_bytes.mjs",
     "test": "npm run test --workspaces --if-present",
     "test:run": "npm run test:run --workspaces --if-present",
     "test:baseline": "npm run test:baseline -w @usejunior/docx-core",

--- a/packages/docx-core/src/baselines/atomizer/documentReconstructor.ts
+++ b/packages/docx-core/src/baselines/atomizer/documentReconstructor.ts
@@ -934,7 +934,7 @@ function hyperlinkKey(el: Element): string {
     if (attr.name.startsWith('xmlns')) continue;
     parts.push(`${attr.name}=${attr.value}`);
   }
-  return parts.sort().join(' ');
+  return parts.sort().join('\u0000');
 }
 
 /**

--- a/scripts/check_control_bytes.mjs
+++ b/scripts/check_control_bytes.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+// Source-hygiene guard: no raw control bytes in tracked JS/TS source (#427).
+//
+// A raw control byte (anything below 0x20 other than tab/LF/CR) in a source
+// file makes grep-family tools classify the whole file as binary and return
+// EMPTY results with no warning — BSD grep and ripgrep both do this. In an
+// agent-operated repo that failure mode is dangerous: a search that silently
+// returns nothing reads as "symbol unused / pattern absent", which is the
+// precondition for duplicated helpers or unsafe deletions. The byte itself is
+// invisible in editors, so review never catches it (#377 shipped one).
+//
+// Legitimate uses of control characters in code (e.g. a NUL fingerprint
+// separator) belong in escape form — '\u0000' produces the identical runtime
+// string and keeps the file text.
+//
+// Pure text inspection — no network, no build. Wired into the workspace-lint
+// required check. Exits non-zero with an actionable message.
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+const SOURCE_EXTENSIONS = new Set([
+  '.ts', '.tsx', '.mts', '.cts',
+  '.js', '.jsx', '.mjs', '.cjs',
+]);
+
+const ALLOWED_CONTROL_BYTES = new Set([0x09, 0x0a, 0x0d]); // tab, LF, CR
+
+const trackedFiles = execFileSync('git', ['ls-files', '-z'], {
+  cwd: REPO_ROOT,
+  maxBuffer: 64 * 1024 * 1024,
+})
+  .toString('utf8')
+  .split('\0')
+  .filter((file) => SOURCE_EXTENSIONS.has(path.extname(file)));
+
+const findings = [];
+
+for (const file of trackedFiles) {
+  const absPath = path.join(REPO_ROOT, file);
+  let bytes;
+  try {
+    bytes = fs.readFileSync(absPath);
+  } catch {
+    continue; // tracked but deleted in working tree
+  }
+  let line = 1;
+  let col = 1;
+  for (const byte of bytes) {
+    if (byte < 0x20 && !ALLOWED_CONTROL_BYTES.has(byte)) {
+      findings.push({ file, line, col, byte });
+    }
+    if (byte === 0x0a) {
+      line++;
+      col = 1;
+    } else {
+      col++;
+    }
+  }
+}
+
+if (findings.length > 0) {
+  console.error('Raw control bytes found in tracked source files:\n');
+  for (const { file, line, col, byte } of findings) {
+    const hex = `0x${byte.toString(16).padStart(2, '0')}`;
+    const escape = `\\u${byte.toString(16).padStart(4, '0')}`;
+    console.error(`  ${file}:${line}:${col} — byte ${hex}; if intentional, write it as the '${escape}' escape instead`);
+  }
+  console.error(
+    `\n${findings.length} raw control byte(s). These make grep/ripgrep treat the file as binary` +
+      ' and silently return no matches — see #427.'
+  );
+  process.exit(1);
+}
+
+console.log(`check:control-bytes OK — ${trackedFiles.length} source files scanned, no raw control bytes.`);


### PR DESCRIPTION
## Problem

`hyperlinkKey()` in `packages/docx-core/src/baselines/atomizer/documentReconstructor.ts` joined attribute fingerprints with a **raw NUL byte (0x00)** embedded directly in the string literal (shipped invisibly in #377). The separator semantics are correct — NUL can't appear in XML attribute values — but the raw byte made grep-family tools classify the entire 1,776-line file as binary and **silently return zero matches**: `grep -rn hyperlinkKey` over the atomizer directory found nothing even though the function is defined and called there. `file` reported the `.ts` as `data`. For agents operating on this repo, a silent search false-negative reads as "symbol unused / pattern absent" — the precondition for duplicated helpers or unsafe deletions.

## Fix

- Write the separator as the six-character Unicode escape — behavior-identical (the escape parses to the same one-character string at JS parse time), and verified that `tsc` carries the escape form through to `dist`, so the compiled output is clean too.
- Add `scripts/check_control_bytes.mjs` + `check:control-bytes` (wired into the `workspace-lint` CI job): scans tracked JS/TS sources for raw bytes below 0x20 (other than tab/LF/CR) and fails with `file:line:col` plus the escape to use instead. Because the failure mode is invisible in editors and review, the one-character fix alone would just reset the clock until the next control byte lands.

## Verification

- Guard **red** against the pre-fix tree: exactly one finding repo-wide (`documentReconstructor.ts:937:29 — byte 0x00`), i.e. no false positives across 584 source files; **green** after the fix.
- `grep -c hyperlinkKey` on the file: 0 matches before → 5 after; `file` reports UTF-8 text again.
- docx-core suite: 1,436 passed / 2 expected-fail / 1 skipped. `lint:workspaces`, `check:cycles` clean.

Fixes: #427
Ref: #377