### PR TITLE
fix(docx-core): localize hyperlink boundary edits

### DIFF
--- a/packages/docx-core/src/primitives/text.test.ts
+++ b/packages/docx-core/src/primitives/text.test.ts
@@ -1313,8 +1313,53 @@ describe('replaceParagraphTextRange tracked-change emission', () => {
     });
   });
 
-  test('preserves UNSAFE_CONTAINER_BOUNDARY refusal for tracked edits crossing a hyperlink boundary', async ({ given, when, then }: AllureBddContext) => {
+  test('allows a tracked edit wholly inside an anchored hyperlink', async ({ given, when, then, and }: AllureBddContext) => {
+    testAllure.conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.16.22' });
     let p: Element;
+
+    await given('literal text followed by a one-run anchored hyperlink and more literal text', () => {
+      const doc = makeDoc(
+        `<w:p>` +
+          `<w:r><w:t xml:space="preserve">See Section </w:t></w:r>` +
+          `<w:hyperlink w:anchor="_Ref1"><w:r><w:t>4.2(b)(ix)</w:t></w:r></w:hyperlink>` +
+          `<w:r><w:t xml:space="preserve"> for details.</w:t></w:r>` +
+        `</w:p>`,
+      );
+      p = firstParagraph(doc);
+    });
+
+    await when('the complete visible hyperlink text is replaced with tracked changes', () => {
+      replaceParagraphTextRange(
+        p,
+        12,
+        22,
+        '4.2(b)(xii)',
+        createRevisionContext({
+          author: 'SafeDocX AI',
+          date: '2026-07-27T12:00:00Z',
+          idState: createRevisionIdState(),
+        }),
+      );
+    });
+
+    await then('the visible paragraph contains the replacement', () => {
+      expect(getParagraphText(p)).toBe('See Section 4.2(b)(xii) for details.');
+    });
+
+    await and('the tracked deletion and insertion stay inside the original hyperlink', () => {
+      const hyperlink = p.getElementsByTagNameNS(W_NS, W.hyperlink).item(0) as Element;
+      expect(hyperlink.getAttributeNS(W_NS, 'anchor')).toBe('_Ref1');
+      expect(hyperlink.getElementsByTagNameNS(W_NS, W.del)).toHaveLength(1);
+      expect(hyperlink.getElementsByTagNameNS(W_NS, 'ins')).toHaveLength(1);
+      expect(p.childNodes.item(1)).toBe(hyperlink);
+    });
+  });
+
+  test('localizes UNSAFE_CONTAINER_BOUNDARY refusal before mutating the paragraph', async ({ given, when, then, and }: AllureBddContext) => {
+    testAllure.conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.16.22' });
+    let p: Element;
+    let beforeXml: string;
+    let error: SafeDocxError | null = null;
 
     await given('a paragraph whose visible range spans from a hyperlink into plain paragraph content', () => {
       const doc = makeDoc(
@@ -1324,13 +1369,10 @@ describe('replaceParagraphTextRange tracked-change emission', () => {
         `</w:p>`,
       );
       p = firstParagraph(doc);
+      beforeXml = serialize(p);
     });
 
     await when('a tracked replacement crosses the hyperlink boundary', () => {
-      // captured for assertion
-    });
-
-    await then('the primitive throws UNSAFE_CONTAINER_BOUNDARY', () => {
       try {
         replaceParagraphTextRange(
           p,
@@ -1343,11 +1385,23 @@ describe('replaceParagraphTextRange tracked-change emission', () => {
             idState: createRevisionIdState(),
           }),
         );
-        expect.unreachable('Should have thrown');
-      } catch (e) {
-        expect(e).toBeInstanceOf(SafeDocxError);
-        expect((e as SafeDocxError).code).toBe('UNSAFE_CONTAINER_BOUNDARY');
+      } catch (caught) {
+        if (!(caught instanceof SafeDocxError)) throw caught;
+        error = caught;
       }
+    });
+
+    await then('the error identifies the range, boundary, containers, and largest safe sub-span', () => {
+      expect(error?.code).toBe('UNSAFE_CONTAINER_BOUNDARY');
+      expect(error?.message).toContain('range [0, 6)');
+      expect(error?.message).toContain('at offset 5');
+      expect(error?.message).toContain('(w:hyperlink → w:p)');
+      expect(error?.message).toContain('[0, 5) in w:hyperlink, "Hello"');
+      expect(error?.hint).toContain('each side of offset 5');
+    });
+
+    await and('the refusal leaves the paragraph XML byte-for-byte unchanged', () => {
+      expect(serialize(p)).toBe(beforeXml);
     });
   });
 });

--- a/packages/docx-core/src/primitives/text.ts
+++ b/packages/docx-core/src/primitives/text.ts
@@ -539,6 +539,87 @@ function applyRunProps(doc: Document, run: Element, add: AddRunProps | undefined
   if (add.fontName !== undefined) ensureFont(doc, rPr, add.fontName);
 }
 
+type ContainerSegment = {
+  parent: Node;
+  start: number;
+  end: number;
+};
+
+function describeRunContainer(node: Node): string {
+  if (node.nodeType !== 1) return node.nodeName;
+  const el = node as Element;
+  if (el.namespaceURI === OOXML.W_NS) return `w:${el.localName}`;
+  return el.tagName;
+}
+
+function previewContainerText(text: string, start: number, end: number): string {
+  const value = text.slice(start, end);
+  return value.length <= 120 ? value : `${value.slice(0, 117)}...`;
+}
+
+function getContainerBoundaryError(
+  runs: readonly TextRun[],
+  startRunIdx: number,
+  endRunIdx: number,
+  start: number,
+  end: number,
+  fullText: string,
+): SafeDocxError | null {
+  const segments: ContainerSegment[] = [];
+  let runStart = 0;
+
+  for (let i = 0; i < runs.length; i++) {
+    const run = runs[i]!;
+    const runEnd = runStart + run.text.length;
+    if (i >= startRunIdx && i <= endRunIdx) {
+      const overlapStart = Math.max(start, runStart);
+      const overlapEnd = Math.min(end, runEnd);
+      if (overlapEnd > overlapStart) {
+        const parent = run.r.parentNode;
+        if (!parent) throw new Error('Run has no parent');
+        const previous = segments.at(-1);
+        if (previous?.parent === parent && previous.end === overlapStart) {
+          previous.end = overlapEnd;
+        } else {
+          segments.push({ parent, start: overlapStart, end: overlapEnd });
+        }
+      }
+    }
+    runStart = runEnd;
+  }
+
+  if (segments.length <= 1) return null;
+
+  const first = segments[0]!;
+  const second = segments[1]!;
+  const largest = segments.reduce((best, segment) =>
+    segment.end - segment.start > best.end - best.start ? segment : best,
+  );
+  const boundaryOffset = first.end;
+  const firstContainer = describeRunContainer(first.parent);
+  const secondContainer = describeRunContainer(second.parent);
+  const largestContainer = describeRunContainer(largest.parent);
+  const preview = previewContainerText(fullText, largest.start, largest.end);
+
+  return new SafeDocxError(
+    'UNSAFE_CONTAINER_BOUNDARY',
+    `Edit range [${start}, ${end}) crosses a container boundary at offset ${boundaryOffset} ` +
+      `(${firstContainer} → ${secondContainer}). Largest contained sub-span: ` +
+      `[${largest.start}, ${largest.end}) in ${largestContainer}, ${JSON.stringify(preview)}.`,
+    `Retry with old_string limited to one container, such as the text in range ` +
+      `[${largest.start}, ${largest.end}), or make separate edits on each side of offset ${boundaryOffset}.`,
+  );
+}
+
+/**
+ * Replace a visible paragraph range while keeping tracked runs inside their
+ * existing run container. In particular, edits wholly inside `w:hyperlink`
+ * remain nested there, while cross-container ranges are refused before the
+ * DOM is changed.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.22
+ * @see #652
+ */
 export function replaceParagraphTextRange(
   p: Element,
   start: number,
@@ -565,6 +646,16 @@ export function replaceParagraphTextRange(
   const { startRunIdx, startOffset, endRunIdx, endOffset } = findOffsetInRuns(runs, start, end);
   const startRun = runs[startRunIdx]!;
   const endRun = runs[endRunIdx]!;
+
+  const containerBoundaryError = getContainerBoundaryError(
+    runs,
+    startRunIdx,
+    endRunIdx,
+    start,
+    end,
+    fullText,
+  );
+  if (containerBoundaryError) throw containerBoundaryError;
 
   // A cached result may span many runs, but every touched run must belong to
   // the same complex field. Moving ordinary text, a field marker, or another
@@ -648,11 +739,7 @@ export function replaceParagraphTextRange(
   const parent = rangeStartRunEl.parentNode;
   if (!parent) throw new Error('Run has no parent');
   if (rangeEndRunEl.parentNode !== parent) {
-    throw new SafeDocxError(
-      'UNSAFE_CONTAINER_BOUNDARY',
-      'Edit crosses container boundaries (e.g. hyperlinks/SDTs).',
-      'Narrow old_string so the match is contained within a single container, or avoid editing inside hyperlinks.',
-    );
+    throw new Error('Container boundary changed while splitting replacement runs');
   }
 
   const insertBeforeNode = rangeEndRunEl.nextSibling;

--- a/packages/docx-mcp/src/tools/batch_edit.test.ts
+++ b/packages/docx-mcp/src/tools/batch_edit.test.ts
@@ -217,6 +217,53 @@ describe('batch_edit tool — edge cases', () => {
     });
   });
 
+  test('returns an actionable hyperlink-boundary error without applying the batch', async ({ given, when, then, and }: AllureBddContext) => {
+    testAllure.conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.16.22' });
+    let opened: Awaited<ReturnType<typeof openSession>>;
+    let result: Awaited<ReturnType<typeof batchEdit>>;
+
+    await given('a paragraph with literal text followed by an anchored hyperlink', async () => {
+      const xml =
+        `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+        `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
+        `<w:body><w:p>` +
+        `<w:r><w:t xml:space="preserve">See Section </w:t></w:r>` +
+        `<w:hyperlink w:anchor="_Ref1"><w:r><w:t>4.2(b)(ix)</w:t></w:r></w:hyperlink>` +
+        `<w:r><w:t xml:space="preserve"> for details.</w:t></w:r>` +
+        `</w:p></w:body></w:document>`;
+      opened = await openSession([], { xml });
+    });
+
+    await when('a batch replacement genuinely crosses the hyperlink boundary', async () => {
+      result = await batchEdit(opened.mgr, {
+        file_path: opened.inputPath,
+        steps: [{
+          step_id: 'cross-hyperlink',
+          operation: 'replace_text',
+          target_paragraph_id: opened.firstParaId,
+          old_string: 'Section 4.2(b)(ix)',
+          new_string: 'Clause 5.3(c)(xii)!',
+          instruction: 'cross hyperlink boundary',
+        }],
+      });
+    });
+
+    await then('batch_edit preserves the structured boundary code and exact localization', () => {
+      assertFailure(result, 'UNSAFE_CONTAINER_BOUNDARY');
+      expect(result.error.message).toContain('range [4, 22)');
+      expect(result.error.message).toContain('at offset 12');
+      expect(result.error.message).toContain('(w:p → w:hyperlink)');
+      expect(result.error.message).toContain('[12, 22) in w:hyperlink, "4.2(b)(ix)"');
+      expect(result.error.hint).toContain('each side of offset 12');
+    });
+
+    await and('the original session remains unchanged', async () => {
+      const session = await opened.mgr.getSessionByFilePath(opened.inputPath);
+      expect(session?.doc.getParagraphTextById(opened.firstParaId))
+        .toBe('See Section 4.2(b)(ix) for details.');
+    });
+  });
+
   test('rejects neither steps nor plan_file_path', async ({ given, when, then }: AllureBddContext) => {
     let opened: Awaited<ReturnType<typeof openSession>>;
     let result: Awaited<ReturnType<typeof batchEdit>>;

--- a/packages/docx-mcp/src/tools/batch_edit.ts
+++ b/packages/docx-mcp/src/tools/batch_edit.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises';
 import {
   DocxDocument,
+  SafeDocxError,
   findUniqueSubstringMatch,
   replaceParagraphTextRange,
   type RevisionContext,
@@ -571,12 +572,22 @@ export async function batchEdit(
 
     const result = await executeSteps(manager, manager.normalizePath(session.originalPath), steps, ctx);
     if (result.failed_step_id !== undefined) {
+      const failedStepResult = result.step_results.find(
+        (stepResult) => stepResult.step_id === result.failed_step_id && !stepResult.success,
+      )?.result as { error?: { code?: string; message?: string; hint?: string } } | undefined;
+      const nestedError = failedStepResult?.error;
+      const preserveStructuralError =
+        nestedError?.code === 'UNSAFE_CONTAINER_BOUNDARY' ||
+        nestedError?.code === 'UNSUPPORTED_EDIT';
       return {
         success: false,
         error: {
-          code: 'BATCH_PARTIAL_FAILURE',
-          message: `Batch execution stopped at step '${result.failed_step_id}' (index ${result.failed_step_index}).`,
-          hint: 'Completed steps have already been applied. Reapply to original DOCX if rollback is needed.',
+          code: preserveStructuralError ? nestedError.code! : 'BATCH_PARTIAL_FAILURE',
+          message: preserveStructuralError && nestedError.message
+            ? `Batch execution stopped at step '${result.failed_step_id}' (index ${result.failed_step_index}): ${nestedError.message}`
+            : `Batch execution stopped at step '${result.failed_step_id}' (index ${result.failed_step_index}).`,
+          hint: (preserveStructuralError ? nestedError.hint : undefined) ??
+            'Completed steps have already been applied. Reapply to original DOCX if rollback is needed.',
         },
         file_path: manager.normalizePath(session.originalPath),
         completed_count: result.completed_step_ids.length,
@@ -598,6 +609,9 @@ export async function batchEdit(
       ...(allWarnings.length > 0 ? { warnings: allWarnings } : {}),
     });
   } catch (e: unknown) {
+    if (e instanceof SafeDocxError) {
+      return err(e.code, e.message, e.hint);
+    }
     return err('BATCH_EDIT_ERROR', `Failed to apply batch edit: ${errorMessage(e)}`);
   }
 }

--- a/packages/docx-mcp/src/tools/replace_text.branch.test.ts
+++ b/packages/docx-mcp/src/tools/replace_text.branch.test.ts
@@ -100,6 +100,58 @@ describe('replace_text branch coverage', () => {
     assertFailure(missingAnchor, 'ANCHOR_NOT_FOUND', 'anchor missing');
   });
 
+  test('edits text wholly inside an anchored hyperlink and localizes a crossing range', async ({ given, when, then, and }: AllureBddContext) => {
+    testAllure.conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.16.22' });
+    let contained: Awaited<ReturnType<typeof openSession>>;
+    let crossing: Awaited<ReturnType<typeof openSession>>;
+    let containedResult: Awaited<ReturnType<typeof replaceText>>;
+    let crossingResult: Awaited<ReturnType<typeof replaceText>>;
+
+    const xml = makeDocXml(
+      `<w:p>` +
+        `<w:r><w:t xml:space="preserve">See Section </w:t></w:r>` +
+        `<w:hyperlink w:anchor="_Ref1"><w:r><w:t>4.2(b)(ix)</w:t></w:r></w:hyperlink>` +
+        `<w:r><w:t xml:space="preserve"> for details.</w:t></w:r>` +
+      `</w:p>`,
+    );
+
+    await given('two sessions containing the same literal-hyperlink-literal paragraph', async () => {
+      contained = await openSession([], { xml });
+      crossing = await openSession([], { xml });
+    });
+
+    await when('one edit stays in the hyperlink and one crosses into it', async () => {
+      containedResult = await replaceText(contained.mgr, {
+        file_path: contained.filePath,
+        target_paragraph_id: contained.firstParaId,
+        old_string: '4.2(b)(ix)',
+        new_string: '4.2(b)(xii)',
+        instruction: 'renumber hyperlink',
+      });
+      crossingResult = await replaceText(crossing.mgr, {
+        file_path: crossing.filePath,
+        target_paragraph_id: crossing.firstParaId,
+        old_string: 'Section 4.2(b)(ix)',
+        new_string: 'Clause 5.3(c)(xii)!',
+        instruction: 'cross hyperlink boundary',
+      });
+    });
+
+    await then('the contained edit succeeds through replace_text', () => {
+      assertSuccess(containedResult);
+      expect(containedResult.after_text).toContain('Section 4.2(b)(xii) for details.');
+    });
+
+    await and('the crossing edit returns a structured, actionable boundary error', () => {
+      assertFailure(crossingResult, 'UNSAFE_CONTAINER_BOUNDARY');
+      expect(crossingResult.error.message).toContain('range [4, 22)');
+      expect(crossingResult.error.message).toContain('at offset 12');
+      expect(crossingResult.error.message).toContain('(w:p → w:hyperlink)');
+      expect(crossingResult.error.message).toContain('[12, 22) in w:hyperlink, "4.2(b)(ix)"');
+      expect(crossingResult.error.hint).toContain('each side of offset 12');
+    });
+  });
+
   test('non-markup replacement across mixed-format runs uses template from trimmed range', async () => {
     // "Alpha " (plain) + "Beta" (bold) → "Gamma Delta"
     // No shared prefix/suffix → full range replacement with predominant template run.

--- a/packages/docx-mcp/src/tools/replace_text.ts
+++ b/packages/docx-mcp/src/tools/replace_text.ts
@@ -8,6 +8,7 @@ import {
   OOXML,
   W,
   DocxDocument,
+  SafeDocxError,
   findUniqueSubstringMatch,
   applyDocumentQuoteStyle,
   getParagraphRuns,
@@ -314,6 +315,9 @@ export async function replaceText(
       after_text: previewText((session.doc.getParagraphTextById(pid) ?? '').trim(), RESULT_PREVIEW_CHARS),
     }, metadata));
   } catch (e: unknown) {
+    if (e instanceof SafeDocxError) {
+      return err(e.code, e.message, e.hint);
+    }
     const msg = errorMessage(e);
     return err('EDIT_ERROR', `Failed to edit document: ${msg}`);
   }


### PR DESCRIPTION
## Summary

- allow tracked replacements whose changed range is wholly contained in one `w:hyperlink`
- validate container ownership before splitting runs so refused edits do not mutate the paragraph
- report the requested range, exact crossing offset, container types, and largest contained sub-span for genuine boundary crossings
- preserve structural `SafeDocxError` codes and hints through `replace_text` and `batch_edit` while retaining generic batch partial-failure behavior for ordinary errors

## Conformance

Tracked hyperlink edits remain nested as `w:hyperlink` → `w:ins`/`w:del`, consistent with ECMA-376 5th edition, Part 1 § 17.16.22.

## Validation

- focused docx-core and MCP regression tests
- full docx-core suite: 1,251 passed (plus expected failures/skips)
- full docx-mcp suite: 900 passed
- mandatory repository chain: `npm run build && npm run lint:workspaces && npm run test:run && npm run check:spec-coverage && npm run check:conformance-citations && npm run check:conformance-doc`

Fixes #652