### PR TITLE
fix(release): install xmllint before preflight tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,6 +148,18 @@ jobs:
             echo "::warning::Resuming a partial release: $published/$total packages already published at $VERSION."
           fi
 
+      # Schema-backed workspace tests shell out to xmllint against the vendored
+      # ECMA-376 XSDs, so it must exist before tests run. ci.yml already does
+      # this ("Install XML schema validator"); release.yml did not, so those
+      # tests failed here with spawnSync status null while passing in CI — a
+      # preflight-only failure that blocks EVERY release. Keep the two in step.
+      - name: Install XML schema validator
+        run: |
+          if ! command -v xmllint >/dev/null; then
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends libxml2-utils
+          fi
+
       - name: Test workspaces
         run: npm run test
 


### PR DESCRIPTION
The **0.17.0 release failed in preflight** and nothing published — npm is still on 0.16.0.

## What failed
`Release preflight → Test workspaces`, three failures in `packages/docx-core/src/generation/generation-structural-vocabularies-conformance.test.ts`:

```
AssertionError: expected null to be +0 // Object.is equality
- Expected: 0
+ Received: null
```

## Cause
Those tests shell out to `xmllint` against the vendored ECMA-376 XSDs and assert `spawnSync(...).status === 0`. When the binary is missing, `spawnSync` returns status **`null`** — precisely the assertion above (and `stderr` is empty, consistent with a spawn that never happened).

`ci.yml` installs it in a step placed deliberately *before* the tests, with this comment:

> `# Schema-backed workspace tests invoke the same vendored-XSD validator as the emitted-document gate below, so xmllint must exist before tests run.`
> `- name: Install XML schema validator`

`release.yml` never got that step. So the same suite **passes in PR CI and fails only in the release preflight** — which is why #604's own CI was green.

Verified in the logs: CI run `29935750274` shows `Install XML schema validator` followed by `✓ generation-structural-vocabularies-conformance.test.ts (7 tests)`; the release run shows the same file with `3 failed` and no install step.

## Why this is worth its own PR
It blocks **every** release, not just 0.17.0. The schema-backed tests landed after the last preflight that ran to completion (0.16.0 got past preflight and died later, at `ENEEDAUTH` in publish), so no release has succeeded since they were added. Same shape as #587: a release-only gap that PR CI structurally cannot catch.

## Change
Adds the identical guarded install to `release.yml`'s preflight, before both `Test workspaces` and `Package-level smoke tests`. No-op when the runner image already has `xmllint`.

## Verification
- YAML parses; the install step precedes the test step in the parsed job object.
- `actionlint` clean.

## After merge
Re-run the release for the existing tag: `gh workflow run release.yml --ref main -f release_tag=v0.17.0`. The tag `v0.17.0` (`e38ad58`) is already pushed, and #587's guard skips already-published packages, so a partial state would be recoverable.