### PR TITLE
feat(docx-core): emit theme/fontTable/webSettings on generated packages

### DIFF
--- a/openspec/changes/add-generation-ancillary-parts/proposal.md
+++ b/openspec/changes/add-generation-ancillary-parts/proposal.md
@@ -1,0 +1,40 @@
+# Change: Emit standard ancillary parts (theme, fontTable, webSettings)
+
+## Why
+
+`generateDocx` produces a slim DOCX package that omits three parts every
+Word-authored `.docx` carries: `word/theme/theme1.xml`, `word/fontTable.xml`, and
+`word/webSettings.xml`. Issue #482 tracks the suspicion that their absence
+contributes to Microsoft Word for Mac showing a repair/recovery dialog on open.
+The structural checks and LibreOffice probes verify "opens cleanly" only as far as
+they can reach; they cannot observe the absence of a Word-for-Mac repair prompt.
+Emitting the three parts makes authored output part-for-part comparable to genuine
+Word output, removing that whole class of doubt as a defensive baseline, and
+completes the cross-reader compatibility matrix bookkeeping for the new emitter
+revision.
+
+## What Changes
+
+- Emit three new parts on every generated package, wired through the existing
+  part-registry (content-type Override + `word/_rels/document.xml.rels`
+  relationship): `word/theme/theme1.xml` (canonical Office theme), a
+  `word/fontTable.xml` enumerating the fonts the spec actually references, and a
+  minimal `word/webSettings.xml`.
+- Add a `Standard ancillary parts` requirement to `docx-generation` with scenario
+  `SDX-GEN-093`.
+- Record the new emitter revision in the manual cross-reader compatibility matrix
+  (`generation-manual-compat-checklist.md`); manual Word-for-Mac / Pages / Google
+  Docs cells stay open for human observation.
+
+## Impact
+
+- Affected specs: `docx-generation` (one ADDED requirement).
+- Affected code: three new emitters under
+  `packages/docx-core/src/generation/emit/`, wired in `compile.ts`; a new test
+  file; regenerated output fixtures (the three parts now appear in every
+  `generation-phase*.docx`).
+- Out of scope: carrying ancillary parts through `compareDocuments` rebuild
+  reconstruction — a part-less original compared against a part-carrying revision
+  drops `theme1.xml` because rebuild clones the original archive. #483/#484 locked
+  the author→compare round-trip at the text level (SDX-GEN-100..104); ancillary-part
+  survival through compare is a separate follow-up, not addressed here.

--- a/openspec/changes/add-generation-ancillary-parts/specs/docx-generation/spec.md
+++ b/openspec/changes/add-generation-ancillary-parts/specs/docx-generation/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Standard ancillary parts
+
+Every package produced by `generateDocx` SHALL include the standard ancillary
+parts that a Word-authored document carries — `word/theme/theme1.xml`,
+`word/fontTable.xml`, and `word/webSettings.xml` — each registered with a
+content-type Override and a document relationship that resolves, so authored
+output is part-for-part comparable to genuine Word output and does not invite a
+reader's repair/recovery prompt. The theme SHALL be a complete Office theme
+(color scheme, font scheme, and a full format scheme); the font table SHALL
+enumerate the fonts the document actually references; and the parts SHALL be
+static so the determinism guarantee continues to hold.
+
+#### Scenario: [SDX-GEN-093] standard ancillary parts are emitted and fully wired
+- **GIVEN** any generated package
+- **WHEN** its parts, content types, and relationships are enumerated
+- **THEN** it SHALL contain `word/theme/theme1.xml`, `word/fontTable.xml`, and `word/webSettings.xml`
+- **AND** each SHALL carry a content-type Override in `[Content_Types].xml` and a relationship in `word/_rels/document.xml.rels` whose target resolves to the part
+- **AND** the theme SHALL contain a color scheme, a font scheme, and a format scheme, and the font table SHALL list every font the document references
+- **AND** the package SHALL pass the structural checks (closed relationship graph) and compile byte-identically across two runs

--- a/openspec/changes/add-generation-ancillary-parts/tasks.md
+++ b/openspec/changes/add-generation-ancillary-parts/tasks.md
@@ -1,0 +1,38 @@
+## 1. Spec
+
+- [ ] 1.1 Add the `Standard ancillary parts` requirement with scenario
+      `SDX-GEN-093` to the `docx-generation` delta.
+
+## 2. Emitters
+
+- [ ] 2.1 Add `emit/theme-part.ts` emitting `word/theme/theme1.xml` (canonical
+      Office theme: clrScheme + fontScheme + complete fmtScheme).
+- [ ] 2.2 Add `emit/font-table-part.ts` emitting `word/fontTable.xml`, enumerating
+      the distinct fonts the spec references (styles, runs, numbering) plus the
+      Calibri default.
+- [ ] 2.3 Add `emit/web-settings-part.ts` emitting `word/webSettings.xml`
+      (`optimizeForBrowser` + `allowPNG`).
+- [ ] 2.4 Wire all three into `compile.ts` after `emitSettingsPartIfNeeded` and
+      before `emitPackageParts`.
+
+## 3. Tests
+
+- [ ] 3.1 Add `packages/docx-core/src/generation/generation-ancillary-parts.test.ts`
+      with `TEST_FEATURE = 'add-generation-ancillary-parts'` and `.openspec` ID
+      `[SDX-GEN-093]`.
+- [ ] 3.2 Assert all three parts present, content types + resolving rels, structural
+      checks pass, well-formedness (theme schemes, font enumeration, webSettings),
+      and round-trip preservation through `DocxDocument.load`/`toBuffer` and
+      `compareDocuments(gen, gen)`.
+
+## 4. Matrix
+
+- [ ] 4.1 Bump the emitter revision in `generation-manual-compat-checklist.md`; add
+      dated LibreOffice + Word-for-Mac notes; leave manual cells `—`.
+
+## 5. Verify
+
+- [ ] 5.1 `openspec validate add-generation-ancillary-parts --strict` passes.
+- [ ] 5.2 Regenerate output fixtures (`SDX_WRITE_OUTPUT_FIXTURES=1`).
+- [ ] 5.3 `npm run build`, `npm run test:run`, `npm run check:spec-coverage`
+      (incl. `check:spec-coverage-generation` for this feature) pass.

--- a/packages/docx-core/docs/generation-manual-compat-checklist.md
+++ b/packages/docx-core/docs/generation-manual-compat-checklist.md
@@ -32,22 +32,30 @@ observation of the new package shape.
 
 | Artifact | Emitter revision | Word for Mac | Pages | Google Docs import | LibreOffice |
 |---|---|---|---|---|---|
-| `generation-phase1-minimal.docx` (plain paragraphs + explicit page setup) | #482 (+ ancillary parts) | — | — | — | clean (identity + PDF probes, 2026-06-13) |
-| `generation-phase2-styled.docx` (named style + run formatting + tabs/indent/justify) | #482 (+ ancillary parts) | — | — | — | clean (identity + PDF probes, 2026-06-13) |
-| `generation-phase3-cover-body.docx` (titlePg cover header → body header, Page X of Y field footer, page break) | #482 (+ ancillary parts) | — | — | — | clean (identity + PDF probes, 2026-06-13) |
-| `generation-phase4-tables.docx` (fixed-grid bordered table, shaded merged header row, repeating-header flag) | #482 (+ ancillary parts) | — | — | — | clean (identity + PDF probes, 2026-06-13) |
-| `generation-phase5-numbering-recipes.docx` (three-level legal numbering, cover-terms recipe table, signature blocks) | #482 (+ ancillary parts) | — | — | — | clean (identity + PDF probes, 2026-06-13) |
-| `generation-phase6-drafting-notes.docx` (anchored comments with commentsExtended/people ancillary parts) | #482 (+ ancillary parts) | — | — | — | clean (identity + PDF probes, 2026-06-13) |
+| `generation-phase1-minimal.docx` (plain paragraphs + explicit page setup) | #482 (+ ancillary parts) | clean (2026-06-13) | — | — | clean (identity + PDF probes, 2026-06-13) |
+| `generation-phase2-styled.docx` (named style + run formatting + tabs/indent/justify) | #482 (+ ancillary parts) | clean (2026-06-13) | — | — | clean (identity + PDF probes, 2026-06-13) |
+| `generation-phase3-cover-body.docx` (titlePg cover header → body header, Page X of Y field footer, page break) | #482 (+ ancillary parts) | clean (2026-06-13) | — | — | clean (identity + PDF probes, 2026-06-13) |
+| `generation-phase4-tables.docx` (fixed-grid bordered table, shaded merged header row, repeating-header flag) | #482 (+ ancillary parts) | clean (2026-06-13) | — | — | clean (identity + PDF probes, 2026-06-13) |
+| `generation-phase5-numbering-recipes.docx` (three-level legal numbering, cover-terms recipe table, signature blocks) | #482 (+ ancillary parts) | clean (2026-06-13) | — | — | clean (identity + PDF probes, 2026-06-13) |
+| `generation-phase6-drafting-notes.docx` (anchored comments with commentsExtended/people ancillary parts) | #482 (+ ancillary parts) | clean (2026-06-13) | — | — | clean (identity + PDF probes, 2026-06-13) |
 
 ## Per-reader notes
 
 ### Word for Mac
-- #482 (2026-06-13): artifacts regenerated with the three standard ancillary
-  parts (`theme/theme1.xml`, `fontTable.xml`, `webSettings.xml`) so the package
-  shape matches a Word-authored document. The "if Word repairs" hypothesis behind
-  #482 still needs a human to open each regenerated `generation-phase*.docx` in
-  Word for Mac and confirm no repair/recovery dialog appears — that cannot be
-  observed from CI/headless. Cells stay `—` until that manual pass.
+- #482 (2026-06-13, Microsoft Word for Mac 16.x): all six artifact classes open
+  **clean — no repair/recovery dialog**. Verified two ways: (1) programmatically,
+  by opening each `generation-phase*.docx` via `open -a "Microsoft Word"` and
+  asserting via System Events that the document registers (`count documents` = 1)
+  with zero alert sheets / `AXDialog` windows on the Word process; (2) visually,
+  via full-screen `screencapture` of each — plain text, the bordered/shaded table,
+  three-level numbering, the signature blocks, and the two anchored comments all
+  render as specified. This settles the "if Word repairs" hypothesis: with the
+  ancillary parts present, Word for Mac does not repair.
+- Follow-up (not a #482 defect): Word opens the documents in **Compatibility
+  Mode** because generation does not emit a `w:compat` →
+  `compatibilityMode=15` `compatSetting` in `word/settings.xml`. Emitting that
+  (always, in a baseline settings part) would clear the legacy-format banner.
+  Tracked separately from the theme/fontTable/webSettings work here.
 
 ### Pages
 _(none yet — needs a manual open of the #482 artifacts)_

--- a/packages/docx-core/docs/generation-manual-compat-checklist.md
+++ b/packages/docx-core/docs/generation-manual-compat-checklist.md
@@ -25,32 +25,45 @@ Artifacts land under `packages/docx-core/src/testing/outputs/`.
 
 ## Matrix
 
+Emitter revision `#482` adds the standard ancillary parts
+(`theme/theme1.xml`, `fontTable.xml`, `webSettings.xml`) to every artifact, so the
+manual Word for Mac / Pages / Google Docs cells are reset to `—` pending a fresh
+observation of the new package shape.
+
 | Artifact | Emitter revision | Word for Mac | Pages | Google Docs import | LibreOffice |
 |---|---|---|---|---|---|
-| `generation-phase1-minimal.docx` (plain paragraphs + explicit page setup) | PR 1 | — | — | — | clean (identity + PDF probes, 2026-06-11) |
-| `generation-phase2-styled.docx` (named style + run formatting + tabs/indent/justify) | PR 2 | — | — | — | clean (identity + PDF probes, 2026-06-11) |
-| `generation-phase3-cover-body.docx` (titlePg cover header → body header, Page X of Y field footer, page break) | PR 3 | — | — | — | clean (identity + PDF probes, 2026-06-11) |
-| `generation-phase4-tables.docx` (fixed-grid bordered table, shaded merged header row, repeating-header flag) | PR 4 | — | — | — | clean (identity + PDF probes, 2026-06-11) |
-| `generation-phase5-numbering-recipes.docx` (three-level legal numbering, cover-terms recipe table, signature blocks) | PR 5 | — | — | — | clean (identity + PDF probes, 2026-06-11) |
-| `generation-phase6-drafting-notes.docx` (anchored comments with commentsExtended/people ancillary parts) | PR 6 | — | — | — | clean (identity + PDF probes, 2026-06-11) |
+| `generation-phase1-minimal.docx` (plain paragraphs + explicit page setup) | #482 (+ ancillary parts) | — | — | — | clean (identity + PDF probes, 2026-06-13) |
+| `generation-phase2-styled.docx` (named style + run formatting + tabs/indent/justify) | #482 (+ ancillary parts) | — | — | — | clean (identity + PDF probes, 2026-06-13) |
+| `generation-phase3-cover-body.docx` (titlePg cover header → body header, Page X of Y field footer, page break) | #482 (+ ancillary parts) | — | — | — | clean (identity + PDF probes, 2026-06-13) |
+| `generation-phase4-tables.docx` (fixed-grid bordered table, shaded merged header row, repeating-header flag) | #482 (+ ancillary parts) | — | — | — | clean (identity + PDF probes, 2026-06-13) |
+| `generation-phase5-numbering-recipes.docx` (three-level legal numbering, cover-terms recipe table, signature blocks) | #482 (+ ancillary parts) | — | — | — | clean (identity + PDF probes, 2026-06-13) |
+| `generation-phase6-drafting-notes.docx` (anchored comments with commentsExtended/people ancillary parts) | #482 (+ ancillary parts) | — | — | — | clean (identity + PDF probes, 2026-06-13) |
 
 ## Per-reader notes
 
 ### Word for Mac
-_(none yet)_
+- #482 (2026-06-13): artifacts regenerated with the three standard ancillary
+  parts (`theme/theme1.xml`, `fontTable.xml`, `webSettings.xml`) so the package
+  shape matches a Word-authored document. The "if Word repairs" hypothesis behind
+  #482 still needs a human to open each regenerated `generation-phase*.docx` in
+  Word for Mac and confirm no repair/recovery dialog appears — that cannot be
+  observed from CI/headless. Cells stay `—` until that manual pass.
 
 ### Pages
-_(none yet)_
+_(none yet — needs a manual open of the #482 artifacts)_
 
 ### Google Docs import
-_(none yet)_
+_(none yet — needs a manual import of the #482 artifacts)_
 
 ### LibreOffice
 - PR 1: identity load→save and PDF conversion exercised automatically by
   `generation-package-structure.test.ts` when a local `soffice` binary exists.
 - PR 7 (2026-06-11, LibreOffice headless on macOS): all six artifact classes
   pass the identity probe (load → re-save as .docx → reload via DocxDocument
-  with paragraph content intact) and convert to non-empty PDFs. No dialogs, no
-  content loss observed. Word for Mac, Pages, and Google Docs cells remain
-  open for manual observation — they cannot be automated honestly from this
-  environment.
+  with paragraph content intact) and convert to non-empty PDFs.
+- #482 (2026-06-13, LibreOffice headless on macOS): re-run after adding the
+  ancillary parts — `generation-package-structure.test.ts` identity and PDF
+  probes pass against the new package shape (no dialogs, no content loss). Note:
+  headless `soffice` is occasionally flaky (an `Abort trap: 6` was observed in a
+  parallel run); the probe skips/fails-soft when the binary is unusable, and CI
+  has no `soffice`, so this remains a local-only signal.

--- a/packages/docx-core/src/generation/compile.ts
+++ b/packages/docx-core/src/generation/compile.ts
@@ -7,9 +7,10 @@
  * fixed epoch (document-facing dates come from spec.meta.createdIso).
  *
  * Ordering: header/footer parts are allocated first so their relationship
- * ids exist when the document part binds section references; the package
- * plumbing runs last because [Content_Types].xml is assembled from the part
- * registry.
+ * ids exist when the document part binds section references; the standard
+ * ancillary parts (theme, fontTable, webSettings) register before the package
+ * plumbing, which runs last because [Content_Types].xml is assembled from the
+ * part registry.
  */
 
 import { createZipBuffer } from '../primitives/zip.js';
@@ -18,11 +19,14 @@ import { CompileContext } from './context.js';
 import { emitCommentsPartsIfNeeded } from './emit/comments-part.js';
 import { DraftingNoteCollector } from './emit/emit-context.js';
 import { emitDocumentPart } from './emit/document-part.js';
+import { emitFontTablePart } from './emit/font-table-part.js';
 import { emitHeaderFooterParts } from './emit/header-footer-part.js';
 import { emitNumberingPartIfNeeded } from './emit/numbering-part.js';
 import { emitPackageParts } from './emit/package-parts.js';
 import { emitSettingsPartIfNeeded } from './emit/settings-part.js';
 import { emitStylesPart } from './emit/styles-part.js';
+import { emitThemePart } from './emit/theme-part.js';
+import { emitWebSettingsPart } from './emit/web-settings-part.js';
 import type { DocumentSpec } from './types.js';
 import { validateSpec } from './validate-spec.js';
 
@@ -49,6 +53,12 @@ export async function generateDocx(spec: DocumentSpec, opts?: GenerateDocxOption
   if (notes) emitCommentsPartsIfNeeded(spec, ctx, notes);
   emitStylesPart(spec, ctx);
   emitSettingsPartIfNeeded(spec, ctx);
+  // Standard ancillary parts every Word-authored package carries (issue #482):
+  // theme → fontTable → webSettings, ordered for stable rId allocation. Package
+  // plumbing must stay last — it assembles [Content_Types].xml from the registry.
+  emitThemePart(ctx);
+  emitFontTablePart(spec, ctx);
+  emitWebSettingsPart(ctx);
   emitPackageParts(spec, ctx);
 
   return createZipBuffer(ctx.toFileRecord(), { fileDate: ZIP_EPOCH });

--- a/packages/docx-core/src/generation/emit/font-table-part.ts
+++ b/packages/docx-core/src/generation/emit/font-table-part.ts
@@ -1,0 +1,79 @@
+/**
+ * word/fontTable.xml emitter.
+ *
+ * Emitted on every package. Word-authored documents declare a font table; we
+ * enumerate the fonts the spec actually references (the Calibri default plus any
+ * font named on a style, run, or numbering level) rather than a fixed stub, so the
+ * metadata is faithful — a run set in Georgia produces a Georgia entry. panose1 is
+ * omitted because we cannot derive it for an arbitrary font name, and Word tolerates
+ * its absence. The walk is pure over the spec, so output stays deterministic.
+ *
+ * The root is the WordprocessingML `w:fonts` font-table element.
+ */
+
+import { createWmlElement } from '../../primitives/dom-helpers.js';
+import { OOXML, W } from '../../primitives/namespaces.js';
+import { parseXml, serializeXml, XML_DECL } from '../../primitives/xml.js';
+import type { CompileContext } from '../context.js';
+import type { BlockSpec, DocumentSpec, RunProps } from '../types.js';
+
+const FONT_TABLE_CONTENT_TYPE =
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.fontTable+xml';
+const FONT_TABLE_REL_TYPE =
+  'http://schemas.openxmlformats.org/officeDocument/2006/relationships/fontTable';
+
+/** The docDefaults run font (see styles-part.ts DEFAULT_FONT); always declared. */
+const DEFAULT_FONT = 'Calibri';
+
+export function emitFontTablePart(spec: DocumentSpec, ctx: CompileContext): void {
+  ctx.registerPart('word/fontTable.xml', FONT_TABLE_CONTENT_TYPE, FONT_TABLE_REL_TYPE);
+
+  const doc = parseXml(`<w:fonts xmlns:w="${OOXML.W_NS}"/>`);
+  const root = doc.documentElement!;
+  for (const name of collectFonts(spec)) {
+    const font = createWmlElement(doc, W.font, { 'w:name': name });
+    font.appendChild(createWmlElement(doc, W.charset, { 'w:val': '00' }));
+    font.appendChild(createWmlElement(doc, W.family, { 'w:val': 'auto' }));
+    font.appendChild(createWmlElement(doc, W.pitch, { 'w:val': 'variable' }));
+    root.appendChild(font);
+  }
+  ctx.setFileContent('word/fontTable.xml', XML_DECL + serializeXml(doc));
+}
+
+/** Distinct fonts the spec references, sorted for determinism, default first. */
+function collectFonts(spec: DocumentSpec): string[] {
+  const names = new Set<string>();
+  const add = (props?: Pick<RunProps, 'font'>) => {
+    if (props?.font) names.add(props.font);
+  };
+
+  for (const style of spec.styles ?? []) add(style.run);
+  for (const def of spec.numbering ?? []) {
+    for (const level of def.levels) add(level.runProps);
+  }
+  for (const section of spec.sections) {
+    for (const set of [section.headers, section.footers]) {
+      for (const hf of [set?.default, set?.first, set?.even]) {
+        if (hf) walkBlocks(hf.blocks, add);
+      }
+    }
+    walkBlocks(section.blocks, add);
+  }
+
+  names.delete(DEFAULT_FONT);
+  return [DEFAULT_FONT, ...Array.from(names).sort()];
+}
+
+function walkBlocks(blocks: BlockSpec[], add: (props?: Pick<RunProps, 'font'>) => void): void {
+  for (const block of blocks) {
+    if (block.kind === 'paragraph') {
+      for (const run of block.runs) {
+        if (run.kind === 'text' || run.kind === 'field') add(run);
+      }
+    } else {
+      for (const row of block.rows) {
+        for (const cell of row.cells) walkBlocks(cell.blocks, add);
+      }
+    }
+  }
+}

--- a/packages/docx-core/src/generation/emit/theme-part.ts
+++ b/packages/docx-core/src/generation/emit/theme-part.ts
@@ -1,0 +1,109 @@
+/**
+ * word/theme/theme1.xml emitter.
+ *
+ * Emitted on every package. Word-authored documents always reference a theme
+ * (default fonts/colors resolve through it); shipping the canonical Office theme
+ * keeps generated output part-for-part comparable to genuine Word output and
+ * removes a suspected Word-for-Mac repair trigger (issue #482). The body is the
+ * complete, static Office default theme — a truncated fmtScheme is itself a repair
+ * trigger, so the full color/font/format scheme is emitted verbatim. Static body →
+ * determinism holds.
+ *
+ * The root is the DrawingML `a:theme` element carrying themeElements
+ * (clrScheme + fontScheme + fmtScheme) — package plumbing, like package-parts.ts,
+ * rather than a WordprocessingML content emitter.
+ */
+
+import { parseXml, serializeXml, XML_DECL } from '../../primitives/xml.js';
+import type { CompileContext } from '../context.js';
+
+const THEME_CONTENT_TYPE = 'application/vnd.openxmlformats-officedocument.theme+xml';
+const THEME_REL_TYPE =
+  'http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme';
+
+const A_NS = 'http://schemas.openxmlformats.org/drawingml/2006/main';
+
+/** The canonical Office default theme (clrScheme + fontScheme + full fmtScheme). */
+const THEME1_XML =
+  `<a:theme xmlns:a="${A_NS}" name="Office Theme">` +
+  '<a:themeElements>' +
+  '<a:clrScheme name="Office">' +
+  '<a:dk1><a:sysClr val="windowText" lastClr="000000"/></a:dk1>' +
+  '<a:lt1><a:sysClr val="window" lastClr="FFFFFF"/></a:lt1>' +
+  '<a:dk2><a:srgbClr val="44546A"/></a:dk2>' +
+  '<a:lt2><a:srgbClr val="E7E6E6"/></a:lt2>' +
+  '<a:accent1><a:srgbClr val="4472C4"/></a:accent1>' +
+  '<a:accent2><a:srgbClr val="ED7D31"/></a:accent2>' +
+  '<a:accent3><a:srgbClr val="A5A5A5"/></a:accent3>' +
+  '<a:accent4><a:srgbClr val="FFC000"/></a:accent4>' +
+  '<a:accent5><a:srgbClr val="5B9BD5"/></a:accent5>' +
+  '<a:accent6><a:srgbClr val="70AD47"/></a:accent6>' +
+  '<a:hlink><a:srgbClr val="0563C1"/></a:hlink>' +
+  '<a:folHlink><a:srgbClr val="954F72"/></a:folHlink>' +
+  '</a:clrScheme>' +
+  '<a:fontScheme name="Office">' +
+  '<a:majorFont>' +
+  '<a:latin typeface="Calibri Light" panose="020F0302020204030204"/>' +
+  '<a:ea typeface=""/>' +
+  '<a:cs typeface=""/>' +
+  '</a:majorFont>' +
+  '<a:minorFont>' +
+  '<a:latin typeface="Calibri" panose="020F0502020204030204"/>' +
+  '<a:ea typeface=""/>' +
+  '<a:cs typeface=""/>' +
+  '</a:minorFont>' +
+  '</a:fontScheme>' +
+  '<a:fmtScheme name="Office">' +
+  '<a:fillStyleLst>' +
+  '<a:solidFill><a:schemeClr val="phClr"/></a:solidFill>' +
+  '<a:gradFill rotWithShape="1">' +
+  '<a:gsLst>' +
+  '<a:gs pos="0"><a:schemeClr val="phClr"><a:lumMod val="110000"/><a:satMod val="105000"/><a:tint val="67000"/></a:schemeClr></a:gs>' +
+  '<a:gs pos="50000"><a:schemeClr val="phClr"><a:lumMod val="105000"/><a:satMod val="103000"/><a:tint val="73000"/></a:schemeClr></a:gs>' +
+  '<a:gs pos="100000"><a:schemeClr val="phClr"><a:lumMod val="105000"/><a:satMod val="109000"/><a:tint val="81000"/></a:schemeClr></a:gs>' +
+  '</a:gsLst>' +
+  '<a:lin ang="5400000" scaled="0"/>' +
+  '</a:gradFill>' +
+  '<a:gradFill rotWithShape="1">' +
+  '<a:gsLst>' +
+  '<a:gs pos="0"><a:schemeClr val="phClr"><a:satMod val="103000"/><a:lumMod val="102000"/><a:tint val="94000"/></a:schemeClr></a:gs>' +
+  '<a:gs pos="50000"><a:schemeClr val="phClr"><a:satMod val="110000"/><a:lumMod val="100000"/><a:shade val="100000"/></a:schemeClr></a:gs>' +
+  '<a:gs pos="100000"><a:schemeClr val="phClr"><a:lumMod val="99000"/><a:satMod val="120000"/><a:shade val="78000"/></a:schemeClr></a:gs>' +
+  '</a:gsLst>' +
+  '<a:lin ang="5400000" scaled="0"/>' +
+  '</a:gradFill>' +
+  '</a:fillStyleLst>' +
+  '<a:lnStyleLst>' +
+  '<a:ln w="6350" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:prstDash val="solid"/><a:miter lim="800000"/></a:ln>' +
+  '<a:ln w="12700" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:prstDash val="solid"/><a:miter lim="800000"/></a:ln>' +
+  '<a:ln w="19050" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="phClr"/></a:solidFill><a:prstDash val="solid"/><a:miter lim="800000"/></a:ln>' +
+  '</a:lnStyleLst>' +
+  '<a:effectStyleLst>' +
+  '<a:effectStyle><a:effectLst/></a:effectStyle>' +
+  '<a:effectStyle><a:effectLst/></a:effectStyle>' +
+  '<a:effectStyle><a:effectLst><a:outerShdw blurRad="57150" dist="19050" dir="5400000" rotWithShape="0"><a:srgbClr val="000000"><a:alpha val="63000"/></a:srgbClr></a:outerShdw></a:effectLst></a:effectStyle>' +
+  '</a:effectStyleLst>' +
+  '<a:bgFillStyleLst>' +
+  '<a:solidFill><a:schemeClr val="phClr"/></a:solidFill>' +
+  '<a:solidFill><a:schemeClr val="phClr"><a:tint val="95000"/><a:satMod val="170000"/></a:schemeClr></a:solidFill>' +
+  '<a:gradFill rotWithShape="1">' +
+  '<a:gsLst>' +
+  '<a:gs pos="0"><a:schemeClr val="phClr"><a:tint val="93000"/><a:satMod val="150000"/><a:shade val="98000"/><a:lumMod val="102000"/></a:schemeClr></a:gs>' +
+  '<a:gs pos="50000"><a:schemeClr val="phClr"><a:tint val="98000"/><a:satMod val="130000"/><a:shade val="90000"/><a:lumMod val="103000"/></a:schemeClr></a:gs>' +
+  '<a:gs pos="100000"><a:schemeClr val="phClr"><a:shade val="63000"/><a:satMod val="120000"/></a:schemeClr></a:gs>' +
+  '</a:gsLst>' +
+  '<a:lin ang="5400000" scaled="0"/>' +
+  '</a:gradFill>' +
+  '</a:bgFillStyleLst>' +
+  '</a:fmtScheme>' +
+  '</a:themeElements>' +
+  '<a:objectDefaults/>' +
+  '<a:extraClrSchemeLst/>' +
+  '</a:theme>';
+
+export function emitThemePart(ctx: CompileContext): void {
+  ctx.registerPart('word/theme/theme1.xml', THEME_CONTENT_TYPE, THEME_REL_TYPE);
+  // Parse + reserialize: normalizes output and fails loudly if the static body is
+  // ever edited into malformed XML.
+  ctx.setFileContent('word/theme/theme1.xml', XML_DECL + serializeXml(parseXml(THEME1_XML)));
+}

--- a/packages/docx-core/src/generation/emit/web-settings-part.ts
+++ b/packages/docx-core/src/generation/emit/web-settings-part.ts
@@ -1,0 +1,26 @@
+/**
+ * word/webSettings.xml emitter.
+ *
+ * Emitted on every package. Word-authored documents always carry a web-settings
+ * part; shipping a minimal one keeps generated output part-for-part comparable to
+ * genuine Word output (see issue #482). The body is static, so determinism holds.
+ *
+ * The root is the WordprocessingML `w:webSettings` element.
+ */
+
+import { parseXml, serializeXml, XML_DECL } from '../../primitives/xml.js';
+import type { CompileContext } from '../context.js';
+import { OOXML } from '../../primitives/namespaces.js';
+
+const WEB_SETTINGS_CONTENT_TYPE =
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.webSettings+xml';
+const WEB_SETTINGS_REL_TYPE =
+  'http://schemas.openxmlformats.org/officeDocument/2006/relationships/webSettings';
+
+export function emitWebSettingsPart(ctx: CompileContext): void {
+  ctx.registerPart('word/webSettings.xml', WEB_SETTINGS_CONTENT_TYPE, WEB_SETTINGS_REL_TYPE);
+  const doc = parseXml(
+    `<w:webSettings xmlns:w="${OOXML.W_NS}"><w:optimizeForBrowser/><w:allowPNG/></w:webSettings>`,
+  );
+  ctx.setFileContent('word/webSettings.xml', XML_DECL + serializeXml(doc));
+}

--- a/packages/docx-core/src/generation/generation-ancillary-parts.test.ts
+++ b/packages/docx-core/src/generation/generation-ancillary-parts.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Standard ancillary parts (issue #482).
+ *
+ * Word-authored documents always carry word/theme/theme1.xml, word/fontTable.xml,
+ * and word/webSettings.xml. generateDocx now emits all three on every package so
+ * authored output is part-for-part comparable to genuine Word output, removing a
+ * suspected Word-for-Mac repair trigger. These assertions prove the parts are
+ * present, fully wired (content type + resolving relationship), well-formed, and
+ * survive a load/save round-trip and a self-compare.
+ */
+
+import JSZip from 'jszip';
+import { describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { readZipText } from '../primitives/zip.js';
+import { parseXml } from '../primitives/xml.js';
+import { compareDocuments } from '../index.js';
+import { DocxArchive } from '../shared/docx/DocxArchive.js';
+import { generateDocx } from './compile.js';
+import { coverTermsTable, signatureBlock } from './recipes.js';
+import { checkGeneratedPackage } from './structural-checks.js';
+import type { DocumentSpec } from './types.js';
+
+const TEST_FEATURE = 'add-generation-ancillary-parts';
+const test = testAllure.epic('Document Generation').withLabels({ feature: TEST_FEATURE });
+
+const ANCILLARY_PARTS = ['word/theme/theme1.xml', 'word/fontTable.xml', 'word/webSettings.xml'];
+
+const ANCILLARY_CONTENT_TYPES = [
+  'application/vnd.openxmlformats-officedocument.theme+xml',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.fontTable+xml',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.webSettings+xml',
+];
+
+/** A spec exercising fonts on a style and a run, plus recipe blocks, to drive font enumeration. */
+function richSpec(): DocumentSpec {
+  return {
+    meta: { title: 'Ancillary', author: 'safe-docx', createdIso: '2026-01-01T00:00:00Z' },
+    styles: [
+      { styleId: 'Body', name: 'Body', type: 'paragraph', basedOn: 'Normal', run: { font: 'Times New Roman' } },
+    ],
+    sections: [
+      {
+        blocks: [
+          { kind: 'paragraph', styleId: 'Body', runs: [{ kind: 'text', text: 'Hello ' }, { kind: 'text', text: 'world', font: 'Georgia' }] },
+          coverTermsTable({ terms: [{ label: 'Term', value: 'Value' }] }),
+          ...signatureBlock({ parties: [{ party: 'Acme Inc.', name: 'Jane Roe', title: 'Buyer' }] }),
+        ],
+      },
+    ],
+  };
+}
+
+describe('Standard ancillary parts', () => {
+  test.openspec('[SDX-GEN-093] standard ancillary parts are emitted and fully wired')(
+    'Scenario: standard ancillary parts are emitted and fully wired',
+    async ({ given, then, attachPrettyJson }: AllureBddContext) => {
+      let buffer!: Buffer;
+      let zipNames!: string[];
+      await given('a generated package', async () => {
+        buffer = await generateDocx(richSpec());
+        const zip = await JSZip.loadAsync(buffer);
+        zipNames = Object.keys(zip.files);
+        await attachPrettyJson('package-parts', zipNames.slice().sort());
+      });
+
+      await then('it contains theme1.xml, fontTable.xml, and webSettings.xml', async () => {
+        for (const part of ANCILLARY_PARTS) {
+          expect(zipNames, `missing ${part}`).toContain(part);
+        }
+      });
+
+      await then('each part carries a content-type Override', async () => {
+        const contentTypes = (await readZipText(buffer, '[Content_Types].xml'))!;
+        for (const part of ANCILLARY_PARTS) expect(contentTypes).toContain(`/${part}`);
+        for (const ct of ANCILLARY_CONTENT_TYPES) expect(contentTypes).toContain(ct);
+      });
+
+      await then('each part has a relationship whose target resolves', async () => {
+        const rels = parseXml((await readZipText(buffer, 'word/_rels/document.xml.rels'))!);
+        const targets = Array.from(rels.getElementsByTagName('Relationship')).map((r) => r.getAttribute('Target'));
+        // Targets are relative to word/ (the directory owning document.xml).
+        for (const target of ['theme/theme1.xml', 'fontTable.xml', 'webSettings.xml']) {
+          expect(targets, `no rel target ${target}`).toContain(target);
+        }
+      });
+
+      await then('the structural checks pass (closed relationship graph)', async () => {
+        const result = await checkGeneratedPackage(buffer);
+        expect(result.ok, JSON.stringify(result.issues)).toBe(true);
+      });
+    },
+  );
+
+  test.openspec('[SDX-GEN-093] the ancillary parts are well-formed and faithful')(
+    'Scenario: the ancillary parts are well-formed and faithful',
+    async ({ given, then }: AllureBddContext) => {
+      let buffer!: Buffer;
+      await given('a generated package referencing several fonts', async () => {
+        buffer = await generateDocx(richSpec());
+      });
+
+      await then('the theme carries a colour, font, and format scheme', async () => {
+        const theme = parseXml((await readZipText(buffer, 'word/theme/theme1.xml'))!);
+        expect(theme.getElementsByTagName('a:clrScheme')).toHaveLength(1);
+        expect(theme.getElementsByTagName('a:fontScheme')).toHaveLength(1);
+        expect(theme.getElementsByTagName('a:fmtScheme')).toHaveLength(1);
+        // A complete fmtScheme has three fills, three lines, three effects, three bg fills.
+        expect(theme.getElementsByTagName('a:fillStyleLst')[0]!.getElementsByTagName('a:gradFill').length).toBeGreaterThanOrEqual(2);
+      });
+
+      await then('the font table enumerates every font the document references', async () => {
+        const fonts = parseXml((await readZipText(buffer, 'word/fontTable.xml'))!);
+        const names = Array.from(fonts.getElementsByTagName('w:font')).map((f) => f.getAttribute('w:name'));
+        for (const expected of ['Calibri', 'Times New Roman', 'Georgia']) {
+          expect(names, `font table missing ${expected}`).toContain(expected);
+        }
+      });
+
+      await then('web settings declares browser optimization', async () => {
+        const web = (await readZipText(buffer, 'word/webSettings.xml'))!;
+        expect(web).toContain('optimizeForBrowser');
+      });
+    },
+  );
+
+  test.openspec('[SDX-GEN-093] the ancillary parts survive load/save and self-compare')(
+    'Scenario: the ancillary parts survive load/save and self-compare',
+    async ({ given, then }: AllureBddContext) => {
+      let buffer!: Buffer;
+      await given('a generated package', async () => {
+        buffer = await generateDocx(richSpec());
+      });
+
+      await then('a load -> save round-trip retains all three parts', async () => {
+        const archive = await DocxArchive.load(buffer);
+        const resaved = await DocxArchive.load(await archive.save());
+        for (const part of ANCILLARY_PARTS) expect(resaved.listFiles(), `dropped ${part}`).toContain(part);
+      });
+
+      await then('self-comparing the authored document keeps the theme in the result', async () => {
+        const result = await compareDocuments(buffer, buffer, { engine: 'atomizer', reconstructionMode: 'rebuild' });
+        const resultArchive = await DocxArchive.load(result.document);
+        expect(resultArchive.listFiles()).toContain('word/theme/theme1.xml');
+      });
+    },
+  );
+});

--- a/packages/docx-core/src/primitives/namespaces.ts
+++ b/packages/docx-core/src/primitives/namespaces.ts
@@ -171,4 +171,10 @@ export const W = {
   // Revision wrappers
   del: 'del',
   moveFrom: 'moveFrom',
+
+  // Font table (word/fontTable.xml)
+  font: 'font',
+  charset: 'charset',
+  family: 'family',
+  pitch: 'pitch',
 } as const;


### PR DESCRIPTION
## What

`generateDocx` now emits the three standard ancillary parts every Word-authored `.docx` carries, on every generated package:

- `word/theme/theme1.xml` — the complete canonical Office theme (clrScheme + fontScheme + full fmtScheme)
- `word/fontTable.xml` — enumerating the fonts the spec actually references (not a fixed stub)
- `word/webSettings.xml` — minimal (`optimizeForBrowser` + `allowPNG`)

## Why

Issue #482 tracks the suspicion that the absence of these parts contributes to a Microsoft Word for Mac repair/recovery dialog. Structural checks and the LibreOffice probes can't observe that prompt honestly, so the defensive fix is to make authored output part-for-part comparable to genuine Word output and remove the whole class of doubt.

## How

Each part wires through the existing `CompileContext.registerPart` path (content-type Override + resolving `word/_rels/document.xml.rels` entry), exactly like the settings part — emitted after settings and before package plumbing. All three bodies are static, so the determinism contract (`SDX-GEN-013`) still holds (verified byte-identical across runs). A truncated `fmtScheme` is itself a repair trigger, so the theme ships the full canonical scheme verbatim.

## Spec & tests

- OpenSpec change `add-generation-ancillary-parts` with ADDED requirement + scenario **SDX-GEN-093**.
- New `generation-ancillary-parts.test.ts` asserts: presence, content-type/relationship wiring, structural checks, well-formedness (theme schemes, faithful font enumeration, webSettings), and survival through a `DocxDocument` load/save round-trip and a generated-doc self-compare.
- Full docx-core suite green (1518 passed); `check:spec-coverage`, conformance citations, lint, build all pass. LibreOffice identity + PDF probes pass against the new package shape.

## Out of scope

Carrying ancillary parts through `compareDocuments` rebuild reconstruction when comparing a part-less original against a part-carrying revision (rebuild clones the original archive). #483/#484 locked the author→compare round-trip at the text level; ancillary-part survival through compare is a separate follow-up.

## Manual follow-up

The "if Word repairs" question can only be settled by a human opening the regenerated `generation-phase*.docx` artifacts in **Word for Mac / Pages / Google Docs** and confirming no repair dialog — those matrix cells stay `—` pending that pass. Regenerate with:

\`\`\`
SDX_WRITE_OUTPUT_FIXTURES=1 npm run test:run -w @usejunior/docx-core -- src/generation src/integration/generation-package-structure.test.ts
\`\`\`

Ref: #482