### PR TITLE
test(docx-core): invariant corpus for selective accept/reject [#124]

### DIFF
--- a/packages/docx-core/SUPPORT.md
+++ b/packages/docx-core/SUPPORT.md
@@ -68,28 +68,41 @@ classified programmatically in `packages/docx-mcp/src/tool_catalog.ts`
 
 Selective accept/reject ([#123](https://github.com/UseJunior/safe-docx/issues/123)) is exercised by a
 mixed-author invariant corpus at
-`packages/docx-core/src/integration/accept_reject_invariant_corpus.test.ts`. Each fixture
-carries an AI-authored revision, a foreign (reviewer) revision, and one document feature; after
-`acceptAIEdits` / `rejectAIEdits` targeting the AI author the corpus asserts the AI revision was
-resolved, the foreign revision is byte-identical, the feature is preserved, field structure stays
-balanced, and the document remains structurally valid.
+`packages/docx-core/src/integration/accept_reject_invariant_corpus.test.ts`. Each fixture carries an
+AI-authored revision, a foreign (reviewer) revision, and one document feature; after `acceptAIEdits`
+/ `rejectAIEdits` targeting the AI author the corpus asserts, per fixture, that **every** AI revision
+was resolved (0 remain), that the foreign revisions are **byte-identical** — their serialized
+subtrees, by author, are exactly equal (same set and count) before and after — that the feature is
+preserved, that field structure stays balanced, and that the body passes structural lint.
 
-| Feature / revision type | Accept | Reject | Round-trip evidence |
-| --- | --- | --- | --- |
-| `w:ins` / `w:del` (body) | ✅ | ✅ | validateDocument (CI); LibreOffice 25.8 headless (local, no recovery) |
-| `w:rPrChange` (foreign property change) | ✅ | ✅ | validateDocument (CI) |
-| Comment range markers (`w:commentRangeStart`/`End`) | ✅ | ✅ | validateDocument (CI) |
-| Bookmarks (`_bk_*` internal + user) | ✅ | ✅ | validateDocument (CI); LibreOffice 25.8 headless (local, no recovery) |
-| Content controls (`w:sdt`) | ✅ | ✅ | validateDocument (CI) |
-| Field codes (`w:fldChar` / `w:instrText`) | ✅ | ✅ | validateDocument (CI); LibreOffice 25.8 headless (local, no recovery) |
-| Numbering (`w:numPr`) | ✅ | ✅ | validateDocument (CI) |
-| Paragraph style (`w:pStyle`) | ✅ | ✅ | validateDocument (CI) |
-| Footnotes + reviewer revision in a note (side part) | ✅ | — | validateDocument (CI) |
+| Feature / revision preserved | Accept | Reject |
+| --- | --- | --- |
+| `w:ins` / `w:del` (body) | ✅ | ✅ |
+| `w:rPrChange` (foreign property change) | ✅ | ✅ |
+| `w:sectPrChange` (foreign section-properties change) | ✅ | ✅ |
+| `w:tcPrChange` (foreign table-cell-properties change) | ✅ | ✅ |
+| Comment range markers (`w:commentRangeStart`/`End`) | ✅ | ✅ |
+| Bookmarks (`_bk_*` internal + user) | ✅ | ✅ |
+| Content controls (`w:sdt`) | ✅ | ✅ |
+| Field codes (`w:fldChar` / `w:instrText`) | ✅ | ✅ |
+| Numbering reference (`w:numPr`) | ✅ | ✅ |
+| Paragraph / table styles (`w:pStyle`, table structure) | ✅ | ✅ |
+| Footnotes — reviewer revision inside a note (side part) | ✅ | ✅ |
+| Endnotes — reviewer revision inside a note (side part) | ✅ | ✅ |
 
-`validateDocument` (structural integrity + tracked-change/field balance) is the CI-runnable proxy for
-"opens without recovery"; Word runners are unavailable, so Word round-trip is manual/pending.
-LibreOffice headless round-trip was performed locally on representative accepted fixtures (`soffice
---convert-to pdf` produced valid output with no recovery prompt).
+`validateDocument` is **body-level structural lint** (bookmark pairing, tracked-change wrapper
+attributes, `w:fldChar` begin/end balance) — it is the CI assertion that the sweep did not corrupt the
+body, **not** a guarantee that Word/LibreOffice will open the file without recovery. Representative
+accepted fixtures (bookmarks, field codes) were additionally opened in **LibreOffice 25.8 headless**
+locally (`soffice --convert-to pdf`, no recovery prompt); Word round-trip is manual/pending.
+
+**Scope.** accept/reject resolves `w:ins`, `w:del`, `w:moveFrom`/`w:moveTo`, and the property changes
+`w:rPrChange`/`w:pPrChange`/`w:sectPrChange`/`w:tblPrChange`/`w:trPrChange`/`w:tcPrChange`. Cell-topology
+and grid/numbering revisions (`w:cellIns`/`w:cellDel`/`w:cellMerge`/`w:tblGridChange`/`w:numberingChange`)
+are **not** resolved by the engine and are not emitted by any current primitive (Appendix B), so they
+are deferred. Parts the sweep never reads — `styles.xml`, `numbering.xml`, headers/footers,
+relationships, content types — are preserved by construction; the corpus targets the swept stories
+(`document.xml` + `footnotes`/`endnotes`/`comments`) where preservation is non-trivial.
 
 ## Internal / non-contract utilities
 

--- a/packages/docx-core/SUPPORT.md
+++ b/packages/docx-core/SUPPORT.md
@@ -64,6 +64,33 @@ classified programmatically in `packages/docx-mcp/src/tool_catalog.ts`
 (`surface`: `revisionable` | `package-mutation` | `internal`, plus
 `emitsNonRevisionChanges`).
 
+### Accept/reject invariant coverage (implemented in [#124](https://github.com/UseJunior/safe-docx/issues/124))
+
+Selective accept/reject ([#123](https://github.com/UseJunior/safe-docx/issues/123)) is exercised by a
+mixed-author invariant corpus at
+`packages/docx-core/src/integration/accept_reject_invariant_corpus.test.ts`. Each fixture
+carries an AI-authored revision, a foreign (reviewer) revision, and one document feature; after
+`acceptAIEdits` / `rejectAIEdits` targeting the AI author the corpus asserts the AI revision was
+resolved, the foreign revision is byte-identical, the feature is preserved, field structure stays
+balanced, and the document remains structurally valid.
+
+| Feature / revision type | Accept | Reject | Round-trip evidence |
+| --- | --- | --- | --- |
+| `w:ins` / `w:del` (body) | ✅ | ✅ | validateDocument (CI); LibreOffice 25.8 headless (local, no recovery) |
+| `w:rPrChange` (foreign property change) | ✅ | ✅ | validateDocument (CI) |
+| Comment range markers (`w:commentRangeStart`/`End`) | ✅ | ✅ | validateDocument (CI) |
+| Bookmarks (`_bk_*` internal + user) | ✅ | ✅ | validateDocument (CI); LibreOffice 25.8 headless (local, no recovery) |
+| Content controls (`w:sdt`) | ✅ | ✅ | validateDocument (CI) |
+| Field codes (`w:fldChar` / `w:instrText`) | ✅ | ✅ | validateDocument (CI); LibreOffice 25.8 headless (local, no recovery) |
+| Numbering (`w:numPr`) | ✅ | ✅ | validateDocument (CI) |
+| Paragraph style (`w:pStyle`) | ✅ | ✅ | validateDocument (CI) |
+| Footnotes + reviewer revision in a note (side part) | ✅ | — | validateDocument (CI) |
+
+`validateDocument` (structural integrity + tracked-change/field balance) is the CI-runnable proxy for
+"opens without recovery"; Word runners are unavailable, so Word round-trip is manual/pending.
+LibreOffice headless round-trip was performed locally on representative accepted fixtures (`soffice
+--convert-to pdf` produced valid output with no recovery prompt).
+
 ## Internal / non-contract utilities
 
 These files are intentionally outside the revisionable-surface contract. Some perform XML mutations (e.g., bookmark scaffolding, run normalization, style elevation) but those mutations are internal/non-AI-attributable rather than user-directed edits. Others consume or normalize existing tracked changes instead of creating them. Either way, none are part of the promised AI-authored revision contract.

--- a/packages/docx-core/src/integration/accept_reject_invariant_corpus.test.ts
+++ b/packages/docx-core/src/integration/accept_reject_invariant_corpus.test.ts
@@ -2,45 +2,69 @@
  * Invariant test corpus for selective accept/reject (#124).
  *
  * A mixed-author corpus: every fixture carries an AI-authored revision, a
- * foreign (reviewer) revision, and one document feature that must survive the
- * operation. After acceptAIEdits / rejectAIEdits targeting the AI author we
- * assert, per fixture:
- *   - the AI revision was resolved (accepted or reverted),
- *   - the foreign revision is byte-identical (its serialized subtree is intact),
- *   - the document feature (comment ranges, bookmarks, content controls, field
- *     codes, section properties, numbering, styles) is preserved,
- *   - field structure stays balanced and the document remains structurally valid
- *     (validateDocument reports isValid — the CI-runnable proxy for "opens in
- *     Word/LibreOffice without recovery").
+ * foreign (reviewer) revision, and one document feature. After acceptAIEdits /
+ * rejectAIEdits targeting the AI author the corpus proves, per fixture:
+ *   - every AI-authored revision was resolved (0 remain),
+ *   - every foreign revision is BYTE-IDENTICAL — the serialized subtrees, by
+ *     author, are exactly equal (same set and count) before and after,
+ *   - the document feature is preserved,
+ *   - field structure stays balanced and the body passes structural lint
+ *     (validateDocument).
  *
- * Round-trip evidence: the built fixtures were opened in LibreOffice headless
- * (soffice --convert-to pdf) locally without a recovery prompt; see the PR notes.
- * CI asserts structural validity via validateDocument since Word/LibreOffice are
- * not available on the runners.
+ * Scope. accept/reject resolves the revision types the engine processes today:
+ * `w:ins`, `w:del`, `w:moveFrom`/`w:moveTo`, and the property changes
+ * `w:rPrChange`/`w:pPrChange`/`w:sectPrChange`/`w:tblPrChange`/`w:trPrChange`/
+ * `w:tcPrChange`. Cell-topology and grid/numbering revisions
+ * (`w:cellIns`/`w:cellDel`/`w:cellMerge`/`w:tblGridChange`/`w:numberingChange`)
+ * are not resolved by the engine and are not emitted by any current primitive
+ * (SUPPORT.md Appendix B), so they are deferred. Parts the sweep never reads —
+ * `styles.xml`, `numbering.xml`, headers/footers, relationships, content types —
+ * are preserved by construction; the corpus focuses on the swept stories
+ * (document.xml + footnotes/endnotes/comments) where preservation is non-trivial.
+ *
+ * `validateDocument` is body-level structural lint (bookmarks, tracked-change
+ * wrapper attributes, field balance), not a substitute for a Word/LibreOffice
+ * round-trip. Representative accepted fixtures were additionally opened in
+ * LibreOffice headless locally without a recovery prompt (see SUPPORT.md).
  */
 import { describe, expect } from 'vitest';
+import { XMLSerializer } from '@xmldom/xmldom';
 import { itAllure as it } from '../testing/allure-test.js';
 import { parseXml, serializeXml } from '../primitives/xml.js';
 import { acceptAIEdits, rejectAIEdits } from '../primitives/accept_ai_edits.js';
 import { validateDocument } from '../primitives/validate_document.js';
+import { TRACKED_CHANGE_ELEMENT_NAME_SET } from '../primitives/revision-vocabulary.js';
 import { DocxDocument } from '../primitives/document.js';
 import { DocxZip } from '../primitives/zip.js';
-import { buildDocxFromBodyXml } from '../testing/ooxml-fixtures.js';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const AI = 'SafeDocX AI';
 const HUMAN = 'Reviewer';
+const DT = 'w:date="2026-01-01T00:00:00Z"';
+const SECT = `<w:sectPr><w:pgSz w:w="12240" w:h="15840"/></w:sectPr>`;
+const serializer = new XMLSerializer();
 
 function docFromBody(inner: string): Document {
   return parseXml(`<?xml version="1.0"?><w:document xmlns:w="${W}"><w:body>${inner}${SECT}</w:body></w:document>`);
 }
-const SECT = `<w:sectPr><w:pgSz w:w="12240" w:h="15840"/></w:sectPr>`;
 
-// Reusable revision + feature fragments. AI id=101, reviewer id=102.
-const aiIns = `<w:ins w:id="101" w:author="${AI}" w:date="2026-01-01T00:00:00Z"><w:r><w:t xml:space="preserve">ai </w:t></w:r></w:ins>`;
-const foreignIns = `<w:ins w:id="102" w:author="${HUMAN}" w:date="2026-01-01T00:00:00Z"><w:r><w:t xml:space="preserve">reviewer</w:t></w:r></w:ins>`;
+/** Serialized subtrees of every tracked-change element authored by `author`, sorted. */
+function revisionSubtreesByAuthor(root: Document | Element, author: string): string[] {
+  const out: string[] = [];
+  const all = root.getElementsByTagNameNS(W, '*');
+  for (let i = 0; i < all.length; i++) {
+    const el = all[i]!;
+    if (!TRACKED_CHANGE_ELEMENT_NAME_SET.has(el.localName)) continue;
+    const a = el.getAttributeNS(W, 'author') ?? el.getAttribute('w:author');
+    if (a === author) out.push(serializer.serializeToString(el));
+  }
+  return out.sort();
+}
 
-/** Field-balance check: count fldChar begin vs end across the doc. */
+function aiRevisionCount(root: Document | Element): number {
+  return revisionSubtreesByAuthor(root, AI).length;
+}
+
 function fieldsBalanced(doc: Document): boolean {
   const chars = Array.from(doc.getElementsByTagNameNS(W, 'fldChar'));
   let depth = 0;
@@ -53,14 +77,14 @@ function fieldsBalanced(doc: Document): boolean {
   return depth === 0;
 }
 
+// AI id=101 (ins carrying "ai "), reviewer id=102. Fixtures may add more.
+const aiIns = `<w:ins w:id="101" w:author="${AI}" ${DT}><w:r><w:t xml:space="preserve">ai </w:t></w:r></w:ins>`;
+const foreignIns = `<w:ins w:id="102" w:author="${HUMAN}" ${DT}><w:r><w:t xml:space="preserve">reviewer</w:t></w:r></w:ins>`;
+
 interface Fixture {
   name: string;
-  /** Feature-bearing paragraph(s), plus the AI + reviewer revisions. */
   body: string;
-  /** Substrings that must survive both accept and reject (the feature markers). */
   featureMarkers: string[];
-  /** Serialized foreign-revision subtree that must remain byte-identical. */
-  foreign: string;
 }
 
 const FIXTURES: Fixture[] = [
@@ -68,10 +92,8 @@ const FIXTURES: Fixture[] = [
     name: 'comment range markers',
     body:
       `<w:p><w:commentRangeStart w:id="5"/><w:r><w:t>anchored</w:t></w:r>` +
-      `<w:commentRangeEnd w:id="5"/><w:r><w:commentReference w:id="5"/></w:r>` +
-      `${aiIns}${foreignIns}</w:p>`,
+      `<w:commentRangeEnd w:id="5"/><w:r><w:commentReference w:id="5"/></w:r>${aiIns}${foreignIns}</w:p>`,
     featureMarkers: ['<w:commentRangeStart w:id="5"/>', '<w:commentRangeEnd w:id="5"/>', 'w:commentReference w:id="5"'],
-    foreign: foreignIns,
   },
   {
     name: 'internal and user bookmarks',
@@ -80,7 +102,6 @@ const FIXTURES: Fixture[] = [
       `<w:p><w:r><w:t>text</w:t></w:r>${aiIns}${foreignIns}</w:p>` +
       `<w:bookmarkEnd w:id="2"/><w:bookmarkEnd w:id="1"/>`,
     featureMarkers: ['w:name="_bk_abc123"', 'w:name="UserBookmark"', '<w:bookmarkEnd w:id="1"/>', '<w:bookmarkEnd w:id="2"/>'],
-    foreign: foreignIns,
   },
   {
     name: 'content control (w:sdt)',
@@ -88,7 +109,6 @@ const FIXTURES: Fixture[] = [
       `<w:sdt><w:sdtPr><w:alias w:val="Field1"/><w:id w:val="99"/></w:sdtPr>` +
       `<w:sdtContent><w:p><w:r><w:t>controlled</w:t></w:r>${aiIns}${foreignIns}</w:p></w:sdtContent></w:sdt>`,
     featureMarkers: ['<w:sdt>', '<w:alias w:val="Field1"/>', '<w:sdtContent>'],
-    foreign: foreignIns,
   },
   {
     name: 'field codes (PAGE)',
@@ -98,15 +118,13 @@ const FIXTURES: Fixture[] = [
       `<w:r><w:fldChar w:fldCharType="separate"/></w:r><w:r><w:t>1</w:t></w:r>` +
       `<w:r><w:fldChar w:fldCharType="end"/></w:r>${aiIns}${foreignIns}</w:p>`,
     featureMarkers: ['w:fldCharType="begin"', 'w:fldCharType="end"', ' PAGE '],
-    foreign: foreignIns,
   },
   {
-    name: 'numbering (numPr)',
+    name: 'numbering reference (numPr)',
     body:
       `<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="3"/></w:numPr></w:pPr>` +
       `<w:r><w:t>item</w:t></w:r>${aiIns}${foreignIns}</w:p>`,
     featureMarkers: ['<w:numPr>', '<w:numId w:val="3"/>'],
-    foreign: foreignIns,
   },
   {
     name: 'styled paragraph (pStyle)',
@@ -114,98 +132,168 @@ const FIXTURES: Fixture[] = [
       `<w:p><w:pPr><w:pStyle w:val="Heading1"/></w:pPr>` +
       `<w:r><w:t>heading</w:t></w:r>${aiIns}${foreignIns}</w:p>`,
     featureMarkers: ['<w:pStyle w:val="Heading1"/>'],
-    foreign: foreignIns,
   },
   {
-    name: 'foreign property change alongside AI insertion',
+    name: 'foreign property change beside AI insertion',
     body:
-      `<w:p><w:r><w:rPr><w:b/><w:rPrChange w:id="102" w:author="${HUMAN}" w:date="2026-01-01T00:00:00Z"><w:rPr/></w:rPrChange></w:rPr>` +
+      `<w:p><w:r><w:rPr><w:b/><w:rPrChange w:id="102" w:author="${HUMAN}" ${DT}><w:rPr/></w:rPrChange></w:rPr>` +
       `<w:t>styled</w:t></w:r>${aiIns}</w:p>`,
     featureMarkers: ['<w:b/>'],
-    foreign: `<w:rPrChange w:id="102" w:author="${HUMAN}" w:date="2026-01-01T00:00:00Z"><w:rPr/></w:rPrChange>`,
+  },
+  {
+    name: 'foreign section-properties change beside AI insertion',
+    body:
+      `<w:p>${aiIns}</w:p>` +
+      `<w:p><w:pPr><w:sectPr><w:sectPrChange w:id="102" w:author="${HUMAN}" ${DT}><w:sectPr/></w:sectPrChange></w:sectPr></w:pPr></w:p>`,
+    featureMarkers: ['<w:sectPr>'],
+  },
+  {
+    name: 'table cell-property change (foreign) beside AI insertion',
+    body:
+      `<w:tbl><w:tr><w:tc><w:tcPr>` +
+      `<w:tcPrChange w:id="102" w:author="${HUMAN}" ${DT}><w:tcPr/></w:tcPrChange></w:tcPr>` +
+      `<w:p><w:r><w:t>cell</w:t></w:r>${aiIns}</w:p></w:tc></w:tr></w:tbl>`,
+    featureMarkers: ['<w:tbl>', '<w:tc>', '<w:tcPr>'],
   },
 ];
 
 describe('accept/reject invariant corpus (#124)', () => {
   for (const fx of FIXTURES) {
-    it(`accept preserves foreign revision + "${fx.name}"`, () => {
+    it(`accept resolves AI + preserves foreign & feature — "${fx.name}"`, () => {
       const doc = docFromBody(fx.body);
-      const { result } = acceptAIEdits(doc, { author: AI });
+      const foreignBefore = revisionSubtreesByAuthor(doc, HUMAN);
+      expect(aiRevisionCount(doc), 'fixture must start with an AI revision').toBeGreaterThan(0);
+      expect(foreignBefore.length, 'fixture must start with a foreign revision').toBeGreaterThan(0);
+
+      acceptAIEdits(doc, { author: AI });
       const out = serializeXml(doc);
-      // AI revision resolved: its wrapper id is gone.
-      expect(out).not.toContain('w:id="101"');
-      expect(result.insertionsAccepted + result.propertyChangesResolved).toBeGreaterThanOrEqual(0);
-      // Foreign revision byte-identical, feature markers intact.
-      expect(out).toContain(fx.foreign);
+
+      // Every AI revision resolved; foreign revisions byte-identical (set + count).
+      expect(aiRevisionCount(doc)).toBe(0);
+      expect(revisionSubtreesByAuthor(doc, HUMAN)).toEqual(foreignBefore);
+      // Accepted AI-inserted text is retained (when the fixture inserted text).
+      if (fx.body.includes('>ai <')) expect(out).toContain('ai ');
       for (const marker of fx.featureMarkers) expect(out, `${fx.name}: ${marker}`).toContain(marker);
-      // Field balance + structural validity.
       expect(fieldsBalanced(doc)).toBe(true);
       expect(validateDocument(doc).isValid).toBe(true);
     });
 
-    it(`reject preserves foreign revision + "${fx.name}"`, () => {
+    it(`reject reverts AI + preserves foreign & feature — "${fx.name}"`, () => {
       const doc = docFromBody(fx.body);
+      const foreignBefore = revisionSubtreesByAuthor(doc, HUMAN);
+
       rejectAIEdits(doc, { author: AI });
       const out = serializeXml(doc);
-      expect(out).not.toContain('ai '); // AI insertion reverted (removed)
-      expect(out).toContain(fx.foreign);
+
+      expect(aiRevisionCount(doc)).toBe(0);
+      expect(revisionSubtreesByAuthor(doc, HUMAN)).toEqual(foreignBefore);
+      // Rejected AI-inserted text is removed.
+      if (fx.body.includes('>ai <')) expect(out).not.toContain('ai ');
       for (const marker of fx.featureMarkers) expect(out, `${fx.name}: ${marker}`).toContain(marker);
       expect(fieldsBalanced(doc)).toBe(true);
       expect(validateDocument(doc).isValid).toBe(true);
     });
   }
 
-  it('accept preserves footnotes + a reviewer revision inside a note (facade, side part)', async () => {
-    const bodyXml =
-      `<w:p><w:r><w:t>body</w:t></w:r>${aiIns}` +
-      `<w:r><w:rPr><w:rStyle w:val="FootnoteReference"/></w:rPr><w:footnoteReference w:id="7"/></w:r></w:p>`;
-    const footnotesXml =
-      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
-      `<w:footnotes xmlns:w="${W}">` +
-      `<w:footnote w:type="separator" w:id="-1"><w:p><w:r><w:separator/></w:r></w:p></w:footnote>` +
-      `<w:footnote w:id="7"><w:p><w:r><w:t>note </w:t></w:r>${foreignIns}</w:p></w:footnote>` +
-      `</w:footnotes>`;
-    const zip = await DocxZip.load(await buildDocxFromBodyXml(bodyXml));
-    zip.writeText('word/footnotes.xml', footnotesXml);
-    const doc = await DocxDocument.load(await zip.toBuffer());
-
-    await doc.acceptAIEdits({ author: AI });
-
-    const outZip = await DocxZip.load((await doc.toBuffer({ cleanBookmarks: false })).buffer);
-    const outBody = await outZip.readText('word/document.xml');
-    const outFootnotes = await outZip.readText('word/footnotes.xml');
-    // AI insertion accepted in the body; footnote reference + note preserved.
-    expect(outBody).not.toContain('w:id="101"');
-    expect(outBody).toContain('w:footnoteReference w:id="7"');
-    expect(outFootnotes).toContain('w:footnote w:id="7"');
-    // Reviewer revision inside the note is byte-identical.
-    expect(outFootnotes).toContain(foreignIns);
-  });
-
-  it('covers each surface revision type at least once (accept and reject)', () => {
-    // Guard: the corpus exercises ins, del, and property-change revision types
-    // across accept and reject on a mixed-author document.
+  it('exercises ins + del + property-change resolution in one mixed-author document', () => {
     const body =
       `<w:p>${aiIns}${foreignIns}` +
-      `<w:del w:id="103" w:author="${AI}" w:date="2026-01-01T00:00:00Z"><w:r><w:delText>d</w:delText></w:r></w:del>` +
-      `<w:del w:id="104" w:author="${HUMAN}" w:date="2026-01-01T00:00:00Z"><w:r><w:delText>keep</w:delText></w:r></w:del>` +
-      `<w:r><w:rPr><w:i/><w:rPrChange w:id="105" w:author="${AI}" w:date="2026-01-01T00:00:00Z"><w:rPr/></w:rPrChange></w:rPr><w:t>x</w:t></w:r></w:p>`;
-    const foreignDel = `<w:del w:id="104" w:author="${HUMAN}" w:date="2026-01-01T00:00:00Z"><w:r><w:delText>keep</w:delText></w:r></w:del>`;
+      `<w:del w:id="103" w:author="${AI}" ${DT}><w:r><w:delText>d</w:delText></w:r></w:del>` +
+      `<w:del w:id="104" w:author="${HUMAN}" ${DT}><w:r><w:delText>keep</w:delText></w:r></w:del>` +
+      `<w:r><w:rPr><w:i/><w:rPrChange w:id="105" w:author="${AI}" ${DT}><w:rPr/></w:rPrChange></w:rPr><w:t>x</w:t></w:r></w:p>`;
 
     const acc = docFromBody(body);
+    const foreignBeforeAcc = revisionSubtreesByAuthor(acc, HUMAN);
     const a = acceptAIEdits(acc, { author: AI });
     expect(a.result.insertionsAccepted).toBe(1);
     expect(a.result.deletionsAccepted).toBe(1);
     expect(a.result.propertyChangesResolved).toBe(1);
-    expect(serializeXml(acc)).toContain(foreignDel); // foreign del untouched
+    expect(a.selectedIds.sort()).toEqual(['101', '103', '105']);
+    expect(aiRevisionCount(acc)).toBe(0);
+    expect(revisionSubtreesByAuthor(acc, HUMAN)).toEqual(foreignBeforeAcc);
     expect(validateDocument(acc).isValid).toBe(true);
 
     const rej = docFromBody(body);
+    const foreignBeforeRej = revisionSubtreesByAuthor(rej, HUMAN);
     const r = rejectAIEdits(rej, { author: AI });
     expect(r.result.insertionsRemoved).toBe(1);
     expect(r.result.deletionsRestored).toBe(1);
     expect(r.result.propertyChangesReverted).toBe(1);
-    expect(serializeXml(rej)).toContain(foreignDel);
+    expect(aiRevisionCount(rej)).toBe(0);
+    expect(revisionSubtreesByAuthor(rej, HUMAN)).toEqual(foreignBeforeRej);
     expect(validateDocument(rej).isValid).toBe(true);
   });
+
+  // ── Side-story parts: footnotes and endnotes (facade sweep) ──────────────
+
+  /** Build a minimal, valid DOCX with a registered side-story part. */
+  async function buildDocxWithSidePart(bodyInner: string, partPath: string, partXml: string): Promise<Buffer> {
+    const rel = partPath.replace('word/', '');
+    const relType = rel.startsWith('footnotes')
+      ? 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/footnotes'
+      : 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/endnotes';
+    const ctOverride = rel.startsWith('footnotes')
+      ? 'application/vnd.openxmlformats-officedocument.wordprocessingml.footnotes+xml'
+      : 'application/vnd.openxmlformats-officedocument.wordprocessingml.endnotes+xml';
+    const files: Record<string, string> = {
+      '[Content_Types].xml':
+        `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+        `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+        `<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        `<Default Extension="xml" ContentType="application/xml"/>` +
+        `<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>` +
+        `<Override PartName="/${partPath}" ContentType="${ctOverride}"/></Types>`,
+      '_rels/.rels':
+        `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+        `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>`,
+      'word/_rels/document.xml.rels':
+        `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+        `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rId10" Type="${relType}" Target="${rel}"/></Relationships>`,
+      'word/document.xml': `<?xml version="1.0"?><w:document xmlns:w="${W}"><w:body>${bodyInner}${SECT}</w:body></w:document>`,
+      [partPath]: partXml,
+    };
+    const JSZip = (await import('jszip')).default;
+    const zip = new JSZip();
+    for (const [p, c] of Object.entries(files)) zip.file(p, c);
+    return zip.generateAsync({ type: 'nodebuffer' });
+  }
+
+  const footnoteFixture = (label: string, id: number) =>
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<w:${label}s xmlns:w="${W}">` +
+    `<w:${label} w:type="separator" w:id="-1"><w:p><w:r><w:separator/></w:r></w:p></w:${label}>` +
+    `<w:${label} w:id="${id}"><w:p><w:r><w:t>note </w:t></w:r>${foreignIns}${aiIns}</w:p></w:${label}>` +
+    `</w:${label}s>`;
+
+  for (const [label, part, refLocal] of [
+    ['footnote', 'word/footnotes.xml', 'footnoteReference'],
+    ['endnote', 'word/endnotes.xml', 'endnoteReference'],
+  ] as const) {
+    for (const op of ['accept', 'reject'] as const) {
+      it(`${op} sweeps ${label}s and preserves a reviewer revision inside the note`, async () => {
+        const bodyInner =
+          `<w:p><w:r><w:t>body</w:t></w:r>` +
+          `<w:r><w:rPr><w:rStyle w:val="${label === 'footnote' ? 'FootnoteReference' : 'EndnoteReference'}"/></w:rPr>` +
+          `<w:${refLocal} w:id="9"/></w:r></w:p>`;
+        const partXml = footnoteFixture(label, 9);
+        const foreignBefore = revisionSubtreesByAuthor(parseXml(partXml), HUMAN);
+        expect(foreignBefore.length).toBe(1);
+
+        const doc = await DocxDocument.load(await buildDocxWithSidePart(bodyInner, part, partXml));
+        if (op === 'accept') await doc.acceptAIEdits({ author: AI });
+        else await doc.rejectAIEdits({ author: AI });
+
+        const outZip = await DocxZip.load((await doc.toBuffer({ cleanBookmarks: false })).buffer);
+        const notePart = parseXml(await outZip.readText(part));
+        // AI revision in the note resolved; reviewer revision byte-identical.
+        expect(aiRevisionCount(notePart)).toBe(0);
+        expect(revisionSubtreesByAuthor(notePart, HUMAN)).toEqual(foreignBefore);
+        // The note itself and its body reference survive.
+        expect(await outZip.readText(part)).toContain(`w:id="9"`);
+        expect(await outZip.readText('word/document.xml')).toContain(`w:${refLocal} w:id="9"`);
+      });
+    }
+  }
 });

--- a/packages/docx-core/src/integration/accept_reject_invariant_corpus.test.ts
+++ b/packages/docx-core/src/integration/accept_reject_invariant_corpus.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Invariant test corpus for selective accept/reject (#124).
+ *
+ * A mixed-author corpus: every fixture carries an AI-authored revision, a
+ * foreign (reviewer) revision, and one document feature that must survive the
+ * operation. After acceptAIEdits / rejectAIEdits targeting the AI author we
+ * assert, per fixture:
+ *   - the AI revision was resolved (accepted or reverted),
+ *   - the foreign revision is byte-identical (its serialized subtree is intact),
+ *   - the document feature (comment ranges, bookmarks, content controls, field
+ *     codes, section properties, numbering, styles) is preserved,
+ *   - field structure stays balanced and the document remains structurally valid
+ *     (validateDocument reports isValid — the CI-runnable proxy for "opens in
+ *     Word/LibreOffice without recovery").
+ *
+ * Round-trip evidence: the built fixtures were opened in LibreOffice headless
+ * (soffice --convert-to pdf) locally without a recovery prompt; see the PR notes.
+ * CI asserts structural validity via validateDocument since Word/LibreOffice are
+ * not available on the runners.
+ */
+import { describe, expect } from 'vitest';
+import { itAllure as it } from '../testing/allure-test.js';
+import { parseXml, serializeXml } from '../primitives/xml.js';
+import { acceptAIEdits, rejectAIEdits } from '../primitives/accept_ai_edits.js';
+import { validateDocument } from '../primitives/validate_document.js';
+import { DocxDocument } from '../primitives/document.js';
+import { DocxZip } from '../primitives/zip.js';
+import { buildDocxFromBodyXml } from '../testing/ooxml-fixtures.js';
+
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const AI = 'SafeDocX AI';
+const HUMAN = 'Reviewer';
+
+function docFromBody(inner: string): Document {
+  return parseXml(`<?xml version="1.0"?><w:document xmlns:w="${W}"><w:body>${inner}${SECT}</w:body></w:document>`);
+}
+const SECT = `<w:sectPr><w:pgSz w:w="12240" w:h="15840"/></w:sectPr>`;
+
+// Reusable revision + feature fragments. AI id=101, reviewer id=102.
+const aiIns = `<w:ins w:id="101" w:author="${AI}" w:date="2026-01-01T00:00:00Z"><w:r><w:t xml:space="preserve">ai </w:t></w:r></w:ins>`;
+const foreignIns = `<w:ins w:id="102" w:author="${HUMAN}" w:date="2026-01-01T00:00:00Z"><w:r><w:t xml:space="preserve">reviewer</w:t></w:r></w:ins>`;
+
+/** Field-balance check: count fldChar begin vs end across the doc. */
+function fieldsBalanced(doc: Document): boolean {
+  const chars = Array.from(doc.getElementsByTagNameNS(W, 'fldChar'));
+  let depth = 0;
+  for (const c of chars) {
+    const t = c.getAttributeNS(W, 'fldCharType') ?? c.getAttribute('w:fldCharType');
+    if (t === 'begin') depth++;
+    else if (t === 'end') depth--;
+    if (depth < 0) return false;
+  }
+  return depth === 0;
+}
+
+interface Fixture {
+  name: string;
+  /** Feature-bearing paragraph(s), plus the AI + reviewer revisions. */
+  body: string;
+  /** Substrings that must survive both accept and reject (the feature markers). */
+  featureMarkers: string[];
+  /** Serialized foreign-revision subtree that must remain byte-identical. */
+  foreign: string;
+}
+
+const FIXTURES: Fixture[] = [
+  {
+    name: 'comment range markers',
+    body:
+      `<w:p><w:commentRangeStart w:id="5"/><w:r><w:t>anchored</w:t></w:r>` +
+      `<w:commentRangeEnd w:id="5"/><w:r><w:commentReference w:id="5"/></w:r>` +
+      `${aiIns}${foreignIns}</w:p>`,
+    featureMarkers: ['<w:commentRangeStart w:id="5"/>', '<w:commentRangeEnd w:id="5"/>', 'w:commentReference w:id="5"'],
+    foreign: foreignIns,
+  },
+  {
+    name: 'internal and user bookmarks',
+    body:
+      `<w:bookmarkStart w:id="1" w:name="_bk_abc123"/><w:bookmarkStart w:id="2" w:name="UserBookmark"/>` +
+      `<w:p><w:r><w:t>text</w:t></w:r>${aiIns}${foreignIns}</w:p>` +
+      `<w:bookmarkEnd w:id="2"/><w:bookmarkEnd w:id="1"/>`,
+    featureMarkers: ['w:name="_bk_abc123"', 'w:name="UserBookmark"', '<w:bookmarkEnd w:id="1"/>', '<w:bookmarkEnd w:id="2"/>'],
+    foreign: foreignIns,
+  },
+  {
+    name: 'content control (w:sdt)',
+    body:
+      `<w:sdt><w:sdtPr><w:alias w:val="Field1"/><w:id w:val="99"/></w:sdtPr>` +
+      `<w:sdtContent><w:p><w:r><w:t>controlled</w:t></w:r>${aiIns}${foreignIns}</w:p></w:sdtContent></w:sdt>`,
+    featureMarkers: ['<w:sdt>', '<w:alias w:val="Field1"/>', '<w:sdtContent>'],
+    foreign: foreignIns,
+  },
+  {
+    name: 'field codes (PAGE)',
+    body:
+      `<w:p><w:r><w:fldChar w:fldCharType="begin"/></w:r>` +
+      `<w:r><w:instrText xml:space="preserve"> PAGE </w:instrText></w:r>` +
+      `<w:r><w:fldChar w:fldCharType="separate"/></w:r><w:r><w:t>1</w:t></w:r>` +
+      `<w:r><w:fldChar w:fldCharType="end"/></w:r>${aiIns}${foreignIns}</w:p>`,
+    featureMarkers: ['w:fldCharType="begin"', 'w:fldCharType="end"', ' PAGE '],
+    foreign: foreignIns,
+  },
+  {
+    name: 'numbering (numPr)',
+    body:
+      `<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="3"/></w:numPr></w:pPr>` +
+      `<w:r><w:t>item</w:t></w:r>${aiIns}${foreignIns}</w:p>`,
+    featureMarkers: ['<w:numPr>', '<w:numId w:val="3"/>'],
+    foreign: foreignIns,
+  },
+  {
+    name: 'styled paragraph (pStyle)',
+    body:
+      `<w:p><w:pPr><w:pStyle w:val="Heading1"/></w:pPr>` +
+      `<w:r><w:t>heading</w:t></w:r>${aiIns}${foreignIns}</w:p>`,
+    featureMarkers: ['<w:pStyle w:val="Heading1"/>'],
+    foreign: foreignIns,
+  },
+  {
+    name: 'foreign property change alongside AI insertion',
+    body:
+      `<w:p><w:r><w:rPr><w:b/><w:rPrChange w:id="102" w:author="${HUMAN}" w:date="2026-01-01T00:00:00Z"><w:rPr/></w:rPrChange></w:rPr>` +
+      `<w:t>styled</w:t></w:r>${aiIns}</w:p>`,
+    featureMarkers: ['<w:b/>'],
+    foreign: `<w:rPrChange w:id="102" w:author="${HUMAN}" w:date="2026-01-01T00:00:00Z"><w:rPr/></w:rPrChange>`,
+  },
+];
+
+describe('accept/reject invariant corpus (#124)', () => {
+  for (const fx of FIXTURES) {
+    it(`accept preserves foreign revision + "${fx.name}"`, () => {
+      const doc = docFromBody(fx.body);
+      const { result } = acceptAIEdits(doc, { author: AI });
+      const out = serializeXml(doc);
+      // AI revision resolved: its wrapper id is gone.
+      expect(out).not.toContain('w:id="101"');
+      expect(result.insertionsAccepted + result.propertyChangesResolved).toBeGreaterThanOrEqual(0);
+      // Foreign revision byte-identical, feature markers intact.
+      expect(out).toContain(fx.foreign);
+      for (const marker of fx.featureMarkers) expect(out, `${fx.name}: ${marker}`).toContain(marker);
+      // Field balance + structural validity.
+      expect(fieldsBalanced(doc)).toBe(true);
+      expect(validateDocument(doc).isValid).toBe(true);
+    });
+
+    it(`reject preserves foreign revision + "${fx.name}"`, () => {
+      const doc = docFromBody(fx.body);
+      rejectAIEdits(doc, { author: AI });
+      const out = serializeXml(doc);
+      expect(out).not.toContain('ai '); // AI insertion reverted (removed)
+      expect(out).toContain(fx.foreign);
+      for (const marker of fx.featureMarkers) expect(out, `${fx.name}: ${marker}`).toContain(marker);
+      expect(fieldsBalanced(doc)).toBe(true);
+      expect(validateDocument(doc).isValid).toBe(true);
+    });
+  }
+
+  it('accept preserves footnotes + a reviewer revision inside a note (facade, side part)', async () => {
+    const bodyXml =
+      `<w:p><w:r><w:t>body</w:t></w:r>${aiIns}` +
+      `<w:r><w:rPr><w:rStyle w:val="FootnoteReference"/></w:rPr><w:footnoteReference w:id="7"/></w:r></w:p>`;
+    const footnotesXml =
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+      `<w:footnotes xmlns:w="${W}">` +
+      `<w:footnote w:type="separator" w:id="-1"><w:p><w:r><w:separator/></w:r></w:p></w:footnote>` +
+      `<w:footnote w:id="7"><w:p><w:r><w:t>note </w:t></w:r>${foreignIns}</w:p></w:footnote>` +
+      `</w:footnotes>`;
+    const zip = await DocxZip.load(await buildDocxFromBodyXml(bodyXml));
+    zip.writeText('word/footnotes.xml', footnotesXml);
+    const doc = await DocxDocument.load(await zip.toBuffer());
+
+    await doc.acceptAIEdits({ author: AI });
+
+    const outZip = await DocxZip.load((await doc.toBuffer({ cleanBookmarks: false })).buffer);
+    const outBody = await outZip.readText('word/document.xml');
+    const outFootnotes = await outZip.readText('word/footnotes.xml');
+    // AI insertion accepted in the body; footnote reference + note preserved.
+    expect(outBody).not.toContain('w:id="101"');
+    expect(outBody).toContain('w:footnoteReference w:id="7"');
+    expect(outFootnotes).toContain('w:footnote w:id="7"');
+    // Reviewer revision inside the note is byte-identical.
+    expect(outFootnotes).toContain(foreignIns);
+  });
+
+  it('covers each surface revision type at least once (accept and reject)', () => {
+    // Guard: the corpus exercises ins, del, and property-change revision types
+    // across accept and reject on a mixed-author document.
+    const body =
+      `<w:p>${aiIns}${foreignIns}` +
+      `<w:del w:id="103" w:author="${AI}" w:date="2026-01-01T00:00:00Z"><w:r><w:delText>d</w:delText></w:r></w:del>` +
+      `<w:del w:id="104" w:author="${HUMAN}" w:date="2026-01-01T00:00:00Z"><w:r><w:delText>keep</w:delText></w:r></w:del>` +
+      `<w:r><w:rPr><w:i/><w:rPrChange w:id="105" w:author="${AI}" w:date="2026-01-01T00:00:00Z"><w:rPr/></w:rPrChange></w:rPr><w:t>x</w:t></w:r></w:p>`;
+    const foreignDel = `<w:del w:id="104" w:author="${HUMAN}" w:date="2026-01-01T00:00:00Z"><w:r><w:delText>keep</w:delText></w:r></w:del>`;
+
+    const acc = docFromBody(body);
+    const a = acceptAIEdits(acc, { author: AI });
+    expect(a.result.insertionsAccepted).toBe(1);
+    expect(a.result.deletionsAccepted).toBe(1);
+    expect(a.result.propertyChangesResolved).toBe(1);
+    expect(serializeXml(acc)).toContain(foreignDel); // foreign del untouched
+    expect(validateDocument(acc).isValid).toBe(true);
+
+    const rej = docFromBody(body);
+    const r = rejectAIEdits(rej, { author: AI });
+    expect(r.result.insertionsRemoved).toBe(1);
+    expect(r.result.deletionsRestored).toBe(1);
+    expect(r.result.propertyChangesReverted).toBe(1);
+    expect(serializeXml(rej)).toContain(foreignDel);
+    expect(validateDocument(rej).isValid).toBe(true);
+  });
+});


### PR DESCRIPTION
## What & why

Part of epic #118. A mixed-author **invariant test corpus** for the selective accept/reject engine (#123). Each fixture carries an AI-authored revision, a foreign (reviewer) revision, and one document feature; after `acceptAIEdits`/`rejectAIEdits` targeting the AI author it asserts the AI revision was resolved, the **foreign revision is byte-identical**, the feature is preserved, fields stay balanced, and the document remains structurally valid.

## Coverage

`packages/docx-core/src/integration/accept_reject_invariant_corpus.test.ts` (16 tests):
- comment range markers, internal (`_bk_*`) + user bookmarks, content controls (`w:sdt`), field codes (`w:fldChar`/`instrText`), numbering (`w:numPr`), paragraph styles, a foreign `w:rPrChange`, and a footnote whose note carries a reviewer revision (facade + side part)
- a dedicated case exercising `ins`/`del`/property-change **accept and reject** in one mixed-author document

## Round-trip evidence

- `validateDocument` (structural integrity + tracked-change/field balance) is the CI-runnable proxy for "opens without recovery".
- The built fixtures were additionally round-tripped through **LibreOffice 25.8 headless** locally (`soffice --convert-to pdf`, no recovery prompt).
- Word round-trip remains manual/pending (runners lack Word). SUPPORT.md records the coverage + evidence table.

No new src logic — pure test + docs for existing #123 behavior (OpenSpec proposal skipped per "tests for existing behavior"). Full docx-core suite green (1631).

Refs #124
Part of #118

https://claude.ai/code/session_01AbPhuyQQAb1sReWxtS24hC