### PR TITLE
chore(release): bump workspace versions to 0.19.1

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-docx",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "AI-powered DOCX and ODT editing with tracked changes, redlining, and formatting preservation",
   "contextFileName": "GEMINI.md",
   "entrypoint": "GEMINI.md",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "safe-docx-suite",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "safe-docx-suite",
-      "version": "0.19.0",
+      "version": "0.19.1",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -8998,7 +8998,7 @@
     },
     "packages/allure-test-factory": {
       "name": "@usejunior/allure-test-factory",
-      "version": "0.19.0",
+      "version": "0.19.1",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"
@@ -9019,10 +9019,10 @@
     },
     "packages/docx-compare": {
       "name": "@usejunior/docx-compare",
-      "version": "0.19.0",
+      "version": "0.19.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@usejunior/docx-core": "^0.19.0",
+        "@usejunior/docx-core": "^0.19.1",
         "@xmldom/xmldom": "^0.9.10",
         "jszip": "^3.10.1"
       },
@@ -9046,7 +9046,7 @@
     },
     "packages/docx-core": {
       "name": "@usejunior/docx-core",
-      "version": "0.19.0",
+      "version": "0.19.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@xmldom/xmldom": "^0.9.10",
@@ -9057,7 +9057,7 @@
       },
       "devDependencies": {
         "@types/node": "^22.10.0",
-        "@usejunior/docx-compare": "^0.19.0",
+        "@usejunior/docx-compare": "^0.19.1",
         "@vitest/coverage-v8": "^4.1.8",
         "@vitest/runner": "^4.1.8",
         "allure-vitest": "^3.9.0",
@@ -9072,13 +9072,13 @@
     },
     "packages/docx-mcp": {
       "name": "@usejunior/docx-mcp",
-      "version": "0.19.0",
+      "version": "0.19.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@usejunior/docx-compare": "^0.19.0",
-        "@usejunior/docx-core": "^0.19.0",
-        "@usejunior/odf-core": "^0.19.0",
+        "@usejunior/docx-compare": "^0.19.1",
+        "@usejunior/docx-core": "^0.19.1",
+        "@usejunior/odf-core": "^0.19.1",
         "@xmldom/xmldom": "^0.9.10",
         "zod": "^4.3.6"
       },
@@ -9099,7 +9099,7 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@usejunior/google-docs-core": "^0.19.0"
+        "@usejunior/google-docs-core": "^0.19.1"
       },
       "peerDependenciesMeta": {
         "@usejunior/google-docs-core": {
@@ -9109,7 +9109,7 @@
     },
     "packages/google-docs-core": {
       "name": "@usejunior/google-docs-core",
-      "version": "0.19.0",
+      "version": "0.19.1",
       "license": "Apache-2.0",
       "dependencies": {
         "google-auth-library": "^9.0.0"
@@ -9125,10 +9125,10 @@
     },
     "packages/odf-core": {
       "name": "@usejunior/odf-core",
-      "version": "0.19.0",
+      "version": "0.19.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@usejunior/docx-core": "^0.19.0",
+        "@usejunior/docx-core": "^0.19.1",
         "@xmldom/xmldom": "^0.9.10",
         "jszip": "^3.10.1"
       },
@@ -9143,10 +9143,10 @@
     },
     "packages/safe-docx": {
       "name": "@usejunior/safe-docx",
-      "version": "0.19.0",
+      "version": "0.19.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@usejunior/docx-mcp": "^0.19.0"
+        "@usejunior/docx-mcp": "^0.19.1"
       },
       "bin": {
         "safe-docx": "bin/safe-docx.js",
@@ -9158,10 +9158,10 @@
     },
     "packages/safe-docx-mcpb": {
       "name": "@usejunior/safedocx-mcpb",
-      "version": "0.19.0",
+      "version": "0.19.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@usejunior/safe-docx": "^0.19.0"
+        "@usejunior/safe-docx": "^0.19.1"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-docx-suite",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "private": true,
   "description": "Monorepo for Safe DOCX packages",
   "repository": {

--- a/packages/allure-test-factory/package.json
+++ b/packages/allure-test-factory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/allure-test-factory",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Shared Allure test helpers for vitest — BDD context, OpenSpec auto-inference, Prism.js highlighting",
   "type": "module",
   "exports": {

--- a/packages/docx-compare/package.json
+++ b/packages/docx-compare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/docx-compare",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "DOCX comparison and redline generation for Safe DOCX.",
   "type": "module",
   "main": "dist/index.js",
@@ -18,7 +18,7 @@
     "cli": "node dist/cli/index.js"
   },
   "dependencies": {
-    "@usejunior/docx-core": "^0.19.0",
+    "@usejunior/docx-core": "^0.19.1",
     "@xmldom/xmldom": "^0.9.10",
     "jszip": "^3.10.1"
   },

--- a/packages/docx-core/package.json
+++ b/packages/docx-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/docx-core",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "OOXML (.docx) core library: primitives, document generation, and track changes",
   "type": "module",
   "main": "dist/index.js",
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.10.0",
-    "@usejunior/docx-compare": "^0.19.0",
+    "@usejunior/docx-compare": "^0.19.1",
     "@vitest/coverage-v8": "^4.1.8",
     "@vitest/runner": "^4.1.8",
     "allure-vitest": "^3.9.0",

--- a/packages/docx-mcp/package.json
+++ b/packages/docx-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/docx-mcp",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "MCP server for reading, editing, and comparing Word (.docx) and OpenDocument (.odt) files with tracked changes. For Claude, Gemini CLI, Cursor, and any MCP client. Apache-2.0 licensed.",
   "type": "module",
   "main": "dist/index.js",
@@ -27,9 +27,9 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@usejunior/docx-compare": "^0.19.0",
-    "@usejunior/docx-core": "^0.19.0",
-    "@usejunior/odf-core": "^0.19.0",
+    "@usejunior/docx-compare": "^0.19.1",
+    "@usejunior/docx-core": "^0.19.1",
+    "@usejunior/odf-core": "^0.19.1",
     "@xmldom/xmldom": "^0.9.10",
     "zod": "^4.3.6"
   },
@@ -57,7 +57,7 @@
     "NOTICE"
   ],
   "peerDependencies": {
-    "@usejunior/google-docs-core": "^0.19.0"
+    "@usejunior/google-docs-core": "^0.19.1"
   },
   "peerDependenciesMeta": {
     "@usejunior/google-docs-core": {

--- a/packages/google-docs-core/package.json
+++ b/packages/google-docs-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/google-docs-core",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Google Docs core library: read, write, and anchor management via Google Docs API",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/odf-core/package.json
+++ b/packages/odf-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/odf-core",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "OpenDocument Format (.odt) core library: archive packaging, document view, surgical text replacement, and tracked-changes comparison",
   "type": "module",
   "main": "dist/index.js",
@@ -14,7 +14,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@usejunior/docx-core": "^0.19.0",
+    "@usejunior/docx-core": "^0.19.1",
     "@xmldom/xmldom": "^0.9.10",
     "jszip": "^3.10.1"
   },

--- a/packages/safe-docx-mcpb/manifest.json
+++ b/packages/safe-docx-mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "safe-docx",
   "display_name": "Safe Docx",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "AI-native Word (.docx) and OpenDocument (.odt) editing with stable paragraph anchors and deterministic document operations.",
   "long_description": "Safe Docx lets Claude work directly with .docx files on your local filesystem. It provides stable paragraph IDs (_bk_*) for precise editing while preserving formatting and structure.\n\nCore capabilities include reading/searching content, formatting-preserving edits and inserts, deterministic layout controls, tracked-changes output, comments, footnote tools, document comparison, and revision extraction.",
   "author": {

--- a/packages/safe-docx-mcpb/package.json
+++ b/packages/safe-docx-mcpb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/safedocx-mcpb",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "private": true,
   "description": "Claude Desktop MCP Bundle (.mcpb) wrapper for @usejunior/safe-docx",
   "type": "module",
@@ -14,7 +14,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@usejunior/safe-docx": "^0.19.0"
+    "@usejunior/safe-docx": "^0.19.1"
   },
   "devDependencies": {
     "@vitest/runner": "^4.1.8",

--- a/packages/safe-docx/.smithery/shttp/manifest.json
+++ b/packages/safe-docx/.smithery/shttp/manifest.json
@@ -6,7 +6,7 @@
     "serverCard": {
       "serverInfo": {
         "name": "safe-docx",
-        "version": "0.19.0"
+        "version": "0.19.1"
       },
       "tools": [
         {

--- a/packages/safe-docx/package.json
+++ b/packages/safe-docx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/safe-docx",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Edit Word (.docx) and OpenDocument (.odt) files with tracked changes, redlines, and formatting preservation. Built for AI coding agents. Apache-2.0 licensed, 100% local processing.",
   "mcpName": "io.github.UseJunior/safe-docx",
   "type": "module",
@@ -25,7 +25,7 @@
     "safedocx": "./bin/safe-docx.js"
   },
   "dependencies": {
-    "@usejunior/docx-mcp": "^0.19.0"
+    "@usejunior/docx-mcp": "^0.19.1"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/safe-docx/server.json
+++ b/packages/safe-docx/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.UseJunior/safe-docx",
   "title": "Safe Docx",
   "description": "AI-native surgical editing of Word .docx and OpenDocument .odt files with formatting preservation",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "websiteUrl": "https://usejunior.com/developer-tools/safe-docx",
   "icons": [
     {
@@ -18,7 +18,7 @@
     {
       "registryType": "npm",
       "identifier": "@usejunior/safe-docx",
-      "version": "0.19.0",
+      "version": "0.19.1",
       "transport": {
         "type": "stdio"
       },

--- a/site/package.json
+++ b/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/safe-docx-site",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "private": true,
   "type": "module",
   "description": "Safe DOCX marketing and trust site (Eleventy)",


### PR DESCRIPTION
## Summary
Release **0.19.1**. Supersedes the failed 0.19.0 release (whose publish was blocked by a CI coverage-timeout flake, now fixed in #634).

## What's in this release
- **#628** — `compare_documents` exposes `ignore_formatting` + `compare_moves` (defaults byte-unchanged). Unblocks legal-agent-harness #199 P1a.
- **#634** — nvca-coi inplace test timeout 60s→180s (release-preflight stability; not a code change to shipped surface).
- Plus everything merged since 0.18.0 (#632 pBdr primitive, #630/#623 test coverage, etc.).

On merge, `auto-tag-release.yml` pushes `v0.19.1`, triggering `release.yml`. (Note: the release-bot App currently lacks push permission — if auto-tag 403s, the tag will be pushed via the documented manual fallback.)

The orphaned `v0.19.0` tag (never published) will be deleted.