### PR TITLE
fix(docx-core): support cached field result edits

### DIFF
--- a/packages/docx-core/src/primitives/text.test.ts
+++ b/packages/docx-core/src/primitives/text.test.ts
@@ -7,6 +7,11 @@ import { SafeDocxError } from './errors.js';
 import { createRevisionContext, createRevisionIdState } from './track-changes-emitter.js';
 import { revisionEvidence, revisionEvidenceCases } from '../testing/revision-evidence.js';
 import {
+  fldChar,
+  instrText,
+  resultText,
+} from '../testing/ooxml-fixtures.js';
+import {
   getParagraphRuns,
   getParagraphText,
   splitRunAtVisibleOffset,
@@ -159,6 +164,37 @@ describe('getParagraphRuns', () => {
       expect(runs).toHaveLength(1);
       expect(runs[0]!.text).toBe('InlineResult');
       expect(runs[0]!.isFieldResult).toBe(true);
+    });
+  });
+
+  test('restores the enclosing result identity after a nested field ends', async ({ given, then }: AllureBddContext) => {
+    testAllure.conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.16.18' });
+    let doc: Document;
+
+    await given('an outer result containing a complete nested field', () => {
+      doc = makeDoc(
+        `<w:p>` +
+        fldChar('begin') +
+        instrText(' IF 1 = 1 ') +
+        fldChar('separate') +
+        resultText('Outer A') +
+        fldChar('begin') +
+        instrText(' REF X ') +
+        fldChar('separate') +
+        resultText('Inner') +
+        fldChar('end') +
+        resultText('Outer B') +
+        fldChar('end') +
+        `</w:p>`,
+      );
+    });
+
+    await then('the outer runs share an identity distinct from the nested result', () => {
+      const runs = getParagraphRuns(firstParagraph(doc));
+      expect(runs.map((run) => run.text)).toEqual(['Outer A', 'Inner', 'Outer B']);
+      expect(runs[0]!.fieldResultId).toBe(runs[2]!.fieldResultId);
+      expect(runs[1]!.fieldResultId).not.toBe(runs[0]!.fieldResultId);
+      expect(runs.map((run) => run.fieldInstruction)).toEqual(['IF 1 = 1', 'REF X', 'IF 1 = 1']);
     });
   });
 
@@ -574,35 +610,32 @@ describe('replaceParagraphTextRange', () => {
     });
   });
 
-  test('throws UNSUPPORTED_EDIT for multi-run edit crossing field results', async ({ given, when, then }: AllureBddContext) => {
+  test('edits a cached field result split across multiple runs', async ({ given, when, then }: AllureBddContext) => {
+    testAllure.conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.16.18' });
     let p: Element;
 
-    await given('a paragraph where a field result spans two runs', () => {
+    await given('a PAGEREF cached result split across two runs', () => {
       const doc = makeDoc(
         `<w:p>` +
-        `<w:r><w:fldChar w:fldCharType="begin"/></w:r>` +
-        `<w:r><w:instrText>REF X</w:instrText></w:r>` +
-        `<w:r><w:fldChar w:fldCharType="separate"/></w:r>` +
-        `<w:r><w:t>Visible</w:t></w:r>` +
-        `<w:r><w:t> Result</w:t></w:r>` +
-        `<w:r><w:fldChar w:fldCharType="end"/></w:r>` +
+        fldChar('begin') +
+        instrText(' PAGEREF _Toc1 \\h ', { preserve: true }) +
+        fldChar('separate') +
+        resultText('1') +
+        resultText('2') +
+        fldChar('end') +
         `</w:p>`,
       );
       p = firstParagraph(doc);
     });
 
-    await when('an edit spanning both field result runs is attempted', () => {
-      // captured for assertion
+    await when('the entire cached result is replaced', () => {
+      replaceParagraphTextRange(p, 0, 2, '13');
     });
 
-    await then('UNSUPPORTED_EDIT error is thrown', () => {
-      try {
-        replaceParagraphTextRange(p, 0, 14, 'Updated');
-        expect.unreachable('Should have thrown');
-      } catch (e) {
-        expect(e).toBeInstanceOf(SafeDocxError);
-        expect((e as SafeDocxError).code).toBe('UNSUPPORTED_EDIT');
-      }
+    await then('the result changes while all complex-field markers remain', () => {
+      expect(getParagraphText(p)).toBe('13');
+      const fldChars = p.getElementsByTagNameNS(W_NS, W.fldChar);
+      expect(fldChars).toHaveLength(3);
     });
   });
 
@@ -628,6 +661,98 @@ describe('replaceParagraphTextRange', () => {
 
     await then('the edit succeeds and text is updated', () => {
       expect(getParagraphText(p)).toBe('Changed');
+    });
+  });
+
+  test('maps a field-result edit correctly when it begins at a run boundary', async ({ given, when, then }: AllureBddContext) => {
+    testAllure.conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.16.18' });
+    let p: Element;
+
+    await given('literal text immediately followed by a PAGEREF cached result', () => {
+      const doc = makeDoc(
+        `<w:p>` +
+        resultText('Section One') +
+        fldChar('begin') +
+        instrText(' PAGEREF _Toc1 \\h ', { preserve: true }) +
+        fldChar('separate') +
+        resultText('8') +
+        fldChar('end') +
+        `</w:p>`,
+      );
+      p = firstParagraph(doc);
+    });
+
+    await when('the one-character cached result is replaced', () => {
+      replaceParagraphTextRange(p, 11, 12, '9');
+    });
+
+    await then('only the cached result changes', () => {
+      expect(getParagraphText(p)).toBe('Section One9');
+      expect(p.getElementsByTagNameNS(W_NS, W.fldChar)).toHaveLength(3);
+    });
+  });
+
+  test('refuses a replacement that crosses into a cached field result', async ({ given, when, then }: AllureBddContext) => {
+    testAllure.conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.16.18' });
+    let p: Element;
+
+    await given('literal text immediately followed by a PAGEREF cached result', () => {
+      const doc = makeDoc(
+        `<w:p>` +
+        resultText('One') +
+        fldChar('begin') +
+        instrText(' PAGEREF _Toc1 \\h ', { preserve: true }) +
+        fldChar('separate') +
+        resultText('8') +
+        fldChar('end') +
+        `</w:p>`,
+      );
+      p = firstParagraph(doc);
+    });
+
+    await when('a raw primitive replacement crosses the field boundary', () => {
+      // captured for assertion
+    });
+
+    await then('the error identifies the PAGEREF result boundary', () => {
+      expect(() => replaceParagraphTextRange(p, 0, 4, 'One9')).toThrowError(
+        expect.objectContaining({
+          code: 'UNSUPPORTED_EDIT',
+          message: expect.stringContaining('PAGEREF field result'),
+        }),
+      );
+    });
+  });
+
+  test('refuses a cached-result edit when its separator shares the visible run', async ({ given, when, then }: AllureBddContext) => {
+    testAllure.conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.16.18' });
+    let p: Element;
+
+    await given('literal text, a complete field, and its cached result serialized in one run', () => {
+      const doc = makeDoc(
+        `<w:p>` +
+        `<w:r>` +
+        `<w:t>Outside</w:t>` +
+        `<w:fldChar w:fldCharType="begin"/>` +
+        `<w:instrText> REF X </w:instrText>` +
+        `<w:fldChar w:fldCharType="separate"/>` +
+        `<w:t>Visible</w:t>` +
+        `<w:fldChar w:fldCharType="end"/>` +
+        `</w:r>` +
+        `</w:p>`,
+      );
+      p = firstParagraph(doc);
+    });
+
+    await when('replacement would remove the run that owns the separator', () => {
+      // captured for assertion
+    });
+
+    await then('the primitive fails closed instead of deleting the separator', () => {
+      expect(() => replaceParagraphTextRange(p, 0, 14, 'Changed')).toThrowError(
+        expect.objectContaining({ code: 'UNSUPPORTED_EDIT' }),
+      );
+      expect(p.getElementsByTagNameNS(W_NS, W.fldChar)).toHaveLength(3);
     });
   });
 

--- a/packages/docx-core/src/primitives/text.ts
+++ b/packages/docx-core/src/primitives/text.ts
@@ -12,26 +12,61 @@ export type TextRun = {
   r: Element; // w:r
   text: string; // visible text for this run (field-code aware)
   isFieldResult: boolean;
+  fieldResultId?: number | null; // paragraph-local identity for one complex field
+  fieldInstruction?: string | null;
 };
 
+/**
+ * Return the paragraph's visible runs while retaining enough complex-field
+ * provenance to distinguish a safe cached-result edit from a field-boundary
+ * rewrite.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.18
+ * @see #651
+ */
 export function getParagraphRuns(p: Element): TextRun[] {
-  enum FieldState {
-    OUTSIDE_FIELD = 0,
-    IN_FIELD_CODE = 1,
-    IN_FIELD_RESULT = 2,
+  type FieldFrame = {
+    id: number;
+    phase: 'instruction' | 'result';
+    instruction: string;
+  };
+
+  type PendingTextRun = Pick<TextRun, 'r' | 'text' | 'isFieldResult'> & {
+    fieldResultId: number | null;
+  };
+
+  function currentResultId(stack: readonly FieldFrame[]): number | null {
+    if (stack.length === 0 || stack.some((frame) => frame.phase === 'instruction')) return null;
+    return stack.at(-1)!.id;
   }
 
   function getWAttr(el: Element, localName: string): string | null {
     return getAttributeSafe(el, OOXML.W_NS, localName, 'w');
   }
 
-  const runs: TextRun[] = [];
+  const runs: PendingTextRun[] = [];
   const rElems = Array.from(p.getElementsByTagNameNS(OOXML.W_NS, W.r));
 
-  let state: FieldState = FieldState.OUTSIDE_FIELD;
+  const fieldStack: FieldFrame[] = [];
+  const fieldInstructions = new Map<number, string>();
+  let nextFieldId = 1;
   for (const r of rElems) {
     let runText = '';
-    let sawResult = state === FieldState.IN_FIELD_RESULT;
+    let sawResult = false;
+    let runFieldResultId: number | null | undefined;
+
+    const appendVisibleText = (text: string): void => {
+      const resultId = currentResultId(fieldStack);
+      sawResult ||= resultId !== null;
+      if (runFieldResultId === undefined) {
+        runFieldResultId = resultId;
+      } else if (runFieldResultId !== resultId) {
+        // A run whose visible content straddles a field boundary cannot be
+        // rewritten as one unit without moving content across that boundary.
+        runFieldResultId = null;
+      }
+      runText += text;
+    };
 
     // Walk children in order so we can handle rare cases where fldChar and result text
     // appear in the same run.
@@ -42,32 +77,54 @@ export function getParagraphRuns(p: Element): TextRun[] {
 
       if (el.localName === W.fldChar) {
         const typ = getWAttr(el, 'fldCharType') ?? '';
-        if (typ === 'begin') state = FieldState.IN_FIELD_CODE;
-        else if (typ === 'separate') state = FieldState.IN_FIELD_RESULT;
-        else if (typ === 'end') state = FieldState.OUTSIDE_FIELD;
+        if (typ === 'begin') {
+          fieldStack.push({ id: nextFieldId++, phase: 'instruction', instruction: '' });
+        } else if (typ === 'separate') {
+          const frame = fieldStack.at(-1);
+          if (frame) {
+            frame.phase = 'result';
+            fieldInstructions.set(frame.id, frame.instruction.trim());
+          }
+        } else if (typ === 'end') {
+          fieldStack.pop();
+        }
         continue;
       }
 
-      if (state === FieldState.IN_FIELD_CODE) {
+      const instructionFrame = [...fieldStack].reverse().find((frame) => frame.phase === 'instruction');
+      if (instructionFrame) {
+        if (el.localName === W.instrText || el.localName === 'delInstrText') {
+          instructionFrame.instruction += el.textContent ?? '';
+        }
         // Skip field code/instruction text.
         continue;
       }
 
-      if (state === FieldState.IN_FIELD_RESULT) sawResult = true;
-
       if (el.localName === W.t) {
-        runText += el.textContent ?? '';
+        appendVisibleText(el.textContent ?? '');
       } else if (el.localName === W.tab) {
-        runText += '\t';
+        appendVisibleText('\t');
       } else if (el.localName === W.br) {
-        runText += '\n';
+        appendVisibleText('\n');
       }
     }
 
-    if (runText) runs.push({ r, text: runText, isFieldResult: sawResult });
+    if (runText) {
+      runs.push({
+        r,
+        text: runText,
+        isFieldResult: sawResult,
+        fieldResultId: runFieldResultId ?? null,
+      });
+    }
   }
 
-  return runs;
+  return runs.map((run) => ({
+    ...run,
+    fieldInstruction: run.fieldResultId === null
+      ? null
+      : (fieldInstructions.get(run.fieldResultId) ?? null),
+  }));
 }
 
 export function getParagraphText(p: Element): string {
@@ -91,16 +148,25 @@ function findOffsetInRuns(runs: TextRun[], start: number, end: number): {
 
   for (let i = 0; i < runs.length; i++) {
     const len = runs[i]!.text.length;
-    if (startRunIdx === -1 && start >= pos && start <= pos + len) {
+    const nextPos = pos + len;
+    const startIsInRun = start === end
+      ? start <= nextPos
+      : start < nextPos;
+    if (startRunIdx === -1 && start >= pos && startIsInRun) {
       startRunIdx = i;
       startOffset = start - pos;
     }
-    if (endRunIdx === -1 && end >= pos && end <= pos + len) {
+    if (endRunIdx === -1 && end > pos && end <= nextPos) {
       endRunIdx = i;
       endOffset = end - pos;
       break;
     }
-    pos += len;
+    pos = nextPos;
+  }
+
+  if (start === end && startRunIdx !== -1) {
+    endRunIdx = startRunIdx;
+    endOffset = startOffset;
   }
 
   if (startRunIdx === -1 || endRunIdx === -1) {
@@ -500,16 +566,36 @@ export function replaceParagraphTextRange(
   const startRun = runs[startRunIdx]!;
   const endRun = runs[endRunIdx]!;
 
-  // For now we only support field edits that stay within a single visible run.
-  if (startRunIdx !== endRunIdx) {
-    for (let i = startRunIdx; i <= endRunIdx; i++) {
-      if (runs[i]?.isFieldResult) {
-        throw new SafeDocxError(
-          'UNSUPPORTED_EDIT',
-          'Edit spans multiple runs and intersects a field result. This is currently unsupported in Safe-Docx TS.',
-          'Narrow old_string so the edit does not cross a field, or edit the field result text in a smaller span.',
-        );
-      }
+  // A cached result may span many runs, but every touched run must belong to
+  // the same complex field. Moving ordinary text, a field marker, or another
+  // field's result across a fldChar boundary would change document semantics.
+  const spanRuns = runs.slice(startRunIdx, endRunIdx + 1);
+  const fieldRuns = spanRuns.filter((run) => run.isFieldResult);
+  if (fieldRuns.length > 0) {
+    const fieldIds = new Set(fieldRuns.map((run) => run.fieldResultId));
+    const containsInlineFieldMarker = fieldRuns.some((run) =>
+      getDirectContentElements(run.r).some((el) => isW(el, W.fldChar)),
+    );
+    const isOneCompleteResultSpan =
+      fieldRuns.length === spanRuns.length &&
+      [...fieldIds].every((fieldId) => typeof fieldId === 'number') &&
+      fieldIds.size === 1 &&
+      !containsInlineFieldMarker;
+
+    if (!isOneCompleteResultSpan) {
+      const instructions = new Set(
+        fieldRuns
+          .map((run) => run.fieldInstruction?.split(/\s+/u)[0])
+          .filter((instruction): instruction is string => !!instruction),
+      );
+      const fieldLabel = instructions.size === 1
+        ? `${[...instructions][0]} field result`
+        : 'complex field result';
+      throw new SafeDocxError(
+        'UNSUPPORTED_EDIT',
+        `Edit crosses the boundary of a ${fieldLabel}; cached-result edits must stay inside one field.`,
+        'Narrow old_string so the changed range is entirely inside one cached field result.',
+      );
     }
   }
 

--- a/packages/docx-mcp/src/add_safe_docx_ts_formatting_parity.test.ts
+++ b/packages/docx-mcp/src/add_safe_docx_ts_formatting_parity.test.ts
@@ -338,10 +338,17 @@ describe('Traceability: TypeScript Formatting Parity', () => {
       target_paragraph_id: paraId,
       old_string: 'Amount: 100 due.',
       new_string: 'Amount: 250 due.',
-      instruction: 'field-aware refusal',
+      instruction: 'update cached field result',
     });
-    assertFailure(edited, 'EDIT_ERROR', 'edit');
-    expect(edited.error.message).toContain('unsupported');
+    assertSuccess(edited, 'edit');
+
+    const session = (await mgr.getSessionByFilePath(inputPath))!;
+    expect(session.doc.getParagraphTextById(paraId)).toBe('Amount: 250 due.');
+    expect(
+      session.doc
+        .getParagraphElementById(paraId)!
+        .getElementsByTagNameNS('http://schemas.openxmlformats.org/wordprocessingml/2006/main', 'fldChar'),
+    ).toHaveLength(3);
   });
 
   humanReadableTest.openspec('pagination rules deterministic for zero offset')('Scenario: pagination rules deterministic for offset=0', async () => {

--- a/packages/docx-mcp/src/tools/batch_edit.test.ts
+++ b/packages/docx-mcp/src/tools/batch_edit.test.ts
@@ -170,6 +170,53 @@ describe('batch_edit tool — edge cases', () => {
     });
   });
 
+  test('replaces a cached field result split across runs', async ({ given, when, then }: AllureBddContext) => {
+    let opened: Awaited<ReturnType<typeof openSession>>;
+    let result: Awaited<ReturnType<typeof batchEdit>>;
+
+    await given('a session containing a two-run PAGEREF cached result', async () => {
+      const xml =
+        `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+        `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
+        `<w:body><w:p>` +
+        `<w:r><w:t>Section One</w:t></w:r>` +
+        `<w:r><w:fldChar w:fldCharType="begin"/></w:r>` +
+        `<w:r><w:instrText xml:space="preserve"> PAGEREF _Toc1 \\h </w:instrText></w:r>` +
+        `<w:r><w:fldChar w:fldCharType="separate"/></w:r>` +
+        `<w:r><w:t>1</w:t></w:r><w:r><w:t>2</w:t></w:r>` +
+        `<w:r><w:fldChar w:fldCharType="end"/></w:r>` +
+        `</w:p></w:body></w:document>`;
+      opened = await openSession([], { xml });
+    });
+
+    await when('batch_edit changes the cached page number', async () => {
+      result = await batchEdit(opened.mgr, {
+        file_path: opened.inputPath,
+        steps: [{
+          step_id: 'field-result',
+          operation: 'replace_text',
+          target_paragraph_id: opened.firstParaId,
+          old_string: '12',
+          new_string: '13',
+          instruction: 'update cached page number',
+        }],
+      });
+    });
+
+    await then('the batch succeeds and preserves the complex-field markers', async () => {
+      assertSuccess(result);
+      const session = (await opened.mgr.getSessionByFilePath(opened.inputPath))!;
+      expect(session.doc.getParagraphTextById(opened.firstParaId)).toBe('Section One13');
+      const paragraph = session.doc.getParagraphElementById(opened.firstParaId)!;
+      expect(
+        paragraph.getElementsByTagNameNS(
+          'http://schemas.openxmlformats.org/wordprocessingml/2006/main',
+          'fldChar',
+        ),
+      ).toHaveLength(3);
+    });
+  });
+
   test('rejects neither steps nor plan_file_path', async ({ given, when, then }: AllureBddContext) => {
     let opened: Awaited<ReturnType<typeof openSession>>;
     let result: Awaited<ReturnType<typeof batchEdit>>;

--- a/packages/docx-mcp/src/tools/normalization_regression.test.ts
+++ b/packages/docx-mcp/src/tools/normalization_regression.test.ts
@@ -146,8 +146,8 @@ describe('normalization regression tests', () => {
 
       const { mgr, filePath, firstParaId } = await openSession([], { xml, prefix: 'barrier-field-' });
 
-      // The field text "100" should still be protected. Editing across field
-      // boundaries should fail.
+      // Common-prefix/suffix trimming narrows this to the cached result. The
+      // edit should succeed without normalization merging away field markers.
       const edited = await replaceText(mgr, {
         file_path: filePath,
         target_paragraph_id: firstParaId,
@@ -155,8 +155,14 @@ describe('normalization regression tests', () => {
         new_string: 'Amount: 250 due.',
         instruction: 'field barrier test',
       });
-      // This should fail because the text spans a field complex.
-      expect(edited.success).toBe(false);
+      expect(edited.success).toBe(true);
+      const session = (await mgr.getSessionByFilePath(filePath))!;
+      expect(session.doc.getParagraphTextById(firstParaId)).toBe('Amount: 250 due.');
+      expect(
+        session.doc
+          .getParagraphElementById(firstParaId)!
+          .getElementsByTagNameNS(W_NS, 'fldChar'),
+      ).toHaveLength(3);
     });
 
     test('bookmark-separated runs are not merged through the full pipeline', async () => {

--- a/packages/docx-mcp/src/tools/replace_text.branch.test.ts
+++ b/packages/docx-mcp/src/tools/replace_text.branch.test.ts
@@ -525,8 +525,7 @@ describe('replace_text branch coverage', () => {
     expect(afterText).toContain('commencement date');
   });
 
-  test('edit that changes field text still throws UNSUPPORTED_EDIT (Fix 3)', async () => {
-    // Try to change the field result text itself — primitive should reject.
+  test('edit that changes cached field text succeeds without removing field markers', async () => {
     const xml = makeDocXml(
       `<w:p>` +
         `<w:r><w:t xml:space="preserve">see </w:t></w:r>` +
@@ -548,9 +547,13 @@ describe('replace_text branch coverage', () => {
       new_string: 'see Changed here',
       instruction: 'edit that changes field text',
     });
-    // This should fail with UNSUPPORTED_EDIT wrapped as EDIT_ERROR because the
-    // trimmed range "Visible" → "Changed" crosses the field result run.
-    assertFailure(edited, 'EDIT_ERROR', 'edit crossing field');
+    assertSuccess(edited, 'edit cached field result');
+
+    const session = (await opened.mgr.getSessionByFilePath(opened.filePath))!;
+    const pEl = session.doc.getParagraphElementById(paraId);
+    expect(pEl).toBeTruthy();
+    expect(session.doc.getParagraphTextById(paraId)).toBe('see Changed here');
+    expect(pEl!.getElementsByTagNameNS(W_NS, 'fldChar')).toHaveLength(3);
   });
 
   humanReadableReplaceTest


### PR DESCRIPTION
## Summary

- fix half-open text range mapping when a cached result starts at a run boundary
- track nested complex-field ownership and allow replacements wholly inside one cached result, including split runs
- keep cross-field rewrites fail-closed with field-specific diagnostics
- cover both `replace_text` and `batch_edit` while preserving all `w:fldChar` markers

## Verification

- `npm run build`
- `npm run lint:workspaces`
- `npm run test:run`
- `npm run check:spec-coverage`
- `npm run check:conformance-citations`
- `npm run check:conformance-doc`
- LibreOffice identity and PDF probes passed in the full suite

Fixes #651