### PR TITLE
fix(docx-mcp): read_file node_ids resolves host-app bookmark names (closes #616)

### DIFF
--- a/packages/docx-mcp/docs/tool-reference.generated.md
+++ b/packages/docx-mcp/docs/tool-reference.generated.md
@@ -18,7 +18,7 @@ Read document content (DOCX, ODT, or Google Doc). Output is token-limited (~14k 
 | `google_doc_id` | `string` | no | Google Doc ID or URL (alternative to file_path). Extract from URL: docs.google.com/document/d/{ID}/edit |
 | `offset` | `number` | no | 1-based paragraph offset for pagination. Negative values count from end. |
 | `limit` | `number` | no | Max paragraphs to return. When omitted, output is token-limited to ~14k tokens with pagination. |
-| `node_ids` | `array<string>` | no |  |
+| `node_ids` | `array<string>` | no | Paragraph selectors. Each accepts a safe-docx `_bk_*` id, or (DOCX only) any other bookmark name — e.g. a host application's own stable paragraph bookmark — whose w:id-paired range covers exactly one paragraph. Exact name match; a point bookmark or a multi-paragraph range is refused. Returned rows always report the paragraph's canonical `_bk_*` id, even when selected by another bookmark name; results are de-duplicated and returned in document order. |
 | `format` | `enum("toon", "json", "simple")` | no |  |
 | `comment_rendering` | `enum("none", "paragraph_notes", "endnotes", "inline_markers")` | no | How to render comments in read_file output. Use "paragraph_notes" (default) for paragraph-local comment threads, "inline_markers" to add `[cm-start:N]`/`[cm-end:N]` milestones in TOON output (combined with the thread blocks), "endnotes" to collect threaded comments into a trailing #COMMENTS block in TOON output, or "none" for the legacy output with no comment rendering. |
 | `show_formatting` | `boolean` | no | When true (default), shows inline formatting tags (<b>, <i>, <u>, <highlighting>, <a>). When false, emits plain text with no inline tags. |

--- a/packages/docx-mcp/src/tool_catalog.ts
+++ b/packages/docx-mcp/src/tool_catalog.ts
@@ -69,7 +69,12 @@ export const SAFE_DOCX_TOOL_CATALOG = [
       ...GOOGLE_DOC_ID_FIELD,
       offset: z.number().optional().describe('1-based paragraph offset for pagination. Negative values count from end.'),
       limit: z.number().optional().describe('Max paragraphs to return. When omitted, output is token-limited to ~14k tokens with pagination.'),
-      node_ids: z.array(z.string()).optional(),
+      node_ids: z
+        .array(z.string())
+        .optional()
+        .describe(
+          'Paragraph selectors. Each accepts a safe-docx `_bk_*` id, or (DOCX only) any other bookmark name — e.g. a host application\'s own stable paragraph bookmark — whose w:id-paired range covers exactly one paragraph. Exact name match; a point bookmark or a multi-paragraph range is refused. Returned rows always report the paragraph\'s canonical `_bk_*` id, even when selected by another bookmark name; results are de-duplicated and returned in document order.',
+        ),
       format: z.enum(['toon', 'json', 'simple']).optional(),
       comment_rendering: z
         .enum(['none', 'paragraph_notes', 'endnotes', 'inline_markers'])

--- a/packages/docx-mcp/src/tools/read_file.ts
+++ b/packages/docx-mcp/src/tools/read_file.ts
@@ -384,8 +384,23 @@ export async function readFile(
     let filtered = nodes;
     let startIdx = 0;
     if (hasNodeIds) {
-      const set = new Set(params.node_ids!);
-      filtered = nodes.filter((n) => set.has(n.id));
+      const requestedIds = new Set(params.node_ids!);
+      const selectedCanonicalIds = new Set(
+        nodes.filter((node) => requestedIds.has(node.id)).map((node) => node.id),
+      );
+
+      for (const requestedId of requestedIds) {
+        if (selectedCanonicalIds.has(requestedId)) continue;
+        // A `_bk_*` selector that didn't already match a node's canonical id can
+        // never resolve via the foreign-bookmark path (findParagraphByBookmarkId
+        // returns null for an unmatched `_bk_*` name), so skip the linear scan.
+        if (requestedId.startsWith('_bk_')) continue;
+        const paragraph = session.doc.getParagraphElementById(requestedId);
+        const canonicalId = paragraph ? getParagraphBookmarkId(paragraph) : null;
+        if (canonicalId) selectedCanonicalIds.add(canonicalId);
+      }
+
+      filtered = nodes.filter((node) => selectedCanonicalIds.has(node.id));
     } else {
       if (hasExplicitOffset) {
         if (params.offset! > 0) startIdx = Math.max(0, params.offset! - 1);

--- a/packages/docx-mcp/src/tools/read_file_node_ids.test.ts
+++ b/packages/docx-mcp/src/tools/read_file_node_ids.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import {
+  assertSuccess,
+  createTestSessionManager,
+  openSession,
+  registerCleanup,
+} from '../testing/session-test-utils.js';
+import { readFile } from './read_file.js';
+
+const CANONICAL_ID = '_bk_616616616616';
+const FOREIGN_ID = 'jr_para_issue616';
+const POINT_ID = '_RefPoint';
+const MULTI_PARAGRAPH_ID = '_TocSpan';
+
+function makeDocumentXml(bodyXml: string): string {
+  return (
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
+    `<w:body>${bodyXml}</w:body>` +
+    `</w:document>`
+  );
+}
+
+describe('read_file node_ids bookmark resolution', () => {
+  const test = testAllure.epic('Document Reading').withLabels({
+    feature: 'Read File Node Ids',
+  });
+
+  registerCleanup();
+
+  test
+    .conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.6.2' })(
+      'accepts a foreign single-paragraph bookmark but refuses point and multi-paragraph bookmarks',
+      async ({ given, when, then, and }: AllureBddContext) => {
+        const documentXml = makeDocumentXml(
+          `<w:bookmarkStart w:id="1" w:name="${FOREIGN_ID}"/>` +
+            `<w:bookmarkStart w:id="2" w:name="${CANONICAL_ID}"/>` +
+            `<w:p><w:r><w:t>Foreign bookmark target</w:t></w:r></w:p>` +
+            `<w:bookmarkEnd w:id="2"/>` +
+            `<w:bookmarkEnd w:id="1"/>` +
+            `<w:bookmarkStart w:id="3" w:name="${POINT_ID}"/>` +
+            `<w:bookmarkEnd w:id="3"/>` +
+            `<w:p><w:r><w:t>Point bookmark neighbor</w:t></w:r></w:p>` +
+            `<w:bookmarkStart w:id="4" w:name="${MULTI_PARAGRAPH_ID}"/>` +
+            `<w:p><w:r><w:t>Multi-paragraph range start</w:t></w:r></w:p>` +
+            `<w:p><w:r><w:t>Multi-paragraph range end</w:t></w:r></w:p>` +
+            `<w:bookmarkEnd w:id="4"/>`,
+        );
+        const mgr = createTestSessionManager();
+        const opened = await given('a DOCX with qualified and refused foreign bookmark ranges', () =>
+          openSession([], { mgr, xml: documentXml }),
+        );
+
+        const selected = await when('read_file targets the qualified foreign bookmark name', async () => {
+          const result = await readFile(mgr, {
+            file_path: opened.filePath,
+            format: 'json',
+            node_ids: [FOREIGN_ID],
+          });
+          assertSuccess(result, 'read qualified foreign bookmark');
+          return {
+            result,
+            nodes: JSON.parse(String(result.content)) as Array<{
+              id: string;
+              clean_text: string;
+            }>,
+          };
+        });
+
+        await then('the target paragraph is returned under its canonical safe-docx id', async () => {
+          expect(Number(selected.result.paragraphs_returned)).toBe(1);
+          expect(selected.nodes).toHaveLength(1);
+          expect(selected.nodes[0]?.clean_text).toBe('Foreign bookmark target');
+          expect(selected.nodes[0]?.id).toBe(CANONICAL_ID);
+          expect(selected.nodes[0]?.id).not.toBe(FOREIGN_ID);
+        });
+
+        const refused = await when('read_file targets point and multi-paragraph bookmark names', async () => {
+          const point = await readFile(mgr, {
+            file_path: opened.filePath,
+            format: 'json',
+            node_ids: [POINT_ID],
+          });
+          const multiParagraph = await readFile(mgr, {
+            file_path: opened.filePath,
+            format: 'json',
+            node_ids: [MULTI_PARAGRAPH_ID],
+          });
+          assertSuccess(point, 'read point bookmark');
+          assertSuccess(multiParagraph, 'read multi-paragraph bookmark');
+          return { point, multiParagraph };
+        });
+
+        await and('both refused selectors return zero rows', async () => {
+          expect(Number(refused.point.paragraphs_returned)).toBe(0);
+          expect(JSON.parse(String(refused.point.content))).toEqual([]);
+          expect(Number(refused.multiParagraph.paragraphs_returned)).toBe(0);
+          expect(JSON.parse(String(refused.multiParagraph.content))).toEqual([]);
+        });
+      },
+    );
+
+  test('de-duplicates aliased selectors and returns rows in document order', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    const CANON_A = '_bk_aaaaaaaaaaaa';
+    const CANON_B = '_bk_bbbbbbbbbbbb';
+    const FOREIGN_A1 = 'jr_para_a_one';
+    const FOREIGN_A2 = 'jr_para_a_two';
+    const FOREIGN_B = 'jr_para_b';
+    // Paragraph A carries a canonical id plus two foreign aliases; paragraph B a
+    // canonical id plus one foreign alias. A appears before B in document order.
+    const documentXml = makeDocumentXml(
+      `<w:bookmarkStart w:id="1" w:name="${CANON_A}"/>` +
+        `<w:bookmarkStart w:id="2" w:name="${FOREIGN_A1}"/>` +
+        `<w:bookmarkStart w:id="3" w:name="${FOREIGN_A2}"/>` +
+        `<w:p><w:r><w:t>Paragraph A</w:t></w:r></w:p>` +
+        `<w:bookmarkEnd w:id="3"/><w:bookmarkEnd w:id="2"/><w:bookmarkEnd w:id="1"/>` +
+        `<w:bookmarkStart w:id="4" w:name="${CANON_B}"/>` +
+        `<w:bookmarkStart w:id="5" w:name="${FOREIGN_B}"/>` +
+        `<w:p><w:r><w:t>Paragraph B</w:t></w:r></w:p>` +
+        `<w:bookmarkEnd w:id="5"/><w:bookmarkEnd w:id="4"/>`,
+    );
+    const mgr = createTestSessionManager();
+    const opened = await given('a DOCX with two paragraphs each carrying foreign aliases', () =>
+      openSession([], { mgr, xml: documentXml }),
+    );
+
+    const readIds = async (nodeIds: string[]) => {
+      const result = await readFile(mgr, { file_path: opened.filePath, format: 'json', node_ids: nodeIds });
+      assertSuccess(result, `read ${nodeIds.join(',')}`);
+      return JSON.parse(String(result.content)) as Array<{ id: string; clean_text: string }>;
+    };
+
+    await then('two foreign aliases for one paragraph emit exactly one canonical row', async () => {
+      const rows = await readIds([FOREIGN_A1, FOREIGN_A2]);
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.id).toBe(CANON_A);
+    });
+
+    await when('a canonical id and a foreign alias select the same paragraph', async () => {
+      const rows = await readIds([CANON_A, FOREIGN_A1]);
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.id).toBe(CANON_A);
+    });
+
+    await then('selectors given out of document order return document-ordered rows', async () => {
+      const rows = await readIds([FOREIGN_B, FOREIGN_A1]);
+      expect(rows.map((r) => r.id)).toEqual([CANON_A, CANON_B]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
`read_file`'s `node_ids` filter resolved only a paragraph's canonical `_bk_*` id, while the edit tools' anchor resolution (`findParagraphByBookmarkId`) also accepts any host-application bookmark name (`jr_para_*`, Word `_Ref*`, …) whose `w:id`-paired range covers exactly one paragraph. So an id that works as an **edit** anchor returned **zero rows** from `read_file(node_ids=[...])` — a silent read/write asymmetry.

## Implementation
- `read_file.ts`: after the exact `_bk_*` match, any unmatched requested id falls through to `session.doc.getParagraphElementById` (wraps `findParagraphByBookmarkId` — the *same* resolver the edit tools use), and the resolved paragraph is mapped back to its canonical `_bk_*` id. Emitted row ids stay `_bk_*` (the foreign name is an input selector only). Point / multi-paragraph bookmarks still resolve to nothing (resolver returns null). Document order and Set-dedup preserved.
- `tool_catalog.ts`: added the missing `.describe()` to `node_ids`, mirroring the anchor params' wording.
- New test `read_file_node_ids.test.ts`: foreign-name selector returns exactly the target paragraph under its canonical id (not the foreign name); point + multi-paragraph names return 0 rows.

## Verification
- [x] New test green (`read_file_node_ids.test.ts`, 1 passed)
- [x] Full `docx-mcp` suite: **885 passed (93 files)**
- [x] Lint: 0 errors (9 pre-existing unrelated warnings)
- [ ] Peer review (agy + Codex) — pending; appended below

## Closes
- #616