### PR TITLE
feat(docx-core): add lvlJc level justification to NumberingSpec (closes #502)

### DIFF
--- a/openspec/changes/add-numbering-level-justification/proposal.md
+++ b/openspec/changes/add-numbering-level-justification/proposal.md
@@ -1,0 +1,38 @@
+# Change: Add numbering level justification
+
+## Why
+
+The numbering generator hardcodes `<w:lvlJc w:val="left"/>` on every list level,
+and the `NumberingSpec` level type exposes no justification field, so a consumer
+cannot produce right-aligned numbering. `<w:lvlJc w:val="right"/>` right-aligns
+the number against the text indent so labels of differing widths line up on
+their right edge (`1.` vs `10.`, `1.1` vs `1.10`) — the standard convention for
+legal-document outline numbering. With forced left alignment a downstream
+legal-agreement renderer cannot match standard/NVCA-style numbering. Issue #502
+tracks this gap.
+
+## What Changes
+
+- Add a closed `NumberingLevelJustification` union (the transitional ST_Jc
+  subset `left`/`center`/`right`) and an optional `lvlJc` to the `NumberingSpec`
+  level type.
+- Emit `level.lvlJc ?? 'left'` for `w:lvlJc` instead of the hardcoded `'left'`,
+  preserving current behavior when the field is omitted.
+- Reject an out-of-enum `lvlJc` (e.g. from a JSON/JS caller bypassing the type)
+  with a validation error before emission.
+- Add a `Numbering level justification` requirement to `docx-generation` with
+  scenario `SDX-GEN-063`.
+
+## Impact
+
+- Affected specs: `docx-generation` (one ADDED requirement).
+- Affected code: `packages/docx-core/src/generation/types.ts`,
+  `packages/docx-core/src/generation/emit/numbering-part.ts`,
+  `packages/docx-core/src/generation/validate-spec.ts`, the
+  `spec-compliance` conformance registry entry for `w:lvlJc`, and a focused
+  generation test.
+- Backward-compatible additive field → patch/minor release.
+- Out of scope: the full `CT_Jc`/`ST_Jc` value space (only the
+  `left`/`center`/`right` subset the generator emits), recipe-helper wiring, and
+  read-side list-label computation (justification is purely visual and does not
+  change label text).

--- a/openspec/changes/add-numbering-level-justification/specs/docx-generation/spec.md
+++ b/openspec/changes/add-numbering-level-justification/specs/docx-generation/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Numbering level justification
+
+`generateDocx` SHALL accept an optional `lvlJc` on each `NumberingSpec` level as
+a fixed enumerated value (the transitional ST_Jc subset `left`/`center`/`right`)
+and emit it as `w:lvlJc`, defaulting to `left` when omitted so existing output is
+unchanged, without accepting values outside that enumeration.
+
+#### Scenario: [SDX-GEN-063] level justification is authorable
+- **GIVEN** a numbering definition whose levels declare `lvlJc` of `right` and `center`, plus a level that omits it
+- **WHEN** the document spec is compiled
+- **THEN** each level's `w:lvlJc` `w:val` SHALL equal the authored value, and `left` for the omitted level
+- **AND** `w:lvlJc` SHALL keep its CT_Lvl position after `w:lvlText` and before any `w:pPr`
+- **AND** a re-render of the same spec SHALL be byte-identical
+- **AND** an `lvlJc` value outside the fixed enumeration (e.g. supplied by a JSON/JS caller bypassing the type) SHALL be rejected with a validation error before emission, so no out-of-enum `w:lvlJc` can be produced
+- **AND** the generated package SHALL remain well-formed

--- a/openspec/changes/add-numbering-level-justification/tasks.md
+++ b/openspec/changes/add-numbering-level-justification/tasks.md
@@ -1,0 +1,30 @@
+## 1. Spec
+
+- [ ] 1.1 Add the `Numbering level justification` requirement with scenario
+      `SDX-GEN-063` to the `docx-generation` delta.
+
+## 2. Types, emitter, and validation
+
+- [ ] 2.1 Add the closed `NUMBERING_LEVEL_JUSTIFICATIONS` array,
+      `NumberingLevelJustification` union, and `NumberingSpec` level `lvlJc`.
+- [ ] 2.2 Emit `w:lvlJc` from `buildLevel` as `level.lvlJc ?? 'left'`.
+- [ ] 2.3 Reject out-of-enum `lvlJc` in `validateNumbering` via a runtime set.
+
+## 3. Conformance registry
+
+- [ ] 3.1 Update the `[ECMA-PART1-17-9-7]` registry prose (no longer "always
+      left") and regenerate `spec-compliance/CONFORMANCE.md`.
+
+## 4. Tests
+
+- [ ] 4.1 Add `packages/docx-core/src/generation/generation-numbering-level-justification.test.ts`
+      with `TEST_FEATURE = 'add-numbering-level-justification'` and `.openspec`
+      ID `[SDX-GEN-063]`.
+- [ ] 4.2 Assert `right`/`center`/default-`left` emission, double-render
+      determinism, package well-formedness, and out-of-enum rejection.
+
+## 5. Verify
+
+- [ ] 5.1 `openspec validate add-numbering-level-justification --strict` passes.
+- [ ] 5.2 Focused package build/test, spec-coverage, conformance-doc and
+      conformance-citation checks, workspace lint, and coverage ratchet pass.

--- a/packages/docx-core/src/generation/emit/numbering-part.ts
+++ b/packages/docx-core/src/generation/emit/numbering-part.ts
@@ -106,7 +106,7 @@ function buildLevel(
     lvl.appendChild(createWmlElement(doc, W.suff, { 'w:val': level.suff }));
   }
   lvl.appendChild(createWmlElement(doc, W.lvlText, { 'w:val': level.lvlText }));
-  lvl.appendChild(createWmlElement(doc, W.lvlJc, { 'w:val': 'left' }));
+  lvl.appendChild(createWmlElement(doc, W.lvlJc, { 'w:val': level.lvlJc ?? 'left' }));
   if (level.indentTwips !== undefined) {
     const pPr = createWmlElement(doc, W.pPr);
     const attrs: Record<string, string> = {};

--- a/packages/docx-core/src/generation/generation-numbering-level-justification.test.ts
+++ b/packages/docx-core/src/generation/generation-numbering-level-justification.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { childElements } from '../primitives/dom-helpers.js';
+import { parseXml } from '../primitives/xml.js';
+import { readZipText } from '../primitives/zip.js';
+import { generateDocx } from './compile.js';
+import { GenerationSpecError } from './errors.js';
+import { checkGeneratedPackage } from './structural-checks.js';
+import type { DocumentSpec, NumberingSpec } from './types.js';
+
+const TEST_FEATURE = 'add-numbering-level-justification';
+const test = testAllure.epic('Document Generation').withLabels({ feature: TEST_FEATURE });
+
+/** One numbering definition whose levels opt into right/center and omit (default left). */
+function justificationNumbering(): NumberingSpec {
+  return {
+    numId: 'clauses',
+    levels: [
+      { ilvl: 0, numFmt: 'decimal', lvlText: '%1.', lvlJc: 'right', indentTwips: { left: 720, hanging: 360 } },
+      { ilvl: 1, numFmt: 'decimal', lvlText: '%1.%2', lvlJc: 'center', indentTwips: { left: 1440, hanging: 360 } },
+      { ilvl: 2, numFmt: 'lowerRoman', lvlText: '(%3)', indentTwips: { left: 2160, hanging: 360 } },
+    ],
+  };
+}
+
+function justificationSpec(): DocumentSpec {
+  return {
+    meta: { title: 'Numbering level justification', createdIso: '2026-06-16T00:00:00Z' },
+    numbering: [justificationNumbering()],
+    sections: [
+      {
+        blocks: [
+          { kind: 'paragraph', list: { numId: 'clauses', ilvl: 0 }, runs: [{ kind: 'text', text: 'Definitions' }] },
+          { kind: 'paragraph', list: { numId: 'clauses', ilvl: 1 }, runs: [{ kind: 'text', text: 'Confidential Information' }] },
+          { kind: 'paragraph', list: { numId: 'clauses', ilvl: 2 }, runs: [{ kind: 'text', text: 'public information' }] },
+        ],
+      },
+    ],
+  };
+}
+
+describe('Traceability: numbering level justification', () => {
+  test
+    .openspec('[SDX-GEN-063] level justification is authorable')
+    .conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.9.7' })(
+    'Scenario: level justification is authorable',
+    async ({ given, when, then, and, attachPrettyXml }: AllureBddContext) => {
+      let buffer!: Buffer;
+      await given('a numbering definition with right/center levels and one default level', async () => {
+        buffer = await generateDocx(justificationSpec());
+        expect((await checkGeneratedPackage(buffer)).ok).toBe(true);
+      });
+
+      let levels!: Element[];
+      await when('word/numbering.xml is parsed back', async () => {
+        const numberingXml = (await readZipText(buffer, 'word/numbering.xml'))!;
+        expect(numberingXml).toBeTruthy();
+        await attachPrettyXml('word/numbering.xml', numberingXml);
+        const abstract = parseXml(numberingXml).getElementsByTagName('w:abstractNum').item(0)!;
+        levels = Array.from(abstract.getElementsByTagName('w:lvl'));
+        expect(levels).toHaveLength(3);
+      });
+
+      await then('each level emits w:lvlJc with the authored value, defaulting to left', async () => {
+        const lvlJc = (lvl: Element) => lvl.getElementsByTagName('w:lvlJc').item(0)!.getAttribute('w:val');
+        expect(lvlJc(levels[0]!)).toBe('right');
+        expect(lvlJc(levels[1]!)).toBe('center');
+        expect(lvlJc(levels[2]!)).toBe('left');
+      });
+
+      await and('w:lvlJc keeps its CT_Lvl position after w:lvlText and before w:pPr', async () => {
+        const names = childElements(levels[0]!).map((el) => el.tagName);
+        expect(names.indexOf('w:lvlJc')).toBe(names.indexOf('w:lvlText') + 1);
+        expect(names.indexOf('w:lvlJc')).toBeLessThan(names.indexOf('w:pPr'));
+      });
+
+      await and('a re-render of the same spec is byte-identical', async () => {
+        const second = await generateDocx(justificationSpec());
+        expect(second.equals(buffer)).toBe(true);
+      });
+
+      let rejection!: unknown;
+      await and('an out-of-enum lvlJc is rejected before emission', async () => {
+        const invalidSpec: DocumentSpec = {
+          meta: { title: 'Invalid', createdIso: '2026-06-16T00:00:00Z' },
+          numbering: [
+            {
+              numId: 'bad',
+              // Bypass the type to simulate a JSON/JS caller supplying a bad value.
+              levels: [{ ilvl: 0, numFmt: 'decimal', lvlText: '%1.', lvlJc: 'justify' as never }],
+            },
+          ],
+          sections: [{ blocks: [{ kind: 'paragraph', list: { numId: 'bad', ilvl: 0 }, runs: [{ kind: 'text', text: 'x' }] }] }],
+        };
+        rejection = await generateDocx(invalidSpec).then(
+          () => null,
+          (err: unknown) => err,
+        );
+        expect(rejection).toBeInstanceOf(GenerationSpecError);
+        const specError = rejection as GenerationSpecError;
+        expect(specError.code).toBe('invalid_value');
+        expect(specError.path).toBe('/numbering/0/levels/0/lvlJc');
+        expect(specError.message).toMatch(/lvlJc must be one of/);
+      });
+    },
+  );
+});

--- a/packages/docx-core/src/generation/types.ts
+++ b/packages/docx-core/src/generation/types.ts
@@ -257,6 +257,18 @@ export type StyleSpec = {
   run?: RunProps;
 };
 
+/**
+ * The level-justification values we author for `w:lvlJc` — the transitional
+ * ST_Jc subset (`left`/`center`/`right`) the numbering generator emits, not the
+ * full CT_Jc value space. Single source of truth: the
+ * {@link NumberingLevelJustification} union is derived from this array, and
+ * validation reuses it as a runtime whitelist so JSON/JS callers cannot author
+ * an out-of-enum `w:lvlJc`.
+ */
+export const NUMBERING_LEVEL_JUSTIFICATIONS = ['left', 'center', 'right'] as const;
+
+export type NumberingLevelJustification = (typeof NUMBERING_LEVEL_JUSTIFICATIONS)[number];
+
 export type NumberingSpec = {
   /** Spec-level handle; the compiler assigns numeric w:numId / abstractNumId. */
   numId: string;
@@ -267,6 +279,11 @@ export type NumberingSpec = {
     /** Level text pattern, e.g. '%1.' or '%1.%2' or a bullet glyph. */
     lvlText: string;
     suff?: 'tab' | 'space' | 'nothing';
+    /**
+     * Level number justification against the text indent (`w:lvlJc`); defaults
+     * to `left`. `right` aligns labels of differing widths on their right edge.
+     */
+    lvlJc?: NumberingLevelJustification;
     indentTwips?: { left?: number; hanging?: number };
     runProps?: RunProps;
   }>;

--- a/packages/docx-core/src/generation/validate-spec.ts
+++ b/packages/docx-core/src/generation/validate-spec.ts
@@ -37,11 +37,12 @@ import type {
   TableBorders,
   TableSpec,
 } from './types.js';
-import { HIGHLIGHT_COLORS, THEME_COLOR_SLOTS } from './types.js';
+import { HIGHLIGHT_COLORS, NUMBERING_LEVEL_JUSTIFICATIONS, THEME_COLOR_SLOTS } from './types.js';
 
 const COLOR_HEX_RE = /^[0-9A-Fa-f]{6}$/;
 const TWO_HEX_RE = /^[0-9A-Fa-f]{2}$/;
 const HIGHLIGHT_COLOR_SET: ReadonlySet<string> = new Set(HIGHLIGHT_COLORS);
+const LVL_JC_SET: ReadonlySet<string> = new Set(NUMBERING_LEVEL_JUSTIFICATIONS);
 const THEME_COLOR_SLOT_SET: ReadonlySet<string> = new Set(THEME_COLOR_SLOTS);
 
 function unsupported(path: string, feature: string): never {
@@ -108,6 +109,13 @@ function validateNumbering(definitions: NumberingSpec[]): Map<string, Set<number
       }
       if (level.start !== undefined && (!Number.isInteger(level.start) || level.start < 0)) {
         throw new GenerationSpecError('invalid_value', `${levelPath}/start`, 'Level start must be a non-negative integer');
+      }
+      if (level.lvlJc !== undefined && !LVL_JC_SET.has(level.lvlJc)) {
+        throw new GenerationSpecError(
+          'invalid_value',
+          `${levelPath}/lvlJc`,
+          `lvlJc must be one of ${NUMBERING_LEVEL_JUSTIFICATIONS.join(', ')}, got '${level.lvlJc}'`,
+        );
       }
       if (level.runProps) validateRunProps(level.runProps, `${levelPath}/runProps`);
     });

--- a/spec-compliance/CONFORMANCE.md
+++ b/spec-compliance/CONFORMANCE.md
@@ -769,8 +769,10 @@ advertise unused depth.
 - **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
 - **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:lvlJc`
 
-Level justification is always emitted (`left`) for determinism — omission
-leaves the alignment to reader defaults.
+Level justification is authorable per level via `NumberingSpec` (`left`,
+`center`, or `right`, the transitional ST_Jc subset) and is always emitted
+deterministically, defaulting to `left` when omitted. `right` aligns labels of
+differing widths on their right edge — the standard legal-outline convention.
 
 ### ECMA-PART1-17-3-1-19 — w:numPr paragraph numbering reference
 

--- a/spec-compliance/registry/ecma-376.md
+++ b/spec-compliance/registry/ecma-376.md
@@ -930,8 +930,10 @@ schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:lvlJc
 verifiedBy:
 ```
 
-Level justification is always emitted (`left`) for determinism — omission
-leaves the alignment to reader defaults.
+Level justification is authorable per level via `NumberingSpec` (`left`,
+`center`, or `right`, the transitional ST_Jc subset) and is always emitted
+deterministically, defaulting to `left` when omitted. `right` aligns labels of
+differing widths on their right edge — the standard legal-outline convention.
 
 ## [ECMA-PART1-17-3-1-19] w:numPr paragraph numbering reference
 


### PR DESCRIPTION
## Summary

The numbering generator hardcoded `<w:lvlJc w:val="left"/>` on every list level and `NumberingSpec` exposed no justification field, so a downstream legal-agreement renderer could not produce right-aligned outline numbering (where labels of differing widths line up on their right edge — `1.` vs `10.`, `1.1` vs `1.10`, the standard/NVCA convention). Closes #502.

## Changes

- **types.ts** — add `NUMBERING_LEVEL_JUSTIFICATIONS` const + `NumberingLevelJustification` union (the transitional ST_Jc subset `left`/`center`/`right`) and optional `level.lvlJc`, mirroring the existing `HIGHLIGHT_COLORS` single-source-of-truth pattern.
- **numbering-part.ts** — emit `level.lvlJc ?? 'left'` for `w:lvlJc` instead of the hardcoded `'left'`; element order (`…lvlText → lvlJc → pPr…`) unchanged, so omitting the field is byte-identical to current output.
- **validate-spec.ts** — reject an out-of-enum `lvlJc` (JSON/JS caller bypassing the type) with `GenerationSpecError('invalid_value', '…/lvlJc', …)` before emission.
- **spec-compliance** — update the `[ECMA-PART1-17-9-7]` registry prose (no longer "always left") and regenerate `CONFORMANCE.md`.
- **OpenSpec** — `add-numbering-level-justification` change with scenario `SDX-GEN-063`.
- **Test** — `generation-numbering-level-justification.test.ts` asserting `right`/`center`/default-`left` emission, CT_Lvl ordering, byte-identical double-render, package well-formedness, and out-of-enum rejection at `/numbering/0/levels/0/lvlJc`.

Backward-compatible additive field → patch/minor release.

## Out of scope

Full `CT_Jc`/`ST_Jc` value space (only the emitted subset), recipe-helper wiring, and read-side label computation (justification is purely visual; label text is unaffected).

## Verification

- `npx vitest run …generation-numbering-level-justification.test.ts …generation-numbering-recipes.test.ts` → 7 passed
- `tsc -p tsconfig.build.json` build clean; `lint` (tsc --noEmit) clean; `lint:workspaces` 0 errors
- `openspec validate add-numbering-level-justification --strict` valid
- `check:spec-coverage-generation` / root `check:spec-coverage` → `add-numbering-level-justification: 1 scenarios covered`
- `check:conformance-citations` OK; `check:conformance-doc` OK (post-commit)
- coverage ratchet passed (no line/branch regressions; +2.30% lines on docx-core)

## Peer review

Plan was peer-reviewed via Codex + agy before implementation. Codex caught the stale `[ECMA-PART1-17-9-7]` registry wording ("always left"), prompting the registry/doc update and the negative-path test; both folded in above.