### PR TITLE
fix(docx-comparison): close comment verifier issue shapes

### DIFF
--- a/openspec/changes/verify-lean-comment-reference-integrity/design.md
+++ b/openspec/changes/verify-lean-comment-reference-integrity/design.md
@@ -866,7 +866,7 @@ Semantic issue fields and ordinals are:
 | `COMMENT_DEFINITION_ID_MALFORMED` | definition / direct ordinal | comments/0 | `rawId` |
 | `COMMENT_DEFINITION_ID_TOO_LONG` | definition / direct ordinal | comments/0 | `rawIdByteLength` |
 | `COMMENT_DEFINITION_LIMIT_EXCEEDED` | definition / `4096` | comments/0 | none |
-| `COMMENT_DEFINITION_NOT_DIRECT` | definition / event ordinal `0..4095` | comments/0 | `canonicalId` |
+| `COMMENT_DEFINITION_NOT_DIRECT` | definition / event ordinal `0..4095` | comments/0 | `canonicalId` only when the nested definition has a valid decimal ID; otherwise none |
 | `COMMENT_NON_DIRECT_DEFINITION_LIMIT_EXCEEDED` | definition / `4096` | comments/0 | none |
 | `COMMENT_DEFINITION_DUPLICATE` | definition / second direct ordinal | comments/0 | `canonicalId` |
 | `COMMENT_DEFINITION_MISSING` | reference / first occurrence for ID | exact first source | `canonicalId` |
@@ -1010,8 +1010,8 @@ inside the 640 unit:
 
 | Exact issue shape | Structural bytes |
 | --- | ---: |
-| base plus no extras: ambiguous, source-incomplete, relationship-required, missing-ID, occurrence/definition/non-direct limits | 512 |
-| base plus one bounded numeric or string extra: target-limit, ID-malformed/too-long, unique-ID, non-direct, duplicate, missing-definition | 544 |
+| base plus no extras: ambiguous, source-incomplete, relationship-required, missing-ID, malformed-ID non-direct, occurrence/definition/non-direct limits | 512 |
+| base plus one bounded numeric or string extra: target-limit, ID-malformed/too-long, valid-ID non-direct, unique-ID, duplicate, missing-definition | 544 |
 | base plus `relationshipId` and `rawTarget`, or identity/path | 576 |
 | base plus `relationshipId`, `rawTarget`, and `targetMode` | 608 |
 | existing v5 selection/note ordinary per-slot upper charge | 640 |

--- a/openspec/changes/verify-lean-comment-reference-integrity/tasks.md
+++ b/openspec/changes/verify-lean-comment-reference-integrity/tasks.md
@@ -85,6 +85,8 @@
   inventory projection and `response.commentParsedEvidence side`; assert
   private-root removal after child close on success, failure, timeout, and
   overflow.
+- [x] 3.10 Close checker/decoder issue-shape drift for malformed non-direct
+  definitions and reject source or optional extras on terminal comment issues.
 
 ## 4. Coverage and acceptance
 

--- a/packages/docx-compare/src/baselines/atomizer/leanXmlVerifier.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/leanXmlVerifier.test.ts
@@ -940,6 +940,23 @@ describeWithLean('Lean conventional comment-reference integrity', () => {
         }),
       ]));
 
+      const nestedDefinitionCases = [
+        `<w:comment><w:p/></w:comment>`,
+        `<w:comment w:id="seven"><w:p/></w:comment>`,
+        `<w:comment w:id="${'1'.repeat(65)}"><w:p/></w:comment>`,
+      ];
+      for (const nestedDefinition of nestedDefinitionCases) {
+        const result = await run(await commentIntegrityDocx({
+          commentsXml: `<w:comments xmlns:w="${W_NS}"><w:custom>` +
+            `${nestedDefinition}</w:custom></w:comments>`,
+        }));
+        expect(result.status, result.reason).toBe('failed');
+        const issue = result.commentIntegrityFailures?.find((candidate) =>
+          candidate.code === 'COMMENT_DEFINITION_NOT_DIRECT');
+        expect(issue).toBeDefined();
+        expect(issue?.canonicalId).toBeUndefined();
+      }
+
       const definitionCases = [
         [
           `<w:comments xmlns:w="${W_NS}"><w:comment><w:p/></w:comment></w:comments>`,
@@ -2824,7 +2841,14 @@ test('enforces the canonical equation table for all 40 comment issue codes', () 
     for (const [key, value] of Object.entries(spec.extras ?? {})) {
       const missing = { ...issue };
       delete missing[key];
-      expect(isCommentIssue(missing), `${spec.code}: missing ${key}`).toBe(false);
+      const optionalNonDirectCanonicalId =
+        spec.code === 'COMMENT_DEFINITION_NOT_DIRECT' && key === 'canonicalId';
+      expect(isCommentIssue(missing), `${spec.code}: missing ${key}`)
+        .toBe(optionalNonDirectCanonicalId);
+      if (optionalNonDirectCanonicalId) {
+        expect(isLeanVerifierJson(reportFor(spec, missing)),
+          `${spec.code}: decoder accepts absent canonicalId`).toBe(true);
+      }
       for (const invalid of invalidExtras[key] ?? []) {
         expect(isCommentIssue({ ...issue, [key]: invalid }),
           `${spec.code}: invalid ${key}=${String(invalid)}`).toBe(false);
@@ -3429,6 +3453,33 @@ describe('Lean fixed-story protocol and security hardening', () => {
       commentIntegrityIssues: [terminalIssue],
     };
     expect(isLeanVerifierJson(terminal)).toBe(true);
+    const forbiddenTerminalExtras = {
+      source: { sourceStory: 'main', sourceStoryOrdinal: 0 },
+      canonicalId: '7',
+      rawId: 'bad',
+      rawIdByteLength: 65,
+      relationshipId: 'rIdComments',
+      rawTarget: 'comments.xml',
+      rawTargetByteLength: 257,
+      targetMode: 'External',
+      normalizedPartPath: 'word/comments.xml',
+    };
+    const terminalIssues = [
+      terminalIssue,
+      {
+        ...terminalIssue,
+        code: 'COMMENT_ISSUE_LIMIT_EXCEEDED',
+        detail: 'protocol v6 aggregate ordinary issue limit exceeded',
+      },
+    ];
+    for (const candidate of terminalIssues) {
+      for (const [key, extra] of Object.entries(forbiddenTerminalExtras)) {
+        expect(isLeanVerifierJson({
+          ...terminal,
+          commentIntegrityIssues: [{ ...candidate, [key]: extra }],
+        }), `${candidate.code} terminal extra ${key}`).toBe(false);
+      }
+    }
     expect(isLeanVerifierJson({
       ...terminal,
       fixedStories: [

--- a/packages/docx-compare/src/baselines/atomizer/leanXmlVerifier.ts
+++ b/packages/docx-compare/src/baselines/atomizer/leanXmlVerifier.ts
@@ -877,9 +877,13 @@ export function isCommentIssue(value: unknown): value is DocumentIntegrityCommen
   const terminal = value.code === 'COMMENT_ISSUE_LIMIT_EXCEEDED' ||
     value.code === 'COMMENT_EVIDENCE_STRING_BUDGET_EXCEEDED';
   if (terminal) {
+    const terminalExtras = [
+      'source', 'canonicalId', 'rawId', 'rawIdByteLength', 'relationshipId',
+      'rawTarget', 'rawTargetByteLength', 'targetMode', 'normalizedPartPath',
+    ] as const;
     return value.ordinalSpace === 'aggregate' && value.side === 'original' &&
       value.firstOccurrenceOrdinal === 0 && value.occurrenceCount === 1 &&
-      !('source' in value);
+      terminalExtras.every((key) => !(key in value));
   }
   if (!('source' in value)) return false;
   const source = value.source as Record<string, unknown>;
@@ -1004,10 +1008,11 @@ export function isCommentIssue(value: unknown): value is DocumentIntegrityCommen
     case 'COMMENT_DEFINITION_ID_TOO_LONG':
       return hasExactExtras(['rawIdByteLength']);
     case 'COMMENT_UNIQUE_REFERENCE_ID_LIMIT_EXCEEDED':
-    case 'COMMENT_DEFINITION_NOT_DIRECT':
     case 'COMMENT_DEFINITION_DUPLICATE':
     case 'COMMENT_DEFINITION_MISSING':
       return hasExactExtras(['canonicalId']);
+    case 'COMMENT_DEFINITION_NOT_DIRECT':
+      return hasExactExtras('canonicalId' in value ? ['canonicalId'] : []);
     default:
       return false;
   }

--- a/verification/lean/LeanDocxChecker.lean
+++ b/verification/lean/LeanDocxChecker.lean
@@ -3195,12 +3195,12 @@ def buildCommentSideEvidence (package : Package) (side : VerifierSide)
       let duplicates := duplicateCommentDefinitionIssues side definitions
       let missing := missingCommentDefinitionIssues side sources references definitions
       let nonDirect := scan.nonDirectDefinitions.map fun definition =>
-        let canonicalId := (definition.rawId.bind fun raw =>
-          (parseDecimalId raw).toOption.map (·.text)).getD ""
+        let canonicalId := definition.rawId.bind fun raw =>
+          (parseDecimalId raw).toOption.map (·.text)
         commentIssueJson "COMMENT_DEFINITION_NOT_DIRECT"
           "w:comment definitions must be direct children of w:comments"
           side "definition" definition.occurrenceOrdinal "comments" 0
-          [("canonicalId", toJson canonicalId)]
+          (canonicalId.map (fun value => ("canonicalId", toJson value))).toList
       let crossingIssues := match retained.output.crossing with
         | none => []
         | some (.references sourceOrdinal ordinal) =>


### PR DESCRIPTION
## Summary

- keep malformed non-direct comment-definition failures inside the strict checker/decoder grammar
- reject source and all optional extras on terminal comment issues
- add regressions for missing, malformed, and overlong nested IDs and both terminal codes
- preserve public certificate v1 and checker protocol v6

## Why

Independent post-merge review of #694 found that one checker issue shape could be rejected by its own TypeScript decoder and that terminal issues admitted forbidden fields. Both defects weaken deterministic fail-closed reporting at the compiled verifier boundary.

## Validation

- focused verifier suite: 95/95 passed
- Lean build passed without `lake update`
- protocol-v6 structural, ordinary-envelope, and terminal-shape witnesses passed
- comment dependency and checker coverage audits passed
- strict OpenSpec validation passed
- docx-compare lint passed
- independent implementation review: APPROVE, no findings
- no LibreOffice/soffice invocation

Refs #708
Refs #694
Refs #706