### PR TITLE
test(docx-compare): raise inPlaceModifier coverage 74.5% → 86.5% (refs #639)

### DIFF
--- a/packages/docx-compare/src/baselines/atomizer/inPlaceModifier-bookmark-boundaries.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/inPlaceModifier-bookmark-boundaries.test.ts
@@ -1,0 +1,129 @@
+import JSZip from 'jszip';
+import { describe, expect } from 'vitest';
+import { compareDocuments } from '../../index.js';
+import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
+import { buildDocxFromBodyXml } from '../../testing/ooxml-fixtures.js';
+
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({ feature: 'Inplace Deleted Paragraph Bookmark Boundaries' });
+
+async function compareInplace(originalBody: string, revisedBody: string) {
+  const original = await buildDocxFromBodyXml(originalBody);
+  const revised = await buildDocxFromBodyXml(revisedBody);
+  const result = await compareDocuments(original, revised, {
+    engine: 'atomizer',
+    reconstructionMode: 'inplace',
+  });
+  expect(result.reconstructionModeUsed).toBe('inplace');
+
+  const documentPart = (await JSZip.loadAsync(result.document)).file('word/document.xml');
+  if (!documentPart) throw new Error('comparison result omitted word/document.xml');
+  return { result, xml: await documentPart.async('string') };
+}
+
+/**
+ * Characterization of KNOWN-DEFECTIVE behavior — see issue #641.
+ *
+ * When a deleted paragraph's text was enclosed by bookmark boundary markers, the markers are
+ * hoisted out of the paragraph to body level and collapse into a zero-length range that no
+ * longer covers the text it named. The markers survive by name only; a cross-reference to the
+ * bookmark resolves to an empty span.
+ *
+ * These tests pin what the engine does today so the behavior cannot change unnoticed. They do
+ * NOT endorse it. When #641 is fixed, they must be rewritten to assert that the bookmark range
+ * still encloses the recreated `<w:del>` content — the way the move-source path already does
+ * (see inPlaceModifier-moved-bookmark-paragraph.test.ts).
+ *
+ * Body-level bookmarkStart/bookmarkEnd is schema-legal (CT_Body -> EG_BlockLevelElts ->
+ * EG_ContentBlockContent -> EG_RunLevelElts), so no validator flags this; the loss is semantic.
+ */
+describe('inplace deleted paragraph bookmark boundaries', () => {
+  test('DEFECT #641: hoists both boundary markers to body level, detaching the bookmark from the deleted text', async ({
+    given,
+    when,
+    then,
+    and,
+  }: AllureBddContext) => {
+    let xml: string;
+    let deletions: number;
+
+    await given('a removed paragraph whose text is enclosed by direct bookmark boundary markers', () => {});
+
+    await when('the documents are compared using inplace reconstruction', async () => {
+      const comparison = await compareInplace(
+        '<w:p><w:r><w:t>Leading survivor</w:t></w:r></w:p>'
+          + '<w:p><w:pPr><w:keepNext/></w:pPr>'
+          + '<w:bookmarkStart w:id="41" w:name="DeletedBoundary"/>'
+          + '<w:r><w:t>Bookmarked deleted text</w:t></w:r>'
+          + '<w:bookmarkEnd w:id="41"/></w:p>'
+          + '<w:p><w:r><w:t>Trailing survivor</w:t></w:r></w:p>',
+        '<w:p><w:r><w:t>Leading survivor</w:t></w:r></w:p>'
+          + '<w:p><w:r><w:t>Trailing survivor</w:t></w:r></w:p>',
+      );
+      xml = comparison.xml;
+      deletions = comparison.result.stats.deletions;
+    });
+
+    await then('the deletion is recorded and retains the original paragraph property', () => {
+      expect(deletions).toBeGreaterThan(0);
+      expect(xml).toContain('<w:keepNext/>');
+      expect(xml).toContain('<w:delText>Bookmarked</w:delText>');
+    });
+
+    await and('DEFECT #641: the markers collapse to an empty range outside the deleted paragraph', () => {
+      const start = xml.indexOf('<w:bookmarkStart w:id="41"');
+      const end = xml.indexOf('<w:bookmarkEnd w:id="41"');
+      const deletedText = xml.indexOf('<w:delText>Bookmarked</w:delText>');
+      expect(xml.match(/<w:bookmarkStart w:id="41"/g)).toHaveLength(1);
+      expect(xml.match(/<w:bookmarkEnd w:id="41"/g)).toHaveLength(1);
+
+      // Both markers land before the recreated paragraph, so the range spans no content at all.
+      expect(start).toBeGreaterThan(-1);
+      expect(end).toBeGreaterThan(start);
+      expect(end).toBeLessThan(deletedText);
+      expect(xml.slice(start, end)).not.toContain('<w:delText>');
+
+      // ...and they sit at body level rather than inside the paragraph holding the deletion.
+      const enclosingParagraphStart = xml.lastIndexOf('<w:p>', deletedText);
+      expect(enclosingParagraphStart).toBeGreaterThan(end);
+    });
+  });
+
+  test('DEFECT #641: hoists nested trailing bookmark ends ahead of the deleted fragments, preserving only their relative order', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    let xml: string;
+
+    await given('a removed multi-run paragraph ending two nested bookmarks', () => {});
+
+    await when('the documents are compared using inplace reconstruction', async () => {
+      ({ xml } = await compareInplace(
+        '<w:p><w:bookmarkStart w:id="51" w:name="Outer"/>'
+          + '<w:bookmarkStart w:id="52" w:name="Inner"/>'
+          + '<w:r><w:t>first deleted fragment</w:t></w:r>'
+          + '<w:r><w:t>second deleted fragment</w:t></w:r>'
+          + '<w:bookmarkEnd w:id="52"/><w:bookmarkEnd w:id="51"/></w:p>'
+          + '<w:p><w:r><w:t>survivor</w:t></w:r></w:p>',
+        '<w:p><w:r><w:t>survivor</w:t></w:r></w:p>',
+      ));
+    });
+
+    await then('both ends precede the fragments they should follow, but stay in nesting order', () => {
+      const finalText = xml.indexOf('<w:delText>fragment</w:delText>', xml.indexOf('second'));
+      const innerEnd = xml.indexOf('<w:bookmarkEnd w:id="52"');
+      const outerEnd = xml.indexOf('<w:bookmarkEnd w:id="51"');
+      expect(finalText).toBeGreaterThan(-1);
+      expect(innerEnd).toBeGreaterThan(-1);
+
+      // Correct output would place both ends AFTER the final fragment. They precede it instead.
+      expect(innerEnd).toBeLessThan(finalText);
+      expect(outerEnd).toBeLessThan(finalText);
+
+      // The one property the hoisting does keep: inner closes before outer.
+      expect(outerEnd).toBeGreaterThan(innerEnd);
+    });
+  });
+});

--- a/packages/docx-compare/src/baselines/atomizer/inPlaceModifier-empty-and-cell-paragraphs.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/inPlaceModifier-empty-and-cell-paragraphs.test.ts
@@ -1,0 +1,101 @@
+import JSZip from 'jszip';
+import { describe, expect } from 'vitest';
+import { compareDocuments } from '../../index.js';
+import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
+import { buildDocxFromBodyXml } from '../../testing/ooxml-fixtures.js';
+
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({ feature: 'Inplace Empty And Table Cell Paragraph Placement' });
+
+async function compareInplace(originalBody: string, revisedBody: string) {
+  const original = await buildDocxFromBodyXml(originalBody);
+  const revised = await buildDocxFromBodyXml(revisedBody);
+  const result = await compareDocuments(original, revised, {
+    engine: 'atomizer',
+    reconstructionMode: 'inplace',
+  });
+  expect(result.reconstructionModeUsed).toBe('inplace');
+
+  const documentPart = (await JSZip.loadAsync(result.document)).file('word/document.xml');
+  if (!documentPart) throw new Error('comparison result omitted word/document.xml');
+  return { result, xml: await documentPart.async('string') };
+}
+
+const paragraph = (text: string) => `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
+
+describe('inplace empty and table-cell paragraph placement', () => {
+  test('tracks an inserted and a deleted empty paragraph by paragraph marks', async ({
+    given,
+    when,
+    then,
+    and,
+  }: AllureBddContext) => {
+    let insertedXml: string;
+    let deletedXml: string;
+
+    await given('documents that respectively add and remove an empty paragraph between stable text', () => {});
+
+    await when('both pairs are compared using inplace reconstruction', async () => {
+      insertedXml = (await compareInplace(
+        `${paragraph('before')}<w:p/><w:p/>${paragraph('after')}`,
+        `${paragraph('before')}<w:p/><w:p/><w:p/>${paragraph('after')}`,
+      )).xml;
+      deletedXml = (await compareInplace(
+        `${paragraph('before')}<w:p/><w:p/><w:p/>${paragraph('after')}`,
+        `${paragraph('before')}<w:p/><w:p/>${paragraph('after')}`,
+      )).xml;
+    });
+
+    await then('the added empty paragraph receives a paragraph-mark insertion', () => {
+      expect(insertedXml).toMatch(/<w:p><w:pPr><w:rPr><w:ins\b[^>]*\/><\/w:rPr><\/w:pPr><\/w:p>/);
+    });
+
+    await and('the removed empty paragraph is recreated with a paragraph-mark deletion', () => {
+      expect(deletedXml).toMatch(/<w:p><w:pPr><w:rPr><w:del\b[^>]*\/><\/w:rPr><\/w:pPr><\/w:p>/);
+      expect(deletedXml).toContain('before');
+      expect(deletedXml).toContain('after');
+    });
+  });
+
+  test('recreates a removed first table-cell paragraph after cell properties', async ({
+    given,
+    when,
+    then,
+    and,
+  }: AllureBddContext) => {
+    let xml: string;
+    let deletions: number;
+
+    await given('a table cell whose first styled paragraph is removed while its second paragraph survives', () => {});
+
+    await when('the documents are compared using inplace reconstruction', async () => {
+      const comparison = await compareInplace(
+        '<w:tbl><w:tr><w:tc><w:tcPr><w:tcW w:w="2400" w:type="dxa"/></w:tcPr>'
+          + '<w:p><w:pPr><w:jc w:val="center"/></w:pPr><w:r><w:t>removed cell heading</w:t></w:r></w:p>'
+          + '<w:p><w:r><w:t>cell survivor</w:t></w:r></w:p>'
+          + '</w:tc></w:tr></w:tbl>',
+        '<w:tbl><w:tr><w:tc><w:tcPr><w:tcW w:w="2400" w:type="dxa"/></w:tcPr>'
+          + '<w:p><w:r><w:t>cell survivor</w:t></w:r></w:p>'
+          + '</w:tc></w:tr></w:tbl>',
+      );
+      xml = comparison.xml;
+      deletions = comparison.result.stats.deletions;
+    });
+
+    await then('the deleted heading remains in the same table cell with its alignment', () => {
+      expect(deletions).toBeGreaterThan(0);
+      expect(xml).toContain('<w:jc w:val="center"/>');
+      expect(xml).toContain('<w:delText>removed</w:delText>');
+    });
+
+    await and('cell properties remain first and precede the recreated paragraph', () => {
+      const cellProperties = xml.indexOf('<w:tcPr>');
+      const deletedHeading = xml.indexOf('<w:delText>removed</w:delText>');
+      const survivingText = xml.indexOf('<w:t>cell survivor</w:t>');
+      expect(cellProperties).toBeGreaterThan(-1);
+      expect(cellProperties).toBeLessThan(deletedHeading);
+      expect(deletedHeading).toBeLessThan(survivingText);
+    });
+  });
+});

--- a/packages/docx-compare/src/baselines/atomizer/inPlaceModifier-empty-and-cell-paragraphs.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/inPlaceModifier-empty-and-cell-paragraphs.test.ts
@@ -24,6 +24,14 @@ async function compareInplace(originalBody: string, revisedBody: string) {
 
 const paragraph = (text: string) => `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
 
+/**
+ * `CT_Tbl` requires `tblPr` and `tblGrid` before any `w:tr`. Omitting them makes the emitted
+ * document.xml fail the ECMA-376 corpus gate (`check_emitted_document_schema.mjs`), because the
+ * comparison faithfully reproduces whatever table shape it was given.
+ */
+const TABLE_PREAMBLE = '<w:tblPr><w:tblW w:w="2400" w:type="dxa"/></w:tblPr>'
+  + '<w:tblGrid><w:gridCol w:w="2400"/></w:tblGrid>';
+
 describe('inplace empty and table-cell paragraph placement', () => {
   test('tracks an inserted and a deleted empty paragraph by paragraph marks', async ({
     given,
@@ -71,11 +79,11 @@ describe('inplace empty and table-cell paragraph placement', () => {
 
     await when('the documents are compared using inplace reconstruction', async () => {
       const comparison = await compareInplace(
-        '<w:tbl><w:tr><w:tc><w:tcPr><w:tcW w:w="2400" w:type="dxa"/></w:tcPr>'
+        `<w:tbl>${TABLE_PREAMBLE}<w:tr><w:tc><w:tcPr><w:tcW w:w="2400" w:type="dxa"/></w:tcPr>`
           + '<w:p><w:pPr><w:jc w:val="center"/></w:pPr><w:r><w:t>removed cell heading</w:t></w:r></w:p>'
           + '<w:p><w:r><w:t>cell survivor</w:t></w:r></w:p>'
           + '</w:tc></w:tr></w:tbl>',
-        '<w:tbl><w:tr><w:tc><w:tcPr><w:tcW w:w="2400" w:type="dxa"/></w:tcPr>'
+        `<w:tbl>${TABLE_PREAMBLE}<w:tr><w:tc><w:tcPr><w:tcW w:w="2400" w:type="dxa"/></w:tcPr>`
           + '<w:p><w:r><w:t>cell survivor</w:t></w:r></w:p>'
           + '</w:tc></w:tr></w:tbl>',
       );

--- a/packages/docx-compare/src/baselines/atomizer/inPlaceModifier-moved-bookmark-paragraph.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/inPlaceModifier-moved-bookmark-paragraph.test.ts
@@ -1,0 +1,107 @@
+import JSZip from 'jszip';
+import { describe, expect } from 'vitest';
+import { compareDocuments } from '../../index.js';
+import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
+import { buildDocxFromBodyXml } from '../../testing/ooxml-fixtures.js';
+
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({ feature: 'Inplace Moved Paragraph Bookmark Reconstruction' });
+
+const paragraph = (text: string) => `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
+
+/**
+ * Returns the single `<w:p>` element enclosing `index`.
+ *
+ * Formatting assertions must be scoped this way: the move destination carries the same
+ * `w:pPr` as the recreated source, so a `toContain` check against the whole document body
+ * passes off the destination even when the source loses its properties entirely.
+ */
+function enclosingParagraph(xml: string, index: number): string {
+  const start = xml.lastIndexOf('<w:p>', index);
+  const end = xml.indexOf('</w:p>', index);
+  if (start === -1 || end === -1) throw new Error(`no enclosing w:p for index ${index}`);
+  return xml.slice(start, end + '</w:p>'.length);
+}
+
+async function compareInplace(originalBody: string, revisedBody: string) {
+  const original = await buildDocxFromBodyXml(originalBody);
+  const revised = await buildDocxFromBodyXml(revisedBody);
+  const result = await compareDocuments(original, revised, {
+    engine: 'atomizer',
+    reconstructionMode: 'inplace',
+    detectMoves: true,
+  });
+  expect(result.reconstructionModeUsed).toBe('inplace');
+
+  const documentPart = (await JSZip.loadAsync(result.document)).file('word/document.xml');
+  if (!documentPart) throw new Error('comparison result omitted word/document.xml');
+  return { result, xml: await documentPart.async('string') };
+}
+
+describe('inplace moved paragraph bookmark reconstruction', () => {
+  test('recreates a styled bookmarked move source after its preceding paragraph', async ({
+    given,
+    when,
+    then,
+    and,
+  }: AllureBddContext) => {
+    let xml: string;
+
+    const movedText = 'Distinctive relocated paragraph contains enough words for reliable move detection';
+    const originalMovedParagraph =
+      '<w:p><w:pPr><w:keepNext/><w:jc w:val="right"/></w:pPr>'
+      + '<w:bookmarkStart w:id="71" w:name="MovedBoundary"/>'
+      + `<w:r><w:t>${movedText}</w:t></w:r>`
+      + '<w:bookmarkEnd w:id="71"/></w:p>';
+    const revisedMovedParagraph =
+      '<w:p><w:pPr><w:keepNext/><w:jc w:val="right"/></w:pPr>'
+      + `<w:r><w:t>${movedText}</w:t></w:r></w:p>`;
+
+    await given('a styled bookmarked paragraph that moves from the middle to the end', () => {});
+
+    await when('the documents are compared with move detection and inplace reconstruction', async () => {
+      ({ xml } = await compareInplace(
+        `${paragraph('stable leading paragraph')}${originalMovedParagraph}${paragraph('stable trailing paragraph')}`,
+        `${paragraph('stable leading paragraph')}${paragraph('stable trailing paragraph')}${revisedMovedParagraph}`,
+      ));
+    });
+
+    await then('the comparison emits both source and destination move revisions', () => {
+      expect(xml).toContain('<w:moveFromRangeStart');
+      expect(xml).toContain('<w:moveFrom ');
+      expect(xml).toContain('<w:moveToRangeStart');
+      expect(xml).toContain('<w:moveTo ');
+    });
+
+    await and('the recreated source paragraph itself retains its formatting', () => {
+      const sourceParagraph = enclosingParagraph(xml, xml.indexOf('<w:moveFrom '));
+      expect(sourceParagraph).toContain('<w:keepNext/>');
+      expect(sourceParagraph).toContain('<w:jc w:val="right"/>');
+    });
+
+    await and('the bookmark range stays inside the recreated source, enclosing the moved-out text', () => {
+      const sourceParagraph = enclosingParagraph(xml, xml.indexOf('<w:moveFrom '));
+      expect(sourceParagraph.match(/<w:bookmarkStart w:id="71"/g)).toHaveLength(1);
+      expect(sourceParagraph.match(/<w:bookmarkEnd w:id="71"/g)).toHaveLength(1);
+      expect(sourceParagraph.indexOf('<w:bookmarkStart w:id="71"')).toBeLessThan(
+        sourceParagraph.indexOf('<w:moveFrom '),
+      );
+      expect(sourceParagraph.indexOf('<w:bookmarkEnd w:id="71"')).toBeGreaterThan(
+        sourceParagraph.lastIndexOf('<w:moveFrom '),
+      );
+      // The whole document carries exactly one pair — the move destination gets none.
+      expect(xml.match(/<w:bookmarkStart w:id="71"/g)).toHaveLength(1);
+      expect(xml.match(/<w:bookmarkEnd w:id="71"/g)).toHaveLength(1);
+    });
+
+    await and('the source is recreated in its original position, ahead of the destination', () => {
+      const source = xml.indexOf('<w:moveFrom ');
+      const destination = xml.indexOf('<w:moveTo ');
+      expect(source).toBeGreaterThan(xml.indexOf('stable leading paragraph'));
+      expect(source).toBeLessThan(xml.indexOf('stable trailing paragraph'));
+      expect(xml.indexOf('stable trailing paragraph')).toBeLessThan(destination);
+    });
+  });
+
+});

--- a/packages/docx-compare/src/baselines/atomizer/inPlaceModifier-original-insertion-provenance.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/inPlaceModifier-original-insertion-provenance.test.ts
@@ -1,0 +1,63 @@
+import JSZip from 'jszip';
+import { describe, expect } from 'vitest';
+import { compareDocuments } from '../../index.js';
+import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
+import { buildDocxFromBodyXml } from '../../testing/ooxml-fixtures.js';
+
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({ feature: 'Inplace Original Insertion Provenance Restoration' });
+
+async function compareInplace(originalBody: string, revisedBody: string) {
+  const original = await buildDocxFromBodyXml(originalBody);
+  const revised = await buildDocxFromBodyXml(revisedBody);
+  const result = await compareDocuments(original, revised, {
+    engine: 'atomizer',
+    reconstructionMode: 'inplace',
+  });
+  expect(result.reconstructionModeUsed).toBe('inplace');
+
+  const documentPart = (await JSZip.loadAsync(result.document)).file('word/document.xml');
+  if (!documentPart) throw new Error('comparison result omitted word/document.xml');
+  return { result, xml: await documentPart.async('string') };
+}
+
+describe('inplace original insertion provenance restoration', () => {
+  test('restores an original insertion wrapper around matched plain revised text', async ({
+    given,
+    when,
+    then,
+    and,
+  }: AllureBddContext) => {
+    let xml: string;
+    let insertions: number;
+
+    await given('matched text that is pre-tracked as inserted only in the original input', () => {});
+
+    await when('the documents are compared using inplace reconstruction', async () => {
+      const comparison = await compareInplace(
+        '<w:p><w:r><w:t>settled prefix </w:t></w:r>'
+          + '<w:ins w:id="17" w:author="Original Reviewer" w:date="2024-03-04T05:06:07Z">'
+          + '<w:r><w:t>lineage text</w:t></w:r></w:ins>'
+          + '<w:r><w:t> settled suffix</w:t></w:r></w:p>',
+        '<w:p><w:r><w:t>settled prefix </w:t></w:r>'
+          + '<w:r><w:t>lineage text</w:t></w:r>'
+          + '<w:r><w:t> settled suffix</w:t></w:r></w:p>',
+      );
+      xml = comparison.xml;
+      insertions = comparison.result.stats.insertions;
+    });
+
+    await then('the matched text is wrapped with its original revision metadata', () => {
+      expect(xml).toMatch(
+        /<w:ins\b[^>]*w:author="Original Reviewer"[^>]*w:date="2024-03-04T05:06:07Z"[^>]*>[\s\S]*?lineage text[\s\S]*?<\/w:ins>/,
+      );
+    });
+
+    await and('the comparison does not misclassify the matched text as a new insertion', () => {
+      expect(insertions).toBe(0);
+      expect(xml).toContain('settled prefix ');
+      expect(xml).toContain(' settled suffix');
+    });
+  });
+});


### PR DESCRIPTION
Refs #639.

Adds four characterization test files for the INPLACE reconstruction handlers in `packages/docx-compare/src/baselines/atomizer/inPlaceModifier.ts`. **Test-only — no production code changed.**

## Coverage

`inPlaceModifier.ts` statements: **231/310 (74.5%) → 268/310 (86.5%)**, +12.0pp.

Completes the atomizer coverage sweep alongside #622 (auxiliaryIdCollision 100%), #630 (inPlaceModifier handlers), #633 (documentReconstructor 89.1%), and #637 (pipeline 89.5%).

## What is covered

| File | Scenarios |
|---|---|
| `inPlaceModifier-bookmark-boundaries.test.ts` | Deleted paragraph whose text is enclosed by bookmark boundary markers; nested trailing `bookmarkEnd`s |
| `inPlaceModifier-empty-and-cell-paragraphs.test.ts` | Paragraph-mark-only insert/delete of empty paragraphs; removed first table-cell paragraph recreated after `w:tcPr` |
| `inPlaceModifier-moved-bookmark-paragraph.test.ts` | Styled bookmarked move source under `detectMoves` |
| `inPlaceModifier-original-insertion-provenance.test.ts` | Restoration of an original `w:ins` wrapper around text the revision left untracked |

Assertions are semantic — emitted OOXML elements, document order, and `result.stats`. No snapshots. Every helper asserts `reconstructionModeUsed === 'inplace'`, which both reviewers confirmed is load-bearing: mutating the handlers trips the `leanXmlVerifier` guard and falls back to rebuild, failing the test.

## A defect this pins: #641

The bookmark-boundary tests characterize **known-defective** behavior. Deleting a bookmarked paragraph hoists `<w:bookmarkStart>`/`<w:bookmarkEnd>` out to body level, where they collapse into a zero-length range detached from the text they named:

```xml
<w:bookmarkStart w:id="41" w:name="DeletedBoundary"/>
<w:bookmarkEnd w:id="41"/>
<w:p><w:pPr>…</w:pPr><w:del …><w:r><w:delText>Bookmarked</w:delText></w:r>…</w:del></w:p>
```

This is schema-legal (`CT_Body → EG_BlockLevelElts → EG_ContentBlockContent → EG_RunLevelElts`), so no validator flags it — the loss is semantic, and a cross-reference to the bookmark now resolves to an empty span. Filed as #641. The test names, a file-level comment, and the BDD step text all say this is a defect being pinned rather than endorsed; when #641 is fixed those tests must be rewritten to assert the enclosing range. Notably the move-source path already gets this right, which this PR asserts.

## Peer review

Both reviewers ran dynamic reviews (built, ran the suite, traced branches, mutation-tested) and initially returned **REQUEST CHANGES**. Both findings were real and are fixed here:

1. **Vacuous source-fidelity assertion.** The move test checked `expect(xml).toContain('<w:keepNext/>')` against the whole document. Because the move *destination* carries the same `w:pPr`, the check passed off the destination — Codex proved it by deleting the recreated source's `w:pPr` and watching the test still pass. Assertions are now scoped to the paragraph enclosing `<w:moveFrom>` via an `enclosingParagraph` helper, plus the bookmark range is asserted to stay *inside* the source and the source position is anchored between the leading and trailing paragraphs. Re-running that exact mutation now fails the test.
2. **Defect pinned under a name that understated it.** Test names and step text now lead with `DEFECT #641`, and #641 was filed.

## Verification

| Check | Result |
|---|---|
| `inPlaceModifier.ts` coverage | 74.5% → **86.5%** |
| `npx vitest run --root packages/docx-compare` | 47 files passed, 661 passed / 48 skipped |
| eslint | clean |
| `check:allure-labels` | pass |
| Production diff | none |

Remaining uncovered lines are defensive fallbacks requiring internally inconsistent atom/context states that valid `compareDocuments` inputs do not produce.

https://claude.ai/code/session_01P4C7hFonxn6KXJqb6GF1Th