### PR TITLE
docs(verification): verified-checker direction + Increment 1 OpenSpec proposal (invariant registry + axiom-audit gate)

### DIFF
--- a/openspec/changes/add-invariant-registry-and-axiom-audit/proposal.md
+++ b/openspec/changes/add-invariant-registry-and-axiom-audit/proposal.md
@@ -1,0 +1,45 @@
+# Change: Add a machine-readable invariant registry and a `#print axioms` CI gate
+
+## Why
+
+The Lean 4 verification spike (`verification/lean/`) is now zero-`sorry` and carries exactly two named residual-obligation axioms — `compareDocumentXml_output_preservation_friendly` and `compareDocumentXml_output_text_roundtrip` (both in `verification/lean/LeanSpike/Spec.lean`), owned by Tier 3 — plus the uninterpreted signature axiom `LeanSpike.compareDocumentXml` (the modeled engine function itself is declared as an `axiom`, so it appears in every flagship theorem's `#print axioms` output; confirmed by running the audit against the current spike during proposal review). That is a strong, honest position. It is also invisible and under-guarded:
+
+1. **The proof status is not machine-readable anywhere.** What is proven (LCS family, DP equivalence), what is proven-modulo-one-axiom (INV-FIELD-001, INV-RT-001), and what is only empirically validated (the differentials, the fast-check bridge, the local-only LibreOffice oracle) lives only as prose in `verification/ROADMAP.md`, `verification/lean/README.md`, and the OpenSpec archive. There is no single source of truth a doc generator, a tool response, or a trust page can read.
+2. **The axiom count is guarded only by prose.** `verification/lean/README.md` suggests inspecting `#print axioms inv_field_001` / `inv_rt_001` by hand. The `lean-build` CI job audits zero-`sorry` (`.github/workflows/lean-build.yml:107-125`) but does **not** audit the axiom set. A future PR could add a *third* residual axiom — silently weakening every downstream claim — and nothing would fail. The zero-`sorry` audit cannot catch this because an `axiom` is not a `sorry`.
+3. **The `lean-build` workflow is path-filtered**, so the proofs can rot on a toolchain or mathlib bump that touches nothing under the filtered paths, with no scheduled re-run to surface it.
+
+This change is the first increment of the verified-checker + trust/demo track recorded in `verification/ROADMAP.md` ("Direction change (2026-07-07)"). It is deliberately **packaging only — no new proofs and no production-engine changes** — because everything downstream (the verified checker's certificate, the per-save verification block, the red-team demo, the site trust page, the README block) generates from the registry this change introduces and is protected by the axiom gate this change enforces. It mirrors the shape of the repo's existing conformance trust pipeline (`spec-compliance/registry/` → `scripts/generate_conformance_doc.mjs` → drift-checked `CONFORMANCE.md`), applied to verification.
+
+## What Changes
+
+- **New `verification/registry/invariants.json`** — the machine-readable source of truth. One entry per invariant, each carrying:
+  - stable ID (e.g. `INV-LCS-001`, `INV-FIELD-001`, `INV-RT-001`, `INV-ATOMSEQ-001`, `INV-LCS-DP-001`),
+  - a plain-English statement,
+  - a **tier** from the four-tier taxonomy: `proven` (model-internal, no assumptions beyond Lean+mathlib), `proven-modulo-axiom`, `empirically-validated` (differential / property test), or `tested-only`,
+  - the exact Lean theorem name + file (e.g. `Tier2.InvFieldOne.field_structure_preserved_doc` in `verification/lean/Tier2/InvFieldOne.lean`),
+  - the production surface it mirrors (e.g. `packages/docx-core/src/baselines/atomizer/atomLcs.ts:45-104`),
+  - residual axioms, if any (verbatim names),
+  - scope caveats (inplace-mode only, text projection only, field-free generators, small-scope-exhaustive sweep bounds, LibreOffice-oracle-local-only, etc.),
+  - the **falsifier**: the concrete CI job or test that fails if the claim breaks (e.g. `lean-build` zero-`sorry` audit + axiom audit; `packages/docx-core/src/integration/lean-differential-lcs.test.ts`; `packages/docx-core/src/integration/lean-spec-bridge.test.ts`). The falsifier field is the highest-trust column and is what distinguishes this from a marketing table.
+- **New `verification/lean/AxiomAudit.lean`** — a Lean module that references the flagship theorems so their axiom dependencies can be printed deterministically in CI: at minimum `inv_field_001`, `inv_rt_001`, `computeAtomLcsDP_eq_computeAtomLcs`, `rawMatches_are_longest_relevant`, and the four Tier 1 LCS theorems. It emits `#print axioms` for each (built by `lake build` like the other modules; no new `sorry`, no new `axiom`).
+- **New `verification/lean/expected-axioms.txt`** — the committed allowlist the audit diffs against, using **fully qualified names** (as `#print axioms` actually emits them): the two residual-obligation axioms (`LeanSpike.compareDocumentXml_output_preservation_friendly`, `LeanSpike.compareDocumentXml_output_text_roundtrip`), the uninterpreted signature axiom (`LeanSpike.compareDocumentXml`), and Lean's standard trusted axioms (`propext`, `Classical.choice`, `Quot.sound`). The observed set is the **union across all flagship theorems** (individual theorems legitimately use subsets — e.g. `inv_field_001` does not use `Classical.choice`). Any axiom outside this set on any flagship theorem fails CI. The registry and generated doc classify the signature axiom separately from the two residual obligations — it declares the modeled function's existence, it is not an additional unproven claim about the engine's behavior.
+- **`.github/workflows/lean-build.yml`** — add an **axiom-audit step** after `lake build` that runs the `AxiomAudit.lean` output through a normalizer (strip per-theorem headers; sort the unioned, fully-qualified axiom names) and diffs the observed union against `expected-axioms.txt`, failing loudly on any addition (a new axiom) and on any removal (an allowlisted axiom no longer observed anywhere — which should force an intentional allowlist edit, not silently pass). Add a **`schedule:` trigger** so the proofs are re-audited on a cadence independent of the path filter. The existing zero-`sorry` audit stays.
+- **New `scripts/generate_invariants_doc.mjs`** — cloned from `scripts/generate_conformance_doc.mjs`; reads `verification/registry/invariants.json` and emits `verification/INVARIANTS.md`, a human-readable table grouped by tier, each row carrying statement / tier / theorem / falsifier / caveats, with the two residual axioms named in full.
+- **New drift check `check:invariants-doc`** — cloned from `scripts/check_conformance_doc.mjs` and wired into the root `package.json` scripts (and the same CI job that already runs `check:conformance-doc`), so `INVARIANTS.md` cannot drift from the registry.
+- **`verification/INVARIANTS.md`** — the generated artifact, committed so it is diffable in PRs.
+- **`verification/ROADMAP.md`** — mark Increment 1 as in progress under the "Direction change (2026-07-07)" section (status bookkeeping only).
+
+## Scope guardrails
+
+- **Packaging only. No new proofs.** No `.lean` proof content changes except the additive, `sorry`-free, `axiom`-free `AxiomAudit.lean`. The registry *describes* the existing proof state; it does not extend it.
+- **No production-engine or MCP changes.** Nothing under `packages/*/src` (outside test/generated surfaces) is touched. The per-save certificate, verified checker, and demo are later increments with their own changes.
+- **The registry records today's truth.** Every tier assignment, theorem name, residual axiom, and falsifier must match the spike as it currently stands (zero-`sorry`, exactly two residual-obligation axioms plus the `compareDocumentXml` signature axiom). No forward-looking or aspirational rows.
+- **The four-tier taxonomy is carried verbatim and no row collapses tiers.** A `proven-modulo-axiom` invariant is never labeled `proven`; an `empirically-validated` correspondence (Lean↔TS extensional equivalence) is never labeled a proof.
+- **The axiom allowlist is exactly the two residual-obligation axioms, the `LeanSpike.compareDocumentXml` signature axiom, and Lean's standard trusted axioms.** Widening it is an explicit, reviewable edit — never an automatic consequence of a proof change.
+
+## Impact
+
+- **Affected specs:** `docx-comparison` (new requirements added — see `specs/docx-comparison/spec.md`).
+- **Affected code:** `verification/registry/invariants.json` (new), `verification/lean/AxiomAudit.lean` (new), `verification/lean/expected-axioms.txt` (new), `.github/workflows/lean-build.yml` (axiom-audit step + `schedule:` trigger), `scripts/generate_invariants_doc.mjs` (new), `scripts/check_invariants_doc.mjs` (new), `verification/INVARIANTS.md` (new, generated), root `package.json` (new `check:invariants-doc` script + wiring), `verification/ROADMAP.md` (status).
+- **No production-engine code changes.** All work is in the verification, CI, docs-generation, and registry surfaces.
+- **CI:** the axiom-audit step and `schedule:` trigger extend `lean-build`; the `check:invariants-doc` drift check joins the existing conformance-doc gate. No new external dependencies (the generator/checker reuse the conformance scripts' Node-only approach; the audit uses `lake`/`grep` already present on the runner).

--- a/openspec/changes/add-invariant-registry-and-axiom-audit/specs/docx-comparison/spec.md
+++ b/openspec/changes/add-invariant-registry-and-axiom-audit/specs/docx-comparison/spec.md
@@ -1,0 +1,62 @@
+## ADDED Requirements
+
+### Requirement: Machine-readable invariant registry is the single source of truth for verification status
+
+The system SHALL maintain a machine-readable registry at `verification/registry/invariants.json` that records, for every named verification invariant, its stable ID, a plain-English statement, its tier from the four-tier taxonomy, the exact Lean theorem name and file that establishes it, the production code surface it mirrors, any residual axioms (by verbatim name), scope caveats, and a falsifier (the concrete CI job or test that fails if the claim breaks). The four tiers are: `proven` (machine-checked in Lean with no assumptions beyond Lean + mathlib), `proven-modulo-axiom` (machine-checked except for explicitly named residual axioms), `empirically-validated` (established by a deterministic differential harness or property test, not a proof — including Lean↔TS extensional equivalence), and `tested-only` (covered by conventional tests, not formally verified). The registry SHALL record today's actual proof state — the spike as it currently stands (zero-`sorry`, exactly two residual-obligation axioms `LeanSpike.compareDocumentXml_output_preservation_friendly` and `LeanSpike.compareDocumentXml_output_text_roundtrip`, plus the uninterpreted signature axiom `LeanSpike.compareDocumentXml` recorded distinctly) — with no aspirational or forward-looking rows, and SHALL NOT collapse tiers (a `proven-modulo-axiom` invariant is never recorded as `proven`; a Lean↔TS differential is never recorded as a proof).
+
+#### Scenario: [INV-REG-01] Registry enumerates every current invariant with its tier and theorem
+
+- **WHEN** `verification/registry/invariants.json` is read
+- **THEN** it contains an entry for each current invariant (`INV-ATOMSEQ-001`, `INV-LCS-001` through `INV-LCS-004`, `INV-LCS-002+` — the `atomsEqual`-level optimality strengthening `rawMatches_are_longest_relevant`, under the ID `verification/lean/README.md` already uses — `INV-LCS-DP-001`, `INV-FIELD-001`, `INV-RT-001`)
+- **AND** each entry carries a `tier` drawn from `{proven, proven-modulo-axiom, empirically-validated, tested-only}`, a `leanTheorem` name, a `leanFile` path under `verification/lean/`, and a `falsifier`
+
+#### Scenario: [INV-REG-02] The residual-obligation axioms and the signature axiom are recorded distinctly on the invariants that carry them
+
+- **WHEN** the `INV-FIELD-001` and `INV-RT-001` entries are read
+- **THEN** their tier is `proven-modulo-axiom`
+- **AND** their `residualAxioms` list names `LeanSpike.compareDocumentXml_output_preservation_friendly` (for `INV-FIELD-001`) and `LeanSpike.compareDocumentXml_output_text_roundtrip` (for `INV-RT-001`) exactly as declared in `verification/lean/LeanSpike/Spec.lean`
+- **AND** the uninterpreted signature axiom `LeanSpike.compareDocumentXml` is recorded in a distinct field (not inside `residualAxioms`), so the declaration of the modeled function's existence is never conflated with an unproven claim about the engine's behavior
+
+#### Scenario: [INV-REG-03] Lean↔TS correspondence is recorded as empirical, not proven
+
+- **WHEN** the entries describing the Lean↔TS differentials and the fast-check bridge are read
+- **THEN** their tier is `empirically-validated`, not `proven` or `proven-modulo-axiom`
+- **AND** the LibreOffice-oracle entry carries caveats recording that it is local-only and compares a structural projection
+
+### Requirement: An enforced CI axiom-audit gate pins the residual-axiom set
+
+The system SHALL enforce, in CI, that the flagship Lean theorems depend on no axioms outside a committed allowlist. A Lean module `verification/lean/AxiomAudit.lean` SHALL emit the axiom dependencies (`#print axioms`) of at least `inv_field_001`, `inv_rt_001`, `computeAtomLcsDP_eq_computeAtomLcs`, `rawMatches_are_longest_relevant`, and the four Tier 1 LCS theorems, adding no `sorry` and no new `axiom`. A committed allowlist `verification/lean/expected-axioms.txt` SHALL contain, in fully qualified form as `#print axioms` emits them, exactly the two residual-obligation axioms (`LeanSpike.compareDocumentXml_output_preservation_friendly`, `LeanSpike.compareDocumentXml_output_text_roundtrip`), the uninterpreted signature axiom (`LeanSpike.compareDocumentXml`), and Lean's standard trusted axioms (`propext`, `Classical.choice`, `Quot.sound`). The `.github/workflows/lean-build.yml` workflow SHALL run an axiom-audit step after `lake build` that diffs the observed axiom set — the union across all flagship theorems, since individual theorems legitimately depend on subsets — against the allowlist and fails the job on any axiom outside the allowlist (a newly introduced axiom) and on any allowlist entry never observed in the union (forcing an intentional allowlist edit rather than silent drift). This audit is distinct from and additional to the existing zero-`sorry` audit, which cannot detect an added `axiom`. The workflow SHALL additionally carry a `schedule:` trigger so the proofs are re-audited on a cadence independent of the existing path filter.
+
+#### Scenario: [INV-AXIOM-01] The audit passes for the current spike
+
+- **WHEN** `lake build` and the axiom-audit step run in `.github/workflows/lean-build.yml` against the current zero-`sorry` spike
+- **THEN** the observed axiom set for the flagship theorems equals the `expected-axioms.txt` allowlist
+- **AND** the job succeeds
+
+#### Scenario: [INV-AXIOM-02] Introducing a third residual axiom fails the gate
+
+- **GIVEN** a change that makes any flagship theorem depend on an axiom not in `verification/lean/expected-axioms.txt`
+- **WHEN** the axiom-audit step runs
+- **THEN** the step fails and names the offending axiom
+- **AND** the failure is not maskable by the zero-`sorry` audit, because the offending declaration is an `axiom`, not a `sorry`
+
+#### Scenario: [INV-AXIOM-03] The proofs are re-audited on a schedule independent of the path filter
+
+- **WHEN** the `lean-build` workflow's `schedule:` trigger fires with no change to the path-filtered files
+- **THEN** `lake build`, the zero-`sorry` audit, and the axiom-audit step all run
+- **AND** a toolchain or mathlib regression that added an unexpected axiom would fail the scheduled run
+
+### Requirement: A generated, drift-checked invariant document is derived from the registry
+
+The system SHALL generate a human-readable `verification/INVARIANTS.md` from `verification/registry/invariants.json` via `scripts/generate_invariants_doc.mjs`, following the same generate-then-drift-check pattern the repo already uses for conformance (`scripts/generate_conformance_doc.mjs` / `scripts/check_conformance_doc.mjs`). The document SHALL group invariants by tier, state the four-tier taxonomy verbatim, name the residual axioms in full, and carry each invariant's falsifier. A drift check `check:invariants-doc` (backed by `scripts/check_invariants_doc.mjs`) SHALL fail if the committed `verification/INVARIANTS.md` differs from what the generator produces from the registry, and SHALL run in the CI job that already runs the conformance-doc drift check.
+
+#### Scenario: [INV-DOC-01] The document regenerates deterministically from the registry
+
+- **WHEN** `scripts/generate_invariants_doc.mjs` is run against `verification/registry/invariants.json`
+- **THEN** it writes `verification/INVARIANTS.md` grouped by tier, with the four-tier taxonomy stated verbatim and each row carrying statement, Lean theorem, residual axioms (if any), and falsifier
+
+#### Scenario: [INV-DOC-02] Drift between registry and document fails CI
+
+- **GIVEN** an edit to `verification/registry/invariants.json` that is not reflected in the committed `verification/INVARIANTS.md`
+- **WHEN** `npm run check:invariants-doc` runs
+- **THEN** it exits non-zero and reports the drift

--- a/openspec/changes/add-invariant-registry-and-axiom-audit/tasks.md
+++ b/openspec/changes/add-invariant-registry-and-axiom-audit/tasks.md
@@ -1,0 +1,31 @@
+## 1. Invariant registry (source of truth)
+
+- [ ] 1.1 Create `verification/registry/invariants.json` with one entry per current invariant: `INV-ATOMSEQ-001`, `INV-LCS-001..004`, `INV-LCS-002+` (the `atomsEqual`-level optimality strengthening, `rawMatches_are_longest_relevant`, matching the ID `verification/lean/README.md` already uses), `INV-LCS-DP-001`, `INV-FIELD-001`, `INV-RT-001`. Each entry: `id`, `statement` (plain English), `tier` (`proven` | `proven-modulo-axiom` | `empirically-validated` | `tested-only`), `leanTheorem` (name), `leanFile`, `productionSurface` (path:lines mirrored), `residualAxioms` (array, verbatim names), `caveats` (array), `falsifier` (CI job/test that fails if the claim breaks).
+- [ ] 1.2 Record the two residual-obligation axioms verbatim on the INV-FIELD-001 / INV-RT-001 entries: `LeanSpike.compareDocumentXml_output_preservation_friendly`, `LeanSpike.compareDocumentXml_output_text_roundtrip`. Record the uninterpreted signature axiom `LeanSpike.compareDocumentXml` in a distinct field (e.g. `signatureAxioms`) on those entries — it declares the modeled function's existence and must not be conflated with the residual obligations.
+- [ ] 1.3 Add entries (tier `empirically-validated`) for the Lean↔TS correspondences that are differentials, not proofs: the LCS differential (`lean-differential-lcs.test.ts`), the Tier 2-helper differential (`lean-differential-helpers.test.ts`), the fast-check bridge (`lean-spec-bridge.test.ts`), and the local-only LibreOffice oracle (`libreoffice-oracle.ts`) with the local-only + structural-projection caveats.
+- [ ] 1.4 Sanity-check every `leanTheorem` name and `leanFile` path against the actual sources in `verification/lean/`; every `productionSurface` path against `packages/docx-core/src`.
+
+## 2. Axiom audit (CI gate)
+
+- [ ] 2.1 Add `verification/lean/AxiomAudit.lean` referencing the flagship theorems and emitting `#print axioms` for each: `inv_field_001`, `inv_rt_001`, `computeAtomLcsDP_eq_computeAtomLcs`, `rawMatches_are_longest_relevant`, and the four Tier 1 LCS theorems. Must add no `sorry` and no `axiom`; builds under `lake build`.
+- [ ] 2.2 Add `verification/lean/expected-axioms.txt` — the allowlist, using fully qualified names as `#print axioms` emits them: `LeanSpike.compareDocumentXml`, `LeanSpike.compareDocumentXml_output_preservation_friendly`, `LeanSpike.compareDocumentXml_output_text_roundtrip`, `propext`, `Classical.choice`, `Quot.sound`. (Verified against the current spike: `inv_field_001` depends on `[propext, LeanSpike.compareDocumentXml, LeanSpike.compareDocumentXml_output_preservation_friendly, Quot.sound]`; `inv_rt_001` adds `Classical.choice` and the text-roundtrip axiom.)
+- [ ] 2.3 Add an axiom-audit step to `.github/workflows/lean-build.yml` after `Build LeanSpike`: run the `AxiomAudit.lean` `#print axioms` output through a normalizer (strip per-theorem headers; sort the **union** of fully-qualified axiom names across all flagship theorems — individual theorems legitimately use subsets) and diff against `expected-axioms.txt`; fail on any observed axiom not in the allowlist AND on any allowlist entry never observed in the union (forces intentional edits). Print the offending axiom(s) on failure.
+- [ ] 2.4 Add a `schedule:` trigger to `lean-build.yml` (e.g. weekly cron) so proofs are re-audited independently of the path filter. Keep the existing `push`/`pull_request`/`workflow_dispatch` triggers and the zero-`sorry` audit.
+- [ ] 2.5 Verify the audit fails as intended: locally add a throwaway `axiom foo : True` used by a flagship theorem's dependency and confirm the diff step reports it; revert.
+
+## 3. Generated doc + drift check
+
+- [ ] 3.1 Add `scripts/generate_invariants_doc.mjs`, cloned from `scripts/generate_conformance_doc.mjs`: read `verification/registry/invariants.json`, emit `verification/INVARIANTS.md` grouped by tier, each row carrying statement / tier / theorem / falsifier / caveats, residual axioms named in full, and a header stating the four-tier taxonomy verbatim.
+- [ ] 3.2 Add `scripts/check_invariants_doc.mjs`, cloned from `scripts/check_conformance_doc.mjs`: regenerate to a temp buffer and fail if it differs from the committed `verification/INVARIANTS.md`.
+- [ ] 3.3 Wire `check:invariants-doc` (and a `generate:invariants-doc` companion, matching the conformance script pair) into root `package.json`, and add `check:invariants-doc` to the CI job that already runs `check:conformance-doc`.
+- [ ] 3.4 Generate and commit `verification/INVARIANTS.md`.
+
+## 4. Roadmap bookkeeping
+
+- [ ] 4.1 Mark Increment 1 as in progress in `verification/ROADMAP.md` under "Direction change (2026-07-07)".
+
+## 5. Validation
+
+- [ ] 5.1 `lake build` in `verification/lean/` succeeds (zero `sorry`, `AxiomAudit.lean` builds); the axiom-audit step passes against the committed allowlist.
+- [ ] 5.2 `node scripts/generate_invariants_doc.mjs` then `npm run check:invariants-doc` is clean; deliberately editing the registry reddens the drift check.
+- [ ] 5.3 `openspec validate add-invariant-registry-and-axiom-audit --strict` passes.

--- a/verification/ROADMAP.md
+++ b/verification/ROADMAP.md
@@ -2,6 +2,8 @@
 
 **Status (2026-06-01)**: Stages 1-6 of the Lean 4 verification spike shipped via PR #164 (merged 2026-05-11). Tiers 1, 1.5, and 1.6 are complete. Tier 2 is **complete**: OpenSpec change `add-ooxml-doc-subset-and-inv-field-001-proof` (issue #201) landed the definitional `OoxmlDoc` subset and **closed `inv_field_001`**, and the successor `add-inv-rt-001-proof` **closed `inv_rt_001`** with the same "definitional model + machine-checked lemma + single named residual axiom" shape. The spike is now **zero-`sorry`**, carrying exactly two named residual axioms (`compareDocumentXml_output_preservation_friendly`, `compareDocumentXml_output_text_roundtrip`), both owned by Tier 3. Tier 2.5 / 3 / 3+ remain not started.
 
+**Direction update (2026-07-07)**: rather than treat Tier 3 (universal discharge of the two axioms) as the sole next climb, the work now runs a parallel **verified-checker (translation-validation) architecture** plus a trust/demo packaging track — see "Direction change (2026-07-07)" below. The first OpenSpec change on this track is `add-invariant-registry-and-axiom-audit` (Increment 1: machine-readable invariant registry + a `#print axioms` CI gate that pins the axiom allowlist — the two residual obligations, the `compareDocumentXml` signature axiom, and Lean's standard trusted axioms).
+
 ## How to use this document
 
 This file is an engineering-internal tracker for verification work next to `verification/lean/`. Updates land through normal PRs. The tiers below are roadmap buckets, not formal release gates, and the estimates are wide error bars against a moving target whose dominant cost is modeling scope rather than theorem-prover keystrokes.
@@ -201,6 +203,57 @@ Rough additional effort beyond Tier 3: **2-4 years.**
 
 The cost driver here is engine evolution. Even a correct proof target today can drift as new comparison features or document-shape repairs are added.
 
+## Direction change (2026-07-07): verified-checker architecture + a trust/demo track
+
+Everything above frames assurance as a climb up the tiers: prove more of the engine, discharge the residual axioms, chase the bug-class layer. That climb is real but slow — Tier 3 alone is a 1.5–3 year modeling effort against a moving target, and none of it is visible to a developer or AI lab deciding whether to trust the MCP/CLI tools. This section records a second, parallel direction adopted to maximize assurance-per-effort *and* legibility: a verified-checker (translation-validation) architecture, plus the packaging that turns existing proofs into something an evaluator can see.
+
+Two facts drive it:
+
+1. **The engine already runs closely related checks at runtime — but they are the theorems' *conclusions*, not the axioms' *premises*.** `evaluateSafetyChecks` (`packages/docx-core/src/baselines/atomizer/pipeline.ts`) runs accept-all/reject-all, field-structure validation of the accepted/rejected output, and accept/reject text round-trip comparisons on every inplace candidate. Those are (close to) the conclusions of `inv_field_001`/`inv_rt_001`. What the residual axioms actually assert — `preservationFriendly combined` and the `revisedText`/`originalText` projection equalities (`Spec.lean`) — is **not** currently computed. The checker increment therefore *adds* those premise checks (the plumbing to attach them cheaply exists); it does not merely relabel today's checks. Nothing today connects any runtime check to the machine-checked lemmas.
+2. **The MCP edit tools ride a second, unmodeled accept/reject engine.** `packages/docx-core/src/primitives/{accept,reject}_changes.ts` — the paragraph-mark/merge path that `insert_paragraph` and the other MCP write tools actually exercise — is neither in the Lean model nor differentially tested against it. The tools most agents call sit outside the verified surface.
+
+### The verified checker (translation validation)
+
+Rather than model `compareDocumentXml` definitionally (Tier 3 as conceived above), prove an **axiom-free** theorem about a small executable checker and run it on every real output:
+
+> `checker_sound : ∀ (a b combined : Doc), comparisonCheckerB a b combined = true → validateFieldStructure (accept combined) ∧ validateFieldStructure (reject combined) ∧ normalizeText (extractText (accept combined)) = normalizeText (extractText (accept b)) ∧ normalizeText (extractText (reject combined)) = normalizeText (extractText (reject a))`
+
+`comparisonCheckerB` is a decidable `Bool`-valued conjunction of exactly the axioms' premises: `preservationFriendly combined` (its conjuncts in `Tier2/AcceptReject.lean` are already decidable equalities over `walkBlocks`/`countBlocks`) and the two `revisedText`/`originalText` projection equalities from `Spec.lean` (decidable). Note these premise checks are **new runtime work** — today's `evaluateSafetyChecks` computes the theorems' conclusions, not these premises (see fact 1 above). The proof composes already-closed lemmas (`field_structure_preserved_doc`, `extractText_reject`, `extractText_accept_normalized`), so `#print axioms checker_sound` shows **no residual-obligation axiom**. Running the checker on a real output replaces the two axioms, *for that document*, with the runtime check actually passing. This delivers per-document instances of exactly what Tier 3 would prove universally — and covers wild documents the definitional model would never parse — at a fraction of the cost. Discharging the axioms universally (Tier 3) is not abandoned; it is demoted below the checker, and the honest residual the checker does *not* guard (the rebuild-fallback path) is called out as its own future checker.
+
+### The honest four-tier taxonomy
+
+Every generated trust artifact carries this taxonomy verbatim; no artifact may collapse tiers. It is itself the differentiator against competitors who say "battle-tested."
+
+1. **Proven** (model-internal, no assumptions beyond Lean+mathlib): the LCS family + DP equivalence.
+2. **Proven modulo one named axiom**: INV-FIELD-001, INV-RT-001 — or, once the checker ships, "proven, with the premise established per-document at runtime."
+3. **Empirically validated** (deterministic differential / property test): Lean↔TS extensional equivalence (the 1.19M-pair sweep, the helper differential with G1–G5 closed, the fast-check bridge, the local-only LibreOffice oracle).
+4. **Tested-only / unverified**: rebuild-fallback mode, ancillary parts (bookmarks/comments/footnotes), formatting, rendering (Tier 3/3+ above).
+
+### Interleaved increment sequence
+
+Proof and packaging interleave so every public artifact ships with the strongest proof backing available at that point, and the demo lands mid-sequence. Each increment is one OpenSpec change + PR.
+
+- **Inc 1 — Invariant registry + `#print axioms` CI gate** (packaging; no new proofs). `verification/registry/invariants.json` (mirroring `spec-compliance/registry/`) as the source of truth — per invariant: ID, plain-English statement, tier, exact Lean theorem name + file, production surface mirrored, residual axioms, scope caveats, and the **falsifier** (the CI job/test that fails if the claim breaks). A new `verification/lean/AxiomAudit.lean` + a `lean-build.yml` step that runs `#print axioms` on the flagship theorems and diffs the observed union against a committed allowlist `verification/lean/expected-axioms.txt` — the two residual-obligation axioms, the uninterpreted signature axiom `LeanSpike.compareDocumentXml` (the engine function itself is declared as an `axiom`; verified by running `#print axioms` on the current spike), and Lean's `propext`/`Classical.choice`/`Quot.sound` — closing the gap where a future PR could silently add another axiom; plus a `schedule:` trigger, since the workflow is path-filtered today. Generated `verification/INVARIANTS.md` via a `scripts/generate_invariants_doc.mjs` cloned from `scripts/generate_conformance_doc.mjs`, drift-checked by `check:invariants-doc`. **This is the first OpenSpec change spun up: `add-invariant-registry-and-axiom-audit`.**
+- **Inc 2 — Verified comparison checker** (proof). `Tier2/Checker.lean` (`comparisonCheckerB` + axiom-free `checker_sound`); a compiled `leanChecker` exe on the `DifferentialHelpers.lean` wire pattern; a TS mirror in `evaluateSafetyChecks` emitting a `certificate` field on `CompareResult`, differential-validated against the exe.
+- **Inc 3 — Per-save verification certificate** (packaging; needs 1+2). A `verification` block on the `save` tool response (`packages/docx-mcp/src/tools/save.ts`) and the compare CLI: which runtime checks ran, `engine_mode`, and per-invariant `{ tier, applies, note }` where `applies` is *computed* from `trackedReconstructionMode === 'inplace'`, not asserted. No `verified: true` boolean anywhere.
+- **Inc 4 — One-command red-team demo** (packaging; needs 3). `packages/docx-mcp/src/cli/commands/verify_demo.ts`: a silent edit is refused by the AI-revision guard; the tracked edit lands and prints the certificate; a Node-only replay of INV-RT-001 on the demo's own redline; the invariant table + repro commands. Best single demo for an AI-lab audience.
+- **Inc 5 — MCP no-silent-mutation certificate + primitives-engine differential** (proof; the flagship product law). Add `PPr.mark` to `Tier2/OoxmlModel.lean` (paragraph-mark revisions `insert_paragraph` emits), extend `accept`/`reject`, re-prove the preservation and round-trip lemmas (paragraph-merge shown walk-invariant is the one real new obligation); run the primitives-side engine against the same Lean spec three-way alongside the atomizer helpers; a runtime `tokenProjection(rejectAll(after)) = tokenProjection(rejectAll(before))` certificate in `preflightAiRevisionMutation` (`packages/docx-mcp/src/tools/ai_revision_guard.ts`).
+- **Inc 6 — Flagship theorem INV-EDIT-001** (proof; needs 5). `Tier2/EditOps.lean` models the MCP edit ops and proves perfect revertability (`tokenProjection (reject (applyOps ops d)) = tokenProjection (reject d)`), by construction per-op then folded over sequences.
+- **Inc 7 — Trust surface** (packaging; needs 1, generates from it). `site/src/trust/verification.njk` + a card, fed from the registry via a `generate_trust_metrics.mjs` sibling (lead with the G4/G5 "verification found real engine bugs" narrative); an `AUTO-GENERATED` "Machine-checked invariants" README block synced by `scripts/sync_readme_blocks.mjs`; `verification/AUDIT.md` ("verify this in 10 minutes"). Problem-first, undersell — state the unverified Tier 3/3+ remainder in the same breath.
+
+**Deferred, gated on data:** definitional `compareDocumentXml` (Tier 3 above) and broad OOXML model widening. Model-coverage telemetry from Incs 2–5 (parse-into-`Doc` rate, checker pass rate on the real-doc corpus) turns "widen toward bookmarks/comments/footnotes next?" into a measured decision; those invariants should enter as decidable checker conjuncts with small preservation lemmas (e.g. `checkRangePairs` in `validate_ai_revisions.ts` is already the runtime half), not deep model widenings.
+
+Dependency graph:
+
+```
+Inc1 (registry + axiom gate) ─► Inc2 (verified checker) ─► Inc3 (save certificate) ─► Inc4 (verify-demo)
+Inc1 ───────────────────────────────────────────────────────────────────────────────► Inc7 (site/README/audit)
+Inc2 ─► Inc5 (pPr marks + 3-way differential + no-silent-mutation cert) ─► Inc6 (INV-EDIT-001)
+Deferred: definitional compareDocumentXml, broad model widening — gated on corpus/telemetry data
+```
+
+This direction keeps the OpenSpec-per-work-item discipline the rest of the roadmap already assumes: Inc 1 is scaffolded as `add-invariant-registry-and-axiom-audit`, and each later increment gets its own change when its work begins.
+
 ## How estimates were calibrated
 
 - The original spike was time-boxed at 6 weeks.
@@ -215,8 +268,6 @@ Why it may not generalize:
 
 The roadmap therefore uses wide error bars such as **4-12 months** instead of point predictions. Those ranges are meant to communicate uncertainty, not precision.
 
-## Why this is not (yet) an OpenSpec change
+## Why this roadmap is not itself an OpenSpec change
 
-OpenSpec change proposals are the right vehicle once Tier 2 is actually being worked on. They force scope clarity and design review around a concrete definitional model. Right now Tier 2 is still not started, and the spike itself is already bounded and documented in `verification/lean/README.md`.
-
-For the current state, a lightweight roadmap is sufficient. The natural next OpenSpec artifact is not "verification roadmap"; it is something closer to "build a definitional `OoxmlDoc` subset and close `INV-FIELD-001` against it."
+This file stays a lightweight engineering-internal tracker; OpenSpec change proposals are the per-work-item vehicle. That pattern has already run its course once — Tier 2 was scoped and closed through `add-ooxml-doc-subset-and-inv-field-001-proof` and `add-inv-rt-001-proof`, exactly as the original version of this section predicted — and it continues under the 2026-07-07 direction change: each increment gets its own OpenSpec change when its work begins, starting with `add-invariant-registry-and-axiom-audit` (Increment 1). The roadmap records direction and status; the changes carry the reviewable scope.


### PR DESCRIPTION
Refs #547 (proposal only — implementation of Increment 1 follows in a separate PR; do not auto-close).

## Why

The Lean spike is zero-`sorry` with two named residual-obligation axioms — a strong, honest position that is currently **invisible** (no registry/README/site/tool-response surface) and **under-guarded** (the zero-`sorry` CI audit cannot detect an added `axiom`; the path-filtered `lean-build` workflow never re-runs on a schedule). Tier 3 as originally conceived (definitional `compareDocumentXml`) is a 1.5–3 year climb whose value never reaches the MCP/CLI surface developers and AI labs evaluate.

## What

- **`verification/ROADMAP.md`** — new "Direction change (2026-07-07)" section: a **verified-checker / translation-validation architecture** (axiom-free `checker_sound` over a decidable premise checker; a passing runtime check replaces the two axioms per-document, including for wild documents outside the definitional model), the honest four-tier taxonomy (proven / proven-modulo-axiom / empirically-validated / tested-only), and a 7-increment interleaved proof+packaging sequence ending in a one-command red-team demo and a generated trust surface. Stale tail section rewritten.
- **`openspec/changes/add-invariant-registry-and-axiom-audit/`** — Increment 1 scaffolded (packaging only, no new proofs): machine-readable invariant registry with per-invariant **falsifiers**, `AxiomAudit.lean` + committed `expected-axioms.txt` allowlist diffed in CI (union across flagship theorems, fully-qualified names), `schedule:` trigger, generated drift-checked `INVARIANTS.md` cloned from the conformance-doc generator pattern.

## Peer review (dynamic, Codex)

The review executed against the live spike (`lake build` 6580 jobs OK; 3 verification test files 27/27; `lake env lean` axiom probe) and drove corrections already included here:

- **BLOCKER fixed**: flagship theorems also depend on the uninterpreted signature axiom `LeanSpike.compareDocumentXml` — allowlisted and classified distinctly from the two residual obligations; names fully qualified; diff over the union (per-theorem subsets are legitimate, e.g. `inv_field_001` omits `Classical.choice`).
- **MAJOR fixed**: roadmap no longer claims runtime safety checks compute the axioms' content — they compute the theorems' *conclusions*; the checker increment must add the *premise* checks.
- **MAJOR fixed**: `INV-LCS-002+` added to the required registry enumeration.
- **MINOR fixed**: stale roadmap tail.

## Verification

- `openspec validate add-invariant-registry-and-axiom-audit --strict` ✅
- `npm run check:spec-coverage` / `check:conformance-doc` / `check:conformance-citations` ✅ (docs-only change; no package code touched)

https://claude.ai/code/session_011G87ncedivbj7JFYQkYfeV