### PR TITLE
docs(comparison): record unavailable run-split control arm

### DIFF
--- a/docs/comparison-failure-diagnosis.md
+++ b/docs/comparison-failure-diagnosis.md
@@ -74,11 +74,12 @@ both requested modes: `inplace` reported `reconstructionModeUsed: 'inplace'`,
 and `rebuild` reported `reconstructionModeUsed: 'rebuild'`.
 
 That result means the real-document run split moved none of the discriminators
-the opaque-boundary guard compares
-(`packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts`):
-placement, paragraph ownership, container identity, body, container, and
-inline-range ordinals, element name, owned-paragraph count, semantic
-fingerprint, and relationship-closure fingerprint. No fixture was committed:
+the opaque-boundary guard compares. In summary those cover boundary placement
+and paragraph ownership, container identity, positional ordinals, element
+identity, owned-paragraph count, semantic fingerprint, and
+relationship-closure fingerprint — the guard's own comparison in
+`packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts` is the
+authoritative list. No fixture was committed:
 tuning the reconstruction until one of those discriminators moved would create
 a deliberately manufactured failure, not a control for the original abort.
 Until an independently occurring known-bad pair can be staged and pinned

--- a/docs/comparison-failure-diagnosis.md
+++ b/docs/comparison-failure-diagnosis.md
@@ -63,6 +63,28 @@ Running only the suspect input establishes what happened to that input. It does 
 
 A comparison run needs its own control — a known-bad document put through the same harness. When a control has to be reconstructed rather than staged, treat the reconstruction as a hypothesis. If it does not reproduce the expected failure, record that as a negative result and stop. A control iterated until something finally breaks is not a control.
 
+**No document-level control is currently available for the run-split abort.** A
+2026-07-27 reconstruction attempt for
+[#693](https://github.com/UseJunior/safe-docx/issues/693) scrubbed the public
+NVCA indemnification agreement in place, preserving its package structure and
+109 `w:instrText` field instructions. In a field-bearing paragraph, the revised
+side changed one character of a 17-character scrubbed text run and split that
+run in two. The committed public `compareDocuments` entry point succeeded in
+both requested modes: `inplace` reported `reconstructionModeUsed: 'inplace'`,
+and `rebuild` reported `reconstructionModeUsed: 'rebuild'`.
+
+That result means the real-document run split moved none of the discriminators
+the opaque-boundary guard compares
+(`packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts`):
+placement, paragraph ownership, container identity, body, container, and
+inline-range ordinals, element name, owned-paragraph count, semantic
+fingerprint, and relationship-closure fingerprint. No fixture was committed:
+tuning the reconstruction until one of those discriminators moved would create
+a deliberately manufactured failure, not a control for the original abort.
+Until an independently occurring known-bad pair can be staged and pinned
+through `compareDocuments`, a diagnostic run can prove the detector self-tests
+ran, but it cannot prove that its comparison harness can surface this abort.
+
 ## Reproducing A Defect Outside The Original Document
 
 When the document that triggered a defect cannot be shared, the repro is built in this order.


### PR DESCRIPTION
## What

Records a negative result in `docs/comparison-failure-diagnosis.md`: no document-level control arm is currently available for the run-split `OpaquePassthroughError` abort, because the prescribed scrub-in-place reconstruction did not reproduce it.

This is the "or:" branch of #693's acceptance criteria — a written negative result, with the control-arm section updated to say plainly that the control is unavailable — chosen because the issue's own stop condition applies:

> If reconstruction does not reproduce the abort, **record that as a negative result and stop.** Do not iterate until something breaks. A control that had to be forced is not a control.

## The reconstruction that was attempted (2026-07-27)

Following the order the doc itself prescribes (scrub a real document in place first; synthesize only as fallback): the public NVCA indemnification agreement was scrubbed in place — package structure untouched, all 109 `w:instrText` field instructions preserved, text content replaced with deterministic filler. The revised side changed one character of a 17-character text run inside a field-bearing paragraph and split that run in two. `compareDocuments` (atomizer engine) **succeeded in both reconstruction modes** — `reconstructionModeUsed: 'inplace'` and `reconstructionModeUsed: 'rebuild'` — instead of aborting.

No fixture was committed. Tuning the reconstruction until one of the opaque-boundary discriminators finally moved would manufacture a failure, not control for the original abort.

## What a reviewer can and cannot verify

**Not re-executable from the repo alone (by design):** no `.docx` pair was committed — that is the point of the negative result — so the "succeeded in both modes" outcome cannot be re-run from what this PR ships. The driver script and its recorded output exist only in the gitignored `.peer-review/` directory of the originating worktree, and the source document lives outside the repo in `/private/tmp`.

**However, the run was independently re-executed during Codex peer review** (2026-07-28): the reviewer found the original source document still on disk, re-ran the provenance driver against the code at this branch, and reproduced the recorded negative result exactly — 152 paragraphs, 109 `w:instrText` field instructions, target run length 17, `compareDocuments` succeeding with `reconstructionModeUsed: 'inplace'` and `'rebuild'`, exit 0. The prose is therefore a dated record that has been reproduced once by an independent reviewer, not accepted purely as testimony. See the adjudication comment on this PR.

**Verified against the code at this SHA:**
- `scripts/check_docx_formatting_loss.mjs` still implements `--self-test` (the doc's claim that detector self-tests are the only standing control).
- `reconstructionModeUsed?: ReconstructionMode` with `ReconstructionMode = 'rebuild' | 'inplace'` (`packages/docx-compare/src/compare-types.ts:78,738`), populated by the atomizer pipeline; `compareDocuments` is the public export (`packages/docx-compare/src/index.ts:85`).
- The discriminator description in the prose was checked against the actual comparison set of the opaque-boundary guard (`packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts:1242-1256`). After peer review (see adjudication comment) it is now written as a conceptual summary that defers to the guard's own code as the authoritative list, rather than an enumeration that could silently drift.

## Gate

`npm run build && npm run lint:workspaces && npm run test:run && npm run check:spec-coverage && npm run check:conformance-citations && npm run check:conformance-doc` — all six exit 0 locally at 015bfa9, rerun after the review fix at 8f06a25.

Refs #693

https://claude.ai/code/session_01QYEsR9B16hbcyDWkr4VPzp
