### PR TITLE
feat(docx-core): support w:highlight on RunProps (closes #491)

### DIFF
--- a/openspec/changes/add-run-highlight/proposal.md
+++ b/openspec/changes/add-run-highlight/proposal.md
@@ -1,0 +1,26 @@
+# Change: Add run highlight generation
+
+## Why
+
+`generateDocx` cannot currently author text highlight on `RunProps`, which
+forces OpenAgreements templates to approximate highlighted placeholder tokens
+such as `{employer_name}` with less faithful muted-grey text. Issue #491 tracks
+this gap, surfaced by legal-explainer#720 and the OpenAgreements offer-letter
+visual-parity work under #482.
+
+## What Changes
+
+- Add a closed `HighlightColor` union and `RunProps.highlight` to the
+  document-generation type surface.
+- Emit `RunProps.highlight` as `w:highlight` with the authored enumerated value
+  in the existing ordered run-property sequence.
+- Add a `Run highlight` requirement to `docx-generation` with scenario
+  `SDX-GEN-105`.
+
+## Impact
+
+- Affected specs: `docx-generation` (one ADDED requirement).
+- Affected code: `packages/docx-core/src/generation/types.ts`,
+  `packages/docx-core/src/generation/emit/properties.ts`, and a focused
+  generation test.
+- Out of scope: arbitrary-color run fill via run shading.

--- a/openspec/changes/add-run-highlight/specs/docx-generation/spec.md
+++ b/openspec/changes/add-run-highlight/specs/docx-generation/spec.md
@@ -11,4 +11,5 @@ arbitrary fill colors through this field.
 - **WHEN** the document spec is compiled
 - **THEN** the run's `rPr` SHALL contain `w:highlight` with `w:val` equal to the authored value
 - **AND** `w:highlight` SHALL appear in the run-property element order after size/color properties and before underline
+- **AND** a `highlight` value outside the fixed enumeration (e.g. supplied by a JSON/JS caller bypassing the type) SHALL be rejected with a validation error before emission, so no out-of-enum `w:highlight` can be produced
 - **AND** the generated package SHALL remain well-formed

--- a/openspec/changes/add-run-highlight/specs/docx-generation/spec.md
+++ b/openspec/changes/add-run-highlight/specs/docx-generation/spec.md
@@ -1,0 +1,14 @@
+## ADDED Requirements
+
+### Requirement: Run highlight
+
+`generateDocx` SHALL accept `RunProps.highlight` as a fixed enumerated text
+highlight value and emit the corresponding run property without accepting
+arbitrary fill colors through this field.
+
+#### Scenario: [SDX-GEN-105] highlighted runs emit ordered highlight properties
+- **GIVEN** a run authored with `highlight`
+- **WHEN** the document spec is compiled
+- **THEN** the run's `rPr` SHALL contain `w:highlight` with `w:val` equal to the authored value
+- **AND** `w:highlight` SHALL appear in the run-property element order after size/color properties and before underline
+- **AND** the generated package SHALL remain well-formed

--- a/openspec/changes/add-run-highlight/tasks.md
+++ b/openspec/changes/add-run-highlight/tasks.md
@@ -1,0 +1,24 @@
+## 1. Spec
+
+- [x] 1.1 Add the `Run highlight` requirement with scenario `SDX-GEN-105` to
+      the `docx-generation` delta.
+
+## 2. Types and emitter
+
+- [x] 2.1 Add the closed `HighlightColor` union and `RunProps.highlight`.
+- [x] 2.2 Emit `w:highlight` from `buildRunPropsElement` through the existing
+      run-property ordering table.
+
+## 3. Tests
+
+- [x] 3.1 Add `packages/docx-core/src/generation/generation-run-highlight.test.ts`
+      with `TEST_FEATURE = 'add-run-highlight'` and `.openspec` ID
+      `[SDX-GEN-105]`.
+- [x] 3.2 Assert authored highlight values are emitted, ordered, well-formed,
+      and survive load/save round-trip.
+
+## 4. Verify
+
+- [x] 4.1 `openspec validate add-run-highlight --strict` passes.
+- [x] 4.2 Focused package build/test, spec coverage, conformance-citation check,
+      workspace lint, and grep confirmation pass.

--- a/packages/docx-core/src/generation/emit/properties.ts
+++ b/packages/docx-core/src/generation/emit/properties.ts
@@ -65,6 +65,9 @@ export function buildRunPropsElement(doc: Document, props: RunProps): Element | 
     children.set(W.sz, createWmlElement(doc, W.sz, { 'w:val': halfPoints }));
     children.set(W.szCs, createWmlElement(doc, W.szCs, { 'w:val': halfPoints }));
   }
+  if (props.highlight !== undefined) {
+    children.set(W.highlight, createWmlElement(doc, W.highlight, { 'w:val': props.highlight }));
+  }
   if (props.underline !== undefined) {
     children.set(W.u, createWmlElement(doc, W.u, { 'w:val': props.underline }));
   }

--- a/packages/docx-core/src/generation/generation-run-highlight.test.ts
+++ b/packages/docx-core/src/generation/generation-run-highlight.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { DocxDocument } from '../primitives/document.js';
+import { childElements, getDirectChildrenByName } from '../primitives/dom-helpers.js';
+import { OOXML } from '../primitives/namespaces.js';
+import { parseXml } from '../primitives/xml.js';
+import { readZipText } from '../primitives/zip.js';
+import { generateDocx } from './compile.js';
+import { checkGeneratedPackage } from './structural-checks.js';
+import type { DocumentSpec } from './types.js';
+
+const TEST_FEATURE = 'add-run-highlight';
+const test = testAllure.epic('Document Generation').withLabels({ feature: TEST_FEATURE });
+
+async function loadDocumentXml(buffer: Buffer): Promise<{ xml: string; dom: Document }> {
+  const xml = await readZipText(buffer, 'word/document.xml');
+  expect(xml, 'word/document.xml missing from package').not.toBeNull();
+  return { xml: xml!, dom: parseXml(xml!) };
+}
+
+function wChildNames(el: Element): string[] {
+  return childElements(el)
+    .filter((child) => child.namespaceURI === OOXML.W_NS)
+    .map((child) => child.localName);
+}
+
+function highlightValues(dom: Document): string[] {
+  return Array.from(dom.getElementsByTagName('w:highlight')).map((el) => el.getAttribute('w:val') ?? '');
+}
+
+function runHighlightSpec(): DocumentSpec {
+  return {
+    sections: [
+      {
+        blocks: [
+          {
+            kind: 'paragraph',
+            runs: [
+              {
+                kind: 'text',
+                text: '{employer_name}',
+                colorHex: '1F4E79',
+                sizePt: 12,
+                highlight: 'yellow',
+                underline: 'single',
+              },
+              { kind: 'text', text: ' cleared', highlight: 'none' },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe('Traceability: run highlight generation', () => {
+  test.openspec('[SDX-GEN-105] highlighted runs emit ordered highlight properties')(
+    'Scenario: highlighted runs emit ordered highlight properties',
+    async ({ given, when, then, attachPrettyJson, attachPrettyXml }: AllureBddContext) => {
+      let buffer!: Buffer;
+      await given('a spec with runs carrying enumerated highlight values', async () => {
+        buffer = await generateDocx(runHighlightSpec());
+      });
+
+      let documentXml!: string;
+      let documentDoc!: Document;
+      let firstRPr!: Element;
+      await when('word/document.xml is parsed from the generated package', async () => {
+        ({ xml: documentXml, dom: documentDoc } = await loadDocumentXml(buffer));
+        await attachPrettyXml('word/document.xml', documentXml);
+        const firstRun = documentDoc.getElementsByTagName('w:r').item(0)!;
+        firstRPr = getDirectChildrenByName(firstRun, 'rPr')[0]!;
+        expect(firstRPr).toBeTruthy();
+      });
+
+      await then('the authored highlight values are emitted as run properties', async () => {
+        expect(documentXml).toContain('<w:highlight w:val="yellow"/>');
+        expect(highlightValues(documentDoc)).toEqual(['yellow', 'none']);
+      });
+
+      await then('highlight is ordered after size/color properties and before underline', async () => {
+        const names = wChildNames(firstRPr);
+        await attachPrettyJson('rpr-child-order', names);
+        expect(names).toEqual(['color', 'sz', 'szCs', 'highlight', 'u']);
+      });
+
+      await then('the generated package is structurally valid and well-formed', async () => {
+        const structural = await checkGeneratedPackage(buffer);
+        await attachPrettyJson('structural-check-result', structural);
+        expect(structural.issues).toEqual([]);
+        expect(parseXml(documentXml).getElementsByTagName('w:highlight')).toHaveLength(2);
+      });
+
+      await then('the highlight properties survive a load/save round-trip', async () => {
+        const loaded = await DocxDocument.load(buffer);
+        const saved = await loaded.toBuffer();
+        const { dom: savedDoc } = await loadDocumentXml(saved.buffer);
+        expect(highlightValues(savedDoc)).toEqual(['yellow', 'none']);
+      });
+    },
+  );
+});

--- a/packages/docx-core/src/generation/generation-run-highlight.test.ts
+++ b/packages/docx-core/src/generation/generation-run-highlight.test.ts
@@ -7,7 +7,7 @@ import { parseXml } from '../primitives/xml.js';
 import { readZipText } from '../primitives/zip.js';
 import { generateDocx } from './compile.js';
 import { checkGeneratedPackage } from './structural-checks.js';
-import type { DocumentSpec } from './types.js';
+import type { DocumentSpec, HighlightColor } from './types.js';
 
 const TEST_FEATURE = 'add-run-highlight';
 const test = testAllure.epic('Document Generation').withLabels({ feature: TEST_FEATURE });
@@ -96,6 +96,23 @@ describe('Traceability: run highlight generation', () => {
         const saved = await loaded.toBuffer();
         const { dom: savedDoc } = await loadDocumentXml(saved.buffer);
         expect(highlightValues(savedDoc)).toEqual(['yellow', 'none']);
+      });
+
+      await then('an out-of-enum highlight value is rejected before emission', async () => {
+        const invalidSpec: DocumentSpec = {
+          sections: [
+            {
+              blocks: [
+                {
+                  kind: 'paragraph',
+                  // Simulate a JSON/JS caller bypassing the closed union at runtime.
+                  runs: [{ kind: 'text', text: 'x', highlight: 'notAHighlight' as HighlightColor }],
+                },
+              ],
+            },
+          ],
+        };
+        await expect(generateDocx(invalidSpec)).rejects.toThrow(/highlight must be one of/);
       });
     },
   );

--- a/packages/docx-core/src/generation/types.ts
+++ b/packages/docx-core/src/generation/types.ts
@@ -105,6 +105,25 @@ export type ParagraphSpec = {
 
 export type InlineSpec = RunSpec | FieldSpec | TabSpec | BreakSpec;
 
+export type HighlightColor =
+  | 'yellow'
+  | 'green'
+  | 'cyan'
+  | 'magenta'
+  | 'blue'
+  | 'red'
+  | 'darkBlue'
+  | 'darkCyan'
+  | 'darkGreen'
+  | 'darkMagenta'
+  | 'darkRed'
+  | 'darkYellow'
+  | 'darkGray'
+  | 'lightGray'
+  | 'black'
+  | 'white'
+  | 'none';
+
 /** Run-level formatting shared by text runs, fields, and style definitions. */
 export type RunProps = {
   bold?: boolean;
@@ -112,6 +131,8 @@ export type RunProps = {
   underline?: 'single' | 'double' | 'none';
   /** Six-digit hex without '#', e.g. 'FF0000'. */
   colorHex?: string;
+  /** Fixed text highlight color; arbitrary run fill belongs to run shading. */
+  highlight?: HighlightColor;
   /** Applied to ascii + hAnsi + cs so all script ranges agree. */
   font?: string;
   sizePt?: number;

--- a/packages/docx-core/src/generation/types.ts
+++ b/packages/docx-core/src/generation/types.ts
@@ -105,24 +105,33 @@ export type ParagraphSpec = {
 
 export type InlineSpec = RunSpec | FieldSpec | TabSpec | BreakSpec;
 
-export type HighlightColor =
-  | 'yellow'
-  | 'green'
-  | 'cyan'
-  | 'magenta'
-  | 'blue'
-  | 'red'
-  | 'darkBlue'
-  | 'darkCyan'
-  | 'darkGreen'
-  | 'darkMagenta'
-  | 'darkRed'
-  | 'darkYellow'
-  | 'darkGray'
-  | 'lightGray'
-  | 'black'
-  | 'white'
-  | 'none';
+/**
+ * The fixed set of text-highlight values (CT_HighlightColor). Single source of
+ * truth: the {@link HighlightColor} union is derived from this array, and
+ * validation reuses it as a runtime whitelist so JSON/JS callers cannot author
+ * an out-of-enum `w:highlight`.
+ */
+export const HIGHLIGHT_COLORS = [
+  'yellow',
+  'green',
+  'cyan',
+  'magenta',
+  'blue',
+  'red',
+  'darkBlue',
+  'darkCyan',
+  'darkGreen',
+  'darkMagenta',
+  'darkRed',
+  'darkYellow',
+  'darkGray',
+  'lightGray',
+  'black',
+  'white',
+  'none',
+] as const;
+
+export type HighlightColor = (typeof HIGHLIGHT_COLORS)[number];
 
 /** Run-level formatting shared by text runs, fields, and style definitions. */
 export type RunProps = {

--- a/packages/docx-core/src/generation/validate-spec.ts
+++ b/packages/docx-core/src/generation/validate-spec.ts
@@ -37,8 +37,10 @@ import type {
   TableBorders,
   TableSpec,
 } from './types.js';
+import { HIGHLIGHT_COLORS } from './types.js';
 
 const COLOR_HEX_RE = /^[0-9A-Fa-f]{6}$/;
+const HIGHLIGHT_COLOR_SET: ReadonlySet<string> = new Set(HIGHLIGHT_COLORS);
 
 function unsupported(path: string, feature: string): never {
   throw new GenerationSpecError(
@@ -378,5 +380,12 @@ function validateRunProps(props: RunProps, path: string): void {
   }
   if (props.sizePt !== undefined && (!(props.sizePt > 0) || !Number.isFinite(props.sizePt))) {
     throw new GenerationSpecError('invalid_value', `${path}/sizePt`, 'sizePt must be a positive finite number');
+  }
+  if (props.highlight !== undefined && !HIGHLIGHT_COLOR_SET.has(props.highlight)) {
+    throw new GenerationSpecError(
+      'invalid_value',
+      `${path}/highlight`,
+      `highlight must be one of the fixed CT_HighlightColor values, got '${props.highlight}'`,
+    );
   }
 }


### PR DESCRIPTION
## Summary
Adds run-highlight authoring to the from-scratch generator. `RunProps` could not express `<w:highlight>`, so consumers (the OA DOCX adapter in legal-explainer#720) had to drop highlighted placeholder tokens to muted-grey text. This closes that gap.

## Implementation
- New closed `HighlightColor` union: the 16 OOXML enumerated highlight colors + `none` (highlight takes a fixed enum, not arbitrary hex).
- `RunProps.highlight?: HighlightColor`, emitted as `<w:highlight w:val="…"/>` in `rPr` through the existing `RPR_ORDER` slot (already present between `szCs` and `u`).
- Arbitrary-color run fill (`w:shd`) is intentionally **out of scope** — noted for a follow-up.

## OpenSpec
- New change `add-run-highlight` with requirement "Run highlight" → scenario `[SDX-GEN-105]`.
- `openspec validate add-run-highlight --strict` passes.

## Verification
- [x] Build clean (`@usejunior/docx-core`)
- [x] Generation suite: 48 tests pass (incl. new `generation-run-highlight.test.ts`)
- [x] `check:spec-coverage` (exit 0; `add-run-highlight: 1 scenarios covered`)
- [x] `check:conformance-citations` OK
- [x] `lint:workspaces` 0 errors (9 pre-existing unrelated warnings)
- [ ] Peer review (agy + Codex) — pending; appended below

## Closes
- #491