### PR TITLE
fix(docx-mcp): surface tracked restore post-pass errors

### DIFF
--- a/packages/docx-mcp/src/session/manager.ts
+++ b/packages/docx-mcp/src/session/manager.ts
@@ -48,6 +48,7 @@ export type SaveCacheEntry = {
   bookmarksRemoved: number;
   blocksRestored: number;
   trackedBlocksRestored: number;
+  trackedRestoreError?: string;
   exportedAtUtc: string;
   cachedAtIso: string;
 };

--- a/packages/docx-mcp/src/tools/save.test.ts
+++ b/packages/docx-mcp/src/tools/save.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect } from 'vitest';
 import { XMLSerializer } from '@xmldom/xmldom';
 import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
-import { save } from './save.js';
+import { restoreTrackedUntouchedBlocks, save } from './save.js';
 import { openDocument } from './open_document.js';
 import { grep } from './grep.js';
 import { replaceText } from './replace_text.js';
@@ -192,6 +192,21 @@ describe('save', () => {
     expect(editedParagraph).toContain('<w:del');
     expect(editedParagraph).toContain('w:author="Test Author"');
     expect(editedParagraph).toContain('replacement');
+    expect((result as Record<string, unknown>).tracked_restore_error).toBeUndefined();
+  });
+
+  test('tracked restore post-pass surfaces failure instead of swallowing it', async () => {
+    // Not a zip at all — DocxZip.load must throw, exercising the catch path.
+    const garbage = Buffer.from('not a zip archive');
+    const restored = await restoreTrackedUntouchedBlocks(garbage, garbage);
+
+    // Degrades to the unrestored artifact: the input buffer passes through
+    // untouched, but the failure is reported rather than reading as the
+    // benign "nothing to restore".
+    expect(restored.buffer).toBe(garbage);
+    expect(restored.blocksRestored).toBe(0);
+    expect(typeof restored.restoreError).toBe('string');
+    expect(restored.restoreError!.length).toBeGreaterThan(0);
   });
 
   test('both-mode generates two files', async () => {

--- a/packages/docx-mcp/src/tools/save.ts
+++ b/packages/docx-mcp/src/tools/save.ts
@@ -108,10 +108,24 @@ async function collectAiRevisionSummary(
   };
 }
 
-async function restoreTrackedUntouchedBlocks(
+/**
+ * Restoration is best-effort: on any failure the tracked artifact degrades to
+ * the unrestored comparison output (the pre-restore behavior), which is valid
+ * — just fully re-serialized. The error is returned rather than thrown so the
+ * save still succeeds, but callers must surface it: a swallowed error is
+ * indistinguishable from "document fully edited, nothing to restore"
+ * (`blocksRestored: 0` reads as benign), so a restore-path regression would
+ * otherwise go dark.
+ *
+ * Exported for direct testing of the failure path; production callers go
+ * through `save`.
+ *
+ * @see https://github.com/UseJunior/safe-docx/issues/436
+ */
+export async function restoreTrackedUntouchedBlocks(
   trackedBuffer: Buffer,
   originalBuffer: Buffer,
-): Promise<{ buffer: Buffer; blocksRestored: number }> {
+): Promise<{ buffer: Buffer; blocksRestored: number; restoreError?: string }> {
   try {
     const [trackedZip, originalZip] = await Promise.all([
       DocxZip.load(trackedBuffer),
@@ -129,8 +143,8 @@ async function restoreTrackedUntouchedBlocks(
 
     trackedZip.writeText('word/document.xml', serializeXml(trackedDoc));
     return { buffer: await trackedZip.toBuffer(), blocksRestored };
-  } catch {
-    return { buffer: trackedBuffer, blocksRestored: 0 };
+  } catch (e: unknown) {
+    return { buffer: trackedBuffer, blocksRestored: 0, restoreError: errorMessage(e) };
   }
 }
 
@@ -220,6 +234,7 @@ export async function save(
     let bookmarksRemoved: number;
     let blocksRestored: number;
     let trackedBlocksRestored: number;
+    let trackedRestoreError: string | undefined;
     let exportTimestamp: string;
 
     // Run implicit validation before producing save artifacts.
@@ -235,6 +250,7 @@ export async function save(
       bookmarksRemoved = cached.bookmarksRemoved;
       blocksRestored = cached.blocksRestored;
       trackedBlocksRestored = cached.trackedBlocksRestored;
+      trackedRestoreError = cached.trackedRestoreError;
       exportTimestamp = cached.exportedAtUtc;
     } else {
       // The clean artifact is the minimal one: untouched body blocks are
@@ -251,6 +267,7 @@ export async function save(
       trackedFallbackDiagnostics = undefined;
       exportTimestamp = formatUtcTimestamp(new Date());
       trackedBlocksRestored = 0;
+      trackedRestoreError = undefined;
 
       if (format === 'tracked' || format === 'both') {
         // Lazily generate comparison baselines if not yet available.
@@ -273,6 +290,7 @@ export async function save(
         const restoredTracked = await restoreTrackedUntouchedBlocks(trackedRes.document, session.originalBuffer);
         trackedBuffer = restoredTracked.buffer;
         trackedBlocksRestored = restoredTracked.blocksRestored;
+        trackedRestoreError = restoredTracked.restoreError;
         trackedStats = trackedRes.stats;
         trackedReconstructionMode = trackedRes.reconstructionModeUsed;
         trackedFallbackReason = trackedRes.fallbackReason;
@@ -304,6 +322,7 @@ export async function save(
         bookmarksRemoved: clean ? bookmarksRemoved : 0,
         blocksRestored,
         trackedBlocksRestored,
+        trackedRestoreError,
         exportedAtUtc: exportTimestamp,
         cachedAtIso: new Date().toISOString(),
       });
@@ -386,6 +405,7 @@ export async function save(
       bookmarks_removed: clean ? bookmarksRemoved : 0,
       blocks_restored: blocksRestored,
       tracked_blocks_restored: trackedBlocksRestored,
+      tracked_restore_error: trackedRestoreError,
       returned_variants: returnedVariants,
       available_variants: ['clean', 'redline'],
       cache_hit: cacheHit,


### PR DESCRIPTION
## Summary

- capture the error in `restoreTrackedUntouchedBlocks` instead of silently swallowing it, and surface it as an additive `tracked_restore_error` field on the save response
- thread the diagnostic through `SaveCacheEntry` so the cached return path reports it identically to the fresh path
- export the helper and cover the catch path directly (garbage buffer → buffer passthrough, count 0, error message captured) — the one line codecov flagged as uncovered on #433

## Why

#433's restore post-pass degrades correctly on failure (the artifact falls back to the unrestored comparison output), but a swallowed error is indistinguishable from "document fully edited, nothing to restore" — `tracked_blocks_restored: 0` reads as benign, so a restore-path regression would go dark. This makes the failure observable without changing the fallback behavior: the save still succeeds, the artifact is still valid, and the diagnostic tells the caller the minimal-redline guarantee was not applied.

Follow-up caveat from the post-merge review of #433.

## Validation

- `agy --print` peer review of the diff: cache parity and conventions confirmed; its schema-stripping concern verified not applicable (`ToolResponse` is an open record, no runtime output schema); its suggested save()-level failure test declined as it requires mocking the SUT (check 14)
- `npm run build && npm run lint:workspaces && npm run test:run && npm run check:spec-coverage && npm run check:conformance-citations && npm run check:conformance-doc` — full chain exit 0

Fixes: #436
Ref: #433, #421