### PR TITLE
fix(docx-compare): preserve body block controls on rebuild

### DIFF
--- a/openspec/changes/preserve-block-sdt-on-rebuild/design.md
+++ b/openspec/changes/preserve-block-sdt-on-rebuild/design.md
@@ -1,0 +1,82 @@
+## Context
+
+The inline-SDT pilot associates one opaque boundary with atoms in one paragraph
+and emits it from the paragraph run stream. A direct body-level block SDT owns
+multiple descendant paragraph slots and must instead be emitted by the original
+body scaffold. Reconstructing any owned paragraph destroys exact subtree
+preservation; preserving the original wrapper after replacing descendants is
+also insufficient because it loses controlled paragraph attributes and complex
+payload such as DrawingML.
+
+## Goals / Non-Goals
+
+- Goals: preserve an unchanged direct `w:body/w:sdt` subtree and its effective
+  namespace/MCE semantics while unrelated body paragraphs rebuild normally.
+- Goals: bind the control to one contiguous source-order paragraph-slot interval,
+  validate every controlled paragraph's relative ownership, and consume that
+  interval atomically in the scaffold.
+- Goals: pair multiple or identical controls deterministically from local body
+  placement and ownership, with precomputed/memoized group identity and
+  deterministic complexity evidence.
+- Non-Goals: row/cell/nested/editable controls; controls outside `document.xml`;
+  footer or ancillary reconstruction; tables inside a supported control; rsids
+  outside the preserved subtree; fields; `sectPr`; arbitrary package parts.
+
+## Decisions
+
+### Placement is explicit
+
+`OpaquePassthroughNode` records `placementKind` as `inline-run` or
+`body-block`. Inline descriptors retain one paragraph owner and paragraph-run
+emission. Body-block descriptors record their direct body-child ordinal and a
+closed, contiguous interval of global paragraph slots. A block descriptor is
+attached to every atom in every owned paragraph, but its subtree is emitted only
+by the body scaffold.
+
+### Correlation is local and fail closed
+
+Original and revised occurrences pair by placement, direct body-child ordinal,
+slot interval, relative paragraph ownership, namespace-aware semantic
+fingerprint, and boundary QName. Document-wide SDT ordinal alone is never used
+to make identical controls appear correlated. Each owned paragraph must remain
+equal at the opaque identity level and in the same relative slot. Mutation,
+insertion, deletion, reordering, movement, non-contiguous ownership, missing
+atoms, or a non-equal owned atom rejects before paragraph serialization.
+
+### The scaffold owns block emission
+
+The reconstructor preflights block ownership before building paragraph XML.
+When its slot cursor reaches the first owned slot, it leaves the validated
+original block subtree in place and advances over the full owned interval.
+No owned paragraph is reconstructed or replaced. Inserted content cannot be
+placed into the interval. Paragraphs outside the interval retain the existing
+tracked-change path.
+
+### Namespace and relationship semantics reuse the opaque substrate
+
+Fingerprinting, effective namespace/MCE validation, and source subtree capture
+are shared between placements. Because rebuild clones the original package,
+preserving the original block subtree also preserves every drawing `r:id`; tests
+resolve each retained ID through the unchanged original relationship part and
+compare the target.
+
+### Claims remain bounded
+
+Block structure is cited to ECMA-376 Part 1 §§17.5.2.29, 17.5.2.34, and
+17.5.2.38. Exact opaque preservation and package-part stability are SafeDocX
+metamorphic invariants, not requirements imposed by ECMA-376.
+
+## Risks / Trade-offs
+
+- An otherwise safe edit inside the control is rejected. This avoids silently
+  preserving stale controlled content or flattening unsupported structure.
+- Block controls containing tables are rejected in this slice because paragraph
+  slot ownership alone cannot represent table/cell placement safely.
+- Footer SDTs remain outside reconstruction support; package-clone identity may
+  be observed only as no-regression evidence.
+
+## Migration Plan
+
+No API migration is required. Existing inline controls keep their current
+behavior. Newly supported direct body-level controls pass through only when the
+strict block ownership contract is satisfied.

--- a/openspec/changes/preserve-block-sdt-on-rebuild/design.md
+++ b/openspec/changes/preserve-block-sdt-on-rebuild/design.md
@@ -60,9 +60,14 @@ every relationship-namespace attribute through the owning part. It includes the
 relationship Id, type, target mode, normalized target, and internal target part
 path and byte hash. Referenced XML parts recursively contribute their referenced
 relationship closure. Relationship tables, part hashes, and closure nodes are
-memoized per package; blocks without relationship attributes avoid all archive
-reads. Dangling, unsafe, cyclic, and unsupported relationship-bearing targets
-fail closed before correlation.
+memoized per package. Recursive closure identities are cached only after they
+complete, and root traversals are serialized so independent roots cannot await
+each other's unresolved cycle. Blocks without relationship attributes avoid all
+archive reads. Internal targets accept only package-root or package-relative URI
+paths after safe decoding; authority references, URI schemes, malformed escapes,
+backslashes, control characters, and package-root escapes fail closed before
+normalization. Dangling, cyclic, and unsupported relationship-bearing targets
+also fail closed before correlation.
 
 ### Claims remain bounded
 

--- a/openspec/changes/preserve-block-sdt-on-rebuild/design.md
+++ b/openspec/changes/preserve-block-sdt-on-rebuild/design.md
@@ -55,10 +55,14 @@ tracked-change path.
 ### Namespace and relationship semantics reuse the opaque substrate
 
 Fingerprinting, effective namespace/MCE validation, and source subtree capture
-are shared between placements. Because rebuild clones the original package,
-preserving the original block subtree also preserves every drawing `r:id`; tests
-resolve each retained ID through the unchanged original relationship part and
-compare the target.
+are shared between placements. Block counterpart identity additionally resolves
+every relationship-namespace attribute through the owning part. It includes the
+relationship Id, type, target mode, normalized target, and internal target part
+path and byte hash. Referenced XML parts recursively contribute their referenced
+relationship closure. Relationship tables, part hashes, and closure nodes are
+memoized per package; blocks without relationship attributes avoid all archive
+reads. Dangling, unsafe, cyclic, and unsupported relationship-bearing targets
+fail closed before correlation.
 
 ### Claims remain bounded
 

--- a/openspec/changes/preserve-block-sdt-on-rebuild/proposal.md
+++ b/openspec/changes/preserve-block-sdt-on-rebuild/proposal.md
@@ -14,6 +14,9 @@ even when the control itself is unchanged.
   and contiguous paragraph-slot ownership while retaining the inline contract.
 - Capture unchanged direct body-level block SDTs, pair them deterministically,
   and preserve the validated original subtree as one scaffold-owned block.
+- Bind every relationship-namespace attribute in a block to a memoized package
+  closure covering relationship metadata, normalized targets, internal part
+  hashes, and recursively referenced XML-part relationships.
 - Reject mutation, movement, ownership loss, nesting, unsupported placement, or
   correlation loss before any lossy rebuilt XML is emitted.
 - Replace the ILPA count-only measurement with forced-rebuild corpus evidence
@@ -28,6 +31,6 @@ even when the control itself is unchanged.
 - Affected specs: `docx-comparison`, `cross-implementation-conformance`,
   `spec-compliance`
 - Affected code: opaque atom metadata/capture/correlation, hierarchical LCS
-  identity, rebuild scaffold, focused and ILPA corpus tests, ECMA registry, DPT
-  pin and capability projection
+  identity, package relationship closure, rebuild scaffold, focused and ILPA
+  corpus tests, ECMA registry, DPT pin and capability projection
 - Ref: #582

--- a/openspec/changes/preserve-block-sdt-on-rebuild/proposal.md
+++ b/openspec/changes/preserve-block-sdt-on-rebuild/proposal.md
@@ -1,0 +1,33 @@
+# Change: Preserve direct body block content controls during rebuild
+
+## Why
+
+Forced comparison rebuild currently descends into direct `w:body/w:sdt`
+controls and replaces each controlled paragraph in the original scaffold. That
+silently rewrites complete cover-page controls in the ILPA corpus, dropping
+DrawingML, relationship references, revision identifiers, and control metadata
+even when the control itself is unchanged.
+
+## What Changes
+
+- Generalize the opaque passthrough descriptor with an explicit placement kind
+  and contiguous paragraph-slot ownership while retaining the inline contract.
+- Capture unchanged direct body-level block SDTs, pair them deterministically,
+  and preserve the validated original subtree as one scaffold-owned block.
+- Reject mutation, movement, ownership loss, nesting, unsupported placement, or
+  correlation loss before any lossy rebuilt XML is emitted.
+- Replace the ILPA count-only measurement with forced-rebuild corpus evidence
+  that makes real unrelated edits and validates the complete SDT subtree,
+  relationship target, package-part change set, and accept/reject projections.
+- Pin docx-platform-tests PR #57 merge `ba9936af06cc18249e892dc594ed9bcefaf98463`,
+  refresh its reviewed capability registry, and retain oracle-specific outcome
+  validation.
+
+## Impact
+
+- Affected specs: `docx-comparison`, `cross-implementation-conformance`,
+  `spec-compliance`
+- Affected code: opaque atom metadata/capture/correlation, hierarchical LCS
+  identity, rebuild scaffold, focused and ILPA corpus tests, ECMA registry, DPT
+  pin and capability projection
+- Ref: #582

--- a/openspec/changes/preserve-block-sdt-on-rebuild/specs/cross-implementation-conformance/spec.md
+++ b/openspec/changes/preserve-block-sdt-on-rebuild/specs/cross-implementation-conformance/spec.md
@@ -1,0 +1,16 @@
+## MODIFIED Requirements
+
+### Requirement: Suite Revision Is SHA-Pinned
+
+The self-check SHALL pin docx-platform-tests PR #57 merge commit
+`ba9936af06cc18249e892dc594ed9bcefaf98463`, execute both content-control
+scenarios through the real neutral runner, and validate outcomes according to
+their oracle class.
+
+#### Scenario: [XIMPL-09] Both neutral content-control scenarios pass at the reviewed pin
+
+- **GIVEN** docx-platform-tests at commit `ba9936af06cc18249e892dc594ed9bcefaf98463`
+- **WHEN** the safe-docx adapter runs both content-control scenarios
+- **THEN** the normative scenario SHALL report only `pass` or `pass-divergent`
+- **AND** the metamorphic scenario SHALL report only `invariant-pass`
+- **AND** ordinary adapter results SHALL NOT be presented as forced-rebuild evidence

--- a/openspec/changes/preserve-block-sdt-on-rebuild/specs/docx-comparison/spec.md
+++ b/openspec/changes/preserve-block-sdt-on-rebuild/specs/docx-comparison/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Forced rebuild preserves unchanged direct body block structured document tags
+
+When comparison uses `reconstructionMode: rebuild`, the system SHALL preserve an
+unchanged direct `w:body/w:sdt` subtree as one opaque scaffold-owned block,
+including ordered `w:sdtPr`, optional `w:sdtEndPr`, `w:sdtContent`, every
+controlled paragraph and attribute, complex DrawingML payload, relationship
+references, and effective namespace/MCE semantics. Exact opaque preservation is
+a bounded SafeDocX metamorphic invariant, not an ECMA-376 requirement.
+
+#### Scenario: [SDX-SDT-BLOCK-01] Outside edits retain a complete block control
+
+- **GIVEN** a direct body-level block control owning a contiguous paragraph interval
+- **WHEN** unrelated body paragraphs are edited through forced rebuild
+- **THEN** the validated original block subtree SHALL remain semantically identical
+- **AND** drawing relationship references SHALL resolve to the same targets
+- **AND** accepting and rejecting changes SHALL retain the block while projecting the outside edit correctly
+
+#### Scenario: [SDX-SDT-BLOCK-02] Multiple identical controls pair locally and deterministically
+
+- **GIVEN** multiple unchanged direct body-level block controls, including semantically identical controls
+- **WHEN** forced rebuild correlates and reconstructs the document
+- **THEN** each control SHALL retain its direct body placement and paragraph-slot ownership
+- **AND** no document-wide ordinal SHALL launder movement or changed ownership into a valid match
+
+#### Scenario: [SDX-SDT-BLOCK-03] Unsupported block ownership fails before output
+
+- **GIVEN** mutation, an internal edit, insertion, deletion, reorder, movement, changed or non-contiguous paragraph ownership, correlation loss, nesting, or table/cell placement
+- **WHEN** forced rebuild attempts opaque block passthrough
+- **THEN** reconstruction SHALL fail before emitting lossy document XML
+- **AND** it SHALL NOT preserve stale content, flatten the control, or partially replace owned paragraphs
+
+#### Scenario: [SDX-SDT-BLOCK-04] Block identity work remains linear in group count
+
+- **GIVEN** ordinary and block-owned paragraph groups
+- **WHEN** hierarchical correlation computes opaque group identity
+- **THEN** identity SHALL be precomputed or memoized once per group per comparison run
+- **AND** deterministic instrumentation counts SHALL prove that bound without timing assertions

--- a/openspec/changes/preserve-block-sdt-on-rebuild/specs/docx-comparison/spec.md
+++ b/openspec/changes/preserve-block-sdt-on-rebuild/specs/docx-comparison/spec.md
@@ -43,5 +43,7 @@ a bounded SafeDocX metamorphic invariant, not an ECMA-376 requirement.
 - **GIVEN** a block control referencing internal or external package relationships
 - **WHEN** an Id binding, type, target mode, normalized target, referenced part bytes, or recursively referenced XML-part closure differs
 - **THEN** forced rebuild SHALL fail before reconstruction
-- **AND** dangling, unsafe, cyclic, or unsupported relationship-bearing targets SHALL fail closed
+- **AND** single-root and multi-root dependency cycles SHALL reject deterministically without unresolved traversal waits
+- **AND** package-root and ordinary relative internal targets SHALL remain valid
+- **AND** decoded authority references, malformed escapes, backslashes, URI schemes, dangling targets, and unsupported relationship-bearing targets SHALL fail closed before package normalization
 - **AND** external targets SHALL be compared without network access

--- a/openspec/changes/preserve-block-sdt-on-rebuild/specs/docx-comparison/spec.md
+++ b/openspec/changes/preserve-block-sdt-on-rebuild/specs/docx-comparison/spec.md
@@ -14,7 +14,7 @@ a bounded SafeDocX metamorphic invariant, not an ECMA-376 requirement.
 - **GIVEN** a direct body-level block control owning a contiguous paragraph interval
 - **WHEN** unrelated body paragraphs are edited through forced rebuild
 - **THEN** the validated original block subtree SHALL remain semantically identical
-- **AND** drawing relationship references SHALL resolve to the same targets
+- **AND** every relationship-namespace attribute SHALL resolve to an identical relationship and dependent-part closure on both sides
 - **AND** accepting and rejecting changes SHALL retain the block while projecting the outside edit correctly
 
 #### Scenario: [SDX-SDT-BLOCK-02] Multiple identical controls pair locally and deterministically
@@ -37,3 +37,11 @@ a bounded SafeDocX metamorphic invariant, not an ECMA-376 requirement.
 - **WHEN** hierarchical correlation computes opaque group identity
 - **THEN** identity SHALL be precomputed or memoized once per group per comparison run
 - **AND** deterministic instrumentation counts SHALL prove that bound without timing assertions
+
+#### Scenario: [SDX-SDT-BLOCK-05] Relationship closure changes fail before reconstruction
+
+- **GIVEN** a block control referencing internal or external package relationships
+- **WHEN** an Id binding, type, target mode, normalized target, referenced part bytes, or recursively referenced XML-part closure differs
+- **THEN** forced rebuild SHALL fail before reconstruction
+- **AND** dangling, unsafe, cyclic, or unsupported relationship-bearing targets SHALL fail closed
+- **AND** external targets SHALL be compared without network access

--- a/openspec/changes/preserve-block-sdt-on-rebuild/specs/spec-compliance/spec.md
+++ b/openspec/changes/preserve-block-sdt-on-rebuild/specs/spec-compliance/spec.md
@@ -1,0 +1,14 @@
+## ADDED Requirements
+
+### Requirement: Block structured document tag claims cite exact normative structure
+
+The conformance registry SHALL cite ECMA-376 edition 5 Part 1 §§17.5.2.29,
+17.5.2.34, and 17.5.2.38 for block SDT structure, block content, and properties,
+while exact opaque preservation remains a separately labeled SafeDocX
+metamorphic invariant.
+
+#### Scenario: [SPEC-COV-SDT-BLOCK-01] Block preservation evidence remains bounded
+
+- **WHEN** block-SDT implementation and tests claim normative structure
+- **THEN** JSDoc and Allure metadata SHALL cite the three exact ECMA sections
+- **AND** no claim SHALL broaden to row, cell, nested, editable, footer, or ancillary control reconstruction

--- a/openspec/changes/preserve-block-sdt-on-rebuild/tasks.md
+++ b/openspec/changes/preserve-block-sdt-on-rebuild/tasks.md
@@ -28,3 +28,11 @@
 - [x] 5.1 Run focused/full tests, build/lint, mandatory pre-submit, emitted-schema MCE/XSD, DPT, and archive checks.
 - [x] 5.2 Run LibreOffice open-save and PDF smoke checks for both ILPA outputs.
 - [x] 5.3 Review scope and commit conventionally with WHY and `Ref: #582`.
+
+## 6. Relationship-closure review fix
+
+- [x] 6.1 Add memoized package relationship-closure identity for opaque body blocks.
+- [x] 6.2 Fail closed on changed, missing, unsafe, cyclic, or unsupported relationship targets and dependent parts.
+- [x] 6.3 Add adversarial direct-image, external-target, recursive XML, alias, and fast-path tests.
+- [x] 6.4 Compare original, revised, and output ILPA relationship closures and media bytes.
+- [x] 6.5 Re-run all required gates and commit the review fix.

--- a/openspec/changes/preserve-block-sdt-on-rebuild/tasks.md
+++ b/openspec/changes/preserve-block-sdt-on-rebuild/tasks.md
@@ -1,0 +1,30 @@
+## 1. Specification and conformance
+
+- [x] 1.1 Validate the OpenSpec proposal and delta requirements.
+- [x] 1.2 Register exact ECMA-376 block SDT, block content, and property sections.
+- [x] 1.3 Keep opaque preservation labeled as a bounded metamorphic invariant.
+
+## 2. Placement-aware opaque substrate
+
+- [x] 2.1 Add placement kind and block paragraph-slot ownership to the reusable descriptor.
+- [x] 2.2 Reuse fingerprint and effective namespace/MCE validation for direct body block SDTs.
+- [x] 2.3 Pair unchanged block controls deterministically without global ordinal laundering.
+- [x] 2.4 Fail closed on mutation, internal edits, movement, ownership loss, nesting, unsupported placement, or correlation loss.
+- [x] 2.5 Precompute/memoize group identity and expose deterministic complexity counts.
+
+## 3. Rebuild scaffold
+
+- [x] 3.1 Advance over every owned paragraph slot without reconstructing or replacing it.
+- [x] 3.2 Preserve unrelated outside edits and correct accept/reject projections.
+
+## 4. Evidence and neutral suite
+
+- [x] 4.1 Add focused positive, multiple/identical, and fail-closed block tests.
+- [x] 4.2 Upgrade both ILPA corpus scenarios to real outside edits and complete subtree/relationship/package-part validation.
+- [x] 4.3 Pin DPT merge `ba9936af06cc18249e892dc594ed9bcefaf98463`, refresh registry hashes/projection, and validate oracle-specific statuses.
+
+## 5. Verification and delivery
+
+- [x] 5.1 Run focused/full tests, build/lint, mandatory pre-submit, emitted-schema MCE/XSD, DPT, and archive checks.
+- [x] 5.2 Run LibreOffice open-save and PDF smoke checks for both ILPA outputs.
+- [x] 5.3 Review scope and commit conventionally with WHY and `Ref: #582`.

--- a/openspec/changes/preserve-block-sdt-on-rebuild/tasks.md
+++ b/openspec/changes/preserve-block-sdt-on-rebuild/tasks.md
@@ -36,3 +36,11 @@
 - [x] 6.3 Add adversarial direct-image, external-target, recursive XML, alias, and fast-path tests.
 - [x] 6.4 Compare original, revised, and output ILPA relationship closures and media bytes.
 - [x] 6.5 Re-run all required gates and commit the review fix.
+
+## 7. Cycle and internal-target review fix
+
+- [x] 7.1 Serialize independent closure roots and cache only completed recursive identities.
+- [x] 7.2 Reject decoded authority, malformed, backslash, scheme, and other unsafe internal target forms before package normalization.
+- [x] 7.3 Add timeout-free multi-root cycle, shared dependency, and positive/negative target controls.
+- [x] 7.4 Re-run focused/full tests, preflight/gates, DPT, schema, and LibreOffice checks.
+- [x] 7.5 Commit the final review fix conventionally without pushing.

--- a/packages/docx-compare/src/atomizer.ts
+++ b/packages/docx-compare/src/atomizer.ts
@@ -23,9 +23,9 @@ import {
 } from '@usejunior/docx-core';
 import { OOXML } from '@usejunior/docx-core';
 import {
-  captureInlineSdtPassthrough,
+  captureSdtPassthrough,
   sameOpaqueOwner,
-  validateInlineSdtNamespaceOwnership,
+  validateSdtNamespaceOwnership,
 } from './baselines/atomizer/opaquePassthrough.js';
 
 // =============================================================================
@@ -532,7 +532,7 @@ export interface AtomizeTreeOptions {
    * Default: false.
    */
   atomizeParagraphLevelMarkers?: boolean;
-  /** Capture unchanged inline SDTs as bounded opaque rebuild nodes. */
+  /** Capture unchanged supported SDT placements as bounded opaque rebuild nodes. */
   captureInlineSdtPassthrough?: boolean;
 }
 
@@ -837,9 +837,9 @@ export function atomizeTree(
     consecutiveEmptyIndex: 0,
     lastContentHash: '',
   };
-  if (normalizedOptions.captureInlineSdtPassthrough) validateInlineSdtNamespaceOwnership(node);
+  if (normalizedOptions.captureInlineSdtPassthrough) validateSdtNamespaceOwnership(node);
   const rawAtoms = atomizeTreeInternal(node, ancestors, part, state, normalizedOptions);
-  if (normalizedOptions.captureInlineSdtPassthrough) captureInlineSdtPassthrough(node, rawAtoms);
+  if (normalizedOptions.captureInlineSdtPassthrough) captureSdtPassthrough(node, rawAtoms);
 
   // Step 1: Collapse field sequences into single atoms based on visible text
   // This allows matching between hardcoded text and field references
@@ -1090,6 +1090,8 @@ export function collapseFieldSequences(
           // Inherit rPr from first atom in the field sequence
           rPr: firstAtom.rPr,
           opaquePassthrough: firstAtom.opaquePassthrough,
+          opaquePassthroughRelativeParagraphOrdinal:
+            firstAtom.opaquePassthroughRelativeParagraphOrdinal,
         },
         (self) => hashElement(self.contentElement),
         elementIdentityString(virtualElement),
@@ -1181,6 +1183,8 @@ function splitAtomIntoWords(atom: ComparisonUnitAtom): ComparisonUnitAtom[] {
         // Share rPr reference (read-only after atomization)
         rPr: atom.rPr,
         opaquePassthrough: atom.opaquePassthrough,
+        opaquePassthroughRelativeParagraphOrdinal:
+          atom.opaquePassthroughRelativeParagraphOrdinal,
       },
       (self) => hashElement(self.contentElement),
       elementIdentityString(wordElement),

--- a/packages/docx-compare/src/baselines/atomizer/documentReconstructor-block-sdt.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/documentReconstructor-block-sdt.test.ts
@@ -17,11 +17,17 @@ import {
   extractTextWithParagraphs,
   rejectAllChanges,
 } from './trackChangesAcceptorAst.js';
+import { OpaqueRelationshipClosureResolver } from './opaquePassthrough.js';
+
+const R_NS = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const IMAGE_REL = `${R_NS}/image`;
+const CUSTOM_XML_REL = `${R_NS}/customXml`;
+const TEST_FEATURE = 'Document Reconstructor Block SDT';
 
 const test = testAllure
   .epic('Document Comparison')
   .withLabels({
-    feature: 'Document Reconstructor Block SDT',
+    feature: TEST_FEATURE,
     story: 'Opaque Direct Body Block Content Control Preservation',
     severity: 'critical',
   })
@@ -60,6 +66,53 @@ async function rebuild(originalBody: string, revisedBody: string): Promise<strin
   );
   expect(result.reconstructionModeUsed).toBe('rebuild');
   return (await DocxArchive.load(result.document)).getDocumentXml();
+}
+
+interface RelationshipFixture {
+  id: string;
+  type: string;
+  target: string;
+  mode?: 'Internal' | 'External';
+}
+
+function relationshipsXml(relationships: RelationshipFixture[]): string {
+  const escape = (value: string) => value.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+  return `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+    relationships.map((relationship) =>
+      `<Relationship Id="${escape(relationship.id)}" Type="${escape(relationship.type)}"` +
+      ` Target="${escape(relationship.target)}"` +
+      (relationship.mode ? ` TargetMode="${relationship.mode}"` : '') + '/>',
+    ).join('') + '</Relationships>';
+}
+
+async function packageWithRelationships(
+  body: string,
+  relationships: RelationshipFixture[],
+  files: Readonly<Record<string, string | Buffer>> = {},
+  namespaces: Readonly<Record<string, string>> = { r: R_NS },
+): Promise<Buffer> {
+  const archive = await DocxArchive.load(await buildDocxFromBodyXml(body, [], { namespaces }));
+  archive.setFile('word/_rels/document.xml.rels', relationshipsXml(relationships));
+  for (const [path, content] of Object.entries(files)) archive.setFile(path, content);
+  return archive.save();
+}
+
+async function rebuildPackages(original: Buffer, revised: Buffer): Promise<Buffer> {
+  const result = await compareDocumentsAtomizer(original, revised, {
+    author: 'Issue 582 Relationship Test',
+    date: new Date('2026-07-22T00:00:00Z'),
+    reconstructionMode: 'rebuild',
+  });
+  expect(result.reconstructionModeUsed).toBe('rebuild');
+  return result.document;
+}
+
+function drawingBlock(relationshipId = 'rIdImage', prefix = 'r'): string {
+  return blockSdt(
+    `<w:p w14:paraId="00000031" w14:textId="77777777">` +
+    `<w:r><w:drawing><a:graphic xmlns:a="urn:test:drawing" ${prefix}:embed="${relationshipId}"/>` +
+    `</w:drawing></w:r></w:p>`,
+  );
 }
 
 function directBodyControls(xml: string): Element[] {
@@ -154,6 +207,190 @@ describe('unsupported body block ownership fails closed', () => {
           await expect(rebuild(original, revised), name).rejects.toThrow(/Opaque passthrough:/);
         }
       });
+    },
+  );
+});
+
+describe('opaque body block relationship closure', () => {
+  const tailOriginal = paragraph('Outside old', '00000032');
+  const tailRevised = paragraph('Outside new', '00000032');
+  const imageRelationship: RelationshipFixture = {
+    id: 'rIdImage',
+    type: IMAGE_REL,
+    target: 'media/logo.png',
+  };
+
+  test.openspec('[SDX-SDT-BLOCK-01] Outside edits retain a complete block control')(
+    'preserves an unchanged direct image binding and media payload',
+    async () => {
+      const bodyOriginal = drawingBlock() + tailOriginal;
+      const bodyRevised = drawingBlock() + tailRevised;
+      const media = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a]);
+      const original = await packageWithRelationships(bodyOriginal, [imageRelationship], {
+        'word/media/logo.png': media,
+      });
+      const revised = await packageWithRelationships(bodyRevised, [imageRelationship], {
+        'word/media/logo.png': media,
+      });
+
+      const output = await rebuildPackages(original, revised);
+      const outputArchive = await DocxArchive.load(output);
+      expect(await outputArchive.getFile('word/_rels/document.xml.rels')).toBe(relationshipsXml([imageRelationship]));
+      expect(await outputArchive.getFileBuffer('word/media/logo.png')).toEqual(media);
+    },
+  );
+
+  test.openspec('[SDX-SDT-BLOCK-05] Relationship closure changes fail before reconstruction')(
+    'rejects direct image retargets, byte changes, type or mode changes, missing media, and changed embed Ids',
+    async () => {
+      const media = Buffer.from('original-image');
+      const original = await packageWithRelationships(drawingBlock() + tailOriginal, [imageRelationship], {
+        'word/media/logo.png': media,
+      });
+      const cases: Array<[string, Promise<Buffer>]> = [
+        ['retarget', packageWithRelationships(drawingBlock() + tailRevised, [
+          { ...imageRelationship, target: 'media/other.png' },
+        ], { 'word/media/other.png': media })],
+        ['changed bytes', packageWithRelationships(drawingBlock() + tailRevised, [imageRelationship], {
+          'word/media/logo.png': Buffer.from('revised-image'),
+        })],
+        ['changed type', packageWithRelationships(drawingBlock() + tailRevised, [
+          { ...imageRelationship, type: `${R_NS}/oleObject` },
+        ], { 'word/media/logo.png': media })],
+        ['changed mode', packageWithRelationships(drawingBlock() + tailRevised, [
+          { ...imageRelationship, target: 'https://example.test/logo.png', mode: 'External' },
+        ])],
+        ['missing media', packageWithRelationships(drawingBlock() + tailRevised, [imageRelationship])],
+        ['changed embed', packageWithRelationships(drawingBlock('rIdOther') + tailRevised, [
+          imageRelationship,
+          { ...imageRelationship, id: 'rIdOther' },
+        ], { 'word/media/logo.png': media })],
+      ];
+
+      for (const [name, revised] of cases) {
+        await expect(rebuildPackages(original, await revised), name).rejects.toThrow(/Opaque passthrough:/);
+      }
+    },
+  );
+
+  test.openspec('[SDX-SDT-BLOCK-05] Relationship closure changes fail before reconstruction')(
+    'handles namespace aliases and compares external targets without fetching',
+    async () => {
+      const external = {
+        id: 'rIdImage',
+        type: IMAGE_REL,
+        target: 'https://example.test/assets/logo.png',
+        mode: 'External' as const,
+      };
+      const original = await packageWithRelationships(
+        drawingBlock('rIdImage', 'rel') + tailOriginal,
+        [external],
+        {},
+        { rel: R_NS },
+      );
+      const unchanged = await packageWithRelationships(
+        drawingBlock('rIdImage', 'rel') + tailRevised,
+        [external],
+        {},
+        { rel: R_NS },
+      );
+      await expect(rebuildPackages(original, unchanged)).resolves.toBeInstanceOf(Buffer);
+
+      const changed = await packageWithRelationships(
+        drawingBlock('rIdImage', 'rel') + tailRevised,
+        [{ ...external, target: 'https://example.test/assets/changed.png' }],
+        {},
+        { rel: R_NS },
+      );
+      await expect(rebuildPackages(original, changed)).rejects.toThrow(/Opaque passthrough:/);
+    },
+  );
+
+  test.openspec('[SDX-SDT-BLOCK-05] Relationship closure changes fail before reconstruction')(
+    'recursively fingerprints relationship-bearing XML target parts',
+    async () => {
+      const control = blockSdt(
+        `<w:p w14:paraId="00000033"><w:r><w:drawing r:id="rIdCustom"/></w:r></w:p>`,
+      );
+      const rootRelationship: RelationshipFixture = {
+        id: 'rIdCustom', type: CUSTOM_XML_REL, target: 'custom/item.xml',
+      };
+      const nestedRelationship: RelationshipFixture = {
+        id: 'rIdNested', type: IMAGE_REL, target: '../media/nested.png',
+      };
+      const customXml = `<x:root xmlns:x="urn:test:custom" xmlns:r="${R_NS}" r:id="rIdNested"/>`;
+      const files = (media: Buffer): Record<string, string | Buffer> => ({
+        'word/custom/item.xml': customXml,
+        'word/custom/_rels/item.xml.rels': relationshipsXml([nestedRelationship]),
+        'word/media/nested.png': media,
+      });
+      const original = await packageWithRelationships(control + tailOriginal, [rootRelationship], files(Buffer.from('one')));
+      const unchanged = await packageWithRelationships(control + tailRevised, [rootRelationship], files(Buffer.from('one')));
+      await expect(rebuildPackages(original, unchanged)).resolves.toBeInstanceOf(Buffer);
+      const changed = await packageWithRelationships(control + tailRevised, [rootRelationship], files(Buffer.from('two')));
+      await expect(rebuildPackages(original, changed)).rejects.toThrow(/Opaque passthrough:/);
+    },
+  );
+
+  test.openspec('[SDX-SDT-BLOCK-05] Relationship closure changes fail before reconstruction')(
+    'rejects dangling, unsafe, cyclic, and unsupported relationship-bearing targets',
+    async () => {
+      const control = drawingBlock() + tailOriginal;
+      const cases: Array<[string, Promise<Buffer>]> = [
+        ['dangling relationship', packageWithRelationships(control, [])],
+        ['unsafe target', packageWithRelationships(control, [{ ...imageRelationship, target: '../../../escape.png' }])],
+        ['unsupported relationship-bearing target', packageWithRelationships(control, [imageRelationship], {
+          'word/media/logo.png': Buffer.from('image'),
+          'word/media/_rels/logo.png.rels': relationshipsXml([]),
+        })],
+      ];
+      for (const [name, input] of cases) {
+        await expect(rebuildPackages(await input, await input), name).rejects.toThrow(/Opaque passthrough:/);
+      }
+
+      const cyclicControl = blockSdt(`<w:p w14:paraId="00000034"><w:r><w:drawing r:id="rIdA"/></w:r></w:p>`);
+      const cyclic = await packageWithRelationships(cyclicControl + tailOriginal, [
+        { id: 'rIdA', type: CUSTOM_XML_REL, target: 'custom/a.xml' },
+      ], {
+        'word/custom/a.xml': `<x:a xmlns:x="urn:test" xmlns:r="${R_NS}" r:id="rIdB"/>`,
+        'word/custom/_rels/a.xml.rels': relationshipsXml([
+          { id: 'rIdB', type: CUSTOM_XML_REL, target: 'b.xml' },
+        ]),
+        'word/custom/b.xml': `<x:b xmlns:x="urn:test" xmlns:r="${R_NS}" r:id="rIdA"/>`,
+        'word/custom/_rels/b.xml.rels': relationshipsXml([
+          { id: 'rIdA', type: CUSTOM_XML_REL, target: 'a.xml' },
+        ]),
+      });
+      await expect(rebuildPackages(cyclic, cyclic)).rejects.toThrow(/cyclic relationship closure/);
+    },
+  );
+
+  test.openspec('[SDX-SDT-BLOCK-04] Block identity work remains linear in group count')(
+    'keeps relationship-free boundaries on the no-read path and memoizes media hashing',
+    async () => {
+      const plainArchive = await DocxArchive.load(await packageFor(blockSdt(paragraph('Plain', '00000035'))));
+      const plainResolver = new OpaqueRelationshipClosureResolver(plainArchive);
+      const plainBoundary = directBodyControls(await plainArchive.getDocumentXml())[0]!;
+      expect(await plainResolver.fingerprintBoundary(plainBoundary, 'word/document.xml')).toBe('');
+      expect(plainResolver.instrumentation.relationshipPartReads).toBe(0);
+      expect(plainResolver.instrumentation.partHashComputations).toBe(0);
+
+      const mediaArchive = await DocxArchive.load(await packageWithRelationships(
+        drawingBlock() + tailOriginal,
+        [imageRelationship],
+        { 'word/media/logo.png': Buffer.from('shared') },
+      ));
+      const mediaResolver = new OpaqueRelationshipClosureResolver(mediaArchive);
+      const boundary = parseXml(
+        `<w:sdt xmlns:w="${OOXML.W_NS}" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"` +
+        ` xmlns:r="${R_NS}"><w:sdtPr/><w:sdtContent><w:p><w:r><w:drawing r:embed="rIdImage"/>` +
+        `</w:r></w:p></w:sdtContent></w:sdt>`,
+      ).documentElement;
+      const first = await mediaResolver.fingerprintBoundary(boundary, 'word/document.xml');
+      const second = await mediaResolver.fingerprintBoundary(boundary, 'word/document.xml');
+      expect(second).toBe(first);
+      expect(mediaResolver.instrumentation.partHashComputations).toBe(1);
+      expect(mediaResolver.instrumentation.relationshipPartReads).toBe(2);
     },
   );
 });

--- a/packages/docx-compare/src/baselines/atomizer/documentReconstructor-block-sdt.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/documentReconstructor-block-sdt.test.ts
@@ -333,6 +333,26 @@ describe('opaque body block relationship closure', () => {
   );
 
   test.openspec('[SDX-SDT-BLOCK-05] Relationship closure changes fail before reconstruction')(
+    'accepts package-root and ordinary relative internal targets',
+    async () => {
+      const rootRelativeRelationship = { ...imageRelationship, target: '/word/media/root-logo.png' };
+      const rootRelative = await packageWithRelationships(
+        drawingBlock() + tailOriginal,
+        [rootRelativeRelationship],
+        { 'word/media/root-logo.png': Buffer.from('root-relative-image') },
+      );
+      await expect(rebuildPackages(rootRelative, rootRelative)).resolves.toBeInstanceOf(Buffer);
+
+      const relative = await packageWithRelationships(
+        drawingBlock() + tailOriginal,
+        [imageRelationship],
+        { 'word/media/logo.png': Buffer.from('relative-image') },
+      );
+      await expect(rebuildPackages(relative, relative)).resolves.toBeInstanceOf(Buffer);
+    },
+  );
+
+  test.openspec('[SDX-SDT-BLOCK-05] Relationship closure changes fail before reconstruction')(
     'rejects dangling, unsafe, cyclic, and unsupported relationship-bearing targets',
     async () => {
       const control = drawingBlock() + tailOriginal;
@@ -365,6 +385,85 @@ describe('opaque body block relationship closure', () => {
     },
   );
 
+  test.openspec('[SDX-SDT-BLOCK-05] Relationship closure changes fail before reconstruction')(
+    'rejects authority, encoded authority, malformed, backslash, and URI-form internal targets',
+    async () => {
+      const invalidTargets = [
+        '//authority.example/logo.png',
+        '%2F%2Fauthority.example%2Flogo.png',
+        '%ZZ',
+        'media\\logo.png',
+        'media%5Clogo.png',
+        'https://example.test/logo.png',
+        '%68%74%74%70%3A%2F%2Fexample.test%2Flogo.png',
+      ];
+      for (const target of invalidTargets) {
+        const input = await packageWithRelationships(drawingBlock() + tailOriginal, [
+          { ...imageRelationship, target },
+        ]);
+        await expect(rebuildPackages(input, input), target).rejects.toThrow(/relationship target/);
+      }
+    },
+  );
+
+  test.openspec('[SDX-SDT-BLOCK-05] Relationship closure changes fail before reconstruction')(
+    'rejects two roots entering opposite sides of the same dependency cycle',
+    async () => {
+      const control = blockSdt(
+        `<w:p w14:paraId="00000036"><w:r><w:drawing r:id="rIdRootA" r:embed="rIdRootB"/>` +
+        `</w:r></w:p>`,
+      );
+      const cyclic = await packageWithRelationships(control + tailOriginal, [
+        { id: 'rIdRootA', type: CUSTOM_XML_REL, target: 'custom/a.xml' },
+        { id: 'rIdRootB', type: CUSTOM_XML_REL, target: 'custom/b.xml' },
+      ], {
+        'word/custom/a.xml': `<x:a xmlns:x="urn:test" xmlns:r="${R_NS}" r:id="rIdToB"/>`,
+        'word/custom/_rels/a.xml.rels': relationshipsXml([
+          { id: 'rIdToB', type: CUSTOM_XML_REL, target: 'b.xml' },
+        ]),
+        'word/custom/b.xml': `<x:b xmlns:x="urn:test" xmlns:r="${R_NS}" r:id="rIdToA"/>`,
+        'word/custom/_rels/b.xml.rels': relationshipsXml([
+          { id: 'rIdToA', type: CUSTOM_XML_REL, target: 'a.xml' },
+        ]),
+      });
+
+      await expect(rebuildPackages(cyclic, cyclic)).rejects.toThrow(/cyclic relationship closure/);
+    },
+  );
+
+  test.openspec('[SDX-SDT-BLOCK-04] Block identity work remains linear in group count')(
+    'computes a shared acyclic dependency once across concurrent boundary requests',
+    async () => {
+      const control = blockSdt(
+        `<w:p w14:paraId="00000037"><w:r><w:drawing r:id="rIdRootA" r:embed="rIdRootB"/>` +
+        `</w:r></w:p>`,
+      );
+      const archive = await DocxArchive.load(await packageWithRelationships(control + tailOriginal, [
+        { id: 'rIdRootA', type: CUSTOM_XML_REL, target: 'custom/shared.xml' },
+        { id: 'rIdRootB', type: CUSTOM_XML_REL, target: 'custom/shared.xml' },
+      ], {
+        'word/custom/shared.xml': `<x:shared xmlns:x="urn:test" xmlns:r="${R_NS}" r:id="rIdNested"/>`,
+        'word/custom/_rels/shared.xml.rels': relationshipsXml([
+          { id: 'rIdNested', type: IMAGE_REL, target: '../media/shared.png' },
+        ]),
+        'word/media/shared.png': Buffer.from('shared-image'),
+      }));
+      const resolver = new OpaqueRelationshipClosureResolver(archive);
+      const boundary = directBodyControls(await archive.getDocumentXml())[0]!;
+
+      const [first, second] = await Promise.all([
+        resolver.fingerprintBoundary(boundary, 'word/document.xml'),
+        resolver.fingerprintBoundary(boundary, 'word/document.xml'),
+      ]);
+
+      expect(second).toBe(first);
+      expect(resolver.instrumentation.boundaryScans).toBe(2);
+      expect(resolver.instrumentation.relationshipIdentityComputations).toBe(3);
+      expect(resolver.instrumentation.partHashComputations).toBe(2);
+      expect(resolver.instrumentation.relationshipPartReads).toBe(3);
+    },
+  );
+
   test.openspec('[SDX-SDT-BLOCK-04] Block identity work remains linear in group count')(
     'keeps relationship-free boundaries on the no-read path and memoizes media hashing',
     async () => {
@@ -372,6 +471,7 @@ describe('opaque body block relationship closure', () => {
       const plainResolver = new OpaqueRelationshipClosureResolver(plainArchive);
       const plainBoundary = directBodyControls(await plainArchive.getDocumentXml())[0]!;
       expect(await plainResolver.fingerprintBoundary(plainBoundary, 'word/document.xml')).toBe('');
+      expect(plainResolver.instrumentation.relationshipIdentityComputations).toBe(0);
       expect(plainResolver.instrumentation.relationshipPartReads).toBe(0);
       expect(plainResolver.instrumentation.partHashComputations).toBe(0);
 
@@ -389,6 +489,7 @@ describe('opaque body block relationship closure', () => {
       const first = await mediaResolver.fingerprintBoundary(boundary, 'word/document.xml');
       const second = await mediaResolver.fingerprintBoundary(boundary, 'word/document.xml');
       expect(second).toBe(first);
+      expect(mediaResolver.instrumentation.relationshipIdentityComputations).toBe(1);
       expect(mediaResolver.instrumentation.partHashComputations).toBe(1);
       expect(mediaResolver.instrumentation.relationshipPartReads).toBe(2);
     },

--- a/packages/docx-compare/src/baselines/atomizer/documentReconstructor-block-sdt.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/documentReconstructor-block-sdt.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Focused forced-rebuild evidence for direct body-level block SDTs.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.5.2.29
+ * @conformance ECMA-376 edition 5, Part 1 § 17.5.2.34
+ * @conformance ECMA-376 edition 5, Part 1 § 17.5.2.38
+ * @see https://github.com/UseJunior/safe-docx/issues/582
+ */
+
+import { describe, expect } from 'vitest';
+import { DocxArchive, OOXML, parseXml } from '@usejunior/docx-core';
+import { buildDocxFromBodyXml } from '../../testing/ooxml-fixtures.js';
+import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
+import { compareDocumentsAtomizer } from './pipeline.js';
+import {
+  acceptAllChanges,
+  extractTextWithParagraphs,
+  rejectAllChanges,
+} from './trackChangesAcceptorAst.js';
+
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({
+    feature: 'Document Reconstructor Block SDT',
+    story: 'Opaque Direct Body Block Content Control Preservation',
+    severity: 'critical',
+  })
+  .conformance(
+    { spec: 'ECMA-376', edition: 5, part: 1, section: '17.5.2.29' },
+    { spec: 'ECMA-376', edition: 5, part: 1, section: '17.5.2.34' },
+    { spec: 'ECMA-376', edition: 5, part: 1, section: '17.5.2.38' },
+  );
+
+function paragraph(text: string, id: string): string {
+  return `<w:p w14:paraId="${id}" w14:textId="77777777" w:rsidR="00112233">` +
+    (text ? `<w:r><w:t>${text}</w:t></w:r>` : '') + '</w:p>';
+}
+
+function blockSdt(content: string): string {
+  return '<w:sdt>' +
+    '<w:sdtPr><w:alias w:val="Opaque block"/><w:id w:val="582"/></w:sdtPr>' +
+    '<w:sdtEndPr><w:rPr><w:b/></w:rPr></w:sdtEndPr>' +
+    `<w:sdtContent>${content}</w:sdtContent>` +
+    '</w:sdt>';
+}
+
+async function packageFor(body: string): Promise<Buffer> {
+  return buildDocxFromBodyXml(body);
+}
+
+async function rebuild(originalBody: string, revisedBody: string): Promise<string> {
+  const result = await compareDocumentsAtomizer(
+    await packageFor(originalBody),
+    await packageFor(revisedBody),
+    {
+      author: 'Issue 582 Test',
+      date: new Date('2026-07-22T00:00:00Z'),
+      reconstructionMode: 'rebuild',
+    },
+  );
+  expect(result.reconstructionModeUsed).toBe('rebuild');
+  return (await DocxArchive.load(result.document)).getDocumentXml();
+}
+
+function directBodyControls(xml: string): Element[] {
+  const body = parseXml(xml).getElementsByTagNameNS(OOXML.W_NS, 'body')[0]!;
+  return Array.from(body.childNodes).filter((node): node is Element =>
+    node.nodeType === 1 &&
+    (node as Element).namespaceURI === OOXML.W_NS &&
+    (node as Element).localName === 'sdt',
+  );
+}
+
+describe('direct body block content-control passthrough', () => {
+  test.openspec('[SDX-SDT-BLOCK-01] Outside edits retain a complete block control')(
+    'preserves ordered properties, empty paragraphs, and every controlled attribute',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      const control = blockSdt(paragraph('Controlled first', '00000001') + paragraph('', '00000002'));
+      let output = '';
+
+      await given('a direct body block control with an empty controlled paragraph', () => {});
+      await when('an outside paragraph changes through forced rebuild', async () => {
+        output = await rebuild(control + paragraph('Outside old', '00000003'),
+          control + paragraph('Outside new', '00000003'));
+      });
+      await then('the complete block shape and controlled attributes remain present once', () => {
+        const controls = directBodyControls(output);
+        expect(controls).toHaveLength(1);
+        expect(Array.from(controls[0]!.childNodes)
+          .filter((node): node is Element => node.nodeType === 1)
+          .map((node) => node.localName)).toEqual(['sdtPr', 'sdtEndPr', 'sdtContent']);
+        const paragraphs = controls[0]!.getElementsByTagNameNS(OOXML.W_NS, 'p');
+        expect(paragraphs).toHaveLength(2);
+        expect(paragraphs[1]!.getAttributeNS('http://schemas.microsoft.com/office/word/2010/wordml', 'paraId'))
+          .toBe('00000002');
+        expect(paragraphs[1]!.getElementsByTagNameNS(OOXML.W_NS, 't')).toHaveLength(0);
+      });
+      await and('accept and reject apply only the outside edit', () => {
+        expect(extractTextWithParagraphs(acceptAllChanges(output))).toContain('Outside new');
+        expect(extractTextWithParagraphs(rejectAllChanges(output))).toContain('Outside old');
+      });
+    },
+  );
+
+  test.openspec('[SDX-SDT-BLOCK-02] Multiple identical controls pair locally and deterministically')(
+    'retains identical sibling controls at their own body positions',
+    async ({ given, when, then }: AllureBddContext) => {
+      const identical = blockSdt(paragraph('Same controlled payload', '00000011'));
+      const original = identical + paragraph('Between', '00000012') + identical + paragraph('Tail old', '00000013');
+      const revised = identical + paragraph('Between', '00000012') + identical + paragraph('Tail new', '00000013');
+      let output = '';
+
+      await given('two byte-identical direct body controls separated by an ordinary paragraph', () => {});
+      await when('the tail paragraph changes through forced rebuild', async () => {
+        output = await rebuild(original, revised);
+      });
+      await then('both controls remain distinct, ordered, and emitted once', () => {
+        expect(directBodyControls(output)).toHaveLength(2);
+        expect((output.match(/Same controlled payload/g) ?? [])).toHaveLength(2);
+      });
+    },
+  );
+});
+
+describe('unsupported body block ownership fails closed', () => {
+  test.openspec('[SDX-SDT-BLOCK-03] Unsupported block ownership fails before output')(
+    'rejects mutation, insertion, deletion, reorder, movement, nesting, and table or cell placement',
+    async ({ given, then }: AllureBddContext) => {
+      const first = paragraph('First', '00000021');
+      const second = paragraph('Second', '00000022');
+      const stable = blockSdt(first + second);
+      const outside = paragraph('Outside', '00000023');
+      const nested = blockSdt(paragraph('Outer', '00000024') + blockSdt(paragraph('Inner', '00000025')));
+      const tableBlock = blockSdt(
+        '<w:tbl><w:tblPr/><w:tblGrid><w:gridCol w:w="1000"/></w:tblGrid>' +
+        '<w:tr><w:tc><w:tcPr/><w:p><w:r><w:t>Cell</w:t></w:r></w:p></w:tc></w:tr></w:tbl>',
+      );
+      const cellControl = '<w:tbl><w:tblPr/><w:tblGrid><w:gridCol w:w="1000"/></w:tblGrid>' +
+        `<w:tr><w:tc><w:tcPr/>${blockSdt(paragraph('Cell control', '00000026'))}</w:tc></w:tr></w:tbl>`;
+      const cases: Array<[string, string, string]> = [
+        ['mutation', stable + outside, blockSdt(paragraph('Changed', '00000021') + second) + outside],
+        ['insertion', stable + outside, blockSdt(first + paragraph('Inserted', '00000027') + second) + outside],
+        ['deletion', stable + outside, blockSdt(first) + outside],
+        ['reorder', stable + outside, blockSdt(second + first) + outside],
+        ['movement', stable + outside, outside + stable],
+        ['nesting', nested + outside, nested + outside],
+        ['table content', tableBlock + outside, tableBlock + outside],
+        ['cell placement', cellControl + outside, cellControl + outside],
+      ];
+
+      await given('block shapes outside the bounded immutable direct-body contract', () => {});
+      await then('each shape rejects without returning lossy rebuilt XML', async () => {
+        for (const [name, original, revised] of cases) {
+          await expect(rebuild(original, revised), name).rejects.toThrow(/Opaque passthrough:/);
+        }
+      });
+    },
+  );
+});

--- a/packages/docx-compare/src/baselines/atomizer/documentReconstructor-block-sdt.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/documentReconstructor-block-sdt.test.ts
@@ -20,6 +20,9 @@ import {
 import { OpaqueRelationshipClosureResolver } from './opaquePassthrough.js';
 
 const R_NS = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const A_NS = 'http://schemas.openxmlformats.org/drawingml/2006/main';
+const PIC_NS = 'http://schemas.openxmlformats.org/drawingml/2006/picture';
+const WP_NS = 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing';
 const IMAGE_REL = `${R_NS}/image`;
 const CUSTOM_XML_REL = `${R_NS}/customXml`;
 const TEST_FEATURE = 'Document Reconstructor Block SDT';
@@ -107,11 +110,34 @@ async function rebuildPackages(original: Buffer, revised: Buffer): Promise<Buffe
   return result.document;
 }
 
-function drawingBlock(relationshipId = 'rIdImage', prefix = 'r'): string {
+function drawingBlock(
+  relationshipId = 'rIdImage',
+  prefix = 'r',
+  relationshipAttribute: 'embed' | 'link' = 'embed',
+): string {
   return blockSdt(
     `<w:p w14:paraId="00000031" w14:textId="77777777">` +
-    `<w:r><w:drawing><a:graphic xmlns:a="urn:test:drawing" ${prefix}:embed="${relationshipId}"/>` +
-    `</w:drawing></w:r></w:p>`,
+    `<w:r><w:drawing><wp:inline xmlns:wp="${WP_NS}">` +
+    `<wp:extent cx="914400" cy="914400"/><wp:docPr id="1" name="Relationship fixture"/>` +
+    `<wp:cNvGraphicFramePr><a:graphicFrameLocks xmlns:a="${A_NS}" noChangeAspect="1"/>` +
+    `</wp:cNvGraphicFramePr><a:graphic xmlns:a="${A_NS}"><a:graphicData uri="${PIC_NS}">` +
+    `<pic:pic xmlns:pic="${PIC_NS}"><pic:nvPicPr><pic:cNvPr id="1" name="fixture.png"/>` +
+    `<pic:cNvPicPr/></pic:nvPicPr><pic:blipFill>` +
+    `<a:blip ${prefix}:${relationshipAttribute}="${relationshipId}"/>` +
+    `<a:stretch><a:fillRect/></a:stretch></pic:blipFill><pic:spPr>` +
+    `<a:xfrm><a:off x="0" y="0"/><a:ext cx="914400" cy="914400"/></a:xfrm>` +
+    `<a:prstGeom prst="rect"><a:avLst/></a:prstGeom></pic:spPr></pic:pic>` +
+    `</a:graphicData></a:graphic></wp:inline></w:drawing></w:r></w:p>`,
+  );
+}
+
+function hyperlinkRelationshipBlock(relationshipIds: readonly string[], paragraphId: string): string {
+  return blockSdt(
+    `<w:p w14:paraId="${paragraphId}">` +
+    relationshipIds.map((id, index) =>
+      `<w:hyperlink r:id="${id}"><w:r><w:t>Dependency ${index + 1}</w:t></w:r></w:hyperlink>`,
+    ).join('') +
+    `</w:p>`,
   );
 }
 
@@ -283,13 +309,13 @@ describe('opaque body block relationship closure', () => {
         mode: 'External' as const,
       };
       const original = await packageWithRelationships(
-        drawingBlock('rIdImage', 'rel') + tailOriginal,
+        drawingBlock('rIdImage', 'rel', 'link') + tailOriginal,
         [external],
         {},
         { rel: R_NS },
       );
       const unchanged = await packageWithRelationships(
-        drawingBlock('rIdImage', 'rel') + tailRevised,
+        drawingBlock('rIdImage', 'rel', 'link') + tailRevised,
         [external],
         {},
         { rel: R_NS },
@@ -297,7 +323,7 @@ describe('opaque body block relationship closure', () => {
       await expect(rebuildPackages(original, unchanged)).resolves.toBeInstanceOf(Buffer);
 
       const changed = await packageWithRelationships(
-        drawingBlock('rIdImage', 'rel') + tailRevised,
+        drawingBlock('rIdImage', 'rel', 'link') + tailRevised,
         [{ ...external, target: 'https://example.test/assets/changed.png' }],
         {},
         { rel: R_NS },
@@ -309,9 +335,7 @@ describe('opaque body block relationship closure', () => {
   test.openspec('[SDX-SDT-BLOCK-05] Relationship closure changes fail before reconstruction')(
     'recursively fingerprints relationship-bearing XML target parts',
     async () => {
-      const control = blockSdt(
-        `<w:p w14:paraId="00000033"><w:r><w:drawing r:id="rIdCustom"/></w:r></w:p>`,
-      );
+      const control = hyperlinkRelationshipBlock(['rIdCustom'], '00000033');
       const rootRelationship: RelationshipFixture = {
         id: 'rIdCustom', type: CUSTOM_XML_REL, target: 'custom/item.xml',
       };
@@ -368,7 +392,7 @@ describe('opaque body block relationship closure', () => {
         await expect(rebuildPackages(await input, await input), name).rejects.toThrow(/Opaque passthrough:/);
       }
 
-      const cyclicControl = blockSdt(`<w:p w14:paraId="00000034"><w:r><w:drawing r:id="rIdA"/></w:r></w:p>`);
+      const cyclicControl = hyperlinkRelationshipBlock(['rIdA'], '00000034');
       const cyclic = await packageWithRelationships(cyclicControl + tailOriginal, [
         { id: 'rIdA', type: CUSTOM_XML_REL, target: 'custom/a.xml' },
       ], {
@@ -409,10 +433,7 @@ describe('opaque body block relationship closure', () => {
   test.openspec('[SDX-SDT-BLOCK-05] Relationship closure changes fail before reconstruction')(
     'rejects two roots entering opposite sides of the same dependency cycle',
     async () => {
-      const control = blockSdt(
-        `<w:p w14:paraId="00000036"><w:r><w:drawing r:id="rIdRootA" r:embed="rIdRootB"/>` +
-        `</w:r></w:p>`,
-      );
+      const control = hyperlinkRelationshipBlock(['rIdRootA', 'rIdRootB'], '00000036');
       const cyclic = await packageWithRelationships(control + tailOriginal, [
         { id: 'rIdRootA', type: CUSTOM_XML_REL, target: 'custom/a.xml' },
         { id: 'rIdRootB', type: CUSTOM_XML_REL, target: 'custom/b.xml' },
@@ -434,10 +455,7 @@ describe('opaque body block relationship closure', () => {
   test.openspec('[SDX-SDT-BLOCK-04] Block identity work remains linear in group count')(
     'computes a shared acyclic dependency once across concurrent boundary requests',
     async () => {
-      const control = blockSdt(
-        `<w:p w14:paraId="00000037"><w:r><w:drawing r:id="rIdRootA" r:embed="rIdRootB"/>` +
-        `</w:r></w:p>`,
-      );
+      const control = hyperlinkRelationshipBlock(['rIdRootA', 'rIdRootB'], '00000037');
       const archive = await DocxArchive.load(await packageWithRelationships(control + tailOriginal, [
         { id: 'rIdRootA', type: CUSTOM_XML_REL, target: 'custom/shared.xml' },
         { id: 'rIdRootB', type: CUSTOM_XML_REL, target: 'custom/shared.xml' },
@@ -481,11 +499,7 @@ describe('opaque body block relationship closure', () => {
         { 'word/media/logo.png': Buffer.from('shared') },
       ));
       const mediaResolver = new OpaqueRelationshipClosureResolver(mediaArchive);
-      const boundary = parseXml(
-        `<w:sdt xmlns:w="${OOXML.W_NS}" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"` +
-        ` xmlns:r="${R_NS}"><w:sdtPr/><w:sdtContent><w:p><w:r><w:drawing r:embed="rIdImage"/>` +
-        `</w:r></w:p></w:sdtContent></w:sdt>`,
-      ).documentElement;
+      const boundary = directBodyControls(await mediaArchive.getDocumentXml())[0]!;
       const first = await mediaResolver.fingerprintBoundary(boundary, 'word/document.xml');
       const second = await mediaResolver.fingerprintBoundary(boundary, 'word/document.xml');
       expect(second).toBe(first);

--- a/packages/docx-compare/src/baselines/atomizer/documentReconstructor-inline-sdt.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/documentReconstructor-inline-sdt.test.ts
@@ -11,7 +11,7 @@
  */
 
 import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, posix } from 'node:path';
 import { XMLSerializer } from '@xmldom/xmldom';
 import JSZip from 'jszip';
 import { describe, expect } from 'vitest';
@@ -26,7 +26,7 @@ import {
 import { buildDocxFromBodyXml } from '../../testing/ooxml-fixtures.js';
 import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
 import { compareDocumentsAtomizer } from './pipeline.js';
-import { renderOpaqueAtomSequence } from './opaquePassthrough.js';
+import { OpaqueRelationshipClosureResolver, renderOpaqueAtomSequence } from './opaquePassthrough.js';
 import {
   acceptAllChanges,
   extractTextWithParagraphs,
@@ -501,6 +501,8 @@ describe('Real block content-control corpus preservation', () => {
         identityAttributes: number;
         drawingRelationshipId: string;
         drawingTarget: string;
+        relationshipClosure: string;
+        mediaBytes: number;
         changedParts: string[];
       }> = [];
 
@@ -511,17 +513,21 @@ describe('Real block content-control corpus preservation', () => {
           const marker = ` [outside rebuild edit: ${relativePaths.indexOf(path) + 1}]`;
           const revised = await reviseOutsideFirstBodySdt(input, marker);
           const outputDocument = await forcedRebuildDocument(input, revised);
-          const [beforeArchive, outputArchive] = await Promise.all([
+          const [beforeArchive, revisedArchive, outputArchive] = await Promise.all([
             DocxArchive.load(input),
+            DocxArchive.load(revised),
             DocxArchive.load(outputDocument),
           ]);
-          const [beforeXml, outputXml, beforeRels, outputRels] = await Promise.all([
+          const [beforeXml, revisedXml, outputXml, beforeRels, revisedRels, outputRels] = await Promise.all([
             beforeArchive.getDocumentXml(),
+            revisedArchive.getDocumentXml(),
             outputArchive.getDocumentXml(),
             beforeArchive.getFile('word/_rels/document.xml.rels'),
+            revisedArchive.getFile('word/_rels/document.xml.rels'),
             outputArchive.getFile('word/_rels/document.xml.rels'),
           ]);
           const beforeControl = firstDirectBodySdt(beforeXml);
+          const revisedControl = firstDirectBodySdt(revisedXml);
           const outputControl = firstDirectBodySdt(outputXml);
           const identityAttributes = Array.from(beforeControl.getElementsByTagName('*'))
             .flatMap((element) => Array.from(element.attributes))
@@ -539,10 +545,33 @@ describe('Real block content-control corpus preservation', () => {
             expect(outputControl.lookupNamespaceURI(prefix), prefix).toBe(beforeControl.lookupNamespaceURI(prefix));
           }
           expect(beforeRels).not.toBeNull();
+          expect(revisedRels).not.toBeNull();
           expect(outputRels).not.toBeNull();
           const drawingTarget = relationshipTarget(beforeRels!, drawingRelationshipId!);
           expect(drawingTarget).not.toBeNull();
+          expect(relationshipTarget(revisedRels!, drawingRelationshipId!)).toBe(drawingTarget);
           expect(relationshipTarget(outputRels!, drawingRelationshipId!)).toBe(drawingTarget);
+          const relationshipClosures = await Promise.all([
+            new OpaqueRelationshipClosureResolver(beforeArchive)
+              .fingerprintBoundary(beforeControl, 'word/document.xml'),
+            new OpaqueRelationshipClosureResolver(revisedArchive)
+              .fingerprintBoundary(revisedControl, 'word/document.xml'),
+            new OpaqueRelationshipClosureResolver(outputArchive)
+              .fingerprintBoundary(outputControl, 'word/document.xml'),
+          ]);
+          expect(relationshipClosures[1]).toBe(relationshipClosures[0]);
+          expect(relationshipClosures[2]).toBe(relationshipClosures[0]);
+          const mediaPath = drawingTarget!.startsWith('/')
+            ? drawingTarget!.slice(1)
+            : posix.normalize(posix.join('word', drawingTarget!));
+          const media = await Promise.all([
+            beforeArchive.getFileBuffer(mediaPath),
+            revisedArchive.getFileBuffer(mediaPath),
+            outputArchive.getFileBuffer(mediaPath),
+          ]);
+          expect(media[0]).not.toBeNull();
+          expect(media[1]).toEqual(media[0]);
+          expect(media[2]).toEqual(media[0]);
           expect(extractTextWithParagraphs(acceptAllChanges(outputXml))).toContain(marker);
           expect(extractTextWithParagraphs(rejectAllChanges(outputXml))).not.toContain(marker);
           const changedParts = await changedPackageParts(input, outputDocument);
@@ -553,6 +582,8 @@ describe('Real block content-control corpus preservation', () => {
             identityAttributes: identityAttributes.length,
             drawingRelationshipId: drawingRelationshipId!,
             drawingTarget: drawingTarget!,
+            relationshipClosure: relationshipClosures[0],
+            mediaBytes: media[0]!.length,
             changedParts,
           });
         }
@@ -563,6 +594,8 @@ describe('Real block content-control corpus preservation', () => {
         for (const measurement of measurements) {
           expect(measurement.controlledParagraphs).toBe(38);
           expect(measurement.identityAttributes).toBe(152);
+          expect(measurement.relationshipClosure).toMatch(/^[a-f0-9]{64}$/);
+          expect(measurement.mediaBytes).toBeGreaterThan(0);
           expect(measurement.changedParts).toEqual(['word/document.xml']);
         }
       });

--- a/packages/docx-compare/src/baselines/atomizer/documentReconstructor-inline-sdt.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/documentReconstructor-inline-sdt.test.ts
@@ -1,9 +1,8 @@
 /**
  * Forced-rebuild evidence for the bounded inline-SDT opaque-passthrough pilot.
  *
- * The focused fixtures are synthetic because the checked-in real documents
- * contain block-level cover-page SDTs, not inline controls. The final test keeps
- * that real corpus measurement separate and does not relabel it as inline proof.
+ * The focused inline fixtures are synthetic. The final suite separately uses
+ * the checked-in block-level ILPA controls as real forced-rebuild evidence.
  *
  * @conformance ECMA-376 edition 5, Part 1 § 17.5.2.31
  * @conformance ECMA-376 edition 5, Part 1 § 17.5.2.36
@@ -13,6 +12,8 @@
 
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { XMLSerializer } from '@xmldom/xmldom';
+import JSZip from 'jszip';
 import { describe, expect } from 'vitest';
 import {
   CorrelationStatus,
@@ -45,6 +46,18 @@ const test = testAllure
   .conformance(
     { spec: 'ECMA-376', edition: 5, part: 1, section: '17.5.2.31' },
     { spec: 'ECMA-376', edition: 5, part: 1, section: '17.5.2.36' },
+    { spec: 'ECMA-376', edition: 5, part: 1, section: '17.5.2.38' },
+  );
+const blockTest = testAllure
+  .epic('Document Comparison')
+  .withLabels({
+    feature: 'Document Reconstructor Block SDT',
+    story: 'Real Opaque Block Content Control Preservation In Rebuild',
+    severity: 'critical',
+  })
+  .conformance(
+    { spec: 'ECMA-376', edition: 5, part: 1, section: '17.5.2.29' },
+    { spec: 'ECMA-376', edition: 5, part: 1, section: '17.5.2.34' },
     { spec: 'ECMA-376', edition: 5, part: 1, section: '17.5.2.38' },
   );
 
@@ -104,6 +117,16 @@ async function forcedRebuild(original: Buffer, revised: Buffer): Promise<string>
   return (await DocxArchive.load(result.document)).getDocumentXml();
 }
 
+async function forcedRebuildDocument(original: Buffer, revised: Buffer): Promise<Buffer> {
+  const result = await compareDocumentsAtomizer(original, revised, {
+    author: 'Issue 582 Test',
+    date: new Date('2026-07-22T00:00:00Z'),
+    reconstructionMode: 'rebuild',
+  });
+  expect(result.reconstructionModeUsed).toBe('rebuild');
+  return result.document;
+}
+
 function elementsByName(xml: string, namespaceUri: string, localName: string): Element[] {
   return Array.from(parseXml(xml).getElementsByTagNameNS(namespaceUri, localName));
 }
@@ -112,6 +135,83 @@ function directElementNames(element: Element): string[] {
   return Array.from(element.childNodes)
     .filter((node): node is Element => node.nodeType === 1)
     .map((node) => `{${node.namespaceURI}}${node.localName}`);
+}
+
+function canonicalSubtree(node: Node): string {
+  if (node.nodeType === 1) {
+    const element = node as Element;
+    const attributes = Array.from(element.attributes)
+      .filter((attribute) => attribute.namespaceURI !== 'http://www.w3.org/2000/xmlns/')
+      .map((attribute) =>
+        `{${attribute.namespaceURI ?? ''}}${attribute.localName ?? attribute.name}=${JSON.stringify(attribute.value)}`,
+      )
+      .sort();
+    return `E{${element.namespaceURI ?? ''}}${element.localName}[${attributes.join(',')}](` +
+      Array.from(element.childNodes).map(canonicalSubtree).join('') + ')';
+  }
+  if (node.nodeType === 3 || node.nodeType === 4) return `T${JSON.stringify(node.nodeValue ?? '')}`;
+  if (node.nodeType === 8) return `C${JSON.stringify(node.nodeValue ?? '')}`;
+  return `N${node.nodeType}:${JSON.stringify(node.nodeValue ?? '')}`;
+}
+
+function firstDirectBodySdt(xml: string): Element {
+  const body = parseXml(xml).getElementsByTagNameNS(OOXML.W_NS, 'body')[0]!;
+  const first = Array.from(body.childNodes).find((node): node is Element => node.nodeType === 1);
+  expect(first?.namespaceURI).toBe(OOXML.W_NS);
+  expect(first?.localName).toBe('sdt');
+  return first!;
+}
+
+async function reviseOutsideFirstBodySdt(input: Buffer, marker: string): Promise<Buffer> {
+  const archive = await DocxArchive.load(input);
+  const document = parseXml(await archive.getDocumentXml());
+  const body = document.getElementsByTagNameNS(OOXML.W_NS, 'body')[0]!;
+  const control = Array.from(body.childNodes).find(
+    (node): node is Element => node.nodeType === 1 &&
+      (node as Element).namespaceURI === OOXML.W_NS && (node as Element).localName === 'sdt',
+  )!;
+  const outsideText = Array.from(body.getElementsByTagNameNS(OOXML.W_NS, 't')).find((text) => {
+    let ancestor: Node | null = text;
+    while (ancestor && ancestor !== body) {
+      if (ancestor === control) return false;
+      ancestor = ancestor.parentNode;
+    }
+    return (text.textContent ?? '').trim().length > 0;
+  });
+  expect(outsideText).toBeDefined();
+  outsideText!.appendChild(document.createTextNode(marker));
+  archive.setDocumentXml(new XMLSerializer().serializeToString(document));
+  return archive.save();
+}
+
+async function changedPackageParts(before: Buffer, after: Buffer): Promise<string[]> {
+  const [beforeZip, afterZip] = await Promise.all([JSZip.loadAsync(before), JSZip.loadAsync(after)]);
+  const paths = [...new Set([...Object.keys(beforeZip.files), ...Object.keys(afterZip.files)])].sort();
+  const changed: string[] = [];
+  for (const path of paths) {
+    if (beforeZip.files[path]?.dir || afterZip.files[path]?.dir) continue;
+    const beforeFile = beforeZip.file(path);
+    const afterFile = afterZip.file(path);
+    if (!beforeFile || !afterFile) {
+      changed.push(path);
+      continue;
+    }
+    const [beforeBytes, afterBytes] = await Promise.all([
+      beforeFile.async('nodebuffer'),
+      afterFile.async('nodebuffer'),
+    ]);
+    if (!beforeBytes.equals(afterBytes)) changed.push(path);
+  }
+  return changed;
+}
+
+function relationshipTarget(relationshipsXml: string, id: string): string | null {
+  const relationships = parseXml(relationshipsXml).getElementsByTagNameNS(
+    'http://schemas.openxmlformats.org/package/2006/relationships',
+    'Relationship',
+  );
+  return Array.from(relationships).find((relationship) => relationship.getAttribute('Id') === id)
+    ?.getAttribute('Target') ?? null;
 }
 
 describe('Forced rebuild preserves unchanged inline content controls', () => {
@@ -355,6 +455,7 @@ describe('Opaque inline content controls fail closed', () => {
     'rejects an opaque owner interrupted by ordinary atoms during emission', () => {
       const document = parseXml(`<w:sdt xmlns:w="${OOXML.W_NS}"/>`);
       const descriptor: OpaquePassthroughNode = {
+        placementKind: 'inline-run',
         namespaceUri: OOXML.W_NS,
         localName: 'sdt',
         documentOrdinal: 0,
@@ -384,39 +485,85 @@ describe('Opaque inline content controls fail closed', () => {
   );
 });
 
-describe('Real content-control corpus measurement', () => {
-  test
-    .openspec('[SDX-SDT-05] Real content-control corpus measurement is labeled without overclaiming')(
-    'records block-SDT no-regression counts separately from synthetic inline evidence',
+describe('Real block content-control corpus preservation', () => {
+  blockTest
+    .openspec('[SDX-SDT-BLOCK-01] Outside edits retain a complete block control')(
+    'applies real outside edits and preserves both complete ILPA cover controls',
     async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
       const repoRoot = join(import.meta.dirname, '../../../../..');
       const relativePaths = [
         'tests/test_documents/redline/ILPA-Model-Limited-Parnership-Agreement-Deal-By-Deal_v1.docx',
         'tests/test_documents/redline/ILPA-Model-Limited-Partnership-Agreement-WOF_v2.docx',
       ];
-      const measurements: Array<{ path: string; before: number; after: number; scope: string }> = [];
+      const measurements: Array<{
+        path: string;
+        controlledParagraphs: number;
+        identityAttributes: number;
+        drawingRelationshipId: string;
+        drawingTarget: string;
+        changedParts: string[];
+      }> = [];
 
-      await given('the checked-in real ILPA documents whose controls are block-level cover-page SDTs', () => {});
-      await when('each real document is compared with itself through forced rebuild', async () => {
+      await given('both checked-in ILPA documents with first-child block cover controls', () => {});
+      await when('each document receives an unrelated outside edit through forced rebuild', async () => {
         for (const path of relativePaths) {
           const input = readFileSync(join(repoRoot, path));
-          const beforeXml = await (await DocxArchive.load(input)).getDocumentXml();
-          const output = await forcedRebuild(input, input);
+          const marker = ` [outside rebuild edit: ${relativePaths.indexOf(path) + 1}]`;
+          const revised = await reviseOutsideFirstBodySdt(input, marker);
+          const outputDocument = await forcedRebuildDocument(input, revised);
+          const [beforeArchive, outputArchive] = await Promise.all([
+            DocxArchive.load(input),
+            DocxArchive.load(outputDocument),
+          ]);
+          const [beforeXml, outputXml, beforeRels, outputRels] = await Promise.all([
+            beforeArchive.getDocumentXml(),
+            outputArchive.getDocumentXml(),
+            beforeArchive.getFile('word/_rels/document.xml.rels'),
+            outputArchive.getFile('word/_rels/document.xml.rels'),
+          ]);
+          const beforeControl = firstDirectBodySdt(beforeXml);
+          const outputControl = firstDirectBodySdt(outputXml);
+          const identityAttributes = Array.from(beforeControl.getElementsByTagName('*'))
+            .flatMap((element) => Array.from(element.attributes))
+            .filter((attribute) =>
+              attribute.localName === 'paraId' ||
+              attribute.localName === 'textId' ||
+              attribute.localName?.startsWith('rsid'),
+            );
+          const drawingRelationshipId = Array.from(beforeControl.getElementsByTagName('*'))
+            .flatMap((element) => Array.from(element.attributes))
+            .find((attribute) => attribute.localName === 'embed')?.value;
+          expect(drawingRelationshipId).toBeDefined();
+          expect(canonicalSubtree(outputControl)).toBe(canonicalSubtree(beforeControl));
+          for (const prefix of ['w', 'w14', 'r', 'wp', 'a', 'pic', 'a14']) {
+            expect(outputControl.lookupNamespaceURI(prefix), prefix).toBe(beforeControl.lookupNamespaceURI(prefix));
+          }
+          expect(beforeRels).not.toBeNull();
+          expect(outputRels).not.toBeNull();
+          const drawingTarget = relationshipTarget(beforeRels!, drawingRelationshipId!);
+          expect(drawingTarget).not.toBeNull();
+          expect(relationshipTarget(outputRels!, drawingRelationshipId!)).toBe(drawingTarget);
+          expect(extractTextWithParagraphs(acceptAllChanges(outputXml))).toContain(marker);
+          expect(extractTextWithParagraphs(rejectAllChanges(outputXml))).not.toContain(marker);
+          const changedParts = await changedPackageParts(input, outputDocument);
+          expect(changedParts).toEqual(['word/document.xml']);
           measurements.push({
             path,
-            before: elementsByName(beforeXml, OOXML.W_NS, 'sdt').length,
-            after: elementsByName(output, OOXML.W_NS, 'sdt').length,
-            scope: 'real block-SDT no-regression only; not inline preservation evidence',
+            controlledParagraphs: beforeControl.getElementsByTagNameNS(OOXML.W_NS, 'p').length,
+            identityAttributes: identityAttributes.length,
+            drawingRelationshipId: drawingRelationshipId!,
+            drawingTarget: drawingTarget!,
+            changedParts,
           });
         }
-        await attachPrettyJson('real-content-control-corpus-measurement', measurements);
+        await attachPrettyJson('real-block-content-control-corpus-evidence', measurements);
       });
-      await then('every real block-SDT count remains stable and the scope label stays explicit', () => {
+      await then('every complete control, identity attribute, drawing target, and package boundary is retained', () => {
         expect(measurements).toHaveLength(relativePaths.length);
         for (const measurement of measurements) {
-          expect(measurement.before).toBeGreaterThan(0);
-          expect(measurement.after).toBe(measurement.before);
-          expect(measurement.scope).toContain('not inline preservation evidence');
+          expect(measurement.controlledParagraphs).toBe(38);
+          expect(measurement.identityAttributes).toBe(152);
+          expect(measurement.changedParts).toEqual(['word/document.xml']);
         }
       });
     },

--- a/packages/docx-compare/src/baselines/atomizer/documentReconstructor.ts
+++ b/packages/docx-compare/src/baselines/atomizer/documentReconstructor.ts
@@ -7,7 +7,7 @@
 
 import { XMLSerializer } from '@xmldom/xmldom';
 import { parseXml } from '@usejunior/docx-core';
-import type { ComparisonUnitAtom } from '@usejunior/docx-core';
+import type { ComparisonUnitAtom, OpaquePassthroughNode } from '@usejunior/docx-core';
 import { CorrelationStatus } from '@usejunior/docx-core';
 import { getLeafText, childElements, findChildByTagName } from '@usejunior/docx-core';
 import {
@@ -127,6 +127,7 @@ export function reconstructDocument(
 
   // Consolidate adjacent same-status changes for better readability
   const paragraphGroups = consolidateAdjacentChanges(rawParagraphGroups);
+  validateBodyBlockGroupSequence(paragraphGroups);
 
   // Reset debug counters
   resetDebugCounters();
@@ -135,9 +136,13 @@ export function reconstructDocument(
   debug('reconstructor', `${mergedAtoms.length} atoms -> ${paragraphGroups.length} paragraphs`);
 
   // Build track changes XML for each paragraph
-  const paragraphXmls: string[] = [];
+  const paragraphXmls: Array<string | null> = [];
 
   for (const group of paragraphGroups) {
+    if (bodyBlockOwnership(group)) {
+      paragraphXmls.push(null);
+      continue;
+    }
     const paragraphXml = buildParagraphXml(
       group, author, dateStr, revState, options.hyperlinkRelResolver
     );
@@ -167,6 +172,67 @@ interface ParagraphGroup {
   pPr: Element | null;
   /** Atoms in this paragraph, grouped by run and status */
   runGroups: RunGroup[];
+}
+
+interface BodyBlockGroupOwnership {
+  descriptor: OpaquePassthroughNode;
+  relativeParagraphOrdinal: number;
+}
+
+function bodyBlockOwnership(group: ParagraphGroup): BodyBlockGroupOwnership | null {
+  const atoms = group.runGroups.flatMap((runGroup) => runGroup.atoms);
+  const blockAtoms = atoms.filter((atom) => atom.opaquePassthrough?.placementKind === 'body-block');
+  if (blockAtoms.length === 0) return null;
+  const descriptor = blockAtoms[0]!.opaquePassthrough!;
+  const relativeParagraphOrdinal = blockAtoms[0]!.opaquePassthroughRelativeParagraphOrdinal;
+  if (
+    relativeParagraphOrdinal === undefined ||
+    blockAtoms.length !== atoms.length ||
+    atoms.some((atom) =>
+      atom.opaquePassthrough !== descriptor ||
+      atom.opaquePassthroughRelativeParagraphOrdinal !== relativeParagraphOrdinal ||
+      atom.correlationStatus !== CorrelationStatus.Equal
+    )
+  ) {
+    throw new OpaquePassthroughError('body-block paragraph has mixed, changed, or incomplete ownership');
+  }
+  return { descriptor, relativeParagraphOrdinal };
+}
+
+function validateBodyBlockGroupSequence(groups: ParagraphGroup[]): void {
+  const nextRelative = new Map<OpaquePassthroughNode, number>();
+  const closed = new Set<OpaquePassthroughNode>();
+  let active: OpaquePassthroughNode | undefined;
+  for (const group of groups) {
+    const ownership = bodyBlockOwnership(group);
+    if (!ownership) {
+      if (active) {
+        closed.add(active);
+        active = undefined;
+      }
+      continue;
+    }
+    const { descriptor, relativeParagraphOrdinal } = ownership;
+    if (active !== descriptor) {
+      if (active) closed.add(active);
+      if (closed.has(descriptor)) {
+        throw new OpaquePassthroughError(`boundary ${descriptor.documentOrdinal} has non-contiguous group ownership`);
+      }
+      active = descriptor;
+    }
+    const expected = nextRelative.get(descriptor) ?? 0;
+    if (relativeParagraphOrdinal !== expected) {
+      throw new OpaquePassthroughError(
+        `boundary ${descriptor.documentOrdinal} changed controlled paragraph order`,
+      );
+    }
+    nextRelative.set(descriptor, expected + 1);
+  }
+  for (const [descriptor, count] of nextRelative) {
+    if (count !== descriptor.ownedParagraphCount) {
+      throw new OpaquePassthroughError(`boundary ${descriptor.documentOrdinal} lost paragraph-group ownership`);
+    }
+  }
 }
 
 /**
@@ -1899,7 +1965,7 @@ function isRootedGroup(group: ParagraphGroup): boolean {
  */
 function buildDocumentPreservingStructure(
   originalXml: string,
-  paragraphXmls: string[],
+  paragraphXmls: Array<string | null>,
   paragraphGroups: ParagraphGroup[],
   allocateRevisionId: () => number
 ): string {
@@ -1907,6 +1973,7 @@ function buildDocumentPreservingStructure(
 
   let slotCursor = 0;
   let lastEmittedNode: Node | null = null;
+  const preservedBlocks = new Map<Element, Element>();
 
   // Find body-level <w:sectPr> (must stay as last child of body)
   const bodyChildren = childElements(body);
@@ -1918,6 +1985,45 @@ function buildDocumentPreservingStructure(
   for (let i = 0; i < paragraphGroups.length; i++) {
     const group = paragraphGroups[i]!;
     const paraXml = paragraphXmls[i]!;
+
+    const blockOwnership = bodyBlockOwnership(group);
+    if (blockOwnership) {
+      const { descriptor, relativeParagraphOrdinal } = blockOwnership;
+      const expectedSlot = descriptor.paragraphOrdinal + relativeParagraphOrdinal;
+      if (slotCursor !== expectedSlot || slotCursor >= slots.length) {
+        throw new OpaquePassthroughError(
+          `boundary ${descriptor.documentOrdinal} does not own the expected scaffold slot`,
+        );
+      }
+      const slot = slots[slotCursor]!;
+      let boundary: Node | null = slot.element.parentNode;
+      while (boundary && boundary !== body &&
+        !((boundary as Element).namespaceURI === W_NS && (boundary as Element).localName === 'sdt')) {
+        boundary = boundary.parentNode;
+      }
+      if (!boundary || boundary === body || boundary.parentNode !== body) {
+        throw new OpaquePassthroughError('body-block scaffold owner is not a direct w:body/w:sdt');
+      }
+      const block = boundary as Element;
+      const bodyOrdinal = childElements(body).indexOf(block);
+      const controlledParagraphs = Array.from(block.getElementsByTagNameNS(W_NS, 'p'));
+      if (
+        bodyOrdinal !== descriptor.bodyChildOrdinal ||
+        controlledParagraphs.length !== descriptor.ownedParagraphCount ||
+        controlledParagraphs[relativeParagraphOrdinal] !== slot.element
+      ) {
+        throw new OpaquePassthroughError(
+          `boundary ${descriptor.documentOrdinal} changed scaffold ownership`,
+        );
+      }
+      if (!preservedBlocks.has(block)) preservedBlocks.set(block, block.cloneNode(true) as Element);
+      lastEmittedNode = block;
+      slotCursor++;
+      continue;
+    }
+    if (paraXml === null) {
+      throw new OpaquePassthroughError('non-block paragraph has no reconstructed XML');
+    }
 
     // Parse the reconstructed paragraph XML into a DOM node
     const fragDoc = parseXml(
@@ -2048,6 +2154,15 @@ function buildDocumentPreservingStructure(
   // synthesizes recovery markers for orphaned starts/ends. Mirrors the
   // post-processing applied in inplace mode (inPlaceModifier.ts).
   enforceConsumerCompatibility(body, allocateRevisionId);
+
+  // Consumer-compatibility cleanup is intentionally document-wide. Restore
+  // validated opaque blocks afterward so no cleanup can alter their subtree.
+  for (const [block, originalClone] of preservedBlocks) {
+    if (!block.parentNode) {
+      throw new OpaquePassthroughError('preserved body-block boundary was removed during scaffold cleanup');
+    }
+    block.parentNode.replaceChild(originalClone, block);
+  }
 
   // Serialize modified body and splice back into original envelope
   const serializer = new XMLSerializer();

--- a/packages/docx-compare/src/baselines/atomizer/hierarchicalLcs-opaque-identity.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/hierarchicalLcs-opaque-identity.test.ts
@@ -11,6 +11,7 @@ const test = testAllure.epic('Document Comparison').withLabels({ feature: 'Hiera
 
 function descriptor(documentOrdinal: number, fingerprint: string): OpaquePassthroughNode {
   return {
+    placementKind: 'inline-run',
     namespaceUri: 'urn:test:w',
     localName: 'sdt',
     documentOrdinal,
@@ -20,11 +21,12 @@ function descriptor(documentOrdinal: number, fingerprint: string): OpaquePassthr
   } as OpaquePassthroughNode;
 }
 
-function atom(owner?: OpaquePassthroughNode): ComparisonUnitAtom {
+function atom(owner?: OpaquePassthroughNode, relativeParagraphOrdinal?: number): ComparisonUnitAtom {
   return {
     contentElement: { tagName: 'w:t' },
     ancestorElements: [],
     opaquePassthrough: owner,
+    opaquePassthroughRelativeParagraphOrdinal: relativeParagraphOrdinal,
   } as unknown as ComparisonUnitAtom;
 }
 
@@ -42,12 +44,13 @@ describe('opaque paragraph identity caching', () => {
   test('computes each ordinary group identity once across DP and backtracking', () => {
     const original = Array.from({ length: 70 }, (_, index) => group(index, [atom()], index + 1));
     const revised = Array.from({ length: 70 }, (_, index) => group(index, [atom()], index + 1));
-    const instrumentation: GroupLcsInstrumentation = { opaqueIdentityComputations: 0 };
+    const instrumentation: GroupLcsInstrumentation = { opaqueIdentityComputations: 0, opaqueAtomScans: 0 };
 
     const result = computeGroupLcs(original, revised, 2, undefined, instrumentation);
 
     expect(result.matchedGroups).toHaveLength(70);
     expect(instrumentation.opaqueIdentityComputations).toBe(original.length + revised.length);
+    expect(instrumentation.opaqueAtomScans).toBe(original.length + revised.length);
   });
 
   test('matches and distinguishes groups containing multiple opaque identities', () => {
@@ -81,5 +84,25 @@ describe('opaque paragraph identity caching', () => {
     mutable.atoms[0]!.opaquePassthrough = descriptor(0, 'added-between-runs');
 
     expect(computeGroupLcs([mutable], [ordinary], 2).matchedGroups).toEqual([]);
+  });
+
+  test('computes each block-owned paragraph group identity once', () => {
+    const originalOwner = {
+      ...descriptor(0, 'block'),
+      placementKind: 'body-block' as const,
+      bodyChildOrdinal: 0,
+      ownedParagraphCount: 38,
+    };
+    const revisedOwner = { ...originalOwner };
+    const original = Array.from({ length: 38 }, (_, index) =>
+      group(index, [atom(originalOwner, index)], index + 100));
+    const revised = Array.from({ length: 38 }, (_, index) =>
+      group(index, [atom(revisedOwner, index)], index + 200));
+    const instrumentation: GroupLcsInstrumentation = { opaqueIdentityComputations: 0, opaqueAtomScans: 0 };
+
+    expect(computeGroupLcs(original, revised, 2, undefined, instrumentation).matchedGroups)
+      .toHaveLength(38);
+    expect(instrumentation.opaqueIdentityComputations).toBe(76);
+    expect(instrumentation.opaqueAtomScans).toBe(76);
   });
 });

--- a/packages/docx-compare/src/baselines/atomizer/hierarchicalLcs-opaque-identity.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/hierarchicalLcs-opaque-identity.test.ts
@@ -105,4 +105,21 @@ describe('opaque paragraph identity caching', () => {
     expect(instrumentation.opaqueIdentityComputations).toBe(76);
     expect(instrumentation.opaqueAtomScans).toBe(76);
   });
+
+  test('includes block relationship closure in opaque group identity', () => {
+    const originalOwner = {
+      ...descriptor(0, 'block'),
+      placementKind: 'body-block' as const,
+      bodyChildOrdinal: 0,
+      ownedParagraphCount: 1,
+      relationshipClosureFingerprint: 'original-media',
+    };
+    const revisedOwner = { ...originalOwner, relationshipClosureFingerprint: 'revised-media' };
+
+    expect(computeGroupLcs(
+      [group(0, [atom(originalOwner, 0)], 10)],
+      [group(0, [atom(revisedOwner, 0)], 10)],
+      2,
+    ).matchedGroups).toEqual([]);
+  });
 });

--- a/packages/docx-compare/src/baselines/atomizer/hierarchicalLcs.ts
+++ b/packages/docx-compare/src/baselines/atomizer/hierarchicalLcs.ts
@@ -99,6 +99,7 @@ export interface GroupLcsResult {
 /** Deterministic complexity counters for focused LCS regression tests. */
 export interface GroupLcsInstrumentation {
   opaqueIdentityComputations: number;
+  opaqueAtomScans: number;
 }
 
 /**
@@ -415,7 +416,9 @@ function createOpaqueGroupIdentityResolver(instrumentation?: GroupLcsInstrumenta
 
     let descriptors: NonNullable<ComparisonUnitAtom['opaquePassthrough']>[] | undefined;
     let seen: Set<NonNullable<ComparisonUnitAtom['opaquePassthrough']>> | undefined;
+    let relativeByDescriptor: Map<NonNullable<ComparisonUnitAtom['opaquePassthrough']>, number | undefined> | undefined;
     for (const atom of group.atoms) {
+      if (instrumentation) instrumentation.opaqueAtomScans++;
       const descriptor = atom.opaquePassthrough;
       if (!descriptor) continue;
       descriptors ??= [];
@@ -423,6 +426,8 @@ function createOpaqueGroupIdentityResolver(instrumentation?: GroupLcsInstrumenta
       if (!seen.has(descriptor)) {
         seen.add(descriptor);
         descriptors.push(descriptor);
+        relativeByDescriptor ??= new Map();
+        relativeByDescriptor.set(descriptor, atom.opaquePassthroughRelativeParagraphOrdinal);
       }
     }
     if (!descriptors) {
@@ -432,7 +437,9 @@ function createOpaqueGroupIdentityResolver(instrumentation?: GroupLcsInstrumenta
     descriptors.sort((left, right) => left.documentOrdinal - right.documentOrdinal);
     const identity = descriptors
       .map((descriptor) =>
-        `${descriptor.containerIdentity}\u0000${descriptor.paragraphOrdinal}\u0000` +
+        `${descriptor.placementKind}\u0000${descriptor.containerIdentity}\u0000${descriptor.paragraphOrdinal}\u0000` +
+        `${descriptor.bodyChildOrdinal ?? ''}\u0000${descriptor.ownedParagraphCount ?? ''}\u0000` +
+        `${relativeByDescriptor?.get(descriptor) ?? ''}\u0000` +
         `${descriptor.documentOrdinal}\u0000${descriptor.semanticFingerprint}`,
       )
       .join('\u0001');

--- a/packages/docx-compare/src/baselines/atomizer/hierarchicalLcs.ts
+++ b/packages/docx-compare/src/baselines/atomizer/hierarchicalLcs.ts
@@ -440,7 +440,8 @@ function createOpaqueGroupIdentityResolver(instrumentation?: GroupLcsInstrumenta
         `${descriptor.placementKind}\u0000${descriptor.containerIdentity}\u0000${descriptor.paragraphOrdinal}\u0000` +
         `${descriptor.bodyChildOrdinal ?? ''}\u0000${descriptor.ownedParagraphCount ?? ''}\u0000` +
         `${relativeByDescriptor?.get(descriptor) ?? ''}\u0000` +
-        `${descriptor.documentOrdinal}\u0000${descriptor.semanticFingerprint}`,
+        `${descriptor.documentOrdinal}\u0000${descriptor.semanticFingerprint}\u0000` +
+        `${descriptor.relationshipClosureFingerprint ?? ''}`,
       )
       .join('\u0001');
     cache.set(group, identity);

--- a/packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts
+++ b/packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts
@@ -1,15 +1,207 @@
 import { createHash } from 'node:crypto';
-import type { ComparisonUnitAtom, OpaquePassthroughNode } from '@usejunior/docx-core';
-import { CorrelationStatus, OOXML } from '@usejunior/docx-core';
+import { posix } from 'node:path';
+import type { ComparisonUnitAtom, DocxArchive, OpaquePassthroughNode } from '@usejunior/docx-core';
+import { CorrelationStatus, OOXML, parseXml } from '@usejunior/docx-core';
 
 const XMLNS_NS = 'http://www.w3.org/2000/xmlns/';
 const XML_NS = 'http://www.w3.org/XML/1998/namespace';
 const MC_NS = 'http://schemas.openxmlformats.org/markup-compatibility/2006';
+const OFFICE_REL_NS = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const PACKAGE_REL_NS = 'http://schemas.openxmlformats.org/package/2006/relationships';
 
 export class OpaquePassthroughError extends Error {
   constructor(message: string) {
     super(`Opaque passthrough: ${message}`);
     this.name = 'OpaquePassthroughError';
+  }
+}
+
+interface PackageRelationship {
+  id: string;
+  type: string;
+  target: string;
+  mode: 'Internal' | 'External';
+}
+
+export interface OpaqueRelationshipInstrumentation {
+  boundaryScans: number;
+  relationshipPartReads: number;
+  partHashComputations: number;
+}
+
+function relationshipPartPath(partPath: string): string {
+  const directory = posix.dirname(partPath);
+  return `${directory === '.' ? '' : `${directory}/`}_rels/${posix.basename(partPath)}.rels`;
+}
+
+function collectRelationshipIds(root: Element): string[] {
+  const ids = new Set<string>();
+  const visit = (element: Element): void => {
+    for (let i = 0; i < element.attributes.length; i++) {
+      const attribute = element.attributes.item(i)!;
+      if (attribute.namespaceURI === OFFICE_REL_NS) {
+        if (!attribute.value) throw new OpaquePassthroughError('empty relationship-namespace attribute');
+        ids.add(attribute.value);
+      }
+    }
+    for (let child = element.firstChild; child; child = child.nextSibling) {
+      if (child.nodeType === 1) visit(child as Element);
+    }
+  };
+  visit(root);
+  return [...ids].sort();
+}
+
+function normalizeInternalTarget(ownerPart: string, target: string): string {
+  if (!target || target.includes('\\') || target.includes('\0') || /[?#]/.test(target) || /^[a-z][a-z0-9+.-]*:/i.test(target)) {
+    throw new OpaquePassthroughError(`unsafe internal relationship target '${target}'`);
+  }
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(target);
+  } catch {
+    throw new OpaquePassthroughError(`invalid encoded relationship target '${target}'`);
+  }
+  if (decoded.includes('\\') || decoded.includes('\0') || /[?#]/.test(decoded)) {
+    throw new OpaquePassthroughError(`unsafe internal relationship target '${target}'`);
+  }
+  const segments = target.startsWith('/') ? [] : posix.dirname(ownerPart).split('/').filter(Boolean);
+  for (const segment of decoded.split('/')) {
+    if (!segment || segment === '.') continue;
+    if (segment === '..') {
+      if (segments.length === 0) {
+        throw new OpaquePassthroughError(`relationship target escapes the package root: '${target}'`);
+      }
+      segments.pop();
+    } else {
+      segments.push(segment);
+    }
+  }
+  if (segments.length === 0) throw new OpaquePassthroughError(`empty resolved relationship target '${target}'`);
+  return segments.join('/');
+}
+
+function normalizeExternalTarget(target: string): string {
+  try {
+    return new URL(target).href;
+  } catch {
+    throw new OpaquePassthroughError(`unsafe external relationship target '${target}'`);
+  }
+}
+
+/** Memoized package-scoped relationship closure used only for opaque body blocks. */
+export class OpaqueRelationshipClosureResolver {
+  readonly instrumentation: OpaqueRelationshipInstrumentation = {
+    boundaryScans: 0,
+    relationshipPartReads: 0,
+    partHashComputations: 0,
+  };
+  private readonly relationshipsByPart = new Map<string, Promise<Map<string, PackageRelationship> | null>>();
+  private readonly partHashes = new Map<string, Promise<string>>();
+  private readonly closures = new Map<string, Promise<string>>();
+
+  constructor(private readonly archive: DocxArchive) {}
+
+  async fingerprintBoundary(boundary: Element, ownerPart: string): Promise<string> {
+    this.instrumentation.boundaryScans++;
+    const ids = collectRelationshipIds(boundary);
+    if (ids.length === 0) return '';
+    const identities = await Promise.all(ids.map((id) => this.relationshipIdentity(ownerPart, id, new Set())));
+    return createHash('sha256').update(JSON.stringify(identities), 'utf8').digest('hex');
+  }
+
+  private relationshipIdentity(ownerPart: string, id: string, active: Set<string>): Promise<string> {
+    const key = `${ownerPart}\u0000${id}`;
+    if (active.has(key)) {
+      throw new OpaquePassthroughError(`cyclic relationship closure at ${ownerPart}#${id}`);
+    }
+    const cached = this.closures.get(key);
+    if (cached) return cached;
+    const nextActive = new Set(active).add(key);
+    const pending = this.buildRelationshipIdentity(ownerPart, id, nextActive);
+    this.closures.set(key, pending);
+    return pending;
+  }
+
+  private async buildRelationshipIdentity(ownerPart: string, id: string, active: Set<string>): Promise<string> {
+    const relationships = await this.relationshipsForPart(ownerPart);
+    const relationship = relationships?.get(id);
+    if (!relationship) throw new OpaquePassthroughError(`dangling relationship ${ownerPart}#${id}`);
+    if (relationship.mode === 'External') {
+      return JSON.stringify({
+        id,
+        type: relationship.type,
+        mode: relationship.mode,
+        target: normalizeExternalTarget(relationship.target),
+      });
+    }
+
+    const targetPart = normalizeInternalTarget(ownerPart, relationship.target);
+    const hash = await this.hashPart(targetPart);
+    const dependentRelationships = await this.relationshipsForPart(targetPart);
+    let dependencies: string[] = [];
+    if (dependentRelationships) {
+      if (!/\.(?:xml|vml)$/i.test(targetPart)) {
+        throw new OpaquePassthroughError(`unsupported relationship-bearing target part '${targetPart}'`);
+      }
+      const targetBytes = await this.archive.getFileBuffer(targetPart);
+      if (!targetBytes) throw new OpaquePassthroughError(`missing relationship target part '${targetPart}'`);
+      const targetDocument = parseXml(targetBytes.toString('utf8'));
+      const targetRoot = targetDocument.documentElement;
+      if (!targetRoot) throw new OpaquePassthroughError(`relationship target is not XML '${targetPart}'`);
+      const dependentIds = collectRelationshipIds(targetRoot);
+      dependencies = await Promise.all(
+        dependentIds.map((dependentId) => this.relationshipIdentity(targetPart, dependentId, active)),
+      );
+    }
+    return JSON.stringify({
+      id,
+      type: relationship.type,
+      mode: relationship.mode,
+      resolvedTarget: targetPart,
+      referencedPart: { path: targetPart, sha256: hash },
+      dependencies,
+    });
+  }
+
+  private relationshipsForPart(partPath: string): Promise<Map<string, PackageRelationship> | null> {
+    const cached = this.relationshipsByPart.get(partPath);
+    if (cached) return cached;
+    const pending = (async () => {
+      this.instrumentation.relationshipPartReads++;
+      const xml = await this.archive.getFile(relationshipPartPath(partPath));
+      if (xml === null) return null;
+      const document = parseXml(xml);
+      const elements = Array.from(document.getElementsByTagNameNS(PACKAGE_REL_NS, 'Relationship'));
+      const relationships = new Map<string, PackageRelationship>();
+      for (const element of elements) {
+        const id = element.getAttribute('Id');
+        const type = element.getAttribute('Type');
+        const target = element.getAttribute('Target');
+        const rawMode = element.getAttribute('TargetMode') || 'Internal';
+        if (!id || !type || !target || (rawMode !== 'Internal' && rawMode !== 'External')) {
+          throw new OpaquePassthroughError(`invalid relationship entry in '${relationshipPartPath(partPath)}'`);
+        }
+        if (relationships.has(id)) throw new OpaquePassthroughError(`duplicate relationship Id ${partPath}#${id}`);
+        relationships.set(id, { id, type, target, mode: rawMode });
+      }
+      return relationships;
+    })();
+    this.relationshipsByPart.set(partPath, pending);
+    return pending;
+  }
+
+  private hashPart(partPath: string): Promise<string> {
+    const cached = this.partHashes.get(partPath);
+    if (cached) return cached;
+    const pending = (async () => {
+      this.instrumentation.partHashComputations++;
+      const bytes = await this.archive.getFileBuffer(partPath);
+      if (!bytes) throw new OpaquePassthroughError(`missing relationship target part '${partPath}'`);
+      return createHash('sha256').update(bytes).digest('hex');
+    })();
+    this.partHashes.set(partPath, pending);
+    return pending;
   }
 }
 
@@ -484,10 +676,13 @@ function uniqueDescriptors(atoms: ComparisonUnitAtom[]): OpaquePassthroughNode[]
 }
 
 /** Validate and bind original/revised opaque occurrences before LCS reconstruction. */
-export function bindOpaquePassthroughCounterparts(
+export async function bindOpaquePassthroughCounterparts(
   originalAtoms: ComparisonUnitAtom[],
   revisedAtoms: ComparisonUnitAtom[],
-): void {
+  originalRelationships: OpaqueRelationshipClosureResolver,
+  revisedRelationships: OpaqueRelationshipClosureResolver,
+  ownerPart: string,
+): Promise<void> {
   const original = uniqueDescriptors(originalAtoms);
   const revised = uniqueDescriptors(revisedAtoms);
   if (original.length !== revised.length) {
@@ -500,6 +695,20 @@ export function bindOpaquePassthroughCounterparts(
         `${descriptor.paragraphOrdinal}\u0000${descriptor.ownedParagraphCount}`;
   original.sort((left, right) => placementKey(left).localeCompare(placementKey(right)));
   revised.sort((left, right) => placementKey(left).localeCompare(placementKey(right)));
+  await Promise.all([
+    ...original.filter((descriptor) => descriptor.placementKind === 'body-block').map(async (descriptor) => {
+      descriptor.relationshipClosureFingerprint = await originalRelationships.fingerprintBoundary(
+        descriptor.sourceElement,
+        ownerPart,
+      );
+    }),
+    ...revised.filter((descriptor) => descriptor.placementKind === 'body-block').map(async (descriptor) => {
+      descriptor.relationshipClosureFingerprint = await revisedRelationships.fingerprintBoundary(
+        descriptor.sourceElement,
+        ownerPart,
+      );
+    }),
+  ]);
   for (let i = 0; i < original.length; i++) {
     const before = original[i]!;
     const after = revised[i]!;
@@ -512,7 +721,8 @@ export function bindOpaquePassthroughCounterparts(
       before.localName !== after.localName ||
       before.bodyChildOrdinal !== after.bodyChildOrdinal ||
       before.ownedParagraphCount !== after.ownedParagraphCount ||
-      before.semanticFingerprint !== after.semanticFingerprint
+      before.semanticFingerprint !== after.semanticFingerprint ||
+      before.relationshipClosureFingerprint !== after.relationshipClosureFingerprint
     ) {
       throw new OpaquePassthroughError(`boundary ${i} changed paragraph ownership, moved, or mutated`);
     }

--- a/packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts
+++ b/packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts
@@ -143,6 +143,20 @@ function nearestInlineBoundary(atom: ComparisonUnitAtom): Element | null {
     : null;
 }
 
+function nearestBodyBlockBoundary(atom: ComparisonUnitAtom): Element | null {
+  for (let i = atom.ancestorElements.length - 1; i >= 0; i--) {
+    const ancestor = atom.ancestorElements[i]!;
+    if (ancestor.namespaceURI !== OOXML.W_NS || ancestor.localName !== 'sdt') continue;
+    const parent = ancestor.parentNode;
+    return parent?.nodeType === 1 &&
+      (parent as Element).namespaceURI === OOXML.W_NS &&
+      (parent as Element).localName === 'body'
+      ? ancestor
+      : null;
+  }
+  return null;
+}
+
 function nearestAncestor(element: Element, namespaceUri: string, localName: string): Element | null {
   let current: Node | null = element.parentNode;
   while (current?.nodeType === 1) {
@@ -164,6 +178,16 @@ function siblingOrdinal(element: Element): number {
     ) {
       ordinal++;
     }
+    sibling = sibling.previousSibling;
+  }
+  return ordinal;
+}
+
+function elementChildOrdinal(element: Element): number {
+  let ordinal = 0;
+  let sibling = element.previousSibling;
+  while (sibling) {
+    if (sibling.nodeType === 1) ordinal++;
     sibling = sibling.previousSibling;
   }
   return ordinal;
@@ -264,16 +288,55 @@ function validateInlineSdtKnownStructure(boundary: Element): void {
   }
 }
 
-/** Validate inline-SDT namespace scope before atomization clones leaf nodes. */
-export function validateInlineSdtNamespaceOwnership(root: Element): void {
+function validateBlockSdtKnownStructure(boundary: Element): Element[] {
+  const directChildren = Array.from(boundary.childNodes)
+    .filter((child): child is Element => child.nodeType === 1);
+  const names = directChildren.map((child) =>
+    child.namespaceURI === OOXML.W_NS ? child.localName : `{${child.namespaceURI}}${child.localName}`,
+  );
+  const expected = names[1] === 'sdtEndPr'
+    ? ['sdtPr', 'sdtEndPr', 'sdtContent']
+    : ['sdtPr', 'sdtContent'];
+  if (names.length !== expected.length || names.some((name, index) => name !== expected[index])) {
+    throw new OpaquePassthroughError(
+      'body-block w:sdt must contain ordered w:sdtPr, optional w:sdtEndPr, and w:sdtContent',
+    );
+  }
+  const content = directChildren[directChildren.length - 1]!;
+  if (content.getElementsByTagNameNS(OOXML.W_NS, 'tbl').length > 0) {
+    throw new OpaquePassthroughError('tables inside a body-block w:sdt are outside the bounded placement');
+  }
+  const paragraphs = Array.from(content.getElementsByTagNameNS(OOXML.W_NS, 'p'));
+  if (paragraphs.length === 0) {
+    throw new OpaquePassthroughError('body-block w:sdt has no controlled paragraphs');
+  }
+  if (paragraphs.some((paragraph) => paragraph.parentNode !== content)) {
+    throw new OpaquePassthroughError('body-block w:sdt paragraphs must be direct children of w:sdtContent');
+  }
+  return paragraphs;
+}
+
+/** Validate supported SDT namespace scope before atomization clones leaf nodes. */
+export function validateSdtNamespaceOwnership(root: Element): void {
   for (const boundary of Array.from(root.getElementsByTagNameNS(OOXML.W_NS, 'sdt'))) {
     const paragraph = nearestAncestor(boundary, OOXML.W_NS, 'p');
-    if (!paragraph || boundary.parentNode !== paragraph) continue;
+    const parent = boundary.parentNode;
+    const isInline = paragraph && parent === paragraph;
+    const isBodyBlock = parent?.nodeType === 1 &&
+      (parent as Element).namespaceURI === OOXML.W_NS &&
+      (parent as Element).localName === 'body';
+    if (!isInline && !isBodyBlock) {
+      throw new OpaquePassthroughError('w:sdt placement is outside inline-run and direct body-block support');
+    }
     const bindings = effectiveNamespaces(boundary);
     if (bindings.w !== OOXML.W_NS) {
       throw new OpaquePassthroughError("inline w:sdt has conflicting 'w' namespace ownership");
     }
-    validateInlineSdtKnownStructure(boundary);
+    if (nearestAncestor(boundary, OOXML.W_NS, 'sdt')) {
+      throw new OpaquePassthroughError('nested w:sdt boundaries are outside the bounded passthrough contract');
+    }
+    if (isInline) validateInlineSdtKnownStructure(boundary);
+    else validateBlockSdtKnownStructure(boundary);
     validateNamespaceOwnership(boundary, bindings);
   }
 }
@@ -303,15 +366,17 @@ function materializeNamespaces(
 }
 
 /**
- * Capture the pilot's inline structured-document-tag boundary without modeling
- * its property or extension vocabulary.
+ * Capture supported structured-document-tag boundaries without modeling their
+ * property or extension vocabulary.
  *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.5.2.29
+ * @conformance ECMA-376 edition 5, Part 1 § 17.5.2.34
  * @conformance ECMA-376 edition 5, Part 1 § 17.5.2.31
  * @conformance ECMA-376 edition 5, Part 1 § 17.5.2.36
  * @conformance ECMA-376 edition 5, Part 1 § 17.5.2.38
  * @see https://github.com/UseJunior/safe-docx/issues/582
  */
-export function captureInlineSdtPassthrough(root: Element, atoms: ComparisonUnitAtom[]): void {
+export function captureSdtPassthrough(root: Element, atoms: ComparisonUnitAtom[]): void {
   const descriptorByElement = new Map<Element, OpaquePassthroughNode>();
   const paragraphOrdinals = new Map(
     Array.from(root.getElementsByTagNameNS(OOXML.W_NS, 'p'))
@@ -320,31 +385,47 @@ export function captureInlineSdtPassthrough(root: Element, atoms: ComparisonUnit
   let nextOrdinal = 0;
   for (const boundary of Array.from(root.getElementsByTagNameNS(OOXML.W_NS, 'sdt'))) {
     const paragraph = nearestAncestor(boundary, OOXML.W_NS, 'p');
-    if (!paragraph) continue; // Block/cell/row SDTs remain scaffold-owned and out of pilot scope.
     if (nearestAncestor(boundary, OOXML.W_NS, 'sdt')) {
-      throw new OpaquePassthroughError('nested inline w:sdt boundaries are outside the pilot');
+      throw new OpaquePassthroughError('nested w:sdt boundaries are outside the bounded passthrough contract');
     }
-    if (boundary.parentNode !== paragraph) {
-      throw new OpaquePassthroughError('inline w:sdt must be a direct child of w:p in the pilot');
+    const parent = boundary.parentNode;
+    const isInline = paragraph && parent === paragraph;
+    const isBodyBlock = parent?.nodeType === 1 &&
+      (parent as Element).namespaceURI === OOXML.W_NS &&
+      (parent as Element).localName === 'body';
+    if (!isInline && !isBodyBlock) {
+      throw new OpaquePassthroughError('w:sdt placement is outside inline-run and direct body-block support');
     }
     const bindings = effectiveNamespaces(boundary);
     const mceDeclarations = effectiveMceDeclarations(boundary);
     if (bindings.w !== OOXML.W_NS) {
       throw new OpaquePassthroughError("inline w:sdt has conflicting 'w' namespace ownership");
     }
-    validateInlineSdtKnownStructure(boundary);
+    const blockParagraphs = isBodyBlock ? validateBlockSdtKnownStructure(boundary) : undefined;
+    if (isInline) validateInlineSdtKnownStructure(boundary);
     validateNamespaceOwnership(boundary, bindings);
     validateIgnorableTokens(mceDeclarations.values, bindings);
-    const paragraphOrdinal = paragraphOrdinals.get(paragraph);
+    const ownedParagraph = isInline ? paragraph! : blockParagraphs![0]!;
+    const paragraphOrdinal = paragraphOrdinals.get(ownedParagraph);
     if (paragraphOrdinal === undefined) {
-      throw new OpaquePassthroughError('inline w:sdt paragraph has no source-order identity');
+      throw new OpaquePassthroughError('w:sdt paragraph has no source-order identity');
+    }
+    if (blockParagraphs) {
+      for (let relative = 0; relative < blockParagraphs.length; relative++) {
+        if (paragraphOrdinals.get(blockParagraphs[relative]!) !== paragraphOrdinal + relative) {
+          throw new OpaquePassthroughError('body-block w:sdt paragraph ownership is non-contiguous');
+        }
+      }
     }
     descriptorByElement.set(boundary, {
+      placementKind: isInline ? 'inline-run' : 'body-block',
       namespaceUri: OOXML.W_NS,
       localName: 'sdt',
       documentOrdinal: nextOrdinal++,
       paragraphOrdinal,
-      containerIdentity: structuralContainerIdentity(paragraph),
+      containerIdentity: structuralContainerIdentity(ownedParagraph),
+      bodyChildOrdinal: isBodyBlock ? elementChildOrdinal(boundary) : undefined,
+      ownedParagraphCount: blockParagraphs?.length,
       semanticFingerprint: semanticFingerprint(boundary, bindings, mceDeclarations.values),
       sourceElement: materializeNamespaces(
         boundary,
@@ -359,13 +440,28 @@ export function captureInlineSdtPassthrough(root: Element, atoms: ComparisonUnit
 
   const ownedCounts = new Map<OpaquePassthroughNode, number>();
   for (const atom of atoms) {
-    const boundary = nearestInlineBoundary(atom);
+    const boundary = nearestInlineBoundary(atom) ?? nearestBodyBlockBoundary(atom);
     if (!boundary) continue;
     const descriptor = descriptorByElement.get(boundary);
     if (!descriptor) {
       throw new OpaquePassthroughError('atom is owned by an unsupported inline w:sdt placement');
     }
     atom.opaquePassthrough = descriptor;
+    if (descriptor.placementKind === 'body-block') {
+      let atomParagraph: Element | undefined;
+      for (let i = atom.ancestorElements.length - 1; i >= 0; i--) {
+        const ancestor = atom.ancestorElements[i]!;
+        if (ancestor.namespaceURI === OOXML.W_NS && ancestor.localName === 'p') {
+          atomParagraph = ancestor;
+          break;
+        }
+      }
+      const atomParagraphOrdinal = atomParagraph ? paragraphOrdinals.get(atomParagraph) : undefined;
+      if (atomParagraphOrdinal === undefined) {
+        throw new OpaquePassthroughError('body-block atom has no controlled paragraph identity');
+      }
+      atom.opaquePassthroughRelativeParagraphOrdinal = atomParagraphOrdinal - descriptor.paragraphOrdinal;
+    }
     ownedCounts.set(descriptor, (ownedCounts.get(descriptor) ?? 0) + 1);
   }
   for (const descriptor of descriptorByElement.values()) {
@@ -397,19 +493,30 @@ export function bindOpaquePassthroughCounterparts(
   if (original.length !== revised.length) {
     throw new OpaquePassthroughError(`boundary count changed (${original.length} original, ${revised.length} revised)`);
   }
+  const placementKey = (descriptor: OpaquePassthroughNode) =>
+    descriptor.placementKind === 'inline-run'
+      ? `inline\u0000${descriptor.containerIdentity}\u0000${descriptor.paragraphOrdinal}\u0000${descriptor.documentOrdinal}`
+      : `block\u0000${descriptor.containerIdentity}\u0000${descriptor.bodyChildOrdinal}\u0000` +
+        `${descriptor.paragraphOrdinal}\u0000${descriptor.ownedParagraphCount}`;
+  original.sort((left, right) => placementKey(left).localeCompare(placementKey(right)));
+  revised.sort((left, right) => placementKey(left).localeCompare(placementKey(right)));
   for (let i = 0; i < original.length; i++) {
     const before = original[i]!;
     const after = revised[i]!;
     if (
-      before.documentOrdinal !== after.documentOrdinal ||
+      placementKey(before) !== placementKey(after) ||
+      before.placementKind !== after.placementKind ||
       before.paragraphOrdinal !== after.paragraphOrdinal ||
       before.containerIdentity !== after.containerIdentity ||
       before.namespaceUri !== after.namespaceUri ||
       before.localName !== after.localName ||
+      before.bodyChildOrdinal !== after.bodyChildOrdinal ||
+      before.ownedParagraphCount !== after.ownedParagraphCount ||
       before.semanticFingerprint !== after.semanticFingerprint
     ) {
       throw new OpaquePassthroughError(`boundary ${i} changed paragraph ownership, moved, or mutated`);
     }
+    before.correlatedNode = after;
     after.emissionElement = before.sourceElement;
   }
 }
@@ -417,24 +524,55 @@ export function bindOpaquePassthroughCounterparts(
 /** Reject opaque correlation loss before any whole-paragraph branch can emit. */
 export function validateOpaquePassthroughCorrelation(atoms: ComparisonUnitAtom[]): void {
   const paragraphByDescriptor = new Map<OpaquePassthroughNode, number | undefined>();
+  const relativeParagraphsByDescriptor = new Map<OpaquePassthroughNode, Set<number>>();
   for (const atom of atoms) {
-    const descriptor = atom.opaquePassthrough;
+    let descriptor = atom.opaquePassthrough;
     if (!descriptor) continue;
     if (atom.correlationStatus !== CorrelationStatus.Equal) {
       throw new OpaquePassthroughError(
         `boundary ${descriptor.documentOrdinal} lost equal correlation (${atom.correlationStatus})`,
       );
     }
-    if (!descriptor.emissionElement || atom.sourceDocument !== 'revised') {
+    if (
+      atom.sourceDocument === 'original' &&
+      atom.contentElement.tagName === '__emptyParagraph__' &&
+      descriptor.correlatedNode
+    ) {
+      descriptor = descriptor.correlatedNode;
+      atom.opaquePassthrough = descriptor;
+    }
+    if (!descriptor.emissionElement ||
+      (atom.sourceDocument !== 'revised' && atom.contentElement.tagName !== '__emptyParagraph__')) {
       throw new OpaquePassthroughError(
         `boundary ${descriptor.documentOrdinal} has no validated revised-side owner`,
       );
     }
-    if (!paragraphByDescriptor.has(descriptor)) {
+    if (descriptor.placementKind === 'body-block') {
+      const relative = atom.opaquePassthroughRelativeParagraphOrdinal;
+      if (
+        relative === undefined ||
+        relative < 0 ||
+        relative >= (descriptor.ownedParagraphCount ?? 0)
+      ) {
+        throw new OpaquePassthroughError(
+          `boundary ${descriptor.documentOrdinal} has changed relative paragraph ownership`,
+        );
+      }
+      const seen = relativeParagraphsByDescriptor.get(descriptor) ?? new Set<number>();
+      seen.add(relative);
+      relativeParagraphsByDescriptor.set(descriptor, seen);
+    } else if (!paragraphByDescriptor.has(descriptor)) {
       paragraphByDescriptor.set(descriptor, atom.paragraphIndex);
     } else if (paragraphByDescriptor.get(descriptor) !== atom.paragraphIndex) {
       throw new OpaquePassthroughError(
         `boundary ${descriptor.documentOrdinal} crossed reconstructed paragraph ownership`,
+      );
+    }
+  }
+  for (const [descriptor, seen] of relativeParagraphsByDescriptor) {
+    if (seen.size !== descriptor.ownedParagraphCount) {
+      throw new OpaquePassthroughError(
+        `boundary ${descriptor.documentOrdinal} lost controlled paragraph correlation`,
       );
     }
   }
@@ -476,6 +614,9 @@ export function renderOpaqueAtomSequence(
         }
         pendingAtoms.push(atom);
         continue;
+      }
+      if (descriptor.placementKind !== 'inline-run') {
+        throw new OpaquePassthroughError('body-block boundary reached paragraph-run emission');
       }
       if (descriptor !== active) {
         if (active) closed.add(active);

--- a/packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts
+++ b/packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts
@@ -25,6 +25,7 @@ interface PackageRelationship {
 
 export interface OpaqueRelationshipInstrumentation {
   boundaryScans: number;
+  relationshipIdentityComputations: number;
   relationshipPartReads: number;
   partHashComputations: number;
 }
@@ -53,7 +54,7 @@ function collectRelationshipIds(root: Element): string[] {
 }
 
 function normalizeInternalTarget(ownerPart: string, target: string): string {
-  if (!target || target.includes('\\') || target.includes('\0') || /[?#]/.test(target) || /^[a-z][a-z0-9+.-]*:/i.test(target)) {
+  if (!target || target.includes('\\') || /[\u0000-\u001f\u007f?#]/.test(target)) {
     throw new OpaquePassthroughError(`unsafe internal relationship target '${target}'`);
   }
   let decoded: string;
@@ -62,10 +63,15 @@ function normalizeInternalTarget(ownerPart: string, target: string): string {
   } catch {
     throw new OpaquePassthroughError(`invalid encoded relationship target '${target}'`);
   }
-  if (decoded.includes('\\') || decoded.includes('\0') || /[?#]/.test(decoded)) {
+  if (
+    decoded.includes('\\') ||
+    /[\u0000-\u001f\u007f?#]/.test(decoded) ||
+    decoded.startsWith('//') ||
+    decoded.includes(':')
+  ) {
     throw new OpaquePassthroughError(`unsafe internal relationship target '${target}'`);
   }
-  const segments = target.startsWith('/') ? [] : posix.dirname(ownerPart).split('/').filter(Boolean);
+  const segments = decoded.startsWith('/') ? [] : posix.dirname(ownerPart).split('/').filter(Boolean);
   for (const segment of decoded.split('/')) {
     if (!segment || segment === '.') continue;
     if (segment === '..') {
@@ -93,34 +99,44 @@ function normalizeExternalTarget(target: string): string {
 export class OpaqueRelationshipClosureResolver {
   readonly instrumentation: OpaqueRelationshipInstrumentation = {
     boundaryScans: 0,
+    relationshipIdentityComputations: 0,
     relationshipPartReads: 0,
     partHashComputations: 0,
   };
   private readonly relationshipsByPart = new Map<string, Promise<Map<string, PackageRelationship> | null>>();
   private readonly partHashes = new Map<string, Promise<string>>();
-  private readonly closures = new Map<string, Promise<string>>();
+  private readonly closures = new Map<string, string>();
+  private workQueue: Promise<void> = Promise.resolve();
 
   constructor(private readonly archive: DocxArchive) {}
 
-  async fingerprintBoundary(boundary: Element, ownerPart: string): Promise<string> {
+  fingerprintBoundary(boundary: Element, ownerPart: string): Promise<string> {
+    const task = this.workQueue.then(() => this.fingerprintBoundaryNow(boundary, ownerPart));
+    this.workQueue = task.then(() => undefined, () => undefined);
+    return task;
+  }
+
+  private async fingerprintBoundaryNow(boundary: Element, ownerPart: string): Promise<string> {
     this.instrumentation.boundaryScans++;
     const ids = collectRelationshipIds(boundary);
     if (ids.length === 0) return '';
-    const identities = await Promise.all(ids.map((id) => this.relationshipIdentity(ownerPart, id, new Set())));
+    const identities: string[] = [];
+    for (const id of ids) identities.push(await this.relationshipIdentity(ownerPart, id, new Set()));
     return createHash('sha256').update(JSON.stringify(identities), 'utf8').digest('hex');
   }
 
-  private relationshipIdentity(ownerPart: string, id: string, active: Set<string>): Promise<string> {
+  private async relationshipIdentity(ownerPart: string, id: string, active: Set<string>): Promise<string> {
     const key = `${ownerPart}\u0000${id}`;
     if (active.has(key)) {
       throw new OpaquePassthroughError(`cyclic relationship closure at ${ownerPart}#${id}`);
     }
     const cached = this.closures.get(key);
     if (cached) return cached;
+    this.instrumentation.relationshipIdentityComputations++;
     const nextActive = new Set(active).add(key);
-    const pending = this.buildRelationshipIdentity(ownerPart, id, nextActive);
-    this.closures.set(key, pending);
-    return pending;
+    const identity = await this.buildRelationshipIdentity(ownerPart, id, nextActive);
+    this.closures.set(key, identity);
+    return identity;
   }
 
   private async buildRelationshipIdentity(ownerPart: string, id: string, active: Set<string>): Promise<string> {
@@ -150,9 +166,9 @@ export class OpaqueRelationshipClosureResolver {
       const targetRoot = targetDocument.documentElement;
       if (!targetRoot) throw new OpaquePassthroughError(`relationship target is not XML '${targetPart}'`);
       const dependentIds = collectRelationshipIds(targetRoot);
-      dependencies = await Promise.all(
-        dependentIds.map((dependentId) => this.relationshipIdentity(targetPart, dependentId, active)),
-      );
+      for (const dependentId of dependentIds) {
+        dependencies.push(await this.relationshipIdentity(targetPart, dependentId, active));
+      }
     }
     return JSON.stringify({
       id,

--- a/packages/docx-compare/src/baselines/atomizer/pipeline.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline.ts
@@ -79,6 +79,7 @@ import {
 } from './documentReconstructor.js';
 import {
   bindOpaquePassthroughCounterparts,
+  OpaqueRelationshipClosureResolver,
   validateOpaquePassthroughCorrelation,
 } from './opaquePassthrough.js';
 import { modifyRevisedDocument, ContainerResolutionError } from './inPlaceModifier.js';
@@ -618,6 +619,8 @@ export async function compareDocumentsAtomizer(
   // Step 1: Load DOCX archives
   const originalArchive = await DocxArchive.load(original);
   const revisedArchive = await DocxArchive.load(revised);
+  const originalOpaqueRelationships = new OpaqueRelationshipClosureResolver(originalArchive);
+  const revisedOpaqueRelationships = new OpaqueRelationshipClosureResolver(revisedArchive);
 
   // Step 1b: Resolve auxiliary ID collisions. When both sides define
   // different content under the same comment/footnote/endnote w:id or the
@@ -691,15 +694,15 @@ export async function compareDocumentsAtomizer(
   const originalBookmarkDiagnostics = collectBookmarkDiagnostics(originalXml);
   const revisedBookmarkDiagnostics = collectBookmarkDiagnostics(revisedXml);
 
-  const runComparisonPass = (
+  const runComparisonPass = async (
     atomizeOptions: Parameters<typeof atomizeTree>[3] | undefined,
     outputMode: ReconstructionMode
-  ): {
+  ): Promise<{
     mergedAtoms: ComparisonUnitAtom[];
     newDocumentXml: string;
     outputMode: ReconstructionMode;
     hyperlinkRelationships: NewHyperlinkRel[];
-  } => {
+  }> => {
     // Parse fresh trees for each pass because inplace reconstruction mutates revised AST.
     const originalTree = parseDocumentXml(originalXml);
     const revisedTree = parseDocumentXml(revisedXml);
@@ -727,7 +730,13 @@ export async function compareDocumentsAtomizer(
     assignParagraphIndices(originalAtoms);
     assignParagraphIndices(revisedAtoms);
     if (outputMode === 'rebuild') {
-      bindOpaquePassthroughCounterparts(originalAtoms, revisedAtoms);
+      await bindOpaquePassthroughCounterparts(
+        originalAtoms,
+        revisedAtoms,
+        originalOpaqueRelationships,
+        revisedOpaqueRelationships,
+        originalPart.uri,
+      );
     }
 
     // Step 5: Apply numbering virtualization (optional)
@@ -880,7 +889,7 @@ export async function compareDocumentsAtomizer(
     for (const { pass, atomizeOptions } of inplacePasses) {
       let candidate: typeof comparisonResult;
       try {
-        candidate = runComparisonPass(atomizeOptions, 'inplace');
+        candidate = await runComparisonPass(atomizeOptions, 'inplace');
       } catch (e) {
         if (e instanceof ContainerResolutionError) {
           // Container topology mismatch — treat as failed pass (issue #65)
@@ -922,7 +931,7 @@ export async function compareDocumentsAtomizer(
         precedingFailedAttempts: failedAttempts,
       };
     } else {
-      comparisonResult = runComparisonPass(
+      comparisonResult = await runComparisonPass(
         { atomizeParagraphLevelMarkers: true },
         'rebuild'
       );
@@ -932,7 +941,7 @@ export async function compareDocumentsAtomizer(
       };
     }
   } else {
-    comparisonResult = runComparisonPass(
+    comparisonResult = await runComparisonPass(
       { atomizeParagraphLevelMarkers: true },
       'rebuild'
     );

--- a/packages/docx-core/src/core-types.ts
+++ b/packages/docx-core/src/core-types.ts
@@ -114,17 +114,25 @@ export interface FormatChangeInfo {
  * assigning `emissionElement` from the original side.
  */
 export interface OpaquePassthroughNode {
+  /** Determines whether paragraph-run emission or the body scaffold owns output. */
+  placementKind: 'inline-run' | 'body-block';
   namespaceUri: string;
   localName: string;
   documentOrdinal: number;
-  /** Source-order paragraph identity; movement is outside the pilot and fails closed. */
+  /** Source-order paragraph identity; movement is outside the bounded contract and fails closed. */
   paragraphOrdinal: number;
   /** Structural parent path (body or table/cell position) owning the paragraph. */
   containerIdentity: string;
+  /** Direct body-child position for a scaffold-owned block boundary. */
+  bodyChildOrdinal?: number;
+  /** Number of contiguous source-order paragraph slots owned by a block boundary. */
+  ownedParagraphCount?: number;
   semanticFingerprint: string;
   sourceElement: WmlElement;
   effectiveNamespaces: Readonly<Record<string, string>>;
   effectiveMceDeclarations: Readonly<Record<string, string>>;
+  /** Revised-side canonical owner for an equal original empty-paragraph atom. */
+  correlatedNode?: OpaquePassthroughNode;
   emissionElement?: WmlElement;
 }
 
@@ -190,6 +198,8 @@ export interface ComparisonUnitAtom extends ComparisonUnit {
 
   /** Opaque XML boundary that owns this atom, when bounded passthrough is enabled. */
   opaquePassthrough?: OpaquePassthroughNode;
+  /** Zero-based paragraph position inside a scaffold-owned opaque block. */
+  opaquePassthroughRelativeParagraphOrdinal?: number;
 }
 
 // =============================================================================

--- a/packages/docx-core/src/core-types.ts
+++ b/packages/docx-core/src/core-types.ts
@@ -131,6 +131,8 @@ export interface OpaquePassthroughNode {
   sourceElement: WmlElement;
   effectiveNamespaces: Readonly<Record<string, string>>;
   effectiveMceDeclarations: Readonly<Record<string, string>>;
+  /** Package relationship closure rooted at relationship attributes in a block subtree. */
+  relationshipClosureFingerprint?: string;
   /** Revised-side canonical owner for an equal original empty-paragraph atom. */
   correlatedNode?: OpaquePassthroughNode;
   emissionElement?: WmlElement;

--- a/packages/docx-core/src/integration/atomizer-parity.test.ts
+++ b/packages/docx-core/src/integration/atomizer-parity.test.ts
@@ -51,6 +51,7 @@ describe('Atomizer Pipeline Parity Test', () => {
       author: 'AtomizerTest',
       date: FIXTURE_STABLE_DATE,
       engine: 'atomizer',
+      reconstructionMode: 'inplace',
     });
 
     // Run diffmatch comparison for comparison (direct import, dev-only)
@@ -174,6 +175,7 @@ describe('Atomizer Track Changes Validation', () => {
     const result = await compareDocuments(originalBuffer, revisedBuffer, {
       author: 'ValidationTest',
       engine: 'atomizer',
+      reconstructionMode: 'inplace',
     });
 
     resultDocument = result.document;

--- a/packages/docx-core/src/integration/cross-implementation-suite.test.ts
+++ b/packages/docx-core/src/integration/cross-implementation-suite.test.ts
@@ -44,6 +44,8 @@ const liveSuiteTest = test.conformance(
   { spec: 'ECMA-376', edition: 5, part: 1, section: '17.15.3.4' },
   { spec: 'ECMA-376', edition: 5, part: 1, section: '17.5.2.31' },
   { spec: 'ECMA-376', edition: 5, part: 1, section: '17.5.2.36' },
+  { spec: 'ECMA-376', edition: 5, part: 1, section: '17.5.2.29' },
+  { spec: 'ECMA-376', edition: 5, part: 1, section: '17.5.2.34' },
   { spec: 'ECMA-376', edition: 5, part: 1, section: '17.5.2.38' },
 );
 
@@ -100,6 +102,10 @@ const COMPATIBILITY_MODE_SCENARIO_ID = 'composeCompatibilityMode15WritesCompatSe
 const CONTENT_CONTROL_SCENARIO_IDS = [
   'unrelatedTextEditPreservesInlineContentControlStructure',
   'unrelatedTextEditPreservesOpaqueInlineContentControl',
+] as const;
+const BLOCK_CONTENT_CONTROL_SCENARIO_IDS = [
+  'unrelatedTextEditPreservesBlockContentControlStructure',
+  'unrelatedTextEditPreservesOpaqueBlockContentControl',
 ] as const;
 const EXPECTED_SUPPORTED_OPERATIONS: ReadonlySet<string> = new Set([
   'acceptAllTrackedChanges',
@@ -339,6 +345,18 @@ describeMaybe('Cross-implementation conformance suite self-check', () => {
           );
           const normative = scenarios.get(CONTENT_CONTROL_SCENARIO_IDS[0]);
           const metamorphic = scenarios.get(CONTENT_CONTROL_SCENARIO_IDS[1]);
+          expect(normative?.oracleKind).toBe('ecma-conformance');
+          expect(['pass', 'pass-divergent']).toContain(normative?.outcomes['safe-docx']?.status);
+          expect(metamorphic?.oracleKind).toBe('metamorphic-invariant');
+          expect(metamorphic?.outcomes['safe-docx']?.status).toBe('invariant-pass');
+        });
+
+        await then('both block content-control scenarios report only their oracle-specific pass statuses', async () => {
+          const scenarios = new Map(
+            results.results.map((scenario) => [scenario.scenarioId, scenario]),
+          );
+          const normative = scenarios.get(BLOCK_CONTENT_CONTROL_SCENARIO_IDS[0]);
+          const metamorphic = scenarios.get(BLOCK_CONTENT_CONTROL_SCENARIO_IDS[1]);
           expect(normative?.oracleKind).toBe('ecma-conformance');
           expect(['pass', 'pass-divergent']).toContain(normative?.outcomes['safe-docx']?.status);
           expect(metamorphic?.oracleKind).toBe('metamorphic-invariant');

--- a/packages/docx-core/src/integration/docx-platform-tests.pin.json
+++ b/packages/docx-core/src/integration/docx-platform-tests.pin.json
@@ -1,4 +1,4 @@
 {
   "repository": "open-agreements/docx-platform-tests",
-  "pinnedCommitSha": "fe0ee99602e6f982255ecaa2b45d4936a7f46150"
+  "pinnedCommitSha": "ba9936af06cc18249e892dc594ed9bcefaf98463"
 }

--- a/packages/docx-core/src/integration/round-trip.test.ts
+++ b/packages/docx-core/src/integration/round-trip.test.ts
@@ -188,6 +188,7 @@ describe('Round-Trip Tests - Accept All Changes', () => {
       comparisonResult = await compareDocuments(originalBuffer, revisedBuffer, {
         engine: 'atomizer',
         date: FIXTURE_STABLE_DATE,
+        reconstructionMode: 'inplace',
       });
     }, 120000);
 
@@ -372,6 +373,7 @@ describe('Round-Trip Tests - Reject All Changes', () => {
       comparisonResult = await compareDocuments(originalBuffer, revisedBuffer, {
         engine: 'atomizer',
         date: FIXTURE_STABLE_DATE,
+        reconstructionMode: 'inplace',
       });
     }, 120000);
 

--- a/packages/docx-core/src/integration/roundtrip-structural-invariants.test.ts
+++ b/packages/docx-core/src/integration/roundtrip-structural-invariants.test.ts
@@ -321,14 +321,18 @@ describe('Structural Round-Trip Invariants - ILPA Pair (feature-rich)', () => {
     }
   }, 240000);
 
-  test('fails closed when rebuild would launder changed block content controls', async () => {
-    const original = await readFile(ILPA_ORIGINAL_DOC);
-    const revised = await readFile(ILPA_REVISED_DOC);
+  test(
+    'fails closed when rebuild would launder changed block content controls',
+    async () => {
+      const original = await readFile(ILPA_ORIGINAL_DOC);
+      const revised = await readFile(ILPA_REVISED_DOC);
 
-    await expect(buildRoundTripArtifacts(original, revised, 'rebuild')).rejects.toThrow(
-      /Opaque passthrough: boundary 0 changed paragraph ownership, moved, or mutated/
-    );
-  });
+      await expect(buildRoundTripArtifacts(original, revised, 'rebuild')).rejects.toThrow(
+        /Opaque passthrough: boundary 0 changed paragraph ownership, moved, or mutated/
+      );
+    },
+    120000
+  );
 
   for (const mode of ILPA_MODES) {
     test(

--- a/packages/docx-core/src/integration/roundtrip-structural-invariants.test.ts
+++ b/packages/docx-core/src/integration/roundtrip-structural-invariants.test.ts
@@ -42,6 +42,7 @@ interface RoundTripArtifacts {
 
 
 const MODES: ReconstructionMode[] = ['rebuild', 'inplace'];
+const ILPA_MODES: ReconstructionMode[] = ['inplace'];
 const CORE_PARTS = [
   DOCX_PATHS.DOCUMENT,
   DOCX_PATHS.NUMBERING,
@@ -315,12 +316,21 @@ describe('Structural Round-Trip Invariants - ILPA Pair (feature-rich)', () => {
     const original = await readFile(ILPA_ORIGINAL_DOC);
     const revised = await readFile(ILPA_REVISED_DOC);
 
-    for (const mode of MODES) {
+    for (const mode of ILPA_MODES) {
       artifactsByMode.set(mode, await buildRoundTripArtifacts(original, revised, mode));
     }
   }, 240000);
 
-  for (const mode of MODES) {
+  test('fails closed when rebuild would launder changed block content controls', async () => {
+    const original = await readFile(ILPA_ORIGINAL_DOC);
+    const revised = await readFile(ILPA_REVISED_DOC);
+
+    await expect(buildRoundTripArtifacts(original, revised, 'rebuild')).rejects.toThrow(
+      /Opaque passthrough: boundary 0 changed paragraph ownership, moved, or mutated/
+    );
+  });
+
+  for (const mode of ILPA_MODES) {
     test(
       `enforces read_text accept/reject parity (${mode})`,
       async ({ given, then }: AllureBddContext) => {

--- a/packages/docx-core/src/shared/docx/DocxArchive.test.ts
+++ b/packages/docx-core/src/shared/docx/DocxArchive.test.ts
@@ -94,6 +94,23 @@ describe('DocxArchive', () => {
     });
   });
 
+  describe('binary package entries', () => {
+    test('returns exact bytes without text decoding', async ({ given, when, then }: AllureBddContext) => {
+      let archive: DocxArchive;
+      const payload = Buffer.from([0x00, 0xff, 0x89, 0x50, 0x4e, 0x47]);
+
+      await given('a created archive with a binary media part', async () => {
+        archive = await DocxArchive.create();
+        archive.setFile('word/media/image.bin', payload);
+      });
+      await when('the media part is read as a buffer', () => {});
+      await then('every byte is retained', async () => {
+        expect(await archive.getFileBuffer('word/media/image.bin')).toEqual(payload);
+        expect(await archive.getFileBuffer('word/media/missing.bin')).toBeNull();
+      });
+    });
+  });
+
   describe('clone', () => {
     test('creates an independent copy', async ({ given, when, then }: AllureBddContext) => {
       let original: DocxArchive;

--- a/packages/docx-core/src/shared/docx/DocxArchive.ts
+++ b/packages/docx-core/src/shared/docx/DocxArchive.ts
@@ -126,13 +126,20 @@ export class DocxArchive {
     return file.async('string');
   }
 
+  /** Get an arbitrary archive entry without decoding binary payloads as text. */
+  async getFileBuffer(path: string): Promise<Buffer | null> {
+    const file = this.zip.file(path);
+    if (!file) return null;
+    return file.async('nodebuffer');
+  }
+
   /**
    * Set an arbitrary file in the archive.
    *
    * @param path - Path within the archive
    * @param content - File contents
    */
-  setFile(path: string, content: string): void {
+  setFile(path: string, content: string | Buffer): void {
     this.zip.file(path, content);
     this.modified.add(path);
   }

--- a/scripts/generate_capability_projection.test.mjs
+++ b/scripts/generate_capability_projection.test.mjs
@@ -25,7 +25,7 @@ async function inputs() {
 
 test('the committed projection matches the exact upstream denominator', async () => {
   const result = await validateProjection(await inputs(), root);
-  assert.equal(result.denominator, 87);
+  assert.equal(result.denominator, 91);
 });
 
 test('a positive claim without executable evidence is rejected', async () => {

--- a/spec-compliance/CONFORMANCE.md
+++ b/spec-compliance/CONFORMANCE.md
@@ -22,9 +22,11 @@ Allure labels via `testAllure.conformance({…})`; source code carries
 | `ECMA-PART1-17-13-8-1` | Proofing error anchors | 5 | 1 | 17.13.8.1 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:proofErr` | — |
 | `ECMA-PART1-17-11-14` | w:footnoteReference identifier vs display number | 5 | 1 | 17.11.14 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:footnoteReference` | packages/docx-core/src/footnotes.ts; packages/docx-core/src/footnotes.test.ts |
 | `ECMA-PART1-17-16-22` | w:hyperlink container preservation under tracked changes | 5 | 1 | 17.16.22 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:hyperlink` | — |
+| `ECMA-PART1-17-5-2-29` | w:sdt block-level structured document tag | 5 | 1 | 17.5.2.29 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#type:CT_SdtBlock` | packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-block-sdt.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-inline-sdt.test.ts |
 | `ECMA-PART1-17-5-2-31` | w:sdt inline-level structured document tag | 5 | 1 | 17.5.2.31 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#type:CT_SdtRun` | packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-inline-sdt.test.ts |
+| `ECMA-PART1-17-5-2-34` | w:sdtContent block-level structured document tag content | 5 | 1 | 17.5.2.34 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#type:CT_SdtContentBlock` | packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-block-sdt.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-inline-sdt.test.ts |
 | `ECMA-PART1-17-5-2-36` | w:sdtContent inline-level structured document tag content | 5 | 1 | 17.5.2.36 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#type:CT_SdtContentRun` | packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-inline-sdt.test.ts |
-| `ECMA-PART1-17-5-2-38` | w:sdtPr structured document tag properties | 5 | 1 | 17.5.2.38 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#type:CT_SdtPr` | packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-inline-sdt.test.ts |
+| `ECMA-PART1-17-5-2-38` | w:sdtPr structured document tag properties | 5 | 1 | 17.5.2.38 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#type:CT_SdtPr` | packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-inline-sdt.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-block-sdt.test.ts |
 | `ECMA-PART1-17-6-17` | w:sectPr document-final section properties | 5 | 1 | 17.6.17 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:sectPr` | — |
 | `ECMA-PART1-17-6-13` | w:pgSz page size emission | 5 | 1 | 17.6.13 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:pgSz` | — |
 | `ECMA-PART1-17-6-11` | w:pgMar page margin emission | 5 | 1 | 17.6.11 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:pgMar` | — |
@@ -252,6 +254,20 @@ lives in `packages/docx-core/src/atomizer.ts`
 `packages/docx-core/src/baselines/atomizer/documentReconstructor.ts`
 (hyperlink wrapper re-emission).
 
+### ECMA-PART1-17-5-2-29 — w:sdt block-level structured document tag
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.5.2.29
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#type:CT_SdtBlock`
+- **Verified by:** packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-block-sdt.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-inline-sdt.test.ts
+
+A block `w:sdt` surrounds one or more block-level structures and orders its
+properties, optional end properties, and content under the CT_SdtBlock model.
+safe-docx preserves an unchanged direct `w:body/w:sdt` as one scaffold-owned
+boundary during forced rebuild. Exact subtree preservation is a bounded
+metamorphic invariant rather than a requirement imposed by ECMA-376.
+
 ### ECMA-PART1-17-5-2-31 — w:sdt inline-level structured document tag
 
 - **Edition:** ECMA-376 5
@@ -263,8 +279,20 @@ lives in `packages/docx-core/src/atomizer.ts`
 An inline `w:sdt` is a run-level structured document tag whose ordered children
 are its properties, optional end properties, and content. The issue #582 pilot
 preserves an unchanged inline SDT as one opaque semantic boundary during rebuild;
-it does not author or edit controls and makes no claim about block, row, or cell
-SDTs.
+it does not author or edit controls and makes no claim about row or cell SDTs.
+
+### ECMA-PART1-17-5-2-34 — w:sdtContent block-level structured document tag content
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.5.2.34
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#type:CT_SdtContentBlock`
+- **Verified by:** packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-block-sdt.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-inline-sdt.test.ts
+
+Block-level `w:sdtContent` contains the controlled block structures. The bounded
+rebuild path recognizes only a contiguous sequence of direct controlled
+paragraphs under a direct body-level control; tables and nested controls remain
+outside the supported placement.
 
 ### ECMA-PART1-17-5-2-36 — w:sdtContent inline-level structured document tag content
 
@@ -283,7 +311,7 @@ controlled text when that subtree is unchanged between comparison inputs.
 - **Part / Section:** Part 1 § 17.5.2.38
 - **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
 - **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#type:CT_SdtPr`
-- **Verified by:** packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-inline-sdt.test.ts
+- **Verified by:** packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-inline-sdt.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-block-sdt.test.ts
 
 The pilot retains known and ignorable-extension children under `w:sdtPr` in
 their source order. Retention of unknown extension payload is a metamorphic

--- a/spec-compliance/capabilities/safe-docx-projection.json
+++ b/spec-compliance/capabilities/safe-docx-projection.json
@@ -3,6 +3,62 @@
   "profileId": "current-neutral-surface",
   "claims": [
     {
+      "capabilityId": "word.content-controls.block",
+      "axis": "preserve",
+      "status": "untested",
+      "evidence": [],
+      "rationale": "The pinned neutral scenarios are executed in the gated DPT self-check, while this projection has no committed neutral result row and does not encode repo-local forced-rebuild evidence.",
+      "implementationVersion": "0.17.0",
+      "lastVerifiedCommit": "ba9936af06cc18249e892dc594ed9bcefaf98463",
+      "scope": {
+        "packageParts": ["word/document.xml"],
+        "stories": ["main"],
+        "reconstructionModes": ["inplace", "rebuild"]
+      }
+    },
+    {
+      "capabilityId": "word.content-controls.block",
+      "axis": "generate",
+      "status": "untested",
+      "evidence": [],
+      "rationale": "No pinned neutral result or mapped local executable evidence is asserted for this pair.",
+      "implementationVersion": "0.17.0",
+      "lastVerifiedCommit": "ba9936af06cc18249e892dc594ed9bcefaf98463",
+      "scope": {
+        "packageParts": ["word/document.xml"],
+        "stories": ["main"],
+        "reconstructionModes": ["not-applicable"]
+      }
+    },
+    {
+      "capabilityId": "word.content-controls.block",
+      "axis": "edit",
+      "status": "untested",
+      "evidence": [],
+      "rationale": "No pinned neutral result or mapped local executable evidence is asserted for this pair.",
+      "implementationVersion": "0.17.0",
+      "lastVerifiedCommit": "ba9936af06cc18249e892dc594ed9bcefaf98463",
+      "scope": {
+        "packageParts": ["word/document.xml"],
+        "stories": ["main"],
+        "reconstructionModes": ["not-applicable"]
+      }
+    },
+    {
+      "capabilityId": "word.content-controls.block",
+      "axis": "crossPlatform",
+      "status": "untested",
+      "evidence": [],
+      "rationale": "No pinned neutral result or mapped local executable evidence is asserted for this pair.",
+      "implementationVersion": "0.17.0",
+      "lastVerifiedCommit": "ba9936af06cc18249e892dc594ed9bcefaf98463",
+      "scope": {
+        "packageParts": ["word/document.xml"],
+        "stories": ["main"],
+        "reconstructionModes": ["not-applicable"]
+      }
+    },
+    {
       "capabilityId": "word.comments.anchors",
       "axis": "generate",
       "status": "untested",

--- a/spec-compliance/capabilities/upstream-pin.json
+++ b/spec-compliance/capabilities/upstream-pin.json
@@ -1,17 +1,17 @@
 {
   "schemaVersion": 1,
   "repository": "open-agreements/docx-platform-tests",
-  "commit": "fe0ee99602e6f982255ecaa2b45d4936a7f46150",
+  "commit": "ba9936af06cc18249e892dc594ed9bcefaf98463",
   "registrySchemaVersion": 1,
   "registryVersion": 1,
   "profileId": "current-neutral-surface",
   "files": [
-    { "path": "spec-compliance/capabilities/upstream/capabilities.json", "sha256": "9e56935473631271b9fd074ea371aea0713022bb3661a85619c43dcb21a35be5" },
+    { "path": "spec-compliance/capabilities/upstream/capabilities.json", "sha256": "9551c483c052cf415105c7c922e7d0ead18c42bf10bc957dc35419e2abfa000c" },
     { "path": "spec-compliance/capabilities/upstream/capabilities.schema.json", "sha256": "0cd004d06db895485cd977b87cd207dcc02e82ae213da27acee145f308c79db4" },
-    { "path": "spec-compliance/capabilities/upstream/profiles.json", "sha256": "34f3837ffc311f1b70227e195d301a0e608a7acb368385e79282d0e32d9cd9c3" },
+    { "path": "spec-compliance/capabilities/upstream/profiles.json", "sha256": "db150c5c739e760f7d92c128f2e5ee76c7dd4e7265b3a647c1197aa90070970e" },
     { "path": "spec-compliance/capabilities/upstream/profiles.schema.json", "sha256": "a61419d3cff77a658f7e9190869426e9177725dfd87c6f9131fa20c934885ef0" },
-    { "path": "spec-compliance/capabilities/upstream/scenario-capabilities.json", "sha256": "ac7eda779c36872fe1a89d3bce91b8e4c4fc2e9d2b3e8d018f020e748fac7fa6" },
+    { "path": "spec-compliance/capabilities/upstream/scenario-capabilities.json", "sha256": "ac520f57d3b1d609d96e4c6a869a46aa7b8db4208d23c1bd449e17797f92f03e" },
     { "path": "spec-compliance/capabilities/upstream/scenario-capabilities.schema.json", "sha256": "0d9850a1782174e9cc206c4b5379a3b20360e2e2cf8e33461e3d49cb4303dc6c" },
-    { "path": "spec-compliance/capabilities/upstream/capability-summary.json", "sha256": "e4e7e25f504fb7113278a76898b75cb0d548afc57ab3bf6c6c8320bbc02eddd7" }
+    { "path": "spec-compliance/capabilities/upstream/capability-summary.json", "sha256": "d7054219e5fdee8000f36b5389cc557ac45ebf280c26b0f16716ad31b9c2f092" }
   ]
 }

--- a/spec-compliance/capabilities/upstream/capabilities.json
+++ b/spec-compliance/capabilities/upstream/capabilities.json
@@ -3,6 +3,23 @@
   "registryVersion": 1,
   "capabilities": [
     {
+      "id": "word.content-controls.block",
+      "title": "Block structured document tags",
+      "family": "content-controls",
+      "description": "Body-level structured document tags retain their properties and multi-paragraph block content during unrelated text edits. Preservation of declared ignorable foreign-extension sentinels is a metamorphic invariant, not an ECMA-376 normative requirement.",
+      "standards": [
+        { "standard": "ECMA-376", "edition": 5, "part": 1, "section": "17.5.2.29" },
+        { "standard": "ECMA-376", "edition": 5, "part": 1, "section": "17.5.2.34" },
+        { "standard": "ECMA-376", "edition": 5, "part": 1, "section": "17.5.2.38" },
+        { "standard": "ECMA-376", "edition": 5, "part": 3, "section": "7.2" },
+        { "standard": "ECMA-376", "edition": 5, "part": 3, "section": "9.2" },
+        { "standard": "ECMA-376", "edition": 5, "part": 3, "section": "9.4" }
+      ],
+      "dependencies": ["word.paragraphs.structure"],
+      "applicableAxes": ["detect", "preserve", "parse", "validate", "generate", "edit", "crossPlatform"],
+      "packageParts": ["word/document.xml"]
+    },
+    {
       "id": "word.content-controls.inline",
       "title": "Inline structured document tags",
       "family": "content-controls",

--- a/spec-compliance/capabilities/upstream/capability-summary.json
+++ b/spec-compliance/capabilities/upstream/capability-summary.json
@@ -65,7 +65,9 @@
     "replaceTextInsideTableCellUpdatesTargetText",
     "setDefaultFooterTextAddsFooterReference",
     "setTableCellTextReplacesCellContentOnly",
+    "unrelatedTextEditPreservesBlockContentControlStructure",
     "unrelatedTextEditPreservesInlineContentControlStructure",
+    "unrelatedTextEditPreservesOpaqueBlockContentControl",
     "unrelatedTextEditPreservesOpaqueInlineContentControl"
   ],
   "capabilities": [

--- a/spec-compliance/capabilities/upstream/profiles.json
+++ b/spec-compliance/capabilities/upstream/profiles.json
@@ -7,6 +7,7 @@
       "title": "Current neutral scenario surface",
       "description": "All capabilities represented by committed neutral scenarios; this profile carries no product-specific weighting.",
       "capabilityIds": [
+        "word.content-controls.block",
         "word.content-controls.inline",
         "word.comments.anchors",
         "word.comments.content",

--- a/spec-compliance/capabilities/upstream/scenario-capabilities.json
+++ b/spec-compliance/capabilities/upstream/scenario-capabilities.json
@@ -3,6 +3,24 @@
   "registryVersion": 1,
   "mappings": [
     {
+      "scenarioId": "unrelatedTextEditPreservesOpaqueBlockContentControl",
+      "capabilityId": "word.content-controls.block",
+      "axis": "preserve",
+      "oracleClasses": ["metamorphic-invariant"]
+    },
+    {
+      "scenarioId": "unrelatedTextEditPreservesBlockContentControlStructure",
+      "capabilityId": "word.content-controls.block",
+      "axis": "preserve",
+      "oracleClasses": ["normative-prose"]
+    },
+    {
+      "scenarioId": "unrelatedTextEditPreservesBlockContentControlStructure",
+      "capabilityId": "word.text.find-replace",
+      "axis": "edit",
+      "oracleClasses": ["normative-prose"]
+    },
+    {
       "scenarioId": "unrelatedTextEditPreservesOpaqueInlineContentControl",
       "capabilityId": "word.content-controls.inline",
       "axis": "preserve",

--- a/spec-compliance/generated/safe-docx-capability-projection.json
+++ b/spec-compliance/generated/safe-docx-capability-projection.json
@@ -2,27 +2,27 @@
   "schemaVersion": 1,
   "generatedFrom": {
     "repository": "open-agreements/docx-platform-tests",
-    "commit": "fe0ee99602e6f982255ecaa2b45d4936a7f46150",
+    "commit": "ba9936af06cc18249e892dc594ed9bcefaf98463",
     "registryVersion": 1,
     "profileId": "current-neutral-surface"
   },
   "profileDenominator": {
-    "capabilityAxisPairs": 87,
+    "capabilityAxisPairs": 91,
     "byAxis": {
-      "preserve": 22,
-      "generate": 15,
-      "edit": 17,
+      "preserve": 23,
+      "generate": 16,
+      "edit": 18,
       "acceptReject": 10,
-      "crossPlatform": 23
+      "crossPlatform": 24
     }
   },
   "evidenceInventory": {
-    "authoredMappingPairs": 28,
-    "crossPlatformDerivedPairsInCompleteRun": 23,
-    "expectedCompleteSummaryRows": 51,
+    "authoredMappingPairs": 29,
+    "crossPlatformDerivedPairsInCompleteRun": 24,
+    "expectedCompleteSummaryRows": 53,
     "pinnedMeasuredSummaryRows": 8,
     "pinnedMeasuredScenarios": 12,
-    "pinnedUnmeasuredScenarios": 30
+    "pinnedUnmeasuredScenarios": 32
   },
   "statusCounts": {
     "supported": 8,
@@ -30,7 +30,7 @@
     "preservation-only": 0,
     "gap": 3,
     "non-goal": 0,
-    "untested": 76
+    "untested": 80
   },
   "formalAssuranceBoundary": {
     "establishesCapabilityClaims": false,
@@ -317,6 +317,95 @@
       },
       "title": "Comment removal",
       "family": "comments"
+    },
+    {
+      "capabilityId": "word.content-controls.block",
+      "axis": "crossPlatform",
+      "status": "untested",
+      "evidence": [],
+      "rationale": "No pinned neutral result or mapped local executable evidence is asserted for this pair.",
+      "implementationVersion": "0.17.0",
+      "lastVerifiedCommit": "ba9936af06cc18249e892dc594ed9bcefaf98463",
+      "scope": {
+        "packageParts": [
+          "word/document.xml"
+        ],
+        "stories": [
+          "main"
+        ],
+        "reconstructionModes": [
+          "not-applicable"
+        ]
+      },
+      "title": "Block structured document tags",
+      "family": "content-controls"
+    },
+    {
+      "capabilityId": "word.content-controls.block",
+      "axis": "edit",
+      "status": "untested",
+      "evidence": [],
+      "rationale": "No pinned neutral result or mapped local executable evidence is asserted for this pair.",
+      "implementationVersion": "0.17.0",
+      "lastVerifiedCommit": "ba9936af06cc18249e892dc594ed9bcefaf98463",
+      "scope": {
+        "packageParts": [
+          "word/document.xml"
+        ],
+        "stories": [
+          "main"
+        ],
+        "reconstructionModes": [
+          "not-applicable"
+        ]
+      },
+      "title": "Block structured document tags",
+      "family": "content-controls"
+    },
+    {
+      "capabilityId": "word.content-controls.block",
+      "axis": "generate",
+      "status": "untested",
+      "evidence": [],
+      "rationale": "No pinned neutral result or mapped local executable evidence is asserted for this pair.",
+      "implementationVersion": "0.17.0",
+      "lastVerifiedCommit": "ba9936af06cc18249e892dc594ed9bcefaf98463",
+      "scope": {
+        "packageParts": [
+          "word/document.xml"
+        ],
+        "stories": [
+          "main"
+        ],
+        "reconstructionModes": [
+          "not-applicable"
+        ]
+      },
+      "title": "Block structured document tags",
+      "family": "content-controls"
+    },
+    {
+      "capabilityId": "word.content-controls.block",
+      "axis": "preserve",
+      "status": "untested",
+      "evidence": [],
+      "rationale": "The pinned neutral scenarios are executed in the gated DPT self-check, while this projection has no committed neutral result row and does not encode repo-local forced-rebuild evidence.",
+      "implementationVersion": "0.17.0",
+      "lastVerifiedCommit": "ba9936af06cc18249e892dc594ed9bcefaf98463",
+      "scope": {
+        "packageParts": [
+          "word/document.xml"
+        ],
+        "stories": [
+          "main"
+        ],
+        "reconstructionModes": [
+          "inplace",
+          "rebuild"
+        ]
+      },
+      "title": "Block structured document tags",
+      "family": "content-controls"
     },
     {
       "capabilityId": "word.content-controls.inline",

--- a/spec-compliance/generated/safe-docx-capability-projection.md
+++ b/spec-compliance/generated/safe-docx-capability-projection.md
@@ -1,6 +1,6 @@
 # SafeDocX Capability Projection
 
-Pinned neutral registry: `open-agreements/docx-platform-tests@fe0ee99602e6f982255ecaa2b45d4936a7f46150`
+Pinned neutral registry: `open-agreements/docx-platform-tests@ba9936af06cc18249e892dc594ed9bcefaf98463`
 
 Profile: `current-neutral-surface` (registry version 1)
 
@@ -22,15 +22,15 @@ Exact known unchecked areas: full ECMA-376 schema validation; rendering equivale
 
 ## Denominator
 
-Profile capability/axis pairs: **87**
+Profile capability/axis pairs: **91**
 
 | Axis | Pairs |
 |---|---:|
-| preserve | 22 |
-| generate | 15 |
-| edit | 17 |
+| preserve | 23 |
+| generate | 16 |
+| edit | 18 |
 | acceptReject | 10 |
-| crossPlatform | 23 |
+| crossPlatform | 24 |
 
 ## Evidence Inventory
 
@@ -38,12 +38,12 @@ These counts are not interchangeable denominators. The profile cross-product inc
 
 | Count | Value | Meaning |
 |---|---:|---|
-| Profile capability/axis pairs | 87 | Every applicable pair selected by the pinned profile |
-| Authored mapping pairs | 28 | Distinct capability/axis pairs with neutral scenarios |
-| Complete-run derived cross-platform pairs | 23 | One potential cross-platform row per mapped capability |
-| Expected complete summary rows | 51 | 28 authored plus 23 derived rows |
+| Profile capability/axis pairs | 91 | Every applicable pair selected by the pinned profile |
+| Authored mapping pairs | 29 | Distinct capability/axis pairs with neutral scenarios |
+| Complete-run derived cross-platform pairs | 24 | One potential cross-platform row per mapped capability |
+| Expected complete summary rows | 53 | 29 authored plus 24 derived rows |
 | Pinned measured summary rows | 8 | Rows actually backed by the pinned result snapshot |
-| Pinned measured / unmeasured scenarios | 12 / 30 | Result-snapshot state at the pinned commit |
+| Pinned measured / unmeasured scenarios | 12 / 32 | Result-snapshot state at the pinned commit |
 
 ## Status Counts
 
@@ -54,7 +54,7 @@ These counts are not interchangeable denominators. The profile cross-product inc
 | preservation-only | 0 |
 | gap | 3 |
 | non-goal | 0 |
-| untested | 76 |
+| untested | 80 |
 
 ## Evidence Projection
 
@@ -70,6 +70,10 @@ These counts are not interchangeable denominators. The profile cross-product inc
 | `word.comments.content` | preserve | untested | `word/comments.xml`<br>stories: comments<br>mode: inplace, rebuild | 0.16.0 / `4ea2a263dc199cb81132a6580a5d22785fcda7e3` | none | No pinned neutral result or mapped local executable evidence is asserted for this preserve pair. |
 | `word.comments.removal` | crossPlatform | untested | `word/document.xml`, `word/comments.xml`<br>stories: main, comments<br>mode: not-applicable | 0.16.0 / `4ea2a263dc199cb81132a6580a5d22785fcda7e3` | none | The pinned neutral result set has no measured cross-platform row for this pair. |
 | `word.comments.removal` | edit | untested | `word/document.xml`, `word/comments.xml`<br>stories: main, comments<br>mode: not-applicable | 0.16.0 / `4ea2a263dc199cb81132a6580a5d22785fcda7e3` | none | Local tests lack structured capability-and-axis metadata, so this pair is untested in this projection. |
+| `word.content-controls.block` | crossPlatform | untested | `word/document.xml`<br>stories: main<br>mode: not-applicable | 0.17.0 / `ba9936af06cc18249e892dc594ed9bcefaf98463` | none | No pinned neutral result or mapped local executable evidence is asserted for this pair. |
+| `word.content-controls.block` | edit | untested | `word/document.xml`<br>stories: main<br>mode: not-applicable | 0.17.0 / `ba9936af06cc18249e892dc594ed9bcefaf98463` | none | No pinned neutral result or mapped local executable evidence is asserted for this pair. |
+| `word.content-controls.block` | generate | untested | `word/document.xml`<br>stories: main<br>mode: not-applicable | 0.17.0 / `ba9936af06cc18249e892dc594ed9bcefaf98463` | none | No pinned neutral result or mapped local executable evidence is asserted for this pair. |
+| `word.content-controls.block` | preserve | untested | `word/document.xml`<br>stories: main<br>mode: inplace, rebuild | 0.17.0 / `ba9936af06cc18249e892dc594ed9bcefaf98463` | none | The pinned neutral scenarios are executed in the gated DPT self-check, while this projection has no committed neutral result row and does not encode repo-local forced-rebuild evidence. |
 | `word.content-controls.inline` | crossPlatform | untested | `word/document.xml`<br>stories: main<br>mode: not-applicable | 0.17.0 / `fe0ee99602e6f982255ecaa2b45d4936a7f46150` | none | No pinned neutral result or mapped local executable evidence is asserted for this pair. |
 | `word.content-controls.inline` | edit | untested | `word/document.xml`<br>stories: main<br>mode: not-applicable | 0.17.0 / `fe0ee99602e6f982255ecaa2b45d4936a7f46150` | none | No pinned neutral result or mapped local executable evidence is asserted for this pair. |
 | `word.content-controls.inline` | generate | untested | `word/document.xml`<br>stories: main<br>mode: not-applicable | 0.17.0 / `fe0ee99602e6f982255ecaa2b45d4936a7f46150` | none | No pinned neutral result or mapped local executable evidence is asserted for this pair. |

--- a/spec-compliance/registry/ecma-376.md
+++ b/spec-compliance/registry/ecma-376.md
@@ -182,6 +182,23 @@ lives in `packages/docx-core/src/atomizer.ts`
 `packages/docx-core/src/baselines/atomizer/documentReconstructor.ts`
 (hyperlink wrapper re-emission).
 
+## [ECMA-PART1-17-5-2-29] w:sdt block-level structured document tag
+
+```yaml
+edition: 5
+part: 1
+section: "17.5.2.29"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#type:CT_SdtBlock
+verifiedBy: packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-block-sdt.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-inline-sdt.test.ts
+```
+
+A block `w:sdt` surrounds one or more block-level structures and orders its
+properties, optional end properties, and content under the CT_SdtBlock model.
+safe-docx preserves an unchanged direct `w:body/w:sdt` as one scaffold-owned
+boundary during forced rebuild. Exact subtree preservation is a bounded
+metamorphic invariant rather than a requirement imposed by ECMA-376.
+
 ## [ECMA-PART1-17-5-2-31] w:sdt inline-level structured document tag
 
 ```yaml
@@ -196,8 +213,23 @@ verifiedBy: packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; p
 An inline `w:sdt` is a run-level structured document tag whose ordered children
 are its properties, optional end properties, and content. The issue #582 pilot
 preserves an unchanged inline SDT as one opaque semantic boundary during rebuild;
-it does not author or edit controls and makes no claim about block, row, or cell
-SDTs.
+it does not author or edit controls and makes no claim about row or cell SDTs.
+
+## [ECMA-PART1-17-5-2-34] w:sdtContent block-level structured document tag content
+
+```yaml
+edition: 5
+part: 1
+section: "17.5.2.34"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#type:CT_SdtContentBlock
+verifiedBy: packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-block-sdt.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-inline-sdt.test.ts
+```
+
+Block-level `w:sdtContent` contains the controlled block structures. The bounded
+rebuild path recognizes only a contiguous sequence of direct controlled
+paragraphs under a direct body-level control; tables and nested controls remain
+outside the supported placement.
 
 ## [ECMA-PART1-17-5-2-36] w:sdtContent inline-level structured document tag content
 
@@ -221,7 +253,7 @@ part: 1
 section: "17.5.2.38"
 url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
 schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#type:CT_SdtPr
-verifiedBy: packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-inline-sdt.test.ts
+verifiedBy: packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-inline-sdt.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-block-sdt.test.ts
 ```
 
 The pilot retains known and ignorable-extension children under `w:sdtPr` in


### PR DESCRIPTION
## Summary\n\n- extends opaque passthrough from direct inline controls to unchanged direct body-level block content controls\n- preserves the complete validated source subtree while rebuild advances across all owned paragraph slots\n- retains sdtPr, sdtEndPr, sdtContent, empty paragraphs, every attribute, effective namespace/MCE scope, DrawingML references, and media relationship closure\n- keeps unrelated outside edits active and preserves accept/reject projections\n- fails closed on internal mutation, insertion/deletion/reordering, movement, ownership loss, nesting, unsupported placement, missing relationship targets, changed media/targets/type/mode, dependency cycles, or invalid package targets\n- memoizes placement-aware LCS identity and package relationship closure without adding archive reads for relationship-free inline controls\n- pins docx-platform-tests PR #57 and refreshes capability evidence\n- upgrades real ILPA corpus tests to force rebuild and compare complete SDT/relationship/media preservation\n\n## Real corpus evidence\n\nBoth checked-in July 2020 ILPA agreements contain one native body-level cover-page control:\n\n- 38 direct controlled paragraphs\n- 152 paraId/textId/rsid attributes\n- DrawingML ILPA logo relationship and media\n- sdtPr, sdtEndPr, and sdtContent\n\nAfter an unrelated forced-rebuild edit, both outputs retain the complete block subtree and relationship closure. Only word/document.xml changes.\n\n## Claims\n\nECMA-376 5th edition Part 1 sections 17.5.2.29, 17.5.2.34, and 17.5.2.38 ground block-SDT structure.\n\nExact unchanged-subtree and opaque-extension retention is a bounded SafeDocX metamorphic invariant, not an ECMA requirement, arbitrary package passthrough, or editing support inside the control.\n\n## Verification\n\n- independent adversarial review: APPROVE\n- focused block/inline/LCS/ILPA: 27 passing\n- full docx-compare: 566 passing, 24 skipped\n- full docx-core and mandatory workspace suite passed\n- preflight:ci passed\n- build and workspace lint passed with nine existing warnings\n- strict OpenSpec, spec coverage, conformance citations/docs\n- capability projection and pinned DPT ba9936af: 9 passing\n- block normative scenario pass; opaque block invariant-pass\n- emitted-schema MCE tests and self-test passed\n- fresh ILPA LibreOffice open-save and PDF conversion passed\n- XSD results contain only the existing pinned #226 bookmark-placement issue, with no SDT/relationship failure\n- cycle, target-normalization, relationship-retarget, changed-media, missing-target, and dependency-closure mutations passed\n\n## Residual scope\n\nThis does not cover row/cell/nested/editable controls, footer or ancillary reconstruction, fields, sectPr, rsids outside preserved subtrees, or arbitrary package-part preservation.\n\nRefs #582