### PR TITLE
docs(openspec): propose deterministic locator primitive

### DIFF
--- a/openspec/changes/add-deterministic-locator-primitive/design.md
+++ b/openspec/changes/add-deterministic-locator-primitive/design.md
@@ -1,0 +1,49 @@
+# Design: Deterministic Locator Primitive
+
+## Context
+open-agreements is replacing brittle global find/replace recipe logic with **selector contracts** resolved against a DOCX. It needs a reusable, deterministic way to locate a span and to learn when an upstream form change has broken a locator. Rather than hand-roll this in open-agreements, we land it in `@usejunior/docx-core` so it is tested once and dogfooded across consumers.
+
+## Goals / Non-goals
+- **Goal:** a pure, deterministic `resolveLocator(view, locator)` over the existing `DocumentView`.
+- **Goal:** make locator results safe to mutate by returning raw-text offsets (retire the #1 offset hazard with a tested map).
+- **Goal:** fix the empty free `buildDocumentView` stub so consumers can't trip on it.
+- **Non-goal:** fuzzy matching, scoring, ranking, or auto-repair. Drift is *reported*, not healed.
+- **Non-goal:** any MCP tool, mutation API, or schema change. The locator only locates; mutation stays on the existing `replaceParagraphTextRange`/`replaceTextAtRange`.
+
+## Types
+```ts
+type LocatorStep =
+  | { kind: 'section'; headingText?: string; headingRegex?: string; headingStyleId?: string; untilLevel?: number }
+  | { kind: 'regex'; pattern: string; flags?: string; group?: number }   // matched on clean_text
+  | { kind: 'contextual'; contextPattern: string; targetPattern: string; rowLabelPattern?: string }
+  | { kind: 'fingerprint'; contentFingerprint: string };                 // whole-node anchor
+
+interface Locator { scope?: LocatorStep[]; primary: LocatorStep; assertions?: LocatorStep[]; }
+
+interface LocatorResolution {
+  match: { nodeId: string; start: number; end: number } | null;  // RAW offsets (clean_text match → raw via map)
+  unresolved: boolean;                                           // primary != exactly one match
+  assertionResults: Array<{ ok: boolean; kind: string; detail?: string }>;
+}
+
+function resolveLocator(view: DocumentViewNode[], locator: Locator): LocatorResolution;
+```
+
+**Step-kind constraints (validated at runtime / via schema):** `section` may appear ONLY in `scope` (it denotes a region, not a span). `primary` and every `assertions` entry MUST be `regex` | `contextual` | `fingerprint`. A `regex`/`contextual` pattern that can match zero-length is invalid (→ `unresolved`). `fingerprint` matches node identity and is computed from the node's raw visible text (`node.text`) via `computeContentFingerprint` — consistent with that function's existing "raw visible text" basis (it NFKC-normalizes/strips/collapses internally).
+
+## Determinism model (primary + assertions)
+- `scope` steps run in order; each `section` must match **exactly one** heading in the current region or the locator is `unresolved`. The region runs from the matched heading to the next heading at outline level `≤ untilLevel`.
+- `primary` must produce **exactly one** span in scope. Zero or many → `unresolved`. There is no tie-break: ambiguity is a drift signal, deliberately, so callers update the selector rather than silently filling the wrong place.
+- `assertions` never select. Span kinds (`regex`/`contextual`) must equal the primary's resolved `{nodeId,start,end}`; `fingerprint` assertions match `nodeId` only. Results are reported; failures are drift.
+- Regex iteration is left-to-right; "exactly one" is counted over all matches in scope. No `Set`/`Map` iteration order is relied upon.
+
+## Offset model (the #1 risk)
+Patterns are authored against `clean_text` (stable, normalized, human/LLM-readable). But mutation needs **raw** offsets. We build a per-node `clean_text → raw` map covering the transforms `clean_text` actually applies — leading/trailing trim, CR/LF removal, and manual-list-label stripping — and translate the matched span before returning it. `clean_text` does NOT collapse internal whitespace (verified: it is `getParagraphText().replace(/\r|\n/g,'').trim()` + optional `stripListLabel`; internal whitespace collapse lives only in `computeContentFingerprint`), so the map does not handle that case. This centralizes the only correctness-sensitive arithmetic in one tested place, generalizing the scalar `visible_offset_correction`. Where `clean_text === raw`, translation is identity.
+
+## buildDocumentView shared core
+The populated per-paragraph logic currently lives only in `DocxDocument.buildDocumentView()`; the free `buildDocumentView(params)` is an empty stub. Extract the per-paragraph builder into a shared pure helper and have both call it, so the free function returns populated nodes. This is an internal refactor: the free function is not re-exported from `index.ts` today and has no non-test callers, so behavior for existing method callers is unchanged. Both paths include only paragraphs carrying a `_bk_*` bookmark id (existing `buildDocumentView` behavior: it drops paragraphs where `getParagraphBookmarkId` is empty) and neither inserts bookmarks — a consumer operating on un-bookmarked source DOCX MUST call `DocxDocument.insertParagraphBookmarks()` first. That is the consuming repo's responsibility, not this primitive's.
+
+## Risks
+- **Offset map correctness** is the highest risk; mitigated by per-transform unit tests (trim / CR-LF / list-label / whitespace-collapse) and an identity test.
+- **Heading detection ambiguity** for `section`: handled by the exactly-one rule (ambiguity → unresolved), not heuristics.
+- **Version coupling:** consumers must pin `^0.12.0`; called out in the proposal and the consuming repo's change.

--- a/openspec/changes/add-deterministic-locator-primitive/proposal.md
+++ b/openspec/changes/add-deterministic-locator-primitive/proposal.md
@@ -1,0 +1,21 @@
+# Change: Add Deterministic Locator Primitive
+
+## Why
+Downstream consumers (starting with open-agreements "selector-contract recipes") need to locate a specific span of text in a DOCX **resiliently and deterministically** — "find the company name inside the preamble", not "replace literal `[Insert Company Name]` everywhere". Today safe-docx exposes a `DocumentView` and `computeContentFingerprint`, but no layer that resolves a *bundle* of anchors (section, regex, contextual, fingerprint) to a single text span and reports drift when the document changes. Each consumer would otherwise hand-roll matching — and the offset translation needed to mutate the result is a known footgun (see below).
+
+Two correctness hazards block consumers from doing this safely on their own:
+1. **Offset coordinate mismatch.** `replaceParagraphTextRange`/`replaceTextAtRange` operate on **raw visible-text** offsets (`getParagraphRuns().map(r => r.text).join('')`), but `DocumentViewNode.clean_text` (the natural text to author patterns against) is `getParagraphText().replace(/\r|\n/g, '').trim()` plus optional manual-list-label stripping — so its offsets diverge from raw by a (mostly leading) correction. The only existing correction, `visible_offset_correction`, is a single scalar. (Note: `clean_text` does NOT collapse internal whitespace; only `computeContentFingerprint` does.)
+2. **Stubbed builder.** The free `buildDocumentView(params)` export currently returns `{ nodes: [] }` — only the `DocxDocument.buildDocumentView()` method is populated. A consumer deep-importing the free function silently gets nothing. (Both the method and the free function include only paragraphs carrying a `_bk_*` bookmark id and do not insert bookmarks — see below.)
+
+## What Changes
+- NEW: `locator.ts` in docx-core — a deterministic `resolveLocator(view, locator)` that resolves a `Locator` (`scope` + `primary` + `assertions`) to one raw-offset span and reports `unresolved` / assertion drift. `section` is a scope-only step kind (not a `primary`/assertion); `fingerprint` is a whole-node anchor computed from the node's raw visible text; zero-length regex matches are invalid.
+- NEW: tested `clean_text → raw` offset-map primitive (per node), generalizing the scalar `visible_offset_correction`, covering the transforms `clean_text` actually applies: leading/trailing trim, CR/LF removal, and manual-list-label stripping. It does NOT cover internal whitespace collapse (`clean_text` does not collapse it).
+- MODIFIED: `document_view.ts` — extract the populated per-paragraph view logic into a shared pure helper so **both** `DocxDocument.buildDocumentView()` and the free `buildDocumentView(params)` produce populated nodes (one node per **bookmarked** paragraph), fixing the empty-stub footgun. Neither inserts bookmarks; consumers operating on un-bookmarked source must call `DocxDocument.insertParagraphBookmarks()` first.
+- MODIFIED: `index.ts` — export `resolveLocator`, the `Locator`/`LocatorStep`/`LocatorResolution` types, and the offset-map helper.
+- NO MCP tool changes and NO new runtime dependencies in this change.
+
+## Impact
+- Affected specs: `docx-primitives`
+- Affected code: `packages/docx-core/src/primitives/locator.ts` (new), `packages/docx-core/src/primitives/locator.test.ts` (new), `packages/docx-core/src/primitives/document_view.ts` (shared-core refactor + offset map), `packages/docx-core/src/primitives/document_view-types.ts` (offset-map field), `packages/docx-core/src/index.ts` (exports)
+- Determinism: resolution is total and reproducible — no randomness, no scoring, no fuzzy matching, no tie-break heuristics. A `primary`/`section` step that does not match **exactly once** in scope yields `unresolved` (a drift signal), never a "best guess".
+- Release: ships as `@usejunior/docx-core` **0.12.0**. Consumers that rely on the locator MUST pin `^0.12.0`.

--- a/openspec/changes/add-deterministic-locator-primitive/specs/docx-primitives/spec.md
+++ b/openspec/changes/add-deterministic-locator-primitive/specs/docx-primitives/spec.md
@@ -42,7 +42,7 @@ A `section` scope step SHALL narrow resolution to a contiguous region of the vie
 - **AND** the resolver SHALL NOT silently choose the first heading
 
 ### Requirement: Locator Step Kinds
-The resolver SHALL support four deterministic step kinds. `section` SHALL match a heading by `headingText`/`headingRegex`/`headingStyleId` and SHALL be valid ONLY as a `scope` step — it SHALL NOT be used as a `primary` or assertion, because it denotes a region, not a span. `regex` SHALL match against node `clean_text` and report 0, 1, or many matches; a pattern that yields a zero-length match SHALL be treated as invalid and make the locator `unresolved` (no heuristic advance). `contextual` SHALL require a `contextPattern` to precede the `targetPattern` within a node, optionally gated by `rowLabelPattern` over `table_context.col_header`; its `targetPattern` SHALL likewise be non-zero-length. `fingerprint` SHALL select a whole node whose content fingerprint — computed from the node's raw visible text (`node.text`) via `computeContentFingerprint`, consistent with that function's existing definition — equals the given `sha256:nfkc:` value; it is a node-level anchor and SHALL NOT denote a sub-span.
+The resolver SHALL support four deterministic step kinds. `section` SHALL match a heading by `headingText`/`headingRegex`/`headingStyleId` and SHALL be valid ONLY as a `scope` step — it SHALL NOT be used as a `primary` or assertion, because it denotes a region, not a span. `regex` SHALL match against node `clean_text` and report 0, 1, or many matches; a pattern that yields a zero-length match SHALL be treated as invalid and make the locator `unresolved` (no heuristic advance). `contextual` SHALL require a `contextPattern` to precede the `targetPattern` within a node, optionally gated by `rowLabelPattern` over `table_context.col_header`; its `targetPattern` SHALL likewise be non-zero-length. `fingerprint` SHALL select a whole node whose content fingerprint — computed from the node's raw visible text (`node.raw_text`, falling back to `node.text` when absent) via `computeContentFingerprint`, consistent with that function's existing definition — equals the given `sha256:nfkc:` value; it is a node-level anchor and SHALL NOT denote a sub-span.
 
 #### Scenario: section is scope-only
 - **GIVEN** a locator whose `primary` (or an assertion) is a `section` step
@@ -62,7 +62,7 @@ The resolver SHALL support four deterministic step kinds. `section` SHALL match 
 - **THEN** the span matching the target after the context SHALL be returned
 
 #### Scenario: fingerprint selects a whole node
-- **GIVEN** a `fingerprint` primary whose value equals one node's `computeContentFingerprint(node.text)` (raw visible text)
+- **GIVEN** a `fingerprint` primary whose value equals one node's `computeContentFingerprint(node.raw_text)` (raw visible text)
 - **WHEN** `resolveLocator` is called
 - **THEN** the match SHALL span that whole node
 - **AND** no sub-span offset narrowing SHALL be applied

--- a/openspec/changes/add-deterministic-locator-primitive/specs/docx-primitives/spec.md
+++ b/openspec/changes/add-deterministic-locator-primitive/specs/docx-primitives/spec.md
@@ -1,0 +1,119 @@
+## ADDED Requirements
+
+### Requirement: Deterministic Locator Resolution
+The system SHALL provide `resolveLocator(view, locator)` that resolves a `Locator` against a `DocumentViewNode[]` to at most one text span, deterministically. A `Locator` SHALL consist of an optional ordered `scope` (one or more `section` steps), a required single `primary` step, and optional ordered `assertions`. Resolution SHALL be total and reproducible: identical inputs SHALL always yield identical output, with no randomness, no scoring, no confidence weighting, and no fuzzy matching. The returned `match` offsets SHALL be **raw** paragraph-text offsets (consumable directly by `replaceParagraphTextRange`/`replaceTextAtRange`), translated from the `clean_text` match position via the offset map.
+
+#### Scenario: primary resolves exactly one span
+- **GIVEN** a view and a locator whose `primary` regex matches exactly one span in scope
+- **WHEN** `resolveLocator` is called
+- **THEN** `match` SHALL be `{ nodeId, start, end }` with raw-text offsets
+- **AND** `unresolved` SHALL be `false`
+
+#### Scenario: zero matches is unresolved
+- **GIVEN** a locator whose `primary` step matches nothing in scope
+- **WHEN** `resolveLocator` is called
+- **THEN** `match` SHALL be `null`
+- **AND** `unresolved` SHALL be `true`
+
+#### Scenario: multiple matches is unresolved, never a guess
+- **GIVEN** a locator whose `primary` step matches more than once in scope
+- **WHEN** `resolveLocator` is called
+- **THEN** `unresolved` SHALL be `true`
+- **AND** the resolver SHALL NOT pick the first or any "best" match
+
+#### Scenario: resolution is reproducible
+- **GIVEN** the same view and locator
+- **WHEN** `resolveLocator` is called twice
+- **THEN** both calls SHALL return byte-identical results
+
+### Requirement: Locator Scope Narrowing
+A `section` scope step SHALL narrow resolution to a contiguous region of the view: from the single heading node it matches, up to (but excluding) the next heading at outline level `≤ untilLevel`. A `section` step SHALL match **exactly one** heading in the current scope; zero or multiple matching headings SHALL make the locator `unresolved`. Multiple `scope` steps SHALL apply in order, each narrowing within the previous region.
+
+#### Scenario: section narrows to its region
+- **GIVEN** a view with a heading "Preamble" followed by body paragraphs and a later heading
+- **AND** a locator with `scope: [{ kind: 'section', headingText: 'Preamble' }]` and a `primary` regex present both inside and outside the region
+- **WHEN** `resolveLocator` is called
+- **THEN** only the occurrence inside the Preamble region SHALL be considered
+
+#### Scenario: repeated heading is unresolved
+- **GIVEN** a view containing two headings with identical text matched by a `section` step
+- **WHEN** `resolveLocator` is called
+- **THEN** `unresolved` SHALL be `true`
+- **AND** the resolver SHALL NOT silently choose the first heading
+
+### Requirement: Locator Step Kinds
+The resolver SHALL support four deterministic step kinds. `section` SHALL match a heading by `headingText`/`headingRegex`/`headingStyleId` and SHALL be valid ONLY as a `scope` step — it SHALL NOT be used as a `primary` or assertion, because it denotes a region, not a span. `regex` SHALL match against node `clean_text` and report 0, 1, or many matches; a pattern that yields a zero-length match SHALL be treated as invalid and make the locator `unresolved` (no heuristic advance). `contextual` SHALL require a `contextPattern` to precede the `targetPattern` within a node, optionally gated by `rowLabelPattern` over `table_context.col_header`; its `targetPattern` SHALL likewise be non-zero-length. `fingerprint` SHALL select a whole node whose content fingerprint — computed from the node's raw visible text (`node.text`) via `computeContentFingerprint`, consistent with that function's existing definition — equals the given `sha256:nfkc:` value; it is a node-level anchor and SHALL NOT denote a sub-span.
+
+#### Scenario: section is scope-only
+- **GIVEN** a locator whose `primary` (or an assertion) is a `section` step
+- **WHEN** `resolveLocator` is called
+- **THEN** it SHALL be rejected as invalid because `section` does not produce a span
+
+#### Scenario: zero-length regex is unresolved
+- **GIVEN** a `regex` primary whose pattern can match an empty string
+- **WHEN** `resolveLocator` is called
+- **THEN** `unresolved` SHALL be `true`
+- **AND** no zero-length span SHALL be returned
+
+#### Scenario: contextual requires context before target
+- **GIVEN** a node "by and among NewCo, Inc., a Delaware corporation and the Investors"
+- **AND** a `contextual` step with `contextPattern: "by and among"` and `targetPattern: "[A-Z][\\w, .]+, a Delaware corporation"`
+- **WHEN** `resolveLocator` is called
+- **THEN** the span matching the target after the context SHALL be returned
+
+#### Scenario: fingerprint selects a whole node
+- **GIVEN** a `fingerprint` primary whose value equals one node's `computeContentFingerprint(node.text)` (raw visible text)
+- **WHEN** `resolveLocator` is called
+- **THEN** the match SHALL span that whole node
+- **AND** no sub-span offset narrowing SHALL be applied
+
+### Requirement: Locator Assertions
+Assertions SHALL corroborate, never select. A `regex` or `contextual` assertion SHALL be satisfied only when it resolves to the **same** `{ nodeId, start, end }` as `primary` (raw coordinate system, post-translation). A `fingerprint` assertion SHALL be satisfied when it matches the **same `nodeId`** as `primary` — span equality SHALL NOT apply to fingerprint assertions, since a fingerprint is a whole-node anchor. Each assertion result SHALL be reported in `assertionResults`; any failed assertion is a drift signal.
+
+#### Scenario: span assertion must equal primary span
+- **GIVEN** a resolved primary span and a `regex` assertion resolving to a different span in the same node
+- **WHEN** `resolveLocator` is called
+- **THEN** that assertion's result SHALL be `ok: false`
+
+#### Scenario: fingerprint assertion matches node identity only
+- **GIVEN** a resolved primary span and a `fingerprint` assertion whose value equals the primary node's fingerprint
+- **WHEN** `resolveLocator` is called
+- **THEN** that assertion's result SHALL be `ok: true`
+- **AND** the whole-node fingerprint SHALL NOT be compared against the primary sub-span offsets
+
+#### Scenario: failed assertion does not change the match
+- **GIVEN** a resolved primary span and a failing assertion
+- **WHEN** `resolveLocator` is called
+- **THEN** `match` SHALL still be the primary span
+- **AND** the failure SHALL be reported in `assertionResults`
+
+### Requirement: Clean-to-Raw Offset Map
+The system SHALL provide a per-node `clean_text → raw` offset map that translates a character offset in a node's `clean_text` to the corresponding offset in its raw visible text. The map SHALL account for the transforms `clean_text` actually applies: leading/trailing trim, CR/LF removal, and manual list-label stripping. It SHALL NOT assume internal whitespace collapse, because `clean_text` does not collapse internal whitespace (only `computeContentFingerprint` does). This map generalizes the scalar `visible_offset_correction` for offset translation and SHALL be the mechanism by which locator matches (authored against `clean_text`) become raw offsets for mutation.
+
+#### Scenario: leading trim is mapped
+- **GIVEN** a paragraph whose raw text has leading whitespace that `clean_text` trims
+- **WHEN** a clean_text offset is translated
+- **THEN** the resulting raw offset SHALL include the trimmed leading length
+
+#### Scenario: stripped list label is mapped
+- **GIVEN** a paragraph with a manual list label stripped from `clean_text`
+- **WHEN** a clean_text offset is translated
+- **THEN** the raw offset SHALL include the stripped-label length
+
+#### Scenario: identity when clean equals raw
+- **GIVEN** a paragraph whose `clean_text` equals its raw text
+- **WHEN** any offset is translated
+- **THEN** the raw offset SHALL equal the clean offset
+
+### Requirement: Populated Free buildDocumentView
+The free `buildDocumentView(params)` export SHALL return populated nodes equivalent to `DocxDocument.buildDocumentView()`, by sharing a common pure core. The previous behavior of returning an empty `nodes` array SHALL be removed. Both the method and the free function SHALL include only paragraphs carrying a `_bk_*` bookmark id, and neither SHALL insert bookmarks.
+
+#### Scenario: free function returns populated nodes
+- **GIVEN** a parsed document XML whose paragraphs carry `_bk_*` bookmark ids
+- **WHEN** the free `buildDocumentView(params)` is called
+- **THEN** it SHALL return one node per bookmarked paragraph (not an empty array)
+
+#### Scenario: free function matches the method
+- **GIVEN** the same bookmarked document loaded via `DocxDocument`
+- **WHEN** both the free function and `DocxDocument.buildDocumentView()` run with equivalent options
+- **THEN** their node lists SHALL be equivalent

--- a/openspec/changes/add-deterministic-locator-primitive/tasks.md
+++ b/openspec/changes/add-deterministic-locator-primitive/tasks.md
@@ -1,23 +1,23 @@
 ## 1. docx-core: buildDocumentView shared core
-- [ ] 1.1 Extract the populated per-paragraph view logic from `DocxDocument.buildDocumentView()` (document.ts) into a shared pure helper in `document_view.ts`
-- [ ] 1.2 Have both `DocxDocument.buildDocumentView()` and the free `buildDocumentView(params)` (document_view.ts) delegate to the shared helper
-- [ ] 1.3 Add a test asserting the free `buildDocumentView` returns populated nodes (one per bookmarked paragraph) and matches the method output; confirm neither inserts bookmarks
+- [x] 1.1 Extract the populated per-paragraph view logic from `DocxDocument.buildDocumentView()` (document.ts) into a shared pure helper in `document_view.ts`
+- [x] 1.2 Have both `DocxDocument.buildDocumentView()` and the free `buildDocumentView(params)` (document_view.ts) delegate to the shared helper
+- [x] 1.3 Add a test asserting the free `buildDocumentView` returns populated nodes (one per bookmarked paragraph) and matches the method output; confirm neither inserts bookmarks
 
 ## 2. docx-core: clean_text → raw offset map
-- [ ] 2.1 Add a per-node `clean_text → raw` offset-map builder in `document_view.ts` covering the actual `clean_text` transforms: leading/trailing trim, CR/LF removal, and manual-list-label stripping (NOT internal whitespace collapse — `clean_text` does not collapse it)
-- [ ] 2.2 Expose a `cleanToRawOffset(node, cleanOffset)` translation helper; generalize the scalar `visible_offset_correction` for translation
-- [ ] 2.3 Unit-test each transform (leading trim, CR/LF, list-label) and the identity case
+- [x] 2.1 Add a per-node `clean_text → raw` offset-map builder in `document_view.ts` covering the actual `clean_text` transforms: leading/trailing trim, CR/LF removal, and manual-list-label stripping (NOT internal whitespace collapse — `clean_text` does not collapse it)
+- [x] 2.2 Expose a `cleanToRawOffset(node, cleanOffset)` translation helper; generalize the scalar `visible_offset_correction` for translation
+- [x] 2.3 Unit-test each transform (leading trim, CR/LF, list-label) and the identity case
 
 ## 3. docx-core: locator primitive
-- [ ] 3.1 Create `locator.ts` with `LocatorStep`/`Locator`/`LocatorResolution` types and `resolveLocator(view, locator)`; constrain `section` to `scope` only and `primary`/`assertions` to `regex`/`contextual`/`fingerprint` (schema/runtime validation)
-- [ ] 3.2 Implement `scope` (`section`) narrowing with the exactly-one-heading rule and `untilLevel` region boundary
-- [ ] 3.3 Implement `primary` resolution (`regex`/`contextual`/`fingerprint`) with the exactly-one-span rule (0/>1 → `unresolved`); reject zero-length `regex`/`contextual` matches as `unresolved`
-- [ ] 3.4 Compute `fingerprint` from the node's raw visible text (`node.text`) via `computeContentFingerprint`; translate the matched clean_text span to raw offsets via the offset map for the returned `match`
-- [ ] 3.5 Implement `assertions`: span kinds (`regex`/`contextual`) compare `{nodeId,start,end}`; `fingerprint` compares `nodeId` only; report `assertionResults`
-- [ ] 3.6 Export `resolveLocator` and the locator types from `index.ts`
+- [x] 3.1 Create `locator.ts` with `LocatorStep`/`Locator`/`LocatorResolution` types and `resolveLocator(view, locator)`; constrain `section` to `scope` only and `primary`/`assertions` to `regex`/`contextual`/`fingerprint` (schema/runtime validation)
+- [x] 3.2 Implement `scope` (`section`) narrowing with the exactly-one-heading rule and `untilLevel` region boundary
+- [x] 3.3 Implement `primary` resolution (`regex`/`contextual`/`fingerprint`) with the exactly-one-span rule (0/>1 → `unresolved`); reject zero-length `regex`/`contextual` matches as `unresolved`
+- [x] 3.4 Compute `fingerprint` from the node's raw visible text (`node.raw_text`, falling back to `node.text`) via `computeContentFingerprint`; translate the matched clean_text span to raw offsets via the offset map for the returned `match`
+- [x] 3.5 Implement `assertions`: span kinds (`regex`/`contextual`) compare `{nodeId,start,end}`; `fingerprint` compares `nodeId` only; report `assertionResults`
+- [x] 3.6 Export `resolveLocator` and the locator types from `index.ts`
 
 ## 4. Tests and verification
-- [ ] 4.1 `locator.test.ts` (allure BDD-style) covers every scenario in the spec delta (exactly-one, zero, many, reproducibility, scope narrowing, repeated-heading, each step kind, assertion semantics)
-- [ ] 4.2 Determinism test: `resolveLocator` called twice on the same inputs returns identical results
-- [ ] 4.3 `npm run build` and `npm run test` pass; `npm run check:spec-coverage` maps new scenarios to tests
+- [x] 4.1 `locator.test.ts` (allure BDD-style) covers every scenario in the spec delta (exactly-one, zero, many, reproducibility, scope narrowing, repeated-heading, each step kind, assertion semantics)
+- [x] 4.2 Determinism test: `resolveLocator` called twice on the same inputs returns identical results
+- [x] 4.3 `npm run build` and `npm run test` pass; `npm run check:spec-coverage` maps new scenarios to tests
 - [ ] 4.4 Release `@usejunior/docx-core` 0.12.0 (this is the hard prerequisite for the open-agreements consuming change)

--- a/openspec/changes/add-deterministic-locator-primitive/tasks.md
+++ b/openspec/changes/add-deterministic-locator-primitive/tasks.md
@@ -1,0 +1,23 @@
+## 1. docx-core: buildDocumentView shared core
+- [ ] 1.1 Extract the populated per-paragraph view logic from `DocxDocument.buildDocumentView()` (document.ts) into a shared pure helper in `document_view.ts`
+- [ ] 1.2 Have both `DocxDocument.buildDocumentView()` and the free `buildDocumentView(params)` (document_view.ts) delegate to the shared helper
+- [ ] 1.3 Add a test asserting the free `buildDocumentView` returns populated nodes (one per bookmarked paragraph) and matches the method output; confirm neither inserts bookmarks
+
+## 2. docx-core: clean_text → raw offset map
+- [ ] 2.1 Add a per-node `clean_text → raw` offset-map builder in `document_view.ts` covering the actual `clean_text` transforms: leading/trailing trim, CR/LF removal, and manual-list-label stripping (NOT internal whitespace collapse — `clean_text` does not collapse it)
+- [ ] 2.2 Expose a `cleanToRawOffset(node, cleanOffset)` translation helper; generalize the scalar `visible_offset_correction` for translation
+- [ ] 2.3 Unit-test each transform (leading trim, CR/LF, list-label) and the identity case
+
+## 3. docx-core: locator primitive
+- [ ] 3.1 Create `locator.ts` with `LocatorStep`/`Locator`/`LocatorResolution` types and `resolveLocator(view, locator)`; constrain `section` to `scope` only and `primary`/`assertions` to `regex`/`contextual`/`fingerprint` (schema/runtime validation)
+- [ ] 3.2 Implement `scope` (`section`) narrowing with the exactly-one-heading rule and `untilLevel` region boundary
+- [ ] 3.3 Implement `primary` resolution (`regex`/`contextual`/`fingerprint`) with the exactly-one-span rule (0/>1 → `unresolved`); reject zero-length `regex`/`contextual` matches as `unresolved`
+- [ ] 3.4 Compute `fingerprint` from the node's raw visible text (`node.text`) via `computeContentFingerprint`; translate the matched clean_text span to raw offsets via the offset map for the returned `match`
+- [ ] 3.5 Implement `assertions`: span kinds (`regex`/`contextual`) compare `{nodeId,start,end}`; `fingerprint` compares `nodeId` only; report `assertionResults`
+- [ ] 3.6 Export `resolveLocator` and the locator types from `index.ts`
+
+## 4. Tests and verification
+- [ ] 4.1 `locator.test.ts` (allure BDD-style) covers every scenario in the spec delta (exactly-one, zero, many, reproducibility, scope narrowing, repeated-heading, each step kind, assertion semantics)
+- [ ] 4.2 Determinism test: `resolveLocator` called twice on the same inputs returns identical results
+- [ ] 4.3 `npm run build` and `npm run test` pass; `npm run check:spec-coverage` maps new scenarios to tests
+- [ ] 4.4 Release `@usejunior/docx-core` 0.12.0 (this is the hard prerequisite for the open-agreements consuming change)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-docx-suite",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "private": true,
   "description": "Monorepo for Safe DOCX packages",
   "repository": {

--- a/packages/docx-core/package.json
+++ b/packages/docx-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/docx-core",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "description": "OOXML (.docx) core library: primitives, comparison, and track changes",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/docx-core/src/primitives/document.ts
+++ b/packages/docx-core/src/primitives/document.ts
@@ -16,7 +16,7 @@ import {
   createRevisionContainer,
   type RevisionContext,
 } from './track-changes-emitter.js';
-import { buildNodesForDocumentView, type DocumentStyles, type DocumentViewNode, type TableContext } from './document_view.js';
+import { buildNodesForDocumentView, collectViewParagraphs, type DocumentStyles, type DocumentViewNode } from './document_view.js';
 import { serializeToMarkdown, type SerializeMarkdownOptions } from './serialize_markdown.js';
 import { serializeToHtml, type SerializeHtmlOptions } from './serialize_html.js';
 import { serializeToPlainText, type SerializePlainTextOptions } from './serialize_plaintext.js';
@@ -184,204 +184,6 @@ function nextElementSibling(node: Node | null): Element | null {
     cur = cur.nextSibling;
   }
   return null;
-}
-
-// ── Table context derivation for document view ───────────────────────
-
-type TableMeta = {
-  tableIndex: number;
-  tableId: string;
-  rows: Element[];
-  headers: string[];
-  totalCols: number;
-};
-
-/**
- * Collect all w:tr descendants of a table element, descending through
- * w:ins/w:del/w:sdt wrappers but not into nested w:tbl elements.
- */
-function collectTableRows(tbl: Element): Element[] {
-  const rows: Element[] = [];
-  function walk(parent: Element) {
-    for (let i = 0; i < parent.childNodes.length; i++) {
-      const child = parent.childNodes[i]!;
-      if (child.nodeType !== 1) continue;
-      const el = child as Element;
-      if (isW(el, W.tr)) {
-        rows.push(el);
-      } else if (!isW(el, W.tbl)) {
-        walk(el);
-      }
-    }
-  }
-  walk(tbl);
-  return rows;
-}
-
-/**
- * Collect all w:tc descendants of a row element, descending through
- * w:ins/w:del/w:sdt wrappers but not into nested w:tr or w:tbl elements.
- */
-function collectRowCells(tr: Element): Element[] {
-  const cells: Element[] = [];
-  function walk(parent: Element) {
-    for (let i = 0; i < parent.childNodes.length; i++) {
-      const child = parent.childNodes[i]!;
-      if (child.nodeType !== 1) continue;
-      const el = child as Element;
-      if (isW(el, W.tc)) {
-        cells.push(el);
-      } else if (!isW(el, W.tr) && !isW(el, W.tbl)) {
-        walk(el);
-      }
-    }
-  }
-  walk(tr);
-  return cells;
-}
-
-/** Get the gridSpan value for a table cell (default 1). */
-function getCellGridSpan(tc: Element): number {
-  const tcPrList = getDirectChildrenByName(tc, W.tcPr);
-  if (tcPrList.length === 0) return 1;
-  const gridSpanEls = getDirectChildrenByName(tcPrList[0]!, 'gridSpan');
-  if (gridSpanEls.length === 0) return 1;
-  const val =
-    gridSpanEls[0]!.getAttributeNS(OOXML.W_NS, W.val) ??
-    gridSpanEls[0]!.getAttribute('w:val') ??
-    gridSpanEls[0]!.getAttribute(W.val);
-  if (!val) return 1;
-  const n = parseInt(val, 10);
-  return n > 0 ? n : 1;
-}
-
-/** Get visible text from a cell's direct paragraphs (excludes nested tables). */
-function getCellHeaderText(tc: Element): string {
-  const parts: string[] = [];
-  for (let i = 0; i < tc.childNodes.length; i++) {
-    const child = tc.childNodes[i]!;
-    if (child.nodeType === 1 && isW(child as Element, W.p)) {
-      parts.push(getParagraphText(child as Element).trim());
-    }
-  }
-  return parts.join(' ').trim();
-}
-
-/**
- * Build metadata map for body-level tables.
- * Only indexes direct w:tbl children of w:body (consistent with extractTables).
- */
-function buildTableMetaMap(body: Element): Map<Element, TableMeta> {
-  const map = new Map<Element, TableMeta>();
-  const tables = getDirectChildrenByName(body, W.tbl);
-
-  for (let tableIndex = 0; tableIndex < tables.length; tableIndex++) {
-    const tbl = tables[tableIndex]!;
-    const rows = collectTableRows(tbl);
-    if (rows.length === 0) continue;
-
-    // Compute max grid columns across all rows
-    let maxGridCols = 0;
-    for (const row of rows) {
-      const cells = collectRowCells(row);
-      let gridCols = 0;
-      for (const cell of cells) {
-        gridCols += getCellGridSpan(cell);
-      }
-      if (gridCols > maxGridCols) maxGridCols = gridCols;
-    }
-
-    // Extract headers from row 0
-    const headerRow = rows[0]!;
-    const headerCells = collectRowCells(headerRow);
-    const headers: string[] = [];
-    for (const cell of headerCells) {
-      const span = getCellGridSpan(cell);
-      const text = getCellHeaderText(cell);
-      headers.push(text);
-      for (let s = 1; s < span; s++) headers.push('');
-    }
-    while (headers.length < maxGridCols) headers.push('');
-    if (headers.length > maxGridCols) headers.length = maxGridCols;
-
-    map.set(tbl, {
-      tableIndex,
-      tableId: `_tbl_${tableIndex}`,
-      rows,
-      headers,
-      totalCols: maxGridCols,
-    });
-  }
-
-  return map;
-}
-
-/**
- * Derive table context for a paragraph by walking up the DOM.
- * Returns undefined if the paragraph is not inside a body-level table.
- */
-function deriveTableContext(p: Element, tableMetaMap: Map<Element, TableMeta>): TableContext | undefined {
-  let tc: Element | null = null;
-  let tr: Element | null = null;
-  let tbl: Element | null = null;
-
-  let current: Node | null = p.parentNode;
-  while (current && current.nodeType === 1) {
-    const el = current as Element;
-    if (isW(el, W.body)) break;
-
-    if (isW(el, W.tc)) tc = el;
-    if (isW(el, W.tr)) tr = el;
-    if (isW(el, W.tbl)) {
-      if (tableMetaMap.has(el)) {
-        tbl = el;
-        break;
-      }
-      // Nested table: reset tc/tr, keep walking to find body-level table
-      tc = null;
-      tr = null;
-    }
-
-    current = el.parentNode;
-  }
-
-  if (!tbl || !tr || !tc) return undefined;
-
-  const meta = tableMetaMap.get(tbl)!;
-
-  // Compute row_index
-  const rowIndex = meta.rows.indexOf(tr);
-  if (rowIndex < 0) return undefined;
-
-  // Compute grid-aware col_index by summing gridSpan for preceding cells
-  const rowCells = collectRowCells(tr);
-  let gridCol = 0;
-  let cellFound = false;
-  for (const cell of rowCells) {
-    if (cell === tc) {
-      cellFound = true;
-      break;
-    }
-    gridCol += getCellGridSpan(cell);
-  }
-  if (!cellFound) return undefined;
-
-  // Compute para_in_cell and cell_para_count
-  const allCellPs = Array.from(tc.getElementsByTagNameNS(OOXML.W_NS, W.p));
-  const paraInCell = allCellPs.indexOf(p);
-
-  return {
-    table_id: meta.tableId,
-    table_index: meta.tableIndex,
-    row_index: rowIndex,
-    col_index: gridCol,
-    col_header: meta.headers[gridCol] ?? '',
-    total_rows: meta.rows.length,
-    total_cols: meta.totalCols,
-    is_header_row: rowIndex === 0,
-    para_in_cell: paraInCell >= 0 ? paraInCell : 0,
-    cell_para_count: allCellPs.length,
-  };
 }
 
 export class DocxDocument {
@@ -667,18 +469,9 @@ export class DocxDocument {
       return { nodes: cached.nodes, styles: cached.styles };
     }
 
-    // Pre-pass: build metadata for body-level tables
-    const body = this.documentXml.getElementsByTagNameNS(OOXML.W_NS, W.body).item(0);
-    const tableMetaMap = body ? buildTableMetaMap(body as Element) : new Map<Element, TableMeta>();
-
-    const paragraphs = this.getParagraphs()
-      .map((p): { id: string; p: Element; tableContext?: TableContext } | null => {
-        const id = getParagraphBookmarkId(p);
-        if (!id) return null;
-        const tableContext = deriveTableContext(p, tableMetaMap);
-        return tableContext ? { id, p, tableContext } : { id, p };
-      })
-      .filter((x): x is { id: string; p: Element; tableContext?: TableContext } => x !== null);
+    // Shared paragraph-collection core (also used by the free buildDocumentView):
+    // attaches each bookmarked paragraph's table context.
+    const paragraphs = collectViewParagraphs(this.documentXml);
 
     const { nodes, styles } = buildNodesForDocumentView({
       paragraphs,

--- a/packages/docx-core/src/primitives/document_view-types.ts
+++ b/packages/docx-core/src/primitives/document_view-types.ts
@@ -117,6 +117,19 @@ export type DocumentViewNode = {
 
   // Metadata for JSON mode / parity tooling.
   clean_text: string;
+  /**
+   * Raw visible paragraph text (field codes stripped) BEFORE CR/LF removal,
+   * trimming, and manual-list-label stripping — i.e. exactly `getParagraphText(p)`.
+   * This is the coordinate system that `replaceParagraphTextRange` /
+   * `DocxDocument.replaceTextAtRange` operate in. Selector patterns are authored
+   * against `clean_text`; {@link buildCleanToRawOffsetMap} uses `raw_text` +
+   * `clean_text` to translate a matched clean-text span back to raw offsets so
+   * mutation lands on the right characters.
+   *
+   * Optional only so legacy test fixtures that hand-build nodes stay valid; the
+   * real builder (`buildNodesForDocumentView`) always populates it.
+   */
+  raw_text?: string;
   tagged_text: string;
   list_metadata: ListMetadata;
   style_fingerprint: FormattingFingerprint;

--- a/packages/docx-core/src/primitives/document_view.ts
+++ b/packages/docx-core/src/primitives/document_view.ts
@@ -1,6 +1,8 @@
 import { OOXML, W } from './namespaces.js';
 import { getAttributeSafe, getFirstChild } from './xml-helpers.js';
 import { getParagraphText, getParagraphRuns } from './text.js';
+import { getParagraphBookmarkId } from './bookmarks.js';
+import { buildTableMetaMap, deriveTableContext } from './table_context.js';
 import { extractListLabel, stripListLabel, LabelType } from './list_labels.js';
 import { parseNumberingXml, type NumberingCounters, computeListLabelForParagraph } from './numbering.js';
 import { parseStylesXml, type StylesModel, extractParagraphFormatting, extractEffectiveRunFormatting, type RunFormatting } from './styles.js';
@@ -81,35 +83,66 @@ function emitHighlightTagsFromParagraph(p: Element): string {
   return out.join('');
 }
 
+/**
+ * Collect the bookmarked paragraphs of a document, each with its derived table
+ * context, in document order. This is the shared paragraph-collection core used
+ * by BOTH `DocxDocument.buildDocumentView()` and the free `buildDocumentView()`
+ * so the two produce identical node sets.
+ *
+ * Only paragraphs carrying a `_bk_*` bookmark id are included (the document view
+ * addresses nodes by that id). This function does NOT insert bookmarks — a
+ * consumer operating on un-bookmarked source DOCX MUST call
+ * `DocxDocument.insertParagraphBookmarks()` first, or the result is empty.
+ */
+export function collectViewParagraphs(
+  documentXml: Document,
+): Array<{ id: string; p: Element; tableContext?: ReturnType<typeof deriveTableContext> }> {
+  const body = documentXml.getElementsByTagNameNS(OOXML.W_NS, W.body).item(0);
+  if (!body) return [];
+  const tableMetaMap = buildTableMetaMap(body as Element);
+
+  return Array.from(body.getElementsByTagNameNS(OOXML.W_NS, W.p))
+    .map((p) => {
+      const id = getParagraphBookmarkId(p);
+      if (!id) return null;
+      const tableContext = deriveTableContext(p, tableMetaMap);
+      return tableContext ? { id, p, tableContext } : { id, p };
+    })
+    .filter((x): x is { id: string; p: Element; tableContext?: TableContext } => x !== null);
+}
+
+/**
+ * Free function form of the document-view builder. Delegates to the same shared
+ * core (`collectViewParagraphs` + `buildNodesForDocumentView`) as
+ * `DocxDocument.buildDocumentView()`, so it returns populated nodes — one per
+ * bookmarked paragraph — rather than the empty stub it used to be.
+ *
+ * Like the method, it includes only paragraphs carrying a `_bk_*` bookmark id
+ * and does NOT insert bookmarks itself.
+ */
 export function buildDocumentView(params: {
   documentXml: Document;
   stylesXml: Document | null;
   numberingXml: Document | null;
-  opts?: BuildDocumentViewOptions;
+  footnotesXml?: Document | null;
+  relsMap?: RelsMap;
+  opts?: BuildDocumentViewOptions & { show_formatting?: boolean; formatting_mode?: FormattingMode };
 }): { nodes: DocumentViewNode[]; styles: DocumentStyles } {
-  const { documentXml, stylesXml, numberingXml, opts } = params;
-  const includeSemantic = opts?.include_semantic_tags ?? true;
-  void includeSemantic;
+  const { documentXml, stylesXml, numberingXml, footnotesXml, relsMap, opts } = params;
 
-  const stylesModel = parseStylesXml(stylesXml);
-  void stylesModel;
-  const numberingModel = parseNumberingXml(numberingXml);
-  void numberingModel;
-  const counters: NumberingCounters = new Map();
-  void counters;
+  const paragraphs = collectViewParagraphs(documentXml);
 
-  const body = getFirstChild(documentXml, OOXML.W_NS, W.body);
-  if (!body) return { nodes: [], styles: { styles: new Map(), fingerprint_to_style: new Map() } };
-
-  const paragraphs = Array.from(body.getElementsByTagNameNS(OOXML.W_NS, W.p));
-  const nodes: DocumentViewNode[] = [];
-
-  for (const p of paragraphs) {
-    const prev = p.previousSibling;
-    void prev;
-  }
-
-  return { nodes, styles: { styles: new Map(), fingerprint_to_style: new Map() } };
+  return buildNodesForDocumentView({
+    paragraphs,
+    stylesXml,
+    numberingXml,
+    include_semantic_tags: opts?.include_semantic_tags ?? true,
+    show_formatting: opts?.show_formatting ?? false,
+    formatting_mode: opts?.formatting_mode ?? 'compact',
+    relsMap,
+    documentXml,
+    footnotesXml: footnotesXml ?? null,
+  });
 }
 
 // ── Helpers for building AnnotatedRun arrays ─────────────────────────
@@ -468,8 +501,13 @@ export function buildNodesForDocumentView(params: {
     const paraPPr = getFirstChild(p, OOXML.W_NS, W.pPr);
     const paraFmt = extractParagraphFormatting(paraPPr ?? null, stylesModel);
 
+    // Raw visible text (field codes stripped, but NOT CR/LF-stripped or trimmed).
+    // This is the coordinate system `replaceParagraphTextRange`/`replaceTextAtRange`
+    // operate in; it is carried on the node so the clean_text → raw offset map can
+    // be rebuilt deterministically. @see buildCleanToRawOffsetMap
+    const rawText = getParagraphText(p);
     // Visible clean text (field codes stripped).
-    const fullText = getParagraphText(p).replace(/\r/g, '').replace(/\n/g, '').trim();
+    const fullText = rawText.replace(/\r/g, '').replace(/\n/g, '').trim();
     // Computed once per paragraph: gates the empty-paragraph skip below, drives
     // the [^N] marker injection, and is exposed as node.footnote_refs.
     const fnMarkers = getFootnoteMarkersForParagraph(p, footnoteDisplayMap);
@@ -720,6 +758,7 @@ export function buildNodesForDocumentView(params: {
       text: tagged, // filled after header stripping at render time
 
       clean_text: cleanTextNoLabel,
+      raw_text: rawText,
       tagged_text: tagged,
       visible_offset_correction: visibleOffsetCorrection > 0 ? visibleOffsetCorrection : undefined,
       list_metadata: {
@@ -758,4 +797,94 @@ export function buildNodesForDocumentView(params: {
   }
 
   return { nodes, styles };
+}
+
+// ── clean_text → raw offset map (the #1 offset hazard, centralized) ──
+//
+// Selector patterns are authored against the stable, normalized `clean_text`,
+// but mutation (`replaceParagraphTextRange` / `DocxDocument.replaceTextAtRange`)
+// operates on RAW offsets — `getParagraphText(p)` coordinates. `clean_text` is
+// derived from `raw_text` by removing CR/LF, trimming leading/trailing
+// whitespace, and (for manually-labelled list paragraphs) stripping the label
+// prefix. Each removed character shifts every following offset, so a scalar
+// correction (`visible_offset_correction`) is insufficient when CR/LF appear in
+// the interior. This builds a per-character map so a matched clean-text span can
+// be translated to exact raw offsets.
+//
+// `clean_text` does NOT collapse internal whitespace (that lives only in
+// `computeContentFingerprint`), so the map deliberately does not handle that.
+
+/**
+ * Build a `clean_text → raw_text` offset map for a node. The returned array has
+ * length `clean_text.length + 1`: index `o` (a clean-text offset, `0..length`)
+ * holds the corresponding raw-text offset. A clean span `[cs, ce)` therefore
+ * maps to the raw span `[map[cs], map[ce])`, ready for `replaceTextAtRange`.
+ *
+ * When `node.raw_text` is absent (legacy hand-built fixtures), the map is the
+ * identity — callers operating on real builder output always have `raw_text`.
+ */
+export function buildCleanToRawOffsetMap(node: Pick<DocumentViewNode, 'clean_text' | 'raw_text'>): number[] {
+  const clean = node.clean_text;
+  const raw = node.raw_text;
+
+  // Identity fallback when raw text is unavailable.
+  if (raw === undefined) {
+    const map = new Array<number>(clean.length + 1);
+    for (let i = 0; i <= clean.length; i++) map[i] = i;
+    return map;
+  }
+
+  // Phase A: drop CR/LF, recording the raw index of every surviving character.
+  const survivingRawIdx: number[] = [];
+  let stripped = '';
+  for (let i = 0; i < raw.length; i++) {
+    const c = raw[i]!;
+    if (c === '\r' || c === '\n') continue;
+    stripped += c;
+    survivingRawIdx.push(i);
+  }
+
+  // Phase B: trim leading/trailing whitespace (String.prototype.trim semantics,
+  // matching the `.trim()` in the clean_text derivation).
+  const leadingTrim = stripped.length - stripped.replace(/^\s+/, '').length;
+  const trimmed = stripped.trim();
+  const fullRawIdx = survivingRawIdx.slice(leadingTrim, leadingTrim + trimmed.length);
+
+  // Phase C: manual-list-label prefix. `clean_text` is a front-stripped suffix
+  // of the trimmed full text, so locate where it begins.
+  let prefixLen = 0;
+  if (clean.length <= trimmed.length && trimmed.endsWith(clean)) {
+    prefixLen = trimmed.length - clean.length;
+  } else {
+    const idx = trimmed.indexOf(clean);
+    prefixLen = idx >= 0 ? idx : 0;
+  }
+  const cleanRawIdx = fullRawIdx.slice(prefixLen, prefixLen + clean.length);
+
+  const map = new Array<number>(clean.length + 1);
+  for (let o = 0; o < clean.length; o++) {
+    map[o] = cleanRawIdx[o] ?? o;
+  }
+  // End offset (one past the last clean char).
+  if (clean.length === 0) {
+    map[0] = fullRawIdx[0] ?? survivingRawIdx[0] ?? 0;
+  } else {
+    const lastRaw = cleanRawIdx[clean.length - 1];
+    map[clean.length] = (lastRaw ?? clean.length - 1) + 1;
+  }
+  return map;
+}
+
+/**
+ * Translate a single `clean_text` offset to its `raw_text` offset for a node.
+ * Convenience wrapper over {@link buildCleanToRawOffsetMap}; for translating
+ * many offsets on one node, build the map once and index it directly.
+ */
+export function cleanToRawOffset(
+  node: Pick<DocumentViewNode, 'clean_text' | 'raw_text'>,
+  cleanOffset: number,
+): number {
+  const map = buildCleanToRawOffsetMap(node);
+  const clamped = Math.max(0, Math.min(cleanOffset, map.length - 1));
+  return map[clamped]!;
 }

--- a/packages/docx-core/src/primitives/index.ts
+++ b/packages/docx-core/src/primitives/index.ts
@@ -32,6 +32,8 @@ export * from './formatting_tags.js';
 export * from './prevent_double_elevation.js';
 export * from './tables.js';
 export * from './content_fingerprint.js';
+export * from './locator.js';
+export { buildTableMetaMap, deriveTableContext, type TableMeta } from './table_context.js';
 export {
   getParagraphBookmarkId,
   findParagraphByBookmarkId,

--- a/packages/docx-core/src/primitives/locator.ts
+++ b/packages/docx-core/src/primitives/locator.ts
@@ -1,0 +1,292 @@
+import type { DocumentViewNode } from './document_view-types.js';
+import { buildCleanToRawOffsetMap } from './document_view.js';
+import { computeContentFingerprint } from './content_fingerprint.js';
+
+/**
+ * Deterministic locator primitive over a `DocumentView`.
+ *
+ * A locator resolves a SINGLE span (raw-text offsets within one node) and never
+ * heals, scores, or guesses. Ambiguity — zero matches or more than one — is a
+ * drift signal reported as `unresolved`, so a caller updates the selector rather
+ * than silently filling the wrong place. Redundant `assertions` corroborate the
+ * `primary` match the moment an upstream change makes them disagree.
+ *
+ * Patterns are authored against the stable, normalized `clean_text`; resolved
+ * spans are returned as RAW offsets (`getParagraphText` / `replaceTextAtRange`
+ * coordinates) via {@link buildCleanToRawOffsetMap}.
+ */
+export type LocatorStep =
+  | {
+      kind: 'section';
+      /** Exact match against the node's derived heading text. */
+      headingText?: string;
+      /** Regex (un-anchored) tested against the node's derived heading text. */
+      headingRegex?: string;
+      /** Exact match against the paragraph's Word style id. */
+      headingStyleId?: string;
+      /**
+       * Outline level at which the region ends: the region runs from the matched
+       * heading until the next heading whose level is `<= untilLevel`. Defaults
+       * to the matched heading's own level (so the region ends at the next
+       * sibling-or-higher heading); when the matched heading has no level and no
+       * `untilLevel` is given, the region runs to the end of the current scope.
+       */
+      untilLevel?: number;
+    }
+  | { kind: 'regex'; pattern: string; flags?: string; group?: number }
+  | { kind: 'contextual'; contextPattern: string; targetPattern: string; rowLabelPattern?: string }
+  | { kind: 'fingerprint'; contentFingerprint: string };
+
+export interface Locator {
+  /** Ordered `section` steps narrowing to a region (Scrapy-style nesting). */
+  scope?: LocatorStep[];
+  /** The deterministic single-span resolver. Must be regex | contextual | fingerprint. */
+  primary: LocatorStep;
+  /** Corroborators that never select. Must be regex | contextual | fingerprint. */
+  assertions?: LocatorStep[];
+}
+
+export interface LocatorAssertionResult {
+  ok: boolean;
+  kind: string;
+  detail?: string;
+}
+
+export interface LocatorResolution {
+  /** RAW-offset span, or null when the primary did not resolve to exactly one span. */
+  match: { nodeId: string; start: number; end: number } | null;
+  /** True when the primary matched zero or more than one span (a drift signal). */
+  unresolved: boolean;
+  /** Per-assertion corroboration results (empty when `unresolved`). */
+  assertionResults: LocatorAssertionResult[];
+}
+
+const SPAN_KINDS = new Set(['regex', 'contextual', 'fingerprint']);
+
+/** Raw visible text of a node — the fingerprint basis and offset coordinate space. */
+function rawTextOf(node: DocumentViewNode): string {
+  return node.raw_text ?? node.text;
+}
+
+function dedupeFlags(flags: string): string {
+  return Array.from(new Set(flags.split(''))).join('');
+}
+
+type CleanSpan = { node: DocumentViewNode; nodeId: string; cleanStart: number; cleanEnd: number };
+
+function collectRegexSpans(nodes: DocumentViewNode[], pattern: string, flags: string | undefined, group: number): CleanSpan[] {
+  const needIndices = group > 0;
+  const reFlags = dedupeFlags(`${flags ?? ''}g${needIndices ? 'd' : ''}`);
+  const spans: CleanSpan[] = [];
+  for (const node of nodes) {
+    const re = new RegExp(pattern, reFlags);
+    const text = node.clean_text;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(text)) !== null) {
+      let cs: number;
+      let ce: number;
+      if (needIndices) {
+        const idx = (m as RegExpExecArray & { indices?: Array<[number, number] | undefined> }).indices?.[group];
+        if (!idx) {
+          if (m.index === re.lastIndex) re.lastIndex++;
+          continue;
+        }
+        cs = idx[0];
+        ce = idx[1];
+      } else {
+        cs = m.index;
+        ce = m.index + m[0].length;
+      }
+      spans.push({ node, nodeId: node.id, cleanStart: cs, cleanEnd: ce });
+      if (m.index === re.lastIndex) re.lastIndex++;
+    }
+  }
+  return spans;
+}
+
+function collectContextualSpans(nodes: DocumentViewNode[], step: Extract<LocatorStep, { kind: 'contextual' }>): CleanSpan[] {
+  const ctxRe = new RegExp(step.contextPattern);
+  const rowRe = step.rowLabelPattern ? new RegExp(step.rowLabelPattern) : null;
+  const spans: CleanSpan[] = [];
+  for (const node of nodes) {
+    if (!ctxRe.test(node.clean_text)) continue;
+    if (rowRe && !rowRe.test(node.table_context?.col_header ?? '')) continue;
+    const tre = new RegExp(step.targetPattern, 'g');
+    const text = node.clean_text;
+    let m: RegExpExecArray | null;
+    while ((m = tre.exec(text)) !== null) {
+      spans.push({ node, nodeId: node.id, cleanStart: m.index, cleanEnd: m.index + m[0].length });
+      if (m.index === tre.lastIndex) tre.lastIndex++;
+    }
+  }
+  return spans;
+}
+
+function collectFingerprintNodes(nodes: DocumentViewNode[], fingerprint: string): DocumentViewNode[] {
+  return nodes.filter((n) => computeContentFingerprint(rawTextOf(n)) === fingerprint);
+}
+
+function headingMatches(node: DocumentViewNode, step: Extract<LocatorStep, { kind: 'section' }>): boolean {
+  let matched = false;
+  if (step.headingStyleId !== undefined) {
+    if (node.paragraph_style_id !== step.headingStyleId) return false;
+    matched = true;
+  }
+  if (step.headingText !== undefined) {
+    if (node.heading?.text !== step.headingText) return false;
+    matched = true;
+  }
+  if (step.headingRegex !== undefined) {
+    if (!new RegExp(step.headingRegex).test(node.heading?.text ?? '')) return false;
+    matched = true;
+  }
+  return matched;
+}
+
+/**
+ * Narrow `nodes` to the region selected by one `section` step. Returns null when
+ * the heading does not match EXACTLY one node (zero or many → unresolved).
+ */
+function narrowToSection(nodes: DocumentViewNode[], step: Extract<LocatorStep, { kind: 'section' }>): DocumentViewNode[] | null {
+  const headingIdx: number[] = [];
+  for (let i = 0; i < nodes.length; i++) {
+    if (headingMatches(nodes[i]!, step)) headingIdx.push(i);
+  }
+  if (headingIdx.length !== 1) return null;
+
+  const start = headingIdx[0]!;
+  const startLevel = nodes[start]!.heading?.level ?? null;
+  const untilLevel = step.untilLevel ?? startLevel;
+
+  let end = nodes.length;
+  if (untilLevel !== null) {
+    for (let j = start + 1; j < nodes.length; j++) {
+      const lvl = nodes[j]!.heading?.level;
+      if (lvl != null && lvl <= untilLevel) {
+        end = j;
+        break;
+      }
+    }
+  }
+  return nodes.slice(start, end);
+}
+
+function narrowScope(view: DocumentViewNode[], scope: LocatorStep[]): DocumentViewNode[] | null {
+  let nodes = view;
+  for (const step of scope) {
+    if (step.kind !== 'section') {
+      throw new Error(`Locator scope steps must be 'section'; got '${step.kind}'`);
+    }
+    const narrowed = narrowToSection(nodes, step);
+    if (narrowed === null) return null;
+    nodes = narrowed;
+  }
+  return nodes;
+}
+
+function resolvePrimary(nodes: DocumentViewNode[], step: LocatorStep): LocatorResolution['match'] {
+  if (step.kind === 'fingerprint') {
+    const hits = collectFingerprintNodes(nodes, step.contentFingerprint);
+    if (hits.length !== 1) return null;
+    const node = hits[0]!;
+    return { nodeId: node.id, start: 0, end: rawTextOf(node).length };
+  }
+
+  let spans: CleanSpan[];
+  if (step.kind === 'regex') {
+    spans = collectRegexSpans(nodes, step.pattern, step.flags, step.group ?? 0);
+  } else if (step.kind === 'contextual') {
+    spans = collectContextualSpans(nodes, step);
+  } else {
+    // 'section' is rejected by validateLocator before we get here.
+    return null;
+  }
+
+  if (spans.length !== 1) return null;
+  const span = spans[0]!;
+  if (span.cleanEnd <= span.cleanStart) return null; // zero-length match is invalid
+
+  const map = buildCleanToRawOffsetMap(span.node);
+  return { nodeId: span.nodeId, start: map[span.cleanStart]!, end: map[span.cleanEnd]! };
+}
+
+function resolveAssertion(
+  nodes: DocumentViewNode[],
+  step: LocatorStep,
+  primary: NonNullable<LocatorResolution['match']>,
+): LocatorAssertionResult {
+  if (step.kind === 'fingerprint') {
+    const hits = collectFingerprintNodes(nodes, step.contentFingerprint);
+    if (hits.length !== 1) {
+      return { ok: false, kind: 'fingerprint', detail: `expected exactly 1 node, found ${hits.length}` };
+    }
+    const ok = hits[0]!.id === primary.nodeId;
+    return { ok, kind: 'fingerprint', detail: ok ? undefined : `node ${hits[0]!.id} != primary node ${primary.nodeId}` };
+  }
+
+  let spans: CleanSpan[];
+  if (step.kind === 'regex') {
+    spans = collectRegexSpans(nodes, step.pattern, step.flags, step.group ?? 0);
+  } else if (step.kind === 'contextual') {
+    spans = collectContextualSpans(nodes, step);
+  } else {
+    return { ok: false, kind: step.kind, detail: "'section' is not a valid assertion kind" };
+  }
+
+  if (spans.length !== 1) {
+    return { ok: false, kind: step.kind, detail: `expected exactly 1 span, found ${spans.length}` };
+  }
+  const span = spans[0]!;
+  if (span.cleanEnd <= span.cleanStart) {
+    return { ok: false, kind: step.kind, detail: 'zero-length match' };
+  }
+  const map = buildCleanToRawOffsetMap(span.node);
+  const start = map[span.cleanStart]!;
+  const end = map[span.cleanEnd]!;
+  const ok = span.nodeId === primary.nodeId && start === primary.start && end === primary.end;
+  return {
+    ok,
+    kind: step.kind,
+    detail: ok
+      ? undefined
+      : `span {${span.nodeId},${start},${end}} != primary {${primary.nodeId},${primary.start},${primary.end}}`,
+  };
+}
+
+function validateLocator(locator: Locator): void {
+  if (!SPAN_KINDS.has(locator.primary.kind)) {
+    throw new Error(`Locator primary must be regex | contextual | fingerprint; got '${locator.primary.kind}'`);
+  }
+  for (const a of locator.assertions ?? []) {
+    if (!SPAN_KINDS.has(a.kind)) {
+      throw new Error(`Locator assertion must be regex | contextual | fingerprint; got '${a.kind}'`);
+    }
+  }
+  for (const s of locator.scope ?? []) {
+    if (s.kind !== 'section') {
+      throw new Error(`Locator scope steps must be 'section'; got '${s.kind}'`);
+    }
+  }
+}
+
+/**
+ * Resolve a {@link Locator} against a document view. Deterministic: the same
+ * `(view, locator)` always yields the same result, with no randomness, scoring,
+ * or tie-breaking.
+ */
+export function resolveLocator(view: DocumentViewNode[], locator: Locator): LocatorResolution {
+  validateLocator(locator);
+
+  const scoped = locator.scope && locator.scope.length > 0 ? narrowScope(view, locator.scope) : view;
+  if (scoped === null) {
+    return { match: null, unresolved: true, assertionResults: [] };
+  }
+
+  const match = resolvePrimary(scoped, locator.primary);
+  if (match === null) {
+    return { match: null, unresolved: true, assertionResults: [] };
+  }
+
+  const assertionResults = (locator.assertions ?? []).map((a) => resolveAssertion(scoped, a, match));
+  return { match, unresolved: false, assertionResults };
+}

--- a/packages/docx-core/src/primitives/table_context.ts
+++ b/packages/docx-core/src/primitives/table_context.ts
@@ -1,0 +1,206 @@
+import { OOXML, W } from './namespaces.js';
+import { isW, getDirectChildrenByName } from './dom-helpers.js';
+import { getParagraphText } from './text.js';
+import type { TableContext } from './document_view-types.js';
+
+// ── Table context derivation for the document view ───────────────────
+//
+// Extracted from document.ts so BOTH `DocxDocument.buildDocumentView()` and the
+// free `buildDocumentView()` can derive identical table context without a
+// circular import (document.ts already imports from document_view.ts).
+
+export type TableMeta = {
+  tableIndex: number;
+  tableId: string;
+  rows: Element[];
+  headers: string[];
+  totalCols: number;
+};
+
+/**
+ * Collect all w:tr descendants of a table element, descending through
+ * w:ins/w:del/w:sdt wrappers but not into nested w:tbl elements.
+ */
+function collectTableRows(tbl: Element): Element[] {
+  const rows: Element[] = [];
+  function walk(parent: Element) {
+    for (let i = 0; i < parent.childNodes.length; i++) {
+      const child = parent.childNodes[i]!;
+      if (child.nodeType !== 1) continue;
+      const el = child as Element;
+      if (isW(el, W.tr)) {
+        rows.push(el);
+      } else if (!isW(el, W.tbl)) {
+        walk(el);
+      }
+    }
+  }
+  walk(tbl);
+  return rows;
+}
+
+/**
+ * Collect all w:tc descendants of a row element, descending through
+ * w:ins/w:del/w:sdt wrappers but not into nested w:tr or w:tbl elements.
+ */
+function collectRowCells(tr: Element): Element[] {
+  const cells: Element[] = [];
+  function walk(parent: Element) {
+    for (let i = 0; i < parent.childNodes.length; i++) {
+      const child = parent.childNodes[i]!;
+      if (child.nodeType !== 1) continue;
+      const el = child as Element;
+      if (isW(el, W.tc)) {
+        cells.push(el);
+      } else if (!isW(el, W.tr) && !isW(el, W.tbl)) {
+        walk(el);
+      }
+    }
+  }
+  walk(tr);
+  return cells;
+}
+
+/** Get the gridSpan value for a table cell (default 1). */
+function getCellGridSpan(tc: Element): number {
+  const tcPrList = getDirectChildrenByName(tc, W.tcPr);
+  if (tcPrList.length === 0) return 1;
+  const gridSpanEls = getDirectChildrenByName(tcPrList[0]!, 'gridSpan');
+  if (gridSpanEls.length === 0) return 1;
+  const val =
+    gridSpanEls[0]!.getAttributeNS(OOXML.W_NS, W.val) ??
+    gridSpanEls[0]!.getAttribute('w:val') ??
+    gridSpanEls[0]!.getAttribute(W.val);
+  if (!val) return 1;
+  const n = parseInt(val, 10);
+  return n > 0 ? n : 1;
+}
+
+/** Get visible text from a cell's direct paragraphs (excludes nested tables). */
+function getCellHeaderText(tc: Element): string {
+  const parts: string[] = [];
+  for (let i = 0; i < tc.childNodes.length; i++) {
+    const child = tc.childNodes[i]!;
+    if (child.nodeType === 1 && isW(child as Element, W.p)) {
+      parts.push(getParagraphText(child as Element).trim());
+    }
+  }
+  return parts.join(' ').trim();
+}
+
+/**
+ * Build metadata map for body-level tables.
+ * Only indexes direct w:tbl children of w:body (consistent with extractTables).
+ */
+export function buildTableMetaMap(body: Element): Map<Element, TableMeta> {
+  const map = new Map<Element, TableMeta>();
+  const tables = getDirectChildrenByName(body, W.tbl);
+
+  for (let tableIndex = 0; tableIndex < tables.length; tableIndex++) {
+    const tbl = tables[tableIndex]!;
+    const rows = collectTableRows(tbl);
+    if (rows.length === 0) continue;
+
+    // Compute max grid columns across all rows
+    let maxGridCols = 0;
+    for (const row of rows) {
+      const cells = collectRowCells(row);
+      let gridCols = 0;
+      for (const cell of cells) {
+        gridCols += getCellGridSpan(cell);
+      }
+      if (gridCols > maxGridCols) maxGridCols = gridCols;
+    }
+
+    // Extract headers from row 0
+    const headerRow = rows[0]!;
+    const headerCells = collectRowCells(headerRow);
+    const headers: string[] = [];
+    for (const cell of headerCells) {
+      const span = getCellGridSpan(cell);
+      const text = getCellHeaderText(cell);
+      headers.push(text);
+      for (let s = 1; s < span; s++) headers.push('');
+    }
+    while (headers.length < maxGridCols) headers.push('');
+    if (headers.length > maxGridCols) headers.length = maxGridCols;
+
+    map.set(tbl, {
+      tableIndex,
+      tableId: `_tbl_${tableIndex}`,
+      rows,
+      headers,
+      totalCols: maxGridCols,
+    });
+  }
+
+  return map;
+}
+
+/**
+ * Derive table context for a paragraph by walking up the DOM.
+ * Returns undefined if the paragraph is not inside a body-level table.
+ */
+export function deriveTableContext(p: Element, tableMetaMap: Map<Element, TableMeta>): TableContext | undefined {
+  let tc: Element | null = null;
+  let tr: Element | null = null;
+  let tbl: Element | null = null;
+
+  let current: Node | null = p.parentNode;
+  while (current && current.nodeType === 1) {
+    const el = current as Element;
+    if (isW(el, W.body)) break;
+
+    if (isW(el, W.tc)) tc = el;
+    if (isW(el, W.tr)) tr = el;
+    if (isW(el, W.tbl)) {
+      if (tableMetaMap.has(el)) {
+        tbl = el;
+        break;
+      }
+      // Nested table: reset tc/tr, keep walking to find body-level table
+      tc = null;
+      tr = null;
+    }
+
+    current = el.parentNode;
+  }
+
+  if (!tbl || !tr || !tc) return undefined;
+
+  const meta = tableMetaMap.get(tbl)!;
+
+  // Compute row_index
+  const rowIndex = meta.rows.indexOf(tr);
+  if (rowIndex < 0) return undefined;
+
+  // Compute grid-aware col_index by summing gridSpan for preceding cells
+  const rowCells = collectRowCells(tr);
+  let gridCol = 0;
+  let cellFound = false;
+  for (const cell of rowCells) {
+    if (cell === tc) {
+      cellFound = true;
+      break;
+    }
+    gridCol += getCellGridSpan(cell);
+  }
+  if (!cellFound) return undefined;
+
+  // Compute para_in_cell and cell_para_count
+  const allCellPs = Array.from(tc.getElementsByTagNameNS(OOXML.W_NS, W.p));
+  const paraInCell = allCellPs.indexOf(p);
+
+  return {
+    table_id: meta.tableId,
+    table_index: meta.tableIndex,
+    row_index: rowIndex,
+    col_index: gridCol,
+    col_header: meta.headers[gridCol] ?? '',
+    total_rows: meta.rows.length,
+    total_cols: meta.totalCols,
+    is_header_row: rowIndex === 0,
+    para_in_cell: paraInCell >= 0 ? paraInCell : 0,
+    cell_para_count: allCellPs.length,
+  };
+}

--- a/packages/docx-core/test-primitives/document_view_free.test.ts
+++ b/packages/docx-core/test-primitives/document_view_free.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from './helpers/allure-test.js';
+import { parseXml } from '../src/primitives/xml.js';
+import { OOXML } from '../src/primitives/namespaces.js';
+import { insertParagraphBookmarks } from '../src/primitives/bookmarks.js';
+import { buildDocumentView } from '../src/primitives/document_view.js';
+import { DocxDocument } from '../src/primitives/document.js';
+import { createZipBuffer } from '../src/primitives/zip.js';
+
+const TEST_FEATURE = 'add-deterministic-locator-primitive';
+const test = testAllure.epic('DOCX Primitives').withLabels({ feature: TEST_FEATURE });
+
+const BODY =
+  `<w:p><w:r><w:t>First paragraph.</w:t></w:r></w:p>` +
+  `<w:p><w:r><w:t>Second [Insert Company Name] paragraph.</w:t></w:r></w:p>`;
+
+function makeDocXml(bodyXml: string): Document {
+  return parseXml(
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+      `<w:document xmlns:w="${OOXML.W_NS}"><w:body>${bodyXml}</w:body></w:document>`,
+  );
+}
+
+async function makeDocxBuffer(bodyXml: string): Promise<Buffer> {
+  return createZipBuffer({
+    '[Content_Types].xml':
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+      `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+      `<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+      `<Default Extension="xml" ContentType="application/xml"/>` +
+      `<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>` +
+      `</Types>`,
+    '_rels/.rels':
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+      `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>` +
+      `</Relationships>`,
+    'word/document.xml':
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+      `<w:document xmlns:w="${OOXML.W_NS}"><w:body>${bodyXml}</w:body></w:document>`,
+  });
+}
+
+describe('free buildDocumentView', () => {
+  test.openspec('free function returns populated nodes')('Scenario: free function returns populated nodes', async ({ given, when, then }: AllureBddContext) => {
+    let nodes: ReturnType<typeof buildDocumentView>['nodes'] = [];
+    await given('a parsed document with inserted paragraph bookmarks', async () => {
+      const doc = makeDocXml(BODY);
+      insertParagraphBookmarks(doc, 'test');
+      await when('the free buildDocumentView is called', async () => {
+        nodes = buildDocumentView({ documentXml: doc, stylesXml: null, numberingXml: null }).nodes;
+      });
+    });
+    await then('it is no longer an empty stub', async () => {
+      expect(nodes).toHaveLength(2);
+      expect(nodes[0]!.clean_text).toBe('First paragraph.');
+      expect(nodes[1]!.clean_text).toBe('Second [Insert Company Name] paragraph.');
+      expect(nodes.every((n) => n.id.startsWith('_bk_'))).toBe(true);
+      // raw_text is populated so offset translation works downstream.
+      expect(nodes[1]!.raw_text).toBe('Second [Insert Company Name] paragraph.');
+    });
+  });
+
+  test.openspec('free function matches the method')('Scenario: free function matches the method', async ({ given, when, then }: AllureBddContext) => {
+    let freeNodes: ReturnType<typeof buildDocumentView>['nodes'] = [];
+    let methodNodes: ReturnType<typeof buildDocumentView>['nodes'] = [];
+    await given('the same body built both ways with the same bookmark attachment id', async () => {
+      const freeDoc = makeDocXml(BODY);
+      insertParagraphBookmarks(freeDoc, 'test');
+      freeNodes = buildDocumentView({ documentXml: freeDoc, stylesXml: null, numberingXml: null }).nodes;
+
+      const buf = await makeDocxBuffer(BODY);
+      const doc = await DocxDocument.load(buf);
+      doc.insertParagraphBookmarks('test');
+      methodNodes = doc.buildDocumentView().nodes;
+    });
+    await then('the id + clean_text + raw_text projections are identical', async () => {
+      const project = (ns: typeof freeNodes) => ns.map((n) => ({ id: n.id, clean_text: n.clean_text, raw_text: n.raw_text }));
+      expect(project(freeNodes)).toEqual(project(methodNodes));
+    });
+    void when;
+  });
+});

--- a/packages/docx-core/test-primitives/locator.test.ts
+++ b/packages/docx-core/test-primitives/locator.test.ts
@@ -1,0 +1,372 @@
+import { describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from './helpers/allure-test.js';
+import { resolveLocator, type Locator } from '../src/primitives/locator.js';
+import { buildCleanToRawOffsetMap, cleanToRawOffset, type DocumentViewNode } from '../src/primitives/document_view.js';
+import { computeContentFingerprint } from '../src/primitives/content_fingerprint.js';
+
+const TEST_FEATURE = 'add-deterministic-locator-primitive';
+const test = testAllure.epic('DOCX Primitives').withLabels({ feature: TEST_FEATURE });
+
+let bkCounter = 0;
+function makeNode(overrides: Partial<DocumentViewNode> & { clean_text: string }): DocumentViewNode {
+  bkCounter += 1;
+  const id = overrides.id ?? `_bk_${String(bkCounter).padStart(12, '0')}`;
+  const clean = overrides.clean_text;
+  return {
+    id,
+    list_label: '',
+    header: '',
+    style: 'body',
+    text: clean,
+    clean_text: clean,
+    raw_text: clean,
+    tagged_text: clean,
+    list_metadata: {
+      list_level: -1,
+      label_type: null,
+      label_string: '',
+      header_text: null,
+      header_style: null,
+      header_formatting: null,
+      is_auto_numbered: false,
+    },
+    style_fingerprint: {
+      list_level: -1,
+      left_indent_pt: 0,
+      first_line_indent_pt: 0,
+      style_name: 'Body Text',
+      alignment: 'LEFT',
+    },
+    paragraph_style_id: null,
+    paragraph_style_name: 'Body Text',
+    paragraph_alignment: 'LEFT',
+    paragraph_indents_pt: { left: 0, first_line: 0 },
+    numbering: { num_id: null, ilvl: null, is_auto_numbered: false },
+    header_formatting: null,
+    body_run_formatting: null,
+    ...overrides,
+  };
+}
+
+function headingNode(text: string, level: number | null, overrides: Partial<DocumentViewNode> = {}): DocumentViewNode {
+  return makeNode({
+    clean_text: text,
+    heading: { text, source: 'word_style', level },
+    ...overrides,
+  });
+}
+
+describe('resolveLocator — primary resolution', () => {
+  test.openspec('primary resolves exactly one span')(
+    'Scenario: primary resolves exactly one span',
+    async ({ given, when, then }: AllureBddContext) => {
+      let view: DocumentViewNode[] = [];
+      let result: ReturnType<typeof resolveLocator>;
+      await given('a view with one paragraph containing the anchor once', async () => {
+        view = [makeNode({ clean_text: 'The company [Insert Company Name] agrees.' })];
+      });
+      await when('a regex primary for the anchor is resolved', async () => {
+        result = resolveLocator(view, { primary: { kind: 'regex', pattern: '\\[Insert Company Name\\]' } });
+      });
+      await then('it resolves to exactly that raw-offset span', async () => {
+        expect(result.unresolved).toBe(false);
+        expect(result.match).toEqual({ nodeId: view[0]!.id, start: 12, end: 33 });
+      });
+    },
+  );
+
+  test.openspec('zero matches is unresolved')(
+    'Scenario: zero matches is unresolved',
+    async ({ given, when, then }: AllureBddContext) => {
+      let view: DocumentViewNode[] = [];
+      let result: ReturnType<typeof resolveLocator>;
+      await given('a view without the anchor', async () => {
+        view = [makeNode({ clean_text: 'Nothing here.' })];
+      });
+      await when('a regex primary is resolved', async () => {
+        result = resolveLocator(view, { primary: { kind: 'regex', pattern: '\\[Insert Company Name\\]' } });
+      });
+      await then('it is unresolved with a null match', async () => {
+        expect(result.unresolved).toBe(true);
+        expect(result.match).toBeNull();
+      });
+    },
+  );
+
+  test.openspec('multiple matches is unresolved, never a guess')(
+    'Scenario: multiple matches is unresolved, never a guess',
+    async ({ given, when, then }: AllureBddContext) => {
+      let view: DocumentViewNode[] = [];
+      let result: ReturnType<typeof resolveLocator>;
+      await given('a view with the anchor twice', async () => {
+        view = [makeNode({ clean_text: 'X [Y] and again [Y].' })];
+      });
+      await when('a regex primary is resolved', async () => {
+        result = resolveLocator(view, { primary: { kind: 'regex', pattern: '\\[Y\\]' } });
+      });
+      await then('ambiguity is a drift signal: unresolved, no first-pick', async () => {
+        expect(result.unresolved).toBe(true);
+        expect(result.match).toBeNull();
+      });
+    },
+  );
+
+  test.openspec('resolution is reproducible')(
+    'Scenario: resolution is reproducible',
+    async ({ given, when, then }: AllureBddContext) => {
+      let view: DocumentViewNode[] = [];
+      await given('a view with one anchor', async () => {
+        view = [makeNode({ clean_text: 'a [Z] b' })];
+      });
+      await then('two resolutions are deep-equal', async () => {
+        const loc: Locator = { primary: { kind: 'regex', pattern: '\\[Z\\]' } };
+        expect(resolveLocator(view, loc)).toEqual(resolveLocator(view, loc));
+      });
+      void when;
+    },
+  );
+});
+
+describe('resolveLocator — scope narrowing', () => {
+  test.openspec('section narrows to its region')(
+    'Scenario: section narrows to its region',
+    async ({ given, when, then }: AllureBddContext) => {
+      let view: DocumentViewNode[] = [];
+      let result: ReturnType<typeof resolveLocator>;
+      await given('two sections, each containing the same anchor', async () => {
+        view = [
+          headingNode('Section A', 1),
+          makeNode({ clean_text: 'value [B] here' }),
+          headingNode('Section B', 1),
+          makeNode({ clean_text: 'value [B] here' }),
+        ];
+      });
+      await when('the locator scopes to Section B', async () => {
+        result = resolveLocator(view, {
+          scope: [{ kind: 'section', headingText: 'Section B' }],
+          primary: { kind: 'regex', pattern: '\\[B\\]' },
+        });
+      });
+      await then('only the occurrence inside Section B is considered', async () => {
+        expect(result.unresolved).toBe(false);
+        expect(result.match?.nodeId).toBe(view[3]!.id);
+      });
+    },
+  );
+
+  test.openspec('repeated heading is unresolved')(
+    'Scenario: repeated heading is unresolved',
+    async ({ given, when, then }: AllureBddContext) => {
+      let view: DocumentViewNode[] = [];
+      let result: ReturnType<typeof resolveLocator>;
+      await given('two headings with identical text', async () => {
+        view = [headingNode('Dup', 1), makeNode({ clean_text: '[B]' }), headingNode('Dup', 1)];
+      });
+      await when('the locator scopes to that heading text', async () => {
+        result = resolveLocator(view, {
+          scope: [{ kind: 'section', headingText: 'Dup' }],
+          primary: { kind: 'regex', pattern: '\\[B\\]' },
+        });
+      });
+      await then('the ambiguous section is unresolved (no silent first-pick)', async () => {
+        expect(result.unresolved).toBe(true);
+      });
+    },
+  );
+});
+
+describe('resolveLocator — step kinds', () => {
+  test.openspec('section is scope-only')(
+    'Scenario: section is scope-only',
+    async ({ given, when, then }: AllureBddContext) => {
+      await given('a locator misusing section as primary', async () => {});
+      await then('resolveLocator rejects it as invalid', async () => {
+        const bad = { primary: { kind: 'section', headingText: 'X' } } as unknown as Locator;
+        expect(() => resolveLocator([makeNode({ clean_text: 'x' })], bad)).toThrow(/primary/i);
+      });
+      void when;
+    },
+  );
+
+  test.openspec('zero-length regex is unresolved')(
+    'Scenario: zero-length regex is unresolved',
+    async ({ given, when, then }: AllureBddContext) => {
+      let view: DocumentViewNode[] = [];
+      let result: ReturnType<typeof resolveLocator>;
+      await given('a single paragraph', async () => {
+        view = [makeNode({ clean_text: 'abc' })];
+      });
+      await when('a regex that can match empty is used', async () => {
+        result = resolveLocator(view, { primary: { kind: 'regex', pattern: 'x?' } });
+      });
+      await then('it is unresolved and returns no zero-length span', async () => {
+        expect(result.unresolved).toBe(true);
+        expect(result.match).toBeNull();
+      });
+    },
+  );
+
+  test.openspec('contextual requires context before target')(
+    'Scenario: contextual requires context before target',
+    async ({ given, when, then }: AllureBddContext) => {
+      let view: DocumentViewNode[] = [];
+      let result: ReturnType<typeof resolveLocator>;
+      await given('a node anchored by "by and among" with one corporation phrase', async () => {
+        view = [
+          makeNode({ clean_text: 'Recitals follow below.' }),
+          makeNode({ clean_text: 'by and among NewCo, Inc., a Delaware corporation and the Investors' }),
+        ];
+      });
+      await when('a contextual step requires the context then the target', async () => {
+        result = resolveLocator(view, {
+          primary: {
+            kind: 'contextual',
+            contextPattern: 'by and among',
+            targetPattern: '[A-Z][\\w, .]+, a Delaware corporation',
+          },
+        });
+      });
+      await then('the target span after the context is returned', async () => {
+        expect(result.unresolved).toBe(false);
+        expect(result.match?.nodeId).toBe(view[1]!.id);
+        const node = view[1]!;
+        const raw = node.raw_text!;
+        expect(raw.slice(result.match!.start, result.match!.end)).toBe('NewCo, Inc., a Delaware corporation');
+      });
+    },
+  );
+
+  test.openspec('fingerprint selects a whole node')(
+    'Scenario: fingerprint selects a whole node',
+    async ({ given, when, then }: AllureBddContext) => {
+      let view: DocumentViewNode[] = [];
+      let result: ReturnType<typeof resolveLocator>;
+      const target = 'The exact preamble sentence.';
+      await given('a view with the target paragraph', async () => {
+        view = [makeNode({ clean_text: 'other' }), makeNode({ clean_text: target })];
+      });
+      await when('a fingerprint primary for the target is resolved', async () => {
+        result = resolveLocator(view, {
+          primary: { kind: 'fingerprint', contentFingerprint: computeContentFingerprint(target) },
+        });
+      });
+      await then('it spans the whole target node, no sub-span narrowing', async () => {
+        expect(result.unresolved).toBe(false);
+        expect(result.match).toEqual({ nodeId: view[1]!.id, start: 0, end: target.length });
+      });
+    },
+  );
+});
+
+describe('resolveLocator — assertions', () => {
+  test.openspec('span assertion must equal primary span')(
+    'Scenario: span assertion must equal primary span',
+    async ({ given, when, then }: AllureBddContext) => {
+      let view: DocumentViewNode[] = [];
+      let result: ReturnType<typeof resolveLocator>;
+      await given('a paragraph with two different anchors', async () => {
+        view = [makeNode({ clean_text: 'a [Q] b [R] c' })];
+      });
+      await when('the assertion targets a different anchor than primary', async () => {
+        result = resolveLocator(view, {
+          primary: { kind: 'regex', pattern: '\\[Q\\]' },
+          assertions: [{ kind: 'regex', pattern: '\\[R\\]' }],
+        });
+      });
+      await then('the assertion result is not ok', async () => {
+        expect(result.assertionResults[0]!.ok).toBe(false);
+      });
+    },
+  );
+
+  test.openspec('fingerprint assertion matches node identity only')(
+    'Scenario: fingerprint assertion matches node identity only',
+    async ({ given, when, then }: AllureBddContext) => {
+      let view: DocumentViewNode[] = [];
+      let result: ReturnType<typeof resolveLocator>;
+      const target = 'a [Q] b';
+      await given('a single paragraph resolved by a sub-span primary', async () => {
+        view = [makeNode({ clean_text: target })];
+      });
+      await when('a fingerprint assertion names the same node', async () => {
+        result = resolveLocator(view, {
+          primary: { kind: 'regex', pattern: '\\[Q\\]' },
+          assertions: [{ kind: 'fingerprint', contentFingerprint: computeContentFingerprint(target) }],
+        });
+      });
+      await then('it passes on node-id match (not span equality)', async () => {
+        expect(result.assertionResults[0]!).toMatchObject({ ok: true, kind: 'fingerprint' });
+      });
+    },
+  );
+
+  test.openspec('failed assertion does not change the match')(
+    'Scenario: failed assertion does not change the match',
+    async ({ given, when, then }: AllureBddContext) => {
+      let view: DocumentViewNode[] = [];
+      let result: ReturnType<typeof resolveLocator>;
+      await given('a resolvable primary and a failing assertion', async () => {
+        view = [makeNode({ clean_text: 'a [Q] b [R] c' })];
+      });
+      await when('resolveLocator runs', async () => {
+        result = resolveLocator(view, {
+          primary: { kind: 'regex', pattern: '\\[Q\\]' },
+          assertions: [{ kind: 'regex', pattern: '\\[R\\]' }],
+        });
+      });
+      await then('match is still the primary span and the failure is reported', async () => {
+        expect(result.match).toEqual({ nodeId: view[0]!.id, start: 2, end: 5 });
+        expect(result.assertionResults[0]!.ok).toBe(false);
+      });
+    },
+  );
+});
+
+describe('clean_text → raw offset map', () => {
+  test.openspec('leading trim is mapped')(
+    'Scenario: leading trim is mapped',
+    async ({ then }: AllureBddContext) => {
+      await then('clean offset 0 maps past the trimmed prefix', async () => {
+        const node = makeNode({ clean_text: '[X] rest', raw_text: '   [X] rest' });
+        const map = buildCleanToRawOffsetMap(node);
+        expect(map[0]).toBe(3);
+        expect(cleanToRawOffset(node, 3)).toBe(6);
+      });
+    },
+  );
+
+  test.openspec('stripped list label is mapped')(
+    'Scenario: stripped list label is mapped',
+    async ({ then }: AllureBddContext) => {
+      await then('clean offset 0 maps past the stripped label', async () => {
+        const node = makeNode({ clean_text: 'Body text', raw_text: '1. Body text' });
+        expect(buildCleanToRawOffsetMap(node)[0]).toBe(3);
+      });
+    },
+  );
+
+  test.openspec('identity when clean equals raw')(
+    'Scenario: identity when clean equals raw',
+    async ({ then }: AllureBddContext) => {
+      await then('every offset is identity', async () => {
+        const node = makeNode({ clean_text: 'hello', raw_text: 'hello' });
+        expect(buildCleanToRawOffsetMap(node)).toEqual([0, 1, 2, 3, 4, 5]);
+      });
+    },
+  );
+
+  // Bonus coverage beyond the spec scenarios: interior CR/LF and the
+  // identity fallback when raw_text is absent.
+  test('interior CR/LF offsets shift; missing raw_text falls back to identity', async ({ then }: AllureBddContext) => {
+    await then('CR/LF mapping and fallback both hold', async () => {
+      const crlf = makeNode({ clean_text: 'Foo[X] bar', raw_text: 'Foo\n[X] bar' });
+      const map = buildCleanToRawOffsetMap(crlf);
+      expect(map[3]).toBe(4);
+      expect(map[6]).toBe(7);
+
+      const noRaw = makeNode({ clean_text: 'abcd' });
+      delete (noRaw as { raw_text?: string }).raw_text;
+      expect(buildCleanToRawOffsetMap(noRaw)).toEqual([0, 1, 2, 3, 4]);
+    });
+  });
+});

--- a/packages/docx-mcp/package.json
+++ b/packages/docx-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/docx-mcp",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "description": "MCP server for reading, editing, and comparing Word (.docx) and OpenDocument (.odt) files with tracked changes. For Claude, Gemini CLI, Cursor, and any MCP client. Apache-2.0 licensed.",
   "type": "module",
   "main": "dist/index.js",
@@ -27,8 +27,8 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@usejunior/docx-core": "^0.11.2",
-    "@usejunior/odf-core": "^0.11.2",
+    "@usejunior/docx-core": "^0.12.0",
+    "@usejunior/odf-core": "^0.12.0",
     "@xmldom/xmldom": "^0.9.10",
     "zod": "^4.3.6"
   },
@@ -56,7 +56,7 @@
     "NOTICE"
   ],
   "peerDependencies": {
-    "@usejunior/google-docs-core": "^0.11.2"
+    "@usejunior/google-docs-core": "^0.12.0"
   },
   "peerDependenciesMeta": {
     "@usejunior/google-docs-core": {

--- a/packages/google-docs-core/package.json
+++ b/packages/google-docs-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/google-docs-core",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "description": "Google Docs core library: read, write, and anchor management via Google Docs API",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/odf-core/package.json
+++ b/packages/odf-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/odf-core",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "description": "OpenDocument Format (.odt) core library: archive packaging, document view, surgical text replacement, and tracked-changes comparison",
   "type": "module",
   "main": "dist/index.js",
@@ -14,7 +14,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@usejunior/docx-core": "^0.11.2",
+    "@usejunior/docx-core": "^0.12.0",
     "@xmldom/xmldom": "^0.9.10",
     "jszip": "^3.10.1"
   },

--- a/packages/safe-docx-mcpb/package.json
+++ b/packages/safe-docx-mcpb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/safedocx-mcpb",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "private": true,
   "description": "Claude Desktop MCP Bundle (.mcpb) wrapper for @usejunior/safe-docx",
   "type": "module",
@@ -14,7 +14,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@usejunior/safe-docx": "^0.11.2"
+    "@usejunior/safe-docx": "^0.12.0"
   },
   "devDependencies": {
     "@vitest/runner": "^4.1.8",

--- a/packages/safe-docx/package.json
+++ b/packages/safe-docx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/safe-docx",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "description": "Edit Word (.docx) and OpenDocument (.odt) files with tracked changes, redlines, and formatting preservation. Built for AI coding agents. Apache-2.0 licensed, 100% local processing.",
   "mcpName": "io.github.UseJunior/safe-docx",
   "type": "module",
@@ -25,7 +25,7 @@
     "safedocx": "./bin/safe-docx.js"
   },
   "dependencies": {
-    "@usejunior/docx-mcp": "^0.11.2"
+    "@usejunior/docx-mcp": "^0.12.0"
   },
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
## Summary
OpenSpec change proposal (proposal only — no production code) extending the `docx-primitives` capability with a **deterministic locator primitive**, to be consumed by open-agreements' selector-contract recipes.

Ships as `@usejunior/docx-core` **0.12.0**:
- `resolveLocator(view, locator)` — deterministic single-span resolver: `scope` (`section` only) + `primary` (exactly-one) + `assertions`. 0/>1 matches => `unresolved` (drift), never a guess. No fuzzy/scoring. `fingerprint` is a whole-node anchor (from `node.text` raw visible text); `section` is scope-only; zero-length regex is invalid.
- Tested `clean_text -> raw` offset-map primitive (generalizes scalar `visible_offset_correction`), covering the actual `clean_text` transforms: trim, CR/LF removal, manual-list-label stripping (NOT internal whitespace collapse — `clean_text` doesn't collapse it).
- Shared-core fix so the free `buildDocumentView(params)` returns populated nodes (one per **bookmarked** paragraph) instead of `[]`. Neither path inserts bookmarks — consumers call `insertParagraphBookmarks()` first.

## Files
- `openspec/changes/add-deterministic-locator-primitive/{proposal,design,tasks}.md`
- `openspec/changes/add-deterministic-locator-primitive/specs/docx-primitives/spec.md`

## Validation
`openspec validate add-deterministic-locator-primitive --strict` passes. Reviewed dynamically by Codex + agy (interface claims verified against source).

## Note
Implementation follows after approval. This 0.12.0 release is a hard prerequisite for the open-agreements `add-selector-contract-recipes` change.