### PR TITLE
fix(release): let a partially-published tag be recovered by re-run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,15 +119,34 @@ jobs:
 
       - name: Guard against duplicate publish
         run: |
+          # A partially-published tag must stay recoverable. The publish step
+          # aborts on the first failure, so a new package in the suite (whose
+          # name does not exist on npm yet, and which OIDC trusted publishing
+          # therefore cannot bootstrap) leaves the earlier packages published
+          # and the rest not — see the v0.16.0 run, where docx-core landed and
+          # docx-compare hit ENEEDAUTH. Failing here on *any* already-published
+          # package made that state unrecoverable by re-run. Fail only when the
+          # whole suite is already on npm, which is the real duplicate release.
           TAG_REF="${RELEASE_TAG:-$GITHUB_REF_NAME}"
           VERSION="${TAG_REF#v}"
+          published=0
+          total=0
           for pkg in @usejunior/docx-core @usejunior/docx-compare @usejunior/odf-core @usejunior/docx-mcp @usejunior/google-docs-core @usejunior/safe-docx; do
+            total=$((total + 1))
             if npm view "$pkg@$VERSION" version >/dev/null 2>&1; then
-              echo "$pkg@$VERSION already exists on npm."
-              exit 1
+              echo "$pkg@$VERSION already exists on npm — will be skipped."
+              published=$((published + 1))
+            else
+              echo "$pkg@$VERSION not yet published."
             fi
-            echo "$pkg@$VERSION not yet published."
           done
+          if [ "$published" -eq "$total" ]; then
+            echo "Every package in the suite is already published at $VERSION; nothing to release."
+            exit 1
+          fi
+          if [ "$published" -gt 0 ]; then
+            echo "::warning::Resuming a partial release: $published/$total packages already published at $VERSION."
+          fi
 
       - name: Test workspaces
         run: npm run test
@@ -263,9 +282,13 @@ jobs:
           for entry in "@usejunior/docx-core:packages/docx-core" "@usejunior/docx-compare:packages/docx-compare" "@usejunior/odf-core:packages/odf-core" "@usejunior/docx-mcp:packages/docx-mcp" "@usejunior/google-docs-core:packages/google-docs-core" "@usejunior/safe-docx:packages/safe-docx"; do
             PKG_NAME="${entry%%:*}"
             PKG_DIR="${entry##*:}"
+            # Skip rather than abort: a re-run of a partially-published tag must
+            # be able to walk past what already landed and publish the rest.
+            # Publishing is still all-or-nothing per package — npm rejects a
+            # duplicate version — so skipping cannot overwrite anything.
             if npm view "$PKG_NAME@$VERSION" version >/dev/null 2>&1; then
-              echo "$PKG_NAME@$VERSION already exists on npm."
-              exit 1
+              echo "$PKG_NAME@$VERSION already exists on npm — skipping."
+              continue
             fi
             echo "Publishing $PKG_NAME from $PKG_DIR"
             (cd "$PKG_DIR" && npm publish --access public --provenance)


### PR DESCRIPTION
## Summary

The `v0.16.0` release is currently wedged in a half-published state, and the release workflow cannot recover it by re-run. This makes it recoverable.

## What happened

[Run 28955844572](https://github.com/UseJunior/safe-docx/actions/runs/28955844572) (tag `v0.16.0`, 2026-07-08) passed preflight, then failed 52s into the publish job:

```
Publishing @usejunior/docx-core from packages/docx-core     ✅
Publishing @usejunior/docx-compare from packages/docx-compare
npm error code ENEEDAUTH
```

`@usejunior/docx-compare` is new to the suite in 0.16.0. npm OIDC trusted publishing matches a trusted-publisher config on an **existing** package, so it cannot bootstrap a package name that has never been published — and the publish step deliberately runs token-free (`unset NODE_AUTH_TOKEN`). The loop aborted on first failure.

Resulting registry state:

| package | version |
|---|---|
| `@usejunior/docx-core` | **0.16.0** |
| `@usejunior/docx-compare` | not published |
| `@usejunior/docx-mcp` | 0.15.0 |
| `@usejunior/safe-docx` | 0.15.0 |
| `@usejunior/odf-core` | 0.15.0 |
| `@usejunior/google-docs-core` | 0.15.0 |

## Why it couldn't be re-run

Both the preflight guard and the publish loop did `exit 1` when **any** package already existed at the tag version. Since `docx-core@0.16.0` now exists, re-running `v0.16.0` (push or `workflow_dispatch`) fails before reaching the four packages that still need publishing.

## Change

- **Preflight** fails only when the *entire* suite is already published — the actual duplicate-release case it was meant to catch. A partial state logs which packages will be skipped and emits a `::warning::`.
- **Publish loop** `continue`s past already-published packages instead of aborting.

Skipping can't overwrite anything — npm rejects a duplicate version outright — so the protection this guard existed to provide is retained.

## Verification

Guard logic exercised against all three states with a stubbed `npm`:

| state | result |
|---|---|
| none published | exit 0, no warning |
| partial (docx-core only) | exit 0, `::warning::Resuming a partial release: 1/6` |
| all six published | exit 1, "nothing to release" |

YAML parses; both modified `run` blocks pass `bash -n`.

## Note — this alone does not unblock 0.16.0

`@usejunior/docx-compare` still needs a **one-time manual publish** with a granular access token to create the package name, after which a trusted publisher can be attached to it. Only then does a re-run of `v0.16.0` complete the suite. This PR removes the second blocker (the unrecoverable guard), not the first.

Downstream context: the harness's [#194](https://github.com/UseJunior/legal-agent-harness/issues/194) is blocked on `accept_ai_edits` reaching npm, which lives in 0.16.0. Related: #586.