### PR TITLE
feat(verification): verify fixed WordprocessingML stories

### DIFF
--- a/openspec/changes/add-lean-fixed-story-verifier/design.md
+++ b/openspec/changes/add-lean-fixed-story-verifier/design.md
@@ -1,0 +1,26 @@
+## Context
+
+TypeScript produces original, revised, and compared DOCX packages. The verifier must independently select and inspect `word/document.xml`, `word/footnotes.xml`, and `word/endnotes.xml`; passing pre-extracted XML would leave package projection in the producer.
+
+## Goals / Non-Goals
+
+- Goals: fixed-part extraction in the verifier process, fail-closed presence matching, independent story state, generic collection theorem, plain per-story certificates.
+- Non-Goals: comments, headers/footers, relationships, note-reference integrity, rendering, arbitrary package parts, rebuild mode, full XML schema validation.
+
+## Decisions
+
+- Protocol v2 passes filesystem paths to immutable temporary snapshots of the three package buffers. Lean invokes `unzip` directly with a fixed part name; TypeScript does not inspect parts or implement verifier predicates.
+- `word/document.xml` is required in all packages. Each optional note part must be present in all three packages or absent from all three; any other pattern is a verifier failure.
+- Lean models `NamedStoryTriple` and checks a list of stories. Every story starts with fresh wrapper and field state.
+- The token parser marks reserved footnote/endnote entries (`w:id=-1` and `w:id=0`), and a Lean projection removes their content before checking. The projection is proved idempotent and proved to remove reserved tokens.
+- Protocol output reports each story separately and includes package hashes computed by TypeScript for certificate reproducibility. Package extraction failures remain `not_run`; logical/presence failures are `failed`.
+
+## Risks / Trade-offs
+
+- `unzip` is an operational dependency of protocol v2. The launcher fails closed and reports the extraction error; packaged distributions must ship or provide it.
+- The XML scanner remains a deliberately narrow token projection. Coverage is stated exactly and does not imply schema or reference validation.
+
+## Migration Plan
+
+Protocol v1 is replaced internally by v2. The verifier option remains opt-in, and rebuild behavior remains `not_applicable`, so default comparison behavior is unchanged.
+

--- a/openspec/changes/add-lean-fixed-story-verifier/design.md
+++ b/openspec/changes/add-lean-fixed-story-verifier/design.md
@@ -4,23 +4,24 @@ TypeScript produces original, revised, and compared DOCX packages. The verifier 
 
 ## Goals / Non-Goals
 
-- Goals: fixed-part extraction in the verifier process, fail-closed presence matching, independent story state, generic collection theorem, plain per-story certificates.
+- Goals: bounded fixed-part extraction in the verifier process, namespace-aware XML projection, missing-as-empty optional stories, independent story state, generic collection theorem, plain per-story certificates.
 - Non-Goals: comments, headers/footers, relationships, note-reference integrity, rendering, arbitrary package parts, rebuild mode, full XML schema validation.
 
 ## Decisions
 
 - Protocol v2 passes filesystem paths to immutable temporary snapshots of the three package buffers. Lean invokes `unzip` directly with a fixed part name; TypeScript does not inspect parts or implement verifier predicates.
-- `word/document.xml` is required in all packages. Each optional note part must be present in all three packages or absent from all three; any other pattern is a verifier failure.
+- `word/document.xml` is required in all packages. If any package supplies an optional note part, absent sides are modeled as empty stories so tracked part addition/removal can be verified; all-absent optional parts are omitted.
 - Lean models `NamedStoryTriple` and checks a list of stories. Every story starts with fresh wrapper and field state.
-- The token parser marks reserved footnote/endnote entries (`w:id=-1` and `w:id=0`), and a Lean projection removes their content before checking. The projection is proved idempotent and proved to remove reserved tokens.
-- Protocol output reports each story separately and includes package hashes computed by TypeScript for certificate reproducibility. Package extraction failures remain `not_run`; logical/presence failures are `failed`.
+- The token parser resolves qualified names to namespace URIs, requires the expected WordprocessingML expanded-name root, and rejects malformed/unbound XML instead of treating it as empty.
+- Reserved notes are selected by namespace-qualified `w:type="separator"` or `w:type="continuationSeparator"`, independent of numeric ID. The Lean projection is proved idempotent and proved to remove a typed reserved payload.
+- Protocol output reports each story separately and includes package hashes computed from immutable TypeScript snapshots. Extraction is preflighted against compressed, expanded, ratio, and package limits and streamed with a hard output bound.
+- The executable protocol is v2. The public certificate retains its v1 fields and adds `checkerProtocolVersion`, fixed-story scope, package hashes, story reports, presence, and exclusions.
 
 ## Risks / Trade-offs
 
-- `unzip` is an operational dependency of protocol v2. The launcher fails closed and reports the extraction error; packaged distributions must ship or provide it.
+- `unzip` is an operational dependency of executable protocol v2. The launcher fails closed and reports missing, corrupt, oversized, or extraction errors; packaged distributions must ship or provide it.
 - The XML scanner remains a deliberately narrow token projection. Coverage is stated exactly and does not imply schema or reference validation.
 
 ## Migration Plan
 
-Protocol v1 is replaced internally by v2. The verifier option remains opt-in, and rebuild behavior remains `not_applicable`, so default comparison behavior is unchanged.
-
+The internal executable protocol moves to v2. The public certificate remains protocol v1 and gains additive fields, so existing consumers retain their discriminator, verifier name, scope, hashes, main checks, and token counts. The verifier option remains opt-in, and rebuild behavior remains `not_applicable`.

--- a/openspec/changes/add-lean-fixed-story-verifier/proposal.md
+++ b/openspec/changes/add-lean-fixed-story-verifier/proposal.md
@@ -7,14 +7,14 @@ The compiled verifier currently checks only XML selected by TypeScript from `wor
 ## What Changes
 
 - Change the verifier protocol to pass three DOCX package snapshots and let the compiled Lean process extract the fixed story parts.
-- Check the required main story and symmetrically present optional footnote and endnote stories as independent named triples.
+- Check the required main story and optional footnote/endnote stories as independent named triples, modeling a missing optional side as empty when any side supplies the part.
 - Prove that a passing collection report implies every supplied story report passes, without residual comparison axioms.
-- Project reserved note separator entries explicitly before note text comparison.
+- Resolve XML namespace prefixes inside Lean, reject malformed roots, and project typed reserved note separator entries explicitly before note text comparison.
+- Bound package and extracted-part sizes and preserve the public v1 certificate shape through additive fixed-story evidence.
 - Return per-story certificates and document the exact fixed-story scope and exclusions.
 
 ## Impact
 
 - Affected specs: `docx-comparison`
 - Affected code: Lean checker/executable, TypeScript launcher and certificate types, comparison integration tests, verification coverage ledger and docs
-- The executable relies on an available `unzip` command for DOCX package extraction; missing extraction support fails closed as `not_run`.
-
+- The executable relies on an available `unzip` command for bounded DOCX package extraction; missing, corrupt, or oversized extraction support fails closed as `not_run`.

--- a/openspec/changes/add-lean-fixed-story-verifier/proposal.md
+++ b/openspec/changes/add-lean-fixed-story-verifier/proposal.md
@@ -1,0 +1,20 @@
+# Change: Verify fixed WordprocessingML stories in Lean
+
+## Why
+
+The compiled verifier currently checks only XML selected by TypeScript from `word/document.xml`. Footnotes and endnotes are independent WordprocessingML stories, so neither package-part selection nor field state may remain outside the Lean verifier trust boundary.
+
+## What Changes
+
+- Change the verifier protocol to pass three DOCX package snapshots and let the compiled Lean process extract the fixed story parts.
+- Check the required main story and symmetrically present optional footnote and endnote stories as independent named triples.
+- Prove that a passing collection report implies every supplied story report passes, without residual comparison axioms.
+- Project reserved note separator entries explicitly before note text comparison.
+- Return per-story certificates and document the exact fixed-story scope and exclusions.
+
+## Impact
+
+- Affected specs: `docx-comparison`
+- Affected code: Lean checker/executable, TypeScript launcher and certificate types, comparison integration tests, verification coverage ledger and docs
+- The executable relies on an available `unzip` command for DOCX package extraction; missing extraction support fails closed as `not_run`.
+

--- a/openspec/changes/add-lean-fixed-story-verifier/specs/docx-comparison/spec.md
+++ b/openspec/changes/add-lean-fixed-story-verifier/specs/docx-comparison/spec.md
@@ -1,0 +1,40 @@
+## ADDED Requirements
+
+### Requirement: Compiled verifier checks fixed WordprocessingML stories from DOCX packages
+
+The system SHALL pass the original, revised, and compared DOCX packages to the compiled Lean verifier. The verifier process SHALL extract and independently check `word/document.xml`, `word/footnotes.xml`, and `word/endnotes.xml`, without a TypeScript implementation of its verification predicates.
+
+#### Scenario: [LEAN-STORY-01] Fixed stories pass together
+- **GIVEN** a valid inplace package triple with main, footnote, and endnote stories
+- **WHEN** the compiled verifier runs
+- **THEN** it returns a passing report for every supplied story
+
+#### Scenario: [LEAN-STORY-02] Side-story state is isolated
+- **GIVEN** a malformed field sequence in one optional story
+- **WHEN** markers in another story would balance the aggregate counts
+- **THEN** the verifier rejects the malformed story and the collection
+
+### Requirement: Fixed story presence is fail closed
+
+The verifier SHALL require `word/document.xml` in all three packages. It SHALL check an optional note story only when present in all three packages and SHALL fail when an optional story is present in only part of the package triple.
+
+#### Scenario: [LEAN-STORY-03] Optional presence mismatch fails
+- **WHEN** a footnote or endnote part is missing from only one package
+- **THEN** the verifier returns a failed collection report identifying that story
+
+### Requirement: Reserved note entries have an explicit proved projection
+
+The Lean verifier SHALL exclude reserved separator and continuation-separator note entries from user-visible note text equivalence through a Lean-defined projection whose key properties are machine-checked.
+
+#### Scenario: [LEAN-STORY-04] Reserved separator text is excluded
+- **GIVEN** differing reserved separator entries and equal user note text
+- **WHEN** the note story is checked
+- **THEN** reserved entry differences do not cause text divergence
+
+### Requirement: Fixed-story certificates state their boundary
+
+The document-integrity certificate SHALL report per-story results and SHALL not imply validation of relationships, note references, comments, headers, footers, rendering, or full ECMA-376 conformance.
+
+#### Scenario: [LEAN-STORY-05] Side-story divergence is visible
+- **WHEN** accept or reject text diverges in a supplied note story
+- **THEN** the certificate is failed and identifies the failed story checks

--- a/openspec/changes/add-lean-fixed-story-verifier/specs/docx-comparison/spec.md
+++ b/openspec/changes/add-lean-fixed-story-verifier/specs/docx-comparison/spec.md
@@ -14,13 +14,14 @@ The system SHALL pass the original, revised, and compared DOCX packages to the c
 - **WHEN** markers in another story would balance the aggregate counts
 - **THEN** the verifier rejects the malformed story and the collection
 
-### Requirement: Fixed story presence is fail closed
+### Requirement: Missing optional stories are modeled explicitly
 
-The verifier SHALL require `word/document.xml` in all three packages. It SHALL check an optional note story only when present in all three packages and SHALL fail when an optional story is present in only part of the package triple.
+The verifier SHALL require `word/document.xml` in all three packages. When any package contains an optional note story, the verifier SHALL model an absent side as an empty token story and check the resulting triple. It SHALL omit an optional story only when all three packages omit it.
 
-#### Scenario: [LEAN-STORY-03] Optional presence mismatch fails
-- **WHEN** a footnote or endnote part is missing from only one package
-- **THEN** the verifier returns a failed collection report identifying that story
+#### Scenario: [LEAN-STORY-03] Optional presence is modeled as an empty story
+- **WHEN** a footnote or endnote part is absent from one side of a package triple
+- **THEN** the verifier reports that side as absent and checks it as empty
+- **AND** tracked additions/removals can pass while untracked divergence fails
 
 ### Requirement: Reserved note entries have an explicit proved projection
 
@@ -38,3 +39,29 @@ The document-integrity certificate SHALL report per-story results and SHALL not 
 #### Scenario: [LEAN-STORY-05] Side-story divergence is visible
 - **WHEN** accept or reject text diverges in a supplied note story
 - **THEN** the certificate is failed and identifies the failed story checks
+
+### Requirement: WordprocessingML parsing is namespace aware and fail closed
+
+The compiled Lean parser SHALL resolve qualified names to namespace URIs, accept any prefix bound to the supported WordprocessingML namespace, require the expected expanded-name root for each fixed part, and reject malformed or unbound XML.
+
+#### Scenario: [LEAN-STORY-06] Alternate namespace prefixes preserve checks
+- **WHEN** a fixed story uses a non-`w` prefix bound to the WordprocessingML namespace
+- **THEN** the verifier recognizes its tracked text and fields
+- **AND** divergent text cannot pass as an empty projection
+
+### Requirement: Package extraction and protocol output are bounded and validated
+
+The launcher and compiled verifier SHALL enforce package, compressed-entry, expanded-entry, compression-ratio, diagnostics, and protocol-output bounds. Missing entries SHALL be distinguished from corrupt archives. The launcher SHALL reject duplicate or unknown stories, invalid counts, extra fields, and inconsistent pass bits, and SHALL terminate verifier descendant processes on timeout.
+
+#### Scenario: [LEAN-STORY-07] Unsafe package extraction fails closed
+- **WHEN** a package is corrupt, oversized, or exceeds the compression-ratio limit
+- **THEN** the certificate status is `not_run` with no passing claim
+
+#### Scenario: [LEAN-STORY-08] Public certificate remains v1 compatible
+- **WHEN** fixed-story evidence is returned
+- **THEN** the existing certificate protocol, verifier, scope, hashes, main checks, and counts remain available
+- **AND** package/story evidence is additive
+
+#### Scenario: [LEAN-STORY-09] Inconsistent executable protocol is rejected
+- **WHEN** the executable returns duplicate stories, invalid counts, unknown fields, or inconsistent pass values
+- **THEN** the launcher returns `not_run`

--- a/openspec/changes/add-lean-fixed-story-verifier/tasks.md
+++ b/openspec/changes/add-lean-fixed-story-verifier/tasks.md
@@ -7,7 +7,7 @@
 ## 2. Executable and protocol
 
 - [x] 2.1 Implement protocol v2 DOCX paths and fixed-part extraction.
-- [x] 2.2 Enforce required main and symmetric optional-part presence.
+- [x] 2.2 Enforce required main and missing-as-empty optional-part semantics.
 - [x] 2.3 Return per-story reports and extraction failures.
 
 ## 3. TypeScript integration
@@ -17,6 +17,6 @@
 
 ## 4. Evidence
 
-- [x] 4.1 Add valid, malformed, presence mismatch, divergence, protocol, and differential tests.
+- [x] 4.1 Add valid, malformed, namespace, add/remove, divergence, protocol, bounds, compatibility, and differential tests.
 - [x] 4.2 Update exact coverage ledger and verifier documentation.
 - [x] 4.3 Run Lean, axiom, OpenSpec, focused, and mandatory repository checks.

--- a/openspec/changes/add-lean-fixed-story-verifier/tasks.md
+++ b/openspec/changes/add-lean-fixed-story-verifier/tasks.md
@@ -1,0 +1,22 @@
+## 1. Lean model and proof
+
+- [x] 1.1 Add named story triples and collection reports.
+- [x] 1.2 Add reserved note-entry projection and lemmas.
+- [x] 1.3 Prove collection checker soundness without residual axioms.
+
+## 2. Executable and protocol
+
+- [x] 2.1 Implement protocol v2 DOCX paths and fixed-part extraction.
+- [x] 2.2 Enforce required main and symmetric optional-part presence.
+- [x] 2.3 Return per-story reports and extraction failures.
+
+## 3. TypeScript integration
+
+- [x] 3.1 Snapshot package buffers and invoke protocol v2 without duplicate predicates.
+- [x] 3.2 Update plain certificate types and pipeline wiring.
+
+## 4. Evidence
+
+- [x] 4.1 Add valid, malformed, presence mismatch, divergence, protocol, and differential tests.
+- [x] 4.2 Update exact coverage ledger and verifier documentation.
+- [x] 4.3 Run Lean, axiom, OpenSpec, focused, and mandatory repository checks.

--- a/packages/docx-compare/src/baselines/atomizer/leanXmlVerifier.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/leanXmlVerifier.test.ts
@@ -205,44 +205,39 @@ describeWithLean('Lean fixed-story package protocol', () => {
     });
 
   test.openspec('[LEAN-STORY-03] Optional presence is modeled as an empty story')(
-    'rejects an untracked optional-part addition against an empty original story', async () => {
+    'checks missing stories as empty so tracked additions and removals pass but untracked divergence fails', async () => {
       const withNote = await buildSyntheticDocx({ paragraphs: ['Body'], footnoteOnParagraph: 0 });
       const withoutNote = await replacePart(withNote, 'word/footnotes.xml', null);
-      const certificate = await run(withoutNote, withNote, withNote);
-      expect(certificate.status).toBe('failed');
-      expect(certificate.presenceMismatches).toEqual([]);
-      expect(certificate.stories?.find((story) => story.name === 'footnotes')?.presence).toEqual({
+      const untrackedAddition = await run(withoutNote, withNote, withNote);
+      expect(untrackedAddition.status).toBe('failed');
+      expect(untrackedAddition.presenceMismatches).toEqual([]);
+      expect(untrackedAddition.stories?.find((story) => story.name === 'footnotes')?.presence).toEqual({
         original: false, revised: true, compared: true,
       });
+      const added = await replacePart(
+        withNote,
+        'word/footnotes.xml',
+        footnotes('<w:ins><w:r><w:t>Added note</w:t></w:r></w:ins>')
+      );
+      const revisedAdded = await replacePart(
+        withNote,
+        'word/footnotes.xml',
+        footnotes('<w:r><w:t>Added note</w:t></w:r>')
+      );
+      const removed = await replacePart(
+        withNote,
+        'word/footnotes.xml',
+        footnotes('<w:del><w:r><w:delText>Removed note</w:delText></w:r></w:del>')
+      );
+      const originalRemoved = await replacePart(
+        withNote,
+        'word/footnotes.xml',
+        footnotes('<w:r><w:t>Removed note</w:t></w:r>')
+      );
+
+      expect((await run(withoutNote, revisedAdded, added)).status).toBe('passed');
+      expect((await run(originalRemoved, withoutNote, removed)).status).toBe('passed');
     });
-
-  test('accepts tracked optional-part addition and removal against empty missing stories', async () => {
-    const withNote = await buildSyntheticDocx({ paragraphs: ['Body'], footnoteOnParagraph: 0 });
-    const withoutNote = await replacePart(withNote, 'word/footnotes.xml', null);
-    const added = await replacePart(
-      withNote,
-      'word/footnotes.xml',
-      footnotes('<w:ins><w:r><w:t>Added note</w:t></w:r></w:ins>')
-    );
-    const revisedAdded = await replacePart(
-      withNote,
-      'word/footnotes.xml',
-      footnotes('<w:r><w:t>Added note</w:t></w:r>')
-    );
-    const removed = await replacePart(
-      withNote,
-      'word/footnotes.xml',
-      footnotes('<w:del><w:r><w:delText>Removed note</w:delText></w:r></w:del>')
-    );
-    const originalRemoved = await replacePart(
-      withNote,
-      'word/footnotes.xml',
-      footnotes('<w:r><w:t>Removed note</w:t></w:r>')
-    );
-
-    expect((await run(withoutNote, revisedAdded, added)).status).toBe('passed');
-    expect((await run(originalRemoved, withoutNote, removed)).status).toBe('passed');
-  });
 
   test('fails closed when the required main story is missing from any package', async () => {
     const base = await buildDocxFromBodyXml(paragraphWithText('Body'));
@@ -416,19 +411,25 @@ describe('Lean fixed-story protocol and security hardening', () => {
   test.openspec('[LEAN-STORY-08] Public certificate remains v1 compatible')(
     'preserves the public v1 certificate fields while adding package-story evidence', async () => {
     const docx = await buildDocxFromBodyXml(paragraphWithText('Body'));
-    const result = await runWith(docx, docx, docx, LEAN_EXE);
-    const legacyShape: {
-      protocolVersion: 1;
-      verifier: 'Lean XML triple checker';
-      scope: 'word/document.xml';
-    } = result;
-    expect(legacyShape).toMatchObject({
-      protocolVersion: 1,
-      verifier: 'Lean XML triple checker',
-      scope: 'word/document.xml',
-    });
-    expect(result.checks.acceptingAllTrackedChangesMatchesRevisedText.status).toBe('passed');
-    expect(result.checkerProtocolVersion).toBe(2);
+    const fake = await fakeChecker(validProtocolReport);
+    try {
+      const result = await runWith(docx, docx, docx, fake.executable);
+      const legacyShape: {
+        protocolVersion: 1;
+        verifier: 'Lean XML triple checker';
+        scope: 'word/document.xml';
+      } = result;
+      expect(legacyShape).toMatchObject({
+        protocolVersion: 1,
+        verifier: 'Lean XML triple checker',
+        scope: 'word/document.xml',
+      });
+      expect(result.status).toBe('passed');
+      expect(result.checks.acceptingAllTrackedChangesMatchesRevisedText.status).toBe('passed');
+      expect(result.checkerProtocolVersion).toBe(2);
+    } finally {
+      await rm(fake.dir, { recursive: true, force: true });
+    }
     });
 
   test.openspec('[LEAN-STORY-09] Inconsistent executable protocol is rejected')(
@@ -475,6 +476,35 @@ describe('Lean fixed-story protocol and security hardening', () => {
       }
     }
     });
+
+  test('rejects contradictory or root-inconsistent required-story presence mismatches', async () => {
+    const docx = await buildDocxFromBodyXml(paragraphWithText('Body'));
+    const impossibleReports = [
+      { ...validProtocolReport, passed: false, presenceMismatches: [{
+        name: 'main',
+        packagePart: 'word/document.xml',
+        required: true,
+        presence: { original: true, revised: true, combined: true },
+      }] },
+      { ...validProtocolReport, passed: false, presenceMismatches: [{
+        name: 'main',
+        packagePart: 'word/document.xml',
+        required: true,
+        presence: { original: false, revised: true, combined: true },
+      }] },
+    ];
+
+    for (const report of impossibleReports) {
+      const fake = await fakeChecker(report);
+      try {
+        const result = await runWith(docx, docx, docx, fake.executable);
+        expect(result.status).toBe('not_run');
+        expect(result.stories).toEqual([]);
+      } finally {
+        await rm(fake.dir, { recursive: true, force: true });
+      }
+    }
+  });
 
   test('snapshots mutable package buffers before hashing, writing, or awaiting', async () => {
     const docx = await buildDocxFromBodyXml(paragraphWithText('Body'));

--- a/packages/docx-compare/src/baselines/atomizer/leanXmlVerifier.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/leanXmlVerifier.test.ts
@@ -1,4 +1,6 @@
 import { existsSync } from 'node:fs';
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { describe, expect } from 'vitest';
 import JSZip from 'jszip';
@@ -56,12 +58,17 @@ describeWithLean('Lean XML triple verifier certificate', () => {
       await then('the certificate reports plain document properties and hashes', () => {
         expect(result.reconstructionModeUsed).toBe('inplace');
         expect(result.documentIntegrity?.status).toBe('passed');
-        expect(result.documentIntegrity?.scope).toEqual([
+        expect(result.documentIntegrity?.protocolVersion).toBe(1);
+        expect(result.documentIntegrity?.scope).toBe('word/document.xml');
+        expect(result.documentIntegrity?.checkerProtocolVersion).toBe(2);
+        expect(result.documentIntegrity?.fixedStoryScope).toEqual([
           'word/document.xml', 'word/footnotes.xml', 'word/endnotes.xml',
         ]);
-        expect(result.documentIntegrity?.inputSha256.originalDocx).toMatch(/^[0-9a-f]{64}$/);
+        expect(result.documentIntegrity?.inputSha256.originalDocumentXml).toMatch(/^[0-9a-f]{64}$/);
+        expect(result.documentIntegrity?.inputPackageSha256?.originalDocx).toMatch(/^[0-9a-f]{64}$/);
+        expect(result.documentIntegrity?.stories?.map((story) => story.name)).toEqual(['main']);
         expect(
-          result.documentIntegrity?.stories[0]?.checks.acceptingAllTrackedChangesMatchesRevisedText.claim
+          result.documentIntegrity?.stories?.[0]?.checks.acceptingAllTrackedChangesMatchesRevisedText.claim
         ).toContain('revised story');
         expect(JSON.stringify(result.documentIntegrity)).not.toContain('tier2.checker_sound');
         expect(JSON.stringify(result.documentIntegrity)).not.toContain('INV');
@@ -129,11 +136,16 @@ describe('Lean XML triple verifier scope boundary', () => {
   );
 });
 
-async function replacePart(docx: Buffer, path: string, xml: string | null): Promise<Buffer> {
+async function replacePart(
+  docx: Buffer,
+  path: string,
+  xml: string | null,
+  compression: 'STORE' | 'DEFLATE' = 'STORE'
+): Promise<Buffer> {
   const zip = await JSZip.loadAsync(docx);
   if (xml === null) zip.remove(path);
   else zip.file(path, xml);
-  return zip.generateAsync({ type: 'nodebuffer' });
+  return zip.generateAsync({ type: 'nodebuffer', compression });
 }
 
 async function readPart(docx: Buffer, path: string): Promise<string> {
@@ -142,22 +154,29 @@ async function readPart(docx: Buffer, path: string): Promise<string> {
   return part.async('string');
 }
 
+function withPrefix(xml: string, from: string, to: string): string {
+  return xml
+    .replace(`xmlns:${from}=`, `xmlns:${to}=`)
+    .replaceAll(`${from}:`, `${to}:`);
+}
+
 const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const footnotes = (userBody: string, separatorBody = '<w:r><w:separator/></w:r>') =>
   `<w:footnotes xmlns:w="${W_NS}">` +
-  `<w:footnote w:id="-1"><w:p>${separatorBody}</w:p></w:footnote>` +
-  `<w:footnote w:id="0"><w:p><w:r><w:continuationSeparator/></w:r></w:p></w:footnote>` +
+  `<w:footnote w:type="separator" w:id="-1"><w:p>${separatorBody}</w:p></w:footnote>` +
+  `<w:footnote w:type="continuationSeparator" w:id="0"><w:p><w:r><w:continuationSeparator/></w:r></w:p></w:footnote>` +
   `<w:footnote w:id="1"><w:p>${userBody}</w:p></w:footnote></w:footnotes>`;
 const endnotes = (userBody: string) =>
   `<w:endnotes xmlns:w="${W_NS}">` +
-  `<w:endnote w:id="-1"><w:p><w:r><w:separator/></w:r></w:p></w:endnote>` +
-  `<w:endnote w:id="0"><w:p><w:r><w:continuationSeparator/></w:r></w:p></w:endnote>` +
+  `<w:endnote w:type="separator" w:id="-1"><w:p><w:r><w:separator/></w:r></w:p></w:endnote>` +
+  `<w:endnote w:type="continuationSeparator" w:id="0"><w:p><w:r><w:continuationSeparator/></w:r></w:p></w:endnote>` +
   `<w:endnote w:id="1"><w:p>${userBody}</w:p></w:endnote></w:endnotes>`;
 
 describeWithLean('Lean fixed-story package protocol', () => {
   const run = (originalDocx: Buffer, revisedDocx: Buffer, comparedDocx: Buffer) =>
     runLeanXmlTripleVerifier({
       originalDocx, revisedDocx, comparedDocx,
+      legacyDocumentXml: { original: '', revised: '', compared: '' },
       reconstructionMode: 'inplace',
       options: { executablePath: LEAN_EXE },
     });
@@ -170,7 +189,7 @@ describeWithLean('Lean fixed-story package protocol', () => {
       });
       const certificate = await run(docx, docx, docx);
       expect(certificate.status).toBe('passed');
-      expect(certificate.stories.map((story) => story.name)).toEqual(['main', 'footnotes', 'endnotes']);
+      expect(certificate.stories?.map((story) => story.name)).toEqual(['main', 'footnotes', 'endnotes']);
     });
 
   test.openspec('[LEAN-STORY-02] Side-story state is isolated')(
@@ -182,17 +201,61 @@ describeWithLean('Lean fixed-story package protocol', () => {
       const malformed = await replacePart(withFootnote, 'word/endnotes.xml', endnotes('<w:r><w:fldChar w:fldCharType="end"/></w:r>'));
       const certificate = await run(malformed, malformed, malformed);
       expect(certificate.status).toBe('failed');
-      expect(certificate.stories.filter((story) => story.status === 'failed').map((story) => story.name)).toEqual(['footnotes', 'endnotes']);
+      expect(certificate.stories?.filter((story) => story.status === 'failed').map((story) => story.name)).toEqual(['footnotes', 'endnotes']);
     });
 
-  test.openspec('[LEAN-STORY-03] Optional presence mismatch fails')(
-    'fails closed when an optional story is absent from one package', async () => {
+  test.openspec('[LEAN-STORY-03] Optional presence is modeled as an empty story')(
+    'rejects an untracked optional-part addition against an empty original story', async () => {
       const withNote = await buildSyntheticDocx({ paragraphs: ['Body'], footnoteOnParagraph: 0 });
       const withoutNote = await replacePart(withNote, 'word/footnotes.xml', null);
-      const certificate = await run(withNote, withNote, withoutNote);
+      const certificate = await run(withoutNote, withNote, withNote);
       expect(certificate.status).toBe('failed');
-      expect(certificate.presenceMismatches?.[0]?.name).toBe('footnotes');
+      expect(certificate.presenceMismatches).toEqual([]);
+      expect(certificate.stories?.find((story) => story.name === 'footnotes')?.presence).toEqual({
+        original: false, revised: true, compared: true,
+      });
     });
+
+  test('accepts tracked optional-part addition and removal against empty missing stories', async () => {
+    const withNote = await buildSyntheticDocx({ paragraphs: ['Body'], footnoteOnParagraph: 0 });
+    const withoutNote = await replacePart(withNote, 'word/footnotes.xml', null);
+    const added = await replacePart(
+      withNote,
+      'word/footnotes.xml',
+      footnotes('<w:ins><w:r><w:t>Added note</w:t></w:r></w:ins>')
+    );
+    const revisedAdded = await replacePart(
+      withNote,
+      'word/footnotes.xml',
+      footnotes('<w:r><w:t>Added note</w:t></w:r>')
+    );
+    const removed = await replacePart(
+      withNote,
+      'word/footnotes.xml',
+      footnotes('<w:del><w:r><w:delText>Removed note</w:delText></w:r></w:del>')
+    );
+    const originalRemoved = await replacePart(
+      withNote,
+      'word/footnotes.xml',
+      footnotes('<w:r><w:t>Removed note</w:t></w:r>')
+    );
+
+    expect((await run(withoutNote, revisedAdded, added)).status).toBe('passed');
+    expect((await run(originalRemoved, withoutNote, removed)).status).toBe('passed');
+  });
+
+  test('fails closed when the required main story is missing from any package', async () => {
+    const base = await buildDocxFromBodyXml(paragraphWithText('Body'));
+    const missingMain = await replacePart(base, 'word/document.xml', null);
+    const certificate = await run(missingMain, base, base);
+    expect(certificate.status).toBe('failed');
+    expect(certificate.presenceMismatches).toEqual([{
+      name: 'main',
+      packagePart: 'word/document.xml',
+      required: true,
+      presence: { original: false, revised: true, combined: true },
+    }]);
+  });
 
   test.openspec('[LEAN-STORY-04] Reserved separator text is excluded')(
     'ignores reserved separator entry text through the Lean projection', async () => {
@@ -202,6 +265,71 @@ describeWithLean('Lean fixed-story package protocol', () => {
       expect((await run(original, revised, revised)).status).toBe('passed');
     });
 
+  test('uses namespace-qualified note type rather than numeric IDs for reserved projection', async () => {
+    const base = await buildSyntheticDocx({ paragraphs: ['Body'], footnoteOnParagraph: 0 });
+    const typedAnyId = (reserved: string, normalZero: string) =>
+      `<w:footnotes xmlns:w="${W_NS}">` +
+      `<w:footnote w:type="separator" w:id="77"><w:p><w:r><w:t>${reserved}</w:t></w:r></w:p></w:footnote>` +
+      `<w:footnote w:id="0"><w:p><w:r><w:t>${normalZero}</w:t></w:r></w:p></w:footnote>` +
+      `</w:footnotes>`;
+    const original = await replacePart(base, 'word/footnotes.xml', typedAnyId('old reserved', 'visible old'));
+    const revisedReservedOnly = await replacePart(base, 'word/footnotes.xml', typedAnyId('new reserved', 'visible old'));
+    const revisedNormalZero = await replacePart(base, 'word/footnotes.xml', typedAnyId('new reserved', 'visible new'));
+
+    expect((await run(original, revisedReservedOnly, revisedReservedOnly)).status).toBe('passed');
+    expect((await run(original, revisedNormalZero, revisedNormalZero)).status).toBe('failed');
+  });
+
+  test.openspec('[LEAN-STORY-06] Alternate namespace prefixes preserve checks')(
+    'accepts alternate WordprocessingML prefixes and detects divergent text through them', async () => {
+    const base = await buildDocxFromBodyXml(paragraphWithText('Original'));
+    const originalXml = withPrefix(await readPart(base, 'word/document.xml'), 'w', 'wp');
+    const original = await replacePart(base, 'word/document.xml', originalXml);
+    const revisedXml = originalXml.replace('Original', 'Revised');
+    const revised = await replacePart(base, 'word/document.xml', revisedXml);
+    const malformedFieldBase = await buildDocxFromBodyXml(
+      '<w:p><w:r><w:fldChar w:fldCharType="end"/></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="begin"/></w:r></w:p>'
+    );
+    const malformedField = await replacePart(
+      malformedFieldBase,
+      'word/document.xml',
+      withPrefix(await readPart(malformedFieldBase, 'word/document.xml'), 'w', 'wp')
+    );
+
+    expect((await run(original, original, original)).status).toBe('passed');
+    expect((await run(original, revised, revised)).status).toBe('failed');
+    expect((await run(malformedField, malformedField, malformedField)).status).toBe('failed');
+    });
+
+  test('rejects malformed or unrecognized WordprocessingML roots instead of accepting empty tokens', async () => {
+    const base = await buildDocxFromBodyXml(paragraphWithText('Body'));
+    const wrongRoot = await replacePart(
+      base,
+      'word/document.xml',
+      '<x:document xmlns:x="urn:not-wordprocessingml"><x:p><x:t>Body</x:t></x:p></x:document>'
+    );
+    const malformed = await replacePart(base, 'word/document.xml', '<w:document><w:p></w:document>');
+    expect((await run(wrongRoot, wrongRoot, wrongRoot)).status).toBe('not_run');
+    expect((await run(malformed, malformed, malformed)).status).toBe('not_run');
+  });
+
+  test('rejects balanced malformed end-before-begin and repeated-separate fields per story', async () => {
+    const base = await buildSyntheticDocx({ paragraphs: ['Body'], footnoteOnParagraph: 0 });
+    const endThenBegin =
+      '<w:r><w:fldChar w:fldCharType="end"/></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="begin"/></w:r>';
+    const repeatedSeparate =
+      '<w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="end"/></w:r>';
+    const malformedOrder = await replacePart(base, 'word/footnotes.xml', footnotes(endThenBegin));
+    const malformedRepeat = await replacePart(base, 'word/footnotes.xml', footnotes(repeatedSeparate));
+    expect((await run(malformedOrder, malformedOrder, malformedOrder)).status).toBe('failed');
+    expect((await run(malformedRepeat, malformedRepeat, malformedRepeat)).status).toBe('failed');
+  });
+
   test.openspec('[LEAN-STORY-05] Side-story divergence is visible')(
     'reports reject text divergence in a footnote story', async () => {
       const base = await buildSyntheticDocx({ paragraphs: ['Body'], footnoteOnParagraph: 0 });
@@ -209,7 +337,7 @@ describeWithLean('Lean fixed-story package protocol', () => {
       const revised = await replacePart(base, 'word/footnotes.xml', footnotes('<w:r><w:t>Revised note</w:t></w:r>'));
       const certificate = await run(original, revised, revised);
       expect(certificate.status).toBe('failed');
-      expect(certificate.stories.find((story) => story.name === 'footnotes')?.checks.rejectingAllTrackedChangesMatchesOriginalText.status).toBe('failed');
+      expect(certificate.stories?.find((story) => story.name === 'footnotes')?.checks.rejectingAllTrackedChangesMatchesOriginalText.status).toBe('failed');
     });
 
   test('agrees with the existing TS accept/reject oracle on a tracked footnote protocol case', async () => {
@@ -233,5 +361,196 @@ describeWithLean('Lean fixed-story package protocol', () => {
       normalizeText(extractTextWithParagraphs(rejectAllChanges(originalXml)))
     );
     expect((await run(original, revised, combined)).status).toBe('passed');
+  });
+});
+
+const validProtocolReport = {
+  protocolVersion: 2,
+  checker: 'safe-docx-lean-fixed-story-checker',
+  passed: true,
+  stories: [{
+    name: 'main',
+    presence: { original: true, revised: true, combined: true },
+    parsedTokenCounts: { original: 1, revised: 1, combined: 1 },
+    report: {
+      passed: true,
+      checks: {
+        acceptPreservesFieldStructure: true,
+        rejectPreservesFieldStructure: true,
+        acceptTextMatchesRevised: true,
+        rejectTextMatchesOriginal: true,
+        combinedHasNoFldCharInsideDel: true,
+      },
+    },
+  }],
+  presenceMismatches: [],
+};
+
+async function fakeChecker(output: unknown): Promise<{ dir: string; executable: string }> {
+  const dir = await mkdtemp(join(tmpdir(), 'safe-docx-fake-checker-'));
+  const executable = join(dir, 'checker');
+  await writeFile(
+    executable,
+    `#!/bin/sh\ncat >/dev/null\nprintf '%s\\n' '${JSON.stringify(output)}'\n`,
+  );
+  await chmod(executable, 0o700);
+  return { dir, executable };
+}
+
+describe('Lean fixed-story protocol and security hardening', () => {
+  const runWith = (
+    originalDocx: Buffer,
+    revisedDocx: Buffer,
+    comparedDocx: Buffer,
+    executablePath: string,
+    timeoutMs = 10_000,
+  ) => runLeanXmlTripleVerifier({
+    originalDocx,
+    revisedDocx,
+    comparedDocx,
+    legacyDocumentXml: { original: '<w:document/>', revised: '<w:document/>', compared: '<w:document/>' },
+    reconstructionMode: 'inplace',
+    options: { executablePath, timeoutMs },
+  });
+
+  test.openspec('[LEAN-STORY-08] Public certificate remains v1 compatible')(
+    'preserves the public v1 certificate fields while adding package-story evidence', async () => {
+    const docx = await buildDocxFromBodyXml(paragraphWithText('Body'));
+    const result = await runWith(docx, docx, docx, LEAN_EXE);
+    const legacyShape: {
+      protocolVersion: 1;
+      verifier: 'Lean XML triple checker';
+      scope: 'word/document.xml';
+    } = result;
+    expect(legacyShape).toMatchObject({
+      protocolVersion: 1,
+      verifier: 'Lean XML triple checker',
+      scope: 'word/document.xml',
+    });
+    expect(result.checks.acceptingAllTrackedChangesMatchesRevisedText.status).toBe('passed');
+    expect(result.checkerProtocolVersion).toBe(2);
+    });
+
+  test.openspec('[LEAN-STORY-09] Inconsistent executable protocol is rejected')(
+    'rejects duplicate, negative-count, inconsistent, and extra-field protocol reports', async () => {
+    const docx = await buildDocxFromBodyXml(paragraphWithText('Body'));
+    const variants = [
+      { ...validProtocolReport, stories: [...validProtocolReport.stories, validProtocolReport.stories[0]] },
+      { ...validProtocolReport, stories: [{
+        ...validProtocolReport.stories[0],
+        parsedTokenCounts: { original: -1, revised: 1, combined: 1 },
+      }] },
+      { ...validProtocolReport, stories: [{
+        ...validProtocolReport.stories[0],
+        parsedTokenCounts: { original: 1.5, revised: 1, combined: 1 },
+      }] },
+      { ...validProtocolReport, stories: [{
+        ...validProtocolReport.stories[0],
+        name: 'comments',
+      }] },
+      { ...validProtocolReport, stories: [{
+        ...validProtocolReport.stories[0],
+        name: 'footnotes',
+      }] },
+      { ...validProtocolReport, stories: [{
+        ...validProtocolReport.stories[0],
+        report: { ...validProtocolReport.stories[0]!.report, passed: false },
+      }] },
+      { ...validProtocolReport, passed: false },
+      { ...validProtocolReport, unexpected: true },
+      { ...validProtocolReport, passed: false, presenceMismatches: [{
+        name: 'main',
+        packagePart: 'word/document.xml',
+        required: true,
+        presence: { original: false, revised: false, combined: false },
+        unexpected: true,
+      }] },
+    ];
+    for (const variant of variants) {
+      const fake = await fakeChecker(variant);
+      try {
+        expect((await runWith(docx, docx, docx, fake.executable)).status).toBe('not_run');
+      } finally {
+        await rm(fake.dir, { recursive: true, force: true });
+      }
+    }
+    });
+
+  test('snapshots mutable package buffers before hashing, writing, or awaiting', async () => {
+    const docx = await buildDocxFromBodyXml(paragraphWithText('Body'));
+    const dir = await mkdtemp(join(tmpdir(), 'safe-docx-snapshot-checker-'));
+    const executable = join(dir, 'checker');
+    await writeFile(executable, `#!/usr/bin/env node
+let raw = '';
+process.stdin.on('data', chunk => raw += chunk);
+process.stdin.on('end', () => setTimeout(() => {
+  const req = JSON.parse(raw);
+  const bytes = require('node:fs').readFileSync(req.originalDocxPath);
+  if (bytes.subarray(0, 2).toString() !== 'PK') process.exit(9);
+  process.stdout.write(${JSON.stringify(JSON.stringify(validProtocolReport))});
+}, 50));
+`);
+    await chmod(executable, 0o700);
+    try {
+      const mutable = Buffer.from(docx);
+      const pending = runWith(mutable, docx, docx, executable);
+      mutable.fill(0);
+      expect((await pending).status).toBe('passed');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('kills verifier process groups when a timeout fires', async () => {
+    const docx = await buildDocxFromBodyXml(paragraphWithText('Body'));
+    const dir = await mkdtemp(join(tmpdir(), 'safe-docx-timeout-checker-'));
+    const executable = join(dir, 'checker');
+    const pidPath = join(dir, 'descendant.pid');
+    await writeFile(executable, `#!/bin/sh\nsleep 30 &\necho $! > '${pidPath}'\ncat >/dev/null\nwait\n`);
+    await chmod(executable, 0o700);
+    try {
+      expect((await runWith(docx, docx, docx, executable, 300)).status).toBe('not_run');
+      const pid = Number((await readFile(pidPath, 'utf8')).trim());
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(() => process.kill(pid, 0)).toThrow();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describeWithLean('Lean compiled package extraction limits', () => {
+  const run = (docx: Buffer) => runLeanXmlTripleVerifier({
+    originalDocx: docx,
+    revisedDocx: docx,
+    comparedDocx: docx,
+    legacyDocumentXml: { original: '', revised: '', compared: '' },
+    reconstructionMode: 'inplace',
+    options: { executablePath: LEAN_EXE },
+  });
+
+  test.openspec('[LEAN-STORY-07] Unsafe package extraction fails closed')(
+    'reports corrupt archives as not_run rather than missing optional stories', async () => {
+    const result = await run(Buffer.from('not a zip archive'));
+    expect(result.status).toBe('not_run');
+    expect(result.reason).toContain('archive metadata failed');
+    });
+
+  test('rejects oversized expanded story output before buffering it', async () => {
+    const base = await buildSyntheticDocx({ paragraphs: ['Body'], footnoteOnParagraph: 0 });
+    const huge = footnotes(`<w:r><w:t>${'x'.repeat(16 * 1024 * 1024 + 1)}</w:t></w:r>`);
+    const oversized = await replacePart(base, 'word/footnotes.xml', huge, 'DEFLATE');
+    const result = await run(oversized);
+    expect(result.status).toBe('not_run');
+    expect(result.reason).toContain('expanded size exceeds');
+  });
+
+  test('rejects excessive compression ratios before extraction', async () => {
+    const base = await buildSyntheticDocx({ paragraphs: ['Body'], footnoteOnParagraph: 0 });
+    const bomb = footnotes(`<w:r><w:t>${'x'.repeat(2 * 1024 * 1024)}</w:t></w:r>`);
+    const compressed = await replacePart(base, 'word/footnotes.xml', bomb, 'DEFLATE');
+    const result = await run(compressed);
+    expect(result.status).toBe('not_run');
+    expect(result.reason).toContain('compression ratio exceeds');
   });
 });

--- a/packages/docx-compare/src/baselines/atomizer/leanXmlVerifier.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/leanXmlVerifier.test.ts
@@ -1,7 +1,16 @@
 import { existsSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { describe, expect } from 'vitest';
+import JSZip from 'jszip';
+import { buildSyntheticDocx } from '@usejunior/docx-core';
 import { compareDocuments } from '../../index.js';
+import { runLeanXmlTripleVerifier } from './leanXmlVerifier.js';
+import {
+  acceptAllChanges,
+  extractTextWithParagraphs,
+  normalizeText,
+  rejectAllChanges,
+} from './trackChangesAcceptorAst.js';
 import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
 import { buildDocxFromBodyXml, paragraphWithText } from '../../testing/ooxml-fixtures.js';
 
@@ -14,7 +23,6 @@ const LEAN_EXE = join(PROJECT_ROOT, 'verification/lean/.lake/build/bin/leanDocxC
 
 const exeExists = existsSync(LEAN_EXE);
 if (!exeExists) {
-  // eslint-disable-next-line no-console
   console.warn(
     `[lean-xml-verifier] SKIP: ${LEAN_EXE} not found. ` +
       `Build it with: (cd verification/lean && lake build leanDocxChecker)`,
@@ -48,11 +56,13 @@ describeWithLean('Lean XML triple verifier certificate', () => {
       await then('the certificate reports plain document properties and hashes', () => {
         expect(result.reconstructionModeUsed).toBe('inplace');
         expect(result.documentIntegrity?.status).toBe('passed');
-        expect(result.documentIntegrity?.scope).toBe('word/document.xml');
-        expect(result.documentIntegrity?.inputSha256.originalDocumentXml).toMatch(/^[0-9a-f]{64}$/);
+        expect(result.documentIntegrity?.scope).toEqual([
+          'word/document.xml', 'word/footnotes.xml', 'word/endnotes.xml',
+        ]);
+        expect(result.documentIntegrity?.inputSha256.originalDocx).toMatch(/^[0-9a-f]{64}$/);
         expect(
-          result.documentIntegrity?.checks.acceptingAllTrackedChangesMatchesRevisedText.claim
-        ).toContain('revised document');
+          result.documentIntegrity?.stories[0]?.checks.acceptingAllTrackedChangesMatchesRevisedText.claim
+        ).toContain('revised story');
         expect(JSON.stringify(result.documentIntegrity)).not.toContain('tier2.checker_sound');
         expect(JSON.stringify(result.documentIntegrity)).not.toContain('INV');
       });
@@ -84,9 +94,7 @@ describe('Lean XML triple verifier scope boundary', () => {
       await then('the certificate does not make a verified claim', () => {
         expect(result.reconstructionModeUsed).toBe('inplace');
         expect(result.documentIntegrity?.status).toBe('not_run');
-        expect(
-          result.documentIntegrity?.checks.acceptingAllTrackedChangesMatchesRevisedText.status
-        ).toBe('not_evaluated');
+        expect(result.documentIntegrity?.stories).toEqual([]);
         expect(JSON.stringify(result.documentIntegrity)).not.toContain('verified');
       });
     },
@@ -119,4 +127,111 @@ describe('Lean XML triple verifier scope boundary', () => {
       });
     },
   );
+});
+
+async function replacePart(docx: Buffer, path: string, xml: string | null): Promise<Buffer> {
+  const zip = await JSZip.loadAsync(docx);
+  if (xml === null) zip.remove(path);
+  else zip.file(path, xml);
+  return zip.generateAsync({ type: 'nodebuffer' });
+}
+
+async function readPart(docx: Buffer, path: string): Promise<string> {
+  const part = (await JSZip.loadAsync(docx)).file(path);
+  if (!part) throw new Error(`missing test part: ${path}`);
+  return part.async('string');
+}
+
+const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const footnotes = (userBody: string, separatorBody = '<w:r><w:separator/></w:r>') =>
+  `<w:footnotes xmlns:w="${W_NS}">` +
+  `<w:footnote w:id="-1"><w:p>${separatorBody}</w:p></w:footnote>` +
+  `<w:footnote w:id="0"><w:p><w:r><w:continuationSeparator/></w:r></w:p></w:footnote>` +
+  `<w:footnote w:id="1"><w:p>${userBody}</w:p></w:footnote></w:footnotes>`;
+const endnotes = (userBody: string) =>
+  `<w:endnotes xmlns:w="${W_NS}">` +
+  `<w:endnote w:id="-1"><w:p><w:r><w:separator/></w:r></w:p></w:endnote>` +
+  `<w:endnote w:id="0"><w:p><w:r><w:continuationSeparator/></w:r></w:p></w:endnote>` +
+  `<w:endnote w:id="1"><w:p>${userBody}</w:p></w:endnote></w:endnotes>`;
+
+describeWithLean('Lean fixed-story package protocol', () => {
+  const run = (originalDocx: Buffer, revisedDocx: Buffer, comparedDocx: Buffer) =>
+    runLeanXmlTripleVerifier({
+      originalDocx, revisedDocx, comparedDocx,
+      reconstructionMode: 'inplace',
+      options: { executablePath: LEAN_EXE },
+    });
+
+  test.openspec('[LEAN-STORY-01] Fixed stories pass together')(
+    'checks main, footnote, and endnote stories in one compiled invocation', async () => {
+      const docx = await buildSyntheticDocx({
+        paragraphs: ['Body'], footnoteOnParagraph: 0, footnoteText: 'Foot',
+        endnoteOnParagraph: 0, endnoteText: 'End',
+      });
+      const certificate = await run(docx, docx, docx);
+      expect(certificate.status).toBe('passed');
+      expect(certificate.stories.map((story) => story.name)).toEqual(['main', 'footnotes', 'endnotes']);
+    });
+
+  test.openspec('[LEAN-STORY-02] Side-story state is isolated')(
+    'rejects malformed fields even when markers balance across side stories', async () => {
+      const base = await buildSyntheticDocx({
+        paragraphs: ['Body'], footnoteOnParagraph: 0, endnoteOnParagraph: 0,
+      });
+      const withFootnote = await replacePart(base, 'word/footnotes.xml', footnotes('<w:r><w:fldChar w:fldCharType="begin"/></w:r>'));
+      const malformed = await replacePart(withFootnote, 'word/endnotes.xml', endnotes('<w:r><w:fldChar w:fldCharType="end"/></w:r>'));
+      const certificate = await run(malformed, malformed, malformed);
+      expect(certificate.status).toBe('failed');
+      expect(certificate.stories.filter((story) => story.status === 'failed').map((story) => story.name)).toEqual(['footnotes', 'endnotes']);
+    });
+
+  test.openspec('[LEAN-STORY-03] Optional presence mismatch fails')(
+    'fails closed when an optional story is absent from one package', async () => {
+      const withNote = await buildSyntheticDocx({ paragraphs: ['Body'], footnoteOnParagraph: 0 });
+      const withoutNote = await replacePart(withNote, 'word/footnotes.xml', null);
+      const certificate = await run(withNote, withNote, withoutNote);
+      expect(certificate.status).toBe('failed');
+      expect(certificate.presenceMismatches?.[0]?.name).toBe('footnotes');
+    });
+
+  test.openspec('[LEAN-STORY-04] Reserved separator text is excluded')(
+    'ignores reserved separator entry text through the Lean projection', async () => {
+      const base = await buildSyntheticDocx({ paragraphs: ['Body'], footnoteOnParagraph: 0 });
+      const original = await replacePart(base, 'word/footnotes.xml', footnotes('<w:r><w:t>User note</w:t></w:r>', '<w:r><w:t>Old separator</w:t></w:r>'));
+      const revised = await replacePart(base, 'word/footnotes.xml', footnotes('<w:r><w:t>User note</w:t></w:r>', '<w:r><w:t>New separator</w:t></w:r>'));
+      expect((await run(original, revised, revised)).status).toBe('passed');
+    });
+
+  test.openspec('[LEAN-STORY-05] Side-story divergence is visible')(
+    'reports reject text divergence in a footnote story', async () => {
+      const base = await buildSyntheticDocx({ paragraphs: ['Body'], footnoteOnParagraph: 0 });
+      const original = await replacePart(base, 'word/footnotes.xml', footnotes('<w:r><w:t>Original note</w:t></w:r>'));
+      const revised = await replacePart(base, 'word/footnotes.xml', footnotes('<w:r><w:t>Revised note</w:t></w:r>'));
+      const certificate = await run(original, revised, revised);
+      expect(certificate.status).toBe('failed');
+      expect(certificate.stories.find((story) => story.name === 'footnotes')?.checks.rejectingAllTrackedChangesMatchesOriginalText.status).toBe('failed');
+    });
+
+  test('agrees with the existing TS accept/reject oracle on a tracked footnote protocol case', async () => {
+    const base = await buildSyntheticDocx({ paragraphs: ['Body'], footnoteOnParagraph: 0 });
+    const original = await replacePart(base, 'word/footnotes.xml', footnotes('<w:r><w:t>Original note</w:t></w:r>'));
+    const revised = await replacePart(base, 'word/footnotes.xml', footnotes('<w:r><w:t>Revised note</w:t></w:r>'));
+    const combinedBody =
+      '<w:del><w:r><w:delText>Original note</w:delText></w:r></w:del>' +
+      '<w:ins><w:r><w:t>Revised note</w:t></w:r></w:ins>';
+    const combined = await replacePart(base, 'word/footnotes.xml', footnotes(combinedBody));
+
+    const [originalXml, revisedXml, combinedXml] = await Promise.all([
+      readPart(original, 'word/footnotes.xml'),
+      readPart(revised, 'word/footnotes.xml'),
+      readPart(combined, 'word/footnotes.xml'),
+    ]);
+    expect(normalizeText(extractTextWithParagraphs(acceptAllChanges(combinedXml)))).toBe(
+      normalizeText(extractTextWithParagraphs(acceptAllChanges(revisedXml)))
+    );
+    expect(normalizeText(extractTextWithParagraphs(rejectAllChanges(combinedXml)))).toBe(
+      normalizeText(extractTextWithParagraphs(rejectAllChanges(originalXml)))
+    );
+    expect((await run(original, revised, combined)).status).toBe('passed');
+  });
 });

--- a/packages/docx-compare/src/baselines/atomizer/leanXmlVerifier.ts
+++ b/packages/docx-compare/src/baselines/atomizer/leanXmlVerifier.ts
@@ -18,12 +18,14 @@ interface LeanVerifierInput {
   originalDocx: Buffer;
   revisedDocx: Buffer;
   comparedDocx: Buffer;
+  legacyDocumentXml: { original: string; revised: string; compared: string };
   reconstructionMode: ReconstructionMode;
   options: LeanXmlVerifierOptions;
 }
 
 interface LeanStoryJson {
-  name: string;
+  name: DocumentIntegrityStoryCertificate['name'];
+  presence: { original: boolean; revised: boolean; combined: boolean };
   parsedTokenCounts: { original: number; revised: number; combined: number };
   report: {
     passed: boolean;
@@ -50,8 +52,32 @@ interface LeanVerifierJson {
   }>;
 }
 
-function sha256(value: Buffer): string {
+function sha256(value: Buffer | string): string {
   return createHash('sha256').update(value).digest('hex');
+}
+
+function notEvaluated(claim: string): DocumentIntegrityCheckCertificate {
+  return { status: 'not_evaluated', claim };
+}
+
+function unevaluatedChecks(): DocumentIntegrityCertificate['checks'] {
+  return {
+    acceptingAllTrackedChangesMatchesRevisedText: notEvaluated(
+      'Accepting all tracked changes in the compared document yields the same normalized text as the revised document.'
+    ),
+    rejectingAllTrackedChangesMatchesOriginalText: notEvaluated(
+      'Rejecting all tracked changes in the compared document yields the same normalized text as the original document.'
+    ),
+    acceptingAllTrackedChangesKeepsValidFieldStructure: notEvaluated(
+      'After accepting all tracked changes, Word field markers remain structurally valid.'
+    ),
+    rejectingAllTrackedChangesKeepsValidFieldStructure: notEvaluated(
+      'After rejecting all tracked changes, Word field markers remain structurally valid.'
+    ),
+    comparedDocumentHasNoFieldMarkersInsideDeletions: notEvaluated(
+      'The compared document does not place Word field markers inside deletion markup.'
+    ),
+  };
 }
 
 function check(status: boolean, claim: string): DocumentIntegrityCheckCertificate {
@@ -90,10 +116,25 @@ function storyCertificate(story: LeanStoryJson): DocumentIntegrityStoryCertifica
       revised: story.parsedTokenCounts.revised,
       compared: story.parsedTokenCounts.combined,
     },
+    presence: {
+      original: story.presence.original,
+      revised: story.presence.revised,
+      compared: story.presence.combined,
+    },
   };
 }
 
-function isBooleanRecord(value: unknown, keys: string[]): boolean {
+function hasExactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  return actual.length === expected.length && actual.every((key, index) => key === expected[index]);
+}
+
+function isNonnegativeInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0;
+}
+
+function isBooleanRecord(value: unknown, keys: readonly string[]): boolean {
   if (typeof value !== 'object' || value === null) return false;
   const record = value as Record<string, unknown>;
   return keys.every((key) => typeof record[key] === 'boolean');
@@ -104,77 +145,177 @@ function isLeanStoryJson(value: unknown): value is LeanStoryJson {
   const story = value as Record<string, unknown>;
   const counts = story.parsedTokenCounts as Record<string, unknown> | undefined;
   const report = story.report as Record<string, unknown> | undefined;
+  const checks = report?.checks as Record<string, unknown> | undefined;
+  const presence = story.presence as Record<string, unknown> | undefined;
+  const checkKeys = [
+    'acceptPreservesFieldStructure',
+    'rejectPreservesFieldStructure',
+    'acceptTextMatchesRevised',
+    'rejectTextMatchesOriginal',
+    'combinedHasNoFldCharInsideDel',
+  ] as const;
   return (
+    hasExactKeys(story, ['name', 'presence', 'parsedTokenCounts', 'report']) &&
     ['main', 'footnotes', 'endnotes'].includes(story.name as string) &&
-    typeof counts?.original === 'number' &&
-    typeof counts.revised === 'number' &&
-    typeof counts.combined === 'number' &&
+    !!presence &&
+    hasExactKeys(presence, ['original', 'revised', 'combined']) &&
+    isBooleanRecord(presence, ['original', 'revised', 'combined']) &&
+    (story.name === 'main' ||
+      presence.original === true ||
+      presence.revised === true ||
+      presence.combined === true) &&
+    !!counts &&
+    hasExactKeys(counts, ['original', 'revised', 'combined']) &&
+    isNonnegativeInteger(counts.original) &&
+    isNonnegativeInteger(counts.revised) &&
+    isNonnegativeInteger(counts.combined) &&
+    (presence.original || counts.original === 0) &&
+    (presence.revised || counts.revised === 0) &&
+    (presence.combined || counts.combined === 0) &&
+    !!report &&
+    hasExactKeys(report, ['passed', 'checks']) &&
     typeof report?.passed === 'boolean' &&
-    isBooleanRecord(report.checks, [
-      'acceptPreservesFieldStructure',
-      'rejectPreservesFieldStructure',
-      'acceptTextMatchesRevised',
-      'rejectTextMatchesOriginal',
-      'combinedHasNoFldCharInsideDel',
-    ])
+    !!checks &&
+    hasExactKeys(checks, checkKeys) &&
+    isBooleanRecord(checks, checkKeys) &&
+    report.passed === checkKeys.every((key) => checks[key] === true)
   );
 }
 
 function isPresenceMismatch(value: unknown): boolean {
   if (typeof value !== 'object' || value === null) return false;
   const mismatch = value as Record<string, unknown>;
+  const presence = mismatch.presence as Record<string, unknown> | undefined;
   return (
-    typeof mismatch.name === 'string' &&
-    typeof mismatch.packagePart === 'string' &&
-    typeof mismatch.required === 'boolean' &&
-    isBooleanRecord(mismatch.presence, ['original', 'revised', 'combined'])
+    hasExactKeys(mismatch, ['name', 'packagePart', 'required', 'presence']) &&
+    mismatch.name === 'main' &&
+    mismatch.packagePart === 'word/document.xml' &&
+    mismatch.required === true &&
+    !!presence &&
+    hasExactKeys(presence, ['original', 'revised', 'combined']) &&
+    isBooleanRecord(presence, ['original', 'revised', 'combined'])
   );
+}
+
+function samePresence(
+  left: { original: boolean; revised: boolean; combined: boolean },
+  right: { original: boolean; revised: boolean; combined: boolean },
+): boolean {
+  return left.original === right.original && left.revised === right.revised && left.combined === right.combined;
 }
 
 function isLeanVerifierJson(value: unknown): value is LeanVerifierJson {
   if (typeof value !== 'object' || value === null) return false;
   const root = value as Record<string, unknown>;
+  const stories = root.stories as LeanStoryJson[] | undefined;
+  const mismatches = root.presenceMismatches as LeanVerifierJson['presenceMismatches'] | undefined;
+  const names = stories?.map((story) => story.name) ?? [];
+  const main = stories?.find((story) => story.name === 'main');
+  const canonicalNames = ['main', 'footnotes', 'endnotes'].filter((name) => names.includes(name as LeanStoryJson['name']));
   return (
+    hasExactKeys(root, ['protocolVersion', 'checker', 'passed', 'stories', 'presenceMismatches']) &&
     root.protocolVersion === 2 &&
     root.checker === 'safe-docx-lean-fixed-story-checker' &&
     typeof root.passed === 'boolean' &&
-    Array.isArray(root.stories) &&
-    root.stories.every(isLeanStoryJson) &&
-    Array.isArray(root.presenceMismatches) &&
-    root.presenceMismatches.every(isPresenceMismatch)
+    Array.isArray(stories) &&
+    stories.every(isLeanStoryJson) &&
+    names[0] === 'main' &&
+    names.every((name, index) => name === canonicalNames[index]) &&
+    new Set(names).size === names.length &&
+    names.every((name) => ['main', 'footnotes', 'endnotes'].includes(name)) &&
+    Array.isArray(mismatches) &&
+    mismatches.every(isPresenceMismatch) &&
+    mismatches.length <= 1 &&
+    !!main &&
+    (mismatches.length === 0
+      ? main.presence.original && main.presence.revised && main.presence.combined
+      : samePresence(mismatches[0]!.presence, main.presence)) &&
+    root.passed === (mismatches.length === 0 && stories.every((story) => story.report.passed))
   );
 }
 
 function runExecutable(executablePath: string, payload: string, timeoutMs: number): Promise<string> {
   return new Promise((resolve, reject) => {
-    const child = spawn(executablePath, [], { stdio: ['pipe', 'pipe', 'pipe'] });
+    const detached = process.platform !== 'win32';
+    const child = spawn(executablePath, [], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      detached,
+    });
     let stdout = '';
     let stderr = '';
-    const timer = setTimeout(() => {
+    let settled = false;
+    let timedOut = false;
+    const killTree = () => {
+      if (child.pid && detached) {
+        try {
+          process.kill(-child.pid, 'SIGKILL');
+          return;
+        } catch {
+          // The process group may already have exited.
+        }
+      }
+      if (child.pid && process.platform === 'win32') {
+        spawn('taskkill', ['/pid', String(child.pid), '/T', '/F'], {
+          stdio: 'ignore',
+          windowsHide: true,
+        });
+        return;
+      }
       child.kill('SIGKILL');
-      reject(new Error(`Lean fixed-story checker timed out after ${timeoutMs}ms`));
+    };
+    const timer = setTimeout(() => {
+      timedOut = true;
+      killTree();
     }, timeoutMs);
     child.stdout.setEncoding('utf8');
     child.stderr.setEncoding('utf8');
-    child.stdout.on('data', (chunk: string) => { stdout += chunk; });
-    child.stderr.on('data', (chunk: string) => { stderr += chunk; });
-    child.on('error', (error) => { clearTimeout(timer); reject(error); });
+    child.stdout.on('data', (chunk: string) => {
+      stdout += chunk;
+      if (stdout.length > 1024 * 1024) killTree();
+    });
+    child.stderr.on('data', (chunk: string) => {
+      stderr += chunk;
+      if (stderr.length > 64 * 1024) killTree();
+    });
+    child.on('error', (error) => {
+      clearTimeout(timer);
+      if (!settled) {
+        settled = true;
+        reject(timedOut ? new Error(`Lean fixed-story checker timed out after ${timeoutMs}ms`) : error);
+      }
+    });
     child.on('close', (code) => {
       clearTimeout(timer);
-      if (code === 0) resolve(stdout);
+      if (settled) return;
+      settled = true;
+      if (timedOut) {
+        reject(new Error(`Lean fixed-story checker timed out after ${timeoutMs}ms`));
+      } else if (stdout.length > 1024 * 1024 || stderr.length > 64 * 1024) {
+        reject(new Error('Lean fixed-story checker exceeded protocol output limits'));
+      } else if (code === 0) resolve(stdout);
       else reject(new Error(`Lean fixed-story checker exited with code ${code}: ${stderr.trim()}`));
     });
     child.stdin.end(payload);
   });
 }
 
-function baseCertificate(input: LeanVerifierInput): Omit<DocumentIntegrityCertificate, 'status' | 'stories'> {
+function baseCertificate(input: LeanVerifierInput): Omit<
+  DocumentIntegrityCertificate,
+  'status' | 'stories' | 'checks'
+> {
   return {
-    verifier: 'Lean fixed-story checker',
-    protocolVersion: 2,
-    scope: ['word/document.xml', 'word/footnotes.xml', 'word/endnotes.xml'],
+    verifier: 'Lean XML triple checker',
+    protocolVersion: 1,
+    scope: 'word/document.xml',
     reconstructionMode: input.reconstructionMode,
     inputSha256: {
+      originalDocumentXml: sha256(input.legacyDocumentXml.original),
+      revisedDocumentXml: sha256(input.legacyDocumentXml.revised),
+      comparedDocumentXml: sha256(input.legacyDocumentXml.compared),
+    },
+    checkerProtocolVersion: 2,
+    fixedStoryScope: ['word/document.xml', 'word/footnotes.xml', 'word/endnotes.xml'],
+    inputPackageSha256: {
       originalDocx: sha256(input.originalDocx),
       revisedDocx: sha256(input.revisedDocx),
       comparedDocx: sha256(input.comparedDocx),
@@ -188,38 +329,75 @@ function baseCertificate(input: LeanVerifierInput): Omit<DocumentIntegrityCertif
 }
 
 export async function runLeanXmlTripleVerifier(input: LeanVerifierInput): Promise<DocumentIntegrityCertificate> {
-  const base = baseCertificate(input);
-  if (input.reconstructionMode !== 'inplace') {
-    return { ...base, status: 'not_applicable', stories: [], reason: 'Lean fixed-story verification currently covers inplace comparison output only.' };
+  const snapshot: LeanVerifierInput = {
+    ...input,
+    originalDocx: Buffer.from(input.originalDocx),
+    revisedDocx: Buffer.from(input.revisedDocx),
+    comparedDocx: Buffer.from(input.comparedDocx),
+    legacyDocumentXml: { ...input.legacyDocumentXml },
+    options: { ...input.options },
+  };
+  const base = baseCertificate(snapshot);
+  if (snapshot.reconstructionMode !== 'inplace') {
+    return {
+      ...base,
+      status: 'not_applicable',
+      stories: [],
+      checks: unevaluatedChecks(),
+      reason: 'Lean fixed-story verification currently covers inplace comparison output only.',
+    };
   }
 
-  const executablePath = input.options.executablePath ?? process.env.SAFE_DOCX_LEAN_XML_CHECKER ?? DEFAULT_EXECUTABLE;
-  const timeoutMs = input.options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-  const scratch = await mkdtemp(join(tmpdir(), 'safe-docx-lean-verifier-'));
+  const executablePath = snapshot.options.executablePath ?? process.env.SAFE_DOCX_LEAN_XML_CHECKER ?? DEFAULT_EXECUTABLE;
+  const timeoutMs = snapshot.options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  let scratch: string | undefined;
   try {
+    scratch = await mkdtemp(join(tmpdir(), 'safe-docx-lean-verifier-'));
     const originalDocxPath = join(scratch, 'original.docx');
     const revisedDocxPath = join(scratch, 'revised.docx');
     const comparedDocxPath = join(scratch, 'compared.docx');
     await Promise.all([
-      writeFile(originalDocxPath, input.originalDocx),
-      writeFile(revisedDocxPath, input.revisedDocx),
-      writeFile(comparedDocxPath, input.comparedDocx),
+      writeFile(originalDocxPath, snapshot.originalDocx),
+      writeFile(revisedDocxPath, snapshot.revisedDocx),
+      writeFile(comparedDocxPath, snapshot.comparedDocx),
     ]);
     const stdout = await runExecutable(executablePath, JSON.stringify({
       protocolVersion: 2, originalDocxPath, revisedDocxPath, comparedDocxPath,
     }), timeoutMs);
     const parsed: unknown = JSON.parse(stdout);
     if (!isLeanVerifierJson(parsed)) throw new Error('Lean fixed-story checker returned an unexpected JSON shape');
+    const stories = parsed.stories.map(storyCertificate);
+    const main = stories.find((story) => story.name === 'main');
+    if (!main) throw new Error('Lean fixed-story checker omitted the required main story');
     return {
       ...base,
       status: parsed.passed ? 'passed' : 'failed',
-      stories: parsed.stories.map(storyCertificate),
+      stories,
+      checks: {
+        acceptingAllTrackedChangesMatchesRevisedText:
+          main.checks.acceptingAllTrackedChangesMatchesRevisedText,
+        rejectingAllTrackedChangesMatchesOriginalText:
+          main.checks.rejectingAllTrackedChangesMatchesOriginalText,
+        acceptingAllTrackedChangesKeepsValidFieldStructure:
+          main.checks.acceptingAllTrackedChangesKeepsValidFieldStructure,
+        rejectingAllTrackedChangesKeepsValidFieldStructure:
+          main.checks.rejectingAllTrackedChangesKeepsValidFieldStructure,
+        comparedDocumentHasNoFieldMarkersInsideDeletions:
+          main.checks.comparedStoryHasNoFieldMarkersInsideDeletions,
+      },
+      parsedTokenCounts: main.parsedTokenCounts,
       presenceMismatches: parsed.presenceMismatches,
       reason: parsed.presenceMismatches.length > 0 ? 'Required or optional fixed-story presence did not match across the DOCX triple.' : undefined,
     };
   } catch (error) {
-    return { ...base, status: 'not_run', stories: [], reason: error instanceof Error ? error.message : 'Lean fixed-story checker failed' };
+    return {
+      ...base,
+      status: 'not_run',
+      stories: [],
+      checks: unevaluatedChecks(),
+      reason: error instanceof Error ? error.message : 'Lean fixed-story checker failed',
+    };
   } finally {
-    await rm(scratch, { recursive: true, force: true });
+    if (scratch) await rm(scratch, { recursive: true, force: true });
   }
 }

--- a/packages/docx-compare/src/baselines/atomizer/leanXmlVerifier.ts
+++ b/packages/docx-compare/src/baselines/atomizer/leanXmlVerifier.ts
@@ -1,8 +1,12 @@
 import { spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import type {
   DocumentIntegrityCertificate,
   DocumentIntegrityCheckCertificate,
+  DocumentIntegrityStoryCertificate,
   LeanXmlVerifierOptions,
   ReconstructionMode,
 } from '../../compare-types.js';
@@ -11,21 +15,16 @@ const DEFAULT_TIMEOUT_MS = 10_000;
 const DEFAULT_EXECUTABLE = 'verification/lean/.lake/build/bin/leanDocxChecker';
 
 interface LeanVerifierInput {
-  originalDocumentXml: string;
-  revisedDocumentXml: string;
-  comparedDocumentXml: string;
+  originalDocx: Buffer;
+  revisedDocx: Buffer;
+  comparedDocx: Buffer;
   reconstructionMode: ReconstructionMode;
   options: LeanXmlVerifierOptions;
 }
 
-interface LeanVerifierJson {
-  protocolVersion: number;
-  checker: string;
-  parsedTokenCounts: {
-    original: number;
-    revised: number;
-    combined: number;
-  };
+interface LeanStoryJson {
+  name: string;
+  parsedTokenCounts: { original: number; revised: number; combined: number };
   report: {
     passed: boolean;
     checks: {
@@ -38,183 +37,189 @@ interface LeanVerifierJson {
   };
 }
 
-function sha256(value: string): string {
-  return createHash('sha256').update(value, 'utf8').digest('hex');
+interface LeanVerifierJson {
+  protocolVersion: 2;
+  checker: string;
+  passed: boolean;
+  stories: LeanStoryJson[];
+  presenceMismatches: Array<{
+    name: string;
+    packagePart: string;
+    required: boolean;
+    presence: { original: boolean; revised: boolean; combined: boolean };
+  }>;
+}
+
+function sha256(value: Buffer): string {
+  return createHash('sha256').update(value).digest('hex');
 }
 
 function check(status: boolean, claim: string): DocumentIntegrityCheckCertificate {
   return { status: status ? 'passed' : 'failed', claim };
 }
 
-function notEvaluated(claim: string): DocumentIntegrityCheckCertificate {
-  return { status: 'not_evaluated', claim };
-}
-
-function baseCertificate(input: LeanVerifierInput): Omit<DocumentIntegrityCertificate, 'status' | 'checks'> {
+function storyCertificate(story: LeanStoryJson): DocumentIntegrityStoryCertificate {
+  const checks = story.report.checks;
   return {
-    verifier: 'Lean XML triple checker',
-    protocolVersion: 1,
-    scope: 'word/document.xml',
-    reconstructionMode: input.reconstructionMode,
-    inputSha256: {
-      originalDocumentXml: sha256(input.originalDocumentXml),
-      revisedDocumentXml: sha256(input.revisedDocumentXml),
-      comparedDocumentXml: sha256(input.comparedDocumentXml),
+    name: story.name as DocumentIntegrityStoryCertificate['name'],
+    status: story.report.passed ? 'passed' : 'failed',
+    checks: {
+      acceptingAllTrackedChangesMatchesRevisedText: check(
+        checks.acceptTextMatchesRevised,
+        'Accepting all tracked changes in this story yields the same normalized text as the revised story.'
+      ),
+      rejectingAllTrackedChangesMatchesOriginalText: check(
+        checks.rejectTextMatchesOriginal,
+        'Rejecting all tracked changes in this story yields the same normalized text as the original story.'
+      ),
+      acceptingAllTrackedChangesKeepsValidFieldStructure: check(
+        checks.acceptPreservesFieldStructure,
+        'After accepting all tracked changes, Word field markers in this story remain structurally valid.'
+      ),
+      rejectingAllTrackedChangesKeepsValidFieldStructure: check(
+        checks.rejectPreservesFieldStructure,
+        'After rejecting all tracked changes, Word field markers in this story remain structurally valid.'
+      ),
+      comparedStoryHasNoFieldMarkersInsideDeletions: check(
+        checks.combinedHasNoFldCharInsideDel,
+        'The compared story does not place Word field markers inside deletion markup.'
+      ),
+    },
+    parsedTokenCounts: {
+      original: story.parsedTokenCounts.original,
+      revised: story.parsedTokenCounts.revised,
+      compared: story.parsedTokenCounts.combined,
     },
   };
 }
 
-function unevaluatedChecks(): DocumentIntegrityCertificate['checks'] {
-  return {
-    acceptingAllTrackedChangesMatchesRevisedText: notEvaluated(
-      'Accepting all tracked changes in the compared document yields the same normalized text as the revised document.'
-    ),
-    rejectingAllTrackedChangesMatchesOriginalText: notEvaluated(
-      'Rejecting all tracked changes in the compared document yields the same normalized text as the original document.'
-    ),
-    acceptingAllTrackedChangesKeepsValidFieldStructure: notEvaluated(
-      'After accepting all tracked changes, Word field markers remain structurally valid.'
-    ),
-    rejectingAllTrackedChangesKeepsValidFieldStructure: notEvaluated(
-      'After rejecting all tracked changes, Word field markers remain structurally valid.'
-    ),
-    comparedDocumentHasNoFieldMarkersInsideDeletions: notEvaluated(
-      'The compared document does not place Word field markers inside deletion markup.'
-    ),
-  };
+function isBooleanRecord(value: unknown, keys: string[]): boolean {
+  if (typeof value !== 'object' || value === null) return false;
+  const record = value as Record<string, unknown>;
+  return keys.every((key) => typeof record[key] === 'boolean');
+}
+
+function isLeanStoryJson(value: unknown): value is LeanStoryJson {
+  if (typeof value !== 'object' || value === null) return false;
+  const story = value as Record<string, unknown>;
+  const counts = story.parsedTokenCounts as Record<string, unknown> | undefined;
+  const report = story.report as Record<string, unknown> | undefined;
+  return (
+    ['main', 'footnotes', 'endnotes'].includes(story.name as string) &&
+    typeof counts?.original === 'number' &&
+    typeof counts.revised === 'number' &&
+    typeof counts.combined === 'number' &&
+    typeof report?.passed === 'boolean' &&
+    isBooleanRecord(report.checks, [
+      'acceptPreservesFieldStructure',
+      'rejectPreservesFieldStructure',
+      'acceptTextMatchesRevised',
+      'rejectTextMatchesOriginal',
+      'combinedHasNoFldCharInsideDel',
+    ])
+  );
+}
+
+function isPresenceMismatch(value: unknown): boolean {
+  if (typeof value !== 'object' || value === null) return false;
+  const mismatch = value as Record<string, unknown>;
+  return (
+    typeof mismatch.name === 'string' &&
+    typeof mismatch.packagePart === 'string' &&
+    typeof mismatch.required === 'boolean' &&
+    isBooleanRecord(mismatch.presence, ['original', 'revised', 'combined'])
+  );
 }
 
 function isLeanVerifierJson(value: unknown): value is LeanVerifierJson {
   if (typeof value !== 'object' || value === null) return false;
   const root = value as Record<string, unknown>;
-  const parsedTokenCounts = root.parsedTokenCounts as Record<string, unknown> | undefined;
-  const report = root.report as Record<string, unknown> | undefined;
-  const checks = report?.checks as Record<string, unknown> | undefined;
   return (
-    root.protocolVersion === 1 &&
-    typeof root.checker === 'string' &&
-    typeof parsedTokenCounts?.original === 'number' &&
-    typeof parsedTokenCounts.revised === 'number' &&
-    typeof parsedTokenCounts.combined === 'number' &&
-    typeof report?.passed === 'boolean' &&
-    typeof checks?.acceptPreservesFieldStructure === 'boolean' &&
-    typeof checks.rejectPreservesFieldStructure === 'boolean' &&
-    typeof checks.acceptTextMatchesRevised === 'boolean' &&
-    typeof checks.rejectTextMatchesOriginal === 'boolean' &&
-    typeof checks.combinedHasNoFldCharInsideDel === 'boolean'
+    root.protocolVersion === 2 &&
+    root.checker === 'safe-docx-lean-fixed-story-checker' &&
+    typeof root.passed === 'boolean' &&
+    Array.isArray(root.stories) &&
+    root.stories.every(isLeanStoryJson) &&
+    Array.isArray(root.presenceMismatches) &&
+    root.presenceMismatches.every(isPresenceMismatch)
   );
 }
 
-function runExecutable(
-  executablePath: string,
-  payload: string,
-  timeoutMs: number
-): Promise<string> {
+function runExecutable(executablePath: string, payload: string, timeoutMs: number): Promise<string> {
   return new Promise((resolve, reject) => {
-    const child = spawn(executablePath, [], {
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
+    const child = spawn(executablePath, [], { stdio: ['pipe', 'pipe', 'pipe'] });
     let stdout = '';
     let stderr = '';
     const timer = setTimeout(() => {
       child.kill('SIGKILL');
-      reject(new Error(`Lean XML triple checker timed out after ${timeoutMs}ms`));
+      reject(new Error(`Lean fixed-story checker timed out after ${timeoutMs}ms`));
     }, timeoutMs);
-
     child.stdout.setEncoding('utf8');
     child.stderr.setEncoding('utf8');
-    child.stdout.on('data', (chunk: string) => {
-      stdout += chunk;
-    });
-    child.stderr.on('data', (chunk: string) => {
-      stderr += chunk;
-    });
-    child.on('error', (error) => {
-      clearTimeout(timer);
-      reject(error);
-    });
+    child.stdout.on('data', (chunk: string) => { stdout += chunk; });
+    child.stderr.on('data', (chunk: string) => { stderr += chunk; });
+    child.on('error', (error) => { clearTimeout(timer); reject(error); });
     child.on('close', (code) => {
       clearTimeout(timer);
-      if (code === 0) {
-        resolve(stdout);
-      } else {
-        reject(new Error(`Lean XML triple checker exited with code ${code}: ${stderr.trim()}`));
-      }
+      if (code === 0) resolve(stdout);
+      else reject(new Error(`Lean fixed-story checker exited with code ${code}: ${stderr.trim()}`));
     });
     child.stdin.end(payload);
   });
 }
 
-export async function runLeanXmlTripleVerifier(
-  input: LeanVerifierInput
-): Promise<DocumentIntegrityCertificate> {
+function baseCertificate(input: LeanVerifierInput): Omit<DocumentIntegrityCertificate, 'status' | 'stories'> {
+  return {
+    verifier: 'Lean fixed-story checker',
+    protocolVersion: 2,
+    scope: ['word/document.xml', 'word/footnotes.xml', 'word/endnotes.xml'],
+    reconstructionMode: input.reconstructionMode,
+    inputSha256: {
+      originalDocx: sha256(input.originalDocx),
+      revisedDocx: sha256(input.revisedDocx),
+      comparedDocx: sha256(input.comparedDocx),
+    },
+    exclusions: [
+      'relationships and note-reference integrity',
+      'comments, headers, and footers',
+      'rendering and full ECMA-376 validation',
+    ],
+  };
+}
+
+export async function runLeanXmlTripleVerifier(input: LeanVerifierInput): Promise<DocumentIntegrityCertificate> {
   const base = baseCertificate(input);
   if (input.reconstructionMode !== 'inplace') {
-    return {
-      ...base,
-      status: 'not_applicable',
-      checks: unevaluatedChecks(),
-      reason: 'Lean XML triple verification currently covers inplace comparison output only.',
-    };
+    return { ...base, status: 'not_applicable', stories: [], reason: 'Lean fixed-story verification currently covers inplace comparison output only.' };
   }
 
-  const executablePath =
-    input.options.executablePath ??
-    process.env.SAFE_DOCX_LEAN_XML_CHECKER ??
-    DEFAULT_EXECUTABLE;
+  const executablePath = input.options.executablePath ?? process.env.SAFE_DOCX_LEAN_XML_CHECKER ?? DEFAULT_EXECUTABLE;
   const timeoutMs = input.options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-  const request = JSON.stringify({
-    protocolVersion: 1,
-    originalDocumentXml: input.originalDocumentXml,
-    revisedDocumentXml: input.revisedDocumentXml,
-    combinedDocumentXml: input.comparedDocumentXml,
-  });
-
+  const scratch = await mkdtemp(join(tmpdir(), 'safe-docx-lean-verifier-'));
   try {
-    const stdout = await runExecutable(executablePath, request, timeoutMs);
+    const originalDocxPath = join(scratch, 'original.docx');
+    const revisedDocxPath = join(scratch, 'revised.docx');
+    const comparedDocxPath = join(scratch, 'compared.docx');
+    await Promise.all([
+      writeFile(originalDocxPath, input.originalDocx),
+      writeFile(revisedDocxPath, input.revisedDocx),
+      writeFile(comparedDocxPath, input.comparedDocx),
+    ]);
+    const stdout = await runExecutable(executablePath, JSON.stringify({
+      protocolVersion: 2, originalDocxPath, revisedDocxPath, comparedDocxPath,
+    }), timeoutMs);
     const parsed: unknown = JSON.parse(stdout);
-    if (!isLeanVerifierJson(parsed)) {
-      throw new Error('Lean XML triple checker returned an unexpected JSON shape');
-    }
-
-    const checks = parsed.report.checks;
+    if (!isLeanVerifierJson(parsed)) throw new Error('Lean fixed-story checker returned an unexpected JSON shape');
     return {
       ...base,
-      status: parsed.report.passed ? 'passed' : 'failed',
-      checks: {
-        acceptingAllTrackedChangesMatchesRevisedText: check(
-          checks.acceptTextMatchesRevised,
-          'Accepting all tracked changes in the compared document yields the same normalized text as the revised document.'
-        ),
-        rejectingAllTrackedChangesMatchesOriginalText: check(
-          checks.rejectTextMatchesOriginal,
-          'Rejecting all tracked changes in the compared document yields the same normalized text as the original document.'
-        ),
-        acceptingAllTrackedChangesKeepsValidFieldStructure: check(
-          checks.acceptPreservesFieldStructure,
-          'After accepting all tracked changes, Word field markers remain structurally valid.'
-        ),
-        rejectingAllTrackedChangesKeepsValidFieldStructure: check(
-          checks.rejectPreservesFieldStructure,
-          'After rejecting all tracked changes, Word field markers remain structurally valid.'
-        ),
-        comparedDocumentHasNoFieldMarkersInsideDeletions: check(
-          checks.combinedHasNoFldCharInsideDel,
-          'The compared document does not place Word field markers inside deletion markup.'
-        ),
-      },
-      parsedTokenCounts: {
-        original: parsed.parsedTokenCounts.original,
-        revised: parsed.parsedTokenCounts.revised,
-        compared: parsed.parsedTokenCounts.combined,
-      },
+      status: parsed.passed ? 'passed' : 'failed',
+      stories: parsed.stories.map(storyCertificate),
+      presenceMismatches: parsed.presenceMismatches,
+      reason: parsed.presenceMismatches.length > 0 ? 'Required or optional fixed-story presence did not match across the DOCX triple.' : undefined,
     };
   } catch (error) {
-    return {
-      ...base,
-      status: 'not_run',
-      checks: unevaluatedChecks(),
-      reason: error instanceof Error ? error.message : 'Lean XML triple checker failed',
-    };
+    return { ...base, status: 'not_run', stories: [], reason: error instanceof Error ? error.message : 'Lean fixed-story checker failed' };
+  } finally {
+    await rm(scratch, { recursive: true, force: true });
   }
 }

--- a/packages/docx-compare/src/baselines/atomizer/leanXmlVerifier.ts
+++ b/packages/docx-compare/src/baselines/atomizer/leanXmlVerifier.ts
@@ -193,7 +193,8 @@ function isPresenceMismatch(value: unknown): boolean {
     mismatch.required === true &&
     !!presence &&
     hasExactKeys(presence, ['original', 'revised', 'combined']) &&
-    isBooleanRecord(presence, ['original', 'revised', 'combined'])
+    isBooleanRecord(presence, ['original', 'revised', 'combined']) &&
+    !(presence.original && presence.revised && presence.combined)
   );
 }
 

--- a/packages/docx-compare/src/baselines/atomizer/pipeline.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline.ts
@@ -975,6 +975,11 @@ export async function compareDocumentsAtomizer(
         originalDocx: original,
         revisedDocx: revised,
         comparedDocx: resultBuffer,
+        legacyDocumentXml: {
+          original: originalXml,
+          revised: revisedXml,
+          compared: newDocumentXml,
+        },
         reconstructionMode: comparisonResult.outputMode,
         options: leanXmlVerifier,
       })

--- a/packages/docx-compare/src/baselines/atomizer/pipeline.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline.ts
@@ -972,9 +972,9 @@ export async function compareDocumentsAtomizer(
   const stats = computeAtomizerStats(mergedAtoms);
   const documentIntegrity = leanXmlVerifier?.enabled
     ? await runLeanXmlTripleVerifier({
-        originalDocumentXml: originalXml,
-        revisedDocumentXml: revisedXml,
-        comparedDocumentXml: newDocumentXml,
+        originalDocx: original,
+        revisedDocx: revised,
+        comparedDocx: resultBuffer,
         reconstructionMode: comparisonResult.outputMode,
         options: leanXmlVerifier,
       })

--- a/packages/docx-compare/src/compare-types.ts
+++ b/packages/docx-compare/src/compare-types.ts
@@ -26,7 +26,8 @@ export interface CompareOptions {
   /**
    * Optional Lean 4 verifier for atomizer inplace output. When enabled, the
    * atomizer still produces the DOCX, then a separately compiled Lean checker
-   * evaluates the original/revised/result document.xml triple.
+   * extracts and evaluates fixed WordprocessingML stories from the actual
+   * original/revised/result DOCX package triple.
    */
   leanXmlVerifier?: LeanXmlVerifierOptions;
   /**
@@ -77,7 +78,10 @@ export type ReconstructionMode = 'rebuild' | 'inplace';
 export type ReconstructionFallbackReason = 'round_trip_safety_check_failed';
 
 export interface LeanXmlVerifierOptions {
-  /** Run the Lean XML triple verifier. Default: false. */
+  /**
+   * Run the Lean fixed-story verifier. Default: false.
+   * The compiled verifier currently requires `unzip` on PATH to extract DOCX parts.
+   */
   enabled?: boolean;
   /**
    * Path to the compiled `leanDocxChecker` executable. Defaults to
@@ -242,35 +246,47 @@ export interface DocumentIntegrityCheckCertificate {
   claim: string;
 }
 
-export interface DocumentIntegrityCertificate {
-  /** Overall result from the separately compiled Lean verifier. */
-  status: DocumentIntegrityCertificateStatus;
-  /** Human-facing verifier name, intentionally not a Lean theorem identifier. */
-  verifier: 'Lean XML triple checker';
-  /** Version of the JSON protocol used between TypeScript and the Lean exe. */
-  protocolVersion: 1;
-  /** Main-document XML only; ancillary OOXML parts are not covered by this increment. */
-  scope: 'word/document.xml';
-  /** Reconstruction mode of the compared DOCX that was offered to the verifier. */
-  reconstructionMode: ReconstructionMode;
-  /** SHA-256 hashes of the exact XML strings sent to the verifier. */
-  inputSha256: {
-    originalDocumentXml: string;
-    revisedDocumentXml: string;
-    comparedDocumentXml: string;
-  };
+export type DocumentIntegrityStoryName = 'main' | 'footnotes' | 'endnotes';
+
+export interface DocumentIntegrityStoryCertificate {
+  name: DocumentIntegrityStoryName;
+  status: 'passed' | 'failed';
   checks: {
     acceptingAllTrackedChangesMatchesRevisedText: DocumentIntegrityCheckCertificate;
     rejectingAllTrackedChangesMatchesOriginalText: DocumentIntegrityCheckCertificate;
     acceptingAllTrackedChangesKeepsValidFieldStructure: DocumentIntegrityCheckCertificate;
     rejectingAllTrackedChangesKeepsValidFieldStructure: DocumentIntegrityCheckCertificate;
-    comparedDocumentHasNoFieldMarkersInsideDeletions: DocumentIntegrityCheckCertificate;
+    comparedStoryHasNoFieldMarkersInsideDeletions: DocumentIntegrityCheckCertificate;
   };
-  parsedTokenCounts?: {
-    original: number;
-    revised: number;
-    compared: number;
+  parsedTokenCounts: { original: number; revised: number; compared: number };
+}
+
+export interface DocumentIntegrityCertificate {
+  /** Overall result from the separately compiled Lean verifier. */
+  status: DocumentIntegrityCertificateStatus;
+  /** Human-facing verifier name, intentionally not a Lean theorem identifier. */
+  verifier: 'Lean fixed-story checker';
+  /** Version of the JSON protocol used between TypeScript and the Lean exe. */
+  protocolVersion: 2;
+  /** Fixed story allowlist selected and extracted by the compiled verifier. */
+  scope: readonly ['word/document.xml', 'word/footnotes.xml', 'word/endnotes.xml'];
+  /** Reconstruction mode of the compared DOCX that was offered to the verifier. */
+  reconstructionMode: ReconstructionMode;
+  /** SHA-256 hashes of the exact DOCX package snapshots offered to the verifier. */
+  inputSha256: {
+    originalDocx: string;
+    revisedDocx: string;
+    comparedDocx: string;
   };
+  stories: DocumentIntegrityStoryCertificate[];
+  presenceMismatches?: Array<{
+    name: string;
+    packagePart: string;
+    required: boolean;
+    presence: { original: boolean; revised: boolean; combined: boolean };
+  }>;
+  /** Important surfaces this certificate does not claim to validate. */
+  exclusions: string[];
   reason?: string;
 }
 

--- a/packages/docx-compare/src/compare-types.ts
+++ b/packages/docx-compare/src/compare-types.ts
@@ -259,26 +259,41 @@ export interface DocumentIntegrityStoryCertificate {
     comparedStoryHasNoFieldMarkersInsideDeletions: DocumentIntegrityCheckCertificate;
   };
   parsedTokenCounts: { original: number; revised: number; compared: number };
+  presence: { original: boolean; revised: boolean; compared: boolean };
 }
 
 export interface DocumentIntegrityCertificate {
   /** Overall result from the separately compiled Lean verifier. */
   status: DocumentIntegrityCertificateStatus;
   /** Human-facing verifier name, intentionally not a Lean theorem identifier. */
-  verifier: 'Lean fixed-story checker';
-  /** Version of the JSON protocol used between TypeScript and the Lean exe. */
-  protocolVersion: 2;
-  /** Fixed story allowlist selected and extracted by the compiled verifier. */
-  scope: readonly ['word/document.xml', 'word/footnotes.xml', 'word/endnotes.xml'];
+  verifier: 'Lean XML triple checker';
+  /** Stable public certificate protocol retained for v1 consumers. */
+  protocolVersion: 1;
+  /** Stable v1 main-document scope. See `fixedStoryScope` for additive coverage. */
+  scope: 'word/document.xml';
   /** Reconstruction mode of the compared DOCX that was offered to the verifier. */
   reconstructionMode: ReconstructionMode;
-  /** SHA-256 hashes of the exact DOCX package snapshots offered to the verifier. */
+  /** Stable v1 hashes of the main-document XML projections. */
   inputSha256: {
-    originalDocx: string;
-    revisedDocx: string;
-    comparedDocx: string;
+    originalDocumentXml: string;
+    revisedDocumentXml: string;
+    comparedDocumentXml: string;
   };
-  stories: DocumentIntegrityStoryCertificate[];
+  /** Stable v1 main-story checks, populated from the compiled checker report. */
+  checks: {
+    acceptingAllTrackedChangesMatchesRevisedText: DocumentIntegrityCheckCertificate;
+    rejectingAllTrackedChangesMatchesOriginalText: DocumentIntegrityCheckCertificate;
+    acceptingAllTrackedChangesKeepsValidFieldStructure: DocumentIntegrityCheckCertificate;
+    rejectingAllTrackedChangesKeepsValidFieldStructure: DocumentIntegrityCheckCertificate;
+    comparedDocumentHasNoFieldMarkersInsideDeletions: DocumentIntegrityCheckCertificate;
+  };
+  /** Stable v1 main-story token counts. */
+  parsedTokenCounts?: { original: number; revised: number; compared: number };
+  /** Internal executable protocol used for package-level verification. */
+  checkerProtocolVersion?: 2;
+  fixedStoryScope?: readonly ['word/document.xml', 'word/footnotes.xml', 'word/endnotes.xml'];
+  inputPackageSha256?: { originalDocx: string; revisedDocx: string; comparedDocx: string };
+  stories?: DocumentIntegrityStoryCertificate[];
   presenceMismatches?: Array<{
     name: string;
     packagePart: string;
@@ -286,7 +301,7 @@ export interface DocumentIntegrityCertificate {
     presence: { original: boolean; revised: boolean; combined: boolean };
   }>;
   /** Important surfaces this certificate does not claim to validate. */
-  exclusions: string[];
+  exclusions?: string[];
   reason?: string;
 }
 

--- a/packages/docx-compare/src/index.ts
+++ b/packages/docx-compare/src/index.ts
@@ -16,6 +16,8 @@ export type {
   DocumentIntegrityCertificateStatus,
   DocumentIntegrityCheckCertificate,
   DocumentIntegrityCheckStatus,
+  DocumentIntegrityStoryCertificate,
+  DocumentIntegrityStoryName,
   LeanXmlVerifierOptions,
   ReconstructionAttemptDiagnostics,
   ReconstructionBookmarkMismatchDetails,

--- a/scripts/check_lean_xml_checker_coverage.mjs
+++ b/scripts/check_lean_xml_checker_coverage.mjs
@@ -5,9 +5,11 @@ import { join } from 'node:path';
 const root = process.cwd();
 const ledgerPath = join(root, 'verification/registry/lean-xml-checker-coverage.json');
 const leanPath = join(root, 'verification/lean/Tier2/XmlTripleChecker.lean');
+const executablePath = join(root, 'verification/lean/LeanDocxChecker.lean');
 
 const ledger = JSON.parse(readFileSync(ledgerPath, 'utf8'));
 const lean = readFileSync(leanPath, 'utf8');
+const executable = readFileSync(executablePath, 'utf8');
 
 const errors = [];
 
@@ -47,6 +49,25 @@ if (!ledger.scope?.reconstructionModes?.covered?.includes('inplace')) {
 }
 if (!ledger.scope?.reconstructionModes?.outOfScope?.includes('rebuild')) {
   errors.push('ledger must mark rebuild as out of scope');
+}
+
+if (ledger.protocolVersion !== 2 || !executable.includes('protocolVersion != 2')) {
+  errors.push('ledger and Lean executable must agree on protocol version 2');
+}
+
+for (const part of ['word/document.xml', 'word/footnotes.xml', 'word/endnotes.xml']) {
+  if (!executable.includes(`packagePart := "${part}"`)) {
+    errors.push(`Lean executable does not own fixed story extraction for ${part}`);
+  }
+  for (const input of ledger.scope?.inputs ?? []) {
+    if (!input.packageParts?.includes(part)) {
+      errors.push(`ledger input ${input.name} does not include fixed story ${part}`);
+    }
+  }
+}
+
+if (!lean.includes('projectUserNoteTokens') || !lean.includes('story_collection_checker_sound')) {
+  errors.push('Lean checker must retain the reserved-note projection and collection theorem');
 }
 
 if (errors.length > 0) {

--- a/scripts/check_lean_xml_checker_coverage.mjs
+++ b/scripts/check_lean_xml_checker_coverage.mjs
@@ -70,6 +70,25 @@ if (!lean.includes('projectUserNoteTokens') || !lean.includes('story_collection_
   errors.push('Lean checker must retain the reserved-note projection and collection theorem');
 }
 
+for (const value of ledger.parsedWordprocessingML?.attributeValues?.['w:type'] ?? []) {
+  if (!lean.includes(`w:type=\\"${value}\\"`)) {
+    errors.push(`ledger reserved note type ${value} is not recognized by the Lean checker`);
+  }
+}
+
+for (const required of [
+  'resolveQName',
+  'wmlNamespace',
+  'maxPackageBytes',
+  'maxPartCompressedBytes',
+  'maxPartExpandedBytes',
+  'maxCompressionRatio',
+]) {
+  if (!lean.includes(required) && !executable.includes(required)) {
+    errors.push(`coverage claim requires ${required} in the Lean checker path`);
+  }
+}
+
 if (errors.length > 0) {
   console.error('Lean XML checker coverage ledger drift detected:');
   for (const error of errors) {

--- a/verification/lean/AxiomAudit.lean
+++ b/verification/lean/AxiomAudit.lean
@@ -14,3 +14,5 @@ import Tier2.XmlTripleChecker
 #print axioms Tier2.XmlTripleChecker.checker_sound
 #print axioms Tier2.XmlTripleChecker.story_collection_checker_sound
 #print axioms Tier2.XmlTripleChecker.projectUserNoteTokens_no_reserved
+#print axioms Tier2.XmlTripleChecker.projectUserNoteTokens_idempotent
+#print axioms Tier2.XmlTripleChecker.projectUserNoteTokens_typed_reserved

--- a/verification/lean/AxiomAudit.lean
+++ b/verification/lean/AxiomAudit.lean
@@ -12,3 +12,5 @@ import Tier2.XmlTripleChecker
 #print axioms LeanSpike.computeAtomLcsDP_eq_computeAtomLcs
 #print axioms LeanSpike.rawMatches_are_longest_relevant
 #print axioms Tier2.XmlTripleChecker.checker_sound
+#print axioms Tier2.XmlTripleChecker.story_collection_checker_sound
+#print axioms Tier2.XmlTripleChecker.projectUserNoteTokens_no_reserved

--- a/verification/lean/LeanDocxChecker.lean
+++ b/verification/lean/LeanDocxChecker.lean
@@ -4,34 +4,96 @@ import Tier2.XmlTripleChecker
 open Lean Tier2.XmlTripleChecker
 
 structure Request where
-  originalDocumentXml : String
-  revisedDocumentXml : String
-  combinedDocumentXml : String
+  originalDocxPath : String
+  revisedDocxPath : String
+  comparedDocxPath : String
+
+structure FixedStory where
+  name : String
+  packagePart : String
+  required : Bool
+  noteProjection : Bool
+
+def fixedStories : List FixedStory :=
+  [ { name := "main", packagePart := "word/document.xml", required := true,
+      noteProjection := false }
+  , { name := "footnotes", packagePart := "word/footnotes.xml", required := false,
+      noteProjection := true }
+  , { name := "endnotes", packagePart := "word/endnotes.xml", required := false,
+      noteProjection := true }
+  ]
 
 def requestFromJson (j : Json) : Except String Request := do
   let protocolVersion ← j.getObjValAs? Nat "protocolVersion"
-  if protocolVersion != 1 then
+  if protocolVersion != 2 then
     throw s!"unsupported protocolVersion: {protocolVersion}"
   return {
-    originalDocumentXml := (← j.getObjValAs? String "originalDocumentXml")
-    revisedDocumentXml := (← j.getObjValAs? String "revisedDocumentXml")
-    combinedDocumentXml := (← j.getObjValAs? String "combinedDocumentXml")
+    originalDocxPath := (← j.getObjValAs? String "originalDocxPath")
+    revisedDocxPath := (← j.getObjValAs? String "revisedDocxPath")
+    comparedDocxPath := (← j.getObjValAs? String "comparedDocxPath")
   }
 
-def runRequest (req : Request) : Json :=
-  let original := parseXmlTokens req.originalDocumentXml
-  let revised := parseXmlTokens req.revisedDocumentXml
-  let combined := parseXmlTokens req.combinedDocumentXml
-  let report := comparisonCheckerB original revised combined
+def extractPart (packagePath partPath : String) : IO (Option String) := do
+  let listing ← IO.Process.output { cmd := "unzip", args := #["-Z1", packagePath, partPath] }
+  if listing.exitCode != 0 then return none
+  let extracted ← IO.Process.output { cmd := "unzip", args := #["-p", packagePath, partPath] }
+  if extracted.exitCode != 0 then
+    throw (IO.userError s!"failed to extract {partPath} from {packagePath}: {extracted.stderr.trimAscii}")
+  return some extracted.stdout
+
+def tokensForStory (story : FixedStory) (xml : String) : List XmlTok :=
+  let tokens := parseXmlTokens xml
+  if story.noteProjection then projectUserNoteTokens tokens else tokens
+
+def presenceJson (original revised combined : Bool) : Json :=
   Json.mkObj
-    [ ("protocolVersion", toJson (1 : Nat))
-    , ("checker", toJson "safe-docx-lean-xml-triple-checker")
-    , ("parsedTokenCounts", Json.mkObj
-        [ ("original", toJson original.length)
-        , ("revised", toJson revised.length)
-        , ("combined", toJson combined.length)
-        ])
-    , ("report", reportToJson report)
+    [ ("original", toJson original)
+    , ("revised", toJson revised)
+    , ("combined", toJson combined)
+    ]
+
+def mismatchJson (story : FixedStory) (original revised combined : Bool) : Json :=
+  Json.mkObj
+    [ ("name", toJson story.name)
+    , ("packagePart", toJson story.packagePart)
+    , ("required", toJson story.required)
+    , ("presence", presenceJson original revised combined)
+    ]
+
+structure LoadedStories where
+  stories : List NamedStoryTriple
+  mismatches : List Json
+
+def loadFixedStories (req : Request) : IO LoadedStories := do
+  let mut stories := []
+  let mut mismatches := []
+  for story in fixedStories do
+    let original ← extractPart req.originalDocxPath story.packagePart
+    let revised ← extractPart req.revisedDocxPath story.packagePart
+    let combined ← extractPart req.comparedDocxPath story.packagePart
+    match original, revised, combined with
+    | some a, some b, some c =>
+      stories := stories ++
+        [{ name := story.name, original := tokensForStory story a,
+           revised := tokensForStory story b, combined := tokensForStory story c }]
+    | none, none, none =>
+      if story.required then
+        mismatches := mismatches ++ [mismatchJson story false false false]
+    | _, _, _ =>
+      mismatches := mismatches ++
+        [mismatchJson story original.isSome revised.isSome combined.isSome]
+  return { stories, mismatches }
+
+def runRequest (req : Request) : IO Json := do
+  let loaded ← loadFixedStories req
+  let reports := checkStoryCollection loaded.stories
+  let passed := loaded.mismatches.isEmpty && storyCollectionPassed reports
+  return Json.mkObj
+    [ ("protocolVersion", toJson (2 : Nat))
+    , ("checker", toJson "safe-docx-lean-fixed-story-checker")
+    , ("passed", toJson passed)
+    , ("stories", Json.arr (reports.map storyReportToJson).toArray)
+    , ("presenceMismatches", Json.arr loaded.mismatches.toArray)
     ]
 
 def main : IO Unit := do
@@ -42,4 +104,4 @@ def main : IO Unit := do
   | .ok j =>
     match requestFromJson j with
     | .error e => throw (IO.userError s!"request parse error: {e}")
-    | .ok req => IO.println (runRequest req).compress
+    | .ok req => IO.println (← runRequest req).compress

--- a/verification/lean/LeanDocxChecker.lean
+++ b/verification/lean/LeanDocxChecker.lean
@@ -11,15 +11,16 @@ structure Request where
 structure FixedStory where
   name : String
   packagePart : String
+  rootLocalName : String
   required : Bool
   noteProjection : Bool
 
 def fixedStories : List FixedStory :=
-  [ { name := "main", packagePart := "word/document.xml", required := true,
+  [ { name := "main", packagePart := "word/document.xml", rootLocalName := "document", required := true,
       noteProjection := false }
-  , { name := "footnotes", packagePart := "word/footnotes.xml", required := false,
+  , { name := "footnotes", packagePart := "word/footnotes.xml", rootLocalName := "footnotes", required := false,
       noteProjection := true }
-  , { name := "endnotes", packagePart := "word/endnotes.xml", required := false,
+  , { name := "endnotes", packagePart := "word/endnotes.xml", rootLocalName := "endnotes", required := false,
       noteProjection := true }
   ]
 
@@ -33,17 +34,93 @@ def requestFromJson (j : Json) : Except String Request := do
     comparedDocxPath := (← j.getObjValAs? String "comparedDocxPath")
   }
 
-def extractPart (packagePath partPath : String) : IO (Option String) := do
-  let listing ← IO.Process.output { cmd := "unzip", args := #["-Z1", packagePath, partPath] }
-  if listing.exitCode != 0 then return none
-  let extracted ← IO.Process.output { cmd := "unzip", args := #["-p", packagePath, partPath] }
-  if extracted.exitCode != 0 then
-    throw (IO.userError s!"failed to extract {partPath} from {packagePath}: {extracted.stderr.trimAscii}")
-  return some extracted.stdout
+def maxPackageBytes : Nat := 100 * 1024 * 1024
+def maxPartCompressedBytes : Nat := 16 * 1024 * 1024
+def maxPartExpandedBytes : Nat := 16 * 1024 * 1024
+def maxCompressionRatio : Nat := 100
+def maxDiagnosticBytes : Nat := 16 * 1024
 
-def tokensForStory (story : FixedStory) (xml : String) : List XmlTok :=
-  let tokens := parseXmlTokens xml
-  if story.noteProjection then projectUserNoteTokens tokens else tokens
+structure BoundedOutput where
+  exitCode : UInt32
+  stdout : String
+  stderr : String
+
+partial def readBounded (handle : IO.FS.Handle) (limit : Nat) (acc : ByteArray := .empty) :
+    IO ByteArray := do
+  let chunk ← handle.read 4096
+  if chunk.isEmpty then return acc
+  let next := acc ++ chunk
+  if next.size > limit then throw (IO.userError s!"process output exceeds {limit} bytes")
+  readBounded handle limit next
+
+def runBounded (cmd : String) (args : Array String) (stdoutLimit : Nat) : IO BoundedOutput := do
+  let child ← IO.Process.spawn {
+    cmd, args, stdout := .piped, stderr := .piped
+  }
+  let stderrTask ← IO.asTask (readBounded child.stderr maxDiagnosticBytes) Task.Priority.dedicated
+  try
+    let stdoutBytes ← readBounded child.stdout stdoutLimit
+    let exitCode ← child.wait
+    let stderrBytes ← IO.ofExcept stderrTask.get
+    let some stdout := String.fromUTF8? stdoutBytes |
+      throw (IO.userError "archive extractor emitted non-UTF-8 output")
+    let some stderr := String.fromUTF8? stderrBytes |
+      throw (IO.userError "archive extractor emitted non-UTF-8 diagnostics")
+    return { exitCode, stdout, stderr }
+  catch error =>
+    child.kill
+    discard child.wait
+    throw error
+
+structure EntryInfo where
+  compressedBytes : Nat
+  expandedBytes : Nat
+
+inductive ExtractedPart where
+  | missing
+  | present (xml : String)
+
+def parseEntryInfo (line : String) : Except String EntryInfo := do
+  let words := (line.replace "\n" " ").splitOn " " |>.filter (· != "")
+  if words.length != 10 then throw "unexpected archive metadata shape"
+  let expanded ← match (List.getD words 3 "").toNat? with
+    | some value => pure value
+    | none => throw "invalid expanded entry size"
+  let compressed ← match (List.getD words 5 "").toNat? with
+    | some value => pure value
+    | none => throw "invalid compressed entry size"
+  return { compressedBytes := compressed, expandedBytes := expanded }
+
+def validateEntryLimits (partPath : String) (info : EntryInfo) : Except String Unit := do
+  if info.compressedBytes > maxPartCompressedBytes then
+    throw s!"{partPath} compressed size exceeds {maxPartCompressedBytes} bytes"
+  if info.expandedBytes > maxPartExpandedBytes then
+    throw s!"{partPath} expanded size exceeds {maxPartExpandedBytes} bytes"
+  if info.compressedBytes == 0 && info.expandedBytes > 0 then
+    throw s!"{partPath} has an invalid zero compressed size"
+  if info.expandedBytes > info.compressedBytes * maxCompressionRatio then
+    throw s!"{partPath} compression ratio exceeds {maxCompressionRatio}"
+
+def extractPart (packagePath partPath : String) : IO ExtractedPart := do
+  let metadata ← (System.FilePath.mk packagePath).metadata
+  if metadata.byteSize > maxPackageBytes.toUInt64 then
+    throw (IO.userError s!"DOCX package exceeds {maxPackageBytes} bytes")
+  let listing ← runBounded "unzip" #["-Z", "-l", packagePath, partPath] maxDiagnosticBytes
+  if listing.exitCode == 11 then return .missing
+  if listing.exitCode != 0 then
+    throw (IO.userError s!"archive metadata failed for {partPath}: {listing.stderr.trimAscii}")
+  let info ← IO.ofExcept (parseEntryInfo listing.stdout.trimAscii.toString)
+  IO.ofExcept (validateEntryLimits partPath info)
+  let extracted ← runBounded "unzip" #["-p", packagePath, partPath] maxPartExpandedBytes
+  if extracted.exitCode != 0 then
+    throw (IO.userError s!"archive extraction failed for {partPath}: {extracted.stderr.trimAscii}")
+  if extracted.stdout.toUTF8.size != info.expandedBytes then
+    throw (IO.userError s!"archive extraction size mismatch for {partPath}")
+  return .present extracted.stdout
+
+def tokensForStory (story : FixedStory) (xml : String) : Except String (List XmlTok) := do
+  let tokens ← parseXmlTokensForRoot xml story.rootLocalName
+  return if story.noteProjection then projectUserNoteTokens tokens else tokens
 
 def presenceJson (original revised combined : Bool) : Json :=
   Json.mkObj
@@ -72,16 +149,31 @@ def loadFixedStories (req : Request) : IO LoadedStories := do
     let revised ← extractPart req.revisedDocxPath story.packagePart
     let combined ← extractPart req.comparedDocxPath story.packagePart
     match original, revised, combined with
-    | some a, some b, some c =>
-      stories := stories ++
-        [{ name := story.name, original := tokensForStory story a,
-           revised := tokensForStory story b, combined := tokensForStory story c }]
-    | none, none, none =>
+    | .missing, .missing, .missing =>
       if story.required then
         mismatches := mismatches ++ [mismatchJson story false false false]
+        stories := stories ++
+          [{ name := story.name, original := [], revised := [], combined := [],
+             originalPresent := false, revisedPresent := false, combinedPresent := false }]
     | _, _, _ =>
-      mismatches := mismatches ++
-        [mismatchJson story original.isSome revised.isSome combined.isSome]
+      let originalPresent := match original with | .present _ => true | .missing => false
+      let revisedPresent := match revised with | .present _ => true | .missing => false
+      let combinedPresent := match combined with | .present _ => true | .missing => false
+      if story.required && !(originalPresent && revisedPresent && combinedPresent) then
+        mismatches := mismatches ++
+          [mismatchJson story originalPresent revisedPresent combinedPresent]
+      let originalTokens ← match original with
+        | .present xml => IO.ofExcept (tokensForStory story xml)
+        | .missing => pure []
+      let revisedTokens ← match revised with
+        | .present xml => IO.ofExcept (tokensForStory story xml)
+        | .missing => pure []
+      let combinedTokens ← match combined with
+        | .present xml => IO.ofExcept (tokensForStory story xml)
+        | .missing => pure []
+      stories := stories ++
+        [{ name := story.name, original := originalTokens, revised := revisedTokens,
+           combined := combinedTokens, originalPresent, revisedPresent, combinedPresent }]
   return { stories, mismatches }
 
 def runRequest (req : Request) : IO Json := do

--- a/verification/lean/README.md
+++ b/verification/lean/README.md
@@ -171,22 +171,38 @@ It concluded *full atom equality* (`a = b`), which held only because `Atom` expo
 
 **Scope note on optimality (INV-LCS-002) — resolved.** `rawMatches_are_longest` bounds the length of every *structural* common subsequence (`isCommonSubseq s orig rev := s <+ orig ∧ s <+ rev`, i.e. literal sublists of both). It remains true and non-vacuous after broadening, but it is *strictly weaker* than "longest under `atomsEqual`": because `atomsEqual` correlates atoms only up to `Atom.relevant`, an `atomsEqual`-matchable common subsequence need not be a structural sublist of both inputs. This gap is now closed by `rawMatches_are_longest_relevant` (`LeanSpike/LcsDP.lean`), which bounds every common subsequence of the relevant projections (`orig.map Atom.relevant`, `rev.map Atom.relevant`) — i.e. optimality at the `atomsEqual` level. It is provably stronger: e.g. two atoms with equal `Atom.relevant` but differing `correlationStatus` have an `atomsEqual`-matchable common subsequence of length 1 that is *not* a structural sublist of both. The proof reuses the `rawMatches_are_longest` induction skeleton, lifted to projected lists via a type-polymorphic `sublist_drop_heads` and the converse lemma `atomsEqual_of_relevant_eq` (projection equality ⇒ `atomsEqual`).
 
-## Lean XML triple checker
+## Lean fixed-story checker
 
-`Tier2/XmlTripleChecker.lean` defines the first compiled verifier for real
-comparison output. The `leanDocxChecker` executable reads a JSON object
-containing the original, revised, and compared `word/document.xml` strings,
-parses the relevant WordprocessingML token subset in Lean, and checks whether:
+`Tier2/XmlTripleChecker.lean` defines the compiled verifier for real comparison
+output. The `leanDocxChecker` executable receives paths to exact snapshots of
+the original, revised, and compared DOCX packages. The Lean process invokes the
+package extractor and selects these fixed WordprocessingML stories itself:
+
+- required `word/document.xml`;
+- optional `word/footnotes.xml`; and
+- optional `word/endnotes.xml`.
+
+Optional parts must be present in all three packages or absent from all three.
+Each supplied story is parsed and checked independently, so field state cannot
+balance across part boundaries. Reserved note IDs `-1` and `0` are removed by
+the Lean-defined `projectUserNoteTokens` projection before user-note text is
+compared. The projection and collection soundness theorem are included in the
+axiom audit.
+
+For every supplied story, the checker checks whether:
 
 - accepting all tracked changes in the compared XML recovers the revised text;
 - rejecting all tracked changes in the compared XML recovers the original text;
 - the accept and reject projections keep valid Word field structure; and
 - the compared XML does not place field markers inside deletion markup.
 
-The public claim is deliberately per-document: a separately compiled Lean
-program checked this XML triple. It is not a proof of the entire TypeScript
-comparison engine, package-level OPC behavior, rendering fidelity, rebuild mode,
-or ancillary parts. The current parsed and out-of-scope surfaces are tracked in
+The public claim is deliberately per-package-triple: a separately compiled Lean
+program extracted and checked these fixed stories. It is not a proof of the
+entire TypeScript comparison engine, note/reference or relationship integrity,
+package-level OPC behavior, rendering fidelity, rebuild mode, comments,
+headers/footers, or full ECMA-376 conformance. Package extraction currently
+requires `unzip`; absence or extraction failure produces `not_run`. The exact
+parsed and out-of-scope surfaces are tracked in
 `verification/registry/lean-xml-checker-coverage.json` and drift-checked by
 `npm run check:lean-xml-checker-coverage`.
 

--- a/verification/lean/README.md
+++ b/verification/lean/README.md
@@ -182,12 +182,20 @@ package extractor and selects these fixed WordprocessingML stories itself:
 - optional `word/footnotes.xml`; and
 - optional `word/endnotes.xml`.
 
-Optional parts must be present in all three packages or absent from all three.
-Each supplied story is parsed and checked independently, so field state cannot
-balance across part boundaries. Reserved note IDs `-1` and `0` are removed by
-the Lean-defined `projectUserNoteTokens` projection before user-note text is
-compared. The projection and collection soundness theorem are included in the
-axiom audit.
+If any package supplies an optional part, absent sides are represented by empty
+token stories. This permits checked tracked-part additions and removals while an
+untracked text divergence still fails; all-absent optional parts are omitted.
+Each story is parsed and checked independently, so field state cannot balance
+across part boundaries.
+
+The Lean parser resolves prefixes to namespace URIs, accepts any prefix bound to
+the WordprocessingML namespace, requires the expected expanded-name root, and
+rejects malformed or unbound XML. Reserved note entries are selected by the
+namespace-qualified `w:type` value `separator` or `continuationSeparator`, not
+by ID. Therefore a normal note with ID `0` remains visible, while a typed
+separator with any ID is excluded. `projectUserNoteTokens` is proved
+idempotent, and its typed-reserved projection theorem is included in the axiom
+audit alongside collection soundness.
 
 For every supplied story, the checker checks whether:
 
@@ -201,7 +209,15 @@ program extracted and checked these fixed stories. It is not a proof of the
 entire TypeScript comparison engine, note/reference or relationship integrity,
 package-level OPC behavior, rendering fidelity, rebuild mode, comments,
 headers/footers, or full ECMA-376 conformance. Package extraction currently
-requires `unzip`; absence or extraction failure produces `not_run`. The exact
+requires `unzip`; absence, corrupt archives, metadata errors, oversized
+packages/parts, excessive compression ratios, output-limit violations, or
+extraction failure produce `not_run`. The extractor checks compressed and
+expanded metadata before extraction and streams output under a hard bound.
+
+The executable speaks protocol v2, but the TypeScript certificate retains the
+public v1 discriminator, verifier name, main-document scope, XML hashes, checks,
+and token counts. Fixed-story scope, package hashes, story presence, per-story
+reports, and exclusions are additive fields. The exact
 parsed and out-of-scope surfaces are tracked in
 `verification/registry/lean-xml-checker-coverage.json` and drift-checked by
 `npm run check:lean-xml-checker-coverage`.

--- a/verification/lean/Tier2/XmlTripleChecker.lean
+++ b/verification/lean/Tier2/XmlTripleChecker.lean
@@ -39,8 +39,17 @@ def decodeXmlText (s : String) : String :=
   let s := s.replace "&apos;" apostrophe
   s.replace "&amp;" "&"
 
+def wmlNamespace : String :=
+  "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+
+def normalizeTagWhitespace (tag : String) : String :=
+  ((tag.replace "\n" " ").replace "\r" " ").replace "\t" " "
+
+def tagWords (tag : String) : List String :=
+  (normalizeTagWhitespace tag).splitOn " " |>.filter (· != "")
+
 def tagName (tag : String) : String :=
-  let first := List.getD (tag.splitOn " ") 0 tag
+  let first := List.getD (tagWords tag) 0 tag
   first.replace "/" ""
 
 def isStartTag (tag name : String) : Bool :=
@@ -54,9 +63,78 @@ def tagPayload (segment : String) : String × String :=
   | [] => ("", "")
   | tag :: rest => (tag, String.intercalate ">" rest)
 
+def splitQName (name : String) : String × String :=
+  match name.splitOn ":" with
+  | [localName] => ("", localName)
+  | [pre, localName] => (pre, localName)
+  | _ => ("", "")
+
+abbrev NamespaceBindings := List (String × String)
+
+def namespaceLookup (bindings : NamespaceBindings) (key : String) : Option String :=
+  match bindings.find? (fun binding => binding.1 == key) with
+  | some binding => some binding.2
+  | none => none
+
+def namespaceLookupD (bindings : NamespaceBindings) (key fallback : String) : String :=
+  (namespaceLookup bindings key).getD fallback
+
+def attrTokenValue (token key : String) : Option String :=
+  let doubleMarker := key ++ "=\""
+  let singleMarker := key ++ "='"
+  if token.startsWith doubleMarker && token.endsWith "\"" then
+    some ((token.drop doubleMarker.length).dropEnd 1).toString
+  else if token.startsWith singleMarker && token.endsWith "'" then
+    some ((token.drop singleMarker.length).dropEnd 1).toString
+  else none
+
+def namespaceDeclarations (tag : String) : List (String × String) :=
+  (tagWords tag).filterMap fun rawToken =>
+    let token := if rawToken.endsWith "/" then (rawToken.dropEnd 1).toString else rawToken
+    if let some value := attrTokenValue token "xmlns" then some ("", value)
+    else if token.startsWith "xmlns:" then
+      let key := List.getD (token.splitOn "=") 0 ""
+      let pre := (List.getD (key.splitOn ":") 1 "")
+      (attrTokenValue token key).map fun value => (pre, value)
+    else none
+
+def extendNamespaces (base : NamespaceBindings) (decls : List (String × String)) : NamespaceBindings :=
+  decls.foldl (fun acc binding => binding :: acc.filter (fun old => old.1 != binding.1)) base
+
+def resolveQName (bindings : NamespaceBindings) (name : String) : Except String (String × String) := do
+  let (pre, localName) := splitQName name
+  if localName.isEmpty then throw s!"invalid qualified name: {name}"
+  if pre.isEmpty then return (namespaceLookupD bindings "" "", localName)
+  match namespaceLookup bindings pre with
+  | some uri => return (uri, localName)
+  | none => throw s!"unbound namespace prefix: {pre}"
+
+def canonicalizeWmlTag (tag localName : String) (bindings : NamespaceBindings) : String :=
+  let attrs := (tagWords tag).drop 1 |>.filter (fun token => !token.startsWith "xmlns")
+  let attrs := attrs.map fun rawToken =>
+    let token := if rawToken.endsWith "/" then (rawToken.dropEnd 1).toString else rawToken
+    let key := List.getD (token.splitOn "=") 0 token
+    let (pre, attrLocal) := splitQName key
+    if !pre.isEmpty && namespaceLookupD bindings pre "" == wmlNamespace then
+      match attrTokenValue token key with
+      | some value => "w:" ++ attrLocal ++ "=\"" ++ value ++ "\""
+      | none => token
+    else token
+  String.intercalate " " (("w:" ++ localName) :: attrs)
+
+def validateAttributeNamespaces (tag : String) (bindings : NamespaceBindings) : Except String Unit := do
+  for rawToken in (tagWords tag).drop 1 do
+    let token := if rawToken.endsWith "/" then (rawToken.dropEnd 1).toString else rawToken
+    let key := List.getD (token.splitOn "=") 0 token
+    if key == "xmlns" || key.startsWith "xmlns:" then continue
+    let (pre, _) := splitQName key
+    if !pre.isEmpty && (namespaceLookup bindings pre).isNone then
+      throw s!"unbound namespace prefix on attribute: {pre}"
+
 def tagToken (tag payload : String) : List XmlTok :=
   if (isStartTag tag "w:footnote" || isStartTag tag "w:endnote") &&
-      (tag.contains "w:id=\"-1\"" || tag.contains "w:id=\"0\"") then [.enterReservedNote]
+      (tag.contains "w:type=\"separator\"" ||
+       tag.contains "w:type=\"continuationSeparator\"") then [.enterReservedNote]
   else if isEndTag tag "w:footnote" || isEndTag tag "w:endnote" then [.exitReservedNote]
   else if isStartTag tag "w:p" then [.pBreak]
   else if isStartTag tag "w:ins" then [.enter .ins]
@@ -78,10 +156,60 @@ def tagToken (tag payload : String) : List XmlTok :=
   else if isStartTag tag "w:delInstrText" then [.delInstrText (decodeXmlText payload)]
   else []
 
-def parseXmlTokens (xml : String) : List XmlTok :=
-  (((xml.splitOn "<").drop 1).map fun segment =>
-    let (tag, payload) := tagPayload segment
-    tagToken tag payload).flatten
+structure OpenElement where
+  uri : String
+  localName : String
+  namespaces : NamespaceBindings
+
+structure XmlParseState where
+  stack : List OpenElement := []
+  tokens : List XmlTok := []
+  rootSeen : Bool := false
+
+def currentNamespaces (state : XmlParseState) : NamespaceBindings :=
+  match state.stack with
+  | top :: _ => top.namespaces
+  | [] => [("xml", "http://www.w3.org/XML/1998/namespace")]
+
+def parseXmlSegment (expectedRoot : String) (state : XmlParseState) (segment : String) :
+    Except String XmlParseState := do
+  let parts := segment.splitOn ">"
+  if parts.length < 2 then throw "malformed XML tag without closing >"
+  let tag := List.getD parts 0 ""
+  let payload := String.intercalate ">" (parts.drop 1)
+  let trimmed := tag.trimAscii.toString
+  if trimmed.isEmpty then throw "empty XML tag"
+  if trimmed.startsWith "?" || trimmed.startsWith "!" then return state
+  if trimmed.startsWith "/" then
+    let rawName := ((List.getD (tagWords trimmed) 0 "").drop 1).toString
+    let some top := state.stack.head? | throw "unexpected closing tag"
+    let (uri, localName) ← resolveQName top.namespaces rawName
+    if uri != top.uri || localName != top.localName then
+      throw s!"mismatched closing tag: {rawName}"
+    let emitted := if uri == wmlNamespace then tagToken ("/w:" ++ localName) payload else []
+    return { state with stack := state.stack.drop 1, tokens := state.tokens ++ emitted }
+  let selfClosing := trimmed.endsWith "/"
+  if state.rootSeen && state.stack.isEmpty then throw "multiple XML root elements"
+  let rawName := List.getD (tagWords trimmed) 0 ""
+  let bindings := extendNamespaces (currentNamespaces state) (namespaceDeclarations trimmed)
+  validateAttributeNamespaces trimmed bindings
+  let (uri, localName) ← resolveQName bindings rawName
+  if !state.rootSeen then
+    if uri != wmlNamespace || localName != expectedRoot then
+      throw s!"unexpected root namespace={uri} local={localName}; expected namespace={wmlNamespace} local={expectedRoot}"
+  let canonical := if uri == wmlNamespace then canonicalizeWmlTag trimmed localName bindings else trimmed
+  let emitted := if uri == wmlNamespace then tagToken canonical payload else []
+  let next := { state with tokens := state.tokens ++ emitted, rootSeen := true }
+  if selfClosing then return next
+  return { next with stack := { uri, localName, namespaces := bindings } :: next.stack }
+
+def parseXmlTokensForRoot (xml expectedRoot : String) : Except String (List XmlTok) := do
+  let segments := (xml.splitOn "<").drop 1
+  if segments.isEmpty then throw "XML has no root element"
+  let final ← segments.foldlM (parseXmlSegment expectedRoot) {}
+  if !final.rootSeen then throw "XML has no root element"
+  if !final.stack.isEmpty then throw "XML has unclosed elements"
+  return final.tokens
 
 def projectUserNoteTokensAux : Bool → List XmlTok → List XmlTok
   | _, [] => []
@@ -105,6 +233,31 @@ theorem projectUserNoteTokens_no_reserved (toks : List XmlTok) :
     (projectUserNoteTokens toks).all (fun tok =>
       tok != .enterReservedNote && tok != .exitReservedNote) = true := by
   exact projectUserNoteTokensAux_no_reserved false toks
+
+theorem projectUserNoteTokensAux_of_no_reserved (inside : Bool) (toks : List XmlTok)
+    (h : toks.all (fun tok => tok != .enterReservedNote && tok != .exitReservedNote) = true) :
+    projectUserNoteTokensAux inside toks = if inside then [] else toks := by
+  induction toks generalizing inside with
+  | nil => simp [projectUserNoteTokensAux]
+  | cons tok rest ih =>
+    simp only [List.all_cons, Bool.and_eq_true] at h
+    rcases h with ⟨⟨hEnter, hExit⟩, hRest⟩
+    cases inside <;> cases tok <;> simp_all [projectUserNoteTokensAux]
+
+theorem projectUserNoteTokens_idempotent (toks : List XmlTok) :
+    projectUserNoteTokens (projectUserNoteTokens toks) = projectUserNoteTokens toks := by
+  apply projectUserNoteTokensAux_of_no_reserved false
+  exact projectUserNoteTokens_no_reserved toks
+
+theorem projectUserNoteTokens_typed_reserved (payload : List XmlTok)
+    (h : payload.all (fun tok => tok != .enterReservedNote && tok != .exitReservedNote) = true) :
+    projectUserNoteTokens (.enterReservedNote :: payload ++ [.exitReservedNote]) = [] := by
+  induction payload with
+  | nil => simp [projectUserNoteTokens, projectUserNoteTokensAux]
+  | cons tok rest ih =>
+    simp only [List.all_cons, Bool.and_eq_true] at h
+    rcases h with ⟨⟨hEnter, hExit⟩, hRest⟩
+    cases tok <;> simp_all [projectUserNoteTokens, projectUserNoteTokensAux]
 
 def popWrapper (w : Wrapper) : List Wrapper → List Wrapper
   | [] => []
@@ -177,12 +330,12 @@ def stepField (r : WalkResult) : XmlTok → WalkResult
     | .invalid => .invalid
   | .fldChar .separate =>
     match r with
-    | .ok [] => .ok []
-    | .ok (_ :: rest) => .ok (true :: rest)
+    | .ok (false :: rest) => .ok (true :: rest)
+    | .ok _ => .invalid
     | .invalid => .invalid
   | .fldChar .endf =>
     match r with
-    | .ok [] => .ok []
+    | .ok [] => .invalid
     | .ok (_ :: rest) => .ok rest
     | .invalid => .invalid
   | .instrText _ =>
@@ -201,7 +354,7 @@ def isEnd : XmlTok → Bool
   | _ => false
 
 def validateFieldStructureTokens (toks : List XmlTok) : Bool :=
-  toks.countP isBegin == toks.countP isEnd && (toks.foldl stepField (.ok [])).isValid
+  toks.countP isBegin == toks.countP isEnd && toks.foldl stepField (.ok []) == .ok []
 
 def tokenText : XmlTok → List Char
   | .text s => s.toList
@@ -261,6 +414,9 @@ structure NamedStoryTriple where
   original : List XmlTok
   revised : List XmlTok
   combined : List XmlTok
+  originalPresent : Bool := true
+  revisedPresent : Bool := true
+  combinedPresent : Bool := true
   deriving Repr, Inhabited
 
 structure StoryReport where
@@ -269,6 +425,9 @@ structure StoryReport where
   originalTokenCount : Nat
   revisedTokenCount : Nat
   combinedTokenCount : Nat
+  originalPresent : Bool
+  revisedPresent : Bool
+  combinedPresent : Bool
   deriving Repr, Inhabited
 
 def checkNamedStory (story : NamedStoryTriple) : StoryReport :=
@@ -276,7 +435,10 @@ def checkNamedStory (story : NamedStoryTriple) : StoryReport :=
     report := comparisonCheckerB story.original story.revised story.combined
     originalTokenCount := story.original.length
     revisedTokenCount := story.revised.length
-    combinedTokenCount := story.combined.length }
+    combinedTokenCount := story.combined.length
+    originalPresent := story.originalPresent
+    revisedPresent := story.revisedPresent
+    combinedPresent := story.combinedPresent }
 
 def checkStoryCollection (stories : List NamedStoryTriple) : List StoryReport :=
   stories.map checkNamedStory
@@ -333,6 +495,11 @@ def reportToJson (r : CheckReport) : Json :=
 def storyReportToJson (r : StoryReport) : Json :=
   Json.mkObj
     [ ("name", toJson r.name)
+    , ("presence", Json.mkObj
+        [ ("original", toJson r.originalPresent)
+        , ("revised", toJson r.revisedPresent)
+        , ("combined", toJson r.combinedPresent)
+        ])
     , ("parsedTokenCounts", Json.mkObj
         [ ("original", toJson r.originalTokenCount)
         , ("revised", toJson r.revisedTokenCount)

--- a/verification/lean/Tier2/XmlTripleChecker.lean
+++ b/verification/lean/Tier2/XmlTripleChecker.lean
@@ -26,6 +26,8 @@ inductive XmlTok
   | instrText (s : String)
   | delInstrText (s : String)
   | fldChar (k : FldCharKind)
+  | enterReservedNote
+  | exitReservedNote
   deriving DecidableEq, Repr, Inhabited
 
 def decodeXmlText (s : String) : String :=
@@ -53,7 +55,10 @@ def tagPayload (segment : String) : String × String :=
   | tag :: rest => (tag, String.intercalate ">" rest)
 
 def tagToken (tag payload : String) : List XmlTok :=
-  if isStartTag tag "w:p" then [.pBreak]
+  if (isStartTag tag "w:footnote" || isStartTag tag "w:endnote") &&
+      (tag.contains "w:id=\"-1\"" || tag.contains "w:id=\"0\"") then [.enterReservedNote]
+  else if isEndTag tag "w:footnote" || isEndTag tag "w:endnote" then [.exitReservedNote]
+  else if isStartTag tag "w:p" then [.pBreak]
   else if isStartTag tag "w:ins" then [.enter .ins]
   else if isEndTag tag "w:ins" then [.exit .ins]
   else if isStartTag tag "w:del" then [.enter .del]
@@ -77,6 +82,29 @@ def parseXmlTokens (xml : String) : List XmlTok :=
   (((xml.splitOn "<").drop 1).map fun segment =>
     let (tag, payload) := tagPayload segment
     tagToken tag payload).flatten
+
+def projectUserNoteTokensAux : Bool → List XmlTok → List XmlTok
+  | _, [] => []
+  | _, .enterReservedNote :: rest => projectUserNoteTokensAux true rest
+  | _, .exitReservedNote :: rest => projectUserNoteTokensAux false rest
+  | true, _ :: rest => projectUserNoteTokensAux true rest
+  | false, tok :: rest => tok :: projectUserNoteTokensAux false rest
+
+def projectUserNoteTokens (toks : List XmlTok) : List XmlTok :=
+  projectUserNoteTokensAux false toks
+
+theorem projectUserNoteTokensAux_no_reserved (inside : Bool) (toks : List XmlTok) :
+    (projectUserNoteTokensAux inside toks).all (fun tok =>
+      tok != .enterReservedNote && tok != .exitReservedNote) = true := by
+  induction toks generalizing inside with
+  | nil => simp [projectUserNoteTokensAux]
+  | cons tok rest ih =>
+    cases inside <;> cases tok <;> simp_all [projectUserNoteTokensAux]
+
+theorem projectUserNoteTokens_no_reserved (toks : List XmlTok) :
+    (projectUserNoteTokens toks).all (fun tok =>
+      tok != .enterReservedNote && tok != .exitReservedNote) = true := by
+  exact projectUserNoteTokensAux_no_reserved false toks
 
 def popWrapper (w : Wrapper) : List Wrapper → List Wrapper
   | [] => []
@@ -228,6 +256,40 @@ def comparisonCheckerB (original revised combined : List XmlTok) : CheckReport :
     combinedHasNoFldCharInsideDel := !hasFldCharInsideDel combined
   }
 
+structure NamedStoryTriple where
+  name : String
+  original : List XmlTok
+  revised : List XmlTok
+  combined : List XmlTok
+  deriving Repr, Inhabited
+
+structure StoryReport where
+  name : String
+  report : CheckReport
+  originalTokenCount : Nat
+  revisedTokenCount : Nat
+  combinedTokenCount : Nat
+  deriving Repr, Inhabited
+
+def checkNamedStory (story : NamedStoryTriple) : StoryReport :=
+  { name := story.name
+    report := comparisonCheckerB story.original story.revised story.combined
+    originalTokenCount := story.original.length
+    revisedTokenCount := story.revised.length
+    combinedTokenCount := story.combined.length }
+
+def checkStoryCollection (stories : List NamedStoryTriple) : List StoryReport :=
+  stories.map checkNamedStory
+
+def storyCollectionPassed (reports : List StoryReport) : Bool :=
+  reports.all (fun report => report.report.passed)
+
+theorem story_collection_sound (stories : List NamedStoryTriple)
+    (h : storyCollectionPassed (checkStoryCollection stories) = true) :
+    ∀ report ∈ checkStoryCollection stories, report.report.passed = true := by
+  intro report hReport
+  simpa [storyCollectionPassed] using List.all_eq_true.mp h report hReport
+
 theorem checker_sound (original revised combined : List XmlTok)
     (h : (comparisonCheckerB original revised combined).passed = true) :
     (comparisonCheckerB original revised combined).acceptPreservesFieldStructure = true ∧
@@ -238,6 +300,21 @@ theorem checker_sound (original revised combined : List XmlTok)
   simp only [CheckReport.passed, Bool.and_eq_true] at h
   rcases h with ⟨⟨⟨⟨hAccept, hReject⟩, hAcceptText⟩, hRejectText⟩, hNoDelField⟩
   exact ⟨hAccept, hReject, hAcceptText, hRejectText, hNoDelField⟩
+
+theorem story_collection_checker_sound (stories : List NamedStoryTriple)
+    (h : storyCollectionPassed (checkStoryCollection stories) = true) :
+    ∀ story ∈ stories,
+      let report := comparisonCheckerB story.original story.revised story.combined
+      report.acceptPreservesFieldStructure = true ∧
+      report.rejectPreservesFieldStructure = true ∧
+      report.acceptTextMatchesRevised = true ∧
+      report.rejectTextMatchesOriginal = true ∧
+      report.combinedHasNoFldCharInsideDel = true := by
+  intro story hStory
+  have hMember : checkNamedStory story ∈ checkStoryCollection stories := by
+    exact List.mem_map.mpr ⟨story, hStory, rfl⟩
+  have hPassed := story_collection_sound stories h (checkNamedStory story) hMember
+  exact checker_sound story.original story.revised story.combined hPassed
 
 def boolJson (b : Bool) : Json := toJson b
 
@@ -251,6 +328,17 @@ def reportToJson (r : CheckReport) : Json :=
         , ("rejectTextMatchesOriginal", boolJson r.rejectTextMatchesOriginal)
         , ("combinedHasNoFldCharInsideDel", boolJson r.combinedHasNoFldCharInsideDel)
         ])
+    ]
+
+def storyReportToJson (r : StoryReport) : Json :=
+  Json.mkObj
+    [ ("name", toJson r.name)
+    , ("parsedTokenCounts", Json.mkObj
+        [ ("original", toJson r.originalTokenCount)
+        , ("revised", toJson r.revisedTokenCount)
+        , ("combined", toJson r.combinedTokenCount)
+        ])
+    , ("report", reportToJson r.report)
     ]
 
 end Tier2.XmlTripleChecker

--- a/verification/lean/lakefile.lean
+++ b/verification/lean/lakefile.lean
@@ -29,8 +29,8 @@ lean_exe leanDifferential where
 lean_exe leanHelperDifferential where
   root := `DifferentialHelpers
 
--- Runtime XML-triple verifier: checks the actual original/revised/combined
--- `word/document.xml` strings emitted by the TypeScript producer.
+-- Runtime fixed-story verifier: extracts the selected WordprocessingML parts
+-- from the actual original/revised/combined DOCX packages and checks them.
 @[default_target]
 lean_exe leanDocxChecker where
   root := `LeanDocxChecker

--- a/verification/registry/lean-xml-checker-coverage.json
+++ b/verification/registry/lean-xml-checker-coverage.json
@@ -26,8 +26,8 @@
     "documentSurfaces": {
       "covered": [
         "word/document.xml text and field-marker token stream (required)",
-        "word/footnotes.xml user-note text and field-marker token stream (optional, symmetric presence)",
-        "word/endnotes.xml user-note text and field-marker token stream (optional, symmetric presence)"
+        "word/footnotes.xml user-note text and field-marker token stream (optional; absent sides modeled as empty when any side is present)",
+        "word/endnotes.xml user-note text and field-marker token stream (optional; absent sides modeled as empty when any side is present)"
       ],
       "outOfScope": [
         "comments.xml",
@@ -51,17 +51,17 @@
       "w:t",
       "w:delText",
       "w:instrText",
-      "w:delInstrText"
-      ,"w:footnote"
-      ,"w:endnote"
+      "w:delInstrText",
+      "w:footnote",
+      "w:endnote"
     ],
     "attributes": [
       "w:fldCharType",
-      "w:id"
+      "w:type"
     ],
     "attributeValues": {
       "w:fldCharType": ["begin", "separate", "end"],
-      "w:id": ["-1", "0"]
+      "w:type": ["separator", "continuationSeparator"]
     },
     "xmlEntitiesDecoded": ["&lt;", "&gt;", "&quot;", "&apos;", "&amp;"]
   },
@@ -70,8 +70,10 @@
     "For every supplied fixed story, rejecting all tracked changes in the compared story yields the same normalized text as the original story.",
     "For every supplied fixed story, accept and reject projections retain structurally valid Word field markers.",
     "For every supplied fixed story, the compared story has no Word field markers inside deletion markup.",
-    "The main story is required and optional note-story presence must match across all three packages.",
-    "Reserved separator and continuation-separator note entries are excluded from user-visible note projection in Lean."
+    "The main story is required; when any optional note story is present, absent sides are checked as empty stories.",
+    "Reserved note entries are selected by namespace-qualified w:type separator or continuationSeparator, independent of numeric ID, and excluded by an idempotent Lean projection.",
+    "Element and attribute prefixes are resolved to namespace URIs, and each fixed part must have its expected WordprocessingML expanded-name root.",
+    "Package and selected-part extraction is bounded by package size, compressed size, expanded size, compression ratio, diagnostics, and streamed-output limits."
   ],
   "ecma376Traceability": [
     {
@@ -101,6 +103,7 @@
     "package-level OPC constraints",
     "field instruction parsing, evaluation, and cached-result correctness, including PAGE and NUMPAGES semantics",
     "OOXML extension and compatibility markup"
+    ,"general-purpose XML canonicalization, DTDs, and CDATA beyond the checked WordprocessingML token surface"
   ],
   "futureObligationQueue": []
 }

--- a/verification/registry/lean-xml-checker-coverage.json
+++ b/verification/registry/lean-xml-checker-coverage.json
@@ -1,22 +1,22 @@
 {
-  "checker": "safe-docx-lean-xml-triple-checker",
-  "protocolVersion": 1,
+  "checker": "safe-docx-lean-fixed-story-checker",
+  "protocolVersion": 2,
   "scope": {
     "inputs": [
       {
         "name": "original",
         "source": "original DOCX package",
-        "packagePart": "word/document.xml"
+        "packageParts": ["word/document.xml", "word/footnotes.xml", "word/endnotes.xml"]
       },
       {
         "name": "revised",
         "source": "revised DOCX package",
-        "packagePart": "word/document.xml"
+        "packageParts": ["word/document.xml", "word/footnotes.xml", "word/endnotes.xml"]
       },
       {
         "name": "compared",
         "source": "safe-docx comparison output DOCX package",
-        "packagePart": "word/document.xml"
+        "packageParts": ["word/document.xml", "word/footnotes.xml", "word/endnotes.xml"]
       }
     ],
     "reconstructionModes": {
@@ -24,11 +24,13 @@
       "outOfScope": ["rebuild"]
     },
     "documentSurfaces": {
-      "covered": ["main document body text and field-marker token stream"],
+      "covered": [
+        "word/document.xml text and field-marker token stream (required)",
+        "word/footnotes.xml user-note text and field-marker token stream (optional, symmetric presence)",
+        "word/endnotes.xml user-note text and field-marker token stream (optional, symmetric presence)"
+      ],
       "outOfScope": [
         "comments.xml",
-        "footnotes.xml",
-        "endnotes.xml",
         "numbering.xml",
         "document relationships",
         "styles.xml",
@@ -50,21 +52,26 @@
       "w:delText",
       "w:instrText",
       "w:delInstrText"
+      ,"w:footnote"
+      ,"w:endnote"
     ],
     "attributes": [
-      "w:fldCharType"
+      "w:fldCharType",
+      "w:id"
     ],
     "attributeValues": {
-      "w:fldCharType": ["begin", "separate", "end"]
+      "w:fldCharType": ["begin", "separate", "end"],
+      "w:id": ["-1", "0"]
     },
     "xmlEntitiesDecoded": ["&lt;", "&gt;", "&quot;", "&apos;", "&amp;"]
   },
   "checkedProperties": [
-    "Accepting all tracked changes in the compared document yields the same normalized text as the revised document.",
-    "Rejecting all tracked changes in the compared document yields the same normalized text as the original document.",
-    "After accepting all tracked changes, Word field markers remain structurally valid.",
-    "After rejecting all tracked changes, Word field markers remain structurally valid.",
-    "The compared document does not place Word field markers inside deletion markup."
+    "For every supplied fixed story, accepting all tracked changes in the compared story yields the same normalized text as the revised story.",
+    "For every supplied fixed story, rejecting all tracked changes in the compared story yields the same normalized text as the original story.",
+    "For every supplied fixed story, accept and reject projections retain structurally valid Word field markers.",
+    "For every supplied fixed story, the compared story has no Word field markers inside deletion markup.",
+    "The main story is required and optional note-story presence must match across all three packages.",
+    "Reserved separator and continuation-separator note entries are excluded from user-visible note projection in Lean."
   ],
   "ecma376Traceability": [
     {
@@ -75,7 +82,7 @@
     {
       "registryId": "ECMA-PART1-17-16-18",
       "section": "Part 1 §17.16.18",
-      "claim": "For original, revised, and compared word/document.xml, the checker recognizes begin, separate, and end markers and requires a valid marker sequence after accepting and rejecting tracked changes."
+      "claim": "For every supplied fixed story, the checker recognizes begin, separate, and end markers and requires a valid marker sequence after accepting and rejecting tracked changes."
     },
     {
       "registryId": "ECMA-PART1-17-16-13",
@@ -89,7 +96,7 @@
     "formatting fidelity",
     "bookmark semantic equivalence",
     "comment anchor and thread integrity",
-    "footnote and endnote definition/reference integrity",
+    "footnote and endnote definition/reference integrity, including reference IDs and relationships",
     "relationship target integrity",
     "package-level OPC constraints",
     "field instruction parsing, evaluation, and cached-result correctness, including PAGE and NUMPAGES semantics",


### PR DESCRIPTION
## Summary

- pass exact original, revised, and compared DOCX package snapshots to protocol v2 and let the compiled Lean process extract the fixed WordprocessingML part allowlist
- model and check generic named story collections with independent field state, required-main and fail-closed optional-part presence semantics
- prove collection-level checker soundness and reserved note separator projection properties, and include both in the union-based axiom audit
- return plain per-story integrity certificates and update the exact coverage ledger, OpenSpec change, and verifier documentation

## Verification

- `lake env lean Tier2/XmlTripleChecker.lean`
- `lake build`
- union-normalized `lake env lean AxiomAudit.lean` matches `expected-axioms.txt`
- zero-`sorry` audit passed
- `npm run build`
- `npm run lint:workspaces` (9 pre-existing warnings after removing one stale warning in the touched test)
- `npm run test:run`: all implementation suites passed; four sandbox-only `tsx` IPC/LibreOffice failures passed on the required unsandboxed rerun
- focused fixed-story verifier suite: 9 passed
- `npm run check:spec-coverage`
- `npm run check:conformance-citations`
- `npm run check:conformance-doc`
- `npm run check:lean-xml-checker-coverage`
- `npm run check:ecma-376-coverage`
- `openspec validate add-lean-fixed-story-verifier --strict`
- `git diff --check`

## Scope

This verifies the required main story and symmetrically present footnote/endnote stories for inplace output. It does not claim relationship or note-reference integrity, comments, headers/footers, rendering equivalence, rebuild verification, package-level OPC conformance, or full ECMA-376 verification. Protocol v2 currently requires `unzip` on PATH; extraction failure is reported as `not_run`.

Fixes: #576
Refs: #547
Refs: #224
Refs: #564
