### PR TITLE
fix(docx-compare): preserve field owners across paragraph deletion

### DIFF
--- a/packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts
@@ -52,6 +52,15 @@ function textRun(text: string): string {
   return `<w:r><w:t>${text}</w:t></w:r>`;
 }
 
+function paragraphWithId(
+  paraId: string,
+  content: string,
+  prefix = 'w14',
+): string {
+  const namespace = prefix === 'w14' ? '' : ` xmlns:${prefix}="${OOXML.W14_NS}"`;
+  return `<w:p${namespace} ${prefix}:paraId="${paraId}">${content}</w:p>`;
+}
+
 function fieldCharType(element: Element): string | null {
   const marker = Array.from(element.getElementsByTagNameNS(OOXML.W_NS, 'fldChar'))[0];
   return marker?.getAttributeNS(OOXML.W_NS, 'fldCharType') ??
@@ -246,6 +255,46 @@ describe('Forced rebuild preserves unchanged supported complex fields', () => {
   );
 
   test
+    .openspec('[SDX-FIELD-REBUILD-01] Outside edit preserves decorated supported fields')(
+      'preserves an unchanged REF field after an earlier paragraph is deleted',
+      async ({
+        given,
+        when,
+        then,
+        and,
+      }: AllureBddContext) => {
+        const field = decoratedComplexField(FIELD_INSTRUCTIONS.REF, 'Section 1', 'Clause_1');
+        const stableFieldParagraph = paragraphWithId('22222222', field, 'word14');
+        const originalBody =
+          paragraphWithId('11111111', textRun('Delete this unrelated paragraph.')) +
+          stableFieldParagraph;
+        const revisedBody = stableFieldParagraph;
+        let output = '';
+
+        await given(
+          'an unchanged REF field whose Word paragraph identity survives an earlier deletion',
+          () => {},
+        );
+        await when('the paragraph deletion is compared through forced rebuild', async () => {
+          output = await outputXml(await compare(originalBody, revisedBody));
+        });
+        await then('the field retains its original ordered topology in its stable owner', async () => {
+          const originalXml = await (await DocxArchive.load(
+            await buildDocxFromBodyXml(originalBody),
+          )).getDocumentXml();
+          expect(canonicalRanges(output)).toEqual(canonicalRanges(originalXml));
+          expect(fieldRanges(output)).toHaveLength(1);
+        });
+        await and('accept and reject projections retain the paragraph deletion', () => {
+          expect(extractTextWithParagraphs(acceptAllChanges(output)))
+            .not.toContain('Delete this unrelated paragraph.');
+          expect(extractTextWithParagraphs(rejectAllChanges(output)))
+            .toContain('Delete this unrelated paragraph.');
+        });
+      },
+    );
+
+  test
     .openspec('[SDX-FIELD-REBUILD-03] Unsafe field ownership fails closed')(
     'rejects changed, moved, nested, spanning, malformed, and shared ranges before reconstruction',
     async ({ given, when, then }: AllureBddContext) => {
@@ -290,8 +339,12 @@ describe('Forced rebuild preserves unchanged supported complex fields', () => {
         },
         {
           name: 'field moved to another paragraph',
-          original: `<w:p>${page}</w:p><w:p>${textRun('plain')}</w:p>`,
-          revised: `<w:p>${textRun('plain')}</w:p><w:p>${page}</w:p>`,
+          original:
+            paragraphWithId('33333333', page) +
+            paragraphWithId('44444444', textRun('plain')),
+          revised:
+            paragraphWithId('33333333', textRun('plain')) +
+            paragraphWithId('44444444', page),
         },
         {
           name: 'nested field',

--- a/packages/docx-compare/src/baselines/atomizer/hierarchicalLcs.ts
+++ b/packages/docx-compare/src/baselines/atomizer/hierarchicalLcs.ts
@@ -436,15 +436,18 @@ function createOpaqueGroupIdentityResolver(instrumentation?: GroupLcsInstrumenta
     }
     descriptors.sort((left, right) => left.documentOrdinal - right.documentOrdinal);
     const identity = descriptors
-      .map((descriptor) =>
-        `${descriptor.placementKind}\u0000${descriptor.containerIdentity}\u0000${descriptor.paragraphOrdinal}\u0000` +
-        `${descriptor.bodyChildOrdinal ?? ''}\u0000${descriptor.containerChildOrdinal ?? ''}\u0000` +
-        `${descriptor.ownedParagraphCount ?? ''}\u0000` +
-        `${descriptor.inlineRangeOrdinal ?? ''}\u0000` +
-        `${relativeByDescriptor?.get(descriptor) ?? ''}\u0000` +
-        `${descriptor.documentOrdinal}\u0000${descriptor.semanticFingerprint}\u0000` +
-        `${descriptor.relationshipClosureFingerprint ?? ''}`,
-      )
+      .map((descriptor) => {
+        const paragraphIdentity = descriptor.placementKind === 'inline-range'
+          ? descriptor.paragraphIdentity ?? descriptor.paragraphOrdinal
+          : descriptor.paragraphOrdinal;
+        return `${descriptor.placementKind}\u0000${descriptor.containerIdentity}\u0000${paragraphIdentity}\u0000` +
+          `${descriptor.bodyChildOrdinal ?? ''}\u0000${descriptor.containerChildOrdinal ?? ''}\u0000` +
+          `${descriptor.ownedParagraphCount ?? ''}\u0000` +
+          `${descriptor.inlineRangeOrdinal ?? ''}\u0000` +
+          `${relativeByDescriptor?.get(descriptor) ?? ''}\u0000` +
+          `${descriptor.documentOrdinal}\u0000${descriptor.semanticFingerprint}\u0000` +
+          `${descriptor.relationshipClosureFingerprint ?? ''}`;
+      })
       .join('\u0001');
     cache.set(group, identity);
     return identity;

--- a/packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts
+++ b/packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts
@@ -3,6 +3,7 @@ import { posix } from 'node:path';
 import type { ComparisonUnitAtom, DocxArchive, OpaquePassthroughNode } from '@usejunior/docx-core';
 import {
   CorrelationStatus,
+  getW14ParaId,
   OOXML,
   normalizeOpcRelationshipTarget,
   parseXml,
@@ -19,16 +20,6 @@ export class OpaquePassthroughError extends Error {
     super(`Opaque passthrough: ${message}`);
     this.name = 'OpaquePassthroughError';
   }
-}
-
-/**
- * Preserve the authoring application's paragraph identity across unrelated
- * insertions and deletions. Absence deliberately retains ordinal fail-closed
- * behavior instead of deriving identity from mutable paragraph text.
- */
-function stableParagraphIdentity(paragraph: Element): string | undefined {
-  const paraId = paragraph.getAttributeNS(OOXML.W14_NS, 'paraId');
-  return paraId ? paraId.toUpperCase() : undefined;
 }
 
 interface PackageRelationship {
@@ -1078,7 +1069,9 @@ export function captureComplexFieldPassthrough(
       localName: `complexField:${fieldKind}`,
       documentOrdinal: nextOrdinal++,
       paragraphOrdinal,
-      paragraphIdentity: stableParagraphIdentity(paragraph),
+      // Preserve Word's stable owner across unrelated paragraph edits. Absence
+      // deliberately retains the ordinal-based fail-closed behavior.
+      paragraphIdentity: getW14ParaId(paragraph) ?? undefined,
       containerIdentity: structuralContainerIdentity(paragraph),
       inlineChildStartOrdinal: startOrdinal,
       inlineChildEndOrdinal: endOrdinal,

--- a/packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts
+++ b/packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts
@@ -21,6 +21,16 @@ export class OpaquePassthroughError extends Error {
   }
 }
 
+/**
+ * Preserve the authoring application's paragraph identity across unrelated
+ * insertions and deletions. Absence deliberately retains ordinal fail-closed
+ * behavior instead of deriving identity from mutable paragraph text.
+ */
+function stableParagraphIdentity(paragraph: Element): string | undefined {
+  const paraId = paragraph.getAttributeNS(OOXML.W14_NS, 'paraId');
+  return paraId ? paraId.toUpperCase() : undefined;
+}
+
 interface PackageRelationship {
   id: string;
   type: string;
@@ -1068,6 +1078,7 @@ export function captureComplexFieldPassthrough(
       localName: `complexField:${fieldKind}`,
       documentOrdinal: nextOrdinal++,
       paragraphOrdinal,
+      paragraphIdentity: stableParagraphIdentity(paragraph),
       containerIdentity: structuralContainerIdentity(paragraph),
       inlineChildStartOrdinal: startOrdinal,
       inlineChildEndOrdinal: endOrdinal,
@@ -1198,7 +1209,8 @@ export async function bindOpaquePassthroughCounterparts(
           `${descriptor.containerChildOrdinal}\u0000${descriptor.paragraphOrdinal}\u0000` +
           `${descriptor.ownedParagraphCount}`
       : descriptor.placementKind === 'inline-range'
-        ? `field\u0000${descriptor.containerIdentity}\u0000${descriptor.paragraphOrdinal}\u0000` +
+        ? `field\u0000${descriptor.containerIdentity}\u0000` +
+          `${descriptor.paragraphIdentity ?? descriptor.paragraphOrdinal}\u0000` +
           `${descriptor.inlineRangeOrdinal}\u0000${descriptor.localName}`
         : `inline\u0000${descriptor.containerIdentity}\u0000${descriptor.paragraphOrdinal}\u0000` +
           `${descriptor.documentOrdinal}\u0000${descriptor.localName}`;
@@ -1229,10 +1241,15 @@ export async function bindOpaquePassthroughCounterparts(
   for (let i = 0; i < original.length; i++) {
     const before = original[i]!;
     const after = revised[i]!;
+    const sameParagraphOwner = before.placementKind === 'inline-range' &&
+        after.placementKind === 'inline-range' &&
+        (before.paragraphIdentity !== undefined || after.paragraphIdentity !== undefined)
+      ? before.paragraphIdentity === after.paragraphIdentity
+      : before.paragraphOrdinal === after.paragraphOrdinal;
     if (
       placementKey(before) !== placementKey(after) ||
       before.placementKind !== after.placementKind ||
-      before.paragraphOrdinal !== after.paragraphOrdinal ||
+      !sameParagraphOwner ||
       before.containerIdentity !== after.containerIdentity ||
       before.namespaceUri !== after.namespaceUri ||
       before.localName !== after.localName ||

--- a/packages/docx-core/src/core-types.ts
+++ b/packages/docx-core/src/core-types.ts
@@ -119,8 +119,10 @@ export interface OpaquePassthroughNode {
   namespaceUri: string;
   localName: string;
   documentOrdinal: number;
-  /** Source-order paragraph identity; movement is outside the bounded contract and fails closed. */
+  /** Source-order paragraph fallback used when no stable Word identity is available. */
   paragraphOrdinal: number;
+  /** Stable Word paragraph identity when the source paragraph carries w14:paraId. */
+  paragraphIdentity?: string;
   /** Structural parent path (body or table/cell position) owning the paragraph. */
   containerIdentity: string;
   /** Direct body-child position for a scaffold-owned block boundary. */

--- a/packages/docx-core/src/primitives/bookmarks.ts
+++ b/packages/docx-core/src/primitives/bookmarks.ts
@@ -29,7 +29,7 @@ function ancestorSignature(p: Element): string {
   return parts.join('/');
 }
 
-function getW14ParaId(p: Element): string | null {
+export function getW14ParaId(p: Element): string | null {
   const namespaced = p.getAttributeNS(W14_NS, 'paraId');
   if (namespaced) return namespaced.toLowerCase();
 

--- a/packages/docx-core/src/primitives/index.ts
+++ b/packages/docx-core/src/primitives/index.ts
@@ -38,6 +38,7 @@ export * from './content_fingerprint.js';
 export * from './locator.js';
 export { buildTableMetaMap, deriveTableContext, type TableMeta } from './table_context.js';
 export {
+  getW14ParaId,
   getParagraphBookmarkId,
   getParagraphBookmarkNames,
   findParagraphByBookmarkId,


### PR DESCRIPTION
## Summary

- capture namespace-aware `w14:paraId` as the stable owner identity for supported opaque complex fields
- use stable paragraph identity during counterpart binding and hierarchical opaque-group matching
- retain ordinal-based fail-closed behavior when stable IDs are absent, and reject fields moved between stable owners
- add a forced-rebuild regression for deleting an unrelated earlier paragraph before a decorated REF field, including an alternate namespace prefix

Fixes #646

## Validation

- focused complex-field and hierarchical opaque-identity tests: 17 passed
- `@usejunior/docx-compare` suite: 675 tests passed; two pre-existing Node 26 timing/process-spawn checks fail locally, while supported Node 20/22 CI is authoritative
- exact NVCA Voting Agreement reproduction: forced rebuild succeeds; accept equals revised and reject equals original
- real-corpus paragraph-deletion matrix: certificate of incorporation, indemnification agreement, ROFR/co-sale, stock purchase agreement, and voting agreement pass
- `npm run build`
- `npm run lint:workspaces`
- `npm run check:spec-coverage`
- `npm run check:conformance-citations`
- `npm run check:conformance-doc`

## Local environment notes

The repository-wide test command reaches all workspaces but is not fully green under local Node 26/sandbox constraints: existing timeout-sensitive tests exceed their fixed limits, `tsx` IPC sockets are denied by the sandbox, and LibreOffice aborts under the sandbox. No failing test touches this patch. GitHub's supported Node 20/22 matrix is the merge gate.