### PR TITLE
fix(docx-core): stabilize empty paragraph atom hashes

### DIFF
--- a/packages/docx-core/src/atomizer.test.ts
+++ b/packages/docx-core/src/atomizer.test.ts
@@ -10,6 +10,7 @@ import {
   createComparisonUnitAtom,
   atomizeTree,
   getAncestors,
+  EMPTY_PARAGRAPH_TAG,
 } from './atomizer.js';
 import { CorrelationStatus, OpcPart } from './core-types.js';
 import { assertDefined } from './testing/test-utils.js';
@@ -736,6 +737,202 @@ describe('atomizeTree', () => {
       expect(atom0.contentElement.tagName).toBe('w:t');
       expect(atom1.contentElement.tagName).toBe('w:br');
       expect(atom2.contentElement.tagName).toBe('w:t');
+    });
+  });
+});
+
+describe('empty paragraph context hashing', () => {
+  const mockPart: OpcPart = {
+    uri: 'word/document.xml',
+    contentType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml',
+  };
+
+  function textParagraph(text: string): Element {
+    return el('w:p', {}, [el('w:r', {}, [el('w:t', {}, undefined, text)])]);
+  }
+
+  function emptyParagraph(children: Element[] = []): Element {
+    return el('w:p', {}, children);
+  }
+
+  function emptyAtoms(document: Element): ReturnType<typeof atomizeTree>['atoms'] {
+    return atomizeTree(document, [], mockPart, {
+      atomizeParagraphLevelMarkers: true,
+    }).atoms.filter((atom) => atom.contentElement.tagName === EMPTY_PARAGRAPH_TAG);
+  }
+
+  test('keeps empty paragraph hashes stable when preceding run text is merged', async ({ given, when, then }: AllureBddContext) => {
+    let splitBody: Element;
+    let mergedBody: Element;
+    let splitEmptyHash: string;
+    let mergedEmptyHash: string;
+
+    await given('two bodies whose preceding paragraph has identical text with different w:t boundaries', () => {
+      splitBody = el('w:body', {}, [
+        el('w:p', {}, [
+          el('w:r', {}, [el('w:t', {}, undefined, 'of ')]),
+          el('w:r', {}, [el('w:t', {}, undefined, 'Disclosure.')]),
+        ]),
+        emptyParagraph(),
+      ]);
+      mergedBody = el('w:body', {}, [
+        el('w:p', {}, [el('w:r', {}, [el('w:t', {}, undefined, 'of Disclosure.')])]),
+        emptyParagraph(),
+      ]);
+    });
+
+    await when('both bodies are atomized', () => {
+      const splitEmpty = emptyAtoms(splitBody)[0];
+      const mergedEmpty = emptyAtoms(mergedBody)[0];
+      assertDefined(splitEmpty, 'split empty paragraph atom');
+      assertDefined(mergedEmpty, 'merged empty paragraph atom');
+      splitEmptyHash = splitEmpty.sha1Hash;
+      mergedEmptyHash = mergedEmpty.sha1Hash;
+    });
+
+    await then('the empty paragraph hashes match', () => {
+      expect(splitEmptyHash).toBe(mergedEmptyHash);
+    });
+  });
+
+  test('disambiguates consecutive empty paragraphs after the same content', async ({ given, when, then }: AllureBddContext) => {
+    let body: Element;
+    let empties: ReturnType<typeof atomizeTree>['atoms'];
+
+    await given('two consecutive empty paragraphs after a content paragraph', () => {
+      body = el('w:body', {}, [textParagraph('alpha'), emptyParagraph(), emptyParagraph()]);
+    });
+
+    await when('the body is atomized', () => {
+      empties = emptyAtoms(body);
+    });
+
+    await then('the empty paragraph hashes differ', () => {
+      expect(empties).toHaveLength(2);
+      expect(empties[0]?.sha1Hash).not.toBe(empties[1]?.sha1Hash);
+    });
+  });
+
+  test('pins shallow paragraph property hashing for empty paragraphs', async ({ given, when, then }: AllureBddContext) => {
+    let noPPrHash: string;
+    let barePPrHash: string;
+    let attributedPPrHash: string;
+    let childPPrHash: string;
+
+    await given('empty paragraphs with absent, bare, attributed, and child-bearing pPr', () => {});
+
+    await when('each empty paragraph is atomized after identical content', () => {
+      const hashFor = (paragraph: Element) => {
+        const atom = emptyAtoms(el('w:body', {}, [textParagraph('alpha'), paragraph]))[0];
+        assertDefined(atom, 'empty paragraph atom');
+        return atom.sha1Hash;
+      };
+
+      noPPrHash = hashFor(emptyParagraph());
+      barePPrHash = hashFor(emptyParagraph([el('w:pPr')]));
+      attributedPPrHash = hashFor(emptyParagraph([el('w:pPr', { 'w:rsidR': '00112233' })]));
+      childPPrHash = hashFor(emptyParagraph([el('w:pPr', {}, [el('w:rPr', {}, [el('w:b')])])]));
+    });
+
+    await then('pPr presence and attributes matter, while pPr children are ignored', () => {
+      expect(noPPrHash).not.toBe(barePPrHash);
+      expect(barePPrHash).not.toBe(attributedPPrHash);
+      expect(barePPrHash).toBe(childPPrHash);
+    });
+  });
+
+  test('keeps later empty paragraph hashes stable after an inserted empty paragraph elsewhere', async ({ given, when, then }: AllureBddContext) => {
+    let originalBody: Element;
+    let revisedBody: Element;
+    let originalLaterEmptyHash: string;
+    let revisedLaterEmptyHash: string;
+
+    await given('one body has a new empty paragraph before unchanged later content', () => {
+      originalBody = el('w:body', {}, [textParagraph('one'), textParagraph('two'), emptyParagraph()]);
+      revisedBody = el('w:body', {}, [
+        textParagraph('one'),
+        emptyParagraph(),
+        textParagraph('two'),
+        emptyParagraph(),
+      ]);
+    });
+
+    await when('both bodies are atomized', () => {
+      const originalEmpty = emptyAtoms(originalBody)[0];
+      const revisedEmpties = emptyAtoms(revisedBody);
+      assertDefined(originalEmpty, 'original later empty paragraph atom');
+      assertDefined(revisedEmpties[1], 'revised later empty paragraph atom');
+      originalLaterEmptyHash = originalEmpty.sha1Hash;
+      revisedLaterEmptyHash = revisedEmpties[1].sha1Hash;
+    });
+
+    await then('the later unchanged empty paragraph hashes match', () => {
+      expect(originalLaterEmptyHash).toBe(revisedLaterEmptyHash);
+    });
+  });
+
+  test('keeps non-text leaf context distinctions', async ({ given, when, then }: AllureBddContext) => {
+    let tabBody: Element;
+    let breakBody: Element;
+    let tabEmptyHash: string;
+    let breakEmptyHash: string;
+
+    await given('empty paragraphs following tab-only and break-only paragraphs', () => {
+      tabBody = el('w:body', {}, [el('w:p', {}, [el('w:r', {}, [el('w:tab')])]), emptyParagraph()]);
+      breakBody = el('w:body', {}, [el('w:p', {}, [el('w:r', {}, [el('w:br')])]), emptyParagraph()]);
+    });
+
+    await when('both bodies are atomized', () => {
+      const tabEmpty = emptyAtoms(tabBody)[0];
+      const breakEmpty = emptyAtoms(breakBody)[0];
+      assertDefined(tabEmpty, 'tab-context empty paragraph atom');
+      assertDefined(breakEmpty, 'break-context empty paragraph atom');
+      tabEmptyHash = tabEmpty.sha1Hash;
+      breakEmptyHash = breakEmpty.sha1Hash;
+    });
+
+    await then('the empty paragraph hashes differ', () => {
+      expect(tabEmptyHash).not.toBe(breakEmptyHash);
+    });
+  });
+
+  test('treats marker-only and proofErr-only paragraphs as content-transparent', async ({ given, when, then }: AllureBddContext) => {
+    let baselineBody: Element;
+    let bookmarkBody: Element;
+    let proofErrBody: Element;
+    let baselineHash: string;
+    let bookmarkHash: string;
+    let proofErrHash: string;
+
+    await given('empty paragraphs after content-transparent marker-only paragraphs', () => {
+      baselineBody = el('w:body', {}, [textParagraph('alpha'), emptyParagraph()]);
+      bookmarkBody = el('w:body', {}, [
+        textParagraph('alpha'),
+        el('w:p', {}, [el('w:bookmarkStart', { 'w:id': '7', 'w:name': 'marker' })]),
+        emptyParagraph(),
+      ]);
+      proofErrBody = el('w:body', {}, [
+        textParagraph('alpha'),
+        el('w:p', {}, [el('w:proofErr', { 'w:type': 'spellStart' })]),
+        emptyParagraph(),
+      ]);
+    });
+
+    await when('the bodies are atomized with paragraph-level markers enabled', () => {
+      const baselineEmpty = emptyAtoms(baselineBody)[0];
+      const bookmarkEmpty = emptyAtoms(bookmarkBody)[0];
+      const proofErrEmpty = emptyAtoms(proofErrBody)[0];
+      assertDefined(baselineEmpty, 'baseline empty paragraph atom');
+      assertDefined(bookmarkEmpty, 'bookmark-context empty paragraph atom');
+      assertDefined(proofErrEmpty, 'proofErr-context empty paragraph atom');
+      baselineHash = baselineEmpty.sha1Hash;
+      bookmarkHash = bookmarkEmpty.sha1Hash;
+      proofErrHash = proofErrEmpty.sha1Hash;
+    });
+
+    await then('the following empty paragraph hashes match the baseline', () => {
+      expect(bookmarkHash).toBe(baselineHash);
+      expect(proofErrHash).toBe(baselineHash);
     });
   });
 });

--- a/packages/docx-core/src/atomizer.ts
+++ b/packages/docx-core/src/atomizer.ts
@@ -404,8 +404,9 @@ function isEmptyParagraph(node: WmlElement): boolean {
  * These atoms represent empty paragraphs that have no text content,
  * ensuring they are preserved during document reconstruction.
  *
- * The hash includes the previous content hash to ensure empty paragraphs
- * only match if they're at the same logical position in the document.
+ * The hash includes a paragraph-level content signature for the previous
+ * content-bearing paragraph and a consecutive-empty index. Text fragment
+ * boundaries are ignored, while non-text leaves contribute stable tokens.
  *
  * @param paragraphElement - The w:p element
  * @param ancestors - Ancestor elements from root to parent
@@ -427,15 +428,10 @@ function createEmptyParagraphAtomWithContext(
   // Determine initial correlation status
   const correlationStatus = getStatusFromRevisionTracking(revTrackElement);
 
-  // Create a hash that uniquely identifies this empty paragraph
-  // Include:
-  // 1. pPr content for paragraph properties
-  // 2. lastContentHash for context (what content precedes this empty paragraph)
-  // 3. emptyParagraphCount for consecutive empty paragraphs with same context
   const pPr = findChildByTagName(paragraphElement, 'w:pPr');
   const pPrHash = pPr ? hashElement(pPr) : 'no-pPr';
   const contextHash = state.lastContentHash || 'document-start';
-  const hashContent = `empty-paragraph:${contextHash}:${state.emptyParagraphCount}:${pPrHash}`;
+  const hashContent = `empty-paragraph:${contextHash}:${state.consecutiveEmptyIndex}:${pPrHash}`;
 
   return {
     contentElement: virtualElement,
@@ -454,10 +450,41 @@ function createEmptyParagraphAtomWithContext(
  * State for tracking context during atomization.
  */
 interface AtomizationState {
-  /** Counter for empty paragraphs (ensures unique hashes) */
+  /** Total empty paragraph count for reporting. */
   emptyParagraphCount: number;
+  /** Index among consecutive empty paragraphs after the same content context. */
+  consecutiveEmptyIndex: number;
   /** Hash of the last non-empty content for context-aware matching */
   lastContentHash: string;
+}
+
+function updateParagraphContentContext(
+  node: WmlElement,
+  atoms: ComparisonUnitAtom[],
+  state: AtomizationState
+): void {
+  if (node.tagName !== 'w:p') {
+    return;
+  }
+
+  const contentAtoms = atoms.filter(
+    (atom) => !PARAGRAPH_LEVEL_TAGS.has(atom.contentElement.tagName)
+  );
+  if (contentAtoms.length === 0) {
+    return;
+  }
+
+  const signature = contentAtoms
+    .map((atom) => {
+      if (atom.contentElement.tagName === 'w:t') {
+        return getLeafText(atom.contentElement) ?? '';
+      }
+      return `\u0000${atom.contentElement.tagName}:${atom.sha1Hash}\u0000`;
+    })
+    .join('');
+
+  state.lastContentHash = sha1(`para-content:${signature}`);
+  state.consecutiveEmptyIndex = 0;
 }
 
 /**
@@ -479,8 +506,6 @@ function atomizeTreeInternal(
       part,
     });
     atoms.push(atom);
-    // Update last content hash for context-aware empty paragraph matching
-    state.lastContentHash = atom.sha1Hash;
   } else if (
     options.atomizeParagraphLevelMarkers &&
     isParagraphLevelLeaf(node) &&
@@ -498,15 +523,16 @@ function atomizeTreeInternal(
       part,
     });
     atoms.push(atom);
-    state.lastContentHash = atom.sha1Hash;
   } else if (isEmptyParagraph(node)) {
     // Create empty paragraph atom with context-aware hash
     atoms.push(createEmptyParagraphAtomWithContext(node, ancestors, part, state));
     state.emptyParagraphCount++;
+    state.consecutiveEmptyIndex++;
   } else {
     for (const child of childElements(node)) {
       atoms.push(...atomizeTreeInternal(child, [...ancestors, node], part, state, options));
     }
+    updateParagraphContentContext(node, atoms, state);
   }
 
   return atoms;
@@ -539,6 +565,7 @@ export function atomizeTree(
 
   const state: AtomizationState = {
     emptyParagraphCount: 0,
+    consecutiveEmptyIndex: 0,
     lastContentHash: '',
   };
   const rawAtoms = atomizeTreeInternal(node, ancestors, part, state, normalizedOptions);

--- a/packages/docx-core/src/integration/issue-409-regression.test.ts
+++ b/packages/docx-core/src/integration/issue-409-regression.test.ts
@@ -1,0 +1,179 @@
+import JSZip from 'jszip';
+import { describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { compareDocuments } from '../index.js';
+import { parseXml } from '../primitives/xml.js';
+import { buildDocxFromBodyXml } from '../testing/ooxml-fixtures.js';
+
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({ feature: 'Issue #409 Empty Paragraph Matching' });
+
+function paragraph(text: string): string {
+  return `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
+}
+
+function splitRunParagraph(): string {
+  return (
+    `<w:p>` +
+    `<w:r><w:t>of </w:t></w:r>` +
+    `<w:r><w:t>Disclosure.</w:t></w:r>` +
+    `</w:p>`
+  );
+}
+
+function mergedRunParagraph(): string {
+  return paragraph('of Disclosure.');
+}
+
+function emptyParagraph(): string {
+  return `<w:p/>`;
+}
+
+async function documentXml(buffer: Buffer): Promise<string> {
+  const zip = await JSZip.loadAsync(buffer);
+  const document = zip.file('word/document.xml');
+  if (!document) {
+    throw new Error('word/document.xml missing from DOCX');
+  }
+  return document.async('string');
+}
+
+function countTag(xml: string, tagName: 'w:ins' | 'w:del'): number {
+  return (xml.match(new RegExp(`<${tagName}\\b`, 'g')) ?? []).length;
+}
+
+function paragraphHasRevision(paragraphElement: Element): boolean {
+  return (
+    paragraphElement.getElementsByTagName('w:ins').length > 0 ||
+    paragraphElement.getElementsByTagName('w:del').length > 0
+  );
+}
+
+function paragraphVisibleText(paragraphElement: Element): string {
+  const pieces: string[] = [];
+  for (const tagName of ['w:t', 'w:delText']) {
+    const nodes = paragraphElement.getElementsByTagName(tagName);
+    for (let i = 0; i < nodes.length; i++) {
+      pieces.push(nodes[i]?.textContent ?? '');
+    }
+  }
+  return pieces.join('');
+}
+
+function emptyParagraphRevisionCount(xml: string): number {
+  const doc = parseXml(xml);
+  const paragraphs = doc.getElementsByTagName('w:p');
+  let count = 0;
+  for (let i = 0; i < paragraphs.length; i++) {
+    const p = paragraphs[i] as Element;
+    if (paragraphHasRevision(p) && paragraphVisibleText(p) === '') {
+      count++;
+    }
+  }
+  return count;
+}
+
+describe('Issue #409 — empty paragraph atom context', () => {
+  test('run-boundary churn near real edits does not emit empty-paragraph delete/insert pairs', async ({ given, when, then, and }: AllureBddContext) => {
+    let original: Buffer;
+    let revised: Buffer;
+    let result: Awaited<ReturnType<typeof compareDocuments>>;
+    let xml: string;
+
+    await given('a document where neighboring paragraph text is preserved but run boundaries change', async () => {
+      original = await buildDocxFromBodyXml(
+        splitRunParagraph() +
+          emptyParagraph() +
+          paragraph('alpha beta gamma') +
+          emptyParagraph() +
+          paragraph('tail omega'),
+      );
+      revised = await buildDocxFromBodyXml(
+        mergedRunParagraph() +
+          emptyParagraph() +
+          paragraph('alpha beta gamma') +
+          emptyParagraph() +
+          paragraph('tail theta'),
+      );
+    });
+
+    await when('comparing in atomizer rebuild mode', async () => {
+      result = await compareDocuments(original, revised, {
+        engine: 'atomizer',
+        reconstructionMode: 'rebuild',
+      });
+      xml = await documentXml(result.document);
+    });
+
+    await then('only the real text edit is emitted as a tracked change', () => {
+      expect(countTag(xml, 'w:ins')).toBe(1);
+      expect(countTag(xml, 'w:del')).toBe(1);
+      expect(result.stats.insertions).toBe(1);
+      expect(result.stats.deletions).toBe(1);
+    });
+
+    await and('no tracked revision region is attached to an empty paragraph', () => {
+      expect(emptyParagraphRevisionCount(xml)).toBe(0);
+    });
+  });
+
+  test('a newly inserted empty paragraph does not churn later identical empty paragraphs', async ({ given, when, then }: AllureBddContext) => {
+    let original: Buffer;
+    let revised: Buffer;
+    let result: Awaited<ReturnType<typeof compareDocuments>>;
+    let xml: string;
+
+    await given('a revised document with one genuine new empty paragraph before later unchanged content', async () => {
+      original = await buildDocxFromBodyXml(
+        paragraph('one') + paragraph('two') + emptyParagraph() + paragraph('tail'),
+      );
+      revised = await buildDocxFromBodyXml(
+        paragraph('one') + emptyParagraph() + paragraph('two') + emptyParagraph() + paragraph('tail'),
+      );
+    });
+
+    await when('comparing in atomizer rebuild mode', async () => {
+      result = await compareDocuments(original, revised, {
+        engine: 'atomizer',
+        reconstructionMode: 'rebuild',
+      });
+      xml = await documentXml(result.document);
+    });
+
+    await then('only one insertion region is emitted', () => {
+      expect(countTag(xml, 'w:ins')).toBe(1);
+      expect(countTag(xml, 'w:del')).toBe(0);
+      expect(result.stats.insertions).toBe(1);
+      expect(result.stats.deletions).toBe(0);
+    });
+  });
+
+  test('identical documents with empty paragraphs stay revision-free', async ({ given, when, then }: AllureBddContext) => {
+    let doc: Buffer;
+    let result: Awaited<ReturnType<typeof compareDocuments>>;
+    let xml: string;
+
+    await given('identical documents containing empty paragraphs', async () => {
+      doc = await buildDocxFromBodyXml(
+        mergedRunParagraph() + emptyParagraph() + paragraph('alpha beta gamma') + emptyParagraph(),
+      );
+    });
+
+    await when('comparing in atomizer rebuild mode', async () => {
+      result = await compareDocuments(doc, doc, {
+        engine: 'atomizer',
+        reconstructionMode: 'rebuild',
+      });
+      xml = await documentXml(result.document);
+    });
+
+    await then('no tracked changes are emitted', () => {
+      expect(countTag(xml, 'w:ins')).toBe(0);
+      expect(countTag(xml, 'w:del')).toBe(0);
+      expect(result.stats.insertions).toBe(0);
+      expect(result.stats.deletions).toBe(0);
+      expect(result.stats.modifications).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes phantom delete+insert pairs on byte-identical empty paragraphs in `docx-comparison` atomizer rebuild mode when nearby paragraph text is unchanged but run/text-node boundaries churn.

## Root Cause

Empty paragraph atoms were keyed from the previous raw leaf atom hash and a global empty-paragraph counter. Run merging changes the previous leaf hash even when paragraph text is identical, and a genuine empty-paragraph insertion earlier in a document re-keyed later unrelated empty paragraphs.

## Changes

- Use a paragraph-level content signature for the previous content-bearing paragraph.
- Concatenate `w:t` text so split/merged run boundaries do not affect empty paragraph context.
- Preserve non-text leaf distinctions with tag/hash tokens.
- Use a local `consecutiveEmptyIndex` for consecutive empty paragraph disambiguation.
- Keep paragraph-level marker/proofErr-only paragraphs content-transparent.
- Add focused atomizer unit coverage and a rebuild-mode issue #409 regression test.

## Validation

- `npm --workspace @usejunior/docx-core run test:run -- src/atomizer.test.ts src/integration/issue-409-regression.test.ts`
- `npm --workspace @usejunior/docx-core run lint`
- `npm run build`
- `npm run lint:workspaces`
- `npm run test:run` passed outside sandbox; sandboxed run was blocked by IPC/LibreOffice restrictions.
- `npm run check:spec-coverage`
- `npm run check:conformance-citations`
- `npm run check:conformance-doc`
- Real-document repro against `common-paper-mutual-nda/template.docx`: `{ "ins": 1, "del": 1, "emptyParagraphRevisionRegions": 0 }`.

## Peer Review

Dynamic agy peer review returned `SOUND` after reading affected files and rerunning the focused tests plus build/spec/conformance checks.

Fixes: #409