### PR TITLE
fix(docx-core): retargeted hyperlink compares as delete-old-link + insert-new-link (#376)

### DIFF
--- a/packages/docx-core/src/atomizer.ts
+++ b/packages/docx-core/src/atomizer.ts
@@ -1034,6 +1034,58 @@ export function nearestHyperlinkAncestor(atom: ComparisonUnitAtom): WmlElement |
 }
 
 /**
+ * The logical destination of a w:hyperlink, used to salt atom identity.
+ *
+ * Prefers the *resolved* target over the raw r:id: an external r:id resolves
+ * through `relsMap` to its URL, an internal link salts on its w:anchor, and an
+ * unresolvable r:id falls back to the raw id so at least attribute-level
+ * discrimination survives. Same destination on both sides yields the same salt
+ * (still Equal); a changed destination yields different salts, which is what
+ * turns a retarget into delete-old-link + insert-new-link.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.22
+ * @see https://github.com/UseJunior/safe-docx/issues/376
+ */
+function hyperlinkDestinationSalt(
+  link: WmlElement,
+  relsMap: ReadonlyMap<string, string>
+): string | null {
+  const rid = link.getAttribute('r:id');
+  const anchor = link.getAttribute('w:anchor');
+  const parts: string[] = [];
+  if (rid) parts.push(`rel=${relsMap.get(rid) ?? `unresolved:${rid}`}`);
+  if (anchor) parts.push(`anchor=${anchor}`);
+  return parts.length > 0 ? parts.join('|') : null;
+}
+
+/**
+ * Fold each atom's nearest-hyperlink destination into its identity hash so the
+ * LCS stops matching equal text that sits under different link targets. Applied
+ * as a post-atomization pass (after run/word merging and numbering salting, all
+ * of which leave each atom with a single well-defined ancestry) so it need not
+ * be duplicated at every hash-recompute site.
+ *
+ * Atoms outside any hyperlink, and hyperlinks with neither r:id nor anchor, are
+ * left untouched — their hashes stay byte-identical to the pre-#376 output.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.22
+ * @see https://github.com/UseJunior/safe-docx/issues/376
+ */
+export function applyHyperlinkDestinationSalt(
+  atoms: ComparisonUnitAtom[],
+  relsMap: ReadonlyMap<string, string>
+): void {
+  for (const atom of atoms) {
+    const link = nearestHyperlinkAncestor(atom);
+    if (!link) continue;
+    const salt = hyperlinkDestinationSalt(link, relsMap);
+    if (salt !== null) {
+      atom.sha1Hash = `${atom.sha1Hash}:hlink:${salt}`;
+    }
+  }
+}
+
+/**
  * Check if two atoms can be merged into one.
  *
  * Atoms can be merged if they:

--- a/packages/docx-core/src/baselines/atomizer/documentReconstructor-hyperlinks.test.ts
+++ b/packages/docx-core/src/baselines/atomizer/documentReconstructor-hyperlinks.test.ts
@@ -14,6 +14,7 @@
 import { describe, expect } from 'vitest';
 import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
 import { buildDocxFromBodyXml } from '../../testing/ooxml-fixtures.js';
+import { parseXml } from '../../primitives/xml.js';
 import { DocxArchive } from '../../shared/docx/DocxArchive.js';
 import { compareDocumentsAtomizer } from './pipeline.js';
 import { compareProjectedFormattingFidelity } from './formattingFidelity.js';
@@ -165,15 +166,20 @@ describe('Rebuild reconstruction preserves w:hyperlink wrappers', () => {
     });
   });
 
-  test('a retargeted link never leaves accepted text on the stale original target', async ({ given, when, then, and }: AllureBddContext) => {
+  test('a retargeted link with no shippable relationship (empty rels) drops the insert wrapper rather than pinning it to the stale target', async ({ given, when, then, and }: AllureBddContext) => {
     let rebuildXml: string;
 
-    await given('a revision that changes the link target (r:id) and part of the link text, keeping a text suffix equal', () => {});
+    await given('a revision that retargets the link (r:id rId7 -> rId99) where neither package declares the relationship', () => {});
 
     await when('compared with reconstructionMode rebuild', async () => {
       const para = (id: string, text: string) =>
         `<w:p><w:r><w:t xml:space="preserve">See </w:t></w:r>` +
         `<w:hyperlink xmlns:r="${R_NS}" r:id="${id}"><w:r><w:t>${text}</w:t></w:r></w:hyperlink></w:p>`;
+      // Fixtures ship an empty document.xml.rels, so the revised r:id has no
+      // relationship to merge — the destination salt still splits this into
+      // delete-old-link + insert-new-link, but the insert stays unwrapped
+      // because there is nothing resolvable to ship (contrast the real-rels
+      // cases below, which do wrap and ship).
       rebuildXml = await rebuildCompare(
         para('rId7', 'alpha target'),
         para('rId99', 'beta target'),
@@ -222,9 +228,204 @@ describe('Rebuild reconstruction preserves w:hyperlink wrappers', () => {
       expect(anchorXml).not.toMatch(/<w:ins[^>]*>\s*<w:hyperlink/);
     });
 
-    await and('the r:id insertion is NOT wrapped — rId99 has no relationship in the original-based package, and a dangling r:id corrupts the document (known boundary, content preserved as plain inserted runs)', () => {
+    await and('the r:id insertion is NOT wrapped — the fixture ships an empty rels so rId99 has no relationship to merge, and a dangling r:id would corrupt the package (the real-rels case below DOES wrap and ship the relationship — #376)', () => {
       expect(relIdXml).not.toContain('rId99');
       expect(relIdXml).toContain('brand-new.example.com');
+    });
+  });
+});
+
+/**
+ * Faithful retarget representation (issue #376): when packages declare real
+ * hyperlink relationships, a changed link target compares as delete-old-link +
+ * insert-new-link, and rebuild output ships a resolvable relationship for the
+ * inserted/retargeted link. Every r:id in the output must resolve.
+ */
+describe('Retargeted / inserted hyperlinks ship a resolvable relationship', () => {
+  const linkPara = (id: string, text: string) =>
+    `<w:p><w:r><w:t xml:space="preserve">See </w:t></w:r>` +
+    `<w:hyperlink xmlns:r="${R_NS}" r:id="${id}"><w:r><w:t>${text}</w:t></w:r></w:hyperlink></w:p>`;
+
+  async function rebuildWithRels(
+    originalBody: string,
+    originalRels: Array<{ id: string; target: string }>,
+    revisedBody: string,
+    revisedRels: Array<{ id: string; target: string }>,
+  ): Promise<{ documentXml: string; relsXml: string }> {
+    const original = await buildDocxFromBodyXml(originalBody, originalRels);
+    const revised = await buildDocxFromBodyXml(revisedBody, revisedRels);
+    const result = await compareDocumentsAtomizer(original, revised, {
+      author: 'Hyperlink Test',
+      date: new Date('2026-06-10T00:00:00Z'),
+      reconstructionMode: 'rebuild',
+    });
+    expect(result.reconstructionModeUsed).toBe('rebuild');
+    const archive = await DocxArchive.load(result.document);
+    const documentXml = await archive.getDocumentXml();
+    const relsXml = (await archive.getFile('word/_rels/document.xml.rels')) ?? '';
+    return { documentXml, relsXml };
+  }
+
+  /** Resolve an r:id to its rels Target, or null when unresolvable. */
+  function relTarget(relsXml: string, id: string): string | null {
+    const re = new RegExp(`<Relationship\\b[^>]*\\bId="${id}"[^>]*\\bTarget="([^"]*)"`);
+    return re.exec(relsXml)?.[1] ?? null;
+  }
+
+  /** Assert every w:hyperlink r:id in the XML resolves against the rels part. */
+  function expectNoDanglingHyperlinkRids(xml: string, relsXml: string): void {
+    const re = /<w:hyperlink[^>]*\br:id="(rId\d+)"/g;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(xml)) !== null) {
+      expect(relTarget(relsXml, m[1]!)).not.toBeNull();
+    }
+  }
+
+  test('an in-place retarget (same r:id, new target) becomes delete-old-link + insert-new-link, each with a resolvable relationship', async ({ given, when, then, and }: AllureBddContext) => {
+    let documentXml: string;
+    let relsXml: string;
+
+    await given('the link keeps r:id="rId7" but its rels Target changes from alpha to beta — Word\'s in-place target edit', () => {});
+
+    await when('compared with reconstructionMode rebuild', async () => {
+      ({ documentXml, relsXml } = await rebuildWithRels(
+        linkPara('rId7', 'alpha target'),
+        [{ id: 'rId7', target: 'https://alpha.example.com' }],
+        linkPara('rId7', 'beta target'),
+        [{ id: 'rId7', target: 'https://beta.example.com' }],
+      ));
+    });
+
+    await then('the deleted old link and inserted new link sit in SEPARATE wrappers, both resolvable', () => {
+      expect(documentXml).toMatch(
+        /<w:hyperlink[^>]*r:id="rId7"[^>]*><w:del[\s\S]*?alpha target[\s\S]*?<\/w:del><\/w:hyperlink>/,
+      );
+      const insMatch = /<w:hyperlink[^>]*r:id="(rId\d+)"[^>]*><w:ins[\s\S]*?beta target[\s\S]*?<\/w:ins><\/w:hyperlink>/.exec(documentXml);
+      expect(insMatch).not.toBeNull();
+      const insId = insMatch![1]!;
+      expect(insId).not.toBe('rId7');
+      expect(relTarget(relsXml, 'rId7')).toBe('https://alpha.example.com');
+      expect(relTarget(relsXml, insId)).toBe('https://beta.example.com');
+      expectNoDanglingHyperlinkRids(documentXml, relsXml);
+    });
+
+    await and('accept yields the new link only and reject the old link only', () => {
+      const accepted = acceptAllChanges(documentXml);
+      const rejected = rejectAllChanges(documentXml);
+
+      const acceptId = /<w:hyperlink[^>]*r:id="(rId\d+)"[^>]*>[\s\S]*?beta target[\s\S]*?<\/w:hyperlink>/.exec(accepted)?.[1];
+      expect(acceptId).toBeDefined();
+      expect(relTarget(relsXml, acceptId!)).toBe('https://beta.example.com');
+      expect(accepted).not.toContain('alpha');
+
+      expect(rejected).toMatch(/<w:hyperlink[^>]*r:id="rId7"[^>]*>[\s\S]*?alpha target[\s\S]*?<\/w:hyperlink>/);
+      expect(relTarget(relsXml, 'rId7')).toBe('https://alpha.example.com');
+      expect(rejected).not.toContain('beta');
+    });
+  });
+
+  test('a retarget to a fresh r:id allocates a collision-free relationship id in the original-based package', async ({ given, when, then }: AllureBddContext) => {
+    let documentXml: string;
+    let relsXml: string;
+
+    await given('original links via rId7 and revised via a brand-new rId99', () => {});
+
+    await when('compared with reconstructionMode rebuild', async () => {
+      ({ documentXml, relsXml } = await rebuildWithRels(
+        linkPara('rId7', 'alpha target'),
+        [{ id: 'rId7', target: 'https://alpha.example.com' }],
+        linkPara('rId99', 'beta target'),
+        [{ id: 'rId99', target: 'https://beta.example.com' }],
+      ));
+    });
+
+    await then('the inserted link ships a freshly-allocated id (not rId99, which never existed in the base) resolving to beta, with no dangling references', () => {
+      const insId = /<w:hyperlink[^>]*r:id="(rId\d+)"[^>]*><w:ins[\s\S]*?beta target[\s\S]*?<\/w:ins><\/w:hyperlink>/.exec(documentXml)?.[1];
+      expect(insId).toBeDefined();
+      expect(relTarget(relsXml, insId!)).toBe('https://beta.example.com');
+      expect(relTarget(relsXml, 'rId7')).toBe('https://alpha.example.com');
+      expectNoDanglingHyperlinkRids(documentXml, relsXml);
+    });
+  });
+
+  test('a bare r:id reshuffle (same URL, new id) stays Equal — no spurious delete/insert', async ({ given, when, then }: AllureBddContext) => {
+    let documentXml: string;
+    let relsXml: string;
+
+    await given('the link text and destination are identical; only the relationship id differs (rId7 -> rId3)', () => {});
+
+    await when('compared with reconstructionMode rebuild', async () => {
+      ({ documentXml, relsXml } = await rebuildWithRels(
+        linkPara('rId7', 'alpha target'),
+        [{ id: 'rId7', target: 'https://alpha.example.com' }],
+        linkPara('rId3', 'alpha target'),
+        [{ id: 'rId3', target: 'https://alpha.example.com' }],
+      ));
+    });
+
+    await then('the link survives whole with no revision markup, resolving to the unchanged target', () => {
+      expect(documentXml).not.toContain('<w:del');
+      expect(documentXml).not.toContain('<w:ins');
+      expect(documentXml).toMatch(/<w:hyperlink[^>]*r:id="rId7"[^>]*>[\s\S]*?alpha target[\s\S]*?<\/w:hyperlink>/);
+      expect(relTarget(relsXml, 'rId7')).toBe('https://alpha.example.com');
+      expectNoDanglingHyperlinkRids(documentXml, relsXml);
+    });
+  });
+
+  test('a purely inserted r:id hyperlink is wrapped and its relationship shipped when the revised package declares it', async ({ given, when, then, and }: AllureBddContext) => {
+    let documentXml: string;
+    let relsXml: string;
+
+    await given('a revision that adds a new hyperlink paragraph whose r:id has a real relationship', () => {});
+
+    await when('compared with reconstructionMode rebuild', async () => {
+      const base = `<w:p><w:r><w:t>Existing text</w:t></w:r></w:p>`;
+      ({ documentXml, relsXml } = await rebuildWithRels(
+        base,
+        [],
+        base + linkPara('rId5', 'brand-new.example.com'),
+        [{ id: 'rId5', target: 'https://brand-new.example.com' }],
+      ));
+    });
+
+    await then('the insertion is wrapped in a hyperlink whose id resolves to the new target', () => {
+      const insId = /<w:hyperlink[^>]*r:id="(rId\d+)"[^>]*><w:ins[\s\S]*?brand-new\.example\.com[\s\S]*?<\/w:ins><\/w:hyperlink>/.exec(documentXml)?.[1];
+      expect(insId).toBeDefined();
+      expect(relTarget(relsXml, insId!)).toBe('https://brand-new.example.com');
+      expectNoDanglingHyperlinkRids(documentXml, relsXml);
+    });
+
+    await and('accepting keeps the wrapped link and rejecting drops it entirely', () => {
+      const accepted = acceptAllChanges(documentXml);
+      const rejected = rejectAllChanges(documentXml);
+      expect(accepted).toMatch(/<w:hyperlink[^>]*>[\s\S]*?brand-new\.example\.com[\s\S]*?<\/w:hyperlink>/);
+      expect(rejected).not.toContain('brand-new.example.com');
+    });
+  });
+
+  test('a shipped Target with XML-sensitive characters is escaped and round-trips', async ({ given, when, then }: AllureBddContext) => {
+    let relsXml: string;
+    const url = 'https://ex.com/search?a=1&b=2&tag=<x>';
+
+    await given('a retarget whose new URL contains & and < >', () => {});
+
+    await when('compared with reconstructionMode rebuild', async () => {
+      ({ relsXml } = await rebuildWithRels(
+        linkPara('rId7', 'alpha'),
+        [{ id: 'rId7', target: 'https://alpha.example.com' }],
+        linkPara('rId7', 'beta'),
+        [{ id: 'rId7', target: url }],
+      ));
+    });
+
+    await then('the appended relationship is well-formed (escaped) and parses back to the exact URL', () => {
+      expect(relsXml).toContain('&amp;');
+      expect(relsXml).not.toMatch(/Target="[^"]*<x>/);
+      // Parsing the rels and reading the Target attribute yields the raw URL.
+      const doc = parseXml(relsXml);
+      const rels = doc.getElementsByTagName('Relationship');
+      const targets = Array.from({ length: rels.length }, (_, i) => rels.item(i)!.getAttribute('Target'));
+      expect(targets).toContain(url);
     });
   });
 });

--- a/packages/docx-core/src/baselines/atomizer/documentReconstructor.ts
+++ b/packages/docx-core/src/baselines/atomizer/documentReconstructor.ts
@@ -47,11 +47,43 @@ function createEl(tag: string, attrs?: Record<string, string>): Element {
 /**
  * Options for document reconstruction.
  */
+/**
+ * Resolves an inserted/retargeted link's revised-side r:id to one that will
+ * actually resolve in the rebuild output package (which is cloned from the
+ * ORIGINAL archive, so revised-only r:ids dangle without help).
+ *
+ * Returns the id to emit — either an existing original id that already points
+ * at the same destination, or a freshly-allocated, collision-free id whose
+ * relationship the pipeline ships into document.xml.rels — or null when the
+ * destination can't be shipped (no revised relationship for that r:id), in
+ * which case the caller emits the content unwrapped (pre-#376 behavior).
+ *
+ * @see https://github.com/UseJunior/safe-docx/issues/376
+ */
+export interface HyperlinkRelResolver {
+  /**
+   * A stable key for a hyperlink's *resolved destination* (r:id resolved to its
+   * target URL via the correct side's rels, folded with any w:anchor), used to
+   * group atoms into wrappers. Two links with the same destination share a
+   * wrapper even if their raw r:id differs; a retarget that reuses the same
+   * r:id for a new target gets two wrappers, so inserted text never inherits
+   * the stale target. `fromOriginal` selects which side's rels resolves r:id.
+   */
+  destinationKey(element: Element, fromOriginal: boolean): string;
+  resolveRevisedOnlyRid(revisedRid: string): string | null;
+}
+
 export interface ReconstructorOptions {
   /** Author name for track changes */
   author: string;
   /** Timestamp for track changes */
   date: Date;
+  /**
+   * Rebuild-only: makes revised-only hyperlink r:ids shippable (issue #376).
+   * Absent in inplace mode, where the revised archive is the base and its
+   * r:ids already resolve.
+   */
+  hyperlinkRelResolver?: HyperlinkRelResolver;
 }
 
 /**
@@ -105,7 +137,9 @@ export function reconstructDocument(
   const paragraphXmls: string[] = [];
 
   for (const group of paragraphGroups) {
-    const paragraphXml = buildParagraphXml(group, author, dateStr, revState);
+    const paragraphXml = buildParagraphXml(
+      group, author, dateStr, revState, options.hyperlinkRelResolver
+    );
     paragraphXmls.push(paragraphXml);
   }
 
@@ -601,7 +635,8 @@ function buildParagraphXml(
   group: ParagraphGroup,
   author: string,
   dateStr: string,
-  revState: RevisionIdState
+  revState: RevisionIdState,
+  hyperlinkRelResolver?: HyperlinkRelResolver
 ): string {
   const revisionCtx = createRevisionContext({ author, date: dateStr, idState: revState });
 
@@ -643,7 +678,7 @@ function buildParagraphXml(
     const paraId = allocateRevisionId(revState);
     const insertedRunXml = paragraphHasHyperlinkAtoms(group)
       ? buildWholeParagraphRevisionContent(group, (runs) =>
-          wrapSerializedContentWithIns(runs, revisionCtx))
+          wrapSerializedContentWithIns(runs, revisionCtx), undefined, hyperlinkRelResolver)
       : wrapSerializedContentWithIns(
           group.runGroups.map((runGroup) => buildRunContentAsPlainRun(runGroup)).join(''),
           revisionCtx,
@@ -679,6 +714,7 @@ function buildParagraphXml(
           hasInsProvenance
             ? (wrapped, prov) => wrapWithIns(wrapped, prov.author, prov.date || dateStr, revState)
             : undefined,
+          hyperlinkRelResolver,
         )
       );
     } else if (hasInsProvenance) {
@@ -752,7 +788,9 @@ function buildParagraphXml(
   // paragraphs keep the legacy per-group emission byte-identical.
   const explicitMoveMarkers = collectExplicitMoveMarkers(group);
   if (paragraphHasHyperlinkAtoms(group)) {
-    parts.push(buildRunGroupsWithHyperlinks(group.runGroups, author, dateStr, revState, explicitMoveMarkers));
+    parts.push(buildRunGroupsWithHyperlinks(
+      group.runGroups, author, dateStr, revState, explicitMoveMarkers, hyperlinkRelResolver
+    ));
   } else {
     for (const runGroup of group.runGroups) {
       const runXml = buildRunGroupXml(runGroup, author, dateStr, revState, explicitMoveMarkers);
@@ -1160,43 +1198,66 @@ function hyperlinkKey(el: Element): string {
  * @conformance ECMA-376 edition 5, Part 1 § 17.16.22
  * @see https://github.com/UseJunior/safe-docx/issues/368
  */
-function resolveHyperlinkForAtom(atom: ComparisonUnitAtom): ResolvedHyperlink | null {
+function resolveHyperlinkForAtom(
+  atom: ComparisonUnitAtom,
+  resolver: HyperlinkRelResolver | undefined
+): ResolvedHyperlink | null {
   const own = nearestHyperlinkAncestor(atom);
   if (!own) return null;
+  // The grouping key is the resolved destination when a resolver is available
+  // (rebuild), falling back to the raw attribute fingerprint otherwise. Keying
+  // by destination is what keeps a same-r:id retarget in two wrappers while a
+  // bare id reshuffle (same URL) still collapses to one.
+  const keyFor = (el: Element, fromOriginal: boolean): string =>
+    resolver ? resolver.destinationKey(el, fromOriginal) : hyperlinkKey(el);
+
   if (atom.sourceDocument === 'original') {
-    return { element: own, key: hyperlinkKey(own), fromOriginal: true };
+    return { element: own, key: keyFor(own, true), fromOriginal: true };
   }
   const before = atom.comparisonUnitAtomBefore;
   const beforeHyperlink = before ? nearestHyperlinkAncestor(before) : null;
-  // Attribute to the original wrapper only when both trees agree on the
-  // hyperlink's attributes. When they differ (e.g. the revision retargeted
-  // the link to a new r:id), emitting the original wrapper would pin the
-  // still-equal link text to the STALE target in the accepted document —
-  // worse than dropping the wrapper. Such atoms fall through to the
-  // revised-only policy below instead.
-  // TODO(#376): the faithful tracked representation of a retargeted link
-  // is delete-old-link + insert-new-link (what Word emits), which needs the
-  // hyperlink fingerprint in atom identity so the LCS stops matching text
-  // across different link targets.
-  if (beforeHyperlink && hyperlinkKey(beforeHyperlink) === hyperlinkKey(own)) {
-    return { element: beforeHyperlink, key: hyperlinkKey(beforeHyperlink), fromOriginal: true };
+  // An equal revised atom attributes to the original wrapper when both sides
+  // resolve to the same destination — then the original wrapper's r:id is
+  // guaranteed to resolve in the original-based package. A bare r:id reshuffle
+  // (same URL, new id) still matches here; a retarget does not.
+  if (
+    beforeHyperlink &&
+    keyFor(beforeHyperlink, true) === keyFor(own, false)
+  ) {
+    return { element: beforeHyperlink, key: keyFor(beforeHyperlink, true), fromOriginal: true };
   }
-  // Revised-only attribution (purely inserted hyperlink). Emitting its r:id
-  // would dangle against the original-based package, so the caller only
-  // wraps when the hyperlink carries no relationship reference (anchor-only).
-  return { element: own, key: hyperlinkKey(own), fromOriginal: false };
+  // Revised-only attribution: a purely inserted hyperlink, or the insert half
+  // of a retarget (delete-old-link + insert-new-link). Its revised r:id would
+  // dangle against the original-based package, so the caller re-maps it through
+  // the HyperlinkRelResolver (shipping a merged relationship) and drops the
+  // wrapper only when the destination can't be shipped (issue #376).
+  return { element: own, key: keyFor(own, false), fromOriginal: false };
 }
 
 /**
- * Whether a resolved hyperlink is safe to re-emit. Original-attributed
- * wrappers always are; revised-only wrappers are safe only without an r:id
- * (internal anchor links), because the rebuild package ships the ORIGINAL
- * document.xml.rels and a revised-only r:id would be a dangling reference
- * (Word treats those as a corrupt package). Revised-only r:id hyperlinks
- * keep today's behavior — content emitted unwrapped.
+ * Compute the opening `<w:hyperlink …>` tag to emit for a resolved wrapper, or
+ * null when the wrapper must be dropped and its content emitted unwrapped.
+ *
+ * Original-attributed wrappers and anchor-only revised wrappers emit verbatim.
+ * A revised-only r:id wrapper is emitted only when `resolver` maps its r:id to
+ * one that resolves in the rebuild package (the mapped id replaces r:id in the
+ * tag); without a resolver or a shippable target the wrapper is dropped,
+ * preserving the pre-#376 behavior (rebuild ships the ORIGINAL
+ * document.xml.rels, so an un-merged revised-only r:id would dangle and Word
+ * treats that as a corrupt package).
+ *
+ * @see https://github.com/UseJunior/safe-docx/issues/376
  */
-function isEmittableHyperlink(resolved: ResolvedHyperlink): boolean {
-  return resolved.fromOriginal || resolved.element.getAttribute('r:id') === null;
+function emitHyperlinkOpenTag(
+  resolved: ResolvedHyperlink,
+  resolver: HyperlinkRelResolver | undefined
+): string | null {
+  if (resolved.fromOriginal) return serializeHyperlinkOpenTag(resolved.element);
+  const rid = resolved.element.getAttribute('r:id');
+  if (rid === null) return serializeHyperlinkOpenTag(resolved.element);
+  const mappedRid = resolver?.resolveRevisedOnlyRid(rid) ?? null;
+  if (mappedRid === null) return null;
+  return serializeHyperlinkOpenTag(resolved.element, mappedRid);
 }
 
 /**
@@ -1226,7 +1287,10 @@ interface HyperlinkSegment {
  * moveFromRangeStart/End once per slice, corrupting the move ranges. A move
  * spanning a hyperlink keeps today's unwrapped emission.
  */
-function splitRunGroupByHyperlink(group: RunGroup): HyperlinkSegment[] {
+function splitRunGroupByHyperlink(
+  group: RunGroup,
+  resolver: HyperlinkRelResolver | undefined
+): HyperlinkSegment[] {
   if (
     group.status === CorrelationStatus.MovedSource ||
     group.status === CorrelationStatus.MovedDestination
@@ -1241,7 +1305,7 @@ function splitRunGroupByHyperlink(group: RunGroup): HyperlinkSegment[] {
     // Emit-ability is decided per merged bucket, not per atom: an inserted
     // atom inside an otherwise-original hyperlink folds into the adjacent
     // original-attributed bucket via the shared key.
-    const resolved = resolveHyperlinkForAtom(atom);
+    const resolved = resolveHyperlinkForAtom(atom, resolver);
     const key = resolved?.key ?? null;
 
     if (current && (current.hyperlink?.key ?? null) === key) {
@@ -1264,14 +1328,19 @@ function splitRunGroupByHyperlink(group: RunGroup): HyperlinkSegment[] {
 
 /**
  * Serialize the opening tag of a re-emitted w:hyperlink wrapper, copying the
- * source element's attributes verbatim (r:id, w:anchor, w:history, ...).
+ * source element's attributes verbatim (r:id, w:anchor, w:history, ...). When
+ * `ridOverride` is given, the r:id value is replaced in place (position
+ * preserved) so a retargeted/inserted link can point at a merged-in
+ * relationship id (issue #376).
  */
-function serializeHyperlinkOpenTag(el: Element): string {
+function serializeHyperlinkOpenTag(el: Element, ridOverride?: string): string {
   const attrs: string[] = [];
   for (let i = 0; i < el.attributes.length; i++) {
     const attr = el.attributes.item(i)!;
     if (attr.name.startsWith('xmlns')) continue;
-    attrs.push(` ${attr.name}="${escapeXmlAttr(attr.value)}"`);
+    const value =
+      attr.name === 'r:id' && ridOverride !== undefined ? ridOverride : attr.value;
+    attrs.push(` ${attr.name}="${escapeXmlAttr(value)}"`);
   }
   return `<w:hyperlink${attrs.join('')}>`;
 }
@@ -1313,10 +1382,11 @@ function buildRunGroupsWithHyperlinks(
   author: string,
   dateStr: string,
   revState: RevisionIdState,
-  explicitMoveMarkers: ExplicitMoveMarkers = NO_EXPLICIT_MOVE_MARKERS
+  explicitMoveMarkers: ExplicitMoveMarkers = NO_EXPLICIT_MOVE_MARKERS,
+  hyperlinkRelResolver?: HyperlinkRelResolver
 ): string {
   const buckets = mergeAdjacentHyperlinkSegments(
-    runGroups.flatMap(splitRunGroupByHyperlink)
+    runGroups.flatMap((g) => splitRunGroupByHyperlink(g, hyperlinkRelResolver))
   );
 
   const parts: string[] = [];
@@ -1325,11 +1395,10 @@ function buildRunGroupsWithHyperlinks(
       .map((g) => buildRunGroupXml(g, author, dateStr, revState, explicitMoveMarkers))
       .join('');
     if (!content) continue;
-    parts.push(
-      bucket.hyperlink && isEmittableHyperlink(bucket.hyperlink)
-        ? `${serializeHyperlinkOpenTag(bucket.hyperlink.element)}${content}</w:hyperlink>`
-        : content
-    );
+    const openTag = bucket.hyperlink
+      ? emitHyperlinkOpenTag(bucket.hyperlink, hyperlinkRelResolver)
+      : null;
+    parts.push(openTag ? `${openTag}${content}</w:hyperlink>` : content);
   }
   return parts.join('');
 }
@@ -1349,10 +1418,11 @@ function buildRunGroupsWithHyperlinks(
 function buildWholeParagraphRevisionContent(
   group: ParagraphGroup,
   wrap: (content: string) => string,
-  provWrap?: (wrappedContent: string, prov: InsProvenance) => string
+  provWrap?: (wrappedContent: string, prov: InsProvenance) => string,
+  hyperlinkRelResolver?: HyperlinkRelResolver
 ): string {
   const buckets = mergeAdjacentHyperlinkSegments(
-    group.runGroups.flatMap(splitRunGroupByHyperlink)
+    group.runGroups.flatMap((g) => splitRunGroupByHyperlink(g, hyperlinkRelResolver))
   );
 
   const parts: string[] = [];
@@ -1387,11 +1457,10 @@ function buildWholeParagraphRevisionContent(
       wrapped = wrap(runs);
     }
 
-    parts.push(
-      bucket.hyperlink && isEmittableHyperlink(bucket.hyperlink)
-        ? `${serializeHyperlinkOpenTag(bucket.hyperlink.element)}${wrapped}</w:hyperlink>`
-        : wrapped
-    );
+    const openTag = bucket.hyperlink
+      ? emitHyperlinkOpenTag(bucket.hyperlink, hyperlinkRelResolver)
+      : null;
+    parts.push(openTag ? `${openTag}${wrapped}</w:hyperlink>` : wrapped);
   }
   return parts.join('');
 }

--- a/packages/docx-core/src/baselines/atomizer/pipeline.ts
+++ b/packages/docx-core/src/baselines/atomizer/pipeline.ts
@@ -39,7 +39,14 @@ import {
   DEFAULT_FORMAT_DETECTION_SETTINGS,
   CorrelationStatus,
 } from '../../core-types.js';
-import { atomizeTree, assignParagraphIndices } from '../../atomizer.js';
+import { atomizeTree, assignParagraphIndices, applyHyperlinkDestinationSalt } from '../../atomizer.js';
+import {
+  parseHyperlinkRelTargets,
+  parseHyperlinkRelEntries,
+  listRelationshipIds,
+  type HyperlinkRelEntry,
+} from '../../primitives/relationships.js';
+import { OOXML } from '../../primitives/namespaces.js';
 import { detectMovesInAtomList } from '../../move-detection.js';
 import { detectFormatChangesInAtomList } from '../../format-detection.js';
 import {
@@ -58,6 +65,7 @@ import {
 } from './hierarchicalLcs.js';
 import {
   reconstructDocument,
+  type HyperlinkRelResolver,
   computeReconstructionStats,
 } from './documentReconstructor.js';
 import { modifyRevisedDocument, ContainerResolutionError } from './inPlaceModifier.js';
@@ -610,6 +618,19 @@ export async function compareDocumentsAtomizer(
   const originalNumberingXml = await originalArchive.getNumberingXml() ?? undefined;
   const revisedNumberingXml = await revisedArchive.getNumberingXml() ?? undefined;
 
+  // Extract hyperlink relationship tables from BOTH archives (issue #376).
+  // The salt uses these to hash a link's resolved destination (so retargeting
+  // becomes delete-old-link + insert-new-link); step 12 uses them to ship a
+  // resolvable relationship for any inserted/retargeted link in rebuild output.
+  const [originalRelsRaw, revisedRelsRaw] = await Promise.all([
+    originalArchive.getFile('word/_rels/document.xml.rels'),
+    revisedArchive.getFile('word/_rels/document.xml.rels'),
+  ]);
+  const originalRelsDoc = originalRelsRaw ? parseXml(originalRelsRaw) : null;
+  const revisedRelsDoc = revisedRelsRaw ? parseXml(revisedRelsRaw) : null;
+  const originalHyperlinkTargets = parseHyperlinkRelTargets(originalRelsDoc);
+  const revisedHyperlinkTargets = parseHyperlinkRelTargets(revisedRelsDoc);
+
   // Extract footnote/endnote sidecars from BOTH archives for per-story
   // field-closure validation (issue #212). Step 12 picks the base archive by
   // reconstruction mode (inplace = revised, rebuild = original) and merges
@@ -659,6 +680,7 @@ export async function compareDocumentsAtomizer(
     mergedAtoms: ComparisonUnitAtom[];
     newDocumentXml: string;
     outputMode: ReconstructionMode;
+    hyperlinkRelationships: NewHyperlinkRel[];
   } => {
     // Parse fresh trees for each pass because inplace reconstruction mutates revised AST.
     const originalTree = parseDocumentXml(originalXml);
@@ -690,6 +712,12 @@ export async function compareDocumentsAtomizer(
       virtualizeNumberingLabels(revisedAtoms, revisedNumberingXml, numberingSettings);
     }
 
+    // Step 5b: Salt atom identity with each side's resolved hyperlink target so
+    // the LCS represents a retargeted link as delete-old-link + insert-new-link
+    // instead of matching its text across different destinations (issue #376).
+    applyHyperlinkDestinationSalt(originalAtoms, originalHyperlinkTargets);
+    applyHyperlinkDestinationSalt(revisedAtoms, revisedHyperlinkTargets);
+
     // Step 6: Run hierarchical LCS (paragraph-level first, then atom-level within)
     const lcsResult = hierarchicalCompare(originalAtoms, revisedAtoms);
 
@@ -719,6 +747,7 @@ export async function compareDocumentsAtomizer(
 
     // Step 11: Reconstruct document with track changes
     let newDocumentXml: string;
+    let hyperlinkRelationships: NewHyperlinkRel[] = [];
     if (outputMode === 'inplace') {
       // In-place mode: modify the revised AST directly, producing revised-based output.
       newDocumentXml = modifyRevisedDocument(
@@ -730,10 +759,18 @@ export async function compareDocumentsAtomizer(
       );
     } else {
       // Rebuild mode: reconstruct from atoms using original as the structural base.
-      newDocumentXml = reconstructDocument(mergedAtoms, originalXml, { author, date });
+      // Ship a resolvable relationship for any inserted/retargeted link whose
+      // r:id lives only in the revised package (issue #376).
+      const { resolver, newRelationships } = createRebuildHyperlinkRelResolver(
+        originalRelsDoc, revisedRelsDoc
+      );
+      newDocumentXml = reconstructDocument(mergedAtoms, originalXml, {
+        author, date, hyperlinkRelResolver: resolver,
+      });
+      hyperlinkRelationships = newRelationships;
     }
 
-    return { mergedAtoms, newDocumentXml, outputMode };
+    return { mergedAtoms, newDocumentXml, outputMode, hyperlinkRelationships };
   };
 
   const evaluateRoundTripSafety = (candidateXml: string) =>
@@ -750,6 +787,7 @@ export async function compareDocumentsAtomizer(
     mergedAtoms: ComparisonUnitAtom[];
     newDocumentXml: string;
     outputMode: ReconstructionMode;
+    hyperlinkRelationships: NewHyperlinkRel[];
   };
   let fallbackReason: ReconstructionFallbackReason | undefined;
   let fallbackDiagnostics: ReconstructionFallbackDiagnostics | undefined;
@@ -887,6 +925,10 @@ export async function compareDocumentsAtomizer(
   const resultArchive = await baseArchive.clone();
   maybeCaptureEmittedDocumentXml(newDocumentXml);
   resultArchive.setDocumentXml(newDocumentXml);
+
+  // Step 12a: Ship relationships for inserted/retargeted hyperlinks whose r:id
+  // the rebuild reconstructor re-mapped into the original-based package (#376).
+  await appendHyperlinkRelationships(resultArchive, comparisonResult.hyperlinkRelationships);
 
   // Step 12b: Merge auxiliary part definitions (footnotes, endnotes, comments).
   // Reconstruction may insert content (deleted in inplace, added in rebuild)
@@ -1135,6 +1177,140 @@ async function ensureOpcMetadata(
       archive.setFile(relsPath, serializer.serializeToString(relsDoc));
     }
   }
+}
+
+// =============================================================================
+// Hyperlink Relationship Merging (issue #376)
+//
+// Rebuild output is cloned from the ORIGINAL archive, so a hyperlink inserted
+// or retargeted by the revision references an r:id that resolves only in the
+// REVISED package. These helpers ship the revised destination into the output's
+// document.xml.rels — reusing an original relationship that already points at
+// the same target, or allocating a fresh collision-free id — mirroring the
+// copy-if-missing convention used for auxiliary parts (issue #94).
+// =============================================================================
+
+/** A hyperlink relationship to append to the rebuild output's rels part. */
+interface NewHyperlinkRel {
+  id: string;
+  target: string;
+  external: boolean;
+}
+
+/** Destination identity that folds in the target mode (external vs internal). */
+function hyperlinkDestKey(entry: HyperlinkRelEntry): string {
+  return `${entry.external ? 'ext' : 'int'}:${entry.target}`;
+}
+
+/** Highest numeric `rIdN` among a set of relationship ids (0 when none). */
+function maxNumericRelId(ids: Set<string>): number {
+  let max = 0;
+  for (const id of ids) {
+    const m = /^rId(\d+)$/.exec(id);
+    if (m) max = Math.max(max, parseInt(m[1]!, 10));
+  }
+  return max;
+}
+
+/**
+ * Build the HyperlinkRelResolver for rebuild output. `resolveRevisedOnlyRid`
+ * maps a revised-only hyperlink r:id to one that resolves in the output
+ * package, recording any freshly-allocated relationship in `newRelationships`
+ * for the pipeline to append. Returns null when the revised side has no
+ * shippable relationship for that r:id (the wrapper is then dropped).
+ */
+function createRebuildHyperlinkRelResolver(
+  originalRelsDoc: Document | null,
+  revisedRelsDoc: Document | null,
+): { resolver: HyperlinkRelResolver; newRelationships: NewHyperlinkRel[] } {
+  const originalEntries = parseHyperlinkRelEntries(originalRelsDoc);
+  const revisedEntries = parseHyperlinkRelEntries(revisedRelsDoc);
+  const existingIds = listRelationshipIds(originalRelsDoc);
+
+  const originalIdByDest = new Map<string, string>();
+  for (const [id, entry] of originalEntries) {
+    if (!originalIdByDest.has(hyperlinkDestKey(entry))) {
+      originalIdByDest.set(hyperlinkDestKey(entry), id);
+    }
+  }
+
+  const newRelationships: NewHyperlinkRel[] = [];
+  const allocatedIdByDest = new Map<string, string>();
+  const resultByRid = new Map<string, string | null>();
+  let maxId = maxNumericRelId(existingIds);
+
+  const resolver: HyperlinkRelResolver = {
+    destinationKey(element, fromOriginal): string {
+      const rid = element.getAttribute('r:id');
+      const anchor = element.getAttribute('w:anchor');
+      const parts: string[] = [];
+      if (rid) {
+        const entry = (fromOriginal ? originalEntries : revisedEntries).get(rid);
+        parts.push(`rel=${entry ? hyperlinkDestKey(entry) : `unresolved:${rid}`}`);
+      }
+      if (anchor) parts.push(`anchor=${anchor}`);
+      // Attribute-less wrapper: fall back to identity so distinct empty
+      // wrappers never accidentally merge.
+      return parts.length > 0 ? parts.join('|') : `wrapper:${fromOriginal ? 'o' : 'r'}`;
+    },
+    resolveRevisedOnlyRid(revisedRid: string): string | null {
+      const cached = resultByRid.get(revisedRid);
+      if (cached !== undefined) return cached;
+
+      const entry = revisedEntries.get(revisedRid);
+      let result: string | null;
+      if (!entry) {
+        result = null;
+      } else {
+        const key = hyperlinkDestKey(entry);
+        const reused = originalIdByDest.get(key) ?? allocatedIdByDest.get(key);
+        if (reused) {
+          result = reused;
+        } else {
+          let id: string;
+          do {
+            id = `rId${++maxId}`;
+          } while (existingIds.has(id));
+          allocatedIdByDest.set(key, id);
+          newRelationships.push({ id, target: entry.target, external: entry.external });
+          result = id;
+        }
+      }
+      resultByRid.set(revisedRid, result);
+      return result;
+    },
+  };
+
+  return { resolver, newRelationships };
+}
+
+/**
+ * Append merged-in hyperlink relationships to the result package's
+ * document.xml.rels. No-op when there are none.
+ */
+async function appendHyperlinkRelationships(
+  archive: DocxArchive,
+  relationships: NewHyperlinkRel[],
+): Promise<void> {
+  if (relationships.length === 0) return;
+  const relsPath = 'word/_rels/document.xml.rels';
+  const relsXml = await archive.getFile(relsPath);
+  const relsDoc = relsXml
+    ? parseXml(relsXml)
+    : parseXml(
+        `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+        `<Relationships xmlns="${REL_NS}"></Relationships>`,
+      );
+  const relsEl = relsDoc.documentElement;
+  for (const rel of relationships) {
+    const el = relsDoc.createElementNS(REL_NS, 'Relationship');
+    el.setAttribute('Id', rel.id);
+    el.setAttribute('Type', OOXML.HYPERLINK_REL_TYPE);
+    el.setAttribute('Target', rel.target);
+    if (rel.external) el.setAttribute('TargetMode', 'External');
+    relsEl.appendChild(el);
+  }
+  archive.setFile(relsPath, serializer.serializeToString(relsDoc));
 }
 
 // =============================================================================

--- a/packages/docx-core/src/primitives/relationships.test.ts
+++ b/packages/docx-core/src/primitives/relationships.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect } from 'vitest';
+import { testAllure } from '../testing/allure-test.js';
+import { parseXml } from './xml.js';
+import {
+  parseDocumentRels,
+  parseHyperlinkRelTargets,
+  parseHyperlinkRelEntries,
+  listRelationshipIds,
+} from './relationships.js';
+
+const test = testAllure.epic('Document Comparison').withLabels({ feature: 'Relationships Parsing' });
+
+const REL_NS = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const HYPERLINK = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink';
+const IMAGE = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/image';
+
+function relsDoc(inner: string): Document {
+  return parseXml(`<Relationships xmlns="${REL_NS}">${inner}</Relationships>`);
+}
+
+describe('document.xml.rels parsing (issue #376 helpers)', () => {
+  const doc = relsDoc(
+    `<Relationship Id="rId1" Type="${HYPERLINK}" Target="https://ext.example.com" TargetMode="External"/>` +
+    `<Relationship Id="rId2" Type="${HYPERLINK}" Target="#anchor-part"/>` +
+    `<Relationship Id="rId3" Type="${IMAGE}" Target="media/image1.png"/>`,
+  );
+
+  test('parseDocumentRels keeps only external hyperlinks', () => {
+    const map = parseDocumentRels(doc);
+    expect(map.get('rId1')).toBe('https://ext.example.com');
+    expect(map.has('rId2')).toBe(false); // internal hyperlink excluded
+    expect(map.has('rId3')).toBe(false); // image excluded
+  });
+
+  test('parseHyperlinkRelTargets covers external AND internal hyperlinks, folding in the mode', () => {
+    const map = parseHyperlinkRelTargets(doc);
+    expect(map.get('rId1')).toBe('External:https://ext.example.com');
+    expect(map.get('rId2')).toBe('Internal:#anchor-part');
+    expect(map.has('rId3')).toBe(false); // non-hyperlink excluded
+  });
+
+  test('parseHyperlinkRelEntries preserves target + external flag', () => {
+    const map = parseHyperlinkRelEntries(doc);
+    expect(map.get('rId1')).toEqual({ target: 'https://ext.example.com', external: true });
+    expect(map.get('rId2')).toEqual({ target: '#anchor-part', external: false });
+    expect(map.has('rId3')).toBe(false);
+  });
+
+  test('listRelationshipIds returns every id regardless of type', () => {
+    expect([...listRelationshipIds(doc)].sort()).toEqual(['rId1', 'rId2', 'rId3']);
+  });
+
+  test('all parsers return empty for a null rels document', () => {
+    expect(parseDocumentRels(null).size).toBe(0);
+    expect(parseHyperlinkRelTargets(null).size).toBe(0);
+    expect(parseHyperlinkRelEntries(null).size).toBe(0);
+    expect(listRelationshipIds(null).size).toBe(0);
+  });
+
+  test('namespace-prefixed Relationship elements are still parsed (not just default-namespace)', () => {
+    // Valid OPC packages may serialize the rels part with a prefix; a plain
+    // getElementsByTagName('Relationship') would miss these and silently drop
+    // every relationship (regressing #376 to unresolved raw r:id).
+    const prefixed = parseXml(
+      `<pr:Relationships xmlns:pr="${REL_NS}">` +
+      `<pr:Relationship Id="rId7" Type="${HYPERLINK}" Target="https://alpha.example.com" TargetMode="External"/>` +
+      `</pr:Relationships>`,
+    );
+    expect(parseHyperlinkRelTargets(prefixed).get('rId7')).toBe('External:https://alpha.example.com');
+    expect(parseHyperlinkRelEntries(prefixed).get('rId7')).toEqual({
+      target: 'https://alpha.example.com',
+      external: true,
+    });
+    expect([...listRelationshipIds(prefixed)]).toEqual(['rId7']);
+    expect(parseDocumentRels(prefixed).get('rId7')).toBe('https://alpha.example.com');
+  });
+});

--- a/packages/docx-core/src/primitives/relationships.ts
+++ b/packages/docx-core/src/primitives/relationships.ts
@@ -4,6 +4,20 @@ import { OOXML } from './namespaces.js';
 
 export type RelsMap = Map<string, string>;
 
+/** OPC package-relationships namespace (parts almost always use it unprefixed). */
+const OPC_RELATIONSHIPS_NS =
+  'http://schemas.openxmlformats.org/package/2006/relationships';
+
+/**
+ * Collect `<Relationship>` elements namespace-aware, matching both the common
+ * default-namespace form and a (valid) prefixed form such as `<pr:Relationship>`.
+ * A raw `getElementsByTagName('Relationship')` would silently miss the prefixed
+ * form; mirrors the namespace-aware lookup the OPC-metadata writer already uses.
+ */
+function relationshipElements(relsDoc: Document): HTMLCollectionOf<Element> {
+  return relsDoc.getElementsByTagNameNS(OPC_RELATIONSHIPS_NS, 'Relationship');
+}
+
 /**
  * Parse a document.xml.rels DOM and return a Map<rId, targetUrl> for external hyperlinks only.
  * Returns an empty map when the rels document is null (e.g. file missing from the DOCX archive).
@@ -12,7 +26,7 @@ export function parseDocumentRels(relsDoc: Document | null): RelsMap {
   const map: RelsMap = new Map();
   if (!relsDoc) return map;
 
-  const relationships = relsDoc.getElementsByTagName('Relationship');
+  const relationships = relationshipElements(relsDoc);
   for (let i = 0; i < relationships.length; i++) {
     const rel = relationships.item(i)!;
     const type = rel.getAttribute('Type');
@@ -25,4 +39,81 @@ export function parseDocumentRels(relsDoc: Document | null): RelsMap {
     }
   }
   return map;
+}
+
+/**
+ * Parse a document.xml.rels DOM into a Map<rId, logicalTarget> covering every
+ * hyperlink relationship — external URLs and internal (same-package) targets
+ * alike. The value folds in the target mode so an external and an internal
+ * relationship that happen to share a target string never collide.
+ *
+ * Used to salt atom identity with a hyperlink's *resolved* destination rather
+ * than its raw r:id: Word keeps the same relationship id when a link's target
+ * is edited in place (only the rels Target changes), so hashing the r:id alone
+ * would miss the retarget.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.22
+ * @see https://github.com/UseJunior/safe-docx/issues/376
+ */
+export function parseHyperlinkRelTargets(relsDoc: Document | null): RelsMap {
+  const map: RelsMap = new Map();
+  if (!relsDoc) return map;
+
+  const relationships = relationshipElements(relsDoc);
+  for (let i = 0; i < relationships.length; i++) {
+    const rel = relationships.item(i)!;
+    if (rel.getAttribute('Type') !== OOXML.HYPERLINK_REL_TYPE) continue;
+    const id = rel.getAttribute('Id');
+    const target = rel.getAttribute('Target');
+    if (!id || !target) continue;
+    // 'External' is the common case; internal hyperlinks omit TargetMode.
+    const mode = rel.getAttribute('TargetMode') ?? 'Internal';
+    map.set(id, `${mode}:${target}`);
+  }
+  return map;
+}
+
+/** A hyperlink relationship's shippable destination. */
+export interface HyperlinkRelEntry {
+  target: string;
+  /** True for `TargetMode="External"` (URLs); false for internal targets. */
+  external: boolean;
+}
+
+/**
+ * Parse hyperlink relationships into structured entries keyed by rId, retaining
+ * the target and its mode so a relationship can be re-emitted verbatim into a
+ * merged package (issue #376, piece 2).
+ */
+export function parseHyperlinkRelEntries(
+  relsDoc: Document | null
+): Map<string, HyperlinkRelEntry> {
+  const map = new Map<string, HyperlinkRelEntry>();
+  if (!relsDoc) return map;
+  const relationships = relationshipElements(relsDoc);
+  for (let i = 0; i < relationships.length; i++) {
+    const rel = relationships.item(i)!;
+    if (rel.getAttribute('Type') !== OOXML.HYPERLINK_REL_TYPE) continue;
+    const id = rel.getAttribute('Id');
+    const target = rel.getAttribute('Target');
+    if (!id || !target) continue;
+    map.set(id, { target, external: rel.getAttribute('TargetMode') === 'External' });
+  }
+  return map;
+}
+
+/**
+ * Collect every relationship id declared in a document.xml.rels DOM, so a
+ * freshly-allocated id can be guaranteed collision-free against ALL existing
+ * relationships (not just hyperlinks). Returns an empty set for a null doc.
+ */
+export function listRelationshipIds(relsDoc: Document | null): Set<string> {
+  const ids = new Set<string>();
+  if (!relsDoc) return ids;
+  const relationships = relationshipElements(relsDoc);
+  for (let i = 0; i < relationships.length; i++) {
+    const id = relationships.item(i)!.getAttribute('Id');
+    if (id) ids.add(id);
+  }
+  return ids;
 }

--- a/packages/docx-core/src/testing/ooxml-fixtures.ts
+++ b/packages/docx-core/src/testing/ooxml-fixtures.ts
@@ -155,8 +155,22 @@ export function WHOLE_FIELD_IN_DEL(
  * Use `buildSyntheticDocx` (in `../integration/synthetic-docx-fixture.ts`)
  * instead when you need paragraph-array input with optional
  * footnote/comment/bookmark scaffolding.
+ *
+ * Pass `hyperlinkRels` to populate `word/_rels/document.xml.rels` with hyperlink
+ * relationships so `r:id` references in the body actually resolve (needed to
+ * exercise link retargeting / relationship merging — issue #376).
  */
-export async function buildDocxFromBodyXml(bodyXml: string): Promise<Buffer> {
+export interface HyperlinkRelFixture {
+  id: string;
+  target: string;
+  /** Defaults to true (external URL); pass false for an internal target. */
+  external?: boolean;
+}
+
+export async function buildDocxFromBodyXml(
+  bodyXml: string,
+  hyperlinkRels: HyperlinkRelFixture[] = [],
+): Promise<Buffer> {
   const documentXml =
     `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
     `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"` +
@@ -179,9 +193,28 @@ export async function buildDocxFromBodyXml(bodyXml: string): Promise<Buffer> {
     `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>` +
     `</Relationships>`;
 
+  const escapeAttr = (value: string): string =>
+    value
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  const hyperlinkRelsXml = hyperlinkRels
+    .map((rel) => {
+      const external = rel.external ?? true;
+      const mode = external ? ` TargetMode="External"` : '';
+      return (
+        `<Relationship Id="${escapeAttr(rel.id)}"` +
+        ` Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink"` +
+        ` Target="${escapeAttr(rel.target)}"${mode}/>`
+      );
+    })
+    .join('');
+
   const docRelsXml =
     `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
     `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+    `${hyperlinkRelsXml}` +
     `</Relationships>`;
 
   const zip = new JSZip();


### PR DESCRIPTION
## What

Fixes #376. When a revision changes a hyperlink's **destination** while some or all of the link text stays identical, the comparison previously matched that text as `Equal` — it had no notion that "same text under a different link target" is a change. Rebuild then either pinned the still-equal text to the **stale** target (the worst outcome) or dropped the wrapper, so accept lost the new link and reject lost the original's link coverage. This was the residual from #368.

Now a retarget compares as **delete-old-link + insert-new-link** (Word's faithful representation), and rebuild ships a resolvable relationship for the inserted link.

## How (two coupled pieces, per the issue)

1. **Destination-salted atom identity** — a single post-atomization pass appends the nearest hyperlink's *resolved destination* (`r:id` → target URL via `document.xml.rels`, folded with any `w:anchor`) to each atom's hash, so the LCS stops matching text across different targets. Resolving the **target** (not the raw `r:id`) is what catches Word's common in-place edit — Word reuses the same `r:id` and only changes the rels `Target`. A bare id reshuffle (same URL, new id) still stays `Equal`, so no spurious del+ins.

2. **Hyperlink relationship merging** — rebuild output is cloned from the original archive, so a revised-only `r:id` would dangle. A `HyperlinkRelResolver` threaded through the reconstructor re-maps each revised-only `r:id` to an output id (reuse an original relationship with the same destination, else allocate a fresh collision-free id) and records the new entries, which the pipeline appends to `document.xml.rels` — copy-if-missing, mirroring the #94 auxiliary-part convention. Wrapper segmentation now keys on the resolved destination, so a same-`r:id` retarget splits into two wrappers instead of pinning the insert to the stale target.

Both projections are faithful: accept carries the full new link, reject restores the full original link, every emitted `r:id` resolves. Where no relationship can be shipped (empty rels), the insert stays unwrapped exactly as before — the documented degenerate boundary.

## Tests

- `documentReconstructor-hyperlinks.test.ts`: in-place retarget (same `r:id`), retarget to a fresh id, same-URL reshuffle (no spurious change), purely-inserted link shipped, and XML-sensitive Target escaping/round-trip.
- `relationships.test.ts`: new unit coverage for the parsers, including namespace-prefixed rels parts.

## Peer review

Reviewed with Codex. It caught one real defensive gap — the new parsers used `getElementsByTagName('Relationship')`, missing valid namespace-prefixed rels parts (which would silently degrade the salt to an unresolved raw `r:id`). Fixed: relationship parsing is now namespace-aware (matches both default-namespace and prefixed `<pr:Relationship>`), with a regression test.

## Gates

`build`, `lint:workspaces`, `test:run` (all packages), `check:spec-coverage`, `check:conformance-citations`, `check:conformance-doc`, and the coverage-ratchet check all pass locally.

Refs: #368, #94

https://claude.ai/code/session_017js33Ho1bkWtoxgMGrT15w