### PR TITLE
[codex] fix compare stats range counts

### DIFF
--- a/packages/docx-core/src/baselines/atomizer/pipeline-stats.test.ts
+++ b/packages/docx-core/src/baselines/atomizer/pipeline-stats.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
+import type { ComparisonUnitAtom } from '../../core-types.js';
+import { CorrelationStatus } from '../../core-types.js';
+import { el } from '../../testing/dom-test-helpers.js';
+import { computeAtomizerStats } from './pipeline.js';
+
+const test = testAllure.epic('Document Comparison').withLabels({
+  feature: 'Atomizer Stats',
+});
+
+function atom(
+  text: string,
+  correlationStatus: CorrelationStatus,
+  paragraphIndex?: number,
+  ancestorElements: Element[] = []
+): ComparisonUnitAtom {
+  return {
+    contentElement: el('w:t', {}, undefined, text),
+    ancestorElements,
+    ancestorUnids: [],
+    part: { uri: 'word/document.xml', contentType: 'text/xml' },
+    sha1Hash: `hash-${paragraphIndex}-${text}-${correlationStatus}`,
+    correlationStatus,
+    paragraphIndex,
+  };
+}
+
+describe('atomizer comparison stats', () => {
+  test('counts contiguous revision ranges separately from atom totals', async ({
+    given,
+    when,
+    then,
+    and,
+    attachPrettyJson,
+  }: AllureBddContext) => {
+    let atoms: ComparisonUnitAtom[];
+    let stats: ReturnType<typeof computeAtomizerStats>;
+
+    await given('one paragraph with a multi-atom replacement and a format-only span', () => {
+      atoms = [
+        atom('{', CorrelationStatus.Deleted, 0),
+        atom('mnda_term', CorrelationStatus.Deleted, 0),
+        atom('}', CorrelationStatus.Deleted, 0),
+        atom('two', CorrelationStatus.Inserted, 0),
+        atom(' ', CorrelationStatus.Inserted, 0),
+        atom('(2)', CorrelationStatus.Inserted, 0),
+        atom(' ', CorrelationStatus.Inserted, 0),
+        atom('years', CorrelationStatus.Inserted, 0),
+        atom('.', CorrelationStatus.Equal, 0),
+        atom('bold', CorrelationStatus.FormatChanged, 0),
+        atom(' text', CorrelationStatus.FormatChanged, 0),
+      ];
+    });
+
+    await when('stats are computed from the merged atom stream', async () => {
+      stats = computeAtomizerStats(atoms!);
+      await attachPrettyJson('Stats', stats);
+    });
+
+    await then('insertions and deletions count coalesced ranges, not word atoms', () => {
+      expect(stats.insertions).toBe(1);
+      expect(stats.deletions).toBe(1);
+      expect(stats.insertedRanges).toBe(1);
+      expect(stats.deletedRanges).toBe(1);
+      expect(stats.insertedAtoms).toBe(5);
+      expect(stats.deletedAtoms).toBe(3);
+    });
+
+    await and('modified paragraphs and format changes are reported separately', () => {
+      expect(stats.modifications).toBe(1);
+      expect(stats.modifiedParagraphs).toBe(1);
+      expect(stats.formatChanges).toBe(1);
+      expect(stats.formatChangeAtoms).toBe(2);
+    });
+  });
+
+  test('starts a new range after equal content or a paragraph boundary', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    let atoms: ComparisonUnitAtom[];
+    let stats: ReturnType<typeof computeAtomizerStats>;
+
+    await given('inserted atoms separated by equal content and by paragraph index', () => {
+      atoms = [
+        atom('alpha', CorrelationStatus.Inserted, 0),
+        atom('beta', CorrelationStatus.Inserted, 0),
+        atom('same', CorrelationStatus.Equal, 0),
+        atom('gamma', CorrelationStatus.Inserted, 0),
+        atom('delta', CorrelationStatus.Inserted, 1),
+      ];
+    });
+
+    await when('stats are computed from the merged atom stream', () => {
+      stats = computeAtomizerStats(atoms!);
+    });
+
+    await then('each contiguous inserted paragraph run is counted as a range', () => {
+      expect(stats.insertions).toBe(3);
+      expect(stats.insertedRanges).toBe(3);
+      expect(stats.insertedAtoms).toBe(4);
+    });
+  });
+
+  test('uses paragraph element identity when paragraph indices are absent', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    let atoms: ComparisonUnitAtom[];
+    let stats: ReturnType<typeof computeAtomizerStats>;
+
+    await given('two changed paragraphs at the same ancestor depth without paragraphIndex values', () => {
+      const firstParagraph = el('w:p');
+      const secondParagraph = el('w:p');
+      atoms = [
+        atom('old-a', CorrelationStatus.Deleted, undefined, [firstParagraph]),
+        atom('new-a', CorrelationStatus.Inserted, undefined, [firstParagraph]),
+        atom('old-b', CorrelationStatus.Deleted, undefined, [secondParagraph]),
+        atom('new-b', CorrelationStatus.Inserted, undefined, [secondParagraph]),
+      ];
+    });
+
+    await when('stats fall back to paragraph element identity', () => {
+      stats = computeAtomizerStats(atoms!);
+    });
+
+    await then('paragraphs remain distinct for range and modification counts', () => {
+      expect(stats.modifiedParagraphs).toBe(2);
+      expect(stats.deletions).toBe(2);
+      expect(stats.insertions).toBe(2);
+    });
+  });
+});

--- a/packages/docx-core/src/baselines/atomizer/pipeline.ts
+++ b/packages/docx-core/src/baselines/atomizer/pipeline.ts
@@ -1021,7 +1021,7 @@ export async function compareDocumentsAtomizer(
 
   // Step 13: Save result and compute stats
   const resultBuffer = await resultArchive.save();
-  const stats = computeStats(mergedAtoms);
+  const stats = computeAtomizerStats(mergedAtoms);
 
   return {
     document: resultBuffer,
@@ -1567,52 +1567,92 @@ async function mergePeople(
   await ensureOpcMetadata(resultArchive, PEOPLE_DESCRIPTOR);
 }
 
+interface ParagraphChangeFlags {
+  hasDeleted: boolean;
+  hasInserted: boolean;
+}
+
+const fallbackParagraphStatsKeys = new WeakMap<Element, string>();
+let nextFallbackParagraphStatsKey = 0;
+
+function paragraphStatsKey(atom: ComparisonUnitAtom): string | undefined {
+  if (atom.paragraphIndex !== undefined) {
+    return `${atom.part.uri}:${atom.paragraphIndex}`;
+  }
+
+  const pAncestor = atom.ancestorElements.find((a) => a.tagName === 'w:p');
+  if (!pAncestor) return undefined;
+
+  let key = fallbackParagraphStatsKeys.get(pAncestor);
+  if (!key) {
+    key = `${atom.part.uri}:paragraph-ref:${nextFallbackParagraphStatsKey++}`;
+    fallbackParagraphStatsKeys.set(pAncestor, key);
+  }
+  return key;
+}
+
 /**
  * Compute comparison statistics from merged atoms.
+ *
+ * Range counts are contiguous same-status runs in the merged atom stream, scoped
+ * to a paragraph. Atom counts remain available under explicit names for callers
+ * that need the old granular benchmark signal.
  */
-function computeStats(mergedAtoms: ComparisonUnitAtom[]): CompareStats {
+export function computeAtomizerStats(mergedAtoms: ComparisonUnitAtom[]): CompareStats {
   const reconstructionStats = computeReconstructionStats(mergedAtoms);
 
-  // Count unique paragraphs for modifications
-  // A modification is when we have both deleted and inserted atoms in the same paragraph
-  const modifiedParagraphs = new Set<string>();
-
-  let currentParagraph = '';
-  let hasDeleted = false;
-  let hasInserted = false;
+  let insertedRanges = 0;
+  let deletedRanges = 0;
+  let formatChanges = 0;
+  let previousRangeStatus: CorrelationStatus.Inserted | CorrelationStatus.Deleted | CorrelationStatus.FormatChanged | null = null;
+  let previousRangeParagraph: string | undefined;
+  const paragraphs = new Map<string, ParagraphChangeFlags>();
 
   for (const atom of mergedAtoms) {
-    // Detect paragraph boundaries
-    const pAncestor = atom.ancestorElements.find((a) => a.tagName === 'w:p');
-    const paragraphId = pAncestor
-      ? `${atom.part.uri}:${atom.ancestorElements.indexOf(pAncestor)}`
-      : '';
+    const paragraphKey = paragraphStatsKey(atom);
+    const status = atom.correlationStatus;
+    const rangeStatus =
+      status === CorrelationStatus.Inserted ||
+      status === CorrelationStatus.Deleted ||
+      status === CorrelationStatus.FormatChanged
+        ? status
+        : null;
 
-    if (paragraphId !== currentParagraph) {
-      // Check previous paragraph
-      if (currentParagraph && hasDeleted && hasInserted) {
-        modifiedParagraphs.add(currentParagraph);
+    if (rangeStatus) {
+      if (rangeStatus !== previousRangeStatus || paragraphKey !== previousRangeParagraph) {
+        if (rangeStatus === CorrelationStatus.Inserted) insertedRanges++;
+        if (rangeStatus === CorrelationStatus.Deleted) deletedRanges++;
+        if (rangeStatus === CorrelationStatus.FormatChanged) formatChanges++;
       }
-      currentParagraph = paragraphId;
-      hasDeleted = false;
-      hasInserted = false;
+      previousRangeStatus = rangeStatus;
+      previousRangeParagraph = paragraphKey;
+    } else {
+      previousRangeStatus = null;
+      previousRangeParagraph = undefined;
     }
 
-    if (atom.correlationStatus === CorrelationStatus.Deleted) {
-      hasDeleted = true;
-    } else if (atom.correlationStatus === CorrelationStatus.Inserted) {
-      hasInserted = true;
+    if (paragraphKey && (status === CorrelationStatus.Deleted || status === CorrelationStatus.Inserted)) {
+      const flags = paragraphs.get(paragraphKey) ?? { hasDeleted: false, hasInserted: false };
+      if (status === CorrelationStatus.Deleted) flags.hasDeleted = true;
+      if (status === CorrelationStatus.Inserted) flags.hasInserted = true;
+      paragraphs.set(paragraphKey, flags);
     }
   }
 
-  // Check last paragraph
-  if (currentParagraph && hasDeleted && hasInserted) {
-    modifiedParagraphs.add(currentParagraph);
-  }
+  const modifiedParagraphs = Array.from(paragraphs.values()).filter(
+    (flags) => flags.hasDeleted && flags.hasInserted
+  ).length;
 
   return {
-    insertions: reconstructionStats.insertions,
-    deletions: reconstructionStats.deletions,
-    modifications: modifiedParagraphs.size + reconstructionStats.formatChanges,
+    insertions: insertedRanges,
+    deletions: deletedRanges,
+    modifications: modifiedParagraphs,
+    insertedRanges,
+    deletedRanges,
+    insertedAtoms: reconstructionStats.insertions,
+    deletedAtoms: reconstructionStats.deletions,
+    modifiedParagraphs,
+    formatChanges,
+    formatChangeAtoms: reconstructionStats.formatChanges,
   };
 }

--- a/packages/docx-core/src/baselines/diffmatch/pipeline.ts
+++ b/packages/docx-core/src/baselines/diffmatch/pipeline.ts
@@ -16,7 +16,18 @@ import type { AlignmentResult } from '../../shared/ooxml/types.js';
 /** Local result type to avoid importing from index.ts (which no longer exports diffmatch). */
 interface BaselineBResult {
   document: Buffer;
-  stats: { insertions: number; deletions: number; modifications: number };
+  stats: {
+    insertions: number;
+    deletions: number;
+    modifications: number;
+    insertedRanges: number;
+    deletedRanges: number;
+    insertedAtoms: number;
+    deletedAtoms: number;
+    modifiedParagraphs: number;
+    formatChanges: number;
+    formatChangeAtoms: number;
+  };
   engine: 'diffmatch';
 }
 import { extractParagraphs } from './xmlParser.js';
@@ -137,5 +148,12 @@ function computeStats(
     insertions,
     deletions,
     modifications,
+    insertedRanges: insertions,
+    deletedRanges: deletions,
+    insertedAtoms: insertions,
+    deletedAtoms: deletions,
+    modifiedParagraphs: modifications,
+    formatChanges: 0,
+    formatChangeAtoms: 0,
   };
 }

--- a/packages/docx-core/src/baselines/wmlcomparer/DotnetCli.ts
+++ b/packages/docx-core/src/baselines/wmlcomparer/DotnetCli.ts
@@ -121,6 +121,13 @@ export async function compareWithDotnet(
       insertions: revisionCount,
       deletions: 0, // Would need to parse output to get this
       modifications: 0,
+      insertedRanges: revisionCount,
+      deletedRanges: 0,
+      insertedAtoms: revisionCount,
+      deletedAtoms: 0,
+      modifiedParagraphs: 0,
+      formatChanges: 0,
+      formatChangeAtoms: 0,
     };
 
     return {

--- a/packages/docx-core/src/cli/compare-two.ts
+++ b/packages/docx-core/src/cli/compare-two.ts
@@ -4,7 +4,9 @@ import { compareDocuments, type CompareOptions } from '../index.js';
 
 const USAGE =
   'Usage: docx-comparison <original.docx> <revised.docx> [output.docx] ' +
-  '[--engine atomizer|auto] [--mode inplace|rebuild] [--author "Name"] [--premerge-runs true|false]';
+  '[--engine atomizer|auto] [--mode inplace|rebuild] [--author "Name"] [--premerge-runs true|false]\n' +
+  'Stats: insertions/deletions count contiguous revision ranges; insertedAtoms/deletedAtoms count granular word atoms; ' +
+  'modifications counts modified paragraphs and formatChanges is separate.';
 
 export interface ParsedCompareCliArgs {
   originalPath: string;

--- a/packages/docx-core/src/compare-types.ts
+++ b/packages/docx-core/src/compare-types.ts
@@ -35,9 +35,35 @@ export interface CompareOptions {
 }
 
 export interface CompareStats {
+  /**
+   * Human-facing inserted change ranges. This counts contiguous inserted atom
+   * runs, matching the coalesced w:ins regions emitted in OOXML.
+   */
   insertions: number;
+  /**
+   * Human-facing deleted change ranges. This counts contiguous deleted atom
+   * runs, matching the coalesced w:del regions emitted in OOXML.
+   */
   deletions: number;
+  /**
+   * Paragraphs containing both inserted and deleted content. Format-only
+   * changes are reported separately in formatChanges.
+   */
   modifications: number;
+  /** Same value as insertions, exposed with explicit range-level semantics. */
+  insertedRanges: number;
+  /** Same value as deletions, exposed with explicit range-level semantics. */
+  deletedRanges: number;
+  /** Atom-level inserted units for granular/benchmark consumers. */
+  insertedAtoms: number;
+  /** Atom-level deleted units for granular/benchmark consumers. */
+  deletedAtoms: number;
+  /** Same value as modifications, exposed without overloading the term. */
+  modifiedParagraphs: number;
+  /** Contiguous format-only change ranges. */
+  formatChanges: number;
+  /** Atom-level format-only units for granular/benchmark consumers. */
+  formatChangeAtoms: number;
 }
 
 export type ReconstructionMode = 'rebuild' | 'inplace';

--- a/packages/docx-core/src/integration/nvca-coi-regression.test.ts
+++ b/packages/docx-core/src/integration/nvca-coi-regression.test.ts
@@ -68,10 +68,11 @@ describe('NVCA COI Regression', () => {
     });
 
     await and('stats are within expected ranges', async () => {
-      // Before fix: 949 insertions (rebuild fallback with phantom changes)
-      // After fix: ~202 insertions (correct inplace)
+      // Range counts stay bounded for the human-facing summary; atom totals
+      // retain the old granular signal for this large legal-document diff.
       expect(res.stats.insertions).toBeLessThan(500);
-      expect(res.stats.deletions).toBeGreaterThan(5000);
+      expect(res.stats.deletions).toBeLessThan(500);
+      expect(res.stats.deletedAtoms).toBeGreaterThan(5000);
     });
 
     await and('accept-all text matches revised document', async () => {

--- a/packages/docx-mcp/docs/tool-reference.generated.md
+++ b/packages/docx-mcp/docs/tool-reference.generated.md
@@ -273,7 +273,7 @@ Delete a comment and all its threaded replies from the document. Cascade-deletes
 
 ## `compare_documents`
 
-Compare two documents and produce a tracked-changes output document. Provide original_file_path + revised_file_path for standalone comparison, or file_path to compare session edits against the original. DOCX and ODF (.odt) support both modes; ODF compares at inline granularity (a modified paragraph is marked up in place — only the changed spans are struck or inserted).
+Compare two documents and produce a tracked-changes output document. Provide original_file_path + revised_file_path for standalone comparison, or file_path to compare session edits against the original. DOCX and ODF (.odt) support both modes. DOCX stats count insertions/deletions as contiguous ranges, expose atom totals as insertedAtoms/deletedAtoms, and report formatChanges separately from modifiedParagraphs. ODF compares at inline granularity (a modified paragraph is marked up in place — only the changed spans are struck or inserted).
 
 - readOnly: `true`
 - destructive: `false`

--- a/packages/docx-mcp/src/cli/help.ts
+++ b/packages/docx-mcp/src/cli/help.ts
@@ -44,6 +44,7 @@ export function renderTopLevelHelp(): string {
   lines.push('Built-in commands:');
   lines.push('  serve                                       Start the MCP server (default)');
   lines.push('  compare <original> <revised> [output]       Compare two DOCX files and write redline output');
+  lines.push('                                                Compare stats count revision ranges; atom totals use *Atoms fields');
   lines.push('  edit <file> [--replace ...] [-o output]     Batch edit a DOCX file');
   lines.push('  grep "pattern" <file> [files...]            Search DOCX files for text');
   lines.push('');

--- a/packages/docx-mcp/src/tool_catalog.ts
+++ b/packages/docx-mcp/src/tool_catalog.ts
@@ -329,7 +329,7 @@ export const SAFE_DOCX_TOOL_CATALOG = [
   {
     name: 'compare_documents',
     description:
-      'Compare two documents and produce a tracked-changes output document. Provide original_file_path + revised_file_path for standalone comparison, or file_path to compare session edits against the original. DOCX and ODF (.odt) support both modes; ODF compares at inline granularity (a modified paragraph is marked up in place — only the changed spans are struck or inserted).',
+      'Compare two documents and produce a tracked-changes output document. Provide original_file_path + revised_file_path for standalone comparison, or file_path to compare session edits against the original. DOCX and ODF (.odt) support both modes. DOCX stats count insertions/deletions as contiguous ranges, expose atom totals as insertedAtoms/deletedAtoms, and report formatChanges separately from modifiedParagraphs. ODF compares at inline granularity (a modified paragraph is marked up in place — only the changed spans are struck or inserted).',
     input: z.object({
       original_file_path: z.string().optional().describe('Path to the original DOCX or .odt file.'),
       revised_file_path: z.string().optional().describe('Path to the revised DOCX or .odt file.'),


### PR DESCRIPTION
## Summary

- Count DOCX compare `insertions`/`deletions` as contiguous revision ranges instead of word-level atoms.
- Keep explicit granular counters as `insertedAtoms` / `deletedAtoms` and split `modifiedParagraphs` from `formatChanges`.
- Document the stats semantics in CLI/MCP help surfaces and add focused atomizer stats regressions.

## Why

Issue #411 reports that replacing one token with a phrase can produce misleading stats such as `insertions: 7`, `deletions: 3`, `modifications: 2` even though the OOXML revision markup is already correctly coalesced. The old reporting path counted per-atom statuses and added modified paragraphs to format-only changes. This PR makes the machine-readable summary line up with the coalesced revision regions while retaining atom totals for benchmark consumers.

## Peer Review

- Ran `agy --print` peer review via CLI.
- First pass found a blocker in the missing-`paragraphIndex` fallback key; fixed it by using paragraph element identity and added a regression for distinct same-depth paragraphs without indices.
- Second pass was attempted after the fix but timed out waiting for an `agy` response.

## Validation

- `npm run test:run -w @usejunior/docx-core -- src/baselines/atomizer/pipeline-stats.test.ts src/cli/compare-two.test.ts`
- `npm run build -w @usejunior/docx-mcp`
- `npm run test:run -w @usejunior/docx-mcp -- src/cli/index.test.ts`
- `npm run lint -w @usejunior/docx-mcp`
- `git diff --check HEAD`

Fixes: #411
