### PR TITLE
fix(docx-core): replace duplicate rPrChange snapshots

### DIFF
--- a/coverage/emitted-schema-known-failures.json
+++ b/coverage/emitted-schema-known-failures.json
@@ -1,11 +1,5 @@
 [
   {
-    "id": "duplicate-rprchange-in-rpr",
-    "issue": "#451",
-    "match": "}rPrChange': This element is not expected.",
-    "reason": "comparison stacks duplicate w:rPrChange children in a single w:rPr; CT_RPr allows at most one"
-  },
-  {
     "id": "duplicate-para-mark-ins",
     "issue": "#452",
     "match": "}ins': This element is not expected.",

--- a/packages/docx-core/src/baselines/atomizer/inPlaceModifier-wrappers.ts
+++ b/packages/docx-core/src/baselines/atomizer/inPlaceModifier-wrappers.ts
@@ -421,6 +421,15 @@ export function addFormatChange(
     run.insertBefore(rPr, run.firstChild);
   }
 
+  // CT_RPr permits at most one w:rPrChange. Comparison can visit multiple
+  // format-changed atoms from the same split run, so keep the latest snapshot
+  // instead of stacking invalid siblings.
+  for (const child of childElements(rPr)) {
+    if (child.tagName === 'w:rPrChange') {
+      rPr.removeChild(child);
+    }
+  }
+
   // Create rPrChange
   const id = allocateRevisionId(state);
   const rPrChange = createEl('w:rPrChange', {

--- a/packages/docx-core/src/baselines/atomizer/inPlaceModifier.test.ts
+++ b/packages/docx-core/src/baselines/atomizer/inPlaceModifier.test.ts
@@ -1653,6 +1653,33 @@ describe('inPlaceModifier', () => {
         expect(childElements(innerRPr)).toHaveLength(3);
       });
     });
+
+    test('replaces an existing rPrChange instead of stacking duplicates', async ({ given, when, then }: AllureBddContext) => {
+      let r: Element;
+      let firstOldRPr: Element;
+      let secondOldRPr: Element;
+      let state: ReturnType<typeof createRevisionIdState>;
+
+      await given('a run whose formatting is visited twice by split format-changed atoms', () => {
+        r = el('w:r', {}, [el('w:rPr', {}, [el('w:b')]), el('w:t', {}, undefined, 'text')]);
+        firstOldRPr = el('w:rPr', {}, [el('w:i')]);
+        secondOldRPr = el('w:rPr', {}, [el('w:color', { 'w:val': 'FF0000' })]);
+        state = createRevisionIdState();
+      });
+
+      await when('addFormatChange is called twice for the same run', () => {
+        addFormatChange(r, firstOldRPr, author, dateStr, state);
+        addFormatChange(r, secondOldRPr, author, dateStr, state);
+      });
+
+      await then('the current rPr contains one replacement rPrChange snapshot', () => {
+        const rPr = childElements(r).find((c) => c.tagName === 'w:rPr')!;
+        const rPrChanges = childElements(rPr).filter((c) => c.tagName === 'w:rPrChange');
+        expect(rPrChanges).toHaveLength(1);
+        const innerRPr = childElements(rPrChanges[0]!).find((c) => c.tagName === 'w:rPr')!;
+        expect(childElements(innerRPr).map((c) => c.tagName)).toEqual(['w:color']);
+      });
+    });
   });
 
   // ── Branch coverage: preSplitMixedStatusRuns ──────────────────────


### PR DESCRIPTION
## What changed

`addFormatChange` now removes any existing `w:rPrChange` under the same `w:rPr` before appending the replacement snapshot. A regression test covers repeated format-change visits for one run, and the #451 emitted-schema known failure was removed.

## Why

The comparison pipeline can visit multiple format-changed atoms that came from the same split run. Appending a new `w:rPrChange` each time creates invalid `CT_RPr` because only one run-property revision child is allowed in a single `w:rPr`.

## Validation

- `npm exec vitest -- packages/docx-core/src/baselines/atomizer/inPlaceModifier.test.ts --run`
- `npm run check:conformance-citations`
- `npm run build -w @usejunior/docx-core`

Note: the full committed output corpus still contains unrelated pre-existing schema failures from other issue branches, so validation here is focused on the #451 invariant.