### PR TITLE
docs(comparison): correct run-split control evidence

### DIFF
--- a/docs/comparison-failure-diagnosis.md
+++ b/docs/comparison-failure-diagnosis.md
@@ -74,14 +74,18 @@ reported `reconstructionModeUsed: 'inplace'`, and `rebuild` reported
 `reconstructionModeUsed: 'rebuild'`.
 
 Later review established the limit of that result: the chosen run followed the
-end of an unsupported `SEQ` field, so no opaque descriptor governed the split.
-Success proved only that this mutation did not reach the opaque-boundary guard;
-it did not prove the guard's discriminators stayed stable. Deliberately moving
-the same split into a supported `REF` field result does make `rebuild` throw the
-expected `OpaquePassthroughError` while `inplace` succeeds. That targeted probe
-validates the guard path, but it is not a control for the original real-world
-abort: its failure was manufactured by placing the split inside a construct
-known to be guarded.
+end of a `SEQ` field and therefore sat outside the field range. Rebuild still
+correlated all 108 captured `REF` boundaries, but success proved only that the
+mutation perturbed none of them. Because the split landed outside every opaque
+descriptor, their stability says nothing about the guard's sensitivity to a
+run split. The authoritative comparison is in
+`packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts`.
+
+An equivalent pure run split deliberately placed inside a supported `REF` field
+result does make `rebuild` throw the expected `OpaquePassthroughError` while
+`inplace` succeeds. That targeted probe validates the guard path, but it is not
+a control for the original real-world abort: its failure was manufactured by
+placing the split inside a construct known to be guarded.
 
 No fixture was therefore committed. Until an independently occurring known-bad
 pair can be staged and pinned through `compareDocuments`, a diagnostic run can

--- a/docs/comparison-failure-diagnosis.md
+++ b/docs/comparison-failure-diagnosis.md
@@ -63,28 +63,32 @@ Running only the suspect input establishes what happened to that input. It does 
 
 A comparison run needs its own control — a known-bad document put through the same harness. When a control has to be reconstructed rather than staged, treat the reconstruction as a hypothesis. If it does not reproduce the expected failure, record that as a negative result and stop. A control iterated until something finally breaks is not a control.
 
-**No document-level control is currently available for the run-split abort.** A
-2026-07-27 reconstruction attempt for
+**No independently occurring document-level control is currently available for
+the run-split abort.** A 2026-07-27 reconstruction attempt for
 [#693](https://github.com/UseJunior/safe-docx/issues/693) scrubbed the public
 NVCA indemnification agreement in place, preserving its package structure and
-109 `w:instrText` field instructions. In a field-bearing paragraph, the revised
-side changed one character of a 17-character scrubbed text run and split that
-run in two. The committed public `compareDocuments` entry point succeeded in
-both requested modes: `inplace` reported `reconstructionModeUsed: 'inplace'`,
-and `rebuild` reported `reconstructionModeUsed: 'rebuild'`.
+109 `w:instrText` field instructions. The revised side changed one character of
+a 17-character scrubbed text run and split that run in two. The public
+`compareDocuments` entry point succeeded in both requested modes: `inplace`
+reported `reconstructionModeUsed: 'inplace'`, and `rebuild` reported
+`reconstructionModeUsed: 'rebuild'`.
 
-That result means the real-document run split moved none of the discriminators
-the opaque-boundary guard compares. In summary those cover boundary placement
-and paragraph ownership, container identity, positional ordinals, element
-identity, owned-paragraph count, semantic fingerprint, and
-relationship-closure fingerprint — the guard's own comparison in
-`packages/docx-compare/src/baselines/atomizer/opaquePassthrough.ts` is the
-authoritative list. No fixture was committed:
-tuning the reconstruction until one of those discriminators moved would create
-a deliberately manufactured failure, not a control for the original abort.
-Until an independently occurring known-bad pair can be staged and pinned
-through `compareDocuments`, a diagnostic run can prove the detector self-tests
-ran, but it cannot prove that its comparison harness can surface this abort.
+Later review established the limit of that result: the chosen run followed the
+end of an unsupported `SEQ` field, so no opaque descriptor governed the split.
+Success proved only that this mutation did not reach the opaque-boundary guard;
+it did not prove the guard's discriminators stayed stable. Deliberately moving
+the same split into a supported `REF` field result does make `rebuild` throw the
+expected `OpaquePassthroughError` while `inplace` succeeds. That targeted probe
+validates the guard path, but it is not a control for the original real-world
+abort: its failure was manufactured by placing the split inside a construct
+known to be guarded.
+
+No fixture was therefore committed. Until an independently occurring known-bad
+pair can be staged and pinned through `compareDocuments`, a diagnostic run can
+prove the detector self-tests ran, but it cannot prove that its comparison
+harness can surface this abort. The reconstruction retained field codes and
+bookmark names only because its source was a public standard form; the same
+scrub would not be sufficient redaction for a confidential document.
 
 ## Reproducing A Defect Outside The Original Document
 


### PR DESCRIPTION
## What

Corrects the negative-result evidence merged in #702 after a later dynamic peer review exposed that the chosen split followed the end of a SEQ field and sat outside every opaque descriptor.

The guide now states the narrower, executed result:

- rebuild still correlated all 108 captured REF boundaries;
- the attempted mutation perturbed none of them because it landed outside every descriptor, so their stability was vacuous evidence about run-split sensitivity;
- an equivalent pure split deliberately placed inside a supported REF result makes rebuild throw the expected OpaquePassthroughError while inplace succeeds;
- that targeted probe validates guard reachability but is not an independently occurring control and remains disqualified by #693's anti-manufacturing rule.

The correction also notes that field codes and bookmark names remained only because the source was a public standard form.

## Review

The first post-merge dynamic review of #702 returned FAIL and demonstrated the unsupported inference. A focused review of this correction reproduced both probes and returned APPROVE-WITH-FIXES. Its major wording fix and all three precision nits are addressed in the final commit. The reviewer agreed that #693 should remain closed and the targeted REF probe should not be promoted to a standing control.

## Verification

Final post-review gate, all explicit exit codes:

- build: 0
- lint: 0
- tests: 0
- spec coverage: 0
- conformance citations: 0
- conformance doc: 0

Refs #693
Refs #702