### PR TITLE
test(docx-compare): retire fixed corpus expectations

### DIFF
--- a/packages/docx-compare/src/integration/real-corpus-paragraph-deletion.test.ts
+++ b/packages/docx-compare/src/integration/real-corpus-paragraph-deletion.test.ts
@@ -86,19 +86,10 @@ const boundaryShiftFailure: ExpectedFailure = {
   messageIncludes: 'boundary 0 changed paragraph ownership, moved, or mutated',
 };
 
-const nestedFieldFailure: ExpectedFailure = {
-  issue: '#645',
-  kind: 'comparison-error',
-  errorName: 'AncillaryStorySafetyError',
-  messageIncludes: 'Ancillary story safety check failed with 3 issue(s)',
-};
-
 const expectedFailures: Readonly<
   Record<string, Partial<Record<ReconstructionMode, ExpectedFailure>>>
 > = {
-  'nvca-certificate-of-incorporation': { rebuild: boundaryShiftFailure },
   'nvca-indemnification-agreement': {
-    inplace: nestedFieldFailure,
     rebuild: {
       issue: '#646',
       kind: 'comparison-error',
@@ -120,7 +111,6 @@ const expectedFailures: Readonly<
       kind: 'bookmark-range-failure',
       names: ['_Ref_ContractCompanion_9kb9Ur019'],
     },
-    rebuild: boundaryShiftFailure,
   },
   'nvca-stock-purchase-agreement': {
     rebuild: {

--- a/packages/docx-compare/src/integration/real-corpus-paragraph-deletion.test.ts
+++ b/packages/docx-compare/src/integration/real-corpus-paragraph-deletion.test.ts
@@ -79,13 +79,6 @@ type ExpectedFailure =
 
 const corpusEntries = JSON.parse(readFileSync(MANIFEST_PATH, 'utf8')) as CorpusEntry[];
 
-const boundaryShiftFailure: ExpectedFailure = {
-  issue: '#646',
-  kind: 'comparison-error',
-  errorName: 'OpaquePassthroughError',
-  messageIncludes: 'boundary 0 changed paragraph ownership, moved, or mutated',
-};
-
 const expectedFailures: Readonly<
   Record<string, Partial<Record<ReconstructionMode, ExpectedFailure>>>
 > = {


### PR DESCRIPTION
## Summary

- remove three stale real-corpus expected-failure entries that now pass after the already-merged #645 and #646 fixes
- retain the remaining corpus characterizations that still reproduce
- restore the currently failing `main` real-corpus gate without changing comparison behavior

## Evidence

Current main CI fails because these cells return `pass` while the test still expects `comparison-error`:

- NVCA certificate of incorporation × rebuild (#646)
- NVCA indemnification agreement × inplace (#645)
- NVCA ROFR/co-sale agreement × rebuild (#646)

## Validation

`SAFE_DOCX_REAL_CORPUS_DIR=/private/tmp/safe-docx-real-corpus SAFE_DOCX_REAL_CORPUS_REQUIRED=1 npm run test:run -w @usejunior/docx-compare -- src/integration/real-corpus-paragraph-deletion.test.ts`

Result: 16/16 real-corpus cells passed against the SHA-256-verified corpus.