### PR TITLE
docs(openspec): propose complex field rebuild preservation

### DIFF
--- a/openspec/changes/preserve-main-story-complex-fields-on-rebuild/design.md
+++ b/openspec/changes/preserve-main-story-complex-fields-on-rebuild/design.md
@@ -1,0 +1,147 @@
+## Context
+
+The comparison atomizer recognizes complete complex fields and collapses their
+constituent atoms so the differ can treat the visible cached result coherently.
+The rebuild reconstructor can expand those atoms, and the pipeline validates
+field structure plus accept/reject projections. Expansion, however, is a modeled
+reconstruction: it does not promise to retain the exact authored run sequence,
+properties, contained range markers, or extension context of an unchanged field.
+
+The opaque SDT work established useful principles—counterpart binding,
+paragraph/container ownership, one-owner emission, namespace validation, and
+fail-closed ambiguity—but a complex field is an ordered sibling interval rather
+than one XML element. Reusing the safety rules does not require pretending the
+field is an `w:sdt` node.
+
+## Goals / Non-Goals
+
+- Goals: preserve an unchanged supported main-story complex field as authored
+  while edits before or after it remain tracked.
+- Goals: make preservation structural and falsifiable through field validation,
+  accept/reject projections, and exact/canonical subtree checks.
+- Goals: land neutral evidence before implementation and keep evidence scopes
+  honest in the capability projection.
+- Non-Goals: edit field instructions/results, evaluate fields, support arbitrary
+  field types or stories, or broaden the general opaque-passthrough substrate
+  beyond what this slice needs.
+
+## Decisions
+
+### A field boundary is an ordered interval descriptor
+
+A `FieldPassthroughSequence` descriptor represents one complete begin →
+instruction → separate → cached-result → end interval. It records:
+
+- paragraph and structural-container identity;
+- zero-based supported-field occurrence ordinal in that paragraph;
+- normalized instruction class and canonical semantic fingerprint;
+- cloned ordered source nodes for the complete interval;
+- the exact constituent atom count and ownership;
+- effective namespace/MCE bindings required by the cloned interval.
+
+Atoms remain the differ's unit. The collapsed field atom carries the descriptor,
+and any expanded constituent view points to the same owner. The descriptor is
+process-local and is not part of a serialized public API.
+
+### The first slice is deliberately narrow
+
+A candidate qualifies only when all of these are true:
+
+- it is in `word/document.xml`;
+- begin, instruction, separate, cached result, and end are complete within one
+  paragraph;
+- the field is not nested and does not cross an SDT or other unsupported
+  structural boundary;
+- the normalized instruction is PAGE, NUMPAGES, REF, or PAGEREF;
+- original and revised occurrences have the same paragraph/container identity,
+  supported-field ordinal, instruction class, and canonical fingerprint.
+
+The fingerprint covers the entire ordered interval, including run properties,
+contained bookmark/range markers, attributes, instruction spacing, cached
+result, and extension payload. It ignores only lexical namespace declaration
+placement when effective namespace-aware meaning is identical.
+
+`REF` is added to the shared field instruction/complete-field fixtures rather
+than re-derived in a test. All minimal packages use
+`buildDocxFromBodyXml`.
+
+### Unchanged passthrough is separate from field editing
+
+Only an exact correlated pair becomes a passthrough sequence. Legitimate field
+insertions, deletions, instruction changes, and cached-result changes continue
+through the existing field-aware comparison path and existing validation.
+
+After a pair is selected for passthrough, any correlation loss, changed atom
+status, mixed ownership, or incomplete interval fails the rebuild. The
+reconstructor never silently falls back from an attempted exact passthrough to
+modeled field expansion.
+
+### One owner emits the sequence
+
+At the first atom for a validated sequence, the reconstructor flushes pending
+ordinary text and emits the cloned ordered nodes once. Every subsequent atom
+owned by that sequence emits nothing. Ordinary atoms before and after it retain
+the existing tracked-change path.
+
+Emission must preserve source order relative to ordinary runs and other
+supported fields. Multiple sibling fields are supported only when each has a
+unique, contiguous, non-crossing interval and counterpart.
+
+### Boundary-crossing markers fail closed
+
+Range markers wholly inside the interval are part of the fingerprint and cloned
+payload. A bookmark, comment range, permission range, move range, or other paired
+marker with one endpoint inside and one outside the interval makes the field
+ineligible for passthrough. If such a field would otherwise be selected, rebuild
+fails with a field-passthrough boundary error rather than duplicating or
+orphaning the range.
+
+The initial implementation does not prove REF/PAGEREF target semantics. Those
+instructions and cached results are preserved exactly; target evaluation remains
+the host application's job.
+
+### Existing validators are mandatory postconditions
+
+Every passthrough result must:
+
+- pass the runtime field-structure validator on combined, accepted, and rejected
+  documents;
+- pass the AI revision validator and emitted schema/MCE gate;
+- satisfy normalized accepted text equals revised and rejected text equals
+  original;
+- contain one structurally equivalent supported field per selected occurrence;
+- retain the outside edit on accept and the original outside text on reject.
+
+The existing Lean field invariant remains relevant structural evidence, but the
+new exact-passthrough property is a repository-level metamorphic invariant, not
+an ECMA-376 claim and not automatically proved by the current Lean model.
+
+### Neutral evidence precedes implementation
+
+The first task is to contribute an implementation-neutral scenario covering an
+unchanged complete field plus a same-paragraph outside edit. The SafeDocX
+implementation then pins the reviewed upstream commit, runs the adapter, and
+refreshes the capability projection.
+
+The neutral scenario demonstrates ordinary user-visible field survival across
+implementations. A separate repository test forces `reconstructionMode:
+rebuild`; only that test supports the rebuild-specific preservation claim.
+
+## Risks / Trade-offs
+
+- Exact fingerprinting rejects documents whose producer rewrites harmless
+  lexical details between original and revised. Failing closed is preferable to
+  emitting a subtly changed cross-reference.
+- The narrow first slice leaves nested and ancillary-story fields unsupported.
+  Keeping story/package ownership out of this PR makes the safety argument
+  reviewable.
+- Cloning the original interval means a field's cached result is intentionally
+  not recalculated after an outside edit. This matches opaque preservation; Word
+  may update fields when the document is opened.
+
+## Migration Plan
+
+No document or API migration is required. Supported unchanged fields become more
+faithful in rebuild output. Other fields retain the current path. A dedicated
+error is returned only when SafeDocX has selected an exact-preservation boundary
+and cannot prove that it remains safe to emit.

--- a/openspec/changes/preserve-main-story-complex-fields-on-rebuild/proposal.md
+++ b/openspec/changes/preserve-main-story-complex-fields-on-rebuild/proposal.md
@@ -1,0 +1,58 @@
+# Change: Preserve unchanged main-story complex fields on rebuild
+
+## Why
+
+Forced comparison rebuild can reconstruct visible field results while losing the
+authored complex-field sequence and run-level payload around it. That is unsafe
+for legal documents: PAGE/NUMPAGES pagination and REF/PAGEREF cross-references
+may still look plausible in extracted text even after their field machinery has
+been flattened or normalized beyond recognition.
+
+SafeDocX already validates complex-field structure, carries collapsed field atoms,
+and formally checks field preservation invariants. The remaining gap is exact,
+bounded passthrough of an unchanged field while an edit elsewhere in the same
+paragraph remains active.
+
+## What Changes
+
+- Add a neutral docx-platform-tests scenario for an unchanged complex field with
+  a same-paragraph outside edit before implementing the repository-specific path.
+- Preserve complete, unchanged, non-nested PAGE, NUMPAGES, REF, and PAGEREF
+  complex fields in the main document story during forced rebuild.
+- Capture the ordered field interval from `w:fldChar` begin through its matching
+  end, including instruction runs, separator, cached result, run properties,
+  bookmarks/range markers wholly contained in the interval, and namespace/MCE
+  context required by the captured nodes.
+- Correlate original and revised field occurrences by paragraph/container
+  ownership, field ordinal, instruction class, and canonical semantic
+  fingerprint; emit the validated original sequence exactly once while applying
+  edits outside it.
+- Fail closed when a field selected for passthrough has ambiguous ownership,
+  non-contiguous atoms, unsafe boundary-crossing markers, correlation loss, or
+  mutation. Existing field insertion, deletion, and modification behavior
+  remains on its current validated path and is not relabeled as passthrough.
+- Verify field structure and accept/reject projections for every preserved
+  output, then measure preservation on real field-bearing repository documents.
+- Pin the reviewed neutral-suite commit and refresh the capability projection
+  without presenting ordinary neutral evidence as proof of forced rebuild.
+
+## Impact
+
+- Affected specs: `docx-comparison`, `cross-implementation-conformance`,
+  `spec-compliance`
+- Affected code: field atomization/correlation, rebuild reconstruction, shared
+  OOXML fixtures, focused/real-document tests, neutral-suite pin and capability
+  projection
+- Ref: #582
+
+## Out of scope
+
+- Field insertions, deletions, instruction rewrites, cached-result changes, or
+  editing inside a preserved field boundary.
+- Nested fields, fields spanning paragraphs, `w:fldSimple`, form fields, TOC
+  fields, and fields in headers, footers, footnotes, endnotes, comments, text
+  boxes, or content controls.
+- Recalculating cached field results or proving that REF/PAGEREF bookmark targets
+  are semantically correct; Word or another host remains the field evaluator.
+- Preserving `sectPr`, arbitrary rsids outside captured nodes, row/cell/nested
+  content controls, ancillary story reconstruction, or arbitrary package parts.

--- a/openspec/changes/preserve-main-story-complex-fields-on-rebuild/specs/cross-implementation-conformance/spec.md
+++ b/openspec/changes/preserve-main-story-complex-fields-on-rebuild/specs/cross-implementation-conformance/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Neutral unchanged-field evidence precedes rebuild implementation
+
+The repository SHALL pin a reviewed docx-platform-tests commit containing an
+implementation-neutral scenario with a complete unchanged complex field and a
+same-paragraph outside edit. The SafeDocX adapter SHALL execute that scenario
+before the forced-rebuild preservation implementation is treated as complete.
+
+#### Scenario: [XIMPL-FIELD-01] Reviewed neutral field scenario runs at the pinned commit
+
+- **GIVEN** the reviewed docx-platform-tests field scenario and its pinned commit
+- **WHEN** the scenario runs through the SafeDocX adapter
+- **THEN** the result SHALL use the registry's oracle-specific pass status
+- **AND** unsupported or error outcomes SHALL remain non-pass
+- **AND** the scenario SHALL verify that the field remains complete and the
+  outside edit is applied
+- **AND** the capability projection SHALL identify this as neutral evidence, not
+  proof that SafeDocX forced rebuild was used

--- a/openspec/changes/preserve-main-story-complex-fields-on-rebuild/specs/docx-comparison/spec.md
+++ b/openspec/changes/preserve-main-story-complex-fields-on-rebuild/specs/docx-comparison/spec.md
@@ -1,0 +1,94 @@
+## ADDED Requirements
+
+### Requirement: Forced rebuild preserves unchanged supported main-story complex fields
+
+When comparison uses `reconstructionMode: rebuild`, the system SHALL preserve
+each unchanged, complete, non-nested, same-paragraph PAGE, NUMPAGES, REF, or
+PAGEREF complex field in `word/document.xml` as one ordered interval. The
+preserved interval SHALL retain its begin, instruction, separator, cached
+result, end, run properties, wholly contained range markers, extension payload,
+and effective namespace/MCE meaning while intentional edits outside the
+interval remain active.
+
+Exact interval preservation is a SafeDocX metamorphic invariant. ECMA-376
+conformance claims remain limited to registered complex-field structure and
+instruction syntax.
+
+#### Scenario: [FIELD-REBUILD-01] Same-paragraph outside edit retains complete field
+
+- **GIVEN** original and revised paragraphs containing the same complete
+  supported complex field and different ordinary text outside that field
+- **WHEN** comparison is forced through `reconstructionMode: rebuild`
+- **THEN** `reconstructionModeUsed` SHALL be `rebuild`
+- **AND** the output SHALL contain exactly one structurally equivalent copy of
+  the complete field interval in its original paragraph order
+- **AND** accepting changes SHALL retain the revised outside text
+- **AND** rejecting changes SHALL retain the original outside text
+- **AND** both projections SHALL contain a structurally valid complete field
+
+#### Scenario: [FIELD-REBUILD-02] All four bounded instruction classes preserve
+
+- **GIVEN** complete unchanged PAGE, NUMPAGES, REF, and PAGEREF fields in
+  separate focused fixtures
+- **WHEN** each fixture is rebuilt with an outside edit
+- **THEN** each instruction, spacing, switches, cached result, run properties,
+  contained payload, and effective namespace/MCE meaning SHALL remain
+  structurally equivalent
+- **AND** the tests SHALL use the shared field constants and
+  `buildDocxFromBodyXml`
+
+#### Scenario: [FIELD-REBUILD-03] Multiple sibling fields emit once in order
+
+- **GIVEN** a paragraph with multiple complete supported sibling fields and
+  ordinary text between them
+- **WHEN** forced rebuild preserves the fields
+- **THEN** each field SHALL be emitted exactly once
+- **AND** field and ordinary-run order SHALL match the source
+- **AND** no interval SHALL overlap, cross, duplicate, or consume another
+
+#### Scenario: [FIELD-REBUILD-04] Unsafe selected interval fails closed
+
+- **GIVEN** a supported field selected for exact passthrough whose counterpart
+  loses paragraph/container ownership, moves or reorders, mutates, becomes
+  non-contiguous, has incomplete atom ownership, or contains a paired range
+  crossing the field boundary
+- **WHEN** forced rebuild attempts preservation
+- **THEN** reconstruction SHALL fail with a dedicated field-passthrough error
+- **AND** it SHALL NOT silently emit a flattened, stale, partial, or duplicated
+  field
+
+#### Scenario: [FIELD-REBUILD-05] Unsupported and edited fields retain existing path
+
+- **GIVEN** a field that is inserted, deleted, instruction-edited,
+  cached-result-edited, nested, paragraph-spanning, ancillary-story, simple, or
+  outside the four supported instruction classes
+- **WHEN** comparison runs
+- **THEN** it SHALL NOT be represented as an exact field-passthrough interval
+- **AND** existing supported comparison behavior and safety validators SHALL
+  remain authoritative
+
+### Requirement: Preserved field outputs satisfy structural and projection gates
+
+Every rebuild output containing an exact field-passthrough interval SHALL pass
+the field-structure validator, AI revision validator, emitted schema/MCE gate,
+and accept/reject text projections before it is returned.
+
+#### Scenario: [FIELD-REBUILD-06] Combined and projected documents pass all gates
+
+- **WHEN** a forced rebuild emits one or more preserved field intervals
+- **THEN** combined, accepted, and rejected documents SHALL pass field-structure
+  validation
+- **AND** the combined output SHALL pass revision and emitted schema/MCE gates
+- **AND** normalized accepted text SHALL equal revised input text
+- **AND** normalized rejected text SHALL equal original input text
+- **AND** the preserved-field count and fingerprints SHALL match the selected
+  occurrences
+
+#### Scenario: [FIELD-REBUILD-07] Real-document evidence is bounded to observed fields
+
+- **GIVEN** the checked-in real DOCX corpus
+- **WHEN** field-bearing documents run through forced rebuild with outside edits
+- **THEN** the test SHALL report field instruction classes, stories, counts, and
+  before/after structural fingerprints
+- **AND** claims SHALL be limited to the supported field types and main-story
+  placements actually observed

--- a/openspec/changes/preserve-main-story-complex-fields-on-rebuild/specs/spec-compliance/spec.md
+++ b/openspec/changes/preserve-main-story-complex-fields-on-rebuild/specs/spec-compliance/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Complex-field capability evidence distinguishes conformance from preservation
+
+Generated capability and conformance artifacts SHALL distinguish normative
+complex-field structure/instruction claims from the repository-level
+metamorphic claim that an unchanged field interval remains structurally
+equivalent through forced rebuild.
+
+#### Scenario: [FIELD-COMP-01] Evidence scope remains explicit
+
+- **WHEN** capability and conformance artifacts are regenerated after the
+  unchanged-field work
+- **THEN** ECMA-376 citations SHALL cover only registered field structure and
+  instruction semantics
+- **AND** exact interval preservation SHALL be labeled as a SafeDocX
+  metamorphic invariant
+- **AND** neutral-suite evidence SHALL not claim forced-rebuild coverage unless
+  the neutral scenario actually requests and observes that mode

--- a/openspec/changes/preserve-main-story-complex-fields-on-rebuild/tasks.md
+++ b/openspec/changes/preserve-main-story-complex-fields-on-rebuild/tasks.md
@@ -1,0 +1,51 @@
+## 1. Neutral scenario and specification
+
+- [ ] 1.1 Add and independently review a docx-platform-tests scenario for a
+  complete unchanged complex field with a same-paragraph outside edit.
+- [ ] 1.2 Pin the reviewed neutral-suite commit and record registry hashes.
+- [ ] 1.3 Validate this OpenSpec proposal and delta requirements.
+- [ ] 1.4 Confirm and cite the existing ECMA-376 edition 5 complex-field and
+  PAGE/NUMPAGES/REF/PAGEREF instruction sections; label exact preservation as a
+  SafeDocX metamorphic invariant.
+
+## 2. Shared fixtures and interval model
+
+- [ ] 2.1 Add REF instruction and complete-field constants to
+  `packages/docx-core/src/testing/ooxml-fixtures.ts`.
+- [ ] 2.2 Add the process-local field interval descriptor with paragraph,
+  container, ordinal, fingerprint, cloned nodes, atom ownership, and namespace
+  context.
+- [ ] 2.3 Detect complete, non-nested, same-paragraph PAGE, NUMPAGES, REF, and
+  PAGEREF candidates in the main story.
+
+## 3. Counterpart binding and rebuild emission
+
+- [ ] 3.1 Bind exact original/revised counterparts and reject ambiguous
+  occurrence, ownership, movement, boundary crossing, or mutation.
+- [ ] 3.2 Preserve existing field insert/delete/modify behavior outside the
+  exact-passthrough path.
+- [ ] 3.3 Emit each validated sequence once in paragraph order while retaining
+  tracked edits before and after it.
+- [ ] 3.4 Run mandatory field, revision, namespace/MCE, schema, and
+  accept/reject postconditions.
+
+## 4. Focused and real-document evidence
+
+- [ ] 4.1 Add shared-fixture forced-rebuild tests for every supported
+  instruction, prefix/suffix edits, split instruction/result runs, multiple
+  sibling fields, run properties, contained markers, and namespace context.
+- [ ] 4.2 Add negative tests for nested/paragraph-spanning fields, mixed
+  ownership, reordered/missing counterparts, mutation, crossed ranges, and
+  non-contiguous atoms.
+- [ ] 4.3 Measure before/after field counts and structural fingerprints on real
+  field-bearing repository DOCX files; label the exact field types/stories
+  actually present without overclaiming.
+
+## 5. Neutral projection and verification
+
+- [ ] 5.1 Run the reviewed neutral field scenario through the SafeDocX adapter.
+- [ ] 5.2 Reconcile and regenerate the capability projection while keeping
+  neutral and forced-rebuild evidence separate.
+- [ ] 5.3 Run focused tests, real-package/LibreOffice smoke where available,
+  and every mandatory repository pre-submit gate.
+- [ ] 5.4 Review the diff for bounded scope and commit with `Ref: #582`.


### PR DESCRIPTION
## Proposal

Define the next bounded issue #582 rebuild-fidelity slice:

- contribute and review a neutral field-survival scenario before implementation
- preserve unchanged, complete, non-nested main-story PAGE, NUMPAGES, REF, and PAGEREF intervals through forced rebuild
- retain exact ordered field machinery while tracked edits before/after remain active
- correlate by paragraph/container ownership, occurrence, instruction class, and full semantic fingerprint
- fail closed on attempted-passthrough mutation, movement, mixed ownership, crossed ranges, or incomplete atoms
- leave field insert/delete/modify behavior on its existing validated path
- require field/revision/schema gates, accept/reject projections, neutral projection, and bounded real-document evidence

Header/footer and note stories remain a separate relationship-aware follow-up, as recommended in #582.

## Approval gate

Proposal only. Per `openspec/AGENTS.md`, implementation will begin after this change is reviewed and approved. The neutral scenario is intentionally the first implementation task.

## Validation

- `openspec validate preserve-main-story-complex-fields-on-rebuild --strict`
- `git diff --check`

Ref: #582