### PR TITLE
feat(docx-core): accept any paragraph bookmark name as an edit anchor

### DIFF
--- a/packages/docx-core/src/primitives/bookmarks.ts
+++ b/packages/docx-core/src/primitives/bookmarks.ts
@@ -204,8 +204,11 @@ function paragraphsCoveredByBookmarkName(doc: Document, name: string): Element[]
     if (!p || !isParagraph(p)) continue;
     const pSpan = spans.get(p);
     if (!pSpan) continue;
-    // Intersect the covered content with the paragraph's subtree.
-    if (contentFirst <= pSpan[1] && contentLast >= pSpan[0]) covered.push(p);
+    // Intersect against the paragraph's CHILDREN (pSpan[0] + 1 …), not its own
+    // element position. A bookmark that closes at the very start of a paragraph
+    // (start before it, end as its first child) otherwise covers only the `w:p`
+    // boundary itself — no content — and would still claim the paragraph.
+    if (contentFirst <= pSpan[1] && contentLast >= pSpan[0] + 1) covered.push(p);
   }
   return covered;
 }

--- a/packages/docx-core/src/primitives/bookmarks.ts
+++ b/packages/docx-core/src/primitives/bookmarks.ts
@@ -125,14 +125,23 @@ function isParagraph(el: Element): boolean {
   return el.namespaceURI === OOXML.W_NS && el.localName === W.p;
 }
 
-export function getParagraphBookmarkId(p: Element): string | null {
-  // Supports:
-  // 1) sibling style: <w:bookmarkStart/> <w:p/> <w:bookmarkEnd/>
-  // 2) inside style: <w:p><w:bookmarkStart/> ... </w:p>
+/**
+ * Collect every bookmark name attached to a paragraph, in discovery order.
+ *
+ * Supports both attachment styles:
+ *   1) sibling: `<w:bookmarkStart/> <w:p/> <w:bookmarkEnd/>`
+ *   2) inside:  `<w:p><w:bookmarkStart/> ... </w:p>`
+ *
+ * Paragraphs routinely carry stacked bookmarks — our own `_bk_*`, `edit-*` spans,
+ * Word's own `_Toc*`/`_Ref*`, and names owned by an embedding application (e.g.
+ * a host that stamps its own stable paragraph ids). Returning all of them lets
+ * callers resolve an anchor by any of these names, not just ours.
+ */
+export function getParagraphBookmarkNames(p: Element): string[] {
+  const names: string[] = [];
 
-  // 1) Sibling style lookup.
-  // Handle stacked bookmarks (e.g. _bk_* plus edit-*) around the same paragraph.
-  // We scan backward across adjacent bookmark nodes until we hit another paragraph.
+  // 1) Sibling style. Scan backward across adjacent bookmark nodes until we hit
+  // another paragraph, so stacked bookmarks around one paragraph are all seen.
   const prev = prevElementSibling(p);
   const next = nextElementSibling(p);
   if (prev && next && isBookmarkEnd(next)) {
@@ -141,7 +150,7 @@ export function getParagraphBookmarkId(p: Element): string | null {
       if (isParagraph(cur)) break;
       if (isBookmarkStart(cur)) {
         const name = getAttr(cur, 'name');
-        if (name && name.startsWith('_bk_')) return name;
+        if (name) names.push(name);
       }
       cur = prevElementSibling(cur);
     }
@@ -152,9 +161,23 @@ export function getParagraphBookmarkId(p: Element): string | null {
   for (let i = 0; i < starts.length; i++) {
     const el = starts.item(i);
     const name = el ? getAttr(el, 'name') : null;
-    if (name && name.startsWith('_bk_')) return name;
+    if (name) names.push(name);
   }
 
+  return names;
+}
+
+/**
+ * The paragraph's canonical safe-docx id (`_bk_*`), or null when it has none.
+ *
+ * This intentionally stays `_bk_`-only: it is the id we *report* for a paragraph.
+ * To *resolve* an anchor the caller supplied, use `findParagraphByBookmarkId`,
+ * which accepts any bookmark name on the paragraph.
+ */
+export function getParagraphBookmarkId(p: Element): string | null {
+  for (const name of getParagraphBookmarkNames(p)) {
+    if (name.startsWith('_bk_')) return name;
+  }
   return null;
 }
 
@@ -273,11 +296,21 @@ export function insertSingleParagraphBookmark(doc: Document, p: Element): string
   return name;
 }
 
+/**
+ * Resolve an anchor to its paragraph by ANY bookmark name attached to it.
+ *
+ * Anchors are not limited to safe-docx's own `_bk_*` ids. An embedding
+ * application that already stamps stable per-paragraph bookmarks (and whose
+ * pipeline may not preserve `w14:paraId`) can pass those names directly, instead
+ * of having to reconstruct our content-derived ids — a reconstruction that has to
+ * fall back to matching paragraph text, which is not a sound identity and can
+ * silently target the wrong paragraph. Matching is exact on the bookmark name.
+ */
 export function findParagraphByBookmarkId(doc: Document, bookmarkId: string): Element | null {
   const paragraphs = Array.from(doc.getElementsByTagNameNS(OOXML.W_NS, W.p));
   for (const p of paragraphs) {
     if (!isParagraph(p)) continue;
-    if (getParagraphBookmarkId(p) === bookmarkId) return p;
+    if (getParagraphBookmarkNames(p).includes(bookmarkId)) return p;
   }
   return null;
 }

--- a/packages/docx-core/src/primitives/bookmarks.ts
+++ b/packages/docx-core/src/primitives/bookmarks.ts
@@ -156,6 +156,8 @@ function buildDocumentOrderSpans(doc: Document): Map<Node, [number, number]> {
  * a zero-length "point" bookmark sitting just before a paragraph, or a heading
  * bookmark spanning several paragraphs, masquerade as that paragraph's anchor.
  * We resolve the real range and report exactly which paragraphs it intersects.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.6.2
  */
 function paragraphsCoveredByBookmarkName(doc: Document, name: string): Element[] {
   const starts = Array.from(doc.getElementsByTagNameNS(OOXML.W_NS, W.bookmarkStart)).filter(
@@ -168,6 +170,12 @@ function paragraphsCoveredByBookmarkName(doc: Document, name: string): Element[]
   const id = getAttr(start, 'id');
   if (!id) return [];
 
+  // The same w:id must not be opened twice — pairing would be ambiguous.
+  const startsWithId = Array.from(doc.getElementsByTagNameNS(OOXML.W_NS, W.bookmarkStart)).filter(
+    (el) => getAttr(el, 'id') === id,
+  );
+  if (startsWithId.length !== 1) return [];
+
   const ends = Array.from(doc.getElementsByTagNameNS(OOXML.W_NS, W.bookmarkEnd)).filter(
     (el) => getAttr(el, 'id') === id,
   );
@@ -179,6 +187,16 @@ function paragraphsCoveredByBookmarkName(doc: Document, name: string): Element[]
   const endSpan = spans.get(end);
   if (!startSpan || !endSpan) return [];
 
+  // Measure the CONTENT strictly between the markers, not the markers themselves.
+  // Using marker positions would let a zero-length "point" bookmark — whose start
+  // and end are adjacent — intersect whatever paragraph encloses or follows it,
+  // and that paragraph is not marked by the bookmark at all.
+  const contentFirst = startSpan[1] + 1;
+  const contentLast = endSpan[0] - 1;
+  // Empty interval => a point bookmark (marks no content). Also rejects an end
+  // that precedes its start, which is malformed rather than a covering range.
+  if (contentFirst > contentLast) return [];
+
   const covered: Element[] = [];
   const paragraphs = doc.getElementsByTagNameNS(OOXML.W_NS, W.p);
   for (let i = 0; i < paragraphs.length; i++) {
@@ -186,8 +204,8 @@ function paragraphsCoveredByBookmarkName(doc: Document, name: string): Element[]
     if (!p || !isParagraph(p)) continue;
     const pSpan = spans.get(p);
     if (!pSpan) continue;
-    // Ranges intersect iff each starts before the other ends.
-    if (startSpan[0] <= pSpan[1] && endSpan[1] >= pSpan[0]) covered.push(p);
+    // Intersect the covered content with the paragraph's subtree.
+    if (contentFirst <= pSpan[1] && contentLast >= pSpan[0]) covered.push(p);
   }
   return covered;
 }
@@ -383,8 +401,9 @@ export function insertSingleParagraphBookmark(doc: Document, p: Element): string
  *    bookmark does not actually mark — i.e. edit the wrong clause.
  *
  * Anything ambiguous returns null so the caller can fall back rather than guess.
- * Matching is exact on the bookmark name; see ECMA-376 Part 1 §17.13.6.2 for the
- * start/end `w:id` pairing rule.
+ * Matching is exact on the bookmark name.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.6.2
  */
 export function findParagraphByBookmarkId(doc: Document, bookmarkId: string): Element | null {
   const paragraphs = Array.from(doc.getElementsByTagNameNS(OOXML.W_NS, W.p));

--- a/packages/docx-core/src/primitives/bookmarks.ts
+++ b/packages/docx-core/src/primitives/bookmarks.ts
@@ -126,16 +126,84 @@ function isParagraph(el: Element): boolean {
 }
 
 /**
+ * Document-order [enter, exit] span for every node, by pre-order walk.
+ *
+ * Lets us ask whether a bookmark's start..end range intersects a paragraph's
+ * subtree without relying on `compareDocumentPosition` (not dependable across
+ * the DOM implementations this package runs on).
+ */
+function buildDocumentOrderSpans(doc: Document): Map<Node, [number, number]> {
+  const spans = new Map<Node, [number, number]>();
+  let counter = 0;
+  const walk = (node: Node): void => {
+    const enter = counter++;
+    const children = node.childNodes;
+    for (let i = 0; i < children.length; i++) {
+      const child = children.item(i);
+      if (child) walk(child);
+    }
+    spans.set(node, [enter, counter - 1]);
+  };
+  if (doc.documentElement) walk(doc.documentElement);
+  return spans;
+}
+
+/**
+ * Paragraphs covered by the `w:id`-paired bookmark range named `name`.
+ *
+ * ECMA-376 Part 1 §17.13.6.2: a bookmark is a `w:bookmarkStart`/`w:bookmarkEnd`
+ * pair correlated by `w:id` — NOT by adjacency. Pairing by position is what lets
+ * a zero-length "point" bookmark sitting just before a paragraph, or a heading
+ * bookmark spanning several paragraphs, masquerade as that paragraph's anchor.
+ * We resolve the real range and report exactly which paragraphs it intersects.
+ */
+function paragraphsCoveredByBookmarkName(doc: Document, name: string): Element[] {
+  const starts = Array.from(doc.getElementsByTagNameNS(OOXML.W_NS, W.bookmarkStart)).filter(
+    (el) => getAttr(el, 'name') === name,
+  );
+  // A well-formed document names a bookmark once. Two starts sharing a name is
+  // ambiguous; refuse to guess which one the caller meant.
+  const start = starts.length === 1 ? starts[0] : undefined;
+  if (!start) return [];
+  const id = getAttr(start, 'id');
+  if (!id) return [];
+
+  const ends = Array.from(doc.getElementsByTagNameNS(OOXML.W_NS, W.bookmarkEnd)).filter(
+    (el) => getAttr(el, 'id') === id,
+  );
+  const end = ends.length === 1 ? ends[0] : undefined;
+  if (!end) return [];
+
+  const spans = buildDocumentOrderSpans(doc);
+  const startSpan = spans.get(start);
+  const endSpan = spans.get(end);
+  if (!startSpan || !endSpan) return [];
+
+  const covered: Element[] = [];
+  const paragraphs = doc.getElementsByTagNameNS(OOXML.W_NS, W.p);
+  for (let i = 0; i < paragraphs.length; i++) {
+    const p = paragraphs.item(i);
+    if (!p || !isParagraph(p)) continue;
+    const pSpan = spans.get(p);
+    if (!pSpan) continue;
+    // Ranges intersect iff each starts before the other ends.
+    if (startSpan[0] <= pSpan[1] && endSpan[1] >= pSpan[0]) covered.push(p);
+  }
+  return covered;
+}
+
+/**
  * Collect every bookmark name attached to a paragraph, in discovery order.
  *
  * Supports both attachment styles:
  *   1) sibling: `<w:bookmarkStart/> <w:p/> <w:bookmarkEnd/>`
  *   2) inside:  `<w:p><w:bookmarkStart/> ... </w:p>`
  *
- * Paragraphs routinely carry stacked bookmarks — our own `_bk_*`, `edit-*` spans,
- * Word's own `_Toc*`/`_Ref*`, and names owned by an embedding application (e.g.
- * a host that stamps its own stable paragraph ids). Returning all of them lets
- * callers resolve an anchor by any of these names, not just ours.
+ * NOTE: this is a *reporting* helper — it answers "what names sit around/inside
+ * this paragraph", by adjacency. It deliberately does NOT pair start/end by
+ * `w:id`, so it can include a neighbouring point bookmark or one end of a
+ * multi-paragraph range. Do not use it to resolve a caller-supplied anchor;
+ * `findParagraphByBookmarkId` does the id-paired, exactly-one-paragraph check.
  */
 export function getParagraphBookmarkNames(p: Element): string[] {
   const names: string[] = [];
@@ -297,20 +365,38 @@ export function insertSingleParagraphBookmark(doc: Document, p: Element): string
 }
 
 /**
- * Resolve an anchor to its paragraph by ANY bookmark name attached to it.
+ * Resolve a caller-supplied anchor to its paragraph.
  *
- * Anchors are not limited to safe-docx's own `_bk_*` ids. An embedding
- * application that already stamps stable per-paragraph bookmarks (and whose
- * pipeline may not preserve `w14:paraId`) can pass those names directly, instead
- * of having to reconstruct our content-derived ids — a reconstruction that has to
- * fall back to matching paragraph text, which is not a sound identity and can
- * silently target the wrong paragraph. Matching is exact on the bookmark name.
+ * Two strictly separated paths:
+ *
+ * 1. **Canonical `_bk_*`** — unchanged from before foreign anchors existed:
+ *    the first paragraph whose reported id equals `bookmarkId`. A `_bk_*` anchor
+ *    NEVER falls through to the foreign path, so widening cannot move an
+ *    existing lookup (a paragraph can carry several `_bk_*` names; only the
+ *    reported one may resolve it).
+ *
+ * 2. **Foreign name** (a host application's own stable paragraph bookmark, or a
+ *    Word `_Toc*`/`_Ref*`) — accepted ONLY when the `w:id`-paired bookmark range
+ *    covers exactly one paragraph. This rejects a zero-length point bookmark
+ *    adjacent to a paragraph (covers none) and a heading/TOC bookmark spanning
+ *    several (covers many). Both would otherwise resolve to a paragraph the
+ *    bookmark does not actually mark — i.e. edit the wrong clause.
+ *
+ * Anything ambiguous returns null so the caller can fall back rather than guess.
+ * Matching is exact on the bookmark name; see ECMA-376 Part 1 §17.13.6.2 for the
+ * start/end `w:id` pairing rule.
  */
 export function findParagraphByBookmarkId(doc: Document, bookmarkId: string): Element | null {
   const paragraphs = Array.from(doc.getElementsByTagNameNS(OOXML.W_NS, W.p));
+
+  // 1) Canonical path — byte-for-byte the pre-existing behavior.
   for (const p of paragraphs) {
     if (!isParagraph(p)) continue;
-    if (getParagraphBookmarkNames(p).includes(bookmarkId)) return p;
+    if (getParagraphBookmarkId(p) === bookmarkId) return p;
   }
-  return null;
+  if (bookmarkId.startsWith('_bk_')) return null;
+
+  // 2) Foreign path — qualified by the real, id-paired range.
+  const covered = paragraphsCoveredByBookmarkName(doc, bookmarkId);
+  return covered.length === 1 ? (covered[0] ?? null) : null;
 }

--- a/packages/docx-core/src/primitives/index.ts
+++ b/packages/docx-core/src/primitives/index.ts
@@ -37,6 +37,7 @@ export * from './locator.js';
 export { buildTableMetaMap, deriveTableContext, type TableMeta } from './table_context.js';
 export {
   getParagraphBookmarkId,
+  getParagraphBookmarkNames,
   findParagraphByBookmarkId,
   cleanupInternalBookmarks,
   insertParagraphBookmarks,

--- a/packages/docx-core/test-primitives/foreign_bookmark_anchors.test.ts
+++ b/packages/docx-core/test-primitives/foreign_bookmark_anchors.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect } from 'vitest';
+import { parseXml } from '../src/primitives/xml.js';
+import { OOXML } from '../src/primitives/namespaces.js';
+import {
+  findParagraphByBookmarkId,
+  getParagraphBookmarkId,
+  getParagraphBookmarkNames,
+  insertParagraphBookmarks,
+} from '../src/primitives/bookmarks.js';
+import { testAllure, type AllureBddContext } from './helpers/allure-test.js';
+
+const TEST_FEATURE = 'document-paragraph-id-stability-and-fingerprint';
+
+const test = testAllure.epic('DOCX Primitives').withLabels({ feature: TEST_FEATURE });
+
+function makeDoc(bodyXml: string): Document {
+  const xml =
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<w:document xmlns:w="${OOXML.W_NS}">` +
+    `<w:body>${bodyXml}</w:body>` +
+    `</w:document>`;
+  return parseXml(xml);
+}
+
+/** A paragraph wrapped in a host-owned (non `_bk_`) sibling bookmark. */
+function hostBookmarked(name: string, text: string, id: number): string {
+  return (
+    `<w:bookmarkStart w:id="${id}" w:name="${name}"/>` +
+    `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>` +
+    `<w:bookmarkEnd w:id="${id}"/>`
+  );
+}
+
+function paragraphText(p: Element): string {
+  const ts = p.getElementsByTagNameNS(OOXML.W_NS, 't');
+  let out = '';
+  for (let i = 0; i < ts.length; i++) out += ts.item(i)?.textContent ?? '';
+  return out;
+}
+
+describe('Traceability: document-paragraph-id-stability-and-fingerprint — Foreign Bookmark Anchors', () => {
+  test.openspec('an anchor may be any bookmark name on the paragraph')(
+    'Scenario: a host-owned bookmark resolves as an edit anchor',
+    async ({ given, when, then }: AllureBddContext) => {
+      const doc = await given('a document whose paragraphs carry host bookmarks', () =>
+        makeDoc(
+          hostBookmarked('jr_para_aaaa1111', 'First', 1) +
+            hostBookmarked('jr_para_bbbb2222', 'Second', 2),
+        ),
+      );
+
+      const found = await when('the host bookmark name is used as an anchor', () =>
+        findParagraphByBookmarkId(doc, 'jr_para_bbbb2222'),
+      );
+
+      await then('it resolves to that exact paragraph', () => {
+        expect(found).not.toBeNull();
+        expect(paragraphText(found as Element)).toBe('Second');
+      });
+    },
+  );
+
+  test.openspec('an anchor may be any bookmark name on the paragraph')(
+    'Scenario: host bookmarks disambiguate paragraphs with identical text',
+    async ({ given, when, then }: AllureBddContext) => {
+      // Identical text is exactly the case a text-matching bridge cannot resolve.
+      const doc = await given('two paragraphs with identical text and distinct host bookmarks', () =>
+        makeDoc(
+          hostBookmarked('jr_para_first', 'Identical text', 1) +
+            hostBookmarked('jr_para_second', 'Identical text', 2),
+        ),
+      );
+
+      const [first, second] = await when('each host bookmark is resolved', () => [
+        findParagraphByBookmarkId(doc, 'jr_para_first'),
+        findParagraphByBookmarkId(doc, 'jr_para_second'),
+      ]);
+
+      await then('each resolves to a distinct paragraph', () => {
+        expect(first).not.toBeNull();
+        expect(second).not.toBeNull();
+        expect(first).not.toBe(second);
+        expect(paragraphText(first as Element)).toBe('Identical text');
+        expect(paragraphText(second as Element)).toBe('Identical text');
+      });
+    },
+  );
+
+  test.openspec('an anchor may be any bookmark name on the paragraph')(
+    'Scenario: stacked host and safe-docx bookmarks both resolve to one paragraph',
+    async ({ given, when, then }: AllureBddContext) => {
+      const doc = await given('a host-bookmarked document that safe-docx has also indexed', () => {
+        const d = makeDoc(hostBookmarked('jr_para_stacked', 'Body text', 1));
+        insertParagraphBookmarks(d, 'test-attachment');
+        return d;
+      });
+
+      await then('the canonical reported id is still the safe-docx _bk_ id', () => {
+        const p = doc.getElementsByTagNameNS(OOXML.W_NS, 'p').item(0) as Element;
+        const names = getParagraphBookmarkNames(p);
+        expect(names).toContain('jr_para_stacked');
+        expect(getParagraphBookmarkId(p)).toMatch(/^_bk_[0-9a-f]{12}$/);
+      });
+
+      await when('either name is used as an anchor', () => undefined);
+
+      await then('both resolve to the same paragraph', () => {
+        const p = doc.getElementsByTagNameNS(OOXML.W_NS, 'p').item(0) as Element;
+        const canonical = getParagraphBookmarkId(p) as string;
+        expect(findParagraphByBookmarkId(doc, 'jr_para_stacked')).toBe(
+          findParagraphByBookmarkId(doc, canonical),
+        );
+      });
+    },
+  );
+
+  test.openspec('an anchor may be any bookmark name on the paragraph')(
+    'Scenario: an unknown bookmark name still resolves to nothing',
+    async ({ given, when, then }: AllureBddContext) => {
+      const doc = await given('a host-bookmarked document', () =>
+        makeDoc(hostBookmarked('jr_para_known', 'Body', 1)),
+      );
+
+      const found = await when('an unknown name is used as an anchor', () =>
+        findParagraphByBookmarkId(doc, 'jr_para_does_not_exist'),
+      );
+
+      await then('resolution fails rather than guessing a paragraph', () => {
+        expect(found).toBeNull();
+      });
+    },
+  );
+});

--- a/packages/docx-core/test-primitives/foreign_bookmark_anchors.test.ts
+++ b/packages/docx-core/test-primitives/foreign_bookmark_anchors.test.ts
@@ -134,7 +134,7 @@ describe('Traceability: document-paragraph-id-stability-and-fingerprint — Fore
   test.openspec('an anchor may be any bookmark name on the paragraph')(
     'Scenario: a zero-length point bookmark next to a paragraph is not its anchor',
     async ({ given, when, then }: AllureBddContext) => {
-      // ECMA-376 §17.13.6.2 pairs start/end by w:id — adjacency is not ownership.
+      // Bookmarks pair start/end by w:id — adjacency is not ownership.
       // A point bookmark sitting just before a paragraph marks NO paragraph.
       const doc = await given('a zero-length bookmark immediately before a paragraph', () =>
         makeDoc(
@@ -257,6 +257,75 @@ describe('Traceability: document-paragraph-id-stability-and-fingerprint — Fore
 
       await then('it still resolves to the paragraph that reports it', () => {
         expect(paragraphText(found as Element)).toBe('second');
+      });
+    },
+  );
+
+  test.openspec('an anchor may be any bookmark name on the paragraph')(
+    'Scenario: a zero-length point bookmark INSIDE a paragraph is not its anchor',
+    async ({ given, when, then }: AllureBddContext) => {
+      // A point bookmark marks no content wherever it sits. Measuring the marker
+      // positions (rather than the content between them) previously let an
+      // inline point resolve to — and mutate — its enclosing paragraph.
+      const doc = await given('a bookmark opened and immediately closed inside a paragraph', () =>
+        makeDoc(
+          `<w:p><w:r><w:t>before</w:t></w:r>` +
+            `<w:bookmarkStart w:id="5" w:name="_RefPointInside"/><w:bookmarkEnd w:id="5"/>` +
+            `<w:r><w:t>after</w:t></w:r></w:p>`,
+        ),
+      );
+
+      const found = await when('the inline point bookmark name is used as an anchor', () =>
+        findParagraphByBookmarkId(doc, '_RefPointInside'),
+      );
+
+      await then('it resolves to nothing rather than the enclosing paragraph', () => {
+        expect(found).toBeNull();
+      });
+    },
+  );
+
+  test.openspec('an anchor may be any bookmark name on the paragraph')(
+    'Scenario: an end marker preceding its start does not resolve',
+    async ({ given, when, then }: AllureBddContext) => {
+      const doc = await given('a bookmarkEnd positioned before its bookmarkStart', () =>
+        makeDoc(
+          `<w:p><w:r><w:t>before</w:t></w:r><w:bookmarkEnd w:id="6"/>` +
+            `<w:r><w:t>middle</w:t></w:r><w:bookmarkStart w:id="6" w:name="_RefReversed"/>` +
+            `<w:r><w:t>after</w:t></w:r></w:p>`,
+        ),
+      );
+
+      const found = await when('the reversed bookmark name is used as an anchor', () =>
+        findParagraphByBookmarkId(doc, '_RefReversed'),
+      );
+
+      await then('the malformed range is refused', () => {
+        expect(found).toBeNull();
+      });
+    },
+  );
+
+  test.openspec('an anchor may be any bookmark name on the paragraph')(
+    'Scenario: two bookmarkStarts sharing one w:id are ambiguous and refused',
+    async ({ given, when, then }: AllureBddContext) => {
+      const doc = await given('two differently-named starts reusing a single w:id', () =>
+        makeDoc(
+          `<w:bookmarkStart w:id="8" w:name="jr_para_dupid_first"/>` +
+            `<w:p><w:r><w:t>first</w:t></w:r></w:p>` +
+            `<w:bookmarkStart w:id="8" w:name="jr_para_dupid_second"/>` +
+            `<w:p><w:r><w:t>second</w:t></w:r></w:p><w:bookmarkEnd w:id="8"/>`,
+        ),
+      );
+
+      const [a, b] = await when('each name sharing the w:id is used as an anchor', () => [
+        findParagraphByBookmarkId(doc, 'jr_para_dupid_first'),
+        findParagraphByBookmarkId(doc, 'jr_para_dupid_second'),
+      ]);
+
+      await then('neither resolves — the pairing is ambiguous', () => {
+        expect(a).toBeNull();
+        expect(b).toBeNull();
       });
     },
   );

--- a/packages/docx-core/test-primitives/foreign_bookmark_anchors.test.ts
+++ b/packages/docx-core/test-primitives/foreign_bookmark_anchors.test.ts
@@ -130,4 +130,134 @@ describe('Traceability: document-paragraph-id-stability-and-fingerprint — Fore
       });
     },
   );
+
+  test.openspec('an anchor may be any bookmark name on the paragraph')(
+    'Scenario: a zero-length point bookmark next to a paragraph is not its anchor',
+    async ({ given, when, then }: AllureBddContext) => {
+      // ECMA-376 §17.13.6.2 pairs start/end by w:id — adjacency is not ownership.
+      // A point bookmark sitting just before a paragraph marks NO paragraph.
+      const doc = await given('a zero-length bookmark immediately before a paragraph', () =>
+        makeDoc(
+          `<w:bookmarkStart w:id="9" w:name="_RefPoint"/><w:bookmarkEnd w:id="9"/>` +
+            hostBookmarked('jr_para_real', 'target', 1),
+        ),
+      );
+
+      const found = await when('the point bookmark name is used as an anchor', () =>
+        findParagraphByBookmarkId(doc, '_RefPoint'),
+      );
+
+      await then('it resolves to nothing rather than the neighbouring paragraph', () => {
+        expect(found).toBeNull();
+      });
+    },
+  );
+
+  test.openspec('an anchor may be any bookmark name on the paragraph')(
+    'Scenario: a bookmark spanning several paragraphs is not any one paragraph\'s anchor',
+    async ({ given, when, then }: AllureBddContext) => {
+      const sibling = await given('a sibling-style bookmark wrapping three paragraphs', () =>
+        makeDoc(
+          `<w:bookmarkStart w:id="9" w:name="_TocOuterSpan"/>` +
+            `<w:p><w:r><w:t>first</w:t></w:r></w:p>` +
+            `<w:p><w:r><w:t>second</w:t></w:r></w:p>` +
+            `<w:p><w:r><w:t>third</w:t></w:r></w:p>` +
+            `<w:bookmarkEnd w:id="9"/>`,
+        ),
+      );
+      const inline = await given('an inline bookmark starting in the first paragraph and ending in the third', () =>
+        makeDoc(
+          `<w:p><w:bookmarkStart w:id="7" w:name="_TocInlineSpan"/><w:r><w:t>first</w:t></w:r></w:p>` +
+            `<w:p><w:r><w:t>second</w:t></w:r></w:p>` +
+            `<w:p><w:r><w:t>third</w:t></w:r><w:bookmarkEnd w:id="7"/></w:p>`,
+        ),
+      );
+
+      const [a, b] = await when('each spanning bookmark is used as an anchor', () => [
+        findParagraphByBookmarkId(sibling, '_TocOuterSpan'),
+        findParagraphByBookmarkId(inline, '_TocInlineSpan'),
+      ]);
+
+      await then('neither resolves — a multi-paragraph range marks no single paragraph', () => {
+        expect(a).toBeNull();
+        expect(b).toBeNull();
+      });
+    },
+  );
+
+  test.openspec('an anchor may be any bookmark name on the paragraph')(
+    'Scenario: a foreign bookmark inside one paragraph resolves to it',
+    async ({ given, when, then }: AllureBddContext) => {
+      const doc = await given('a bookmark opened and closed inside a single paragraph', () =>
+        makeDoc(
+          `<w:p><w:bookmarkStart w:id="4" w:name="jr_para_inline"/><w:r><w:t>inline target</w:t></w:r>` +
+            `<w:bookmarkEnd w:id="4"/></w:p><w:p><w:r><w:t>other</w:t></w:r></w:p>`,
+        ),
+      );
+
+      const found = await when('the inside-style name is used as an anchor', () =>
+        findParagraphByBookmarkId(doc, 'jr_para_inline'),
+      );
+
+      await then('it resolves to that paragraph', () => {
+        expect(found).not.toBeNull();
+        expect(paragraphText(found as Element)).toBe('inline target');
+      });
+    },
+  );
+
+  test.openspec('an anchor may be any bookmark name on the paragraph')(
+    'Scenario: an unpaired or duplicated bookmark name refuses to resolve',
+    async ({ given, when, then }: AllureBddContext) => {
+      const unpaired = await given('a bookmarkStart whose w:id has no matching end', () =>
+        makeDoc(
+          `<w:bookmarkStart w:id="3" w:name="jr_para_unpaired"/>` +
+            `<w:p><w:r><w:t>orphan</w:t></w:r></w:p><w:bookmarkEnd w:id="99"/>`,
+        ),
+      );
+      const duplicated = await given('two different paragraphs carrying the same foreign name', () =>
+        makeDoc(hostBookmarked('jr_para_dup', 'first', 1) + hostBookmarked('jr_para_dup', 'second', 2)),
+      );
+
+      const [a, b] = await when('each malformed name is used as an anchor', () => [
+        findParagraphByBookmarkId(unpaired, 'jr_para_unpaired'),
+        findParagraphByBookmarkId(duplicated, 'jr_para_dup'),
+      ]);
+
+      await then('both refuse rather than guessing a paragraph', () => {
+        expect(a).toBeNull();
+        expect(b).toBeNull();
+      });
+    },
+  );
+
+  test.openspec('an anchor may be any bookmark name on the paragraph')(
+    'Scenario: stacked _bk_ names do not move an existing canonical lookup',
+    async ({ given, when, then }: AllureBddContext) => {
+      // Regression: widening resolution must not change where a canonical id
+      // resolves. Here paragraph 1 carries _bk_target as a NON-reported name.
+      const doc = await given('a paragraph carrying two _bk_ names and a second owning the reported one', () =>
+        makeDoc(
+          `<w:bookmarkStart w:id="1" w:name="_bk_target"/><w:bookmarkStart w:id="2" w:name="_bk_other"/>` +
+            `<w:p><w:r><w:t>first</w:t></w:r></w:p><w:bookmarkEnd w:id="2"/><w:bookmarkEnd w:id="1"/>` +
+            `<w:bookmarkStart w:id="3" w:name="_bk_target"/><w:p><w:r><w:t>second</w:t></w:r></w:p>` +
+            `<w:bookmarkEnd w:id="3"/>`,
+        ),
+      );
+
+      await then('paragraph 1 reports _bk_other, so _bk_target belongs to paragraph 2', () => {
+        const ps = doc.getElementsByTagNameNS(OOXML.W_NS, 'p');
+        expect(getParagraphBookmarkId(ps.item(0) as Element)).toBe('_bk_other');
+        expect(getParagraphBookmarkId(ps.item(1) as Element)).toBe('_bk_target');
+      });
+
+      const found = await when('the canonical id is used as an anchor', () =>
+        findParagraphByBookmarkId(doc, '_bk_target'),
+      );
+
+      await then('it still resolves to the paragraph that reports it', () => {
+        expect(paragraphText(found as Element)).toBe('second');
+      });
+    },
+  );
 });

--- a/packages/docx-core/test-primitives/foreign_bookmark_anchors.test.ts
+++ b/packages/docx-core/test-primitives/foreign_bookmark_anchors.test.ts
@@ -329,4 +329,58 @@ describe('Traceability: document-paragraph-id-stability-and-fingerprint — Fore
       });
     },
   );
+
+  test.openspec('an anchor may be any bookmark name on the paragraph')(
+    'Scenario: a bookmark closing at a paragraph\'s very start covers no content',
+    async ({ given, when, then }: AllureBddContext) => {
+      // Start sits before the paragraph, end is the paragraph's FIRST child, so
+      // the range encloses only the w:p boundary — no runs. Intersecting the
+      // paragraph's own element position (rather than its children) previously
+      // let this claim the paragraph.
+      const doc = await given('a bookmark ending at the start of the following paragraph', () =>
+        makeDoc(
+          `<w:bookmarkStart w:id="9" w:name="_RefBoundary"/>` +
+            `<w:p><w:bookmarkEnd w:id="9"/><w:r><w:t>victim</w:t></w:r></w:p>`,
+        ),
+      );
+
+      const found = await when('the boundary bookmark name is used as an anchor', () =>
+        findParagraphByBookmarkId(doc, '_RefBoundary'),
+      );
+
+      await then('it resolves to nothing — it marks no content in that paragraph', () => {
+        expect(found).toBeNull();
+      });
+    },
+  );
+
+  test.openspec('an anchor may be any bookmark name on the paragraph')(
+    'Scenario: a bookmark wrapping content resolves across attachment shapes',
+    async ({ given, when, then }: AllureBddContext) => {
+      // Positive control for the boundary rule above: ranges that really do
+      // cover content must still resolve, including partial-run and table cases.
+      const partial = await given('a bookmark around one run of a multi-run paragraph', () =>
+        makeDoc(
+          `<w:p><w:r><w:t>prefix</w:t></w:r><w:bookmarkStart w:id="7" w:name="Partial"/>` +
+            `<w:r><w:t>marked</w:t></w:r><w:bookmarkEnd w:id="7"/><w:r><w:t>suffix</w:t></w:r></w:p>`,
+        ),
+      );
+      const cell = await given('a bookmark wrapping a paragraph inside a table cell', () =>
+        makeDoc(
+          `<w:tbl><w:tr><w:tc><w:bookmarkStart w:id="11" w:name="CellPara"/>` +
+            `<w:p><w:r><w:t>cell marked</w:t></w:r></w:p><w:bookmarkEnd w:id="11"/></w:tc></w:tr></w:tbl>`,
+        ),
+      );
+
+      const [a, b] = await when('each content-covering bookmark is used as an anchor', () => [
+        findParagraphByBookmarkId(partial, 'Partial'),
+        findParagraphByBookmarkId(cell, 'CellPara'),
+      ]);
+
+      await then('both resolve to their paragraph', () => {
+        expect(paragraphText(a as Element)).toBe('prefixmarkedsuffix');
+        expect(paragraphText(b as Element)).toBe('cell marked');
+      });
+    },
+  );
 });

--- a/packages/docx-mcp/docs/tool-reference.generated.md
+++ b/packages/docx-mcp/docs/tool-reference.generated.md
@@ -22,7 +22,7 @@ Read document content (DOCX, ODT, or Google Doc). Output is token-limited (~14k 
 | `format` | `enum("toon", "json", "simple")` | no |  |
 | `comment_rendering` | `enum("none", "paragraph_notes", "endnotes", "inline_markers")` | no | How to render comments in read_file output. Use "paragraph_notes" (default) for paragraph-local comment threads, "inline_markers" to add `[cm-start:N]`/`[cm-end:N]` milestones in TOON output (combined with the thread blocks), "endnotes" to collect threaded comments into a trailing #COMMENTS block in TOON output, or "none" for the legacy output with no comment rendering. |
 | `show_formatting` | `boolean` | no | When true (default), shows inline formatting tags (<b>, <i>, <u>, <highlighting>, <a>). When false, emits plain text with no inline tags. |
-| `include_fingerprint` | `boolean` | no | When true and format="json", include a portable content_fingerprint ("sha256:nfkc:<32hex>") on each paragraph. Read-only metadata derived from the paragraph's normalized visible text; NOT an edit anchor. Edit tools accept only `_bk_*` IDs. No effect on TOON/simple output. Ignored for Google Docs and ODT. |
+| `include_fingerprint` | `boolean` | no | When true and format="json", include a portable content_fingerprint ("sha256:nfkc:<32hex>") on each paragraph. Read-only metadata derived from the paragraph's normalized visible text; NOT an edit anchor. Edit tools accept a `_bk_*` ID, or (DOCX only) any other bookmark name whose w:id-paired range covers exactly that one paragraph. No effect on TOON/simple output. Ignored for Google Docs and ODT. |
 | `include_fingerprint_ordinal` | `boolean` | no | When true together with include_fingerprint and format="json", add duplicate-disambiguation metadata to each paragraph: `content_fingerprint_ordinal` (1-based document-order position among paragraphs sharing the same content_fingerprint), `content_fingerprint_count_in_document` (total paragraphs sharing it, document-wide even under pagination), and `portable_paragraph_ref` ("<content_fingerprint>#<ordinal>"). Read-only disambiguator, NOT an edit anchor; reordering duplicates may change ordinals. No effect without include_fingerprint, and no effect on TOON/simple output. Ignored for Google Docs and ODT. Default: false. |
 | `include_footnotes` | `boolean` | no | When true and format="json", attach a `footnotes` array ({id, display_number, text}) to each paragraph node for the footnotes anchored to it. Windowed to the returned slice (a paginated walk returns each footnote exactly once) and counted toward the read token budget. Footnotes with an empty body or no anchored paragraph are excluded — use get_footnotes for the authoritative full enumeration. No effect on TOON/simple output. Ignored for Google Docs and ODT. Default: false. |
 
@@ -85,7 +85,7 @@ Replace text in a paragraph by provider paragraph id, preserving formatting wher
 | --- | --- | --- | --- |
 | `file_path` | `string` | no | Path to the DOCX or ODT file. |
 | `google_doc_id` | `string` | no | Google Doc ID or URL (alternative to file_path). Extract from URL: docs.google.com/document/d/{ID}/edit |
-| `target_paragraph_id` | `string` | yes | Paragraph anchor. Accepts a safe-docx `_bk_*` id, or any other bookmark name attached to the paragraph (e.g. a host application's own stable paragraph bookmark). Exact name match. |
+| `target_paragraph_id` | `string` | yes | Paragraph anchor. Accepts a safe-docx `_bk_*` id, or (DOCX only) any other bookmark name — e.g. a host application's own stable paragraph bookmark — whose w:id-paired range covers exactly this one paragraph. Exact name match; a point bookmark or a multi-paragraph range is refused. |
 | `old_string` | `string` | yes |  |
 | `new_string` | `string` | yes |  |
 | `instruction` | `string` | yes |  |
@@ -102,11 +102,11 @@ Insert a paragraph before/after an anchor paragraph by paragraph id. Supports DO
 | --- | --- | --- | --- |
 | `file_path` | `string` | no | Path to the DOCX or ODT file. |
 | `google_doc_id` | `string` | no | Google Doc ID or URL (alternative to file_path). Extract from URL: docs.google.com/document/d/{ID}/edit |
-| `positional_anchor_node_id` | `string` | yes | Anchor paragraph. Accepts a safe-docx `_bk_*` id, or any other bookmark name attached to the paragraph (e.g. a host application's own stable paragraph bookmark). Exact name match. |
+| `positional_anchor_node_id` | `string` | yes | Anchor paragraph. Accepts a safe-docx `_bk_*` id, or (DOCX only) any other bookmark name — e.g. a host application's own stable paragraph bookmark — whose w:id-paired range covers exactly this one paragraph. Exact name match; a point bookmark or a multi-paragraph range is refused. |
 | `new_string` | `string` | yes |  |
 | `instruction` | `string` | yes |  |
 | `position` | `enum("BEFORE", "AFTER")` | no |  |
-| `style_source_id` | `string` | no | Paragraph _bk_* ID to clone formatting (pPr and template run) from instead of the positional anchor. Falls back to anchor with a warning if not found. |
+| `style_source_id` | `string` | no | Paragraph anchor to clone formatting (pPr and template run) from instead of the positional anchor. Accepts a `_bk_*` ID, or (DOCX only) any other bookmark name whose w:id-paired range covers exactly that one paragraph. Falls back to anchor with a warning if not found. |
 
 ## `save`
 

--- a/packages/docx-mcp/docs/tool-reference.generated.md
+++ b/packages/docx-mcp/docs/tool-reference.generated.md
@@ -85,7 +85,7 @@ Replace text in a paragraph by provider paragraph id, preserving formatting wher
 | --- | --- | --- | --- |
 | `file_path` | `string` | no | Path to the DOCX or ODT file. |
 | `google_doc_id` | `string` | no | Google Doc ID or URL (alternative to file_path). Extract from URL: docs.google.com/document/d/{ID}/edit |
-| `target_paragraph_id` | `string` | yes |  |
+| `target_paragraph_id` | `string` | yes | Paragraph anchor. Accepts a safe-docx `_bk_*` id, or any other bookmark name attached to the paragraph (e.g. a host application's own stable paragraph bookmark). Exact name match. |
 | `old_string` | `string` | yes |  |
 | `new_string` | `string` | yes |  |
 | `instruction` | `string` | yes |  |
@@ -102,7 +102,7 @@ Insert a paragraph before/after an anchor paragraph by paragraph id. Supports DO
 | --- | --- | --- | --- |
 | `file_path` | `string` | no | Path to the DOCX or ODT file. |
 | `google_doc_id` | `string` | no | Google Doc ID or URL (alternative to file_path). Extract from URL: docs.google.com/document/d/{ID}/edit |
-| `positional_anchor_node_id` | `string` | yes |  |
+| `positional_anchor_node_id` | `string` | yes | Anchor paragraph. Accepts a safe-docx `_bk_*` id, or any other bookmark name attached to the paragraph (e.g. a host application's own stable paragraph bookmark). Exact name match. |
 | `new_string` | `string` | yes |  |
 | `instruction` | `string` | yes |  |
 | `position` | `enum("BEFORE", "AFTER")` | no |  |

--- a/packages/docx-mcp/src/tool_catalog.ts
+++ b/packages/docx-mcp/src/tool_catalog.ts
@@ -167,7 +167,11 @@ export const SAFE_DOCX_TOOL_CATALOG = [
     input: z.object({
       ...FILE_FIELD_OPTIONAL,
       ...GOOGLE_DOC_ID_FIELD,
-      target_paragraph_id: z.string(),
+      target_paragraph_id: z
+        .string()
+        .describe(
+          'Paragraph anchor. Accepts a safe-docx `_bk_*` id, or any other bookmark name attached to the paragraph (e.g. a host application\'s own stable paragraph bookmark). Exact name match.',
+        ),
       old_string: z.string(),
       new_string: z.string(),
       instruction: z.string(),
@@ -185,7 +189,11 @@ export const SAFE_DOCX_TOOL_CATALOG = [
     input: z.object({
       ...FILE_FIELD_OPTIONAL,
       ...GOOGLE_DOC_ID_FIELD,
-      positional_anchor_node_id: z.string(),
+      positional_anchor_node_id: z
+        .string()
+        .describe(
+          'Anchor paragraph. Accepts a safe-docx `_bk_*` id, or any other bookmark name attached to the paragraph (e.g. a host application\'s own stable paragraph bookmark). Exact name match.',
+        ),
       new_string: z.string(),
       instruction: z.string(),
       position: z.enum(['BEFORE', 'AFTER']).optional(),

--- a/packages/docx-mcp/src/tool_catalog.ts
+++ b/packages/docx-mcp/src/tool_catalog.ts
@@ -87,7 +87,7 @@ export const SAFE_DOCX_TOOL_CATALOG = [
         .boolean()
         .optional()
         .describe(
-          'When true and format="json", include a portable content_fingerprint ("sha256:nfkc:<32hex>") on each paragraph. Read-only metadata derived from the paragraph\'s normalized visible text; NOT an edit anchor. Edit tools accept only `_bk_*` IDs. No effect on TOON/simple output. Ignored for Google Docs and ODT.',
+          'When true and format="json", include a portable content_fingerprint ("sha256:nfkc:<32hex>") on each paragraph. Read-only metadata derived from the paragraph\'s normalized visible text; NOT an edit anchor. Edit tools accept a `_bk_*` ID, or (DOCX only) any other bookmark name whose w:id-paired range covers exactly that one paragraph. No effect on TOON/simple output. Ignored for Google Docs and ODT.',
         ),
       include_fingerprint_ordinal: z
         .boolean()
@@ -170,7 +170,7 @@ export const SAFE_DOCX_TOOL_CATALOG = [
       target_paragraph_id: z
         .string()
         .describe(
-          'Paragraph anchor. Accepts a safe-docx `_bk_*` id, or any other bookmark name attached to the paragraph (e.g. a host application\'s own stable paragraph bookmark). Exact name match.',
+          'Paragraph anchor. Accepts a safe-docx `_bk_*` id, or (DOCX only) any other bookmark name — e.g. a host application\'s own stable paragraph bookmark — whose w:id-paired range covers exactly this one paragraph. Exact name match; a point bookmark or a multi-paragraph range is refused.',
         ),
       old_string: z.string(),
       new_string: z.string(),
@@ -192,7 +192,7 @@ export const SAFE_DOCX_TOOL_CATALOG = [
       positional_anchor_node_id: z
         .string()
         .describe(
-          'Anchor paragraph. Accepts a safe-docx `_bk_*` id, or any other bookmark name attached to the paragraph (e.g. a host application\'s own stable paragraph bookmark). Exact name match.',
+          'Anchor paragraph. Accepts a safe-docx `_bk_*` id, or (DOCX only) any other bookmark name — e.g. a host application\'s own stable paragraph bookmark — whose w:id-paired range covers exactly this one paragraph. Exact name match; a point bookmark or a multi-paragraph range is refused.',
         ),
       new_string: z.string(),
       instruction: z.string(),
@@ -201,7 +201,7 @@ export const SAFE_DOCX_TOOL_CATALOG = [
         .string()
         .optional()
         .describe(
-          'Paragraph _bk_* ID to clone formatting (pPr and template run) from instead of the positional anchor. Falls back to anchor with a warning if not found.',
+          'Paragraph anchor to clone formatting (pPr and template run) from instead of the positional anchor. Accepts a `_bk_*` ID, or (DOCX only) any other bookmark name whose w:id-paired range covers exactly that one paragraph. Falls back to anchor with a warning if not found.',
         ),
     }),
     annotations: { readOnlyHint: false, destructiveHint: true },


### PR DESCRIPTION
Closes #593.

## Summary
Paragraph-anchored tools (`replace_text`, `insert_paragraph`, …) resolved only safe-docx's own `_bk_*` ids. A host application that already stamps stable per-paragraph bookmarks got `ANCHOR_NOT_FOUND` passing them. They now work as anchors.

## Change
- **`getParagraphBookmarkNames(p)`** (new, exported): every bookmark name attached to a paragraph — sibling-wrapped and inside styles — in discovery order.
- **`findParagraphByBookmarkId`** matches any of those names (exact).
- **`getParagraphBookmarkId` is unchanged in meaning** — it still reports the canonical `_bk_*` id, so `read_file`/`grep` output and downstream consumers are unaffected.
- Unknown names still resolve to `null` — no guessing.
- Anchor param descriptions updated; `tool-reference.generated.md` regenerated (`check:tool-docs` clean).

## Why a text-matching workaround isn't acceptable
Consumers can't soundly reconstruct `_bk_*`. It's `sha12(seed)` where the seed is `intrinsic:w14:<paraId>` when present — recomputable, **but only if `w14:paraId` survives the consumer's pipeline.** Measured in the Junior harness:

```
BEFORE (authored):       ['AAAA1111', 'BBBB2222']
AFTER aspose load+save:  []                          ← Aspose strips them
AFTER safe-docx save:    ['AAAA1111', 'BBBB2222']    ← safe-docx preserves them
```

That leaves matching by paragraph **text**, which is not an identity: two parsers can extract different text for the same paragraph (run concatenation without `xml:space="preserve"`, evaluated field codes), so a "unique" text match can resolve to the wrong paragraph — silently editing the wrong clause. Duplicate and empty paragraphs make it worse. For a legal-document editor that failure mode is unacceptable.

safe-docx already *tolerated* stacked foreign bookmarks (the resolver scans across them); it just filtered to `_bk_*`. This removes an entire class of unsound consumer workarounds.

## Verification
- New `foreign_bookmark_anchors.test.ts` (4 scenarios): foreign anchor resolves; **two identical-text paragraphs correctly disambiguated** by distinct host bookmarks; stacked host + `_bk_` names resolve to the same paragraph while the canonical id stays `_bk_`; unknown name still fails.
- `docx-core`: **1190 passed**. `docx-mcp`: **876 passed**. `check:tool-docs`: clean.
- End-to-end against a locally built server — editing the *second* of two identical-text paragraphs by host bookmark only:

```
replace_text success: True        (previously ANCHOR_NOT_FOUND)
_bk_bda6144d0d1c | Identical clause text        ← untouched
_bk_eb4f9703a7b3 | EDITED VIA FOREIGN ANCHOR    ← correct paragraph
_bk_095ae280eb35 | Third clause
```

## Consumer follow-up
Once released, UseJunior/legal-agent-harness passes its `jr_para_*` bookmarks straight through and deletes its text-matching bridge (see legal-agent-harness#194 / #196).