### PR TITLE
fix(docx-core): rewrite serialized deletion text via DOM traversal

### DIFF
--- a/packages/docx-core/src/primitives/track-changes-emitter.test.ts
+++ b/packages/docx-core/src/primitives/track-changes-emitter.test.ts
@@ -10,11 +10,13 @@ import {
   buildRPrChangeElement,
   buildTcPrChangeElement,
   buildTrPrChangeElement,
+  convertSerializedDeletionContent,
   createRevisionContainer,
   createRevisionContext,
   createRevisionIdState,
   wrapElementWithDel,
   wrapElementWithIns,
+  wrapSerializedContentWithDel,
 } from './track-changes-emitter.js';
 
 const test = testAllure.epic('Document Comparison').withLabels({
@@ -271,6 +273,111 @@ describe('track-changes-emitter', () => {
       expect(serialized).toContain('<w:rPrChange ');
       expect(serialized).toContain('<w:rPr><w:b/></w:rPr>');
       expect(serialized).not.toContain('w:rPrChange w:id="99"');
+    });
+  });
+
+  test('convertSerializedDeletionContent converts entity-laden text without corrupting it', async ({ given, when, then }: AllureBddContext) => {
+    let content: string;
+    let converted: string;
+
+    await given('serialized run content whose text holds escaped angle brackets and ampersands', () => {
+      content =
+        '<w:r><w:t xml:space="preserve">if a &lt; b &amp;&amp; b &gt; c</w:t></w:r>';
+    });
+
+    await when('the content is converted for deletion', () => {
+      converted = convertSerializedDeletionContent(content);
+    });
+
+    await then('the renamed element preserves the entity references and attributes', () => {
+      expect(converted).toBe(
+        '<w:r><w:delText xml:space="preserve">if a &lt; b &amp;&amp; b &gt; c</w:delText></w:r>',
+      );
+    });
+  });
+
+  test('convertSerializedDeletionContent converts every w:t in a run with multiple text children', async ({ given, when, then }: AllureBddContext) => {
+    let content: string;
+    let converted: string;
+
+    await given('a run holding consecutive w:t elements and a field instruction', () => {
+      content =
+        '<w:r><w:t>first</w:t><w:t xml:space="preserve"> second</w:t><w:instrText>PAGEREF _Ref1</w:instrText></w:r>';
+    });
+
+    await when('the content is converted for deletion', () => {
+      converted = convertSerializedDeletionContent(content);
+    });
+
+    await then('all text children are renamed and none survive as insertion-style tags', () => {
+      expect(converted).toBe(
+        '<w:r><w:delText>first</w:delText><w:delText xml:space="preserve"> second</w:delText><w:delInstrText>PAGEREF _Ref1</w:delInstrText></w:r>',
+      );
+    });
+  });
+
+  test('convertSerializedDeletionContent converts shapes the legacy regex sweep missed', async ({ given, when, then }: AllureBddContext) => {
+    let selfClosing: string;
+    let gtInAttribute: string;
+
+    await given('runs with a self-closing w:t and an attribute value containing ">"', () => {
+      selfClosing = '<w:r><w:t/></w:r>';
+      gtInAttribute = '<w:r><w:t w14:textId="a>b">text</w:t></w:r>';
+    });
+
+    await when('the content is converted for deletion', () => {
+      selfClosing = convertSerializedDeletionContent(selfClosing);
+      gtInAttribute = convertSerializedDeletionContent(gtInAttribute);
+    });
+
+    await then('both shapes are renamed instead of leaking w:t into the deletion wrapper', () => {
+      expect(selfClosing).toBe('<w:r><w:delText/></w:r>');
+      expect(gtInAttribute).toContain('<w:delText ');
+      expect(gtInAttribute).toContain('text</w:delText>');
+      expect(gtInAttribute).not.toContain('<w:t');
+    });
+  });
+
+  test('convertSerializedDeletionContent leaves non-text run content untouched', async ({ given, when, then }: AllureBddContext) => {
+    let content: string;
+    let converted: string;
+
+    await given('serialized run content with no convertible text elements', () => {
+      content = '<w:r><w:rPr><w:b/></w:rPr><w:tab/><w:br w:type="page"/></w:r>';
+    });
+
+    await when('the content is converted for deletion', () => {
+      converted = convertSerializedDeletionContent(content);
+    });
+
+    await then('the content is returned byte-for-byte unchanged', () => {
+      expect(converted).toBe(content);
+    });
+  });
+
+  test('wrapSerializedContentWithDel wraps converted content with revision metadata', async ({ given, when, then }: AllureBddContext) => {
+    let wrapped: string;
+
+    await given('serialized run content with text', () => {
+      wrapped = '';
+    });
+
+    await when('the content is wrapped in a w:del element', () => {
+      wrapped = wrapSerializedContentWithDel(
+        '<w:r><w:t>gone</w:t></w:r>',
+        createRevisionContext({
+          author: 'Comparison',
+          date: '2026-05-03T14:15:16Z',
+          idState: createRevisionIdState(),
+        }),
+      );
+    });
+
+    await then('the wrapper carries revision metadata around deletion-style content', () => {
+      expect(wrapped).toBe(
+        '<w:del w:id="1" w:author="Comparison" w:date="2026-05-03T14:15:16Z">' +
+          '<w:r><w:delText>gone</w:delText></w:r></w:del>',
+      );
     });
   });
 });

--- a/packages/docx-core/src/primitives/track-changes-emitter.ts
+++ b/packages/docx-core/src/primitives/track-changes-emitter.ts
@@ -1,5 +1,6 @@
-import { parseXml } from './xml.js';
+import { parseXml, serializeXml } from './xml.js';
 import { childElements, createWmlElement, renameElement } from './dom-helpers.js';
+import { OOXML } from './namespaces.js';
 
 const SYNTHETIC_DOC = parseXml(
   '<root xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"/>',
@@ -278,13 +279,67 @@ export function wrapSerializedContentWithDel(content: string, ctx: RevisionConte
 }
 
 /**
+ * Matches a `<w:t>` or `<w:instrText>` open tag (including the self-closing
+ * form). Used as a fast path: content with no convertible tags is returned
+ * byte-for-byte unchanged, skipping the parse/serialize round-trip.
+ */
+const CONVERTIBLE_TEXT_TAG = /<w:(?:t|instrText)[\s/>]/;
+
+/**
  * Convert serialized run content from insertion-style text tags to deletion
  * equivalents (`w:t` -> `w:delText`, `w:instrText` -> `w:delInstrText`).
+ *
+ * The fragment is parsed into a DOM and renamed via the same traversal as
+ * `prepareElementForDeletion`, so attribute order is preserved and shapes a
+ * regex sweep mishandles (self-closing `<w:t/>`, attribute values containing
+ * `>`) convert correctly. Namespace prefixes the fragment uses without an
+ * inline declaration are bound on a temporary wrapper root that is stripped
+ * from the returned serialization.
+ *
+ * @see https://github.com/UseJunior/safe-docx/issues/102
  */
 export function convertSerializedDeletionContent(content: string): string {
-  return content
-    .replace(/<w:t([^>]*)>([^<]*)<\/w:t>/g, '<w:delText$1>$2</w:delText>')
-    .replace(/<w:instrText([^>]*)>([^<]*)<\/w:instrText>/g, '<w:delInstrText$1>$2</w:delInstrText>');
+  if (!CONVERTIBLE_TEXT_TAG.test(content)) {
+    return content;
+  }
+
+  const doc = parseXml(`<root${declareContentPrefixes(content)}>${content}</root>`);
+  for (const child of childElements(doc.documentElement)) {
+    normalizeDeletionElement(child);
+  }
+
+  // Strip the wrapper root: everything between the end of its open tag and
+  // the start of its close tag. Safe because the declared URIs contain no '>'.
+  const serialized = serializeXml(doc);
+  return serialized.slice(serialized.indexOf('>') + 1, serialized.lastIndexOf('<'));
+}
+
+/**
+ * Matches a `prefix:` occurrence in markup context — after `<`, `</`, or
+ * whitespace (attribute position). May over-match inside text content, which
+ * is harmless: it only yields an unused declaration on the wrapper root.
+ */
+const PREFIX_SCAN = /[<\s]\/?([A-Za-z_][A-Za-z0-9_.-]*):/g;
+
+/**
+ * Build `xmlns` declarations for every namespace prefix a serialized fragment
+ * uses, so the fragment parses under a wrapper root (xmldom rejects
+ * undeclared prefixes). `w` binds to the real WordprocessingML namespace —
+ * the deletion rename produces elements in that namespace — while unknown
+ * prefixes get placeholder URIs. The wrapper root carrying these declarations
+ * is stripped after serialization, so placeholders never reach the output;
+ * fragments serialized from a real document carry their own inline
+ * declarations, which take precedence over the wrapper's.
+ */
+function declareContentPrefixes(content: string): string {
+  const declarations = new Map<string, string>([['w', OOXML.W_NS]]);
+  for (const match of content.matchAll(PREFIX_SCAN)) {
+    const prefix = match[1]!;
+    if (prefix !== 'xml' && prefix !== 'xmlns' && !declarations.has(prefix)) {
+      declarations.set(prefix, `urn:safe-docx:undeclared-prefix:${prefix}`);
+    }
+  }
+  return [...declarations].map(([prefix, uri]) => ` xmlns:${prefix}="${uri}"`).join('');
 }
 
 function getOwnerDocument(element: Element | null): Document {


### PR DESCRIPTION
## Summary

`convertSerializedDeletionContent` (the regex sweep issue #102 flagged in the reconstructor's `wrapWithDel`, since extracted to `track-changes-emitter.ts`) rewrote `<w:t>` → `<w:delText>` and `<w:instrText>` → `<w:delInstrText>` with regexes. The pattern silently skips legal serialized shapes — a self-closing `<w:t/>` and attribute values containing `>` — leaving insertion-style text tags inside `<w:del>`, which is schema-invalid.

The helper now parses the fragment into a DOM and reuses the same traversal as `prepareElementForDeletion` (`normalizeDeletionElement`), so the serialized-string path and the DOM path share one rename implementation. Attribute order and namespaces are preserved.

Because xmldom rejects undeclared namespace prefixes, prefixes the fragment uses without an inline declaration are bound on a temporary wrapper root (`w` to the real WordprocessingML namespace, others to placeholder URIs) that is stripped from the returned serialization — placeholders never reach the output. Content with no convertible tags returns byte-for-byte unchanged via a fast path.

## Acceptance criteria from #102

- ✅ DOM-based rewrite that preserves attribute order and namespaces
- ✅ Test fixture exercising entity-laden text (`&lt;`/`&amp;`/`&gt;`) asserting exact output
- ✅ Test fixture with a run holding multiple `<w:t>` children asserting all are converted
- ➕ Regression tests for the shapes the regex actually mishandled: self-closing `<w:t/>` and `>` inside an attribute value (with an undeclared `w14:` prefix exercising the wrapper-declaration path)

## Testing

Full pre-submit suite passed locally: `build`, `lint:workspaces`, `test:run`, `check:spec-coverage`, `check:conformance-citations`, `check:conformance-doc`.

Credit to external contributor @Data9210, whose diagnosis in #94 surfaced this.

Fixes: #102