### PR TITLE
feat(docx-core): custom theme palette + theme-relative color authoring (closes #492)

### DIFF
--- a/openspec/changes/add-custom-theme/proposal.md
+++ b/openspec/changes/add-custom-theme/proposal.md
@@ -1,0 +1,30 @@
+# Change: Add custom theme generation
+
+## Why
+
+`generateDocx` always emits the canonical Office theme, so consumers that need a
+single source of brand color must thread literal hex values through every run
+and table cell. Issue #492 requires custom theme palette overrides plus
+theme-relative authoring fields so downstream templates can map role colors to
+theme slots once.
+
+## What Changes
+
+- Add `DocumentSpec.theme` with partial color-slot overrides and optional
+  major/minor latin typeface overrides.
+- Emit custom theme colors into `word/theme/theme1.xml` while preserving the
+  canonical default for unspecified slots and unchanged output when no theme is
+  supplied.
+- Add theme-relative run color and table-cell shading fields with runtime
+  validation.
+- Add scenario `SDX-GEN-107` to `docx-generation`.
+
+## Impact
+
+- Affected specs: `docx-generation` (one ADDED requirement).
+- Affected code: `packages/docx-core/src/generation/types.ts`,
+  `packages/docx-core/src/generation/emit/theme-part.ts`,
+  `packages/docx-core/src/generation/emit/properties.ts`,
+  `packages/docx-core/src/generation/emit/table.ts`,
+  `packages/docx-core/src/generation/validate-spec.ts`, and focused generation
+  tests.

--- a/openspec/changes/add-custom-theme/specs/docx-generation/spec.md
+++ b/openspec/changes/add-custom-theme/specs/docx-generation/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Custom theme and theme-relative colors
+
+`generateDocx` SHALL accept an optional partial document theme that overrides
+canonical theme color slots and latin major/minor fonts, and SHALL allow runs
+and table-cell shading to reference the supported theme color slots without
+requiring literal hex colors at each authoring site.
+
+#### Scenario: [SDX-GEN-107] custom theme slots drive theme-relative authoring
+- **GIVEN** a document spec with `theme.colors.accent1` set to a custom six-digit hex value
+- **WHEN** the document spec is compiled
+- **THEN** `word/theme/theme1.xml` SHALL contain that value in the `accent1` color slot
+- **AND** a run authored with `themeColor: "accent1"` SHALL emit `w:color` with `w:themeColor="accent1"`
+- **AND** a table cell authored with a theme fill SHALL emit `w:shd` with the matching theme-fill attribute
+- **AND** compiling without `spec.theme` SHALL preserve the canonical default theme output
+- **AND** invalid theme color slots or specs that set both literal and theme-relative colors for the same run or cell SHALL be rejected before emission

--- a/openspec/changes/add-custom-theme/tasks.md
+++ b/openspec/changes/add-custom-theme/tasks.md
@@ -1,0 +1,28 @@
+## 1. Spec
+
+- [x] 1.1 Add the custom theme requirement with scenario `SDX-GEN-107` to the
+      `docx-generation` delta.
+
+## 2. Types and emitters
+
+- [x] 2.1 Add `ThemeColorSlot`, `DocumentThemeSpec`, `DocumentSpec.theme`,
+      run theme-color fields, and cell theme-fill fields.
+- [x] 2.2 Emit partial color/font theme overrides into `word/theme/theme1.xml`
+      while preserving the no-theme default output.
+- [x] 2.3 Emit run `w:color` theme attributes and cell `w:shd` theme-fill
+      attributes.
+
+## 3. Validation and tests
+
+- [x] 3.1 Validate theme slots, theme color hex values, tint/shade hex values,
+      and mutual exclusivity with existing hex fields.
+- [x] 3.2 Add `packages/docx-core/src/generation/generation-custom-theme.test.ts`
+      with `TEST_FEATURE = 'add-custom-theme'` and `.openspec` ID
+      `[SDX-GEN-107]`.
+
+## 4. Verify
+
+- [x] 4.1 Run focused package build/test, spec coverage, conformance-citation
+      check, workspace lint, and `openspec validate add-custom-theme --strict`.
+- [x] 4.2 Generate sample documents and verify theme-relative colors convert
+      through LibreOffice.

--- a/packages/docx-core/src/generation/compile.ts
+++ b/packages/docx-core/src/generation/compile.ts
@@ -27,6 +27,7 @@ import { emitSettingsPartIfNeeded } from './emit/settings-part.js';
 import { emitStylesPart } from './emit/styles-part.js';
 import { emitThemePart } from './emit/theme-part.js';
 import { emitWebSettingsPart } from './emit/web-settings-part.js';
+import { resolveThemeColorValues } from './theme-colors.js';
 import type { DocumentSpec } from './types.js';
 import { validateSpec } from './validate-spec.js';
 
@@ -44,10 +45,11 @@ export async function generateDocx(spec: DocumentSpec, opts?: GenerateDocxOption
 
   const notesEnabled = opts?.includeDraftingNotes ?? spec.options?.includeDraftingNotes ?? true;
   const ctx = new CompileContext();
+  const themeColorValues = resolveThemeColorValues(spec.theme);
   const numberingIds = emitNumberingPartIfNeeded(spec, ctx);
-  const headerFooterRefs = emitHeaderFooterParts(spec, ctx, { numberingIds });
+  const headerFooterRefs = emitHeaderFooterParts(spec, ctx, { numberingIds, themeColorValues });
   const notes = notesEnabled ? new DraftingNoteCollector() : undefined;
-  const documentPartXml = emitDocumentPart(spec, headerFooterRefs, { numberingIds, notes });
+  const documentPartXml = emitDocumentPart(spec, headerFooterRefs, { numberingIds, notes, themeColorValues });
   maybeCaptureEmittedDocumentXml(documentPartXml);
   ctx.setFileContent('word/document.xml', documentPartXml);
   if (notes) emitCommentsPartsIfNeeded(spec, ctx, notes);
@@ -56,7 +58,7 @@ export async function generateDocx(spec: DocumentSpec, opts?: GenerateDocxOption
   // Standard ancillary parts every Word-authored package carries (issue #482):
   // theme → fontTable → webSettings, ordered for stable rId allocation. Package
   // plumbing must stay last — it assembles [Content_Types].xml from the registry.
-  emitThemePart(ctx);
+  emitThemePart(ctx, spec.theme);
   emitFontTablePart(spec, ctx);
   emitWebSettingsPart(ctx);
   emitPackageParts(spec, ctx);

--- a/packages/docx-core/src/generation/emit/emit-context.ts
+++ b/packages/docx-core/src/generation/emit/emit-context.ts
@@ -7,7 +7,7 @@
  * cannot carry notes, e.g. headers/footers, and when notes are disabled).
  */
 
-import type { DraftingNoteSpec } from '../types.js';
+import type { DraftingNoteSpec, ThemeColorSlot } from '../types.js';
 
 /** Spec-level numbering handle → numeric w:numId value. */
 export type NumberingIdMap = ReadonlyMap<string, number>;
@@ -28,4 +28,6 @@ export type BlockEmitContext = {
   numberingIds?: NumberingIdMap;
   /** Present only where drafting notes may anchor (body story, notes enabled). */
   notes?: DraftingNoteCollector;
+  /** Merged canonical/custom theme colors used as reader fallback values. */
+  themeColorValues?: ReadonlyMap<ThemeColorSlot, string>;
 };

--- a/packages/docx-core/src/generation/emit/numbering-part.ts
+++ b/packages/docx-core/src/generation/emit/numbering-part.ts
@@ -21,7 +21,7 @@ import { createWmlElement } from '../../primitives/dom-helpers.js';
 import { OOXML, W } from '../../primitives/namespaces.js';
 import { parseXml, serializeXml, XML_DECL } from '../../primitives/xml.js';
 import type { CompileContext } from '../context.js';
-import type { DocumentSpec, NumberingSpec } from '../types.js';
+import type { DocumentSpec, NumberingSpec, ThemeColorSlot } from '../types.js';
 import { resolveThemeColorValues } from '../theme-colors.js';
 import type { NumberingIdMap } from './emit-context.js';
 import { buildRunPropsElement } from './properties.js';
@@ -50,9 +50,10 @@ export function emitNumberingPartIfNeeded(spec: DocumentSpec, ctx: CompileContex
   definitions.forEach((definition, index) => {
     ids.set(definition.numId, index + 1);
   });
+  const themeColorValues = resolveThemeColorValues(spec.theme);
   // CT_Numbering sequence: every abstractNum precedes every num.
   definitions.forEach((definition, index) => {
-    root.appendChild(buildAbstractNum(doc, definition, index, spec));
+    root.appendChild(buildAbstractNum(doc, definition, index, themeColorValues));
   });
   definitions.forEach((_definition, index) => {
     const num = createWmlElement(doc, W.num, { 'w:numId': String(index + 1) });
@@ -68,7 +69,12 @@ export function emitNumberingPartIfNeeded(spec: DocumentSpec, ctx: CompileContex
  * @conformance ECMA-376 edition 5, Part 1 § 17.9.12
  * @conformance ECMA-376 edition 5, Part 1 § 17.9.6
  */
-function buildAbstractNum(doc: Document, definition: NumberingSpec, abstractId: number, spec: DocumentSpec): Element {
+function buildAbstractNum(
+  doc: Document,
+  definition: NumberingSpec,
+  abstractId: number,
+  themeColorValues: ReadonlyMap<ThemeColorSlot, string>,
+): Element {
   const abstractNum = createWmlElement(doc, W.abstractNum, { 'w:abstractNumId': String(abstractId) });
   abstractNum.appendChild(
     createWmlElement(doc, W.multiLevelType, {
@@ -76,7 +82,7 @@ function buildAbstractNum(doc: Document, definition: NumberingSpec, abstractId: 
     }),
   );
   for (const level of definition.levels) {
-    abstractNum.appendChild(buildLevel(doc, level, spec));
+    abstractNum.appendChild(buildLevel(doc, level, themeColorValues));
   }
   return abstractNum;
 }
@@ -88,7 +94,11 @@ function buildAbstractNum(doc: Document, definition: NumberingSpec, abstractId: 
  * @conformance ECMA-376 edition 5, Part 1 § 17.9.11
  * @conformance ECMA-376 edition 5, Part 1 § 17.9.7
  */
-function buildLevel(doc: Document, level: NumberingSpec['levels'][number], spec: DocumentSpec): Element {
+function buildLevel(
+  doc: Document,
+  level: NumberingSpec['levels'][number],
+  themeColorValues: ReadonlyMap<ThemeColorSlot, string>,
+): Element {
   const lvl = createWmlElement(doc, W.lvl, { 'w:ilvl': String(level.ilvl) });
   lvl.appendChild(createWmlElement(doc, W.start, { 'w:val': String(level.start ?? 1) }));
   lvl.appendChild(createWmlElement(doc, W.numFmt, { 'w:val': level.numFmt }));
@@ -106,7 +116,7 @@ function buildLevel(doc: Document, level: NumberingSpec['levels'][number], spec:
     lvl.appendChild(pPr);
   }
   if (level.runProps !== undefined) {
-    const rPr = buildRunPropsElement(doc, level.runProps, { themeColorValues: resolveThemeColorValues(spec.theme) });
+    const rPr = buildRunPropsElement(doc, level.runProps, { themeColorValues });
     if (rPr) lvl.appendChild(rPr);
   }
   return lvl;

--- a/packages/docx-core/src/generation/emit/numbering-part.ts
+++ b/packages/docx-core/src/generation/emit/numbering-part.ts
@@ -22,6 +22,7 @@ import { OOXML, W } from '../../primitives/namespaces.js';
 import { parseXml, serializeXml, XML_DECL } from '../../primitives/xml.js';
 import type { CompileContext } from '../context.js';
 import type { DocumentSpec, NumberingSpec } from '../types.js';
+import { resolveThemeColorValues } from '../theme-colors.js';
 import type { NumberingIdMap } from './emit-context.js';
 import { buildRunPropsElement } from './properties.js';
 
@@ -51,7 +52,7 @@ export function emitNumberingPartIfNeeded(spec: DocumentSpec, ctx: CompileContex
   });
   // CT_Numbering sequence: every abstractNum precedes every num.
   definitions.forEach((definition, index) => {
-    root.appendChild(buildAbstractNum(doc, definition, index));
+    root.appendChild(buildAbstractNum(doc, definition, index, spec));
   });
   definitions.forEach((_definition, index) => {
     const num = createWmlElement(doc, W.num, { 'w:numId': String(index + 1) });
@@ -67,7 +68,7 @@ export function emitNumberingPartIfNeeded(spec: DocumentSpec, ctx: CompileContex
  * @conformance ECMA-376 edition 5, Part 1 § 17.9.12
  * @conformance ECMA-376 edition 5, Part 1 § 17.9.6
  */
-function buildAbstractNum(doc: Document, definition: NumberingSpec, abstractId: number): Element {
+function buildAbstractNum(doc: Document, definition: NumberingSpec, abstractId: number, spec: DocumentSpec): Element {
   const abstractNum = createWmlElement(doc, W.abstractNum, { 'w:abstractNumId': String(abstractId) });
   abstractNum.appendChild(
     createWmlElement(doc, W.multiLevelType, {
@@ -75,7 +76,7 @@ function buildAbstractNum(doc: Document, definition: NumberingSpec, abstractId: 
     }),
   );
   for (const level of definition.levels) {
-    abstractNum.appendChild(buildLevel(doc, level));
+    abstractNum.appendChild(buildLevel(doc, level, spec));
   }
   return abstractNum;
 }
@@ -87,7 +88,7 @@ function buildAbstractNum(doc: Document, definition: NumberingSpec, abstractId: 
  * @conformance ECMA-376 edition 5, Part 1 § 17.9.11
  * @conformance ECMA-376 edition 5, Part 1 § 17.9.7
  */
-function buildLevel(doc: Document, level: NumberingSpec['levels'][number]): Element {
+function buildLevel(doc: Document, level: NumberingSpec['levels'][number], spec: DocumentSpec): Element {
   const lvl = createWmlElement(doc, W.lvl, { 'w:ilvl': String(level.ilvl) });
   lvl.appendChild(createWmlElement(doc, W.start, { 'w:val': String(level.start ?? 1) }));
   lvl.appendChild(createWmlElement(doc, W.numFmt, { 'w:val': level.numFmt }));
@@ -105,7 +106,7 @@ function buildLevel(doc: Document, level: NumberingSpec['levels'][number]): Elem
     lvl.appendChild(pPr);
   }
   if (level.runProps !== undefined) {
-    const rPr = buildRunPropsElement(doc, level.runProps);
+    const rPr = buildRunPropsElement(doc, level.runProps, { themeColorValues: resolveThemeColorValues(spec.theme) });
     if (rPr) lvl.appendChild(rPr);
   }
   return lvl;

--- a/packages/docx-core/src/generation/emit/paragraph.ts
+++ b/packages/docx-core/src/generation/emit/paragraph.ts
@@ -54,7 +54,7 @@ export function buildParagraph(doc: Document, paragraph: ParagraphSpec, ctx?: Bl
     p.appendChild(createWmlElement(doc, W.commentRangeStart, { 'w:id': String(noteId) }));
   }
   for (const inline of paragraph.runs) {
-    for (const run of buildInlineRuns(doc, inline)) {
+    for (const run of buildInlineRuns(doc, inline, ctx)) {
       p.appendChild(run);
     }
   }

--- a/packages/docx-core/src/generation/emit/properties.ts
+++ b/packages/docx-core/src/generation/emit/properties.ts
@@ -8,7 +8,7 @@
 import { createWmlElement } from '../../primitives/dom-helpers.js';
 import { W } from '../../primitives/namespaces.js';
 import { appendInOrder, PPR_ORDER, RPR_ORDER } from '../ordering.js';
-import type { ParagraphSpec, RunProps, StyleSpec } from '../types.js';
+import type { ParagraphSpec, RunProps, StyleSpec, ThemeColorSlot } from '../types.js';
 
 /** Paragraph-formatting subset shared by ParagraphSpec and StyleSpec.paragraph. */
 export type ParagraphProps = Pick<
@@ -33,7 +33,11 @@ const ALIGNMENT_TO_JC: Record<NonNullable<ParagraphProps['alignment']>, string> 
  *
  * @conformance ECMA-376 edition 5, Part 1 § 17.3.2.28
  */
-export function buildRunPropsElement(doc: Document, props: RunProps): Element | null {
+export function buildRunPropsElement(
+  doc: Document,
+  props: RunProps,
+  opts?: { themeColorValues?: ReadonlyMap<ThemeColorSlot, string> },
+): Element | null {
   const children = new Map<string, Element | Element[]>();
 
   if (props.font !== undefined) {
@@ -57,8 +61,17 @@ export function buildRunPropsElement(doc: Document, props: RunProps): Element | 
   if (props.smallCaps !== undefined) {
     children.set(W.smallCaps, createWmlElement(doc, W.smallCaps, props.smallCaps ? undefined : { 'w:val': '0' }));
   }
-  if (props.colorHex !== undefined) {
-    children.set(W.color, createWmlElement(doc, W.color, { 'w:val': props.colorHex }));
+  if (props.colorHex !== undefined || props.themeColor !== undefined) {
+    const attrs: Record<string, string> = {};
+    if (props.colorHex !== undefined) attrs['w:val'] = props.colorHex;
+    if (props.themeColor !== undefined) {
+      attrs['w:themeColor'] = props.themeColor;
+      const fallback = opts?.themeColorValues?.get(props.themeColor);
+      if (fallback !== undefined && attrs['w:val'] === undefined) attrs['w:val'] = fallback;
+    }
+    if (props.themeTint !== undefined) attrs['w:themeTint'] = props.themeTint;
+    if (props.themeShade !== undefined) attrs['w:themeShade'] = props.themeShade;
+    children.set(W.color, createWmlElement(doc, W.color, attrs));
   }
   if (props.sizePt !== undefined) {
     const halfPoints = String(Math.round(props.sizePt * 2));

--- a/packages/docx-core/src/generation/emit/run.ts
+++ b/packages/docx-core/src/generation/emit/run.ts
@@ -14,6 +14,7 @@ import { createWmlElement, createWmlTextElement } from '../../primitives/dom-hel
 import { W } from '../../primitives/namespaces.js';
 import { GenerationInternalError } from '../errors.js';
 import type { FieldSpec, InlineSpec, RunProps } from '../types.js';
+import type { BlockEmitContext } from './emit-context.js';
 import { buildRunPropsElement } from './properties.js';
 
 /** Instruction text per field, with the canonical surrounding spaces. */
@@ -22,9 +23,9 @@ const FIELD_INSTRUCTION_TEXT: Record<FieldSpec['field'], string> = {
   NUMPAGES: ' NUMPAGES ',
 };
 
-function makeRun(doc: Document, props: RunProps, ...children: Element[]): Element {
+function makeRun(doc: Document, props: RunProps, ctx: BlockEmitContext | undefined, ...children: Element[]): Element {
   const run = createWmlElement(doc, W.r);
-  const rPr = buildRunPropsElement(doc, props);
+  const rPr = buildRunPropsElement(doc, props, { themeColorValues: ctx?.themeColorValues });
   if (rPr) run.appendChild(rPr);
   for (const child of children) run.appendChild(child);
   return run;
@@ -36,37 +37,37 @@ function makeRun(doc: Document, props: RunProps, ...children: Element[]): Elemen
  *
  * @conformance ECMA-376 edition 5, Part 1 § 17.16.18
  */
-function buildFieldRuns(doc: Document, field: FieldSpec): Element[] {
+function buildFieldRuns(doc: Document, field: FieldSpec, ctx?: BlockEmitContext): Element[] {
   const instr = createWmlElement(doc, W.instrText);
   instr.setAttribute('xml:space', 'preserve');
   instr.appendChild(doc.createTextNode(FIELD_INSTRUCTION_TEXT[field.field]));
 
   return [
-    makeRun(doc, field, createWmlElement(doc, W.fldChar, { 'w:fldCharType': 'begin' })),
-    makeRun(doc, field, instr),
-    makeRun(doc, field, createWmlElement(doc, W.fldChar, { 'w:fldCharType': 'separate' })),
-    makeRun(doc, field, createWmlTextElement(doc, field.cachedResult)),
-    makeRun(doc, field, createWmlElement(doc, W.fldChar, { 'w:fldCharType': 'end' })),
+    makeRun(doc, field, ctx, createWmlElement(doc, W.fldChar, { 'w:fldCharType': 'begin' })),
+    makeRun(doc, field, ctx, instr),
+    makeRun(doc, field, ctx, createWmlElement(doc, W.fldChar, { 'w:fldCharType': 'separate' })),
+    makeRun(doc, field, ctx, createWmlTextElement(doc, field.cachedResult)),
+    makeRun(doc, field, ctx, createWmlElement(doc, W.fldChar, { 'w:fldCharType': 'end' })),
   ];
 }
 
 /** Build the w:r element(s) for one inline spec node. */
-export function buildInlineRuns(doc: Document, inline: InlineSpec): Element[] {
+export function buildInlineRuns(doc: Document, inline: InlineSpec, ctx?: BlockEmitContext): Element[] {
   switch (inline.kind) {
     case 'text': {
       const run = createWmlElement(doc, W.r);
-      const rPr = buildRunPropsElement(doc, inline);
+      const rPr = buildRunPropsElement(doc, inline, { themeColorValues: ctx?.themeColorValues });
       if (rPr) run.appendChild(rPr);
       run.appendChild(createWmlTextElement(doc, inline.text));
       return [run];
     }
     case 'field':
-      return buildFieldRuns(doc, inline);
+      return buildFieldRuns(doc, inline, ctx);
     case 'tab':
-      return [makeRun(doc, {}, createWmlElement(doc, W.tab))];
+      return [makeRun(doc, {}, ctx, createWmlElement(doc, W.tab))];
     case 'break': {
       const attrs = inline.breakType === 'page' ? { 'w:type': 'page' } : undefined;
-      return [makeRun(doc, {}, createWmlElement(doc, W.br, attrs))];
+      return [makeRun(doc, {}, ctx, createWmlElement(doc, W.br, attrs))];
     }
     default:
       throw new GenerationInternalError(

--- a/packages/docx-core/src/generation/emit/settings-part.ts
+++ b/packages/docx-core/src/generation/emit/settings-part.ts
@@ -1,9 +1,9 @@
 /**
  * word/settings.xml emitter.
  *
- * Only emitted when the document actually needs a setting — today that is
- * `w:evenAndOddHeaders`, required for any section declaring an even-page
- * header or footer (without it readers ignore the even-page parts entirely).
+ * Only emitted when the document actually needs a setting: `w:evenAndOddHeaders`
+ * for any section declaring an even-page header or footer, or
+ * `w:clrSchemeMapping` when theme-relative authoring or a custom theme is used.
  *
  * @conformance ECMA-376 edition 5, Part 1 § 17.10.1
  */
@@ -12,17 +12,64 @@ import { createWmlElement } from '../../primitives/dom-helpers.js';
 import { OOXML, W } from '../../primitives/namespaces.js';
 import { parseXml, serializeXml, XML_DECL } from '../../primitives/xml.js';
 import type { CompileContext } from '../context.js';
-import type { DocumentSpec } from '../types.js';
+import type { BlockSpec, DocumentSpec, InlineSpec, TableCellSpec } from '../types.js';
 
 const SETTINGS_CONTENT_TYPE = 'application/vnd.openxmlformats-officedocument.wordprocessingml.settings+xml';
 const SETTINGS_REL_TYPE = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/settings';
 
 export function emitSettingsPartIfNeeded(spec: DocumentSpec, ctx: CompileContext): void {
   const needsEvenOdd = spec.sections.some((s) => s.headers?.even || s.footers?.even);
-  if (!needsEvenOdd) return;
+  const needsColorSchemeMapping = spec.theme !== undefined || usesThemeRelativeAuthoring(spec);
+  if (!needsEvenOdd && !needsColorSchemeMapping) return;
 
   ctx.registerPart('word/settings.xml', SETTINGS_CONTENT_TYPE, SETTINGS_REL_TYPE);
   const doc = parseXml(`<w:settings xmlns:w="${OOXML.W_NS}"/>`);
-  doc.documentElement!.appendChild(createWmlElement(doc, W.evenAndOddHeaders));
+  if (needsEvenOdd) {
+    doc.documentElement!.appendChild(createWmlElement(doc, W.evenAndOddHeaders));
+  }
+  if (needsColorSchemeMapping) {
+    doc.documentElement!.appendChild(
+      createWmlElement(doc, W.clrSchemeMapping, {
+        'w:bg1': 'light1',
+        'w:t1': 'dark1',
+        'w:bg2': 'light2',
+        'w:t2': 'dark2',
+        'w:accent1': 'accent1',
+        'w:accent2': 'accent2',
+        'w:accent3': 'accent3',
+        'w:accent4': 'accent4',
+        'w:accent5': 'accent5',
+        'w:accent6': 'accent6',
+        'w:hyperlink': 'hyperlink',
+        'w:followedHyperlink': 'followedHyperlink',
+      }),
+    );
+  }
   ctx.setFileContent('word/settings.xml', XML_DECL + serializeXml(doc));
+}
+
+function usesThemeRelativeAuthoring(spec: DocumentSpec): boolean {
+  if (spec.styles?.some((style) => style.run?.themeColor !== undefined)) return true;
+  if (spec.numbering?.some((numbering) => numbering.levels.some((level) => level.runProps?.themeColor !== undefined))) return true;
+  return spec.sections.some((section) => {
+    const blocks = [
+      ...section.blocks,
+      ...Object.values(section.headers ?? {}).flatMap((story) => story?.blocks ?? []),
+      ...Object.values(section.footers ?? {}).flatMap((story) => story?.blocks ?? []),
+    ];
+    return blocks.some(blockUsesThemeRelativeAuthoring);
+  });
+}
+
+function blockUsesThemeRelativeAuthoring(block: BlockSpec): boolean {
+  if (block.kind === 'paragraph') return block.runs.some(inlineUsesThemeRelativeAuthoring);
+  return block.rows.some((row) => row.cells.some(cellUsesThemeRelativeAuthoring));
+}
+
+function inlineUsesThemeRelativeAuthoring(inline: InlineSpec): boolean {
+  return (inline.kind === 'text' || inline.kind === 'field') && inline.themeColor !== undefined;
+}
+
+function cellUsesThemeRelativeAuthoring(cell: TableCellSpec): boolean {
+  return cell.themeFill !== undefined || cell.blocks.some(blockUsesThemeRelativeAuthoring);
 }

--- a/packages/docx-core/src/generation/emit/styles-part.ts
+++ b/packages/docx-core/src/generation/emit/styles-part.ts
@@ -14,6 +14,7 @@ import { OOXML, W } from '../../primitives/namespaces.js';
 import { parseXml, serializeXml, XML_DECL } from '../../primitives/xml.js';
 import type { CompileContext } from '../context.js';
 import type { DocumentSpec, StyleSpec } from '../types.js';
+import { resolveThemeColorValues } from '../theme-colors.js';
 import { buildParagraphPropsElement, buildRunPropsElement, styleParagraphProps } from './properties.js';
 
 export const STYLES_CONTENT_TYPE = 'application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml';
@@ -34,7 +35,7 @@ export function emitStylesPart(spec: DocumentSpec, ctx: CompileContext): void {
   root.appendChild(buildDocDefaults(doc));
   root.appendChild(buildNormalStyle(doc));
   for (const style of spec.styles ?? []) {
-    root.appendChild(buildStyle(doc, style));
+    root.appendChild(buildStyle(doc, style, spec));
   }
 
   ctx.setFileContent('word/styles.xml', XML_DECL + serializeXml(doc));
@@ -70,7 +71,7 @@ function buildNormalStyle(doc: Document): Element {
 }
 
 /** @conformance ECMA-376 edition 5, Part 1 § 17.7.4.17 */
-function buildStyle(doc: Document, spec: StyleSpec): Element {
+function buildStyle(doc: Document, spec: StyleSpec, documentSpec: DocumentSpec): Element {
   const style = createWmlElement(doc, W.style, { 'w:type': spec.type, 'w:styleId': spec.styleId });
   style.appendChild(createWmlElement(doc, W.name, { 'w:val': spec.name }));
   if (spec.basedOn !== undefined) {
@@ -87,7 +88,7 @@ function buildStyle(doc: Document, spec: StyleSpec): Element {
     if (pPr) style.appendChild(pPr);
   }
   if (spec.run) {
-    const rPr = buildRunPropsElement(doc, spec.run);
+    const rPr = buildRunPropsElement(doc, spec.run, { themeColorValues: resolveThemeColorValues(documentSpec.theme) });
     if (rPr) style.appendChild(rPr);
   }
   return style;

--- a/packages/docx-core/src/generation/emit/styles-part.ts
+++ b/packages/docx-core/src/generation/emit/styles-part.ts
@@ -13,7 +13,7 @@ import { createWmlElement } from '../../primitives/dom-helpers.js';
 import { OOXML, W } from '../../primitives/namespaces.js';
 import { parseXml, serializeXml, XML_DECL } from '../../primitives/xml.js';
 import type { CompileContext } from '../context.js';
-import type { DocumentSpec, StyleSpec } from '../types.js';
+import type { DocumentSpec, StyleSpec, ThemeColorSlot } from '../types.js';
 import { resolveThemeColorValues } from '../theme-colors.js';
 import { buildParagraphPropsElement, buildRunPropsElement, styleParagraphProps } from './properties.js';
 
@@ -32,10 +32,11 @@ export function emitStylesPart(spec: DocumentSpec, ctx: CompileContext): void {
   const doc = parseXml(STYLES_SKELETON);
   const root = doc.documentElement!;
 
+  const themeColorValues = resolveThemeColorValues(spec.theme);
   root.appendChild(buildDocDefaults(doc));
   root.appendChild(buildNormalStyle(doc));
   for (const style of spec.styles ?? []) {
-    root.appendChild(buildStyle(doc, style, spec));
+    root.appendChild(buildStyle(doc, style, themeColorValues));
   }
 
   ctx.setFileContent('word/styles.xml', XML_DECL + serializeXml(doc));
@@ -71,7 +72,11 @@ function buildNormalStyle(doc: Document): Element {
 }
 
 /** @conformance ECMA-376 edition 5, Part 1 § 17.7.4.17 */
-function buildStyle(doc: Document, spec: StyleSpec, documentSpec: DocumentSpec): Element {
+function buildStyle(
+  doc: Document,
+  spec: StyleSpec,
+  themeColorValues: ReadonlyMap<ThemeColorSlot, string>,
+): Element {
   const style = createWmlElement(doc, W.style, { 'w:type': spec.type, 'w:styleId': spec.styleId });
   style.appendChild(createWmlElement(doc, W.name, { 'w:val': spec.name }));
   if (spec.basedOn !== undefined) {
@@ -88,7 +93,7 @@ function buildStyle(doc: Document, spec: StyleSpec, documentSpec: DocumentSpec):
     if (pPr) style.appendChild(pPr);
   }
   if (spec.run) {
-    const rPr = buildRunPropsElement(doc, spec.run, { themeColorValues: resolveThemeColorValues(documentSpec.theme) });
+    const rPr = buildRunPropsElement(doc, spec.run, { themeColorValues });
     if (rPr) style.appendChild(rPr);
   }
   return style;

--- a/packages/docx-core/src/generation/emit/table.ts
+++ b/packages/docx-core/src/generation/emit/table.ts
@@ -141,8 +141,17 @@ function buildCell(doc: Document, table: TableSpec, cell: TableCellSpec, gridOff
   if (cell.borders) {
     props.set(W.tcBorders, buildBordersElement(doc, W.tcBorders, cell.borders));
   }
-  if (cell.shadingHex !== undefined) {
-    props.set(W.shd, createWmlElement(doc, W.shd, { 'w:val': 'clear', 'w:color': 'auto', 'w:fill': cell.shadingHex }));
+  if (cell.shadingHex !== undefined || cell.themeFill !== undefined) {
+    const attrs: Record<string, string> = { 'w:val': 'clear', 'w:color': 'auto' };
+    if (cell.shadingHex !== undefined) attrs['w:fill'] = cell.shadingHex;
+    if (cell.themeFill !== undefined) {
+      attrs['w:themeFill'] = cell.themeFill;
+      const fallback = ctx?.themeColorValues?.get(cell.themeFill);
+      if (fallback !== undefined && attrs['w:fill'] === undefined) attrs['w:fill'] = fallback;
+    }
+    if (cell.themeFillTint !== undefined) attrs['w:themeFillTint'] = cell.themeFillTint;
+    if (cell.themeFillShade !== undefined) attrs['w:themeFillShade'] = cell.themeFillShade;
+    props.set(W.shd, createWmlElement(doc, W.shd, attrs));
   }
   if (cell.marginsTwips) {
     props.set(W.tcMar, buildCellMargins(doc, cell.marginsTwips));

--- a/packages/docx-core/src/generation/emit/theme-part.ts
+++ b/packages/docx-core/src/generation/emit/theme-part.ts
@@ -10,18 +10,34 @@
  * determinism holds.
  *
  * The root is the DrawingML `a:theme` element carrying themeElements
- * (clrScheme + fontScheme + fmtScheme) — package plumbing, like package-parts.ts,
- * rather than a WordprocessingML content emitter.
+ * (clrScheme + fontScheme + fmtScheme). Optional generation theme input applies
+ * partial color/font overrides to that canonical template before serialization.
  */
 
 import { parseXml, serializeXml, XML_DECL } from '../../primitives/xml.js';
 import type { CompileContext } from '../context.js';
+import type { DocumentThemeSpec, ThemeColorSlot } from '../types.js';
 
 const THEME_CONTENT_TYPE = 'application/vnd.openxmlformats-officedocument.theme+xml';
 const THEME_REL_TYPE =
   'http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme';
 
 const A_NS = 'http://schemas.openxmlformats.org/drawingml/2006/main';
+
+const THEME_SLOT_TO_CLR_SCHEME: Record<ThemeColorSlot, string> = {
+  text1: 'dk1',
+  background1: 'lt1',
+  text2: 'dk2',
+  background2: 'lt2',
+  accent1: 'accent1',
+  accent2: 'accent2',
+  accent3: 'accent3',
+  accent4: 'accent4',
+  accent5: 'accent5',
+  accent6: 'accent6',
+  hyperlink: 'hlink',
+  followedHyperlink: 'folHlink',
+};
 
 /** The canonical Office default theme (clrScheme + fontScheme + full fmtScheme). */
 const THEME1_XML =
@@ -101,9 +117,44 @@ const THEME1_XML =
   '<a:extraClrSchemeLst/>' +
   '</a:theme>';
 
-export function emitThemePart(ctx: CompileContext): void {
+export function emitThemePart(ctx: CompileContext, theme?: DocumentThemeSpec): void {
   ctx.registerPart('word/theme/theme1.xml', THEME_CONTENT_TYPE, THEME_REL_TYPE);
   // Parse + reserialize: normalizes output and fails loudly if the static body is
-  // ever edited into malformed XML.
-  ctx.setFileContent('word/theme/theme1.xml', XML_DECL + serializeXml(parseXml(THEME1_XML)));
+  // ever edited into malformed XML. Theme overrides mutate that parsed template
+  // so callers get the complete Office fmtScheme with only requested changes.
+  const doc = parseXml(THEME1_XML);
+  applyThemeOverrides(doc, theme);
+  ctx.setFileContent('word/theme/theme1.xml', XML_DECL + serializeXml(doc));
+}
+
+function applyThemeOverrides(doc: Document, theme?: DocumentThemeSpec): void {
+  if (!theme) return;
+
+  for (const [slot, hex] of Object.entries(theme.colors ?? {}) as Array<[ThemeColorSlot, string]>) {
+    replaceSchemeColor(doc, slot, hex);
+  }
+  if (theme.fonts?.major !== undefined) {
+    setLatinTypeface(doc, 'a:majorFont', theme.fonts.major);
+  }
+  if (theme.fonts?.minor !== undefined) {
+    setLatinTypeface(doc, 'a:minorFont', theme.fonts.minor);
+  }
+}
+
+function replaceSchemeColor(doc: Document, slot: ThemeColorSlot, hex: string): void {
+  const elementName = THEME_SLOT_TO_CLR_SCHEME[slot];
+  const schemeEl = doc.getElementsByTagName(`a:${elementName}`).item(0);
+  if (!schemeEl) throw new Error(`theme clrScheme is missing a:${elementName}`);
+
+  while (schemeEl.firstChild) schemeEl.removeChild(schemeEl.firstChild);
+  const srgb = doc.createElementNS(A_NS, 'a:srgbClr');
+  srgb.setAttribute('val', hex);
+  schemeEl.appendChild(srgb);
+}
+
+function setLatinTypeface(doc: Document, fontElementName: 'a:majorFont' | 'a:minorFont', typeface: string): void {
+  const fontEl = doc.getElementsByTagName(fontElementName).item(0);
+  const latin = fontEl?.getElementsByTagName('a:latin').item(0);
+  if (!latin) throw new Error(`theme fontScheme is missing ${fontElementName}/a:latin`);
+  latin.setAttribute('typeface', typeface);
 }

--- a/packages/docx-core/src/generation/emit/theme-part.ts
+++ b/packages/docx-core/src/generation/emit/theme-part.ts
@@ -24,7 +24,8 @@ const THEME_REL_TYPE =
 
 const A_NS = 'http://schemas.openxmlformats.org/drawingml/2006/main';
 
-const THEME_SLOT_TO_CLR_SCHEME: Record<ThemeColorSlot, string> = {
+/** Maps each authoring slot to its `clrScheme` child element name in theme1.xml. */
+export const THEME_SLOT_TO_CLR_SCHEME: Record<ThemeColorSlot, string> = {
   text1: 'dk1',
   background1: 'lt1',
   text2: 'dk2',

--- a/packages/docx-core/src/generation/generation-custom-theme.test.ts
+++ b/packages/docx-core/src/generation/generation-custom-theme.test.ts
@@ -2,8 +2,10 @@ import { describe, expect } from 'vitest';
 import { childElements } from '../primitives/dom-helpers.js';
 import { parseXml } from '../primitives/xml.js';
 import { readZipText } from '../primitives/zip.js';
-import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { itAllure, testAllure, type AllureBddContext } from '../testing/allure-test.js';
 import { generateDocx } from './compile.js';
+import { THEME_SLOT_TO_CLR_SCHEME } from './emit/theme-part.js';
+import { CANONICAL_THEME_COLORS } from './theme-colors.js';
 import type { DocumentSpec, ThemeColorSlot } from './types.js';
 
 const TEST_FEATURE = 'add-custom-theme';
@@ -185,4 +187,25 @@ describe('Traceability: custom theme generation', () => {
       });
     },
   );
+
+  // Regression guard: CANONICAL_THEME_COLORS (used to derive the w:color/@w:val
+  // fallback for theme-relative authoring) and the clrScheme baked into the
+  // emitted default theme1.xml are two declarations of the same palette. If they
+  // drift, a themed run's fallback hex would disagree with the theme it points at.
+  // Lock them to the actually-emitted default theme.
+  itAllure('canonical theme color fallbacks match the emitted default theme1.xml', async () => {
+    const theme = await readPartDom(
+      await generateDocx({ sections: [{ blocks: [{ kind: 'paragraph', runs: [{ kind: 'text', text: 'plain' }] }] }] }),
+      'word/theme/theme1.xml',
+    );
+    for (const [slot, elementName] of Object.entries(THEME_SLOT_TO_CLR_SCHEME) as Array<[ThemeColorSlot, string]>) {
+      const schemeEl = theme.getElementsByTagName(`a:${elementName}`).item(0);
+      expect(schemeEl, `theme1.xml clrScheme missing a:${elementName}`).toBeTruthy();
+      const colorEl = firstChildElement(schemeEl!);
+      // Canonical dk1/lt1 use sysClr (val=windowText/window, lastClr=hex); other
+      // slots use srgbClr (val=hex). Read whichever carries the resolved hex.
+      const emittedHex = colorEl.tagName === 'a:sysClr' ? colorEl.getAttribute('lastClr') : colorEl.getAttribute('val');
+      expect(emittedHex, `mismatch for slot ${slot} (a:${elementName})`).toBe(CANONICAL_THEME_COLORS[slot]);
+    }
+  });
 });

--- a/packages/docx-core/src/generation/generation-custom-theme.test.ts
+++ b/packages/docx-core/src/generation/generation-custom-theme.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect } from 'vitest';
+import { childElements } from '../primitives/dom-helpers.js';
+import { parseXml } from '../primitives/xml.js';
+import { readZipText } from '../primitives/zip.js';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { generateDocx } from './compile.js';
+import type { DocumentSpec, ThemeColorSlot } from './types.js';
+
+const TEST_FEATURE = 'add-custom-theme';
+const test = testAllure.epic('Document Generation').withLabels({ feature: TEST_FEATURE });
+
+function themedSpec(): DocumentSpec {
+  return {
+    theme: {
+      colors: {
+        accent1: '117086',
+        text1: '222222',
+      },
+      fonts: {
+        major: 'Aptos Display',
+        minor: 'Aptos',
+      },
+    },
+    sections: [
+      {
+        blocks: [
+          {
+            kind: 'paragraph',
+            runs: [{ kind: 'text', text: 'BRAND', themeColor: 'accent1', themeTint: '99', themeShade: '33' }],
+          },
+          {
+            kind: 'table',
+            columnWidthsTwips: [4320],
+            rows: [
+              {
+                cells: [
+                  {
+                    themeFill: 'accent1',
+                    themeFillTint: '66',
+                    themeFillShade: '22',
+                    blocks: [{ kind: 'paragraph', runs: [{ kind: 'text', text: 'cell' }] }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+async function readPartDom(buffer: Buffer, path: string): Promise<Document> {
+  const xml = await readZipText(buffer, path);
+  expect(xml, `${path} missing from package`).not.toBeNull();
+  return parseXml(xml!);
+}
+
+function firstChildElement(el: Element): Element {
+  const child = childElements(el)[0];
+  expect(child).toBeTruthy();
+  return child!;
+}
+
+describe('Traceability: custom theme generation', () => {
+  test.openspec('[SDX-GEN-107] custom theme slots drive theme-relative authoring')(
+    'Scenario: custom theme slots drive theme-relative authoring',
+    async ({ given, when, then, attachPrettyXml }: AllureBddContext) => {
+      let buffer!: Buffer;
+      await given('a spec with custom theme colors and theme-relative run and cell colors', async () => {
+        buffer = await generateDocx(themedSpec());
+      });
+
+      let theme!: Document;
+      let document!: Document;
+      await when('the generated theme and document parts are parsed', async () => {
+        const themeXml = (await readZipText(buffer, 'word/theme/theme1.xml'))!;
+        const documentXml = (await readZipText(buffer, 'word/document.xml'))!;
+        await attachPrettyXml('word/theme/theme1.xml', themeXml);
+        await attachPrettyXml('word/document.xml', documentXml);
+        theme = parseXml(themeXml);
+        document = parseXml(documentXml);
+      });
+
+      await then('custom theme slots and fonts are emitted into theme1.xml', async () => {
+        expect(firstChildElement(theme.getElementsByTagName('a:accent1').item(0)!).tagName).toBe('a:srgbClr');
+        expect(firstChildElement(theme.getElementsByTagName('a:accent1').item(0)!).getAttribute('val')).toBe('117086');
+        expect(firstChildElement(theme.getElementsByTagName('a:dk1').item(0)!).tagName).toBe('a:srgbClr');
+        expect(firstChildElement(theme.getElementsByTagName('a:dk1').item(0)!).getAttribute('val')).toBe('222222');
+        expect(theme.getElementsByTagName('a:majorFont').item(0)!.getElementsByTagName('a:latin').item(0)!.getAttribute('typeface')).toBe(
+          'Aptos Display',
+        );
+        expect(theme.getElementsByTagName('a:minorFont').item(0)!.getElementsByTagName('a:latin').item(0)!.getAttribute('typeface')).toBe('Aptos');
+      });
+
+      await then('run theme color attributes are emitted on w:color', async () => {
+        const color = document.getElementsByTagName('w:color').item(0)!;
+        expect(color.getAttribute('w:themeColor')).toBe('accent1');
+        expect(color.getAttribute('w:val')).toBe('117086');
+        expect(color.getAttribute('w:themeTint')).toBe('99');
+        expect(color.getAttribute('w:themeShade')).toBe('33');
+      });
+
+      await then('cell theme fill attributes are emitted on w:shd', async () => {
+        const shd = document.getElementsByTagName('w:shd').item(0)!;
+        expect(shd.getAttribute('w:themeFill')).toBe('accent1');
+        expect(shd.getAttribute('w:fill')).toBe('117086');
+        expect(shd.getAttribute('w:themeFillTint')).toBe('66');
+        expect(shd.getAttribute('w:themeFillShade')).toBe('22');
+      });
+
+      await then('the default theme remains canonical when no custom theme is supplied', async () => {
+        const defaultTheme = await readPartDom(
+          await generateDocx({
+            sections: [{ blocks: [{ kind: 'paragraph', runs: [{ kind: 'text', text: 'plain' }] }] }],
+          }),
+          'word/theme/theme1.xml',
+        );
+        expect(firstChildElement(defaultTheme.getElementsByTagName('a:accent1').item(0)!).getAttribute('val')).toBe('4472C4');
+      });
+
+      await then('invalid theme slots and mixed literal/theme colors are rejected', async () => {
+        await expect(
+          generateDocx({
+            theme: { colors: { notASlot: '117086' } as unknown as Partial<Record<ThemeColorSlot, string>> },
+            sections: [{ blocks: [{ kind: 'paragraph', runs: [{ kind: 'text', text: 'x' }] }] }],
+          }),
+        ).rejects.toThrow(/theme color slot must be one of/);
+
+        await expect(
+          generateDocx({
+            sections: [
+              {
+                blocks: [
+                  {
+                    kind: 'paragraph',
+                    runs: [{ kind: 'text', text: 'x', colorHex: '000000', themeColor: 'accent1' }],
+                  },
+                ],
+              },
+            ],
+          }),
+        ).rejects.toThrow(/themeColor cannot be set/);
+
+        await expect(
+          generateDocx({
+            sections: [
+              {
+                blocks: [
+                  {
+                    kind: 'paragraph',
+                    runs: [{ kind: 'text', text: 'x', themeColor: 'notASlot' as ThemeColorSlot }],
+                  },
+                ],
+              },
+            ],
+          }),
+        ).rejects.toThrow(/themeColor must be one of/);
+
+        await expect(
+          generateDocx({
+            sections: [
+              {
+                blocks: [
+                  {
+                    kind: 'table',
+                    columnWidthsTwips: [1440],
+                    rows: [
+                      {
+                        cells: [
+                          {
+                            shadingHex: 'FFFFFF',
+                            themeFill: 'accent1',
+                            blocks: [{ kind: 'paragraph', runs: [] }],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          }),
+        ).rejects.toThrow(/themeFill cannot be set/);
+      });
+    },
+  );
+});

--- a/packages/docx-core/src/generation/theme-colors.ts
+++ b/packages/docx-core/src/generation/theme-colors.ts
@@ -1,0 +1,20 @@
+import type { DocumentThemeSpec, ThemeColorSlot } from './types.js';
+
+export const CANONICAL_THEME_COLORS: Record<ThemeColorSlot, string> = {
+  text1: '000000',
+  background1: 'FFFFFF',
+  text2: '44546A',
+  background2: 'E7E6E6',
+  accent1: '4472C4',
+  accent2: 'ED7D31',
+  accent3: 'A5A5A5',
+  accent4: 'FFC000',
+  accent5: '5B9BD5',
+  accent6: '70AD47',
+  hyperlink: '0563C1',
+  followedHyperlink: '954F72',
+};
+
+export function resolveThemeColorValues(theme?: DocumentThemeSpec): ReadonlyMap<ThemeColorSlot, string> {
+  return new Map(Object.entries({ ...CANONICAL_THEME_COLORS, ...(theme?.colors ?? {}) }) as Array<[ThemeColorSlot, string]>);
+}

--- a/packages/docx-core/src/generation/types.ts
+++ b/packages/docx-core/src/generation/types.ts
@@ -15,6 +15,8 @@
 
 export type DocumentSpec = {
   meta?: DocumentMetaSpec;
+  /** Optional partial override for the emitted package theme. */
+  theme?: DocumentThemeSpec;
   /** Emitted to word/styles.xml. Document defaults + Normal are always emitted. */
   styles?: StyleSpec[];
   /** Emitted to word/numbering.xml when non-empty. */
@@ -32,6 +34,30 @@ export type DocumentMetaSpec = {
   author?: string;
   /** ISO-8601 timestamp used for docProps dates. Generation never reads the clock. */
   createdIso?: string;
+};
+
+export const THEME_COLOR_SLOTS = [
+  'text1',
+  'background1',
+  'text2',
+  'background2',
+  'accent1',
+  'accent2',
+  'accent3',
+  'accent4',
+  'accent5',
+  'accent6',
+  'hyperlink',
+  'followedHyperlink',
+] as const;
+
+export type ThemeColorSlot = (typeof THEME_COLOR_SLOTS)[number];
+
+export type DocumentThemeSpec = {
+  /** Partial slot overrides; values are six-digit hex without '#'. */
+  colors?: Partial<Record<ThemeColorSlot, string>>;
+  /** Optional major (headings) and minor (body) latin typefaces. */
+  fonts?: { major?: string; minor?: string };
 };
 
 export type SectionSpec = {
@@ -140,6 +166,12 @@ export type RunProps = {
   underline?: 'single' | 'double' | 'none';
   /** Six-digit hex without '#', e.g. 'FF0000'. */
   colorHex?: string;
+  /** Theme color slot emitted as w:color/@w:themeColor. */
+  themeColor?: ThemeColorSlot;
+  /** Two-digit hex tint emitted as w:color/@w:themeTint. */
+  themeTint?: string;
+  /** Two-digit hex shade emitted as w:color/@w:themeShade. */
+  themeShade?: string;
   /** Fixed text highlight color; arbitrary run fill belongs to run shading. */
   highlight?: HighlightColor;
   /** Applied to ascii + hAnsi + cs so all script ranges agree. */
@@ -205,6 +237,9 @@ export type TableCellSpec = {
   vMerge?: 'restart' | 'continue';
   borders?: TableBorders;
   shadingHex?: string;
+  themeFill?: ThemeColorSlot;
+  themeFillTint?: string;
+  themeFillShade?: string;
   vAlign?: 'top' | 'center' | 'bottom';
   marginsTwips?: { top?: number; right?: number; bottom?: number; left?: number };
   blocks: BlockSpec[];

--- a/packages/docx-core/src/generation/validate-spec.ts
+++ b/packages/docx-core/src/generation/validate-spec.ts
@@ -37,10 +37,12 @@ import type {
   TableBorders,
   TableSpec,
 } from './types.js';
-import { HIGHLIGHT_COLORS } from './types.js';
+import { HIGHLIGHT_COLORS, THEME_COLOR_SLOTS } from './types.js';
 
 const COLOR_HEX_RE = /^[0-9A-Fa-f]{6}$/;
+const TWO_HEX_RE = /^[0-9A-Fa-f]{2}$/;
 const HIGHLIGHT_COLOR_SET: ReadonlySet<string> = new Set(HIGHLIGHT_COLORS);
+const THEME_COLOR_SLOT_SET: ReadonlySet<string> = new Set(THEME_COLOR_SLOTS);
 
 function unsupported(path: string, feature: string): never {
   throw new GenerationSpecError(
@@ -56,12 +58,25 @@ export function validateSpec(spec: DocumentSpec): void {
     throw new GenerationSpecError('empty_sections', '/sections', 'DocumentSpec.sections must contain at least one section');
   }
 
+  validateTheme(spec);
   const declaredStyleIds = validateStyles(spec.styles ?? []);
   const numbering = validateNumbering(spec.numbering ?? []);
 
   spec.sections.forEach((section, sectionIndex) => {
     validateSection(section, `/sections/${sectionIndex}`, declaredStyleIds, numbering);
   });
+}
+
+function validateTheme(spec: DocumentSpec): void {
+  if (!spec.theme?.colors) return;
+  for (const [slot, hex] of Object.entries(spec.theme.colors)) {
+    if (!THEME_COLOR_SLOT_SET.has(slot)) {
+      throw new GenerationSpecError('invalid_value', `/theme/colors/${slot}`, `theme color slot must be one of the supported theme slots, got '${slot}'`);
+    }
+    if (typeof hex !== 'string' || !COLOR_HEX_RE.test(hex)) {
+      throw new GenerationSpecError('invalid_value', `/theme/colors/${slot}`, `theme color value must be six hex digits without '#', got '${hex}'`);
+    }
+  }
 }
 
 /** Returns numId handle → set of declared levels, for list-reference checks. */
@@ -251,6 +266,17 @@ function validateTable(table: TableSpec, path: string, styleIds: Set<string>, nu
       if (cell.shadingHex !== undefined && !COLOR_HEX_RE.test(cell.shadingHex)) {
         throw new GenerationSpecError('invalid_value', `${cellPath}/shadingHex`, `shadingHex must be six hex digits without '#', got '${cell.shadingHex}'`);
       }
+      if (cell.themeFill !== undefined) {
+        validateThemeColorSlot(cell.themeFill, `${cellPath}/themeFill`, 'themeFill');
+      }
+      if (cell.shadingHex !== undefined && cell.themeFill !== undefined) {
+        throw new GenerationSpecError('invalid_value', `${cellPath}/themeFill`, 'themeFill cannot be set when shadingHex is also set');
+      }
+      validateOptionalTwoHex(cell.themeFillTint, `${cellPath}/themeFillTint`, 'themeFillTint');
+      validateOptionalTwoHex(cell.themeFillShade, `${cellPath}/themeFillShade`, 'themeFillShade');
+      if ((cell.themeFillTint !== undefined || cell.themeFillShade !== undefined) && cell.themeFill === undefined) {
+        throw new GenerationSpecError('invalid_value', `${cellPath}/themeFill`, 'themeFill is required when themeFillTint or themeFillShade is set');
+      }
       if (cell.marginsTwips) {
         for (const [key, value] of Object.entries(cell.marginsTwips)) {
           if (value !== undefined && (typeof value !== 'number' || value < 0 || !Number.isFinite(value))) {
@@ -378,6 +404,17 @@ function validateRunProps(props: RunProps, path: string): void {
   if (props.colorHex !== undefined && !COLOR_HEX_RE.test(props.colorHex)) {
     throw new GenerationSpecError('invalid_value', `${path}/colorHex`, `colorHex must be six hex digits without '#', got '${props.colorHex}'`);
   }
+  if (props.themeColor !== undefined) {
+    validateThemeColorSlot(props.themeColor, `${path}/themeColor`, 'themeColor');
+  }
+  if (props.colorHex !== undefined && props.themeColor !== undefined) {
+    throw new GenerationSpecError('invalid_value', `${path}/themeColor`, 'themeColor cannot be set when colorHex is also set');
+  }
+  validateOptionalTwoHex(props.themeTint, `${path}/themeTint`, 'themeTint');
+  validateOptionalTwoHex(props.themeShade, `${path}/themeShade`, 'themeShade');
+  if ((props.themeTint !== undefined || props.themeShade !== undefined) && props.themeColor === undefined) {
+    throw new GenerationSpecError('invalid_value', `${path}/themeColor`, 'themeColor is required when themeTint or themeShade is set');
+  }
   if (props.sizePt !== undefined && (!(props.sizePt > 0) || !Number.isFinite(props.sizePt))) {
     throw new GenerationSpecError('invalid_value', `${path}/sizePt`, 'sizePt must be a positive finite number');
   }
@@ -387,5 +424,17 @@ function validateRunProps(props: RunProps, path: string): void {
       `${path}/highlight`,
       `highlight must be one of the fixed CT_HighlightColor values, got '${props.highlight}'`,
     );
+  }
+}
+
+function validateThemeColorSlot(value: string, path: string, fieldName: string): void {
+  if (!THEME_COLOR_SLOT_SET.has(value)) {
+    throw new GenerationSpecError('invalid_value', path, `${fieldName} must be one of the supported theme slots, got '${value}'`);
+  }
+}
+
+function validateOptionalTwoHex(value: string | undefined, path: string, fieldName: string): void {
+  if (value !== undefined && !TWO_HEX_RE.test(value)) {
+    throw new GenerationSpecError('invalid_value', path, `${fieldName} must be two hex digits without '#', got '${value}'`);
   }
 }

--- a/packages/docx-core/src/primitives/namespaces.ts
+++ b/packages/docx-core/src/primitives/namespaces.ts
@@ -118,6 +118,7 @@ export const W = {
   ftr: 'ftr',
   settings: 'settings',
   evenAndOddHeaders: 'evenAndOddHeaders',
+  clrSchemeMapping: 'clrSchemeMapping',
 
   // Styles part + paragraph/run formatting (generation emitters)
   docDefaults: 'docDefaults',


### PR DESCRIPTION
## Summary
The single-source-of-brand feature: let a `DocumentSpec` define a custom theme palette once and author colors theme-relative, so the legal-explainer#720 renderer maps its role-based palette (accent/accent_deep/ink) onto theme slots instead of threading hex everywhere. #482 shipped a fixed Office theme (`accent1=4472C4`); this makes it overridable.

## Implementation (per the two locked API decisions)
- **Partial-override palette** — `spec.theme.colors` is a `Partial<Record<ThemeColorSlot, hex>>`; any slot set overrides the canonical default, unset slots keep #482 values. `spec.theme.fonts.major/minor` override the latin typefaces. `emitThemePart` applies the override by DOM-patching the static canonical theme.
- **Additive authoring** — `RunProps.themeColor/themeTint/themeShade` (beside `colorHex`, not a union) emit `<w:color w:themeColor=… w:themeTint=… w:val=<derived fallback>>`; parallel `themeFill` on `TableCellSpec` shading. The derived `w:val` is the resolved palette hex (standard OOXML; required for LibreOffice/Word to render the brand color).
- **Validation** — slot-enum, mutual exclusivity (`colorHex`⊕`themeColor`, `shadingHex`⊕`themeFill`), 2-hex tint/shade, 6-hex palette values, all with negative tests.
- **`clrSchemeMapping`** — emitted in `settings.xml` only for themed/theme-relative docs (needed for `text1/background1` resolution). Default path (no `spec.theme`) is **byte-identical** — `[SDX-GEN-093]` unchanged.

## OpenSpec
- New change `add-custom-theme`, requirement + scenario `[SDX-GEN-107]`. `openspec validate --strict` passes.

## Verification
- [x] Build clean
- [x] Full docx-core suite: 1538 passed, 2 expected-fail (11 skips are environmental — missing Lean binaries / unset `DOCX_PLATFORM_TESTS_DIR` in a fresh worktree, not regressions)
- [x] New generation test `[SDX-GEN-107]` + `[SDX-GEN-093]` (default theme) pass
- [x] `check:spec-coverage` (exit 0) · `check:conformance-citations` OK · `lint:workspaces` 0 errors
- [x] **Default path byte-identical**: no `spec.theme` → `theme1.xml` still `4472C4`, `settings.xml` minimal (no `clrSchemeMapping`)
- [x] **Empirical render**: custom `accent1`/`text1` = `117086` → raster dominant text pixel `#117086` in LibreOffice (both)
- [ ] Peer review (agy + Codex) — pending; appended below

## Known item for review
`CANONICAL_THEME_COLORS` (in the new `theme-colors.ts`, used to derive the `w:val` fallback) duplicates the hex values baked into `THEME1_XML` (in `theme-part.ts`). They match today, but are two sources of truth that could drift — flagging for reviewer opinion on whether to unify or lock with a consistency test.

## Closes
- #492