### PR TITLE
fix(docx-compare): preserve complex fields on rebuild

### DIFF
--- a/openspec/changes/preserve-complex-fields-on-rebuild/design.md
+++ b/openspec/changes/preserve-complex-fields-on-rebuild/design.md
@@ -1,0 +1,106 @@
+## Context
+
+`collapseFieldSequences` intentionally reduces a same-paragraph complex field to
+one visible-result atom so LCS can match field results with ordinary text. The
+collapsed atom retains its constituent leaves, but rebuild reconstruction emits
+those leaves inside one new `w:r`. A valid multi-run field therefore keeps its
+text and markers while losing its authored XML topology.
+
+The inline/block SDT work already provides a fail-closed opaque passthrough
+substrate: atoms carry a process-local owner descriptor, counterpart binding
+compares semantic fingerprints and placement, merged correlation must remain
+equal and contiguous, and reconstruction emits one validated owner.
+
+## Goals / Non-Goals
+
+- Goals: preserve the ordered direct paragraph-child range from the child
+  containing the outer `w:fldChar` begin through the child containing its
+  matching end.
+- Goals: preserve run boundaries/properties, field markers, fragmented
+  instruction text, cached result runs, supported non-revision wrappers,
+  attributes, namespaces, MCE declarations, and extension payload.
+- Goals: support PAGE, NUMPAGES, REF, and PAGEREF instruction codes with
+  conservative case, whitespace, argument, and switch parsing.
+- Goals: fail before reconstruction when an unchanged opaque range cannot be
+  established and correlated exactly.
+- Non-Goals: ancillary stories, field evaluation, cached-result correctness,
+  changed fields, nested fields, fields spanning paragraphs, or fields owned by
+  tracked paragraph revisions.
+- Non-Goals: changes to inplace comparison or its field-fragmentation behavior.
+- Non-Goals: extending the Lean XML verifier. Rebuild evidence remains
+  `not_applicable`; the current Lean token model does not express run topology,
+  wrappers, instruction semantics, or extension payload.
+
+## Decisions
+
+### Ordered inline ranges extend the existing opaque owner
+
+`OpaquePassthroughNode` gains an ordered-inline-range placement and ordered
+source/emission element arrays. Existing SDT owners continue to contain one
+element. A field owner contains every direct paragraph child in its bounded
+range, with effective namespace and MCE declarations materialized on each
+cloned child. Reconstruction serializes the array in order exactly once.
+
+This keeps counterpart, equal-correlation, contiguity, source-order, and
+one-owner checks shared rather than introducing field-specific reconstruction.
+Direct-child start/end positions locate the source payload but are not
+counterpart identity. Field ranges pair by stable paragraph/container identity
+and their sequence ordinal among captured fields in that paragraph, so an
+ordinary sibling insertion or deletion before a field may shift source
+positions without changing field identity.
+
+### Capture operates on raw atoms before collapse
+
+The capture pass walks raw field atoms using a begin/separate/end state machine,
+maps each outer field endpoint to its direct paragraph child, and validates that
+the complete direct-child range contains no atoms outside that field. It then
+classifies the concatenated `w:instrText` payload.
+
+Only one non-nested field may own a supported range. Identifiable supported
+fields that are malformed, nested, overlapping, spanning, shared-endpoint, or
+unsupported-placement fail closed. Malformed unsupported instructions retain
+the existing post-rebuild safety-diagnostics behavior rather than becoming new
+opaque-preflight errors. A field wholly inside an already captured unchanged
+inline SDT remains owned by that SDT. Partial overlap with another opaque owner
+fails. Non-revision wrappers such as `w:hyperlink` are retained; field ranges
+owned by `w:ins`, `w:del`, `w:moveFrom`, or `w:moveTo` are excluded.
+
+### Field classification is semantic and conservative
+
+Instruction text is concatenated in document order, trimmed, and tokenized with
+quoted arguments and backslash switches retained. The leading keyword is
+case-insensitive. PAGE and NUMPAGES accept only their defined switch-shaped
+tails. REF and PAGEREF require one bookmark argument and accept switch-shaped
+tails. REF `\d` additionally requires and consumes one separator argument.
+Unknown keywords, malformed quoting, missing arguments, nested field payload,
+or non-instruction content before `separate` are unsupported.
+
+Classification controls eligibility only; the exact authored instruction XML is
+preserved and fingerprinted.
+
+### Exact preservation is a metamorphic invariant
+
+ECMA-376 edition 5 Part 1 §§17.16.18, 17.16.5.42, 17.16.5.44,
+17.16.5.45, and 17.16.5.51 identify complex-field structure and the supported
+instructions. They do not require SafeDocX to preserve lexical topology through
+comparison. Tests therefore cite the normative field clauses while describing
+ordered topology preservation as a stronger SafeDocX metamorphic invariant.
+
+## Risks / Trade-offs
+
+- Conservative ownership rejects documents that could potentially be rebuilt
+  safely. This is preferable to silently flattening an unmodeled field shape.
+- Materializing inherited namespace declarations may change lexical placement
+  while preserving namespace semantics. Assertions compare ordered DOM topology,
+  QNames, attributes, and text rather than package bytes.
+- Pairing requires stable paragraph/container ownership and field-range
+  sequence. Unrelated sibling edits may shift direct-child positions.
+  Cross-paragraph movement and reordering of distinct fields are intentionally
+  unsupported.
+
+## Migration Plan
+
+No public API migration is required. Existing inplace behavior is unchanged.
+Forced rebuild gains preservation for unchanged supported fields and explicit
+failure for identifiable supported field topology that would otherwise be
+lossy. Unsupported field instructions retain existing rebuild diagnostics.

--- a/openspec/changes/preserve-complex-fields-on-rebuild/proposal.md
+++ b/openspec/changes/preserve-complex-fields-on-rebuild/proposal.md
@@ -1,0 +1,32 @@
+# Change: Preserve unchanged complex fields during rebuild comparison
+
+## Why
+
+Rebuild comparison collapses each same-paragraph complex field to its visible
+result for matching, then expands the field leaves inside one synthesized run.
+That preserves marker balance but silently loses the original run boundaries,
+run properties, non-revision wrappers, attributes, namespaces, and extension
+payload.
+
+## What Changes
+
+- Extend the opaque passthrough substrate with ordered inline ranges.
+- Capture unchanged, self-contained PAGE, NUMPAGES, REF, and PAGEREF fields in
+  the main document and preserve their complete direct paragraph-child topology.
+- Pair original and revised field ranges deterministically and emit each range
+  exactly once while rebuilding unrelated edits normally.
+- Allow harmless direct-child position shifts caused by unrelated sibling edits,
+  while rejecting changed, cross-paragraph moved, field-reordered, overlapping,
+  malformed supported, tracked-revision-owned, or otherwise unsafe ranges before
+  lossy output.
+- Add focused positive and adversarial tests plus exact ECMA-376 registry and
+  source/test citations.
+- Keep inplace field fragmentation behavior unchanged and leave rebuild evidence
+  outside the current Lean XML verifier.
+
+## Impact
+
+- Affected specs: `docx-comparison`, `spec-compliance`
+- Affected code: comparison atom types, atomizer, opaque passthrough correlation,
+  rebuild reconstruction, shared field fixtures, focused tests, ECMA registry
+- Ref: #582

--- a/openspec/changes/preserve-complex-fields-on-rebuild/specs/docx-comparison/spec.md
+++ b/openspec/changes/preserve-complex-fields-on-rebuild/specs/docx-comparison/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: Forced rebuild preserves unchanged supported complex fields as ordered opaque ranges
+
+When comparison uses `reconstructionMode: rebuild`, the system SHALL preserve
+an unchanged, self-contained PAGE, NUMPAGES, REF, or PAGEREF complex field in
+`word/document.xml` as the ordered direct paragraph-child range that contains
+the field. The preserved range SHALL retain run boundaries, run properties,
+field markers, instruction fragments, cached-result runs, supported
+non-revision wrappers, attributes, namespace/MCE declarations, and extension
+payload.
+
+#### Scenario: [SDX-FIELD-REBUILD-01] Outside edit preserves decorated supported fields
+
+- **GIVEN** an unchanged supported complex field whose markers, instruction, and result occupy distinct decorated runs and a supported non-revision wrapper
+- **WHEN** unrelated text in the same or another paragraph changes and comparison is forced through rebuild
+- **THEN** the output SHALL contain the original ordered field topology exactly once
+- **AND** the unrelated edit SHALL be represented normally
+- **AND** insertion or deletion of an unrelated direct paragraph child before the field SHALL NOT change field counterpart identity
+
+#### Scenario: [SDX-FIELD-REBUILD-02] Multiple fields preserve deterministic order
+
+- **GIVEN** multiple unchanged supported fields in one main-document paragraph
+- **WHEN** unrelated content is rebuilt
+- **THEN** each field range SHALL be paired by stable paragraph ownership and field-range sequence
+- **AND** each range SHALL be emitted exactly once in source order
+
+#### Scenario: [SDX-FIELD-REBUILD-03] Unsafe field ownership fails closed
+
+- **GIVEN** an identifiable supported field is changed, inserted, deleted, reordered relative to another distinct field, moved across paragraphs, nested, overlapping, paragraph-spanning, malformed, tracked-revision-owned, shares an endpoint child with unrelated content, or loses merged correlation
+- **WHEN** rebuild passthrough is evaluated
+- **THEN** comparison SHALL fail before emitting a flattened field
+
+#### Scenario: [SDX-FIELD-REBUILD-03] Unsupported malformed fields retain diagnostics
+
+- **GIVEN** a malformed field whose instruction keyword is outside PAGE, NUMPAGES, REF, and PAGEREF
+- **WHEN** rebuild passthrough and safety screening are evaluated
+- **THEN** opaque preflight SHALL NOT reject it merely for being malformed
+- **AND** existing rebuild safety diagnostics SHALL report its malformed field structure
+
+#### Scenario: [SDX-FIELD-REBUILD-04] Inline SDT remains the sole owner
+
+- **GIVEN** a supported field is wholly contained by an unchanged supported opaque inline SDT
+- **WHEN** forced rebuild preserves that paragraph
+- **THEN** the SDT SHALL remain the sole opaque owner and emitter
+- **AND** the nested field SHALL NOT be captured or emitted independently
+
+#### Scenario: [SDX-FIELD-REBUILD-05] Inplace and Lean boundaries remain unchanged
+
+- **WHEN** this rebuild-only capability is enabled
+- **THEN** direct inplace comparison SHALL NOT engage ordered-range capture or emission
+- **AND** inplace field fragmentation and reconstruction SHALL remain unchanged
+- **AND** Lean XML verifier evidence for rebuild SHALL remain `not_applicable`

--- a/openspec/changes/preserve-complex-fields-on-rebuild/specs/spec-compliance/spec.md
+++ b/openspec/changes/preserve-complex-fields-on-rebuild/specs/spec-compliance/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Complex-field rebuild evidence separates normative structure from topology preservation
+
+The ECMA-376 registry SHALL target edition 5 Part 1 §§17.16.18,
+17.16.5.42, 17.16.5.44, 17.16.5.45, and 17.16.5.51 for the bounded supported
+field vocabulary. Source and tests SHALL cite those clauses using the repository
+conformance grammar. Exact ordered topology preservation through rebuild SHALL
+be labeled as a SafeDocX metamorphic invariant rather than an ECMA requirement.
+
+#### Scenario: [SDX-FIELD-CONFORMANCE-01] REF and PAGEREF claims are bounded
+
+- **WHEN** REF and PAGEREF are added to the targeted registry
+- **THEN** their entries SHALL describe classification and unchanged rebuild preservation
+- **AND** SHALL NOT claim field evaluation, pagination, cached-result correctness, or complete field-engine equivalence
+
+#### Scenario: [SDX-FIELD-CONFORMANCE-02] Executable evidence names the verification boundary
+
+- **WHEN** conformance checks inspect the field rebuild implementation and tests
+- **THEN** citations SHALL resolve to registry entries for each supported instruction and complex-field structure
+- **AND** the evidence SHALL state that the Lean verifier does not cover rebuild topology

--- a/openspec/changes/preserve-complex-fields-on-rebuild/tasks.md
+++ b/openspec/changes/preserve-complex-fields-on-rebuild/tasks.md
@@ -1,0 +1,29 @@
+## 1. Specification and conformance
+
+- [x] 1.1 Validate this OpenSpec proposal and both capability deltas.
+- [x] 1.2 Add bounded REF/PAGEREF registry entries and update the field non-goal.
+- [x] 1.3 Add leading JSDoc and structured test citations without overclaiming topology preservation.
+
+## 2. Ordered field passthrough
+
+- [x] 2.1 Generalize opaque passthrough descriptors and emission to ordered inline ranges.
+- [x] 2.2 Capture and classify self-contained PAGE, NUMPAGES, REF, and PAGEREF ranges before field collapse.
+- [x] 2.3 Reuse counterpart, fingerprint, ownership, contiguity, and emit-once validation.
+- [x] 2.4 Fail closed for supported-field mutation, cross-paragraph movement, tracked ownership, malformed/nested/spanning/shared ranges, overlap, and correlation loss.
+- [x] 2.5 Keep inline-SDT ownership authoritative and leave inplace behavior unchanged.
+- [x] 2.6 Pair field ranges by paragraph-local sequence rather than shifting direct-child positions.
+- [x] 2.7 Restrict malformed preflight errors to identifiable supported instructions and enforce REF switch arity.
+
+## 3. Evidence
+
+- [x] 3.1 Add shared decorated complex-field fixtures for all four instructions.
+- [x] 3.2 Add forced-rebuild tests for same/other paragraph edits and multiple fields.
+- [x] 3.3 Add adversarial fail-closed tests for every bounded exclusion.
+- [x] 3.4 Assert the Lean rebuild evidence remains `not_applicable`.
+- [x] 3.5 Add sibling-shift, unsupported DATE, REF `\d`, revision-wrapper, and direct-inplace regressions.
+
+## 4. Verification
+
+- [x] 4.1 Run focused tests and TypeScript build/lint.
+- [x] 4.2 Run strict OpenSpec and conformance checks.
+- [x] 4.3 Run the mandatory repository pre-submit suite and review the final diff.

--- a/packages/docx-compare/src/atomizer.ts
+++ b/packages/docx-compare/src/atomizer.ts
@@ -23,6 +23,7 @@ import {
 } from '@usejunior/docx-core';
 import { OOXML } from '@usejunior/docx-core';
 import {
+  captureComplexFieldPassthrough,
   captureSdtPassthrough,
   sameOpaqueOwner,
   validateSdtNamespaceOwnership,
@@ -534,6 +535,8 @@ export interface AtomizeTreeOptions {
   atomizeParagraphLevelMarkers?: boolean;
   /** Capture unchanged supported SDT placements as bounded opaque rebuild nodes. */
   captureInlineSdtPassthrough?: boolean;
+  /** Capture unchanged supported complex fields as ordered opaque rebuild ranges. */
+  captureComplexFieldPassthrough?: boolean;
 }
 
 /**
@@ -830,6 +833,7 @@ export function atomizeTree(
     splitTextIntoWords: options.splitTextIntoWords ?? true,
     atomizeParagraphLevelMarkers: options.atomizeParagraphLevelMarkers ?? false,
     captureInlineSdtPassthrough: options.captureInlineSdtPassthrough ?? false,
+    captureComplexFieldPassthrough: options.captureComplexFieldPassthrough ?? false,
   };
 
   const state: AtomizationState = {
@@ -840,6 +844,9 @@ export function atomizeTree(
   if (normalizedOptions.captureInlineSdtPassthrough) validateSdtNamespaceOwnership(node);
   const rawAtoms = atomizeTreeInternal(node, ancestors, part, state, normalizedOptions);
   if (normalizedOptions.captureInlineSdtPassthrough) captureSdtPassthrough(node, rawAtoms);
+  if (normalizedOptions.captureComplexFieldPassthrough) {
+    captureComplexFieldPassthrough(node, rawAtoms);
+  }
 
   // Step 1: Collapse field sequences into single atoms based on visible text
   // This allows matching between hardcoded text and field references

--- a/packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts
@@ -32,10 +32,11 @@ import {
 } from './trackChangesAcceptorAst.js';
 
 const MC_NS = 'http://schemas.openxmlformats.org/markup-compatibility/2006';
+const TEST_FEATURE = 'Document Reconstructor Complex Fields';
 const test = testAllure
   .epic('Document Comparison')
   .withLabels({
-    feature: 'Document Reconstructor Complex Fields',
+    feature: TEST_FEATURE,
     story: 'Ordered Complex Field Preservation In Rebuild',
     severity: 'critical',
   })

--- a/packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts
@@ -1,0 +1,525 @@
+/**
+ * Forced-rebuild evidence for unchanged complex-field ordered passthrough.
+ *
+ * The ECMA clauses identify the field structures and instructions. Preserving
+ * their exact authored topology through comparison is a stronger SafeDocX
+ * metamorphic invariant, not an ECMA-376 requirement.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.18
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.5.42
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.5.44
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.5.45
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.5.51
+ * @see https://github.com/UseJunior/safe-docx/issues/582
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect } from 'vitest';
+import { DocxArchive, OOXML, parseXml } from '@usejunior/docx-core';
+import {
+  buildDocxFromBodyXml,
+  completeField,
+  decoratedComplexField,
+  FIELD_INSTRUCTIONS,
+} from '../../testing/ooxml-fixtures.js';
+import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
+import { compareDocumentsAtomizer } from './pipeline.js';
+import {
+  acceptAllChanges,
+  extractTextWithParagraphs,
+  rejectAllChanges,
+} from './trackChangesAcceptorAst.js';
+
+const MC_NS = 'http://schemas.openxmlformats.org/markup-compatibility/2006';
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({
+    feature: 'Document Reconstructor Complex Fields',
+    story: 'Ordered Complex Field Preservation In Rebuild',
+    severity: 'critical',
+  })
+  .conformance(
+    { spec: 'ECMA-376', edition: 5, part: 1, section: '17.16.18' },
+    { spec: 'ECMA-376', edition: 5, part: 1, section: '17.16.5.42' },
+    { spec: 'ECMA-376', edition: 5, part: 1, section: '17.16.5.44' },
+    { spec: 'ECMA-376', edition: 5, part: 1, section: '17.16.5.45' },
+    { spec: 'ECMA-376', edition: 5, part: 1, section: '17.16.5.51' },
+  );
+
+function textRun(text: string): string {
+  return `<w:r><w:t>${text}</w:t></w:r>`;
+}
+
+function fieldCharType(element: Element): string | null {
+  const marker = Array.from(element.getElementsByTagNameNS(OOXML.W_NS, 'fldChar'))[0];
+  return marker?.getAttributeNS(OOXML.W_NS, 'fldCharType') ??
+    marker?.getAttribute('w:fldCharType') ??
+    null;
+}
+
+function fieldRanges(xml: string): Element[][] {
+  const ranges: Element[][] = [];
+  for (const paragraph of Array.from(parseXml(xml).getElementsByTagNameNS(OOXML.W_NS, 'p'))) {
+    const children = Array.from(paragraph.childNodes)
+      .filter((child): child is Element => child.nodeType === 1);
+    let active: Element[] | null = null;
+    for (const child of children) {
+      const kind = fieldCharType(child);
+      if (kind === 'begin') active = [];
+      if (active) active.push(child);
+      if (kind === 'end' && active) {
+        ranges.push(active);
+        active = null;
+      }
+    }
+  }
+  return ranges;
+}
+
+function canonicalNode(node: Node): string {
+  if (node.nodeType === 1) {
+    const element = node as Element;
+    const attributes = Array.from(element.attributes)
+      .filter((attribute) =>
+        attribute.namespaceURI !== 'http://www.w3.org/2000/xmlns/' &&
+        attribute.namespaceURI !== MC_NS)
+      .map((attribute) =>
+        `{${attribute.namespaceURI ?? ''}}${attribute.localName ?? attribute.name}=${JSON.stringify(attribute.value)}`,
+      )
+      .sort();
+    return `E{${element.namespaceURI ?? ''}}${element.localName}[${attributes.join(',')}](` +
+      Array.from(element.childNodes).map(canonicalNode).join('') + ')';
+  }
+  if (node.nodeType === 3 || node.nodeType === 4) return `T${JSON.stringify(node.nodeValue ?? '')}`;
+  if (node.nodeType === 8) return `C${JSON.stringify(node.nodeValue ?? '')}`;
+  return `N${node.nodeType}:${JSON.stringify(node.nodeValue ?? '')}`;
+}
+
+function canonicalRanges(xml: string): string[][] {
+  return fieldRanges(xml).map((range) => range.map(canonicalNode));
+}
+
+async function compare(
+  originalBody: string,
+  revisedBody: string,
+  lean = false,
+) {
+  const original = await buildDocxFromBodyXml(originalBody);
+  const revised = await buildDocxFromBodyXml(revisedBody);
+  return compareDocumentsAtomizer(original, revised, {
+    author: 'Issue 582 Test',
+    date: new Date('2026-07-23T00:00:00Z'),
+    reconstructionMode: 'rebuild',
+    leanXmlVerifier: { enabled: lean },
+  });
+}
+
+async function compareInplace(originalBody: string, revisedBody: string) {
+  const original = await buildDocxFromBodyXml(originalBody);
+  const revised = await buildDocxFromBodyXml(revisedBody);
+  return compareDocumentsAtomizer(original, revised, {
+    author: 'Issue 582 Test',
+    date: new Date('2026-07-23T00:00:00Z'),
+    reconstructionMode: 'inplace',
+  });
+}
+
+async function outputXml(result: Awaited<ReturnType<typeof compareDocumentsAtomizer>>): Promise<string> {
+  expect(result.reconstructionModeUsed).toBe('rebuild');
+  return (await DocxArchive.load(result.document)).getDocumentXml();
+}
+
+const decoratedFields = [
+  { instruction: '\tPaGe   \\* MERGEFORMAT ', result: '7', anchor: '_Page' },
+  { instruction: ' NUMPAGES \t\\# "0" ', result: '12', anchor: '_NumPages' },
+  { instruction: ' ref Clause_1 \\h \\* MERGEFORMAT ', result: 'Section 1', anchor: 'Clause_1' },
+  { instruction: FIELD_INSTRUCTIONS.PAGEREF, result: '42', anchor: '_Toc123' },
+] as const;
+
+function allDecoratedFields(): string {
+  return decoratedFields
+    .map(({ instruction, result, anchor }, index) =>
+      decoratedComplexField(instruction, result, anchor) +
+      (index === decoratedFields.length - 1 ? '' : textRun(' | ')))
+    .join('');
+}
+
+describe('Forced rebuild preserves unchanged supported complex fields', () => {
+  test
+    .openspec('[SDX-FIELD-REBUILD-01] Outside edit preserves decorated supported fields')(
+    'preserves PAGE, NUMPAGES, REF, and PAGEREF run topology during a same-paragraph edit',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      const fields = allDecoratedFields();
+      const originalBody = `<w:p>${textRun('Before ')}${fields}${textRun(' old tail')}</w:p>`;
+      const revisedBody = `<w:p>${textRun('Before ')}${fields}${textRun(' new tail')}</w:p>`;
+      let originalXml = '';
+      let output = '';
+
+      await given('four decorated complex fields with fragmented instructions and wrapped results', async () => {
+        originalXml = await (await DocxArchive.load(
+          await buildDocxFromBodyXml(originalBody),
+        )).getDocumentXml();
+      });
+      await when('unrelated text in the same paragraph is compared through forced rebuild', async () => {
+        output = await outputXml(await compare(originalBody, revisedBody));
+      });
+      await then('all four ordered field ranges match their original topology exactly once', () => {
+        expect(canonicalRanges(output)).toEqual(canonicalRanges(originalXml));
+        expect(fieldRanges(output)).toHaveLength(4);
+        expect(Array.from(parseXml(output).getElementsByTagNameNS(OOXML.W_NS, 'hyperlink')))
+          .toHaveLength(4);
+        expect(Array.from(parseXml(output).getElementsByTagNameNS(OOXML.W_NS, 'rPr')))
+          .toHaveLength(24);
+      });
+      await and('accept and reject projections retain only their intended outside text', () => {
+        expect(extractTextWithParagraphs(acceptAllChanges(output))).toContain('new tail');
+        expect(extractTextWithParagraphs(rejectAllChanges(output))).toContain('old tail');
+      });
+    },
+  );
+
+  test
+    .openspec('[SDX-FIELD-REBUILD-01] Outside edit preserves decorated supported fields')(
+    'allows unrelated direct-child insertion and deletion before an unchanged field',
+    async ({ given, when, then }: AllureBddContext) => {
+      const field = decoratedComplexField(FIELD_INSTRUCTIONS.PAGE, '7', '_Page');
+      const cases = [
+        {
+          name: 'insert before',
+          original: `<w:p>${textRun('Stable ')}${field}${textRun(' tail')}</w:p>`,
+          revised: `<w:p>${textRun('Stable ')}${textRun('inserted ')}${field}${textRun(' tail')}</w:p>`,
+        },
+        {
+          name: 'delete before',
+          original: `<w:p>${textRun('Stable ')}${textRun('deleted ')}${field}${textRun(' tail')}</w:p>`,
+          revised: `<w:p>${textRun('Stable ')}${field}${textRun(' tail')}</w:p>`,
+        },
+      ];
+      const outputs: string[] = [];
+
+      await given('unchanged PAGE topology preceded by an unrelated direct paragraph child', () => {});
+      await when('that sibling is inserted or deleted during forced rebuild', async () => {
+        for (const scenario of cases) {
+          outputs.push(await outputXml(await compare(scenario.original, scenario.revised)));
+        }
+      });
+      await then('positional shifts do not alter field counterpart identity or topology', async () => {
+        for (const [index, scenario] of cases.entries()) {
+          const originalXml = await (await DocxArchive.load(
+            await buildDocxFromBodyXml(scenario.original),
+          )).getDocumentXml();
+          expect(canonicalRanges(outputs[index]!)).toEqual(canonicalRanges(originalXml));
+        }
+      });
+    },
+  );
+
+  test
+    .openspec('[SDX-FIELD-REBUILD-02] Multiple fields preserve deterministic order')(
+    'preserves multiple fields while rebuilding an edit in another paragraph',
+    async ({ given, when, then }: AllureBddContext) => {
+      const fields = allDecoratedFields();
+      const originalBody =
+        `<w:p>${textRun('Stable ')}${fields}</w:p><w:p>${textRun('Old second paragraph')}</w:p>`;
+      const revisedBody =
+        `<w:p>${textRun('Stable ')}${fields}</w:p><w:p>${textRun('New second paragraph')}</w:p>`;
+      let output = '';
+
+      await given('multiple unchanged fields in a paragraph separate from the edit', () => {});
+      await when('the complete main story is rebuilt', async () => {
+        output = await outputXml(await compare(originalBody, revisedBody));
+      });
+      await then('every field emits once in PAGE, NUMPAGES, REF, PAGEREF order', () => {
+        expect(fieldRanges(output).map((range) =>
+          range.flatMap((element) =>
+            Array.from(element.getElementsByTagNameNS(OOXML.W_NS, 'instrText')))
+            .map((element) => element.textContent ?? '')
+            .join('')
+            .trim()
+            .split(/\s+/)[0]!
+            .toUpperCase(),
+        )).toEqual(['PAGE', 'NUMPAGES', 'REF', 'PAGEREF']);
+      });
+    },
+  );
+
+  test
+    .openspec('[SDX-FIELD-REBUILD-03] Unsafe field ownership fails closed')(
+    'rejects changed, moved, nested, spanning, malformed, and shared ranges before reconstruction',
+    async ({ given, when, then }: AllureBddContext) => {
+      const page = decoratedComplexField(FIELD_INSTRUCTIONS.PAGE, '7', '_Page');
+      const numPages = decoratedComplexField(FIELD_INSTRUCTIONS.NUMPAGES, '12', '_NumPages');
+      const simplePage = completeField(FIELD_INSTRUCTIONS.PAGE, '7');
+      const cases: Array<{ name: string; original: string; revised: string }> = [
+        {
+          name: 'result mutation',
+          original: `<w:p>${page}</w:p>`,
+          revised: `<w:p>${decoratedComplexField(FIELD_INSTRUCTIONS.PAGE, '8', '_Page')}</w:p>`,
+        },
+        {
+          name: 'instruction mutation',
+          original: `<w:p>${page}</w:p>`,
+          revised: `<w:p>${decoratedComplexField(' page \\* MERGEFORMAT ', '7', '_Page')}</w:p>`,
+        },
+        {
+          name: 'format mutation',
+          original: `<w:p>${page}</w:p>`,
+          revised: `<w:p>${page.replace('<w:b/>', '<w:i/>')}</w:p>`,
+        },
+        {
+          name: 'wrapper attribute mutation',
+          original: `<w:p>${page}</w:p>`,
+          revised: `<w:p>${page.replace('w:history="1"', 'w:history="0"')}</w:p>`,
+        },
+        {
+          name: 'inserted field',
+          original: `<w:p>${textRun('plain')}</w:p>`,
+          revised: `<w:p>${textRun('plain')}${page}</w:p>`,
+        },
+        {
+          name: 'deleted field',
+          original: `<w:p>${textRun('plain')}${page}</w:p>`,
+          revised: `<w:p>${textRun('plain')}</w:p>`,
+        },
+        {
+          name: 'reordered fields',
+          original: `<w:p>${page}${numPages}</w:p>`,
+          revised: `<w:p>${numPages}${page}</w:p>`,
+        },
+        {
+          name: 'field moved to another paragraph',
+          original: `<w:p>${page}</w:p><w:p>${textRun('plain')}</w:p>`,
+          revised: `<w:p>${textRun('plain')}</w:p><w:p>${page}</w:p>`,
+        },
+        {
+          name: 'nested field',
+          original: `<w:p>${simplePage}</w:p>`,
+          revised:
+            `<w:p><w:r><w:fldChar w:fldCharType="begin"/></w:r>` +
+            `<w:r><w:instrText xml:space="preserve"> PAGE </w:instrText></w:r>` +
+            simplePage +
+            `<w:r><w:fldChar w:fldCharType="separate"/></w:r>` +
+            `<w:r><w:t>7</w:t></w:r><w:r><w:fldChar w:fldCharType="end"/></w:r></w:p>`,
+        },
+        {
+          name: 'paragraph-spanning field',
+          original: `<w:p>${simplePage}</w:p>`,
+          revised:
+            `<w:p><w:r><w:fldChar w:fldCharType="begin"/></w:r>` +
+            `<w:r><w:instrText xml:space="preserve"> PAGE </w:instrText></w:r></w:p>` +
+            `<w:p><w:r><w:fldChar w:fldCharType="separate"/></w:r>` +
+            `<w:r><w:t>7</w:t></w:r><w:r><w:fldChar w:fldCharType="end"/></w:r></w:p>`,
+        },
+        {
+          name: 'shared begin run',
+          original: `<w:p>${simplePage}</w:p>`,
+          revised:
+            `<w:p><w:r><w:t>unrelated</w:t><w:fldChar w:fldCharType="begin"/></w:r>` +
+            `<w:r><w:instrText xml:space="preserve"> PAGE </w:instrText></w:r>` +
+            `<w:r><w:fldChar w:fldCharType="separate"/></w:r><w:r><w:t>7</w:t></w:r>` +
+            `<w:r><w:fldChar w:fldCharType="end"/></w:r></w:p>`,
+        },
+        {
+          name: 'tracked paragraph owner',
+          original: `<w:p>${simplePage}</w:p>`,
+          revised: `<w:ins w:id="9"><w:p>${simplePage}</w:p></w:ins>`,
+        },
+        {
+          name: 'inline revision wrapper ownership',
+          original: `<w:p>${simplePage}</w:p>`,
+          revised: `<w:p><w:ins w:id="9" w:author="Reviewer">${simplePage}</w:ins></w:p>`,
+        },
+        {
+          name: 'unmatched begin',
+          original: `<w:p>${simplePage}</w:p>`,
+          revised:
+            `<w:p><w:r><w:fldChar w:fldCharType="begin"/></w:r>` +
+            `<w:r><w:instrText xml:space="preserve"> PAGE </w:instrText></w:r></w:p>`,
+        },
+      ];
+
+      await given('adversarial supported-field shapes that violate bounded ownership', () => {});
+      await when('each shape is compared through forced rebuild', async () => {
+        for (const scenario of cases) {
+          await expect(compare(scenario.original, scenario.revised), scenario.name)
+            .rejects.toThrow(/Opaque passthrough:/);
+        }
+      });
+      await then('none can reach lossy field reconstruction', () => {});
+    },
+  );
+
+  test
+    .openspec('[SDX-FIELD-REBUILD-03] Unsafe field ownership fails closed')(
+    'accepts REF separator switches only when the required argument is present',
+    async ({ given, when, then }: AllureBddContext) => {
+      const valid = decoratedComplexField(' REF Clause_1 \\d ":" ', 'Section:1', 'Clause_1');
+      const invalid = completeField(' REF Clause_1 \\d ', 'Section 1');
+      let output = '';
+
+      await given('REF fields with valid and missing separator-switch arguments', () => {});
+      await when('the valid field is rebuilt around an unrelated edit', async () => {
+        output = await outputXml(await compare(
+          `<w:p>${valid}${textRun(' old')}</w:p>`,
+          `<w:p>${valid}${textRun(' new')}</w:p>`,
+        ));
+      });
+      await then('the valid field is preserved and the missing argument fails closed', async () => {
+        expect(fieldRanges(output)).toHaveLength(1);
+        await expect(compare(
+          `<w:p>${invalid}</w:p>`,
+          `<w:p>${invalid}</w:p>`,
+        )).rejects.toThrow(/unsupported REF field instruction shape/);
+      });
+    },
+  );
+
+  test
+    .openspec('[SDX-FIELD-REBUILD-04] Inline SDT remains the sole owner')(
+    'leaves a field wholly inside an unchanged inline SDT under SDT ownership',
+    async ({ given, when, then }: AllureBddContext) => {
+      const field = decoratedComplexField(FIELD_INSTRUCTIONS.REF, 'Section 1', 'Clause_1');
+      const sdt =
+        `<w:sdt><w:sdtPr><w:id w:val="82"/></w:sdtPr>` +
+        `<w:sdtContent>${field}</w:sdtContent></w:sdt>`;
+      let output = '';
+
+      await given('a supported complex field wholly owned by an unchanged inline SDT', () => {});
+      await when('outside text changes in the containing paragraph', async () => {
+        output = await outputXml(await compare(
+          `<w:p>${sdt}${textRun(' old')}</w:p>`,
+          `<w:p>${sdt}${textRun(' new')}</w:p>`,
+        ));
+      });
+      await then('one SDT and one field range survive without duplicate emission', () => {
+        expect(Array.from(parseXml(output).getElementsByTagNameNS(OOXML.W_NS, 'sdt'))).toHaveLength(1);
+        expect(fieldRanges(output)).toHaveLength(0);
+        expect(Array.from(parseXml(output).getElementsByTagNameNS(OOXML.W_NS, 'fldChar')))
+          .toHaveLength(3);
+      });
+    },
+  );
+
+  test
+    .openspec('[SDX-FIELD-REBUILD-04] Inline SDT remains the sole owner')(
+    'retains source order when independent field and SDT owners are interleaved',
+    async ({ given, when, then }: AllureBddContext) => {
+      const field = decoratedComplexField(FIELD_INSTRUCTIONS.PAGE, '7', '_Page');
+      const sdt =
+        `<w:sdt><w:sdtPr><w:id w:val="83"/></w:sdtPr>` +
+        `<w:sdtContent>${textRun('controlled')}</w:sdtContent></w:sdt>`;
+      let output = '';
+
+      await given('an independent field owner before an unchanged inline SDT owner', () => {});
+      await when('outside text changes after both owners', async () => {
+        output = await outputXml(await compare(
+          `<w:p>${field}${sdt}${textRun(' old')}</w:p>`,
+          `<w:p>${field}${sdt}${textRun(' new')}</w:p>`,
+        ));
+      });
+      await then('both owners emit exactly once in field-then-SDT order', () => {
+        const paragraph = parseXml(output).getElementsByTagNameNS(OOXML.W_NS, 'p')[0]!;
+        const children = Array.from(paragraph.childNodes)
+          .filter((child): child is Element => child.nodeType === 1);
+        expect(children.findIndex((child) => fieldCharType(child) === 'begin'))
+          .toBeLessThan(children.findIndex((child) => child.localName === 'sdt'));
+        expect(fieldRanges(output)).toHaveLength(1);
+        expect(Array.from(parseXml(output).getElementsByTagNameNS(OOXML.W_NS, 'sdt'))).toHaveLength(1);
+      });
+    },
+  );
+
+  test
+    .openspec('[SDX-FIELD-REBUILD-05] Inplace and Lean boundaries remain unchanged')(
+    'does not engage ordered-range capture for direct inplace comparison',
+    async ({ given, when, then }: AllureBddContext) => {
+      const field = decoratedComplexField(FIELD_INSTRUCTIONS.PAGE, '7', '_Page');
+      const originalBody = `<w:p>${textRun('Before ')}${field}${textRun(' old')}</w:p>`;
+      const revisedBody = `<w:p>${textRun('Before ')}${field}${textRun(' new')}</w:p>`;
+      let result: Awaited<ReturnType<typeof compareDocumentsAtomizer>>;
+      let revisedXml = '';
+      let output = '';
+
+      await given('an unchanged fragmented PAGE field and an outside text edit', async () => {
+        revisedXml = await (await DocxArchive.load(
+          await buildDocxFromBodyXml(revisedBody),
+        )).getDocumentXml();
+      });
+      await when('comparison is requested directly in inplace mode', async () => {
+        result = await compareInplace(originalBody, revisedBody);
+        output = await (await DocxArchive.load(result.document)).getDocumentXml();
+      });
+      await then('inplace remains selected and retains its established revised field topology', () => {
+        expect(result.reconstructionModeUsed).toBe('inplace');
+        expect(canonicalRanges(output)).toEqual(canonicalRanges(revisedXml));
+      });
+    },
+  );
+
+  test
+    .openspec('[SDX-FIELD-REBUILD-05] Inplace and Lean boundaries remain unchanged')(
+    'reports Lean rebuild evidence as not applicable',
+    async ({ given, when, then }: AllureBddContext) => {
+      const field = decoratedComplexField(FIELD_INSTRUCTIONS.PAGE, '7', '_Page');
+      let status: string | undefined;
+
+      await given('a forced rebuild with the compiled Lean verifier requested', () => {});
+      await when('the comparison certificate is assembled', async () => {
+        const result = await compare(
+          `<w:p>${field}${textRun(' old')}</w:p>`,
+          `<w:p>${field}${textRun(' new')}</w:p>`,
+          true,
+        );
+        status = result.documentIntegrity?.status;
+      });
+      await then('the Lean evidence remains explicitly outside rebuild scope', () => {
+        expect(status).toBe('not_applicable');
+      });
+    },
+  );
+
+  test
+    .openspec('[SDX-FIELD-CONFORMANCE-01] REF and PAGEREF claims are bounded')(
+    'registers REF and PAGEREF without field-engine claims',
+    async ({ given, when, then }: AllureBddContext) => {
+      let registry = '';
+
+      await given('the machine-readable ECMA-376 registry', () => {});
+      await when('the REF and PAGEREF entries are read', () => {
+        registry = readFileSync(
+          join(import.meta.dirname, '../../../../../spec-compliance/registry/ecma-376.md'),
+          'utf8',
+        );
+      });
+      await then('both entries state the bounded preservation and evaluation exclusions', () => {
+        expect(registry).toContain('[ECMA-PART1-17-16-5-45]');
+        expect(registry).toContain('[ECMA-PART1-17-16-5-51]');
+        expect(registry).toContain('does not claim bookmark resolution');
+        expect(registry).toContain('cached-result correctness, or field evaluation');
+      });
+    },
+  );
+
+  test
+    .openspec('[SDX-FIELD-CONFORMANCE-02] Executable evidence names the verification boundary')(
+    'keeps rebuild topology outside the Lean certificate claim',
+    async ({ given, when, then }: AllureBddContext) => {
+      const field = decoratedComplexField(FIELD_INSTRUCTIONS.REF, 'Section 1', 'Clause_1');
+      let reason: string | undefined;
+
+      await given('a supported field rebuild with Lean evidence enabled', () => {});
+      await when('the document-integrity certificate is returned', async () => {
+        const result = await compare(
+          `<w:p>${field}${textRun(' old')}</w:p>`,
+          `<w:p>${field}${textRun(' new')}</w:p>`,
+          true,
+        );
+        reason = result.documentIntegrity?.reason;
+      });
+      await then('the certificate says fixed-story verification covers inplace output only', () => {
+        expect(reason).toContain('inplace comparison output only');
+      });
+    },
+  );
+});

--- a/packages/docx-compare/src/baselines/atomizer/hierarchicalLcs.ts
+++ b/packages/docx-compare/src/baselines/atomizer/hierarchicalLcs.ts
@@ -439,6 +439,7 @@ function createOpaqueGroupIdentityResolver(instrumentation?: GroupLcsInstrumenta
       .map((descriptor) =>
         `${descriptor.placementKind}\u0000${descriptor.containerIdentity}\u0000${descriptor.paragraphOrdinal}\u0000` +
         `${descriptor.bodyChildOrdinal ?? ''}\u0000${descriptor.ownedParagraphCount ?? ''}\u0000` +
+        `${descriptor.inlineRangeOrdinal ?? ''}\u0000` +
         `${relativeByDescriptor?.get(descriptor) ?? ''}\u0000` +
         `${descriptor.documentOrdinal}\u0000${descriptor.semanticFingerprint}\u0000` +
         `${descriptor.relationshipClosureFingerprint ?? ''}`,

--- a/packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts
+++ b/packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts
@@ -679,6 +679,375 @@ export function captureSdtPassthrough(root: Element, atoms: ComparisonUnitAtom[]
   }
 }
 
+type SupportedComplexField = 'PAGE' | 'NUMPAGES' | 'REF' | 'PAGEREF';
+
+function fieldCharType(atom: ComparisonUnitAtom): string | null {
+  const element = atom.contentElement;
+  if (element.namespaceURI !== OOXML.W_NS || element.localName !== 'fldChar') return null;
+  return element.getAttributeNS(OOXML.W_NS, 'fldCharType') ||
+    element.getAttribute('w:fldCharType') ||
+    element.getAttribute('fldCharType');
+}
+
+function paragraphAndDirectChild(
+  atom: ComparisonUnitAtom,
+): { paragraph: Element; child: Element } | null {
+  const paragraphIndex = atom.ancestorElements.findIndex(
+    (ancestor) => ancestor.namespaceURI === OOXML.W_NS && ancestor.localName === 'p',
+  );
+  if (paragraphIndex < 0) return null;
+  const paragraph = atom.ancestorElements[paragraphIndex]!;
+  const child = atom.ancestorElements[paragraphIndex + 1] ?? atom.contentElement;
+  return child.parentNode === paragraph ? { paragraph, child } : null;
+}
+
+function hasTrackedParagraphOwnership(atom: ComparisonUnitAtom, paragraph: Element): boolean {
+  for (const ancestor of atom.ancestorElements) {
+    if (ancestor === paragraph) return false;
+    if (
+      ancestor.namespaceURI === OOXML.W_NS &&
+      (ancestor.localName === 'ins' || ancestor.localName === 'del' ||
+        ancestor.localName === 'moveFrom' || ancestor.localName === 'moveTo')
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function tokenizeFieldInstruction(instruction: string): string[] | null {
+  const tokens: string[] = [];
+  let index = 0;
+  while (index < instruction.length) {
+    while (index < instruction.length && /\s/.test(instruction[index]!)) index++;
+    if (index >= instruction.length) break;
+    if (instruction[index] === '"') {
+      index++;
+      let value = '';
+      let closed = false;
+      while (index < instruction.length) {
+        const character = instruction[index++]!;
+        if (character === '"') {
+          closed = true;
+          break;
+        }
+        if (character === '\r' || character === '\n') return null;
+        value += character;
+      }
+      if (!closed || (index < instruction.length && !/\s/.test(instruction[index]!))) return null;
+      tokens.push(value);
+      continue;
+    }
+    const start = index;
+    while (index < instruction.length && !/\s/.test(instruction[index]!)) {
+      if (instruction[index] === '"') return null;
+      index++;
+    }
+    tokens.push(instruction.slice(start, index));
+  }
+  return tokens;
+}
+
+function validFieldSwitches(
+  tokens: readonly string[],
+  allowed: ReadonlySet<string>,
+  argumentSwitches: ReadonlySet<string> = new Set(['*', '#', '@']),
+): boolean {
+  for (let index = 0; index < tokens.length; index++) {
+    const token = tokens[index]!;
+    if (!token.startsWith('\\') || token.length !== 2) return false;
+    const name = token[1]!.toLowerCase();
+    if (!allowed.has(name)) return false;
+    if (argumentSwitches.has(name)) {
+      const argument = tokens[++index];
+      if (!argument || argument.startsWith('\\')) return false;
+    }
+  }
+  return true;
+}
+
+function supportedFieldKeyword(instruction: string): SupportedComplexField | null {
+  const match = /^\s*([A-Za-z]+)/.exec(instruction);
+  if (!match) return null;
+  const keyword = match[1]!.toUpperCase();
+  return keyword === 'PAGE' || keyword === 'NUMPAGES' ||
+    keyword === 'REF' || keyword === 'PAGEREF'
+    ? keyword
+    : null;
+}
+
+function classifyFieldInstruction(instruction: string): SupportedComplexField | null {
+  const tokens = tokenizeFieldInstruction(instruction);
+  if (!tokens || tokens.length === 0) return null;
+  const keyword = tokens[0]!.toUpperCase();
+  if (keyword === 'PAGE') {
+    return validFieldSwitches(tokens.slice(1), new Set(['*', '#'])) ? 'PAGE' : null;
+  }
+  if (keyword === 'NUMPAGES') {
+    return validFieldSwitches(tokens.slice(1), new Set(['*', '#'])) ? 'NUMPAGES' : null;
+  }
+  if (keyword !== 'REF' && keyword !== 'PAGEREF') return null;
+  const bookmark = tokens[1];
+  if (!bookmark || bookmark.startsWith('\\')) return null;
+  const allowed = keyword === 'REF'
+    ? new Set(['d', 'f', 'h', 'n', 'p', 'r', 't', 'w', '*'])
+    : new Set(['h', 'p', '*']);
+  const argumentSwitches = keyword === 'REF'
+    ? new Set(['*', 'd'])
+    : new Set(['*']);
+  return validFieldSwitches(tokens.slice(2), allowed, argumentSwitches) ? keyword : null;
+}
+
+function materializeOrderedRange(elements: readonly Element[]): {
+  sourceElements: Element[];
+  fingerprint: string;
+  namespaces: Readonly<Record<string, string>>;
+  mce: Readonly<Record<string, string>>;
+} {
+  const sourceElements: Element[] = [];
+  const fingerprints: string[] = [];
+  let firstNamespaces: Readonly<Record<string, string>> = {};
+  let firstMce: Readonly<Record<string, string>> = {};
+  for (const [index, element] of elements.entries()) {
+    const bindings = effectiveNamespaces(element);
+    const declarations = effectiveMceDeclarations(element);
+    validateNamespaceOwnership(element, bindings);
+    validateIgnorableTokens(declarations.values, bindings);
+    if (index === 0) {
+      firstNamespaces = bindings;
+      firstMce = declarations.values;
+    }
+    sourceElements.push(materializeNamespaces(
+      element,
+      bindings,
+      declarations.values,
+      declarations.qualifiedNames,
+    ));
+    fingerprints.push(semanticFingerprint(element, bindings, declarations.values));
+  }
+  return {
+    sourceElements,
+    fingerprint: createHash('sha256').update(JSON.stringify(fingerprints), 'utf8').digest('hex'),
+    namespaces: firstNamespaces,
+    mce: firstMce,
+  };
+}
+
+/**
+ * Capture unchanged supported complex fields as ordered direct paragraph-child
+ * ranges before the atomizer collapses them to visible-result atoms.
+ *
+ * Ordered topology preservation is a SafeDocX metamorphic invariant.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.18
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.5.42
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.5.44
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.5.45
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.5.51
+ * @see https://github.com/UseJunior/safe-docx/issues/582
+ */
+export function captureComplexFieldPassthrough(
+  root: Element,
+  atoms: ComparisonUnitAtom[],
+): void {
+  const paragraphOrdinals = new Map(
+    Array.from(root.getElementsByTagNameNS(OOXML.W_NS, 'p'))
+      .map((paragraph, ordinal) => [paragraph, ordinal] as const),
+  );
+  let nextOrdinal = uniqueDescriptors(atoms).length;
+  const nextFieldRangeOrdinal = new Map<Element, number>();
+  let fieldStart = -1;
+  let separator = -1;
+  let ignoredDepth = 0;
+
+  const capture = (start: number, end: number, separate: number): void => {
+    const fieldAtoms = atoms.slice(start, end + 1);
+    const instructionEnd = separate >= 0 ? separate - start : fieldAtoms.length - 1;
+    const beforeSeparator = fieldAtoms.slice(1, instructionEnd);
+    if (
+      beforeSeparator.length === 0 ||
+      beforeSeparator.some((atom) =>
+        atom.contentElement.namespaceURI !== OOXML.W_NS ||
+        atom.contentElement.localName !== 'instrText')
+    ) {
+      return;
+    }
+    const instruction = beforeSeparator.map((atom) => atom.contentElement.textContent ?? '').join('');
+    const supportedKeyword = supportedFieldKeyword(instruction);
+    if (!supportedKeyword) return;
+    const fieldKind = classifyFieldInstruction(instruction);
+    if (!fieldKind) {
+      throw new OpaquePassthroughError(`unsupported ${supportedKeyword} field instruction shape`);
+    }
+    if (separate < 0) throw new OpaquePassthroughError('complex field has no separator');
+
+    const firstLocation = paragraphAndDirectChild(fieldAtoms[0]!);
+    const lastLocation = paragraphAndDirectChild(fieldAtoms[fieldAtoms.length - 1]!);
+    if (!firstLocation || !lastLocation || firstLocation.paragraph !== lastLocation.paragraph) {
+      throw new OpaquePassthroughError('complex field spans paragraphs or has unsupported placement');
+    }
+    const paragraph = firstLocation.paragraph;
+    if (
+      fieldAtoms.some((atom) => {
+        const location = paragraphAndDirectChild(atom);
+        return !location || location.paragraph !== paragraph;
+      })
+    ) {
+      throw new OpaquePassthroughError('complex field spans paragraphs or containers');
+    }
+
+    const existingOwners = new Set(
+      fieldAtoms.map((atom) => atom.opaquePassthrough).filter(
+        (owner): owner is OpaquePassthroughNode => owner !== undefined,
+      ),
+    );
+    if (existingOwners.size === 1) {
+      const [owner] = existingOwners;
+      if (
+        owner!.placementKind === 'inline-run' &&
+        fieldAtoms.every((atom) => atom.opaquePassthrough === owner)
+      ) {
+        return;
+      }
+    }
+    if (existingOwners.size > 0) {
+      throw new OpaquePassthroughError('complex field overlaps another opaque boundary');
+    }
+    if (fieldAtoms.some((atom) => hasTrackedParagraphOwnership(atom, paragraph))) {
+      throw new OpaquePassthroughError('complex field paragraph is owned by a tracked-change wrapper');
+    }
+
+    const paragraphChildren = Array.from(paragraph.childNodes)
+      .filter((child): child is Element => child.nodeType === 1);
+    const startOrdinal = paragraphChildren.indexOf(firstLocation.child);
+    const endOrdinal = paragraphChildren.indexOf(lastLocation.child);
+    if (startOrdinal < 0 || endOrdinal < startOrdinal) {
+      throw new OpaquePassthroughError('complex field direct-child range is malformed');
+    }
+    const rangeElements = paragraphChildren.slice(startOrdinal, endOrdinal + 1);
+    const fieldAtomSet = new Set(fieldAtoms);
+    for (const atom of atoms) {
+      const location = paragraphAndDirectChild(atom);
+      if (
+        location?.paragraph === paragraph &&
+        rangeElements.includes(location.child) &&
+        !fieldAtomSet.has(atom)
+      ) {
+        throw new OpaquePassthroughError(
+          'complex field range contains unrelated or shared-endpoint content',
+        );
+      }
+    }
+
+    const paragraphOrdinal = paragraphOrdinals.get(paragraph);
+    if (paragraphOrdinal === undefined) {
+      throw new OpaquePassthroughError('complex field paragraph has no source-order identity');
+    }
+    const fieldRangeOrdinal = nextFieldRangeOrdinal.get(paragraph) ?? 0;
+    nextFieldRangeOrdinal.set(paragraph, fieldRangeOrdinal + 1);
+    const materialized = materializeOrderedRange(rangeElements);
+    const descriptor: OpaquePassthroughNode = {
+      placementKind: 'inline-range',
+      namespaceUri: OOXML.W_NS,
+      localName: `complexField:${fieldKind}`,
+      documentOrdinal: nextOrdinal++,
+      paragraphOrdinal,
+      containerIdentity: structuralContainerIdentity(paragraph),
+      inlineChildStartOrdinal: startOrdinal,
+      inlineChildEndOrdinal: endOrdinal,
+      inlineRangeOrdinal: fieldRangeOrdinal,
+      semanticFingerprint: materialized.fingerprint,
+      sourceElement: materialized.sourceElements[0]!,
+      sourceElements: materialized.sourceElements,
+      effectiveNamespaces: materialized.namespaces,
+      effectiveMceDeclarations: materialized.mce,
+    };
+    for (const atom of fieldAtoms) atom.opaquePassthrough = descriptor;
+  };
+
+  for (let index = 0; index < atoms.length; index++) {
+    const atom = atoms[index]!;
+    const kind = fieldCharType(atom);
+    if (ignoredDepth > 0) {
+      if (kind === 'begin') ignoredDepth++;
+      else if (kind === 'end') ignoredDepth--;
+      continue;
+    }
+    if (atom.opaquePassthrough) {
+      if (fieldStart >= 0) {
+        const instructionEnd = separator >= 0 ? separator : index;
+        const instruction = atoms.slice(fieldStart + 1, instructionEnd)
+          .map((candidate) => candidate.contentElement.textContent ?? '')
+          .join('');
+        if (supportedFieldKeyword(instruction)) {
+          throw new OpaquePassthroughError('complex field crosses another opaque boundary');
+        }
+        fieldStart = -1;
+        separator = -1;
+      }
+      continue;
+    }
+    if (kind === 'begin') {
+      if (fieldStart >= 0) {
+        const instructionEnd = separator >= 0 ? separator : index;
+        const instructionAtoms = atoms.slice(fieldStart + 1, instructionEnd);
+        const supportedOuter = instructionAtoms.length > 0 &&
+          instructionAtoms.every((candidate) =>
+            candidate.contentElement.namespaceURI === OOXML.W_NS &&
+            candidate.contentElement.localName === 'instrText') &&
+          supportedFieldKeyword(
+            instructionAtoms.map((candidate) => candidate.contentElement.textContent ?? '').join(''),
+          );
+        if (supportedOuter) {
+          throw new OpaquePassthroughError('nested or overlapping complex fields are unsupported');
+        }
+        fieldStart = -1;
+        separator = -1;
+        ignoredDepth = 2;
+        continue;
+      }
+      fieldStart = index;
+      separator = -1;
+    } else if (kind === 'separate' && fieldStart >= 0) {
+      if (separator >= 0) {
+        const instruction = atoms.slice(fieldStart + 1, separator)
+          .map((candidate) => candidate.contentElement.textContent ?? '')
+          .join('');
+        if (supportedFieldKeyword(instruction)) {
+          throw new OpaquePassthroughError('complex field has multiple separators');
+        }
+        continue;
+      }
+      separator = index;
+    } else if (kind === 'end') {
+      if (fieldStart < 0) continue;
+      capture(fieldStart, index, separator);
+      fieldStart = -1;
+      separator = -1;
+    }
+  }
+  if (fieldStart >= 0) {
+    const instructionEnd = separator >= 0 ? separator : atoms.length;
+    const instruction = atoms.slice(fieldStart + 1, instructionEnd)
+      .map((candidate) => candidate.contentElement.textContent ?? '')
+      .join('');
+    if (supportedFieldKeyword(instruction)) {
+      throw new OpaquePassthroughError('complex field has unmatched begin marker');
+    }
+  }
+
+  // SDTs are captured first and fields second. Renumber all owners by first atom
+  // occurrence so mixed owner kinds retain one monotonic document order.
+  const orderedDescriptors = new Set<OpaquePassthroughNode>();
+  for (const atom of atoms) {
+    const descriptor = atom.opaquePassthrough;
+    if (descriptor) orderedDescriptors.add(descriptor);
+  }
+  Array.from(orderedDescriptors).forEach((descriptor, ordinal) => {
+    descriptor.documentOrdinal = ordinal;
+  });
+}
+
 function uniqueDescriptors(atoms: ComparisonUnitAtom[]): OpaquePassthroughNode[] {
   const seen = new Set<OpaquePassthroughNode>();
   const result: OpaquePassthroughNode[] = [];
@@ -705,10 +1074,14 @@ export async function bindOpaquePassthroughCounterparts(
     throw new OpaquePassthroughError(`boundary count changed (${original.length} original, ${revised.length} revised)`);
   }
   const placementKey = (descriptor: OpaquePassthroughNode) =>
-    descriptor.placementKind === 'inline-run'
-      ? `inline\u0000${descriptor.containerIdentity}\u0000${descriptor.paragraphOrdinal}\u0000${descriptor.documentOrdinal}`
-      : `block\u0000${descriptor.containerIdentity}\u0000${descriptor.bodyChildOrdinal}\u0000` +
-        `${descriptor.paragraphOrdinal}\u0000${descriptor.ownedParagraphCount}`;
+    descriptor.placementKind === 'body-block'
+      ? `block\u0000${descriptor.containerIdentity}\u0000${descriptor.bodyChildOrdinal}\u0000` +
+        `${descriptor.paragraphOrdinal}\u0000${descriptor.ownedParagraphCount}`
+      : descriptor.placementKind === 'inline-range'
+        ? `field\u0000${descriptor.containerIdentity}\u0000${descriptor.paragraphOrdinal}\u0000` +
+          `${descriptor.inlineRangeOrdinal}\u0000${descriptor.localName}`
+        : `inline\u0000${descriptor.containerIdentity}\u0000${descriptor.paragraphOrdinal}\u0000` +
+          `${descriptor.documentOrdinal}\u0000${descriptor.localName}`;
   original.sort((left, right) => placementKey(left).localeCompare(placementKey(right)));
   revised.sort((left, right) => placementKey(left).localeCompare(placementKey(right)));
   await Promise.all([
@@ -736,6 +1109,7 @@ export async function bindOpaquePassthroughCounterparts(
       before.namespaceUri !== after.namespaceUri ||
       before.localName !== after.localName ||
       before.bodyChildOrdinal !== after.bodyChildOrdinal ||
+      before.inlineRangeOrdinal !== after.inlineRangeOrdinal ||
       before.ownedParagraphCount !== after.ownedParagraphCount ||
       before.semanticFingerprint !== after.semanticFingerprint ||
       before.relationshipClosureFingerprint !== after.relationshipClosureFingerprint
@@ -744,6 +1118,7 @@ export async function bindOpaquePassthroughCounterparts(
     }
     before.correlatedNode = after;
     after.emissionElement = before.sourceElement;
+    after.emissionElements = before.sourceElements ?? [before.sourceElement];
   }
 }
 
@@ -767,7 +1142,7 @@ export function validateOpaquePassthroughCorrelation(atoms: ComparisonUnitAtom[]
       descriptor = descriptor.correlatedNode;
       atom.opaquePassthrough = descriptor;
     }
-    if (!descriptor.emissionElement ||
+    if ((!descriptor.emissionElements && !descriptor.emissionElement) ||
       (atom.sourceDocument !== 'revised' && atom.contentElement.tagName !== '__emptyParagraph__')) {
       throw new OpaquePassthroughError(
         `boundary ${descriptor.documentOrdinal} has no validated revised-side owner`,
@@ -841,7 +1216,7 @@ export function renderOpaqueAtomSequence(
         pendingAtoms.push(atom);
         continue;
       }
-      if (descriptor.placementKind !== 'inline-run') {
+      if (descriptor.placementKind === 'body-block') {
         throw new OpaquePassthroughError('body-block boundary reached paragraph-run emission');
       }
       if (descriptor !== active) {
@@ -860,11 +1235,13 @@ export function renderOpaqueAtomSequence(
       if (atom.correlationStatus !== CorrelationStatus.Equal) {
         throw new OpaquePassthroughError(`boundary ${descriptor.documentOrdinal} contains a non-equal atom`);
       }
-      if (!descriptor.emissionElement) {
+      if (!descriptor.emissionElements && !descriptor.emissionElement) {
         throw new OpaquePassthroughError(`boundary ${descriptor.documentOrdinal} has no validated original owner`);
       }
       if (!emitted.has(descriptor)) {
-        output.push(serialize(descriptor.emissionElement));
+        output.push(
+          (descriptor.emissionElements ?? [descriptor.emissionElement!]).map(serialize).join(''),
+        );
         emitted.add(descriptor);
       }
     }

--- a/packages/docx-compare/src/baselines/atomizer/pipeline.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline.ts
@@ -721,7 +721,11 @@ export async function compareDocumentsAtomizer(
     }
 
     const effectiveAtomizeOptions = outputMode === 'rebuild'
-      ? { ...atomizeOptions, captureInlineSdtPassthrough: true }
+      ? {
+          ...atomizeOptions,
+          captureInlineSdtPassthrough: true,
+          captureComplexFieldPassthrough: reconstructionMode === 'rebuild',
+        }
       : atomizeOptions;
     const { atoms: originalAtoms } = atomizeTree(originalBody, [], originalPart, effectiveAtomizeOptions);
     const { atoms: revisedAtoms } = atomizeTree(revisedBody, [], revisedPart, effectiveAtomizeOptions);

--- a/packages/docx-compare/src/testing/ooxml-fixtures.ts
+++ b/packages/docx-compare/src/testing/ooxml-fixtures.ts
@@ -66,6 +66,7 @@ export const FIELD_INSTRUCTIONS = {
   NUMPAGES: ' NUMPAGES ',
   PAGE: ' PAGE ',
   PAGEREF: ' PAGEREF _Toc123 \\h ',
+  REF: ' REF Clause_1 \\h ',
 } as const;
 
 // A complete, self-contained simple field: begin → instrText → separate →
@@ -86,6 +87,40 @@ export const COMPLETE_NUMPAGES_FIELD = completeField(FIELD_INSTRUCTIONS.NUMPAGES
 export const COMPLETE_PAGE_FIELD = completeField(FIELD_INSTRUCTIONS.PAGE, '1');
 
 export const COMPLETE_PAGEREF_FIELD = completeField(FIELD_INSTRUCTIONS.PAGEREF, '42');
+
+export const COMPLETE_REF_FIELD = completeField(FIELD_INSTRUCTIONS.REF, 'Section 1');
+
+/**
+ * Build a topology-sensitive complex field used by forced-rebuild tests.
+ *
+ * Every field component has distinct run properties, the instruction is
+ * fragmented across two runs, and the cached result retains a pre-existing
+ * wrapper. The extension payload is intentionally opaque to the comparison
+ * engine.
+ */
+export function decoratedComplexField(
+  instruction: string,
+  result: string,
+  anchor = '_FieldResult',
+): string {
+  const split = Math.max(1, Math.floor(instruction.length / 2));
+  const firstInstruction = escapeXmlText(instruction.slice(0, split));
+  const secondInstruction = escapeXmlText(instruction.slice(split));
+  return (
+    `<w:r w:rsidR="A0000001"><w:rPr><w:b/></w:rPr>` +
+    `<w:fldChar w:fldCharType="begin" w:dirty="false"/></w:r>` +
+    `<w:r><w:rPr><w:i/></w:rPr><w:instrText xml:space="preserve">${firstInstruction}</w:instrText></w:r>` +
+    `<w:r><w:rPr><w:color w:val="336699"/></w:rPr>` +
+    `<w:instrText xml:space="preserve">${secondInstruction}</w:instrText></w:r>` +
+    `<w:r><w:rPr><w:u w:val="single"/></w:rPr>` +
+    `<w:fldChar w:fldCharType="separate"/></w:r>` +
+    `<w:hyperlink w:anchor="${escapeXmlText(anchor)}" w:history="1">` +
+    `<w:r><w:rPr><w:smallCaps/></w:rPr><w:t>${escapeXmlText(result)}</w:t></w:r>` +
+    `</w:hyperlink>` +
+    `<w:r><w:rPr><w:vanish/><w14:textEffect w14:val="none"/></w:rPr>` +
+    `<w:fldChar w:fldCharType="end"/></w:r>`
+  );
+}
 
 // ECMA-376 conformant field-modification pattern: a field whose instruction
 // text is changing under track changes. The fldChars remain UNWRAPPED at the

--- a/packages/docx-core/src/core-types.ts
+++ b/packages/docx-core/src/core-types.ts
@@ -111,11 +111,11 @@ export interface FormatChangeInfo {
  * retains a cloned element rather than exposing a serialized public contract.
  * `documentOrdinal` identifies the boundary among other captured boundaries in
  * source order. The reconstructor validates original/revised counterparts before
- * assigning `emissionElement` from the original side.
+ * assigning `emissionElements` from the original side.
  */
 export interface OpaquePassthroughNode {
   /** Determines whether paragraph-run emission or the body scaffold owns output. */
-  placementKind: 'inline-run' | 'body-block';
+  placementKind: 'inline-run' | 'inline-range' | 'body-block';
   namespaceUri: string;
   localName: string;
   documentOrdinal: number;
@@ -125,10 +125,18 @@ export interface OpaquePassthroughNode {
   containerIdentity: string;
   /** Direct body-child position for a scaffold-owned block boundary. */
   bodyChildOrdinal?: number;
+  /** Inclusive direct paragraph-child range for an ordered inline payload. */
+  inlineChildStartOrdinal?: number;
+  inlineChildEndOrdinal?: number;
+  /** Stable sequence position among captured field ranges in this paragraph. */
+  inlineRangeOrdinal?: number;
   /** Number of contiguous source-order paragraph slots owned by a block boundary. */
   ownedParagraphCount?: number;
   semanticFingerprint: string;
+  /** First retained XML element; kept for source compatibility with single-node owners. */
   sourceElement: WmlElement;
+  /** Ordered XML payload retained by this boundary. */
+  sourceElements?: WmlElement[];
   effectiveNamespaces: Readonly<Record<string, string>>;
   effectiveMceDeclarations: Readonly<Record<string, string>>;
   /** Package relationship closure rooted at relationship attributes in a block subtree. */
@@ -136,6 +144,7 @@ export interface OpaquePassthroughNode {
   /** Revised-side canonical owner for an equal original empty-paragraph atom. */
   correlatedNode?: OpaquePassthroughNode;
   emissionElement?: WmlElement;
+  emissionElements?: WmlElement[];
 }
 
 /**

--- a/packages/docx-core/src/generation/generation-compare-roundtrip.test.ts
+++ b/packages/docx-core/src/generation/generation-compare-roundtrip.test.ts
@@ -378,25 +378,42 @@ describe('Author->compare round-trip guarantee', () => {
           malformed = await archive.save();
         });
 
-        let result!: CompareResult;
+        let result: CompareResult | undefined;
+        let rejectionMessage: string | undefined;
         await when(`the original is compared against the malformed revision in '${mode}' mode`, async () => {
-          result = await compareDocuments(original, malformed, { engine: 'atomizer', reconstructionMode: mode });
-          await attachPrettyJson('guard-diagnostics', {
-            used: result.reconstructionModeUsed,
-            fallbackReason: result.fallbackReason ?? null,
-            fallbackAttempts: result.fallbackDiagnostics?.attempts?.map((a) => a.failedChecks) ?? null,
-            rebuild: result.rebuildSafetyDiagnostics?.failedChecks ?? null,
-          });
+          try {
+            result = await compareDocuments(original, malformed, { engine: 'atomizer', reconstructionMode: mode });
+          } catch (error) {
+            rejectionMessage = error instanceof Error ? error.message : String(error);
+          }
+          await attachPrettyJson(
+            'guard-diagnostics',
+            result
+              ? {
+                  used: result.reconstructionModeUsed,
+                  fallbackReason: result.fallbackReason ?? null,
+                  fallbackAttempts: result.fallbackDiagnostics?.attempts?.map((a) => a.failedChecks) ?? null,
+                  rebuild: result.rebuildSafetyDiagnostics?.failedChecks ?? null,
+                }
+              : { rejectionMessage },
+          );
         });
 
         await then('the reconstruction guard reports a fieldStructure failure rather than passing silently', async () => {
-          expect(result.rebuildSafetyDiagnostics?.failedChecks ?? []).toContain('fieldStructure');
-          if (mode === 'inplace') {
-            expect(result.fallbackReason).toBe('round_trip_safety_check_failed');
-            const attempts = result.fallbackDiagnostics?.attempts ?? [];
-            expect(attempts.length).toBeGreaterThan(0);
-            expect(attempts.every((a) => a.failedChecks.includes('fieldStructure'))).toBe(true);
+          if (mode === 'rebuild') {
+            expect(result).toBeUndefined();
+            expect(rejectionMessage).toMatch(
+              /Opaque passthrough: complex field has unmatched begin marker/,
+            );
+            return;
           }
+
+          expect(result).toBeDefined();
+          expect(result?.rebuildSafetyDiagnostics?.failedChecks ?? []).toContain('fieldStructure');
+          expect(result?.fallbackReason).toBe('round_trip_safety_check_failed');
+          const attempts = result?.fallbackDiagnostics?.attempts ?? [];
+          expect(attempts.length).toBeGreaterThan(0);
+          expect(attempts.every((a) => a.failedChecks.includes('fieldStructure'))).toBe(true);
         });
 
         await then('a well-formed revision in the same mode surfaces no safety failures (control)', async () => {

--- a/packages/docx-core/src/integration/rebuild-safety-diagnostics-pipeline.test.ts
+++ b/packages/docx-core/src/integration/rebuild-safety-diagnostics-pipeline.test.ts
@@ -3,12 +3,9 @@
  *
  * Verifies that `compareDocumentsAtomizer` runs the round-trip safety suite
  * (text equality, bookmark diagnostics, per-story field structure) on rebuild
- * output. Rebuild is the terminal reconstruction strategy — there is no
- * further fallback — so failures must not block the output; they surface in
- * `rebuildSafetyDiagnostics` as a caller-visible warning. Previously the
- * direct-rebuild path (including the default mode) returned its output with
- * zero safety screening, so a malformed field per the ECMA-376 fldChar
- * begin/end pairing rules could ship undetected.
+ * output. Rebuild is the terminal reconstruction strategy, so failures that
+ * are outside the supported opaque-field preflight surface in
+ * `rebuildSafetyDiagnostics` as caller-visible warnings.
  *
  * @see https://github.com/UseJunior/safe-docx/issues/226
  */
@@ -21,7 +18,6 @@ import {
   instrText,
   paragraphWithField,
   paragraphWithText,
-  FIELD_INSTRUCTIONS,
   resultText,
 } from '../testing/ooxml-fixtures.js';
 import { compareDocuments } from '@usejunior/docx-compare';
@@ -34,32 +30,32 @@ const test = testAllure
 // A field opened (begin → instrText → separate → result) but never closed:
 // the body story's begin/end counts are 1:0, so validateFieldStructure must
 // reject any output that carries it.
-const UNCLOSED_PAGE_FIELD =
+const UNCLOSED_DATE_FIELD =
   fldChar('begin') +
-  instrText(FIELD_INSTRUCTIONS.PAGE, { preserve: true }) +
+  instrText(' DATE ', { preserve: true }) +
   fldChar('separate') +
   resultText('3');
 
 async function buildMalformedFieldPair(): Promise<{ original: Buffer; revised: Buffer }> {
   return {
     original: await buildDocxFromBodyXml(
-      paragraphWithField('Intro', UNCLOSED_PAGE_FIELD, '') + paragraphWithText('Hello'),
+      paragraphWithField('Intro', UNCLOSED_DATE_FIELD, '') + paragraphWithText('Hello'),
     ),
     revised: await buildDocxFromBodyXml(
-      paragraphWithField('Intro', UNCLOSED_PAGE_FIELD, '') + paragraphWithText('Hello world'),
+      paragraphWithField('Intro', UNCLOSED_DATE_FIELD, '') + paragraphWithText('Hello world'),
     ),
   };
 }
 
 describe('Rebuild-output safety screening (issue #226) — pipeline-level', () => {
   test(
-    'explicit rebuild with a malformed body field returns output WITH fieldStructure failure surfaced',
+    'explicit rebuild returns unsupported malformed fields with fieldStructure diagnostics',
     async ({ given, when, then, and, attachPrettyJson }: AllureBddContext) => {
       let original: Buffer = Buffer.alloc(0);
       let revised: Buffer = Buffer.alloc(0);
       let result: Awaited<ReturnType<typeof compareDocuments>>;
 
-      await given('original/revised pair whose body opens a field that never closes', async () => {
+      await given('original/revised pair whose body opens an unsupported DATE field that never closes', async () => {
         ({ original, revised } = await buildMalformedFieldPair());
       });
 
@@ -75,41 +71,33 @@ describe('Rebuild-output safety screening (issue #226) — pipeline-level', () =
         });
       });
 
-      await then('rebuild output is still returned (no further fallback exists)', () => {
+      await then('rebuild output is returned for the unsupported field instruction', () => {
         expect(result.document.length).toBeGreaterThan(0);
         expect(result.reconstructionModeUsed).toBe('rebuild');
-        expect(result.fallbackReason).toBeUndefined();
       });
-
-      await and('the fieldStructure failure is surfaced in rebuildSafetyDiagnostics', () => {
-        const diagnostics = result.rebuildSafetyDiagnostics;
-        expect(diagnostics, 'rebuild output must be safety-screened').toBeDefined();
-        expect(diagnostics?.failedChecks).toContain('fieldStructure');
-        expect(diagnostics?.checks.fieldStructure).toBe(false);
+      await and('the existing fieldStructure diagnostic remains caller-visible', () => {
+        expect(result.rebuildSafetyDiagnostics?.failedChecks).toContain('fieldStructure');
+        expect(result.rebuildSafetyDiagnostics?.checks.fieldStructure).toBe(false);
       });
     },
   );
 
   test(
-    'default mode (no reconstructionMode) gets the same rebuild safety screening',
-    async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
+    'default rebuild mode keeps unsupported malformed-field safety diagnostics',
+    async ({ given, when, then }: AllureBddContext) => {
       let original: Buffer = Buffer.alloc(0);
       let revised: Buffer = Buffer.alloc(0);
       let result: Awaited<ReturnType<typeof compareDocuments>>;
 
-      await given('original/revised pair whose body opens a field that never closes', async () => {
+      await given('original/revised pair whose body opens an unsupported DATE field that never closes', async () => {
         ({ original, revised } = await buildMalformedFieldPair());
       });
 
       await when('compared without specifying a reconstruction mode', async () => {
         result = await compareDocuments(original, revised, { engine: 'atomizer' });
-        await attachPrettyJson('comparison-metadata.json', {
-          reconstructionModeUsed: result.reconstructionModeUsed,
-          rebuildSafetyDiagnostics: result.rebuildSafetyDiagnostics,
-        });
       });
 
-      await then('the fieldStructure failure is surfaced in rebuildSafetyDiagnostics', () => {
+      await then('the fieldStructure failure is surfaced without opaque preflight rejection', () => {
         expect(result.reconstructionModeUsed).toBe('rebuild');
         expect(result.rebuildSafetyDiagnostics?.failedChecks).toContain('fieldStructure');
       });

--- a/packages/docx-core/src/integration/roundtrip-structural-invariants.test.ts
+++ b/packages/docx-core/src/integration/roundtrip-structural-invariants.test.ts
@@ -328,7 +328,7 @@ describe('Structural Round-Trip Invariants - ILPA Pair (feature-rich)', () => {
       const revised = await readFile(ILPA_REVISED_DOC);
 
       await expect(buildRoundTripArtifacts(original, revised, 'rebuild')).rejects.toThrow(
-        /Opaque passthrough: boundary 0 changed paragraph ownership, moved, or mutated/
+        /Opaque passthrough: (?:boundary count changed|boundary 0 changed paragraph ownership, moved, or mutated)/
       );
     },
     120000

--- a/packages/docx-core/src/testing/ooxml-fixtures.ts
+++ b/packages/docx-core/src/testing/ooxml-fixtures.ts
@@ -66,6 +66,7 @@ export const FIELD_INSTRUCTIONS = {
   NUMPAGES: ' NUMPAGES ',
   PAGE: ' PAGE ',
   PAGEREF: ' PAGEREF _Toc123 \\h ',
+  REF: ' REF Clause_1 \\h ',
 } as const;
 
 // A complete, self-contained simple field: begin → instrText → separate →
@@ -86,6 +87,40 @@ export const COMPLETE_NUMPAGES_FIELD = completeField(FIELD_INSTRUCTIONS.NUMPAGES
 export const COMPLETE_PAGE_FIELD = completeField(FIELD_INSTRUCTIONS.PAGE, '1');
 
 export const COMPLETE_PAGEREF_FIELD = completeField(FIELD_INSTRUCTIONS.PAGEREF, '42');
+
+export const COMPLETE_REF_FIELD = completeField(FIELD_INSTRUCTIONS.REF, 'Section 1');
+
+/**
+ * Build a topology-sensitive complex field used by forced-rebuild tests.
+ *
+ * Every field component has distinct run properties, the instruction is
+ * fragmented across two runs, and the cached result retains a pre-existing
+ * wrapper. The extension payload is intentionally opaque to the comparison
+ * engine.
+ */
+export function decoratedComplexField(
+  instruction: string,
+  result: string,
+  anchor = '_FieldResult',
+): string {
+  const split = Math.max(1, Math.floor(instruction.length / 2));
+  const firstInstruction = escapeXmlText(instruction.slice(0, split));
+  const secondInstruction = escapeXmlText(instruction.slice(split));
+  return (
+    `<w:r w:rsidR="A0000001"><w:rPr><w:b/></w:rPr>` +
+    `<w:fldChar w:fldCharType="begin" w:dirty="false"/></w:r>` +
+    `<w:r><w:rPr><w:i/></w:rPr><w:instrText xml:space="preserve">${firstInstruction}</w:instrText></w:r>` +
+    `<w:r><w:rPr><w:color w:val="336699"/></w:rPr>` +
+    `<w:instrText xml:space="preserve">${secondInstruction}</w:instrText></w:r>` +
+    `<w:r><w:rPr><w:u w:val="single"/></w:rPr>` +
+    `<w:fldChar w:fldCharType="separate"/></w:r>` +
+    `<w:hyperlink w:anchor="${escapeXmlText(anchor)}" w:history="1">` +
+    `<w:r><w:rPr><w:smallCaps/></w:rPr><w:t>${escapeXmlText(result)}</w:t></w:r>` +
+    `</w:hyperlink>` +
+    `<w:r><w:rPr><w:vanish/><w14:textEffect w14:val="none"/></w:rPr>` +
+    `<w:fldChar w:fldCharType="end"/></w:r>`
+  );
+}
 
 // ECMA-376 conformant field-modification pattern: a field whose instruction
 // text is changing under track changes. The fldChars remain UNWRAPPED at the

--- a/packages/docx-mcp/docs/tool-reference.generated.md
+++ b/packages/docx-mcp/docs/tool-reference.generated.md
@@ -120,7 +120,7 @@ Save document. For DOCX: saves clean and/or tracked changes output. For ODT: sav
 | `file_path` | `string` | no | Path to the DOCX or ODT file. |
 | `google_doc_id` | `string` | no | Google Doc ID or URL (alternative to file_path). Extract from URL: docs.google.com/document/d/{ID}/edit |
 | `save_to_local_path` | `string` | yes |  |
-| `clean_bookmarks` | `boolean` | no |  |
+| `clean_bookmarks` | `boolean` | no | Controls removal of internal bookmarks from DOCX output. Behavior is intentionally three-way: OMIT (recommended for tracked/persistence saves) preserves the document's own bookmarks — only safe-docx paragraph anchors (`_bk_*`) are removed. Explicit `true` ALSO strips harness edit-span bookmarks (`edit-*`) to produce a clean deliverable; do NOT pass it when the tracked output feeds a redline pipeline, because that reproduces the pre-#609 loss of `edit-*` anchors. `false` keeps all bookmarks. Omitting is NOT equivalent to passing `true` — they differ precisely in whether original `edit-*` bookmarks survive. |
 | `save_format` | `enum("clean", "tracked", "both")` | no |  |
 | `allow_overwrite` | `boolean` | no |  |
 | `tracked_save_to_local_path` | `string` | no |  |

--- a/packages/docx-mcp/src/tools/save.test.ts
+++ b/packages/docx-mcp/src/tools/save.test.ts
@@ -19,7 +19,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 
 const WORDPROCESSING_ML_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
-const TEST_FEATURE = 'Save';
+const TEST_FEATURE = 'update-safe-docx-save-defaults-and-stable-node-ids';
 
 const CONTENT_TYPES_XML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">

--- a/packages/docx-mcp/src/tools/save.test.ts
+++ b/packages/docx-mcp/src/tools/save.test.ts
@@ -19,6 +19,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 
 const WORDPROCESSING_ML_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const TEST_FEATURE = 'Save';
 
 const CONTENT_TYPES_XML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">

--- a/spec-compliance/CONFORMANCE.md
+++ b/spec-compliance/CONFORMANCE.md
@@ -45,9 +45,11 @@ Allure labels via `testAllure.conformance({…})`; source code carries
 | `ECMA-PART1-11-3-3` | Document Settings part | 5 | 1 | 11.3.3 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:settings` | packages/docx-core/src/generation/emit/settings-part.ts; packages/docx-core/src/generation/generation-baseline-settings.test.ts; packages/docx-core/src/integration/cross-implementation-suite.test.ts |
 | `ECMA-PART1-17-15-3-4` | w:compatSetting custom compatibility setting | 5 | 1 | 17.15.3.4 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:compatSetting` | packages/docx-core/src/generation/emit/settings-part.ts; packages/docx-core/src/generation/generation-baseline-settings.test.ts; packages/docx-core/src/integration/cross-implementation-suite.test.ts |
 | `ECMA-PART1-17-10-1` | w:evenAndOddHeaders setting | 5 | 1 | 17.10.1 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:evenAndOddHeaders` | — |
-| `ECMA-PART1-17-16-18` | w:fldChar five-part complex-field emission | 5 | 1 | 17.16.18 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:fldChar` | packages/docx-core/src/generation/emit/run.ts; packages/docx-core/src/generation/structural-checks.ts; packages/docx-compare/src/baselines/atomizer/inPlaceModifier-deletion.ts; packages/docx-compare/src/baselines/atomizer/pipeline.field-validation.test.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts; verification/lean/Tier2/XmlTripleChecker.lean; verification/registry/lean-xml-checker-coverage.json |
-| `ECMA-PART1-17-16-5-44` | PAGE field instruction emission | 5 | 1 | 17.16.5.44 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:instrText` | packages/docx-core/src/generation/emit/run.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts |
-| `ECMA-PART1-17-16-5-42` | NUMPAGES field instruction emission | 5 | 1 | 17.16.5.42 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:instrText` | packages/docx-core/src/generation/emit/run.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts |
+| `ECMA-PART1-17-16-18` | w:fldChar five-part complex-field emission | 5 | 1 | 17.16.18 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:fldChar` | packages/docx-core/src/generation/emit/run.ts; packages/docx-core/src/generation/structural-checks.ts; packages/docx-compare/src/baselines/atomizer/inPlaceModifier-deletion.ts; packages/docx-compare/src/baselines/atomizer/pipeline.field-validation.test.ts; packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts; verification/lean/Tier2/XmlTripleChecker.lean; verification/registry/lean-xml-checker-coverage.json |
+| `ECMA-PART1-17-16-5-44` | PAGE field instruction emission | 5 | 1 | 17.16.5.44 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:instrText` | packages/docx-core/src/generation/emit/run.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts; packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts |
+| `ECMA-PART1-17-16-5-42` | NUMPAGES field instruction emission | 5 | 1 | 17.16.5.42 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:instrText` | packages/docx-core/src/generation/emit/run.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts; packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts |
+| `ECMA-PART1-17-16-5-45` | PAGEREF field instruction classification and preservation | 5 | 1 | 17.16.5.45 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:instrText` | packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts |
+| `ECMA-PART1-17-16-5-51` | REF field instruction classification and preservation | 5 | 1 | 17.16.5.51 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:instrText` | packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts |
 | `ECMA-PART1-17-4-37` | w:tbl table emission | 5 | 1 | 17.4.37 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:tbl` | — |
 | `ECMA-PART1-17-4-59` | w:tblPr table-properties emission | 5 | 1 | 17.4.59 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:tblPr` | — |
 | `ECMA-PART1-17-4-63` | w:tblW preferred-width consistency | 5 | 1 | 17.4.63 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:tblW` | — |
@@ -577,7 +579,7 @@ and conditionally adds this switch exactly when some section declares an
 - **Part / Section:** Part 1 § 17.16.18
 - **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
 - **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:fldChar`
-- **Verified by:** packages/docx-core/src/generation/emit/run.ts; packages/docx-core/src/generation/structural-checks.ts; packages/docx-compare/src/baselines/atomizer/inPlaceModifier-deletion.ts; packages/docx-compare/src/baselines/atomizer/pipeline.field-validation.test.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts; verification/lean/Tier2/XmlTripleChecker.lean; verification/registry/lean-xml-checker-coverage.json
+- **Verified by:** packages/docx-core/src/generation/emit/run.ts; packages/docx-core/src/generation/structural-checks.ts; packages/docx-compare/src/baselines/atomizer/inPlaceModifier-deletion.ts; packages/docx-compare/src/baselines/atomizer/pipeline.field-validation.test.ts; packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts; verification/lean/Tier2/XmlTripleChecker.lean; verification/registry/lean-xml-checker-coverage.json
 
 Every generated field is a complete five-run sequence — `fldChar begin`,
 preserved-space `w:instrText`, `fldChar separate`, a cached-result run,
@@ -594,7 +596,7 @@ Part 1 complex-field and deleted-field-code syntax.
 - **Part / Section:** Part 1 § 17.16.5.44
 - **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
 - **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:instrText`
-- **Verified by:** packages/docx-core/src/generation/emit/run.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts
+- **Verified by:** packages/docx-core/src/generation/emit/run.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts; packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts
 
 The PAGE instruction is emitted with canonical surrounding spaces
 (` PAGE `) inside a preserved-space `w:instrText`, matching the shape of
@@ -606,11 +608,40 @@ the committed field fixtures used by the comparison pipeline.
 - **Part / Section:** Part 1 § 17.16.5.42
 - **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
 - **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:instrText`
-- **Verified by:** packages/docx-core/src/generation/emit/run.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts
+- **Verified by:** packages/docx-core/src/generation/emit/run.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts; packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts
 
 The NUMPAGES instruction follows the same emission discipline as PAGE
 (` NUMPAGES `, preserved spacing, cached result required), giving
 "Page X of Y" footers structurally correct field pairs.
+
+### ECMA-PART1-17-16-5-45 — PAGEREF field instruction classification and preservation
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.16.5.45
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:instrText`
+- **Verified by:** packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts
+
+Forced main-document rebuild classifies a self-contained PAGEREF instruction
+with one bookmark argument and a bounded switch vocabulary. When the complete
+field range is unchanged, comparison preserves its ordered XML topology as a
+SafeDocX metamorphic invariant. This entry does not claim bookmark resolution,
+pagination, cached-result correctness, or field evaluation.
+
+### ECMA-PART1-17-16-5-51 — REF field instruction classification and preservation
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.16.5.51
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:instrText`
+- **Verified by:** packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts
+
+Forced main-document rebuild classifies a self-contained REF instruction with
+one bookmark argument and a bounded switch vocabulary; the `\d` switch requires
+and consumes one separator argument. When the complete field range is unchanged,
+comparison preserves its ordered XML topology as a SafeDocX metamorphic
+invariant. This entry does not claim bookmark resolution, cached-result
+correctness, or field evaluation.
 
 ### ECMA-PART1-17-4-37 — w:tbl table emission
 
@@ -1384,9 +1415,19 @@ section; they are described under
 in the root README.
 
 Within Part 1 §17.16, safe-docx targets structural emission of complex fields
-and the PAGE and NUMPAGES instructions listed above. Other field instructions,
-field-code parsing and evaluation, cached-result correctness, pagination, and
-equivalence to a Word application's field engine are out of scope.
+and the PAGE and NUMPAGES instructions listed above. Forced rebuild additionally
+classifies unchanged, self-contained main-document PAGE, NUMPAGES, REF, and
+PAGEREF fields for exact ordered-range passthrough. Unrelated direct-child edits
+may shift a field's paragraph-child positions; pairing instead uses stable
+paragraph ownership and field-range sequence. Non-revision wrappers such as
+`w:hyperlink` are preserved, while tracked-revision-owned, changed, reordered,
+cross-paragraph, or nested field rebuild is outside this bounded claim. Other
+field instructions retain the existing rebuild safety-diagnostics behavior and
+are not newly rejected merely for malformed structure. General field-code
+parsing and evaluation, ancillary-story topology preservation, cached-result
+correctness, pagination, and equivalence to a Word application's field engine
+are out of scope. The Lean XML verifier remains inapplicable to rebuild output
+and does not prove this topology-preservation invariant.
 
 Within Part 1 §17.11 and §17.13.4, safe-docx targets document-order note
 display numbering for Word-conventional packages plus generated

--- a/spec-compliance/registry/ecma-376.md
+++ b/spec-compliance/registry/ecma-376.md
@@ -592,7 +592,7 @@ part: 1
 section: "17.16.18"
 url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
 schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:fldChar
-verifiedBy: packages/docx-core/src/generation/emit/run.ts; packages/docx-core/src/generation/structural-checks.ts; packages/docx-compare/src/baselines/atomizer/inPlaceModifier-deletion.ts; packages/docx-compare/src/baselines/atomizer/pipeline.field-validation.test.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts; verification/lean/Tier2/XmlTripleChecker.lean; verification/registry/lean-xml-checker-coverage.json
+verifiedBy: packages/docx-core/src/generation/emit/run.ts; packages/docx-core/src/generation/structural-checks.ts; packages/docx-compare/src/baselines/atomizer/inPlaceModifier-deletion.ts; packages/docx-compare/src/baselines/atomizer/pipeline.field-validation.test.ts; packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts; verification/lean/Tier2/XmlTripleChecker.lean; verification/registry/lean-xml-checker-coverage.json
 ```
 
 Every generated field is a complete five-run sequence — `fldChar begin`,
@@ -612,7 +612,7 @@ part: 1
 section: "17.16.5.44"
 url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
 schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:instrText
-verifiedBy: packages/docx-core/src/generation/emit/run.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts
+verifiedBy: packages/docx-core/src/generation/emit/run.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts; packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts
 ```
 
 The PAGE instruction is emitted with canonical surrounding spaces
@@ -627,12 +627,47 @@ part: 1
 section: "17.16.5.42"
 url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
 schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:instrText
-verifiedBy: packages/docx-core/src/generation/emit/run.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts
+verifiedBy: packages/docx-core/src/generation/emit/run.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts; packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts
 ```
 
 The NUMPAGES instruction follows the same emission discipline as PAGE
 (` NUMPAGES `, preserved spacing, cached result required), giving
 "Page X of Y" footers structurally correct field pairs.
+
+## [ECMA-PART1-17-16-5-45] PAGEREF field instruction classification and preservation
+
+```yaml
+edition: 5
+part: 1
+section: "17.16.5.45"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:instrText
+verifiedBy: packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts
+```
+
+Forced main-document rebuild classifies a self-contained PAGEREF instruction
+with one bookmark argument and a bounded switch vocabulary. When the complete
+field range is unchanged, comparison preserves its ordered XML topology as a
+SafeDocX metamorphic invariant. This entry does not claim bookmark resolution,
+pagination, cached-result correctness, or field evaluation.
+
+## [ECMA-PART1-17-16-5-51] REF field instruction classification and preservation
+
+```yaml
+edition: 5
+part: 1
+section: "17.16.5.51"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:instrText
+verifiedBy: packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts
+```
+
+Forced main-document rebuild classifies a self-contained REF instruction with
+one bookmark argument and a bounded switch vocabulary; the `\d` switch requires
+and consumes one separator argument. When the complete field range is unchanged,
+comparison preserves its ordered XML topology as a SafeDocX metamorphic
+invariant. This entry does not claim bookmark resolution, cached-result
+correctness, or field evaluation.
 
 ## [ECMA-PART1-17-4-37] w:tbl table emission
 
@@ -1632,9 +1667,19 @@ section; they are described under
 in the root README.
 
 Within Part 1 §17.16, safe-docx targets structural emission of complex fields
-and the PAGE and NUMPAGES instructions listed above. Other field instructions,
-field-code parsing and evaluation, cached-result correctness, pagination, and
-equivalence to a Word application's field engine are out of scope.
+and the PAGE and NUMPAGES instructions listed above. Forced rebuild additionally
+classifies unchanged, self-contained main-document PAGE, NUMPAGES, REF, and
+PAGEREF fields for exact ordered-range passthrough. Unrelated direct-child edits
+may shift a field's paragraph-child positions; pairing instead uses stable
+paragraph ownership and field-range sequence. Non-revision wrappers such as
+`w:hyperlink` are preserved, while tracked-revision-owned, changed, reordered,
+cross-paragraph, or nested field rebuild is outside this bounded claim. Other
+field instructions retain the existing rebuild safety-diagnostics behavior and
+are not newly rejected merely for malformed structure. General field-code
+parsing and evaluation, ancillary-story topology preservation, cached-result
+correctness, pagination, and equivalence to a Word application's field engine
+are out of scope. The Lean XML verifier remains inapplicable to rebuild output
+and does not prove this topology-preservation invariant.
 
 Within Part 1 §17.11 and §17.13.4, safe-docx targets document-order note
 display numbering for Word-conventional packages plus generated


### PR DESCRIPTION
## Summary

- preserve unchanged, self-contained main-story PAGE, NUMPAGES, REF, and PAGEREF field ranges during forced rebuild
- retain ordered run boundaries, properties, field markers, fragmented instructions, cached-result wrappers, namespaces, and extension payload
- fail closed for changed, reordered, cross-paragraph, nested, spanning, malformed supported, tracked-owner, or ambiguous field topology
- keep unsupported fields on the existing diagnostics path, keep inplace behavior unchanged, and keep Lean rebuild evidence explicitly not applicable
- add exact ECMA-376 citations, bounded REF/PAGEREF registry entries, and an approved OpenSpec change

## Verification

- independent implementation review: approved after three findings were repaired
- focused field/SDT/rebuild/safety suites: 92/92; parent rerun 58/58; reviewer probes 41/41
- `npm run build`: pass
- `npm run lint:workspaces`: pass (existing warnings only)
- full workspace tests: all passing except one load-sensitive 5s timeout in the combined run; the exact advanced-revision file passes 11/11 in isolation
- LibreOffice and adapter protocol tests: 14/14 passing outside sandbox
- `openspec validate preserve-complex-fields-on-rebuild --strict`: pass
- `npm run check:spec-coverage`: pass
- `npm run check:conformance-citations`: pass
- `npm run check:conformance-doc`: pass

## Scope

This is a bounded SafeDocX metamorphic preservation invariant, not a claim that ECMA-376 requires lexical topology preservation. Ancillary stories, field evaluation, cached-result correctness, changed/nested fields, tracked field wrappers, and the current Lean token model remain out of scope. Neutral docx-platform-tests evidence is deferred because protocol v1 has one input and cannot invoke a two-document comparison without a neutral protocol extension.

Refs #582