### PR TITLE
feat(docx-core): two-column signatureBlock layout + keepLines on ParagraphSpec

### DIFF
--- a/openspec/changes/add-signature-and-keeplines/proposal.md
+++ b/openspec/changes/add-signature-and-keeplines/proposal.md
@@ -1,0 +1,38 @@
+# Change: Add two-column signature block and paragraph keep-lines
+
+## Why
+
+OpenAgreements execution pages need a two-column signing grid (two signers per
+row, each a centered uppercase muted party header over ruled Signature / Print
+Name / Title / Date lines) and a way to keep a multi-line signer block from
+splitting across a page. Today `signatureBlock` is single-column, so the
+OpenAgreements DOCX adapter hand-rolls the grid from raw `TableSpec`s, and
+`ParagraphSpec` exposes `keepNext` but not `keepLines`, so consumers chain
+`keepNext` across paragraphs as a keep-together workaround. These are the two
+remaining items of #488 (items 1 and 4 landed in #497).
+
+## What Changes
+
+- Add an optional `layout: 'two-column'` mode to `signatureBlock` that renders
+  the parties as a paired signing grid — two signers per row with a center
+  gutter column, each signer cell a centered uppercase muted header over four
+  ruled fields with Print Name and Title pre-filled from the party data and
+  Signature/Date left blank, plus an empty padding cell when the signer count is
+  odd. Omitting `layout` preserves the existing single-column block.
+- Add a first-class `keepLines?: boolean` to `ParagraphSpec`, emitted as
+  `w:keepLines` in `w:pPr` (it already sits after `keepNext` in `PPR_ORDER`).
+  Because the paragraph-property builder is shared, `keepLines` is also honored
+  on `StyleSpec.paragraph`.
+- Add scenarios `SDX-GEN-108` (keep-lines) and `SDX-GEN-109` (two-column
+  signature) covering recipe output, emitted XML, and default compatibility.
+
+## Impact
+
+- Affected specs: `docx-generation` (two ADDED requirements).
+- Affected code: `packages/docx-core/src/generation/recipes.ts`,
+  `.../generation/types.ts`, `.../primitives/namespaces.ts`,
+  `.../generation/emit/properties.ts`, `.../generation/emit/paragraph.ts`, and
+  two focused generation tests.
+- Out of scope: paragraph-level borders (ruled lines reuse the existing
+  bottom-bordered-cell grammar via nested tables) and any change to the
+  single-column signature output.

--- a/openspec/changes/add-signature-and-keeplines/specs/docx-generation/spec.md
+++ b/openspec/changes/add-signature-and-keeplines/specs/docx-generation/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Paragraph keep-lines pagination
+
+`ParagraphSpec` SHALL support an optional `keepLines` flag that emits
+`w:keepLines` in the paragraph properties so a paragraph's lines stay together
+on one page, ordered immediately after `w:keepNext`, and SHALL omit the element
+when the flag is unset.
+
+#### Scenario: [SDX-GEN-108] keepLines emits w:keepLines after w:keepNext and is absent when unset
+- **GIVEN** a paragraph with both `keepLines` and `keepNext`, a paragraph without either, and a paragraph style whose paragraph properties set `keepLines`
+- **WHEN** the document is generated and parsed back
+- **THEN** the keep-together paragraph's `w:pPr` SHALL contain `w:keepLines` immediately after `w:keepNext`
+- **AND** the paragraph without the flag SHALL emit no `w:keepLines`
+- **AND** the paragraph style SHALL also emit `w:keepLines` through the shared paragraph-property builder
+- **AND** the generated package SHALL remain structurally valid and well-formed
+
+### Requirement: Two-column signature block layout
+
+`signatureBlock` SHALL support an optional two-column layout that renders signers
+as a paired signing grid while preserving the existing single-column block when
+the layout option is omitted.
+
+#### Scenario: [SDX-GEN-109] two-column signature renders a paired pre-filled signing grid
+- **GIVEN** a `signatureBlock` authored with `layout: 'two-column'` over three signers
+- **WHEN** the recipe builds the block and the document is generated
+- **THEN** the recipe SHALL return a single three-column grid table (signer / gutter / signer)
+- **AND** each signer cell SHALL lead with a centered uppercase muted party header
+- **AND** each signer cell SHALL carry ruled Signature / Print Name / Title / Date lines with Print Name and Title pre-filled from the party data and Signature/Date left blank
+- **AND** an odd signer count SHALL produce a trailing empty padding cell with no nested form
+- **AND** the grid SHALL use no VML or pictures
+- **AND** omitting the layout option SHALL preserve the existing single-column signature behavior
+- **AND** the generated package SHALL remain structurally valid and well-formed

--- a/openspec/changes/add-signature-and-keeplines/tasks.md
+++ b/openspec/changes/add-signature-and-keeplines/tasks.md
@@ -1,0 +1,43 @@
+## 1. Spec
+
+- [x] 1.1 Add the `Two-column signature block layout` requirement with scenario
+      `SDX-GEN-109` and the `Paragraph keep-lines pagination` requirement with
+      scenario `SDX-GEN-108` to the `docx-generation` delta (one `## ADDED
+      Requirements` section, two `### Requirement:` blocks).
+
+## 2. Paragraph keep-lines
+
+- [x] 2.1 Add `keepLines?: boolean` to `ParagraphSpec` and `W.keepLines` to the
+      namespace map.
+- [x] 2.2 Add `keepLines` to the `ParagraphProps` pick and emit `w:keepLines`
+      after `w:keepNext` in `buildParagraphPropsElement` (ordered by
+      `PPR_ORDER`).
+
+## 3. Two-column signature recipe
+
+- [x] 3.1 Add optional `layout`, `totalWidthTwips`, `gutterTwips`,
+      `headerColorHex`, and `ruledLineLabels` controls to `signatureBlock`.
+- [x] 3.2 Build the two-column path as a 3-column grid of signer cells (centered
+      uppercase muted header + nested ruled-field table, Print Name/Title
+      pre-filled) with a padding cell for odd counts, composing only the
+      existing table/paragraph/run grammar, without changing the single-column
+      default.
+
+## 4. Tests
+
+- [x] 4.1 Add `generation-keep-lines.test.ts` and
+      `generation-two-column-signature.test.ts`, both with
+      `TEST_FEATURE = 'add-signature-and-keeplines'` and `.openspec` scenarios
+      `[SDX-GEN-108]` / `[SDX-GEN-109]`.
+- [x] 4.2 Assert keepLines emission order, absence when unset, and style-level
+      emission; assert the two-column grid columns, caps/muted header,
+      pre-filled Print Name/Title with blank ruled Signature/Date, odd-count
+      padding cell, no VML, structural validity, and single-column default
+      compatibility.
+
+## 5. Verify
+
+- [ ] 5.1 Focused package build/test, spec coverage, conformance-citation check,
+      workspace lint, conformance-doc, and strict OpenSpec validation pass.
+- [ ] 5.2 Real-DOCX visual confirm in Word for Mac (keep-lines block near a page
+      break + odd-count two-column signature open without a repair dialog).

--- a/packages/docx-core/src/generation/emit/paragraph.ts
+++ b/packages/docx-core/src/generation/emit/paragraph.ts
@@ -2,7 +2,7 @@
  * Paragraph emitter.
  *
  * Shipped: paragraphs with style references and direct formatting
- * (alignment, spacing, indentation, tabs, keepNext, pageBreakBefore), all
+ * (alignment, spacing, indentation, tabs, keepNext, keepLines, pageBreakBefore), all
  * routed through the shared pPr builder and PPR_ORDER. The section-break
  * injection hook (a pPr-only sectPr) arrives with the multi-section phase.
  */

--- a/packages/docx-core/src/generation/emit/properties.ts
+++ b/packages/docx-core/src/generation/emit/properties.ts
@@ -13,7 +13,7 @@ import type { ParagraphSpec, RunProps, StyleSpec, ThemeColorSlot } from '../type
 /** Paragraph-formatting subset shared by ParagraphSpec and StyleSpec.paragraph. */
 export type ParagraphProps = Pick<
   ParagraphSpec,
-  'alignment' | 'spacing' | 'indent' | 'tabs' | 'pageBreakBefore' | 'keepNext'
+  'alignment' | 'spacing' | 'indent' | 'tabs' | 'pageBreakBefore' | 'keepNext' | 'keepLines'
 > & { styleId?: string };
 
 const ALIGNMENT_TO_JC: Record<NonNullable<ParagraphProps['alignment']>, string> = {
@@ -111,6 +111,9 @@ export function buildParagraphPropsElement(
   }
   if (props.keepNext) {
     children.set(W.keepNext, createWmlElement(doc, W.keepNext));
+  }
+  if (props.keepLines) {
+    children.set(W.keepLines, createWmlElement(doc, W.keepLines));
   }
   if (props.pageBreakBefore) {
     children.set(W.pageBreakBefore, createWmlElement(doc, W.pageBreakBefore));

--- a/packages/docx-core/src/generation/generation-keep-lines.test.ts
+++ b/packages/docx-core/src/generation/generation-keep-lines.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect } from 'vitest';
+import { childElements, getDirectChildrenByName } from '../primitives/dom-helpers.js';
+import { parseXml } from '../primitives/xml.js';
+import { readZipText } from '../primitives/zip.js';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { generateDocx } from './compile.js';
+import { checkGeneratedPackage } from './structural-checks.js';
+import type { DocumentSpec } from './types.js';
+
+const TEST_FEATURE = 'add-signature-and-keeplines';
+const test = testAllure.epic('Document Generation').withLabels({ feature: TEST_FEATURE });
+
+function specWithKeepLines(): DocumentSpec {
+  return {
+    meta: { title: 'Keep lines', createdIso: '2026-06-15T00:00:00Z' },
+    styles: [
+      {
+        styleId: 'SignerBlock',
+        name: 'Signer Block',
+        type: 'paragraph',
+        basedOn: 'Normal',
+        paragraph: { keepLines: true },
+      },
+    ],
+    sections: [
+      {
+        blocks: [
+          // keepNext + keepLines together: lets us assert both emit and their order.
+          { kind: 'paragraph', keepNext: true, keepLines: true, runs: [{ kind: 'text', text: 'Kept together' }] },
+          // No keep* flags: must emit no w:keepLines.
+          { kind: 'paragraph', runs: [{ kind: 'text', text: 'Free to break' }] },
+        ],
+      },
+    ],
+  };
+}
+
+async function generatePackage(spec: DocumentSpec): Promise<Buffer> {
+  const buffer = await generateDocx(spec);
+  const structural = await checkGeneratedPackage(buffer);
+  expect(structural.issues).toEqual([]);
+  return buffer;
+}
+
+describe('Traceability: paragraph keep-lines pagination', () => {
+  test.openspec('[SDX-GEN-108] keepLines emits w:keepLines after w:keepNext and is absent when unset')(
+    'Scenario: keepLines emits w:keepLines after w:keepNext and is absent when unset',
+    async ({ given, when, then, attachPrettyJson, attachPrettyXml }: AllureBddContext) => {
+      let spec!: DocumentSpec;
+      await given('a paragraph with keepLines + keepNext, a paragraph without, and a style carrying keepLines', async () => {
+        spec = specWithKeepLines();
+        await attachPrettyJson('spec', spec);
+        expect(spec.sections[0]!.blocks[0]!.kind).toBe('paragraph');
+      });
+
+      let documentDom!: Document;
+      let stylesDom!: Document;
+      await when('the document is generated and parsed back', async () => {
+        const buffer = await generatePackage(spec);
+        const documentXml = (await readZipText(buffer, 'word/document.xml'))!;
+        const stylesXml = (await readZipText(buffer, 'word/styles.xml'))!;
+        await attachPrettyXml('word/document.xml', documentXml);
+        await attachPrettyXml('word/styles.xml', stylesXml);
+        documentDom = parseXml(documentXml);
+        stylesDom = parseXml(stylesXml);
+      });
+
+      await then('the keep-together paragraph emits w:keepLines immediately after w:keepNext', async () => {
+        const firstPPr = documentDom.getElementsByTagName('w:pPr').item(0)!;
+        const order = childElements(firstPPr).map((el) => el.localName ?? el.nodeName.replace(/^w:/, ''));
+        expect(order).toContain('keepNext');
+        expect(order).toContain('keepLines');
+        expect(order.indexOf('keepLines')).toBe(order.indexOf('keepNext') + 1);
+      });
+
+      await then('a paragraph without keepLines emits none', async () => {
+        // Two body paragraphs: the second has no pPr at all (no formatting), so the doc carries exactly one keepLines.
+        expect(documentDom.getElementsByTagName('w:keepLines')).toHaveLength(1);
+      });
+
+      await then('a paragraph style carrying keepLines also emits w:keepLines (shared emitter)', async () => {
+        const styleEls = Array.from(stylesDom.getElementsByTagName('w:style'));
+        const signer = styleEls.find((el) => el.getAttribute('w:styleId') === 'SignerBlock');
+        expect(signer, 'SignerBlock style missing').toBeTruthy();
+        const pPr = getDirectChildrenByName(signer!, 'pPr')[0];
+        expect(pPr, 'style pPr missing').toBeTruthy();
+        expect(getDirectChildrenByName(pPr!, 'keepLines')).toHaveLength(1);
+      });
+    },
+  );
+});

--- a/packages/docx-core/src/generation/generation-two-column-signature.test.ts
+++ b/packages/docx-core/src/generation/generation-two-column-signature.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect } from 'vitest';
+import { getDirectChildrenByName } from '../primitives/dom-helpers.js';
+import { parseXml } from '../primitives/xml.js';
+import { readZipText } from '../primitives/zip.js';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { generateDocx } from './compile.js';
+import { signatureBlock } from './recipes.js';
+import { checkGeneratedPackage } from './structural-checks.js';
+import type { DocumentSpec } from './types.js';
+
+const TEST_FEATURE = 'add-signature-and-keeplines';
+const test = testAllure.epic('Document Generation').withLabels({ feature: TEST_FEATURE });
+
+// Three signers → an odd count, so the second grid row carries a trailing empty padding cell.
+const PARTIES = [
+  { party: 'Acme Manufacturing, Inc.', name: 'Jane Doe', title: 'CEO' },
+  { party: 'Northeast Logistics LLC', name: 'John Smith', title: 'Managing Member' },
+  { party: 'Third Signer Inc.', name: 'Pat Lee', title: 'Secretary' },
+];
+
+function twoColumnSpec(): DocumentSpec {
+  return {
+    meta: { title: 'Two-column signature', createdIso: '2026-06-15T00:00:00Z' },
+    sections: [{ blocks: signatureBlock({ layout: 'two-column', parties: PARTIES }) }],
+  };
+}
+
+async function generateDocumentXml(spec: DocumentSpec): Promise<string> {
+  const buffer = await generateDocx(spec);
+  const structural = await checkGeneratedPackage(buffer);
+  expect(structural.issues).toEqual([]);
+  const xml = await readZipText(buffer, 'word/document.xml');
+  expect(xml, 'word/document.xml missing').not.toBeNull();
+  return xml!;
+}
+
+function firstDirectChild(parent: Element, localName: string): Element {
+  const child = getDirectChildrenByName(parent, localName)[0];
+  expect(child, `missing direct w:${localName}`).toBeTruthy();
+  return child!;
+}
+
+function cellText(cell: Element): string {
+  return Array.from(cell.getElementsByTagName('w:t'))
+    .map((t) => t.textContent ?? '')
+    .join('');
+}
+
+describe('Traceability: two-column signature block layout', () => {
+  test.openspec('[SDX-GEN-109] two-column signature renders a paired pre-filled signing grid')(
+    'Scenario: two-column signature renders a paired pre-filled signing grid',
+    async ({ given, when, then, attachPrettyJson, attachPrettyXml }: AllureBddContext) => {
+      let spec!: DocumentSpec;
+      await given('a two-column signature block over three signers', async () => {
+        const blocks = signatureBlock({ layout: 'two-column', parties: PARTIES });
+        await attachPrettyJson('recipe-output', blocks);
+        // The two-column recipe returns exactly one grid table block.
+        expect(blocks).toHaveLength(1);
+        expect(blocks[0]!.kind).toBe('table');
+        if (blocks[0]!.kind !== 'table') throw new Error('expected table');
+        expect(blocks[0]!.columnWidthsTwips).toHaveLength(3);
+        spec = twoColumnSpec();
+      });
+
+      let dom!: Document;
+      await when('the document is generated and parsed back', async () => {
+        const xml = await generateDocumentXml(spec);
+        await attachPrettyXml('word/document.xml', xml);
+        dom = parseXml(xml);
+      });
+
+      await then('the outer table is a 3-column grid with two signer rows', async () => {
+        const outer = dom.getElementsByTagName('w:tbl').item(0)!;
+        const grid = firstDirectChild(outer, 'tblGrid');
+        expect(getDirectChildrenByName(grid, 'gridCol')).toHaveLength(3);
+        expect(getDirectChildrenByName(outer, 'tr')).toHaveLength(2);
+      });
+
+      await then('each signer cell leads with a centered uppercase muted party header', async () => {
+        const outer = dom.getElementsByTagName('w:tbl').item(0)!;
+        const firstRow = firstDirectChild(outer, 'tr');
+        const signerCell = getDirectChildrenByName(firstRow, 'tc')[0]!;
+        const header = getDirectChildrenByName(signerCell, 'p')[0]!;
+        const pPr = firstDirectChild(header, 'pPr');
+        expect(firstDirectChild(pPr, 'jc').getAttribute('w:val')).toBe('center');
+        const rPr = firstDirectChild(header.getElementsByTagName('w:r').item(0)!, 'rPr');
+        expect(rPr.getElementsByTagName('w:caps')).toHaveLength(1);
+        expect(rPr.getElementsByTagName('w:color').item(0)!.getAttribute('w:val')).toBe('595959');
+        expect(cellText(header)).toBe('Acme Manufacturing, Inc.');
+      });
+
+      await then('the signer form pre-fills Print Name and Title and leaves Signature/Date blank on ruled lines', async () => {
+        const outer = dom.getElementsByTagName('w:tbl').item(0)!;
+        const firstRow = firstDirectChild(outer, 'tr');
+        const signerCell = getDirectChildrenByName(firstRow, 'tc')[0]!;
+        const form = getDirectChildrenByName(signerCell, 'tbl')[0]!;
+        const formRows = getDirectChildrenByName(form, 'tr');
+        // Four fields × (rule row + caption row) = 8 rows.
+        expect(formRows).toHaveLength(8);
+        const ruleCell = (i: number) => getDirectChildrenByName(formRows[i]!, 'tc')[0]!;
+        const captions = [1, 3, 5, 7].map((i) => cellText(ruleCell(i)));
+        expect(captions).toEqual(['Signature', 'Print Name', 'Title', 'Date']);
+        // Value lines: Signature blank, Print Name = name, Title = title, Date blank.
+        expect(cellText(ruleCell(0))).toBe('');
+        expect(cellText(ruleCell(2))).toBe('Jane Doe');
+        expect(cellText(ruleCell(4))).toBe('CEO');
+        expect(cellText(ruleCell(6))).toBe('');
+        // Each value line is a bottom-ruled cell.
+        for (const i of [0, 2, 4, 6]) {
+          const tcBorders = firstDirectChild(firstDirectChild(ruleCell(i), 'tcPr'), 'tcBorders');
+          expect(firstDirectChild(tcBorders, 'bottom').getAttribute('w:val')).toBe('single');
+        }
+      });
+
+      await then('an odd signer count yields a trailing empty padding cell with no nested form', async () => {
+        const outer = dom.getElementsByTagName('w:tbl').item(0)!;
+        const secondRow = getDirectChildrenByName(outer, 'tr')[1]!;
+        const cells = getDirectChildrenByName(secondRow, 'tc');
+        expect(cells).toHaveLength(3);
+        // Third signer present in the left cell; padding cell on the right has no nested table and no text.
+        expect(cellText(cells[0]!)).toContain('Third Signer Inc.');
+        expect(getDirectChildrenByName(cells[2]!, 'tbl')).toHaveLength(0);
+        expect(cellText(cells[2]!)).toBe('');
+      });
+
+      await then('the grid uses no VML or pictures', async () => {
+        expect(dom.getElementsByTagName('w:pict')).toHaveLength(0);
+        expect(dom.getElementsByTagName('v:shape')).toHaveLength(0);
+      });
+
+      await then('omitting layout preserves the single-column recipe behavior', async () => {
+        const xml = await generateDocumentXml({
+          sections: [{ blocks: signatureBlock({ parties: [PARTIES[0]!] }) }],
+        });
+        const singleDom = parseXml(xml);
+        // Single-column path: a bold heading paragraph + a one-column table with "Name: ..." rows, no caps header.
+        expect(singleDom.getElementsByTagName('w:caps')).toHaveLength(0);
+        const allText = Array.from(singleDom.getElementsByTagName('w:t'))
+          .map((t) => t.textContent ?? '')
+          .join('|');
+        expect(allText).toContain('Name: Jane Doe');
+      });
+    },
+  );
+});

--- a/packages/docx-core/src/generation/recipes.ts
+++ b/packages/docx-core/src/generation/recipes.ts
@@ -135,16 +135,38 @@ export type SignatureBlockOptions = {
     /** Label for the date row; defaults to 'Date:'. */
     dateLabel?: string;
   }>;
-  /** Signature-line column width in twips; defaults to 4320 (3"). */
+  /** Signature-line column width in twips; defaults to 4320 (3"). Single-column only. */
   lineWidthTwips?: number;
+
+  // ---- two-column mode (all optional; ignored unless layout === 'two-column') ----
+  /** Layout selector. Defaults to 'single-column' (the historical behavior). */
+  layout?: 'single-column' | 'two-column';
+  /** Total grid width in twips, split across the two signer columns. Defaults to 9360 (6.5" body). */
+  totalWidthTwips?: number;
+  /** Center gutter column width between the two signer cells. Defaults to 360 (0.25"). */
+  gutterTwips?: number;
+  /** Color for the muted party header and field captions. Defaults to '595959'. */
+  headerColorHex?: string;
+  /** Captions for the four ruled lines. Defaults to ['Signature', 'Print Name', 'Title', 'Date']. */
+  ruledLineLabels?: [string, string, string, string];
 };
 
 /**
- * Signature blocks rendered as borderless single-column tables whose first
- * content cell carries only a bottom border — the signature line — followed
- * by name, title, and date rows (scenario SDX-GEN-071). No VML, no images.
+ * Signature blocks rendered as borderless tables whose content cells carry
+ * only bottom borders — the signature lines. No VML, no images.
+ *
+ * Default `layout: 'single-column'` keeps the historical stacked block: one
+ * table per party, a bottom-bordered line then name/title/date rows
+ * (scenario SDX-GEN-071). With `layout: 'two-column'` the parties render as a
+ * paired signing grid — two signers per row, each a centered uppercase muted
+ * header over ruled Signature / Print Name / Title / Date lines (Print Name and
+ * Title pre-filled from the party data), with an empty padding cell when the
+ * signer count is odd (scenario SDX-GEN-109).
  */
 export function signatureBlock(options: SignatureBlockOptions): BlockSpec[] {
+  if ((options.layout ?? 'single-column') === 'two-column') {
+    return [twoColumnSignatureGrid(options)];
+  }
   const width = options.lineWidthTwips ?? 4320;
   const blocks: BlockSpec[] = [];
   options.parties.forEach((party, index) => {
@@ -170,7 +192,7 @@ export function signatureBlock(options: SignatureBlockOptions): BlockSpec[] {
 
 function paragraph(
   text: string,
-  opts?: { bold?: boolean; italic?: boolean; colorHex?: string; alignment?: ParagraphSpec['alignment'] },
+  opts?: { bold?: boolean; italic?: boolean; caps?: boolean; colorHex?: string; alignment?: ParagraphSpec['alignment'] },
 ): ParagraphSpec {
   return {
     kind: 'paragraph',
@@ -181,10 +203,92 @@ function paragraph(
         text,
         ...(opts?.bold ? { bold: true } : {}),
         ...(opts?.italic ? { italic: true } : {}),
+        ...(opts?.caps ? { caps: true } : {}),
         ...(opts?.colorHex !== undefined ? { colorHex: opts.colorHex } : {}),
       },
     ],
   };
+}
+
+/**
+ * Two-column signing grid: parties chunked into pairs across a 3-column table
+ * `[signer, gutter, signer]`, with an empty padding cell for an odd final
+ * signer. Each signer cell stacks a centered uppercase muted header over a
+ * nested one-column table of four ruled fields (Signature / Print Name / Title
+ * / Date), reusing the bottom-bordered-cell rule from the single-column path.
+ */
+function twoColumnSignatureGrid(options: SignatureBlockOptions): TableSpec {
+  const total = options.totalWidthTwips ?? 9360;
+  const gutter = options.gutterTwips ?? 360;
+  const signer = Math.max(1, Math.floor((total - gutter) / 2));
+  const mutedColor = options.headerColorHex ?? DEFAULT_SUBROW_COLOR_HEX;
+  const labels = options.ruledLineLabels ?? ['Signature', 'Print Name', 'Title', 'Date'];
+
+  const gutterCell: TableSpec['rows'][number]['cells'][number] = {
+    borders: { top: NONE, bottom: NONE, left: NONE, right: NONE },
+    blocks: [paragraph('')],
+  };
+  const paddingCell: TableSpec['rows'][number]['cells'][number] = {
+    borders: { top: NONE, bottom: NONE, left: NONE, right: NONE },
+    blocks: [paragraph('')],
+  };
+
+  const rows: TableSpec['rows'] = [];
+  for (let i = 0; i < options.parties.length; i += 2) {
+    const left = options.parties[i];
+    if (left === undefined) continue;
+    const right = options.parties[i + 1];
+    rows.push({
+      cells: [
+        signerCell(left, labels, mutedColor),
+        gutterCell,
+        right === undefined ? paddingCell : signerCell(right, labels, mutedColor),
+      ],
+    });
+  }
+
+  return {
+    kind: 'table',
+    layout: 'fixed',
+    columnWidthsTwips: [signer, gutter, signer],
+    borders: { top: NONE, bottom: NONE, left: NONE, right: NONE, insideH: NONE, insideV: NONE },
+    rows,
+  };
+}
+
+function signerCell(
+  party: SignatureBlockOptions['parties'][number],
+  labels: [string, string, string, string],
+  mutedColor: string,
+): TableSpec['rows'][number]['cells'][number] {
+  // Pre-fill Print Name / Title from the party data; Signature / Date stay blank.
+  const fields: Array<[value: string, caption: string]> = [
+    ['', labels[0]],
+    [party.name, labels[1]],
+    [party.title ?? '', labels[2]],
+    ['', party.dateLabel ?? labels[3]],
+  ];
+  return {
+    vAlign: 'top',
+    blocks: [
+      paragraph(party.party, { alignment: 'center', caps: true, colorHex: mutedColor }),
+      {
+        kind: 'table',
+        layout: 'fixed',
+        columnWidthsTwips: [4320],
+        borders: { top: NONE, bottom: NONE, left: NONE, right: NONE, insideH: NONE, insideV: NONE },
+        rows: fields.flatMap(([value, caption]) => ruledFieldRows(value, caption, mutedColor)),
+      },
+    ],
+  };
+}
+
+/** A ruled field = the bottom-bordered value line, then its muted caption beneath. */
+function ruledFieldRows(value: string, caption: string, mutedColor: string): TableSpec['rows'] {
+  return [
+    { cells: [{ borders: { bottom: SINGLE }, blocks: [paragraph(value)] }] },
+    { cells: [{ blocks: [paragraph(caption, { colorHex: mutedColor })] }] },
+  ];
 }
 
 function rowRhythmProps(options: CoverTermsOptions): Pick<TableSpec['rows'][number], 'heightTwips' | 'heightRule'> {

--- a/packages/docx-core/src/generation/types.ts
+++ b/packages/docx-core/src/generation/types.ts
@@ -119,6 +119,8 @@ export type ParagraphSpec = {
   list?: { numId: string; ilvl: number };
   pageBreakBefore?: boolean;
   keepNext?: boolean;
+  /** Keep every line of this paragraph on one page (w:keepLines). */
+  keepLines?: boolean;
   tabs?: Array<{
     posTwips: number;
     align: 'left' | 'center' | 'right';

--- a/packages/docx-core/src/primitives/namespaces.ts
+++ b/packages/docx-core/src/primitives/namespaces.ts
@@ -131,6 +131,7 @@ export const W = {
   caps: 'caps',
   smallCaps: 'smallCaps',
   keepNext: 'keepNext',
+  keepLines: 'keepLines',
   pageBreakBefore: 'pageBreakBefore',
   tabs: 'tabs',
 


### PR DESCRIPTION
Closes #488 — the two remaining house-style recipe gaps (items 1 and 4 landed in #497).

## What

**Two-column `signatureBlock`** (`layout: 'two-column'`) — renders signers as a paired signing grid: two per row with a center gutter column, each cell a centered uppercase muted party header over ruled Signature / Print Name / Title / Date lines, with **Print Name and Title pre-filled** from the party data and Signature/Date left blank. An odd signer count gets a trailing empty padding cell. Omitting `layout` preserves the single-column block (SDX-GEN-071) unchanged. Ruled lines reuse the existing bottom-bordered-cell grammar via a nested one-column table — no new spec surface.

**`keepLines?: boolean` on `ParagraphSpec`** — emitted as `w:keepLines` immediately after `w:keepNext` (already ordered in `PPR_ORDER`). The shared paragraph-property builder means `StyleSpec.paragraph` honors it too, replacing the `keepNext`-chaining keep-together workaround.

## Why

The OpenAgreements DOCX adapter hand-rolled the two-column grid from raw `TableSpec`s and chained `keepNext` across paragraphs to approximate keep-together. Absorbing both into docx-core recipes keeps the house style in one place instead of duplicated per consumer.

## Scenarios / spec

- `SDX-GEN-108` — keep-lines (emit order, absence when unset, style-level emission)
- `SDX-GEN-109` — two-column signature (3-column grid, caps/muted header, pre-filled Print Name/Title with blank ruled Signature/Date, odd-count padding cell, no VML, single-column default compatibility)
- OpenSpec change `add-signature-and-keeplines` (two ADDED requirements)

## Verification

- Full pre-submit gate green locally: build, `lint:workspaces` (0 errors), `test:run` (docx-core **1541 passed**, 2 expected-fail, 11 skipped), `check:spec-coverage` (`add-signature-and-keeplines: 2 scenarios covered`), `check:conformance-citations`, `check:conformance-doc`, and `openspec validate add-signature-and-keeplines --strict`.
- Real-DOCX visual confirm in **Word for Mac**: a generated doc exercising both features (a `keepLines` block near a page break + an odd-count two-column signature) opens **clean — no repair/recovery dialog** — and the grid renders two-up with the center gutter, the trailing empty padding cell for the odd third signer, uppercase muted headers, and Print Name/Title pre-filled over blank Signature/Date rules.