### PR TITLE
test(docx-core): complete numbering emission evidence

### DIFF
--- a/packages/docx-core/SUPPORT.md
+++ b/packages/docx-core/SUPPORT.md
@@ -16,6 +16,7 @@ The "OOXML revision element" column uses ECMA-376 element names from the tracked
 | `layout.ts` — `setParagraphSpacing` | `packages/docx-core/src/primitives/layout.ts` | `w:pPrChange` | Paragraph spacing mutations change paragraph properties, not spacer-paragraph structure. **Verified by [120.8] (#143) regression test.** |
 | `layout.ts` — `setTableRowHeight` | `packages/docx-core/src/primitives/layout.ts` | `w:trPrChange` | Row geometry changes belong under row-property revisions. **Verified by [120.8] (#143) regression test.** |
 | `layout.ts` — `setTableCellPadding` | `packages/docx-core/src/primitives/layout.ts` | `w:tcPrChange` | Cell padding changes belong under cell-property revisions. **Verified by [120.8] (#143) regression test.** |
+| `paragraph_numbering.ts` — `setDirectParagraphNumbering` | `packages/docx-core/src/primitives/paragraph_numbering.ts` | `w:pPrChange` | Direct `w:numPr` assignment, replacement, and removal preserve the prior paragraph properties under a native property-change revision. **Verified by the #653 canonical-emission regression test.** |
 | `comments.ts` — `addComment` | `packages/docx-core/src/primitives/comments.ts` | `w:ins` | Only the body-story `w:commentReference` run is wrapped in `w:ins`; range markers and root-comment text in `comments.xml` are not revision-wrapped. Comment body text, author metadata, and package bootstrap are listed in Table B. **Verified by [120.8] (#143) regression test.** |
 | `comments.ts` — `deleteComment` | `packages/docx-core/src/primitives/comments.ts` | `w:del` | Only the removed body-story `w:commentReference` run is wrapped in `w:del`; range markers are removed structurally, and comment/reply text removal from `comments.xml` is a Table B side-part mutation. `commentsExtended.xml` cleanup is also the Table B companion. **Verified by [120.8] (#143) regression test.** |
 | `footnotes.ts` — `addFootnote` | `packages/docx-core/src/primitives/footnotes.ts` | `w:ins` | The inserted `w:footnoteReference` in the body story and the new footnote text both belong to the revisionable surface. Companion package bootstrap is listed in Table B. **Verified by [120.8] (#143) regression test.** |
@@ -26,6 +27,7 @@ The "OOXML revision element" column uses ECMA-376 element names from the tracked
 | `batch_edit` | `packages/docx-mcp/src/tools/batch_edit.ts` | `w:ins`, `w:del`, `w:pPrChange`, `w:rPrChange` | Batch execution is only an orchestrator, but every applied step delegates to revisionable body-edit primitives. **Verified by [120.8] (#143) regression test.** |
 | `clear_formatting` | `packages/docx-mcp/src/tools/clear_formatting.ts` | `w:rPrChange` | Run-property clearing is a run formatting revision, not a package mutation. **Verified by [120.8] (#143) regression test.** |
 | `format_layout` | `packages/docx-mcp/src/tools/format_layout.ts` | `w:pPrChange`, `w:trPrChange`, `w:tcPrChange` | Deterministic OOXML geometry edits belong under native property-change revisions. **Verified by [120.8] (#143) regression test.** |
+| `format_numbering` | `packages/docx-mcp/src/tools/format_numbering.ts` | `w:pPrChange` | DOCX-only direct paragraph numbering changes delegate to the canonical numbering primitive and retain the previous `w:numPr` in tracked output. **Verified by the #653 canonical-emission MCP regression test.** |
 | `add_comment` | `packages/docx-mcp/src/tools/add_comment.ts` | `w:ins` (root-comment mode only) | Root-comment mode wraps only the body-story `w:commentReference` run in `w:ins`; range markers and root-comment text in `comments.xml` are not revision-wrapped. **Reply-mode** dispatches through `comments.ts` `addCommentReply` which is Table B (side-part metadata only; no body revision marker). Missing comment infrastructure is also a Table B companion. **Verified by [120.8] (#143) regression test.** |
 | `delete_comment` | `packages/docx-mcp/src/tools/delete_comment.ts` | `w:del` | Comment deletion wraps only the removed body-story `w:commentReference` run in `w:del`; range markers and `comments.xml` comment/reply text are removed as Table B side-part/structural mutations. `commentsExtended.xml` cleanup is the Table B companion. **Verified by [120.8] (#143) regression test.** |
 | `add_footnote` | `packages/docx-mcp/src/tools/add_footnote.ts` | `w:ins` | Footnote reference insertion and note-body creation are revisionable content. Missing footnote infrastructure is the Table B companion. **Verified by [120.8] (#143) regression test.** |
@@ -211,6 +213,7 @@ This appendix is deliberately mechanical. It makes it easy to audit that every n
 - `merge_runs.ts` — Internal / non-contract utilities
 - `namespaces.ts` — Internal / non-contract utilities
 - `numbering.ts` — Internal / non-contract utilities
+- `paragraph_numbering.ts` — Table A
 - `prevent_double_elevation.ts` — Internal / non-contract utilities
 - `reject_changes.ts` — Internal / non-contract utilities
 - `relationships.ts` — Internal / non-contract utilities
@@ -239,6 +242,7 @@ This appendix is deliberately mechanical. It makes it easy to audit that every n
 - `docx_archive_guard.ts` — Internal / non-contract utilities
 - `extract_revisions.ts` — Internal / non-contract utilities
 - `format_layout.ts` — Table A
+- `format_numbering.ts` — Table A
 - `get_comments.ts` — Internal / non-contract utilities
 - `get_file_status.ts` — Internal / non-contract utilities
 - `get_footnotes.ts` — Internal / non-contract utilities

--- a/packages/docx-core/src/integration/canonical-emission-regression.test.ts
+++ b/packages/docx-core/src/integration/canonical-emission-regression.test.ts
@@ -16,6 +16,11 @@ import { buildSyntheticDocx, getResultParts } from './synthetic-docx-fixture.js'
 const test = testAllure.epic('Document Comparison').withLabels({
   feature: 'Canonical Emission Regression',
 });
+const numberingTest = test.conformance(
+  { spec: 'ECMA-376', edition: 5, part: 1, section: '17.3.1.19' },
+  { spec: 'ECMA-376', edition: 5, part: 1, section: '17.9.18' },
+  { spec: 'ECMA-376', edition: 5, part: 1, section: '17.9.3' },
+);
 
 const AI_AUTHOR = 'SafeDocX';
 const FIXED_DATE = '2026-05-07T12:00:00Z';
@@ -202,6 +207,46 @@ describe('Canonical emission catalog', () => {
 
     await then('the paragraph properties change wrapper carries revision metadata', () => {
       expectTrackedElementsWithFixedMetadata(documentXml, ['pPrChange']);
+    });
+  });
+
+  numberingTest('Table A: paragraph_numbering.ts setDirectParagraphNumbering emits w:pPrChange', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    let documentXml: string;
+
+    await given('a directly numbered paragraph and its numbering definitions', async () => {
+      const numberingXml =
+        `<w:numbering xmlns:w="${W_NS}">`
+        + '<w:abstractNum w:abstractNumId="1">'
+        + '<w:lvl w:ilvl="0"><w:numFmt w:val="decimal"/><w:lvlText w:val="%1."/></w:lvl>'
+        + '<w:lvl w:ilvl="1"><w:numFmt w:val="lowerLetter"/><w:lvlText w:val="%2."/></w:lvl>'
+        + '</w:abstractNum>'
+        + '<w:num w:numId="10"><w:abstractNumId w:val="1"/></w:num>'
+        + '</w:numbering>';
+      const { doc, paragraphIds } = await loadIndexedDoc(
+        await makeMinimalDocx(
+          '<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="10"/></w:numPr></w:pPr><w:r><w:t>Numbered</w:t></w:r></w:p>',
+          { 'word/numbering.xml': numberingXml },
+        ),
+      );
+
+      await when('tracked direct numbering is changed to another valid level', async () => {
+        doc.setDirectParagraphNumbering(
+          { paragraphId: paragraphIds[0]!, numbering: { numId: '10', ilvl: 1 } },
+          createCtx(),
+        );
+        ({ parts: { 'word/document.xml': documentXml } } = await toPartMap(doc, ['word/document.xml']));
+      });
+    });
+
+    await then('the paragraph property change preserves the prior numbering with revision metadata', () => {
+      expectTrackedElementsWithFixedMetadata(documentXml, ['pPrChange']);
+      const change = elementsByName(documentXml, 'pPrChange')[0]!;
+      const priorIlvl = change.getElementsByTagNameNS(W_NS, 'ilvl')[0] as Element;
+      expect(wordAttr(priorIlvl, 'val')).toBe('0');
     });
   });
 

--- a/packages/docx-mcp/src/integration/canonical-emission-mcp.test.ts
+++ b/packages/docx-mcp/src/integration/canonical-emission-mcp.test.ts
@@ -10,6 +10,7 @@ import { insertParagraph } from '../tools/insert_paragraph.js';
 import { batchEdit } from '../tools/batch_edit.js';
 import { clearFormatting } from '../tools/clear_formatting.js';
 import { formatLayout } from '../tools/format_layout.js';
+import { formatNumbering } from '../tools/format_numbering.js';
 import { addComment } from '../tools/add_comment.js';
 import { deleteComment } from '../tools/delete_comment.js';
 import { addFootnote } from '../tools/add_footnote.js';
@@ -20,6 +21,11 @@ import { save } from '../tools/save.js';
 const test = testAllure.epic('Document Editing').withLabels({
   feature: 'Canonical Emission MCP Regression',
 });
+const numberingTest = test.conformance(
+  { spec: 'ECMA-376', edition: 5, part: 1, section: '17.3.1.19' },
+  { spec: 'ECMA-376', edition: 5, part: 1, section: '17.9.18' },
+  { spec: 'ECMA-376', edition: 5, part: 1, section: '17.9.3' },
+);
 
 const AI_AUTHOR = 'SafeDocX';
 const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
@@ -312,6 +318,60 @@ describe('Tool integration through SessionManager: canonical revision emission',
 
     await then('document.xml contains SafeDocX-authored layout property changes', () => {
       expectTrackedElementsWithAuthor(documentXml, ['pPrChange', 'trPrChange', 'tcPrChange']);
+    });
+  });
+
+  numberingTest('format_numbering saves a SafeDocX-authored paragraph property change', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    let opened: Awaited<ReturnType<typeof openSession>>;
+    let documentXml: string;
+
+    await given('a tracked session with a directly numbered paragraph', async () => {
+      opened = await openSession([], {
+        mgr: createManager(),
+        xml: makeDocXml(
+          '<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="10"/></w:numPr></w:pPr><w:r><w:t>Numbered</w:t></w:r></w:p>',
+        ),
+        extraFiles: {
+          'word/numbering.xml':
+            `<w:numbering xmlns:w="${W_NS}">`
+            + '<w:abstractNum w:abstractNumId="1">'
+            + '<w:lvl w:ilvl="0"><w:numFmt w:val="decimal"/><w:lvlText w:val="%1."/></w:lvl>'
+            + '<w:lvl w:ilvl="1"><w:numFmt w:val="lowerLetter"/><w:lvlText w:val="%2."/></w:lvl>'
+            + '</w:abstractNum>'
+            + '<w:num w:numId="10"><w:abstractNumId w:val="1"/></w:num>'
+            + '</w:numbering>',
+        },
+      });
+    });
+
+    await when('format_numbering changes the direct list level and saves tracked output', async () => {
+      const formatted = await formatNumbering(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.firstParaId,
+        num_id: '10',
+        ilvl: 1,
+      });
+      assertSuccess(formatted, 'format_numbering');
+
+      const parts = await saveAndReadParts(
+        opened.mgr,
+        opened.inputPath,
+        path.join(opened.tmpDir, 'format-numbering-regression.docx'),
+        ['word/document.xml'],
+      );
+      documentXml = parts['word/document.xml'];
+    });
+
+    await then('document.xml contains a SafeDocX-authored paragraph property change', () => {
+      expectTrackedElementsWithAuthor(documentXml, ['pPrChange']);
+      const doc = parseXml(documentXml);
+      const change = doc.getElementsByTagNameNS(W_NS, 'pPrChange')[0] as Element;
+      const priorIlvl = change.getElementsByTagNameNS(W_NS, 'ilvl')[0] as Element;
+      expect(wordAttr(priorIlvl, 'val')).toBe('0');
     });
   });
 


### PR DESCRIPTION
## Summary

- classify `setDirectParagraphNumbering` and `format_numbering` in the supported revisionable editing surface
- add core canonical-emission coverage for prior `w:numPr` preservation under `w:pPrChange`
- add MCP tracked-save coverage proving authored revision metadata survives serialization

This is the focused follow-up to the advisory review on #673.

Ref: #653

## Validation

- `npm run build`
- `npm run lint:workspaces`
- `npm run test:run`
- `npm run check:spec-coverage`
- `npm run check:conformance-citations`
- `npm run check:conformance-doc`
- focused canonical-emission tests: 26/26 passed