### PR TITLE
fix(docx-core): accept nested field instruction results

### DIFF
--- a/packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.ts
+++ b/packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.ts
@@ -46,13 +46,27 @@ const IGNORED_STRICT_ISSUES = new Set([
   'DELETED_TEXT_OUTSIDE_DELETION',
 ]);
 
+export interface AncillaryStorySafetyAttempt {
+  reconstructionMode: ReconstructionMode;
+  issues: AncillaryStorySafetyIssue[];
+}
+
 export class AncillaryStorySafetyError extends Error {
   readonly issues: AncillaryStorySafetyIssue[];
+  readonly attempts?: AncillaryStorySafetyAttempt[];
 
-  constructor(issues: AncillaryStorySafetyIssue[]) {
-    super(`Ancillary story safety check failed with ${issues.length} issue(s)`);
+  constructor(
+    issues: AncillaryStorySafetyIssue[],
+    attempts?: AncillaryStorySafetyAttempt[],
+  ) {
+    super(
+      attempts
+        ? `Ancillary story safety check failed in ${attempts.length} reconstruction attempt(s)`
+        : `Ancillary story safety check failed with ${issues.length} issue(s)`,
+    );
     this.name = 'AncillaryStorySafetyError';
     this.issues = issues;
+    this.attempts = attempts;
   }
 }
 

--- a/packages/docx-compare/src/baselines/atomizer/pipeline-safety-guards.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline-safety-guards.test.ts
@@ -174,8 +174,7 @@ describe('pipeline safety and input guards', () => {
   }: AllureBddContext) => {
     // The inplace attempt throws AncillaryStorySafetyError; the pipeline then
     // retries in rebuild mode, whose base archive still carries the corrupted
-    // footnotes.xml, so rebuild fails closed with the same typed diagnostic —
-    // which is what surfaces to the caller. We assert on that terminal error.
+    // footnotes.xml. The terminal error retains diagnostics from both attempts.
     let original: Buffer;
     let revised: Buffer;
     let failure: unknown;
@@ -218,6 +217,24 @@ describe('pipeline safety and input guards', () => {
               normalizedPartPath: 'word/footnotes.xml',
             }),
           }),
+        ],
+        attempts: [
+          {
+            reconstructionMode: 'inplace',
+            issues: [
+              expect.objectContaining({
+                code: 'NOTE_PART_XML_INVALID',
+              }),
+            ],
+          },
+          {
+            reconstructionMode: 'rebuild',
+            issues: [
+              expect.objectContaining({
+                code: 'NOTE_PART_XML_INVALID',
+              }),
+            ],
+          },
         ],
       });
     });

--- a/packages/docx-compare/src/baselines/atomizer/pipeline.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline.ts
@@ -1017,12 +1017,20 @@ export async function compareDocumentsAtomizer(
       { atomizeParagraphLevelMarkers: true },
       'rebuild'
     );
-    assembled = await assembleCandidate(comparisonResult);
+    try {
+      assembled = await assembleCandidate(comparisonResult);
+    } catch (rebuildError) {
+      if (!(rebuildError instanceof AncillaryStorySafetyError)) throw rebuildError;
+      throw new AncillaryStorySafetyError(rebuildError.issues, [
+        { reconstructionMode: 'inplace', issues: error.issues },
+        { reconstructionMode: 'rebuild', issues: rebuildError.issues },
+      ]);
+    }
   }
 
   // Rebuild remains the terminal main-story strategy. Its established
-  // round-trip diagnostics stay caller-visible; ancillary failures have
-  // already thrown before this point.
+  // round-trip diagnostics stay caller-visible. A terminal ancillary failure
+  // throws with both reconstruction attempts attached.
   let rebuildSafetyDiagnostics: ReconstructionRebuildSafetyDiagnostics | undefined;
   if (comparisonResult.outputMode === 'rebuild') {
     const safety = evaluateRoundTripSafety(comparisonResult.newDocumentXml);

--- a/packages/docx-compare/src/index.ts
+++ b/packages/docx-compare/src/index.ts
@@ -136,7 +136,10 @@ export {
   compareDocumentsAtomizer,
 } from './baselines/atomizer/pipeline.js';
 export { parseDocumentXml } from './baselines/atomizer/xmlToWmlElement.js';
-export { AncillaryStorySafetyError } from './baselines/atomizer/ancillaryFieldSafety.js';
+export {
+  AncillaryStorySafetyError,
+  type AncillaryStorySafetyAttempt,
+} from './baselines/atomizer/ancillaryFieldSafety.js';
 export {
   UnsupportedTextBoxRevisionError,
   assertTextBoxContentUnchanged,

--- a/packages/docx-core/src/integration/lean-differential-helpers.test.ts
+++ b/packages/docx-core/src/integration/lean-differential-helpers.test.ts
@@ -23,8 +23,9 @@
  *
  * Faithful subset: the random generator stays inside the region where the Lean model and
  * the production engine provably agree — fldChar/instrText only in top-level runs;
- * delInstrText only in its one OOXML-legal home (inside a w:del, in an open pre-separate
- * field), where both engines agree; and every paragraph keeps a surviving top-level run.
+ * delInstrText only inside a w:del while at least one enclosing field remains
+ * pre-separator, where both engines agree; and every paragraph keeps a surviving
+ * top-level run.
  * Model gaps that live OUTSIDE that subset are pinned by explicit cases rather than hidden.
  * G1/G2 — the DeletedFieldCode locality constraint — are now CLOSED: the Lean model enforces
  * it (`add-lean-deleted-field-code-constraint`), so the two engines AGREE:
@@ -604,6 +605,47 @@ describeMaybe('Lean Differential Harness - Tier 2 helper extensional equivalence
         expect(lean!.validate).toBe(true);
         expect(tsValidate).toBe(true);
         expect(lean!.validate).toBe(tsValidate);
+      });
+    },
+  );
+
+  test(
+    'nested-field instruction result: Lean and TS both use any enclosing pre-separator field',
+    async ({ given, when, then }: AllureBddContext) => {
+      const nestedWordField: WireDoc = [
+        {
+          body: [
+            {
+              run: {
+                content: [
+                  { fldChar: 'begin' },
+                  { instrText: ' IF "0" = "1" "' },
+                  { fldChar: 'begin' },
+                  { instrText: ' DOCPROPERTY "SWDocID" ' },
+                  { fldChar: 'separate' },
+                  { instrText: 'RLF1 23607329v.2' },
+                  { fldChar: 'end' },
+                  { instrText: '" ""' },
+                  { fldChar: 'end' },
+                ],
+              },
+            },
+          ],
+        },
+      ];
+      let lean: HelperResult;
+      let tsValidate = false;
+
+      await given('Word instruction text after an inner separator while the outer IF field remains pre-separator', () => {
+        lean = leanHelperBatch([nestedWordField])[0]!;
+      });
+      await when('both field-structure implementations validate it', () => {
+        tsValidate = validateFieldStructure(renderDocToXml(nestedWordField));
+      });
+      await then('both accept the Word-authored nested-field serialization', () => {
+        expect(lean.validate).toBe(true);
+        expect(tsValidate).toBe(true);
+        expect(lean.validate).toBe(tsValidate);
       });
     },
   );

--- a/packages/docx-core/src/shared/field-structure.test.ts
+++ b/packages/docx-core/src/shared/field-structure.test.ts
@@ -1,0 +1,104 @@
+import { expect } from 'vitest';
+import {
+  NESTED_IF_DOCPROPERTY_FIELD_WITH_INSTRUCTION_RESULT,
+  delInstrText,
+  fldChar,
+  instrText,
+} from '../testing/ooxml-fixtures.js';
+import {
+  validateFieldStructure,
+  validateStrictFieldStructure,
+} from './field-structure.js';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({ feature: 'Nested Field Structure Validation' })
+  .conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.16.18' });
+
+const NS = 'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
+
+function buildDoc(bodyXml: string): string {
+  return `<w:document ${NS}><w:body>${bodyXml}<w:sectPr/></w:body></w:document>`;
+}
+
+test(
+  'Word nested-field instruction-result serialization is valid',
+  async ({ given, when, then }: AllureBddContext) => {
+    let xml = '';
+    let leanPinned = false;
+    let strict = false;
+
+    await given('an IF field whose nested DOCPROPERTY result is serialized as instruction text', () => {
+      xml = buildDoc(`<w:p>${NESTED_IF_DOCPROPERTY_FIELD_WITH_INSTRUCTION_RESULT}</w:p>`);
+    });
+    await when('the document is validated by both runtime predicates', () => {
+      leanPinned = validateFieldStructure(xml);
+      strict = validateStrictFieldStructure(xml);
+    });
+    await then('the outer pre-separator field keeps the nested result in a legal code region', () => {
+      expect(leanPinned).toBe(true);
+      expect(strict).toBe(true);
+    });
+  },
+);
+
+test(
+  'deleted nested-field instruction text uses the outer field code region',
+  async ({ given, when, then }: AllureBddContext) => {
+    let xml = '';
+    let ok = false;
+
+    await given('deleted instruction text after an inner separator while the outer field is pre-separator', () => {
+      xml = buildDoc(
+        `<w:p>` +
+          fldChar('begin') +
+          instrText(' IF ', { preserve: true }) +
+          fldChar('begin') +
+          instrText(' DOCPROPERTY "SWDocID" ', { preserve: true }) +
+          fldChar('separate') +
+          `<w:del>${delInstrText('RLF1 23607329v.2', { preserve: true })}</w:del>` +
+          fldChar('end') +
+          instrText(' = "1" ', { preserve: true }) +
+          fldChar('end') +
+          `</w:p>`,
+      );
+    });
+    await when('the document is validated', () => {
+      ok = validateFieldStructure(xml);
+    });
+    await then('the deleted instruction text is accepted', () => {
+      expect(ok).toBe(true);
+    });
+  },
+);
+
+test(
+  'nested instruction text is rejected after every enclosing separator',
+  async ({ given, when, then }: AllureBddContext) => {
+    let xml = '';
+    let ok = true;
+
+    await given('instruction text after both the outer and inner fields have entered their result regions', () => {
+      xml = buildDoc(
+        `<w:p>` +
+          fldChar('begin') +
+          instrText(' OUTER ', { preserve: true }) +
+          fldChar('separate') +
+          fldChar('begin') +
+          instrText(' INNER ', { preserve: true }) +
+          fldChar('separate') +
+          instrText('not a field instruction', { preserve: true }) +
+          fldChar('end') +
+          fldChar('end') +
+          `</w:p>`,
+      );
+    });
+    await when('the document is validated', () => {
+      ok = validateFieldStructure(xml);
+    });
+    await then('the validator still rejects instruction text outside every open code region', () => {
+      expect(ok).toBe(false);
+    });
+  },
+);

--- a/packages/docx-core/src/shared/field-structure.ts
+++ b/packages/docx-core/src/shared/field-structure.ts
@@ -59,6 +59,7 @@ export function hasFldCharInsideDel(documentXml: string): boolean {
  *
  * @conformance ECMA-376 edition 5, Part 1 § 17.16.18
  * @ooxmlSpec ooxml.ecma376.5ed.part1.fields.complex-field-characters
+ * @see https://github.com/UseJunior/safe-docx/issues/645
  */
 export function collectFieldStructureIssues(input: string | FieldStory[]): FieldStructureIssue[] {
   if (typeof input === 'string') {
@@ -219,6 +220,13 @@ function collectFieldStructureIssuesForStory(documentXml: string, story: string)
     issues.push({ code, message, story, element });
   }
 
+  function isInsideOpenFieldCodeRegion(): boolean {
+    for (let fieldDepth = 1; fieldDepth <= depth; fieldDepth++) {
+      if (!pastSeparatorAtDepth[fieldDepth]) return true;
+    }
+    return false;
+  }
+
   function scan(node: Element): void {
     for (let child = node.firstChild; child; child = child.nextSibling) {
       if (child.nodeType !== 1) continue;
@@ -252,14 +260,14 @@ function collectFieldStructureIssuesForStory(documentXml: string, story: string)
           if (depth > 0) depth--;
         }
       } else if (isW(el, 'instrText')) {
-        if (depth === 0 || pastSeparatorAtDepth[depth]) {
+        if (!isInsideOpenFieldCodeRegion()) {
           push('INSTRUCTION_TEXT_OUTSIDE_FIELD_CODE', 'w:instrText must appear inside an open field code region', 'w:instrText');
         }
       } else if (isW(el, 'delInstrText')) {
         if (insideDelDepth === 0) {
           push('DELETED_INSTRUCTION_TEXT_OUTSIDE_DELETION', 'w:delInstrText must appear inside w:del', 'w:delInstrText');
         }
-        if (depth === 0 || pastSeparatorAtDepth[depth]) {
+        if (!isInsideOpenFieldCodeRegion()) {
           push('DELETED_INSTRUCTION_TEXT_OUTSIDE_FIELD_CODE', 'w:delInstrText must appear inside an open field code region', 'w:delInstrText');
         }
       } else if (isW(el, 't') && (insideDelDepth > 0 || insideMoveFromDepth > 0)) {

--- a/packages/docx-core/src/testing/ooxml-fixtures.ts
+++ b/packages/docx-core/src/testing/ooxml-fixtures.ts
@@ -107,6 +107,22 @@ export const COMPLETE_PAGEREF_FIELD = completeField(FIELD_INSTRUCTIONS.PAGEREF, 
 export const COMPLETE_REF_FIELD = completeField(FIELD_INSTRUCTIONS.REF, 'Section 1');
 
 /**
+ * Word/DMS serialization of an inner field result while the enclosing field is
+ * still in its instruction-code region. Although the inner field is past its
+ * separator, the cached value remains instruction text for the outer field.
+ */
+export const NESTED_IF_DOCPROPERTY_FIELD_WITH_INSTRUCTION_RESULT =
+  fldChar('begin') +
+  instrText(' IF "0" = "1" "', { preserve: true }) +
+  fldChar('begin') +
+  instrText(' DOCPROPERTY "SWDocID" ', { preserve: true }) +
+  fldChar('separate') +
+  instrText('RLF1 23607329v.2', { preserve: true }) +
+  fldChar('end') +
+  instrText('" ""', { preserve: true }) +
+  fldChar('end');
+
+/**
  * Build a topology-sensitive complex field used by forced-rebuild tests.
  *
  * Every field component has distinct run properties, the instruction is

--- a/verification/lean/Tier2/FieldStructure.lean
+++ b/verification/lean/Tier2/FieldStructure.lean
@@ -2,11 +2,11 @@
 Tier 2 — field-structure predicate.
 
 Definitional mirror of the two checks in `validateFieldStructure`
-(`packages/docx-core/src/baselines/atomizer/pipeline.ts:352-402`):
+(`packages/docx-core/src/shared/field-structure.ts`):
 
   1. global `w:fldChar` begin/end counts are balanced;
-  2. every `w:instrText` / `w:delInstrText` sits inside an open, pre-`separate`
-     field body.
+  2. every `w:instrText` / `w:delInstrText` sits inside the instruction-code
+     region of at least one enclosing field.
 
 Check (2) walks every atom in document order carrying a *stack* of
 "separator-seen" bits indexed by field depth — exactly the TS engine's
@@ -40,20 +40,27 @@ def WalkResult.isValid : WalkResult → Bool
   | .ok _ => true
   | .invalid => false
 
+/-- At least one enclosing field is still before its separator. Word may emit
+    an inner field's cached result as instruction text while an outer field
+    remains in its instruction-code region. -/
+def FieldCtx.insideCode (ctx : FieldCtx) : Bool :=
+  ctx.any (fun pastSeparator => !pastSeparator)
+
 /-- Step the field-context walk across one atom, at structural del-ancestry depth
     `delDepth` (the number of enclosing `w:del` wrappers). Mirrors the main
-    `validateFieldStructure` scan at `pipeline.ts:525-560`:
+    `validateFieldStructure` scan in `field-structure.ts`:
 
     * field-context state — `begin` pushes a fresh `false`; `separate` sets the
-      top bit (no-op on the empty stack, matching the `if (depth > 0)` guard at
-      `pipeline.ts:548`); `end` pops (no-op on empty, `pipeline.ts:550`);
-      `instrText` requires a non-empty stack whose top bit is `false`
-      (`pipeline.ts:553`);
+      top bit (no-op on the empty stack, matching the runtime's `depth > 0`
+      guard); `end` pops (no-op on empty);
+      `instrText` requires at least one `false` bit in the stack, because an
+      outer field may remain in its instruction region after an inner field's
+      separator (`field-structure.ts`, issue #645);
     * DeletedFieldCode locality (constraint (3)) — a `w:fldChar` of ANY
-      `w:fldCharType` at `delDepth > 0` is `invalid` (`pipeline.ts:542`, G1), and a
-      `w:delInstrText` at `delDepth = 0` is `invalid` (`pipeline.ts:555`, G2). The
-      `delInstrText` open-pre-`separate` field check (`pipeline.ts:556`) still
-      applies once the del-ancestry gate passes. -/
+      `w:fldCharType` at `delDepth > 0` is `invalid` (G1), and a
+      `w:delInstrText` at `delDepth = 0` is `invalid` (G2). The same
+      enclosing-code-region check still applies to `delInstrText` once
+      the del-ancestry gate passes. -/
 def stepAtom (delDepth : Nat) (r : WalkResult) (a : Atom) : WalkResult :=
   match r with
   | .invalid => .invalid
@@ -76,16 +83,12 @@ def stepAtom (delDepth : Nat) (r : WalkResult) (a : Atom) : WalkResult :=
           | [] => .ok []
           | _ :: rest => .ok rest
     | .instrText _ =>
-      match ctx with
-      | false :: _ => .ok ctx
-      | _ => .invalid
+      if ctx.insideCode then .ok ctx else .invalid
     | .delInstrText _ =>
       -- constraint (3): `delInstrText` only inside a `del` ancestor (G2)
       if delDepth = 0 then .invalid
       else
-        match ctx with
-        | false :: _ => .ok ctx
-        | _ => .invalid
+        if ctx.insideCode then .ok ctx else .invalid
 
 /-- Step the field-context walk across a run's atoms, left to right, at del-depth
     `delDepth`. -/
@@ -95,9 +98,9 @@ def stepAtoms (delDepth : Nat) (r : WalkResult) (as : List Atom) : WalkResult :=
 /-- Walk the field context across a block sequence in document order at
     del-ancestry depth `delDepth`. The walk descends into every wrapper and
     transparent container, because the TS `validateFieldStructure` scans every
-    element regardless of tag (`pipeline.ts:528`). Only `del` is structurally
+    element regardless of tag. Only `del` is structurally
     significant: descending into a `del` subtree increments `delDepth`
-    (`pipeline.ts:533-538`), so the atom-level constraint-(3) gate in `stepAtom`
+    so the atom-level constraint-(3) gate in `stepAtom`
     can see the del-ancestry. The linear field context flows across the `del`
     boundary unchanged, exactly as the engine shares `depth`/`pastSeparatorAtDepth`
     across the `insideDelDepth` recursion. -/
@@ -142,8 +145,8 @@ termination_by bs => sizeOf bs
 def fldCharBalanced (d : Doc) : Bool :=
   countBlocks Atom.isBegin d.blocks == countBlocks Atom.isEnd d.blocks
 
-/-- `validateFieldStructure` — definitional mirror of the main scan at
-    `pipeline.ts:496-565` (begin/end balance, the open-field walk, and the
+/-- `validateFieldStructure` — definitional mirror of the main scan in
+    `field-structure.ts` (begin/end balance, the open-field walk, and the
     DeletedFieldCode locality constraint). The walk starts at del-depth 0. -/
 def validateFieldStructure (d : Doc) : Bool :=
   fldCharBalanced d && (walkBlocks 0 (.ok []) d.blocks).isValid

--- a/verification/lean/Tier2/README.md
+++ b/verification/lean/Tier2/README.md
@@ -45,10 +45,11 @@ the document-level `preservationFriendly d`, both `accept d` and `reject d` sati
 document-level field walk and begin/end balance unchanged — strictly weaker than
 the per-subtree `recursivelyWellformed` (`∀ ctx` neutrality of every wrapper
 subtree). The field-context walk carries a depth-indexed stack of "separator-seen"
-bits mirroring the TS engine's `pastSeparatorAtDepth: number[]`
-(`packages/docx-core/src/baselines/atomizer/pipeline.ts:525-560`) and a structural
-del-ancestry depth enforcing the DeletedFieldCode locality constraint
-(`pipeline.ts:542`/`555`).
+bits mirroring the TS engine's `pastSeparatorAtDepth: number[]`. Instruction text
+is valid when at least one enclosing field remains before its separator, which
+covers Word's nested-field result serialization (#645). The walk also carries a
+structural del-ancestry depth enforcing the DeletedFieldCode locality constraint
+in `field-structure.ts`.
 
 `inv_field_001` in `Spec.lean` is closed by composing `field_structure_preserved_doc`
 with the single named residual axiom

--- a/verification/lean/Tier2/XmlTripleChecker.lean
+++ b/verification/lean/Tier2/XmlTripleChecker.lean
@@ -837,6 +837,9 @@ def WalkResult.isValid : WalkResult → Bool
   | .ok _ => true
   | .invalid => false
 
+def FieldCtx.insideCode (ctx : FieldCtx) : Bool :=
+  ctx.any (fun pastSeparator => !pastSeparator)
+
 def stepField (r : WalkResult) : XmlTok → WalkResult
   | .fldChar .begin =>
     match r with
@@ -854,8 +857,8 @@ def stepField (r : WalkResult) : XmlTok → WalkResult
     | .invalid => .invalid
   | .instrText _ =>
     match r with
-    | .ok (false :: _) => r
-    | _ => .invalid
+    | .ok ctx => if ctx.insideCode then r else .invalid
+    | .invalid => .invalid
   | .delInstrText _ => .invalid
   | _ => r
 


### PR DESCRIPTION
## Summary

- treat `w:instrText` / `w:delInstrText` as inside a field-code region when **any** enclosing field remains pre-separator
- mirror the corrected semantics in both Lean field validators and pin Lean↔TypeScript parity
- retain diagnostics from both inplace and rebuild ancillary-publication attempts on terminal failure
- add the canonical Word `IF` / `DOCPROPERTY` nested-field fixture and positive/negative regression coverage

This fixes Word-authored DMS footer fields where an inner field's cached result is serialized as `w:instrText` while the outer field is still in its instruction region.

## Validation

- full mandatory pre-submit sequence passed:
  - `npm run build`
  - `npm run lint:workspaces` (0 errors; 9 pre-existing warnings)
  - `npm run test:run`
  - `npm run check:spec-coverage`
  - `npm run check:conformance-citations`
  - `npm run check:conformance-doc`
- compiled Lean targets: `Tier2.FieldStructure`, `Tier2.XmlTripleChecker`, `leanDocxChecker`, and `leanHelperDifferential`
- Lean↔TypeScript differential: 12/12 passed with LibreOffice oracle
- real NVCA Indemnification Agreement zero-edit self-compare:
  - inplace: PASS, zero revisions
  - rebuild: PASS, zero revisions

One pre-existing move-emission test hit its 5-second timeout during the first heavily loaded full run; it passed in isolation (610 ms), and the complete workspace test command then passed on rerun.

Fixes #645