### PR TITLE
feat(docx-mcp): forbid untracked AI mutations (surface classification + non-revision manifest) [#122]

### DIFF
--- a/openspec/changes/forbid-untracked-ai-mutations/proposal.md
+++ b/openspec/changes/forbid-untracked-ai-mutations/proposal.md
@@ -1,0 +1,37 @@
+# Change: Forbid untracked AI mutations within the supported surface
+
+## Why
+
+The Anthropic differentiator (#118) is that AI-authored edits in the *supported
+revisionable surface* (#119) cannot be untracked. Today every write tool routes
+through the write-time tracked-change emitter (#120) and validator (#121), but
+the contract is implicit: nothing classifies each tool as revisionable versus
+package-mutation, and package-level mutations that have no native OOXML revision
+wrapper (comment/footnote side parts, relationships, content types) land
+silently. Removing whole-document comparison from the default finalization path
+(#126) depends on those untracked mutations being *accounted for* rather than
+caught after the fact by a diff.
+
+## What Changes
+
+- Classify every MCP tool's write surface as `revisionable`, `package-mutation`,
+  or `internal`, mirroring the ratified inventory in `packages/docx-core/SUPPORT.md`.
+  The classification is advertised in each tool's description and in the exported
+  tool metadata (`surface`, `emitsNonRevisionChanges`).
+- Add a session **non-revision change manifest**: dual-surface tools
+  (`add_comment`, `delete_comment`, `add_footnote`) record the package parts they
+  mutate without a tracked-change wrapper, and the `save` report surfaces the
+  manifest alongside the revisions list.
+- Add a revisionable-surface property test asserting that every fresh-emission
+  edit tool produces at least one valid AI-authored tracked-change element
+  (validity delegated to the #121 validator) and that AI-inserted body text is
+  never left as untracked content.
+
+## Impact
+
+- Affected specs: `mcp-server`
+- Affected code: `packages/docx-mcp/src/tool_catalog.ts`,
+  `packages/docx-mcp/src/session/manager.ts`,
+  `packages/docx-mcp/src/tools/{add_comment,delete_comment,add_footnote,save}.ts`,
+  `packages/docx-core/SUPPORT.md`
+- Unblocks: #126 (remove comparison from the default finalization path)

--- a/openspec/changes/forbid-untracked-ai-mutations/specs/mcp-server/spec.md
+++ b/openspec/changes/forbid-untracked-ai-mutations/specs/mcp-server/spec.md
@@ -1,0 +1,59 @@
+## ADDED Requirements
+
+### Requirement: Contract Surface Classification
+
+Every MCP tool SHALL declare a contract-surface classification of its writes:
+`revisionable` (AI-attributed writes emit native OOXML tracked-change markup),
+`package-mutation` (writes mutate package-level parts with no native revision
+wrapper), or `internal` (read-only utilities, tracked-change consumers, and
+derived-output tools). The classification SHALL be advertised in the tool's
+description and in the exported tool metadata, and SHALL mirror the ratified
+inventory in `packages/docx-core/SUPPORT.md`.
+
+A tool MAY be `revisionable` and also mutate package parts; such tools SHALL set
+`emitsNonRevisionChanges` and record manifest entries for the untracked portion.
+
+#### Scenario: every tool declares a contract surface
+- **GIVEN** the MCP tool catalog is loaded
+- **WHEN** each tool is inspected
+- **THEN** every tool SHALL declare a surface of `revisionable`, `package-mutation`, or `internal`
+- **AND** the dual-surface tools that also record non-revision changes SHALL be exactly `add_comment`, `delete_comment`, and `add_footnote`
+
+#### Scenario: revisionable edit tools emit valid AI tracked changes
+- **GIVEN** an AI-authored session over a document
+- **WHEN** a fresh-emission revisionable edit tool performs a write
+- **THEN** the write SHALL succeed
+- **AND** the resulting document SHALL contain at least one AI-authored tracked-change element
+- **AND** AI revision validation SHALL report no errors
+
+#### Scenario: revisionable edits produce no untracked AI body content
+- **GIVEN** an AI-authored session over a single paragraph
+- **WHEN** `replace_text` rewrites text under the AI actor
+- **THEN** the inserted text SHALL appear only inside a `w:ins` tracked-change wrapper
+- **AND** no AI-introduced text SHALL remain as a bare untracked run in the body
+
+### Requirement: Non-Revision Change Manifest
+
+The MCP server SHALL maintain a per-session manifest of package-level
+(non-revision) mutations — writes whose effect is not, and cannot be, captured by
+OOXML tracked-change markup. Dual-surface tools SHALL record an entry naming the
+package parts they mutated, and the `save` report SHALL surface the manifest as
+`non_revision_changes` so those mutations are accounted for rather than landing
+silently.
+
+#### Scenario: comment side-part writes are recorded in the save manifest
+- **GIVEN** an AI-authored session in which a comment has been added
+- **WHEN** the document is saved
+- **THEN** the save report SHALL include a non-revision change entry for `add_comment`
+- **AND** the entry SHALL name `word/comments.xml` among the mutated parts
+
+#### Scenario: footnote part creation is recorded in the save manifest
+- **GIVEN** an AI-authored session in which a footnote has been added
+- **WHEN** the document is saved
+- **THEN** the save report SHALL include a non-revision change entry for `add_footnote`
+- **AND** the entry SHALL name `word/footnotes.xml` among the mutated parts
+
+#### Scenario: tracked-only edits report no non-revision changes
+- **GIVEN** an AI-authored session in which only a body text edit was performed
+- **WHEN** the document is saved
+- **THEN** the save report SHALL NOT include a non-revision change manifest

--- a/openspec/changes/forbid-untracked-ai-mutations/specs/mcp-server/spec.md
+++ b/openspec/changes/forbid-untracked-ai-mutations/specs/mcp-server/spec.md
@@ -57,3 +57,14 @@ silently.
 - **GIVEN** an AI-authored session in which only a body text edit was performed
 - **WHEN** the document is saved
 - **THEN** the save report SHALL NOT include a non-revision change manifest
+
+#### Scenario: comment reply mode is package-only with no tracked element
+- **GIVEN** an AI-authored session containing a root comment
+- **WHEN** a threaded reply is added
+- **THEN** the reply SHALL NOT emit any new tracked-change element
+- **AND** the reply SHALL record a non-revision change entry naming comment side parts only, never `word/document.xml`
+
+#### Scenario: comment reply deletion is package-only
+- **GIVEN** an AI-authored session containing a root comment and a threaded reply
+- **WHEN** the reply is deleted
+- **THEN** the deletion SHALL record a non-revision change entry naming comment side parts only, never `word/document.xml`

--- a/openspec/changes/forbid-untracked-ai-mutations/tasks.md
+++ b/openspec/changes/forbid-untracked-ai-mutations/tasks.md
@@ -1,0 +1,19 @@
+# Tasks
+
+## 1. Surface classification
+- [x] 1.1 Add a `surface` (`revisionable` | `package-mutation` | `internal`) field to every tool-catalog entry.
+- [x] 1.2 Flag dual-surface tools with `emitsNonRevisionChanges`.
+- [x] 1.3 Reflect the classification in each write tool's description and in the exported tool metadata + `TOOL_SURFACE_INDEX`.
+
+## 2. Non-revision change manifest
+- [x] 2.1 Add `nonRevisionManifest` to `DocxSession` and a `recordNonRevisionChange` manager method.
+- [x] 2.2 Record manifest entries in `add_comment`, `delete_comment`, and `add_footnote`.
+- [x] 2.3 Surface the manifest as `non_revision_changes` in the `save` report.
+
+## 3. Tests
+- [x] 3.1 Property test: every fresh-emission revisionable editor produces a valid AI tracked change.
+- [x] 3.2 Assert AI-inserted body text is never untracked.
+- [x] 3.3 Manifest scenarios for comment and footnote side parts, and the tracked-only empty-manifest case.
+
+## 4. Docs
+- [x] 4.1 Update `packages/docx-core/SUPPORT.md` to describe the implemented manifest shape.

--- a/packages/docx-core/SUPPORT.md
+++ b/packages/docx-core/SUPPORT.md
@@ -50,6 +50,20 @@ Use the alternate contract below whenever a primitive/tool mutates relationships
 
 No current file under `packages/docx-core/src/primitives/*.ts` or `packages/docx-mcp/src/tools/*.ts` directly exposes theme replacement, header/footer part creation, image-part insertion, or `core.xml` / `app.xml` metadata editing. If those surfaces are added later, they belong in Table B unless OOXML supplies a first-class revision wrapper for that exact mutation.
 
+### Non-revision change manifest (implemented in [#122](https://github.com/UseJunior/safe-docx/issues/122))
+
+Table B mutations are recorded in a per-session **non-revision change manifest**
+(`DocxSession.nonRevisionManifest`, populated via `SessionManager.recordNonRevisionChange`).
+Each entry is `{ tool, editRevision, parts, description }`, where `parts` names the
+package parts mutated without a tracked-change wrapper. The `save` report surfaces
+the manifest as `non_revision_changes` (omitted when empty), so package-level
+mutations are accounted for alongside the tracked revisions list rather than
+landing silently. The dual-surface tools that record entries are `add_comment`,
+`delete_comment`, and `add_footnote`; the write surface of every tool is
+classified programmatically in `packages/docx-mcp/src/tool_catalog.ts`
+(`surface`: `revisionable` | `package-mutation` | `internal`, plus
+`emitsNonRevisionChanges`).
+
 ## Internal / non-contract utilities
 
 These files are intentionally outside the revisionable-surface contract. Some perform XML mutations (e.g., bookmark scaffolding, run normalization, style elevation) but those mutations are internal/non-AI-attributable rather than user-directed edits. Others consume or normalize existing tracked changes instead of creating them. Either way, none are part of the promised AI-authored revision contract.

--- a/packages/docx-mcp/docs/tool-reference.generated.md
+++ b/packages/docx-mcp/docs/tool-reference.generated.md
@@ -63,7 +63,7 @@ Search paragraphs with regex. Use file_path for session-based search, file_paths
 
 ## `batch_edit`
 
-Single-agent front door for applying multiple edit steps (replace_text, insert_paragraph) to a document in one call. Validates all steps first, rejects conflicts before applying anything, then executes valid steps sequentially. Accepts inline steps or a plan_file_path JSON array.
+Single-agent front door for applying multiple edit steps (replace_text, insert_paragraph) to a document in one call. Validates all steps first, rejects conflicts before applying anything, then executes valid steps sequentially. Accepts inline steps or a plan_file_path JSON array. Surface: revisionable — every applied step emits native OOXML tracked changes.
 
 - readOnly: `false`
 - destructive: `true`
@@ -76,7 +76,7 @@ Single-agent front door for applying multiple edit steps (replace_text, insert_p
 
 ## `replace_text`
 
-Replace text in a paragraph by provider paragraph id, preserving formatting where supported. Supports DOCX, ODT, and Google Docs.
+Replace text in a paragraph by provider paragraph id, preserving formatting where supported. Supports DOCX, ODT, and Google Docs. Surface: revisionable — DOCX edits emit native OOXML tracked changes (w:ins/w:del/w:rPrChange).
 
 - readOnly: `false`
 - destructive: `true`
@@ -93,7 +93,7 @@ Replace text in a paragraph by provider paragraph id, preserving formatting wher
 
 ## `insert_paragraph`
 
-Insert a paragraph before/after an anchor paragraph by paragraph id. Supports DOCX, ODT, and Google Docs. (ODT paragraph ids are positional and shift after insertion — re-read before further edits.)
+Insert a paragraph before/after an anchor paragraph by paragraph id. Supports DOCX, ODT, and Google Docs. (ODT paragraph ids are positional and shift after insertion — re-read before further edits.) Surface: revisionable — DOCX insertions emit native OOXML tracked changes.
 
 - readOnly: `false`
 - destructive: `true`
@@ -110,7 +110,7 @@ Insert a paragraph before/after an anchor paragraph by paragraph id. Supports DO
 
 ## `save`
 
-Save document. For DOCX: saves clean and/or tracked changes output. For ODT: saves an .odt package. For Google Docs: checkpoint (default) returns revisionId, or snapshot exports as DOCX.
+Save document. For DOCX: saves clean and/or tracked changes output. For ODT: saves an .odt package. For Google Docs: checkpoint (default) returns revisionId, or snapshot exports as DOCX. Surface: revisionable — the save report lists both the AI revisions applied and a non-revision change manifest of any package-level mutations (comment/footnote side parts, relationships) that have no tracked-change wrapper.
 
 - readOnly: `false`
 - destructive: `true`
@@ -158,7 +158,7 @@ Convert a DOCX document to OpenDocument Text (.odt) using the native model-to-mo
 
 ## `format_layout`
 
-Apply layout controls (paragraph spacing, table row height, cell padding). Google Docs supports paragraph spacing only.
+Apply layout controls (paragraph spacing, table row height, cell padding). Google Docs supports paragraph spacing only. Surface: revisionable — DOCX geometry edits emit native property-change revisions (w:pPrChange/w:trPrChange/w:tcPrChange).
 
 - readOnly: `false`
 - destructive: `true`
@@ -222,7 +222,7 @@ Close an open file session, or close all sessions with explicit confirmation. Su
 
 ## `add_comment`
 
-Add a comment or threaded reply to a document. Provide target_paragraph_id + anchor_text for root comments, or parent_comment_id for replies. Supports DOCX and ODT (ODT backs comments with office:annotation; threaded replies are DOCX-only).
+Add a comment or threaded reply to a document. Provide target_paragraph_id + anchor_text for root comments, or parent_comment_id for replies. Supports DOCX and ODT (ODT backs comments with office:annotation; threaded replies are DOCX-only). Surface: revisionable + package-mutation — the body-story comment reference is tracked (w:ins), while comment text and author metadata are recorded in the save report non-revision change manifest.
 
 - readOnly: `false`
 - destructive: `true`
@@ -250,7 +250,7 @@ Get all comments from the document with IDs, authors, dates, text, and anchored 
 
 ## `delete_comment`
 
-Delete a comment and all its threaded replies from the document. Cascade-deletes all descendants.
+Delete a comment and all its threaded replies from the document. Cascade-deletes all descendants. Surface: revisionable + package-mutation — the body-story comment reference removal is tracked (w:del), while comment/reply text cleanup is recorded in the save report non-revision change manifest.
 
 - readOnly: `false`
 - destructive: `true`
@@ -289,7 +289,7 @@ Get all footnotes from the document with IDs, display numbers, text, and anchore
 
 ## `add_footnote`
 
-Add a footnote anchored to a paragraph. Optionally position the reference after specific text using after_text. Note: [^N] markers in read_file output are display-only and not part of the editable text used by replace_text.
+Add a footnote anchored to a paragraph. Optionally position the reference after specific text using after_text. Note: [^N] markers in read_file output are display-only and not part of the editable text used by replace_text. Surface: revisionable + package-mutation — the footnote reference and note text are tracked (w:ins), while footnote-part creation and registration are recorded in the save report non-revision change manifest.
 
 - readOnly: `false`
 - destructive: `true`
@@ -303,7 +303,7 @@ Add a footnote anchored to a paragraph. Optionally position the reference after 
 
 ## `update_footnote`
 
-Update the text content of an existing footnote.
+Update the text content of an existing footnote. Surface: revisionable — note-text changes emit native OOXML tracked changes (w:ins/w:del) inside the footnote body.
 
 - readOnly: `false`
 - destructive: `true`
@@ -316,7 +316,7 @@ Update the text content of an existing footnote.
 
 ## `delete_footnote`
 
-Delete a footnote and its reference from the document.
+Delete a footnote and its reference from the document. Surface: revisionable — the reference and note text are removed as native OOXML tracked deletions (w:del).
 
 - readOnly: `false`
 - destructive: `true`
@@ -328,7 +328,7 @@ Delete a footnote and its reference from the document.
 
 ## `clear_formatting`
 
-Clear specific run-level formatting (bold, italic, underline, highlight, color, font) from paragraphs.
+Clear specific run-level formatting (bold, italic, underline, highlight, color, font) from paragraphs. Surface: revisionable — clearing emits a native run-property-change revision (w:rPrChange).
 
 - readOnly: `false`
 - destructive: `true`

--- a/packages/docx-mcp/src/session/manager.ts
+++ b/packages/docx-mcp/src/session/manager.ts
@@ -60,6 +60,30 @@ export type ExtractionCacheEntry = {
   changes: ParagraphRevision[];
 };
 
+/**
+ * A package-level (non-revision) mutation recorded during a session.
+ *
+ * Per #122, AI-attributed writes in the *revisionable* surface must land as
+ * native OOXML tracked-change markup. Writes in the *package-mutation* surface
+ * (side-story parts, relationships, content types — things OOXML has no native
+ * revision wrapper for) cannot be tracked, so instead of being emitted silently
+ * they are recorded here and surfaced in the save report. This keeps the
+ * "every AI mutation is accounted for" invariant honest even where the mutation
+ * is not, and cannot be, a tracked change.
+ *
+ * @see packages/docx-core/SUPPORT.md (Table B) for the ratified classification.
+ */
+export type NonRevisionChange = {
+  /** MCP tool that produced the change (e.g. `add_comment`). */
+  tool: string;
+  /** Session edit revision at which the change was recorded. */
+  editRevision: number;
+  /** Package parts mutated without tracked-change markup. */
+  parts: string[];
+  /** Human-readable summary of what was mutated and why it is untracked. */
+  description: string;
+};
+
 export type DocxSession = {
   provider: 'docx';
   sessionId: string;
@@ -86,6 +110,12 @@ export type DocxSession = {
   editRevision: number;
   saveCache: Map<string, SaveCacheEntry>;
   extractionCache: ExtractionCacheEntry | null;
+  /**
+   * Non-revision (package-mutation) changes recorded this session, in order.
+   * Surfaced in the save report so package-level mutations that have no native
+   * OOXML revision wrapper are still accounted for (#122).
+   */
+  nonRevisionManifest: NonRevisionChange[];
   createdAt: Date;
   lastAccessedAt: Date;
   expiresAt: Date;
@@ -335,6 +365,7 @@ export class SessionManager {
       editRevision: 0,
       saveCache: new Map<string, SaveCacheEntry>(),
       extractionCache: null,
+      nonRevisionManifest: [],
       createdAt: now,
       lastAccessedAt: now,
       expiresAt,
@@ -523,6 +554,19 @@ export class SessionManager {
       session.saveCache.clear();
       session.extractionCache = null;
     }
+  }
+
+  /**
+   * Record a package-level (non-revision) mutation for later surfacing in the
+   * save report (#122). Call this after a successful mutation whose effect is
+   * not, and cannot be, captured by OOXML tracked-change markup — e.g. creating
+   * `word/comments.xml`, rewriting relationships, or editing side-story parts.
+   */
+  recordNonRevisionChange(
+    session: DocxSession,
+    change: Omit<NonRevisionChange, 'editRevision'>,
+  ): void {
+    session.nonRevisionManifest.push({ ...change, editRevision: session.editRevision });
   }
 
   getSaveCache(session: DocxSession, cacheKey: string): SaveCacheEntry | null {

--- a/packages/docx-mcp/src/tool_catalog.ts
+++ b/packages/docx-mcp/src/tool_catalog.ts
@@ -5,11 +5,37 @@ type ToolAnnotations = {
   destructiveHint: boolean;
 };
 
+/**
+ * Contract-surface classification for a tool's writes (#118 / #122).
+ *
+ * - `revisionable` — AI-attributed writes land as native OOXML tracked-change
+ *   markup (Table A of SUPPORT.md). Enforced by the write-time emitter (#120)
+ *   and validator (#121); exercised by the revisionable-surface property test.
+ * - `package-mutation` — writes mutate package-level parts with no native
+ *   revision wrapper (Table B). Recorded in the session non-revision change
+ *   manifest and surfaced in the save report rather than tracked.
+ * - `internal` — outside the AI-authoring contract: read-only utilities,
+ *   tracked-change consumers (accept_changes), and derived-output tools
+ *   (export, convert_to_odt). Matches SUPPORT.md's "Internal / non-contract".
+ *
+ * A tool may be primarily `revisionable` yet also touch package parts; those
+ * set `emitsNonRevisionChanges` and record manifest entries for the untracked
+ * portion (e.g. add_comment tracks the body reference but writes comment text
+ * to comments.xml).
+ *
+ * @see packages/docx-core/SUPPORT.md for the ratified per-tool inventory (#119).
+ */
+type ToolSurface = 'revisionable' | 'package-mutation' | 'internal';
+
 type ToolCatalogEntry = {
   name: string;
   description: string;
   input: z.ZodTypeAny;
   annotations: ToolAnnotations;
+  /** Contract-surface classification of this tool's writes (#122). */
+  surface: ToolSurface;
+  /** True when a revisionable tool also records non-revision manifest entries. */
+  emitsNonRevisionChanges?: boolean;
 };
 
 const FILE_FIELD = {
@@ -36,6 +62,7 @@ const GOOGLE_DOC_ID_FIELD = {
 export const SAFE_DOCX_TOOL_CATALOG = [
   {
     name: 'read_file',
+    surface: 'internal',
     description: 'Read document content (DOCX, ODT, or Google Doc). Output is token-limited (~14k tokens) by default with pagination metadata (has_more, next_offset). Use offset/limit to paginate.',
     input: z.object({
       ...FILE_FIELD_OPTIONAL,
@@ -79,6 +106,7 @@ export const SAFE_DOCX_TOOL_CATALOG = [
   },
   {
     name: 'get_document_outline',
+    surface: 'internal',
     description:
       'Get a compact structural map of a document\'s headings (DOCX only). Returns one entry per heading paragraph with its text, outline level, source, and stable `_bk_*` paragraph_id — so an agent can read the cheap outline first, then scope a targeted read_file/replace_text to the right section instead of scanning the whole body. Style-based (Word HeadingN) headings only by default; set include_heuristic_headings=true to also include heuristic titles/run-in headers. Read-only.',
     input: z.object({
@@ -96,6 +124,7 @@ export const SAFE_DOCX_TOOL_CATALOG = [
   },
   {
     name: 'grep',
+    surface: 'internal',
     description: 'Search paragraphs with regex. Use file_path for session-based search, file_paths for stateless multi-file search, or google_doc_id for Google Docs. ODT supported via file_path (single-file) only.',
     input: z.object({
       ...FILE_FIELD_OPTIONAL,
@@ -115,8 +144,9 @@ export const SAFE_DOCX_TOOL_CATALOG = [
   },
   {
     name: 'batch_edit',
+    surface: 'revisionable',
     description:
-      'Single-agent front door for applying multiple edit steps (replace_text, insert_paragraph) to a document in one call. Validates all steps first, rejects conflicts before applying anything, then executes valid steps sequentially. Accepts inline steps or a plan_file_path JSON array.',
+      'Single-agent front door for applying multiple edit steps (replace_text, insert_paragraph) to a document in one call. Validates all steps first, rejects conflicts before applying anything, then executes valid steps sequentially. Accepts inline steps or a plan_file_path JSON array. Surface: revisionable — every applied step emits native OOXML tracked changes.',
     input: z.object({
       ...FILE_FIELD,
       steps: z
@@ -132,7 +162,8 @@ export const SAFE_DOCX_TOOL_CATALOG = [
   },
   {
     name: 'replace_text',
-    description: 'Replace text in a paragraph by provider paragraph id, preserving formatting where supported. Supports DOCX, ODT, and Google Docs.',
+    surface: 'revisionable',
+    description: 'Replace text in a paragraph by provider paragraph id, preserving formatting where supported. Supports DOCX, ODT, and Google Docs. Surface: revisionable — DOCX edits emit native OOXML tracked changes (w:ins/w:del/w:rPrChange).',
     input: z.object({
       ...FILE_FIELD_OPTIONAL,
       ...GOOGLE_DOC_ID_FIELD,
@@ -149,7 +180,8 @@ export const SAFE_DOCX_TOOL_CATALOG = [
   },
   {
     name: 'insert_paragraph',
-    description: 'Insert a paragraph before/after an anchor paragraph by paragraph id. Supports DOCX, ODT, and Google Docs. (ODT paragraph ids are positional and shift after insertion — re-read before further edits.)',
+    surface: 'revisionable',
+    description: 'Insert a paragraph before/after an anchor paragraph by paragraph id. Supports DOCX, ODT, and Google Docs. (ODT paragraph ids are positional and shift after insertion — re-read before further edits.) Surface: revisionable — DOCX insertions emit native OOXML tracked changes.',
     input: z.object({
       ...FILE_FIELD_OPTIONAL,
       ...GOOGLE_DOC_ID_FIELD,
@@ -168,8 +200,9 @@ export const SAFE_DOCX_TOOL_CATALOG = [
   },
   {
     name: 'save',
+    surface: 'revisionable',
     description:
-      'Save document. For DOCX: saves clean and/or tracked changes output. For ODT: saves an .odt package. For Google Docs: checkpoint (default) returns revisionId, or snapshot exports as DOCX.',
+      'Save document. For DOCX: saves clean and/or tracked changes output. For ODT: saves an .odt package. For Google Docs: checkpoint (default) returns revisionId, or snapshot exports as DOCX. Surface: revisionable — the save report lists both the AI revisions applied and a non-revision change manifest of any package-level mutations (comment/footnote side parts, relationships) that have no tracked-change wrapper.',
     input: z.object({
       ...FILE_FIELD_OPTIONAL,
       ...GOOGLE_DOC_ID_FIELD,
@@ -191,6 +224,7 @@ export const SAFE_DOCX_TOOL_CATALOG = [
   },
   {
     name: 'export',
+    surface: 'internal',
     description:
       'Export a document to a portable rendering (Markdown, semantic HTML, or plain text). Writes an output file (default: source path with the format extension, e.g. .md, .html, or .txt) and returns its path, byte count, and the rendered content (under `content`). Intentionally lossy (no round-trip); HTML is the semantic tier, not pixel-faithful. DOCX only — Google Docs is not supported.',
     input: z.object({
@@ -216,6 +250,7 @@ export const SAFE_DOCX_TOOL_CATALOG = [
   },
   {
     name: 'convert_to_odt',
+    surface: 'internal',
     description:
       'Convert a DOCX document to OpenDocument Text (.odt) using the native model-to-model converter (no LibreOffice involved). Writes the .odt (default: source path with the .odt extension), validates ODF packaging safety before writing, and returns the output path plus a `lossiness` summary itemizing every downgraded construct. Conversion is semantic and intentionally lossy: text, headings, bold/italic/underline, hyperlinks, lists, and tables are mapped; richer styling, tracked changes, comments, and headers/footers are not. DOCX in, ODT out — Google Docs and .odt inputs are not supported.',
     input: z.object({
@@ -233,7 +268,8 @@ export const SAFE_DOCX_TOOL_CATALOG = [
   },
   {
     name: 'format_layout',
-    description: 'Apply layout controls (paragraph spacing, table row height, cell padding). Google Docs supports paragraph spacing only.',
+    surface: 'revisionable',
+    description: 'Apply layout controls (paragraph spacing, table row height, cell padding). Google Docs supports paragraph spacing only. Surface: revisionable — DOCX geometry edits emit native property-change revisions (w:pPrChange/w:trPrChange/w:tcPrChange).',
     input: z.object({
       ...FILE_FIELD_OPTIONAL,
       ...GOOGLE_DOC_ID_FIELD,
@@ -271,6 +307,7 @@ export const SAFE_DOCX_TOOL_CATALOG = [
   },
   {
     name: 'accept_changes',
+    surface: 'internal',
     description: 'Accept all tracked changes in the document body, producing a clean document with no revision markup. Returns acceptance stats.',
     input: z.object({
       ...FILE_FIELD,
@@ -279,6 +316,7 @@ export const SAFE_DOCX_TOOL_CATALOG = [
   },
   {
     name: 'has_tracked_changes',
+    surface: 'internal',
     description: 'Check whether the document body contains tracked-change markers (insertions, deletions, moves, and property-change records). Read-only.',
     input: z.object({
       ...FILE_FIELD,
@@ -287,6 +325,7 @@ export const SAFE_DOCX_TOOL_CATALOG = [
   },
   {
     name: 'get_file_status',
+    surface: 'internal',
     description: 'Get file/session metadata including edit count, normalization stats, and cache info. Supports DOCX, ODT, and Google Docs.',
     input: z.object({
       ...FILE_FIELD_OPTIONAL,
@@ -296,6 +335,7 @@ export const SAFE_DOCX_TOOL_CATALOG = [
   },
   {
     name: 'close_file',
+    surface: 'internal',
     description: 'Close an open file session, or close all sessions with explicit confirmation. Supports DOCX, ODT, and Google Docs.',
     input: z.object({
       ...FILE_FIELD_OPTIONAL,
@@ -307,8 +347,10 @@ export const SAFE_DOCX_TOOL_CATALOG = [
   },
   {
     name: 'add_comment',
+    surface: 'revisionable',
+    emitsNonRevisionChanges: true,
     description:
-      'Add a comment or threaded reply to a document. Provide target_paragraph_id + anchor_text for root comments, or parent_comment_id for replies. Supports DOCX and ODT (ODT backs comments with office:annotation; threaded replies are DOCX-only).',
+      'Add a comment or threaded reply to a document. Provide target_paragraph_id + anchor_text for root comments, or parent_comment_id for replies. Supports DOCX and ODT (ODT backs comments with office:annotation; threaded replies are DOCX-only). Surface: revisionable + package-mutation — the body-story comment reference is tracked (w:ins), while comment text and author metadata are recorded in the save report non-revision change manifest.',
     input: z.object({
       ...FILE_FIELD,
       target_paragraph_id: z.string().optional().describe('Paragraph ID to anchor the comment to (for root comments).'),
@@ -322,6 +364,7 @@ export const SAFE_DOCX_TOOL_CATALOG = [
   },
   {
     name: 'get_comments',
+    surface: 'internal',
     description:
       'Get all comments from the document with IDs, authors, dates, text, and anchored paragraph IDs. Range-anchored DOCX comments also expose optional end_paragraph_id, start_run_index, start_char_offset, end_run_index, and end_char_offset fields describing the covered span. Includes threaded replies (DOCX). Supports DOCX and ODT. Read-only.',
     input: z.object({
@@ -331,8 +374,10 @@ export const SAFE_DOCX_TOOL_CATALOG = [
   },
   {
     name: 'delete_comment',
+    surface: 'revisionable',
+    emitsNonRevisionChanges: true,
     description:
-      'Delete a comment and all its threaded replies from the document. Cascade-deletes all descendants.',
+      'Delete a comment and all its threaded replies from the document. Cascade-deletes all descendants. Surface: revisionable + package-mutation — the body-story comment reference removal is tracked (w:del), while comment/reply text cleanup is recorded in the save report non-revision change manifest.',
     input: z.object({
       ...FILE_FIELD,
       comment_id: z.number().describe('Comment ID to delete.'),
@@ -341,6 +386,7 @@ export const SAFE_DOCX_TOOL_CATALOG = [
   },
   {
     name: 'compare_documents',
+    surface: 'revisionable',
     description:
       'Compare two documents and produce a tracked-changes output document. Provide original_file_path + revised_file_path for standalone comparison, or file_path to compare session edits against the original. DOCX and ODF (.odt) support both modes. DOCX stats count insertions/deletions as contiguous ranges, expose atom totals as insertedAtoms/deletedAtoms, and report formatChanges separately from modifiedParagraphs. ODF compares at inline granularity (a modified paragraph is marked up in place — only the changed spans are struck or inserted).',
     input: z.object({
@@ -355,6 +401,7 @@ export const SAFE_DOCX_TOOL_CATALOG = [
   },
   {
     name: 'get_footnotes',
+    surface: 'internal',
     description: 'Get all footnotes from the document with IDs, display numbers, text, and anchored paragraph IDs. Read-only.',
     input: z.object({
       ...FILE_FIELD,
@@ -363,8 +410,10 @@ export const SAFE_DOCX_TOOL_CATALOG = [
   },
   {
     name: 'add_footnote',
+    surface: 'revisionable',
+    emitsNonRevisionChanges: true,
     description:
-      'Add a footnote anchored to a paragraph. Optionally position the reference after specific text using after_text. Note: [^N] markers in read_file output are display-only and not part of the editable text used by replace_text.',
+      'Add a footnote anchored to a paragraph. Optionally position the reference after specific text using after_text. Note: [^N] markers in read_file output are display-only and not part of the editable text used by replace_text. Surface: revisionable + package-mutation — the footnote reference and note text are tracked (w:ins), while footnote-part creation and registration are recorded in the save report non-revision change manifest.',
     input: z.object({
       ...FILE_FIELD,
       target_paragraph_id: z.string().describe('Paragraph ID to anchor the footnote to.'),
@@ -375,7 +424,8 @@ export const SAFE_DOCX_TOOL_CATALOG = [
   },
   {
     name: 'update_footnote',
-    description: 'Update the text content of an existing footnote.',
+    surface: 'revisionable',
+    description: 'Update the text content of an existing footnote. Surface: revisionable — note-text changes emit native OOXML tracked changes (w:ins/w:del) inside the footnote body.',
     input: z.object({
       ...FILE_FIELD,
       note_id: z.number().describe('Footnote ID to update.'),
@@ -385,7 +435,8 @@ export const SAFE_DOCX_TOOL_CATALOG = [
   },
   {
     name: 'delete_footnote',
-    description: 'Delete a footnote and its reference from the document.',
+    surface: 'revisionable',
+    description: 'Delete a footnote and its reference from the document. Surface: revisionable — the reference and note text are removed as native OOXML tracked deletions (w:del).',
     input: z.object({
       ...FILE_FIELD,
       note_id: z.number().describe('Footnote ID to delete.'),
@@ -394,8 +445,9 @@ export const SAFE_DOCX_TOOL_CATALOG = [
   },
   {
     name: 'clear_formatting',
+    surface: 'revisionable',
     description:
-      'Clear specific run-level formatting (bold, italic, underline, highlight, color, font) from paragraphs.',
+      'Clear specific run-level formatting (bold, italic, underline, highlight, color, font) from paragraphs. Surface: revisionable — clearing emits a native run-property-change revision (w:rPrChange).',
     input: z.object({
       ...FILE_FIELD,
       paragraph_ids: z.array(z.string()).optional().describe('Paragraph IDs to clear formatting from. If omitted, clears from all paragraphs.'),
@@ -410,6 +462,7 @@ export const SAFE_DOCX_TOOL_CATALOG = [
   },
   {
     name: 'extract_revisions',
+    surface: 'internal',
     description:
       'Extract tracked changes as structured JSON with before/after text per paragraph, revision details, and comments. Supports pagination via offset and limit. Read-only - does not modify the document.',
     input: z.object({
@@ -429,11 +482,30 @@ function toJsonObjectSchema(schema: z.ZodTypeAny, name: string): Record<string, 
   return jsonSchema as Record<string, unknown>;
 }
 
-export const SAFE_DOCX_MCP_TOOLS = SAFE_DOCX_TOOL_CATALOG.map((tool) => ({
+export const SAFE_DOCX_MCP_TOOLS = SAFE_DOCX_TOOL_CATALOG.map((tool: ToolCatalogEntry) => ({
   name: tool.name,
   description: tool.description,
   inputSchema: toJsonObjectSchema(tool.input, tool.name),
   annotations: tool.annotations,
+  // #122: contract-surface classification, advertised alongside the tool so
+  // clients can distinguish tracked (revisionable) writes from untracked
+  // package mutations without reading SUPPORT.md.
+  surface: tool.surface,
+  emitsNonRevisionChanges: tool.emitsNonRevisionChanges ?? false,
 }));
+
+/**
+ * Programmatic index of the contract surface each tool writes to (#122),
+ * mirroring the ratified inventory in `packages/docx-core/SUPPORT.md`.
+ * Consumed by the revisionable-surface property test and by the classification
+ * coverage test.
+ */
+export const TOOL_SURFACE_INDEX: Record<string, { surface: ToolSurface; emitsNonRevisionChanges: boolean }> =
+  Object.fromEntries(
+    SAFE_DOCX_TOOL_CATALOG.map((tool: ToolCatalogEntry) => [
+      tool.name,
+      { surface: tool.surface, emitsNonRevisionChanges: tool.emitsNonRevisionChanges ?? false },
+    ]),
+  );
 
 export type SafeDocxToolName = (typeof SAFE_DOCX_TOOL_CATALOG)[number]['name'];

--- a/packages/docx-mcp/src/tools/add_comment.ts
+++ b/packages/docx-mcp/src/tools/add_comment.ts
@@ -48,6 +48,13 @@ export async function addComment(
 
       const result = await mutate(session.doc, ctx);
       manager.markEdited(session);
+      // Replies have no body anchor, so the whole write is package-mutation
+      // side-part metadata (#122): record it in the non-revision manifest.
+      manager.recordNonRevisionChange(session, {
+        tool: 'add_comment',
+        parts: [...COMMENT_TOUCHED_CONTEXT.sideParts, ...COMMENT_TOUCHED_CONTEXT.relationshipParts],
+        description: `Threaded reply to comment ${parentCommentId} written to comment side-story parts (comments.xml, commentsExtended.xml, people.xml). Replies have no body anchor, so no tracked-change marker is emitted.`,
+      });
       return ok(mergeSessionResolutionMetadata({
         comment_id: result.commentId,
         parent_comment_id: result.parentCommentId,
@@ -126,6 +133,15 @@ export async function addComment(
     const result = await mutate(session.doc, ctx);
 
     manager.markEdited(session);
+    // The body-story w:commentReference run is wrapped in w:ins (Table A), but
+    // the comment body text, author metadata, and any comment-infrastructure
+    // bootstrap are package-mutation side-part writes with no revision wrapper
+    // (#122): record them in the non-revision manifest.
+    manager.recordNonRevisionChange(session, {
+      tool: 'add_comment',
+      parts: [...COMMENT_TOUCHED_CONTEXT.sideParts, ...COMMENT_TOUCHED_CONTEXT.relationshipParts],
+      description: `Comment ${result.commentId} body text and author metadata written to comment side-story parts (comments.xml, people.xml). The body-story comment reference is tracked separately as a w:ins revision.`,
+    });
     return ok(mergeSessionResolutionMetadata({
       comment_id: result.commentId,
       anchor_paragraph_id: pid,

--- a/packages/docx-mcp/src/tools/add_comment.ts
+++ b/packages/docx-mcp/src/tools/add_comment.ts
@@ -10,6 +10,32 @@ const COMMENT_TOUCHED_CONTEXT = {
   sideParts: ['word/comments.xml', 'word/commentsExtended.xml', 'word/people.xml'],
 };
 
+// Non-revision parts a *root* comment can mutate without a tracked-change
+// wrapper. Unlike the body-story w:commentReference run (which is wrapped in
+// w:ins, Table A), the w:commentRangeStart/End milestones are written to
+// word/document.xml as structural markers and are NOT revision-wrapped (Word's
+// own behavior; see SUPPORT.md Table A note), so document.xml belongs here. The
+// content-types and relationship parts are touched only when comment
+// infrastructure is bootstrapped; they are declared conservatively so the
+// manifest never under-reports a package mutation.
+const ROOT_COMMENT_NON_REVISION_PARTS = [
+  'word/document.xml',
+  'word/comments.xml',
+  'word/commentsExtended.xml',
+  'word/people.xml',
+  '[Content_Types].xml',
+  'word/_rels/document.xml.rels',
+];
+
+// A threaded reply has no body anchor at all: the entire write is side-part
+// metadata (comments.xml text + commentsExtended.xml graph + people.xml), so no
+// tracked-change marker is emitted and document.xml is untouched.
+const REPLY_COMMENT_NON_REVISION_PARTS = [
+  'word/comments.xml',
+  'word/commentsExtended.xml',
+  'word/people.xml',
+];
+
 export async function addComment(
   manager: SessionManager,
   params: {
@@ -52,8 +78,8 @@ export async function addComment(
       // side-part metadata (#122): record it in the non-revision manifest.
       manager.recordNonRevisionChange(session, {
         tool: 'add_comment',
-        parts: [...COMMENT_TOUCHED_CONTEXT.sideParts, ...COMMENT_TOUCHED_CONTEXT.relationshipParts],
-        description: `Threaded reply to comment ${parentCommentId} written to comment side-story parts (comments.xml, commentsExtended.xml, people.xml). Replies have no body anchor, so no tracked-change marker is emitted.`,
+        parts: REPLY_COMMENT_NON_REVISION_PARTS,
+        description: `Threaded reply to comment ${parentCommentId} written to comment side-story parts (comments.xml, commentsExtended.xml, people.xml). Reply mode is package-mutation only: it has no body anchor, so no tracked-change marker is emitted and word/document.xml is untouched.`,
       });
       return ok(mergeSessionResolutionMetadata({
         comment_id: result.commentId,
@@ -139,8 +165,8 @@ export async function addComment(
     // (#122): record them in the non-revision manifest.
     manager.recordNonRevisionChange(session, {
       tool: 'add_comment',
-      parts: [...COMMENT_TOUCHED_CONTEXT.sideParts, ...COMMENT_TOUCHED_CONTEXT.relationshipParts],
-      description: `Comment ${result.commentId} body text and author metadata written to comment side-story parts (comments.xml, people.xml). The body-story comment reference is tracked separately as a w:ins revision.`,
+      parts: ROOT_COMMENT_NON_REVISION_PARTS,
+      description: `Comment ${result.commentId}: body text and author metadata written to comment side parts (comments.xml, people.xml), and w:commentRangeStart/End milestones written to word/document.xml as structural markers (not revision-wrapped). Comment infrastructure and its content-type/relationship registration are created when the package lacked them. The body-story w:commentReference run is tracked separately as a w:ins revision.`,
     });
     return ok(mergeSessionResolutionMetadata({
       comment_id: result.commentId,

--- a/packages/docx-mcp/src/tools/add_footnote.ts
+++ b/packages/docx-mcp/src/tools/add_footnote.ts
@@ -56,6 +56,15 @@ export async function addFootnote(
     const result = await mutate(session.doc, ctx);
 
     manager.markEdited(session);
+    // The body-story w:footnoteReference and note text are tracked as w:ins
+    // (Table A), but creating word/footnotes.xml and registering the part in
+    // relationships/content-types is a package mutation with no revision
+    // wrapper (#122): record it in the non-revision manifest.
+    manager.recordNonRevisionChange(session, {
+      tool: 'add_footnote',
+      parts: [...FOOTNOTE_TOUCHED_CONTEXT.sideParts, ...FOOTNOTE_TOUCHED_CONTEXT.relationshipParts],
+      description: `Footnote ${result.noteId} note body written to word/footnotes.xml. When the document lacked footnote infrastructure, the part, its relationship, and content-type registration were bootstrapped. The body-story footnote reference is tracked separately as a w:ins revision.`,
+    });
     return ok(mergeSessionResolutionMetadata({
       note_id: result.noteId,
       target_paragraph_id: pid,

--- a/packages/docx-mcp/src/tools/add_footnote.ts
+++ b/packages/docx-mcp/src/tools/add_footnote.ts
@@ -10,6 +10,19 @@ const FOOTNOTE_TOUCHED_CONTEXT = {
   sideParts: ['word/footnotes.xml'],
 };
 
+// Non-revision parts add_footnote can mutate without a tracked-change wrapper.
+// The note text runs and the body-story w:footnoteReference are wrapped in w:ins
+// (Table A), but the <w:footnote> container element appended to footnotes.xml is
+// a structural addition with no revision wrapper, and the content-type /
+// relationship registration is created when footnote infrastructure is
+// bootstrapped. [Content_Types].xml is declared so bootstrap registration is
+// never under-reported.
+const FOOTNOTE_NON_REVISION_PARTS = [
+  'word/footnotes.xml',
+  '[Content_Types].xml',
+  'word/_rels/document.xml.rels',
+];
+
 export async function addFootnote(
   manager: SessionManager,
   params: {
@@ -62,8 +75,8 @@ export async function addFootnote(
     // wrapper (#122): record it in the non-revision manifest.
     manager.recordNonRevisionChange(session, {
       tool: 'add_footnote',
-      parts: [...FOOTNOTE_TOUCHED_CONTEXT.sideParts, ...FOOTNOTE_TOUCHED_CONTEXT.relationshipParts],
-      description: `Footnote ${result.noteId} note body written to word/footnotes.xml. When the document lacked footnote infrastructure, the part, its relationship, and content-type registration were bootstrapped. The body-story footnote reference is tracked separately as a w:ins revision.`,
+      parts: FOOTNOTE_NON_REVISION_PARTS,
+      description: `Footnote ${result.noteId}: the <w:footnote> container element is appended to word/footnotes.xml as a structural addition (the note text runs are tracked separately as w:ins). When the document lacked footnote infrastructure, the part and its content-type/relationship registration were bootstrapped. The body-story footnote reference is also tracked as a w:ins revision.`,
     });
     return ok(mergeSessionResolutionMetadata({
       note_id: result.noteId,

--- a/packages/docx-mcp/src/tools/delete_comment.ts
+++ b/packages/docx-mcp/src/tools/delete_comment.ts
@@ -2,13 +2,34 @@ import { SessionManager, getRevisionContextForSession } from '../session/manager
 import { errorCode, errorMessage } from "../error_utils.js";
 import { resolveSessionForTool, mergeSessionResolutionMetadata } from './session_resolution.js';
 import { ok, err, type ToolResponse } from './types.js';
-import { DocxDocument, type RevisionContext } from '@usejunior/docx-core';
+import { DocxDocument, type Comment, type RevisionContext } from '@usejunior/docx-core';
 import { preflightAiRevisionMutation } from './ai_revision_guard.js';
 
 const COMMENT_TOUCHED_CONTEXT = {
   relationshipParts: ['word/_rels/document.xml.rels'],
   sideParts: ['word/comments.xml', 'word/commentsExtended.xml', 'word/people.xml'],
 };
+
+// Non-revision parts a comment deletion mutates without a tracked-change
+// wrapper. Both cases touch the comment side parts. A *root* (anchored) comment
+// additionally has its w:commentRangeStart/End milestones removed from
+// word/document.xml as structural markers (the reference-run removal is tracked
+// separately as w:del); a reply-only deletion has no body anchor and touches the
+// side parts only. The mode is resolved from the live comment tree so the
+// manifest neither under-reports (root) nor over-reports (reply) document.xml.
+const COMMENT_SIDE_PARTS = ['word/comments.xml', 'word/commentsExtended.xml'];
+
+/**
+ * A comment is a *root* (anchored) comment iff it appears at the top level of
+ * the comment tree; threaded replies are always nested under a parent's
+ * `replies`. Only root comments carry w:commentRangeStart/End milestones in
+ * word/document.xml, so this structural check — not the derived paragraphId
+ * fields, which replies can also inherit — determines whether a deletion mutates
+ * document.xml.
+ */
+function isRootComment(comments: Comment[], id: number): boolean {
+  return comments.some((c) => c.id === id);
+}
 
 export async function deleteComment(
   manager: SessionManager,
@@ -33,17 +54,24 @@ export async function deleteComment(
     const revisionPreflight = await preflightAiRevisionMutation(session, ctx, mutate, COMMENT_TOUCHED_CONTEXT);
     if (revisionPreflight) return revisionPreflight;
 
+    // Resolve root-vs-reply before mutating: an anchored (root) comment removes
+    // structural range markers from document.xml, a reply does not.
+    const anchored = isRootComment(await session.doc.getComments(), params.comment_id);
+
     await mutate(session.doc, ctx);
 
     manager.markEdited(session);
     // The removed body-story w:commentReference run is wrapped in w:del (Table
-    // A), but removing the comment/reply body text from comments.xml and the
-    // reply graph from commentsExtended.xml is package-mutation side-part
+    // A). Removing the comment/reply body text from comments.xml and the reply
+    // graph from commentsExtended.xml — and, for a root comment, the structural
+    // w:commentRangeStart/End milestones from document.xml — is package-mutation
     // cleanup with no revision wrapper (#122): record it.
     manager.recordNonRevisionChange(session, {
       tool: 'delete_comment',
-      parts: [...COMMENT_TOUCHED_CONTEXT.sideParts, ...COMMENT_TOUCHED_CONTEXT.relationshipParts],
-      description: `Comment ${params.comment_id} and its threaded replies removed from comment side-story parts (comments.xml, commentsExtended.xml). The body-story comment reference removal is tracked separately as a w:del revision.`,
+      parts: anchored ? ['word/document.xml', ...COMMENT_SIDE_PARTS] : [...COMMENT_SIDE_PARTS],
+      description: anchored
+        ? `Root comment ${params.comment_id} and its threaded replies removed from comment side parts (comments.xml, commentsExtended.xml); its w:commentRangeStart/End milestones were removed from word/document.xml as structural markers (the body-story reference removal is tracked separately as a w:del revision).`
+        : `Reply comment ${params.comment_id} removed from comment side parts (comments.xml, commentsExtended.xml). Reply-only deletion is package-mutation with no body anchor, so word/document.xml is untouched.`,
     });
     return ok(mergeSessionResolutionMetadata({
       comment_id: params.comment_id,

--- a/packages/docx-mcp/src/tools/delete_comment.ts
+++ b/packages/docx-mcp/src/tools/delete_comment.ts
@@ -36,6 +36,15 @@ export async function deleteComment(
     await mutate(session.doc, ctx);
 
     manager.markEdited(session);
+    // The removed body-story w:commentReference run is wrapped in w:del (Table
+    // A), but removing the comment/reply body text from comments.xml and the
+    // reply graph from commentsExtended.xml is package-mutation side-part
+    // cleanup with no revision wrapper (#122): record it.
+    manager.recordNonRevisionChange(session, {
+      tool: 'delete_comment',
+      parts: [...COMMENT_TOUCHED_CONTEXT.sideParts, ...COMMENT_TOUCHED_CONTEXT.relationshipParts],
+      description: `Comment ${params.comment_id} and its threaded replies removed from comment side-story parts (comments.xml, commentsExtended.xml). The body-story comment reference removal is tracked separately as a w:del revision.`,
+    });
     return ok(mergeSessionResolutionMetadata({
       comment_id: params.comment_id,
       file_path: manager.normalizePath(session.originalPath),

--- a/packages/docx-mcp/src/tools/forbid_untracked_ai_mutations.test.ts
+++ b/packages/docx-mcp/src/tools/forbid_untracked_ai_mutations.test.ts
@@ -9,6 +9,7 @@ import { SessionManager, type DocxSession } from '../session/manager.js';
 import { TOOL_SURFACE_INDEX, SAFE_DOCX_MCP_TOOLS } from '../tool_catalog.js';
 import { addComment } from './add_comment.js';
 import { addFootnote } from './add_footnote.js';
+import { deleteComment } from './delete_comment.js';
 import { batchEdit } from './batch_edit.js';
 import { clearFormatting } from './clear_formatting.js';
 import { formatLayout } from './format_layout.js';
@@ -159,6 +160,44 @@ const REVISIONABLE_EDITORS: Array<{
   },
 ];
 
+// Revisionable + destructive tools NOT in REVISIONABLE_EDITORS, with the reason
+// each is exempt from the fresh-emission property. Together with the editor set
+// this must exhaust the revisionable-destructive surface, so a future tool
+// cannot silently escape the forbid-untracked guarantee.
+const EXEMPT_REVISIONABLE_DESTRUCTIVE: Record<string, string> = {
+  save: 'finalizer, not an editor — emits no new revisions of its own',
+  delete_comment: 'operates on an existing comment; covered by dedicated root/reply manifest scenarios',
+  update_footnote: 'edits existing note text; emission covered by the #120/#121 emitter tests',
+  delete_footnote: 'removes an existing footnote; emission covered by the #120/#121 emitter tests',
+};
+
+/**
+ * Assert that every occurrence of `insertedText` in the body appears only inside
+ * a `w:ins` tracked-change wrapper — i.e. the AI edit introduced no untracked
+ * body text. Returns the number of matched text nodes (must be > 0).
+ */
+async function assertInsertedTextIsTracked(doc: DocxDocument, insertedText: string): Promise<number> {
+  const { buffer } = await doc.toBuffer({ cleanBookmarks: false });
+  const zip = await DocxZip.load(buffer);
+  const documentXmlText = await zip.readText('word/document.xml');
+  const parsed = parseXml(documentXmlText);
+  let matched = 0;
+  for (const t of Array.from(parsed.getElementsByTagName('*'))) {
+    if (t.namespaceURI !== W_NS || t.localName !== 't') continue;
+    if ((t.textContent ?? '') !== insertedText) continue;
+    matched += 1;
+    let el: Node | null = t.parentNode;
+    let insAncestor = false;
+    while (el) {
+      const asEl = el as Element;
+      if (asEl.namespaceURI === W_NS && asEl.localName === 'ins') insAncestor = true;
+      el = el.parentNode;
+    }
+    expect(insAncestor, `inserted text "${insertedText}" was not wrapped in w:ins`).toBe(true);
+  }
+  return matched;
+}
+
 describe('Forbid untracked AI mutations (#122)', () => {
   registerCleanup();
 
@@ -179,6 +218,19 @@ describe('Forbid untracked AI mutations (#122)', () => {
         for (const name of dual) {
           expect(TOOL_SURFACE_INDEX[name]!.surface).toBe('revisionable');
         }
+        // Coverage guard (derived from the catalog, not hand-maintained): every
+        // revisionable + destructive tool must be either exercised by the
+        // fresh-emission property or explicitly exempted with a reason, so a new
+        // tool cannot silently escape the forbid-untracked guarantee.
+        const revisionableDestructive = SAFE_DOCX_MCP_TOOLS
+          .filter((t) => t.surface === 'revisionable' && !t.annotations.readOnlyHint)
+          .map((t) => t.name)
+          .sort();
+        const accountedFor = [
+          ...REVISIONABLE_EDITORS.map((e) => e.name),
+          ...Object.keys(EXEMPT_REVISIONABLE_DESTRUCTIVE),
+        ].sort();
+        expect(accountedFor).toEqual(revisionableDestructive);
       });
     },
   );
@@ -213,48 +265,160 @@ describe('Forbid untracked AI mutations (#122)', () => {
   test.openspec('revisionable edits produce no untracked AI body content')(
     'Scenario: revisionable edits produce no untracked AI body content',
     async ({ given, when, then }: AllureBddContext) => {
-      const opened = await given('an AI session with a single paragraph', () =>
-        openSession([], {
+      // Each text-inserting editor introduces a unique sentinel token; the
+      // token must appear only inside a w:ins wrapper afterwards.
+      const cases: Array<{ name: string; token: string; run: (o: Awaited<ReturnType<typeof openSession>>) => Promise<unknown> }> = [
+        {
+          name: 'replace_text',
+          token: 'ZULU',
+          run: (o) =>
+            replaceText(o.mgr, {
+              file_path: o.filePath,
+              target_paragraph_id: o.firstParaId,
+              old_string: 'bravo',
+              new_string: 'ZULU',
+              instruction: 'replace bravo',
+            }),
+        },
+        {
+          name: 'insert_paragraph',
+          token: 'YANKEE',
+          run: (o) =>
+            insertParagraph(o.mgr, {
+              file_path: o.filePath,
+              positional_anchor_node_id: o.firstParaId,
+              new_string: 'YANKEE',
+              instruction: 'insert paragraph',
+              position: 'AFTER',
+            }),
+        },
+        {
+          name: 'batch_edit',
+          token: 'XRAY',
+          run: (o) =>
+            batchEdit(o.mgr, {
+              file_path: o.filePath,
+              steps: [
+                {
+                  step_id: 's1',
+                  operation: 'replace_text',
+                  target_paragraph_id: o.firstParaId,
+                  old_string: 'charlie',
+                  new_string: 'XRAY',
+                  instruction: 'replace charlie',
+                },
+              ],
+            }),
+        },
+      ];
+
+      for (const c of cases) {
+        const opened = await given(`an AI session for ${c.name}`, () =>
+          openSession([], {
+            mgr: aiManager(),
+            xml: documentXml(`<w:p><w:r><w:t>Alpha bravo charlie</w:t></w:r></w:p>`),
+          }),
+        );
+
+        const result = await when(`${c.name} introduces text under the AI actor`, () => c.run(opened));
+
+        await then(`${c.name}'s inserted text lands only inside w:ins`, async () => {
+          assertSuccess(result as { success: boolean }, c.name);
+          const session = await docxSession(opened.mgr, opened.filePath);
+          const matched = await assertInsertedTextIsTracked(session.doc, c.token);
+          expect(matched, `expected ${c.name} to insert "${c.token}"`).toBeGreaterThan(0);
+          const validation = await session.doc.validateAiRevisions(AI);
+          expect(validation.errors).toEqual([]);
+        });
+      }
+    },
+  );
+
+  test.openspec('comment reply mode is package-only with no tracked element')(
+    'Scenario: comment reply mode is package-only with no tracked element',
+    async ({ given, when, then }: AllureBddContext) => {
+      const opened = await given('an AI session with a root comment', async () => {
+        const o = await openSession([], {
           mgr: aiManager(),
           xml: documentXml(`<w:p><w:r><w:t>Alpha bravo charlie</w:t></w:r></w:p>`),
-        }),
-      );
+        });
+        const root = await addComment(o.mgr, {
+          file_path: o.filePath,
+          target_paragraph_id: o.firstParaId,
+          anchor_text: 'bravo',
+          author: 'Reviewer',
+          text: 'root note',
+        });
+        assertSuccess(root, 'root comment');
+        return { ...o, rootCommentId: root.comment_id as number };
+      });
 
-      await when('replace_text rewrites text under the AI actor', () =>
-        replaceText(opened.mgr, {
+      const before = await docxSession(opened.mgr, opened.filePath);
+      const revisionsBeforeReply = await countAiRevisions(before.doc, AI);
+
+      const reply = await when('a threaded reply is added', () =>
+        addComment(opened.mgr, {
           file_path: opened.filePath,
-          target_paragraph_id: opened.firstParaId,
-          old_string: 'bravo',
-          new_string: 'BRAVO',
-          instruction: 'uppercase bravo',
+          parent_comment_id: opened.rootCommentId,
+          author: 'Reviewer',
+          text: 'a reply',
         }),
       );
 
-      await then('the replaced text lands only inside tracked-change wrappers', async () => {
+      await then('the reply adds no tracked change and records a package-only manifest entry', async () => {
+        assertSuccess(reply, 'reply');
         const session = await docxSession(opened.mgr, opened.filePath);
-        const { buffer } = await session.doc.toBuffer({ cleanBookmarks: false });
-        const zip = await DocxZip.load(buffer);
-        const documentXmlText = await zip.readText('word/document.xml');
-        const doc = parseXml(documentXmlText);
-        // The inserted run carrying "BRAVO" must have a w:ins ancestor; no
-        // AI-introduced text may sit as a bare run in the body.
-        let sawInsertedText = false;
-        for (const t of Array.from(doc.getElementsByTagName('*'))) {
-          if (t.namespaceURI !== W_NS || t.localName !== 't') continue;
-          if ((t.textContent ?? '') !== 'BRAVO') continue;
-          sawInsertedText = true;
-          let el: Node | null = t.parentNode;
-          let insAncestor = false;
-          while (el) {
-            const asEl = el as Element;
-            if (asEl.namespaceURI === W_NS && asEl.localName === 'ins') insAncestor = true;
-            el = el.parentNode;
-          }
-          expect(insAncestor, 'AI-inserted text was not wrapped in w:ins').toBe(true);
-        }
-        expect(sawInsertedText, 'expected the inserted text to be present').toBe(true);
-        const validation = await session.doc.validateAiRevisions(AI);
-        expect(validation.errors).toEqual([]);
+        const revisionsAfterReply = await countAiRevisions(session.doc, AI);
+        expect(revisionsAfterReply, 'reply must not emit a new tracked-change element').toBe(revisionsBeforeReply);
+        // The reply's manifest entry names side parts only — never document.xml.
+        const replyEntry = session.nonRevisionManifest.find(
+          (e) => e.tool === 'add_comment' && !e.parts.includes('word/document.xml'),
+        );
+        expect(replyEntry, 'expected a package-only reply manifest entry').toBeDefined();
+        expect(replyEntry!.parts).toContain('word/commentsExtended.xml');
+      });
+    },
+  );
+
+  test.openspec('comment reply deletion is package-only')(
+    'Scenario: comment reply deletion is package-only',
+    async ({ given, when, then }: AllureBddContext) => {
+      const opened = await given('an AI session with a root comment and a reply', async () => {
+        const o = await openSession([], {
+          mgr: aiManager(),
+          xml: documentXml(`<w:p><w:r><w:t>Alpha bravo charlie</w:t></w:r></w:p>`),
+        });
+        const root = await addComment(o.mgr, {
+          file_path: o.filePath,
+          target_paragraph_id: o.firstParaId,
+          anchor_text: 'bravo',
+          author: 'Reviewer',
+          text: 'root note',
+        });
+        assertSuccess(root, 'root comment');
+        const reply = await addComment(o.mgr, {
+          file_path: o.filePath,
+          parent_comment_id: root.comment_id as number,
+          author: 'Reviewer',
+          text: 'a reply',
+        });
+        assertSuccess(reply, 'reply');
+        return { ...o, replyId: reply.comment_id as number };
+      });
+
+      const result = await when('the reply is deleted', () =>
+        deleteComment(opened.mgr, { file_path: opened.filePath, comment_id: opened.replyId }),
+      );
+
+      await then('the deletion records a package-only manifest entry without document.xml', async () => {
+        assertSuccess(result, 'delete reply');
+        const session = await docxSession(opened.mgr, opened.filePath);
+        const entry = session.nonRevisionManifest.find(
+          (e) => e.tool === 'delete_comment' && e.editRevision === session.editRevision,
+        );
+        expect(entry, 'expected a delete_comment manifest entry').toBeDefined();
+        expect(entry!.parts).not.toContain('word/document.xml');
+        expect(entry!.parts).toContain('word/comments.xml');
       });
     },
   );

--- a/packages/docx-mcp/src/tools/forbid_untracked_ai_mutations.test.ts
+++ b/packages/docx-mcp/src/tools/forbid_untracked_ai_mutations.test.ts
@@ -1,0 +1,372 @@
+import { describe, expect } from 'vitest';
+import {
+  DocxZip,
+  TRACKED_CHANGE_ELEMENT_NAME_SET,
+  parseXml,
+  type DocxDocument,
+} from '@usejunior/docx-core';
+import { SessionManager, type DocxSession } from '../session/manager.js';
+import { TOOL_SURFACE_INDEX, SAFE_DOCX_MCP_TOOLS } from '../tool_catalog.js';
+import { addComment } from './add_comment.js';
+import { addFootnote } from './add_footnote.js';
+import { batchEdit } from './batch_edit.js';
+import { clearFormatting } from './clear_formatting.js';
+import { formatLayout } from './format_layout.js';
+import { insertParagraph } from './insert_paragraph.js';
+import { replaceText } from './replace_text.js';
+import { save } from './save.js';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import {
+  assertSuccess,
+  createTrackedTempDir,
+  openSession,
+  registerCleanup,
+} from '../testing/session-test-utils.js';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+// OpenSpec traceability: forbid-untracked-ai-mutations
+const TEST_FEATURE = 'forbid-untracked-ai-mutations';
+const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const AI = 'SafeDocX AI';
+
+const test = testAllure.epic('Document Editing').withLabels({ feature: TEST_FEATURE });
+
+function aiManager(): SessionManager {
+  return new SessionManager({ defaultAiAuthor: AI });
+}
+
+function documentXml(body: string): string {
+  return (
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<w:document xmlns:w="${W_NS}"><w:body>${body}</w:body></w:document>`
+  );
+}
+
+async function docxSession(mgr: SessionManager, filePath: string): Promise<DocxSession> {
+  const session = await mgr.getSessionByFilePath(filePath);
+  if (!session || session.provider !== 'docx') throw new Error('Expected DOCX session');
+  return session;
+}
+
+/**
+ * Count tracked-change elements attributed to `author` across every word/*.xml
+ * story (body + footnotes + comments). This is the ground truth for "the write
+ * produced a native OOXML revision element," independent of the write-time
+ * emitter's internal bookkeeping.
+ */
+async function countAiRevisions(doc: DocxDocument, author: string): Promise<number> {
+  const { buffer } = await doc.toBuffer({ cleanBookmarks: false });
+  const zip = await DocxZip.load(buffer);
+  let count = 0;
+  for (const fileName of zip.listFiles()) {
+    if (!fileName.startsWith('word/') || !fileName.endsWith('.xml')) continue;
+    const xml = await zip.readTextOrNull(fileName);
+    if (!xml) continue;
+    const parsed = parseXml(xml);
+    for (const node of Array.from(parsed.getElementsByTagName('*'))) {
+      if (node.namespaceURI !== W_NS || !TRACKED_CHANGE_ELEMENT_NAME_SET.has(node.localName)) continue;
+      const attr =
+        node.getAttributeNS(W_NS, 'author') ?? node.getAttribute('w:author') ?? node.getAttribute('author');
+      if (attr === author) count += 1;
+    }
+  }
+  return count;
+}
+
+// The write-time revisionable editors that must emit at least one AI-authored
+// tracked-change element per invocation. Delete/update variants operate on
+// pre-existing structures and are exercised by the #120/#121 emitter tests; the
+// forbid-untracked guarantee here targets the fresh-emission editors.
+const REVISIONABLE_EDITORS: Array<{
+  name: string;
+  run: (mgr: SessionManager, filePath: string, firstParaId: string, paraIds: string[]) => Promise<unknown>;
+  bodyXml?: string;
+}> = [
+  {
+    name: 'replace_text',
+    run: (mgr, filePath, firstParaId) =>
+      replaceText(mgr, {
+        file_path: filePath,
+        target_paragraph_id: firstParaId,
+        old_string: 'bravo',
+        new_string: 'BRAVO',
+        instruction: 'uppercase bravo',
+      }),
+  },
+  {
+    name: 'insert_paragraph',
+    run: (mgr, filePath, firstParaId) =>
+      insertParagraph(mgr, {
+        file_path: filePath,
+        positional_anchor_node_id: firstParaId,
+        new_string: 'Inserted paragraph',
+        instruction: 'add a paragraph',
+        position: 'AFTER',
+      }),
+  },
+  {
+    name: 'batch_edit',
+    run: (mgr, filePath, firstParaId) =>
+      batchEdit(mgr, {
+        file_path: filePath,
+        steps: [
+          {
+            step_id: 's1',
+            operation: 'replace_text',
+            target_paragraph_id: firstParaId,
+            old_string: 'charlie',
+            new_string: 'CHARLIE',
+            instruction: 'uppercase charlie',
+          },
+        ],
+      }),
+  },
+  {
+    name: 'format_layout',
+    run: (mgr, filePath, firstParaId) =>
+      formatLayout(mgr, {
+        file_path: filePath,
+        paragraph_spacing: { paragraph_ids: [firstParaId], before_twips: 240 },
+      }),
+  },
+  {
+    name: 'clear_formatting',
+    bodyXml: `<w:p><w:r><w:rPr><w:b/></w:rPr><w:t>Alpha bravo charlie</w:t></w:r></w:p>`,
+    run: (mgr, filePath, firstParaId) =>
+      clearFormatting(mgr, { file_path: filePath, paragraph_ids: [firstParaId], clear_bold: true }),
+  },
+  {
+    name: 'add_comment',
+    run: (mgr, filePath, firstParaId) =>
+      addComment(mgr, {
+        file_path: filePath,
+        target_paragraph_id: firstParaId,
+        anchor_text: 'bravo',
+        author: 'Reviewer',
+        text: 'a note',
+      }),
+  },
+  {
+    name: 'add_footnote',
+    run: (mgr, filePath, firstParaId) =>
+      addFootnote(mgr, {
+        file_path: filePath,
+        target_paragraph_id: firstParaId,
+        after_text: 'bravo',
+        text: 'a footnote',
+      }),
+  },
+];
+
+describe('Forbid untracked AI mutations (#122)', () => {
+  registerCleanup();
+
+  test.openspec('every tool declares a contract surface')(
+    'Scenario: every tool declares a contract surface',
+    async ({ given, when, then }: AllureBddContext) => {
+      await given('the MCP tool catalog is loaded', () => undefined);
+      await when('each tool is inspected for a surface classification', () => undefined);
+      await then('every tool declares revisionable, package-mutation, or internal', () => {
+        for (const tool of SAFE_DOCX_MCP_TOOLS) {
+          expect(TOOL_SURFACE_INDEX[tool.name], `tool ${tool.name} missing surface`).toBeDefined();
+          expect(['revisionable', 'package-mutation', 'internal']).toContain(tool.surface);
+        }
+        // Tools that also mutate package parts are precisely the comment/footnote
+        // dual-surface tools ratified in SUPPORT.md Table B.
+        const dual = SAFE_DOCX_MCP_TOOLS.filter((t) => t.emitsNonRevisionChanges).map((t) => t.name).sort();
+        expect(dual).toEqual(['add_comment', 'add_footnote', 'delete_comment']);
+        for (const name of dual) {
+          expect(TOOL_SURFACE_INDEX[name]!.surface).toBe('revisionable');
+        }
+      });
+    },
+  );
+
+  test.openspec('revisionable edit tools emit valid AI tracked changes')(
+    'Scenario: revisionable edit tools emit valid AI tracked changes',
+    async ({ given, when, then }: AllureBddContext) => {
+      for (const editor of REVISIONABLE_EDITORS) {
+        const opened = await given(`an AI session for ${editor.name}`, () =>
+          openSession([], {
+            mgr: aiManager(),
+            xml: documentXml(editor.bodyXml ?? `<w:p><w:r><w:t>Alpha bravo charlie</w:t></w:r></w:p>`),
+          }),
+        );
+
+        const result = await when(`${editor.name} performs an AI write`, () =>
+          editor.run(opened.mgr, opened.filePath, opened.firstParaId, opened.paraIds),
+        );
+
+        await then(`${editor.name} produced valid AI tracked changes`, async () => {
+          assertSuccess(result as { success: boolean }, editor.name);
+          const session = await docxSession(opened.mgr, opened.filePath);
+          const validation = await session.doc.validateAiRevisions(AI);
+          expect(validation.errors, `${editor.name} emitted invalid AI revisions`).toEqual([]);
+          const revisions = await countAiRevisions(session.doc, AI);
+          expect(revisions, `${editor.name} emitted no AI-authored tracked change`).toBeGreaterThan(0);
+        });
+      }
+    },
+  );
+
+  test.openspec('revisionable edits produce no untracked AI body content')(
+    'Scenario: revisionable edits produce no untracked AI body content',
+    async ({ given, when, then }: AllureBddContext) => {
+      const opened = await given('an AI session with a single paragraph', () =>
+        openSession([], {
+          mgr: aiManager(),
+          xml: documentXml(`<w:p><w:r><w:t>Alpha bravo charlie</w:t></w:r></w:p>`),
+        }),
+      );
+
+      await when('replace_text rewrites text under the AI actor', () =>
+        replaceText(opened.mgr, {
+          file_path: opened.filePath,
+          target_paragraph_id: opened.firstParaId,
+          old_string: 'bravo',
+          new_string: 'BRAVO',
+          instruction: 'uppercase bravo',
+        }),
+      );
+
+      await then('the replaced text lands only inside tracked-change wrappers', async () => {
+        const session = await docxSession(opened.mgr, opened.filePath);
+        const { buffer } = await session.doc.toBuffer({ cleanBookmarks: false });
+        const zip = await DocxZip.load(buffer);
+        const documentXmlText = await zip.readText('word/document.xml');
+        const doc = parseXml(documentXmlText);
+        // The inserted run carrying "BRAVO" must have a w:ins ancestor; no
+        // AI-introduced text may sit as a bare run in the body.
+        let sawInsertedText = false;
+        for (const t of Array.from(doc.getElementsByTagName('*'))) {
+          if (t.namespaceURI !== W_NS || t.localName !== 't') continue;
+          if ((t.textContent ?? '') !== 'BRAVO') continue;
+          sawInsertedText = true;
+          let el: Node | null = t.parentNode;
+          let insAncestor = false;
+          while (el) {
+            const asEl = el as Element;
+            if (asEl.namespaceURI === W_NS && asEl.localName === 'ins') insAncestor = true;
+            el = el.parentNode;
+          }
+          expect(insAncestor, 'AI-inserted text was not wrapped in w:ins').toBe(true);
+        }
+        expect(sawInsertedText, 'expected the inserted text to be present').toBe(true);
+        const validation = await session.doc.validateAiRevisions(AI);
+        expect(validation.errors).toEqual([]);
+      });
+    },
+  );
+
+  test.openspec('comment side-part writes are recorded in the save manifest')(
+    'Scenario: comment side-part writes are recorded in the save manifest',
+    async ({ given, when, then }: AllureBddContext) => {
+      const opened = await given('an AI session with one paragraph', () =>
+        openSession([], {
+          mgr: aiManager(),
+          xml: documentXml(`<w:p><w:r><w:t>Alpha bravo charlie</w:t></w:r></w:p>`),
+        }),
+      );
+
+      await when('a comment is added', () =>
+        addComment(opened.mgr, {
+          file_path: opened.filePath,
+          target_paragraph_id: opened.firstParaId,
+          anchor_text: 'bravo',
+          author: 'Reviewer',
+          text: 'a note',
+        }),
+      );
+
+      await then('the save report lists the comment side parts as a non-revision change', async () => {
+        const tmpDir = await createTrackedTempDir();
+        const outPath = path.join(tmpDir, 'out.docx');
+        const result = await save(opened.mgr, {
+          file_path: opened.filePath,
+          save_to_local_path: outPath,
+          save_format: 'clean',
+        });
+        assertSuccess(result, 'save');
+        const manifest = result.non_revision_changes as Array<{ tool: string; parts: string[] }> | undefined;
+        expect(manifest, 'expected a non-revision manifest').toBeDefined();
+        const entry = manifest!.find((e) => e.tool === 'add_comment');
+        expect(entry, 'expected an add_comment manifest entry').toBeDefined();
+        expect(entry!.parts).toContain('word/comments.xml');
+        // Ensure the artifact actually exists (save succeeded end-to-end).
+        await fs.access(outPath);
+      });
+    },
+  );
+
+  test.openspec('footnote part creation is recorded in the save manifest')(
+    'Scenario: footnote part creation is recorded in the save manifest',
+    async ({ given, when, then }: AllureBddContext) => {
+      const opened = await given('an AI session with one paragraph', () =>
+        openSession([], {
+          mgr: aiManager(),
+          xml: documentXml(`<w:p><w:r><w:t>Alpha bravo charlie</w:t></w:r></w:p>`),
+        }),
+      );
+
+      await when('a footnote is added', () =>
+        addFootnote(opened.mgr, {
+          file_path: opened.filePath,
+          target_paragraph_id: opened.firstParaId,
+          after_text: 'bravo',
+          text: 'a footnote',
+        }),
+      );
+
+      await then('the save report lists word/footnotes.xml as a non-revision change', async () => {
+        const tmpDir = await createTrackedTempDir();
+        const outPath = path.join(tmpDir, 'out.docx');
+        const result = await save(opened.mgr, {
+          file_path: opened.filePath,
+          save_to_local_path: outPath,
+          save_format: 'clean',
+        });
+        assertSuccess(result, 'save');
+        const manifest = result.non_revision_changes as Array<{ tool: string; parts: string[] }> | undefined;
+        expect(manifest, 'expected a non-revision manifest').toBeDefined();
+        const entry = manifest!.find((e) => e.tool === 'add_footnote');
+        expect(entry, 'expected an add_footnote manifest entry').toBeDefined();
+        expect(entry!.parts).toContain('word/footnotes.xml');
+      });
+    },
+  );
+
+  test.openspec('tracked-only edits report no non-revision changes')(
+    'Scenario: tracked-only edits report no non-revision changes',
+    async ({ given, when, then }: AllureBddContext) => {
+      const opened = await given('an AI session with one paragraph', () =>
+        openSession([], {
+          mgr: aiManager(),
+          xml: documentXml(`<w:p><w:r><w:t>Alpha bravo charlie</w:t></w:r></w:p>`),
+        }),
+      );
+
+      await when('only a body text edit is performed', () =>
+        replaceText(opened.mgr, {
+          file_path: opened.filePath,
+          target_paragraph_id: opened.firstParaId,
+          old_string: 'bravo',
+          new_string: 'BRAVO',
+          instruction: 'uppercase bravo',
+        }),
+      );
+
+      await then('the save report contains no non-revision change manifest', async () => {
+        const tmpDir = await createTrackedTempDir();
+        const outPath = path.join(tmpDir, 'out.docx');
+        const result = await save(opened.mgr, {
+          file_path: opened.filePath,
+          save_to_local_path: outPath,
+          save_format: 'clean',
+        });
+        assertSuccess(result, 'save');
+        expect(result.non_revision_changes).toBeUndefined();
+      });
+    },
+  );
+});

--- a/packages/docx-mcp/src/tools/save.ts
+++ b/packages/docx-mcp/src/tools/save.ts
@@ -438,6 +438,13 @@ export async function save(
         ? 'Rebuild mode was used which may alter document structure (tables, fonts, etc.)'
         : undefined,
       revisions,
+      // #122: package-level mutations with no native OOXML revision wrapper
+      // (comment/footnote side parts, relationships, content types) are not
+      // tracked changes, so surface them explicitly alongside the revisions
+      // list rather than letting them land silently.
+      non_revision_changes: session.nonRevisionManifest.length > 0
+        ? session.nonRevisionManifest
+        : undefined,
       exported_at_utc: exportTimestamp,
       bookmarks_removed: clean ? bookmarksRemoved : 0,
       blocks_restored: blocksRestored,


### PR DESCRIPTION
## What & why

Part of epic #118 (tracked-changes-as-canonical). This PR makes the contract *"AI edits in the supported surface cannot be untracked"* **explicit and enforceable** — the prerequisite for removing whole-document comparison from the default finalization path (#126).

Until now the contract was implicit: every write tool routed through the write-time tracked-change emitter (#120) and validator (#121), but nothing classified each tool's write surface, and package-level mutations with no native OOXML revision wrapper (comment/footnote side parts, relationships, content types) landed silently — masked today only because the default save re-derives a redline by diffing.

## Changes

- **Surface classification.** Every MCP tool declares `surface: 'revisionable' | 'package-mutation' | 'internal'`, mirroring the ratified `SUPPORT.md` inventory (#119). Advertised in each write tool's description, in the exported tool metadata (`surface`, `emitsNonRevisionChanges`), and via `TOOL_SURFACE_INDEX`.
- **Non-revision change manifest.** Dual-surface tools (`add_comment`, `delete_comment`, `add_footnote`) record the package parts they mutate without a tracked-change wrapper. The `save` report surfaces it as `non_revision_changes` (omitted when empty), so those mutations are accounted for rather than landing silently.
- **Property test.** Asserts every fresh-emission revisionable editor produces ≥1 valid AI-authored tracked change (validity delegated to the #121 validator) and that AI-inserted body text is never left untracked; plus manifest scenarios for comments/footnotes and the tracked-only empty-manifest case.
- **OpenSpec** change `forbid-untracked-ai-mutations` (mcp-server delta) + `SUPPORT.md` manifest docs.

## Verification

- `npm run build`, `lint:workspaces`, full `docx-mcp` suite (866 tests), `check:spec-coverage`, `check:tool-docs`, `check:conformance-*`, `check:cycles`, `check:allure-*` all pass locally.
- New test: `packages/docx-mcp/src/tools/forbid_untracked_ai_mutations.test.ts` (6 scenarios).

Refs #122
Part of #118

https://claude.ai/code/session_01AbPhuyQQAb1sReWxtS24hC