### PR TITLE
fix(docx-core): screen rebuild output through round-trip safety checks

### DIFF
--- a/packages/docx-core/src/baselines/atomizer/pipeline.ts
+++ b/packages/docx-core/src/baselines/atomizer/pipeline.ts
@@ -19,6 +19,7 @@ import type {
   ReconstructionFallbackReason,
   ReconstructionIdDelta,
   ReconstructionIdDeltaSummary,
+  ReconstructionRebuildSafetyDiagnostics,
   ReconstructionSafetyFailureSummary,
   ReconstructionSafetyFailureDetails,
   ReconstructionSafetyCheckName,
@@ -988,6 +989,24 @@ export async function compareDocumentsAtomizer(
     );
   }
 
+  // Rebuild output gets the same safety screening as inplace attempts, whether
+  // rebuild was requested directly or reached via inplace fallback. Rebuild is
+  // the terminal strategy, so failures are surfaced in diagnostics rather than
+  // blocking the output.
+  // @see https://github.com/UseJunior/safe-docx/issues/226
+  let rebuildSafetyDiagnostics: ReconstructionRebuildSafetyDiagnostics | undefined;
+  if (comparisonResult.outputMode === 'rebuild') {
+    const safety = evaluateRoundTripSafety(comparisonResult.newDocumentXml);
+    if (!safety.safe) {
+      rebuildSafetyDiagnostics = {
+        checks: safety.checks,
+        failedChecks: safety.failedChecks,
+        failureDetails: safety.failureDetails,
+        firstDiffSummary: safety.failureSummary,
+      };
+    }
+  }
+
   const { mergedAtoms, newDocumentXml } = comparisonResult;
 
   // Step 12: Clone appropriate archive and update document.xml.
@@ -1031,6 +1050,7 @@ export async function compareDocumentsAtomizer(
     reconstructionModeUsed: comparisonResult.outputMode,
     fallbackReason,
     fallbackDiagnostics,
+    rebuildSafetyDiagnostics,
   };
 }
 

--- a/packages/docx-core/src/compare-types.ts
+++ b/packages/docx-core/src/compare-types.ts
@@ -173,6 +173,21 @@ export interface ReconstructionFallbackDiagnostics {
   attempts: ReconstructionAttemptDiagnostics[];
 }
 
+/**
+ * Round-trip safety evaluation of rebuild output. Rebuild is the terminal
+ * reconstruction strategy — there is no further fallback — so a failed check
+ * cannot reroute the pipeline. The document is returned anyway and the
+ * failures are surfaced here as a caller-visible warning.
+ *
+ * @see https://github.com/UseJunior/safe-docx/issues/226
+ */
+export interface ReconstructionRebuildSafetyDiagnostics {
+  checks: ReconstructionSafetyChecks;
+  failedChecks: ReconstructionSafetyCheckName[];
+  failureDetails?: ReconstructionSafetyFailureDetails;
+  firstDiffSummary?: ReconstructionSafetyFailureSummary;
+}
+
 export interface CompareResult {
   /** The resulting DOCX with track changes */
   document: Buffer;
@@ -198,4 +213,10 @@ export interface CompareResult {
    * Present only when atomizer falls back.
    */
   fallbackDiagnostics?: ReconstructionFallbackDiagnostics;
+  /**
+   * Safety-check failures observed on rebuild output — whether rebuild was
+   * requested explicitly (the default mode) or reached via inplace fallback.
+   * Present only when at least one check failed.
+   */
+  rebuildSafetyDiagnostics?: ReconstructionRebuildSafetyDiagnostics;
 }

--- a/packages/docx-core/src/integration/rebuild-safety-diagnostics-pipeline.test.ts
+++ b/packages/docx-core/src/integration/rebuild-safety-diagnostics-pipeline.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Integration Tests — Round-trip safety screening of rebuild output
+ *
+ * Verifies that `compareDocumentsAtomizer` runs the round-trip safety suite
+ * (text equality, bookmark diagnostics, per-story field structure) on rebuild
+ * output. Rebuild is the terminal reconstruction strategy — there is no
+ * further fallback — so failures must not block the output; they surface in
+ * `rebuildSafetyDiagnostics` as a caller-visible warning. Previously the
+ * direct-rebuild path (including the default mode) returned its output with
+ * zero safety screening, so a malformed field per the ECMA-376 fldChar
+ * begin/end pairing rules could ship undetected.
+ *
+ * @see https://github.com/UseJunior/safe-docx/issues/226
+ */
+
+import { describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import {
+  buildDocxFromBodyXml,
+  fldChar,
+  instrText,
+  paragraphWithField,
+  paragraphWithText,
+  FIELD_INSTRUCTIONS,
+  resultText,
+} from '../testing/ooxml-fixtures.js';
+import { compareDocuments } from '../index.js';
+
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({ feature: 'Rebuild Safety Diagnostics (#226)' })
+  .conformance({ spec: 'ECMA-376', edition: 5, part: 4, section: '17.16.5' });
+
+// A field opened (begin → instrText → separate → result) but never closed:
+// the body story's begin/end counts are 1:0, so validateFieldStructure must
+// reject any output that carries it.
+const UNCLOSED_PAGE_FIELD =
+  fldChar('begin') +
+  instrText(FIELD_INSTRUCTIONS.PAGE, { preserve: true }) +
+  fldChar('separate') +
+  resultText('3');
+
+async function buildMalformedFieldPair(): Promise<{ original: Buffer; revised: Buffer }> {
+  return {
+    original: await buildDocxFromBodyXml(
+      paragraphWithField('Intro', UNCLOSED_PAGE_FIELD, '') + paragraphWithText('Hello'),
+    ),
+    revised: await buildDocxFromBodyXml(
+      paragraphWithField('Intro', UNCLOSED_PAGE_FIELD, '') + paragraphWithText('Hello world'),
+    ),
+  };
+}
+
+describe('Rebuild-output safety screening (issue #226) — pipeline-level', () => {
+  test(
+    'explicit rebuild with a malformed body field returns output WITH fieldStructure failure surfaced',
+    async ({ given, when, then, and, attachPrettyJson }: AllureBddContext) => {
+      let original: Buffer = Buffer.alloc(0);
+      let revised: Buffer = Buffer.alloc(0);
+      let result: Awaited<ReturnType<typeof compareDocuments>>;
+
+      await given('original/revised pair whose body opens a field that never closes', async () => {
+        ({ original, revised } = await buildMalformedFieldPair());
+      });
+
+      await when('compared with reconstructionMode: rebuild requested explicitly', async () => {
+        result = await compareDocuments(original, revised, {
+          engine: 'atomizer',
+          reconstructionMode: 'rebuild',
+        });
+        await attachPrettyJson('comparison-metadata.json', {
+          reconstructionModeUsed: result.reconstructionModeUsed,
+          fallbackReason: result.fallbackReason,
+          rebuildSafetyDiagnostics: result.rebuildSafetyDiagnostics,
+        });
+      });
+
+      await then('rebuild output is still returned (no further fallback exists)', () => {
+        expect(result.document.length).toBeGreaterThan(0);
+        expect(result.reconstructionModeUsed).toBe('rebuild');
+        expect(result.fallbackReason).toBeUndefined();
+      });
+
+      await and('the fieldStructure failure is surfaced in rebuildSafetyDiagnostics', () => {
+        const diagnostics = result.rebuildSafetyDiagnostics;
+        expect(diagnostics, 'rebuild output must be safety-screened').toBeDefined();
+        expect(diagnostics?.failedChecks).toContain('fieldStructure');
+        expect(diagnostics?.checks.fieldStructure).toBe(false);
+      });
+    },
+  );
+
+  test(
+    'default mode (no reconstructionMode) gets the same rebuild safety screening',
+    async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
+      let original: Buffer = Buffer.alloc(0);
+      let revised: Buffer = Buffer.alloc(0);
+      let result: Awaited<ReturnType<typeof compareDocuments>>;
+
+      await given('original/revised pair whose body opens a field that never closes', async () => {
+        ({ original, revised } = await buildMalformedFieldPair());
+      });
+
+      await when('compared without specifying a reconstruction mode', async () => {
+        result = await compareDocuments(original, revised, { engine: 'atomizer' });
+        await attachPrettyJson('comparison-metadata.json', {
+          reconstructionModeUsed: result.reconstructionModeUsed,
+          rebuildSafetyDiagnostics: result.rebuildSafetyDiagnostics,
+        });
+      });
+
+      await then('the fieldStructure failure is surfaced in rebuildSafetyDiagnostics', () => {
+        expect(result.reconstructionModeUsed).toBe('rebuild');
+        expect(result.rebuildSafetyDiagnostics?.failedChecks).toContain('fieldStructure');
+      });
+    },
+  );
+
+  test(
+    'explicit rebuild on a well-formed pair reports no safety diagnostics',
+    async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
+      let original: Buffer = Buffer.alloc(0);
+      let revised: Buffer = Buffer.alloc(0);
+      let result: Awaited<ReturnType<typeof compareDocuments>>;
+
+      await given('original/revised pair with plain well-formed paragraphs', async () => {
+        original = await buildDocxFromBodyXml(paragraphWithText('Hello'));
+        revised = await buildDocxFromBodyXml(paragraphWithText('Hello world'));
+      });
+
+      await when('compared with reconstructionMode: rebuild requested explicitly', async () => {
+        result = await compareDocuments(original, revised, {
+          engine: 'atomizer',
+          reconstructionMode: 'rebuild',
+        });
+        await attachPrettyJson('comparison-metadata.json', {
+          reconstructionModeUsed: result.reconstructionModeUsed,
+          rebuildSafetyDiagnostics: result.rebuildSafetyDiagnostics,
+        });
+      });
+
+      await then('all safety checks pass and no diagnostics field is present', () => {
+        expect(result.reconstructionModeUsed).toBe('rebuild');
+        expect(result.rebuildSafetyDiagnostics).toBeUndefined();
+      });
+    },
+  );
+});


### PR DESCRIPTION
## Summary

Fixes #226 — direct `reconstructionMode: 'rebuild'` (and the default mode, which is rebuild) bypassed `evaluateRoundTripSafety` entirely. The safety suite (text round-trip equality, bookmark diagnostics, per-story field structure from #225) only ran on inplace attempts; the direct-rebuild branch returned `runComparisonPass` output with zero screening.

## Approach

Option (1) from the issue, as recommended for back-compat: rebuild is the terminal reconstruction strategy with no further fallback, so the document is returned regardless and failures surface in a new caller-visible `CompareResult.rebuildSafetyDiagnostics` field (`checks`, `failedChecks`, `failureDetails`, `firstDiffSummary` — same shape as an inplace attempt's diagnostics, minus `pass`). The field is present only when at least one check failed.

The evaluation gates on `outputMode === 'rebuild'` after mode selection, so it applies uniformly to explicit rebuild requests, default-mode comparisons, and inplace requests that fell back to rebuild.

## Acceptance criteria from #226

- [x] `evaluateRoundTripSafety` runs on direct rebuild output
- [x] Failure surfacing decided and documented: non-blocking, surfaced via `rebuildSafetyDiagnostics` (JSDoc on the new type documents the disposition)
- [x] Regression test analogous to `field-cross-story-pipeline.test.ts` requesting rebuild explicitly: `rebuild-safety-diagnostics-pipeline.test.ts` confirms an unclosed body field surfaces a `fieldStructure` failure while output is still returned (explicit + default mode), and a well-formed pair reports no diagnostics

## Testing

Full pre-submit suite green locally: `npm run build && npm run lint:workspaces && npm run test:run && npm run check:spec-coverage && npm run check:conformance-citations && npm run check:conformance-doc` (exit 0; 858 docx-core tests + downstream workspaces all passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)