### PR TITLE
docs(github): add issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,71 @@
+name: Bug report
+description: Report a reproducible problem in safe-docx.
+title: "fix(scope): "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Please include enough detail for a maintainer to reproduce the behavior.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What went wrong?
+      placeholder: Describe the observed behavior and why it is incorrect.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Provide commands, a small fixture, or a minimal code sample.
+      placeholder: |
+        1. Run ...
+        2. Open ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: dropdown
+    id: package
+    attributes:
+      label: Affected package
+      options:
+        - packages/docx-core
+        - packages/docx-mcp
+        - packages/safe-docx-mcpb
+        - spec-compliance
+        - openspec
+        - CI / release
+        - unknown / multiple
+    validations:
+      required: true
+  - type: textarea
+    id: conformance
+    attributes:
+      label: ECMA-376 / OOXML impact
+      description: If this touches OOXML behavior, cite the relevant ECMA-376 section or explain why none is known.
+      placeholder: "ECMA-376 5th edition, Part ..., section ..."
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or artifacts
+      description: Paste relevant logs, failing test output, screenshots, or attach a DOCX fixture if appropriate.
+      render: shell
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include Node/npm versions, OS, package version, and any relevant runtime details.
+      placeholder: |
+        node --version:
+        npm --version:
+        OS:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Contributing guide
+    url: https://github.com/UseJunior/safe-docx/blob/main/CONTRIBUTING.md
+    about: Read branch, commit, PR, and local pre-submit conventions.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,64 @@
+name: Feature or change request
+description: Propose a new capability, behavior change, or repo improvement.
+title: "feat(scope): "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For new capabilities, breaking changes, architecture shifts, or substantial performance/security work, include an OpenSpec change proposal.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What user or maintainer problem should this solve?
+      placeholder: Describe the use case and current limitation.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the desired behavior or change.
+    validations:
+      required: true
+  - type: dropdown
+    id: package
+    attributes:
+      label: Affected area
+      options:
+        - packages/docx-core
+        - packages/docx-mcp
+        - packages/safe-docx-mcpb
+        - spec-compliance
+        - openspec
+        - CI / release
+        - docs
+        - unknown / multiple
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What other approaches were considered?
+  - type: checkboxes
+    id: change-type
+    attributes:
+      label: Change type
+      options:
+        - label: This introduces a new capability or behavior shift and needs an OpenSpec proposal.
+        - label: This may affect ECMA-376 / OOXML conformance.
+        - label: This is a minor tweak that should not require OpenSpec.
+  - type: textarea
+    id: conformance
+    attributes:
+      label: ECMA-376 / OOXML notes
+      description: If applicable, cite targeted sections or explain conformance risks.
+      placeholder: "ECMA-376 5th edition, Part ..., section ..."
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add links, examples, fixtures, or related issues.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,47 @@
+## Summary
+
+- 
+
+## Why
+
+- 
+
+## Scope
+
+- 
+
+## OpenSpec
+
+- [ ] Not required: this is not a new capability, breaking change, architecture shift, or substantial performance/security work.
+- [ ] Required and included: `openspec/changes/<change-id>/`.
+
+## ECMA-376 / OOXML Conformance
+
+- [ ] Not applicable: this does not change OOXML behavior.
+- [ ] Applicable: conformance claims use `@conformance ECMA-376 edition <N>, Part <N> § <SECTION>`.
+- [ ] Applicable: tests use `testAllure.conformance({ spec, edition, part, section })`.
+
+## Testing
+
+- [ ] `npm run build`
+- [ ] `npm run lint:workspaces`
+- [ ] `npm run test:run`
+- [ ] `npm run check:spec-coverage`
+- [ ] `npm run check:conformance-citations`
+- [ ] `npm run check:conformance-doc`
+
+## Fixtures
+
+- [ ] Not applicable.
+- [ ] Reused helpers from `packages/docx-core/src/testing/` where possible.
+- [ ] Added inline OOXML only because the literal shape is the subject of the test.
+
+## Visual Changes
+
+- [ ] Not applicable.
+- [ ] Screenshots or gifs included.
+
+## Related Issues
+
+Fixes: 
+Ref: 


### PR DESCRIPTION
## Summary

- Add GitHub issue forms for bug reports and feature/change requests.
- Add an issue-template config with a contributing-guide link.
- Add a pull request template aligned with repo review expectations.

## Why

The repository already documents branch, commit, OpenSpec, ECMA-376 conformance, fixture, and pre-submit expectations in `CONTRIBUTING.md` and `AGENTS.md`, but GitHub did not prompt contributors for that context at issue or PR creation time.

These templates make that context explicit during triage and review, reducing back-and-forth and keeping conformance-sensitive changes visible.

## Scope

- `.github/ISSUE_TEMPLATE/bug_report.yml`
- `.github/ISSUE_TEMPLATE/feature_request.yml`
- `.github/ISSUE_TEMPLATE/config.yml`
- `.github/pull_request_template.md`

## Validation

- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/ISSUE_TEMPLATE/bug_report.yml .github/ISSUE_TEMPLATE/feature_request.yml .github/ISSUE_TEMPLATE/config.yml`

Full repository checks were not run because this is a GitHub metadata/documentation-only change.