### PR TITLE
chore(release): bump workspace versions to 0.17.0

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-docx",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "AI-powered DOCX and ODT editing with tracked changes, redlining, and formatting preservation",
   "contextFileName": "GEMINI.md",
   "entrypoint": "GEMINI.md",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "safe-docx-suite",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "safe-docx-suite",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -8998,7 +8998,7 @@
     },
     "packages/allure-test-factory": {
       "name": "@usejunior/allure-test-factory",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"
@@ -9019,10 +9019,10 @@
     },
     "packages/docx-compare": {
       "name": "@usejunior/docx-compare",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@usejunior/docx-core": "^0.16.0",
+        "@usejunior/docx-core": "^0.17.0",
         "@xmldom/xmldom": "^0.9.10",
         "diff-match-patch": "^1.0.5",
         "jszip": "^3.10.1"
@@ -9048,7 +9048,7 @@
     },
     "packages/docx-core": {
       "name": "@usejunior/docx-core",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@xmldom/xmldom": "^0.9.10",
@@ -9060,7 +9060,7 @@
       "devDependencies": {
         "@types/diff-match-patch": "^1.0.36",
         "@types/node": "^22.10.0",
-        "@usejunior/docx-compare": "^0.16.0",
+        "@usejunior/docx-compare": "^0.17.0",
         "@vitest/coverage-v8": "^4.1.8",
         "@vitest/runner": "^4.1.8",
         "allure-vitest": "^3.9.0",
@@ -9076,13 +9076,13 @@
     },
     "packages/docx-mcp": {
       "name": "@usejunior/docx-mcp",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@usejunior/docx-compare": "^0.16.0",
-        "@usejunior/docx-core": "^0.16.0",
-        "@usejunior/odf-core": "^0.16.0",
+        "@usejunior/docx-compare": "^0.17.0",
+        "@usejunior/docx-core": "^0.17.0",
+        "@usejunior/odf-core": "^0.17.0",
         "@xmldom/xmldom": "^0.9.10",
         "zod": "^4.3.6"
       },
@@ -9103,7 +9103,7 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@usejunior/google-docs-core": "^0.16.0"
+        "@usejunior/google-docs-core": "^0.17.0"
       },
       "peerDependenciesMeta": {
         "@usejunior/google-docs-core": {
@@ -9113,7 +9113,7 @@
     },
     "packages/google-docs-core": {
       "name": "@usejunior/google-docs-core",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "google-auth-library": "^9.0.0"
@@ -9129,10 +9129,10 @@
     },
     "packages/odf-core": {
       "name": "@usejunior/odf-core",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@usejunior/docx-core": "^0.16.0",
+        "@usejunior/docx-core": "^0.17.0",
         "@xmldom/xmldom": "^0.9.10",
         "jszip": "^3.10.1"
       },
@@ -9147,10 +9147,10 @@
     },
     "packages/safe-docx": {
       "name": "@usejunior/safe-docx",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@usejunior/docx-mcp": "^0.16.0"
+        "@usejunior/docx-mcp": "^0.17.0"
       },
       "bin": {
         "safe-docx": "bin/safe-docx.js",
@@ -9162,10 +9162,10 @@
     },
     "packages/safe-docx-mcpb": {
       "name": "@usejunior/safedocx-mcpb",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@usejunior/safe-docx": "^0.16.0"
+        "@usejunior/safe-docx": "^0.17.0"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-docx-suite",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "private": true,
   "description": "Monorepo for Safe DOCX packages",
   "repository": {

--- a/packages/allure-test-factory/package.json
+++ b/packages/allure-test-factory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/allure-test-factory",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Shared Allure test helpers for vitest — BDD context, OpenSpec auto-inference, Prism.js highlighting",
   "type": "module",
   "exports": {

--- a/packages/docx-compare/package.json
+++ b/packages/docx-compare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/docx-compare",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "DOCX comparison and redline generation for Safe DOCX.",
   "type": "module",
   "main": "dist/index.js",
@@ -18,7 +18,7 @@
     "cli": "node dist/cli/index.js"
   },
   "dependencies": {
-    "@usejunior/docx-core": "^0.16.0",
+    "@usejunior/docx-core": "^0.17.0",
     "@xmldom/xmldom": "^0.9.10",
     "diff-match-patch": "^1.0.5",
     "jszip": "^3.10.1"

--- a/packages/docx-core/package.json
+++ b/packages/docx-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/docx-core",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "OOXML (.docx) core library: primitives, document generation, and track changes",
   "type": "module",
   "main": "dist/index.js",
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@types/diff-match-patch": "^1.0.36",
     "@types/node": "^22.10.0",
-    "@usejunior/docx-compare": "^0.16.0",
+    "@usejunior/docx-compare": "^0.17.0",
     "@vitest/coverage-v8": "^4.1.8",
     "@vitest/runner": "^4.1.8",
     "allure-vitest": "^3.9.0",

--- a/packages/docx-mcp/package.json
+++ b/packages/docx-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/docx-mcp",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "MCP server for reading, editing, and comparing Word (.docx) and OpenDocument (.odt) files with tracked changes. For Claude, Gemini CLI, Cursor, and any MCP client. Apache-2.0 licensed.",
   "type": "module",
   "main": "dist/index.js",
@@ -27,9 +27,9 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@usejunior/docx-compare": "^0.16.0",
-    "@usejunior/docx-core": "^0.16.0",
-    "@usejunior/odf-core": "^0.16.0",
+    "@usejunior/docx-compare": "^0.17.0",
+    "@usejunior/docx-core": "^0.17.0",
+    "@usejunior/odf-core": "^0.17.0",
     "@xmldom/xmldom": "^0.9.10",
     "zod": "^4.3.6"
   },
@@ -57,7 +57,7 @@
     "NOTICE"
   ],
   "peerDependencies": {
-    "@usejunior/google-docs-core": "^0.16.0"
+    "@usejunior/google-docs-core": "^0.17.0"
   },
   "peerDependenciesMeta": {
     "@usejunior/google-docs-core": {

--- a/packages/google-docs-core/package.json
+++ b/packages/google-docs-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/google-docs-core",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Google Docs core library: read, write, and anchor management via Google Docs API",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/odf-core/package.json
+++ b/packages/odf-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/odf-core",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "OpenDocument Format (.odt) core library: archive packaging, document view, surgical text replacement, and tracked-changes comparison",
   "type": "module",
   "main": "dist/index.js",
@@ -14,7 +14,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@usejunior/docx-core": "^0.16.0",
+    "@usejunior/docx-core": "^0.17.0",
     "@xmldom/xmldom": "^0.9.10",
     "jszip": "^3.10.1"
   },

--- a/packages/safe-docx-mcpb/manifest.json
+++ b/packages/safe-docx-mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "safe-docx",
   "display_name": "Safe Docx",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "AI-native Word (.docx) and OpenDocument (.odt) editing with stable paragraph anchors and deterministic document operations.",
   "long_description": "Safe Docx lets Claude work directly with .docx files on your local filesystem. It provides stable paragraph IDs (_bk_*) for precise editing while preserving formatting and structure.\n\nCore capabilities include reading/searching content, formatting-preserving edits and inserts, deterministic layout controls, tracked-changes output, comments, footnote tools, document comparison, and revision extraction.",
   "author": {

--- a/packages/safe-docx-mcpb/package.json
+++ b/packages/safe-docx-mcpb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/safedocx-mcpb",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "private": true,
   "description": "Claude Desktop MCP Bundle (.mcpb) wrapper for @usejunior/safe-docx",
   "type": "module",
@@ -14,7 +14,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@usejunior/safe-docx": "^0.16.0"
+    "@usejunior/safe-docx": "^0.17.0"
   },
   "devDependencies": {
     "@vitest/runner": "^4.1.8",

--- a/packages/safe-docx/.smithery/shttp/manifest.json
+++ b/packages/safe-docx/.smithery/shttp/manifest.json
@@ -6,7 +6,7 @@
     "serverCard": {
       "serverInfo": {
         "name": "safe-docx",
-        "version": "0.16.0"
+        "version": "0.17.0"
       },
       "tools": [
         {

--- a/packages/safe-docx/package.json
+++ b/packages/safe-docx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/safe-docx",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Edit Word (.docx) and OpenDocument (.odt) files with tracked changes, redlines, and formatting preservation. Built for AI coding agents. Apache-2.0 licensed, 100% local processing.",
   "mcpName": "io.github.UseJunior/safe-docx",
   "type": "module",
@@ -25,7 +25,7 @@
     "safedocx": "./bin/safe-docx.js"
   },
   "dependencies": {
-    "@usejunior/docx-mcp": "^0.16.0"
+    "@usejunior/docx-mcp": "^0.17.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/safe-docx/server.json
+++ b/packages/safe-docx/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.UseJunior/safe-docx",
   "title": "Safe Docx",
   "description": "AI-native surgical editing of Word .docx and OpenDocument .odt files with formatting preservation",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "websiteUrl": "https://usejunior.com/developer-tools/safe-docx",
   "icons": [
     {
@@ -18,7 +18,7 @@
     {
       "registryType": "npm",
       "identifier": "@usejunior/safe-docx",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "transport": {
         "type": "stdio"
       },

--- a/site/package.json
+++ b/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/safe-docx-site",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "private": true,
   "type": "module",
   "description": "Safe DOCX marketing and trust site (Eleventy)",


### PR DESCRIPTION
Cuts **0.17.0** so the anchor-resolution work reaches consumers.

0.16.0 sat wedged half-published for two weeks (docx-core published, the rest didn't — a new package couldn't be bootstrapped by OIDC trusted publishing) until #587 made a partial release recoverable by re-run. Cutting this one deliberately rather than letting it drift again.

## What ships in 0.17.0

- **#594 (closes #593) — paragraph anchors accept any bookmark name.** `findParagraphByBookmarkId` resolves a foreign name (a host application's own stable paragraph bookmark, a Word `_Toc*`/`_Ref*`) as an edit anchor, qualified by the `w:id`-paired range per **ECMA-376 Part 1 §17.13.6.2** and accepted only when that range covers **exactly one paragraph**. A zero-length point bookmark (covers none) and a multi-paragraph span (covers many) are refused, as are unpaired or duplicated names. Canonical `_bk_*` resolution runs first and is byte-for-byte unchanged.

  Why it matters: consumers cannot soundly reconstruct `_bk_*` ids. The id is `sha12("intrinsic:w14:<paraId>")` when a paragraph has a `w14:paraId` — but Aspose strips `w14:paraId` on save (safe-docx preserves it), so an Aspose-backed pipeline has none. The only remaining join is paragraph *text*, which is not an identity: two parsers extract it differently, so a "unique" text match can silently edit the wrong clause.

- **#531** — always emit `settings.xml` with `compatibilityMode=15`.
- **#603** — capability evidence projection (spec-compliance).

## Verification
- `node scripts/bump_version.mjs --check` → all 14 files at 0.17.0 (lockfile included).
- Clean `npm ci`; `docx-core`, `docx-compare`, `docx-mcp` all build at the bumped version.
- `main` CI green at `defd7b0`, `96ae994`, `b65600f`.
- #594 itself: docx-core 1200 passed · docx-mcp 876 passed · conformance + tool-docs clean · post-merge smoke drove a real `replace_text` on a real NVCA legal form through a real Word bookmark anchor (33/35 real bookmarks resolved correctly, 2 refused by the range guard, canonical round-trip 153/153).

## Release mechanics
On merge, `auto-tag-release.yml` pushes `v0.17.0` with the release-bot App token, which triggers `release.yml` (npm OIDC trusted publishing is pinned to that workflow filename). Manual fallback if the tag doesn't appear: `git tag v0.17.0 && git push origin v0.17.0`.

Watch for the failure mode from last time: the publish loop now **skips** already-published packages instead of aborting (#587), so a partial publish is recoverable by re-running the workflow.

## Consumer follow-up
`UseJunior/legal-agent-harness` pins `@usejunior/safe-docx@0.16.0` and currently falls back to its Python edit path because a `jr_para_*` anchor returns `ANCHOR_NOT_FOUND`. Once this publishes, bumping that pin makes the MCP edit path functional with no further harness changes (legal-agent-harness#196).