### PR TITLE
docs: translated README generation parity + ODT generation boundary proposal

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -1,4 +1,4 @@
-# Word-Dokumente (.docx) mit Programmier-Agenten via MCP bearbeiten
+# Word-Dokumente (.docx) mit Programmier-Agenten via MCP bearbeiten — mit OpenDocument- (.odt-) Unterstützung
 
 <!-- SYNC:badges BEGIN -->
 [![CI](https://github.com/usejunior/safe-docx/actions/workflows/ci.yml/badge.svg)](https://github.com/usejunior/safe-docx/actions/workflows/ci.yml)
@@ -77,7 +77,7 @@ flowchart LR
 ```
 <!-- SYNC:architecture-diagram END -->
 
-Safe Docx ist ein Open-Source-TypeScript-Stack für die chirurgische Bearbeitung bestehender Microsoft Word `.docx`-Dateien. Es wurde für Workflows entwickelt, in denen ein Agent Änderungen vorschlägt und ein Mensch weiterhin zuverlässige, formatierungserhaltende Dokumentenbearbeitungen benötigt.
+Safe Docx ist ein Open-Source-TypeScript-Stack für die chirurgische Bearbeitung bestehender Microsoft Word `.docx`-Dateien — und, über dieselbe Tool-Oberfläche, OpenDocument- `.odt`-Dateien. Es wurde für Workflows entwickelt, in denen ein Agent Änderungen vorschlägt und ein Mensch weiterhin zuverlässige, formatierungserhaltende Dokumentenbearbeitungen benötigt.
 
 Wenn du Verträge mit KI prüfst, ist der langsamste Schritt oft das Anwenden akzeptierter Empfehlungen in Word. Safe Docx verwandelt das in deterministische Tool-Aufrufe.
 
@@ -210,11 +210,23 @@ Füge zu `~/Library/Application Support/Claude/claude_desktop_config.json` (macO
 - Nachverfolgte Ausgaben zur Überprüfung (`download`, `compare_documents`)
 - Revisionsextraktion als strukturiertes JSON (`extract_revisions`)
 
+## Erstellung von Grund auf
+
+`@usejunior/docx-core` erzeugt auch neue `.docx`-Dateien aus einer deklarativen, JSON-serialisierbaren `DocumentSpec`: Abschnitte mit Kopf-/Fußzeilen und PAGE-/NUMPAGES-Feldern, benannte Stile, Tabellen, mehrstufige Nummerierung, juristische Dokumentrezepte (`coverTermsTable`, `signatureBlock`) und eine trennbare Entwurfsnotiz-Ebene, die zu OOXML-Kommentaren kompiliert wird. Die Erzeugung ist deterministisch (identische Specs erzeugen byte-identische Pakete) und unterliegt derselben ECMA-376-Konformitätsdisziplin wie der Bearbeitungspfad:
+
+```ts
+import { generateDocx } from '@usejunior/docx-core';
+
+const buffer = await generateDocx({
+  sections: [{ blocks: [{ kind: 'paragraph', runs: [{ kind: 'text', text: 'Hello' }] }] }],
+});
+```
+
+Die Erzeugung ist derzeit eine Library-API; der MCP-Server stellt noch kein `generate_document`-Tool bereit.
+
 ## Wofür Safe Docx nicht optimiert ist
 
-Safe Docx ist kein Toolkit zur Dokumentenerstellung von Grund auf.
-
-Wenn dein Hauptbedarf die Erstellung neuer `.docx`-Dateien aus Vorlagen oder programmatischem Layout ist, verwende Pakete wie [`docx`](https://www.npmjs.com/package/docx).
+Die lokale Safe-Docx-Laufzeit weist Word-Vorlagendateien (`.dotx`) derzeit bewusst zurück. Wandle die Vorlage in ein normales `.docx`-Dokument um, bevor du sie hier öffnest. Safe Docx macht außerdem keine Rendering-, Layout- oder Paginierungsgarantien — erzeugte und bearbeitete Dokumente werden strukturell und gegen ECMA-376 validiert, nicht pixelgenau.
 
 ## Dokumentenfamilien
 
@@ -236,6 +248,7 @@ Wenn dein Hauptbedarf die Erstellung neuer `.docx`-Dateien aus Vorlagen oder pro
 ## Pakete
 
 - `@usejunior/docx-core`: Primitive und Vergleichs-Engine für bestehende `.docx`-Dokumente
+- `@usejunior/odf-core`: OpenDocument- (`.odt`) Primitive und Vergleichs-Engine mit Änderungsnachverfolgung
 - `@usejunior/docx-mcp`: MCP-Server-Implementierung und Tool-Oberfläche
 - `@usejunior/safe-docx`: Kanonischer Installationsname für Endbenutzer (`npx -y @usejunior/safe-docx`)
 - `@usejunior/safedocx-mcpb`: Privater MCP-Bundle-Wrapper
@@ -263,7 +276,7 @@ Nein. Die unterstützte Laufzeitnutzung ist JavaScript/TypeScript mit `jszip` + 
 
 ### Kann man damit Verträge von Grund auf erstellen?
 
-Nicht der Hauptfokus. Für die Erstellung von Grund auf verwende Pakete wie [`docx`](https://www.npmjs.com/package/docx).
+Ja. `@usejunior/docx-core` liefert `generateDocx(spec)` — einen deklarativen DocumentSpec-Compiler für Abschnitte, Kopf-/Fußzeilen, Felder, Stile, Tabellen, mehrstufige Nummerierung, juristische Rezepte (Cover-Terms-Tabellen, Signaturblöcke) und eine trennbare Entwurfsnotiz-Ebene. Brownfield-Bearbeitung bestehender Dokumente bleibt der Hauptfokus; die Erzeugung nutzt dieselbe Konformitäts- und Validierungsinfrastruktur.
 
 ### Welche Dokumenttypen wurden in den Repository-Fixtures getestet?
 

--- a/README.es.md
+++ b/README.es.md
@@ -1,4 +1,4 @@
-# Edita documentos de Word (.docx) con agentes de programación vía MCP
+# Edita documentos de Word (.docx) con agentes de programación vía MCP — con soporte para OpenDocument (.odt)
 
 <!-- SYNC:badges BEGIN -->
 [![CI](https://github.com/usejunior/safe-docx/actions/workflows/ci.yml/badge.svg)](https://github.com/usejunior/safe-docx/actions/workflows/ci.yml)
@@ -77,7 +77,7 @@ flowchart LR
 ```
 <!-- SYNC:architecture-diagram END -->
 
-Safe Docx es un stack de TypeScript de código abierto para la edición quirúrgica de archivos Microsoft Word `.docx` existentes. Está diseñado para flujos de trabajo donde un agente propone cambios y un humano aún necesita ediciones de documentos confiables que preserven el formato.
+Safe Docx es un stack de TypeScript de código abierto para la edición quirúrgica de archivos Microsoft Word `.docx` existentes y, mediante la misma superficie de herramientas, archivos OpenDocument `.odt`. Está diseñado para flujos de trabajo donde un agente propone cambios y un humano aún necesita ediciones de documentos confiables que preserven el formato.
 
 Si revisas contratos con IA, el paso más lento suele ser aplicar las recomendaciones aceptadas en Word. Safe Docx convierte eso en llamadas de herramientas deterministas.
 
@@ -209,11 +209,23 @@ Añade a `~/Library/Application Support/Claude/claude_desktop_config.json` (macO
 - Salidas con control de cambios para revisión (`download`, `compare_documents`)
 - Extracción de revisiones como JSON estructurado (`extract_revisions`)
 
+## Generación desde cero
+
+`@usejunior/docx-core` también genera nuevos archivos `.docx` desde una `DocumentSpec` declarativa y serializable como JSON: secciones con encabezados/pies de página y campos PAGE/NUMPAGES, estilos con nombre, tablas, numeración multinivel, recetas para documentos legales (`coverTermsTable`, `signatureBlock`) y una capa separable de notas de redacción compilada como comentarios OOXML. La generación es determinista (especificaciones idénticas producen paquetes byte-idénticos) y sigue la misma disciplina de conformidad ECMA-376 que la ruta de edición:
+
+```ts
+import { generateDocx } from '@usejunior/docx-core';
+
+const buffer = await generateDocx({
+  sections: [{ blocks: [{ kind: 'paragraph', runs: [{ kind: 'text', text: 'Hello' }] }] }],
+});
+```
+
+La generación es actualmente una API de biblioteca; el servidor MCP aún no expone una herramienta `generate_document`.
+
 ## Para qué no está optimizado Safe Docx
 
-Safe Docx no es un toolkit de generación de documentos desde cero.
-
-Si tu necesidad principal es generar nuevos archivos `.docx` desde plantillas o diseño programático, usa paquetes como [`docx`](https://www.npmjs.com/package/docx).
+El runtime local de Safe Docx rechaza intencionalmente por ahora los archivos de plantilla de Word (`.dotx`). Convierte la plantilla en un documento `.docx` normal antes de abrirla aquí. Safe Docx tampoco ofrece garantías de renderizado, diseño o paginación: los documentos generados y editados se validan estructuralmente y contra ECMA-376, no píxel por píxel.
 
 ## Familias de documentos
 
@@ -235,6 +247,7 @@ Si tu necesidad principal es generar nuevos archivos `.docx` desde plantillas o 
 ## Paquetes
 
 - `@usejunior/docx-core`: primitivas y motor de comparación para documentos `.docx` existentes
+- `@usejunior/odf-core`: primitivas OpenDocument (`.odt`) y motor de comparación con control de cambios
 - `@usejunior/docx-mcp`: implementación del servidor MCP y superficie de herramientas
 - `@usejunior/safe-docx`: nombre canónico de instalación para el usuario final (`npx -y @usejunior/safe-docx`)
 - `@usejunior/safedocx-mcpb`: wrapper privado de bundle MCP
@@ -262,7 +275,7 @@ No. El uso soportado en tiempo de ejecución es JavaScript/TypeScript con `jszip
 
 ### ¿Puede generar contratos desde cero?
 
-No es el enfoque principal. Para generación desde cero, usa paquetes como [`docx`](https://www.npmjs.com/package/docx).
+Sí. `@usejunior/docx-core` incluye `generateDocx(spec)`: un compilador declarativo de DocumentSpec que cubre secciones, encabezados/pies de página, campos, estilos, tablas, numeración multinivel, recetas legales (tablas de términos de portada, bloques de firma) y una capa separable de notas de redacción. La edición brownfield de documentos existentes sigue siendo el enfoque principal; la generación comparte la maquinaria de conformidad y validación.
 
 ### ¿Qué tipos de documentos se han probado en los fixtures del repositorio?
 

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -1,4 +1,4 @@
-# Edite documentos do Word (.docx) com agentes de programação via MCP
+# Edite documentos do Word (.docx) com agentes de programação via MCP — com suporte a OpenDocument (.odt)
 
 <!-- SYNC:badges BEGIN -->
 [![CI](https://github.com/usejunior/safe-docx/actions/workflows/ci.yml/badge.svg)](https://github.com/usejunior/safe-docx/actions/workflows/ci.yml)
@@ -77,7 +77,7 @@ flowchart LR
 ```
 <!-- SYNC:architecture-diagram END -->
 
-Safe Docx é um stack TypeScript de código aberto para edição cirúrgica de arquivos Microsoft Word `.docx` existentes. Foi construído para fluxos de trabalho onde um agente propõe alterações e um humano ainda precisa de edições de documentos confiáveis que preservem a formatação.
+Safe Docx é um stack TypeScript de código aberto para edição cirúrgica de arquivos Microsoft Word `.docx` existentes e, pela mesma superfície de ferramentas, arquivos OpenDocument `.odt`. Foi construído para fluxos de trabalho onde um agente propõe alterações e um humano ainda precisa de edições de documentos confiáveis que preservem a formatação.
 
 Se você revisa contratos com IA, a etapa mais lenta geralmente é aplicar as recomendações aceitas no Word. Safe Docx transforma isso em chamadas de ferramentas determinísticas.
 
@@ -209,11 +209,23 @@ Adicione a `~/Library/Application Support/Claude/claude_desktop_config.json` (ma
 - Saídas com controle de alterações para revisão (`download`, `compare_documents`)
 - Extração de revisões como JSON estruturado (`extract_revisions`)
 
+## Geração do zero
+
+`@usejunior/docx-core` também gera novos arquivos `.docx` a partir de uma `DocumentSpec` declarativa e serializável como JSON: seções com cabeçalhos/rodapés e campos PAGE/NUMPAGES, estilos nomeados, tabelas, numeração multinível, receitas de documentos jurídicos (`coverTermsTable`, `signatureBlock`) e uma camada separável de notas de minuta compilada para comentários OOXML. A geração é determinística (specs idênticas produzem pacotes byte-idênticos) e segue a mesma disciplina de conformidade ECMA-376 do caminho de edição:
+
+```ts
+import { generateDocx } from '@usejunior/docx-core';
+
+const buffer = await generateDocx({
+  sections: [{ blocks: [{ kind: 'paragraph', runs: [{ kind: 'text', text: 'Hello' }] }] }],
+});
+```
+
+A geração atualmente é uma API de biblioteca; o servidor MCP ainda não expõe uma ferramenta `generate_document`.
+
 ## Para que o Safe Docx não é otimizado
 
-Safe Docx não é um toolkit de geração de documentos do zero.
-
-Se sua necessidade principal é gerar novos arquivos `.docx` a partir de templates ou layout programático, use pacotes como [`docx`](https://www.npmjs.com/package/docx).
+O runtime local do Safe Docx rejeita intencionalmente arquivos de template do Word (`.dotx`) por enquanto. Converta o template em um documento `.docx` normal antes de abri-lo aqui. O Safe Docx também não oferece garantias de renderização, layout ou paginação — documentos gerados e editados são validados estruturalmente e contra a ECMA-376, não pixel a pixel.
 
 ## Famílias de documentos
 
@@ -235,6 +247,7 @@ Se sua necessidade principal é gerar novos arquivos `.docx` a partir de templat
 ## Pacotes
 
 - `@usejunior/docx-core`: primitivas e motor de comparação para documentos `.docx` existentes
+- `@usejunior/odf-core`: primitivas OpenDocument (`.odt`) e motor de comparação com controle de alterações
 - `@usejunior/docx-mcp`: implementação do servidor MCP e superfície de ferramentas
 - `@usejunior/safe-docx`: nome canônico de instalação para o usuário final (`npx -y @usejunior/safe-docx`)
 - `@usejunior/safedocx-mcpb`: wrapper privado de bundle MCP
@@ -262,7 +275,7 @@ Não. O uso suportado em tempo de execução é JavaScript/TypeScript com `jszip
 
 ### Pode gerar contratos do zero?
 
-Não é o foco principal. Para geração do zero, use pacotes como [`docx`](https://www.npmjs.com/package/docx).
+Sim. `@usejunior/docx-core` inclui `generateDocx(spec)`: um compilador declarativo de DocumentSpec que cobre seções, cabeçalhos/rodapés, campos, estilos, tabelas, numeração multinível, receitas jurídicas (tabelas de termos de capa, blocos de assinatura) e uma camada separável de notas de minuta. A edição brownfield de documentos existentes continua sendo o foco principal; a geração compartilha a infraestrutura de conformidade e validação.
 
 ### Quais tipos de documentos foram testados nos fixtures do repositório?
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,4 +1,4 @@
-# 使用编程代理通过 MCP 编辑 Word 文档 (.docx)
+# 使用编程代理通过 MCP 编辑 Word 文档 (.docx) — 支持 OpenDocument (.odt)
 
 <!-- SYNC:badges BEGIN -->
 [![CI](https://github.com/usejunior/safe-docx/actions/workflows/ci.yml/badge.svg)](https://github.com/usejunior/safe-docx/actions/workflows/ci.yml)
@@ -77,7 +77,7 @@ flowchart LR
 ```
 <!-- SYNC:architecture-diagram END -->
 
-Safe Docx 是一套开源 TypeScript 技术栈，用于对现有 Microsoft Word `.docx` 文件进行精确编辑。它专为代理提出更改建议、人工仍需可靠且保留格式的文档编辑场景而构建。
+Safe Docx 是一套开源 TypeScript 技术栈，用于对现有 Microsoft Word `.docx` 文件进行精确编辑，并通过同一套工具表面支持 OpenDocument `.odt` 文件。它专为代理提出更改建议、人工仍需可靠且保留格式的文档编辑场景而构建。
 
 如果你使用 AI 审阅合同，最慢的步骤往往是在 Word 中应用已接受的建议。Safe Docx 将其转化为确定性工具调用。
 
@@ -207,11 +207,23 @@ claude mcp add safe-docx -- npx -y @usejunior/safe-docx
 - 带修订标记的输出供审阅（`download`、`compare_documents`）
 - 将修订提取为结构化 JSON（`extract_revisions`）
 
+## 从零开始生成
+
+`@usejunior/docx-core` 也可以从声明式、JSON 可序列化的 `DocumentSpec` 生成新的 `.docx` 文件：带页眉/页脚和 PAGE/NUMPAGES 字段的节、命名样式、表格、多级编号、法律文档配方（`coverTermsTable`、`signatureBlock`），以及可分离的起草说明层（编译为 OOXML 批注）。生成是确定性的（相同 spec 产生字节相同的包），并遵循与编辑路径相同的 ECMA-376 合规纪律：
+
+```ts
+import { generateDocx } from '@usejunior/docx-core';
+
+const buffer = await generateDocx({
+  sections: [{ blocks: [{ kind: 'paragraph', runs: [{ kind: 'text', text: 'Hello' }] }] }],
+});
+```
+
+生成能力目前是库 API；MCP 服务器尚未暴露 `generate_document` 工具。
+
 ## Safe Docx 不擅长什么
 
-Safe Docx 不是从零开始的文档生成工具包。
-
-如果你的主要需求是从模板或程序化布局生成新 `.docx` 文件，请使用 [`docx`](https://www.npmjs.com/package/docx) 等包。
+本地 Safe Docx 运行时目前会有意拒绝 Word 模板文件（`.dotx`）。请先将模板转换为普通 `.docx` 文档再在这里打开。Safe Docx 也不保证渲染、版式或分页效果；生成和编辑后的文档会按结构和 ECMA-376 验证，而不是逐像素验证。
 
 ## 文档类别
 
@@ -233,6 +245,7 @@ Safe Docx 不是从零开始的文档生成工具包。
 ## 包
 
 - `@usejunior/docx-core`：现有 `.docx` 文档的原语和比较引擎
+- `@usejunior/odf-core`：OpenDocument (`.odt`) 原语和带修订比较引擎
 - `@usejunior/docx-mcp`：MCP 服务器实现和工具表面
 - `@usejunior/safe-docx`：规范的终端用户安装名（`npx -y @usejunior/safe-docx`）
 - `@usejunior/safedocx-mcpb`：私有 MCP 打包封装
@@ -260,7 +273,7 @@ Safe Docx 不是从零开始的文档生成工具包。
 
 ### 能从零开始生成合同吗？
 
-这不是主要关注点。从零生成请使用 [`docx`](https://www.npmjs.com/package/docx) 等包。
+可以。`@usejunior/docx-core` 提供 `generateDocx(spec)`：一个声明式 DocumentSpec 编译器，覆盖节、页眉/页脚、字段、样式、表格、多级编号、法律配方（封面条款表、签名块）以及可分离的起草说明层。对现有文档的棕地编辑仍是主要关注点；生成能力共享同一套合规和验证机制。
 
 ### 本仓库测试文件中测试了哪些文档类型？
 

--- a/openspec/changes/document-odt-generation-boundary/design.md
+++ b/openspec/changes/document-odt-generation-boundary/design.md
@@ -1,0 +1,22 @@
+## Context
+`@usejunior/docx-core` owns the declarative `DocumentSpec` grammar and compiles it to ECMA-376 DOCX packages. `@usejunior/odf-core` owns OpenDocument archive/session primitives, tracked-changes comparison, and native DOCX-to-ODT conversion. The two packages overlap at the document-family level, but they do not currently share a format-neutral intermediate representation that can emit both OOXML and ODF with equivalent fidelity.
+
+## Decision
+The near-term product boundary is conversion-first ODT generation:
+
+- Users who need a generated ODT should call `generateDocx(spec)` and then `convertDocxToOdt(docx)`.
+- `@usejunior/odf-core` should document this as an intentional boundary, not as a missing accidental feature.
+- Native `generateOdt(spec)` remains a candidate future capability, but it is not silently promised by the current `DocumentSpec` compiler.
+
+## Alternatives Considered
+
+### Compile the same DocumentSpec directly to ODF
+This gives the cleanest user-facing symmetry, but it is materially larger than documentation: it needs ODF style/list/table/header/footer mapping, package validation, deterministic output rules, lossiness decisions, and cross-reader evidence. It also needs an explicit stance on whether the DOCX-oriented `DocumentSpec` grammar is format-neutral enough or whether ODF requires a different abstraction.
+
+### Conversion-first boundary
+This is the chosen near-term answer. Native DOCX-to-ODT conversion already exists, so users can generate a DOCX artifact from the authoritative `DocumentSpec` compiler and convert it to ODT through the existing ODF path. The tradeoff is that ODT output inherits conversion lossiness reporting rather than native ODF-first guarantees.
+
+## Non-Goals
+- No `generateOdt(spec)` API in this change.
+- No changes to the `DocumentSpec` grammar.
+- No new ODF conformance claims beyond the already scoped DOCX-to-ODT conversion behavior.

--- a/openspec/changes/document-odt-generation-boundary/proposal.md
+++ b/openspec/changes/document-odt-generation-boundary/proposal.md
@@ -1,0 +1,14 @@
+# Change: Document odf-core ODT generation boundary
+
+## Why
+`@usejunior/docx-core` now supports from-scratch DOCX generation through `generateDocx(spec)` and a declarative `DocumentSpec`, while `@usejunior/odf-core` has no equivalent native ODT compiler. Without an explicit decision, the sister packages can appear to drift accidentally: users may expect the same `DocumentSpec` to compile directly to ODT even though the shipped ODT path is DOCX-to-ODT conversion.
+
+## What Changes
+- Record `@usejunior/odf-core` as conversion-first for near-term generation workflows: generate DOCX with `generateDocx(spec)`, then convert with `convertDocxToOdt`.
+- Add a package README for `@usejunior/odf-core` that makes this boundary explicit and links native ODT generation to a future proposal rather than an implied roadmap.
+- Keep `generateOdt(spec)` out of scope for this change. A future native compiler would require a separate OpenSpec proposal covering ODF schema mapping, fidelity guarantees, validation, and parity with the DOCX `DocumentSpec` compiler.
+
+## Impact
+- Affected specs: `odf-core`
+- Affected code/docs: `packages/odf-core/README.md`
+- Related issues: #426, #280, #401

--- a/openspec/changes/document-odt-generation-boundary/specs/odf-core/spec.md
+++ b/openspec/changes/document-odt-generation-boundary/specs/odf-core/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: ODT generation boundary
+`@usejunior/odf-core` SHALL document that it does not currently expose a native
+`generateOdt(spec)` compiler. For generation workflows that need ODT output, the documented
+near-term path SHALL be `@usejunior/docx-core` `generateDocx(spec)` followed by
+`@usejunior/odf-core` `convertDocxToOdt(docx)`, with any conversion downgrade surfaced through
+the existing lossiness report.
+
+Native ODT generation from `DocumentSpec` SHALL NOT be implied by package positioning or README
+copy. If native `generateOdt(spec)` is added later, it SHALL be introduced through a separate
+OpenSpec proposal that defines its ODF mapping, validation, determinism, fidelity, and
+cross-reader compatibility expectations.
+
+#### Scenario: [ODT-GEN-BND-01] Package README describes the supported ODT generation path
+- **WHEN** a user reads the `@usejunior/odf-core` package README
+- **THEN** the README SHALL describe DOCX generation followed by DOCX-to-ODT conversion as the supported near-term path for generated ODT files
+- **AND** it SHALL identify native `generateOdt(spec)` as not currently shipped
+
+#### Scenario: [ODT-GEN-BND-02] Native ODT generation is not implied
+- **WHEN** package positioning describes `@usejunior/odf-core` capabilities
+- **THEN** it SHALL avoid presenting `DocumentSpec` as a directly supported ODT compiler input
+- **AND** it SHALL direct native ODT compiler work to a future OpenSpec proposal

--- a/openspec/changes/document-odt-generation-boundary/tasks.md
+++ b/openspec/changes/document-odt-generation-boundary/tasks.md
@@ -1,0 +1,8 @@
+## 1. Documentation
+- [ ] 1.1 Add `packages/odf-core/README.md` that documents current ODT capabilities and the conversion-first generation path.
+- [ ] 1.2 State explicitly that `generateOdt(spec)` is not currently shipped and would require a future OpenSpec proposal.
+- [ ] 1.3 Cross-link the README to root generation docs and DOCX-to-ODT conversion docs where available.
+
+## 2. Validation
+- [ ] 2.1 Run `openspec validate document-odt-generation-boundary --strict`.
+- [ ] 2.2 Run the lightweight docs/spec checks relevant to the changed files.


### PR DESCRIPTION
## Summary
- Bring the de/es/pt-br/zh root READMEs into parity with the English README's from-scratch generation positioning: localized **From-Scratch Generation** sections (`generateDocx(spec)` example + library-API-only caveat), ODT mention in title/intro, `@usejunior/odf-core` in the packages list, and updated FAQ answers replacing the old "not a generator / use the `docx` package" wording.
- Add OpenSpec proposal `document-odt-generation-boundary` recording `@usejunior/odf-core` as **conversion-first** for ODT generation (generate DOCX, then `convertDocxToOdt`), deferring native `generateOdt(spec)` to a future proposal.

Fixes #425
Ref #426

## Verification
- `openspec validate document-odt-generation-boundary --strict` — valid
- Full pre-submit chain green in the worktree: `npm run build && npm run lint:workspaces && npm run test:run && npm run check:spec-coverage && npm run check:conformance-citations && npm run check:conformance-doc`
  - Note: one environment flake on the first pass (`generation-package-structure.test.ts` LibreOffice identity round-trip, soffice contention under full parallel suite); passed standalone (2.4s) and on full rerun.
- `git diff --check` clean; scan for residual old translated wording returned no matches.
- Version files untouched per the release-train note.