### PR TITLE
fix(docx-core): renumber colliding auxiliary part IDs before comparison

### DIFF
--- a/packages/docx-core/src/baselines/atomizer/auxiliaryIdCollision.ts
+++ b/packages/docx-core/src/baselines/atomizer/auxiliaryIdCollision.ts
@@ -1,0 +1,280 @@
+/**
+ * Auxiliary Part ID Collision Resolution
+ *
+ * Auxiliary part IDs (`w:id` on comments, footnotes, endnotes — OOXML
+ * ST_DecimalNumber) are document-local: independently authored documents
+ * routinely both start at `w:id="1"`. When the original and revised inputs
+ * define *different* content under the same ID, the post-reconstruction
+ * definition merge used to silently skip the source-side definition ("ID
+ * already present"), leaving anchors from one side bound to the other side's
+ * content.
+ *
+ * Strategy decision (issue #107 offered renumber vs. detect-and-flag): we
+ * renumber, because detect-and-flag would fail comparisons between any two
+ * independently authored commented documents — a core use case — and there is
+ * no collision-free fallback mode to flag into. Renumbering happens *before*
+ * comparison, on the revised archive, rather than inside the merge step:
+ * after reconstruction the merged document.xml no longer records which anchor
+ * came from which side, but at load time the revised archive can be rewritten
+ * consistently (part definition + every ID-bearing anchor in document.xml,
+ * header/footer parts, and the note stories — comments may be anchored on
+ * footnote/endnote text). Downstream, colliding anchors then differ by ID, so
+ * the LCS emits them as delete/insert pairs and the existing definition merge
+ * imports the renumbered definition — each anchor resolves to the content it
+ * was authored against, in both reconstruction modes.
+ *
+ * IDs whose definitions are content-identical on both sides are left alone so
+ * their anchors still match as unchanged content (no duplicate definitions),
+ * which keeps the common derived-document case byte-stable.
+ *
+ * @see https://github.com/UseJunior/safe-docx/issues/107
+ */
+
+import { XMLSerializer } from '@xmldom/xmldom';
+import { parseXml } from '../../primitives/xml.js';
+import type { DocxArchive } from '../../shared/docx/DocxArchive.js';
+
+const serializer = new XMLSerializer();
+
+export interface AuxiliaryPartDescriptor {
+  label: string;
+  partPath: string;
+  referenceTag: string;
+  entryTag: string;
+  rootTag: string;
+  contentType: string;
+  relationshipType: string;
+  /**
+   * Every document.xml / header / footer tag that carries this part's `w:id`.
+   * Superset of `referenceTag`: comments also anchor via range markers.
+   */
+  idBearingTags: string[];
+}
+
+export const AUXILIARY_PARTS: AuxiliaryPartDescriptor[] = [
+  {
+    label: 'footnote',
+    partPath: 'word/footnotes.xml',
+    referenceTag: 'w:footnoteReference',
+    entryTag: 'w:footnote',
+    rootTag: 'w:footnotes',
+    contentType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.footnotes+xml',
+    relationshipType: 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/footnotes',
+    idBearingTags: ['w:footnoteReference'],
+  },
+  {
+    label: 'endnote',
+    partPath: 'word/endnotes.xml',
+    referenceTag: 'w:endnoteReference',
+    entryTag: 'w:endnote',
+    rootTag: 'w:endnotes',
+    contentType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.endnotes+xml',
+    relationshipType: 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/endnotes',
+    idBearingTags: ['w:endnoteReference'],
+  },
+  {
+    label: 'comment',
+    partPath: 'word/comments.xml',
+    referenceTag: 'w:commentReference',
+    entryTag: 'w:comment',
+    rootTag: 'w:comments',
+    contentType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.comments+xml',
+    relationshipType: 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/comments',
+    idBearingTags: ['w:commentReference', 'w:commentRangeStart', 'w:commentRangeEnd'],
+  },
+];
+
+/**
+ * Parse an auxiliary part and extract entry elements by ID.
+ */
+export function parseEntries(
+  xml: string,
+  entryTag: string
+): { doc: Document; entries: Map<string, Element> } {
+  const doc = parseXml(xml);
+  const entries = new Map<string, Element>();
+  const elements = doc.getElementsByTagName(entryTag);
+  for (let i = 0; i < elements.length; i++) {
+    const el = elements[i] as Element;
+    const id = el.getAttribute('w:id');
+    if (id) entries.set(id, el);
+  }
+  return { doc, entries };
+}
+
+export interface RenumberedAuxiliaryId {
+  label: string;
+  fromId: string;
+  toId: string;
+}
+
+/**
+ * Footnote/endnote separator entries exist in virtually every document and
+ * are never anchored from document.xml; renumbering them would only churn
+ * IDs Word expects to find.
+ */
+function isSeparatorEntry(el: Element): boolean {
+  const type = el.getAttribute('w:type');
+  return type === 'separator' || type === 'continuationSeparator';
+}
+
+function trackMaxNumericId(value: string | null, current: number): number {
+  if (!value) return current;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isSafeInteger(parsed)) return current;
+  return Math.max(current, parsed);
+}
+
+/** Lazily-parsed XML file inside an archive, serialized back only if touched. */
+class LazyArchiveXml {
+  private parsed: Document | null = null;
+  private dirty = false;
+
+  constructor(
+    private readonly archive: DocxArchive,
+    private readonly path: string,
+    private readonly xml: string,
+  ) {}
+
+  doc(): Document {
+    if (!this.parsed) this.parsed = parseXml(this.xml);
+    return this.parsed;
+  }
+
+  /** Rewrite `w:id` on every `tag` element per `idMap`. */
+  applyIdMap(tags: string[], idMap: Map<string, string>): void {
+    for (const tag of tags) {
+      const elements = this.doc().getElementsByTagName(tag);
+      for (let i = 0; i < elements.length; i++) {
+        const el = elements[i] as Element;
+        const id = el.getAttribute('w:id');
+        if (id !== null && idMap.has(id)) {
+          el.setAttribute('w:id', idMap.get(id)!);
+          this.dirty = true;
+        }
+      }
+    }
+  }
+
+  flush(): void {
+    if (!this.dirty || !this.parsed) return;
+    // xmldom 0.9 keeps the source's XML declaration as a document child, so
+    // plain serialization round-trips it.
+    this.archive.setFile(this.path, serializer.serializeToString(this.parsed));
+  }
+}
+
+/**
+ * Detect auxiliary `w:id` values defined with different content on both
+ * sides and renumber the revised side's definitions and anchors into a fresh
+ * ID space, so the comparison never binds an anchor to the other document's
+ * content. Mutates `revisedArchive` in place; the originals' IDs are kept so
+ * the comparison base (rebuild mode clones the original archive) stays
+ * untouched.
+ *
+ * Anchors are rewritten in every revised-side story that can carry them:
+ * document.xml, header/footer parts, and the auxiliary parts themselves —
+ * Word allows comments anchored on footnote/endnote text, so a renumbered
+ * comment's anchor may live inside footnotes.xml/endnotes.xml.
+ *
+ * Returns the applied renumberings (empty on the no-collision fast path).
+ */
+export async function renumberCollidingAuxiliaryIds(
+  originalArchive: DocxArchive,
+  revisedArchive: DocxArchive,
+): Promise<RenumberedAuxiliaryId[]> {
+  // Phase 1: detect collisions per descriptor (read-only).
+  const plans: Array<{ descriptor: AuxiliaryPartDescriptor; collidingIds: string[] }> = [];
+  const originalEntryIds = new Map<string, Set<string>>();
+  for (const descriptor of AUXILIARY_PARTS) {
+    const [originalPartXml, revisedPartXml] = await Promise.all([
+      originalArchive.getFile(descriptor.partPath),
+      revisedArchive.getFile(descriptor.partPath),
+    ]);
+    // A collision needs a definition on both sides.
+    if (!originalPartXml || !revisedPartXml) continue;
+
+    const originalParsed = parseEntries(originalPartXml, descriptor.entryTag);
+    const revisedParsed = parseEntries(revisedPartXml, descriptor.entryTag);
+    originalEntryIds.set(descriptor.label, new Set(originalParsed.entries.keys()));
+
+    const collidingIds: string[] = [];
+    for (const [id, revisedEntry] of revisedParsed.entries) {
+      const originalEntry = originalParsed.entries.get(id);
+      if (!originalEntry) continue;
+      if (isSeparatorEntry(originalEntry) || isSeparatorEntry(revisedEntry)) continue;
+      // Both parts went through the same parse, so serialization is a
+      // canonical-enough content identity. xmldom preserves source attribute
+      // order, so two byte-different but semantically identical entries DO
+      // mismatch — intentionally accepted: a false mismatch only costs an
+      // unnecessary renumber (both definitions ship as a delete/insert
+      // anchor pair), never a wrong binding.
+      if (serializer.serializeToString(originalEntry) === serializer.serializeToString(revisedEntry)) {
+        continue;
+      }
+      collidingIds.push(id);
+    }
+    if (collidingIds.length > 0) plans.push({ descriptor, collidingIds });
+  }
+  if (plans.length === 0) return [];
+
+  // Phase 2: rewrite. Load every revised-side story file that can define or
+  // anchor auxiliary content; each descriptor's definitions AND anchors are
+  // rewritten through this one set of parsed docs so later descriptors can't
+  // clobber earlier rewrites of the same file.
+  const rewriteFiles = new Map<string, LazyArchiveXml>();
+  const rewritePaths = [
+    'word/document.xml',
+    ...revisedArchive.listFiles().filter((p) => /^word\/(?:header|footer)\d*\.xml$/.test(p)),
+    ...AUXILIARY_PARTS.map((d) => d.partPath),
+  ];
+  for (const path of rewritePaths) {
+    const xml = await revisedArchive.getFile(path);
+    if (xml) rewriteFiles.set(path, new LazyArchiveXml(revisedArchive, path, xml));
+  }
+  const originalDocumentDoc = parseXml(await originalArchive.getDocumentXml());
+
+  const renumbered: RenumberedAuxiliaryId[] = [];
+  for (const { descriptor, collidingIds } of plans) {
+    // Fresh IDs must clear every ID either side defines or references —
+    // the merged output part will contain the union of both sides.
+    let maxUsedId = 0;
+    const revisedPart = rewriteFiles.get(descriptor.partPath)!;
+    const entryElements = revisedPart.doc().getElementsByTagName(descriptor.entryTag);
+    for (let i = 0; i < entryElements.length; i++) {
+      maxUsedId = trackMaxNumericId((entryElements[i] as Element).getAttribute('w:id'), maxUsedId);
+    }
+    for (const id of originalEntryIds.get(descriptor.label) ?? []) {
+      maxUsedId = trackMaxNumericId(id, maxUsedId);
+    }
+    const anchorDocs = [originalDocumentDoc, ...Array.from(rewriteFiles.values(), (f) => f.doc())];
+    for (const doc of anchorDocs) {
+      for (const tag of descriptor.idBearingTags) {
+        const refs = doc.getElementsByTagName(tag);
+        for (let i = 0; i < refs.length; i++) {
+          maxUsedId = trackMaxNumericId((refs[i] as Element).getAttribute('w:id'), maxUsedId);
+        }
+      }
+    }
+
+    let nextId = maxUsedId + 1;
+    const idMap = new Map<string, string>();
+    for (const fromId of collidingIds) {
+      const toId = String(nextId++);
+      idMap.set(fromId, toId);
+      renumbered.push({ label: descriptor.label, fromId, toId });
+    }
+
+    // Rewrite the revised part's definitions and every revised-side anchor
+    // that carries the part's IDs (the definition rewrite is safe as an
+    // id-map application: separator entries never enter the map).
+    revisedPart.applyIdMap([descriptor.entryTag], idMap);
+    for (const file of rewriteFiles.values()) {
+      file.applyIdMap(descriptor.idBearingTags, idMap);
+    }
+  }
+
+  for (const file of rewriteFiles.values()) file.flush();
+
+  return renumbered;
+}

--- a/packages/docx-core/src/baselines/atomizer/pipeline.ts
+++ b/packages/docx-core/src/baselines/atomizer/pipeline.ts
@@ -73,6 +73,12 @@ import {
   DEFAULT_NUMBERING_OPTIONS,
 } from './numberingIntegration.js';
 import { premergeAdjacentRuns } from './premergeRuns.js';
+import {
+  AUXILIARY_PARTS,
+  parseEntries,
+  renumberCollidingAuxiliaryIds,
+  type AuxiliaryPartDescriptor,
+} from './auxiliaryIdCollision.js';
 
 /**
  * Options for the atomizer pipeline.
@@ -736,6 +742,13 @@ export async function compareDocumentsAtomizer(
   const originalArchive = await DocxArchive.load(original);
   const revisedArchive = await DocxArchive.load(revised);
 
+  // Step 1b: Resolve auxiliary ID collisions (issue #107). When both sides
+  // define different content under the same comment/footnote/endnote w:id,
+  // renumber the revised side so no anchor in the merged output can bind to
+  // the other document's definition. Must run before any document.xml
+  // extraction so every downstream step sees the renumbered archive.
+  await renumberCollidingAuxiliaryIds(originalArchive, revisedArchive);
+
   // Step 2: Extract document.xml
   const originalXml = await originalArchive.getDocumentXml();
   const revisedXml = await revisedArchive.getDocumentXml();
@@ -1033,7 +1046,10 @@ export async function compareDocumentsAtomizer(
   // Gated on root comment IDs in the *result* document (not on what the
   // generic merge appended), so the pass runs even when the original already
   // contains the root and revised only adds replies under it (issue #108).
-  const rootCommentIds = collectReferenceIds(newDocumentXml, 'w:commentReference');
+  // Comments anchored on footnote/endnote text count as roots too.
+  const rootCommentIds = await collectStoryReferenceIds(
+    resultArchive, newDocumentXml, 'w:commentReference', null
+  );
   if (rootCommentIds.size > 0) {
     await mergeCommentAncillaryParts(mergeSourceArchive, resultArchive, rootCommentIds);
   }
@@ -1064,50 +1080,33 @@ export async function compareDocumentsAtomizer(
 // definitions). Step 12 in the pipeline picks the correct source per mode.
 // =============================================================================
 
-interface AuxiliaryPartDescriptor {
-  label: string;
-  partPath: string;
-  referenceTag: string;
-  entryTag: string;
-  rootTag: string;
-  contentType: string;
-  relationshipType: string;
-}
-
 export interface AuxiliaryMergeResult {
   mergedIds: Set<string>;
   createdPart: boolean;
 }
 
-const AUXILIARY_PARTS: AuxiliaryPartDescriptor[] = [
-  {
-    label: 'footnote',
-    partPath: 'word/footnotes.xml',
-    referenceTag: 'w:footnoteReference',
-    entryTag: 'w:footnote',
-    rootTag: 'w:footnotes',
-    contentType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.footnotes+xml',
-    relationshipType: 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/footnotes',
-  },
-  {
-    label: 'endnote',
-    partPath: 'word/endnotes.xml',
-    referenceTag: 'w:endnoteReference',
-    entryTag: 'w:endnote',
-    rootTag: 'w:endnotes',
-    contentType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.endnotes+xml',
-    relationshipType: 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/endnotes',
-  },
-  {
-    label: 'comment',
-    partPath: 'word/comments.xml',
-    referenceTag: 'w:commentReference',
-    entryTag: 'w:comment',
-    rootTag: 'w:comments',
-    contentType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.comments+xml',
-    relationshipType: 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/comments',
-  },
-];
+/**
+ * Collect reference IDs across every result story that can host anchors: the
+ * merged document.xml plus the result archive's footnote/endnote parts (Word
+ * allows comments anchored on note text). `excludePartPath` skips the part
+ * whose own definitions are being merged — entries can't reference
+ * themselves.
+ */
+async function collectStoryReferenceIds(
+  resultArchive: DocxArchive,
+  documentXml: string,
+  referenceTag: string,
+  excludePartPath: string | null,
+): Promise<Set<string>> {
+  const ids = collectReferenceIds(documentXml, referenceTag);
+  for (const storyPath of ['word/footnotes.xml', 'word/endnotes.xml']) {
+    if (storyPath === excludePartPath) continue;
+    const storyXml = await resultArchive.getFile(storyPath);
+    if (!storyXml) continue;
+    for (const id of collectReferenceIds(storyXml, referenceTag)) ids.add(id);
+  }
+  return ids;
+}
 
 /**
  * Collect reference IDs from document.xml using DOM parsing.
@@ -1121,21 +1120,6 @@ function collectReferenceIds(documentXml: string, referenceTag: string): Set<str
     if (id) ids.add(id);
   }
   return ids;
-}
-
-/**
- * Parse an auxiliary part and extract entry elements by ID.
- */
-function parseEntries(xml: string, entryTag: string): { doc: Document; entries: Map<string, Element> } {
-  const doc = parseXml(xml);
-  const entries = new Map<string, Element>();
-  const elements = doc.getElementsByTagName(entryTag);
-  for (let i = 0; i < elements.length; i++) {
-    const el = elements[i] as Element;
-    const id = el.getAttribute('w:id');
-    if (id) entries.set(id, el);
-  }
-  return { doc, entries };
 }
 
 /**
@@ -1153,7 +1137,13 @@ async function mergeAuxiliaryPartDefinitions(
 ): Promise<AuxiliaryMergeResult> {
   const result: AuxiliaryMergeResult = { mergedIds: new Set(), createdPart: false };
 
-  const referencedIds = collectReferenceIds(documentXml, descriptor.referenceTag);
+  // Anchors may live in the merged body or on note text in the result's
+  // footnote/endnote stories. AUXILIARY_PARTS merges notes before comments,
+  // so by the comment pass the note stories already carry any merged-in
+  // comment anchors.
+  const referencedIds = await collectStoryReferenceIds(
+    resultArchive, documentXml, descriptor.referenceTag, descriptor.partPath
+  );
   if (referencedIds.size === 0) return result;
 
   const sourcePartXml = await sourceArchive.getFile(descriptor.partPath);
@@ -1511,6 +1501,7 @@ const COMMENTS_EXTENDED_DESCRIPTOR: AuxiliaryPartDescriptor = {
   rootTag: 'w15:commentsEx',
   contentType: 'application/vnd.ms-word.commentsExtended+xml',
   relationshipType: 'http://schemas.microsoft.com/office/2011/relationships/commentsExtended',
+  idBearingTags: [], // keyed by w15:paraId, not w:id
 };
 
 const PEOPLE_DESCRIPTOR: AuxiliaryPartDescriptor = {
@@ -1521,6 +1512,7 @@ const PEOPLE_DESCRIPTOR: AuxiliaryPartDescriptor = {
   rootTag: 'w15:people',
   contentType: 'application/vnd.ms-word.people+xml',
   relationshipType: 'http://schemas.microsoft.com/office/2011/relationships/people',
+  idBearingTags: [], // keyed by w15:author, not w:id
 };
 
 async function mergePeople(

--- a/packages/docx-core/src/integration/auxiliary-id-collision.test.ts
+++ b/packages/docx-core/src/integration/auxiliary-id-collision.test.ts
@@ -1,0 +1,387 @@
+/**
+ * Integration Tests — Auxiliary Part ID Collisions (regression for issue #107)
+ *
+ * Auxiliary IDs reset to 1 per document, so two independently authored
+ * documents routinely define *different* comments/footnotes/endnotes under
+ * the same w:id. The definition merge used to treat "ID already present in
+ * the result part" as success and skip the source side, leaving one side's
+ * anchors bound to the other side's content (or missing entirely).
+ *
+ * The fix renumbers the revised side's colliding IDs before comparison, so
+ * each anchor in the output resolves to the definition it was authored
+ * against, in both reconstruction modes.
+ *
+ * Reported in https://github.com/UseJunior/safe-docx/issues/107 (surfaced by
+ * peer review of PR #101).
+ */
+
+import { describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { compareDocuments } from '../index.js';
+import { buildSyntheticDocx, getResultParts } from './synthetic-docx-fixture.js';
+import { parseXml } from '../primitives/xml.js';
+
+/** Collect w:id values of every `tag` element in the XML. */
+function idsOf(xml: string, tag: string): Set<string> {
+  const ids = new Set<string>();
+  const elements = parseXml(xml).getElementsByTagName(tag);
+  for (let i = 0; i < elements.length; i++) {
+    const id = elements[i]!.getAttribute('w:id');
+    if (id) ids.add(id);
+  }
+  return ids;
+}
+
+/** Map each auxiliary entry's w:id to its author (comments) and text. */
+function entriesById(
+  partXml: string,
+  entryTag: string
+): Map<string, { author: string | null; text: string }> {
+  const map = new Map<string, { author: string | null; text: string }>();
+  const elements = parseXml(partXml).getElementsByTagName(entryTag);
+  for (let i = 0; i < elements.length; i++) {
+    const el = elements[i]!;
+    const id = el.getAttribute('w:id');
+    if (!id) continue;
+    map.set(id, { author: el.getAttribute('w:author'), text: el.textContent ?? '' });
+  }
+  return map;
+}
+
+/**
+ * The issue-#107 acceptance invariant: every anchor in document.xml resolves
+ * to a definition, and each side's content is present under its own ID.
+ */
+function expectAnchorsResolve(
+  documentXml: string,
+  partXml: string,
+  referenceTag: string,
+  entryTag: string
+): Map<string, { author: string | null; text: string }> {
+  const referencedIds = idsOf(documentXml, referenceTag);
+  const definitions = entriesById(partXml, entryTag);
+  expect(referencedIds.size).toBeGreaterThan(0);
+  for (const id of referencedIds) {
+    expect(definitions.has(id), `anchor w:id="${id}" has no ${entryTag} definition`).toBe(true);
+  }
+  return definitions;
+}
+
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({ feature: 'Auxiliary Part ID Collisions' });
+
+describe('Auxiliary part ID collisions (issue #107)', () => {
+  describe('Comment w:id="1" means different content on each side', () => {
+    const buildInputs = async () => {
+      const original = await buildSyntheticDocx({
+        paragraphs: ['First paragraph', 'Commented paragraph', 'Third paragraph'],
+        commentOnParagraph: 1,
+        commentText: 'Original comment',
+        commentAuthor: 'A',
+      });
+      const revised = await buildSyntheticDocx({
+        paragraphs: ['First paragraph', 'Commented paragraph', 'Third paragraph'],
+        commentOnParagraph: 1,
+        commentText: 'Revised comment',
+        commentAuthor: 'B',
+      });
+      return { original, revised };
+    };
+
+    const expectBothCommentsCorrectlyBound = async (resultDoc: Buffer) => {
+      const parts = await getResultParts(resultDoc);
+      expect(parts.commentsXml).not.toBeNull();
+
+      const definitions = expectAnchorsResolve(
+        parts.documentXml, parts.commentsXml!, 'w:commentReference', 'w:comment'
+      );
+
+      // Both threads survive, each under its own ID with its own author.
+      const byText = new Map(
+        Array.from(definitions.entries()).map(([id, def]) => [def.text, { id, author: def.author }])
+      );
+      expect(byText.get('Original comment')?.author).toBe('A');
+      expect(byText.get('Revised comment')?.author).toBe('B');
+      expect(byText.get('Original comment')!.id).not.toBe(byText.get('Revised comment')!.id);
+
+      // Range markers were renumbered in lockstep with the references.
+      const startIds = idsOf(parts.documentXml, 'w:commentRangeStart');
+      const endIds = idsOf(parts.documentXml, 'w:commentRangeEnd');
+      expect(startIds).toEqual(endIds);
+      for (const id of startIds) {
+        expect(definitions.has(id), `commentRangeStart w:id="${id}" has no definition`).toBe(true);
+      }
+    };
+
+    test('rebuild binds each anchor to its own side\'s comment', async ({ given, when, then }: AllureBddContext) => {
+      let original: Buffer, revised: Buffer;
+      await given('both sides define a different comment under w:id="1"', async () => {
+        ({ original, revised } = await buildInputs());
+      });
+
+      let result: Awaited<ReturnType<typeof compareDocuments>>;
+      await when('documents are compared in rebuild mode', async () => {
+        result = await compareDocuments(original, revised, {
+          engine: 'atomizer',
+          reconstructionMode: 'rebuild',
+        });
+      });
+
+      await then('both comments ship under distinct IDs and every anchor resolves', async () => {
+        expect(result.reconstructionModeUsed).toBe('rebuild');
+        await expectBothCommentsCorrectlyBound(result.document);
+      });
+    });
+
+    test('inplace binds each anchor to its own side\'s comment', async ({ given, when, then }: AllureBddContext) => {
+      let original: Buffer, revised: Buffer;
+      await given('both sides define a different comment under w:id="1"', async () => {
+        ({ original, revised } = await buildInputs());
+      });
+
+      let result: Awaited<ReturnType<typeof compareDocuments>>;
+      await when('documents are compared in inplace mode', async () => {
+        result = await compareDocuments(original, revised, {
+          engine: 'atomizer',
+          reconstructionMode: 'inplace',
+        });
+      });
+
+      await then('both comments ship under distinct IDs and every anchor resolves', async () => {
+        await expectBothCommentsCorrectlyBound(result.document);
+      });
+    });
+  });
+
+  describe('Footnote w:id="1" means different content on each side', () => {
+    test('rebuild ships both footnotes under distinct IDs', async ({ given, when, then }: AllureBddContext) => {
+      let original: Buffer, revised: Buffer;
+      await given('both sides define a different footnote under w:id="1"', async () => {
+        original = await buildSyntheticDocx({
+          paragraphs: ['First paragraph', 'Second paragraph'],
+          footnoteOnParagraph: 0,
+          footnoteText: 'Original footnote',
+        });
+        revised = await buildSyntheticDocx({
+          paragraphs: ['First paragraph', 'Second paragraph'],
+          footnoteOnParagraph: 0,
+          footnoteText: 'Revised footnote',
+        });
+      });
+
+      let result: Awaited<ReturnType<typeof compareDocuments>>;
+      await when('documents are compared in rebuild mode', async () => {
+        result = await compareDocuments(original, revised, {
+          engine: 'atomizer',
+          reconstructionMode: 'rebuild',
+        });
+      });
+
+      await then('both footnotes ship and every reference resolves', async () => {
+        expect(result.reconstructionModeUsed).toBe('rebuild');
+        const parts = await getResultParts(result.document);
+        expect(parts.footnotesXml).not.toBeNull();
+
+        const definitions = expectAnchorsResolve(
+          parts.documentXml, parts.footnotesXml!, 'w:footnoteReference', 'w:footnote'
+        );
+        const texts = new Set(Array.from(definitions.values()).map((d) => d.text));
+        expect(texts).toContain('Original footnote');
+        expect(texts).toContain('Revised footnote');
+      });
+    });
+  });
+
+  describe('Endnote w:id="1" means different content on each side', () => {
+    test('rebuild ships both endnotes under distinct IDs', async ({ given, when, then }: AllureBddContext) => {
+      let original: Buffer, revised: Buffer;
+      await given('both sides define a different endnote under w:id="1"', async () => {
+        original = await buildSyntheticDocx({
+          paragraphs: ['First paragraph', 'Second paragraph'],
+          endnoteOnParagraph: 0,
+          endnoteText: 'Original endnote',
+        });
+        revised = await buildSyntheticDocx({
+          paragraphs: ['First paragraph', 'Second paragraph'],
+          endnoteOnParagraph: 0,
+          endnoteText: 'Revised endnote',
+        });
+      });
+
+      let result: Awaited<ReturnType<typeof compareDocuments>>;
+      await when('documents are compared in rebuild mode', async () => {
+        result = await compareDocuments(original, revised, {
+          engine: 'atomizer',
+          reconstructionMode: 'rebuild',
+        });
+      });
+
+      await then('both endnotes ship and every reference resolves', async () => {
+        expect(result.reconstructionModeUsed).toBe('rebuild');
+        const parts = await getResultParts(result.document);
+        expect(parts.endnotesXml).not.toBeNull();
+
+        const definitions = expectAnchorsResolve(
+          parts.documentXml, parts.endnotesXml!, 'w:endnoteReference', 'w:endnote'
+        );
+        const texts = new Set(Array.from(definitions.values()).map((d) => d.text));
+        expect(texts).toContain('Original endnote');
+        expect(texts).toContain('Revised endnote');
+      });
+    });
+  });
+
+  describe('Comment anchored on footnote text (note-story anchors)', () => {
+    test('rebuild renumbers the footnote-hosted comment anchor and ships its definition', async ({ given, when, then }: AllureBddContext) => {
+      let original: Buffer, revised: Buffer;
+      await given('both w:id="1" spaces collide and the revised comment is anchored only inside its footnote', async () => {
+        original = await buildSyntheticDocx({
+          paragraphs: ['First paragraph', 'Second paragraph'],
+          footnoteOnParagraph: 0,
+          footnoteText: 'Original footnote',
+          commentOnParagraph: 1,
+          commentText: 'Original comment',
+          commentAuthor: 'A',
+        });
+
+        // The synthetic fixture can't anchor a comment inside a footnote
+        // body, and this nesting is the subject of the test (surfaced by
+        // peer review of this fix), so splice it in via archive mutation.
+        const baseRevised = await buildSyntheticDocx({
+          paragraphs: ['First paragraph', 'Second paragraph'],
+          footnoteOnParagraph: 0,
+          footnoteText: 'Revised footnote',
+        });
+        const JSZip = (await import('jszip')).default;
+        const zip = await JSZip.loadAsync(baseRevised);
+
+        const footnotesXml = await zip.file('word/footnotes.xml')!.async('string');
+        zip.file(
+          'word/footnotes.xml',
+          footnotesXml.replace(
+            '<w:t>Revised footnote</w:t></w:r>',
+            '<w:t>Revised footnote</w:t></w:r>' +
+              '<w:r><w:rPr><w:rStyle w:val="CommentReference"/></w:rPr><w:commentReference w:id="1"/></w:r>'
+          )
+        );
+
+        zip.file(
+          'word/comments.xml',
+          `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+            `<w:comments xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"` +
+            ` xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">` +
+            `<w:comment w:id="1" w:author="B" w:date="2025-01-01T00:00:00Z">` +
+            `<w:p w14:paraId="00000009"><w:r><w:t>Revised comment</w:t></w:r></w:p>` +
+            `</w:comment></w:comments>`
+        );
+
+        const contentTypes = await zip.file('[Content_Types].xml')!.async('string');
+        zip.file(
+          '[Content_Types].xml',
+          contentTypes.replace(
+            '</Types>',
+            `<Override PartName="/word/comments.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.comments+xml"/></Types>`
+          )
+        );
+        const rels = await zip.file('word/_rels/document.xml.rels')!.async('string');
+        zip.file(
+          'word/_rels/document.xml.rels',
+          rels.replace(
+            '</Relationships>',
+            `<Relationship Id="rId99" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/comments" Target="comments.xml"/></Relationships>`
+          )
+        );
+
+        revised = (await zip.generateAsync({ type: 'nodebuffer' })) as Buffer;
+      });
+
+      let result: Awaited<ReturnType<typeof compareDocuments>>;
+      await when('documents are compared in rebuild mode', async () => {
+        result = await compareDocuments(original, revised, {
+          engine: 'atomizer',
+          reconstructionMode: 'rebuild',
+        });
+      });
+
+      await then('the footnote-hosted anchor binds to the revised comment, not the original', async () => {
+        expect(result.reconstructionModeUsed).toBe('rebuild');
+        const parts = await getResultParts(result.document);
+        expect(parts.footnotesXml).not.toBeNull();
+        expect(parts.commentsXml).not.toBeNull();
+
+        const commentDefs = entriesById(parts.commentsXml!, 'w:comment');
+        const footnoteDefs = entriesById(parts.footnotesXml!, 'w:footnote');
+
+        // Both footnotes and both comments ship.
+        const footnoteTexts = new Set(Array.from(footnoteDefs.values()).map((d) => d.text));
+        expect(footnoteTexts).toContain('Original footnote');
+        const commentTexts = new Set(Array.from(commentDefs.values()).map((d) => d.text));
+        expect(commentTexts).toContain('Original comment');
+        expect(commentTexts).toContain('Revised comment');
+
+        // The revised footnote's internal comment anchor resolves to the
+        // REVISED comment (pre-fix it kept w:id="1" → original's content).
+        const revisedFootnote = Array.from(footnoteDefs.entries())
+          .find(([, d]) => d.text.includes('Revised footnote'));
+        expect(revisedFootnote).toBeDefined();
+        const revisedFootnoteEl = parseXml(parts.footnotesXml!)
+          .getElementsByTagName('w:footnote');
+        let anchorId: string | null = null;
+        for (let i = 0; i < revisedFootnoteEl.length; i++) {
+          const el = revisedFootnoteEl[i]!;
+          if ((el.textContent ?? '').includes('Revised footnote')) {
+            anchorId = el.getElementsByTagName('w:commentReference')[0]?.getAttribute('w:id') ?? null;
+          }
+        }
+        expect(anchorId).not.toBeNull();
+        expect(commentDefs.get(anchorId!)?.text).toBe('Revised comment');
+        expect(commentDefs.get(anchorId!)?.author).toBe('B');
+
+        // No dangling comment anchors anywhere (body or note stories).
+        for (const xml of [parts.documentXml, parts.footnotesXml!]) {
+          for (const id of idsOf(xml, 'w:commentReference')) {
+            expect(commentDefs.has(id), `dangling comment anchor w:id="${id}"`).toBe(true);
+          }
+        }
+      });
+    });
+  });
+
+  describe('Identical comment on both sides is NOT a collision', () => {
+    test('shared comment keeps its ID and is not duplicated', async ({ given, when, then }: AllureBddContext) => {
+      let original: Buffer, revised: Buffer;
+      await given('both sides carry the byte-identical comment under w:id="1"', async () => {
+        original = await buildSyntheticDocx({
+          paragraphs: ['First paragraph', 'Commented paragraph'],
+          commentOnParagraph: 1,
+          commentText: 'Shared comment',
+          commentAuthor: 'Alice',
+        });
+        revised = await buildSyntheticDocx({
+          paragraphs: ['First paragraph', 'Commented paragraph'],
+          commentOnParagraph: 1,
+          commentText: 'Shared comment',
+          commentAuthor: 'Alice',
+        });
+      });
+
+      let result: Awaited<ReturnType<typeof compareDocuments>>;
+      await when('documents are compared in rebuild mode', async () => {
+        result = await compareDocuments(original, revised, {
+          engine: 'atomizer',
+          reconstructionMode: 'rebuild',
+        });
+      });
+
+      await then('exactly one comment definition ships under the original ID', async () => {
+        const parts = await getResultParts(result.document);
+        expect(parts.commentsXml).not.toBeNull();
+
+        const definitions = entriesById(parts.commentsXml!, 'w:comment');
+        expect(Array.from(definitions.keys())).toEqual(['1']);
+        expect(idsOf(parts.documentXml, 'w:commentReference')).toEqual(new Set(['1']));
+      });
+    });
+  });
+});

--- a/packages/docx-core/src/integration/synthetic-docx-fixture.ts
+++ b/packages/docx-core/src/integration/synthetic-docx-fixture.ts
@@ -5,6 +5,8 @@ export interface SyntheticDocxOptions {
   paragraphs: string[];
   footnoteOnParagraph?: number;
   footnoteText?: string;
+  endnoteOnParagraph?: number;
+  endnoteText?: string;
   commentOnParagraph?: number;
   commentText?: string;
   commentAuthor?: string;
@@ -55,6 +57,7 @@ export interface SyntheticDocxOptions {
 
 export async function buildSyntheticDocx(opts: SyntheticDocxOptions): Promise<Buffer> {
   const hasFootnote = opts.footnoteOnParagraph != null;
+  const hasEndnote = opts.endnoteOnParagraph != null;
   const hasComment = opts.commentOnParagraph != null;
   const hasCommentSpan = opts.commentSpanParagraphs != null;
   const hasBookmark = opts.bookmarkOnParagraph != null;
@@ -81,6 +84,10 @@ export async function buildSyntheticDocx(opts: SyntheticDocxOptions): Promise<Bu
 
     if (hasFootnote && idx === opts.footnoteOnParagraph) {
       extra += `<w:r><w:rPr><w:rStyle w:val="FootnoteReference"/></w:rPr><w:footnoteReference w:id="1"/></w:r>`;
+    }
+
+    if (hasEndnote && idx === opts.endnoteOnParagraph) {
+      extra += `<w:r><w:rPr><w:rStyle w:val="EndnoteReference"/></w:rPr><w:endnoteReference w:id="1"/></w:r>`;
     }
 
     if (hasComment && idx === opts.commentOnParagraph) {
@@ -173,6 +180,25 @@ export async function buildSyntheticDocx(opts: SyntheticDocxOptions): Promise<Bu
     rIdCounter++;
     docRelEntries.push(
       `<Relationship Id="rId${rIdCounter}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/footnotes" Target="footnotes.xml"/>`
+    );
+  }
+
+  if (hasEndnote) {
+    const enText = opts.endnoteText ?? 'Test endnote';
+    const endnotesXml =
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+      `<w:endnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
+      `<w:endnote w:type="separator" w:id="-1"><w:p><w:r><w:separator/></w:r></w:p></w:endnote>` +
+      `<w:endnote w:type="continuationSeparator" w:id="0"><w:p><w:r><w:continuationSeparator/></w:r></w:p></w:endnote>` +
+      `<w:endnote w:id="1"><w:p><w:r><w:t>${enText}</w:t></w:r></w:p></w:endnote>` +
+      `</w:endnotes>`;
+    zip.file('word/endnotes.xml', endnotesXml);
+    contentTypeParts.push(
+      `<Override PartName="/word/endnotes.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.endnotes+xml"/>`
+    );
+    rIdCounter++;
+    docRelEntries.push(
+      `<Relationship Id="rId${rIdCounter}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/endnotes" Target="endnotes.xml"/>`
     );
   }
 


### PR DESCRIPTION
## Summary

Fixes #107 — auxiliary part ID collisions silently binding anchors to the wrong document's content.

`mergeAuxiliaryPartDefinitions` treated "this `w:id` already exists in the result part" as success and skipped the source-side definition. Since comment/footnote/endnote IDs reset to 1 per document, independently authored inputs routinely define *different* content under the same ID — the output then had anchors bound to the other side's comment/footnote/endnote, in both reconstruction modes.

## Strategy decision (acceptance item)

#107 offered **renumber** vs. **detect-and-flag**. This PR implements **renumbering**, because detect-and-flag would fail comparison for any two independently authored commented documents — a core use case — and there is no collision-free mode to flag into. The decision and its rationale are documented in the new module's JSDoc (`auxiliaryIdCollision.ts`).

## How it works

- **Step 1b (new), at archive-load time:** for every auxiliary `w:id` defined with *different* content on both sides, the revised archive is renumbered in place into a fresh ID space — the part definition plus every ID-bearing anchor (`w:commentReference`, `w:commentRangeStart/End`, `w:footnoteReference`, `w:endnoteReference`) across all story parts: `document.xml`, headers/footers, **and the note stories themselves** (Word allows comments anchored on footnote/endnote text).
- Downstream, colliding anchors differ by ID, the LCS emits them as delete/insert pairs, and the existing definition merge — extended to collect referenced IDs from the result's note stories as well as the body — imports the renumbered definition. Each anchor resolves to the content it was authored against.
- **Content-identical IDs are left untouched**, so derived-document comparisons keep matching their anchors as unchanged (no duplicate definitions).
- Attribute-order differences between semantically identical entries cause a harmless extra renumber — documented as intentional asymmetry (noise, never a wrong binding).

## Acceptance (from #107)

- [x] Strategy chosen and documented (renumber; module JSDoc)
- [x] Regression: both sides `w:id="1"` for different **comments** → each anchor resolves to the correct content (rebuild + inplace)
- [x] Same regression for **footnotes** and **endnotes** (synthetic fixture gained endnote support)
- [x] Extra: comment anchored on **footnote text** with colliding IDs (peer-review finding) — anchor renumbered in the note story and definition imported
- [x] Control: identical-content IDs are not renumbered or duplicated

All collision tests red-checked: they fail with Step 1b disabled.

## Peer review

Reviewed pre-PR by Codex (`codex exec`) and agy, both dynamic with execution traces. Codex's High finding (note-story anchors not rewritten → wrong binding/dangling definition, reproduced with an in-memory DOCX pair) is fixed in this PR with a dedicated regression test. Both reviewers' Medium/minor note on attribute-order false mismatches is documented as intentional.

## Known residual (out of scope)

`commentsExtended.xml` / `commentsIds.xml` are keyed by `w15:paraId`, which can collide across independent documents the same way; renumbering `w:id` does not address that axis. Follow-up issue to be filed.

## Testing

- `npm run build && npm run lint:workspaces && npm run test:run && npm run check:spec-coverage && npm run check:conformance-citations && npm run check:conformance-doc` — all green
- New `auxiliary-id-collision.test.ts`: 6 tests (5 collision scenarios + 1 no-collision control)
