### PR TITLE
fix(odf-core): pure end-of-document deletion after a table restores after the cell, not inside it

### DIFF
--- a/packages/odf-core/src/compare/emit.test.ts
+++ b/packages/odf-core/src/compare/emit.test.ts
@@ -259,6 +259,45 @@ describe('compareOdf — ODF tracked-changes emission', () => {
     expect(out).toContain('<table:table-cell><text:p>Cell</text:p></table:table-cell>');
   });
 
+  it('pure end-of-document deletion after a table anchors in a synthesized residual body paragraph (issue #540)', () => {
+    // The backward anchor would be the table-cell paragraph; anchoring there makes LibreOffice
+    // restore the deleted body paragraph INSIDE the cell on reject. The emitter instead appends a
+    // residual empty body paragraph after the table to host the marker (its no-artifact merge slot).
+    const { contentXml: out, stats } = compareOdf(
+      contentXmlWithTable(['Drop this trailing paragraph.']),
+      contentXmlWithTable([]),
+    );
+    expect(stats).toEqual({ insertions: 0, deletions: 1, modifications: 0 });
+    const ot = officeText(out);
+    const regions = trackedRegions(ot);
+    expect(regions).toHaveLength(1);
+    // No merge-artifact paragraph: the synthesized residual empty body paragraph is the merge slot.
+    expect(deletionStored(regions[0]!)).toEqual(['Drop this trailing paragraph.']);
+    // The table-cell paragraph carries no markers.
+    expect(out).toContain('<table:table-cell><text:p>Cell</text:p></table:table-cell>');
+    // The marker lives at the start of a trailing empty body paragraph after the table.
+    const ps = bodyParagraphs(ot);
+    const residual = ps[ps.length - 1]!;
+    expect(firstElLocal(residual)).toBe('change');
+    expect(residual.textContent).toBe('');
+    // Exactly one in-body change marker, and it is not inside the cell.
+    expect(out.match(/<text:change /g) ?? []).toHaveLength(1);
+    expect(out).not.toMatch(/<table:table-cell>(?:(?!<\/table:table-cell>)[\s\S])*<text:change /);
+  });
+
+  it('coalesced multi-paragraph end-of-document deletion after a table stores no artifact (issue #540)', () => {
+    const out = compareOdf(
+      contentXmlWithTable(['First trailing.', 'Second trailing.']),
+      contentXmlWithTable([]),
+    ).contentXml;
+    const regions = trackedRegions(officeText(out));
+    expect(regions).toHaveLength(1);
+    // Both deleted paragraphs, no artifact: the one synthesized residual empty paragraph supplies
+    // the single missing break when reject re-inserts the two stored paragraphs.
+    expect(deletionStored(regions[0]!)).toEqual(['First trailing.', 'Second trailing.']);
+    expect(out.match(/<text:change /g) ?? []).toHaveLength(1);
+  });
+
   it('fails closed when every paragraph is deleted (no anchor)', () => {
     expect(() => compareOdf(contentXml(['A', 'B']), contentXml([]))).toThrow(OdfEmitError);
   });

--- a/packages/odf-core/src/compare/emit.test.ts
+++ b/packages/odf-core/src/compare/emit.test.ts
@@ -298,6 +298,57 @@ describe('compareOdf — ODF tracked-changes emission', () => {
     expect(out.match(/<text:change /g) ?? []).toHaveLength(1);
   });
 
+  it('residual body paragraph is appended AFTER the trailing table, in document order (issue #540)', () => {
+    // The residual must land after the real table element, not merely after the last collected
+    // paragraph — otherwise reject would restore the paragraph in the wrong place.
+    const out = compareOdf(
+      contentXmlWithTable(['Drop this trailing paragraph.']),
+      contentXmlWithTable([]),
+    ).contentXml;
+    const ot = officeText(out);
+    // Direct office:text child order: tracked-changes, intro paragraph, table, residual paragraph.
+    const order = elementChildren(ot).map((e) => e.localName);
+    expect(order).toEqual(['tracked-changes', 'p', 'table', 'p']);
+    const residual = elementChildren(ot).at(-1)!;
+    expect(residual.localName).toBe('p');
+    expect(firstElLocal(residual)).toBe('change');
+    expect(residual.textContent).toBe('');
+  });
+
+  it('residual-body deletion coexists with an unrelated earlier insertion (issue #540)', () => {
+    // A leading inserted paragraph plus the pure end-of-document deletion after a table: the
+    // synthesized residual (appended last, after all other marker placement) must not disturb the
+    // insertion's bracket, and the two regions keep distinct ids.
+    const { contentXml: out, stats } = compareOdf(
+      contentXmlWithTable(['Drop this trailing paragraph.']),
+      `<?xml version="1.0" encoding="UTF-8"?>
+<office:document-content
+  xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0"
+  xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"
+  xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0"
+  xmlns:dc="http://purl.org/dc/elements/1.1/"
+  xmlns:xml="http://www.w3.org/XML/1998/namespace">
+  <office:body><office:text><text:p>Fresh lead paragraph.</text:p><text:p>Intro</text:p><table:table><table:table-row><table:table-cell><text:p>Cell</text:p></table:table-cell></table:table-row></table:table></office:text></office:body>
+</office:document-content>`,
+    );
+    expect(stats).toEqual({ insertions: 1, deletions: 1, modifications: 0 });
+    const ot = officeText(out);
+    const regions = trackedRegions(ot);
+    expect(regions).toHaveLength(2);
+    // Distinct ids for the two regions (one insertion, one deletion).
+    const ids = [...out.matchAll(/xml:id="(ct\d+)"/g)].map((mm) => mm[1]);
+    expect(new Set(ids).size).toBe(2);
+    // The inserted lead paragraph keeps its own change-start bracket (undisturbed by the residual).
+    const ps = bodyParagraphs(ot);
+    expect(ps[0]!.textContent).toBe('Fresh lead paragraph.');
+    expect(firstElLocal(ps[0]!)).toBe('change-start');
+    // The deletion's marker lives in the synthesized trailing residual, not in the cell.
+    const residual = ps.at(-1)!;
+    expect(firstElLocal(residual)).toBe('change');
+    expect(residual.textContent).toBe('');
+    expect(out).toContain('<table:table-cell><text:p>Cell</text:p></table:table-cell>');
+  });
+
   it('fails closed when every paragraph is deleted (no anchor)', () => {
     expect(() => compareOdf(contentXml(['A', 'B']), contentXml([]))).toThrow(OdfEmitError);
   });

--- a/packages/odf-core/src/compare/emit.ts
+++ b/packages/odf-core/src/compare/emit.ts
@@ -29,7 +29,12 @@
  *    co-located `text:change-start`, hence still outside the insertion span — and its region
  *    stores NO merge-artifact paragraph: rejecting the content-only insertion leaves one
  *    residual empty paragraph behind, and that residual paragraph is the merge slot the
- *    artifact normally provides (issue #380). Consecutive deletions coalesce into ONE region with
+ *    artifact normally provides (issue #380). A PURE end-of-document deletion (no paired
+ *    insertion) whose backward anchor is a table-cell paragraph likewise cannot anchor in the
+ *    cell — LibreOffice would restore the deleted paragraph INSIDE the cell (issue #540); instead
+ *    a fresh empty body `text:p` is appended after the table to host the marker and serve as the
+ *    (no-artifact) merge slot, so rejecting restores the paragraph after the table. Consecutive
+ *    deletions coalesce into ONE region with
  *    all deleted paragraphs plus one empty merge-artifact paragraph (artifact last for forward,
  *    first for backward). `text:change` is inline and is never a direct block child of
  *    `office:text`.
@@ -233,10 +238,11 @@ export function emitTrackedChanges(params: EmitParams): EmitResult {
       build: () => {
         const mode = deletionAnchorMode(dr, insertRuns, revisedBlocks, m);
         const deletedPs = dr.originalIndices.map((i) => revisedDoc.importNode(originalBlocks[i]!, true) as Element);
-        // 'insertion-start' stores no merge artifact: the residual empty paragraph left by
-        // rejecting the co-located content-only insertion is the merge slot (issue #380).
+        // 'insertion-start' and 'residual-body' store no merge artifact: the residual empty
+        // body paragraph — left by rejecting a co-located content-only insertion (issue #380)
+        // or synthesized after the trailing table (issue #540) — IS the merge slot.
         const stored =
-          mode === 'insertion-start'
+          mode === 'insertion-start' || mode === 'residual-body'
             ? deletedPs
             : mode === 'forward'
               ? [...deletedPs, makeEmptyParagraph(revisedDoc, originalBlocks[dr.originalIndices[0]!]!)]
@@ -271,8 +277,17 @@ export function emitTrackedChanges(params: EmitParams): EmitResult {
   // --- Place whole-paragraph deletion point markers.
   for (const run of deleteRuns) {
     const marker = makeMarker(revisedDoc, 'change', run.id);
-    if (deletionAnchorMode(run, insertRuns, revisedBlocks, m) === 'backward') {
+    const mode = deletionAnchorMode(run, insertRuns, revisedBlocks, m);
+    if (mode === 'backward') {
       appendOutsideInsertionStart(revisedBlocks[Math.min(run.revisedCursor, m) - 1]!, marker);
+    } else if (mode === 'residual-body') {
+      // Pure end-of-document deletion after a trailing table (issue #540): synthesize an empty
+      // body paragraph after the table to host the marker, so Reject All restores the deleted
+      // paragraph AFTER the table rather than inside the cell. The paragraph inherits the deleted
+      // block's style and is the region's merge slot.
+      const residual = makeEmptyParagraph(revisedDoc, originalBlocks[run.originalIndices[0]!]!);
+      prepend(residual, marker);
+      officeText.appendChild(residual);
     } else {
       // 'forward' and 'insertion-start' both prepend at the cursor block. For 'insertion-start'
       // the co-located insertion's `change-start` was prepended first (insertion markers are
@@ -358,8 +373,17 @@ function placeModifyMarkers(doc: Document, block: Element, placements: MarkerPla
  *    table-cell paragraph: there the insertion bracket stays within the inserted run (see
  *    `placeInsertionMarkers`), so the paragraph start is outside the insertion span, and the
  *    deletion's region stores no merge-artifact paragraph (issue #380).
+ *  - `residual-body`: a fresh empty body `text:p` appended after the trailing table hosts the
+ *    marker at its start. Chosen instead of `backward` for a PURE end-of-document deletion (no
+ *    paired insertion) whose backward anchor would be a table-cell paragraph: anchoring in the
+ *    cell makes LibreOffice Reject All restore the deleted body paragraph INSIDE the cell
+ *    (issue #540). LibreOffice cannot delete a document's final paragraph mark nor merge a body
+ *    paragraph into a table cell, so the faithful shape keeps a residual empty body paragraph
+ *    after the table — the merge slot — and the deletion's region stores no merge-artifact
+ *    paragraph (mirrors the `insertion-start` residual, whose slot is left by rejecting a
+ *    content-only insertion). Reject re-inserts the stored paragraphs there, after the table.
  */
-type DeletionAnchorMode = 'forward' | 'backward' | 'insertion-start';
+type DeletionAnchorMode = 'forward' | 'backward' | 'insertion-start' | 'residual-body';
 
 function deletionAnchorMode(
   run: DeleteRun,
@@ -367,7 +391,7 @@ function deletionAnchorMode(
   revisedBlocks: Element[],
   m: number,
 ): DeletionAnchorMode {
-  if (run.revisedCursor >= m) return 'backward';
+  if (run.revisedCursor >= m) return isInsideTableCell(revisedBlocks[m - 1]!) ? 'residual-body' : 'backward';
   if (run.revisedCursor === 0) return 'forward';
   if (!insertRuns.some((ins) => ins.a === run.revisedCursor && ins.b === m - 1)) return 'forward';
   return isInsideTableCell(revisedBlocks[run.revisedCursor - 1]!) ? 'insertion-start' : 'backward';

--- a/packages/odf-core/src/compare/lo_paragraph_roundtrip.test.ts
+++ b/packages/odf-core/src/compare/lo_paragraph_roundtrip.test.ts
@@ -20,12 +20,11 @@
  *    so reject-all left a stray trailing empty paragraph; the emitter now keeps the bracket
  *    within the inserted run and stores the paired deletion without a merge artifact)
  *
- * Also pinned here, G-case style (KNOWN ENGINE BUG, issue #540): a pure end-of-document deletion
- * whose backward anchor is a table-cell paragraph. Its reject target (table + trailing
- * paragraph) IS representable, but the point marker sits at the end of the CELL paragraph, so
- * LibreOffice restores the deleted body paragraph inside the cell. The composition's
- * `expectedAccept`/`expectedReject`/`assertRejectXml` pin today's wrong output so any drift —
- * regression or accidental fix — surfaces.
+ *  - pure end-of-document deletion whose backward anchor is a table-cell paragraph (issue #540 —
+ *    anchoring the point marker at the end of the CELL paragraph made LibreOffice restore the
+ *    deleted body paragraph INSIDE the cell on reject-all; the emitter now synthesizes a residual
+ *    empty body paragraph after the table to host the marker, so reject-all restores the deleted
+ *    paragraph after the table and `assertRejectXml` guards that it is NOT inside the cell)
  *
  * Separately: any document that ENDS with a table gains a trailing empty paragraph on a
  * LibreOffice load/save (observed even on accept-all with no rejection involved), so
@@ -152,11 +151,13 @@ const COMPOSITIONS: Composition[] = [
     ],
   },
   {
-    // KNOWN ENGINE BUG (issue #540), pinned: the deletion's backward anchor is the table-cell
-    // paragraph, so reject-all restores the deleted body paragraph INSIDE the cell (and the
-    // accept target ends with the table, so LibreOffice's load/save normalization appends a
-    // trailing empty paragraph). Update these pins when the anchoring is fixed.
-    name: 'KNOWN BUG (issue #540): pure end-of-document deletion after a table restores inside the cell',
+    // issue #540 (fixed): a PURE end-of-document deletion whose backward anchor is the table-cell
+    // paragraph. Anchoring the marker in the cell made reject-all restore the deleted body
+    // paragraph INSIDE the cell; the emitter now hosts the marker in a synthesized residual empty
+    // body paragraph after the table, so reject-all restores the original AFTER the table.
+    // Accept-all leaves that residual empty paragraph (the document then ends with an empty body
+    // paragraph — same visible text LibreOffice's end-with-a-table normalization would produce).
+    name: 'issue #540 (fixed): pure end-of-document deletion after a table restores after the cell',
     original: ['Intro paragraph.', 'Signature cell.', 'Drop this trailing paragraph.'],
     revised: ['Intro paragraph.', 'Signature cell.'],
     originalXml: [
@@ -166,12 +167,13 @@ const COMPOSITIONS: Composition[] = [
     ],
     revisedXml: [standardParagraph('Intro paragraph.'), SIGNATURE_TABLE],
     expectedAccept: ['Intro paragraph.', 'Signature cell.', ''],
-    expectedReject: ['Intro paragraph.', 'Signature cell.', 'Drop this trailing paragraph.', ''],
+    // reject-all reproduces the original exactly (no stray trailing empty paragraph): default.
     assertRejectXml: (content) => {
-      // The restored paragraph sits inside the table cell — the issue #540 signature.
-      expect(content).toMatch(
+      // The restored paragraph is a body paragraph AFTER the table, NOT inside the cell.
+      expect(content).not.toMatch(
         /<table:table-cell[^>]*>(?:(?!<\/table:table-cell>)[\s\S])*Drop this trailing paragraph\./,
       );
+      expect(content).toMatch(/<\/table:table>[\s\S]*Drop this trailing paragraph\./);
     },
   },
 ];

--- a/packages/odf-core/src/compare/lo_paragraph_roundtrip.test.ts
+++ b/packages/odf-core/src/compare/lo_paragraph_roundtrip.test.ts
@@ -176,6 +176,32 @@ const COMPOSITIONS: Composition[] = [
       expect(content).toMatch(/<\/table:table>[\s\S]*Drop this trailing paragraph\./);
     },
   },
+  {
+    // issue #540, coalesced N>1: two trailing paragraphs deleted after the table. The single
+    // synthesized residual empty body paragraph is the only merge slot, yet reject-all must restore
+    // BOTH paragraphs after the table in order — the no-artifact storage supplies the one missing
+    // break between them (same accounting as the issue #380 coalesced insertion-start case). Proves
+    // the residual-body representation is faithful for N > 1, not just the single-paragraph shape.
+    name: 'issue #540 (fixed): coalesced multi-paragraph end-of-document deletion after a table',
+    original: ['Intro paragraph.', 'Signature cell.', 'First trailing.', 'Second trailing.'],
+    revised: ['Intro paragraph.', 'Signature cell.'],
+    originalXml: [
+      standardParagraph('Intro paragraph.'),
+      SIGNATURE_TABLE,
+      standardParagraph('First trailing.'),
+      standardParagraph('Second trailing.'),
+    ],
+    revisedXml: [standardParagraph('Intro paragraph.'), SIGNATURE_TABLE],
+    expectedAccept: ['Intro paragraph.', 'Signature cell.', ''],
+    // reject-all reproduces the original exactly (both trailing paragraphs, in order): default.
+    assertRejectXml: (content) => {
+      // Neither restored paragraph sits inside the cell; both are body paragraphs after the table.
+      expect(content).not.toMatch(
+        /<table:table-cell[^>]*>(?:(?!<\/table:table-cell>)[\s\S])*(First|Second) trailing\./,
+      );
+      expect(content).toMatch(/<\/table:table>[\s\S]*First trailing\.[\s\S]*Second trailing\./);
+    },
+  },
 ];
 
 describe('LibreOffice accept/reject round-trip of the paragraph-granularity redline', () => {


### PR DESCRIPTION
## Problem

A pure end-of-document paragraph deletion (no paired insertion) whose nearest surviving block is a table-cell paragraph — original `[Intro ¶, table, trailing body ¶]`, revised `[Intro ¶, table]` — anchored its `text:change` point marker at the **end of the table-cell paragraph**, the only surviving block. On LibreOffice **Reject All** that restored the deleted body paragraph **inside the cell** — structural corruption of the cell, distinct from the unavoidable trailing-empty-paragraph normalization LibreOffice applies to documents ending with a table.

Found by Codex peer review of PR #539 and pinned G-case style as a gated characterization test on `main`.

## Fix

The reject target (`table + trailing paragraph`) is fully representable, so this was an engine anchoring bug, not a LibreOffice limit. LibreOffice cannot delete a document's final paragraph mark nor merge a body paragraph into a table cell, so the faithful shape keeps a **residual empty body paragraph after the table** to host the marker and serve as the (no-artifact) merge slot — the mirror of the issue #380 `insertion-start` residual, whose slot is instead left behind by rejecting a content-only insertion.

A new `residual-body` deletion-anchor mode synthesizes and appends that empty `text:p` (inheriting the deleted block's style) after the trailing table.

## Verification

Oracle-confirmed against real LibreOffice (`lo_paragraph_roundtrip.test.ts`):
- **reject-all** → `["Intro paragraph.","Signature cell.","Drop this trailing paragraph."]` — the original exactly; paragraph **after** the table, no stray trailing empty, **not inside the cell**.
- **accept-all** → `["Intro paragraph.","Signature cell.",""]` — residual empty paragraph.

The gated characterization test flips from KNOWN-BUG pins to the corrected behavior (`assertRejectXml` now guards the paragraph is after `</table:table>` and not inside a `table:table-cell`). `emit.test.ts` gains deterministic coverage of the single- and coalesced-multi-paragraph shapes. Full odf-core suite: 138 passed; `tsc --noEmit` clean.

Fixes #540. Refs #539, #380.