### PR TITLE
feat(docx-core): deterministic THEN-keyword spec-coverage check

### DIFF
--- a/packages/docx-core/scripts/validate_openspec_coverage.mjs
+++ b/packages/docx-core/scripts/validate_openspec_coverage.mjs
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
 import fs from 'node:fs/promises';
+import { realpathSync } from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -24,7 +25,7 @@ const SPEC_CONFIGS = [
   },
 ];
 
-function normalizeScenarioName(value) {
+export function normalizeScenarioName(value) {
   return value
     .replace(/^Scenario:\s*/i, '')
     .replace(/^\[[^\]]+\]\s*/, '')
@@ -37,6 +38,176 @@ const SERIAL_ID_RE = /^(?:SDX|OA|XIMPL)-[\w-]+-?\d+$/;
 function extractScenarioId(rawScenario) {
   const match = rawScenario.trim().match(/^\[([^\]]+)\]/);
   return match ? match[1].trim() : null;
+}
+
+// Scenarios whose tagged test genuinely exercises the scenario but cannot
+// reference the scenario's tokens in its own body — because the observable is
+// asserted by an external suite runner or compiled Lean proof, or through a
+// shared assertion helper that wraps the primitive the spec names. Each is a
+// real, peer-reviewed mapping, not a stuffed tag. Keep this list short; every
+// entry carries a one-line justification. It is NOT a place to silence a
+// genuinely stuffed tag — fix those by asserting the scenario in the test.
+const THEN_CHECK_ALLOWLIST = new Set([
+  // External docx-platform-tests suite runner asserts acceptChanges semantics
+  // (no remaining w:ins) in a separate process; the TS test only drives it.
+  'acceptAllTrackedChanges round-trip through the adapter',
+  // Lean proof-closure ([LEAN-RT-03]) is validated by `lake build` / Spec.lean
+  // in the lean-build workflow; this TS bridge is the falsifiability layer, not
+  // the proof, so it cannot reference the proof's identifiers.
+  '`inv_rt_001` sorry is replaced by a proof composing the named residual axiom and the lemmas',
+  // The round-trip observable is asserted via the `assertRoundTripInvariant`
+  // helper, which wraps `normalizeText`/`extractTextWithParagraphs`; the
+  // property-test body references the wrapper, not the wrapped primitives.
+  'Field-bearing arbitrary drives INV-RT-001 round-trip',
+]);
+
+// Generic words that appear inside backtick spans but carry no scenario-specific
+// signal. Kept tiny and lowercase-compared so the THEN-token check stays a
+// fail-closed guard against tag-stuffing, not a prose linter.
+const TOKEN_STOPLIST = new Set([
+  'true',
+  'false',
+  'null',
+  'undefined',
+  'nan',
+]);
+
+// Pull code-like tokens out of a single backtick code span. Splits dotted
+// property paths (`OpcPart.uri` -> `OpcPart`, `uri`) and value expressions
+// (`reconstructionModeUsed: rebuild` -> `reconstructionModeUsed`, `rebuild`)
+// into individual identifiers, while keeping OOXML namespace-prefixed names
+// (`w:tbl`, `pt14:Unid`) intact.
+export function tokenizeCodeSpan(span) {
+  const tokens = [];
+  const re = /[A-Za-z_][A-Za-z0-9_]*(?::[A-Za-z_][A-Za-z0-9_]*)*/g;
+  let m;
+  while ((m = re.exec(span))) {
+    const token = m[0];
+    if (token.length < 2) continue;
+    if (TOKEN_STOPLIST.has(token.toLowerCase())) continue;
+    tokens.push(token);
+  }
+  return tokens;
+}
+
+function collectSpanTokens(line, sink) {
+  const spanRe = /`([^`]+)`/g;
+  let m;
+  while ((m = spanRe.exec(line))) {
+    for (const token of tokenizeCodeSpan(m[1])) {
+      sink.add(token);
+    }
+  }
+}
+
+// Mine a scenario's code-like tokens into two sets:
+//
+//   gateTokens  — tokens in the observable (THEN and any trailing AND clauses).
+//                 The check only fires for a scenario when this set is non-empty.
+//                 A pure-prose observable (documentation/proof scenarios like the
+//                 Lean bridge cases) yields nothing here and is exempt — this is
+//                 the issue's "fail-closed only when THEN has a code token" rule,
+//                 auto-detected with no allowlist.
+//
+//   matchTokens — gateTokens plus the action that produces the observable (the
+//                 WHEN). A tagged test passes if its body references any of these.
+//                 The WHEN is in the match set because a genuine test almost
+//                 always invokes the subject under test even when it asserts the
+//                 THEN through a returned value or variable rather than repeating
+//                 the THEN's literal element name; including it is what keeps real
+//                 unit tests from being flagged. The GIVEN (pure setup) is
+//                 excluded from both sets so shared fixture vocabulary can neither
+//                 trigger nor mask a finding.
+//
+// Only backtick-delimited code spans are mined: the spec wraps every concrete
+// identifier/literal/element name in backticks.
+export function extractThenTokens(bodyLines) {
+  const gateTokens = new Set();
+  const matchTokens = new Set();
+  let inWhen = false;
+  let inThen = false;
+  for (const line of bodyLines) {
+    const keyword = line.match(/^\s*[-*]\s*\*\*([A-Z]+)\*\*/);
+    if (keyword) {
+      const kw = keyword[1];
+      if (kw === 'WHEN') {
+        inWhen = true;
+        inThen = false;
+      } else if (kw === 'THEN') {
+        inWhen = false;
+        inThen = true;
+      } else if (kw === 'AND') {
+        // AND inherits whichever clause is open (WHEN or THEN); an AND under
+        // GIVEN leaves both closed and contributes nothing.
+      } else {
+        inWhen = false;
+        inThen = false;
+      }
+    }
+    if (inThen) {
+      collectSpanTokens(line, gateTokens);
+      collectSpanTokens(line, matchTokens);
+    } else if (inWhen) {
+      collectSpanTokens(line, matchTokens);
+    }
+  }
+  return { gateTokens, matchTokens };
+}
+
+// Narrow a tagged-test slice to just the test's body — everything from the
+// callback's opening (the first `=>` or `function`) onward. The preamble that is
+// dropped is the tag chain (`.openspec('…')`) and the test title string, which
+// echoes the scenario name and would otherwise let a title like
+// "Scenario: Cross-run pass rescues inplace output" satisfy the `inplace` token
+// on its own — defeating the check for exactly the kind of tag-stuffing it
+// targets. Tokens are only credible when the test body itself uses them. If no
+// callback is found, the whole slice is returned (fail-open for that slice).
+export function extractTestBody(slice) {
+  const arrow = slice.indexOf('=>');
+  const fn = slice.indexOf('function');
+  const candidates = [arrow, fn].filter((i) => i !== -1);
+  if (candidates.length === 0) return slice;
+  return slice.slice(Math.min(...candidates));
+}
+
+// Returns true if `slice` references `token` as a standalone identifier (not as
+// a substring of a longer identifier). Lookaround on identifier characters lets
+// `Equal` match `CorrelationStatus.Equal` but not `toEqual`, and keeps
+// namespace-prefixed names like `w:tbl` matchable.
+export function sliceReferencesToken(slice, token) {
+  const escaped = token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const re = new RegExp(`(?<![A-Za-z0-9_])${escaped}(?![A-Za-z0-9_])`);
+  return re.test(slice);
+}
+
+// The deterministic THEN-keyword check, as a pure function over already-parsed
+// inputs so it can be unit-tested without filesystem access.
+//
+//   scenarioEntries — `{ name, gateTokens, matchTokens }[]` from parseScenariosFromSpec.
+//   storyToSlices   — Map<resolvedScenarioName, { file, slice }[]> of tagged-test bodies.
+//
+// A scenario is checked only when its observable carries at least one code token
+// (gateTokens non-empty) and it is not on the allowlist. Each tagged test must
+// reference at least one of the scenario's matchTokens; otherwise it is a
+// violation (a tag whose test does not exercise the scenario — i.e. stuffing).
+export function findThenKeywordViolations(scenarioEntries, storyToSlices, allowlist = THEN_CHECK_ALLOWLIST) {
+  const violations = [];
+  for (const scenario of scenarioEntries) {
+    if (scenario.gateTokens.size === 0) continue;
+    if (allowlist.has(scenario.name)) continue;
+    const tagged = storyToSlices.get(scenario.name);
+    if (!tagged || tagged.length === 0) continue;
+
+    const matchTokens = [...scenario.matchTokens];
+    for (const { file, slice } of tagged) {
+      const body = extractTestBody(slice);
+      const matched = matchTokens.some((token) => sliceReferencesToken(body, token));
+      if (!matched) {
+        violations.push({ scenario: scenario.name, file, tokens: matchTokens });
+      }
+    }
+  }
+  return violations;
 }
 
 function parseSerialIdMap(specContent) {
@@ -61,21 +232,35 @@ function resolveSerialIds(stories, serialIdMap) {
   return resolved;
 }
 
-function parseScenariosFromSpec(content) {
+export function parseScenariosFromSpec(content) {
   const scenarios = [];
   const seen = new Set();
-  const scenarioHeader = /^\s*####\s+Scenario:\s*(.+?)\s*$/gm;
-  let m = scenarioHeader.exec(content);
-  while (m) {
-    const raw = m[1].trim();
-    const name = normalizeScenarioName(raw);
-    if (seen.has(name)) {
-      m = scenarioHeader.exec(content);
-      continue;
+  const lines = content.split(/\r?\n/);
+  const headerRe = /^\s*####\s+Scenario:\s*(.+?)\s*$/;
+  const sectionRe = /^\s*#{1,6}\s/;
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const headerMatch = lines[i].match(headerRe);
+    if (!headerMatch) continue;
+
+    const raw = headerMatch[1].trim();
+    // Collect the scenario body — every line up to the next markdown heading.
+    const bodyLines = [];
+    for (let j = i + 1; j < lines.length; j += 1) {
+      if (sectionRe.test(lines[j])) break;
+      bodyLines.push(lines[j]);
     }
+
+    const name = normalizeScenarioName(raw);
+    if (seen.has(name)) continue;
     seen.add(name);
-    scenarios.push({ name, id: extractScenarioId(raw) });
-    m = scenarioHeader.exec(content);
+    const { gateTokens, matchTokens } = extractThenTokens(bodyLines);
+    scenarios.push({
+      name,
+      id: extractScenarioId(raw),
+      gateTokens,
+      matchTokens,
+    });
   }
   return scenarios;
 }
@@ -111,6 +296,56 @@ function parseStoriesFromTest(content) {
   }
 
   return { stories, storyIdsByName };
+}
+
+// Slice the source of each tagged test so the THEN-token check can scope its
+// assertion to the body of the specific `test(...)` that carries a tag, rather
+// than the whole file. Each tag-introducing call (`.openspec('…')` or
+// `allure.story('…')`) is located, then tags are grouped per test: a test may
+// chain several tags before its body (`test.openspec(a).openspec(b)('title', fn)`),
+// so all tags in one chain must share that test's body. A chain breaks when the
+// gap between two consecutive tags contains a test body (an arrow `=>` or a
+// `function` literal); tags before the body are chained, the next tag after it
+// starts a new test. Every tag is then assigned its whole test's slice (its
+// chain's first tag through the next chain's first tag, or EOF).
+// Returns `{ rawStory, slice }[]`, one entry per tag.
+export function parseTaggedTestSlices(content) {
+  const tagRe = /\.openspec\(\s*(["'`])([\s\S]*?)\1\s*\)|allure\.story\(\s*(["'`])([\s\S]*?)\3\s*\)/g;
+  const tags = [];
+  let m = tagRe.exec(content);
+  while (m) {
+    tags.push({ rawStory: m[2] ?? m[4], start: m.index, end: m.index + m[0].length });
+    m = tagRe.exec(content);
+  }
+
+  // Group consecutive tags that belong to the same test (one chain → one body).
+  const groups = [];
+  let group = null;
+  for (let i = 0; i < tags.length; i += 1) {
+    if (i === 0) {
+      group = [tags[0]];
+      continue;
+    }
+    const between = content.slice(tags[i - 1].end, tags[i].start);
+    if (/=>|\bfunction\b/.test(between)) {
+      groups.push(group);
+      group = [tags[i]];
+    } else {
+      group.push(tags[i]);
+    }
+  }
+  if (group) groups.push(group);
+
+  const slices = [];
+  for (let gi = 0; gi < groups.length; gi += 1) {
+    const start = groups[gi][0].start;
+    const end = gi + 1 < groups.length ? groups[gi + 1][0].start : content.length;
+    const slice = content.slice(start, end);
+    for (const tag of groups[gi]) {
+      slices.push({ rawStory: tag.rawStory, slice });
+    }
+  }
+  return slices;
 }
 
 function parseSkippedStoriesFromTest(content) {
@@ -269,10 +504,27 @@ async function main() {
   const storySet = new Set();
   const storyIdsByName = new Map();
   const skippedStorySet = new Set();
+  // resolved scenario name -> [{ file, slice }] for each test carrying that tag.
+  const storyToSlices = new Map();
+
+  function resolveStoryName(rawStory) {
+    const bare = rawStory.trim();
+    if (SERIAL_ID_RE.test(bare) && serialIdMap.has(bare)) {
+      return serialIdMap.get(bare);
+    }
+    return normalizeScenarioName(rawStory);
+  }
 
   for (const tf of testFiles) {
     const content = await fs.readFile(tf, 'utf-8');
     const rel = path.relative(PACKAGE_ROOT, tf).split(path.sep).join('/');
+
+    for (const { rawStory, slice } of parseTaggedTestSlices(content)) {
+      const resolved = resolveStoryName(rawStory);
+      const entries = storyToSlices.get(resolved) ?? [];
+      entries.push({ file: rel, slice });
+      storyToSlices.set(resolved, entries);
+    }
 
     const parsedStories = parseStoriesFromTest(content);
     for (const story of resolveSerialIds(parsedStories.stories, serialIdMap)) {
@@ -356,6 +608,37 @@ async function main() {
     }
   }
 
+  // THEN-keyword check (deterministic, no LLM). For every mapped scenario whose
+  // observable contains at least one code-like token, require the body of each
+  // test carrying that scenario's tag to reference at least one of those tokens.
+  // This catches tag-stuffing — a tag slapped on a test that never asserts the
+  // scenario — which the presence-only coverage check above cannot see. It
+  // fails closed regardless of --strict: validity is not negotiable the way the
+  // coverage ratio is. Scenarios with a pure-prose observable yield no tokens
+  // and are exempt, so doc/proof-style mappings never produce a false positive.
+  const thenViolations = [];
+  for (const report of specReports) {
+    for (const violation of findThenKeywordViolations(report.scenarioEntries, storyToSlices)) {
+      thenViolations.push({ id: report.id, ...violation });
+    }
+  }
+
+  if (thenViolations.length > 0) {
+    console.error(`THEN-keyword check FAILED (${thenViolations.length} stuffed mapping(s)):`);
+    for (const violation of thenViolations) {
+      console.error(`  - [${violation.id}] "${violation.scenario}"`);
+      console.error(`      tagged in ${violation.file}, but its test body references none of:`);
+      console.error(`      ${violation.tokens.map((t) => `\`${t}\``).join(', ')}`);
+    }
+    console.error(
+      '  A tagged test must assert its scenario\'s observable. Either fix the mapping, ' +
+        'or assert the scenario\'s THEN inside the tagged test.',
+    );
+    process.exitCode = 1;
+  } else {
+    console.log('PASS THEN-keyword check: every tagged test references its scenario observable.');
+  }
+
   const matrix = buildMatrixMarkdown({
     reports: specReports,
     storyToFiles,
@@ -377,4 +660,17 @@ async function main() {
   console.log(`Wrote traceability matrix: ${relative}`);
 }
 
-await main();
+// Run only when executed directly (`node scripts/validate_openspec_coverage.mjs`),
+// not when imported by unit tests. realpathSync(argv[1]) resolves any symlink so
+// the comparison holds however the script is invoked.
+function isDirectRun() {
+  try {
+    return import.meta.url === pathToFileURL(realpathSync(process.argv[1])).href;
+  } catch {
+    return false;
+  }
+}
+
+if (isDirectRun()) {
+  await main();
+}

--- a/packages/docx-core/test-primitives/validate_openspec_coverage.test.ts
+++ b/packages/docx-core/test-primitives/validate_openspec_coverage.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from './helpers/allure-test.js';
+import {
+  extractTestBody,
+  extractThenTokens,
+  findThenKeywordViolations,
+  normalizeScenarioName,
+  parseScenariosFromSpec,
+  parseTaggedTestSlices,
+  sliceReferencesToken,
+  tokenizeCodeSpan,
+} from '../scripts/validate_openspec_coverage.mjs';
+
+const test = testAllure
+  .epic('DOCX Primitives')
+  .withLabels({ feature: 'OpenSpec Coverage Validator' });
+
+// The validator scripts grep their scan roots (which include this test-primitives/
+// directory) for the literal `.openspec(` call. Build that call at runtime so this
+// fixture file's own source never contains the substring those scanners match.
+const OPENSPEC = `.open${'spec'}`;
+const tag = (story: string): string => `${OPENSPEC}('${story}')`;
+
+// Build the Map<scenarioName, {file, slice}[]> the way the validator's main()
+// does, from a fixture test source string.
+function storyToSlicesFrom(testSource: string, file = 'fixture.test.ts'): Map<string, { file: string; slice: string }[]> {
+  const map = new Map<string, { file: string; slice: string }[]>();
+  for (const { rawStory, slice } of parseTaggedTestSlices(testSource)) {
+    const name = normalizeScenarioName(rawStory);
+    const entries = map.get(name) ?? [];
+    entries.push({ file, slice });
+    map.set(name, entries);
+  }
+  return map;
+}
+
+// A spec with three scenarios: one with a code token in its THEN, one whose THEN
+// is pure prose, and one whose observable token is an OOXML element name.
+const SPEC = [
+  '### Requirement: Correlation Status',
+  '',
+  '#### Scenario: Status set to Equal',
+  '- **WHEN** `markCorrelationStatus()` is called',
+  '- **THEN** its `correlationStatus` is set to `Equal`',
+  '',
+  '#### Scenario: Result is acceptable',
+  '- **WHEN** the comparison finishes',
+  '- **THEN** the result is acceptable and clearly documented for the reader',
+  '',
+  '#### Scenario: Table structure preserved',
+  '- **WHEN** a tracked edit is applied',
+  '- **THEN** tracked output preserves table structure (`w:tbl` remains present)',
+  '',
+].join('\n');
+
+describe('validate_openspec_coverage THEN-keyword check', () => {
+  describe('tokenizeCodeSpan', () => {
+    test('keeps namespaced names and splits dotted/value expressions', (_: AllureBddContext) => {
+      expect(tokenizeCodeSpan('w:tbl')).toEqual(['w:tbl']);
+      expect(tokenizeCodeSpan('OpcPart.uri')).toEqual(['OpcPart', 'uri']);
+      expect(tokenizeCodeSpan('reconstructionModeUsed: rebuild')).toEqual([
+        'reconstructionModeUsed',
+        'rebuild',
+      ]);
+    });
+
+    test('drops generic stoplisted words and single characters', (_: AllureBddContext) => {
+      expect(tokenizeCodeSpan('true')).toEqual([]);
+      expect(tokenizeCodeSpan('x')).toEqual([]);
+    });
+  });
+
+  describe('sliceReferencesToken', () => {
+    test('matches a standalone identifier but not a substring of a longer one', (_: AllureBddContext) => {
+      expect(sliceReferencesToken('CorrelationStatus.Equal', 'Equal')).toBe(true);
+      expect(sliceReferencesToken('expect(x).toEqual(y)', 'Equal')).toBe(false);
+      expect(sliceReferencesToken('parse(<w:tbl/>)', 'w:tbl')).toBe(true);
+    });
+  });
+
+  describe('extractThenTokens', () => {
+    test('gates on THEN tokens and includes the WHEN in the match set', (_: AllureBddContext) => {
+      const lines = [
+        '- **WHEN** `markCorrelationStatus()` is called',
+        '- **THEN** its `correlationStatus` is set to `Equal`',
+      ];
+      const { gateTokens, matchTokens } = extractThenTokens(lines);
+      expect([...gateTokens].sort()).toEqual(['Equal', 'correlationStatus']);
+      expect([...matchTokens].sort()).toEqual(['Equal', 'correlationStatus', 'markCorrelationStatus']);
+    });
+
+    test('a pure-prose observable yields no gate tokens', (_: AllureBddContext) => {
+      const lines = [
+        '- **WHEN** the comparison finishes',
+        '- **THEN** the result is acceptable and clearly documented for the reader',
+      ];
+      const { gateTokens } = extractThenTokens(lines);
+      expect(gateTokens.size).toBe(0);
+    });
+
+    test('a GIVEN-only token is excluded from both sets', (_: AllureBddContext) => {
+      const lines = [
+        '- **GIVEN** an atom with `ancestorElements`',
+        '- **WHEN** the comparison finishes',
+        '- **THEN** the result is acceptable',
+      ];
+      const { gateTokens, matchTokens } = extractThenTokens(lines);
+      expect(gateTokens.size).toBe(0);
+      expect(matchTokens.has('ancestorElements')).toBe(false);
+    });
+  });
+
+  describe('extractTestBody', () => {
+    test('drops the tag/title preamble before the callback arrow', (_: AllureBddContext) => {
+      const slice = `${tag('Status set to Equal')}('Scenario: Status set to Equal', () => { doThing(); })`;
+      const body = extractTestBody(slice);
+      expect(body.startsWith('=>')).toBe(true);
+      expect(body.includes('Scenario: Status set to Equal')).toBe(false);
+    });
+  });
+
+  describe('findThenKeywordViolations', () => {
+    const entries = parseScenariosFromSpec(SPEC);
+
+    test('a genuine mapping passes', (_: AllureBddContext) => {
+      const source = `humanReadableTest${tag('Status set to Equal')}(
+        'Scenario: Status set to Equal',
+        () => {
+          markCorrelationStatus(original, revised, matches);
+          expect(revised.correlationStatus).toBe(CorrelationStatus.Equal);
+        },
+      );`;
+      const violations = findThenKeywordViolations(entries, storyToSlicesFrom(source), new Set());
+      expect(violations).toEqual([]);
+    });
+
+    test('a stuffed mapping fails (token in THEN, absent in body)', (_: AllureBddContext) => {
+      const source = `test${tag('Status set to Equal')}(
+        'Scenario: Status set to Equal',
+        () => {
+          const result = authorAndCompare(doc);
+          expect(result.ok).toBe(true);
+        },
+      );`;
+      const violations = findThenKeywordViolations(entries, storyToSlicesFrom(source), new Set());
+      expect(violations.map((v) => v.scenario)).toEqual(['Status set to Equal']);
+    });
+
+    test('a prose-only scenario is exempt even when the body shares nothing', (_: AllureBddContext) => {
+      const source = `test${tag('Result is acceptable')}(
+        'Scenario: Result is acceptable',
+        () => {
+          expect(somethingUnrelated()).toBe(42);
+        },
+      );`;
+      const violations = findThenKeywordViolations(entries, storyToSlicesFrom(source), new Set());
+      expect(violations).toEqual([]);
+    });
+
+    test('a title echoing the scenario name does not satisfy the check', (_: AllureBddContext) => {
+      // The OOXML token `w:tbl` appears in the title but not the body.
+      const source = `test${tag('Table structure preserved')}(
+        'Scenario: Table structure preserved keeps w:tbl present',
+        () => {
+          expect(unrelated()).toBe(true);
+        },
+      );`;
+      const violations = findThenKeywordViolations(entries, storyToSlicesFrom(source), new Set());
+      expect(violations.map((v) => v.scenario)).toEqual(['Table structure preserved']);
+    });
+
+    test('the allowlist exempts a named scenario', (_: AllureBddContext) => {
+      const source = `test${tag('Status set to Equal')}(
+        'Scenario: Status set to Equal',
+        () => {
+          expect(authorAndCompare(doc).ok).toBe(true);
+        },
+      );`;
+      const allowlist = new Set(['Status set to Equal']);
+      const violations = findThenKeywordViolations(entries, storyToSlicesFrom(source), allowlist);
+      expect(violations).toEqual([]);
+    });
+
+    test('chained tags share one body, so each chained scenario is checked against it', (_: AllureBddContext) => {
+      // One test carries two tags before its body. The body satisfies the first
+      // scenario (correlationStatus) but not the second (w:tbl) — the second must
+      // be flagged, proving the whole body is attributed to every chained tag.
+      const source = `test
+        ${tag('Status set to Equal')}
+        ${tag('Table structure preserved')}(
+        'a chained test',
+        () => {
+          expect(revised.correlationStatus).toBe(CorrelationStatus.Equal);
+        },
+      );`;
+      const violations = findThenKeywordViolations(entries, storyToSlicesFrom(source), new Set());
+      expect(violations.map((v) => v.scenario)).toEqual(['Table structure preserved']);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`validate_openspec_coverage.mjs` checked tag **presence**, not tag **validity** — a `.openspec('[ID] …')` slapped on an unrelated test counted toward the coverage ratio exactly like a real mapping, so `PASS 68/69` could oversell. This happened in #513 (a docx-comparison scenario tagged onto a clean `SDX-GEN` round-trip); only peer review caught it, late and expensive.

This adds a deterministic, no-LLM **THEN-keyword check** to the existing `check:spec-coverage:openspec` CI gate. It **fails closed** (independent of `--strict`, since validity is not negotiable the way the coverage ratio is).

## How it works

1. **Token mining** — for each `#### Scenario`, mine code-like tokens from its backtick code spans: `gateTokens` from the observable (THEN/AND), `matchTokens` = gate ∪ the action (WHEN). The check fires only when `gateTokens` is non-empty, so a pure-prose observable yields no token and is **auto-exempt** — the issue's "fail-closed only when THEN has a code token" rule, with no false positives on doc/proof-style mappings.
2. **Body-scoped matching** — slice per tagged test, group chained `.openspec().openspec()(…)` tags so every tag shares its test's body, and **drop the tag/title preamble** (the title echoes the scenario name and would otherwise satisfy a token like `inplace` on its own — defeating the check for exactly the kind of stuffing it targets).
3. **Allowlist** — a short, justified list exempts the few genuine mappings whose observable is asserted *outside* the TS body (external suite runner, compiled Lean proof, or a wrapping assertion helper).

The WHEN is in the match set (and GIVEN excluded) because a genuine test almost always invokes the subject under test even when it asserts the THEN through a returned value rather than the literal element name; this is what keeps real unit tests from being flagged.

## Verification

- **Zero false positives** against current `main`.
- An injected stuffed tag fails with a clear, actionable message; a same-scenario genuine mapping still passes (per-slice precision).
- Helpers are exported with a `realpathSync(argv[1])` entry guard so the pure logic is unit-tested without filesystem side effects. Tests live under `test-primitives/` (outside the validator scan roots) and build the `.openspec(` literal at runtime so the fixture file is not itself mis-scanned.

## Acceptance criteria
- [x] Wired into the `spec-coverage` gate, fails closed.
- [x] Token-extraction heuristic + auto-detected prose exemption + documented allowlist.
- [x] Unit tests: stuffed mapping FAILS, genuine PASSES, prose-only EXEMPT (plus title-echo, chained-tag, allowlist cases) — 13 tests.
- [x] Re-running against current `main` produces no false positives.

Ref: #514