### PR TITLE
ci(docx-core): validate emitted document.xml against the ECMA-376 schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,6 +333,8 @@ jobs:
           exit 1
       - name: Test workspaces (with coverage)
         if: matrix.coverage
+        env:
+          SDX_SCHEMA_CORPUS_DIR: ${{ runner.temp }}/schema-corpus
         run: |
           npm run test:coverage -w @usejunior/docx-core
           npm run test:coverage -w @usejunior/docx-mcp
@@ -340,7 +342,18 @@ jobs:
           npm run test:run -w @usejunior/safedocx-mcpb
       - name: Test workspaces
         if: ${{ !matrix.coverage }}
+        env:
+          SDX_SCHEMA_CORPUS_DIR: ${{ runner.temp }}/schema-corpus
         run: npm run test
+      - name: Validate emitted document.xml corpus against ECMA-376 schema
+        run: |
+          if ! command -v xmllint >/dev/null; then
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends libxml2-utils
+          fi
+          node scripts/check_emitted_document_schema.mjs --self-test \
+            --known-failures coverage/emitted-schema-known-failures.json \
+            "$RUNNER_TEMP/schema-corpus"
       - name: Generate package coverage dashboard + enforce ratchet
         if: matrix.coverage
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ node_modules/
 dist/
 *.tgz
 .DS_Store
+# Scratch outputs (schema-validation corpus runs, oracle scratch, etc.)
+.tmp/
 # Office lock files (Word/Excel/PowerPoint create these while a file is open)
 ~$*
 .mcpregistry_*
@@ -21,6 +23,7 @@ coverage/
 coverage/*
 !coverage/package-coverage-baseline.json
 !coverage/allure-test-filename-baseline.json
+!coverage/emitted-schema-known-failures.json
 packages/*/coverage/
 .claude/settings.local.json
 

--- a/coverage/emitted-schema-known-failures.json
+++ b/coverage/emitted-schema-known-failures.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "ilpa-orphaned-ppr-close",
+    "issue": "#450",
+    "match": "not well-formed: Opening and ending tag mismatch: \"w:body\" != \"w:pPr\"",
+    "reason": "ILPA-pair comparison drops the opening <w:p><w:pPr> of a paragraph-mark sectPr paragraph, leaving orphaned close tags at body level"
+  },
+  {
+    "id": "duplicate-rprchange-in-rpr",
+    "issue": "#451",
+    "match": "}rPrChange': This element is not expected.",
+    "reason": "comparison stacks duplicate w:rPrChange children in a single w:rPr; CT_RPr allows at most one"
+  },
+  {
+    "id": "duplicate-para-mark-ins",
+    "issue": "#452",
+    "match": "}ins': This element is not expected.",
+    "reason": "tracked paragraph insertion emits two paragraph-mark w:ins markers in w:pPr/w:rPr; CT_ParaRPr allows at most one"
+  },
+  {
+    "id": "synthetic-table-missing-tblgrid",
+    "issue": "#453",
+    "match": "}tr': This element is not expected.",
+    "reason": "synthetic table fixtures omit the required w:tblGrid, and the engine faithfully preserves the gap into emitted output"
+  }
+]

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "generate:conformance-doc": "node scripts/generate_conformance_doc.mjs",
     "check:conformance-citations": "node scripts/check_conformance_citations.mjs",
     "check:conformance-doc": "node scripts/check_conformance_doc.mjs",
+    "check:emitted-schema": "node scripts/check_emitted_document_schema.mjs --self-test --known-failures coverage/emitted-schema-known-failures.json",
     "generate:tests-corpus-schema": "npm run build -w @usejunior/test-narrative && node scripts/generate_tests_corpus_schema.mjs",
     "check:tests-corpus-schema": "npm run build -w @usejunior/test-narrative && node scripts/check_tests_corpus_schema.mjs",
     "build:tests-corpus": "npm run build -w @usejunior/test-narrative && node scripts/build_tests_corpus.mjs",

--- a/packages/docx-core/src/baselines/atomizer/pipeline.ts
+++ b/packages/docx-core/src/baselines/atomizer/pipeline.ts
@@ -79,6 +79,7 @@ import {
   renumberCollidingAuxiliaryIds,
   type AuxiliaryPartDescriptor,
 } from './auxiliaryIdCollision.js';
+import { maybeCaptureEmittedDocumentXml } from '../../primitives/schema-corpus-capture.js';
 
 /**
  * Options for the atomizer pipeline.
@@ -1032,6 +1033,7 @@ export async function compareDocumentsAtomizer(
   // auxiliary part that the revised side introduced (issue #94).
   const mergeSourceArchive = comparisonResult.outputMode === 'inplace' ? originalArchive : revisedArchive;
   const resultArchive = await baseArchive.clone();
+  maybeCaptureEmittedDocumentXml(newDocumentXml);
   resultArchive.setDocumentXml(newDocumentXml);
 
   // Step 12b: Merge auxiliary part definitions (footnotes, endnotes, comments).

--- a/packages/docx-core/src/baselines/diffmatch/pipeline.ts
+++ b/packages/docx-core/src/baselines/diffmatch/pipeline.ts
@@ -31,6 +31,7 @@ interface BaselineBResult {
   engine: 'diffmatch';
 }
 import { extractParagraphs } from './xmlParser.js';
+import { maybeCaptureEmittedDocumentXml } from '../../primitives/schema-corpus-capture.js';
 import { alignParagraphs, classifyAlignment } from './paragraphAlignment.js';
 import { resetRevisionIds } from './trackChangesRenderer.js';
 import {
@@ -105,6 +106,7 @@ export async function compareDocumentsBaselineB(
 
   // 8. Clone original archive and update document.xml
   const resultArchive = await originalArchive.clone();
+  maybeCaptureEmittedDocumentXml(newDocumentXml);
   resultArchive.setDocumentXml(newDocumentXml);
 
   // 9. Save result and compute stats

--- a/packages/docx-core/src/generation/compile.ts
+++ b/packages/docx-core/src/generation/compile.ts
@@ -13,6 +13,7 @@
  */
 
 import { createZipBuffer } from '../primitives/zip.js';
+import { maybeCaptureEmittedDocumentXml } from '../primitives/schema-corpus-capture.js';
 import { CompileContext } from './context.js';
 import { emitCommentsPartsIfNeeded } from './emit/comments-part.js';
 import { DraftingNoteCollector } from './emit/emit-context.js';
@@ -42,7 +43,9 @@ export async function generateDocx(spec: DocumentSpec, opts?: GenerateDocxOption
   const numberingIds = emitNumberingPartIfNeeded(spec, ctx);
   const headerFooterRefs = emitHeaderFooterParts(spec, ctx, { numberingIds });
   const notes = notesEnabled ? new DraftingNoteCollector() : undefined;
-  ctx.setFileContent('word/document.xml', emitDocumentPart(spec, headerFooterRefs, { numberingIds, notes }));
+  const documentPartXml = emitDocumentPart(spec, headerFooterRefs, { numberingIds, notes });
+  maybeCaptureEmittedDocumentXml(documentPartXml);
+  ctx.setFileContent('word/document.xml', documentPartXml);
   if (notes) emitCommentsPartsIfNeeded(spec, ctx, notes);
   emitStylesPart(spec, ctx);
   emitSettingsPartIfNeeded(spec, ctx);

--- a/packages/docx-core/src/integration/synthetic-docx-fixture.ts
+++ b/packages/docx-core/src/integration/synthetic-docx-fixture.ts
@@ -195,7 +195,9 @@ export async function buildSyntheticDocx(opts: SyntheticDocxOptions): Promise<Bu
   const documentXml =
     `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
     `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"` +
-    ` xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">` +
+    ` xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"` +
+    ` xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"` +
+    ` mc:Ignorable="w14">` +
     `<w:body>${paragraphsXml}<w:sectPr/></w:body></w:document>`;
 
   const contentTypeParts: string[] = [
@@ -371,7 +373,9 @@ export async function buildDocxFromParts(opts: DocxPartsOptions): Promise<Buffer
     `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
     `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"` +
     ` xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"` +
-    ` xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
+    ` xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"` +
+    ` xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"` +
+    ` mc:Ignorable="w14">` +
     `<w:body>${opts.bodyXml}<w:sectPr/></w:body></w:document>`;
 
   const overrides = [

--- a/packages/docx-core/src/primitives/document.ts
+++ b/packages/docx-core/src/primitives/document.ts
@@ -1,5 +1,6 @@
 import { DocxZip } from './zip.js';
 import { parseXml, serializeXml } from './xml.js';
+import { maybeCaptureEmittedDocumentXml } from './schema-corpus-capture.js';
 import { OOXML, W } from './namespaces.js';
 import { createWmlElement, isW, getDirectChildrenByName } from './dom-helpers.js';
 import {
@@ -1220,6 +1221,7 @@ export class DocxDocument {
     // Always write the latest document.xml when saving.
     // Important: when cleanBookmarks=true (download), we must NOT mutate session state.
     const xmlWithBookmarks = serializeXml(this.documentXml);
+    maybeCaptureEmittedDocumentXml(xmlWithBookmarks);
     this.zip.writeText('word/document.xml', xmlWithBookmarks);
 
     if (opts?.cleanBookmarks) {
@@ -1238,6 +1240,7 @@ export class DocxDocument {
       const cleanedXml = serializeXml(cloned);
 
       // Temporarily swap document.xml in the zip for output, then restore.
+      maybeCaptureEmittedDocumentXml(cleanedXml);
       this.zip.writeText('word/document.xml', cleanedXml);
       const buffer = await this.zip.toBuffer();
       this.zip.writeText('word/document.xml', xmlWithBookmarks);

--- a/packages/docx-core/src/primitives/schema-corpus-capture.ts
+++ b/packages/docx-core/src/primitives/schema-corpus-capture.ts
@@ -1,0 +1,28 @@
+import { createHash } from 'node:crypto';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Opt-in capture of every `word/document.xml` the engine emits, so an
+ * external OOXML schema validator can check the whole corpus after a test
+ * run. No-op (zero I/O) unless `SDX_SCHEMA_CORPUS_DIR` is set.
+ *
+ * Files are named by content hash, so repeated emissions of the same XML
+ * deduplicate and the corpus stays bounded across a full test run. The
+ * consumer is `scripts/check_emitted_document_schema.mjs`, which validates
+ * the captured corpus against the vendored Transitional WML schema.
+ *
+ * Capture sites are the three emission choke points: comparison pipelines
+ * (`DocxArchive.setDocumentXml`), primitives saves (`DocxDocument.toBuffer`),
+ * and generation (`generateDocx`). Capture failures propagate: when the
+ * corpus is requested, a partially written corpus must not validate cleanly.
+ *
+ * @see https://github.com/UseJunior/safe-docx/issues/214
+ */
+export function maybeCaptureEmittedDocumentXml(xml: string): void {
+  const dir = process.env.SDX_SCHEMA_CORPUS_DIR;
+  if (!dir) return;
+  const digest = createHash('sha256').update(xml).digest('hex').slice(0, 16);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `document-${digest}.xml`), xml);
+}

--- a/packages/docx-core/src/testing/ooxml-fixtures.ts
+++ b/packages/docx-core/src/testing/ooxml-fixtures.ts
@@ -160,7 +160,9 @@ export async function buildDocxFromBodyXml(bodyXml: string): Promise<Buffer> {
   const documentXml =
     `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
     `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"` +
-    ` xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">` +
+    ` xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"` +
+    ` xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"` +
+    ` mc:Ignorable="w14">` +
     `<w:body>${bodyXml}<w:sectPr/></w:body></w:document>`;
 
   const contentTypesXml =

--- a/packages/docx-mcp/src/integration/canonical-emission-mcp.test.ts
+++ b/packages/docx-mcp/src/integration/canonical-emission-mcp.test.ts
@@ -31,7 +31,7 @@ function createManager(aiAuthor: string = AI_AUTHOR): SessionManager {
 function makeDocXml(bodyXml: string): string {
   return (
     `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
-    `<w:document xmlns:w="${W_NS}" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">` +
+    `<w:document xmlns:w="${W_NS}" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="w14">` +
     `<w:body>${bodyXml}<w:sectPr/></w:body>` +
     `</w:document>`
   );

--- a/packages/docx-mcp/src/integration/preservation_invariants.test.ts
+++ b/packages/docx-mcp/src/integration/preservation_invariants.test.ts
@@ -33,7 +33,7 @@ function createManager(): SessionManager {
 function makeDocXml(bodyXml: string): string {
   return (
     `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
-    `<w:document xmlns:w="${W_NS}" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">` +
+    `<w:document xmlns:w="${W_NS}" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="w14">` +
     `<w:body>${bodyXml}</w:body>` +
     `</w:document>`
   );
@@ -99,6 +99,7 @@ describe('OOXML preservation invariants: brownfield mutations preserve what the 
       const bodyXml =
         `<w:p><w:r><w:t>Anchor.</w:t></w:r></w:p>` +
         `<w:tbl>` +
+        `<w:tblPr><w:tblW w:w="0" w:type="auto"/></w:tblPr>` +
         `<w:tblGrid><w:gridCol w:w="2500"/><w:gridCol w:w="2500"/></w:tblGrid>` +
         `<w:tr>` +
         `<w:tc><w:p><w:r><w:t>cellA1</w:t></w:r></w:p></w:tc>` +

--- a/packages/docx-mcp/src/tools/get_comments_range_metadata.test.ts
+++ b/packages/docx-mcp/src/tools/get_comments_range_metadata.test.ts
@@ -17,7 +17,7 @@ const humanReadableTest = test.allure({
 function makeDocumentXml(bodyXml: string): string {
   return (
     `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
-    `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">` +
+    `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="w14">` +
     `<w:body>${bodyXml}</w:body>` +
     `</w:document>`
   );

--- a/packages/docx-mcp/src/tools/read_file_anchor_only_paragraphs.test.ts
+++ b/packages/docx-mcp/src/tools/read_file_anchor_only_paragraphs.test.ts
@@ -7,7 +7,7 @@ import { readFile } from './read_file.js';
 const test = testAllure.epic('Document Reading');
 
 const W_DOC_OPEN =
-  '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">';
+  '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="w14">';
 
 function makeDocumentXml(bodyXml: string): string {
   return (

--- a/packages/docx-mcp/src/tools/read_file_comments.test.ts
+++ b/packages/docx-mcp/src/tools/read_file_comments.test.ts
@@ -35,7 +35,7 @@ type CommentFixtureEntry = {
 function makeDocumentXml(bodyXml: string): string {
   return (
     `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
-    `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">` +
+    `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="w14">` +
     `<w:body>${bodyXml}</w:body>` +
     `</w:document>`
   );

--- a/packages/docx-mcp/src/tools/save.test.ts
+++ b/packages/docx-mcp/src/tools/save.test.ts
@@ -128,7 +128,7 @@ describe('save', () => {
       `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
       `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" ` +
       `xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" ` +
-      `xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">` +
+      `xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="w14">` +
       `<w:body>` +
       `<w:p w14:paraId="11111111"><w:r><w:t>Alpha target text</w:t></w:r></w:p>` +
       `<w:p w14:paraId="22222222" w:rsidR="00AA00AA">` +

--- a/scripts/check_emitted_document_schema.mjs
+++ b/scripts/check_emitted_document_schema.mjs
@@ -1,0 +1,332 @@
+#!/usr/bin/env node
+/**
+ * Validate emitted word/document.xml files against the vendored ECMA-376
+ * Transitional WML schema (issue #214 CI gate).
+ *
+ * Inputs are directories or files:
+ *   - a directory is scanned (non-recursively) for *.xml and *.docx entries
+ *   - a *.xml file is validated as a document.xml instance
+ *   - a *.docx file has its word/document.xml extracted and validated
+ *
+ * The corpus is produced by running the docx-core test suite with
+ * SDX_SCHEMA_CORPUS_DIR set (see src/primitives/schema-corpus-capture.ts):
+ *
+ *   SDX_SCHEMA_CORPUS_DIR=.tmp/schema-corpus npm run test:run -w @usejunior/docx-core
+ *   node scripts/check_emitted_document_schema.mjs --self-test .tmp/schema-corpus
+ *
+ * Flags:
+ *   --self-test            first prove the harness can both accept a known-good
+ *                          and reject a known-bad instance (guards against a
+ *                          broken schema wrapper silently passing everything)
+ *   --allow-empty          do not fail when the inputs yield zero instances
+ *   --known-failures FILE  JSON array of { id, issue, match, reason } entries
+ *                          pinning known engine-bug error classes. An invalid
+ *                          instance whose every error line contains some
+ *                          entry's `match` substring is reported but does not
+ *                          fail the gate; an entry that matches nothing warns
+ *                          (the bug is probably fixed — remove the entry).
+ *                          Classes, not file hashes: emitted XML embeds
+ *                          revision timestamps, so content hashes churn.
+ *
+ * Requires xmllint (libxml2). The script fails loudly when xmllint is
+ * missing — a gate that silently skips is not a gate.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import JSZip from 'jszip';
+import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const WRAPPER_XSD = join(repoRoot, 'spec-compliance/ecma-376/validation/wml-document-transitional.xsd');
+
+const KNOWN_GOOD = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body><w:p><w:r><w:t>ok</w:t></w:r></w:p></w:body>
+</w:document>`;
+
+// Invalid: CT_Body forbids a bare w:r child, and w:p forbids a w:body child.
+const KNOWN_BAD = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body><w:r><w:t>bad</w:t></w:r></w:body>
+</w:document>`;
+
+function fail(message) {
+  console.error(`check_emitted_document_schema: ${message}`);
+  process.exit(1);
+}
+
+function requireXmllint() {
+  const probe = spawnSync('xmllint', ['--version'], { encoding: 'utf-8' });
+  if (probe.error) {
+    fail(
+      'xmllint not found. Install libxml2 (macOS: bundled with the OS; ' +
+        'Debian/Ubuntu: apt-get install libxml2-utils) and re-run.'
+    );
+  }
+}
+
+/** Run xmllint over a batch of instance files. Returns per-file errors. */
+function validateBatch(files) {
+  const failures = [];
+  const CHUNK = 100;
+  for (let i = 0; i < files.length; i += CHUNK) {
+    const chunk = files.slice(i, i + CHUNK);
+    const result = spawnSync(
+      'xmllint',
+      ['--noout', '--nonet', '--schema', WRAPPER_XSD, ...chunk],
+      { encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 }
+    );
+    if (result.error) fail(`xmllint failed to run: ${result.error.message}`);
+    if (result.status === 0) continue;
+    // stderr carries both "<file> validates" and per-file error lines; keep
+    // everything except the "validates" confirmations.
+    const stderr = (result.stderr ?? '').split('\n');
+    let chunkFailures = 0;
+    for (const file of chunk) {
+      const lines = stderr.filter(
+        (line) =>
+          line.startsWith(file) && !line.endsWith(' validates') && !line.endsWith(' fails to validate')
+      );
+      if (lines.length > 0) {
+        failures.push({ file, lines });
+        chunkFailures += 1;
+      }
+    }
+    if (chunkFailures === 0) {
+      // Non-zero exit with no parseable per-file errors (e.g. schema compile
+      // failure) must still fail the gate, with full output for diagnosis.
+      fail(`xmllint exited ${result.status} without per-file errors:\n${result.stderr}`);
+    }
+  }
+  return failures;
+}
+
+function selfTest() {
+  const dir = mkdtempSync(join(tmpdir(), 'sdx-schema-selftest-'));
+  try {
+    const goodPath = join(dir, 'known-good.xml');
+    const badPath = join(dir, 'known-bad.xml');
+    writeFileSync(goodPath, KNOWN_GOOD);
+    writeFileSync(badPath, KNOWN_BAD);
+    const failures = validateBatch([goodPath, badPath]);
+    const failedFiles = failures.map((f) => f.file);
+    if (failedFiles.includes(goodPath)) {
+      fail(`self-test: known-good instance did not validate:\n${failures.map((f) => f.lines.join('\n')).join('\n')}`);
+    }
+    if (!failedFiles.includes(badPath)) {
+      fail('self-test: known-bad instance validated — the schema wrapper is not enforcing anything');
+    }
+    console.log('self-test passed: known-good validates, known-bad is rejected');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+const MC_NS = 'http://schemas.openxmlformats.org/markup-compatibility/2006';
+
+/**
+ * Markup Compatibility and Extensibility (ECMA-376 Part 3) preprocessing.
+ *
+ * Word-emitted documents carry extension markup (w14:paraId, wp14 anchor
+ * attributes, ...) in namespaces the root declares via mc:Ignorable. A
+ * conformant consumer removes ignorable markup before structural validation;
+ * the WML XSD alone cannot express this, so we preprocess here:
+ *   - resolve each mc:Ignorable prefix to its namespace URI
+ *   - drop attributes and elements in those namespaces
+ *   - drop all mc-namespace attributes (mc:Ignorable itself)
+ *   - resolve mc:AlternateContent to its mc:Fallback content
+ *
+ * Returns the input unchanged when no mc markup is present, so plain
+ * documents are validated byte-for-byte as emitted.
+ */
+function applyMcePreprocessing(xml) {
+  if (!xml.includes(MC_NS)) return { xml };
+  let doc;
+  try {
+    doc = new DOMParser().parseFromString(xml, 'application/xml');
+  } catch (error) {
+    // Not even well-formed. Surface as a gate failure with the parser's
+    // message instead of crashing the whole run.
+    return { parseError: String(error?.message ?? error).split('\n')[0] };
+  }
+  const root = doc.documentElement;
+  if (!root) return { xml };
+
+  const ignorableNs = new Set();
+  const ignorable = root.getAttributeNS(MC_NS, 'Ignorable');
+  if (ignorable) {
+    for (const prefix of ignorable.trim().split(/\s+/)) {
+      const ns = root.lookupNamespaceURI(prefix);
+      if (ns) ignorableNs.add(ns);
+    }
+  }
+
+  const visit = (element) => {
+    if (element.namespaceURI === MC_NS && element.localName === 'AlternateContent') {
+      const fallback = Array.from(element.childNodes).find(
+        (n) => n.namespaceURI === MC_NS && n.localName === 'Fallback'
+      );
+      const parent = element.parentNode;
+      if (fallback) {
+        for (const child of Array.from(fallback.childNodes)) {
+          parent.insertBefore(child, element);
+          if (child.nodeType === 1) visit(child);
+        }
+      }
+      parent.removeChild(element);
+      return;
+    }
+    if (element.namespaceURI && ignorableNs.has(element.namespaceURI)) {
+      element.parentNode.removeChild(element);
+      return;
+    }
+    for (const attr of Array.from(element.attributes ?? [])) {
+      if (attr.namespaceURI === MC_NS || (attr.namespaceURI && ignorableNs.has(attr.namespaceURI))) {
+        element.removeAttributeNode(attr);
+      }
+    }
+    for (const child of Array.from(element.childNodes)) {
+      if (child.nodeType === 1) visit(child);
+    }
+  };
+  visit(root);
+  return { xml: new XMLSerializer().serializeToString(doc) };
+}
+
+async function collectInstances(inputs, scratchDir) {
+  const xmlFiles = [];
+  const docxFiles = [];
+  for (const input of inputs) {
+    const path = resolve(input);
+    let stats;
+    try {
+      stats = statSync(path);
+    } catch {
+      fail(`input not found: ${path}`);
+    }
+    if (stats.isDirectory()) {
+      for (const entry of readdirSync(path)) {
+        if (entry.endsWith('.xml')) xmlFiles.push(join(path, entry));
+        else if (entry.endsWith('.docx')) docxFiles.push(join(path, entry));
+      }
+    } else if (path.endsWith('.docx')) {
+      docxFiles.push(path);
+    } else {
+      xmlFiles.push(path);
+    }
+  }
+  for (const docxPath of docxFiles) {
+    const zip = await JSZip.loadAsync(readFileSync(docxPath));
+    const part = zip.file('word/document.xml');
+    if (!part) fail(`${docxPath}: missing word/document.xml`);
+    const extracted = join(scratchDir, `${basename(docxPath, '.docx')}.document.xml`);
+    writeFileSync(extracted, await part.async('string'));
+    xmlFiles.push(extracted);
+  }
+  // MCE preprocessing: validate the post-MCE projection, written to scratch
+  // under the same basename so failures still identify the source instance.
+  return xmlFiles.map((file) => {
+    const xml = readFileSync(file, 'utf-8');
+    const result = applyMcePreprocessing(xml);
+    if (result.parseError) {
+      return { path: file, name: basename(file), parseError: result.parseError };
+    }
+    if (result.xml === xml) return { path: file, name: basename(file) };
+    const projected = join(scratchDir, basename(file));
+    writeFileSync(projected, result.xml);
+    return { path: projected, name: basename(file) };
+  });
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const runSelfTest = args.includes('--self-test');
+  const allowEmpty = args.includes('--allow-empty');
+  const knownFailuresIdx = args.indexOf('--known-failures');
+  const knownFailuresPath = knownFailuresIdx >= 0 ? args[knownFailuresIdx + 1] : null;
+  const inputs = args.filter(
+    (arg, i) => !arg.startsWith('--') && (knownFailuresIdx < 0 || i !== knownFailuresIdx + 1)
+  );
+
+  const knownFailures = knownFailuresPath
+    ? JSON.parse(readFileSync(knownFailuresPath, 'utf-8'))
+    : [];
+
+  requireXmllint();
+  try {
+    statSync(WRAPPER_XSD);
+  } catch {
+    fail(`validation entry schema missing: ${WRAPPER_XSD}`);
+  }
+  if (runSelfTest) selfTest();
+
+  if (inputs.length === 0) {
+    if (runSelfTest) return;
+    fail('no inputs given (pass directories/files, or --self-test)');
+  }
+
+  const scratchDir = mkdtempSync(join(tmpdir(), 'sdx-schema-corpus-'));
+  try {
+    const instances = await collectInstances(inputs, scratchDir);
+    if (instances.length === 0) {
+      if (allowEmpty) {
+        console.log('no document.xml instances found (allowed by --allow-empty)');
+        return;
+      }
+      fail('no document.xml instances found — the corpus capture produced nothing');
+    }
+
+    const failures = instances
+      .filter((inst) => inst.parseError)
+      .map((inst) => ({ name: inst.name, lines: [`not well-formed: ${inst.parseError}`] }));
+    const validatable = instances.filter((inst) => !inst.parseError);
+    const byPath = new Map(validatable.map((inst) => [inst.path, inst.name]));
+    for (const { file, lines } of validateBatch(validatable.map((inst) => inst.path))) {
+      failures.push({ name: byPath.get(file) ?? basename(file), lines });
+    }
+
+    const unexpected = [];
+    const usedEntries = new Set();
+    let pinnedCount = 0;
+    for (const failure of failures) {
+      const entryFor = (line) => knownFailures.find((entry) => line.includes(entry.match));
+      const entries = failure.lines.map(entryFor);
+      if (failure.lines.length > 0 && entries.every(Boolean)) {
+        pinnedCount += 1;
+        for (const entry of entries) usedEntries.add(entry.id);
+        const ids = [...new Set(entries.map((entry) => `${entry.id} (${entry.issue})`))];
+        console.log(`pinned known failure: ${failure.name} — ${ids.join(', ')}`);
+      } else {
+        unexpected.push(failure);
+      }
+    }
+    for (const entry of knownFailures) {
+      if (!usedEntries.has(entry.id)) {
+        console.warn(
+          `WARNING: known-failure entry '${entry.id}' (${entry.issue}) matched nothing — probably fixed; remove it from the baseline`
+        );
+      }
+    }
+
+    if (unexpected.length > 0) {
+      for (const { name, lines } of unexpected) {
+        console.error(`\nINVALID: ${name}`);
+        for (const line of lines.slice(0, 20)) console.error(`  ${line}`);
+        if (lines.length > 20) console.error(`  … ${lines.length - 20} more errors in this instance`);
+      }
+      fail(`${unexpected.length} of ${instances.length} document.xml instances failed schema validation`);
+    }
+    const knownNote = pinnedCount > 0 ? ` (${pinnedCount} instances pinned to known engine bugs)` : '';
+    console.log(
+      `${instances.length - pinnedCount} of ${instances.length} document.xml instances validate against the Transitional WML schema${knownNote}`
+    );
+  } finally {
+    rmSync(scratchDir, { recursive: true, force: true });
+  }
+}
+
+await main();

--- a/scripts/check_emitted_document_schema.mjs
+++ b/scripts/check_emitted_document_schema.mjs
@@ -141,10 +141,10 @@ const MC_NS = 'http://schemas.openxmlformats.org/markup-compatibility/2006';
  *   - resolve mc:AlternateContent to its mc:Fallback content
  *
  * Returns the input unchanged when no mc markup is present, so plain
- * documents are validated byte-for-byte as emitted.
+ * documents are validated byte-for-byte as emitted. The decision is made on
+ * the parsed DOM (namespace-aware), never on substring probing.
  */
 function applyMcePreprocessing(xml) {
-  if (!xml.includes(MC_NS)) return { xml };
   let doc;
   try {
     doc = new DOMParser().parseFromString(xml, 'application/xml');
@@ -165,6 +165,7 @@ function applyMcePreprocessing(xml) {
     }
   }
 
+  let changed = false;
   const visit = (element) => {
     if (element.namespaceURI === MC_NS && element.localName === 'AlternateContent') {
       const fallback = Array.from(element.childNodes).find(
@@ -178,15 +179,18 @@ function applyMcePreprocessing(xml) {
         }
       }
       parent.removeChild(element);
+      changed = true;
       return;
     }
     if (element.namespaceURI && ignorableNs.has(element.namespaceURI)) {
       element.parentNode.removeChild(element);
+      changed = true;
       return;
     }
     for (const attr of Array.from(element.attributes ?? [])) {
       if (attr.namespaceURI === MC_NS || (attr.namespaceURI && ignorableNs.has(attr.namespaceURI))) {
         element.removeAttributeNode(attr);
+        changed = true;
       }
     }
     for (const child of Array.from(element.childNodes)) {
@@ -194,6 +198,7 @@ function applyMcePreprocessing(xml) {
     }
   };
   visit(root);
+  if (!changed) return { xml };
   return { xml: new XMLSerializer().serializeToString(doc) };
 }
 

--- a/spec-compliance/ecma-376/README.md
+++ b/spec-compliance/ecma-376/README.md
@@ -37,6 +37,12 @@ schemas/
                  Kept for completeness but not used by the conformance lint.
 ```
 
+A sibling `validation/` directory (NOT part of ECMA-376) holds the
+safe-docx-authored entry schema used by the emitted-document schema gate
+(`scripts/check_emitted_document_schema.mjs`), plus a vendored copy of the
+W3C `xml.xsd` that the ECMA-376 schemas import without a schemaLocation.
+Nothing under `schemas/` is modified to make validation work.
+
 ## Why XSDs and not PDFs?
 
 The XSDs encode the **machine-readable** structural rules of ECMA-376 —

--- a/spec-compliance/ecma-376/validation/w3c/SOURCE.txt
+++ b/spec-compliance/ecma-376/validation/w3c/SOURCE.txt
@@ -1,0 +1,13 @@
+xml.xsd is an unmodified copy of the W3C schema for the XML namespace
+(http://www.w3.org/XML/1998/namespace), retrieved 2026-06-11 from:
+
+    https://www.w3.org/2001/xml.xsd
+
+It is reproduced under the W3C Software and Document License:
+
+    https://www.w3.org/copyright/software-license/
+
+It is vendored because the ECMA-376 XSDs import the XML namespace without a
+schemaLocation, and the validation entry schema in the parent directory must
+resolve that import locally (xmllint runs with --nonet; no network fetches).
+Do not modify this file; refresh it only by re-downloading from the URL above.

--- a/spec-compliance/ecma-376/validation/w3c/xml.xsd
+++ b/spec-compliance/ecma-376/validation/w3c/xml.xsd
@@ -1,0 +1,287 @@
+<?xml version='1.0'?>
+<?xml-stylesheet href="../2008/09/xsd.xsl" type="text/xsl"?>
+<xs:schema targetNamespace="http://www.w3.org/XML/1998/namespace" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+  xmlns   ="http://www.w3.org/1999/xhtml"
+  xml:lang="en">
+
+ <xs:annotation>
+  <xs:documentation>
+   <div>
+    <h1>About the XML namespace</h1>
+
+    <div class="bodytext">
+     <p>
+      This schema document describes the XML namespace, in a form
+      suitable for import by other schema documents.
+     </p>
+     <p>
+      See <a href="http://www.w3.org/XML/1998/namespace.html">
+      http://www.w3.org/XML/1998/namespace.html</a> and
+      <a href="http://www.w3.org/TR/REC-xml">
+      http://www.w3.org/TR/REC-xml</a> for information 
+      about this namespace.
+     </p>
+     <p>
+      Note that local names in this namespace are intended to be
+      defined only by the World Wide Web Consortium or its subgroups.
+      The names currently defined in this namespace are listed below.
+      They should not be used with conflicting semantics by any Working
+      Group, specification, or document instance.
+     </p>
+     <p>   
+      See further below in this document for more information about <a
+      href="#usage">how to refer to this schema document from your own
+      XSD schema documents</a> and about <a href="#nsversioning">the
+      namespace-versioning policy governing this schema document</a>.
+     </p>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:attribute name="lang">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>lang (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose value
+       is a language code for the natural language of the content of
+       any element; its value is inherited.  This name is reserved
+       by virtue of its definition in the XML specification.</p>
+     
+    </div>
+    <div>
+     <h4>Notes</h4>
+     <p>
+      Attempting to install the relevant ISO 2- and 3-letter
+      codes as the enumerated possible values is probably never
+      going to be a realistic possibility.  
+     </p>
+     <p>
+      See BCP 47 at <a href="http://www.rfc-editor.org/rfc/bcp/bcp47.txt">
+       http://www.rfc-editor.org/rfc/bcp/bcp47.txt</a>
+      and the IANA language subtag registry at
+      <a href="http://www.iana.org/assignments/language-subtag-registry">
+       http://www.iana.org/assignments/language-subtag-registry</a>
+      for further information.
+     </p>
+     <p>
+      The union allows for the 'un-declaration' of xml:lang with
+      the empty string.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+  <xs:simpleType>
+   <xs:union memberTypes="xs:language">
+    <xs:simpleType>    
+     <xs:restriction base="xs:string">
+      <xs:enumeration value=""/>
+     </xs:restriction>
+    </xs:simpleType>
+   </xs:union>
+  </xs:simpleType>
+ </xs:attribute>
+
+ <xs:attribute name="space">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>space (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose
+       value is a keyword indicating what whitespace processing
+       discipline is intended for the content of the element; its
+       value is inherited.  This name is reserved by virtue of its
+       definition in the XML specification.</p>
+     
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+  <xs:simpleType>
+   <xs:restriction base="xs:NCName">
+    <xs:enumeration value="default"/>
+    <xs:enumeration value="preserve"/>
+   </xs:restriction>
+  </xs:simpleType>
+ </xs:attribute>
+ 
+ <xs:attribute name="base" type="xs:anyURI"> <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>base (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose value
+       provides a URI to be used as the base for interpreting any
+       relative URIs in the scope of the element on which it
+       appears; its value is inherited.  This name is reserved
+       by virtue of its definition in the XML Base specification.</p>
+     
+     <p>
+      See <a
+      href="http://www.w3.org/TR/xmlbase/">http://www.w3.org/TR/xmlbase/</a>
+      for information about this attribute.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+ 
+ <xs:attribute name="id" type="xs:ID">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>id (as an attribute name)</h3> 
+      <p>
+       denotes an attribute whose value
+       should be interpreted as if declared to be of type ID.
+       This name is reserved by virtue of its definition in the
+       xml:id specification.</p>
+     
+     <p>
+      See <a
+      href="http://www.w3.org/TR/xml-id/">http://www.w3.org/TR/xml-id/</a>
+      for information about this attribute.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+
+ <xs:attributeGroup name="specialAttrs">
+  <xs:attribute ref="xml:base"/>
+  <xs:attribute ref="xml:lang"/>
+  <xs:attribute ref="xml:space"/>
+  <xs:attribute ref="xml:id"/>
+ </xs:attributeGroup>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div>
+   
+    <h3>Father (in any context at all)</h3> 
+
+    <div class="bodytext">
+     <p>
+      denotes Jon Bosak, the chair of 
+      the original XML Working Group.  This name is reserved by 
+      the following decision of the W3C XML Plenary and 
+      XML Coordination groups:
+     </p>
+     <blockquote>
+       <p>
+	In appreciation for his vision, leadership and
+	dedication the W3C XML Plenary on this 10th day of
+	February, 2000, reserves for Jon Bosak in perpetuity
+	the XML name "xml:Father".
+       </p>
+     </blockquote>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div xml:id="usage" id="usage">
+    <h2><a name="usage">About this schema document</a></h2>
+
+    <div class="bodytext">
+     <p>
+      This schema defines attributes and an attribute group suitable
+      for use by schemas wishing to allow <code>xml:base</code>,
+      <code>xml:lang</code>, <code>xml:space</code> or
+      <code>xml:id</code> attributes on elements they define.
+     </p>
+     <p>
+      To enable this, such a schema must import this schema for
+      the XML namespace, e.g. as follows:
+     </p>
+     <pre>
+          &lt;schema . . .>
+           . . .
+           &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                      schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+     </pre>
+     <p>
+      or
+     </p>
+     <pre>
+           &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                      schemaLocation="http://www.w3.org/2009/01/xml.xsd"/>
+     </pre>
+     <p>
+      Subsequently, qualified reference to any of the attributes or the
+      group defined below will have the desired effect, e.g.
+     </p>
+     <pre>
+          &lt;type . . .>
+           . . .
+           &lt;attributeGroup ref="xml:specialAttrs"/>
+     </pre>
+     <p>
+      will define a type which will schema-validate an instance element
+      with any of those attributes.
+     </p>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div id="nsversioning" xml:id="nsversioning">
+    <h2><a name="nsversioning">Versioning policy for this schema document</a></h2>
+    <div class="bodytext">
+     <p>
+      In keeping with the XML Schema WG's standard versioning
+      policy, this schema document will persist at
+      <a href="http://www.w3.org/2009/01/xml.xsd">
+       http://www.w3.org/2009/01/xml.xsd</a>.
+     </p>
+     <p>
+      At the date of issue it can also be found at
+      <a href="http://www.w3.org/2001/xml.xsd">
+       http://www.w3.org/2001/xml.xsd</a>.
+     </p>
+     <p>
+      The schema document at that URI may however change in the future,
+      in order to remain compatible with the latest version of XML
+      Schema itself, or with the XML namespace itself.  In other words,
+      if the XML Schema or XML namespaces change, the version of this
+      document at <a href="http://www.w3.org/2001/xml.xsd">
+       http://www.w3.org/2001/xml.xsd 
+      </a> 
+      will change accordingly; the version at 
+      <a href="http://www.w3.org/2009/01/xml.xsd">
+       http://www.w3.org/2009/01/xml.xsd 
+      </a> 
+      will not change.
+     </p>
+     <p>
+      Previous dated (and unchanging) versions of this schema 
+      document are at:
+     </p>
+     <ul>
+      <li><a href="http://www.w3.org/2009/01/xml.xsd">
+	http://www.w3.org/2009/01/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2007/08/xml.xsd">
+	http://www.w3.org/2007/08/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2004/10/xml.xsd">
+	http://www.w3.org/2004/10/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2001/03/xml.xsd">
+	http://www.w3.org/2001/03/xml.xsd</a></li>
+     </ul>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+</xs:schema>
+

--- a/spec-compliance/ecma-376/validation/wml-document-transitional.xsd
+++ b/spec-compliance/ecma-376/validation/wml-document-transitional.xsd
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Validation entry schema for emitted word/document.xml.
+
+  The vendored Transitional WML schema (../schemas/transitional/wml.xsd)
+  imports the XML namespace (xml:space, xml:lang) without a schemaLocation,
+  so xmllint (run with its "nonet" option) cannot compile it. This wrapper loads
+  the vendored W3C xml.xsd for that namespace first, then pulls in wml.xsd;
+  by the time wml.xsd's namespace-only import is processed, the namespace is
+  already resolved locally.
+
+  This file is safe-docx-authored plumbing, NOT part of ECMA-376. The files
+  under ../schemas/ remain unmodified normative copies.
+
+  Used by: scripts/check_emitted_document_schema.mjs (issue #214 CI gate).
+-->
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            elementFormDefault="qualified">
+  <xsd:import namespace="http://www.w3.org/XML/1998/namespace"
+              schemaLocation="w3c/xml.xsd"/>
+  <xsd:import namespace="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+              schemaLocation="../schemas/transitional/wml.xsd"/>
+</xsd:schema>


### PR DESCRIPTION
## Summary

Implements the #214 defense-in-depth gate: every `word/document.xml` the engine emits during the docx-core test run is captured and validated against the vendored ECMA-376 Transitional WML schema in CI.

- **Capture** (`SDX_SCHEMA_CORPUS_DIR`, opt-in, content-hash dedup) at the engine's emission choke points: both comparison pipelines, primitives saves (`DocxDocument.toBuffer`), and generation (`generateDocx`). Deliberately *not* in `DocxArchive.setDocumentXml` — tests use that setter to author adversarial inputs, which must not poison the corpus.
- **Validator** (`scripts/check_emitted_document_schema.mjs`, `npm run check:emitted-schema`): drives `xmllint --nonet` against the vendored `transitional/wml.xsd`, with ECMA-376 Part 3 (MCE) preprocessing first (strip `mc:Ignorable`-declared namespaces, resolve `mc:AlternateContent` to its fallback) so Word-real `w14`/`wp14` extension markup validates the way a conformant consumer sees it. A `--self-test` proves the harness rejects a known-bad instance before trusting any pass.
- **Entry schema** (`spec-compliance/ecma-376/validation/`): the Ecma XSDs import the XML namespace without a `schemaLocation`, which `xmllint --nonet` cannot resolve; a safe-docx-authored wrapper imports a vendored W3C `xml.xsd` explicitly first. Nothing under `schemas/` is modified.
- **CI**: the `workspace-test` job exports `SDX_SCHEMA_CORPUS_DIR` during the existing test steps (no duplicate test run) and a new step validates the ~1600-instance corpus on both matrix legs. Any unpinned violation fails the job.

## The gate found real bugs on its first run

Filed separately per the one-fix-per-PR convention, pinned as **error-class** entries in `coverage/emitted-schema-known-failures.json` (matched by message class, not content hash — emitted XML embeds revision timestamps, so hashes churn). A pinned class that stops matching prints a remove-me warning:

- #450 — comparison emits **non-well-formed** document.xml on the ILPA fixture pair (orphaned `</w:pPr>` after a paragraph-mark `sectPr`); the committed `typescript_redline.docx` artifact exhibits it too
- #451 — duplicate `w:rPrChange` stacking in a single `w:rPr`
- #452 — duplicate paragraph-mark `w:ins` in `w:pPr/w:rPr` (one of the two also bypasses the fixed-date revision context)
- #453 — synthetic table fixtures omit the required `w:tblGrid` (test debt)

Also fixed inline: the synthetic fixture builders now declare `mc:Ignorable="w14"` like every Word-authored document, so fixture-derived corpus instances validate the same way real documents do.

## Validation

- `node scripts/check_emitted_document_schema.mjs --self-test --known-failures … .tmp/schema-corpus` → **1564 of 1621 instances validate** (57 pinned to the four issues above, zero stale entries)
- Full pre-submit chain green: build, lint:workspaces, check:cycles, test:run (all workspaces), check:spec-coverage, check:conformance-citations, check:conformance-doc, check:emitted-schema
- `actionlint` clean on the workflow change

Fixes: #214