### PR TITLE
test(docx-core): raise nvca-coi inplace test timeout 60s→180s for loaded CI

### DIFF
--- a/packages/docx-core/src/integration/nvca-coi-regression.test.ts
+++ b/packages/docx-core/src/integration/nvca-coi-regression.test.ts
@@ -122,7 +122,13 @@ describe('NVCA COI Regression', () => {
       const comparison = compareTexts(originalText, rejectedText);
       expect(comparison.normalizedIdentical).toBe(true);
     });
-  }, 60_000);
+    // This drives a full inplace comparison + accept-all + reject-all round-trip on a
+    // real ~5000-atom NVCA COI document. In isolation under v8 coverage it runs ~29s
+    // (measured identical on 0.18.0 and 0.19.0 — no regression), but in the release
+    // preflight it runs concurrently with the full docx-core suite under coverage +
+    // parallel workers, where CI contention pushed it past the previous 60s cap. Give
+    // it 3 min of headroom for the loaded CI environment.
+  }, 180_000);
 });
 
 describe('NVCA COI ancillary field evidence', () => {


### PR DESCRIPTION
## Summary
Raises the per-test timeout on `nvca-coi-regression.test.ts`'s inplace comparison test from 60s to 180s. This test failed the **v0.19.0 release preflight twice** (`Test timed out in 60000ms`), blocking publish.

## It is NOT a perf regression (measured)
Ran the test in isolation under v8 coverage on both versions:

| Version | inplace test duration |
|---|---|
| 0.18.0 | 28,826 ms |
| 0.19.0 | 29,886 ms |

~1s difference (3.7%) — flat. The compare-options change (#628) is off this test's code path.

## Root cause
The test is ~29s in isolation but runs concurrently with the full 1226-test docx-core suite under coverage + parallel workers in the release preflight, where CI contention roughly doubles it past the 60s cap. #623 dropped this test's inline timeout, defaulting it to the allure factory's 60s. 180s gives ~6× the isolated runtime as headroom for the loaded CI environment.

## Verification
- [x] All 3 tests in the file pass locally after a clean build (41.97s)
- [x] The bumped test itself passes (~29s isolated)

Unblocks the safe-docx 0.19.x release (which carries #628's `ignore_formatting`/`compare_moves`).