### PR TITLE
fix(docx-compare): track paragraph style changes

### DIFF
--- a/openspec/changes/add-paragraph-property-change-tracking/design.md
+++ b/openspec/changes/add-paragraph-property-change-tracking/design.md
@@ -109,6 +109,11 @@ outside scope and must receive separate requirements before implementation.
   whose explicit style reference did not change neither enter the
   paragraph-style inventory nor gain `w:pPrChange` attributable to that
   detector.
+- The existing #646 unsupported-REF characterization blocks the
+  investors-rights document before rebuild atomization. That document remains
+  covered through inplace detection, while every currently rebuild-supported
+  corpus member runs in both modes; the pre-detection #646 pin does not count
+  as paragraph-style evidence.
 
 ## Open Questions
 

--- a/openspec/changes/add-paragraph-property-change-tracking/design.md
+++ b/openspec/changes/add-paragraph-property-change-tracking/design.md
@@ -1,0 +1,116 @@
+## Context
+
+Run-format comparison is atom-level: equal text atoms are compared through
+their `w:rPr` ancestors and changed atoms drive `w:rPrChange` emission.
+Paragraph style is shared by every atom in a paragraph, and an empty paragraph
+has only its boundary atom. Treating a paragraph-style change as one change per
+atom would overcount non-empty paragraphs, allocate duplicate revisions, and
+make behavior depend on run fragmentation.
+
+Both reconstruction paths already know how to emit or preserve
+`w:pPrChange`, and accept/reject already understands the element. The missing
+contract is a paragraph-level comparison result that both paths consume.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Detect an explicit `w:pStyle` reference change once per aligned paragraph.
+- Support aligned empty and non-empty paragraphs through the same path.
+- Emit schema-ordered `w:pPrChange` with the original properties as its
+  snapshot and revised properties as the live state.
+- Give inplace and rebuild equivalent accept/reject projections.
+- Define deterministic `ignoreFormatting` behavior.
+- Avoid phantom paragraph-property revisions on the real corpus.
+
+### Non-Goals
+
+- Comparing the effective formatting resolved through `styles.xml`.
+- Tracking edits to `styles.xml` itself.
+- Detecting `w:numPr`, `w:jc`, `w:ind`, `w:spacing`, or other paragraph
+  properties in this slice.
+- Changing run-property detection or `w:rPrChange` behavior.
+- Reclassifying inserted, deleted, or moved paragraphs as paragraph-property
+  changes.
+
+## Decisions
+
+### Detect at paragraph granularity after content alignment
+
+Build a paragraph-pair inventory from the existing atom/LCS correspondence,
+deduplicate by original/revised paragraph identity, and compare the direct
+`w:pStyle/@w:val` references only when the paragraph is otherwise aligned.
+Represent the result once per paragraph instead of changing every atom's
+correlation status.
+
+This keeps counts stable across run fragmentation and gives empty paragraphs
+the same semantics as paragraphs containing text.
+
+### Keep the revised style live and snapshot the original properties
+
+The output paragraph's direct properties use the revised `w:pStyle`.
+`w:pPrChange` is appended in schema order and contains a bounded original
+`w:pPr` snapshot compatible with `CT_PPrBase`. Revision identifiers, author,
+and date use the comparison's existing allocation context.
+
+The implementation should reuse or generalize the existing
+`addParagraphPropertyChange` machinery rather than create a second serializer.
+The generalized helper must accept an explicit original snapshot; snapshotting
+the already-revised live paragraph would record the wrong side.
+
+### Report one format change per paragraph
+
+Comparison statistics count one paragraph-style format change for each
+affected paragraph, independent of its run count. Revision extraction reports
+the emitted `w:pPrChange` through the existing format-change surface without
+inventing insertion or deletion counts.
+
+### `ignoreFormatting` accepts the revised style without revision markup
+
+When `ignoreFormatting` is `true`, paragraph-style detection and
+`w:pPrChange` emission are disabled. Both reconstruction modes retain the
+revised direct `w:pStyle`, so the option does not reintroduce the current
+mode-dependent winner. Accept and reject therefore both observe the revised
+style for this deliberately ignored difference.
+
+### Compare references, not style semantics
+
+This slice compares absent/present/value changes in direct `w:pStyle`
+references. If both paragraphs reference the same style name, changes to that
+style's definition are outside scope. Direct formatting and numbering remain
+outside scope and must receive separate requirements before implementation.
+
+## Risks / Trade-offs
+
+- Paragraph correspondence assembled from atom matches could be ambiguous
+  when repeated empty paragraphs are present. Existing paragraph identity and
+  positional context must be used to deduplicate and pair them; tests must
+  include consecutive empty paragraphs.
+- Reusing a helper designed for inserted paragraphs could capture the live
+  properties instead of the original properties. The helper contract and
+  projection tests must make the source side explicit.
+- A paragraph can contain multiple text atoms. Statistics and revision IDs
+  must be paragraph-based to prevent fragmentation-dependent output.
+- Choosing revised formatting under `ignoreFormatting` is intentionally
+  lossy, but deterministic and consistent with treating the revised document
+  as the accepted formatting baseline.
+
+## Validation
+
+- Synthetic DOCX pairs cover style addition, removal, and replacement on empty
+  and non-empty paragraphs in both reconstruction modes.
+- Accept-all matches the revised style; reject-all matches the original style
+  when formatting tracking is enabled.
+- Inplace and rebuild projected formatting fidelity is exact for the scoped
+  pairs.
+- `ignoreFormatting` produces no `w:pPrChange` and retains the revised style
+  in both modes.
+- A SHA-256-pinned real-corpus measurement asserts that aligned paragraphs
+  whose explicit style reference did not change neither enter the
+  paragraph-style inventory nor gain `w:pPrChange` attributable to that
+  detector.
+
+## Open Questions
+
+None for the scoped `w:pStyle` slice. Additional paragraph properties require
+separate semantic decisions and follow-up deltas.

--- a/openspec/changes/add-paragraph-property-change-tracking/proposal.md
+++ b/openspec/changes/add-paragraph-property-change-tracking/proposal.md
@@ -1,0 +1,36 @@
+# Change: Track paragraph style changes during comparison
+
+## Why
+
+The comparison engine detects run-property changes but silently drops a change
+confined to `w:pStyle`. Inplace reconstruction keeps the revised style while
+rebuild keeps the original style, so identical inputs can produce
+mode-dependent output with no revision explaining the difference.
+
+Issue #678 removed paragraph properties from empty-paragraph identity so empty
+paragraphs can remain aligned. The comparison layer can now address the actual
+capability gap consistently for empty and non-empty paragraphs.
+
+## What Changes
+
+- Detect an explicit `w:pStyle` reference change on an otherwise aligned
+  paragraph, including empty paragraphs.
+- Emit one native `w:pPrChange` record per changed paragraph, with the revised
+  style active and the original paragraph properties stored in the snapshot.
+- Make inplace and rebuild comparison agree on accept/reject projections and
+  paragraph-level format-change reporting.
+- Define `ignoreFormatting: true` to suppress paragraph-style revision markup
+  while retaining the revised style consistently in both reconstruction modes.
+- Measure the SHA-256-pinned real corpus to ensure unchanged paragraph styles
+  do not acquire phantom `w:pPrChange` markup.
+- Explicitly defer direct paragraph properties (`w:jc`, `w:ind`, `w:spacing`),
+  numbering (`w:numPr`), and semantic changes within `styles.xml`.
+
+## Impact
+
+- Affected specs: `docx-comparison`
+- Affected code: paragraph alignment and format detection, inplace and rebuild
+  reconstruction, comparison statistics/revision extraction, and real-corpus
+  comparison evidence
+- Conformance target: ECMA-376 5th edition, Part 1 § 17.13.5.29
+- Related issues: #679, #678

--- a/openspec/changes/add-paragraph-property-change-tracking/specs/docx-comparison/spec.md
+++ b/openspec/changes/add-paragraph-property-change-tracking/specs/docx-comparison/spec.md
@@ -1,0 +1,96 @@
+## ADDED Requirements
+
+### Requirement: Explicit paragraph style changes are tracked once per aligned paragraph
+
+The atomizer comparison engine SHALL detect an addition, removal, or
+replacement of the direct `w:pStyle/@w:val` reference on an otherwise aligned
+paragraph. It SHALL represent the difference as one paragraph-level format
+change regardless of the paragraph's run fragmentation or whether the
+paragraph is empty.
+
+The engine SHALL NOT classify inserted, deleted, moved, or text-divergent
+paragraphs as paragraph-style-only changes. Direct paragraph formatting,
+numbering properties, style-definition changes, and effective-style resolution
+are outside this requirement.
+
+#### Scenario: [SDX-CMP-PSTYLE-01] Non-empty paragraph style replacement is detected once
+
+- **GIVEN** aligned original and revised paragraphs with identical text and run properties
+- **AND** the original paragraph directly references `Heading1`
+- **AND** the revised paragraph directly references `Normal`
+- **WHEN** atomizer comparison runs with formatting detection enabled
+- **THEN** exactly one paragraph-level format change SHALL be reported
+- **AND** insertion and deletion counts SHALL remain zero
+
+#### Scenario: [SDX-CMP-PSTYLE-02] Empty paragraph style replacement uses the same classification
+
+- **GIVEN** aligned empty original and revised paragraphs
+- **AND** their only substantive difference is direct `w:pStyle`
+- **WHEN** atomizer comparison runs with formatting detection enabled
+- **THEN** exactly one paragraph-level format change SHALL be reported
+- **AND** the paragraph SHALL NOT be represented as a delete-and-insert pair
+
+#### Scenario: [SDX-CMP-PSTYLE-03] Run fragmentation does not multiply paragraph changes
+
+- **GIVEN** an aligned paragraph whose unchanged text is split across multiple runs
+- **AND** its direct `w:pStyle` reference changes
+- **WHEN** atomizer comparison runs with formatting detection enabled
+- **THEN** exactly one paragraph-level format change SHALL be reported
+
+### Requirement: Paragraph style changes use native paragraph-property revision markup
+
+For each detected paragraph-style change, the comparison output SHALL keep the
+revised direct paragraph properties active and SHALL append one
+`w:pPrChange` containing the original paragraph properties as a bounded
+`w:pPr` snapshot. The change record SHALL carry the comparison author, date,
+and an allocated revision identifier, and SHALL occupy the schema-defined
+position in `w:pPr`.
+
+Inplace and rebuild reconstruction SHALL produce equivalent accept and reject
+paragraph-style projections: accept SHALL expose the revised style and reject
+SHALL restore the original style.
+
+#### Scenario: [SDX-CMP-PSTYLE-04] Style replacement emits a reversible pPrChange
+
+- **GIVEN** an aligned paragraph whose direct style changes from `Heading1` to `Normal`
+- **WHEN** comparison runs in either reconstruction mode
+- **THEN** the live `w:pPr` SHALL contain `w:pStyle w:val="Normal"`
+- **AND** one `w:pPrChange` SHALL contain an original `w:pPr` snapshot with `w:pStyle w:val="Heading1"`
+- **AND** the change record SHALL carry `w:id`, `w:author`, and `w:date`
+- **AND** accept SHALL retain `Normal` while reject SHALL restore `Heading1`
+
+#### Scenario: [SDX-CMP-PSTYLE-05] Style addition and removal remain reversible
+
+- **GIVEN** aligned paragraph pairs that respectively add and remove a direct style reference
+- **WHEN** comparison runs in each reconstruction mode
+- **THEN** each output SHALL contain one schema-valid `w:pPrChange`
+- **AND** accept and reject SHALL recover the corresponding revised and original direct style states
+
+### Requirement: Ignored paragraph style changes use the revised style consistently
+
+When `ignoreFormatting` is `true`, the comparison engine SHALL suppress
+paragraph-style format-change reporting and `w:pPrChange` emission. Both
+reconstruction modes SHALL retain the revised direct style reference as the
+untracked formatting baseline.
+
+#### Scenario: [SDX-CMP-PSTYLE-06] ignoreFormatting suppresses paragraph style markup
+
+- **GIVEN** aligned paragraphs whose only difference is direct `w:pStyle`
+- **WHEN** comparison runs with `ignoreFormatting: true` in either reconstruction mode
+- **THEN** no paragraph-level format change SHALL be reported
+- **AND** no `w:pPrChange` SHALL be emitted for that difference
+- **AND** both outputs SHALL retain the revised direct style
+
+### Requirement: Real-corpus comparison does not invent paragraph style changes
+
+The required SHA-256-pinned real-corpus comparison evidence SHALL verify that
+aligned paragraphs with unchanged direct `w:pStyle` references do not enter
+the paragraph-style change inventory or acquire a `w:pPrChange` attributable
+to paragraph-style detection.
+
+#### Scenario: [SDX-CMP-PSTYLE-07] Unchanged real paragraph styles produce no phantom markup
+
+- **GIVEN** the required SHA-256-verified real DOCX corpus
+- **WHEN** its comparison pairs run in both reconstruction modes
+- **THEN** every paragraph-style change inventory entry SHALL correspond to an explicit direct style-reference difference in the aligned inputs
+- **AND** an aligned paragraph with equal direct style references SHALL acquire no `w:pPrChange` attributable to paragraph-style detection

--- a/openspec/changes/add-paragraph-property-change-tracking/tasks.md
+++ b/openspec/changes/add-paragraph-property-change-tracking/tasks.md
@@ -1,40 +1,40 @@
 ## 1. Specification and evidence
 
-- [ ] 1.1 Add failing traceability scenarios for `w:pStyle` addition,
+- [x] 1.1 Add failing traceability scenarios for `w:pStyle` addition,
   removal, and replacement on aligned empty and non-empty paragraphs.
-- [ ] 1.2 Add both-mode accept/reject projection assertions and
+- [x] 1.2 Add both-mode accept/reject projection assertions and
   paragraph-level statistics/revision-extraction assertions.
-- [ ] 1.3 Add `ignoreFormatting` scenarios proving both modes retain the
+- [x] 1.3 Add `ignoreFormatting` scenarios proving both modes retain the
   revised style without `w:pPrChange`.
-- [ ] 1.4 Add a SHA-256-pinned real-corpus no-phantom measurement.
+- [x] 1.4 Add a SHA-256-pinned real-corpus no-phantom measurement.
 
 ## 2. Paragraph-style detection
 
-- [ ] 2.1 Build a deduplicated inventory of aligned paragraph pairs from the
+- [x] 2.1 Build a deduplicated inventory of aligned paragraph pairs from the
   existing atom correspondence.
-- [ ] 2.2 Compare direct `w:pStyle/@w:val` references once per aligned
+- [x] 2.2 Compare direct `w:pStyle/@w:val` references once per aligned
   paragraph and carry explicit original/revised paragraph properties.
-- [ ] 2.3 Exclude inserted, deleted, moved, and text-divergent paragraph pairs
+- [x] 2.3 Exclude inserted, deleted, moved, and text-divergent paragraph pairs
   from this property-only classification.
-- [ ] 2.4 Count each detected paragraph-style change once, independent of run
+- [x] 2.4 Count each detected paragraph-style change once, independent of run
   fragmentation.
 
 ## 3. Reconstruction and revision surfaces
 
-- [ ] 3.1 Generalize the existing paragraph-property revision helper to accept
+- [x] 3.1 Generalize the existing paragraph-property revision helper to accept
   the original `w:pPr` snapshot while keeping revised properties live.
-- [ ] 3.2 Apply the same paragraph-style change inventory in inplace and
+- [x] 3.2 Apply the same paragraph-style change inventory in inplace and
   rebuild reconstruction with schema-ordered `w:pPrChange`.
-- [ ] 3.3 Surface emitted paragraph-property revisions through existing
+- [x] 3.3 Surface emitted paragraph-property revisions through existing
   revision extraction without changing insertion or deletion counts.
-- [ ] 3.4 Make `ignoreFormatting` consistently retain revised `w:pStyle` in
+- [x] 3.4 Make `ignoreFormatting` consistently retain revised `w:pStyle` in
   both reconstruction modes without revision markup.
 
 ## 4. Conformance and validation
 
-- [ ] 4.1 Add ECMA-376 5th edition, Part 1 § 17.13.5.29 source citations and
+- [x] 4.1 Add ECMA-376 5th edition, Part 1 § 17.13.5.29 source citations and
   structured test conformance labels.
-- [ ] 4.2 Run `openspec validate add-paragraph-property-change-tracking
+- [x] 4.2 Run `openspec validate add-paragraph-property-change-tracking
   --strict`.
-- [ ] 4.3 Run the repository pre-submit suite and the required real-corpus
+- [x] 4.3 Run the repository pre-submit suite and the required real-corpus
   comparison gate.

--- a/openspec/changes/add-paragraph-property-change-tracking/tasks.md
+++ b/openspec/changes/add-paragraph-property-change-tracking/tasks.md
@@ -1,0 +1,40 @@
+## 1. Specification and evidence
+
+- [ ] 1.1 Add failing traceability scenarios for `w:pStyle` addition,
+  removal, and replacement on aligned empty and non-empty paragraphs.
+- [ ] 1.2 Add both-mode accept/reject projection assertions and
+  paragraph-level statistics/revision-extraction assertions.
+- [ ] 1.3 Add `ignoreFormatting` scenarios proving both modes retain the
+  revised style without `w:pPrChange`.
+- [ ] 1.4 Add a SHA-256-pinned real-corpus no-phantom measurement.
+
+## 2. Paragraph-style detection
+
+- [ ] 2.1 Build a deduplicated inventory of aligned paragraph pairs from the
+  existing atom correspondence.
+- [ ] 2.2 Compare direct `w:pStyle/@w:val` references once per aligned
+  paragraph and carry explicit original/revised paragraph properties.
+- [ ] 2.3 Exclude inserted, deleted, moved, and text-divergent paragraph pairs
+  from this property-only classification.
+- [ ] 2.4 Count each detected paragraph-style change once, independent of run
+  fragmentation.
+
+## 3. Reconstruction and revision surfaces
+
+- [ ] 3.1 Generalize the existing paragraph-property revision helper to accept
+  the original `w:pPr` snapshot while keeping revised properties live.
+- [ ] 3.2 Apply the same paragraph-style change inventory in inplace and
+  rebuild reconstruction with schema-ordered `w:pPrChange`.
+- [ ] 3.3 Surface emitted paragraph-property revisions through existing
+  revision extraction without changing insertion or deletion counts.
+- [ ] 3.4 Make `ignoreFormatting` consistently retain revised `w:pStyle` in
+  both reconstruction modes without revision markup.
+
+## 4. Conformance and validation
+
+- [ ] 4.1 Add ECMA-376 5th edition, Part 1 § 17.13.5.29 source citations and
+  structured test conformance labels.
+- [ ] 4.2 Run `openspec validate add-paragraph-property-change-tracking
+  --strict`.
+- [ ] 4.3 Run the repository pre-submit suite and the required real-corpus
+  comparison gate.

--- a/packages/docx-compare/src/atomizer.test.ts
+++ b/packages/docx-compare/src/atomizer.test.ts
@@ -928,11 +928,9 @@ describe('empty paragraph context hashing', () => {
    * CANONICAL projection of w:pPr. Serialization topology — bare vs absent
    * pPr, namespace declarations (OOXML CT_PPrBase permits no attributes, so
    * only xmlns:* ever appears there), child order, whitespace — and
-   * revision-tracking provenance never distinguish; substantive property
-   * children, including w:sectPr (section topology), always do, so that
-   * both reconstruction modes represent a genuine property difference
-   * instead of silently keeping one side. Representing such a delta as
-   * w:pPrChange instead of delete+insert is #679's change-detection scope.
+   * revision-tracking provenance never distinguish. Direct w:pStyle is also
+   * excluded for #679's paragraph-level change detector; other substantive
+   * property children, including w:sectPr (section topology), still do.
    *
    * @see https://github.com/UseJunior/safe-docx/issues/678
    * @see https://github.com/UseJunior/safe-docx/issues/679

--- a/packages/docx-compare/src/atomizer.ts
+++ b/packages/docx-compare/src/atomizer.ts
@@ -682,15 +682,11 @@ function isEmptyParagraph(node: WmlElement): boolean {
  * `<w:pPr/>` vs absent, inter-element whitespace, child order, and
  * revision-tracking metadata (`w:pPrChange`, `w:pPr/w:rPr/w:ins|w:del`)
  * are serialization topology or provenance. Folding those into identity
- * produced phantom paragraph delete+insert pairs. Substantive children —
- * including `w:sectPr`, which is section topology — DO distinguish: two
- * empty paragraphs with genuinely different properties must pair as
- * delete+insert so both reconstruction modes represent the difference,
- * rather than one side's properties being silently kept and the other's
- * silently dropped depending on mode. Representing a paragraph-property
- * delta as `w:pPrChange` instead of delete+insert — for empty and
- * non-empty paragraphs alike — is change *detection* and is tracked in
- * issue #679.
+ * produced phantom paragraph delete+insert pairs. Direct `w:pStyle` is also
+ * excluded so issue #679's paragraph-level detector can pair the paragraphs
+ * and emit `w:pPrChange`. Other substantive children — including `w:sectPr`,
+ * which is section topology — still distinguish and remain outside that
+ * focused style-reference slice.
  *
  * @see https://github.com/UseJunior/safe-docx/issues/678
  * @see https://github.com/UseJunior/safe-docx/issues/679

--- a/packages/docx-compare/src/baselines/atomizer/documentReconstructor.ts
+++ b/packages/docx-compare/src/baselines/atomizer/documentReconstructor.ts
@@ -7,7 +7,11 @@
 
 import { XMLSerializer } from '@xmldom/xmldom';
 import { parseXml } from '@usejunior/docx-core';
-import type { ComparisonUnitAtom, OpaquePassthroughNode } from '@usejunior/docx-core';
+import type {
+  ComparisonUnitAtom,
+  OpaquePassthroughNode,
+  ParagraphStyleChangeInfo,
+} from '@usejunior/docx-core';
 import { CorrelationStatus } from '@usejunior/docx-core';
 import { getLeafText, childElements, findChildByTagName } from '@usejunior/docx-core';
 import {
@@ -170,6 +174,8 @@ export function reconstructDocument(
 interface ParagraphGroup {
   /** Paragraph properties (w:pPr) if available */
   pPr: Element | null;
+  /** Direct style change shared by this aligned paragraph, if any. */
+  paragraphStyleChange?: ParagraphStyleChangeInfo;
   /** Atoms in this paragraph, grouped by run and status */
   runGroups: RunGroup[];
 }
@@ -277,7 +283,11 @@ function groupAtomsByParagraph(atoms: ComparisonUnitAtom[]): ParagraphGroup[] {
     const rAncestor = findAncestorByTag(atom, 'w:r');
 
     // Check if we need a new paragraph
-    const pPr = pAncestor ? findChildByTag(pAncestor, 'w:pPr') : null;
+    const pPr = atom.paragraphStyleChange
+      ? atom.paragraphStyleChange.newParagraphProperties
+      : pAncestor
+        ? findChildByTag(pAncestor, 'w:pPr')
+        : null;
 
     // Pass currentRunGroup and current atom to check if we should start a new paragraph
     // Uses paragraphIndex for comparison instead of object references
@@ -288,6 +298,7 @@ function groupAtomsByParagraph(atoms: ComparisonUnitAtom[]): ParagraphGroup[] {
       currentRunGroup = null;
       currentGroup = {
         pPr: pPr ? cloneElement(pPr) : null,
+        paragraphStyleChange: atom.paragraphStyleChange,
         runGroups: [],
       };
       groups.push(currentGroup);
@@ -706,6 +717,7 @@ function buildParagraphXml(
   hyperlinkRelResolver?: HyperlinkRelResolver
 ): string {
   const revisionCtx = createRevisionContext({ author, date: dateStr, idState: revState });
+  const livePPr = paragraphPropertiesWithStyleChange(group, revisionCtx);
   const hasOpaqueAtoms = group.runGroups.some((runGroup) =>
     runGroup.atoms.some((atom) =>
       atom.opaquePassthrough !== undefined &&
@@ -860,8 +872,8 @@ function buildParagraphXml(
   parts.push('<w:p>');
 
   // Add paragraph properties
-  if (group.pPr) {
-    parts.push(serializeToXml(group.pPr));
+  if (livePPr) {
+    parts.push(serializeToXml(livePPr));
   }
 
   // Add run groups with track changes, restoring validated opaque boundaries
@@ -893,6 +905,31 @@ function buildParagraphXml(
   parts.push('</w:p>');
 
   return parts.join('');
+}
+
+/**
+ * Keep revised paragraph properties live and append the original CT_PPrBase
+ * snapshot as the final child required by CT_PPr.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.5.29
+ * @see https://github.com/UseJunior/safe-docx/issues/679
+ */
+function paragraphPropertiesWithStyleChange(
+  group: ParagraphGroup,
+  revisionCtx: ReturnType<typeof createRevisionContext>,
+): Element | null {
+  if (!group.paragraphStyleChange?.tracked) return group.pPr;
+
+  const livePPr = group.pPr ? cloneElement(group.pPr) : createEl('w:pPr');
+  if (!findChildByTagName(livePPr, 'w:pPrChange')) {
+    livePPr.appendChild(
+      buildPPrChangeElement(
+        group.paragraphStyleChange.oldParagraphProperties,
+        revisionCtx,
+      ),
+    );
+  }
+  return livePPr;
 }
 
 /**

--- a/packages/docx-compare/src/baselines/atomizer/formattingFidelity.ts
+++ b/packages/docx-compare/src/baselines/atomizer/formattingFidelity.ts
@@ -149,9 +149,11 @@ function canonicalizeElement(el: Element): string {
  * identity. Serialization topology is erased — namespace declarations,
  * inter-element whitespace, child order, attributes on the `w:pPr` itself
  * (OOXML `CT_PPrBase` permits none, so only namespace declarations or
- * non-conforming noise ever appear there), and a bare or revision-only
+ * non-conforming noise ever appear there), direct `w:pStyle`, and a bare or revision-only
  * `w:pPr` versus an absent one — while substantive children remain
- * identity-distinguishing.
+ * identity-distinguishing. Direct style is excluded so an empty paragraph can
+ * align and the comparison layer can represent the difference as one native
+ * `w:pPrChange`.
  *
  * `w:sectPr` participates as a PRESENCE marker only. A section break's
  * existence is document topology: letting a section-break paragraph
@@ -169,13 +171,15 @@ function canonicalizeElement(el: Element): string {
  * are provenance, not content.
  *
  * @see https://github.com/UseJunior/safe-docx/issues/678
+ * @see https://github.com/UseJunior/safe-docx/issues/679
  */
 export function canonicalizeParagraphPropertiesForIdentity(
   pPr: Element | null | undefined,
 ): string {
   if (!pPr) return '<w:pPr/>';
   const children = childElements(pPr)
-    .filter((child) => !REVISION_PROPERTY_TAGS.has(child.tagName))
+    .filter((child) =>
+      !REVISION_PROPERTY_TAGS.has(child.tagName) && child.tagName !== 'w:pStyle')
     .map((child) => (child.tagName === 'w:sectPr' ? '<w:sectPr/>' : canonicalizeElement(child)))
     .filter((canonical) => canonical !== '<w:rPr/>')
     .sort();

--- a/packages/docx-compare/src/baselines/atomizer/inPlaceModifier-empty-and-cell-paragraphs.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/inPlaceModifier-empty-and-cell-paragraphs.test.ts
@@ -148,9 +148,9 @@ describe('inplace empty and table-cell paragraph placement', () => {
  * `CT_PPrBase` permits no attributes, so only xmlns:* ever appears there —
  * whitespace, child order) and revision provenance never distinguish, so
  * none of these shapes may produce phantom paragraph-mark delete+insert
- * pairs. Substantive property children still distinguish (see the
- * substantive/sectPr describe blocks below). Representing a property delta
- * as w:pPrChange instead of delete+insert is #679's change-detection scope.
+ * pairs. Direct w:pStyle is also aligned for #679's detector; other
+ * substantive property children still distinguish (see the
+ * substantive/sectPr describe blocks below).
  *
  * @see https://github.com/UseJunior/safe-docx/issues/678
  * @see https://github.com/UseJunior/safe-docx/issues/679
@@ -302,12 +302,13 @@ describe('deleted body paragraph after equal table-cell empties', () => {
 });
 
 /**
- * Substantive w:pPr children distinguish empty-paragraph identity: pairing
+ * Substantive w:pPr children other than direct w:pStyle distinguish
+ * empty-paragraph identity: pairing
  * two empty paragraphs whose properties genuinely differ would let
  * reconstruction mode decide which side's properties survive, silently.
  * As delete+insert markup, the difference is representable: accept yields
  * the revised properties, reject restores the original's, identically in
- * both modes. Representing the delta as w:pPrChange instead is #679.
+ * both modes. Direct style deltas instead use #679's w:pPrChange path.
  *
  * @see https://github.com/UseJunior/safe-docx/issues/678
  * @see https://github.com/UseJunior/safe-docx/issues/679

--- a/packages/docx-compare/src/baselines/atomizer/inPlaceModifier-wrappers.ts
+++ b/packages/docx-compare/src/baselines/atomizer/inPlaceModifier-wrappers.ts
@@ -603,12 +603,18 @@ export function addFormatChange(
  * @param author - Author name
  * @param dateStr - Formatted date
  * @param state - Revision ID state
+ * @param originalParagraphProperties - Explicit before-state snapshot. When
+ * omitted, the live properties are snapshotted for inserted-paragraph callers.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.5.29
+ * @see https://github.com/UseJunior/safe-docx/issues/679
  */
 export function addParagraphPropertyChange(
   paragraph: Element,
   author: string,
   dateStr: string,
-  state: RevisionIdState
+  state: RevisionIdState,
+  originalParagraphProperties?: Element | null,
 ): void {
   let pPr = findChildByTagName(paragraph, 'w:pPr');
   if (!pPr) {
@@ -625,12 +631,17 @@ export function addParagraphPropertyChange(
     'w:date': dateStr,
   });
 
-  // Clone current pPr content as "before" snapshot.
+  // Clone the explicit original pPr when provided; legacy callers that mark
+  // inserted paragraphs snapshot the live pPr.
   // pPrChange child pPr must be CT_PPrBase — exclude rPr, rPrChange, sectPr, pPrChange.
   const EXCLUDED = new Set(['w:rPr', 'w:rPrChange', 'w:pPrChange', 'w:sectPr']);
   const oldPPr = createEl('w:pPr');
-  for (const child of childElements(pPr)) {
-    if (!EXCLUDED.has(child.tagName)) oldPPr.appendChild(child.cloneNode(true) as Element);
+  const snapshotSource =
+    originalParagraphProperties === undefined ? pPr : originalParagraphProperties;
+  if (snapshotSource) {
+    for (const child of childElements(snapshotSource)) {
+      if (!EXCLUDED.has(child.tagName)) oldPPr.appendChild(child.cloneNode(true) as Element);
+    }
   }
   pPrChange.appendChild(oldPPr);
   pPr.appendChild(pPrChange); // pPrChange goes last in pPr per schema

--- a/packages/docx-compare/src/baselines/atomizer/inPlaceModifier.ts
+++ b/packages/docx-compare/src/baselines/atomizer/inPlaceModifier.ts
@@ -46,6 +46,7 @@ import {
 } from './inPlaceModifier-bookmarks.js';
 import {
   addFormatChange,
+  addParagraphPropertyChange,
   getAtomRunAtBoundary,
   getAtomRuns,
   getOriginalInsProvenance,
@@ -112,6 +113,8 @@ export function modifyRevisedDocument(
     state,
     revisedRoot
   );
+
+  applyParagraphStyleChanges(mergedAtoms, ctx);
 
   // Add paragraph-mark revision markers for whole-paragraph insert/delete cases.
   // This is required for idempotency in Word:
@@ -1051,6 +1054,40 @@ function applyWholeParagraphRevisionMarkers(
         wrapParagraphAsDeleted(para, ctx.author, ctx.dateStr, ctx.state);
       }
     }
+  }
+}
+
+/**
+ * Emit one paragraph-property revision for each aligned direct style change.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.5.29
+ * @see https://github.com/UseJunior/safe-docx/issues/679
+ */
+function applyParagraphStyleChanges(
+  mergedAtoms: ComparisonUnitAtom[],
+  ctx: ProcessingContext,
+): void {
+  const handledParagraphs = new Set<number>();
+  for (const atom of mergedAtoms) {
+    const paragraphIndex = atom.paragraphIndex;
+    const change = atom.paragraphStyleChange;
+    if (
+      paragraphIndex === undefined ||
+      !change?.tracked ||
+      handledParagraphs.has(paragraphIndex)
+    ) {
+      continue;
+    }
+    const paragraph = ctx.unifiedParaToElement.get(paragraphIndex);
+    if (!paragraph) continue;
+    addParagraphPropertyChange(
+      paragraph,
+      ctx.author,
+      ctx.dateStr,
+      ctx.state,
+      change.oldParagraphProperties,
+    );
+    handledParagraphs.add(paragraphIndex);
   }
 }
 

--- a/packages/docx-compare/src/baselines/atomizer/pipeline.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline.ts
@@ -59,6 +59,7 @@ import {
 import { OOXML } from '@usejunior/docx-core';
 import { collectPreservedMoveNames, detectMovesInAtomList } from '../../move-detection.js';
 import { detectFormatChangesInAtomList } from '../../format-detection.js';
+import { detectParagraphStyleChanges } from '../../paragraph-style-detection.js';
 import {
   parseDocumentXml,
   findBody,
@@ -772,6 +773,13 @@ export async function compareDocumentsAtomizer(
     }
 
     // Step 9: Run format detection
+    // Paragraph styles are inventoried even when formatting is ignored so the
+    // rebuild path can retain the revised live style for equal empty paragraphs.
+    detectParagraphStyleChanges(
+      originalAtoms,
+      revisedAtoms,
+      formatSettings.detectFormatChanges,
+    );
     if (formatSettings.detectFormatChanges) {
       // Format detection operates on the revised atoms that are Equal
       detectFormatChangesInAtomList(revisedAtoms, formatSettings);
@@ -1889,10 +1897,14 @@ export function computeAtomizerStats(mergedAtoms: ComparisonUnitAtom[]): Compare
   let previousRangeStatus: CorrelationStatus.Inserted | CorrelationStatus.Deleted | CorrelationStatus.FormatChanged | null = null;
   let previousRangeParagraph: string | undefined;
   const paragraphs = new Map<string, ParagraphChangeFlags>();
+  const paragraphStyleChanges = new Set<string>();
 
   for (const atom of mergedAtoms) {
     const paragraphKey = paragraphStatsKey(atom);
     const status = atom.correlationStatus;
+    if (paragraphKey && atom.paragraphStyleChange?.tracked) {
+      paragraphStyleChanges.add(paragraphKey);
+    }
     const rangeStatus =
       status === CorrelationStatus.Inserted ||
       status === CorrelationStatus.Deleted ||
@@ -1934,7 +1946,7 @@ export function computeAtomizerStats(mergedAtoms: ComparisonUnitAtom[]): Compare
     insertedAtoms: reconstructionStats.insertions,
     deletedAtoms: reconstructionStats.deletions,
     modifiedParagraphs,
-    formatChanges,
-    formatChangeAtoms: reconstructionStats.formatChanges,
+    formatChanges: formatChanges + paragraphStyleChanges.size,
+    formatChangeAtoms: reconstructionStats.formatChanges + paragraphStyleChanges.size,
   };
 }

--- a/packages/docx-compare/src/baselines/atomizer/trackChangesAcceptorAst.ts
+++ b/packages/docx-compare/src/baselines/atomizer/trackChangesAcceptorAst.ts
@@ -629,7 +629,12 @@ export function rejectAllChanges(documentXml: string): string {
     renameElement(delInstrText, 'w:instrText');
   }
 
-  // Remove format change tracking
+  // Restore original direct paragraph properties before removing format
+  // tracking. The pPrChange child is a CT_PPrBase snapshot; paragraph-mark
+  // properties and section topology sit outside that base and remain live.
+  restoreParagraphPropertiesFromChanges(root);
+
+  // Remove remaining format change tracking
   removeAllByTagName(root, 'w:rPrChange');
   removeAllByTagName(root, 'w:pPrChange');
 
@@ -640,6 +645,40 @@ export function rejectAllChanges(documentXml: string): string {
   removeEmptyHyperlinks(root);
 
   return serializeToXml(root);
+}
+
+/**
+ * Restore the original paragraph-property snapshot carried by `w:pPrChange`.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.5.29
+ * @see https://github.com/UseJunior/safe-docx/issues/679
+ */
+function restoreParagraphPropertiesFromChanges(root: Element): void {
+  const changes = findAllByTagName(root, 'w:pPrChange');
+  for (const change of changes) {
+    const livePPr = change.parentNode as Element | null;
+    const paragraph = livePPr?.parentNode;
+    if (
+      !livePPr ||
+      livePPr.tagName !== 'w:pPr' ||
+      !paragraph ||
+      (paragraph as Element).tagName !== 'w:p'
+    ) {
+      continue;
+    }
+
+    const snapshot = childElements(change).find((child) => child.tagName === 'w:pPr');
+    if (!snapshot) continue;
+    const restored = snapshot.cloneNode(true) as Element;
+
+    // CT_PPrBase intentionally excludes these live, non-base children.
+    for (const child of childElements(livePPr)) {
+      if (child.tagName === 'w:rPr' || child.tagName === 'w:sectPr') {
+        restored.appendChild(child.cloneNode(true));
+      }
+    }
+    paragraph.replaceChild(restored, livePPr);
+  }
 }
 
 /**

--- a/packages/docx-compare/src/index.ts
+++ b/packages/docx-compare/src/index.ts
@@ -132,6 +132,7 @@ export async function compareDocuments(
 export * from './atomizer.js';
 export * from './move-detection.js';
 export * from './format-detection.js';
+export * from './paragraph-style-detection.js';
 export * from './baselines/atomizer/formattingFidelity.js';
 export {
   acceptAllChanges,

--- a/packages/docx-compare/src/integration/paragraph-style-comparison.test.ts
+++ b/packages/docx-compare/src/integration/paragraph-style-comparison.test.ts
@@ -19,11 +19,12 @@ import { parseDocumentXml } from '../baselines/atomizer/xmlToWmlElement.js';
 const AUTHOR = 'Paragraph Style Comparison';
 const DATE = new Date('2026-07-28T16:00:00Z');
 const MODES = ['inplace', 'rebuild'] as const;
+const TEST_FEATURE = 'docx-comparison';
 
 const test = testAllure
   .epic('Document Comparison')
   .withLabels({
-    feature: 'Paragraph Style Change Tracking',
+    feature: TEST_FEATURE,
     story: 'Direct w:pStyle Comparison',
     severity: 'critical',
   })

--- a/packages/docx-compare/src/integration/paragraph-style-comparison.test.ts
+++ b/packages/docx-compare/src/integration/paragraph-style-comparison.test.ts
@@ -1,0 +1,320 @@
+import {
+  DocxArchive,
+  childElements,
+  extractRevisions,
+  findChildByTagName,
+  insertParagraphBookmarks,
+  parseXml,
+} from '@usejunior/docx-core';
+import { describe, expect } from 'vitest';
+import { compareDocuments } from '../index.js';
+import { buildDocxFromBodyXml } from '../testing/ooxml-fixtures.js';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import {
+  acceptAllChanges,
+  rejectAllChanges,
+} from '../baselines/atomizer/trackChangesAcceptorAst.js';
+import { parseDocumentXml } from '../baselines/atomizer/xmlToWmlElement.js';
+
+const AUTHOR = 'Paragraph Style Comparison';
+const DATE = new Date('2026-07-28T16:00:00Z');
+const MODES = ['inplace', 'rebuild'] as const;
+
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({
+    feature: 'Paragraph Style Change Tracking',
+    story: 'Direct w:pStyle Comparison',
+    severity: 'critical',
+  })
+  .conformance({
+    spec: 'ECMA-376',
+    edition: 5,
+    part: 1,
+    section: '17.13.5.29',
+  });
+
+function styledParagraph(style: string | null, runXml: string): string {
+  const pPr = style === null ? '' : `<w:pPr><w:pStyle w:val="${style}"/></w:pPr>`;
+  return `<w:p>${pPr}${runXml}</w:p>`;
+}
+
+function textRun(text: string): string {
+  return `<w:r><w:t>${text}</w:t></w:r>`;
+}
+
+async function documentXml(docx: Buffer): Promise<string> {
+  return (await DocxArchive.load(docx)).getDocumentXml();
+}
+
+async function compareBodies(
+  originalBody: string,
+  revisedBody: string,
+  mode: (typeof MODES)[number],
+  ignoreFormatting = false,
+) {
+  const original = await buildDocxFromBodyXml(originalBody);
+  const revised = await buildDocxFromBodyXml(revisedBody);
+  const result = await compareDocuments(original, revised, {
+    engine: 'atomizer',
+    reconstructionMode: mode,
+    ignoreFormatting,
+    author: AUTHOR,
+    date: DATE,
+  });
+  expect(result.reconstructionModeUsed).toBe(mode);
+  return {
+    result,
+    xml: await documentXml(result.document),
+  };
+}
+
+function firstParagraph(xml: string): Element {
+  const paragraph = parseDocumentXml(xml).getElementsByTagName('w:p').item(0);
+  if (!paragraph) throw new Error('document has no paragraph');
+  return paragraph;
+}
+
+function directStyle(pPr: Element | null): string | null {
+  const style = pPr
+    ? childElements(pPr).find((child) => child.tagName === 'w:pStyle')
+    : undefined;
+  return style?.getAttribute('w:val') ?? null;
+}
+
+function liveStyle(xml: string): string | null {
+  return directStyle(findChildByTagName(firstParagraph(xml), 'w:pPr'));
+}
+
+function paragraphPropertyChanges(xml: string): Element[] {
+  return Array.from(parseDocumentXml(xml).getElementsByTagName('w:pPrChange'));
+}
+
+function snapshotStyle(change: Element): string | null {
+  return directStyle(findChildByTagName(change, 'w:pPr'));
+}
+
+describe('direct paragraph style comparison', () => {
+  test.openspec('[SDX-CMP-PSTYLE-01] Non-empty paragraph style replacement is detected once')(
+    'tracks one paragraph change for fragmented non-empty text',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      const original = await given('a Heading1 paragraph split across two runs', () =>
+        styledParagraph('Heading1', textRun('Same ') + textRun('text')),
+      );
+      const revised = await given('the same text with Normal style and different run splits', () =>
+        styledParagraph('Normal', textRun('Same text')),
+      );
+
+      for (const mode of MODES) {
+        const compared = await when(`${mode} comparison runs`, () =>
+          compareBodies(original, revised, mode),
+        );
+        await then('one paragraph-level format change is reported', () => {
+          expect(compared.result.stats.formatChanges).toBe(1);
+          expect(compared.result.stats.formatChangeAtoms).toBe(1);
+        });
+        await and('no text insertion or deletion is reported', () => {
+          expect(compared.result.stats.insertions).toBe(0);
+          expect(compared.result.stats.deletions).toBe(0);
+        });
+      }
+    },
+  );
+
+  test.openspec('[SDX-CMP-PSTYLE-02] Empty paragraph style replacement uses the same classification')(
+    'tracks an empty paragraph style change without delete-insert markup',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      const original = await given('an empty Heading1 paragraph', () =>
+        styledParagraph('Heading1', ''),
+      );
+      const revised = await given('the same empty paragraph with Normal style', () =>
+        styledParagraph('Normal', ''),
+      );
+
+      for (const mode of MODES) {
+        const compared = await when(`${mode} comparison runs`, () =>
+          compareBodies(original, revised, mode),
+        );
+        await then('the empty paragraph contributes one format change', () => {
+          expect(compared.result.stats.formatChanges).toBe(1);
+        });
+        await and('paragraph insertion and deletion remain zero', () => {
+          expect(compared.result.stats.insertions).toBe(0);
+          expect(compared.result.stats.deletions).toBe(0);
+          expect(compared.xml).not.toMatch(/<w:rPr><w:(?:ins|del)\b/);
+        });
+      }
+    },
+  );
+
+  test.openspec('[SDX-CMP-PSTYLE-03] Run fragmentation does not multiply paragraph changes')(
+    'deduplicates a direct style change across many text atoms',
+    async ({ given, when, then }: AllureBddContext) => {
+      const original = await given('a paragraph with five independently formatted runs', () =>
+        styledParagraph(
+          'Heading1',
+          ['One', ' ', 'two', ' ', 'three'].map(textRun).join(''),
+        ),
+      );
+      const revised = await given('the same run sequence under a new style', () =>
+        styledParagraph(
+          'Normal',
+          ['One', ' ', 'two', ' ', 'three'].map(textRun).join(''),
+        ),
+      );
+
+      const compared = await when('comparison runs', () =>
+        compareBodies(original, revised, 'rebuild'),
+      );
+      await then('one style revision is emitted and counted', () => {
+        expect(compared.result.stats.formatChanges).toBe(1);
+        expect(paragraphPropertyChanges(compared.xml)).toHaveLength(1);
+      });
+    },
+  );
+
+  test.openspec('[SDX-CMP-PSTYLE-04] Style replacement emits a reversible pPrChange')(
+    'emits revised live style and an extractable original snapshot in both modes',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      const original = await given('a Heading1 paragraph', () =>
+        styledParagraph('Heading1', textRun('Reversible')),
+      );
+      const revised = await given('the same paragraph with Normal style', () =>
+        styledParagraph('Normal', textRun('Reversible')),
+      );
+
+      for (const mode of MODES) {
+        const compared = await when(`${mode} comparison runs`, () =>
+          compareBodies(original, revised, mode),
+        );
+        const changes = paragraphPropertyChanges(compared.xml);
+        await then('the live and snapshotted styles use the correct sides', () => {
+          expect(liveStyle(compared.xml)).toBe('Normal');
+          expect(changes).toHaveLength(1);
+          expect(snapshotStyle(changes[0]!)).toBe('Heading1');
+          expect(changes[0]!.getAttribute('w:author')).toBe(AUTHOR);
+          expect(changes[0]!.getAttribute('w:date')).toBe('2026-07-28T16:00:00Z');
+          expect(changes[0]!.getAttribute('w:id')).not.toBe('');
+        });
+        await and('accept and reject recover revised and original styles', () => {
+          expect(liveStyle(acceptAllChanges(compared.xml))).toBe('Normal');
+          expect(liveStyle(rejectAllChanges(compared.xml))).toBe('Heading1');
+        });
+        await and('revision extraction reports the paragraph property change', () => {
+          const doc = parseXml(compared.xml);
+          insertParagraphBookmarks(doc, 'paragraph-style-test');
+          const extracted = extractRevisions(doc, []);
+          expect(extracted.total_changes).toBe(1);
+          expect(extracted.changes[0]!.revisions).toEqual([
+            expect.objectContaining({
+              type: 'FORMAT_CHANGE',
+              author: AUTHOR,
+            }),
+          ]);
+        });
+      }
+    },
+  );
+
+  test.openspec('[SDX-CMP-PSTYLE-05] Style addition and removal remain reversible')(
+    'tracks direct style addition and removal in both modes',
+    async ({ given, when, then }: AllureBddContext) => {
+      const cases = await given('paragraph pairs that add and remove a direct style', () => [
+        { original: null, revised: 'Normal' },
+        { original: 'Heading1', revised: null },
+      ] as const);
+
+      for (const pair of cases) {
+        for (const mode of MODES) {
+          const compared = await when(`${mode} compares ${pair.original} to ${pair.revised}`, () =>
+            compareBodies(
+              styledParagraph(pair.original, textRun('Same')),
+              styledParagraph(pair.revised, textRun('Same')),
+              mode,
+            ),
+          );
+          await then('accept and reject recover the corresponding style states', () => {
+            expect(liveStyle(acceptAllChanges(compared.xml))).toBe(pair.revised);
+            expect(liveStyle(rejectAllChanges(compared.xml))).toBe(pair.original);
+            expect(paragraphPropertyChanges(compared.xml)).toHaveLength(1);
+          });
+        }
+      }
+    },
+  );
+
+  test.openspec('[SDX-CMP-PSTYLE-06] ignoreFormatting suppresses paragraph style markup')(
+    'keeps the revised style untracked in both modes',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      const original = await given('an empty Heading1 paragraph', () =>
+        styledParagraph('Heading1', ''),
+      );
+      const revised = await given('the same paragraph with Normal style', () =>
+        styledParagraph('Normal', ''),
+      );
+
+      for (const mode of MODES) {
+        const compared = await when(`${mode} ignores formatting`, () =>
+          compareBodies(original, revised, mode, true),
+        );
+        await then('no format change or paragraph property markup is emitted', () => {
+          expect(compared.result.stats.formatChanges).toBe(0);
+          expect(paragraphPropertyChanges(compared.xml)).toHaveLength(0);
+        });
+        await and('both projections retain the revised style', () => {
+          expect(liveStyle(acceptAllChanges(compared.xml))).toBe('Normal');
+          expect(liveStyle(rejectAllChanges(compared.xml))).toBe('Normal');
+        });
+      }
+    },
+  );
+
+  test(
+    'pairs consecutive empty paragraphs positionally and tracks only the changed style',
+    async ({ given, when, then }: AllureBddContext) => {
+      const anchor = styledParagraph(null, textRun('Anchor'));
+      const tail = styledParagraph(null, textRun('Tail'));
+      const original = await given('two consecutive styled empty paragraphs', () =>
+        anchor +
+        styledParagraph('Heading1', '') +
+        styledParagraph('Normal', '') +
+        tail,
+      );
+      const revised = await given('only the first empty paragraph changes style', () =>
+        anchor +
+        styledParagraph('Normal', '') +
+        styledParagraph('Normal', '') +
+        tail,
+      );
+
+      const compared = await when('comparison runs', () =>
+        compareBodies(original, revised, 'rebuild'),
+      );
+      await then('exactly one paragraph style revision is emitted', () => {
+        expect(compared.result.stats.formatChanges).toBe(1);
+        expect(paragraphPropertyChanges(compared.xml)).toHaveLength(1);
+      });
+    },
+  );
+
+  test(
+    'does not classify a text-divergent paragraph as style-only',
+    async ({ given, when, then }: AllureBddContext) => {
+      const original = await given('a Heading1 paragraph with original text', () =>
+        styledParagraph('Heading1', textRun('Original text')),
+      );
+      const revised = await given('a Normal paragraph with different text', () =>
+        styledParagraph('Normal', textRun('Revised text')),
+      );
+
+      const compared = await when('comparison runs', () =>
+        compareBodies(original, revised, 'rebuild'),
+      );
+      await then('the paragraph is a text replacement, not a style-only change', () => {
+        expect(compared.result.stats.formatChanges).toBe(0);
+        expect(compared.result.stats.insertions).toBe(1);
+        expect(compared.result.stats.deletions).toBe(1);
+      });
+    },
+  );
+});

--- a/packages/docx-compare/src/integration/real-corpus-paragraph-deletion.test.ts
+++ b/packages/docx-compare/src/integration/real-corpus-paragraph-deletion.test.ts
@@ -41,6 +41,7 @@ const REQUIRED_ENV = 'SAFE_DOCX_REAL_CORPUS_REQUIRED';
 const INTEGRATION_DIR = dirname(fileURLToPath(import.meta.url));
 const MANIFEST_PATH = join(INTEGRATION_DIR, 'real-corpus-manifest.json');
 const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const TEST_FEATURE = 'docx-comparison';
 
 interface CorpusEntry {
   id: string;
@@ -123,7 +124,7 @@ const preferredDeletionTarget: Readonly<Partial<Record<string, string>>> = {
 const test = testAllure
   .epic('Document Comparison')
   .withLabels({
-    feature: 'Real-Corpus Paragraph Deletion Gate',
+    feature: TEST_FEATURE,
     story: 'Word-Authored Agreement Paragraph Deletion',
     severity: 'critical',
   })

--- a/packages/docx-compare/src/integration/real-corpus-paragraph-deletion.test.ts
+++ b/packages/docx-compare/src/integration/real-corpus-paragraph-deletion.test.ts
@@ -132,6 +132,12 @@ const test = testAllure
     { spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.6.1' },
     { spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.6.2' },
   );
+const paragraphStyleTest = test.conformance({
+  spec: 'ECMA-376',
+  edition: 5,
+  part: 1,
+  section: '17.13.5.29',
+});
 
 function sha256(buffer: Buffer): string {
   return createHash('sha256').update(buffer).digest('hex');
@@ -444,6 +450,51 @@ describe.skipIf(!corpusAvailability.available)('real-corpus paragraph deletion m
             await runCell(entry, reconstructionMode),
             expectedFailure,
           );
+        },
+        120_000,
+      );
+    }
+  }
+});
+
+describe.skipIf(!corpusAvailability.available)('real-corpus paragraph style no-phantom matrix', () => {
+  for (const entry of corpusAvailability.entries) {
+    // The investors-rights rebuild cell is blocked before style detection by
+    // the exact unsupported-REF characterization pinned to #646 above. Inplace
+    // still exercises that SHA-pinned document, while every currently
+    // rebuild-supported corpus member exercises both reconstruction modes.
+    const reconstructionModes: readonly ReconstructionMode[] =
+      entry.id === 'nvca-investors-rights-agreement'
+        ? ['inplace']
+        : ['inplace', 'rebuild'];
+    for (const reconstructionMode of reconstructionModes) {
+      paragraphStyleTest.openspec('[SDX-CMP-PSTYLE-07] Unchanged real paragraph styles produce no phantom markup')(
+        `${entry.id} × ${reconstructionMode} × unchanged paragraph styles`,
+        async () => {
+          const source = readFileSync(join(corpusRoot, entry.id, 'source.docx'));
+          const author = 'Real Corpus Paragraph Style Gate';
+          const result = await compareDocumentsAtomizer(source, source, {
+            author,
+            date: new Date('2026-07-28T00:00:00Z'),
+            reconstructionMode,
+          });
+          expect(result.reconstructionModeUsed).toBe(reconstructionMode);
+          expect(result.stats.formatChanges).toBe(0);
+
+          const comparedZip = await JSZip.loadAsync(result.document);
+          const comparedDocumentXml = await comparedZip
+            .file('word/document.xml')!
+            .async('string');
+          const comparedDocument = new DOMParser().parseFromString(
+            comparedDocumentXml,
+            'text/xml',
+          );
+          const authoredPPrChanges = elements(comparedDocument, 'w:pPrChange')
+            .filter((change) =>
+              (change.getAttribute('w:author') ??
+                change.getAttributeNS(W_NS, 'author')) === author,
+            );
+          expect(authoredPPrChanges).toHaveLength(0);
         },
         120_000,
       );

--- a/packages/docx-compare/src/paragraph-style-detection.ts
+++ b/packages/docx-compare/src/paragraph-style-detection.ts
@@ -1,0 +1,111 @@
+import type {
+  ComparisonUnitAtom,
+  ParagraphStyleChangeInfo,
+} from '@usejunior/docx-core';
+import {
+  CorrelationStatus,
+  childElements,
+  findChildByTagName,
+} from '@usejunior/docx-core';
+
+const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+function paragraphOf(atom: ComparisonUnitAtom): Element | null {
+  if (atom.sourceParagraphElement) return atom.sourceParagraphElement;
+  for (let index = atom.ancestorElements.length - 1; index >= 0; index--) {
+    const ancestor = atom.ancestorElements[index]!;
+    if (ancestor.tagName === 'w:p') return ancestor;
+  }
+  return null;
+}
+
+function paragraphAtoms(
+  atoms: readonly ComparisonUnitAtom[],
+): Map<Element, ComparisonUnitAtom[]> {
+  const result = new Map<Element, ComparisonUnitAtom[]>();
+  for (const atom of atoms) {
+    const paragraph = paragraphOf(atom);
+    if (!paragraph) continue;
+    const group = result.get(paragraph) ?? [];
+    group.push(atom);
+    result.set(paragraph, group);
+  }
+  return result;
+}
+
+function directStyleValue(pPr: Element | null): string | null {
+  if (!pPr) return null;
+  const style = childElements(pPr).find(
+    (child) => child.namespaceURI === W_NS && child.localName === 'pStyle',
+  );
+  if (!style) return null;
+  return style.getAttributeNS(W_NS, 'val') ?? style.getAttribute('w:val');
+}
+
+/**
+ * Detect direct `w:pStyle` changes once per fully aligned paragraph.
+ *
+ * Detection deliberately leaves atom correlation statuses unchanged. A
+ * paragraph property revision is one revision even when its text spans many
+ * atoms, and empty paragraphs use the same inventory as non-empty paragraphs.
+ */
+export function detectParagraphStyleChanges(
+  originalAtoms: readonly ComparisonUnitAtom[],
+  revisedAtoms: readonly ComparisonUnitAtom[],
+  tracked: boolean,
+): ParagraphStyleChangeInfo[] {
+  const originalByParagraph = paragraphAtoms(originalAtoms);
+  const revisedByParagraph = paragraphAtoms(revisedAtoms);
+  const changes: ParagraphStyleChangeInfo[] = [];
+
+  for (const revisedGroup of revisedByParagraph.values()) {
+    if (
+      revisedGroup.length === 0 ||
+      revisedGroup.some(
+        (atom) =>
+          atom.correlationStatus !== CorrelationStatus.Equal ||
+          !atom.comparisonUnitAtomBefore,
+      )
+    ) {
+      continue;
+    }
+
+    const originalParagraphs = new Set(
+      revisedGroup.map((atom) => paragraphOf(atom.comparisonUnitAtomBefore!)),
+    );
+    if (originalParagraphs.size !== 1) continue;
+    const originalParagraph = [...originalParagraphs][0];
+    if (!originalParagraph) continue;
+
+    const originalGroup = originalByParagraph.get(originalParagraph);
+    if (
+      !originalGroup ||
+      originalGroup.length !== revisedGroup.length ||
+      originalGroup.some((atom) => atom.correlationStatus !== CorrelationStatus.Equal)
+    ) {
+      continue;
+    }
+
+    const matchedOriginalAtoms = new Set(
+      revisedGroup.map((atom) => atom.comparisonUnitAtomBefore!),
+    );
+    if (matchedOriginalAtoms.size !== originalGroup.length) continue;
+
+    const revisedParagraph = paragraphOf(revisedGroup[0]!);
+    if (!revisedParagraph) continue;
+    const oldPPr = findChildByTagName(originalParagraph, 'w:pPr');
+    const newPPr = findChildByTagName(revisedParagraph, 'w:pPr');
+    if (directStyleValue(oldPPr) === directStyleValue(newPPr)) continue;
+
+    const change: ParagraphStyleChangeInfo = {
+      oldParagraphProperties: oldPPr,
+      newParagraphProperties: newPPr,
+      tracked,
+    };
+    for (const atom of originalGroup) atom.paragraphStyleChange = change;
+    for (const atom of revisedGroup) atom.paragraphStyleChange = change;
+    changes.push(change);
+  }
+
+  return changes;
+}

--- a/packages/docx-core/src/core-types.ts
+++ b/packages/docx-core/src/core-types.ts
@@ -105,6 +105,22 @@ export interface FormatChangeInfo {
 }
 
 /**
+ * Paragraph-scoped direct-style change detected after content alignment.
+ *
+ * The payload is attached to every atom in the aligned paragraph so either
+ * reconstruction path can recover it without making run fragmentation part
+ * of the revision identity.
+ */
+export interface ParagraphStyleChangeInfo {
+  /** Original paragraph properties captured before the direct style change. */
+  oldParagraphProperties: WmlElement | null;
+  /** Revised paragraph properties that remain live in comparison output. */
+  newParagraphProperties: WmlElement | null;
+  /** Whether comparison should emit/report the change instead of ignoring it. */
+  tracked: boolean;
+}
+
+/**
  * Process-local payload for a comparison atom owned by an opaque XML boundary.
  *
  * The comparison model is already DOM-backed; this descriptor intentionally
@@ -188,6 +204,8 @@ export interface ComparisonUnitAtom extends ComparisonUnit {
   // Format change properties
   /** Format change details when text is equal but formatting differs */
   formatChange?: FormatChangeInfo;
+  /** Direct w:pStyle change shared by the atom's aligned paragraph. */
+  paragraphStyleChange?: ParagraphStyleChangeInfo;
   /** Reference to the corresponding atom in the other document (for Equal atoms) */
   comparisonUnitAtomBefore?: ComparisonUnitAtom;
 


### PR DESCRIPTION
## Summary

- detect direct `w:pStyle` addition, removal, and replacement once per fully aligned paragraph
- emit reversible native `w:pPrChange` markup in inplace and rebuild modes with revised properties live and original `CT_PPrBase` snapshotted
- make `ignoreFormatting` consistently keep the revised style without revision markup
- restore paragraph-property snapshots during reject projection and expose the change through existing statistics/revision extraction
- add synthetic traceability scenarios and a SHA-256-pinned real-corpus no-phantom matrix

## Root cause

Run formatting was compared at atom level, but paragraph style lived outside that model. Empty-paragraph identity also treated substantive paragraph properties as identity, so mode selection could silently determine which style survived instead of producing a revision.

## Validation

- `openspec validate add-paragraph-property-change-tracking --strict`
- `npm run build`
- `npm run lint:workspaces` (9 existing warnings, 0 errors)
- full workspace test suite
- docx-core: 1,267 passed, 2 expected failures, 14 skipped
- docx-compare with required real corpus: 760 passed, 71 skipped
- `npm run check:spec-coverage`
- `npm run check:conformance-citations`
- `npm run check:conformance-doc`

## Real-corpus note

All seven SHA-256-pinned NVCA documents run through the no-phantom detector gate. Every currently supported rebuild cell also runs in rebuild mode; the investors-rights rebuild cell remains blocked before detection by the existing exact #646 unsupported-REF characterization and is covered through inplace.

Fixes: #679