### PR TITLE
[codex] Link compatibility matrix and bump 0.16.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ Safe Docx is not intended to replace generation-first `.docx` libraries.
 
 Safe Docx is a deliberately narrow tool, and for plenty of document work it is not the one you want. Below are the alternatives people most often weigh it against — each is a genuinely good fit for cases Safe Docx is not built for. The links go to fuller write-ups.
 
+For a fixture-by-fixture view, see the [live DOCX compatibility matrix](https://usejunior.com/safe-docx/compatibility/?utm_source=github&utm_medium=readme&utm_campaign=safe-docx), which compares Safe Docx with python-docx, LibreOffice, Open XML SDK, docx, SuperDoc, and docx-rs.
+
 ### vs SuperDoc
 
 SuperDoc is a polished, full-featured WYSIWYG editor: a browser-based document engine with real-time multi-user collaboration and a large MCP tool surface. If you want people to *see and edit* a document in the browser, it is the more complete product and the one we would point you to. Safe Docx is headless — no editor, no rendering, no collaboration layer — so it can offer nothing on that front. Reach for Safe Docx only when you specifically want a lightweight, local MCP server for agent-driven edits; reach for SuperDoc when humans need a real editing surface. [Full comparison →](https://usejunior.com/comparisons/safe-docx-vs-superdoc?utm_source=github&utm_medium=readme&utm_campaign=safe-docx)

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-docx",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "AI-powered DOCX and ODT editing with tracked changes, redlining, and formatting preservation",
   "contextFileName": "GEMINI.md",
   "entrypoint": "GEMINI.md",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "safe-docx-suite",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "safe-docx-suite",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -8998,7 +8998,7 @@
     },
     "packages/allure-test-factory": {
       "name": "@usejunior/allure-test-factory",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"
@@ -9019,10 +9019,10 @@
     },
     "packages/docx-compare": {
       "name": "@usejunior/docx-compare",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@usejunior/docx-core": "^0.15.0",
+        "@usejunior/docx-core": "^0.16.0",
         "@xmldom/xmldom": "^0.9.10",
         "diff-match-patch": "^1.0.5",
         "jszip": "^3.10.1"
@@ -9048,7 +9048,7 @@
     },
     "packages/docx-core": {
       "name": "@usejunior/docx-core",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@xmldom/xmldom": "^0.9.10",
@@ -9060,7 +9060,7 @@
       "devDependencies": {
         "@types/diff-match-patch": "^1.0.36",
         "@types/node": "^22.10.0",
-        "@usejunior/docx-compare": "^0.15.0",
+        "@usejunior/docx-compare": "^0.16.0",
         "@vitest/coverage-v8": "^4.1.8",
         "@vitest/runner": "^4.1.8",
         "allure-vitest": "^3.9.0",
@@ -9076,13 +9076,13 @@
     },
     "packages/docx-mcp": {
       "name": "@usejunior/docx-mcp",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@usejunior/docx-compare": "^0.15.0",
-        "@usejunior/docx-core": "^0.15.0",
-        "@usejunior/odf-core": "^0.15.0",
+        "@usejunior/docx-compare": "^0.16.0",
+        "@usejunior/docx-core": "^0.16.0",
+        "@usejunior/odf-core": "^0.16.0",
         "@xmldom/xmldom": "^0.9.10",
         "zod": "^4.3.6"
       },
@@ -9103,7 +9103,7 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@usejunior/google-docs-core": "^0.15.0"
+        "@usejunior/google-docs-core": "^0.16.0"
       },
       "peerDependenciesMeta": {
         "@usejunior/google-docs-core": {
@@ -9113,7 +9113,7 @@
     },
     "packages/google-docs-core": {
       "name": "@usejunior/google-docs-core",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "dependencies": {
         "google-auth-library": "^9.0.0"
@@ -9129,10 +9129,10 @@
     },
     "packages/odf-core": {
       "name": "@usejunior/odf-core",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@usejunior/docx-core": "^0.15.0",
+        "@usejunior/docx-core": "^0.16.0",
         "@xmldom/xmldom": "^0.9.10",
         "jszip": "^3.10.1"
       },
@@ -9147,10 +9147,10 @@
     },
     "packages/safe-docx": {
       "name": "@usejunior/safe-docx",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@usejunior/docx-mcp": "^0.15.0"
+        "@usejunior/docx-mcp": "^0.16.0"
       },
       "bin": {
         "safe-docx": "bin/safe-docx.js",
@@ -9162,10 +9162,10 @@
     },
     "packages/safe-docx-mcpb": {
       "name": "@usejunior/safedocx-mcpb",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@usejunior/safe-docx": "^0.15.0"
+        "@usejunior/safe-docx": "^0.16.0"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-docx-suite",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "private": true,
   "description": "Monorepo for Safe DOCX packages",
   "repository": {

--- a/packages/allure-test-factory/package.json
+++ b/packages/allure-test-factory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/allure-test-factory",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Shared Allure test helpers for vitest — BDD context, OpenSpec auto-inference, Prism.js highlighting",
   "type": "module",
   "exports": {

--- a/packages/docx-compare/package.json
+++ b/packages/docx-compare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/docx-compare",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "DOCX comparison and redline generation for Safe DOCX.",
   "type": "module",
   "main": "dist/index.js",
@@ -18,7 +18,7 @@
     "cli": "node dist/cli/index.js"
   },
   "dependencies": {
-    "@usejunior/docx-core": "^0.15.0",
+    "@usejunior/docx-core": "^0.16.0",
     "@xmldom/xmldom": "^0.9.10",
     "diff-match-patch": "^1.0.5",
     "jszip": "^3.10.1"

--- a/packages/docx-core/package.json
+++ b/packages/docx-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/docx-core",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "OOXML (.docx) core library: primitives, document generation, and track changes",
   "type": "module",
   "main": "dist/index.js",
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@types/diff-match-patch": "^1.0.36",
     "@types/node": "^22.10.0",
-    "@usejunior/docx-compare": "^0.15.0",
+    "@usejunior/docx-compare": "^0.16.0",
     "@vitest/coverage-v8": "^4.1.8",
     "@vitest/runner": "^4.1.8",
     "allure-vitest": "^3.9.0",

--- a/packages/docx-mcp/package.json
+++ b/packages/docx-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/docx-mcp",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "MCP server for reading, editing, and comparing Word (.docx) and OpenDocument (.odt) files with tracked changes. For Claude, Gemini CLI, Cursor, and any MCP client. Apache-2.0 licensed.",
   "type": "module",
   "main": "dist/index.js",
@@ -27,9 +27,9 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@usejunior/docx-compare": "^0.15.0",
-    "@usejunior/docx-core": "^0.15.0",
-    "@usejunior/odf-core": "^0.15.0",
+    "@usejunior/docx-compare": "^0.16.0",
+    "@usejunior/docx-core": "^0.16.0",
+    "@usejunior/odf-core": "^0.16.0",
     "@xmldom/xmldom": "^0.9.10",
     "zod": "^4.3.6"
   },
@@ -57,7 +57,7 @@
     "NOTICE"
   ],
   "peerDependencies": {
-    "@usejunior/google-docs-core": "^0.15.0"
+    "@usejunior/google-docs-core": "^0.16.0"
   },
   "peerDependenciesMeta": {
     "@usejunior/google-docs-core": {

--- a/packages/google-docs-core/package.json
+++ b/packages/google-docs-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/google-docs-core",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Google Docs core library: read, write, and anchor management via Google Docs API",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/odf-core/package.json
+++ b/packages/odf-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/odf-core",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "OpenDocument Format (.odt) core library: archive packaging, document view, surgical text replacement, and tracked-changes comparison",
   "type": "module",
   "main": "dist/index.js",
@@ -14,7 +14,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@usejunior/docx-core": "^0.15.0",
+    "@usejunior/docx-core": "^0.16.0",
     "@xmldom/xmldom": "^0.9.10",
     "jszip": "^3.10.1"
   },

--- a/packages/safe-docx-mcpb/manifest.json
+++ b/packages/safe-docx-mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "safe-docx",
   "display_name": "Safe Docx",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "AI-native Word (.docx) and OpenDocument (.odt) editing with stable paragraph anchors and deterministic document operations.",
   "long_description": "Safe Docx lets Claude work directly with .docx files on your local filesystem. It provides stable paragraph IDs (_bk_*) for precise editing while preserving formatting and structure.\n\nCore capabilities include reading/searching content, formatting-preserving edits and inserts, deterministic layout controls, tracked-changes output, comments, footnote tools, document comparison, and revision extraction.",
   "author": {

--- a/packages/safe-docx-mcpb/package.json
+++ b/packages/safe-docx-mcpb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/safedocx-mcpb",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "private": true,
   "description": "Claude Desktop MCP Bundle (.mcpb) wrapper for @usejunior/safe-docx",
   "type": "module",
@@ -14,7 +14,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@usejunior/safe-docx": "^0.15.0"
+    "@usejunior/safe-docx": "^0.16.0"
   },
   "devDependencies": {
     "@vitest/runner": "^4.1.8",

--- a/packages/safe-docx/.smithery/shttp/manifest.json
+++ b/packages/safe-docx/.smithery/shttp/manifest.json
@@ -6,7 +6,7 @@
     "serverCard": {
       "serverInfo": {
         "name": "safe-docx",
-        "version": "0.15.0"
+        "version": "0.16.0"
       },
       "tools": [
         {

--- a/packages/safe-docx/package.json
+++ b/packages/safe-docx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/safe-docx",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Edit Word (.docx) and OpenDocument (.odt) files with tracked changes, redlines, and formatting preservation. Built for AI coding agents. Apache-2.0 licensed, 100% local processing.",
   "mcpName": "io.github.UseJunior/safe-docx",
   "type": "module",
@@ -25,7 +25,7 @@
     "safedocx": "./bin/safe-docx.js"
   },
   "dependencies": {
-    "@usejunior/docx-mcp": "^0.15.0"
+    "@usejunior/docx-mcp": "^0.16.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/safe-docx/server.json
+++ b/packages/safe-docx/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.UseJunior/safe-docx",
   "title": "Safe Docx",
   "description": "AI-native surgical editing of Word .docx and OpenDocument .odt files with formatting preservation",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "websiteUrl": "https://usejunior.com/developer-tools/safe-docx",
   "icons": [
     {
@@ -18,7 +18,7 @@
     {
       "registryType": "npm",
       "identifier": "@usejunior/safe-docx",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "transport": {
         "type": "stdio"
       },

--- a/site/package.json
+++ b/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/safe-docx-site",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "private": true,
   "type": "module",
   "description": "Safe DOCX marketing and trust site (Eleventy)",


### PR DESCRIPTION
## Summary

Adds a high-signal README link to the live DOCX compatibility matrix and bumps the workspace release train to `0.16.0` so npm can catch up to current `main`.

## Why

The compatibility matrix is generated from current mainline behavior. npm `@usejunior/safe-docx` is currently `0.15.0`, published on 2026-06-22, while `main` has 26 commits after `v0.15.0`, including feature/fix changes across the DOCX packages. Publishing `0.16.0` keeps the public package aligned with the matrix we are linking and promoting.

## Changes

- Adds a README link to `https://usejunior.com/safe-docx/compatibility/` in the comparison section.
- Bumps the synchronized workspace/package/manifest versions from `0.15.0` to `0.16.0`.
- Regenerates `package-lock.json` through `scripts/bump_version.mjs`.

## Release impact

After this PR merges to `main`, `auto-tag-release.yml` should create `v0.16.0`, which triggers `release.yml` to publish the npm packages through trusted publishing.

## Validation

- `node scripts/bump_version.mjs --check`
- `npm run check:readme-sync`
- `npm run check:release-isolation`