### PR TITLE
test(docx-compare): cover documentReconstructor provenance + structure paths

### DIFF
--- a/packages/docx-compare/src/baselines/atomizer/documentReconstructor-provenance.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/documentReconstructor-provenance.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Characterization tests for the rebuild-side original-`w:ins` provenance
+ * threading in documentReconstructor (issue #358).
+ *
+ * When merged atoms whose ORIGINAL lineage sat inside a pre-tracked `<w:ins>`
+ * are reconstructed on the rebuild path, the reconstructor must nest the fresh
+ * comparison deletion inside a restored insertion —
+ * `<w:ins original-author><w:del>…</w:del></w:ins>` — so that reject-all drops
+ * the content together with the original insertion (INV-RT-001), while
+ * accept-all unwraps the emptied insertion. These paths
+ * (`partitionAtomsByInsProvenance`, `buildRunGroupXmlWithInsProvenance`, and the
+ * whole-paragraph provenance branch of `buildParagraphXml`) are reachable only
+ * by handing `reconstructDocument` atoms that carry an original `w:ins`
+ * `revTrackElement`, which no pipeline-driven sibling test produces.
+ *
+ * @see https://github.com/UseJunior/safe-docx/issues/358
+ */
+
+import { describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
+import { el } from '../../testing/dom-test-helpers.js';
+import { reconstructDocument } from './documentReconstructor.js';
+import type { ComparisonUnitAtom, OpcPart } from '@usejunior/docx-core';
+import { CorrelationStatus } from '@usejunior/docx-core';
+
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({ feature: 'Document Reconstructor Provenance' });
+
+const PART: OpcPart = { uri: 'word/document.xml', contentType: 'text/xml' };
+const OPTS = { author: 'Comparison', date: new Date('2025-01-01T00:00:00Z') };
+
+const MINIMAL_BODY = [
+  '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>',
+  '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">',
+  '<w:body>',
+  '<w:p><w:r><w:t>placeholder</w:t></w:r></w:p>',
+  '</w:body>',
+  '</w:document>',
+].join('');
+
+/**
+ * Build a Deleted atom. When `insAuthor` is provided the atom is annotated as
+ * an original-tree atom whose lineage sat inside a pre-tracked `<w:ins>`, so
+ * `getOriginalInsProvenance` resolves to that author.
+ */
+function deletedAtom(
+  text: string,
+  opts: { insAuthor?: string; insDate?: string; paragraphIndex?: number } = {},
+): ComparisonUnitAtom {
+  const textEl = el('w:t', {}, undefined, text);
+  const run = el('w:r', {}, [textEl]);
+  const paragraph = el('w:p', {}, [run]);
+  const atom: ComparisonUnitAtom = {
+    sha1Hash: `hash-${text}`,
+    correlationStatus: CorrelationStatus.Deleted,
+    contentElement: textEl,
+    ancestorElements: [paragraph, run],
+    ancestorUnids: [],
+    part: PART,
+    paragraphIndex: opts.paragraphIndex ?? 0,
+    sourceDocument: 'original',
+    rPr: null,
+  };
+  if (opts.insAuthor) {
+    const insAttrs: Record<string, string> = { 'w:author': opts.insAuthor };
+    if (opts.insDate) insAttrs['w:date'] = opts.insDate;
+    atom.revTrackElement = el('w:ins', insAttrs);
+  }
+  return atom;
+}
+
+describe('documentReconstructor original-ins provenance (issue #358, rebuild path)', () => {
+  test('whole-paragraph delete of pre-tracked-inserted text nests w:del inside a restored w:ins', async ({
+    given,
+    when,
+    then,
+    and,
+  }: AllureBddContext) => {
+    let xml: string;
+
+    await given('a fully-deleted paragraph whose words came from an original w:ins by "Alice"', () => {});
+
+    await when('the document is reconstructed', () => {
+      const atoms = [
+        deletedAtom('deleted', { insAuthor: 'Alice', insDate: '2024-06-01T00:00:00Z' }),
+        deletedAtom('words', { insAuthor: 'Alice', insDate: '2024-06-01T00:00:00Z' }),
+      ];
+      xml = reconstructDocument(atoms, MINIMAL_BODY, OPTS);
+    });
+
+    await then('the deletion is wrapped in a restored insertion attributed to the original author', () => {
+      expect(xml).toContain('<w:ins');
+      expect(xml).toContain('w:author="Alice"');
+      expect(xml).toContain('w:date="2024-06-01T00:00:00Z"');
+      expect(xml).toContain('<w:del');
+      expect(xml).toContain('<w:delText');
+    });
+
+    await and('the restored insertion directly encloses the content deletion (ins outside, del inside)', () => {
+      // The pPr carries an independent paragraph-mark w:del; the content
+      // nesting is the w:ins by Alice immediately wrapping a w:del.
+      expect(xml).toMatch(/<w:ins\b[^>]*w:author="Alice"[^>]*>\s*<w:del\b/);
+    });
+  });
+
+  test('a provenance boundary splits one run group into separate w:del spans', async ({
+    given,
+    when,
+    then,
+    and,
+  }: AllureBddContext) => {
+    let xml: string;
+
+    await given('a deleted run mixing pre-tracked-inserted words with plain words', () => {});
+
+    await when('the paragraph is NOT wholly deleted so the inline provenance path runs', () => {
+      // A trailing Equal atom keeps the paragraph from being an entire-paragraph
+      // delete, routing the deleted run through buildRunGroupXmlWithInsProvenance.
+      const equalTextEl = el('w:t', {}, undefined, 'kept');
+      const equalRun = el('w:r', {}, [equalTextEl]);
+      const equalPara = el('w:p', {}, [equalRun]);
+      const equal: ComparisonUnitAtom = {
+        sha1Hash: 'hash-kept',
+        correlationStatus: CorrelationStatus.Equal,
+        contentElement: equalTextEl,
+        ancestorElements: [equalPara, equalRun],
+        ancestorUnids: [],
+        part: PART,
+        paragraphIndex: 0,
+        sourceDocument: 'revised',
+        rPr: null,
+      };
+      const atoms = [
+        deletedAtom('fromIns', { insAuthor: 'Bob', insDate: '2024-02-02T00:00:00Z' }),
+        deletedAtom('plain'),
+        equal,
+      ];
+      xml = reconstructDocument(atoms, MINIMAL_BODY, OPTS);
+    });
+
+    await then('the pre-tracked span is wrapped in a restored w:ins by "Bob"', () => {
+      expect(xml).toContain('w:author="Bob"');
+      expect(xml).toContain('<w:ins');
+    });
+
+    await and('the plain deleted span and the equal text are still emitted', () => {
+      expect(xml).toContain('<w:del');
+      expect(xml).toContain('plain');
+      expect(xml).toContain('kept');
+    });
+  });
+
+  test('provenance atoms sharing one author collapse into a single restored insertion span', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    let xml: string;
+
+    await given('two adjacent deleted atoms from the same original w:ins author+date', () => {});
+
+    await when('the whole paragraph is reconstructed', () => {
+      const atoms = [
+        deletedAtom('one', { insAuthor: 'Carol', insDate: '2024-03-03T00:00:00Z' }),
+        deletedAtom('two', { insAuthor: 'Carol', insDate: '2024-03-03T00:00:00Z' }),
+      ];
+      xml = reconstructDocument(atoms, MINIMAL_BODY, OPTS);
+    });
+
+    await then('the two atoms share a single w:ins wrapper (one restored insertion)', () => {
+      const insCount = (xml.match(/<w:ins\b/g) ?? []).length;
+      expect(insCount).toBe(1);
+      expect(xml).toContain('w:author="Carol"');
+    });
+  });
+});

--- a/packages/docx-compare/src/baselines/atomizer/documentReconstructor-structure.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/documentReconstructor-structure.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Characterization tests for structural helpers of documentReconstructor:
+ * the legacy `buildDocument` splicer, the "no w:body" guards, and the
+ * paragraph/run-group boundary fallbacks in `shouldStartNewParagraph` /
+ * `shouldStartNewRunGroup`.
+ *
+ * These paths are reachable either directly (the exported legacy
+ * `buildDocument`) or by handing `reconstructDocument` atom streams whose
+ * `paragraphIndex` / `moveName` shapes drive the grouping fallbacks that
+ * pipeline-sourced atoms never produce.
+ */
+
+import { describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
+import { el } from '../../testing/dom-test-helpers.js';
+import { buildDocument, reconstructDocument } from './documentReconstructor.js';
+import type { ComparisonUnitAtom, OpcPart } from '@usejunior/docx-core';
+import { CorrelationStatus } from '@usejunior/docx-core';
+
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({ feature: 'Document Reconstructor Structure' });
+
+const PART: OpcPart = { uri: 'word/document.xml', contentType: 'text/xml' };
+const OPTS = { author: 'Comparison', date: new Date('2025-01-01T00:00:00Z') };
+
+function docXml(bodyInner: string): string {
+  return [
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>',
+    '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">',
+    '<w:body>',
+    bodyInner,
+    '</w:body>',
+    '</w:document>',
+  ].join('');
+}
+
+const MINIMAL_BODY = docXml('<w:p><w:r><w:t>placeholder</w:t></w:r></w:p>');
+
+/** Build a simple text atom with the given status and paragraph index. */
+function atom(
+  text: string,
+  opts: {
+    status?: CorrelationStatus;
+    paragraphIndex?: number | undefined;
+    moveName?: string;
+  } = {},
+): ComparisonUnitAtom {
+  const textEl = el('w:t', {}, undefined, text);
+  const run = el('w:r', {}, [textEl]);
+  const paragraph = el('w:p', {}, [run]);
+  const a: ComparisonUnitAtom = {
+    sha1Hash: `hash-${text}`,
+    correlationStatus: opts.status ?? CorrelationStatus.Equal,
+    contentElement: textEl,
+    ancestorElements: [paragraph, run],
+    ancestorUnids: [],
+    part: PART,
+    sourceDocument: 'revised',
+    rPr: null,
+  };
+  if ('paragraphIndex' in opts) a.paragraphIndex = opts.paragraphIndex;
+  else a.paragraphIndex = 0;
+  if (opts.moveName !== undefined) a.moveName = opts.moveName;
+  return a;
+}
+
+describe('legacy buildDocument splicer', () => {
+  test('splices reconstructed paragraphs between the original w:body tags', async ({
+    given,
+    when,
+    then,
+    and,
+  }: AllureBddContext) => {
+    let result: string;
+
+    await given('an original document and two reconstructed paragraph fragments', () => {});
+
+    await when('buildDocument splices them in', () => {
+      result = buildDocument(
+        docXml('<w:p><w:r><w:t>old</w:t></w:r></w:p>'),
+        ['<w:p><w:r><w:t>one</w:t></w:r></w:p>', '<w:p><w:r><w:t>two</w:t></w:r></w:p>'],
+      );
+    });
+
+    await then('both new paragraphs appear inside the body', () => {
+      expect(result).toContain('<w:body>');
+      expect(result).toContain('one');
+      expect(result).toContain('two');
+    });
+
+    await and('the original body content is replaced, not appended', () => {
+      expect(result).not.toContain('old');
+    });
+  });
+
+  test('throws when the original document has no w:body', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    let thrown: Error | undefined;
+
+    await given('an original XML string with no w:body element', () => {});
+
+    await when('buildDocument is invoked', () => {
+      try {
+        buildDocument('<w:document xmlns:w="http://x"/>', ['<w:p/>']);
+      } catch (e) {
+        thrown = e as Error;
+      }
+    });
+
+    await then('it throws a "Could not find w:body" error', () => {
+      expect(thrown).toBeInstanceOf(Error);
+      expect(thrown?.message).toContain('Could not find w:body');
+    });
+  });
+});
+
+describe('reconstructDocument body guard', () => {
+  test('throws when the original XML lacks a w:body', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    let thrown: Error | undefined;
+
+    await given('a valid atom stream but an original XML with no w:body', () => {});
+
+    await when('reconstructDocument is invoked', () => {
+      try {
+        reconstructDocument([atom('text')], '<w:document xmlns:w="http://x"/>', OPTS);
+      } catch (e) {
+        thrown = e as Error;
+      }
+    });
+
+    await then('it throws a "Could not find w:body" error', () => {
+      expect(thrown).toBeInstanceOf(Error);
+      expect(thrown?.message).toContain('Could not find w:body');
+    });
+  });
+});
+
+describe('paragraph / run-group boundary fallbacks', () => {
+  test('an atom with no paragraphIndex stays in the current paragraph', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    let xml: string;
+
+    await given('two atoms where the second has an undefined paragraphIndex', () => {});
+
+    await when('the document is reconstructed', () => {
+      const atoms = [
+        atom('first', { paragraphIndex: 0 }),
+        atom('second', { paragraphIndex: undefined }),
+      ];
+      xml = reconstructDocument(atoms, MINIMAL_BODY, OPTS);
+    });
+
+    await then('both atoms land in a single paragraph (no split on the undefined index)', () => {
+      const paraCount = (xml.match(/<w:p\b/g) ?? []).length;
+      expect(paraCount).toBe(1);
+      expect(xml).toContain('first');
+      expect(xml).toContain('second');
+    });
+  });
+
+  test('adjacent same-status atoms with different move names split into separate run groups', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    let xml: string;
+
+    await given('two Equal atoms in one paragraph carrying different move names', () => {});
+
+    await when('the document is reconstructed', () => {
+      const atoms = [
+        atom('alpha', { status: CorrelationStatus.Equal, moveName: 'moveA' }),
+        atom('beta', { status: CorrelationStatus.Equal, moveName: 'moveB' }),
+      ];
+      xml = reconstructDocument(atoms, MINIMAL_BODY, OPTS);
+    });
+
+    await then('both texts survive as distinct runs (grouping split on move name)', () => {
+      expect(xml).toContain('alpha');
+      expect(xml).toContain('beta');
+      // Distinct move names force distinct run groups → two <w:r> runs.
+      const runCount = (xml.match(/<w:r\b/g) ?? []).length;
+      expect(runCount).toBeGreaterThanOrEqual(2);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Characterization tests for previously-uncovered branches of the atomizer `documentReconstructor`, lifting its statement coverage **84.3% → 88.9%**. Test-only; no production code changes.

## What's covered
**`documentReconstructor-provenance.test.ts`** — the issue-#358 rebuild-side original-`w:ins` provenance threading. When merged atoms whose ORIGINAL lineage sat inside a pre-tracked `<w:ins>` are reconstructed, the deletion must nest as `<w:ins original-author><w:del>…</w:del></w:ins>` so reject-all drops the content with the original insertion (INV-RT-001) while accept-all unwraps the emptied insertion. Exercises `partitionAtomsByInsProvenance`, `buildRunGroupXmlWithInsProvenance`, and the whole-paragraph provenance branch of `buildParagraphXml`. These are reachable only by handing `reconstructDocument` atoms carrying an original `w:ins` `revTrackElement` — no pipeline-driven sibling test produced them.
- whole-paragraph delete of pre-tracked-inserted text → nested `w:ins`/`w:del`
- a provenance boundary splits one run group into separate `w:del` spans (inline path)
- same-author atoms collapse into a single restored insertion span

**`documentReconstructor-structure.test.ts`** — structural helpers:
- legacy exported `buildDocument` splicer (happy path + `Could not find w:body` throw)
- `reconstructDocument` no-`w:body` guard throw
- `shouldStartNewParagraph` / `shouldStartNewRunGroup` boundary fallbacks (undefined `paragraphIndex`; differing `moveName`)

## Verification
- [x] Both new files green (8 tests)
- [x] Full `@usejunior/docx-compare` suite: 40 files, 644 passed, 24 skipped
- [x] `documentReconstructor.ts` coverage: 84.3% → 88.9% statements
- [x] eslint clean; `check:allure-labels` exit 0; `check:allure-quality` 0 errors

## Notes
Remaining uncovered lines are mostly defensive `OpaquePassthroughError` / body-block validation throws and specialized opaque-scaffold / hyperlink-resolver-absent paths that need elaborate malformed fixtures — candidates for a targeted follow-up. Two lines the analysis flagged as dead (a both-null rPr fast-path shadow and an empty-atoms guard) were intentionally not chased.

https://claude.ai/code/session_01P4C7hFonxn6KXJqb6GF1Th