### PR TITLE
fix(docx-core): reconstruct explicit moveFromRange*/moveToRange* markers on rebuild

### DIFF
--- a/packages/docx-core/src/atomizer.test.ts
+++ b/packages/docx-core/src/atomizer.test.ts
@@ -741,6 +741,108 @@ describe('atomizeTree', () => {
   });
 });
 
+describe('move-range marker atomization (issue #110)', () => {
+  const mockPart: OpcPart = {
+    uri: 'word/document.xml',
+    contentType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml',
+  };
+
+  function paragraphWithTrackedMove(): Element {
+    return el('w:p', {}, [
+      el('w:moveFromRangeStart', {
+        'w:id': '300',
+        'w:name': 'userMove1',
+        'w:author': 'Mover',
+        'w:date': '2025-01-01T00:00:00Z',
+      }),
+      el('w:moveFrom', { 'w:id': '301', 'w:author': 'Mover', 'w:date': '2025-01-01T00:00:00Z' }, [
+        el('w:r', {}, [el('w:delText', {}, undefined, 'moved')]),
+      ]),
+      el('w:moveFromRangeEnd', { 'w:id': '300' }),
+      el('w:moveToRangeStart', {
+        'w:id': '302',
+        'w:name': 'userMove1',
+        'w:author': 'Mover',
+        'w:date': '2025-01-01T00:00:00Z',
+      }),
+      el('w:moveTo', { 'w:id': '303', 'w:author': 'Mover', 'w:date': '2025-01-01T00:00:00Z' }, [
+        el('w:r', {}, [el('w:t', {}, undefined, 'moved')]),
+      ]),
+      el('w:moveToRangeEnd', { 'w:id': '302' }),
+    ]);
+  }
+
+  test('move-range markers inside w:p become atoms when atomizeParagraphLevelMarkers is true', async ({ given, when, then }: AllureBddContext) => {
+    let body: Element;
+    let atoms: ReturnType<typeof atomizeTree>['atoms'];
+
+    await given('a body whose paragraph carries an explicit tracked move with range markers', () => {
+      body = el('w:body', {}, [paragraphWithTrackedMove()]);
+    });
+
+    await when('the tree is atomized with paragraph-level markers enabled', () => {
+      ({ atoms } = atomizeTree(body, [], mockPart, { atomizeParagraphLevelMarkers: true }));
+    });
+
+    await then('all four move-range marker kinds appear as atoms', () => {
+      const tags = atoms.map((a) => a.contentElement.tagName);
+      expect(tags).toContain('w:moveFromRangeStart');
+      expect(tags).toContain('w:moveFromRangeEnd');
+      expect(tags).toContain('w:moveToRangeStart');
+      expect(tags).toContain('w:moveToRangeEnd');
+    });
+  });
+
+  test('move-range markers are NOT atomized when atomizeParagraphLevelMarkers is false', async ({ given, when, then }: AllureBddContext) => {
+    let body: Element;
+    let atoms: ReturnType<typeof atomizeTree>['atoms'];
+
+    await given('a body whose paragraph carries an explicit tracked move with range markers', () => {
+      body = el('w:body', {}, [paragraphWithTrackedMove()]);
+    });
+
+    await when('the tree is atomized with default options', () => {
+      ({ atoms } = atomizeTree(body, [], mockPart));
+    });
+
+    await then('no move-range marker atoms enter the stream', () => {
+      const tags = atoms.map((a) => a.contentElement.tagName);
+      expect(tags).not.toContain('w:moveFromRangeStart');
+      expect(tags).not.toContain('w:moveFromRangeEnd');
+      expect(tags).not.toContain('w:moveToRangeStart');
+      expect(tags).not.toContain('w:moveToRangeEnd');
+    });
+  });
+
+  test('body-level move-range markers stay out of the atom stream', async ({ given, when, then }: AllureBddContext) => {
+    let body: Element;
+    let atoms: ReturnType<typeof atomizeTree>['atoms'];
+
+    await given('move-range markers that are siblings of w:p at body level', () => {
+      body = el('w:body', {}, [
+        el('w:moveFromRangeStart', {
+          'w:id': '300',
+          'w:name': 'userMove1',
+          'w:author': 'Mover',
+          'w:date': '2025-01-01T00:00:00Z',
+        }),
+        el('w:p', {}, [el('w:r', {}, [el('w:t', {}, undefined, 'text')])]),
+        el('w:moveFromRangeEnd', { 'w:id': '300' }),
+      ]);
+    });
+
+    await when('the tree is atomized with paragraph-level markers enabled', () => {
+      ({ atoms } = atomizeTree(body, [], mockPart, { atomizeParagraphLevelMarkers: true }));
+    });
+
+    await then('only the paragraph content is atomized — markers are scaffold-handled', () => {
+      const tags = atoms.map((a) => a.contentElement.tagName);
+      expect(tags).not.toContain('w:moveFromRangeStart');
+      expect(tags).not.toContain('w:moveFromRangeEnd');
+    });
+  });
+});
+
 describe('empty paragraph context hashing', () => {
   const mockPart: OpcPart = {
     uri: 'word/document.xml',

--- a/packages/docx-core/src/atomizer.ts
+++ b/packages/docx-core/src/atomizer.ts
@@ -223,18 +223,25 @@ const LEAF_NODE_TAGS = new Set([
  * rebuild reconstructor emits them as siblings of <w:r>, not leaves wrapped in
  * a synthetic run.
  *
- * Scope: commentRange and bookmark only. moveFromRange / moveToRange and
- * permStart / permEnd are deferred to follow-up issues — moveRange collides
- * with the synthetic emission in wrapWithMoveFrom and wrapWithMoveTo, and
- * permStart / permEnd needs fixture coverage.
+ * Scope: commentRange, bookmark, and moveFromRange / moveToRange. Explicit
+ * move-range markers coexist with the synthetic emission in wrapWithMoveFrom
+ * and wrapWithMoveTo: the reconstructor suppresses synthesis for paragraphs
+ * whose atom stream already carries explicit markers of the same kind, so the
+ * two paths never double-emit. permStart / permEnd is deferred to a follow-up
+ * issue — it needs fixture coverage.
  *
  * @conformance ECMA-376 edition 5, Part 1 § 17.13.5
+ * @see https://github.com/UseJunior/safe-docx/issues/110
  */
 export const PARAGRAPH_LEVEL_TAGS = new Set([
   'w:commentRangeStart',
   'w:commentRangeEnd',
   'w:bookmarkStart',
   'w:bookmarkEnd',
+  'w:moveFromRangeStart',
+  'w:moveFromRangeEnd',
+  'w:moveToRangeStart',
+  'w:moveToRangeEnd',
 ]);
 
 /**
@@ -275,8 +282,9 @@ export interface AtomizeTreeOptions {
    */
   splitTextIntoWords?: boolean;
   /**
-   * Atomize paragraph-level markers (commentRangeStart/End, bookmarkStart/End)
-   * so the rebuild reconstructor can re-emit them as siblings of <w:r>.
+   * Atomize paragraph-level markers (commentRange*, bookmark*, moveFromRange*,
+   * moveToRange* — see PARAGRAPH_LEVEL_TAGS) so the rebuild reconstructor can
+   * re-emit them as siblings of <w:r>.
    *
    * MUST be false for inplace mode. Inplace handlers are run-anchored and
    * silently no-op on atoms with no sourceRunElement, but inplace's bookmark
@@ -303,7 +311,8 @@ export function isLeafNode(element: WmlElement): boolean {
 /**
  * Check if an element is a paragraph-level OOXML marker.
  *
- * Paragraph-level markers (commentRangeStart/End, bookmarkStart/End) are
+ * Paragraph-level markers (PARAGRAPH_LEVEL_TAGS: commentRange*, bookmark*,
+ * moveFromRange*, moveToRange*) are
  * atomized only when they sit inside a <w:p> ancestor — body/table-sibling
  * placements stay out of the atom stream and are handled by the scaffold-strip
  * block in the reconstructor.

--- a/packages/docx-core/src/baselines/atomizer/documentReconstructor-moveRanges.test.ts
+++ b/packages/docx-core/src/baselines/atomizer/documentReconstructor-moveRanges.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Tests for move-range marker reconstruction (issue #110).
+ *
+ * Validates that the rebuild reconstructor:
+ * - still synthesizes exactly one w:moveFromRangeStart/End (resp.
+ *   w:moveToRangeStart/End) pair per detected move when the paragraph carries
+ *   no explicit markers, and
+ * - suppresses that synthetic emission when explicit move-range marker atoms
+ *   (now in PARAGRAPH_LEVEL_TAGS) are present in the same paragraph, so the
+ *   explicit pair is emitted exactly once instead of being doubled.
+ */
+
+import { describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
+import { el } from '../../testing/dom-test-helpers.js';
+import { reconstructDocument } from './documentReconstructor.js';
+import type { ComparisonUnitAtom, OpcPart } from '../../core-types.js';
+import { CorrelationStatus } from '../../core-types.js';
+
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({ feature: 'Document Reconstructor Move Ranges' });
+
+const PART: OpcPart = { uri: 'word/document.xml', contentType: 'text/xml' };
+
+const MINIMAL_DOCXML = [
+  '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>',
+  '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">',
+  '<w:body>',
+  '<w:p><w:r><w:t>placeholder</w:t></w:r></w:p>',
+  '</w:body>',
+  '</w:document>',
+].join('');
+
+const OPTS = { author: 'Test', date: new Date('2025-01-01T00:00:00Z') };
+
+function makeTextAtom(
+  text: string,
+  status: CorrelationStatus,
+  paragraphIndex = 0
+): ComparisonUnitAtom {
+  const textEl = el('w:t', {}, undefined, text);
+  const run = el('w:r', {}, [textEl]);
+  const paragraph = el('w:p', {}, [run]);
+
+  return {
+    sha1Hash: `hash-${text}`,
+    correlationStatus: status,
+    contentElement: textEl,
+    ancestorElements: [paragraph, run],
+    ancestorUnids: [],
+    part: PART,
+    paragraphIndex,
+    rPr: null,
+  };
+}
+
+/**
+ * Explicit paragraph-level move-range marker atom, as produced by
+ * atomizeTree with atomizeParagraphLevelMarkers: true. The marker is a
+ * direct child of <w:p> in the source, so its ancestry has no <w:r>.
+ */
+function makeMarkerAtom(
+  tagName: string,
+  attrs: Record<string, string>,
+  status: CorrelationStatus,
+  paragraphIndex = 0
+): ComparisonUnitAtom {
+  const markerEl = el(tagName, attrs);
+  const paragraph = el('w:p', {}, [markerEl]);
+
+  return {
+    sha1Hash: `hash-${tagName}-${attrs['w:id']}`,
+    correlationStatus: status,
+    contentElement: markerEl,
+    ancestorElements: [paragraph],
+    ancestorUnids: [],
+    part: PART,
+    paragraphIndex,
+    rPr: null,
+  };
+}
+
+function count(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
+
+describe('Move-range marker reconstruction (issue #110)', () => {
+  test('detected move without explicit markers synthesizes exactly one range pair per side', async ({ given, when, then }: AllureBddContext) => {
+    let atoms: ComparisonUnitAtom[];
+    let result: string;
+
+    await given('a MovedSource atom and a MovedDestination atom in marker-free paragraphs', () => {
+      const source = makeTextAtom('moved text', CorrelationStatus.MovedSource, 0);
+      source.moveName = 'move1';
+      const dest = makeTextAtom('moved text', CorrelationStatus.MovedDestination, 1);
+      dest.moveName = 'move1';
+      atoms = [source, dest];
+    });
+
+    await when('reconstructDocument is called', () => {
+      result = reconstructDocument(atoms, MINIMAL_DOCXML, OPTS);
+    });
+
+    await then('exactly one synthetic moveFromRange and moveToRange pair is emitted', () => {
+      expect(count(result, 'w:moveFromRangeStart')).toBe(1);
+      expect(count(result, 'w:moveFromRangeEnd')).toBe(1);
+      expect(count(result, 'w:moveToRangeStart')).toBe(1);
+      expect(count(result, 'w:moveToRangeEnd')).toBe(1);
+      expect(result).toContain('w:name="move1"');
+      expect(result).toContain('<w:moveFrom ');
+      expect(result).toContain('<w:moveTo ');
+    });
+  });
+
+  test('explicit moveFromRange markers in the paragraph suppress synthetic range emission', async ({ given, when, then, and }: AllureBddContext) => {
+    let atoms: ComparisonUnitAtom[];
+    let result: string;
+
+    await given('explicit moveFromRangeStart/End marker atoms bracketing a MovedSource atom', () => {
+      const start = makeMarkerAtom(
+        'w:moveFromRangeStart',
+        { 'w:id': '300', 'w:name': 'userMove1', 'w:author': 'Mover', 'w:date': '2025-01-01T00:00:00Z' },
+        CorrelationStatus.Equal,
+        0
+      );
+      const moved = makeTextAtom('moved text', CorrelationStatus.MovedSource, 0);
+      moved.moveName = 'move1';
+      const end = makeMarkerAtom(
+        'w:moveFromRangeEnd',
+        { 'w:id': '300' },
+        CorrelationStatus.Equal,
+        0
+      );
+      atoms = [start, moved, end];
+    });
+
+    await when('reconstructDocument is called', () => {
+      result = reconstructDocument(atoms, MINIMAL_DOCXML, OPTS);
+    });
+
+    await then('only the explicit range pair survives — no synthetic duplicate', () => {
+      expect(count(result, 'w:moveFromRangeStart')).toBe(1);
+      expect(count(result, 'w:moveFromRangeEnd')).toBe(1);
+      expect(result).toContain('w:name="userMove1"');
+      expect(result).not.toContain('w:name="move1"');
+    });
+
+    await and('the w:moveFrom wrapper is still emitted around the moved content', () => {
+      expect(count(result, '<w:moveFrom ')).toBe(1);
+      expect(result).toContain('<w:delText');
+    });
+  });
+
+  test('explicit moveToRange markers in the paragraph suppress synthetic range emission', async ({ given, when, then, and }: AllureBddContext) => {
+    let atoms: ComparisonUnitAtom[];
+    let result: string;
+
+    await given('explicit moveToRangeStart/End marker atoms bracketing a MovedDestination atom', () => {
+      const start = makeMarkerAtom(
+        'w:moveToRangeStart',
+        { 'w:id': '302', 'w:name': 'userMove1', 'w:author': 'Mover', 'w:date': '2025-01-01T00:00:00Z' },
+        CorrelationStatus.Equal,
+        0
+      );
+      const moved = makeTextAtom('moved text', CorrelationStatus.MovedDestination, 0);
+      moved.moveName = 'move1';
+      const end = makeMarkerAtom(
+        'w:moveToRangeEnd',
+        { 'w:id': '302' },
+        CorrelationStatus.Equal,
+        0
+      );
+      atoms = [start, moved, end];
+    });
+
+    await when('reconstructDocument is called', () => {
+      result = reconstructDocument(atoms, MINIMAL_DOCXML, OPTS);
+    });
+
+    await then('only the explicit range pair survives — no synthetic duplicate', () => {
+      expect(count(result, 'w:moveToRangeStart')).toBe(1);
+      expect(count(result, 'w:moveToRangeEnd')).toBe(1);
+      expect(result).toContain('w:name="userMove1"');
+      expect(result).not.toContain('w:name="move1"');
+    });
+
+    await and('the w:moveTo wrapper is still emitted around the moved content', () => {
+      expect(count(result, '<w:moveTo ')).toBe(1);
+    });
+  });
+
+  test('explicit markers suppress only their own kind — the other side still synthesizes', async ({ given, when, then }: AllureBddContext) => {
+    let atoms: ComparisonUnitAtom[];
+    let result: string;
+
+    await given('a paragraph with explicit moveFromRange markers and a separate marker-free MovedDestination paragraph', () => {
+      const start = makeMarkerAtom(
+        'w:moveFromRangeStart',
+        { 'w:id': '300', 'w:name': 'userMove1', 'w:author': 'Mover', 'w:date': '2025-01-01T00:00:00Z' },
+        CorrelationStatus.Equal,
+        0
+      );
+      const movedSource = makeTextAtom('moved text', CorrelationStatus.MovedSource, 0);
+      movedSource.moveName = 'move1';
+      const end = makeMarkerAtom(
+        'w:moveFromRangeEnd',
+        { 'w:id': '300' },
+        CorrelationStatus.Equal,
+        0
+      );
+      const movedDest = makeTextAtom('moved text', CorrelationStatus.MovedDestination, 1);
+      movedDest.moveName = 'move1';
+      atoms = [start, movedSource, end, movedDest];
+    });
+
+    await when('reconstructDocument is called', () => {
+      result = reconstructDocument(atoms, MINIMAL_DOCXML, OPTS);
+    });
+
+    await then('the moveFrom side keeps the explicit pair while the moveTo side synthesizes its own', () => {
+      expect(count(result, 'w:moveFromRangeStart')).toBe(1);
+      expect(count(result, 'w:moveFromRangeEnd')).toBe(1);
+      expect(result).toContain('w:name="userMove1"');
+      expect(count(result, 'w:moveToRangeStart')).toBe(1);
+      expect(count(result, 'w:moveToRangeEnd')).toBe(1);
+      expect(result).toContain('w:name="move1"');
+    });
+  });
+
+  test('explicit markers are emitted outside synthetic <w:r> wrappers', async ({ given, when, then }: AllureBddContext) => {
+    let atoms: ComparisonUnitAtom[];
+    let result: string;
+
+    await given('an Equal paragraph whose atom stream contains explicit move-range markers', () => {
+      const before = makeTextAtom('before ', CorrelationStatus.Equal, 0);
+      const start = makeMarkerAtom(
+        'w:moveFromRangeStart',
+        { 'w:id': '300', 'w:name': 'userMove1', 'w:author': 'Mover', 'w:date': '2025-01-01T00:00:00Z' },
+        CorrelationStatus.Equal,
+        0
+      );
+      const end = makeMarkerAtom(
+        'w:moveFromRangeEnd',
+        { 'w:id': '300' },
+        CorrelationStatus.Equal,
+        0
+      );
+      const after = makeTextAtom('after', CorrelationStatus.Equal, 0);
+      atoms = [before, start, end, after];
+    });
+
+    await when('reconstructDocument is called', () => {
+      result = reconstructDocument(atoms, MINIMAL_DOCXML, OPTS);
+    });
+
+    await then('the markers are siblings of <w:r>, never inside a run', () => {
+      // A marker nested in a run would serialize as <w:r>...<w:moveFromRange...
+      // with no closing </w:r> before it; assert the run closes first.
+      expect(result).toMatch(/<\/w:r><w:moveFromRangeStart /);
+      expect(result).toMatch(/<w:moveFromRangeEnd [^>]*\/><w:r>/);
+    });
+  });
+});

--- a/packages/docx-core/src/baselines/atomizer/documentReconstructor.ts
+++ b/packages/docx-core/src/baselines/atomizer/documentReconstructor.ts
@@ -439,8 +439,14 @@ function shouldStartNewRunGroup(
     return true;
   }
 
-  // Skip rPr splitting for MovedSource/MovedDestination to avoid
-  // duplicate move range markers (moveFromRangeStart/End)
+  // Skip rPr splitting for MovedSource/MovedDestination: every moved run
+  // group is wrapped by wrapWithMoveFrom/wrapWithMoveTo, so splitting one
+  // move into several groups would emit moveFromRangeStart/End (resp.
+  // moveToRangeStart/End) once per slice with the same w:name and range ids.
+  // This stays required now that explicit move-range markers atomize: the
+  // synthetic-range suppression keyed off those markers is per paragraph, so
+  // a detected move in a marker-free paragraph still synthesizes one range
+  // pair per moved run group.
   if (currentGroup.status === CorrelationStatus.MovedSource ||
       currentGroup.status === CorrelationStatus.MovedDestination) {
     return false;
@@ -539,6 +545,46 @@ function isEmptyParagraphGroup(group: ParagraphGroup): boolean {
     }
   }
   return group.runGroups.length > 0;
+}
+
+/**
+ * Which explicit move-range marker kinds a paragraph's atom stream already
+ * carries. Computed once per paragraph and threaded into buildRunGroupXml so
+ * wrapWithMoveFrom / wrapWithMoveTo suppress their synthetic
+ * moveFromRangeStart/End (resp. moveToRangeStart/End) emission instead of
+ * doubling the explicit markers that buildRunContentWithParagraphMarkers
+ * re-emits from the atom stream.
+ *
+ * Granularity is the paragraph, keyed by marker kind. Explicit markers carry
+ * their own w:name from the source document while detected moves get
+ * synthetic names ("move1", ...), so pairing an explicit marker pair with a
+ * specific moved run group is not possible. A paragraph that mixes an
+ * explicit-marker move with a second, independently detected move of the same
+ * kind keeps the explicit pair and loses the synthetic one.
+ *
+ * @see https://github.com/UseJunior/safe-docx/issues/110
+ */
+interface ExplicitMoveMarkers {
+  moveFrom: boolean;
+  moveTo: boolean;
+}
+
+const NO_EXPLICIT_MOVE_MARKERS: ExplicitMoveMarkers = { moveFrom: false, moveTo: false };
+
+function collectExplicitMoveMarkers(group: ParagraphGroup): ExplicitMoveMarkers {
+  let moveFrom = false;
+  let moveTo = false;
+  for (const runGroup of group.runGroups) {
+    for (const atom of runGroup.atoms) {
+      const tag = atom.contentElement.tagName;
+      if (tag === 'w:moveFromRangeStart' || tag === 'w:moveFromRangeEnd') {
+        moveFrom = true;
+      } else if (tag === 'w:moveToRangeStart' || tag === 'w:moveToRangeEnd') {
+        moveTo = true;
+      }
+    }
+  }
+  return { moveFrom, moveTo };
 }
 
 /**
@@ -659,11 +705,12 @@ function buildParagraphXml(
   // Add run groups with track changes, restoring w:hyperlink wrappers when
   // the paragraph contains hyperlink atoms (issue #368). Hyperlink-free
   // paragraphs keep the legacy per-group emission byte-identical.
+  const explicitMoveMarkers = collectExplicitMoveMarkers(group);
   if (paragraphHasHyperlinkAtoms(group)) {
-    parts.push(buildRunGroupsWithHyperlinks(group.runGroups, author, dateStr, revState));
+    parts.push(buildRunGroupsWithHyperlinks(group.runGroups, author, dateStr, revState, explicitMoveMarkers));
   } else {
     for (const runGroup of group.runGroups) {
-      const runXml = buildRunGroupXml(runGroup, author, dateStr, revState);
+      const runXml = buildRunGroupXml(runGroup, author, dateStr, revState, explicitMoveMarkers);
       parts.push(runXml);
     }
   }
@@ -795,12 +842,17 @@ function buildRunContentAsPlainRun(group: RunGroup): string {
 
 /**
  * Build XML for a run group with appropriate track changes wrapper.
+ *
+ * `explicitMoveMarkers` reports whether the surrounding paragraph's atom
+ * stream already carries explicit moveFromRange / moveToRange markers; moved
+ * groups then skip synthetic range emission (see ExplicitMoveMarkers).
  */
 function buildRunGroupXml(
   group: RunGroup,
   author: string,
   dateStr: string,
-  revState: RevisionIdState
+  revState: RevisionIdState,
+  explicitMoveMarkers: ExplicitMoveMarkers = NO_EXPLICIT_MOVE_MARKERS
 ): string {
   const runContent = buildRunContent(group);
 
@@ -827,7 +879,8 @@ function buildRunGroupXml(
         author,
         dateStr,
         group.moveName || 'move1',
-        revState
+        revState,
+        explicitMoveMarkers.moveFrom
       );
 
     case CorrelationStatus.MovedDestination:
@@ -836,7 +889,8 @@ function buildRunGroupXml(
         author,
         dateStr,
         group.moveName || 'move1',
-        revState
+        revState,
+        explicitMoveMarkers.moveTo
       );
 
     case CorrelationStatus.FormatChanged:
@@ -1098,7 +1152,8 @@ function buildRunGroupsWithHyperlinks(
   runGroups: RunGroup[],
   author: string,
   dateStr: string,
-  revState: RevisionIdState
+  revState: RevisionIdState,
+  explicitMoveMarkers: ExplicitMoveMarkers = NO_EXPLICIT_MOVE_MARKERS
 ): string {
   const buckets = mergeAdjacentHyperlinkSegments(
     runGroups.flatMap(splitRunGroupByHyperlink)
@@ -1107,7 +1162,7 @@ function buildRunGroupsWithHyperlinks(
   const parts: string[] = [];
   for (const bucket of buckets) {
     const content = bucket.groups
-      .map((g) => buildRunGroupXml(g, author, dateStr, revState))
+      .map((g) => buildRunGroupXml(g, author, dateStr, revState, explicitMoveMarkers))
       .join('');
     if (!content) continue;
     parts.push(
@@ -1148,7 +1203,8 @@ function buildWholeParagraphRevisionContent(
 
 /**
  * Returns true when any atom in the group is a paragraph-level marker
- * (commentRange / bookmark) that must be emitted outside <w:r>.
+ * (commentRange / bookmark / moveFromRange / moveToRange) that must be
+ * emitted outside <w:r>.
  */
 function groupHasParagraphLevelAtoms(group: RunGroup): boolean {
   for (const atom of group.atoms) {
@@ -1349,14 +1405,28 @@ function wrapWithDel(
 
 /**
  * Wrap content with w:moveFrom elements.
+ *
+ * When `suppressRangeMarkers` is true the paragraph's atom stream already
+ * carries explicit w:moveFromRangeStart/End markers (re-emitted by
+ * buildRunContentWithParagraphMarkers), so only the w:moveFrom wrapper is
+ * synthesized — emitting a second range pair would corrupt the move ranges.
+ *
+ * @see https://github.com/UseJunior/safe-docx/issues/110
  */
 function wrapWithMoveFrom(
   content: string,
   author: string,
   dateStr: string,
   moveName: string,
-  revState: RevisionIdState
+  revState: RevisionIdState,
+  suppressRangeMarkers = false
 ): string {
+  if (suppressRangeMarkers) {
+    const moveId = allocateRevisionId(revState);
+    const delContent = convertSerializedDeletionContent(content);
+    return `<w:moveFrom w:id="${moveId}" w:author="${escapeXmlAttr(author)}" w:date="${dateStr}">${delContent}</w:moveFrom>`;
+  }
+
   const ids = getMoveRangeIds(revState, moveName);
   const moveId = allocateRevisionId(revState);
 
@@ -1371,14 +1441,24 @@ function wrapWithMoveFrom(
 
 /**
  * Wrap content with w:moveTo elements.
+ *
+ * When `suppressRangeMarkers` is true the paragraph's atom stream already
+ * carries explicit w:moveToRangeStart/End markers, so only the w:moveTo
+ * wrapper is synthesized (see wrapWithMoveFrom).
  */
 function wrapWithMoveTo(
   content: string,
   author: string,
   dateStr: string,
   moveName: string,
-  revState: RevisionIdState
+  revState: RevisionIdState,
+  suppressRangeMarkers = false
 ): string {
+  if (suppressRangeMarkers) {
+    const moveId = allocateRevisionId(revState);
+    return `<w:moveTo w:id="${moveId}" w:author="${escapeXmlAttr(author)}" w:date="${dateStr}">${content}</w:moveTo>`;
+  }
+
   const ids = getMoveRangeIds(revState, moveName);
   const moveId = allocateRevisionId(revState);
 
@@ -1613,11 +1693,15 @@ function buildDocumentPreservingStructure(
     slot.parent.removeChild(slot.element);
   }
 
-  // Strip inter-paragraph bookmark/comment range markers from the scaffold.
-  // These are bookmarkStart/End, commentRangeStart/End elements that were
-  // siblings of <w:p> in the original body. The paragraph rebuilder handles
-  // its own bookmark logic, so keeping these orphaned markers causes
-  // unmatched bookmark IDs.
+  // Strip inter-paragraph bookmark/comment/move-range markers from the
+  // scaffold. These are bookmarkStart/End, commentRangeStart/End, and
+  // moveFromRange*/moveToRange* elements that were siblings of <w:p> in the
+  // original body. The paragraph rebuilder handles its own bookmark logic, so
+  // keeping these orphaned markers causes unmatched bookmark IDs. Body-level
+  // move-range markers are likewise scaffold remnants: in-paragraph markers
+  // travel through the atom stream, and detected moves synthesize fresh range
+  // pairs inside the reconstructed paragraphs, so a leftover body-level pair
+  // would either dangle or double an emitted range.
   //
   // Comment range markers are treated differently: a sibling-level
   // commentRangeStart/End is the legitimate shape for a comment range that
@@ -1630,6 +1714,8 @@ function buildDocumentPreservingStructure(
   const SCAFFOLD_STRIP_TAGS = new Set([
     'w:bookmarkStart', 'w:bookmarkEnd',
     'w:commentRangeStart', 'w:commentRangeEnd',
+    'w:moveFromRangeStart', 'w:moveFromRangeEnd',
+    'w:moveToRangeStart', 'w:moveToRangeEnd',
   ]);
   const COMMENT_RANGE_TAGS = new Set(['w:commentRangeStart', 'w:commentRangeEnd']);
   const commentRangeStartIds = new Set<string>();

--- a/packages/docx-core/src/integration/rebuild-auxiliary-merge.test.ts
+++ b/packages/docx-core/src/integration/rebuild-auxiliary-merge.test.ts
@@ -15,7 +15,7 @@
 import { describe, expect } from 'vitest';
 import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
 import { compareDocuments } from '../index.js';
-import { buildSyntheticDocx, getResultParts } from './synthetic-docx-fixture.js';
+import { buildSyntheticDocx, buildDocxFromParts, getResultParts } from './synthetic-docx-fixture.js';
 import { buildDocxFromBodyXml } from '../testing/ooxml-fixtures.js';
 import { parseXml } from '../primitives/xml.js';
 
@@ -658,6 +658,194 @@ describe('Multi-paragraph sibling comment ranges on rebuild (issue #103)', () =>
         expect(result.reconstructionModeUsed).toBe('rebuild');
         const parts = await getResultParts(result.document);
         expect(parts.documentXml).not.toContain('w:commentRangeStart');
+      });
+    });
+  });
+});
+
+describe('Move-range marker reconstruction on rebuild (issue #110)', () => {
+  /**
+   * No-doubling invariant for one move-range kind: every start id is unique
+   * (a doubled emission repeats the id), every start has a matching end, and
+   * no marker sits inside a <w:r>. Pass expectedPairs when the scenario pins
+   * the exact number of ranges.
+   */
+  function expectUndoubledRanges(xml: string, kind: 'moveFromRange' | 'moveToRange', expectedPairs?: number) {
+    const starts = inspectElements(xml, `w:${kind}Start`);
+    const ends = inspectElements(xml, `w:${kind}End`);
+    const startIds = starts.map((s) => s.idAttr);
+    expect(new Set(startIds).size).toBe(startIds.length);
+    expect(ends.length).toBe(starts.length);
+    expect(new Set(startIds)).toEqual(new Set(ends.map((e) => e.idAttr)));
+    if (expectedPairs !== undefined) {
+      expect(starts.length).toBe(expectedPairs);
+    }
+    for (const m of [...starts, ...ends]) {
+      expect(m.ancestors).not.toContain('w:r');
+    }
+    return { starts, ends };
+  }
+
+  describe('Explicit in-paragraph markers on the revised side', () => {
+    test('rebuild emits each move-range marker exactly once — no synthetic doubling', async ({ given, when, then, and }: AllureBddContext) => {
+      let original: Buffer, revised: Buffer;
+      await given('original is plain and revised carries a tracked move with explicit range markers', async () => {
+        original = await buildSyntheticDocx({
+          paragraphs: ['The quick brown fox jumps over the dog', 'Middle paragraph stays put'],
+        });
+        revised = await buildSyntheticDocx({
+          paragraphs: [
+            'The quick brown fox jumps over the dog',
+            'Middle paragraph stays put',
+            'The quick brown fox jumps over the dog',
+          ],
+          trackedMove: { from: 0, to: 2, name: 'userMove1' },
+        });
+      });
+
+      let result: Awaited<ReturnType<typeof compareDocuments>>;
+      await when('documents are compared in rebuild mode', async () => {
+        result = await compareDocuments(original, revised, {
+          engine: 'atomizer',
+          reconstructionMode: 'rebuild',
+        });
+      });
+
+      await then('every range id is emitted exactly once per kind — nothing is doubled', async () => {
+        expect(result.reconstructionModeUsed).toBe('rebuild');
+        const parts = await getResultParts(result.document);
+        // Move detection may additionally re-detect the move and synthesize
+        // its own "move1" pair; the invariant is that no pair (explicit or
+        // synthetic) is ever emitted twice.
+        expectUndoubledRanges(parts.documentXml, 'moveFromRange');
+        expectUndoubledRanges(parts.documentXml, 'moveToRange');
+      });
+
+      await and('the explicit markers survive exactly once each, name intact', async () => {
+        const parts = await getResultParts(result.document);
+        const fromStarts = inspectElements(parts.documentXml, 'w:moveFromRangeStart');
+        const toStarts = inspectElements(parts.documentXml, 'w:moveToRangeStart');
+        expect(fromStarts.filter((m) => m.idAttr === '300').length).toBe(1);
+        expect(toStarts.filter((m) => m.idAttr === '302').length).toBe(1);
+        // One w:name on the explicit moveFromRangeStart + one on the explicit
+        // moveToRangeStart. Before issue #110 these markers were dropped from
+        // rebuilt paragraphs entirely (not atomized), so this count was 0.
+        expect(parts.documentXml.match(/w:name="userMove1"/g)?.length).toBe(2);
+      });
+    });
+
+    test('inplace mode preserves explicit move-range markers without duplication', async ({ given, when, then }: AllureBddContext) => {
+      let original: Buffer, revised: Buffer;
+      await given('original is plain and revised carries a tracked move with explicit range markers', async () => {
+        original = await buildSyntheticDocx({
+          paragraphs: ['The quick brown fox jumps over the dog', 'Middle paragraph stays put'],
+        });
+        revised = await buildSyntheticDocx({
+          paragraphs: [
+            'The quick brown fox jumps over the dog',
+            'Middle paragraph stays put',
+            'The quick brown fox jumps over the dog',
+          ],
+          trackedMove: { from: 0, to: 2, name: 'userMove1' },
+        });
+      });
+
+      let result: Awaited<ReturnType<typeof compareDocuments>>;
+      await when('documents are compared in inplace mode', async () => {
+        result = await compareDocuments(original, revised, {
+          engine: 'atomizer',
+          reconstructionMode: 'inplace',
+        });
+      });
+
+      await then('whichever mode is used, the explicit markers survive exactly once each', async () => {
+        const parts = await getResultParts(result.document);
+        // Only the explicit markers are asserted here: inplace's own synthetic
+        // emission duplicates range pairs per moved run (one identical-id pair
+        // per wrapped <w:r>) — a pre-existing engine bug independent of the
+        // explicit-marker reconstruction this suite covers.
+        // See https://github.com/UseJunior/safe-docx/issues/446
+        const fromStarts = inspectElements(parts.documentXml, 'w:moveFromRangeStart');
+        const fromEnds = inspectElements(parts.documentXml, 'w:moveFromRangeEnd');
+        const toStarts = inspectElements(parts.documentXml, 'w:moveToRangeStart');
+        const toEnds = inspectElements(parts.documentXml, 'w:moveToRangeEnd');
+        expect(fromStarts.filter((m) => m.idAttr === '300').length).toBe(1);
+        expect(fromEnds.filter((m) => m.idAttr === '300').length).toBe(1);
+        expect(toStarts.filter((m) => m.idAttr === '302').length).toBe(1);
+        expect(toEnds.filter((m) => m.idAttr === '302').length).toBe(1);
+      });
+    });
+  });
+
+  describe('Synthetic emission path (no explicit markers)', () => {
+    test('a detected move still synthesizes exactly one range pair per side', async ({ given, when, then }: AllureBddContext) => {
+      let original: Buffer, revised: Buffer;
+      await given('revised moves a whole paragraph with no pre-existing markers', async () => {
+        original = await buildSyntheticDocx({
+          paragraphs: [
+            'The quick brown fox jumps over the lazy dog today',
+            'Middle paragraph stays put',
+            'Final paragraph also stays',
+          ],
+        });
+        revised = await buildSyntheticDocx({
+          paragraphs: [
+            'Middle paragraph stays put',
+            'Final paragraph also stays',
+            'The quick brown fox jumps over the lazy dog today',
+          ],
+        });
+      });
+
+      let result: Awaited<ReturnType<typeof compareDocuments>>;
+      await when('documents are compared in rebuild mode', async () => {
+        result = await compareDocuments(original, revised, {
+          engine: 'atomizer',
+          reconstructionMode: 'rebuild',
+        });
+      });
+
+      await then('synthetic moveFromRange/moveToRange pairs are emitted once each with a shared name', async () => {
+        expect(result.reconstructionModeUsed).toBe('rebuild');
+        const parts = await getResultParts(result.document);
+        expectUndoubledRanges(parts.documentXml, 'moveFromRange', 1);
+        expectUndoubledRanges(parts.documentXml, 'moveToRange', 1);
+        const names = [...parts.documentXml.matchAll(/<w:move(?:From|To)RangeStart [^>]*w:name="([^"]+)"/g)].map((m) => m[1]);
+        expect(names.length).toBe(2);
+        expect(names[0]).toBe(names[1]);
+      });
+    });
+  });
+
+  describe('Body-level move-range scaffold remnants', () => {
+    test('sibling-of-paragraph move-range markers are stripped on rebuild', async ({ given, when, then }: AllureBddContext) => {
+      const bodyLevelMarkers =
+        `<w:moveFromRangeStart w:id="900" w:name="orphanMove" w:author="Mover" w:date="2025-01-01T00:00:00Z"/>` +
+        `<w:moveFromRangeEnd w:id="900"/>`;
+      const makeBody = (firstParaText: string) =>
+        `<w:p><w:r><w:t>${firstParaText}</w:t></w:r></w:p>` +
+        bodyLevelMarkers +
+        `<w:p><w:r><w:t>Second paragraph</w:t></w:r></w:p>`;
+
+      let original: Buffer, revised: Buffer;
+      await given('both sides have a body-level move-range pair between two paragraphs', async () => {
+        original = await buildDocxFromParts({ bodyXml: makeBody('First paragraph') });
+        revised = await buildDocxFromParts({ bodyXml: makeBody('First paragraph revised') });
+      });
+
+      let result: Awaited<ReturnType<typeof compareDocuments>>;
+      await when('documents are compared in rebuild mode', async () => {
+        result = await compareDocuments(original, revised, {
+          engine: 'atomizer',
+          reconstructionMode: 'rebuild',
+        });
+      });
+
+      await then('the body-level markers do not survive as scaffold remnants', async () => {
+        expect(result.reconstructionModeUsed).toBe('rebuild');
+        const parts = await getResultParts(result.document);
+        expect(inspectElements(parts.documentXml, 'w:moveFromRangeStart').length).toBe(0);
+        expect(inspectElements(parts.documentXml, 'w:moveFromRangeEnd').length).toBe(0);
       });
     });
   });

--- a/packages/docx-core/src/integration/synthetic-docx-fixture.ts
+++ b/packages/docx-core/src/integration/synthetic-docx-fixture.ts
@@ -51,6 +51,17 @@ export interface SyntheticDocxOptions {
    * Mutually exclusive with commentOnParagraph and commentSpanParagraphs.
    */
   siblingCommentRange?: { startBeforeParagraph: number; endAfterParagraph: number };
+  /**
+   * Pre-existing tracked move with explicit in-paragraph range markers.
+   * paragraphs[from]'s text is wrapped in <w:moveFrom> (as w:delText)
+   * bracketed by w:moveFromRangeStart/End; paragraphs[to]'s text is wrapped
+   * in <w:moveTo> bracketed by w:moveToRangeStart/End. All four markers are
+   * direct children of their <w:p>, sharing the given w:name. Callers should
+   * pass identical text for paragraphs[from] and paragraphs[to] so the shape
+   * matches what Word produces for a real tracked move. Used to verify
+   * explicit move-range marker reconstruction (issue #110).
+   */
+  trackedMove?: { from: number; to: number; name: string; author?: string; firstId?: number };
 }
 
 export async function buildSyntheticDocx(opts: SyntheticDocxOptions): Promise<Buffer> {
@@ -71,6 +82,10 @@ export async function buildSyntheticDocx(opts: SyntheticDocxOptions): Promise<Bu
   const siblingBookmarkId = opts.siblingBookmarkBefore?.id ?? 200;
   const spanStart = opts.commentSpanParagraphs?.start;
   const spanEnd = opts.commentSpanParagraphs?.end;
+  const hasTrackedMove = opts.trackedMove != null;
+  const moveAuthor = opts.trackedMove?.author ?? 'Mover';
+  const moveBaseId = opts.trackedMove?.firstId ?? 300;
+  const moveDate = '2025-01-01T00:00:00Z';
 
   const paragraphParts: string[] = opts.paragraphs.map((text, idx) => {
     const escaped = text
@@ -99,6 +114,34 @@ export async function buildSyntheticDocx(opts: SyntheticDocxOptions): Promise<Bu
           `<w:r><w:rPr><w:rStyle w:val="CommentReference"/></w:rPr><w:commentReference w:id="1"/></w:r>`
         : '';
       return `<w:p>${before}<w:r><w:t>${escaped}</w:t></w:r>${after}${extra}</w:p>`;
+    }
+
+    if (hasTrackedMove && idx === opts.trackedMove!.from) {
+      const name = opts.trackedMove!.name;
+      return (
+        `<w:p>` +
+        `<w:moveFromRangeStart w:id="${moveBaseId}" w:name="${name}" w:author="${moveAuthor}" w:date="${moveDate}"/>` +
+        `<w:moveFrom w:id="${moveBaseId + 1}" w:author="${moveAuthor}" w:date="${moveDate}">` +
+        `<w:r><w:delText>${escaped}</w:delText></w:r>` +
+        `</w:moveFrom>` +
+        `<w:moveFromRangeEnd w:id="${moveBaseId}"/>` +
+        extra +
+        `</w:p>`
+      );
+    }
+
+    if (hasTrackedMove && idx === opts.trackedMove!.to) {
+      const name = opts.trackedMove!.name;
+      return (
+        `<w:p>` +
+        `<w:moveToRangeStart w:id="${moveBaseId + 2}" w:name="${name}" w:author="${moveAuthor}" w:date="${moveDate}"/>` +
+        `<w:moveTo w:id="${moveBaseId + 3}" w:author="${moveAuthor}" w:date="${moveDate}">` +
+        `<w:r><w:t>${escaped}</w:t></w:r>` +
+        `</w:moveTo>` +
+        `<w:moveToRangeEnd w:id="${moveBaseId + 2}"/>` +
+        extra +
+        `</w:p>`
+      );
     }
 
     if (hasBookmark && idx === opts.bookmarkOnParagraph!.paragraph) {


### PR DESCRIPTION
Fixes: #110

## What

Adds `w:moveFromRangeStart/End` and `w:moveToRangeStart/End` to `PARAGRAPH_LEVEL_TAGS` so explicit move-range markers atomize on rebuild and are re-emitted as siblings of `<w:r>` — completing the follow-up that #109 deferred. Before this change, in-paragraph move-range markers were silently dropped by rebuild reconstruction (neither leaf nodes nor paragraph-level atoms), breaking the `w:name` pairing between a move's source and destination ranges.

## How the synthesis collision is resolved (issue scope item 2, option a)

The reconstructor already synthesizes range pairs in `wrapWithMoveFrom`/`wrapWithMoveTo` for detected moves; atomizing explicit markers on top would double the ranges. `buildParagraphXml` now computes which explicit marker kinds the paragraph's atom stream carries (`collectExplicitMoveMarkers`) and moved run groups suppress synthetic range emission of that kind, emitting only the `w:moveFrom`/`w:moveTo` wrapper.

Suppression is paragraph-scoped and kind-keyed: explicit markers carry their own `w:name` from the source document while detected moves get synthetic names (`move1`, …), so per-move pairing between the two populations is not possible. The trade-off (a paragraph mixing an explicit-marker move with an independently detected move of the same kind keeps the explicit pair and loses the synthetic one) is documented at the `ExplicitMoveMarkers` declaration.

## Scope items 3–6

- **Scaffold strip (item 3):** body-level (sibling-of-`w:p`) move-range markers join `SCAFFOLD_STRIP_TAGS`, matching bookmark/commentRange handling — detected moves synthesize fresh in-paragraph ranges, so leftover body-level pairs would dangle or double.
- **Split-suppression re-evaluation (item 4):** the `shouldStartNewRunGroup` move split-suppression is kept and its comment now explains why it remains required (synthetic suppression is per paragraph; a marker-free paragraph still needs one range pair per moved group, not one per rPr slice).
- **Fixtures (item 5):** `buildSyntheticDocx` gains a `trackedMove` option emitting a pre-existing tracked move with explicit in-paragraph range markers.
- **Regression tests (item 6):** unit tests (`documentReconstructor-moveRanges.test.ts`) deterministically cover synthesis, suppression per kind, and outside-`<w:r>` placement; integration tests cover rebuild no-doubling + name survival, the untouched synthetic path, body-level scaffold strip, and inplace.

## Discovered en route: pre-existing inplace bug (#446)

Inplace mode emits one identical-id range pair per moved `<w:r>` for detected moves (`wrapAsMove` brackets every run it wraps). Reproduced at this branch's base with no pre-existing markers anywhere, so it is independent of this change — filed as #446 per the discovery/remediation convention. The inplace regression test here pins only the explicit-marker invariant and references #446.

## Acceptance criteria from #110

- ✅ Move atoms with explicit range markers in source survive rebuild without being doubled (unit + integration assertions on unique range ids and explicit-marker counts).
- ✅ Synthetic emission path (no explicit markers) still works (exactly one pair per side, shared name).
- ✅ No regression on existing move-detection tests (full gate green: build, lint, 1451 tests, spec-coverage, conformance-citations, conformance-doc).