### PR TITLE
chore(release): bump workspace versions to 0.11.1

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-docx",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "AI-powered DOCX and ODT editing with tracked changes, redlining, and formatting preservation",
   "contextFileName": "GEMINI.md",
   "entrypoint": "GEMINI.md",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "safe-docx-suite",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "safe-docx-suite",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -8995,7 +8995,7 @@
     },
     "packages/allure-test-factory": {
       "name": "@usejunior/allure-test-factory",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"
@@ -9016,7 +9016,7 @@
     },
     "packages/docx-core": {
       "name": "@usejunior/docx-core",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@xmldom/xmldom": "^0.9.10",
@@ -9045,12 +9045,12 @@
     },
     "packages/docx-mcp": {
       "name": "@usejunior/docx-mcp",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@usejunior/docx-core": "^0.11.0",
-        "@usejunior/odf-core": "^0.11.0",
+        "@usejunior/docx-core": "^0.11.1",
+        "@usejunior/odf-core": "^0.11.1",
         "@xmldom/xmldom": "^0.9.10",
         "zod": "^4.3.6"
       },
@@ -9071,7 +9071,7 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@usejunior/google-docs-core": "^0.11.0"
+        "@usejunior/google-docs-core": "^0.11.1"
       },
       "peerDependenciesMeta": {
         "@usejunior/google-docs-core": {
@@ -9081,7 +9081,7 @@
     },
     "packages/google-docs-core": {
       "name": "@usejunior/google-docs-core",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "Apache-2.0",
       "dependencies": {
         "google-auth-library": "^9.0.0"
@@ -9097,10 +9097,10 @@
     },
     "packages/odf-core": {
       "name": "@usejunior/odf-core",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@usejunior/docx-core": "^0.11.0",
+        "@usejunior/docx-core": "^0.11.1",
         "@xmldom/xmldom": "^0.9.10",
         "jszip": "^3.10.1"
       },
@@ -9115,10 +9115,10 @@
     },
     "packages/safe-docx": {
       "name": "@usejunior/safe-docx",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@usejunior/docx-mcp": "^0.11.0"
+        "@usejunior/docx-mcp": "^0.11.1"
       },
       "bin": {
         "safe-docx": "bin/safe-docx.js",
@@ -9130,10 +9130,10 @@
     },
     "packages/safe-docx-mcpb": {
       "name": "@usejunior/safedocx-mcpb",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@usejunior/safe-docx": "^0.11.0"
+        "@usejunior/safe-docx": "^0.11.1"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-docx-suite",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "private": true,
   "description": "Monorepo for Safe DOCX packages",
   "repository": {

--- a/packages/allure-test-factory/package.json
+++ b/packages/allure-test-factory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/allure-test-factory",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Shared Allure test helpers for vitest — BDD context, OpenSpec auto-inference, Prism.js highlighting",
   "type": "module",
   "exports": {

--- a/packages/docx-core/package.json
+++ b/packages/docx-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/docx-core",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "OOXML (.docx) core library: primitives, comparison, and track changes",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/docx-mcp/package.json
+++ b/packages/docx-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/docx-mcp",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "MCP server for reading, editing, and comparing Word (.docx) and OpenDocument (.odt) files with tracked changes. For Claude, Gemini CLI, Cursor, and any MCP client. Apache-2.0 licensed.",
   "type": "module",
   "main": "dist/index.js",
@@ -27,8 +27,8 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@usejunior/docx-core": "^0.11.0",
-    "@usejunior/odf-core": "^0.11.0",
+    "@usejunior/docx-core": "^0.11.1",
+    "@usejunior/odf-core": "^0.11.1",
     "@xmldom/xmldom": "^0.9.10",
     "zod": "^4.3.6"
   },
@@ -56,7 +56,7 @@
     "NOTICE"
   ],
   "peerDependencies": {
-    "@usejunior/google-docs-core": "^0.11.0"
+    "@usejunior/google-docs-core": "^0.11.1"
   },
   "peerDependenciesMeta": {
     "@usejunior/google-docs-core": {

--- a/packages/google-docs-core/package.json
+++ b/packages/google-docs-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/google-docs-core",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Google Docs core library: read, write, and anchor management via Google Docs API",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/odf-core/package.json
+++ b/packages/odf-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/odf-core",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "OpenDocument Format (.odt) core library: archive packaging, document view, surgical text replacement, and tracked-changes comparison",
   "type": "module",
   "main": "dist/index.js",
@@ -14,7 +14,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@usejunior/docx-core": "^0.11.0",
+    "@usejunior/docx-core": "^0.11.1",
     "@xmldom/xmldom": "^0.9.10",
     "jszip": "^3.10.1"
   },

--- a/packages/safe-docx-mcpb/manifest.json
+++ b/packages/safe-docx-mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "safe-docx",
   "display_name": "Safe Docx",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "AI-native Word (.docx) and OpenDocument (.odt) editing with stable paragraph anchors and deterministic document operations.",
   "long_description": "Safe Docx lets Claude work directly with .docx files on your local filesystem. It provides stable paragraph IDs (_bk_*) for precise editing while preserving formatting and structure.\n\nCore capabilities include reading/searching content, formatting-preserving edits and inserts, deterministic layout controls, tracked-changes output, comments, footnote tools, document comparison, and revision extraction.",
   "author": {

--- a/packages/safe-docx-mcpb/package.json
+++ b/packages/safe-docx-mcpb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/safedocx-mcpb",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "private": true,
   "description": "Claude Desktop MCP Bundle (.mcpb) wrapper for @usejunior/safe-docx",
   "type": "module",
@@ -14,7 +14,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@usejunior/safe-docx": "^0.11.0"
+    "@usejunior/safe-docx": "^0.11.1"
   },
   "devDependencies": {
     "@vitest/runner": "^4.1.8",

--- a/packages/safe-docx/.smithery/shttp/manifest.json
+++ b/packages/safe-docx/.smithery/shttp/manifest.json
@@ -6,7 +6,7 @@
     "serverCard": {
       "serverInfo": {
         "name": "safe-docx",
-        "version": "0.11.0"
+        "version": "0.11.1"
       },
       "tools": [
         {

--- a/packages/safe-docx/package.json
+++ b/packages/safe-docx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/safe-docx",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Edit Word (.docx) and OpenDocument (.odt) files with tracked changes, redlines, and formatting preservation. Built for AI coding agents. Apache-2.0 licensed, 100% local processing.",
   "mcpName": "io.github.UseJunior/safe-docx",
   "type": "module",
@@ -25,7 +25,7 @@
     "safedocx": "./bin/safe-docx.js"
   },
   "dependencies": {
-    "@usejunior/docx-mcp": "^0.11.0"
+    "@usejunior/docx-mcp": "^0.11.1"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/safe-docx/server.json
+++ b/packages/safe-docx/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.UseJunior/safe-docx",
   "title": "Safe Docx",
   "description": "AI-native surgical editing of Word .docx and OpenDocument .odt files with formatting preservation",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "websiteUrl": "https://usejunior.com/developer-tools/safe-docx",
   "icons": [
     {
@@ -18,7 +18,7 @@
     {
       "registryType": "npm",
       "identifier": "@usejunior/safe-docx",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "transport": {
         "type": "stdio"
       },

--- a/site/package.json
+++ b/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/safe-docx-site",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "private": true,
   "type": "module",
   "description": "Safe DOCX marketing and trust site (Eleventy)",


### PR DESCRIPTION
Version-only bump of the workspace suite 0.11.0 → 0.11.1 so the visual-parity work merged since the 0.11.0 tag can ship to npm.

Ships:
- `feat(docx-core): emit theme/fontTable/webSettings on generated packages` (#485) — Word font/theme fidelity on generated packages.
- `feat(docx-core): support w:highlight on RunProps` (#495) — run-level text highlight (e.g. yellow fillable fields).
- plus the docx-core/docx-mcp fixes merged to main since 0.11.0.

Consumed by legal-explainer#720 (the agreement DOCX adapter) — it pins exact docx-core and needs these for canonical visual parity.

On merge, `auto-tag-release.yml` should push `v0.11.1` (or it'll be pushed manually as the documented fallback), triggering `release.yml` to publish the suite. No code changes — version strings only.