### PR TITLE
fix(ci): stop persisted token overriding app token on auto-tag push

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -36,6 +36,13 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+          # Do NOT persist the default GITHUB_TOKEN credential. actions/checkout
+          # otherwise writes an http.extraheader Authorization for
+          # github-actions[bot], which OVERRIDES the URL-embedded app token on the
+          # tag push below — so the push authenticates as github-actions[bot]
+          # (which cannot push tags) and fails with "denied to github-actions[bot]".
+          # With this off, the explicit x-access-token URL in the push step wins.
+          persist-credentials: false
 
       - name: Detect a merged version bump without a tag
         id: detect


### PR DESCRIPTION
## Problem

`auto-tag-release.yml` is supposed to push the `v<version>` tag (which triggers `release.yml` to publish) when a `chore(release): bump workspace versions` PR merges to main. It has **failed on every release** — `v0.11.0` and `v0.11.1` both had to be tagged manually — with:

```
remote: Permission to UseJunior/safe-docx.git denied to github-actions[bot].
fatal: ... The requested URL returned error: 403
```

## Root cause

It is **not** the release-bot app or its key — the token mints fine (`APP_TOKEN: ***` is non-empty in the failing log, and the same app token works in `release.yml`'s changelog job). The bug:

1. `actions/checkout` persists an `http.https://github.com/.extraheader` Authorization header for `github-actions[bot]`.
2. The tag-push step runs `git push https://x-access-token:${APP_TOKEN}@github.com/...`.
3. Git's persisted `extraheader` **overrides** the URL-embedded credential, so the push authenticates as `github-actions[bot]` — which can't push tags — instead of the release-bot app.

## Fix

`persist-credentials: false` on the checkout, so no `extraheader` is written and the explicit `x-access-token` URL in the push step is the credential used.

Safe because this job's only other git work is local reads (`git show`, `git cat-file`) plus an unauthenticated `git ls-remote --tags origin` on this public repo — none need the persisted credential.

## After this merges

The next version-bump merge should auto-push its tag with no manual intervention. (This PR itself is not a version bump, so it won't trigger a release.)