### PR TITLE
test(docx-compare): label table SDT regressions

### DIFF
--- a/openspec/changes/preserve-block-sdt-on-rebuild/design.md
+++ b/openspec/changes/preserve-block-sdt-on-rebuild/design.md
@@ -18,20 +18,27 @@ payload such as DrawingML.
 - Goals: pair multiple or identical controls deterministically from local body
   placement and ownership, with precomputed/memoized group identity and
   deterministic complexity evidence.
-- Non-Goals: row/cell/nested/editable controls; controls outside `document.xml`;
-  footer or ancillary reconstruction; tables inside a supported control; rsids
-  outside the preserved subtree; fields; `sectPr`; arbitrary package parts.
+- Goals: preserve row- and cell-scoped control wrappers through their existing
+  table scaffold while allowing ordinary tracked paragraph reconstruction
+  inside `w:sdtContent`.
+- Non-Goals: nested controls; controls outside `document.xml`;
+  footer or ancillary reconstruction; tables inside a direct-body opaque
+  control; rsids outside the preserved subtree; fields; `sectPr`; arbitrary
+  package parts.
 
 ## Decisions
 
 ### Placement is explicit
 
 `OpaquePassthroughNode` records `placementKind` as `inline-run` or
-`body-block`. Inline descriptors retain one paragraph owner and paragraph-run
+`body-block`, plus `row-block` and `cell-block`. Inline descriptors retain one paragraph owner and paragraph-run
 emission. Body-block descriptors record their direct body-child ordinal and a
 closed, contiguous interval of global paragraph slots. A block descriptor is
 attached to every atom in every owned paragraph, but its subtree is emitted only
-by the body scaffold.
+by the body scaffold. Row/cell descriptors record their direct parent-child
+ordinal and a wrapper fingerprint that replaces controlled paragraphs with
+structural markers, so paragraph content can change without laundering wrapper
+or table/cell scaffold changes.
 
 ### Correlation is local and fail closed
 
@@ -72,20 +79,24 @@ also fail closed before correlation.
 ### Claims remain bounded
 
 Block structure is cited to ECMA-376 Part 1 §§17.5.2.29, 17.5.2.34, and
-17.5.2.38. Exact opaque preservation and package-part stability are SafeDocX
+17.5.2.38; cell-level structure inside a row is cited to §§17.5.2.32 and
+17.5.2.33. Exact opaque preservation and package-part stability are SafeDocX
 metamorphic invariants, not requirements imposed by ECMA-376.
 
 ## Risks / Trade-offs
 
-- An otherwise safe edit inside the control is rejected. This avoids silently
-  preserving stale controlled content or flattening unsupported structure.
-- Block controls containing tables are rejected in this slice because paragraph
-  slot ownership alone cannot represent table/cell placement safely.
+- An otherwise safe edit inside a direct-body opaque control is rejected. This
+  avoids silently preserving stale controlled content or flattening unsupported
+  structure.
+- Direct body controls containing tables remain rejected because their opaque
+  paragraph-slot ownership cannot represent nested table placement safely.
+- Row/cell controls allow paragraph edits but reject wrapper, cell-property, or
+  table-shape changes that the paragraph reconstructor cannot safely represent.
 - Footer SDTs remain outside reconstruction support; package-clone identity may
   be observed only as no-regression evidence.
 
 ## Migration Plan
 
-No API migration is required. Existing inline controls keep their current
-behavior. Newly supported direct body-level controls pass through only when the
-strict block ownership contract is satisfied.
+No API migration is required. Existing inline and direct-body controls keep
+their current behavior. Row/cell controls use the existing table scaffold only
+when their wrapper and structural identity correlate.

--- a/openspec/changes/preserve-block-sdt-on-rebuild/proposal.md
+++ b/openspec/changes/preserve-block-sdt-on-rebuild/proposal.md
@@ -14,10 +14,12 @@ even when the control itself is unchanged.
   and contiguous paragraph-slot ownership while retaining the inline contract.
 - Capture unchanged direct body-level block SDTs, pair them deterministically,
   and preserve the validated original subtree as one scaffold-owned block.
+- Correlate row- and cell-scoped SDT wrappers by their container-relative
+  scaffold placement while allowing their controlled paragraphs to rebuild.
 - Bind every relationship-namespace attribute in a block to a memoized package
   closure covering relationship metadata, normalized targets, internal part
   hashes, and recursively referenced XML-part relationships.
-- Reject mutation, movement, ownership loss, nesting, unsupported placement, or
+- Reject wrapper mutation, movement, ownership loss, nesting, unsupported placement, or
   correlation loss before any lossy rebuilt XML is emitted.
 - Replace the ILPA count-only measurement with forced-rebuild corpus evidence
   that makes real unrelated edits and validates the complete SDT subtree,
@@ -33,4 +35,4 @@ even when the control itself is unchanged.
 - Affected code: opaque atom metadata/capture/correlation, hierarchical LCS
   identity, package relationship closure, rebuild scaffold, focused and ILPA
   corpus tests, ECMA registry, DPT pin and capability projection
-- Ref: #582
+- Ref: #582, #660

--- a/openspec/changes/preserve-block-sdt-on-rebuild/specs/docx-comparison/spec.md
+++ b/openspec/changes/preserve-block-sdt-on-rebuild/specs/docx-comparison/spec.md
@@ -24,9 +24,9 @@ a bounded SafeDocX metamorphic invariant, not an ECMA-376 requirement.
 - **THEN** each control SHALL retain its direct body placement and paragraph-slot ownership
 - **AND** no document-wide ordinal SHALL launder movement or changed ownership into a valid match
 
-#### Scenario: [SDX-SDT-BLOCK-03] Unsupported block ownership fails before output
+#### Scenario: [SDX-SDT-BLOCK-03] Unsupported direct-body block ownership fails before output
 
-- **GIVEN** mutation, an internal edit, insertion, deletion, reorder, movement, changed or non-contiguous paragraph ownership, correlation loss, nesting, or table/cell placement
+- **GIVEN** mutation, an internal edit, insertion, deletion, reorder, movement, changed or non-contiguous paragraph ownership, correlation loss, nesting, or a table inside a direct-body control
 - **WHEN** forced rebuild attempts opaque block passthrough
 - **THEN** reconstruction SHALL fail before emitting lossy document XML
 - **AND** it SHALL NOT preserve stale content, flatten the control, or partially replace owned paragraphs
@@ -47,3 +47,24 @@ a bounded SafeDocX metamorphic invariant, not an ECMA-376 requirement.
 - **AND** package-root and ordinary relative internal targets SHALL remain valid
 - **AND** decoded authority references, malformed escapes, backslashes, URI schemes, dangling targets, and unsupported relationship-bearing targets SHALL fail closed before package normalization
 - **AND** external targets SHALL be compared without network access
+
+### Requirement: Forced rebuild retains legal table-scoped structured document tags
+
+When comparison uses `reconstructionMode: rebuild`, the system SHALL retain a
+`w:sdt` directly parented by `w:tr` or `w:tc` in its original table scaffold,
+SHALL rebuild changed controlled paragraphs with tracked revisions, and SHALL
+correlate the wrapper by container-relative placement and a paragraph-insensitive
+structural fingerprint.
+
+#### Scenario: [SDX-SDT-TABLE-01] Row and cell controls retain their scaffold while content changes
+
+- **GIVEN** a row-scoped control whose `w:sdtContent` directly contains `w:tc` and a cell-scoped control whose content directly contains `w:p` or `w:tbl`
+- **WHEN** controlled paragraph text changes through forced rebuild
+- **THEN** each `w:sdt` SHALL remain under its original `w:tr` or `w:tc` parent
+- **AND** accepting and rejecting changes SHALL project revised and original controlled text respectively
+
+#### Scenario: [SDX-SDT-TABLE-02] Table control scaffold mutation fails before rebuild
+
+- **GIVEN** a row- or cell-scoped control whose properties, container-relative placement, cell scaffold, or wrapper structure differs between inputs
+- **WHEN** forced rebuild correlates the table-scoped boundary
+- **THEN** reconstruction SHALL fail before preserving stale wrapper or scaffold metadata

--- a/openspec/changes/preserve-block-sdt-on-rebuild/specs/spec-compliance/spec.md
+++ b/openspec/changes/preserve-block-sdt-on-rebuild/specs/spec-compliance/spec.md
@@ -3,12 +3,12 @@
 ### Requirement: Block structured document tag claims cite exact normative structure
 
 The conformance registry SHALL cite ECMA-376 edition 5 Part 1 §§17.5.2.29,
-17.5.2.34, and 17.5.2.38 for block SDT structure, block content, and properties,
-while exact opaque preservation remains a separately labeled SafeDocX
-metamorphic invariant.
+17.5.2.32, 17.5.2.33, 17.5.2.34, and 17.5.2.38 for block/cell SDT structure,
+content, and properties, while exact opaque or scaffold preservation remains a
+separately labeled SafeDocX metamorphic invariant.
 
 #### Scenario: [SPEC-COV-SDT-BLOCK-01] Block preservation evidence remains bounded
 
 - **WHEN** block-SDT implementation and tests claim normative structure
-- **THEN** JSDoc and Allure metadata SHALL cite the three exact ECMA sections
-- **AND** no claim SHALL broaden to row, cell, nested, editable, footer, or ancillary control reconstruction
+- **THEN** JSDoc and Allure metadata SHALL cite the exact ECMA sections for each supported placement
+- **AND** no claim SHALL broaden to nested, footer, ancillary, or structurally mutated control reconstruction

--- a/openspec/changes/preserve-block-sdt-on-rebuild/tasks.md
+++ b/openspec/changes/preserve-block-sdt-on-rebuild/tasks.md
@@ -44,3 +44,10 @@
 - [x] 7.3 Add timeout-free multi-root cycle, shared dependency, and positive/negative target controls.
 - [x] 7.4 Re-run focused/full tests, preflight/gates, DPT, schema, and LibreOffice checks.
 - [x] 7.5 Commit the final review fix conventionally without pushing.
+
+## 8. Table-scoped reconstruction bug fix
+
+- [x] 8.1 Add row-block and cell-block placement identities with container-relative anchoring.
+- [x] 8.2 Permit controlled paragraph edits while failing closed on wrapper or scaffold mutation.
+- [x] 8.3 Add forced-rebuild accept/reject evidence for both legal table-scoped placements.
+- [x] 8.4 Run the focused and mandatory repository gates and commit with `Fixes: #660`.

--- a/packages/docx-compare/src/baselines/atomizer/documentReconstructor-block-sdt.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/documentReconstructor-block-sdt.test.ts
@@ -203,7 +203,7 @@ describe('direct body block content-control passthrough', () => {
 
 describe('unsupported body block ownership fails closed', () => {
   test.openspec('[SDX-SDT-BLOCK-03] Unsupported block ownership fails before output')(
-    'rejects mutation, insertion, deletion, reorder, movement, nesting, and table or cell placement',
+    'rejects mutation, insertion, deletion, reorder, movement, nesting, and tables inside body controls',
     async ({ given, then }: AllureBddContext) => {
       const first = paragraph('First', '00000021');
       const second = paragraph('Second', '00000022');
@@ -214,8 +214,6 @@ describe('unsupported body block ownership fails closed', () => {
         '<w:tbl><w:tblPr/><w:tblGrid><w:gridCol w:w="1000"/></w:tblGrid>' +
         '<w:tr><w:tc><w:tcPr/><w:p><w:r><w:t>Cell</w:t></w:r></w:p></w:tc></w:tr></w:tbl>',
       );
-      const cellControl = '<w:tbl><w:tblPr/><w:tblGrid><w:gridCol w:w="1000"/></w:tblGrid>' +
-        `<w:tr><w:tc><w:tcPr/>${blockSdt(paragraph('Cell control', '00000026'))}</w:tc></w:tr></w:tbl>`;
       const cases: Array<[string, string, string]> = [
         ['mutation', stable + outside, blockSdt(paragraph('Changed', '00000021') + second) + outside],
         ['insertion', stable + outside, blockSdt(first + paragraph('Inserted', '00000027') + second) + outside],
@@ -224,7 +222,6 @@ describe('unsupported body block ownership fails closed', () => {
         ['movement', stable + outside, outside + stable],
         ['nesting', nested + outside, nested + outside],
         ['table content', tableBlock + outside, tableBlock + outside],
-        ['cell placement', cellControl + outside, cellControl + outside],
       ];
 
       await given('block shapes outside the bounded immutable direct-body contract', () => {});

--- a/packages/docx-compare/src/baselines/atomizer/documentReconstructor-table-sdt.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/documentReconstructor-table-sdt.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Forced-rebuild evidence for table-scoped structured document tags.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.5.2.29
+ * @conformance ECMA-376 edition 5, Part 1 § 17.5.2.32
+ * @conformance ECMA-376 edition 5, Part 1 § 17.5.2.33
+ * @conformance ECMA-376 edition 5, Part 1 § 17.5.2.34
+ * @conformance ECMA-376 edition 5, Part 1 § 17.5.2.38
+ * @see https://github.com/UseJunior/safe-docx/issues/660
+ */
+
+import { describe, expect } from 'vitest';
+import { DocxArchive, OOXML, parseXml } from '@usejunior/docx-core';
+import { buildDocxFromBodyXml } from '../../testing/ooxml-fixtures.js';
+import { testAllure } from '../../testing/allure-test.js';
+import { compareDocumentsAtomizer } from './pipeline.js';
+import {
+  acceptAllChanges,
+  extractTextWithParagraphs,
+  rejectAllChanges,
+} from './trackChangesAcceptorAst.js';
+
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({
+    feature: 'Document Reconstructor Table SDT',
+    story: 'Table-scoped content controls remain editable in rebuild',
+    severity: 'critical',
+  })
+  .conformance(
+    { spec: 'ECMA-376', edition: 5, part: 1, section: '17.5.2.29' },
+    { spec: 'ECMA-376', edition: 5, part: 1, section: '17.5.2.32' },
+    { spec: 'ECMA-376', edition: 5, part: 1, section: '17.5.2.33' },
+    { spec: 'ECMA-376', edition: 5, part: 1, section: '17.5.2.34' },
+    { spec: 'ECMA-376', edition: 5, part: 1, section: '17.5.2.38' },
+  );
+
+function paragraph(text: string): string {
+  return `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
+}
+
+function cell(content: string): string {
+  return '<w:tc><w:tcPr><w:tcW w:w="4000" w:type="dxa"/></w:tcPr>' + content + '</w:tc>';
+}
+
+function control(id: string, alias: string, content: string): string {
+  return '<w:sdt>' +
+    `<w:sdtPr><w:alias w:val="${alias}"/><w:id w:val="${id}"/></w:sdtPr>` +
+    `<w:sdtContent>${content}</w:sdtContent>` +
+    '</w:sdt>';
+}
+
+function table(row: string): string {
+  return '<w:tbl><w:tblPr><w:tblW w:w="0" w:type="auto"/></w:tblPr>' +
+    '<w:tblGrid><w:gridCol w:w="4000"/><w:gridCol w:w="4000"/></w:tblGrid>' +
+    row +
+    '</w:tbl>';
+}
+
+async function rebuild(originalBody: string, revisedBody: string): Promise<string> {
+  const result = await compareDocumentsAtomizer(
+    await buildDocxFromBodyXml(originalBody),
+    await buildDocxFromBodyXml(revisedBody),
+    {
+      author: 'Issue 660 Test',
+      date: new Date('2026-07-26T00:00:00Z'),
+      reconstructionMode: 'rebuild',
+    },
+  );
+  expect(result.reconstructionModeUsed).toBe('rebuild');
+  return (await DocxArchive.load(result.document)).getDocumentXml();
+}
+
+function controls(xml: string): Element[] {
+  return Array.from(parseXml(xml).getElementsByTagNameNS(OOXML.W_NS, 'sdt'));
+}
+
+describe('table-scoped content controls in forced rebuild', () => {
+  test.openspec('[SDX-SDT-TABLE-01] Row and cell controls retain their scaffold while content changes')(
+    'reconstructs tracked text edits inside row- and cell-scoped controls',
+    async () => {
+      const original = paragraph('Lead paragraph.') +
+        table(
+          '<w:tr>' +
+          control('101', 'RowControl', cell(paragraph('Original row text.'))) +
+          cell(control('102', 'CellControl', paragraph('Original cell text.'))) +
+          '</w:tr>',
+        ) +
+        paragraph('Trailing paragraph.');
+      const revised = paragraph('Lead paragraph.') +
+        table(
+          '<w:tr>' +
+          control('101', 'RowControl', cell(paragraph('Revised row text.'))) +
+          cell(control('102', 'CellControl', paragraph('Revised cell text.'))) +
+          '</w:tr>',
+        ) +
+        paragraph('Trailing paragraph.');
+
+      const output = await rebuild(original, revised);
+      const outputControls = controls(output);
+      expect(outputControls).toHaveLength(2);
+      expect(outputControls.map((boundary) => (boundary.parentNode as Element).localName))
+        .toEqual(['tr', 'tc']);
+      expect(outputControls.map((boundary) =>
+        boundary.getElementsByTagNameNS(OOXML.W_NS, 'alias')[0]!.getAttributeNS(OOXML.W_NS, 'val'),
+      )).toEqual(['RowControl', 'CellControl']);
+      expect(outputControls[0]!.getElementsByTagNameNS(OOXML.W_NS, 'ins')).toHaveLength(1);
+      expect(outputControls[0]!.getElementsByTagNameNS(OOXML.W_NS, 'del')).toHaveLength(1);
+      expect(outputControls[1]!.getElementsByTagNameNS(OOXML.W_NS, 'ins')).toHaveLength(1);
+      expect(outputControls[1]!.getElementsByTagNameNS(OOXML.W_NS, 'del')).toHaveLength(1);
+
+      const accepted = extractTextWithParagraphs(acceptAllChanges(output));
+      const rejected = extractTextWithParagraphs(rejectAllChanges(output));
+      expect(accepted).toContain('Revised row text.');
+      expect(accepted).toContain('Revised cell text.');
+      expect(accepted).not.toContain('Original row text.');
+      expect(rejected).toContain('Original row text.');
+      expect(rejected).toContain('Original cell text.');
+      expect(rejected).not.toContain('Revised row text.');
+    },
+  );
+
+  test.openspec('[SDX-SDT-TABLE-02] Table control scaffold mutation fails before rebuild')(
+    'rejects a changed table-scoped control wrapper instead of preserving stale metadata',
+    async () => {
+      const original = table(
+        '<w:tr>' +
+        control('201', 'StableControl', cell(paragraph('Original text.'))) +
+        cell(paragraph('Static cell.')) +
+        '</w:tr>',
+      );
+      const revised = table(
+        '<w:tr>' +
+        control('201', 'ChangedControl', cell(paragraph('Revised text.'))) +
+        cell(paragraph('Static cell.')) +
+        '</w:tr>',
+      );
+
+      await expect(rebuild(original, revised))
+        .rejects.toThrow(/Opaque passthrough: boundary 0 changed paragraph ownership, moved, or mutated/);
+    },
+  );
+});

--- a/packages/docx-compare/src/baselines/atomizer/documentReconstructor-table-sdt.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/documentReconstructor-table-sdt.test.ts
@@ -20,10 +20,12 @@ import {
   rejectAllChanges,
 } from './trackChangesAcceptorAst.js';
 
+const TEST_FEATURE = 'Document Reconstructor Table SDT';
+
 const test = testAllure
   .epic('Document Comparison')
   .withLabels({
-    feature: 'Document Reconstructor Table SDT',
+    feature: TEST_FEATURE,
     story: 'Table-scoped content controls remain editable in rebuild',
     severity: 'critical',
   })

--- a/packages/docx-compare/src/baselines/atomizer/documentReconstructor.ts
+++ b/packages/docx-compare/src/baselines/atomizer/documentReconstructor.ts
@@ -707,7 +707,11 @@ function buildParagraphXml(
 ): string {
   const revisionCtx = createRevisionContext({ author, date: dateStr, idState: revState });
   const hasOpaqueAtoms = group.runGroups.some((runGroup) =>
-    runGroup.atoms.some((atom) => atom.opaquePassthrough !== undefined),
+    runGroup.atoms.some((atom) =>
+      atom.opaquePassthrough !== undefined &&
+      atom.opaquePassthrough.placementKind !== 'row-block' &&
+      atom.opaquePassthrough.placementKind !== 'cell-block'
+    ),
   );
   if (
     hasOpaqueAtoms &&

--- a/packages/docx-compare/src/baselines/atomizer/hierarchicalLcs.ts
+++ b/packages/docx-compare/src/baselines/atomizer/hierarchicalLcs.ts
@@ -438,7 +438,8 @@ function createOpaqueGroupIdentityResolver(instrumentation?: GroupLcsInstrumenta
     const identity = descriptors
       .map((descriptor) =>
         `${descriptor.placementKind}\u0000${descriptor.containerIdentity}\u0000${descriptor.paragraphOrdinal}\u0000` +
-        `${descriptor.bodyChildOrdinal ?? ''}\u0000${descriptor.ownedParagraphCount ?? ''}\u0000` +
+        `${descriptor.bodyChildOrdinal ?? ''}\u0000${descriptor.containerChildOrdinal ?? ''}\u0000` +
+        `${descriptor.ownedParagraphCount ?? ''}\u0000` +
         `${descriptor.inlineRangeOrdinal ?? ''}\u0000` +
         `${relativeByDescriptor?.get(descriptor) ?? ''}\u0000` +
         `${descriptor.documentOrdinal}\u0000${descriptor.semanticFingerprint}\u0000` +

--- a/packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts
+++ b/packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts
@@ -319,6 +319,54 @@ function semanticFingerprint(
     .digest('hex');
 }
 
+function scaffoldNode(node: Node): string {
+  if (
+    node.nodeType === 1 &&
+    (node as Element).namespaceURI === OOXML.W_NS &&
+    (node as Element).localName === 'p'
+  ) {
+    return 'P';
+  }
+  if (node.nodeType === 1) {
+    const element = node as Element;
+    const attributes: string[] = [];
+    for (let i = 0; i < element.attributes.length; i++) {
+      const attribute = element.attributes.item(i)!;
+      if (isXmlnsAttribute(attribute)) continue;
+      attributes.push(
+        `{${attribute.namespaceURI ?? ''}}${attribute.localName ?? attribute.name}=${JSON.stringify(attribute.value)}`,
+      );
+    }
+    attributes.sort();
+    return `E{${element.namespaceURI ?? ''}}${element.localName}[${attributes.join(',')}](` +
+      Array.from(element.childNodes).map(scaffoldNode).join('') + ')';
+  }
+  if (node.nodeType === 3 || node.nodeType === 4) {
+    return (node.nodeValue ?? '').trim() ? `T${JSON.stringify(node.nodeValue)}` : '';
+  }
+  if (node.nodeType === 8) return `C${JSON.stringify(node.nodeValue ?? '')}`;
+  return '';
+}
+
+function scaffoldFingerprint(
+  element: Element,
+  bindings: Readonly<Record<string, string>>,
+  mceDeclarations: Readonly<Record<string, string>>,
+): string {
+  const namespaceIdentity = Object.entries(bindings)
+    .filter(([prefix]) => prefix !== 'xml')
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([prefix, uri]) => `${prefix}=${uri}`)
+    .join('\u0000');
+  const mceIdentity = Object.entries(mceDeclarations)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([name, value]) => `${name}=${value}`)
+    .join('\u0000');
+  return createHash('sha256')
+    .update(`${scaffoldNode(element)}\u0001${namespaceIdentity}\u0001${mceIdentity}`, 'utf8')
+    .digest('hex');
+}
+
 function nearestInlineBoundary(atom: ComparisonUnitAtom): Element | null {
   let paragraphIndex = -1;
   let boundaryIndex = -1;
@@ -346,6 +394,22 @@ function nearestBodyBlockBoundary(atom: ComparisonUnitAtom): Element | null {
       (parent as Element).localName === 'body'
       ? ancestor
       : null;
+  }
+  return null;
+}
+
+function nearestTableScopedBoundary(atom: ComparisonUnitAtom): Element | null {
+  for (let i = atom.ancestorElements.length - 1; i >= 0; i--) {
+    const ancestor = atom.ancestorElements[i]!;
+    if (ancestor.namespaceURI !== OOXML.W_NS || ancestor.localName !== 'sdt') continue;
+    const parent = ancestor.parentNode;
+    if (
+      parent?.nodeType === 1 &&
+      (parent as Element).namespaceURI === OOXML.W_NS &&
+      ((parent as Element).localName === 'tr' || (parent as Element).localName === 'tc')
+    ) {
+      return ancestor;
+    }
   }
   return null;
 }
@@ -509,6 +573,41 @@ function validateBlockSdtKnownStructure(boundary: Element): Element[] {
   return paragraphs;
 }
 
+function validateTableSdtKnownStructure(boundary: Element, parentName: 'tr' | 'tc'): Element[] {
+  const directChildren = Array.from(boundary.childNodes)
+    .filter((child): child is Element => child.nodeType === 1);
+  const names = directChildren.map((child) =>
+    child.namespaceURI === OOXML.W_NS ? child.localName : `{${child.namespaceURI}}${child.localName}`,
+  );
+  const expected = names[1] === 'sdtEndPr'
+    ? ['sdtPr', 'sdtEndPr', 'sdtContent']
+    : ['sdtPr', 'sdtContent'];
+  if (names.length !== expected.length || names.some((name, index) => name !== expected[index])) {
+    throw new OpaquePassthroughError(
+      'table-scoped w:sdt must contain ordered w:sdtPr, optional w:sdtEndPr, and w:sdtContent',
+    );
+  }
+  const content = directChildren[directChildren.length - 1]!;
+  const contentChildren = Array.from(content.childNodes)
+    .filter((child): child is Element => child.nodeType === 1);
+  const allowed = parentName === 'tr' ? new Set(['tc']) : new Set(['p', 'tbl']);
+  if (
+    contentChildren.length === 0 ||
+    contentChildren.some((child) => child.namespaceURI !== OOXML.W_NS || !allowed.has(child.localName))
+  ) {
+    throw new OpaquePassthroughError(
+      parentName === 'tr'
+        ? 'row-scoped w:sdtContent must directly contain one or more w:tc elements'
+        : 'cell-scoped w:sdtContent must directly contain one or more w:p or w:tbl elements',
+    );
+  }
+  const paragraphs = Array.from(content.getElementsByTagNameNS(OOXML.W_NS, 'p'));
+  if (paragraphs.length === 0) {
+    throw new OpaquePassthroughError('table-scoped w:sdt has no controlled paragraphs');
+  }
+  return paragraphs;
+}
+
 /** Validate supported SDT namespace scope before atomization clones leaf nodes. */
 export function validateSdtNamespaceOwnership(root: Element): void {
   for (const boundary of Array.from(root.getElementsByTagNameNS(OOXML.W_NS, 'sdt'))) {
@@ -518,8 +617,15 @@ export function validateSdtNamespaceOwnership(root: Element): void {
     const isBodyBlock = parent?.nodeType === 1 &&
       (parent as Element).namespaceURI === OOXML.W_NS &&
       (parent as Element).localName === 'body';
-    if (!isInline && !isBodyBlock) {
-      throw new OpaquePassthroughError('w:sdt placement is outside inline-run and direct body-block support');
+    const tableParent = parent?.nodeType === 1 &&
+        (parent as Element).namespaceURI === OOXML.W_NS &&
+        ((parent as Element).localName === 'tr' || (parent as Element).localName === 'tc')
+      ? (parent as Element).localName as 'tr' | 'tc'
+      : undefined;
+    if (!isInline && !isBodyBlock && !tableParent) {
+      throw new OpaquePassthroughError(
+        'w:sdt placement is outside inline-run, body-block, row-block, and cell-block support',
+      );
     }
     const bindings = effectiveNamespaces(boundary);
     if (bindings.w !== OOXML.W_NS) {
@@ -529,7 +635,8 @@ export function validateSdtNamespaceOwnership(root: Element): void {
       throw new OpaquePassthroughError('nested w:sdt boundaries are outside the bounded passthrough contract');
     }
     if (isInline) validateInlineSdtKnownStructure(boundary);
-    else validateBlockSdtKnownStructure(boundary);
+    else if (isBodyBlock) validateBlockSdtKnownStructure(boundary);
+    else validateTableSdtKnownStructure(boundary, tableParent!);
     validateNamespaceOwnership(boundary, bindings);
   }
 }
@@ -563,6 +670,8 @@ function materializeNamespaces(
  * property or extension vocabulary.
  *
  * @conformance ECMA-376 edition 5, Part 1 § 17.5.2.29
+ * @conformance ECMA-376 edition 5, Part 1 § 17.5.2.32
+ * @conformance ECMA-376 edition 5, Part 1 § 17.5.2.33
  * @conformance ECMA-376 edition 5, Part 1 § 17.5.2.34
  * @conformance ECMA-376 edition 5, Part 1 § 17.5.2.31
  * @conformance ECMA-376 edition 5, Part 1 § 17.5.2.36
@@ -586,15 +695,26 @@ export function captureSdtPassthrough(root: Element, atoms: ComparisonUnitAtom[]
     const isBodyBlock = parent?.nodeType === 1 &&
       (parent as Element).namespaceURI === OOXML.W_NS &&
       (parent as Element).localName === 'body';
-    if (!isInline && !isBodyBlock) {
-      throw new OpaquePassthroughError('w:sdt placement is outside inline-run and direct body-block support');
+    const tableParent = parent?.nodeType === 1 &&
+        (parent as Element).namespaceURI === OOXML.W_NS &&
+        ((parent as Element).localName === 'tr' || (parent as Element).localName === 'tc')
+      ? (parent as Element).localName as 'tr' | 'tc'
+      : undefined;
+    if (!isInline && !isBodyBlock && !tableParent) {
+      throw new OpaquePassthroughError(
+        'w:sdt placement is outside inline-run, body-block, row-block, and cell-block support',
+      );
     }
     const bindings = effectiveNamespaces(boundary);
     const mceDeclarations = effectiveMceDeclarations(boundary);
     if (bindings.w !== OOXML.W_NS) {
       throw new OpaquePassthroughError("inline w:sdt has conflicting 'w' namespace ownership");
     }
-    const blockParagraphs = isBodyBlock ? validateBlockSdtKnownStructure(boundary) : undefined;
+    const blockParagraphs = isBodyBlock
+      ? validateBlockSdtKnownStructure(boundary)
+      : tableParent
+        ? validateTableSdtKnownStructure(boundary, tableParent)
+        : undefined;
     if (isInline) validateInlineSdtKnownStructure(boundary);
     validateNamespaceOwnership(boundary, bindings);
     validateIgnorableTokens(mceDeclarations.values, bindings);
@@ -611,15 +731,24 @@ export function captureSdtPassthrough(root: Element, atoms: ComparisonUnitAtom[]
       }
     }
     descriptorByElement.set(boundary, {
-      placementKind: isInline ? 'inline-run' : 'body-block',
+      placementKind: isInline
+        ? 'inline-run'
+        : isBodyBlock
+          ? 'body-block'
+          : tableParent === 'tr'
+            ? 'row-block'
+            : 'cell-block',
       namespaceUri: OOXML.W_NS,
       localName: 'sdt',
       documentOrdinal: nextOrdinal++,
       paragraphOrdinal,
       containerIdentity: structuralContainerIdentity(ownedParagraph),
       bodyChildOrdinal: isBodyBlock ? elementChildOrdinal(boundary) : undefined,
+      containerChildOrdinal: tableParent ? elementChildOrdinal(boundary) : undefined,
       ownedParagraphCount: blockParagraphs?.length,
-      semanticFingerprint: semanticFingerprint(boundary, bindings, mceDeclarations.values),
+      semanticFingerprint: tableParent
+        ? scaffoldFingerprint(boundary, bindings, mceDeclarations.values)
+        : semanticFingerprint(boundary, bindings, mceDeclarations.values),
       sourceElement: materializeNamespaces(
         boundary,
         bindings,
@@ -633,7 +762,9 @@ export function captureSdtPassthrough(root: Element, atoms: ComparisonUnitAtom[]
 
   const ownedCounts = new Map<OpaquePassthroughNode, number>();
   for (const atom of atoms) {
-    const boundary = nearestInlineBoundary(atom) ?? nearestBodyBlockBoundary(atom);
+    const boundary = nearestInlineBoundary(atom) ??
+      nearestBodyBlockBoundary(atom) ??
+      nearestTableScopedBoundary(atom);
     if (!boundary) continue;
     const descriptor = descriptorByElement.get(boundary);
     if (!descriptor) {
@@ -1062,6 +1193,10 @@ export async function bindOpaquePassthroughCounterparts(
     descriptor.placementKind === 'body-block'
       ? `block\u0000${descriptor.containerIdentity}\u0000${descriptor.bodyChildOrdinal}\u0000` +
         `${descriptor.paragraphOrdinal}\u0000${descriptor.ownedParagraphCount}`
+      : descriptor.placementKind === 'row-block' || descriptor.placementKind === 'cell-block'
+        ? `${descriptor.placementKind}\u0000${descriptor.containerIdentity}\u0000` +
+          `${descriptor.containerChildOrdinal}\u0000${descriptor.paragraphOrdinal}\u0000` +
+          `${descriptor.ownedParagraphCount}`
       : descriptor.placementKind === 'inline-range'
         ? `field\u0000${descriptor.containerIdentity}\u0000${descriptor.paragraphOrdinal}\u0000` +
           `${descriptor.inlineRangeOrdinal}\u0000${descriptor.localName}`
@@ -1070,13 +1205,21 @@ export async function bindOpaquePassthroughCounterparts(
   original.sort((left, right) => placementKey(left).localeCompare(placementKey(right)));
   revised.sort((left, right) => placementKey(left).localeCompare(placementKey(right)));
   await Promise.all([
-    ...original.filter((descriptor) => descriptor.placementKind === 'body-block').map(async (descriptor) => {
+    ...original.filter((descriptor) =>
+      descriptor.placementKind === 'body-block' ||
+      descriptor.placementKind === 'row-block' ||
+      descriptor.placementKind === 'cell-block'
+    ).map(async (descriptor) => {
       descriptor.relationshipClosureFingerprint = await originalRelationships.fingerprintBoundary(
         descriptor.sourceElement,
         ownerPart,
       );
     }),
-    ...revised.filter((descriptor) => descriptor.placementKind === 'body-block').map(async (descriptor) => {
+    ...revised.filter((descriptor) =>
+      descriptor.placementKind === 'body-block' ||
+      descriptor.placementKind === 'row-block' ||
+      descriptor.placementKind === 'cell-block'
+    ).map(async (descriptor) => {
       descriptor.relationshipClosureFingerprint = await revisedRelationships.fingerprintBoundary(
         descriptor.sourceElement,
         ownerPart,
@@ -1094,6 +1237,7 @@ export async function bindOpaquePassthroughCounterparts(
       before.namespaceUri !== after.namespaceUri ||
       before.localName !== after.localName ||
       before.bodyChildOrdinal !== after.bodyChildOrdinal ||
+      before.containerChildOrdinal !== after.containerChildOrdinal ||
       before.inlineRangeOrdinal !== after.inlineRangeOrdinal ||
       before.ownedParagraphCount !== after.ownedParagraphCount ||
       before.semanticFingerprint !== after.semanticFingerprint ||
@@ -1114,6 +1258,9 @@ export function validateOpaquePassthroughCorrelation(atoms: ComparisonUnitAtom[]
   for (const atom of atoms) {
     let descriptor = atom.opaquePassthrough;
     if (!descriptor) continue;
+    if (descriptor.placementKind === 'row-block' || descriptor.placementKind === 'cell-block') {
+      continue;
+    }
     if (atom.correlationStatus !== CorrelationStatus.Equal) {
       throw new OpaquePassthroughError(
         `boundary ${descriptor.documentOrdinal} lost equal correlation (${atom.correlationStatus})`,

--- a/packages/docx-core/src/core-types.ts
+++ b/packages/docx-core/src/core-types.ts
@@ -114,8 +114,8 @@ export interface FormatChangeInfo {
  * assigning `emissionElements` from the original side.
  */
 export interface OpaquePassthroughNode {
-  /** Determines whether paragraph-run emission or the body scaffold owns output. */
-  placementKind: 'inline-run' | 'inline-range' | 'body-block';
+  /** Determines whether paragraph-run emission or a structural scaffold owns output. */
+  placementKind: 'inline-run' | 'inline-range' | 'body-block' | 'row-block' | 'cell-block';
   namespaceUri: string;
   localName: string;
   documentOrdinal: number;
@@ -125,6 +125,8 @@ export interface OpaquePassthroughNode {
   containerIdentity: string;
   /** Direct body-child position for a scaffold-owned block boundary. */
   bodyChildOrdinal?: number;
+  /** Direct parent-child position for a table-scoped scaffold boundary. */
+  containerChildOrdinal?: number;
   /** Inclusive direct paragraph-child range for an ordered inline payload. */
   inlineChildStartOrdinal?: number;
   inlineChildEndOrdinal?: number;

--- a/spec-compliance/CONFORMANCE.md
+++ b/spec-compliance/CONFORMANCE.md
@@ -22,11 +22,13 @@ Allure labels via `testAllure.conformance({…})`; source code carries
 | `ECMA-PART1-17-13-8-1` | Proofing error anchors | 5 | 1 | 17.13.8.1 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:proofErr` | — |
 | `ECMA-PART1-17-11-14` | w:footnoteReference identifier vs display number | 5 | 1 | 17.11.14 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:footnoteReference` | packages/docx-core/src/footnotes.ts; packages/docx-core/src/footnotes.test.ts |
 | `ECMA-PART1-17-16-22` | w:hyperlink container preservation under tracked changes | 5 | 1 | 17.16.22 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:hyperlink` | — |
-| `ECMA-PART1-17-5-2-29` | w:sdt block-level structured document tag | 5 | 1 | 17.5.2.29 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#type:CT_SdtBlock` | packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-block-sdt.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-inline-sdt.test.ts |
+| `ECMA-PART1-17-5-2-29` | w:sdt block-level structured document tag | 5 | 1 | 17.5.2.29 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#type:CT_SdtBlock` | packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-block-sdt.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-inline-sdt.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-table-sdt.test.ts |
 | `ECMA-PART1-17-5-2-31` | w:sdt inline-level structured document tag | 5 | 1 | 17.5.2.31 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#type:CT_SdtRun` | packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-inline-sdt.test.ts |
-| `ECMA-PART1-17-5-2-34` | w:sdtContent block-level structured document tag content | 5 | 1 | 17.5.2.34 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#type:CT_SdtContentBlock` | packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-block-sdt.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-inline-sdt.test.ts |
+| `ECMA-PART1-17-5-2-32` | w:sdt cell-level structured document tag | 5 | 1 | 17.5.2.32 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#type:CT_SdtCell` | packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-table-sdt.test.ts |
+| `ECMA-PART1-17-5-2-33` | w:sdtContent cell-level structured document tag content | 5 | 1 | 17.5.2.33 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#type:CT_SdtContentCell` | packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-table-sdt.test.ts |
+| `ECMA-PART1-17-5-2-34` | w:sdtContent block-level structured document tag content | 5 | 1 | 17.5.2.34 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#type:CT_SdtContentBlock` | packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-block-sdt.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-inline-sdt.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-table-sdt.test.ts |
 | `ECMA-PART1-17-5-2-36` | w:sdtContent inline-level structured document tag content | 5 | 1 | 17.5.2.36 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#type:CT_SdtContentRun` | packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-inline-sdt.test.ts |
-| `ECMA-PART1-17-5-2-38` | w:sdtPr structured document tag properties | 5 | 1 | 17.5.2.38 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#type:CT_SdtPr` | packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-inline-sdt.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-block-sdt.test.ts |
+| `ECMA-PART1-17-5-2-38` | w:sdtPr structured document tag properties | 5 | 1 | 17.5.2.38 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#type:CT_SdtPr` | packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-inline-sdt.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-block-sdt.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-table-sdt.test.ts |
 | `ECMA-PART1-17-6-17` | w:sectPr document-final section properties | 5 | 1 | 17.6.17 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:sectPr` | — |
 | `ECMA-PART1-17-6-13` | w:pgSz page size emission | 5 | 1 | 17.6.13 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:pgSz` | — |
 | `ECMA-PART1-17-6-11` | w:pgMar page margin emission | 5 | 1 | 17.6.11 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:pgMar` | — |
@@ -265,13 +267,14 @@ lives in `packages/docx-core/src/atomizer.ts`
 - **Part / Section:** Part 1 § 17.5.2.29
 - **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
 - **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#type:CT_SdtBlock`
-- **Verified by:** packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-block-sdt.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-inline-sdt.test.ts
+- **Verified by:** packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-block-sdt.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-inline-sdt.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-table-sdt.test.ts
 
 A block `w:sdt` surrounds one or more block-level structures and orders its
 properties, optional end properties, and content under the CT_SdtBlock model.
 safe-docx preserves an unchanged direct `w:body/w:sdt` as one scaffold-owned
-boundary during forced rebuild. Exact subtree preservation is a bounded
-metamorphic invariant rather than a requirement imposed by ECMA-376.
+boundary during forced rebuild and reconstructs controlled paragraphs for a
+block control directly inside `w:tc`. Exact subtree/wrapper preservation is a
+bounded metamorphic invariant rather than a requirement imposed by ECMA-376.
 
 ### ECMA-PART1-17-5-2-31 — w:sdt inline-level structured document tag
 
@@ -286,18 +289,44 @@ are its properties, optional end properties, and content. The issue #582 pilot
 preserves an unchanged inline SDT as one opaque semantic boundary during rebuild;
 it does not author or edit controls and makes no claim about row or cell SDTs.
 
+### ECMA-PART1-17-5-2-32 — w:sdt cell-level structured document tag
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.5.2.32
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#type:CT_SdtCell`
+- **Verified by:** packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-table-sdt.test.ts
+
+A cell-level `w:sdt` surrounds one or more `w:tc` elements within a table row
+and orders its properties, optional end properties, and content under the
+CT_SdtCell model. safe-docx correlates the wrapper at its direct `w:tr` child
+position while rebuilding controlled paragraphs inside the cells.
+
+### ECMA-PART1-17-5-2-33 — w:sdtContent cell-level structured document tag content
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.5.2.33
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#type:CT_SdtContentCell`
+- **Verified by:** packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-table-sdt.test.ts
+
+Cell-level `w:sdtContent` contains controlled table cells. The bounded rebuild
+path recognizes one or more direct `w:tc` children and fails closed on wrapper
+or cell-scaffold mutation.
+
 ### ECMA-PART1-17-5-2-34 — w:sdtContent block-level structured document tag content
 
 - **Edition:** ECMA-376 5
 - **Part / Section:** Part 1 § 17.5.2.34
 - **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
 - **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#type:CT_SdtContentBlock`
-- **Verified by:** packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-block-sdt.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-inline-sdt.test.ts
+- **Verified by:** packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-block-sdt.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-inline-sdt.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-table-sdt.test.ts
 
 Block-level `w:sdtContent` contains the controlled block structures. The bounded
-rebuild path recognizes only a contiguous sequence of direct controlled
-paragraphs under a direct body-level control; tables and nested controls remain
-outside the supported placement.
+rebuild path recognizes a contiguous sequence of direct controlled paragraphs
+under a direct body-level control, or direct paragraph/table children when the
+block control is inside `w:tc`; nested controls remain outside the supported
+placement.
 
 ### ECMA-PART1-17-5-2-36 — w:sdtContent inline-level structured document tag content
 
@@ -316,7 +345,7 @@ controlled text when that subtree is unchanged between comparison inputs.
 - **Part / Section:** Part 1 § 17.5.2.38
 - **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
 - **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#type:CT_SdtPr`
-- **Verified by:** packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-inline-sdt.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-block-sdt.test.ts
+- **Verified by:** packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-inline-sdt.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-block-sdt.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-table-sdt.test.ts
 
 The pilot retains known and ignorable-extension children under `w:sdtPr` in
 their source order. Retention of unknown extension payload is a metamorphic

--- a/spec-compliance/registry/ecma-376.md
+++ b/spec-compliance/registry/ecma-376.md
@@ -190,14 +190,15 @@ part: 1
 section: "17.5.2.29"
 url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
 schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#type:CT_SdtBlock
-verifiedBy: packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-block-sdt.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-inline-sdt.test.ts
+verifiedBy: packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-block-sdt.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-inline-sdt.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-table-sdt.test.ts
 ```
 
 A block `w:sdt` surrounds one or more block-level structures and orders its
 properties, optional end properties, and content under the CT_SdtBlock model.
 safe-docx preserves an unchanged direct `w:body/w:sdt` as one scaffold-owned
-boundary during forced rebuild. Exact subtree preservation is a bounded
-metamorphic invariant rather than a requirement imposed by ECMA-376.
+boundary during forced rebuild and reconstructs controlled paragraphs for a
+block control directly inside `w:tc`. Exact subtree/wrapper preservation is a
+bounded metamorphic invariant rather than a requirement imposed by ECMA-376.
 
 ## [ECMA-PART1-17-5-2-31] w:sdt inline-level structured document tag
 
@@ -215,6 +216,37 @@ are its properties, optional end properties, and content. The issue #582 pilot
 preserves an unchanged inline SDT as one opaque semantic boundary during rebuild;
 it does not author or edit controls and makes no claim about row or cell SDTs.
 
+## [ECMA-PART1-17-5-2-32] w:sdt cell-level structured document tag
+
+```yaml
+edition: 5
+part: 1
+section: "17.5.2.32"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#type:CT_SdtCell
+verifiedBy: packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-table-sdt.test.ts
+```
+
+A cell-level `w:sdt` surrounds one or more `w:tc` elements within a table row
+and orders its properties, optional end properties, and content under the
+CT_SdtCell model. safe-docx correlates the wrapper at its direct `w:tr` child
+position while rebuilding controlled paragraphs inside the cells.
+
+## [ECMA-PART1-17-5-2-33] w:sdtContent cell-level structured document tag content
+
+```yaml
+edition: 5
+part: 1
+section: "17.5.2.33"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#type:CT_SdtContentCell
+verifiedBy: packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-table-sdt.test.ts
+```
+
+Cell-level `w:sdtContent` contains controlled table cells. The bounded rebuild
+path recognizes one or more direct `w:tc` children and fails closed on wrapper
+or cell-scaffold mutation.
+
 ## [ECMA-PART1-17-5-2-34] w:sdtContent block-level structured document tag content
 
 ```yaml
@@ -223,13 +255,14 @@ part: 1
 section: "17.5.2.34"
 url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
 schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#type:CT_SdtContentBlock
-verifiedBy: packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-block-sdt.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-inline-sdt.test.ts
+verifiedBy: packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-block-sdt.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-inline-sdt.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-table-sdt.test.ts
 ```
 
 Block-level `w:sdtContent` contains the controlled block structures. The bounded
-rebuild path recognizes only a contiguous sequence of direct controlled
-paragraphs under a direct body-level control; tables and nested controls remain
-outside the supported placement.
+rebuild path recognizes a contiguous sequence of direct controlled paragraphs
+under a direct body-level control, or direct paragraph/table children when the
+block control is inside `w:tc`; nested controls remain outside the supported
+placement.
 
 ## [ECMA-PART1-17-5-2-36] w:sdtContent inline-level structured document tag content
 
@@ -253,7 +286,7 @@ part: 1
 section: "17.5.2.38"
 url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
 schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#type:CT_SdtPr
-verifiedBy: packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-inline-sdt.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-block-sdt.test.ts
+verifiedBy: packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-inline-sdt.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-block-sdt.test.ts; packages/docx-compare/src/baselines/atomizer/documentReconstructor-table-sdt.test.ts
 ```
 
 The pilot retains known and ignorable-extension children under `w:sdtPr` in


### PR DESCRIPTION
## Summary

- declare the deterministic Allure feature constant required by OpenSpec traceability for the table-SDT regression suite

## Validation

- `npm run check:allure-labels`
- `npm test --workspace=@usejunior/docx-compare -- --run src/baselines/atomizer/documentReconstructor-table-sdt.test.ts`

Follow-up to #662 after its automerge completed before this CI metadata correction was pushed.

Ref #660