### PR TITLE
feat(docx-core): expose deterministic heading provenance

### DIFF
--- a/openspec/changes/add-deterministic-heading-provenance/design.md
+++ b/openspec/changes/add-deterministic-heading-provenance/design.md
@@ -1,0 +1,118 @@
+## Context
+
+`buildDocumentView` currently derives `heading` from a literal paragraph style
+ID match before falling through to existing run-in/title heuristics. Paragraph
+formatting resolves alignment and indentation through direct properties and a
+`basedOn` chain, but does not resolve `w:outlineLvl`. The numbering model parses
+level counters and labels but discards `w:lvl/w:pStyle`.
+
+The default `get_document_outline` projection currently admits only
+`source === "word_style"`. Adding deterministic sources without updating that
+filter would improve the internal view while leaving the agent-facing outline
+incomplete.
+
+## Goals / Non-Goals
+
+- Goals: make explicit OOXML outline intent visible to agents by default.
+- Goals: preserve provenance so consumers can distinguish style, numbering, and
+  outline-property evidence from heuristic inference.
+- Goals: keep classification deterministic, bounded, and cheap enough for the
+  existing map-first workflow.
+- Goals: avoid breaking the existing `HeadingValue` object or heuristic source
+  values.
+- Non-Goals: invent semantic headings from arbitrary formatting, mutate source
+  documents, or introduce a graphical review surface.
+
+## Decisions
+
+### Extend the existing source union
+
+`HeadingSource` gains `list_metadata` and `outline_level`. `word_style` remains
+the public name for built-in-style evidence. Existing heuristic values remain
+unchanged, and `HeuristicHeadingSource` is redefined explicitly so adding
+deterministic sources cannot accidentally make them heuristic.
+
+This is additive at runtime, but downstream TypeScript consumers with exhaustive
+switches will receive an intentional compiler signal to handle the new
+provenance.
+
+### Resolve effective outline level like other paragraph properties
+
+`ParagraphFormatting.outlineLevel` is `number | null`. Direct
+`w:pPr/w:outlineLvl` wins; otherwise the first value in the paragraph style's
+`basedOn` chain wins. Valid heading levels are OOXML values 0 through 8 and map
+to public levels 1 through 9. Value 9 means body text and suppresses
+`outline_level` classification. Missing, malformed, negative, or out-of-range
+values do not produce a heading.
+
+The implementation will register and cite the exact ECMA-376 edition 5 sections
+for `w:pPr`, `w:outlineLvl`, `w:lvl`, and `w:pStyle` before making conformance
+claims.
+
+### Match built-in heading styles through IDs and a versioned alias table
+
+A pure lookup module owns normalized built-in Heading 1 through Heading 9 names.
+It includes at least English, French, German, Spanish, and Japanese aliases and
+is covered by one table-driven test per entry. Normalization is Unicode-aware,
+trims surrounding whitespace, collapses internal whitespace, and compares using
+locale-independent lowercase. It does not strip arbitrary punctuation or use
+fuzzy matching, which would turn localization support into a heuristic.
+
+Literal `Heading1` through `Heading9` IDs remain the fastest path. Style display
+names are consulted only when the ID is not a built-in heading ID. `TOC` styles
+are never aliases.
+
+### Use numbering-level style association only for the active level
+
+Each parsed `NumberingLevel` retains its optional `pStyle`. The public lookup
+accepts a paragraph's resolved `numId` and `ilvl`, follows the `w:num` to its
+`w:abstractNum`, and returns that exact level definition without mutating
+counters.
+
+A paragraph is `list_metadata` only when its active numbering level's `pStyle`
+resolves to a recognized built-in heading level. An unrelated heading style on
+another list level, a missing level, an unknown style, or a `TOC` style does not
+classify the paragraph.
+
+### First deterministic match wins
+
+Classification order is:
+
+1. recognized built-in heading style on the paragraph (`word_style`);
+2. active list level linked to a recognized built-in heading style
+   (`list_metadata`);
+3. effective `w:outlineLvl` (`outline_level`);
+4. existing heuristic detectors.
+
+The selected source supplies the level. Explicit paragraph style therefore wins
+over inconsistent numbering metadata, and both win over an inconsistent outline
+property. Table-cell suppression continues to apply only to heuristics; explicit
+deterministic structure remains visible in tables.
+
+### Default outline means all deterministic sources
+
+`get_document_outline` replaces its single-source check with a deterministic
+source predicate. `word_style`, `list_metadata`, and `outline_level` appear by
+default. Existing heuristic sources still require
+`include_heuristic_headings=true`.
+
+JSON preserves levels 1 through 9. Markdown rendering retains its existing ATX
+clamp at depth 6 because Markdown has no deeper heading syntax; the structured
+JSON remains authoritative for levels 7 through 9.
+
+## Risks / Trade-offs
+
+- Some documents contain inconsistent style, numbering, and outline metadata.
+  Fixed precedence makes the result explainable and stable rather than trying to
+  reconcile author intent.
+- Localized style aliases require maintenance. A narrow data table plus
+  table-driven tests is safer than fuzzy matching and easy to extend.
+- New union members may break exhaustive consumer switches at compile time.
+  This is preferable to silently relabeling the new evidence as `word_style`.
+
+## Migration Plan
+
+No document migration is required. Existing headings retain their current
+source values. Consumers that treat only `word_style` as deterministic should
+accept the two new deterministic values. Generated MCP documentation will call
+out this additive taxonomy change.

--- a/openspec/changes/add-deterministic-heading-provenance/proposal.md
+++ b/openspec/changes/add-deterministic-heading-provenance/proposal.md
@@ -1,0 +1,59 @@
+# Change: Add deterministic heading provenance
+
+## Why
+
+SafeDocX already gives agents a compact document outline, but its deterministic
+path recognizes only literal `Heading1` through `Heading6` paragraph style IDs.
+Real legal documents frequently encode outline intent through `w:outlineLvl`,
+numbering levels linked to paragraph styles, or localized Word style names.
+Those headings are currently invisible to the default low-noise outline, forcing
+agents to scan more prose or rely on lower-confidence formatting heuristics.
+
+The document view already exposes a `heading.source` taxonomy and several
+heuristic sources. This change extends that existing contract instead of adding
+parallel heading fields or another UI.
+
+## What Changes
+
+- Resolve effective paragraph `w:outlineLvl` through direct formatting and the
+  paragraph style chain and expose it on `ParagraphFormatting`.
+- Parse the optional `w:pStyle` association on numbering levels and expose a
+  read-only level lookup so document-view classification can use it.
+- Extend `HeadingSource` with deterministic `list_metadata` and
+  `outline_level` values while retaining `word_style` and all current heuristic
+  source values.
+- Recognize Word built-in Heading 1 through Heading 9 style IDs and a maintained,
+  versioned alias table for localized built-in heading names, including English,
+  French, German, Spanish, and Japanese.
+- Apply one documented precedence order:
+  `word_style` → `list_metadata` → `outline_level` → existing heuristics.
+- Treat deterministic sources as default outline entries; retain the existing
+  opt-in boundary for heuristic headings.
+- Document the complete heading shape and source taxonomy in generated MCP
+  reference material.
+
+## Impact
+
+- Affected specs: `docx-primitives`, `mcp-server`
+- Affected code:
+  - paragraph style/property parsing
+  - numbering-level parsing and lookup
+  - document-view heading classification and types
+  - `get_document_outline` deterministic-source filtering
+  - shared fixtures, tests, generated MCP reference, and conformance registry
+- Ref: #206
+
+## Out of scope
+
+- Adding another formatting-inference flag: the existing document view already
+  implements heuristic heading sources and `get_document_outline` already gates
+  them behind `include_heuristic_headings`.
+- Renaming `word_style` to `builtin_style`, which would break existing consumers.
+- Inferring hierarchy for Word `Title` or `Subtitle`, whose outline level is not
+  intrinsic to the style name; those paragraphs remain eligible through an
+  explicit effective `w:outlineLvl`.
+- Promoting detected headings into Word styles, generating a table of contents,
+  or detecting headings in text boxes, ancillary stories, or Google Docs.
+- The signature-cluster suppression inconsistency described in the issue
+  discussion; that is an independent existing-behavior bug and should remain a
+  focused fix.

--- a/openspec/changes/add-deterministic-heading-provenance/specs/docx-primitives/spec.md
+++ b/openspec/changes/add-deterministic-heading-provenance/specs/docx-primitives/spec.md
@@ -1,0 +1,72 @@
+## ADDED Requirements
+
+### Requirement: Deterministic heading metadata carries explicit provenance
+
+The document view SHALL classify explicit DOCX heading intent using the existing
+`HeadingValue` object. It SHALL retain all existing source values and add
+`list_metadata` and `outline_level`. Deterministic classification SHALL use
+first-match precedence `word_style` → `list_metadata` → `outline_level` before
+evaluating existing heuristic detectors.
+
+#### Scenario: [HEAD-PROV-01] Effective outline level classifies a generic paragraph
+
+- **GIVEN** a paragraph whose effective `w:outlineLvl` is 1 and whose paragraph
+  style and active numbering level do not identify a built-in heading
+- **WHEN** the document view is built
+- **THEN** `heading.level` SHALL be 2
+- **AND** `heading.source` SHALL be `outline_level`
+- **AND** a direct paragraph outline level SHALL override a style-chain value
+
+#### Scenario: [HEAD-PROV-02] Body-text and malformed outline values do not classify
+
+- **GIVEN** a paragraph whose effective `w:outlineLvl` is body-text value 9,
+  missing, malformed, negative, or outside the supported OOXML range
+- **WHEN** no higher-precedence heading evidence or heuristic applies
+- **THEN** the paragraph SHALL NOT receive a heading from `outline_level`
+
+#### Scenario: [HEAD-PROV-03] Active numbering-level style association classifies
+
+- **GIVEN** a paragraph on numbering level 1 whose active
+  `w:lvl/w:pStyle` resolves to a recognized Heading 2 style
+- **WHEN** the document view is built
+- **THEN** `heading.level` SHALL be 2
+- **AND** `heading.source` SHALL be `list_metadata`
+- **AND** a heading association on a different numbering level SHALL NOT
+  classify the paragraph
+
+#### Scenario: [HEAD-PROV-04] Built-in heading style wins conflicting metadata
+
+- **GIVEN** a paragraph with a recognized Heading 1 paragraph style, an active
+  list level associated with Heading 2, and effective outline level 2
+- **WHEN** the document view is built
+- **THEN** `heading.level` SHALL be 1
+- **AND** `heading.source` SHALL be `word_style`
+
+### Requirement: Built-in heading recognition is localized and bounded
+
+The document view SHALL recognize literal Heading 1 through Heading 9 style IDs
+and a maintained built-in-name alias table covering at least English, French,
+German, Spanish, and Japanese. Matching SHALL be exact after documented Unicode
+and whitespace normalization and SHALL NOT use fuzzy similarity.
+
+#### Scenario: [HEAD-PROV-05] Localized built-in name maps to its heading level
+
+- **GIVEN** a paragraph style whose display name is the French built-in name
+  `Titre 1`
+- **WHEN** a paragraph uses that style
+- **THEN** `heading.level` SHALL be 1
+- **AND** `heading.source` SHALL be `word_style`
+
+#### Scenario: [HEAD-PROV-06] TOC style is not a built-in heading alias
+
+- **GIVEN** a paragraph using a `TOC 1` style and no other heading evidence
+- **WHEN** the document view is built
+- **THEN** the paragraph SHALL NOT receive a deterministic heading
+
+#### Scenario: [HEAD-PROV-07] Nested deterministic headings retain order and levels
+
+- **GIVEN** three document-order paragraphs classified at levels 1, 2, and 1
+  through any deterministic sources
+- **WHEN** the document view is built
+- **THEN** the three headings SHALL retain document order
+- **AND** their levels SHALL be 1, 2, and 1 respectively

--- a/openspec/changes/add-deterministic-heading-provenance/specs/mcp-server/spec.md
+++ b/openspec/changes/add-deterministic-heading-provenance/specs/mcp-server/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: Document outline includes all deterministic heading sources by default
+
+`get_document_outline` SHALL include `word_style`, `list_metadata`, and
+`outline_level` headings without an inference opt-in. Existing heuristic
+heading sources SHALL remain excluded by default and included only when
+`include_heuristic_headings=true`.
+
+#### Scenario: [HEAD-OUTLINE-01] Default outline includes mixed deterministic sources
+
+- **GIVEN** a DOCX with headings sourced from a built-in style, active list
+  metadata, and effective outline level
+- **WHEN** `get_document_outline` is called with default options
+- **THEN** all three headings SHALL appear in document order
+- **AND** each entry SHALL expose its exact `source`, `level`, text, and stable
+  paragraph id
+
+#### Scenario: [HEAD-OUTLINE-02] Heuristic boundary remains opt-in
+
+- **GIVEN** a DOCX containing deterministic and heuristic headings
+- **WHEN** `get_document_outline` is called without
+  `include_heuristic_headings`
+- **THEN** only deterministic headings SHALL appear
+- **AND** when `include_heuristic_headings=true`, the existing heuristic
+  headings SHALL also appear with their existing source values
+
+#### Scenario: [HEAD-OUTLINE-03] Structured levels exceed Markdown syntax safely
+
+- **GIVEN** a deterministic Heading 7 through Heading 9
+- **WHEN** JSON output is requested
+- **THEN** the exact level 7 through 9 SHALL be returned
+- **AND** when Markdown output is requested, rendering SHALL clamp the visual
+  ATX depth to 6 without changing the underlying structured heading level
+
+### Requirement: MCP reference documents heading provenance
+
+Generated MCP reference material SHALL document the `HeadingValue` fields, all
+deterministic and heuristic source values, first-match precedence, default
+outline filtering, and the Markdown depth clamp.
+
+#### Scenario: [HEAD-OUTLINE-04] Generated reference lists the complete taxonomy
+
+- **WHEN** the generated MCP tool reference is rebuilt
+- **THEN** it SHALL list `word_style`, `list_metadata`, `outline_level`,
+  `run_in_header`, `title_with_period`, `title_with_colon`,
+  `title_caps_centered`, and `title_bare`
+- **AND** it SHALL distinguish default deterministic sources from opt-in
+  heuristic sources

--- a/openspec/changes/add-deterministic-heading-provenance/tasks.md
+++ b/openspec/changes/add-deterministic-heading-provenance/tasks.md
@@ -1,0 +1,45 @@
+## 1. Specification and conformance
+
+- [ ] 1.1 Validate this OpenSpec proposal and delta requirements.
+- [ ] 1.2 Register the exact ECMA-376 edition 5 sections for paragraph outline
+  levels and numbering-level paragraph-style associations.
+- [ ] 1.3 Add conformance JSDoc and Allure citations only where behavior is
+  grounded in normative OOXML structure.
+
+## 2. Deterministic metadata parsing
+
+- [ ] 2.1 Add effective `outlineLevel` resolution to paragraph formatting,
+  including direct-over-style precedence, 0..8 mapping, body-text value 9, and
+  malformed-value handling.
+- [ ] 2.2 Retain optional `pStyle` on numbering levels and expose a read-only
+  lookup for a paragraph's active `numId`/`ilvl`.
+- [ ] 2.3 Add the maintained localized built-in heading alias table for English,
+  French, German, Spanish, and Japanese.
+
+## 3. Classification and agent surface
+
+- [ ] 3.1 Extend `HeadingSource` with `list_metadata` and `outline_level`
+  without changing existing source values.
+- [ ] 3.2 Apply the documented first-match precedence and support Heading 1
+  through Heading 9.
+- [ ] 3.3 Include every deterministic source in the default
+  `get_document_outline` projection while retaining heuristic opt-in.
+- [ ] 3.4 Document the complete `HeadingValue` shape, taxonomy, precedence, and
+  Markdown depth clamp in generated MCP reference material.
+
+## 4. Tests
+
+- [ ] 4.1 Cover direct and inherited `w:outlineLvl`, body-text value 9,
+  malformed values, and direct-over-style precedence.
+- [ ] 4.2 Cover active numbering levels linked to heading styles, mismatched
+  levels, missing definitions, and conflicting deterministic evidence.
+- [ ] 4.3 Cover every localized alias entry, literal Heading 1..9 IDs, and
+  explicit negative `TOC` cases.
+- [ ] 4.4 Cover nested 1 → 2 → 1 outline order, default deterministic inclusion,
+  heuristic opt-in, table behavior, and Markdown level clamping.
+
+## 5. Verification and delivery
+
+- [ ] 5.1 Regenerate tool reference and OpenSpec traceability artifacts.
+- [ ] 5.2 Run focused tests and every mandatory repository pre-submit gate.
+- [ ] 5.3 Review the diff for bounded scope and commit with `Ref: #206`.

--- a/openspec/changes/add-deterministic-heading-provenance/tasks.md
+++ b/openspec/changes/add-deterministic-heading-provenance/tasks.md
@@ -1,45 +1,45 @@
 ## 1. Specification and conformance
 
-- [ ] 1.1 Validate this OpenSpec proposal and delta requirements.
-- [ ] 1.2 Register the exact ECMA-376 edition 5 sections for paragraph outline
+- [x] 1.1 Validate this OpenSpec proposal and delta requirements.
+- [x] 1.2 Register the exact ECMA-376 edition 5 sections for paragraph outline
   levels and numbering-level paragraph-style associations.
-- [ ] 1.3 Add conformance JSDoc and Allure citations only where behavior is
+- [x] 1.3 Add conformance JSDoc and Allure citations only where behavior is
   grounded in normative OOXML structure.
 
 ## 2. Deterministic metadata parsing
 
-- [ ] 2.1 Add effective `outlineLevel` resolution to paragraph formatting,
+- [x] 2.1 Add effective `outlineLevel` resolution to paragraph formatting,
   including direct-over-style precedence, 0..8 mapping, body-text value 9, and
   malformed-value handling.
-- [ ] 2.2 Retain optional `pStyle` on numbering levels and expose a read-only
+- [x] 2.2 Retain optional `pStyle` on numbering levels and expose a read-only
   lookup for a paragraph's active `numId`/`ilvl`.
-- [ ] 2.3 Add the maintained localized built-in heading alias table for English,
+- [x] 2.3 Add the maintained localized built-in heading alias table for English,
   French, German, Spanish, and Japanese.
 
 ## 3. Classification and agent surface
 
-- [ ] 3.1 Extend `HeadingSource` with `list_metadata` and `outline_level`
+- [x] 3.1 Extend `HeadingSource` with `list_metadata` and `outline_level`
   without changing existing source values.
-- [ ] 3.2 Apply the documented first-match precedence and support Heading 1
+- [x] 3.2 Apply the documented first-match precedence and support Heading 1
   through Heading 9.
-- [ ] 3.3 Include every deterministic source in the default
+- [x] 3.3 Include every deterministic source in the default
   `get_document_outline` projection while retaining heuristic opt-in.
-- [ ] 3.4 Document the complete `HeadingValue` shape, taxonomy, precedence, and
+- [x] 3.4 Document the complete `HeadingValue` shape, taxonomy, precedence, and
   Markdown depth clamp in generated MCP reference material.
 
 ## 4. Tests
 
-- [ ] 4.1 Cover direct and inherited `w:outlineLvl`, body-text value 9,
+- [x] 4.1 Cover direct and inherited `w:outlineLvl`, body-text value 9,
   malformed values, and direct-over-style precedence.
-- [ ] 4.2 Cover active numbering levels linked to heading styles, mismatched
+- [x] 4.2 Cover active numbering levels linked to heading styles, mismatched
   levels, missing definitions, and conflicting deterministic evidence.
-- [ ] 4.3 Cover every localized alias entry, literal Heading 1..9 IDs, and
+- [x] 4.3 Cover every localized alias entry, literal Heading 1..9 IDs, and
   explicit negative `TOC` cases.
-- [ ] 4.4 Cover nested 1 → 2 → 1 outline order, default deterministic inclusion,
+- [x] 4.4 Cover nested 1 → 2 → 1 outline order, default deterministic inclusion,
   heuristic opt-in, table behavior, and Markdown level clamping.
 
 ## 5. Verification and delivery
 
-- [ ] 5.1 Regenerate tool reference and OpenSpec traceability artifacts.
-- [ ] 5.2 Run focused tests and every mandatory repository pre-submit gate.
-- [ ] 5.3 Review the diff for bounded scope and commit with `Ref: #206`.
+- [x] 5.1 Regenerate tool reference and OpenSpec traceability artifacts.
+- [x] 5.2 Run focused tests and every mandatory repository pre-submit gate.
+- [x] 5.3 Review the diff for bounded scope and commit with `Ref: #206`.

--- a/packages/docx-core/src/primitives/document_view-headings.ts
+++ b/packages/docx-core/src/primitives/document_view-headings.ts
@@ -1,9 +1,22 @@
 import { OOXML, W } from './namespaces.js';
 import { getParagraphRuns } from './text.js';
 import { extractEffectiveRunFormatting, type ParagraphAlignment, type StylesModel } from './styles.js';
-import type { DocumentViewNode, HeaderFormatting, HeadingValue, HeuristicHeadingSource } from './document_view-types.js';
+import { getBuiltInHeadingLevel } from './heading_styles.js';
+import type {
+  DeterministicHeadingSource,
+  DocumentViewNode,
+  HeaderFormatting,
+  HeadingValue,
+  HeuristicHeadingSource,
+} from './document_view-types.js';
 
-export type { HeaderFormatting, HeadingSource, HeadingValue, HeuristicHeadingSource } from './document_view-types.js';
+export type {
+  DeterministicHeadingSource,
+  HeaderFormatting,
+  HeadingSource,
+  HeadingValue,
+  HeuristicHeadingSource,
+} from './document_view-types.js';
 
 const SHORT_HEADER_MAX_LENGTH = 50;
 const MAX_HEADER_TEXT_LENGTH = 60;
@@ -46,19 +59,66 @@ export function extractHeaderInfo(cleanText: string): { header_text: string | nu
   return { header_text: null, header_style: null };
 }
 
-export function deriveHeading(
-  paragraphStyleId: string | null,
+const DETERMINISTIC_HEADING_SOURCES = new Set<DeterministicHeadingSource>([
+  'word_style',
+  'list_metadata',
+  'outline_level',
+]);
+
+export function isDeterministicHeadingSource(
+  source: string,
+): source is DeterministicHeadingSource {
+  return DETERMINISTIC_HEADING_SOURCES.has(source as DeterministicHeadingSource);
+}
+
+export function deriveHeading(params: {
+  paragraphStyleId: string | null;
+  paragraphStyleName: string;
+  numberingLevelStyleId: string | null;
+  numberingLevelStyleName: string | null;
+  outlineLevel: number | null;
   cleanText: string,
   headerText: string | null,
   headerStyle: HeuristicHeadingSource | null,
   isInTableCell: boolean,
-): HeadingValue | undefined {
-  const styleMatch = paragraphStyleId ? /^Heading([1-6])$/.exec(paragraphStyleId) : null;
-  if (styleMatch) {
+}): HeadingValue | undefined {
+  const {
+    paragraphStyleId,
+    paragraphStyleName,
+    numberingLevelStyleId,
+    numberingLevelStyleName,
+    outlineLevel,
+    cleanText,
+    headerText,
+    headerStyle,
+    isInTableCell,
+  } = params;
+  const styleLevel = getBuiltInHeadingLevel(paragraphStyleId, paragraphStyleName);
+  if (styleLevel !== null) {
     return {
       text: cleanText,
       source: 'word_style',
-      level: Number.parseInt(styleMatch[1]!, 10),
+      level: styleLevel,
+    };
+  }
+
+  const listLevel = getBuiltInHeadingLevel(
+    numberingLevelStyleId,
+    numberingLevelStyleName,
+  );
+  if (listLevel !== null) {
+    return {
+      text: cleanText,
+      source: 'list_metadata',
+      level: listLevel,
+    };
+  }
+
+  if (outlineLevel !== null && outlineLevel >= 0 && outlineLevel <= 8) {
+    return {
+      text: cleanText,
+      source: 'outline_level',
+      level: outlineLevel + 1,
     };
   }
 

--- a/packages/docx-core/src/primitives/document_view-types.ts
+++ b/packages/docx-core/src/primitives/document_view-types.ts
@@ -7,20 +7,25 @@ export type HeaderFormatting = {
   underline: boolean;
 };
 
-export type HeadingSource =
+export type DeterministicHeadingSource =
   | 'word_style'
+  | 'list_metadata'
+  | 'outline_level';
+
+export type HeuristicHeadingSource =
   | 'run_in_header'
   | 'title_with_period'
   | 'title_with_colon'
   | 'title_caps_centered'
   | 'title_bare';
 
-export type HeuristicHeadingSource = Exclude<HeadingSource, 'word_style'>;
+export type HeadingSource = DeterministicHeadingSource | HeuristicHeadingSource;
 
 export type HeadingValue = {
   /**
    * Heading label text. Semantics depend on `source`:
-   * - `word_style`: the full paragraph text (the entire paragraph IS the heading).
+   * - Deterministic sources (`word_style`, `list_metadata`, `outline_level`):
+   *   the full paragraph text (the entire paragraph IS the heading).
    * - All heuristic sources (`run_in_header`, `title_with_period`, `title_with_colon`,
    *   `title_caps_centered`, `title_bare`): only the extracted heading prefix.
    *   For example, on `"Indemnification. The Company shall …"` the value is

--- a/packages/docx-core/src/primitives/document_view.ts
+++ b/packages/docx-core/src/primitives/document_view.ts
@@ -4,7 +4,12 @@ import { getParagraphText, getParagraphRuns } from './text.js';
 import { getParagraphBookmarkId } from './bookmarks.js';
 import { buildTableMetaMap, deriveTableContext } from './table_context.js';
 import { extractListLabel, stripListLabel, LabelType } from './list_labels.js';
-import { parseNumberingXml, type NumberingCounters, computeListLabelForParagraph } from './numbering.js';
+import {
+  parseNumberingXml,
+  type NumberingCounters,
+  computeListLabelForParagraph,
+  getNumberingLevel,
+} from './numbering.js';
 import { parseStylesXml, type StylesModel, extractParagraphFormatting, extractEffectiveRunFormatting, type RunFormatting } from './styles.js';
 import { HIGHLIGHT_TAG } from './semantic_tags.js';
 import { type AnnotatedRun, type FormattingBaseline, type FormattingMode, computeModalBaseline, computeParagraphFontBaseline, emitFormattingTags, mergeAdjacentTags } from './formatting_tags.js';
@@ -17,6 +22,7 @@ import {
   extractHeaderInfo,
   suppressSignatureClusters,
 } from './document_view-headings.js';
+import { getBuiltInHeadingLevel } from './heading_styles.js';
 import { discoverStyles, fingerprintKey } from './document_view-styles.js';
 import { findTaggedTextInsertionIndex } from './document_view-comments.js';
 import type {
@@ -30,7 +36,14 @@ import type {
 } from './document_view-types.js';
 
 export type { BuildDocumentViewOptions, DocumentViewNode, ListMetadata, TableContext } from './document_view-types.js';
-export type { HeaderFormatting, HeadingSource, HeadingValue, HeuristicHeadingSource } from './document_view-headings.js';
+export {
+  isDeterministicHeadingSource,
+  type DeterministicHeadingSource,
+  type HeaderFormatting,
+  type HeadingSource,
+  type HeadingValue,
+  type HeuristicHeadingSource,
+} from './document_view-headings.js';
 export { discoverStyles } from './document_view-styles.js';
 export type { DocumentStyleInfo, DocumentStyles, FormattingFingerprint } from './document_view-styles.js';
 export { INLINE_COMMENT_MARKER_RUNTIME, TOON_INLINE_TAG_RE, collectInlineCommentMarkers, tokenizeToonInline } from './document_view-comments.js';
@@ -481,7 +494,9 @@ export function buildNodesForDocumentView(params: {
 
       // Skip heading-style paragraphs from baseline computation.
       const styleName = (paraFmt.styleName ?? '').toLowerCase();
-      const isHeadingStyle = styleName.includes('heading') || styleName.includes('title');
+      const isHeadingStyle =
+        getBuiltInHeadingLevel(paraFmt.styleId, paraFmt.styleName) !== null ||
+        styleName.includes('title');
       if (!isHeadingStyle) {
         for (const r of runs) {
           if (r.charCount > 0) allBodyRuns.push(r);
@@ -629,7 +644,23 @@ export function buildNodesForDocumentView(params: {
       headerStyle = fallback.header_style;
     }
 
-    const heading = deriveHeading(paraFmt.styleId, cleanTextNoLabel, headerText, headerStyle, tableContext != null);
+    const numberingLevel = numId && ilvl != null
+      ? getNumberingLevel(numberingModel, numId, ilvl)
+      : null;
+    const numberingLevelStyle = numberingLevel?.pStyle
+      ? stylesModel.byId.get(numberingLevel.pStyle)
+      : undefined;
+    const heading = deriveHeading({
+      paragraphStyleId: paraFmt.styleId,
+      paragraphStyleName: paraFmt.styleName,
+      numberingLevelStyleId: numberingLevel?.pStyle ?? null,
+      numberingLevelStyleName: numberingLevelStyle?.name ?? null,
+      outlineLevel: paraFmt.outlineLevel,
+      cleanText: cleanTextNoLabel,
+      headerText,
+      headerStyle,
+      isInTableCell: tableContext != null,
+    });
 
     // ── Tag emission ──
     let tagged = cleanTextNoLabel;

--- a/packages/docx-core/src/primitives/heading_styles.ts
+++ b/packages/docx-core/src/primitives/heading_styles.ts
@@ -1,0 +1,52 @@
+/**
+ * Versioned, bounded aliases for Microsoft Word's built-in Heading 1..9
+ * paragraph styles. These are exact aliases after Unicode and whitespace
+ * normalization; this module deliberately performs no fuzzy matching.
+ */
+
+export type BuiltInHeadingAlias = {
+  locale: 'en' | 'fr' | 'de' | 'es' | 'ja';
+  name: string;
+  level: number;
+};
+
+const LOCALIZED_STEMS: ReadonlyArray<{
+  locale: BuiltInHeadingAlias['locale'];
+  stem: string;
+}> = [
+  { locale: 'en', stem: 'Heading' },
+  { locale: 'fr', stem: 'Titre' },
+  { locale: 'de', stem: 'Überschrift' },
+  { locale: 'es', stem: 'Título' },
+  { locale: 'ja', stem: '見出し' },
+];
+
+export const BUILT_IN_HEADING_ALIASES_V1: readonly BuiltInHeadingAlias[] =
+  LOCALIZED_STEMS.flatMap(({ locale, stem }) =>
+    Array.from({ length: 9 }, (_, index) => ({
+      locale,
+      name: `${stem} ${index + 1}`,
+      level: index + 1,
+    })),
+  );
+
+export function normalizeBuiltInStyleName(value: string): string {
+  return value.normalize('NFKC').trim().replace(/\s+/gu, ' ').toLowerCase();
+}
+
+const LEVEL_BY_NORMALIZED_ALIAS = new Map(
+  BUILT_IN_HEADING_ALIASES_V1.map(({ name, level }) => [
+    normalizeBuiltInStyleName(name),
+    level,
+  ]),
+);
+
+export function getBuiltInHeadingLevel(
+  styleId: string | null,
+  styleName: string | null,
+): number | null {
+  const idMatch = styleId ? /^Heading([1-9])$/.exec(styleId) : null;
+  if (idMatch) return Number(idMatch[1]);
+  if (!styleName) return null;
+  return LEVEL_BY_NORMALIZED_ALIAS.get(normalizeBuiltInStyleName(styleName)) ?? null;
+}

--- a/packages/docx-core/src/primitives/namespaces.ts
+++ b/packages/docx-core/src/primitives/namespaces.ts
@@ -30,6 +30,7 @@ export const W = {
 
   // Paragraph formatting
   pStyle: 'pStyle',
+  outlineLvl: 'outlineLvl',
   jc: 'jc',
   ind: 'ind',
   spacing: 'spacing',

--- a/packages/docx-core/src/primitives/numbering.ts
+++ b/packages/docx-core/src/primitives/numbering.ts
@@ -1,4 +1,5 @@
 import { OOXML, W } from './namespaces.js';
+import { getFirstChild } from './xml-helpers.js';
 
 function getWAttr(el: Element, localName: string): string | null {
   return el.getAttributeNS(OOXML.W_NS, localName) ?? el.getAttribute(`w:${localName}`) ?? el.getAttribute(localName);
@@ -10,6 +11,7 @@ export type NumberingLevel = {
   numFmt: string; // decimal, lowerLetter, upperLetter, lowerRoman, upperRoman, bullet, none...
   lvlText: string; // e.g. "%1.%2."
   suff: string; // tab, space, nothing
+  pStyle: string | null;
 };
 
 export type AbstractNum = {
@@ -46,13 +48,15 @@ export function parseNumberingXml(numberingDoc: Document | null): NumberingModel
       const numFmtEl = lvl.getElementsByTagNameNS(OOXML.W_NS, W.numFmt).item(0);
       const lvlTextEl = lvl.getElementsByTagNameNS(OOXML.W_NS, W.lvlText).item(0);
       const suffEl = lvl.getElementsByTagNameNS(OOXML.W_NS, W.suff).item(0);
+      const pStyleEl = getFirstChild(lvl, OOXML.W_NS, W.pStyle);
 
       const startVal = startEl ? Number.parseInt(getWAttr(startEl, 'val') ?? '1', 10) : 1;
       const numFmt = numFmtEl ? (getWAttr(numFmtEl, 'val') ?? 'decimal') : 'decimal';
       const lvlText = lvlTextEl ? (getWAttr(lvlTextEl, 'val') ?? `%${ilvl + 1}.`) : `%${ilvl + 1}.`;
       const suff = suffEl ? (getWAttr(suffEl, 'val') ?? 'tab') : 'tab';
+      const pStyle = pStyleEl ? (getWAttr(pStyleEl, 'val') ?? null) : null;
 
-      levels.set(ilvl, { ilvl, start: startVal, numFmt, lvlText, suff });
+      levels.set(ilvl, { ilvl, start: startVal, numFmt, lvlText, suff, pStyle });
     }
     model.abstractNums.set(id, { abstractNumId: id, levels });
   }
@@ -159,7 +163,18 @@ function getStartForLevel(model: NumberingModel, numId: string, ilvl: number): n
   return lvl?.start ?? 1;
 }
 
-function getLevel(model: NumberingModel, numId: string, ilvl: number): NumberingLevel | null {
+/**
+ * Resolve the exact numbering-level definition active for a paragraph without
+ * advancing or otherwise mutating list counters.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.9.6
+ * @conformance ECMA-376 edition 5, Part 1 § 17.9.22
+ */
+export function getNumberingLevel(
+  model: NumberingModel,
+  numId: string,
+  ilvl: number,
+): Readonly<NumberingLevel> | null {
   const num = model.nums.get(numId);
   if (!num) return null;
   const abs = model.abstractNums.get(num.abstractNumId);
@@ -172,7 +187,7 @@ export function computeListLabelForParagraph(
   params: { numId: string; ilvl: number },
 ): string {
   const { numId, ilvl } = params;
-  const level = getLevel(model, numId, ilvl);
+  const level = getNumberingLevel(model, numId, ilvl);
   if (!level) return '';
 
   let arr = counters.get(numId);
@@ -205,7 +220,7 @@ export function computeListLabelForParagraph(
     const levelNum = Number.parseInt(String(nStr), 10) - 1;
     if (Number.isNaN(levelNum) || levelNum < 0) return '';
     const v = arr[levelNum] ?? 0;
-    const lvlDef = getLevel(model, numId, levelNum);
+    const lvlDef = getNumberingLevel(model, numId, levelNum);
     const fmt = lvlDef?.numFmt ?? 'decimal';
     return formatCounter(fmt, v);
   });

--- a/packages/docx-core/src/primitives/styles.ts
+++ b/packages/docx-core/src/primitives/styles.ts
@@ -69,6 +69,8 @@ export type ParagraphFormatting = {
   alignment: ParagraphAlignment;
   leftIndentPt: number;
   firstLineIndentPt: number;
+  /** Effective raw OOXML outline value: 0..8 are headings; 9 is body text. */
+  outlineLevel: number | null;
 };
 
 function twipsToPt(v: number): number {
@@ -109,6 +111,20 @@ function firstNonNull<T>(vals: Array<T | null | undefined>): T | null {
   return null;
 }
 
+/**
+ * Parse the paragraph outline level defined by WordprocessingML. Values 0..8
+ * represent heading levels 1..9; value 9 explicitly marks body text.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.3.1.20
+ */
+function parseOutlineLevel(outlineEl: Element | null): number | null {
+  if (!outlineEl) return null;
+  const raw = (getWAttr(outlineEl, 'val') ?? '').trim();
+  if (!/^\+?\d+$/u.test(raw)) return null;
+  const value = Number(raw);
+  return Number.isSafeInteger(value) && value >= 0 && value <= 9 ? value : null;
+}
+
 export function extractParagraphFormatting(
   pPr: Element | null,
   styles: StylesModel,
@@ -122,9 +138,15 @@ export function extractParagraphFormatting(
   // Resolve alignment and indents: direct pPr overrides style chain.
   const directJc = pPr ? getFirstChild(pPr, OOXML.W_NS, W.jc) : null;
   const directInd = pPr ? getFirstChild(pPr, OOXML.W_NS, W.ind) : null;
+  const directOutline = pPr ? getFirstChild(pPr, OOXML.W_NS, W.outlineLvl) : null;
 
   const styleJc = firstNonNull(chain.map((s) => (s.pPr ? getFirstChild(s.pPr, OOXML.W_NS, W.jc) : null)));
   const styleInd = firstNonNull(chain.map((s) => (s.pPr ? getFirstChild(s.pPr, OOXML.W_NS, W.ind) : null)));
+  const styleOutlineLevel = firstNonNull(
+    chain.map((s) =>
+      parseOutlineLevel(s.pPr ? getFirstChild(s.pPr, OOXML.W_NS, W.outlineLvl) : null),
+    ),
+  );
 
   const alignment = parseAlignment(directJc ?? styleJc);
   const ind = parseIndentPt(directInd ?? styleInd);
@@ -135,6 +157,7 @@ export function extractParagraphFormatting(
     alignment,
     leftIndentPt: ind.leftIndentPt,
     firstLineIndentPt: ind.firstLineIndentPt,
+    outlineLevel: parseOutlineLevel(directOutline) ?? styleOutlineLevel,
   };
 }
 

--- a/packages/docx-core/test-primitives/document_view.branch.test.ts
+++ b/packages/docx-core/test-primitives/document_view.branch.test.ts
@@ -680,8 +680,8 @@ describe('document_view branch coverage', () => {
     let bodyXml: string;
     let nodes: ReturnType<typeof buildNodesForDocumentView>['nodes'];
 
-    await given('four signature labels followed by four non-Heading1-6 styled headings', async () => {
-      // The fixture corpus uses heading-ish styles beyond Heading1-6
+    await given('four signature labels followed by four non-builtin heading styles', async () => {
+      // The fixture corpus uses custom heading-like styles outside Heading1-9
       // (Heading7-9, Title, Subtitle, Article5L1-8). They are not signature
       // labels, so they must survive suppression even though they sit
       // adjacent to a label-dense window.
@@ -1038,7 +1038,7 @@ describe('document_view branch coverage', () => {
     });
   });
 
-  test('derives word_style headings only from exact Heading1-Heading6 paragraph style IDs', async ({ given, when, then, and }: AllureBddContext) => {
+  test('derives word_style headings from exact Heading1-Heading9 paragraph style IDs', async ({ given, when, then, and }: AllureBddContext) => {
     let bodyXml: string;
     let stylesXml: Document;
     let nodes: DocumentViewNode[];
@@ -1048,6 +1048,7 @@ describe('document_view branch coverage', () => {
         `<w:style w:type="paragraph" w:styleId="Normal"><w:name w:val="Normal"/></w:style>` +
         `<w:style w:type="paragraph" w:styleId="Heading1"><w:name w:val="heading 1"/></w:style>` +
         `<w:style w:type="paragraph" w:styleId="Heading6"><w:name w:val="heading 6"/></w:style>` +
+        `<w:style w:type="paragraph" w:styleId="Heading9"><w:name w:val="heading 9"/></w:style>` +
         `<w:style w:type="paragraph" w:styleId="HeadingPara1">` +
           `<w:name w:val="Heading Para 1"/>` +
           `<w:basedOn w:val="Heading1"/>` +
@@ -1057,6 +1058,7 @@ describe('document_view branch coverage', () => {
       bodyXml =
         `<w:p><w:pPr><w:pStyle w:val="Heading1"/></w:pPr><w:r><w:t>Board Approval</w:t></w:r></w:p>` +
         `<w:p><w:pPr><w:pStyle w:val="Heading6"/></w:pPr><w:r><w:t>Minor Conditions</w:t></w:r></w:p>` +
+        `<w:p><w:pPr><w:pStyle w:val="Heading9"/></w:pPr><w:r><w:t>Deep Conditions</w:t></w:r></w:p>` +
         `<w:p><w:pPr><w:pStyle w:val="HeadingPara1"/></w:pPr><w:r><w:t>this inherited style stays body prose.</w:t></w:r></w:p>` +
         `<w:p><w:pPr><w:pStyle w:val="Normal"/></w:pPr><w:r><w:t>this is ordinary body text.</w:t></w:r></w:p>`;
     });
@@ -1065,20 +1067,21 @@ describe('document_view branch coverage', () => {
       nodes = buildTestNodes(bodyXml!, stylesXml!);
     });
 
-    await then('Heading1 and Heading6 paragraphs emit word_style headings with exact levels', async () => {
-      expect(nodes).toHaveLength(4);
+    await then('Heading1, Heading6, and Heading9 paragraphs emit exact levels', async () => {
+      expect(nodes).toHaveLength(5);
       expect(nodes[0]!.heading).toEqual({ text: 'Board Approval', source: 'word_style', level: 1 });
       expect(nodes[1]!.heading).toEqual({ text: 'Minor Conditions', source: 'word_style', level: 6 });
+      expect(nodes[2]!.heading).toEqual({ text: 'Deep Conditions', source: 'word_style', level: 9 });
     });
 
     await and('HeadingPara1 inheritance does not produce a heading object', async () => {
-      expect(nodes[2]!.heading).toBeUndefined();
-      expect(Object.prototype.hasOwnProperty.call(nodes[2]!, 'heading')).toBe(false);
+      expect(nodes[3]!.heading).toBeUndefined();
+      expect(Object.prototype.hasOwnProperty.call(nodes[3]!, 'heading')).toBe(false);
     });
 
     await and('body paragraphs omit the heading field entirely', async () => {
-      expect(nodes[3]!.heading).toBeUndefined();
-      expect(Object.prototype.hasOwnProperty.call(nodes[3]!, 'heading')).toBe(false);
+      expect(nodes[4]!.heading).toBeUndefined();
+      expect(Object.prototype.hasOwnProperty.call(nodes[4]!, 'heading')).toBe(false);
     });
   });
 
@@ -1227,7 +1230,7 @@ describe('document_view branch coverage', () => {
     });
   });
 
-  test('still promotes word_style headings inside table cells (Heading1..6 wins over the cell gate)', async ({ given, when, then }: AllureBddContext) => {
+  test('still promotes word_style headings inside table cells (Heading1..9 wins over the cell gate)', async ({ given, when, then }: AllureBddContext) => {
     let bodyXml: string;
     let stylesXml: Document;
     let nodes: DocumentViewNode[];

--- a/packages/docx-core/test-primitives/heading_provenance.traceability.test.ts
+++ b/packages/docx-core/test-primitives/heading_provenance.traceability.test.ts
@@ -1,0 +1,387 @@
+import { describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from './helpers/allure-test.js';
+import {
+  buildNodesForDocumentView,
+  type DocumentViewNode,
+} from '../src/primitives/document_view.js';
+import {
+  BUILT_IN_HEADING_ALIASES_V1,
+  getBuiltInHeadingLevel,
+} from '../src/primitives/heading_styles.js';
+import { parseXml } from '../src/primitives/xml.js';
+
+const TEST_FEATURE = 'add-deterministic-heading-provenance';
+const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const test = testAllure.epic('DOCX Primitives').withLabels({ feature: TEST_FEATURE });
+const outlineTest = test.conformance({
+  spec: 'ECMA-376',
+  edition: 5,
+  part: 1,
+  section: '17.3.1.20',
+});
+const numberingTest = test
+  .conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.9.6' })
+  .conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.9.22' });
+
+function wrapDocument(bodyXml: string): Document {
+  return parseXml(
+    `<w:document xmlns:w="${W_NS}"><w:body>${bodyXml}</w:body></w:document>`,
+  );
+}
+
+function wrapStyles(stylesXml: string): Document {
+  return parseXml(`<w:styles xmlns:w="${W_NS}">${stylesXml}</w:styles>`);
+}
+
+function wrapNumbering(numberingXml: string): Document {
+  return parseXml(`<w:numbering xmlns:w="${W_NS}">${numberingXml}</w:numbering>`);
+}
+
+function buildNodes(params: {
+  bodyXml: string;
+  stylesXml?: string;
+  numberingXml?: string;
+  inTable?: boolean;
+}): DocumentViewNode[] {
+  const document = wrapDocument(params.bodyXml);
+  const paragraphs = Array.from(document.getElementsByTagNameNS(W_NS, 'p')).map(
+    (p, index) => ({
+      id: `_bk_${index + 1}`,
+      p,
+      ...(params.inTable
+        ? {
+            tableContext: {
+              table_id: '_tbl_0',
+              table_index: 0,
+              row_index: 0,
+              col_index: index,
+              col_header: '',
+              total_rows: 1,
+              total_cols: 1,
+              is_header_row: false,
+              para_in_cell: 0,
+              cell_para_count: 1,
+            },
+          }
+        : {}),
+    }),
+  );
+  return buildNodesForDocumentView({
+    paragraphs,
+    stylesXml: params.stylesXml ? wrapStyles(params.stylesXml) : null,
+    numberingXml: params.numberingXml ? wrapNumbering(params.numberingXml) : null,
+    include_semantic_tags: false,
+    show_formatting: false,
+  }).nodes;
+}
+
+function paragraph(
+  text: string,
+  properties = '',
+): string {
+  return `<w:p>${properties ? `<w:pPr>${properties}</w:pPr>` : ''}<w:r><w:t>${text}</w:t></w:r></w:p>`;
+}
+
+const BODY_STYLE =
+  `<w:style w:type="paragraph" w:styleId="BodyText">` +
+  `<w:name w:val="Body Text"/></w:style>`;
+const HEADING_STYLES =
+  `<w:style w:type="paragraph" w:styleId="Heading1">` +
+  `<w:name w:val="heading 1"/></w:style>` +
+  `<w:style w:type="paragraph" w:styleId="Heading2">` +
+  `<w:name w:val="heading 2"/></w:style>`;
+
+describe('deterministic heading provenance', () => {
+  outlineTest.openspec('[HEAD-PROV-01] Effective outline level classifies a generic paragraph')(
+    'resolves direct and inherited outline levels with direct precedence',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      const stylesXml =
+        `<w:style w:type="paragraph" w:styleId="OutlineBase">` +
+        `<w:name w:val="Outline Base"/><w:pPr><w:outlineLvl w:val="4"/></w:pPr>` +
+        `</w:style>` +
+        `<w:style w:type="paragraph" w:styleId="OutlineChild">` +
+        `<w:name w:val="Outline Child"/><w:basedOn w:val="OutlineBase"/></w:style>`;
+      const bodyXml =
+        paragraph(
+          'Direct outline heading',
+          `<w:pStyle w:val="OutlineChild"/><w:outlineLvl w:val="1"/>`,
+        ) +
+        paragraph('Inherited outline heading', `<w:pStyle w:val="OutlineChild"/>`);
+
+      await given('a style-chain outline level and a conflicting direct value', () => {});
+      const nodes = buildNodes({ bodyXml, stylesXml });
+      await when('the document view is built', () => {});
+
+      await then('the direct value maps from OOXML 1 to public heading level 2', () => {
+        expect(nodes[0]!.heading).toEqual({
+          text: 'Direct outline heading',
+          source: 'outline_level',
+          level: 2,
+        });
+      });
+      await and('the inherited value is used when no direct value exists', () => {
+        expect(nodes[1]!.heading).toEqual({
+          text: 'Inherited outline heading',
+          source: 'outline_level',
+          level: 5,
+        });
+      });
+    },
+  );
+
+  outlineTest.openspec('[HEAD-PROV-02] Body-text and malformed outline values do not classify')(
+    'ignores body-text, missing, malformed, negative, and out-of-range outline values',
+    async ({ given, when, then }: AllureBddContext) => {
+      const values = ['9', null, 'not-a-number', '-1', '10'];
+      const bodyXml = values
+        .map((value, index) =>
+          paragraph(
+            `ordinary body paragraph ${index}`,
+            value === null ? '' : `<w:outlineLvl w:val="${value}"/>`,
+          ),
+        )
+        .join('');
+
+      await given('paragraphs carrying every non-heading outline-level shape', () => {});
+      const nodes = buildNodes({ bodyXml });
+      await when('the document view is built without other heading evidence', () => {});
+
+      await then('none receives deterministic or heuristic heading metadata', () => {
+        expect(nodes).toHaveLength(values.length);
+        expect(nodes.every((node) => node.heading === undefined)).toBe(true);
+      });
+    },
+  );
+
+  numberingTest.openspec('[HEAD-PROV-03] Active numbering-level style association classifies')(
+    'uses only the active numbering level and fails closed on missing definitions',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      const numberingXml =
+        `<w:abstractNum w:abstractNumId="1">` +
+        `<w:lvl w:ilvl="0"><w:numFmt w:val="decimal"/><w:pStyle w:val="BodyText"/>` +
+        `<w:lvlText w:val="%1."/></w:lvl>` +
+        `<w:lvl w:ilvl="1"><w:numFmt w:val="decimal"/><w:pStyle w:val="Heading2"/>` +
+        `<w:lvlText w:val="%2."/></w:lvl>` +
+        `</w:abstractNum>` +
+        `<w:num w:numId="10"><w:abstractNumId w:val="1"/></w:num>`;
+      const bodyXml =
+        paragraph(
+          'Numbered Terms',
+          `<w:numPr><w:ilvl w:val="1"/><w:numId w:val="10"/></w:numPr>`,
+        ) +
+        paragraph(
+          'ordinary numbered body',
+          `<w:numPr><w:ilvl w:val="0"/><w:numId w:val="10"/></w:numPr>`,
+        ) +
+        paragraph(
+          'missing numbering definition body',
+          `<w:numPr><w:ilvl w:val="1"/><w:numId w:val="999"/></w:numPr>`,
+        );
+
+      await given('one active heading-associated level, another level, and a missing numId', () => {});
+      const nodes = buildNodes({
+        bodyXml,
+        stylesXml: BODY_STYLE + HEADING_STYLES,
+        numberingXml,
+      });
+      await when('the document view is built', () => {});
+
+      await then('the active Heading 2 association classifies with list provenance', () => {
+        expect(nodes[0]!.heading).toEqual({
+          text: 'Numbered Terms',
+          source: 'list_metadata',
+          level: 2,
+        });
+      });
+      await and('an unrelated level and missing definition do not classify', () => {
+        expect(nodes[1]!.heading).toBeUndefined();
+        expect(nodes[2]!.heading).toBeUndefined();
+      });
+    },
+  );
+
+  test.openspec('[HEAD-PROV-04] Built-in heading style wins conflicting metadata')(
+    'applies word-style then list-metadata then outline-level precedence',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      const numberingXml =
+        `<w:abstractNum w:abstractNumId="2">` +
+        `<w:lvl w:ilvl="0"><w:pStyle w:val="Heading2"/></w:lvl>` +
+        `</w:abstractNum>` +
+        `<w:num w:numId="20"><w:abstractNumId w:val="2"/></w:num>`;
+      const list = `<w:numPr><w:ilvl w:val="0"/><w:numId w:val="20"/></w:numPr>`;
+      const bodyXml =
+        paragraph(
+          'Style Wins',
+          `<w:pStyle w:val="Heading1"/>${list}<w:outlineLvl w:val="2"/>`,
+        ) +
+        paragraph(
+          'List Wins',
+          `<w:pStyle w:val="BodyText"/>${list}<w:outlineLvl w:val="0"/>`,
+        );
+
+      await given('paragraphs with conflicting deterministic evidence', () => {});
+      const nodes = buildNodes({
+        bodyXml,
+        stylesXml: BODY_STYLE + HEADING_STYLES,
+        numberingXml,
+      });
+      await when('the document view is built', () => {});
+
+      await then('the built-in paragraph style wins list and outline metadata', () => {
+        expect(nodes[0]!.heading).toEqual({
+          text: 'Style Wins',
+          source: 'word_style',
+          level: 1,
+        });
+      });
+      await and('list metadata wins outline metadata when the style is not a heading', () => {
+        expect(nodes[1]!.heading).toEqual({
+          text: 'List Wins',
+          source: 'list_metadata',
+          level: 2,
+        });
+      });
+    },
+  );
+
+  test.openspec('[HEAD-PROV-05] Localized built-in name maps to its heading level')(
+    'recognizes the French built-in heading display name',
+    async ({ given, when, then }: AllureBddContext) => {
+      await given('a custom style id whose exact display name is Titre 1', () => {});
+      const nodes = buildNodes({
+        bodyXml: paragraph('Objet', `<w:pStyle w:val="FrenchHeading"/>`),
+        stylesXml:
+          `<w:style w:type="paragraph" w:styleId="FrenchHeading">` +
+          `<w:name w:val="Titre 1"/></w:style>`,
+      });
+      await when('the document view is built', () => {});
+
+      await then('the paragraph is a level-1 word-style heading', () => {
+        expect(nodes[0]!.heading).toEqual({
+          text: 'Objet',
+          source: 'word_style',
+          level: 1,
+        });
+      });
+    },
+  );
+
+  test.openspec('[HEAD-PROV-06] TOC style is not a built-in heading alias')(
+    'does not classify TOC styles as headings',
+    async ({ given, when, then }: AllureBddContext) => {
+      await given('a TOC 1 paragraph style with no other heading evidence', () => {});
+      const nodes = buildNodes({
+        bodyXml: paragraph(
+          'ordinary table of contents entry body',
+          `<w:pStyle w:val="TOC1"/>`,
+        ),
+        stylesXml:
+          `<w:style w:type="paragraph" w:styleId="TOC1">` +
+          `<w:name w:val="TOC 1"/></w:style>`,
+      });
+      await when('the document view is built', () => {});
+
+      await then('the paragraph has no deterministic heading', () => {
+        expect(nodes[0]!.heading).toBeUndefined();
+      });
+    },
+  );
+
+  test.openspec('[HEAD-PROV-07] Nested deterministic headings retain order and levels')(
+    'retains 1-2-1 order across style, list, and outline provenance',
+    async ({ given, when, then }: AllureBddContext) => {
+      const numberingXml =
+        `<w:abstractNum w:abstractNumId="3">` +
+        `<w:lvl w:ilvl="0"><w:pStyle w:val="Heading2"/></w:lvl>` +
+        `</w:abstractNum>` +
+        `<w:num w:numId="30"><w:abstractNumId w:val="3"/></w:num>`;
+      const bodyXml =
+        paragraph('First', `<w:pStyle w:val="Heading1"/>`) +
+        paragraph(
+          'Second',
+          `<w:numPr><w:ilvl w:val="0"/><w:numId w:val="30"/></w:numPr>`,
+        ) +
+        paragraph('Third', `<w:outlineLvl w:val="0"/>`);
+
+      await given('three deterministic headings from distinct sources', () => {});
+      const nodes = buildNodes({
+        bodyXml,
+        stylesXml: HEADING_STYLES,
+        numberingXml,
+      });
+      await when('the document view is built', () => {});
+
+      await then('document order and levels remain exactly 1, 2, 1', () => {
+        expect(nodes.map((node) => node.heading?.level)).toEqual([1, 2, 1]);
+        expect(nodes.map((node) => node.heading?.source)).toEqual([
+          'word_style',
+          'list_metadata',
+          'outline_level',
+        ]);
+      });
+    },
+  );
+
+  test('the versioned alias table and literal style IDs are exact and bounded', async ({
+    given,
+    when,
+    then,
+    and,
+  }: AllureBddContext) => {
+    await given('every v1 localized alias and every literal Heading1 through Heading9 id', () => {});
+    const aliasLevels = BUILT_IN_HEADING_ALIASES_V1.map(({ name }) =>
+      getBuiltInHeadingLevel('CustomStyle', `  ${name.replace(' ', '   ')}  `),
+    );
+    const idLevels = Array.from({ length: 9 }, (_, index) =>
+      getBuiltInHeadingLevel(`Heading${index + 1}`, null),
+    );
+    await when('the bounded lookup normalizes Unicode whitespace but performs no fuzzy match', () => {});
+
+    await then('every alias and literal id maps to its declared level', () => {
+      expect(aliasLevels).toEqual(
+        BUILT_IN_HEADING_ALIASES_V1.map(({ level }) => level),
+      );
+      expect(idLevels).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    });
+    await and('TOC and near-miss names remain outside the alias table', () => {
+      expect(getBuiltInHeadingLevel('TOC1', 'TOC 1')).toBeNull();
+      expect(getBuiltInHeadingLevel('Custom', 'Headingish 1')).toBeNull();
+    });
+  });
+
+  test('explicit deterministic structure remains visible inside table cells', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    const numberingXml =
+      `<w:abstractNum w:abstractNumId="4">` +
+      `<w:lvl w:ilvl="0"><w:pStyle w:val="Heading2"/></w:lvl>` +
+      `</w:abstractNum>` +
+      `<w:num w:numId="40"><w:abstractNumId w:val="4"/></w:num>`;
+    const bodyXml =
+      paragraph('Styled Cell', `<w:pStyle w:val="Heading1"/>`) +
+      paragraph(
+        'Numbered Cell',
+        `<w:numPr><w:ilvl w:val="0"/><w:numId w:val="40"/></w:numPr>`,
+      ) +
+      paragraph('Outlined Cell', `<w:outlineLvl w:val="2"/>`);
+
+    await given('style, list, and outline headings inside table cells', () => {});
+    const nodes = buildNodes({
+      bodyXml,
+      stylesXml: HEADING_STYLES,
+      numberingXml,
+      inTable: true,
+    });
+    await when('the document view is built', () => {});
+
+    await then('all deterministic sources remain headings in their cells', () => {
+      expect(nodes.map((node) => node.heading?.source)).toEqual([
+        'word_style',
+        'list_metadata',
+        'outline_level',
+      ]);
+    });
+  });
+});

--- a/packages/docx-mcp/docs/tool-reference.generated.md
+++ b/packages/docx-mcp/docs/tool-reference.generated.md
@@ -28,7 +28,7 @@ Read document content (DOCX, ODT, or Google Doc). Output is token-limited (~14k 
 
 ## `get_document_outline`
 
-Get a compact structural map of a document's headings (DOCX only). Returns one entry per heading paragraph with its text, outline level, source, and stable `_bk_*` paragraph_id — so an agent can read the cheap outline first, then scope a targeted read_file/replace_text to the right section instead of scanning the whole body. Style-based (Word HeadingN) headings only by default; set include_heuristic_headings=true to also include heuristic titles/run-in headers. Read-only.
+Get a compact structural map of a document's headings (DOCX only). Each entry is `{paragraph_id, text, level, source}`. Deterministic sources are `word_style`, `list_metadata`, and `outline_level`, selected in that precedence order and included by default. Heuristic sources are `run_in_header`, `title_with_period`, `title_with_colon`, `title_caps_centered`, and `title_bare`; set include_heuristic_headings=true to include them. JSON preserves levels 1-9; Markdown clamps visual ATX depth to 6. Read-only.
 
 - readOnly: `true`
 - destructive: `false`
@@ -37,7 +37,7 @@ Get a compact structural map of a document's headings (DOCX only). Returns one e
 | --- | --- | --- | --- |
 | `file_path` | `string` | no | Path to the DOCX file. |
 | `format` | `enum("json", "markdown")` | no | Output format: 'json' (default, structured outline array) or 'markdown' (indented ATX outline under `content`). |
-| `include_heuristic_headings` | `boolean` | no | When true, also include heuristically-detected headings (manual title / run-in / centered-caps) alongside Word HeadingN styles. Default: false (style-based only). |
+| `include_heuristic_headings` | `boolean` | no | When true, also include heuristic title/run-in/centered-caps headings alongside deterministic word_style, list_metadata, and outline_level headings. Default: false (all deterministic sources only). |
 
 ## `grep`
 

--- a/packages/docx-mcp/src/tool_catalog.ts
+++ b/packages/docx-mcp/src/tool_catalog.ts
@@ -108,7 +108,7 @@ export const SAFE_DOCX_TOOL_CATALOG = [
     name: 'get_document_outline',
     surface: 'internal',
     description:
-      'Get a compact structural map of a document\'s headings (DOCX only). Returns one entry per heading paragraph with its text, outline level, source, and stable `_bk_*` paragraph_id — so an agent can read the cheap outline first, then scope a targeted read_file/replace_text to the right section instead of scanning the whole body. Style-based (Word HeadingN) headings only by default; set include_heuristic_headings=true to also include heuristic titles/run-in headers. Read-only.',
+      'Get a compact structural map of a document\'s headings (DOCX only). Each entry is `{paragraph_id, text, level, source}`. Deterministic sources are `word_style`, `list_metadata`, and `outline_level`, selected in that precedence order and included by default. Heuristic sources are `run_in_header`, `title_with_period`, `title_with_colon`, `title_caps_centered`, and `title_bare`; set include_heuristic_headings=true to include them. JSON preserves levels 1-9; Markdown clamps visual ATX depth to 6. Read-only.',
     input: z.object({
       ...FILE_FIELD_OPTIONAL_DOCX_ONLY,
       format: z
@@ -118,7 +118,7 @@ export const SAFE_DOCX_TOOL_CATALOG = [
       include_heuristic_headings: z
         .boolean()
         .optional()
-        .describe('When true, also include heuristically-detected headings (manual title / run-in / centered-caps) alongside Word HeadingN styles. Default: false (style-based only).'),
+        .describe('When true, also include heuristic title/run-in/centered-caps headings alongside deterministic word_style, list_metadata, and outline_level headings. Default: false (all deterministic sources only).'),
     }),
     annotations: { readOnlyHint: true, destructiveHint: false },
   },

--- a/packages/docx-mcp/src/tools/get_document_outline.heading_provenance.test.ts
+++ b/packages/docx-mcp/src/tools/get_document_outline.heading_provenance.test.ts
@@ -1,0 +1,188 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { buildDocxFromParts } from '@usejunior/docx-core';
+import { describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import {
+  assertSuccess,
+  createTestSessionManager,
+  createTrackedTempDir,
+  registerCleanup,
+} from '../testing/session-test-utils.js';
+import { getDocumentOutline } from './get_document_outline.js';
+
+const TEST_FEATURE = 'add-deterministic-heading-provenance';
+const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const test = testAllure.epic('Document Editing').withLabels({ feature: TEST_FEATURE });
+
+type OutlineEntry = {
+  paragraph_id: string;
+  text: string;
+  level: number | null;
+  source: string;
+};
+
+function outlineEntries(value: unknown): OutlineEntry[] {
+  return ((value as { outline?: OutlineEntry[] }).outline ?? []);
+}
+
+async function writeDocx(params: {
+  bodyXml: string;
+  stylesXml?: string;
+  numberingXml?: string;
+  filename: string;
+}): Promise<string> {
+  const tmpDir = await createTrackedTempDir('heading-provenance-outline-');
+  const filePath = path.join(tmpDir, params.filename);
+  const buffer = await buildDocxFromParts(params);
+  await fs.writeFile(filePath, new Uint8Array(buffer));
+  return filePath;
+}
+
+const STYLES_XML =
+  `<w:styles xmlns:w="${W_NS}">` +
+  `<w:style w:type="paragraph" w:styleId="Heading1"><w:name w:val="Heading 1"/></w:style>` +
+  `<w:style w:type="paragraph" w:styleId="Heading2"><w:name w:val="Heading 2"/></w:style>` +
+  `<w:style w:type="paragraph" w:styleId="Heading9"><w:name w:val="Heading 9"/></w:style>` +
+  `</w:styles>`;
+
+const NUMBERING_XML =
+  `<w:numbering xmlns:w="${W_NS}">` +
+  `<w:abstractNum w:abstractNumId="1">` +
+  `<w:lvl w:ilvl="0"><w:pStyle w:val="Heading2"/></w:lvl>` +
+  `</w:abstractNum>` +
+  `<w:num w:numId="10"><w:abstractNumId w:val="1"/></w:num>` +
+  `</w:numbering>`;
+
+describe('get_document_outline deterministic heading provenance', () => {
+  registerCleanup();
+
+  test.openspec('[HEAD-OUTLINE-01] Default outline includes mixed deterministic sources')(
+    'includes style, active list metadata, and outline-property headings by default',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      const manager = createTestSessionManager();
+      const filePath = await writeDocx({
+        filename: 'mixed-deterministic.docx',
+        stylesXml: STYLES_XML,
+        numberingXml: NUMBERING_XML,
+        bodyXml:
+          `<w:p><w:pPr><w:pStyle w:val="Heading1"/></w:pPr><w:r><w:t>Styled</w:t></w:r></w:p>` +
+          `<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="10"/></w:numPr>` +
+          `</w:pPr><w:r><w:t>Numbered</w:t></w:r></w:p>` +
+          `<w:p><w:pPr><w:outlineLvl w:val="2"/></w:pPr><w:r><w:t>Outlined</w:t></w:r></w:p>`,
+      });
+
+      await given('one heading from each deterministic source', () => {});
+      const result = await getDocumentOutline(manager, { file_path: filePath });
+      assertSuccess(result, 'get_document_outline');
+      const outline = outlineEntries(result);
+      await when('the default JSON outline is requested', () => {});
+
+      await then('all three entries retain document order, source, level, and text', () => {
+        expect(outline.map(({ text, level, source }) => ({ text, level, source }))).toEqual([
+          { text: 'Styled', level: 1, source: 'word_style' },
+          { text: 'Numbered', level: 2, source: 'list_metadata' },
+          { text: 'Outlined', level: 3, source: 'outline_level' },
+        ]);
+      });
+      await and('every entry exposes a stable paragraph id', () => {
+        expect(outline.every(({ paragraph_id }) => paragraph_id.startsWith('_bk_'))).toBe(true);
+      });
+    },
+  );
+
+  test.openspec('[HEAD-OUTLINE-02] Heuristic boundary remains opt-in')(
+    'keeps heuristic headings opt-in while deterministic headings remain default',
+    async ({ given, when, then }: AllureBddContext) => {
+      const manager = createTestSessionManager();
+      const filePath = await writeDocx({
+        filename: 'heuristic-boundary.docx',
+        stylesXml: STYLES_XML,
+        bodyXml:
+          `<w:p><w:pPr><w:pStyle w:val="Heading1"/></w:pPr><w:r><w:t>Deterministic</w:t></w:r></w:p>` +
+          `<w:p><w:r><w:t>Heuristic Title</w:t></w:r></w:p>`,
+      });
+
+      await given('one deterministic and one short bare heuristic heading', () => {});
+      const defaults = await getDocumentOutline(manager, { file_path: filePath });
+      const optedIn = await getDocumentOutline(manager, {
+        file_path: filePath,
+        include_heuristic_headings: true,
+      });
+      assertSuccess(defaults, 'default get_document_outline');
+      assertSuccess(optedIn, 'opted-in get_document_outline');
+      await when('the outline is requested without and with heuristic opt-in', () => {});
+
+      await then('default returns only deterministic and opt-in adds the existing heuristic source', () => {
+        expect(outlineEntries(defaults).map(({ source }) => source)).toEqual(['word_style']);
+        expect(outlineEntries(optedIn).map(({ source }) => source)).toEqual([
+          'word_style',
+          'title_bare',
+        ]);
+      });
+    },
+  );
+
+  test.openspec('[HEAD-OUTLINE-03] Structured levels exceed Markdown syntax safely')(
+    'preserves level 9 in JSON and clamps Markdown to ATX depth 6',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      const manager = createTestSessionManager();
+      const filePath = await writeDocx({
+        filename: 'deep-heading.docx',
+        stylesXml: STYLES_XML,
+        bodyXml:
+          `<w:p><w:pPr><w:pStyle w:val="Heading9"/></w:pPr>` +
+          `<w:r><w:t>Deep Heading</w:t></w:r></w:p>`,
+      });
+
+      await given('a deterministic Heading 9 paragraph', () => {});
+      const json = await getDocumentOutline(manager, { file_path: filePath });
+      const markdown = await getDocumentOutline(manager, {
+        file_path: filePath,
+        format: 'markdown',
+      });
+      assertSuccess(json, 'JSON get_document_outline');
+      assertSuccess(markdown, 'Markdown get_document_outline');
+      await when('JSON and Markdown projections are requested', () => {});
+
+      await then('structured JSON retains the exact level 9', () => {
+        expect(outlineEntries(json)[0]?.level).toBe(9);
+      });
+      await and('Markdown uses the deepest valid ATX syntax without altering JSON', () => {
+        expect((markdown as { content?: string }).content).toBe('###### Deep Heading');
+      });
+    },
+  );
+
+  test.openspec('[HEAD-OUTLINE-04] Generated reference lists the complete taxonomy')(
+    'documents all heading sources, deterministic defaults, precedence, and Markdown clamp',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      const referencePath = path.resolve(
+        import.meta.dirname,
+        '../../docs/tool-reference.generated.md',
+      );
+      await given('the generated MCP tool reference', () => {});
+      const reference = await fs.readFile(referencePath, 'utf8');
+      await when('the get_document_outline contract is inspected', () => {});
+
+      await then('it lists every deterministic and heuristic source value', () => {
+        for (const source of [
+          'word_style',
+          'list_metadata',
+          'outline_level',
+          'run_in_header',
+          'title_with_period',
+          'title_with_colon',
+          'title_caps_centered',
+          'title_bare',
+        ]) {
+          expect(reference).toContain(source);
+        }
+      });
+      await and('it states precedence, deterministic defaults, and the ATX clamp', () => {
+        expect(reference).toContain('selected in that precedence order and included by default');
+        expect(reference).toContain('Markdown clamps visual ATX depth to 6');
+      });
+    },
+  );
+});

--- a/packages/docx-mcp/src/tools/get_document_outline.ts
+++ b/packages/docx-mcp/src/tools/get_document_outline.ts
@@ -2,7 +2,11 @@ import { SessionManager } from '../session/manager.js';
 import { errorMessage } from '../error_utils.js';
 import { ok, err, type ToolResponse } from './types.js';
 import { resolveSessionForTool, mergeSessionResolutionMetadata } from './session_resolution.js';
-import type { DocumentViewNode, HeadingSource } from '@usejunior/docx-core';
+import {
+  isDeterministicHeadingSource,
+  type DocumentViewNode,
+  type HeadingSource,
+} from '@usejunior/docx-core';
 
 type OutlineEntry = {
   paragraph_id: string;
@@ -12,10 +16,9 @@ type OutlineEntry = {
 };
 
 /**
- * Projects the document view into outline entries. Word `HeadingN` styles carry
- * a numeric `level`; heuristic sources (title/run-in/centered-caps) have a null
- * level and are only emitted when explicitly requested, so the default outline
- * stays low-noise on documents that mix manual emphasis with real structure.
+ * Projects the document view into outline entries. Deterministic style,
+ * numbering, and outline-property sources are included by default; heuristic
+ * sources remain opt-in so the default outline stays low-noise.
  */
 export function projectOutline(
   nodes: readonly DocumentViewNode[],
@@ -25,7 +28,7 @@ export function projectOutline(
   for (const node of nodes) {
     const heading = node.heading;
     if (!heading) continue;
-    if (!includeHeuristic && heading.source !== 'word_style') continue;
+    if (!includeHeuristic && !isDeterministicHeadingSource(heading.source)) continue;
     entries.push({
       paragraph_id: node.id,
       text: heading.text,

--- a/packages/odf-core/src/convert/convert_basics.test.ts
+++ b/packages/odf-core/src/convert/convert_basics.test.ts
@@ -59,11 +59,12 @@ describe('convertDocxToOdt — package validity, text, headings, runs', () => {
     expect(lossiness.some((e) => e.construct === 'unsurfaced-paragraphs-dropped')).toBe(false);
   });
 
-  it('[CONV-03] Word-style headings become text:h with the mapped outline level; plain text stays text:p', async () => {
+  it('[CONV-03] supported Word headings become text:h; deeper and manually labeled paragraphs stay text:p', async () => {
     const bodyXml =
       styledP('Heading1', 'Top heading') +
       styledP('Heading2', 'Sub heading') +
       styledP('Heading9', 'Not a real heading level') +
+      styledP('Heading3', '(i) Manually labeled legal paragraph') +
       p('Body paragraph.');
     const docx = await buildDocxFromParts({ bodyXml });
     const { odt } = await convertDocxToOdt(docx);
@@ -76,9 +77,10 @@ describe('convertDocxToOdt — package validity, text, headings, runs', () => {
       'Heading_20_1',
       'Heading_20_2',
     ]);
-    // The non-Heading[1-6] style and the body paragraph both stay text:p.
+    // The non-Heading[1-6] style, manual legal label, and body paragraph stay text:p.
     const paragraphTexts = Array.from(doc.getElementsByTagNameNS(ODF_NS.TEXT, 'p')).map((el) => el.textContent);
     expect(paragraphTexts).toContain('Not a real heading level');
+    expect(paragraphTexts).toContain('(i) Manually labeled legal paragraph');
     expect(paragraphTexts).toContain('Body paragraph.');
   });
 

--- a/packages/odf-core/src/convert/docx_to_odt.ts
+++ b/packages/odf-core/src/convert/docx_to_odt.ts
@@ -39,9 +39,24 @@ import {
 } from './package.js';
 import { LossinessCollector, type ConvertDocxToOdtOptions, type ConvertDocxToOdtResult } from './types.js';
 
-/** A heading is structural only when Word's style said so — heuristic headings stay paragraphs. */
+/**
+ * ODF's built-in heading styles are bounded to levels 1–6 in the package we emit.
+ * Manual/legal labels take precedence over heading structure so their visible prefix is
+ * preserved as literal text rather than disappearing into a structural `text:h`.
+ */
 function isStructuralHeading(node: DocumentViewNode): boolean {
-  return node.heading?.source === 'word_style' && typeof node.heading.level === 'number';
+  const level = node.heading?.level;
+  const hasManualLabel =
+    node.list_metadata.list_level >= 0 &&
+    !node.list_metadata.is_auto_numbered &&
+    node.list_metadata.label_string.trim() !== '';
+  return (
+    node.heading?.source === 'word_style' &&
+    typeof level === 'number' &&
+    level >= 1 &&
+    level <= 6 &&
+    !hasManualLabel
+  );
 }
 
 /** True when the paragraph element sits inside a table cell (any depth up to the body). */
@@ -186,7 +201,7 @@ export async function convertDocxToOdt(
     // ── Word-styled headings ──
     if (isStructuralHeading(node)) {
       listBuilder = null;
-      const level = Math.min(6, Math.max(1, node.heading!.level as number));
+      const level = node.heading!.level as number;
       const h = doc.createElementNS(ODF_NS.TEXT, 'text:h');
       h.setAttributeNS(ODF_NS.TEXT, 'text:outline-level', String(level));
       h.setAttributeNS(ODF_NS.TEXT, 'text:style-name', paragraphStyles.styleFor(`Heading_20_${level}`, node));

--- a/spec-compliance/CONFORMANCE.md
+++ b/spec-compliance/CONFORMANCE.md
@@ -31,6 +31,7 @@ Allure labels via `testAllure.conformance({…})`; source code carries
 | `ECMA-PART1-17-6-13` | w:pgSz page size emission | 5 | 1 | 17.6.13 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:pgSz` | — |
 | `ECMA-PART1-17-6-11` | w:pgMar page margin emission | 5 | 1 | 17.6.11 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:pgMar` | — |
 | `ECMA-PART1-17-3-1-26` | w:pPr child-element ordering | 5 | 1 | 17.3.1.26 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:pPr` | packages/docx-core/src/generation/ordering.ts; packages/docx-core/src/generation/emit/properties.ts; packages/docx-core/src/generation/ordering-schema.test.ts; packages/docx-core/src/generation/generation-styles-formatting.test.ts |
+| `ECMA-PART1-17-3-1-20` | w:outlineLvl paragraph outline level | 5 | 1 | 17.3.1.20 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:outlineLvl` | packages/docx-core/src/primitives/styles.ts; packages/docx-core/test-primitives/heading_provenance.traceability.test.ts |
 | `ECMA-PART1-17-3-2-28` | w:rPr direct-property uniqueness | 5 | 1 | 17.3.2.28 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:rPr` | packages/docx-core/src/generation/ordering.ts; packages/docx-core/src/generation/emit/properties.ts; packages/docx-core/src/generation/ordering-schema.test.ts; packages/docx-core/src/generation/generation-styles-formatting.test.ts |
 | `ECMA-PART1-17-7-4-18` | w:styles style-definitions part emission | 5 | 1 | 17.7.4.18 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:styles` | — |
 | `ECMA-PART1-17-7-4-17` | w:style style-definition emission | 5 | 1 | 17.7.4.17 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:style` | — |
@@ -75,6 +76,7 @@ Allure labels via `testAllure.conformance({…})`; source code carries
 | `ECMA-PART1-17-9-18` | w:numId numbering instance reference | 5 | 1 | 17.9.18 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:numId` | — |
 | `ECMA-PART1-17-9-3` | w:ilvl numbering level reference | 5 | 1 | 17.9.3 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:ilvl` | — |
 | `ECMA-PART1-17-9-6` | w:lvl numbering level definition | 5 | 1 | 17.9.6 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:lvl` | — |
+| `ECMA-PART1-17-9-22` | w:pStyle numbering-level paragraph style | 5 | 1 | 17.9.22 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:pStyle` | packages/docx-core/src/primitives/numbering.ts; packages/docx-core/test-primitives/heading_provenance.traceability.test.ts |
 | `ECMA-PART1-17-9-17` | w:numFmt numbering format | 5 | 1 | 17.9.17 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:numFmt` | — |
 | `ECMA-PART1-17-9-11` | w:lvlText numbering level text | 5 | 1 | 17.9.11 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:lvlText` | — |
 | `ECMA-PART1-17-9-25` | w:start numbering level starting value | 5 | 1 | 17.9.25 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:start` | — |
@@ -377,6 +379,19 @@ subset of that sequence as `PPR_ORDER` and routes every paragraph
 property through `appendInOrder`, which throws on any property name
 missing from the table so new properties force a conscious ordering
 decision.
+
+### ECMA-PART1-17-3-1-20 — w:outlineLvl paragraph outline level
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.3.1.20
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:outlineLvl`
+- **Verified by:** packages/docx-core/src/primitives/styles.ts; packages/docx-core/test-primitives/heading_provenance.traceability.test.ts
+
+`w:outlineLvl` records a paragraph's outline level. Values 0 through 8
+correspond to heading levels 1 through 9, while value 9 marks body text.
+Document-view formatting resolves the direct paragraph property before the
+paragraph style chain and ignores malformed or out-of-range values.
 
 ### ECMA-PART1-17-3-2-28 — w:rPr direct-property uniqueness
 
@@ -910,6 +925,19 @@ in the bound definition.
 Level definitions follow the CT_Lvl child sequence (start, numFmt, suff,
 lvlText, lvlJc, pPr, rPr); level indents emit through `w:pPr`/`w:ind` and
 level run properties reuse the shared rPr builder.
+
+### ECMA-PART1-17-9-22 — w:pStyle numbering-level paragraph style
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.9.22
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:pStyle`
+- **Verified by:** packages/docx-core/src/primitives/numbering.ts; packages/docx-core/test-primitives/heading_provenance.traceability.test.ts
+
+An optional `w:pStyle` on `w:lvl` associates that exact numbering level with
+a paragraph style. The numbering model retains the association and exposes a
+read-only active-level lookup so heading classification never consults an
+unrelated level or mutates list counters.
 
 ### ECMA-PART1-17-9-17 — w:numFmt numbering format
 

--- a/spec-compliance/registry/ecma-376.md
+++ b/spec-compliance/registry/ecma-376.md
@@ -336,6 +336,22 @@ property through `appendInOrder`, which throws on any property name
 missing from the table so new properties force a conscious ordering
 decision.
 
+## [ECMA-PART1-17-3-1-20] w:outlineLvl paragraph outline level
+
+```yaml
+edition: 5
+part: 1
+section: "17.3.1.20"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:outlineLvl
+verifiedBy: packages/docx-core/src/primitives/styles.ts; packages/docx-core/test-primitives/heading_provenance.traceability.test.ts
+```
+
+`w:outlineLvl` records a paragraph's outline level. Values 0 through 8
+correspond to heading levels 1 through 9, while value 9 marks body text.
+Document-view formatting resolves the direct paragraph property before the
+paragraph style chain and ignores malformed or out-of-range values.
+
 ## [ECMA-PART1-17-3-2-28] w:rPr direct-property uniqueness
 
 ```yaml
@@ -1040,6 +1056,22 @@ verifiedBy:
 Level definitions follow the CT_Lvl child sequence (start, numFmt, suff,
 lvlText, lvlJc, pPr, rPr); level indents emit through `w:pPr`/`w:ind` and
 level run properties reuse the shared rPr builder.
+
+## [ECMA-PART1-17-9-22] w:pStyle numbering-level paragraph style
+
+```yaml
+edition: 5
+part: 1
+section: "17.9.22"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:pStyle
+verifiedBy: packages/docx-core/src/primitives/numbering.ts; packages/docx-core/test-primitives/heading_provenance.traceability.test.ts
+```
+
+An optional `w:pStyle` on `w:lvl` associates that exact numbering level with
+a paragraph style. The numbering model retains the association and exposes a
+read-only active-level lookup so heading classification never consults an
+unrelated level or mutates list counters.
 
 ## [ECMA-PART1-17-9-17] w:numFmt numbering format
 


### PR DESCRIPTION
## Summary

- resolve deterministic heading intent from built-in paragraph styles, active numbering-level `w:pStyle`, and effective `w:outlineLvl`
- preserve fixed precedence `word_style` → `list_metadata` → `outline_level` before existing heuristics
- recognize bounded Heading 1–9 aliases across English, French, German, Spanish, and Japanese
- include all deterministic sources in `get_document_outline` by default while keeping heuristic headings opt-in
- preserve structured levels 1–9 and clamp Markdown rendering only to ATX depth 6
- document the complete source taxonomy and precedence in generated MCP reference material

## Why

SafeDocX's long-term consumers are agents. They need a stable, authored structural map of a DOCX rather than UI-oriented title guesses. This implementation exposes explicit document intent through the existing API without adding a graphical interface or changing existing heuristic source values.

## Validation

- OpenSpec strict validation: 11/11 scenarios mapped (7 core, 4 MCP)
- focused core heading suites: 41/41 passed
- focused MCP outline suites: 7/7 passed
- core and MCP builds and TypeScript lint passed
- `npm run check:spec-coverage`
- `npm run check:tool-docs`
- `npm run check:conformance-citations`
- `npm run check:conformance-doc`

Ref: #206