### PR TITLE
docs(readme): link the conformance explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ See [Installation and verification](docs/installation.md) for locating the execu
 
 ## Standards Conformance
 
-See the generated [ECMA-376 conformance report](spec-compliance/CONFORMANCE.md) for targeted sections, explicit non-goals, and verification references.
+Browse the [Safe Docx Conformance Explorer](https://usejunior.com/engineering/safe-docx/conformance) to navigate ECMA-376 sections, OOXML schema declarations, capability claims, explicit non-goals, and measured cross-implementation outcomes.
+
+The generated [repository conformance report](spec-compliance/CONFORMANCE.md) remains the source-controlled record of targeted sections, non-goals, and verification references.
 
 ## What Safe Docx Is Not Optimized For
 


### PR DESCRIPTION
## What changed

- Makes the hosted Safe Docx Conformance Explorer the primary human-facing conformance link in the README.
- Keeps the generated repository conformance report linked as the source-controlled record.

## Why

The explorer provides navigable ECMA-376 sections, OOXML schema declarations, capability claims, explicit non-goals, and measured cross-implementation outcomes. The Markdown report remains valuable as the auditable artifact in the repository, but it is not the best entry point for most readers.

## Validation

- `npm run build`
- `npm run lint:workspaces` (passes with 9 pre-existing warnings)
- `npm run test:run`
- `npm run check:spec-coverage`
- `npm run check:conformance-citations`
- `npm run check:conformance-doc`
- `git diff --check`