### PR TITLE
fix(docx-comparison): preserve isolated word-split spaces

### DIFF
--- a/packages/docx-compare/src/baselines/atomizer/atomLcs.ts
+++ b/packages/docx-compare/src/baselines/atomizer/atomLcs.ts
@@ -82,7 +82,7 @@ export function computeAtomLcs(
   }
 
   // Backtrack to find the actual LCS matches
-  const matches: AtomMatch[] = [];
+  let matches: AtomMatch[] = [];
   let i = n;
   let j = m;
 
@@ -97,6 +97,32 @@ export function computeAtomLcs(
       j--;
     }
   }
+
+  // Word tokenization deliberately preserves whitespace as standalone atoms.
+  // Those atoms all have the same identity, so an LCS can otherwise align an
+  // isolated source space with an unrelated revised space inside a replacement.
+  // In-place reconstruction then treats that space as Equal and may omit the
+  // source-side separator from the reject projection. A split whitespace match
+  // is meaningful only when it is diagonally adjacent to another matched atom;
+  // explicit whitespace-only runs are not affected. (#720)
+  const matchedPairs = new Set(
+    matches.map((match) => `${match.originalIndex}:${match.revisedIndex}`),
+  );
+  const isSplitWhitespace = (atom: ComparisonUnitAtom): boolean =>
+    atom.splitFromAtom !== undefined &&
+    atom.contentElement.tagName === 'w:t' &&
+    /^\s+$/u.test(atom.contentElement.textContent ?? '');
+  matches = matches.filter((match) => {
+    const originalAtom = original[match.originalIndex]!;
+    const revisedAtom = revised[match.revisedIndex]!;
+    if (!isSplitWhitespace(originalAtom) || !isSplitWhitespace(revisedAtom)) {
+      return true;
+    }
+    return (
+      matchedPairs.has(`${match.originalIndex - 1}:${match.revisedIndex - 1}`) ||
+      matchedPairs.has(`${match.originalIndex + 1}:${match.revisedIndex + 1}`)
+    );
+  });
 
   // Find deleted and inserted indices
   const matchedOriginal = new Set(matches.map((m) => m.originalIndex));

--- a/packages/docx-compare/src/baselines/atomizer/pipeline-word-split-whitespace.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline-word-split-whitespace.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Word-split in-place reconstruction must retain source whitespace when an LCS
+ * could otherwise align identical standalone space atoms across reordered text.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.3.3.31
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.5
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.6.1
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.6.2
+ * @see https://github.com/UseJunior/safe-docx/issues/720
+ */
+
+import { DocxArchive, parseXml } from '@usejunior/docx-core';
+import { describe, expect } from 'vitest';
+import { buildDocxFromBodyXml } from '../../testing/ooxml-fixtures.js';
+import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
+import { compareDocumentsAtomizer } from './pipeline.js';
+import {
+  acceptAllChanges,
+  extractTextWithParagraphs,
+  rejectAllChanges,
+} from './trackChangesAcceptorAst.js';
+
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({
+    feature: 'In-Place Reconstruction',
+    story: 'Word-Split Whitespace Projection',
+    severity: 'critical',
+  })
+  .conformance(
+    { spec: 'ECMA-376', edition: 5, part: 1, section: '17.3.3.31' },
+    { spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.5' },
+    { spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.6.1' },
+    { spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.6.2' },
+  );
+
+const ORIGINAL_CHANGED_RUN =
+  'vgjwsxyt zjq kotvr uajifak eofxjlas kkqje rb vue Uajifak';
+const REVISED_CHANGED_RUN =
+  'uajifak eofxjlas kkqje (kotvr cugl xbhov mzqfyfkvf sh qxrpcm (dzb) gcqmm) og vgjwsxyt rb vue Uajifak';
+const PREFIX =
+  'Stable alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu xi omicron. ';
+const SUFFIX =
+  ' Stable suffix pi rho sigma tau upsilon phi chi psi omega remains exactly the same.';
+
+function body(changedRun: string): string {
+  return (
+    '<w:p>' +
+    `<w:r><w:t xml:space="preserve">${PREFIX}</w:t></w:r>` +
+    `<w:r><w:t xml:space="preserve">${changedRun}</w:t></w:r>` +
+    `<w:r><w:t xml:space="preserve">${SUFFIX}</w:t></w:r>` +
+    '</w:p>'
+  );
+}
+
+async function documentXml(docx: Buffer): Promise<string> {
+  return (await DocxArchive.load(docx)).getDocumentXml();
+}
+
+function bodyText(bodyXml: string): string {
+  return parseXml(
+    `<w:root xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">${bodyXml}</w:root>`,
+  ).documentElement.textContent ?? '';
+}
+
+describe('adaptive word-split whitespace parity (#720)', () => {
+  test('keeps isolated spaces on both projections when words are reordered inside one run', async ({
+    given,
+    when,
+    then,
+    and,
+  }: AllureBddContext) => {
+    const originalBody = body(ORIGINAL_CHANGED_RUN);
+    const revisedBody = body(REVISED_CHANGED_RUN);
+    const original = await given('a paragraph with a multi-word source run', () =>
+      buildDocxFromBodyXml(originalBody),
+    );
+    const revised = await given('the paragraph with reordered and inserted words in that run', () =>
+      buildDocxFromBodyXml(revisedBody),
+    );
+
+    const result = await when('the adaptive in-place comparison runs', () =>
+      compareDocumentsAtomizer(original, revised, {
+        reconstructionMode: 'inplace',
+        date: new Date('2026-07-28T12:00:00Z'),
+      }),
+    );
+    const xml = await documentXml(result.document);
+
+    await then('the highest-fidelity word-split pass satisfies the safety gate', () => {
+      expect(result.reconstructionModeUsed).toBe('inplace');
+      expect(result.inplaceSuccessDiagnostics?.passUsed).toBe('inplace_word_split');
+      expect(result.inplaceSuccessDiagnostics?.precedingFailedAttempts).toEqual([]);
+    });
+
+    await and('accept and reject preserve every character, including spaces', () => {
+      expect(extractTextWithParagraphs(acceptAllChanges(xml))).toBe(bodyText(revisedBody));
+      expect(extractTextWithParagraphs(rejectAllChanges(xml))).toBe(bodyText(originalBody));
+    });
+  });
+});

--- a/packages/docx-core/src/integration/nvca-structural-regression.test.ts
+++ b/packages/docx-core/src/integration/nvca-structural-regression.test.ts
@@ -34,12 +34,18 @@ describe('NVCA Structural Regression', () => {
       // Check that it used inplace mode (meaning it passed all safety checks)
       expect(res.reconstructionModeUsed).toBe('inplace');
       expect(res.fallbackReason).toBeUndefined();
+      expect(res.inplaceSuccessDiagnostics?.passUsed).toBe('inplace_word_split');
+      expect(res.inplaceSuccessDiagnostics?.precedingFailedAttempts).toEqual([]);
     });
 
     await and('stats are within expected ranges', async () => {
-      // Verify stats are within expected ranges (v0.3: improved matching yields lower counts)
-      expect(res.stats.insertions).toBeGreaterThan(100);
-      expect(res.stats.deletions).toBeGreaterThan(200);
+      // Pin a bounded characterization range. A lower-bound-only assertion
+      // accidentally rewarded extra revision noise and failed when #720 let the
+      // higher-fidelity word-split pass reduce insertion ranges from 101+ to 99.
+      expect(res.stats.insertions).toBeGreaterThanOrEqual(90);
+      expect(res.stats.insertions).toBeLessThanOrEqual(110);
+      expect(res.stats.deletions).toBeGreaterThanOrEqual(250);
+      expect(res.stats.deletions).toBeLessThanOrEqual(300);
     });
   }, 60000); // 60 second timeout for large document comparison
 });


### PR DESCRIPTION
## Summary

- reject isolated word-tokenizer whitespace matches unless adjacent matched
  content supports the alignment
- add a synthetic DOCX regression proving exact accept/reject whitespace parity
  and first-pass `inplace_word_split` selection
- replace a lower-bound-only NVCA revision-count assertion with a bounded
  characterization and explicit first-pass diagnostics

## Why

All standalone spaces created by word tokenization shared one identity. Inside a
rewritten run, LCS could pair unrelated spaces. In-place rejection then omitted
the actual source separator, the safety gate rejected the word-split candidate,
and the adaptive pipeline selected a coarser run-level redline.

The rule applies only to tokenizer-derived whitespace. Explicit whitespace-only
runs are unchanged.

## Competitive acceptance evidence

On the private aggregate-only acceptance oracle:

- the adaptive pass changes from `inplace_run_level` to
  `inplace_word_split`, with no failed preceding attempts;
- unchanged currency delete/reinsert artifacts fall from 2 to 0;
- overlapping delete/reinsert tokens fall from 295 to 94 (pinned baseline: 146).

No private filenames, parties, terms, values, or document text are included in
this PR or its fixtures.

## Verification

- full mandatory pre-submit chain passed:
  `npm run build && npm run lint:workspaces && npm run test:run && npm run check:spec-coverage && npm run check:conformance-citations && npm run check:conformance-doc`
- post-rebase focused tests passed

Fixes #720
Ref #717
Ref #718
