### PR TITLE
fix(docx-core): harden serialized attribute escaping

### DIFF
--- a/packages/docx-compare/src/testing/ooxml-fixtures.test.ts
+++ b/packages/docx-compare/src/testing/ooxml-fixtures.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect } from 'vitest';
+import { DocxArchive, OOXML, parseXml } from '@usejunior/docx-core';
+import { testAllure, type AllureBddContext } from './allure-test.js';
+import {
+  buildDocxFromBodyXml,
+  decoratedComplexField,
+  FIELD_INSTRUCTIONS,
+} from './ooxml-fixtures.js';
+
+const MC_NS = 'http://schemas.openxmlformats.org/markup-compatibility/2006';
+const test = testAllure.epic('Document Comparison').withLabels({
+  feature: 'OOXML Fixtures',
+  severity: 'critical',
+});
+
+describe('OOXML fixture attribute safety', () => {
+  test(
+    'decoratedComplexField keeps a quote-bearing bookmark anchor in one attribute',
+    async ({ when, then }: AllureBddContext) => {
+      const anchor = 'safe" w:tooltip="injected & < >';
+      let hyperlink: Element | undefined;
+
+      await when('the decorated field is parsed as OOXML', () => {
+        const xml =
+          `<w:p xmlns:w="${OOXML.W_NS}" xmlns:w14="${OOXML.W14_NS}">` +
+          decoratedComplexField(FIELD_INSTRUCTIONS.PAGE, '7', anchor) +
+          `</w:p>`;
+        const doc = parseXml(xml);
+        const found = doc.getElementsByTagNameNS(OOXML.W_NS, 'hyperlink')[0];
+        if (!found) throw new Error('missing hyperlink');
+        hyperlink = found;
+      });
+
+      await then('the original anchor round-trips without injecting another attribute', () => {
+        if (!hyperlink) throw new Error('missing hyperlink');
+        expect(hyperlink.getAttributeNS(OOXML.W_NS, 'anchor')).toBe(anchor);
+        expect(hyperlink.hasAttributeNS(OOXML.W_NS, 'tooltip')).toBe(false);
+      });
+    },
+  );
+
+  test(
+    'buildDocxFromBodyXml keeps a quote-bearing namespace URI in one attribute',
+    async ({ when, then }: AllureBddContext) => {
+      const namespaceUri = 'urn:fixture" injected="yes & more';
+      let documentRoot: Element | undefined;
+
+      await when('the fixture package is built with the namespace', async () => {
+        const buffer = await buildDocxFromBodyXml('<w:p/>', [], {
+          namespaces: { ext: namespaceUri },
+          ignorablePrefixes: ['ext'],
+        });
+        const archive = await DocxArchive.load(buffer);
+        documentRoot = parseXml(await archive.getDocumentXml()).documentElement;
+      });
+
+      await then('the namespace and ignorable list round-trip without attribute injection', () => {
+        if (!documentRoot) throw new Error('missing document root');
+        expect(documentRoot.getAttribute('xmlns:ext')).toBe(namespaceUri);
+        expect(documentRoot.getAttributeNS(MC_NS, 'Ignorable')).toBe('w14 ext');
+        expect(documentRoot.hasAttribute('injected')).toBe(false);
+      });
+    },
+  );
+
+  test(
+    'buildDocxFromBodyXml rejects unsafe namespace prefix tokens',
+    async ({ then }: AllureBddContext) => {
+      await then('attribute-name and ignorable-list injection attempts fail closed', async () => {
+        await expect(
+          buildDocxFromBodyXml('<w:p/>', [], {
+            namespaces: { 'ext" injected': 'urn:fixture' },
+          }),
+        ).rejects.toThrow('Invalid XML namespace prefix');
+        await expect(
+          buildDocxFromBodyXml('<w:p/>', [], {
+            ignorablePrefixes: ['ext injected'],
+          }),
+        ).rejects.toThrow('Invalid XML namespace prefix');
+      });
+    },
+  );
+});

--- a/packages/docx-compare/src/testing/ooxml-fixtures.ts
+++ b/packages/docx-compare/src/testing/ooxml-fixtures.ts
@@ -51,6 +51,22 @@ function escapeXmlText(text: string): string {
     .replace(/>/g, '&gt;');
 }
 
+function escapeXmlAttr(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+const XML_PREFIX_RE = /^[A-Za-z_][A-Za-z0-9._-]*$/u;
+
+function assertXmlPrefix(prefix: string): void {
+  if (!XML_PREFIX_RE.test(prefix) || /^xml/i.test(prefix)) {
+    throw new Error(`Invalid XML namespace prefix: ${JSON.stringify(prefix)}`);
+  }
+}
+
 export function paragraphWithText(text: string): string {
   return `<w:p>${resultText(escapeXmlText(text))}</w:p>`;
 }
@@ -114,7 +130,7 @@ export function decoratedComplexField(
     `<w:instrText xml:space="preserve">${secondInstruction}</w:instrText></w:r>` +
     `<w:r><w:rPr><w:u w:val="single"/></w:rPr>` +
     `<w:fldChar w:fldCharType="separate"/></w:r>` +
-    `<w:hyperlink w:anchor="${escapeXmlText(anchor)}" w:history="1">` +
+    `<w:hyperlink w:anchor="${escapeXmlAttr(anchor)}" w:history="1">` +
     `<w:r><w:rPr><w:smallCaps/></w:rPr><w:t>${escapeXmlText(result)}</w:t></w:r>` +
     `</w:hyperlink>` +
     `<w:r><w:rPr><w:vanish/><w14:textEffect w14:val="none"/></w:rPr>` +
@@ -214,17 +230,22 @@ export async function buildDocxFromBodyXml(
   hyperlinkRels: HyperlinkRelFixture[] = [],
   namespaceOptions: MinimalDocumentNamespaceOptions = {},
 ): Promise<Buffer> {
-  const extraNamespaces = Object.entries(namespaceOptions.namespaces ?? {})
-    .map(([prefix, uri]) => ` xmlns:${prefix}="${escapeXmlText(uri)}"`)
+  const namespaceEntries = Object.entries(namespaceOptions.namespaces ?? {});
+  for (const [prefix] of namespaceEntries) assertXmlPrefix(prefix);
+  const additionalIgnorablePrefixes = namespaceOptions.ignorablePrefixes ?? [];
+  for (const prefix of additionalIgnorablePrefixes) assertXmlPrefix(prefix);
+
+  const extraNamespaces = namespaceEntries
+    .map(([prefix, uri]) => ` xmlns:${prefix}="${escapeXmlAttr(uri)}"`)
     .join('');
-  const ignorable = ['w14', ...(namespaceOptions.ignorablePrefixes ?? [])].join(' ');
+  const ignorable = ['w14', ...additionalIgnorablePrefixes].join(' ');
   const documentXml =
     `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
     `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"` +
     ` xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"` +
     ` xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"` +
     extraNamespaces +
-    ` mc:Ignorable="${ignorable}">` +
+    ` mc:Ignorable="${escapeXmlAttr(ignorable)}">` +
     `<w:body>${bodyXml}<w:sectPr/></w:body></w:document>`;
 
   const contentTypesXml =
@@ -241,20 +262,14 @@ export async function buildDocxFromBodyXml(
     `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>` +
     `</Relationships>`;
 
-  const escapeAttr = (value: string): string =>
-    value
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;');
   const hyperlinkRelsXml = hyperlinkRels
     .map((rel) => {
       const external = rel.external ?? true;
       const mode = external ? ` TargetMode="External"` : '';
       return (
-        `<Relationship Id="${escapeAttr(rel.id)}"` +
+        `<Relationship Id="${escapeXmlAttr(rel.id)}"` +
         ` Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink"` +
-        ` Target="${escapeAttr(rel.target)}"${mode}/>`
+        ` Target="${escapeXmlAttr(rel.target)}"${mode}/>`
       );
     })
     .join('');

--- a/packages/docx-core/src/integration/synthetic-docx-fixture.test.ts
+++ b/packages/docx-core/src/integration/synthetic-docx-fixture.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect } from 'vitest';
+import { OOXML } from '../primitives/namespaces.js';
+import { parseXml } from '../primitives/xml.js';
+import { DocxArchive } from '../shared/docx/DocxArchive.js';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { buildSyntheticDocx } from './synthetic-docx-fixture.js';
+
+const test = testAllure.epic('Document Generation').withLabels({
+  feature: 'Synthetic DOCX Fixture',
+  severity: 'critical',
+});
+
+function elements(doc: Document, namespace: string, localName: string): Element[] {
+  return Array.from(doc.getElementsByTagNameNS(namespace, localName));
+}
+
+describe('synthetic DOCX fixture escaping', () => {
+  test(
+    'semantic text inputs remain text in every generated story',
+    async ({ when, then }: AllureBddContext) => {
+      const text = 'safe & <w:r><w:t>injected</w:t></w:r> "quoted"';
+      let archive: DocxArchive | undefined;
+
+      await when('the same adversarial text is used across document stories', async () => {
+        archive = await DocxArchive.load(
+          await buildSyntheticDocx({
+            paragraphs: [text],
+            footnoteOnParagraph: 0,
+            footnoteText: text,
+            endnoteOnParagraph: 0,
+            endnoteText: text,
+            commentOnParagraph: 0,
+            commentText: text,
+            replyText: text,
+          }),
+        );
+      });
+
+      await then('each story contains the exact text and no injected run', async () => {
+        if (!archive) throw new Error('missing synthetic archive');
+        const partPaths = [
+          'word/document.xml',
+          'word/footnotes.xml',
+          'word/endnotes.xml',
+          'word/comments.xml',
+        ];
+        for (const path of partPaths) {
+          const xml = await archive.getFile(path);
+          if (!xml) throw new Error(`missing ${path}`);
+          const doc = parseXml(xml);
+          expect(elements(doc, OOXML.W_NS, 't').some((node) => node.textContent === text)).toBe(true);
+          expect(elements(doc, OOXML.W_NS, 't').some((node) => node.textContent === 'injected')).toBe(false);
+        }
+      });
+    },
+  );
+
+  test(
+    'semantic attribute inputs remain in their original OOXML attributes',
+    async ({ when, then }: AllureBddContext) => {
+      const value = 'safe" injected="yes & < >';
+      let archive: DocxArchive | undefined;
+
+      await when('move, bookmark, and comment metadata contain attribute delimiters', async () => {
+        archive = await DocxArchive.load(
+          await buildSyntheticDocx({
+            paragraphs: ['from', 'to', 'bookmark', 'comment'],
+            trackedMove: { from: 0, to: 1, name: value, author: value },
+            bookmarkOnParagraph: { paragraph: 2, name: value },
+            siblingBookmarkBefore: { index: 2, name: value },
+            commentOnParagraph: 3,
+            commentAuthor: value,
+            replyText: 'reply',
+            replyAuthor: value,
+            commentAncillaryParts: true,
+          }),
+        );
+      });
+
+      await then('all metadata round-trips without injected attributes', async () => {
+        if (!archive) throw new Error('missing synthetic archive');
+        const documentXml = await archive.getDocumentXml();
+        const document = parseXml(documentXml);
+        const move = elements(document, OOXML.W_NS, 'moveFromRangeStart')[0];
+        if (!move) throw new Error('missing tracked move');
+        expect(move.getAttributeNS(OOXML.W_NS, 'name')).toBe(value);
+        expect(move.getAttributeNS(OOXML.W_NS, 'author')).toBe(value);
+        expect(move.hasAttribute('injected')).toBe(false);
+
+        for (const bookmark of elements(document, OOXML.W_NS, 'bookmarkStart')) {
+          expect(bookmark.getAttributeNS(OOXML.W_NS, 'name')).toBe(value);
+          expect(bookmark.hasAttribute('injected')).toBe(false);
+        }
+
+        const commentsXml = await archive.getFile('word/comments.xml');
+        const peopleXml = await archive.getFile('word/people.xml');
+        if (!commentsXml || !peopleXml) throw new Error('missing comment metadata parts');
+        for (const comment of elements(parseXml(commentsXml), OOXML.W_NS, 'comment')) {
+          expect(comment.getAttributeNS(OOXML.W_NS, 'author')).toBe(value);
+          expect(comment.hasAttribute('injected')).toBe(false);
+        }
+        for (const person of elements(parseXml(peopleXml), OOXML.W15_NS, 'person')) {
+          expect(person.getAttributeNS(OOXML.W15_NS, 'author')).toBe(value);
+          expect(person.hasAttribute('injected')).toBe(false);
+        }
+        for (const presence of elements(parseXml(peopleXml), OOXML.W15_NS, 'presenceInfo')) {
+          expect(presence.getAttributeNS(OOXML.W15_NS, 'userId')).toBe(`${value}@example.com`);
+          expect(presence.hasAttribute('injected')).toBe(false);
+        }
+      });
+    },
+  );
+});

--- a/packages/docx-core/src/integration/synthetic-docx-fixture.ts
+++ b/packages/docx-core/src/integration/synthetic-docx-fixture.ts
@@ -1,5 +1,13 @@
 import JSZip from 'jszip';
+import { escapeXmlAttr } from '../primitives/track-changes-emitter.js';
 import { DocxArchive } from '../shared/docx/DocxArchive.js';
+
+function escapeXmlText(text: string): string {
+  return text
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
+}
 
 export interface SyntheticDocxOptions {
   paragraphs: string[];
@@ -109,10 +117,7 @@ export async function buildSyntheticDocx(opts: SyntheticDocxOptions): Promise<Bu
   const permSpanEnd = opts.permSpanParagraphs?.end;
 
   const paragraphParts: string[] = opts.paragraphs.map((text, idx) => {
-    const escaped = text
-      .replaceAll('&', '&amp;')
-      .replaceAll('<', '&lt;')
-      .replaceAll('>', '&gt;');
+    const escaped = escapeXmlText(text);
     let extra = '';
 
     if (hasFootnote && idx === opts.footnoteOnParagraph) {
@@ -142,11 +147,12 @@ export async function buildSyntheticDocx(opts: SyntheticDocxOptions): Promise<Bu
     }
 
     if (hasTrackedMove && idx === opts.trackedMove!.from) {
-      const name = opts.trackedMove!.name;
+      const name = escapeXmlAttr(opts.trackedMove!.name);
+      const author = escapeXmlAttr(moveAuthor);
       return (
         `<w:p>` +
-        `<w:moveFromRangeStart w:id="${moveBaseId}" w:name="${name}" w:author="${moveAuthor}" w:date="${moveDate}"/>` +
-        `<w:moveFrom w:id="${moveBaseId + 1}" w:author="${moveAuthor}" w:date="${moveDate}">` +
+        `<w:moveFromRangeStart w:id="${moveBaseId}" w:name="${name}" w:author="${author}" w:date="${moveDate}"/>` +
+        `<w:moveFrom w:id="${moveBaseId + 1}" w:author="${author}" w:date="${moveDate}">` +
         `<w:r><w:delText>${escaped}</w:delText></w:r>` +
         `</w:moveFrom>` +
         `<w:moveFromRangeEnd w:id="${moveBaseId}"/>` +
@@ -156,11 +162,12 @@ export async function buildSyntheticDocx(opts: SyntheticDocxOptions): Promise<Bu
     }
 
     if (hasTrackedMove && idx === opts.trackedMove!.to) {
-      const name = opts.trackedMove!.name;
+      const name = escapeXmlAttr(opts.trackedMove!.name);
+      const author = escapeXmlAttr(moveAuthor);
       return (
         `<w:p>` +
-        `<w:moveToRangeStart w:id="${moveBaseId + 2}" w:name="${name}" w:author="${moveAuthor}" w:date="${moveDate}"/>` +
-        `<w:moveTo w:id="${moveBaseId + 3}" w:author="${moveAuthor}" w:date="${moveDate}">` +
+        `<w:moveToRangeStart w:id="${moveBaseId + 2}" w:name="${name}" w:author="${author}" w:date="${moveDate}"/>` +
+        `<w:moveTo w:id="${moveBaseId + 3}" w:author="${author}" w:date="${moveDate}">` +
         `<w:r><w:t>${escaped}</w:t></w:r>` +
         `</w:moveTo>` +
         `<w:moveToRangeEnd w:id="${moveBaseId + 2}"/>` +
@@ -170,7 +177,7 @@ export async function buildSyntheticDocx(opts: SyntheticDocxOptions): Promise<Bu
     }
 
     if (hasBookmark && idx === opts.bookmarkOnParagraph!.paragraph) {
-      const name = opts.bookmarkOnParagraph!.name;
+      const name = escapeXmlAttr(opts.bookmarkOnParagraph!.name);
       return (
         `<w:p>` +
         `<w:bookmarkStart w:id="${bookmarkId}" w:name="${name}"/>` +
@@ -196,8 +203,9 @@ export async function buildSyntheticDocx(opts: SyntheticDocxOptions): Promise<Bu
   // Bookmark*Start*/End placed as sibling of <w:p> per ECMA-376 §17.13.5.
   if (hasSiblingBookmark) {
     const { index, name } = opts.siblingBookmarkBefore!;
+    const escapedName = escapeXmlAttr(name);
     const sibling =
-      `<w:bookmarkStart w:id="${siblingBookmarkId}" w:name="${name}"/>` +
+      `<w:bookmarkStart w:id="${siblingBookmarkId}" w:name="${escapedName}"/>` +
       `<w:bookmarkEnd w:id="${siblingBookmarkId}"/>`;
     paragraphParts.splice(index, 0, sibling);
   }
@@ -246,7 +254,7 @@ export async function buildSyntheticDocx(opts: SyntheticDocxOptions): Promise<Bu
   const zip = new JSZip();
 
   if (hasFootnote) {
-    const fnText = opts.footnoteText ?? 'Test footnote';
+    const fnText = escapeXmlText(opts.footnoteText ?? 'Test footnote');
     const footnotesXml =
       `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
       `<w:footnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
@@ -265,7 +273,7 @@ export async function buildSyntheticDocx(opts: SyntheticDocxOptions): Promise<Bu
   }
 
   if (hasEndnote) {
-    const enText = opts.endnoteText ?? 'Test endnote';
+    const enText = escapeXmlText(opts.endnoteText ?? 'Test endnote');
     const endnotesXml =
       `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
       `<w:endnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
@@ -284,13 +292,15 @@ export async function buildSyntheticDocx(opts: SyntheticDocxOptions): Promise<Bu
   }
 
   if (hasComment || hasCommentSpan || hasSiblingCommentRange) {
-    const cText = opts.commentText ?? 'Test comment';
-    const cAuthor = opts.commentAuthor ?? 'Author';
+    const cText = escapeXmlText(opts.commentText ?? 'Test comment');
+    const rawCommentAuthor = opts.commentAuthor ?? 'Author';
+    const cAuthor = escapeXmlAttr(rawCommentAuthor);
     const hasReply = opts.replyText != null;
-    const replyAuthor = opts.replyAuthor ?? 'Replier';
+    const rawReplyAuthor = opts.replyAuthor ?? 'Replier';
+    const replyAuthor = escapeXmlAttr(rawReplyAuthor);
     const replyEntry = hasReply
       ? `<w:comment w:id="2" w:author="${replyAuthor}" w:date="2025-01-02T00:00:00Z">` +
-        `<w:p w14:paraId="00000002"><w:r><w:t>${opts.replyText}</w:t></w:r></w:p>` +
+        `<w:p w14:paraId="00000002"><w:r><w:t>${escapeXmlText(opts.replyText!)}</w:t></w:r></w:p>` +
         `</w:comment>`
       : '';
     const commentsXml =
@@ -332,7 +342,7 @@ export async function buildSyntheticDocx(opts: SyntheticDocxOptions): Promise<Bu
 
       const replyPersonEntry = hasReply
         ? `<w15:person w15:author="${replyAuthor}">` +
-          `<w15:presenceInfo w15:providerId="None" w15:userId="${replyAuthor}@example.com"/>` +
+          `<w15:presenceInfo w15:providerId="None" w15:userId="${escapeXmlAttr(`${rawReplyAuthor}@example.com`)}"/>` +
           `</w15:person>`
         : '';
       const peopleXml =
@@ -340,7 +350,7 @@ export async function buildSyntheticDocx(opts: SyntheticDocxOptions): Promise<Bu
         `<w15:people xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml"` +
         ` xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
         `<w15:person w15:author="${cAuthor}">` +
-        `<w15:presenceInfo w15:providerId="None" w15:userId="${cAuthor}@example.com"/>` +
+        `<w15:presenceInfo w15:providerId="None" w15:userId="${escapeXmlAttr(`${rawCommentAuthor}@example.com`)}"/>` +
         `</w15:person>` +
         replyPersonEntry +
         `</w15:people>`;

--- a/packages/docx-core/src/primitives/formatting_tags.ts
+++ b/packages/docx-core/src/primitives/formatting_tags.ts
@@ -215,9 +215,9 @@ function tagsEqual(a: ActiveTags, b: ActiveTags): boolean {
 
 function fontTagString(tags: ActiveTags): string | null {
   const attrs: string[] = [];
-  if (tags.color !== null) attrs.push(`color="${tags.color}"`);
+  if (tags.color !== null) attrs.push(`color="${escapeHtmlAttribute(tags.color)}"`);
   if (tags.fontSize !== null) attrs.push(`size="${tags.fontSize}"`);
-  if (tags.fontName !== null) attrs.push(`face="${tags.fontName}"`);
+  if (tags.fontName !== null) attrs.push(`face="${escapeHtmlAttribute(tags.fontName)}"`);
   return attrs.length > 0 ? `<font ${attrs.join(' ')}>` : null;
 }
 

--- a/packages/docx-core/src/primitives/serialize_html.test.ts
+++ b/packages/docx-core/src/primitives/serialize_html.test.ts
@@ -333,6 +333,22 @@ describe('OpenSpec traceability: add-html-export (HTML serializer)', () => {
   );
 
   test(
+    'escaped TOON font attributes are decoded once before safe HTML emission',
+    async ({ then }: AllureBddContext) => {
+      const out = inlineTagsToHtml(
+        '<font face="A&amp;B &quot;Display&quot; &lt;Fallback&gt;">x</font>',
+      );
+
+      await then('font semantics survive without double encoding or injected markup', () => {
+        expect(out).toBe(
+          `<span style="font-family:'A&amp;B Display Fallback'">x</span>`,
+        );
+        expect(out).not.toContain('&amp;amp;');
+      });
+    },
+  );
+
+  test(
     'repeated items at the same level after a jump are siblings, not nested deeper',
     async ({ then }: AllureBddContext) => {
       const html = body([
@@ -352,14 +368,22 @@ describe('OpenSpec traceability: add-html-export (HTML serializer)', () => {
   );
 
   test(
-    'an unsafe javascript: hyperlink is neutralized while a safe one is kept',
+    'unsafe or injected hyperlink markup is neutralized while safe hrefs are rebuilt',
     async ({ then }: AllureBddContext) => {
       const evil = inlineTagsToHtml('<a href="javascript:alert(1)">x</a>');
-      const safe = inlineTagsToHtml('<a href="https://example.com/p?a=1">x</a>');
-      await then('javascript: loses its href; https keeps it', async () => {
+      const numericLetter = inlineTagsToHtml('<a href="jav&#x61;script:alert(1)">x</a>');
+      const numericTab = inlineTagsToHtml('<a href="java&#x09;script:alert(1)">x</a>');
+      const injectedAttribute = inlineTagsToHtml(
+        '<a href="https://safe.example" onclick="alert(1)">x</a>',
+      );
+      const safe = inlineTagsToHtml('<a href="https://example.com/p?a=1&amp;b=2">x</a>');
+      await then('only a validated and freshly escaped href reaches the output', async () => {
         expect(evil).toBe('<a>x</a>');
         expect(evil).not.toContain('javascript:');
-        expect(safe).toBe('<a href="https://example.com/p?a=1">x</a>');
+        expect(numericLetter).toBe('<a href="jav&amp;#x61;script:alert(1)">x</a>');
+        expect(numericTab).toBe('<a href="java&amp;#x09;script:alert(1)">x</a>');
+        expect(injectedAttribute).toBe('<a href="https://safe.example">x</a>');
+        expect(safe).toBe('<a href="https://example.com/p?a=1&amp;b=2">x</a>');
       });
     },
   );

--- a/packages/docx-core/src/primitives/serialize_html.ts
+++ b/packages/docx-core/src/primitives/serialize_html.ts
@@ -99,10 +99,19 @@ function sanitizeFontFamily(raw: string | undefined): string | null {
   return clean ? `'${clean}'` : null;
 }
 
+/** Decode the named entities emitted by `escapeHtmlAttribute` before semantic validation. */
+function decodeHtmlAttribute(raw: string | undefined): string | undefined {
+  return raw
+    ?.replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>')
+    .replaceAll('&quot;', '"')
+    .replaceAll('&amp;', '&');
+}
+
 function fontTagToSpan(tag: string): string {
-  const color = sanitizeColor(/color="([^"]*)"/.exec(tag)?.[1]);
-  const size = sanitizeFontSize(/size="([^"]*)"/.exec(tag)?.[1]);
-  const face = sanitizeFontFamily(/face="([^"]*)"/.exec(tag)?.[1]);
+  const color = sanitizeColor(decodeHtmlAttribute(/color="([^"]*)"/.exec(tag)?.[1]));
+  const size = sanitizeFontSize(decodeHtmlAttribute(/size="([^"]*)"/.exec(tag)?.[1]));
+  const face = sanitizeFontFamily(decodeHtmlAttribute(/face="([^"]*)"/.exec(tag)?.[1]));
   const decls: string[] = [];
   if (color) decls.push(`color:${color}`);
   if (size) decls.push(`font-size:${size}`);
@@ -138,10 +147,13 @@ export function inlineTagsToHtml(text: string, refs?: FootnoteRefs): string {
     else if (tag.startsWith('<font ')) out += fontTagToSpan(tag);
     else if (tag === '</font>') out += '</span>';
     else if (tag.startsWith('<a ')) {
-      // Drop the href for unsafe schemes (e.g. `javascript:`); keep the anchor so `</a>` still
-      // balances and the link text survives as plain text.
-      const href = /href="([^"]*)"/.exec(tag)?.[1] ?? '';
-      out += isSafeHref(href) ? tag : '<a>';
+      // Rebuild the tag from the sole supported attribute. Literal document text can look like
+      // a TOON tag, so passing the input tag through would retain injected event attributes.
+      const rawHref = /href="([^"]*)"/.exec(tag)?.[1];
+      const href = decodeHtmlAttribute(rawHref);
+      out += href !== undefined && isSafeHref(href)
+        ? `<a href="${escapeHtmlAttribute(href)}">`
+        : '<a>';
     }
     // <b>/<i>/<u> and `</a>` and the closers are already valid HTML — pass through.
     else out += tag;

--- a/packages/docx-core/src/primitives/track-changes-emitter.test.ts
+++ b/packages/docx-core/src/primitives/track-changes-emitter.test.ts
@@ -412,4 +412,31 @@ describe('track-changes-emitter', () => {
       );
     });
   });
+
+  test(
+    'wrapSerializedContentWithDel keeps a quote-bearing date in one attribute',
+    async ({ when, then }: AllureBddContext) => {
+      const date = '2026-05-03T14:15:16Z" data-injected="yes&<>';
+      let wrapper: Element | undefined;
+
+      await when('caller-supplied revision metadata is serialized', () => {
+        const wrapped = wrapSerializedContentWithDel(
+          '<w:r><w:t>gone</w:t></w:r>',
+          createRevisionContext({
+            author: 'Comparison',
+            date,
+            idState: createRevisionIdState(),
+          }),
+        );
+        wrapper = parseFragment(wrapped);
+      });
+
+      await then('the date round-trips without injecting another attribute', () => {
+        if (!wrapper) throw new Error('missing revision wrapper');
+        expect(wrapper.getAttributeNS(OOXML.W_NS, 'date')).toBe(date);
+        expect(wrapper.hasAttribute('data-injected')).toBe(false);
+        expect(wrapper.attributes).toHaveLength(3);
+      });
+    },
+  );
 });

--- a/packages/docx-core/src/primitives/track-changes-emitter.ts
+++ b/packages/docx-core/src/primitives/track-changes-emitter.ts
@@ -370,7 +370,7 @@ function createSerializedRevisionOpenTag(
   ctx: RevisionContext,
 ): string {
   const id = allocateRevisionId(ctx.idState);
-  return `<${tagName} w:id="${id}" w:author="${escapeXmlAttr(ctx.author)}" w:date="${ctx.date}">`;
+  return `<${tagName} w:id="${id}" w:author="${escapeXmlAttr(ctx.author)}" w:date="${escapeXmlAttr(ctx.date)}">`;
 }
 
 function normalizeDeletionElement(element: Element): Element {

--- a/packages/docx-core/src/testing/ooxml-fixtures.test.ts
+++ b/packages/docx-core/src/testing/ooxml-fixtures.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect } from 'vitest';
+import { OOXML } from '../primitives/namespaces.js';
+import { parseXml } from '../primitives/xml.js';
+import { DocxArchive } from '../shared/docx/DocxArchive.js';
+import { testAllure, type AllureBddContext } from './allure-test.js';
+import {
+  buildDocxFromBodyXml,
+  decoratedComplexField,
+  FIELD_INSTRUCTIONS,
+} from './ooxml-fixtures.js';
+
+const MC_NS = 'http://schemas.openxmlformats.org/markup-compatibility/2006';
+const test = testAllure.epic('Document Comparison').withLabels({
+  feature: 'OOXML Fixtures',
+  severity: 'critical',
+});
+
+describe('OOXML fixture attribute safety', () => {
+  test(
+    'decoratedComplexField keeps a quote-bearing bookmark anchor in one attribute',
+    async ({ when, then }: AllureBddContext) => {
+      const anchor = 'safe" w:tooltip="injected & < >';
+      let hyperlink: Element | undefined;
+
+      await when('the decorated field is parsed as OOXML', () => {
+        const xml =
+          `<w:p xmlns:w="${OOXML.W_NS}" xmlns:w14="${OOXML.W14_NS}">` +
+          decoratedComplexField(FIELD_INSTRUCTIONS.PAGE, '7', anchor) +
+          `</w:p>`;
+        const doc = parseXml(xml);
+        const found = doc.getElementsByTagNameNS(OOXML.W_NS, 'hyperlink')[0];
+        if (!found) throw new Error('missing hyperlink');
+        hyperlink = found;
+      });
+
+      await then('the original anchor round-trips without injecting another attribute', () => {
+        if (!hyperlink) throw new Error('missing hyperlink');
+        expect(hyperlink.getAttributeNS(OOXML.W_NS, 'anchor')).toBe(anchor);
+        expect(hyperlink.hasAttributeNS(OOXML.W_NS, 'tooltip')).toBe(false);
+      });
+    },
+  );
+
+  test(
+    'buildDocxFromBodyXml keeps a quote-bearing namespace URI in one attribute',
+    async ({ when, then }: AllureBddContext) => {
+      const namespaceUri = 'urn:fixture" injected="yes & more';
+      let documentRoot: Element | undefined;
+
+      await when('the fixture package is built with the namespace', async () => {
+        const buffer = await buildDocxFromBodyXml('<w:p/>', [], {
+          namespaces: { ext: namespaceUri },
+          ignorablePrefixes: ['ext'],
+        });
+        const archive = await DocxArchive.load(buffer);
+        documentRoot = parseXml(await archive.getDocumentXml()).documentElement;
+      });
+
+      await then('the namespace and ignorable list round-trip without attribute injection', () => {
+        if (!documentRoot) throw new Error('missing document root');
+        expect(documentRoot.getAttribute('xmlns:ext')).toBe(namespaceUri);
+        expect(documentRoot.getAttributeNS(MC_NS, 'Ignorable')).toBe('w14 ext');
+        expect(documentRoot.hasAttribute('injected')).toBe(false);
+      });
+    },
+  );
+
+  test(
+    'buildDocxFromBodyXml rejects unsafe namespace prefix tokens',
+    async ({ then }: AllureBddContext) => {
+      await then('attribute-name and ignorable-list injection attempts fail closed', async () => {
+        await expect(
+          buildDocxFromBodyXml('<w:p/>', [], {
+            namespaces: { 'ext" injected': 'urn:fixture' },
+          }),
+        ).rejects.toThrow('Invalid XML namespace prefix');
+        await expect(
+          buildDocxFromBodyXml('<w:p/>', [], {
+            ignorablePrefixes: ['ext injected'],
+          }),
+        ).rejects.toThrow('Invalid XML namespace prefix');
+      });
+    },
+  );
+});

--- a/packages/docx-core/src/testing/ooxml-fixtures.ts
+++ b/packages/docx-core/src/testing/ooxml-fixtures.ts
@@ -51,6 +51,22 @@ function escapeXmlText(text: string): string {
     .replace(/>/g, '&gt;');
 }
 
+function escapeXmlAttr(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+const XML_PREFIX_RE = /^[A-Za-z_][A-Za-z0-9._-]*$/u;
+
+function assertXmlPrefix(prefix: string): void {
+  if (!XML_PREFIX_RE.test(prefix) || /^xml/i.test(prefix)) {
+    throw new Error(`Invalid XML namespace prefix: ${JSON.stringify(prefix)}`);
+  }
+}
+
 export function paragraphWithText(text: string): string {
   return `<w:p>${resultText(escapeXmlText(text))}</w:p>`;
 }
@@ -114,7 +130,7 @@ export function decoratedComplexField(
     `<w:instrText xml:space="preserve">${secondInstruction}</w:instrText></w:r>` +
     `<w:r><w:rPr><w:u w:val="single"/></w:rPr>` +
     `<w:fldChar w:fldCharType="separate"/></w:r>` +
-    `<w:hyperlink w:anchor="${escapeXmlText(anchor)}" w:history="1">` +
+    `<w:hyperlink w:anchor="${escapeXmlAttr(anchor)}" w:history="1">` +
     `<w:r><w:rPr><w:smallCaps/></w:rPr><w:t>${escapeXmlText(result)}</w:t></w:r>` +
     `</w:hyperlink>` +
     `<w:r><w:rPr><w:vanish/><w14:textEffect w14:val="none"/></w:rPr>` +
@@ -214,17 +230,22 @@ export async function buildDocxFromBodyXml(
   hyperlinkRels: HyperlinkRelFixture[] = [],
   namespaceOptions: MinimalDocumentNamespaceOptions = {},
 ): Promise<Buffer> {
-  const extraNamespaces = Object.entries(namespaceOptions.namespaces ?? {})
-    .map(([prefix, uri]) => ` xmlns:${prefix}="${escapeXmlText(uri)}"`)
+  const namespaceEntries = Object.entries(namespaceOptions.namespaces ?? {});
+  for (const [prefix] of namespaceEntries) assertXmlPrefix(prefix);
+  const additionalIgnorablePrefixes = namespaceOptions.ignorablePrefixes ?? [];
+  for (const prefix of additionalIgnorablePrefixes) assertXmlPrefix(prefix);
+
+  const extraNamespaces = namespaceEntries
+    .map(([prefix, uri]) => ` xmlns:${prefix}="${escapeXmlAttr(uri)}"`)
     .join('');
-  const ignorable = ['w14', ...(namespaceOptions.ignorablePrefixes ?? [])].join(' ');
+  const ignorable = ['w14', ...additionalIgnorablePrefixes].join(' ');
   const documentXml =
     `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
     `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"` +
     ` xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"` +
     ` xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"` +
     extraNamespaces +
-    ` mc:Ignorable="${ignorable}">` +
+    ` mc:Ignorable="${escapeXmlAttr(ignorable)}">` +
     `<w:body>${bodyXml}<w:sectPr/></w:body></w:document>`;
 
   const contentTypesXml =
@@ -241,20 +262,14 @@ export async function buildDocxFromBodyXml(
     `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>` +
     `</Relationships>`;
 
-  const escapeAttr = (value: string): string =>
-    value
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;');
   const hyperlinkRelsXml = hyperlinkRels
     .map((rel) => {
       const external = rel.external ?? true;
       const mode = external ? ` TargetMode="External"` : '';
       return (
-        `<Relationship Id="${escapeAttr(rel.id)}"` +
+        `<Relationship Id="${escapeXmlAttr(rel.id)}"` +
         ` Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink"` +
-        ` Target="${escapeAttr(rel.target)}"${mode}/>`
+        ` Target="${escapeXmlAttr(rel.target)}"${mode}/>`
       );
     })
     .join('');

--- a/packages/docx-core/test-primitives/formatting_tags.test.ts
+++ b/packages/docx-core/test-primitives/formatting_tags.test.ts
@@ -316,6 +316,43 @@ describe('formatting_tags', () => {
     });
   });
 
+  test(
+    'emitFormattingTags attribute-escapes document-derived font metadata',
+    async ({ when, then }: AllureBddContext) => {
+      let tagged: string;
+
+      await when('a run contains quote-bearing color and font values', () => {
+        const runs: AnnotatedRun[] = [
+          annotatedRun('X', {
+            colorHex: 'FF0000" onmouseover="alert(1)&<>',
+            fontName: 'A&B "Display" <Fallback>',
+          }),
+        ];
+        const baseline: FormattingBaseline = {
+          bold: false,
+          italic: false,
+          underline: false,
+          suppressed: false,
+        };
+        const fontBaseline = computeParagraphFontBaseline(runs, { formattingMode: 'full' });
+
+        tagged = emitFormattingTags({
+          runs,
+          baseline,
+          fontBaseline,
+          formattingMode: 'full',
+        });
+      });
+
+      await then('the values remain inside their original attributes', () => {
+        expect(tagged).toBe(
+          '<font color="FF0000&quot; onmouseover=&quot;alert(1)&amp;&lt;&gt;" ' +
+            'face="A&amp;B &quot;Display&quot; &lt;Fallback&gt;">X</font>',
+        );
+      });
+    },
+  );
+
   test('emitFormattingTags combines font and BIU tags', async ({ given, when, then }: AllureBddContext) => {
     let tagged: string;
 

--- a/packages/docx-mcp/src/tools/tag_parser.test.ts
+++ b/packages/docx-mcp/src/tools/tag_parser.test.ts
@@ -105,6 +105,15 @@ describe('tag_parser', () => {
       const result = splitTaggedText('<font face="Times New Roman">serif</font>');
       expect(result).toEqual([seg('serif', { fontName: 'Times New Roman' })]);
     });
+
+    test('emitter-escaped font attributes decode exactly once', () => {
+      const result = splitTaggedText(
+        '<font face="A&amp;B &quot;Display&quot; &lt;Fallback&gt;">serif</font>',
+      );
+      expect(result).toEqual([
+        seg('serif', { fontName: 'A&B "Display" <Fallback>' }),
+      ]);
+    });
   });
 
   // ─── splitTaggedText: mixed and nested tags ────────────────────

--- a/packages/docx-mcp/src/tools/tag_parser.test.ts
+++ b/packages/docx-mcp/src/tools/tag_parser.test.ts
@@ -114,6 +114,15 @@ describe('tag_parser', () => {
         seg('serif', { fontName: 'A&B "Display" <Fallback>' }),
       ]);
     });
+
+    test('nested named entities remain literal after one DOM decode', () => {
+      const result = splitTaggedText(
+        '<font face="Literal &amp;quot; entity">serif</font>',
+      );
+      expect(result).toEqual([
+        seg('serif', { fontName: 'Literal &quot; entity' }),
+      ]);
+    });
   });
 
   // ─── splitTaggedText: mixed and nested tags ────────────────────

--- a/packages/docx-mcp/src/tools/tag_parser.ts
+++ b/packages/docx-mcp/src/tools/tag_parser.ts
@@ -373,7 +373,7 @@ const TAG_NAME_TO_STATE_KEY: Record<string, keyof ParsedSegmentState | 'font'> =
   font: 'font',
 };
 
-/** Decode the named entities emitted by the public formatting-tag attribute escaper. */
+/** Decode one named-entity layer emitted by the public formatting-tag attribute escaper. */
 function decodeFormattingAttribute(value: string | null): string | null {
   return value
     ?.replaceAll('&lt;', '<')
@@ -396,8 +396,10 @@ function walkNode(
       const stateKey = TAG_NAME_TO_STATE_KEY[tagName]!;
 
       if (stateKey === 'font') {
-        // Read font attributes. getAttribute returns "" for absent attrs in xmldom,
-        // so use || null to normalize empty strings.
+        // Attribute scanning escapes raw ampersands before XML parsing, so the
+        // DOM decode only removes that parser-safety layer. Remove exactly one
+        // additional emitter-owned entity layer here; getAttribute returns ""
+        // for absent attrs, so use || null to normalize empty strings.
         const colorAttr = decodeFormattingAttribute(el.getAttribute('color') || null);
         const sizeAttr = decodeFormattingAttribute(el.getAttribute('size') || null);
         const faceAttr = decodeFormattingAttribute(el.getAttribute('face') || null);

--- a/packages/docx-mcp/src/tools/tag_parser.ts
+++ b/packages/docx-mcp/src/tools/tag_parser.ts
@@ -373,6 +373,15 @@ const TAG_NAME_TO_STATE_KEY: Record<string, keyof ParsedSegmentState | 'font'> =
   font: 'font',
 };
 
+/** Decode the named entities emitted by the public formatting-tag attribute escaper. */
+function decodeFormattingAttribute(value: string | null): string | null {
+  return value
+    ?.replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>')
+    .replaceAll('&quot;', '"')
+    .replaceAll('&amp;', '&') ?? null;
+}
+
 function walkNode(
   node: XmlDomNode,
   state: ParsedSegmentState,
@@ -389,9 +398,9 @@ function walkNode(
       if (stateKey === 'font') {
         // Read font attributes. getAttribute returns "" for absent attrs in xmldom,
         // so use || null to normalize empty strings.
-        const colorAttr = el.getAttribute('color') || null;
-        const sizeAttr = el.getAttribute('size') || null;
-        const faceAttr = el.getAttribute('face') || null;
+        const colorAttr = decodeFormattingAttribute(el.getAttribute('color') || null);
+        const sizeAttr = decodeFormattingAttribute(el.getAttribute('size') || null);
+        const faceAttr = decodeFormattingAttribute(el.getAttribute('face') || null);
 
         const newState: ParsedSegmentState = {
           ...state,


### PR DESCRIPTION
## Summary

- use context-specific XML attribute escaping for complex-field anchors, namespace URIs, relationship metadata, revision dates, and semantic synthetic-DOCX metadata
- validate dynamic XML namespace prefixes before they can become attribute names or `mc:Ignorable` tokens
- escape document-derived `<font>` attributes while preserving the Safe-DOCX emitter/parser round trip through one-layer entity decoding
- reconstruct HTML anchors from the sole supported `href`, validate the decoded scheme, re-escape it, and drop injected event attributes
- add adversarial regression tests for attribute breakout, raw XML injection, unsafe namespace prefixes, double encoding, and entity-obfuscated hyperlink schemes

## Root cause

Several string serializers reused text-context escaping in quoted attribute contexts. Text escaping protects `&`, `<`, and `>`, but leaves `"` able to terminate an attribute. That caused the CodeQL review finding added after #617 merged and the duplicate finding in the mirrored core fixture. The same audit found two pre-existing namespace-URI alerts plus analogous production paths in formatting-tag HTML, serialized revision metadata, and semantic fixture generation.

Consumers that parse producer-owned formatting tags now decode exactly one known entity layer before semantic validation. This preserves round trips without recursively decoding attacker-controlled numeric or nested entities.

## Impact

Caller- or document-controlled values remain inside their intended XML/HTML attributes or text nodes. Unsafe hyperlink markup loses unsupported attributes, and obfuscated unsafe schemes cannot become executable through recursive entity decoding. Existing safe font names and URLs keep their prior semantic values.

Follow-up to #617 and its CodeQL discussion: https://github.com/UseJunior/safe-docx/pull/617#discussion_r3641835293

## Verification

- focused core/compare/MCP security regressions: 146/146 passing
- full `docx-mcp` suite, serial execution: 890/890 passing
- three load-sensitive MCP tests from the aggregate workspace run: 21/21 passing in isolation
- LibreOffice oracle tests from the aggregate workspace run: 4/4 passing serially
- `npm run build`: passing on the rebased remote head
- `npm run lint:workspaces`: passing (9 pre-existing warnings, 0 errors)
- `npm run check:spec-coverage`: passing
- `npm run check:conformance-citations`: passing
- `npm run check:conformance-doc`: passing

The single aggregate `npm run test:run` invocation reported only the six concurrency/environment timeouts called out above; every timed-out test passes under isolated or serial execution.