### PR TITLE
fix(docx-mcp): clear CodeQL alerts for biased RNG and no-op replace

### DIFF
--- a/packages/docx-core/src/baselines/diffmatch/trackChangesRenderer.ts
+++ b/packages/docx-core/src/baselines/diffmatch/trackChangesRenderer.ts
@@ -27,7 +27,7 @@ export function allocateRevisionId(): number {
  * Format a date for OOXML (ISO 8601 format).
  */
 export function formatOoxmlDate(date: Date): string {
-  return date.toISOString().replace('Z', 'Z');
+  return date.toISOString();
 }
 
 /**

--- a/packages/docx-mcp/src/session/manager.ts
+++ b/packages/docx-mcp/src/session/manager.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from 'node:crypto';
+import { randomInt } from 'node:crypto';
 import path from 'node:path';
 import os from 'node:os';
 import fs from 'node:fs/promises';
@@ -292,10 +292,11 @@ export class SessionManager {
   private newSessionId(): string {
     // Format: ses_[12 alphanumeric] — kept for temp dir naming only.
     const alphabet = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
-    const bytes = randomBytes(12);
     let out = '';
     for (let i = 0; i < 12; i++) {
-      out += alphabet[bytes[i] % alphabet.length];
+      // randomInt gives a uniform value in [0, alphabet.length); avoids the
+      // modulo bias of randomBytes()[i] % alphabet.length (256 % 62 != 0).
+      out += alphabet[randomInt(alphabet.length)];
     }
     return `ses_${out}`;
   }

--- a/packages/docx-mcp/src/tools/init_plan.ts
+++ b/packages/docx-mcp/src/tools/init_plan.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from 'node:crypto';
+import { randomInt } from 'node:crypto';
 import { errorCode, errorMessage } from "../error_utils.js";
 import { SessionManager } from '../session/manager.js';
 import { err, ok, type ToolResponse } from './types.js';
@@ -6,10 +6,11 @@ import { mergeSessionResolutionMetadata, resolveSessionForTool } from './session
 
 function createPlanContextId(): string {
   const alphabet = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
-  const bytes = randomBytes(12);
   let suffix = '';
   for (let i = 0; i < 12; i += 1) {
-    suffix += alphabet[bytes[i]! % alphabet.length];
+    // randomInt gives a uniform value in [0, alphabet.length); avoids the
+    // modulo bias of randomBytes()[i] % alphabet.length (256 % 62 != 0).
+    suffix += alphabet[randomInt(alphabet.length)];
   }
   return `plctx_${suffix}`;
 }


### PR DESCRIPTION
## What

Clears three CodeQL code-scanning alerts on `main`:

| Alert | Rule | Location | Fix |
|-------|------|----------|-----|
| #5 | `js/biased-cryptographic-random` | `session/manager.ts` `newSessionId()` | `randomInt(alphabet.length)` instead of `randomBytes()[i] % 62` |
| #6 | `js/biased-cryptographic-random` | `tools/init_plan.ts` `createPlanContextId()` | same |
| #1 | `js/identity-replacement` | `diffmatch/trackChangesRenderer.ts` `formatOoxmlDate()` | drop the `.replace('Z','Z')` no-op |

## Why

- **Modulo bias** (#5/#6): `256 % 62 != 0`, so the first few alphabet chars were slightly over-represented. These IDs are temp-dir / plan-context names, not security tokens, so it isn't exploitable — but the bias is real and `crypto.randomInt` is the unbiased, idiomatic fix.
- **No-op replace** (#1): `toISOString()` already emits the trailing `Z`; `.replace('Z','Z')` did nothing. Output is byte-identical, so the renderer is unaffected.

## Verification

- `npm run build` ✅
- `npm run lint:workspaces` ✅ (0 errors)
- docx-mcp `src/session` + `src/tools/init_plan` suites: 40 passed ✅

This is PR A of the security-notice cleanup. Follow-ups: dependency bumps (uuid→≥11.1.1, esbuild→≥0.28.1) and hardening the remaining build/test-tooling CodeQL false-positives.

Ref: CodeQL alerts #1, #5, #6