### PR TITLE
test(docx-compare): profile corpus outcomes by runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,6 +408,43 @@ jobs:
             packages/docx-core/allure-results/
             packages/docx-mcp/allure-results/
 
+  real-corpus-comparison:
+    name: Real-corpus paragraph deletion
+    runs-on: ubuntu-latest
+    needs: workspace-lint
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies (npm ci with retry)
+        run: |
+          for attempt in 1 2 3; do
+            echo "npm ci attempt ${attempt}/3"
+            if npm ci; then
+              exit 0
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              sleep $((attempt * 20))
+            fi
+          done
+          echo "npm ci failed after 3 attempts"
+          exit 1
+      - name: Materialize SHA-256-verified comparison corpus
+        env:
+          SAFE_DOCX_REAL_CORPUS_DIR: ${{ runner.temp }}/open-agreements-cache
+        run: node scripts/prepare_real_comparison_corpus.mjs "$SAFE_DOCX_REAL_CORPUS_DIR"
+      - name: Run real-corpus paragraph-deletion gate
+        env:
+          SAFE_DOCX_REAL_CORPUS_DIR: ${{ runner.temp }}/open-agreements-cache
+          SAFE_DOCX_REAL_CORPUS_REQUIRED: "1"
+        run: >-
+          npm run test:run -w @usejunior/docx-compare --
+          src/integration/real-corpus-paragraph-deletion.test.ts
+
   mcpb-bundle:
     runs-on: ubuntu-latest
     needs: workspace-test

--- a/packages/docx-compare/src/integration/real-corpus-manifest.json
+++ b/packages/docx-compare/src/integration/real-corpus-manifest.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": "nvca-certificate-of-incorporation",
+    "sourceUrl": "https://nvca.org/wp-content/uploads/2025/10/NVCA-Model-COI-10-1-2025.docx",
+    "sha256": "d75600769c12724990de48149d7a2bb161f3522daa54b1783672f93697d87d29"
+  },
+  {
+    "id": "nvca-indemnification-agreement",
+    "sourceUrl": "https://nvca.org/wp-content/uploads/2021/12/NVCA-2020-Indemnification-Agreement.docx",
+    "sha256": "f9b61b4d99e245573de41d9469925b4332f871ec0e6ac6593055cdfe17825300"
+  },
+  {
+    "id": "nvca-investors-rights-agreement",
+    "sourceUrl": "https://nvca.org/wp-content/uploads/2025/10/NVCA-Model-IRA-10-1-2025-2-1.docx",
+    "sha256": "be8ad13f171a343bdb53716b1d318689ae3477cdf7f1986b2e3985e1cabbd08a"
+  },
+  {
+    "id": "nvca-management-rights-letter",
+    "sourceUrl": "https://nvca.org/wp-content/uploads/2025/12/NVCA-2020-Management-Rights-Letter-1-1.docx",
+    "sha256": "9661d2a68ca20ee77cf553f1ec5804f08147e7e4c35f5a03938e76a778083e8b"
+  },
+  {
+    "id": "nvca-rofr-co-sale-agreement",
+    "sourceUrl": "https://nvca.org/wp-content/uploads/2025/10/NVCA-Model-ROFRA-10-1-2025.docx",
+    "sha256": "126b4a402d41b768ff0c9aebf593792159c31ca7a930c440dd5ae0516ef4c4ad"
+  },
+  {
+    "id": "nvca-stock-purchase-agreement",
+    "sourceUrl": "https://nvca.org/wp-content/uploads/2025/10/NVCA-Model-SPA-10-28-2025-1.docx",
+    "sha256": "b2c76452fa82dcda72f1fa9f82ba0ce28ea9445441c897f9cb7ac6663930dcab"
+  },
+  {
+    "id": "nvca-voting-agreement",
+    "sourceUrl": "https://nvca.org/wp-content/uploads/2024/10/NVCA-Model-VA-10-1-2025.docx",
+    "sha256": "3496d7ae9343d1b5b7db13239313c6512e7e0d68d13273538c4dbf06416a5f0d"
+  }
+]

--- a/packages/docx-compare/src/integration/real-corpus-paragraph-deletion.test.ts
+++ b/packages/docx-compare/src/integration/real-corpus-paragraph-deletion.test.ts
@@ -1,0 +1,481 @@
+/**
+ * Real-corpus paragraph-deletion comparison gate.
+ *
+ * Synthetic fixtures are deliberately insufficient here: Word-authored NVCA
+ * agreements contain field and bookmark layouts that previously escaped a
+ * completely green suite. Each corpus source is SHA-256-pinned and exercised
+ * in both reconstruction modes after removing one real paragraph.
+ *
+ * Known defects use exact characterization outcomes so a behavior change fails
+ * the gate in either direction. A different failure is a regression; a cell
+ * that unexpectedly starts passing also fails and requires its pin to be removed.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.5
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.6.1
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.6.2
+ * @see https://github.com/UseJunior/safe-docx/issues/658
+ * @see https://github.com/UseJunior/safe-docx/issues/643
+ * @see https://github.com/UseJunior/safe-docx/issues/645
+ * @see https://github.com/UseJunior/safe-docx/issues/646
+ */
+
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  DOMParser,
+  XMLSerializer,
+  type Document as XmlDocument,
+  type Element as XmlElement,
+  type Node as XmlNode,
+} from '@xmldom/xmldom';
+import JSZip from 'jszip';
+import { describe, expect } from 'vitest';
+import { compareDocumentsAtomizer } from '../baselines/atomizer/pipeline.js';
+import type { ReconstructionMode } from '../compare-types.js';
+import { testAllure } from '../testing/allure-test.js';
+
+const CORPUS_ENV = 'SAFE_DOCX_REAL_CORPUS_DIR';
+const REQUIRED_ENV = 'SAFE_DOCX_REAL_CORPUS_REQUIRED';
+const INTEGRATION_DIR = dirname(fileURLToPath(import.meta.url));
+const MANIFEST_PATH = join(INTEGRATION_DIR, 'real-corpus-manifest.json');
+const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+interface CorpusEntry {
+  id: string;
+  sourceUrl: string;
+  sha256: string;
+}
+
+interface CorpusAvailability {
+  available: boolean;
+  skipWarning: string | null;
+  entries: CorpusEntry[];
+}
+
+interface ParagraphDeletion {
+  revised: Buffer;
+  targetedBookmarkNames: string[];
+}
+
+type CellOutcome =
+  | { kind: 'pass' }
+  | { kind: 'bookmark-range-failure'; names: string[] }
+  | { kind: 'comparison-error'; errorName: string; message: string };
+
+type ExpectedFailure =
+  | {
+      issue: string;
+      kind: 'bookmark-range-failure';
+      names: string[];
+    }
+  | {
+      issue: string;
+      kind: 'comparison-error';
+      errorName: string;
+      messageIncludes: string;
+    };
+
+const corpusEntries = JSON.parse(readFileSync(MANIFEST_PATH, 'utf8')) as CorpusEntry[];
+
+const boundaryShiftFailure: ExpectedFailure = {
+  issue: '#646',
+  kind: 'comparison-error',
+  errorName: 'OpaquePassthroughError',
+  messageIncludes: 'boundary 0 changed paragraph ownership, moved, or mutated',
+};
+
+const nestedFieldFailure: ExpectedFailure = {
+  issue: '#645',
+  kind: 'comparison-error',
+  errorName: 'AncillaryStorySafetyError',
+  messageIncludes: 'Ancillary story safety check failed with 3 issue(s)',
+};
+
+const expectedFailures: Readonly<
+  Record<string, Partial<Record<ReconstructionMode, ExpectedFailure>>>
+> = {
+  'nvca-certificate-of-incorporation': { rebuild: boundaryShiftFailure },
+  'nvca-indemnification-agreement': {
+    inplace: nestedFieldFailure,
+    rebuild: {
+      issue: '#646',
+      kind: 'comparison-error',
+      errorName: 'OpaquePassthroughError',
+      messageIncludes: 'boundary count changed (108 original, 106 revised)',
+    },
+  },
+  'nvca-investors-rights-agreement': {
+    rebuild: {
+      issue: '#646',
+      kind: 'comparison-error',
+      errorName: 'OpaquePassthroughError',
+      messageIncludes: 'unsupported REF field instruction shape',
+    },
+  },
+  'nvca-rofr-co-sale-agreement': {
+    inplace: {
+      issue: '#643',
+      kind: 'bookmark-range-failure',
+      names: ['_Ref_ContractCompanion_9kb9Ur019'],
+    },
+    rebuild: boundaryShiftFailure,
+  },
+  'nvca-stock-purchase-agreement': {
+    rebuild: {
+      issue: '#646',
+      kind: 'comparison-error',
+      errorName: 'OpaquePassthroughError',
+      messageIncludes: 'boundary count changed (68 original, 67 revised)',
+    },
+  },
+  'nvca-voting-agreement': {
+    inplace: {
+      issue: '#643',
+      kind: 'bookmark-range-failure',
+      names: ['_Ref444624639'],
+    },
+    rebuild: {
+      issue: '#646',
+      kind: 'comparison-error',
+      errorName: 'OpaquePassthroughError',
+      messageIncludes: 'boundary count changed (64 original, 63 revised)',
+    },
+  },
+};
+
+const preferredDeletionTarget: Readonly<Partial<Record<string, string>>> = {
+  'nvca-voting-agreement': '_Ref444624639',
+};
+
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({
+    feature: 'Real-Corpus Paragraph Deletion Gate',
+    story: 'Word-Authored Agreement Paragraph Deletion',
+    severity: 'critical',
+  })
+  .conformance(
+    { spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.5' },
+    { spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.6.1' },
+    { spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.6.2' },
+  );
+
+function sha256(buffer: Buffer): string {
+  return createHash('sha256').update(buffer).digest('hex');
+}
+
+function resolveCorpusAvailability(corpusRoot: string): CorpusAvailability {
+  const problems: string[] = [];
+  if (!corpusRoot) {
+    problems.push(`${CORPUS_ENV} is unset`);
+  } else {
+    for (const entry of corpusEntries) {
+      const sourcePath = join(corpusRoot, entry.id, 'source.docx');
+      if (!existsSync(sourcePath)) {
+        problems.push(`${entry.id}/source.docx is missing`);
+        continue;
+      }
+      const actualSha256 = sha256(readFileSync(sourcePath));
+      if (actualSha256 !== entry.sha256) {
+        problems.push(`${entry.id}/source.docx failed SHA-256 verification`);
+      }
+    }
+  }
+
+  return {
+    available: problems.length === 0,
+    entries: corpusEntries,
+    skipWarning:
+      problems.length === 0
+        ? null
+        : `[real-corpus-paragraph-deletion] SKIP: set ${CORPUS_ENV} to the ` +
+          `SHA-256-verified Open Agreements cache root. ${problems.join('; ')}.`,
+  };
+}
+
+function elements(node: XmlDocument | XmlElement, tagName: string): XmlElement[] {
+  return Array.from(node.getElementsByTagName(tagName));
+}
+
+function fieldTargetNames(documentXml: string): Set<string> {
+  const document = new DOMParser().parseFromString(documentXml, 'text/xml');
+  const instructions = [
+    ...elements(document, 'w:instrText').map((node) => node.textContent ?? ''),
+    ...elements(document, 'w:fldSimple').map(
+      (node) => node.getAttribute('w:instr') ?? node.getAttributeNS(W_NS, 'instr') ?? '',
+    ),
+  ];
+  const names = new Set<string>();
+  for (const instruction of instructions) {
+    const match = instruction.match(/\b(?:REF|PAGEREF)\s+(?:"([^"]+)"|([^\s\\]+))/i);
+    const name = match?.[1] ?? match?.[2];
+    if (name) names.add(name);
+  }
+  return names;
+}
+
+function directBodyParagraphs(document: XmlDocument): XmlElement[] {
+  const body = elements(document, 'w:body')[0];
+  if (!body) throw new Error('word/document.xml has no w:body');
+  return Array.from(body.childNodes).filter(
+    (node): node is XmlElement =>
+      node.nodeType === 1 && (node as XmlElement).tagName === 'w:p',
+  );
+}
+
+function targetedBookmarkNames(
+  paragraph: XmlElement,
+  targets: Set<string>,
+): { all: string[]; midParagraph: string[] } {
+  const orderedNodes: XmlNode[] = [];
+  const visit = (node: XmlNode): void => {
+    orderedNodes.push(node);
+    for (const child of Array.from(node.childNodes)) visit(child);
+  };
+  visit(paragraph);
+
+  const all: string[] = [];
+  const midParagraph: string[] = [];
+  for (const start of elements(paragraph, 'w:bookmarkStart')) {
+    const name = start.getAttribute('w:name') ?? start.getAttributeNS(W_NS, 'name');
+    const id = start.getAttribute('w:id') ?? start.getAttributeNS(W_NS, 'id');
+    if (!name || !id || !targets.has(name)) continue;
+    const end = elements(paragraph, 'w:bookmarkEnd').find(
+      (candidate) =>
+        (candidate.getAttribute('w:id') ?? candidate.getAttributeNS(W_NS, 'id')) === id,
+    );
+    if (!end) continue;
+    const startIndex = orderedNodes.indexOf(start);
+    const endIndex = orderedNodes.indexOf(end);
+    const hasTextInside = orderedNodes.some(
+      (node, index) =>
+        index > startIndex &&
+        index < endIndex &&
+        node.nodeType === 3 &&
+        (node.nodeValue ?? '').trim() !== '',
+    );
+    if (!hasTextInside) continue;
+    all.push(name);
+    const hasTextAfter = orderedNodes.some(
+      (node, index) =>
+        index > endIndex && node.nodeType === 3 && (node.nodeValue ?? '').trim() !== '',
+    );
+    if (hasTextAfter) midParagraph.push(name);
+  }
+  return { all, midParagraph };
+}
+
+function selectDeletionParagraph(
+  paragraphs: XmlElement[],
+  targetNames: Set<string>,
+  preferredTargetName?: string,
+): { paragraph: XmlElement; targetedBookmarkNames: string[] } {
+  const candidates = paragraphs
+    .map((paragraph) => {
+      const targets = targetedBookmarkNames(paragraph, targetNames);
+      return {
+        paragraph,
+        targetedBookmarkNames: targets.all,
+        midParagraphTargetedBookmarkNames: targets.midParagraph,
+        text: paragraph.textContent?.trim() ?? '',
+      };
+    })
+    .filter((candidate) => candidate.text.length >= 20);
+
+  const selected =
+    candidates.find((candidate) =>
+      candidate.midParagraphTargetedBookmarkNames.includes(preferredTargetName ?? ''),
+    ) ??
+    candidates.find((candidate) => candidate.midParagraphTargetedBookmarkNames.length > 0) ??
+    candidates.find((candidate) => candidate.targetedBookmarkNames.length > 0) ??
+    candidates.find((_candidate, index) => index > 0 && index < candidates.length - 1);
+
+  if (!selected) throw new Error('no suitable body-level paragraph found for deletion');
+  return {
+    paragraph: selected.paragraph,
+    targetedBookmarkNames:
+      preferredTargetName &&
+      selected.midParagraphTargetedBookmarkNames.includes(preferredTargetName)
+        ? [preferredTargetName]
+        : selected.midParagraphTargetedBookmarkNames.length > 0
+        ? selected.midParagraphTargetedBookmarkNames
+        : selected.targetedBookmarkNames,
+  };
+}
+
+async function deleteOneRealParagraph(
+  original: Buffer,
+  preferredTargetName?: string,
+): Promise<ParagraphDeletion> {
+  const zip = await JSZip.loadAsync(original);
+  const documentPart = zip.file('word/document.xml');
+  if (!documentPart) throw new Error('DOCX has no word/document.xml');
+  const documentXml = await documentPart.async('string');
+  const document = new DOMParser().parseFromString(documentXml, 'text/xml');
+  const selected = selectDeletionParagraph(
+    directBodyParagraphs(document),
+    fieldTargetNames(documentXml),
+    preferredTargetName,
+  );
+  selected.paragraph.parentNode?.removeChild(selected.paragraph);
+  zip.file('word/document.xml', new XMLSerializer().serializeToString(document));
+  return {
+    revised: await zip.generateAsync({ type: 'nodebuffer' }),
+    targetedBookmarkNames: selected.targetedBookmarkNames,
+  };
+}
+
+function collapsedTargetedBookmarkNames(
+  comparedDocumentXml: string,
+  names: string[],
+): string[] {
+  const document = new DOMParser().parseFromString(comparedDocumentXml, 'text/xml');
+  const collapsed: string[] = [];
+  for (const name of names) {
+    const start = elements(document, 'w:bookmarkStart').find(
+      (candidate) =>
+        (candidate.getAttribute('w:name') ?? candidate.getAttributeNS(W_NS, 'name')) === name,
+    );
+    if (!start) {
+      collapsed.push(name);
+      continue;
+    }
+    const id = start.getAttribute('w:id') ?? start.getAttributeNS(W_NS, 'id');
+    const end = elements(document, 'w:bookmarkEnd').find(
+      (candidate) =>
+        (candidate.getAttribute('w:id') ?? candidate.getAttributeNS(W_NS, 'id')) === id,
+    );
+    if (!end) {
+      collapsed.push(name);
+      continue;
+    }
+
+    const paragraph = start.parentNode as XmlElement | null;
+    if (paragraph?.tagName !== 'w:p' || end.parentNode !== paragraph) {
+      collapsed.push(name);
+      continue;
+    }
+
+    const orderedElements: XmlElement[] = [];
+    const visit = (node: XmlNode): void => {
+      if (node.nodeType === 1) orderedElements.push(node as XmlElement);
+      for (const child of Array.from(node.childNodes)) visit(child);
+    };
+    visit(paragraph);
+    const startIndex = orderedElements.indexOf(start);
+    const endIndex = orderedElements.indexOf(end);
+    const deletedTextIndex = orderedElements.findIndex(
+      (element, index) =>
+        index > startIndex && index < endIndex && element.tagName === 'w:delText',
+    );
+    if (startIndex >= endIndex || deletedTextIndex <= startIndex) collapsed.push(name);
+  }
+  return collapsed;
+}
+
+async function runCell(
+  entry: CorpusEntry,
+  reconstructionMode: ReconstructionMode,
+): Promise<CellOutcome> {
+  const original = readFileSync(join(corpusRoot, entry.id, 'source.docx'));
+  const deletion = await deleteOneRealParagraph(
+    original,
+    preferredDeletionTarget[entry.id],
+  );
+  try {
+    const result = await compareDocumentsAtomizer(original, deletion.revised, {
+      author: 'Real Corpus Gate',
+      date: new Date('2026-07-26T00:00:00Z'),
+      reconstructionMode,
+    });
+    if (result.reconstructionModeUsed !== reconstructionMode) {
+      return {
+        kind: 'comparison-error',
+        errorName: 'ReconstructionModeMismatch',
+        message: `requested ${reconstructionMode}, used ${String(result.reconstructionModeUsed)}`,
+      };
+    }
+    const comparedZip = await JSZip.loadAsync(result.document);
+    const comparedDocumentXml = await comparedZip.file('word/document.xml')!.async('string');
+    const collapsedNames = collapsedTargetedBookmarkNames(
+      comparedDocumentXml,
+      deletion.targetedBookmarkNames,
+    );
+    return collapsedNames.length === 0
+      ? { kind: 'pass' }
+      : { kind: 'bookmark-range-failure', names: collapsedNames };
+  } catch (error) {
+    if (!(error instanceof Error)) throw error;
+    return {
+      kind: 'comparison-error',
+      errorName: error.constructor.name,
+      message: error.message,
+    };
+  }
+}
+
+function assertExpectedOutcome(outcome: CellOutcome, expectedFailure?: ExpectedFailure): void {
+  if (!expectedFailure) {
+    expect(outcome).toEqual({ kind: 'pass' });
+    return;
+  }
+  expect(outcome.kind, `${expectedFailure.issue} characterization kind`).toBe(
+    expectedFailure.kind,
+  );
+  if (
+    outcome.kind === 'bookmark-range-failure' &&
+    expectedFailure.kind === 'bookmark-range-failure'
+  ) {
+    expect(outcome.names).toEqual(expectedFailure.names);
+    return;
+  }
+  if (outcome.kind === 'comparison-error' && expectedFailure.kind === 'comparison-error') {
+    expect(outcome.errorName).toBe(expectedFailure.errorName);
+    expect(outcome.message).toContain(expectedFailure.messageIncludes);
+  }
+}
+
+const corpusRoot = process.env[CORPUS_ENV] ?? '';
+const corpusAvailability = resolveCorpusAvailability(corpusRoot);
+if (!corpusAvailability.available) {
+  console.warn(corpusAvailability.skipWarning);
+}
+
+describe('real-corpus gate availability', () => {
+  test('an unset corpus directory resolves to a logged skip warning naming the variable', () => {
+    const resolution = resolveCorpusAvailability('');
+    expect(resolution.available).toBe(false);
+    expect(resolution.skipWarning).toContain('SKIP');
+    expect(resolution.skipWarning).toContain(CORPUS_ENV);
+  });
+
+  if (process.env[REQUIRED_ENV] === '1') {
+    test('required CI corpus is complete and SHA-256 verified', () => {
+      expect(corpusAvailability.skipWarning).toBeNull();
+      expect(corpusAvailability.available).toBe(true);
+    });
+  }
+});
+
+describe.skipIf(!corpusAvailability.available)('real-corpus paragraph deletion matrix', () => {
+  for (const entry of corpusAvailability.entries) {
+    for (const reconstructionMode of ['inplace', 'rebuild'] as const) {
+      const expectedFailure = expectedFailures[entry.id]?.[reconstructionMode];
+      const title =
+        `${entry.id} × ${reconstructionMode} × paragraph-deletion` +
+        (expectedFailure ? ` characterizes ${expectedFailure.issue}` : '');
+      test(
+        title,
+        async () => {
+          assertExpectedOutcome(
+            await runCell(entry, reconstructionMode),
+            expectedFailure,
+          );
+        },
+        120_000,
+      );
+    }
+  }
+});

--- a/packages/docx-compare/src/integration/real-corpus-paragraph-deletion.test.ts
+++ b/packages/docx-compare/src/integration/real-corpus-paragraph-deletion.test.ts
@@ -38,6 +38,7 @@ import { testAllure } from '../testing/allure-test.js';
 
 const CORPUS_ENV = 'SAFE_DOCX_REAL_CORPUS_DIR';
 const REQUIRED_ENV = 'SAFE_DOCX_REAL_CORPUS_REQUIRED';
+const CI_RUNTIME_PROFILE = 'linux-node20';
 const INTEGRATION_DIR = dirname(fileURLToPath(import.meta.url));
 const MANIFEST_PATH = join(INTEGRATION_DIR, 'real-corpus-manifest.json');
 const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
@@ -93,12 +94,12 @@ const nestedFieldFailure: ExpectedFailure = {
   messageIncludes: 'Ancillary story safety check failed with 3 issue(s)',
 };
 
-const expectedFailures: Readonly<
+type ExpectedFailures = Readonly<
   Record<string, Partial<Record<ReconstructionMode, ExpectedFailure>>>
-> = {
-  'nvca-certificate-of-incorporation': { rebuild: boundaryShiftFailure },
+>;
+
+const commonExpectedFailures: ExpectedFailures = {
   'nvca-indemnification-agreement': {
-    inplace: nestedFieldFailure,
     rebuild: {
       issue: '#646',
       kind: 'comparison-error',
@@ -120,7 +121,6 @@ const expectedFailures: Readonly<
       kind: 'bookmark-range-failure',
       names: ['_Ref_ContractCompanion_9kb9Ur019'],
     },
-    rebuild: boundaryShiftFailure,
   },
   'nvca-stock-purchase-agreement': {
     rebuild: {
@@ -144,6 +144,37 @@ const expectedFailures: Readonly<
     },
   },
 };
+
+const darwinNode26ExpectedFailures: ExpectedFailures = {
+  'nvca-certificate-of-incorporation': { rebuild: boundaryShiftFailure },
+  'nvca-indemnification-agreement': { inplace: nestedFieldFailure },
+  'nvca-rofr-co-sale-agreement': { rebuild: boundaryShiftFailure },
+};
+
+function currentRuntimeProfile(): string {
+  const nodeMajor = process.versions.node.split('.')[0];
+  return `${process.platform}-node${nodeMajor}`;
+}
+
+function expectedFailuresForRuntime(runtimeProfile: string): ExpectedFailures {
+  if (runtimeProfile !== 'darwin-node26') return commonExpectedFailures;
+
+  return Object.fromEntries(
+    Array.from(
+      new Set([
+        ...Object.keys(commonExpectedFailures),
+        ...Object.keys(darwinNode26ExpectedFailures),
+      ]),
+      (entryId) => [
+        entryId,
+        {
+          ...commonExpectedFailures[entryId],
+          ...darwinNode26ExpectedFailures[entryId],
+        },
+      ],
+    ),
+  );
+}
 
 const preferredDeletionTarget: Readonly<Partial<Record<string, string>>> = {
   'nvca-voting-agreement': '_Ref444624639',
@@ -439,6 +470,8 @@ function assertExpectedOutcome(outcome: CellOutcome, expectedFailure?: ExpectedF
 
 const corpusRoot = process.env[CORPUS_ENV] ?? '';
 const corpusAvailability = resolveCorpusAvailability(corpusRoot);
+const runtimeProfile = currentRuntimeProfile();
+const expectedFailures = expectedFailuresForRuntime(runtimeProfile);
 if (!corpusAvailability.available) {
   console.warn(corpusAvailability.skipWarning);
 }
@@ -451,10 +484,32 @@ describe('real-corpus gate availability', () => {
     expect(resolution.skipWarning).toContain(CORPUS_ENV);
   });
 
+  test('runtime profiles preserve the characterized Darwin-only failures', () => {
+    const linuxFailures = expectedFailuresForRuntime(CI_RUNTIME_PROFILE);
+    const darwinFailures = expectedFailuresForRuntime('darwin-node26');
+
+    expect(linuxFailures['nvca-certificate-of-incorporation']?.rebuild).toBeUndefined();
+    expect(linuxFailures['nvca-indemnification-agreement']?.inplace).toBeUndefined();
+    expect(linuxFailures['nvca-rofr-co-sale-agreement']?.rebuild).toBeUndefined();
+    expect(darwinFailures['nvca-certificate-of-incorporation']?.rebuild).toEqual(
+      boundaryShiftFailure,
+    );
+    expect(darwinFailures['nvca-indemnification-agreement']?.inplace).toEqual(
+      nestedFieldFailure,
+    );
+    expect(darwinFailures['nvca-rofr-co-sale-agreement']?.rebuild).toEqual(
+      boundaryShiftFailure,
+    );
+  });
+
   if (process.env[REQUIRED_ENV] === '1') {
     test('required CI corpus is complete and SHA-256 verified', () => {
       expect(corpusAvailability.skipWarning).toBeNull();
       expect(corpusAvailability.available).toBe(true);
+    });
+
+    test('required CI runs on the characterized runtime profile', () => {
+      expect(runtimeProfile).toBe(CI_RUNTIME_PROFILE);
     });
   }
 });

--- a/packages/docx-core/src/integration/nvca-structural-regression.test.ts
+++ b/packages/docx-core/src/integration/nvca-structural-regression.test.ts
@@ -16,10 +16,8 @@ describe('NVCA Structural Regression', () => {
     let res: Awaited<ReturnType<typeof compareDocuments>>;
 
     await given('NVCA source and filled fixture files exist and are loaded', async () => {
-      if (!fs.existsSync(sourcePath) || !fs.existsSync(filledPath)) {
-        console.warn('Skipping NVCA Structural Regression: fixture files not found');
-        return;
-      }
+      expect(fs.existsSync(sourcePath), `missing committed fixture: ${sourcePath}`).toBe(true);
+      expect(fs.existsSync(filledPath), `missing committed fixture: ${filledPath}`).toBe(true);
       sourceBuf = fs.readFileSync(sourcePath);
       filledBuf = fs.readFileSync(filledPath);
     });

--- a/scripts/prepare_real_comparison_corpus.mjs
+++ b/scripts/prepare_real_comparison_corpus.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = resolve(SCRIPT_DIR, '..');
+const MANIFEST_PATH = join(
+  PROJECT_ROOT,
+  'packages/docx-compare/src/integration/real-corpus-manifest.json',
+);
+const destinationRoot = process.argv[2];
+
+if (!destinationRoot) {
+  console.error(
+    'Usage: node scripts/prepare_real_comparison_corpus.mjs <corpus-cache-directory>',
+  );
+  process.exit(2);
+}
+
+const manifest = JSON.parse(readFileSync(MANIFEST_PATH, 'utf8'));
+
+function sha256(buffer) {
+  return createHash('sha256').update(buffer).digest('hex');
+}
+
+async function downloadWithRetry(entry) {
+  let lastError;
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    try {
+      const response = await fetch(entry.sourceUrl);
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status} ${response.statusText}`);
+      }
+      return Buffer.from(await response.arrayBuffer());
+    } catch (error) {
+      lastError = error;
+      console.warn(
+        `[real-comparison-corpus] ${entry.id} download attempt ${attempt}/3 failed: ${error}`,
+      );
+    }
+  }
+  throw lastError;
+}
+
+for (const entry of manifest) {
+  const destination = join(destinationRoot, entry.id, 'source.docx');
+  if (existsSync(destination)) {
+    const cached = readFileSync(destination);
+    if (sha256(cached) === entry.sha256) {
+      console.log(`[real-comparison-corpus] verified cached ${entry.id}`);
+      continue;
+    }
+    console.warn(
+      `[real-comparison-corpus] cached ${entry.id} failed SHA-256 verification; downloading again`,
+    );
+  }
+
+  console.log(`[real-comparison-corpus] downloading ${entry.id}`);
+  const downloaded = await downloadWithRetry(entry);
+  const actualSha256 = sha256(downloaded);
+  if (actualSha256 !== entry.sha256) {
+    throw new Error(
+      `${entry.id} SHA-256 mismatch: expected ${entry.sha256}, received ${actualSha256}`,
+    );
+  }
+  mkdirSync(dirname(destination), { recursive: true });
+  writeFileSync(destination, downloaded);
+  console.log(`[real-comparison-corpus] cached verified ${entry.id}`);
+}


### PR DESCRIPTION
## Summary

- separate the real-corpus failure fingerprints common to CI and local development from three Darwin/Node 26-only fingerprints
- pin required CI to the characterized Linux/Node 20 profile so runtime upgrades require deliberate re-characterization
- cover profile selection directly while preserving the two-way behavior gate

## Why

PR #671 merged while its newly added real-corpus job was still non-blocking. That job showed three cells pass on Linux/Node 20 but fail on Darwin/Node 26. A single expected-outcome map therefore made the gate non-portable even though both runtimes were stable.

## Validation

- full 14-cell SHA-256-pinned corpus matrix on Darwin/Node 26
- docx-compare TypeScript lint and no-cache skip path
- repository build and workspace lint
- docx-core: 1,238 passed, 2 expected failures, 12 skipped
- spec coverage and all conformance checks

Follow-up to #671.
Ref: #658