### PR TITLE
docs(conformance): close complex field coverage

### DIFF
--- a/packages/docx-core/src/generation/emit/run.ts
+++ b/packages/docx-core/src/generation/emit/run.ts
@@ -17,7 +17,12 @@ import type { FieldSpec, InlineSpec, RunProps } from '../types.js';
 import type { BlockEmitContext } from './emit-context.js';
 import { buildRunPropsElement } from './properties.js';
 
-/** Instruction text per field, with the canonical surrounding spaces. */
+/**
+ * Instruction text per supported field, with canonical surrounding spaces.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.5.44
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.5.42
+ */
 const FIELD_INSTRUCTION_TEXT: Record<FieldSpec['field'], string> = {
   PAGE: ' PAGE ',
   NUMPAGES: ' NUMPAGES ',

--- a/packages/docx-core/src/generation/generation-sections-fields.test.ts
+++ b/packages/docx-core/src/generation/generation-sections-fields.test.ts
@@ -272,32 +272,34 @@ describe('Traceability: multi-section documents, headers/footers, and fields', (
     },
   );
 
-  test.openspec('[SDX-GEN-032] field pairing holds in every story part')(
-    'Scenario: field pairing holds in every story part',
-    async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
-      let buffer!: Buffer;
-      await given('a generated package with fields in its footer story', async () => {
-        buffer = await generateDocx(coverBodySpec());
-      });
+  test
+    .openspec('[SDX-GEN-032] field pairing holds in every story part')
+    .conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.16.18' })(
+      'Scenario: field pairing holds in every story part',
+      async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
+        let buffer!: Buffer;
+        await given('a generated package with fields in its footer story', async () => {
+          buffer = await generateDocx(coverBodySpec());
+        });
 
-      await when('the structural field-pairing check scans every story part', async () => {
-        const result = await checkGeneratedPackage(buffer);
-        expect(result.ok, JSON.stringify(result.issues)).toBe(true);
-      });
+        await when('the structural field-pairing check scans every story part', async () => {
+          const result = await checkGeneratedPackage(buffer);
+          expect(result.ok, JSON.stringify(result.issues)).toBe(true);
+        });
 
-      await then('removing a fldChar end from the footer is detected as an unclosed field', async () => {
-        const zip = await JSZip.loadAsync(buffer);
-        const footer = await zip.file('word/footer1.xml')!.async('text');
-        const tampered = footer.replace(/<w:r><w:fldChar w:fldCharType="end"\/><\/w:r>/, '');
-        expect(tampered).not.toBe(footer);
-        zip.file('word/footer1.xml', tampered);
-        const result = await checkGeneratedPackage((await zip.generateAsync({ type: 'nodebuffer' })) as Buffer);
-        await attachPrettyJson('tampered-field-result', result);
-        expect(result.ok).toBe(false);
-        expect(result.issues.some((i) => i.check === 'field_pairing' && i.part === 'word/footer1.xml')).toBe(true);
-      });
-    },
-  );
+        await then('removing a fldChar end from the footer is detected as an unclosed field', async () => {
+          const zip = await JSZip.loadAsync(buffer);
+          const footer = await zip.file('word/footer1.xml')!.async('text');
+          const tampered = footer.replace(/<w:r><w:fldChar w:fldCharType="end"\/><\/w:r>/, '');
+          expect(tampered).not.toBe(footer);
+          zip.file('word/footer1.xml', tampered);
+          const result = await checkGeneratedPackage((await zip.generateAsync({ type: 'nodebuffer' })) as Buffer);
+          await attachPrettyJson('tampered-field-result', result);
+          expect(result.ok).toBe(false);
+          expect(result.issues.some((i) => i.check === 'field_pairing' && i.part === 'word/footer1.xml')).toBe(true);
+        });
+      },
+    );
 
   test('cover→body acceptance artifact is written for the manual compatibility matrix', async () => {
     const buffer = await generateDocx(coverBodySpec());

--- a/packages/docx-core/src/generation/structural-checks.ts
+++ b/packages/docx-core/src/generation/structural-checks.ts
@@ -233,6 +233,12 @@ function isStoryPart(name: string): boolean {
   );
 }
 
+/**
+ * Validate begin → separate → end field structure independently in each
+ * generated WordprocessingML story part.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.18
+ */
 function checkFieldPairing(contents: Map<string, string>): StructuralIssue[] {
   const issues: StructuralIssue[] = [];
   for (const [name, text] of contents) {

--- a/spec-compliance/CONFORMANCE.md
+++ b/spec-compliance/CONFORMANCE.md
@@ -34,9 +34,9 @@ Allure labels via `testAllure.conformance({…})`; source code carries
 | `ECMA-PART1-17-10-4` | w:hdr header part emission | 5 | 1 | 17.10.4 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:hdr` | — |
 | `ECMA-PART1-17-10-3` | w:ftr footer part emission | 5 | 1 | 17.10.3 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:ftr` | — |
 | `ECMA-PART1-17-10-1` | w:evenAndOddHeaders setting | 5 | 1 | 17.10.1 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:evenAndOddHeaders` | — |
-| `ECMA-PART1-17-16-18` | w:fldChar five-part complex-field emission | 5 | 1 | 17.16.18 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:fldChar` | — |
-| `ECMA-PART1-17-16-5-44` | PAGE field instruction emission | 5 | 1 | 17.16.5.44 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:instrText` | — |
-| `ECMA-PART1-17-16-5-42` | NUMPAGES field instruction emission | 5 | 1 | 17.16.5.42 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:instrText` | — |
+| `ECMA-PART1-17-16-18` | w:fldChar five-part complex-field emission | 5 | 1 | 17.16.18 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:fldChar` | packages/docx-core/src/generation/emit/run.ts; packages/docx-core/src/generation/structural-checks.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts; verification/lean/Tier2/XmlTripleChecker.lean; verification/registry/lean-xml-checker-coverage.json |
+| `ECMA-PART1-17-16-5-44` | PAGE field instruction emission | 5 | 1 | 17.16.5.44 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:instrText` | packages/docx-core/src/generation/emit/run.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts |
+| `ECMA-PART1-17-16-5-42` | NUMPAGES field instruction emission | 5 | 1 | 17.16.5.42 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:instrText` | packages/docx-core/src/generation/emit/run.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts |
 | `ECMA-PART1-17-4-37` | w:tbl table emission | 5 | 1 | 17.4.37 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:tbl` | — |
 | `ECMA-PART1-17-4-59` | w:tblPr table-properties emission | 5 | 1 | 17.4.59 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:tblPr` | — |
 | `ECMA-PART1-17-4-63` | w:tblW preferred-width consistency | 5 | 1 | 17.4.63 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:tblW` | — |
@@ -381,6 +381,7 @@ document-level switch can never drift apart.
 - **Part / Section:** Part 1 § 17.16.18
 - **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
 - **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:fldChar`
+- **Verified by:** packages/docx-core/src/generation/emit/run.ts; packages/docx-core/src/generation/structural-checks.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts; verification/lean/Tier2/XmlTripleChecker.lean; verification/registry/lean-xml-checker-coverage.json
 
 Every generated field is a complete five-run sequence — `fldChar begin`,
 preserved-space `w:instrText`, `fldChar separate`, a cached-result run,
@@ -395,6 +396,7 @@ separate → end state machine over every story part.
 - **Part / Section:** Part 1 § 17.16.5.44
 - **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
 - **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:instrText`
+- **Verified by:** packages/docx-core/src/generation/emit/run.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts
 
 The PAGE instruction is emitted with canonical surrounding spaces
 (` PAGE `) inside a preserved-space `w:instrText`, matching the shape of
@@ -406,6 +408,7 @@ the committed field fixtures used by the comparison pipeline.
 - **Part / Section:** Part 1 § 17.16.5.42
 - **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
 - **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:instrText`
+- **Verified by:** packages/docx-core/src/generation/emit/run.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts
 
 The NUMPAGES instruction follows the same emission discipline as PAGE
 (` NUMPAGES `, preserved spacing, cached result required), giving
@@ -893,6 +896,11 @@ non-goal, ships in `packages/docx-core/src/generation/` under the
 section; they are described under
 [“What Safe Docx Is Not Optimized For”](/README.md#what-safe-docx-is-not-optimized-for)
 in the root README.
+
+Within Part 1 §17.16, safe-docx targets structural emission of complex fields
+and the PAGE and NUMPAGES instructions listed above. Other field instructions,
+field-code parsing and evaluation, cached-result correctness, pagination, and
+equivalence to a Word application's field engine are out of scope.
 
 A source `@conformance` JSDoc tag that points at one of these Non-Goal IDs fails
 the citation lint. For a deliberate divergence *inside a targeted section*, use

--- a/spec-compliance/registry/ecma-376.md
+++ b/spec-compliance/registry/ecma-376.md
@@ -398,7 +398,7 @@ part: 1
 section: "17.16.18"
 url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
 schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:fldChar
-verifiedBy:
+verifiedBy: packages/docx-core/src/generation/emit/run.ts; packages/docx-core/src/generation/structural-checks.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts; verification/lean/Tier2/XmlTripleChecker.lean; verification/registry/lean-xml-checker-coverage.json
 ```
 
 Every generated field is a complete five-run sequence — `fldChar begin`,
@@ -416,7 +416,7 @@ part: 1
 section: "17.16.5.44"
 url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
 schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:instrText
-verifiedBy:
+verifiedBy: packages/docx-core/src/generation/emit/run.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts
 ```
 
 The PAGE instruction is emitted with canonical surrounding spaces
@@ -431,7 +431,7 @@ part: 1
 section: "17.16.5.42"
 url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
 schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:instrText
-verifiedBy:
+verifiedBy: packages/docx-core/src/generation/emit/run.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts
 ```
 
 The NUMPAGES instruction follows the same emission discipline as PAGE
@@ -1082,6 +1082,11 @@ non-goal, ships in `packages/docx-core/src/generation/` under the
 section; they are described under
 [“What Safe Docx Is Not Optimized For”](/README.md#what-safe-docx-is-not-optimized-for)
 in the root README.
+
+Within Part 1 §17.16, safe-docx targets structural emission of complex fields
+and the PAGE and NUMPAGES instructions listed above. Other field instructions,
+field-code parsing and evaluation, cached-result correctness, pagination, and
+equivalence to a Word application's field engine are out of scope.
 
 A source `@conformance` JSDoc tag that points at one of these Non-Goal IDs fails
 the citation lint. For a deliberate divergence *inside a targeted section*, use

--- a/verification/registry/lean-xml-checker-coverage.json
+++ b/verification/registry/lean-xml-checker-coverage.json
@@ -73,6 +73,11 @@
       "claim": "The parser recognizes the tracked-run wrappers that affect accept/reject text projection in the main document body."
     },
     {
+      "registryId": "ECMA-PART1-17-16-18",
+      "section": "Part 1 §17.16.18",
+      "claim": "For original, revised, and compared word/document.xml, the checker recognizes begin, separate, and end markers and requires a valid marker sequence after accepting and rejecting tracked changes."
+    },
+    {
       "registryId": "ECMA-PART4-17-16-5",
       "section": "Part 4 §17.16.5",
       "claim": "The checker rejects field markers under deletion markup and requires deleted field-code text to stay under deletion markup."
@@ -87,6 +92,7 @@
     "footnote and endnote definition/reference integrity",
     "relationship target integrity",
     "package-level OPC constraints",
+    "field instruction parsing, evaluation, and cached-result correctness, including PAGE and NUMPAGES semantics",
     "OOXML extension and compatibility markup"
   ],
   "futureObligationQueue": []


### PR DESCRIPTION
## Summary

- bind the ECMA-376 Part 1 complex-field, PAGE, and NUMPAGES registry entries to existing implementation and test evidence
- add source and test conformance citations for complex-field structure and supported field instructions
- document the Lean checker's exact three-input field-marker scope and explicitly exclude field-code evaluation semantics
- regenerate the public conformance report

## Why

The priority ledger described this slice as partially implemented, but the registry did not identify the emitter, structural validator, tests, or formal-checker boundary. This change makes the existing support auditable without claiming that safe-docx or Lean evaluates Word field instructions.

## Validation

- `npm run build`
- `npm run lint:workspaces`
- `npm run test:run` (sandbox run: 2,303 passing/expected/skipped cases; five environment-blocked tests rerun successfully outside the sandbox)
- `npm run test:run -w @usejunior/docx-core -- src/integration/cross-implementation-suite.test.ts src/integration/generation-package-structure.test.ts`
- `npm run check:spec-coverage`
- `npm run check:conformance-citations`
- `npm run check:conformance-doc`
- `npm run check:lean-xml-checker-coverage`

Fixes #558
Refs #547
