### PR TITLE
test(docx-core): resolve split packages from source in vitest

### DIFF
--- a/packages/docx-compare/vitest.config.ts
+++ b/packages/docx-compare/vitest.config.ts
@@ -39,6 +39,12 @@ if (!hasAllure) {
 }
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@usejunior/docx-core': resolve(__dirname, '../docx-core/src/index.ts'),
+      '@usejunior/docx-compare': resolve(__dirname, 'src/index.ts'),
+    },
+  },
   test: {
     globals: true,
     environment: 'node',

--- a/packages/docx-core/vitest.config.ts
+++ b/packages/docx-core/vitest.config.ts
@@ -39,6 +39,12 @@ if (!hasAllure) {
 }
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@usejunior/docx-core': resolve(__dirname, 'src/index.ts'),
+      '@usejunior/docx-compare': resolve(__dirname, '../docx-compare/src/index.ts'),
+    },
+  },
   test: {
     globals: true,
     environment: 'node',


### PR DESCRIPTION
## Summary
- resolve @usejunior/docx-core and @usejunior/docx-compare to source files during Vitest runs
- keep Lean differential and package tests runnable in fresh CI checkouts without prebuilt dist output

## Verification
- npm run test:run -w @usejunior/docx-core -- src/integration/lean-differential-lcs.test.ts
- npm run test:run -w @usejunior/docx-compare -- src/baselines/atomizer/atomLcs.test.ts
- npm run lint -w @usejunior/docx-core
- npm run lint -w @usejunior/docx-compare

Ref: #128