### PR TITLE
fix(docx-core): restore untouched hyperlink paragraphs

### DIFF
--- a/packages/docx-core/src/primitives/minimal_save.test.ts
+++ b/packages/docx-core/src/primitives/minimal_save.test.ts
@@ -188,6 +188,54 @@ describe('minimal re-serialization on save (issue #408)', () => {
     });
   });
 
+  test('an untouched hyperlink paragraph restores when tracked output groups link text into one run', async ({ given, when, then }: AllureBddContext) => {
+    const originalXmlText =
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+      `<w:document xmlns:w="${OOXML.W_NS}" xmlns:r="${OOXML.R_NS}"><w:body>` +
+      `<w:p w14:paraId="56317D3A" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" w:rsidR="00AA00AA">` +
+      `<w:proofErr w:type="spellStart"/>` +
+      `<w:r w:rsidR="00AA00AA"><w:t>Untouched</w:t></w:r>` +
+      `<w:hyperlink r:id="rIdHyperlink">` +
+      `<w:r w:rsidR="00AA0001"><w:t>commonpaper.com/standards/mutual-</w:t></w:r>` +
+      `<w:r w:rsidR="00AA0002"><w:t>nda</w:t></w:r>` +
+      `<w:r w:rsidR="00AA0003"><w:t>/1.0</w:t></w:r>` +
+      `</w:hyperlink>` +
+      `<w:r w:rsidR="00BB00BB"><w:t xml:space="preserve"> paragraph</w:t></w:r>` +
+      `<w:proofErr w:type="spellEnd"/>` +
+      `</w:p>` +
+      `</w:body></w:document>`;
+    let currentDoc: Document;
+    let restored = 0;
+
+    await given('a tracked-save paragraph reconstructed with one hyperlink run and multiple text nodes', () => {
+      currentDoc = parseXml(
+        `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+          `<w:document xmlns:w="${OOXML.W_NS}" xmlns:r="${OOXML.R_NS}"><w:body>` +
+          `<w:p w14:paraId="56317D3A" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" w:rsidR="00AA00AA">` +
+          `<w:r><w:t>Untouched</w:t></w:r>` +
+          `<w:hyperlink r:id="rIdHyperlink">` +
+          `<w:r><w:t>commonpaper.com/standards/mutual-</w:t><w:t>nda</w:t><w:t>/1.0</w:t></w:r>` +
+          `</w:hyperlink>` +
+          `<w:r><w:t xml:space="preserve"> paragraph</w:t></w:r>` +
+          `</w:p>` +
+          `</w:body></w:document>`,
+      );
+    });
+
+    await when('untouched blocks are restored', () => {
+      restored = restoreUntouchedBlocks(currentDoc, originalXmlText);
+    });
+
+    await then('the original hyperlink paragraph is restored with proofing markers and run boundaries', () => {
+      const [original] = bodyBlocks(originalXmlText);
+      const [current] = bodyBlocks(serializer.serializeToString(currentDoc as never));
+      expect(restored).toBe(1);
+      expect(current).toBe(original);
+      expect(current).toContain('<w:proofErr w:type="spellStart"/>');
+      expect(current).toContain('<w:r w:rsidR="00AA0002"><w:t>nda</w:t></w:r>');
+    });
+  });
+
   test('an untouched table restores while a modified table keeps its edit', async ({ given, when, then }: AllureBddContext) => {
     const CELL_P =
       `<w:p><w:proofErr w:type="spellStart"/><w:r w:rsidR="00CC0001"><w:t>cell</w:t></w:r>` +

--- a/packages/docx-core/src/primitives/minimal_save.ts
+++ b/packages/docx-core/src/primitives/minimal_save.ts
@@ -137,6 +137,134 @@ function sameQualifiedName(a: Element, b: Element): boolean {
   return a.namespaceURI === b.namespaceURI && a.localName === b.localName;
 }
 
+function isWElement(node: Node, localName: string): node is Element {
+  return (
+    node.nodeType === 1 &&
+    (node as Element).namespaceURI === OOXML.W_NS &&
+    (node as Element).localName === localName
+  );
+}
+
+function directChildElement(el: Element, localName: string): Element | null {
+  let child = el.firstChild;
+  while (child) {
+    if (isWElement(child, localName)) return child;
+    child = child.nextSibling;
+  }
+  return null;
+}
+
+function clonedRunFormattingKey(run: Element): string {
+  const rPr = directChildElement(run, W.rPr);
+  return rPr ? serializer.serializeToString(rPr) : '';
+}
+
+function clonedRunContentChildren(run: Element): Node[] {
+  const out: Node[] = [];
+  let child = run.firstChild;
+  while (child) {
+    const next = child.nextSibling;
+    if (!isWElement(child, W.rPr)) out.push(child);
+    child = next;
+  }
+  return out;
+}
+
+function runHasOnlyTextContent(run: Element): boolean {
+  return clonedRunContentChildren(run).every((child) => {
+    if (child.nodeType === 3) return !(child.textContent ?? '').trim();
+    return isWElement(child, W.t);
+  });
+}
+
+function consolidateAdjacentTextChildren(run: Element): void {
+  let child = run.firstChild;
+  while (child) {
+    if (!isWElement(child, W.t)) {
+      child = child.nextSibling;
+      continue;
+    }
+
+    const first = child;
+    let next: Node | null = first.nextSibling;
+    while (next) {
+      if (next.nodeType === 3 && !(next.textContent ?? '').trim()) {
+        const whitespace = next;
+        next = whitespace.nextSibling;
+        whitespace.parentNode?.removeChild(whitespace);
+        continue;
+      }
+      if (!isWElement(next, W.t)) break;
+
+      const following = next.nextSibling;
+      first.textContent = (first.textContent ?? '') + (next.textContent ?? '');
+      next.parentNode?.removeChild(next);
+      next = following;
+    }
+
+    const text = first.textContent ?? '';
+    if (text.startsWith(' ') || text.endsWith(' ')) {
+      first.setAttributeNS('http://www.w3.org/XML/1998/namespace', 'xml:space', 'preserve');
+    } else {
+      first.removeAttributeNS('http://www.w3.org/XML/1998/namespace', 'space');
+    }
+    child = first.nextSibling;
+  }
+}
+
+function mergeAdjacentRunsForKey(container: Element): void {
+  let child = container.firstChild;
+  let currentRun: Element | null = null;
+
+  while (child) {
+    const next = child.nextSibling;
+    if (!isWElement(child, W.r)) {
+      currentRun = null;
+      child = next;
+      continue;
+    }
+
+    if (
+      currentRun &&
+      runHasOnlyTextContent(currentRun) &&
+      runHasOnlyTextContent(child) &&
+      clonedRunFormattingKey(currentRun) === clonedRunFormattingKey(child)
+    ) {
+      for (const node of clonedRunContentChildren(child)) {
+        currentRun.appendChild(node);
+      }
+      consolidateAdjacentTextChildren(currentRun);
+      child.parentNode?.removeChild(child);
+    } else {
+      currentRun = child;
+      consolidateAdjacentTextChildren(currentRun);
+    }
+    child = next;
+  }
+}
+
+function canonicalizeHyperlinkRunsForKey(root: Element): void {
+  const hyperlinks = Array.from(root.getElementsByTagNameNS(OOXML.W_NS, W.hyperlink));
+  if (root.namespaceURI === OOXML.W_NS && root.localName === W.hyperlink) {
+    hyperlinks.unshift(root);
+  }
+  for (const hyperlink of hyperlinks) {
+    mergeAdjacentRunsForKey(hyperlink);
+  }
+}
+
+/**
+ * The atomizer can reconstruct untouched hyperlink text as one run with
+ * multiple `w:t` children, while open-time `mergeRuns` leaves the original
+ * as adjacent runs inside `w:hyperlink`. Canonicalize that comparison-only
+ * shape so restore can still import the pristine original block.
+ */
+function restoreKey(el: Element): string {
+  const clone = el.cloneNode(true) as Element;
+  canonicalizeHyperlinkRunsForKey(clone);
+  return serializer.serializeToString(clone);
+}
+
 /**
  * Reconcile the element children of one container: LCS-matched (untouched)
  * children of `cur` are replaced with the corresponding pristine `orig`
@@ -160,8 +288,8 @@ function reconcileChildren(
   if (origChildren.length !== normChildren.length) return 0;
   if (origChildren.length === 0 || curChildren.length === 0) return 0;
 
-  const normKeys = normChildren.map((el) => serializer.serializeToString(el));
-  const curKeys = curChildren.map((el) => serializer.serializeToString(el));
+  const normKeys = normChildren.map(restoreKey);
+  const curKeys = curChildren.map(restoreKey);
   const pairs = lcsPairs(normKeys, curKeys);
 
   let restored = 0;

--- a/packages/docx-mcp/src/tools/save.test.ts
+++ b/packages/docx-mcp/src/tools/save.test.ts
@@ -133,7 +133,11 @@ describe('save', () => {
       `<w:p w14:paraId="11111111"><w:r><w:t>Alpha target text</w:t></w:r></w:p>` +
       `<w:p w14:paraId="22222222" w:rsidR="00AA00AA">` +
       `<w:r w:rsidR="00AA00AA"><w:t>Untouched</w:t></w:r>` +
-      `<w:hyperlink r:id="rIdHyperlink"><w:r><w:t>link</w:t></w:r></w:hyperlink>` +
+      `<w:hyperlink r:id="rIdHyperlink">` +
+      `<w:r w:rsidR="00AA0001"><w:t>commonpaper.com/standards/mutual-</w:t></w:r>` +
+      `<w:r w:rsidR="00AA0002"><w:t>nda</w:t></w:r>` +
+      `<w:r w:rsidR="00AA0003"><w:t>/1.0</w:t></w:r>` +
+      `</w:hyperlink>` +
       `<w:proofErr w:type="spellStart"/>` +
       `<w:r w:rsidR="00BB00BB"><w:t xml:space="preserve"> paragraph</w:t></w:r>` +
       `<w:proofErr w:type="spellEnd"/>` +


### PR DESCRIPTION
## What changed

- Canonicalize plain-text run grouping inside `w:hyperlink` for minimal-save restore comparison keys.
- Keep the restored output conservative: matching still imports the pristine original block rather than a canonicalized clone.
- Add a core regression for the issue #444 tracked-save shape and strengthen the MCP tracked-save fixture to use a multi-run hyperlink.

## Why

Tracked-save restore compares the current tracked artifact with a normalized original. Untouched hyperlink-bearing paragraphs could fail that comparison because atomizer inplace reconstruction emits one hyperlink run with multiple `w:t` children, while the normalized original keeps adjacent runs inside `w:hyperlink`. The paragraph was untouched, but the false mismatch meant proofErr and run-boundary fidelity stayed lost.

Fixes: #444

## Validation

- `node /Users/stevenobiajulu/Projects/safe-docx/node_modules/vitest/vitest.mjs run packages/docx-core/src/primitives/minimal_save.test.ts`
- `PATH=/Users/stevenobiajulu/Projects/safe-docx/node_modules/.bin:$PATH npm run lint -w @usejunior/docx-core`
- `PATH=/Users/stevenobiajulu/Projects/safe-docx/node_modules/.bin:$PATH npm run lint -w @usejunior/docx-mcp`
- `git diff --check`