### PR TITLE
fix(docx-mcp): align CLI comparison default

### DIFF
--- a/packages/docx-mcp/src/cli/commands/compare.test.ts
+++ b/packages/docx-mcp/src/cli/commands/compare.test.ts
@@ -1,0 +1,62 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
+import { makeMinimalDocx } from '../../testing/docx_test_utils.js';
+import { createTrackedTempDir, registerCleanup } from '../../testing/session-test-utils.js';
+import { runCompareCommand } from './compare.js';
+
+registerCleanup();
+
+const test = testAllure.epic('Document Editing').withLabels({ feature: 'CLI Comparison' });
+
+describe('safe-docx compare command', () => {
+  test('defaults to the shared inplace reconstruction mode', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    const tmpDir = await createTrackedTempDir('safe-docx-compare-default-');
+    const originalPath = path.join(tmpDir, 'original.docx');
+    const revisedPath = path.join(tmpDir, 'revised.docx');
+    await given('a minimal document pair with one text revision', async () => {
+      await Promise.all([
+        fs.writeFile(originalPath, await makeMinimalDocx(['Original text'])),
+        fs.writeFile(revisedPath, await makeMinimalDocx(['Revised text'])),
+      ]);
+    });
+
+    let result: Awaited<ReturnType<typeof runCompareCommand>>;
+    await when('the CLI compare command runs without an explicit mode', async () => {
+      result = await runCompareCommand({ originalPath, revisedPath });
+    });
+
+    await then('inplace is requested and reflected in the default output name', async () => {
+      expect(result.mode_requested).toBe('inplace');
+      expect(result.output).toBe(path.join(tmpDir, 'revised.REDLINE.atomizer.inplace.docx'));
+      expect((await fs.stat(result.output)).isFile()).toBe(true);
+    });
+  });
+
+  test('honors an explicit rebuild mode', async ({ given, when, then }: AllureBddContext) => {
+    const tmpDir = await createTrackedTempDir('safe-docx-compare-rebuild-');
+    const originalPath = path.join(tmpDir, 'original.docx');
+    const revisedPath = path.join(tmpDir, 'revised.docx');
+    await given('a minimal document pair', async () => {
+      await Promise.all([
+        fs.writeFile(originalPath, await makeMinimalDocx(['Original text'])),
+        fs.writeFile(revisedPath, await makeMinimalDocx(['Revised text'])),
+      ]);
+    });
+
+    let result: Awaited<ReturnType<typeof runCompareCommand>>;
+    await when('the CLI compare command explicitly requests rebuild', async () => {
+      result = await runCompareCommand({ originalPath, revisedPath, mode: 'rebuild' });
+    });
+
+    await then('the explicit mode remains authoritative', () => {
+      expect(result.mode_requested).toBe('rebuild');
+      expect(result.output).toBe(path.join(tmpDir, 'revised.REDLINE.atomizer.rebuild.docx'));
+    });
+  });
+});

--- a/packages/docx-mcp/src/cli/commands/compare.ts
+++ b/packages/docx-mcp/src/cli/commands/compare.ts
@@ -1,6 +1,7 @@
 import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { compareDocuments, type CompareOptions } from '@usejunior/docx-compare';
+import { DEFAULT_RECONSTRUCTION_MODE } from '../../tools/comparison_defaults.js';
 
 const SUPPORTED_ENGINES: ReadonlySet<NonNullable<CompareOptions['engine']>> = new Set([
   'auto',
@@ -36,7 +37,7 @@ function normalizeEngine(raw: string | undefined): NonNullable<CompareOptions['e
 }
 
 function normalizeMode(raw: string | undefined): 'inplace' | 'rebuild' {
-  const candidate = (raw ?? 'rebuild').trim().toLowerCase();
+  const candidate = (raw ?? DEFAULT_RECONSTRUCTION_MODE).trim().toLowerCase();
   if (candidate !== 'inplace' && candidate !== 'rebuild') {
     throw new Error(`Unsupported mode: ${String(raw)}. Use inplace or rebuild.`);
   }

--- a/packages/docx-mcp/src/cli/help.ts
+++ b/packages/docx-mcp/src/cli/help.ts
@@ -44,6 +44,7 @@ export function renderTopLevelHelp(): string {
   lines.push('Built-in commands:');
   lines.push('  serve                                       Start the MCP server (default)');
   lines.push('  compare <original> <revised> [output]       Compare two DOCX files and write redline output');
+  lines.push('    --mode <inplace|rebuild>                   Reconstruction mode (default: inplace)');
   lines.push('                                                Compare stats count revision ranges; atom totals use *Atoms fields');
   lines.push('  edit <file> [--replace ...] [-o output]     Batch edit a DOCX file');
   lines.push('  grep "pattern" <file> [files...]            Search DOCX files for text');

--- a/packages/docx-mcp/src/cli/index.test.ts
+++ b/packages/docx-mcp/src/cli/index.test.ts
@@ -125,6 +125,7 @@ describe('safe-docx CLI routing', () => {
       expect(output).toHaveLength(1);
       expect(output[0]).toContain('safe-docx CLI');
       expect(output[0]).toContain('compare <original> <revised> [output]');
+      expect(output[0]).toContain('Reconstruction mode (default: inplace)');
       expect(serve).not.toHaveBeenCalled();
       expect(compare).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
## Summary

- make `safe-docx compare` consume the same shared `inplace` reconstruction default as `compare_documents`
- preserve explicit `--mode rebuild` behavior
- document the default in CLI help
- add command-level regression coverage for default and explicit modes

## Why

The CLI hardcoded `rebuild`, bypassing the higher-fidelity inplace pass ladder and producing different output fidelity from the MCP surface for identical inputs. A single shared default prevents the two entry points from drifting again.

## Validation

- exact repository pre-submit chain passed outside the sandbox:
  - `npm run build`
  - `npm run lint:workspaces`
  - `npm run test:run`
  - `npm run check:spec-coverage`
  - `npm run check:conformance-citations`
  - `npm run check:conformance-doc`
- built CLI smoke on `simple-word-change` reported `mode_requested: inplace` by default and `mode_requested: rebuild` with the explicit flag
- both smoke outputs passed `unzip -t`

Fixes #649