### PR TITLE
feat(docx-core): cover-terms table house style (horizontal rules, groups, vertical rhythm)

### DIFF
--- a/openspec/changes/add-cover-terms-house-style/proposal.md
+++ b/openspec/changes/add-cover-terms-house-style/proposal.md
@@ -1,0 +1,26 @@
+# Change: Add cover-terms table house style
+
+## Why
+
+OpenAgreements cover pages need a horizontal-rule cover-terms table with grouped
+rows, subordinate rows, and taller row rhythm. Today `coverTermsTable` only
+produces a compact full-grid label/value table, which forces adapters to build
+the cover table by hand.
+
+## What Changes
+
+- Add optional `coverTermsTable` controls for full-grid versus horizontal-rules
+  table borders.
+- Allow cover-terms entries to include full-width group rows and italic
+  subordinate rows while keeping plain label/value rows unchanged.
+- Add optional row-height and uniform cell-padding controls for cover-terms
+  vertical rhythm.
+- Add scenario `SDX-GEN-106` covering the recipe output, emitted XML, and
+  default compatibility.
+
+## Impact
+
+- Affected specs: `docx-generation` (one ADDED requirement).
+- Affected code: `packages/docx-core/src/generation/recipes.ts` and a focused
+  generation test.
+- Out of scope: signature-block layout and paragraph grammar changes.

--- a/openspec/changes/add-cover-terms-house-style/specs/docx-generation/spec.md
+++ b/openspec/changes/add-cover-terms-house-style/specs/docx-generation/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Cover-terms table house style
+
+`coverTermsTable` SHALL support optional house-style table rows and vertical
+rhythm while preserving the existing full-grid label/value table when the new
+options are omitted.
+
+#### Scenario: [SDX-GEN-106] cover-terms tables support house-style rows and rhythm
+- **GIVEN** a cover-terms table authored in horizontal-rules mode with a group row, a subrow, and an authored row height
+- **WHEN** `coverTermsTable` builds the `TableSpec` and the document is generated
+- **THEN** the produced table SHALL rule `top`, `bottom`, and `insideH` borders while emitting `left`, `right`, and `insideV` borders as `none`
+- **AND** the group row SHALL span both columns, render bold text, and emit no shading
+- **AND** the subrow SHALL render italic soft-ink text with an indented label cell
+- **AND** body rows SHALL carry the authored minimum `w:trHeight`
+- **AND** omitting the new options SHALL preserve the existing full-grid label/value behavior
+- **AND** the generated package SHALL remain structurally valid and well-formed

--- a/openspec/changes/add-cover-terms-house-style/tasks.md
+++ b/openspec/changes/add-cover-terms-house-style/tasks.md
@@ -1,0 +1,27 @@
+## 1. Spec
+
+- [x] 1.1 Add the `Cover-terms table house style` requirement with scenario
+      `SDX-GEN-106` to the `docx-generation` delta.
+
+## 2. Recipe
+
+- [x] 2.1 Add optional `borderMode`, `rowHeightTwips`, and `cellPaddingTwips`
+      controls to `coverTermsTable`.
+- [x] 2.2 Add group-row and subrow term entry support without changing the
+      default label/value behavior.
+- [x] 2.3 Compose the new behavior only from the existing table, paragraph, and
+      run grammar.
+
+## 3. Tests
+
+- [x] 3.1 Add `packages/docx-core/src/generation/generation-cover-terms-house-style.test.ts`
+      with `TEST_FEATURE = 'add-cover-terms-house-style'` and `.openspec`
+      scenario `[SDX-GEN-106]`.
+- [x] 3.2 Assert horizontal-rule borders, group-row span and bold styling,
+      subrow italic/soft-ink/indent styling, authored row height, structural
+      validity, and default full-grid compatibility.
+
+## 4. Verify
+
+- [x] 4.1 Focused package build/test, spec coverage, conformance-citation check,
+      workspace lint, and strict OpenSpec validation pass.

--- a/packages/docx-core/src/generation/generation-cover-terms-house-style.test.ts
+++ b/packages/docx-core/src/generation/generation-cover-terms-house-style.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect } from 'vitest';
+import { getDirectChildrenByName } from '../primitives/dom-helpers.js';
+import { parseXml } from '../primitives/xml.js';
+import { readZipText } from '../primitives/zip.js';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { generateDocx } from './compile.js';
+import { coverTermsTable } from './recipes.js';
+import { checkGeneratedPackage } from './structural-checks.js';
+import type { DocumentSpec } from './types.js';
+
+const TEST_FEATURE = 'add-cover-terms-house-style';
+const test = testAllure.epic('Document Generation').withLabels({ feature: TEST_FEATURE });
+
+function specWithCoverTable(): DocumentSpec {
+  return {
+    meta: { title: 'Cover terms house style', createdIso: '2026-06-14T00:00:00Z' },
+    sections: [
+      {
+        blocks: [
+          coverTermsTable({
+            title: 'Cover Terms',
+            borderMode: 'horizontal-rules',
+            rowHeightTwips: 560,
+            cellPaddingTwips: 120,
+            subrowLabelIndentTwips: 360,
+            terms: [
+              { group: 'Transaction Parties' },
+              { label: 'Disclosing Party', value: 'Acme Manufacturing, Inc.' },
+              { label: 'Affiliate', value: 'Acme Services LLC', subrow: true },
+            ],
+          }),
+        ],
+      },
+    ],
+  };
+}
+
+async function generateDocumentXml(spec: DocumentSpec): Promise<string> {
+  const buffer = await generateDocx(spec);
+  const structural = await checkGeneratedPackage(buffer);
+  expect(structural.issues).toEqual([]);
+  const xml = await readZipText(buffer, 'word/document.xml');
+  expect(xml, 'word/document.xml missing from package').not.toBeNull();
+  return xml!;
+}
+
+function firstDirectChild(parent: Element, localName: string): Element {
+  const child = getDirectChildrenByName(parent, localName)[0];
+  expect(child, `missing direct w:${localName}`).toBeTruthy();
+  return child!;
+}
+
+function borderValues(tbl: Element): Record<string, string | null> {
+  const tblPr = firstDirectChild(tbl, 'tblPr');
+  const tblBorders = firstDirectChild(tblPr, 'tblBorders');
+  return Object.fromEntries(
+    ['top', 'left', 'bottom', 'right', 'insideH', 'insideV'].map((edge) => [
+      edge,
+      firstDirectChild(tblBorders, edge).getAttribute('w:val'),
+    ]),
+  );
+}
+
+function firstRunProps(cell: Element): Element {
+  const run = cell.getElementsByTagName('w:r').item(0);
+  expect(run).toBeTruthy();
+  return firstDirectChild(run!, 'rPr');
+}
+
+describe('Traceability: cover-terms house style', () => {
+  test.openspec('[SDX-GEN-106] cover-terms tables support house-style rows and rhythm')(
+    'Scenario: cover-terms tables support house-style rows and rhythm',
+    async ({ given, when, then, attachPrettyJson, attachPrettyXml }: AllureBddContext) => {
+      let spec!: DocumentSpec;
+      await given('a cover-terms table using horizontal rules, a group row, a subrow, and row height', async () => {
+        const table = specWithCoverTable().sections[0]!.blocks[0]!;
+        await attachPrettyJson('recipe-output', table);
+        expect(table.kind).toBe('table');
+        if (table.kind !== 'table') throw new Error('expected table');
+        expect(table.borders?.left?.style).toBe('none');
+        expect(table.borders?.right?.style).toBe('none');
+        expect(table.borders?.insideV?.style).toBe('none');
+        expect(table.rows[1]!.heightTwips).toBe(560);
+        expect(table.rows[1]!.heightRule).toBe('atLeast');
+        expect(table.rows[1]!.cells[0]!.gridSpan).toBe(2);
+        expect(table.rows[1]!.cells[0]!.shadingHex).toBeUndefined();
+        expect(table.rows[3]!.cells[0]!.marginsTwips?.left).toBe(360);
+        spec = specWithCoverTable();
+      });
+
+      let documentXml!: string;
+      let dom!: Document;
+      await when('the document is generated and parsed back', async () => {
+        documentXml = await generateDocumentXml(spec);
+        dom = parseXml(documentXml);
+        await attachPrettyXml('word/document.xml', documentXml);
+      });
+
+      await then('the table emits horizontal rules with no vertical outside or inside borders', async () => {
+        const tbl = dom.getElementsByTagName('w:tbl').item(0)!;
+        expect(borderValues(tbl)).toEqual({
+          top: 'single',
+          left: 'none',
+          bottom: 'single',
+          right: 'none',
+          insideH: 'single',
+          insideV: 'none',
+        });
+      });
+
+      await then('the group row spans both columns, is bold, and does not emit shading', async () => {
+        const rows = Array.from(dom.getElementsByTagName('w:tr'));
+        const groupCell = firstDirectChild(rows[1]!, 'tc');
+        const groupCellPr = firstDirectChild(groupCell, 'tcPr');
+        expect(firstDirectChild(groupCellPr, 'gridSpan').getAttribute('w:val')).toBe('2');
+        expect(getDirectChildrenByName(groupCellPr, 'shd')).toHaveLength(0);
+        expect(firstRunProps(groupCell).getElementsByTagName('w:b')).toHaveLength(1);
+      });
+
+      await then('the subrow is italic, soft-ink, and left-indented through its label-cell margin', async () => {
+        const rows = Array.from(dom.getElementsByTagName('w:tr'));
+        const subrowCells = getDirectChildrenByName(rows[3]!, 'tc');
+        const labelPr = firstDirectChild(subrowCells[0]!, 'tcPr');
+        const labelMargins = firstDirectChild(labelPr, 'tcMar');
+        expect(firstDirectChild(labelMargins, 'left').getAttribute('w:w')).toBe('360');
+        for (const cell of subrowCells) {
+          const rPr = firstRunProps(cell);
+          expect(rPr.getElementsByTagName('w:i')).toHaveLength(1);
+          expect(rPr.getElementsByTagName('w:color').item(0)!.getAttribute('w:val')).toBe('595959');
+        }
+      });
+
+      await then('body rows carry the authored minimum row height', async () => {
+        const rows = Array.from(dom.getElementsByTagName('w:tr'));
+        expect(rows).toHaveLength(4);
+        expect(getDirectChildrenByName(rows[0]!, 'trPr')).toHaveLength(1);
+        for (const row of rows.slice(1)) {
+          const trHeight = firstDirectChild(firstDirectChild(row, 'trPr'), 'trHeight');
+          expect(trHeight.getAttribute('w:val')).toBe('560');
+          expect(trHeight.getAttribute('w:hRule')).toBe('atLeast');
+        }
+      });
+
+      await then('default options preserve the existing full-grid recipe behavior', async () => {
+        const defaultXml = await generateDocumentXml({
+          sections: [
+            {
+              blocks: [
+                coverTermsTable({
+                  terms: [{ label: 'Effective Date', value: 'June 14, 2026' }],
+                }),
+              ],
+            },
+          ],
+        });
+        const defaultDom = parseXml(defaultXml);
+        await attachPrettyXml('default-word/document.xml', defaultXml);
+        expect(borderValues(defaultDom.getElementsByTagName('w:tbl').item(0)!)).toEqual({
+          top: 'single',
+          left: 'single',
+          bottom: 'single',
+          right: 'single',
+          insideH: 'single',
+          insideV: 'single',
+        });
+        expect(defaultDom.getElementsByTagName('w:trHeight')).toHaveLength(0);
+        expect(defaultDom.getElementsByTagName('w:tcMar')).toHaveLength(0);
+      });
+    },
+  );
+});

--- a/packages/docx-core/src/generation/generation-cover-terms-house-style.test.ts
+++ b/packages/docx-core/src/generation/generation-cover-terms-house-style.test.ts
@@ -84,7 +84,10 @@ describe('Traceability: cover-terms house style', () => {
         expect(table.rows[1]!.heightRule).toBe('atLeast');
         expect(table.rows[1]!.cells[0]!.gridSpan).toBe(2);
         expect(table.rows[1]!.cells[0]!.shadingHex).toBeUndefined();
-        expect(table.rows[3]!.cells[0]!.marginsTwips?.left).toBe(360);
+        // Subrow label indent is additive over the uniform cell padding: 120 + 360 = 480.
+        expect(table.rows[3]!.cells[0]!.marginsTwips?.left).toBe(480);
+        // The subrow value cell keeps the plain uniform padding (only the label is indented).
+        expect(table.rows[3]!.cells[1]!.marginsTwips?.left).toBe(120);
         spec = specWithCoverTable();
       });
 
@@ -122,7 +125,7 @@ describe('Traceability: cover-terms house style', () => {
         const subrowCells = getDirectChildrenByName(rows[3]!, 'tc');
         const labelPr = firstDirectChild(subrowCells[0]!, 'tcPr');
         const labelMargins = firstDirectChild(labelPr, 'tcMar');
-        expect(firstDirectChild(labelMargins, 'left').getAttribute('w:w')).toBe('360');
+        expect(firstDirectChild(labelMargins, 'left').getAttribute('w:w')).toBe('480');
         for (const cell of subrowCells) {
           const rPr = firstRunProps(cell);
           expect(rPr.getElementsByTagName('w:i')).toHaveLength(1);

--- a/packages/docx-core/src/generation/recipes.ts
+++ b/packages/docx-core/src/generation/recipes.ts
@@ -12,22 +12,45 @@
 import type { BlockSpec, BorderSpec, ParagraphSpec, TableSpec } from './types.js';
 
 const SINGLE: BorderSpec = { style: 'single' };
+const NONE: BorderSpec = { style: 'none' };
+const DEFAULT_SUBROW_COLOR_HEX = '595959';
+const DEFAULT_SUBROW_LABEL_INDENT_TWIPS = 240;
+
+export type CoverTermRow = { label: string; value: string };
+export type CoverTermGroupRow = { group: string };
+export type CoverTermSubrow = { label: string; value: string; subrow: true };
+export type CoverTermEntry = CoverTermRow | CoverTermGroupRow | CoverTermSubrow;
 
 export type CoverTermsOptions = {
-  /** Label/value pairs, rendered one row each in declaration order. */
-  terms: Array<{ label: string; value: string }>;
+  /** Plain rows, group headers, and subrows rendered in declaration order. */
+  terms: CoverTermEntry[];
   /** Two-column widths in twips; defaults to a 2880/6480 split of a 6.5" body. */
   columnWidthsTwips?: [number, number];
   /** Heading text for a shaded full-width header row; omitted when absent. */
   title?: string;
+  /** Table border style; defaults to the historical full grid. */
+  borderMode?: 'grid' | 'horizontal-rules';
+  /** Optional minimum row height applied to term/group/sub rows, not the title row. */
+  rowHeightTwips?: number;
+  /** Optional uniform cell padding applied to every cover-terms cell. */
+  cellPaddingTwips?: number;
+  /** Text color for subrow labels and values; defaults to mid-gray. */
+  subrowColorHex?: string;
+  /** Additional left padding on subrow label cells; defaults to 240 twips. */
+  subrowLabelIndentTwips?: number;
 };
 
 /**
  * A fixed-layout two-column label/value table for cover-terms blocks
- * (scenario SDX-GEN-070).
+ * (scenario SDX-GEN-070), with optional house-style grouped/sub rows.
  */
 export function coverTermsTable(options: CoverTermsOptions): TableSpec {
   const [labelWidth, valueWidth] = options.columnWidthsTwips ?? [2880, 6480];
+  const borders =
+    options.borderMode === 'horizontal-rules'
+      ? { top: SINGLE, bottom: SINGLE, left: NONE, right: NONE, insideH: SINGLE, insideV: NONE }
+      : { top: SINGLE, bottom: SINGLE, left: SINGLE, right: SINGLE, insideH: SINGLE, insideV: SINGLE };
+  const rowRhythm = rowRhythmProps(options);
   const rows: TableSpec['rows'] = [];
   if (options.title !== undefined) {
     rows.push({
@@ -37,16 +60,51 @@ export function coverTermsTable(options: CoverTermsOptions): TableSpec {
           gridSpan: 2,
           shadingHex: 'D9D9D9',
           vAlign: 'center',
+          ...cellPaddingProps(options),
           blocks: [paragraph(options.title, { bold: true, alignment: 'center' })],
         },
       ],
     });
   }
   for (const term of options.terms) {
+    if ('group' in term) {
+      rows.push({
+        ...rowRhythm,
+        cells: [
+          {
+            gridSpan: 2,
+            vAlign: 'center',
+            ...cellPaddingProps(options),
+            blocks: [paragraph(term.group, { bold: true })],
+          },
+        ],
+      });
+      continue;
+    }
+
+    const subrow = 'subrow' in term && term.subrow === true;
     rows.push({
+      ...rowRhythm,
       cells: [
-        { blocks: [paragraph(term.label, { bold: true })] },
-        { blocks: [paragraph(term.value)] },
+        {
+          ...cellPaddingProps(options, subrow ? { left: options.subrowLabelIndentTwips ?? DEFAULT_SUBROW_LABEL_INDENT_TWIPS } : undefined),
+          blocks: [
+            paragraph(term.label, {
+              bold: !subrow,
+              italic: subrow,
+              colorHex: subrow ? (options.subrowColorHex ?? DEFAULT_SUBROW_COLOR_HEX) : undefined,
+            }),
+          ],
+        },
+        {
+          ...cellPaddingProps(options),
+          blocks: [
+            paragraph(term.value, {
+              italic: subrow,
+              colorHex: subrow ? (options.subrowColorHex ?? DEFAULT_SUBROW_COLOR_HEX) : undefined,
+            }),
+          ],
+        },
       ],
     });
   }
@@ -54,7 +112,7 @@ export function coverTermsTable(options: CoverTermsOptions): TableSpec {
     kind: 'table',
     layout: 'fixed',
     columnWidthsTwips: [labelWidth, valueWidth],
-    borders: { top: SINGLE, bottom: SINGLE, left: SINGLE, right: SINGLE, insideH: SINGLE, insideV: SINGLE },
+    borders,
     rows,
   };
 }
@@ -104,11 +162,37 @@ export function signatureBlock(options: SignatureBlockOptions): BlockSpec[] {
 
 function paragraph(
   text: string,
-  opts?: { bold?: boolean; alignment?: ParagraphSpec['alignment'] },
+  opts?: { bold?: boolean; italic?: boolean; colorHex?: string; alignment?: ParagraphSpec['alignment'] },
 ): ParagraphSpec {
   return {
     kind: 'paragraph',
     ...(opts?.alignment !== undefined ? { alignment: opts.alignment } : {}),
-    runs: [{ kind: 'text', text, ...(opts?.bold ? { bold: true } : {}) }],
+    runs: [
+      {
+        kind: 'text',
+        text,
+        ...(opts?.bold ? { bold: true } : {}),
+        ...(opts?.italic ? { italic: true } : {}),
+        ...(opts?.colorHex !== undefined ? { colorHex: opts.colorHex } : {}),
+      },
+    ],
+  };
+}
+
+function rowRhythmProps(options: CoverTermsOptions): Pick<TableSpec['rows'][number], 'heightTwips' | 'heightRule'> {
+  return options.rowHeightTwips === undefined ? {} : { heightTwips: options.rowHeightTwips, heightRule: 'atLeast' };
+}
+
+function cellPaddingProps(
+  options: CoverTermsOptions,
+  overrides?: NonNullable<TableSpec['rows'][number]['cells'][number]['marginsTwips']>,
+): Pick<TableSpec['rows'][number]['cells'][number], 'marginsTwips'> {
+  if (options.cellPaddingTwips === undefined && overrides === undefined) return {};
+  const uniform = options.cellPaddingTwips;
+  return {
+    marginsTwips: {
+      ...(uniform === undefined ? {} : { top: uniform, right: uniform, bottom: uniform, left: uniform }),
+      ...overrides,
+    },
   };
 }

--- a/packages/docx-core/src/generation/recipes.ts
+++ b/packages/docx-core/src/generation/recipes.ts
@@ -36,7 +36,10 @@ export type CoverTermsOptions = {
   cellPaddingTwips?: number;
   /** Text color for subrow labels and values; defaults to mid-gray. */
   subrowColorHex?: string;
-  /** Additional left padding on subrow label cells; defaults to 240 twips. */
+  /**
+   * Extra left indent on subrow label cells, added on top of `cellPaddingTwips`
+   * (so the label sits further right than a normal row). Defaults to 240 twips.
+   */
   subrowLabelIndentTwips?: number;
 };
 
@@ -87,7 +90,12 @@ export function coverTermsTable(options: CoverTermsOptions): TableSpec {
       ...rowRhythm,
       cells: [
         {
-          ...cellPaddingProps(options, subrow ? { left: options.subrowLabelIndentTwips ?? DEFAULT_SUBROW_LABEL_INDENT_TWIPS } : undefined),
+          ...cellPaddingProps(
+            options,
+            subrow
+              ? { left: (options.cellPaddingTwips ?? 0) + (options.subrowLabelIndentTwips ?? DEFAULT_SUBROW_LABEL_INDENT_TWIPS) }
+              : undefined,
+          ),
           blocks: [
             paragraph(term.label, {
               bold: !subrow,


### PR DESCRIPTION
## Summary
Extends the `coverTermsTable` recipe so consumers can express the OpenAgreements cover-page house style that the legal-explainer#720 adapter currently hand-rolls as raw `TableSpec`s. Addresses **items 1 and 4** of #488.

## Implementation (backward-compatible — all new options optional)
- `borderMode?: 'grid' | 'horizontal-rules'` (default `'grid'`). Rules-only mode sets `left`/`right`/`insideV` = `none`, keeps `top`/`bottom`/`insideH` ruled.
- Grouped rows (`{ group }` → `gridSpan 2`, bold, no shading) and italic soft-ink left-indented sub-rows (`{ label, value, subrow: true }`), via a `CoverTermEntry` discriminated union. Plain `{ label, value }` is unchanged.
- `rowHeightTwips` + `cellPaddingTwips` for vertical rhythm — the #482 OA parity gap where canonical cover rows are ~2× taller.
- Composes entirely from the existing `TableSpec`/`RunProps` grammar — **no emitter or `types.ts` changes**.

## OpenSpec
- New change `add-cover-terms-house-style`, requirement "Cover-terms table house style" → scenario `[SDX-GEN-106]`.
- `openspec validate add-cover-terms-house-style --strict` passes.

## Verification
- [x] Build clean
- [x] Generation suite: 49 tests pass — incl. existing `[SDX-GEN-070]` (no regression; default options reproduce current output) and new `[SDX-GEN-106]`
- [x] `check:spec-coverage` (exit 0; `add-cover-terms-house-style: 1 scenarios covered`)
- [x] `check:conformance-citations` OK · `lint:workspaces` 0 errors
- [ ] Peer review (agy + Codex) — pending; appended below

## Scope / follow-up
Implements the **cover-terms table** portion of #488 (items 1 + 4). Deliberately out of scope here and remaining on #488: item 2 (two-column `signatureBlock`) and item 3 (`keepLines` on `ParagraphSpec`). This PR therefore references #488 but does not close it.

## Refs
- #488 (items 1, 4) · legal-explainer#720 · parity gap from #482