### PR TITLE
fix(safe-docx): escape invariant table backslashes

### DIFF
--- a/scripts/generate_invariants_doc.mjs
+++ b/scripts/generate_invariants_doc.mjs
@@ -16,6 +16,7 @@ function loadRegistry() {
 
 function escapeCell(value) {
   return String(value ?? '—')
+    .replace(/\\/g, '\\\\')
     .replace(/\|/g, '\\|')
     .replace(/\r?\n/g, '<br>');
 }


### PR DESCRIPTION
## Summary

Escapes literal backslashes before escaping Markdown table pipes in `scripts/generate_invariants_doc.mjs`.

## Why

CodeQL alert #21 (`js/incomplete-sanitization`) flagged the generator's pipe escaping as incomplete. This script is internal and fed by the invariant registry, but a literal trailing backslash could still cancel the generated `\|` escape in a Markdown table cell. The fix matches the existing Markdown table escaping pattern used by other repo generators.

Ref: CodeQL alert #21

## Validation

Run from dedicated worktree: `.worktrees/21-codeql-invariants-backslash-escape-20260708`

- `npm ci`
- `npm run build`
- `npm run lint:workspaces` (0 errors; existing warning-only unused eslint-disable notices)
- `npm run test:run` (initial sandbox run failed only in `@usejunior/docx-core` due `tsx` IPC / LibreOffice sandbox restrictions; escalated `npm run test:run -w @usejunior/docx-core` passed)
- `npm run check:spec-coverage`
- `npm run check:conformance-citations`
- `npm run check:conformance-doc`
- `npm run check:invariants-doc`
