### PR TITLE
feat(docx-core): add tracked section page numbering

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -144,6 +144,30 @@ change numbering inherited only through a paragraph style, restart lists, or
 guarantee a rendered label without the surrounding list context. Effective
 changes are recorded as paragraph-property tracked changes.
 
+### Inspect Sections and Restart Page Numbering
+
+Read the current main-document sections before choosing a target:
+
+```text
+get_sections(file_path="~/docs/NDA.docx")
+```
+
+Then restart numbering for one returned section:
+
+```text
+format_section(
+  file_path="~/docs/NDA.docx",
+  section_index=1,
+  page_number_start=1
+)
+```
+
+`section_index` is zero-based and session-relative, so call `get_sections` again
+after any operation that changes section topology. This first slice changes only
+the page-number restart. It preserves break type, page size, margins, columns,
+page-number format, and header/footer references, and it does not create or split
+sections.
+
 ## Step 6: Save Reviewable Outputs
 
 ```text
@@ -188,6 +212,7 @@ Visual review remains appropriate for material documents because Safe Docx is no
 | Insert a paragraph | `insert_paragraph` |
 | Delete an ordinary DOCX body paragraph | `replace_text` with the complete text and an empty `new_string` |
 | Remove or repair direct DOCX paragraph numbering | `format_numbering` |
+| Inspect DOCX sections or restart page numbering | `get_sections`, `format_section` |
 | Apply several edits together | `batch_edit` |
 | Convert DOCX to ODT | `convert_to_odt` |
 | Convert DOCX to Markdown | `export` with `format="markdown"` |

--- a/openspec/changes/add-section-page-numbering-formatting/design.md
+++ b/openspec/changes/add-section-page-numbering-formatting/design.md
@@ -1,0 +1,110 @@
+## Context
+
+WordprocessingML stores non-final section properties in the paragraph properties
+of the paragraph that terminates the section. The final section properties are a
+direct, final child of `w:body`. A restart is represented by the `w:start`
+attribute on `w:sectPr/w:pgNumType`; the same element may also carry unrelated
+format and chapter-number settings.
+
+The repository already preserves and audits these shapes and accepts/rejects
+existing `w:sectPrChange` records. This slice adds the missing read and tracked
+write surfaces without expanding into section topology or general page setup.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Enumerate supported main-document section boundaries deterministically.
+- Expose enough read metadata for a caller to select the intended section.
+- Set one section's page-number restart without replacing its `w:sectPr`.
+- Emit a schema-valid, reviewable section-property revision.
+- Preserve document structure and all untargeted section settings.
+
+### Non-Goals
+
+- Author section boundaries or auxiliary story content.
+- Offer a generic raw-OOXML property editor.
+- Infer which section a natural-language reference describes.
+- Repair malformed or unsupported section-property placement.
+
+## Decisions
+
+### 1. Use document-order section indexes
+
+`get_sections` returns `section_index` values starting at zero. Direct
+`w:p/w:pPr/w:sectPr` boundaries are collected in document order, followed by the
+final direct `w:body/w:sectPr`. A paragraph-boundary record includes its stable
+`anchor_paragraph_id`; the final body record reports a `null` anchor and
+`location: "body"`.
+
+`format_section` targets the same `section_index`. Indexes are intentionally
+session-relative selectors, not durable edit anchors: callers should call
+`get_sections` again after any operation that changes section topology.
+
+### 2. Read broadly, write narrowly
+
+Each section record projects:
+
+- boundary location and paragraph anchor;
+- section-break type;
+- page-number start and format;
+- page size and orientation;
+- page margins;
+- header and footer relationship IDs and roles.
+
+Missing properties are returned as `null` or empty arrays. This lets a caller
+verify the target and observe preservation. Only `page_number_start` is writable
+in this change.
+
+### 3. Accept non-negative decimal restart values
+
+`page_number_start` must be a non-negative safe integer, matching the
+`ST_DecimalNumber`-backed `w:start` representation and existing documents that
+legitimately use zero. The mutation creates `w:pgNumType` in schema order when
+absent and otherwise updates only `w:start`, preserving `w:fmt`, `w:chapStyle`,
+and `w:chapSep`.
+
+Removal of an existing restart is deferred. The tool always receives an explicit
+integer.
+
+### 4. Snapshot the prior section properties
+
+An effective mutation appends one `w:sectPrChange` containing a cloned prior
+`w:sectPr`. Existing nested `w:sectPrChange` children are excluded so a
+change-of-a-change is never emitted. Revision ID, author, and date come from the
+session revision context.
+
+The mutation uses the repository's normal AI-revision preflight. An identical
+requested start is a no-op and consumes no edit accounting or revision ID.
+
+### 5. Validate before live mutation
+
+The tool validates the value and resolves the section index before allocating
+revision metadata. It then previews the mutation through the AI revision guard
+before applying it to the live session. Failures return structured errors and
+leave serialized document XML unchanged.
+
+The implementation verifies that section count, paragraph count, visible text,
+and the targeted section's unrelated serialized properties remain stable.
+
+## Risks / Trade-offs
+
+- Section indexes can shift after a future section insertion. Describing them as
+  session-relative and pairing them with boundary metadata avoids implying
+  durable identity.
+- Some third-party DOCX files contain invalid `w:sectPr` placements. The new
+  surface enumerates only the two canonical main-document placements and does
+  not silently repair malformed topology.
+- Word may not visibly refresh page-number fields until pagination occurs. Smoke
+  testing therefore checks OOXML, accept/reject projections, and rendered output
+  after LibreOffice refresh.
+
+## Migration Plan
+
+This is additive. Existing sessions, tools, and documents require no migration.
+The feature can be reverted without changing existing tool contracts or stored
+document data.
+
+## Open Questions
+
+None. General page setup and section topology remain explicit follow-up slices.

--- a/openspec/changes/add-section-page-numbering-formatting/proposal.md
+++ b/openspec/changes/add-section-page-numbering-formatting/proposal.md
@@ -1,0 +1,43 @@
+# Change: Add Section Page Numbering Formatting
+
+## Why
+
+Safe DOCX can preserve and audit section properties, but callers cannot discover
+the document's ordered sections or restart page numbering without editing
+`word/document.xml` directly. Direct XML edits bypass session safeguards,
+tracked-change attribution, and preservation checks around page layout and
+header/footer relationships.
+
+## What Changes
+
+- Add a DOCX-only `get_sections` MCP tool that returns main-document sections in
+  document order, including their boundary location and existing page-number,
+  page-size, margin, and header/footer-reference metadata.
+- Add a DOCX-only `format_section` MCP tool that targets one section by its
+  zero-based `section_index` and sets `page_number_start`.
+- Represent an effective restart as `w:pgNumType w:start` and record the prior
+  section properties in a native `w:sectPrChange`.
+- Preserve all untargeted `w:sectPr` children and attributes, including page
+  size, margins, page-number format, columns, and header/footer references.
+- Make an already-matching restart a deterministic no-op and reject invalid
+  section indexes or values before live-session mutation.
+
+## Impact
+
+- Affected specs:
+  - `docx-primitives`
+  - `mcp-server`
+- Affected code:
+  - `packages/docx-core/src/primitives/` and `DocxDocument`
+  - `packages/docx-mcp/src/tools/`, `server.ts`, and `tool_catalog.ts`
+  - generated tool documentation and support matrices
+  - unit, integration, conformance, and real-DOCX regression tests
+
+## Non-Goals
+
+- Inserting, removing, splitting, or reordering sections.
+- Changing section-break type, page size, orientation, margins, columns, or
+  line numbering.
+- Creating, deleting, or editing headers, footers, or their relationships.
+- Changing page-number format or chapter-number settings.
+- Editing sections in headers, footers, notes, ODT, or Google Docs.

--- a/openspec/changes/add-section-page-numbering-formatting/specs/docx-primitives/spec.md
+++ b/openspec/changes/add-section-page-numbering-formatting/specs/docx-primitives/spec.md
@@ -1,0 +1,72 @@
+## ADDED Requirements
+
+### Requirement: Deterministic Main-Document Section Inventory
+The DOCX primitives library SHALL enumerate canonically placed main-document
+section properties in document order without treating nested revision snapshots
+as live sections.
+
+#### Scenario: Paragraph boundaries precede the final body section
+- **GIVEN** a document with direct `w:p/w:pPr/w:sectPr` boundaries and a final
+  direct `w:body/w:sectPr`
+- **WHEN** the section inventory is read
+- **THEN** paragraph-boundary sections SHALL appear in document order
+- **AND** the final body section SHALL appear last
+
+#### Scenario: Section inventory projects existing settings
+- **GIVEN** section properties containing page numbering, page size, margins,
+  and header/footer references
+- **WHEN** the section inventory is read
+- **THEN** the corresponding values and relationship roles SHALL be returned
+- **AND** reading SHALL NOT mutate serialized document XML
+
+#### Scenario: Revision snapshots are not live sections
+- **GIVEN** a live `w:sectPr` containing `w:sectPrChange/w:sectPr`
+- **WHEN** the section inventory is read
+- **THEN** the nested prior-properties snapshot SHALL NOT receive a
+  `section_index`
+
+### Requirement: Section Page Number Restart Mutation
+The DOCX primitives library SHALL set the page-number restart of one indexed
+main-document section by changing only `w:sectPr/w:pgNumType/@w:start`.
+
+#### Scenario: Missing page numbering settings are created in schema order
+- **GIVEN** a valid section without `w:pgNumType`
+- **WHEN** its restart is set
+- **THEN** one `w:pgNumType` SHALL be inserted in the `CT_SectPr` schema slot
+- **AND** its `w:start` SHALL equal the requested non-negative integer
+
+#### Scenario: Existing page numbering attributes are preserved
+- **GIVEN** `w:pgNumType` with format or chapter-number attributes
+- **WHEN** its restart is changed
+- **THEN** only `w:start` SHALL change
+- **AND** `w:fmt`, `w:chapStyle`, and `w:chapSep` SHALL remain unchanged
+
+#### Scenario: Unrelated section properties are preserved
+- **GIVEN** a section with page size, margins, columns, and header/footer
+  references
+- **WHEN** its restart is changed
+- **THEN** those untargeted properties and relationships SHALL remain unchanged
+- **AND** section count, paragraph count, and visible text SHALL remain unchanged
+
+#### Scenario: Identical page number restart is a deterministic no-op
+- **GIVEN** a section whose `w:start` already equals the requested value
+- **WHEN** the same restart is requested
+- **THEN** the mutation SHALL report `changed: false`
+- **AND** SHALL NOT allocate or append a section-property revision
+
+### Requirement: Section Page Number Changes Are Reviewable
+An effective section restart mutation SHALL be represented as a native
+section-property tracked change.
+
+#### Scenario: Prior section properties are captured
+- **GIVEN** a section whose page-number restart changes
+- **WHEN** the mutation receives a revision context
+- **THEN** the live `w:sectPr` SHALL contain one `w:sectPrChange`
+- **AND** its nested `w:sectPr` SHALL contain the prior section properties
+- **AND** no `w:sectPrChange` SHALL be nested inside that snapshot
+
+#### Scenario: Accept and reject preserve section semantics
+- **GIVEN** a restart recorded as `w:sectPrChange`
+- **WHEN** the revision is accepted or rejected
+- **THEN** acceptance SHALL keep the requested restart
+- **AND** rejection SHALL restore the prior restart and unrelated properties

--- a/openspec/changes/add-section-page-numbering-formatting/specs/mcp-server/spec.md
+++ b/openspec/changes/add-section-page-numbering-formatting/specs/mcp-server/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: DOCX Section Discovery Tool
+The Safe-DOCX MCP server SHALL provide a read-only DOCX `get_sections` tool that
+returns canonical main-document section properties in document order.
+
+#### Scenario: Section discovery returns selectable boundaries
+- **WHEN** `get_sections` is called for a DOCX session
+- **THEN** each section SHALL include its zero-based `section_index`,
+  `location`, and nullable `anchor_paragraph_id`
+- **AND** each section SHALL project its existing page-number, page-size,
+  margin, and header/footer-reference metadata
+
+#### Scenario: File-first and session reuse are supported
+- **WHEN** `get_sections` is called with a DOCX `file_path`
+- **THEN** the server SHALL resolve or reuse a session under the standard
+  file-first contract
+- **AND** repeated reads SHALL NOT increment edit accounting
+
+### Requirement: DOCX Section Page Number Formatting Tool
+The Safe-DOCX MCP server SHALL provide a revisionable DOCX `format_section` tool
+that sets `page_number_start` on one section selected by `section_index`.
+
+#### Scenario: Page numbering restarts at the requested value
+- **GIVEN** a valid section index and non-negative safe integer
+- **WHEN** `format_section` sets `page_number_start`
+- **THEN** the resulting section SHALL report that restart
+- **AND** an effective edit SHALL be represented by `w:sectPrChange`
+
+#### Scenario: Identical restart does not create an edit
+- **GIVEN** a section already using the requested restart
+- **WHEN** `format_section` is called
+- **THEN** the response SHALL report `changed: false`
+- **AND** session edit accounting SHALL remain unchanged
+
+#### Scenario: Invalid input is transactional
+- **WHEN** `section_index` is absent, negative, unsafe, or out of range, or
+  `page_number_start` is not a non-negative safe integer
+- **THEN** the server SHALL return a structured validation or not-found error
+- **AND** serialized document XML SHALL remain unchanged
+
+#### Scenario: Unsupported providers are rejected
+- **WHEN** `get_sections` or `format_section` targets ODT or Google Docs
+- **THEN** the server SHALL return a structured unsupported-provider error
+- **AND** SHALL NOT mutate the source
+
+### Requirement: Section Formatting Preserves Untargeted Content
+The section formatting tool SHALL limit its live-document mutation to the
+selected section's page-number restart and tracked prior-properties record.
+
+#### Scenario: Page setup and references survive formatting
+- **GIVEN** a selected section with page size, margins, page-number format,
+  columns, and header/footer references
+- **WHEN** `format_section` changes its restart
+- **THEN** all those untargeted settings and relationships SHALL remain unchanged
+- **AND** section count, paragraph count, anchors, and visible text SHALL remain
+  unchanged
+
+#### Scenario: Clean and tracked saves agree on current state
+- **GIVEN** a successful section restart mutation
+- **WHEN** the session is saved in clean and tracked forms
+- **THEN** both outputs SHALL contain the requested current restart
+- **AND** only the tracked output SHALL retain the reviewable prior-properties
+  record

--- a/openspec/changes/add-section-page-numbering-formatting/tasks.md
+++ b/openspec/changes/add-section-page-numbering-formatting/tasks.md
@@ -1,0 +1,51 @@
+## 1. Core Section Model And Mutation
+
+- [x] 1.1 Add typed section inventory and page-number restart models.
+- [x] 1.2 Enumerate canonical paragraph-boundary and final-body sections in
+      document order, excluding revision snapshots.
+- [x] 1.3 Project boundary, page-number, page-size, margin, and header/footer
+      reference metadata without mutating the document.
+- [x] 1.4 Set `w:pgNumType/@w:start` in schema order while preserving every
+      unrelated section property and attribute.
+- [x] 1.5 Add a `w:sectPrChange` emitter that snapshots prior section properties
+      without nesting an existing change record.
+- [x] 1.6 Expose inventory and mutation through `DocxDocument` and package
+      exports.
+
+## 2. MCP Tool Surface
+
+- [x] 2.1 Add DOCX-only `get_sections` and revisionable `format_section` schemas
+      to the tool catalog.
+- [x] 2.2 Implement file-first/session-first section inventory responses.
+- [x] 2.3 Implement section restart validation, AI-revision preflight, mutation,
+      edit accounting, and structured response metadata.
+- [x] 2.4 Register tool dispatch and structured unsupported-provider behavior.
+
+## 3. Tests And Conformance
+
+- [x] 3.1 Add core tests for section ordering, read projection, missing optional
+      properties, schema-ordered creation, update, and deterministic no-op.
+- [x] 3.2 Add preservation tests for page size, margins, page-number format,
+      columns, header/footer references, paragraph count, and visible text.
+- [x] 3.3 Add tracked-change and accept/reject tests proving the prior
+      `w:sectPr` is captured and restored.
+- [x] 3.4 Add MCP tests for both tools, session reuse, invalid input,
+      transactional failure, edit accounting, and unsupported providers.
+- [x] 3.5 Add canonical-emission regression coverage and ECMA-376 citation /
+      Allure evidence for `w:pgNumType` and `w:sectPrChange`.
+- [x] 3.6 Run a real-DOCX smoke for tracked and clean outputs, package/schema
+      validation, accept/reject projections, and LibreOffice rendering.
+
+## 4. Documentation
+
+- [x] 4.1 Regenerate MCP tool reference and pass tool-doc freshness checks.
+- [x] 4.2 Update support matrices and usage documentation with section-index
+      stability and v1 write boundaries.
+
+## 5. Validation
+
+- [x] 5.1 `openspec validate add-section-page-numbering-formatting --strict`
+      passes.
+- [x] 5.2 Focused core and MCP test suites pass.
+- [x] 5.3 The mandatory build, lint, test, spec-coverage, and conformance
+      pre-submit suite passes.

--- a/packages/docx-core/SUPPORT.md
+++ b/packages/docx-core/SUPPORT.md
@@ -17,6 +17,7 @@ The "OOXML revision element" column uses ECMA-376 element names from the tracked
 | `layout.ts` — `setTableRowHeight` | `packages/docx-core/src/primitives/layout.ts` | `w:trPrChange` | Row geometry changes belong under row-property revisions. **Verified by [120.8] (#143) regression test.** |
 | `layout.ts` — `setTableCellPadding` | `packages/docx-core/src/primitives/layout.ts` | `w:tcPrChange` | Cell padding changes belong under cell-property revisions. **Verified by [120.8] (#143) regression test.** |
 | `paragraph_numbering.ts` — `setDirectParagraphNumbering` | `packages/docx-core/src/primitives/paragraph_numbering.ts` | `w:pPrChange` | Direct `w:numPr` assignment, replacement, and removal preserve the prior paragraph properties under a native property-change revision. **Verified by the #653 canonical-emission regression test.** |
+| `sections.ts` — `setSectionPageNumberStart` | `packages/docx-core/src/primitives/sections.ts` | `w:sectPrChange` | DOCX section page-number restarts preserve unrelated section properties and capture the prior `w:sectPr`. **Verified by the #654 canonical-emission regression test.** |
 | `comments.ts` — `addComment` | `packages/docx-core/src/primitives/comments.ts` | `w:ins` | Only the body-story `w:commentReference` run is wrapped in `w:ins`; range markers and root-comment text in `comments.xml` are not revision-wrapped. Comment body text, author metadata, and package bootstrap are listed in Table B. **Verified by [120.8] (#143) regression test.** |
 | `comments.ts` — `deleteComment` | `packages/docx-core/src/primitives/comments.ts` | `w:del` | Only the removed body-story `w:commentReference` run is wrapped in `w:del`; range markers are removed structurally, and comment/reply text removal from `comments.xml` is a Table B side-part mutation. `commentsExtended.xml` cleanup is also the Table B companion. **Verified by [120.8] (#143) regression test.** |
 | `footnotes.ts` — `addFootnote` | `packages/docx-core/src/primitives/footnotes.ts` | `w:ins` | The inserted `w:footnoteReference` in the body story and the new footnote text both belong to the revisionable surface. Companion package bootstrap is listed in Table B. **Verified by [120.8] (#143) regression test.** |
@@ -28,6 +29,7 @@ The "OOXML revision element" column uses ECMA-376 element names from the tracked
 | `clear_formatting` | `packages/docx-mcp/src/tools/clear_formatting.ts` | `w:rPrChange` | Run-property clearing is a run formatting revision, not a package mutation. **Verified by [120.8] (#143) regression test.** |
 | `format_layout` | `packages/docx-mcp/src/tools/format_layout.ts` | `w:pPrChange`, `w:trPrChange`, `w:tcPrChange` | Deterministic OOXML geometry edits belong under native property-change revisions. **Verified by [120.8] (#143) regression test.** |
 | `format_numbering` | `packages/docx-mcp/src/tools/format_numbering.ts` | `w:pPrChange` | DOCX-only direct paragraph numbering changes delegate to the canonical numbering primitive and retain the previous `w:numPr` in tracked output. **Verified by the #653 canonical-emission MCP regression test.** |
+| `format_section` | `packages/docx-mcp/src/tools/format_section.ts` | `w:sectPrChange` | DOCX-only page-number restarts delegate to the canonical section primitive and retain the prior `w:sectPr` in tracked output. **Verified by the #654 canonical-emission MCP regression test.** |
 | `add_comment` | `packages/docx-mcp/src/tools/add_comment.ts` | `w:ins` (root-comment mode only) | Root-comment mode wraps only the body-story `w:commentReference` run in `w:ins`; range markers and root-comment text in `comments.xml` are not revision-wrapped. **Reply-mode** dispatches through `comments.ts` `addCommentReply` which is Table B (side-part metadata only; no body revision marker). Missing comment infrastructure is also a Table B companion. **Verified by [120.8] (#143) regression test.** |
 | `delete_comment` | `packages/docx-mcp/src/tools/delete_comment.ts` | `w:del` | Comment deletion wraps only the removed body-story `w:commentReference` run in `w:del`; range markers and `comments.xml` comment/reply text are removed as Table B side-part/structural mutations. `commentsExtended.xml` cleanup is the Table B companion. **Verified by [120.8] (#143) regression test.** |
 | `add_footnote` | `packages/docx-mcp/src/tools/add_footnote.ts` | `w:ins` | Footnote reference insertion and note-body creation are revisionable content. Missing footnote infrastructure is the Table B companion. **Verified by [120.8] (#143) regression test.** |
@@ -214,6 +216,7 @@ This appendix is deliberately mechanical. It makes it easy to audit that every n
 - `namespaces.ts` — Internal / non-contract utilities
 - `numbering.ts` — Internal / non-contract utilities
 - `paragraph_numbering.ts` — Table A
+- `sections.ts` — Table A
 - `prevent_double_elevation.ts` — Internal / non-contract utilities
 - `reject_changes.ts` — Internal / non-contract utilities
 - `relationships.ts` — Internal / non-contract utilities
@@ -243,6 +246,8 @@ This appendix is deliberately mechanical. It makes it easy to audit that every n
 - `extract_revisions.ts` — Internal / non-contract utilities
 - `format_layout.ts` — Table A
 - `format_numbering.ts` — Table A
+- `format_section.ts` — Table A
+- `get_sections.ts` — Internal / non-contract utilities
 - `get_comments.ts` — Internal / non-contract utilities
 - `get_file_status.ts` — Internal / non-contract utilities
 - `get_footnotes.ts` — Internal / non-contract utilities
@@ -269,7 +274,6 @@ This appendix is deliberately mechanical. It makes it easy to audit that every n
 These ECMA-376 elements stay in the canonical vocabulary even though the current repo snapshot does not expose a dedicated primitive or MCP tool file for each one yet.
 
 - `w:moveFrom`, `w:moveTo`, `w:moveFromRangeStart`, `w:moveFromRangeEnd`, `w:moveToRangeStart`, and `w:moveToRangeEnd` — no dedicated move primitive is surfaced today.
-- `w:sectPrChange` — no dedicated section-layout mutation file is surfaced today.
 - `w:tblPrChange`, `w:tblPrExChange`, and `w:tblGridChange` — no dedicated table-wide property/grid mutation file is surfaced today.
 - `w:cellIns`, `w:cellDel`, and `w:cellMerge` — no dedicated cell-topology mutation file is surfaced today.
 - `w:numberingChange` — no dedicated numbering mutation file is surfaced today.

--- a/packages/docx-core/src/integration/canonical-emission-regression.test.ts
+++ b/packages/docx-core/src/integration/canonical-emission-regression.test.ts
@@ -21,6 +21,10 @@ const numberingTest = test.conformance(
   { spec: 'ECMA-376', edition: 5, part: 1, section: '17.9.18' },
   { spec: 'ECMA-376', edition: 5, part: 1, section: '17.9.3' },
 );
+const sectionTest = test.conformance(
+  { spec: 'ECMA-376', edition: 5, part: 1, section: '17.6.12' },
+  { spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.5.32' },
+);
 
 const AI_AUTHOR = 'SafeDocX';
 const FIXED_DATE = '2026-05-07T12:00:00Z';
@@ -133,7 +137,7 @@ type RevisionTuple = {
 
 function revisionTuples(xml: string, requiredAuthor?: string): RevisionTuple[] {
   const out: RevisionTuple[] = [];
-  for (const kind of ['ins', 'del', 'pPrChange', 'rPrChange', 'trPrChange', 'tcPrChange']) {
+  for (const kind of ['ins', 'del', 'pPrChange', 'rPrChange', 'sectPrChange', 'trPrChange', 'tcPrChange']) {
     for (const el of elementsByName(xml, kind)) {
       const author = wordAttr(el, 'author');
       if (requiredAuthor && author !== requiredAuthor) continue;
@@ -247,6 +251,43 @@ describe('Canonical emission catalog', () => {
       const change = elementsByName(documentXml, 'pPrChange')[0]!;
       const priorIlvl = change.getElementsByTagNameNS(W_NS, 'ilvl')[0] as Element;
       expect(wordAttr(priorIlvl, 'val')).toBe('0');
+    });
+  });
+
+  sectionTest('Table A: sections.ts setSectionPageNumberStart emits w:sectPrChange', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    let documentXml: string;
+
+    await given('a final section with an existing page-number restart', async () => {
+      const { doc } = await loadIndexedDoc(
+        await makeMinimalDocx('<w:p><w:r><w:t>Section body</w:t></w:r></w:p>'),
+      );
+      doc.setSectionPageNumberStart({ sectionIndex: 0, pageNumberStart: 3 });
+
+      await when('the restart is changed with a revision context', async () => {
+        doc.setSectionPageNumberStart(
+          { sectionIndex: 0, pageNumberStart: 1 },
+          createCtx(),
+        );
+        ({ parts: { 'word/document.xml': documentXml } } = await toPartMap(
+          doc,
+          ['word/document.xml'],
+        ));
+      });
+    });
+
+    await then('the prior restart is captured with canonical revision metadata', () => {
+      expectTrackedElementsWithFixedMetadata(documentXml, ['sectPrChange']);
+      const change = elementsByName(documentXml, 'sectPrChange')[0]!;
+      const priorPgNumType = change.getElementsByTagNameNS(
+        W_NS,
+        'pgNumType',
+      )[0] as Element;
+      expect(wordAttr(priorPgNumType, 'start')).toBe('3');
+      expect(change.getElementsByTagNameNS(W_NS, 'sectPrChange')).toHaveLength(0);
     });
   });
 

--- a/packages/docx-core/src/primitives/document.ts
+++ b/packages/docx-core/src/primitives/document.ts
@@ -30,6 +30,13 @@ import {
   type ParagraphNumberingMutation,
   type ParagraphNumberingMutationResult,
 } from './paragraph_numbering.js';
+import {
+  getDocumentSections,
+  setSectionPageNumberStart,
+  type DocumentSection,
+  type SectionPageNumberMutation,
+  type SectionPageNumberMutationResult,
+} from './sections.js';
 import { findUniqueSubstringMatch } from './matching.js';
 import { parseDocumentRels, type RelsMap } from './relationships.js';
 import {
@@ -950,6 +957,22 @@ export class DocxDocument {
       mutation,
       ctx,
     );
+    if (result.changed) {
+      this.dirty = true;
+      this.documentViewCache = null;
+    }
+    return result;
+  }
+
+  getSections(): DocumentSection[] {
+    return getDocumentSections(this.documentXml);
+  }
+
+  setSectionPageNumberStart(
+    mutation: SectionPageNumberMutation,
+    ctx?: RevisionContext,
+  ): SectionPageNumberMutationResult {
+    const result = setSectionPageNumberStart(this.documentXml, mutation, ctx);
     if (result.changed) {
       this.dirty = true;
       this.documentViewCache = null;

--- a/packages/docx-core/src/primitives/index.ts
+++ b/packages/docx-core/src/primitives/index.ts
@@ -32,6 +32,7 @@ export * from './footnotes.js';
 export * from './relationships.js';
 export * from './opc-target.js';
 export * from './sectPrAudit.js';
+export * from './sections.js';
 export * from './formatting_tags.js';
 export * from './prevent_double_elevation.js';
 export * from './tables.js';

--- a/packages/docx-core/src/primitives/reject_changes.ts
+++ b/packages/docx-core/src/primitives/reject_changes.ts
@@ -494,6 +494,22 @@ export function rejectChanges(
       if (originalProps) {
         // Replace the current property element with the original
         const restored = originalProps.cloneNode(true) as Element;
+        // CT_SectPrChange carries CT_SectPrBase, which intentionally excludes
+        // header/footer references. Those live bindings are not part of the
+        // page-setup property revision and must survive rejection.
+        if (localName === 'sectPrChange') {
+          const liveReferences = Array.from(parentProp.childNodes)
+            .filter((node): node is Element =>
+              node.nodeType === 1
+              && (
+                isW(node as Element, 'headerReference')
+                || isW(node as Element, 'footerReference')
+              ))
+            .map((reference) => reference.cloneNode(true));
+          for (const reference of liveReferences.reverse()) {
+            restored.insertBefore(reference, restored.firstChild);
+          }
+        }
         grandParent.replaceChild(restored, parentProp);
       } else {
         // Original props were empty — remove the parent property element entirely

--- a/packages/docx-core/src/primitives/sections.test.ts
+++ b/packages/docx-core/src/primitives/sections.test.ts
@@ -132,7 +132,7 @@ describe('OpenSpec traceability: section page numbering', () => {
     () => {
       const doc = makeDocument(
         '<w:p><w:r><w:t>Body</w:t></w:r></w:p>'
-          + '<w:sectPr><w:pgSz w:w="12240"/><w:pgMar w:top="1440"/><w:cols w:num="2"/><w:titlePg/><w:docGrid w:linePitch="360"/></w:sectPr>',
+          + '<w:sectPr><w:pgSz w:w="12240"/><w:pgMar w:top="1440" w:right="720" w:bottom="1440" w:left="720" w:header="360" w:footer="360" w:gutter="0"/><w:cols w:num="2"/><w:titlePg/><w:docGrid w:linePitch="360"/></w:sectPr>',
       );
 
       expect(setSectionPageNumberStart(
@@ -165,7 +165,7 @@ describe('OpenSpec traceability: section page numbering', () => {
           + '<w:sectPr w:rsidR="AA">'
           + '<w:headerReference w:type="default" r:id="rId1"/>'
           + '<w:pgSz w:w="12240" w:h="15840"/>'
-          + '<w:pgMar w:top="1440" w:left="720"/>'
+          + '<w:pgMar w:top="1440" w:right="720" w:bottom="1440" w:left="720" w:header="360" w:footer="360" w:gutter="0"/>'
           + '<w:pgNumType w:start="2" w:fmt="lowerRoman" w:chapStyle="1" w:chapSep="hyphen"/>'
           + '<w:cols w:num="2"/>'
           + '<w:titlePg/>'
@@ -207,7 +207,7 @@ describe('OpenSpec traceability: section page numbering', () => {
           + '<w:headerReference w:type="default" r:id="rId1"/>'
           + '<w:footerReference w:type="first" r:id="rId2"/>'
           + '<w:pgSz w:w="12240" w:h="15840"/>'
-          + '<w:pgMar w:top="1440" w:left="720"/>'
+          + '<w:pgMar w:top="1440" w:right="720" w:bottom="1440" w:left="720" w:header="360" w:footer="360" w:gutter="0"/>'
           + '<w:pgNumType w:start="2"/><w:cols w:num="2"/>'
           + '</w:sectPr>',
       );

--- a/packages/docx-core/src/primitives/sections.test.ts
+++ b/packages/docx-core/src/primitives/sections.test.ts
@@ -1,0 +1,350 @@
+import { describe, expect } from 'vitest';
+import { testAllure } from '../testing/allure-test.js';
+import { getParagraphBookmarkId, insertParagraphBookmarks } from './bookmarks.js';
+import { getDirectChildrenByName } from './dom-helpers.js';
+import { acceptChanges } from './accept_changes.js';
+import { rejectChanges } from './reject_changes.js';
+import {
+  getDocumentSections,
+  SectionMutationError,
+  setSectionPageNumberStart,
+} from './sections.js';
+import { createRevisionContext, createRevisionIdState } from './track-changes-emitter.js';
+import { parseXml, serializeXml } from './xml.js';
+import { OOXML, W } from './namespaces.js';
+
+const W_NS = OOXML.W_NS;
+const R_NS = OOXML.R_NS;
+const TEST_FEATURE = 'add-section-page-numbering-formatting';
+const test = testAllure.epic('Document Comparison').withLabels({
+  feature: TEST_FEATURE,
+});
+const conformanceTest = test.conformance(
+  { spec: 'ECMA-376', edition: 5, part: 1, section: '17.6.12' },
+  { spec: 'ECMA-376', edition: 5, part: 1, section: '17.6.18' },
+  { spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.5.32' },
+);
+
+function makeDocument(bodyXml: string): Document {
+  const doc = parseXml(
+    `<w:document xmlns:w="${W_NS}" xmlns:r="${R_NS}"><w:body>${bodyXml}</w:body></w:document>`,
+  );
+  insertParagraphBookmarks(doc, 'sections-test');
+  return doc;
+}
+
+function direct(parent: Element, name: string): Element {
+  const child = getDirectChildrenByName(parent, name)[0];
+  if (!child) throw new Error(`Expected direct ${name}`);
+  return child;
+}
+
+function attr(el: Element, name: string): string | null {
+  return el.getAttributeNS(W_NS, name) || el.getAttribute(`w:${name}`) || null;
+}
+
+function liveSectPr(doc: Document, index: number): Element {
+  const sections = Array.from(doc.getElementsByTagNameNS(W_NS, W.sectPr))
+    .filter((sectPr) =>
+      (sectPr.parentNode as Element | null)?.localName !== 'sectPrChange');
+  const sectPr = sections[index];
+  if (!sectPr) throw new Error(`Expected section ${index}`);
+  return sectPr;
+}
+
+describe('OpenSpec traceability: section page numbering', () => {
+  test.openspec('Paragraph boundaries precede the final body section')(
+    'enumerates canonical live sections in document order',
+    () => {
+      const doc = makeDocument(
+        '<w:p><w:r><w:t>First</w:t></w:r></w:p>'
+          + '<w:p><w:pPr><w:sectPr><w:type w:val="nextPage"/></w:sectPr></w:pPr><w:r><w:t>Boundary</w:t></w:r></w:p>'
+          + '<w:p><w:r><w:t>Second</w:t></w:r></w:p>'
+          + '<w:sectPr><w:sectPrChange w:id="9"><w:sectPr><w:pgNumType w:start="8"/></w:sectPr></w:sectPrChange></w:sectPr>',
+      );
+
+      const sections = getDocumentSections(doc);
+      expect(sections).toHaveLength(2);
+      expect(sections.map((section) => section.location))
+        .toEqual(['paragraph', 'body']);
+      const boundaryParagraph = doc.getElementsByTagNameNS(W_NS, W.p).item(1) as Element;
+      expect(sections[0]?.anchorParagraphId)
+        .toBe(getParagraphBookmarkId(boundaryParagraph));
+      expect(sections[1]?.anchorParagraphId).toBeNull();
+      expect(sections[0]?.breakType).toBe('nextPage');
+      expect(sections[1]?.pageNumberStart).toBeNull();
+    },
+  );
+
+  test.openspec('Section inventory projects existing settings')(
+    'projects page setup and references without mutating XML',
+    () => {
+      const doc = makeDocument(
+        '<w:p><w:r><w:t>Body</w:t></w:r></w:p>'
+          + '<w:sectPr>'
+          + '<w:headerReference w:type="default" r:id="rId4"/>'
+          + '<w:footerReference w:type="first" r:id="rId5"/>'
+          + '<w:pgSz w:w="12240" w:h="15840" w:orient="portrait"/>'
+          + '<w:pgMar w:top="1440" w:right="720" w:bottom="1440" w:left="720" w:header="360" w:footer="360" w:gutter="0"/>'
+          + '<w:pgNumType w:start="3" w:fmt="lowerRoman"/>'
+          + '</w:sectPr>',
+      );
+      const before = serializeXml(doc);
+
+      expect(getDocumentSections(doc)[0]).toMatchObject({
+        pageNumberStart: 3,
+        pageNumberFormat: 'lowerRoman',
+        pageSize: {
+          widthTwips: 12240,
+          heightTwips: 15840,
+          orientation: 'portrait',
+        },
+        margins: {
+          topTwips: 1440,
+          rightTwips: 720,
+          gutterTwips: 0,
+        },
+        headers: [{ type: 'default', relationshipId: 'rId4' }],
+        footers: [{ type: 'first', relationshipId: 'rId5' }],
+      });
+      expect(serializeXml(doc)).toBe(before);
+    },
+  );
+
+  test.openspec('Revision snapshots are not live sections')(
+    'excludes nested prior-properties snapshots from the inventory',
+    () => {
+      const doc = makeDocument(
+        '<w:p><w:r><w:t>Body</w:t></w:r></w:p>'
+          + '<w:sectPr><w:sectPrChange w:id="9"><w:sectPr>'
+          + '<w:pgNumType w:start="8"/>'
+          + '</w:sectPr></w:sectPrChange></w:sectPr>',
+      );
+
+      const sections = getDocumentSections(doc);
+      expect(sections).toHaveLength(1);
+      expect(sections[0]?.pageNumberStart).toBeNull();
+    },
+  );
+
+  conformanceTest.openspec('Missing page numbering settings are created in schema order')(
+    'creates pgNumType between margins and later section properties',
+    () => {
+      const doc = makeDocument(
+        '<w:p><w:r><w:t>Body</w:t></w:r></w:p>'
+          + '<w:sectPr><w:pgSz w:w="12240"/><w:pgMar w:top="1440"/><w:cols w:num="2"/><w:titlePg/><w:docGrid w:linePitch="360"/></w:sectPr>',
+      );
+
+      expect(setSectionPageNumberStart(
+        doc,
+        { sectionIndex: 0, pageNumberStart: 1 },
+      )).toEqual({
+        sectionIndex: 0,
+        changed: true,
+        previousPageNumberStart: null,
+        currentPageNumberStart: 1,
+      });
+      const children = Array.from(liveSectPr(doc, 0).children)
+        .map((child) => child.localName);
+      expect(children).toEqual([
+        W.pgSz,
+        W.pgMar,
+        W.pgNumType,
+        'cols',
+        W.titlePg,
+        'docGrid',
+      ]);
+    },
+  );
+
+  conformanceTest.openspec('Existing page numbering attributes are preserved')(
+    'updates only start and preserves unrelated section XML',
+    () => {
+      const doc = makeDocument(
+        '<w:p><w:r><w:t>Body</w:t></w:r></w:p>'
+          + '<w:sectPr w:rsidR="AA">'
+          + '<w:headerReference w:type="default" r:id="rId1"/>'
+          + '<w:pgSz w:w="12240" w:h="15840"/>'
+          + '<w:pgMar w:top="1440" w:left="720"/>'
+          + '<w:pgNumType w:start="2" w:fmt="lowerRoman" w:chapStyle="1" w:chapSep="hyphen"/>'
+          + '<w:cols w:num="2"/>'
+          + '<w:titlePg/>'
+          + '</w:sectPr>',
+      );
+      const sectPr = liveSectPr(doc, 0);
+      const preservedBefore = [
+        direct(sectPr, W.headerReference).toString(),
+        direct(sectPr, W.pgSz).toString(),
+        direct(sectPr, W.pgMar).toString(),
+        direct(sectPr, 'cols').toString(),
+        direct(sectPr, W.titlePg).toString(),
+      ];
+
+      setSectionPageNumberStart(doc, { sectionIndex: 0, pageNumberStart: 7 });
+
+      const pgNumType = direct(sectPr, W.pgNumType);
+      expect(attr(pgNumType, W.start)).toBe('7');
+      expect(attr(pgNumType, 'fmt')).toBe('lowerRoman');
+      expect(attr(pgNumType, 'chapStyle')).toBe('1');
+      expect(attr(pgNumType, 'chapSep')).toBe('hyphen');
+      expect([
+        direct(sectPr, W.headerReference).toString(),
+        direct(sectPr, W.pgSz).toString(),
+        direct(sectPr, W.pgMar).toString(),
+        direct(sectPr, 'cols').toString(),
+        direct(sectPr, W.titlePg).toString(),
+      ]).toEqual(preservedBefore);
+      expect(attr(sectPr, 'rsidR')).toBe('AA');
+    },
+  );
+
+  conformanceTest.openspec('Unrelated section properties are preserved')(
+    'keeps page setup, columns, references, topology, and text unchanged',
+    () => {
+      const doc = makeDocument(
+        '<w:p><w:r><w:t>Visible body</w:t></w:r></w:p>'
+          + '<w:sectPr>'
+          + '<w:headerReference w:type="default" r:id="rId1"/>'
+          + '<w:footerReference w:type="first" r:id="rId2"/>'
+          + '<w:pgSz w:w="12240" w:h="15840"/>'
+          + '<w:pgMar w:top="1440" w:left="720"/>'
+          + '<w:pgNumType w:start="2"/><w:cols w:num="2"/>'
+          + '</w:sectPr>',
+      );
+      const sectionBefore = liveSectPr(doc, 0);
+      const preservedBefore = [
+        direct(sectionBefore, W.headerReference).toString(),
+        direct(sectionBefore, W.footerReference).toString(),
+        direct(sectionBefore, W.pgSz).toString(),
+        direct(sectionBefore, W.pgMar).toString(),
+        direct(sectionBefore, 'cols').toString(),
+      ];
+      const paragraphCountBefore = doc.getElementsByTagNameNS(W_NS, W.p).length;
+      const textBefore = doc.documentElement.textContent;
+
+      setSectionPageNumberStart(doc, { sectionIndex: 0, pageNumberStart: 6 });
+
+      const sectionAfter = liveSectPr(doc, 0);
+      expect([
+        direct(sectionAfter, W.headerReference).toString(),
+        direct(sectionAfter, W.footerReference).toString(),
+        direct(sectionAfter, W.pgSz).toString(),
+        direct(sectionAfter, W.pgMar).toString(),
+        direct(sectionAfter, 'cols').toString(),
+      ]).toEqual(preservedBefore);
+      expect(getDocumentSections(doc)).toHaveLength(1);
+      expect(doc.getElementsByTagNameNS(W_NS, W.p)).toHaveLength(paragraphCountBefore);
+      expect(doc.documentElement.textContent).toBe(textBefore);
+    },
+  );
+
+  conformanceTest.openspec('Prior section properties are captured')(
+    'emits a single prior snapshot and supports accept/reject projections',
+    () => {
+      const doc = makeDocument(
+        '<w:p><w:r><w:t>Body</w:t></w:r></w:p>'
+          + '<w:sectPr w:rsidR="AABBCCDD">'
+          + '<w:headerReference w:type="default" r:id="rId1"/>'
+          + '<w:pgSz w:w="12240"/><w:pgNumType w:start="2" w:fmt="decimal"/>'
+          + '</w:sectPr>',
+      );
+      const ctx = createRevisionContext({
+        author: 'SafeDocX AI',
+        date: '2026-07-27T12:00:00Z',
+        idState: createRevisionIdState(),
+      });
+
+      setSectionPageNumberStart(
+        doc,
+        { sectionIndex: 0, pageNumberStart: 5 },
+        ctx,
+      );
+      const sectPr = liveSectPr(doc, 0);
+      const change = direct(sectPr, 'sectPrChange');
+      expect(attr(change, 'author')).toBe('SafeDocX AI');
+      const priorSectPr = direct(change, W.sectPr);
+      expect(attr(direct(priorSectPr, W.pgNumType), W.start)).toBe('2');
+      expect(getDirectChildrenByName(priorSectPr, 'sectPrChange')).toHaveLength(0);
+      expect(getDirectChildrenByName(priorSectPr, W.headerReference)).toHaveLength(0);
+      expect(attr(priorSectPr, 'rsidR')).toBe('AABBCCDD');
+    },
+  );
+
+  conformanceTest.openspec('Accept and reject preserve section semantics')(
+    'keeps the new restart on accept and restores prior properties on reject',
+    () => {
+      const doc = makeDocument(
+        '<w:p><w:r><w:t>Body</w:t></w:r></w:p>'
+          + '<w:sectPr><w:headerReference w:type="default" r:id="rId1"/>'
+          + '<w:pgSz w:w="12240"/><w:pgNumType w:start="2"/>'
+          + '</w:sectPr>',
+      );
+      setSectionPageNumberStart(
+        doc,
+        { sectionIndex: 0, pageNumberStart: 5 },
+        createRevisionContext({
+          author: 'SafeDocX AI',
+          idState: createRevisionIdState(),
+        }),
+      );
+      const accepted = doc.cloneNode(true) as Document;
+      acceptChanges(accepted);
+      expect(attr(direct(liveSectPr(accepted, 0), W.pgNumType), W.start)).toBe('5');
+      expect(getDirectChildrenByName(liveSectPr(accepted, 0), 'sectPrChange'))
+        .toHaveLength(0);
+
+      const rejected = doc.cloneNode(true) as Document;
+      rejectChanges(rejected);
+      expect(attr(direct(liveSectPr(rejected, 0), W.pgNumType), W.start)).toBe('2');
+      expect(attr(direct(liveSectPr(rejected, 0), W.pgSz), W.w)).toBe('12240');
+      expect(
+        direct(liveSectPr(rejected, 0), W.headerReference)
+          .getAttributeNS(R_NS, 'id'),
+      ).toBe('rId1');
+    },
+  );
+
+  test.openspec('Identical page number restart is a deterministic no-op')(
+    'does not serialize or allocate a revision for an identical request',
+    () => {
+      const doc = makeDocument(
+        '<w:p><w:r><w:t>Body</w:t></w:r></w:p>'
+          + '<w:sectPr><w:pgNumType w:start="4"/></w:sectPr>',
+      );
+      const ctx = createRevisionContext({
+        author: 'SafeDocX AI',
+        idState: createRevisionIdState(),
+      });
+      const before = serializeXml(doc);
+
+      expect(setSectionPageNumberStart(
+        doc,
+        { sectionIndex: 0, pageNumberStart: 4 },
+        ctx,
+      ).changed).toBe(false);
+      expect(serializeXml(doc)).toBe(before);
+      expect(ctx.idState.nextId).toBe(1);
+    },
+  );
+
+  test.openspec('Invalid input is transactional')(
+    'rejects invalid selectors and values before mutation',
+    () => {
+      const doc = makeDocument(
+        '<w:p><w:r><w:t>Body</w:t></w:r></w:p><w:sectPr/>',
+      );
+      const before = serializeXml(doc);
+      expect(() => setSectionPageNumberStart(
+        doc,
+        { sectionIndex: 9, pageNumberStart: 1 },
+      )).toThrowError(SectionMutationError);
+      expect(() => setSectionPageNumberStart(
+        doc,
+        { sectionIndex: 0, pageNumberStart: -1 },
+      )).toThrowError(expect.objectContaining({
+        code: 'INVALID_PAGE_NUMBER_START',
+      }));
+      expect(serializeXml(doc)).toBe(before);
+    },
+  );
+});

--- a/packages/docx-core/src/primitives/sections.ts
+++ b/packages/docx-core/src/primitives/sections.ts
@@ -1,0 +1,294 @@
+import { getParagraphBookmarkId } from './bookmarks.js';
+import { childElements, createWmlElement, getDirectChildrenByName, isW } from './dom-helpers.js';
+import { OOXML, W } from './namespaces.js';
+import {
+  buildSectPrChangeElement,
+  type RevisionContext,
+} from './track-changes-emitter.js';
+
+export type SectionBoundaryLocation = 'paragraph' | 'body';
+
+export type SectionReference = {
+  type: string | null;
+  relationshipId: string | null;
+};
+
+export type SectionPageSize = {
+  widthTwips: number | null;
+  heightTwips: number | null;
+  orientation: string | null;
+};
+
+export type SectionMargins = {
+  topTwips: number | null;
+  rightTwips: number | null;
+  bottomTwips: number | null;
+  leftTwips: number | null;
+  headerTwips: number | null;
+  footerTwips: number | null;
+  gutterTwips: number | null;
+};
+
+export type DocumentSection = {
+  sectionIndex: number;
+  location: SectionBoundaryLocation;
+  anchorParagraphId: string | null;
+  breakType: string | null;
+  pageNumberStart: number | null;
+  pageNumberFormat: string | null;
+  pageSize: SectionPageSize | null;
+  margins: SectionMargins | null;
+  headers: SectionReference[];
+  footers: SectionReference[];
+};
+
+export type SectionPageNumberMutation = {
+  sectionIndex: number;
+  pageNumberStart: number;
+};
+
+export type SectionPageNumberMutationResult = {
+  sectionIndex: number;
+  changed: boolean;
+  previousPageNumberStart: number | null;
+  currentPageNumberStart: number;
+};
+
+export type SectionMutationErrorCode =
+  | 'INVALID_SECTION_INDEX'
+  | 'SECTION_NOT_FOUND'
+  | 'INVALID_PAGE_NUMBER_START';
+
+export class SectionMutationError extends Error {
+  constructor(
+    public readonly code: SectionMutationErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'SectionMutationError';
+  }
+}
+
+type LiveSection = {
+  sectPr: Element;
+  location: SectionBoundaryLocation;
+  paragraph: Element | null;
+};
+
+function getWAttr(el: Element, localName: string): string | null {
+  return el.getAttributeNS(OOXML.W_NS, localName)
+    || el.getAttribute(`w:${localName}`)
+    || null;
+}
+
+function getRAttr(el: Element, localName: string): string | null {
+  return el.getAttributeNS(OOXML.R_NS, localName)
+    || el.getAttribute(`r:${localName}`)
+    || null;
+}
+
+function decimalAttr(el: Element | null, localName: string): number | null {
+  if (!el) return null;
+  const raw = getWAttr(el, localName);
+  if (raw === null || !/^-?\d+$/.test(raw)) return null;
+  const value = Number(raw);
+  return Number.isSafeInteger(value) ? value : null;
+}
+
+/**
+ * Collect the two canonical live section-property placements without
+ * descending into `w:sectPrChange` snapshots.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.6.18
+ * @see #654
+ */
+function collectLiveSections(doc: Document): LiveSection[] {
+  const body = doc.getElementsByTagNameNS(OOXML.W_NS, W.body).item(0);
+  if (!body) return [];
+
+  const sections: LiveSection[] = [];
+  const paragraphs = body.getElementsByTagNameNS(OOXML.W_NS, W.p);
+  for (let i = 0; i < paragraphs.length; i++) {
+    const paragraph = paragraphs.item(i) as Element;
+    const pPr = getDirectChildrenByName(paragraph, W.pPr)[0];
+    const sectPr = pPr
+      ? getDirectChildrenByName(pPr, W.sectPr)[0]
+      : undefined;
+    if (sectPr) {
+      sections.push({ sectPr, location: 'paragraph', paragraph });
+    }
+  }
+
+  const finalSectPr = childElements(body)
+    .find((child) => isW(child, W.sectPr));
+  if (finalSectPr) {
+    sections.push({ sectPr: finalSectPr, location: 'body', paragraph: null });
+  }
+  return sections;
+}
+
+function projectReferences(sectPr: Element, localName: string): SectionReference[] {
+  return getDirectChildrenByName(sectPr, localName).map((reference) => ({
+    type: getWAttr(reference, W.type),
+    relationshipId: getRAttr(reference, 'id'),
+  }));
+}
+
+function projectSection(section: LiveSection, sectionIndex: number): DocumentSection {
+  const type = getDirectChildrenByName(section.sectPr, W.type)[0] ?? null;
+  const pgNumType = getDirectChildrenByName(section.sectPr, W.pgNumType)[0] ?? null;
+  const pgSz = getDirectChildrenByName(section.sectPr, W.pgSz)[0] ?? null;
+  const pgMar = getDirectChildrenByName(section.sectPr, W.pgMar)[0] ?? null;
+
+  return {
+    sectionIndex,
+    location: section.location,
+    anchorParagraphId: section.paragraph
+      ? getParagraphBookmarkId(section.paragraph)
+      : null,
+    breakType: type ? getWAttr(type, W.val) : null,
+    pageNumberStart: decimalAttr(pgNumType, W.start),
+    pageNumberFormat: pgNumType ? getWAttr(pgNumType, 'fmt') : null,
+    pageSize: pgSz
+      ? {
+          widthTwips: decimalAttr(pgSz, W.w),
+          heightTwips: decimalAttr(pgSz, 'h'),
+          orientation: getWAttr(pgSz, 'orient'),
+        }
+      : null,
+    margins: pgMar
+      ? {
+          topTwips: decimalAttr(pgMar, W.top),
+          rightTwips: decimalAttr(pgMar, W.right),
+          bottomTwips: decimalAttr(pgMar, W.bottom),
+          leftTwips: decimalAttr(pgMar, W.left),
+          headerTwips: decimalAttr(pgMar, 'header'),
+          footerTwips: decimalAttr(pgMar, 'footer'),
+          gutterTwips: decimalAttr(pgMar, 'gutter'),
+        }
+      : null,
+    headers: projectReferences(section.sectPr, W.headerReference),
+    footers: projectReferences(section.sectPr, W.footerReference),
+  };
+}
+
+/**
+ * Return canonical main-document section properties in document order.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.6.18
+ * @conformance ECMA-376 edition 5, Part 1 § 17.6.12
+ * @see #654
+ */
+export function getDocumentSections(doc: Document): DocumentSection[] {
+  return collectLiveSections(doc).map(projectSection);
+}
+
+function validateMutation(mutation: SectionPageNumberMutation): void {
+  if (!Number.isSafeInteger(mutation.sectionIndex) || mutation.sectionIndex < 0) {
+    throw new SectionMutationError(
+      'INVALID_SECTION_INDEX',
+      'sectionIndex must be a non-negative safe integer.',
+    );
+  }
+  if (
+    !Number.isSafeInteger(mutation.pageNumberStart)
+    || mutation.pageNumberStart < 0
+  ) {
+    throw new SectionMutationError(
+      'INVALID_PAGE_NUMBER_START',
+      'pageNumberStart must be a non-negative safe integer.',
+    );
+  }
+}
+
+function insertPgNumTypeInSchemaOrder(sectPr: Element, pgNumType: Element): void {
+  const successors = new Set([
+    'cols',
+    'formProt',
+    'vAlign',
+    'noEndnote',
+    W.titlePg,
+    'textDirection',
+    'bidi',
+    'rtlGutter',
+    'docGrid',
+    'printerSettings',
+    'sectPrChange',
+  ]);
+  const successor = childElements(sectPr)
+    .find((child) => successors.has(child.localName));
+  if (successor) sectPr.insertBefore(pgNumType, successor);
+  else sectPr.appendChild(pgNumType);
+}
+
+/**
+ * Set one section's page-number restart while preserving all unrelated section
+ * properties and recording the prior state when a revision context is supplied.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.6.12
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.5.32
+ * @see #654
+ */
+export function setSectionPageNumberStart(
+  doc: Document,
+  mutation: SectionPageNumberMutation,
+  ctx?: RevisionContext,
+): SectionPageNumberMutationResult {
+  validateMutation(mutation);
+  const liveSection = collectLiveSections(doc)[mutation.sectionIndex];
+  if (!liveSection) {
+    throw new SectionMutationError(
+      'SECTION_NOT_FOUND',
+      `Section index ${mutation.sectionIndex} was not found.`,
+    );
+  }
+
+  const existingPgNumTypes = getDirectChildrenByName(
+    liveSection.sectPr,
+    W.pgNumType,
+  );
+  const previousPageNumberStart = decimalAttr(
+    existingPgNumTypes[0] ?? null,
+    W.start,
+  );
+  if (
+    existingPgNumTypes.length === 1
+    && previousPageNumberStart === mutation.pageNumberStart
+  ) {
+    return {
+      sectionIndex: mutation.sectionIndex,
+      changed: false,
+      previousPageNumberStart,
+      currentPageNumberStart: mutation.pageNumberStart,
+    };
+  }
+
+  const oldSectPr = liveSection.sectPr.cloneNode(true) as Element;
+  let pgNumType = existingPgNumTypes[0];
+  for (const duplicate of existingPgNumTypes.slice(1)) {
+    liveSection.sectPr.removeChild(duplicate);
+  }
+  if (!pgNumType) {
+    pgNumType = createWmlElement(doc, W.pgNumType);
+    insertPgNumTypeInSchemaOrder(liveSection.sectPr, pgNumType);
+  }
+  pgNumType.setAttributeNS(
+    OOXML.W_NS,
+    `w:${W.start}`,
+    String(mutation.pageNumberStart),
+  );
+
+  if (ctx) {
+    for (const stale of getDirectChildrenByName(liveSection.sectPr, 'sectPrChange')) {
+      liveSection.sectPr.removeChild(stale);
+    }
+    liveSection.sectPr.appendChild(buildSectPrChangeElement(oldSectPr, ctx));
+  }
+
+  return {
+    sectionIndex: mutation.sectionIndex,
+    changed: true,
+    previousPageNumberStart,
+    currentPageNumberStart: mutation.pageNumberStart,
+  };
+}

--- a/packages/docx-core/src/primitives/track-changes-emitter.ts
+++ b/packages/docx-core/src/primitives/track-changes-emitter.ts
@@ -1,6 +1,6 @@
 import { parseXml, serializeXml } from './xml.js';
 import { childElements, createWmlElement, renameElement } from './dom-helpers.js';
-import { OOXML } from './namespaces.js';
+import { OOXML, W } from './namespaces.js';
 
 const SYNTHETIC_DOC = parseXml(
   '<root xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"/>',
@@ -13,6 +13,17 @@ const EXCLUDED_TRPR_CHANGE_CHILDREN = new Set(['w:trPrChange', 'w:ins', 'w:del']
 // change-of-a-change marker w:tcPrChange itself is excluded. See:
 // https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.wordprocessing.previoustablecellproperties
 const EXCLUDED_TCPR_CHANGE_CHILDREN = new Set(['w:tcPrChange']);
+const EXCLUDED_SECTPR_CHANGE_CHILDREN = new Set([
+  'w:headerReference',
+  'w:footerReference',
+  'w:sectPrChange',
+]);
+const SECTPR_BASE_ATTRIBUTE_NAMES = new Set([
+  'rsidRPr',
+  'rsidDel',
+  'rsidR',
+  'rsidSect',
+]);
 
 /**
  * State for allocating monotonically increasing revision IDs.
@@ -228,6 +239,50 @@ export function buildTcPrChangeElement(oldTcPr: Element | null, ctx: RevisionCon
 
   tcPrChange.appendChild(previousTcPr);
   return tcPrChange;
+}
+
+/**
+ * Build a `<w:sectPrChange>` wrapper containing the previous section
+ * properties. A prior change record is excluded from the nested snapshot so
+ * the emitter never authors a change-of-a-change.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.5.32
+ * @see #654
+ */
+export function buildSectPrChangeElement(
+  oldSectPr: Element,
+  ctx: RevisionContext,
+): Element {
+  const sectPrChange = createWmlElement(
+    getOwnerDocument(oldSectPr),
+    'sectPrChange',
+    revisionAttributes(ctx),
+  );
+  const previousSectPr = createWmlElement(getOwnerDocument(oldSectPr), W.sectPr);
+
+  for (let i = 0; i < oldSectPr.attributes.length; i++) {
+    const attribute = oldSectPr.attributes.item(i);
+    if (
+      attribute
+      && attribute.namespaceURI === OOXML.W_NS
+      && SECTPR_BASE_ATTRIBUTE_NAMES.has(attribute.localName)
+    ) {
+      previousSectPr.setAttributeNS(
+        OOXML.W_NS,
+        `w:${attribute.localName}`,
+        attribute.value,
+      );
+    }
+  }
+
+  for (const child of childElements(oldSectPr)) {
+    if (!EXCLUDED_SECTPR_CHANGE_CHILDREN.has(child.tagName)) {
+      previousSectPr.appendChild(child.cloneNode(true));
+    }
+  }
+
+  sectPrChange.appendChild(previousSectPr);
+  return sectPrChange;
 }
 
 /**

--- a/packages/docx-mcp/docs/tool-reference.generated.md
+++ b/packages/docx-mcp/docs/tool-reference.generated.md
@@ -39,6 +39,18 @@ Get a compact structural map of a document's headings (DOCX only). Each entry is
 | `format` | `enum("json", "markdown")` | no | Output format: 'json' (default, structured outline array) or 'markdown' (indented ATX outline under `content`). |
 | `include_heuristic_headings` | `boolean` | no | When true, also include heuristic title/run-in/centered-caps headings alongside deterministic word_style, list_metadata, and outline_level headings. Default: false (all deterministic sources only). |
 
+## `get_sections`
+
+Read DOCX main-document sections in document order. Returns zero-based session-relative section_index values, paragraph/body boundary metadata, page numbering, page size, margins, and header/footer relationship references. Call again after any operation that changes section topology. Read-only.
+
+- readOnly: `true`
+- destructive: `false`
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `file_path` | `string` | no | Path to the DOCX or ODT file. |
+| `google_doc_id` | `string` | no | Google Doc ID or URL (alternative to file_path). Extract from URL: docs.google.com/document/d/{ID}/edit |
+
 ## `grep`
 
 Search paragraphs with regex. Use file_path for session-based search, file_paths for stateless multi-file search, or google_doc_id for Google Docs. ODT supported via file_path (single-file) only.
@@ -189,6 +201,20 @@ Change one DOCX body paragraph’s direct numbering reference. Use remove=true t
 | `match_paragraph_id` | `string` | no | Copy this paragraph’s complete direct num_id and ilvl to the target. |
 | `num_id` | `string` | no | Existing positive decimal w:numId from this DOCX; requires ilvl. |
 | `ilvl` | `integer` | no | Existing numbering level for num_id; requires num_id. |
+
+## `format_section`
+
+Set one DOCX section’s page-number restart using a zero-based section_index from get_sections. This first slice writes only w:pgNumType/@w:start, preserves page setup and header/footer references, and emits a native w:sectPrChange. It does not create sections or change page size, margins, break type, headers, footers, or page-number format.
+
+- readOnly: `false`
+- destructive: `true`
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `file_path` | `string` | no | Path to the DOCX or ODT file. |
+| `google_doc_id` | `string` | no | Google Doc ID or URL (alternative to file_path). Extract from URL: docs.google.com/document/d/{ID}/edit |
+| `section_index` | `integer` | yes | Zero-based session-relative index returned by get_sections. |
+| `page_number_start` | `integer` | yes | Non-negative page number at which this section starts. |
 
 ## `accept_changes`
 

--- a/packages/docx-mcp/src/add_typescript_mcp_server.test.ts
+++ b/packages/docx-mcp/src/add_typescript_mcp_server.test.ts
@@ -71,6 +71,8 @@ describe('TypeScript MCP server behavior', () => {
       'insert_paragraph',
       'format_layout',
       'format_numbering',
+      'get_sections',
+      'format_section',
       'save',
       'has_tracked_changes',
       'get_file_status',
@@ -89,7 +91,7 @@ describe('TypeScript MCP server behavior', () => {
   });
 
   humanReadableTest.openspec('Read-only tools annotated correctly')('Scenario: Read-only tools annotated correctly', async () => {
-    const readOnlyTools = new Set(['read_file', 'grep', 'has_tracked_changes', 'get_file_status']);
+    const readOnlyTools = new Set(['read_file', 'grep', 'get_sections', 'has_tracked_changes', 'get_file_status']);
     for (const tool of MCP_TOOLS) {
       if (!readOnlyTools.has(tool.name)) continue;
       expect(tool.annotations.readOnlyHint).toBe(true);
@@ -98,7 +100,7 @@ describe('TypeScript MCP server behavior', () => {
   });
 
   humanReadableTest.openspec('Destructive tools annotated correctly')('Scenario: Destructive tools annotated correctly', async () => {
-    const destructiveTools = new Set(['batch_edit', 'replace_text', 'insert_paragraph', 'format_layout', 'format_numbering', 'save']);
+    const destructiveTools = new Set(['batch_edit', 'replace_text', 'insert_paragraph', 'format_layout', 'format_numbering', 'format_section', 'save']);
     for (const tool of MCP_TOOLS) {
       if (!destructiveTools.has(tool.name)) continue;
       expect(tool.annotations.readOnlyHint).toBe(false);

--- a/packages/docx-mcp/src/integration/canonical-emission-mcp.test.ts
+++ b/packages/docx-mcp/src/integration/canonical-emission-mcp.test.ts
@@ -11,6 +11,7 @@ import { batchEdit } from '../tools/batch_edit.js';
 import { clearFormatting } from '../tools/clear_formatting.js';
 import { formatLayout } from '../tools/format_layout.js';
 import { formatNumbering } from '../tools/format_numbering.js';
+import { formatSection } from '../tools/format_section.js';
 import { addComment } from '../tools/add_comment.js';
 import { deleteComment } from '../tools/delete_comment.js';
 import { addFootnote } from '../tools/add_footnote.js';
@@ -25,6 +26,10 @@ const numberingTest = test.conformance(
   { spec: 'ECMA-376', edition: 5, part: 1, section: '17.3.1.19' },
   { spec: 'ECMA-376', edition: 5, part: 1, section: '17.9.18' },
   { spec: 'ECMA-376', edition: 5, part: 1, section: '17.9.3' },
+);
+const sectionTest = test.conformance(
+  { spec: 'ECMA-376', edition: 5, part: 1, section: '17.6.12' },
+  { spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.5.32' },
 );
 
 const AI_AUTHOR = 'SafeDocX';
@@ -372,6 +377,45 @@ describe('Tool integration through SessionManager: canonical revision emission',
       const change = doc.getElementsByTagNameNS(W_NS, 'pPrChange')[0] as Element;
       const priorIlvl = change.getElementsByTagNameNS(W_NS, 'ilvl')[0] as Element;
       expect(wordAttr(priorIlvl, 'val')).toBe('0');
+    });
+  });
+
+  sectionTest('format_section saves a SafeDocX-authored section property change', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    let opened: Awaited<ReturnType<typeof openSession>>;
+    let documentXml: string;
+
+    await given('a tracked session with a final section', async () => {
+      opened = await openSession([], {
+        mgr: createManager(),
+        xml: makeDocXml('<w:p><w:r><w:t>Section body</w:t></w:r></w:p>'),
+      });
+    });
+
+    await when('format_section restarts page numbering and saves tracked output', async () => {
+      const formatted = await formatSection(opened.mgr, {
+        file_path: opened.inputPath,
+        section_index: 0,
+        page_number_start: 1,
+      });
+      assertSuccess(formatted, 'format_section');
+      const parts = await saveAndReadParts(
+        opened.mgr,
+        opened.inputPath,
+        path.join(opened.tmpDir, 'format-section-regression.docx'),
+        ['word/document.xml'],
+      );
+      documentXml = parts['word/document.xml'];
+    });
+
+    await then('document.xml contains a SafeDocX-authored section property change', () => {
+      expectTrackedElementsWithAuthor(documentXml, ['sectPrChange']);
+      const doc = parseXml(documentXml);
+      const current = doc.getElementsByTagNameNS(W_NS, 'pgNumType')[0] as Element;
+      expect(wordAttr(current, 'start')).toBe('1');
     });
   });
 

--- a/packages/docx-mcp/src/server.ts
+++ b/packages/docx-mcp/src/server.ts
@@ -8,6 +8,7 @@ import { SAFE_DOCX_MCP_TOOLS } from './tool_catalog.js';
 import { readFile } from './tools/read_file.js';
 import { grep } from './tools/grep.js';
 import { getDocumentOutline } from './tools/get_document_outline.js';
+import { getSections } from './tools/get_sections.js';
 import { replaceText } from './tools/replace_text.js';
 import { insertParagraph } from './tools/insert_paragraph.js';
 import { batchEdit } from './tools/batch_edit.js';
@@ -19,6 +20,7 @@ import { hasTrackedChanges_tool } from './tools/has_tracked_changes.js';
 import { closeFile } from './tools/close_file.js';
 import { formatLayout } from './tools/format_layout.js';
 import { formatNumbering } from './tools/format_numbering.js';
+import { formatSection } from './tools/format_section.js';
 import { acceptChanges } from './tools/accept_changes.js';
 import { acceptAiEdits } from './tools/accept_ai_edits.js';
 import { rejectAiEdits } from './tools/reject_ai_edits.js';
@@ -165,6 +167,10 @@ export async function dispatchToolCall(
       return await grep(sessions, args as Parameters<typeof grep>[1]);
     case 'get_document_outline':
       return await getDocumentOutline(sessions, args as Parameters<typeof getDocumentOutline>[1]);
+    case 'get_sections':
+      if (isGDocsRequest(args)) return await dispatchGDocs(sessions, args, 'get_sections');
+      if (isOdfRequest(args)) return await dispatchOdf(sessions, args, 'get_sections');
+      return await getSections(sessions, args as Parameters<typeof getSections>[1]);
     case 'batch_edit':
       return await batchEdit(sessions, args as Parameters<typeof batchEdit>[1]);
     case 'replace_text':
@@ -190,6 +196,10 @@ export async function dispatchToolCall(
       if (isGDocsRequest(args)) return await dispatchGDocs(sessions, args, 'format_numbering');
       if (isOdfRequest(args)) return await dispatchOdf(sessions, args, 'format_numbering');
       return await formatNumbering(sessions, args as Parameters<typeof formatNumbering>[1]);
+    case 'format_section':
+      if (isGDocsRequest(args)) return await dispatchGDocs(sessions, args, 'format_section');
+      if (isOdfRequest(args)) return await dispatchOdf(sessions, args, 'format_section');
+      return await formatSection(sessions, args as Parameters<typeof formatSection>[1]);
     case 'accept_changes':
       return await acceptChanges(sessions, args as Parameters<typeof acceptChanges>[1]);
     case 'accept_ai_edits':

--- a/packages/docx-mcp/src/tool_catalog.ts
+++ b/packages/docx-mcp/src/tool_catalog.ts
@@ -128,6 +128,17 @@ export const SAFE_DOCX_TOOL_CATALOG = [
     annotations: { readOnlyHint: true, destructiveHint: false },
   },
   {
+    name: 'get_sections',
+    surface: 'internal',
+    description:
+      'Read DOCX main-document sections in document order. Returns zero-based session-relative section_index values, paragraph/body boundary metadata, page numbering, page size, margins, and header/footer relationship references. Call again after any operation that changes section topology. Read-only.',
+    input: z.object({
+      ...FILE_FIELD_OPTIONAL,
+      ...GOOGLE_DOC_ID_FIELD,
+    }),
+    annotations: { readOnlyHint: true, destructiveHint: false },
+  },
+  {
     name: 'grep',
     surface: 'internal',
     description: 'Search paragraphs with regex. Use file_path for session-based search, file_paths for stateless multi-file search, or google_doc_id for Google Docs. ODT supported via file_path (single-file) only.',
@@ -364,6 +375,27 @@ export const SAFE_DOCX_TOOL_CATALOG = [
         .nonnegative()
         .optional()
         .describe('Existing numbering level for num_id; requires num_id.'),
+    }),
+    annotations: { readOnlyHint: false, destructiveHint: true },
+  },
+  {
+    name: 'format_section',
+    surface: 'revisionable',
+    description:
+      'Set one DOCX section’s page-number restart using a zero-based section_index from get_sections. This first slice writes only w:pgNumType/@w:start, preserves page setup and header/footer references, and emits a native w:sectPrChange. It does not create sections or change page size, margins, break type, headers, footers, or page-number format.',
+    input: z.object({
+      ...FILE_FIELD_OPTIONAL,
+      ...GOOGLE_DOC_ID_FIELD,
+      section_index: z
+        .number()
+        .int()
+        .nonnegative()
+        .describe('Zero-based session-relative index returned by get_sections.'),
+      page_number_start: z
+        .number()
+        .int()
+        .nonnegative()
+        .describe('Non-negative page number at which this section starts.'),
     }),
     annotations: { readOnlyHint: false, destructiveHint: true },
   },

--- a/packages/docx-mcp/src/tools/forbid_untracked_ai_mutations.test.ts
+++ b/packages/docx-mcp/src/tools/forbid_untracked_ai_mutations.test.ts
@@ -14,6 +14,7 @@ import { batchEdit } from './batch_edit.js';
 import { clearFormatting } from './clear_formatting.js';
 import { formatLayout } from './format_layout.js';
 import { formatNumbering } from './format_numbering.js';
+import { formatSection } from './format_section.js';
 import { insertParagraph } from './insert_paragraph.js';
 import { replaceText } from './replace_text.js';
 import { save } from './save.js';
@@ -142,6 +143,18 @@ const REVISIONABLE_EDITORS: Array<{
         file_path: filePath,
         target_paragraph_id: firstParaId,
         remove: true,
+      }),
+  },
+  {
+    name: 'format_section',
+    bodyXml:
+      '<w:p><w:r><w:t>Alpha bravo charlie</w:t></w:r></w:p>'
+      + '<w:sectPr><w:pgNumType w:start="2"/></w:sectPr>',
+    run: (mgr, filePath) =>
+      formatSection(mgr, {
+        file_path: filePath,
+        section_index: 0,
+        page_number_start: 1,
       }),
   },
   {

--- a/packages/docx-mcp/src/tools/format_section.test.ts
+++ b/packages/docx-mcp/src/tools/format_section.test.ts
@@ -1,0 +1,297 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { readZipText } from '@usejunior/docx-core';
+import { describe, expect } from 'vitest';
+import { dispatchToolCall } from '../server.js';
+import { testAllure } from '../testing/allure-test.js';
+import {
+  assertFailure,
+  assertSuccess,
+  createTestSessionManager,
+  openSession,
+  registerCleanup,
+} from '../testing/session-test-utils.js';
+import { acceptAiEdits } from './accept_ai_edits.js';
+import { formatSection } from './format_section.js';
+import { getSections } from './get_sections.js';
+import { rejectAiEdits } from './reject_ai_edits.js';
+import { save } from './save.js';
+
+const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const R_NS = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const TEST_FEATURE = 'add-section-page-numbering-formatting';
+const test = testAllure.epic('Document Editing').withLabels({
+  feature: TEST_FEATURE,
+});
+
+const DOCUMENT_XML =
+  `<w:document xmlns:w="${W_NS}" xmlns:r="${R_NS}"><w:body>`
+  + '<w:p><w:r><w:t>First section</w:t></w:r></w:p>'
+  + '<w:p><w:pPr><w:sectPr>'
+  + '<w:headerReference w:type="default" r:id="rId4"/>'
+  + '<w:pgSz w:w="12240" w:h="15840"/>'
+  + '<w:pgMar w:top="1440" w:right="720" w:bottom="1440" w:left="720"/>'
+  + '<w:pgNumType w:start="2" w:fmt="lowerRoman"/>'
+  + '<w:cols w:num="2"/><w:titlePg/>'
+  + '</w:sectPr></w:pPr><w:r><w:t>Section boundary</w:t></w:r></w:p>'
+  + '<w:p><w:r><w:t>Final section</w:t></w:r></w:p>'
+  + '<w:sectPr><w:footerReference w:type="default" r:id="rId5"/>'
+  + '<w:pgSz w:w="15840" w:h="12240" w:orient="landscape"/>'
+  + '<w:pgMar w:top="720" w:right="720" w:bottom="720" w:left="720"/>'
+  + '</w:sectPr>'
+  + '</w:body></w:document>';
+
+async function openSectionSession() {
+  const mgr = createTestSessionManager({ defaultAiAuthor: 'SafeDocX AI' });
+  return openSession([], {
+    mgr,
+    xml: DOCUMENT_XML,
+    extraFiles: {
+      'word/custom-preserved.xml': '<root keep="yes"/>',
+    },
+  });
+}
+
+async function getSessionSections(
+  opened: Awaited<ReturnType<typeof openSectionSession>>,
+) {
+  const session = await opened.mgr.getSessionByFilePath(opened.inputPath);
+  if (!session || session.provider !== 'docx') throw new Error('Expected DOCX session');
+  return session.doc.getSections();
+}
+
+registerCleanup();
+
+describe('OpenSpec traceability: section tools', () => {
+  test.openspec('Section discovery returns selectable boundaries')(
+    'returns ordered boundary and page-setup metadata',
+    async () => {
+      const opened = await openSectionSession();
+      const result = await getSections(opened.mgr, {
+        file_path: opened.inputPath,
+      });
+      assertSuccess(result, 'get_sections');
+      expect(result.section_count).toBe(2);
+      expect(result.sections).toEqual([
+        expect.objectContaining({
+          section_index: 0,
+          location: 'paragraph',
+          anchor_paragraph_id: opened.paraIds[1],
+          page_numbering: { start: 2, format: 'lowerRoman' },
+          page_size: expect.objectContaining({ width_twips: 12240 }),
+          headers: [{ type: 'default', relationship_id: 'rId4' }],
+        }),
+        expect.objectContaining({
+          section_index: 1,
+          location: 'body',
+          anchor_paragraph_id: null,
+          page_numbering: { start: null, format: null },
+          page_size: expect.objectContaining({ orientation: 'landscape' }),
+          footers: [{ type: 'default', relationship_id: 'rId5' }],
+        }),
+      ]);
+    },
+  );
+
+  test.openspec('File-first and session reuse are supported')(
+    'reuses the session without recording edits',
+    async () => {
+      const opened = await openSectionSession();
+      const session = await opened.mgr.getSessionByFilePath(opened.inputPath);
+      const editsBefore = session?.editCount;
+      const first = await getSections(opened.mgr, { file_path: opened.inputPath });
+      const second = await getSections(opened.mgr, { file_path: opened.inputPath });
+      assertSuccess(first, 'first get_sections');
+      assertSuccess(second, 'second get_sections');
+      expect(second.session_resolution).toBe('reused');
+      expect(session?.editCount).toBe(editsBefore);
+    },
+  );
+
+  test.openspec('Page numbering restarts at the requested value')(
+    'sets the final section restart with tracked metadata',
+    async () => {
+      const opened = await openSectionSession();
+      const result = await formatSection(opened.mgr, {
+        file_path: opened.inputPath,
+        section_index: 1,
+        page_number_start: 1,
+      });
+      assertSuccess(result, 'format_section');
+      expect(result).toMatchObject({
+        section_index: 1,
+        changed: true,
+        previous_page_number_start: null,
+        resulting_page_number_start: 1,
+        section_count_before: 2,
+        section_count_after: 2,
+      });
+      expect((await getSessionSections(opened))[1]?.pageNumberStart).toBe(1);
+      const session = await opened.mgr.getSessionByFilePath(opened.inputPath);
+      if (!session || session.provider !== 'docx') throw new Error('Expected DOCX session');
+      const packed = await session.doc.toBuffer({ cleanBookmarks: false });
+      const xml = await readZipText(packed.buffer, 'word/document.xml');
+      expect(xml).toContain('<w:sectPrChange');
+      expect(xml).toContain('w:author="SafeDocX AI"');
+    },
+  );
+
+  test.openspec('Identical restart does not create an edit')(
+    'leaves edit accounting unchanged on an identical request',
+    async () => {
+      const opened = await openSectionSession();
+      const session = await opened.mgr.getSessionByFilePath(opened.inputPath);
+      const editsBefore = session?.editCount;
+      const result = await formatSection(opened.mgr, {
+        file_path: opened.inputPath,
+        section_index: 0,
+        page_number_start: 2,
+      });
+      assertSuccess(result, 'format_section');
+      expect(result.changed).toBe(false);
+      expect(session?.editCount).toBe(editsBefore);
+    },
+  );
+
+  test.openspec('Invalid input is transactional')(
+    'rejects invalid and missing indexes without changing section state',
+    async () => {
+      const opened = await openSectionSession();
+      const before = await getSessionSections(opened);
+      assertFailure(await formatSection(opened.mgr, {
+        file_path: opened.inputPath,
+        section_index: -1,
+        page_number_start: 1,
+      }), 'VALIDATION_ERROR');
+      assertFailure(await formatSection(opened.mgr, {
+        file_path: opened.inputPath,
+        section_index: 9,
+        page_number_start: 1,
+      }), 'SECTION_NOT_FOUND');
+      assertFailure(await formatSection(opened.mgr, {
+        file_path: opened.inputPath,
+        section_index: 0,
+        page_number_start: -1,
+      }), 'VALIDATION_ERROR');
+      expect(await getSessionSections(opened)).toEqual(before);
+    },
+  );
+
+  test.openspec('Unsupported providers are rejected')(
+    'routes ODT and Google Docs through provider chokepoints',
+    async () => {
+      const manager = createTestSessionManager();
+      for (const toolName of ['get_sections', 'format_section']) {
+        const extra = toolName === 'format_section'
+          ? { section_index: 0, page_number_start: 1 }
+          : {};
+        assertFailure(
+          await dispatchToolCall(manager, toolName, {
+            file_path: '/tmp/not-opened-sections-test.odt',
+            ...extra,
+          }) as { success: boolean; error?: { code?: string } },
+          'UNSUPPORTED_FOR_ODF',
+        );
+        assertFailure(
+          await dispatchToolCall(manager, toolName, {
+            google_doc_id: 'fake-id',
+            ...extra,
+          }) as { success: boolean; error?: { code?: string } },
+          'UNSUPPORTED_FOR_PROVIDER',
+        );
+      }
+    },
+  );
+
+  test.openspec('Page setup and references survive formatting')(
+    'preserves every projected untargeted property and package side part',
+    async () => {
+      const opened = await openSectionSession();
+      const before = (await getSessionSections(opened))[0]!;
+      assertSuccess(await formatSection(opened.mgr, {
+        file_path: opened.inputPath,
+        section_index: 0,
+        page_number_start: 6,
+      }), 'format_section');
+      const after = (await getSessionSections(opened))[0]!;
+      expect({
+        ...after,
+        pageNumberStart: before.pageNumberStart,
+      }).toEqual(before);
+
+      const output = path.join(opened.tmpDir, 'section-preserved.docx');
+      assertSuccess(await save(opened.mgr, {
+        file_path: opened.inputPath,
+        save_to_local_path: output,
+        save_format: 'tracked',
+      }), 'save');
+      expect(await readZipText(
+        await fs.readFile(output),
+        'word/custom-preserved.xml',
+      )).toBe('<root keep="yes"/>');
+    },
+  );
+
+  test.openspec('Clean and tracked saves agree on current state')(
+    'keeps the restart in both variants and review markup only in tracked',
+    async () => {
+      const opened = await openSectionSession();
+      assertSuccess(await formatSection(opened.mgr, {
+        file_path: opened.inputPath,
+        section_index: 1,
+        page_number_start: 1,
+      }), 'format_section');
+      const cleanPath = path.join(opened.tmpDir, 'section-clean.docx');
+      const trackedPath = path.join(opened.tmpDir, 'section-tracked.docx');
+      assertSuccess(await save(opened.mgr, {
+        file_path: opened.inputPath,
+        save_to_local_path: cleanPath,
+        tracked_save_to_local_path: trackedPath,
+        save_format: 'both',
+      }), 'save');
+      const cleanXml = await readZipText(
+        await fs.readFile(cleanPath),
+        'word/document.xml',
+      );
+      const trackedXml = await readZipText(
+        await fs.readFile(trackedPath),
+        'word/document.xml',
+      );
+      expect(cleanXml).toContain('<w:pgNumType w:start="1"/>');
+      expect(cleanXml).not.toContain('<w:sectPrChange');
+      expect(trackedXml).toContain('<w:pgNumType w:start="1"/>');
+      expect(trackedXml).toContain('<w:sectPrChange');
+    },
+  );
+
+  test.openspec('Accept and reject preserve section semantics')(
+    'keeps current restart on accept and restores the prior restart on reject',
+    async () => {
+      const accepted = await openSectionSession();
+      assertSuccess(await formatSection(accepted.mgr, {
+        file_path: accepted.inputPath,
+        section_index: 0,
+        page_number_start: 7,
+      }), 'format_section');
+      assertSuccess(await acceptAiEdits(accepted.mgr, {
+        file_path: accepted.inputPath,
+        author: 'SafeDocX AI',
+      }), 'accept_ai_edits');
+      expect((await getSessionSections(accepted))[0]?.pageNumberStart).toBe(7);
+
+      const rejected = await openSectionSession();
+      assertSuccess(await formatSection(rejected.mgr, {
+        file_path: rejected.inputPath,
+        section_index: 0,
+        page_number_start: 7,
+      }), 'format_section');
+      assertSuccess(await rejectAiEdits(rejected.mgr, {
+        file_path: rejected.inputPath,
+        author: 'SafeDocX AI',
+      }), 'reject_ai_edits');
+      expect((await getSessionSections(rejected))[0]?.pageNumberStart).toBe(2);
+      expect((await getSessionSections(rejected))[0]?.pageNumberFormat)
+        .toBe('lowerRoman');
+    },
+  );
+});

--- a/packages/docx-mcp/src/tools/format_section.test.ts
+++ b/packages/docx-mcp/src/tools/format_section.test.ts
@@ -30,14 +30,14 @@ const DOCUMENT_XML =
   + '<w:p><w:pPr><w:sectPr>'
   + '<w:headerReference w:type="default" r:id="rId4"/>'
   + '<w:pgSz w:w="12240" w:h="15840"/>'
-  + '<w:pgMar w:top="1440" w:right="720" w:bottom="1440" w:left="720"/>'
+  + '<w:pgMar w:top="1440" w:right="720" w:bottom="1440" w:left="720" w:header="360" w:footer="360" w:gutter="0"/>'
   + '<w:pgNumType w:start="2" w:fmt="lowerRoman"/>'
   + '<w:cols w:num="2"/><w:titlePg/>'
   + '</w:sectPr></w:pPr><w:r><w:t>Section boundary</w:t></w:r></w:p>'
   + '<w:p><w:r><w:t>Final section</w:t></w:r></w:p>'
   + '<w:sectPr><w:footerReference w:type="default" r:id="rId5"/>'
   + '<w:pgSz w:w="15840" w:h="12240" w:orient="landscape"/>'
-  + '<w:pgMar w:top="720" w:right="720" w:bottom="720" w:left="720"/>'
+  + '<w:pgMar w:top="720" w:right="720" w:bottom="720" w:left="720" w:header="360" w:footer="360" w:gutter="0"/>'
   + '</w:sectPr>'
   + '</w:body></w:document>';
 

--- a/packages/docx-mcp/src/tools/format_section.ts
+++ b/packages/docx-mcp/src/tools/format_section.ts
@@ -1,0 +1,131 @@
+import { SectionMutationError } from '@usejunior/docx-core';
+import { errorMessage } from '../error_utils.js';
+import {
+  getRevisionContextForSession,
+  type SessionManager,
+} from '../session/manager.js';
+import { preflightAiRevisionMutation } from './ai_revision_guard.js';
+import {
+  mergeSessionResolutionMetadata,
+  resolveSessionForTool,
+} from './session_resolution.js';
+import { err, ok, type ToolResponse } from './types.js';
+
+export type FormatSectionParams = {
+  file_path?: string;
+  section_index?: unknown;
+  page_number_start?: unknown;
+};
+
+function mutationHint(code: SectionMutationError['code']): string {
+  switch (code) {
+    case 'INVALID_SECTION_INDEX':
+      return 'Pass a non-negative section_index returned by get_sections.';
+    case 'SECTION_NOT_FOUND':
+      return 'Call get_sections again and choose a current section_index.';
+    case 'INVALID_PAGE_NUMBER_START':
+      return 'Pass page_number_start as a non-negative integer.';
+  }
+}
+
+export async function formatSection(
+  manager: SessionManager,
+  params: FormatSectionParams,
+): Promise<ToolResponse> {
+  if (
+    typeof params.section_index !== 'number'
+    || !Number.isSafeInteger(params.section_index)
+    || params.section_index < 0
+  ) {
+    return err(
+      'VALIDATION_ERROR',
+      'section_index must be a non-negative safe integer.',
+      'Call get_sections and pass one of its section_index values.',
+    );
+  }
+  if (
+    typeof params.page_number_start !== 'number'
+    || !Number.isSafeInteger(params.page_number_start)
+    || params.page_number_start < 0
+  ) {
+    return err(
+      'VALIDATION_ERROR',
+      'page_number_start must be a non-negative safe integer.',
+      'Pass an integer such as 0 or 1.',
+    );
+  }
+
+  try {
+    const resolved = await resolveSessionForTool(manager, params, {
+      toolName: 'format_section',
+    });
+    if (!resolved.ok) return resolved.response;
+    const { session, metadata } = resolved;
+
+    const sectionsBefore = session.doc.getSections();
+    const targetBefore = sectionsBefore[params.section_index];
+    if (!targetBefore) {
+      return err(
+        'SECTION_NOT_FOUND',
+        `Section index ${params.section_index} was not found.`,
+        'Call get_sections again and choose a current section_index.',
+      );
+    }
+
+    const paragraphCountBefore = session.doc.getParagraphs().length;
+    const ctx = await getRevisionContextForSession(session);
+    const mutation = {
+      sectionIndex: params.section_index,
+      pageNumberStart: params.page_number_start,
+    };
+    const revisionPreflight = await preflightAiRevisionMutation(
+      session,
+      ctx,
+      (previewDoc, previewCtx) => {
+        previewDoc.setSectionPageNumberStart(mutation, previewCtx);
+      },
+    );
+    if (revisionPreflight) return revisionPreflight;
+
+    const result = session.doc.setSectionPageNumberStart(mutation, ctx);
+    const sectionsAfter = session.doc.getSections();
+    const paragraphCountAfter = session.doc.getParagraphs().length;
+    if (
+      sectionsBefore.length !== sectionsAfter.length
+      || paragraphCountBefore !== paragraphCountAfter
+    ) {
+      return err(
+        'INVARIANT_VIOLATION',
+        'Section formatting changed section or paragraph count.',
+        'Section page-number formatting must preserve document topology.',
+      );
+    }
+
+    if (result.changed) manager.markEdited(session);
+    manager.touch(session);
+
+    return ok(mergeSessionResolutionMetadata({
+      file_path: manager.normalizePath(session.originalPath),
+      section_index: result.sectionIndex,
+      changed: result.changed,
+      previous_page_number_start: result.previousPageNumberStart,
+      resulting_page_number_start: result.currentPageNumberStart,
+      section_count_before: sectionsBefore.length,
+      section_count_after: sectionsAfter.length,
+      paragraph_count_before: paragraphCountBefore,
+      paragraph_count_after: paragraphCountAfter,
+      message: result.changed
+        ? 'Section page numbering updated with a tracked property change.'
+        : 'Section page numbering already matched the requested state; no edit was recorded.',
+    }, metadata));
+  } catch (error: unknown) {
+    if (error instanceof SectionMutationError) {
+      return err(error.code, error.message, mutationHint(error.code));
+    }
+    return err(
+      'FORMAT_SECTION_ERROR',
+      `Failed to format section: ${errorMessage(error)}`,
+      'Call get_sections, verify the target, and retry.',
+    );
+  }
+}

--- a/packages/docx-mcp/src/tools/get_sections.ts
+++ b/packages/docx-mcp/src/tools/get_sections.ts
@@ -1,0 +1,72 @@
+import type { DocumentSection } from '@usejunior/docx-core';
+import { errorMessage } from '../error_utils.js';
+import type { SessionManager } from '../session/manager.js';
+import {
+  mergeSessionResolutionMetadata,
+  resolveSessionForTool,
+} from './session_resolution.js';
+import { err, ok, type ToolResponse } from './types.js';
+
+function projectSection(section: DocumentSection) {
+  return {
+    section_index: section.sectionIndex,
+    location: section.location,
+    anchor_paragraph_id: section.anchorParagraphId,
+    break_type: section.breakType,
+    page_numbering: {
+      start: section.pageNumberStart,
+      format: section.pageNumberFormat,
+    },
+    page_size: section.pageSize && {
+      width_twips: section.pageSize.widthTwips,
+      height_twips: section.pageSize.heightTwips,
+      orientation: section.pageSize.orientation,
+    },
+    margins: section.margins && {
+      top_twips: section.margins.topTwips,
+      right_twips: section.margins.rightTwips,
+      bottom_twips: section.margins.bottomTwips,
+      left_twips: section.margins.leftTwips,
+      header_twips: section.margins.headerTwips,
+      footer_twips: section.margins.footerTwips,
+      gutter_twips: section.margins.gutterTwips,
+    },
+    headers: section.headers.map((reference) => ({
+      type: reference.type,
+      relationship_id: reference.relationshipId,
+    })),
+    footers: section.footers.map((reference) => ({
+      type: reference.type,
+      relationship_id: reference.relationshipId,
+    })),
+  };
+}
+
+export async function getSections(
+  manager: SessionManager,
+  params: { file_path?: string },
+): Promise<ToolResponse> {
+  const resolved = await resolveSessionForTool(manager, params, {
+    toolName: 'get_sections',
+  });
+  if (!resolved.ok) return resolved.response;
+  const { session, metadata } = resolved;
+
+  try {
+    const sections = session.doc.getSections().map(projectSection);
+    manager.touch(session);
+    return ok(mergeSessionResolutionMetadata({
+      file_path: manager.normalizePath(session.originalPath),
+      section_count: sections.length,
+      sections,
+      selector_note:
+        'section_index is session-relative; call get_sections again after changing section topology.',
+    }, metadata));
+  } catch (error: unknown) {
+    return err(
+      'GET_SECTIONS_ERROR',
+      `Failed to read sections: ${errorMessage(error)}`,
+      'Validate the DOCX structure and retry.',
+    );
+  }
+}

--- a/packages/safe-docx-mcpb/manifest.json
+++ b/packages/safe-docx-mcpb/manifest.json
@@ -33,6 +33,10 @@
       "description": "Get a compact structural map of the document's headings with stable paragraph IDs."
     },
     {
+      "name": "get_sections",
+      "description": "Inspect DOCX sections, page setup, header/footer references, and page-number settings."
+    },
+    {
       "name": "batch_edit",
       "description": "Validate, conflict-check, and apply multiple edit steps in one call."
     },
@@ -59,6 +63,10 @@
     {
       "name": "format_layout",
       "description": "Apply deterministic paragraph/table layout formatting controls."
+    },
+    {
+      "name": "format_section",
+      "description": "Set a DOCX section's page-number restart with tracked-change support."
     },
     {
       "name": "format_numbering",

--- a/spec-compliance/CONFORMANCE.md
+++ b/spec-compliance/CONFORMANCE.md
@@ -51,7 +51,7 @@ Allure labels via `testAllure.conformance({…})`; source code carries
 | `ECMA-PART1-17-7-4-17` | w:style style-definition emission | 5 | 1 | 17.7.4.17 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:style` | — |
 | `ECMA-PART1-17-7-5-1` | w:docDefaults document-default properties | 5 | 1 | 17.7.5.1 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:docDefaults` | — |
 | `ECMA-PART1-17-6-18` | w:sectPr paragraph-level section break emission | 5 | 1 | 17.6.18 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:sectPr` | — |
-| `ECMA-PART1-17-6-12` | w:pgNumType page-numbering settings emission | 5 | 1 | 17.6.12 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:pgNumType` | — |
+| `ECMA-PART1-17-6-12` | w:pgNumType page-numbering settings emission | 5 | 1 | 17.6.12 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:pgNumType` | packages/docx-core/src/generation/generation-sections-fields.test.ts; packages/docx-core/src/primitives/sections.ts; packages/docx-core/src/primitives/sections.test.ts; packages/docx-core/src/integration/canonical-emission-regression.test.ts; packages/docx-mcp/src/tools/format_section.test.ts; packages/docx-mcp/src/integration/canonical-emission-mcp.test.ts |
 | `ECMA-PART1-17-10-5` | w:headerReference binding | 5 | 1 | 17.10.5 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:headerReference` | packages/docx-core/src/primitives/sectPrAudit.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts; packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.ts; verification/lean/Tier2/RelationshipStorySelector.lean; verification/lean/LeanDocxChecker.lean; packages/docx-compare/src/baselines/atomizer/leanXmlVerifier.test.ts; packages/docx-core/src/integration/ancillary-field-safety.test.ts; packages/docx-core/src/integration/nvca-coi-regression.test.ts |
 | `ECMA-PART1-17-10-2` | w:footerReference binding | 5 | 1 | 17.10.2 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:footerReference` | packages/docx-core/src/primitives/sectPrAudit.ts; packages/docx-core/src/generation/generation-sections-fields.test.ts; packages/docx-compare/src/baselines/atomizer/ancillaryFieldSafety.ts; verification/lean/Tier2/RelationshipStorySelector.lean; verification/lean/LeanDocxChecker.lean; packages/docx-compare/src/baselines/atomizer/leanXmlVerifier.test.ts; packages/docx-core/src/integration/ancillary-field-safety.test.ts; packages/docx-core/src/integration/nvca-coi-regression.test.ts |
 | `ECMA-PART1-17-10-6` | w:titlePg first-page header/footer switch | 5 | 1 | 17.10.6 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:titlePg` | — |
@@ -126,7 +126,7 @@ Allure labels via `testAllure.conformance({…})`; source code carries
 | `ECMA-PART1-17-13-5-29` | Paragraph-property revisions (w:pPrChange) | 5 | 1 | 17.13.5.29 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:pPrChange` | packages/docx-core/src/primitives/accept_changes.ts; packages/docx-core/src/primitives/reject_changes.ts; packages/docx-core/src/integration/advanced-revision-classification.test.ts |
 | `ECMA-PART1-17-13-5-30` | Paragraph-mark run-property revisions (w:rPrChange) | 5 | 1 | 17.13.5.30 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:rPrChange` | packages/docx-core/src/primitives/track-changes-emitter.ts; packages/docx-core/src/primitives/accept_changes.ts; packages/docx-core/src/primitives/reject_changes.ts; packages/docx-core/src/integration/advanced-revision-classification.test.ts |
 | `ECMA-PART1-17-13-5-31` | Run-property revisions (w:rPrChange) | 5 | 1 | 17.13.5.31 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:rPrChange` | packages/docx-core/src/primitives/track-changes-emitter.ts; packages/docx-core/src/primitives/accept_changes.ts; packages/docx-core/src/primitives/reject_changes.ts; packages/docx-core/src/integration/advanced-revision-classification.test.ts |
-| `ECMA-PART1-17-13-5-32` | Section-property revisions (w:sectPrChange) | 5 | 1 | 17.13.5.32 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:sectPrChange` | packages/docx-core/src/primitives/accept_changes.ts; packages/docx-core/src/primitives/reject_changes.ts; packages/docx-core/src/integration/advanced-revision-classification.test.ts |
+| `ECMA-PART1-17-13-5-32` | Section-property revisions (w:sectPrChange) | 5 | 1 | 17.13.5.32 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:sectPrChange` | packages/docx-core/src/primitives/track-changes-emitter.ts; packages/docx-core/src/primitives/sections.ts; packages/docx-core/src/primitives/accept_changes.ts; packages/docx-core/src/primitives/reject_changes.ts; packages/docx-core/src/primitives/sections.test.ts; packages/docx-core/src/integration/advanced-revision-classification.test.ts; packages/docx-core/src/integration/canonical-emission-regression.test.ts; packages/docx-mcp/src/integration/canonical-emission-mcp.test.ts |
 | `ECMA-PART1-17-13-5-34` | Table-property revisions (w:tblPrChange) | 5 | 1 | 17.13.5.34 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:tblPrChange` | packages/docx-core/src/primitives/accept_changes.ts; packages/docx-core/src/primitives/reject_changes.ts; packages/docx-core/src/integration/advanced-revision-classification.test.ts |
 | `ECMA-PART1-17-13-5-36` | Table-cell-property revisions (w:tcPrChange) | 5 | 1 | 17.13.5.36 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:tcPrChange` | packages/docx-core/src/primitives/track-changes-emitter.ts; packages/docx-core/src/primitives/accept_changes.ts; packages/docx-core/src/primitives/reject_changes.ts; packages/docx-core/src/integration/advanced-revision-classification.test.ts |
 | `ECMA-PART1-17-13-5-37` | Table-row-property revisions (w:trPrChange) | 5 | 1 | 17.13.5.37 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:trPrChange` | packages/docx-core/src/primitives/track-changes-emitter.ts; packages/docx-core/src/primitives/accept_changes.ts; packages/docx-core/src/primitives/reject_changes.ts; packages/docx-core/src/integration/advanced-revision-classification.test.ts |
@@ -652,10 +652,13 @@ appends such a break paragraph after every non-final section's blocks;
 - **Part / Section:** Part 1 § 17.6.12
 - **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
 - **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:pgNumType`
+- **Verified by:** packages/docx-core/src/generation/generation-sections-fields.test.ts; packages/docx-core/src/primitives/sections.ts; packages/docx-core/src/primitives/sections.test.ts; packages/docx-core/src/integration/canonical-emission-regression.test.ts; packages/docx-mcp/src/tools/format_section.test.ts; packages/docx-mcp/src/integration/canonical-emission-mcp.test.ts
 
 `w:pgNumType` declares a section's page-number format and restart value.
-Generation emits `w:start`/`w:fmt` only when the spec requests them, so
-sections without explicit numbering inherit continuous decimal numbering.
+Generation emits `w:start`/`w:fmt` only when the spec requests them. The
+section-formatting primitive updates only `w:start` and preserves any existing
+format or chapter-number attributes. Sections without explicit numbering
+inherit continuous decimal numbering.
 
 ### ECMA-PART1-17-10-5 — w:headerReference binding
 
@@ -1577,11 +1580,12 @@ safe-docx emits bounded run-formatting snapshots and consumes existing
 - **Part / Section:** Part 1 § 17.13.5.32
 - **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
 - **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:sectPrChange`
-- **Verified by:** packages/docx-core/src/primitives/accept_changes.ts; packages/docx-core/src/primitives/reject_changes.ts; packages/docx-core/src/integration/advanced-revision-classification.test.ts
+- **Verified by:** packages/docx-core/src/primitives/track-changes-emitter.ts; packages/docx-core/src/primitives/sections.ts; packages/docx-core/src/primitives/accept_changes.ts; packages/docx-core/src/primitives/reject_changes.ts; packages/docx-core/src/primitives/sections.test.ts; packages/docx-core/src/integration/advanced-revision-classification.test.ts; packages/docx-core/src/integration/canonical-emission-regression.test.ts; packages/docx-mcp/src/integration/canonical-emission-mcp.test.ts
 
-safe-docx consumes existing `w:sectPrChange` records: accept removes the prior
-snapshot and reject restores it. No current primitive authors these records;
-headers, footers, relationship semantics, pagination, and Lean are outside the
+safe-docx emits bounded page-number restart snapshots and consumes existing
+`w:sectPrChange` records: accept removes the prior snapshot and reject restores
+it. The authoring claim is limited to `w:pgNumType/@w:start`; header/footer part
+editing, relationship mutation, general pagination, and Lean are outside the
 claim.
 
 ### ECMA-PART1-17-13-5-34 — Table-property revisions (w:tblPrChange)

--- a/spec-compliance/registry/ecma-376.md
+++ b/spec-compliance/registry/ecma-376.md
@@ -658,12 +658,14 @@ part: 1
 section: "17.6.12"
 url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
 schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:pgNumType
-verifiedBy:
+verifiedBy: packages/docx-core/src/generation/generation-sections-fields.test.ts; packages/docx-core/src/primitives/sections.ts; packages/docx-core/src/primitives/sections.test.ts; packages/docx-core/src/integration/canonical-emission-regression.test.ts; packages/docx-mcp/src/tools/format_section.test.ts; packages/docx-mcp/src/integration/canonical-emission-mcp.test.ts
 ```
 
 `w:pgNumType` declares a section's page-number format and restart value.
-Generation emits `w:start`/`w:fmt` only when the spec requests them, so
-sections without explicit numbering inherit continuous decimal numbering.
+Generation emits `w:start`/`w:fmt` only when the spec requests them. The
+section-formatting primitive updates only `w:start` and preserves any existing
+format or chapter-number attributes. Sections without explicit numbering
+inherit continuous decimal numbering.
 
 ## [ECMA-PART1-17-10-5] w:headerReference binding
 
@@ -1842,12 +1844,13 @@ part: 1
 section: "17.13.5.32"
 url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
 schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:sectPrChange
-verifiedBy: packages/docx-core/src/primitives/accept_changes.ts; packages/docx-core/src/primitives/reject_changes.ts; packages/docx-core/src/integration/advanced-revision-classification.test.ts
+verifiedBy: packages/docx-core/src/primitives/track-changes-emitter.ts; packages/docx-core/src/primitives/sections.ts; packages/docx-core/src/primitives/accept_changes.ts; packages/docx-core/src/primitives/reject_changes.ts; packages/docx-core/src/primitives/sections.test.ts; packages/docx-core/src/integration/advanced-revision-classification.test.ts; packages/docx-core/src/integration/canonical-emission-regression.test.ts; packages/docx-mcp/src/integration/canonical-emission-mcp.test.ts
 ```
 
-safe-docx consumes existing `w:sectPrChange` records: accept removes the prior
-snapshot and reject restores it. No current primitive authors these records;
-headers, footers, relationship semantics, pagination, and Lean are outside the
+safe-docx emits bounded page-number restart snapshots and consumes existing
+`w:sectPrChange` records: accept removes the prior snapshot and reject restores
+it. The authoring claim is limited to `w:pgNumType/@w:start`; header/footer part
+editing, relationship mutation, general pagination, and Lean are outside the
 claim.
 
 ## [ECMA-PART1-17-13-5-34] Table-property revisions (w:tblPrChange)


### PR DESCRIPTION
## Summary
- add deterministic DOCX section discovery through the core API and the internal get_sections tool
- add a bounded format_section mutation for w:pgNumType/@w:start with native w:sectPrChange tracking
- preserve section topology, page setup, numbering format/chapter settings, columns, and header/footer references
- add OpenSpec, ECMA-376 citations, generated docs, bundle metadata, and accept/reject regression coverage

## Scope boundary
This is the first #654 slice. It does not create or split sections, edit break type/page size/margins, mutate header/footer parts, or change page-number format.

## Validation
- exact mandatory pre-submit sequence passed: build, workspace lint, full workspace tests, strict spec coverage, conformance citations, and conformance-doc freshness
- OpenSpec strict validation passed
- tool-doc freshness and emitted-schema self-test passed
- real mutual-NDA DOCX smoke passed for tracked, clean, accepted, and rejected outputs; all packages were ZIP-valid, all four document.xml parts passed the Transitional WML schema, and LibreOffice rendered all variants without visual drift

Ref: #654