### PR TITLE
fix(docx-core): flip spec-coverage gate to --strict (honest cross-run scenario reclassification)

### DIFF
--- a/openspec/changes/reclassify-cross-run-rescue-as-residual/proposal.md
+++ b/openspec/changes/reclassify-cross-run-rescue-as-residual/proposal.md
@@ -1,0 +1,64 @@
+# Reclassify the cross-run inplace rescue scenario as a documented residual
+
+## Why
+
+The root `check:spec-coverage` gate runs the docx-core matrix validator WARN-only
+because `--strict` never reached `validate_openspec_coverage.mjs` (issue #469).
+#513 closed the tooling and coverage gaps for every docx-comparison scenario
+except one — "Cross-run pass rescues inplace output" — leaving the gate stuck at
+68/69 and therefore unable to flip to `--strict`.
+
+That last scenario cannot be honestly mapped to a test, and the blocker is not
+the one #513 assumed. #513 assumed the problem was *observability* (the engine
+surfaced cross-run pass diagnostics only on rebuild fallback). The real blocker
+is *reachability*: the scenario's precondition — "no-cross-run inplace passes
+fail round-trip safety" — is not satisfiable by any known input.
+
+The inplace pipeline evaluates passes in order: `inplace_word_split`,
+`inplace_run_level`, `inplace_word_split_cross_run`, `inplace_run_level_cross_run`.
+`inplace_run_level` deletes and re-inserts whole runs, which preserves normalized
+text by construction, so it satisfies the round-trip text checks on every case
+that `inplace_word_split` fails. The cross-run passes (3–4) are therefore never
+the selected rescuer. Verified empirically: ~3,900 synthetic fragmentation cases
+and all 508 integration/atomizer tests (fields, tables, hyperlinks, NVCA, ILPA,
+and the OpenAgreements fixtures added precisely because they historically
+triggered this path) produced **zero** cross-run pass selections. Later
+`inplace_word_split`/premerge improvements appear to have subsumed the cross-run
+safety net.
+
+Tag-stuffing a clean inplace test as a "cross-run rescue" was already rejected in
+peer review of #513, so the honest close is to stop asserting the unreachable
+branch as a mappable scenario.
+
+## What Changes
+
+- **Expose which inplace pass produced the output.** Add
+  `inplaceSuccessDiagnostics` (`passUsed` + `precedingFailedAttempts`) to
+  `CompareResult`, populated on the inplace success path. This mirrors, on the
+  success path, the per-pass detail that `fallbackDiagnostics.attempts` already
+  surfaces on the rebuild-fallback path. (This is #469 step 1, kept because it is
+  genuinely useful independent of the reachability finding.)
+- **Reclassify the "Cross-run pass rescues inplace output" scenario.** Fold its
+  intent into the requirement prose as a documented residual (the cross-run
+  passes are a currently-unreachable safety net), and replace it with a genuine,
+  reachable scenario that asserts the pipeline reports the selected pass and its
+  superseded attempts — exercising the real fail-then-rescue machinery
+  (`inplace_word_split` fails a safety check → `inplace_run_level` rescues,
+  staying inplace) via the new diagnostics.
+- **Flip the gate to `--strict`.** Change the root `check:spec-coverage` script
+  so `check:spec-coverage:openspec` runs with `--strict`, making a docx-comparison
+  or cross-implementation-conformance coverage regression fail CI instead of
+  merely warning.
+
+## Impact
+
+- Affected specs: `docx-comparison` (one requirement's scenario set reframed).
+- Affected code: `packages/docx-core/src/compare-types.ts`,
+  `packages/docx-core/src/baselines/atomizer/pipeline.ts` (additive metadata),
+  root `package.json` (`check:spec-coverage`), one docx-core integration test,
+  the auto-generated traceability matrix.
+- Gate: docx-core matrix coverage becomes enforcing (`--strict`), closing the
+  WARN-only rot described in #469.
+- Follow-up: the apparent unreachability of the cross-run passes (candidate dead
+  code) is tracked separately for engine cleanup; this change does not remove
+  them.

--- a/openspec/changes/reclassify-cross-run-rescue-as-residual/specs/docx-comparison/spec.md
+++ b/openspec/changes/reclassify-cross-run-rescue-as-residual/specs/docx-comparison/spec.md
@@ -1,0 +1,26 @@
+## MODIFIED Requirements
+
+### Requirement: Inplace Reconstruction Cross-Run Recovery
+The atomizer comparison pipeline SHALL evaluate cross-run inplace reconstruction passes before using rebuild fallback when `reconstructionMode` is `inplace`, and SHALL report which inplace pass produced the output.
+
+The pipeline evaluates inplace passes in a fixed order — `inplace_word_split`, `inplace_run_level`, `inplace_word_split_cross_run`, `inplace_run_level_cross_run` — selecting the first whose reconstruction satisfies every round-trip safety check. The cross-run passes are a safety net for run-fragmented documents that the no-cross-run passes cannot reconstruct safely.
+
+As of this change that safety net is not reachable by any known input: `inplace_run_level` deletes and re-inserts whole runs, which preserves normalized text by construction, so it satisfies the round-trip text checks on every case that `inplace_word_split` fails — the cross-run passes are therefore never the selected rescuer. A prior "Cross-run pass rescues inplace output" scenario asserted that unreachable branch and could not be honestly mapped to a test; it is reclassified here as a documented residual rather than a routinely-exercised path. The general recovery guarantee is preserved by the "Rebuild fallback only after all inplace passes fail" scenario, which requires the cross-run passes to be evaluated before any rebuild fallback. Reachability of the cross-run passes (candidate dead code superseded by `inplace_word_split` / premerge improvements) is tracked as an engine follow-up. See #469.
+
+#### Scenario: Inplace reconstruction reports the pass that produced the output
+- **GIVEN** a run-fragmented document pair compared with `reconstructionMode: inplace` whose first inplace pass fails a round-trip safety check
+- **WHEN** a later inplace pass satisfies every safety check and is selected
+- **THEN** the result SHALL report `inplaceSuccessDiagnostics.passUsed` naming the selected pass
+- **AND** `inplaceSuccessDiagnostics.precedingFailedAttempts` SHALL list every earlier pass that failed a safety check, in evaluation order
+
+#### Scenario: Rebuild fallback only after all inplace passes fail
+- **GIVEN** all inplace passes (no-cross-run and cross-run) fail at least one safety check
+- **WHEN** comparison completes
+- **THEN** the pipeline SHALL use `reconstructionModeUsed: rebuild`
+- **AND** `fallbackReason` SHALL be `round_trip_safety_check_failed`
+
+#### Scenario: Table-heavy run-fragmented templates preserve tracked table structure
+- **GIVEN** table-heavy OpenAgreements templates with differing run segmentation across original and revised documents
+- **WHEN** a small text edit is applied and tracked output is downloaded with `fail_on_rebuild_fallback: true`
+- **THEN** download SHALL succeed without rebuild fallback
+- **AND** tracked output SHALL preserve table structure (`w:tbl` remains present)

--- a/openspec/changes/reclassify-cross-run-rescue-as-residual/tasks.md
+++ b/openspec/changes/reclassify-cross-run-rescue-as-residual/tasks.md
@@ -1,0 +1,28 @@
+## 1. Engine diagnostics (issue #469 step 1)
+
+- [x] 1.1 Add `ReconstructionInplaceSuccessDiagnostics` and the
+      `inplaceSuccessDiagnostics` field to `CompareResult` in `compare-types.ts`
+- [x] 1.2 Populate `inplaceSuccessDiagnostics` (selected pass + preceding failed
+      attempts) on the inplace success path in `pipeline.ts`
+
+## 2. Spec reclassification
+
+- [x] 2.1 Reframe the "Inplace Reconstruction Cross-Run Recovery" requirement in
+      `openspec/specs/docx-comparison/spec.md`: document the cross-run passes as a
+      currently-unreachable residual and replace the phantom "Cross-run pass
+      rescues inplace output" scenario with a genuine pass-reporting scenario
+- [x] 2.2 Add the genuine fail-then-rescue test mapping the new scenario and
+      asserting `inplaceSuccessDiagnostics`
+
+## 3. Gate enforcement (issue #469 step 3)
+
+- [x] 3.1 Flip `check:spec-coverage:openspec` to `--strict` in the root
+      `check:spec-coverage` script
+- [x] 3.2 Regenerate the traceability matrix and confirm
+      `npm run check:spec-coverage` passes with all scenarios mapped
+
+## 4. Verification
+
+- [x] 4.1 `openspec validate reclassify-cross-run-rescue-as-residual --strict`
+- [x] 4.2 Build docx-core and run the affected integration tests
+- [x] 4.3 Run `node scripts/validate_openspec_coverage.mjs --strict` → exit 0

--- a/openspec/specs/docx-comparison/spec.md
+++ b/openspec/specs/docx-comparison/spec.md
@@ -539,13 +539,17 @@ The system SHALL provide friendly names for common run properties:
 - **THEN** the local name (`emboss`) is used as the property name
 
 ### Requirement: Inplace Reconstruction Cross-Run Recovery
-The atomizer comparison pipeline SHALL evaluate cross-run inplace reconstruction passes before using rebuild fallback when `reconstructionMode` is `inplace`.
+The atomizer comparison pipeline SHALL evaluate cross-run inplace reconstruction passes before using rebuild fallback when `reconstructionMode` is `inplace`, and SHALL report which inplace pass produced the output.
 
-#### Scenario: Cross-run pass rescues inplace output
-- **GIVEN** a run-fragmented document pair where no-cross-run inplace passes fail round-trip safety
-- **WHEN** cross-run inplace passes are evaluated
-- **THEN** the pipeline SHALL keep `reconstructionModeUsed` as `inplace` if any cross-run pass satisfies all safety checks
-- **AND** tracked output SHALL avoid rebuild fallback-driven structure loss
+The pipeline evaluates inplace passes in a fixed order — `inplace_word_split`, `inplace_run_level`, `inplace_word_split_cross_run`, `inplace_run_level_cross_run` — selecting the first whose reconstruction satisfies every round-trip safety check. The cross-run passes are a safety net for run-fragmented documents that the no-cross-run passes cannot reconstruct safely.
+
+As of this requirement's last revision that safety net is not reachable by any known input: `inplace_run_level` deletes and re-inserts whole runs, which preserves normalized text by construction, so it satisfies the round-trip text checks on every case that `inplace_word_split` fails — the cross-run passes are therefore never the selected rescuer. A prior "Cross-run pass rescues inplace output" scenario asserted that unreachable branch and could not be honestly mapped to a test; it is reclassified as a documented residual rather than a routinely-exercised path. The general recovery guarantee is preserved by the "Rebuild fallback only after all inplace passes fail" scenario, which requires the cross-run passes to be evaluated before any rebuild fallback. Reachability of the cross-run passes (candidate dead code superseded by `inplace_word_split` / premerge improvements) is tracked as an engine follow-up. See #469.
+
+#### Scenario: Inplace reconstruction reports the pass that produced the output
+- **GIVEN** a run-fragmented document pair compared with `reconstructionMode: inplace` whose first inplace pass fails a round-trip safety check
+- **WHEN** a later inplace pass satisfies every safety check and is selected
+- **THEN** the result SHALL report `inplaceSuccessDiagnostics.passUsed` naming the selected pass
+- **AND** `inplaceSuccessDiagnostics.precedingFailedAttempts` SHALL list every earlier pass that failed a safety check, in evaluation order
 
 #### Scenario: Rebuild fallback only after all inplace passes fail
 - **GIVEN** all inplace passes (no-cross-run and cross-run) fail at least one safety check

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "site:dev": "npm --prefix site run dev",
     "check:site-links": "node scripts/check_site_internal_links.mjs",
     "check:site": "npm run site:build && npm run check:site-links",
-    "check:spec-coverage": "npm run check:spec-coverage:openspec -w @usejunior/docx-core && npm run check:spec-coverage:primitives -w @usejunior/docx-core -- --strict && npm run check:spec-coverage:tag-density -w @usejunior/docx-core && npm run check:spec-coverage -w @usejunior/docx-mcp -- --strict && npm run check:spec-coverage-generation -w @usejunior/docx-core -- --strict",
+    "check:spec-coverage": "npm run check:spec-coverage:openspec -w @usejunior/docx-core -- --strict && npm run check:spec-coverage:primitives -w @usejunior/docx-core -- --strict && npm run check:spec-coverage:tag-density -w @usejunior/docx-core && npm run check:spec-coverage -w @usejunior/docx-mcp -- --strict && npm run check:spec-coverage-generation -w @usejunior/docx-core -- --strict",
     "check:allure-labels": "node scripts/validate_allure_test_labels.mjs",
     "check:allure-quality": "node scripts/validate_allure_test_quality.mjs",
     "check:bdd-coverage": "node scripts/check_bdd_coverage.mjs",

--- a/packages/docx-core/src/baselines/atomizer/pipeline.ts
+++ b/packages/docx-core/src/baselines/atomizer/pipeline.ts
@@ -19,6 +19,7 @@ import type {
   ReconstructionFallbackReason,
   ReconstructionIdDelta,
   ReconstructionIdDeltaSummary,
+  ReconstructionInplaceSuccessDiagnostics,
   ReconstructionRebuildSafetyDiagnostics,
   ReconstructionSafetyFailureSummary,
   ReconstructionSafetyFailureDetails,
@@ -753,6 +754,7 @@ export async function compareDocumentsAtomizer(
   };
   let fallbackReason: ReconstructionFallbackReason | undefined;
   let fallbackDiagnostics: ReconstructionFallbackDiagnostics | undefined;
+  let inplaceSuccessDiagnostics: ReconstructionInplaceSuccessDiagnostics | undefined;
   if (reconstructionMode === 'inplace') {
     // Adaptive strategy:
     // 1) Try no-cross-run passes first (higher run anchoring fidelity).
@@ -802,6 +804,7 @@ export async function compareDocumentsAtomizer(
 
     const failedAttempts: ReconstructionAttemptDiagnostics[] = [];
     let selected: typeof comparisonResult | undefined;
+    let selectedPass: ReconstructionAttemptDiagnostics['pass'] | undefined;
     for (const { pass, atomizeOptions } of inplacePasses) {
       let candidate: typeof comparisonResult;
       try {
@@ -824,6 +827,7 @@ export async function compareDocumentsAtomizer(
 
       if (safety.safe) {
         selected = candidate;
+        selectedPass = pass;
         break;
       }
 
@@ -838,6 +842,13 @@ export async function compareDocumentsAtomizer(
 
     if (selected) {
       comparisonResult = selected;
+      // selectedPass is always set when `selected` is (assigned together at the
+      // break). Surface which pass won and which it superseded so callers can
+      // distinguish a cross-run rescue from a first-pass success.
+      inplaceSuccessDiagnostics = {
+        passUsed: selectedPass!,
+        precedingFailedAttempts: failedAttempts,
+      };
     } else {
       comparisonResult = runComparisonPass(
         { atomizeParagraphLevelMarkers: true },
@@ -921,6 +932,7 @@ export async function compareDocumentsAtomizer(
     fallbackReason,
     fallbackDiagnostics,
     rebuildSafetyDiagnostics,
+    inplaceSuccessDiagnostics,
   };
 }
 

--- a/packages/docx-core/src/compare-types.ts
+++ b/packages/docx-core/src/compare-types.ts
@@ -174,6 +174,28 @@ export interface ReconstructionFallbackDiagnostics {
 }
 
 /**
+ * Diagnostics for a *successful* inplace reconstruction: which pass produced the
+ * accepted output, and the passes that were tried and rejected before it. The
+ * fallback diagnostics above only surface when every inplace pass fails and the
+ * pipeline reroutes to rebuild; this surfaces the same per-pass detail on the
+ * success path, so a caller can tell which pass produced the output — e.g. a
+ * later pass rescuing what an earlier pass could not reconstruct safely —
+ * without inferring it from the absence of a fallback. Present only for atomizer
+ * inplace output (`reconstructionModeUsed === 'inplace'`).
+ *
+ * @see https://github.com/UseJunior/safe-docx/issues/469
+ */
+export interface ReconstructionInplaceSuccessDiagnostics {
+  /** The inplace pass whose output passed all round-trip safety checks. */
+  passUsed: ReconstructionAttemptDiagnostics['pass'];
+  /**
+   * Passes tried and rejected (in evaluation order) before `passUsed`
+   * succeeded. Empty when the first pass already satisfied every safety check.
+   */
+  precedingFailedAttempts: ReconstructionAttemptDiagnostics[];
+}
+
+/**
  * Round-trip safety evaluation of rebuild output. Rebuild is the terminal
  * reconstruction strategy — there is no further fallback — so a failed check
  * cannot reroute the pipeline. The document is returned anyway and the
@@ -219,4 +241,9 @@ export interface CompareResult {
    * Present only when at least one check failed.
    */
   rebuildSafetyDiagnostics?: ReconstructionRebuildSafetyDiagnostics;
+  /**
+   * Which inplace pass produced the output and which passes it superseded.
+   * Present only when atomizer produced inplace output.
+   */
+  inplaceSuccessDiagnostics?: ReconstructionInplaceSuccessDiagnostics;
 }

--- a/packages/docx-core/src/index.ts
+++ b/packages/docx-core/src/index.ts
@@ -21,6 +21,7 @@ export type {
   ReconstructionFallbackReason,
   ReconstructionIdDelta,
   ReconstructionIdDeltaSummary,
+  ReconstructionInplaceSuccessDiagnostics,
   ReconstructionMode,
   ReconstructionSafetyCheckName,
   ReconstructionSafetyChecks,

--- a/packages/docx-core/src/integration/table-heavy-run-fragmented-inplace.test.ts
+++ b/packages/docx-core/src/integration/table-heavy-run-fragmented-inplace.test.ts
@@ -80,6 +80,85 @@ async function fragmentRevisedTableRuns(buffer: Buffer): Promise<Buffer> {
   return archive.save();
 }
 
+/**
+ * A single-run paragraph whose revised copy splits one run at a formatting
+ * boundary (a bold fragment mid-phrase) and edits a nearby word. The word-split
+ * inplace pass cannot reconstruct this safely — splitting the bold run corrupts
+ * the reject-side round-trip text — so it fails, and the run-level pass (which
+ * deletes/inserts whole runs) rescues the output while keeping inplace mode.
+ * This is a genuine fail-then-rescue that exercises the pass-supersession
+ * machinery and the `inplaceSuccessDiagnostics` reporting.
+ */
+async function fragmentAtFormattingBoundary(original: Buffer): Promise<Buffer> {
+  const archive = await DocxArchive.load(original);
+  const xml = await archive.getDocumentXml();
+  const target = 'The Receiving Party shall protect Confidential Information carefully.';
+  // Edit "Receiving" -> "Reviewing" and split the run after "The" into a bold fragment.
+  const edited = target.replace('Receiving', 'Reviewing');
+  const cut = 'The'.length;
+  const fragmented =
+    `${edited.slice(0, cut)}</w:t></w:r>` +
+    `<w:r><w:rPr><w:b/></w:rPr><w:t xml:space="preserve">${edited.slice(cut)}`;
+  const revisedXml = xml.replace(`>${target}<`, `>${fragmented}<`);
+  expect(revisedXml, 'fixture mutation should split the run at a formatting boundary').not.toBe(xml);
+  archive.setDocumentXml(revisedXml);
+  return archive.save();
+}
+
+describe('Inplace reconstruction pass selection', () => {
+  test.openspec('Inplace reconstruction reports the pass that produced the output')(
+    'reports the winning pass and the earlier pass it superseded',
+    async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
+      let original!: Buffer;
+      let revised!: Buffer;
+      let result!: Awaited<ReturnType<typeof compareDocuments>>;
+
+      await given(
+        'a single-run paragraph whose revised copy splits a run at a bold formatting boundary and edits a nearby word',
+        async () => {
+          original = await generateDocx({
+            meta: { title: 'Formatting-boundary fragmentation', author: 'safe-docx tests', createdIso: '2026-06-20T00:00:00Z' },
+            sections: [{ blocks: [{ kind: 'paragraph', runs: [{ kind: 'text', text: 'The Receiving Party shall protect Confidential Information carefully.' }] }] }],
+          });
+          revised = await fragmentAtFormattingBoundary(original);
+        },
+      );
+
+      await when('the fragmented pair is compared in inplace mode with run premerge disabled', async () => {
+        result = await compareDocuments(original, revised, {
+          engine: 'atomizer',
+          reconstructionMode: 'inplace',
+          premergeRuns: false,
+        });
+        await attachPrettyJson('inplace-pass-diagnostics.json', {
+          reconstructionModeUsed: result.reconstructionModeUsed,
+          passUsed: result.inplaceSuccessDiagnostics?.passUsed ?? null,
+          precedingFailedAttempts: result.inplaceSuccessDiagnostics?.precedingFailedAttempts?.map((a) => ({
+            pass: a.pass,
+            failedChecks: a.failedChecks,
+          })) ?? null,
+        });
+      });
+
+      await then('inplace output is kept and the diagnostics name the winning pass and the pass it superseded', () => {
+        expect(result.reconstructionModeUsed).toBe('inplace');
+        expect(result.fallbackReason).toBeUndefined();
+
+        const diagnostics = result.inplaceSuccessDiagnostics;
+        expect(diagnostics).toBeDefined();
+        // The run-level pass rescued output that word-split could not reconstruct safely.
+        expect(diagnostics!.passUsed).toBe('inplace_run_level');
+        expect(diagnostics!.precedingFailedAttempts.length).toBeGreaterThan(0);
+        expect(diagnostics!.precedingFailedAttempts[0]!.pass).toBe('inplace_word_split');
+        // Every superseded attempt records at least one failed safety check, in evaluation order.
+        for (const attempt of diagnostics!.precedingFailedAttempts) {
+          expect(attempt.failedChecks.length).toBeGreaterThan(0);
+        }
+      });
+    },
+  );
+});
+
 describe('Inplace reconstruction on table-heavy run-fragmented templates', () => {
   test.openspec('Table-heavy run-fragmented templates preserve tracked table structure')(
     'table-heavy run-fragmented template preserves w:tbl without rebuild fallback',

--- a/packages/docx-core/src/testing/DOCX_COMPARISON_OPENSPEC_TRACEABILITY.md
+++ b/packages/docx-core/src/testing/DOCX_COMPARISON_OPENSPEC_TRACEABILITY.md
@@ -26,7 +26,6 @@ This matrix maps docx-core OpenSpec `#### Scenario:` entries to scenario mapping
 | Continuation pattern inherits formatting | covered | `src/openspec.traceability.test.ts` |  |
 | Creating atom with revision detection | covered | `src/openspec.traceability.test.ts` |  |
 | Creating atom without revision context | covered | `src/openspec.traceability.test.ts` |  |
-| Cross-run pass rescues inplace output | missing | n/a | No scenario mapping found in current tests |
 | Custom footnote marks respected | covered | `src/openspec.traceability.test.ts` |  |
 | Custom threshold applied | covered | `src/openspec.traceability.test.ts` |  |
 | Different properties | covered | `src/openspec.traceability.test.ts` |  |
@@ -44,6 +43,7 @@ This matrix maps docx-core OpenSpec `#### Scenario:` entries to scenario mapping
 | Get format change revisions | covered | `src/openspec.traceability.test.ts` |  |
 | Hash calculation for content identity | covered | `src/openspec.traceability.test.ts` |  |
 | Identical text returns 1.0 | covered | `src/openspec.traceability.test.ts` |  |
+| Inplace reconstruction reports the pass that produced the output | covered | `src/integration/table-heavy-run-fragmented-inplace.test.ts` |  |
 | Move destination markup structure | covered | `src/openspec.traceability.test.ts` |  |
 | Move detected between similar blocks | covered | `src/openspec.priority-scenarios.test.ts`, `src/openspec.traceability.test.ts` |  |
 | Move detection disabled | covered | `src/openspec.priority-scenarios.test.ts`, `src/openspec.traceability.test.ts` |  |


### PR DESCRIPTION
## Summary

Closes the WARN-only rot in the docx-core matrix coverage gate (#469): the root `check:spec-coverage` never passed `--strict` to `validate_openspec_coverage.mjs`, so a docx-comparison or cross-implementation-conformance coverage regression could not fail CI.

#513 mapped every docx-comparison scenario except **"Cross-run pass rescues inplace output"**, leaving the gate stuck at 68/69 and unable to flip strict. This PR resolves that scenario honestly and flips the gate.

## The key finding

#513 assumed the blocker was *observability* (cross-run pass diagnostics only surfaced on rebuild fallback). The real blocker is **reachability**: the scenario's precondition — *"no-cross-run inplace passes fail round-trip safety"* — is not satisfiable by any known input.

The inplace pipeline evaluates passes in order: `inplace_word_split` → `inplace_run_level` → `inplace_word_split_cross_run` → `inplace_run_level_cross_run`, selecting the first that passes round-trip safety. `inplace_run_level` deletes and re-inserts **whole runs**, which preserves normalized text by construction, so it satisfies the accept/reject text checks on every case `inplace_word_split` fails — the cross-run passes (3–4) are **never the selected rescuer**.

Verified empirically: ~3,900 synthetic fragmentation cases + all 508 integration/atomizer tests (fields, tables, hyperlinks, NVCA, ILPA, and the OpenAgreements fixtures added *because* they historically triggered this path) produced **zero** cross-run selections. Later `word_split`/premerge improvements appear to have subsumed the cross-run safety net. Peer review (Codex) independently ran its own dynamic probe — including malformed-field topology (→ rebuild) and a 27-case split/style sweep — and also **could not construct a cross-run counterexample**.

Tag-stuffing a clean inplace test as a "cross-run rescue" was rejected in peer review of #513, so this closes the gate honestly instead of faking coverage.

## What changed

1. **Expose `inplaceSuccessDiagnostics`** (`passUsed` + `precedingFailedAttempts`) on `CompareResult`, mirroring on the success path the per-pass detail `fallbackDiagnostics.attempts` already surfaces on rebuild fallback (#469 step 1). Exported from the package root.
2. **Reclassify the unreachable scenario**: its intent is folded into the "Inplace Reconstruction Cross-Run Recovery" requirement prose as a documented residual (a currently-unreachable safety net), and replaced by a genuine, reachable scenario — *"Inplace reconstruction reports the pass that produced the output"* — mapped to a real fail-then-rescue test (`word_split` fails `rejectText` → `run_level` rescues, staying inplace). Coverage stays **69/69**, all mapped.
3. **Flip `--strict`**: `check:spec-coverage:openspec` now runs with `--strict`, so docx-comparison + cross-impl-conformance coverage regressions fail CI.

The OpenSpec change is documented under `openspec/changes/reclassify-cross-run-rescue-as-residual/`.

## Follow-up

The apparent unreachability of the cross-run passes (candidate dead code superseded by earlier-pass improvements) is left for a separate engine-cleanup investigation; this PR does not remove them.

## Verification

- `npm run check:spec-coverage` → exit 0 (docx-comparison 69/69, cross-impl 6/6, THEN-keyword check passes)
- `openspec validate reclassify-cross-run-rescue-as-residual --strict` → valid
- docx-core: build ✓, lint ✓, integration (219) ✓, atomizer baselines (290) ✓, new test ✓
- `check:conformance-citations` ✓, `check:conformance-doc` ✓
- Peer-reviewed by Codex (dynamic): verdict defensible; one API-export nit fixed.

Fixes: #469

https://claude.ai/code/session_01Ci8P2AyzVgPJRDAbtRSGno