### PR TITLE
fix(docx-compare): exclude rsid attributes from run-merge identity

### DIFF
--- a/packages/docx-compare/src/atomizer.test.ts
+++ b/packages/docx-compare/src/atomizer.test.ts
@@ -10,6 +10,7 @@ import {
   createComparisonUnitAtom,
   atomizeTree,
   getAncestors,
+  splitAtomsIntoWords,
   EMPTY_PARAGRAPH_TAG,
 } from './atomizer.js';
 import { CorrelationStatus, OpcPart } from '@usejunior/docx-core';
@@ -1347,6 +1348,80 @@ describe('getAncestors', () => {
       expect(ancestors[1]).toBe(body);
       expect(ancestors[2]).toBe(para);
       expect(ancestors[3]).toBe(run);
+    });
+  });
+});
+
+describe('splitAtomsIntoWords edge punctuation', () => {
+  const PART: OpcPart = { uri: 'word/document.xml', contentType: 'text/xml' };
+
+  function wordTexts(text: string): string[] {
+    const textEl = el('w:t', {}, undefined, text);
+    const run = el('w:r', {}, [textEl]);
+    const paragraph = el('w:p', {}, [run]);
+    const atom = createComparisonUnitAtom({
+      contentElement: textEl,
+      ancestors: [paragraph, run],
+      part: PART,
+    });
+    return splitAtomsIntoWords([atom]).map((a) => a.contentElement.textContent ?? '');
+  }
+
+  test('splits bracket edges into their own atoms', async ({ given, when, then }: AllureBddContext) => {
+    let tokens: string[];
+
+    await given('text with template brackets "[or officer]"', () => {});
+
+    await when('the atom is word-split', () => {
+      tokens = wordTexts('[or officer]');
+    });
+
+    await then('brackets become separate atoms so the words can match a bracketless side', () => {
+      // Tokenization must be a pure function of paragraph text: "[or officer]"
+      // vs "or officer" must share the "or" and "officer" atoms (issue #675).
+      expect(tokens).toEqual(['[', 'or', ' ', 'officer', ']']);
+    });
+  });
+
+  test('keeps currency amounts as single atoms', async ({ given, when, then }: AllureBddContext) => {
+    let tokens: string[];
+
+    await given('text containing a currency amount', () => {});
+
+    await when('the atom is word-split', () => {
+      tokens = wordTexts('exceed $204,000.00 net');
+    });
+
+    await then('the amount stays one atom; interior and currency punctuation stay glued', () => {
+      expect(tokens).toEqual(['exceed', ' ', '$204,000.00', ' ', 'net']);
+    });
+  });
+
+  test('splits trailing sentence punctuation', async ({ given, when, then }: AllureBddContext) => {
+    let tokens: string[];
+
+    await given('a single-token atom with trailing punctuation', () => {});
+
+    await when('the atom is word-split', () => {
+      tokens = wordTexts('Conduct,');
+    });
+
+    await then('the comma becomes its own atom, matching a "Conduct" + "," run split', () => {
+      expect(tokens).toEqual(['Conduct', ',']);
+    });
+  });
+
+  test('leaves pure punctuation tokens intact', async ({ given, when, then }: AllureBddContext) => {
+    let tokens: string[];
+
+    await given('a token made only of punctuation', () => {});
+
+    await when('the atom is word-split', () => {
+      tokens = wordTexts('a ). b');
+    });
+
+    await then('the punctuation token stays a single atom', () => {
+      expect(tokens).toEqual(['a', ' ', ').', ' ', 'b']);
     });
   });
 });

--- a/packages/docx-compare/src/atomizer.ts
+++ b/packages/docx-compare/src/atomizer.ts
@@ -863,9 +863,15 @@ export function atomizeTree(
     : mergedAtoms;
 
   // Step 4: Merge punctuation-only atoms with preceding text
-  // This handles "Conduct" + "," vs "Conduct," split differences
-  // Must run AFTER word split since that's when punctuation becomes separate atoms
-  const atoms = mergePunctuationAtoms(wordSplitAtoms, normalizedOptions);
+  // This handles "Conduct" + "," vs "Conduct," split differences for
+  // run-level atomization. When word-splitting ran, edge punctuation was
+  // already split into its own atoms on BOTH sides (splitTokenAtPunctuationEdges),
+  // which normalizes the same boundary differences symmetrically; re-gluing
+  // here would depend on run structure and re-introduce asymmetric tokens
+  // (e.g. "officer]" on one side vs "officer" + "]" on the other).
+  const atoms = normalizedOptions.splitTextIntoWords
+    ? wordSplitAtoms
+    : mergePunctuationAtoms(wordSplitAtoms, normalizedOptions);
 
   console.log(
     `[DEBUG] atomizeTree: created ${rawAtoms.length} atoms, field-collapsed to ${fieldCollapsedAtoms.length}, merged to ${mergedAtoms.length}, word-split to ${wordSplitAtoms.length}, punct-merged to ${atoms.length}, ${state.emptyParagraphCount} empty paragraphs`
@@ -1132,6 +1138,40 @@ export function collapseFieldSequences(
  * @param atom - A w:t atom to split
  * @returns Array of word-level atoms (or original atom if not w:t)
  */
+/**
+ * Punctuation classes split off token edges by {@link splitAtomIntoWords}.
+ *
+ * The trailing class mirrors {@link isPunctuationOnlyAtom}; the leading class
+ * holds the matching openers. Kept deliberately narrow: currency/percent signs
+ * and interior punctuation (e.g. "$204,000.00", "don't") stay glued to their
+ * token so figures remain single atoms on both sides of a comparison.
+ */
+const LEADING_EDGE_PUNCTUATION = /^['"(\[{<]+/;
+const TRAILING_EDGE_PUNCTUATION = /[,.:;!?'")\]}>]+$/;
+
+/**
+ * Split a whitespace-free token into leading punctuation, core, and trailing
+ * punctuation parts, dropping empty parts.
+ *
+ * Tokenization must be a pure function of paragraph text — not of run
+ * boundaries — or identical text on the two sides of a comparison can
+ * tokenize differently and produce delete+insert pairs over unchanged words.
+ * Splitting edge punctuation into its own atoms keeps a punctuation-only edit
+ * (e.g. removing template brackets: "[or officer]" -> "or officer") from
+ * consuming its neighbouring unchanged words (issue #675).
+ */
+function splitTokenAtPunctuationEdges(token: string): string[] {
+  const leading = LEADING_EDGE_PUNCTUATION.exec(token)?.[0] ?? '';
+  let core = token.slice(leading.length);
+  const trailing = TRAILING_EDGE_PUNCTUATION.exec(core)?.[0] ?? '';
+  core = core.slice(0, core.length - trailing.length);
+  const parts: string[] = [];
+  if (leading) parts.push(leading);
+  if (core) parts.push(core);
+  if (trailing) parts.push(trailing);
+  return parts.length > 0 ? parts : [token];
+}
+
 function splitAtomIntoWords(atom: ComparisonUnitAtom): ComparisonUnitAtom[] {
   // Only split w:t elements
   if (atom.contentElement.tagName !== 'w:t') {
@@ -1145,14 +1185,18 @@ function splitAtomIntoWords(atom: ComparisonUnitAtom): ComparisonUnitAtom[] {
 
   const text = getLeafText(atom.contentElement) ?? '';
 
-  // Don't split short text or single words
-  if (text.length <= 1 || !text.includes(' ')) {
+  // Don't split short text
+  if (text.length <= 1) {
     return [atom];
   }
 
-  // Split into words and whitespace, preserving both
-  // Uses regex to split on word boundaries while keeping whitespace
-  const parts = text.split(/(\s+)/);
+  // Split into words and whitespace, preserving both, then split edge
+  // punctuation off each word so tokenization does not depend on how runs
+  // happened to fragment the text.
+  const parts = text
+    .split(/(\s+)/)
+    .filter((part) => part !== '')
+    .flatMap((part) => (/^\s+$/.test(part) ? [part] : splitTokenAtPunctuationEdges(part)));
   if (parts.length <= 1) {
     return [atom];
   }

--- a/packages/docx-compare/src/atomizer.ts
+++ b/packages/docx-compare/src/atomizer.ts
@@ -1145,9 +1145,13 @@ export function collapseFieldSequences(
  * holds the matching openers. Kept deliberately narrow: currency/percent signs
  * and interior punctuation (e.g. "$204,000.00", "don't") stay glued to their
  * token so figures remain single atoms on both sides of a comparison.
+ *
+ * Implemented as character sets scanned linearly (not regexes) because the
+ * input is document-controlled text and an end-anchored `[...]+$` pattern is
+ * quadratic on adversarial inputs (CodeQL js/polynomial-redos).
  */
-const LEADING_EDGE_PUNCTUATION = /^['"(\[{<]+/;
-const TRAILING_EDGE_PUNCTUATION = /[,.:;!?'")\]}>]+$/;
+const LEADING_EDGE_PUNCTUATION = new Set(["'", '"', '(', '[', '{', '<']);
+const TRAILING_EDGE_PUNCTUATION = new Set([',', '.', ':', ';', '!', '?', "'", '"', ')', ']', '}', '>']);
 
 /**
  * Split a whitespace-free token into leading punctuation, core, and trailing
@@ -1161,14 +1165,18 @@ const TRAILING_EDGE_PUNCTUATION = /[,.:;!?'")\]}>]+$/;
  * consuming its neighbouring unchanged words (issue #675).
  */
 function splitTokenAtPunctuationEdges(token: string): string[] {
-  const leading = LEADING_EDGE_PUNCTUATION.exec(token)?.[0] ?? '';
-  let core = token.slice(leading.length);
-  const trailing = TRAILING_EDGE_PUNCTUATION.exec(core)?.[0] ?? '';
-  core = core.slice(0, core.length - trailing.length);
+  let coreStart = 0;
+  while (coreStart < token.length && LEADING_EDGE_PUNCTUATION.has(token[coreStart]!)) {
+    coreStart++;
+  }
+  let coreEnd = token.length;
+  while (coreEnd > coreStart && TRAILING_EDGE_PUNCTUATION.has(token[coreEnd - 1]!)) {
+    coreEnd--;
+  }
   const parts: string[] = [];
-  if (leading) parts.push(leading);
-  if (core) parts.push(core);
-  if (trailing) parts.push(trailing);
+  if (coreStart > 0) parts.push(token.slice(0, coreStart));
+  if (coreEnd > coreStart) parts.push(token.slice(coreStart, coreEnd));
+  if (coreEnd < token.length) parts.push(token.slice(coreEnd));
   return parts.length > 0 ? parts : [token];
 }
 

--- a/packages/docx-compare/src/baselines/atomizer/premergeRuns.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/premergeRuns.test.ts
@@ -1,7 +1,10 @@
+import JSZip from 'jszip';
 import { describe, expect } from 'vitest';
+import { compareDocuments } from '../../index.js';
 import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
 import { premergeAdjacentRuns } from './premergeRuns.js';
 import { el } from '../../testing/dom-test-helpers.js';
+import { buildDocxFromBodyXml } from '../../testing/ooxml-fixtures.js';
 import { childElements, getLeafText } from '@usejunior/docx-core';
 import { assertDefined } from '../../testing/test-utils.js';
 
@@ -82,11 +85,66 @@ describe('premergeAdjacentRuns', () => {
     });
   });
 
-  test('does not merge runs when run attributes differ', async ({ given, when, then }: AllureBddContext) => {
+  test('does not merge runs when non-rsid run attributes differ', async ({ given, when, then }: AllureBddContext) => {
     let p: Element;
     let merges: number;
 
-    await given('two runs with different w:rsidRPr attributes', () => {
+    await given('two runs with different non-rsid attributes', () => {
+      // The strict OOXML run schema only defines rsid attributes on w:r, but
+      // extension/foreign attributes occur in the wild — stay conservative and
+      // refuse to merge when any non-rsid attribute differs.
+      const r1 = el('w:r', { 'w:author': 'alice' }, [el('w:t', {}, undefined, 'A')]);
+      const r2 = el('w:r', { 'w:author': 'bob' }, [el('w:t', {}, undefined, 'B')]);
+      p = el('w:p', {}, [r1, r2]);
+    });
+
+    await when('premergeAdjacentRuns is called', () => {
+      merges = premergeAdjacentRuns(p);
+    });
+
+    await then('no merges are reported and both runs remain', () => {
+      expect(merges).toBe(0);
+      expect(childElements(p)).toHaveLength(2);
+    });
+  });
+
+  test('merges runs whose attributes differ only by rsids', async ({ given, when, then, and }: AllureBddContext) => {
+    let p: Element;
+    let merges: number;
+
+    await given('three runs where the middle run lacks w:rsidRPr (issue #675 shape)', () => {
+      // Word produces this shape when a token is retyped in a later editing
+      // session: the fragments differ only in revision-save identifiers.
+      const r1 = el('w:r', { 'w:rsidRPr': '00F9719D', 'w:rsidR': '00932CCC' }, [el('w:t', { 'xml:space': 'preserve' }, undefined, '$')]);
+      const r2 = el('w:r', { 'w:rsidR': '00932CCC' }, [el('w:t', {}, undefined, '204')]);
+      const r3 = el('w:r', { 'w:rsidRPr': '00F9719D', 'w:rsidR': '00932CCC' }, [el('w:t', {}, undefined, ',000.00')]);
+      p = el('w:p', {}, [r1, r2, r3]);
+    });
+
+    await when('premergeAdjacentRuns is called', () => {
+      merges = premergeAdjacentRuns(p);
+    });
+
+    await then('all three runs collapse into one', () => {
+      expect(merges).toBe(2);
+      expect(childElements(p)).toHaveLength(1);
+      const merged = childElements(p)[0]!;
+      const textChildren = childElements(merged).filter((c) => c.tagName === 'w:t');
+      expect(textChildren.map((c) => getLeafText(c) ?? '').join('')).toBe('$204,000.00');
+    });
+
+    await and('the merged run keeps the first run\'s rsid attributes', () => {
+      const merged = childElements(p)[0]!;
+      expect(merged.getAttribute('w:rsidRPr')).toBe('00F9719D');
+      expect(merged.getAttribute('w:rsidR')).toBe('00932CCC');
+    });
+  });
+
+  test('merges runs with entirely different rsid values', async ({ given, when, then }: AllureBddContext) => {
+    let p: Element;
+    let merges: number;
+
+    await given('two runs with different w:rsidRPr values and identical formatting', () => {
       const r1 = el('w:r', { 'w:rsidRPr': 'AAAA' }, [el('w:t', {}, undefined, 'A')]);
       const r2 = el('w:r', { 'w:rsidRPr': 'BBBB' }, [el('w:t', {}, undefined, 'B')]);
       p = el('w:p', {}, [r1, r2]);
@@ -96,7 +154,54 @@ describe('premergeAdjacentRuns', () => {
       merges = premergeAdjacentRuns(p);
     });
 
+    await then('one merge is reported and the runs collapse into one', () => {
+      expect(merges).toBe(1);
+      expect(childElements(p)).toHaveLength(1);
+    });
+  });
+
+  test('merges pretty-printed runs containing whitespace-only text nodes', async ({ given, when, then }: AllureBddContext) => {
+    let p: Element;
+    let merges: number;
+
+    await given('two runs with indentation text nodes as direct children', () => {
+      // Pretty-printed document.xml puts whitespace text nodes inside every
+      // run; that whitespace is insignificant and must not block merging.
+      const r1 = el('w:r', {}, [el('w:t', {}, undefined, 'Hello')], '\n        ');
+      const r2 = el('w:r', {}, [el('w:t', {}, undefined, ' world')], '\n        ');
+      p = el('w:p', {}, [r1, r2]);
+    });
+
+    await when('premergeAdjacentRuns is called', () => {
+      merges = premergeAdjacentRuns(p);
+    });
+
+    await then('one merge is reported and text concatenates across the runs', () => {
+      expect(merges).toBe(1);
+      expect(childElements(p)).toHaveLength(1);
+      const merged = childElements(p)[0]!;
+      const textChildren = childElements(merged).filter((c) => c.tagName === 'w:t');
+      expect(textChildren.map((c) => getLeafText(c) ?? '').join('')).toBe('Hello world');
+    });
+  });
+
+  test('does not merge runs with stray non-whitespace direct text', async ({ given, when, then }: AllureBddContext) => {
+    let p: Element;
+    let merges: number;
+
+    await given('a run with non-whitespace text directly under w:r', () => {
+      const r1 = el('w:r', {}, [el('w:t', {}, undefined, 'A')], 'stray');
+      const r2 = el('w:r', {}, [el('w:t', {}, undefined, 'B')]);
+      p = el('w:p', {}, [r1, r2]);
+    });
+
+    await when('premergeAdjacentRuns is called', () => {
+      merges = premergeAdjacentRuns(p);
+    });
+
     await then('no merges are reported and both runs remain', () => {
+      // Direct non-whitespace text under w:r is not representable content the
+      // merge understands — stay conservative and refuse.
       expect(merges).toBe(0);
       expect(childElements(p)).toHaveLength(2);
     });
@@ -310,6 +415,87 @@ describe('premergeAdjacentRuns', () => {
       // w:delText is in SAFE_RUN_CHILD_TAGS, runs have no rPr — should merge
       expect(merges).toBe(1);
       expect(childElements(p)).toHaveLength(1);
+    });
+  });
+});
+
+describe('rsid-fragmented runs through the comparison pipeline (issue #675)', () => {
+  // Source: unchanged amount split across three runs; the middle run carries no
+  // w:rsidRPr while its neighbours do. Word produces this shape routinely when
+  // a figure is retyped in a later editing session.
+  const SPLIT_ALTERNATING_RSID =
+    '<w:p>' +
+    '<w:r w:rsidRPr="00F9719D" w:rsidR="00932CCC"><w:t xml:space="preserve">Alpha clause; beta clause; the amount shall not exceed $</w:t></w:r>' +
+    '<w:r w:rsidR="00932CCC"><w:t>204</w:t></w:r>' +
+    '<w:r w:rsidRPr="00F9719D" w:rsidR="00932CCC"><w:t xml:space="preserve">,000.00 or 0.50%, whichever is greater. Legacy Costs settle monthly.</w:t></w:r>' +
+    '</w:p>';
+
+  // Control: identical split, all three runs carry the same rsids.
+  const SPLIT_UNIFORM_RSID = SPLIT_ALTERNATING_RSID.replace(
+    '<w:r w:rsidR="00932CCC"><w:t>204</w:t></w:r>',
+    '<w:r w:rsidRPr="00F9719D" w:rsidR="00932CCC"><w:t>204</w:t></w:r>',
+  );
+
+  // Revised: one run. "$204,000.00" is unchanged; the only real edits are the
+  // leading clause and the trailing term.
+  const SINGLE_RUN =
+    '<w:p>' +
+    '<w:r><w:t xml:space="preserve">Alpha clause and any further clause reasonably incurred; the amount shall not exceed $204,000.00 or 0.50%, whichever is greater. Updated Costs settle monthly.</w:t></w:r>' +
+    '</w:p>';
+
+  async function documentXml(docx: Buffer): Promise<string> {
+    const part = (await JSZip.loadAsync(docx)).file('word/document.xml');
+    assertDefined(part, 'word/document.xml in comparison result');
+    return part.async('string');
+  }
+
+  function delTexts(xml: string): string[] {
+    return [...xml.matchAll(/<w:delText[^>]*>([^<]*)<\/w:delText>/g)].map((m) => m[1]!);
+  }
+
+  test('alternating-rsid run split does not produce a phantom delete+insert', async ({ given, when, then, and }: AllureBddContext) => {
+    let alternating!: Buffer;
+    let uniform!: Buffer;
+    let revised!: Buffer;
+    let alternatingResult!: Awaited<ReturnType<typeof compareDocuments>>;
+    let uniformResult!: Awaited<ReturnType<typeof compareDocuments>>;
+    let alternatingXml!: string;
+    let uniformXml!: string;
+
+    await given('a repro pair and a control pair differing only in rsid uniformity', async () => {
+      alternating = await buildDocxFromBodyXml(SPLIT_ALTERNATING_RSID);
+      uniform = await buildDocxFromBodyXml(SPLIT_UNIFORM_RSID);
+      revised = await buildDocxFromBodyXml(SINGLE_RUN);
+    });
+
+    await when('both pairs are compared in inplace mode', async () => {
+      alternatingResult = await compareDocuments(alternating, revised, {
+        engine: 'atomizer',
+        reconstructionMode: 'inplace',
+      });
+      uniformResult = await compareDocuments(uniform, revised, {
+        engine: 'atomizer',
+        reconstructionMode: 'inplace',
+      });
+      alternatingXml = await documentXml(alternatingResult.document);
+      uniformXml = await documentXml(uniformResult.document);
+    });
+
+    await then('the unchanged amount is not struck through in the repro output', () => {
+      expect(delTexts(alternatingXml).join('')).not.toContain('204');
+    });
+
+    await and('both pairs report identical comparison stats', () => {
+      expect(alternatingResult.stats).toEqual(uniformResult.stats);
+    });
+
+    await and('both outputs mark only the genuine edits', () => {
+      for (const xml of [alternatingXml, uniformXml]) {
+        const deleted = delTexts(xml).join('');
+        expect(deleted).toContain('Legacy');
+        expect(deleted).not.toContain('$');
+        expect(xml).toContain('$204,000.00');
+      }
     });
   });
 });

--- a/packages/docx-compare/src/baselines/atomizer/premergeRuns.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/premergeRuns.test.ts
@@ -3,7 +3,7 @@ import { describe, expect } from 'vitest';
 import { compareDocuments } from '../../index.js';
 import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
 import { premergeAdjacentRuns } from './premergeRuns.js';
-import { el } from '../../testing/dom-test-helpers.js';
+import { el, testDoc } from '../../testing/dom-test-helpers.js';
 import { buildDocxFromBodyXml } from '../../testing/ooxml-fixtures.js';
 import { childElements, getLeafText } from '@usejunior/docx-core';
 import { assertDefined } from '../../testing/test-utils.js';
@@ -204,6 +204,32 @@ describe('premergeAdjacentRuns', () => {
       // merge understands — stay conservative and refuse.
       expect(merges).toBe(0);
       expect(childElements(p)).toHaveLength(2);
+    });
+  });
+
+  test('does not merge when stray text follows an initial whitespace text node', async ({ given, when, then }: AllureBddContext) => {
+    let p: Element;
+    let merges: number;
+
+    await given('a run with indentation before w:t and stray text after it', () => {
+      // Every direct text child must be scanned: getLeafText() returns only
+      // the FIRST text child, so a whitespace node before <w:t> must not let
+      // later non-whitespace text slip past the guard — mergeRunInto moves
+      // element children only and would silently drop the stray text.
+      const r1 = el('w:r', {}, [el('w:t', {}, undefined, 'A')], '\n        ');
+      r1.appendChild(testDoc.createTextNode('stray'));
+      const r2 = el('w:r', {}, [el('w:t', {}, undefined, 'B')]);
+      p = el('w:p', {}, [r1, r2]);
+    });
+
+    await when('premergeAdjacentRuns is called', () => {
+      merges = premergeAdjacentRuns(p);
+    });
+
+    await then('no merges are reported and both runs remain', () => {
+      expect(merges).toBe(0);
+      expect(childElements(p)).toHaveLength(2);
+      expect(childElements(p)[0]!.textContent).toContain('stray');
     });
   });
 
@@ -496,6 +522,55 @@ describe('rsid-fragmented runs through the comparison pipeline (issue #675)', ()
         expect(deleted).not.toContain('$');
         expect(xml).toContain('$204,000.00');
       }
+    });
+  });
+
+  test('bracket removal around unchanged words does not strike the words', async ({ given, when, then, and }: AllureBddContext) => {
+    let source!: Buffer;
+    let revised!: Buffer;
+    let xml!: string;
+
+    await given('a source with "[or officer]" split across rsid-fragmented runs and a bracketless revision', async () => {
+      // Reduced from the NVCA COI pair: premerge heals the run fragmentation,
+      // so tokenization must split the brackets into their own atoms or the
+      // unchanged words "or" / "officer" get struck and reinserted.
+      source = await buildDocxFromBodyXml(
+        '<w:p>' +
+          '<w:r w:rsidRPr="00F9719D" w:rsidR="00932CCC"><w:t xml:space="preserve">No director [or</w:t></w:r>' +
+          '<w:r w:rsidR="00932CCC"><w:t xml:space="preserve"> officer]</w:t></w:r>' +
+          '<w:r w:rsidRPr="00F9719D" w:rsidR="00932CCC"><w:t xml:space="preserve"> shall be personally liable. Legacy term applies.</w:t></w:r>' +
+          '</w:p>',
+      );
+      revised = await buildDocxFromBodyXml(
+        '<w:p>' +
+          '<w:r><w:t xml:space="preserve">No director or officer shall be personally liable. Updated term applies.</w:t></w:r>' +
+          '</w:p>',
+      );
+    });
+
+    await when('the documents are compared in inplace mode', async () => {
+      const result = await compareDocuments(source, revised, {
+        engine: 'atomizer',
+        reconstructionMode: 'inplace',
+      });
+      xml = await documentXml(result.document);
+    });
+
+    await then('only the brackets and the genuine edit are deleted', () => {
+      const deleted = delTexts(xml);
+      expect(deleted).toContain('[');
+      expect(deleted).toContain(']');
+      expect(deleted.join(' ')).toContain('Legacy');
+      expect(deleted.join(' ')).not.toContain('or');
+      expect(deleted.join(' ')).not.toContain('officer');
+    });
+
+    await and('the unchanged words are not reinserted', () => {
+      const inserted = [...xml.matchAll(/<w:ins [^>]*>([\s\S]*?)<\/w:ins>/g)]
+        .flatMap((m) => [...m[1]!.matchAll(/<w:t[^>]*>([^<]*)<\/w:t>/g)].map((t) => t[1]!))
+        .join(' ');
+      expect(inserted).toContain('Updated');
+      expect(inserted).not.toContain('officer');
     });
   });
 });

--- a/packages/docx-compare/src/baselines/atomizer/premergeRuns.ts
+++ b/packages/docx-compare/src/baselines/atomizer/premergeRuns.ts
@@ -15,6 +15,10 @@
  * This step is intentionally conservative:
  * - Only merges immediately-adjacent <w:r> siblings under the same parent.
  * - Requires identical run attributes and identical <w:rPr> formatting subtree.
+ *   Revision-save identifiers (OOXML w:rsidR, w:rsidRPr, w:rsidDel, ...) are
+ *   excluded from that comparison: they record which editing session last
+ *   touched a run — bookkeeping with no rendering or semantic effect — so they
+ *   must not keep two otherwise-identical runs fragmented (issue #675).
  * - Only merges runs that contain a small, "safe" subset of child elements.
  */
 
@@ -62,12 +66,44 @@ function hashElementDeep(element: Element): string {
   return sha1([tagName, ...parts].join('|'));
 }
 
+const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+/**
+ * Whether an attribute is an OOXML revision-save identifier (w:rsidR,
+ * w:rsidRPr, w:rsidDel, ...).
+ *
+ * Attributes on elements parsed from a document carry namespace metadata, so
+ * the primary check is w-namespace + localName. Attributes created without it
+ * (e.g. via `setAttribute('w:rsidR', ...)` in fixtures) expose the qualified
+ * name only, so fall back to the `w:`-prefixed name.
+ */
+function isRsidAttribute(attr: Attr): boolean {
+  if (attr.namespaceURI) {
+    return attr.namespaceURI === W_NS && (attr.localName ?? '').startsWith('rsid');
+  }
+  return attr.name.startsWith('w:rsid');
+}
+
+function nonRsidAttributes(element: Element): Attr[] {
+  const attrs: Attr[] = [];
+  for (let i = 0; i < element.attributes.length; i++) {
+    const attr = element.attributes[i]!;
+    if (!isRsidAttribute(attr)) attrs.push(attr);
+  }
+  return attrs;
+}
+
+/**
+ * Compare run attributes, ignoring rsid revision-save identifiers on both
+ * sides. Equal filtered counts plus a value check of every remaining `a`
+ * attribute against `b` gives symmetric equality over the non-rsid sets.
+ */
 function attrsEqual(a: Element, b: Element): boolean {
-  if (a.attributes.length !== b.attributes.length) return false;
-  for (let i = 0; i < a.attributes.length; i++) {
-    const aAttr = a.attributes[i]!;
-    const bVal = b.getAttribute(aAttr.name);
-    if (bVal !== aAttr.value) return false;
+  const aAttrs = nonRsidAttributes(a);
+  const bAttrs = nonRsidAttributes(b);
+  if (aAttrs.length !== bAttrs.length) return false;
+  for (const aAttr of aAttrs) {
+    if (b.getAttribute(aAttr.name) !== aAttr.value) return false;
   }
   return true;
 }
@@ -90,7 +126,15 @@ function runPropertiesEqual(aRun: Element, bRun: Element): boolean {
 
 function runIsSafeToMerge(run: Element): boolean {
   if (run.tagName !== 'w:r') return false;
-  if (getLeafText(run) !== undefined) return false;
+  // Direct text under <w:r> is meaningless in OOXML (significant text lives in
+  // <w:t>), but pretty-printed documents put indentation text nodes inside
+  // every run. Treating those as content made premerge a no-op on one side of
+  // a comparison whenever only that side was pretty-printed, which
+  // desynchronised run boundaries between the two documents and produced
+  // phantom delete+insert pairs at every shared fragment boundary (issue #675).
+  // Only non-whitespace direct text marks a run unsafe.
+  const leafText = getLeafText(run);
+  if (leafText !== undefined && leafText.trim() !== '') return false;
 
   for (const child of childElements(run)) {
     if (!SAFE_RUN_CHILD_TAGS.has(child.tagName)) return false;

--- a/packages/docx-compare/src/baselines/atomizer/premergeRuns.ts
+++ b/packages/docx-compare/src/baselines/atomizer/premergeRuns.ts
@@ -23,7 +23,7 @@
  */
 
 import { createHash } from 'crypto';
-import { getLeafText, childElements } from '@usejunior/docx-core';
+import { getLeafText, childElements, NODE_TYPE } from '@usejunior/docx-core';
 
 const SAFE_RUN_CHILD_TAGS = new Set([
   'w:rPr',
@@ -124,6 +124,16 @@ function runPropertiesEqual(aRun: Element, bRun: Element): boolean {
   return hashElementDeep(aRPr) === hashElementDeep(bRPr);
 }
 
+function hasNonWhitespaceDirectText(element: Element): boolean {
+  for (let i = 0; i < element.childNodes.length; i++) {
+    const child = element.childNodes[i]!;
+    if (child.nodeType === NODE_TYPE.TEXT && (child.nodeValue ?? '').trim() !== '') {
+      return true;
+    }
+  }
+  return false;
+}
+
 function runIsSafeToMerge(run: Element): boolean {
   if (run.tagName !== 'w:r') return false;
   // Direct text under <w:r> is meaningless in OOXML (significant text lives in
@@ -132,9 +142,10 @@ function runIsSafeToMerge(run: Element): boolean {
   // a comparison whenever only that side was pretty-printed, which
   // desynchronised run boundaries between the two documents and produced
   // phantom delete+insert pairs at every shared fragment boundary (issue #675).
-  // Only non-whitespace direct text marks a run unsafe.
-  const leafText = getLeafText(run);
-  if (leafText !== undefined && leafText.trim() !== '') return false;
+  // Only non-whitespace direct text marks a run unsafe — and every direct text
+  // child is checked, not just the first, because mergeRunInto moves element
+  // children only and would silently drop stray text that slipped through.
+  if (hasNonWhitespaceDirectText(run)) return false;
 
   for (const child of childElements(run)) {
     if (!SAFE_RUN_CHILD_TAGS.has(child.tagName)) return false;


### PR DESCRIPTION
## Summary

The docx-compare atomizer emitted phantom delete+insert markup over byte-identical text when a source document split a token across runs whose rsid attributes differed (e.g. `$204,000.00` struck through and reinserted unchanged). Root cause: the run pre-merge step treated rsid attributes (`w:rsidR`, `w:rsidRPr`, `w:rsidDel`, ...) — revision-save session bookkeeping with no rendering or semantic effect — as part of run-merge identity, so rsid-fragmented runs never premerged and could not match the revised document's single atom.

Fixes: #675

## Changes

Three coupled changes, each empirically load-bearing (details in the commit bodies):

1. **rsid attributes excluded from run-merge identity** (`premergeRuns.ts` `attrsEqual`): compares only non-rsid attributes, symmetrically (equal filtered counts + per-attribute value check). rsids are recognised by w-namespace + `localName.startsWith('rsid')`, with a qualified-name (`w:rsid*`) fallback for attributes created without namespace metadata. Merged runs keep the target (first) run's rsid attributes — the conservative choice versus stripping or synthesising one. Non-rsid attribute differences still block merging.
2. **Whitespace-only direct text no longer marks a run unsafe to merge** (`runIsSafeToMerge`): pretty-printed documents put indentation text nodes inside every run; treating those as content made premerge a no-op on one side of a comparison and desynchronised run boundaries (NVCA COI `deletions` 385 → 540 with fix 1 alone). Every direct text child is scanned — not just the first — so stray non-whitespace text still blocks merging and can never be silently dropped (peer-review Medium finding).
3. **Edge punctuation split into its own atoms during word tokenization** (`atomizer.ts` `splitAtomIntoWords`): with premerge healing run fragmentation, whitespace-only word-splitting produced tokens like `[or` / `officer]`, so a punctuation-only edit (template bracket removal) struck and reinserted the unchanged neighbouring words (peer-review High finding). No premerge-local gate can separate the harmful glue (`[`+`or`) from the essential one (`$`+`204` — the issue-675 case): same character classes. Tokenization is now a pure function of paragraph text: leading `'"([{<` and trailing `,.:;!?'")]}>` punctuation become separate atoms on both sides; currency and interior punctuation stay glued (`$204,000.00` remains one atom). The punctuation-merge pass is skipped when word-splitting ran (edge splitting normalizes the same boundary differences symmetrically); run-level passes keep it unchanged.

## Verification

Issue repro (clean `main` build first, then fixed build):

| pair | before | after |
|---|---|---|
| alternating-rsid (bug) | insertions 5 / deletions 5 / deletedAtoms 7 | insertions 3 / deletions 3 / deletedAtoms 3 |
| uniform-rsid (control) | insertions 4 / deletions 4 / deletedAtoms 4 | insertions 3 / deletions 3 / deletedAtoms 3 |

Both pairs now produce byte-identical `document.xml`; `$204,000.00` never appears in a `w:delText`. (The control also improved: edge-punct tokenization keeps `clause` matched where `clause;` was previously deleted whole.)

Real-document check (NVCA COI regression pair, inplace) — final state is strictly better than the pre-PR baseline on every stat: insertions **205** / deletions **375** / modifiedParagraphs **26** vs baseline 224 / 385 / 27. The `[or officer]` "personally liable" paragraph emits exactly the baseline markup (brackets deleted, unchanged words untouched). Intermediate states that regressed this document (fix 1 alone: 401/540/79; fixes 1+2: 235/380/33 with word-consuming bracket edits) are why all three changes ship together.

Full pre-submit chain (`build`, `lint:workspaces`, `test:run` — 50/50 docx-compare files, 121/121 docx-core files — `check:spec-coverage`, `check:conformance-citations`, `check:conformance-doc`) passes locally.

## Peer review

Codex dynamic review: REQUEST-CHANGES with one High (bracket-adjacent unchanged words struck on NVCA — fixed by change 3), one Medium (first-text-child-only guard could silently drop stray run text — fixed by change 2's full scan). Both findings verified, accepted, and covered by new regression tests. Adjudication comment on this PR has the details.

## Follow-up candidates (not in this PR)

- `atomizer.ts` `elementIdentityString` hashes all attributes, including rsids, into empty-paragraph `pPr` identity (`atomizer.test.ts` asserts `w:rsidR` on `w:pPr` changes the hash). A pPr rsid difference on an otherwise-identical empty paragraph could produce the same phantom-diff class at paragraph level. `w:rPr` carries no rsid attributes in the vendored strict schema (confirmed by review), so `runPropertiesEqual` needs no change.

https://claude.ai/code/session_01KaEPsSLwFzxfWiSr8Mpy7K
