### PR TITLE
test(docx-compare): cover atomizer pipeline auxiliary-merge + safety paths (closes #636)

### DIFF
--- a/packages/docx-compare/src/baselines/atomizer/pipeline-auxiliary-notes.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline-auxiliary-notes.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect } from 'vitest';
+import JSZip from 'jszip';
+import { buildSyntheticDocx } from '@usejunior/docx-core';
+import { compareDocumentsAtomizer } from './pipeline.js';
+import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
+
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({ feature: 'Pipeline Auxiliary Note Merge' });
+
+async function resultParts(docx: Buffer) {
+  const zip = await JSZip.loadAsync(docx);
+  const read = async (path: string): Promise<string | null> =>
+    (await zip.file(path)?.async('string')) ?? null;
+  return {
+    documentXml: await read('word/document.xml'),
+    footnotesXml: await read('word/footnotes.xml'),
+    endnotesXml: await read('word/endnotes.xml'),
+    contentTypesXml: await read('[Content_Types].xml'),
+    relsXml: await read('word/_rels/document.xml.rels'),
+  };
+}
+
+describe('pipeline auxiliary note publication', () => {
+  test('rebuild creates referenced footnote and endnote parts with package metadata', async ({
+    given,
+    when,
+    then,
+    and,
+  }: AllureBddContext) => {
+    let original: Buffer;
+    let revised: Buffer;
+    let result: Awaited<ReturnType<typeof compareDocumentsAtomizer>>;
+
+    await given('a plain original and a revised document with new footnote and endnote stories', async () => {
+      original = await buildSyntheticDocx({ paragraphs: ['Stable body text'] });
+      revised = await buildSyntheticDocx({
+        paragraphs: ['Stable body text'],
+        footnoteOnParagraph: 0,
+        footnoteText: 'Inserted footnote definition',
+        endnoteOnParagraph: 0,
+        endnoteText: 'Inserted endnote definition',
+      });
+    });
+
+    await when('the pair is compared using rebuild reconstruction', async () => {
+      result = await compareDocumentsAtomizer(original, revised, {
+        author: 'Pipeline test',
+        date: new Date('2025-01-01T00:00:00Z'),
+        reconstructionMode: 'rebuild',
+      });
+    });
+
+    await then('the emitted main story tracks both inserted note references', async () => {
+      const parts = await resultParts(result.document);
+      expect(parts.documentXml).toContain('<w:ins');
+      expect(parts.documentXml).toContain('<w:footnoteReference w:id="1"');
+      expect(parts.documentXml).toContain('<w:endnoteReference w:id="1"');
+    });
+
+    await and('the referenced definitions and reserved separator entries are published', async () => {
+      const parts = await resultParts(result.document);
+      expect(parts.footnotesXml).toContain('Inserted footnote definition');
+      expect(parts.footnotesXml).toContain('w:type="separator"');
+      expect(parts.footnotesXml).toContain('w:type="continuationSeparator"');
+      expect(parts.endnotesXml).toContain('Inserted endnote definition');
+      expect(parts.endnotesXml).toContain('w:type="separator"');
+      expect(parts.endnotesXml).toContain('w:type="continuationSeparator"');
+    });
+
+    await and('content types and document relationships advertise both created parts', async () => {
+      const parts = await resultParts(result.document);
+      expect(parts.contentTypesXml).toContain('PartName="/word/footnotes.xml"');
+      expect(parts.contentTypesXml).toContain('PartName="/word/endnotes.xml"');
+      expect(parts.relsXml).toContain('Target="footnotes.xml"');
+      expect(parts.relsXml).toContain('Target="endnotes.xml"');
+      expect(result.reconstructionModeUsed).toBe('rebuild');
+      expect(result.ancillaryFieldEvidence).toMatchObject({
+        status: 'passed',
+        reconstructionMode: 'rebuild',
+      });
+    });
+  });
+
+  test('rebuild appends a renumbered revised footnote to an existing original part', async ({
+    given,
+    when,
+    then,
+    and,
+  }: AllureBddContext) => {
+    let original: Buffer;
+    let revised: Buffer;
+    let result: Awaited<ReturnType<typeof compareDocumentsAtomizer>>;
+
+    await given('both documents use footnote id 1 for different definitions', async () => {
+      original = await buildSyntheticDocx({
+        paragraphs: ['Original body'],
+        footnoteOnParagraph: 0,
+        footnoteText: 'Original footnote definition',
+      });
+      revised = await buildSyntheticDocx({
+        paragraphs: ['Revised body'],
+        footnoteOnParagraph: 0,
+        footnoteText: 'Revised footnote definition',
+      });
+    });
+
+    await when('the collision-aware pipeline compares the documents', async () => {
+      result = await compareDocumentsAtomizer(original, revised, {
+        reconstructionMode: 'rebuild',
+        moveDetection: { detectMoves: false },
+      });
+    });
+
+    await then('the output preserves both independently authored definitions', async () => {
+      const parts = await resultParts(result.document);
+      expect(parts.footnotesXml).toContain('Original footnote definition');
+      expect(parts.footnotesXml).toContain('Revised footnote definition');
+    });
+
+    await and('the revised anchor points at a distinct non-reserved id', async () => {
+      const parts = await resultParts(result.document);
+      expect(parts.documentXml).toMatch(/<w:footnoteReference w:id="2"/);
+      expect(parts.footnotesXml).toMatch(/<w:footnote w:id="2"/);
+      expect(result.stats.insertions).toBeGreaterThan(0);
+      expect(result.stats.deletions).toBeGreaterThan(0);
+    });
+  });
+});

--- a/packages/docx-compare/src/baselines/atomizer/pipeline-comment-ancillary.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline-comment-ancillary.test.ts
@@ -1,0 +1,205 @@
+import JSZip from 'jszip';
+import { describe, expect } from 'vitest';
+import { buildSyntheticDocx } from '@usejunior/docx-core';
+import { compareDocumentsAtomizer } from './pipeline.js';
+import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
+
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({ feature: 'Pipeline Comment Ancillary Merge' });
+
+const COMMENTS_IDS_CONTENT_TYPE =
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.commentsIds+xml';
+const COMMENTS_IDS_REL_TYPE =
+  'http://schemas.microsoft.com/office/2016/09/relationships/commentsIds';
+
+async function resultParts(docx: Buffer) {
+  const zip = await JSZip.loadAsync(docx);
+  const read = async (path: string): Promise<string | null> =>
+    (await zip.file(path)?.async('string')) ?? null;
+  return {
+    documentXml: await read('word/document.xml'),
+    commentsXml: await read('word/comments.xml'),
+    commentsExtendedXml: await read('word/commentsExtended.xml'),
+    commentsIdsXml: await read('word/commentsIds.xml'),
+    peopleXml: await read('word/people.xml'),
+    contentTypesXml: await read('[Content_Types].xml'),
+    relsXml: await read('word/_rels/document.xml.rels'),
+  };
+}
+
+async function withCommentsIds(
+  docx: Buffer,
+  rows: ReadonlyArray<{ paraId: string; durableId: string }>,
+): Promise<Buffer> {
+  const zip = await JSZip.loadAsync(docx);
+  const contentTypes = await zip.file('[Content_Types].xml')!.async('string');
+  const relationships = await zip.file('word/_rels/document.xml.rels')!.async('string');
+  const rowsXml = rows
+    .map(
+      ({ paraId, durableId }) =>
+        `<w16cid:commentId w16cid:paraId="${paraId}" w16cid:durableId="${durableId}"/>`,
+    )
+    .join('');
+
+  zip.file(
+    'word/commentsIds.xml',
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+      `<w16cid:commentsIds xmlns:w16cid="http://schemas.microsoft.com/office/word/2016/wordml/cid">` +
+      `${rowsXml}</w16cid:commentsIds>`,
+  );
+  zip.file(
+    '[Content_Types].xml',
+    contentTypes.replace(
+      '</Types>',
+      `<Override PartName="/word/commentsIds.xml" ContentType="${COMMENTS_IDS_CONTENT_TYPE}"/></Types>`,
+    ),
+  );
+  zip.file(
+    'word/_rels/document.xml.rels',
+    relationships.replace(
+      '</Relationships>',
+      `<Relationship Id="rId99" Type="${COMMENTS_IDS_REL_TYPE}" Target="commentsIds.xml"/></Relationships>`,
+    ),
+  );
+  return (await zip.generateAsync({ type: 'nodebuffer' })) as Buffer;
+}
+
+describe('pipeline comment ancillary publication', () => {
+  test('rebuild bootstraps a new threaded comment graph and its durable identities', async ({
+    given,
+    when,
+    then,
+    and,
+  }: AllureBddContext) => {
+    let original: Buffer;
+    let revised: Buffer;
+    let result: Awaited<ReturnType<typeof compareDocumentsAtomizer>>;
+
+    await given('a revised document with a root comment, an unanchored reply, and all ancillary rows', async () => {
+      original = await buildSyntheticDocx({ paragraphs: ['Commented text'] });
+      revised = await withCommentsIds(
+        await buildSyntheticDocx({
+          paragraphs: ['Commented text'],
+          commentOnParagraph: 0,
+          commentText: 'Root review',
+          commentAuthor: 'Root Author',
+          replyText: 'Thread reply',
+          replyAuthor: 'Reply Author',
+          commentAncillaryParts: true,
+        }),
+        [
+          { paraId: '00000001', durableId: '11111111' },
+          { paraId: '00000002', durableId: '22222222' },
+          { paraId: 'UNRELATED', durableId: '99999999' },
+        ],
+      );
+    });
+
+    await when('the comparison publishes the inserted comment through rebuild mode', async () => {
+      result = await compareDocumentsAtomizer(original, revised, {
+        reconstructionMode: 'rebuild',
+        author: 'Pipeline test',
+      });
+    });
+
+    await then('the anchored root and graph-discovered reply definitions are both present', async () => {
+      const parts = await resultParts(result.document);
+      expect(parts.documentXml).toContain('<w:commentReference w:id="1"');
+      expect(parts.commentsXml).toContain('Root review');
+      expect(parts.commentsXml).toContain('Thread reply');
+    });
+
+    await and('threading, durable ids, and both authors are retained without unrelated rows', async () => {
+      const parts = await resultParts(result.document);
+      expect(parts.commentsExtendedXml).toContain('w15:paraId="00000002"');
+      expect(parts.commentsExtendedXml).toContain('w15:paraIdParent="00000001"');
+      expect(parts.commentsIdsXml).toContain('w16cid:durableId="11111111"');
+      expect(parts.commentsIdsXml).toContain('w16cid:durableId="22222222"');
+      expect(parts.commentsIdsXml).not.toContain('99999999');
+      expect(parts.peopleXml).toContain('w15:author="Root Author"');
+      expect(parts.peopleXml).toContain('w15:author="Reply Author"');
+    });
+
+    await and('every newly created ancillary part has OPC metadata', async () => {
+      const parts = await resultParts(result.document);
+      for (const path of [
+        '/word/comments.xml',
+        '/word/commentsExtended.xml',
+        '/word/commentsIds.xml',
+        '/word/people.xml',
+      ]) {
+        expect(parts.contentTypesXml).toContain(`PartName="${path}"`);
+      }
+      expect(parts.relsXml).toContain('Target="comments.xml"');
+      expect(parts.relsXml).toContain('Target="commentsExtended.xml"');
+      expect(parts.relsXml).toContain('Target="commentsIds.xml"');
+      expect(parts.relsXml).toContain('Target="people.xml"');
+    });
+  });
+
+  test('rebuild appends a colliding revised comment thread to existing ancillary parts', async ({
+    given,
+    when,
+    then,
+    and,
+  }: AllureBddContext) => {
+    let original: Buffer;
+    let revised: Buffer;
+    let result: Awaited<ReturnType<typeof compareDocumentsAtomizer>>;
+
+    await given('both sides contain distinct comment id 1 graphs with extension metadata', async () => {
+      original = await withCommentsIds(
+        await buildSyntheticDocx({
+          paragraphs: ['Original commented text'],
+          commentOnParagraph: 0,
+          commentText: 'Original root',
+          commentAuthor: 'Original Author',
+          commentAncillaryParts: true,
+        }),
+        [{ paraId: '00000001', durableId: 'AAAAAAAA' }],
+      );
+      revised = await withCommentsIds(
+        await buildSyntheticDocx({
+          paragraphs: ['Revised commented text'],
+          commentOnParagraph: 0,
+          commentText: 'Revised root',
+          commentAuthor: 'Revised Author',
+          replyText: 'Revised reply',
+          replyAuthor: 'Reply Author',
+          commentAncillaryParts: true,
+        }),
+        [
+          { paraId: '00000001', durableId: 'BBBBBBBB' },
+          { paraId: '00000002', durableId: 'CCCCCCCC' },
+        ],
+      );
+    });
+
+    await when('the pipeline resolves collisions and merges the revised graph', async () => {
+      result = await compareDocumentsAtomizer(original, revised, {
+        reconstructionMode: 'rebuild',
+        moveDetection: { detectMoves: false },
+      });
+    });
+
+    await then('all root and reply definitions survive under distinct ids', async () => {
+      const parts = await resultParts(result.document);
+      expect(parts.commentsXml).toContain('Original root');
+      expect(parts.commentsXml).toContain('Revised root');
+      expect(parts.commentsXml).toContain('Revised reply');
+      expect(parts.documentXml).toMatch(/<w:commentReference w:id="3"/);
+    });
+
+    await and('existing extension parts receive the revised thread rows and authors', async () => {
+      const parts = await resultParts(result.document);
+      expect(parts.commentsExtendedXml).toContain('w15:paraIdParent=');
+      expect(parts.commentsIdsXml).toContain('AAAAAAAA');
+      expect(parts.commentsIdsXml).toContain('BBBBBBBB');
+      expect(parts.commentsIdsXml).toContain('CCCCCCCC');
+      expect(parts.peopleXml).toContain('Original Author');
+      expect(parts.peopleXml).toContain('Revised Author');
+      expect(parts.peopleXml).toContain('Reply Author');
+    });
+  });
+});

--- a/packages/docx-compare/src/baselines/atomizer/pipeline-safety-guards.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline-safety-guards.test.ts
@@ -1,0 +1,160 @@
+import JSZip from 'jszip';
+import { describe, expect } from 'vitest';
+import type { ComparisonUnitAtom } from '@usejunior/docx-core';
+import { CorrelationStatus } from '@usejunior/docx-core';
+import { compareDocumentsAtomizer, computeAtomizerStats } from './pipeline.js';
+import { buildDocxFromBodyXml } from '../../testing/ooxml-fixtures.js';
+import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
+import { el } from '../../testing/dom-test-helpers.js';
+
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({ feature: 'Pipeline Safety Guard Diagnostics' });
+
+async function replacePart(docx: Buffer, path: string, xml: string): Promise<Buffer> {
+  const zip = await JSZip.loadAsync(docx);
+  zip.file(path, xml);
+  return (await zip.generateAsync({ type: 'nodebuffer' })) as Buffer;
+}
+
+function paragraph(text: string): string {
+  return `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
+}
+
+describe('pipeline safety and input guards', () => {
+  test('rejects a loadable package whose main part has no body', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    let original: Buffer;
+    let revised: Buffer;
+    let failure: unknown;
+
+    await given('one DOCX main part contains a document root without w:body', async () => {
+      const seed = await buildDocxFromBodyXml(paragraph('Original'));
+      original = await replacePart(
+        seed,
+        'word/document.xml',
+        `<?xml version="1.0" encoding="UTF-8"?>` +
+          `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"/>`,
+      );
+      revised = await buildDocxFromBodyXml(paragraph('Revised'));
+    });
+
+    await when('the atomizer attempts to enter the comparison pass', async () => {
+      try {
+        await compareDocumentsAtomizer(original, revised);
+      } catch (error) {
+        failure = error;
+      }
+    });
+
+    await then('the missing story container is reported explicitly', () => {
+      expect(failure).toBeInstanceOf(Error);
+      expect((failure as Error).message).toBe('Could not find w:body in one or both documents');
+    });
+  });
+
+  test('inplace publication falls back through rebuild when a contributing note part is malformed', async ({
+    given,
+    when,
+    then,
+    and,
+  }: AllureBddContext) => {
+    let original: Buffer;
+    let revised: Buffer;
+    let failure: unknown;
+
+    await given('the original references a footnote whose contributing XML part is truncated', async () => {
+      const originalSeed = await buildDocxFromBodyXml(
+        `${paragraph('Shared')}<w:p><w:r><w:footnoteReference w:id="1"/></w:r></w:p>`,
+      );
+      original = await replacePart(
+        originalSeed,
+        'word/footnotes.xml',
+        `<w:footnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
+          `<w:footnote w:id="1"><w:p>`,
+      );
+      revised = await buildDocxFromBodyXml(paragraph('Shared'));
+    });
+
+    await when('inplace comparison tries to publish the deleted note reference', async () => {
+      try {
+        await compareDocumentsAtomizer(original, revised, {
+          reconstructionMode: 'inplace',
+          moveDetection: { detectMoves: false },
+        });
+      } catch (error) {
+        failure = error;
+      }
+    });
+
+    await then('publication fails closed with typed ancillary note diagnostics', () => {
+      expect(failure).toBeInstanceOf(Error);
+      expect((failure as Error).name).toBe('AncillaryStorySafetyError');
+    });
+
+    await and('the diagnostic identifies invalid note-part XML rather than a text mismatch', () => {
+      expect(failure).toMatchObject({
+        issues: [
+          expect.objectContaining({
+            code: 'NOTE_PART_XML_INVALID',
+            locator: expect.objectContaining({
+              normalizedPartPath: 'word/footnotes.xml',
+            }),
+          }),
+        ],
+      });
+    });
+  });
+
+  test('stats ignore changed atoms that have no paragraph identity', async ({
+    given,
+    when,
+    then,
+    and,
+  }: AllureBddContext) => {
+    let atoms: ComparisonUnitAtom[];
+    let stats: ReturnType<typeof computeAtomizerStats>;
+
+    await given('inserted and deleted atoms whose ancestors contain no w:p element', () => {
+      const part = { uri: 'word/document.xml', contentType: 'text/xml' };
+      atoms = [
+        {
+          sha1Hash: 'deleted',
+          correlationStatus: CorrelationStatus.Deleted,
+          contentElement: el('w:t', {}, undefined, 'old'),
+          ancestorElements: [el('w:r')],
+          ancestorUnids: [],
+          part,
+        },
+        {
+          sha1Hash: 'inserted',
+          correlationStatus: CorrelationStatus.Inserted,
+          contentElement: el('w:t', {}, undefined, 'new'),
+          ancestorElements: [el('w:r')],
+          ancestorUnids: [],
+          part,
+        },
+      ];
+    });
+
+    await when('pipeline statistics are computed', () => {
+      stats = computeAtomizerStats(atoms);
+    });
+
+    await then('the atom and contiguous-range counts still reflect both changes', () => {
+      expect(stats).toMatchObject({
+        insertedAtoms: 1,
+        deletedAtoms: 1,
+        insertedRanges: 1,
+        deletedRanges: 1,
+      });
+    });
+
+    await and('neither orphan atom is misreported as a modified paragraph', () => {
+      expect(stats.modifiedParagraphs).toBe(0);
+    });
+  });
+});

--- a/packages/docx-compare/src/baselines/atomizer/pipeline-safety-guards.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline-safety-guards.test.ts
@@ -56,12 +56,16 @@ describe('pipeline safety and input guards', () => {
     });
   });
 
-  test('inplace publication falls back through rebuild when a contributing note part is malformed', async ({
+  test('inplace publication fails closed — the rebuild fallback also rejects a malformed contributing note part', async ({
     given,
     when,
     then,
     and,
   }: AllureBddContext) => {
+    // The inplace attempt throws AncillaryStorySafetyError; the pipeline then
+    // retries in rebuild mode, whose base archive still carries the corrupted
+    // footnotes.xml, so rebuild fails closed with the same typed diagnostic —
+    // which is what surfaces to the caller. We assert on that terminal error.
     let original: Buffer;
     let revised: Buffer;
     let failure: unknown;


### PR DESCRIPTION
## Summary
Characterization tests for the atomizer comparison pipeline (`compareDocumentsAtomizer` and its internal helpers), lifting `pipeline.ts` statement coverage **47.0% → 89.5%** (672/751). Test-only; no production changes. Implemented via `/codex-implement`, supervised + independently verified.

## What's covered
- **pipeline-auxiliary-notes.test.ts** — footnote/endnote auxiliary-part merging through the comparison + reconstruction path.
- **pipeline-comment-ancillary.test.ts** — comment-range ancillary-story merging and comment-part reconciliation.
- **pipeline-safety-guards.test.ts** — input/publication guards: missing-`w:body` rejection, `AncillaryStorySafetyError` fail-closed on a malformed note part (`NOTE_PART_XML_INVALID`), and `computeAtomizerStats` on paragraph-less orphan atoms.

Assertions are semantic — typed error names, diagnostic codes + locators, emitted OOXML markup, and `stats` shapes — not snapshot- or existence-only.

## Verification (independently re-run by supervisor)
- [x] `pipeline.ts` coverage 47.0% → **89.5%** (672/751 statements)
- [x] Full `@usejunior/docx-compare` suite: 43 files, **651 passed**, 24 skipped
- [x] eslint clean; `check:allure-labels` exit 0 (features: Pipeline Auxiliary Note Merge / Pipeline Comment Ancillary Merge / Pipeline Safety Guard Diagnostics)
- [ ] Peer review (agy + Codex) — pending; appended below

## Remaining uncovered
~79 lines: rare diagnostic-detail combinations, forced `ContainerResolutionError` recovery, rebuild round-trip failure, malformed-comment rethrow, and defensive early returns — candidates for a later targeted pass.

## Closes
- #636

https://claude.ai/code/session_01P4C7hFonxn6KXJqb6GF1Th