### PR TITLE
feat(compare): expose ignore_formatting + compare_moves on compare_documents (closes #625)

### DIFF
--- a/packages/docx-compare/src/compare-options.test.ts
+++ b/packages/docx-compare/src/compare-options.test.ts
@@ -1,0 +1,190 @@
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { DocxArchive } from '@usejunior/docx-core';
+import { describe, expect } from 'vitest';
+import { compareDocuments } from './index.js';
+import { testAllure, type AllureBddContext } from './testing/allure-test.js';
+import {
+  buildDocxFromBodyXml,
+  paragraphWithText,
+} from './testing/ooxml-fixtures.js';
+
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({ feature: 'Comparison Options' });
+const formatTest = test.conformance({
+  spec: 'ECMA-376',
+  edition: 5,
+  part: 1,
+  section: '17.13.5.31',
+});
+const moveTest = test
+  .conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.5.22' })
+  .conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.5.25' });
+
+const FIXED_DATE = new Date('2026-07-24T12:00:00Z');
+const REAL_FIXTURES_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../../tests/test_documents/open-agreements',
+);
+const MOVED_PARAGRAPH = 'The quick brown fox jumps over the lazy dog today';
+
+async function documentXml(docx: Buffer): Promise<string> {
+  return (await DocxArchive.load(docx)).getDocumentXml();
+}
+
+describe('compareDocuments options', () => {
+  formatTest(
+    'ignoreFormatting controls run-property revision detection',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      const original = await given('an italic run and a revised bold run with identical text', () =>
+        buildDocxFromBodyXml(
+          '<w:p><w:r><w:rPr><w:i/></w:rPr><w:t>Same text</w:t></w:r></w:p>',
+        ),
+      );
+      const revised = await given('the revised document applies bold formatting', () =>
+        buildDocxFromBodyXml(
+          '<w:p><w:r><w:rPr><w:b/></w:rPr><w:t>Same text</w:t></w:r></w:p>',
+        ),
+      );
+
+      const detected = await when('formatting comparison is explicitly enabled', () =>
+        compareDocuments(original, revised, {
+          engine: 'atomizer',
+          date: FIXED_DATE,
+          ignoreFormatting: false,
+        }),
+      );
+      const ignored = await when('formatting differences are ignored', () =>
+        compareDocuments(original, revised, {
+          engine: 'atomizer',
+          date: FIXED_DATE,
+          ignoreFormatting: true,
+        }),
+      );
+
+      await then('enabled formatting comparison emits a run-property revision', async () => {
+        expect(await documentXml(detected.document)).toContain('<w:rPrChange');
+      });
+      await and('ignored formatting emits no run-property revision', async () => {
+        expect(await documentXml(ignored.document)).not.toContain('<w:rPrChange');
+      });
+    },
+  );
+
+  moveTest(
+    'detectMoves prevents matching deleted and inserted content from becoming moves',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      const original = await given('a paragraph that moves from first to last position', () =>
+        buildDocxFromBodyXml(
+          paragraphWithText(MOVED_PARAGRAPH) +
+            paragraphWithText('Middle paragraph stays put') +
+            paragraphWithText('Final paragraph also stays'),
+        ),
+      );
+      const revised = await given('the same paragraph in its revised final position', () =>
+        buildDocxFromBodyXml(
+          paragraphWithText('Middle paragraph stays put') +
+            paragraphWithText('Final paragraph also stays') +
+            paragraphWithText(MOVED_PARAGRAPH),
+        ),
+      );
+
+      const compared = await when('move comparison is explicitly enabled', () =>
+        compareDocuments(original, revised, {
+          engine: 'atomizer',
+          date: FIXED_DATE,
+          detectMoves: true,
+        }),
+      );
+      const disabled = await when('move comparison is disabled', () =>
+        compareDocuments(original, revised, {
+          engine: 'atomizer',
+          date: FIXED_DATE,
+          detectMoves: false,
+        }),
+      );
+      const comparedXml = await documentXml(compared.document);
+      const disabledXml = await documentXml(disabled.document);
+
+      await then('enabled move comparison emits move revisions', () => {
+        expect(comparedXml).toContain('<w:moveFrom');
+        expect(comparedXml).toContain('<w:moveTo');
+      });
+      await and('disabled move comparison retains deletion and insertion revisions', () => {
+        expect(disabledXml).not.toContain('<w:moveFrom');
+        expect(disabledXml).not.toContain('<w:moveTo');
+        expect(disabledXml).toContain('<w:del');
+        expect(disabledXml).toContain('<w:ins');
+      });
+    },
+  );
+
+  test(
+    'omitted options preserve the current output bytes for a real-world DOCX fixture',
+    async ({ given, when, then }: AllureBddContext) => {
+      const fixture = await given('the checked-in Bonterms mutual NDA fixture', () =>
+        readFile(join(REAL_FIXTURES_DIR, 'bonterms-mutual-nda.docx')),
+      );
+
+      const omitted = await when('the fixture is compared with both options omitted', () =>
+        compareDocuments(fixture, fixture, {
+          engine: 'atomizer',
+          date: FIXED_DATE,
+        }),
+      );
+      const explicitDefaults = await when('the fixture is compared with current defaults explicit', () =>
+        compareDocuments(fixture, fixture, {
+          engine: 'atomizer',
+          date: FIXED_DATE,
+          ignoreFormatting: false,
+          detectMoves: true,
+        }),
+      );
+
+      await then('the complete DOCX output is byte-identical', () => {
+        expect(Buffer.compare(omitted.document, explicitDefaults.document)).toBe(0);
+      });
+    },
+  );
+
+  test(
+    'omitted options apply the documented defaults on a differing pair (format detection on, move detection on)',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      // A self-compare cannot prove the default *values* (no diff exists to act on).
+      // Compare a pair with BOTH a formatting change and a moved paragraph, with the
+      // options OMITTED, and assert the output carries the markup those defaults produce.
+      const original = await given('an italic paragraph plus a paragraph that will move to the end', () =>
+        buildDocxFromBodyXml(
+          '<w:p><w:r><w:rPr><w:i/></w:rPr><w:t>Formatting sample</w:t></w:r></w:p>' +
+            paragraphWithText(MOVED_PARAGRAPH) +
+            paragraphWithText('Static middle paragraph'),
+        ),
+      );
+      const revised = await given('the same text bolded, with the movable paragraph relocated last', () =>
+        buildDocxFromBodyXml(
+          '<w:p><w:r><w:rPr><w:b/></w:rPr><w:t>Formatting sample</w:t></w:r></w:p>' +
+            paragraphWithText('Static middle paragraph') +
+            paragraphWithText(MOVED_PARAGRAPH),
+        ),
+      );
+
+      const omitted = await when('the pair is compared with both options omitted', () =>
+        compareDocuments(original, revised, {
+          engine: 'atomizer',
+          date: FIXED_DATE,
+        }),
+      );
+      const omittedXml = await documentXml(omitted.document);
+
+      await then('the default (omitted) output detects the formatting change', () => {
+        expect(omittedXml).toContain('<w:rPrChange');
+      });
+      await and('the default (omitted) output detects the move', () => {
+        expect(omittedXml).toContain('<w:moveFrom');
+        expect(omittedXml).toContain('<w:moveTo');
+      });
+    },
+  );
+});

--- a/packages/docx-compare/src/compare-types.ts
+++ b/packages/docx-compare/src/compare-types.ts
@@ -6,8 +6,10 @@ export interface CompareOptions {
    * Default: current time.
    */
   date?: Date;
-  /** Ignore formatting differences. Default: true (v1) */
+  /** Ignore formatting differences. Default: false */
   ignoreFormatting?: boolean;
+  /** Detect content moved within the document. Default: true */
+  detectMoves?: boolean;
   /**
    * Atomizer-only normalization: merge adjacent <w:r> siblings with identical formatting
    * prior to comparison. This can reduce overly-granular diffs for heavily-fragmented docs.

--- a/packages/docx-compare/src/index.ts
+++ b/packages/docx-compare/src/index.ts
@@ -64,7 +64,16 @@ export async function compareDocuments(
   revised: Buffer,
   options: CompareOptions = {},
 ): Promise<CompareResult> {
-  const { engine = 'auto', author, date, reconstructionMode, premergeRuns, leanXmlVerifier } = options;
+  const {
+    engine = 'auto',
+    author,
+    date,
+    ignoreFormatting,
+    detectMoves,
+    reconstructionMode,
+    premergeRuns,
+    leanXmlVerifier,
+  } = options;
 
   if ((engine as string) === 'diffmatch') {
     throw new Error(
@@ -77,6 +86,14 @@ export async function compareDocuments(
     return compareDocumentsAtomizer(original, revised, {
       author,
       date,
+      formatDetection:
+        ignoreFormatting === undefined
+          ? undefined
+          : { detectFormatChanges: !ignoreFormatting },
+      moveDetection:
+        detectMoves === undefined
+          ? undefined
+          : { detectMoves },
       reconstructionMode,
       premergeRuns,
       leanXmlVerifier,

--- a/packages/docx-mcp/docs/tool-reference.generated.md
+++ b/packages/docx-mcp/docs/tool-reference.generated.md
@@ -304,6 +304,8 @@ Compare two documents and produce a tracked-changes output document. Provide ori
 | `save_to_local_path` | `string` | yes | Path to save the tracked-changes output (DOCX or .odt). |
 | `author` | `string` | no | Author name for track changes. Default: 'Comparison' (DOCX) or the configured AI author (ODF). |
 | `engine` | `enum("auto", "atomizer")` | no | Comparison engine (DOCX only). Default: 'auto'. |
+| `ignore_formatting` | `boolean` | no | Ignore formatting differences (DOCX only). Default: false. |
+| `compare_moves` | `boolean` | no | Detect moved content (DOCX only). Default: true. |
 
 ## `get_footnotes`
 

--- a/packages/docx-mcp/src/tool_catalog.ts
+++ b/packages/docx-mcp/src/tool_catalog.ts
@@ -469,6 +469,8 @@ export const SAFE_DOCX_TOOL_CATALOG = [
       save_to_local_path: z.string().describe('Path to save the tracked-changes output (DOCX or .odt).'),
       author: z.string().optional().describe("Author name for track changes. Default: 'Comparison' (DOCX) or the configured AI author (ODF)."),
       engine: z.enum(['auto', 'atomizer']).optional().describe("Comparison engine (DOCX only). Default: 'auto'."),
+      ignore_formatting: z.boolean().optional().describe('Ignore formatting differences (DOCX only). Default: false.'),
+      compare_moves: z.boolean().optional().describe('Detect moved content (DOCX only). Default: true.'),
     }),
     annotations: { readOnlyHint: true, destructiveHint: false },
   },

--- a/packages/docx-mcp/src/tools/compare_documents.test.ts
+++ b/packages/docx-mcp/src/tools/compare_documents.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect } from 'vitest';
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { createZipBuffer } from '@usejunior/docx-core';
+import { createZipBuffer, DocxArchive } from '@usejunior/docx-core';
 
 import { compareDocuments_tool } from './compare_documents.js';
 import { replaceText } from './replace_text.js';
@@ -16,7 +16,7 @@ import {
   openSession,
 } from '../testing/session-test-utils.js';
 
-const FEATURE_NAME = 'compare-documents-tool';
+const FEATURE_NAME = 'Compare Documents Tool';
 
 const CONTENT_TYPES_XML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
@@ -35,11 +35,17 @@ function xmlEscape(text: string): string {
 }
 
 async function makeCompleteDocx(paragraphs: string[]): Promise<Buffer> {
+  return makeDocxFromBodyXml(
+    paragraphs.map((t) => `<w:p><w:r><w:t>${xmlEscape(t)}</w:t></w:r></w:p>`).join(''),
+  );
+}
+
+async function makeDocxFromBodyXml(bodyXml: string): Promise<Buffer> {
   const documentXml =
     `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
     `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
     `<w:body>` +
-    paragraphs.map((t) => `<w:p><w:r><w:t>${xmlEscape(t)}</w:t></w:r></w:p>`).join('') +
+    bodyXml +
     `</w:body></w:document>`;
 
   return createZipBuffer({
@@ -54,6 +60,17 @@ async function writeTestDocx(dir: string, name: string, paragraphs: string[]): P
   const p = path.join(dir, name);
   await fs.writeFile(p, new Uint8Array(buf));
   return p;
+}
+
+async function writeBodyTestDocx(dir: string, name: string, bodyXml: string): Promise<string> {
+  const buf = await makeDocxFromBodyXml(bodyXml);
+  const p = path.join(dir, name);
+  await fs.writeFile(p, new Uint8Array(buf));
+  return p;
+}
+
+async function readDocumentXml(docxPath: string): Promise<string> {
+  return (await DocxArchive.load(await fs.readFile(docxPath))).getDocumentXml();
 }
 
 describe('compare_documents tool', () => {
@@ -77,6 +94,7 @@ describe('compare_documents tool', () => {
           original_file_path: originalPath,
           revised_file_path: revisedPath,
           save_to_local_path: outputPath,
+          author: 'Tool Test Author',
         }),
       );
       assertSuccess(result, 'compare_documents');
@@ -94,6 +112,89 @@ describe('compare_documents tool', () => {
         expect(result.saved_to).toBe(outputPath);
         expect(result.size_bytes).toBeGreaterThan(0);
         expect(result.engine_used).toBeDefined();
+      });
+
+      await then('the requested author is forwarded to generated revisions', async () => {
+        expect(await readDocumentXml(outputPath)).toContain('w:author="Tool Test Author"');
+      });
+    },
+  );
+
+  test(
+    'ignore_formatting suppresses formatting revisions',
+    async ({ given, when, then }: AllureBddContext) => {
+      const mgr = createTestSessionManager();
+      const dir = await createTrackedTempDir();
+      const originalPath = await given('an italic run', () =>
+        writeBodyTestDocx(
+          dir,
+          'format-original.docx',
+          '<w:p><w:r><w:rPr><w:i/></w:rPr><w:t>Same text</w:t></w:r></w:p>',
+        ),
+      );
+      const revisedPath = await given('the same run made bold', () =>
+        writeBodyTestDocx(
+          dir,
+          'format-revised.docx',
+          '<w:p><w:r><w:rPr><w:b/></w:rPr><w:t>Same text</w:t></w:r></w:p>',
+        ),
+      );
+      const outputPath = path.join(dir, 'format-redline.docx');
+
+      const result = await when('compare_documents ignores formatting', () =>
+        compareDocuments_tool(mgr, {
+          original_file_path: originalPath,
+          revised_file_path: revisedPath,
+          save_to_local_path: outputPath,
+          ignore_formatting: true,
+        }),
+      );
+
+      await then('the output contains no run-property revision', async () => {
+        assertSuccess(result, 'compare_documents');
+        expect(await readDocumentXml(outputPath)).not.toContain('<w:rPrChange');
+      });
+    },
+  );
+
+  test(
+    'compare_moves disables conversion of matching changes into moves',
+    async ({ given, when, then }: AllureBddContext) => {
+      const mgr = createTestSessionManager();
+      const dir = await createTrackedTempDir();
+      const moved = 'The quick brown fox jumps over the lazy dog today';
+      const originalPath = await given('a paragraph in first position', () =>
+        writeTestDocx(dir, 'move-original.docx', [
+          moved,
+          'Middle paragraph stays put',
+          'Final paragraph also stays',
+        ]),
+      );
+      const revisedPath = await given('the same paragraph in final position', () =>
+        writeTestDocx(dir, 'move-revised.docx', [
+          'Middle paragraph stays put',
+          'Final paragraph also stays',
+          moved,
+        ]),
+      );
+      const outputPath = path.join(dir, 'move-redline.docx');
+
+      const result = await when('compare_documents disables move detection', () =>
+        compareDocuments_tool(mgr, {
+          original_file_path: originalPath,
+          revised_file_path: revisedPath,
+          save_to_local_path: outputPath,
+          compare_moves: false,
+        }),
+      );
+
+      await then('the output uses deletion and insertion revisions instead of moves', async () => {
+        assertSuccess(result, 'compare_documents');
+        const xml = await readDocumentXml(outputPath);
+        expect(xml).not.toContain('<w:moveFrom');
+        expect(xml).not.toContain('<w:moveTo');
+        expect(xml).toContain('<w:del');
+        expect(xml).toContain('<w:ins');
       });
     },
   );
@@ -293,6 +394,8 @@ describe('compare_documents tool', () => {
       expect(tool!.inputSchema.properties).toHaveProperty('revised_file_path');
       expect(tool!.inputSchema.properties).toHaveProperty('file_path');
       expect(tool!.inputSchema.properties).toHaveProperty('engine');
+      expect(tool!.inputSchema.properties).toHaveProperty('ignore_formatting');
+      expect(tool!.inputSchema.properties).toHaveProperty('compare_moves');
     },
   );
 });

--- a/packages/docx-mcp/src/tools/compare_documents.ts
+++ b/packages/docx-mcp/src/tools/compare_documents.ts
@@ -36,6 +36,8 @@ export async function compareDocuments_tool(
     save_to_local_path: string;
     author?: string;
     engine?: string;
+    ignore_formatting?: boolean;
+    compare_moves?: boolean;
   },
 ): Promise<ToolResponse> {
   try {
@@ -120,6 +122,8 @@ export async function compareDocuments_tool(
       compareDocuments(originalBuffer, revisedBuffer, {
         author,
         engine: compareEngine,
+        ignoreFormatting: params.ignore_formatting,
+        detectMoves: params.compare_moves,
         reconstructionMode: DEFAULT_RECONSTRUCTION_MODE,
       }),
     );


### PR DESCRIPTION
## Summary
Exposes two comparison knobs the atomizer already supports — `ignore_formatting` and `compare_moves` — through both the `compareDocuments()` API and the `compare_documents` MCP tool. Previously the public entry and MCP schema forwarded only `author`/`engine`, so callers couldn't suppress formatting revisions or toggle move detection.

## Changes
- **`compare-types.ts`**: `CompareOptions` gains `detectMoves`; `ignoreFormatting` doc comment corrected to the real default (`false`).
- **`index.ts`**: threads `ignoreFormatting → formatDetection.detectFormatChanges` (inverted) and `detectMoves → moveDetection.detectMoves`; passes `undefined` when omitted so the atomizer coalesces to `DEFAULT_*_SETTINGS` (byte-unchanged output).
- **`docx-mcp`**: `compare_documents` gains `ignore_formatting` + `compare_moves` params (forwarded); tool reference regenerated.

## Default preservation (the critical invariant)
`docx-core` defaults are `detectMoves=true` / `detectFormatChanges=true` (`core-types.ts:239,277`), matching the corrected doc comments. Omitting both options passes `undefined` through to the atomizer's `...DEFAULT, ...undefined` merge → defaults unchanged.

## Tests
- Engine-level toggles, both directions (`ignoreFormatting` gates `<w:rPrChange>`; `detectMoves` gates `<w:moveFrom>/<w:moveTo>` vs `<w:del>/<w:ins>`).
- Self-compare byte-identity (`omitted ≡ explicit-defaults`).
- **Differing-pair omitted-defaults guard** (added in review): a fixture pair with a formatting change + a move, compared with options **omitted**, asserts the output contains `<w:rPrChange>` and `<w:moveFrom>` — guards the default *values*, not just mapping equivalence.
- MCP `author`-forwarding covered per the issue.

## Verification
- [x] `docx-compare`: 629 passed / 24 skipped
- [x] `docx-mcp`: 897 passed
- [x] lint:workspaces, conformance-citations/doc, allure-labels (Title Case), tool-docs idempotent — all pass
- [x] Defaults byte-unchanged (self-compare + differing-pair guards)

## Peer review
agy (Gemini 3.1 Pro): PASS on all checks. Codex: implementation correct + byte-identical to main; flagged the original self-compare test as too weak to guard defaults (BLOCKER) → addressed with the differing-pair guard above.

## Scope
No header/footer comparison (`ignore_headers_and_footers`) — separate, larger effort (atomizer diffs `word/document.xml` only). No default behavior change.

Closes #625. Unblocks legal-agent-harness #199 P1a (routing redline compare through the safe-docx MCP with per-site options).