### PR TITLE
docs(readme): add Report Bug / Request Feature quick links under badges

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -9,6 +9,10 @@
 [![GitHub issues closed](https://img.shields.io/github/issues-closed/UseJunior/safe-docx)](https://github.com/UseJunior/safe-docx/issues?q=is%3Aissue+is%3Aclosed)
 <!-- SYNC:badges END -->
 
+<!-- SYNC:issue-quick-links BEGIN -->
+[Report Bug](https://github.com/usejunior/safe-docx/issues/new?template=bug_report.yml) · [Request Feature](https://github.com/usejunior/safe-docx/issues/new?template=feature_request.yml)
+<!-- SYNC:issue-quick-links END -->
+
 <!-- SYNC:lang-nav BEGIN -->
 [English](./README.md) | [Español](./README.es.md) | [简体中文](./README.zh.md) | [Português (Brasil)](./README.pt-br.md) | [Deutsch](./README.de.md)
 <!-- SYNC:lang-nav END -->

--- a/README.es.md
+++ b/README.es.md
@@ -9,6 +9,10 @@
 [![GitHub issues closed](https://img.shields.io/github/issues-closed/UseJunior/safe-docx)](https://github.com/UseJunior/safe-docx/issues?q=is%3Aissue+is%3Aclosed)
 <!-- SYNC:badges END -->
 
+<!-- SYNC:issue-quick-links BEGIN -->
+[Report Bug](https://github.com/usejunior/safe-docx/issues/new?template=bug_report.yml) · [Request Feature](https://github.com/usejunior/safe-docx/issues/new?template=feature_request.yml)
+<!-- SYNC:issue-quick-links END -->
+
 <!-- SYNC:lang-nav BEGIN -->
 [English](./README.md) | [Español](./README.es.md) | [简体中文](./README.zh.md) | [Português (Brasil)](./README.pt-br.md) | [Deutsch](./README.de.md)
 <!-- SYNC:lang-nav END -->

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@
 [![GitHub issues closed](https://img.shields.io/github/issues-closed/UseJunior/safe-docx)](https://github.com/UseJunior/safe-docx/issues?q=is%3Aissue+is%3Aclosed)
 <!-- SYNC:badges END -->
 
+<!-- SYNC:issue-quick-links BEGIN -->
+[Report Bug](https://github.com/usejunior/safe-docx/issues/new?template=bug_report.yml) · [Request Feature](https://github.com/usejunior/safe-docx/issues/new?template=feature_request.yml)
+<!-- SYNC:issue-quick-links END -->
+
 <!-- SYNC:lang-nav BEGIN -->
 [English](./README.md) | [Español](./README.es.md) | [简体中文](./README.zh.md) | [Português (Brasil)](./README.pt-br.md) | [Deutsch](./README.de.md)
 <!-- SYNC:lang-nav END -->

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -9,6 +9,10 @@
 [![GitHub issues closed](https://img.shields.io/github/issues-closed/UseJunior/safe-docx)](https://github.com/UseJunior/safe-docx/issues?q=is%3Aissue+is%3Aclosed)
 <!-- SYNC:badges END -->
 
+<!-- SYNC:issue-quick-links BEGIN -->
+[Report Bug](https://github.com/usejunior/safe-docx/issues/new?template=bug_report.yml) · [Request Feature](https://github.com/usejunior/safe-docx/issues/new?template=feature_request.yml)
+<!-- SYNC:issue-quick-links END -->
+
 <!-- SYNC:lang-nav BEGIN -->
 [English](./README.md) | [Español](./README.es.md) | [简体中文](./README.zh.md) | [Português (Brasil)](./README.pt-br.md) | [Deutsch](./README.de.md)
 <!-- SYNC:lang-nav END -->

--- a/README.zh.md
+++ b/README.zh.md
@@ -9,6 +9,10 @@
 [![GitHub issues closed](https://img.shields.io/github/issues-closed/UseJunior/safe-docx)](https://github.com/UseJunior/safe-docx/issues?q=is%3Aissue+is%3Aclosed)
 <!-- SYNC:badges END -->
 
+<!-- SYNC:issue-quick-links BEGIN -->
+[Report Bug](https://github.com/usejunior/safe-docx/issues/new?template=bug_report.yml) · [Request Feature](https://github.com/usejunior/safe-docx/issues/new?template=feature_request.yml)
+<!-- SYNC:issue-quick-links END -->
+
 <!-- SYNC:lang-nav BEGIN -->
 [English](./README.md) | [Español](./README.es.md) | [简体中文](./README.zh.md) | [Português (Brasil)](./README.pt-br.md) | [Deutsch](./README.de.md)
 <!-- SYNC:lang-nav END -->

--- a/scripts/sync_readme_blocks.mjs
+++ b/scripts/sync_readme_blocks.mjs
@@ -9,7 +9,7 @@ const repoRoot = path.resolve(__dirname, '..');
 
 const SOURCE = 'README.md';
 const TARGETS = ['README.es.md', 'README.zh.md', 'README.de.md', 'README.pt-br.md'];
-const BLOCKS = ['badges', 'lang-nav', 'architecture-diagram'];
+const BLOCKS = ['badges', 'issue-quick-links', 'lang-nav', 'architecture-diagram'];
 
 const BEGIN = (name) => `<!-- SYNC:${name} BEGIN -->`;
 const END = (name) => `<!-- SYNC:${name} END -->`;


### PR DESCRIPTION
## Summary
- Add "Report Bug · Request Feature" quick links directly beneath the badges in `README.md`, deep-linking to the existing GitHub issue forms (`bug_report.yml`, `feature_request.yml`). The templates already prefill labels (`bug` / `enhancement`) and conventional-commit title prefixes, so no extra query params are needed.
- Register the links as a new `SYNC:issue-quick-links` block in `scripts/sync_readme_blocks.mjs` so all four translated READMEs stay mechanically in sync, matching how `badges` and `lang-nav` are maintained.

## Why
The issue forms exist but nothing in the README surfaces them; readers have to discover the Issues tab on their own. This adopts the one piece of the Best-README-Template hero block worth taking here: lowering the cost of reporting for first-time visitors.

## Verification
- `npm run check:readme-sync` passes (all five READMEs in sync).
- Peer-reviewed by Codex (`codex exec`, dynamic) and agy — both APPROVED. Codex additionally confirmed via HTTP that GitHub recognizes both `issues/new?template=` routes, and both reviewers grepped for other `SYNC:`-marker consumers (only `scripts/sync_readme_blocks.mjs` and CI's `readme-sync` job).