### PR TITLE
fix(docx-core): keep matched multi-paragraph comment ranges on rebuild

### DIFF
--- a/packages/docx-core/src/baselines/atomizer/documentReconstructor.ts
+++ b/packages/docx-core/src/baselines/atomizer/documentReconstructor.ts
@@ -1618,10 +1618,28 @@ function buildDocumentPreservingStructure(
   // siblings of <w:p> in the original body. The paragraph rebuilder handles
   // its own bookmark logic, so keeping these orphaned markers causes
   // unmatched bookmark IDs.
+  //
+  // Comment range markers are treated differently: a sibling-level
+  // commentRangeStart/End is the legitimate shape for a comment range that
+  // spans whole paragraphs, and such markers never enter the atom stream
+  // (see isParagraphLevelLeaf in atomizer.ts), so nothing re-emits them.
+  // Stripping them unconditionally destroys multi-paragraph comment ranges
+  // (issue #103). Instead, strip a sibling-level comment range marker only
+  // when its counterpart (same w:id) is absent from the rebuilt body —
+  // i.e., it is a genuinely orphaned scaffold remnant.
   const SCAFFOLD_STRIP_TAGS = new Set([
     'w:bookmarkStart', 'w:bookmarkEnd',
     'w:commentRangeStart', 'w:commentRangeEnd',
   ]);
+  const COMMENT_RANGE_TAGS = new Set(['w:commentRangeStart', 'w:commentRangeEnd']);
+  const commentRangeStartIds = new Set<string>();
+  const commentRangeEndIds = new Set<string>();
+  for (const el of Array.from(body.getElementsByTagName('*'))) {
+    const id = (el as Element).getAttribute('w:id');
+    if (id == null) continue;
+    if (el.tagName === 'w:commentRangeStart') commentRangeStartIds.add(id);
+    else if (el.tagName === 'w:commentRangeEnd') commentRangeEndIds.add(id);
+  }
   const toRemove: Element[] = [];
   for (const el of Array.from(body.getElementsByTagName('*'))) {
     if (SCAFFOLD_STRIP_TAGS.has(el.tagName) && el.parentNode) {
@@ -1635,9 +1653,15 @@ function buildDocumentPreservingStructure(
         }
         ancestor = ancestor.parentNode;
       }
-      if (!insideParagraph) {
-        toRemove.push(el as Element);
+      if (insideParagraph) continue;
+      if (COMMENT_RANGE_TAGS.has(el.tagName)) {
+        const id = (el as Element).getAttribute('w:id');
+        const counterpartIds = el.tagName === 'w:commentRangeStart'
+          ? commentRangeEndIds
+          : commentRangeStartIds;
+        if (id != null && counterpartIds.has(id)) continue;
       }
+      toRemove.push(el as Element);
     }
   }
   for (const el of toRemove) {

--- a/packages/docx-core/src/integration/rebuild-auxiliary-merge.test.ts
+++ b/packages/docx-core/src/integration/rebuild-auxiliary-merge.test.ts
@@ -16,6 +16,7 @@ import { describe, expect } from 'vitest';
 import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
 import { compareDocuments } from '../index.js';
 import { buildSyntheticDocx, getResultParts } from './synthetic-docx-fixture.js';
+import { buildDocxFromBodyXml } from '../testing/ooxml-fixtures.js';
 import { parseXml } from '../primitives/xml.js';
 
 /**
@@ -577,6 +578,86 @@ describe('Paragraph-level marker reconstruction on rebuild (issue #106)', () => 
         // inplace output must contain the comment anchor; the full span survives
         // because the markers are already present in the revised archive.
         expect(parts.documentXml).toContain('w:commentReference');
+      });
+    });
+  });
+});
+
+describe('Multi-paragraph sibling comment ranges on rebuild (issue #103)', () => {
+  describe('Body-level comment range wrapping whole paragraphs', () => {
+    test('rebuild preserves matched sibling-level commentRangeStart/End markers', async ({ given, when, then }: AllureBddContext) => {
+      let original: Buffer, revised: Buffer;
+      await given('both sides have a comment range whose markers sit outside any <w:p>, wrapping the first two paragraphs', async () => {
+        original = await buildSyntheticDocx({
+          paragraphs: ['First paragraph', 'Second paragraph', 'Third paragraph'],
+          siblingCommentRange: { startBeforeParagraph: 0, endAfterParagraph: 1 },
+          commentText: 'Spanning comment',
+          commentAuthor: 'Reviewer',
+        });
+        revised = await buildSyntheticDocx({
+          paragraphs: ['First paragraph', 'Second paragraph revised', 'Third paragraph'],
+          siblingCommentRange: { startBeforeParagraph: 0, endAfterParagraph: 1 },
+          commentText: 'Spanning comment',
+          commentAuthor: 'Reviewer',
+        });
+      });
+
+      let result: Awaited<ReturnType<typeof compareDocuments>>;
+      await when('documents are compared in rebuild mode', async () => {
+        result = await compareDocuments(original, revised, {
+          engine: 'atomizer',
+          reconstructionMode: 'rebuild',
+        });
+      });
+
+      await then('both range markers survive at body level with matching ids and the anchor is intact', async () => {
+        expect(result.reconstructionModeUsed).toBe('rebuild');
+        const parts = await getResultParts(result.document);
+
+        const starts = inspectElements(parts.documentXml, 'w:commentRangeStart');
+        const ends = inspectElements(parts.documentXml, 'w:commentRangeEnd');
+        expect(starts.length).toBe(1);
+        expect(ends.length).toBe(1);
+        expect(starts[0]!.idAttr).toBe(ends[0]!.idAttr);
+
+        // The markers wrap whole paragraphs, so they must stay siblings of
+        // <w:p>, not get pulled inside a reconstructed paragraph.
+        for (const m of [...starts, ...ends]) {
+          expect(m.ancestors).not.toContain('w:p');
+          expect(m.parent).toBe('w:body');
+        }
+
+        // The comment anchor and definition must still be present.
+        expect(parts.documentXml).toContain('w:commentReference');
+        expect(parts.commentsXml).toContain('Spanning comment');
+      });
+    });
+  });
+
+  describe('Orphaned body-level comment range remnant', () => {
+    test('a sibling commentRangeStart with no matching end is still stripped', async ({ given, when, then }: AllureBddContext) => {
+      let original: Buffer, revised: Buffer;
+      await given('both sides carry an unmatched body-level commentRangeStart between two paragraphs', async () => {
+        const bodyXml = (textA: string) =>
+          `<w:p><w:r><w:t>${textA}</w:t></w:r></w:p>` +
+          `<w:commentRangeStart w:id="7"/>` +
+          `<w:p><w:r><w:t>Para B</w:t></w:r></w:p>`;
+        original = await buildDocxFromBodyXml(bodyXml('Para A'));
+        revised = await buildDocxFromBodyXml(bodyXml('Para A revised'));
+      });
+
+      let result: Awaited<ReturnType<typeof compareDocuments>>;
+      await when('documents are compared in rebuild mode', async () => {
+        result = await compareDocuments(original, revised, {
+          engine: 'atomizer',
+          reconstructionMode: 'rebuild',
+        });
+      });
+
+      await then('the orphaned marker does not survive into the rebuilt document', async () => {
+        expect(result.reconstructionModeUsed).toBe('rebuild');
+        const parts = await getResultParts(result.document);
+        expect(parts.documentXml).not.toContain('w:commentRangeStart');
       });
     });
   });

--- a/packages/docx-core/src/integration/synthetic-docx-fixture.ts
+++ b/packages/docx-core/src/integration/synthetic-docx-fixture.ts
@@ -40,6 +40,17 @@ export interface SyntheticDocxOptions {
    * markers do not leak into reconstructed paragraphs.
    */
   siblingBookmarkBefore?: { index: number; name: string; id?: number };
+  /**
+   * Multi-paragraph comment range with body-level markers: the
+   * commentRangeStart is emitted as a sibling of <w:p> before
+   * paragraphs[startBeforeParagraph] and the commentRangeEnd as a sibling
+   * after paragraphs[endAfterParagraph]. The commentReference run is
+   * appended inside paragraphs[endAfterParagraph]. This is the issue #103
+   * shape: range markers spanning whole paragraphs sit outside any <w:p>.
+   *
+   * Mutually exclusive with commentOnParagraph and commentSpanParagraphs.
+   */
+  siblingCommentRange?: { startBeforeParagraph: number; endAfterParagraph: number };
 }
 
 export async function buildSyntheticDocx(opts: SyntheticDocxOptions): Promise<Buffer> {
@@ -48,9 +59,12 @@ export async function buildSyntheticDocx(opts: SyntheticDocxOptions): Promise<Bu
   const hasCommentSpan = opts.commentSpanParagraphs != null;
   const hasBookmark = opts.bookmarkOnParagraph != null;
   const hasSiblingBookmark = opts.siblingBookmarkBefore != null;
+  const hasSiblingCommentRange = opts.siblingCommentRange != null;
 
-  if (hasComment && hasCommentSpan) {
-    throw new Error('commentOnParagraph and commentSpanParagraphs are mutually exclusive');
+  if ([hasComment, hasCommentSpan, hasSiblingCommentRange].filter(Boolean).length > 1) {
+    throw new Error(
+      'commentOnParagraph, commentSpanParagraphs and siblingCommentRange are mutually exclusive'
+    );
   }
 
   const bookmarkId = opts.bookmarkOnParagraph?.id ?? 100;
@@ -112,6 +126,20 @@ export async function buildSyntheticDocx(opts: SyntheticDocxOptions): Promise<Bu
     paragraphParts.splice(index, 0, sibling);
   }
 
+  // Inject body-level comment range markers around whole paragraphs (the
+  // issue #103 shape). The range markers are siblings of <w:p>; only the
+  // commentReference run anchors inside the last spanned paragraph. End is
+  // spliced before start so the start index is not shifted.
+  if (hasSiblingCommentRange) {
+    const { startBeforeParagraph, endAfterParagraph } = opts.siblingCommentRange!;
+    paragraphParts[endAfterParagraph] = paragraphParts[endAfterParagraph]!.replace(
+      '</w:p>',
+      `<w:r><w:rPr><w:rStyle w:val="CommentReference"/></w:rPr><w:commentReference w:id="1"/></w:r></w:p>`
+    );
+    paragraphParts.splice(endAfterParagraph + 1, 0, `<w:commentRangeEnd w:id="1"/>`);
+    paragraphParts.splice(startBeforeParagraph, 0, `<w:commentRangeStart w:id="1"/>`);
+  }
+
   const paragraphsXml = paragraphParts.join('\n    ');
 
   const documentXml =
@@ -148,7 +176,7 @@ export async function buildSyntheticDocx(opts: SyntheticDocxOptions): Promise<Bu
     );
   }
 
-  if (hasComment || hasCommentSpan) {
+  if (hasComment || hasCommentSpan || hasSiblingCommentRange) {
     const cText = opts.commentText ?? 'Test comment';
     const cAuthor = opts.commentAuthor ?? 'Author';
     const hasReply = opts.replyText != null;


### PR DESCRIPTION
## Summary
The scaffold-strip pass in `buildDocumentPreservingStructure` removed every `w:commentRangeStart`/`w:commentRangeEnd` not inside a `<w:p>`, treating all sibling-level markers as orphaned scaffold remnants. That destroys legitimate multi-paragraph comment ranges: a comment spanning whole paragraphs has its range markers as siblings of `<w:p>`, and since body-level markers never enter the atom stream (`isParagraphLevelLeaf` only atomizes markers inside a `<w:p>`), nothing re-emits them after rebuild. The result was a comment reduced to its `w:commentReference` anchor with no range.

## Fix
Strip a sibling-level comment range marker only when its counterpart (same `w:id`) is absent from the rebuilt body — i.e. when it is a genuinely orphaned remnant. Matched pairs stay in place; because the paragraph rebuilder never re-emits them, keeping them cannot introduce duplicates. Bookmark handling is unchanged (the rebuilder owns bookmark reconstruction and `enforceConsumerCompatibility` balances the result).

## Tests
- New `siblingCommentRange` option on `buildSyntheticDocx` builds the issue #103 shape (body-level start/end wrapping whole paragraphs, reference run inside the last spanned paragraph).
- Regression test: a matched body-level range survives rebuild at body level with matching ids — verified to fail without the engine change.
- Pin test: an unmatched sibling `commentRangeStart` is still stripped.

Full pre-submit gate passed locally (build, lint, test:run, spec-coverage, conformance-citations, conformance-doc).

Fixes: #103
Credit to @Data9210 for the original report in #94.