### PR TITLE
test(docx-core): lock the author->compare round-trip guarantee (#483)

### DIFF
--- a/openspec/changes/add-generation-compare-roundtrip/proposal.md
+++ b/openspec/changes/add-generation-compare-roundtrip/proposal.md
@@ -1,0 +1,29 @@
+# Change: Lock the author→compare round-trip guarantee with tests
+
+## Why
+
+`docx-core` both authors documents (`generateDocx`) and compares/redlines them
+(`compareDocuments`). The strategic value of owning both halves is that an authored
+document and a comparable document share one AST/OOXML model, so a freshly generated
+contract should be a first-class citizen of the redline workflow. Today that synergy is
+**assumed but never asserted**: the generation suite proves determinism and clone
+stability, but nothing proves `generateDocx` output flows cleanly through
+`compareDocuments` + accept/reject. This change locks that guarantee with real (no-mock)
+tests and documents it in the generation capability spec (issue #483).
+
+## What Changes
+
+- Add a new requirement to `docx-generation`: **Author-to-compare round-trip guarantee**,
+  with five scenarios (`SDX-GEN-100`..`SDX-GEN-104`).
+- Add a real round-trip test surface
+  (`packages/docx-core/src/generation/generation-compare-roundtrip.test.ts`) exercising
+  `generateDocx` → `compareDocuments` → accept/reject against the actual implementations.
+- Include a self-contained negative-control test that injects a malformed field into an
+  authored document and asserts the round-trip guard catches it — proving the assertions
+  have teeth.
+
+## Impact
+
+- Affected specs: `docx-generation` (one ADDED requirement).
+- Affected code: one new test file under `packages/docx-core/src/generation/`. No
+  production-source changes — this change only asserts and documents existing behavior.

--- a/openspec/changes/add-generation-compare-roundtrip/specs/docx-generation/spec.md
+++ b/openspec/changes/add-generation-compare-roundtrip/specs/docx-generation/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Author-to-compare round-trip guarantee
+
+A document produced by `generateDocx` SHALL be a first-class citizen of the
+`compareDocuments` redline workflow: authored output SHALL flow through comparison and
+accept/reject reconstruction with no impedance mismatch. Self-comparison of an authored
+document SHALL report no changes; a known authored edit SHALL produce exactly that
+redline; accepting all changes SHALL reproduce the revised authored document and rejecting
+all changes SHALL reproduce the original; and authored fields and tables SHALL survive the
+round-trip. The guarantee SHALL be enforced against the real `generateDocx` and
+`compareDocuments` (no mocks), and a deliberately malformed authored field SHALL be caught
+by the reconstruction safety checks rather than passing silently.
+
+#### Scenario: [SDX-GEN-100] self-compare of an authored document is empty
+- **GIVEN** a `DocumentSpec` compiled twice with `generateDocx` (deterministic, byte-identical output)
+- **WHEN** the two buffers are passed to `compareDocuments`
+- **THEN** the comparison SHALL report zero insertions, deletions, modifications, and format changes
+
+#### Scenario: [SDX-GEN-101] a known single-paragraph edit produces exactly that redline
+- **GIVEN** two authored documents differing by one paragraph's text (a word replacement)
+- **WHEN** they are compared
+- **THEN** the redline SHALL be confined to that one paragraph and report no spurious changes
+- **AND** accepting all changes SHALL yield the revised text and rejecting all changes SHALL yield the original text
+
+#### Scenario: [SDX-GEN-102] accept-all equals revised and reject-all equals original
+- **GIVEN** an authored original and a revised authored document compared with the atomizer engine
+- **WHEN** all tracked changes are accepted, and separately all are rejected, under both `rebuild` and `inplace` reconstruction modes
+- **THEN** the accepted text SHALL match the revised authored document and the rejected text SHALL match the original authored document
+
+#### Scenario: [SDX-GEN-103] authored fields and tables survive the compare round-trip
+- **GIVEN** an authored document containing a `Page X of Y` field footer, a cover-terms table, and a signature block
+- **WHEN** it is edited, compared, and round-tripped through accept/reject
+- **THEN** field structure SHALL remain intact and table-cell text SHALL round-trip (accepted matches revised, rejected matches original)
+
+#### Scenario: [SDX-GEN-104] a malformed authored field is caught by the round-trip guard
+- **GIVEN** an authored document whose field is deliberately malformed (a dropped `fldChar` end marker)
+- **WHEN** it is compared and reconstructed
+- **THEN** the reconstruction safety checks SHALL report a `fieldStructure` failure rather than passing silently

--- a/openspec/changes/add-generation-compare-roundtrip/tasks.md
+++ b/openspec/changes/add-generation-compare-roundtrip/tasks.md
@@ -1,0 +1,23 @@
+## 1. Spec
+
+- [ ] 1.1 Add the `Author-to-compare round-trip guarantee` requirement with scenarios
+      `SDX-GEN-100`..`SDX-GEN-104` to the `docx-generation` delta.
+
+## 2. Tests
+
+- [ ] 2.1 Add `packages/docx-core/src/generation/generation-compare-roundtrip.test.ts`
+      with `TEST_FEATURE = 'add-generation-compare-roundtrip'` and `.openspec` IDs matching
+      the delta scenarios.
+- [ ] 2.2 SDX-GEN-100: self-compare of an authored doc reports zero changes.
+- [ ] 2.3 SDX-GEN-101: a known single-paragraph replacement produces exactly that redline.
+- [ ] 2.4 SDX-GEN-102: accept-all == revised, reject-all == original (rebuild + inplace).
+- [ ] 2.5 SDX-GEN-103: a fields + tables spec (Page X of Y footer, coverTermsTable,
+      signatureBlock) survives the compare round-trip.
+- [ ] 2.6 SDX-GEN-104: negative control — a malformed authored field trips the
+      `fieldStructure` guard.
+
+## 3. Verify
+
+- [ ] 3.1 `openspec validate add-generation-compare-roundtrip --strict` passes.
+- [ ] 3.2 New test file passes; `npm run build`, `npm run test:run`, `npm run preflight:ci`
+      pass (incl. `check:spec-coverage-generation` for this feature).

--- a/packages/docx-core/src/generation/generation-compare-roundtrip.test.ts
+++ b/packages/docx-core/src/generation/generation-compare-roundtrip.test.ts
@@ -1,0 +1,376 @@
+/**
+ * Author->compare round-trip guarantee (issue #483).
+ *
+ * docx-core owns both halves of the contract lifecycle: it authors documents
+ * from scratch (`generateDocx`) and compares/redlines them (`compareDocuments`).
+ * The strategic value of owning both is that an authored document and a
+ * comparable document share one AST/OOXML model, so a freshly generated
+ * contract should be a first-class citizen of the redline workflow with no
+ * impedance mismatch. The generation skeleton suite proves determinism and
+ * clone-stability; this suite proves the synergy: authored output flows cleanly
+ * through compare + accept/reject, and a deliberately malformed authored field
+ * is caught by the reconstruction safety checks rather than passing silently.
+ *
+ * No mocks: every assertion runs against the real `generateDocx` and
+ * `compareDocuments`.
+ */
+
+import { describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { generateDocx } from './compile.js';
+import { coverTermsTable, signatureBlock } from './recipes.js';
+import { compareDocuments } from '../index.js';
+import type { CompareResult, ReconstructionMode } from '../compare-types.js';
+import { DocxArchive } from '../shared/docx/DocxArchive.js';
+import {
+  acceptAllChanges,
+  rejectAllChanges,
+  extractTextWithParagraphs,
+  compareTexts,
+} from '../baselines/atomizer/trackChangesAcceptorAst.js';
+import type { BlockSpec, DocumentSpec, HeaderFooterSpec } from './types.js';
+
+const TEST_FEATURE = 'add-generation-compare-roundtrip';
+const test = testAllure.epic('Document Generation').withLabels({ feature: TEST_FEATURE });
+
+const MODES: ReconstructionMode[] = ['rebuild', 'inplace'];
+
+// --- Spec builders ----------------------------------------------------------
+
+/** A two-paragraph contract body whose first paragraph names a date we can edit. */
+function datedSpec(month: string): DocumentSpec {
+  return {
+    meta: { title: 'Round-trip', author: 'safe-docx tests', createdIso: '2026-06-13T00:00:00Z' },
+    sections: [
+      {
+        blocks: [
+          { kind: 'paragraph', runs: [{ kind: 'text', text: `The Effective Date is ${month} 1, 2026.` }] },
+          { kind: 'paragraph', runs: [{ kind: 'text', text: 'This Agreement is governed by the laws of Delaware.' }] },
+        ],
+      },
+    ],
+  };
+}
+
+/** Same text in both, but one run's bold differs — a format-only edit. */
+function emphasisSpec(bold: boolean): DocumentSpec {
+  return {
+    meta: { title: 'Round-trip format', author: 'safe-docx tests', createdIso: '2026-06-13T00:00:00Z' },
+    sections: [
+      {
+        blocks: [
+          {
+            kind: 'paragraph',
+            runs: [
+              { kind: 'text', text: 'Status: ' },
+              { kind: 'text', text: 'Confidential', ...(bold ? { bold: true } : {}) },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function pageXofYFooter(): HeaderFooterSpec {
+  return {
+    blocks: [
+      {
+        kind: 'paragraph',
+        alignment: 'center',
+        runs: [
+          { kind: 'text', text: 'Page ' },
+          { kind: 'field', field: 'PAGE', cachedResult: '1' },
+          { kind: 'text', text: ' of ' },
+          { kind: 'field', field: 'NUMPAGES', cachedResult: '1' },
+        ],
+      },
+    ],
+  };
+}
+
+/**
+ * A feature-rich contract: a cover-terms table, a body "Page X of Y" line
+ * (so the field-structure safety path is exercised through compare — the check
+ * runs over document.xml, not headers/footers), a Page-X-of-Y footer, and a
+ * signature block. `effectiveDate` is the one value we edit between revisions.
+ */
+function fieldsAndTablesSpec(effectiveDate: string): DocumentSpec {
+  const blocks: BlockSpec[] = [
+    coverTermsTable({
+      title: 'Cover Terms',
+      terms: [
+        { label: 'Disclosing Party', value: 'Acme Manufacturing, Inc.' },
+        { label: 'Receiving Party', value: 'Northeast Logistics LLC' },
+        { label: 'Effective Date', value: effectiveDate },
+      ],
+    }),
+    {
+      kind: 'paragraph',
+      runs: [
+        { kind: 'text', text: 'Page ' },
+        { kind: 'field', field: 'PAGE', cachedResult: '1' },
+        { kind: 'text', text: ' of ' },
+        { kind: 'field', field: 'NUMPAGES', cachedResult: '1' },
+      ],
+    },
+    { kind: 'paragraph', runs: [{ kind: 'text', text: 'IN WITNESS WHEREOF, the parties execute this Agreement.' }] },
+    ...signatureBlock({
+      parties: [
+        { party: 'Acme Manufacturing, Inc.', name: 'Jane Doe', title: 'CEO' },
+        { party: 'Northeast Logistics LLC', name: 'John Smith', title: 'Managing Member', dateLabel: 'Dated:' },
+      ],
+    }),
+  ];
+  return {
+    meta: { title: 'Round-trip fields+tables', author: 'safe-docx tests', createdIso: '2026-06-13T00:00:00Z' },
+    sections: [{ footers: { default: pageXofYFooter() }, blocks }],
+  };
+}
+
+/** A single body PAGE field — the subject of the negative-control mutation. */
+function bodyFieldSpec(): DocumentSpec {
+  return {
+    meta: { title: 'Round-trip field guard', author: 'safe-docx tests', createdIso: '2026-06-13T00:00:00Z' },
+    sections: [
+      {
+        blocks: [
+          {
+            kind: 'paragraph',
+            runs: [
+              { kind: 'text', text: 'Page ' },
+              { kind: 'field', field: 'PAGE', cachedResult: '1' },
+            ],
+          },
+          { kind: 'paragraph', runs: [{ kind: 'text', text: 'Body follows the field.' }] },
+        ],
+      },
+    ],
+  };
+}
+
+// --- Round-trip harness -----------------------------------------------------
+
+interface RoundTripArtifacts {
+  result: CompareResult;
+  originalArchive: DocxArchive;
+  revisedArchive: DocxArchive;
+  resultArchive: DocxArchive;
+  acceptedArchive: DocxArchive;
+  rejectedArchive: DocxArchive;
+}
+
+/**
+ * Mirror of the file-local helper in
+ * integration/roundtrip-structural-invariants.test.ts, extended to also return
+ * the CompareResult so callers can assert stats and reconstruction diagnostics.
+ */
+async function buildRoundTripArtifacts(
+  originalBuffer: Buffer,
+  revisedBuffer: Buffer,
+  mode: ReconstructionMode,
+): Promise<RoundTripArtifacts> {
+  const result = await compareDocuments(originalBuffer, revisedBuffer, {
+    engine: 'atomizer',
+    reconstructionMode: mode,
+  });
+
+  const originalArchive = await DocxArchive.load(originalBuffer);
+  const revisedArchive = await DocxArchive.load(revisedBuffer);
+  const resultArchive = await DocxArchive.load(result.document);
+
+  const resultDocumentXml = await resultArchive.getDocumentXml();
+  const acceptedArchive = await resultArchive.clone();
+  acceptedArchive.setDocumentXml(acceptAllChanges(resultDocumentXml));
+  const rejectedArchive = await resultArchive.clone();
+  rejectedArchive.setDocumentXml(rejectAllChanges(resultDocumentXml));
+
+  return { result, originalArchive, revisedArchive, resultArchive, acceptedArchive, rejectedArchive };
+}
+
+async function readText(archive: DocxArchive): Promise<string> {
+  return extractTextWithParagraphs(await archive.getDocumentXml());
+}
+
+async function assertAcceptRejectParity(artifacts: RoundTripArtifacts, context: string): Promise<void> {
+  const [revisedText, originalText, acceptedText, rejectedText] = await Promise.all([
+    readText(artifacts.revisedArchive),
+    readText(artifacts.originalArchive),
+    readText(artifacts.acceptedArchive),
+    readText(artifacts.rejectedArchive),
+  ]);
+  expect(compareTexts(revisedText, acceptedText).normalizedIdentical, `${context}: accept-all should equal revised`).toBe(true);
+  expect(compareTexts(originalText, rejectedText).normalizedIdentical, `${context}: reject-all should equal original`).toBe(true);
+}
+
+// --- Scenarios --------------------------------------------------------------
+
+describe('Author->compare round-trip guarantee', () => {
+  test.openspec('[SDX-GEN-100] self-compare of an authored document is empty')(
+    'Scenario: self-compare of an authored document is empty',
+    async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
+      let original!: Buffer;
+      let copy!: Buffer;
+      await given('an authored document compiled twice (generation is deterministic)', async () => {
+        const spec = datedSpec('January');
+        original = await generateDocx(spec);
+        copy = await generateDocx(spec);
+        expect(copy.equals(original)).toBe(true);
+      });
+
+      let result!: CompareResult;
+      await when('the two authored buffers are compared', async () => {
+        result = await compareDocuments(original, copy, { engine: 'atomizer' });
+        await attachPrettyJson('self-compare-stats', result.stats);
+      });
+
+      await then('the comparison reports no changes', async () => {
+        expect(result.stats.insertions).toBe(0);
+        expect(result.stats.deletions).toBe(0);
+        expect(result.stats.modifications).toBe(0);
+        expect(result.stats.formatChanges).toBe(0);
+        expect(result.stats.insertedAtoms).toBe(0);
+        expect(result.stats.deletedAtoms).toBe(0);
+      });
+    },
+  );
+
+  test.openspec('[SDX-GEN-101] a known single-paragraph edit produces exactly that redline')(
+    'Scenario: a known single-paragraph edit produces exactly that redline',
+    async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
+      let original!: Buffer;
+      let revised!: Buffer;
+      await given('two authored documents differing by one paragraph word (a replacement)', async () => {
+        original = await generateDocx(datedSpec('January'));
+        revised = await generateDocx(datedSpec('February'));
+      });
+
+      let result!: CompareResult;
+      let artifacts!: RoundTripArtifacts;
+      await when('they are compared and round-tripped', async () => {
+        artifacts = await buildRoundTripArtifacts(original, revised, 'rebuild');
+        result = artifacts.result;
+        await attachPrettyJson('known-edit-stats', result.stats);
+      });
+
+      await then('the redline is confined to one paragraph with no spurious changes', async () => {
+        // A word replacement trips both insert and delete on the same paragraph.
+        expect(result.stats.modifiedParagraphs).toBe(1);
+        expect(result.stats.insertions).toBe(1);
+        expect(result.stats.deletions).toBe(1);
+      });
+
+      await then('accept-all yields the revised text and reject-all yields the original text', async () => {
+        await assertAcceptRejectParity(artifacts, 'SDX-GEN-101');
+      });
+
+      await then('a format-only edit reports a format change and no text atoms', async () => {
+        const formatOriginal = await generateDocx(emphasisSpec(false));
+        const formatRevised = await generateDocx(emphasisSpec(true));
+        const formatResult = await compareDocuments(formatOriginal, formatRevised, { engine: 'atomizer' });
+        await attachPrettyJson('format-edit-stats', formatResult.stats);
+        expect(formatResult.stats.formatChanges).toBeGreaterThanOrEqual(1);
+        expect(formatResult.stats.insertedAtoms).toBe(0);
+        expect(formatResult.stats.deletedAtoms).toBe(0);
+      });
+    },
+  );
+
+  for (const mode of MODES) {
+    test.openspec('[SDX-GEN-102] accept-all equals revised and reject-all equals original')(
+      `Scenario: accept-all equals revised and reject-all equals original (${mode})`,
+      async ({ given, when, then }: AllureBddContext) => {
+        let original!: Buffer;
+        let revised!: Buffer;
+        await given(`an authored original and revised document compared in '${mode}' mode`, async () => {
+          original = await generateDocx(datedSpec('January'));
+          revised = await generateDocx(datedSpec('February'));
+        });
+
+        let artifacts!: RoundTripArtifacts;
+        await when('all changes are accepted, and separately all are rejected', async () => {
+          artifacts = await buildRoundTripArtifacts(original, revised, mode);
+        });
+
+        await then('accepted text matches revised and rejected text matches original', async () => {
+          await assertAcceptRejectParity(artifacts, `SDX-GEN-102/${mode}`);
+        });
+      },
+    );
+  }
+
+  for (const mode of MODES) {
+    test.openspec('[SDX-GEN-103] authored fields and tables survive the compare round-trip')(
+      `Scenario: authored fields and tables survive the compare round-trip (${mode})`,
+      async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
+        let original!: Buffer;
+        let revised!: Buffer;
+        await given('an authored document with a Page X of Y field, a cover-terms table, and a signature block', async () => {
+          original = await generateDocx(fieldsAndTablesSpec('June 11, 2026'));
+          revised = await generateDocx(fieldsAndTablesSpec('July 11, 2026'));
+        });
+
+        let artifacts!: RoundTripArtifacts;
+        await when(`it is edited, compared, and round-tripped in '${mode}' mode`, async () => {
+          artifacts = await buildRoundTripArtifacts(original, revised, mode);
+          await attachPrettyJson('fields-tables-diagnostics', {
+            failedChecks: artifacts.result.rebuildSafetyDiagnostics?.failedChecks ?? null,
+            fallbackReason: artifacts.result.fallbackReason ?? null,
+          });
+        });
+
+        await then('field structure stays intact and table-cell text round-trips', async () => {
+          await assertAcceptRejectParity(artifacts, `SDX-GEN-103/${mode}`);
+          // A clean round-trip surfaces no safety failures (field structure included).
+          expect(artifacts.result.rebuildSafetyDiagnostics?.failedChecks ?? []).not.toContain('fieldStructure');
+        });
+      },
+    );
+  }
+
+  for (const mode of MODES) {
+    test.openspec('[SDX-GEN-104] a malformed authored field is caught by the round-trip guard')(
+      `Scenario: a malformed authored field is caught by the round-trip guard (${mode})`,
+      async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
+        let original!: Buffer;
+        let malformed!: Buffer;
+        await given('an authored document whose body field has a dropped fldChar end marker', async () => {
+          original = await generateDocx(bodyFieldSpec());
+          const archive = await DocxArchive.load(original);
+          const documentXml = await archive.getDocumentXml();
+          const broken = documentXml.replace(/<w:fldChar w:fldCharType="end"\s*\/>/, '');
+          expect(broken, 'mutation should remove a fldChar end marker').not.toBe(documentXml);
+          archive.setDocumentXml(broken);
+          malformed = await archive.save();
+        });
+
+        let result!: CompareResult;
+        await when(`the original is compared against the malformed revision in '${mode}' mode`, async () => {
+          result = await compareDocuments(original, malformed, { engine: 'atomizer', reconstructionMode: mode });
+          await attachPrettyJson('guard-diagnostics', {
+            used: result.reconstructionModeUsed,
+            fallbackReason: result.fallbackReason ?? null,
+            fallbackAttempts: result.fallbackDiagnostics?.attempts?.map((a) => a.failedChecks) ?? null,
+            rebuild: result.rebuildSafetyDiagnostics?.failedChecks ?? null,
+          });
+        });
+
+        await then('the reconstruction guard reports a fieldStructure failure rather than passing silently', async () => {
+          expect(result.rebuildSafetyDiagnostics?.failedChecks ?? []).toContain('fieldStructure');
+          if (mode === 'inplace') {
+            expect(result.fallbackReason).toBe('round_trip_safety_check_failed');
+            const attempts = result.fallbackDiagnostics?.attempts ?? [];
+            expect(attempts.length).toBeGreaterThan(0);
+            expect(attempts.every((a) => a.failedChecks.includes('fieldStructure'))).toBe(true);
+          }
+        });
+
+        await then('a well-formed revision in the same mode surfaces no safety failures (control)', async () => {
+          const goodRevised = await generateDocx(bodyFieldSpec());
+          const goodResult = await compareDocuments(original, goodRevised, { engine: 'atomizer', reconstructionMode: mode });
+          expect(goodResult.rebuildSafetyDiagnostics).toBeUndefined();
+        });
+      },
+    );
+  }
+});


### PR DESCRIPTION
## What

Locks the **author→compare round-trip guarantee** with tests + an OpenSpec requirement (issue #483).

`docx-core` both authors documents (`generateDocx`) and compares/redlines them (`compareDocuments`). The strategic value of owning both halves is that an authored document and a comparable document share one AST/OOXML model — but that synergy was *assumed and never asserted*. This PR proves it.

## Changes

- **New requirement** `Author-to-compare round-trip guarantee` on the `docx-generation` capability (OpenSpec change `add-generation-compare-roundtrip`), scenarios `SDX-GEN-100`..`SDX-GEN-104`.
- **New test** `packages/docx-core/src/generation/generation-compare-roundtrip.test.ts` — real `generateDocx` + `compareDocuments`, no mocks:
  - `SDX-GEN-100` — self-compare of an authored doc reports zero changes.
  - `SDX-GEN-101` — a known single-paragraph **replacement** produces exactly that redline (plus a format-only sub-case); accept-all == revised, reject-all == original.
  - `SDX-GEN-102` — accept-all == revised and reject-all == original, parametrized over **both** `rebuild` and `inplace`.
  - `SDX-GEN-103` — a `Page X of Y` field, `coverTermsTable`, and `signatureBlock` survive the compare round-trip (field-structure + table-cell paths).
  - `SDX-GEN-104` — **negative control**: a deliberately malformed authored field (dropped `fldChar` end) trips the `fieldStructure` reconstruction guard rather than passing silently, in both modes.

No production-source changes — this PR only asserts and documents existing behavior.

## Verification

- New suite: 8 tests pass.
- Full `docx-core` suite: 1514 passed, 2 expected-fail, 11 skipped.
- `openspec validate add-generation-compare-roundtrip --strict` ✓
- `npm run build` ✓; `preflight:ci` gates ✓ (lint, spec-coverage incl. `check:spec-coverage-generation`, allure-labels/filenames/quality, bdd-coverage, conformance-citations/doc, cycles). `check:site` was not run locally (the `site/` workspace deps aren't installed in the worktree); it is unaffected by this change and runs in CI.

### Notes on test design (peer-reviewed pre-implementation by Codex + agy)
- The "known edit" uses a **word replacement** because `modifiedParagraphs` only counts paragraphs with *both* an insert and a delete; a pure addition would report `modifiedParagraphs: 0`.
- The format-only sub-case asserts observed `formatChanges`/atom counts directly; it does **not** rely on `ignoreFormatting` (which `compareDocuments` does not forward to the atomizer).
- Field-structure is checked on the document body, so `SDX-GEN-103`/`104` place a field in the body (the footer `Page X of Y` is also present).
- The negative-control diagnostics path was confirmed empirically: `compareDocuments` does not throw; it surfaces `rebuildSafetyDiagnostics.failedChecks` containing `fieldStructure` in `rebuild`, and `inplace` falls back with `fallbackReason: 'round_trip_safety_check_failed'`.

Fixes #483