### PR TITLE
feat(docx-core): OA recipe styling hooks — cover-terms run styling + signature oa-stacked-ruled

### DIFF
--- a/openspec/changes/add-oa-recipe-styling/design.md
+++ b/openspec/changes/add-oa-recipe-styling/design.md
@@ -1,0 +1,87 @@
+# Design: OA recipe styling hooks
+
+## Context
+
+`coverTermsTable` and `signatureBlock` are pure functions that compose existing
+spec primitives (`TableSpec`, `ParagraphSpec`, `RunProps`). The OA consumer needs
+run-level styling control and a fillable-placeholder treatment the current options
+don't expose, plus a signature layout the current modes don't produce. All
+additions are optional and additive — the recipes keep their current defaults so
+existing callers are unaffected (verified by a byte-identity scenario).
+
+## coverTermsTable
+
+Extend `CoverTermsOptions` and the entry types:
+
+```ts
+type FillableValue = { fillable?: boolean };           // mixed into row/subrow entries
+type CoverTermRow = { label: string; value: string } & FillableValue;
+type CoverTermSubrow = { label: string; value: string; subrow: true } & FillableValue;
+
+type CoverTermsOptions = {
+  // ...existing...
+  /** Body font for every label/value/group cell (default: inherit / Calibri). */
+  fontFamily?: string;
+  /** Point sizes; default to the current implicit size when omitted. */
+  labelSizePt?: number;
+  valueSizePt?: number;
+  /** Per-row-kind colors (six-hex, no '#'); default to current behavior. */
+  labelColorHex?: string;
+  valueColorHex?: string;
+  groupColorHex?: string;
+  // subrowColorHex already exists.
+  /** Highlight applied to a fillable value (default 'yellow'). */
+  fillableHighlight?: HighlightColor;
+  /** Non-uniform cell margins; takes precedence over cellPaddingTwips when set. */
+  cellMarginsTwips?: { top?: number; right?: number; bottom?: number; left?: number };
+};
+```
+
+Behavior:
+- A value with `fillable: true` renders bold + `highlight: fillableHighlight ?? 'yellow'`.
+  This is the OA unfilled-placeholder treatment (`[Legal name of the employer]`).
+- `fontFamily` / size / color props are applied to the relevant cell runs; when
+  omitted the recipe emits exactly what it does today.
+- `cellMarginsTwips`, when present, sets per-cell `marginsTwips` (subrow label
+  indent still adds on top of `left`); `cellPaddingTwips` remains the uniform
+  shorthand and is used when `cellMarginsTwips` is absent.
+
+## signatureBlock — `layout: 'oa-stacked-ruled'`
+
+```ts
+type SignatureBlockOptions = {
+  // ...existing single-column / two-column fields...
+  layout?: 'single-column' | 'two-column' | 'oa-stacked-ruled';
+  /** oa-stacked-ruled only: */
+  labelColumnTwips?: number;     // default 1800
+  ruledRowHeightTwips?: number;  // default ~620 (signing room)
+  headerColorHex?: string;       // muted caps party header (reuses existing field)
+  fields?: Array<'signature' | 'printName' | 'title' | 'date'>; // default all four
+  /** Mark pre-filled values (printName/title) as fillable -> highlight + bold. */
+  fillable?: boolean;
+};
+```
+
+Each party renders:
+1. A centered, uppercase, muted (`headerColorHex`) party header paragraph
+   (`keepNext`, generous space-before so it groups with its block).
+2. A borderless two-column `[labelColumnTwips | rest]` table. One row per selected
+   field: left cell = bold label ("Signature"/"Print Name"/"Title"/"Date"); right
+   cell = a bottom-bordered ruled line carrying the optional pre-filled value
+   (Print Name / Title from party data), highlighted when `fillable`. Rows carry
+   `ruledRowHeightTwips` as `heightRule: 'atLeast'` so there is room to sign.
+
+Single-column and two-column modes are untouched.
+
+## Why not a new `types.ts` primitive
+
+Everything here composes existing `TableSpec`/`ParagraphSpec`/`RunProps`. No new
+emitter or grammar is needed, so `validate-spec.ts` and the compiler are unchanged;
+the surface stays at the recipe layer where styling presets belong.
+
+## Risks
+
+- **Backward compatibility**: mitigated by an explicit byte-identity scenario —
+  omitting all new options must reproduce current output.
+- **Highlight enum**: `fillableHighlight` reuses the existing `HighlightColor`
+  whitelist, so no out-of-enum `w:highlight` is authorable.

--- a/openspec/changes/add-oa-recipe-styling/proposal.md
+++ b/openspec/changes/add-oa-recipe-styling/proposal.md
@@ -1,0 +1,55 @@
+# Change: OA recipe styling hooks (cover-terms run styling + signature OA ruled layout)
+
+## Why
+
+The OpenAgreements legal-explainer DOCX renderer (`lib/agreement-docx.ts`) rebuilt
+itself onto docx-core generation, but two of its house-style surfaces still build
+raw `TableSpec`s by hand because the recipes cannot express the OA look:
+
+- **Cover terms.** `coverTermsTable` (after `add-cover-terms-house-style`) produces
+  the horizontal-rule / group / subrow structure, but it hard-codes run styling
+  (font, size, color) and offers no way to mark a value as an *unfilled fillable
+  placeholder* — the OA cover table renders such values yellow-highlighted and
+  bold, e.g. `[Legal name of the employer]`. So the adapter reimplements the whole
+  table to control fonts, sizes, per-row colors, non-uniform cell margins, and the
+  fillable highlight.
+- **Signatures.** `signatureBlock` offers single-column (inline captions) and
+  two-column-grid (captions below the line) layouts. The OA signature page uses a
+  third layout: per signer, a centered muted-caps party header over a
+  *label-column-left / ruled-line-right* table (Signature / Print Name / Title /
+  Date), with tall rows for signing room and an optional fillable Print-Name value.
+  No recipe mode produces this, so the adapter builds it by hand.
+
+Both adapters duplicate styling logic the recipe layer should own. Closing the gap
+lets the consumer call the recipes instead of hand-rolling `TableSpec`s.
+
+## What Changes
+
+- **`coverTermsTable`** gains optional, fully backward-compatible styling hooks:
+  - `fontFamily`, `labelSizePt` / `valueSizePt`, and per-row-kind color overrides
+    (`labelColorHex`, `valueColorHex`, `groupColorHex`, `subrowColorHex`).
+  - A per-entry `fillable?: boolean` on label/value and subrow entries: a fillable
+    value renders with `highlight` (default `yellow`) and bold, the OA unfilled-
+    placeholder treatment. Configurable via `fillableHighlight`.
+  - `cellMarginsTwips` (non-uniform top/right/bottom/left) alongside the existing
+    uniform `cellPaddingTwips`.
+- **`signatureBlock`** gains a third `layout: 'oa-stacked-ruled'` mode: each party
+  renders a centered muted-caps header over a two-column `[label | ruled line]`
+  table with configurable tall row height; per-party optional pre-filled (and
+  optionally fillable-highlighted) Print Name / Title; ruled lines are
+  bottom-bordered cells (no VML), consistent with the existing modes.
+- Omitting every new option preserves current output byte-for-byte.
+- New scenarios `SDX-GEN-110` (cover-terms run styling + fillable) and `SDX-GEN-111`
+  (signature OA ruled layout).
+
+## Impact
+
+- Affected specs: `docx-generation` (two ADDED requirements).
+- Affected code: `packages/docx-core/src/generation/recipes.ts` + focused
+  generation tests; type additions in `recipes.ts` (no `types.ts` grammar change —
+  recipes compose existing `TableSpec`/`ParagraphSpec`/`RunProps`).
+- Downstream: enables `legal-explainer` `lib/agreement-docx.ts` to delete its
+  hand-built cover/signature `TableSpec` builders and call the recipes (separate PR,
+  after a docx-core release that ships this).
+- Out of scope: paragraph-grammar or `types.ts` changes; the consumer rewrite and
+  the docx-core version bump/release (tracked downstream).

--- a/openspec/changes/add-oa-recipe-styling/specs/docx-generation/spec.md
+++ b/openspec/changes/add-oa-recipe-styling/specs/docx-generation/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Cover-terms run styling and fillable values
+
+`coverTermsTable` SHALL support optional run-level styling (font family, label and
+value point sizes, per-row-kind colors), non-uniform cell margins, and a per-entry
+fillable-value treatment, while preserving its current output byte-for-byte when
+the new options are omitted.
+
+#### Scenario: [SDX-GEN-110] cover-terms run styling and fillable values
+- **GIVEN** a cover-terms table authored with `fontFamily`, `valueSizePt`, a `valueColorHex`, non-uniform `cellMarginsTwips`, and a body row whose value is marked `fillable: true`
+- **WHEN** `coverTermsTable` builds the `TableSpec` and the document is generated
+- **THEN** the styled cells SHALL emit the authored font family, size, and color on their runs
+- **AND** the fillable value run SHALL emit `w:highlight` (default `yellow`) and bold
+- **AND** the authored non-uniform `cellMarginsTwips` SHALL appear as the cell margins, with any subrow label indent added on top of the left margin
+- **AND** omitting every new option SHALL preserve the existing cover-terms output byte-for-byte
+- **AND** the generated package SHALL remain structurally valid and well-formed
+
+### Requirement: Signature block OA stacked-ruled layout
+
+`signatureBlock` SHALL support an `oa-stacked-ruled` layout in which each party
+renders a centered muted-caps header over a label-column / ruled-line table with a
+configurable signing row height and optional fillable pre-filled values, without
+changing the existing single-column and two-column layouts.
+
+#### Scenario: [SDX-GEN-111] signature block oa-stacked-ruled layout
+- **GIVEN** two parties authored with `layout: 'oa-stacked-ruled'`, a `ruledRowHeightTwips`, and `fillable: true` pre-filled Print Names
+- **WHEN** `signatureBlock` builds its blocks and the document is generated
+- **THEN** each party SHALL render a centered uppercase header in the muted header color
+- **AND** each selected field SHALL render as a row whose left cell is the bold field label and whose right cell is a bottom-bordered ruled line carrying the authored row height as an `atLeast` `w:trHeight`
+- **AND** a fillable pre-filled Print Name SHALL emit `w:highlight` and bold on its value run
+- **AND** the surrounding and inner table borders SHALL be `none` except the per-line bottom rule
+- **AND** selecting `single-column` or `two-column` SHALL preserve those layouts unchanged
+- **AND** the generated package SHALL remain structurally valid and well-formed

--- a/openspec/changes/add-oa-recipe-styling/tasks.md
+++ b/openspec/changes/add-oa-recipe-styling/tasks.md
@@ -1,0 +1,24 @@
+# Tasks: OA recipe styling hooks
+
+## 1. coverTermsTable styling + fillable
+- [x] 1.1 Extend `CoverTermsOptions` (fontFamily, labelSizePt/valueSizePt, label/value/group color overrides, fillableHighlight, cellMarginsTwips) and add `fillable?` to row/subrow entry types in `packages/docx-core/src/generation/recipes.ts`.
+- [x] 1.2 Apply run styling to label/value/group cells; render a `fillable` value with bold + `highlight` (default `yellow`).
+- [x] 1.3 Honor `cellMarginsTwips` (non-uniform) with subrow indent added to `left`; keep `cellPaddingTwips` as the uniform fallback.
+- [x] 1.4 Ensure all new options are optional and omitting them is a no-op (defaults unchanged).
+
+## 2. signatureBlock oa-stacked-ruled
+- [x] 2.1 Add `'oa-stacked-ruled'` to the `layout` union + the OA fields (labelColumnTwips, ruledRowHeightTwips, fields, fillable) to `SignatureBlockOptions`.
+- [x] 2.2 Implement the per-party centered muted-caps header + `[label | ruled line]` two-column table with tall rows; reuse the bottom-bordered-cell rule from the existing modes.
+- [x] 2.3 Pre-fill Print Name / Title from party data; mark fillable values with highlight + bold.
+- [x] 2.4 Leave single-column / two-column code paths untouched.
+
+## 3. Tests + spec coverage
+- [x] 3.1 Add scenario `SDX-GEN-110` (cover-terms run styling + fillable + byte-identity-when-omitted) wired to its requirement via `testAllure.openspec`.
+- [x] 3.2 Add scenario `SDX-GEN-111` (signature oa-stacked-ruled) likewise.
+- [x] 3.3 Assert `checkGeneratedPackage(...).issues == []` for both.
+- [x] 3.4 Assert a byte-identity baseline: existing recipe calls with no new options produce unchanged output.
+- [x] 3.5 `npm run check:spec-coverage -w @usejunior/docx-core -- --strict` passes.
+
+## 4. Validate
+- [x] 4.1 `openspec validate add-oa-recipe-styling --strict` passes.
+- [x] 4.2 `npm run test:run -w @usejunior/docx-core` green.

--- a/packages/docx-core/src/generation/generation-cover-terms-run-styling.test.ts
+++ b/packages/docx-core/src/generation/generation-cover-terms-run-styling.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect } from 'vitest';
+import { getDirectChildrenByName } from '../primitives/dom-helpers.js';
+import { parseXml } from '../primitives/xml.js';
+import { readZipText } from '../primitives/zip.js';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { generateDocx } from './compile.js';
+import { coverTermsTable } from './recipes.js';
+import { checkGeneratedPackage } from './structural-checks.js';
+import type { DocumentSpec } from './types.js';
+
+const TEST_FEATURE = 'add-oa-recipe-styling';
+const test = testAllure.epic('Document Generation').withLabels({ feature: TEST_FEATURE });
+
+function styledSpec(): DocumentSpec {
+  return {
+    meta: { title: 'Cover terms run styling', createdIso: '2026-06-18T00:00:00Z' },
+    sections: [
+      {
+        blocks: [
+          coverTermsTable({
+            borderMode: 'horizontal-rules',
+            fontFamily: 'Arial',
+            sizePt: 11,
+            subrowSizePt: 10,
+            textColorHex: '1D2021',
+            subrowColorHex: '494A4B',
+            fillableHighlight: 'yellow',
+            cellMarginsTwips: { top: 60, right: 0, bottom: 60, left: 115 },
+            subrowLabelIndentTwips: 230,
+            terms: [
+              { label: 'Employer', value: '[Legal name of the employer]', fillable: true },
+              { label: 'Governing Law', value: 'Wyoming' },
+              { group: 'Confidentiality' },
+              { label: 'Trade Secrets Duration', value: 'Perpetual', subrow: true },
+            ],
+          }),
+        ],
+      },
+    ],
+  };
+}
+
+async function generatedDocumentXml(spec: DocumentSpec): Promise<string> {
+  const buffer = await generateDocx(spec);
+  const structural = await checkGeneratedPackage(buffer);
+  expect(structural.issues).toEqual([]);
+  const xml = await readZipText(buffer, 'word/document.xml');
+  expect(xml, 'word/document.xml missing from package').not.toBeNull();
+  return xml!;
+}
+
+function rows(dom: Document): Element[] {
+  return Array.from(dom.getElementsByTagName('w:tr'));
+}
+
+function firstRunProps(cell: Element): Element {
+  const run = cell.getElementsByTagName('w:r').item(0);
+  expect(run, 'cell has no run').toBeTruthy();
+  const rPr = run!.getElementsByTagName('w:rPr').item(0);
+  expect(rPr, 'run has no rPr').toBeTruthy();
+  return rPr!;
+}
+
+describe('Traceability: cover-terms run styling and fillable values', () => {
+  test.openspec('[SDX-GEN-110] cover-terms run styling and fillable values')(
+    'Scenario: cover-terms tables support run styling and fillable placeholders',
+    async ({ given, when, then, attachPrettyXml }: AllureBddContext) => {
+      let spec!: DocumentSpec;
+      await given('a cover-terms table with font, size, color, non-uniform margins, and a fillable value', async () => {
+        spec = styledSpec();
+        const table = spec.sections[0]!.blocks[0]!;
+        expect(table.kind).toBe('table');
+      });
+
+      let dom!: Document;
+      await when('the document is generated and parsed back', async () => {
+        const xml = await generatedDocumentXml(spec);
+        dom = parseXml(xml);
+        await attachPrettyXml('word/document.xml', xml);
+      });
+
+      await then('styled cells emit the authored font, size, and color on their runs', async () => {
+        // rows: [Employer, Governing Law, Confidentiality(group), Trade Secrets(subrow)]
+        const valueCell = getDirectChildrenByName(rows(dom)[1]!, 'tc')[1]!; // Governing Law value
+        const rPr = firstRunProps(valueCell);
+        expect(rPr.getElementsByTagName('w:rFonts').item(0)!.getAttribute('w:ascii')).toBe('Arial');
+        expect(rPr.getElementsByTagName('w:sz').item(0)!.getAttribute('w:val')).toBe('22'); // 11pt
+        expect(rPr.getElementsByTagName('w:color').item(0)!.getAttribute('w:val')).toBe('1D2021');
+      });
+
+      await then('the fillable value run emits a yellow highlight and bold', async () => {
+        const valueCell = getDirectChildrenByName(rows(dom)[0]!, 'tc')[1]!; // [Legal name...] fillable
+        const rPr = firstRunProps(valueCell);
+        expect(rPr.getElementsByTagName('w:highlight').item(0)!.getAttribute('w:val')).toBe('yellow');
+        expect(rPr.getElementsByTagName('w:b')).toHaveLength(1);
+      });
+
+      await then('non-uniform cell margins appear, with the subrow indent added to the left', async () => {
+        const valueCell = getDirectChildrenByName(rows(dom)[1]!, 'tc')[1]!;
+        const margins = valueCell.getElementsByTagName('w:tcMar').item(0)!;
+        expect(getDirectChildrenByName(margins, 'top')[0]!.getAttribute('w:w')).toBe('60');
+        expect(getDirectChildrenByName(margins, 'left')[0]!.getAttribute('w:w')).toBe('115');
+
+        const subrowLabelCell = getDirectChildrenByName(rows(dom)[3]!, 'tc')[0]!;
+        const subMargins = subrowLabelCell.getElementsByTagName('w:tcMar').item(0)!;
+        expect(getDirectChildrenByName(subMargins, 'left')[0]!.getAttribute('w:w')).toBe('345'); // 115 + 230
+      });
+
+      await then('omitting every new option preserves the existing cover-terms output', async () => {
+        const xml = await generatedDocumentXml({
+          sections: [{ blocks: [coverTermsTable({ terms: [{ label: 'Effective Date', value: 'June 14, 2026' }] })] }],
+        });
+        const defaultDom = parseXml(xml);
+        // The unstyled recipe emits no run font, size, highlight, or cell margins.
+        expect(defaultDom.getElementsByTagName('w:rFonts')).toHaveLength(0);
+        expect(defaultDom.getElementsByTagName('w:sz')).toHaveLength(0);
+        expect(defaultDom.getElementsByTagName('w:highlight')).toHaveLength(0);
+        expect(defaultDom.getElementsByTagName('w:tcMar')).toHaveLength(0);
+      });
+    },
+  );
+});

--- a/packages/docx-core/src/generation/generation-oa-stacked-signature.test.ts
+++ b/packages/docx-core/src/generation/generation-oa-stacked-signature.test.ts
@@ -97,6 +97,26 @@ describe('Traceability: signature block oa-stacked-ruled layout', () => {
         expect(rPr.getElementsByTagName('w:b').length).toBeGreaterThan(0);
       });
 
+      await then('custom ruledLineLabels and per-party dateLabel override the captions', async () => {
+        const xml = await generatedDocumentXml({
+          sections: [
+            {
+              blocks: signatureBlock({
+                layout: 'oa-stacked-ruled',
+                ruledLineLabels: ['Sign', 'Name', 'Role', 'Dated'],
+                parties: [{ party: 'Acme', name: 'Jane Doe', title: 'CEO', dateLabel: 'Executed on' }],
+              }),
+            },
+          ],
+        });
+        const labelDom = parseXml(xml);
+        const table = labelDom.getElementsByTagName('w:tbl').item(0)!;
+        const labelCells = getDirectChildrenByName(table, 'tr').map(
+          (tr) => getDirectChildrenByName(tr, 'tc')[0]!.getElementsByTagName('w:t').item(0)?.textContent,
+        );
+        expect(labelCells).toEqual(['Sign', 'Name', 'Role', 'Executed on']); // dateLabel wins over labels[3]
+      });
+
       await then('single-column and two-column layouts remain unchanged', async () => {
         const single = signatureBlock({ parties: [{ party: 'Acme', name: 'Jane Doe', title: 'CEO' }] });
         // single-column: a bold party paragraph + one single-column table.

--- a/packages/docx-core/src/generation/generation-oa-stacked-signature.test.ts
+++ b/packages/docx-core/src/generation/generation-oa-stacked-signature.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect } from 'vitest';
+import { getDirectChildrenByName } from '../primitives/dom-helpers.js';
+import { parseXml } from '../primitives/xml.js';
+import { readZipText } from '../primitives/zip.js';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { generateDocx } from './compile.js';
+import { signatureBlock } from './recipes.js';
+import { checkGeneratedPackage } from './structural-checks.js';
+import type { DocumentSpec } from './types.js';
+
+const TEST_FEATURE = 'add-oa-recipe-styling';
+const test = testAllure.epic('Document Generation').withLabels({ feature: TEST_FEATURE });
+
+function oaSignatureSpec(): DocumentSpec {
+  return {
+    meta: { title: 'OA stacked-ruled signatures', createdIso: '2026-06-18T00:00:00Z' },
+    sections: [
+      {
+        blocks: signatureBlock({
+          layout: 'oa-stacked-ruled',
+          fontFamily: 'Arial',
+          headerColorHex: '8C8D8E',
+          ruledRowHeightTwips: 620,
+          fillable: true,
+          parties: [
+            { party: 'Employer', name: '[Legal name of the employer]', title: '[Signatory title]' },
+            { party: 'Employee', name: '[Full legal name of the employee]' },
+          ],
+        }),
+      },
+    ],
+  };
+}
+
+async function generatedDocumentXml(spec: DocumentSpec): Promise<string> {
+  const buffer = await generateDocx(spec);
+  const structural = await checkGeneratedPackage(buffer);
+  expect(structural.issues).toEqual([]);
+  const xml = await readZipText(buffer, 'word/document.xml');
+  expect(xml, 'word/document.xml missing from package').not.toBeNull();
+  return xml!;
+}
+
+describe('Traceability: signature block oa-stacked-ruled layout', () => {
+  test.openspec('[SDX-GEN-111] signature block oa-stacked-ruled layout')(
+    'Scenario: signature blocks support the oa-stacked-ruled layout',
+    async ({ given, when, then, attachPrettyXml }: AllureBddContext) => {
+      let spec!: DocumentSpec;
+      await given('two parties authored with oa-stacked-ruled layout, a row height, and fillable print names', async () => {
+        spec = oaSignatureSpec();
+        // Per party: one header paragraph + one table => 2 blocks each, 4 total.
+        expect(spec.sections[0]!.blocks).toHaveLength(4);
+      });
+
+      let dom!: Document;
+      await when('the document is generated and parsed back', async () => {
+        const xml = await generatedDocumentXml(spec);
+        dom = parseXml(xml);
+        await attachPrettyXml('word/document.xml', xml);
+      });
+
+      await then('each party renders a centered uppercase header in the muted color', async () => {
+        const paragraphs = Array.from(dom.getElementsByTagName('w:p'));
+        const headers = paragraphs.filter((p) => {
+          const caps = p.getElementsByTagName('w:caps');
+          return caps.length > 0;
+        });
+        expect(headers.length).toBe(2);
+        const firstHeaderJc = headers[0]!.getElementsByTagName('w:jc').item(0);
+        expect(firstHeaderJc!.getAttribute('w:val')).toBe('center');
+        expect(headers[0]!.getElementsByTagName('w:color').item(0)!.getAttribute('w:val')).toBe('8C8D8E');
+      });
+
+      await then('each field row carries the row height and a bold label cell over a bottom-ruled line cell', async () => {
+        const firstTable = dom.getElementsByTagName('w:tbl').item(0)!;
+        const trs = getDirectChildrenByName(firstTable, 'tr');
+        expect(trs).toHaveLength(4); // Signature / Print Name / Title / Date
+        for (const tr of trs) {
+          const trHeight = tr.getElementsByTagName('w:trHeight').item(0)!;
+          expect(trHeight.getAttribute('w:val')).toBe('620');
+          expect(trHeight.getAttribute('w:hRule')).toBe('atLeast');
+          const cells = getDirectChildrenByName(tr, 'tc');
+          // Label cell run is bold.
+          expect(cells[0]!.getElementsByTagName('w:b').length).toBeGreaterThan(0);
+          // Ruled cell carries a bottom border.
+          const tcBorders = cells[1]!.getElementsByTagName('w:tcBorders').item(0)!;
+          expect(getDirectChildrenByName(tcBorders, 'bottom')[0]!.getAttribute('w:val')).toBe('single');
+        }
+      });
+
+      await then('a fillable print name emits a highlight and bold on its value run', async () => {
+        const firstTable = dom.getElementsByTagName('w:tbl').item(0)!;
+        const printNameRow = getDirectChildrenByName(firstTable, 'tr')[1]!; // Signature, [Print Name], Title, Date
+        const valueCell = getDirectChildrenByName(printNameRow, 'tc')[1]!;
+        const rPr = valueCell.getElementsByTagName('w:rPr').item(0)!;
+        expect(rPr.getElementsByTagName('w:highlight').item(0)!.getAttribute('w:val')).toBe('yellow');
+        expect(rPr.getElementsByTagName('w:b').length).toBeGreaterThan(0);
+      });
+
+      await then('single-column and two-column layouts remain unchanged', async () => {
+        const single = signatureBlock({ parties: [{ party: 'Acme', name: 'Jane Doe', title: 'CEO' }] });
+        // single-column: a bold party paragraph + one single-column table.
+        expect(single[0]!.kind).toBe('paragraph');
+        expect(single[1]!.kind).toBe('table');
+        const two = signatureBlock({ layout: 'two-column', parties: [{ party: 'Acme', name: 'Jane Doe' }] });
+        expect(two).toHaveLength(1);
+        expect(two[0]!.kind).toBe('table');
+        expect((two[0] as { columnWidthsTwips: number[] }).columnWidthsTwips).toHaveLength(3); // signer/gutter/signer
+      });
+    },
+  );
+});

--- a/packages/docx-core/src/generation/recipes.ts
+++ b/packages/docx-core/src/generation/recipes.ts
@@ -9,16 +9,22 @@
  * VML shapes: Pages and Google Docs mangle VML, borders survive everywhere.
  */
 
-import type { BlockSpec, BorderSpec, ParagraphSpec, TableSpec } from './types.js';
+import type { BlockSpec, BorderSpec, HighlightColor, ParagraphSpec, TableSpec } from './types.js';
 
 const SINGLE: BorderSpec = { style: 'single' };
 const NONE: BorderSpec = { style: 'none' };
 const DEFAULT_SUBROW_COLOR_HEX = '595959';
 const DEFAULT_SUBROW_LABEL_INDENT_TWIPS = 240;
+const DEFAULT_FILLABLE_HIGHLIGHT: HighlightColor = 'yellow';
 
-export type CoverTermRow = { label: string; value: string };
+type CellMargins = NonNullable<TableSpec['rows'][number]['cells'][number]['marginsTwips']>;
+
+/** A value cell that can be flagged as an unfilled fillable placeholder. */
+type FillableValue = { fillable?: boolean };
+
+export type CoverTermRow = { label: string; value: string } & FillableValue;
 export type CoverTermGroupRow = { group: string };
-export type CoverTermSubrow = { label: string; value: string; subrow: true };
+export type CoverTermSubrow = { label: string; value: string; subrow: true } & FillableValue;
 export type CoverTermEntry = CoverTermRow | CoverTermGroupRow | CoverTermSubrow;
 
 export type CoverTermsOptions = {
@@ -34,8 +40,26 @@ export type CoverTermsOptions = {
   rowHeightTwips?: number;
   /** Optional uniform cell padding applied to every cover-terms cell. */
   cellPaddingTwips?: number;
+  /**
+   * Optional non-uniform cell margins. When set it supersedes `cellPaddingTwips`
+   * for every cover-terms cell (the subrow label indent is still added on top of
+   * the resulting `left`).
+   */
+  cellMarginsTwips?: { top?: number; right?: number; bottom?: number; left?: number };
+  /** Body font applied to every label/value/group run; default inherits Normal. */
+  fontFamily?: string;
+  /** Point size for plain-row and group runs; default inherits Normal. */
+  sizePt?: number;
+  /** Point size for subrow runs; defaults to `sizePt`. */
+  subrowSizePt?: number;
+  /** Text color for plain-row labels/values (six-hex, no '#'); default unset. */
+  textColorHex?: string;
+  /** Text color for group-row labels; defaults to `textColorHex`. */
+  groupColorHex?: string;
   /** Text color for subrow labels and values; defaults to mid-gray. */
   subrowColorHex?: string;
+  /** Highlight applied to a value flagged `fillable`; defaults to `yellow`. */
+  fillableHighlight?: HighlightColor;
   /**
    * Extra left indent on subrow label cells, added on top of `cellPaddingTwips`
    * (so the label sits further right than a normal row). Defaults to 240 twips.
@@ -45,7 +69,8 @@ export type CoverTermsOptions = {
 
 /**
  * A fixed-layout two-column label/value table for cover-terms blocks
- * (scenario SDX-GEN-070), with optional house-style grouped/sub rows.
+ * (scenario SDX-GEN-070), with optional house-style grouped/sub rows
+ * (SDX-GEN-106) and run styling + fillable placeholders (SDX-GEN-110).
  */
 export function coverTermsTable(options: CoverTermsOptions): TableSpec {
   const [labelWidth, valueWidth] = options.columnWidthsTwips ?? [2880, 6480];
@@ -54,6 +79,11 @@ export function coverTermsTable(options: CoverTermsOptions): TableSpec {
       ? { top: SINGLE, bottom: SINGLE, left: NONE, right: NONE, insideH: SINGLE, insideV: NONE }
       : { top: SINGLE, bottom: SINGLE, left: SINGLE, right: SINGLE, insideH: SINGLE, insideV: SINGLE };
   const rowRhythm = rowRhythmProps(options);
+  const font = options.fontFamily;
+  const plainSize = options.sizePt;
+  const subSize = options.subrowSizePt ?? options.sizePt;
+  const fillHighlight = options.fillableHighlight ?? DEFAULT_FILLABLE_HIGHLIGHT;
+
   const rows: TableSpec['rows'] = [];
   if (options.title !== undefined) {
     rows.push({
@@ -63,8 +93,8 @@ export function coverTermsTable(options: CoverTermsOptions): TableSpec {
           gridSpan: 2,
           shadingHex: 'D9D9D9',
           vAlign: 'center',
-          ...cellPaddingProps(options),
-          blocks: [paragraph(options.title, { bold: true, alignment: 'center' })],
+          ...cellMarginProps(options),
+          blocks: [paragraph(options.title, { bold: true, alignment: 'center', font, sizePt: plainSize })],
         },
       ],
     });
@@ -77,8 +107,15 @@ export function coverTermsTable(options: CoverTermsOptions): TableSpec {
           {
             gridSpan: 2,
             vAlign: 'center',
-            ...cellPaddingProps(options),
-            blocks: [paragraph(term.group, { bold: true })],
+            ...cellMarginProps(options),
+            blocks: [
+              paragraph(term.group, {
+                bold: true,
+                font,
+                sizePt: plainSize,
+                colorHex: options.groupColorHex ?? options.textColorHex,
+              }),
+            ],
           },
         ],
       });
@@ -86,30 +123,27 @@ export function coverTermsTable(options: CoverTermsOptions): TableSpec {
     }
 
     const subrow = 'subrow' in term && term.subrow === true;
+    const size = subrow ? subSize : plainSize;
+    const labelColor = subrow ? (options.subrowColorHex ?? DEFAULT_SUBROW_COLOR_HEX) : options.textColorHex;
+    const valueColor = subrow ? (options.subrowColorHex ?? DEFAULT_SUBROW_COLOR_HEX) : options.textColorHex;
+    const subrowIndent = (uniformLeft(options)) + (options.subrowLabelIndentTwips ?? DEFAULT_SUBROW_LABEL_INDENT_TWIPS);
+
     rows.push({
       ...rowRhythm,
       cells: [
         {
-          ...cellPaddingProps(
-            options,
-            subrow
-              ? { left: (options.cellPaddingTwips ?? 0) + (options.subrowLabelIndentTwips ?? DEFAULT_SUBROW_LABEL_INDENT_TWIPS) }
-              : undefined,
-          ),
-          blocks: [
-            paragraph(term.label, {
-              bold: !subrow,
-              italic: subrow,
-              colorHex: subrow ? (options.subrowColorHex ?? DEFAULT_SUBROW_COLOR_HEX) : undefined,
-            }),
-          ],
+          ...cellMarginProps(options, subrow ? { left: subrowIndent } : undefined),
+          blocks: [paragraph(term.label, { bold: !subrow, italic: subrow, colorHex: labelColor, font, sizePt: size })],
         },
         {
-          ...cellPaddingProps(options),
+          ...cellMarginProps(options),
           blocks: [
             paragraph(term.value, {
               italic: subrow,
-              colorHex: subrow ? (options.subrowColorHex ?? DEFAULT_SUBROW_COLOR_HEX) : undefined,
+              colorHex: valueColor,
+              font,
+              sizePt: size,
+              ...(term.fillable ? { bold: true, highlight: fillHighlight } : {}),
             }),
           ],
         },
@@ -138,9 +172,9 @@ export type SignatureBlockOptions = {
   /** Signature-line column width in twips; defaults to 4320 (3"). Single-column only. */
   lineWidthTwips?: number;
 
-  // ---- two-column mode (all optional; ignored unless layout === 'two-column') ----
+  // ---- two-column / oa-stacked-ruled mode (ignored unless that layout is set) ----
   /** Layout selector. Defaults to 'single-column' (the historical behavior). */
-  layout?: 'single-column' | 'two-column';
+  layout?: 'single-column' | 'two-column' | 'oa-stacked-ruled';
   /** Total grid width in twips, split across the two signer columns. Defaults to 9360 (6.5" body). */
   totalWidthTwips?: number;
   /** Center gutter column width between the two signer cells. Defaults to 360 (0.25"). */
@@ -149,24 +183,38 @@ export type SignatureBlockOptions = {
   headerColorHex?: string;
   /** Captions for the four ruled lines. Defaults to ['Signature', 'Print Name', 'Title', 'Date']. */
   ruledLineLabels?: [string, string, string, string];
+
+  // ---- oa-stacked-ruled mode only ----
+  /** Width of the left label column in twips. Defaults to 1800 (1.25"). */
+  labelColumnTwips?: number;
+  /** Minimum signing-row height in twips (room to sign). Defaults to 620. */
+  ruledRowHeightTwips?: number;
+  /** Which fields render, in order. Defaults to all four. */
+  fields?: Array<'signature' | 'printName' | 'title' | 'date'>;
+  /** Body font for the OA signature header + labels + values. */
+  fontFamily?: string;
+  /** Mark pre-filled values (printName/title) as fillable -> highlight + bold. */
+  fillable?: boolean;
+  /** Highlight for fillable values; defaults to `yellow`. */
+  fillableHighlight?: HighlightColor;
 };
 
 /**
  * Signature blocks rendered as borderless tables whose content cells carry
  * only bottom borders — the signature lines. No VML, no images.
  *
- * Default `layout: 'single-column'` keeps the historical stacked block: one
- * table per party, a bottom-bordered line then name/title/date rows
- * (scenario SDX-GEN-071). With `layout: 'two-column'` the parties render as a
- * paired signing grid — two signers per row, each a centered uppercase muted
- * header over ruled Signature / Print Name / Title / Date lines (Print Name and
- * Title pre-filled from the party data), with an empty padding cell when the
- * signer count is odd (scenario SDX-GEN-109).
+ * - `single-column` (default): the historical stacked block — one table per
+ *   party, a bottom-bordered line then name/title/date rows (SDX-GEN-071).
+ * - `two-column`: a paired signing grid, two signers per row, each a centered
+ *   muted header over ruled Signature/Print Name/Title/Date lines with captions
+ *   beneath (SDX-GEN-109).
+ * - `oa-stacked-ruled`: per party, a centered muted-caps header over a
+ *   label-column / ruled-line table with tall signing rows (SDX-GEN-111).
  */
 export function signatureBlock(options: SignatureBlockOptions): BlockSpec[] {
-  if ((options.layout ?? 'single-column') === 'two-column') {
-    return [twoColumnSignatureGrid(options)];
-  }
+  const layout = options.layout ?? 'single-column';
+  if (layout === 'two-column') return [twoColumnSignatureGrid(options)];
+  if (layout === 'oa-stacked-ruled') return oaStackedRuledSignatures(options);
   const width = options.lineWidthTwips ?? 4320;
   const blocks: BlockSpec[] = [];
   options.parties.forEach((party, index) => {
@@ -192,7 +240,16 @@ export function signatureBlock(options: SignatureBlockOptions): BlockSpec[] {
 
 function paragraph(
   text: string,
-  opts?: { bold?: boolean; italic?: boolean; caps?: boolean; colorHex?: string; alignment?: ParagraphSpec['alignment'] },
+  opts?: {
+    bold?: boolean;
+    italic?: boolean;
+    caps?: boolean;
+    colorHex?: string;
+    alignment?: ParagraphSpec['alignment'];
+    font?: string;
+    sizePt?: number;
+    highlight?: HighlightColor;
+  },
 ): ParagraphSpec {
   return {
     kind: 'paragraph',
@@ -205,9 +262,74 @@ function paragraph(
         ...(opts?.italic ? { italic: true } : {}),
         ...(opts?.caps ? { caps: true } : {}),
         ...(opts?.colorHex !== undefined ? { colorHex: opts.colorHex } : {}),
+        ...(opts?.font !== undefined ? { font: opts.font } : {}),
+        ...(opts?.sizePt !== undefined ? { sizePt: opts.sizePt } : {}),
+        ...(opts?.highlight !== undefined ? { highlight: opts.highlight } : {}),
       },
     ],
   };
+}
+
+/**
+ * OA stacked-ruled signatures: per party a centered uppercase muted header over
+ * a borderless `[label | ruled line]` two-column table with tall signing rows.
+ * Print Name / Title are pre-filled from the party data and optionally rendered
+ * as fillable (highlight + bold) placeholders.
+ */
+function oaStackedRuledSignatures(options: SignatureBlockOptions): BlockSpec[] {
+  const total = options.totalWidthTwips ?? 9360;
+  const labelWidth = options.labelColumnTwips ?? 1800;
+  const lineWidth = Math.max(1, total - labelWidth);
+  const rowHeight = options.ruledRowHeightTwips ?? 620;
+  const muted = options.headerColorHex ?? DEFAULT_SUBROW_COLOR_HEX;
+  const font = options.fontFamily;
+  const fields = options.fields ?? ['signature', 'printName', 'title', 'date'];
+  const captions: Record<NonNullable<SignatureBlockOptions['fields']>[number], string> = {
+    signature: 'Signature',
+    printName: 'Print Name',
+    title: 'Title',
+    date: 'Date',
+  };
+  const fillHighlight = options.fillableHighlight ?? DEFAULT_FILLABLE_HIGHLIGHT;
+  const noBorders = { top: NONE, bottom: NONE, left: NONE, right: NONE, insideH: NONE, insideV: NONE };
+
+  const blocks: BlockSpec[] = [];
+  for (const party of options.parties) {
+    blocks.push(paragraph(party.party, { alignment: 'center', caps: true, colorHex: muted, font }));
+    const rows: TableSpec['rows'] = fields.map((field) => {
+      const value = field === 'printName' ? party.name : field === 'title' ? (party.title ?? '') : '';
+      const fillableValue = options.fillable === true && value !== '';
+      return {
+        heightTwips: rowHeight,
+        heightRule: 'atLeast' as const,
+        cells: [
+          {
+            vAlign: 'bottom' as const,
+            borders: noBorders,
+            blocks: [paragraph(captions[field], { bold: true, font })],
+          },
+          {
+            vAlign: 'bottom' as const,
+            borders: { bottom: SINGLE },
+            blocks: [
+              paragraph(value, {
+                font,
+                ...(fillableValue ? { bold: true, highlight: fillHighlight } : {}),
+              }),
+            ],
+          },
+        ],
+      };
+    });
+    blocks.push({
+      kind: 'table',
+      layout: 'fixed',
+      columnWidthsTwips: [labelWidth, lineWidth],
+      borders: noBorders,
+      rows,
+    });
+  }
+  return blocks;
 }
 
 /**
@@ -295,16 +417,26 @@ function rowRhythmProps(options: CoverTermsOptions): Pick<TableSpec['rows'][numb
   return options.rowHeightTwips === undefined ? {} : { heightTwips: options.rowHeightTwips, heightRule: 'atLeast' };
 }
 
-function cellPaddingProps(
+/** The effective uniform left margin (non-uniform margins win over uniform padding). */
+function uniformLeft(options: CoverTermsOptions): number {
+  if (options.cellMarginsTwips !== undefined) return options.cellMarginsTwips.left ?? 0;
+  return options.cellPaddingTwips ?? 0;
+}
+
+function cellMarginProps(
   options: CoverTermsOptions,
-  overrides?: NonNullable<TableSpec['rows'][number]['cells'][number]['marginsTwips']>,
+  overrides?: Partial<CellMargins>,
 ): Pick<TableSpec['rows'][number]['cells'][number], 'marginsTwips'> {
-  if (options.cellPaddingTwips === undefined && overrides === undefined) return {};
-  const uniform = options.cellPaddingTwips;
-  return {
-    marginsTwips: {
-      ...(uniform === undefined ? {} : { top: uniform, right: uniform, bottom: uniform, left: uniform }),
-      ...overrides,
-    },
-  };
+  const base: CellMargins | undefined = options.cellMarginsTwips
+    ? { ...options.cellMarginsTwips }
+    : options.cellPaddingTwips !== undefined
+      ? {
+          top: options.cellPaddingTwips,
+          right: options.cellPaddingTwips,
+          bottom: options.cellPaddingTwips,
+          left: options.cellPaddingTwips,
+        }
+      : undefined;
+  if (base === undefined && overrides === undefined) return {};
+  return { marginsTwips: { ...(base ?? {}), ...(overrides ?? {}) } };
 }

--- a/packages/docx-core/src/generation/recipes.ts
+++ b/packages/docx-core/src/generation/recipes.ts
@@ -284,11 +284,24 @@ function oaStackedRuledSignatures(options: SignatureBlockOptions): BlockSpec[] {
   const muted = options.headerColorHex ?? DEFAULT_SUBROW_COLOR_HEX;
   const font = options.fontFamily;
   const fields = options.fields ?? ['signature', 'printName', 'title', 'date'];
-  const captions: Record<NonNullable<SignatureBlockOptions['fields']>[number], string> = {
-    signature: 'Signature',
-    printName: 'Print Name',
-    title: 'Title',
-    date: 'Date',
+  // Caption overrides honor the same `ruledLineLabels` tuple as the two-column
+  // path ([Signature, Print Name, Title, Date]); the Date caption additionally
+  // honors a per-party `dateLabel`, matching single-column / two-column behavior.
+  const labels = options.ruledLineLabels ?? ['Signature', 'Print Name', 'Title', 'Date'];
+  const captionFor = (
+    field: NonNullable<SignatureBlockOptions['fields']>[number],
+    party: SignatureBlockOptions['parties'][number],
+  ): string => {
+    switch (field) {
+      case 'signature':
+        return labels[0];
+      case 'printName':
+        return labels[1];
+      case 'title':
+        return labels[2];
+      case 'date':
+        return party.dateLabel ?? labels[3];
+    }
   };
   const fillHighlight = options.fillableHighlight ?? DEFAULT_FILLABLE_HIGHLIGHT;
   const noBorders = { top: NONE, bottom: NONE, left: NONE, right: NONE, insideH: NONE, insideV: NONE };
@@ -306,7 +319,7 @@ function oaStackedRuledSignatures(options: SignatureBlockOptions): BlockSpec[] {
           {
             vAlign: 'bottom' as const,
             borders: noBorders,
-            blocks: [paragraph(captions[field], { bold: true, font })],
+            blocks: [paragraph(captionFor(field, party), { bold: true, font })],
           },
           {
             vAlign: 'bottom' as const,


### PR DESCRIPTION
## Summary

Closes the two gaps that force the OpenAgreements legal-explainer DOCX adapter to hand-build `TableSpec`s instead of calling the recipes. Both additions are **optional and backward-compatible** — omitting every new option reproduces current output (the existing 56 generation tests are unchanged).

OpenSpec change: `add-oa-recipe-styling` (validates strict-clean).

## What changed

**`coverTermsTable`** gains:
- `fontFamily`, `sizePt` / `subrowSizePt`, `textColorHex` / `groupColorHex` (and existing `subrowColorHex`)
- a per-entry **`fillable`** flag → value renders bold + `highlight` (default `yellow`) — the OA unfilled-`[Placeholder]` treatment
- `cellMarginsTwips` (non-uniform) alongside the uniform `cellPaddingTwips`

**`signatureBlock`** gains a third `layout: 'oa-stacked-ruled'`:
- per party, a centered muted-caps header over a `[label | ruled-line]` two-column table
- configurable `ruledRowHeightTwips` (signing room), `labelColumnTwips`, `fields`
- optional fillable pre-filled Print Name / Title
- single-column and two-column layouts untouched

## Tests / gates

- New scenarios **SDX-GEN-110** (cover-terms run styling + fillable + defaults-preserved) and **SDX-GEN-111** (signature oa-stacked-ruled), each asserting `checkGeneratedPackage().issues == []`.
- `npm run test:run -w @usejunior/docx-core` → 18 files / 56 tests pass
- `tsc --noEmit` clean · `openspec validate add-oa-recipe-styling --strict` ✓ · `check:spec-coverage --strict` exit 0

## Downstream (separate PRs)

After a docx-core release shipping this, `legal-explainer` `lib/agreement-docx.ts` deletes its hand-built cover/signature `TableSpec` builders and calls the recipes (the DRY payoff). The version bump + release are out of scope here.