### PR TITLE
fix(docx-core): merge paragraph-mark revisions into the following paragraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ safe-docx targets a defined subset of **ECMA-376 5th edition**. The full surface
 (targeted sections, Non-Goals, and verification status) lives at
 [spec-compliance/CONFORMANCE.md](spec-compliance/CONFORMANCE.md).
 
-- **63** sections claimed
+- **65** sections claimed
 - **5** sections explicitly out-of-scope (Non-Goals)
 - **0** known gaps under `@conformance-gap`
 - Vendored normative schemas: `spec-compliance/ecma-376/schemas/`

--- a/packages/docx-core/src/baselines/atomizer/trackChangesAcceptorAst.test.ts
+++ b/packages/docx-core/src/baselines/atomizer/trackChangesAcceptorAst.test.ts
@@ -12,6 +12,7 @@ import { parseDocumentXml } from './xmlToWmlElement.js';
 import {
   findAllByTagName,
   acceptChanges as acceptChangesPrimitive,
+  rejectChanges as rejectChangesPrimitive,
   parseXml,
   serializeXml,
 } from '../../primitives/index.js';
@@ -856,14 +857,16 @@ describe('trackChangesAcceptorAst', () => {
   });
 });
 
-// ── G5 regression: Accept-All paragraph removal is purely mark-based (both accept paths) ──
+// ── G5 regression: Accept-All paragraph-mark handling is purely mark-based (both accept paths) ──
 //
 // Closes G5 — the accept-side mirror of #337's reject fix. Both accept entry points — the
 // baseline-atomizer `acceptAllChanges` (string→string) and the primitive `acceptChanges`
-// (Document, mutated in place) — must drop a paragraph IFF its paragraph MARK is PPR-DEL
+// (Document, mutated in place) — must resolve a paragraph IFF its paragraph MARK is PPR-DEL
 // (<w:pPr><w:rPr><w:del/></w:rPr>), never via a content-based heuristic. A run-level deletion
 // (or moveFrom) under an UNTRACKED mark means text removed from a pre-existing paragraph, which
-// Word/LibreOffice keep (empty) on accept. The two paths must agree on every case.
+// Word/LibreOffice keep (empty) on accept. Resolving a PPR-DEL mark merges the paragraph into
+// the following one (#431) — only the break is deleted, not the contents. The two paths must
+// agree on every case.
 describe('Accept-All paragraph removal is mark-based (G5, both accept paths agree)', () => {
   const wrapBody = (inner: string): string =>
     `<?xml version="1.0"?>` +
@@ -883,19 +886,24 @@ describe('Accept-All paragraph removal is mark-based (G5, both accept paths agre
     return { ast, primitive: serializeXml(doc) };
   };
 
-  test('PPR-DEL-marked paragraph: both paths DROP it', async ({ when, then }: AllureBddContext) => {
+  test('PPR-DEL-marked paragraph: both paths MERGE it into the following paragraph', async ({ when, then }: AllureBddContext) => {
+    // The PPR-DEL mark deletes only the paragraph BREAK (ECMA-376 § 17.13.5.15); the
+    // paragraph's untracked content is NOT deleted and must survive the merge (#431).
     let out: { ast: string; primitive: string };
-    await when('both accept paths run on a PPR-DEL-marked paragraph + a plain paragraph', () => {
+    await when('both accept paths run on a PPR-DEL-marked paragraph with untracked content + a plain paragraph', () => {
       out = acceptBoth(
-        `<w:p><w:pPr><w:rPr><w:del w:id="1" w:author="T"/></w:rPr></w:pPr><w:r><w:t>gone</w:t></w:r></w:p>` +
+        `<w:p><w:pPr><w:rPr><w:del w:id="1" w:author="T"/></w:rPr></w:pPr><w:r><w:t>merged</w:t></w:r></w:p>` +
           KEEP_PARA,
       );
     });
-    await then('only the survivor paragraph remains, on both paths', () => {
+    await then('one paragraph remains holding the merged content before the survivor text, on both paths', () => {
       expect(countParagraphs(out.ast)).toBe(1);
       expect(countParagraphs(out.primitive)).toBe(1);
-      expect(out.ast).not.toContain('gone');
-      expect(out.primitive).not.toContain('gone');
+      for (const xml of [out.ast, out.primitive]) {
+        expect(xml).toContain('merged');
+        expect(xml).toContain('keep');
+        expect(xml.indexOf('merged')).toBeLessThan(xml.indexOf('keep'));
+      }
     });
   });
 
@@ -943,6 +951,367 @@ describe('Accept-All paragraph removal is mark-based (G5, both accept paths agre
       expect(countParagraphs(out.primitive)).toBe(1);
       expect(out.ast).toContain('survives');
       expect(out.primitive).toContain('survives');
+    });
+  });
+});
+
+// ── #431: a paragraph-mark revision merges the paragraph into the following one ──
+//
+// ECMA-376 Part 1 § 17.13.5.15 (del / Deleted Paragraph) and § 17.13.5.20 (ins /
+// Inserted Paragraph) make the paragraph MARK the revision target; the paragraph's
+// contents are not implicitly part of the revision. Accepting a deleted mark (or
+// rejecting an inserted one) therefore removes only the paragraph BREAK: the
+// paragraph's surviving content merges into the following paragraph, which keeps
+// its own w:pPr (formatting follows the surviving mark). Both engine paths — the
+// baseline-atomizer string functions and the in-place primitives — must agree.
+describe('Paragraph-mark revisions merge into the following paragraph (#431)', () => {
+  const acceptTest = testAllure
+    .epic('Document Comparison')
+    .withLabels({ feature: 'Track Changes Acceptor' })
+    .conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.5.15' });
+  const rejectTest = testAllure
+    .epic('Document Comparison')
+    .withLabels({ feature: 'Track Changes Acceptor' })
+    .conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.5.20' });
+
+  const wrapBody = (inner: string): string =>
+    `<?xml version="1.0"?>` +
+    `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
+    `<w:body>${inner}</w:body></w:document>`;
+
+  // Count <w:p> opens, matching self-closing empties (<w:p/>) too; never matches <w:pPr>/<w:pPrChange>.
+  const countParagraphs = (xml: string): number => (xml.match(/<w:p(?:\s|\/|>)/g) ?? []).length;
+
+  const extractText = (xml: string): string =>
+    (xml.match(/<w:t[^>]*>([^<]*)<\/w:t>/g) ?? [])
+      .map((t) => t.replace(/<[^>]+>/g, ''))
+      .join('');
+
+  const acceptBoth = (inner: string): { ast: string; primitive: string } => {
+    const ast = acceptAllChanges(wrapBody(inner));
+    const doc = parseXml(wrapBody(inner));
+    acceptChangesPrimitive(doc);
+    return { ast, primitive: serializeXml(doc) };
+  };
+
+  const rejectBoth = (inner: string): { ast: string; primitive: string } => {
+    const ast = rejectAllChanges(wrapBody(inner));
+    const doc = parseXml(wrapBody(inner));
+    rejectChangesPrimitive(doc);
+    return { ast, primitive: serializeXml(doc) };
+  };
+
+  const DEL_MARK = `<w:del w:id="1" w:author="T" w:date="2024-01-01T00:00:00Z"/>`;
+  const INS_MARK = `<w:ins w:id="1" w:author="T" w:date="2024-01-01T00:00:00Z"/>`;
+
+  acceptTest('accepting a deleted paragraph mark merges the preceding content into the next paragraph', async ({ when, then }: AllureBddContext) => {
+    // The docx-platform-tests acceptDeletedParagraphMarkMergesParagraphs scenario.
+    let out: { ast: string; primitive: string };
+    await when('accept runs on a mark-deleted paragraph "First half " followed by "second half"', () => {
+      out = acceptBoth(
+        `<w:p><w:pPr><w:rPr>${DEL_MARK}</w:rPr></w:pPr><w:r><w:t xml:space="preserve">First half </w:t></w:r></w:p>` +
+          `<w:p><w:r><w:t>second half</w:t></w:r></w:p>`,
+      );
+    });
+    await then('one paragraph remains reading "First half second half", on both paths', () => {
+      for (const xml of [out.ast, out.primitive]) {
+        expect(countParagraphs(xml)).toBe(1);
+        expect(extractText(xml)).toBe('First half second half');
+      }
+    });
+  });
+
+  rejectTest('rejecting an inserted paragraph mark merges the preceding content into the next paragraph', async ({ when, then }: AllureBddContext) => {
+    // The docx-platform-tests rejectInsertedParagraphMarkMergesParagraphs scenario.
+    let out: { ast: string; primitive: string };
+    await when('reject runs on a mark-inserted paragraph "First half " followed by "second half"', () => {
+      out = rejectBoth(
+        `<w:p><w:pPr><w:rPr>${INS_MARK}</w:rPr></w:pPr><w:r><w:t xml:space="preserve">First half </w:t></w:r></w:p>` +
+          `<w:p><w:r><w:t>second half</w:t></w:r></w:p>`,
+      );
+    });
+    await then('one paragraph remains reading "First half second half", on both paths', () => {
+      for (const xml of [out.ast, out.primitive]) {
+        expect(countParagraphs(xml)).toBe(1);
+        expect(extractText(xml)).toBe('First half second half');
+      }
+    });
+  });
+
+  acceptTest('the merged paragraph keeps the FOLLOWING paragraph\'s w:pPr (formatting follows the surviving mark)', async ({ when, then }: AllureBddContext) => {
+    let out: { ast: string; primitive: string };
+    await when('accept runs on a centered mark-deleted paragraph followed by a styled paragraph', () => {
+      out = acceptBoth(
+        `<w:p><w:pPr><w:rPr>${DEL_MARK}</w:rPr><w:jc w:val="center"/></w:pPr><w:r><w:t>head</w:t></w:r></w:p>` +
+          `<w:p><w:pPr><w:pStyle w:val="Quote"/></w:pPr><w:r><w:t>tail</w:t></w:r></w:p>`,
+      );
+    });
+    await then('the survivor keeps its pStyle and the merged-away paragraph\'s jc is gone, on both paths', () => {
+      for (const xml of [out.ast, out.primitive]) {
+        expect(countParagraphs(xml)).toBe(1);
+        expect(extractText(xml)).toBe('headtail');
+        expect(xml).toContain('Quote');
+        expect(xml).not.toContain('center');
+      }
+    });
+  });
+
+  acceptTest('consecutive mark-deleted paragraphs cascade into the first surviving paragraph', async ({ when, then }: AllureBddContext) => {
+    let out: { ast: string; primitive: string };
+    await when('accept runs on two consecutive mark-deleted paragraphs followed by a plain one', () => {
+      out = acceptBoth(
+        `<w:p><w:pPr><w:rPr>${DEL_MARK}</w:rPr></w:pPr><w:r><w:t>one </w:t></w:r></w:p>` +
+          `<w:p><w:pPr><w:rPr><w:del w:id="2" w:author="T" w:date="2024-01-01T00:00:00Z"/></w:rPr></w:pPr><w:r><w:t>two </w:t></w:r></w:p>` +
+          `<w:p><w:r><w:t>three</w:t></w:r></w:p>`,
+      );
+    });
+    await then('one paragraph remains with all three contents in order, on both paths', () => {
+      for (const xml of [out.ast, out.primitive]) {
+        expect(countParagraphs(xml)).toBe(1);
+        expect(extractText(xml)).toBe('one two three');
+      }
+    });
+  });
+
+  acceptTest('a trailing mark-deleted paragraph with surviving content is KEPT (no break to remove, no data loss)', async ({ when, then }: AllureBddContext) => {
+    let out: { ast: string; primitive: string };
+    await when('accept runs on a plain paragraph followed by a trailing mark-deleted paragraph with untracked content', () => {
+      out = acceptBoth(
+        `<w:p><w:r><w:t>lead</w:t></w:r></w:p>` +
+          `<w:p><w:pPr><w:rPr>${DEL_MARK}</w:rPr></w:pPr><w:r><w:t>tail</w:t></w:r></w:p>`,
+      );
+    });
+    await then('both paragraphs survive with their content, on both paths', () => {
+      for (const xml of [out.ast, out.primitive]) {
+        expect(countParagraphs(xml)).toBe(2);
+        expect(extractText(xml)).toBe('leadtail');
+      }
+    });
+  });
+
+  acceptTest('a trailing mark-deleted paragraph emptied by its own w:del content is removed (comparison round-trip shape)', async ({ when, then }: AllureBddContext) => {
+    // wrapParagraphAsDeleted emits all runs inside w:del + the PPR-DEL mark; once the
+    // run-level deletions are accepted nothing remains to merge or keep.
+    let out: { ast: string; primitive: string };
+    await when('accept runs on a plain paragraph followed by a trailing fully-deleted paragraph', () => {
+      out = acceptBoth(
+        `<w:p><w:r><w:t>lead</w:t></w:r></w:p>` +
+          `<w:p><w:pPr><w:rPr>${DEL_MARK}</w:rPr></w:pPr>` +
+          `<w:del w:id="2" w:author="T" w:date="2024-01-01T00:00:00Z"><w:r><w:delText>gone</w:delText></w:r></w:del></w:p>`,
+      );
+    });
+    await then('only the lead paragraph remains, on both paths', () => {
+      for (const xml of [out.ast, out.primitive]) {
+        expect(countParagraphs(xml)).toBe(1);
+        expect(extractText(xml)).toBe('lead');
+      }
+    });
+  });
+
+  acceptTest('a mark-deleted paragraph directly before a table is KEPT (no paragraph to merge into)', async ({ when, then }: AllureBddContext) => {
+    let out: { ast: string; primitive: string };
+    await when('accept runs on a mark-deleted paragraph with content followed by a table', () => {
+      out = acceptBoth(
+        `<w:p><w:pPr><w:rPr>${DEL_MARK}</w:rPr></w:pPr><w:r><w:t>before table</w:t></w:r></w:p>` +
+          `<w:tbl><w:tr><w:tc><w:p><w:r><w:t>cell</w:t></w:r></w:p></w:tc></w:tr></w:tbl>` +
+          `<w:p><w:r><w:t>after</w:t></w:r></w:p>`,
+      );
+    });
+    await then('the paragraph content is not merged into the table and not lost, on both paths', () => {
+      for (const xml of [out.ast, out.primitive]) {
+        expect(extractText(xml)).toBe('before tablecellafter');
+        // The content stays in its own paragraph before the table.
+        expect(xml.indexOf('before table')).toBeLessThan(xml.indexOf('<w:tbl'));
+      }
+    });
+  });
+
+  rejectTest('consecutive mark-inserted paragraphs cascade into the first surviving paragraph on reject', async ({ when, then }: AllureBddContext) => {
+    let out: { ast: string; primitive: string };
+    await when('reject runs on two consecutive mark-inserted paragraphs followed by a plain one', () => {
+      out = rejectBoth(
+        `<w:p><w:pPr><w:rPr>${INS_MARK}</w:rPr></w:pPr><w:r><w:t>one </w:t></w:r></w:p>` +
+          `<w:p><w:pPr><w:rPr><w:ins w:id="2" w:author="T" w:date="2024-01-01T00:00:00Z"/></w:rPr></w:pPr><w:r><w:t>two </w:t></w:r></w:p>` +
+          `<w:p><w:r><w:t>three</w:t></w:r></w:p>`,
+      );
+    });
+    await then('one paragraph remains with all three contents in order, on both paths', () => {
+      for (const xml of [out.ast, out.primitive]) {
+        expect(countParagraphs(xml)).toBe(1);
+        expect(extractText(xml)).toBe('one two three');
+      }
+    });
+  });
+
+  rejectTest('on reject the merged paragraph keeps the FOLLOWING paragraph\'s w:pPr', async ({ when, then }: AllureBddContext) => {
+    let out: { ast: string; primitive: string };
+    await when('reject runs on a centered mark-inserted paragraph followed by a styled paragraph', () => {
+      out = rejectBoth(
+        `<w:p><w:pPr><w:rPr>${INS_MARK}</w:rPr><w:jc w:val="center"/></w:pPr><w:r><w:t>head</w:t></w:r></w:p>` +
+          `<w:p><w:pPr><w:pStyle w:val="Quote"/></w:pPr><w:r><w:t>tail</w:t></w:r></w:p>`,
+      );
+    });
+    await then('the survivor keeps its pStyle and the merged-away paragraph\'s jc is gone, on both paths', () => {
+      for (const xml of [out.ast, out.primitive]) {
+        expect(countParagraphs(xml)).toBe(1);
+        expect(extractText(xml)).toBe('headtail');
+        expect(xml).toContain('Quote');
+        expect(xml).not.toContain('center');
+      }
+    });
+  });
+
+  rejectTest('a trailing mark-inserted paragraph with surviving content is KEPT on reject', async ({ when, then }: AllureBddContext) => {
+    let out: { ast: string; primitive: string };
+    await when('reject runs on a plain paragraph followed by a trailing mark-inserted paragraph with untracked content', () => {
+      out = rejectBoth(
+        `<w:p><w:r><w:t>lead</w:t></w:r></w:p>` +
+          `<w:p><w:pPr><w:rPr>${INS_MARK}</w:rPr></w:pPr><w:r><w:t>tail</w:t></w:r></w:p>`,
+      );
+    });
+    await then('both paragraphs survive with their content, on both paths', () => {
+      for (const xml of [out.ast, out.primitive]) {
+        expect(countParagraphs(xml)).toBe(2);
+        expect(extractText(xml)).toBe('leadtail');
+      }
+    });
+  });
+
+  rejectTest('a trailing mark-inserted paragraph emptied by its own w:ins content is removed on reject', async ({ when, then }: AllureBddContext) => {
+    // wrapParagraphAsInserted emits all runs inside w:ins + the PPR-INS mark; once the
+    // run-level insertions are rejected nothing remains to merge or keep.
+    let out: { ast: string; primitive: string };
+    await when('reject runs on a plain paragraph followed by a trailing fully-inserted paragraph', () => {
+      out = rejectBoth(
+        `<w:p><w:r><w:t>lead</w:t></w:r></w:p>` +
+          `<w:p><w:pPr><w:rPr>${INS_MARK}</w:rPr></w:pPr>` +
+          `<w:ins w:id="2" w:author="T" w:date="2024-01-01T00:00:00Z"><w:r><w:t>gone</w:t></w:r></w:ins></w:p>`,
+      );
+    });
+    await then('only the lead paragraph remains, on both paths', () => {
+      for (const xml of [out.ast, out.primitive]) {
+        expect(countParagraphs(xml)).toBe(1);
+        expect(extractText(xml)).toBe('lead');
+      }
+    });
+  });
+
+  rejectTest('a mark-inserted paragraph directly before a table is KEPT on reject', async ({ when, then }: AllureBddContext) => {
+    let out: { ast: string; primitive: string };
+    await when('reject runs on a mark-inserted paragraph with untracked content followed by a table', () => {
+      out = rejectBoth(
+        `<w:p><w:pPr><w:rPr>${INS_MARK}</w:rPr></w:pPr><w:r><w:t>before table</w:t></w:r></w:p>` +
+          `<w:tbl><w:tr><w:tc><w:p><w:r><w:t>cell</w:t></w:r></w:p></w:tc></w:tr></w:tbl>` +
+          `<w:p><w:r><w:t>after</w:t></w:r></w:p>`,
+      );
+    });
+    await then('the paragraph content is not merged into the table and not lost, on both paths', () => {
+      for (const xml of [out.ast, out.primitive]) {
+        expect(extractText(xml)).toBe('before tablecellafter');
+        expect(xml.indexOf('before table')).toBeLessThan(xml.indexOf('<w:tbl'));
+      }
+    });
+  });
+
+  acceptTest('block-level customXml range markup between the paragraphs does not block the merge', async ({ when, then }: AllureBddContext) => {
+    // EG_RangeMarkupElements members are valid block-level siblings (wml.xsd);
+    // the merge-target scan must skip them, not bail out.
+    let out: { ast: string; primitive: string };
+    await when('accept runs on a mark-deleted paragraph separated from the next by a customXmlInsRangeEnd marker', () => {
+      out = acceptBoth(
+        `<w:p><w:pPr><w:rPr>${DEL_MARK}</w:rPr></w:pPr><w:r><w:t xml:space="preserve">First half </w:t></w:r></w:p>` +
+          `<w:customXmlInsRangeEnd w:id="9"/>` +
+          `<w:p><w:r><w:t>second half</w:t></w:r></w:p>`,
+      );
+    });
+    await then('one paragraph remains reading "First half second half", on both paths', () => {
+      for (const xml of [out.ast, out.primitive]) {
+        expect(countParagraphs(xml)).toBe(1);
+        expect(extractText(xml)).toBe('First half second half');
+      }
+    });
+  });
+
+  rejectTest('a direct-child bookmark boundary keeps its position relative to merged content on reject', async ({ when, then }: AllureBddContext) => {
+    // Regression: bookmark preservation must not pre-relocate direct-child
+    // bookmarks of a merging paragraph — the merge carries them in document
+    // order, and an early move would put the start BEFORE the surviving
+    // untracked content it follows.
+    let out: { ast: string; primitive: string };
+    await when('reject runs on a mark-inserted paragraph with untracked content then a bookmarkStart, whose end is in the next paragraph', () => {
+      out = rejectBoth(
+        `<w:p><w:pPr><w:rPr>${INS_MARK}</w:rPr></w:pPr><w:r><w:t xml:space="preserve">head </w:t></w:r><w:bookmarkStart w:id="7" w:name="bm"/></w:p>` +
+          `<w:p><w:bookmarkEnd w:id="7"/><w:r><w:t>tail</w:t></w:r></w:p>`,
+      );
+    });
+    await then('the merged paragraph reads head-bookmarkStart-bookmarkEnd-tail in that order, on both paths', () => {
+      for (const xml of [out.ast, out.primitive]) {
+        expect(countParagraphs(xml)).toBe(1);
+        expect(extractText(xml)).toBe('head tail');
+        expect(xml.indexOf('head')).toBeLessThan(xml.indexOf('bookmarkStart'));
+        expect(xml.indexOf('bookmarkStart')).toBeLessThan(xml.indexOf('bookmarkEnd'));
+        expect(xml.indexOf('bookmarkEnd')).toBeLessThan(xml.indexOf('tail'));
+      }
+    });
+  });
+
+  acceptTest('an emptied mark-deleted paragraph after a trailing table is KEPT (a table must not become the last block)', async ({ when, then }: AllureBddContext) => {
+    let out: { ast: string; primitive: string };
+    await when('accept runs on a fully-deleted paragraph that trails a table at the end of the body', () => {
+      out = acceptBoth(
+        `<w:p><w:r><w:t>lead</w:t></w:r></w:p>` +
+          `<w:tbl><w:tr><w:tc><w:p><w:r><w:t>cell</w:t></w:r></w:p></w:tc></w:tr></w:tbl>` +
+          `<w:p><w:pPr><w:rPr>${DEL_MARK}</w:rPr></w:pPr>` +
+          `<w:del w:id="2" w:author="T" w:date="2024-01-01T00:00:00Z"><w:r><w:delText>gone</w:delText></w:r></w:del></w:p>`,
+      );
+    });
+    await then('the emptied paragraph survives so the table is not the last block, on both paths', () => {
+      for (const xml of [out.ast, out.primitive]) {
+        expect(extractText(xml)).toBe('leadcell');
+        // lead + cell paragraph + kept empty trailing paragraph
+        expect(countParagraphs(xml)).toBe(3);
+        expect(xml.indexOf('</w:tbl>')).toBeLessThan(xml.lastIndexOf('<w:p'));
+      }
+    });
+  });
+
+  acceptTest('an emptied mark-deleted paragraph between two tables is KEPT (adjacent tables would merge)', async ({ when, then }: AllureBddContext) => {
+    let out: { ast: string; primitive: string };
+    await when('accept runs on a fully-deleted paragraph sitting between two tables', () => {
+      out = acceptBoth(
+        `<w:tbl><w:tr><w:tc><w:p><w:r><w:t>alpha</w:t></w:r></w:p></w:tc></w:tr></w:tbl>` +
+          `<w:p><w:pPr><w:rPr>${DEL_MARK}</w:rPr></w:pPr>` +
+          `<w:del w:id="2" w:author="T" w:date="2024-01-01T00:00:00Z"><w:r><w:delText>gone</w:delText></w:r></w:del></w:p>` +
+          `<w:tbl><w:tr><w:tc><w:p><w:r><w:t>beta</w:t></w:r></w:p></w:tc></w:tr></w:tbl>` +
+          `<w:p><w:r><w:t>after</w:t></w:r></w:p>`,
+      );
+    });
+    await then('the separator paragraph survives between the tables, on both paths', () => {
+      for (const xml of [out.ast, out.primitive]) {
+        expect(extractText(xml)).toBe('alphabetaafter');
+        // alpha cell + separator + beta cell + after
+        expect(countParagraphs(xml)).toBe(4);
+      }
+    });
+  });
+
+  acceptTest('a lone emptied mark-deleted paragraph in a table cell is KEPT (a cell needs a block element)', async ({ when, then }: AllureBddContext) => {
+    let out: { ast: string; primitive: string };
+    await when('accept runs on a table cell whose only paragraph is fully deleted', () => {
+      out = acceptBoth(
+        `<w:tbl><w:tr><w:tc>` +
+          `<w:p><w:pPr><w:rPr>${DEL_MARK}</w:rPr></w:pPr>` +
+          `<w:del w:id="2" w:author="T" w:date="2024-01-01T00:00:00Z"><w:r><w:delText>gone</w:delText></w:r></w:del></w:p>` +
+          `</w:tc></w:tr></w:tbl>` +
+          `<w:p><w:r><w:t>after</w:t></w:r></w:p>`,
+      );
+    });
+    await then('the cell keeps an empty paragraph, on both paths', () => {
+      for (const xml of [out.ast, out.primitive]) {
+        expect(extractText(xml)).toBe('after');
+        // the kept empty cell paragraph + the body paragraph
+        expect(countParagraphs(xml)).toBe(2);
+      }
     });
   });
 });

--- a/packages/docx-core/src/baselines/atomizer/trackChangesAcceptorAst.ts
+++ b/packages/docx-core/src/baselines/atomizer/trackChangesAcceptorAst.ts
@@ -127,6 +127,116 @@ function paragraphContentStartIndex(paragraph: Element): number {
   return idx;
 }
 
+// Marker-ish elements that may sit between two paragraphs at block level
+// without ending the search for a merge target: the full EG_RangeMarkupElements
+// schema group (wml.xsd), plus permStart/permEnd range markers and proofErr
+// proofing anchors.
+const RANGE_MARKUP_BLOCK_SIBLING_TAGS = new Set([
+  'w:bookmarkStart', 'w:bookmarkEnd',
+  'w:commentRangeStart', 'w:commentRangeEnd',
+  'w:moveFromRangeStart', 'w:moveFromRangeEnd',
+  'w:moveToRangeStart', 'w:moveToRangeEnd',
+  'w:customXmlInsRangeStart', 'w:customXmlInsRangeEnd',
+  'w:customXmlDelRangeStart', 'w:customXmlDelRangeEnd',
+  'w:customXmlMoveFromRangeStart', 'w:customXmlMoveFromRangeEnd',
+  'w:customXmlMoveToRangeStart', 'w:customXmlMoveToRangeEnd',
+  'w:permStart', 'w:permEnd',
+  'w:proofErr',
+]);
+
+/**
+ * Find the next sibling paragraph a paragraph-mark revision can merge into,
+ * skipping block-level range/annotation markers. Returns undefined when the
+ * next block is not a paragraph (table, sdt, sectPr, end of parent).
+ */
+function findFollowingSiblingParagraph(p: Element): Element | undefined {
+  const parent = parentElement(p);
+  if (!parent) return undefined;
+  const siblings = childElements(parent);
+  const idx = siblings.indexOf(p);
+  if (idx < 0) return undefined;
+  for (let i = idx + 1; i < siblings.length; i++) {
+    const sibling = siblings[i]!;
+    if (sibling.tagName === 'w:p') return sibling;
+    if (RANGE_MARKUP_BLOCK_SIBLING_TAGS.has(sibling.tagName)) continue;
+    return undefined;
+  }
+  return undefined;
+}
+
+/** True iff the paragraph still holds content beyond w:pPr and bare annotation markers. */
+function paragraphHasContent(p: Element): boolean {
+  return childElements(p).some(
+    (c) => c.tagName !== 'w:pPr' && !RANGE_MARKUP_BLOCK_SIBLING_TAGS.has(c.tagName)
+  );
+}
+
+/**
+ * True iff removing an emptied mark-revised paragraph keeps its parent
+ * structurally valid for Word: the parent must retain at least one block
+ * element, must not end on a w:tbl (a trailing table needs a following
+ * paragraph), and two tables must not become adjacent (Word merges
+ * back-to-back tables). w:sectPr is ignored — a trailing body sectPr is not a
+ * block element.
+ */
+function canSafelyRemoveEmptyParagraph(p: Element): boolean {
+  const parent = parentElement(p);
+  if (!parent) return false;
+  const siblings = childElements(parent).filter(
+    (c) => !RANGE_MARKUP_BLOCK_SIBLING_TAGS.has(c.tagName) && c.tagName !== 'w:sectPr'
+  );
+  const idx = siblings.indexOf(p);
+  if (idx < 0) return false;
+  const prev = siblings[idx - 1];
+  const next = siblings[idx + 1];
+  if (!prev && !next) return false;
+  if (prev?.tagName === 'w:tbl' && !next) return false;
+  if (prev?.tagName === 'w:tbl' && next?.tagName === 'w:tbl') return false;
+  return true;
+}
+
+/**
+ * Resolve a paragraph whose paragraph MARK revision was applied (deleted mark
+ * accepted, or inserted mark rejected): the paragraph break disappears, so the
+ * paragraph's remaining content merges into the FOLLOWING paragraph. The
+ * surviving (following) paragraph keeps its own w:pPr — formatting follows the
+ * surviving paragraph mark — and the merged-away paragraph's w:pPr is dropped.
+ *
+ * The revision targets only the mark, never the paragraph's contents, so the
+ * contents must not be dropped wholesale (they are removed only via their own
+ * run-level w:del / w:ins wrappers). When no following sibling paragraph
+ * exists (last block, or the next block is a table), there is no break to
+ * remove into: content-bearing paragraphs are kept, and emptied ones are
+ * removed only where removal keeps the parent structurally valid
+ * (canSafelyRemoveEmptyParagraph).
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.5.15
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.5.20
+ * @see https://github.com/UseJunior/safe-docx/issues/431
+ */
+function resolveParagraphMarkRevision(p: Element): void {
+  const parent = p.parentNode;
+  if (!parent) return;
+
+  const target = findFollowingSiblingParagraph(p);
+  if (!target) {
+    if (!paragraphHasContent(p) && canSafelyRemoveEmptyParagraph(p)) {
+      parent.removeChild(p);
+    }
+    return;
+  }
+
+  // The merged content precedes the target's own content in document order.
+  let insertIndex = paragraphContentStartIndex(target);
+  for (const child of childElements(p)) {
+    if (child.tagName === 'w:pPr') continue;
+    p.removeChild(child);
+    insertChildAt(target, child, insertIndex);
+    insertIndex++;
+  }
+  parent.removeChild(p);
+}
+
 function moveBookmarkMarker(
   marker: Element,
   targetParagraph: Element,
@@ -287,6 +397,13 @@ function preserveCrossParagraphBookmarksForReject(
         continue;
       }
 
+      if (parentElement(start) === paragraph && findFollowingSiblingParagraph(paragraph)) {
+        // A direct child of a merging paragraph rides the Step-3 merge in
+        // document order; pre-moving it here would reorder the boundary
+        // relative to the surviving untracked content.
+        continue;
+      }
+
       const id = start.getAttribute('w:id');
       if (!id) {
         continue;
@@ -321,6 +438,13 @@ function preserveCrossParagraphBookmarksForReject(
 
     for (const end of findAllByTagName(paragraph, 'w:bookmarkEnd')) {
       if (!end.parentNode || !endTarget) {
+        continue;
+      }
+
+      if (parentElement(end) === paragraph && findFollowingSiblingParagraph(paragraph)) {
+        // A direct child of a merging paragraph rides the Step-3 merge in
+        // document order; pre-moving it here would reorder the boundary
+        // relative to the surviving untracked content.
         continue;
       }
 
@@ -372,21 +496,23 @@ function preserveCrossParagraphBookmarksForReject(
 export function acceptAllChanges(documentXml: string): string {
   const root = parseDocumentXml(documentXml);
 
-  // Remove a paragraph on Accept All iff its paragraph MARK is a tracked deletion
-  // (<w:pPr><w:rPr><w:del .../></w:rPr>) — the paragraph break itself was deleted, so accepting
-  // the deletion removes the whole paragraph. This is the Word/LibreOffice-faithful, purely
-  // mark-based rule (the accept-side mirror of rejectAllChanges).
+  // Merge a paragraph on Accept All iff its paragraph MARK is a tracked deletion
+  // (<w:pPr><w:rPr><w:del .../></w:rPr>) — the paragraph BREAK itself was deleted, so accepting
+  // the deletion merges the paragraph's surviving content into the following paragraph
+  // (resolveParagraphMarkRevision). The contents are deleted only via their own run-level
+  // w:del wrappers. This is the Word/LibreOffice-faithful, purely mark-based rule (the
+  // accept-side mirror of rejectAllChanges).
   //
-  // We deliberately do NOT drop a paragraph based on content (e.g. "all runs are inside w:del"
+  // We deliberately do NOT touch a paragraph based on content (e.g. "all runs are inside w:del"
   // or "w:moveFrom"). A run-level deletion under an UNTRACKED paragraph mark means text was
   // deleted from a pre-existing paragraph; Word and LibreOffice both keep that paragraph (empty)
   // on accept, and a content-based drop over-deletes it. safe-docx's own deleted paragraphs
   // always carry the PPR-DEL mark (wrapParagraphAsDeleted), so the mark-based rule covers them
   // without the old content heuristic.
-  const paragraphsToRemove = new Set<Element>();
+  const markDeletedParagraphs: Element[] = [];
   for (const p of findAllByTagName(root, 'w:p')) {
     if (paragraphHasParaMarker(p, 'w:del')) {
-      paragraphsToRemove.add(p);
+      markDeletedParagraphs.push(p);
     }
   }
 
@@ -415,11 +541,11 @@ export function acceptAllChanges(documentXml: string): string {
   // Strip paragraph-level markers now that changes are accepted.
   removeParaMarkers(root);
 
-  // Remove the PPR-DEL-marked paragraphs (their paragraph mark was deleted).
-  for (const p of paragraphsToRemove) {
-    if (p.parentNode) {
-      p.parentNode.removeChild(p);
-    }
+  // Resolve the PPR-DEL-marked paragraphs (their paragraph mark was deleted):
+  // merge each into its following paragraph (document order, so consecutive
+  // mark-deleted paragraphs cascade forward into the first surviving one).
+  for (const p of markDeletedParagraphs) {
+    resolveParagraphMarkRevision(p);
   }
 
   // Drop hyperlink wrappers emptied by the accepted deletions above.
@@ -442,34 +568,40 @@ export function acceptAllChanges(documentXml: string): string {
 export function rejectAllChanges(documentXml: string): string {
   const root = parseDocumentXml(documentXml);
 
-  // Step 1: Remove a paragraph on Reject All iff its paragraph MARK is a tracked
+  // Step 1: Merge a paragraph on Reject All iff its paragraph MARK is a tracked
   // insertion (<w:pPr><w:rPr><w:ins .../></w:rPr>) — i.e. the paragraph break itself
-  // was inserted, so rejecting the insertion removes the whole paragraph. This is the
+  // was inserted, so rejecting the insertion merges the paragraph's surviving content
+  // into the following paragraph (resolveParagraphMarkRevision). The contents
+  // disappear only via their own run-level w:ins wrappers. This is the
   // Word/LibreOffice-faithful, purely mark-based rule.
   //
-  // We deliberately do NOT drop a paragraph based on content (e.g. "all runs are inside
+  // We deliberately do NOT touch a paragraph based on content (e.g. "all runs are inside
   // w:ins"). A run-level insertion under an UNTRACKED paragraph mark means text was
   // inserted into a pre-existing paragraph; Word and LibreOffice both keep that
   // paragraph (empty) on reject, and a content-based drop over-deletes it. safe-docx's
   // own inserted paragraphs always carry the PPR-INS mark now (wrapParagraphAsInserted),
   // so the mark-based rule covers them without the old content heuristic.
-  const paragraphsToRemove = new Set<Element>();
+  const markInsertedParagraphs = new Set<Element>();
   for (const p of findAllByTagName(root, 'w:p')) {
     if (paragraphHasParaMarker(p, 'w:ins')) {
-      paragraphsToRemove.add(p);
+      markInsertedParagraphs.add(p);
     }
   }
 
-  preserveCrossParagraphBookmarksForReject(root, paragraphsToRemove);
+  // Bookmarks nested inside w:ins content are dropped with Step 2's wrapper
+  // removal, so boundaries whose counterpart lives in a kept paragraph must
+  // move out first. (Direct-child bookmarks would survive the Step-3 merge.)
+  preserveCrossParagraphBookmarksForReject(root, markInsertedParagraphs);
 
   // Step 2: Remove w:ins elements entirely (inserted content disappears)
   removeAllByTagName(root, 'w:ins');
 
-  // Step 3: Remove the PPR-INS-marked paragraphs (their paragraph mark was inserted)
-  for (const p of paragraphsToRemove) {
-    if (p.parentNode) {
-      p.parentNode.removeChild(p);
-    }
+  // Step 3: Resolve the PPR-INS-marked paragraphs (their paragraph mark was
+  // inserted): merge each into its following paragraph (document order, so
+  // consecutive mark-inserted paragraphs cascade forward into the first
+  // surviving one).
+  for (const p of markInsertedParagraphs) {
+    resolveParagraphMarkRevision(p);
   }
 
   // Remove w:moveTo elements entirely

--- a/packages/docx-core/src/integration/lean-spec-bridge.test.ts
+++ b/packages/docx-core/src/integration/lean-spec-bridge.test.ts
@@ -361,15 +361,22 @@ const trackedFootnoteAnchorScenarioArb: fc.Arbitrary<FootnoteAnchorScenario> = p
 //     — the engine flattens the original's inline insertion provenance
 //     unconditionally, so reject(combined) keeps text reject(original) drops
 //     for EVERY revised counterpart (probed: matched, deleted, identical,
-//     unrelated). Paragraph-insert originals are INCLUDED: paragraph-MARK
-//     provenance threads correctly (stacked PPR-DEL(Comparison) +
-//     PPR-INS(input-author) marks compose under mark-based accept/reject).
+//     unrelated). Paragraph-insert ORIGINALS are excluded for the same
+//     flattening: when the comparison deletes the pre-tracked inserted
+//     paragraph, its content is emitted as bare w:del (the original-author
+//     w:ins wrapper is lost), so reject(combined) restores text that
+//     reject(original) discards. The paragraph MARKS themselves thread
+//     correctly (stacked PPR-DEL(Comparison) + PPR-INS(input-author)), and
+//     while paragraph-mark resolution dropped the whole paragraph the content
+//     flattening was unobservable — the #431 merge rule (a mark revision
+//     resolves by merging, never by discarding content) made it visible, so
+//     the exclusion now covers both pre-tracked-insertion shapes. Pinned in
+//     the characterization test below.
 //   - Issue #359: pairs whose pre-tracked-insertion text collides with the
 //     other side's plain text are excluded via `hasInsProvenanceCollision` on
 //     the pair arbitrary below.
 const trackedOriginalScenarioArb: fc.Arbitrary<TrackedScenario> = fc.oneof(
   trackedDeletionScenarioArb,
-  trackedParagraphInsertScenarioArb,
   trackedParagraphPropertyScenarioArb,
   trackedCommentAnchorScenarioArb,
   trackedFootnoteAnchorScenarioArb,
@@ -1504,6 +1511,11 @@ describe('Lean Spec Bridge - Inplace Reconstruction', { timeout: 60_000 }, () =>
           expectedRejectOriginal: '!\n!\nI',
         },
         {
+          // Before #431 the combined output rejected to 'Alpha text.' (the
+          // PPR-INS mark dropped the whole flattened paragraph, a law
+          // violation). The mark-merge rule keeps the flattened content, which
+          // here happens to match reject(original) — the law holds for this
+          // colliding shape even though the provenance is still lost (#359).
           name: '#359 paragraph-insert revised colliding with a plain original paragraph',
           build: async () => ({
             original: await buildSyntheticDocx({ paragraphs: ['Alpha text.', 'Added para.'] }),
@@ -1517,7 +1529,7 @@ describe('Lean Spec Bridge - Inplace Reconstruction', { timeout: 60_000 }, () =>
               })
             ).document,
           }),
-          expectedRejectCombined: 'Alpha text.',
+          expectedRejectCombined: 'Alpha text.\nAdded para.',
           expectedRejectOriginal: 'Alpha text.\nAdded para.',
         },
         {
@@ -1533,6 +1545,31 @@ describe('Lean Spec Bridge - Inplace Reconstruction', { timeout: 60_000 }, () =>
               })
             ).document,
             revised: await buildSyntheticDocx({ paragraphs: ['Alpha text.', 'Added para.'] }),
+          }),
+          expectedRejectCombined: 'Alpha text.\nAdded para.',
+          expectedRejectOriginal: 'Alpha text.',
+        },
+        {
+          // The non-colliding mirror: the comparison deletes the pre-tracked
+          // inserted paragraph and emits its content as bare w:del(Comparison)
+          // under correctly stacked PPR-DEL(Comparison) + PPR-INS(original)
+          // marks — the original-author content w:ins wrapper is lost (#358
+          // class). While paragraph-mark resolution DROPPED the marked
+          // paragraph this was unobservable; the #431 mark-merge rule restores
+          // the flattened content on reject, so reject(combined) keeps text
+          // reject(original) discards and the engine permanently falls back.
+          name: '#358 paragraph-insert original deleted by the comparison (made observable by the #431 mark-merge rule)',
+          build: async () => ({
+            original: (
+              await materializeTrackedScenario({
+                family: 'paragraph-insert',
+                paragraphs: ['Alpha text.'],
+                anchorIndex: 0,
+                relativePosition: 'AFTER',
+                newParagraphText: 'Added para.',
+              })
+            ).document,
+            revised: await buildSyntheticDocx({ paragraphs: ['Alpha text.'] }),
           }),
           expectedRejectCombined: 'Alpha text.\nAdded para.',
           expectedRejectOriginal: 'Alpha text.',

--- a/packages/docx-core/src/primitives/accept_changes.ts
+++ b/packages/docx-core/src/primitives/accept_changes.ts
@@ -6,7 +6,8 @@
  * - Unwrapping w:ins elements (promoting children)
  * - Removing w:moveFrom (source), unwrapping w:moveTo (destination)
  * - Removing all *PrChange property change records
- * - Stripping paragraph-level revision markers
+ * - Stripping paragraph-level revision markers, merging a paragraph whose
+ *   mark was a tracked deletion into the following paragraph
  * - Cleaning up move range markers and rsidDel attributes
  *
  * Operates on the W3C DOM (`@xmldom/xmldom`) — the same API used
@@ -105,6 +106,145 @@ const PR_CHANGE_LOCALS = [
   'tblPrChange', 'trPrChange', 'tcPrChange',
 ];
 
+// Marker-ish elements that may sit between two paragraphs at block level
+// without ending the search for a merge target: the full EG_RangeMarkupElements
+// schema group (wml.xsd), plus permStart/permEnd range markers and proofErr
+// proofing anchors.
+const RANGE_MARKUP_BLOCK_SIBLING_LOCALS = new Set([
+  'bookmarkStart', 'bookmarkEnd',
+  'commentRangeStart', 'commentRangeEnd',
+  'moveFromRangeStart', 'moveFromRangeEnd',
+  'moveToRangeStart', 'moveToRangeEnd',
+  'customXmlInsRangeStart', 'customXmlInsRangeEnd',
+  'customXmlDelRangeStart', 'customXmlDelRangeEnd',
+  'customXmlMoveFromRangeStart', 'customXmlMoveFromRangeEnd',
+  'customXmlMoveToRangeStart', 'customXmlMoveToRangeEnd',
+  'permStart', 'permEnd',
+  'proofErr',
+]);
+
+/**
+ * Find the next sibling paragraph a paragraph-mark revision can merge into,
+ * skipping block-level range/annotation markers. Returns null when the next
+ * block is not a paragraph (table, sdt, sectPr, end of parent).
+ */
+function findFollowingSiblingParagraph(p: Element): Element | null {
+  let sibling: Node | null = p.nextSibling;
+  while (sibling) {
+    if (sibling.nodeType === 1) {
+      if (isW(sibling, 'p')) return sibling;
+      const el = sibling as Element;
+      if (el.namespaceURI === W_NS && RANGE_MARKUP_BLOCK_SIBLING_LOCALS.has(el.localName ?? '')) {
+        sibling = sibling.nextSibling;
+        continue;
+      }
+      return null;
+    }
+    sibling = sibling.nextSibling;
+  }
+  return null;
+}
+
+/** True iff the paragraph still holds content beyond w:pPr and bare annotation markers. */
+function paragraphHasContent(p: Element): boolean {
+  for (let i = 0; i < p.childNodes.length; i++) {
+    const child = p.childNodes[i]!;
+    if (child.nodeType !== 1) continue;
+    if (isW(child, 'pPr')) continue;
+    const el = child as Element;
+    if (el.namespaceURI === W_NS && RANGE_MARKUP_BLOCK_SIBLING_LOCALS.has(el.localName ?? '')) continue;
+    return true;
+  }
+  return false;
+}
+
+/**
+ * True iff removing an emptied mark-revised paragraph keeps its parent
+ * structurally valid for Word: the parent must retain at least one block
+ * element, must not end on a w:tbl (a trailing table needs a following
+ * paragraph), and two tables must not become adjacent (Word merges
+ * back-to-back tables). w:sectPr is ignored — a trailing body sectPr is not a
+ * block element.
+ */
+function canSafelyRemoveEmptyParagraph(p: Element): boolean {
+  const blockSibling = (start: Node | null, dir: 'previousSibling' | 'nextSibling'): Element | null => {
+    let sibling = start;
+    while (sibling) {
+      if (sibling.nodeType === 1) {
+        const el = sibling as Element;
+        if (
+          (el.namespaceURI === W_NS && RANGE_MARKUP_BLOCK_SIBLING_LOCALS.has(el.localName ?? '')) ||
+          isW(el, 'sectPr')
+        ) {
+          sibling = sibling[dir];
+          continue;
+        }
+        return el;
+      }
+      sibling = sibling[dir];
+    }
+    return null;
+  };
+
+  const prev = blockSibling(p.previousSibling, 'previousSibling');
+  const next = blockSibling(p.nextSibling, 'nextSibling');
+  if (!prev && !next) return false;
+  if (prev && isW(prev, 'tbl') && !next) return false;
+  if (prev && next && isW(prev, 'tbl') && isW(next, 'tbl')) return false;
+  return true;
+}
+
+/**
+ * Resolve a paragraph whose paragraph MARK revision was applied (deleted mark
+ * accepted): the paragraph break disappears, so the paragraph's remaining
+ * content merges into the FOLLOWING paragraph. The surviving (following)
+ * paragraph keeps its own w:pPr — formatting follows the surviving paragraph
+ * mark — and the merged-away paragraph's w:pPr is dropped.
+ *
+ * The revision targets only the mark, never the paragraph's contents, so the
+ * contents must not be dropped wholesale. When no following sibling paragraph
+ * exists (last block, or the next block is a table), there is no break to
+ * remove into: content-bearing paragraphs are kept, and emptied ones are
+ * removed only where removal keeps the parent structurally valid
+ * (canSafelyRemoveEmptyParagraph).
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.5.15
+ * @see https://github.com/UseJunior/safe-docx/issues/431
+ */
+function resolveParagraphMarkRevision(p: Element): void {
+  const parent = p.parentNode;
+  if (!parent) return;
+
+  const target = findFollowingSiblingParagraph(p);
+  if (!target) {
+    if (!paragraphHasContent(p) && canSafelyRemoveEmptyParagraph(p)) {
+      parent.removeChild(p);
+    }
+    return;
+  }
+
+  // Insertion point: before the target's first non-pPr child (the merged
+  // content precedes the target's own content in document order).
+  let ref: Node | null = null;
+  for (let i = 0; i < target.childNodes.length; i++) {
+    const c = target.childNodes[i]!;
+    if (c.nodeType === 1 && isW(c as Element, 'pPr')) continue;
+    ref = c;
+    break;
+  }
+
+  const toMove: Node[] = [];
+  for (let i = 0; i < p.childNodes.length; i++) {
+    const c = p.childNodes[i]!;
+    if (c.nodeType === 1 && isW(c as Element, 'pPr')) continue;
+    toMove.push(c);
+  }
+  for (const c of toMove) {
+    target.insertBefore(c, ref);
+  }
+  parent.removeChild(p);
+}
+
 // ── Public API ──────────────────────────────────────────────────────
 
 /**
@@ -120,21 +260,23 @@ export function acceptChanges(doc: Document): AcceptChangesResult {
     return { insertionsAccepted: 0, deletionsAccepted: 0, movesResolved: 0, propertyChangesResolved: 0 };
   }
 
-  // Phase A — Identify paragraphs to remove
-  const paragraphsToRemove = new Set<Element>();
+  // Phase A — Identify paragraphs whose MARK is a tracked deletion
+  const markDeletedParagraphs: Element[] = [];
   const allParagraphs = collectByLocalName(root, 'p');
 
   for (const p of allParagraphs) {
-    // Remove a paragraph iff its paragraph MARK is a tracked deletion
-    // (w:p > w:pPr > w:rPr > w:del) — the paragraph break itself was deleted.
-    // We deliberately do NOT drop a paragraph based on content ("all runs inside
+    // A paragraph-mark deletion (w:p > w:pPr > w:rPr > w:del) means the
+    // paragraph BREAK was deleted — accepting it merges the paragraph into the
+    // following one (resolveParagraphMarkRevision); the contents are deleted
+    // only via their own run-level w:del wrappers.
+    // We deliberately do NOT touch a paragraph based on content ("all runs inside
     // w:del/w:moveFrom"): a run-level deletion under an untracked mark means text was
     // deleted from a pre-existing paragraph, which Word/LibreOffice keep (empty) on
     // accept. safe-docx's deleted paragraphs always carry the mark now, so the
     // mark-based rule suffices and is Word-faithful. (Mirrors acceptAllChanges and the
     // reject-side rule.)
     if (paragraphHasParaMarker(p, 'del')) {
-      paragraphsToRemove.add(p);
+      markDeletedParagraphs.push(p);
     }
   }
 
@@ -180,11 +322,11 @@ export function acceptChanges(doc: Document): AcceptChangesResult {
     }
   }
 
-  // Remove paragraphs collected in Phase A (check parentNode still exists)
-  for (const p of paragraphsToRemove) {
-    if (p.parentNode) {
-      p.parentNode.removeChild(p);
-    }
+  // Resolve paragraphs collected in Phase A: merge each into its following
+  // paragraph (document order, so consecutive mark-deleted paragraphs cascade
+  // forward into the first surviving one).
+  for (const p of markDeletedParagraphs) {
+    resolveParagraphMarkRevision(p);
   }
 
   // Strip w:rsidDel attributes on remaining elements

--- a/packages/docx-core/src/primitives/reject_changes.ts
+++ b/packages/docx-core/src/primitives/reject_changes.ts
@@ -6,8 +6,10 @@
  * - Unwrapping w:del elements and converting w:delText → w:t (deletions restored)
  * - Unwrapping w:moveFrom (keep at original position), removing w:moveTo and content
  * - Restoring original properties from *PrChange records
- * - Preserving cross-paragraph bookmark boundaries when removing inserted paragraphs
- * - Stripping paragraph-level revision markers and rsidDel attributes
+ * - Preserving cross-paragraph bookmark boundaries when resolving inserted paragraph marks
+ * - Stripping paragraph-level revision markers, merging a paragraph whose
+ *   mark was a tracked insertion into the following paragraph
+ * - Stripping rsidDel attributes
  *
  * Operates on the W3C DOM (`@xmldom/xmldom`).
  */
@@ -102,6 +104,145 @@ const PR_CHANGE_LOCALS = [
   'tblPrChange', 'trPrChange', 'tcPrChange',
 ];
 
+// Marker-ish elements that may sit between two paragraphs at block level
+// without ending the search for a merge target: the full EG_RangeMarkupElements
+// schema group (wml.xsd), plus permStart/permEnd range markers and proofErr
+// proofing anchors.
+const RANGE_MARKUP_BLOCK_SIBLING_LOCALS = new Set([
+  'bookmarkStart', 'bookmarkEnd',
+  'commentRangeStart', 'commentRangeEnd',
+  'moveFromRangeStart', 'moveFromRangeEnd',
+  'moveToRangeStart', 'moveToRangeEnd',
+  'customXmlInsRangeStart', 'customXmlInsRangeEnd',
+  'customXmlDelRangeStart', 'customXmlDelRangeEnd',
+  'customXmlMoveFromRangeStart', 'customXmlMoveFromRangeEnd',
+  'customXmlMoveToRangeStart', 'customXmlMoveToRangeEnd',
+  'permStart', 'permEnd',
+  'proofErr',
+]);
+
+/**
+ * Find the next sibling paragraph a paragraph-mark revision can merge into,
+ * skipping block-level range/annotation markers. Returns null when the next
+ * block is not a paragraph (table, sdt, sectPr, end of parent).
+ */
+function findFollowingSiblingParagraph(p: Element): Element | null {
+  let sibling: Node | null = p.nextSibling;
+  while (sibling) {
+    if (sibling.nodeType === 1) {
+      if (isW(sibling, 'p')) return sibling;
+      const el = sibling as Element;
+      if (el.namespaceURI === W_NS && RANGE_MARKUP_BLOCK_SIBLING_LOCALS.has(el.localName ?? '')) {
+        sibling = sibling.nextSibling;
+        continue;
+      }
+      return null;
+    }
+    sibling = sibling.nextSibling;
+  }
+  return null;
+}
+
+/** True iff the paragraph still holds content beyond w:pPr and bare annotation markers. */
+function paragraphHasContent(p: Element): boolean {
+  for (let i = 0; i < p.childNodes.length; i++) {
+    const child = p.childNodes[i]!;
+    if (child.nodeType !== 1) continue;
+    if (isW(child, 'pPr')) continue;
+    const el = child as Element;
+    if (el.namespaceURI === W_NS && RANGE_MARKUP_BLOCK_SIBLING_LOCALS.has(el.localName ?? '')) continue;
+    return true;
+  }
+  return false;
+}
+
+/**
+ * True iff removing an emptied mark-revised paragraph keeps its parent
+ * structurally valid for Word: the parent must retain at least one block
+ * element, must not end on a w:tbl (a trailing table needs a following
+ * paragraph), and two tables must not become adjacent (Word merges
+ * back-to-back tables). w:sectPr is ignored — a trailing body sectPr is not a
+ * block element.
+ */
+function canSafelyRemoveEmptyParagraph(p: Element): boolean {
+  const blockSibling = (start: Node | null, dir: 'previousSibling' | 'nextSibling'): Element | null => {
+    let sibling = start;
+    while (sibling) {
+      if (sibling.nodeType === 1) {
+        const el = sibling as Element;
+        if (
+          (el.namespaceURI === W_NS && RANGE_MARKUP_BLOCK_SIBLING_LOCALS.has(el.localName ?? '')) ||
+          isW(el, 'sectPr')
+        ) {
+          sibling = sibling[dir];
+          continue;
+        }
+        return el;
+      }
+      sibling = sibling[dir];
+    }
+    return null;
+  };
+
+  const prev = blockSibling(p.previousSibling, 'previousSibling');
+  const next = blockSibling(p.nextSibling, 'nextSibling');
+  if (!prev && !next) return false;
+  if (prev && isW(prev, 'tbl') && !next) return false;
+  if (prev && next && isW(prev, 'tbl') && isW(next, 'tbl')) return false;
+  return true;
+}
+
+/**
+ * Resolve a paragraph whose paragraph MARK revision was applied (inserted mark
+ * rejected): the inserted paragraph break disappears, so the paragraph's
+ * surviving content merges into the FOLLOWING paragraph. The surviving
+ * (following) paragraph keeps its own w:pPr — formatting follows the surviving
+ * paragraph mark — and the merged-away paragraph's w:pPr is dropped.
+ *
+ * The revision targets only the mark, never the paragraph's contents, so the
+ * contents must not be dropped wholesale (they disappear only via their own
+ * run-level w:ins wrappers). When no following sibling paragraph exists (last
+ * block, or the next block is a table), there is no break to remove into:
+ * content-bearing paragraphs are kept, and emptied ones are removed only where
+ * removal keeps the parent structurally valid (canSafelyRemoveEmptyParagraph).
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.5.20
+ * @see https://github.com/UseJunior/safe-docx/issues/431
+ */
+function resolveParagraphMarkRevision(p: Element): void {
+  const parent = p.parentNode;
+  if (!parent) return;
+
+  const target = findFollowingSiblingParagraph(p);
+  if (!target) {
+    if (!paragraphHasContent(p) && canSafelyRemoveEmptyParagraph(p)) {
+      parent.removeChild(p);
+    }
+    return;
+  }
+
+  // Insertion point: before the target's first non-pPr child (the merged
+  // content precedes the target's own content in document order).
+  let ref: Node | null = null;
+  for (let i = 0; i < target.childNodes.length; i++) {
+    const c = target.childNodes[i]!;
+    if (c.nodeType === 1 && isW(c as Element, 'pPr')) continue;
+    ref = c;
+    break;
+  }
+
+  const toMove: Node[] = [];
+  for (let i = 0; i < p.childNodes.length; i++) {
+    const c = p.childNodes[i]!;
+    if (c.nodeType === 1 && isW(c as Element, 'pPr')) continue;
+    toMove.push(c);
+  }
+  for (const c of toMove) {
+    target.insertBefore(c, ref);
+  }
+  parent.removeChild(p);
+}
+
 /**
  * Relocate orphaned bookmarks from a paragraph being removed to an
  * adjacent kept paragraph. This preserves cross-paragraph bookmark boundaries.
@@ -132,14 +273,21 @@ function relocateBookmarks(p: Element, paragraphsToRemove: Set<Element>): void {
   }
   if (!target) return;
 
-  // Move bookmarkStart/bookmarkEnd elements that are direct children of the paragraph
+  // Move bookmarkStart/bookmarkEnd elements that are direct children of the
+  // paragraph — but only when the paragraph will NOT merge into a following
+  // paragraph. The Phase-G merge carries direct children in document order;
+  // pre-relocating them here would reorder bookmark boundaries relative to the
+  // surviving untracked content. Without a merge target the paragraph may be
+  // removed outright, so the markers must be rescued.
   const toMove: Element[] = [];
-  for (let i = 0; i < p.childNodes.length; i++) {
-    const child = p.childNodes[i]!;
-    if (child.nodeType !== 1) continue;
-    const el = child as Element;
-    if (isW(el, 'bookmarkStart') || isW(el, 'bookmarkEnd')) {
-      toMove.push(el);
+  if (!findFollowingSiblingParagraph(p)) {
+    for (let i = 0; i < p.childNodes.length; i++) {
+      const child = p.childNodes[i]!;
+      if (child.nodeType !== 1) continue;
+      const el = child as Element;
+      if (isW(el, 'bookmarkStart') || isW(el, 'bookmarkEnd')) {
+        toMove.push(el);
+      }
     }
   }
 
@@ -195,26 +343,32 @@ export function rejectChanges(doc: Document): RejectChangesResult {
     return { insertionsRemoved: 0, deletionsRestored: 0, movesReverted: 0, propertyChangesReverted: 0 };
   }
 
-  // Phase A — Identify paragraphs to remove (entirely inserted paragraphs)
-  const paragraphsToRemove = new Set<Element>();
+  // Phase A — Identify paragraphs whose MARK is a tracked insertion
+  const markInsertedParagraphs = new Set<Element>();
   const allParagraphs = collectByLocalName(root, 'p');
 
   for (const p of allParagraphs) {
-    // Remove a paragraph iff its paragraph MARK is a tracked insertion
-    // (w:p > w:pPr > w:rPr > w:ins) — the paragraph break itself was inserted.
-    // We deliberately do NOT drop a paragraph based on content ("all runs inside
+    // A paragraph-mark insertion (w:p > w:pPr > w:rPr > w:ins) means the
+    // paragraph BREAK was inserted — rejecting it merges the paragraph into the
+    // following one (resolveParagraphMarkRevision); the contents disappear only
+    // via their own run-level w:ins wrappers.
+    // We deliberately do NOT touch a paragraph based on content ("all runs inside
     // w:ins/w:moveTo"): a run-level insertion under an untracked mark means text was
     // inserted into a pre-existing paragraph, which Word/LibreOffice keep (empty) on
     // reject. safe-docx's inserted paragraphs always carry the mark now, so the
     // mark-based rule suffices and is Word-faithful. (Mirrors rejectAllChanges.)
     if (paragraphHasParaMarker(p, 'ins')) {
-      paragraphsToRemove.add(p);
+      markInsertedParagraphs.add(p);
     }
   }
 
-  // Phase B — Preserve cross-paragraph bookmark boundaries
-  for (const p of paragraphsToRemove) {
-    relocateBookmarks(p, paragraphsToRemove);
+  // Phase B — Preserve cross-paragraph bookmark boundaries. Direct-child
+  // bookmarks of a paragraph that will merge ride the Phase-G merge in
+  // document order; relocateBookmarks rescues the rest (direct children of a
+  // paragraph with no merge target, which may be removed outright, plus
+  // adjacent sibling-style markers).
+  for (const p of markInsertedParagraphs) {
+    relocateBookmarks(p, markInsertedParagraphs);
   }
 
   // Phase C — Remove insertions and move destinations
@@ -313,11 +467,11 @@ export function rejectChanges(doc: Document): RejectChangesResult {
     }
   }
 
-  // Remove paragraphs collected in Phase A
-  for (const p of paragraphsToRemove) {
-    if (p.parentNode) {
-      p.parentNode.removeChild(p);
-    }
+  // Resolve paragraphs collected in Phase A: merge each into its following
+  // paragraph (document order, so consecutive mark-inserted paragraphs cascade
+  // forward into the first surviving one).
+  for (const p of markInsertedParagraphs) {
+    resolveParagraphMarkRevision(p);
   }
 
   // Strip w:rsidDel attributes on remaining elements

--- a/spec-compliance/CONFORMANCE.md
+++ b/spec-compliance/CONFORMANCE.md
@@ -76,6 +76,8 @@ Allure labels via `testAllure.conformance({…})`; source code carries
 | `ECMA-PART1-17-13-4-4` | w:commentRangeStart comment anchor opening | 5 | 1 | 17.13.4.4 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:commentRangeStart` | — |
 | `ECMA-PART1-17-13-4-3` | w:commentRangeEnd comment anchor closing | 5 | 1 | 17.13.4.3 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:commentRangeEnd` | — |
 | `ECMA-PART1-17-13-4-5` | w:commentReference comment reference mark | 5 | 1 | 17.13.4.5 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:commentReference` | — |
+| `ECMA-PART1-17-13-5-15` | Deleted paragraph mark (w:del under w:pPr/w:rPr) | 5 | 1 | 17.13.5.15 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:del` | — |
+| `ECMA-PART1-17-13-5-20` | Inserted paragraph mark (w:ins under w:pPr/w:rPr) | 5 | 1 | 17.13.5.20 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:ins` | — |
 
 ### ECMA-PART4-17-16-5 — w:delInstrText and w:fldChar placement in tracked deletions
 
@@ -838,6 +840,38 @@ reference run, so the anchored extent is exactly the paragraph content.
 The trailing reference run carries `w:commentReference` with the same id
 as its range anchors; the existing deleteComment editing path removes the
 trio cleanly, which the strip scenario verifies on generated output.
+
+### ECMA-PART1-17-13-5-15 — Deleted paragraph mark (w:del under w:pPr/w:rPr)
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.13.5.15
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:del`
+
+ECMA-376 Part 1 §17.13.5.15 defines `w:del` inside `w:pPr/w:rPr` as a tracked
+deletion of the *paragraph mark* (the glyph ending the paragraph), not of the
+paragraph's contents. Accepting the revision removes the paragraph break, so
+the paragraph's remaining content merges into the following paragraph; the
+contents themselves are deleted only where they carry their own run-level
+`w:del` wrappers. safe-docx's accept paths implement this merge in
+`packages/docx-core/src/primitives/accept_changes.ts` and
+`packages/docx-core/src/baselines/atomizer/trackChangesAcceptorAst.ts`.
+
+### ECMA-PART1-17-13-5-20 — Inserted paragraph mark (w:ins under w:pPr/w:rPr)
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.13.5.20
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:ins`
+
+ECMA-376 Part 1 §17.13.5.20 defines `w:ins` inside `w:pPr/w:rPr` as a tracked
+insertion of the *paragraph mark*, not of the paragraph's contents. Rejecting
+the revision removes the inserted paragraph break, so the paragraph's
+surviving content merges into the following paragraph; the contents disappear
+only where they carry their own run-level `w:ins` wrappers. safe-docx's reject
+paths implement this merge in
+`packages/docx-core/src/primitives/reject_changes.ts` and
+`packages/docx-core/src/baselines/atomizer/trackChangesAcceptorAst.ts`.
 
 ## Non-Goals
 

--- a/spec-compliance/registry/ecma-376.md
+++ b/spec-compliance/registry/ecma-376.md
@@ -1026,6 +1026,46 @@ The trailing reference run carries `w:commentReference` with the same id
 as its range anchors; the existing deleteComment editing path removes the
 trio cleanly, which the strip scenario verifies on generated output.
 
+## [ECMA-PART1-17-13-5-15] Deleted paragraph mark (w:del under w:pPr/w:rPr)
+
+```yaml
+edition: 5
+part: 1
+section: "17.13.5.15"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:del
+verifiedBy:
+```
+
+ECMA-376 Part 1 §17.13.5.15 defines `w:del` inside `w:pPr/w:rPr` as a tracked
+deletion of the *paragraph mark* (the glyph ending the paragraph), not of the
+paragraph's contents. Accepting the revision removes the paragraph break, so
+the paragraph's remaining content merges into the following paragraph; the
+contents themselves are deleted only where they carry their own run-level
+`w:del` wrappers. safe-docx's accept paths implement this merge in
+`packages/docx-core/src/primitives/accept_changes.ts` and
+`packages/docx-core/src/baselines/atomizer/trackChangesAcceptorAst.ts`.
+
+## [ECMA-PART1-17-13-5-20] Inserted paragraph mark (w:ins under w:pPr/w:rPr)
+
+```yaml
+edition: 5
+part: 1
+section: "17.13.5.20"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:ins
+verifiedBy:
+```
+
+ECMA-376 Part 1 §17.13.5.20 defines `w:ins` inside `w:pPr/w:rPr` as a tracked
+insertion of the *paragraph mark*, not of the paragraph's contents. Rejecting
+the revision removes the inserted paragraph break, so the paragraph's
+surviving content merges into the following paragraph; the contents disappear
+only where they carry their own run-level `w:ins` wrappers. safe-docx's reject
+paths implement this merge in
+`packages/docx-core/src/primitives/reject_changes.ts` and
+`packages/docx-core/src/baselines/atomizer/trackChangesAcceptorAst.ts`.
+
 ## Non-Goals
 
 Sections explicitly **out of scope** for safe-docx. Each entry below carries the


### PR DESCRIPTION
## Summary

Fixes #431 — accepting a deleted paragraph mark (or rejecting an inserted one) dropped the paragraph's untracked content instead of merging it into the following paragraph.

ECMA-376 Part 1 § 17.13.5.15 (`del` / Deleted Paragraph) and § 17.13.5.20 (`ins` / Inserted Paragraph) make the paragraph **mark** the revision target; the paragraph's contents are not implicitly part of the revision. Both engine layers treated the mark as "remove the whole paragraph", which silently lost any content not separately wrapped in run-level `w:del`/`w:ins` — the data loss the `docx-platform-tests` matrix surfaced (`acceptDeletedParagraphMarkMergesParagraphs`, `rejectInsertedParagraphMarkMergesParagraphs` left `"second half"` instead of `"First half second half"`).

## What changed

- **Mark resolution is now a merge, not a drop** (`resolveParagraphMarkRevision` in both layers — DOM primitives `accept_changes.ts`/`reject_changes.ts` and AST `trackChangesAcceptorAst.ts`): the paragraph's surviving non-`pPr` children move to the head of the following sibling paragraph; the survivor keeps its own `w:pPr` (formatting follows the surviving paragraph mark). Consecutive marked paragraphs cascade in document order.
- **No-merge-target fallback** (last block, or next block is a table): keep the paragraph if it still has content (no data loss); remove it only when emptied — which preserves the comparison round-trip shape, since `wrapParagraphAsDeleted`/`AsInserted` carry all content in run-level wrappers.
- The forward scan for the merge target skips block-level annotation markers (`bookmarkStart/End`, `commentRange*`, `perm*`, `proofErr`, `move*Range*`).
- **Registry**: added targeted entries `ECMA-PART1-17-13-5-15` / `-20`; `CONFORMANCE.md` + README counters regenerated. New code carries `@conformance` tags.

## Tests

- New `#431` describe block in `trackChangesAcceptorAst.test.ts` (7 cases, both engine paths each): the two platform-test scenarios, surviving-`pPr` ownership, cascade, trailing kept/removed, table no-target. Tagged with `.conformance(...)` for § 17.13.5.15 / § 17.13.5.20.
- Updated the G5 characterization test that previously **pinned the over-delete** (`PPR-DEL-marked paragraph: both paths DROP it` asserted the untracked content disappears) to assert the merge.
- `cross-implementation-suite` against `docx-platform-tests` now passes **every** scenario, including the two #431 rows (previously failing).

## lean-spec-bridge fallout (pinned, not fixed here)

The merge rule made a known engine bug newly observable: when the comparison deletes a pre-tracked **inserted paragraph** (paragraph-insert original), the inplace emitter stacks the paragraph marks correctly (`PPR-DEL(Comparison)` + `PPR-INS(original)`) but flattens the content to bare `w:del(Comparison)` — the original-author `w:ins` wrapper is lost (#358 bug class). While mark resolution dropped the whole paragraph this was invisible; under the merge rule reject(combined) restores that content and diverges from reject(original), so the engine (correctly) falls back to rebuild.

Per the bounded-remediation discipline:
- `trackedOriginalScenarioArb` now excludes paragraph-insert originals (mirroring the existing inline-`w:ins` exclusion), with the rationale in the comment block;
- the shape is pinned verbatim as a new case in the `INV-RT-001 pinned engine bugs` characterization test;
- the shifted #359 case-3 pin was updated — the rebuild output's reject projection now **equals** reject(original) for the colliding shape (the law accidentally holds; provenance is still lost).

## Verification

- `npm run build && npm run lint:workspaces && npm run test:run && npm run check:spec-coverage && npm run check:conformance-citations && npm run check:conformance-doc` — all green.
- `DOCX_PLATFORM_TESTS_DIR=… vitest run cross-implementation-suite` — every scenario passes.
- Peer-reviewed (Codex + agy, both dynamic — each ran the test suites). All findings applied:
  - **Codex MAJOR**: merge-target scan skip-list completed to the full `EG_RangeMarkupElements` schema group (`customXml*Range*` markers were missing); sets renamed to `RANGE_MARKUP_BLOCK_SIBLING_*`.
  - **Codex MAJOR**: bookmark preservation no longer pre-relocates direct-child bookmarks of a *merging* paragraph (the merge carries them in document order; the early move reordered boundaries relative to surviving content). Relocation still rescues markers of paragraphs with no merge target.
  - **agy MAJOR**: the emptied-paragraph removal fallback is now gated on `canSafelyRemoveEmptyParagraph` — keep the empty `<w:p>` when removal would leave a parent with no block element, a `w:tbl` as the last block, or two adjacent tables.
  - **Codex MINOR**: reject-side test mirrors added (cascade, `pPr` survival, trailing keep/remove, table no-target) plus regressions for all three findings above.
  - **Codex NIT**: `accept_changes.ts` no longer claims § 17.13.5.20 (inserted marks are reject-side).
