### PR TITLE
test(docx-compare): label table SDT regressions

### DIFF
--- a/packages/docx-compare/src/baselines/atomizer/documentReconstructor-table-sdt.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/documentReconstructor-table-sdt.test.ts
@@ -20,10 +20,12 @@ import {
   rejectAllChanges,
 } from './trackChangesAcceptorAst.js';
 
+const TEST_FEATURE = 'Document Reconstructor Table SDT';
+
 const test = testAllure
   .epic('Document Comparison')
   .withLabels({
-    feature: 'Document Reconstructor Table SDT',
+    feature: TEST_FEATURE,
     story: 'Table-scoped content controls remain editable in rebuild',
     severity: 'critical',
   })


### PR DESCRIPTION
## Summary

- declare the deterministic Allure feature constant required by OpenSpec traceability for the table-SDT regression suite

## Validation

- `npm run check:allure-labels`
- `npm test --workspace=@usejunior/docx-compare -- --run src/baselines/atomizer/documentReconstructor-table-sdt.test.ts`

One-file CI metadata follow-up to #662. The feature PR automerged before this correction was pushed.

Ref #660