### PR TITLE
fix(docx-compare): keep a deleted paragraph's bookmark range around its content (closes #641)

### DIFF
--- a/packages/docx-compare/src/baselines/atomizer/consumerCompatibility-bookmark-ranges.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/consumerCompatibility-bookmark-ranges.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Bookmark ranges stay attached to the content they name.
+ *
+ * The consumer-compatibility pass repositions `w:bookmarkStart` /
+ * `w:bookmarkEnd` so a range survives both the Accept All and the Reject All
+ * projection. It used to lift both boundaries of a wholly deleted or inserted
+ * paragraph out to body level, which is schema-legal but collapses the range to
+ * a zero-length span: the bookmark keeps its name and stops covering any text,
+ * so a `REF` / `PAGEREF` field aimed at it resolves to nothing.
+ *
+ * A range whose two boundaries both sit inside the revised paragraph now stays
+ * inside it, wrapped around the revision marker. A range with one boundary in
+ * surviving content still gets that boundary anchored outside, because the
+ * paragraph disappears in one of the two projections.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.6.1
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.6.2
+ * @see https://github.com/UseJunior/safe-docx/issues/641
+ */
+
+import { describe, expect } from 'vitest';
+import { DocxArchive, childElements, parseXml } from '@usejunior/docx-core';
+import { buildDocxFromBodyXml } from '../../testing/ooxml-fixtures.js';
+import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
+import { compareDocumentsAtomizer } from './pipeline.js';
+import { acceptAllChanges, rejectAllChanges } from './trackChangesAcceptorAst.js';
+import type { ReconstructionMode } from '../../compare-types.js';
+
+const TEST_FEATURE = 'Consumer Compatibility Bookmark Ranges';
+
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({
+    feature: TEST_FEATURE,
+    story: 'Bookmark Range Stays Around Revised Content',
+    severity: 'critical',
+  })
+  .conformance(
+    { spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.6.1' },
+    { spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.6.2' },
+  );
+
+const AUTHOR = 'Bookmark Range Test';
+const DATE = new Date('2026-07-25T00:00:00Z');
+
+function textParagraph(text: string): string {
+  return `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
+}
+
+/** Paragraph whose whole text is enclosed by one bookmark range. */
+function bookmarkedParagraph(id: string, name: string, text: string, pPr = ''): string {
+  return (
+    `<w:p>${pPr}` +
+    `<w:bookmarkStart w:id="${id}" w:name="${name}"/>` +
+    `<w:r><w:t>${text}</w:t></w:r>` +
+    `<w:bookmarkEnd w:id="${id}"/>` +
+    `</w:p>`
+  );
+}
+
+async function compare(
+  originalBody: string,
+  revisedBody: string,
+  reconstructionMode: ReconstructionMode
+): Promise<string> {
+  const original = await buildDocxFromBodyXml(originalBody);
+  const revised = await buildDocxFromBodyXml(revisedBody);
+  const result = await compareDocumentsAtomizer(original, revised, {
+    author: AUTHOR,
+    date: DATE,
+    reconstructionMode,
+  });
+  expect(result.reconstructionModeUsed).toBe(reconstructionMode);
+  return (await DocxArchive.load(result.document)).getDocumentXml();
+}
+
+function bodyOf(documentXml: string): Element {
+  const doc = parseXml(documentXml);
+  const body = doc.getElementsByTagName('w:body')[0];
+  if (!body) throw new Error('no w:body in document');
+  return body as Element;
+}
+
+/** Tag names of the direct children of `w:body`, in document order. */
+function bodyChildTags(documentXml: string): string[] {
+  return childElements(bodyOf(documentXml)).map((child) => child.tagName);
+}
+
+/**
+ * Tag names of the direct children of the paragraph carrying `text`, in
+ * document order, with runs of the same tag collapsed to one entry. Word-level
+ * atomization splits a sentence across several sibling `w:r`, and how many it
+ * produces is beside the point here.
+ */
+function paragraphChildTags(documentXml: string, text: string): string[] {
+  const body = bodyOf(documentXml);
+  for (const paragraph of Array.from(body.getElementsByTagName('w:p')) as Element[]) {
+    if (paragraph.textContent?.includes(text)) {
+      return childElements(paragraph)
+        .map((child) => child.tagName)
+        .filter((tag, index, tags) => tag !== tags[index - 1]);
+    }
+  }
+  throw new Error(`no paragraph containing ${JSON.stringify(text)}`);
+}
+
+const ORIGINAL_WITH_BOOKMARKED_PARAGRAPH =
+  textParagraph('Leading survivor') +
+  bookmarkedParagraph('41', 'DeletedBoundary', 'Bookmarked deleted text', '<w:pPr><w:keepNext/></w:pPr>') +
+  textParagraph('Trailing survivor');
+
+const REVISED_WITHOUT_BOOKMARKED_PARAGRAPH =
+  textParagraph('Leading survivor') + textParagraph('Trailing survivor');
+
+describe('Bookmark ranges survive paragraph-level revisions', () => {
+  for (const mode of ['inplace', 'rebuild'] as const) {
+    test(`a deleted bookmarked paragraph keeps its range inside the paragraph [${mode}]`, async (
+      { given, when, then, and }: AllureBddContext
+    ) => {
+      let documentXml: string;
+
+      await given('an original paragraph whose whole text is one bookmark range', () => {});
+
+      await when(`the paragraph is dropped and the documents are compared in ${mode} mode`, async () => {
+        documentXml = await compare(
+          ORIGINAL_WITH_BOOKMARKED_PARAGRAPH,
+          REVISED_WITHOUT_BOOKMARKED_PARAGRAPH,
+          mode
+        );
+      });
+
+      await then('no bookmark marker is left stranded at body level', () => {
+        expect(bodyChildTags(documentXml)).not.toContain('w:bookmarkStart');
+        expect(bodyChildTags(documentXml)).not.toContain('w:bookmarkEnd');
+      });
+
+      await and('the range wraps the deletion inside the recreated paragraph', () => {
+        expect(paragraphChildTags(documentXml, 'Bookmarked deleted text')).toEqual([
+          'w:pPr',
+          'w:bookmarkStart',
+          'w:del',
+          'w:bookmarkEnd',
+        ]);
+      });
+
+      await and('Reject All restores the range around the restored text', () => {
+        const rejected = rejectAllChanges(documentXml);
+        expect(paragraphChildTags(rejected, 'Bookmarked deleted text')).toEqual([
+          'w:pPr',
+          'w:bookmarkStart',
+          'w:r',
+          'w:bookmarkEnd',
+        ]);
+      });
+
+      await and('Accept All keeps the emptied bookmark inside a paragraph, not at body level', () => {
+        // Word leaves a bookmark in place as a zero-length range when all of the
+        // text it covered is deleted; what it never does is detach it from the
+        // paragraph flow.
+        const accepted = acceptAllChanges(documentXml);
+        expect(accepted).toContain('w:name="DeletedBoundary"');
+        expect(bodyChildTags(accepted)).not.toContain('w:bookmarkStart');
+        expect(bodyChildTags(accepted)).not.toContain('w:bookmarkEnd');
+      });
+    });
+
+    test(`an inserted bookmarked paragraph keeps its range inside the paragraph [${mode}]`, async (
+      { given, when, then, and }: AllureBddContext
+    ) => {
+      let documentXml: string;
+
+      await given('a revision that adds a paragraph whose whole text is one bookmark range', () => {});
+
+      await when(`the documents are compared in ${mode} mode`, async () => {
+        documentXml = await compare(
+          textParagraph('Leading survivor') + textParagraph('Trailing survivor'),
+          textParagraph('Leading survivor') +
+            bookmarkedParagraph('42', 'InsertedBoundary', 'Bookmarked inserted text') +
+            textParagraph('Trailing survivor'),
+          mode
+        );
+      });
+
+      await then('no bookmark marker is left stranded at body level', () => {
+        expect(bodyChildTags(documentXml)).not.toContain('w:bookmarkStart');
+        expect(bodyChildTags(documentXml)).not.toContain('w:bookmarkEnd');
+      });
+
+      await and('the range wraps the insertion inside the paragraph', () => {
+        const tags = paragraphChildTags(documentXml, 'Bookmarked inserted text');
+        expect(tags.filter((tag) => tag !== 'w:pPr' && tag !== 'w:pPrChange')).toEqual([
+          'w:bookmarkStart',
+          'w:ins',
+          'w:bookmarkEnd',
+        ]);
+      });
+
+      await and('Accept All keeps the range around the accepted text', () => {
+        const accepted = acceptAllChanges(documentXml);
+        const tags = paragraphChildTags(accepted, 'Bookmarked inserted text');
+        expect(tags.filter((tag) => tag !== 'w:pPr')).toEqual([
+          'w:bookmarkStart',
+          'w:r',
+          'w:bookmarkEnd',
+        ]);
+      });
+    });
+
+    test(`a range spanning out of a deleted paragraph keeps its outside anchor [${mode}]`, async (
+      { given, when, then, and }: AllureBddContext
+    ) => {
+      let documentXml: string;
+
+      await given('a bookmark that opens in the deleted paragraph and closes in a survivor', () => {});
+
+      await when(`the paragraph is dropped and the documents are compared in ${mode} mode`, async () => {
+        documentXml = await compare(
+          textParagraph('Leading survivor') +
+            '<w:p><w:bookmarkStart w:id="43" w:name="SpanningBoundary"/>' +
+            '<w:r><w:t>Bookmarked deleted text</w:t></w:r></w:p>' +
+            '<w:p><w:r><w:t>Trailing survivor</w:t></w:r><w:bookmarkEnd w:id="43"/></w:p>',
+          textParagraph('Leading survivor') +
+            '<w:p><w:r><w:t>Trailing survivor</w:t></w:r><w:bookmarkEnd w:id="43"/></w:p>',
+          mode
+        );
+      });
+
+      await then('the start is anchored ahead of the deleted paragraph, outside it', () => {
+        expect(bodyChildTags(documentXml)).toContain('w:bookmarkStart');
+        expect(paragraphChildTags(documentXml, 'Bookmarked deleted text')).not.toContain(
+          'w:bookmarkStart'
+        );
+      });
+
+      await and('the range still covers the surviving text after Accept All', () => {
+        const accepted = acceptAllChanges(documentXml);
+        expect(accepted).toContain('w:name="SpanningBoundary"');
+        expect(paragraphChildTags(accepted, 'Trailing survivor')).toContain('w:bookmarkEnd');
+      });
+    });
+  }
+});

--- a/packages/docx-compare/src/baselines/atomizer/consumerCompatibility-bookmark-ranges.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/consumerCompatibility-bookmark-ranges.test.ts
@@ -13,9 +13,14 @@
  * surviving content still gets that boundary anchored outside, because the
  * paragraph disappears in one of the two projections.
  *
+ * The second describe block drives the pass directly, because the boundary cases
+ * it covers are hard to reach through a whole comparison: the atomizer is free
+ * to align a fixture into a different revision shape than the one under test.
+ *
  * @conformance ECMA-376 edition 5, Part 1 § 17.13.6.1
  * @conformance ECMA-376 edition 5, Part 1 § 17.13.6.2
  * @see https://github.com/UseJunior/safe-docx/issues/641
+ * @see https://github.com/UseJunior/safe-docx/issues/643
  */
 
 import { describe, expect } from 'vitest';
@@ -23,6 +28,7 @@ import { DocxArchive, childElements, parseXml } from '@usejunior/docx-core';
 import { buildDocxFromBodyXml } from '../../testing/ooxml-fixtures.js';
 import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
 import { compareDocumentsAtomizer } from './pipeline.js';
+import { enforceConsumerCompatibility } from './consumerCompatibility.js';
 import { acceptAllChanges, rejectAllChanges } from './trackChangesAcceptorAst.js';
 import type { ReconstructionMode } from '../../compare-types.js';
 
@@ -153,14 +159,61 @@ describe('Bookmark ranges survive paragraph-level revisions', () => {
         ]);
       });
 
-      await and('Accept All keeps the emptied bookmark inside a paragraph, not at body level', () => {
-        // Word leaves a bookmark in place as a zero-length range when all of the
-        // text it covered is deleted; what it never does is detach it from the
-        // paragraph flow.
+      await and('Accept All leaves the emptied bookmark in the paragraph flow, not at body level', () => {
+        // Keeping the name once its text is gone is safe-docx policy, unchanged
+        // by this fix: the pass has always preserved bookmark names so a REF or
+        // PAGEREF still resolves. What changes is placement — the emptied range
+        // lands at the paragraph merge point instead of detached at body level.
+        // Word's own output for this scenario has not been captured, and the
+        // repo's LibreOffice oracle drops the bookmark outright on accept, so
+        // this asserts our policy rather than a consumer's behavior (issue #641).
         const accepted = acceptAllChanges(documentXml);
         expect(accepted).toContain('w:name="DeletedBoundary"');
         expect(bodyChildTags(accepted)).not.toContain('w:bookmarkStart');
         expect(bodyChildTags(accepted)).not.toContain('w:bookmarkEnd');
+      });
+    });
+
+    test(`a deleted bookmarked paragraph in a table cell keeps its range in the cell [${mode}]`, async (
+      { given, when, then, and }: AllureBddContext
+    ) => {
+      let documentXml: string;
+      const cell = (content: string) =>
+        `<w:tbl><w:tblPr/><w:tblGrid><w:gridCol w:w="5000"/></w:tblGrid>` +
+        `<w:tr><w:tc><w:tcPr/>${content}</w:tc></w:tr></w:tbl>`;
+
+      await given('a bookmarked paragraph inside a single-cell table', () => {});
+
+      await when(`the cell paragraph is dropped and compared in ${mode} mode`, async () => {
+        documentXml = await compare(
+          textParagraph('Leading survivor') +
+            cell(
+              bookmarkedParagraph('44', 'CellBoundary', 'Bookmarked cell text') +
+                textParagraph('Cell survivor')
+            ),
+          textParagraph('Leading survivor') + cell(textParagraph('Cell survivor')),
+          mode
+        );
+      });
+
+      await then('the range wraps the deletion inside the cell paragraph', () => {
+        expect(paragraphChildTags(documentXml, 'Bookmarked cell text')).toEqual([
+          'w:pPr',
+          'w:bookmarkStart',
+          'w:del',
+          'w:bookmarkEnd',
+        ]);
+      });
+
+      await and('no marker escapes to body level or to the row/cell level', () => {
+        expect(bodyChildTags(documentXml)).not.toContain('w:bookmarkStart');
+        const body = bodyOf(documentXml);
+        const cellEl = body.getElementsByTagName('w:tc')[0] as Element;
+        expect(childElements(cellEl).map((child) => child.tagName)).toEqual([
+          'w:tcPr',
+          'w:p',
+          'w:p',
+        ]);
       });
     });
 
@@ -204,6 +257,15 @@ describe('Bookmark ranges survive paragraph-level revisions', () => {
           'w:bookmarkEnd',
         ]);
       });
+
+      await and('Reject All takes the inserted text away with its paragraph', () => {
+        const rejected = rejectAllChanges(documentXml);
+        expect(rejected).not.toContain('Bookmarked inserted text');
+        // The name outlives the rejected text, per the same policy the deletion
+        // case documents; what matters is that it stays in the paragraph flow.
+        expect(bodyChildTags(rejected)).not.toContain('w:bookmarkStart');
+        expect(bodyChildTags(rejected)).not.toContain('w:bookmarkEnd');
+      });
     });
 
     test(`a range spanning out of a deleted paragraph keeps its outside anchor [${mode}]`, async (
@@ -239,4 +301,133 @@ describe('Bookmark ranges survive paragraph-level revisions', () => {
       });
     });
   }
+});
+
+const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+/** Run the pass over one hand-written paragraph and report where markers landed. */
+function markerLayout(paragraphXml: string): { paragraph: string[]; body: string[] } {
+  const doc = parseXml(`<w:document xmlns:w="${W_NS}"><w:body>${paragraphXml}</w:body></w:document>`);
+  const body = doc.getElementsByTagName('w:body')[0] as Element;
+  let nextRevisionId = 900;
+  enforceConsumerCompatibility(body, () => nextRevisionId++);
+  const paragraph = body.getElementsByTagName('w:p')[0] as Element;
+  const label = (child: Element) =>
+    child.tagName.startsWith('w:bookmark')
+      ? `${child.tagName}#${child.getAttribute('w:id')}`
+      : child.tagName;
+  return {
+    paragraph: childElements(paragraph).map(label),
+    body: childElements(body).map(label),
+  };
+}
+
+describe('Bookmark boundaries relative to an inline revision wrapper', () => {
+  test('a range the wrapper encloses is placed around the wrapper', async (
+    { given, when, then, and }: AllureBddContext
+  ) => {
+    let deletion: ReturnType<typeof markerLayout>;
+    let move: ReturnType<typeof markerLayout>;
+
+    await given('a w:del and a w:moveFrom that each contain a whole bookmark range', () => {});
+
+    await when('the consumer-compatibility pass runs', () => {
+      deletion = markerLayout(
+        '<w:p><w:del w:id="1">' +
+          '<w:bookmarkStart w:id="52" w:name="Whole"/>' +
+          '<w:r><w:delText>all-deleted</w:delText></w:r>' +
+          '<w:bookmarkEnd w:id="52"/></w:del></w:p>'
+      );
+      move = markerLayout(
+        '<w:p><w:moveFrom w:id="1" w:name="move1">' +
+          '<w:bookmarkStart w:id="53" w:name="Moved"/>' +
+          '<w:r><w:t>moved-away</w:t></w:r>' +
+          '<w:bookmarkEnd w:id="53"/></w:moveFrom></w:p>'
+      );
+    });
+
+    await then('the deletion keeps the range spanning the wrapper, not collapsed ahead of it', () => {
+      expect(deletion.paragraph).toEqual(['w:bookmarkStart#52', 'w:del', 'w:bookmarkEnd#52']);
+      expect(deletion.body).toEqual(['w:p']);
+    });
+
+    await and('a move source behaves the same way', () => {
+      expect(move.paragraph).toEqual(['w:bookmarkStart#53', 'w:moveFrom', 'w:bookmarkEnd#53']);
+    });
+  });
+
+  test('a boundary partway inside a wrapper keeps the long-standing placement ahead of it', async (
+    { given, when, then, and }: AllureBddContext
+  ) => {
+    let endInside: ReturnType<typeof markerLayout>;
+    let startInside: ReturnType<typeof markerLayout>;
+
+    await given('ranges with exactly one boundary inside a w:del', () => {});
+
+    await when('the consumer-compatibility pass runs', () => {
+      endInside = markerLayout(
+        '<w:p><w:bookmarkStart w:id="50" w:name="Partial"/>' +
+          '<w:r><w:t>kept</w:t></w:r>' +
+          '<w:del w:id="1"><w:r><w:delText>inside-range</w:delText></w:r>' +
+          '<w:bookmarkEnd w:id="50"/>' +
+          '<w:r><w:delText>outside-range</w:delText></w:r></w:del></w:p>'
+      );
+      startInside = markerLayout(
+        '<w:p><w:del w:id="1"><w:r><w:delText>before-range</w:delText></w:r>' +
+          '<w:bookmarkStart w:id="51" w:name="PartialStart"/>' +
+          '<w:r><w:delText>inside-range</w:delText></w:r></w:del>' +
+          '<w:r><w:t>kept</w:t></w:r>' +
+          '<w:bookmarkEnd w:id="51"/></w:p>'
+      );
+    });
+
+    await then('the inside end is anchored before the wrapper, shrinking the range', () => {
+      // Neither placement outside the wrapper reproduces the original span, so
+      // this keeps the placement the pass has always used rather than swapping
+      // one inaccuracy for another. Splitting the wrapper at the boundary is the
+      // faithful fix, tracked in issue #643 — update this test when it lands.
+      expect(endInside.paragraph).toEqual([
+        'w:bookmarkStart#50',
+        'w:r',
+        'w:bookmarkEnd#50',
+        'w:del',
+      ]);
+    });
+
+    await and('the mirrored case leaves the start before the wrapper too', () => {
+      expect(startInside.paragraph).toEqual([
+        'w:bookmarkStart#51',
+        'w:del',
+        'w:r',
+        'w:bookmarkEnd#51',
+      ]);
+    });
+  });
+
+  test('a bookmark inside nested revision wrappers lands outside the outermost one', async (
+    { given, when, then, and }: AllureBddContext
+  ) => {
+    let layout: ReturnType<typeof markerLayout>;
+
+    await given('a comparison deletion nested in an earlier author\'s insertion', () => {});
+
+    await when('the consumer-compatibility pass runs', () => {
+      layout = markerLayout(
+        '<w:p><w:ins w:id="2" w:author="Earlier" w:date="2026-01-01T00:00:00Z">' +
+          '<w:del w:id="1">' +
+          '<w:bookmarkStart w:id="56" w:name="Nested"/>' +
+          '<w:r><w:delText>pre-inserted then deleted</w:delText></w:r>' +
+          '<w:bookmarkEnd w:id="56"/>' +
+          '</w:del></w:ins></w:p>'
+      );
+    });
+
+    await then('the range spans the outer wrapper, since either projection removes the content', () => {
+      expect(layout.paragraph).toEqual(['w:bookmarkStart#56', 'w:ins', 'w:bookmarkEnd#56']);
+    });
+
+    await and('nothing escapes to body level', () => {
+      expect(layout.body).toEqual(['w:p']);
+    });
+  });
 });

--- a/packages/docx-compare/src/baselines/atomizer/consumerCompatibility.ts
+++ b/packages/docx-compare/src/baselines/atomizer/consumerCompatibility.ts
@@ -45,18 +45,19 @@ const BOOKMARK_MARKER_TAGS = ['w:bookmarkStart', 'w:bookmarkEnd'] as const;
 const REVISION_WRAPPER_TAGS = new Set(['w:ins', 'w:del', 'w:moveFrom', 'w:moveTo']);
 
 /**
- * Whether a marker's counterpart (matched on `w:id`) also lives inside `paragraph`.
+ * Whether a marker's counterpart (matched on `w:id`) also lives inside `container`.
  *
  * A bookmark range is identified by the `w:id` shared between its
- * `w:bookmarkStart` and `w:bookmarkEnd`; the name lives on the start only.
- * A range with both ends inside one paragraph covers only that paragraph's
- * content, so it must travel with the paragraph. A range with one end outside
- * spans surviving content and has to keep an anchor there.
+ * `w:bookmarkStart` and `w:bookmarkEnd`; the name lives on the start only. A
+ * range with both boundaries inside one container covers only that container's
+ * content, so it can be repositioned as a unit. A range with one boundary
+ * outside reaches into content the container does not own, and moving the inside
+ * boundary changes which text the range covers.
  *
  * @conformance ECMA-376 edition 5, Part 1 § 17.13.6.2
  * @conformance ECMA-376 edition 5, Part 1 § 17.13.6.1
  */
-function bookmarkRangeIsEnclosedBy(paragraph: Element, marker: Element): boolean {
+function bookmarkRangeIsEnclosedBy(container: Element, marker: Element): boolean {
   const id = marker.getAttribute('w:id');
   if (!id) return false;
   const counterpartTag =
@@ -64,19 +65,29 @@ function bookmarkRangeIsEnclosedBy(paragraph: Element, marker: Element): boolean
 
   // An unmatched marker has no range to preserve; the orphan repair below
   // synthesizes a counterpart, so treat it as spanning and hoist it out.
-  const counterparts = Array.from(paragraph.getElementsByTagName(counterpartTag)) as Element[];
+  const counterparts = Array.from(container.getElementsByTagName(counterpartTag)) as Element[];
   return counterparts.some((candidate) => candidate.getAttribute('w:id') === id);
 }
 
 /**
  * Lift the bookmark markers nested inside an inline revision wrapper out to the
- * wrapper's own level, keeping starts before it and ends after it.
+ * wrapper's own level.
  *
  * A marker inside `<w:del>` vanishes on Accept All even though the surrounding
- * paragraph survives, so it cannot stay there. Splitting the two sides around
- * the wrapper — rather than dropping both in front of it — keeps the range
- * spanning the content it named instead of collapsing it to zero length. Word
- * emits boundary markers as siblings of the wrapper in the same arrangement.
+ * paragraph survives, so it cannot stay there. Where it lands depends on how
+ * much of the range the wrapper owns:
+ *
+ * - A range the wrapper encloses entirely is placed around the wrapper — start
+ *   before, end after — so it still spans the content it named. Dropping both
+ *   boundaries in front of the wrapper (what this pass used to do) collapses it
+ *   to zero length, which is how the rebuild path lost the range in issue #641.
+ * - A boundary whose counterpart is outside the wrapper keeps the long-standing
+ *   placement in front of the wrapper. Anchoring such a boundary after the
+ *   wrapper instead would silently grow the range over the whole wrapped run.
+ *   Neither placement reproduces the original span, because the boundary sat
+ *   partway through content that one projection removes; repositioning it
+ *   faithfully means splitting the wrapper at the boundary, which is out of
+ *   scope here and tracked separately.
  */
 function liftMarkersAroundWrapper(wrapper: Element): void {
   const parent = wrapper.parentNode;
@@ -85,13 +96,21 @@ function liftMarkersAroundWrapper(wrapper: Element): void {
   const starts = Array.from(wrapper.getElementsByTagName('w:bookmarkStart')) as Element[];
   const ends = Array.from(wrapper.getElementsByTagName('w:bookmarkEnd')) as Element[];
 
+  // Decide before moving anything: lifting the starts out first would empty the
+  // wrapper of them and make every range look like it reaches outside.
+  const endsAfter = ends.filter((end) => bookmarkRangeIsEnclosedBy(wrapper, end));
+  const endsBefore = ends.filter((end) => !endsAfter.includes(end));
+
   for (const start of starts) {
     parent.insertBefore(start, wrapper);
   }
-  let anchor: Node = wrapper;
-  for (const end of ends) {
-    parent.insertBefore(end, anchor.nextSibling);
-    anchor = end;
+  for (const end of endsBefore) {
+    parent.insertBefore(end, wrapper);
+  }
+  // Reverse so each insert lands directly after the wrapper, which leaves
+  // document order among these ends unchanged.
+  for (const end of [...endsAfter].reverse()) {
+    parent.insertBefore(end, wrapper.nextSibling);
   }
 }
 

--- a/packages/docx-compare/src/baselines/atomizer/consumerCompatibility.ts
+++ b/packages/docx-compare/src/baselines/atomizer/consumerCompatibility.ts
@@ -41,31 +41,103 @@ function isParagraphInsertedOrDeleted(p: Element): boolean {
   return false;
 }
 
-export function enforceConsumerCompatibility(root: Element, allocateRevisionId: () => number): void {
-  // 1. Hoist bookmark markers out of revision wrappers AND fully deleted/inserted paragraphs
-  const wrappers = new Set(['w:ins', 'w:del', 'w:moveFrom', 'w:moveTo']);
-  const markers = ['w:bookmarkStart', 'w:bookmarkEnd'];
-  
-  function hoistBookmarks(node: Element) {
-    if (wrappers.has(node.tagName) || (node.tagName === 'w:p' && isParagraphInsertedOrDeleted(node))) {
-      for (const markerTag of markers) {
-        // Only get immediate children if we're hoisting out of p, otherwise get all descendants
-        // Actually, if it's a p, we want to hoist all markers out of it so they survive.
-        const nestedMarkers = Array.from(node.getElementsByTagName(markerTag));
-        for (const marker of nestedMarkers) {
-          // Move the marker to be a sibling BEFORE the wrapper/paragraph, if it has a parent
-          if (node.parentNode) {
-            node.parentNode.insertBefore(marker, node);
-          }
-        }
-      }
-    } else {
-      for (const child of childElements(node)) {
-        hoistBookmarks(child);
-      }
+const BOOKMARK_MARKER_TAGS = ['w:bookmarkStart', 'w:bookmarkEnd'] as const;
+const REVISION_WRAPPER_TAGS = new Set(['w:ins', 'w:del', 'w:moveFrom', 'w:moveTo']);
+
+/**
+ * Whether a marker's counterpart (matched on `w:id`) also lives inside `paragraph`.
+ *
+ * A bookmark range is identified by the `w:id` shared between its
+ * `w:bookmarkStart` and `w:bookmarkEnd`; the name lives on the start only.
+ * A range with both ends inside one paragraph covers only that paragraph's
+ * content, so it must travel with the paragraph. A range with one end outside
+ * spans surviving content and has to keep an anchor there.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.6.2
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.6.1
+ */
+function bookmarkRangeIsEnclosedBy(paragraph: Element, marker: Element): boolean {
+  const id = marker.getAttribute('w:id');
+  if (!id) return false;
+  const counterpartTag =
+    marker.tagName === 'w:bookmarkStart' ? 'w:bookmarkEnd' : 'w:bookmarkStart';
+
+  // An unmatched marker has no range to preserve; the orphan repair below
+  // synthesizes a counterpart, so treat it as spanning and hoist it out.
+  const counterparts = Array.from(paragraph.getElementsByTagName(counterpartTag)) as Element[];
+  return counterparts.some((candidate) => candidate.getAttribute('w:id') === id);
+}
+
+/**
+ * Lift the bookmark markers nested inside an inline revision wrapper out to the
+ * wrapper's own level, keeping starts before it and ends after it.
+ *
+ * A marker inside `<w:del>` vanishes on Accept All even though the surrounding
+ * paragraph survives, so it cannot stay there. Splitting the two sides around
+ * the wrapper — rather than dropping both in front of it — keeps the range
+ * spanning the content it named instead of collapsing it to zero length. Word
+ * emits boundary markers as siblings of the wrapper in the same arrangement.
+ */
+function liftMarkersAroundWrapper(wrapper: Element): void {
+  const parent = wrapper.parentNode;
+  if (!parent) return;
+
+  const starts = Array.from(wrapper.getElementsByTagName('w:bookmarkStart')) as Element[];
+  const ends = Array.from(wrapper.getElementsByTagName('w:bookmarkEnd')) as Element[];
+
+  for (const start of starts) {
+    parent.insertBefore(start, wrapper);
+  }
+  let anchor: Node = wrapper;
+  for (const end of ends) {
+    parent.insertBefore(end, anchor.nextSibling);
+    anchor = end;
+  }
+}
+
+/**
+ * Move bookmark markers to positions that keep their ranges meaningful in both
+ * the Accept All and Reject All projections.
+ *
+ * Two moves happen, in this order:
+ *
+ * 1. Out of inline revision wrappers, as described on
+ *    {@link liftMarkersAroundWrapper}.
+ *
+ * 2. Out of a wholly inserted or deleted paragraph, but only for ranges whose
+ *    other end lies outside that paragraph. Those need an anchor in content the
+ *    projection keeps. A range enclosed by the paragraph stays put: hoisting it
+ *    to body level collapses it to a zero-length span that no longer names the
+ *    text it was created for, and such a range is meant to travel with the
+ *    content it covers (issue #641).
+ */
+function hoistBookmarkMarkers(node: Element): void {
+  if (REVISION_WRAPPER_TAGS.has(node.tagName)) {
+    liftMarkersAroundWrapper(node);
+    return;
+  }
+
+  for (const child of childElements(node)) {
+    hoistBookmarkMarkers(child);
+  }
+
+  if (node.tagName !== 'w:p' || !isParagraphInsertedOrDeleted(node) || !node.parentNode) {
+    return;
+  }
+
+  // Wrapper lifting above has already moved nested markers to paragraph level,
+  // so every marker of this paragraph is now visible to the enclosure test.
+  for (const markerTag of BOOKMARK_MARKER_TAGS) {
+    for (const marker of Array.from(node.getElementsByTagName(markerTag)) as Element[]) {
+      if (bookmarkRangeIsEnclosedBy(node, marker)) continue;
+      node.parentNode.insertBefore(marker, node);
     }
   }
-  hoistBookmarks(root);
+}
+
+export function enforceConsumerCompatibility(root: Element, allocateRevisionId: () => number): void {
+  // 1. Reposition bookmark markers so their ranges survive both projections.
+  hoistBookmarkMarkers(root);
 
   // 2. Remove empty w:t tags
   const textNodes = Array.from(root.getElementsByTagName('w:t'));

--- a/packages/docx-compare/src/baselines/atomizer/inPlaceModifier-bookmark-boundaries.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/inPlaceModifier-bookmark-boundaries.test.ts
@@ -23,23 +23,24 @@ async function compareInplace(originalBody: string, revisedBody: string) {
 }
 
 /**
- * Characterization of KNOWN-DEFECTIVE behavior — see issue #641.
+ * A deleted paragraph's bookmark range keeps enclosing the content it named.
  *
- * When a deleted paragraph's text was enclosed by bookmark boundary markers, the markers are
- * hoisted out of the paragraph to body level and collapse into a zero-length range that no
- * longer covers the text it named. The markers survive by name only; a cross-reference to the
- * bookmark resolves to an empty span.
+ * These tests were written against the defect in issue #641: both boundary markers were hoisted
+ * out of the paragraph to body level, where they collapsed into a zero-length range. The markers
+ * survived by name only, so a cross-reference to the bookmark resolved to an empty span. Body-level
+ * bookmarkStart/bookmarkEnd is schema-legal (CT_Body -> EG_BlockLevelElts ->
+ * EG_ContentBlockContent -> EG_RunLevelElts), so no validator flagged it; the loss was semantic.
  *
- * These tests pin what the engine does today so the behavior cannot change unnoticed. They do
- * NOT endorse it. When #641 is fixed, they must be rewritten to assert that the bookmark range
- * still encloses the recreated `<w:del>` content — the way the move-source path already does
- * (see inPlaceModifier-moved-bookmark-paragraph.test.ts).
+ * They now assert the fixed shape — markers inside the recreated paragraph, wrapped around the
+ * `<w:del>` — which matches what the move-source path already produced (see
+ * inPlaceModifier-moved-bookmark-paragraph.test.ts).
  *
- * Body-level bookmarkStart/bookmarkEnd is schema-legal (CT_Body -> EG_BlockLevelElts ->
- * EG_ContentBlockContent -> EG_RunLevelElts), so no validator flags this; the loss is semantic.
+ * A boundary sitting only PARTWAY inside a revision wrapper is a separate case that still cannot be
+ * repositioned faithfully; it is pinned in consumerCompatibility-bookmark-ranges.test.ts and tracked
+ * in issue #643.
  */
 describe('inplace deleted paragraph bookmark boundaries', () => {
-  test('DEFECT #641: hoists both boundary markers to body level, detaching the bookmark from the deleted text', async ({
+  test('keeps both boundary markers inside the paragraph, wrapped around the deleted text', async ({
     given,
     when,
     then,
@@ -71,29 +72,37 @@ describe('inplace deleted paragraph bookmark boundaries', () => {
       expect(xml).toContain('<w:delText>Bookmarked</w:delText>');
     });
 
-    await and('DEFECT #641: the markers collapse to an empty range outside the deleted paragraph', () => {
+    await and('the range still covers the deleted text (issue #641)', () => {
       const start = xml.indexOf('<w:bookmarkStart w:id="41"');
       const end = xml.indexOf('<w:bookmarkEnd w:id="41"');
       const deletedText = xml.indexOf('<w:delText>Bookmarked</w:delText>');
       expect(xml.match(/<w:bookmarkStart w:id="41"/g)).toHaveLength(1);
       expect(xml.match(/<w:bookmarkEnd w:id="41"/g)).toHaveLength(1);
 
-      // Both markers land before the recreated paragraph, so the range spans no content at all.
+      // The deleted text sits between the two boundaries rather than after both of them.
       expect(start).toBeGreaterThan(-1);
-      expect(end).toBeGreaterThan(start);
-      expect(end).toBeLessThan(deletedText);
-      expect(xml.slice(start, end)).not.toContain('<w:delText>');
+      expect(start).toBeLessThan(deletedText);
+      expect(end).toBeGreaterThan(deletedText);
+      expect(xml.slice(start, end)).toContain('<w:delText>');
+    });
 
-      // ...and they sit at body level rather than inside the paragraph holding the deletion.
+    await and('both markers sit inside the paragraph holding the deletion, not at body level', () => {
+      const start = xml.indexOf('<w:bookmarkStart w:id="41"');
+      const end = xml.indexOf('<w:bookmarkEnd w:id="41"');
+      const deletedText = xml.indexOf('<w:delText>Bookmarked</w:delText>');
       const enclosingParagraphStart = xml.lastIndexOf('<w:p>', deletedText);
-      expect(enclosingParagraphStart).toBeGreaterThan(end);
+      const enclosingParagraphEnd = xml.indexOf('</w:p>', deletedText);
+
+      expect(enclosingParagraphStart).toBeLessThan(start);
+      expect(enclosingParagraphEnd).toBeGreaterThan(end);
     });
   });
 
-  test('DEFECT #641: hoists nested trailing bookmark ends ahead of the deleted fragments, preserving only their relative order', async ({
+  test('places nested trailing bookmark ends after the deleted fragments, in nesting order', async ({
     given,
     when,
     then,
+    and,
   }: AllureBddContext) => {
     let xml: string;
 
@@ -111,19 +120,30 @@ describe('inplace deleted paragraph bookmark boundaries', () => {
       ));
     });
 
-    await then('both ends precede the fragments they should follow, but stay in nesting order', () => {
+    await then('both ends follow the last fragment they cover', () => {
       const finalText = xml.indexOf('<w:delText>fragment</w:delText>', xml.indexOf('second'));
       const innerEnd = xml.indexOf('<w:bookmarkEnd w:id="52"');
       const outerEnd = xml.indexOf('<w:bookmarkEnd w:id="51"');
       expect(finalText).toBeGreaterThan(-1);
       expect(innerEnd).toBeGreaterThan(-1);
 
-      // Correct output would place both ends AFTER the final fragment. They precede it instead.
-      expect(innerEnd).toBeLessThan(finalText);
-      expect(outerEnd).toBeLessThan(finalText);
+      expect(innerEnd).toBeGreaterThan(finalText);
+      expect(outerEnd).toBeGreaterThan(finalText);
+    });
 
-      // The one property the hoisting does keep: inner closes before outer.
+    await and('nesting order survives — inner closes before outer', () => {
+      const innerEnd = xml.indexOf('<w:bookmarkEnd w:id="52"');
+      const outerEnd = xml.indexOf('<w:bookmarkEnd w:id="51"');
       expect(outerEnd).toBeGreaterThan(innerEnd);
+    });
+
+    await and('both starts still precede the deleted fragments, keeping each range non-empty', () => {
+      const outerStart = xml.indexOf('<w:bookmarkStart w:id="51"');
+      const innerStart = xml.indexOf('<w:bookmarkStart w:id="52"');
+      const firstText = xml.indexOf('<w:delText>first</w:delText>');
+      expect(outerStart).toBeGreaterThan(-1);
+      expect(outerStart).toBeLessThan(innerStart);
+      expect(innerStart).toBeLessThan(firstText);
     });
   });
 });

--- a/packages/docx-compare/src/baselines/atomizer/inPlaceModifier-empty-and-cell-paragraphs.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/inPlaceModifier-empty-and-cell-paragraphs.test.ts
@@ -6,7 +6,12 @@ import { buildDocxFromBodyXml } from '../../testing/ooxml-fixtures.js';
 
 const test = testAllure
   .epic('Document Comparison')
-  .withLabels({ feature: 'Inplace Empty And Table Cell Paragraph Placement' });
+  .withLabels({ feature: 'Inplace Empty And Table Cell Paragraph Placement' })
+  .conformance(
+    { spec: 'ECMA-376', edition: 5, part: 1, section: '17.4.37' },
+    { spec: 'ECMA-376', edition: 5, part: 1, section: '17.4.48' },
+    { spec: 'ECMA-376', edition: 5, part: 1, section: '17.4.65' },
+  );
 
 async function compareInplace(originalBody: string, revisedBody: string) {
   const original = await buildDocxFromBodyXml(originalBody);


### PR DESCRIPTION
## Problem

Deleting a bookmarked paragraph detached its bookmark: both boundary markers
were lifted out to body level, adjacent to each other. That is schema-legal, so
no validator objected, but it collapses the range to zero length — the bookmark
survives by name and stops covering any text, so a `REF` / `PAGEREF` aimed at it
resolves to an empty span.

## Root cause

Not in the atomizer's paragraph-recreation code, which places the markers inside
the recreated paragraph correctly. The detaching happens afterwards, in
`enforceConsumerCompatibility` — the post-reconstruction pass that **both**
`inplace` and `rebuild` share, so both modes were affected and both are fixed
here. Two defects in its bookmark step:

1. **Paragraph-level lift was unconditional.** Every boundary of a wholly
   inserted or deleted `w:p` was moved to body level.
2. **Wrapper lift dropped both boundaries in front of the wrapper.** Same
   collapse in miniature. This is why the rebuild path still emitted a
   zero-length range even after fixing (1) — its reconstructor emits the markers
   inside the `w:del`.

## Fix

The lift now depends on how much of a range the container owns:

- A range with **both** boundaries inside the revised paragraph stays inside it,
  wrapped around the revision marker. It covers only that paragraph's text and
  is meant to travel with it.
- A range with one boundary in **surviving** content still gets that boundary
  anchored outside, because the paragraph vanishes in one projection. (Guarded by
  a test that passes both before and after, so it catches over-fixing.)
- Inside an inline wrapper, a range the wrapper **encloses** is placed around it
  — start before, end after. A boundary only **partway** inside keeps the
  long-standing placement ahead of the wrapper; see Known limitation.

Output now matches the issue's Expected, in both modes:

```xml
<w:p><w:pPr><w:keepNext/><w:rPr><w:del .../></w:rPr></w:pPr>
  <w:bookmarkStart w:id="41" w:name="DeletedBoundary"/>
  <w:del ...><w:r><w:delText>Bookmarked deleted text</w:delText></w:r></w:del>
  <w:bookmarkEnd w:id="41"/></w:p>
```

Reject All restores the enclosing range. Accept All leaves the emptied bookmark
at the paragraph merge point instead of detached at body level.

## Known limitation (issue #643)

A boundary sitting partway inside a revision wrapper cannot be repositioned
faithfully by moving it: before the wrapper shrinks the range, after it grows
it. Repositioning it exactly means splitting the wrapper at the boundary, which
is a distinct change — filed as #643 and pinned here as characterization, so
this PR introduces no new inaccuracy of its own.

## Bookmark-name-on-accept is policy, not measured Word behavior

An earlier draft of the tests claimed Word leaves a zero-length bookmark when
all of a range's text is deleted. No Word-generated oracle backs that, and the
repo's LibreOffice oracle drops the bookmark outright on accept. Preserving the
name is safe-docx policy that this pass already had, unchanged here; the test
comments now say so rather than attributing it to a consumer. Capturing real
Word output for this scenario is worth doing separately.

## Interaction with #642

#642 (`cover-inplacemodifier2-20260725`) adds
`inPlaceModifier-bookmark-boundaries.test.ts`, which pins the old hoisting as
characterization. It is a **new file**, so there is no textual merge conflict
either way — but its two `DEFECT #641: …` tests fail against this fix (verified
by running that file against this branch). They were written to be flipped:
"When this issue is fixed, those tests must be updated to assert the enclosing
range." Whichever PR lands second needs that flip.

## Verification

- 11 new tests (`consumerCompatibility-bookmark-ranges.test.ts`): deleted,
  inserted, table-cell, and spanning paragraph cases across both reconstruction
  modes, plus wrapper-boundary cases for `w:del`, `w:moveFrom`, nested
  `<w:ins><w:del>`, and the partial boundary.
- Red/green: 8 fail against the parent commit; the 3 that pass in both states are
  the deliberate guards.
- Full suite green. Also `lint:workspaces`, `check:spec-coverage`,
  `check:conformance-citations`, `check:conformance-doc`, `check:allure-labels`,
  `check:allure-quality`, `check:allure-filenames`, `check:bdd-coverage`,
  `check:test-narratives`, `check:cycles`, `check:control-bytes`,
  `check:emitted-schema`, and the coverage ratchet (docx-compare lines +27.37%).

Peer-reviewed by Codex, which ran the fixtures rather than reading them; both of
its blocking findings are addressed above.

Closes #641

https://claude.ai/code/session_01NNSDJd4kNg5wgBnKmL69WS