### PR TITLE
feat(docx-core): verify section story relationships

### DIFF
--- a/packages/docx-core/src/generation/generation-sections-fields.test.ts
+++ b/packages/docx-core/src/generation/generation-sections-fields.test.ts
@@ -72,7 +72,94 @@ async function loadPart(buffer: Buffer, part: string): Promise<Document> {
   return parseXml(xml!);
 }
 
+async function mutatePackage(buffer: Buffer, mutate: (zip: JSZip) => void | Promise<void>): Promise<Buffer> {
+  const zip = await JSZip.loadAsync(buffer);
+  await mutate(zip);
+  return (await zip.generateAsync({ type: 'nodebuffer' })) as Buffer;
+}
+
 describe('Traceability: multi-section documents, headers/footers, and fields', () => {
+  test
+    .conformance(
+      { spec: 'ECMA-376', edition: 5, part: 1, section: '17.10.5' },
+      { spec: 'ECMA-376', edition: 5, part: 1, section: '17.10.2' },
+    )(
+    'resolves header and footer roles through document relationships and target parts',
+    async ({ given, when, then }: AllureBddContext) => {
+      let buffer!: Buffer;
+      await given('two sections using all roles, including a relationship reused by both sections', async () => {
+        const repeated = header('Shared default header');
+        buffer = await generateDocx({
+          sections: [
+            {
+              headers: { first: header('First A'), default: repeated, even: header('Even A') },
+              footers: { first: header('First footer A'), default: header('Default footer A'), even: header('Even footer A') },
+              blocks: [{ kind: 'paragraph', runs: [{ kind: 'text', text: 'Section A' }] }],
+            },
+            {
+              headers: { default: repeated },
+              blocks: [{ kind: 'paragraph', runs: [{ kind: 'text', text: 'Section B' }] }],
+            },
+          ],
+        });
+        buffer = await mutatePackage(buffer, async (zip) => {
+          const xml = await zip.file('word/document.xml')!.async('text');
+          const defaults = [...xml.matchAll(/<w:headerReference[^>]*w:type="default"[^>]*r:id="([^"]+)"[^>]*\/>/g)];
+          expect(defaults).toHaveLength(2);
+          zip.file('word/document.xml', xml.replace(defaults[1]![0], defaults[1]![0].replace(defaults[1]![1]!, defaults[0]![1]!)));
+        });
+      });
+
+      await when('the intact package is checked', async () => {
+        const result = await checkGeneratedPackage(buffer);
+        expect(result.ok, JSON.stringify(result.issues)).toBe(true);
+      });
+
+      await then('missing optional first/even roles remain valid', async () => {
+        const result = await checkGeneratedPackage(await generateDocx(coverBodySpec()));
+        expect(result.ok, JSON.stringify(result.issues)).toBe(true);
+      });
+
+      await then('a header reference bound to a footer relationship is rejected', async () => {
+        const tampered = await mutatePackage(buffer, async (zip) => {
+          const xml = await zip.file('word/_rels/document.xml.rels')!.async('text');
+          zip.file('word/_rels/document.xml.rels', xml.replace('/relationships/header', '/relationships/footer'));
+        });
+        const result = await checkGeneratedPackage(tampered);
+        expect(result.issues.some((issue) => issue.message.includes('sectpr_reference_wrong_relationship_type'))).toBe(true);
+      });
+
+      await then('a footer reference bound to a header relationship is rejected', async () => {
+        const tampered = await mutatePackage(buffer, async (zip) => {
+          const xml = await zip.file('word/_rels/document.xml.rels')!.async('text');
+          zip.file('word/_rels/document.xml.rels', xml.replace('/relationships/footer', '/relationships/header'));
+        });
+        const result = await checkGeneratedPackage(tampered);
+        expect(result.issues.some((issue) => issue.message.includes('sectpr_reference_wrong_relationship_type'))).toBe(true);
+      });
+
+      await then('a reference whose relationship id is absent is rejected', async () => {
+        const tampered = await mutatePackage(buffer, async (zip) => {
+          const xml = await zip.file('word/document.xml')!.async('text');
+          zip.file('word/document.xml', xml.replace(/r:id="rId\d+"/, 'r:id="rIdMissing"'));
+        });
+        const result = await checkGeneratedPackage(tampered);
+        expect(result.issues.some((issue) => issue.message.includes('sectpr_reference_dangling_rid'))).toBe(true);
+      });
+
+      await then('missing and wrong-root target parts are rejected', async () => {
+        const zip = await JSZip.loadAsync(buffer);
+        const headerXml = await zip.file('word/header1.xml')!.async('text');
+        zip.file('word/header1.xml', headerXml.replace('<w:hdr', '<w:ftr').replace('</w:hdr>', '</w:ftr>'));
+        let result = await checkGeneratedPackage((await zip.generateAsync({ type: 'nodebuffer' })) as Buffer);
+        expect(result.issues.some((issue) => issue.message.includes('sectpr_reference_wrong_target_root'))).toBe(true);
+
+        zip.remove('word/header1.xml');
+        result = await checkGeneratedPackage((await zip.generateAsync({ type: 'nodebuffer' })) as Buffer);
+        expect(result.issues.some((issue) => issue.message.includes('sectpr_reference_missing_target_part'))).toBe(true);
+      });
+    },
+  );
   test
     .openspec('[SDX-GEN-021] non-final sections end with a dedicated break paragraph')
     .conformance(

--- a/packages/docx-core/src/generation/generation-sections-fields.test.ts
+++ b/packages/docx-core/src/generation/generation-sections-fields.test.ts
@@ -133,6 +133,51 @@ describe('Traceability: multi-section documents, headers/footers, and fields', (
         expect(result.issues.filter((issue) => issue.type === 'sectpr_duplicate_relationship_id')).toEqual([
           expect.objectContaining({ rid: 'rId1' }),
         ]);
+
+        const reversed = duplicateRelationships.replace(
+          /(<Relationship Id="rId1"[^>]+\/>)(<Relationship Id="rId1"[^>]+\/>)/,
+          '$2$1',
+        );
+        expect(auditSectPr(documentXml, reversed).issues.filter(
+          (issue) => issue.type === 'sectpr_duplicate_relationship_id',
+        )).toEqual([expect.objectContaining({ rid: 'rId1' })]);
+      });
+
+      await then('duplicate header and footer roles within one section are rejected', () => {
+        for (const kind of ['header', 'footer']) {
+          const duplicateDocument = documentXml.replace(
+            /<wp:headerReference[^>]+\/>/,
+            `<wp:${kind}Reference wp:type="default" rel:id="rId1"/><wp:${kind}Reference wp:type="default" rel:id="rId1"/>`,
+          );
+          expect(auditSectPr(duplicateDocument, relationships).issues).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({ type: 'sectpr_duplicate_reference_type' }),
+            ]),
+          );
+        }
+      });
+
+      await then('relative and package-absolute targets normalize dot segments without escaping the package', () => {
+        const parts = new Map([['word/header1.xml', `<wp:hdr xmlns:wp="${w}"/>`]]);
+        for (const target of ['./headers/../header1.xml', '/word/./headers/../header1.xml']) {
+          const normalizedRelationships = relationships.replace('header1.xml', target);
+          expect(auditSectPr(documentXml, normalizedRelationships, parts).ok).toBe(true);
+        }
+
+        const escapingRelationships = relationships.replace('header1.xml', '/../../header1.xml');
+        expect(auditSectPr(documentXml, escapingRelationships, parts).issues).toEqual(
+          expect.arrayContaining([expect.objectContaining({ type: 'sectpr_reference_invalid_target' })]),
+        );
+      });
+
+      await then('fragment-bearing targets are rejected as outside the supported OPC target model', () => {
+        const fragmentRelationships = relationships.replace('header1.xml', 'header1.xml#section');
+        const result = auditSectPr(documentXml, fragmentRelationships, new Map([
+          ['word/header1.xml', `<wp:hdr xmlns:wp="${w}"/>`],
+        ]));
+        expect(result.issues).toEqual(
+          expect.arrayContaining([expect.objectContaining({ type: 'sectpr_reference_invalid_target' })]),
+        );
       });
     },
   );

--- a/packages/docx-core/src/generation/generation-sections-fields.test.ts
+++ b/packages/docx-core/src/generation/generation-sections-fields.test.ts
@@ -101,6 +101,25 @@ describe('Traceability: multi-section documents, headers/footers, and fields', (
         expect(result.stats.referenceCount).toBe(1);
       });
 
+      await then('prefixed package relationships are matched by namespace URI and local name', () => {
+        const prefixedRelationships = `<pr:Relationships xmlns:pr="${pr}"><pr:Relationship Id="rId1" Type="${r}/header" Target="header1.xml"/></pr:Relationships>`;
+        const result = auditSectPr(documentXml, prefixedRelationships, new Map([
+          ['word/header1.xml', `<wp:hdr xmlns:wp="${w}"/>`],
+        ]));
+        expect(result.ok, JSON.stringify(result.issues)).toBe(true);
+        expect(result.stats.referenceCount).toBe(1);
+      });
+
+      await then('a package Relationship prefix bound to the wrong namespace is ignored', () => {
+        const spoofedRelationships = `<pr:Relationships xmlns:pr="urn:not-package-relationships"><pr:Relationship Id="rId1" Type="${r}/header" Target="header1.xml"/></pr:Relationships>`;
+        const result = auditSectPr(documentXml, spoofedRelationships, new Map([
+          ['word/header1.xml', `<wp:hdr xmlns:wp="${w}"/>`],
+        ]));
+        expect(result.issues).toEqual(
+          expect.arrayContaining([expect.objectContaining({ type: 'sectpr_reference_dangling_rid', rid: 'rId1' })]),
+        );
+      });
+
       await then('a familiar prefix bound to the wrong namespace is rejected', () => {
         const result = auditSectPr(documentXml, relationships, new Map([
           ['word/header1.xml', '<w:hdr xmlns:w="urn:not-wordprocessingml"/>'],
@@ -113,6 +132,31 @@ describe('Traceability: multi-section documents, headers/footers, and fields', (
           const invalidDocument = documentXml.replace(' wp:type="default"', typeAttribute);
           const result = auditSectPr(invalidDocument, relationships);
           expect(result.issues.map((issue) => issue.type)).toContain('sectpr_reference_invalid_type');
+        }
+      });
+
+      await then('missing and invalid footer roles are rejected', () => {
+        const footerDocument = documentXml.replace('headerReference', 'footerReference');
+        const footerRelationships = relationships.replace(`${r}/header`, `${r}/footer`).replace('header1.xml', 'footer1.xml');
+        for (const typeAttribute of ['', ' wp:type="odd"']) {
+          const invalidDocument = footerDocument.replace(' wp:type="default"', typeAttribute);
+          const result = auditSectPr(invalidDocument, footerRelationships);
+          expect(result.issues).toEqual(
+            expect.arrayContaining([expect.objectContaining({ type: 'sectpr_reference_invalid_type' })]),
+          );
+        }
+      });
+
+      await then('external header and footer relationship targets are rejected', () => {
+        for (const kind of ['header', 'footer']) {
+          const referenceDocument = documentXml.replace('headerReference', `${kind}Reference`);
+          const externalRelationships = relationships
+            .replace(`${r}/header`, `${r}/${kind}`)
+            .replace('Target="header1.xml"', 'Target="https://example.test/story.xml" TargetMode="External"');
+          const result = auditSectPr(referenceDocument, externalRelationships);
+          expect(result.issues).toEqual(
+            expect.arrayContaining([expect.objectContaining({ type: 'sectpr_reference_wrong_relationship_type', rid: 'rId1' })]),
+          );
         }
       });
 

--- a/packages/docx-core/src/generation/generation-sections-fields.test.ts
+++ b/packages/docx-core/src/generation/generation-sections-fields.test.ts
@@ -4,6 +4,7 @@ import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
 import { childElements } from '../primitives/dom-helpers.js';
 import { readZipText } from '../primitives/zip.js';
 import { parseXml } from '../primitives/xml.js';
+import { auditSectPr } from '../primitives/sectPrAudit.js';
 import { generateDocx } from './compile.js';
 import { checkGeneratedPackage } from './structural-checks.js';
 import type { DocumentSpec, HeaderFooterSpec } from './types.js';
@@ -79,6 +80,62 @@ async function mutatePackage(buffer: Buffer, mutate: (zip: JSZip) => void | Prom
 }
 
 describe('Traceability: multi-section documents, headers/footers, and fields', () => {
+  test
+    .conformance(
+      { spec: 'ECMA-376', edition: 5, part: 1, section: '17.10.5' },
+      { spec: 'ECMA-376', edition: 5, part: 1, section: '17.10.2' },
+    )(
+    'validates expanded names, explicit roles, absolute targets, and unique relationship ids',
+    async ({ then }: AllureBddContext) => {
+      const w = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+      const r = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+      const pr = 'http://schemas.openxmlformats.org/package/2006/relationships';
+      const documentXml = `<wp:document xmlns:wp="${w}" xmlns:rel="${r}"><wp:body><wp:sectPr><wp:headerReference wp:type="default" rel:id="rId1"/></wp:sectPr></wp:body></wp:document>`;
+      const relationships = `<Relationships xmlns="${pr}"><Relationship Id="rId1" Type="${r}/header" Target="header1.xml"/></Relationships>`;
+
+      await then('valid alternate prefixes are accepted by namespace URI and local name', () => {
+        const result = auditSectPr(documentXml, relationships, new Map([
+          ['word/header1.xml', `<alt:hdr xmlns:alt="${w}"/>`],
+        ]));
+        expect(result.ok, JSON.stringify(result.issues)).toBe(true);
+        expect(result.stats.referenceCount).toBe(1);
+      });
+
+      await then('a familiar prefix bound to the wrong namespace is rejected', () => {
+        const result = auditSectPr(documentXml, relationships, new Map([
+          ['word/header1.xml', '<w:hdr xmlns:w="urn:not-wordprocessingml"/>'],
+        ]));
+        expect(result.issues.map((issue) => issue.type)).toContain('sectpr_reference_wrong_target_root');
+      });
+
+      await then('missing and invalid reference roles are rejected', () => {
+        for (const typeAttribute of ['', ' wp:type="odd"']) {
+          const invalidDocument = documentXml.replace(' wp:type="default"', typeAttribute);
+          const result = auditSectPr(invalidDocument, relationships);
+          expect(result.issues.map((issue) => issue.type)).toContain('sectpr_reference_invalid_type');
+        }
+      });
+
+      await then('a package-absolute relationship target resolves from the package root', () => {
+        const absoluteRelationships = relationships.replace('Target="header1.xml"', 'Target="/word/header1.xml"');
+        const result = auditSectPr(documentXml, absoluteRelationships, new Map([
+          ['word/header1.xml', `<wp:hdr xmlns:wp="${w}"/>`],
+        ]));
+        expect(result.ok, JSON.stringify(result.issues)).toBe(true);
+      });
+
+      await then('duplicate relationship ids are rejected deterministically', () => {
+        const duplicateRelationships = relationships.replace(
+          '</Relationships>',
+          `<Relationship Id="rId1" Type="${r}/footer" Target="footer1.xml"/></Relationships>`,
+        );
+        const result = auditSectPr(documentXml, duplicateRelationships);
+        expect(result.issues.filter((issue) => issue.type === 'sectpr_duplicate_relationship_id')).toEqual([
+          expect.objectContaining({ rid: 'rId1' }),
+        ]);
+      });
+    },
+  );
   test
     .conformance(
       { spec: 'ECMA-376', edition: 5, part: 1, section: '17.10.5' },

--- a/packages/docx-core/src/generation/structural-checks.ts
+++ b/packages/docx-core/src/generation/structural-checks.ts
@@ -208,7 +208,7 @@ function checkSectPr(contents: Map<string, string>): StructuralIssue[] {
   if (!documentXml) {
     return [{ check: 'sectpr', part: 'word/document.xml', message: 'Part is missing' }];
   }
-  const audit = auditSectPr(documentXml, contents.get('word/_rels/document.xml.rels') ?? null);
+  const audit = auditSectPr(documentXml, contents.get('word/_rels/document.xml.rels') ?? null, contents);
   for (const issue of audit.issues) {
     issues.push({ check: 'sectpr', part: 'word/document.xml', message: `${issue.type}: ${issue.message}` });
   }

--- a/packages/docx-core/src/primitives/sectPrAudit.ts
+++ b/packages/docx-core/src/primitives/sectPrAudit.ts
@@ -10,9 +10,11 @@ export type SectPrIssueType =
   | 'sectpr_in_ppr_without_paragraph_parent'
   | 'sectpr_reference_missing_rid'
   | 'sectpr_reference_invalid_type'
+  | 'sectpr_duplicate_reference_type'
   | 'sectpr_reference_dangling_rid'
   | 'sectpr_duplicate_relationship_id'
   | 'sectpr_reference_wrong_relationship_type'
+  | 'sectpr_reference_invalid_target'
   | 'sectpr_reference_missing_target_part'
   | 'sectpr_reference_wrong_target_root';
 
@@ -112,14 +114,19 @@ function collectRelationships(documentRelsXml: string | null | undefined): Relat
   }
 }
 
-function resolveDocumentTarget(target: string): string {
+function resolveDocumentTarget(target: string): string | undefined {
+  // Part-name fragments are outside this audit's explicit OPC target model.
+  if (target.includes('#')) return undefined;
   const parts = target.startsWith('/') ? [] : ['word'];
   for (const segment of target.split('/')) {
     if (!segment || segment === '.') continue;
-    if (segment === '..') parts.pop();
+    if (segment === '..') {
+      if (parts.length === 0) return undefined;
+      parts.pop();
+    }
     else parts.push(segment);
   }
-  return parts.join('/');
+  return parts.length > 0 ? parts.join('/') : undefined;
 }
 
 function getRid(ref: Element): string | undefined {
@@ -206,6 +213,7 @@ export function auditSectPr(
   let referenceCount = 0;
 
   for (const sectPr of sectPrNodes) {
+    const seenReferenceTypes = new Set<string>();
     const parent = sectPr.parentNode;
     const parentTag = parent && parent.nodeType === 1 ? (parent as Element).tagName : '';
 
@@ -242,6 +250,17 @@ export function auditSectPr(
           path: nodePath(child),
           message: `${child.tagName} has missing or invalid w:type '${referenceType || '(missing)'}'; expected first, default, or even`,
         });
+      } else {
+        const referenceKey = `${isHeaderReference ? 'header' : 'footer'}:${referenceType}`;
+        if (seenReferenceTypes.has(referenceKey)) {
+          issues.push({
+            type: 'sectpr_duplicate_reference_type',
+            path: nodePath(child),
+            message: `${child.tagName} duplicates the '${referenceType}' role within this w:sectPr`,
+          });
+        } else {
+          seenReferenceTypes.add(referenceKey);
+        }
       }
       const rid = getRid(child);
       if (!rid) {
@@ -278,6 +297,15 @@ export function auditSectPr(
 
       if (packageParts) {
         const targetName = resolveDocumentTarget(relationship.target);
+        if (!targetName) {
+          issues.push({
+            type: 'sectpr_reference_invalid_target',
+            path: nodePath(child),
+            message: `${child.tagName} relationship '${rid}' has unsupported or malformed target '${relationship.target}'`,
+            rid,
+          });
+          continue;
+        }
         const targetXml = packageParts.get(targetName);
         if (!targetXml) {
           issues.push({

--- a/packages/docx-core/src/primitives/sectPrAudit.ts
+++ b/packages/docx-core/src/primitives/sectPrAudit.ts
@@ -9,7 +9,9 @@ export type SectPrIssueType =
   | 'sectpr_invalid_parent'
   | 'sectpr_in_ppr_without_paragraph_parent'
   | 'sectpr_reference_missing_rid'
+  | 'sectpr_reference_invalid_type'
   | 'sectpr_reference_dangling_rid'
+  | 'sectpr_duplicate_relationship_id'
   | 'sectpr_reference_wrong_relationship_type'
   | 'sectpr_reference_missing_target_part'
   | 'sectpr_reference_wrong_target_root';
@@ -37,7 +39,7 @@ function elementSiblingIndex(node: Element): number {
   if (!parent) return 1;
   let idx = 0;
   for (const sibling of childElements(parent as Element)) {
-    if (sibling.tagName === node.tagName) {
+    if (sibling.namespaceURI === node.namespaceURI && sibling.localName === node.localName) {
       idx++;
     }
     if (sibling === node) {
@@ -67,19 +69,36 @@ interface DocumentRelationship {
   external: boolean;
 }
 
-function collectRelationships(documentRelsXml: string | null | undefined): Map<string, DocumentRelationship> {
+interface RelationshipCollection {
+  relationships: Map<string, DocumentRelationship>;
+  duplicateIds: string[];
+}
+
+const RELATIONSHIPS_NS = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const REFERENCE_TYPES = new Set(['first', 'default', 'even']);
+
+function isWmlElement(element: Element, localName: string): boolean {
+  return element.namespaceURI === OOXML.W_NS && element.localName === localName;
+}
+
+function collectRelationships(documentRelsXml: string | null | undefined): RelationshipCollection {
   if (!documentRelsXml) {
-    return new Map();
+    return { relationships: new Map(), duplicateIds: [] };
   }
 
   try {
     const relDoc = parseXml(documentRelsXml);
     const relationshipsById = new Map<string, DocumentRelationship>();
-    const relationships = relDoc.getElementsByTagName('Relationship');
+    const duplicateIds = new Set<string>();
+    const relationships = relDoc.getElementsByTagNameNS(RELATIONSHIPS_NS, 'Relationship');
     for (let i = 0; i < relationships.length; i++) {
       const rel = relationships.item(i);
       const id = rel?.getAttribute('Id');
       if (id) {
+        if (relationshipsById.has(id)) {
+          duplicateIds.add(id);
+          continue;
+        }
         relationshipsById.set(id, {
           type: rel?.getAttribute('Type') ?? '',
           target: rel?.getAttribute('Target') ?? '',
@@ -87,14 +106,14 @@ function collectRelationships(documentRelsXml: string | null | undefined): Map<s
         });
       }
     }
-    return relationshipsById;
+    return { relationships: relationshipsById, duplicateIds: [...duplicateIds].sort() };
   } catch {
-    return new Map();
+    return { relationships: new Map(), duplicateIds: [] };
   }
 }
 
 function resolveDocumentTarget(target: string): string {
-  const parts = ['word'];
+  const parts = target.startsWith('/') ? [] : ['word'];
   for (const segment of target.split('/')) {
     if (!segment || segment === '.') continue;
     if (segment === '..') parts.pop();
@@ -104,12 +123,7 @@ function resolveDocumentTarget(target: string): string {
 }
 
 function getRid(ref: Element): string | undefined {
-  return (
-    ref.getAttribute('r:id') ??
-    ref.getAttributeNS(OOXML.R_NS, 'id') ??
-    ref.getAttribute('id') ??
-    undefined
-  );
+  return ref.getAttributeNS(OOXML.R_NS, 'id') || undefined;
 }
 
 /**
@@ -127,10 +141,20 @@ export function auditSectPr(
   packageParts?: ReadonlyMap<string, string>,
 ): SectPrAuditSummary {
   const issues: SectPrAuditIssue[] = [];
-  const relationships = collectRelationships(documentRelsXml);
+  const relationshipCollection = collectRelationships(documentRelsXml);
+  const relationships = relationshipCollection.relationships;
+
+  for (const id of relationshipCollection.duplicateIds) {
+    issues.push({
+      type: 'sectpr_duplicate_relationship_id',
+      path: 'Relationships',
+      message: `document.xml.rels contains duplicate relationship id '${id}'`,
+      rid: id,
+    });
+  }
 
   const doc = parseXml(documentXml);
-  const body = doc.getElementsByTagName('w:body').item(0) as Element | null;
+  const body = doc.getElementsByTagNameNS(OOXML.W_NS, 'body').item(0) as Element | null;
 
   if (!body) {
     return {
@@ -152,7 +176,7 @@ export function auditSectPr(
   }
 
   const bodyChildren = childElements(body);
-  const bodyLevelSectPrNodes = bodyChildren.filter((child) => child.tagName === 'w:sectPr');
+  const bodyLevelSectPrNodes = bodyChildren.filter((child) => isWmlElement(child, 'sectPr'));
 
   if (bodyLevelSectPrNodes.length > 1) {
     for (const sectPr of bodyLevelSectPrNodes) {
@@ -177,7 +201,7 @@ export function auditSectPr(
     }
   }
 
-  const sectPrNodes = Array.from(doc.getElementsByTagName('w:sectPr'));
+  const sectPrNodes = Array.from(doc.getElementsByTagNameNS(OOXML.W_NS, 'sectPr'));
   let paragraphLevelSectPrCount = 0;
   let referenceCount = 0;
 
@@ -185,18 +209,17 @@ export function auditSectPr(
     const parent = sectPr.parentNode;
     const parentTag = parent && parent.nodeType === 1 ? (parent as Element).tagName : '';
 
-    if (parentTag === 'w:pPr') {
+    if (parent && parent.nodeType === 1 && isWmlElement(parent as Element, 'pPr')) {
       paragraphLevelSectPrCount++;
       const grand = (parent as Element).parentNode;
-      const grandTag = grand && grand.nodeType === 1 ? (grand as Element).tagName : '';
-      if (grandTag !== 'w:p') {
+      if (!(grand && grand.nodeType === 1 && isWmlElement(grand as Element, 'p'))) {
         issues.push({
           type: 'sectpr_in_ppr_without_paragraph_parent',
           path: nodePath(sectPr),
           message: 'w:sectPr in w:pPr does not have w:p as parent',
         });
       }
-    } else if (parentTag !== 'w:body') {
+    } else if (!(parent && parent.nodeType === 1 && isWmlElement(parent as Element, 'body'))) {
       issues.push({
         type: 'sectpr_invalid_parent',
         path: nodePath(sectPr),
@@ -205,11 +228,21 @@ export function auditSectPr(
     }
 
     for (const child of childElements(sectPr)) {
-      if (child.tagName !== 'w:headerReference' && child.tagName !== 'w:footerReference') {
+      const isHeaderReference = isWmlElement(child, 'headerReference');
+      const isFooterReference = isWmlElement(child, 'footerReference');
+      if (!isHeaderReference && !isFooterReference) {
         continue;
       }
 
       referenceCount++;
+      const referenceType = child.getAttributeNS(OOXML.W_NS, 'type') ?? '';
+      if (!REFERENCE_TYPES.has(referenceType)) {
+        issues.push({
+          type: 'sectpr_reference_invalid_type',
+          path: nodePath(child),
+          message: `${child.tagName} has missing or invalid w:type '${referenceType || '(missing)'}'; expected first, default, or even`,
+        });
+      }
       const rid = getRid(child);
       if (!rid) {
         issues.push({
@@ -231,7 +264,7 @@ export function auditSectPr(
         continue;
       }
 
-      const kind = child.tagName === 'w:headerReference' ? 'header' : 'footer';
+      const kind = isHeaderReference ? 'header' : 'footer';
       const expectedType = `http://schemas.openxmlformats.org/officeDocument/2006/relationships/${kind}`;
       if (relationship.type !== expectedType || relationship.external) {
         issues.push({
@@ -256,13 +289,13 @@ export function auditSectPr(
           continue;
         }
         try {
-          const expectedRoot = kind === 'header' ? 'w:hdr' : 'w:ftr';
-          const actualRoot = parseXml(targetXml).documentElement?.tagName;
-          if (actualRoot !== expectedRoot) {
+          const expectedRoot = kind === 'header' ? 'hdr' : 'ftr';
+          const actualRoot = parseXml(targetXml).documentElement;
+          if (!actualRoot || !isWmlElement(actualRoot, expectedRoot)) {
             issues.push({
               type: 'sectpr_reference_wrong_target_root',
               path: nodePath(child),
-              message: `${child.tagName} relationship '${rid}' targets <${actualRoot ?? 'nothing'}>, expected <${expectedRoot}>`,
+              message: `${child.tagName} relationship '${rid}' targets <${actualRoot?.tagName ?? 'nothing'}>, expected WordprocessingML <${expectedRoot}>`,
               rid,
             });
           }

--- a/packages/docx-core/src/primitives/sectPrAudit.ts
+++ b/packages/docx-core/src/primitives/sectPrAudit.ts
@@ -9,7 +9,10 @@ export type SectPrIssueType =
   | 'sectpr_invalid_parent'
   | 'sectpr_in_ppr_without_paragraph_parent'
   | 'sectpr_reference_missing_rid'
-  | 'sectpr_reference_dangling_rid';
+  | 'sectpr_reference_dangling_rid'
+  | 'sectpr_reference_wrong_relationship_type'
+  | 'sectpr_reference_missing_target_part'
+  | 'sectpr_reference_wrong_target_root';
 
 export interface SectPrAuditIssue {
   type: SectPrIssueType;
@@ -58,26 +61,46 @@ function nodePath(node: Element): string {
   return parts.reverse().join('/');
 }
 
-function collectRelationshipIds(documentRelsXml: string | null | undefined): Set<string> {
+interface DocumentRelationship {
+  type: string;
+  target: string;
+  external: boolean;
+}
+
+function collectRelationships(documentRelsXml: string | null | undefined): Map<string, DocumentRelationship> {
   if (!documentRelsXml) {
-    return new Set<string>();
+    return new Map();
   }
 
   try {
     const relDoc = parseXml(documentRelsXml);
-    const ids = new Set<string>();
+    const relationshipsById = new Map<string, DocumentRelationship>();
     const relationships = relDoc.getElementsByTagName('Relationship');
     for (let i = 0; i < relationships.length; i++) {
       const rel = relationships.item(i);
       const id = rel?.getAttribute('Id');
       if (id) {
-        ids.add(id);
+        relationshipsById.set(id, {
+          type: rel?.getAttribute('Type') ?? '',
+          target: rel?.getAttribute('Target') ?? '',
+          external: rel?.getAttribute('TargetMode') === 'External',
+        });
       }
     }
-    return ids;
+    return relationshipsById;
   } catch {
-    return new Set<string>();
+    return new Map();
   }
+}
+
+function resolveDocumentTarget(target: string): string {
+  const parts = ['word'];
+  for (const segment of target.split('/')) {
+    if (!segment || segment === '.') continue;
+    if (segment === '..') parts.pop();
+    else parts.push(segment);
+  }
+  return parts.join('/');
 }
 
 function getRid(ref: Element): string | undefined {
@@ -89,9 +112,22 @@ function getRid(ref: Element): string | undefined {
   );
 }
 
-export function auditSectPr(documentXml: string, documentRelsXml?: string | null): SectPrAuditSummary {
+/**
+ * Audit section placement and header/footer bindings. When package parts are
+ * supplied, every typed reference is followed through document.xml.rels to a
+ * target part whose root must match the reference kind.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.10.5
+ * @conformance ECMA-376 edition 5, Part 1 § 17.10.2
+ * @see https://github.com/UseJunior/safe-docx/issues/560
+ */
+export function auditSectPr(
+  documentXml: string,
+  documentRelsXml?: string | null,
+  packageParts?: ReadonlyMap<string, string>,
+): SectPrAuditSummary {
   const issues: SectPrAuditIssue[] = [];
-  const relIds = collectRelationshipIds(documentRelsXml);
+  const relationships = collectRelationships(documentRelsXml);
 
   const doc = parseXml(documentXml);
   const body = doc.getElementsByTagName('w:body').item(0) as Element | null;
@@ -184,13 +220,60 @@ export function auditSectPr(documentXml: string, documentRelsXml?: string | null
         continue;
       }
 
-      if (relIds.size > 0 && !relIds.has(rid)) {
+      const relationship = relationships.get(rid);
+      if (!relationship) {
         issues.push({
           type: 'sectpr_reference_dangling_rid',
           path: nodePath(child),
           message: `${child.tagName} references missing relationship id '${rid}'`,
           rid,
         });
+        continue;
+      }
+
+      const kind = child.tagName === 'w:headerReference' ? 'header' : 'footer';
+      const expectedType = `http://schemas.openxmlformats.org/officeDocument/2006/relationships/${kind}`;
+      if (relationship.type !== expectedType || relationship.external) {
+        issues.push({
+          type: 'sectpr_reference_wrong_relationship_type',
+          path: nodePath(child),
+          message: `${child.tagName} relationship '${rid}' has type '${relationship.type || '(missing)'}'`,
+          rid,
+        });
+        continue;
+      }
+
+      if (packageParts) {
+        const targetName = resolveDocumentTarget(relationship.target);
+        const targetXml = packageParts.get(targetName);
+        if (!targetXml) {
+          issues.push({
+            type: 'sectpr_reference_missing_target_part',
+            path: nodePath(child),
+            message: `${child.tagName} relationship '${rid}' resolves to missing part '${targetName}'`,
+            rid,
+          });
+          continue;
+        }
+        try {
+          const expectedRoot = kind === 'header' ? 'w:hdr' : 'w:ftr';
+          const actualRoot = parseXml(targetXml).documentElement?.tagName;
+          if (actualRoot !== expectedRoot) {
+            issues.push({
+              type: 'sectpr_reference_wrong_target_root',
+              path: nodePath(child),
+              message: `${child.tagName} relationship '${rid}' targets <${actualRoot ?? 'nothing'}>, expected <${expectedRoot}>`,
+              rid,
+            });
+          }
+        } catch {
+          issues.push({
+            type: 'sectpr_reference_wrong_target_root',
+            path: nodePath(child),
+            message: `${child.tagName} relationship '${rid}' targets malformed XML`,
+            rid,
+          });
+        }
       }
     }
   }

--- a/spec-compliance/CONFORMANCE.md
+++ b/spec-compliance/CONFORMANCE.md
@@ -326,6 +326,12 @@ via `setAttributeNS`) resolves in the document's relationships. References
 lead the `w:sectPr` child sequence; the structural validator rejects
 dangling or missing ids.
 
+The package audit follows each reference through `document.xml.rels`, checks
+the header relationship type, resolves its target part, and requires a
+`w:hdr` root. Relationship reuse across sections is accepted. Pagination,
+role inheritance when a reference is absent, and reader rendering are not
+evaluated.
+
 ### ECMA-PART1-17-10-2 — w:footerReference binding
 
 - **Edition:** ECMA-376 5
@@ -336,6 +342,10 @@ dangling or missing ids.
 Footer references follow the same typed-binding discipline as header
 references, emitted in a fixed first/default/even order for deterministic
 output.
+
+The package audit applies the corresponding footer relationship and `w:ftr`
+target checks. It verifies explicit bindings only; it does not predict page
+assignment or consumer fallback behavior for omitted roles.
 
 ### ECMA-PART1-17-10-6 — w:titlePg first-page header/footer switch
 
@@ -940,6 +950,16 @@ The compiled Lean checker independently covers fixed-story text projection and
 field-marker structure in `word/footnotes.xml` and `word/endnotes.xml`; it does
 not cover any of those excluded reference, relationship, anchor, or thread
 semantics and does not read `word/comments.xml`.
+
+Within Part 1 §17.6 and §17.10, safe-docx targets generated section-property
+placement, explicit page-setup values, and explicit first/default/even
+header/footer bindings. The package audit resolves those bindings through the
+main-document relationships and checks the target story root. It does not
+implement pagination, section inheritance or omitted-role fallback semantics,
+style inheritance, layout, rendering, or assertions about arbitrary consumer
+behavior. Comparison preserves ancillary parts according to its documented
+in-place/rebuild rules; this registry does not claim semantic comparison of
+header or footer content across document versions.
 
 A source `@conformance` JSDoc tag that points at one of these Non-Goal IDs fails
 the citation lint. For a deliberate divergence *inside a targeted section*, use

--- a/spec-compliance/CONFORMANCE.md
+++ b/spec-compliance/CONFORMANCE.md
@@ -328,7 +328,11 @@ dangling or missing ids.
 
 The package audit follows each reference through `document.xml.rels`, checks
 the header relationship type, resolves its target part, and requires a
-`w:hdr` root. Relationship reuse across sections is accepted. Pagination,
+`w:hdr` root. Duplicate roles within one section, duplicate relationship ids,
+targets that escape the package root, and fragment-bearing targets are
+rejected. Relative and package-absolute targets are normalized before lookup;
+URI-fragment semantics are outside this audit's supported OPC target model.
+Relationship reuse across sections is accepted. Pagination,
 role inheritance when a reference is absent, and reader rendering are not
 evaluated.
 

--- a/spec-compliance/registry/ecma-376.md
+++ b/spec-compliance/registry/ecma-376.md
@@ -312,6 +312,7 @@ section: "17.10.5"
 url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
 schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:headerReference
 verifiedBy:
+  packages/docx-core/src/primitives/sectPrAudit.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts
 ```
 
 Each declared header slot (first/default/even) becomes its own part bound
@@ -319,6 +320,12 @@ through a typed `w:headerReference` whose `r:id` (written namespace-aware
 via `setAttributeNS`) resolves in the document's relationships. References
 lead the `w:sectPr` child sequence; the structural validator rejects
 dangling or missing ids.
+
+The package audit follows each reference through `document.xml.rels`, checks
+the header relationship type, resolves its target part, and requires a
+`w:hdr` root. Relationship reuse across sections is accepted. Pagination,
+role inheritance when a reference is absent, and reader rendering are not
+evaluated.
 
 ## [ECMA-PART1-17-10-2] w:footerReference binding
 
@@ -329,11 +336,16 @@ section: "17.10.2"
 url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
 schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:footerReference
 verifiedBy:
+  packages/docx-core/src/primitives/sectPrAudit.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts
 ```
 
 Footer references follow the same typed-binding discipline as header
 references, emitted in a fixed first/default/even order for deterministic
 output.
+
+The package audit applies the corresponding footer relationship and `w:ftr`
+target checks. It verifies explicit bindings only; it does not predict page
+assignment or consumer fallback behavior for omitted roles.
 
 ## [ECMA-PART1-17-10-6] w:titlePg first-page header/footer switch
 
@@ -1120,6 +1132,16 @@ The compiled Lean checker independently covers fixed-story text projection and
 field-marker structure in `word/footnotes.xml` and `word/endnotes.xml`; it does
 not cover any of those excluded reference, relationship, anchor, or thread
 semantics and does not read `word/comments.xml`.
+
+Within Part 1 §17.6 and §17.10, safe-docx targets generated section-property
+placement, explicit page-setup values, and explicit first/default/even
+header/footer bindings. The package audit resolves those bindings through the
+main-document relationships and checks the target story root. It does not
+implement pagination, section inheritance or omitted-role fallback semantics,
+style inheritance, layout, rendering, or assertions about arbitrary consumer
+behavior. Comparison preserves ancillary parts according to its documented
+in-place/rebuild rules; this registry does not claim semantic comparison of
+header or footer content across document versions.
 
 A source `@conformance` JSDoc tag that points at one of these Non-Goal IDs fails
 the citation lint. For a deliberate divergence *inside a targeted section*, use

--- a/spec-compliance/registry/ecma-376.md
+++ b/spec-compliance/registry/ecma-376.md
@@ -323,7 +323,11 @@ dangling or missing ids.
 
 The package audit follows each reference through `document.xml.rels`, checks
 the header relationship type, resolves its target part, and requires a
-`w:hdr` root. Relationship reuse across sections is accepted. Pagination,
+`w:hdr` root. Duplicate roles within one section, duplicate relationship ids,
+targets that escape the package root, and fragment-bearing targets are
+rejected. Relative and package-absolute targets are normalized before lookup;
+URI-fragment semantics are outside this audit's supported OPC target model.
+Relationship reuse across sections is accepted. Pagination,
 role inheritance when a reference is absent, and reader rendering are not
 evaluated.
 


### PR DESCRIPTION
## Summary
- follow every explicit first/default/even header and footer reference through document.xml.rels
- reject wrong relationship kinds, missing target parts, and target parts with the wrong WordprocessingML root
- add conformance evidence for multiple sections, relationship reuse, absent optional roles, dangling ids, role mismatches, and malformed targets
- document the boundary around pagination, inheritance/fallback, rendering, and semantic header/footer comparison

## OpenSpec
No new change proposal is required. The archived docx-generation specification already requires fully wired header/footer parts; this PR closes an enforcement gap in that existing requirement.

## Verification
- npm run build
- npm run lint:workspaces
- npm run test:run
- npm run check:spec-coverage
- npm run check:conformance-citations
- npm run check:conformance-doc
- focused generation-sections-fields suite: 9 passed

Fixes: #560
Refs: #547