### PR TITLE
docs(verification): record comment verifier acceptance gap

### DIFF
--- a/openspec/changes/verify-lean-comment-reference-integrity/tasks.md
+++ b/openspec/changes/verify-lean-comment-reference-integrity/tasks.md
@@ -102,3 +102,10 @@
   real-DOCX tests.
 - [ ] 4.5 Obtain independent implementation review and post-merge real-document
   smoke before closing #672.
+
+Independent review findings were repaired by #709, but its exact-merge smoke
+found that full-document comment scanning exhausts the native stack. Issue #672
+was reopened, and #710 tracks the stack-safe full-document acceptance work.
+
+Archive is deferred to #706 so formal Lean theorem evidence is not
+misrepresented as TypeScript runtime-test coverage.


### PR DESCRIPTION
## Summary

- keep the comment verifier real-document acceptance task open
- record that #709 fixed protocol-shape findings but full-document scanning exposed #710
- record that #672 was reopened
- retain #706 as the prerequisite for truthful OpenSpec archival

## Validation

- workspace build passed
- workspace lint passed with 9 existing warnings, 0 errors
- strict spec coverage passed
- conformance citation/document checks passed
- strict OpenSpec validation passed
- independent review: APPROVE, no findings
- no LibreOffice/soffice or `lake update`

Refs #672
Refs #706
Refs #710