### PR TITLE
fix(docx-core): reuse ordered paragraph mark revisions

### DIFF
--- a/coverage/emitted-schema-known-failures.json
+++ b/coverage/emitted-schema-known-failures.json
@@ -1,11 +1,5 @@
 [
   {
-    "id": "duplicate-para-mark-ins",
-    "issue": "#452",
-    "match": "}ins': This element is not expected.",
-    "reason": "tracked paragraph insertion emits two paragraph-mark w:ins markers in w:pPr/w:rPr; CT_ParaRPr allows at most one"
-  },
-  {
     "id": "synthetic-table-missing-tblgrid",
     "issue": "#453",
     "match": "}tr': This element is not expected.",

--- a/packages/docx-core/src/baselines/atomizer/documentReconstructor.ts
+++ b/packages/docx-core/src/baselines/atomizer/documentReconstructor.ts
@@ -25,6 +25,7 @@ import {
 import { serializeToXml, cloneElement } from './xmlToWmlElement.js';
 import { EMPTY_PARAGRAPH_TAG, isParagraphLevelLeaf, nearestHyperlinkAncestor } from '../../atomizer.js';
 import { enforceConsumerCompatibility } from './consumerCompatibility.js';
+import { placeParagraphMarkRevisionMarker } from './inPlaceModifier-wrappers.js';
 import { areRunPropertiesEqual } from '../../format-detection.js';
 import { debug } from './debug.js';
 
@@ -751,13 +752,20 @@ function serializePPrWithParaRevisionMarker(
     }
   }
 
-  // Insert revision marker at start of rPr.
-  const marker = createEl(markerTag, {
-    'w:id': String(id),
-    'w:author': author,
-    'w:date': dateStr,
-  });
-  rPr.insertBefore(marker, rPr.firstChild);
+  // Reuse a pre-existing paragraph-mark marker of the same kind cloned from the
+  // source pPr (issue #452): CT_ParaRPr allows at most one of each tracked-change
+  // child, and the source revision's metadata (author/date/id) outranks a
+  // synthetic duplicate. Either way the marker is placed in its schema-correct
+  // slot ahead of formatting children.
+  const existingMarker = findChildByTagName(rPr, markerTag);
+  const marker =
+    existingMarker ??
+    createEl(markerTag, {
+      'w:id': String(id),
+      'w:author': author,
+      'w:date': dateStr,
+    });
+  placeParagraphMarkRevisionMarker(rPr, marker, markerTag);
 
   // Append pPrChange at end if provided.
   if (pPrChangeEl) {

--- a/packages/docx-core/src/baselines/atomizer/inPlaceModifier-wrappers.ts
+++ b/packages/docx-core/src/baselines/atomizer/inPlaceModifier-wrappers.ts
@@ -208,6 +208,9 @@ export function addParagraphMarkRevisionMarker(
     if (!existingMarker.getAttribute('w:id')) {
       existingMarker.setAttribute('w:id', String(allocateRevisionId(state)));
     }
+    // The bypass path may have left the marker mid-sequence (or in another
+    // w:rPr); move it to the schema-correct slot in the canonical rPr.
+    placeParagraphMarkRevisionMarker(rPr, existingMarker, markerTag);
     return;
   }
 
@@ -218,8 +221,30 @@ export function addParagraphMarkRevisionMarker(
     'w:date': dateStr,
   });
 
-  // Insert marker at the start of rPr for consistency with Aspose/Word patterns.
-  rPr.insertBefore(marker, rPr.firstChild);
+  placeParagraphMarkRevisionMarker(rPr, marker, markerTag);
+}
+
+/**
+ * Position a paragraph-mark revision marker in its schema-correct rPr slot.
+ *
+ * CT_ParaRPr ordering: the tracked-change group (w:ins, w:del, w:moveFrom,
+ * w:moveTo — in that order) comes before every formatting child (w:rStyle,
+ * w:rFonts, ...). So w:ins always goes first, and w:del goes right after a
+ * w:ins sibling when one exists, else first.
+ */
+export function placeParagraphMarkRevisionMarker(
+  rPr: Element,
+  marker: Element,
+  markerTag: 'w:ins' | 'w:del'
+): void {
+  const insSibling = markerTag === 'w:del' ? findChildByTagName(rPr, 'w:ins') : null;
+  if (insSibling) {
+    if (insSibling.nextSibling !== marker) {
+      insertAfterElement(insSibling, marker);
+    }
+  } else if (rPr.firstChild !== marker) {
+    rPr.insertBefore(marker, rPr.firstChild);
+  }
 }
 
 function findParagraphMarkRevisionMarker(

--- a/packages/docx-core/src/baselines/atomizer/inPlaceModifier-wrappers.ts
+++ b/packages/docx-core/src/baselines/atomizer/inPlaceModifier-wrappers.ts
@@ -181,6 +181,8 @@ export function addParagraphMarkRevisionMarker(
     paragraph.insertBefore(pPr, paragraph.firstChild);
   }
 
+  const existingMarker = findParagraphMarkRevisionMarker(pPr, markerTag);
+
   // Find or create rPr within pPr (paragraph mark properties).
   let rPr = findChildByTagName(pPr, 'w:rPr');
   if (!rPr) {
@@ -197,8 +199,17 @@ export function addParagraphMarkRevisionMarker(
     }
   }
 
-  // Avoid duplicating markers.
-  if (findChildByTagName(rPr, markerTag)) return;
+  // Avoid duplicating markers. A legacy/bypass path may already have put the
+  // paragraph-mark marker in another w:rPr under the same pPr; keep that marker
+  // and normalize its revision context instead of adding a second CT_ParaRPr child.
+  if (existingMarker) {
+    existingMarker.setAttribute('w:author', author);
+    existingMarker.setAttribute('w:date', dateStr);
+    if (!existingMarker.getAttribute('w:id')) {
+      existingMarker.setAttribute('w:id', String(allocateRevisionId(state)));
+    }
+    return;
+  }
 
   const id = allocateRevisionId(state);
   const marker = createEl(markerTag, {
@@ -209,6 +220,18 @@ export function addParagraphMarkRevisionMarker(
 
   // Insert marker at the start of rPr for consistency with Aspose/Word patterns.
   rPr.insertBefore(marker, rPr.firstChild);
+}
+
+function findParagraphMarkRevisionMarker(
+  pPr: Element,
+  markerTag: 'w:ins' | 'w:del'
+): Element | null {
+  for (const child of childElements(pPr)) {
+    if (child.tagName !== 'w:rPr') continue;
+    const marker = findChildByTagName(child, markerTag);
+    if (marker) return marker;
+  }
+  return null;
 }
 
 // @lean-segment: field-wrapper-emission

--- a/packages/docx-core/src/baselines/atomizer/inPlaceModifier.test.ts
+++ b/packages/docx-core/src/baselines/atomizer/inPlaceModifier.test.ts
@@ -819,8 +819,11 @@ describe('inPlaceModifier', () => {
       let state: ReturnType<typeof createRevisionIdState>;
 
       await given('a paragraph with a pre-existing paragraph-mark w:ins from a bypass path', () => {
+        // The bypass marker sits AFTER a formatting child — an invalid
+        // CT_ParaRPr sequence that reuse must repair, not preserve.
         pPr = el('w:pPr', {}, [
           el('w:rPr', {}, [
+            el('w:b'),
             el('w:ins', {
               'w:id': '99',
               'w:author': 'Bypass',
@@ -836,7 +839,7 @@ describe('inPlaceModifier', () => {
         wrapParagraphAsInserted(p, author, dateStr, state);
       });
 
-      await then('only one paragraph-mark w:ins remains with the comparison author and date', () => {
+      await then('only one paragraph-mark w:ins remains, first in rPr, with the comparison author and date', () => {
         const markers = childElements(pPr)
           .filter((c) => c.tagName === 'w:rPr')
           .flatMap((rPr) => childElements(rPr).filter((c) => c.tagName === 'w:ins'));
@@ -844,6 +847,39 @@ describe('inPlaceModifier', () => {
         expect(markers[0]!.getAttribute('w:id')).toBe('99');
         expect(markers[0]!.getAttribute('w:author')).toBe(author);
         expect(markers[0]!.getAttribute('w:date')).toBe(dateStr);
+
+        // CT_ParaRPr puts the tracked-change group before formatting children,
+        // so the reused w:ins must be moved to the front of rPr.
+        const rPr = childElements(pPr).find((c) => c.tagName === 'w:rPr');
+        expect(childElements(rPr!).map((c) => c.tagName)).toEqual(['w:ins', 'w:b']);
+      });
+    });
+
+    test('keeps the paragraph-mark w:del after w:ins per CT_ParaRPr order', async ({ given, when, then }: AllureBddContext) => {
+      let pPr: Element, p: Element;
+      let state: ReturnType<typeof createRevisionIdState>;
+
+      await given('a paragraph whose mark already carries a w:ins marker', () => {
+        pPr = el('w:pPr', {}, [
+          el('w:rPr', {}, [
+            el('w:ins', {
+              'w:id': '7',
+              'w:author': 'Bypass',
+              'w:date': '2020-01-01T00:00:00Z',
+            }),
+          ]),
+        ]);
+        p = el('w:p', {}, [pPr, el('w:r', {}, [el('w:t', {}, undefined, 'text')])]);
+        state = createRevisionIdState();
+      });
+
+      await when('wrapParagraphAsDeleted marks the paragraph mark as deleted', () => {
+        wrapParagraphAsDeleted(p, author, dateStr, state);
+      });
+
+      await then('rPr orders the tracked-change group w:ins then w:del', () => {
+        const rPr = childElements(pPr).find((c) => c.tagName === 'w:rPr');
+        expect(childElements(rPr!).map((c) => c.tagName)).toEqual(['w:ins', 'w:del']);
       });
     });
   });

--- a/packages/docx-core/src/baselines/atomizer/inPlaceModifier.test.ts
+++ b/packages/docx-core/src/baselines/atomizer/inPlaceModifier.test.ts
@@ -813,6 +813,39 @@ describe('inPlaceModifier', () => {
         expect(insMarker).toBeDefined();
       });
     });
+
+    test('reuses an existing paragraph-mark insertion and normalizes revision context', async ({ given, when, then }: AllureBddContext) => {
+      let pPr: Element, p: Element;
+      let state: ReturnType<typeof createRevisionIdState>;
+
+      await given('a paragraph with a pre-existing paragraph-mark w:ins from a bypass path', () => {
+        pPr = el('w:pPr', {}, [
+          el('w:rPr', {}, [
+            el('w:ins', {
+              'w:id': '99',
+              'w:author': 'Bypass',
+              'w:date': '2020-01-01T00:00:00Z',
+            }),
+          ]),
+        ]);
+        p = el('w:p', {}, [pPr, el('w:r', {}, [el('w:t', {}, undefined, 'text')])]);
+        state = createRevisionIdState();
+      });
+
+      await when('wrapParagraphAsInserted applies the comparison revision context', () => {
+        wrapParagraphAsInserted(p, author, dateStr, state);
+      });
+
+      await then('only one paragraph-mark w:ins remains with the comparison author and date', () => {
+        const markers = childElements(pPr)
+          .filter((c) => c.tagName === 'w:rPr')
+          .flatMap((rPr) => childElements(rPr).filter((c) => c.tagName === 'w:ins'));
+        expect(markers).toHaveLength(1);
+        expect(markers[0]!.getAttribute('w:id')).toBe('99');
+        expect(markers[0]!.getAttribute('w:author')).toBe(author);
+        expect(markers[0]!.getAttribute('w:date')).toBe(dateStr);
+      });
+    });
   });
 
   describe('addParagraphPropertyChange', () => {


### PR DESCRIPTION
## What changed

- Reuses existing paragraph-mark `w:ins` / `w:del` markers instead of emitting duplicates.
- Places reused or newly-created paragraph-mark revision markers in `CT_ParaRPr` tracked-change order: `w:ins`, then `w:del`, before base run properties.
- Applies the same reuse/positioning path to cloned `pPr` serialization in `documentReconstructor`, not only the in-place wrapper path.
- Normalizes reused marker author/date to the active comparison context while preserving an existing revision id.

## Why

Issue #452 originally exposed duplicate paragraph-mark insertion markers. Removing that known-failure pin also exposed a second schema failure: reused `w:ins` markers could sit after `w:del` or formatting children, which violates the `CT_ParaRPr` sequence and caused the emitted schema gate to reject comparison output.

## Validation

- `npm run build`
- `npm run lint:workspaces`
- `npm run test:run -w @usejunior/docx-core` (rerun unsandboxed after sandbox IPC/LibreOffice probe failures)
- `npm run check:spec-coverage`
- `npm run check:conformance-citations`
- `npm run check:conformance-doc`
- `node scripts/check_emitted_document_schema.mjs --self-test --known-failures coverage/emitted-schema-known-failures.json .tmp/schema-corpus`
  - Result: `3181 of 3189 document.xml instances validate`; the 8 remaining failures are the existing #453 known pins.

Fixes: #452