### PR TITLE
fix(docx-mcp): guard selective revisions on clean save

### DIFF
--- a/packages/docx-mcp/docs/tool-reference.generated.md
+++ b/packages/docx-mcp/docs/tool-reference.generated.md
@@ -110,7 +110,7 @@ Insert a paragraph before/after an anchor paragraph by paragraph id. Supports DO
 
 ## `save`
 
-Save document. For DOCX: saves clean and/or tracked changes output. For ODT: saves an .odt package. For Google Docs: checkpoint (default) returns revisionId, or snapshot exports as DOCX. Surface: revisionable — the save report lists both the AI revisions applied and a non-revision change manifest of any package-level mutations (comment/footnote side parts, relationships) that have no tracked-change wrapper.
+Persist the current in-memory document session. For DOCX: saves clean and/or tracked changes output. For ODT: saves an .odt package. For Google Docs: checkpoint (default) returns revisionId, or snapshot exports as DOCX. Surface: revisionable — the save report lists both the AI revisions applied and a non-revision change manifest of any package-level mutations (comment/footnote side parts, relationships) that have no tracked-change wrapper.
 
 - readOnly: `false`
 - destructive: `true`
@@ -123,6 +123,7 @@ Save document. For DOCX: saves clean and/or tracked changes output. For ODT: sav
 | `clean_bookmarks` | `boolean` | no |  |
 | `save_format` | `enum("clean", "tracked", "both")` | no |  |
 | `allow_overwrite` | `boolean` | no |  |
+| `allow_discard_preserved_revisions` | `boolean` | no | Explicitly allow a clean artifact to auto-accept remaining revisions by the session AI author after accept_ai_edits/reject_ai_edits selectively left revisions unresolved. Default: false. |
 | `tracked_save_to_local_path` | `string` | no |  |
 | `tracked_changes_author` | `string` | no |  |
 | `tracked_changes_engine` | `enum("auto", "atomizer")` | no | Deprecated and ignored (#126). The redline is now the session's write-time tracked markup, serialized directly — there is no comparison engine to select. Use the compare_documents tool for comparison-based redlines. |
@@ -185,7 +186,7 @@ Accept all tracked changes in the document body, producing a clean document with
 
 ## `accept_ai_edits`
 
-Selectively accept tracked changes by revision id or author, leaving all other (e.g. third-party reviewer) revisions byte-untouched. Provide revision_ids (array of w:id values) to target specific revisions, or author to accept every revision by one actor. Sweeps document.xml and supported side-story parts (footnotes, endnotes, comments). An ambiguous overlap — a targeted revision structurally containing, or contained by, a non-targeted revision (nested ins/del/move) — hard-errors with code AMBIGUOUS_REVISION_OVERLAP and a structured `overlaps` list unless normalize_first is set (best-effort, no byte-identical promise).
+Selectively accept tracked changes by revision id or author in the in-memory session, leaving all other (e.g. third-party reviewer) revisions byte-untouched. This does not write file_path; call save to persist the mutation. Provide revision_ids (array of w:id values) to target specific revisions, or author to accept every revision by one actor. Sweeps document.xml and supported side-story parts (footnotes, endnotes, comments). An ambiguous overlap — a targeted revision structurally containing, or contained by, a non-targeted revision (nested ins/del/move) — hard-errors with code AMBIGUOUS_REVISION_OVERLAP and a structured `overlaps` list unless normalize_first is set (best-effort, no byte-identical promise).
 
 - readOnly: `false`
 - destructive: `true`
@@ -199,7 +200,7 @@ Selectively accept tracked changes by revision id or author, leaving all other (
 
 ## `reject_ai_edits`
 
-Selectively reject tracked changes by revision id or author (restoring their pre-edit state), leaving all other revisions byte-untouched. Symmetric to accept_ai_edits: provide revision_ids or author, sweeps document.xml and supported side-story parts, and hard-errors on an ambiguous overlap (code AMBIGUOUS_REVISION_OVERLAP with a structured `overlaps` list) unless normalize_first is set.
+Selectively reject tracked changes by revision id or author in the in-memory session (restoring their pre-edit state), leaving all other revisions byte-untouched. This does not write file_path; call save to persist the mutation. Symmetric to accept_ai_edits: provide revision_ids or author, sweeps document.xml and supported side-story parts, and hard-errors on an ambiguous overlap (code AMBIGUOUS_REVISION_OVERLAP with a structured `overlaps` list) unless normalize_first is set.
 
 - readOnly: `false`
 - destructive: `true`

--- a/packages/docx-mcp/src/session/manager.ts
+++ b/packages/docx-mcp/src/session/manager.ts
@@ -56,6 +56,13 @@ export type ExtractionCacheEntry = {
   changes: ParagraphRevision[];
 };
 
+export type SelectiveRevisionAction = {
+  tool: 'accept_ai_edits' | 'reject_ai_edits';
+  selector: 'revision_ids' | 'author';
+  selectedRevisionIds: string[];
+  editRevision: number;
+};
+
 /**
  * A package-level (non-revision) mutation recorded during a session.
  *
@@ -112,6 +119,12 @@ export type DocxSession = {
    * OOXML revision wrapper are still accounted for (#122).
    */
   nonRevisionManifest: NonRevisionChange[];
+  /**
+   * Most recent selective revision disposition in this in-memory session.
+   * A later clean save uses this marker to prevent automatically accepting
+   * remaining revisions that the caller deliberately left unresolved.
+   */
+  selectiveRevisionAction: SelectiveRevisionAction | null;
   createdAt: Date;
   lastAccessedAt: Date;
   expiresAt: Date;
@@ -362,6 +375,7 @@ export class SessionManager {
       saveCache: new Map<string, SaveCacheEntry>(),
       extractionCache: null,
       nonRevisionManifest: [],
+      selectiveRevisionAction: null,
       createdAt: now,
       lastAccessedAt: now,
       expiresAt,
@@ -563,6 +577,16 @@ export class SessionManager {
     change: Omit<NonRevisionChange, 'editRevision'>,
   ): void {
     session.nonRevisionManifest.push({ ...change, editRevision: session.editRevision });
+  }
+
+  recordSelectiveRevisionAction(
+    session: DocxSession,
+    action: Omit<SelectiveRevisionAction, 'editRevision'>,
+  ): void {
+    session.selectiveRevisionAction = {
+      ...action,
+      editRevision: session.editRevision,
+    };
   }
 
   getSaveCache(session: DocxSession, cacheKey: string): SaveCacheEntry | null {

--- a/packages/docx-mcp/src/tool_catalog.ts
+++ b/packages/docx-mcp/src/tool_catalog.ts
@@ -210,7 +210,7 @@ export const SAFE_DOCX_TOOL_CATALOG = [
     name: 'save',
     surface: 'revisionable',
     description:
-      'Save document. For DOCX: saves clean and/or tracked changes output. For ODT: saves an .odt package. For Google Docs: checkpoint (default) returns revisionId, or snapshot exports as DOCX. Surface: revisionable — the save report lists both the AI revisions applied and a non-revision change manifest of any package-level mutations (comment/footnote side parts, relationships) that have no tracked-change wrapper.',
+      'Persist the current in-memory document session. For DOCX: saves clean and/or tracked changes output. For ODT: saves an .odt package. For Google Docs: checkpoint (default) returns revisionId, or snapshot exports as DOCX. Surface: revisionable — the save report lists both the AI revisions applied and a non-revision change manifest of any package-level mutations (comment/footnote side parts, relationships) that have no tracked-change wrapper.',
     input: z.object({
       ...FILE_FIELD_OPTIONAL,
       ...GOOGLE_DOC_ID_FIELD,
@@ -218,6 +218,12 @@ export const SAFE_DOCX_TOOL_CATALOG = [
       clean_bookmarks: z.boolean().optional(),
       save_format: z.enum(['clean', 'tracked', 'both']).optional(),
       allow_overwrite: z.boolean().optional(),
+      allow_discard_preserved_revisions: z
+        .boolean()
+        .optional()
+        .describe(
+          'Explicitly allow a clean artifact to auto-accept remaining revisions by the session AI author after accept_ai_edits/reject_ai_edits selectively left revisions unresolved. Default: false.',
+        ),
       tracked_save_to_local_path: z.string().optional(),
       tracked_changes_author: z.string().optional(),
       tracked_changes_engine: z
@@ -331,7 +337,7 @@ export const SAFE_DOCX_TOOL_CATALOG = [
     name: 'accept_ai_edits',
     surface: 'internal',
     description:
-      'Selectively accept tracked changes by revision id or author, leaving all other (e.g. third-party reviewer) revisions byte-untouched. Provide revision_ids (array of w:id values) to target specific revisions, or author to accept every revision by one actor. Sweeps document.xml and supported side-story parts (footnotes, endnotes, comments). An ambiguous overlap — a targeted revision structurally containing, or contained by, a non-targeted revision (nested ins/del/move) — hard-errors with code AMBIGUOUS_REVISION_OVERLAP and a structured `overlaps` list unless normalize_first is set (best-effort, no byte-identical promise).',
+      'Selectively accept tracked changes by revision id or author in the in-memory session, leaving all other (e.g. third-party reviewer) revisions byte-untouched. This does not write file_path; call save to persist the mutation. Provide revision_ids (array of w:id values) to target specific revisions, or author to accept every revision by one actor. Sweeps document.xml and supported side-story parts (footnotes, endnotes, comments). An ambiguous overlap — a targeted revision structurally containing, or contained by, a non-targeted revision (nested ins/del/move) — hard-errors with code AMBIGUOUS_REVISION_OVERLAP and a structured `overlaps` list unless normalize_first is set (best-effort, no byte-identical promise).',
     input: z.object({
       ...FILE_FIELD,
       revision_ids: z
@@ -353,7 +359,7 @@ export const SAFE_DOCX_TOOL_CATALOG = [
     name: 'reject_ai_edits',
     surface: 'internal',
     description:
-      'Selectively reject tracked changes by revision id or author (restoring their pre-edit state), leaving all other revisions byte-untouched. Symmetric to accept_ai_edits: provide revision_ids or author, sweeps document.xml and supported side-story parts, and hard-errors on an ambiguous overlap (code AMBIGUOUS_REVISION_OVERLAP with a structured `overlaps` list) unless normalize_first is set.',
+      'Selectively reject tracked changes by revision id or author in the in-memory session (restoring their pre-edit state), leaving all other revisions byte-untouched. This does not write file_path; call save to persist the mutation. Symmetric to accept_ai_edits: provide revision_ids or author, sweeps document.xml and supported side-story parts, and hard-errors on an ambiguous overlap (code AMBIGUOUS_REVISION_OVERLAP with a structured `overlaps` list) unless normalize_first is set.',
     input: z.object({
       ...FILE_FIELD,
       revision_ids: z

--- a/packages/docx-mcp/src/tools/accept_ai_edits.ts
+++ b/packages/docx-mcp/src/tools/accept_ai_edits.ts
@@ -37,10 +37,21 @@ export async function acceptAiEdits(
       normalizeFirst: params.normalize_first,
     });
     manager.markEdited(session);
+    if (selectedIds.length > 0) {
+      manager.recordSelectiveRevisionAction(session, {
+        tool: 'accept_ai_edits',
+        selector: hasIds ? 'revision_ids' : 'author',
+        selectedRevisionIds: selectedIds,
+      });
+    }
     return ok(mergeSessionResolutionMetadata({
       ...result,
       selected_revision_ids: selectedIds,
       file_path: manager.normalizePath(session.originalPath),
+      persistence_required: selectedIds.length > 0,
+      ...(selectedIds.length > 0
+        ? { next_step: "Call save with save_format='tracked' or 'both' to persist this session-scoped mutation." }
+        : {}),
     }, metadata));
   } catch (e: unknown) {
     if (e instanceof AmbiguousRevisionOverlapError) {

--- a/packages/docx-mcp/src/tools/add_selective_ai_accept_reject.test.ts
+++ b/packages/docx-mcp/src/tools/add_selective_ai_accept_reject.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
 import { DocxZip } from '@usejunior/docx-core';
 import { SessionManager, type DocxSession } from '../session/manager.js';
 import { acceptAiEdits } from './accept_ai_edits.js';
 import { rejectAiEdits } from './reject_ai_edits.js';
+import { save } from './save.js';
 import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
 import { assertFailure, assertSuccess, openSession, registerCleanup } from '../testing/session-test-utils.js';
 
@@ -10,6 +13,7 @@ const TEST_FEATURE = 'add-selective-ai-accept-reject';
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const AI = 'SafeDocX AI';
 const HUMAN = 'Reviewer';
+const DATE = '2026-07-23T12:00:00Z';
 
 const test = testAllure.epic('Document Editing').withLabels({ feature: TEST_FEATURE });
 
@@ -28,17 +32,17 @@ function documentXml(bodyInner: string): string {
 // (w:id="1"...) that normalization backfills on open.
 const MIXED_AUTHOR_BODY =
   `<w:p><w:r><w:t xml:space="preserve">base </w:t></w:r>` +
-  `<w:ins w:id="101" w:author="${AI}"><w:r><w:t xml:space="preserve">ai-add </w:t></w:r></w:ins>` +
-  `<w:ins w:id="102" w:author="${HUMAN}"><w:r><w:t xml:space="preserve">human-add </w:t></w:r></w:ins>` +
-  `<w:del w:id="103" w:author="${AI}"><w:r><w:delText xml:space="preserve">ai-del </w:delText></w:r></w:del>` +
-  `<w:del w:id="104" w:author="${HUMAN}"><w:r><w:delText xml:space="preserve">human-del</w:delText></w:r></w:del></w:p>`;
+  `<w:ins w:id="101" w:author="${AI}" w:date="${DATE}"><w:r><w:t xml:space="preserve">ai-add </w:t></w:r></w:ins>` +
+  `<w:ins w:id="102" w:author="${HUMAN}" w:date="${DATE}"><w:r><w:t xml:space="preserve">human-add </w:t></w:r></w:ins>` +
+  `<w:del w:id="103" w:author="${AI}" w:date="${DATE}"><w:r><w:delText xml:space="preserve">ai-del </w:delText></w:r></w:del>` +
+  `<w:del w:id="104" w:author="${HUMAN}" w:date="${DATE}"><w:r><w:delText xml:space="preserve">human-del</w:delText></w:r></w:del></w:p>`;
 
 // A visible anchor paragraph so the session read finds a paragraph id, followed
 // by the overlap paragraph (AI ins structurally containing a reviewer del).
 const OVERLAP_BODY =
   `<w:p><w:r><w:t xml:space="preserve">anchor</w:t></w:r></w:p>` +
-  `<w:p><w:ins w:id="107" w:author="${AI}">` +
-  `<w:del w:id="108" w:author="${HUMAN}"><w:r><w:delText>x</w:delText></w:r></w:del></w:ins></w:p>`;
+  `<w:p><w:ins w:id="107" w:author="${AI}" w:date="${DATE}">` +
+  `<w:del w:id="108" w:author="${HUMAN}" w:date="${DATE}"><w:r><w:delText>x</w:delText></w:r></w:del></w:ins></w:p>`;
 
 async function docxSession(mgr: SessionManager, filePath: string): Promise<DocxSession> {
   const session = await mgr.getSessionByFilePath(filePath);
@@ -125,6 +129,92 @@ describe('Selective accept/reject AI edits (#123)', () => {
       });
     },
   );
+
+  test('requires explicit acknowledgement before a clean save discards selectively preserved AI revisions', async () => {
+    const opened = await openSession([], { mgr: manager(), xml: documentXml(MIXED_AUTHOR_BODY) });
+    const cleanPath = path.join(opened.tmpDir, 'selective-clean.docx');
+
+    const accepted = await acceptAiEdits(opened.mgr, {
+      file_path: opened.filePath,
+      revision_ids: [101],
+    });
+    assertSuccess(accepted, 'accept_ai_edits');
+    expect(accepted.persistence_required).toBe(true);
+
+    const blocked = await save(opened.mgr, {
+      file_path: opened.filePath,
+      save_to_local_path: cleanPath,
+      save_format: 'clean',
+    });
+    assertFailure(blocked, 'SELECTIVE_REVISIONS_WOULD_BE_DISCARDED');
+    expect(blocked.preserved_revisions).toMatchObject({
+      count: 1,
+      author: AI,
+      ids: [103],
+    });
+    await expect(fs.access(cleanPath)).rejects.toThrow();
+
+    const acknowledged = await save(opened.mgr, {
+      file_path: opened.filePath,
+      save_to_local_path: cleanPath,
+      save_format: 'clean',
+      allow_discard_preserved_revisions: true,
+    });
+    assertSuccess(acknowledged, 'acknowledged clean save');
+    expect(acknowledged.selective_revision_disposition).toMatchObject({
+      acknowledged: true,
+      clean_artifact_accepted_remaining_author_revisions: {
+        count: 1,
+        author: AI,
+        ids: [103],
+      },
+    });
+  });
+
+  test('tracked save persists a selective revision operation without an acknowledgement', async () => {
+    const opened = await openSession([], { mgr: manager(), xml: documentXml(MIXED_AUTHOR_BODY) });
+    const trackedPath = path.join(opened.tmpDir, 'selective-tracked.docx');
+
+    const accepted = await acceptAiEdits(opened.mgr, {
+      file_path: opened.filePath,
+      revision_ids: [101],
+    });
+    assertSuccess(accepted, 'accept_ai_edits');
+
+    const saved = await save(opened.mgr, {
+      file_path: opened.filePath,
+      save_to_local_path: trackedPath,
+      save_format: 'tracked',
+    });
+    assertSuccess(saved, 'tracked save');
+    const zip = await DocxZip.load(await fs.readFile(trackedPath));
+    const xml = await zip.readText('word/document.xml');
+    expect(xml).not.toContain('w:id="101"');
+    expect(xml).toContain('w:id="103"');
+    expect(xml).toContain('w:id="102"');
+    expect(xml).toContain('w:id="104"');
+  });
+
+  test('a selector with no matches does not arm the clean-save safeguard', async () => {
+    const opened = await openSession([], { mgr: manager(), xml: documentXml(MIXED_AUTHOR_BODY) });
+    const cleanPath = path.join(opened.tmpDir, 'no-op-selective-clean.docx');
+
+    const accepted = await acceptAiEdits(opened.mgr, {
+      file_path: opened.filePath,
+      author: 'Unknown reviewer',
+    });
+    assertSuccess(accepted, 'accept_ai_edits');
+    expect(accepted.selected_revision_ids).toEqual([]);
+    expect(accepted.persistence_required).toBe(false);
+
+    const saved = await save(opened.mgr, {
+      file_path: opened.filePath,
+      save_to_local_path: cleanPath,
+      save_format: 'clean',
+    });
+    assertSuccess(saved, 'clean save after no-op selection');
+    await expect(fs.access(cleanPath)).resolves.toBeUndefined();
+  });
 
   test.openspec('missing selector is rejected')(
     'Scenario: missing selector is rejected',

--- a/packages/docx-mcp/src/tools/reject_ai_edits.ts
+++ b/packages/docx-mcp/src/tools/reject_ai_edits.ts
@@ -38,10 +38,21 @@ export async function rejectAiEdits(
       normalizeFirst: params.normalize_first,
     });
     manager.markEdited(session);
+    if (selectedIds.length > 0) {
+      manager.recordSelectiveRevisionAction(session, {
+        tool: 'reject_ai_edits',
+        selector: hasIds ? 'revision_ids' : 'author',
+        selectedRevisionIds: selectedIds,
+      });
+    }
     return ok(mergeSessionResolutionMetadata({
       ...result,
       selected_revision_ids: selectedIds,
       file_path: manager.normalizePath(session.originalPath),
+      persistence_required: selectedIds.length > 0,
+      ...(selectedIds.length > 0
+        ? { next_step: "Call save with save_format='tracked' or 'both' to persist this session-scoped mutation." }
+        : {}),
     }, metadata));
   } catch (e: unknown) {
     if (e instanceof AmbiguousRevisionOverlapError) {

--- a/packages/docx-mcp/src/tools/save.ts
+++ b/packages/docx-mcp/src/tools/save.ts
@@ -129,6 +129,7 @@ export async function save(
     track_changes?: boolean;
     author?: string;
     allow_overwrite?: boolean;
+    allow_discard_preserved_revisions?: boolean;
     tracked_save_to_local_path?: string;
     tracked_changes_author?: string;
     // Deprecated (#126): comparison-based redlines moved to the compare_documents
@@ -180,6 +181,29 @@ export async function save(
     // comparison re-authoring happens here.
     const author = params.tracked_changes_author ?? params.author ?? session.aiAuthor ?? 'SafeDocX';
     const allowOverwrite = params.allow_overwrite ?? false;
+
+    let cleanArtifactDiscardedRevisions: SaveRevisionSummary | undefined;
+    if (
+      (format === 'clean' || format === 'both')
+      && session.selectiveRevisionAction
+      && session.aiAuthor
+    ) {
+      const current = await session.doc.toBuffer({ cleanBookmarks: false });
+      const remaining = await collectAiRevisionSummary(current.buffer, session.aiAuthor);
+      if (remaining && !params.allow_discard_preserved_revisions) {
+        return {
+          ...err(
+            'SELECTIVE_REVISIONS_WOULD_BE_DISCARDED',
+            `Clean output would auto-accept ${remaining.count} remaining revision(s) by ${session.aiAuthor} after a selective revision operation.`,
+            "Use save_format='tracked', finish accepting/rejecting the remaining revisions, or explicitly set allow_discard_preserved_revisions=true.",
+          ),
+          selective_revision_action: session.selectiveRevisionAction,
+          preserved_revisions: remaining,
+        };
+      }
+      cleanArtifactDiscardedRevisions = remaining;
+    }
+
     const cacheKey = JSON.stringify({
       revision: session.editRevision,
       format,
@@ -388,6 +412,12 @@ export async function save(
       cache_hit: cacheHit,
       format_source: formatSource,
       parameter_warning: parameterWarning,
+      selective_revision_disposition: cleanArtifactDiscardedRevisions
+        ? {
+            acknowledged: true,
+            clean_artifact_accepted_remaining_author_revisions: cleanArtifactDiscardedRevisions,
+          }
+        : undefined,
       validation: validation.warnings.length > 0 || (aiRevisionValidation?.warnings.length ?? 0) > 0
         ? {
             warnings: [


### PR DESCRIPTION
## Summary

- make `accept_ai_edits` / `reject_ai_edits` explicitly report that successful mutations are session-scoped and require `save`
- record successful selective revision dispositions in the DOCX session
- fail closed when a later `clean`/`both` save would auto-accept remaining revisions by the session AI author
- add an explicit `allow_discard_preserved_revisions` acknowledgement for callers that intentionally want that clean-output behavior
- preserve tracked-save behavior and document the contract in the generated tool reference

## Why

Selective revision tools can intentionally leave some AI-authored revisions unresolved. A later clean save previously auto-accepted all remaining revisions by that author, silently defeating the caller's selective intent. This makes that irreversible disposition explicit and agent-readable.

## Validation

- `npm run test:run -w @usejunior/docx-mcp -- src/tools/add_selective_ai_accept_reject.test.ts` (9/9)
- `npm run build -w @usejunior/docx-mcp`
- `npm run lint -w @usejunior/docx-mcp`
- `npm run check:tool-docs`
- `npm run check:spec-coverage`
- `npm run check:conformance-citations`
- `npm run check:conformance-doc`
- repository test run: all workspaces passed except five environment-blocked docx-core probes; those five passed when rerun outside the sandbox (14 passed, 1 expected skip)

Fixes #586