### PR TITLE
fix(docx-core): atomize proofErr-only paragraphs as empty-paragraph atoms

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ safe-docx targets a defined subset of **ECMA-376 5th edition**. The full surface
 (targeted sections, Non-Goals, and verification status) lives at
 [spec-compliance/CONFORMANCE.md](spec-compliance/CONFORMANCE.md).
 
-- **62** sections claimed
+- **63** sections claimed
 - **5** sections explicitly out-of-scope (Non-Goals)
 - **0** known gaps under `@conformance-gap`
 - Vendored normative schemas: `spec-compliance/ecma-376/schemas/`

--- a/packages/docx-core/src/atomizer.test.ts
+++ b/packages/docx-core/src/atomizer.test.ts
@@ -863,6 +863,12 @@ describe('empty paragraph context hashing', () => {
     }).atoms.filter((atom) => atom.contentElement.tagName === EMPTY_PARAGRAPH_TAG);
   }
 
+  function defaultEmptyAtoms(document: Element): ReturnType<typeof atomizeTree>['atoms'] {
+    return atomizeTree(document, [], mockPart).atoms.filter(
+      (atom) => atom.contentElement.tagName === EMPTY_PARAGRAPH_TAG
+    );
+  }
+
   test('keeps empty paragraph hashes stable when preceding run text is merged', async ({ given, when, then }: AllureBddContext) => {
     let splitBody: Element;
     let mergedBody: Element;
@@ -1005,6 +1011,7 @@ describe('empty paragraph context hashing', () => {
     let baselineHash: string;
     let bookmarkHash: string;
     let proofErrHash: string;
+    let proofErrEmptyCount: number;
 
     await given('empty paragraphs after content-transparent marker-only paragraphs', () => {
       baselineBody = el('w:body', {}, [textParagraph('alpha'), emptyParagraph()]);
@@ -1023,18 +1030,89 @@ describe('empty paragraph context hashing', () => {
     await when('the bodies are atomized with paragraph-level markers enabled', () => {
       const baselineEmpty = emptyAtoms(baselineBody)[0];
       const bookmarkEmpty = emptyAtoms(bookmarkBody)[0];
-      const proofErrEmpty = emptyAtoms(proofErrBody)[0];
+      const proofErrEmpties = emptyAtoms(proofErrBody);
+      const proofErrEmpty = proofErrEmpties[0];
       assertDefined(baselineEmpty, 'baseline empty paragraph atom');
       assertDefined(bookmarkEmpty, 'bookmark-context empty paragraph atom');
       assertDefined(proofErrEmpty, 'proofErr-context empty paragraph atom');
       baselineHash = baselineEmpty.sha1Hash;
       bookmarkHash = bookmarkEmpty.sha1Hash;
       proofErrHash = proofErrEmpty.sha1Hash;
+      proofErrEmptyCount = proofErrEmpties.length;
     });
 
     await then('the following empty paragraph hashes match the baseline', () => {
+      expect(proofErrEmptyCount).toBe(2);
       expect(bookmarkHash).toBe(baselineHash);
       expect(proofErrHash).toBe(baselineHash);
+    });
+  });
+
+  test('proofErr-only paragraphs hash like stripped empty paragraphs', async ({ given, when, then }: AllureBddContext) => {
+    let bareProofErrBody: Element;
+    let bareStrippedBody: Element;
+    let pPrProofErrBody: Element;
+    let pPrStrippedBody: Element;
+    let bareProofErrHash: string;
+    let bareStrippedHash: string;
+    let pPrProofErrHash: string;
+    let pPrStrippedHash: string;
+
+    await given('proofErr-only paragraphs and matching stripped empty paragraphs', () => {
+      const pPr = () => el('w:pPr', {}, [el('w:spacing', { 'w:after': '0' })]);
+      const proofErr = () => el('w:proofErr', { 'w:type': 'spellStart' });
+      bareProofErrBody = el('w:body', {}, [textParagraph('alpha'), emptyParagraph([proofErr()])]);
+      bareStrippedBody = el('w:body', {}, [textParagraph('alpha'), emptyParagraph()]);
+      pPrProofErrBody = el('w:body', {}, [textParagraph('alpha'), emptyParagraph([pPr(), proofErr()])]);
+      pPrStrippedBody = el('w:body', {}, [textParagraph('alpha'), emptyParagraph([pPr()])]);
+    });
+
+    await when('the bodies are atomized with paragraph-level markers enabled', () => {
+      const bareProofErr = emptyAtoms(bareProofErrBody)[0];
+      const bareStripped = emptyAtoms(bareStrippedBody)[0];
+      const pPrProofErr = emptyAtoms(pPrProofErrBody)[0];
+      const pPrStripped = emptyAtoms(pPrStrippedBody)[0];
+      assertDefined(bareProofErr, 'bare proofErr empty atom');
+      assertDefined(bareStripped, 'bare stripped empty atom');
+      assertDefined(pPrProofErr, 'pPr proofErr empty atom');
+      assertDefined(pPrStripped, 'pPr stripped empty atom');
+      bareProofErrHash = bareProofErr.sha1Hash;
+      bareStrippedHash = bareStripped.sha1Hash;
+      pPrProofErrHash = pPrProofErr.sha1Hash;
+      pPrStrippedHash = pPrStripped.sha1Hash;
+    });
+
+    await then('proofErr anchors do not affect empty-paragraph hashes', () => {
+      expect(bareProofErrHash).toBe(bareStrippedHash);
+      expect(pPrProofErrHash).toBe(pPrStrippedHash);
+    });
+  });
+
+  test('proofErr-only paragraphs atomize as empty paragraphs with default options', async ({ given, when, then }: AllureBddContext) => {
+    let proofErrBody: Element;
+    let strippedBody: Element;
+    let proofErrHash: string;
+    let strippedHash: string;
+
+    await given('a proofErr-only paragraph and its stripped counterpart', () => {
+      proofErrBody = el('w:body', {}, [
+        textParagraph('alpha'),
+        emptyParagraph([el('w:proofErr', { 'w:type': 'gramStart' })]),
+      ]);
+      strippedBody = el('w:body', {}, [textParagraph('alpha'), emptyParagraph()]);
+    });
+
+    await when('the bodies are atomized with default options', () => {
+      const proofErrEmpty = defaultEmptyAtoms(proofErrBody)[0];
+      const strippedEmpty = defaultEmptyAtoms(strippedBody)[0];
+      assertDefined(proofErrEmpty, 'default proofErr empty atom');
+      assertDefined(strippedEmpty, 'default stripped empty atom');
+      proofErrHash = proofErrEmpty.sha1Hash;
+      strippedHash = strippedEmpty.sha1Hash;
+    });
+
+    await then('their empty-paragraph hashes match', () => {
+      expect(proofErrHash).toBe(strippedHash);
     });
   });
 });

--- a/packages/docx-core/src/atomizer.ts
+++ b/packages/docx-core/src/atomizer.ts
@@ -389,18 +389,25 @@ export function createComparisonUnitAtom(
 // =============================================================================
 
 /**
- * Check if a paragraph element is empty (has no content, only properties).
+ * Check if a paragraph element is empty (has no content-bearing children).
  *
- * Empty paragraphs have only w:pPr children, no w:r (run) elements.
+ * Empty paragraphs have only paragraph properties, or proofing-error anchors.
+ * `w:proofErr` marks spelling/grammar proofing state and carries no document
+ * content, so a paragraph containing only those anchors is empty for
+ * comparison.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.8.1
+ * @see https://github.com/UseJunior/safe-docx/issues/456
  */
+const EMPTY_PARAGRAPH_TRANSPARENT_TAGS = new Set(['w:pPr', 'w:proofErr']);
+
 function isEmptyParagraph(node: WmlElement): boolean {
   if (node.tagName !== 'w:p') return false;
   const kids = childElements(node);
   if (kids.length === 0) return true;
 
-  // Check if all children are w:pPr (no runs)
   for (const child of kids) {
-    if (child.tagName !== 'w:pPr') {
+    if (!EMPTY_PARAGRAPH_TRANSPARENT_TAGS.has(child.tagName)) {
       return false;
     }
   }

--- a/packages/docx-core/src/integration/issue-456-regression.test.ts
+++ b/packages/docx-core/src/integration/issue-456-regression.test.ts
@@ -1,0 +1,178 @@
+import JSZip from 'jszip';
+import { describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { compareDocuments } from '../index.js';
+import { parseXml } from '../primitives/xml.js';
+import { buildDocxFromBodyXml } from '../testing/ooxml-fixtures.js';
+
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({ feature: 'Issue #456 proofErr-only paragraph matching' });
+
+type ReconstructionMode = 'rebuild' | 'inplace';
+
+function paragraph(text: string): string {
+  return `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
+}
+
+function emptyParagraph(): string {
+  return `<w:p/>`;
+}
+
+function proofErrOnlyParagraph(): string {
+  return `<w:p><w:proofErr w:type="spellStart"/><w:proofErr w:type="spellEnd"/></w:p>`;
+}
+
+async function documentXml(buffer: Buffer): Promise<string> {
+  const zip = await JSZip.loadAsync(buffer);
+  const document = zip.file('word/document.xml');
+  if (!document) {
+    throw new Error('word/document.xml missing from DOCX');
+  }
+  return document.async('string');
+}
+
+function countTag(xml: string, tagName: 'w:p' | 'w:ins' | 'w:del' | 'w:proofErr'): number {
+  return (xml.match(new RegExp(`<${tagName}\\b`, 'g')) ?? []).length;
+}
+
+function documentParagraphCount(xml: string): number {
+  const doc = parseXml(xml);
+  return doc.getElementsByTagName('w:p').length;
+}
+
+async function compareBodyXml(
+  originalBodyXml: string,
+  revisedBodyXml: string,
+  reconstructionMode: ReconstructionMode
+): Promise<{ result: Awaited<ReturnType<typeof compareDocuments>>; xml: string }> {
+  const original = await buildDocxFromBodyXml(originalBodyXml);
+  const revised = await buildDocxFromBodyXml(revisedBodyXml);
+  const result = await compareDocuments(original, revised, {
+    engine: 'atomizer',
+    reconstructionMode,
+  });
+  return { result, xml: await documentXml(result.document) };
+}
+
+const proofErrFixture = paragraph('alpha') + proofErrOnlyParagraph() + paragraph('omega');
+const strippedFixture = paragraph('alpha') + emptyParagraph() + paragraph('omega');
+const withoutMiddleFixture = paragraph('alpha') + paragraph('omega');
+
+describe('Issue #456 — proofErr-only paragraph atomization', () => {
+  for (const mode of ['rebuild', 'inplace'] as const) {
+    test(`${mode} identity comparison preserves the proofErr-only paragraph without changes`, async ({
+      given,
+      when,
+      then,
+      and,
+    }: AllureBddContext) => {
+      let result: Awaited<ReturnType<typeof compareDocuments>>;
+      let xml: string;
+
+      await given('identical documents with a proofErr-only middle paragraph', async () => {});
+
+      await when(`compared in ${mode} mode`, async () => {
+        ({ result, xml } = await compareBodyXml(proofErrFixture, proofErrFixture, mode));
+      });
+
+      await then('no tracked changes are emitted', () => {
+        expect(countTag(xml, 'w:ins')).toBe(0);
+        expect(countTag(xml, 'w:del')).toBe(0);
+        expect(result.stats.insertions).toBe(0);
+        expect(result.stats.deletions).toBe(0);
+        expect(result.stats.modifications).toBe(0);
+      });
+
+      await and('the empty middle paragraph remains present', () => {
+        expect(documentParagraphCount(xml)).toBe(3);
+        expect(countTag(xml, 'w:p')).toBe(3);
+        expect(countTag(xml, 'w:proofErr')).toBe(mode === 'inplace' ? 2 : 0);
+      });
+    });
+
+    test(`${mode} comparison against a stripped counterpart does not report phantom changes`, async ({
+      given,
+      when,
+      then,
+      and,
+    }: AllureBddContext) => {
+      let result: Awaited<ReturnType<typeof compareDocuments>>;
+      let xml: string;
+
+      await given('a proofErr-only paragraph and the same paragraph with proofErr stripped', async () => {});
+
+      await when(`compared in ${mode} mode`, async () => {
+        ({ result, xml } = await compareBodyXml(proofErrFixture, strippedFixture, mode));
+      });
+
+      await then('no tracked changes are emitted', () => {
+        expect(countTag(xml, 'w:ins')).toBe(0);
+        expect(countTag(xml, 'w:del')).toBe(0);
+        expect(result.stats.insertions).toBe(0);
+        expect(result.stats.deletions).toBe(0);
+        expect(result.stats.modifications).toBe(0);
+      });
+
+      await and('the middle paragraph remains present', () => {
+        expect(documentParagraphCount(xml)).toBe(3);
+      });
+    });
+
+    test(`${mode} comparison reports a deleted proofErr-only paragraph`, async ({
+      given,
+      when,
+      then,
+      and,
+    }: AllureBddContext) => {
+      let result: Awaited<ReturnType<typeof compareDocuments>>;
+      let xml: string;
+
+      await given('an original proofErr-only paragraph removed from the revised document', async () => {});
+
+      await when(`compared in ${mode} mode`, async () => {
+        ({ result, xml } = await compareBodyXml(proofErrFixture, withoutMiddleFixture, mode));
+      });
+
+      await then('one paragraph-mark deletion is emitted', () => {
+        expect(countTag(xml, 'w:ins')).toBe(0);
+        expect(countTag(xml, 'w:del')).toBe(1);
+        expect(result.stats.insertions).toBe(0);
+        expect(result.stats.deletions).toBe(1);
+      });
+
+      await and('the deleted paragraph remains in the output with mode-specific proofErr retention', () => {
+        expect(documentParagraphCount(xml)).toBe(3);
+        expect(countTag(xml, 'w:proofErr')).toBe(mode === 'inplace' ? 2 : 0);
+      });
+    });
+
+    test(`${mode} comparison reports an inserted proofErr-only paragraph`, async ({
+      given,
+      when,
+      then,
+      and,
+    }: AllureBddContext) => {
+      let result: Awaited<ReturnType<typeof compareDocuments>>;
+      let xml: string;
+
+      await given('a revised proofErr-only paragraph inserted between unchanged paragraphs', async () => {});
+
+      await when(`compared in ${mode} mode`, async () => {
+        ({ result, xml } = await compareBodyXml(withoutMiddleFixture, proofErrFixture, mode));
+      });
+
+      await then('one paragraph-mark insertion is emitted', () => {
+        expect(countTag(xml, 'w:ins')).toBe(1);
+        expect(countTag(xml, 'w:del')).toBe(0);
+        expect(result.stats.insertions).toBe(1);
+        expect(result.stats.deletions).toBe(0);
+      });
+
+      await and('the inserted paragraph remains in the output with mode-specific proofErr retention', () => {
+        expect(documentParagraphCount(xml)).toBe(3);
+        expect(countTag(xml, 'w:proofErr')).toBe(mode === 'inplace' ? 2 : 0);
+      });
+    });
+  }
+});

--- a/spec-compliance/CONFORMANCE.md
+++ b/spec-compliance/CONFORMANCE.md
@@ -15,6 +15,7 @@ Allure labels via `testAllure.conformance({…})`; source code carries
 | --- | --- | --- | --- | --- | --- | --- |
 | `ECMA-PART4-17-16-5` | w:delInstrText and w:fldChar placement in tracked deletions | 5 | 4 | 17.16.5 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:delInstrText` | — |
 | `ECMA-PART1-17-13-5` | Paragraph-level OOXML markers | 5 | 1 | 17.13.5 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:pPrChange` | — |
+| `ECMA-PART1-17-13-8-1` | Proofing error anchors | 5 | 1 | 17.13.8.1 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:proofErr` | — |
 | `ECMA-PART1-17-11-14` | w:footnoteReference identifier vs display number | 5 | 1 | 17.11.14 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:footnoteReference` | — |
 | `ECMA-PART1-17-16-22` | w:hyperlink container preservation under tracked changes | 5 | 1 | 17.16.22 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:hyperlink` | — |
 | `ECMA-PART1-17-6-17` | w:sectPr document-final section properties | 5 | 1 | 17.6.17 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:sectPr` | — |
@@ -107,6 +108,19 @@ wrappers like `<w:ins>` / `<w:del>` / `<w:moveFrom>` / `<w:moveTo>`) but
 never inside `<w:r>`. safe-docx's rebuild reconstructor emits them as
 siblings of `<w:r>`, not as leaves wrapped in a synthetic run. The
 authoritative list lives in `packages/docx-core/src/atomizer.ts`.
+
+### ECMA-PART1-17-13-8-1 — Proofing error anchors
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.13.8.1
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:proofErr`
+
+`w:proofErr` anchors mark spelling or grammar proofing state. They are
+consumer-rewritable metadata and carry no document content, so safe-docx
+treats a paragraph whose only children are proofing anchors as an empty
+paragraph for comparison. Rebuild reconstruction does not re-emit those
+anchors.
 
 ### ECMA-PART1-17-11-14 — w:footnoteReference identifier vs display number
 

--- a/spec-compliance/registry/ecma-376.md
+++ b/spec-compliance/registry/ecma-376.md
@@ -52,6 +52,23 @@ never inside `<w:r>`. safe-docx's rebuild reconstructor emits them as
 siblings of `<w:r>`, not as leaves wrapped in a synthetic run. The
 authoritative list lives in `packages/docx-core/src/atomizer.ts`.
 
+## [ECMA-PART1-17-13-8-1] Proofing error anchors
+
+```yaml
+edition: 5
+part: 1
+section: "17.13.8.1"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:proofErr
+verifiedBy:
+```
+
+`w:proofErr` anchors mark spelling or grammar proofing state. They are
+consumer-rewritable metadata and carry no document content, so safe-docx
+treats a paragraph whose only children are proofing anchors as an empty
+paragraph for comparison. Rebuild reconstruction does not re-emit those
+anchors.
+
 ## [ECMA-PART1-17-11-14] w:footnoteReference identifier vs display number
 
 ```yaml


### PR DESCRIPTION
## Summary

Fixes #456 by treating `w:proofErr` proofing anchors as transparent for empty-paragraph atomization. A paragraph containing only `w:pPr` and `w:proofErr` now produces an empty-paragraph atom instead of disappearing from the atom stream.

This also registers ECMA-376 Part 1 § 17.13.8.1 for the new conformance citation and regenerates the conformance docs.

A proofErr-only paragraph and a truly empty paragraph in the same context now hash identically by design. LCS may pair either with either, which is harmless because both reconstruct to the same output for the relevant mode.

## Validation

- `cd packages/docx-core && npx vitest run src/atomizer.test.ts src/integration/issue-456-regression.test.ts` — 67 passed
- `node /tmp/probe-proofErr-only-paragraph.mjs` — identity output has 3 paragraphs; stripped counterpart has `ins: 0`, `del: 0`, 3 paragraphs
- `npm run build && npm run lint:workspaces && npm run test:run && npm run check:spec-coverage && npm run check:conformance-citations && npm run check:conformance-doc`
  - initial sandbox run failed in `npm run test:run` because `tsx` could not create an IPC pipe and LibreOffice aborted under sandboxing
  - reran `npm run test:run` with sandbox escalation: all workspaces passed
  - reran `npm run check:conformance-doc` after committing generated docs: OK