### PR TITLE
fix(docx-compare): resolve insertion provenance collisions

### DIFF
--- a/packages/docx-compare/src/baselines/atomizer/inPlaceModifier.ts
+++ b/packages/docx-compare/src/baselines/atomizer/inPlaceModifier.ts
@@ -327,7 +327,7 @@ function removeParagraphInsertionMarker(paragraph: Element | undefined): void {
  * @conformance ECMA-376 edition 5, Part 1 § 17.13.5.20
  * @see https://github.com/UseJunior/safe-docx/issues/359
  */
-function resolveRevisedInsCollisionOnRun(
+export function resolveRevisedInsCollisionOnRun(
   atom: ComparisonUnitAtom,
   run: Element
 ): void {

--- a/packages/docx-compare/src/baselines/atomizer/inPlaceModifier.ts
+++ b/packages/docx-compare/src/baselines/atomizer/inPlaceModifier.ts
@@ -13,7 +13,12 @@
 
 import type { ComparisonUnitAtom } from '@usejunior/docx-core';
 import { CorrelationStatus } from '@usejunior/docx-core';
-import { childElements, findChildByTagName, insertAfterElement } from '@usejunior/docx-core';
+import {
+  childElements,
+  findChildByTagName,
+  insertAfterElement,
+  unwrapElement,
+} from '@usejunior/docx-core';
 import { enforceConsumerCompatibility } from './consumerCompatibility.js';
 import { XMLSerializer } from '@xmldom/xmldom';
 import { findChild } from '@usejunior/docx-core';
@@ -278,6 +283,75 @@ function restoreOriginalInsProvenanceOnRun(
     dateStr: prov.date || ctx.dateStr,
     state: ctx.state,
   });
+}
+
+function paragraphHasRevisionMarker(paragraph: Element | undefined): boolean {
+  if (!paragraph) return false;
+  const pPr = findChildByTagName(paragraph, 'w:pPr');
+  const rPr = pPr ? findChildByTagName(pPr, 'w:rPr') : null;
+  return !!rPr && childElements(rPr).some((child) =>
+    child.tagName === 'w:ins'
+    || child.tagName === 'w:del'
+    || child.tagName === 'w:moveFrom'
+    || child.tagName === 'w:moveTo'
+  );
+}
+
+function removeParagraphInsertionMarker(paragraph: Element | undefined): void {
+  if (!paragraph) return;
+  const pPr = findChildByTagName(paragraph, 'w:pPr');
+  const rPr = pPr ? findChildByTagName(pPr, 'w:rPr') : null;
+  if (!pPr || !rPr) return;
+
+  for (const child of childElements(rPr)) {
+    if (child.tagName === 'w:ins') rPr.removeChild(child);
+  }
+  if (childElements(rPr).length === 0) pPr.removeChild(rPr);
+  if (childElements(pPr).length === 0) paragraph.removeChild(pPr);
+}
+
+/**
+ * Resolve a revised-side insertion claim to settled content when its matched
+ * original lineage is plain.
+ *
+ * The two inputs then agree that the text exists after accepting revisions,
+ * while only the revised input calls it inserted. Keeping that physical
+ * `w:ins` in the combined output makes reject-all drop text that
+ * reject(original) keeps. Promoting the one-run collision out of `w:ins`
+ * represents the shared settled lineage and preserves both projections.
+ *
+ * Paragraph-mark insertion metadata is removed at the same time: the matched
+ * original paragraph proves that the paragraph itself is settled, while any
+ * unmatched revised runs remain independently tracked as insertions.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.5.20
+ * @see https://github.com/UseJunior/safe-docx/issues/359
+ */
+function resolveRevisedInsCollisionOnRun(
+  atom: ComparisonUnitAtom,
+  run: Element
+): void {
+  const before = atom.comparisonUnitAtomBefore;
+  if (
+    atom.sourceDocument !== 'revised'
+    || atom.revTrackElement?.tagName !== 'w:ins'
+    || !before
+    || before.revTrackElement
+    || paragraphHasRevisionMarker(before.sourceParagraphElement)
+  ) {
+    return;
+  }
+
+  const insertion = getRunInsertionAnchor(run);
+  if (insertion.tagName !== 'w:ins') return;
+
+  const insertionChildren = childElements(insertion);
+  if (insertionChildren.length !== 1 || insertionChildren[0] !== run) {
+    return;
+  }
+
+  unwrapElement(insertion);
+  removeParagraphInsertionMarker(atom.sourceParagraphElement);
 }
 
 function isParagraphRemovedOnRejectInContext(paragraph: Element, ctx: ProcessingContext): boolean {
@@ -684,6 +758,7 @@ function handleFormatChanged(atom: ComparisonUnitAtom, ctx: ProcessingContext): 
   const run = getAtomRunAtBoundary(atom, 'start');
   if (run && atom.formatChange?.oldRunProperties) {
     addFormatChange(run, atom.formatChange.oldRunProperties, ctx.author, ctx.dateStr, ctx.state);
+    resolveRevisedInsCollisionOnRun(atom, run);
     // Equal-text/changed-format content keeps its original-side w:ins lineage
     // too (issue #358); the w:rPrChange then lives inside the wrapper.
     restoreOriginalInsProvenanceOnRun(atom, run, ctx);
@@ -725,6 +800,7 @@ function handleEqual(atom: ComparisonUnitAtom, ctx: ProcessingContext): HandlerR
   // For non-empty atoms, sourceRunElement points to revised tree - safe to use directly
   const run = getAtomRunAtBoundary(atom, 'end');
   if (run) {
+    resolveRevisedInsCollisionOnRun(atom, run);
     // Matched content whose original lineage was inside a pre-tracked w:ins
     // must keep that wrapper in the combined output (issue #358).
     restoreOriginalInsProvenanceOnRun(atom, run, ctx);

--- a/packages/docx-compare/src/baselines/atomizer/inplace-insertion-provenance-collision.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/inplace-insertion-provenance-collision.test.ts
@@ -1,0 +1,107 @@
+/**
+ * End-to-end coverage for revised insertion claims that collide with settled
+ * original content.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.5.20
+ * @see https://github.com/UseJunior/safe-docx/issues/359
+ */
+
+import JSZip from 'jszip';
+import { describe, expect } from 'vitest';
+import {
+  acceptAllChanges,
+  compareDocuments,
+  extractTextWithParagraphs,
+  normalizeText,
+  rejectAllChanges,
+} from '../../index.js';
+import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
+import {
+  buildDocxFromBodyXml,
+  paragraphWithText,
+} from '../../testing/ooxml-fixtures.js';
+
+const TEST_FEATURE = 'Inplace Insertion Provenance';
+const TRACKED_AUTHOR = 'Revised Author';
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({ feature: TEST_FEATURE })
+  .conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.5.20' });
+
+async function documentXml(docx: Buffer): Promise<string> {
+  const part = (await JSZip.loadAsync(docx)).file('word/document.xml');
+  if (!part) throw new Error('comparison result omitted word/document.xml');
+  return part.async('string');
+}
+
+function projectionText(xml: string, projection: 'accept' | 'reject'): string {
+  const projected = projection === 'accept' ? acceptAllChanges(xml) : rejectAllChanges(xml);
+  return normalizeText(extractTextWithParagraphs(projected));
+}
+
+describe('Inplace revised insertion provenance collisions', () => {
+  test(
+    'promotes a colliding inline insertion to settled content',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      const original = await buildDocxFromBodyXml(
+        paragraphWithText('!') + paragraphWithText('!') + paragraphWithText('I'),
+      );
+      const revised = await buildDocxFromBodyXml(
+        `<w:p><w:r><w:t>6.</w:t></w:r>` +
+          `<w:ins w:id="7" w:author="${TRACKED_AUTHOR}" w:date="2026-07-23T12:00:00Z">` +
+          `<w:r><w:t>I</w:t></w:r></w:ins></w:p>`,
+      );
+
+      await given('settled original text matched by a revised-side inline insertion', () => {});
+      const result = await compareDocuments(original, revised, {
+        engine: 'atomizer',
+        reconstructionMode: 'inplace',
+      });
+      const combined = await documentXml(result.document);
+      await when('the documents are compared in inplace mode', () => {});
+
+      await then('the comparison remains inplace and removes the stale insertion claim', () => {
+        expect(result.reconstructionModeUsed).toBe('inplace');
+        expect(combined).not.toContain(`w:author="${TRACKED_AUTHOR}"`);
+      });
+      await and('accept and reject preserve the revised and original projections', () => {
+        expect(projectionText(combined, 'accept')).toBe('6.I');
+        expect(projectionText(combined, 'reject')).toBe('!\n!\nI');
+      });
+    },
+  );
+
+  test(
+    'promotes a colliding inserted paragraph to settled content',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      const original = await buildDocxFromBodyXml(
+        paragraphWithText('Alpha text.') + paragraphWithText('Added para.'),
+      );
+      const revised = await buildDocxFromBodyXml(
+        paragraphWithText('Alpha text.') +
+          `<w:p><w:pPr><w:rPr>` +
+          `<w:ins w:id="8" w:author="${TRACKED_AUTHOR}" w:date="2026-07-23T12:00:00Z"/>` +
+          `</w:rPr></w:pPr>` +
+          `<w:ins w:id="9" w:author="${TRACKED_AUTHOR}" w:date="2026-07-23T12:00:00Z">` +
+          `<w:r><w:t>Added para.</w:t></w:r></w:ins></w:p>`,
+      );
+
+      await given('a settled original paragraph marked inserted on the revised side', () => {});
+      const result = await compareDocuments(original, revised, {
+        engine: 'atomizer',
+        reconstructionMode: 'inplace',
+      });
+      const combined = await documentXml(result.document);
+      await when('the documents are compared in inplace mode', () => {});
+
+      await then('the comparison remains inplace and removes both insertion markers', () => {
+        expect(result.reconstructionModeUsed).toBe('inplace');
+        expect(combined).not.toContain(`w:author="${TRACKED_AUTHOR}"`);
+      });
+      await and('both projections keep the settled paragraph', () => {
+        expect(projectionText(combined, 'accept')).toBe('Alpha text.\nAdded para.');
+        expect(projectionText(combined, 'reject')).toBe('Alpha text.\nAdded para.');
+      });
+    },
+  );
+});

--- a/packages/docx-compare/src/baselines/atomizer/inplace-insertion-provenance-collision.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/inplace-insertion-provenance-collision.test.ts
@@ -9,6 +9,12 @@
 import JSZip from 'jszip';
 import { describe, expect } from 'vitest';
 import {
+  CorrelationStatus,
+  childElements,
+  type ComparisonUnitAtom,
+  type OpcPart,
+} from '@usejunior/docx-core';
+import {
   acceptAllChanges,
   compareDocuments,
   extractTextWithParagraphs,
@@ -20,6 +26,8 @@ import {
   buildDocxFromBodyXml,
   paragraphWithText,
 } from '../../testing/ooxml-fixtures.js';
+import { el } from '../../testing/dom-test-helpers.js';
+import { resolveRevisedInsCollisionOnRun } from './inPlaceModifier.js';
 
 const TEST_FEATURE = 'Inplace Insertion Provenance';
 const TRACKED_AUTHOR = 'Revised Author';
@@ -27,6 +35,40 @@ const test = testAllure
   .epic('Document Comparison')
   .withLabels({ feature: TEST_FEATURE })
   .conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.5.20' });
+
+const MOCK_PART: OpcPart = {
+  uri: 'word/document.xml',
+  contentType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml',
+};
+
+function mockAtom(overrides: Partial<ComparisonUnitAtom> = {}): ComparisonUnitAtom {
+  return {
+    contentElement: el('w:t', {}, undefined, 'text'),
+    ancestorElements: [],
+    ancestorUnids: [],
+    part: MOCK_PART,
+    sha1Hash: 'collision',
+    correlationStatus: CorrelationStatus.Equal,
+    ...overrides,
+  };
+}
+
+function collisionAtom(
+  revisedParagraph: Element | undefined,
+  originalParagraph: Element | undefined,
+  overrides: Partial<ComparisonUnitAtom> = {},
+): ComparisonUnitAtom {
+  return mockAtom({
+    sourceDocument: 'revised',
+    revTrackElement: el('w:ins'),
+    sourceParagraphElement: revisedParagraph,
+    comparisonUnitAtomBefore: mockAtom({
+      sourceDocument: 'original',
+      sourceParagraphElement: originalParagraph,
+    }),
+    ...overrides,
+  });
+}
 
 async function documentXml(docx: Buffer): Promise<string> {
   const part = (await JSZip.loadAsync(docx)).file('word/document.xml');
@@ -101,6 +143,144 @@ describe('Inplace revised insertion provenance collisions', () => {
       await and('both projections keep the settled paragraph', () => {
         expect(projectionText(combined, 'accept')).toBe('Alpha text.\nAdded para.');
         expect(projectionText(combined, 'reject')).toBe('Alpha text.\nAdded para.');
+      });
+    },
+  );
+
+  test(
+    'promotes a colliding formatted insertion to settled formatted content',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      const original = await buildDocxFromBodyXml(
+        `<w:p><w:r><w:rPr><w:i/></w:rPr><w:t>Formatted text</w:t></w:r></w:p>`,
+      );
+      const revised = await buildDocxFromBodyXml(
+        `<w:p><w:ins w:id="10" w:author="${TRACKED_AUTHOR}" w:date="2026-07-23T12:00:00Z">` +
+          `<w:r><w:rPr><w:b/></w:rPr><w:t>Formatted text</w:t></w:r></w:ins></w:p>`,
+      );
+
+      await given('settled text whose revised insertion also changes formatting', () => {});
+      const result = await compareDocuments(original, revised, {
+        engine: 'atomizer',
+        reconstructionMode: 'inplace',
+      });
+      const combined = await documentXml(result.document);
+      await when('the documents are compared in inplace mode', () => {});
+
+      await then('the stale insertion claim is removed without losing the format change', () => {
+        expect(result.reconstructionModeUsed).toBe('inplace');
+        expect(combined).not.toContain(`w:author="${TRACKED_AUTHOR}"`);
+        expect(combined).toContain('<w:rPrChange');
+      });
+      await and('both projections retain the settled text', () => {
+        expect(projectionText(combined, 'accept')).toBe('Formatted text');
+        expect(projectionText(combined, 'reject')).toBe('Formatted text');
+      });
+    },
+  );
+
+  test(
+    'leaves non-collisions and ambiguous insertion wrappers unchanged',
+    async ({ given, when, then }: AllureBddContext) => {
+      const originalPlainParagraph = el('w:p');
+      const guardAtoms = [
+        collisionAtom(undefined, undefined, { sourceDocument: 'original' }),
+        collisionAtom(undefined, undefined, { revTrackElement: el('w:del') }),
+        mockAtom({ sourceDocument: 'revised', revTrackElement: el('w:ins') }),
+        collisionAtom(undefined, undefined, {
+          comparisonUnitAtomBefore: mockAtom({ revTrackElement: el('w:del') }),
+        }),
+      ];
+
+      await given('atoms that do not meet every collision precondition', () => {});
+      for (const atom of guardAtoms) {
+        const run = el('w:r', {}, [el('w:t', {}, undefined, 'guarded')]);
+        const wrapper = el('w:ins', {}, [run]);
+        el('w:p', {}, [wrapper]);
+        resolveRevisedInsCollisionOnRun(atom, run);
+        expect(run.parentNode).toBe(wrapper);
+      }
+
+      const bareRun = el('w:r', {}, [el('w:t', {}, undefined, 'bare')]);
+      el('w:p', {}, [bareRun]);
+      resolveRevisedInsCollisionOnRun(collisionAtom(undefined, originalPlainParagraph), bareRun);
+
+      const firstRun = el('w:r', {}, [el('w:t', {}, undefined, 'first')]);
+      const secondRun = el('w:r', {}, [el('w:t', {}, undefined, 'second')]);
+      const multiRunWrapper = el('w:ins', {}, [firstRun, secondRun]);
+      el('w:p', {}, [multiRunWrapper]);
+      resolveRevisedInsCollisionOnRun(
+        collisionAtom(undefined, originalPlainParagraph),
+        firstRun,
+      );
+      await when('the resolver examines the guarded and ambiguous cases', () => {});
+
+      await then('it retains bare runs and multi-run insertion wrappers', () => {
+        expect(bareRun.parentNode?.nodeName).toBe('w:p');
+        expect(firstRun.parentNode).toBe(multiRunWrapper);
+        expect(childElements(multiRunWrapper)).toEqual([firstRun, secondRun]);
+      });
+    },
+  );
+
+  test(
+    'respects original paragraph revisions and removes only revised insertion metadata',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      await given('each supported original paragraph revision marker', () => {});
+      for (const marker of ['w:ins', 'w:del', 'w:moveFrom', 'w:moveTo']) {
+        const originalParagraph = el('w:p', {}, [
+          el('w:pPr', {}, [el('w:rPr', {}, [el(marker)])]),
+        ]);
+        const run = el('w:r', {}, [el('w:t', {}, undefined, marker)]);
+        const wrapper = el('w:ins', {}, [run]);
+        el('w:p', {}, [wrapper]);
+        resolveRevisedInsCollisionOnRun(
+          collisionAtom(undefined, originalParagraph),
+          run,
+        );
+        expect(run.parentNode).toBe(wrapper);
+      }
+
+      const originalParagraphWithoutRevision = el('w:p', {}, [
+        el('w:pPr', {}, [el('w:rPr', {}, [el('w:b')])]),
+      ]);
+      const revisedParagraph = el('w:p', {}, [
+        el('w:pPr', {}, [
+          el('w:rPr', {}, [el('w:ins'), el('w:moveTo')]),
+          el('w:spacing'),
+        ]),
+      ]);
+      const run = el('w:r', {}, [el('w:t', {}, undefined, 'settled')]);
+      const wrapper = el('w:ins', {}, [run]);
+      revisedParagraph.appendChild(wrapper);
+
+      resolveRevisedInsCollisionOnRun(
+        collisionAtom(revisedParagraph, originalParagraphWithoutRevision),
+        run,
+      );
+      await when('a true collision is resolved', () => {});
+
+      await then('the run is unwrapped and only the paragraph insertion marker is removed', () => {
+        expect(run.parentNode).toBe(revisedParagraph);
+        const pPr = childElements(revisedParagraph)[0]!;
+        const rPr = childElements(pPr)[0]!;
+        expect(childElements(rPr).map((child) => child.tagName)).toEqual(['w:moveTo']);
+      });
+      await and('missing paragraph-property shapes are handled safely', () => {
+        for (const paragraph of [
+          undefined,
+          el('w:p'),
+          el('w:p', {}, [el('w:pPr')]),
+          el('w:p', {}, [el('w:pPr', {}, [el('w:rPr', {}, [el('w:ins')])])]),
+        ]) {
+          const guardedRun = el('w:r', {}, [el('w:t', {}, undefined, 'safe')]);
+          const guardedWrapper = el('w:ins', {}, [guardedRun]);
+          (paragraph ?? el('w:p')).appendChild(guardedWrapper);
+          resolveRevisedInsCollisionOnRun(
+            collisionAtom(paragraph, el('w:p')),
+            guardedRun,
+          );
+          expect(guardedRun.parentNode?.nodeName).toBe('w:p');
+        }
       });
     },
   );

--- a/packages/docx-core/src/integration/lean-spec-bridge.test.ts
+++ b/packages/docx-core/src/integration/lean-spec-bridge.test.ts
@@ -11,11 +11,10 @@
  *     carries one focused tracked-change family:
  *       `w:ins`, `w:del`, paragraph-insert, `pPrChange`, comment-anchor,
  *       footnote-anchor.
- *     As of #347 the ORIGINAL side spans every family except inline `w:ins`
- *     (pinned out per #358 — the engine flattens original-side inline
- *     insertion provenance), and pairs whose pre-tracked-insertion text
- *     collides with the other side's plain text are filtered per #359; both
- *     pins carry a characterization test below asserting today's divergence.
+ *     As of #347 the ORIGINAL side spans every family. The insertion-provenance
+ *     fixes in #358 and #359 keep both original-side tracked insertions and
+ *     revised-side insertions that collide with settled original text inside
+ *     this generated property surface.
  *   - Tier 2 field-bearing clean pairs whose `document.xml` carries a complete
  *     NUMPAGES / PAGE / PAGEREF field and realizes one focused operation:
  *       field-insert, field-delete, field-stable, text-only.
@@ -354,9 +353,7 @@ const trackedFootnoteAnchorScenarioArb: fc.Arbitrary<FootnoteAnchorScenario> = p
 // falsified by construction under the old raw-text oracle) to the full
 // tracked-change scope the corrected projection oracle claims — paragraph
 // inserts included. The relaxation did its discovery job: it surfaced two
-// genuine engine bug classes, pinned per the bounded-remediation discipline
-// (narrow, named, issue-linked exclusions + the characterization test
-// 'INV-RT-001 pinned engine bugs …' below) rather than fixed inline:
+// genuine engine bug classes, now fixed with issue-linked regressions:
 //   - Issue #358 (FIXED): inline run-level and paragraph-insert pre-tracked
 //     `w:ins` ORIGINALS are back in scope. The engine now threads the
 //     original's insertion provenance through both reconstruction paths —
@@ -365,9 +362,10 @@ const trackedFootnoteAnchorScenarioArb: fc.Arbitrary<FootnoteAnchorScenario> = p
 //     restored `w:ins(original-author)` — so reject(combined) drops exactly
 //     what reject(original) drops. Dedicated regression coverage lives in
 //     pretracked-ins-provenance.test.ts.
-//   - Issue #359: pairs whose pre-tracked-insertion text collides with the
-//     other side's plain text are excluded via `hasInsProvenanceCollision` on
-//     the pair arbitrary below, and stay pinned in the characterization test.
+//   - Issue #359 (FIXED): a REVISED-side `w:ins` that matches settled original
+//     text is promoted to the shared settled lineage. Those collision pairs
+//     are no longer filtered and remain inplace while preserving both
+//     accept/reject projections.
 const trackedOriginalScenarioArb: fc.Arbitrary<TrackedScenario> = fc.oneof(
   trackedInsertionScenarioArb,
   trackedDeletionScenarioArb,
@@ -385,79 +383,10 @@ const trackedRevisedScenarioArb: fc.Arbitrary<TrackedScenario> = fc.oneof(
   trackedFootnoteAnchorScenarioArb,
 );
 
-// The raw document.xml paragraph texts a scenario materializes to. Used only
-// by the #359 collision filter: w:del keeps its delText in the raw extraction,
-// and comment/footnote bodies live outside document.xml, so only the `w:ins`
-// splice and the inserted paragraph alter the raw paragraph list.
-function scenarioRawParagraphTexts(scenario: TrackedScenario): string[] {
-  switch (scenario.family) {
-    case 'w:ins': {
-      const paragraphs = [...scenario.paragraphs];
-      const target = paragraphs[scenario.paragraphIndex]!;
-      paragraphs[scenario.paragraphIndex] =
-        target.slice(0, scenario.offset) + scenario.insertedText + target.slice(scenario.offset);
-      return paragraphs;
-    }
-    case 'paragraph-insert':
-      return [...scenario.paragraphs, scenario.newParagraphText];
-    default:
-      return [...scenario.paragraphs];
-  }
-}
-
-// The text a scenario claims as a pre-tracked INSERTION (`w:ins` wrapping run
-// text). comment-anchor / footnote-anchor wrap only reference runs (no run
-// text); pPrChange and w:del claim no inserted text.
-function claimedInsertionTexts(scenario: TrackedScenario): string[] {
-  switch (scenario.family) {
-    case 'w:ins':
-      return [scenario.insertedText];
-    case 'paragraph-insert':
-      return [scenario.newParagraphText];
-    default:
-      return [];
-  }
-}
-
-// Conservative collision proxy for the word-level atomization that produces
-// LCS matches: whitespace tokens, substring containment in either direction
-// (the inplace passes can merge runs across the `w:ins` boundary, so a token
-// of one side matching INSIDE a token of the other can still correlate).
-function textsCollide(claimed: string, otherRawParagraphs: string[]): boolean {
-  const otherRaw = otherRawParagraphs.join('\n');
-  const claimedTokens = claimed.split(/\s+/).filter((token) => token.length > 0);
-  const otherTokens = otherRaw.split(/\s+/).filter((token) => token.length > 0);
-  return (
-    claimedTokens.some((token) => otherRaw.includes(token)) ||
-    otherTokens.some((token) => claimed.includes(token))
-  );
-}
-
-// Issue #359: REVISED-side pre-tracked-insertion content that textually
-// collides with the original's plain text keeps the revised lineage's claim
-// (the physical `w:ins` wrapper survives around content whose original lineage
-// was plain), so the inplace candidate's reject projection diverges and the
-// engine permanently falls back to rebuild. The #358 fix resolved the
-// original-side half of this filter's old scope; the filter stays pair-level
-// (both directions) because the property asserts inplace mode and the
-// revised-side fallback is unconditional on collision. Until #359 lands,
-// exclude exactly the colliding pairs; the characterization test below pins
-// today's behavior.
-function hasInsProvenanceCollision(pair: TrackedScenarioPair): boolean {
-  const originalRaw = scenarioRawParagraphTexts(pair.originalScenario);
-  const revisedRaw = scenarioRawParagraphTexts(pair.revisedScenario);
-  return (
-    claimedInsertionTexts(pair.revisedScenario).some((text) => textsCollide(text, originalRaw)) ||
-    claimedInsertionTexts(pair.originalScenario).some((text) => textsCollide(text, revisedRaw))
-  );
-}
-
-const trackedPairArb: fc.Arbitrary<TrackedScenarioPair> = fc
-  .record({
-    originalScenario: trackedOriginalScenarioArb,
-    revisedScenario: trackedRevisedScenarioArb,
-  })
-  .filter((pair) => !hasInsProvenanceCollision(pair));
+const trackedPairArb: fc.Arbitrary<TrackedScenarioPair> = fc.record({
+  originalScenario: trackedOriginalScenarioArb,
+  revisedScenario: trackedRevisedScenarioArb,
+});
 
 const fieldTextShapeArb = fc.record({
   prefix: fc.constantFrom('Total pages ', 'Field value ', 'Reference '),
@@ -1450,38 +1379,23 @@ describe('Lean Spec Bridge - Inplace Reconstruction', { timeout: 60_000 }, () =>
   );
 
   test(
-    'INV-RT-001 pinned engine bug: revised-side pre-tracked insertion provenance is lost on collision (#359)',
+    'INV-RT-001: revised-side insertion collisions resolve to settled provenance (#359)',
     async ({ given, when, then }: AllureBddContext) => {
-      // Characterization of TODAY's behavior for the remaining engine bug class
-      // the #347 arbitrary relaxation surfaced (pin + file, fix in its own PR —
-      // mirroring how [LEAN-HELP-08] pinned G5 before its fix). Each case
-      // asserts the CURRENT divergence precisely so the eventual fix flips
-      // this test deliberately rather than silently:
-      //   - #359: REVISED-side pre-tracked-insertion text colliding with the
-      //     original's plain text keeps exactly one lineage's provenance — the
-      //     revised document's physical `w:ins` wrapper survives around content
-      //     whose original lineage was plain, so the inplace candidate's reject
-      //     projection drops text reject(original) keeps and the engine
-      //     permanently falls back to rebuild. The rebuild output happens to
-      //     satisfy the projection law for these shapes (the inline shape is
-      //     the #339 flake, rescued; the paragraph-insert shape holds via the
-      //     #431 mark-merge rule), so the residual harm is the lost provenance
-      //     and the unconditional fallback, not a law violation.
-      //   - #358 (original-side provenance flattening, both inline and
-      //     paragraph-insert shapes) is FIXED: those pairs now stay inplace and
-      //     are covered by trackedOriginalScenarioArb above plus the dedicated
-      //     regression suite in pretracked-ins-provenance.test.ts.
-      interface PinnedProvenanceCase {
+      // When revised calls matched content inserted but original says it is
+      // settled, the common lineage is settled: both accept and reject keep it.
+      // The physical revised-side insertion wrapper (and paragraph insertion
+      // mark, where present) must be removed so the in-place candidate passes
+      // the projection checks without rebuild fallback.
+      interface ProvenanceCollisionCase {
         name: string;
         build: () => Promise<{ original: Buffer; revised: Buffer }>;
-        // Normalized reject projections asserted VERBATIM as they are today.
         expectedRejectCombined: string;
         expectedRejectOriginal: string;
       }
 
-      const cases: PinnedProvenanceCase[] = [
+      const cases: ProvenanceCollisionCase[] = [
         {
-          name: '#359 inline-ins revised colliding with a plain original word (#339 shape, rebuild rescues)',
+          name: '#359 inline-ins revised colliding with a plain original word',
           build: async () => ({
             original: await buildSyntheticDocx({ paragraphs: ['!', '!', 'I'] }),
             revised: (
@@ -1498,11 +1412,6 @@ describe('Lean Spec Bridge - Inplace Reconstruction', { timeout: 60_000 }, () =>
           expectedRejectOriginal: '!\n!\nI',
         },
         {
-          // Before #431 the combined output rejected to 'Alpha text.' (the
-          // PPR-INS mark dropped the whole flattened paragraph, a law
-          // violation). The mark-merge rule keeps the flattened content, which
-          // here happens to match reject(original) — the law holds for this
-          // colliding shape even though the provenance is still lost (#359).
           name: '#359 paragraph-insert revised colliding with a plain original paragraph',
           build: async () => ({
             original: await buildSyntheticDocx({ paragraphs: ['Alpha text.', 'Added para.'] }),
@@ -1522,31 +1431,37 @@ describe('Lean Spec Bridge - Inplace Reconstruction', { timeout: 60_000 }, () =>
       ];
 
       await given(
-        'minimal repro pairs for the #359 revised-side pre-tracked insertion provenance bug class',
+        'minimal collision pairs where revised insertion text is settled in original',
         async () => {},
       );
 
       await when('each pair runs through the live inplace-requested comparison', async () => {});
 
       await then(
-        'every case falls back on rejectText today, accept projections hold, and the reject divergences match the filed issue verbatim',
+        'every case remains inplace with settled provenance and exact accept/reject projections',
         async () => {
-          for (const pinned of cases) {
-            const { original, revised } = await pinned.build();
+          for (const collision of cases) {
+            const { original, revised } = await collision.build();
             const result = await compareDocumentBuffers(original, revised);
 
-            if (result.modeUsed === 'inplace') {
+            if (result.modeUsed !== 'inplace') {
               throw new Error(
-                `${pinned.name}: engine stayed inplace — the pinned bug appears FIXED. ` +
-                  `Re-enable the corresponding generator scope (trackedOriginalScenarioArb / ` +
-                  `hasInsProvenanceCollision) and retire this case alongside the issue.`,
+                `${collision.name}: expected inplace output after resolving the provenance ` +
+                  `collision, got mode=${result.modeUsed} ` +
+                  `failedChecks=${JSON.stringify(result.failedChecks)} ` +
+                  `fallbackReason=${result.fallbackReason ?? '(none)'}`,
               );
             }
-            if (!result.failedChecks.includes('rejectText')) {
+            if (result.failedChecks.length > 0) {
               throw new Error(
-                `${pinned.name}: expected the inplace candidate to fail the rejectText safety ` +
-                  `check, got failedChecks=${JSON.stringify(result.failedChecks)} ` +
-                  `fallbackReason=${result.fallbackReason ?? '(none)'}`,
+                `${collision.name}: inplace output retained failed safety checks: ` +
+                  JSON.stringify(result.failedChecks),
+              );
+            }
+            if (result.combined.includes(`w:author="${TRACKED_REVISION_AUTHOR}"`)) {
+              throw new Error(
+                `${collision.name}: combined output retained revised insertion provenance ` +
+                  `for text proven settled by the original`,
               );
             }
 
@@ -1559,19 +1474,19 @@ describe('Lean Spec Bridge - Inplace Reconstruction', { timeout: 60_000 }, () =>
 
             if (acceptedCombined !== revisedViews.acceptedText) {
               throw new Error(
-                `${pinned.name}: accept projection unexpectedly diverged. ` +
+                `${collision.name}: accept projection unexpectedly diverged. ` +
                   `acceptedCombined=${JSON.stringify(acceptedCombined)} ` +
                   `acceptedRevised=${JSON.stringify(revisedViews.acceptedText)}`,
               );
             }
             if (
-              rejectedCombined !== pinned.expectedRejectCombined ||
-              originalViews.rejectedText !== pinned.expectedRejectOriginal
+              rejectedCombined !== collision.expectedRejectCombined ||
+              originalViews.rejectedText !== collision.expectedRejectOriginal
             ) {
               throw new Error(
-                `${pinned.name}: pinned reject divergence shifted (engine behavior changed). ` +
-                  `rejectedCombined=${JSON.stringify(rejectedCombined)} (pinned ${JSON.stringify(pinned.expectedRejectCombined)}) ` +
-                  `rejectedOriginal=${JSON.stringify(originalViews.rejectedText)} (pinned ${JSON.stringify(pinned.expectedRejectOriginal)})`,
+                `${collision.name}: reject projection diverged. ` +
+                  `rejectedCombined=${JSON.stringify(rejectedCombined)} (expected ${JSON.stringify(collision.expectedRejectCombined)}) ` +
+                  `rejectedOriginal=${JSON.stringify(originalViews.rejectedText)} (expected ${JSON.stringify(collision.expectedRejectOriginal)})`,
               );
             }
           }


### PR DESCRIPTION
## Summary

- promote revised-side pre-tracked insertions to settled content when their matched original lineage is plain
- remove the corresponding paragraph insertion mark for matched settled paragraphs
- keep unmatched revised insertions tracked and fail closed on ambiguous wrapper shapes
- re-enable insertion-collision pairs in the generated Lean bridge
- flip the two pinned fallback characterizations into in-place projection regressions

## Why

When revised calls matched text inserted but original treats it as settled, preserving the revised `w:ins` makes Reject All drop text that `rejectAllChanges(original)` keeps. The shared lineage must be represented as settled so both Accept All and Reject All projections remain lawful without an unnecessary rebuild fallback.

Fixes #359

## Validation

- `npm run build`
- `npm run lint:workspaces`
- `npm run test:run` (all workspaces green except nine environment/contention-sensitive docx-core cases in the restricted sandbox)
- unrestricted rerun of all nine reported cases: 27 passed, 1 expected external-suite skip
- Lean spec bridge: 14/14 passed, including generated collision coverage
- related atomizer/provenance suites: 151/151 passed
- `npm run check:spec-coverage`
- `npm run check:conformance-citations`
- `npm run check:conformance-doc`