### PR TITLE
feat(docx-mcp): add paragraph numbering formatting

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -114,6 +114,36 @@ matches the complete paragraph text. Inspect the document structure before using
 it on a paragraph that carries section properties, is structurally required as
 the last paragraph in a table cell, or owns bookmark or comment anchors.
 
+### Repair DOCX Paragraph Numbering
+
+Use `format_numbering` when a paragraph has a stray direct list label:
+
+```text
+format_numbering(
+  file_path="~/docs/NDA.docx",
+  target_paragraph_id="_bk_4d71f33e924a",
+  remove=true
+)
+```
+
+To join a paragraph to an existing list sequence, copy another paragraph's
+explicit numbering:
+
+```text
+format_numbering(
+  file_path="~/docs/NDA.docx",
+  target_paragraph_id="_bk_9fc26ad74408",
+  match_paragraph_id="_bk_d39ac1a3b3f0"
+)
+```
+
+The tool also accepts an existing `num_id` with its `ilvl`, but matching a
+paragraph is usually safer because numbering IDs are local to each DOCX. The
+tool changes only direct `w:numPr`: it does not create numbering definitions,
+change numbering inherited only through a paragraph style, restart lists, or
+guarantee a rendered label without the surrounding list context. Effective
+changes are recorded as paragraph-property tracked changes.
+
 ## Step 6: Save Reviewable Outputs
 
 ```text
@@ -157,6 +187,7 @@ Visual review remains appropriate for material documents because Safe Docx is no
 | Inspect or accept revisions | `has_tracked_changes`, `extract_revisions`, `accept_changes` |
 | Insert a paragraph | `insert_paragraph` |
 | Delete an ordinary DOCX body paragraph | `replace_text` with the complete text and an empty `new_string` |
+| Remove or repair direct DOCX paragraph numbering | `format_numbering` |
 | Apply several edits together | `batch_edit` |
 | Convert DOCX to ODT | `convert_to_odt` |
 | Convert DOCX to Markdown | `export` with `format="markdown"` |

--- a/openspec/changes/add-paragraph-numbering-formatting/design.md
+++ b/openspec/changes/add-paragraph-numbering-formatting/design.md
@@ -1,0 +1,117 @@
+## Context
+
+Paragraph numbering in WordprocessingML is a paragraph property: direct list
+membership is represented by `w:pPr/w:numPr`, containing `w:ilvl` followed by
+`w:numId`. Safe DOCX already parses this state for `read_file` and loads
+`word/numbering.xml`, but its mutation surface only changes text, spacing, table
+geometry, and run formatting.
+
+The implementation must preserve Safe DOCX's session-first behavior, stable
+bookmark anchors, tracked-change policy, and ECMA-376 subset. It must also avoid
+silently manufacturing or repairing numbering definitions.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Mutate one main-document paragraph's direct numbering deterministically.
+- Cover the two common repairs: remove an unwanted direct number and join an
+  existing list sequence.
+- Make the common "match this paragraph" request independent of raw numeric IDs.
+- Emit a reviewable paragraph-property revision and preserve unrelated OOXML.
+- Reject dangling references before the document DOM is changed.
+
+### Non-Goals
+
+- Author or alter `word/numbering.xml`.
+- Override numbering inherited only from styles.
+- Infer semantic list membership or list continuation.
+- Extend the tool to non-DOCX providers or auxiliary story parts.
+
+## Decisions
+
+### 1. Add a dedicated `format_numbering` tool
+
+Numbering is structural formatting rather than text replacement or layout
+geometry. A dedicated tool keeps its mutually exclusive operations and
+numbering-specific validation visible in the schema.
+
+The request targets one `target_paragraph_id` and supplies exactly one of:
+
+- `remove: true`
+- `match_paragraph_id: "_bk_..."`
+- `num_id: "<existing decimal id>"` together with `ilvl: <existing level>`
+
+The raw-reference form is retained for deterministic automation. The match form
+is preferred for agents because it copies the source paragraph's explicit
+`w:numPr` without requiring the caller to reason about package-local IDs.
+
+### 2. Only direct paragraph numbering is in scope
+
+`remove: true` removes a direct `w:numPr` from the target paragraph. It does not
+change paragraph styles or numbering inherited through styles. If the target has
+no direct `w:numPr`, the operation returns a successful no-op with a warning so
+callers are not misled about inherited numbering.
+
+The match form requires the source paragraph to have a complete direct
+`w:numPr`. Pointing at an unnumbered or style-only source is rejected with a
+structured error.
+
+### 3. Existing numbering definitions are authoritative
+
+Before either set operation, the tool validates that:
+
+- `word/numbering.xml` is present;
+- the requested `w:numId` resolves to an existing numbering instance;
+- the instance resolves to an abstract numbering definition; and
+- the requested `w:ilvl` exists on that definition.
+
+The direct form accepts a positive decimal `num_id`; `0` is not overloaded as a
+removal request. No numbering-part mutation is permitted.
+
+### 4. Mutation is transactional and tracked
+
+All validation and anchor resolution happen before mutation. The core primitive
+changes only `w:pPr/w:numPr`, emits a `w:pPrChange` containing the prior paragraph
+properties, and uses the session's revision author, date, and ID allocator.
+
+The primitive uses schema-order insertion (`w:ilvl` before `w:numId`, and
+`w:numPr` in its `CT_PPrBase` slot), preserves unrelated `w:pPr` children, and
+keeps at most one direct `w:pPrChange` according to the existing tracked property
+mutation policy. The standard AI-revision preflight guard remains mandatory.
+
+An identical requested direct state is a no-op: it does not increment the edit
+revision or append another property-change record.
+
+### 5. Response reports both requested and resulting state
+
+The response includes the target paragraph ID, previous direct numbering,
+resulting direct numbering, whether a mutation occurred, and source paragraph ID
+when match mode is used. It also includes standard session-resolution metadata.
+
+## Risks / Trade-offs
+
+- A caller may expect removing direct numbering to suppress style-inherited
+  numbering. The tool reports a no-op warning when no direct `w:numPr` exists and
+  documentation states this boundary explicitly.
+- Copying a list reference joins the same numbering instance but does not promise
+  a particular rendered label without the surrounding list context. Tests verify
+  both the emitted reference and the label produced by the existing reader.
+- Word's property-change model snapshots the previous paragraph properties rather
+  than wrapping `w:numPr` alone. Reusing the established `w:pPrChange` emitter
+  minimizes revision-shape drift.
+- Restricting v1 to existing definitions means callers still cannot create a new
+  list. This keeps the change focused and prevents package-wide relationship and
+  numbering-definition mutation.
+
+## Migration Plan
+
+This is an additive tool and core primitive. Existing callers and documents
+require no migration. If post-merge smoke reveals a fidelity or rendering
+regression, the PR can be reverted without changing stored user data or existing
+tool schemas.
+
+## Open Questions
+
+None. Style-inherited numbering, list restarts, and numbering-definition authoring
+remain explicit follow-up capabilities.

--- a/openspec/changes/add-paragraph-numbering-formatting/proposal.md
+++ b/openspec/changes/add-paragraph-numbering-formatting/proposal.md
@@ -1,0 +1,47 @@
+# Change: Add Paragraph Numbering Formatting
+
+## Why
+
+Safe DOCX exposes a paragraph's effective numbering through `read_file`, but no
+editing tool can change its direct `w:numPr`. Callers therefore cannot remove a
+stray auto-number or reconnect a paragraph to an existing list without manually
+editing `word/document.xml`, which bypasses tracked changes and the normal
+mutation safeguards.
+
+## What Changes
+
+- Add a DOCX-only `format_numbering` MCP tool targeting one paragraph anchor.
+- Support three mutually exclusive operations:
+  - remove the target paragraph's direct `w:numPr`;
+  - copy the explicit `w:numId` and `w:ilvl` from another anchored paragraph;
+  - set an explicit `w:numId` and `w:ilvl` that already exist in the document's
+    numbering definitions.
+- Validate all anchors and numbering references before mutation and return
+  structured errors for invalid or ambiguous requests.
+- Record an effective numbering change as a native `w:pPrChange`, using the
+  repository's existing revision metadata and mutation guardrails.
+- Preserve paragraph text, identity, unrelated paragraph properties, numbering
+  definitions, and non-body package parts.
+- Make repeated requests for the already-effective direct state deterministic
+  no-ops rather than adding duplicate revision records.
+
+## Impact
+
+- Affected specs:
+  - `mcp-server`
+- Affected code:
+  - `packages/docx-core/src/primitives/` for the tracked numbering mutation
+  - `packages/docx-mcp/src/tools/`, `server.ts`, and `tool_catalog.ts` for the
+    tool contract and dispatch
+  - generated tool documentation and the canonical tutorial
+  - unit, integration, conformance, and real-DOCX regression tests
+
+## Non-Goals
+
+- Creating, cloning, renumbering, or deleting definitions in
+  `word/numbering.xml`.
+- Editing numbering inherited only through paragraph styles.
+- Restarting a list at an arbitrary value or changing label formats, indentation,
+  justification, or numbering-level styles.
+- Numbering edits in headers, footers, footnotes, endnotes, ODT, or Google Docs.
+- Automatically choosing which list a paragraph should join.

--- a/openspec/changes/add-paragraph-numbering-formatting/specs/mcp-server/spec.md
+++ b/openspec/changes/add-paragraph-numbering-formatting/specs/mcp-server/spec.md
@@ -1,0 +1,103 @@
+## ADDED Requirements
+
+### Requirement: Deterministic Paragraph Numbering Formatting Tool
+The Safe-DOCX MCP server SHALL provide a DOCX-only `format_numbering` tool that targets one main-document paragraph by anchor and changes its direct `w:numPr` without changing visible paragraph text.
+
+#### Scenario: Remove direct paragraph numbering
+- **GIVEN** a target paragraph with a direct `w:numPr`
+- **WHEN** `format_numbering` is called with `remove: true`
+- **THEN** the server SHALL remove the target's direct `w:numPr`
+- **AND** SHALL preserve its text, anchor, and unrelated paragraph properties
+
+#### Scenario: Match another paragraph's explicit numbering
+- **GIVEN** source and target paragraph anchors in the same DOCX
+- **AND** the source has a complete direct `w:numPr`
+- **WHEN** `format_numbering` is called with the source as `match_paragraph_id`
+- **THEN** the target SHALL receive the source's explicit `w:numId` and `w:ilvl`
+- **AND** `word/numbering.xml` SHALL remain unchanged
+
+#### Scenario: Set an existing numbering reference directly
+- **GIVEN** a DOCX whose numbering part defines the requested numbering instance
+  and level
+- **WHEN** `format_numbering` is called with that `num_id` and `ilvl`
+- **THEN** the target SHALL receive a schema-ordered `w:numPr` containing
+  `w:ilvl` followed by `w:numId`
+- **AND** no numbering definition SHALL be created or modified
+
+#### Scenario: Identical direct numbering is a deterministic no-op
+- **GIVEN** the target already has the requested direct `w:numId` and `w:ilvl`
+- **WHEN** the same `format_numbering` request is repeated
+- **THEN** the server SHALL report that no mutation occurred
+- **AND** SHALL NOT increment edit accounting or add another property revision
+
+### Requirement: Paragraph Numbering Validation Is Transactional
+The paragraph numbering tool SHALL resolve and validate the complete request before mutating the document.
+
+#### Scenario: Mutually exclusive operation forms are enforced
+- **WHEN** a request supplies zero operation forms or combines remove, match, or
+  direct-reference forms
+- **THEN** the server SHALL reject it with a structured validation error
+- **AND** SHALL include remediation guidance describing the accepted forms
+
+#### Scenario: Match source must have complete direct numbering
+- **GIVEN** a source paragraph that is unnumbered or numbered only through style
+  inheritance
+- **WHEN** it is supplied as `match_paragraph_id`
+- **THEN** the server SHALL reject the request with a structured error
+- **AND** the target paragraph SHALL remain unchanged
+
+#### Scenario: Dangling numbering references are rejected before mutation
+- **WHEN** a direct or matched `numId` instance, abstract definition, or `ilvl`
+  cannot be resolved in `word/numbering.xml`
+- **THEN** the server SHALL reject the request with a structured error and hint
+- **AND** the serialized document XML SHALL remain unchanged
+
+#### Scenario: Removing absent direct numbering is explicit
+- **GIVEN** a target paragraph without a direct `w:numPr`
+- **WHEN** `format_numbering` is called with `remove: true`
+- **THEN** the server SHALL return a successful no-op with a warning
+- **AND** SHALL NOT claim that style-inherited numbering was removed
+
+#### Scenario: Unsupported providers are rejected
+- **WHEN** `format_numbering` targets an ODT file or Google Doc
+- **THEN** the server SHALL return a structured unsupported-provider error
+- **AND** SHALL NOT mutate the source
+
+### Requirement: Paragraph Numbering Changes Are Reviewable
+An effective direct-numbering mutation SHALL be represented as a native paragraph-property tracked change using the session revision context.
+
+#### Scenario: Effective numbering change emits prior properties
+- **GIVEN** a target whose direct numbering differs from the requested state
+- **WHEN** `format_numbering` applies the change
+- **THEN** the target `w:pPr` SHALL contain one `w:pPrChange` with the prior
+  paragraph properties
+- **AND** its revision ID, author, and date SHALL come from the session revision
+  context
+
+#### Scenario: Clean and tracked saves represent the same numbering edit
+- **GIVEN** a successful direct-numbering mutation
+- **WHEN** the session is saved in clean and tracked forms
+- **THEN** the clean output SHALL contain the requested current `w:numPr` state
+- **AND** the tracked output SHALL retain a reviewable `w:pPrChange`
+
+#### Scenario: Standard accept and reject semantics cover numbering changes
+- **GIVEN** a numbering mutation recorded as `w:pPrChange`
+- **WHEN** that property revision is accepted or rejected through supported
+  revision workflows
+- **THEN** acceptance SHALL keep the requested numbering state
+- **AND** rejection SHALL restore the prior direct numbering state
+
+### Requirement: Paragraph Numbering Mutation Preserves Document Identity
+The paragraph numbering tool SHALL limit its mutation to the selected paragraph's direct numbering property and revision record.
+
+#### Scenario: Text and paragraph anchors remain stable
+- **GIVEN** a document with stable paragraph anchors
+- **WHEN** one paragraph's direct numbering is changed
+- **THEN** paragraph count and visible text SHALL remain unchanged
+- **AND** every pre-existing paragraph anchor SHALL remain addressable
+
+#### Scenario: Non-target package content remains unchanged
+- **WHEN** `format_numbering` changes one paragraph
+- **THEN** unrelated paragraph properties and non-target paragraphs SHALL remain
+  unchanged
+- **AND** numbering definitions and non-body package parts SHALL remain unchanged

--- a/openspec/changes/add-paragraph-numbering-formatting/tasks.md
+++ b/openspec/changes/add-paragraph-numbering-formatting/tasks.md
@@ -1,0 +1,59 @@
+## 1. Core Numbering Mutation
+
+- [x] 1.1 Add typed direct-numbering mutation input/result models in
+      `@usejunior/docx-core`.
+- [x] 1.2 Implement paragraph-anchor resolution and read the target's complete
+      direct `w:numPr` without falling back to style-inherited numbering.
+- [x] 1.3 Validate `numId` instance, abstract numbering reference, and `ilvl`
+      existence before changing the DOM.
+- [x] 1.4 Implement schema-ordered set/remove behavior that preserves unrelated
+      paragraph properties and creates a missing `w:pPr` only when setting.
+- [x] 1.5 Emit `w:pPrChange` with session revision metadata for effective changes
+      and make identical state requests no-ops.
+- [x] 1.6 Expose the primitive through `DocxDocument` and package exports.
+
+## 2. MCP Tool Surface
+
+- [x] 2.1 Add the revisionable DOCX-only `format_numbering` schema to the tool
+      catalog with mutually exclusive remove, match, and direct-reference forms.
+- [x] 2.2 Implement file-first/session-first tool resolution, AI-revision
+      preflight, validation, mutation, edit accounting, and structured response
+      metadata.
+- [x] 2.3 Register tool dispatch and ensure unsupported ODT and Google Docs
+      requests fail with provider-specific structured errors.
+- [x] 2.4 Return structured validation errors with remediation hints for missing
+      anchors, incomplete source numbering, dangling instances, missing levels,
+      and mutually exclusive inputs.
+
+## 3. Tests And Conformance
+
+- [x] 3.1 Add core unit tests for set, remove, container creation, schema order,
+      unrelated-property preservation, and deterministic no-op behavior.
+- [x] 3.2 Add tracked-change tests proving the prior numbering is captured in one
+      `w:pPrChange` and clean accept/reject semantics restore the expected state.
+- [x] 3.3 Add MCP integration tests for all three modes, session reuse, edit
+      accounting, and structured result metadata.
+- [x] 3.4 Add transactional failure tests proving invalid anchors and dangling
+      numbering references leave serialized document XML unchanged.
+- [x] 3.5 Add read-after-write tests proving copied numbering joins the source
+      `numId`/`ilvl` and produces the expected list-label sequence.
+- [x] 3.6 Add ECMA-376 conformance citations and Allure evidence for
+      `w:numPr`, `w:numId`, and `w:ilvl`.
+- [x] 3.7 Run an end-to-end real-DOCX smoke covering clean and tracked outputs,
+      package/XML validation, and LibreOffice rendering.
+
+## 4. Documentation
+
+- [x] 4.1 Regenerate the MCP tool reference from the catalog.
+- [x] 4.2 Add canonical tutorial examples for removing direct numbering and
+      matching another paragraph.
+- [x] 4.3 Document the v1 boundaries: existing definitions only, direct
+      numbering only, and no guaranteed label without surrounding list context.
+
+## 5. Validation
+
+- [x] 5.1 `openspec validate add-paragraph-numbering-formatting --strict`
+      passes.
+- [x] 5.2 Tool-documentation freshness and site checks pass.
+- [x] 5.3 The repository's mandatory build, lint, test, spec-coverage, and
+      conformance pre-submit suite passes.

--- a/packages/docx-core/src/primitives/document.ts
+++ b/packages/docx-core/src/primitives/document.ts
@@ -23,6 +23,13 @@ import { serializeToPlainText, type SerializePlainTextOptions } from './serializ
 import type { FormattingMode } from './formatting_tags.js';
 import { parseStylesXml, type StylesModel } from './styles.js';
 import { parseNumberingXml, type NumberingModel } from './numbering.js';
+import {
+  getDirectParagraphNumbering,
+  setDirectParagraphNumbering,
+  type DirectParagraphNumbering,
+  type ParagraphNumberingMutation,
+  type ParagraphNumberingMutationResult,
+} from './paragraph_numbering.js';
 import { findUniqueSubstringMatch } from './matching.js';
 import { parseDocumentRels, type RelsMap } from './relationships.js';
 import {
@@ -923,6 +930,27 @@ export class DocxDocument {
   ): ParagraphSpacingMutationResult {
     const result = setParagraphSpacing(this.documentXml, mutation, ctx);
     if (result.affectedParagraphs > 0) {
+      this.dirty = true;
+      this.documentViewCache = null;
+    }
+    return result;
+  }
+
+  getDirectParagraphNumbering(paragraphId: string): DirectParagraphNumbering | null {
+    return getDirectParagraphNumbering(this.documentXml, paragraphId);
+  }
+
+  setDirectParagraphNumbering(
+    mutation: ParagraphNumberingMutation,
+    ctx?: RevisionContext,
+  ): ParagraphNumberingMutationResult {
+    const result = setDirectParagraphNumbering(
+      this.documentXml,
+      this.numberingXml,
+      mutation,
+      ctx,
+    );
+    if (result.changed) {
       this.dirty = true;
       this.documentViewCache = null;
     }

--- a/packages/docx-core/src/primitives/index.ts
+++ b/packages/docx-core/src/primitives/index.ts
@@ -6,6 +6,7 @@ export * from './layout.js';
 export * from './matching.js';
 export * from './namespaces.js';
 export * from './numbering.js';
+export * from './paragraph_numbering.js';
 export * from './semantic_tags.js';
 export * from './serialize_markdown.js';
 export * from './serialize_html.js';

--- a/packages/docx-core/src/primitives/paragraph_numbering.test.ts
+++ b/packages/docx-core/src/primitives/paragraph_numbering.test.ts
@@ -13,7 +13,7 @@ import { parseXml, serializeXml } from './xml.js';
 
 const W_NS = OOXML.W_NS;
 const test = testAllure.epic('Document Comparison').withLabels({
-  feature: 'add-paragraph-numbering-formatting',
+  feature: 'Add Paragraph Numbering Formatting',
 });
 const numberingConformanceTest = test.conformance(
   { spec: 'ECMA-376', edition: 5, part: 1, section: '17.3.1.19' },

--- a/packages/docx-core/src/primitives/paragraph_numbering.test.ts
+++ b/packages/docx-core/src/primitives/paragraph_numbering.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect } from 'vitest';
+import { testAllure } from '../testing/allure-test.js';
+import { getParagraphBookmarkId, insertParagraphBookmarks } from './bookmarks.js';
+import { getDirectChildrenByName } from './dom-helpers.js';
+import { OOXML, W } from './namespaces.js';
+import {
+  ParagraphNumberingMutationError,
+  getDirectParagraphNumbering,
+  setDirectParagraphNumbering,
+} from './paragraph_numbering.js';
+import { createRevisionContext, createRevisionIdState } from './track-changes-emitter.js';
+import { parseXml, serializeXml } from './xml.js';
+
+const W_NS = OOXML.W_NS;
+const test = testAllure.epic('Document Comparison').withLabels({
+  feature: 'add-paragraph-numbering-formatting',
+});
+const numberingConformanceTest = test.conformance(
+  { spec: 'ECMA-376', edition: 5, part: 1, section: '17.3.1.19' },
+  { spec: 'ECMA-376', edition: 5, part: 1, section: '17.9.18' },
+  { spec: 'ECMA-376', edition: 5, part: 1, section: '17.9.3' },
+);
+
+function makeDocument(bodyXml: string): Document {
+  const doc = parseXml(
+    `<w:document xmlns:w="${W_NS}"><w:body>${bodyXml}</w:body></w:document>`,
+  );
+  insertParagraphBookmarks(doc, 'paragraph-numbering-test');
+  return doc;
+}
+
+function makeNumbering(): Document {
+  return parseXml(
+    `<w:numbering xmlns:w="${W_NS}">`
+      + '<w:abstractNum w:abstractNumId="1">'
+      + '<w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="lowerLetter"/><w:lvlText w:val="(%1)"/></w:lvl>'
+      + '<w:lvl w:ilvl="1"><w:start w:val="1"/><w:numFmt w:val="lowerRoman"/><w:lvlText w:val="(%2)"/></w:lvl>'
+      + '</w:abstractNum>'
+      + '<w:num w:numId="10"><w:abstractNumId w:val="1"/></w:num>'
+      + '</w:numbering>',
+  );
+}
+
+function paragraphId(doc: Document, index = 0): string {
+  const paragraph = doc.getElementsByTagNameNS(W_NS, W.p).item(index) as Element;
+  const id = getParagraphBookmarkId(paragraph);
+  if (!id) throw new Error('Expected paragraph bookmark');
+  return id;
+}
+
+function direct(parent: Element, name: string): Element {
+  const child = getDirectChildrenByName(parent, name)[0];
+  if (!child) throw new Error(`Expected ${name}`);
+  return child;
+}
+
+function attr(el: Element, name: string): string | null {
+  return el.getAttributeNS(W_NS, name) || el.getAttribute(`w:${name}`) || null;
+}
+
+describe('direct paragraph numbering mutation', () => {
+  numberingConformanceTest('sets a validated reference in schema order and preserves unrelated properties', () => {
+    const doc = makeDocument(
+      '<w:p><w:pPr><w:pStyle w:val="Body"/><w:spacing w:after="120"/></w:pPr><w:r><w:t>Alpha</w:t></w:r></w:p>',
+    );
+    const id = paragraphId(doc);
+
+    const result = setDirectParagraphNumbering(
+      doc,
+      makeNumbering(),
+      { paragraphId: id, numbering: { numId: '10', ilvl: 1 } },
+    );
+
+    expect(result).toEqual({
+      paragraphId: id,
+      changed: true,
+      previous: null,
+      current: { numId: '10', ilvl: 1 },
+    });
+    const pPr = direct(doc.getElementsByTagNameNS(W_NS, W.p).item(0) as Element, W.pPr);
+    expect(Array.from(pPr.children).map((child) => child.localName))
+      .toEqual([W.pStyle, W.numPr, W.spacing]);
+    const numPr = direct(pPr, W.numPr);
+    expect(Array.from(numPr.children).map((child) => child.localName))
+      .toEqual([W.ilvl, W.numId]);
+    expect(attr(direct(numPr, W.ilvl), W.val)).toBe('1');
+    expect(attr(direct(numPr, W.numId), W.val)).toBe('10');
+    expect(getDirectParagraphNumbering(doc, id)).toEqual({ numId: '10', ilvl: 1 });
+  });
+
+  test('emits one tracked property snapshot and makes an identical request a no-op', () => {
+    const doc = makeDocument(
+      '<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="10"/></w:numPr><w:jc w:val="left"/></w:pPr><w:r><w:t>Alpha</w:t></w:r></w:p>',
+    );
+    const id = paragraphId(doc);
+    const ctx = createRevisionContext({
+      author: 'SafeDocX AI',
+      date: '2026-07-27T12:00:00Z',
+      idState: createRevisionIdState(),
+    });
+
+    const changed = setDirectParagraphNumbering(
+      doc,
+      makeNumbering(),
+      { paragraphId: id, numbering: { numId: '10', ilvl: 1 } },
+      ctx,
+    );
+    expect(changed.changed).toBe(true);
+
+    const pPr = direct(doc.getElementsByTagNameNS(W_NS, W.p).item(0) as Element, W.pPr);
+    const change = direct(pPr, 'pPrChange');
+    expect(attr(change, 'author')).toBe('SafeDocX AI');
+    expect(attr(change, 'date')).toBe('2026-07-27T12:00:00Z');
+    const prior = direct(direct(change, W.pPr), W.numPr);
+    expect(attr(direct(prior, W.ilvl), W.val)).toBe('0');
+    expect(getDirectChildrenByName(pPr, 'pPrChange')).toHaveLength(1);
+
+    const before = serializeXml(doc);
+    const noOp = setDirectParagraphNumbering(
+      doc,
+      makeNumbering(),
+      { paragraphId: id, numbering: { numId: '10', ilvl: 1 } },
+      ctx,
+    );
+    expect(noOp.changed).toBe(false);
+    expect(serializeXml(doc)).toBe(before);
+    expect(ctx.idState.nextId).toBe(2);
+  });
+
+  test('removes direct numbering and reports absent direct numbering explicitly', () => {
+    const doc = makeDocument(
+      '<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="10"/></w:numPr></w:pPr><w:r><w:t>Alpha</w:t></w:r></w:p>'
+        + '<w:p><w:pPr><w:pStyle w:val="ListParagraph"/></w:pPr><w:r><w:t>Beta</w:t></w:r></w:p>',
+    );
+
+    expect(setDirectParagraphNumbering(
+      doc,
+      makeNumbering(),
+      { paragraphId: paragraphId(doc, 0), numbering: null },
+    )).toMatchObject({
+      changed: true,
+      previous: { numId: '10', ilvl: 0 },
+      current: null,
+    });
+    expect(setDirectParagraphNumbering(
+      doc,
+      makeNumbering(),
+      { paragraphId: paragraphId(doc, 1), numbering: null },
+    )).toMatchObject({
+      changed: false,
+      warning: expect.stringContaining('style-inherited'),
+    });
+  });
+
+  test('rejects dangling references before changing serialized XML', () => {
+    const doc = makeDocument('<w:p><w:r><w:t>Alpha</w:t></w:r></w:p>');
+    const before = serializeXml(doc);
+    expect(() => setDirectParagraphNumbering(
+      doc,
+      makeNumbering(),
+      { paragraphId: paragraphId(doc), numbering: { numId: '99', ilvl: 0 } },
+    )).toThrowError(ParagraphNumberingMutationError);
+    expect(serializeXml(doc)).toBe(before);
+
+    expect(() => setDirectParagraphNumbering(
+      doc,
+      makeNumbering(),
+      { paragraphId: paragraphId(doc), numbering: { numId: '10', ilvl: 8 } },
+    )).toThrowError(expect.objectContaining({ code: 'NUMBERING_LEVEL_NOT_FOUND' }));
+    expect(serializeXml(doc)).toBe(before);
+  });
+});

--- a/packages/docx-core/src/primitives/paragraph_numbering.ts
+++ b/packages/docx-core/src/primitives/paragraph_numbering.ts
@@ -1,0 +1,288 @@
+import { findParagraphByBookmarkId } from './bookmarks.js';
+import { getDirectChildrenByName } from './dom-helpers.js';
+import { OOXML, W } from './namespaces.js';
+import { parseNumberingXml } from './numbering.js';
+import {
+  buildPPrChangeElement,
+  type RevisionContext,
+} from './track-changes-emitter.js';
+
+export type DirectParagraphNumbering = {
+  numId: string;
+  ilvl: number;
+};
+
+export type ParagraphNumberingMutation = {
+  paragraphId: string;
+  numbering: DirectParagraphNumbering | null;
+};
+
+export type ParagraphNumberingMutationResult = {
+  paragraphId: string;
+  changed: boolean;
+  previous: DirectParagraphNumbering | null;
+  current: DirectParagraphNumbering | null;
+  warning?: string;
+};
+
+export type ParagraphNumberingMutationErrorCode =
+  | 'PARAGRAPH_NOT_FOUND'
+  | 'INCOMPLETE_NUMBERING'
+  | 'NUMBERING_PART_MISSING'
+  | 'NUMBERING_INSTANCE_NOT_FOUND'
+  | 'ABSTRACT_NUMBERING_NOT_FOUND'
+  | 'NUMBERING_LEVEL_NOT_FOUND'
+  | 'INVALID_NUMBERING_REFERENCE';
+
+export class ParagraphNumberingMutationError extends Error {
+  constructor(
+    public readonly code: ParagraphNumberingMutationErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'ParagraphNumberingMutationError';
+  }
+}
+
+function getWAttr(el: Element, localName: string): string | null {
+  return el.getAttributeNS(OOXML.W_NS, localName)
+    || el.getAttribute(`w:${localName}`)
+    || el.getAttribute(localName)
+    || null;
+}
+
+function parseDirectNumberingFromParagraph(
+  paragraph: Element,
+): { value: DirectParagraphNumbering | null; complete: boolean } {
+  const pPr = getDirectChildrenByName(paragraph, W.pPr)[0] ?? null;
+  const numPr = pPr ? getDirectChildrenByName(pPr, W.numPr)[0] ?? null : null;
+  if (!numPr) return { value: null, complete: true };
+
+  const numIdEl = getDirectChildrenByName(numPr, W.numId)[0] ?? null;
+  const ilvlEl = getDirectChildrenByName(numPr, W.ilvl)[0] ?? null;
+  const numId = numIdEl ? getWAttr(numIdEl, W.val) : null;
+  const ilvlText = ilvlEl ? getWAttr(ilvlEl, W.val) : null;
+  const ilvl = ilvlText !== null ? Number(ilvlText) : Number.NaN;
+
+  if (
+    numId === null
+    || !/^[1-9]\d*$/.test(numId)
+    || !Number.isSafeInteger(ilvl)
+    || ilvl < 0
+  ) {
+    return { value: null, complete: false };
+  }
+
+  return { value: { numId, ilvl }, complete: true };
+}
+
+/**
+ * Read only the paragraph's direct `w:numPr`; style-inherited numbering is not
+ * considered.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.3.1.19
+ * @see #653
+ */
+export function getDirectParagraphNumbering(
+  doc: Document,
+  paragraphId: string,
+): DirectParagraphNumbering | null {
+  const paragraph = findParagraphByBookmarkId(doc, paragraphId);
+  if (!paragraph) {
+    throw new ParagraphNumberingMutationError(
+      'PARAGRAPH_NOT_FOUND',
+      `Paragraph '${paragraphId}' was not found.`,
+    );
+  }
+  const parsed = parseDirectNumberingFromParagraph(paragraph);
+  if (!parsed.complete) {
+    throw new ParagraphNumberingMutationError(
+      'INCOMPLETE_NUMBERING',
+      `Paragraph '${paragraphId}' has an incomplete or invalid direct w:numPr.`,
+    );
+  }
+  return parsed.value;
+}
+
+function validateRequestedNumbering(
+  numberingDoc: Document | null,
+  requested: DirectParagraphNumbering,
+): void {
+  if (
+    !/^[1-9]\d*$/.test(requested.numId)
+    || !Number.isSafeInteger(requested.ilvl)
+    || requested.ilvl < 0
+  ) {
+    throw new ParagraphNumberingMutationError(
+      'INVALID_NUMBERING_REFERENCE',
+      'numId must be a positive decimal string and ilvl must be a non-negative safe integer.',
+    );
+  }
+  if (!numberingDoc) {
+    throw new ParagraphNumberingMutationError(
+      'NUMBERING_PART_MISSING',
+      'The document has no word/numbering.xml part.',
+    );
+  }
+
+  const model = parseNumberingXml(numberingDoc);
+  const instance = model.nums.get(requested.numId);
+  if (!instance) {
+    throw new ParagraphNumberingMutationError(
+      'NUMBERING_INSTANCE_NOT_FOUND',
+      `Numbering instance '${requested.numId}' was not found in word/numbering.xml.`,
+    );
+  }
+  const abstract = model.abstractNums.get(instance.abstractNumId);
+  if (!abstract) {
+    throw new ParagraphNumberingMutationError(
+      'ABSTRACT_NUMBERING_NOT_FOUND',
+      `Numbering instance '${requested.numId}' references missing abstract numbering '${instance.abstractNumId}'.`,
+    );
+  }
+  if (!abstract.levels.has(requested.ilvl)) {
+    throw new ParagraphNumberingMutationError(
+      'NUMBERING_LEVEL_NOT_FOUND',
+      `Numbering instance '${requested.numId}' has no level ${requested.ilvl}.`,
+    );
+  }
+}
+
+function ensureParagraphProperties(paragraph: Element): Element {
+  const existing = getDirectChildrenByName(paragraph, W.pPr)[0];
+  if (existing) return existing;
+  const pPr = paragraph.ownerDocument!.createElementNS(OOXML.W_NS, `w:${W.pPr}`);
+  paragraph.insertBefore(pPr, paragraph.firstChild);
+  return pPr;
+}
+
+function insertNumPrInSchemaOrder(pPr: Element, numPr: Element): void {
+  const successors = new Set([
+    'suppressLineNumbers',
+    'pBdr',
+    'shd',
+    'tabs',
+    'suppressAutoHyphens',
+    'kinsoku',
+    'wordWrap',
+    'overflowPunct',
+    'topLinePunct',
+    'autoSpaceDE',
+    'autoSpaceDN',
+    'bidi',
+    'adjustRightInd',
+    'snapToGrid',
+    W.spacing,
+    W.ind,
+    'contextualSpacing',
+    'mirrorIndents',
+    'suppressOverlap',
+    W.jc,
+    'textDirection',
+    'textAlignment',
+    'textboxTightWrap',
+    'outlineLvl',
+    'divId',
+    'cnfStyle',
+    W.rPr,
+    W.sectPr,
+    'pPrChange',
+  ]);
+  const successor = Array.from(pPr.children)
+    .find((child) => successors.has((child as Element).localName));
+  if (successor) pPr.insertBefore(numPr, successor);
+  else pPr.appendChild(numPr);
+}
+
+/**
+ * Mutate one paragraph's direct list reference while preserving the numbering
+ * definitions and unrelated paragraph properties.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.3.1.19
+ * @conformance ECMA-376 edition 5, Part 1 § 17.9.18
+ * @conformance ECMA-376 edition 5, Part 1 § 17.9.3
+ * @see #653
+ */
+export function setDirectParagraphNumbering(
+  documentDoc: Document,
+  numberingDoc: Document | null,
+  mutation: ParagraphNumberingMutation,
+  ctx?: RevisionContext,
+): ParagraphNumberingMutationResult {
+  const paragraph = findParagraphByBookmarkId(documentDoc, mutation.paragraphId);
+  if (!paragraph) {
+    throw new ParagraphNumberingMutationError(
+      'PARAGRAPH_NOT_FOUND',
+      `Paragraph '${mutation.paragraphId}' was not found.`,
+    );
+  }
+
+  if (mutation.numbering) {
+    validateRequestedNumbering(numberingDoc, mutation.numbering);
+  }
+
+  const parsedPrevious = parseDirectNumberingFromParagraph(paragraph);
+  const existingPPr = getDirectChildrenByName(paragraph, W.pPr)[0] ?? null;
+  const existingNumPrs = existingPPr
+    ? getDirectChildrenByName(existingPPr, W.numPr)
+    : [];
+
+  if (!mutation.numbering && existingNumPrs.length === 0) {
+    return {
+      paragraphId: mutation.paragraphId,
+      changed: false,
+      previous: null,
+      current: null,
+      warning: 'The paragraph has no direct w:numPr; style-inherited numbering was not changed.',
+    };
+  }
+
+  if (
+    mutation.numbering
+    && parsedPrevious.complete
+    && parsedPrevious.value?.numId === mutation.numbering.numId
+    && parsedPrevious.value.ilvl === mutation.numbering.ilvl
+    && existingNumPrs.length === 1
+  ) {
+    return {
+      paragraphId: mutation.paragraphId,
+      changed: false,
+      previous: parsedPrevious.value,
+      current: parsedPrevious.value,
+    };
+  }
+
+  const oldPPr = existingPPr ? existingPPr.cloneNode(true) as Element : null;
+  const pPr = mutation.numbering
+    ? ensureParagraphProperties(paragraph)
+    : existingPPr!;
+
+  for (const stale of getDirectChildrenByName(pPr, W.numPr)) {
+    pPr.removeChild(stale);
+  }
+
+  if (mutation.numbering) {
+    const numPr = documentDoc.createElementNS(OOXML.W_NS, `w:${W.numPr}`);
+    const ilvl = documentDoc.createElementNS(OOXML.W_NS, `w:${W.ilvl}`);
+    ilvl.setAttributeNS(OOXML.W_NS, `w:${W.val}`, String(mutation.numbering.ilvl));
+    const numId = documentDoc.createElementNS(OOXML.W_NS, `w:${W.numId}`);
+    numId.setAttributeNS(OOXML.W_NS, `w:${W.val}`, mutation.numbering.numId);
+    numPr.appendChild(ilvl);
+    numPr.appendChild(numId);
+    insertNumPrInSchemaOrder(pPr, numPr);
+  }
+
+  if (ctx) {
+    for (const stale of getDirectChildrenByName(pPr, 'pPrChange')) {
+      pPr.removeChild(stale);
+    }
+    pPr.appendChild(buildPPrChangeElement(oldPPr, ctx));
+  }
+
+  return {
+    paragraphId: mutation.paragraphId,
+    changed: true,
+    previous: parsedPrevious.complete ? parsedPrevious.value : null,
+    current: mutation.numbering,
+  };
+}

--- a/packages/docx-mcp/docs/tool-reference.generated.md
+++ b/packages/docx-mcp/docs/tool-reference.generated.md
@@ -173,6 +173,23 @@ Apply layout controls (paragraph spacing, table row height, cell padding). Googl
 | `row_height` | `object` | no |  |
 | `cell_padding` | `object` | no |  |
 
+## `format_numbering`
+
+Change one DOCX body paragraph’s direct numbering reference. Use remove=true to drop direct w:numPr, match_paragraph_id to adopt another paragraph’s explicit numbering, or num_id with ilvl to reference an existing numbering definition. This tool does not create numbering definitions or change style-inherited numbering. Effective edits emit a native w:pPrChange; identical requests are no-ops.
+
+- readOnly: `false`
+- destructive: `true`
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `file_path` | `string` | no | Path to the DOCX or ODT file. |
+| `google_doc_id` | `string` | no | Google Doc ID or URL (alternative to file_path). Extract from URL: docs.google.com/document/d/{ID}/edit |
+| `target_paragraph_id` | `string` | yes | Target paragraph anchor returned by read_file. |
+| `remove` | `boolean` | no | Set true to remove the target paragraph’s direct w:numPr. |
+| `match_paragraph_id` | `string` | no | Copy this paragraph’s complete direct num_id and ilvl to the target. |
+| `num_id` | `string` | no | Existing positive decimal w:numId from this DOCX; requires ilvl. |
+| `ilvl` | `integer` | no | Existing numbering level for num_id; requires num_id. |
+
 ## `accept_changes`
 
 Accept all tracked changes in the document body, producing a clean document with no revision markup. Returns acceptance stats.

--- a/packages/docx-mcp/src/add_typescript_mcp_server.test.ts
+++ b/packages/docx-mcp/src/add_typescript_mcp_server.test.ts
@@ -70,6 +70,7 @@ describe('TypeScript MCP server behavior', () => {
       'replace_text',
       'insert_paragraph',
       'format_layout',
+      'format_numbering',
       'save',
       'has_tracked_changes',
       'get_file_status',
@@ -97,7 +98,7 @@ describe('TypeScript MCP server behavior', () => {
   });
 
   humanReadableTest.openspec('Destructive tools annotated correctly')('Scenario: Destructive tools annotated correctly', async () => {
-    const destructiveTools = new Set(['batch_edit', 'replace_text', 'insert_paragraph', 'format_layout', 'save']);
+    const destructiveTools = new Set(['batch_edit', 'replace_text', 'insert_paragraph', 'format_layout', 'format_numbering', 'save']);
     for (const tool of MCP_TOOLS) {
       if (!destructiveTools.has(tool.name)) continue;
       expect(tool.annotations.readOnlyHint).toBe(false);

--- a/packages/docx-mcp/src/server.ts
+++ b/packages/docx-mcp/src/server.ts
@@ -18,6 +18,7 @@ import { getFileStatus } from './tools/get_file_status.js';
 import { hasTrackedChanges_tool } from './tools/has_tracked_changes.js';
 import { closeFile } from './tools/close_file.js';
 import { formatLayout } from './tools/format_layout.js';
+import { formatNumbering } from './tools/format_numbering.js';
 import { acceptChanges } from './tools/accept_changes.js';
 import { acceptAiEdits } from './tools/accept_ai_edits.js';
 import { rejectAiEdits } from './tools/reject_ai_edits.js';
@@ -185,6 +186,10 @@ export async function dispatchToolCall(
     case 'format_layout':
       if (isGDocsRequest(args)) return await dispatchGDocs(sessions, args, 'format_layout');
       return await formatLayout(sessions, args as Parameters<typeof formatLayout>[1]);
+    case 'format_numbering':
+      if (isGDocsRequest(args)) return await dispatchGDocs(sessions, args, 'format_numbering');
+      if (isOdfRequest(args)) return await dispatchOdf(sessions, args, 'format_numbering');
+      return await formatNumbering(sessions, args as Parameters<typeof formatNumbering>[1]);
     case 'accept_changes':
       return await acceptChanges(sessions, args as Parameters<typeof acceptChanges>[1]);
     case 'accept_ai_edits':

--- a/packages/docx-mcp/src/tool_catalog.ts
+++ b/packages/docx-mcp/src/tool_catalog.ts
@@ -336,6 +336,38 @@ export const SAFE_DOCX_TOOL_CATALOG = [
     annotations: { readOnlyHint: false, destructiveHint: true },
   },
   {
+    name: 'format_numbering',
+    surface: 'revisionable',
+    description:
+      'Change one DOCX body paragraph’s direct numbering reference. Use remove=true to drop direct w:numPr, match_paragraph_id to adopt another paragraph’s explicit numbering, or num_id with ilvl to reference an existing numbering definition. This tool does not create numbering definitions or change style-inherited numbering. Effective edits emit a native w:pPrChange; identical requests are no-ops.',
+    input: z.object({
+      ...FILE_FIELD_OPTIONAL,
+      ...GOOGLE_DOC_ID_FIELD,
+      target_paragraph_id: z
+        .string()
+        .describe('Target paragraph anchor returned by read_file.'),
+      remove: z
+        .boolean()
+        .optional()
+        .describe('Set true to remove the target paragraph’s direct w:numPr.'),
+      match_paragraph_id: z
+        .string()
+        .optional()
+        .describe('Copy this paragraph’s complete direct num_id and ilvl to the target.'),
+      num_id: z
+        .string()
+        .optional()
+        .describe('Existing positive decimal w:numId from this DOCX; requires ilvl.'),
+      ilvl: z
+        .number()
+        .int()
+        .nonnegative()
+        .optional()
+        .describe('Existing numbering level for num_id; requires num_id.'),
+    }),
+    annotations: { readOnlyHint: false, destructiveHint: true },
+  },
+  {
     name: 'accept_changes',
     surface: 'internal',
     description: 'Accept all tracked changes in the document body, producing a clean document with no revision markup. Returns acceptance stats.',

--- a/packages/docx-mcp/src/tools/forbid_untracked_ai_mutations.test.ts
+++ b/packages/docx-mcp/src/tools/forbid_untracked_ai_mutations.test.ts
@@ -13,6 +13,7 @@ import { deleteComment } from './delete_comment.js';
 import { batchEdit } from './batch_edit.js';
 import { clearFormatting } from './clear_formatting.js';
 import { formatLayout } from './format_layout.js';
+import { formatNumbering } from './format_numbering.js';
 import { insertParagraph } from './insert_paragraph.js';
 import { replaceText } from './replace_text.js';
 import { save } from './save.js';
@@ -129,6 +130,18 @@ const REVISIONABLE_EDITORS: Array<{
       formatLayout(mgr, {
         file_path: filePath,
         paragraph_spacing: { paragraph_ids: [firstParaId], before_twips: 240 },
+      }),
+  },
+  {
+    name: 'format_numbering',
+    bodyXml:
+      '<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr></w:pPr>'
+      + '<w:r><w:t>Alpha bravo charlie</w:t></w:r></w:p>',
+    run: (mgr, filePath, firstParaId) =>
+      formatNumbering(mgr, {
+        file_path: filePath,
+        target_paragraph_id: firstParaId,
+        remove: true,
       }),
   },
   {

--- a/packages/docx-mcp/src/tools/format_numbering.test.ts
+++ b/packages/docx-mcp/src/tools/format_numbering.test.ts
@@ -1,0 +1,369 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { describe, expect } from 'vitest';
+import { readZipText } from '@usejunior/docx-core';
+import { dispatchToolCall } from '../server.js';
+import { testAllure } from '../testing/allure-test.js';
+import {
+  assertFailure,
+  assertSuccess,
+  createTestSessionManager,
+  openSession,
+  registerCleanup,
+} from '../testing/session-test-utils.js';
+import { acceptAiEdits } from './accept_ai_edits.js';
+import { formatNumbering } from './format_numbering.js';
+import { readFile } from './read_file.js';
+import { rejectAiEdits } from './reject_ai_edits.js';
+import { save } from './save.js';
+
+const TEST_FEATURE = 'add-paragraph-numbering-formatting';
+const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const test = testAllure.epic('Document Editing').withLabels({ feature: TEST_FEATURE });
+
+const DOCUMENT_XML =
+  `<w:document xmlns:w="${W_NS}"><w:body>`
+  + '<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="10"/></w:numPr></w:pPr><w:r><w:t>Alpha item</w:t></w:r></w:p>'
+  + '<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="20"/></w:numPr><w:spacing w:after="120"/></w:pPr><w:r><w:t>Beta item</w:t></w:r></w:p>'
+  + '<w:p><w:pPr><w:pStyle w:val="ListParagraph"/></w:pPr><w:r><w:t>Plain item</w:t></w:r></w:p>'
+  + '</w:body></w:document>';
+
+const NUMBERING_XML =
+  `<w:numbering xmlns:w="${W_NS}">`
+  + '<w:abstractNum w:abstractNumId="1">'
+  + '<w:lvl w:ilvl="0"><w:start w:val="1"/><w:numFmt w:val="lowerLetter"/><w:lvlText w:val="(%1)"/></w:lvl>'
+  + '<w:lvl w:ilvl="1"><w:start w:val="1"/><w:numFmt w:val="lowerRoman"/><w:lvlText w:val="(%2)"/></w:lvl>'
+  + '</w:abstractNum>'
+  + '<w:num w:numId="10"><w:abstractNumId w:val="1"/></w:num>'
+  + '<w:num w:numId="20"><w:abstractNumId w:val="1"/></w:num>'
+  + '</w:numbering>';
+
+async function openNumberingSession() {
+  const mgr = createTestSessionManager({ defaultAiAuthor: 'SafeDocX AI' });
+  return openSession([], {
+    mgr,
+    xml: DOCUMENT_XML,
+    extraFiles: {
+      'word/numbering.xml': NUMBERING_XML,
+      'word/custom-preserved.xml': '<root keep="yes"/>',
+    },
+  });
+}
+
+async function sessionNumbering(
+  opened: Awaited<ReturnType<typeof openNumberingSession>>,
+  index: number,
+) {
+  const session = await opened.mgr.getSessionByFilePath(opened.inputPath);
+  if (!session || session.provider !== 'docx') throw new Error('Expected DOCX session');
+  return session.doc.getDirectParagraphNumbering(opened.paraIds[index]!);
+}
+
+registerCleanup();
+
+describe('OpenSpec traceability: paragraph numbering formatting', () => {
+  test.openspec('Remove direct paragraph numbering')(
+    'removes direct numbering without changing paragraph text',
+    async () => {
+      const opened = await openNumberingSession();
+      const result = await formatNumbering(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.paraIds[1],
+        remove: true,
+      });
+      assertSuccess(result, 'format_numbering');
+      expect(result.changed).toBe(true);
+      expect(result.previous_numbering).toEqual({ num_id: '20', ilvl: 0 });
+      expect(result.resulting_numbering).toBeNull();
+      expect(await sessionNumbering(opened, 1)).toBeNull();
+      const reread = await readFile(opened.mgr, { file_path: opened.inputPath });
+      assertSuccess(reread, 'read_file');
+      expect(String(reread.content)).toContain('Beta item');
+    },
+  );
+
+  test.openspec("Match another paragraph's explicit numbering")(
+    'copies the source reference and joins its visible sequence',
+    async () => {
+      const opened = await openNumberingSession();
+      const result = await formatNumbering(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.paraIds[1],
+        match_paragraph_id: opened.paraIds[0],
+      });
+      assertSuccess(result, 'format_numbering');
+      expect(result.resulting_numbering).toEqual({ num_id: '10', ilvl: 0 });
+      const reread = await readFile(opened.mgr, { file_path: opened.inputPath, format: 'json' });
+      assertSuccess(reread, 'read_file');
+      const nodes = JSON.parse(String(reread.content)) as Array<{
+        text: string;
+        list_label: string;
+      }>;
+      expect(nodes.find((node) => node.text === 'Alpha item')?.list_label).toBe('(a)');
+      expect(nodes.find((node) => node.text === 'Beta item')?.list_label).toBe('(b)');
+    },
+  );
+
+  test.openspec('Set an existing numbering reference directly')(
+    'sets an existing instance and level',
+    async () => {
+      const opened = await openNumberingSession();
+      const result = await formatNumbering(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.paraIds[2],
+        num_id: '10',
+        ilvl: 1,
+      });
+      assertSuccess(result, 'format_numbering');
+      expect(await sessionNumbering(opened, 2)).toEqual({ numId: '10', ilvl: 1 });
+    },
+  );
+
+  test.openspec('Identical direct numbering is a deterministic no-op')(
+    'does not increment edit accounting for an identical request',
+    async () => {
+      const opened = await openNumberingSession();
+      const first = await formatNumbering(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.paraIds[1],
+        num_id: '10',
+        ilvl: 0,
+      });
+      assertSuccess(first, 'format_numbering');
+      const session = await opened.mgr.getSessionByFilePath(opened.inputPath);
+      const editCount = session?.editCount;
+      const second = await formatNumbering(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.paraIds[1],
+        num_id: '10',
+        ilvl: 0,
+      });
+      assertSuccess(second, 'format_numbering');
+      expect(second.changed).toBe(false);
+      expect(session?.editCount).toBe(editCount);
+    },
+  );
+
+  test.openspec('Mutually exclusive operation forms are enforced')(
+    'rejects combined and incomplete operation forms',
+    async () => {
+      const opened = await openNumberingSession();
+      const combined = await formatNumbering(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.paraIds[1],
+        remove: true,
+        num_id: '10',
+        ilvl: 0,
+      });
+      assertFailure(combined, 'VALIDATION_ERROR');
+      const incomplete = await formatNumbering(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.paraIds[1],
+        num_id: '10',
+      });
+      assertFailure(incomplete, 'VALIDATION_ERROR');
+    },
+  );
+
+  test.openspec('Match source must have complete direct numbering')(
+    'rejects an unnumbered match source',
+    async () => {
+      const opened = await openNumberingSession();
+      const result = await formatNumbering(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.paraIds[1],
+        match_paragraph_id: opened.paraIds[2],
+      });
+      assertFailure(result, 'SOURCE_NUMBERING_NOT_DIRECT');
+      expect(await sessionNumbering(opened, 1)).toEqual({ numId: '20', ilvl: 0 });
+    },
+  );
+
+  test.openspec('Dangling numbering references are rejected before mutation')(
+    'rejects missing instances and levels transactionally',
+    async () => {
+      const opened = await openNumberingSession();
+      const missingInstance = await formatNumbering(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.paraIds[1],
+        num_id: '99',
+        ilvl: 0,
+      });
+      assertFailure(missingInstance, 'NUMBERING_INSTANCE_NOT_FOUND');
+      const missingLevel = await formatNumbering(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.paraIds[1],
+        num_id: '10',
+        ilvl: 8,
+      });
+      assertFailure(missingLevel, 'NUMBERING_LEVEL_NOT_FOUND');
+      expect(await sessionNumbering(opened, 1)).toEqual({ numId: '20', ilvl: 0 });
+    },
+  );
+
+  test('returns a structured error for a missing target anchor', async () => {
+    const opened = await openNumberingSession();
+    const result = await formatNumbering(opened.mgr, {
+      file_path: opened.inputPath,
+      target_paragraph_id: '_bk_missing',
+      remove: true,
+    });
+    assertFailure(result, 'PARAGRAPH_NOT_FOUND');
+  });
+
+  test.openspec('Removing absent direct numbering is explicit')(
+    'returns a warning without changing style-inherited state',
+    async () => {
+      const opened = await openNumberingSession();
+      const result = await formatNumbering(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.paraIds[2],
+        remove: true,
+      });
+      assertSuccess(result, 'format_numbering');
+      expect(result.changed).toBe(false);
+      expect(result.warning).toContain('style-inherited');
+    },
+  );
+
+  test.openspec('Unsupported providers are rejected')(
+    'uses provider chokepoints for ODT and Google Docs',
+    async () => {
+      const manager = createTestSessionManager();
+      const odt = await dispatchToolCall(manager, 'format_numbering', {
+        file_path: '/tmp/not-opened-numbering-test.odt',
+        target_paragraph_id: '_bk_target',
+        remove: true,
+      });
+      assertFailure(
+        odt as { success: boolean; error?: { code?: string } },
+        'UNSUPPORTED_FOR_ODF',
+      );
+      const gdocs = await dispatchToolCall(manager, 'format_numbering', {
+        google_doc_id: 'fake-id',
+        target_paragraph_id: '_bk_target',
+        remove: true,
+      });
+      assertFailure(
+        gdocs as { success: boolean; error?: { code?: string } },
+        'UNSUPPORTED_FOR_PROVIDER',
+      );
+    },
+  );
+
+  test.openspec('Effective numbering change emits prior properties')(
+    'emits one pPrChange with session metadata and old numPr',
+    async () => {
+      const opened = await openNumberingSession();
+      const result = await formatNumbering(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.paraIds[1],
+        match_paragraph_id: opened.paraIds[0],
+      });
+      assertSuccess(result, 'format_numbering');
+      const session = await opened.mgr.getSessionByFilePath(opened.inputPath);
+      if (!session || session.provider !== 'docx') throw new Error('Expected DOCX session');
+      const packed = await session.doc.toBuffer({ cleanBookmarks: false });
+      const xml = await readZipText(packed.buffer, 'word/document.xml');
+      expect(xml?.match(/<w:pPrChange\b/g)).toHaveLength(1);
+      expect(xml).toContain('w:author="SafeDocX AI"');
+      expect(xml).toMatch(/<w:pPrChange[^>]*>[\s\S]*?<w:numId w:val="20"/);
+    },
+  );
+
+  test.openspec('Clean and tracked saves represent the same numbering edit')(
+    'persists current numbering cleanly and keeps tracked review markup',
+    async () => {
+      const opened = await openNumberingSession();
+      assertSuccess(await formatNumbering(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.paraIds[1],
+        match_paragraph_id: opened.paraIds[0],
+      }), 'format_numbering');
+      const cleanPath = path.join(opened.tmpDir, 'numbering-clean.docx');
+      const trackedPath = path.join(opened.tmpDir, 'numbering-tracked.docx');
+      const saved = await save(opened.mgr, {
+        file_path: opened.inputPath,
+        save_to_local_path: cleanPath,
+        tracked_save_to_local_path: trackedPath,
+        save_format: 'both',
+      });
+      assertSuccess(saved, 'save');
+      const cleanXml = await readZipText(await fs.readFile(cleanPath), 'word/document.xml');
+      const trackedXml = await readZipText(await fs.readFile(trackedPath), 'word/document.xml');
+      expect(cleanXml).toContain('<w:numId w:val="10"/>');
+      expect(trackedXml).toContain('<w:pPrChange');
+    },
+  );
+
+  test.openspec('Standard accept and reject semantics cover numbering changes')(
+    'keeps current numbering on accept and restores old numbering on reject',
+    async () => {
+      const accepted = await openNumberingSession();
+      assertSuccess(await formatNumbering(accepted.mgr, {
+        file_path: accepted.inputPath,
+        target_paragraph_id: accepted.paraIds[1],
+        match_paragraph_id: accepted.paraIds[0],
+      }), 'format_numbering');
+      assertSuccess(await acceptAiEdits(accepted.mgr, {
+        file_path: accepted.inputPath,
+        author: 'SafeDocX AI',
+      }), 'accept_ai_edits');
+      expect(await sessionNumbering(accepted, 1)).toEqual({ numId: '10', ilvl: 0 });
+
+      const rejected = await openNumberingSession();
+      assertSuccess(await formatNumbering(rejected.mgr, {
+        file_path: rejected.inputPath,
+        target_paragraph_id: rejected.paraIds[1],
+        match_paragraph_id: rejected.paraIds[0],
+      }), 'format_numbering');
+      assertSuccess(await rejectAiEdits(rejected.mgr, {
+        file_path: rejected.inputPath,
+        author: 'SafeDocX AI',
+      }), 'reject_ai_edits');
+      expect(await sessionNumbering(rejected, 1)).toEqual({ numId: '20', ilvl: 0 });
+    },
+  );
+
+  test.openspec('Text and paragraph anchors remain stable')(
+    'preserves paragraph count, text, and every anchor',
+    async () => {
+      const opened = await openNumberingSession();
+      const before = await readFile(opened.mgr, { file_path: opened.inputPath });
+      assertSuccess(before, 'read_file');
+      assertSuccess(await formatNumbering(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.paraIds[1],
+        remove: true,
+      }), 'format_numbering');
+      const after = await readFile(opened.mgr, { file_path: opened.inputPath });
+      assertSuccess(after, 'read_file');
+      expect(after.total_paragraphs).toBe(before.total_paragraphs);
+      for (const id of opened.paraIds) expect(String(after.content)).toContain(id);
+      for (const text of ['Alpha item', 'Beta item', 'Plain item']) {
+        expect(String(after.content)).toContain(text);
+      }
+    },
+  );
+
+  test.openspec('Non-target package content remains unchanged')(
+    'preserves numbering definitions and an unrelated package part',
+    async () => {
+      const opened = await openNumberingSession();
+      assertSuccess(await formatNumbering(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.paraIds[1],
+        match_paragraph_id: opened.paraIds[0],
+      }), 'format_numbering');
+      const output = path.join(opened.tmpDir, 'preserved.docx');
+      assertSuccess(await save(opened.mgr, {
+        file_path: opened.inputPath,
+        save_to_local_path: output,
+        save_format: 'tracked',
+      }), 'save');
+      const bytes = await fs.readFile(output);
+      expect(await readZipText(bytes, 'word/numbering.xml')).toBe(NUMBERING_XML);
+      expect(await readZipText(bytes, 'word/custom-preserved.xml')).toBe('<root keep="yes"/>');
+    },
+  );
+});

--- a/packages/docx-mcp/src/tools/format_numbering.ts
+++ b/packages/docx-mcp/src/tools/format_numbering.ts
@@ -1,0 +1,234 @@
+import {
+  ParagraphNumberingMutationError,
+  type DirectParagraphNumbering,
+} from '@usejunior/docx-core';
+import { errorMessage } from '../error_utils.js';
+import { getRevisionContextForSession, type SessionManager } from '../session/manager.js';
+import { preflightAiRevisionMutation } from './ai_revision_guard.js';
+import { mergeSessionResolutionMetadata, resolveSessionForTool } from './session_resolution.js';
+import { err, ok, type ToolResponse } from './types.js';
+
+export type FormatNumberingParams = {
+  file_path?: string;
+  target_paragraph_id?: unknown;
+  remove?: unknown;
+  match_paragraph_id?: unknown;
+  num_id?: unknown;
+  ilvl?: unknown;
+};
+
+type ParsedOperation =
+  | { kind: 'remove'; numbering: null }
+  | { kind: 'match'; sourceParagraphId: string; numbering: DirectParagraphNumbering }
+  | { kind: 'set'; numbering: DirectParagraphNumbering };
+
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0
+    ? value.trim()
+    : null;
+}
+
+function mutationHint(code: ParagraphNumberingMutationError['code']): string {
+  switch (code) {
+    case 'PARAGRAPH_NOT_FOUND':
+      return 'Re-read the document and pass a current paragraph anchor.';
+    case 'INCOMPLETE_NUMBERING':
+      return 'Choose a source paragraph with a complete direct num_id and ilvl, or repair the malformed OOXML first.';
+    case 'NUMBERING_PART_MISSING':
+      return 'Choose a paragraph from a DOCX that already contains numbering definitions.';
+    case 'NUMBERING_INSTANCE_NOT_FOUND':
+    case 'ABSTRACT_NUMBERING_NOT_FOUND':
+      return 'Use read_file to select an existing paragraph numbering reference from this document.';
+    case 'NUMBERING_LEVEL_NOT_FOUND':
+      return 'Use a level that exists on the selected numbering instance, or match a valid numbered paragraph.';
+    case 'INVALID_NUMBERING_REFERENCE':
+      return 'Pass num_id as a positive decimal string and ilvl as a non-negative integer.';
+  }
+}
+
+function parseTargetParagraphId(value: unknown): string | ToolResponse {
+  const target = nonEmptyString(value);
+  if (!target) {
+    return err(
+      'VALIDATION_ERROR',
+      'target_paragraph_id must be a non-empty string.',
+      'Pass a paragraph anchor returned by read_file.',
+    );
+  }
+  return target;
+}
+
+function isToolResponse(value: string | ToolResponse): value is ToolResponse {
+  return typeof value !== 'string';
+}
+
+function parseOperationShape(params: FormatNumberingParams):
+  | { kind: 'remove' }
+  | { kind: 'match'; sourceParagraphId: string }
+  | { kind: 'set'; numbering: DirectParagraphNumbering }
+  | ToolResponse {
+  if (params.remove !== undefined && typeof params.remove !== 'boolean') {
+    return err('VALIDATION_ERROR', 'remove must be a boolean.', 'Pass remove=true, or omit remove.');
+  }
+
+  const removeSelected = params.remove === true;
+  const matchProvided = params.match_paragraph_id !== undefined;
+  const directProvided = params.num_id !== undefined || params.ilvl !== undefined;
+  const selectedCount = Number(removeSelected) + Number(matchProvided) + Number(directProvided);
+  if (selectedCount !== 1) {
+    return err(
+      'VALIDATION_ERROR',
+      'Provide exactly one numbering operation: remove, match_paragraph_id, or num_id with ilvl.',
+      'Use remove=true; or match_paragraph_id="_bk_..."; or provide both num_id="..." and ilvl=0.',
+    );
+  }
+
+  if (removeSelected) return { kind: 'remove' };
+
+  if (matchProvided) {
+    const sourceParagraphId = nonEmptyString(params.match_paragraph_id);
+    if (!sourceParagraphId) {
+      return err(
+        'VALIDATION_ERROR',
+        'match_paragraph_id must be a non-empty string.',
+        'Pass an anchored paragraph with complete direct numbering.',
+      );
+    }
+    return { kind: 'match', sourceParagraphId };
+  }
+
+  if (typeof params.num_id !== 'string' || !/^[1-9]\d*$/.test(params.num_id)) {
+    return err(
+      'VALIDATION_ERROR',
+      'num_id must be a positive decimal string.',
+      'Pass both num_id="..." and ilvl=0 using an existing reference from read_file.',
+    );
+  }
+  if (
+    typeof params.ilvl !== 'number'
+    || !Number.isSafeInteger(params.ilvl)
+    || params.ilvl < 0
+  ) {
+    return err(
+      'VALIDATION_ERROR',
+      'ilvl must be a non-negative safe integer.',
+      'Pass both num_id="..." and an existing ilvl such as 0.',
+    );
+  }
+  return {
+    kind: 'set',
+    numbering: { numId: params.num_id, ilvl: params.ilvl },
+  };
+}
+
+export async function formatNumbering(
+  manager: SessionManager,
+  params: FormatNumberingParams,
+): Promise<ToolResponse> {
+  try {
+    const targetParagraphId = parseTargetParagraphId(params.target_paragraph_id);
+    if (isToolResponse(targetParagraphId)) return targetParagraphId;
+
+    const operationShape = parseOperationShape(params);
+    if ('success' in operationShape) return operationShape;
+
+    const resolved = await resolveSessionForTool(manager, params, {
+      toolName: 'format_numbering',
+    });
+    if (!resolved.ok) return resolved.response;
+    const { session, metadata } = resolved;
+
+    let operation: ParsedOperation;
+    if (operationShape.kind === 'remove') {
+      operation = { kind: 'remove', numbering: null };
+    } else if (operationShape.kind === 'set') {
+      operation = operationShape;
+    } else {
+      const numbering = session.doc.getDirectParagraphNumbering(
+        operationShape.sourceParagraphId,
+      );
+      if (!numbering) {
+        return err(
+          'SOURCE_NUMBERING_NOT_DIRECT',
+          `Paragraph '${operationShape.sourceParagraphId}' has no direct w:numPr.`,
+          'Choose a source whose read_file numbering is explicit, or pass num_id with ilvl directly.',
+        );
+      }
+      operation = {
+        kind: 'match',
+        sourceParagraphId: operationShape.sourceParagraphId,
+        numbering,
+      };
+    }
+
+    // Resolve the target before allocating revision metadata, and validate the
+    // requested numbering through the same primitive used for the live edit.
+    if (!session.doc.getParagraphElementById(targetParagraphId)) {
+      return err(
+        'PARAGRAPH_NOT_FOUND',
+        `Paragraph '${targetParagraphId}' was not found.`,
+        'Re-read the document and pass a current paragraph anchor.',
+      );
+    }
+    const ctx = await getRevisionContextForSession(session);
+    const revisionPreflight = await preflightAiRevisionMutation(
+      session,
+      ctx,
+      (previewDoc, previewCtx) => {
+        previewDoc.setDirectParagraphNumbering(
+          { paragraphId: targetParagraphId, numbering: operation.numbering },
+          previewCtx,
+        );
+      },
+    );
+    if (revisionPreflight) return revisionPreflight;
+
+    const paragraphCountBefore = session.doc.getParagraphs().length;
+    const result = session.doc.setDirectParagraphNumbering(
+      { paragraphId: targetParagraphId, numbering: operation.numbering },
+      ctx,
+    );
+    const paragraphCountAfter = session.doc.getParagraphs().length;
+    if (paragraphCountBefore !== paragraphCountAfter) {
+      return err(
+        'INVARIANT_VIOLATION',
+        `Numbering formatting changed paragraph count (${paragraphCountBefore} -> ${paragraphCountAfter}).`,
+        'Paragraph numbering mutations must preserve document structure.',
+      );
+    }
+
+    if (result.changed) manager.markEdited(session);
+    manager.touch(session);
+
+    return ok(mergeSessionResolutionMetadata({
+      file_path: manager.normalizePath(session.originalPath),
+      target_paragraph_id: targetParagraphId,
+      operation: operation.kind,
+      match_paragraph_id: operation.kind === 'match'
+        ? operation.sourceParagraphId
+        : undefined,
+      changed: result.changed,
+      previous_numbering: result.previous
+        ? { num_id: result.previous.numId, ilvl: result.previous.ilvl }
+        : null,
+      resulting_numbering: result.current
+        ? { num_id: result.current.numId, ilvl: result.current.ilvl }
+        : null,
+      warning: result.warning,
+      paragraph_count_before: paragraphCountBefore,
+      paragraph_count_after: paragraphCountAfter,
+      message: result.changed
+        ? 'Paragraph direct numbering updated with a tracked property change.'
+        : 'Paragraph direct numbering already matched the requested state; no edit was recorded.',
+    }, metadata));
+  } catch (error: unknown) {
+    if (error instanceof ParagraphNumberingMutationError) {
+      return err(error.code, error.message, mutationHint(error.code));
+    }
+    return err(
+      'FORMAT_NUMBERING_ERROR',
+      `Failed to apply paragraph numbering: ${errorMessage(error)}`,
+      'Check paragraph anchors and numbering references, then retry.',
+    );
+  }
+}

--- a/packages/safe-docx-mcpb/manifest.json
+++ b/packages/safe-docx-mcpb/manifest.json
@@ -61,6 +61,10 @@
       "description": "Apply deterministic paragraph/table layout formatting controls."
     },
     {
+      "name": "format_numbering",
+      "description": "Change one DOCX paragraph's direct numbering reference using existing numbering definitions."
+    },
+    {
       "name": "accept_changes",
       "description": "Accept tracked changes in the document body."
     },

--- a/spec-compliance/CONFORMANCE.md
+++ b/spec-compliance/CONFORMANCE.md
@@ -89,8 +89,8 @@ Allure labels via `testAllure.conformance({…})`; source code carries
 | `ECMA-PART1-17-9-1` | w:abstractNum abstract numbering definition | 5 | 1 | 17.9.1 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:abstractNum` | — |
 | `ECMA-PART1-17-9-2` | w:abstractNumId abstract definition reference | 5 | 1 | 17.9.2 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:abstractNumId` | — |
 | `ECMA-PART1-17-9-15` | w:num numbering definition instance | 5 | 1 | 17.9.15 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:num` | — |
-| `ECMA-PART1-17-9-18` | w:numId numbering instance reference | 5 | 1 | 17.9.18 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:numId` | — |
-| `ECMA-PART1-17-9-3` | w:ilvl numbering level reference | 5 | 1 | 17.9.3 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:ilvl` | — |
+| `ECMA-PART1-17-9-18` | w:numId numbering instance reference | 5 | 1 | 17.9.18 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:numId` | packages/docx-core/src/primitives/paragraph_numbering.ts; packages/docx-core/src/primitives/paragraph_numbering.test.ts |
+| `ECMA-PART1-17-9-3` | w:ilvl numbering level reference | 5 | 1 | 17.9.3 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:ilvl` | packages/docx-core/src/primitives/paragraph_numbering.ts; packages/docx-core/src/primitives/paragraph_numbering.test.ts |
 | `ECMA-PART1-17-9-6` | w:lvl numbering level definition | 5 | 1 | 17.9.6 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:lvl` | — |
 | `ECMA-PART1-17-9-22` | w:pStyle numbering-level paragraph style | 5 | 1 | 17.9.22 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:pStyle` | packages/docx-core/src/primitives/numbering.ts; packages/docx-core/test-primitives/heading_provenance.traceability.test.ts |
 | `ECMA-PART1-17-9-17` | w:numFmt numbering format | 5 | 1 | 17.9.17 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:numFmt` | — |
@@ -99,7 +99,7 @@ Allure labels via `testAllure.conformance({…})`; source code carries
 | `ECMA-PART1-17-9-28` | w:suff content between numbering symbol and text | 5 | 1 | 17.9.28 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:suff` | — |
 | `ECMA-PART1-17-9-12` | w:multiLevelType abstract definition type | 5 | 1 | 17.9.12 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:multiLevelType` | — |
 | `ECMA-PART1-17-9-7` | w:lvlJc numbering level justification | 5 | 1 | 17.9.7 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:lvlJc` | — |
-| `ECMA-PART1-17-3-1-19` | w:numPr paragraph numbering reference | 5 | 1 | 17.3.1.19 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:numPr` | — |
+| `ECMA-PART1-17-3-1-19` | w:numPr paragraph numbering reference | 5 | 1 | 17.3.1.19 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:numPr` | packages/docx-core/src/primitives/paragraph_numbering.ts; packages/docx-core/src/primitives/paragraph_numbering.test.ts |
 | `ECMA-PART1-17-13-4-6` | w:comments comment-collection part emission | 5 | 1 | 17.13.4.6 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:comments` | packages/docx-core/src/generation/emit/comments-part.ts; packages/docx-core/src/generation/generation-drafting-notes.test.ts |
 | `ECMA-PART1-17-13-4-2` | w:comment comment content emission | 5 | 1 | 17.13.4.2 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:comment` | packages/docx-core/src/generation/emit/comments-part.ts; packages/docx-core/src/generation/generation-drafting-notes.test.ts |
 | `ECMA-PART1-17-13-4-4` | w:commentRangeStart comment anchor opening | 5 | 1 | 17.13.4.4 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:commentRangeStart` | packages/docx-core/src/generation/emit/paragraph.ts; packages/docx-core/src/generation/generation-drafting-notes.test.ts |
@@ -1119,10 +1119,11 @@ paragraph references bind through.
 - **Part / Section:** Part 1 § 17.9.18
 - **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
 - **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:numId`
+- **Verified by:** packages/docx-core/src/primitives/paragraph_numbering.ts; packages/docx-core/src/primitives/paragraph_numbering.test.ts
 
-List paragraphs reference their instance via `w:numId` inside `w:numPr`;
-spec validation rejects handles with no declared definition
-(`dangling_numbering_reference`) before any XML is produced.
+List paragraphs reference their instance via `w:numId` inside `w:numPr`.
+Generation and paragraph mutation validate that the instance exists before
+emitting or changing document XML.
 
 ### ECMA-PART1-17-9-3 — w:ilvl numbering level reference
 
@@ -1130,10 +1131,11 @@ spec validation rejects handles with no declared definition
 - **Part / Section:** Part 1 § 17.9.3
 - **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
 - **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:ilvl`
+- **Verified by:** packages/docx-core/src/primitives/paragraph_numbering.ts; packages/docx-core/src/primitives/paragraph_numbering.test.ts
 
 The paragraph's level reference is emitted before `w:numId` per the
-CT_NumPr sequence, and validation requires the referenced level to exist
-in the bound definition.
+CT_NumPr sequence. Generation and paragraph mutation require the referenced
+level to exist in the bound definition.
 
 ### ECMA-PART1-17-9-6 — w:lvl numbering level definition
 
@@ -1231,10 +1233,11 @@ differing widths on their right edge — the standard legal-outline convention.
 - **Part / Section:** Part 1 § 17.3.1.19
 - **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
 - **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:numPr`
+- **Verified by:** packages/docx-core/src/primitives/paragraph_numbering.ts; packages/docx-core/src/primitives/paragraph_numbering.test.ts
 
-List paragraphs carry `w:numPr` (ilvl then numId) at its CT_PPrBase slot
-via the PPR_ORDER table; the numeric id comes from the numbering part's
-deterministic handle map.
+List paragraphs carry `w:numPr` (ilvl then numId) at its CT_PPrBase slot.
+Generation binds deterministic handles; paragraph mutation can remove or
+re-point a direct reference while preserving the numbering definitions.
 
 ### ECMA-PART1-17-13-4-6 — w:comments comment-collection part emission
 

--- a/spec-compliance/registry/ecma-376.md
+++ b/spec-compliance/registry/ecma-376.md
@@ -1266,12 +1266,12 @@ part: 1
 section: "17.9.18"
 url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
 schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:numId
-verifiedBy:
+verifiedBy: packages/docx-core/src/primitives/paragraph_numbering.ts; packages/docx-core/src/primitives/paragraph_numbering.test.ts
 ```
 
-List paragraphs reference their instance via `w:numId` inside `w:numPr`;
-spec validation rejects handles with no declared definition
-(`dangling_numbering_reference`) before any XML is produced.
+List paragraphs reference their instance via `w:numId` inside `w:numPr`.
+Generation and paragraph mutation validate that the instance exists before
+emitting or changing document XML.
 
 ## [ECMA-PART1-17-9-3] w:ilvl numbering level reference
 
@@ -1281,12 +1281,12 @@ part: 1
 section: "17.9.3"
 url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
 schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:ilvl
-verifiedBy:
+verifiedBy: packages/docx-core/src/primitives/paragraph_numbering.ts; packages/docx-core/src/primitives/paragraph_numbering.test.ts
 ```
 
 The paragraph's level reference is emitted before `w:numId` per the
-CT_NumPr sequence, and validation requires the referenced level to exist
-in the bound definition.
+CT_NumPr sequence. Generation and paragraph mutation require the referenced
+level to exist in the bound definition.
 
 ## [ECMA-PART1-17-9-6] w:lvl numbering level definition
 
@@ -1417,12 +1417,12 @@ part: 1
 section: "17.3.1.19"
 url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
 schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:numPr
-verifiedBy:
+verifiedBy: packages/docx-core/src/primitives/paragraph_numbering.ts; packages/docx-core/src/primitives/paragraph_numbering.test.ts
 ```
 
-List paragraphs carry `w:numPr` (ilvl then numId) at its CT_PPrBase slot
-via the PPR_ORDER table; the numeric id comes from the numbering part's
-deterministic handle map.
+List paragraphs carry `w:numPr` (ilvl then numId) at its CT_PPrBase slot.
+Generation binds deterministic handles; paragraph mutation can remove or
+re-point a direct reference while preserving the numbering definitions.
 
 ## [ECMA-PART1-17-13-4-6] w:comments comment-collection part emission
 


### PR DESCRIPTION
Closes #653

## Summary

- add a typed `docx-core` primitive for reading and mutating a paragraph's direct `w:numPr`
- add the revisionable, DOCX-only `format_numbering` MCP tool with remove, match-paragraph, and existing `num_id`/`ilvl` modes
- validate numbering instances, abstract definitions, and levels transactionally before mutation
- emit native `w:pPrChange` records for effective edits while keeping identical requests deterministic no-ops
- register the tool in the catalog, MCP bundle manifest, generated reference, and tutorial
- add the approved OpenSpec change and ECMA-376 §17.3.1.19, §17.9.18, and §17.9.3 evidence

## Deliberate v1 boundaries

- uses existing numbering definitions only; it does not create `word/numbering.xml` definitions
- changes direct paragraph numbering only; it does not rewrite style-inherited numbering
- guarantees structural/reference correctness, not a visible label in isolation from surrounding list context

## Validation

- `npm run build && npm run lint:workspaces && npm run test:run && npm run check:spec-coverage && npm run check:conformance-citations && npm run check:conformance-doc`
- `npm run check:tool-docs`
- `npm run check:site`
- `npx openspec validate add-paragraph-numbering-formatting --strict`
- focused regression set: 75 tests passed

## Real-DOCX smoke

Exercised `tests/test_documents/nvca-coi-regression/source.docx` end to end:

- removed direct numbering from a real numbered paragraph
- preserved paragraph count (234 → 234), paragraph text, and `word/numbering.xml` byte-for-byte
- clean save reread with no direct numbering/list label
- tracked save contained exactly one modification and one `w:pPrChange`
- clean and tracked DOCX archives passed `unzip -t`; `word/document.xml` passed `xmllint`
- source, clean, and tracked outputs rendered successfully in headless LibreOffice; inspected page 2 and confirmed the target label removal with surrounding text/layout intact