### PR TITLE
fix(docx-core): preserve original-document bookmarks through default tracked save (closes #609)

### DIFF
--- a/packages/docx-core/src/primitives/bookmarks.ts
+++ b/packages/docx-core/src/primitives/bookmarks.ts
@@ -270,7 +270,18 @@ export function getParagraphBookmarkId(p: Element): string | null {
   return null;
 }
 
-export function cleanupInternalBookmarks(doc: Document): number {
+/**
+ * Remove Safe-DOCX paragraph anchors and edit-harness ranges, except for any
+ * bookmark ids the caller knows came from the source document.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.6.1
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.6.2
+ * @see #609
+ */
+export function cleanupInternalBookmarks(
+  doc: Document,
+  opts?: { preserveBookmarkIds?: ReadonlySet<string> },
+): number {
   // Remove paragraph bookmarks (_bk_*) and edit span bookmarks (edit-*).
   const starts = Array.from(doc.getElementsByTagNameNS(OOXML.W_NS, W.bookmarkStart));
   const ends = Array.from(doc.getElementsByTagNameNS(OOXML.W_NS, W.bookmarkEnd));
@@ -280,6 +291,7 @@ export function cleanupInternalBookmarks(doc: Document): number {
     const name = getAttr(s, 'name') ?? '';
     if (name.startsWith('_bk_') || name.startsWith('edit-')) {
       const id = getAttr(s, 'id') ?? '';
+      if (id && opts?.preserveBookmarkIds?.has(id)) continue;
       if (id) idsToRemove.add(id);
       s.parentNode?.removeChild(s);
     }

--- a/packages/docx-core/src/primitives/document.ts
+++ b/packages/docx-core/src/primitives/document.ts
@@ -220,6 +220,18 @@ function nextElementSibling(node: Node | null): Element | null {
   return null;
 }
 
+function collectNamedBookmarkIds(doc: Document): Set<string> {
+  const ids = new Set<string>();
+  const starts = doc.getElementsByTagNameNS(OOXML.W_NS, W.bookmarkStart);
+  for (let i = 0; i < starts.length; i++) {
+    const start = starts.item(i);
+    const name = start?.getAttributeNS(OOXML.W_NS, 'name') ?? start?.getAttribute('w:name');
+    const id = start?.getAttributeNS(OOXML.W_NS, 'id') ?? start?.getAttribute('w:id');
+    if (name && id) ids.add(id);
+  }
+  return ids;
+}
+
 export class DocxDocument {
   private zip: DocxZip;
   private documentXml: Document;
@@ -1173,7 +1185,11 @@ export class DocxDocument {
    *
    * @see https://github.com/UseJunior/safe-docx/issues/408
    */
-  async toBuffer(opts?: { cleanBookmarks?: boolean; minimalReserialization?: boolean }): Promise<{ buffer: Buffer; bookmarksRemoved: number; blocksRestored: number }> {
+  async toBuffer(opts?: {
+    cleanBookmarks?: boolean;
+    minimalReserialization?: boolean;
+    preserveOriginalBookmarks?: boolean;
+  }): Promise<{ buffer: Buffer; bookmarksRemoved: number; blocksRestored: number }> {
     // Always write the latest document.xml when saving.
     // Important: when cleanBookmarks=true (download), we must NOT mutate session state.
     const xmlWithBookmarks = serializeXml(this.documentXml);
@@ -1182,7 +1198,11 @@ export class DocxDocument {
 
     if (opts?.cleanBookmarks) {
       const cloned = parseXml(xmlWithBookmarks);
-      const bookmarksRemoved = cleanupInternalBookmarks(cloned);
+      const preserveBookmarkIds =
+        opts.preserveOriginalBookmarks && this.originalDocumentXmlText !== null
+          ? collectNamedBookmarkIds(parseXml(this.originalDocumentXmlText))
+          : undefined;
+      const bookmarksRemoved = cleanupInternalBookmarks(cloned, { preserveBookmarkIds });
       let blocksRestored = 0;
       if (opts.minimalReserialization && this.originalDocumentXmlText !== null) {
         try {

--- a/packages/docx-mcp/src/tool_catalog.ts
+++ b/packages/docx-mcp/src/tool_catalog.ts
@@ -215,7 +215,12 @@ export const SAFE_DOCX_TOOL_CATALOG = [
       ...FILE_FIELD_OPTIONAL,
       ...GOOGLE_DOC_ID_FIELD,
       save_to_local_path: z.string(),
-      clean_bookmarks: z.boolean().optional(),
+      clean_bookmarks: z
+        .boolean()
+        .optional()
+        .describe(
+          "Controls removal of internal bookmarks from DOCX output. Behavior is intentionally three-way: OMIT (recommended for tracked/persistence saves) preserves the document's own bookmarks — only safe-docx paragraph anchors (`_bk_*`) are removed. Explicit `true` ALSO strips harness edit-span bookmarks (`edit-*`) to produce a clean deliverable; do NOT pass it when the tracked output feeds a redline pipeline, because that reproduces the pre-#609 loss of `edit-*` anchors. `false` keeps all bookmarks. Omitting is NOT equivalent to passing `true` — they differ precisely in whether original `edit-*` bookmarks survive.",
+        ),
       save_format: z.enum(['clean', 'tracked', 'both']).optional(),
       allow_overwrite: z.boolean().optional(),
       tracked_save_to_local_path: z.string().optional(),

--- a/packages/docx-mcp/src/tools/open_document.ts
+++ b/packages/docx-mcp/src/tools/open_document.ts
@@ -18,7 +18,12 @@ function getAvailableToolsSchema(): Array<{
     grep: { dedupe_by_paragraph: true },
     save: {
       save_format: 'both',
-      clean_bookmarks: true,
+      // clean_bookmarks is intentionally NOT advertised with a default value:
+      // omitting it (the default) preserves the document's own bookmarks on the
+      // tracked save, whereas explicitly passing `true` also strips `edit-*`
+      // anchors (#609). Advertising `true` would nudge clients to send the value
+      // that reproduces the bug. See the param's schema description for the
+      // three-way semantics.
       returned_variants: ['clean', 'tracked'],
     },
   };

--- a/packages/docx-mcp/src/tools/save.test.ts
+++ b/packages/docx-mcp/src/tools/save.test.ts
@@ -14,9 +14,11 @@ import {
   createTrackedTempDir,
 } from '../testing/session-test-utils.js';
 import { makeDocxWithDocumentXml } from '../testing/docx_test_utils.js';
-import { DocxZip, parseXml } from '@usejunior/docx-core';
+import { buildDocxFromParts, DocxZip, parseXml } from '@usejunior/docx-core';
 import fs from 'node:fs/promises';
 import path from 'node:path';
+
+const WORDPROCESSING_ML_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 
 const CONTENT_TYPES_XML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
@@ -120,6 +122,87 @@ describe('save', () => {
     }
     assertSuccess(result, 'tracked save');
   });
+
+  /**
+   * @conformance ECMA-376 edition 5, Part 1 § 17.13.6.1
+   * @conformance ECMA-376 edition 5, Part 1 § 17.13.6.2
+   * @see #609
+   */
+  test
+    .openspec('namespaced XML preserved through round-trip')
+    .conformance(
+      { spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.6.1' },
+      { spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.6.2' },
+    )(
+      'tracked save preserves run-spanning and paragraph-anchor bookmark pairs by default',
+      async () => {
+        const mgr = createTestSessionManager();
+        const tmpDir = await createTrackedTempDir('save-bookmark-round-trip-');
+        const inputPath = path.join(tmpDir, 'bookmark-source.docx');
+        const outputPath = path.join(tmpDir, 'bookmark-output.docx');
+        const buf = await buildDocxFromParts({
+          bodyXml:
+            `<w:p w14:paraId="11111111">` +
+            `<w:bookmarkStart w:id="41" w:name="edit-contract-term"/>` +
+            `<w:r><w:t>Existing </w:t></w:r>` +
+            `<w:ins w:id="77" w:author="Reviewer" w:date="2026-07-23T12:00:00Z">` +
+            `<w:r><w:t>tracked </w:t></w:r>` +
+            `</w:ins>` +
+            `<w:r><w:t>text</w:t></w:r>` +
+            `<w:bookmarkEnd w:id="41"/>` +
+            `<w:bookmarkStart w:id="42" w:name="jr_para_11111111"/>` +
+            `<w:bookmarkEnd w:id="42"/>` +
+            `</w:p>`,
+        });
+        await fs.writeFile(inputPath, new Uint8Array(buf));
+
+        const opened = await openDocument(mgr, { file_path: inputPath });
+        assertSuccess(opened, 'open');
+        const saved = await save(mgr, {
+          file_path: inputPath,
+          save_to_local_path: outputPath,
+          save_format: 'tracked',
+        });
+        assertSuccess(saved, 'tracked save');
+
+        const output = parseXml(await documentXmlFromDocx(outputPath));
+        const starts = Array.from(
+          output.getElementsByTagNameNS(WORDPROCESSING_ML_NS, 'bookmarkStart'),
+        );
+        const ends = Array.from(
+          output.getElementsByTagNameNS(WORDPROCESSING_ML_NS, 'bookmarkEnd'),
+        );
+        const startNamesById = new Map(
+          starts.map((start) => [
+            start.getAttributeNS(WORDPROCESSING_ML_NS, 'id'),
+            start.getAttributeNS(WORDPROCESSING_ML_NS, 'name'),
+          ]),
+        );
+        const endIds = new Set(
+          ends.map((end) => end.getAttributeNS(WORDPROCESSING_ML_NS, 'id')),
+        );
+
+        expect(startNamesById.get('41')).toBe('edit-contract-term');
+        expect(endIds.has('41')).toBe(true);
+        expect(startNamesById.get('42')).toBe('jr_para_11111111');
+        expect(endIds.has('42')).toBe(true);
+        expect(starts).toHaveLength(2);
+        expect(ends).toHaveLength(2);
+        expect(output.getElementsByTagNameNS(WORDPROCESSING_ML_NS, 'ins')).toHaveLength(1);
+
+        const cleanedOutputPath = path.join(tmpDir, 'bookmark-cleaned-output.docx');
+        const cleaned = await save(mgr, {
+          file_path: inputPath,
+          save_to_local_path: cleanedOutputPath,
+          save_format: 'tracked',
+          clean_bookmarks: true,
+        });
+        assertSuccess(cleaned, 'explicit bookmark-cleaning tracked save');
+        const cleanedXml = await documentXmlFromDocx(cleanedOutputPath);
+        expect(cleanedXml).not.toContain('edit-contract-term');
+        expect(cleanedXml).toContain('jr_para_11111111');
+      },
+    );
 
   test('tracked save emits write-time markup and preserves untouched blocks + rels (#126)', async () => {
     const mgr = new SessionManager({ defaultAiAuthor: 'Test Author' });

--- a/packages/docx-mcp/src/tools/save.test.ts
+++ b/packages/docx-mcp/src/tools/save.test.ts
@@ -190,6 +190,28 @@ describe('save', () => {
         expect(ends).toHaveLength(2);
         expect(output.getElementsByTagNameNS(WORDPROCESSING_ML_NS, 'ins')).toHaveLength(1);
 
+        // Parse balanced start/end pairs by name — string absence alone would
+        // miss an orphaned bookmarkEnd left behind by a half-removed range.
+        const bookmarkNames = async (docxPath: string): Promise<string[]> => {
+          const doc = parseXml(await documentXmlFromDocx(docxPath));
+          const s = Array.from(doc.getElementsByTagNameNS(WORDPROCESSING_ML_NS, 'bookmarkStart'));
+          const e = Array.from(doc.getElementsByTagNameNS(WORDPROCESSING_ML_NS, 'bookmarkEnd'));
+          const namesById = new Map(
+            s.map((el) => [
+              el.getAttributeNS(WORDPROCESSING_ML_NS, 'id'),
+              el.getAttributeNS(WORDPROCESSING_ML_NS, 'name'),
+            ]),
+          );
+          for (const end of e) {
+            // no orphaned bookmarkEnd
+            expect(namesById.has(end.getAttributeNS(WORDPROCESSING_ML_NS, 'id'))).toBe(true);
+          }
+          expect(s).toHaveLength(e.length);
+          return [...namesById.values()].filter((n): n is string => n !== null);
+        };
+
+        // Explicit clean_bookmarks:true strips edit-* (and safe-docx _bk_*) while
+        // keeping jr_para_*, with no orphaned bookmarkEnd.
         const cleanedOutputPath = path.join(tmpDir, 'bookmark-cleaned-output.docx');
         const cleaned = await save(mgr, {
           file_path: inputPath,
@@ -198,9 +220,28 @@ describe('save', () => {
           clean_bookmarks: true,
         });
         assertSuccess(cleaned, 'explicit bookmark-cleaning tracked save');
-        const cleanedXml = await documentXmlFromDocx(cleanedOutputPath);
-        expect(cleanedXml).not.toContain('edit-contract-term');
-        expect(cleanedXml).toContain('jr_para_11111111');
+        const cleanedNames = await bookmarkNames(cleanedOutputPath);
+        expect(cleanedNames).not.toContain('edit-contract-term');
+        expect(cleanedNames).toContain('jr_para_11111111');
+
+        // save_format:'both' is the harness default: the tracked variant must
+        // still preserve edit-* (persistence), while the clean deliverable
+        // strips it (#609).
+        const bothCleanPath = path.join(tmpDir, 'both-clean.docx');
+        const bothTrackedPath = path.join(tmpDir, 'both-tracked.docx');
+        const both = await save(mgr, {
+          file_path: inputPath,
+          save_to_local_path: bothCleanPath,
+          tracked_save_to_local_path: bothTrackedPath,
+          save_format: 'both',
+        });
+        assertSuccess(both, 'both-mode save');
+        const bothTrackedNames = await bookmarkNames(bothTrackedPath);
+        expect(bothTrackedNames).toContain('edit-contract-term');
+        expect(bothTrackedNames).toContain('jr_para_11111111');
+        const bothCleanNames = await bookmarkNames(bothCleanPath);
+        expect(bothCleanNames).not.toContain('edit-contract-term');
+        expect(bothCleanNames).toContain('jr_para_11111111');
       },
     );
 

--- a/packages/docx-mcp/src/tools/save.ts
+++ b/packages/docx-mcp/src/tools/save.ts
@@ -175,6 +175,7 @@ export async function save(
     const format: SaveFormat = formatRaw;
 
     const clean = params.clean_bookmarks ?? true;
+    const preserveOriginalBookmarksInTracked = params.clean_bookmarks === undefined;
     // Display author for the tracked-changes report. The actual markup author is
     // whatever the write-time emitter recorded on session.doc (#120/#126); no
     // comparison re-authoring happens here.
@@ -184,6 +185,7 @@ export async function save(
       revision: session.editRevision,
       format,
       clean_bookmarks: clean,
+      preserve_original_bookmarks_in_tracked: preserveOriginalBookmarksInTracked,
       tracked_author: author,
     });
 
@@ -280,9 +282,15 @@ export async function save(
       // pre-existing reviewer revisions preserved). Comparison-based redlining is
       // available only via the compare_documents tool.
       if (format === 'tracked' || format === 'both') {
-        const tracked = await session.doc.toBuffer({ cleanBookmarks: clean });
+        const tracked = await session.doc.toBuffer({
+          cleanBookmarks: clean,
+          preserveOriginalBookmarks: preserveOriginalBookmarksInTracked,
+        });
         trackedBuffer = tracked.buffer;
         trackedStats = await collectTrackedStats(trackedBuffer, session.aiAuthor);
+        if (format === 'tracked') {
+          bookmarksRemoved = tracked.bookmarksRemoved;
+        }
       }
 
       manager.setSaveCache(session, {


### PR DESCRIPTION
## Summary
`save` with `save_format="tracked"` was dropping original `edit-*` **range** bookmarks on a plain open→save round-trip (measured `bookmarkStart` 126→120, `edit` 6→0), while `jr_para_*` and `w14:paraId` survived. That silently regressed the redline pipeline, which copies `edit-*` (edit-span / navigation anchors) forward through persistence.

## Root cause
The default tracked save resolved `clean_bookmarks` to `true`, and `cleanupInternalBookmarks` strips every bookmark whose name begins `_bk_` or `edit-`. So original-document `edit-*` bookmarks were being cleaned alongside the session-generated `_bk_*` anchors the cleanup targets. `jr_para_*` was outside that filter, which is why the loss was selective.

## Fix
- On the **default** tracked save (`clean_bookmarks` omitted), preserve bookmark ids that were present in the **original** document (`toBuffer({ preserveOriginalBookmarks: true })` → `cleanupInternalBookmarks(doc, { preserveBookmarkIds })`), while still cleaning session-generated `_bk_*` anchors.
- Explicit `clean_bookmarks: true` is unchanged — still strips harness bookmarks.
- Provenance-based (original vs session-generated), **not** a `edit-` name special-case, so it preserves run-spanning range bookmarks generally.

## Verification
- [x] Build clean (`npm run build`)
- [x] Lint (`lint:workspaces`): 0 errors, 9 pre-existing warnings
- [x] `check:spec-coverage`, `check:conformance-citations`, `check:conformance-doc`: OK
- [x] New real open→save round-trip test (`docx-mcp/src/tools/save.test.ts`): range `edit-*` + `jr_para_*` both survive default tracked save; explicit `clean_bookmarks: true` still strips `edit-*`, keeps `jr_para_*`
- [x] Targeted suites: `save.test.ts` 13/13, `docx-core` round-trip + inplace-bookmark-regression 13/13
- [ ] Peer review (agy + Codex) — pending; appended below

## Closes
- #609