### PR TITLE
docs(docx-mcp): document paragraph deletion

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -93,6 +93,27 @@ replace_text(
 
 The change is applied to the live document session. Untouched paragraphs remain outside the edit operation.
 
+### Delete An Ordinary DOCX Paragraph
+
+There is no separate `delete_paragraph` tool. To delete an ordinary body
+paragraph, target its exact full visible text and replace it with an empty string:
+
+```text
+replace_text(
+  file_path="~/docs/NDA.docx",
+  target_paragraph_id="_bk_7d130acfe245",
+  old_string="This duplicated paragraph should be removed.",
+  new_string="",
+  instruction="Delete the duplicated paragraph"
+)
+```
+
+A clean save removes the paragraph. A tracked save retains its deletion for
+review. Re-read the target first and use this pattern only when `old_string`
+matches the complete paragraph text. Inspect the document structure before using
+it on a paragraph that carries section properties, is structurally required as
+the last paragraph in a table cell, or owns bookmark or comment anchors.
+
 ## Step 6: Save Reviewable Outputs
 
 ```text
@@ -135,6 +156,7 @@ Visual review remains appropriate for material documents because Safe Docx is no
 | Compare two documents | `compare_documents` |
 | Inspect or accept revisions | `has_tracked_changes`, `extract_revisions`, `accept_changes` |
 | Insert a paragraph | `insert_paragraph` |
+| Delete an ordinary DOCX body paragraph | `replace_text` with the complete text and an empty `new_string` |
 | Apply several edits together | `batch_edit` |
 | Convert DOCX to ODT | `convert_to_odt` |
 | Convert DOCX to Markdown | `export` with `format="markdown"` |

--- a/packages/docx-mcp/docs/tool-reference.generated.md
+++ b/packages/docx-mcp/docs/tool-reference.generated.md
@@ -76,7 +76,7 @@ Single-agent front door for applying multiple edit steps (replace_text, insert_p
 
 ## `replace_text`
 
-Replace text in a paragraph by provider paragraph id, preserving formatting where supported. Supports DOCX, ODT, and Google Docs. Surface: revisionable — DOCX edits emit native OOXML tracked changes (w:ins/w:del/w:rPrChange).
+Replace text in a paragraph by provider paragraph id, preserving formatting where supported. Supports DOCX, ODT, and Google Docs. To delete an ordinary DOCX body paragraph, pass its complete visible text as old_string and an empty new_string; a clean save removes the paragraph and a tracked save keeps the deletion for review. Do not use this shortcut for paragraphs that carry section properties, are structurally required by a table cell, or own bookmark/comment anchors without inspecting the structure first. Surface: revisionable — DOCX edits emit native OOXML tracked changes (w:ins/w:del/w:rPrChange).
 
 - readOnly: `false`
 - destructive: `true`

--- a/packages/docx-mcp/src/tool_catalog.ts
+++ b/packages/docx-mcp/src/tool_catalog.ts
@@ -168,7 +168,8 @@ export const SAFE_DOCX_TOOL_CATALOG = [
   {
     name: 'replace_text',
     surface: 'revisionable',
-    description: 'Replace text in a paragraph by provider paragraph id, preserving formatting where supported. Supports DOCX, ODT, and Google Docs. Surface: revisionable — DOCX edits emit native OOXML tracked changes (w:ins/w:del/w:rPrChange).',
+    description:
+      'Replace text in a paragraph by provider paragraph id, preserving formatting where supported. Supports DOCX, ODT, and Google Docs. To delete an ordinary DOCX body paragraph, pass its complete visible text as old_string and an empty new_string; a clean save removes the paragraph and a tracked save keeps the deletion for review. Do not use this shortcut for paragraphs that carry section properties, are structurally required by a table cell, or own bookmark/comment anchors without inspecting the structure first. Surface: revisionable — DOCX edits emit native OOXML tracked changes (w:ins/w:del/w:rPrChange).',
     input: z.object({
       ...FILE_FIELD_OPTIONAL,
       ...GOOGLE_DOC_ID_FIELD,


### PR DESCRIPTION
## Summary
- document the existing full-text-to-empty `replace_text` paragraph deletion workflow in the canonical tutorial
- expose the workflow in the agent-facing tool catalog and regenerate the tool reference
- call out section, table-cell, bookmark, and comment-anchor cases that require structural inspection

## Decision
Issue #656 allows either documenting the existing workaround or adding a dedicated tool. This PR chooses the smaller documentation path because clean and tracked paragraph deletion already work end to end; adding another mutation surface would duplicate that behavior.

## Validation
- `npm run build && npm run lint:workspaces && npm run test:run && npm run check:spec-coverage && npm run check:conformance-citations && npm run check:conformance-doc`
- `npm run check:tool-docs`
- `npm run check:site`
- real Common Paper mutual NDA smoke: clean output removed the title paragraph (50 → 49 paragraphs), tracked output retained one deletion, and both DOCX archives passed integrity checks

Fixes #656