### PR TITLE
fix(docx-core): thread original inline w:ins provenance through comparison (#358)

### DIFF
--- a/packages/docx-core/src/baselines/atomizer/documentReconstructor.ts
+++ b/packages/docx-core/src/baselines/atomizer/documentReconstructor.ts
@@ -27,7 +27,10 @@ import { EMPTY_PARAGRAPH_TAG, isParagraphLevelLeaf, nearestHyperlinkAncestor } f
 import { enforceConsumerCompatibility } from './consumerCompatibility.js';
 import {
   findParagraphMarkRevisionMarker,
+  getOriginalInsProvenance,
+  getOriginalInsProvenanceKey,
   placeParagraphMarkRevisionMarker,
+  type InsProvenance,
 } from './inPlaceModifier-wrappers.js';
 import { areRunPropertiesEqual } from '../../format-detection.js';
 import { debug } from './debug.js';
@@ -660,18 +663,56 @@ function buildParagraphXml(
     const paraId = allocateRevisionId(revState);
     const parts: string[] = [];
     parts.push('<w:p>');
+    // A pre-tracked inserted paragraph keeps its PPR-INS mark from the cloned
+    // source pPr; the comparison's w:del marker stacks after it (issue #452).
     parts.push(serializePPrWithParaRevisionMarker(
       group.pPr, 'w:del', paraId, author, dateStr
     ));
-    parts.push(
-      paragraphHasHyperlinkAtoms(group)
-        ? buildWholeParagraphRevisionContent(group, (runs) =>
-            wrapSerializedContentWithDel(runs, revisionCtx))
-        : wrapSerializedContentWithDel(
-            group.runGroups.map((runGroup) => buildRunContentAsPlainRun(runGroup)).join(''),
-            revisionCtx,
-          )
+    const hasInsProvenance = group.runGroups.some((runGroup) =>
+      runGroup.atoms.some((atom) => getOriginalInsProvenanceKey(atom) !== null)
     );
+    if (paragraphHasHyperlinkAtoms(group)) {
+      parts.push(
+        buildWholeParagraphRevisionContent(
+          group,
+          (runs) => wrapSerializedContentWithDel(runs, revisionCtx),
+          hasInsProvenance
+            ? (wrapped, prov) => wrapWithIns(wrapped, prov.author, prov.date || dateStr, revState)
+            : undefined,
+        )
+      );
+    } else if (hasInsProvenance) {
+      // Issue #358: content whose original lineage was inside an inline
+      // pre-tracked w:ins nests as <w:ins original-author><w:del>…</w:del></w:ins>
+      // so reject-all drops it together with the PPR-INS paragraph mark,
+      // matching reject(original). Provenance-free content keeps a plain w:del.
+      for (const runGroup of group.runGroups) {
+        if (groupHasParagraphLevelAtoms(runGroup)) {
+          const markerContent = buildRunContentAsPlainRun(runGroup);
+          if (markerContent) {
+            parts.push(wrapSerializedContentWithDel(markerContent, revisionCtx));
+          }
+          continue;
+        }
+        for (const span of partitionAtomsByInsProvenance(runGroup.atoms)) {
+          const content = buildRunContentAsPlainRun({ ...runGroup, atoms: span.atoms });
+          if (!content) continue;
+          const del = wrapSerializedContentWithDel(content, revisionCtx);
+          parts.push(
+            span.prov
+              ? wrapWithIns(del, span.prov.author, span.prov.date || dateStr, revState)
+              : del
+          );
+        }
+      }
+    } else {
+      parts.push(
+        wrapSerializedContentWithDel(
+          group.runGroups.map((runGroup) => buildRunContentAsPlainRun(runGroup)).join(''),
+          revisionCtx,
+        )
+      );
+    }
     parts.push('</w:p>');
     return parts.join('');
   }
@@ -858,6 +899,101 @@ function buildRunContentAsPlainRun(group: RunGroup): string {
 }
 
 /**
+ * Contiguous slice of a RunGroup's atoms sharing one original-side inline
+ * `<w:ins>` provenance (null = plain lineage). See issue #358.
+ */
+interface InsProvenanceSpan {
+  prov: InsProvenance | null;
+  atoms: ComparisonUnitAtom[];
+}
+
+/**
+ * Partition a RunGroup's atoms into contiguous spans by original-ins
+ * provenance key. Atom order is preserved, so document order is unchanged.
+ */
+function partitionAtomsByInsProvenance(atoms: ComparisonUnitAtom[]): InsProvenanceSpan[] {
+  const spans: InsProvenanceSpan[] = [];
+  let lastKey: string | null | undefined;
+  for (const atom of atoms) {
+    const key = getOriginalInsProvenanceKey(atom);
+    const lastSpan = spans[spans.length - 1];
+    if (lastSpan && key === lastKey) {
+      lastSpan.atoms.push(atom);
+    } else {
+      spans.push({ prov: getOriginalInsProvenance(atom), atoms: [atom] });
+    }
+    lastKey = key;
+  }
+  return spans;
+}
+
+/**
+ * Statuses whose emission must preserve the ORIGINAL input's inline `w:ins`
+ * provenance (issue #358): matched content keeps its original wrapper, and
+ * comparison deletions of pre-tracked-inserted content nest the `w:del`
+ * inside the restored `w:ins`. Moved content is out of scope (see #358).
+ */
+const INS_PROVENANCE_STATUSES: ReadonlySet<CorrelationStatus> = new Set([
+  CorrelationStatus.Equal,
+  CorrelationStatus.Unknown,
+  CorrelationStatus.Deleted,
+  CorrelationStatus.FormatChanged,
+]);
+
+function groupHasInsProvenance(group: RunGroup): boolean {
+  return (
+    INS_PROVENANCE_STATUSES.has(group.status) &&
+    group.atoms.some((atom) => getOriginalInsProvenanceKey(atom) !== null)
+  );
+}
+
+/**
+ * Provenance-aware emission for a run group carrying original-ins lineage
+ * (issue #358). Each contiguous provenance span is emitted separately:
+ *
+ * - Equal/Unknown span with provenance → `<w:ins original-author>run</w:ins>`
+ * - Deleted span with provenance →
+ *   `<w:ins original-author><w:del Comparison>run</w:del></w:ins>`
+ * - FormatChanged span with provenance → the rPrChange run inside `w:ins`
+ * - spans without provenance → the legacy per-status emission
+ *
+ * Reject-all then removes the restored `w:ins` subtrees (matching
+ * reject(original), which drops pre-tracked insertions) while accept-all
+ * resolves the inner deletion and unwraps the `w:ins` (matching
+ * accept(revised)).
+ *
+ * Only called when the group actually carries provenance, so paragraphs
+ * without pre-tracked-insertion lineage keep byte-identical output.
+ */
+function buildRunGroupXmlWithInsProvenance(
+  group: RunGroup,
+  author: string,
+  dateStr: string,
+  revState: RevisionIdState
+): string {
+  const parts: string[] = [];
+  for (const span of partitionAtomsByInsProvenance(group.atoms)) {
+    const spanGroup: RunGroup = { ...group, atoms: span.atoms };
+    const content =
+      group.status === CorrelationStatus.FormatChanged
+        ? buildFormatChangeRun(spanGroup, author, dateStr, revState)
+        : buildRunContent(spanGroup);
+    if (!content) continue;
+
+    const inner =
+      group.status === CorrelationStatus.Deleted
+        ? wrapWithDel(content, author, dateStr, revState)
+        : content;
+    parts.push(
+      span.prov
+        ? wrapWithIns(inner, span.prov.author, span.prov.date || dateStr, revState)
+        : inner
+    );
+  }
+  return parts.join('');
+}
+
+/**
  * Build XML for a run group with appropriate track changes wrapper.
  *
  * `explicitMoveMarkers` reports whether the surrounding paragraph's atom
@@ -871,6 +1007,13 @@ function buildRunGroupXml(
   revState: RevisionIdState,
   explicitMoveMarkers: ExplicitMoveMarkers = NO_EXPLICIT_MOVE_MARKERS
 ): string {
+  // Original-ins provenance threading (issue #358). Paragraph-level marker
+  // atoms keep the legacy marker-aware route — their emission interleaves
+  // bare markers with runs and is not span-partitionable.
+  if (groupHasInsProvenance(group) && !groupHasParagraphLevelAtoms(group)) {
+    return buildRunGroupXmlWithInsProvenance(group, author, dateStr, revState);
+  }
+
   const runContent = buildRunContent(group);
 
   // If run content is empty (e.g., only empty paragraph atoms), return empty string
@@ -1195,10 +1338,18 @@ function buildRunGroupsWithHyperlinks(
  * Whole-paragraph insert/delete emission with hyperlink wrappers restored.
  * Each bucket gets its own revision wrapper so the hyperlink can stay
  * OUTSIDE the w:ins / w:del (see buildRunGroupsWithHyperlinks).
+ *
+ * When `provWrap` is provided (whole-paragraph DELETED emission, issue #358),
+ * buckets whose atoms carry original-ins provenance are emitted per
+ * provenance span, with each wrapped chunk further nested via `provWrap`
+ * (`<w:ins original-author><w:del>…</w:del></w:ins>`); the nesting sits
+ * INSIDE the hyperlink wrapper, mirroring the plain `w:del` placement.
+ * Provenance-free buckets keep the legacy single-wrapper emission.
  */
 function buildWholeParagraphRevisionContent(
   group: ParagraphGroup,
-  wrap: (content: string) => string
+  wrap: (content: string) => string,
+  provWrap?: (wrappedContent: string, prov: InsProvenance) => string
 ): string {
   const buckets = mergeAdjacentHyperlinkSegments(
     group.runGroups.flatMap(splitRunGroupByHyperlink)
@@ -1206,9 +1357,36 @@ function buildWholeParagraphRevisionContent(
 
   const parts: string[] = [];
   for (const bucket of buckets) {
-    const runs = bucket.groups.map((g) => buildRunContentAsPlainRun(g)).join('');
-    if (!runs) continue;
-    const wrapped = wrap(runs);
+    const bucketHasProvenance =
+      provWrap !== undefined &&
+      bucket.groups.some((g) =>
+        g.atoms.some((atom) => getOriginalInsProvenanceKey(atom) !== null)
+      );
+
+    let wrapped: string;
+    if (bucketHasProvenance) {
+      const chunks: string[] = [];
+      for (const g of bucket.groups) {
+        if (groupHasParagraphLevelAtoms(g)) {
+          const markerContent = buildRunContentAsPlainRun(g);
+          if (markerContent) chunks.push(wrap(markerContent));
+          continue;
+        }
+        for (const span of partitionAtomsByInsProvenance(g.atoms)) {
+          const content = buildRunContentAsPlainRun({ ...g, atoms: span.atoms });
+          if (!content) continue;
+          const chunk = wrap(content);
+          chunks.push(span.prov ? provWrap!(chunk, span.prov) : chunk);
+        }
+      }
+      wrapped = chunks.join('');
+      if (!wrapped) continue;
+    } else {
+      const runs = bucket.groups.map((g) => buildRunContentAsPlainRun(g)).join('');
+      if (!runs) continue;
+      wrapped = wrap(runs);
+    }
+
     parts.push(
       bucket.hyperlink && isEmittableHyperlink(bucket.hyperlink)
         ? `${serializeHyperlinkOpenTag(bucket.hyperlink.element)}${wrapped}</w:hyperlink>`

--- a/packages/docx-core/src/baselines/atomizer/inPlaceModifier-presplit.ts
+++ b/packages/docx-core/src/baselines/atomizer/inPlaceModifier-presplit.ts
@@ -10,6 +10,7 @@ import { CorrelationStatus } from '../../core-types.js';
 import { getDirectContentElements, splitRunAtVisibleOffset, visibleLengthForEl } from '../../primitives/index.js';
 import { warn } from './debug.js';
 import { FIELD_CHAR_TAG_NAMES } from './inPlaceModifier-deletion.js';
+import { getOriginalInsProvenanceKey, getRunInsertionAnchor } from './inPlaceModifier-wrappers.js';
 
 export function atomContentVisibleLength(el: Element): number {
   const tag = el.tagName;
@@ -146,6 +147,154 @@ export function preSplitMixedStatusRuns(mergedAtoms: ComparisonUnitAtom[]): void
       // DOM operation failed — skip this run. The existing fallback-to-rebuild
       // architecture will handle it if the overall safety check fails.
       warn('preSplitMixedStatusRuns', `Skipping run split due to error: ${_err}`);
+    }
+  }
+}
+
+/**
+ * Pre-split revised-tree runs whose atoms carry different ORIGINAL-side inline
+ * `<w:ins>` provenance (issue #358).
+ *
+ * When the original input pre-tracked part of a paragraph as an insertion and
+ * the revised text matches it, the matched (Equal) atoms land in one revised
+ * run together with plain-lineage atoms — e.g. revised run "Alpha beta" where
+ * only " beta" descends from the original's `<w:ins>`. `handleEqual` wraps at
+ * run granularity, so the run must first be split at provenance boundaries;
+ * afterwards each fragment is uniformly plain or uniformly provenance-bearing
+ * and the per-status handlers wrap the right fragment only.
+ *
+ * Mirrors the span/split machinery of {@link preSplitMixedStatusRuns}; runs
+ * after it (and after {@link preSplitInterleavedWordRuns}), so it operates on
+ * the already status-homogeneous fragments those passes produced.
+ *
+ * Safety: wrapped in try/catch per run group. If any DOM operation fails, the
+ * run is skipped and the existing fallback-to-rebuild architecture handles it.
+ *
+ * @see https://github.com/UseJunior/safe-docx/issues/358
+ */
+export function preSplitInsProvenanceRuns(mergedAtoms: ComparisonUnitAtom[]): void {
+  // Group atoms by their sourceRunElement (revised-tree runs only).
+  const runGroups = new Map<Element, ComparisonUnitAtom[]>();
+
+  for (const atom of mergedAtoms) {
+    if (!atom.sourceRunElement) continue;
+
+    // Skip original-tree atoms — Deleted/MovedSource runs are cloned, not wrapped.
+    if (
+      atom.correlationStatus === CorrelationStatus.Deleted ||
+      atom.correlationStatus === CorrelationStatus.MovedSource
+    ) continue;
+
+    // Skip collapsed field atoms (multi-run field sequences).
+    if (atom.collapsedFieldAtoms && atom.collapsedFieldAtoms.length > 0) continue;
+
+    // Skip field character elements — semantically fragile.
+    if (FIELD_CHAR_TAG_NAMES.has(atom.contentElement.tagName)) continue;
+
+    const group = runGroups.get(atom.sourceRunElement);
+    if (group) {
+      group.push(atom);
+    } else {
+      runGroups.set(atom.sourceRunElement, [atom]);
+    }
+  }
+
+  for (const [run, atoms] of runGroups) {
+    // Early check: skip runs whose atoms all share one provenance key.
+    const keys = new Set(atoms.map((a) => getOriginalInsProvenanceKey(a)));
+    if (keys.size <= 1) continue;
+
+    // Guard: skip runs already detached from the tree.
+    if (!run.parentNode) continue;
+
+    // Skip runs already inside a physical track-change wrapper: the revised
+    // document's own pre-tracked wrapper governs the whole run, and wrapping
+    // fragments of it again would nest revision markup incorrectly.
+    if (getRunInsertionAnchor(run) !== run) continue;
+
+    try {
+      // Compute the run's actual visible length via DOM traversal.
+      const contentEls = getDirectContentElements(run);
+      let runVisibleLength = 0;
+      for (const cel of contentEls) {
+        runVisibleLength += visibleLengthForEl(cel);
+      }
+
+      // Cross-run safety: if sum of atom lengths exceeds run visible length,
+      // this group contains a cross-run merged atom (passes 3/4). Skip it.
+      let sumAtomLengths = 0;
+      for (const atom of atoms) {
+        sumAtomLengths += atomContentVisibleLength(atom.contentElement);
+      }
+      if (sumAtomLengths > runVisibleLength) continue;
+
+      // Compute contiguous provenance spans with character offsets.
+      interface ProvenanceSpan {
+        key: string | null;
+        startOffset: number;
+        length: number;
+        atoms: ComparisonUnitAtom[];
+      }
+
+      const spans: ProvenanceSpan[] = [];
+      let offset = 0;
+      for (const atom of atoms) {
+        const len = atomContentVisibleLength(atom.contentElement);
+        const key = getOriginalInsProvenanceKey(atom);
+        const lastSpan = spans[spans.length - 1];
+        if (lastSpan && lastSpan.key === key) {
+          lastSpan.length += len;
+          lastSpan.atoms.push(atom);
+        } else {
+          spans.push({
+            key,
+            startOffset: offset,
+            length: len,
+            atoms: [atom],
+          });
+        }
+        offset += len;
+      }
+
+      // If only one span after grouping, no split needed.
+      if (spans.length <= 1) continue;
+
+      // Collect split points: startOffset of each span after the first.
+      const splitPoints: number[] = [];
+      for (let i = 1; i < spans.length; i++) {
+        const pt = spans[i]!.startOffset;
+        // Filter out degenerate split points at boundaries.
+        if (pt > 0 && pt < runVisibleLength) {
+          splitPoints.push(pt);
+        }
+      }
+
+      if (splitPoints.length === 0) continue;
+
+      // Split DOM run right-to-left to keep earlier offsets valid.
+      const rightFragments: Element[] = [];
+      for (let i = splitPoints.length - 1; i >= 0; i--) {
+        const { right } = splitRunAtVisibleOffset(run, splitPoints[i]!);
+        rightFragments.push(right);
+      }
+
+      // Map fragments: [originalRun (leftmost), ...reverse(rightFragments)]
+      // After R-to-L splits, rightFragments are in reverse document order.
+      const fragments = [run, ...rightFragments.reverse()];
+
+      // Update atom sourceRunElement pointers to the correct fragment.
+      // Each span maps to one fragment in order.
+      for (let i = 0; i < spans.length; i++) {
+        const fragment = fragments[i];
+        if (!fragment) continue;
+        for (const atom of spans[i]!.atoms) {
+          atom.sourceRunElement = fragment;
+        }
+      }
+    } catch (_err) {
+      // DOM operation failed — skip this run. The existing fallback-to-rebuild
+      // architecture will handle it if the overall safety check fails.
+      warn('preSplitInsProvenanceRuns', `Skipping run split due to error: ${_err}`);
     }
   }
 }

--- a/packages/docx-core/src/baselines/atomizer/inPlaceModifier-wrappers.ts
+++ b/packages/docx-core/src/baselines/atomizer/inPlaceModifier-wrappers.ts
@@ -88,6 +88,92 @@ export function isCollapsedFieldAtom(atom: ComparisonUnitAtom): boolean {
 }
 
 /**
+ * Author/date identity of a pre-tracked `<w:ins>` wrapper carried by the
+ * ORIGINAL input document.
+ */
+export interface InsProvenance {
+  author: string;
+  date: string;
+}
+
+/**
+ * Resolve the ORIGINAL document's inline `<w:ins>` provenance for a merged
+ * atom, or null when the original lineage was not inside a pre-tracked
+ * insertion.
+ *
+ * Merged atoms come from two trees: Deleted/MovedSource atoms (and
+ * original-sourced empty-paragraph atoms) ARE original-tree atoms and carry
+ * the input wrapper on `revTrackElement` directly. Equal/FormatChanged/
+ * Inserted atoms — plus the whitespace duplicates reorderChangeBlocks
+ * synthesizes from them — are revised-tree atoms, where `revTrackElement`
+ * describes the REVISED document's own wrapper; the original lineage is only
+ * reachable through the LCS match link (`comparisonUnitAtomBefore`).
+ * `sourceDocument` (assigned in createMergedAtomList) is the discriminator.
+ *
+ * Threading this provenance into reconstruction is what keeps the INV-RT-001
+ * reject projection lawful: content the original tracked as inserted must
+ * stay droppable by reject-all in the combined output.
+ *
+ * @see https://github.com/UseJunior/safe-docx/issues/358
+ */
+export function getOriginalInsProvenance(atom: ComparisonUnitAtom): InsProvenance | null {
+  const revTrack =
+    atom.sourceDocument === 'original'
+      ? atom.revTrackElement
+      : atom.comparisonUnitAtomBefore?.revTrackElement;
+  if (!revTrack || revTrack.tagName !== 'w:ins') {
+    return null;
+  }
+  const author = revTrack.getAttribute('w:author');
+  if (!author) {
+    return null;
+  }
+  return { author, date: revTrack.getAttribute('w:date') ?? '' };
+}
+
+/**
+ * Grouping key for {@link getOriginalInsProvenance} — atoms whose original
+ * lineage sits in the same-authored `<w:ins>` share a key; plain atoms map to
+ * null. Used to split runs/groups at provenance boundaries.
+ */
+export function getOriginalInsProvenanceKey(atom: ComparisonUnitAtom): string | null {
+  const prov = getOriginalInsProvenance(atom);
+  return prov ? `${prov.author}\u0000${prov.date}` : null;
+}
+
+/**
+ * Nest an already-placed element (typically a freshly emitted `<w:del>`)
+ * inside a `<w:ins>` that restores the original input's insertion provenance:
+ * `<w:ins original-author><w:del Comparison>…</w:del></w:ins>`.
+ *
+ * Projection law: reject-all removes the outer w:ins with its whole subtree
+ * (matching reject(original), which drops the pre-tracked insertion), while
+ * accept-all removes the inner w:del and unwraps the then-empty w:ins
+ * (matching accept(revised), which never had the text).
+ *
+ * The ins-outside/del-inside order mirrors the paragraph-mark analogue
+ * ({@link placeParagraphMarkRevisionMarker} stacks w:ins before w:del).
+ *
+ * @see https://github.com/UseJunior/safe-docx/issues/358
+ */
+export function wrapWithOriginalInsProvenance(
+  element: Element,
+  prov: InsProvenance,
+  state: RevisionIdState
+): Element {
+  const attrs: Record<string, string> = {
+    'w:id': String(allocateRevisionId(state)),
+    'w:author': prov.author,
+  };
+  if (prov.date) {
+    attrs['w:date'] = prov.date;
+  }
+  const ins = createEl('w:ins', attrs);
+  wrapElement(element, ins);
+  return ins;
+}
+
+/**
  * Convert a run node to the correct insertion anchor.
  *
  * If the run is wrapped in a track-change container, the insertion anchor

--- a/packages/docx-core/src/baselines/atomizer/inPlaceModifier.ts
+++ b/packages/docx-core/src/baselines/atomizer/inPlaceModifier.ts
@@ -42,14 +42,22 @@ import {
   addFormatChange,
   getAtomRunAtBoundary,
   getAtomRuns,
+  getOriginalInsProvenance,
   getRunInsertionAnchor,
+  isCollapsedFieldAtom,
   wrapAsInserted,
   wrapAsMoveTo,
   wrapParagraphAsDeleted,
   wrapParagraphAsInserted,
+  wrapRunWithTrackChange,
+  wrapWithOriginalInsProvenance,
 } from './inPlaceModifier-wrappers.js';
 import { insertDeletedParagraph, insertDeletedRun, insertMoveFromRun } from './inPlaceModifier-deletion.js';
-import { preSplitInterleavedWordRuns, preSplitMixedStatusRuns } from './inPlaceModifier-presplit.js';
+import {
+  preSplitInsProvenanceRuns,
+  preSplitInterleavedWordRuns,
+  preSplitMixedStatusRuns,
+} from './inPlaceModifier-presplit.js';
 import {
   coalesceDelInsPairChains,
   groupDeletionsBeforeInsertions,
@@ -82,6 +90,7 @@ export function modifyRevisedDocument(
   attachSourceElementPointers(revisedAtoms);
   preSplitMixedStatusRuns(mergedAtoms);
   preSplitInterleavedWordRuns(mergedAtoms);
+  preSplitInsProvenanceRuns(mergedAtoms);
 
   // Process atoms and apply track changes to the revised tree
   // Group atoms by paragraph for efficient processing
@@ -233,6 +242,35 @@ interface HandlerResult {
  * Handler function type for processing atoms by status.
  */
 type AtomHandler = (atom: ComparisonUnitAtom, ctx: ProcessingContext) => HandlerResult;
+
+/**
+ * Restore the ORIGINAL input's inline `<w:ins>` provenance on a matched
+ * revised run (issue #358).
+ *
+ * Content whose original lineage was pre-tracked as an insertion must stay
+ * inside a `w:ins` in the combined output, otherwise reject-all keeps text
+ * that reject(original) drops (INV-RT-001 violation). preSplitInsProvenanceRuns
+ * has already isolated the provenance-bearing fragment, so wrapping the whole
+ * run is exact. Runs already sitting inside a physical track-change wrapper
+ * (the revised document's own pre-tracked markup) are left alone — re-wrapping
+ * them would nest revision markup incorrectly.
+ */
+function restoreOriginalInsProvenanceOnRun(
+  atom: ComparisonUnitAtom,
+  run: Element,
+  ctx: ProcessingContext
+): void {
+  const prov = getOriginalInsProvenance(atom);
+  if (!prov) return;
+  if (getRunInsertionAnchor(run) !== run) return;
+  wrapRunWithTrackChange({
+    run,
+    tagName: 'w:ins',
+    author: prov.author,
+    dateStr: prov.date || ctx.dateStr,
+    state: ctx.state,
+  });
+}
 
 function isParagraphRemovedOnRejectInContext(paragraph: Element, ctx: ProcessingContext): boolean {
   if (paragraphHasParaInsMarker(paragraph)) {
@@ -435,12 +473,20 @@ function handleDeleted(atom: ComparisonUnitAtom, ctx: ProcessingContext): Handle
     );
 
     if (del) {
+      // Deleted content whose original lineage was inside a pre-tracked w:ins
+      // nests as <w:ins original-author><w:del Comparison>…</w:del></w:ins>,
+      // so reject-all drops it (with the w:ins) and accept-all resolves the
+      // deletion — both matching the input projections (issue #358).
+      // Collapsed-field atoms emit multiple siblings (some outside <w:del>)
+      // and are left unnested; a pre-tracked inserted field is out of scope.
+      const prov = !isCollapsedFieldAtom(atom) ? getOriginalInsProvenance(atom) : null;
+      const anchor = prov ? wrapWithOriginalInsProvenance(del, prov, ctx.state) : del;
       // Track last run in created paragraphs
       if (unifiedPara !== undefined && ctx.createdParagraphs.has(unifiedPara)) {
-        ctx.createdParagraphLastRun.set(unifiedPara, del);
+        ctx.createdParagraphLastRun.set(unifiedPara, anchor);
       }
       return {
-        newLastRun: del,
+        newLastRun: anchor,
         newLastParagraph: targetParagraph,
         newLastParagraphIndex: atom.paragraphIndex,
       };
@@ -630,6 +676,9 @@ function handleFormatChanged(atom: ComparisonUnitAtom, ctx: ProcessingContext): 
   const run = getAtomRunAtBoundary(atom, 'start');
   if (run && atom.formatChange?.oldRunProperties) {
     addFormatChange(run, atom.formatChange.oldRunProperties, ctx.author, ctx.dateStr, ctx.state);
+    // Equal-text/changed-format content keeps its original-side w:ins lineage
+    // too (issue #358); the w:rPrChange then lives inside the wrapper.
+    restoreOriginalInsProvenanceOnRun(atom, run, ctx);
     const endRun = getAtomRunAtBoundary(atom, 'end') ?? run;
     const insertionPoint = getRunInsertionAnchor(endRun);
 
@@ -668,6 +717,9 @@ function handleEqual(atom: ComparisonUnitAtom, ctx: ProcessingContext): HandlerR
   // For non-empty atoms, sourceRunElement points to revised tree - safe to use directly
   const run = getAtomRunAtBoundary(atom, 'end');
   if (run) {
+    // Matched content whose original lineage was inside a pre-tracked w:ins
+    // must keep that wrapper in the combined output (issue #358).
+    restoreOriginalInsProvenanceOnRun(atom, run, ctx);
     const insertionPoint = getRunInsertionAnchor(run);
 
     // BUG FIX: Don't move the insertion point backwards if we are still in the same run.
@@ -923,6 +975,8 @@ export {
 export {
   addFormatChange,
   addParagraphPropertyChange,
+  getOriginalInsProvenance,
+  getOriginalInsProvenanceKey,
   runHasVisibleContent,
   wrapAsDeleted,
   wrapAsInserted,
@@ -930,6 +984,8 @@ export {
   wrapAsMoveTo,
   wrapParagraphAsDeleted,
   wrapParagraphAsInserted,
+  wrapWithOriginalInsProvenance,
+  type InsProvenance,
 } from './inPlaceModifier-wrappers.js';
 export {
   insertDeletedParagraph,
@@ -937,6 +993,7 @@ export {
   insertMoveFromRun,
 } from './inPlaceModifier-deletion.js';
 export {
+  preSplitInsProvenanceRuns,
   preSplitInterleavedWordRuns,
   preSplitMixedStatusRuns,
 } from './inPlaceModifier-presplit.js';

--- a/packages/docx-core/src/integration/lean-spec-bridge.test.ts
+++ b/packages/docx-core/src/integration/lean-spec-bridge.test.ts
@@ -356,27 +356,22 @@ const trackedFootnoteAnchorScenarioArb: fc.Arbitrary<FootnoteAnchorScenario> = p
 // inserts included. The relaxation did its discovery job: it surfaced two
 // genuine engine bug classes, pinned per the bounded-remediation discipline
 // (narrow, named, issue-linked exclusions + the characterization test
-// 'INV-RT-001 pinned engine bugs …' below) rather than fixed here:
-//   - Issue #358: inline run-level pre-tracked `w:ins` ORIGINALS stay excluded
-//     — the engine flattens the original's inline insertion provenance
-//     unconditionally, so reject(combined) keeps text reject(original) drops
-//     for EVERY revised counterpart (probed: matched, deleted, identical,
-//     unrelated). Paragraph-insert ORIGINALS are excluded for the same
-//     flattening: when the comparison deletes the pre-tracked inserted
-//     paragraph, its content is emitted as bare w:del (the original-author
-//     w:ins wrapper is lost), so reject(combined) restores text that
-//     reject(original) discards. The paragraph MARKS themselves thread
-//     correctly (stacked PPR-DEL(Comparison) + PPR-INS(input-author)), and
-//     while paragraph-mark resolution dropped the whole paragraph the content
-//     flattening was unobservable — the #431 merge rule (a mark revision
-//     resolves by merging, never by discarding content) made it visible, so
-//     the exclusion now covers both pre-tracked-insertion shapes. Pinned in
-//     the characterization test below.
+// 'INV-RT-001 pinned engine bugs …' below) rather than fixed inline:
+//   - Issue #358 (FIXED): inline run-level and paragraph-insert pre-tracked
+//     `w:ins` ORIGINALS are back in scope. The engine now threads the
+//     original's insertion provenance through both reconstruction paths —
+//     matched content keeps its original-author `w:ins` wrapper and
+//     comparison-deleted content nests `w:del(Comparison)` INSIDE the
+//     restored `w:ins(original-author)` — so reject(combined) drops exactly
+//     what reject(original) drops. Dedicated regression coverage lives in
+//     pretracked-ins-provenance.test.ts.
 //   - Issue #359: pairs whose pre-tracked-insertion text collides with the
 //     other side's plain text are excluded via `hasInsProvenanceCollision` on
-//     the pair arbitrary below.
+//     the pair arbitrary below, and stay pinned in the characterization test.
 const trackedOriginalScenarioArb: fc.Arbitrary<TrackedScenario> = fc.oneof(
+  trackedInsertionScenarioArb,
   trackedDeletionScenarioArb,
+  trackedParagraphInsertScenarioArb,
   trackedParagraphPropertyScenarioArb,
   trackedCommentAnchorScenarioArb,
   trackedFootnoteAnchorScenarioArb,
@@ -438,12 +433,16 @@ function textsCollide(claimed: string, otherRawParagraphs: string[]): boolean {
   );
 }
 
-// Issue #359: pre-tracked-insertion content that textually collides with the
-// other input's plain text loses provenance through the comparison (the
-// combined output keeps exactly one lineage's claim), so the global reject
-// projection diverges and the engine falls back — with a law-violating rebuild
-// output in the paragraph-insert shapes. Until #359 lands, exclude exactly the
-// colliding pairs; the characterization test below pins today's behavior.
+// Issue #359: REVISED-side pre-tracked-insertion content that textually
+// collides with the original's plain text keeps the revised lineage's claim
+// (the physical `w:ins` wrapper survives around content whose original lineage
+// was plain), so the inplace candidate's reject projection diverges and the
+// engine permanently falls back to rebuild. The #358 fix resolved the
+// original-side half of this filter's old scope; the filter stays pair-level
+// (both directions) because the property asserts inplace mode and the
+// revised-side fallback is unconditional on collision. Until #359 lands,
+// exclude exactly the colliding pairs; the characterization test below pins
+// today's behavior.
 function hasInsProvenanceCollision(pair: TrackedScenarioPair): boolean {
   const originalRaw = scenarioRawParagraphTexts(pair.originalScenario);
   const revisedRaw = scenarioRawParagraphTexts(pair.revisedScenario);
@@ -1451,48 +1450,36 @@ describe('Lean Spec Bridge - Inplace Reconstruction', { timeout: 60_000 }, () =>
   );
 
   test(
-    'INV-RT-001 pinned engine bugs: pre-tracked insertion provenance is lost across comparison (#358, #359)',
+    'INV-RT-001 pinned engine bug: revised-side pre-tracked insertion provenance is lost on collision (#359)',
     async ({ given, when, then }: AllureBddContext) => {
-      // Characterization of TODAY's behavior for the two engine bug classes the
-      // #347 arbitrary relaxation surfaced (pin + file, fix in their own PRs —
+      // Characterization of TODAY's behavior for the remaining engine bug class
+      // the #347 arbitrary relaxation surfaced (pin + file, fix in its own PR —
       // mirroring how [LEAN-HELP-08] pinned G5 before its fix). Each case
-      // asserts the CURRENT divergence precisely so the eventual fixes flip
+      // asserts the CURRENT divergence precisely so the eventual fix flips
       // this test deliberately rather than silently:
-      //   - #358: the original's inline run-level `w:ins` provenance is
-      //     flattened, so reject(combined) keeps text reject(original) drops —
-      //     on BOTH reconstruction paths (the rebuild fallback output violates
-      //     the projection law too, unchecked per #226).
-      //   - #359: pre-tracked-insertion text colliding with the other side's
-      //     plain text keeps exactly one lineage's provenance. The inline shape
-      //     (the #339 flake) is rescued by the rebuild fallback; the
-      //     paragraph-insert shapes ship law-violating output.
+      //   - #359: REVISED-side pre-tracked-insertion text colliding with the
+      //     original's plain text keeps exactly one lineage's provenance — the
+      //     revised document's physical `w:ins` wrapper survives around content
+      //     whose original lineage was plain, so the inplace candidate's reject
+      //     projection drops text reject(original) keeps and the engine
+      //     permanently falls back to rebuild. The rebuild output happens to
+      //     satisfy the projection law for these shapes (the inline shape is
+      //     the #339 flake, rescued; the paragraph-insert shape holds via the
+      //     #431 mark-merge rule), so the residual harm is the lost provenance
+      //     and the unconditional fallback, not a law violation.
+      //   - #358 (original-side provenance flattening, both inline and
+      //     paragraph-insert shapes) is FIXED: those pairs now stay inplace and
+      //     are covered by trackedOriginalScenarioArb above plus the dedicated
+      //     regression suite in pretracked-ins-provenance.test.ts.
       interface PinnedProvenanceCase {
         name: string;
         build: () => Promise<{ original: Buffer; revised: Buffer }>;
         // Normalized reject projections asserted VERBATIM as they are today.
-        // When they differ, the shipped output violates the projection law.
         expectedRejectCombined: string;
         expectedRejectOriginal: string;
       }
 
       const cases: PinnedProvenanceCase[] = [
-        {
-          name: '#358 inline-ins original vs clean revised equal to accept(original)',
-          build: async () => ({
-            original: (
-              await materializeTrackedScenario({
-                family: 'w:ins',
-                paragraphs: ['Alpha'],
-                paragraphIndex: 0,
-                offset: 'Alpha'.length,
-                insertedText: ' beta',
-              })
-            ).document,
-            revised: await buildSyntheticDocx({ paragraphs: ['Alpha beta'] }),
-          }),
-          expectedRejectCombined: 'Alpha beta',
-          expectedRejectOriginal: 'Alpha',
-        },
         {
           name: '#359 inline-ins revised colliding with a plain original word (#339 shape, rebuild rescues)',
           build: async () => ({
@@ -1532,59 +1519,17 @@ describe('Lean Spec Bridge - Inplace Reconstruction', { timeout: 60_000 }, () =>
           expectedRejectCombined: 'Alpha text.\nAdded para.',
           expectedRejectOriginal: 'Alpha text.\nAdded para.',
         },
-        {
-          name: '#359 paragraph-insert original appearing plain in the revised',
-          build: async () => ({
-            original: (
-              await materializeTrackedScenario({
-                family: 'paragraph-insert',
-                paragraphs: ['Alpha text.'],
-                anchorIndex: 0,
-                relativePosition: 'AFTER',
-                newParagraphText: 'Added para.',
-              })
-            ).document,
-            revised: await buildSyntheticDocx({ paragraphs: ['Alpha text.', 'Added para.'] }),
-          }),
-          expectedRejectCombined: 'Alpha text.\nAdded para.',
-          expectedRejectOriginal: 'Alpha text.',
-        },
-        {
-          // The non-colliding mirror: the comparison deletes the pre-tracked
-          // inserted paragraph and emits its content as bare w:del(Comparison)
-          // under correctly stacked PPR-DEL(Comparison) + PPR-INS(original)
-          // marks — the original-author content w:ins wrapper is lost (#358
-          // class). While paragraph-mark resolution DROPPED the marked
-          // paragraph this was unobservable; the #431 mark-merge rule restores
-          // the flattened content on reject, so reject(combined) keeps text
-          // reject(original) discards and the engine permanently falls back.
-          name: '#358 paragraph-insert original deleted by the comparison (made observable by the #431 mark-merge rule)',
-          build: async () => ({
-            original: (
-              await materializeTrackedScenario({
-                family: 'paragraph-insert',
-                paragraphs: ['Alpha text.'],
-                anchorIndex: 0,
-                relativePosition: 'AFTER',
-                newParagraphText: 'Added para.',
-              })
-            ).document,
-            revised: await buildSyntheticDocx({ paragraphs: ['Alpha text.'] }),
-          }),
-          expectedRejectCombined: 'Alpha text.\nAdded para.',
-          expectedRejectOriginal: 'Alpha text.',
-        },
       ];
 
       await given(
-        'minimal repro pairs for the #358 and #359 pre-tracked insertion provenance bug classes',
+        'minimal repro pairs for the #359 revised-side pre-tracked insertion provenance bug class',
         async () => {},
       );
 
       await when('each pair runs through the live inplace-requested comparison', async () => {});
 
       await then(
-        'every case falls back on rejectText today, accept projections hold, and the reject divergences match the filed issues verbatim',
+        'every case falls back on rejectText today, accept projections hold, and the reject divergences match the filed issue verbatim',
         async () => {
           for (const pinned of cases) {
             const { original, revised } = await pinned.build();

--- a/packages/docx-core/src/integration/pretracked-ins-provenance.test.ts
+++ b/packages/docx-core/src/integration/pretracked-ins-provenance.test.ts
@@ -1,0 +1,367 @@
+/**
+ * Integration Tests — Original-side pre-tracked insertion provenance (#358)
+ *
+ * When the ORIGINAL input carries a pre-tracked insertion (an inline run-level
+ * `w:ins`, or an inserted paragraph whose runs sit inside `w:ins` under a
+ * PPR-INS paragraph mark), the comparison must thread that provenance through
+ * to the combined output instead of flattening it:
+ *
+ * - matched content keeps its original-author `w:ins` wrapper, and
+ * - comparison-deleted content nests `w:del(Comparison)` INSIDE the restored
+ *   `w:ins(original-author)`.
+ *
+ * That shape is what keeps the INV-RT-001 projection law intact on both
+ * projections: reject-all removes the restored `w:ins` subtrees exactly like
+ * reject(original) drops the pre-tracked insertion, while accept-all resolves
+ * the inner deletion and unwraps the emptied `w:ins` exactly like
+ * accept(revised). Before the fix, the inserted text entered the combined
+ * output as plain matched content or bare `w:delText`, so reject(combined)
+ * kept text reject(original) drops — on the inplace path AND the rebuild
+ * fallback (issue #226's screening surfaced but could not repair it).
+ *
+ * The run-level mechanism mirrors the paragraph-mark precedent (stacked
+ * PPR-DEL(Comparison) + PPR-INS(original-author)) from the G4/G5 fixes.
+ *
+ * Revised-side provenance collisions remain pinned separately (issue #359,
+ * lean-spec-bridge.test.ts).
+ *
+ * @see https://github.com/UseJunior/safe-docx/issues/358
+ */
+
+import { describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { compareDocuments, type ReconstructionMode } from '../index.js';
+import {
+  acceptAllChanges,
+  rejectAllChanges,
+  extractTextWithParagraphs,
+  normalizeText,
+} from '../baselines/atomizer/trackChangesAcceptorAst.js';
+import { DocxArchive } from '../shared/docx/DocxArchive.js';
+import { DocxDocument } from '../primitives/document.js';
+import { getParagraphBookmarkId } from '../primitives/bookmarks.js';
+import { replaceParagraphTextRange } from '../primitives/text.js';
+import {
+  createRevisionContext,
+  createRevisionIdState,
+} from '../primitives/track-changes-emitter.js';
+import { buildSyntheticDocx } from './synthetic-docx-fixture.js';
+import { buildDocxFromBodyXml, paragraphWithText } from '../testing/ooxml-fixtures.js';
+
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({ feature: 'Pre-tracked Insertion Provenance (#358)' });
+
+const ORIGINAL_AUTHOR = 'Lean Bridge';
+const ORIGINAL_DATE = '2026-05-11T00:00:00Z';
+const BOOKMARK_ATTACHMENT_ID = 'pretracked-ins-provenance';
+
+async function getDocumentXml(document: Buffer): Promise<string> {
+  const archive = await DocxArchive.load(document);
+  return await archive.getDocumentXml();
+}
+
+function normalizeDocumentXmlText(documentXml: string): string {
+  return normalizeText(extractTextWithParagraphs(documentXml));
+}
+
+function createOriginalRevisionCtx() {
+  return createRevisionContext({
+    author: ORIGINAL_AUTHOR,
+    date: ORIGINAL_DATE,
+    idState: createRevisionIdState(),
+  });
+}
+
+function getParagraphIds(document: DocxDocument): string[] {
+  return document.getParagraphs().map((paragraph) => {
+    const paragraphId = getParagraphBookmarkId(paragraph);
+    if (!paragraphId) {
+      throw new Error('Paragraph bookmark missing after insertParagraphBookmarks');
+    }
+    return paragraphId;
+  });
+}
+
+/** Original with an inline run-level pre-tracked `w:ins` splice. */
+async function buildInlineInsOriginal(
+  paragraphs: string[],
+  paragraphIndex: number,
+  offset: number,
+  insertedText: string,
+): Promise<Buffer> {
+  const document = await DocxDocument.load(await buildSyntheticDocx({ paragraphs }));
+  document.insertParagraphBookmarks(BOOKMARK_ATTACHMENT_ID);
+  const ids = getParagraphIds(document);
+  const paragraph = document.getParagraphElementById(ids[paragraphIndex]!);
+  if (!paragraph) {
+    throw new Error(`Paragraph not found for tracked insertion: ${paragraphIndex}`);
+  }
+  replaceParagraphTextRange(paragraph, offset, offset, insertedText, createOriginalRevisionCtx());
+  const { buffer } = await document.toBuffer({ cleanBookmarks: true });
+  return buffer;
+}
+
+/** Original with a pre-tracked inserted paragraph (PPR-INS mark + w:ins runs). */
+async function buildParagraphInsertOriginal(
+  paragraphs: string[],
+  anchorIndex: number,
+  relativePosition: 'BEFORE' | 'AFTER',
+  newParagraphText: string,
+): Promise<Buffer> {
+  const document = await DocxDocument.load(await buildSyntheticDocx({ paragraphs }));
+  document.insertParagraphBookmarks(BOOKMARK_ATTACHMENT_ID);
+  const ids = getParagraphIds(document);
+  document.insertParagraph(
+    {
+      positionalAnchorNodeId: ids[anchorIndex]!,
+      relativePosition,
+      newText: newParagraphText,
+    },
+    createOriginalRevisionCtx(),
+  );
+  const { buffer } = await document.toBuffer({ cleanBookmarks: true });
+  return buffer;
+}
+
+interface ProvenanceCase {
+  name: string;
+  build: () => Promise<{ original: Buffer; revised: Buffer }>;
+}
+
+// The issue's repro matrix: every revised counterpart of the inline-ins
+// original used to violate the reject projection (matched, reverted,
+// identical-to-accept, unrelated), plus both paragraph-insert shapes and the
+// shrunk fast-check counterexample from #347's discovery run.
+const CASES: ProvenanceCase[] = [
+  {
+    name: 'inline-ins original vs revised extending the insertion',
+    build: async () => ({
+      original: await buildInlineInsOriginal(['Alpha'], 0, 'Alpha'.length, ' beta'),
+      revised: await buildSyntheticDocx({ paragraphs: ['Alpha beta tail'] }),
+    }),
+  },
+  {
+    name: 'inline-ins original vs revised equal to reject(original)',
+    build: async () => ({
+      original: await buildInlineInsOriginal(['Alpha'], 0, 'Alpha'.length, ' beta'),
+      revised: await buildSyntheticDocx({ paragraphs: ['Alpha'] }),
+    }),
+  },
+  {
+    name: 'inline-ins original vs revised equal to accept(original)',
+    build: async () => ({
+      original: await buildInlineInsOriginal(['Alpha'], 0, 'Alpha'.length, ' beta'),
+      revised: await buildSyntheticDocx({ paragraphs: ['Alpha beta'] }),
+    }),
+  },
+  {
+    name: 'inline-ins original vs unrelated revised',
+    build: async () => ({
+      original: await buildInlineInsOriginal(['Alpha'], 0, 'Alpha'.length, ' beta'),
+      revised: await buildSyntheticDocx({ paragraphs: ['Gamma delta'] }),
+    }),
+  },
+  {
+    name: 'shrunk #347 counterexample: !-ins original vs !-paragraph-insert revised',
+    build: async () => ({
+      original: await buildInlineInsOriginal(['!'], 0, 0, '!'),
+      revised: await buildParagraphInsertOriginal(['!'], 0, 'BEFORE', '!'),
+    }),
+  },
+  {
+    name: 'paragraph-insert original deleted by the comparison',
+    build: async () => ({
+      original: await buildParagraphInsertOriginal(['Alpha text.'], 0, 'AFTER', 'Added para.'),
+      revised: await buildSyntheticDocx({ paragraphs: ['Alpha text.'] }),
+    }),
+  },
+  {
+    name: 'paragraph-insert original appearing plain mid-document in the revised',
+    build: async () => ({
+      original: await buildParagraphInsertOriginal(
+        ['Alpha text.', 'Omega end.'],
+        0,
+        'AFTER',
+        'Added para.',
+      ),
+      revised: await buildSyntheticDocx({
+        paragraphs: ['Alpha text.', 'Added para.', 'Omega end.'],
+      }),
+    }),
+  },
+  {
+    name: 'inline-ins original with edits in both paragraphs of a two-paragraph document',
+    build: async () => ({
+      original: await buildInlineInsOriginal(['Alpha one', 'Second para'], 1, 'Second'.length, ' inserted'),
+      revised: await buildSyntheticDocx({ paragraphs: ['Alpha one more', 'Second altered para'] }),
+    }),
+  },
+  {
+    // Whole-paragraph deletion of a pre-tracked inserted HYPERLINK paragraph.
+    // The rebuild path routes hyperlink-bearing paragraphs through
+    // buildWholeParagraphRevisionContent, which needs its own provenance
+    // nesting (peer-review finding on the initial #358 fix): the w:del chunk
+    // nests inside the restored w:ins, both inside the hyperlink wrapper.
+    name: 'pre-tracked inserted hyperlink paragraph deleted by the comparison',
+    build: async () => ({
+      original: await buildDocxFromBodyXml(
+        paragraphWithText('Alpha') +
+          '<w:p>' +
+          `<w:pPr><w:rPr><w:ins w:id="90" w:author="${ORIGINAL_AUTHOR}" w:date="${ORIGINAL_DATE}"/></w:rPr></w:pPr>` +
+          '<w:hyperlink w:anchor="target">' +
+          `<w:ins w:id="91" w:author="${ORIGINAL_AUTHOR}" w:date="${ORIGINAL_DATE}">` +
+          '<w:r><w:t>LinkText</w:t></w:r>' +
+          '</w:ins>' +
+          '</w:hyperlink>' +
+          '</w:p>',
+      ),
+      revised: await buildDocxFromBodyXml(paragraphWithText('Alpha')),
+    }),
+  },
+];
+
+interface ProjectionReport {
+  modeUsed: ReconstructionMode | undefined;
+  fallbackReason: string | undefined;
+  combinedXml: string;
+  acceptCombined: string;
+  acceptRevised: string;
+  rejectCombined: string;
+  rejectOriginal: string;
+}
+
+async function runComparison(
+  original: Buffer,
+  revised: Buffer,
+  reconstructionMode: ReconstructionMode,
+): Promise<ProjectionReport> {
+  const result = await compareDocuments(original, revised, {
+    engine: 'atomizer',
+    reconstructionMode,
+  });
+  const [combinedXml, originalXml, revisedXml] = await Promise.all([
+    getDocumentXml(result.document),
+    getDocumentXml(original),
+    getDocumentXml(revised),
+  ]);
+  return {
+    modeUsed: result.reconstructionModeUsed,
+    fallbackReason: result.fallbackReason,
+    combinedXml,
+    acceptCombined: normalizeDocumentXmlText(acceptAllChanges(combinedXml)),
+    acceptRevised: normalizeDocumentXmlText(acceptAllChanges(revisedXml)),
+    rejectCombined: normalizeDocumentXmlText(rejectAllChanges(combinedXml)),
+    rejectOriginal: normalizeDocumentXmlText(rejectAllChanges(originalXml)),
+  };
+}
+
+describe('Original-side pre-tracked insertion provenance (issue #358)', () => {
+  test(
+    'inplace comparison stays inplace and satisfies both INV-RT-001 projections across the repro matrix',
+    async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
+      const reports: Record<string, unknown>[] = [];
+
+      await given('original documents carrying inline and paragraph-level pre-tracked insertions', async () => {});
+
+      await when('each pair runs through the live inplace-requested comparison', async () => {});
+
+      await then('no pair falls back and accept/reject both project to their inputs', async () => {
+        for (const provenanceCase of CASES) {
+          const { original, revised } = await provenanceCase.build();
+          const report = await runComparison(original, revised, 'inplace');
+          reports.push({
+            name: provenanceCase.name,
+            modeUsed: report.modeUsed,
+            fallbackReason: report.fallbackReason ?? null,
+          });
+
+          expect
+            .soft(report.modeUsed, `${provenanceCase.name}: reconstruction mode`)
+            .toBe('inplace');
+          expect(report.acceptCombined, `${provenanceCase.name}: accept projection`).toBe(
+            report.acceptRevised,
+          );
+          expect(report.rejectCombined, `${provenanceCase.name}: reject projection`).toBe(
+            report.rejectOriginal,
+          );
+        }
+        await attachPrettyJson('inplace-provenance-reports', reports);
+      });
+    },
+  );
+
+  test(
+    'rebuild comparison output satisfies both INV-RT-001 projections across the repro matrix',
+    async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
+      const reports: Record<string, unknown>[] = [];
+
+      await given('the same pre-tracked-insertion pairs as the inplace matrix', async () => {});
+
+      await when('each pair runs through the rebuild-requested comparison', async () => {});
+
+      await then('the rebuilt output projects to its inputs on accept and reject', async () => {
+        for (const provenanceCase of CASES) {
+          const { original, revised } = await provenanceCase.build();
+          const report = await runComparison(original, revised, 'rebuild');
+          reports.push({ name: provenanceCase.name, modeUsed: report.modeUsed });
+
+          expect(report.acceptCombined, `${provenanceCase.name}: accept projection`).toBe(
+            report.acceptRevised,
+          );
+          expect(report.rejectCombined, `${provenanceCase.name}: reject projection`).toBe(
+            report.rejectOriginal,
+          );
+        }
+        await attachPrettyJson('rebuild-provenance-reports', reports);
+      });
+    },
+  );
+
+  test(
+    'combined output preserves the original author on the restored w:ins and nests the comparison w:del inside it',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      let matchedXml = '';
+      let deletedXml = '';
+
+      await given('an inline-ins original compared against matched and reverted revised texts', async () => {
+        const original = await buildInlineInsOriginal(['Alpha'], 0, 'Alpha'.length, ' beta');
+        matchedXml = (
+          await runComparison(
+            original,
+            await buildSyntheticDocx({ paragraphs: ['Alpha beta'] }),
+            'inplace',
+          )
+        ).combinedXml;
+        deletedXml = (
+          await runComparison(
+            original,
+            await buildSyntheticDocx({ paragraphs: ['Alpha'] }),
+            'inplace',
+          )
+        ).combinedXml;
+      });
+
+      await when('the combined markup is inspected', async () => {});
+
+      await then('matched pre-tracked content keeps an original-author w:ins wrapper', async () => {
+        expect(matchedXml).toMatch(
+          new RegExp(`<w:ins[^>]*w:author="${ORIGINAL_AUTHOR}"[^>]*>(?:(?!</w:ins>).)*beta`),
+        );
+      });
+
+      await and(
+        'comparison-deleted pre-tracked content nests w:del(Comparison) inside w:ins(original-author)',
+        async () => {
+          expect(deletedXml).toMatch(
+            new RegExp(
+              `<w:ins[^>]*w:author="${ORIGINAL_AUTHOR}"[^>]*>` +
+                `(?:(?!</w:ins>).)*<w:del[^>]*w:author="Comparison"[^>]*>` +
+                `(?:(?!</w:del>).)*<w:delText[^>]*>[^<]*beta`,
+            ),
+          );
+        },
+      );
+    },
+  );
+});


### PR DESCRIPTION
Fixes #358

## Problem

When the **original** input carries an inline (run-level) pre-tracked `<w:ins>` — or a pre-tracked inserted paragraph whose runs sit inside `w:ins` — the comparison flattened that provenance: the inserted text entered the combined output as plain matched content or bare `w:delText`, with no surviving `w:ins` from the original lineage. Globally rejecting the combined output therefore kept text that `rejectAllChanges(original)` drops, violating the corrected INV-RT-001 projection law (#347) on **both** reconstruction paths: the inplace safety check caught it and fell back, but the rebuild output violated the law too and shipped with only #226's diagnostics. This was unconditional over the revised side — every probed variant failed.

## Root cause

The provenance linkage survived all the way to reconstruction but was never read. Deleted merged atoms *are* original-tree atoms carrying the input wrapper on `revTrackElement`; Equal/FormatChanged merged atoms are revised-tree atoms linked to their original counterpart via `comparisonUnitAtomBefore`. Both reconstruction paths wrapped purely on the post-LCS `correlationStatus`.

## Fix — the run-level analogue of the mark-based G4/G5 paragraph fixes

`getOriginalInsProvenance` resolves the original lineage's `w:ins` author/date for any merged atom, using `sourceDocument` to pick the correct link (`revTrackElement` for original-tree atoms; `comparisonUnitAtomBefore` for revised-tree atoms, including the whitespace duplicates `reorderChangeBlocks` synthesizes).

**Inplace** (primary ship path): a new `preSplitInsProvenanceRuns` pass splits revised runs at provenance boundaries; `handleEqual`/`handleFormatChanged` wrap the matched fragment in `w:ins(original-author)` (guarded against runs already inside a physical wrapper); `handleDeleted` nests the emitted `w:del(Comparison)` **inside** a restored `w:ins(original-author)`. Reject-all then removes the `w:ins` subtree exactly like `reject(original)`, and accept-all resolves the inner deletion and unwraps the emptied `w:ins` exactly like `accept(revised)`.

**Rebuild** (fallback, defense-in-depth for #226): `buildRunGroupXml` partitions Equal/Unknown/Deleted/FormatChanged groups into contiguous provenance spans with the same wrapping/nesting; the whole-paragraph-deleted branch of `buildParagraphXml` does the same per span — including its hyperlink route through `buildWholeParagraphRevisionContent` (a peer-review finding: the initial fix had gated hyperlink paragraphs out, and rebuild still flattened a deleted pre-tracked inserted hyperlink paragraph). Provenance-free documents keep byte-identical output.

## Gate flips

- `trackedOriginalScenarioArb` re-enables the inline `w:ins` **and** `paragraph-insert` original families (the #347 relaxation's exclusions).
- The two pinned `#358` characterization cases are retired — they now stay inplace and satisfy both projections. The formerly `#359`-labeled "paragraph-insert original appearing plain in the revised" case was original-side provenance (this bug class) and is fixed and retired with them.
- The characterization test now pins only the genuinely revised-side #359 collision cases; their shipped output holds the law (residual harm: lost provenance + unconditional rebuild fallback). `hasInsProvenanceCollision` stays as the #359 pair filter.
- New regression suite `pretracked-ins-provenance.test.ts`: the issue's full repro matrix (incl. the shrunk #347 fast-check counterexample and the hyperlink shape) through both modes, plus nested-markup shape assertions (`<w:ins original-author>` wrapping / `<w:del Comparison>` nesting). The hyperlink case was verified red against the pre-fix reconstructor.

## Out of scope (documented in code)

- Revised-side provenance collisions (#359) — still pinned + generator-excluded.
- Moved pre-tracked insertions (`MovedSource`/`MovedDestination` handlers don't thread provenance).
- Pre-tracked inserted complete fields (collapsed-field deletions stay unnested).

## Verification

- `lean-spec-bridge` property suite green with the re-enabled generator scope, 3× stress runs (100 fast-check runs each).
- Full `docx-core` suite: 1584 passed / 2 expected-fail / 11 skipped.
- Pre-submit chain green: `build`, `lint:workspaces`, `test:run`, `check:spec-coverage`, `check:conformance-citations`, `check:conformance-doc`; coverage ratchet: docx-core lines +2.27% vs baseline.
- Peer-reviewed (Codex + agy, both dynamic): Codex found the hyperlink rebuild gap (fixed above, with a red→green regression case); agy verified the seven flagged uncertainty areas (sourceDocument discriminator, physical-wrapper guard, anchor tracking after nesting, per-span paragraph-deleted emission, byte-identity for provenance-free inputs, provenance-key separator, #359 comment accuracy) and returned MERGE-READY.
