### PR TITLE
test(docx-core): bump docx-platform-tests pin to cover paragraph-mark merge scenarios

### DIFF
--- a/packages/docx-core/src/integration/docx-platform-tests.pin.json
+++ b/packages/docx-core/src/integration/docx-platform-tests.pin.json
@@ -1,4 +1,4 @@
 {
   "repository": "open-agreements/docx-platform-tests",
-  "pinnedCommitSha": "bbf891847fdad142737346eabfb530694e530187"
+  "pinnedCommitSha": "d648ac493ef49350fc59a8bc4a8894e813144aa2"
 }


### PR DESCRIPTION
## What

Bump the cross-implementation conformance pin `packages/docx-core/src/integration/docx-platform-tests.pin.json` from `bbf8918` → `d648ac4` (open-agreements/docx-platform-tests `origin/main` HEAD).

## Why

The old pin (`bbf8918`, "Register safe-docx and python-docx adapters; first results matrix") **predated** the two paragraph-mark revision scenarios authored in suite #26 (`db59331`):

- `acceptDeletedParagraphMarkMergesParagraphs` — ECMA-376 §17.13.5.15
- `rejectInsertedParagraphMarkMergesParagraphs` — ECMA-376 §17.13.5.20

So safe-docx's `cross-implementation-suite.test.ts` self-check never exercised them. The engine fix that makes these pass landed in #464 (merge paragraph-mark revisions into the following paragraph). Current `main` resolves both correctly; this bump locks the two clauses into safe-docx's declared conformance baseline and guards against regression.

## Verification

Full suite run against the checkout at the new pin (`d648ac4`), from `packages/docx-core`:

```
DOCX_PLATFORM_TESTS_DIR=/…/docx-platform-tests npx vitest run src/integration/cross-implementation-suite.test.ts
```

- ✅ 5/5 tests pass, including **"safe-docx adapter passes every docx-platform-tests scenario"** (all 12 scenarios, not just the two paragraph-mark ones).
- ✅ No pin-mismatch warning (checkout SHA == new pin SHA).
- ✅ `check:conformance-citations` OK.
- ✅ `git ls-remote origin refs/heads/main` on the suite resolves to `d648ac4` (real, pushed commit).

Peer-reviewed with Codex (dynamic, executed the suite): no blocking issues; assumption "adapter passes the *full* suite at the new pin" independently verified.

Ref: #431
Ref: #481
Ref: #464

https://claude.ai/code/session_018i7v4JR1B9zndafw3yftxn