### PR TITLE
fix(docx-compare): split revision wrappers at partial bookmark boundaries

### DIFF
--- a/packages/docx-compare/src/baselines/atomizer/consumerCompatibility-bookmark-ranges.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/consumerCompatibility-bookmark-ranges.test.ts
@@ -143,6 +143,21 @@ function rangeText(documentXml: string, id: string): string {
   return text;
 }
 
+const REVISION_WRAPPER_TAGS = ['w:ins', 'w:del', 'w:moveFrom', 'w:moveTo'] as const;
+
+/** Assert every emitted revision wrapper carries a unique `w:id`. */
+function expectUniqueWrapperIds(documentXml: string): void {
+  const body = bodyOf(documentXml);
+  const ids: string[] = [];
+  for (const tag of REVISION_WRAPPER_TAGS) {
+    for (const wrapper of Array.from(body.getElementsByTagName(tag)) as Element[]) {
+      const id = wrapper.getAttribute('w:id');
+      if (id !== null) ids.push(`${tag}#${id}`);
+    }
+  }
+  expect(new Set(ids).size).toBe(ids.length);
+}
+
 const ORIGINAL_WITH_BOOKMARKED_PARAGRAPH =
   textParagraph('Leading survivor') +
   bookmarkedParagraph('41', 'DeletedBoundary', 'Bookmarked deleted text', '<w:pPr><w:keepNext/></w:pPr>') +
@@ -372,6 +387,10 @@ describe('Bookmark ranges survive paragraph-level revisions', () => {
     await and('Accept All shrinks the range to the surviving text only', () => {
       expect(rangeText(acceptAllChanges(documentXml), '50')).toBe('kept');
     });
+
+    await and('every emitted revision wrapper keeps a unique w:id', () => {
+      expectUniqueWrapperIds(documentXml);
+    });
   });
 
   test('a boundary partway through newly deleted text closes between the deletions [inplace]', async (
@@ -409,6 +428,10 @@ describe('Bookmark ranges survive paragraph-level revisions', () => {
 
     await and('Accept All leaves the range without the deleted text', () => {
       expect(rangeText(acceptAllChanges(documentXml), '50')).toBe('');
+    });
+
+    await and('every emitted revision wrapper keeps a unique w:id', () => {
+      expectUniqueWrapperIds(documentXml);
     });
   });
 
@@ -458,6 +481,10 @@ describe('Bookmark ranges survive paragraph-level revisions', () => {
 
     await and('Accept All keeps the range over the surviving text only', () => {
       expect(rangeText(acceptAllChanges(documentXml), '50')).toBe('kept');
+    });
+
+    await and('the split half w:id does not collide with the pre-existing wrapper ids', () => {
+      expectUniqueWrapperIds(documentXml);
     });
   });
 });

--- a/packages/docx-compare/src/baselines/atomizer/consumerCompatibility-bookmark-ranges.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/consumerCompatibility-bookmark-ranges.test.ts
@@ -13,6 +13,11 @@
  * surviving content still gets that boundary anchored outside, because the
  * paragraph disappears in one of the two projections.
  *
+ * A boundary partway inside an inline revision wrapper splits the wrapper at
+ * the boundary (attributes copied, fresh `w:id` on the second half), so the
+ * range keeps its exact original span instead of shrinking or growing to the
+ * nearest wrapper edge (issue #643).
+ *
  * The second describe block drives the pass directly, because the boundary cases
  * it covers are hard to reach through a whole comparison: the atomizer is free
  * to align a fixture into a different revision shape than the one under test.
@@ -108,6 +113,34 @@ function paragraphChildTags(documentXml: string, text: string): string[] {
     }
   }
   throw new Error(`no paragraph containing ${JSON.stringify(text)}`);
+}
+
+/**
+ * Concatenated visible text (`w:t` / `w:delText`) lying between the
+ * `w:bookmarkStart` and `w:bookmarkEnd` of range `id`, in document order.
+ * This is the text a `REF` field aimed at the bookmark would resolve to.
+ */
+function rangeText(documentXml: string, id: string): string {
+  let inside = false;
+  let text = '';
+  const visit = (node: Element): void => {
+    for (const child of childElements(node)) {
+      if (child.tagName === 'w:bookmarkStart' && child.getAttribute('w:id') === id) {
+        inside = true;
+        continue;
+      }
+      if (child.tagName === 'w:bookmarkEnd' && child.getAttribute('w:id') === id) {
+        inside = false;
+        continue;
+      }
+      if (inside && (child.tagName === 'w:t' || child.tagName === 'w:delText')) {
+        text += child.textContent ?? '';
+      }
+      visit(child);
+    }
+  };
+  visit(bodyOf(documentXml));
+  return text;
 }
 
 const ORIGINAL_WITH_BOOKMARKED_PARAGRAPH =
@@ -301,12 +334,142 @@ describe('Bookmark ranges survive paragraph-level revisions', () => {
       });
     });
   }
+
+  test('a boundary partway through newly deleted text splits the emitted deletion [rebuild]', async (
+    { given, when, then, and }: AllureBddContext
+  ) => {
+    let documentXml: string;
+
+    await given('an original whose bookmark ends partway through text the revision deletes', () => {});
+
+    await when('the documents are compared in rebuild mode', async () => {
+      documentXml = await compare(
+        '<w:p><w:bookmarkStart w:id="50" w:name="Partial"/>' +
+          '<w:r><w:t>kept inside-range</w:t></w:r>' +
+          '<w:bookmarkEnd w:id="50"/>' +
+          '<w:r><w:t>outside-range</w:t></w:r></w:p>',
+        '<w:p><w:r><w:t>kept</w:t></w:r></w:p>',
+        'rebuild'
+      );
+    });
+
+    await then('the emitted deletion is split with the boundary between the halves', () => {
+      // The join proves the split survived into the FINAL document XML: had a
+      // postprocess pass re-merged the halves across the boundary, the marker
+      // would sit before or after one w:del instead of between two.
+      expect(paragraphChildTags(documentXml, 'inside-range').join(',')).toContain(
+        'w:del,w:bookmarkEnd,w:del'
+      );
+    });
+
+    await and('Reject All restores the range over exactly its original span', () => {
+      const restored = rangeText(rejectAllChanges(documentXml), '50');
+      expect(restored).toContain('kept');
+      expect(restored).toContain('inside-range');
+      expect(restored).not.toContain('outside-range');
+    });
+
+    await and('Accept All shrinks the range to the surviving text only', () => {
+      expect(rangeText(acceptAllChanges(documentXml), '50')).toBe('kept');
+    });
+  });
+
+  test('a boundary partway through newly deleted text closes between the deletions [inplace]', async (
+    { given, when, then, and }: AllureBddContext
+  ) => {
+    let documentXml: string;
+
+    await given('an original whose bookmark ends partway through text the revision deletes', () => {});
+
+    await when('the documents are compared in inplace mode', async () => {
+      documentXml = await compare(
+        '<w:p><w:bookmarkStart w:id="50" w:name="Partial"/>' +
+          '<w:r><w:t>kept inside-range</w:t></w:r>' +
+          '<w:bookmarkEnd w:id="50"/>' +
+          '<w:r><w:t>outside-range</w:t></w:r></w:p>',
+        '<w:p><w:r><w:t>kept</w:t></w:r></w:p>',
+        'inplace'
+      );
+    });
+
+    await then('the end marker sits between the two emitted deletions', () => {
+      // The end sat between the two original runs, so it must re-emit between
+      // their deletion wrappers — not collapse onto the leading edge of the
+      // first one, which is what shrank the NVCA heading ranges (issue #643).
+      expect(paragraphChildTags(documentXml, 'inside-range').join(',')).toContain(
+        'w:del,w:bookmarkEnd,w:del'
+      );
+    });
+
+    await and('Reject All keeps the deleted inside text within the range', () => {
+      const restored = rangeText(rejectAllChanges(documentXml), '50');
+      expect(restored).toContain('inside-range');
+      expect(restored).not.toContain('outside-range');
+    });
+
+    await and('Accept All leaves the range without the deleted text', () => {
+      expect(rangeText(acceptAllChanges(documentXml), '50')).toBe('');
+    });
+  });
+
+  test('a boundary partway inside a pre-existing deletion splits it in the final document [inplace]', async (
+    { given, when, then, and }: AllureBddContext
+  ) => {
+    let documentXml: string;
+    const trackedBody =
+      '<w:p><w:bookmarkStart w:id="50" w:name="Partial"/>' +
+      '<w:r><w:t>kept</w:t></w:r>' +
+      '<w:del w:id="1" w:author="Earlier" w:date="2026-01-01T00:00:00Z">' +
+      '<w:r><w:delText>inside-range</w:delText></w:r>' +
+      '<w:bookmarkEnd w:id="50"/>' +
+      '<w:r><w:delText>outside-range</w:delText></w:r></w:del></w:p>';
+
+    await given('both documents carry a tracked deletion with a bookmark end partway inside', () => {});
+
+    await when('the identical documents are compared in inplace mode', async () => {
+      // The inplace pipeline runs its wrapper-merging postprocess passes over
+      // this tree, so this asserts end-to-end that none of them re-merge the
+      // split halves across the boundary.
+      documentXml = await compare(trackedBody, trackedBody, 'inplace');
+    });
+
+    await then('the pre-existing wrapper is split with the boundary between the halves', () => {
+      expect(paragraphChildTags(documentXml, 'inside-range')).toEqual([
+        'w:bookmarkStart',
+        'w:r',
+        'w:del',
+        'w:bookmarkEnd',
+        'w:del',
+      ]);
+    });
+
+    await and('the second half keeps the original author under a fresh w:id', () => {
+      const paragraph = bodyOf(documentXml).getElementsByTagName('w:p')[0] as Element;
+      const halves = childElements(paragraph).filter((child) => child.tagName === 'w:del');
+      expect(halves[0]!.getAttribute('w:id')).toBe('1');
+      expect(halves[1]!.getAttribute('w:id')).not.toBe('1');
+      expect(halves[1]!.getAttribute('w:author')).toBe('Earlier');
+    });
+
+    await and('Reject All restores the range over exactly its original span', () => {
+      const restored = rangeText(rejectAllChanges(documentXml), '50');
+      expect(restored).toBe('keptinside-range');
+    });
+
+    await and('Accept All keeps the range over the surviving text only', () => {
+      expect(rangeText(acceptAllChanges(documentXml), '50')).toBe('kept');
+    });
+  });
 });
 
 const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 
 /** Run the pass over one hand-written paragraph and report where markers landed. */
-function markerLayout(paragraphXml: string): { paragraph: string[]; body: string[] } {
+function markerLayout(paragraphXml: string): {
+  paragraph: string[];
+  body: string[];
+  paragraphEl: Element;
+} {
   const doc = parseXml(`<w:document xmlns:w="${W_NS}"><w:body>${paragraphXml}</w:body></w:document>`);
   const body = doc.getElementsByTagName('w:body')[0] as Element;
   let nextRevisionId = 900;
@@ -319,6 +482,7 @@ function markerLayout(paragraphXml: string): { paragraph: string[]; body: string
   return {
     paragraph: childElements(paragraph).map(label),
     body: childElements(body).map(label),
+    paragraphEl: paragraph,
   };
 }
 
@@ -356,7 +520,7 @@ describe('Bookmark boundaries relative to an inline revision wrapper', () => {
     });
   });
 
-  test('a boundary partway inside a wrapper keeps the long-standing placement ahead of it', async (
+  test('a boundary partway inside a wrapper splits the wrapper at the boundary', async (
     { given, when, then, and }: AllureBddContext
   ) => {
     let endInside: ReturnType<typeof markerLayout>;
@@ -368,7 +532,8 @@ describe('Bookmark boundaries relative to an inline revision wrapper', () => {
       endInside = markerLayout(
         '<w:p><w:bookmarkStart w:id="50" w:name="Partial"/>' +
           '<w:r><w:t>kept</w:t></w:r>' +
-          '<w:del w:id="1"><w:r><w:delText>inside-range</w:delText></w:r>' +
+          '<w:del w:id="1" w:author="A" w:date="2026-01-01T00:00:00Z">' +
+          '<w:r><w:delText>inside-range</w:delText></w:r>' +
           '<w:bookmarkEnd w:id="50"/>' +
           '<w:r><w:delText>outside-range</w:delText></w:r></w:del></w:p>'
       );
@@ -381,25 +546,157 @@ describe('Bookmark boundaries relative to an inline revision wrapper', () => {
       );
     });
 
-    await then('the inside end is anchored before the wrapper, shrinking the range', () => {
-      // Neither placement outside the wrapper reproduces the original span, so
-      // this keeps the placement the pass has always used rather than swapping
-      // one inaccuracy for another. Splitting the wrapper at the boundary is the
-      // faithful fix, tracked in issue #643 — update this test when it lands.
+    await then('the wrapper is split in two with the end between the halves', () => {
+      // Anchoring the end before or after the whole wrapper would shrink or
+      // grow the range, because the boundary sat partway through content one
+      // projection removes. Splitting keeps the original span exactly
+      // (issue #643, superseding the lossy placement pinned before it).
       expect(endInside.paragraph).toEqual([
         'w:bookmarkStart#50',
         'w:r',
+        'w:del',
         'w:bookmarkEnd#50',
         'w:del',
       ]);
     });
 
-    await and('the mirrored case leaves the start before the wrapper too', () => {
+    await and('the second half copies the wrapper attributes under a fresh w:id', () => {
+      const halves = childElements(endInside.paragraphEl).filter(
+        (child) => child.tagName === 'w:del'
+      );
+      expect(halves[0]!.textContent).toBe('inside-range');
+      expect(halves[1]!.textContent).toBe('outside-range');
+      expect(halves[0]!.getAttribute('w:id')).toBe('1');
+      expect(halves[1]!.getAttribute('w:id')).toBe('900');
+      expect(halves[1]!.getAttribute('w:author')).toBe('A');
+      expect(halves[1]!.getAttribute('w:date')).toBe('2026-01-01T00:00:00Z');
+    });
+
+    await and('the mirrored case splits around the inside start the same way', () => {
       expect(startInside.paragraph).toEqual([
+        'w:del',
         'w:bookmarkStart#51',
         'w:del',
         'w:r',
         'w:bookmarkEnd#51',
+      ]);
+      const halves = childElements(startInside.paragraphEl).filter(
+        (child) => child.tagName === 'w:del'
+      );
+      expect(halves[0]!.textContent).toBe('before-range');
+      expect(halves[1]!.textContent).toBe('inside-range');
+    });
+  });
+
+  test('a boundary partway inside a move wrapper splits it too', async (
+    { given, when, then }: AllureBddContext
+  ) => {
+    let layout: ReturnType<typeof markerLayout>;
+
+    await given('a range whose end sits partway inside a w:moveFrom', () => {});
+
+    await when('the consumer-compatibility pass runs', () => {
+      layout = markerLayout(
+        '<w:p><w:bookmarkStart w:id="54" w:name="MovePartial"/>' +
+          '<w:r><w:t>kept</w:t></w:r>' +
+          '<w:moveFrom w:id="7" w:author="A" w:date="2026-01-01T00:00:00Z">' +
+          '<w:r><w:t>inside-range</w:t></w:r>' +
+          '<w:bookmarkEnd w:id="54"/>' +
+          '<w:r><w:t>outside-range</w:t></w:r></w:moveFrom></w:p>'
+      );
+    });
+
+    await then('the move wrapper is split with the end between the halves', () => {
+      expect(layout.paragraph).toEqual([
+        'w:bookmarkStart#54',
+        'w:r',
+        'w:moveFrom',
+        'w:bookmarkEnd#54',
+        'w:moveFrom',
+      ]);
+      const halves = childElements(layout.paragraphEl).filter(
+        (child) => child.tagName === 'w:moveFrom'
+      );
+      expect(halves[1]!.getAttribute('w:author')).toBe('A');
+      expect(halves[1]!.getAttribute('w:id')).not.toBe('7');
+    });
+  });
+
+  test('an enclosed range and a partial boundary in one wrapper come out in content order', async (
+    { given, when, then, and }: AllureBddContext
+  ) => {
+    let layout: ReturnType<typeof markerLayout>;
+
+    await given('a wrapper holding a partial end followed by a whole enclosed range', () => {});
+
+    await when('the consumer-compatibility pass runs', () => {
+      layout = markerLayout(
+        '<w:p><w:bookmarkStart w:id="60" w:name="Outer"/>' +
+          '<w:r><w:t>lead</w:t></w:r>' +
+          '<w:del w:id="1" w:author="A" w:date="2026-01-01T00:00:00Z">' +
+          '<w:r><w:delText>up-to-boundary</w:delText></w:r>' +
+          '<w:bookmarkEnd w:id="60"/>' +
+          '<w:bookmarkStart w:id="61" w:name="Inner"/>' +
+          '<w:r><w:delText>enclosed</w:delText></w:r>' +
+          '<w:bookmarkEnd w:id="61"/>' +
+          '</w:del></w:p>'
+      );
+    });
+
+    await then('the two ranges stay disjoint instead of crossing', () => {
+      // Before the split fix, the partial end and the enclosed start were both
+      // dropped in front of the wrapper in a crossing order — legal, since
+      // bookmark markers pair by id rather than nesting, but a gratuitous
+      // reshuffle of ranges that were disjoint in the input (issue #643).
+      expect(layout.paragraph).toEqual([
+        'w:bookmarkStart#60',
+        'w:r',
+        'w:del',
+        'w:bookmarkEnd#60',
+        'w:bookmarkStart#61',
+        'w:del',
+        'w:bookmarkEnd#61',
+      ]);
+    });
+
+    await and('each range still covers exactly its original content', () => {
+      const halves = childElements(layout.paragraphEl).filter(
+        (child) => child.tagName === 'w:del'
+      );
+      expect(halves[0]!.textContent).toBe('up-to-boundary');
+      expect(halves[1]!.textContent).toBe('enclosed');
+    });
+  });
+
+  test('adjacent boundaries inside a wrapper do not leave an empty wrapper half behind', async (
+    { given, when, then }: AllureBddContext
+  ) => {
+    let layout: ReturnType<typeof markerLayout>;
+
+    await given('two ranges whose ends sit back to back inside a w:del', () => {});
+
+    await when('the consumer-compatibility pass runs', () => {
+      layout = markerLayout(
+        '<w:p><w:bookmarkStart w:id="64" w:name="First"/>' +
+          '<w:bookmarkStart w:id="65" w:name="Second"/>' +
+          '<w:r><w:t>kept</w:t></w:r>' +
+          '<w:del w:id="1" w:author="A" w:date="2026-01-01T00:00:00Z">' +
+          '<w:r><w:delText>inside</w:delText></w:r>' +
+          '<w:bookmarkEnd w:id="64"/>' +
+          '<w:bookmarkEnd w:id="65"/>' +
+          '<w:r><w:delText>outside</w:delText></w:r></w:del></w:p>'
+      );
+    });
+
+    await then('one split serves both boundaries, in their original order', () => {
+      expect(layout.paragraph).toEqual([
+        'w:bookmarkStart#64',
+        'w:bookmarkStart#65',
+        'w:r',
+        'w:del',
+        'w:bookmarkEnd#64',
+        'w:bookmarkEnd#65',
+        'w:del',
       ]);
     });
   });

--- a/packages/docx-compare/src/baselines/atomizer/consumerCompatibility.ts
+++ b/packages/docx-compare/src/baselines/atomizer/consumerCompatibility.ts
@@ -42,6 +42,7 @@ function isParagraphInsertedOrDeleted(p: Element): boolean {
 }
 
 const BOOKMARK_MARKER_TAGS = ['w:bookmarkStart', 'w:bookmarkEnd'] as const;
+const BOOKMARK_MARKER_TAG_SET: ReadonlySet<string> = new Set(BOOKMARK_MARKER_TAGS);
 const REVISION_WRAPPER_TAGS = new Set(['w:ins', 'w:del', 'w:moveFrom', 'w:moveTo']);
 
 /**
@@ -69,48 +70,123 @@ function bookmarkRangeIsEnclosedBy(container: Element, marker: Element): boolean
   return counterparts.some((candidate) => candidate.getAttribute('w:id') === id);
 }
 
+/** Whether the marker has any sibling before/after it inside its parent. */
+function hasSibling(marker: Element, direction: 'previous' | 'next'): boolean {
+  let node = direction === 'previous' ? marker.previousSibling : marker.nextSibling;
+  while (node) {
+    // Elements count as content; so do non-whitespace text nodes. Interelement
+    // whitespace never carries content in WordprocessingML run containers.
+    if (node.nodeType === 1) return true;
+    if (node.nodeType === 3 && (node.nodeValue ?? '').trim().length > 0) return true;
+    node = direction === 'previous' ? node.previousSibling : node.nextSibling;
+  }
+  return false;
+}
+
+/**
+ * Move `marker` out of every revision wrapper between it and `boundary`,
+ * splitting each wrapper the marker sits partway through so the marker keeps
+ * its exact position in the content stream.
+ *
+ * At each level the marker is either at an edge of its container — then it
+ * steps directly outside that edge, which is exact and creates nothing — or it
+ * has content on both sides, and the container is split in two: the trailing
+ * content moves into a fresh clone of the container (attributes copied, fresh
+ * `w:id`) placed after the marker. Both projections then keep the original
+ * span: accepting or rejecting the two halves is equivalent to accepting or
+ * rejecting the one wrapper they came from, and the marker stays anchored
+ * between the same two runs of content.
+ *
+ * Clones a marker only ever steps over — never into — are collected in
+ * `createdTails` so the caller can drop any that later markers empty out.
+ */
+function splitWrapperAtMarker(
+  marker: Element,
+  boundary: Node,
+  allocateRevisionId: () => number,
+  createdTails: Element[],
+): void {
+  while (marker.parentNode && marker.parentNode !== boundary) {
+    const container = marker.parentNode as Element;
+    const containerParent = container.parentNode;
+    if (!containerParent) return;
+
+    if (!hasSibling(marker, 'previous')) {
+      containerParent.insertBefore(marker, container);
+    } else if (!hasSibling(marker, 'next')) {
+      containerParent.insertBefore(marker, container.nextSibling);
+    } else {
+      const tail = container.cloneNode(false) as Element;
+      if (container.getAttribute('w:id') !== null) {
+        tail.setAttribute('w:id', String(allocateRevisionId()));
+      }
+      while (marker.nextSibling) {
+        tail.appendChild(marker.nextSibling);
+      }
+      containerParent.insertBefore(marker, container.nextSibling);
+      containerParent.insertBefore(tail, marker.nextSibling);
+      createdTails.push(tail);
+    }
+  }
+}
+
 /**
  * Lift the bookmark markers nested inside an inline revision wrapper out to the
- * wrapper's own level.
+ * wrapper's own level, splitting the wrapper wherever a marker sits partway
+ * through its content.
  *
  * A marker inside `<w:del>` vanishes on Accept All even though the surrounding
- * paragraph survives, so it cannot stay there. Where it lands depends on how
- * much of the range the wrapper owns:
+ * paragraph survives, so it cannot stay there. Every marker is walked out via
+ * {@link splitWrapperAtMarker}, which preserves the marker's exact position in
+ * the content stream:
  *
- * - A range the wrapper encloses entirely is placed around the wrapper — start
- *   before, end after — so it still spans the content it named. Dropping both
- *   boundaries in front of the wrapper (what this pass used to do) collapses it
- *   to zero length, which is how the rebuild path lost the range in issue #641.
- * - A boundary whose counterpart is outside the wrapper keeps the long-standing
- *   placement in front of the wrapper. Anchoring such a boundary after the
- *   wrapper instead would silently grow the range over the whole wrapped run.
- *   Neither placement reproduces the original span, because the boundary sat
- *   partway through content that one projection removes; repositioning it
- *   faithfully means splitting the wrapper at the boundary, which is out of
- *   scope here and tracked separately.
+ * - A range the wrapper encloses entirely comes out placed around the wrapper —
+ *   start before, end after — so it still spans the content it named. Dropping
+ *   both boundaries in front of the wrapper (what this pass used to do)
+ *   collapses it to zero length, which is how the rebuild path lost the range
+ *   in issue #641.
+ * - A boundary partway inside the wrapper used to be dropped in front of it,
+ *   silently shrinking the range (or growing it, for a start boundary).
+ *   Splitting the wrapper at the boundary — attributes copied onto the second
+ *   half, fresh `w:id` — keeps the original span in both projections
+ *   (issue #643).
+ *
+ * Markers are processed in document order so each split sees the pieces earlier
+ * splits produced; a tail clone that later markers empty out entirely is
+ * dropped rather than emitted as a contentless revision wrapper.
+ *
+ * @see https://github.com/UseJunior/safe-docx/issues/641
+ * @see https://github.com/UseJunior/safe-docx/issues/643
  */
-function liftMarkersAroundWrapper(wrapper: Element): void {
+function liftMarkersAroundWrapper(wrapper: Element, allocateRevisionId: () => number): void {
   const parent = wrapper.parentNode;
   if (!parent) return;
 
-  const starts = Array.from(wrapper.getElementsByTagName('w:bookmarkStart')) as Element[];
-  const ends = Array.from(wrapper.getElementsByTagName('w:bookmarkEnd')) as Element[];
+  // Collect markers in document order before mutating anything.
+  const markers: Element[] = [];
+  const collect = (node: Element): void => {
+    for (const child of childElements(node)) {
+      if (BOOKMARK_MARKER_TAG_SET.has(child.tagName)) {
+        markers.push(child);
+      } else {
+        collect(child);
+      }
+    }
+  };
+  collect(wrapper);
 
-  // Decide before moving anything: lifting the starts out first would empty the
-  // wrapper of them and make every range look like it reaches outside.
-  const endsAfter = ends.filter((end) => bookmarkRangeIsEnclosedBy(wrapper, end));
-  const endsBefore = ends.filter((end) => !endsAfter.includes(end));
+  const createdTails: Element[] = [];
+  for (const marker of markers) {
+    splitWrapperAtMarker(marker, parent, allocateRevisionId, createdTails);
+  }
 
-  for (const start of starts) {
-    parent.insertBefore(start, wrapper);
-  }
-  for (const end of endsBefore) {
-    parent.insertBefore(end, wrapper);
-  }
-  // Reverse so each insert lands directly after the wrapper, which leaves
-  // document order among these ends unchanged.
-  for (const end of [...endsAfter].reverse()) {
-    parent.insertBefore(end, wrapper.nextSibling);
+  // A tail created for one marker can be emptied by the next marker stepping
+  // out of it (adjacent boundaries); an empty revision wrapper says nothing
+  // and only confuses consumers, so drop it.
+  for (const tail of createdTails) {
+    if (!tail.firstChild && tail.parentNode) {
+      tail.parentNode.removeChild(tail);
+    }
   }
 }
 
@@ -130,14 +206,14 @@ function liftMarkersAroundWrapper(wrapper: Element): void {
  *    text it was created for, and such a range is meant to travel with the
  *    content it covers (issue #641).
  */
-function hoistBookmarkMarkers(node: Element): void {
+function hoistBookmarkMarkers(node: Element, allocateRevisionId: () => number): void {
   if (REVISION_WRAPPER_TAGS.has(node.tagName)) {
-    liftMarkersAroundWrapper(node);
+    liftMarkersAroundWrapper(node, allocateRevisionId);
     return;
   }
 
   for (const child of childElements(node)) {
-    hoistBookmarkMarkers(child);
+    hoistBookmarkMarkers(child, allocateRevisionId);
   }
 
   if (node.tagName !== 'w:p' || !isParagraphInsertedOrDeleted(node) || !node.parentNode) {
@@ -156,7 +232,7 @@ function hoistBookmarkMarkers(node: Element): void {
 
 export function enforceConsumerCompatibility(root: Element, allocateRevisionId: () => number): void {
   // 1. Reposition bookmark markers so their ranges survive both projections.
-  hoistBookmarkMarkers(root);
+  hoistBookmarkMarkers(root, allocateRevisionId);
 
   // 2. Remove empty w:t tags
   const textNodes = Array.from(root.getElementsByTagName('w:t'));

--- a/packages/docx-compare/src/baselines/atomizer/inPlaceModifier-bookmark-boundaries.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/inPlaceModifier-bookmark-boundaries.test.ts
@@ -35,9 +35,9 @@ async function compareInplace(originalBody: string, revisedBody: string) {
  * `<w:del>` — which matches what the move-source path already produced (see
  * inPlaceModifier-moved-bookmark-paragraph.test.ts).
  *
- * A boundary sitting only PARTWAY inside a revision wrapper is a separate case that still cannot be
- * repositioned faithfully; it is pinned in consumerCompatibility-bookmark-ranges.test.ts and tracked
- * in issue #643.
+ * A boundary sitting only PARTWAY inside a revision wrapper is repositioned by splitting the
+ * wrapper at the boundary (issue #643); that behavior is covered in
+ * consumerCompatibility-bookmark-ranges.test.ts.
  */
 describe('inplace deleted paragraph bookmark boundaries', () => {
   test('keeps both boundary markers inside the paragraph, wrapped around the deleted text', async ({

--- a/packages/docx-compare/src/baselines/atomizer/inPlaceModifier-bookmarks.ts
+++ b/packages/docx-compare/src/baselines/atomizer/inPlaceModifier-bookmarks.ts
@@ -94,22 +94,36 @@ export function isBookmarkMarkerTag(tagName: string): tagName is BookmarkMarkerT
 }
 
 /**
+ * Bookmark markers adjacent to a source run, keyed by which side of the run
+ * they sit on. The side decides where a reconstructed fragment must re-emit
+ * them: a marker that preceded the run goes in front of the fragment's
+ * revision wrapper, a marker that followed it goes after — collapsing both
+ * onto one side shrinks or grows the bookmark's range (issue #643).
+ */
+export interface AdjacentSourceBookmarkMarkers {
+  before: Element[];
+  after: Element[];
+}
+
+/**
  * Collect direct paragraph bookmark markers adjacent to a source run.
  *
  * Markers between runs (or at paragraph boundaries) are represented as siblings
  * of w:r under w:p. We clone nearby markers so reconstructed deleted/moveFrom
  * fragments preserve bookmark names/IDs needed for Reject All parity.
  */
-export function collectAdjacentSourceBookmarkMarkers(sourceRun: Element): Element[] {
+export function collectAdjacentSourceBookmarkMarkers(
+  sourceRun: Element
+): AdjacentSourceBookmarkMarkers {
   const paragraph = sourceRun.parentNode as Element | null;
   if (!paragraph || paragraph.tagName !== 'w:p') {
-    return [];
+    return { before: [], after: [] };
   }
 
   const children = childElements(paragraph);
   const runIndex = children.indexOf(sourceRun);
   if (runIndex < 0) {
-    return [];
+    return { before: [], after: [] };
   }
 
   const before: Element[] = [];
@@ -132,7 +146,7 @@ export function collectAdjacentSourceBookmarkMarkers(sourceRun: Element): Elemen
     }
   }
 
-  return [...before, ...after];
+  return { before, after };
 }
 
 
@@ -199,26 +213,29 @@ export function cloneUnemittedSourceBookmarkMarkers(
   targetParagraph: Element,
   state: RevisionIdState,
   context?: BookmarkSurvivalContext
-): Element[] {
+): AdjacentSourceBookmarkMarkers {
   const markers = collectAdjacentSourceBookmarkMarkers(sourceRun);
-  const clones: Element[] = [];
 
-  for (const marker of markers) {
-    if (state.emittedSourceBookmarkMarkers.has(marker)) {
-      continue;
-    }
+  const cloneUnemitted = (side: Element[]): Element[] => {
+    const clones: Element[] = [];
+    for (const marker of side) {
+      if (state.emittedSourceBookmarkMarkers.has(marker)) {
+        continue;
+      }
 
-    if (targetTreeHasEquivalentBookmarkMarker(targetParagraph, marker, context)) {
+      if (targetTreeHasEquivalentBookmarkMarker(targetParagraph, marker, context)) {
+        state.emittedSourceBookmarkMarkers.add(marker);
+        continue;
+      }
+
       state.emittedSourceBookmarkMarkers.add(marker);
-      continue;
+      const cloned = marker.cloneNode(true) as Element;
+      clones.push(cloned);
     }
+    return clones;
+  };
 
-    state.emittedSourceBookmarkMarkers.add(marker);
-    const cloned = marker.cloneNode(true) as Element;
-    clones.push(cloned);
-  }
-
-  return clones;
+  return { before: cloneUnemitted(markers.before), after: cloneUnemitted(markers.after) };
 }
 
 export function insertMarkersBeforeWrapper(wrapper: Element, markers: Element[]): void {
@@ -228,6 +245,76 @@ export function insertMarkersBeforeWrapper(wrapper: Element, markers: Element[])
     if (!marker) continue;
     parent.insertBefore(marker, wrapper);
   }
+}
+
+/**
+ * Insert `markers` directly after `anchor`, preserving their order.
+ *
+ * Used for source markers that FOLLOWED the source run: they must re-emit
+ * after the fragment's revision wrapper so the bookmark range still closes
+ * after the content it covered, not collapse to the wrapper's leading edge.
+ */
+export function insertMarkersAfterElement(anchor: Element, markers: Element[]): void {
+  const parent = anchor.parentNode;
+  if (!parent) return;
+  let cursor: Element = anchor;
+  for (const marker of markers) {
+    if (!marker) continue;
+    // A marker being MOVED forward may already sit exactly where it belongs;
+    // re-inserting a node before itself corrupts the xmldom child list.
+    if (cursor.nextSibling !== marker) insertAfterElement(cursor, marker);
+    cursor = marker;
+  }
+}
+
+/**
+ * Place the clones of the markers that FOLLOWED `sourceRun` directly after
+ * `anchor`, the fragment just emitted for that run.
+ *
+ * Word-level atomization fragments one source run into several wrappers, each
+ * inserted after the previous one — which would leave markers anchored after
+ * the FIRST fragment stranded mid-run. Every fragment therefore re-anchors its
+ * run's trailing clones after itself (DOM insertion moves an already-inserted
+ * node), so the clones come to rest after the run's final fragment, exactly
+ * where the source markers sat. Dropping them in front of the wrapper instead
+ * — the pre-fix behavior — collapsed the bookmark range to the wrapper's
+ * leading edge (issue #643, observed on NVCA heading bookmarks).
+ *
+ * @see https://github.com/UseJunior/safe-docx/issues/643
+ */
+export function emitTrailingSourceBookmarkClones(
+  sourceRun: Element,
+  anchor: Element,
+  newClones: Element[],
+  state: RevisionIdState,
+): void {
+  const pending = state.trailingSourceBookmarkClones.get(sourceRun) ?? [];
+  const clones = [...pending, ...newClones];
+  if (clones.length === 0) return;
+  insertMarkersAfterElement(anchor, clones);
+  state.trailingSourceBookmarkClones.set(sourceRun, clones);
+}
+
+/**
+ * The insertion anchor to hand the NEXT atom after emitting a fragment for
+ * `sourceRun`: past the run's trailing marker clones when they directly
+ * follow the fragment, otherwise the fragment itself.
+ *
+ * Without this, every later atom would insert via
+ * `insertAfterElement(previousFragment, …)` — between the fragment and its
+ * trailing markers — pushing the markers rightward past content that was
+ * never inside their bookmark range (issue #643).
+ */
+export function anchorPastTrailingBookmarkClones(
+  anchor: Element,
+  sourceRun: Element | undefined,
+  state: RevisionIdState,
+): Element {
+  if (!sourceRun) return anchor;
+  const clones = state.trailingSourceBookmarkClones.get(sourceRun);
+  if (!clones || clones.length === 0) return anchor;
+  const last = clones[clones.length - 1]!;
+  return last.parentNode !== null && last.parentNode === anchor.parentNode ? last : anchor;
 }
 
 export function filterEquivalentBookmarkMarkers(

--- a/packages/docx-compare/src/baselines/atomizer/inPlaceModifier-deletion.ts
+++ b/packages/docx-compare/src/baselines/atomizer/inPlaceModifier-deletion.ts
@@ -17,6 +17,7 @@ import {
 } from './inPlaceModifier-shared.js';
 import {
   cloneUnemittedSourceBookmarkMarkers,
+  emitTrailingSourceBookmarkClones,
   insertMarkersBeforeWrapper,
   type BookmarkSurvivalContext,
 } from './inPlaceModifier-bookmarks.js';
@@ -162,8 +163,11 @@ export function insertDeletedRun(
     }
   }
 
+  // Re-emit source markers on the side of the run they came from, so a range
+  // that closed after this run's content still closes there (issue #643).
   const sourceMarkers = cloneUnemittedSourceBookmarkMarkers(sourceRun, targetParagraph, state, context);
-  if (sourceMarkers.length > 0) insertMarkersBeforeWrapper(del, sourceMarkers);
+  insertMarkersBeforeWrapper(del, sourceMarkers.before);
+  emitTrailingSourceBookmarkClones(sourceRun, del, sourceMarkers.after, state);
 
   return del;
 }
@@ -245,9 +249,10 @@ export function insertFragmentedDeletedField(
     place(del);
   }
 
-  if (firstInserted) {
+  if (firstInserted && lastInserted) {
     const sourceMarkers = cloneUnemittedSourceBookmarkMarkers(sourceRun, targetParagraph, state, context);
-    if (sourceMarkers.length > 0) insertMarkersBeforeWrapper(firstInserted, sourceMarkers);
+    insertMarkersBeforeWrapper(firstInserted, sourceMarkers.before);
+    emitTrailingSourceBookmarkClones(sourceRun, lastInserted, sourceMarkers.after, state);
   }
 
   return lastInserted;
@@ -351,7 +356,8 @@ export function insertMoveFromRun(
   }
 
   const sourceMarkers = cloneUnemittedSourceBookmarkMarkers(sourceRun, targetParagraph, state, context);
-  if (sourceMarkers.length > 0) insertMarkersBeforeWrapper(moveFrom, sourceMarkers);
+  insertMarkersBeforeWrapper(moveFrom, sourceMarkers.before);
+  emitTrailingSourceBookmarkClones(sourceRun, rangeEnd, sourceMarkers.after, state);
 
   return moveFrom;
 }

--- a/packages/docx-compare/src/baselines/atomizer/inPlaceModifier-shared.ts
+++ b/packages/docx-compare/src/baselines/atomizer/inPlaceModifier-shared.ts
@@ -52,6 +52,14 @@ export interface RevisionIdState {
    * multiple atoms (word-level atomization).
    */
   emittedSourceBookmarkMarkers: Set<Element>;
+  /**
+   * Marker clones emitted for the markers that FOLLOWED a source run, keyed by
+   * that source run. Word-level atomization fragments one source run into many
+   * wrappers inserted one after another; each later fragment moves its run's
+   * trailing clones after itself, so they come to rest after the run's final
+   * fragment — where the source markers sat (issue #643).
+   */
+  trailingSourceBookmarkClones: Map<Element, Element[]>;
 }
 
 /**
@@ -65,6 +73,7 @@ export function createRevisionIdState(preservedRoots: readonly Element[] = []): 
     generatedMoveRangeMarkers: new Set(),
     wrappedRuns: new Set(),
     emittedSourceBookmarkMarkers: new Set(),
+    trailingSourceBookmarkClones: new Map(),
   };
   for (const root of preservedRoots) seedRevisionIdsFromMarkup(state, root);
   return state;

--- a/packages/docx-compare/src/baselines/atomizer/inPlaceModifier.ts
+++ b/packages/docx-compare/src/baselines/atomizer/inPlaceModifier.ts
@@ -38,6 +38,7 @@ import {
   isEntireParagraphAtomsWithStatus,
 } from './inPlaceModifier-containers.js';
 import {
+  anchorPastTrailingBookmarkClones,
   cloneParagraphBoundaryBookmarkMarkers,
   filterEquivalentBookmarkMarkers,
   insertLeadingMarkers,
@@ -562,7 +563,11 @@ function handleDeleted(atom: ComparisonUnitAtom, ctx: ProcessingContext): Handle
       // Collapsed-field atoms emit multiple siblings (some outside <w:del>)
       // and are left unnested; a pre-tracked inserted field is out of scope.
       const prov = !isCollapsedFieldAtom(atom) ? getOriginalInsProvenance(atom) : null;
-      const anchor = prov ? wrapWithOriginalInsProvenance(del, prov, ctx.state) : del;
+      const wrapped = prov ? wrapWithOriginalInsProvenance(del, prov, ctx.state) : del;
+      // Anchor the next atom past this run's trailing bookmark clones, so a
+      // range closing after this run's content is not pushed rightward by
+      // later fragments (issue #643).
+      const anchor = anchorPastTrailingBookmarkClones(wrapped, atom.sourceRunElement, ctx.state);
       // Track last run in created paragraphs
       if (unifiedPara !== undefined && ctx.createdParagraphs.has(unifiedPara)) {
         ctx.createdParagraphLastRun.set(unifiedPara, anchor);
@@ -703,12 +708,15 @@ function handleMovedSource(atom: ComparisonUnitAtom, ctx: ProcessingContext): Ha
     );
 
     if (moveFrom) {
+      // See handleDeleted: keep later fragments from landing between this
+      // fragment and its run's trailing bookmark clones (issue #643).
+      const anchor = anchorPastTrailingBookmarkClones(moveFrom, atom.sourceRunElement, ctx.state);
       // Track last run in created paragraphs
       if (unifiedPara !== undefined && ctx.createdParagraphs.has(unifiedPara)) {
-        ctx.createdParagraphLastRun.set(unifiedPara, moveFrom);
+        ctx.createdParagraphLastRun.set(unifiedPara, anchor);
       }
       return {
-        newLastRun: moveFrom,
+        newLastRun: anchor,
         newLastParagraph: targetParagraph,
         newLastParagraphIndex: atom.paragraphIndex,
       };

--- a/packages/docx-compare/src/integration/real-corpus-paragraph-deletion.test.ts
+++ b/packages/docx-compare/src/integration/real-corpus-paragraph-deletion.test.ts
@@ -98,13 +98,6 @@ const expectedFailures: Readonly<
       messageIncludes: 'unsupported REF field instruction shape',
     },
   },
-  'nvca-rofr-co-sale-agreement': {
-    inplace: {
-      issue: '#643',
-      kind: 'bookmark-range-failure',
-      names: ['_Ref_ContractCompanion_9kb9Ur019'],
-    },
-  },
   'nvca-stock-purchase-agreement': {
     rebuild: {
       issue: '#646',
@@ -114,11 +107,6 @@ const expectedFailures: Readonly<
     },
   },
   'nvca-voting-agreement': {
-    inplace: {
-      issue: '#643',
-      kind: 'bookmark-range-failure',
-      names: ['_Ref444624639'],
-    },
     rebuild: {
       issue: '#646',
       kind: 'comparison-error',


### PR DESCRIPTION
## Summary

A bookmark boundary sitting partway inside an inline revision wrapper (`w:ins` / `w:del` / `w:moveFrom` / `w:moveTo`) is now repositioned by **splitting the wrapper at the boundary**, copying its attributes onto the second half under a fresh `w:id`, so the range keeps its exact original span in both the Accept All and Reject All projections.

Before (pinned lossy behavior — the end was dropped in front of the wrapper, shrinking the range to `kept`):

```xml
<w:bookmarkStart w:id="50" w:name="Partial"/>
<w:r><w:t>kept</w:t></w:r>
<w:bookmarkEnd w:id="50"/>
<w:del w:id="1">
  <w:r><w:delText>inside-range</w:delText></w:r>
  <w:r><w:delText>outside-range</w:delText></w:r>
</w:del>
```

After (the range still covers `kept` + `inside-range`):

```xml
<w:bookmarkStart w:id="50" w:name="Partial"/>
<w:r><w:t>kept</w:t></w:r>
<w:del w:id="1"><w:r><w:delText>inside-range</w:delText></w:r></w:del>
<w:bookmarkEnd w:id="50"/>
<w:del w:id="900"><w:r><w:delText>outside-range</w:delText></w:r></w:del>
```

## Why two sites

Empirically (repro first, on a clean build), each reconstruction mode reaches the collapse through a different placement:

1. **`enforceConsumerCompatibility` / `liftMarkersAroundWrapper`** (shared by both modes; how the rebuild path and pre-existing tracked markup collapse). The pass now walks every marker out of the wrapper level by level. A marker partway through a container splits it — trailing content moves into a shallow clone (attributes copied, fresh `w:id` from the caller's existing collision-aware allocator) placed after the marker. A marker at a container edge steps directly outside that edge, which reproduces the exact pinned #641 shapes for wholly-enclosed ranges with no special case, and handles nested wrappers (`w:ins` around `w:del`) by construction. Tail clones emptied by adjacent boundaries are dropped.

2. **The inplace deletion/moveFrom emission** (how the NVCA corpus collapse actually happens: the markers never sit inside a wrapper by the time the pass runs). `cloneUnemittedSourceBookmarkMarkers` now reports which side of the source run each marker sat on; markers that FOLLOWED the run re-emit after the fragment's wrapper, and because word-level atomization fragments one source run into many wrappers, each later fragment re-anchors its run's trailing clones after itself so they come to rest after the run's final fragment. The next-atom insertion anchor advances past those clones so later runs cannot push them rightward.

## Postprocess passes cannot undo the split

`mergeAdjacentTrackChangeSiblings`, `coalesceDelInsPairChains`, and `mergeWhitespaceBridgedTrackChanges` all run BEFORE `enforceConsumerCompatibility` in the inplace pipeline (rebuild runs none of them), and their predicates require direct element adjacency or a whitespace-only `w:r` bridge — an interposed `w:bookmarkEnd` blocks all three. This is verified empirically, not by inspection: the new e2e tests assert the `w:del, w:bookmarkEnd, w:del` shape on the FINAL emitted document XML in both modes, plus both projections' spans.

## Real-corpus evidence

The two `#643` characterization pins in the real-corpus paragraph-deletion gate (`nvca-voting-agreement × inplace`, `nvca-rofr-co-sale-agreement × inplace`) flipped to passing against the SHA-256-verified corpus and are removed — exactly the signal #658 defined for this fix landing. Emitted NVCA voting output for the struck `Board Composition` clause is now:

```xml
<w:bookmarkStart w:name="_Ref444624639" w:id="30"/>
<w:bookmarkStart w:name="_Toc469383986" w:id="31"/>
<w:bookmarkStart w:name="_Ref145424752" w:id="32"/>
<w:del w:id="127">…Board Composition…</w:del>
<w:bookmarkEnd w:id="30"/><w:bookmarkEnd w:id="31"/>
<w:del w:id="140">…. Each Stockholder…</w:del>
```

The `#646` rebuild pins are untouched.

## The crossing-ranges wart

The issue's related wart — one range wholly inside a wrapper plus one partially inside coming out crossing — is normalized as a **side effect of the split**, not by a separate pass: every boundary keeps its position in the content stream, so ranges that were disjoint or nested in the input stay that way. Pinned by the new "come out in content order" test.

## Residuals (out of scope, verified pre-existing)

Both were surfaced by Codex peer review with executed fixtures and adjudicated by running the same fixtures against origin/main sources:

1. **Equal-content marker anchoring (inplace).** When a bookmarked source run is partly kept (e.g. `alpha removedOne beta removedTwo gamma` revised to `alpha inserted beta gamma`, bookmark around the whole original run), the cloned start re-anchors at the first deleted fragment rather than before the surviving equal prefix — the rejected projection covers `removedOne beta removedTwo gamma` but not `alpha`. On origin/main the SAME fixture collapses the range to zero length in BOTH projections (`accepted="" rejected=""`), so this PR strictly improves it. Faithful anchoring relative to equal/inserted fragments of the same source run is a marker-anchoring redesign, not a wrapper split.

2. **Revised-side partial `w:ins` boundary in rebuild mode.** A bookmark end that closes partway through newly inserted revised content is reconstructed past the insertion by the rebuild reconstructor before the consumer pass runs, so Accept All over-covers (`keptinsideoutside` instead of `keptinside`). Output is byte-identical on origin/main — untouched by this PR. The shared pass DOES split all four wrapper types when a marker reaches it inside a wrapper (unit-covered for `w:del`, `w:ins`, `w:moveFrom`, nested); this residual is upstream marker reconstruction, not the pass.

Not filing follow-up issues without discussion, per review protocol.

## Testing

- `packages/docx-compare/src/baselines/atomizer/consumerCompatibility-bookmark-ranges.test.ts`: the pinned lossy case now asserts the split shape (both `w:del` halves' content, attribute copy, fresh `w:id`); new cases for `w:moveFrom` splits, content-order (crossing) normalization, adjacent boundaries (no empty wrapper half), and three e2e cases asserting final emitted XML + both projections in both modes.
- Real-corpus matrix re-run against the verified NVCA cache: 15/15 pass with the pins removed.
- Full pre-submit chain green: build, lint:workspaces, test:run (all workspaces, corpus env set), check:spec-coverage, check:conformance-citations, check:conformance-doc.

Fixes: #643

https://claude.ai/code/session_01KaEPsSLwFzxfWiSr8Mpy7K
