### PR TITLE
feat(docx-core): OA recipe border + header styling hooks (SDX-GEN-112/113)

### DIFF
--- a/openspec/changes/add-oa-recipe-borders-header/design.md
+++ b/openspec/changes/add-oa-recipe-borders-header/design.md
@@ -1,0 +1,85 @@
+# Design: OA recipe border + header styling hooks
+
+## Context
+
+`coverTermsTable` and `signatureBlock` (`oa-stacked-ruled`) compose existing spec
+primitives. Today both draw borders from module-level constants
+(`const SINGLE: BorderSpec = { style: 'single' }`), and the `oa-stacked-ruled` party
+header is a `paragraph(party, { caps, colorHex, font })` with no weight/size. The OA
+consumer needs to set the rule/line **color and weight**, the header **bold + size**,
+and a **per-value** fillable decision. All additions are optional and additive — the
+defaults reproduce current output (a byte-identity scenario guards this).
+
+## coverTermsTable
+
+Add two options:
+
+```ts
+type CoverTermsOptions = {
+  // ...existing...
+  /** Color (six-hex, no '#') for the table's single-style borders. Default 'auto'. */
+  ruleColorHex?: string;
+  /** Weight in eighths of a point for the single-style borders. Default 4 (0.5pt). */
+  ruleSizeEighthPt?: number;
+};
+```
+
+Behavior:
+- Build the single border from the options instead of the shared `SINGLE` constant:
+  `const rule: BorderSpec = { style: 'single', ...(ruleSizeEighthPt !== undefined ? { sizeEighthPt } : {}), ...(ruleColorHex !== undefined ? { colorHex } : {}) }`.
+- Use `rule` wherever the border map currently uses `SINGLE` (both `horizontal-rules`
+  — top/bottom/insideH — and `grid` — all six). `NONE` is unchanged.
+- When neither option is set, `rule` is structurally `{ style: 'single' }`, so the
+  emitted `w:sz="4" w:color="auto"` is unchanged → byte-identical.
+
+## signatureBlock — oa-stacked-ruled
+
+Add header, line, and per-value-fillable options:
+
+```ts
+type SignatureBlockOptions = {
+  // ...existing oa-stacked-ruled fields...
+  /** Bold the centered party header. Default false. */
+  headerBold?: boolean;
+  /** Party-header point size. Default: inherit Normal. */
+  headerSizePt?: number;
+  /** Color (six-hex) for the ruled signing line. Default 'auto'. */
+  lineColorHex?: string;
+  /** Ruled signing-line weight in eighths of a point. Default 4. */
+  lineSizeEighthPt?: number;
+  parties: Array<{
+    // ...existing party fields...
+    /** Override block `fillable` for this party's Print Name. Default: `fillable`. */
+    nameFillable?: boolean;
+    /** Override block `fillable` for this party's Title. Default: `fillable`. */
+    titleFillable?: boolean;
+  }>;
+};
+```
+
+Behavior:
+- Header: extend the header `paragraph(...)` opts with
+  `...(headerBold ? { bold: true } : {})` and
+  `...(headerSizePt !== undefined ? { sizePt: headerSizePt } : {})`. Defaults unchanged.
+- Ruled line: build the bottom border from `lineColorHex` / `lineSizeEighthPt` exactly
+  as for cover-terms `rule`; default `{ style: 'single' }` → unchanged.
+- Per-value fillable: when deciding whether a value is highlighted, resolve the
+  per-field flag — Print Name uses `party.nameFillable ?? options.fillable`, Title uses
+  `party.titleFillable ?? options.fillable`. A value is highlighted only when its
+  resolved flag is true **and** the value is non-empty (current non-empty guard kept).
+  Signature / Date stay blank, never fillable.
+
+## Why options, not a generic border passthrough
+
+A full `borders?: TableBorders` override on `coverTermsTable` would let a caller fight
+the `borderMode` map and produce contradictory states (e.g. a left border in
+`horizontal-rules` mode). The OA need is precisely color + weight on the *existing*
+single rules, so two scalar options keep the recipe's structural guarantee intact
+while exposing exactly what the house style varies. Same reasoning for the signature
+line.
+
+## Backward compatibility
+
+Every new field is optional; omitting all of them yields the current spec nodes.
+Guarded by an explicit "defaults preserved" assertion in each new scenario (no
+`w:color`/`w:sz` beyond the current `sz=4`/`auto`, no `w:b`/`w:sz` on the header).

--- a/openspec/changes/add-oa-recipe-borders-header/proposal.md
+++ b/openspec/changes/add-oa-recipe-borders-header/proposal.md
@@ -1,0 +1,60 @@
+# Change: OA recipe border + header styling hooks
+
+## Why
+
+`add-oa-recipe-styling` (SDX-GEN-110/111) gave `coverTermsTable` and
+`signatureBlock` the run-styling, fillable, and `oa-stacked-ruled` layout hooks the
+OpenAgreements DOCX renderer (`lib/agreement-docx.ts`) needs — but integration
+revealed three remaining surfaces the recipes still cannot express, so the consumer
+would have to keep hand-rolling raw `TableSpec`s (or regress its canonical match):
+
+- **Border color + weight.** The OA cover table draws its horizontal rules in a
+  light gray (`C7C7C7`) at 0.5pt; the OA signature line is a darker gray (`494A4B`)
+  at 0.75pt. Both recipe paths emit a bare `{ style: 'single' }` border, which
+  serializes to `w:color="auto"` (black). There is no option to set the rule/line
+  color or weight, so consuming the recipe turns gray rules black — a visible
+  regression against the canonical template.
+- **Signature party-header weight + size.** The `oa-stacked-ruled` header renders
+  `paragraph(party, { caps, colorHex, font })` with no bold and no size, so it
+  inherits Normal (~11pt). The OA header is 9pt **bold**. No option exposes either.
+- **Per-value fillable.** `oa-stacked-ruled` exposes a single block-level
+  `fillable` flag that highlights *every* non-empty Print Name / Title. The OA
+  renderer highlights a value **only when it is an unfilled placeholder**, so a
+  filled assignment must not be highlighted — which the block-level flag cannot
+  express.
+
+Closing these lets `lib/agreement-docx.ts` delete its hand-built cover/signature
+`TableSpec` builders and call the recipes while staying byte-for-byte on the
+canonical house style.
+
+## What Changes
+
+- **`coverTermsTable`** gains optional, backward-compatible border hooks:
+  - `ruleColorHex` — color (six-hex, no `#`) for the table's single-style borders
+    (the horizontal rules, or the full grid in `grid` mode). Default `auto`.
+  - `ruleSizeEighthPt` — weight in eighths of a point for those borders. Default 4.
+- **`signatureBlock` `oa-stacked-ruled`** gains:
+  - `headerBold` (default `false`) and `headerSizePt` (default: inherit) on the
+    party header.
+  - `lineColorHex` (default `auto`) and `lineSizeEighthPt` (default 4) on the ruled
+    signing line.
+  - Per-party `nameFillable?` / `titleFillable?` that override the block-level
+    `fillable` for that party's Print Name / Title value (default: fall back to
+    `fillable`), so an unfilled placeholder can be highlighted while a filled value
+    is not.
+- Omitting every new option preserves current output byte-for-byte.
+- New scenarios `SDX-GEN-112` (cover-terms rule color/weight) and `SDX-GEN-113`
+  (signature header weight/size + ruled-line color/weight + per-value fillable).
+
+## Impact
+
+- Affected specs: `docx-generation` (two ADDED requirements carrying the new
+  SDX-GEN-112/113 scenarios — mirroring how `add-oa-recipe-styling` added 110/111
+  rather than modifying the base recipe requirement).
+- Affected code: `packages/docx-core/src/generation/recipes.ts` + focused
+  generation tests. No `types.ts` grammar change — recipes still compose existing
+  `BorderSpec` / `ParagraphSpec` / `TableSpec`.
+- Downstream: unblocks the `legal-explainer` `lib/agreement-docx.ts` rewire onto the
+  recipes (separate PR, after a docx-core release that ships this — 0.14.0).
+- Out of scope: paragraph-grammar / `types.ts` changes; the consumer rewrite and the
+  version bump/release (tracked downstream).

--- a/openspec/changes/add-oa-recipe-borders-header/specs/docx-generation/spec.md
+++ b/openspec/changes/add-oa-recipe-borders-header/specs/docx-generation/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Cover-terms rule color and weight
+
+`coverTermsTable` SHALL support optional color and weight for its single-style
+borders (the horizontal rules, or the full grid in `grid` mode), while preserving
+its current output byte-for-byte when the options are omitted.
+
+#### Scenario: [SDX-GEN-112] cover-terms rule color and weight
+- **GIVEN** a cover-terms table authored with `borderMode: 'horizontal-rules'`, a `ruleColorHex`, and a `ruleSizeEighthPt`
+- **WHEN** `coverTermsTable` builds the `TableSpec` and the document is generated
+- **THEN** the table's top, bottom, and inside-horizontal borders SHALL carry the authored color and weight
+- **AND** the left, right, and inside-vertical borders SHALL remain `none`
+- **AND** omitting both options SHALL preserve the existing borders byte-for-byte (single style, `w:sz="4"`, `w:color="auto"`)
+- **AND** the generated package SHALL remain structurally valid and well-formed
+
+### Requirement: Signature OA stacked-ruled border and header styling
+
+The `oa-stacked-ruled` `signatureBlock` layout SHALL support an optional bold and
+sized party header, an optional color and weight for the ruled signing line, and a
+per-party fillable decision for the Print Name and Title values, without changing
+the existing single-column and two-column layouts and preserving current
+`oa-stacked-ruled` output byte-for-byte when the options are omitted.
+
+#### Scenario: [SDX-GEN-113] signature header weight, ruled-line styling, and per-value fillable
+- **GIVEN** an `oa-stacked-ruled` block authored with `headerBold`, a `headerSizePt`, a `lineColorHex`, a `lineSizeEighthPt`, block `fillable: true`, and a party whose `titleFillable` is `false`
+- **WHEN** `signatureBlock` builds its blocks and the document is generated
+- **THEN** each party header SHALL render bold at the authored point size
+- **AND** each ruled signing line SHALL carry the authored bottom-border color and weight
+- **AND** the Print Name value SHALL emit `w:highlight` and bold (block `fillable` applies)
+- **AND** the Title value SHALL NOT emit a highlight (per-party `titleFillable: false` overrides the block flag)
+- **AND** omitting every new option SHALL preserve the existing `oa-stacked-ruled` output byte-for-byte
+- **AND** selecting `single-column` or `two-column` SHALL preserve those layouts unchanged
+- **AND** the generated package SHALL remain structurally valid and well-formed

--- a/openspec/changes/add-oa-recipe-borders-header/tasks.md
+++ b/openspec/changes/add-oa-recipe-borders-header/tasks.md
@@ -1,0 +1,24 @@
+# Tasks: OA recipe border + header styling hooks
+
+## 1. coverTermsTable rule color + weight
+- [ ] 1.1 Add `ruleColorHex` / `ruleSizeEighthPt` to `CoverTermsOptions` in `packages/docx-core/src/generation/recipes.ts`.
+- [ ] 1.2 Build the single border from those options and use it wherever `borderMode` currently uses the shared `SINGLE` constant (horizontal-rules + grid).
+- [ ] 1.3 Ensure omitting both options yields `{ style: 'single' }` (byte-identical to today).
+
+## 2. signatureBlock oa-stacked-ruled header + line + per-value fillable
+- [ ] 2.1 Add `headerBold` / `headerSizePt` / `lineColorHex` / `lineSizeEighthPt` to `SignatureBlockOptions` and `nameFillable?` / `titleFillable?` to the party entry.
+- [ ] 2.2 Apply header bold/size to the centered party header paragraph.
+- [ ] 2.3 Build the ruled signing-line bottom border from `lineColorHex` / `lineSizeEighthPt`.
+- [ ] 2.4 Resolve highlight per value: Print Name uses `party.nameFillable ?? fillable`, Title uses `party.titleFillable ?? fillable`; keep the non-empty guard; Signature/Date never fillable.
+- [ ] 2.5 Leave single-column / two-column code paths untouched; omitting all new options is a no-op.
+
+## 3. Tests + spec coverage
+- [ ] 3.1 Add scenario `SDX-GEN-112` (cover-terms rule color/weight + byte-identity-when-omitted) wired via `testAllure.openspec`.
+- [ ] 3.2 Add scenario `SDX-GEN-113` (signature header weight/size + ruled-line color/weight + per-value fillable) likewise.
+- [ ] 3.3 Assert `checkGeneratedPackage(...).issues == []` for both.
+- [ ] 3.4 Assert defaults preserved: with no new options, the cover rule emits no `colorHex` beyond `auto` and the header carries no `w:b`/`w:sz`.
+- [ ] 3.5 `npm run check:spec-coverage -w @usejunior/docx-core -- --strict` passes.
+
+## 4. Validate
+- [ ] 4.1 `openspec validate add-oa-recipe-borders-header --strict` passes.
+- [ ] 4.2 `npm run test:run -w @usejunior/docx-core` green.

--- a/openspec/changes/add-oa-recipe-borders-header/tasks.md
+++ b/openspec/changes/add-oa-recipe-borders-header/tasks.md
@@ -1,24 +1,24 @@
 # Tasks: OA recipe border + header styling hooks
 
 ## 1. coverTermsTable rule color + weight
-- [ ] 1.1 Add `ruleColorHex` / `ruleSizeEighthPt` to `CoverTermsOptions` in `packages/docx-core/src/generation/recipes.ts`.
-- [ ] 1.2 Build the single border from those options and use it wherever `borderMode` currently uses the shared `SINGLE` constant (horizontal-rules + grid).
-- [ ] 1.3 Ensure omitting both options yields `{ style: 'single' }` (byte-identical to today).
+- [x] 1.1 Add `ruleColorHex` / `ruleSizeEighthPt` to `CoverTermsOptions` in `packages/docx-core/src/generation/recipes.ts`.
+- [x] 1.2 Build the single border from those options and use it wherever `borderMode` currently uses the shared `SINGLE` constant (horizontal-rules + grid).
+- [x] 1.3 Ensure omitting both options yields `{ style: 'single' }` (byte-identical to today).
 
 ## 2. signatureBlock oa-stacked-ruled header + line + per-value fillable
-- [ ] 2.1 Add `headerBold` / `headerSizePt` / `lineColorHex` / `lineSizeEighthPt` to `SignatureBlockOptions` and `nameFillable?` / `titleFillable?` to the party entry.
-- [ ] 2.2 Apply header bold/size to the centered party header paragraph.
-- [ ] 2.3 Build the ruled signing-line bottom border from `lineColorHex` / `lineSizeEighthPt`.
-- [ ] 2.4 Resolve highlight per value: Print Name uses `party.nameFillable ?? fillable`, Title uses `party.titleFillable ?? fillable`; keep the non-empty guard; Signature/Date never fillable.
-- [ ] 2.5 Leave single-column / two-column code paths untouched; omitting all new options is a no-op.
+- [x] 2.1 Add `headerBold` / `headerSizePt` / `lineColorHex` / `lineSizeEighthPt` to `SignatureBlockOptions` and `nameFillable?` / `titleFillable?` to the party entry.
+- [x] 2.2 Apply header bold/size to the centered party header paragraph.
+- [x] 2.3 Build the ruled signing-line bottom border from `lineColorHex` / `lineSizeEighthPt`.
+- [x] 2.4 Resolve highlight per value: Print Name uses `party.nameFillable ?? fillable`, Title uses `party.titleFillable ?? fillable`; keep the non-empty guard; Signature/Date never fillable.
+- [x] 2.5 Leave single-column / two-column code paths untouched; omitting all new options is a no-op.
 
 ## 3. Tests + spec coverage
-- [ ] 3.1 Add scenario `SDX-GEN-112` (cover-terms rule color/weight + byte-identity-when-omitted) wired via `testAllure.openspec`.
-- [ ] 3.2 Add scenario `SDX-GEN-113` (signature header weight/size + ruled-line color/weight + per-value fillable) likewise.
-- [ ] 3.3 Assert `checkGeneratedPackage(...).issues == []` for both.
-- [ ] 3.4 Assert defaults preserved: with no new options, the cover rule emits no `colorHex` beyond `auto` and the header carries no `w:b`/`w:sz`.
-- [ ] 3.5 `npm run check:spec-coverage -w @usejunior/docx-core -- --strict` passes.
+- [x] 3.1 Add scenario `SDX-GEN-112` (cover-terms rule color/weight + byte-identity-when-omitted) wired via `testAllure.openspec`.
+- [x] 3.2 Add scenario `SDX-GEN-113` (signature header weight/size + ruled-line color/weight + per-value fillable) likewise.
+- [x] 3.3 Assert `checkGeneratedPackage(...).issues == []` for both.
+- [x] 3.4 Assert defaults preserved: with no new options, the cover rule emits no `colorHex` beyond `auto` and the header carries no `w:b`/`w:sz`.
+- [x] 3.5 `npm run check:spec-coverage -w @usejunior/docx-core -- --strict` passes.
 
 ## 4. Validate
-- [ ] 4.1 `openspec validate add-oa-recipe-borders-header --strict` passes.
-- [ ] 4.2 `npm run test:run -w @usejunior/docx-core` green.
+- [x] 4.1 `openspec validate add-oa-recipe-borders-header --strict` passes.
+- [x] 4.2 `npm run test:run -w @usejunior/docx-core` green.

--- a/packages/docx-core/src/generation/generation-cover-terms-rule-styling.test.ts
+++ b/packages/docx-core/src/generation/generation-cover-terms-rule-styling.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect } from 'vitest';
+import { getDirectChildrenByName } from '../primitives/dom-helpers.js';
+import { parseXml } from '../primitives/xml.js';
+import { readZipText } from '../primitives/zip.js';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { generateDocx } from './compile.js';
+import { coverTermsTable } from './recipes.js';
+import { checkGeneratedPackage } from './structural-checks.js';
+import type { DocumentSpec } from './types.js';
+
+const TEST_FEATURE = 'add-oa-recipe-borders-header';
+const test = testAllure.epic('Document Generation').withLabels({ feature: TEST_FEATURE });
+
+function ruledSpec(): DocumentSpec {
+  return {
+    meta: { title: 'Cover terms rule styling', createdIso: '2026-06-20T00:00:00Z' },
+    sections: [
+      {
+        blocks: [
+          coverTermsTable({
+            borderMode: 'horizontal-rules',
+            ruleColorHex: 'C7C7C7',
+            ruleSizeEighthPt: 4,
+            terms: [
+              { label: 'Employer', value: 'Acme, Inc.' },
+              { label: 'Governing Law', value: 'Wyoming' },
+            ],
+          }),
+        ],
+      },
+    ],
+  };
+}
+
+async function generatedDocumentXml(spec: DocumentSpec): Promise<string> {
+  const buffer = await generateDocx(spec);
+  const structural = await checkGeneratedPackage(buffer);
+  expect(structural.issues).toEqual([]);
+  const xml = await readZipText(buffer, 'word/document.xml');
+  expect(xml, 'word/document.xml missing from package').not.toBeNull();
+  return xml!;
+}
+
+function tblBorders(dom: Document): Element {
+  const borders = dom.getElementsByTagName('w:tblBorders').item(0);
+  expect(borders, 'w:tblBorders missing').toBeTruthy();
+  return borders!;
+}
+
+function edge(borders: Element, name: string): Element {
+  const el = getDirectChildrenByName(borders, name)[0];
+  expect(el, `border edge ${name} missing`).toBeTruthy();
+  return el!;
+}
+
+describe('Traceability: cover-terms rule color and weight', () => {
+  test.openspec('[SDX-GEN-112] cover-terms rule color and weight')(
+    'Scenario: cover-terms tables support an authored rule color and weight',
+    async ({ given, when, then, attachPrettyXml }: AllureBddContext) => {
+      let spec!: DocumentSpec;
+      await given('a horizontal-rules cover-terms table with a rule color and weight', async () => {
+        spec = ruledSpec();
+        expect(spec.sections[0]!.blocks[0]!.kind).toBe('table');
+      });
+
+      let dom!: Document;
+      await when('the document is generated and parsed back', async () => {
+        const xml = await generatedDocumentXml(spec);
+        dom = parseXml(xml);
+        await attachPrettyXml('word/document.xml', xml);
+      });
+
+      await then('the top, bottom, and inside-horizontal rules carry the authored color and weight', async () => {
+        const borders = tblBorders(dom);
+        for (const name of ['top', 'bottom', 'insideH']) {
+          const e = edge(borders, name);
+          expect(e.getAttribute('w:val')).toBe('single');
+          expect(e.getAttribute('w:sz')).toBe('4');
+          expect(e.getAttribute('w:color')).toBe('C7C7C7');
+        }
+      });
+
+      await then('the left, right, and inside-vertical edges remain none', async () => {
+        const borders = tblBorders(dom);
+        for (const name of ['left', 'right', 'insideV']) {
+          expect(edge(borders, name).getAttribute('w:val')).toBe('none');
+        }
+      });
+
+      await then('omitting both options preserves the existing borders byte-for-byte', async () => {
+        const xml = await generatedDocumentXml({
+          sections: [{ blocks: [coverTermsTable({ borderMode: 'horizontal-rules', terms: [{ label: 'A', value: 'B' }] })] }],
+        });
+        const defaultDom = parseXml(xml);
+        const top = edge(tblBorders(defaultDom), 'top');
+        expect(top.getAttribute('w:val')).toBe('single');
+        expect(top.getAttribute('w:sz')).toBe('4');
+        expect(top.getAttribute('w:color')).toBe('auto');
+      });
+    },
+  );
+});

--- a/packages/docx-core/src/generation/generation-oa-stacked-signature-borders.test.ts
+++ b/packages/docx-core/src/generation/generation-oa-stacked-signature-borders.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect } from 'vitest';
+import { getDirectChildrenByName } from '../primitives/dom-helpers.js';
+import { parseXml } from '../primitives/xml.js';
+import { readZipText } from '../primitives/zip.js';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { generateDocx } from './compile.js';
+import { signatureBlock } from './recipes.js';
+import { checkGeneratedPackage } from './structural-checks.js';
+import type { DocumentSpec } from './types.js';
+
+const TEST_FEATURE = 'add-oa-recipe-borders-header';
+const test = testAllure.epic('Document Generation').withLabels({ feature: TEST_FEATURE });
+
+function styledSignatureSpec(): DocumentSpec {
+  return {
+    meta: { title: 'OA stacked-ruled border + header', createdIso: '2026-06-20T00:00:00Z' },
+    sections: [
+      {
+        blocks: signatureBlock({
+          layout: 'oa-stacked-ruled',
+          fontFamily: 'Arial',
+          headerBold: true,
+          headerSizePt: 9,
+          lineColorHex: '494A4B',
+          lineSizeEighthPt: 6,
+          fillable: true,
+          parties: [
+            // Title is a real filled value here, so titleFillable:false suppresses its highlight.
+            { party: 'Employer', name: '[Legal name of the employer]', title: 'Authorized Officer', titleFillable: false },
+          ],
+        }),
+      },
+    ],
+  };
+}
+
+async function generatedDocumentXml(spec: DocumentSpec): Promise<string> {
+  const buffer = await generateDocx(spec);
+  const structural = await checkGeneratedPackage(buffer);
+  expect(structural.issues).toEqual([]);
+  const xml = await readZipText(buffer, 'word/document.xml');
+  expect(xml, 'word/document.xml missing from package').not.toBeNull();
+  return xml!;
+}
+
+describe('Traceability: signature oa-stacked-ruled border and header styling', () => {
+  test.openspec('[SDX-GEN-113] signature header weight, ruled-line styling, and per-value fillable')(
+    'Scenario: oa-stacked-ruled supports header weight, ruled-line styling, and per-value fillable',
+    async ({ given, when, then, attachPrettyXml }: AllureBddContext) => {
+      let spec!: DocumentSpec;
+      await given('an oa-stacked-ruled block with a bold sized header, a styled line, and a non-fillable title', async () => {
+        spec = styledSignatureSpec();
+        expect(spec.sections[0]!.blocks).toHaveLength(2); // header paragraph + table
+      });
+
+      let dom!: Document;
+      await when('the document is generated and parsed back', async () => {
+        const xml = await generatedDocumentXml(spec);
+        dom = parseXml(xml);
+        await attachPrettyXml('word/document.xml', xml);
+      });
+
+      await then('the party header renders bold at the authored point size', async () => {
+        const header = Array.from(dom.getElementsByTagName('w:p')).find(
+          (p) => p.getElementsByTagName('w:caps').length > 0,
+        );
+        expect(header, 'caps header paragraph missing').toBeTruthy();
+        const rPr = header!.getElementsByTagName('w:rPr').item(0)!;
+        expect(rPr.getElementsByTagName('w:b').length).toBeGreaterThan(0);
+        expect(rPr.getElementsByTagName('w:sz').item(0)!.getAttribute('w:val')).toBe('18'); // 9pt
+      });
+
+      await then('each ruled signing line carries the authored bottom-border color and weight', async () => {
+        const firstTable = dom.getElementsByTagName('w:tbl').item(0)!;
+        const trs = getDirectChildrenByName(firstTable, 'tr');
+        expect(trs.length).toBeGreaterThan(0);
+        for (const tr of trs) {
+          const lineCell = getDirectChildrenByName(tr, 'tc')[1]!;
+          const tcBorders = lineCell.getElementsByTagName('w:tcBorders').item(0)!;
+          const bottom = getDirectChildrenByName(tcBorders, 'bottom')[0]!;
+          expect(bottom.getAttribute('w:val')).toBe('single');
+          expect(bottom.getAttribute('w:sz')).toBe('6');
+          expect(bottom.getAttribute('w:color')).toBe('494A4B');
+        }
+      });
+
+      await then('the Print Name value is highlighted (block fillable) but the Title is not (per-party override)', async () => {
+        const firstTable = dom.getElementsByTagName('w:tbl').item(0)!;
+        const trs = getDirectChildrenByName(firstTable, 'tr');
+        // fields order: signature / printName / title / date
+        const printNameValue = getDirectChildrenByName(trs[1]!, 'tc')[1]!;
+        const titleValue = getDirectChildrenByName(trs[2]!, 'tc')[1]!;
+        const pnRpr = printNameValue.getElementsByTagName('w:rPr').item(0)!;
+        expect(pnRpr.getElementsByTagName('w:highlight').item(0)!.getAttribute('w:val')).toBe('yellow');
+        expect(pnRpr.getElementsByTagName('w:b').length).toBeGreaterThan(0);
+        expect(titleValue.getElementsByTagName('w:highlight').length).toBe(0);
+      });
+
+      await then('omitting every new option preserves the existing oa-stacked-ruled output', async () => {
+        const xml = await generatedDocumentXml({
+          sections: [
+            { blocks: signatureBlock({ layout: 'oa-stacked-ruled', parties: [{ party: 'Acme', name: 'Jane Doe', title: 'CEO' }] }) },
+          ],
+        });
+        const defaultDom = parseXml(xml);
+        const header = Array.from(defaultDom.getElementsByTagName('w:p')).find(
+          (p) => p.getElementsByTagName('w:caps').length > 0,
+        )!;
+        const rPr = header.getElementsByTagName('w:rPr').item(0)!;
+        expect(rPr.getElementsByTagName('w:b').length).toBe(0); // no bold by default
+        expect(rPr.getElementsByTagName('w:sz').length).toBe(0); // no size by default
+        const bottom = getDirectChildrenByName(
+          getDirectChildrenByName(getDirectChildrenByName(defaultDom.getElementsByTagName('w:tbl').item(0)!, 'tr')[0]!, 'tc')[1]!.getElementsByTagName('w:tcBorders').item(0)!,
+          'bottom',
+        )[0]!;
+        expect(bottom.getAttribute('w:sz')).toBe('4');
+        expect(bottom.getAttribute('w:color')).toBe('auto');
+      });
+
+      await then('single-column and two-column layouts remain unchanged', async () => {
+        const single = signatureBlock({ parties: [{ party: 'Acme', name: 'Jane Doe', title: 'CEO' }] });
+        expect(single[0]!.kind).toBe('paragraph');
+        expect(single[1]!.kind).toBe('table');
+        const two = signatureBlock({ layout: 'two-column', parties: [{ party: 'Acme', name: 'Jane Doe' }] });
+        expect(two).toHaveLength(1);
+        expect(two[0]!.kind).toBe('table');
+      });
+    },
+  );
+});

--- a/packages/docx-core/src/generation/recipes.ts
+++ b/packages/docx-core/src/generation/recipes.ts
@@ -65,6 +65,10 @@ export type CoverTermsOptions = {
    * (so the label sits further right than a normal row). Defaults to 240 twips.
    */
   subrowLabelIndentTwips?: number;
+  /** Color (six-hex, no '#') for the table's single-style borders. Default 'auto'. */
+  ruleColorHex?: string;
+  /** Weight in eighths of a point for the single-style borders. Default 4 (0.5pt). */
+  ruleSizeEighthPt?: number;
 };
 
 /**
@@ -74,10 +78,17 @@ export type CoverTermsOptions = {
  */
 export function coverTermsTable(options: CoverTermsOptions): TableSpec {
   const [labelWidth, valueWidth] = options.columnWidthsTwips ?? [2880, 6480];
+  // The single-style borders honor an optional house-style color/weight; omitting
+  // both yields the bare `{ style: 'single' }` (w:sz="4" w:color="auto") as before.
+  const rule: BorderSpec = {
+    style: 'single',
+    ...(options.ruleSizeEighthPt !== undefined ? { sizeEighthPt: options.ruleSizeEighthPt } : {}),
+    ...(options.ruleColorHex !== undefined ? { colorHex: options.ruleColorHex } : {}),
+  };
   const borders =
     options.borderMode === 'horizontal-rules'
-      ? { top: SINGLE, bottom: SINGLE, left: NONE, right: NONE, insideH: SINGLE, insideV: NONE }
-      : { top: SINGLE, bottom: SINGLE, left: SINGLE, right: SINGLE, insideH: SINGLE, insideV: SINGLE };
+      ? { top: rule, bottom: rule, left: NONE, right: NONE, insideH: rule, insideV: NONE }
+      : { top: rule, bottom: rule, left: rule, right: rule, insideH: rule, insideV: rule };
   const rowRhythm = rowRhythmProps(options);
   const font = options.fontFamily;
   const plainSize = options.sizePt;
@@ -168,6 +179,10 @@ export type SignatureBlockOptions = {
     title?: string;
     /** Label for the date row; defaults to 'Date:'. */
     dateLabel?: string;
+    /** Override block `fillable` for this party's Print Name (oa-stacked-ruled). Default: `fillable`. */
+    nameFillable?: boolean;
+    /** Override block `fillable` for this party's Title (oa-stacked-ruled). Default: `fillable`. */
+    titleFillable?: boolean;
   }>;
   /** Signature-line column width in twips; defaults to 4320 (3"). Single-column only. */
   lineWidthTwips?: number;
@@ -197,6 +212,14 @@ export type SignatureBlockOptions = {
   fillable?: boolean;
   /** Highlight for fillable values; defaults to `yellow`. */
   fillableHighlight?: HighlightColor;
+  /** Bold the centered party header (oa-stacked-ruled). Default false. */
+  headerBold?: boolean;
+  /** Party-header point size (oa-stacked-ruled). Default: inherit Normal. */
+  headerSizePt?: number;
+  /** Color (six-hex) for the ruled signing line (oa-stacked-ruled). Default 'auto'. */
+  lineColorHex?: string;
+  /** Ruled signing-line weight in eighths of a point (oa-stacked-ruled). Default 4. */
+  lineSizeEighthPt?: number;
 };
 
 /**
@@ -305,13 +328,38 @@ function oaStackedRuledSignatures(options: SignatureBlockOptions): BlockSpec[] {
   };
   const fillHighlight = options.fillableHighlight ?? DEFAULT_FILLABLE_HIGHLIGHT;
   const noBorders = { top: NONE, bottom: NONE, left: NONE, right: NONE, insideH: NONE, insideV: NONE };
+  // The ruled signing line honors an optional house-style color/weight; omitting
+  // both yields the bare `{ style: 'single' }` bottom border as before.
+  const lineBorder: BorderSpec = {
+    style: 'single',
+    ...(options.lineSizeEighthPt !== undefined ? { sizeEighthPt: options.lineSizeEighthPt } : {}),
+    ...(options.lineColorHex !== undefined ? { colorHex: options.lineColorHex } : {}),
+  };
 
   const blocks: BlockSpec[] = [];
   for (const party of options.parties) {
-    blocks.push(paragraph(party.party, { alignment: 'center', caps: true, colorHex: muted, font }));
+    blocks.push(
+      paragraph(party.party, {
+        alignment: 'center',
+        caps: true,
+        colorHex: muted,
+        font,
+        ...(options.headerBold ? { bold: true } : {}),
+        ...(options.headerSizePt !== undefined ? { sizePt: options.headerSizePt } : {}),
+      }),
+    );
     const rows: TableSpec['rows'] = fields.map((field) => {
       const value = field === 'printName' ? party.name : field === 'title' ? (party.title ?? '') : '';
-      const fillableValue = options.fillable === true && value !== '';
+      // Print Name / Title resolve their fillable flag per party, falling back to
+      // the block-level `fillable`; Signature / Date are never fillable. This lets
+      // a filled assignment stay un-highlighted while an unfilled placeholder is.
+      const fieldFillable =
+        field === 'printName'
+          ? (party.nameFillable ?? options.fillable)
+          : field === 'title'
+            ? (party.titleFillable ?? options.fillable)
+            : false;
+      const fillableValue = fieldFillable === true && value !== '';
       return {
         heightTwips: rowHeight,
         heightRule: 'atLeast' as const,
@@ -323,7 +371,7 @@ function oaStackedRuledSignatures(options: SignatureBlockOptions): BlockSpec[] {
           },
           {
             vAlign: 'bottom' as const,
-            borders: { bottom: SINGLE },
+            borders: { bottom: lineBorder },
             blocks: [
               paragraph(value, {
                 font,


### PR DESCRIPTION
## Summary

Closes the integration gaps that surfaced when wiring legal-explainer's agreement DOCX renderer (`lib/agreement-docx.ts`) onto the `0.13.0` recipes. After `#507`, the recipes still could **not** express:

- the cover-table **rule color/weight** (canonical is light-gray `C7C7C7` @ 0.5pt; recipe emitted `auto`/black),
- the `oa-stacked-ruled` signature **line color/weight** (canonical `494A4B` @ 0.75pt),
- the signature **party-header bold + size** (canonical 9pt bold; recipe inherited ~11pt non-bold),
- a **per-value** fillable decision (only a block-level flag existed → a *filled* assignment got wrongly highlighted).

Consuming the recipes as-shipped would have regressed the canonical match the consumer verified. This PR adds exactly those knobs, all optional/backward-compatible.

## What changed

**`coverTermsTable`**
- `ruleColorHex` / `ruleSizeEighthPt` on the single-style borders (horizontal-rules + grid).

**`signatureBlock` (`oa-stacked-ruled`)**
- `headerBold` / `headerSizePt` on the centered party header.
- `lineColorHex` / `lineSizeEighthPt` on the ruled signing line.
- per-party `nameFillable` / `titleFillable` overriding the block `fillable`.

## Verification
- [x] `tsc --noEmit` clean
- [x] New scenarios **SDX-GEN-112** (cover rule color/weight) + **SDX-GEN-113** (sig header/line/per-value fillable), each asserting **defaults preserved byte-for-byte**
- [x] Prior SDX-GEN-110/111 unaffected
- [x] Full docx-core suite green (1565 passed / 2 expected-fail / skips), strict spec-coverage PASS
- [ ] Peer review (agy + codex) — pending; appended below

## OpenSpec
`openspec/changes/add-oa-recipe-borders-header` — `validate --strict` passes.

## Downstream
Unblocks the `legal-explainer` `#711` adapter rewire onto the recipes (after a `0.14.0` release).