### PR TITLE
fix(docx-core): restamp colliding comment paraIds before comparison

### DIFF
--- a/packages/docx-core/src/baselines/atomizer/auxiliaryIdCollision.ts
+++ b/packages/docx-core/src/baselines/atomizer/auxiliaryIdCollision.ts
@@ -27,7 +27,14 @@
  * their anchors still match as unchanged content (no duplicate definitions),
  * which keeps the common derived-document case byte-stable.
  *
+ * Comment ancillary parts have a second collision axis: commentsExtended.xml
+ * and commentsIds.xml are keyed by the w14:paraId on comment-content
+ * paragraphs, not by w:id. We restamp colliding revised-side comment paraIds
+ * before comparison for the same reason: merged ancillary rows must never bind
+ * to the other document's comment paragraph.
+ *
  * @see https://github.com/UseJunior/safe-docx/issues/107
+ * @see https://github.com/UseJunior/safe-docx/issues/448
  */
 
 import { XMLSerializer } from '@xmldom/xmldom';
@@ -141,19 +148,32 @@ class LazyArchiveXml {
     return this.parsed;
   }
 
-  /** Rewrite `w:id` on every `tag` element per `idMap`. */
-  applyIdMap(tags: string[], idMap: Map<string, string>): void {
+  /** Rewrite matching attributes on every `tag` element per `valueMap`. */
+  applyAttributeMap(
+    tags: string[],
+    attrName: string,
+    valueMap: Map<string, string>,
+    normalizeKey: (value: string) => string = (value) => value,
+  ): void {
+    if (valueMap.size === 0) return;
     for (const tag of tags) {
       const elements = this.doc().getElementsByTagName(tag);
       for (let i = 0; i < elements.length; i++) {
         const el = elements[i] as Element;
-        const id = el.getAttribute('w:id');
-        if (id !== null && idMap.has(id)) {
-          el.setAttribute('w:id', idMap.get(id)!);
+        const value = el.getAttribute(attrName);
+        if (value === null) continue;
+        const replacement = valueMap.get(normalizeKey(value));
+        if (replacement) {
+          el.setAttribute(attrName, replacement);
           this.dirty = true;
         }
       }
     }
+  }
+
+  /** Rewrite `w:id` on every `tag` element per `idMap`. */
+  applyIdMap(tags: string[], idMap: Map<string, string>): void {
+    this.applyAttributeMap(tags, 'w:id', idMap);
   }
 
   flush(): void {
@@ -277,4 +297,188 @@ export async function renumberCollidingAuxiliaryIds(
   for (const file of rewriteFiles.values()) file.flush();
 
   return renumbered;
+}
+
+export interface RestampedCommentParaId {
+  fromParaId: string;
+  toParaId: string;
+}
+
+function normalizeParaId(value: string): string {
+  return value.toUpperCase();
+}
+
+function collectCommentParaIdOwners(xml: string | null): Map<string, Element[]> {
+  const owners = new Map<string, Element[]>();
+  if (!xml) return owners;
+
+  const doc = parseXml(xml);
+  const comments = doc.getElementsByTagName('w:comment');
+  for (let i = 0; i < comments.length; i++) {
+    const comment = comments[i] as Element;
+    const seenInComment = new Set<string>();
+    const paragraphs = comment.getElementsByTagName('w:p');
+    for (let j = 0; j < paragraphs.length; j++) {
+      const paraId = (paragraphs[j] as Element).getAttribute('w14:paraId');
+      if (!paraId) continue;
+      const normalized = normalizeParaId(paraId);
+      if (seenInComment.has(normalized)) continue;
+      seenInComment.add(normalized);
+      const entries = owners.get(normalized);
+      if (entries) entries.push(comment);
+      else owners.set(normalized, [comment]);
+    }
+  }
+  return owners;
+}
+
+function collectAttributeValues(xml: string | null, tag: string, attrNames: string[]): Set<string> {
+  const values = new Set<string>();
+  if (!xml) return values;
+
+  const doc = parseXml(xml);
+  const elements = doc.getElementsByTagName(tag);
+  for (let i = 0; i < elements.length; i++) {
+    const el = elements[i] as Element;
+    for (const attrName of attrNames) {
+      const value = el.getAttribute(attrName);
+      if (value) values.add(normalizeParaId(value));
+    }
+  }
+  return values;
+}
+
+function collectUsedParaIds(xml: string | null, used: Set<string>): void {
+  if (!xml) return;
+  const paraIdAttrPattern =
+    /(?:w14:paraId|w15:paraId|w15:paraIdParent|w16cid:paraId)\s*=\s*["']([0-9A-Fa-f]{1,8})["']/g;
+  for (const match of xml.matchAll(paraIdAttrPattern)) {
+    used.add(normalizeParaId(match[1]!));
+  }
+}
+
+/**
+ * Restamp revised-side comment paragraph paraIds when they collide with
+ * original-side comment paraIds that belong to different comment content.
+ *
+ * This pass intentionally matches literal Word prefixes (`w14`, `w15`, and
+ * `w16cid`) for both DOM lookup and raw allocation scans, consistent with the
+ * rest of this module's prefix-literal auxiliary part handling. Mutates
+ * `revisedArchive` in place and returns the applied restamps.
+ *
+ * @see https://github.com/UseJunior/safe-docx/issues/448
+ */
+export async function restampCollidingCommentParaIds(
+  originalArchive: DocxArchive,
+  revisedArchive: DocxArchive,
+): Promise<RestampedCommentParaId[]> {
+  const [
+    originalCommentsXml,
+    revisedCommentsXml,
+    revisedCommentsExtendedXml,
+    revisedCommentsIdsXml,
+  ] = await Promise.all([
+    originalArchive.getFile('word/comments.xml'),
+    revisedArchive.getFile('word/comments.xml'),
+    revisedArchive.getFile('word/commentsExtended.xml'),
+    revisedArchive.getFile('word/commentsIds.xml'),
+  ]);
+
+  if (!originalCommentsXml) return [];
+
+  const originalOwners = collectCommentParaIdOwners(originalCommentsXml);
+  if (originalOwners.size === 0) return [];
+
+  const revisedOwners = collectCommentParaIdOwners(revisedCommentsXml);
+  const collidingParaIds = new Set<string>();
+  for (const [paraId, revisedOwnerEntries] of revisedOwners) {
+    const originalOwnerEntries = originalOwners.get(paraId);
+    if (!originalOwnerEntries) continue;
+
+    if (
+      originalOwnerEntries.length === 1 &&
+      revisedOwnerEntries.length === 1 &&
+      serializer.serializeToString(originalOwnerEntries[0]!) ===
+        serializer.serializeToString(revisedOwnerEntries[0]!)
+    ) {
+      continue;
+    }
+
+    collidingParaIds.add(paraId);
+  }
+
+  const revisedBackedParaIds = new Set(revisedOwners.keys());
+  const revisedAncillaryParaIds = new Set<string>();
+  for (const value of collectAttributeValues(
+    revisedCommentsExtendedXml,
+    'w15:commentEx',
+    ['w15:paraId', 'w15:paraIdParent'],
+  )) {
+    revisedAncillaryParaIds.add(value);
+  }
+  for (const value of collectAttributeValues(
+    revisedCommentsIdsXml,
+    'w16cid:commentId',
+    ['w16cid:paraId'],
+  )) {
+    revisedAncillaryParaIds.add(value);
+  }
+
+  for (const paraId of revisedAncillaryParaIds) {
+    if (!revisedBackedParaIds.has(paraId) && originalOwners.has(paraId)) {
+      collidingParaIds.add(paraId);
+    }
+  }
+
+  if (collidingParaIds.size === 0) return [];
+
+  const usedParaIds = new Set<string>();
+  const allocationScanPaths = [
+    'word/comments.xml',
+    'word/commentsExtended.xml',
+    'word/commentsIds.xml',
+    'word/document.xml',
+  ];
+  for (const archive of [originalArchive, revisedArchive]) {
+    await Promise.all(
+      allocationScanPaths.map(async (path) => {
+        collectUsedParaIds(await archive.getFile(path), usedParaIds);
+      }),
+    );
+  }
+
+  const valueMap = new Map<string, string>();
+  let next = 1;
+  for (const fromParaId of [...collidingParaIds].sort()) {
+    let toParaId: string;
+    do {
+      toParaId = next.toString(16).toUpperCase().padStart(8, '0');
+      next++;
+    } while (usedParaIds.has(toParaId) || toParaId === '00000000');
+    usedParaIds.add(toParaId);
+    valueMap.set(fromParaId, toParaId);
+  }
+
+  const rewriteFiles = new Map<string, LazyArchiveXml>();
+  for (const path of ['word/comments.xml', 'word/commentsExtended.xml', 'word/commentsIds.xml']) {
+    const xml = await revisedArchive.getFile(path);
+    if (xml) rewriteFiles.set(path, new LazyArchiveXml(revisedArchive, path, xml));
+  }
+
+  rewriteFiles
+    .get('word/comments.xml')
+    ?.applyAttributeMap(['w:p'], 'w14:paraId', valueMap, normalizeParaId);
+  rewriteFiles
+    .get('word/commentsExtended.xml')
+    ?.applyAttributeMap(['w15:commentEx'], 'w15:paraId', valueMap, normalizeParaId);
+  rewriteFiles
+    .get('word/commentsExtended.xml')
+    ?.applyAttributeMap(['w15:commentEx'], 'w15:paraIdParent', valueMap, normalizeParaId);
+  rewriteFiles
+    .get('word/commentsIds.xml')
+    ?.applyAttributeMap(['w16cid:commentId'], 'w16cid:paraId', valueMap, normalizeParaId);
+
+  for (const file of rewriteFiles.values()) file.flush();
+
+  return [...valueMap].map(([fromParaId, toParaId]) => ({ fromParaId, toParaId }));
 }

--- a/packages/docx-core/src/baselines/atomizer/pipeline.ts
+++ b/packages/docx-core/src/baselines/atomizer/pipeline.ts
@@ -77,6 +77,7 @@ import {
   AUXILIARY_PARTS,
   parseEntries,
   renumberCollidingAuxiliaryIds,
+  restampCollidingCommentParaIds,
   type AuxiliaryPartDescriptor,
 } from './auxiliaryIdCollision.js';
 import { maybeCaptureEmittedDocumentXml } from '../../primitives/schema-corpus-capture.js';
@@ -743,12 +744,14 @@ export async function compareDocumentsAtomizer(
   const originalArchive = await DocxArchive.load(original);
   const revisedArchive = await DocxArchive.load(revised);
 
-  // Step 1b: Resolve auxiliary ID collisions (issue #107). When both sides
-  // define different content under the same comment/footnote/endnote w:id,
-  // renumber the revised side so no anchor in the merged output can bind to
-  // the other document's definition. Must run before any document.xml
-  // extraction so every downstream step sees the renumbered archive.
+  // Step 1b: Resolve auxiliary ID collisions. When both sides define
+  // different content under the same comment/footnote/endnote w:id or the
+  // same comment paraId, rewrite the revised side so no anchor or ancillary
+  // row in the merged output can bind to the other document's definition.
+  // Must run before any document.xml extraction so every downstream step sees
+  // the rewritten archive.
   await renumberCollidingAuxiliaryIds(originalArchive, revisedArchive);
+  await restampCollidingCommentParaIds(originalArchive, revisedArchive);
 
   // Step 2: Extract document.xml
   const originalXml = await originalArchive.getDocumentXml();

--- a/packages/docx-core/src/integration/auxiliary-id-collision.test.ts
+++ b/packages/docx-core/src/integration/auxiliary-id-collision.test.ts
@@ -20,6 +20,7 @@ import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
 import { compareDocuments } from '../index.js';
 import { buildSyntheticDocx, getResultParts } from './synthetic-docx-fixture.js';
 import { parseXml } from '../primitives/xml.js';
+import type JSZip from 'jszip';
 
 /** Collect w:id values of every `tag` element in the XML. */
 function idsOf(xml: string, tag: string): Set<string> {
@@ -70,6 +71,87 @@ function expectAnchorsResolve(
 const test = testAllure
   .epic('Document Comparison')
   .withLabels({ feature: 'Auxiliary Part ID Collisions' });
+
+function firstCommentParagraphParaIds(commentsXml: string): string[] {
+  const paraIds: string[] = [];
+  const comments = parseXml(commentsXml).getElementsByTagName('w:comment');
+  for (let i = 0; i < comments.length; i++) {
+    const firstP = (comments[i] as Element).getElementsByTagName('w:p')[0] as Element | undefined;
+    const paraId = firstP?.getAttribute('w14:paraId');
+    if (paraId) paraIds.push(paraId);
+  }
+  return paraIds;
+}
+
+function commentParaIdByText(commentsXml: string): Map<string, string> {
+  const byText = new Map<string, string>();
+  const comments = parseXml(commentsXml).getElementsByTagName('w:comment');
+  for (let i = 0; i < comments.length; i++) {
+    const comment = comments[i] as Element;
+    const firstP = comment.getElementsByTagName('w:p')[0] as Element | undefined;
+    const paraId = firstP?.getAttribute('w14:paraId');
+    if (paraId) byText.set(comment.textContent ?? '', paraId);
+  }
+  return byText;
+}
+
+function commentExEntries(commentsExtendedXml: string): Array<{ paraId: string; parentParaId: string | null; done: string | null }> {
+  const entries: Array<{ paraId: string; parentParaId: string | null; done: string | null }> = [];
+  const elements = parseXml(commentsExtendedXml).getElementsByTagName('w15:commentEx');
+  for (let i = 0; i < elements.length; i++) {
+    const el = elements[i] as Element;
+    const paraId = el.getAttribute('w15:paraId');
+    if (!paraId) continue;
+    entries.push({
+      paraId,
+      parentParaId: el.getAttribute('w15:paraIdParent'),
+      done: el.getAttribute('w15:done'),
+    });
+  }
+  return entries;
+}
+
+function commentsIdsEntries(commentsIdsXml: string): Array<{ paraId: string; durableId: string | null }> {
+  const entries: Array<{ paraId: string; durableId: string | null }> = [];
+  const elements = parseXml(commentsIdsXml).getElementsByTagName('w16cid:commentId');
+  for (let i = 0; i < elements.length; i++) {
+    const el = elements[i] as Element;
+    const paraId = el.getAttribute('w16cid:paraId');
+    if (!paraId) continue;
+    entries.push({ paraId, durableId: el.getAttribute('w16cid:durableId') });
+  }
+  return entries;
+}
+
+async function expectThreadedCommentParaIdsCorrect(resultDoc: Buffer): Promise<void> {
+  const parts = await getResultParts(resultDoc);
+  expect(parts.commentsXml).not.toBeNull();
+  expect(parts.commentsExtendedXml).not.toBeNull();
+
+  const paraIds = firstCommentParagraphParaIds(parts.commentsXml!);
+  expect(paraIds).toHaveLength(4);
+  expect(new Set(paraIds).size).toBe(4);
+
+  const paraIdSet = new Set(paraIds);
+  const exEntries = commentExEntries(parts.commentsExtendedXml!);
+  expect(exEntries).toHaveLength(4);
+  for (const entry of exEntries) {
+    expect(paraIdSet.has(entry.paraId), `commentEx paraId="${entry.paraId}" has no comment paragraph`).toBe(true);
+  }
+
+  const byText = commentParaIdByText(parts.commentsXml!);
+  const revisedReply = exEntries.find((entry) => entry.paraId === byText.get('Revised reply'));
+  const originalReply = exEntries.find((entry) => entry.paraId === byText.get('Original reply'));
+  expect(revisedReply?.parentParaId).toBe(byText.get('Revised comment'));
+  expect(originalReply?.parentParaId).toBe(byText.get('Original comment'));
+}
+
+async function spliceZip(buffer: Buffer, mutate: (zip: JSZip) => Promise<void>): Promise<Buffer> {
+  const JSZip = (await import('jszip')).default;
+  const zip = await JSZip.loadAsync(buffer);
+  await mutate(zip);
+  return (await zip.generateAsync({ type: 'nodebuffer' })) as Buffer;
+}
 
 describe('Auxiliary part ID collisions (issue #107)', () => {
   describe('Comment w:id="1" means different content on each side', () => {
@@ -382,6 +464,274 @@ describe('Auxiliary part ID collisions (issue #107)', () => {
         expect(Array.from(definitions.keys())).toEqual(['1']);
         expect(idsOf(parts.documentXml, 'w:commentReference')).toEqual(new Set(['1']));
       });
+    });
+  });
+});
+
+describe('Comment paraId collisions (issue #448)', () => {
+  const buildThreadedInputs = async () => {
+    const original = await buildSyntheticDocx({
+      paragraphs: ['First paragraph', 'Commented paragraph', 'Third paragraph'],
+      commentOnParagraph: 1,
+      commentText: 'Original comment',
+      commentAuthor: 'A',
+      replyText: 'Original reply',
+      replyAuthor: 'AA',
+      commentAncillaryParts: true,
+    });
+    const revised = await buildSyntheticDocx({
+      paragraphs: ['First paragraph', 'Commented paragraph', 'Third paragraph'],
+      commentOnParagraph: 1,
+      commentText: 'Revised comment',
+      commentAuthor: 'B',
+      replyText: 'Revised reply',
+      replyAuthor: 'BB',
+      commentAncillaryParts: true,
+    });
+    return { original, revised };
+  };
+
+  test('rebuild keeps commentEx threading bound to each side after paraId restamp', async ({ given, when, then }: AllureBddContext) => {
+    let original: Buffer, revised: Buffer;
+    await given('both sides have threaded comments with colliding comment paragraph paraIds', async () => {
+      ({ original, revised } = await buildThreadedInputs());
+    });
+
+    let result: Awaited<ReturnType<typeof compareDocuments>>;
+    await when('documents are compared in rebuild mode', async () => {
+      result = await compareDocuments(original, revised, {
+        engine: 'atomizer',
+        reconstructionMode: 'rebuild',
+      });
+    });
+
+    await then('all commentEx rows resolve and reply parents stay on the same side', async () => {
+      expect(result.reconstructionModeUsed).toBe('rebuild');
+      await expectThreadedCommentParaIdsCorrect(result.document);
+    });
+  });
+
+  test('inplace keeps commentEx threading bound to each side after paraId restamp', async ({ given, when, then }: AllureBddContext) => {
+    let original: Buffer, revised: Buffer;
+    await given('both sides have threaded comments with colliding comment paragraph paraIds', async () => {
+      ({ original, revised } = await buildThreadedInputs());
+    });
+
+    let result: Awaited<ReturnType<typeof compareDocuments>>;
+    await when('documents are compared in inplace mode', async () => {
+      result = await compareDocuments(original, revised, {
+        engine: 'atomizer',
+        reconstructionMode: 'inplace',
+      });
+    });
+
+    await then('all commentEx rows resolve and reply parents stay on the same side', async () => {
+      expect(result.reconstructionModeUsed).toBe('inplace');
+      await expectThreadedCommentParaIdsCorrect(result.document);
+    });
+  });
+
+  test('identical threaded comments are not restamped', async ({ given, when, then }: AllureBddContext) => {
+    let original: Buffer, revised: Buffer;
+    await given('both sides carry byte-identical threaded comments and ancillary rows', async () => {
+      original = await buildSyntheticDocx({
+        paragraphs: ['First paragraph', 'Commented paragraph'],
+        commentOnParagraph: 1,
+        commentText: 'Shared comment',
+        commentAuthor: 'Alice',
+        replyText: 'Shared reply',
+        replyAuthor: 'Bob',
+        commentAncillaryParts: true,
+      });
+      revised = await buildSyntheticDocx({
+        paragraphs: ['First paragraph', 'Commented paragraph'],
+        commentOnParagraph: 1,
+        commentText: 'Shared comment',
+        commentAuthor: 'Alice',
+        replyText: 'Shared reply',
+        replyAuthor: 'Bob',
+        commentAncillaryParts: true,
+      });
+    });
+
+    let result: Awaited<ReturnType<typeof compareDocuments>>;
+    await when('documents are compared in rebuild mode', async () => {
+      result = await compareDocuments(original, revised, {
+        engine: 'atomizer',
+        reconstructionMode: 'rebuild',
+      });
+    });
+
+    await then('the shared paraIds remain unchanged and are not duplicated', async () => {
+      const parts = await getResultParts(result.document);
+      expect(parts.commentsXml).not.toBeNull();
+      expect(parts.commentsExtendedXml).not.toBeNull();
+      expect(new Set(firstCommentParagraphParaIds(parts.commentsXml!))).toEqual(
+        new Set(['00000001', '00000002'])
+      );
+      expect(commentExEntries(parts.commentsExtendedXml!).map((entry) => entry.paraId)).toEqual([
+        '00000001',
+        '00000002',
+      ]);
+      expect(parts.commentsExtendedXml!).toContain('w15:paraIdParent="00000001"');
+    });
+  });
+
+  test('same paraId with different comment IDs still restamps', async ({ given, when, then }: AllureBddContext) => {
+    let original: Buffer, revised: Buffer;
+    await given('comment IDs do not collide but comment paragraph paraIds do', async () => {
+      original = await buildSyntheticDocx({
+        paragraphs: ['First paragraph', 'Commented paragraph'],
+        commentOnParagraph: 1,
+        commentText: 'Original comment',
+        commentAuthor: 'A',
+        commentAncillaryParts: true,
+      });
+      const baseRevised = await buildSyntheticDocx({
+        paragraphs: ['First paragraph', 'Commented paragraph'],
+        commentOnParagraph: 1,
+        commentText: 'Revised comment',
+        commentAuthor: 'B',
+        commentAncillaryParts: true,
+      });
+      revised = await spliceZip(baseRevised, async (zip) => {
+        const commentsXml = await zip.file('word/comments.xml')!.async('string');
+        zip.file('word/comments.xml', commentsXml.replace('w:id="1"', 'w:id="5"'));
+        const documentXml = await zip.file('word/document.xml')!.async('string');
+        zip.file(
+          'word/document.xml',
+          documentXml
+            .replaceAll('w:commentRangeStart w:id="1"', 'w:commentRangeStart w:id="5"')
+            .replaceAll('w:commentRangeEnd w:id="1"', 'w:commentRangeEnd w:id="5"')
+            .replaceAll('w:commentReference w:id="1"', 'w:commentReference w:id="5"')
+        );
+      });
+    });
+
+    let result: Awaited<ReturnType<typeof compareDocuments>>;
+    await when('documents are compared in rebuild mode', async () => {
+      result = await compareDocuments(original, revised, {
+        engine: 'atomizer',
+        reconstructionMode: 'rebuild',
+      });
+    });
+
+    await then('both comments ship with distinct paraIds and commentEx rows', async () => {
+      const parts = await getResultParts(result.document);
+      expect(parts.commentsXml).not.toBeNull();
+      expect(parts.commentsExtendedXml).not.toBeNull();
+      const byText = commentParaIdByText(parts.commentsXml!);
+      expect(byText.get('Original comment')).toBeDefined();
+      expect(byText.get('Revised comment')).toBeDefined();
+      expect(byText.get('Original comment')).not.toBe(byText.get('Revised comment'));
+      const exParaIds = new Set(commentExEntries(parts.commentsExtendedXml!).map((entry) => entry.paraId));
+      expect(exParaIds.has(byText.get('Original comment')!)).toBe(true);
+      expect(exParaIds.has(byText.get('Revised comment')!)).toBe(true);
+    });
+  });
+
+  test('inplace restamps commentsIds.xml durable ID rows with revised comments', async ({ given, when, then }: AllureBddContext) => {
+    let original: Buffer, revised: Buffer;
+    await given('the revised archive carries Word commentsIds.xml rows for colliding paraIds', async () => {
+      ({ original, revised } = await buildThreadedInputs());
+      revised = await spliceZip(revised, async (zip) => {
+        zip.file(
+          'word/commentsIds.xml',
+          `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+            `<w16cid:commentsIds xmlns:w16cid="http://schemas.microsoft.com/office/word/2016/wordml/cid">` +
+            `<w16cid:commentId w16cid:paraId="00000001" w16cid:durableId="11111111"/>` +
+            `<w16cid:commentId w16cid:paraId="00000002" w16cid:durableId="22222222"/>` +
+            `</w16cid:commentsIds>`
+        );
+        const contentTypes = await zip.file('[Content_Types].xml')!.async('string');
+        zip.file(
+          '[Content_Types].xml',
+          contentTypes.replace(
+            '</Types>',
+            `<Override PartName="/word/commentsIds.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.commentsIds+xml"/></Types>`
+          )
+        );
+        const rels = await zip.file('word/_rels/document.xml.rels')!.async('string');
+        zip.file(
+          'word/_rels/document.xml.rels',
+          rels.replace(
+            '</Relationships>',
+            `<Relationship Id="rId99" Type="http://schemas.microsoft.com/office/2016/09/relationships/commentsIds" Target="commentsIds.xml"/></Relationships>`
+          )
+        );
+      });
+    });
+
+    let result: Awaited<ReturnType<typeof compareDocuments>>;
+    await when('documents are compared in inplace mode', async () => {
+      result = await compareDocuments(original, revised, {
+        engine: 'atomizer',
+        reconstructionMode: 'inplace',
+      });
+    });
+
+    await then('commentsIds rows point at the restamped revised comment paragraphs', async () => {
+      const parts = await getResultParts(result.document);
+      expect(parts.commentsXml).not.toBeNull();
+      expect(parts.commentsIdsXml).not.toBeNull();
+      const commentParaIds = new Set(firstCommentParagraphParaIds(parts.commentsXml!));
+      const idsEntries = commentsIdsEntries(parts.commentsIdsXml!);
+      expect(idsEntries.map((entry) => entry.durableId)).toEqual(['11111111', '22222222']);
+      for (const entry of idsEntries) {
+        expect(commentParaIds.has(entry.paraId), `commentsIds paraId="${entry.paraId}" has no comment paragraph`).toBe(true);
+      }
+    });
+  });
+
+  test('inplace restamps dangling ancillary paraIds that would bind to original comments', async ({ given, when, then }: AllureBddContext) => {
+    let original: Buffer, revised: Buffer;
+    await given('a revised dangling commentEx row collides with an original comment paraId', async () => {
+      original = await buildSyntheticDocx({
+        paragraphs: ['First paragraph', 'Commented paragraph'],
+        commentOnParagraph: 1,
+        commentText: 'Original comment',
+        commentAuthor: 'A',
+        commentAncillaryParts: true,
+      });
+      const baseRevised = await buildSyntheticDocx({
+        paragraphs: ['First paragraph', 'Commented paragraph'],
+        commentOnParagraph: 1,
+        commentText: 'Revised comment',
+        commentAuthor: 'B',
+        commentAncillaryParts: true,
+      });
+      revised = await spliceZip(baseRevised, async (zip) => {
+        const commentsXml = await zip.file('word/comments.xml')!.async('string');
+        zip.file('word/comments.xml', commentsXml.replace('w14:paraId="00000001"', 'w14:paraId="00000009"'));
+        const commentsExtendedXml = await zip.file('word/commentsExtended.xml')!.async('string');
+        zip.file(
+          'word/commentsExtended.xml',
+          commentsExtendedXml
+            .replace('w15:paraId="00000001"', 'w15:paraId="00000009"')
+            .replace(
+              '</w15:commentsEx>',
+              `<w15:commentEx w15:paraId="00000001" w15:done="1"/></w15:commentsEx>`
+            )
+        );
+      });
+    });
+
+    let result: Awaited<ReturnType<typeof compareDocuments>>;
+    await when('documents are compared in inplace mode', async () => {
+      result = await compareDocuments(original, revised, {
+        engine: 'atomizer',
+        reconstructionMode: 'inplace',
+      });
+    });
+
+    await then('the dangling row no longer uses the original comment paraId', async () => {
+      const parts = await getResultParts(result.document);
+      expect(parts.commentsXml).not.toBeNull();
+      expect(parts.commentsExtendedXml).not.toBeNull();
+      const originalParaId = commentParaIdByText(parts.commentsXml!).get('Original comment');
+      const danglingEntry = commentExEntries(parts.commentsExtendedXml!).find((entry) => entry.done === '1');
+      expect(danglingEntry).toBeDefined();
+      expect(danglingEntry!.paraId).not.toBe(originalParaId);
     });
   });
 });

--- a/packages/docx-core/src/integration/synthetic-docx-fixture.ts
+++ b/packages/docx-core/src/integration/synthetic-docx-fixture.ts
@@ -459,6 +459,7 @@ export interface SyntheticResultParts {
   endnotesXml: string | null;
   commentsXml: string | null;
   commentsExtendedXml: string | null;
+  commentsIdsXml: string | null;
   peopleXml: string | null;
   contentTypesXml: string | null;
   relsXml: string | null;
@@ -472,6 +473,7 @@ export async function getResultParts(resultBuffer: Buffer): Promise<SyntheticRes
     endnotesXml: await archive.getFile('word/endnotes.xml'),
     commentsXml: await archive.getFile('word/comments.xml'),
     commentsExtendedXml: await archive.getFile('word/commentsExtended.xml'),
+    commentsIdsXml: await archive.getFile('word/commentsIds.xml'),
     peopleXml: await archive.getFile('word/people.xml'),
     contentTypesXml: await archive.getFile('[Content_Types].xml'),
     relsXml: await archive.getFile('word/_rels/document.xml.rels'),


### PR DESCRIPTION
## Summary

- Restamp revised-side comment paragraph paraIds when they collide with original-side comments or dangling revised ancillary rows.
- Rewrite comments.xml, commentsExtended.xml, and commentsIds.xml consistently before atomizer comparison.
- Add issue #448 regression coverage for rebuild, inplace, unchanged identical comments, w:id-independent collisions, commentsIds.xml, and dangling commentEx rows.

## Why

- Root cause: commentsExtended.xml and commentsIds.xml are keyed by comment paragraph paraIds, not auxiliary w:id values. After the issue #107 w:id renumbering, independently authored documents could still reuse the same comment paraIds, causing ancillary rows to bind to the wrong side or get skipped during merge.
- The comparison pipeline needs to preserve comment threading and durable-ID ancillary rows while keeping original and revised comment paragraphs distinct.

## Scope

- `packages/docx-core` atomizer auxiliary-ID collision handling.
- Integration coverage for comment paraId collisions across comments.xml, commentsExtended.xml, and commentsIds.xml.
- No public API changes.

## OpenSpec

- [x] Not required: this is not a new capability, breaking change, architecture shift, or substantial performance/security work.
- [ ] Required and included: `openspec/changes/<change-id>/`.

## ECMA-376 / OOXML Conformance

- [x] Not applicable: this does not change ECMA-376 OOXML behavior. The affected paraId, commentsExtended.xml, and commentsIds.xml data are Microsoft Word extension surfaces ([MS-DOCX]), not ECMA-376 conformance targets.
- [ ] Applicable: conformance claims use `@conformance ECMA-376 edition <N>, Part <N> § <SECTION>`.
- [ ] Applicable: tests use `testAllure.conformance({ spec, edition, part, section })`.

## Testing

- [x] `npm run build`
- [x] `npm run lint:workspaces`
- [x] `npm run test:run`
- [x] `npm run check:spec-coverage`
- [x] `npm run check:conformance-citations`
- [x] `npm run check:conformance-doc`

Notes:
- `npm run test:run -w @usejunior/docx-core -- src/integration/auxiliary-id-collision.test.ts` passed.
- `npm run build -w @usejunior/docx-core` passed.
- `npm run lint:workspaces` passed with existing warnings.
- Full `npm run test:run` was also run locally and failed in unrelated dirty-work areas: MCP AI revision validation/insert_paragraph tests and ODF LibreOffice oracle tests where `/opt/homebrew/bin/soffice` aborts. The workspace test jobs were green in CI.

## Fixtures

- [ ] Not applicable.
- [x] Reused helpers from `packages/docx-core/src/testing/` where possible.
- [x] Added inline OOXML only because the literal shape is the subject of the test.

`buildSyntheticDocx` is reused for the package scaffolding. Inline XML splices are limited to the scenario-specific ancillary part shapes under test.

## Visual Changes

- [x] Not applicable.
- [ ] Screenshots or gifs included.

## Related Issues

Fixes: #448
