### PR TITLE
docs(docx-core): record commentsIds OPC string provenance

### DIFF
--- a/packages/docx-core/src/integration/auxiliary-id-collision.test.ts
+++ b/packages/docx-core/src/integration/auxiliary-id-collision.test.ts
@@ -644,6 +644,8 @@ describe('Comment paraId collisions (issue #448)', () => {
             `</w16cid:commentsIds>`
         );
         const contentTypes = await zip.file('[Content_Types].xml')!.async('string');
+        // [MS-DOCX] defines the commentsIds OPC part with this content type and
+        // relationship type; no shared test fixture currently carries the part.
         zip.file(
           '[Content_Types].xml',
           contentTypes.replace(


### PR DESCRIPTION
## Summary

- Add an inline provenance note for the commentsIds OPC content type and relationship literals in the #448 regression test.

## Why

- The test intentionally splices a Microsoft Word commentsIds part because no shared fixture currently carries that part.
- Calling out the [MS-DOCX] source near the literals makes the inline package metadata intentional and easier to review.

## Scope

- Comment-only test documentation in `packages/docx-core/src/integration/auxiliary-id-collision.test.ts`.
- No runtime behavior changes.

## OpenSpec

- [x] Not required: this is not a new capability, breaking change, architecture shift, or substantial performance/security work.
- [ ] Required and included: `openspec/changes/<change-id>/`.

## ECMA-376 / OOXML Conformance

- [x] Not applicable: this does not change OOXML behavior. The note documents Microsoft Word extension OPC metadata for `commentsIds.xml` ([MS-DOCX]).
- [ ] Applicable: conformance claims use `@conformance ECMA-376 edition <N>, Part <N> § <SECTION>`.
- [ ] Applicable: tests use `testAllure.conformance({ spec, edition, part, section })`.

## Testing

- [ ] `npm run build`
- [ ] `npm run lint:workspaces`
- [ ] `npm run test:run`
- [ ] `npm run check:spec-coverage`
- [ ] `npm run check:conformance-citations`
- [ ] `npm run check:conformance-doc`

Comment-only change; not run locally.

## Fixtures

- [ ] Not applicable.
- [x] Reused helpers from `packages/docx-core/src/testing/` where possible.
- [x] Added inline OOXML only because the literal shape is the subject of the test.

## Visual Changes

- [x] Not applicable.
- [ ] Screenshots or gifs included.

## Related Issues

Ref: #448
Ref: #465
