### PR TITLE
fix(docx-core): interleave logical start/end cell margins in CT_TcMar order

### DIFF
--- a/packages/docx-core/src/primitives/layout.test.ts
+++ b/packages/docx-core/src/primitives/layout.test.ts
@@ -199,6 +199,40 @@ describe('layout tracked-change emission', () => {
       },
     );
 
+  test
+    .conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.4.68' })(
+      'setTableCellPadding keeps logical start/end margins in the CT_TcMar sequence',
+      async ({ given, when, then }: AllureBddContext) => {
+        let doc: Document;
+        let tcMar: Element;
+
+        await given('a table cell whose margins use logical start/end directions', () => {
+          doc = makeDocument(
+            `<w:tbl><w:tblPr/><w:tblGrid><w:gridCol/></w:tblGrid><w:tr><w:tc><w:tcPr><w:tcMar><w:top w:w="100" w:type="dxa"/><w:start w:w="80" w:type="dxa"/><w:end w:w="80" w:type="dxa"/></w:tcMar></w:tcPr><w:p><w:r><w:t>Cell</w:t></w:r></w:p></w:tc></w:tr></w:tbl>`,
+          );
+        });
+
+        await when('left and bottom padding are added', () => {
+          const result = setTableCellPadding(doc, { tableIndexes: [0], leftDxa: 240, bottomDxa: 60 });
+          expect(result.affectedCells).toBe(1);
+
+          const table = doc.getElementsByTagNameNS(W_NS, W.tbl).item(0) as Element;
+          const cell = firstDirectChild(firstDirectChild(table, W.tr), W.tc);
+          tcMar = firstDirectChild(firstDirectChild(cell, W.tcPr), W.tcMar);
+        });
+
+        await then('the pre-existing start/end margins stay interleaved per the schema sequence', () => {
+          expect(Array.from(tcMar.children).map((child) => child.localName)).toEqual([
+            W.top,
+            W.start,
+            W.left,
+            W.bottom,
+            W.end,
+          ]);
+        });
+      },
+    );
+
   test('layout primitives preserve legacy mutation behavior when revision context is omitted', async ({ given, when, then }: AllureBddContext) => {
     let doc: Document;
     let paragraphId: string;

--- a/packages/docx-core/src/primitives/layout.ts
+++ b/packages/docx-core/src/primitives/layout.ts
@@ -98,7 +98,7 @@ function ensureChild(parent: Element, localName: string): Element {
  * @conformance ECMA-376 edition 5, Part 1 § 17.4.68
  */
 function reorderCellMarginEdges(tcMar: Element): void {
-  const orderedNames = [W.top, W.left, W.bottom, W.right];
+  const orderedNames = [W.top, W.start, W.left, W.bottom, W.end, W.right];
   const ordered = orderedNames.flatMap((name) => getDirectChildrenByName(tcMar, name));
   for (const child of ordered) {
     tcMar.appendChild(child);

--- a/packages/docx-core/src/primitives/namespaces.ts
+++ b/packages/docx-core/src/primitives/namespaces.ts
@@ -100,6 +100,7 @@ export const W = {
   bottom: 'bottom',
   left: 'left',
   right: 'right',
+  end: 'end',
   val: 'val',
   hRule: 'hRule',
   w: 'w',


### PR DESCRIPTION
## Why

Dynamic peer review of #461 (Codex + agy, both executing against the merged commit) found that the new `reorderCellMarginEdges` helper only re-appends the four physical margin edges. A cell whose `w:tcMar` legitimately carries logical `w:start`/`w:end` margins gets them parked ahead of `w:top` when `setTableCellPadding` runs, turning a schema-valid document invalid. The Transitional `CT_TcMar` sequence is `top, start, left, bottom, end, right`.

## What

- `orderedNames` now lists all six CT_TcMar children in schema order, so pre-existing logical margins are interleaved instead of stranded.
- Adds `W.end` to the namespace constants (`W.start` already existed).
- Conformance-tagged regression test (§ 17.4.68): a `top + start + end` prior `tcMar` plus tracked left/bottom padding must come out as `top, start, left, bottom, end`.

## Verification

- Runtime probe reproducing the reviewer's failing case (`top, start` prior + `leftDxa`) now emits `top, start, left` and passes `xmllint --schema wml-document-transitional.xsd` (previously: `start, top, left`, exit 3).
- `npm run test:run -w @usejunior/docx-core -- src/primitives/layout.test.ts` — 10/10 pass.
- `npm run lint` for docx-core and docx-mcp, `npm run check:conformance-citations` — all exit 0.

The emitted-schema gate cannot catch this class (no corpus fixture uses logical margins), hence the direct regression test.

Fixes: #477
Ref: #461, #453