### PR TITLE
test(docx-compare): add structural formatting-loss detectors and a stated pass criterion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,8 @@ jobs:
         run: npm run check:release-isolation
       - name: Test release-isolation guard
         run: npm run test:release-isolation
+      - name: Test formatting-loss detectors (unit tests + known-bad self-test)
+        run: npm run test:docx-formatting-loss
 
   spec-coverage:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ integration-tests/OPENSPEC_TRACEABILITY.md
 *.mcpb
 *.dxt
 site/src/trust/system-card.md
+.peer-review/

--- a/docs/comparison-failure-diagnosis.md
+++ b/docs/comparison-failure-diagnosis.md
@@ -1,0 +1,70 @@
+# Comparison Failure Diagnosis
+
+A comparison run that produces no visible error is not the same as a comparison run that succeeded. Extracted text can come back byte-identical, the round-trip can report success, and the output can open cleanly in Word while a defect a reader would notice on the first page is still present. This page states the failure classes a diagnosis has to distinguish, the criterion a run has to clear before it counts as a pass, and the evidence a negative result needs to be believable.
+
+## Failure Classes
+
+| Class | What it looks like | How it is caught |
+|---|---|---|
+| Throw | `OpaquePassthroughError`, a field-structure validation error, or a round-trip safety abort | The stack trace, plus the offending node's ancestor chain |
+| Phantom markup | Unchanged text struck and reinserted — `w:delText` and `w:t` carrying the same characters | Scan the output for adjacent `w:delText` / `w:t` pairs with matching text |
+| Silent content loss | Content present in the input and absent from the output | Round-trip identity of extracted text |
+| Degraded redline | Comparison succeeds and the redline is unusable | Inspection |
+| Formatting loss | Character formatting destroyed while every character survives | [The structural detectors below](#detecting-formatting-loss) |
+
+The last class is the one that hides. It passes text-level checks by construction, because no text changed. Two shapes have been observed:
+
+- A replacement whose span crosses a run boundary collapses the boundary and drops bold or italic from the affected span, so a defined term loses its emphasis.
+- Replacing a block leaves paragraph shells behind. An empty body paragraph renders as a blank line. An empty list paragraph that kept its `w:numPr` renders an orphan numbered label, which a reader sees and a text diff does not.
+
+## Detecting Formatting Loss
+
+`scripts/check_docx_formatting_loss.mjs` compares a before/after `.docx` pair and reports two detectors:
+
+- **D1 — run-formatting flattening.** Each character of a paragraph is projected onto its `(bold, italic, underline)` triple. When a paragraph's text is unchanged but that projection changed, emphasis was flattened. The projection is compared rather than a multiset of runs so that a run boundary moving without changing any character's emphasis — which token splitting and rsid churn produce routinely — is not reported as loss.
+- **D2 — emptied-but-retained paragraphs.** Paragraphs are matched on `w14:paraId` and flagged when they carried text before and carry none after, plus any empty paragraph still carrying `w:numPr`.
+
+```bash
+npm run check:docx-formatting-loss -- before.docx after.docx   # exit 1 on findings
+npm run check:docx-formatting-loss -- --json before.docx after.docx
+npm run test:docx-formatting-loss                              # unit tests + self-test
+```
+
+The tool emits counts, `w14:paraId` values, and element names, and never document text, so its output can be reported from a run over material that cannot be shared. The projection holds a digest of each paragraph's text rather than the text.
+
+Two limits the output states rather than hides. Paragraphs without a `w14:paraId` cannot be matched at all; they are counted and named in the coverage line, and a zero finding does not cover them. Duplicate `paraId` values are dropped from the match set rather than resolved by last write, for the same reason. The emphasis key is deliberately narrow — bold, italic, underline — so losses confined to other run properties pass unreported.
+
+## Pass Criterion
+
+A diagnostic run is a pass only when all five hold. Anything short of all five is a fail and should be reported as one.
+
+1. **Round-trip identity.** Accepting all revisions in the produced redline reproduces the revised document's extracted text exactly. Text inside `w:txbxContent` is the one documented boundary: text boxes are passed through opaquely and never carry redline markup, so their content is outside the compared projection. Note what this does *not* license. A text-box difference is not a benign residue to be waved through — `assertTextBoxContentUnchanged` fails closed and aborts the comparison before atomization when text-box content differs between the two sides (issue #647). Any residue confined to `w:txbxContent` therefore has to be named and explained, not absorbed into an expected-exception bucket.
+2. **`PAGEREF` field count preserved** between input and output. This is how table-of-contents destruction shows up.
+3. **Zero `w:ins` and `w:del` markers** in any clean output.
+4. **Both formatting-loss detectors report zero.**
+5. **`reconstructionModeUsed` reported** for both an `inplace` and a `rebuild` run — reported, not merely requested. The library defaults to `rebuild` while the MCP tool hardcodes `inplace` (`packages/docx-mcp/src/cli/commands/compare.ts`), so the same input can succeed through one entry point and abort through the other.
+
+Report every detector count explicitly, including the zeros. A detector that prints nothing when it finds nothing cannot be told apart from a detector that never ran.
+
+## Control Arm
+
+Running only the suspect input establishes what happened to that input. It does not establish that the instrumentation can detect anything, which is what turns "no failure reproduced" from an ambiguous result into a trustworthy one.
+
+`--self-test` is the standing control for the detectors themselves: it proves they fire on a known-bad pair and stay silent on a known-good one before any real run is believed. It runs in CI.
+
+A comparison run needs its own control — a known-bad document put through the same harness. When a control has to be reconstructed rather than staged, treat the reconstruction as a hypothesis. If it does not reproduce the expected failure, record that as a negative result and stop. A control iterated until something finally breaks is not a control.
+
+## Reproducing A Defect Outside The Original Document
+
+When the document that triggered a defect cannot be shared, the repro is built in this order.
+
+1. **Scrub in place.** Copy the document and replace text content with deterministic filler, leaving markup untouched — runs and run properties, `w:sdt`, fields and `w:instrText`, numbering, bookmarks, and section properties. Then confirm the scrubbed pair still reproduces. These defects live in structure, so structure has to survive the scrub.
+2. **Synthesise from scratch** only when scrubbing fails to reproduce.
+
+A synthetic that does not reproduce is not evidence that there is no bug. Hand-built fixtures have repeatedly passed on shapes that real documents fail. Report the outcome as "scrub reproduces, synthetic does not", which is itself a finding about how tightly the defect is coupled to real document structure.
+
+Redaction is by inspection, not by category. Text-carrying payloads that are easy to miss: OOXML exception messages, which quote source text; bookmark names; and `w:instrText` field codes, which hold table-of-contents and `PAGEREF` strings.
+
+## Build Hygiene
+
+Gate on the build's exit status before trusting any result. A failed build leaves stale `dist` artifacts in place, and every measurement taken after it describes the previous build. When comparing two revisions of the library, confirm the two trees actually differ in the code under test before reading anything into the comparison — each worktree needs its own `npm install`, or `@usejunior/*` resolves to another tree's stale output.

--- a/docs/comparison-failure-diagnosis.md
+++ b/docs/comparison-failure-diagnosis.md
@@ -22,17 +22,26 @@ The last class is the one that hides. It passes text-level checks by constructio
 `scripts/check_docx_formatting_loss.mjs` compares a before/after `.docx` pair and reports two detectors:
 
 - **D1 — run-formatting flattening.** Each character of a paragraph is projected onto its `(bold, italic, underline)` triple. When a paragraph's text is unchanged but that projection changed, emphasis was flattened. The projection is compared rather than a multiset of runs so that a run boundary moving without changing any character's emphasis — which token splitting and rsid churn produce routinely — is not reported as loss.
-- **D2 — emptied-but-retained paragraphs.** Paragraphs are matched on `w14:paraId` and flagged when they carried text before and carry none after, plus any empty paragraph still carrying `w:numPr`.
+- **D2 — emptied-but-retained paragraphs.** Paragraphs are matched on `w14:paraId` and flagged when they carried content before and carry none after, including the case where the emptied paragraph kept its `w:numPr`. Both halves are transitions: a paragraph that was already empty is a property of the input, not damage the comparison caused, and is reported separately as hygiene. "Empty" means no text *and* no renderable payload, so an image-only or field-only paragraph does not count as empty.
 
 ```bash
-npm run check:docx-formatting-loss -- before.docx after.docx   # exit 1 on findings
+npm run check:docx-formatting-loss -- before.docx after.docx   # 0 clean, 1 findings, 2 inconclusive
 npm run check:docx-formatting-loss -- --json before.docx after.docx
 npm run test:docx-formatting-loss                              # unit tests + self-test
 ```
 
-The tool emits counts, `w14:paraId` values, and element names, and never document text, so its output can be reported from a run over material that cannot be shared. The projection holds a digest of each paragraph's text rather than the text.
+Both inputs must be clean documents. The tool refuses a redline, because in a document carrying `w:del` the deleted text is still present and "empty" does not mean what D2 assumes.
 
-Two limits the output states rather than hides. Paragraphs without a `w14:paraId` cannot be matched at all; they are counted and named in the coverage line, and a zero finding does not cover them. Duplicate `paraId` values are dropped from the match set rather than resolved by last write, for the same reason. The emphasis key is deliberately narrow — bold, italic, underline — so losses confined to other run properties pass unreported.
+**Coverage is enforced, not merely reported.** The match key is the tool's sharpest edge: `reconstructionMode: 'rebuild'` emits output carrying no `w14:paraId` at all, so every paragraph fails to match, every detector reports zero, and the run reads as a clean pass having inspected nothing. Coverage below 95% of the larger side's paragraph count is therefore reported as `INCONCLUSIVE` and exits 2. Use `--min-coverage` to move the floor once you have decided what the gap means. In practice an `inplace` output keeps its ids; a real contract pair measured 97%, the shortfall being duplicate ids.
+
+What the detectors do not see, stated rather than hidden:
+
+- **D1 compares declared formatting, not resolved formatting.** It reads direct `w:rPr` plus the `w:rStyle` reference. Dropping a style that carried the emphasis is caught, because the reference changes. Editing that style's definition in `styles.xml`, or emphasis arriving through paragraph-style inheritance, is not. Consolidating onto docx-core's effective-formatting resolver is tracked in [#684](https://github.com/UseJunior/safe-docx/issues/684).
+- **D1 requires identical text.** Formatting loss that co-occurs with a text edit in the same paragraph is out of reach.
+- **The emphasis key is deliberately narrow** — bold, italic, underline, character style — so losses confined to other run properties pass unreported.
+- **Paragraphs without a `w14:paraId`, and paragraphs sharing a duplicate one, are not compared.** Duplicates are dropped from the match set rather than resolved by last write; both are counted in the coverage line.
+
+The tool emits counts, `w14:paraId` values, and element names in its detector reports, and the projection holds a digest of each paragraph's text rather than the text, so results from a run over material that cannot be shared are still reportable. Usage and IO errors do echo the paths you passed in.
 
 ## Pass Criterion
 
@@ -41,8 +50,8 @@ A diagnostic run is a pass only when all five hold. Anything short of all five i
 1. **Round-trip identity.** Accepting all revisions in the produced redline reproduces the revised document's extracted text exactly. Text inside `w:txbxContent` is the one documented boundary: text boxes are passed through opaquely and never carry redline markup, so their content is outside the compared projection. Note what this does *not* license. A text-box difference is not a benign residue to be waved through — `assertTextBoxContentUnchanged` fails closed and aborts the comparison before atomization when text-box content differs between the two sides (issue #647). Any residue confined to `w:txbxContent` therefore has to be named and explained, not absorbed into an expected-exception bucket.
 2. **`PAGEREF` field count preserved** between input and output. This is how table-of-contents destruction shows up.
 3. **Zero `w:ins` and `w:del` markers** in any clean output.
-4. **Both formatting-loss detectors report zero.**
-5. **`reconstructionModeUsed` reported** for both an `inplace` and a `rebuild` run — reported, not merely requested. The library defaults to `rebuild` while the MCP tool hardcodes `inplace` (`packages/docx-mcp/src/cli/commands/compare.ts`), so the same input can succeed through one entry point and abort through the other.
+4. **Both formatting-loss detectors report zero, on a run that was conclusive.** An `INCONCLUSIVE` result is not a pass, and neither is a zero count taken from one. Rebuild output cannot satisfy this criterion by paraId matching alone.
+5. **`reconstructionModeUsed` reported** for both an `inplace` and a `rebuild` run — reported, not merely requested. The library leaves `reconstructionMode` unset by default, while the MCP tool passes `DEFAULT_RECONSTRUCTION_MODE`, which is `inplace` (`packages/docx-mcp/src/tools/comparison_defaults.ts`). The `compare` CLI accepts an explicit `mode` and falls back to the same default. The same input can therefore succeed through one entry point and abort through another, and `inplace` can silently fall back to `rebuild` — which is why the mode that ran, not the mode requested, is what gets recorded.
 
 Report every detector count explicitly, including the zeros. A detector that prints nothing when it finds nothing cannot be told apart from a detector that never ran.
 
@@ -50,7 +59,7 @@ Report every detector count explicitly, including the zeros. A detector that pri
 
 Running only the suspect input establishes what happened to that input. It does not establish that the instrumentation can detect anything, which is what turns "no failure reproduced" from an ambiguous result into a trustworthy one.
 
-`--self-test` is the standing control for the detectors themselves: it proves they fire on a known-bad pair and stay silent on a known-good one before any real run is believed. It runs in CI.
+`--self-test` is the standing control for the detectors themselves: it proves they fire on a known-bad pair and stay silent on a known-good one before any real run is believed. It runs in CI. It is a synthetic control over the detector logic, which is not the same as a control over the comparison engine — and this page's own warning about synthetic fixtures applies to it.
 
 A comparison run needs its own control — a known-bad document put through the same harness. When a control has to be reconstructed rather than staged, treat the reconstruction as a hypothesis. If it does not reproduce the expected failure, record that as a negative result and stop. A control iterated until something finally breaks is not a control.
 

--- a/docs/testing-and-evidence.md
+++ b/docs/testing-and-evidence.md
@@ -21,6 +21,10 @@ OpenSpec is the repository's statement of intended behavior. It does not prove t
 
 Tests use shared DOCX builders and OOXML fixtures so repeated package shapes have one canonical implementation.
 
+## Diagnosing A Comparison Failure
+
+Automated tests cover named shapes. Diagnosing a comparison failure on a document outside the corpus is a separate procedure, because some failure classes leave extracted text unchanged and therefore pass every text-level check. The [comparison failure diagnosis guide](comparison-failure-diagnosis.md) states those classes, the structural detectors that catch them, and the criterion a diagnostic run has to clear before it counts as a pass.
+
 ## Human-Readable Test Evidence
 
 Tests attach Allure metadata describing the capability, scenario, conformance citation, and business-readable steps. Generated reports make the exercised behavior easier to inspect without treating report prose as a separate source of requirements.

--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
     "check:gemini-extension-manifest": "node scripts/check_gemini_extension_manifest.mjs",
     "check:release-isolation": "node scripts/check-release-isolation.mjs",
     "test:release-isolation": "node --test scripts/check-release-isolation.test.mjs",
+    "check:docx-formatting-loss": "node scripts/check_docx_formatting_loss.mjs",
+    "test:docx-formatting-loss": "node --test scripts/check_docx_formatting_loss.test.mjs && node scripts/check_docx_formatting_loss.mjs --self-test",
     "preflight:ci": "npm run lint:workspaces && npm run check:spec-coverage && npm run check:tool-docs && npm run check:mcpb-manifest && npm run check:gemini-extension-manifest && npm run check:allure-labels && npm run check:allure-filenames && npm run check:allure-quality && npm run check:conformance-citations && npm run check:conformance-doc && npm run check:ecma-376-coverage && npm run check:capability-projection && npm run check:invariants-doc && npm run check:lean-xml-checker-coverage && npm run check:site && npm run check:cycles",
     "test:coverage:packages": "npm run test:coverage -w @usejunior/docx-core && npm run test:coverage -w @usejunior/docx-compare && npm run test:coverage -w @usejunior/docx-mcp",
     "coverage:matrix": "node scripts/print_coverage_matrix.mjs",

--- a/scripts/check_docx_formatting_loss.mjs
+++ b/scripts/check_docx_formatting_loss.mjs
@@ -1,0 +1,466 @@
+#!/usr/bin/env node
+/**
+ * Structural formatting-loss detectors for a before/after .docx pair (issue #682).
+ *
+ * The comparison failure taxonomy classified failures as a throw, phantom
+ * markup, silent content loss, or a degraded-but-valid redline. None of those
+ * cover the class where *formatting* is destroyed while the text survives, and
+ * that class is invisible to every check the diagnostic procedure routinely
+ * runs: extracted text comes back byte-identical, round-trip reports success,
+ * and the document opens cleanly in Word. Two observed shapes:
+ *
+ *   D1 run-formatting flattening — a replacement whose span crosses a run
+ *      boundary collapses the boundary and drops bold/italic from the affected
+ *      span. Detected per paragraph by projecting each character of the
+ *      paragraph onto its (bold, italic, underline) triple: if the text is
+ *      unchanged but that projection changed, emphasis was flattened.
+ *
+ *      Issue #682 sketched D1 as a multiset of runs keyed on
+ *      (text, bold, italic, underline). That formulation fires on any run
+ *      boundary move, including boundary moves that preserve every character's
+ *      emphasis — which this codebase produces routinely, via atomizer token
+ *      splitting and rsid churn (#677). The character projection is invariant
+ *      to boundary churn and fires only on actual loss, so it is what shipped.
+ *
+ *   D2 emptied-but-retained paragraphs — replacing a block leaves paragraph
+ *      shells behind. An empty body paragraph renders as a blank line; an empty
+ *      list paragraph that keeps its w:numPr renders an orphan numbered label,
+ *      which a reader sees and a text diff does not. Detected by matching
+ *      paragraphs on w14:paraId.
+ *
+ * Paragraphs are matched on w14:paraId rather than on document order because
+ * order shifts whenever a comparison inserts or deletes a paragraph, which is
+ * exactly the run this check has to survive. Paragraphs without a paraId cannot
+ * be matched at all; they are counted and reported rather than key-substituted,
+ * so the coverage line always states what the detectors could not see.
+ *
+ * Output discipline: this runs over confidential documents, so it emits only
+ * counts, w14:paraId values, and element names — never document text. The
+ * projection keeps a digest of each paragraph's text rather than the text
+ * itself, so even a dump of the intermediate state carries no recoverable
+ * prose, and a unit test holds the report to the same line.
+ *
+ * Usage:
+ *   node scripts/check_docx_formatting_loss.mjs <before.docx> <after.docx>
+ *   node scripts/check_docx_formatting_loss.mjs --self-test
+ *   node scripts/check_docx_formatting_loss.mjs --json <before.docx> <after.docx>
+ *
+ * --self-test first proves the detectors fire on a known-bad pair and stay
+ * silent on a known-good one. A detector that has never been shown to fire is
+ * indistinguishable from no detector, and "no findings" from such a run is not
+ * evidence of anything.
+ *
+ * Exit status: 0 when no detector fires, 1 when any does, 2 on usage or IO error.
+ */
+
+import { createHash } from 'node:crypto';
+import { readFileSync, realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { DOMParser } from '@xmldom/xmldom';
+import JSZip from 'jszip';
+
+const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const W14_NS = 'http://schemas.microsoft.com/office/word/2010/wordml';
+
+/** Maximum paraIds listed per detector line before the tail is summarized. */
+const MAX_LISTED_IDS = 20;
+
+/** ST_OnOff values that turn a toggle property off. ECMA-376 Part 1 § 17.17.4. */
+const OFF_VALUES = new Set(['0', 'false', 'off']);
+
+function elementsByTag(node, localName) {
+  return Array.from(node.getElementsByTagNameNS(W_NS, localName));
+}
+
+function directChild(element, localName) {
+  for (let child = element.firstChild; child; child = child.nextSibling) {
+    if (child.nodeType === 1 && child.namespaceURI === W_NS && child.localName === localName) {
+      return child;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * The nearest ancestor-or-self w:p. A w:p can nest inside another w:p via a
+ * text box (w:txbxContent) or a table cell, so descendant queries have to be
+ * filtered by ownership or the outer paragraph absorbs the inner one's runs.
+ */
+function owningParagraph(node) {
+  for (let current = node; current; current = current.parentNode) {
+    if (current.nodeType === 1 && current.namespaceURI === W_NS && current.localName === 'p') {
+      return current;
+    }
+  }
+  return undefined;
+}
+
+function attributeValue(element, namespaceUri, localName) {
+  const value = element.getAttributeNS(namespaceUri, localName);
+  return value === null || value === '' ? undefined : value;
+}
+
+/** A toggle property is on when present unless w:val says otherwise. */
+function toggleIsOn(runProperties, localName) {
+  if (!runProperties) return false;
+  const property = directChild(runProperties, localName);
+  if (!property) return false;
+  const value = attributeValue(property, W_NS, 'val');
+  return value === undefined ? true : !OFF_VALUES.has(value.toLowerCase());
+}
+
+/**
+ * w:u is not a toggle — it carries an underline style. The raw value is kept so
+ * a single-to-dotted change counts as a formatting change, not just on/off.
+ */
+function underlineValue(runProperties) {
+  if (!runProperties) return 'none';
+  const underline = directChild(runProperties, 'u');
+  if (!underline) return 'none';
+  return attributeValue(underline, W_NS, 'val') ?? 'unspecified';
+}
+
+function runText(run, paragraph) {
+  let text = '';
+  for (const node of elementsByTag(run, 't')) {
+    if (owningParagraph(node) === paragraph) text += node.textContent ?? '';
+  }
+  return text;
+}
+
+function runEmphasis(run) {
+  const runProperties = directChild(run, 'rPr');
+  return [toggleIsOn(runProperties, 'b'), toggleIsOn(runProperties, 'i'), underlineValue(runProperties)];
+}
+
+/**
+ * Append `length` characters of `emphasis` to a run-length-encoded projection,
+ * merging into the previous span when the emphasis matches. Merging is what
+ * makes the encoding canonical, and therefore what makes a plain array
+ * comparison equivalent to comparing the two per-character projections.
+ */
+function appendEmphasisSpan(spans, length, emphasis) {
+  if (length === 0) return;
+  const previous = spans[spans.length - 1];
+  if (previous && previous[1] === emphasis[0] && previous[2] === emphasis[1] && previous[3] === emphasis[2]) {
+    previous[0] += length;
+    return;
+  }
+  spans.push([length, ...emphasis]);
+}
+
+function sameEmphasisProjection(before, after) {
+  if (before.length !== after.length) return false;
+  return before.every((span, index) => span.every((value, position) => value === after[index][position]));
+}
+
+/**
+ * Project word/document.xml into the per-paragraph shape both detectors read.
+ *
+ * Duplicate paraIds are dropped from the match set rather than last-write-wins:
+ * two paragraphs sharing an id cannot be told apart, and silently keeping one
+ * would report a comparison the tool did not actually make.
+ *
+ * @param {string} documentXml raw word/document.xml
+ */
+export function projectParagraphs(documentXml) {
+  // A parse failure has to be loud: a document that silently projects to zero
+  // paragraphs makes every detector report zero findings, which reads as a pass.
+  const errors = [];
+  let document;
+  try {
+    document = new DOMParser({
+      onError: (level, message) => {
+        if (level === 'error' || level === 'fatalError') errors.push(String(message));
+      },
+    }).parseFromString(documentXml, 'application/xml');
+  } catch (error) {
+    throw new Error(`word/document.xml did not parse: ${error.message}`);
+  }
+
+  if (errors.length > 0) {
+    throw new Error(`word/document.xml did not parse: ${errors[0]}`);
+  }
+
+  const byParaId = new Map();
+  const duplicateParaIds = new Set();
+  let unkeyedParagraphs = 0;
+  let totalParagraphs = 0;
+
+  for (const paragraph of elementsByTag(document, 'p')) {
+    totalParagraphs += 1;
+    const paraId = attributeValue(paragraph, W14_NS, 'paraId');
+    if (paraId === undefined) {
+      unkeyedParagraphs += 1;
+      continue;
+    }
+    if (byParaId.has(paraId) || duplicateParaIds.has(paraId)) {
+      byParaId.delete(paraId);
+      duplicateParaIds.add(paraId);
+      continue;
+    }
+
+    const emphasisSpans = [];
+    let text = '';
+    for (const run of elementsByTag(paragraph, 'r')) {
+      if (owningParagraph(run) !== paragraph) continue;
+      const ownText = runText(run, paragraph);
+      text += ownText;
+      // Empty runs (bookmarks, field characters, breaks) span no characters, so
+      // they carry no emphasis that could be lost.
+      appendEmphasisSpan(emphasisSpans, ownText.length, runEmphasis(run));
+    }
+
+    const paragraphProperties = directChild(paragraph, 'pPr');
+    byParaId.set(paraId, {
+      emphasisSpans,
+      textDigest: createHash('sha256').update(text).digest('hex'),
+      isEmpty: text.trim() === '',
+      hasNumbering: paragraphProperties ? directChild(paragraphProperties, 'numPr') !== undefined : false,
+    });
+  }
+
+  return {
+    byParaId,
+    duplicateParaIds: [...duplicateParaIds].sort(),
+    unkeyedParagraphs,
+    totalParagraphs,
+  };
+}
+
+/**
+ * Run D1 and D2 over two projections.
+ *
+ * @param {ReturnType<typeof projectParagraphs>} before
+ * @param {ReturnType<typeof projectParagraphs>} after
+ */
+export function detectFormattingLoss(before, after) {
+  const flattenedParagraphIds = [];
+  const emptiedParagraphIds = [];
+  const orphanNumberingParagraphIds = [];
+  let matchedParagraphs = 0;
+
+  for (const [paraId, beforeParagraph] of before.byParaId) {
+    const afterParagraph = after.byParaId.get(paraId);
+    if (!afterParagraph) continue;
+    matchedParagraphs += 1;
+
+    // D1 — same characters, different emphasis.
+    if (
+      beforeParagraph.textDigest === afterParagraph.textDigest &&
+      !sameEmphasisProjection(beforeParagraph.emphasisSpans, afterParagraph.emphasisSpans)
+    ) {
+      flattenedParagraphIds.push(paraId);
+    }
+
+    // D2a — carried text before, carries none after.
+    if (!beforeParagraph.isEmpty && afterParagraph.isEmpty) {
+      emptiedParagraphIds.push(paraId);
+    }
+  }
+
+  // D2b — an empty paragraph that kept its numbering renders an orphan label.
+  for (const [paraId, afterParagraph] of after.byParaId) {
+    if (afterParagraph.isEmpty && afterParagraph.hasNumbering) {
+      orphanNumberingParagraphIds.push(paraId);
+    }
+  }
+
+  return {
+    flattenedParagraphIds: flattenedParagraphIds.sort(),
+    emptiedParagraphIds: emptiedParagraphIds.sort(),
+    orphanNumberingParagraphIds: orphanNumberingParagraphIds.sort(),
+    matchedParagraphs,
+    coverage: {
+      beforeTotal: before.totalParagraphs,
+      afterTotal: after.totalParagraphs,
+      beforeUnkeyed: before.unkeyedParagraphs,
+      afterUnkeyed: after.unkeyedParagraphs,
+      beforeDuplicateIds: before.duplicateParaIds.length,
+      afterDuplicateIds: after.duplicateParaIds.length,
+    },
+  };
+}
+
+export function hasFindings(result) {
+  return (
+    result.flattenedParagraphIds.length > 0 ||
+    result.emptiedParagraphIds.length > 0 ||
+    result.orphanNumberingParagraphIds.length > 0
+  );
+}
+
+function formatIdList(ids) {
+  const listed = ids.slice(0, MAX_LISTED_IDS).join(' ');
+  const remaining = ids.length - MAX_LISTED_IDS;
+  return remaining > 0 ? `[${listed} (+${remaining} more)]` : `[${listed}]`;
+}
+
+/**
+ * Render the result as text. Every count is printed even when zero — a detector
+ * that reports nothing when it found nothing is indistinguishable from a
+ * detector that did not run.
+ */
+export function formatReport(result) {
+  const { coverage } = result;
+  const unmatched = coverage.beforeUnkeyed + coverage.afterUnkeyed;
+  const lines = [
+    `D1 run-formatting flattened paragraphs: ${result.flattenedParagraphIds.length} ${formatIdList(result.flattenedParagraphIds)}`,
+    `D2 emptied-but-retained paragraphs: ${result.emptiedParagraphIds.length} ${formatIdList(result.emptiedParagraphIds)}`,
+    `D2 empty paragraphs retaining w:numPr: ${result.orphanNumberingParagraphIds.length} ${formatIdList(result.orphanNumberingParagraphIds)}`,
+    `coverage: ${result.matchedParagraphs} paragraphs matched by w14:paraId ` +
+      `(before ${coverage.beforeTotal} paragraphs, ${coverage.beforeUnkeyed} unkeyed, ${coverage.beforeDuplicateIds} duplicate ids; ` +
+      `after ${coverage.afterTotal} paragraphs, ${coverage.afterUnkeyed} unkeyed, ${coverage.afterDuplicateIds} duplicate ids)`,
+  ];
+  if (unmatched > 0) {
+    lines.push(
+      `note: ${unmatched} paragraphs carry no w14:paraId and were not compared — ` +
+        `a zero count above does not cover them`,
+    );
+  }
+  return lines;
+}
+
+export async function readDocumentXml(docxPath) {
+  let archive;
+  try {
+    archive = await JSZip.loadAsync(readFileSync(docxPath));
+  } catch (error) {
+    throw new Error(`${docxPath} is not a readable .docx package: ${error.message}`);
+  }
+  const entry = archive.file('word/document.xml');
+  if (!entry) throw new Error(`${docxPath} has no word/document.xml`);
+  return entry.async('string');
+}
+
+/** Minimal OOXML package used by --self-test and the unit tests. */
+export async function buildMinimalDocx(bodyXml) {
+  const zip = new JSZip();
+  zip.file(
+    '[Content_Types].xml',
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+      `<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+      `<Default Extension="xml" ContentType="application/xml"/>` +
+      `<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+      `<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>` +
+      `</Types>`,
+  );
+  zip.file(
+    '_rels/.rels',
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+      `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>` +
+      `</Relationships>`,
+  );
+  zip.file('word/document.xml', wrapBodyXml(bodyXml));
+  return zip.generateAsync({ type: 'nodebuffer' });
+}
+
+export function wrapBodyXml(bodyXml) {
+  return (
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<w:document xmlns:w="${W_NS}" xmlns:w14="${W14_NS}" mc:Ignorable="w14" ` +
+    `xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006">` +
+    `<w:body>${bodyXml}</w:body></w:document>`
+  );
+}
+
+/**
+ * Known-good and known-bad body XML for the self-test. The bad side is the two
+ * shapes this check exists for: a defined term whose cross-run bold was
+ * flattened into a single plain run, and a numbered paragraph emptied but kept.
+ */
+export const SELF_TEST_BEFORE_BODY =
+  `<w:p w14:paraId="11111111">` +
+  `<w:r><w:rPr><w:b/></w:rPr><w:t xml:space="preserve">Term</w:t></w:r>` +
+  `<w:r><w:t xml:space="preserve"> means the defined thing.</w:t></w:r>` +
+  `</w:p>` +
+  `<w:p w14:paraId="22222222">` +
+  `<w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="3"/></w:numPr></w:pPr>` +
+  `<w:r><w:t>A numbered obligation.</w:t></w:r>` +
+  `</w:p>`;
+
+export const SELF_TEST_AFTER_BODY =
+  `<w:p w14:paraId="11111111">` +
+  `<w:r><w:t xml:space="preserve">Term means the defined thing.</w:t></w:r>` +
+  `</w:p>` +
+  `<w:p w14:paraId="22222222">` +
+  `<w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="3"/></w:numPr></w:pPr>` +
+  `</w:p>`;
+
+async function runSelfTest() {
+  const before = projectParagraphs(wrapBodyXml(SELF_TEST_BEFORE_BODY));
+  const after = projectParagraphs(wrapBodyXml(SELF_TEST_AFTER_BODY));
+
+  const unchanged = detectFormattingLoss(before, projectParagraphs(wrapBodyXml(SELF_TEST_BEFORE_BODY)));
+  const damaged = detectFormattingLoss(before, after);
+
+  const failures = [];
+  if (hasFindings(unchanged)) {
+    failures.push('known-good pair reported findings — the detectors have false positives');
+  }
+  if (damaged.flattenedParagraphIds.length !== 1) {
+    failures.push(`D1 did not fire on the known-bad pair (got ${damaged.flattenedParagraphIds.length}, expected 1)`);
+  }
+  if (damaged.emptiedParagraphIds.length !== 1) {
+    failures.push(`D2 emptied did not fire on the known-bad pair (got ${damaged.emptiedParagraphIds.length}, expected 1)`);
+  }
+  if (damaged.orphanNumberingParagraphIds.length !== 1) {
+    failures.push(
+      `D2 orphan-numbering did not fire on the known-bad pair (got ${damaged.orphanNumberingParagraphIds.length}, expected 1)`,
+    );
+  }
+
+  if (failures.length > 0) {
+    for (const failure of failures) console.error(`check_docx_formatting_loss: self-test FAILED — ${failure}`);
+    return 1;
+  }
+
+  console.log('self-test: known-good pair clean, known-bad pair caught by D1 and both D2 checks');
+  for (const line of formatReport(damaged)) console.log(`self-test known-bad ${line}`);
+  return 0;
+}
+
+export async function main(argv) {
+  const useJson = argv.includes('--json');
+  const positional = argv.filter((argument) => !argument.startsWith('--'));
+
+  if (argv.includes('--self-test')) return runSelfTest();
+
+  if (positional.length !== 2) {
+    console.error('usage: check_docx_formatting_loss.mjs [--json] <before.docx> <after.docx>');
+    console.error('       check_docx_formatting_loss.mjs --self-test');
+    return 2;
+  }
+
+  let result;
+  try {
+    const [beforeXml, afterXml] = await Promise.all(positional.map(readDocumentXml));
+    result = detectFormattingLoss(projectParagraphs(beforeXml), projectParagraphs(afterXml));
+  } catch (error) {
+    console.error(`check_docx_formatting_loss: ${error.message}`);
+    return 2;
+  }
+
+  if (useJson) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    for (const line of formatReport(result)) console.log(line);
+  }
+  return hasFindings(result) ? 1 : 0;
+}
+
+function invokedDirectly() {
+  // A node_modules/.bin symlink makes import.meta.url and argv[1] differ, so
+  // both sides are resolved through realpath before comparison.
+  if (!process.argv[1]) return false;
+  try {
+    return realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedDirectly()) {
+  process.exitCode = await main(process.argv.slice(2));
+}

--- a/scripts/check_docx_formatting_loss.mjs
+++ b/scripts/check_docx_formatting_loss.mjs
@@ -12,45 +12,63 @@
  *   D1 run-formatting flattening — a replacement whose span crosses a run
  *      boundary collapses the boundary and drops bold/italic from the affected
  *      span. Detected per paragraph by projecting each character of the
- *      paragraph onto its (bold, italic, underline) triple: if the text is
- *      unchanged but that projection changed, emphasis was flattened.
+ *      paragraph onto its (bold, italic, underline, character style) tuple: if
+ *      the text is unchanged but that projection changed, emphasis was lost.
  *
  *      Issue #682 sketched D1 as a multiset of runs keyed on
  *      (text, bold, italic, underline). That formulation fires on any run
- *      boundary move, including boundary moves that preserve every character's
- *      emphasis — which this codebase produces routinely, via atomizer token
- *      splitting and rsid churn (#677). The character projection is invariant
- *      to boundary churn and fires only on actual loss, so it is what shipped.
+ *      boundary move, including moves that preserve every character's emphasis
+ *      — which this codebase produces routinely, via atomizer token splitting
+ *      and rsid churn (#677). The character projection is invariant to boundary
+ *      churn and fires only on actual loss, so it is what shipped.
  *
  *   D2 emptied-but-retained paragraphs — replacing a block leaves paragraph
  *      shells behind. An empty body paragraph renders as a blank line; an empty
  *      list paragraph that keeps its w:numPr renders an orphan numbered label,
- *      which a reader sees and a text diff does not. Detected by matching
- *      paragraphs on w14:paraId.
+ *      which a reader sees and a text diff does not. Both are reported only as
+ *      transitions: a paragraph that was already empty before is not a loss
+ *      this comparison caused.
  *
  * Paragraphs are matched on w14:paraId rather than on document order because
  * order shifts whenever a comparison inserts or deletes a paragraph, which is
- * exactly the run this check has to survive. Paragraphs without a paraId cannot
- * be matched at all; they are counted and reported rather than key-substituted,
- * so the coverage line always states what the detectors could not see.
+ * exactly the run this check has to survive.
  *
- * Output discipline: this runs over confidential documents, so it emits only
- * counts, w14:paraId values, and element names — never document text. The
- * projection keeps a digest of each paragraph's text rather than the text
- * itself, so even a dump of the intermediate state carries no recoverable
- * prose, and a unit test holds the report to the same line.
+ * That match key is also this tool's sharpest edge, so it is enforced rather
+ * than assumed. `reconstructionMode: 'rebuild'` emits output carrying no
+ * w14:paraId at all, which matches nothing, finds nothing, and reads as a clean
+ * pass. Coverage below --min-coverage is therefore reported as INCONCLUSIVE and
+ * exits 2. A detector that cannot see the document must not be able to bless it.
+ *
+ * Scope of D1. It compares *declared* formatting — direct w:rPr plus the
+ * w:rStyle reference — not formatting resolved through styles.xml. Removing a
+ * style that carried bold is caught, because the reference changes. Editing the
+ * definition of that style, or a change expressed only through paragraph-style
+ * inheritance, is not. Consolidating onto docx-core's effective-formatting
+ * resolver is tracked in #684; until then this limit is stated rather than
+ * papered over.
+ *
+ * D1 also requires the two paragraphs to carry identical text. Formatting loss
+ * that co-occurs with a text edit in the same paragraph is out of its reach.
+ *
+ * Output discipline: this runs over confidential documents. Detector reports
+ * emit only counts, w14:paraId values, and element names, and the projection
+ * keeps a digest of each paragraph's text rather than the text itself, so even
+ * a dump of the intermediate state carries no recoverable prose. Usage and IO
+ * errors do echo the paths you passed in.
  *
  * Usage:
  *   node scripts/check_docx_formatting_loss.mjs <before.docx> <after.docx>
  *   node scripts/check_docx_formatting_loss.mjs --self-test
  *   node scripts/check_docx_formatting_loss.mjs --json <before.docx> <after.docx>
+ *   node scripts/check_docx_formatting_loss.mjs --min-coverage 0.9 <a.docx> <b.docx>
  *
  * --self-test first proves the detectors fire on a known-bad pair and stay
  * silent on a known-good one. A detector that has never been shown to fire is
  * indistinguishable from no detector, and "no findings" from such a run is not
  * evidence of anything.
  *
- * Exit status: 0 when no detector fires, 1 when any does, 2 on usage or IO error.
+ * Exit status: 0 when no detector fires, 1 when any does, 2 on usage or IO
+ * error or when coverage is too low for the result to mean anything.
  */
 
 import { createHash } from 'node:crypto';
@@ -67,6 +85,25 @@ const MAX_LISTED_IDS = 20;
 
 /** ST_OnOff values that turn a toggle property off. ECMA-376 Part 1 § 17.17.4. */
 const OFF_VALUES = new Set(['0', 'false', 'off']);
+
+/**
+ * Fraction of the larger side's paragraphs that must be matched by paraId
+ * before a finding count is worth believing. Real documents fall a little short
+ * of 1 because duplicate paraIds occur; rebuild output falls to 0.
+ */
+const DEFAULT_MIN_COVERAGE = 0.95;
+
+/**
+ * Run children that put marks on the page without contributing w:t text. A
+ * paragraph holding only one of these is not empty, and reporting it as
+ * emptied would flag every image-only paragraph in the document.
+ */
+const RENDERABLE_RUN_CONTENT = new Set([
+  'drawing', 'object', 'pict', 'tab', 'br', 'sym', 'ptab', 'softHyphen', 'noBreakHyphen', 'fldChar', 'instrText',
+]);
+
+/** Presence of any of these means the document is a redline, not clean output. */
+const REVISION_MARKERS = ['ins', 'del', 'rPrChange', 'pPrChange', 'moveFrom', 'moveTo'];
 
 function elementsByTag(node, localName) {
   return Array.from(node.getElementsByTagNameNS(W_NS, localName));
@@ -120,6 +157,17 @@ function underlineValue(runProperties) {
   return attributeValue(underline, W_NS, 'val') ?? 'unspecified';
 }
 
+/**
+ * The character style reference. Included so that dropping a style that carried
+ * the emphasis is visible: without it, removing w:rStyle="Strong" changes no
+ * direct property and the loss is silent.
+ */
+function characterStyleId(runProperties) {
+  if (!runProperties) return '';
+  const style = directChild(runProperties, 'rStyle');
+  return style ? (attributeValue(style, W_NS, 'val') ?? '') : '';
+}
+
 function runText(run, paragraph) {
   let text = '';
   for (const node of elementsByTag(run, 't')) {
@@ -128,9 +176,23 @@ function runText(run, paragraph) {
   return text;
 }
 
+function runHasRenderableContent(run, paragraph) {
+  for (const localName of RENDERABLE_RUN_CONTENT) {
+    for (const node of elementsByTag(run, localName)) {
+      if (owningParagraph(node) === paragraph) return true;
+    }
+  }
+  return false;
+}
+
 function runEmphasis(run) {
   const runProperties = directChild(run, 'rPr');
-  return [toggleIsOn(runProperties, 'b'), toggleIsOn(runProperties, 'i'), underlineValue(runProperties)];
+  return [
+    toggleIsOn(runProperties, 'b'),
+    toggleIsOn(runProperties, 'i'),
+    underlineValue(runProperties),
+    characterStyleId(runProperties),
+  ];
 }
 
 /**
@@ -142,7 +204,7 @@ function runEmphasis(run) {
 function appendEmphasisSpan(spans, length, emphasis) {
   if (length === 0) return;
   const previous = spans[spans.length - 1];
-  if (previous && previous[1] === emphasis[0] && previous[2] === emphasis[1] && previous[3] === emphasis[2]) {
+  if (previous && emphasis.every((value, index) => previous[index + 1] === value)) {
     previous[0] += length;
     return;
   }
@@ -152,6 +214,38 @@ function appendEmphasisSpan(spans, length, emphasis) {
 function sameEmphasisProjection(before, after) {
   if (before.length !== after.length) return false;
   return before.every((span, index) => span.every((value, position) => value === after[index][position]));
+}
+
+function parseDocumentPart(documentXml) {
+  const errors = [];
+  let document;
+  try {
+    document = new DOMParser({
+      onError: (level, message) => {
+        if (level === 'error' || level === 'fatalError') errors.push(String(message));
+      },
+    }).parseFromString(documentXml, 'application/xml');
+  } catch (error) {
+    throw new Error(`word/document.xml did not parse: ${error.message}`);
+  }
+  if (errors.length > 0) throw new Error(`word/document.xml did not parse: ${errors[0]}`);
+
+  // A well-formed but structurally wrong part would otherwise project zero
+  // paragraphs, and zero paragraphs reads exactly like a clean pass.
+  const root = document.documentElement;
+  if (!root || root.namespaceURI !== W_NS || root.localName !== 'document') {
+    throw new Error('word/document.xml is not a WordprocessingML w:document part');
+  }
+  if (!directChild(root, 'body')) {
+    throw new Error('word/document.xml has no w:body');
+  }
+  return document;
+}
+
+/** Revision markup means this is a redline, where "empty" means something else. */
+export function findRevisionMarkers(documentXml) {
+  const document = parseDocumentPart(documentXml);
+  return REVISION_MARKERS.filter((localName) => elementsByTag(document, localName).length > 0);
 }
 
 /**
@@ -164,26 +258,11 @@ function sameEmphasisProjection(before, after) {
  * @param {string} documentXml raw word/document.xml
  */
 export function projectParagraphs(documentXml) {
-  // A parse failure has to be loud: a document that silently projects to zero
-  // paragraphs makes every detector report zero findings, which reads as a pass.
-  const errors = [];
-  let document;
-  try {
-    document = new DOMParser({
-      onError: (level, message) => {
-        if (level === 'error' || level === 'fatalError') errors.push(String(message));
-      },
-    }).parseFromString(documentXml, 'application/xml');
-  } catch (error) {
-    throw new Error(`word/document.xml did not parse: ${error.message}`);
-  }
-
-  if (errors.length > 0) {
-    throw new Error(`word/document.xml did not parse: ${errors[0]}`);
-  }
+  const document = parseDocumentPart(documentXml);
 
   const byParaId = new Map();
   const duplicateParaIds = new Set();
+  let duplicateParagraphs = 0;
   let unkeyedParagraphs = 0;
   let totalParagraphs = 0;
 
@@ -195,13 +274,15 @@ export function projectParagraphs(documentXml) {
       continue;
     }
     if (byParaId.has(paraId) || duplicateParaIds.has(paraId)) {
-      byParaId.delete(paraId);
+      if (byParaId.delete(paraId)) duplicateParagraphs += 1;
       duplicateParaIds.add(paraId);
+      duplicateParagraphs += 1;
       continue;
     }
 
     const emphasisSpans = [];
     let text = '';
+    let hasRenderableContent = false;
     for (const run of elementsByTag(paragraph, 'r')) {
       if (owningParagraph(run) !== paragraph) continue;
       const ownText = runText(run, paragraph);
@@ -209,13 +290,14 @@ export function projectParagraphs(documentXml) {
       // Empty runs (bookmarks, field characters, breaks) span no characters, so
       // they carry no emphasis that could be lost.
       appendEmphasisSpan(emphasisSpans, ownText.length, runEmphasis(run));
+      if (!hasRenderableContent && runHasRenderableContent(run, paragraph)) hasRenderableContent = true;
     }
 
     const paragraphProperties = directChild(paragraph, 'pPr');
     byParaId.set(paraId, {
       emphasisSpans,
       textDigest: createHash('sha256').update(text).digest('hex'),
-      isEmpty: text.trim() === '',
+      isEmpty: text.trim() === '' && !hasRenderableContent,
       hasNumbering: paragraphProperties ? directChild(paragraphProperties, 'numPr') !== undefined : false,
     });
   }
@@ -223,6 +305,7 @@ export function projectParagraphs(documentXml) {
   return {
     byParaId,
     duplicateParaIds: [...duplicateParaIds].sort(),
+    duplicateParagraphs,
     unkeyedParagraphs,
     totalParagraphs,
   };
@@ -233,11 +316,14 @@ export function projectParagraphs(documentXml) {
  *
  * @param {ReturnType<typeof projectParagraphs>} before
  * @param {ReturnType<typeof projectParagraphs>} after
+ * @param {{ minCoverage?: number }} [options]
  */
-export function detectFormattingLoss(before, after) {
+export function detectFormattingLoss(before, after, options = {}) {
+  const minCoverage = options.minCoverage ?? DEFAULT_MIN_COVERAGE;
   const flattenedParagraphIds = [];
   const emptiedParagraphIds = [];
   const orphanNumberingParagraphIds = [];
+  let preExistingEmptyNumbered = 0;
   let matchedParagraphs = 0;
 
   for (const [paraId, beforeParagraph] of before.byParaId) {
@@ -253,31 +339,36 @@ export function detectFormattingLoss(before, after) {
       flattenedParagraphIds.push(paraId);
     }
 
-    // D2a — carried text before, carries none after.
+    // D2 — carried content before, carries none after. Both halves are
+    // transitions: a paragraph already empty on the before side is a property
+    // of the input, not damage this comparison did.
     if (!beforeParagraph.isEmpty && afterParagraph.isEmpty) {
       emptiedParagraphIds.push(paraId);
+      if (afterParagraph.hasNumbering) orphanNumberingParagraphIds.push(paraId);
+    } else if (afterParagraph.isEmpty && afterParagraph.hasNumbering) {
+      preExistingEmptyNumbered += 1;
     }
   }
 
-  // D2b — an empty paragraph that kept its numbering renders an orphan label.
-  for (const [paraId, afterParagraph] of after.byParaId) {
-    if (afterParagraph.isEmpty && afterParagraph.hasNumbering) {
-      orphanNumberingParagraphIds.push(paraId);
-    }
-  }
+  const comparableParagraphs = Math.max(before.totalParagraphs, after.totalParagraphs);
+  const coverageRatio = comparableParagraphs === 0 ? 1 : matchedParagraphs / comparableParagraphs;
 
   return {
     flattenedParagraphIds: flattenedParagraphIds.sort(),
     emptiedParagraphIds: emptiedParagraphIds.sort(),
     orphanNumberingParagraphIds: orphanNumberingParagraphIds.sort(),
     matchedParagraphs,
+    preExistingEmptyNumbered,
+    coverageRatio,
+    minCoverage,
+    inconclusive: coverageRatio < minCoverage,
     coverage: {
       beforeTotal: before.totalParagraphs,
       afterTotal: after.totalParagraphs,
       beforeUnkeyed: before.unkeyedParagraphs,
       afterUnkeyed: after.unkeyedParagraphs,
-      beforeDuplicateIds: before.duplicateParaIds.length,
-      afterDuplicateIds: after.duplicateParaIds.length,
+      beforeDuplicateParagraphs: before.duplicateParagraphs,
+      afterDuplicateParagraphs: after.duplicateParagraphs,
     },
   };
 }
@@ -303,21 +394,32 @@ function formatIdList(ids) {
  */
 export function formatReport(result) {
   const { coverage } = result;
-  const unmatched = coverage.beforeUnkeyed + coverage.afterUnkeyed;
+  const percent = (result.coverageRatio * 100).toFixed(1);
   const lines = [
     `D1 run-formatting flattened paragraphs: ${result.flattenedParagraphIds.length} ${formatIdList(result.flattenedParagraphIds)}`,
     `D2 emptied-but-retained paragraphs: ${result.emptiedParagraphIds.length} ${formatIdList(result.emptiedParagraphIds)}`,
     `D2 empty paragraphs retaining w:numPr: ${result.orphanNumberingParagraphIds.length} ${formatIdList(result.orphanNumberingParagraphIds)}`,
-    `coverage: ${result.matchedParagraphs} paragraphs matched by w14:paraId ` +
-      `(before ${coverage.beforeTotal} paragraphs, ${coverage.beforeUnkeyed} unkeyed, ${coverage.beforeDuplicateIds} duplicate ids; ` +
-      `after ${coverage.afterTotal} paragraphs, ${coverage.afterUnkeyed} unkeyed, ${coverage.afterDuplicateIds} duplicate ids)`,
+    `coverage: ${result.matchedParagraphs} of ${Math.max(coverage.beforeTotal, coverage.afterTotal)} paragraphs matched by w14:paraId (${percent}%) ` +
+      `(before ${coverage.beforeTotal} paragraphs, ${coverage.beforeUnkeyed} unkeyed, ${coverage.beforeDuplicateParagraphs} sharing a duplicate id; ` +
+      `after ${coverage.afterTotal} paragraphs, ${coverage.afterUnkeyed} unkeyed, ${coverage.afterDuplicateParagraphs} sharing a duplicate id)`,
   ];
-  if (unmatched > 0) {
+
+  if (result.preExistingEmptyNumbered > 0) {
     lines.push(
-      `note: ${unmatched} paragraphs carry no w14:paraId and were not compared — ` +
-        `a zero count above does not cover them`,
+      `note: ${result.preExistingEmptyNumbered} numbered paragraphs were already empty before the change — ` +
+        `document hygiene, not loss this comparison caused`,
     );
   }
+
+  if (result.inconclusive) {
+    lines.push(
+      `INCONCLUSIVE: coverage ${percent}% is below the ${(result.minCoverage * 100).toFixed(1)}% floor, ` +
+        `so the counts above describe only a fragment of the document and must not be read as a pass. ` +
+        `reconstructionMode 'rebuild' emits no w14:paraId at all; compare an 'inplace' output, ` +
+        `or lower the floor with --min-coverage once you have decided what the gap means`,
+    );
+  }
+
   return lines;
 }
 
@@ -399,6 +501,9 @@ async function runSelfTest() {
   if (hasFindings(unchanged)) {
     failures.push('known-good pair reported findings — the detectors have false positives');
   }
+  if (unchanged.inconclusive || damaged.inconclusive) {
+    failures.push('self-test fixtures did not reach full coverage — the harness itself is broken');
+  }
   if (damaged.flattenedParagraphIds.length !== 1) {
     failures.push(`D1 did not fire on the known-bad pair (got ${damaged.flattenedParagraphIds.length}, expected 1)`);
   }
@@ -421,22 +526,56 @@ async function runSelfTest() {
   return 0;
 }
 
+const KNOWN_FLAGS = new Set(['--json', '--self-test', '--min-coverage']);
+
+function usage() {
+  console.error('usage: check_docx_formatting_loss.mjs [--json] [--min-coverage <0..1>] <before.docx> <after.docx>');
+  console.error('       check_docx_formatting_loss.mjs --self-test');
+  return 2;
+}
+
 export async function main(argv) {
-  const useJson = argv.includes('--json');
-  const positional = argv.filter((argument) => !argument.startsWith('--'));
+  const positional = [];
+  let useJson = false;
+  let minCoverage = DEFAULT_MIN_COVERAGE;
 
-  if (argv.includes('--self-test')) return runSelfTest();
-
-  if (positional.length !== 2) {
-    console.error('usage: check_docx_formatting_loss.mjs [--json] <before.docx> <after.docx>');
-    console.error('       check_docx_formatting_loss.mjs --self-test');
-    return 2;
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === '--self-test') return runSelfTest();
+    if (argument === '--json') {
+      useJson = true;
+    } else if (argument === '--min-coverage') {
+      minCoverage = Number(argv[index + 1]);
+      index += 1;
+      if (!Number.isFinite(minCoverage) || minCoverage < 0 || minCoverage > 1) {
+        console.error('check_docx_formatting_loss: --min-coverage takes a fraction between 0 and 1');
+        return 2;
+      }
+    } else if (argument.startsWith('--') && !KNOWN_FLAGS.has(argument)) {
+      // Silently ignoring an unknown flag lets a typo'd threshold read as a pass.
+      console.error(`check_docx_formatting_loss: unknown option ${argument}`);
+      return usage();
+    } else {
+      positional.push(argument);
+    }
   }
+
+  if (positional.length !== 2) return usage();
 
   let result;
   try {
     const [beforeXml, afterXml] = await Promise.all(positional.map(readDocumentXml));
-    result = detectFormattingLoss(projectParagraphs(beforeXml), projectParagraphs(afterXml));
+    for (const [path, xml] of [[positional[0], beforeXml], [positional[1], afterXml]]) {
+      const markers = findRevisionMarkers(xml);
+      if (markers.length > 0) {
+        throw new Error(
+          `${path} carries revision markup (${markers.map((name) => `w:${name}`).join(', ')}). ` +
+            `These detectors read clean output — in a redline, deleted text is still present ` +
+            `and "empty" does not mean what D2 assumes. Accept or reject the revisions first.`,
+        );
+      }
+    }
+    result = detectFormattingLoss(projectParagraphs(beforeXml), projectParagraphs(afterXml), { minCoverage });
   } catch (error) {
     console.error(`check_docx_formatting_loss: ${error.message}`);
     return 2;
@@ -447,6 +586,8 @@ export async function main(argv) {
   } else {
     for (const line of formatReport(result)) console.log(line);
   }
+
+  if (result.inconclusive) return 2;
   return hasFindings(result) ? 1 : 0;
 }
 

--- a/scripts/check_docx_formatting_loss.test.mjs
+++ b/scripts/check_docx_formatting_loss.test.mjs
@@ -1,0 +1,248 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import {
+  buildMinimalDocx,
+  detectFormattingLoss,
+  formatReport,
+  hasFindings,
+  main,
+  projectParagraphs,
+  readDocumentXml,
+  SELF_TEST_AFTER_BODY,
+  SELF_TEST_BEFORE_BODY,
+  wrapBodyXml,
+} from './check_docx_formatting_loss.mjs';
+
+function compare(beforeBody, afterBody) {
+  return detectFormattingLoss(projectParagraphs(wrapBodyXml(beforeBody)), projectParagraphs(wrapBodyXml(afterBody)));
+}
+
+function paragraph(paraId, inner, properties = '') {
+  return `<w:p w14:paraId="${paraId}">${properties}${inner}</w:p>`;
+}
+
+function run(text, runProperties = '') {
+  const wrapped = runProperties ? `<w:rPr>${runProperties}</w:rPr>` : '';
+  return `<w:r>${wrapped}<w:t xml:space="preserve">${text}</w:t></w:r>`;
+}
+
+function captureConsole(callback) {
+  const lines = [];
+  const originalLog = console.log;
+  const originalError = console.error;
+  console.log = (...args) => lines.push(args.join(' '));
+  console.error = (...args) => lines.push(args.join(' '));
+  return Promise.resolve(callback())
+    .then((value) => ({ value, lines }))
+    .finally(() => {
+      console.log = originalLog;
+      console.error = originalError;
+    });
+}
+
+test('D1 fires when a cross-run replacement flattens bold onto a defined term', () => {
+  const result = compare(
+    paragraph('AAAA0001', run('Term', '<w:b/>') + run(' means the defined thing.')),
+    paragraph('AAAA0001', run('Term means the defined thing.')),
+  );
+
+  assert.deepEqual(result.flattenedParagraphIds, ['AAAA0001']);
+  assert.equal(hasFindings(result), true);
+});
+
+test('D1 stays silent when a run boundary moves but every character keeps its emphasis', () => {
+  // The shape atomizer token splitting and rsid churn (#677) produce. The
+  // multiset formulation sketched in #682 would report this as a finding.
+  const result = compare(
+    paragraph('AAAA0002', run('Term', '<w:b/>') + run(' means.')),
+    paragraph('AAAA0002', run('Te', '<w:b/>') + run('rm', '<w:b/>') + run(' means.')),
+  );
+
+  assert.deepEqual(result.flattenedParagraphIds, []);
+  assert.equal(hasFindings(result), false);
+});
+
+test('D1 stays silent when the text itself changed, which is a content edit rather than formatting loss', () => {
+  const result = compare(
+    paragraph('AAAA0003', run('Term', '<w:b/>') + run(' means.')),
+    paragraph('AAAA0003', run('Term means something else.')),
+  );
+
+  assert.deepEqual(result.flattenedParagraphIds, []);
+});
+
+test('D1 distinguishes underline styles rather than collapsing them to on/off', () => {
+  const result = compare(
+    paragraph('AAAA0004', run('Signature', '<w:u w:val="single"/>')),
+    paragraph('AAAA0004', run('Signature', '<w:u w:val="dotted"/>')),
+  );
+
+  assert.deepEqual(result.flattenedParagraphIds, ['AAAA0004']);
+});
+
+test('D1 reads w:val on toggle properties, so an explicit on-value is not a change', () => {
+  const unchanged = compare(
+    paragraph('AAAA0005', run('Term', '<w:b/>')),
+    paragraph('AAAA0005', run('Term', '<w:b w:val="1"/>')),
+  );
+  assert.deepEqual(unchanged.flattenedParagraphIds, []);
+
+  const turnedOff = compare(
+    paragraph('AAAA0006', run('Term', '<w:b/>')),
+    paragraph('AAAA0006', run('Term', '<w:b w:val="0"/>')),
+  );
+  assert.deepEqual(turnedOff.flattenedParagraphIds, ['AAAA0006']);
+});
+
+test('D2 flags a paragraph that carried text before and carries none after', () => {
+  const result = compare(paragraph('BBBB0001', run('An obligation.')), paragraph('BBBB0001', ''));
+
+  assert.deepEqual(result.emptiedParagraphIds, ['BBBB0001']);
+});
+
+test('D2 does not flag a paragraph that was already empty', () => {
+  const result = compare(paragraph('BBBB0002', ''), paragraph('BBBB0002', ''));
+
+  assert.deepEqual(result.emptiedParagraphIds, []);
+  assert.deepEqual(result.orphanNumberingParagraphIds, []);
+});
+
+test('D2 flags an emptied paragraph that kept w:numPr, because it renders an orphan label', () => {
+  const numbering = '<w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="3"/></w:numPr></w:pPr>';
+  const result = compare(
+    paragraph('BBBB0003', run('A numbered obligation.'), numbering),
+    paragraph('BBBB0003', '', numbering),
+  );
+
+  assert.deepEqual(result.emptiedParagraphIds, ['BBBB0003']);
+  assert.deepEqual(result.orphanNumberingParagraphIds, ['BBBB0003']);
+});
+
+test('D2 does not report an orphan label for an emptied paragraph with no numbering', () => {
+  const result = compare(paragraph('BBBB0004', run('Body text.')), paragraph('BBBB0004', ''));
+
+  assert.deepEqual(result.emptiedParagraphIds, ['BBBB0004']);
+  assert.deepEqual(result.orphanNumberingParagraphIds, []);
+});
+
+test('a paragraph nested in a text box is projected separately from the paragraph containing it', () => {
+  // A w:p inside w:txbxContent sits inside a run of the outer w:p. Attributing
+  // its runs to the outer paragraph would mask changes on both.
+  const textBox = (inner) =>
+    `<w:r><mc:AlternateContent xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006">` +
+    `<mc:Fallback><w:pict><v:shape xmlns:v="urn:schemas-microsoft-com:vml"><v:textbox><w:txbxContent>` +
+    `${inner}</w:txbxContent></v:textbox></v:shape></w:pict></mc:Fallback></mc:AlternateContent></w:r>`;
+
+  const before = paragraph('CCCC0001', run('Outer', '<w:b/>') + textBox(paragraph('CCCC0002', run('Inner', '<w:b/>'))));
+  const after = paragraph('CCCC0001', run('Outer', '<w:b/>') + textBox(paragraph('CCCC0002', run('Inner'))));
+
+  const projection = projectParagraphs(wrapBodyXml(before));
+  assert.equal(projection.totalParagraphs, 2);
+  assert.deepEqual(projection.byParaId.get('CCCC0001').emphasisSpans, [[5, true, false, 'none']]);
+
+  const result = compare(before, after);
+  assert.deepEqual(result.flattenedParagraphIds, ['CCCC0002']);
+});
+
+test('duplicate paraIds are excluded from matching rather than silently resolved', () => {
+  const body = paragraph('DDDD0001', run('First.')) + paragraph('DDDD0001', run('Second.'));
+  const projection = projectParagraphs(wrapBodyXml(body));
+
+  assert.equal(projection.totalParagraphs, 2);
+  assert.equal(projection.byParaId.has('DDDD0001'), false);
+  assert.deepEqual(projection.duplicateParaIds, ['DDDD0001']);
+
+  const result = detectFormattingLoss(projection, projection);
+  assert.equal(result.matchedParagraphs, 0);
+  assert.equal(result.coverage.beforeDuplicateIds, 1);
+});
+
+test('paragraphs without a paraId are counted as uncompared instead of being key-substituted', () => {
+  const result = compare(
+    paragraph('EEEE0001', run('Keyed.')) + `<w:p>${run('Unkeyed.')}</w:p>`,
+    paragraph('EEEE0001', run('Keyed.')) + `<w:p>${run('Unkeyed.')}</w:p>`,
+  );
+
+  assert.equal(result.matchedParagraphs, 1);
+  assert.equal(result.coverage.beforeUnkeyed, 1);
+  assert.equal(result.coverage.afterUnkeyed, 1);
+  assert.ok(formatReport(result).some((line) => line.includes('carry no w14:paraId and were not compared')));
+});
+
+test('the report states all three counts even when every detector is silent', () => {
+  const lines = formatReport(compare(paragraph('FFFF0001', run('Same.')), paragraph('FFFF0001', run('Same.'))));
+
+  assert.ok(lines.some((line) => line.startsWith('D1 run-formatting flattened paragraphs: 0')));
+  assert.ok(lines.some((line) => line.startsWith('D2 emptied-but-retained paragraphs: 0')));
+  assert.ok(lines.some((line) => line.startsWith('D2 empty paragraphs retaining w:numPr: 0')));
+});
+
+test('neither the report nor the projection carries document text', () => {
+  const secret = 'Zephyrine Quartermain';
+  const before = paragraph('FFFF0002', run(secret, '<w:b/>') + run(' signs.'));
+  const after = paragraph('FFFF0002', run(`${secret} signs.`));
+
+  const projection = projectParagraphs(wrapBodyXml(before));
+  assert.equal(JSON.stringify([...projection.byParaId]).includes(secret), false);
+
+  const result = compare(before, after);
+  assert.equal(formatReport(result).join('\n').includes(secret), false);
+  assert.equal(JSON.stringify(result).includes(secret), false);
+});
+
+test('the id list is truncated so a damaged document cannot flood the report', () => {
+  const ids = Array.from({ length: 25 }, (_, index) => `GGGG${String(index).padStart(4, '0')}`);
+  const before = ids.map((id) => paragraph(id, run('Text.', '<w:b/>'))).join('');
+  const after = ids.map((id) => paragraph(id, run('Text.'))).join('');
+
+  const line = formatReport(compare(before, after)).find((entry) => entry.startsWith('D1'));
+  assert.ok(line.includes('25 ['));
+  assert.ok(line.includes('(+5 more)'));
+});
+
+test('a malformed document part fails loudly instead of projecting zero paragraphs', () => {
+  // Zero paragraphs projects to zero findings, which reads exactly like a pass.
+  assert.throws(() => projectParagraphs(wrapBodyXml('<w:p><w:r></w:p>')), /did not parse/);
+  assert.throws(() => projectParagraphs('<w:p xmlns:w="urn:x"/>garbage'), /did not parse/);
+});
+
+test('the CLI reads real .docx packages and exits 1 on findings, 0 when clean, 2 on misuse', async () => {
+  const directory = mkdtempSync(join(tmpdir(), 'formatting-loss-'));
+  try {
+    const beforePath = join(directory, 'before.docx');
+    const afterPath = join(directory, 'after.docx');
+    writeFileSync(beforePath, await buildMinimalDocx(SELF_TEST_BEFORE_BODY));
+    writeFileSync(afterPath, await buildMinimalDocx(SELF_TEST_AFTER_BODY));
+
+    assert.ok((await readDocumentXml(beforePath)).includes('w:document'));
+
+    const damaged = await captureConsole(() => main([beforePath, afterPath]));
+    assert.equal(damaged.value, 1);
+    assert.ok(damaged.lines.some((line) => line.startsWith('D1 run-formatting flattened paragraphs: 1')));
+
+    const clean = await captureConsole(() => main([beforePath, beforePath]));
+    assert.equal(clean.value, 0);
+
+    const asJson = await captureConsole(() => main(['--json', beforePath, afterPath]));
+    assert.equal(JSON.parse(asJson.lines.join('\n')).flattenedParagraphIds.length, 1);
+
+    const misuse = await captureConsole(() => main([beforePath]));
+    assert.equal(misuse.value, 2);
+
+    const missing = await captureConsole(() => main([beforePath, join(directory, 'absent.docx')]));
+    assert.equal(missing.value, 2);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test('the self-test proves the detectors fire before any run is believed', async () => {
+  const { value, lines } = await captureConsole(() => main(['--self-test']));
+
+  assert.equal(value, 0);
+  assert.ok(lines.some((line) => line.includes('known-good pair clean')));
+  assert.ok(lines.some((line) => line.includes('self-test known-bad D1 run-formatting flattened paragraphs: 1')));
+});

--- a/scripts/check_docx_formatting_loss.test.mjs
+++ b/scripts/check_docx_formatting_loss.test.mjs
@@ -6,6 +6,7 @@ import test from 'node:test';
 import {
   buildMinimalDocx,
   detectFormattingLoss,
+  findRevisionMarkers,
   formatReport,
   hasFindings,
   main,
@@ -16,9 +17,15 @@ import {
   wrapBodyXml,
 } from './check_docx_formatting_loss.mjs';
 
-function compare(beforeBody, afterBody) {
-  return detectFormattingLoss(projectParagraphs(wrapBodyXml(beforeBody)), projectParagraphs(wrapBodyXml(afterBody)));
+function compare(beforeBody, afterBody, options) {
+  return detectFormattingLoss(
+    projectParagraphs(wrapBodyXml(beforeBody)),
+    projectParagraphs(wrapBodyXml(afterBody)),
+    options,
+  );
 }
+
+const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 
 function paragraph(paraId, inner, properties = '') {
   return `<w:p w14:paraId="${paraId}">${properties}${inner}</w:p>`;
@@ -97,6 +104,17 @@ test('D1 reads w:val on toggle properties, so an explicit on-value is not a chan
   assert.deepEqual(turnedOff.flattenedParagraphIds, ['AAAA0006']);
 });
 
+test('D1 sees emphasis dropped by removing a character style, not only direct properties', () => {
+  // Without w:rStyle in the tuple this loss is silent: no direct property
+  // changed, so the projection would compare equal.
+  const result = compare(
+    paragraph('AAAA0007', run('Term', '<w:rStyle w:val="Strong"/>')),
+    paragraph('AAAA0007', run('Term')),
+  );
+
+  assert.deepEqual(result.flattenedParagraphIds, ['AAAA0007']);
+});
+
 test('D2 flags a paragraph that carried text before and carries none after', () => {
   const result = compare(paragraph('BBBB0001', run('An obligation.')), paragraph('BBBB0001', ''));
 
@@ -128,6 +146,34 @@ test('D2 does not report an orphan label for an emptied paragraph with no number
   assert.deepEqual(result.orphanNumberingParagraphIds, []);
 });
 
+test('D2 does not report a numbered paragraph that was already empty before the change', () => {
+  // Otherwise comparing an untouched document to itself exits 1.
+  const numbering = '<w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="3"/></w:numPr></w:pPr>';
+  const body = paragraph('BBBB0005', '', numbering);
+  const result = compare(body, body);
+
+  assert.deepEqual(result.orphanNumberingParagraphIds, []);
+  assert.equal(hasFindings(result), false);
+  assert.equal(result.preExistingEmptyNumbered, 1);
+  assert.ok(formatReport(result).some((line) => line.includes('were already empty before the change')));
+});
+
+test('D2 does not treat an image-only paragraph as empty', () => {
+  // A w:drawing puts marks on the page even though it contributes no w:t text.
+  const drawing = '<w:r><w:drawing><wp:inline xmlns:wp="urn:x"/></w:drawing></w:r>';
+  const numbering = '<w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="3"/></w:numPr></w:pPr>';
+
+  const stillAnImage = compare(paragraph('BBBB0006', drawing, numbering), paragraph('BBBB0006', drawing, numbering));
+  assert.deepEqual(stillAnImage.orphanNumberingParagraphIds, []);
+  assert.equal(stillAnImage.preExistingEmptyNumbered, 0);
+
+  const textToImage = compare(paragraph('BBBB0007', run('Caption.')), paragraph('BBBB0007', drawing));
+  assert.deepEqual(textToImage.emptiedParagraphIds, []);
+
+  const imageRemoved = compare(paragraph('BBBB0008', drawing), paragraph('BBBB0008', ''));
+  assert.deepEqual(imageRemoved.emptiedParagraphIds, ['BBBB0008']);
+});
+
 test('a paragraph nested in a text box is projected separately from the paragraph containing it', () => {
   // A w:p inside w:txbxContent sits inside a run of the outer w:p. Attributing
   // its runs to the outer paragraph would mask changes on both.
@@ -141,7 +187,7 @@ test('a paragraph nested in a text box is projected separately from the paragrap
 
   const projection = projectParagraphs(wrapBodyXml(before));
   assert.equal(projection.totalParagraphs, 2);
-  assert.deepEqual(projection.byParaId.get('CCCC0001').emphasisSpans, [[5, true, false, 'none']]);
+  assert.deepEqual(projection.byParaId.get('CCCC0001').emphasisSpans, [[5, true, false, 'none', '']]);
 
   const result = compare(before, after);
   assert.deepEqual(result.flattenedParagraphIds, ['CCCC0002']);
@@ -157,19 +203,44 @@ test('duplicate paraIds are excluded from matching rather than silently resolved
 
   const result = detectFormattingLoss(projection, projection);
   assert.equal(result.matchedParagraphs, 0);
-  assert.equal(result.coverage.beforeDuplicateIds, 1);
+  assert.equal(result.coverage.beforeDuplicateParagraphs, 2);
 });
 
 test('paragraphs without a paraId are counted as uncompared instead of being key-substituted', () => {
   const result = compare(
     paragraph('EEEE0001', run('Keyed.')) + `<w:p>${run('Unkeyed.')}</w:p>`,
     paragraph('EEEE0001', run('Keyed.')) + `<w:p>${run('Unkeyed.')}</w:p>`,
+    { minCoverage: 0 },
   );
 
   assert.equal(result.matchedParagraphs, 1);
   assert.equal(result.coverage.beforeUnkeyed, 1);
   assert.equal(result.coverage.afterUnkeyed, 1);
-  assert.ok(formatReport(result).some((line) => line.includes('carry no w14:paraId and were not compared')));
+  assert.equal(result.coverageRatio, 0.5);
+});
+
+test('output carrying no paraId at all is inconclusive rather than a clean pass', () => {
+  // reconstructionMode 'rebuild' emits exactly this: every paragraph unkeyed.
+  // Matched=0 makes every detector report zero, which reads as a pass.
+  const result = compare(
+    paragraph('EEEE0002', run('Term', '<w:b/>') + run(' means.')),
+    `<w:p>${run('Term means.')}</w:p>`,
+  );
+
+  assert.equal(result.matchedParagraphs, 0);
+  assert.equal(result.coverageRatio, 0);
+  assert.equal(result.inconclusive, true);
+  assert.equal(hasFindings(result), false);
+  assert.ok(formatReport(result).some((line) => line.startsWith('INCONCLUSIVE')));
+});
+
+test('an unresolvable duplicate group counts every excluded paragraph, not just the id', () => {
+  const body = ['First.', 'Second.', 'Third.'].map((text) => paragraph('EEEE0003', run(text))).join('');
+  const projection = projectParagraphs(wrapBodyXml(body));
+
+  assert.equal(projection.duplicateParagraphs, 3);
+  assert.deepEqual(projection.duplicateParaIds, ['EEEE0003']);
+  assert.equal(detectFormattingLoss(projection, projection).inconclusive, true);
 });
 
 test('the report states all three counts even when every detector is silent', () => {
@@ -209,6 +280,23 @@ test('a malformed document part fails loudly instead of projecting zero paragrap
   assert.throws(() => projectParagraphs('<w:p xmlns:w="urn:x"/>garbage'), /did not parse/);
 });
 
+test('a well-formed part that is not a w:document is rejected rather than read as empty', () => {
+  assert.throws(() => projectParagraphs('<foo/>'), /not a WordprocessingML w:document part/);
+  assert.throws(
+    () => projectParagraphs(`<w:document xmlns:w="${W_NS}"><w:notBody/></w:document>`),
+    /has no w:body/,
+  );
+});
+
+test('revision markup is detected so a redline is never mistaken for clean output', () => {
+  assert.deepEqual(findRevisionMarkers(wrapBodyXml(paragraph('HHHH0001', run('Clean.')))), []);
+
+  const redline =
+    `<w:p w14:paraId="HHHH0002"><w:del w:id="1" w:author="x" w:date="2026-01-01T00:00:00Z">` +
+    `<w:r><w:delText>Gone.</w:delText></w:r></w:del></w:p>`;
+  assert.deepEqual(findRevisionMarkers(wrapBodyXml(redline)), ['del']);
+});
+
 test('the CLI reads real .docx packages and exits 1 on findings, 0 when clean, 2 on misuse', async () => {
   const directory = mkdtempSync(join(tmpdir(), 'formatting-loss-'));
   try {
@@ -234,6 +322,51 @@ test('the CLI reads real .docx packages and exits 1 on findings, 0 when clean, 2
 
     const missing = await captureConsole(() => main([beforePath, join(directory, 'absent.docx')]));
     assert.equal(missing.value, 2);
+
+    // An unknown flag must not be swallowed — a typo'd threshold would
+    // otherwise silently run at the default and read as a deliberate result.
+    const typo = await captureConsole(() => main(['--min-coverge', '0.5', beforePath, afterPath]));
+    assert.equal(typo.value, 2);
+    assert.ok(typo.lines.some((line) => line.includes('unknown option --min-coverge')));
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test('the CLI refuses a redline and exits 2 rather than answering a question it cannot answer', async () => {
+  const directory = mkdtempSync(join(tmpdir(), 'formatting-loss-redline-'));
+  try {
+    const cleanPath = join(directory, 'clean.docx');
+    const redlinePath = join(directory, 'redline.docx');
+    writeFileSync(cleanPath, await buildMinimalDocx(SELF_TEST_BEFORE_BODY));
+    writeFileSync(
+      redlinePath,
+      await buildMinimalDocx(
+        `<w:p w14:paraId="11111111"><w:ins w:id="1" w:author="x" w:date="2026-01-01T00:00:00Z">` +
+          `<w:r><w:t>Added.</w:t></w:r></w:ins></w:p>`,
+      ),
+    );
+
+    const { value, lines } = await captureConsole(() => main([cleanPath, redlinePath]));
+    assert.equal(value, 2);
+    assert.ok(lines.some((line) => line.includes('carries revision markup')));
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test('rebuild-shaped output exits 2 through the CLI instead of reporting a pass', async () => {
+  const directory = mkdtempSync(join(tmpdir(), 'formatting-loss-rebuild-'));
+  try {
+    const keyedPath = join(directory, 'keyed.docx');
+    const unkeyedPath = join(directory, 'unkeyed.docx');
+    writeFileSync(keyedPath, await buildMinimalDocx(SELF_TEST_BEFORE_BODY));
+    // Same content with every w14:paraId removed — what 'rebuild' emits.
+    writeFileSync(unkeyedPath, await buildMinimalDocx(SELF_TEST_AFTER_BODY.replace(/ w14:paraId="[^"]*"/g, '')));
+
+    const { value, lines } = await captureConsole(() => main([keyedPath, unkeyedPath]));
+    assert.equal(value, 2);
+    assert.ok(lines.some((line) => line.startsWith('INCONCLUSIVE')));
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }


### PR DESCRIPTION
Closes #682.

## Problem

A comparison run that produces no visible error is not the same as one that
succeeded. Extracted text can come back byte-identical, round-trip can report
success, and the output can open cleanly in Word while a defect a reader
notices on the first page is still there.

The failure taxonomy had no class for formatting destroyed while every
character survives, so that class passed every check the diagnostic procedure
routinely runs, and shipped twice unnoticed. Two shapes: a replacement whose
span crosses a run boundary flattens bold off a defined term; replacing a block
leaves an emptied paragraph shell that renders a blank line, or an orphan
numbered label when it keeps its `w:numPr`.

There was also no stated pass criterion, which made "it worked" unfalsifiable,
and no control arm, which made "no failure reproduced" ambiguous.

## What this adds

`scripts/check_docx_formatting_loss.mjs` — two structural detectors over a
before/after pair, plus `docs/comparison-failure-diagnosis.md` stating the
five-part pass criterion, the control-arm requirement, and the scrub-in-place
repro policy.

- **D1** projects each character of a paragraph onto its
  `(bold, italic, underline, character style)` tuple and fires when the text is
  unchanged but the projection is not.
- **D2** matches paragraphs on `w14:paraId` and flags those emptied between the
  two sides, including emptied paragraphs that kept their numbering.
- `--self-test` proves the detectors fire on a known-bad pair and stay silent on
  a known-good one. It runs in CI. A detector never shown to fire cannot be told
  apart from one that did not run.

Detector reports emit counts, `w14:paraId` values, and element names only, and
the projection keeps a digest of each paragraph's text rather than the text, so
a run over material that cannot be shared still produces reportable output.

## Two deliberate deviations from the issue

**D1 is a per-character projection, not the multiset of runs the issue
sketches.** A multiset keyed on `(text, bold, italic, underline)` fires whenever
a run boundary moves, including moves that preserve every character's emphasis
— which this codebase produces routinely via atomizer token splitting and rsid
churn (#677). On a 1500-paragraph document that false-positive class would swamp
the signal. Regression test included.

**Duplicate `w14:paraId` values are excluded from matching, not resolved.** The
issue's sketch keys a dictionary on `paraId`, which resolves duplicates by last
write. Real documents carry them — a real contract pair measured 17 and 19 per
side — so those paragraphs are counted as uncompared instead.

## Peer review found a defect that would have made the tool useless

Codex executed the detectors against real engine output rather than reading the
diff, and demonstrated that **`reconstructionMode: 'rebuild'` emits output
carrying no `w14:paraId` at all**. Independently reproduced: 1 paragraph in, 0
`paraId` attributes out. Every paragraph then failed to match, every detector
reported zero, and the CLI exited 0 — a clean pass over a document it had never
read, which is exactly the failure mode this change exists to prevent. Pass
criterion item 5 requires running rebuild, so the criterion was self-defeating
as first written.

Coverage is now enforced rather than merely reported: below 95% the result is
`INCONCLUSIVE` and exits 2, with `--min-coverage` to move the floor
deliberately. The real pair measures 97% and stays conclusive.

The same review also caught: D1 missing emphasis dropped via `w:rStyle`
removal; D2 flagging unchanged empty numbered paragraphs, so an untouched
document compared to itself exited 1; image-only paragraphs read as empty; and
the tool silently accepting redlines, non-`w:document` parts, and unknown
flags. All fixed with tests against their reproductions.

## Known limits, stated rather than hidden

- D1 compares *declared* formatting — direct `w:rPr` plus the `w:rStyle`
  reference — not formatting resolved through `styles.xml`. Paragraph-style
  inheritance and edits to a style definition are invisible. #684 tracks
  consolidating onto docx-core's existing effective-formatting resolver rather
  than growing a second one here.
- D1 requires identical text, so loss co-occurring with a text edit in the same
  paragraph is out of reach.
- The `--self-test` is a synthetic control over the detector logic, not over the
  comparison engine. The guide's own warning about synthetic fixtures applies to
  it.

## Verification

```
node --test scripts/check_docx_formatting_loss.test.mjs   27 pass, 0 fail
npm run test:docx-formatting-loss                         exit 0
npm run build                                             exit 0
npm run lint:workspaces                                   exit 0
npm run check:control-bytes                               exit 0
```

Also exercised end-to-end against a real 1500-paragraph document pair (0.9s),
and against real `compareDocuments` output in both reconstruction modes.