### PR TITLE
feat(docx-compare): verify ancillary field stories

### DIFF
--- a/openspec/changes/verify-ancillary-field-stories/design.md
+++ b/openspec/changes/verify-ancillary-field-stories/design.md
@@ -1,0 +1,362 @@
+## Context
+
+`evaluateSafetyChecks` currently applies the Lean-pinned
+`validateFieldStructure` predicate to `word/document.xml` and footnote/endnote
+entries extracted from both input sidecars. That runs before reconstruction
+mode selection and before auxiliary definitions are merged into the result.
+Header/footer parts are excluded because selecting them requires section-binding
+and relationship resolution.
+
+The final package is mode-dependent. True inplace output clones the revised
+archive and imports still-referenced definitions from the original; forced
+rebuild and inplace fallback clone the original archive and import definitions
+from the revised. Before either assembly, auxiliary ID collision handling may
+mutate the revised in-memory archive and renumber definitions and references.
+Final ancillary validation and preservation evidence must therefore use those
+post-collision in-memory archives and the actual merge results, not the original
+input buffers or a reconstructed guess at provenance.
+
+## Goals / Non-Goals
+
+- Goals: reuse or extract the existing `sectPrAudit` binding contract to select
+  every valid section-bound header/footer and retain all binding locators.
+- Goals: validate every selected header/footer and every final
+  footnote/endnote entry with a strict runtime field predicate and fresh state.
+- Goals: reject duplicate direct note-entry IDs before locator/provenance
+  construction.
+- Goals: enumerate eligible source fields first and require exact final
+  inventory equality by deterministic structural locator and canonical range.
+- Goals: retain entry-level provenance across base wins, imports, created note
+  parts, reserved-entry copies, same-ID identical definitions, and collision
+  renumbering.
+- Goals: expose successful preservation evidence and structured typed-error
+  diagnostics with story locator, failure category, issue codes, and details.
+- Goals: add optional success evidence and ancillary fallback diagnostics to
+  `CompareResult` without changing existing result field meanings.
+- Goals: cover forced rebuild, true inplace, ancillary-triggered inplace
+  fallback, terminal failure, and a minimally edited pair derived from the
+  checked-in NVCA COI source document.
+- Non-Goals: selecting headers/footers by filename, validating unreferenced
+  header/footer parts, or predicting first/default/even pagination behavior.
+- Non-Goals: comparing ancillary text, synthesizing ancillary revisions,
+  evaluating fields, computing pagination or cached results, or resolving REF
+  and PAGEREF bookmarks.
+- Non-Goals: complete footnote/endnote definition/reference integrity,
+  relationship validation for note parts, or a claim that every note definition
+  is reachable.
+- Non-Goals: changing the Lean checker, executable protocol v3, its
+  inplace-only mode, or its fixed main/footnotes/endnotes scope.
+
+## Decisions
+
+### Selection reuses the section-binding audit contract
+
+The implementation reuses or extracts the binding-resolution portion of
+`auditSectPr` instead of creating a looser relationship walker. A selected valid
+section binding must be a direct `w:headerReference` or `w:footerReference`
+child of a structurally valid `w:sectPr`; carry a `w:type` role of `default`,
+`first`, or `even`; be unique by kind and role within that section; carry an
+unambiguous `r:id`; resolve through exactly one final
+`word/_rels/document.xml.rels` relationship of the matching header/footer type;
+use an internal package-contained safe target; and point to a part with the
+expected `w:hdr` or `w:ftr` root.
+
+The resolver and opaque passthrough use one docx-core OPC target helper. It
+rejects empty, query/fragment-bearing, control-bearing, encoded traversal or
+separator, backslash, scheme-like, network-path, and package-escaping internal
+targets. Missing `TargetMode` and exact `Internal` are internal; exact
+`External` is rejected for section bindings, and any other value is invalid.
+
+Each binding receives a locator consisting of depth-first section ordinal,
+`header` or `footer` kind, and role. Multiple valid bindings may reuse one
+normalized target. Target XML and strict field validation are deduplicated by
+normalized part path, but diagnostics and successful evidence retain every
+binding locator that selected that target.
+
+The selector never enumerates `word/header*.xml` or `word/footer*.xml`.
+Malformed unreferenced parts therefore remain outside validation. Invalid
+section bindings, duplicate relationship IDs, missing relationships, wrong or
+external relationship types, unsafe targets, missing parts, malformed XML, or
+wrong roots are binding-resolution failures.
+
+Target normalization and package containment are explicit SafeDocX safety
+policies. They are not attributed to ECMA-376.
+
+### Strict ancillary field validation is separate from Lean
+
+A new strict ancillary predicate is independent of the Lean-pinned
+`validateFieldStructure`. It may reuse `collectFieldStructureIssues`, but its
+per-story stack additionally rejects:
+
+- an `end` marker when no field is open;
+- a `separate` marker when no field is open;
+- a second `separate` marker at the same open-field depth;
+- any missing or unknown `w:fldCharType`; and
+- nonzero field depth at the end of the story.
+
+The stack tracks separator state per depth. A complete begin/end-only field is
+valid because `separate` is optional for this structural predicate. Properly
+stacked nested fields are valid. Every selected header/footer part and every
+direct `w:footnote` and `w:endnote` entry, including reserved entries, starts
+with fresh state. This note-entry isolation is a SafeDocX safety policy, not a
+new ECMA note claim.
+
+A `separate` marker encountered at depth zero is rejected independently as
+`FIELD_STRAY_SEPARATOR`. It is not folded into duplicate-separator or
+instruction-text diagnostics.
+
+Before strict entry validation, provenance mapping, or evidence inventory, each
+final note part and its base contributor is scanned namespace-aware. A
+merge-source part is scanned only when merge results show imported definitions
+or a newly created final part. An unused merge-source part is not parsed and
+cannot poison the selected package. Direct `w:footnote/@w:id` and
+`w:endnote/@w:id` values are whitespace-collapsed, validated against the
+`xsd:integer` lexical form, and canonicalized to their integer value before
+duplicate detection or mapping. Thus `1`, `01`, and `+1` collide, while valid
+negative reserved IDs remain valid. Invalid lexical forms use
+`INVALID_NOTE_ENTRY_ID`; numeric duplicates use `DUPLICATE_NOTE_ENTRY_ID` in
+the `canonical_evidence` category. The locator uses the archive side when
+applicable, note part path, and canonical entry ID, not an entry ordinal. This
+is an explicit SafeDocX evidence-safety policy needed for unambiguous locators;
+it does not claim complete note integrity.
+
+Tests pin examples where the strict predicate intentionally differs from
+`validateFieldStructure`, while the production Lean predicate, differential
+harness, executable protocol v3, and certificate remain unchanged.
+
+### Failure handling is deterministic and terminal
+
+The post-assembly gate has three failure categories:
+
+- `binding_resolution`;
+- `strict_field_structure`; and
+- `canonical_evidence`.
+
+Each issue has a stable code, human-readable detail, and a structured story
+locator. Header/footer locators carry section ordinal, kind, role, and normalized
+part path when resolution reached one. Note locators carry normalized part path
+and entry ID. Canonical evidence locators additionally carry paragraph ordinal,
+eligible field ordinal, and instruction kind.
+
+The error contract uses discriminated data rather than parsing messages:
+
+- `AncillaryBindingLocator` carries `locatorType: "section_binding"`,
+  `sectionOrdinal`, `kind`, `role`, and optional `normalizedPartPath`;
+- `AncillaryHeaderFooterStoryLocator` carries
+  `locatorType: "header_footer_story"`, `normalizedPartPath`, and all selecting
+  binding locators;
+- `AncillaryNoteStoryLocator` carries `locatorType: "note_entry"`,
+  `normalizedPartPath`, and `entryId`; and
+- canonical issues extend the header/footer or note locator with
+  `paragraphOrdinal`, `eligibleFieldOrdinal`, and `instructionKind`.
+
+`AncillaryStorySafetyIssue` carries `category`, `code`, `detail`, and one of
+those locators. Binding codes reuse the applicable `SectPrIssueType` values.
+Strict-only codes include `FIELD_STRAY_END`, `FIELD_STRAY_SEPARATOR`,
+`FIELD_DUPLICATE_SEPARATOR`, `FIELD_UNKNOWN_CHAR_TYPE`, and
+`FIELD_UNCLOSED_DEPTH`, alongside reused field issue codes. Evidence codes
+include `DUPLICATE_NOTE_ENTRY_ID` and distinguish `FIELD_RANGE_MISSING`,
+`INVALID_NOTE_ENTRY_ID`, `FIELD_RANGE_EXTRA`, `FIELD_RANGE_KIND_MISMATCH`, and
+`FIELD_RANGE_CANONICAL_MISMATCH`.
+`AncillaryStorySafetyError` exposes a non-empty ordered `issues` array.
+
+Any category failure rejects an inplace candidate and triggers exactly one
+rebuild assembly. Selection, strict validation, provenance, and evidence are
+recomputed against that rebuilt package. Any category failure on forced/direct
+rebuild, or on the terminal rebuild after inplace rejection, throws
+`AncillaryStorySafetyError` before serialization is returned or published. The
+error exposes all structured issues. A failed call returns no `CompareResult`
+and therefore no public preservation evidence. There is no warning-only success
+path for these failures.
+
+### Preservation inventory is source-first and locator-based
+
+For each source story selected for assembly, the implementation enumerates
+eligible ranges in deterministic depth-first document order. Eligibility
+requires a complete, non-nested complex field wholly contained in one paragraph
+whose instruction is accepted by the same PAGE/NUMPAGES/REF/PAGEREF parser and
+switch rules introduced by PR #617. Header/footer inventories retain only PAGE
+and NUMPAGES; note-entry inventories retain only REF and PAGEREF.
+
+Each source item has a stable structural identity composed of:
+
+- normalized package part path;
+- note entry ID for note stories;
+- paragraph ordinal within the header/footer story or note entry;
+- eligible-field ordinal within that paragraph.
+
+Instruction kind remains reported on the locator and evidence item but is not
+part of structural identity. This makes a PAGE-to-NUMPAGES change at the same
+source-first ordinal a reachable `FIELD_RANGE_KIND_MISMATCH`.
+
+The final package is independently inventoried by the same algorithm. Source
+and final structural locators and canonical ranges must match exactly. Missing,
+extra, relocated, reclassified, or canonically mismatched ranges are failures.
+Ordering is represented by paragraph and eligible-field ordinals rather than a
+separate order diagnostic. Repeated canonically identical fields remain
+distinct because locators, not hashes, establish identity.
+
+Nested and cross-paragraph fields are excluded from exact preservation
+inventory, but the complete containing story still must pass strict field
+validation. Exclusion from inventory is not a passing preservation claim.
+
+### Canonical ranges reuse PR #617 expanded-name canonicalization
+
+The implementation extracts and reuses the PR #617 canonical subtree algorithm
+instead of defining a second representation. A range is the ordered direct
+paragraph-child span from the child containing `fldChar begin` through the child
+containing its matching `fldChar end`. Canonicalization ignores namespace
+declaration spelling/order and ordinary attribute order. It retains expanded
+element and attribute names, attribute values, text, child order, run
+boundaries, wrappers, and all other represented subtree structure.
+
+Exact canonical equality is a SafeDocX metamorphic invariant. It is not package
+byte identity and is not an ECMA-376 preservation requirement.
+
+### Provenance follows post-collision assembly inputs
+
+Provenance is captured from the post-collision in-memory base and merge-source
+archives actually consumed by assembly:
+
+- an entry ID already present in the base is base-provenance and wins;
+- an ID returned by auxiliary merge as imported is merge-source provenance;
+- when a note part is newly created, copied reserved entries are merge-source
+  provenance and imported referenced entries retain merge-source provenance;
+- same-ID content-identical definitions are not renumbered, so the base entry
+  wins and receives base provenance; and
+- content-different collisions use the revised-side post-renumber ID and source
+  entry, so evidence locators and provenance reflect the rewritten in-memory
+  archive rather than the pre-collision ID.
+
+Provenance is defined for every final note entry even though exact evidence
+inventories only eligible REF/PAGEREF ranges. This avoids inferring source from
+final XML after merge and makes created-part reserved-entry ownership explicit.
+
+### Successful result and fallback fields are additive
+
+Successful atomizer results may include this optional contract:
+
+```ts
+interface AncillaryFieldEvidence {
+  status: 'passed';
+  reconstructionMode: ReconstructionMode;
+  selectedBindings: AncillarySelectedBindingSummary[];
+  stories: AncillaryStorySummary[];
+  ranges: AncillaryFieldRangeEvidence[];
+}
+
+interface AncillarySelectedBindingSummary {
+  sectionOrdinal: number;
+  kind: 'header' | 'footer';
+  role: 'default' | 'first' | 'even';
+  relationshipId: string;
+  normalizedPartPath: string;
+}
+
+interface AncillaryStorySummary {
+  storyKind: 'header' | 'footer' | 'footnote' | 'endnote';
+  normalizedPartPath: string;
+  entryId?: string;
+  selectingBindings?: AncillaryBindingLocator[];
+  sourceSide?: 'original' | 'revised';
+  provenance?: 'base' | 'imported';
+  strictFieldStructure: 'passed';
+}
+
+interface AncillaryFieldRangeEvidence {
+  locator: AncillaryFieldLocator;
+  instructionKind: 'PAGE' | 'NUMPAGES' | 'REF' | 'PAGEREF';
+  sourceSide: 'original' | 'revised';
+  provenance: 'base' | 'imported';
+  canonicalMatch: true;
+}
+
+interface AncillaryFallbackDiagnostics {
+  issues: AncillaryStorySafetyIssue[];
+}
+```
+
+`CompareResult.ancillaryFieldEvidence?: AncillaryFieldEvidence` is optional at
+the type level for compatibility, but an atomizer comparison that reaches and
+passes this gate returns it. Its `reconstructionMode` always equals
+`reconstructionModeUsed`. `stories` summarizes each deduplicated header/footer
+target and note entry. Every `ranges` item carries the stable structural locator
+already defined above; `instructionKind` is repeated as a convenient
+discriminator.
+
+`ReconstructionFallbackReason` gains
+`ancillary_story_safety_check_failed`. When ancillary failure rejects an
+inplace candidate and rebuild succeeds, `fallbackReason` has that value and
+`CompareResult.ancillaryFallbackDiagnostics?: AncillaryFallbackDiagnostics`
+contains the rejected candidate's ordered structured ancillary issues. The
+successful `ancillaryFieldEvidence` is newly computed from the final rebuild,
+identifies `rebuild`, and contains no rejected-candidate evidence.
+
+These fields are additive and optional for compatibility with prior producers,
+other comparison engines, and results where the capability is unavailable.
+Consumers treat absence as unavailable evidence, never as a pass. Terminal
+failure throws and returns no `CompareResult`, so there is no failed
+`AncillaryFieldEvidence` status.
+
+### NVCA evidence uses one real source-derived pair
+
+The real-document test loads
+`tests/test_documents/nvca-coi-regression/source.docx`, clones it, and uses the
+exported `replaceParagraphTextRange` primitive to make one minimal body-text
+edit outside the ancillary fields being inventoried. It does not use
+`filled.docx` as the revised side. The same real source-derived pair runs
+through requested inplace and forced rebuild. The inplace run must remain true
+inplace; both runs must report final-mode evidence with at least one selected
+footer PAGE range and at least one footnote REF range, including exact canonical
+matches and concrete provenance.
+
+### Conformance claims remain bounded
+
+ECMA-376 edition 5 Part 1 §§17.10.2 and 17.10.5 cover the registered typed
+footer/header binding surface; §§17.10.3 and 17.10.4 cover the expected story
+roots. Section 17.16.18 covers complex-field structure, and §§17.16.5.42,
+17.16.5.44, 17.16.5.45, and 17.16.5.51 cover the bounded instruction
+vocabulary.
+
+Target normalization, package containment, note-entry isolation, provenance,
+duplicate direct note-ID rejection, and exact canonical preservation are
+SafeDocX policies or invariants, not ECMA claims. This change adds no unsupported
+Part 2 or note clauses. Section
+17.11.14 is cited only by implementation or tests that actually exercise
+`w:footnoteReference/@w:id` as a reference identifier; independent note-entry
+validation or REF/PAGEREF preservation does not justify that citation.
+
+### Lean remains a fixed-story certificate
+
+The Lean certificate remains executable protocol v3, public certificate
+protocol v1, inplace-only, and fixed to `word/document.xml`,
+`word/footnotes.xml`, and `word/endnotes.xml`. Strict runtime ancillary
+validation and preservation diagnostics do not become Lean evidence.
+Dynamically relationship-addressed header/footer stories require a separate
+protocol and proof-model change and are the next separate slice.
+
+## Risks / Trade-offs
+
+- A post-assembly failure may cause a second full assembly. The one-rebuild
+  limit gives deterministic cost and behavior.
+- Strict runtime validation intentionally rejects malformed shapes tolerated by
+  the Lean-pinned predicate. Keeping separate APIs and differential tests avoids
+  silently changing an established proof boundary.
+- Locator equality treats paragraph or eligible-field reordering as a
+  preservation failure even when canonical ranges are identical. This is
+  required to make repeated fields non-ambiguous.
+- Canonical DOM equality is stricter than semantic field equivalence but weaker
+  than ZIP-byte equality. It matches the established PR #617 invariant.
+- Relationship resolution deliberately rejects ambiguous targets rather than
+  guessing filenames, so some malformed third-party packages fail closed.
+
+## Migration Plan
+
+Successful results gain optional additive ancillary evidence. The fallback
+reason union and result gain an ancillary reason and optional rejected-candidate
+diagnostics. Existing fields, comparison options, and Lean certificate fields
+do not change meaning. Calls that would previously return a package with
+malformed selected ancillary stories, duplicate direct note IDs, or mismatched
+eligible ranges now either recover through one rebuild or throw
+`AncillaryStorySafetyError`; callers can inspect its structured issues.
+Unreferenced malformed header/footer files remain ignored.

--- a/openspec/changes/verify-ancillary-field-stories/proposal.md
+++ b/openspec/changes/verify-ancillary-field-stories/proposal.md
@@ -1,0 +1,54 @@
+# Change: Verify ancillary field stories after package assembly
+
+## Why
+
+Comparison currently validates main-document field structure and pre-merge note
+sidecars before it chooses and assembles the output package. That does not prove
+that valid section-bound header/footer parts or the final, merged note entries
+are independently well formed, and it provides no source-first preservation
+evidence for unchanged fields in those ancillary stories.
+
+## What Changes
+
+- Reuse the section-property audit contract to select only valid
+  `w:headerReference` and `w:footerReference` bindings through typed final
+  `word/_rels/document.xml.rels` relationships and the shared robust OPC
+  target normalizer; reject indirect binding placement, invalid target modes,
+  and unsafe targets, and never discover parts by filename glob.
+- Add a strict runtime ancillary field-story predicate, separate from the
+  Lean-pinned `validateFieldStructure`, and apply it independently to every
+  selected header/footer and every final footnote/endnote entry.
+- Canonicalize direct footnote/endnote entry IDs as `xsd:integer` values and
+  reject invalid lexical IDs or numeric-equivalent duplicates before
+  provenance or evidence mapping so structural locators remain unambiguous.
+- Inventory eligible source PAGE/NUMPAGES ranges in selected headers/footers
+  and REF/PAGEREF ranges in note definitions, retain post-collision assembly
+  provenance, and require the final inventory to match exactly by structural
+  locator and PR #617 canonical range.
+- Reject a failing inplace package candidate and attempt one rebuilt assembly.
+  Throw a typed ancillary-story safety error if direct/forced rebuild or the
+  terminal rebuilt fallback fails; never return a warning-only successful
+  comparison for relationship, strict-field, or preservation failures.
+- Add optional successful `CompareResult.ancillaryFieldEvidence`, an ancillary
+  fallback reason, and rejected-candidate ancillary fallback diagnostics without
+  changing existing result fields.
+- Exercise forced rebuild, true inplace, ancillary-triggered inplace fallback,
+  terminal failure, ID collision/renumbering, and a minimally edited pair
+  derived from the checked-in NVCA COI source document. Run that same real
+  source-derived pair through true inplace and forced rebuild and require
+  nonzero footer PAGE and footnote REF evidence in both.
+- Keep ancillary revision synthesis, ancillary text comparison, field
+  evaluation, pagination, bookmark resolution, and complete note
+  reference/relationship integrity outside this change.
+- Keep the compiled Lean checker at protocol v3 with its existing inplace-only
+  fixed scope of main, footnotes, and endnotes. Relationship-addressed
+  header/footer Lean stories remain a separate next slice.
+
+## Impact
+
+- Affected specs: `docx-comparison`, `spec-compliance`
+- Affected code: section binding audit extraction, atomizer package assembly
+  and typed safety errors, strict runtime field-story validation, auxiliary
+  merge provenance, source/final field inventory, synthetic and NVCA tests,
+  ECMA-376 registry evidence
+- Ref: #582

--- a/openspec/changes/verify-ancillary-field-stories/specs/docx-comparison/spec.md
+++ b/openspec/changes/verify-ancillary-field-stories/specs/docx-comparison/spec.md
@@ -1,0 +1,314 @@
+## ADDED Requirements
+
+### Requirement: Final packages verify selected valid section-bound field stories
+
+After complete reconstruction-mode-specific package assembly, the system SHALL
+validate every header/footer part selected by a valid section binding and every
+final footnote/endnote entry as an independent strict field story. Selection
+SHALL reuse or extract the `sectPrAudit` binding contract: a reference must be a
+direct child of a valid `w:sectPr`, have a valid and per-section unique
+default/first/even role, carry an unambiguous `r:id`, resolve through the exact
+matching internal relationship type to a safe package-contained target, and
+point to the expected `w:hdr` or `w:ftr` root.
+
+The shared OPC target normalizer SHALL reject empty targets, query/fragment or
+control characters, encoded traversal or separators, backslashes, scheme-like
+or network-path forms, and package-root escape. An absent `TargetMode` or exact
+`Internal` SHALL be internal. Exact `External` SHALL be rejected for selected
+headers/footers, and every other `TargetMode` value SHALL be invalid.
+
+Target validation SHALL be deduplicated by normalized part path while retaining
+every selecting binding locator as section ordinal, kind, and role. The system
+SHALL NOT select header/footer stories by filename glob, and an unreferenced
+malformed header/footer part SHALL NOT affect the safety result.
+
+#### Scenario: [SDX-ANC-STORY-01] Valid section bindings select header and footer targets
+
+- **GIVEN** final section properties containing direct header/footer references and the package also containing unreferenced header/footer filenames
+- **WHEN** the final ancillary story set is selected
+- **THEN** every selected binding SHALL have a valid role, unique kind/role within its section, unambiguous relationship ID, exact relationship type, safe internal target, and expected root
+- **AND** indirect reference placement, invalid target modes, external targets, and unsafe internal target forms SHALL fail with binding-resolution diagnostics
+- **AND** each binding locator SHALL retain section ordinal, kind, and role
+- **AND** no filename glob SHALL add an unreferenced part
+
+#### Scenario: [SDX-ANC-STORY-02] Reused targets validate once but retain all bindings
+
+- **GIVEN** multiple valid section bindings that resolve to the same normalized header or footer target
+- **WHEN** final ancillary validation runs
+- **THEN** the target story SHALL be parsed and strictly validated once
+- **AND** diagnostics and evidence SHALL retain every binding locator that selected it
+
+#### Scenario: [SDX-ANC-STORY-03] Every selected story has independent field state
+
+- **GIVEN** selected headers, selected footers, and final footnote/endnote parts with multiple entries
+- **WHEN** final-package field validation runs
+- **THEN** every deduplicated selected header/footer target SHALL start with fresh field state
+- **AND** every direct footnote/endnote entry, including reserved entries, SHALL start with fresh field state
+- **AND** field markers in one story SHALL NOT balance markers in another
+
+#### Scenario: [SDX-ANC-STORY-04] Invalid selected bindings fail and unreferenced malformed parts do not
+
+- **WHEN** a section binding violates placement, role, uniqueness, relationship-ID, relationship-type, target-safety, part-presence, XML, or expected-root requirements
+- **THEN** the assembled candidate SHALL fail with a structured binding-resolution issue
+- **AND** a malformed header/footer part with no valid selecting section binding SHALL not be parsed, trigger failure, or receive passing evidence
+
+### Requirement: Strict ancillary field validation is separate from the Lean-pinned predicate
+
+The system SHALL provide a strict ancillary field-story predicate without
+changing the Lean-pinned `validateFieldStructure` predicate. The strict
+predicate MAY reuse existing field issues and SHALL additionally reject a stray
+end marker, a `separate` marker at depth zero, a duplicate separator at the same
+open-field depth, a missing or unknown `w:fldCharType`, and unclosed field depth
+at story end. Separator state SHALL be tracked independently at each nested
+depth. A depth-zero separator SHALL report the distinct issue code
+`FIELD_STRAY_SEPARATOR`.
+
+A properly stacked nested field SHALL pass strict structural validation. A
+begin/end-only field SHALL pass because a separator is optional for this
+predicate. The Lean predicate, differential harness, checker protocol, and
+certificate semantics SHALL remain unchanged.
+
+#### Scenario: [SDX-ANC-STRICT-01] Strict-only malformed shapes are rejected
+
+- **WHEN** one ancillary story contains a stray end, stray depth-zero separator, duplicate same-depth separator, unknown or missing `fldCharType`, or unclosed field depth
+- **THEN** the strict predicate SHALL return a stable issue code and story locator for that defect
+- **AND** a depth-zero separator SHALL report `FIELD_STRAY_SEPARATOR`
+- **AND** tests SHALL explicitly record any case intentionally tolerated by `validateFieldStructure`
+
+#### Scenario: [SDX-ANC-STRICT-02] Valid optional separators and nested stacks pass
+
+- **GIVEN** one begin/end-only field and one properly stacked nested field with separator state isolated per depth
+- **WHEN** strict ancillary validation runs
+- **THEN** both stories SHALL pass
+- **AND** nested markers SHALL close in last-opened-first-closed order
+
+#### Scenario: [SDX-ANC-STRICT-03] Lean behavior does not change
+
+- **WHEN** the strict ancillary predicate is introduced
+- **THEN** `validateFieldStructure` and its Lean differential expectations SHALL remain unchanged
+- **AND** executable checker protocol v3 and the existing certificate SHALL remain unchanged
+
+### Requirement: Ancillary field preservation evidence is source-first and provenance-aware
+
+Before provenance mapping or evidence inventory, the system SHALL validate
+each final note part and its base contributor. It SHALL validate a
+post-collision merge-source note part only when merge results show that it
+supplied imported definitions or a newly created final part. An unused
+merge-source defect SHALL not reject. Direct `w:footnote/@w:id` and
+`w:endnote/@w:id` values SHALL be canonicalized as `xsd:integer` values before
+duplicate detection and mapping. Invalid lexical forms SHALL fail with
+`INVALID_NOTE_ENTRY_ID`; numerically equivalent values such as `1`, `01`, and
+`+1` SHALL fail with `DUPLICATE_NOTE_ENTRY_ID`, source side when applicable,
+normalized part path, and canonical duplicated ID rather than an invented
+entry ordinal. Valid negative reserved IDs SHALL remain valid. This is an
+evidence-safety policy for unambiguous locators and SHALL NOT imply complete
+note integrity.
+
+The system SHALL inventory eligible source fields before inspecting the final
+package. Eligible fields are complete, non-nested, self-contained within one
+paragraph, and accepted by the same supported instruction parser as PR #617.
+Selected header/footer inventories SHALL include PAGE and NUMPAGES; note-entry
+inventories SHALL include REF and PAGEREF.
+
+Source fields SHALL be enumerated in deterministic depth-first order and
+located by normalized part path, canonical note entry ID when applicable,
+paragraph ordinal within the story or entry, and eligible-field ordinal within
+that paragraph. Instruction kind SHALL remain reported but SHALL not be part of
+structural locator identity. The final package SHALL be independently
+inventoried by the same algorithm. Missing, extra, relocated, reclassified, or
+canonically mismatched ranges SHALL fail. Reordering is represented by the
+structural ordinals rather than a separate order diagnostic. Repeated identical
+fields SHALL be distinguished by locator rather than hash.
+
+Each eligible range SHALL use the extracted PR #617 expanded-name canonical
+subtree algorithm. Namespace declaration spelling/order and ordinary attribute
+order SHALL be ignored; expanded names, attribute values, text, child order,
+run boundaries, wrappers, and represented subtree structure SHALL be retained.
+Nested and cross-paragraph fields SHALL be excluded from exact-preservation
+inventory but SHALL remain subject to whole-story strict validation.
+
+#### Scenario: [SDX-ANC-EVIDENCE-01] Selected header and footer source inventories match exactly
+
+- **GIVEN** eligible PAGE and NUMPAGES fields in source parts selected by valid final section bindings
+- **WHEN** forced rebuild or true inplace output is assembled
+- **THEN** each source locator SHALL have exactly one corresponding final locator
+- **AND** every corresponding complete canonical begin-through-end range SHALL match
+- **AND** missing, extra, relocated, reclassified, or mismatched ranges SHALL fail with reachable distinct diagnostics
+
+#### Scenario: [SDX-ANC-EVIDENCE-02] Duplicate direct note IDs are rejected before mapping
+
+- **GIVEN** a base/final contributor or actually contributing post-collision merge source with invalid or numerically equivalent direct note IDs
+- **WHEN** ancillary provenance and evidence preparation begins
+- **THEN** invalid lexical IDs SHALL fail with `INVALID_NOTE_ENTRY_ID`
+- **AND** numeric-equivalent duplicates SHALL fail with `DUPLICATE_NOTE_ENTRY_ID`, normalized part path, and canonical duplicated ID
+- **AND** no entry ordinal SHALL be invented to disambiguate the duplicate
+- **AND** the failure SHALL remain an evidence-safety policy rather than a complete note-integrity claim
+
+#### Scenario: [SDX-ANC-EVIDENCE-06] Unused merge-source defects do not poison evidence
+
+- **GIVEN** the final package and base contributor contain valid note entries and the opposite merge-source note part is malformed or has duplicate IDs
+- **WHEN** merge results show that the opposite note part supplied no imported definitions and did not create the final part
+- **THEN** ancillary evidence SHALL not parse or reject that unused merge-source part
+
+#### Scenario: [SDX-ANC-EVIDENCE-03] Note evidence follows actual assembly provenance
+
+- **GIVEN** eligible REF or PAGEREF fields in base-resident and imported note definitions
+- **WHEN** auxiliary definitions are merged and final evidence is collected
+- **THEN** existing base IDs SHALL use base provenance and imported IDs SHALL use merge-source provenance
+- **AND** the source and final locator inventories and canonical ranges SHALL match exactly
+
+#### Scenario: [SDX-ANC-EVIDENCE-04] Created parts and collision outcomes have defined provenance
+
+- **GIVEN** a newly created note part, copied reserved entries, same-ID identical definitions, or content-different IDs renumbered before assembly
+- **WHEN** provenance is recorded
+- **THEN** copied reserved and imported entries in a created part SHALL identify the merge source
+- **AND** a same-ID identical definition SHALL identify the base because the base entry wins
+- **AND** a renumbered definition SHALL identify its post-collision source archive and rewritten entry ID
+
+#### Scenario: [SDX-ANC-EVIDENCE-05] Repeated and excluded ranges are not confused
+
+- **GIVEN** repeated canonically identical eligible fields plus nested or cross-paragraph fields
+- **WHEN** source and final inventories are compared
+- **THEN** repeated eligible fields SHALL remain distinct by structural locator
+- **AND** nested and cross-paragraph ranges SHALL produce no exact-preservation evidence
+- **AND** the containing stories SHALL still require strict validation
+
+### Requirement: Ancillary safety failures rebuild once or throw before publication
+
+The system SHALL classify post-assembly ancillary failures as
+`binding_resolution`, `strict_field_structure`, or `canonical_evidence`.
+Diagnostics SHALL include a stable issue code, detail, and structured story
+locator. Field-evidence locators SHALL additionally identify paragraph ordinal,
+eligible-field ordinal, and instruction kind.
+
+Binding locators SHALL identify section ordinal, kind, role, and normalized
+part path when available. Deduplicated header/footer story locators SHALL
+identify their normalized path and all selecting bindings. Note-story locators
+SHALL identify normalized part path and entry ID. Binding issue codes SHALL
+reuse applicable section-audit codes; strict-only and evidence issue codes SHALL
+distinguish the exact structural or inventory failure. The typed error SHALL
+expose a non-empty ordered issue array without requiring callers to parse
+messages.
+
+Any ancillary failure SHALL reject an inplace candidate and trigger exactly one
+rebuild assembly. Selection, strict validation, provenance, and evidence SHALL
+be recomputed against the rebuilt package. Any ancillary failure on
+forced/direct rebuild or on the terminal rebuilt fallback SHALL throw
+`AncillaryStorySafetyError` before returning or publishing a document. A failed
+call SHALL return neither a successful `CompareResult` nor public preservation
+evidence.
+
+`ReconstructionFallbackReason` SHALL add
+`ancillary_story_safety_check_failed`. A successful rebuild caused by ancillary
+inplace rejection SHALL use that reason and SHALL return optional
+`ancillaryFallbackDiagnostics` containing the rejected candidate's ordered
+structured ancillary issues. Those diagnostics SHALL NOT substitute for final
+evidence.
+
+#### Scenario: [SDX-ANC-FAIL-01] Ancillary failure itself triggers inplace fallback
+
+- **GIVEN** an otherwise safe inplace candidate whose assembled ancillary package fails binding resolution, strict field validation, or canonical evidence
+- **WHEN** comparison evaluates the candidate
+- **THEN** that ancillary failure SHALL reject the inplace candidate and trigger one rebuilt assembly
+- **AND** no preexisting main-story failure SHALL be required to cause fallback
+
+#### Scenario: [SDX-ANC-FAIL-02] Successful fallback recomputes all ancillary evidence
+
+- **GIVEN** ancillary failure rejects a revised-based inplace candidate and the original-based rebuild is valid
+- **WHEN** the rebuilt package passes
+- **THEN** comparison SHALL return the rebuilt document
+- **AND** `fallbackReason` SHALL be `ancillary_story_safety_check_failed`
+- **AND** `ancillaryFallbackDiagnostics` SHALL contain the rejected inplace candidate's structured issues
+- **AND** selection, validation, provenance, and evidence SHALL describe only the rebuilt package
+- **AND** no stale candidate evidence SHALL be returned
+
+#### Scenario: [SDX-ANC-FAIL-03] Terminal ancillary failure throws a typed error
+
+- **WHEN** direct/forced rebuild or the terminal rebuild fallback has any ancillary failure
+- **THEN** comparison SHALL throw `AncillaryStorySafetyError` before returning or publishing document bytes
+- **AND** the error SHALL expose a non-empty ordered array of structured category, locator, issue-code, and detail diagnostics
+- **AND** no warning-only successful result or public evidence SHALL be returned
+
+### Requirement: Successful ancillary evidence is an additive public result
+
+`CompareResult` SHALL add the optional field
+`ancillaryFieldEvidence?: AncillaryFieldEvidence`. A present value SHALL have
+`status: "passed"`, the final `reconstructionMode`, selected binding and story
+summaries, and range items. Each range item SHALL contain its stable locator,
+instruction kind, source side (`original` or `revised`), provenance (`base` or
+`imported`), and `canonicalMatch: true`.
+
+The evidence reconstruction mode SHALL equal `reconstructionModeUsed`.
+Successful fallback evidence SHALL be recomputed from the final rebuild and
+SHALL identify `rebuild`. A terminal failure SHALL throw and return no
+`CompareResult`; there SHALL be no failed evidence value. The new evidence,
+fallback diagnostics, and fallback-reason member SHALL be additive and
+compatible with prior consumers. Absence of either optional evidence or
+diagnostics SHALL mean unavailable, not passing.
+
+The field SHALL remain optional at the type level for compatibility. An
+atomizer comparison that reaches and passes the ancillary gate SHALL populate
+it. Selected binding summaries SHALL contain section ordinal, kind, role,
+relationship ID, and normalized target. Story summaries SHALL contain story
+kind, normalized path, strict-pass status, and selecting bindings or note entry
+ID/source provenance as applicable.
+
+#### Scenario: [SDX-ANC-RESULT-01] Successful true inplace evidence identifies the final package
+
+- **WHEN** a true inplace package passes all ancillary checks
+- **THEN** `ancillaryFieldEvidence.status` SHALL be `passed`
+- **AND** its reconstruction mode SHALL be `inplace`
+- **AND** its binding/story summaries and range items SHALL describe the returned package
+
+#### Scenario: [SDX-ANC-RESULT-02] Range items expose stable successful evidence
+
+- **WHEN** an eligible ancillary field range passes exact comparison
+- **THEN** its public item SHALL contain the stable locator, instruction kind, source side, base/imported provenance, and `canonicalMatch: true`
+- **AND** no hash alone SHALL serve as field identity
+
+#### Scenario: [SDX-ANC-RESULT-03] Optional fields preserve compatibility
+
+- **WHEN** a prior consumer reads a result without ancillary evidence or fallback diagnostics
+- **THEN** existing result fields SHALL retain their meanings
+- **AND** absence SHALL be interpreted as unavailable evidence rather than a pass
+
+### Requirement: Real-source-derived and Lean boundaries remain explicit
+
+The NVCA COI regression SHALL load the checked-in
+`tests/test_documents/nvca-coi-regression/source.docx` as the real package
+substrate and derive a revised copy by applying exported
+`replaceParagraphTextRange` to a minimal body-text range unrelated to the
+ancillary fields under test. The source-derived pair SHALL run once with true
+inplace selected and once with forced rebuild. Both successful results SHALL
+contain nonzero selected-footer PAGE evidence and nonzero footnote REF evidence,
+with concrete part/entry provenance and exact canonical matches. This
+requirement makes no PAGE-field claim about the checked-in `filled.docx`.
+
+This capability SHALL NOT synthesize ancillary revisions, compare ancillary
+text, evaluate fields, paginate content, resolve bookmarks, or claim complete
+note-definition/reference or relationship integrity. The compiled Lean checker
+SHALL remain executable protocol v3, inplace-only, and fixed to
+`word/document.xml`, `word/footnotes.xml`, and `word/endnotes.xml`. Headers and
+footers SHALL remain excluded. Dynamically relationship-addressed Lean stories
+SHALL remain the next separate verification slice.
+
+#### Scenario: [SDX-ANC-BOUNDARY-01] NVCA COI source-derived pair supplies non-vacuous evidence in both modes
+
+- **GIVEN** the checked-in NVCA COI `source.docx` and a revised copy created from it by one minimal unrelated body edit through exported `replaceParagraphTextRange`
+- **WHEN** the real source-derived pair is compared once with true inplace and once with forced rebuild
+- **THEN** each run's successful evidence SHALL include at least one selected-footer PAGE range with concrete part provenance and an exact canonical match
+- **AND** each run's successful evidence SHALL include at least one footnote REF range with concrete part, entry-ID, source side, and base/imported provenance and an exact canonical match
+- **AND** the inplace run SHALL report `inplace` and the forced run SHALL report `rebuild` in both reconstruction result and ancillary evidence
+
+#### Scenario: [SDX-ANC-BOUNDARY-02] Runtime evidence remains structural and preservation-only
+
+- **WHEN** ancillary field evidence passes
+- **THEN** the result SHALL claim only selected valid binding structure, strict story field structure, provenance, and exact eligible-range preservation
+- **AND** it SHALL NOT claim ancillary text equivalence, field values, pagination, bookmark resolution, or complete note integrity
+
+#### Scenario: [SDX-ANC-BOUNDARY-03] Lean protocol and scope remain unchanged
+
+- **WHEN** document-integrity evidence is requested for comparison
+- **THEN** the compiled checker SHALL still speak protocol v3 and run only for inplace output
+- **AND** its fixed story scope SHALL remain main, footnotes, and endnotes
+- **AND** headers and footers SHALL remain explicit certificate exclusions

--- a/openspec/changes/verify-ancillary-field-stories/specs/spec-compliance/spec.md
+++ b/openspec/changes/verify-ancillary-field-stories/specs/spec-compliance/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: Ancillary field evidence separates ECMA structure from SafeDocX safety policy
+
+The ECMA-376 registry SHALL bind ancillary implementation claims only to
+edition 5 Part 1 §§17.10.2 and 17.10.5 for registered typed footer/header
+bindings, §§17.10.3 and 17.10.4 for footer/header story roots, §17.16.18 for
+complex-field structure, and §§17.16.5.42, 17.16.5.44, 17.16.5.45, and
+17.16.5.51 for the bounded NUMPAGES, PAGE, PAGEREF, and REF instruction
+vocabulary.
+
+Target normalization, package containment, note-entry isolation, duplicate
+direct note-ID rejection, assembly provenance, and exact canonical range
+preservation SHALL be labeled as SafeDocX safety policies or metamorphic
+invariants rather than ECMA-376 requirements. This change SHALL add no
+unsupported Part 2 or note clause.
+Section 17.11.14 SHALL be cited only where implementation or tests actually use
+`w:footnoteReference/@w:id` as a reference identifier; independent note-entry
+validation and REF/PAGEREF preservation SHALL NOT establish that claim.
+
+#### Scenario: [SDX-ANC-CONFORMANCE-01] Binding, root, and field citations match exercised structure
+
+- **WHEN** source and tests claim typed section bindings, expected header/footer roots, complex-field structure, or supported instruction classification
+- **THEN** their single-line conformance tags SHALL cite only the corresponding registered Part 1 clauses
+- **AND** target normalization, package containment, note-entry isolation, and duplicate direct note-ID rejection SHALL not be presented as consequences of those clauses
+
+#### Scenario: [SDX-ANC-CONFORMANCE-02] Exact range and provenance evidence remain repository invariants
+
+- **WHEN** tests compare a source ancillary field inventory with the final assembled package
+- **THEN** they SHALL describe source provenance and canonical whole-range equality as SafeDocX evidence
+- **AND** they SHALL NOT attribute exact preservation, field evaluation, pagination, cached-result correctness, bookmark resolution, or note-entry provenance to ECMA-376
+
+#### Scenario: [SDX-ANC-CONFORMANCE-03] Note citations remain bounded
+
+- **WHEN** independent note-entry validation or note-field preservation tests run
+- **THEN** they SHALL add no unsupported Part 2 or note citation
+- **AND** duplicate direct note-ID rejection SHALL be described only as a SafeDocX evidence-safety policy
+- **AND** §17.11.14 SHALL appear only on a test that actually distinguishes a footnote reference ID from a display number
+- **AND** no evidence SHALL claim complete note-definition/reference or relationship integrity
+
+#### Scenario: [SDX-ANC-CONFORMANCE-04] Registry non-goals preserve the Lean boundary
+
+- **WHEN** the registry documents runtime ancillary comparison evidence
+- **THEN** it SHALL state that the strict runtime predicate and relationship-selected stories do not broaden the Lean checker
+- **AND** executable protocol v3 SHALL remain inplace-only with fixed main/footnotes/endnotes scope and headers/footers excluded
+- **AND** dynamic relationship-addressed Lean stories SHALL be named as a separate successor slice

--- a/openspec/changes/verify-ancillary-field-stories/tasks.md
+++ b/openspec/changes/verify-ancillary-field-stories/tasks.md
@@ -1,0 +1,54 @@
+## 1. Specification and conformance
+
+- [x] 1.1 Update the ECMA-376 registry and non-goals with only the registered header/footer binding/root and field structure/instruction claims.
+- [x] 1.2 Label target normalization, package containment, note-entry isolation, duplicate direct note-ID rejection, provenance, and exact canonical preservation as SafeDocX policies or invariants.
+- [x] 1.3 Add source JSDoc and structured test citations only where the implementation exercises the cited clause; use §17.11.14 only for actual reference-ID semantics.
+- [x] 1.4 Keep the Lean predicate, executable protocol v3, inplace-only mode, and fixed main/footnotes/endnotes scope unchanged.
+
+## 2. Binding selection and strict stories
+
+- [x] 2.1 Reuse `sectPrAudit` binding resolution and a shared robust OPC target normalizer for direct section-property bindings, valid roles, per-section role uniqueness, unambiguous relationship IDs, exact relationship types, exact target modes, safe internal targets, and expected roots.
+- [x] 2.2 Return binding locators with section ordinal, kind, and role; deduplicate target validation by normalized path while retaining every selecting binding.
+- [x] 2.3 Add a strict ancillary field-story predicate separate from `validateFieldStructure`.
+- [x] 2.4 Reject stray end, stray depth-zero separator, duplicate same-depth separator, unknown/missing `fldCharType`, and unclosed depth while accepting begin/end-only and properly stacked nested fields.
+- [x] 2.5 Extract every final footnote/endnote entry, including reserved entries, as an independent strict story.
+- [x] 2.6 Canonicalize note IDs as `xsd:integer`; reject invalid lexical IDs and numeric-equivalent duplicate direct IDs in base/final contributors and only actually contributing merge-source parts before provenance or evidence mapping.
+- [x] 2.7 Ensure unreferenced header/footer files are never globbed or admitted to the selected story set.
+
+## 3. Provenance and preservation inventory
+
+- [x] 3.1 Capture entry provenance from the post-collision in-memory base and merge-source archives used by assembly.
+- [x] 3.2 Record base wins, imported IDs, newly created note-part entries, copied reserved entries, same-ID identical definitions, and collision-renumbered IDs deterministically.
+- [x] 3.3 Extract and reuse PR #617 supported-instruction parsing and expanded-name canonical subtree logic.
+- [x] 3.4 Enumerate eligible source fields first in depth-first order with part, entry, paragraph, eligible-field, and instruction locators.
+- [x] 3.5 Compare independent final inventories by structural locator excluding instruction kind and by canonical range; reject missing, extra, relocated, reclassified, or mismatched ranges with reachable diagnostics.
+- [x] 3.6 Exclude nested and cross-paragraph ranges from preservation inventory while retaining whole-story strict validation.
+
+## 4. Failure contract
+
+- [x] 4.1 Add `AncillaryStorySafetyError` with binding-resolution, strict-field-structure, and canonical-evidence categories plus structured locators, issue codes, and details.
+- [x] 4.2 Run the ancillary gate after complete mode-specific assembly and reject a failing inplace candidate.
+- [x] 4.3 Attempt exactly one rebuilt assembly after ancillary inplace rejection and recompute selection, validation, provenance, and evidence.
+- [x] 4.4 Throw before returning or publishing output when direct/forced rebuild or terminal fallback fails; never return warning-only success or public evidence on failure.
+- [x] 4.5 Leave ancillary revision synthesis, text comparison, field evaluation, pagination, bookmark resolution, and complete note integrity unchanged.
+- [x] 4.6 Add optional passed-only `CompareResult.ancillaryFieldEvidence` with final mode, binding/story summaries, and provenance-bearing canonical range items.
+- [x] 4.7 Extend fallback reason with `ancillary_story_safety_check_failed` and add optional rejected-candidate `ancillaryFallbackDiagnostics`.
+
+## 5. Evidence coverage
+
+- [x] 5.1 Extend shared OOXML/DOCX fixtures for valid section bindings, malformed unreferenced parts, independent note entries, created parts, imports, identical IDs, and collision renumbering.
+- [x] 5.2 Add strict-predicate tests that pin its differences from Lean-pinned `validateFieldStructure`, including stray depth-zero separator rejection and valid begin/end-only and nested fields.
+- [x] 5.3 Add forced-rebuild and true-inplace tests for source-first inventories and exact canonical evidence.
+- [x] 5.4 Add a test where ancillary failure itself rejects inplace, one rebuilt assembly succeeds, and stale candidate evidence is discarded.
+- [x] 5.5 Add terminal direct-rebuild and fallback error tests for all failure categories and structured diagnostics.
+- [x] 5.6 Add adversarial binding target/mode/placement, reachable inventory-code, repeated-field, nested/cross-paragraph exclusion, and unreferenced-malformed-part tests.
+- [x] 5.7 Cover invalid and numeric-equivalent note IDs, unused malformed merge-source parts, base wins, imported definitions, new-part reserved provenance, same-ID identical definitions, and post-collision renumbered IDs.
+- [x] 5.8 Preserve the existing NVCA source-vs-filled large-diff regression, then derive a minimally edited revised copy from `nvca-coi-regression/source.docx` with exported `replaceParagraphTextRange`; require true inplace and forced rebuild runs with nonzero selected-footer PAGE and footnote REF evidence.
+- [x] 5.9 Assert successful evidence reports final mode, fallback diagnostics retain only rejected-candidate issues, and terminal errors return no result.
+- [x] 5.10 Assert Lean remains protocol v3, inplace-only, fixed to main/footnotes/endnotes, with headers/footers excluded.
+
+## 6. Verification
+
+- [x] 6.1 Run focused comparison, package-assembly, conformance, and NVCA COI tests.
+- [x] 6.2 Run build, workspace lint, strict OpenSpec validation, spec coverage, and conformance checks.
+- [x] 6.3 Run the mandatory repository pre-submit suite and review the final diff.

--- a/packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.test.ts
@@ -18,6 +18,7 @@ import {
   type AncillaryNoteMergeResult,
 } from './ancillaryFieldSafety.js';
 
+const TEST_FEATURE = 'verify-ancillary-field-stories';
 const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const R_NS = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
 const PR_NS = 'http://schemas.openxmlformats.org/package/2006/relationships';

--- a/packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.test.ts
@@ -25,7 +25,7 @@ const PR_NS = 'http://schemas.openxmlformats.org/package/2006/relationships';
 
 const test = testAllure
   .epic('Document Comparison')
-  .withLabels({ feature: 'Ancillary Canonical Evidence' });
+  .withLabels({ feature: TEST_FEATURE });
 
 interface ArchiveOptions {
   footer?: string;

--- a/packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.test.ts
@@ -1,0 +1,632 @@
+import { describe, expect } from 'vitest';
+import { DocxArchive } from '@usejunior/docx-core';
+import {
+  COMPLETE_NUMPAGES_FIELD,
+  COMPLETE_PAGE_FIELD,
+  COMPLETE_REF_FIELD,
+  buildDocxFromBodyXml,
+  completeField,
+  fldChar,
+  instrText,
+  paragraphWithText,
+  resultText,
+} from '../../testing/ooxml-fixtures.js';
+import { testAllure } from '../../testing/allure-test.js';
+import {
+  AncillaryStorySafetyError,
+  evaluateAncillaryFieldSafety,
+  type AncillaryNoteMergeResult,
+} from './ancillaryFieldSafety.js';
+
+const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const R_NS = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const PR_NS = 'http://schemas.openxmlformats.org/package/2006/relationships';
+
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({ feature: 'Ancillary Canonical Evidence' });
+
+interface ArchiveOptions {
+  footer?: string;
+  footnotes?: string;
+}
+
+async function archiveWith(options: ArchiveOptions): Promise<DocxArchive> {
+  const archive = await DocxArchive.load(
+    await buildDocxFromBodyXml(paragraphWithText('Body')),
+  );
+  const footerReference = options.footer
+    ? '<w:footerReference w:type="default" r:id="rIdFooter"/>'
+    : '';
+  archive.setDocumentXml(
+    `<w:document xmlns:w="${W_NS}" xmlns:r="${R_NS}">` +
+      `<w:body>${paragraphWithText('Body')}<w:sectPr>${footerReference}</w:sectPr></w:body>` +
+      `</w:document>`,
+  );
+  archive.setFile(
+    'word/_rels/document.xml.rels',
+    `<Relationships xmlns="${PR_NS}">` +
+      (options.footer
+        ? `<Relationship Id="rIdFooter" Type="${R_NS}/footer" Target="footer1.xml"/>`
+        : '') +
+      `</Relationships>`,
+  );
+  if (options.footer) archive.setFile('word/footer1.xml', options.footer);
+  if (options.footnotes) archive.setFile('word/footnotes.xml', options.footnotes);
+  return archive;
+}
+
+function footer(fieldXml: string, prefix = 'w'): string {
+  return `<${prefix}:ftr xmlns:${prefix}="${W_NS}"><${prefix}:p>${fieldXml}</${prefix}:p></${prefix}:ftr>`;
+}
+
+function footnotes(entries: readonly { id: string; type?: string; content: string }[]): string {
+  return (
+    `<w:footnotes xmlns:w="${W_NS}">` +
+    entries.map(({ id, type, content }) =>
+      `<w:footnote w:id="${id}"${type ? ` w:type="${type}"` : ''}>` +
+        `<w:p>${content}</w:p></w:footnote>`,
+    ).join('') +
+    `</w:footnotes>`
+  );
+}
+
+function noteMergeResults(
+  footnote?: AncillaryNoteMergeResult,
+): ReadonlyMap<'footnote' | 'endnote', AncillaryNoteMergeResult> {
+  return new Map(footnote ? [['footnote', footnote]] : []);
+}
+
+describe('source-first ancillary canonical inventories', () => {
+  test.openspec('[SDX-ANC-EVIDENCE-01] Selected header and footer source inventories match exactly')(
+    '[SDX-ANC-EVIDENCE-01] changed canonical range fails closed at its stable locator',
+    async () => {
+      const base = await archiveWith({
+        footer: footer(COMPLETE_PAGE_FIELD + COMPLETE_PAGE_FIELD),
+      });
+      const result = await archiveWith({
+        footer: footer(completeField(' PAGE ', '9') + COMPLETE_PAGE_FIELD),
+      });
+      const mergeSource = await archiveWith({});
+
+      await expect(evaluateAncillaryFieldSafety({
+        resultArchive: result,
+        baseArchive: base,
+        mergeSourceArchive: mergeSource,
+        reconstructionMode: 'rebuild',
+        baseSide: 'original',
+        mergeSourceSide: 'revised',
+        noteMergeResults: noteMergeResults(),
+      })).rejects.toMatchObject({
+        name: 'AncillaryStorySafetyError',
+        issues: [{
+          category: 'canonical_evidence',
+          code: 'FIELD_RANGE_CANONICAL_MISMATCH',
+          locator: {
+            locatorType: 'field_range',
+            normalizedPartPath: 'word/footer1.xml',
+            paragraphOrdinal: 0,
+            eligibleFieldOrdinal: 0,
+            instructionKind: 'PAGE',
+          },
+        }],
+      });
+    },
+  );
+
+  test.openspec('[SDX-ANC-EVIDENCE-05] Repeated and excluded ranges are not confused')(
+    '[SDX-ANC-EVIDENCE-02] repeated fields use ordinals while nested and cross-paragraph ranges are excluded',
+    async () => {
+      testAllure.conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.16.18' });
+      const nested =
+        fldChar('begin') +
+        instrText(' PAGE ') +
+        fldChar('begin') +
+        instrText(' NUMPAGES ') +
+        fldChar('end') +
+        fldChar('end');
+      const crossParagraph =
+        `<w:p>${fldChar('begin')}${instrText(' PAGE ')}</w:p>` +
+        `<w:p>${resultText('1')}${fldChar('end')}</w:p>`;
+      const repeated = `<w:p>${COMPLETE_PAGE_FIELD}${COMPLETE_PAGE_FIELD}</w:p>`;
+      const sourceFooter =
+        `<w:ftr xmlns:w="${W_NS}"><w:p>${nested}</w:p>${crossParagraph}${repeated}</w:ftr>`;
+      const finalFooter = sourceFooter
+        .replaceAll('w:', 'alt:')
+        .replace('xmlns:w=', 'xmlns:alt=');
+      const base = await archiveWith({ footer: sourceFooter });
+      const result = await archiveWith({ footer: finalFooter });
+      const mergeSource = await archiveWith({});
+
+      const evidence = await evaluateAncillaryFieldSafety({
+        resultArchive: result,
+        baseArchive: base,
+        mergeSourceArchive: mergeSource,
+        reconstructionMode: 'inplace',
+        baseSide: 'revised',
+        mergeSourceSide: 'original',
+        noteMergeResults: noteMergeResults(),
+      });
+
+      expect(evidence.ranges).toEqual([
+        expect.objectContaining({
+          instructionKind: 'PAGE',
+          locator: expect.objectContaining({
+            paragraphOrdinal: 3,
+            eligibleFieldOrdinal: 0,
+          }),
+        }),
+        expect.objectContaining({
+          instructionKind: 'PAGE',
+          locator: expect.objectContaining({
+            paragraphOrdinal: 3,
+            eligibleFieldOrdinal: 1,
+          }),
+        }),
+      ]);
+    },
+  );
+
+  test.openspec('[SDX-ANC-EVIDENCE-04] Created parts and collision outcomes have defined provenance')(
+    '[SDX-ANC-EVIDENCE-03] created note parts assign imported provenance to reserved and user entries',
+    async () => {
+      const sourceNotes = footnotes([
+        { id: '-1', type: 'separator', content: '<w:r><w:separator/></w:r>' },
+        { id: '-2', type: 'continuationSeparator', content: '<w:r><w:continuationSeparator/></w:r>' },
+        { id: '5', content: COMPLETE_REF_FIELD },
+      ]);
+      const base = await archiveWith({});
+      const mergeSource = await archiveWith({ footnotes: sourceNotes });
+      const result = await archiveWith({ footnotes: sourceNotes });
+
+      const evidence = await evaluateAncillaryFieldSafety({
+        resultArchive: result,
+        baseArchive: base,
+        mergeSourceArchive: mergeSource,
+        reconstructionMode: 'rebuild',
+        baseSide: 'original',
+        mergeSourceSide: 'revised',
+        noteMergeResults: noteMergeResults({
+          mergedIds: new Set(['5']),
+          createdPart: true,
+        }),
+      });
+
+      expect(evidence.stories.filter((story) => story.storyKind === 'footnote')).toEqual([
+        expect.objectContaining({ entryId: '-1', provenance: 'imported' }),
+        expect.objectContaining({ entryId: '-2', provenance: 'imported' }),
+        expect.objectContaining({ entryId: '5', provenance: 'imported' }),
+      ]);
+      expect(evidence.ranges).toEqual([
+        expect.objectContaining({
+          instructionKind: 'REF',
+          sourceSide: 'revised',
+          provenance: 'imported',
+          locator: expect.objectContaining({ entryId: '5' }),
+        }),
+      ]);
+    },
+  );
+
+  test.openspec('[SDX-ANC-EVIDENCE-01] Selected header and footer source inventories match exactly')(
+    '[SDX-ANC-EVIDENCE-04] instruction changes produce a reachable kind diagnostic',
+    async () => {
+      const base = await archiveWith({ footer: footer(COMPLETE_PAGE_FIELD) });
+      const result = await archiveWith({ footer: footer(COMPLETE_NUMPAGES_FIELD) });
+      const mergeSource = await archiveWith({});
+
+      const rejection = evaluateAncillaryFieldSafety({
+        resultArchive: result,
+        baseArchive: base,
+        mergeSourceArchive: mergeSource,
+        reconstructionMode: 'rebuild',
+        baseSide: 'original',
+        mergeSourceSide: 'revised',
+        noteMergeResults: noteMergeResults(),
+      });
+      await expect(rejection).rejects.toBeInstanceOf(AncillaryStorySafetyError);
+      await expect(rejection).rejects.toMatchObject({
+        issues: expect.arrayContaining([
+          expect.objectContaining({
+            code: 'FIELD_RANGE_KIND_MISMATCH',
+            locator: expect.objectContaining({
+              paragraphOrdinal: 0,
+              eligibleFieldOrdinal: 0,
+              instructionKind: 'PAGE',
+            }),
+          }),
+        ]),
+      });
+    },
+  );
+
+  test.openspec('[SDX-ANC-EVIDENCE-01] Selected header and footer source inventories match exactly')(
+    '[SDX-ANC-EVIDENCE-05] structurally missing and extra ranges retain distinct diagnostics',
+    async () => {
+      const base = await archiveWith({
+        footer: `<w:ftr xmlns:w="${W_NS}"><w:p>${COMPLETE_PAGE_FIELD}</w:p>` +
+          `<w:p>${COMPLETE_NUMPAGES_FIELD}</w:p></w:ftr>`,
+      });
+      const result = await archiveWith({
+        footer: `<w:ftr xmlns:w="${W_NS}"><w:p>${COMPLETE_PAGE_FIELD}</w:p>` +
+          `<w:p>${COMPLETE_REF_FIELD}</w:p><w:p>${COMPLETE_NUMPAGES_FIELD}</w:p></w:ftr>`,
+      });
+      const mergeSource = await archiveWith({});
+
+      await expect(evaluateAncillaryFieldSafety({
+        resultArchive: result,
+        baseArchive: base,
+        mergeSourceArchive: mergeSource,
+        reconstructionMode: 'rebuild',
+        baseSide: 'original',
+        mergeSourceSide: 'revised',
+        noteMergeResults: noteMergeResults(),
+      })).rejects.toMatchObject({
+        issues: expect.arrayContaining([
+          expect.objectContaining({ code: 'FIELD_RANGE_MISSING' }),
+          expect.objectContaining({ code: 'FIELD_RANGE_EXTRA' }),
+        ]),
+      });
+    },
+  );
+
+  test.openspec('[SDX-ANC-EVIDENCE-02] Duplicate direct note IDs are rejected before mapping')(
+    '[SDX-ANC-EVIDENCE-06] numeric-equivalent note IDs reject with a canonical locator',
+    async () => {
+      const equivalentIds = footnotes([
+        { id: '1', content: COMPLETE_REF_FIELD },
+        { id: '01', content: COMPLETE_REF_FIELD },
+        { id: '+1', content: COMPLETE_REF_FIELD },
+      ]);
+      const base = await archiveWith({ footnotes: equivalentIds });
+      const result = await archiveWith({ footnotes: equivalentIds });
+      const mergeSource = await archiveWith({});
+
+      await expect(evaluateAncillaryFieldSafety({
+        resultArchive: result,
+        baseArchive: base,
+        mergeSourceArchive: mergeSource,
+        reconstructionMode: 'rebuild',
+        baseSide: 'original',
+        mergeSourceSide: 'revised',
+        noteMergeResults: noteMergeResults(),
+      })).rejects.toMatchObject({
+        issues: expect.arrayContaining([
+          expect.objectContaining({
+            code: 'DUPLICATE_NOTE_ENTRY_ID',
+            locator: expect.objectContaining({ entryId: '1' }),
+          }),
+        ]),
+      });
+    },
+  );
+
+  test.openspec('[SDX-ANC-EVIDENCE-02] Duplicate direct note IDs are rejected before mapping')(
+    '[SDX-ANC-EVIDENCE-07] invalid note ID lexical forms reject explicitly',
+    async () => {
+      const invalidIds = footnotes([{ id: '1.0', content: COMPLETE_REF_FIELD }]);
+      const base = await archiveWith({ footnotes: invalidIds });
+      const result = await archiveWith({ footnotes: invalidIds });
+      const mergeSource = await archiveWith({});
+
+      await expect(evaluateAncillaryFieldSafety({
+        resultArchive: result,
+        baseArchive: base,
+        mergeSourceArchive: mergeSource,
+        reconstructionMode: 'rebuild',
+        baseSide: 'original',
+        mergeSourceSide: 'revised',
+        noteMergeResults: noteMergeResults(),
+      })).rejects.toMatchObject({
+        issues: expect.arrayContaining([
+          expect.objectContaining({
+            code: 'INVALID_NOTE_ENTRY_ID',
+            locator: expect.objectContaining({ entryId: '1.0' }),
+          }),
+        ]),
+      });
+    },
+  );
+
+  test.openspec('[SDX-ANC-EVIDENCE-02] Duplicate direct note IDs are rejected before mapping')(
+    '[SDX-ANC-EVIDENCE-07] non-XML whitespace around a note ID remains lexically invalid',
+    async () => {
+      const invalidIds = footnotes([{
+        id: '&#160;1&#160;',
+        content: COMPLETE_REF_FIELD,
+      }]);
+      const base = await archiveWith({ footnotes: invalidIds });
+      const result = await archiveWith({ footnotes: invalidIds });
+      const mergeSource = await archiveWith({});
+
+      await expect(evaluateAncillaryFieldSafety({
+        resultArchive: result,
+        baseArchive: base,
+        mergeSourceArchive: mergeSource,
+        reconstructionMode: 'rebuild',
+        baseSide: 'original',
+        mergeSourceSide: 'revised',
+        noteMergeResults: noteMergeResults(),
+      })).rejects.toMatchObject({
+        issues: expect.arrayContaining([
+          expect.objectContaining({
+            code: 'INVALID_NOTE_ENTRY_ID',
+            locator: expect.objectContaining({ entryId: '\u00a01\u00a0' }),
+          }),
+        ]),
+      });
+    },
+  );
+
+  test.openspec('[SDX-ANC-EVIDENCE-03] Note evidence follows actual assembly provenance')(
+    '[SDX-ANC-EVIDENCE-08] XML whitespace collapses before integer canonicalization',
+    async () => {
+      const base = await archiveWith({
+        footnotes: footnotes([{
+          id: '&#x9;&#xD;&#xA;+01&#x20;',
+          content: COMPLETE_REF_FIELD,
+        }]),
+      });
+      const result = await archiveWith({
+        footnotes: footnotes([{ id: '1', content: COMPLETE_REF_FIELD }]),
+      });
+      const mergeSource = await archiveWith({});
+
+      const evidence = await evaluateAncillaryFieldSafety({
+        resultArchive: result,
+        baseArchive: base,
+        mergeSourceArchive: mergeSource,
+        reconstructionMode: 'rebuild',
+        baseSide: 'original',
+        mergeSourceSide: 'revised',
+        noteMergeResults: noteMergeResults(),
+      });
+
+      expect(evidence.ranges).toEqual([
+        expect.objectContaining({
+          locator: expect.objectContaining({ entryId: '1' }),
+          provenance: 'base',
+          canonicalMatch: true,
+        }),
+      ]);
+    },
+  );
+
+  test.openspec('[SDX-ANC-EVIDENCE-03] Note evidence follows actual assembly provenance')(
+    '[SDX-ANC-EVIDENCE-08] numeric note IDs match provenance by integer value',
+    async () => {
+      const base = await archiveWith({
+        footnotes: footnotes([{ id: '01', content: COMPLETE_REF_FIELD }]),
+      });
+      const result = await archiveWith({
+        footnotes: footnotes([{ id: '+1', content: COMPLETE_REF_FIELD }]),
+      });
+      const mergeSource = await archiveWith({});
+
+      const evidence = await evaluateAncillaryFieldSafety({
+        resultArchive: result,
+        baseArchive: base,
+        mergeSourceArchive: mergeSource,
+        reconstructionMode: 'rebuild',
+        baseSide: 'original',
+        mergeSourceSide: 'revised',
+        noteMergeResults: noteMergeResults(),
+      });
+      expect(evidence.ranges).toEqual([
+        expect.objectContaining({
+          provenance: 'base',
+          locator: expect.objectContaining({ entryId: '1' }),
+        }),
+      ]);
+    },
+  );
+
+  test
+    .openspec('[SDX-ANC-EVIDENCE-03] Note evidence follows actual assembly provenance')
+    .openspec('[SDX-ANC-EVIDENCE-06] Unused merge-source defects do not poison evidence')(
+    '[SDX-ANC-EVIDENCE-09] unused malformed merge-source notes do not reject',
+    async () => {
+      const validNotes = footnotes([{ id: '1', content: COMPLETE_REF_FIELD }]);
+      const base = await archiveWith({ footnotes: validNotes });
+      const result = await archiveWith({ footnotes: validNotes });
+      const mergeSource = await archiveWith({
+        footnotes: `<w:footnotes xmlns:w="${W_NS}"><w:footnote w:id="9">`,
+      });
+
+      const evidence = await evaluateAncillaryFieldSafety({
+        resultArchive: result,
+        baseArchive: base,
+        mergeSourceArchive: mergeSource,
+        reconstructionMode: 'rebuild',
+        baseSide: 'original',
+        mergeSourceSide: 'revised',
+        noteMergeResults: noteMergeResults({
+          mergedIds: new Set(),
+          createdPart: false,
+        }),
+      });
+      expect(evidence.ranges).toEqual([
+        expect.objectContaining({
+          instructionKind: 'REF',
+          provenance: 'base',
+          locator: expect.objectContaining({ entryId: '1' }),
+        }),
+      ]);
+    },
+  );
+
+  test.openspec('[SDX-ANC-EVIDENCE-06] Unused merge-source defects do not poison evidence')(
+    '[SDX-ANC-EVIDENCE-11] unused merge-source duplicate IDs do not reject',
+    async () => {
+      const validNotes = footnotes([{ id: '1', content: COMPLETE_REF_FIELD }]);
+      const base = await archiveWith({ footnotes: validNotes });
+      const result = await archiveWith({ footnotes: validNotes });
+      const mergeSource = await archiveWith({
+        footnotes: footnotes([
+          { id: '9', content: COMPLETE_REF_FIELD },
+          { id: '+9', content: COMPLETE_REF_FIELD },
+        ]),
+      });
+
+      const evidence = await evaluateAncillaryFieldSafety({
+        resultArchive: result,
+        baseArchive: base,
+        mergeSourceArchive: mergeSource,
+        reconstructionMode: 'rebuild',
+        baseSide: 'original',
+        mergeSourceSide: 'revised',
+        noteMergeResults: noteMergeResults({
+          mergedIds: new Set(),
+          createdPart: false,
+        }),
+      });
+      expect(evidence.ranges).toHaveLength(1);
+      expect(evidence.ranges[0]).toMatchObject({
+        provenance: 'base',
+        locator: { entryId: '1' },
+      });
+    },
+  );
+
+  test.openspec('[SDX-ANC-EVIDENCE-02] Duplicate direct note IDs are rejected before mapping')(
+    '[SDX-ANC-EVIDENCE-12] contributing merge-source duplicate IDs reject',
+    async () => {
+      const sourceNotes = footnotes([
+        { id: '9', content: COMPLETE_REF_FIELD },
+        { id: '+9', content: COMPLETE_REF_FIELD },
+      ]);
+      const base = await archiveWith({});
+      const result = await archiveWith({
+        footnotes: footnotes([{ id: '9', content: COMPLETE_REF_FIELD }]),
+      });
+      const mergeSource = await archiveWith({ footnotes: sourceNotes });
+
+      await expect(evaluateAncillaryFieldSafety({
+        resultArchive: result,
+        baseArchive: base,
+        mergeSourceArchive: mergeSource,
+        reconstructionMode: 'rebuild',
+        baseSide: 'original',
+        mergeSourceSide: 'revised',
+        noteMergeResults: noteMergeResults({
+          mergedIds: new Set(['9']),
+          createdPart: true,
+        }),
+      })).rejects.toMatchObject({
+        issues: expect.arrayContaining([
+          expect.objectContaining({
+            code: 'DUPLICATE_NOTE_ENTRY_ID',
+            locator: expect.objectContaining({
+              entryId: '9',
+              sourceSide: 'revised',
+            }),
+          }),
+        ]),
+      });
+    },
+  );
+
+  test.openspec('[SDX-ANC-EVIDENCE-03] Note evidence follows actual assembly provenance')(
+    '[SDX-ANC-EVIDENCE-10] contributing malformed merge-source notes reject',
+    async () => {
+      const base = await archiveWith({});
+      const result = await archiveWith({
+        footnotes: footnotes([{ id: '9', content: COMPLETE_REF_FIELD }]),
+      });
+      const mergeSource = await archiveWith({
+        footnotes: `<w:footnotes xmlns:w="${W_NS}"><w:footnote w:id="9">`,
+      });
+
+      await expect(evaluateAncillaryFieldSafety({
+        resultArchive: result,
+        baseArchive: base,
+        mergeSourceArchive: mergeSource,
+        reconstructionMode: 'rebuild',
+        baseSide: 'original',
+        mergeSourceSide: 'revised',
+        noteMergeResults: noteMergeResults({
+          mergedIds: new Set(['9']),
+          createdPart: true,
+        }),
+      })).rejects.toMatchObject({
+        issues: expect.arrayContaining([
+          expect.objectContaining({ code: 'NOTE_PART_XML_INVALID' }),
+        ]),
+      });
+    },
+  );
+
+  test.openspec('[SDX-ANC-STORY-02] Reused targets validate once but retain all bindings')(
+    '[SDX-ANC-STORY-02] reused target validates once and retains every selecting binding',
+    async () => {
+      const base = await archiveWith({ footer: footer(COMPLETE_PAGE_FIELD) });
+      const result = await archiveWith({ footer: footer(COMPLETE_PAGE_FIELD) });
+      const mergeSource = await archiveWith({});
+      const twoSectionDocument =
+        `<w:document xmlns:w="${W_NS}" xmlns:r="${R_NS}"><w:body>` +
+        `<w:p><w:pPr><w:sectPr>` +
+        `<w:footerReference w:type="default" r:id="rIdFooter"/>` +
+        `</w:sectPr></w:pPr><w:r><w:t>First</w:t></w:r></w:p>` +
+        `<w:sectPr><w:footerReference w:type="even" r:id="rIdFooter"/></w:sectPr>` +
+        `</w:body></w:document>`;
+      base.setDocumentXml(twoSectionDocument);
+      result.setDocumentXml(twoSectionDocument);
+
+      const evidence = await evaluateAncillaryFieldSafety({
+        resultArchive: result,
+        baseArchive: base,
+        mergeSourceArchive: mergeSource,
+        reconstructionMode: 'rebuild',
+        baseSide: 'original',
+        mergeSourceSide: 'revised',
+        noteMergeResults: noteMergeResults(),
+      });
+
+      expect(evidence.selectedBindings).toHaveLength(2);
+      expect(evidence.stories.filter((story) => story.storyKind === 'footer')).toEqual([
+        expect.objectContaining({
+          normalizedPartPath: 'word/footer1.xml',
+          selectingBindings: [
+            expect.objectContaining({ sectionOrdinal: 0, role: 'default' }),
+            expect.objectContaining({ sectionOrdinal: 1, role: 'even' }),
+          ],
+        }),
+      ]);
+      expect(evidence.ranges).toHaveLength(1);
+    },
+  );
+
+  test.openspec('[SDX-ANC-STORY-03] Every selected story has independent field state')(
+    '[SDX-ANC-STORY-03] note entries cannot balance field state across entry boundaries',
+    async () => {
+      const splitStateNotes = footnotes([
+        { id: '1', content: fldChar('begin') + instrText(' REF Clause_1 ') },
+        { id: '2', content: fldChar('end') },
+      ]);
+      const base = await archiveWith({ footnotes: splitStateNotes });
+      const result = await archiveWith({ footnotes: splitStateNotes });
+      const mergeSource = await archiveWith({});
+
+      await expect(evaluateAncillaryFieldSafety({
+        resultArchive: result,
+        baseArchive: base,
+        mergeSourceArchive: mergeSource,
+        reconstructionMode: 'rebuild',
+        baseSide: 'original',
+        mergeSourceSide: 'revised',
+        noteMergeResults: noteMergeResults(),
+      })).rejects.toMatchObject({
+        issues: expect.arrayContaining([
+          expect.objectContaining({
+            code: 'FIELD_UNCLOSED_DEPTH',
+            locator: expect.objectContaining({ entryId: '1' }),
+          }),
+          expect.objectContaining({
+            code: 'FIELD_STRAY_END',
+            locator: expect.objectContaining({ entryId: '2' }),
+          }),
+        ]),
+      });
+    },
+  );
+});

--- a/packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.ts
+++ b/packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.ts
@@ -1,0 +1,645 @@
+import { XMLSerializer } from '@xmldom/xmldom';
+import {
+  DocxArchive,
+  OOXML,
+  auditSectPr,
+  collectStrictFieldStructureIssues,
+  parseXml,
+  type FieldStructureIssue,
+  type SectPrAuditIssue,
+  type SectPrBinding,
+} from '@usejunior/docx-core';
+import type {
+  AncillaryBindingLocator,
+  AncillaryFieldEvidence,
+  AncillaryFieldInstructionKind,
+  AncillaryFieldLocator,
+  AncillaryFieldRangeEvidence,
+  AncillarySelectedBindingSummary,
+  AncillaryStorySafetyIssue,
+  AncillaryStorySummary,
+  ReconstructionMode,
+} from '../../compare-types.js';
+import {
+  canonicalNode,
+  classifyFieldInstruction,
+  type SupportedComplexField,
+} from './opaquePassthrough.js';
+
+const serializer = new XMLSerializer();
+const NOTE_PARTS = [
+  {
+    path: 'word/footnotes.xml' as const,
+    root: 'footnotes',
+    entry: 'footnote',
+    storyKind: 'footnote' as const,
+  },
+  {
+    path: 'word/endnotes.xml' as const,
+    root: 'endnotes',
+    entry: 'endnote',
+    storyKind: 'endnote' as const,
+  },
+] as const;
+const IGNORED_STRICT_ISSUES = new Set([
+  'TEXT_INSIDE_DELETION',
+  'DELETED_TEXT_OUTSIDE_DELETION',
+]);
+
+export class AncillaryStorySafetyError extends Error {
+  readonly issues: AncillaryStorySafetyIssue[];
+
+  constructor(issues: AncillaryStorySafetyIssue[]) {
+    super(`Ancillary story safety check failed with ${issues.length} issue(s)`);
+    this.name = 'AncillaryStorySafetyError';
+    this.issues = issues;
+  }
+}
+
+export interface AncillaryNoteMergeResult {
+  mergedIds: ReadonlySet<string>;
+  createdPart: boolean;
+}
+
+export interface AncillaryFieldSafetyInput {
+  resultArchive: DocxArchive;
+  baseArchive: DocxArchive;
+  mergeSourceArchive: DocxArchive;
+  reconstructionMode: ReconstructionMode;
+  baseSide: 'original' | 'revised';
+  mergeSourceSide: 'original' | 'revised';
+  noteMergeResults: ReadonlyMap<'footnote' | 'endnote', AncillaryNoteMergeResult>;
+}
+
+interface InternalFieldRange {
+  locator: AncillaryFieldLocator;
+  instructionKind: AncillaryFieldInstructionKind;
+  canonical: string;
+}
+
+interface NoteEntry {
+  id: string;
+  element: Element;
+}
+
+interface NotePartInspection {
+  entries: NoteEntry[];
+  issues: AncillaryStorySafetyIssue[];
+}
+
+function packageLocator(path: string): AncillaryStorySafetyIssue['locator'] {
+  return { locatorType: 'package_part', normalizedPartPath: path };
+}
+
+function bindingLocator(issue: SectPrAuditIssue): AncillaryStorySafetyIssue['locator'] {
+  if (issue.sectionOrdinal === undefined || !issue.kind || !issue.role) {
+    return packageLocator(
+      issue.type === 'sectpr_duplicate_relationship_id'
+        ? 'word/_rels/document.xml.rels'
+        : 'word/document.xml',
+    );
+  }
+  return {
+    locatorType: 'section_binding',
+    sectionOrdinal: issue.sectionOrdinal,
+    kind: issue.kind,
+    role: issue.role,
+    normalizedPartPath: issue.targetPath,
+  };
+}
+
+function bindingSummary(binding: SectPrBinding): AncillarySelectedBindingSummary {
+  return {
+    sectionOrdinal: binding.sectionOrdinal,
+    kind: binding.kind,
+    role: binding.role,
+    relationshipId: binding.rid,
+    normalizedPartPath: binding.targetPath,
+  };
+}
+
+function publicBindingLocator(binding: SectPrBinding): AncillaryBindingLocator {
+  return {
+    locatorType: 'section_binding',
+    sectionOrdinal: binding.sectionOrdinal,
+    kind: binding.kind,
+    role: binding.role,
+    normalizedPartPath: binding.targetPath,
+  };
+}
+
+function canonicalNoteId(value: string): string | undefined {
+  const collapsed = value
+    .replace(/[ \t\r\n]+/gu, ' ')
+    .replace(/^ | $/gu, '');
+  if (!/^[+-]?\d+$/u.test(collapsed)) return undefined;
+  try {
+    return BigInt(collapsed).toString();
+  } catch {
+    return undefined;
+  }
+}
+
+function inspectNotePart(
+  xml: string,
+  path: typeof NOTE_PARTS[number]['path'],
+  rootName: string,
+  entryName: string,
+  sourceSide?: 'original' | 'revised',
+): NotePartInspection {
+  const root = parseXml(xml).documentElement;
+  if (root.namespaceURI !== OOXML.W_NS || root.localName !== rootName) {
+    throw new Error(`Expected WordprocessingML ${rootName} root`);
+  }
+  const entries: NoteEntry[] = [];
+  const issues: AncillaryStorySafetyIssue[] = [];
+  const seen = new Set<string>();
+  const duplicates = new Set<string>();
+  for (let child = root.firstChild; child; child = child.nextSibling) {
+    if (child.nodeType !== 1) continue;
+    const element = child as Element;
+    if (element.namespaceURI !== OOXML.W_NS || element.localName !== entryName) continue;
+    const lexicalId = element.getAttributeNS(OOXML.W_NS, 'id') ??
+      element.getAttribute('w:id') ??
+      '';
+    const id = canonicalNoteId(lexicalId);
+    if (id === undefined) {
+      issues.push({
+        category: 'canonical_evidence',
+        code: 'INVALID_NOTE_ENTRY_ID',
+        detail: `${path} contains invalid direct entry id '${lexicalId || '(missing)'}'`,
+        locator: {
+          locatorType: 'note_entry',
+          normalizedPartPath: path,
+          entryId: lexicalId,
+          sourceSide,
+        },
+      });
+      continue;
+    }
+    if (seen.has(id)) duplicates.add(id);
+    else seen.add(id);
+    entries.push({ id, element });
+  }
+  issues.push(...[...duplicates].sort((a, b) => {
+    const left = BigInt(a);
+    const right = BigInt(b);
+    return left < right ? -1 : left > right ? 1 : 0;
+  }).map((entryId): AncillaryStorySafetyIssue => ({
+      category: 'canonical_evidence',
+      code: 'DUPLICATE_NOTE_ENTRY_ID',
+      detail: `${path} contains numerically duplicate direct entry id '${entryId}'`,
+      locator: {
+        locatorType: 'note_entry',
+        normalizedPartPath: path,
+        entryId,
+        sourceSide,
+      },
+    })));
+  return { entries, issues };
+}
+
+function strictIssues(
+  xml: string,
+  label: string,
+  locator: AncillaryStorySafetyIssue['locator'],
+): AncillaryStorySafetyIssue[] {
+  try {
+    return collectStrictFieldStructureIssues([{ label, xml }])
+      .filter((issue) => !IGNORED_STRICT_ISSUES.has(issue.code))
+      .map((issue: FieldStructureIssue) => ({
+        category: 'strict_field_structure',
+        code: issue.code,
+        detail: issue.message,
+        locator,
+      }));
+  } catch (error) {
+    return [{
+      category: 'strict_field_structure',
+      code: 'STORY_XML_INVALID',
+      detail: error instanceof Error ? error.message : String(error),
+      locator,
+    }];
+  }
+}
+
+function directParagraphChild(paragraph: Element, element: Element): Element | null {
+  let current: Element | null = element;
+  while (current && current.parentNode !== paragraph) {
+    const parent: Node | null = current.parentNode;
+    current = parent?.nodeType === 1 ? parent as Element : null;
+  }
+  return current;
+}
+
+function fieldCharType(element: Element): string | null {
+  return element.getAttributeNS(OOXML.W_NS, 'fldCharType') ??
+    element.getAttribute('w:fldCharType');
+}
+
+function inventoryEligibleFields(
+  xml: string,
+  normalizedPartPath: string,
+  entryId: string | undefined,
+  allowedKinds: ReadonlySet<SupportedComplexField>,
+): InternalFieldRange[] {
+  const document = parseXml(xml);
+  const paragraphs = Array.from(document.getElementsByTagNameNS(OOXML.W_NS, 'p'));
+  const inventory: InternalFieldRange[] = [];
+
+  for (const [paragraphOrdinal, paragraph] of paragraphs.entries()) {
+    const stack: Array<{
+      beginChild: Element | null;
+      instruction: string[];
+      separated: boolean;
+      nestedInParent: boolean;
+      containsNested: boolean;
+    }> = [];
+    const completed: Array<{
+      beginChild: Element;
+      endChild: Element;
+      instruction: string;
+    }> = [];
+
+    const scan = (node: Element): void => {
+      for (let child = node.firstChild; child; child = child.nextSibling) {
+        if (child.nodeType !== 1) continue;
+        const element = child as Element;
+        if (element.namespaceURI === OOXML.W_NS && element.localName === 'fldChar') {
+          const type = fieldCharType(element);
+          if (type === 'begin') {
+            if (stack.length > 0) stack[stack.length - 1]!.containsNested = true;
+            stack.push({
+              beginChild: directParagraphChild(paragraph, element),
+              instruction: [],
+              separated: false,
+              nestedInParent: stack.length > 0,
+              containsNested: false,
+            });
+          } else if (type === 'separate' && stack.length > 0) {
+            stack[stack.length - 1]!.separated = true;
+          } else if (type === 'end' && stack.length > 0) {
+            const field = stack.pop()!;
+            const endChild = directParagraphChild(paragraph, element);
+            if (
+              field.beginChild &&
+              endChild &&
+              !field.nestedInParent &&
+              !field.containsNested
+            ) {
+              completed.push({
+                beginChild: field.beginChild,
+                endChild,
+                instruction: field.instruction.join(''),
+              });
+            }
+          }
+        } else if (
+          element.namespaceURI === OOXML.W_NS &&
+          (element.localName === 'instrText' || element.localName === 'delInstrText') &&
+          stack.length > 0 &&
+          !stack[stack.length - 1]!.separated
+        ) {
+          stack[stack.length - 1]!.instruction.push(element.textContent ?? '');
+        }
+        scan(element);
+      }
+    };
+    scan(paragraph);
+
+    const paragraphChildren = Array.from(paragraph.childNodes)
+      .filter((node): node is Element => node.nodeType === 1);
+    let eligibleFieldOrdinal = 0;
+    for (const field of completed) {
+      const instructionKind = classifyFieldInstruction(field.instruction);
+      if (!instructionKind || !allowedKinds.has(instructionKind)) continue;
+      const start = paragraphChildren.indexOf(field.beginChild);
+      const end = paragraphChildren.indexOf(field.endChild);
+      if (start < 0 || end < start) continue;
+      const canonical = paragraphChildren
+        .slice(start, end + 1)
+        .map(canonicalNode)
+        .join('');
+      inventory.push({
+        locator: {
+          locatorType: 'field_range',
+          normalizedPartPath,
+          entryId,
+          paragraphOrdinal,
+          eligibleFieldOrdinal,
+          instructionKind,
+        },
+        instructionKind,
+        canonical,
+      });
+      eligibleFieldOrdinal++;
+    }
+  }
+  return inventory;
+}
+
+function locatorKey(locator: AncillaryFieldLocator): string {
+  return JSON.stringify([
+    locator.normalizedPartPath,
+    locator.entryId ?? null,
+    locator.paragraphOrdinal,
+    locator.eligibleFieldOrdinal,
+  ]);
+}
+
+function compareInventories(
+  source: InternalFieldRange[],
+  final: InternalFieldRange[],
+  sourceSide: 'original' | 'revised',
+  provenance: 'base' | 'imported',
+): { issues: AncillaryStorySafetyIssue[]; ranges: AncillaryFieldRangeEvidence[] } {
+  const issues: AncillaryStorySafetyIssue[] = [];
+  const ranges: AncillaryFieldRangeEvidence[] = [];
+  const sourceKeys = new Set(source.map((item) => locatorKey(item.locator)));
+
+  for (const item of source) {
+    const key = locatorKey(item.locator);
+    const counterpart = final.find((candidate) => locatorKey(candidate.locator) === key);
+    if (!counterpart) {
+      issues.push({
+        category: 'canonical_evidence',
+        code: 'FIELD_RANGE_MISSING',
+        detail: 'Eligible source field range is missing from the final package',
+        locator: item.locator,
+      });
+      continue;
+    }
+    if (counterpart.instructionKind !== item.instructionKind) {
+      issues.push({
+        category: 'canonical_evidence',
+        code: 'FIELD_RANGE_KIND_MISMATCH',
+        detail: `Eligible field instruction changed from ${item.instructionKind} to ${counterpart.instructionKind}`,
+        locator: item.locator,
+      });
+      continue;
+    }
+    if (counterpart.canonical !== item.canonical) {
+      issues.push({
+        category: 'canonical_evidence',
+        code: 'FIELD_RANGE_CANONICAL_MISMATCH',
+        detail: 'Final field range differs from its source canonical subtree range',
+        locator: item.locator,
+      });
+      continue;
+    }
+    ranges.push({
+      locator: item.locator,
+      instructionKind: item.instructionKind,
+      sourceSide,
+      provenance,
+      canonicalMatch: true,
+    });
+  }
+
+  for (const item of final) {
+    if (sourceKeys.has(locatorKey(item.locator))) continue;
+    issues.push({
+      category: 'canonical_evidence',
+      code: 'FIELD_RANGE_EXTRA',
+      detail: 'Final package contains an eligible field range absent from its source story',
+      locator: item.locator,
+    });
+  }
+
+  return { issues, ranges: issues.length === 0 ? ranges : [] };
+}
+
+function entryMap(entries: NoteEntry[]): Map<string, Element> {
+  return new Map(entries.map((entry) => [entry.id, entry.element]));
+}
+
+/**
+ * Validate and inventory ancillary stories at the final package boundary.
+ *
+ * Header/footer structure follows the existing section binding audit. Complex
+ * field citations cover structural validation and instruction classification;
+ * target containment, note isolation, provenance, and canonical preservation
+ * are stronger SafeDocX safety policies and metamorphic invariants.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.10.5
+ * @conformance ECMA-376 edition 5, Part 1 § 17.10.2
+ * @conformance ECMA-376 edition 5, Part 1 § 17.10.4
+ * @conformance ECMA-376 edition 5, Part 1 § 17.10.3
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.18
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.5.44
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.5.42
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.5.51
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.5.45
+ */
+async function evaluateAncillaryFieldSafetyUnsafe(
+  input: AncillaryFieldSafetyInput,
+): Promise<AncillaryFieldEvidence> {
+  const issues: AncillaryStorySafetyIssue[] = [];
+  const ranges: AncillaryFieldRangeEvidence[] = [];
+  const stories: AncillaryStorySummary[] = [];
+  const resultDocumentXml = await input.resultArchive.getDocumentXml();
+  const resultRelationships = await input.resultArchive.getFile('word/_rels/document.xml.rels');
+  const preliminarySectionAudit = auditSectPr(resultDocumentXml, resultRelationships);
+  const resultParts = new Map<string, string>();
+  for (const targetPath of [...new Set(
+    preliminarySectionAudit.bindings.map((binding) => binding.targetPath),
+  )].sort()) {
+    const xml = await input.resultArchive.getFile(targetPath);
+    if (xml !== null) resultParts.set(targetPath, xml);
+  }
+  const sectionAudit = auditSectPr(resultDocumentXml, resultRelationships, resultParts);
+
+  for (const issue of sectionAudit.issues) {
+    issues.push({
+      category: 'binding_resolution',
+      code: issue.type,
+      detail: issue.message,
+      locator: bindingLocator(issue),
+    });
+  }
+  if (issues.length > 0) throw new AncillaryStorySafetyError(issues);
+
+  const bindings = sectionAudit.bindings.map(bindingSummary);
+  const bindingsByTarget = new Map<string, SectPrBinding[]>();
+  for (const binding of sectionAudit.bindings) {
+    const list = bindingsByTarget.get(binding.targetPath);
+    if (list) list.push(binding);
+    else bindingsByTarget.set(binding.targetPath, [binding]);
+  }
+
+  for (const [targetPath, targetBindings] of [...bindingsByTarget].sort(([a], [b]) => a.localeCompare(b))) {
+    const finalXml = resultParts.get(targetPath)!;
+    const sourceXml = await input.baseArchive.getFile(targetPath);
+    const locator = {
+      locatorType: 'header_footer_story' as const,
+      normalizedPartPath: targetPath,
+      selectingBindings: targetBindings.map(publicBindingLocator),
+    };
+    const storyStrictIssues = strictIssues(finalXml, targetPath, locator);
+    issues.push(...storyStrictIssues);
+    if (storyStrictIssues.length > 0) continue;
+    if (sourceXml === null) {
+      issues.push({
+        category: 'canonical_evidence',
+        code: 'FIELD_RANGE_MISSING',
+        detail: `Selected source story '${targetPath}' is absent from the assembly base`,
+        locator,
+      });
+      continue;
+    }
+    const allowed = new Set<SupportedComplexField>(['PAGE', 'NUMPAGES']);
+    const comparison = compareInventories(
+      inventoryEligibleFields(sourceXml, targetPath, undefined, allowed),
+      inventoryEligibleFields(finalXml, targetPath, undefined, allowed),
+      input.baseSide,
+      'base',
+    );
+    issues.push(...comparison.issues);
+    ranges.push(...comparison.ranges);
+    stories.push({
+      storyKind: targetBindings[0]!.kind,
+      normalizedPartPath: targetPath,
+      selectingBindings: targetBindings.map(publicBindingLocator),
+      sourceSide: input.baseSide,
+      provenance: 'base',
+      strictFieldStructure: 'passed',
+    });
+  }
+
+  for (const note of NOTE_PARTS) {
+    const noteIssueStart = issues.length;
+    const [baseXml, sourceXml, finalXml] = await Promise.all([
+      input.baseArchive.getFile(note.path),
+      input.mergeSourceArchive.getFile(note.path),
+      input.resultArchive.getFile(note.path),
+    ]);
+    if (finalXml === null) continue;
+
+    const mergeResult = input.noteMergeResults.get(note.storyKind);
+    const sourceContributes = Boolean(
+      mergeResult?.createdPart || (mergeResult && mergeResult.mergedIds.size > 0),
+    );
+    let baseInspection: NotePartInspection = { entries: [], issues: [] };
+    let sourceInspection: NotePartInspection = { entries: [], issues: [] };
+    let finalInspection: NotePartInspection;
+    try {
+      if (baseXml !== null) {
+        baseInspection = inspectNotePart(
+          baseXml,
+          note.path,
+          note.root,
+          note.entry,
+          input.baseSide,
+        );
+        issues.push(...baseInspection.issues);
+      }
+      if (sourceContributes && sourceXml !== null) {
+        sourceInspection = inspectNotePart(
+          sourceXml,
+          note.path,
+          note.root,
+          note.entry,
+          input.mergeSourceSide,
+        );
+        issues.push(...sourceInspection.issues);
+      }
+      finalInspection = inspectNotePart(finalXml, note.path, note.root, note.entry);
+      issues.push(...finalInspection.issues);
+    } catch (error) {
+      issues.push({
+        category: 'strict_field_structure',
+        code: 'NOTE_PART_XML_INVALID',
+        detail: error instanceof Error ? error.message : String(error),
+        locator: packageLocator(note.path),
+      });
+      continue;
+    }
+
+    if (issues.length > noteIssueStart) continue;
+
+    const finalEntries = finalInspection.entries;
+    const baseEntries = entryMap(baseInspection.entries);
+    const sourceEntries = entryMap(sourceInspection.entries);
+    const canonicalMergedIds = new Set(
+      [...(mergeResult?.mergedIds ?? [])]
+        .map(canonicalNoteId)
+        .filter((id): id is string => id !== undefined),
+    );
+    const allowed = new Set<SupportedComplexField>(['REF', 'PAGEREF']);
+
+    for (const entry of finalEntries) {
+      const provenance = baseEntries.has(entry.id) ? 'base' : 'imported';
+      const sourceSide = provenance === 'base' ? input.baseSide : input.mergeSourceSide;
+      const sourceEntry = provenance === 'base'
+        ? baseEntries.get(entry.id)
+        : sourceEntries.get(entry.id);
+      const locator = {
+        locatorType: 'note_entry' as const,
+        normalizedPartPath: note.path,
+        entryId: entry.id,
+      };
+      const entryStrictIssues = strictIssues(
+        serializer.serializeToString(entry.element),
+        `${note.path}:${entry.id}`,
+        locator,
+      );
+      issues.push(...entryStrictIssues);
+      if (entryStrictIssues.length > 0) continue;
+      if (
+        !sourceEntry ||
+        (provenance === 'imported' && !canonicalMergedIds.has(entry.id) && !mergeResult?.createdPart)
+      ) {
+        issues.push({
+          category: 'canonical_evidence',
+          code: 'NOTE_ENTRY_PROVENANCE_MISSING',
+          detail: `Final note entry '${entry.id}' has no assembly source provenance`,
+          locator,
+        });
+        continue;
+      }
+      const sourceEntryXml = serializer.serializeToString(sourceEntry);
+      const finalEntryXml = serializer.serializeToString(entry.element);
+      const comparison = compareInventories(
+        inventoryEligibleFields(sourceEntryXml, note.path, entry.id, allowed),
+        inventoryEligibleFields(finalEntryXml, note.path, entry.id, allowed),
+        sourceSide,
+        provenance,
+      );
+      issues.push(...comparison.issues);
+      ranges.push(...comparison.ranges);
+      stories.push({
+        storyKind: note.storyKind,
+        normalizedPartPath: note.path,
+        entryId: entry.id,
+        sourceSide,
+        provenance,
+        strictFieldStructure: 'passed',
+      });
+    }
+  }
+
+  if (issues.length > 0) throw new AncillaryStorySafetyError(issues);
+  return {
+    status: 'passed',
+    reconstructionMode: input.reconstructionMode,
+    selectedBindings: bindings,
+    stories,
+    ranges,
+  };
+}
+
+export async function evaluateAncillaryFieldSafety(
+  input: AncillaryFieldSafetyInput,
+): Promise<AncillaryFieldEvidence> {
+  try {
+    return await evaluateAncillaryFieldSafetyUnsafe(input);
+  } catch (error) {
+    if (error instanceof AncillaryStorySafetyError) throw error;
+    throw new AncillaryStorySafetyError([{
+      category: 'strict_field_structure',
+      code: 'ANCILLARY_PACKAGE_XML_INVALID',
+      detail: error instanceof Error ? error.message : String(error),
+      locator: packageLocator('word/document.xml'),
+    }]);
+  }
+}

--- a/packages/docx-compare/src/baselines/atomizer/auxiliaryIdCollision.ts
+++ b/packages/docx-compare/src/baselines/atomizer/auxiliaryIdCollision.ts
@@ -214,8 +214,19 @@ export async function renumberCollidingAuxiliaryIds(
     // A collision needs a definition on both sides.
     if (!originalPartXml || !revisedPartXml) continue;
 
-    const originalParsed = parseEntries(originalPartXml, descriptor.entryTag);
-    const revisedParsed = parseEntries(revisedPartXml, descriptor.entryTag);
+    let originalParsed: ReturnType<typeof parseEntries>;
+    let revisedParsed: ReturnType<typeof parseEntries>;
+    try {
+      originalParsed = parseEntries(originalPartXml, descriptor.entryTag);
+      revisedParsed = parseEntries(revisedPartXml, descriptor.entryTag);
+    } catch (error) {
+      // Note XML is validated at the publication boundary after the selected
+      // assembly mode is known. Deferring malformed note parts here lets an
+      // unused opposite-side part remain irrelevant while a contributing or
+      // final malformed part still fails with typed ancillary diagnostics.
+      if (descriptor.label === 'footnote' || descriptor.label === 'endnote') continue;
+      throw error;
+    }
     originalEntryIds.set(descriptor.label, new Set(originalParsed.entries.keys()));
 
     const collidingIds: string[] = [];

--- a/packages/docx-compare/src/baselines/atomizer/leanXmlVerifier.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/leanXmlVerifier.test.ts
@@ -65,6 +65,13 @@ describeWithLean('Lean XML triple verifier certificate', () => {
         expect(result.documentIntegrity?.fixedStoryScope).toEqual([
           'word/document.xml', 'word/footnotes.xml', 'word/endnotes.xml',
         ]);
+        expect(result.documentIntegrity?.exclusions).toContain(
+          'comments, headers, and footers',
+        );
+        expect(result.ancillaryFieldEvidence).toMatchObject({
+          status: 'passed',
+          reconstructionMode: 'inplace',
+        });
         expect(result.documentIntegrity?.inputSha256.originalDocumentXml).toMatch(/^[0-9a-f]{64}$/);
         expect(result.documentIntegrity?.inputPackageSha256?.originalDocx).toMatch(/^[0-9a-f]{64}$/);
         expect(result.documentIntegrity?.stories?.map((story) => story.name)).toEqual(['main']);
@@ -695,7 +702,9 @@ describe('Lean fixed-story protocol and security hardening', () => {
     options: { executablePath, timeoutMs },
   });
 
-  test.openspec('[LEAN-STORY-08] Public certificate remains v1 compatible')(
+  test
+    .openspec('[LEAN-STORY-08] Public certificate remains v1 compatible')
+    .openspec('[SDX-ANC-BOUNDARY-03] Lean protocol and scope remain unchanged')(
     'preserves the public v1 certificate fields while adding package-story evidence', async () => {
     const docx = await buildDocxFromBodyXml(paragraphWithText('Body'));
     const fake = await fakeChecker(validProtocolReport);
@@ -714,6 +723,10 @@ describe('Lean fixed-story protocol and security hardening', () => {
       expect(result.status).toBe('passed');
       expect(result.checks.acceptingAllTrackedChangesMatchesRevisedText.status).toBe('passed');
       expect(result.checkerProtocolVersion).toBe(3);
+      expect(result.fixedStoryScope).toEqual([
+        'word/document.xml', 'word/footnotes.xml', 'word/endnotes.xml',
+      ]);
+      expect(result.exclusions).toContain('comments, headers, and footers');
     } finally {
       await rm(fake.dir, { recursive: true, force: true });
     }

--- a/packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts
+++ b/packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts
@@ -1,7 +1,12 @@
 import { createHash } from 'node:crypto';
 import { posix } from 'node:path';
 import type { ComparisonUnitAtom, DocxArchive, OpaquePassthroughNode } from '@usejunior/docx-core';
-import { CorrelationStatus, OOXML, parseXml } from '@usejunior/docx-core';
+import {
+  CorrelationStatus,
+  OOXML,
+  normalizeOpcRelationshipTarget,
+  parseXml,
+} from '@usejunior/docx-core';
 
 const XMLNS_NS = 'http://www.w3.org/2000/xmlns/';
 const XML_NS = 'http://www.w3.org/XML/1998/namespace';
@@ -51,48 +56,6 @@ function collectRelationshipIds(root: Element): string[] {
   };
   visit(root);
   return [...ids].sort();
-}
-
-function normalizeInternalTarget(ownerPart: string, target: string): string {
-  if (!target || target.includes('\\') || /[\u0000-\u001f\u007f?#]/.test(target)) {
-    throw new OpaquePassthroughError(`unsafe internal relationship target '${target}'`);
-  }
-  let decoded: string;
-  try {
-    decoded = decodeURIComponent(target);
-  } catch {
-    throw new OpaquePassthroughError(`invalid encoded relationship target '${target}'`);
-  }
-  if (
-    decoded.includes('\\') ||
-    /[\u0000-\u001f\u007f?#]/.test(decoded) ||
-    decoded.startsWith('//') ||
-    decoded.includes(':')
-  ) {
-    throw new OpaquePassthroughError(`unsafe internal relationship target '${target}'`);
-  }
-  const segments = decoded.startsWith('/') ? [] : posix.dirname(ownerPart).split('/').filter(Boolean);
-  for (const segment of decoded.split('/')) {
-    if (!segment || segment === '.') continue;
-    if (segment === '..') {
-      if (segments.length === 0) {
-        throw new OpaquePassthroughError(`relationship target escapes the package root: '${target}'`);
-      }
-      segments.pop();
-    } else {
-      segments.push(segment);
-    }
-  }
-  if (segments.length === 0) throw new OpaquePassthroughError(`empty resolved relationship target '${target}'`);
-  return segments.join('/');
-}
-
-function normalizeExternalTarget(target: string): string {
-  try {
-    return new URL(target).href;
-  } catch {
-    throw new OpaquePassthroughError(`unsafe external relationship target '${target}'`);
-  }
 }
 
 /** Memoized package-scoped relationship closure used only for opaque body blocks. */
@@ -148,11 +111,11 @@ export class OpaqueRelationshipClosureResolver {
         id,
         type: relationship.type,
         mode: relationship.mode,
-        target: normalizeExternalTarget(relationship.target),
+        target: relationship.target,
       });
     }
 
-    const targetPart = normalizeInternalTarget(ownerPart, relationship.target);
+    const targetPart = relationship.target;
     const hash = await this.hashPart(targetPart);
     const dependentRelationships = await this.relationshipsForPart(targetPart);
     let dependencies: string[] = [];
@@ -194,12 +157,33 @@ export class OpaqueRelationshipClosureResolver {
         const id = element.getAttribute('Id');
         const type = element.getAttribute('Type');
         const target = element.getAttribute('Target');
-        const rawMode = element.getAttribute('TargetMode') || 'Internal';
-        if (!id || !type || !target || (rawMode !== 'Internal' && rawMode !== 'External')) {
+        const rawMode = element.hasAttribute('TargetMode')
+          ? element.getAttribute('TargetMode')
+          : undefined;
+        if (!id || !type) {
           throw new OpaquePassthroughError(`invalid relationship entry in '${relationshipPartPath(partPath)}'`);
         }
         if (relationships.has(id)) throw new OpaquePassthroughError(`duplicate relationship Id ${partPath}#${id}`);
-        relationships.set(id, { id, type, target, mode: rawMode });
+        try {
+          const normalized = normalizeOpcRelationshipTarget({
+            ownerPart: partPath,
+            target: target ?? '',
+            targetMode: rawMode,
+            allowExternal: true,
+          });
+          relationships.set(id, {
+            id,
+            type,
+            target: normalized.target,
+            mode: normalized.mode,
+          });
+        } catch (error) {
+          throw new OpaquePassthroughError(
+            error instanceof Error
+              ? error.message
+              : `invalid relationship entry in '${relationshipPartPath(partPath)}'`,
+          );
+        }
       }
       return relationships;
     })();
@@ -294,7 +278,8 @@ function effectiveMceDeclarations(element: Element): {
   };
 }
 
-function canonicalNode(node: Node): string {
+/** Expanded-name canonical subtree form used by opaque preservation checks. */
+export function canonicalNode(node: Node): string {
   if (node.nodeType === 1) {
     const element = node as Element;
     const attributes: string[] = [];
@@ -679,7 +664,7 @@ export function captureSdtPassthrough(root: Element, atoms: ComparisonUnitAtom[]
   }
 }
 
-type SupportedComplexField = 'PAGE' | 'NUMPAGES' | 'REF' | 'PAGEREF';
+export type SupportedComplexField = 'PAGE' | 'NUMPAGES' | 'REF' | 'PAGEREF';
 
 function fieldCharType(atom: ComparisonUnitAtom): string | null {
   const element = atom.contentElement;
@@ -776,7 +761,7 @@ function supportedFieldKeyword(instruction: string): SupportedComplexField | nul
     : null;
 }
 
-function classifyFieldInstruction(instruction: string): SupportedComplexField | null {
+export function classifyFieldInstruction(instruction: string): SupportedComplexField | null {
   const tokens = tokenizeFieldInstruction(instruction);
   if (!tokens || tokens.length === 0) return null;
   const keyword = tokens[0]!.toUpperCase();

--- a/packages/docx-compare/src/baselines/atomizer/pipeline.field-validation.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline.field-validation.test.ts
@@ -13,11 +13,11 @@ import {
 const TEST_FEATURE = 'verify-ancillary-field-stories';
 const test = testAllure
   .epic('Document Comparison')
-  .withLabels({ feature: 'Field Structure Validation (ECMA-376)' })
+  .withLabels({ feature: TEST_FEATURE })
   .conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.16.13' });
 const strictTest = testAllure
   .epic('Document Comparison')
-  .withLabels({ feature: 'Strict Ancillary Field Stories' })
+  .withLabels({ feature: TEST_FEATURE })
   .conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.16.18' });
 
 const NS = 'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';

--- a/packages/docx-compare/src/baselines/atomizer/pipeline.field-validation.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline.field-validation.test.ts
@@ -10,6 +10,7 @@ import {
   validateStrictFieldStructure,
 } from '@usejunior/docx-core';
 
+const TEST_FEATURE = 'verify-ancillary-field-stories';
 const test = testAllure
   .epic('Document Comparison')
   .withLabels({ feature: 'Field Structure Validation (ECMA-376)' })

--- a/packages/docx-compare/src/baselines/atomizer/pipeline.field-validation.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline.field-validation.test.ts
@@ -5,11 +5,19 @@ import {
   FRAGMENTED_NUMPAGES_MODIFICATION as MODIFIED_FIELD_FRAGMENTED,
 } from '../../testing/ooxml-fixtures.js';
 import { hasFldCharInsideDel, splitStories, validateFieldStructure } from './pipeline.js';
+import {
+  collectStrictFieldStructureIssues,
+  validateStrictFieldStructure,
+} from '@usejunior/docx-core';
 
 const test = testAllure
   .epic('Document Comparison')
   .withLabels({ feature: 'Field Structure Validation (ECMA-376)' })
   .conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.16.13' });
+const strictTest = testAllure
+  .epic('Document Comparison')
+  .withLabels({ feature: 'Strict Ancillary Field Stories' })
+  .conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.16.18' });
 
 const NS = 'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
 
@@ -232,6 +240,118 @@ describe('validateFieldStructure', () => {
       });
       await then('it passes', () => {
         expect(ok).toBe(true);
+      });
+    },
+  );
+});
+
+describe('strict ancillary field structure', () => {
+  strictTest.openspec('[SDX-ANC-STRICT-01] Strict-only malformed shapes are rejected')(
+    'rejects strict-only marker defects with distinct issue codes',
+    async ({ given, when, then }: AllureBddContext) => {
+      const cases = [
+        {
+          code: 'FIELD_STRAY_SEPARATOR',
+          xml: buildDoc(`<w:p><w:r><w:fldChar w:fldCharType="separate"/></w:r></w:p>`),
+          leanPinnedPasses: true,
+        },
+        {
+          code: 'FIELD_STRAY_END',
+          xml: buildDoc(
+            `<w:p>` +
+              `<w:r><w:fldChar w:fldCharType="end"/></w:r>` +
+              `<w:r><w:fldChar w:fldCharType="begin"/></w:r>` +
+              `</w:p>`,
+          ),
+          leanPinnedPasses: true,
+        },
+        {
+          code: 'FIELD_DUPLICATE_SEPARATOR',
+          xml: buildDoc(
+            `<w:p>` +
+              `<w:r><w:fldChar w:fldCharType="begin"/></w:r>` +
+              `<w:r><w:fldChar w:fldCharType="separate"/></w:r>` +
+              `<w:r><w:fldChar w:fldCharType="separate"/></w:r>` +
+              `<w:r><w:fldChar w:fldCharType="end"/></w:r>` +
+              `</w:p>`,
+          ),
+          leanPinnedPasses: true,
+        },
+        {
+          code: 'FIELD_UNKNOWN_CHAR_TYPE',
+          xml: buildDoc(`<w:p><w:r><w:fldChar w:fldCharType="mystery"/></w:r></w:p>`),
+          leanPinnedPasses: true,
+        },
+        {
+          code: 'FIELD_UNCLOSED_DEPTH',
+          xml: buildDoc(`<w:p><w:r><w:fldChar w:fldCharType="begin"/></w:r></w:p>`),
+          leanPinnedPasses: false,
+        },
+      ];
+      let observed: Array<{ code: string; strict: boolean; leanPinned: boolean }> = [];
+
+      await given('strict-only malformed field marker stories', () => {});
+      await when('both runtime predicates evaluate each story', () => {
+        observed = cases.map(({ code, xml }) => ({
+          code,
+          strict: validateStrictFieldStructure(xml),
+          leanPinned: validateFieldStructure(xml),
+        }));
+      });
+      await then('strict validation rejects every case with the expected code', () => {
+        for (const [index, item] of observed.entries()) {
+          expect(item.strict).toBe(false);
+          expect(collectStrictFieldStructureIssues(cases[index]!.xml).map((issue) => issue.code))
+            .toContain(item.code);
+          expect(item.leanPinned).toBe(cases[index]!.leanPinnedPasses);
+        }
+      });
+    },
+  );
+
+  strictTest.openspec('[SDX-ANC-STRICT-02] Valid optional separators and nested stacks pass')(
+    'accepts begin-end-only and properly stacked nested fields',
+    async ({ given, when, then }: AllureBddContext) => {
+      let stories: string[] = [];
+
+      await given('a begin-end-only field and a properly nested field', () => {
+        stories = [
+          buildDoc(
+            `<w:p>` +
+              `<w:r><w:fldChar w:fldCharType="begin"/></w:r>` +
+              `<w:r><w:fldChar w:fldCharType="end"/></w:r>` +
+              `</w:p>`,
+          ),
+          buildDoc(
+            `<w:p>` +
+              `<w:r><w:fldChar w:fldCharType="begin"/></w:r>` +
+              `<w:r><w:instrText> REF Outer </w:instrText></w:r>` +
+              `<w:r><w:fldChar w:fldCharType="begin"/></w:r>` +
+              `<w:r><w:instrText> PAGE </w:instrText></w:r>` +
+              `<w:r><w:fldChar w:fldCharType="separate"/></w:r>` +
+              `<w:r><w:t>1</w:t></w:r>` +
+              `<w:r><w:fldChar w:fldCharType="end"/></w:r>` +
+              `<w:r><w:fldChar w:fldCharType="separate"/></w:r>` +
+              `<w:r><w:t>outer</w:t></w:r>` +
+              `<w:r><w:fldChar w:fldCharType="end"/></w:r>` +
+              `</w:p>`,
+          ),
+        ];
+      });
+      await when('strict validation runs', () => {});
+      await then('both valid stack shapes pass', () => {
+        for (const xml of stories) expect(validateStrictFieldStructure(xml)).toBe(true);
+      });
+    },
+  );
+
+  strictTest.openspec('[SDX-ANC-STRICT-03] Lean behavior does not change')(
+    'keeps the original predicate intentionally unchanged',
+    async ({ then }: AllureBddContext) => {
+      await then('a stray separator remains tolerated only by the Lean-pinned predicate', () => {
+        const xml = buildDoc(`<w:p><w:r><w:fldChar w:fldCharType="separate"/></w:r></w:p>`);
+        expect(validateFieldStructure(xml)).toBe(true);
+        expect(validateStrictFieldStructure(xml)).toBe(false);
       });
     },
   );

--- a/packages/docx-compare/src/baselines/atomizer/pipeline.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline.ts
@@ -12,6 +12,8 @@ import { DocxArchive } from '@usejunior/docx-core';
 import type {
   CompareResult,
   CompareStats,
+  AncillaryFallbackDiagnostics,
+  AncillaryFieldEvidence,
   ReconstructionAttemptDiagnostics,
   ReconstructionBookmarkMismatchDetails,
   ReconstructionBookmarkMismatchSummary,
@@ -114,6 +116,10 @@ import {
   type AuxiliaryPartDescriptor,
 } from './auxiliaryIdCollision.js';
 import { maybeCaptureEmittedDocumentXml } from '@usejunior/docx-core';
+import {
+  AncillaryStorySafetyError,
+  evaluateAncillaryFieldSafety,
+} from './ancillaryFieldSafety.js';
 
 /**
  * Options for the atomizer pipeline.
@@ -483,15 +489,9 @@ function evaluateSafetyChecks(
     rejectedBookmarkDiagnostics
   );
 
-  // Validate field structure per-story. Each footnote/endnote entry is its own
-  // ECMA-376 story; a complex field that crosses a story boundary breaks
-  // Word's field state machine even when global begin/end counts balance.
-  // Sidecars from BOTH archives are validated because Step 12's auxiliary-part
-  // merge picks its base and source archives by reconstruction mode (inplace
-  // base = revised; rebuild base = original) and validating only one side
-  // would miss field issues that would still ship in the merged result.
-  // `acceptAllChanges` / `rejectAllChanges` only transform document.xml, so
-  // the sidecar set is identical for both transforms.
+  // Validate field structure for the main-story round-trip projection. Final
+  // note entries are validated after mode-specific assembly, where the gate
+  // knows which base and merge-source definitions actually contributed.
   const acceptedStories = splitStories(
     acceptedXml,
     auxiliarySidecars.footnotesXmls,
@@ -652,26 +652,12 @@ export async function compareDocumentsAtomizer(
   const originalHyperlinkTargets = parseHyperlinkRelTargets(originalRelsDoc);
   const revisedHyperlinkTargets = parseHyperlinkRelTargets(revisedRelsDoc);
 
-  // Extract footnote/endnote sidecars from BOTH archives for per-story
-  // field-closure validation (issue #212). Step 12 picks the base archive by
-  // reconstruction mode (inplace = revised, rebuild = original) and merges
-  // missing referenced entries from the opposite archive. Validating both
-  // archives' sidecars covers the union of entries that could ship without
-  // having to duplicate the merge logic at safety-check time.
-  const [
-    originalFootnotesXml,
-    originalEndnotesXml,
-    revisedFootnotesXml,
-    revisedEndnotesXml,
-  ] = await Promise.all([
-    originalArchive.getFile('word/footnotes.xml'),
-    originalArchive.getFile('word/endnotes.xml'),
-    revisedArchive.getFile('word/footnotes.xml'),
-    revisedArchive.getFile('word/endnotes.xml'),
-  ]);
+  // The legacy round-trip check remains main-story-only. The publication gate
+  // validates every final note entry and inspects the opposite archive only
+  // when merge provenance proves that it contributed definitions.
   const auxiliarySidecars = {
-    footnotesXmls: [originalFootnotesXml, revisedFootnotesXml] as const,
-    endnotesXmls: [originalEndnotesXml, revisedEndnotesXml] as const,
+    footnotesXmls: [] as const,
+    endnotesXmls: [] as const,
   };
 
   const originalPart: OpcPart = {
@@ -951,11 +937,90 @@ export async function compareDocumentsAtomizer(
     );
   }
 
-  // Rebuild output gets the same safety screening as inplace attempts, whether
-  // rebuild was requested directly or reached via inplace fallback. Rebuild is
-  // the terminal strategy, so failures are surfaced in diagnostics rather than
-  // blocking the output.
-  // @see https://github.com/UseJunior/safe-docx/issues/226
+  const assembleCandidate = async (candidate: typeof comparisonResult): Promise<{
+    resultBuffer: Buffer;
+    ancillaryFieldEvidence: AncillaryFieldEvidence;
+  }> => {
+    const { newDocumentXml } = candidate;
+    // Step 12: Clone the mode-selected archive and update document.xml.
+    const baseArchive = candidate.outputMode === 'inplace' ? revisedArchive : originalArchive;
+    const mergeSourceArchive = candidate.outputMode === 'inplace' ? originalArchive : revisedArchive;
+    const baseSide = candidate.outputMode === 'inplace' ? 'revised' : 'original';
+    const mergeSourceSide = candidate.outputMode === 'inplace' ? 'original' : 'revised';
+    const resultArchive = await baseArchive.clone();
+    maybeCaptureEmittedDocumentXml(newDocumentXml);
+    resultArchive.setDocumentXml(newDocumentXml);
+
+    await appendHyperlinkRelationships(resultArchive, candidate.hyperlinkRelationships);
+
+    const noteMergeResults = new Map<'footnote' | 'endnote', AuxiliaryMergeResult>();
+    for (const descriptor of AUXILIARY_PARTS) {
+      let mergeResult: AuxiliaryMergeResult;
+      try {
+        mergeResult = await mergeAuxiliaryPartDefinitions(
+          mergeSourceArchive, resultArchive, newDocumentXml, descriptor
+        );
+      } catch (error) {
+        if (descriptor.label !== 'footnote' && descriptor.label !== 'endnote') throw error;
+        throw new AncillaryStorySafetyError([{
+          category: 'strict_field_structure',
+          code: 'NOTE_PART_XML_INVALID',
+          detail: error instanceof Error ? error.message : String(error),
+          locator: {
+            locatorType: 'package_part',
+            normalizedPartPath: descriptor.partPath,
+          },
+        }]);
+      }
+      if (descriptor.label === 'footnote' || descriptor.label === 'endnote') {
+        noteMergeResults.set(descriptor.label, mergeResult);
+      }
+    }
+
+    const rootCommentIds = await collectStoryReferenceIds(
+      resultArchive, newDocumentXml, 'w:commentReference', null
+    );
+    if (rootCommentIds.size > 0) {
+      await mergeCommentAncillaryParts(mergeSourceArchive, resultArchive, rootCommentIds);
+    }
+
+    const ancillaryFieldEvidence = await evaluateAncillaryFieldSafety({
+      resultArchive,
+      baseArchive,
+      mergeSourceArchive,
+      reconstructionMode: candidate.outputMode,
+      baseSide,
+      mergeSourceSide,
+      noteMergeResults,
+    });
+    return {
+      resultBuffer: await resultArchive.save(),
+      ancillaryFieldEvidence,
+    };
+  };
+
+  let ancillaryFallbackDiagnostics: AncillaryFallbackDiagnostics | undefined;
+  let assembled: Awaited<ReturnType<typeof assembleCandidate>>;
+  try {
+    assembled = await assembleCandidate(comparisonResult);
+  } catch (error) {
+    if (comparisonResult.outputMode !== 'inplace' || !(error instanceof AncillaryStorySafetyError)) {
+      throw error;
+    }
+    ancillaryFallbackDiagnostics = { issues: error.issues };
+    fallbackReason = 'ancillary_story_safety_check_failed';
+    fallbackDiagnostics = undefined;
+    inplaceSuccessDiagnostics = undefined;
+    comparisonResult = await runComparisonPass(
+      { atomizeParagraphLevelMarkers: true },
+      'rebuild'
+    );
+    assembled = await assembleCandidate(comparisonResult);
+  }
+
+  // Rebuild remains the terminal main-story strategy. Its established
+  // round-trip diagnostics stay caller-visible; ancillary failures have
+  // already thrown before this point.
   let rebuildSafetyDiagnostics: ReconstructionRebuildSafetyDiagnostics | undefined;
   if (comparisonResult.outputMode === 'rebuild') {
     const safety = evaluateRoundTripSafety(comparisonResult.newDocumentXml);
@@ -970,46 +1035,7 @@ export async function compareDocumentsAtomizer(
   }
 
   const { mergedAtoms, newDocumentXml } = comparisonResult;
-
-  // Step 12: Clone appropriate archive and update document.xml.
-  // Use the revised archive only for true inplace output.
-  const baseArchive = comparisonResult.outputMode === 'inplace' ? revisedArchive : originalArchive;
-  // The merge source is the *opposite* archive from the base: inplace pulls
-  // deleted-but-still-referenced definitions from the original, rebuild pulls
-  // added-but-still-referenced definitions from the revised. Without this,
-  // rebuild output ships dangling references when the original lacks an
-  // auxiliary part that the revised side introduced (issue #94).
-  const mergeSourceArchive = comparisonResult.outputMode === 'inplace' ? originalArchive : revisedArchive;
-  const resultArchive = await baseArchive.clone();
-  maybeCaptureEmittedDocumentXml(newDocumentXml);
-  resultArchive.setDocumentXml(newDocumentXml);
-
-  // Step 12a: Ship relationships for inserted/retargeted hyperlinks whose r:id
-  // the rebuild reconstructor re-mapped into the original-based package (#376).
-  await appendHyperlinkRelationships(resultArchive, comparisonResult.hyperlinkRelationships);
-
-  // Step 12b: Merge auxiliary part definitions (footnotes, endnotes, comments).
-  // Reconstruction may insert content (deleted in inplace, added in rebuild)
-  // whose definitions are missing from the base archive.
-  for (const descriptor of AUXILIARY_PARTS) {
-    await mergeAuxiliaryPartDefinitions(
-      mergeSourceArchive, resultArchive, newDocumentXml, descriptor
-    );
-  }
-  // Comment-specific post-pass: walk reply threads via commentsExtended.xml.
-  // Gated on root comment IDs in the *result* document (not on what the
-  // generic merge appended), so the pass runs even when the original already
-  // contains the root and revised only adds replies under it (issue #108).
-  // Comments anchored on footnote/endnote text count as roots too.
-  const rootCommentIds = await collectStoryReferenceIds(
-    resultArchive, newDocumentXml, 'w:commentReference', null
-  );
-  if (rootCommentIds.size > 0) {
-    await mergeCommentAncillaryParts(mergeSourceArchive, resultArchive, rootCommentIds);
-  }
-
-  // Step 13: Save result and compute stats
-  const resultBuffer = await resultArchive.save();
+  const { resultBuffer, ancillaryFieldEvidence } = assembled;
   const stats = computeAtomizerStats(mergedAtoms);
   const documentIntegrity = leanXmlVerifier?.enabled
     ? await runLeanXmlTripleVerifier({
@@ -1034,8 +1060,10 @@ export async function compareDocumentsAtomizer(
     reconstructionModeUsed: comparisonResult.outputMode,
     fallbackReason,
     fallbackDiagnostics,
+    ancillaryFallbackDiagnostics,
     rebuildSafetyDiagnostics,
     inplaceSuccessDiagnostics,
+    ancillaryFieldEvidence,
     documentIntegrity,
   };
 }
@@ -1116,18 +1144,19 @@ async function mergeAuxiliaryPartDefinitions(
   );
   if (referencedIds.size === 0) return result;
 
+  const resultPartXml = await resultArchive.getFile(descriptor.partPath);
+  const resultParsed = resultPartXml ? parseEntries(resultPartXml, descriptor.entryTag) : null;
+  const missingIds = [...referencedIds].filter((id) => !resultParsed?.entries.has(id));
+  if (missingIds.length === 0) return result;
+
   const sourcePartXml = await sourceArchive.getFile(descriptor.partPath);
   if (!sourcePartXml) return result;
-
-  const resultPartXml = await resultArchive.getFile(descriptor.partPath);
-
   const sourceParsed = parseEntries(sourcePartXml, descriptor.entryTag);
-  const resultParsed = resultPartXml ? parseEntries(resultPartXml, descriptor.entryTag) : null;
 
   // Find missing entries: referenced in document.xml but not in result
   const missingElements: Element[] = [];
-  for (const id of referencedIds) {
-    if (!(resultParsed?.entries.has(id)) && sourceParsed.entries.has(id)) {
+  for (const id of missingIds) {
+    if (sourceParsed.entries.has(id)) {
       missingElements.push(sourceParsed.entries.get(id)!);
       result.mergedIds.add(id);
     }

--- a/packages/docx-compare/src/compare-types.ts
+++ b/packages/docx-compare/src/compare-types.ts
@@ -75,7 +75,9 @@ export interface CompareStats {
 
 export type ReconstructionMode = 'rebuild' | 'inplace';
 
-export type ReconstructionFallbackReason = 'round_trip_safety_check_failed';
+export type ReconstructionFallbackReason =
+  | 'round_trip_safety_check_failed'
+  | 'ancillary_story_safety_check_failed';
 
 export interface LeanXmlVerifierOptions {
   /**
@@ -233,6 +235,100 @@ export interface ReconstructionRebuildSafetyDiagnostics {
   firstDiffSummary?: ReconstructionSafetyFailureSummary;
 }
 
+export type AncillaryStorySafetyCategory =
+  | 'binding_resolution'
+  | 'strict_field_structure'
+  | 'canonical_evidence';
+
+export interface AncillaryBindingLocator {
+  locatorType: 'section_binding';
+  sectionOrdinal: number;
+  kind: 'header' | 'footer';
+  role: 'default' | 'first' | 'even';
+  normalizedPartPath?: string;
+}
+
+export interface AncillaryHeaderFooterStoryLocator {
+  locatorType: 'header_footer_story';
+  normalizedPartPath: string;
+  selectingBindings: AncillaryBindingLocator[];
+}
+
+export interface AncillaryNoteStoryLocator {
+  locatorType: 'note_entry';
+  normalizedPartPath: 'word/footnotes.xml' | 'word/endnotes.xml';
+  entryId: string;
+  sourceSide?: 'original' | 'revised';
+}
+
+export interface AncillaryPackageLocator {
+  locatorType: 'package_part';
+  normalizedPartPath: string;
+}
+
+export interface AncillaryFieldLocator {
+  locatorType: 'field_range';
+  normalizedPartPath: string;
+  entryId?: string;
+  paragraphOrdinal: number;
+  eligibleFieldOrdinal: number;
+  instructionKind: AncillaryFieldInstructionKind;
+}
+
+export type AncillaryStoryLocator =
+  | AncillaryBindingLocator
+  | AncillaryHeaderFooterStoryLocator
+  | AncillaryNoteStoryLocator
+  | AncillaryPackageLocator
+  | AncillaryFieldLocator;
+
+export interface AncillaryStorySafetyIssue {
+  category: AncillaryStorySafetyCategory;
+  code: string;
+  detail: string;
+  locator: AncillaryStoryLocator;
+}
+
+export interface AncillaryFallbackDiagnostics {
+  issues: AncillaryStorySafetyIssue[];
+}
+
+export type AncillaryFieldInstructionKind = 'PAGE' | 'NUMPAGES' | 'REF' | 'PAGEREF';
+
+export interface AncillarySelectedBindingSummary {
+  sectionOrdinal: number;
+  kind: 'header' | 'footer';
+  role: 'default' | 'first' | 'even';
+  relationshipId: string;
+  normalizedPartPath: string;
+}
+
+export interface AncillaryStorySummary {
+  storyKind: 'header' | 'footer' | 'footnote' | 'endnote';
+  normalizedPartPath: string;
+  entryId?: string;
+  selectingBindings?: AncillaryBindingLocator[];
+  sourceSide?: 'original' | 'revised';
+  provenance?: 'base' | 'imported';
+  strictFieldStructure: 'passed';
+}
+
+export interface AncillaryFieldRangeEvidence {
+  locator: AncillaryFieldLocator;
+  instructionKind: AncillaryFieldInstructionKind;
+  sourceSide: 'original' | 'revised';
+  provenance: 'base' | 'imported';
+  canonicalMatch: true;
+}
+
+export interface AncillaryFieldEvidence {
+  status: 'passed';
+  reconstructionMode: ReconstructionMode;
+  selectedBindings: AncillarySelectedBindingSummary[];
+  stories: AncillaryStorySummary[];
+  ranges: AncillaryFieldRangeEvidence[];
+}
+
 export type DocumentIntegrityCertificateStatus =
   | 'passed'
   | 'failed'
@@ -342,6 +438,11 @@ export interface CompareResult {
    */
   fallbackDiagnostics?: ReconstructionFallbackDiagnostics;
   /**
+   * Ancillary issues from an inplace candidate rejected at package assembly.
+   * Present only when ancillary validation itself caused rebuild fallback.
+   */
+  ancillaryFallbackDiagnostics?: AncillaryFallbackDiagnostics;
+  /**
    * Safety-check failures observed on rebuild output — whether rebuild was
    * requested explicitly (the default mode) or reached via inplace fallback.
    * Present only when at least one check failed.
@@ -352,6 +453,11 @@ export interface CompareResult {
    * Present only when atomizer produced inplace output.
    */
   inplaceSuccessDiagnostics?: ReconstructionInplaceSuccessDiagnostics;
+  /**
+   * Successful structural and canonical evidence for the final assembled
+   * ancillary stories. Absence means unavailable evidence, not a pass.
+   */
+  ancillaryFieldEvidence?: AncillaryFieldEvidence;
   /**
    * Optional per-document integrity certificate from the separately compiled
    * Lean XML triple verifier. Present only when `leanXmlVerifier.enabled` is set.

--- a/packages/docx-compare/src/index.ts
+++ b/packages/docx-compare/src/index.ts
@@ -12,6 +12,20 @@ export type {
   CompareOptions,
   CompareResult,
   CompareStats,
+  AncillaryBindingLocator,
+  AncillaryFallbackDiagnostics,
+  AncillaryFieldEvidence,
+  AncillaryFieldInstructionKind,
+  AncillaryFieldLocator,
+  AncillaryFieldRangeEvidence,
+  AncillaryHeaderFooterStoryLocator,
+  AncillaryNoteStoryLocator,
+  AncillaryPackageLocator,
+  AncillarySelectedBindingSummary,
+  AncillaryStoryLocator,
+  AncillaryStorySafetyCategory,
+  AncillaryStorySafetyIssue,
+  AncillaryStorySummary,
   DocumentIntegrityCertificate,
   DocumentIntegrityCertificateStatus,
   DocumentIntegrityCheckCertificate,
@@ -92,5 +106,6 @@ export {
   compareDocumentsAtomizer,
 } from './baselines/atomizer/pipeline.js';
 export { parseDocumentXml } from './baselines/atomizer/xmlToWmlElement.js';
+export { AncillaryStorySafetyError } from './baselines/atomizer/ancillaryFieldSafety.js';
 export { computeAtomLcs, markCorrelationStatus } from './baselines/atomizer/atomLcs.js';
 export { compareDocumentsBaselineB } from './baselines/diffmatch/pipeline.js';

--- a/packages/docx-core/src/generation/generation-sections-fields.test.ts
+++ b/packages/docx-core/src/generation/generation-sections-fields.test.ts
@@ -99,6 +99,14 @@ describe('Traceability: multi-section documents, headers/footers, and fields', (
         ]));
         expect(result.ok, JSON.stringify(result.issues)).toBe(true);
         expect(result.stats.referenceCount).toBe(1);
+        expect(result.bindings).toEqual([{
+          sectionOrdinal: 0,
+          kind: 'header',
+          role: 'default',
+          rid: 'rId1',
+          targetPath: 'word/header1.xml',
+          path: 'wp:document[1]/wp:body[1]/wp:sectPr[1]/wp:headerReference[1]',
+        }]);
       });
 
       await then('prefixed package relationships are matched by namespace URI and local name', () => {
@@ -155,7 +163,21 @@ describe('Traceability: multi-section documents, headers/footers, and fields', (
             .replace('Target="header1.xml"', 'Target="https://example.test/story.xml" TargetMode="External"');
           const result = auditSectPr(referenceDocument, externalRelationships);
           expect(result.issues).toEqual(
-            expect.arrayContaining([expect.objectContaining({ type: 'sectpr_reference_wrong_relationship_type', rid: 'rId1' })]),
+            expect.arrayContaining([expect.objectContaining({ type: 'sectpr_reference_external_target', rid: 'rId1' })]),
+          );
+        }
+      });
+
+      await then('invalid TargetMode values are rejected rather than treated as internal', () => {
+        for (const mode of ['', 'internal', 'EXTERNAL']) {
+          const invalidModeRelationships = relationships.replace(
+            'Target="header1.xml"',
+            `Target="header1.xml" TargetMode="${mode}"`,
+          );
+          expect(auditSectPr(documentXml, invalidModeRelationships).issues).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({ type: 'sectpr_reference_invalid_target_mode' }),
+            ]),
           );
         }
       });
@@ -177,6 +199,7 @@ describe('Traceability: multi-section documents, headers/footers, and fields', (
         expect(result.issues.filter((issue) => issue.type === 'sectpr_duplicate_relationship_id')).toEqual([
           expect.objectContaining({ rid: 'rId1' }),
         ]);
+        expect(result.bindings).toEqual([]);
 
         const reversed = duplicateRelationships.replace(
           /(<Relationship Id="rId1"[^>]+\/>)(<Relationship Id="rId1"[^>]+\/>)/,
@@ -198,6 +221,17 @@ describe('Traceability: multi-section documents, headers/footers, and fields', (
               expect.objectContaining({ type: 'sectpr_duplicate_reference_type' }),
             ]),
           );
+          const kindRelationships = relationships
+            .replace(`${r}/header`, `${r}/${kind}`)
+            .replace('header1.xml', `${kind}1.xml`);
+          expect(auditSectPr(
+            duplicateDocument,
+            kindRelationships,
+            new Map([[
+              `word/${kind}1.xml`,
+              `<wp:${kind === 'header' ? 'hdr' : 'ftr'} xmlns:wp="${w}"/>`,
+            ]]),
+          ).bindings).toHaveLength(1);
         }
       });
 
@@ -222,6 +256,46 @@ describe('Traceability: multi-section documents, headers/footers, and fields', (
         expect(result.issues).toEqual(
           expect.arrayContaining([expect.objectContaining({ type: 'sectpr_reference_invalid_target' })]),
         );
+      });
+
+      await then('ambiguous URI and encoded path forms are rejected', () => {
+        for (const target of [
+          '',
+          'header1.xml?query',
+          'header1.xml#fragment',
+          'headers\\header1.xml',
+          'https:header1.xml',
+          '//server/header1.xml',
+          '%2e%2e/header1.xml',
+          'headers%2fheader1.xml',
+        ]) {
+          const unsafeRelationships = relationships.replace('header1.xml', target);
+          expect(auditSectPr(documentXml, unsafeRelationships).issues).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({ type: 'sectpr_reference_invalid_target' }),
+            ]),
+          );
+        }
+      });
+
+      await then('header and footer references nested below sectPr are rejected by placement', () => {
+        const nestedDocument = documentXml.replace(
+          '<wp:headerReference wp:type="default" rel:id="rId1"/>',
+          '<wp:extLst><wp:headerReference wp:type="default" rel:id="rId1"/></wp:extLst>',
+        );
+        const result = auditSectPr(nestedDocument, relationships);
+        expect(result.issues).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              type: 'sectpr_reference_invalid_placement',
+              sectionOrdinal: 0,
+              kind: 'header',
+              role: 'default',
+            }),
+          ]),
+        );
+        expect(result.bindings).toEqual([]);
+        expect(result.stats.referenceCount).toBe(1);
       });
     },
   );

--- a/packages/docx-core/src/integration/ancillary-field-safety.test.ts
+++ b/packages/docx-core/src/integration/ancillary-field-safety.test.ts
@@ -1,0 +1,501 @@
+import { describe, expect } from 'vitest';
+import {
+  AncillaryStorySafetyError,
+  compareDocuments,
+  type AncillaryFieldRangeEvidence,
+} from '@usejunior/docx-compare';
+import {
+  COMPLETE_NUMPAGES_FIELD,
+  COMPLETE_PAGE_FIELD,
+  COMPLETE_PAGEREF_FIELD,
+  COMPLETE_REF_FIELD,
+  buildDocxWithAncillaryParts,
+  paragraphWithText,
+  type AncillaryPartFixture,
+} from '../testing/ooxml-fixtures.js';
+import { testAllure } from '../testing/allure-test.js';
+
+const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const REL_BASE = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const HEADER_CONTENT_TYPE =
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml';
+const FOOTER_CONTENT_TYPE =
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.footer+xml';
+const FOOTNOTES_CONTENT_TYPE =
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.footnotes+xml';
+const ENDNOTES_CONTENT_TYPE =
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.endnotes+xml';
+
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({ feature: 'Ancillary Field Story Safety' });
+
+function footerXml(field: string): string {
+  return `<w:ftr xmlns:w="${W_NS}"><w:p>${field}</w:p></w:ftr>`;
+}
+
+function notePartXml(
+  kind: 'footnote' | 'endnote',
+  entries: readonly { id: string; content: string }[],
+): string {
+  const root = `${kind}s`;
+  return (
+    `<w:${root} xmlns:w="${W_NS}">` +
+    entries.map(({ id, content }) =>
+      `<w:${kind} w:id="${id}"><w:p>${content}</w:p></w:${kind}>`,
+    ).join('') +
+    `</w:${root}>`
+  );
+}
+
+function noteReference(kind: 'footnote' | 'endnote', id: string): string {
+  return `<w:p><w:r><w:t>Clause</w:t><w:${kind}Reference w:id="${id}"/></w:r></w:p>`;
+}
+
+interface PackageOptions {
+  text: string;
+  header?: string;
+  footer?: string;
+  footnotes?: string;
+  endnotes?: string;
+  extraParts?: readonly AncillaryPartFixture[];
+  footerRelationshipType?: string;
+  bodyXml?: string;
+}
+
+async function buildPackage(options: PackageOptions): Promise<Buffer> {
+  const parts: AncillaryPartFixture[] = [...(options.extraParts ?? [])];
+  const relationships = [];
+  const sectionReferences: string[] = [];
+
+  if (options.header) {
+    parts.push({
+      path: 'word/header1.xml',
+      contentType: HEADER_CONTENT_TYPE,
+      xml: options.header,
+    });
+    relationships.push({
+      id: 'rIdHeader',
+      type: `${REL_BASE}/header`,
+      target: 'header1.xml',
+    });
+    sectionReferences.push(
+      '<w:headerReference w:type="default" r:id="rIdHeader"/>',
+    );
+  }
+  if (options.footer) {
+    parts.push({
+      path: 'word/footer1.xml',
+      contentType: FOOTER_CONTENT_TYPE,
+      xml: options.footer,
+    });
+    relationships.push({
+      id: 'rIdFooter',
+      type: options.footerRelationshipType ?? `${REL_BASE}/footer`,
+      target: 'footer1.xml',
+    });
+    sectionReferences.push(
+      '<w:footerReference w:type="default" r:id="rIdFooter"/>',
+    );
+  }
+  if (options.footnotes) {
+    parts.push({
+      path: 'word/footnotes.xml',
+      contentType: FOOTNOTES_CONTENT_TYPE,
+      xml: options.footnotes,
+    });
+    relationships.push({
+      id: 'rIdFootnotes',
+      type: `${REL_BASE}/footnotes`,
+      target: 'footnotes.xml',
+    });
+  }
+  if (options.endnotes) {
+    parts.push({
+      path: 'word/endnotes.xml',
+      contentType: ENDNOTES_CONTENT_TYPE,
+      xml: options.endnotes,
+    });
+    relationships.push({
+      id: 'rIdEndnotes',
+      type: `${REL_BASE}/endnotes`,
+      target: 'endnotes.xml',
+    });
+  }
+
+  return buildDocxWithAncillaryParts({
+    bodyXml: options.bodyXml ?? paragraphWithText(options.text),
+    sectPrXml: `<w:sectPr>${sectionReferences.join('')}</w:sectPr>`,
+    relationships,
+    parts,
+  });
+}
+
+function evidenceRanges(
+  result: Awaited<ReturnType<typeof compareDocuments>>,
+): AncillaryFieldRangeEvidence[] {
+  expect(result.ancillaryFieldEvidence?.status).toBe('passed');
+  expect(result.ancillaryFieldEvidence?.reconstructionMode)
+    .toBe(result.reconstructionModeUsed);
+  return result.ancillaryFieldEvidence!.ranges;
+}
+
+describe('ancillary field story publication boundary', () => {
+  test
+    .openspec('[SDX-ANC-STORY-01] Valid section bindings select header and footer targets')
+    .openspec('[SDX-ANC-STORY-04] Invalid selected bindings fail and unreferenced malformed parts do not')(
+    '[SDX-ANC-PACKAGE-01] relationship-selected stories satisfy the canonical-range metamorphic invariant',
+    async () => {
+      testAllure.conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.10.5' });
+      testAllure.conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.10.2' });
+      testAllure.conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.16.18' });
+      testAllure.conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.16.5.44' });
+      testAllure.conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.16.5.42' });
+      testAllure.conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.16.5.51' });
+      testAllure.conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.16.5.45' });
+      const footnotes = notePartXml('footnote', [
+        { id: '1', content: COMPLETE_REF_FIELD + COMPLETE_PAGEREF_FIELD },
+      ]);
+      const original = await buildPackage({
+        text: 'Original',
+        header: `<w:hdr xmlns:w="${W_NS}"><w:p>${COMPLETE_NUMPAGES_FIELD}</w:p></w:hdr>`,
+        footer: footerXml(COMPLETE_PAGE_FIELD + COMPLETE_NUMPAGES_FIELD),
+        footnotes,
+        bodyXml: noteReference('footnote', '1') + paragraphWithText('Original'),
+        extraParts: [{
+          path: 'word/header-unreferenced.xml',
+          contentType:
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml',
+          xml: `<w:hdr xmlns:w="${W_NS}"><w:p><w:r><w:fldChar w:fldCharType="end"/></w:r></w:p>`,
+        }],
+      });
+      const revised = await buildPackage({
+        text: 'Revised',
+        header: `<w:hdr xmlns:w="${W_NS}"><w:p>${COMPLETE_NUMPAGES_FIELD}</w:p></w:hdr>`,
+        footer: footerXml(COMPLETE_PAGE_FIELD + COMPLETE_NUMPAGES_FIELD),
+        footnotes,
+        bodyXml: noteReference('footnote', '1') + paragraphWithText('Revised'),
+        extraParts: [{
+          path: 'word/header-unreferenced.xml',
+          contentType:
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml',
+          xml: `<w:hdr xmlns:w="${W_NS}"><w:p><w:r><w:fldChar w:fldCharType="end"/></w:r></w:p>`,
+        }],
+      });
+
+      const result = await compareDocuments(original, revised, {
+        engine: 'atomizer',
+        reconstructionMode: 'inplace',
+      });
+      const ranges = evidenceRanges(result);
+
+      expect(result.reconstructionModeUsed).toBe('inplace');
+      expect(result.ancillaryFieldEvidence?.selectedBindings).toEqual([
+        {
+          sectionOrdinal: 0,
+          kind: 'header',
+          role: 'default',
+          relationshipId: 'rIdHeader',
+          normalizedPartPath: 'word/header1.xml',
+        },
+        {
+          sectionOrdinal: 0,
+          kind: 'footer',
+          role: 'default',
+          relationshipId: 'rIdFooter',
+          normalizedPartPath: 'word/footer1.xml',
+        },
+      ]);
+      expect(ranges.map((range) => range.instructionKind)).toEqual([
+        'PAGE',
+        'NUMPAGES',
+        'NUMPAGES',
+        'REF',
+        'PAGEREF',
+      ]);
+      expect(ranges.every((range) =>
+        range.canonicalMatch &&
+        range.provenance === 'base' &&
+        range.sourceSide === 'revised',
+      )).toBe(true);
+    },
+  );
+
+  test
+    .openspec('[SDX-ANC-FAIL-01] Ancillary failure itself triggers inplace fallback')
+    .openspec('[SDX-ANC-FAIL-02] Successful fallback recomputes all ancillary evidence')(
+    '[SDX-ANC-PACKAGE-02] selected malformed inplace story causes one rebuild fallback',
+    async () => {
+      testAllure.conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.16.18' });
+      const original = await buildPackage({
+        text: 'Original',
+        footer: footerXml(COMPLETE_PAGE_FIELD),
+      });
+      const revised = await buildPackage({
+        text: 'Revised',
+        footer: footerXml(
+          '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' + COMPLETE_PAGE_FIELD,
+        ),
+      });
+
+      const result = await compareDocuments(original, revised, {
+        engine: 'atomizer',
+        reconstructionMode: 'inplace',
+      });
+
+      expect(result.reconstructionModeUsed).toBe('rebuild');
+      expect(result.fallbackReason).toBe('ancillary_story_safety_check_failed');
+      expect(result.ancillaryFallbackDiagnostics?.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            category: 'strict_field_structure',
+            code: 'FIELD_STRAY_SEPARATOR',
+            locator: expect.objectContaining({
+              locatorType: 'header_footer_story',
+              normalizedPartPath: 'word/footer1.xml',
+            }),
+          }),
+        ]),
+      );
+      expect(result.fallbackDiagnostics).toBeUndefined();
+      expect(result.inplaceSuccessDiagnostics).toBeUndefined();
+      expect(evidenceRanges(result)).toEqual([
+        expect.objectContaining({
+          instructionKind: 'PAGE',
+          sourceSide: 'original',
+          provenance: 'base',
+          canonicalMatch: true,
+        }),
+      ]);
+    },
+  );
+
+  test.openspec('[SDX-ANC-FAIL-03] Terminal ancillary failure throws a typed error')(
+    '[SDX-ANC-PACKAGE-03] forced rebuild selected-story failure throws a typed error',
+    async () => {
+      testAllure.conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.16.18' });
+      const malformed =
+        '<w:r><w:fldChar w:fldCharType="mystery"/></w:r>' + COMPLETE_PAGE_FIELD;
+      const original = await buildPackage({
+        text: 'Original',
+        footer: footerXml(malformed),
+      });
+      const revised = await buildPackage({
+        text: 'Revised',
+        footer: footerXml(COMPLETE_PAGE_FIELD),
+      });
+
+      await expect(compareDocuments(original, revised, {
+        engine: 'atomizer',
+        reconstructionMode: 'rebuild',
+      })).rejects.toMatchObject({
+        name: 'AncillaryStorySafetyError',
+        issues: expect.arrayContaining([
+          expect.objectContaining({ code: 'FIELD_UNKNOWN_CHAR_TYPE' }),
+        ]),
+      });
+    },
+  );
+
+  test.openspec('[SDX-ANC-EVIDENCE-02] Duplicate direct note IDs are rejected before mapping')(
+    '[SDX-ANC-PACKAGE-04] duplicate direct note IDs reject before provenance mapping',
+    async () => {
+      const duplicateFootnotes = notePartXml('footnote', [
+        { id: '1', content: COMPLETE_REF_FIELD },
+        { id: '01', content: COMPLETE_PAGEREF_FIELD },
+      ]);
+      const original = await buildPackage({
+        text: 'Original',
+        footnotes: duplicateFootnotes,
+        bodyXml: noteReference('footnote', '1'),
+      });
+      const revised = await buildPackage({
+        text: 'Revised',
+        footnotes: notePartXml('footnote', [{ id: '1', content: COMPLETE_REF_FIELD }]),
+        bodyXml: noteReference('footnote', '1') + paragraphWithText('Revised'),
+      });
+
+      const rejection = compareDocuments(original, revised, {
+        engine: 'atomizer',
+        reconstructionMode: 'rebuild',
+      });
+      await expect(rejection).rejects.toBeInstanceOf(AncillaryStorySafetyError);
+      await expect(rejection).rejects.toMatchObject({
+        issues: expect.arrayContaining([
+          expect.objectContaining({
+            category: 'canonical_evidence',
+            code: 'DUPLICATE_NOTE_ENTRY_ID',
+            locator: expect.objectContaining({
+              locatorType: 'note_entry',
+              normalizedPartPath: 'word/footnotes.xml',
+              entryId: '1',
+              sourceSide: 'original',
+            }),
+          }),
+        ]),
+      });
+    },
+  );
+
+  test.openspec('[SDX-ANC-STORY-04] Invalid selected bindings fail and unreferenced malformed parts do not')(
+    '[SDX-ANC-PACKAGE-05] exact binding type is required at the publication boundary',
+    async () => {
+      testAllure.conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.10.4' });
+      const original = await buildPackage({
+        text: 'Original',
+        footer: footerXml(COMPLETE_PAGE_FIELD),
+        footerRelationshipType: `${REL_BASE}/header`,
+      });
+      const revised = await buildPackage({
+        text: 'Revised',
+        footer: footerXml(COMPLETE_PAGE_FIELD),
+      });
+
+      await expect(compareDocuments(original, revised, {
+        engine: 'atomizer',
+        reconstructionMode: 'rebuild',
+      })).rejects.toMatchObject({
+        name: 'AncillaryStorySafetyError',
+        issues: expect.arrayContaining([
+          expect.objectContaining({
+            category: 'binding_resolution',
+            code: 'sectpr_reference_wrong_relationship_type',
+          }),
+        ]),
+      });
+    },
+  );
+
+  test.openspec('[SDX-ANC-EVIDENCE-03] Note evidence follows actual assembly provenance')(
+    '[SDX-ANC-PACKAGE-06] collision-renumbered imported note ranges retain provenance',
+    async () => {
+      const original = await buildPackage({
+        text: 'Original',
+        footnotes: notePartXml('footnote', [{ id: '1', content: COMPLETE_REF_FIELD }]),
+        bodyXml: noteReference('footnote', '1') + paragraphWithText('Original'),
+      });
+      const revised = await buildPackage({
+        text: 'Revised',
+        footnotes: notePartXml('footnote', [{ id: '1', content: COMPLETE_PAGEREF_FIELD }]),
+        bodyXml: noteReference('footnote', '1') + paragraphWithText('Revised'),
+      });
+
+      const result = await compareDocuments(original, revised, {
+        engine: 'atomizer',
+        reconstructionMode: 'rebuild',
+      });
+      const ranges = evidenceRanges(result);
+      const base = ranges.find((range) => range.instructionKind === 'REF');
+      const imported = ranges.find((range) => range.instructionKind === 'PAGEREF');
+
+      expect(base).toMatchObject({
+        provenance: 'base',
+        sourceSide: 'original',
+        locator: { entryId: '1' },
+      });
+      expect(imported).toMatchObject({
+        provenance: 'imported',
+        sourceSide: 'revised',
+        canonicalMatch: true,
+      });
+      expect(imported?.locator.entryId).not.toBe('1');
+    },
+  );
+
+  test.openspec('[SDX-ANC-EVIDENCE-04] Created parts and collision outcomes have defined provenance')(
+    '[SDX-ANC-PACKAGE-07] identical same-ID note definitions remain base provenance',
+    async () => {
+      const notes = notePartXml('endnote', [{ id: '2', content: COMPLETE_REF_FIELD }]);
+      const original = await buildPackage({
+        text: 'Original',
+        endnotes: notes,
+        bodyXml: noteReference('endnote', '2') + paragraphWithText('Original'),
+      });
+      const revised = await buildPackage({
+        text: 'Revised',
+        endnotes: notes,
+        bodyXml: noteReference('endnote', '2') + paragraphWithText('Revised'),
+      });
+
+      const result = await compareDocuments(original, revised, {
+        engine: 'atomizer',
+        reconstructionMode: 'rebuild',
+      });
+      expect(evidenceRanges(result)).toEqual([
+        expect.objectContaining({
+          instructionKind: 'REF',
+          provenance: 'base',
+          sourceSide: 'original',
+          locator: expect.objectContaining({
+            normalizedPartPath: 'word/endnotes.xml',
+            entryId: '2',
+          }),
+        }),
+      ]);
+    },
+  );
+
+  test.openspec('[SDX-ANC-FAIL-03] Terminal ancillary failure throws a typed error')(
+    '[SDX-ANC-PACKAGE-08] terminal rebuild fallback failure returns no comparison result',
+    async () => {
+      const original = await buildPackage({
+        text: 'Original',
+        footer: footerXml(
+          '<w:r><w:fldChar w:fldCharType="end"/></w:r>' + COMPLETE_PAGE_FIELD,
+        ),
+      });
+      const revised = await buildPackage({
+        text: 'Revised',
+        footer: footerXml(
+          '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' + COMPLETE_PAGE_FIELD,
+        ),
+      });
+
+      await expect(compareDocuments(original, revised, {
+        engine: 'atomizer',
+        reconstructionMode: 'inplace',
+      })).rejects.toMatchObject({
+        name: 'AncillaryStorySafetyError',
+        issues: expect.arrayContaining([
+          expect.objectContaining({ code: 'FIELD_STRAY_END' }),
+        ]),
+      });
+    },
+  );
+
+  test
+    .openspec('[SDX-ANC-EVIDENCE-03] Note evidence follows actual assembly provenance')
+    .openspec('[SDX-ANC-EVIDENCE-06] Unused merge-source defects do not poison evidence')(
+    '[SDX-ANC-PACKAGE-09] unused malformed merge-source note part does not poison rebuild',
+    async () => {
+      const validFootnotes = notePartXml('footnote', [
+        { id: '1', content: COMPLETE_REF_FIELD },
+      ]);
+      const original = await buildPackage({
+        text: 'Original',
+        footnotes: validFootnotes,
+        bodyXml: noteReference('footnote', '1') + paragraphWithText('Original'),
+      });
+      const revised = await buildPackage({
+        text: 'Revised',
+        footnotes: `<w:footnotes xmlns:w="${W_NS}"><w:footnote w:id="9">`,
+        bodyXml: noteReference('footnote', '1') + paragraphWithText('Revised'),
+      });
+
+      const result = await compareDocuments(original, revised, {
+        engine: 'atomizer',
+        reconstructionMode: 'rebuild',
+      });
+
+      expect(result.reconstructionModeUsed).toBe('rebuild');
+      expect(evidenceRanges(result)).toEqual([
+        expect.objectContaining({
+          instructionKind: 'REF',
+          sourceSide: 'original',
+          provenance: 'base',
+          locator: expect.objectContaining({ entryId: '1' }),
+        }),
+      ]);
+    },
+  );
+});

--- a/packages/docx-core/src/integration/ancillary-field-safety.test.ts
+++ b/packages/docx-core/src/integration/ancillary-field-safety.test.ts
@@ -15,6 +15,7 @@ import {
 } from '../testing/ooxml-fixtures.js';
 import { testAllure } from '../testing/allure-test.js';
 
+const TEST_FEATURE = 'verify-ancillary-field-stories';
 const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const REL_BASE = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
 const HEADER_CONTENT_TYPE =

--- a/packages/docx-core/src/integration/ancillary-field-safety.test.ts
+++ b/packages/docx-core/src/integration/ancillary-field-safety.test.ts
@@ -29,7 +29,7 @@ const ENDNOTES_CONTENT_TYPE =
 
 const test = testAllure
   .epic('Document Comparison')
-  .withLabels({ feature: 'Ancillary Field Story Safety' });
+  .withLabels({ feature: TEST_FEATURE });
 
 function footerXml(field: string): string {
   return `<w:ftr xmlns:w="${W_NS}"><w:p>${field}</w:p></w:ftr>`;

--- a/packages/docx-core/src/integration/field-cross-story-pipeline.test.ts
+++ b/packages/docx-core/src/integration/field-cross-story-pipeline.test.ts
@@ -12,7 +12,7 @@
 import { describe, expect } from 'vitest';
 import JSZip from 'jszip';
 import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
-import { compareDocuments } from '@usejunior/docx-compare';
+import { AncillaryStorySafetyError, compareDocuments } from '@usejunior/docx-compare';
 
 const TEST_FEATURE = 'Cross-story Field Closure (#212)';
 const test = testAllure
@@ -129,11 +129,11 @@ const END_ONLY_FIELD_FOOTNOTE_BODY =
 
 describe('Cross-story field-closure check (issue #212) — pipeline-level', () => {
   test(
-    'inplace comparison with a malformed field inside a footnote falls back to rebuild via fieldStructure failure',
-    async ({ given, when, then, and, attachPrettyJson }: AllureBddContext) => {
+    'inplace comparison with a malformed field inside a footnote rejects the terminal rebuild',
+    async ({ given, when, then }: AllureBddContext) => {
       let original: Buffer = Buffer.alloc(0);
       let revised: Buffer = Buffer.alloc(0);
-      let result: Awaited<ReturnType<typeof compareDocuments>>;
+      let rejection: Promise<Awaited<ReturnType<typeof compareDocuments>>>;
 
       await given(
         'original/revised pair whose footnotes sidecar contains a fldChar begin with no matching end',
@@ -151,42 +151,36 @@ describe('Cross-story field-closure check (issue #212) — pipeline-level', () =
       );
 
       await when('compared in inplace mode', async () => {
-        result = await compareDocuments(original, revised, {
+        rejection = compareDocuments(original, revised, {
           engine: 'atomizer',
           reconstructionMode: 'inplace',
         });
-        await attachPrettyJson('comparison-metadata.json', {
-          reconstructionModeUsed: result.reconstructionModeUsed,
-          fallbackReason: result.fallbackReason,
-          fallbackDiagnostics: result.fallbackDiagnostics,
+      });
+
+      await then('the rebuilt candidate fails closed with structured ancillary diagnostics', async () => {
+        await expect(rejection).rejects.toBeInstanceOf(AncillaryStorySafetyError);
+        await expect(rejection).rejects.toMatchObject({
+          issues: expect.arrayContaining([
+            expect.objectContaining({
+              code: 'FIELD_UNCLOSED_DEPTH',
+              locator: expect.objectContaining({
+                locatorType: 'note_entry',
+                normalizedPartPath: 'word/footnotes.xml',
+                entryId: '1',
+              }),
+            }),
+          ]),
         });
-      });
-
-      await then('every inplace attempt records fieldStructure as failed', () => {
-        const attempts = result.fallbackDiagnostics?.attempts ?? [];
-        expect(attempts.length, 'at least one inplace attempt should be diagnosed').toBeGreaterThan(0);
-        for (const attempt of attempts) {
-          const failed = attempt.failedChecks ?? [];
-          expect(
-            failed.includes('fieldStructure'),
-            `attempt ${attempt.pass} should report fieldStructure failure but failed=${JSON.stringify(failed)}`,
-          ).toBe(true);
-        }
-      });
-
-      await and('the pipeline falls back to rebuild output', () => {
-        expect(result.reconstructionModeUsed).toBe('rebuild');
-        expect(result.fallbackReason).toBe('round_trip_safety_check_failed');
       });
     },
   );
 
   test.openspec('Rebuild fallback only after all inplace passes fail')(
     'globally-balanced but per-story-unbalanced field across body and footnote is rejected',
-    async ({ given, when, then, and, attachPrettyJson }: AllureBddContext) => {
+    async ({ given, when, then }: AllureBddContext) => {
       let original: Buffer = Buffer.alloc(0);
       let revised: Buffer = Buffer.alloc(0);
-      let result: Awaited<ReturnType<typeof compareDocuments>>;
+      let rejection: Promise<Awaited<ReturnType<typeof compareDocuments>>>;
 
       await given(
         'a docx whose body opens a field that never closes and ONE archive has a footnote with a stray end',
@@ -217,32 +211,30 @@ describe('Cross-story field-closure check (issue #212) — pipeline-level', () =
       );
 
       await when('compared in inplace mode', async () => {
-        result = await compareDocuments(original, revised, {
+        rejection = compareDocuments(original, revised, {
           engine: 'atomizer',
           reconstructionMode: 'inplace',
         });
-        await attachPrettyJson('comparison-metadata.json', {
-          reconstructionModeUsed: result.reconstructionModeUsed,
-          fallbackReason: result.fallbackReason,
-          fallbackDiagnostics: result.fallbackDiagnostics,
+      });
+
+      await then('the original-based terminal rebuild rejects the malformed note entry', async () => {
+        await expect(rejection).rejects.toBeInstanceOf(AncillaryStorySafetyError);
+        await expect(rejection).rejects.toMatchObject({
+          issues: expect.arrayContaining([
+            expect.objectContaining({
+              code: 'FIELD_STRAY_SEPARATOR',
+              locator: expect.objectContaining({
+                locatorType: 'note_entry',
+                normalizedPartPath: 'word/footnotes.xml',
+                entryId: '1',
+              }),
+            }),
+            expect.objectContaining({
+              code: 'FIELD_STRAY_END',
+              locator: expect.objectContaining({ entryId: '1' }),
+            }),
+          ]),
         });
-      });
-
-      await then('every inplace attempt records fieldStructure as failed', () => {
-        const attempts = result.fallbackDiagnostics?.attempts ?? [];
-        expect(attempts.length, 'at least one inplace attempt should be diagnosed').toBeGreaterThan(0);
-        for (const attempt of attempts) {
-          const failed = attempt.failedChecks ?? [];
-          expect(
-            failed.includes('fieldStructure'),
-            `attempt ${attempt.pass} should report fieldStructure failure but failed=${JSON.stringify(failed)}`,
-          ).toBe(true);
-        }
-      });
-
-      await and('the pipeline falls back to rebuild output', () => {
-        expect(result.reconstructionModeUsed).toBe('rebuild');
-        expect(result.fallbackReason).toBe('round_trip_safety_check_failed');
       });
     },
   );

--- a/packages/docx-core/src/integration/nvca-coi-regression.test.ts
+++ b/packages/docx-core/src/integration/nvca-coi-regression.test.ts
@@ -1,46 +1,67 @@
 /**
- * Regression test for NVCA COI comparison (Certificate of Incorporation).
+ * Regression coverage using the checked-in NVCA COI source package.
  *
- * Validates that the comparison engine correctly handles documents with:
- * - Large paragraph count differences (234 vs 175 paragraphs)
- * - 94 footnote references in source, 0 in revised
- * - Extensive legal boilerplate sharing between paragraphs
- *
- * Root cause (fixed): The similarity fallback in hierarchical paragraph matching
- * used a greedy first-match algorithm that allowed low-similarity matches to
- * consume revised paragraphs intended for higher-similarity matches later in the
- * document. This caused incorrect paragraph alignment, producing garbled text
- * after reject-all and triggering a fallback to the rebuild reconstruction path.
- *
- * Fix: Two-part improvement:
- * 1. Order-constrained gap matching (Option 6): Pass 1 exact-hash anchors divide
- *    documents into gaps. Similarity matching is scoped to each gap via mini-LCS,
- *    guaranteeing document order preservation.
- * 2. TF-IDF cosine similarity (Option 8): Replaces Jaccard, which over-weights
- *    common legal boilerplate. IDF down-weights words like "holders", "Preferred
- *    Stock" that appear in many paragraphs.
+ * The revised side is derived from that source with a minimal body-text edit,
+ * so both packages retain the real relationship-addressed footer and footnote
+ * stories while exercising the two publication modes.
  */
 
-import { describe, expect } from 'vitest';
-import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
-import { compareDocuments } from '@usejunior/docx-compare';
-import {
-  acceptAllChanges,
-  rejectAllChanges,
-  extractTextWithParagraphs,
-  compareTexts,
-} from '@usejunior/docx-compare';
-import { DocxArchive } from '../shared/docx/DocxArchive.js';
 import fs from 'fs';
 import path from 'path';
+import { describe, expect } from 'vitest';
+import {
+  acceptAllChanges,
+  compareDocuments,
+  compareTexts,
+  extractTextWithParagraphs,
+  rejectAllChanges,
+  type ReconstructionMode,
+} from '@usejunior/docx-compare';
+import { DocxDocument } from '../primitives/document.js';
+import { DocxArchive } from '../shared/docx/DocxArchive.js';
+import {
+  getParagraphText,
+  replaceParagraphTextRange,
+} from '../primitives/text.js';
+import { OOXML } from '../primitives/namespaces.js';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
 
-const test = testAllure.epic('Document Comparison').withLabels({ feature: 'NVCA COI Regression' });
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({ feature: 'NVCA COI Regression' });
+
+const sourcePath = path.resolve(
+  __dirname,
+  '../../../../tests/test_documents/nvca-coi-regression/source.docx',
+);
+const filledPath = path.resolve(
+  __dirname,
+  '../../../../tests/test_documents/nvca-coi-regression/filled.docx',
+);
+
+async function deriveMinimallyEditedRevision(source: Buffer): Promise<Buffer> {
+  const document = await DocxDocument.load(source);
+  const paragraph = document.getParagraphs().find((candidate) => {
+    const text = getParagraphText(candidate);
+    return text.length >= 20 &&
+      candidate.getElementsByTagNameNS(OOXML.W_NS, 'fldChar').length === 0;
+  });
+  if (!paragraph) {
+    throw new Error('NVCA source has no suitable body paragraph for a minimal text edit');
+  }
+  const text = getParagraphText(paragraph);
+  const replacement = text[0] === 'A' ? 'B' : 'A';
+  replaceParagraphTextRange(paragraph, 0, 1, replacement);
+  return (await document.toBuffer({ cleanBookmarks: false })).buffer;
+}
 
 describe('NVCA COI Regression', () => {
-  const sourcePath = path.resolve(__dirname, '../../../../tests/test_documents/nvca-coi-regression/source.docx');
-  const filledPath = path.resolve(__dirname, '../../../../tests/test_documents/nvca-coi-regression/filled.docx');
-
-  test('should compare COI source vs filled in inplace mode without safety fallback', async ({ given, when, then, and }: AllureBddContext) => {
+  test('should compare COI source vs filled in inplace mode without safety fallback', async ({
+    given,
+    when,
+    then,
+    and,
+  }: AllureBddContext) => {
     let sourceBuf: Buffer;
     let filledBuf: Buffer;
     let res: Awaited<ReturnType<typeof compareDocuments>>;
@@ -68,8 +89,6 @@ describe('NVCA COI Regression', () => {
     });
 
     await and('stats are within expected ranges', async () => {
-      // Range counts stay bounded for the human-facing summary; atom totals
-      // retain the old granular signal for this large legal-document diff.
       expect(res.stats.insertions).toBeLessThan(500);
       expect(res.stats.deletions).toBeLessThan(500);
       expect(res.stats.deletedAtoms).toBeGreaterThan(5000);
@@ -102,8 +121,58 @@ describe('NVCA COI Regression', () => {
       const comparison = compareTexts(originalText, rejectedText);
       expect(comparison.normalizedIdentical).toBe(true);
     });
+  }, 60_000);
+});
 
-    // Note: fieldStructure validation is handled by the inplace safety check.
-    // If reconstructionModeUsed === 'inplace', fieldStructure already passed.
-  }, 60000);
+describe('NVCA COI ancillary field evidence', () => {
+  for (const reconstructionMode of ['inplace', 'rebuild'] as const satisfies readonly ReconstructionMode[]) {
+    test
+      .openspec('[SDX-ANC-BOUNDARY-01] NVCA COI source-derived pair supplies non-vacuous evidence in both modes')(
+      `[SDX-ANC-NVCA-${reconstructionMode}] real source-derived pair preserves footer PAGE and footnote REF in ${reconstructionMode}`,
+      async () => {
+        testAllure.conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.10.5' });
+        testAllure.conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.10.2' });
+        testAllure.conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.16.18' });
+        testAllure.conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.16.5.44' });
+        testAllure.conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.16.5.51' });
+
+        if (!fs.existsSync(sourcePath)) {
+          throw new Error(`NVCA COI source fixture not found: ${sourcePath}`);
+        }
+        const source = fs.readFileSync(sourcePath);
+        const revised = await deriveMinimallyEditedRevision(source);
+
+        const result = await compareDocuments(source, revised, {
+          engine: 'atomizer',
+          reconstructionMode,
+          author: 'RegressionTest',
+        });
+        const evidence = result.ancillaryFieldEvidence;
+        const footerPageRanges = evidence?.ranges.filter((range) =>
+          range.instructionKind === 'PAGE' &&
+          /^word\/footer[^/]*\.xml$/u.test(range.locator.normalizedPartPath),
+        ) ?? [];
+        const footnoteRefRanges = evidence?.ranges.filter((range) =>
+          range.instructionKind === 'REF' &&
+          range.locator.normalizedPartPath === 'word/footnotes.xml' &&
+          range.locator.entryId !== undefined,
+        ) ?? [];
+
+        expect(result.reconstructionModeUsed).toBe(reconstructionMode);
+        expect(result.fallbackReason).toBeUndefined();
+        expect(evidence).toMatchObject({
+          status: 'passed',
+          reconstructionMode,
+        });
+        expect(footerPageRanges.length).toBeGreaterThan(0);
+        expect(footnoteRefRanges.length).toBeGreaterThan(0);
+        expect([...footerPageRanges, ...footnoteRefRanges].every((range) =>
+          range.canonicalMatch &&
+          range.provenance === 'base' &&
+          range.sourceSide === (reconstructionMode === 'inplace' ? 'revised' : 'original'),
+        )).toBe(true);
+      },
+      60_000,
+    );
+  }
 });

--- a/packages/docx-core/src/integration/nvca-coi-regression.test.ts
+++ b/packages/docx-core/src/integration/nvca-coi-regression.test.ts
@@ -26,6 +26,7 @@ import {
 import { OOXML } from '../primitives/namespaces.js';
 import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
 
+const TEST_FEATURE = 'verify-ancillary-field-stories';
 const test = testAllure
   .epic('Document Comparison')
   .withLabels({ feature: 'NVCA COI Regression' });

--- a/packages/docx-core/src/integration/nvca-coi-regression.test.ts
+++ b/packages/docx-core/src/integration/nvca-coi-regression.test.ts
@@ -29,7 +29,7 @@ import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
 const TEST_FEATURE = 'verify-ancillary-field-stories';
 const test = testAllure
   .epic('Document Comparison')
-  .withLabels({ feature: 'NVCA COI Regression' });
+  .withLabels({ feature: TEST_FEATURE });
 
 const sourcePath = path.resolve(
   __dirname,

--- a/packages/docx-core/src/primitives/index.ts
+++ b/packages/docx-core/src/primitives/index.ts
@@ -29,6 +29,8 @@ export * from './extract_revisions.js';
 export * from './comments.js';
 export * from './footnotes.js';
 export * from './relationships.js';
+export * from './opc-target.js';
+export * from './sectPrAudit.js';
 export * from './formatting_tags.js';
 export * from './prevent_double_elevation.js';
 export * from './tables.js';

--- a/packages/docx-core/src/primitives/opc-target.test.ts
+++ b/packages/docx-core/src/primitives/opc-target.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect } from 'vitest';
+import { testAllure } from '../testing/allure-test.js';
+import {
+  OpcRelationshipTargetError,
+  normalizeOpcRelationshipTarget,
+} from './opc-target.js';
+
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({ feature: 'OPC Relationship Target Safety' });
+
+describe('normalizeOpcRelationshipTarget', () => {
+  test('normalizes package-relative and package-absolute internal targets', () => {
+    expect(normalizeOpcRelationshipTarget({
+      ownerPart: 'word/document.xml',
+      target: './headers/../header1.xml',
+    })).toEqual({ mode: 'Internal', target: 'word/header1.xml' });
+    expect(normalizeOpcRelationshipTarget({
+      ownerPart: 'word/document.xml',
+      target: '/word/header1.xml',
+      targetMode: 'Internal',
+    })).toEqual({ mode: 'Internal', target: 'word/header1.xml' });
+  });
+
+  const unsafeTargets = [
+    ['', 'empty_target'],
+    ['header.xml?x=1', 'unsafe_target'],
+    ['header.xml#x', 'unsafe_target'],
+    ['header\u0001.xml', 'unsafe_target'],
+    ['headers\\header.xml', 'unsafe_target'],
+    ['https:header.xml', 'unsafe_target'],
+    ['//server/header.xml', 'unsafe_target'],
+    ['%2e%2e/header.xml', 'unsafe_target'],
+    ['%252e%252e/header.xml', 'unsafe_target'],
+    ['headers%2fheader.xml', 'unsafe_target'],
+    ['headers%252fheader.xml', 'unsafe_target'],
+    ['headers%5cheader.xml', 'unsafe_target'],
+    ['/../../header.xml', 'package_escape'],
+  ] as const;
+  for (const [target, issue] of unsafeTargets) {
+    test(`rejects unsafe internal target ${JSON.stringify(target)}`, () => {
+      expect(() => normalizeOpcRelationshipTarget({
+        ownerPart: 'word/document.xml',
+        target,
+      })).toThrowError(expect.objectContaining<Partial<OpcRelationshipTargetError>>({ issue }));
+    });
+  }
+
+  test('classifies TargetMode exactly and gates external targets', () => {
+    expect(() => normalizeOpcRelationshipTarget({
+      ownerPart: 'word/document.xml',
+      target: 'header.xml',
+      targetMode: 'internal',
+    })).toThrowError(expect.objectContaining<Partial<OpcRelationshipTargetError>>({
+      issue: 'invalid_target_mode',
+    }));
+    expect(() => normalizeOpcRelationshipTarget({
+      ownerPart: 'word/document.xml',
+      target: 'https://example.test/header.xml',
+      targetMode: 'External',
+    })).toThrowError(expect.objectContaining<Partial<OpcRelationshipTargetError>>({
+      issue: 'external_target_not_allowed',
+    }));
+    expect(normalizeOpcRelationshipTarget({
+      ownerPart: 'word/document.xml',
+      target: 'https://example.test/header.xml',
+      targetMode: 'External',
+      allowExternal: true,
+    })).toEqual({
+      mode: 'External',
+      target: 'https://example.test/header.xml',
+    });
+  });
+});

--- a/packages/docx-core/src/primitives/opc-target.ts
+++ b/packages/docx-core/src/primitives/opc-target.ts
@@ -1,0 +1,158 @@
+import { posix } from 'node:path';
+
+export type OpcRelationshipTargetMode = 'Internal' | 'External';
+
+export type OpcRelationshipTargetIssue =
+  | 'empty_target'
+  | 'invalid_target_mode'
+  | 'external_target_not_allowed'
+  | 'invalid_encoding'
+  | 'unsafe_target'
+  | 'package_escape'
+  | 'empty_resolved_target'
+  | 'invalid_external_target';
+
+export class OpcRelationshipTargetError extends Error {
+  constructor(
+    readonly issue: OpcRelationshipTargetIssue,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'OpcRelationshipTargetError';
+  }
+}
+
+export interface NormalizeOpcRelationshipTargetOptions {
+  ownerPart: string;
+  target: string;
+  targetMode?: string | null;
+  allowExternal?: boolean;
+}
+
+export interface NormalizedOpcRelationshipTarget {
+  mode: OpcRelationshipTargetMode;
+  target: string;
+}
+
+function targetMode(value: string | null | undefined): OpcRelationshipTargetMode {
+  if (value === null || value === undefined || value === 'Internal') {
+    return 'Internal';
+  }
+  if (value === 'External') return 'External';
+  throw new OpcRelationshipTargetError(
+    'invalid_target_mode',
+    `invalid relationship TargetMode '${value}'`,
+  );
+}
+
+function normalizeInternalTarget(ownerPart: string, target: string): string {
+  if (!target) {
+    throw new OpcRelationshipTargetError('empty_target', 'empty internal relationship target');
+  }
+  if (target.includes('\\') || /[\u0000-\u001f\u007f?#]/u.test(target)) {
+    throw new OpcRelationshipTargetError(
+      'unsafe_target',
+      `unsafe internal relationship target '${target}'`,
+    );
+  }
+  let decoded = target;
+  for (let pass = 0; pass <= target.length; pass++) {
+    if (/%(?:2f|5c)/iu.test(decoded)) {
+      throw new OpcRelationshipTargetError(
+        'unsafe_target',
+        `encoded path separator in internal relationship target '${target}'`,
+      );
+    }
+    let next: string;
+    try {
+      next = decodeURIComponent(decoded);
+    } catch {
+      throw new OpcRelationshipTargetError(
+        'invalid_encoding',
+        `invalid encoded relationship target '${target}'`,
+      );
+    }
+    const rawSegments = decoded.split('/');
+    const nextSegments = next.split('/');
+    if (
+      next.includes('\\') ||
+      /[\u0000-\u001f\u007f?#]/u.test(next) ||
+      next.startsWith('//') ||
+      next.includes(':') ||
+      nextSegments.some((segment, index) =>
+        (segment === '.' || segment === '..') && rawSegments[index] !== segment
+      )
+    ) {
+      throw new OpcRelationshipTargetError(
+        'unsafe_target',
+        `unsafe internal relationship target '${target}'`,
+      );
+    }
+    decoded = next;
+    if (!/%[0-9a-f]{2}/iu.test(decoded)) break;
+    if (pass === target.length) {
+      throw new OpcRelationshipTargetError(
+        'invalid_encoding',
+        `excessively nested encoded relationship target '${target}'`,
+      );
+    }
+  }
+  const decodedSegments = decoded.split('/');
+
+  const segments = decoded.startsWith('/')
+    ? []
+    : posix.dirname(ownerPart).split('/').filter(Boolean);
+  for (const segment of decodedSegments) {
+    if (!segment || segment === '.') continue;
+    if (segment === '..') {
+      if (segments.length === 0) {
+        throw new OpcRelationshipTargetError(
+          'package_escape',
+          `relationship target escapes the package root: '${target}'`,
+        );
+      }
+      segments.pop();
+    } else {
+      segments.push(segment);
+    }
+  }
+  if (segments.length === 0) {
+    throw new OpcRelationshipTargetError(
+      'empty_resolved_target',
+      `empty resolved relationship target '${target}'`,
+    );
+  }
+  return segments.join('/');
+}
+
+/**
+ * Normalize one OPC relationship target under SafeDocX package-containment
+ * policy. Internal targets are decoded once, checked for ambiguous or unsafe
+ * URI/path forms, and resolved relative to the owning part. External targets
+ * are accepted only when the caller opts in.
+ */
+export function normalizeOpcRelationshipTarget(
+  options: NormalizeOpcRelationshipTargetOptions,
+): NormalizedOpcRelationshipTarget {
+  const mode = targetMode(options.targetMode);
+  if (mode === 'External') {
+    if (!options.allowExternal) {
+      throw new OpcRelationshipTargetError(
+        'external_target_not_allowed',
+        `external relationship target is not allowed: '${options.target}'`,
+      );
+    }
+    try {
+      return { mode, target: new URL(options.target).href };
+    } catch {
+      throw new OpcRelationshipTargetError(
+        'invalid_external_target',
+        `unsafe external relationship target '${options.target}'`,
+      );
+    }
+  }
+  return {
+    mode,
+    target: normalizeInternalTarget(options.ownerPart, options.target),
+  };
+}

--- a/packages/docx-core/src/primitives/sectPrAudit.ts
+++ b/packages/docx-core/src/primitives/sectPrAudit.ts
@@ -1,6 +1,10 @@
 import { parseXml } from './xml.js';
 import { childElements } from './dom-helpers.js';
 import { OOXML } from './namespaces.js';
+import {
+  OpcRelationshipTargetError,
+  normalizeOpcRelationshipTarget,
+} from './opc-target.js';
 
 export type SectPrIssueType =
   | 'missing_body'
@@ -10,10 +14,13 @@ export type SectPrIssueType =
   | 'sectpr_in_ppr_without_paragraph_parent'
   | 'sectpr_reference_missing_rid'
   | 'sectpr_reference_invalid_type'
+  | 'sectpr_reference_invalid_placement'
   | 'sectpr_duplicate_reference_type'
   | 'sectpr_reference_dangling_rid'
   | 'sectpr_duplicate_relationship_id'
   | 'sectpr_reference_wrong_relationship_type'
+  | 'sectpr_reference_invalid_target_mode'
+  | 'sectpr_reference_external_target'
   | 'sectpr_reference_invalid_target'
   | 'sectpr_reference_missing_target_part'
   | 'sectpr_reference_wrong_target_root';
@@ -23,11 +30,28 @@ export interface SectPrAuditIssue {
   path: string;
   message: string;
   rid?: string;
+  sectionOrdinal?: number;
+  kind?: SectPrBindingKind;
+  role?: SectPrBindingRole;
+  targetPath?: string;
+}
+
+export type SectPrBindingKind = 'header' | 'footer';
+export type SectPrBindingRole = 'default' | 'first' | 'even';
+
+export interface SectPrBinding {
+  sectionOrdinal: number;
+  kind: SectPrBindingKind;
+  role: SectPrBindingRole;
+  rid: string;
+  targetPath: string;
+  path: string;
 }
 
 export interface SectPrAuditSummary {
   ok: boolean;
   issues: SectPrAuditIssue[];
+  bindings: SectPrBinding[];
   stats: {
     bodyLevelSectPrCount: number;
     paragraphLevelSectPrCount: number;
@@ -68,7 +92,7 @@ function nodePath(node: Element): string {
 interface DocumentRelationship {
   type: string;
   target: string;
-  external: boolean;
+  targetMode?: string;
 }
 
 interface RelationshipCollection {
@@ -104,7 +128,9 @@ function collectRelationships(documentRelsXml: string | null | undefined): Relat
         relationshipsById.set(id, {
           type: rel?.getAttribute('Type') ?? '',
           target: rel?.getAttribute('Target') ?? '',
-          external: rel?.getAttribute('TargetMode') === 'External',
+          targetMode: rel?.hasAttribute('TargetMode')
+            ? rel.getAttribute('TargetMode') ?? undefined
+            : undefined,
         });
       }
     }
@@ -112,21 +138,6 @@ function collectRelationships(documentRelsXml: string | null | undefined): Relat
   } catch {
     return { relationships: new Map(), duplicateIds: [] };
   }
-}
-
-function resolveDocumentTarget(target: string): string | undefined {
-  // Part-name fragments are outside this audit's explicit OPC target model.
-  if (target.includes('#')) return undefined;
-  const parts = target.startsWith('/') ? [] : ['word'];
-  for (const segment of target.split('/')) {
-    if (!segment || segment === '.') continue;
-    if (segment === '..') {
-      if (parts.length === 0) return undefined;
-      parts.pop();
-    }
-    else parts.push(segment);
-  }
-  return parts.length > 0 ? parts.join('/') : undefined;
 }
 
 function getRid(ref: Element): string | undefined {
@@ -140,6 +151,8 @@ function getRid(ref: Element): string | undefined {
  *
  * @conformance ECMA-376 edition 5, Part 1 § 17.10.5
  * @conformance ECMA-376 edition 5, Part 1 § 17.10.2
+ * @conformance ECMA-376 edition 5, Part 1 § 17.10.4
+ * @conformance ECMA-376 edition 5, Part 1 § 17.10.3
  * @see https://github.com/UseJunior/safe-docx/issues/560
  */
 export function auditSectPr(
@@ -148,8 +161,10 @@ export function auditSectPr(
   packageParts?: ReadonlyMap<string, string>,
 ): SectPrAuditSummary {
   const issues: SectPrAuditIssue[] = [];
+  const bindings: SectPrBinding[] = [];
   const relationshipCollection = collectRelationships(documentRelsXml);
   const relationships = relationshipCollection.relationships;
+  const ambiguousRelationshipIds = new Set(relationshipCollection.duplicateIds);
 
   for (const id of relationshipCollection.duplicateIds) {
     issues.push({
@@ -173,6 +188,7 @@ export function auditSectPr(
           message: 'Missing w:body element',
         },
       ],
+      bindings,
       stats: {
         bodyLevelSectPrCount: 0,
         paragraphLevelSectPrCount: 0,
@@ -212,7 +228,7 @@ export function auditSectPr(
   let paragraphLevelSectPrCount = 0;
   let referenceCount = 0;
 
-  for (const sectPr of sectPrNodes) {
+  for (const [sectionOrdinal, sectPr] of sectPrNodes.entries()) {
     const seenReferenceTypes = new Set<string>();
     const parent = sectPr.parentNode;
     const parentTag = parent && parent.nodeType === 1 ? (parent as Element).tagName : '';
@@ -235,6 +251,35 @@ export function auditSectPr(
       });
     }
 
+    const descendantReferences = Array.from(
+      sectPr.getElementsByTagNameNS(OOXML.W_NS, '*'),
+    ).filter((element) => {
+      if (element.localName !== 'headerReference' && element.localName !== 'footerReference') {
+        return false;
+      }
+      let ancestor = element.parentNode;
+      while (ancestor && ancestor !== sectPr) {
+        if (ancestor.nodeType === 1 && isWmlElement(ancestor as Element, 'sectPr')) return false;
+        ancestor = ancestor.parentNode;
+      }
+      return ancestor === sectPr;
+    });
+    referenceCount += descendantReferences.length;
+    for (const reference of descendantReferences) {
+      if (reference.parentNode === sectPr) continue;
+      const referenceType = reference.getAttributeNS(OOXML.W_NS, 'type') ?? '';
+      issues.push({
+        type: 'sectpr_reference_invalid_placement',
+        path: nodePath(reference),
+        message: `${reference.tagName} must be a direct child of w:sectPr`,
+        sectionOrdinal,
+        kind: reference.localName === 'headerReference' ? 'header' : 'footer',
+        role: REFERENCE_TYPES.has(referenceType)
+          ? referenceType as SectPrBindingRole
+          : undefined,
+      });
+    }
+
     for (const child of childElements(sectPr)) {
       const isHeaderReference = isWmlElement(child, 'headerReference');
       const isFooterReference = isWmlElement(child, 'footerReference');
@@ -242,14 +287,20 @@ export function auditSectPr(
         continue;
       }
 
-      referenceCount++;
+      const kind = isHeaderReference ? 'header' : 'footer';
       const referenceType = child.getAttributeNS(OOXML.W_NS, 'type') ?? '';
+      const role = REFERENCE_TYPES.has(referenceType)
+        ? referenceType as SectPrBindingRole
+        : undefined;
       if (!REFERENCE_TYPES.has(referenceType)) {
         issues.push({
           type: 'sectpr_reference_invalid_type',
           path: nodePath(child),
           message: `${child.tagName} has missing or invalid w:type '${referenceType || '(missing)'}'; expected first, default, or even`,
+          sectionOrdinal,
+          kind,
         });
+        continue;
       } else {
         const referenceKey = `${isHeaderReference ? 'header' : 'footer'}:${referenceType}`;
         if (seenReferenceTypes.has(referenceKey)) {
@@ -257,7 +308,11 @@ export function auditSectPr(
             type: 'sectpr_duplicate_reference_type',
             path: nodePath(child),
             message: `${child.tagName} duplicates the '${referenceType}' role within this w:sectPr`,
+            sectionOrdinal,
+            kind,
+            role,
           });
+          continue;
         } else {
           seenReferenceTypes.add(referenceKey);
         }
@@ -268,9 +323,13 @@ export function auditSectPr(
           type: 'sectpr_reference_missing_rid',
           path: nodePath(child),
           message: `${child.tagName} is missing r:id`,
+          sectionOrdinal,
+          kind,
+          role,
         });
         continue;
       }
+      if (ambiguousRelationshipIds.has(rid)) continue;
 
       const relationship = relationships.get(rid);
       if (!relationship) {
@@ -279,33 +338,55 @@ export function auditSectPr(
           path: nodePath(child),
           message: `${child.tagName} references missing relationship id '${rid}'`,
           rid,
+          sectionOrdinal,
+          kind,
+          role,
         });
         continue;
       }
 
-      const kind = isHeaderReference ? 'header' : 'footer';
       const expectedType = `http://schemas.openxmlformats.org/officeDocument/2006/relationships/${kind}`;
-      if (relationship.type !== expectedType || relationship.external) {
+      if (relationship.type !== expectedType) {
         issues.push({
           type: 'sectpr_reference_wrong_relationship_type',
           path: nodePath(child),
           message: `${child.tagName} relationship '${rid}' has type '${relationship.type || '(missing)'}'`,
           rid,
+          sectionOrdinal,
+          kind,
+          role,
         });
         continue;
       }
 
+      let targetName: string;
+      try {
+        targetName = normalizeOpcRelationshipTarget({
+          ownerPart: 'word/document.xml',
+          target: relationship.target,
+          targetMode: relationship.targetMode,
+        }).target;
+      } catch (error) {
+        const targetError = error instanceof OpcRelationshipTargetError ? error : undefined;
+        const type = targetError?.issue === 'invalid_target_mode'
+          ? 'sectpr_reference_invalid_target_mode'
+          : targetError?.issue === 'external_target_not_allowed'
+            ? 'sectpr_reference_external_target'
+            : 'sectpr_reference_invalid_target';
+        issues.push({
+          type,
+          path: nodePath(child),
+          message: `${child.tagName} relationship '${rid}' has unsupported or malformed target '${relationship.target}': ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+          rid,
+          sectionOrdinal,
+          kind,
+          role,
+        });
+        continue;
+      }
       if (packageParts) {
-        const targetName = resolveDocumentTarget(relationship.target);
-        if (!targetName) {
-          issues.push({
-            type: 'sectpr_reference_invalid_target',
-            path: nodePath(child),
-            message: `${child.tagName} relationship '${rid}' has unsupported or malformed target '${relationship.target}'`,
-            rid,
-          });
-          continue;
-        }
         const targetXml = packageParts.get(targetName);
         if (!targetXml) {
           issues.push({
@@ -313,6 +394,10 @@ export function auditSectPr(
             path: nodePath(child),
             message: `${child.tagName} relationship '${rid}' resolves to missing part '${targetName}'`,
             rid,
+            sectionOrdinal,
+            kind,
+            role,
+            targetPath: targetName,
           });
           continue;
         }
@@ -325,7 +410,12 @@ export function auditSectPr(
               path: nodePath(child),
               message: `${child.tagName} relationship '${rid}' targets <${actualRoot?.tagName ?? 'nothing'}>, expected WordprocessingML <${expectedRoot}>`,
               rid,
+              sectionOrdinal,
+              kind,
+              role,
+              targetPath: targetName,
             });
+            continue;
           }
         } catch {
           issues.push({
@@ -333,15 +423,29 @@ export function auditSectPr(
             path: nodePath(child),
             message: `${child.tagName} relationship '${rid}' targets malformed XML`,
             rid,
+            sectionOrdinal,
+            kind,
+            role,
+            targetPath: targetName,
           });
+          continue;
         }
       }
+      bindings.push({
+        sectionOrdinal,
+        kind,
+        role: referenceType as SectPrBindingRole,
+        rid,
+        targetPath: targetName,
+        path: nodePath(child),
+      });
     }
   }
 
   return {
     ok: issues.length === 0,
     issues,
+    bindings,
     stats: {
       bodyLevelSectPrCount: bodyLevelSectPrNodes.length,
       paragraphLevelSectPrCount,

--- a/packages/docx-core/src/shared/field-structure.ts
+++ b/packages/docx-core/src/shared/field-structure.ts
@@ -89,6 +89,90 @@ export function validateFieldStructure(input: string | FieldStory[]): boolean {
     .length === 0;
 }
 
+function collectStrictStackIssuesForStory(xml: string, story: string): FieldStructureIssue[] {
+  const root = parseXml(xml).documentElement;
+  const issues: FieldStructureIssue[] = [];
+  const separators: boolean[] = [];
+
+  function push(code: string, message: string): void {
+    issues.push({ code, message, story, element: 'w:fldChar' });
+  }
+
+  function scan(node: Element): void {
+    for (let child = node.firstChild; child; child = child.nextSibling) {
+      if (child.nodeType !== 1) continue;
+      const element = child as Element;
+      if (isW(element, 'fldChar')) {
+        const type = getWAttr(element, 'fldCharType');
+        if (type === 'begin') {
+          separators.push(false);
+        } else if (type === 'separate') {
+          if (separators.length === 0) {
+            push('FIELD_STRAY_SEPARATOR', `Field separator appears outside an open field in ${story}`);
+          } else {
+            const depthIndex = separators.length - 1;
+            if (separators[depthIndex]) {
+              push(
+                'FIELD_DUPLICATE_SEPARATOR',
+                `Field at depth ${separators.length} has more than one separator in ${story}`,
+              );
+            } else {
+              separators[depthIndex] = true;
+            }
+          }
+        } else if (type === 'end') {
+          if (separators.length === 0) {
+            push('FIELD_STRAY_END', `Field end appears outside an open field in ${story}`);
+          } else {
+            separators.pop();
+          }
+        } else {
+          push(
+            'FIELD_UNKNOWN_CHAR_TYPE',
+            `w:fldChar has missing or unknown w:fldCharType '${type ?? '(missing)'}' in ${story}`,
+          );
+        }
+      }
+      scan(element);
+    }
+  }
+
+  scan(root);
+  if (separators.length > 0) {
+    push(
+      'FIELD_UNCLOSED_DEPTH',
+      `Field story ${story} ends with ${separators.length} unclosed field level(s)`,
+    );
+  }
+  return issues;
+}
+
+/**
+ * Reports strict runtime field-story violations without changing the
+ * Lean-pinned `validateFieldStructure` predicate.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.18
+ */
+export function collectStrictFieldStructureIssues(
+  input: string | FieldStory[],
+): FieldStructureIssue[] {
+  const stories = typeof input === 'string'
+    ? [{ label: 'document', xml: input }]
+    : input;
+  const issues: FieldStructureIssue[] = [];
+  for (const story of stories) {
+    issues.push(...collectFieldStructureIssuesForStory(story.xml, story.label));
+    issues.push(...collectStrictStackIssuesForStory(story.xml, story.label));
+  }
+  return issues;
+}
+
+export function validateStrictFieldStructure(input: string | FieldStory[]): boolean {
+  return collectStrictFieldStructureIssues(input)
+    .filter((issue) => !TEXT_PLACEMENT_ISSUE_CODES.has(issue.code))
+    .length === 0;
+}
+
 function collectFieldStructureIssuesForStory(documentXml: string, story: string): FieldStructureIssue[] {
   const issues: FieldStructureIssue[] = [];
   const root = parseXml(documentXml).documentElement;

--- a/packages/docx-core/src/testing/ooxml-fixtures.ts
+++ b/packages/docx-core/src/testing/ooxml-fixtures.ts
@@ -225,6 +225,26 @@ export interface MinimalDocumentNamespaceOptions {
   ignorablePrefixes?: readonly string[];
 }
 
+export interface AncillaryPartFixture {
+  path: string;
+  contentType: string;
+  xml: string;
+}
+
+export interface DocumentRelationshipFixture {
+  id: string;
+  type: string;
+  target: string;
+  targetMode?: 'External';
+}
+
+export interface AncillaryDocxFixtureOptions {
+  bodyXml: string;
+  sectPrXml: string;
+  relationships?: readonly DocumentRelationshipFixture[];
+  parts?: readonly AncillaryPartFixture[];
+}
+
 export async function buildDocxFromBodyXml(
   bodyXml: string,
   hyperlinkRels: HyperlinkRelFixture[] = [],
@@ -285,6 +305,62 @@ export async function buildDocxFromBodyXml(
   zip.file('_rels/.rels', rootRelsXml);
   zip.file('word/document.xml', documentXml);
   zip.file('word/_rels/document.xml.rels', docRelsXml);
+
+  return (await zip.generateAsync({ type: 'nodebuffer' })) as Buffer;
+}
+
+/**
+ * Extend the minimal package shape with section bindings and ancillary parts.
+ *
+ * This keeps relationship-addressed header/footer and note fixtures in the
+ * shared package builder instead of re-deriving JSZip scaffolding per test.
+ */
+export async function buildDocxWithAncillaryParts(
+  options: AncillaryDocxFixtureOptions,
+): Promise<Buffer> {
+  const base = await buildDocxFromBodyXml(options.bodyXml, [], {
+    namespaces: {
+      r: 'http://schemas.openxmlformats.org/officeDocument/2006/relationships',
+    },
+  });
+  const zip = await JSZip.loadAsync(base);
+  const documentFile = zip.file('word/document.xml');
+  const contentTypesFile = zip.file('[Content_Types].xml');
+  if (!documentFile || !contentTypesFile) {
+    throw new Error('Minimal DOCX fixture is missing required package parts');
+  }
+
+  const documentXml = await documentFile.async('string');
+  zip.file('word/document.xml', documentXml.replace('<w:sectPr/>', options.sectPrXml));
+
+  const relationships = (options.relationships ?? []).map((relationship) => {
+    const targetMode = relationship.targetMode
+      ? ` TargetMode="${relationship.targetMode}"`
+      : '';
+    return (
+      `<Relationship Id="${escapeXmlAttr(relationship.id)}"` +
+      ` Type="${escapeXmlAttr(relationship.type)}"` +
+      ` Target="${escapeXmlAttr(relationship.target)}"${targetMode}/>`
+    );
+  }).join('');
+  zip.file(
+    'word/_rels/document.xml.rels',
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+      `${relationships}</Relationships>`,
+  );
+
+  let contentTypesXml = await contentTypesFile.async('string');
+  for (const part of options.parts ?? []) {
+    const normalizedPath = part.path.replace(/^\/+/, '');
+    zip.file(normalizedPath, part.xml);
+    contentTypesXml = contentTypesXml.replace(
+      '</Types>',
+      `<Override PartName="/${escapeXmlAttr(normalizedPath)}"` +
+        ` ContentType="${escapeXmlAttr(part.contentType)}"/></Types>`,
+    );
+  }
+  zip.file('[Content_Types].xml', contentTypesXml);
 
   return (await zip.generateAsync({ type: 'nodebuffer' })) as Buffer;
 }

--- a/spec-compliance/CONFORMANCE.md
+++ b/spec-compliance/CONFORMANCE.md
@@ -41,16 +41,16 @@ Allure labels via `testAllure.conformance({…})`; source code carries
 | `ECMA-PART1-17-10-5` | w:headerReference binding | 5 | 1 | 17.10.5 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:headerReference` | — |
 | `ECMA-PART1-17-10-2` | w:footerReference binding | 5 | 1 | 17.10.2 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:footerReference` | — |
 | `ECMA-PART1-17-10-6` | w:titlePg first-page header/footer switch | 5 | 1 | 17.10.6 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:titlePg` | — |
-| `ECMA-PART1-17-10-4` | w:hdr header part emission | 5 | 1 | 17.10.4 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:hdr` | — |
-| `ECMA-PART1-17-10-3` | w:ftr footer part emission | 5 | 1 | 17.10.3 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:ftr` | — |
+| `ECMA-PART1-17-10-4` | w:hdr header part emission | 5 | 1 | 17.10.4 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:hdr` | packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.ts; packages/docx-core/src/integration/ancillary-field-safety.test.ts |
+| `ECMA-PART1-17-10-3` | w:ftr footer part emission | 5 | 1 | 17.10.3 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:ftr` | packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.ts; packages/docx-core/src/integration/ancillary-field-safety.test.ts; packages/docx-core/src/integration/nvca-coi-regression.test.ts |
 | `ECMA-PART1-11-3-3` | Document Settings part | 5 | 1 | 11.3.3 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:settings` | packages/docx-core/src/generation/emit/settings-part.ts; packages/docx-core/src/generation/generation-baseline-settings.test.ts; packages/docx-core/src/integration/cross-implementation-suite.test.ts |
 | `ECMA-PART1-17-15-3-4` | w:compatSetting custom compatibility setting | 5 | 1 | 17.15.3.4 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:compatSetting` | packages/docx-core/src/generation/emit/settings-part.ts; packages/docx-core/src/generation/generation-baseline-settings.test.ts; packages/docx-core/src/integration/cross-implementation-suite.test.ts |
 | `ECMA-PART1-17-10-1` | w:evenAndOddHeaders setting | 5 | 1 | 17.10.1 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:evenAndOddHeaders` | — |
-| `ECMA-PART1-17-16-18` | w:fldChar five-part complex-field emission | 5 | 1 | 17.16.18 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:fldChar` | packages/docx-core/src/generation/emit/run.ts; packages/docx-core/src/generation/structural-checks.ts; packages/docx-compare/src/baselines/atomizer/inPlaceModifier-deletion.ts; packages/docx-compare/src/baselines/atomizer/pipeline.field-validation.test.ts; packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts; verification/lean/Tier2/XmlTripleChecker.lean; verification/registry/lean-xml-checker-coverage.json |
-| `ECMA-PART1-17-16-5-44` | PAGE field instruction emission | 5 | 1 | 17.16.5.44 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:instrText` | packages/docx-core/src/generation/emit/run.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts; packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts |
-| `ECMA-PART1-17-16-5-42` | NUMPAGES field instruction emission | 5 | 1 | 17.16.5.42 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:instrText` | packages/docx-core/src/generation/emit/run.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts; packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts |
-| `ECMA-PART1-17-16-5-45` | PAGEREF field instruction classification and preservation | 5 | 1 | 17.16.5.45 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:instrText` | packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts |
-| `ECMA-PART1-17-16-5-51` | REF field instruction classification and preservation | 5 | 1 | 17.16.5.51 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:instrText` | packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts |
+| `ECMA-PART1-17-16-18` | w:fldChar five-part complex-field emission | 5 | 1 | 17.16.18 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:fldChar` | packages/docx-core/src/generation/emit/run.ts; packages/docx-core/src/generation/structural-checks.ts; packages/docx-core/src/shared/field-structure.ts; packages/docx-compare/src/baselines/atomizer/inPlaceModifier-deletion.ts; packages/docx-compare/src/baselines/atomizer/pipeline.field-validation.test.ts; packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.ts; packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts; packages/docx-core/src/integration/ancillary-field-safety.test.ts; packages/docx-core/src/integration/nvca-coi-regression.test.ts; verification/lean/Tier2/XmlTripleChecker.lean; verification/registry/lean-xml-checker-coverage.json |
+| `ECMA-PART1-17-16-5-44` | PAGE field instruction emission | 5 | 1 | 17.16.5.44 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:instrText` | packages/docx-core/src/generation/emit/run.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts; packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.ts; packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts; packages/docx-core/src/integration/ancillary-field-safety.test.ts; packages/docx-core/src/integration/nvca-coi-regression.test.ts |
+| `ECMA-PART1-17-16-5-42` | NUMPAGES field instruction emission | 5 | 1 | 17.16.5.42 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:instrText` | packages/docx-core/src/generation/emit/run.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts; packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.ts; packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts; packages/docx-core/src/integration/ancillary-field-safety.test.ts |
+| `ECMA-PART1-17-16-5-45` | PAGEREF field instruction classification and preservation | 5 | 1 | 17.16.5.45 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:instrText` | packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.ts; packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts; packages/docx-core/src/integration/ancillary-field-safety.test.ts |
+| `ECMA-PART1-17-16-5-51` | REF field instruction classification and preservation | 5 | 1 | 17.16.5.51 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:instrText` | packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.ts; packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts; packages/docx-core/src/integration/ancillary-field-safety.test.ts; packages/docx-core/src/integration/nvca-coi-regression.test.ts |
 | `ECMA-PART1-17-4-37` | w:tbl table emission | 5 | 1 | 17.4.37 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:tbl` | — |
 | `ECMA-PART1-17-4-59` | w:tblPr table-properties emission | 5 | 1 | 17.4.59 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:tblPr` | — |
 | `ECMA-PART1-17-4-63` | w:tblW preferred-width consistency | 5 | 1 | 17.4.63 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:tblW` | — |
@@ -497,7 +497,9 @@ rejected. Relative and package-absolute targets are normalized before lookup;
 URI-fragment semantics are outside this audit's supported OPC target model.
 Relationship reuse across sections is accepted. Pagination,
 role inheritance when a reference is absent, and reader rendering are not
-evaluated.
+evaluated. Comparison uses this same audit to select only valid direct
+section bindings; target normalization and package containment are additional
+SafeDocX safety policies rather than claims made by this clause.
 
 ### ECMA-PART1-17-10-2 — w:footerReference binding
 
@@ -532,6 +534,7 @@ silently ignored by readers.
 - **Part / Section:** Part 1 § 17.10.4
 - **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
 - **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:hdr`
+- **Verified by:** packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.ts; packages/docx-core/src/integration/ancillary-field-safety.test.ts
 
 Header parts are emitted as standalone `w:hdr` documents
 (word/headerN.xml) with content-type overrides, sharing the body's
@@ -544,6 +547,7 @@ formatting and field machinery as body content.
 - **Part / Section:** Part 1 § 17.10.3
 - **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
 - **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:ftr`
+- **Verified by:** packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.ts; packages/docx-core/src/integration/ancillary-field-safety.test.ts; packages/docx-core/src/integration/nvca-coi-regression.test.ts
 
 Footer parts mirror header parts as `w:ftr` documents (word/footerN.xml);
 "Page X of Y" footers carry complete five-part PAGE/NUMPAGES fields with
@@ -594,7 +598,7 @@ and conditionally adds this switch exactly when some section declares an
 - **Part / Section:** Part 1 § 17.16.18
 - **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
 - **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:fldChar`
-- **Verified by:** packages/docx-core/src/generation/emit/run.ts; packages/docx-core/src/generation/structural-checks.ts; packages/docx-compare/src/baselines/atomizer/inPlaceModifier-deletion.ts; packages/docx-compare/src/baselines/atomizer/pipeline.field-validation.test.ts; packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts; verification/lean/Tier2/XmlTripleChecker.lean; verification/registry/lean-xml-checker-coverage.json
+- **Verified by:** packages/docx-core/src/generation/emit/run.ts; packages/docx-core/src/generation/structural-checks.ts; packages/docx-core/src/shared/field-structure.ts; packages/docx-compare/src/baselines/atomizer/inPlaceModifier-deletion.ts; packages/docx-compare/src/baselines/atomizer/pipeline.field-validation.test.ts; packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.ts; packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts; packages/docx-core/src/integration/ancillary-field-safety.test.ts; packages/docx-core/src/integration/nvca-coi-regression.test.ts; verification/lean/Tier2/XmlTripleChecker.lean; verification/registry/lean-xml-checker-coverage.json
 
 Every generated field is a complete five-run sequence — `fldChar begin`,
 preserved-space `w:instrText`, `fldChar separate`, a cached-result run,
@@ -604,6 +608,8 @@ unrepresentable-by-omission; the structural validator runs a begin →
 separate → end state machine over every story part. The comparison path keeps
 these field-state markers outside the `w:del` payload wrappers shown by the
 Part 1 complex-field and deleted-field-code syntax.
+The runtime ancillary predicate adds fail-closed stack diagnostics without
+changing the Lean-pinned predicate or protocol.
 
 ### ECMA-PART1-17-16-5-44 — PAGE field instruction emission
 
@@ -611,7 +617,7 @@ Part 1 complex-field and deleted-field-code syntax.
 - **Part / Section:** Part 1 § 17.16.5.44
 - **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
 - **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:instrText`
-- **Verified by:** packages/docx-core/src/generation/emit/run.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts; packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts
+- **Verified by:** packages/docx-core/src/generation/emit/run.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts; packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.ts; packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts; packages/docx-core/src/integration/ancillary-field-safety.test.ts; packages/docx-core/src/integration/nvca-coi-regression.test.ts
 
 The PAGE instruction is emitted with canonical surrounding spaces
 (` PAGE `) inside a preserved-space `w:instrText`, matching the shape of
@@ -623,7 +629,7 @@ the committed field fixtures used by the comparison pipeline.
 - **Part / Section:** Part 1 § 17.16.5.42
 - **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
 - **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:instrText`
-- **Verified by:** packages/docx-core/src/generation/emit/run.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts; packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts
+- **Verified by:** packages/docx-core/src/generation/emit/run.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts; packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.ts; packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts; packages/docx-core/src/integration/ancillary-field-safety.test.ts
 
 The NUMPAGES instruction follows the same emission discipline as PAGE
 (` NUMPAGES `, preserved spacing, cached result required), giving
@@ -635,7 +641,7 @@ The NUMPAGES instruction follows the same emission discipline as PAGE
 - **Part / Section:** Part 1 § 17.16.5.45
 - **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
 - **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:instrText`
-- **Verified by:** packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts
+- **Verified by:** packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.ts; packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts; packages/docx-core/src/integration/ancillary-field-safety.test.ts
 
 Forced main-document rebuild classifies a self-contained PAGEREF instruction
 with one bookmark argument and a bounded switch vocabulary. When the complete
@@ -649,7 +655,7 @@ pagination, cached-result correctness, or field evaluation.
 - **Part / Section:** Part 1 § 17.16.5.51
 - **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
 - **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:instrText`
-- **Verified by:** packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts
+- **Verified by:** packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.ts; packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts; packages/docx-core/src/integration/ancillary-field-safety.test.ts; packages/docx-core/src/integration/nvca-coi-regression.test.ts
 
 Forced main-document rebuild classifies a self-contained REF instruction with
 one bookmark argument and a bounded switch vocabulary; the `\d` switch requires
@@ -1443,19 +1449,21 @@ section; they are described under
 in the root README.
 
 Within Part 1 §17.16, safe-docx targets structural emission of complex fields
-and the PAGE and NUMPAGES instructions listed above. Forced rebuild additionally
-classifies unchanged, self-contained main-document PAGE, NUMPAGES, REF, and
-PAGEREF fields for exact ordered-range passthrough. Unrelated direct-child edits
-may shift a field's paragraph-child positions; pairing instead uses stable
-paragraph ownership and field-range sequence. Non-revision wrappers such as
-`w:hyperlink` are preserved, while tracked-revision-owned, changed, reordered,
-cross-paragraph, or nested field rebuild is outside this bounded claim. Other
-field instructions retain the existing rebuild safety-diagnostics behavior and
-are not newly rejected merely for malformed structure. General field-code
-parsing and evaluation, ancillary-story topology preservation, cached-result
-correctness, pagination, and equivalence to a Word application's field engine
-are out of scope. The Lean XML verifier remains inapplicable to rebuild output
-and does not prove this topology-preservation invariant.
+and the PAGE and NUMPAGES instructions listed above. Forced main-story rebuild
+classifies unchanged, self-contained PAGE, NUMPAGES, REF, and PAGEREF fields
+for exact ordered-range passthrough. At the final package boundary, comparison
+also classifies eligible PAGE/NUMPAGES ranges in selected headers/footers and
+REF/PAGEREF ranges in individual note entries for source-first exact canonical
+evidence in both reconstruction modes. Exact whole-range equality, stable
+locators, source provenance, and note-entry isolation are SafeDocX
+metamorphic/evidence policies, not ECMA claims. Nested and cross-paragraph
+ranges are excluded from exact evidence but remain subject to strict story
+validation. General field-code parsing and evaluation, ancillary revision
+synthesis or text comparison, cached-result correctness, pagination, bookmark
+resolution, and equivalence to a Word application's field engine are out of
+scope. The Lean XML verifier remains protocol v3, inplace-only, and fixed to
+main/footnotes/endnotes; it does not prove this canonical-preservation
+invariant and still excludes headers/footers.
 
 Within Part 1 §17.11 and §17.13.4, safe-docx targets document-order note
 display numbering for Word-conventional packages plus generated
@@ -1464,6 +1472,12 @@ assignment, complete `w:type` or `w:customMarkFollows` display semantics,
 complete note-definition/reference integrity, relationship validation,
 arbitrary cross-paragraph comment ranges, threaded-comment semantics,
 resolution-state semantics, or repair of malformed third-party comment parts.
+Comparison's integer-canonical note-ID validation, rejection of invalid or
+numeric-equivalent duplicate direct IDs, contributor-aware post-collision
+provenance mapping, and per-entry validation are SafeDocX evidence-safety
+policies and do not broaden this into a complete note integrity or relationship
+claim. Unused merge-source note parts are outside the selected assembly
+evidence boundary.
 The compiled Lean checker independently covers fixed-story text projection and
 field-marker structure in `word/footnotes.xml` and `word/endnotes.xml`; it does
 not cover any of those excluded reference, relationship, anchor, or thread
@@ -1475,9 +1489,13 @@ header/footer bindings. The package audit resolves those bindings through the
 main-document relationships and checks the target story root. It does not
 implement pagination, section inheritance or omitted-role fallback semantics,
 style inheritance, layout, rendering, or assertions about arbitrary consumer
-behavior. Comparison preserves ancillary parts according to its documented
-in-place/rebuild rules; this registry does not claim semantic comparison of
-header or footer content across document versions.
+behavior. Direct binding placement, exact target-mode handling, URI/path
+normalization, and package containment use a shared SafeDocX OPC safety policy;
+they are not additional claims attributed to these clauses. Comparison
+preserves ancillary parts according to its documented
+in-place/rebuild rules and validates selected field stories before publication;
+this registry does not claim revision synthesis, text comparison, or semantic
+comparison of header or footer content across document versions.
 
 Within Part 1 §17.3, safe-docx targets the direct-formatting properties exposed
 by `ParagraphSpec` and `RunProps`: paragraph style references, keep controls,

--- a/spec-compliance/registry/ecma-376.md
+++ b/spec-compliance/registry/ecma-376.md
@@ -465,7 +465,7 @@ section: "17.10.5"
 url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
 schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:headerReference
 verifiedBy:
-  packages/docx-core/src/primitives/sectPrAudit.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts
+  packages/docx-core/src/primitives/sectPrAudit.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts; packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.ts; packages/docx-core/src/integration/ancillary-field-safety.test.ts; packages/docx-core/src/integration/nvca-coi-regression.test.ts
 ```
 
 Each declared header slot (first/default/even) becomes its own part bound
@@ -482,7 +482,9 @@ rejected. Relative and package-absolute targets are normalized before lookup;
 URI-fragment semantics are outside this audit's supported OPC target model.
 Relationship reuse across sections is accepted. Pagination,
 role inheritance when a reference is absent, and reader rendering are not
-evaluated.
+evaluated. Comparison uses this same audit to select only valid direct
+section bindings; target normalization and package containment are additional
+SafeDocX safety policies rather than claims made by this clause.
 
 ## [ECMA-PART1-17-10-2] w:footerReference binding
 
@@ -493,7 +495,7 @@ section: "17.10.2"
 url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
 schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:footerReference
 verifiedBy:
-  packages/docx-core/src/primitives/sectPrAudit.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts
+  packages/docx-core/src/primitives/sectPrAudit.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts; packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.ts; packages/docx-core/src/integration/ancillary-field-safety.test.ts; packages/docx-core/src/integration/nvca-coi-regression.test.ts
 ```
 
 Footer references follow the same typed-binding discipline as header
@@ -528,7 +530,7 @@ part: 1
 section: "17.10.4"
 url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
 schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:hdr
-verifiedBy:
+verifiedBy: packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.ts; packages/docx-core/src/integration/ancillary-field-safety.test.ts
 ```
 
 Header parts are emitted as standalone `w:hdr` documents
@@ -544,7 +546,7 @@ part: 1
 section: "17.10.3"
 url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
 schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:ftr
-verifiedBy:
+verifiedBy: packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.ts; packages/docx-core/src/integration/ancillary-field-safety.test.ts; packages/docx-core/src/integration/nvca-coi-regression.test.ts
 ```
 
 Footer parts mirror header parts as `w:ftr` documents (word/footerN.xml);
@@ -608,7 +610,7 @@ part: 1
 section: "17.16.18"
 url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
 schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:fldChar
-verifiedBy: packages/docx-core/src/generation/emit/run.ts; packages/docx-core/src/generation/structural-checks.ts; packages/docx-compare/src/baselines/atomizer/inPlaceModifier-deletion.ts; packages/docx-compare/src/baselines/atomizer/pipeline.field-validation.test.ts; packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts; verification/lean/Tier2/XmlTripleChecker.lean; verification/registry/lean-xml-checker-coverage.json
+verifiedBy: packages/docx-core/src/generation/emit/run.ts; packages/docx-core/src/generation/structural-checks.ts; packages/docx-core/src/shared/field-structure.ts; packages/docx-compare/src/baselines/atomizer/inPlaceModifier-deletion.ts; packages/docx-compare/src/baselines/atomizer/pipeline.field-validation.test.ts; packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.ts; packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts; packages/docx-core/src/integration/ancillary-field-safety.test.ts; packages/docx-core/src/integration/nvca-coi-regression.test.ts; verification/lean/Tier2/XmlTripleChecker.lean; verification/registry/lean-xml-checker-coverage.json
 ```
 
 Every generated field is a complete five-run sequence — `fldChar begin`,
@@ -619,6 +621,8 @@ unrepresentable-by-omission; the structural validator runs a begin →
 separate → end state machine over every story part. The comparison path keeps
 these field-state markers outside the `w:del` payload wrappers shown by the
 Part 1 complex-field and deleted-field-code syntax.
+The runtime ancillary predicate adds fail-closed stack diagnostics without
+changing the Lean-pinned predicate or protocol.
 
 ## [ECMA-PART1-17-16-5-44] PAGE field instruction emission
 
@@ -628,7 +632,7 @@ part: 1
 section: "17.16.5.44"
 url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
 schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:instrText
-verifiedBy: packages/docx-core/src/generation/emit/run.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts; packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts
+verifiedBy: packages/docx-core/src/generation/emit/run.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts; packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.ts; packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts; packages/docx-core/src/integration/ancillary-field-safety.test.ts; packages/docx-core/src/integration/nvca-coi-regression.test.ts
 ```
 
 The PAGE instruction is emitted with canonical surrounding spaces
@@ -643,7 +647,7 @@ part: 1
 section: "17.16.5.42"
 url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
 schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:instrText
-verifiedBy: packages/docx-core/src/generation/emit/run.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts; packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts
+verifiedBy: packages/docx-core/src/generation/emit/run.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts; packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.ts; packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts; packages/docx-core/src/integration/ancillary-field-safety.test.ts
 ```
 
 The NUMPAGES instruction follows the same emission discipline as PAGE
@@ -658,7 +662,7 @@ part: 1
 section: "17.16.5.45"
 url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
 schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:instrText
-verifiedBy: packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts
+verifiedBy: packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.ts; packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts; packages/docx-core/src/integration/ancillary-field-safety.test.ts
 ```
 
 Forced main-document rebuild classifies a self-contained PAGEREF instruction
@@ -675,7 +679,7 @@ part: 1
 section: "17.16.5.51"
 url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
 schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:instrText
-verifiedBy: packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts
+verifiedBy: packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.ts; packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts; packages/docx-core/src/integration/ancillary-field-safety.test.ts; packages/docx-core/src/integration/nvca-coi-regression.test.ts
 ```
 
 Forced main-document rebuild classifies a self-contained REF instruction with
@@ -1699,19 +1703,21 @@ section; they are described under
 in the root README.
 
 Within Part 1 §17.16, safe-docx targets structural emission of complex fields
-and the PAGE and NUMPAGES instructions listed above. Forced rebuild additionally
-classifies unchanged, self-contained main-document PAGE, NUMPAGES, REF, and
-PAGEREF fields for exact ordered-range passthrough. Unrelated direct-child edits
-may shift a field's paragraph-child positions; pairing instead uses stable
-paragraph ownership and field-range sequence. Non-revision wrappers such as
-`w:hyperlink` are preserved, while tracked-revision-owned, changed, reordered,
-cross-paragraph, or nested field rebuild is outside this bounded claim. Other
-field instructions retain the existing rebuild safety-diagnostics behavior and
-are not newly rejected merely for malformed structure. General field-code
-parsing and evaluation, ancillary-story topology preservation, cached-result
-correctness, pagination, and equivalence to a Word application's field engine
-are out of scope. The Lean XML verifier remains inapplicable to rebuild output
-and does not prove this topology-preservation invariant.
+and the PAGE and NUMPAGES instructions listed above. Forced main-story rebuild
+classifies unchanged, self-contained PAGE, NUMPAGES, REF, and PAGEREF fields
+for exact ordered-range passthrough. At the final package boundary, comparison
+also classifies eligible PAGE/NUMPAGES ranges in selected headers/footers and
+REF/PAGEREF ranges in individual note entries for source-first exact canonical
+evidence in both reconstruction modes. Exact whole-range equality, stable
+locators, source provenance, and note-entry isolation are SafeDocX
+metamorphic/evidence policies, not ECMA claims. Nested and cross-paragraph
+ranges are excluded from exact evidence but remain subject to strict story
+validation. General field-code parsing and evaluation, ancillary revision
+synthesis or text comparison, cached-result correctness, pagination, bookmark
+resolution, and equivalence to a Word application's field engine are out of
+scope. The Lean XML verifier remains protocol v3, inplace-only, and fixed to
+main/footnotes/endnotes; it does not prove this canonical-preservation
+invariant and still excludes headers/footers.
 
 Within Part 1 §17.11 and §17.13.4, safe-docx targets document-order note
 display numbering for Word-conventional packages plus generated
@@ -1720,6 +1726,12 @@ assignment, complete `w:type` or `w:customMarkFollows` display semantics,
 complete note-definition/reference integrity, relationship validation,
 arbitrary cross-paragraph comment ranges, threaded-comment semantics,
 resolution-state semantics, or repair of malformed third-party comment parts.
+Comparison's integer-canonical note-ID validation, rejection of invalid or
+numeric-equivalent duplicate direct IDs, contributor-aware post-collision
+provenance mapping, and per-entry validation are SafeDocX evidence-safety
+policies and do not broaden this into a complete note integrity or relationship
+claim. Unused merge-source note parts are outside the selected assembly
+evidence boundary.
 The compiled Lean checker independently covers fixed-story text projection and
 field-marker structure in `word/footnotes.xml` and `word/endnotes.xml`; it does
 not cover any of those excluded reference, relationship, anchor, or thread
@@ -1731,9 +1743,13 @@ header/footer bindings. The package audit resolves those bindings through the
 main-document relationships and checks the target story root. It does not
 implement pagination, section inheritance or omitted-role fallback semantics,
 style inheritance, layout, rendering, or assertions about arbitrary consumer
-behavior. Comparison preserves ancillary parts according to its documented
-in-place/rebuild rules; this registry does not claim semantic comparison of
-header or footer content across document versions.
+behavior. Direct binding placement, exact target-mode handling, URI/path
+normalization, and package containment use a shared SafeDocX OPC safety policy;
+they are not additional claims attributed to these clauses. Comparison
+preserves ancillary parts according to its documented
+in-place/rebuild rules and validates selected field stories before publication;
+this registry does not claim revision synthesis, text comparison, or semantic
+comparison of header or footer content across document versions.
 
 Within Part 1 §17.3, safe-docx targets the direct-formatting properties exposed
 by `ParagraphSpec` and `RunProps`: paragraph style references, keep controls,


### PR DESCRIPTION
## Summary

- relationship-select valid section header/footer bindings from the assembled package instead of globbing part names
- strictly validate every selected header/footer and final note entry with independent field state
- emit source-first PAGE/NUMPAGES/REF/PAGEREF preservation evidence with base/import provenance
- reject unsafe targets, ambiguous note IDs, malformed selected stories, and terminal evidence mismatches before publication
- allow one ancillary-triggered inplace-to-rebuild fallback with typed diagnostics
- keep Lean protocol v3 and its fixed main/footnotes/endnotes, inplace-only scope unchanged

## Evidence

- real NVCA source-derived comparison passes in true inplace and forced rebuild with nonzero footer PAGE and footnote REF evidence
- original NVCA source-vs-filled large-diff regression remains covered
- focused docx-core: 52/52
- focused docx-compare: 57 passed, 23 Lean-binary skips
- full docx-core excluding three local-only LibreOffice tests: 1,242 passed, 2 expected failures, 3 skipped
- full docx-compare: 602 passed, 24 skipped
- build and workspace lint passed; 9 pre-existing warnings, 0 errors
- strict OpenSpec, spec coverage, conformance citations, generated conformance idempotence, and diff checks passed

LibreOffice-backed local-only tests were not rerun after final repair because macOS sandbox startup aborts inside AppKit even under `--headless`; CI does not install LibreOffice. No runtime dependency is added.

## Scope boundaries

This does not synthesize or compare ancillary revisions, evaluate fields, paginate, resolve bookmarks, establish complete note-reference integrity, or broaden the Lean certificate. Exact canonical range preservation is recorded as a SafeDocX metamorphic invariant, not an ECMA-376 requirement.

Refs #582