### PR TITLE
docs(openspec): propose centralizing the LLM quality gate behind a GitHub App

### DIFF
--- a/openspec/changes/refactor-centralize-llm-quality-gate/design.md
+++ b/openspec/changes/refactor-centralize-llm-quality-gate/design.md
@@ -1,0 +1,310 @@
+# Design: Centralize the LLM quality gate behind a GitHub App
+
+## Context
+
+The current LLM quality gate is a GitHub Actions workflow plus composite action
+copied across four consumers. In safe-docx, the workflow is 747 lines and the
+action is 426 lines, with policy under `.github/llm-based-quality-gate/`.
+Because the implementation is copied, every security, reliability, provider, or
+review-output fix has to be re-landed in each repo.
+
+The desired sharing mechanism must work across both private repos and a public
+repo in a different organization. Private reusable workflows and composite
+actions cannot cover that shape uniformly, and opening the engine source is not
+a goal. The viable common mechanism is a dedicated GitHub App plus a central
+runner: the consumer emits a normalized request, the master repo evaluates the
+trusted base policy and untrusted PR diff, then the App posts a Check Run and PR
+comment back to the consumer.
+
+Branch protection is the highest-stakes migration constraint. Verified on
+2026-07-08 via `gh api repos/<owner>/<repo>/branches/main/protection/required_status_checks`:
+
+| Repo | Current `Aggregate and post review` protection |
+| --- | --- |
+| `UseJunior/safe-docx` | Required, source-pinned to app id `15368` (GitHub Actions) |
+| `open-agreements/open-agreements` | Required, source-pinned to app id `15368` (GitHub Actions) |
+| `UseJunior/tests-renderer` | Required, source-pinned to app id `15368` (GitHub Actions) |
+| `UseJunior/legal-explainer` | Not currently required |
+
+A Check Run with the same name from the new LLM-Gate App will not satisfy a
+source-pinned requirement until branch protection is re-pointed to that App (or
+to any source). Re-pointing must happen only after the new App has posted a live
+check on that repo, or merges can be wedged.
+
+## Goals / Non-Goals
+
+**Goals**
+- Make `UseJunior/llm-gate` the single source of gate implementation logic.
+- Keep repo-specific review policy in each consumer repo and read it only from
+  the trusted base ref.
+- Preserve current gate behavior before enforcing the new source.
+- Cut over all four consumers through shadow/advisory operation before
+  removing the copied engine.
+- Support both GitHub-hosted execution now and a webhook/local-model transport
+  later without changing the engine.
+- Support Gemini now and an OpenAI-compatible local provider later without
+  changing the engine core.
+
+**Non-Goals**
+- This proposal does not create the private master repo, register the GitHub
+  App, edit branch protection, or add secrets.
+- This proposal does not implement the engine CLI, router, webhook receiver, or
+  consumer dispatch workflows.
+- This proposal does not make the LLM gate blocking by default.
+- This proposal does not expose the gate engine as a public reusable workflow or
+  public composite action.
+
+## Decisions
+
+### Four independently maintainable layers
+
+| Layer | Lives in | Changes when |
+| --- | --- | --- |
+| Policy | Each consumer repo: `checklist.md`, current `system-prompt.md` or future overlay, `LLM_GATE_BLOCKING` | That repo's review criteria change |
+| Transport | Master router workflow in v1, webhook stub in v2 | A repo switches between GitHub-hosted and local/webhook execution |
+| Engine | `UseJunior/llm-gate` TypeScript CLI | Gate logic, security, output, provider, or reliability behavior changes |
+| Identity | Dedicated LLM-Gate GitHub App plus central secrets | App permissions, installations, or shared provider credentials change |
+
+This layering is the de-duplication boundary: policy can vary per repo, but the
+gate algorithm and security hardening are implemented once.
+
+### Master repo and identity
+
+Create a new private `UseJunior/llm-gate` repo containing:
+
+- `src/` for the TypeScript CLI.
+- `.github/workflows/router.yml` for the central router.
+- `config/routes.yml` for the consumer allowlist and transport selection.
+- `prompts/system-prompt.base.md` for the shared system prompt.
+- Secrets `LLM_GATE_APP_ID`, `LLM_GATE_APP_PRIVATE_KEY`, and `GEMINI_API_KEY`.
+
+The master repo must have branch protection and required review on `main`.
+
+Create a dedicated LLM-Gate GitHub App with minimal permissions:
+`Checks: write`, `Contents: read`, `Pull requests: read`, and `Metadata: read`.
+Install it on all four consumers and the master repo. Store its id/private key
+only in the master repo. The router mints per-run installation tokens scoped to
+the single target consumer, using the same general GitHub App token pattern
+already used by safe-docx release automation for RELEASE_BOT.
+
+### Engine CLI
+
+The current bash and workflow logic is extracted into a transport-agnostic
+TypeScript CLI:
+
+```text
+llm-gate gate --request request.json --out result.json
+```
+
+The CLI parses a normalized request, reads the consumer policy from the trusted
+base ref, evaluates each checklist item against the untrusted PR diff, and
+emits a normalized result. The row contract must remain byte-for-byte compatible
+for the cutover golden test:
+
+```text
+id, question, status, justification, attempts,
+estimated_input_tokens, estimated_output_tokens, estimated_usd, model
+```
+
+`status` is `PASS | WARN | SKIPPED`. `SKIPPED` is pass-like during aggregation.
+For evaluated runs with at least one row, the overall verdict is
+`PASS | WARN`. The CLI must also preserve the current operational guards for
+skipped/no-result runs: a legitimate package-lock-only skip stays non-blocking,
+but a non-skipped run that produces zero rows fails closed when
+`LLM_GATE_BLOCKING=1`.
+
+The CLI must retain per-item failure isolation even though the current workflow
+uses separate matrix jobs. Each item is wrapped in try/catch, has its own
+timeout, and falls back to a determinate WARN row on failure. Internal
+concurrency is bounded and backed off with `LLM_GATE_MAX_PARALLEL`, default `2`.
+Timeout and rate-limit behavior must have tests.
+
+### Provider seam
+
+The engine calls a provider interface:
+
+```text
+GateProvider.evaluate(prompt) -> { status, justification, usage }
+```
+
+v1 ships `GeminiProvider`, wrapping the pinned Gemini CLI for behavior parity.
+The future local-model path adds an `OpenAICompatProvider` that points at a
+local GLM endpoint and is selected by `routes.yml`. The engine orchestration,
+result aggregation, Check Run logic, and comment rendering do not change when
+the provider changes.
+
+### Transport seam
+
+The normalized gate request is identical for workflow dispatch and webhook
+execution:
+
+```json
+{
+  "consumer_repo": "owner/name",
+  "installation_id": 123,
+  "pr_number": 123,
+  "base_ref": "main",
+  "base_sha": "base",
+  "head_sha": "head",
+  "event": "opened",
+  "labels": ["label"]
+}
+```
+
+The normalized gate result is also transport-independent:
+
+```json
+{
+  "overall": "PASS",
+  "rows": [],
+  "check_run": {
+    "name": "Aggregate and post review",
+    "conclusion": "success",
+    "summary": "..."
+  },
+  "comment_markdown": "..."
+}
+```
+
+v1 uses a `workflow_dispatch` router in the master repo. This requires a
+cross-repo credential in each consumer with `Actions: write` on the master repo.
+That is narrower than `repository_dispatch`, which requires `Contents: write`
+on the master and would let a compromised consumer credential push code to the
+master. `workflow_dispatch` is therefore the recommended v1 trigger, provided
+the master keeps the router as the only manually dispatchable workflow.
+
+The router also supports `repository_dispatch` for compatibility, but it is not
+the recommended trigger because of the `Contents: write` over-grant. v2 adds a
+documented webhook transport branch that POSTs the same normalized request to a
+configured URL and exits. A local receiver then runs the same CLI and posts the
+same Check Run through the App.
+
+### Router behavior
+
+The router runs only from the master default branch. It validates the payload
+against `config/routes.yml`, refuses unknown consumer repos, and never checks
+out an untrusted ref. For `github-hosted` routes it:
+
+1. Mints a GitHub App installation token scoped to the target consumer.
+2. Shallow-clones or fetches the consumer at `base_sha` for policy.
+3. Computes the trusted `base...head` diff using the consumer token.
+4. Runs `llm-gate gate`.
+5. Posts a Check Run to the consumer `head_sha`.
+6. Upserts the PR comment.
+
+The v2 `webhook` route is a stub and contract only in the first implementation.
+It sends the normalized request to the route's webhook URL and does not run the
+engine locally.
+
+### Consumer workflow
+
+Each consumer keeps:
+
+- `.github/llm-based-quality-gate/checklist.md`.
+- Today's `.github/llm-based-quality-gate/system-prompt.md`, or an optional
+  `.github/llm-based-quality-gate/system-prompt.overlay.md` after the base
+  prompt split is introduced.
+- `LLM_GATE_BLOCKING`.
+- A thin `.github/workflows/llm-gate-dispatch.yml`.
+
+The dispatch workflow runs on `pull_request` events
+`opened`, `ready_for_review`, `synchronize`, `labeled`, and `unlabeled`. It
+short-circuits when the dispatch credential is unavailable and keeps an explicit
+`head.repo.full_name == github.repository` guard.
+
+The workflow must not use `pull_request_target`. GitHub does not pass consumer
+repo or org secrets to fork-triggered `pull_request` workflows, so fork PRs do
+not receive the cross-repo dispatch credential and cannot reach the central
+engine or provider key.
+
+Manual recovery must remain available after cutover. Maintainers can re-run the
+gate by manually dispatching the master router with the normalized request for a
+specific PR, and the router updates the existing PR comment on dispatch. A
+consumer-local `workflow_dispatch` wrapper may also be kept if it only forwards
+the normalized request and does not reintroduce engine logic.
+
+### Security model and behavior parity
+
+The implementation must port all current security and behavior guarantees:
+
+- Trusted base-ref read of checklist and prompt policy.
+- Same-repo/fork guard.
+- `package-lock.json`-only skip.
+- `synchronize` stamp mode that skips re-run when a follow-up push only touches
+  `package-lock.json`.
+- Per-item `paths` filters and path-scoped diffs, with `SKIPPED` for untouched
+  items.
+- `max-diff-bytes` truncation with the exact marker and a closed tilde fence.
+- Gemini CLI pinning and `.npmrc` poisoning hardening by installing from
+  `$RUNNER_TEMP` with forced-empty `NPM_CONFIG_*`, then unsetting those
+  variables before running the provider binary.
+- `.gemini` symlink removal.
+- `GITHUB_TOKEN: ''` passed into the provider.
+- `tools.core` allowlist.
+- Staggering, escalating backoff, and at most three retries for malformed JSON.
+- Per-item WARN fallback that always emits a row.
+- Literal-key and `AIza[0-9A-Za-z_-]{35}` redaction.
+- Cost estimate fields.
+- `LLM_GATE_BLOCKING` plus `llm-gate/override` policy.
+- PR-comment upsert behavior: update on dispatch, append on PR event.
+- Fail-closed no-result behavior in blocking mode: if a non-skipped run produces
+  zero rows and `LLM_GATE_BLOCKING=1`, the Check Run fails instead of passing an
+  empty result.
+
+## Risks / Trade-offs
+
+- **Branch protection source pin can wedge merges.** Mitigation: run the new
+  App in shadow/advisory mode first, verify a live Check Run exists on the repo,
+  then re-point branch protection to the LLM-Gate App or any source. Verify with
+  `gh api .../required_status_checks` and `gh pr view --json statusCheckRollup`.
+- **A consumer dispatch credential is still sensitive.** Mitigation:
+  `workflow_dispatch` with `Actions: write` is the v1 path, the master keeps only
+  the router as manually dispatchable, the router is default-branch-only, and the
+  v2 webhook path removes the credential entirely. `Actions: write` can also
+  cancel or re-run master workflow runs, so run isolation and audit logging must
+  treat consumer credentials as capable of operational disruption even though
+  they cannot write master repo contents.
+- **One CLI process changes the failure domain.** Mitigation: per-item
+  try/catch, per-item timeout, WARN fallback, bounded concurrency, and tests for
+  timeout/rate-limit paths.
+- **Shadow mode temporarily duplicates checks/comments.** Mitigation: use an
+  advisory check/comment name or clearly marked body during pilot, then switch
+  the required status only after parity is proven.
+- **Private master repo concentrates gate power.** Mitigation: branch
+  protection, required review, narrow App permissions, route allowlist, no
+  untrusted checkout, and central secret storage.
+
+## Migration Plan
+
+1. Create `UseJunior/llm-gate` as a private repo with protected `main`.
+2. Register the dedicated LLM-Gate GitHub App, install it on all four consumers
+   and the master, and add secrets only to the master repo.
+3. Extract the engine CLI with golden-output parity tests against the existing
+   safe-docx result JSON and comment/check output.
+4. Build the router and run safe-docx in shadow/advisory mode.
+5. After the new App has posted a live safe-docx check, re-point safe-docx
+   branch protection from GitHub Actions app id `15368` to the LLM-Gate App (or
+   any source), then verify status rollup behavior.
+6. Cut over `open-agreements/open-agreements` and `UseJunior/tests-renderer`
+   with the same shadow, verify, and re-point sequence.
+7. Cut over `UseJunior/legal-explainer`; add `Aggregate and post review` as a
+   required source-pinned check only if product policy wants it to gate merges.
+8. Remove copied workflow/action engine files and per-repo `GEMINI_API_KEY`
+   secrets from consumers after each repo is fully cut over.
+9. Rollback: restore the old consumer workflow/action files and re-point
+   required checks back to GitHub Actions app id `15368` for repos where the old
+   source is still present.
+
+## Open Questions
+
+- Should the base prompt be split immediately into
+  `system-prompt.base.md` plus per-consumer overlays, or should the first
+  cutover preserve each repo's full current prompt and introduce overlays in a
+  follow-up?
+- Should `synchronize` stamp mode be kept in the first CLI port or deferred if
+  golden parity shows it is lower risk to ship after the initial shadow phase?
+- Should v1 `GeminiProvider` wrap the pinned Gemini CLI for maximum parity, or
+  switch directly to an API call if that simplifies installation hardening?
+- During shadow mode, should the central check use the final
+  `Aggregate and post review` name with a neutral conclusion, or a temporary
+  name to avoid confusing required-check source migration?

--- a/openspec/changes/refactor-centralize-llm-quality-gate/proposal.md
+++ b/openspec/changes/refactor-centralize-llm-quality-gate/proposal.md
@@ -1,0 +1,61 @@
+# Change: Centralize the LLM quality gate behind a GitHub App
+
+## Why
+
+The LLM-based quality gate is copied near-verbatim across four repositories:
+`UseJunior/safe-docx`, `open-agreements/open-agreements`,
+`UseJunior/legal-explainer`, and `UseJunior/tests-renderer`. Infrastructure
+fixes therefore have to be ported four times, and the copies drift. The issue
+#272 flakiness fix followed that path through safe-docx #533, open-agreements
+#594, legal-explainer #1647, and tests-renderer #88.
+
+Reusable workflows and composite actions do not solve this uniformly because
+private `uses:` sharing is limited to the same organization or enterprise.
+`open-agreements/open-agreements` lives in a different organization, and the
+gate engine should remain private. A GitHub App plus a central runner can read a
+consumer PR, evaluate it with one private implementation, and post the resulting
+Check Run back to the consumer repo without copying the engine.
+
+## What Changes
+
+- Add a new `ci-quality-gate` capability describing a centralized LLM gate
+  architecture.
+- Stand up a new private master repository, `UseJunior/llm-gate`, containing the
+  transport-agnostic TypeScript `llm-gate` CLI, router workflow, routes
+  allowlist, and shared base prompt.
+- Create a dedicated LLM-Gate GitHub App with minimal read/check permissions and
+  a single centralized `GEMINI_API_KEY` held only by the master repo.
+- Keep policy in each consumer repo: `checklist.md`, today's
+  `system-prompt.md` or a future `system-prompt.overlay.md`, and
+  `LLM_GATE_BLOCKING`.
+- Replace each consumer's copied workflow/action implementation with a thin
+  dispatch workflow after a shadow/advisory phase.
+- Preserve the current result contract: per-row status
+  `PASS | WARN | SKIPPED`, overall verdict `PASS | WARN`, advisory by default,
+  and blocking only when `LLM_GATE_BLOCKING=1` and `llm-gate/override` is absent.
+- **BREAKING**: remove the per-repo gate engine copies and per-repo
+  `GEMINI_API_KEY` secrets after cutover.
+- **BREAKING**: required branch-protection status checks that are source-pinned
+  to the GitHub Actions App must be re-pointed after the new LLM-Gate App has
+  posted at least one live Check Run for the repo.
+
+## Impact
+
+- Affected specs: new `ci-quality-gate` capability.
+- Affected code:
+  - New private repo: `UseJunior/llm-gate`.
+  - Consumer policy and dispatch paths:
+    - `UseJunior/safe-docx`: `.github/llm-based-quality-gate/`,
+      `.github/workflows/llm-gate-dispatch.yml`.
+    - `open-agreements/open-agreements`: `.github/llm-based-quality-gate/`,
+      `.github/workflows/llm-gate-dispatch.yml`.
+    - `UseJunior/legal-explainer`: `.github/llm-based-quality-gate/`,
+      `.github/workflows/llm-gate-dispatch.yml`.
+    - `UseJunior/tests-renderer`: `.github/llm-based-quality-gate/`,
+      `.github/workflows/llm-gate-dispatch.yml`.
+  - Old copied implementations removed from the consumer repos:
+    `.github/workflows/llm-based-quality-gate.yml` and
+    `.github/actions/llm-gate-check/action.yml` where present.
+- Existing safe-docx source size to port: 747-line workflow and 426-line
+  composite action, plus policy files in `.github/llm-based-quality-gate/`.
+- Ref: #553.

--- a/openspec/changes/refactor-centralize-llm-quality-gate/specs/ci-quality-gate/spec.md
+++ b/openspec/changes/refactor-centralize-llm-quality-gate/specs/ci-quality-gate/spec.md
@@ -1,0 +1,163 @@
+## ADDED Requirements
+
+### Requirement: Centralized Gate Engine
+
+The system SHALL run LLM quality-gate logic from a single private master
+implementation rather than copied workflow/action engines in each consumer repo.
+Consumer repos SHALL retain only policy, configuration, and a thin dispatch
+workflow after cutover.
+
+#### Scenario: Gate logic fix ships once
+- **WHEN** a gate parsing, security, provider, or aggregation fix is merged to the master `llm-gate` engine
+- **THEN** all configured consumer repos use that fixed engine without re-porting the implementation into each repo
+
+#### Scenario: Consumer keeps repo-specific policy
+- **WHEN** a consumer repo changes review criteria in `checklist.md`, today's `system-prompt.md`, or a future prompt overlay
+- **THEN** only that repo's policy changes and the shared engine implementation remains unchanged
+
+### Requirement: Trusted Policy Source
+
+The system SHALL read checklist and prompt policy only from the trusted base ref
+of the consumer PR. The system MUST treat PR head content and diffs as
+untrusted input and MUST NOT execute code from the untrusted head ref.
+
+#### Scenario: Fork changes gate policy in the PR
+- **WHEN** a PR modifies `.github/llm-based-quality-gate/checklist.md` on the head branch
+- **THEN** the gate evaluates using the checklist from the trusted base ref, not the untrusted head version
+
+#### Scenario: Router handles untrusted diff
+- **WHEN** the router evaluates a PR from a consumer repo
+- **THEN** it fetches trusted policy from `base_sha`, computes the `base...head` diff as data, and does not run scripts from the PR head
+
+### Requirement: Untrusted Diff Boundary
+
+The system SHALL place the PR diff in a clearly fenced untrusted section of the
+provider prompt. If the diff exceeds the configured maximum size, the system
+SHALL truncate it with the established marker and still close the tilde fence.
+
+#### Scenario: Oversized diff is truncated safely
+- **WHEN** a PR diff exceeds `max-diff-bytes`
+- **THEN** the prompt includes the truncation marker and a closed tilde fence before any trusted instructions continue
+
+#### Scenario: Path filter scopes item evidence
+- **WHEN** a checklist item declares `paths` globs and the PR touches matching files
+- **THEN** the provider prompt for that item includes only the path-scoped relevant diff
+
+### Requirement: Fork PRs Cannot Reach Central Secrets
+
+The system SHALL trigger consumer dispatch from `pull_request`, not
+`pull_request_target`, and SHALL short-circuit when the cross-repo dispatch
+credential is unavailable. The system MUST keep an explicit same-repository head
+guard as defense in depth.
+
+#### Scenario: Fork PR opens against a consumer
+- **WHEN** a fork-origin PR opens against a consumer repo
+- **THEN** GitHub withholds the consumer dispatch credential, the dispatch workflow does not call the master router, and the central provider key is never reachable
+
+#### Scenario: Same-repo PR opens against a consumer
+- **WHEN** a same-repository PR opens against a consumer repo and the dispatch credential is present
+- **THEN** the dispatch workflow sends the normalized request to the master router
+
+### Requirement: Normalized Gate Contracts
+
+The system SHALL use a transport-independent gate-request contract containing
+`consumer_repo`, `installation_id`, `pr_number`, `base_ref`, `base_sha`,
+`head_sha`, `event`, and `labels`. The system SHALL emit a
+transport-independent gate-result contract containing the overall verdict, row
+results, Check Run payload, and PR comment markdown.
+
+#### Scenario: GitHub-hosted route evaluates a request
+- **WHEN** a consumer dispatches a normalized request to the master router
+- **THEN** the router can run the engine and post the result without consumer-specific engine code
+
+#### Scenario: Webhook route receives the same request
+- **WHEN** a route is configured for webhook execution
+- **THEN** the router sends the same normalized request shape that the GitHub-hosted route would evaluate locally
+
+### Requirement: Result Parity and Failure Isolation
+
+The system SHALL preserve the current per-row result schema with statuses
+`PASS`, `WARN`, and `SKIPPED`. `SKIPPED` rows SHALL be pass-like during
+aggregation, and evaluated runs with at least one row SHALL aggregate to an
+overall verdict of either `PASS` or `WARN`. Each checklist item MUST have an
+isolated timeout and failure handler that emits a determinate WARN row if
+evaluation fails.
+
+#### Scenario: Untouched path-filtered item
+- **WHEN** a checklist item's `paths` globs do not match any changed file
+- **THEN** the row status is `SKIPPED` and the aggregate verdict treats it as pass-like
+
+#### Scenario: One provider call fails
+- **WHEN** the provider crashes, times out, or returns malformed JSON for one checklist item
+- **THEN** that item emits a WARN fallback row and other checklist items still complete independently
+
+#### Scenario: Blocking run produces no rows
+- **WHEN** a non-skipped gate run emits zero result rows and `LLM_GATE_BLOCKING=1`
+- **THEN** the Check Run fails closed instead of passing an empty result
+
+### Requirement: Blocking and Override Policy
+
+The system SHALL be advisory by default. A WARN verdict SHALL block merges only
+when `LLM_GATE_BLOCKING=1` for the consumer repo and the PR does not have the
+`llm-gate/override` label.
+
+#### Scenario: Advisory default
+- **WHEN** a consumer repo does not set `LLM_GATE_BLOCKING=1` and the gate finds WARN rows
+- **THEN** the Check Run conclusion does not block the PR solely because of those WARN rows
+
+#### Scenario: Blocking without override
+- **WHEN** `LLM_GATE_BLOCKING=1`, the gate finds WARN rows, and the PR lacks `llm-gate/override`
+- **THEN** the Check Run conclusion is failure
+
+#### Scenario: Override label is present
+- **WHEN** `LLM_GATE_BLOCKING=1`, the gate finds WARN rows, and the PR has `llm-gate/override`
+- **THEN** the Check Run conclusion is success or neutral according to the override policy and the comment records the override
+
+### Requirement: Branch Protection Source Migration
+
+The system SHALL NOT rely on a new App-posted Check Run to satisfy a
+source-pinned required status until branch protection has been re-pointed to
+the LLM-Gate App or to any source. For each source-pinned consumer, the system
+MUST first verify that the LLM-Gate App has posted a live Check Run on that repo.
+
+#### Scenario: New App posts same check name before re-point
+- **WHEN** branch protection requires `Aggregate and post review` from GitHub Actions app id `15368` and the LLM-Gate App posts a Check Run with the same name
+- **THEN** the new Check Run does not satisfy the source-pinned requirement until branch protection is updated
+
+#### Scenario: Re-point happens after live App check
+- **WHEN** the LLM-Gate App has posted a live `Aggregate and post review` Check Run on a consumer repo
+- **THEN** maintainers may re-point the required-check source and verify the status rollup before removing the old gate
+
+### Requirement: Workflow Dispatch Transport
+
+The system SHALL prefer `workflow_dispatch` for v1 consumer-to-master routing
+because it requires `Actions: write` on the master repo rather than
+`Contents: write`. The master repo MUST keep the router default-branch-only and
+MUST NOT expose unrelated manually dispatchable workflows to that credential.
+
+#### Scenario: Consumer dispatches v1 request
+- **WHEN** a same-repo PR event fires in a consumer with the dispatch credential available
+- **THEN** the consumer triggers the master router through `workflow_dispatch` using the normalized request payload
+
+#### Scenario: Maintainer manually re-runs a PR gate
+- **WHEN** a maintainer needs to re-run the gate for a specific PR after cutover
+- **THEN** the maintainer can manually dispatch the master router with the normalized request and the router updates the existing PR comment
+
+#### Scenario: Repository dispatch is considered
+- **WHEN** maintainers compare `repository_dispatch` for v1 routing
+- **THEN** they treat its `Contents: write` requirement on the master repo as an over-grant and do not choose it as the recommended v1 trigger
+
+### Requirement: Provider Seam
+
+The system SHALL isolate model execution behind a provider interface so changing
+from the pinned Gemini CLI to an OpenAI-compatible local endpoint does not
+change gate orchestration, result aggregation, Check Run posting, or comment
+rendering.
+
+#### Scenario: Gemini provider evaluates a row
+- **WHEN** a route selects the v1 Gemini provider
+- **THEN** the engine evaluates checklist items through `GeminiProvider` and emits the standard row schema
+
+#### Scenario: Local provider is added later
+- **WHEN** a route later selects an OpenAI-compatible local provider
+- **THEN** the engine uses that provider through the same interface and preserves the normalized result contract

--- a/openspec/changes/refactor-centralize-llm-quality-gate/tasks.md
+++ b/openspec/changes/refactor-centralize-llm-quality-gate/tasks.md
@@ -1,0 +1,81 @@
+## 1. Master repo and identity
+- [ ] 1.1 Create private repo `UseJunior/llm-gate` with protected `main` and required review.
+- [ ] 1.2 Add initial layout: `src/`, `.github/workflows/router.yml`, `config/routes.yml`, `prompts/system-prompt.base.md`, and test fixtures.
+- [ ] 1.3 Register the dedicated LLM-Gate GitHub App with `Checks: write`, `Contents: read`, `Pull requests: read`, and `Metadata: read`.
+- [ ] 1.4 Install the App on `UseJunior/llm-gate`, `UseJunior/safe-docx`, `open-agreements/open-agreements`, `UseJunior/legal-explainer`, and `UseJunior/tests-renderer`.
+- [ ] 1.5 Add master-repo secrets `LLM_GATE_APP_ID`, `LLM_GATE_APP_PRIVATE_KEY`, and `GEMINI_API_KEY`; do not copy provider credentials to consumers.
+
+## 2. Engine CLI
+- [ ] 2.1 Implement `llm-gate gate --request request.json --out result.json`.
+- [ ] 2.2 Parse `checklist.md` items from `- [ ] ...` rows, including optional `<!-- paths: ... -->` globs.
+- [ ] 2.3 Compose prompts from `system-prompt.base.md`, optional consumer overlay, the checklist question, and a tilde-fenced untrusted diff.
+- [ ] 2.4 Add `GateProvider.evaluate(prompt) -> { status, justification, usage }`.
+- [ ] 2.5 Implement `GeminiProvider` around the pinned Gemini CLI for first-cut parity.
+- [ ] 2.6 Emit per-row JSON fields `id`, `question`, `status`, `justification`, `attempts`, `estimated_input_tokens`, `estimated_output_tokens`, `estimated_usd`, and `model`.
+- [ ] 2.7 Aggregate `PASS | WARN | SKIPPED` rows into overall `PASS | WARN`, treating `SKIPPED` as pass-like.
+- [ ] 2.8 Render the existing comment table, overall verdict, and Check Run conclusion.
+- [ ] 2.9 Add golden-output tests that reproduce current per-row result JSON byte-for-byte before cutover.
+- [ ] 2.10 Wrap each checklist item in try/catch with a determinate WARN fallback row.
+- [ ] 2.11 Enforce a per-item timeout.
+- [ ] 2.12 Bound internal concurrency with `LLM_GATE_MAX_PARALLEL`, default `2`, and add rate-limit/backoff tests.
+
+## 3. Parity behavior inventory
+- [ ] 3.1 Trusted base-ref read of checklist and system prompt.
+- [ ] 3.2 Same-repo/fork guard.
+- [ ] 3.3 `package-lock.json`-only skip.
+- [ ] 3.4 `synchronize` stamp mode for follow-up pushes that only touch `package-lock.json`.
+- [ ] 3.5 Per-item `paths` filters.
+- [ ] 3.6 Path-scoped diffs.
+- [ ] 3.7 `SKIPPED` rows for untouched path-filtered items.
+- [ ] 3.8 `max-diff-bytes` truncation with the exact marker.
+- [ ] 3.9 Closed tilde fence after diff truncation.
+- [ ] 3.10 Gemini CLI pin.
+- [ ] 3.11 `.npmrc` poisoning hardening: install from `$RUNNER_TEMP` with forced-empty `NPM_CONFIG_*`, then unset before provider execution.
+- [ ] 3.12 `.gemini` symlink removal.
+- [ ] 3.13 `GITHUB_TOKEN: ''` in the provider environment.
+- [ ] 3.14 `tools.core` allowlist.
+- [ ] 3.15 Staggered starts and escalating backoff.
+- [ ] 3.16 At most three retries for malformed JSON.
+- [ ] 3.17 `always()`-equivalent WARN fallback row.
+- [ ] 3.18 Literal-key redaction.
+- [ ] 3.19 `AIza[0-9A-Za-z_-]{35}` redaction.
+- [ ] 3.20 Cost estimate fields.
+- [ ] 3.21 `LLM_GATE_BLOCKING` policy.
+- [ ] 3.22 `llm-gate/override` label policy.
+- [ ] 3.23 PR-comment upsert: update on dispatch, append on PR event.
+- [ ] 3.24 Fail-closed no-result behavior when a non-skipped blocking run emits zero rows.
+
+## 4. Router and transport
+- [ ] 4.1 Implement `workflow_dispatch` router as the recommended v1 trigger using a consumer credential with `Actions: write` on the master repo.
+- [ ] 4.2 Keep `repository_dispatch` supported but documented as non-recommended because it requires `Contents: write` on the master repo.
+- [ ] 4.3 Validate every payload against the `routes.yml` consumer allowlist.
+- [ ] 4.4 Refuse to run outside the master default branch.
+- [ ] 4.5 Mint a consumer-scoped GitHub App installation token per run.
+- [ ] 4.6 Fetch trusted policy from `base_sha` and compute the `base...head` diff without checking out untrusted code as executable.
+- [ ] 4.7 Post a Check Run to the consumer `head_sha`.
+- [ ] 4.8 Upsert the PR comment.
+- [ ] 4.9 Add the v2 webhook branch as a documented no-op/stub with the same normalized request payload.
+- [ ] 4.10 Preserve a manual re-run path by allowing maintainers to dispatch the master router for a specific PR and update the existing PR comment.
+
+## 5. Consumer cutover PRs
+- [ ] 5.1 `UseJunior/safe-docx`: add thin dispatch workflow and keep existing gate in shadow until parity is proven.
+- [ ] 5.2 `UseJunior/safe-docx`: after branch-protection re-point, remove copied workflow/action engine and delete the per-repo `GEMINI_API_KEY`.
+- [ ] 5.3 `open-agreements/open-agreements`: add thin dispatch workflow and keep existing gate in shadow until parity is proven.
+- [ ] 5.4 `open-agreements/open-agreements`: after branch-protection re-point, remove copied workflow/action engine and delete the per-repo `GEMINI_API_KEY`.
+- [ ] 5.5 `UseJunior/legal-explainer`: add thin dispatch workflow and keep existing gate in shadow until parity is proven.
+- [ ] 5.6 `UseJunior/legal-explainer`: remove copied workflow/action engine and delete the per-repo `GEMINI_API_KEY`; add the check as required only if desired.
+- [ ] 5.7 `UseJunior/tests-renderer`: add thin dispatch workflow and keep existing gate in shadow until parity is proven.
+- [ ] 5.8 `UseJunior/tests-renderer`: after branch-protection re-point, remove copied workflow/action engine and delete the per-repo `GEMINI_API_KEY`.
+
+## 6. Branch protection and verification
+- [ ] 6.1 Verify the new LLM-Gate App has posted at least one live `Aggregate and post review` Check Run on `UseJunior/safe-docx`.
+- [ ] 6.2 Re-point `UseJunior/safe-docx` required-check source from app id `15368` to the LLM-Gate App or any source; verify with `gh api` and `gh pr view --json statusCheckRollup`.
+- [ ] 6.3 Verify the new LLM-Gate App has posted at least one live `Aggregate and post review` Check Run on `open-agreements/open-agreements`.
+- [ ] 6.4 Re-point `open-agreements/open-agreements` required-check source from app id `15368` to the LLM-Gate App or any source; verify with `gh api` and `gh pr view --json statusCheckRollup`.
+- [ ] 6.5 Verify the new LLM-Gate App has posted at least one live `Aggregate and post review` Check Run on `UseJunior/tests-renderer`.
+- [ ] 6.6 Re-point `UseJunior/tests-renderer` required-check source from app id `15368` to the LLM-Gate App or any source; verify with `gh api` and `gh pr view --json statusCheckRollup`.
+- [ ] 6.7 For `UseJunior/legal-explainer`, decide whether to add `Aggregate and post review` as required; if yes, source-pin it only after the LLM-Gate App has posted a live check.
+
+## 7. OpenSpec
+- [ ] 7.1 Validate this change with `openspec validate refactor-centralize-llm-quality-gate --strict`.
+- [ ] 7.2 Keep implementation work out of this proposal PR until the OpenSpec change is reviewed and approved.


### PR DESCRIPTION
## Summary
- Adds the `refactor-centralize-llm-quality-gate` OpenSpec proposal.
- Defines the new `ci-quality-gate` capability and target GitHub App architecture.
- Records parity, security, transport, provider, branch-protection source-pin, and migration requirements for the follow-up implementation.

## Validation
- `openspec validate refactor-centralize-llm-quality-gate --strict`
- Claude headless review: APPROVE-WITH-FIXES; addressed fail-closed zero-row blocking behavior, manual re-run path, prompt filename wording, and `Actions: write` operational risk before opening this PR.

Ref: #553