### PR TITLE
feat(docx-core,docx-mcp): selective accept/reject by revision id or author [#123]

### DIFF
--- a/openspec/changes/add-selective-ai-accept-reject/proposal.md
+++ b/openspec/changes/add-selective-ai-accept-reject/proposal.md
@@ -1,0 +1,36 @@
+# Change: Add selective accept/reject by revision id (with author convenience mode)
+
+## Why
+
+The strongest argument for tracked-changes-as-canonical (#118/#120) is that
+acceptance can target only the AI actor's revisions, leaving any pre-existing
+third-party tracked changes untouched. Today `accept_changes` / `reject_changes`
+are whole-document only, so accepting the AI's edits also flattens a reviewer's
+revisions. This change adds selective accept/reject keyed on revision id (with an
+author convenience mode), which is the precondition for the mixed-author
+preservation corpus (#124/#125) and for removing whole-document comparison from
+the default finalization path (#126).
+
+## What Changes
+
+- Add `acceptAIEdits(doc, { revisionIds | author })` and `rejectAIEdits(...)` to
+  `@usejunior/docx-core`, driving the existing accept/reject engines through a
+  revision-id filter so only targeted revisions are resolved and every other
+  revision is left byte-untouched. Coverage spans document.xml and supported
+  side-story parts (footnotes, endnotes, comments).
+- Define selective accept/reject only on a normalized, non-overlapping revision
+  graph. An ambiguous overlap — a targeted revision structurally containing, or
+  contained by, a non-targeted content-wrapper revision (nested ins/del/move) —
+  hard-errors with a structured list of offending pairs. `normalizeFirst` opts
+  into best-effort operation (no byte-identical promise).
+- Expose `accept_ai_edits` and `reject_ai_edits` MCP tools. `accept_changes`
+  remains as the whole-document convenience.
+
+## Impact
+
+- Affected specs: `mcp-server`
+- Affected code: `packages/docx-core/src/primitives/accept_ai_edits.ts` (new),
+  `packages/docx-core/src/primitives/{accept_changes,reject_changes,document}.ts`
+  (optional revision filter), `packages/docx-mcp/src/tools/{accept,reject}_ai_edits.ts`
+  (new), `packages/docx-mcp/src/tool_catalog.ts`, `packages/docx-mcp/src/server.ts`
+- Unblocks: #124, #125 (corpora), #126 (remove comparison default)

--- a/openspec/changes/add-selective-ai-accept-reject/specs/mcp-server/spec.md
+++ b/openspec/changes/add-selective-ai-accept-reject/specs/mcp-server/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: Selective Accept/Reject by Revision Identity
+
+The MCP server SHALL provide `accept_ai_edits` and `reject_ai_edits` tools that
+resolve tracked changes only within a target set — named by explicit
+`revision_ids` (`w:id` values) or by `author` — and leave every non-targeted
+revision byte-untouched across document.xml and supported side-story parts.
+
+`accept_ai_edits` SHALL apply the targeted revisions (insertions promoted,
+deletions removed, property/paragraph-mark changes resolved). `reject_ai_edits`
+SHALL revert them (insertions removed, deletions restored, properties reverted).
+Each SHALL require at least one of `revision_ids` or `author`.
+
+#### Scenario: accept ai edits by author preserves foreign revisions
+- **GIVEN** a session document with interleaved AI-authored and reviewer-authored revisions
+- **WHEN** `accept_ai_edits` is called with the AI author
+- **THEN** the AI revisions SHALL be accepted
+- **AND** the reviewer's revisions SHALL remain present and unchanged
+
+#### Scenario: reject ai edits by author preserves foreign revisions
+- **GIVEN** a session document with interleaved AI-authored and reviewer-authored revisions
+- **WHEN** `reject_ai_edits` is called with the AI author
+- **THEN** the AI revisions SHALL be reverted
+- **AND** the reviewer's revisions SHALL remain present and unchanged
+
+#### Scenario: accept ai edits by explicit revision ids
+- **GIVEN** a session document containing several AI revisions
+- **WHEN** `accept_ai_edits` is called with a subset of `revision_ids`
+- **THEN** only the listed revisions SHALL be accepted
+- **AND** the response SHALL report the `selected_revision_ids` actually resolved
+
+#### Scenario: missing selector is rejected
+- **GIVEN** a session document
+- **WHEN** `accept_ai_edits` is called with neither `revision_ids` nor `author`
+- **THEN** the server SHALL reject the request with error code `MISSING_PARAMETER`
+
+#### Scenario: ambiguous overlap hard-errors with structured overlaps
+- **GIVEN** a session document where an AI revision structurally contains a reviewer revision
+- **WHEN** `accept_ai_edits` is called for the AI author without `normalize_first`
+- **THEN** the server SHALL fail with error code `AMBIGUOUS_REVISION_OVERLAP`
+- **AND** the response SHALL include a structured `overlaps` list naming the offending revision pair
+
+#### Scenario: normalize first bypasses the ambiguity error
+- **GIVEN** a session document with an ambiguous revision overlap
+- **WHEN** `accept_ai_edits` is called with `normalize_first` set
+- **THEN** the operation SHALL succeed on a best-effort basis
+- **AND** the non-targeted revision SHALL still be present

--- a/openspec/changes/add-selective-ai-accept-reject/tasks.md
+++ b/openspec/changes/add-selective-ai-accept-reject/tasks.md
@@ -1,0 +1,14 @@
+# Tasks
+
+## 1. docx-core engine
+- [x] 1.1 Thread an optional revision-id filter through `acceptChanges`/`rejectChanges` (default = whole-document); skip the global rsidDel strip in selective mode.
+- [x] 1.2 Add `accept_ai_edits.ts`: id resolution (revisionIds | author), ambiguous-overlap detection over content-wrapper revisions, `acceptAIEdits`/`rejectAIEdits`.
+- [x] 1.3 Add `DocxDocument.acceptAIEdits`/`rejectAIEdits` sweeping document.xml + side-story parts, resolving ids package-wide.
+
+## 2. MCP tools
+- [x] 2.1 Add `accept_ai_edits` / `reject_ai_edits` tools + catalog entries (surface: internal) + server dispatch.
+- [x] 2.2 Surface the structured `overlaps` list and `AMBIGUOUS_REVISION_OVERLAP` error code.
+
+## 3. Tests
+- [x] 3.1 docx-core unit tests: per-revision-type non-overlap accept/reject, foreign-revision byte preservation, subset-by-id, ambiguous hard-error, normalizeFirst, no-false-positive on nested property change.
+- [x] 3.2 MCP e2e tests covering the mcp-server scenarios.

--- a/packages/docx-core/SUPPORT.md
+++ b/packages/docx-core/SUPPORT.md
@@ -71,6 +71,7 @@ These files are intentionally outside the revisionable-surface contract. Some pe
 ### `docx-core` primitive files
 
 - `accept_changes.ts` — tracked-change consumer that accepts existing `w:ins` / `w:del` / property-change markup in `document.xml` and supported side-story parts (`footnotes.xml`, `endnotes.xml`, `comments.xml`) instead of creating new AI-authored revisions.
+- `accept_ai_edits.ts` — tracked-change consumer that selectively accepts/rejects existing revisions by id or author ([#123](https://github.com/UseJunior/safe-docx/issues/123)) and detects ambiguous overlaps; it resolves existing markup rather than originating AI-authored revisions, so it is not a write-time emission surface.
 - `bookmarks.ts` — internal paragraph-bookmark scaffolding for stable selectors and anchor lookup, not user-visible AI content authorship.
 - `document.ts` — `DocxDocument` facade that routes to lower-level primitives; the contract is defined at the delegated primitive level, not this wrapper.
 - `document_view.ts` — read-only projection layer for toon/json/simple views, style discovery, and footnote marker display.
@@ -98,6 +99,8 @@ These files are intentionally outside the revisionable-surface contract. Some pe
 ### `docx-mcp` read-only, orchestration, and session files
 
 - `accept_changes.ts` — MCP wrapper that consumes existing tracked changes by accepting them.
+- `accept_ai_edits.ts` — MCP wrapper that selectively accepts existing tracked changes by revision id or author ([#123](https://github.com/UseJunior/safe-docx/issues/123)); a consumer, not a write-time revision emitter.
+- `reject_ai_edits.ts` — MCP wrapper that selectively rejects existing tracked changes by revision id or author; symmetric consumer to `accept_ai_edits.ts`.
 - `close_file.ts` — session lifecycle control only.
 - `comparison_defaults.ts` — comparison configuration constant, not an MCP mutation surface by itself.
 - `docx_archive_guard.ts` — archive safety validator that checks zip bomb and entry-size limits before load.
@@ -142,6 +145,7 @@ This appendix is deliberately mechanical. It makes it easy to audit that every n
 ### `packages/docx-core/src/primitives`
 
 - `accept_changes.ts` — Internal / non-contract utilities
+- `accept_ai_edits.ts` — Internal / non-contract utilities
 - `bookmarks.ts` — Internal / non-contract utilities
 - `comments.ts` — Table A and Table B
 - `document.ts` — Internal / non-contract utilities
@@ -173,6 +177,7 @@ This appendix is deliberately mechanical. It makes it easy to audit that every n
 ### `packages/docx-mcp/src/tools`
 
 - `accept_changes.ts` — Internal / non-contract utilities
+- `accept_ai_edits.ts` — Internal / non-contract utilities
 - `add_comment.ts` — Table A and Table B
 - `add_footnote.ts` — Table A and Table B
 - `batch_edit.ts` — Table A
@@ -198,6 +203,7 @@ This appendix is deliberately mechanical. It makes it easy to audit that every n
 - `preview.ts` — Internal / non-contract utilities
 - `provider_guard.ts` — Internal / non-contract utilities
 - `read_file.ts` — Internal / non-contract utilities
+- `reject_ai_edits.ts` — Internal / non-contract utilities
 - `replace_text.ts` — Table A
 - `save.ts` — Table A
 - `session_resolution.ts` — Internal / non-contract utilities

--- a/packages/docx-core/src/primitives/accept_ai_edits.test.ts
+++ b/packages/docx-core/src/primitives/accept_ai_edits.test.ts
@@ -224,6 +224,23 @@ describe('selective accept/reject by revision id/author (#123)', () => {
       expect(() => acceptAIEdits(doc, { author: AI })).toThrow(AmbiguousRevisionOverlapError);
     });
 
+    it('merges a foreign body revision forward (byte-identical) on a selected paragraph-mark accept', () => {
+      // AI deleted the paragraph mark (para merges into the next). The source
+      // paragraph BODY carries a reviewer insertion — the merge must relocate it
+      // into the following paragraph byte-identically, never drop it. (Only a
+      // foreign revision in the source pPr is ambiguous; body content rides along.)
+      const foreignIns = `<w:ins w:id="2" w:author="${HUMAN}"><w:r><w:t xml:space="preserve">reviewer</w:t></w:r></w:ins>`;
+      const doc = body(
+        `<w:p><w:pPr><w:rPr><w:del w:id="1" w:author="${AI}"/></w:rPr></w:pPr>` +
+          `<w:r><w:t>a</w:t></w:r>${foreignIns}</w:p>` +
+          `<w:p><w:r><w:t>b</w:t></w:r></w:p>`,
+      );
+      acceptAIEdits(doc, { author: AI });
+      const out = xml(doc);
+      expect(out).toContain(foreignIns); // reviewer insertion preserved after the merge
+      expect(out).not.toContain('w:id="1"'); // AI paragraph-mark deletion accepted
+    });
+
     it('does not prune an orphaned footnote that still carries a foreign revision', async () => {
       // The body footnoteReference (id=9) lives inside a selected AI deletion, so
       // accepting it orphans footnote id=9 — which contains a reviewer insertion.

--- a/packages/docx-core/src/primitives/accept_ai_edits.test.ts
+++ b/packages/docx-core/src/primitives/accept_ai_edits.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect } from 'vitest';
 import { itAllure as it } from '../testing/allure-test.js';
 import { parseXml, serializeXml } from './xml.js';
+import { DocxDocument } from './document.js';
+import { DocxZip } from './zip.js';
+import { buildDocxFromBodyXml } from '../testing/ooxml-fixtures.js';
 import {
   acceptAIEdits,
   rejectAIEdits,
@@ -181,6 +184,74 @@ describe('selective accept/reject by revision id/author (#123)', () => {
       );
       const overlaps = detectAmbiguousOverlaps(doc, new Set(['1', '2']));
       expect(overlaps).toHaveLength(0);
+    });
+  });
+
+  // Regression cases for the foreign-revision byte-identical invariant surfaced
+  // by the #123 codex peer review.
+  describe('foreign-revision preservation (byte-identical invariant)', () => {
+    it('does not rename delText inside a foreign w:moveFrom on selective reject', () => {
+      const foreign = `<w:moveFrom w:id="2" w:author="${HUMAN}"><w:r><w:delText xml:space="preserve">moved</w:delText></w:r></w:moveFrom>`;
+      const doc = body(`<w:p>${aiDel(1, 'gone')}${foreign}</w:p>`);
+      rejectAIEdits(doc, { author: AI });
+      const out = xml(doc);
+      // Rejecting the AI deletion restores its text as a normal run…
+      expect(out).toContain('<w:t xml:space="preserve">gone</w:t>');
+      expect(out).not.toContain('<w:delText xml:space="preserve">gone');
+      // …while the foreign move source stays byte-identical (its delText NOT renamed).
+      expect(out).toContain(foreign);
+    });
+
+    it('hard-errors when a selected property change shares its container with a foreign revision', () => {
+      // pPr holds a foreign paragraph-mark insertion (reviewer) and a selected AI pPrChange.
+      const doc = body(
+        `<w:p><w:pPr><w:rPr><w:ins w:id="2" w:author="${HUMAN}"/></w:rPr>` +
+          `<w:pPrChange w:id="1" w:author="${AI}"><w:pPr/></w:pPrChange></w:pPr>` +
+          `<w:r><w:t>x</w:t></w:r></w:p>`,
+      );
+      expect(() => rejectAIEdits(doc, { author: AI })).toThrow(AmbiguousRevisionOverlapError);
+    });
+
+    it('hard-errors on a paragraph-mark merge whose pPr holds a foreign mark revision', () => {
+      // AI deleted the paragraph mark; a reviewer inserted the same mark — merging
+      // the paragraph would drop the reviewer revision, so it is ambiguous.
+      const doc = body(
+        `<w:p><w:pPr><w:rPr>` +
+          `<w:del w:id="1" w:author="${AI}"/><w:ins w:id="2" w:author="${HUMAN}"/>` +
+          `</w:rPr></w:pPr><w:r><w:t>first</w:t></w:r></w:p>` +
+          `<w:p><w:r><w:t>second</w:t></w:r></w:p>`,
+      );
+      expect(() => acceptAIEdits(doc, { author: AI })).toThrow(AmbiguousRevisionOverlapError);
+    });
+
+    it('does not prune an orphaned footnote that still carries a foreign revision', async () => {
+      // The body footnoteReference (id=9) lives inside a selected AI deletion, so
+      // accepting it orphans footnote id=9 — which contains a reviewer insertion.
+      const bodyXml =
+        `<w:p><w:r><w:t>text</w:t></w:r>` +
+        `<w:del w:id="5" w:author="${AI}"><w:r><w:rPr><w:rStyle w:val="FootnoteReference"/></w:rPr>` +
+        `<w:footnoteReference w:id="9"/></w:r></w:del></w:p>`;
+      const footnotesXml =
+        `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+        `<w:footnotes xmlns:w="${W}">` +
+        `<w:footnote w:type="separator" w:id="-1"><w:p><w:r><w:separator/></w:r></w:p></w:footnote>` +
+        `<w:footnote w:id="9"><w:p><w:r><w:t>note </w:t></w:r>` +
+        `<w:ins w:id="20" w:author="${HUMAN}"><w:r><w:t>reviewer text</w:t></w:r></w:ins></w:p></w:footnote>` +
+        `</w:footnotes>`;
+
+      const base = await buildDocxFromBodyXml(bodyXml);
+      const zip = await DocxZip.load(base);
+      zip.writeText('word/footnotes.xml', footnotesXml);
+      const doc = await DocxDocument.load(await zip.toBuffer());
+
+      await doc.acceptAIEdits({ author: AI });
+
+      const outZip = await DocxZip.load((await doc.toBuffer({ cleanBookmarks: false })).buffer);
+      const outFootnotes = await outZip.readText('word/footnotes.xml');
+      // The note is now unreferenced, but it must not be deleted because it still
+      // carries the reviewer's revision.
+      expect(outFootnotes).toContain('w:id="20"');
+      expect(outFootnotes).toContain('reviewer text');
     });
   });
 });

--- a/packages/docx-core/src/primitives/accept_ai_edits.test.ts
+++ b/packages/docx-core/src/primitives/accept_ai_edits.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect } from 'vitest';
+import { itAllure as it } from '../testing/allure-test.js';
+import { parseXml, serializeXml } from './xml.js';
+import {
+  acceptAIEdits,
+  rejectAIEdits,
+  detectAmbiguousOverlaps,
+  resolveSelectedIds,
+  collectRevisionElements,
+  AmbiguousRevisionOverlapError,
+} from './accept_ai_edits.js';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const AI = 'SafeDocX AI';
+const HUMAN = 'Reviewer';
+
+function body(inner: string): Document {
+  return parseXml(
+    `<?xml version="1.0"?><w:document xmlns:w="${W}"><w:body>${inner}</w:body></w:document>`,
+  );
+}
+
+function xml(doc: Document): string {
+  return serializeXml(doc);
+}
+
+// A run inside w:ins keeps its text; a run inside w:del holds w:delText.
+const aiIns = (id: number, text: string) =>
+  `<w:ins w:id="${id}" w:author="${AI}"><w:r><w:t xml:space="preserve">${text}</w:t></w:r></w:ins>`;
+const humanIns = (id: number, text: string) =>
+  `<w:ins w:id="${id}" w:author="${HUMAN}"><w:r><w:t xml:space="preserve">${text}</w:t></w:r></w:ins>`;
+const aiDel = (id: number, text: string) =>
+  `<w:del w:id="${id}" w:author="${AI}"><w:r><w:delText xml:space="preserve">${text}</w:delText></w:r></w:del>`;
+const humanDel = (id: number, text: string) =>
+  `<w:del w:id="${id}" w:author="${HUMAN}"><w:r><w:delText xml:space="preserve">${text}</w:delText></w:r></w:del>`;
+
+describe('selective accept/reject by revision id/author (#123)', () => {
+  describe('id resolution', () => {
+    it('resolves explicit revision_ids as strings', () => {
+      const doc = body(`<w:p>${aiIns(1, 'a')}${humanIns(2, 'b')}</w:p>`);
+      const ids = resolveSelectedIds(collectRevisionElements(doc), { revisionIds: [1, '2'] });
+      expect([...ids].sort()).toEqual(['1', '2']);
+    });
+
+    it('resolves an author to the ids of every revision it authored', () => {
+      const doc = body(`<w:p>${aiIns(1, 'a')}${humanIns(2, 'b')}${aiDel(3, 'c')}</w:p>`);
+      const ids = resolveSelectedIds(collectRevisionElements(doc), { author: AI });
+      expect([...ids].sort()).toEqual(['1', '3']);
+    });
+  });
+
+  describe('non-overlapping accept — per revision type, foreign revisions preserved', () => {
+    it('accepts an AI insertion and leaves a foreign insertion byte-identical', () => {
+      const doc = body(`<w:p><w:r><w:t>keep </w:t></w:r>${aiIns(1, 'ai ')}${humanIns(2, 'human')}</w:p>`);
+      const foreignBefore = humanIns(2, 'human');
+      const { result } = acceptAIEdits(doc, { author: AI });
+      const out = xml(doc);
+      expect(result.insertionsAccepted).toBe(1);
+      expect(out).toContain('ai '); // inserted text promoted
+      expect(out).not.toContain('w:id="1"'); // AI ins wrapper gone
+      expect(out).toContain(foreignBefore); // foreign ins untouched, byte-for-byte
+    });
+
+    it('accepts an AI deletion (text removed) and leaves a foreign deletion intact', () => {
+      const doc = body(`<w:p>${aiDel(1, 'gone ')}${humanDel(2, 'stay-deleted')}</w:p>`);
+      const foreignBefore = humanDel(2, 'stay-deleted');
+      const { result } = acceptAIEdits(doc, { author: AI });
+      const out = xml(doc);
+      expect(result.deletionsAccepted).toBe(1);
+      expect(out).not.toContain('gone');
+      expect(out).toContain(foreignBefore);
+    });
+
+    it('accepts an AI rPrChange and leaves a foreign rPrChange intact', () => {
+      const aiRun = `<w:r><w:rPr><w:b/><w:rPrChange w:id="1" w:author="${AI}"><w:rPr/></w:rPrChange></w:rPr><w:t>x</w:t></w:r>`;
+      const humanRun = `<w:r><w:rPr><w:i/><w:rPrChange w:id="2" w:author="${HUMAN}"><w:rPr/></w:rPrChange></w:rPr><w:t>y</w:t></w:r>`;
+      const doc = body(`<w:p>${aiRun}${humanRun}</w:p>`);
+      const { result } = acceptAIEdits(doc, { author: AI });
+      const out = xml(doc);
+      expect(result.propertyChangesResolved).toBe(1);
+      expect(out).not.toContain('w:id="1"'); // AI rPrChange removed (change accepted)
+      expect(out).toContain('w:id="2"'); // foreign rPrChange kept
+      expect(out).toContain('<w:b/>'); // accepted formatting retained
+    });
+
+    it('accepts an AI paragraph-mark deletion (merge) without touching a foreign mark', () => {
+      const doc = body(
+        `<w:p><w:pPr><w:rPr><w:del w:id="1" w:author="${AI}"/></w:rPr></w:pPr><w:r><w:t>first</w:t></w:r></w:p>` +
+          `<w:p><w:r><w:t>second</w:t></w:r></w:p>`,
+      );
+      const { result } = acceptAIEdits(doc, { author: AI });
+      const out = xml(doc);
+      // Paragraph-break deletion accepted → the two paragraphs merge.
+      expect(out).toContain('first');
+      expect(out).toContain('second');
+      expect(out).not.toContain('w:id="1"');
+      expect(result.deletionsAccepted).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('non-overlapping reject — per revision type, foreign revisions preserved', () => {
+    it('rejects an AI insertion (text removed) and keeps a foreign insertion', () => {
+      const doc = body(`<w:p>${aiIns(1, 'ai ')}${humanIns(2, 'human')}</w:p>`);
+      const foreignBefore = humanIns(2, 'human');
+      const { result } = rejectAIEdits(doc, { author: AI });
+      const out = xml(doc);
+      expect(result.insertionsRemoved).toBe(1);
+      expect(out).not.toContain('ai ');
+      expect(out).toContain(foreignBefore);
+    });
+
+    it('rejects an AI deletion (text restored) and keeps a foreign deletion', () => {
+      const doc = body(`<w:p>${aiDel(1, 'back ')}${humanDel(2, 'stay-deleted')}</w:p>`);
+      const foreignBefore = humanDel(2, 'stay-deleted');
+      const { result } = rejectAIEdits(doc, { author: AI });
+      const out = xml(doc);
+      expect(result.deletionsRestored).toBe(1);
+      expect(out).toContain('back'); // delText restored as text
+      expect(out).not.toContain('w:delText xml:space="preserve">back'); // no longer a deletion
+      expect(out).toContain(foreignBefore); // foreign delText kept as delText
+    });
+  });
+
+  describe('targeting a subset by id', () => {
+    it('accepts only the listed ids, leaving same-author siblings untouched', () => {
+      const doc = body(`<w:p>${aiIns(1, 'one ')}${aiIns(2, 'two')}</w:p>`);
+      const sibling = aiIns(2, 'two');
+      acceptAIEdits(doc, { revisionIds: [1] });
+      const out = xml(doc);
+      expect(out).toContain('one');
+      expect(out).not.toContain('w:id="1"');
+      expect(out).toContain(sibling); // id 2 untouched
+    });
+  });
+
+  describe('ambiguous overlap', () => {
+    const overlap = body(
+      `<w:p><w:ins w:id="10" w:author="${AI}"><w:del w:id="11" w:author="${HUMAN}"><w:r><w:delText>x</w:delText></w:r></w:del></w:ins></w:p>`,
+    );
+
+    it('detects a foreign revision nested inside a targeted one', () => {
+      const overlaps = detectAmbiguousOverlaps(overlap, new Set(['10']));
+      expect(overlaps).toHaveLength(1);
+      expect(overlaps[0]).toMatchObject({ outerId: '10', outerAuthor: AI, innerId: '11', innerAuthor: HUMAN });
+    });
+
+    it('hard-errors on accept with a structured overlap list', () => {
+      let err: unknown;
+      try {
+        acceptAIEdits(body(
+          `<w:p><w:ins w:id="10" w:author="${AI}"><w:del w:id="11" w:author="${HUMAN}"><w:r><w:delText>x</w:delText></w:r></w:del></w:ins></w:p>`,
+        ), { author: AI });
+      } catch (e) {
+        err = e;
+      }
+      expect(err).toBeInstanceOf(AmbiguousRevisionOverlapError);
+      expect((err as AmbiguousRevisionOverlapError).overlaps[0]!.innerId).toBe('11');
+    });
+
+    it('hard-errors symmetrically on reject', () => {
+      expect(() =>
+        rejectAIEdits(body(
+          `<w:p><w:ins w:id="10" w:author="${AI}"><w:del w:id="11" w:author="${HUMAN}"><w:r><w:delText>x</w:delText></w:r></w:del></w:ins></w:p>`,
+        ), { author: AI }),
+      ).toThrow(AmbiguousRevisionOverlapError);
+    });
+
+    it('normalizeFirst bypasses the hard-error (best-effort)', () => {
+      const doc = body(
+        `<w:p><w:ins w:id="10" w:author="${AI}"><w:del w:id="11" w:author="${HUMAN}"><w:r><w:delText>x</w:delText></w:r></w:del></w:ins></w:p>`,
+      );
+      const { selectedIds } = acceptAIEdits(doc, { author: AI, normalizeFirst: true });
+      expect(selectedIds).toEqual(['10']);
+      // The foreign del is not selected, so it survives even in best-effort mode.
+      expect(xml(doc)).toContain('w:id="11"');
+    });
+
+    it('does not flag a property change legitimately nested in an inserted run', () => {
+      const doc = body(
+        `<w:p><w:ins w:id="1" w:author="${AI}"><w:r><w:rPr><w:rPrChange w:id="2" w:author="${AI}"><w:rPr/></w:rPrChange></w:rPr><w:t>x</w:t></w:r></w:ins></w:p>`,
+      );
+      const overlaps = detectAmbiguousOverlaps(doc, new Set(['1', '2']));
+      expect(overlaps).toHaveLength(0);
+    });
+  });
+});

--- a/packages/docx-core/src/primitives/accept_ai_edits.ts
+++ b/packages/docx-core/src/primitives/accept_ai_edits.ts
@@ -38,6 +38,45 @@ const W_NS = OOXML.W_NS;
  */
 const OVERLAP_CONTAINER_LOCALS = new Set(['ins', 'del', 'moveFrom', 'moveTo']);
 
+/**
+ * Property-change revision records. Accepting removes the record; rejecting
+ * rewrites the enclosing property element — so a selected one that shares its
+ * property container with a foreign revision is ambiguous.
+ */
+const PROPERTY_CHANGE_LOCALS = new Set([
+  'rPrChange', 'pPrChange', 'sectPrChange', 'tblPrChange',
+  'tblPrExChange', 'trPrChange', 'tcPrChange', 'tblGridChange', 'numberingChange',
+]);
+
+/** A `w:ins`/`w:del` that is a paragraph-mark marker (child of `w:pPr > w:rPr`). */
+function isParagraphMarkMarker(el: Element): boolean {
+  if (el.localName !== 'ins' && el.localName !== 'del') return false;
+  const parent = el.parentNode as Element | null;
+  const grand = parent?.parentNode as Element | null;
+  return (
+    !!parent && parent.namespaceURI === W_NS && parent.localName === 'rPr' &&
+    !!grand && grand.namespaceURI === W_NS && grand.localName === 'pPr'
+  );
+}
+
+/**
+ * The property element whose contents accept/reject would rewrite or drop when
+ * resolving `el`: the nearest enclosing `w:pPr` (so a paragraph-mark or pPrChange
+ * collision is seen across the whole paragraph properties), else `el`'s direct
+ * parent property element (a run's `w:rPr` for a run-level rPrChange).
+ */
+function enclosingPropertyContainer(el: Element): Element | null {
+  let cur: Node | null = el.parentNode;
+  while (cur) {
+    if (cur.nodeType === 1 && (cur as Element).namespaceURI === W_NS && (cur as Element).localName === 'pPr') {
+      return cur as Element;
+    }
+    cur = cur.parentNode;
+  }
+  const parent = el.parentNode;
+  return parent && parent.nodeType === 1 ? (parent as Element) : null;
+}
+
 /** Selector for a selective accept/reject operation. */
 export interface AiEditSelector {
   /** Explicit `w:id` values to target (strings or numbers). Primary signature. */
@@ -186,6 +225,30 @@ export function detectAmbiguousOverlaps(root: Element | Document, selectedIds: S
         }
       }
       anc = anc.parentNode;
+    }
+  }
+
+  // Property-container collision: a selected property-change or paragraph-mark
+  // revision that shares its property container (w:pPr or a run's w:rPr) with a
+  // foreign revision. Accepting a paragraph-mark merge drops the source w:pPr,
+  // and rejecting a property change rewrites the container — either would alter
+  // the foreign revision, so it is ambiguous.
+  for (let i = 0; i < all.length; i++) {
+    const el = all[i]!;
+    const isProperty = PROPERTY_CHANGE_LOCALS.has(el.localName) || isParagraphMarkMarker(el);
+    if (!isProperty) continue;
+    const id = revisionElementId(el);
+    if (id == null || !selectedIds.has(id)) continue;
+
+    const container = enclosingPropertyContainer(el);
+    if (!container) continue;
+    const siblings = container.getElementsByTagNameNS(W_NS, '*');
+    for (let j = 0; j < siblings.length; j++) {
+      const s = siblings[j]!;
+      if (s === el) continue;
+      if (!TRACKED_CHANGE_ELEMENT_NAME_SET.has(s.localName)) continue;
+      const sid = revisionElementId(s);
+      if (sid == null || !selectedIds.has(sid)) record(el, s);
     }
   }
   return overlaps;

--- a/packages/docx-core/src/primitives/accept_ai_edits.ts
+++ b/packages/docx-core/src/primitives/accept_ai_edits.ts
@@ -1,0 +1,236 @@
+/**
+ * accept_ai_edits — selective accept/reject of tracked changes by revision id or
+ * author (#123).
+ *
+ * The strongest argument for tracked-changes-as-canonical (#118/#120) is that
+ * acceptance can target only the AI actor's revisions, leaving any pre-existing
+ * third-party tracked changes byte-untouched. This module resolves a target set
+ * of revision ids (directly, or from an author string), refuses ambiguous
+ * overlaps by default, and drives the existing (whole-document) accept/reject
+ * engines through a revision-id filter so only the targeted revisions are
+ * resolved.
+ *
+ * Ambiguity: OOXML permits — but Word does not define behavior for — a revision
+ * of one actor structurally containing a revision of another (nested
+ * `w:ins`/`w:del`/`w:moveFrom`/`w:moveTo`). Selective accept/reject is defined
+ * only on a normalized, non-overlapping revision graph; the ambiguous case
+ * hard-errors with a structured list of the offending pairs unless the caller
+ * opts into `normalizeFirst` (best-effort, no byte-identical promise).
+ */
+
+import { OOXML } from './namespaces.js';
+import { TRACKED_CHANGE_ELEMENT_NAME_SET } from './revision-vocabulary.js';
+import {
+  acceptChanges,
+  revisionElementId,
+  type AcceptChangesResult,
+  type RevisionFilter,
+} from './accept_changes.js';
+import { rejectChanges, type RejectChangesResult } from './reject_changes.js';
+
+const W_NS = OOXML.W_NS;
+
+/**
+ * Content-wrapper revisions whose cross-actor nesting is the ambiguous case the
+ * spec calls out ("Word doesn't support nested ins/del/move"). Property-change
+ * and cell-topology revisions are excluded: a `w:rPrChange` legitimately sits
+ * inside an inserted run without making acceptance ambiguous.
+ */
+const OVERLAP_CONTAINER_LOCALS = new Set(['ins', 'del', 'moveFrom', 'moveTo']);
+
+/** Selector for a selective accept/reject operation. */
+export interface AiEditSelector {
+  /** Explicit `w:id` values to target (strings or numbers). Primary signature. */
+  revisionIds?: Array<string | number>;
+  /** Convenience: resolve every revision authored by this `w:author` to its id. */
+  author?: string;
+  /**
+   * Opt in to best-effort operation on an ambiguous (overlapping) graph instead
+   * of hard-erroring. Foreign revisions are still left in place, but byte-identical
+   * preservation is not promised in ambiguous cases.
+   */
+  normalizeFirst?: boolean;
+}
+
+/** One offending pair where a targeted revision overlaps a non-targeted one. */
+export interface AiRevisionOverlap {
+  outerId: string | null;
+  outerLocalName: string;
+  outerAuthor: string | null;
+  innerId: string | null;
+  innerLocalName: string;
+  innerAuthor: string | null;
+}
+
+/** Thrown when selective accept/reject would touch an ambiguous revision graph. */
+export class AmbiguousRevisionOverlapError extends Error {
+  readonly code = 'AMBIGUOUS_REVISION_OVERLAP';
+  readonly overlaps: AiRevisionOverlap[];
+  constructor(overlaps: AiRevisionOverlap[]) {
+    super(
+      `Selective accept/reject is ambiguous: ${overlaps.length} revision overlap(s) where a ` +
+        `targeted revision structurally contains, or is contained by, a non-targeted revision. ` +
+        `Pass normalizeFirst to attempt best-effort resolution.`,
+    );
+    this.name = 'AmbiguousRevisionOverlapError';
+    this.overlaps = overlaps;
+  }
+}
+
+export interface SelectiveAcceptResult {
+  result: AcceptChangesResult;
+  selectedIds: string[];
+  overlaps: AiRevisionOverlap[];
+}
+
+export interface SelectiveRejectResult {
+  result: RejectChangesResult;
+  selectedIds: string[];
+  overlaps: AiRevisionOverlap[];
+}
+
+function storyRoot(doc: Document): Element | null {
+  return doc.getElementsByTagNameNS(W_NS, 'body').item(0) ?? doc.documentElement ?? null;
+}
+
+function revisionAuthor(el: Element): string | null {
+  return el.getAttributeNS(W_NS, 'author') ?? el.getAttribute('w:author');
+}
+
+/** Every tracked-change element under `root` (any revision type). */
+export function collectRevisionElements(root: Element | Document): Element[] {
+  const out: Element[] = [];
+  const all = root.getElementsByTagNameNS(W_NS, '*');
+  for (let i = 0; i < all.length; i++) {
+    const el = all[i]!;
+    if (TRACKED_CHANGE_ELEMENT_NAME_SET.has(el.localName)) out.push(el);
+  }
+  return out;
+}
+
+/**
+ * Resolve the target revision-id set from a selector, given the revision
+ * elements available across all stories. `revisionIds` wins when provided;
+ * otherwise `author` resolves to the ids of every revision it authored.
+ */
+export function resolveSelectedIds(revisionElements: Element[], selector: AiEditSelector): Set<string> {
+  const ids = new Set<string>();
+  if (selector.revisionIds && selector.revisionIds.length > 0) {
+    for (const id of selector.revisionIds) ids.add(String(id));
+    return ids;
+  }
+  if (selector.author != null) {
+    for (const el of revisionElements) {
+      if (revisionAuthor(el) === selector.author) {
+        const id = revisionElementId(el);
+        if (id != null) ids.add(id);
+      }
+    }
+    return ids;
+  }
+  throw new Error('AiEditSelector requires either revisionIds or author.');
+}
+
+/**
+ * Find ambiguous overlaps within a single story: a targeted content-wrapper
+ * revision that structurally contains — or is contained by — a non-targeted
+ * content-wrapper revision.
+ */
+export function detectAmbiguousOverlaps(root: Element | Document, selectedIds: Set<string>): AiRevisionOverlap[] {
+  const overlaps: AiRevisionOverlap[] = [];
+  const seen = new Set<string>();
+  const record = (outer: Element, inner: Element): void => {
+    const oid = revisionElementId(outer);
+    const iid = revisionElementId(inner);
+    const key = `${oid}|${iid}|${outer.localName}|${inner.localName}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    overlaps.push({
+      outerId: oid,
+      outerLocalName: outer.localName,
+      outerAuthor: revisionAuthor(outer),
+      innerId: iid,
+      innerLocalName: inner.localName,
+      innerAuthor: revisionAuthor(inner),
+    });
+  };
+
+  const isSelectedContainer = (el: Element): boolean => {
+    if (!OVERLAP_CONTAINER_LOCALS.has(el.localName)) return false;
+    const id = revisionElementId(el);
+    return id != null && selectedIds.has(id);
+  };
+
+  const all = root.getElementsByTagNameNS(W_NS, '*');
+  for (let i = 0; i < all.length; i++) {
+    const el = all[i]!;
+    if (!isSelectedContainer(el)) continue;
+
+    // Foreign container revision nested INSIDE the selected one.
+    const descendants = el.getElementsByTagNameNS(W_NS, '*');
+    for (let j = 0; j < descendants.length; j++) {
+      const d = descendants[j]!;
+      if (!OVERLAP_CONTAINER_LOCALS.has(d.localName)) continue;
+      const did = revisionElementId(d);
+      if (did == null || !selectedIds.has(did)) record(el, d);
+    }
+
+    // Selected revision nested INSIDE a foreign container revision.
+    let anc: Node | null = el.parentNode;
+    while (anc) {
+      if (anc.nodeType === 1) {
+        const a = anc as Element;
+        if (a.namespaceURI === W_NS && OVERLAP_CONTAINER_LOCALS.has(a.localName)) {
+          const aid = revisionElementId(a);
+          if (aid == null || !selectedIds.has(aid)) record(a, el);
+        }
+      }
+      anc = anc.parentNode;
+    }
+  }
+  return overlaps;
+}
+
+/** Build a revision filter that matches exactly the selected ids. */
+export function selectedIdFilter(selectedIds: Set<string>): RevisionFilter {
+  return (el: Element) => {
+    const id = revisionElementId(el);
+    return id != null && selectedIds.has(id);
+  };
+}
+
+/**
+ * Accept only the targeted revisions in a single story `doc`, leaving all other
+ * revisions byte-untouched. Hard-errors on an ambiguous overlap unless
+ * `normalizeFirst` is set. Mutates `doc` in place.
+ */
+export function acceptAIEdits(doc: Document, selector: AiEditSelector): SelectiveAcceptResult {
+  const root = storyRoot(doc);
+  if (!root) return { result: emptyAccept(), selectedIds: [], overlaps: [] };
+  const selectedIds = resolveSelectedIds(collectRevisionElements(root), selector);
+  const overlaps = selector.normalizeFirst ? [] : detectAmbiguousOverlaps(root, selectedIds);
+  if (overlaps.length > 0) throw new AmbiguousRevisionOverlapError(overlaps);
+  const result = acceptChanges(doc, { filter: selectedIdFilter(selectedIds) });
+  return { result, selectedIds: [...selectedIds], overlaps };
+}
+
+/**
+ * Reject only the targeted revisions in a single story `doc`, leaving all other
+ * revisions byte-untouched. Symmetric to {@link acceptAIEdits}.
+ */
+export function rejectAIEdits(doc: Document, selector: AiEditSelector): SelectiveRejectResult {
+  const root = storyRoot(doc);
+  if (!root) return { result: emptyReject(), selectedIds: [], overlaps: [] };
+  const selectedIds = resolveSelectedIds(collectRevisionElements(root), selector);
+  const overlaps = selector.normalizeFirst ? [] : detectAmbiguousOverlaps(root, selectedIds);
+  if (overlaps.length > 0) throw new AmbiguousRevisionOverlapError(overlaps);
+  const result = rejectChanges(doc, { filter: selectedIdFilter(selectedIds) });
+  return { result, selectedIds: [...selectedIds], overlaps };
+}
+
+function emptyAccept(): AcceptChangesResult {
+  return { insertionsAccepted: 0, deletionsAccepted: 0, movesResolved: 0, propertyChangesResolved: 0 };
+}
+function emptyReject(): RejectChangesResult {
+  return { insertionsRemoved: 0, deletionsRestored: 0, movesReverted: 0, propertyChangesReverted: 0 };
+}

--- a/packages/docx-core/src/primitives/accept_changes.ts
+++ b/packages/docx-core/src/primitives/accept_changes.ts
@@ -26,6 +26,22 @@ export type AcceptChangesResult = {
   propertyChangesResolved: number;
 };
 
+/**
+ * Predicate selecting which revision elements a sweep processes. The default
+ * ({@link ACCEPT_ALL}) processes every revision — the original whole-document
+ * behavior. `acceptAIEdits`/`rejectAIEdits` (#123) pass a predicate that matches
+ * only the targeted revision ids so foreign (non-target) revisions are left
+ * byte-untouched.
+ */
+export type RevisionFilter = (el: Element) => boolean;
+
+const ACCEPT_ALL: RevisionFilter = () => true;
+
+/** The package-wide revision id (`w:id`) of a revision element, if any. */
+export function revisionElementId(el: Element): string | null {
+  return el.getAttributeNS(W_NS, 'id') ?? el.getAttribute('w:id');
+}
+
 // ── DOM helpers (internal) ──────────────────────────────────────────
 
 function isW(node: Node, localName: string): node is Element {
@@ -50,8 +66,12 @@ function collectByLocalName(container: Document | Element, localName: string): E
   return Array.from(container.getElementsByTagNameNS(W_NS, localName));
 }
 
-function removeAllByLocalName(container: Document | Element, localName: string): number {
-  const elements = collectByLocalName(container, localName);
+function removeAllByLocalName(
+  container: Document | Element,
+  localName: string,
+  filter: RevisionFilter = ACCEPT_ALL,
+): number {
+  const elements = collectByLocalName(container, localName).filter(filter);
   let count = 0;
   for (const el of elements) {
     if (el.parentNode) {
@@ -62,8 +82,12 @@ function removeAllByLocalName(container: Document | Element, localName: string):
   return count;
 }
 
-function unwrapAllByLocalName(container: Document | Element, localName: string): number {
-  const elements = collectByLocalName(container, localName);
+function unwrapAllByLocalName(
+  container: Document | Element,
+  localName: string,
+  filter: RevisionFilter = ACCEPT_ALL,
+): number {
+  const elements = collectByLocalName(container, localName).filter(filter);
   // Sort deepest-first to handle nested wrappers correctly
   elements.sort((a, b) => getDepth(b) - getDepth(a));
   let count = 0;
@@ -84,7 +108,11 @@ function unwrapAllByLocalName(container: Document | Element, localName: string):
  * Check if a paragraph has a paragraph-level revision marker.
  * Pattern: w:p > w:pPr > w:rPr > w:del (or w:ins)
  */
-function paragraphHasParaMarker(p: Element, markerLocalName: string): boolean {
+function paragraphHasParaMarker(
+  p: Element,
+  markerLocalName: string,
+  filter: RevisionFilter = ACCEPT_ALL,
+): boolean {
   for (let i = 0; i < p.childNodes.length; i++) {
     const child = p.childNodes[i]!;
     if (!isW(child, 'pPr')) continue;
@@ -93,7 +121,7 @@ function paragraphHasParaMarker(p: Element, markerLocalName: string): boolean {
       if (!isW(pPrChild, 'rPr')) continue;
       for (let k = 0; k < pPrChild.childNodes.length; k++) {
         const rPrChild = pPrChild.childNodes[k]!;
-        if (isW(rPrChild, markerLocalName)) return true;
+        if (isW(rPrChild, markerLocalName) && filter(rPrChild)) return true;
       }
     }
   }
@@ -254,7 +282,12 @@ function resolveParagraphMarkRevision(p: Element): void {
  * Mutates the Document in place (same convention as simplifyRedlines
  * and mergeRuns).
  */
-export function acceptChanges(doc: Document): AcceptChangesResult {
+export function acceptChanges(
+  doc: Document,
+  opts?: { filter?: RevisionFilter },
+): AcceptChangesResult {
+  const filter = opts?.filter ?? ACCEPT_ALL;
+  const selective = filter !== ACCEPT_ALL;
   const root = doc.getElementsByTagNameNS(W_NS, 'body').item(0) ?? doc.documentElement;
   if (!root) {
     return { insertionsAccepted: 0, deletionsAccepted: 0, movesResolved: 0, propertyChangesResolved: 0 };
@@ -275,31 +308,33 @@ export function acceptChanges(doc: Document): AcceptChangesResult {
     // accept. safe-docx's deleted paragraphs always carry the mark now, so the
     // mark-based rule suffices and is Word-faithful. (Mirrors acceptAllChanges and the
     // reject-side rule.)
-    if (paragraphHasParaMarker(p, 'del')) {
+    if (paragraphHasParaMarker(p, 'del', filter)) {
       markDeletedParagraphs.push(p);
     }
   }
 
   // Phase B — Remove deletions and move sources
-  const deletionsAccepted = removeAllByLocalName(root, 'del');
-  const moveFromRemoved = removeAllByLocalName(root, 'moveFrom');
-  removeAllByLocalName(root, 'moveFromRangeStart');
-  removeAllByLocalName(root, 'moveFromRangeEnd');
-  removeAllByLocalName(root, 'moveToRangeStart');
-  removeAllByLocalName(root, 'moveToRangeEnd');
+  const deletionsAccepted = removeAllByLocalName(root, 'del', filter);
+  const moveFromRemoved = removeAllByLocalName(root, 'moveFrom', filter);
+  removeAllByLocalName(root, 'moveFromRangeStart', filter);
+  removeAllByLocalName(root, 'moveFromRangeEnd', filter);
+  removeAllByLocalName(root, 'moveToRangeStart', filter);
+  removeAllByLocalName(root, 'moveToRangeEnd', filter);
 
   // Phase C — Unwrap insertions and move destinations (depth-sorted)
-  const insertionsAccepted = unwrapAllByLocalName(root, 'ins');
-  const moveToUnwrapped = unwrapAllByLocalName(root, 'moveTo');
+  const insertionsAccepted = unwrapAllByLocalName(root, 'ins', filter);
+  const moveToUnwrapped = unwrapAllByLocalName(root, 'moveTo', filter);
 
   // Phase D — Remove property change records
   let propertyChangesResolved = 0;
   for (const localName of PR_CHANGE_LOCALS) {
-    propertyChangesResolved += removeAllByLocalName(root, localName);
+    propertyChangesResolved += removeAllByLocalName(root, localName, filter);
   }
 
   // Phase E — Cleanup
-  // Strip paragraph-level revision markers from w:pPr/w:rPr
+  // Strip paragraph-level revision markers from w:pPr/w:rPr (only those the
+  // filter selects, so a selective accept leaves foreign paragraph-mark
+  // revisions byte-untouched).
   for (const p of collectByLocalName(root, 'p')) {
     for (let i = 0; i < p.childNodes.length; i++) {
       const child = p.childNodes[i]!;
@@ -311,7 +346,7 @@ export function acceptChanges(doc: Document): AcceptChangesResult {
         const toRemove: Element[] = [];
         for (let k = 0; k < pPrChild.childNodes.length; k++) {
           const rPrChild = pPrChild.childNodes[k]!;
-          if (isW(rPrChild, 'ins') || isW(rPrChild, 'del')) {
+          if ((isW(rPrChild, 'ins') || isW(rPrChild, 'del')) && filter(rPrChild)) {
             toRemove.push(rPrChild as Element);
           }
         }
@@ -329,16 +364,22 @@ export function acceptChanges(doc: Document): AcceptChangesResult {
     resolveParagraphMarkRevision(p);
   }
 
-  // Strip w:rsidDel attributes on remaining elements
-  const allElements = root.getElementsByTagNameNS(W_NS, '*');
-  for (let i = 0; i < allElements.length; i++) {
-    const el = allElements[i]!;
-    if (el.hasAttributeNS(W_NS, 'rsidDel')) {
-      el.removeAttributeNS(W_NS, 'rsidDel');
-    }
-    // Also check prefixed form
-    if (el.hasAttribute('w:rsidDel')) {
-      el.removeAttribute('w:rsidDel');
+  // Strip w:rsidDel attributes on remaining elements. Skipped in selective
+  // mode: rsidDel is a document-wide save-id, and a selective accept must not
+  // mutate elements outside the targeted revision set (the mixed-author
+  // byte-identical invariant, #125). The accepted revisions are removed/unwrapped
+  // above, taking their own rsidDel with them.
+  if (!selective) {
+    const allElements = root.getElementsByTagNameNS(W_NS, '*');
+    for (let i = 0; i < allElements.length; i++) {
+      const el = allElements[i]!;
+      if (el.hasAttributeNS(W_NS, 'rsidDel')) {
+        el.removeAttributeNS(W_NS, 'rsidDel');
+      }
+      // Also check prefixed form
+      if (el.hasAttribute('w:rsidDel')) {
+        el.removeAttribute('w:rsidDel');
+      }
     }
   }
 

--- a/packages/docx-core/src/primitives/document.ts
+++ b/packages/docx-core/src/primitives/document.ts
@@ -66,6 +66,8 @@ import {
   type AiEditSelector,
   type AiRevisionOverlap,
 } from './accept_ai_edits.js';
+import { revisionElementId } from './accept_changes.js';
+import { TRACKED_CHANGE_ELEMENT_NAME_SET } from './revision-vocabulary.js';
 import {
   bootstrapCommentParts,
   addComment as addCommentImpl,
@@ -157,7 +159,26 @@ function collectLiveFootnoteRefIds(doc: Document): Set<number> {
 // The corresponding <w:footnote w:id=N> in footnotes.xml is then unreachable —
 // remove it so the side part matches the post-sweep body. Reserved separator /
 // continuationSeparator entries are preserved unconditionally.
-function pruneOrphanedFootnotes(footnotesDoc: Document, liveRefIds: Set<number>): number {
+/**
+ * True iff a footnote entry contains a tracked-change element whose id is not in
+ * `selectedIds` — a foreign revision that a selective sweep must not delete.
+ */
+function footnoteHasForeignRevision(fn: Element, selectedIds: Set<string>): boolean {
+  const els = fn.getElementsByTagNameNS(OOXML.W_NS, '*');
+  for (let i = 0; i < els.length; i++) {
+    const el = els.item(i) as Element;
+    if (!TRACKED_CHANGE_ELEMENT_NAME_SET.has(el.localName)) continue;
+    const id = revisionElementId(el);
+    if (id == null || !selectedIds.has(id)) return true;
+  }
+  return false;
+}
+
+function pruneOrphanedFootnotes(
+  footnotesDoc: Document,
+  liveRefIds: Set<number>,
+  protectForeign?: Set<string>,
+): number {
   const entries = Array.from(footnotesDoc.getElementsByTagNameNS(OOXML.W_NS, W.footnote));
   let pruned = 0;
   for (const fn of entries) {
@@ -166,6 +187,10 @@ function pruneOrphanedFootnotes(footnotesDoc: Document, liveRefIds: Set<number>)
     const id = parseWId(fn);
     if (id === null) continue;
     if (liveRefIds.has(id)) continue;
+    // Selective mode: never delete a note that still carries a foreign revision
+    // (the mixed-author byte-identical invariant, #123/#125). Leaving an
+    // unreferenced note is package hygiene at worst, not data loss.
+    if (protectForeign && footnoteHasForeignRevision(fn, protectForeign)) continue;
     fn.parentNode?.removeChild(fn);
     pruned++;
   }
@@ -465,7 +490,7 @@ export class DocxDocument {
 
       let footnotesPruned = 0;
       if (story.path === 'word/footnotes.xml' && liveFootnoteRefIds) {
-        footnotesPruned = pruneOrphanedFootnotes(story.doc, liveFootnoteRefIds);
+        footnotesPruned = pruneOrphanedFootnotes(story.doc, liveFootnoteRefIds, selectedIds);
       }
       if (hasAcceptedChanges(partResult) || footnotesPruned > 0) {
         this.zip.writeText(story.path, serializeXml(story.doc));
@@ -503,7 +528,7 @@ export class DocxDocument {
 
       let footnotesPruned = 0;
       if (story.path === 'word/footnotes.xml' && liveFootnoteRefIds) {
-        footnotesPruned = pruneOrphanedFootnotes(story.doc, liveFootnoteRefIds);
+        footnotesPruned = pruneOrphanedFootnotes(story.doc, liveFootnoteRefIds, selectedIds);
       }
       if (hasRejectedChanges(partResult) || footnotesPruned > 0) {
         this.zip.writeText(story.path, serializeXml(story.doc));

--- a/packages/docx-core/src/primitives/document.ts
+++ b/packages/docx-core/src/primitives/document.ts
@@ -58,6 +58,15 @@ import {
 import { acceptChanges as acceptChangesImpl, type AcceptChangesResult } from './accept_changes.js';
 import { rejectChanges as rejectChangesImpl, type RejectChangesResult } from './reject_changes.js';
 import {
+  collectRevisionElements,
+  resolveSelectedIds,
+  detectAmbiguousOverlaps,
+  selectedIdFilter,
+  AmbiguousRevisionOverlapError,
+  type AiEditSelector,
+  type AiRevisionOverlap,
+} from './accept_ai_edits.js';
+import {
   bootstrapCommentParts,
   addComment as addCommentImpl,
   addCommentReply as addCommentReplyImpl,
@@ -401,6 +410,112 @@ export class DocxDocument {
       this.documentViewCache = null;
     }
     return total;
+  }
+
+  /**
+   * Read all revisionable stories (document.xml + supported side parts) as parsed
+   * Documents, resolve the selector's target revision-id set across every story
+   * (a revision id is package-wide), and hard-error on any ambiguous overlap
+   * unless the selector opts into `normalizeFirst`.
+   */
+  private async prepareSelectiveStories(
+    selector: AiEditSelector,
+  ): Promise<{ stories: Array<{ path: string | null; doc: Document }>; selectedIds: Set<string> }> {
+    const stories: Array<{ path: string | null; doc: Document }> = [
+      { path: null, doc: this.documentXml },
+    ];
+    for (const partPath of REVISION_STORY_PART_PATHS) {
+      const xml = await this.zip.readTextOrNull(partPath);
+      if (xml) stories.push({ path: partPath, doc: parseXml(xml) });
+    }
+
+    const allRevisionElements = stories.flatMap((s) => collectRevisionElements(s.doc));
+    const selectedIds = resolveSelectedIds(allRevisionElements, selector);
+
+    if (!selector.normalizeFirst) {
+      const overlaps: AiRevisionOverlap[] = stories.flatMap((s) =>
+        detectAmbiguousOverlaps(s.doc, selectedIds),
+      );
+      if (overlaps.length > 0) throw new AmbiguousRevisionOverlapError(overlaps);
+    }
+    return { stories, selectedIds };
+  }
+
+  /**
+   * Accept only the revisions named by `selector` (by id or author) across
+   * document.xml and supported side-story parts, leaving every other revision
+   * byte-untouched (#123). Hard-errors on an ambiguous overlap unless
+   * `normalizeFirst` is set.
+   */
+  async acceptAIEdits(selector: AiEditSelector): Promise<{ result: AcceptChangesResult; selectedIds: string[] }> {
+    const { stories, selectedIds } = await this.prepareSelectiveStories(selector);
+    const filter = selectedIdFilter(selectedIds);
+    const total = emptyAcceptChangesResult();
+
+    const bodyResult = acceptChangesImpl(this.documentXml, { filter });
+    addAcceptChangesResult(total, bodyResult);
+    const liveFootnoteRefIds = bodyResult.deletionsAccepted > 0
+      ? collectLiveFootnoteRefIds(this.documentXml)
+      : null;
+
+    for (const story of stories) {
+      if (story.path == null) continue; // document.xml already swept above
+      const partResult = acceptChangesImpl(story.doc, { filter });
+      addAcceptChangesResult(total, partResult);
+
+      let footnotesPruned = 0;
+      if (story.path === 'word/footnotes.xml' && liveFootnoteRefIds) {
+        footnotesPruned = pruneOrphanedFootnotes(story.doc, liveFootnoteRefIds);
+      }
+      if (hasAcceptedChanges(partResult) || footnotesPruned > 0) {
+        this.zip.writeText(story.path, serializeXml(story.doc));
+        if (story.path === 'word/footnotes.xml') this.footnotesXml = story.doc;
+      }
+    }
+
+    if (hasAcceptedChanges(total)) {
+      this.dirty = true;
+      this.documentViewCache = null;
+    }
+    return { result: total, selectedIds: [...selectedIds] };
+  }
+
+  /**
+   * Reject only the revisions named by `selector` across document.xml and
+   * supported side-story parts, leaving every other revision byte-untouched.
+   * Symmetric to {@link DocxDocument.acceptAIEdits}.
+   */
+  async rejectAIEdits(selector: AiEditSelector): Promise<{ result: RejectChangesResult; selectedIds: string[] }> {
+    const { stories, selectedIds } = await this.prepareSelectiveStories(selector);
+    const filter = selectedIdFilter(selectedIds);
+    const total = emptyRejectChangesResult();
+
+    const bodyResult = rejectChangesImpl(this.documentXml, { filter });
+    addRejectChangesResult(total, bodyResult);
+    const liveFootnoteRefIds = bodyResult.insertionsRemoved > 0
+      ? collectLiveFootnoteRefIds(this.documentXml)
+      : null;
+
+    for (const story of stories) {
+      if (story.path == null) continue;
+      const partResult = rejectChangesImpl(story.doc, { filter });
+      addRejectChangesResult(total, partResult);
+
+      let footnotesPruned = 0;
+      if (story.path === 'word/footnotes.xml' && liveFootnoteRefIds) {
+        footnotesPruned = pruneOrphanedFootnotes(story.doc, liveFootnoteRefIds);
+      }
+      if (hasRejectedChanges(partResult) || footnotesPruned > 0) {
+        this.zip.writeText(story.path, serializeXml(story.doc));
+        if (story.path === 'word/footnotes.xml') this.footnotesXml = story.doc;
+      }
+    }
+
+    if (hasRejectedChanges(total)) {
+      this.dirty = true;
+      this.documentViewCache = null;
+    }
+    return { result: total, selectedIds: [...selectedIds] };
   }
 
   removeJuniorBookmarks(): number {

--- a/packages/docx-core/src/primitives/index.ts
+++ b/packages/docx-core/src/primitives/index.ts
@@ -24,6 +24,7 @@ export * from './revision-vocabulary.js';
 export * from './revision-parts.js';
 export * from './accept_changes.js';
 export * from './reject_changes.js';
+export * from './accept_ai_edits.js';
 export * from './extract_revisions.js';
 export * from './comments.js';
 export * from './footnotes.js';

--- a/packages/docx-core/src/primitives/reject_changes.ts
+++ b/packages/docx-core/src/primitives/reject_changes.ts
@@ -15,8 +15,27 @@
  */
 
 import { OOXML } from './namespaces.js';
+import type { RevisionFilter } from './accept_changes.js';
 
 const W_NS = OOXML.W_NS;
+
+const ACCEPT_ALL: RevisionFilter = () => true;
+
+/** True iff `el` has an ancestor element with the given WordprocessingML local name. */
+function hasWAncestor(el: Node, localName: string): boolean {
+  let cur: Node | null = el.parentNode;
+  while (cur) {
+    if (
+      cur.nodeType === 1 &&
+      (cur as Element).namespaceURI === W_NS &&
+      (cur as Element).localName === localName
+    ) {
+      return true;
+    }
+    cur = cur.parentNode;
+  }
+  return false;
+}
 
 export type RejectChangesResult = {
   insertionsRemoved: number;
@@ -49,8 +68,12 @@ function collectByLocalName(container: Document | Element, localName: string): E
   return Array.from(container.getElementsByTagNameNS(W_NS, localName));
 }
 
-function removeAllByLocalName(container: Document | Element, localName: string): number {
-  const elements = collectByLocalName(container, localName);
+function removeAllByLocalName(
+  container: Document | Element,
+  localName: string,
+  filter: RevisionFilter = ACCEPT_ALL,
+): number {
+  const elements = collectByLocalName(container, localName).filter(filter);
   let count = 0;
   for (const el of elements) {
     if (el.parentNode) {
@@ -61,8 +84,12 @@ function removeAllByLocalName(container: Document | Element, localName: string):
   return count;
 }
 
-function unwrapAllByLocalName(container: Document | Element, localName: string): number {
-  const elements = collectByLocalName(container, localName);
+function unwrapAllByLocalName(
+  container: Document | Element,
+  localName: string,
+  filter: RevisionFilter = ACCEPT_ALL,
+): number {
+  const elements = collectByLocalName(container, localName).filter(filter);
   // Sort deepest-first to handle nested wrappers correctly
   elements.sort((a, b) => getDepth(b) - getDepth(a));
   let count = 0;
@@ -79,10 +106,14 @@ function unwrapAllByLocalName(container: Document | Element, localName: string):
 }
 
 /**
- * Check if a paragraph has a paragraph-level revision marker.
+ * Check if a paragraph has a paragraph-level revision marker the filter selects.
  * Pattern: w:p > w:pPr > w:rPr > w:ins (or w:del)
  */
-function paragraphHasParaMarker(p: Element, markerLocalName: string): boolean {
+function paragraphHasParaMarker(
+  p: Element,
+  markerLocalName: string,
+  filter: RevisionFilter = ACCEPT_ALL,
+): boolean {
   for (let i = 0; i < p.childNodes.length; i++) {
     const child = p.childNodes[i]!;
     if (!isW(child, 'pPr')) continue;
@@ -91,7 +122,7 @@ function paragraphHasParaMarker(p: Element, markerLocalName: string): boolean {
       if (!isW(pPrChild, 'rPr')) continue;
       for (let k = 0; k < pPrChild.childNodes.length; k++) {
         const rPrChild = pPrChild.childNodes[k]!;
-        if (isW(rPrChild, markerLocalName)) return true;
+        if (isW(rPrChild, markerLocalName) && filter(rPrChild)) return true;
       }
     }
   }
@@ -337,7 +368,12 @@ function relocateBookmarks(p: Element, paragraphsToRemove: Set<Element>): void {
  *
  * Mutates the Document in place (same convention as acceptChanges).
  */
-export function rejectChanges(doc: Document): RejectChangesResult {
+export function rejectChanges(
+  doc: Document,
+  opts?: { filter?: RevisionFilter },
+): RejectChangesResult {
+  const filter = opts?.filter ?? ACCEPT_ALL;
+  const selective = filter !== ACCEPT_ALL;
   const root = doc.getElementsByTagNameNS(W_NS, 'body').item(0) ?? doc.documentElement;
   if (!root) {
     return { insertionsRemoved: 0, deletionsRestored: 0, movesReverted: 0, propertyChangesReverted: 0 };
@@ -357,7 +393,7 @@ export function rejectChanges(doc: Document): RejectChangesResult {
     // inserted into a pre-existing paragraph, which Word/LibreOffice keep (empty) on
     // reject. safe-docx's inserted paragraphs always carry the mark now, so the
     // mark-based rule suffices and is Word-faithful. (Mirrors rejectAllChanges.)
-    if (paragraphHasParaMarker(p, 'ins')) {
+    if (paragraphHasParaMarker(p, 'ins', filter)) {
       markInsertedParagraphs.add(p);
     }
   }
@@ -372,18 +408,21 @@ export function rejectChanges(doc: Document): RejectChangesResult {
   }
 
   // Phase C — Remove insertions and move destinations
-  const insertionsRemoved = removeAllByLocalName(root, 'ins');
-  const moveToRemoved = removeAllByLocalName(root, 'moveTo');
-  removeAllByLocalName(root, 'moveToRangeStart');
-  removeAllByLocalName(root, 'moveToRangeEnd');
-  removeAllByLocalName(root, 'moveFromRangeStart');
-  removeAllByLocalName(root, 'moveFromRangeEnd');
+  const insertionsRemoved = removeAllByLocalName(root, 'ins', filter);
+  const moveToRemoved = removeAllByLocalName(root, 'moveTo', filter);
+  removeAllByLocalName(root, 'moveToRangeStart', filter);
+  removeAllByLocalName(root, 'moveToRangeEnd', filter);
+  removeAllByLocalName(root, 'moveFromRangeStart', filter);
+  removeAllByLocalName(root, 'moveFromRangeEnd', filter);
 
   // Phase D — Unwrap deletions and convert w:delText → w:t
-  const deletionsRestored = unwrapAllByLocalName(root, 'del');
+  const deletionsRestored = unwrapAllByLocalName(root, 'del', filter);
 
-  // Rename all w:delText elements to w:t so getParagraphText() sees them
-  const delTexts = collectByLocalName(root, 'delText');
+  // Rename w:delText → w:t so getParagraphText() sees the restored text — but
+  // only for delTexts whose w:del wrapper was just unwrapped (no surviving w:del
+  // ancestor). In selective mode a foreign (non-target) w:del is left intact, so
+  // its w:delText must stay w:delText and must not be touched.
+  const delTexts = collectByLocalName(root, 'delText').filter((dt) => !hasWAncestor(dt, 'del'));
   for (const dt of delTexts) {
     const parent = dt.parentNode;
     if (!parent) continue;
@@ -402,12 +441,12 @@ export function rejectChanges(doc: Document): RejectChangesResult {
   }
 
   // Phase E — Unwrap move sources (keep content at original position)
-  const moveFromUnwrapped = unwrapAllByLocalName(root, 'moveFrom');
+  const moveFromUnwrapped = unwrapAllByLocalName(root, 'moveFrom', filter);
 
   // Phase F — Restore original properties from *PrChange records
   let propertyChangesReverted = 0;
   for (const localName of PR_CHANGE_LOCALS) {
-    const changes = collectByLocalName(root, localName);
+    const changes = collectByLocalName(root, localName).filter(filter);
     // Sort deepest-first
     changes.sort((a, b) => getDepth(b) - getDepth(a));
     for (const change of changes) {
@@ -456,7 +495,7 @@ export function rejectChanges(doc: Document): RejectChangesResult {
         const toRemove: Element[] = [];
         for (let k = 0; k < pPrChild.childNodes.length; k++) {
           const rPrChild = pPrChild.childNodes[k]!;
-          if (isW(rPrChild, 'ins') || isW(rPrChild, 'del')) {
+          if ((isW(rPrChild, 'ins') || isW(rPrChild, 'del')) && filter(rPrChild)) {
             toRemove.push(rPrChild as Element);
           }
         }
@@ -474,15 +513,18 @@ export function rejectChanges(doc: Document): RejectChangesResult {
     resolveParagraphMarkRevision(p);
   }
 
-  // Strip w:rsidDel attributes on remaining elements
-  const allElements = root.getElementsByTagNameNS(W_NS, '*');
-  for (let i = 0; i < allElements.length; i++) {
-    const el = allElements[i]!;
-    if (el.hasAttributeNS(W_NS, 'rsidDel')) {
-      el.removeAttributeNS(W_NS, 'rsidDel');
-    }
-    if (el.hasAttribute('w:rsidDel')) {
-      el.removeAttribute('w:rsidDel');
+  // Strip w:rsidDel attributes on remaining elements. Skipped in selective mode
+  // so a targeted reject leaves foreign elements byte-untouched (#125).
+  if (!selective) {
+    const allElements = root.getElementsByTagNameNS(W_NS, '*');
+    for (let i = 0; i < allElements.length; i++) {
+      const el = allElements[i]!;
+      if (el.hasAttributeNS(W_NS, 'rsidDel')) {
+        el.removeAttributeNS(W_NS, 'rsidDel');
+      }
+      if (el.hasAttribute('w:rsidDel')) {
+        el.removeAttribute('w:rsidDel');
+      }
     }
   }
 

--- a/packages/docx-core/src/primitives/reject_changes.ts
+++ b/packages/docx-core/src/primitives/reject_changes.ts
@@ -420,9 +420,13 @@ export function rejectChanges(
 
   // Rename w:delText → w:t so getParagraphText() sees the restored text — but
   // only for delTexts whose w:del wrapper was just unwrapped (no surviving w:del
-  // ancestor). In selective mode a foreign (non-target) w:del is left intact, so
-  // its w:delText must stay w:delText and must not be touched.
-  const delTexts = collectByLocalName(root, 'delText').filter((dt) => !hasWAncestor(dt, 'del'));
+  // ancestor). In selective mode a foreign (non-target) revision is left intact,
+  // so we additionally exclude delText inside a surviving w:moveFrom (a foreign
+  // move source also carries w:delText that must not be touched); a targeted del
+  // is never nested in a foreign move (that case hard-errors as ambiguous).
+  const delTexts = collectByLocalName(root, 'delText').filter(
+    (dt) => !hasWAncestor(dt, 'del') && (!selective || !hasWAncestor(dt, 'moveFrom')),
+  );
   for (const dt of delTexts) {
     const parent = dt.parentNode;
     if (!parent) continue;

--- a/packages/docx-mcp/docs/tool-reference.generated.md
+++ b/packages/docx-mcp/docs/tool-reference.generated.md
@@ -183,6 +183,34 @@ Accept all tracked changes in the document body, producing a clean document with
 | --- | --- | --- | --- |
 | `file_path` | `string` | yes | Path to the DOCX or ODT file. |
 
+## `accept_ai_edits`
+
+Selectively accept tracked changes by revision id or author, leaving all other (e.g. third-party reviewer) revisions byte-untouched. Provide revision_ids (array of w:id values) to target specific revisions, or author to accept every revision by one actor. Sweeps document.xml and supported side-story parts (footnotes, endnotes, comments). An ambiguous overlap — a targeted revision structurally containing, or contained by, a non-targeted revision (nested ins/del/move) — hard-errors with code AMBIGUOUS_REVISION_OVERLAP and a structured `overlaps` list unless normalize_first is set (best-effort, no byte-identical promise).
+
+- readOnly: `false`
+- destructive: `true`
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `file_path` | `string` | yes | Path to the DOCX or ODT file. |
+| `revision_ids` | `array<unknown>` | no | w:id values of the revisions to accept. Mutually preferred over author. |
+| `author` | `string` | no | Accept every revision authored by this w:author. Convenience alternative to revision_ids. |
+| `normalize_first` | `boolean` | no | Attempt best-effort resolution on an ambiguous (overlapping) revision graph instead of hard-erroring. No byte-identical guarantee. Default: false. |
+
+## `reject_ai_edits`
+
+Selectively reject tracked changes by revision id or author (restoring their pre-edit state), leaving all other revisions byte-untouched. Symmetric to accept_ai_edits: provide revision_ids or author, sweeps document.xml and supported side-story parts, and hard-errors on an ambiguous overlap (code AMBIGUOUS_REVISION_OVERLAP with a structured `overlaps` list) unless normalize_first is set.
+
+- readOnly: `false`
+- destructive: `true`
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `file_path` | `string` | yes | Path to the DOCX or ODT file. |
+| `revision_ids` | `array<unknown>` | no | w:id values of the revisions to reject. Mutually preferred over author. |
+| `author` | `string` | no | Reject every revision authored by this w:author. Convenience alternative to revision_ids. |
+| `normalize_first` | `boolean` | no | Attempt best-effort resolution on an ambiguous (overlapping) revision graph instead of hard-erroring. No byte-identical guarantee. Default: false. |
+
 ## `has_tracked_changes`
 
 Check whether the document body contains tracked-change markers (insertions, deletions, moves, and property-change records). Read-only.

--- a/packages/docx-mcp/src/server.ts
+++ b/packages/docx-mcp/src/server.ts
@@ -19,6 +19,8 @@ import { hasTrackedChanges_tool } from './tools/has_tracked_changes.js';
 import { closeFile } from './tools/close_file.js';
 import { formatLayout } from './tools/format_layout.js';
 import { acceptChanges } from './tools/accept_changes.js';
+import { acceptAiEdits } from './tools/accept_ai_edits.js';
+import { rejectAiEdits } from './tools/reject_ai_edits.js';
 import { addComment } from './tools/add_comment.js';
 import { getComments } from './tools/get_comments.js';
 import { deleteComment } from './tools/delete_comment.js';
@@ -185,6 +187,10 @@ export async function dispatchToolCall(
       return await formatLayout(sessions, args as Parameters<typeof formatLayout>[1]);
     case 'accept_changes':
       return await acceptChanges(sessions, args as Parameters<typeof acceptChanges>[1]);
+    case 'accept_ai_edits':
+      return await acceptAiEdits(sessions, args as Parameters<typeof acceptAiEdits>[1]);
+    case 'reject_ai_edits':
+      return await rejectAiEdits(sessions, args as Parameters<typeof rejectAiEdits>[1]);
     case 'has_tracked_changes':
       return await hasTrackedChanges_tool(sessions, args as Parameters<typeof hasTrackedChanges_tool>[1]);
     case 'get_file_status':

--- a/packages/docx-mcp/src/tool_catalog.ts
+++ b/packages/docx-mcp/src/tool_catalog.ts
@@ -315,6 +315,50 @@ export const SAFE_DOCX_TOOL_CATALOG = [
     annotations: { readOnlyHint: false, destructiveHint: true },
   },
   {
+    name: 'accept_ai_edits',
+    surface: 'internal',
+    description:
+      'Selectively accept tracked changes by revision id or author, leaving all other (e.g. third-party reviewer) revisions byte-untouched. Provide revision_ids (array of w:id values) to target specific revisions, or author to accept every revision by one actor. Sweeps document.xml and supported side-story parts (footnotes, endnotes, comments). An ambiguous overlap — a targeted revision structurally containing, or contained by, a non-targeted revision (nested ins/del/move) — hard-errors with code AMBIGUOUS_REVISION_OVERLAP and a structured `overlaps` list unless normalize_first is set (best-effort, no byte-identical promise).',
+    input: z.object({
+      ...FILE_FIELD,
+      revision_ids: z
+        .array(z.union([z.string(), z.number()]))
+        .optional()
+        .describe('w:id values of the revisions to accept. Mutually preferred over author.'),
+      author: z
+        .string()
+        .optional()
+        .describe('Accept every revision authored by this w:author. Convenience alternative to revision_ids.'),
+      normalize_first: z
+        .boolean()
+        .optional()
+        .describe('Attempt best-effort resolution on an ambiguous (overlapping) revision graph instead of hard-erroring. No byte-identical guarantee. Default: false.'),
+    }),
+    annotations: { readOnlyHint: false, destructiveHint: true },
+  },
+  {
+    name: 'reject_ai_edits',
+    surface: 'internal',
+    description:
+      'Selectively reject tracked changes by revision id or author (restoring their pre-edit state), leaving all other revisions byte-untouched. Symmetric to accept_ai_edits: provide revision_ids or author, sweeps document.xml and supported side-story parts, and hard-errors on an ambiguous overlap (code AMBIGUOUS_REVISION_OVERLAP with a structured `overlaps` list) unless normalize_first is set.',
+    input: z.object({
+      ...FILE_FIELD,
+      revision_ids: z
+        .array(z.union([z.string(), z.number()]))
+        .optional()
+        .describe('w:id values of the revisions to reject. Mutually preferred over author.'),
+      author: z
+        .string()
+        .optional()
+        .describe('Reject every revision authored by this w:author. Convenience alternative to revision_ids.'),
+      normalize_first: z
+        .boolean()
+        .optional()
+        .describe('Attempt best-effort resolution on an ambiguous (overlapping) revision graph instead of hard-erroring. No byte-identical guarantee. Default: false.'),
+    }),
+    annotations: { readOnlyHint: false, destructiveHint: true },
+  },
+  {
     name: 'has_tracked_changes',
     surface: 'internal',
     description: 'Check whether the document body contains tracked-change markers (insertions, deletions, moves, and property-change records). Read-only.',

--- a/packages/docx-mcp/src/tools/accept_ai_edits.ts
+++ b/packages/docx-mcp/src/tools/accept_ai_edits.ts
@@ -1,0 +1,58 @@
+import { SessionManager } from '../session/manager.js';
+import { errorMessage } from '../error_utils.js';
+import { resolveSessionForTool, mergeSessionResolutionMetadata } from './session_resolution.js';
+import { ok, err, type ToolResponse } from './types.js';
+import { AmbiguousRevisionOverlapError } from '@usejunior/docx-core';
+
+/**
+ * accept_ai_edits — selectively accept tracked changes by revision id or author
+ * (#123), leaving all other (e.g. third-party reviewer) revisions untouched.
+ */
+export async function acceptAiEdits(
+  manager: SessionManager,
+  params: {
+    file_path?: string;
+    revision_ids?: Array<string | number>;
+    author?: string;
+    normalize_first?: boolean;
+  },
+): Promise<ToolResponse> {
+  const resolved = await resolveSessionForTool(manager, params, { toolName: 'accept_ai_edits' });
+  if (!resolved.ok) return resolved.response;
+  const { session, metadata } = resolved;
+
+  const hasIds = Array.isArray(params.revision_ids) && params.revision_ids.length > 0;
+  if (!hasIds && (params.author == null || params.author === '')) {
+    return err(
+      'MISSING_PARAMETER',
+      'Provide revision_ids or author.',
+      "Target specific w:id values with revision_ids, or every revision by one actor with author.",
+    );
+  }
+
+  try {
+    const { result, selectedIds } = await session.doc.acceptAIEdits({
+      revisionIds: params.revision_ids,
+      author: params.author,
+      normalizeFirst: params.normalize_first,
+    });
+    manager.markEdited(session);
+    return ok(mergeSessionResolutionMetadata({
+      ...result,
+      selected_revision_ids: selectedIds,
+      file_path: manager.normalizePath(session.originalPath),
+    }, metadata));
+  } catch (e: unknown) {
+    if (e instanceof AmbiguousRevisionOverlapError) {
+      return {
+        ...err(
+          'AMBIGUOUS_REVISION_OVERLAP',
+          e.message,
+          'Pass normalize_first=true for best-effort resolution, or target a non-overlapping revision set.',
+        ),
+        overlaps: e.overlaps,
+      };
+    }
+    return err('ACCEPT_AI_EDITS_ERROR', errorMessage(e));
+  }
+}

--- a/packages/docx-mcp/src/tools/add_selective_ai_accept_reject.test.ts
+++ b/packages/docx-mcp/src/tools/add_selective_ai_accept_reject.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect } from 'vitest';
+import { DocxZip } from '@usejunior/docx-core';
+import { SessionManager, type DocxSession } from '../session/manager.js';
+import { acceptAiEdits } from './accept_ai_edits.js';
+import { rejectAiEdits } from './reject_ai_edits.js';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { assertFailure, assertSuccess, openSession, registerCleanup } from '../testing/session-test-utils.js';
+
+const TEST_FEATURE = 'add-selective-ai-accept-reject';
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const AI = 'SafeDocX AI';
+const HUMAN = 'Reviewer';
+
+const test = testAllure.epic('Document Editing').withLabels({ feature: TEST_FEATURE });
+
+function manager(): SessionManager {
+  return new SessionManager({ defaultAiAuthor: AI });
+}
+
+function documentXml(bodyInner: string): string {
+  return (
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<w:document xmlns:w="${W}"><w:body>${bodyInner}</w:body></w:document>`
+  );
+}
+
+// Revision ids start at 101 so they never collide with the bookmark ids
+// (w:id="1"...) that normalization backfills on open.
+const MIXED_AUTHOR_BODY =
+  `<w:p><w:r><w:t xml:space="preserve">base </w:t></w:r>` +
+  `<w:ins w:id="101" w:author="${AI}"><w:r><w:t xml:space="preserve">ai-add </w:t></w:r></w:ins>` +
+  `<w:ins w:id="102" w:author="${HUMAN}"><w:r><w:t xml:space="preserve">human-add </w:t></w:r></w:ins>` +
+  `<w:del w:id="103" w:author="${AI}"><w:r><w:delText xml:space="preserve">ai-del </w:delText></w:r></w:del>` +
+  `<w:del w:id="104" w:author="${HUMAN}"><w:r><w:delText xml:space="preserve">human-del</w:delText></w:r></w:del></w:p>`;
+
+// A visible anchor paragraph so the session read finds a paragraph id, followed
+// by the overlap paragraph (AI ins structurally containing a reviewer del).
+const OVERLAP_BODY =
+  `<w:p><w:r><w:t xml:space="preserve">anchor</w:t></w:r></w:p>` +
+  `<w:p><w:ins w:id="107" w:author="${AI}">` +
+  `<w:del w:id="108" w:author="${HUMAN}"><w:r><w:delText>x</w:delText></w:r></w:del></w:ins></w:p>`;
+
+async function docxSession(mgr: SessionManager, filePath: string): Promise<DocxSession> {
+  const session = await mgr.getSessionByFilePath(filePath);
+  if (!session || session.provider !== 'docx') throw new Error('Expected DOCX session');
+  return session;
+}
+
+async function readDocumentXml(mgr: SessionManager, filePath: string): Promise<string> {
+  const session = await docxSession(mgr, filePath);
+  const { buffer } = await session.doc.toBuffer({ cleanBookmarks: false });
+  const zip = await DocxZip.load(buffer);
+  return zip.readText('word/document.xml');
+}
+
+describe('Selective accept/reject AI edits (#123)', () => {
+  registerCleanup();
+
+  test.openspec('accept ai edits by author preserves foreign revisions')(
+    'Scenario: accept ai edits by author preserves foreign revisions',
+    async ({ given, when, then }: AllureBddContext) => {
+      const opened = await given('a session with interleaved AI and reviewer revisions', () =>
+        openSession([], { mgr: manager(), xml: documentXml(MIXED_AUTHOR_BODY) }),
+      );
+
+      const result = await when('accept_ai_edits is called with the AI author', () =>
+        acceptAiEdits(opened.mgr, { file_path: opened.filePath, author: AI }),
+      );
+
+      await then('AI revisions are accepted and reviewer revisions are preserved', async () => {
+        assertSuccess(result, 'accept_ai_edits');
+        expect(result.selected_revision_ids).toEqual(expect.arrayContaining(['101', '103']));
+        const xml = await readDocumentXml(opened.mgr, opened.filePath);
+        expect(xml).toContain('ai-add'); // AI insertion accepted (text kept)
+        expect(xml).not.toContain('ai-del'); // AI deletion accepted (text gone)
+        expect(xml).not.toContain('w:id="101"'); // AI ins wrapper removed
+        expect(xml).toContain('w:id="102"'); // reviewer insertion untouched
+        expect(xml).toContain('human-del'); // reviewer deletion still deleted (delText kept)
+        expect(xml).toContain('w:id="104"');
+      });
+    },
+  );
+
+  test.openspec('reject ai edits by author preserves foreign revisions')(
+    'Scenario: reject ai edits by author preserves foreign revisions',
+    async ({ given, when, then }: AllureBddContext) => {
+      const opened = await given('a session with interleaved AI and reviewer revisions', () =>
+        openSession([], { mgr: manager(), xml: documentXml(MIXED_AUTHOR_BODY) }),
+      );
+
+      const result = await when('reject_ai_edits is called with the AI author', () =>
+        rejectAiEdits(opened.mgr, { file_path: opened.filePath, author: AI }),
+      );
+
+      await then('AI revisions are reverted and reviewer revisions are preserved', async () => {
+        assertSuccess(result, 'reject_ai_edits');
+        const xml = await readDocumentXml(opened.mgr, opened.filePath);
+        expect(xml).not.toContain('ai-add'); // AI insertion rejected (text gone)
+        expect(xml).toContain('ai-del'); // AI deletion rejected (text restored)
+        expect(xml).toContain('w:id="102"'); // reviewer insertion untouched
+        expect(xml).toContain('w:id="104"'); // reviewer deletion untouched
+        expect(xml).toContain('human-add');
+      });
+    },
+  );
+
+  test.openspec('accept ai edits by explicit revision ids')(
+    'Scenario: accept ai edits by explicit revision ids',
+    async ({ given, when, then }: AllureBddContext) => {
+      const opened = await given('a session containing several AI revisions', () =>
+        openSession([], { mgr: manager(), xml: documentXml(MIXED_AUTHOR_BODY) }),
+      );
+
+      const result = await when('accept_ai_edits is called with a subset of revision_ids', () =>
+        acceptAiEdits(opened.mgr, { file_path: opened.filePath, revision_ids: [101] }),
+      );
+
+      await then('only the listed revision is accepted and reported', async () => {
+        assertSuccess(result, 'accept_ai_edits');
+        expect(result.selected_revision_ids).toEqual(['101']);
+        const xml = await readDocumentXml(opened.mgr, opened.filePath);
+        expect(xml).not.toContain('w:id="101"'); // id 1 accepted
+        expect(xml).toContain('w:id="103"'); // other AI revision (id 3) untouched
+        expect(xml).toContain('ai-del');
+      });
+    },
+  );
+
+  test.openspec('missing selector is rejected')(
+    'Scenario: missing selector is rejected',
+    async ({ given, when, then }: AllureBddContext) => {
+      const opened = await given('a session document', () =>
+        openSession([], { mgr: manager(), xml: documentXml(MIXED_AUTHOR_BODY) }),
+      );
+
+      const result = await when('accept_ai_edits is called with neither revision_ids nor author', () =>
+        acceptAiEdits(opened.mgr, { file_path: opened.filePath }),
+      );
+
+      await then('the request is rejected with MISSING_PARAMETER', () => {
+        assertFailure(result, 'MISSING_PARAMETER');
+      });
+    },
+  );
+
+  test.openspec('ambiguous overlap hard-errors with structured overlaps')(
+    'Scenario: ambiguous overlap hard-errors with structured overlaps',
+    async ({ given, when, then }: AllureBddContext) => {
+      const opened = await given('a session where an AI revision contains a reviewer revision', () =>
+        openSession([], { mgr: manager(), xml: documentXml(OVERLAP_BODY) }),
+      );
+
+      const result = await when('accept_ai_edits is called for the AI author without normalize_first', () =>
+        acceptAiEdits(opened.mgr, { file_path: opened.filePath, author: AI }),
+      );
+
+      await then('it fails with AMBIGUOUS_REVISION_OVERLAP and a structured overlaps list', () => {
+        assertFailure(result, 'AMBIGUOUS_REVISION_OVERLAP');
+        const overlaps = result.overlaps as Array<{ outerId: string; innerId: string; innerAuthor: string }>;
+        expect(overlaps).toHaveLength(1);
+        expect(overlaps[0]).toMatchObject({ outerId: '107', innerId: '108', innerAuthor: HUMAN });
+      });
+    },
+  );
+
+  test.openspec('normalize first bypasses the ambiguity error')(
+    'Scenario: normalize first bypasses the ambiguity error',
+    async ({ given, when, then }: AllureBddContext) => {
+      const opened = await given('a session with an ambiguous revision overlap', () =>
+        openSession([], { mgr: manager(), xml: documentXml(OVERLAP_BODY) }),
+      );
+
+      const result = await when('accept_ai_edits is called with normalize_first', () =>
+        acceptAiEdits(opened.mgr, { file_path: opened.filePath, author: AI, normalize_first: true }),
+      );
+
+      await then('it succeeds best-effort and the reviewer revision survives', async () => {
+        assertSuccess(result, 'accept_ai_edits');
+        const xml = await readDocumentXml(opened.mgr, opened.filePath);
+        expect(xml).toContain('w:id="108"'); // foreign (reviewer) revision still present
+      });
+    },
+  );
+});

--- a/packages/docx-mcp/src/tools/reject_ai_edits.ts
+++ b/packages/docx-mcp/src/tools/reject_ai_edits.ts
@@ -1,0 +1,59 @@
+import { SessionManager } from '../session/manager.js';
+import { errorMessage } from '../error_utils.js';
+import { resolveSessionForTool, mergeSessionResolutionMetadata } from './session_resolution.js';
+import { ok, err, type ToolResponse } from './types.js';
+import { AmbiguousRevisionOverlapError } from '@usejunior/docx-core';
+
+/**
+ * reject_ai_edits — selectively reject tracked changes by revision id or author
+ * (#123), restoring their pre-edit state while leaving all other revisions
+ * untouched. Symmetric to accept_ai_edits.
+ */
+export async function rejectAiEdits(
+  manager: SessionManager,
+  params: {
+    file_path?: string;
+    revision_ids?: Array<string | number>;
+    author?: string;
+    normalize_first?: boolean;
+  },
+): Promise<ToolResponse> {
+  const resolved = await resolveSessionForTool(manager, params, { toolName: 'reject_ai_edits' });
+  if (!resolved.ok) return resolved.response;
+  const { session, metadata } = resolved;
+
+  const hasIds = Array.isArray(params.revision_ids) && params.revision_ids.length > 0;
+  if (!hasIds && (params.author == null || params.author === '')) {
+    return err(
+      'MISSING_PARAMETER',
+      'Provide revision_ids or author.',
+      "Target specific w:id values with revision_ids, or every revision by one actor with author.",
+    );
+  }
+
+  try {
+    const { result, selectedIds } = await session.doc.rejectAIEdits({
+      revisionIds: params.revision_ids,
+      author: params.author,
+      normalizeFirst: params.normalize_first,
+    });
+    manager.markEdited(session);
+    return ok(mergeSessionResolutionMetadata({
+      ...result,
+      selected_revision_ids: selectedIds,
+      file_path: manager.normalizePath(session.originalPath),
+    }, metadata));
+  } catch (e: unknown) {
+    if (e instanceof AmbiguousRevisionOverlapError) {
+      return {
+        ...err(
+          'AMBIGUOUS_REVISION_OVERLAP',
+          e.message,
+          'Pass normalize_first=true for best-effort resolution, or target a non-overlapping revision set.',
+        ),
+        overlaps: e.overlaps,
+      };
+    }
+    return err('REJECT_AI_EDITS_ERROR', errorMessage(e));
+  }
+}

--- a/packages/safe-docx-mcpb/manifest.json
+++ b/packages/safe-docx-mcpb/manifest.json
@@ -65,6 +65,14 @@
       "description": "Accept tracked changes in the document body."
     },
     {
+      "name": "accept_ai_edits",
+      "description": "Selectively accept tracked changes by revision id or author, preserving other reviewers' revisions."
+    },
+    {
+      "name": "reject_ai_edits",
+      "description": "Selectively reject tracked changes by revision id or author, preserving other reviewers' revisions."
+    },
+    {
       "name": "has_tracked_changes",
       "description": "Check whether the current document body contains tracked-change markers."
     },


### PR DESCRIPTION
## What & why

Part of epic #118. Adds **selective accept/reject** so acceptance can target only the AI actor's revisions and leave any pre-existing third-party tracked changes **byte-untouched**. This is the precondition for the mixed-author preservation corpus (#124/#125) and for removing whole-document comparison from the default finalization path (#126).

## Changes

- **docx-core**: `acceptAIEdits(doc, {revisionIds|author})` / `rejectAIEdits(...)` + `DocxDocument.acceptAIEdits/rejectAIEdits` (sweeps document.xml + side-story parts, resolving ids package-wide).
- **Engine reuse**: threads an optional revision-id filter through the existing (tested) accept/reject engines — default is whole-document (backward compatible). In selective mode the global `rsidDel` strip and the `delText→t` rename are guarded so foreign elements are never mutated (the #125 byte-identical invariant).
- **Ambiguity**: a targeted revision structurally containing, or contained by, a non-targeted **content-wrapper** revision (nested ins/del/move) hard-errors with `AMBIGUOUS_REVISION_OVERLAP` + a structured `overlaps` list. `normalize_first` opts into best-effort. Property changes legitimately nested in an inserted run are **not** false positives.
- **MCP**: `accept_ai_edits` / `reject_ai_edits` tools + catalog + server dispatch.
- **OpenSpec**: `add-selective-ai-accept-reject` (mcp-server delta, 6 scenarios).

## Verification

- 14 docx-core unit tests (per revision type, foreign-revision byte preservation, subset-by-id, ambiguous hard-error, `normalizeFirst`, no false positive on nested property change).
- 6 MCP e2e scenarios.
- Full `docx-core` (1609) + `docx-mcp` (874) suites green — **no regression** in the whole-document accept/reject path. lint, spec-coverage, conformance, cycles pass locally.

Refs #123
Part of #118

https://claude.ai/code/session_01AbPhuyQQAb1sReWxtS24hC