### PR TITLE
fix(docx-compare): fail closed on text-box revisions

### DIFF
--- a/packages/docx-compare/src/baselines/atomizer/pipeline-safety-guards.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline-safety-guards.test.ts
@@ -3,6 +3,7 @@ import { describe, expect } from 'vitest';
 import type { ComparisonUnitAtom } from '@usejunior/docx-core';
 import { CorrelationStatus } from '@usejunior/docx-core';
 import { compareDocumentsAtomizer, computeAtomizerStats } from './pipeline.js';
+import { UnsupportedTextBoxRevisionError } from './textBoxRevisionSafety.js';
 import { buildDocxFromBodyXml } from '../../testing/ooxml-fixtures.js';
 import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
 import { el } from '../../testing/dom-test-helpers.js';
@@ -21,7 +22,116 @@ function paragraph(text: string): string {
   return `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
 }
 
+const TEXT_BOX_NAMESPACES = {
+  v: 'urn:schemas-microsoft-com:vml',
+  o: 'urn:schemas-microsoft-com:office:office',
+} as const;
+
+function paragraphWithTextBox(text: string, paragraphId = '20000001'): string {
+  return (
+    `<w:p><w:r><w:pict>` +
+    `<v:shape id="shape1" o:spid="_x0000_s1026">` +
+    `<v:textbox><w:txbxContent>` +
+    `<w:p w14:paraId="${paragraphId}" w14:textId="${paragraphId}">` +
+    `<w:r><w:t>${text}</w:t></w:r>` +
+    `</w:p>` +
+    `</w:txbxContent></v:textbox>` +
+    `</v:shape></w:pict></w:r></w:p>`
+  );
+}
+
 describe('pipeline safety and input guards', () => {
+  test('fails closed before emitting a revision inside w:txbxContent', async ({
+    given,
+    when,
+    then,
+    and,
+  }: AllureBddContext) => {
+    let original: Buffer;
+    let revised: Buffer;
+    const failures = new Map<'inplace' | 'rebuild', unknown>();
+
+    await given('a DOCX pair whose only change is text inside one VML text box', async () => {
+      original = await buildDocxFromBodyXml(
+        paragraphWithTextBox('05 Main Street'),
+        [],
+        { namespaces: TEXT_BOX_NAMESPACES },
+      );
+      revised = await buildDocxFromBodyXml(
+        paragraphWithTextBox('405 Main Street'),
+        [],
+        { namespaces: TEXT_BOX_NAMESPACES },
+      );
+    });
+
+    await when('the pair is compared using both reconstruction modes', async () => {
+      for (const reconstructionMode of ['inplace', 'rebuild'] as const) {
+        try {
+          await compareDocumentsAtomizer(original, revised, { reconstructionMode });
+        } catch (error) {
+          failures.set(reconstructionMode, error);
+        }
+      }
+    });
+
+    await then('comparison rejects the unsupported text-box revision explicitly', () => {
+      for (const reconstructionMode of ['inplace', 'rebuild'] as const) {
+        const failure = failures.get(reconstructionMode);
+        expect(failure, reconstructionMode).toBeInstanceOf(UnsupportedTextBoxRevisionError);
+        expect((failure as Error).message, reconstructionMode).toContain(
+          'Tracked revisions inside w:txbxContent are unsupported',
+        );
+      }
+    });
+
+    await and('the diagnostic identifies the affected text-box paragraph', () => {
+      for (const reconstructionMode of ['inplace', 'rebuild'] as const) {
+        expect(failures.get(reconstructionMode), reconstructionMode).toMatchObject({
+          changes: [{
+            index: 0,
+            originalParagraphId: '20000001',
+            revisedParagraphId: '20000001',
+          }],
+        });
+      }
+    });
+  });
+
+  test('permits body revisions when unchanged text boxes are present', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    let original: Buffer;
+    let revised: Buffer;
+    let result: Awaited<ReturnType<typeof compareDocumentsAtomizer>>;
+
+    await given('a DOCX pair with an unchanged text box and changed body text', async () => {
+      original = await buildDocxFromBodyXml(
+        `${paragraph('Original body')}${paragraphWithTextBox('05 Main Street')}`,
+        [],
+        { namespaces: TEXT_BOX_NAMESPACES },
+      );
+      revised = await buildDocxFromBodyXml(
+        `${paragraph('Revised body')}${paragraphWithTextBox('05 Main Street')}`,
+        [],
+        { namespaces: TEXT_BOX_NAMESPACES },
+      );
+    });
+
+    await when('the pair is compared', async () => {
+      result = await compareDocumentsAtomizer(original, revised, {
+        reconstructionMode: 'inplace',
+      });
+    });
+
+    await then('comparison succeeds without treating the unchanged text box as a change', () => {
+      expect(result.document.length).toBeGreaterThan(0);
+      expect(result.stats.insertions).toBeGreaterThan(0);
+      expect(result.stats.deletions).toBeGreaterThan(0);
+    });
+  });
+
   test('rejects a loadable package whose main part has no body', async ({
     given,
     when,

--- a/packages/docx-compare/src/baselines/atomizer/pipeline.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline.ts
@@ -120,6 +120,7 @@ import {
   AncillaryStorySafetyError,
   evaluateAncillaryFieldSafety,
 } from './ancillaryFieldSafety.js';
+import { assertTextBoxContentUnchanged } from './textBoxRevisionSafety.js';
 
 /**
  * Options for the atomizer pipeline.
@@ -634,6 +635,7 @@ export async function compareDocumentsAtomizer(
   // Step 2: Extract document.xml
   const originalXml = canonicalizeWordprocessingPrefixes(await originalArchive.getDocumentXml());
   const revisedXml = canonicalizeWordprocessingPrefixes(await revisedArchive.getDocumentXml());
+  assertTextBoxContentUnchanged(originalXml, revisedXml);
 
   // Extract numbering.xml if available
   const originalNumberingXml = await originalArchive.getNumberingXml() ?? undefined;

--- a/packages/docx-compare/src/baselines/atomizer/textBoxRevisionSafety.ts
+++ b/packages/docx-compare/src/baselines/atomizer/textBoxRevisionSafety.ts
@@ -1,8 +1,8 @@
 import { createHash } from 'node:crypto';
 import { OOXML } from '@usejunior/docx-core';
+import { canonicalNode } from './opaquePassthrough.js';
 import { parseDocumentXml } from './xmlToWmlElement.js';
 
-const XMLNS_NS = 'http://www.w3.org/2000/xmlns/';
 const WORD_2010_NS = 'http://schemas.microsoft.com/office/word/2010/wordml';
 
 export interface TextBoxRevisionChange {
@@ -35,35 +35,6 @@ export class UnsupportedTextBoxRevisionError extends Error {
     this.name = 'UnsupportedTextBoxRevisionError';
     this.changes = changes;
   }
-}
-
-function structuralSignature(node: Node): string {
-  if (node.nodeType === 3 || node.nodeType === 4) {
-    return JSON.stringify(['text', node.nodeValue ?? '']);
-  }
-  if (node.nodeType !== 1) return '';
-
-  const element = node as Element;
-  const attributes = Array.from(element.attributes)
-    .filter((attribute) => attribute.namespaceURI !== XMLNS_NS)
-    .map((attribute) => [
-      attribute.namespaceURI ?? '',
-      attribute.localName,
-      attribute.value,
-    ] as const)
-    .sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)));
-  const children: string[] = [];
-  for (let child = element.firstChild; child; child = child.nextSibling) {
-    const signature = structuralSignature(child);
-    if (signature) children.push(signature);
-  }
-
-  return JSON.stringify([
-    element.namespaceURI ?? '',
-    element.localName,
-    attributes,
-    children,
-  ]);
 }
 
 function textBoxParagraphId(textBox: Element): string | undefined {
@@ -99,10 +70,10 @@ export function assertTextBoxContentUnchanged(
     const originalTextBox = originalTextBoxes[index];
     const revisedTextBox = revisedTextBoxes[index];
     const originalSignature = originalTextBox
-      ? createHash('sha256').update(structuralSignature(originalTextBox)).digest('hex')
+      ? createHash('sha256').update(canonicalNode(originalTextBox)).digest('hex')
       : undefined;
     const revisedSignature = revisedTextBox
-      ? createHash('sha256').update(structuralSignature(revisedTextBox)).digest('hex')
+      ? createHash('sha256').update(canonicalNode(revisedTextBox)).digest('hex')
       : undefined;
     if (originalSignature === revisedSignature) continue;
 

--- a/packages/docx-compare/src/baselines/atomizer/textBoxRevisionSafety.ts
+++ b/packages/docx-compare/src/baselines/atomizer/textBoxRevisionSafety.ts
@@ -1,0 +1,121 @@
+import { createHash } from 'node:crypto';
+import { OOXML } from '@usejunior/docx-core';
+import { parseDocumentXml } from './xmlToWmlElement.js';
+
+const XMLNS_NS = 'http://www.w3.org/2000/xmlns/';
+const WORD_2010_NS = 'http://schemas.microsoft.com/office/word/2010/wordml';
+
+export interface TextBoxRevisionChange {
+  index: number;
+  originalParagraphId?: string;
+  revisedParagraphId?: string;
+}
+
+export class UnsupportedTextBoxRevisionError extends Error {
+  readonly changes: TextBoxRevisionChange[];
+
+  constructor(changes: TextBoxRevisionChange[]) {
+    const locations = changes
+      .map(({ index, originalParagraphId, revisedParagraphId }) => {
+        const paragraphIds = [...new Set(
+          [originalParagraphId, revisedParagraphId].filter(
+            (value): value is string => value !== undefined,
+          ),
+        )];
+        return paragraphIds.length > 0
+          ? `w:txbxContent[${index}] (paragraph ${paragraphIds.join(' → ')})`
+          : `w:txbxContent[${index}]`;
+      })
+      .join(', ');
+    super(
+      `Tracked revisions inside w:txbxContent are unsupported because the comparison ` +
+        `engine cannot currently emit a Word-readable redline for that container. ` +
+        `Changed container(s): ${locations}`,
+    );
+    this.name = 'UnsupportedTextBoxRevisionError';
+    this.changes = changes;
+  }
+}
+
+function structuralSignature(node: Node): string {
+  if (node.nodeType === 3 || node.nodeType === 4) {
+    return JSON.stringify(['text', node.nodeValue ?? '']);
+  }
+  if (node.nodeType !== 1) return '';
+
+  const element = node as Element;
+  const attributes = Array.from(element.attributes)
+    .filter((attribute) => attribute.namespaceURI !== XMLNS_NS)
+    .map((attribute) => [
+      attribute.namespaceURI ?? '',
+      attribute.localName,
+      attribute.value,
+    ] as const)
+    .sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)));
+  const children: string[] = [];
+  for (let child = element.firstChild; child; child = child.nextSibling) {
+    const signature = structuralSignature(child);
+    if (signature) children.push(signature);
+  }
+
+  return JSON.stringify([
+    element.namespaceURI ?? '',
+    element.localName,
+    attributes,
+    children,
+  ]);
+}
+
+function textBoxParagraphId(textBox: Element): string | undefined {
+  const paragraph = textBox.getElementsByTagNameNS(OOXML.W_NS, 'p').item(0) as Element | null;
+  return paragraph?.getAttributeNS(WORD_2010_NS, 'paraId') || undefined;
+}
+
+function textBoxes(documentXml: string): Element[] {
+  const root = parseDocumentXml(documentXml);
+  return Array.from(
+    root.getElementsByTagNameNS(OOXML.W_NS, 'txbxContent'),
+  ) as Element[];
+}
+
+/**
+ * Fail closed when a comparison would need to place tracked revision markup
+ * inside a text-box story. The atomizer currently treats the containing VML or
+ * DrawingML object as atomic, and wrapping the changed object produces a DOCX
+ * that Microsoft Word rejects as unreadable.
+ *
+ * @see https://github.com/UseJunior/safe-docx/issues/647
+ */
+export function assertTextBoxContentUnchanged(
+  originalDocumentXml: string,
+  revisedDocumentXml: string,
+): void {
+  const originalTextBoxes = textBoxes(originalDocumentXml);
+  const revisedTextBoxes = textBoxes(revisedDocumentXml);
+  const count = Math.max(originalTextBoxes.length, revisedTextBoxes.length);
+  const changes: TextBoxRevisionChange[] = [];
+
+  for (let index = 0; index < count; index++) {
+    const originalTextBox = originalTextBoxes[index];
+    const revisedTextBox = revisedTextBoxes[index];
+    const originalSignature = originalTextBox
+      ? createHash('sha256').update(structuralSignature(originalTextBox)).digest('hex')
+      : undefined;
+    const revisedSignature = revisedTextBox
+      ? createHash('sha256').update(structuralSignature(revisedTextBox)).digest('hex')
+      : undefined;
+    if (originalSignature === revisedSignature) continue;
+
+    changes.push({
+      index,
+      originalParagraphId: originalTextBox
+        ? textBoxParagraphId(originalTextBox)
+        : undefined,
+      revisedParagraphId: revisedTextBox
+        ? textBoxParagraphId(revisedTextBox)
+        : undefined,
+    });
+  }
+
+  if (changes.length > 0) throw new UnsupportedTextBoxRevisionError(changes);
+}

--- a/packages/docx-compare/src/index.ts
+++ b/packages/docx-compare/src/index.ts
@@ -137,4 +137,9 @@ export {
 } from './baselines/atomizer/pipeline.js';
 export { parseDocumentXml } from './baselines/atomizer/xmlToWmlElement.js';
 export { AncillaryStorySafetyError } from './baselines/atomizer/ancillaryFieldSafety.js';
+export {
+  UnsupportedTextBoxRevisionError,
+  assertTextBoxContentUnchanged,
+} from './baselines/atomizer/textBoxRevisionSafety.js';
+export type { TextBoxRevisionChange } from './baselines/atomizer/textBoxRevisionSafety.js';
 export { computeAtomLcs, markCorrelationStatus } from './baselines/atomizer/atomLcs.js';


### PR DESCRIPTION
## What changed

- detect changes to `w:txbxContent` before atomization/reconstruction
- fail with a typed `UnsupportedTextBoxRevisionError` that identifies the affected text-box index and paragraph id
- preserve ordinary comparisons when text-box content is unchanged
- cover both `inplace` and `rebuild` reconstruction modes with a shared minimal DOCX fixture

## Why

The atomizer treats VML/DrawingML objects as atomic. When text inside a text box changes, the existing reconstruction paths can wrap the object in revision markup that produces a DOCX Microsoft Word rejects as unreadable even though comparison reports success. Until valid text-box revision emission is supported, failing closed prevents callers from shipping corrupt redlines.

Fixes #647

## Validation

- `npm run build`
- `npm run lint:workspaces` (passes with 9 pre-existing unused-disable warnings)
- `npm run test:run`
- `npm run check:spec-coverage`
- `npm run check:conformance-citations`
- `npm run check:conformance-doc`
- focused `@usejunior/docx-compare` suite: 674 passed, 48 skipped
