### PR TITLE
fix(docx-comparison): make Lean comment checks stack safe

### DIFF
--- a/.github/workflows/lean-build.yml
+++ b/.github/workflows/lean-build.yml
@@ -13,6 +13,9 @@ on:
       - 'scripts/check_lean_note_semantics_dependencies.mjs'
       - 'scripts/check_lean_comment_semantics_dependencies.mjs'
       - 'scripts/check_lean_production_axiom_target.mjs'
+      - 'scripts/check_lean_xml_checker_coverage.mjs'
+      - 'scripts/check_lean_comment_memory.mjs'
+      - 'package.json'
       - '.github/workflows/lean-build.yml'
       - 'packages/docx-core/src/integration/lean-differential-lcs.test.ts'
       # The differential gate guards the production TS LCS against the Lean model,
@@ -29,6 +32,8 @@ on:
       - 'packages/docx-compare/src/compare-types.ts'
       - 'packages/docx-core/src/integration/nvca-coi-regression.test.ts'
       - 'tests/test_documents/nvca-coi-regression/source.docx'
+      - 'packages/docx-core/src/integration/nvca-structural-regression.test.ts'
+      - 'tests/test_documents/nvca-regression/**'
   pull_request:
     branches: [main]
     paths:
@@ -39,6 +44,9 @@ on:
       - 'scripts/check_lean_note_semantics_dependencies.mjs'
       - 'scripts/check_lean_comment_semantics_dependencies.mjs'
       - 'scripts/check_lean_production_axiom_target.mjs'
+      - 'scripts/check_lean_xml_checker_coverage.mjs'
+      - 'scripts/check_lean_comment_memory.mjs'
+      - 'package.json'
       - '.github/workflows/lean-build.yml'
       - 'packages/docx-core/src/integration/lean-differential-lcs.test.ts'
       - 'packages/docx-core/src/baselines/atomizer/atomLcs.ts'
@@ -51,6 +59,8 @@ on:
       - 'packages/docx-compare/src/compare-types.ts'
       - 'packages/docx-core/src/integration/nvca-coi-regression.test.ts'
       - 'tests/test_documents/nvca-coi-regression/source.docx'
+      - 'packages/docx-core/src/integration/nvca-structural-regression.test.ts'
+      - 'tests/test_documents/nvca-regression/**'
   workflow_dispatch:
 
 permissions:
@@ -130,6 +140,7 @@ jobs:
           lake env lean ProtocolV6StructuralChargeAudit.lean
           lake env lean ProtocolV6OrdinaryEnvelopeWitness.lean
           lake env lean ProtocolV6CanonicalTerminalShapes.lean
+          lake env lean TypedCommentStackSafetyWitnesses.lean
           node ../../scripts/check_lean_note_semantics_dependencies.mjs
           node ../../scripts/check_lean_comment_semantics_dependencies.mjs
 
@@ -198,10 +209,23 @@ jobs:
           echo "npm ci failed after 3 attempts"
           exit 1
       - name: Compiled Lean relationship-story protocol v6
+        env:
+          SAFE_DOCX_REQUIRE_LEAN_CHECKER: '1'
         run: npm run test:run -w @usejunior/docx-compare -- src/baselines/atomizer/leanXmlVerifier.test.ts
+
+      - name: Audit Lean checker coverage and stack-safety wiring
+        run: npm run check:lean-xml-checker-coverage
+
+      - name: Near-limit comment payload memory acceptance
+        run: npm run check:lean-comment-memory
 
       - name: Real NVCA compared-only relationship-story mutations
         run: npm run test:run -w @usejunior/docx-core -- src/integration/nvca-coi-regression.test.ts
+
+      - name: Complete NVCA selected-comment fixed-stack acceptance
+        env:
+          SAFE_DOCX_REQUIRE_LEAN_CHECKER: '1'
+        run: npm run test:run -w @usejunior/docx-core -- src/integration/nvca-structural-regression.test.ts
 
       - name: Lean↔TS LCS differential harness (exhaustive)
         env:

--- a/openspec/changes/verify-lean-comment-reference-integrity/design.md
+++ b/openspec/changes/verify-lean-comment-reference-integrity/design.md
@@ -1099,6 +1099,32 @@ v5/v6 serialization helpers.
 extraction, parser, source-scan, comment-scan, and inherited semantic
 evaluation records into typed inputs. It never decodes `result.response` or
 uses `protocolV6Projection` as an expected typed response.
+Request-bound package, snapshot, compressed-slice, and expanded-part bytes are
+compared by a reverse indexed, tail-recursive `ByteArray` check without
+conversion to `List UInt8`. Text and attribute values in typed XML events use
+bounded `ByteArray` storage; only a namespace-selected `w:id` value is converted
+to the bounded list consumed by decimal semantics. Parsed XML events,
+attributes, bounded name lists, and packed payloads are compared by custom
+lockstep tail recursion with sparse-case generation disabled. Production
+attribute conversion uses `List.mapTR`, and the two retained views of one
+parsed Comments event list share the same typed conversion. The selected
+Comments branch MUST NOT use derived `List UInt8` equality, whole-payload
+`ByteArray.toList`, or ordinary recursive `List.map` on any package-, part-,
+event-, attribute-, or payload-sized value: those forms consume native stack or
+heap proportional to a legal part with excessive representation amplification.
+Axiom-free equivalence theorems relate indexed byte-array equality and the
+custom event-sequence equality to the prior structural identities. Native
+400,000-byte text/attribute witnesses and a production
+TypeScript-to-checker regression exercise the compiled implementation under
+the normal fixed 8 MiB macOS process stack.
+
+The common XML/extraction path also avoids large transient lists: BOM detection
+examines the first three UTF-8 bytes, ordinary ASCII legality and entity-free
+decoding use indexed byte loops, XML tag boundaries are scanned without
+whole-input `List Char` conversion,
+decompressor output is collected as bounded chunks into one preallocated
+`ByteArray`, and CRC-32 walks the array by forward index. Entity-bearing and
+non-ASCII inputs retain the original fail-closed decoder semantics.
 `ProtocolV6JsonProjectionOf` then requires
 `response.compress.toUTF8.data.toList =
 independentProtocolV6Projection typedResponse`. Thus the production response
@@ -1134,6 +1160,36 @@ before any mutation. Relocation changes both relationship target and ZIP entry.
 Compared-only mutations cover every issue family while asserting unrelated
 story identities and original/revised evidence remain stable. LibreOffice is
 not invoked.
+
+The operational acceptance fixture additionally uses the complete checked-in
+NVCA-derived package, whose `word/document.xml` exceeds 350,000 characters and
+whose comparison path produces approximately 41,000 atoms. It enables one
+selected valid Comments part on every side, then applies compared-only missing,
+malformed, and over-64-byte nested `w:comment` ID mutations. Every run crosses
+the production TypeScript supervisor and compiled protocol-v6 executable under
+the normal fixed 8 MiB stack; baseline must pass and each mutation must return
+structured `failed` evidence rather than `not_run` or abnormal process exit.
+
+The July 28, 2026 complete-NVCA checker-only measurement used the normal macOS
+`ulimit -s` value of 8176 KiB and piped one protocol-v6 JSON request directly
+to `verification/lean/.lake/build/bin/leanDocxChecker`, with stdout redirected
+away from `/usr/bin/time -l`. The request referenced the complete real
+NVCA-derived original/revised/compared triple with selected comments and a
+nested-definition mutation. The checker completed in 1.31 seconds wall time
+with a 306,937,856-byte maximum resident set and returned structured protocol-v6
+issues. The production supervisor and both fixed-stack regressions enforce a
+120-second ceiling per checker invocation.
+
+Near-limit memory acceptance is separately executable through
+`npm run check:lean-comment-memory`. Each case invokes only the compiled checker
+under an 8192 KiB stack with one selected 16,775,168-byte Comments payload and
+two small valid sides, excluding fixture generation, Node, Vitest, and repeated
+checker invocations from the measured process. `/usr/bin/time -l` on macOS and
+GNU `time` on Linux supply checker wall time and maximum RSS. The test fails at
+or above 1.5 GiB (1,610,612,736 bytes) or after 120 seconds. On July 28, 2026,
+the near-limit text case completed in 1.45 seconds at 1,277,116,416 bytes peak
+RSS, and the near-limit attribute case completed in 3.32 seconds at
+1,314,979,840 bytes peak RSS.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/verify-lean-comment-reference-integrity/specs/docx-comparison/spec.md
+++ b/openspec/changes/verify-lean-comment-reference-integrity/specs/docx-comparison/spec.md
@@ -264,3 +264,25 @@ endnote stories before applying compared-only mutations.
 - **WHEN** one referenced definition is removed only from compared
 - **THEN** only the compared comment inventory SHALL fail
 - **AND** unrelated selected-story identities SHALL remain unchanged
+
+#### Scenario: [LEAN-COMMENT-11] Complete NVCA package is stack-safe
+- **GIVEN** the complete checked-in NVCA-derived package with a
+  `word/document.xml` exceeding 350,000 characters and selected valid legacy
+  Comments infrastructure on all three sides
+- **WHEN** the production TypeScript supervisor invokes the compiled
+  protocol-v6 verifier under the normal fixed 8 MiB macOS process stack
+- **THEN** the baseline SHALL return a passing public certificate v1
+- **AND** compared-only nested `w:comment` definitions with a missing,
+  malformed, or over-64-byte `w:id` SHALL each return structured failed
+  evidence
+- **AND** no case SHALL exit abnormally or return `not_run`
+
+#### Scenario: [LEAN-COMMENT-12] Large comment payload equality is stack-safe
+- **GIVEN** a selected Comments part containing one 400,000-byte attribute
+  value and one 400,000-byte text event
+- **WHEN** the production TypeScript supervisor invokes the compiled verifier
+  under the normal fixed 8 MiB process stack
+- **THEN** typed byte, attribute, and event-sequence admission SHALL complete
+  within the 120-second per-invocation ceiling
+- **AND** the verifier SHALL return a structured protocol-v6 result rather than
+  exiting abnormally or returning `not_run`

--- a/openspec/changes/verify-lean-comment-reference-integrity/tasks.md
+++ b/openspec/changes/verify-lean-comment-reference-integrity/tasks.md
@@ -87,6 +87,18 @@
   overflow.
 - [x] 3.10 Close checker/decoder issue-shape drift for malformed non-direct
   definitions and reject source or optional extras on terminal comment issues.
+- [x] 3.11 Run selected legacy-comment scanning on the complete checked-in
+  approximately 41,000-atom NVCA-derived package through the production
+  TypeScript-to-compiled-Lean boundary; cover a passing baseline plus
+  missing/malformed/overlong nested definition IDs as structured failures under
+  the fixed 8 MiB stack.
+- [x] 3.12 Replace derived byte/event equality with custom tail-recursive
+  checks, prove byte-array and event-sequence equivalence without axioms, and
+  execute native plus production-boundary 400,000-byte text/attribute witnesses.
+- [x] 3.13 Keep text and attribute values packed as bounded byte arrays through
+  typed admission, remove whole-part list conversions from XML/extraction
+  scanning, and enforce checker-only near-limit text and attribute peak RSS
+  below 1.5 GiB with a 120-second ceiling.
 
 ## 4. Coverage and acceptance
 
@@ -102,6 +114,14 @@
   real-DOCX tests.
 - [ ] 4.5 Obtain independent implementation review and post-merge real-document
   smoke before closing #672.
+- [x] 4.6 Re-run focused TypeScript tests, full Lean builds and audits, strict
+  OpenSpec/spec/conformance checks, and record wall-time/peak-RSS measurements
+  for #710 without raising stack limits. Complete-NVCA checker-only evidence:
+  1.31 seconds wall time and 306,937,856-byte peak RSS at
+  `ulimit -s = 8176` KiB. Near-limit checker-only evidence at an 8192 KiB
+  stack: text 1.45 seconds / 1,277,116,416 bytes peak RSS; attribute
+  3.32 seconds / 1,314,979,840 bytes peak RSS. The executable acceptance gate
+  retains the 120-second timeout and rejects peak RSS at or above 1.5 GiB.
 
 Independent review findings were repaired by #709, but its exact-merge smoke
 found that full-document comment scanning exhausts the native stack. Issue #672

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "generate:invariants-doc": "node scripts/generate_invariants_doc.mjs",
     "check:invariants-doc": "node scripts/check_invariants_doc.mjs",
     "check:lean-xml-checker-coverage": "node scripts/check_lean_xml_checker_coverage.mjs",
+    "check:lean-comment-memory": "node scripts/check_lean_comment_memory.mjs",
     "check:emitted-schema": "node --test scripts/check_emitted_document_schema.test.mjs && node scripts/check_emitted_document_schema.mjs --self-test --known-failures coverage/emitted-schema-known-failures.json",
     "generate:tests-corpus-schema": "npm run build -w @usejunior/test-narrative && node scripts/generate_tests_corpus_schema.mjs",
     "check:tests-corpus-schema": "npm run build -w @usejunior/test-narrative && node scripts/check_tests_corpus_schema.mjs",

--- a/packages/docx-compare/src/baselines/atomizer/leanXmlVerifier.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/leanXmlVerifier.test.ts
@@ -99,6 +99,9 @@ function canonicalJsonForTest(value: unknown): string {
 }
 
 const exeExists = existsSync(LEAN_EXE);
+if (process.env.SAFE_DOCX_REQUIRE_LEAN_CHECKER === '1' && !exeExists) {
+  throw new Error(`required compiled Lean checker is missing: ${LEAN_EXE}`);
+}
 if (!exeExists) {
   console.warn(
     `[lean-xml-verifier] SKIP: ${LEAN_EXE} not found. ` +
@@ -642,6 +645,19 @@ async function commentIntegrityDocx(options: {
   return zip.generateAsync({ type: 'nodebuffer', compression: 'DEFLATE' });
 }
 
+function deterministicXmlPayload(length: number, seed: number): string {
+  const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  const output = Buffer.allocUnsafe(length);
+  let state = seed >>> 0;
+  for (let index = 0; index < length; index++) {
+    state ^= state << 13;
+    state ^= state >>> 17;
+    state ^= state << 5;
+    output[index] = alphabet.charCodeAt((state >>> 0) % alphabet.length);
+  }
+  return output.toString('ascii');
+}
+
 /**
  * @conformance ECMA-376 edition 5, Part 1 § 17.13.4.2
  * @conformance ECMA-376 edition 5, Part 1 § 17.13.4.5
@@ -731,7 +747,7 @@ describeWithLean('Lean conventional comment-reference integrity', () => {
     comparedDocx,
     legacyDocumentXml: { original: '', revised: '', compared: '' },
     reconstructionMode: 'inplace',
-    options: { executablePath: LEAN_EXE },
+    options: { executablePath: LEAN_EXE, timeoutMs: 120_000 },
   });
   const expectGlobalCommentStop = (
     certificate: Awaited<ReturnType<typeof run>>,
@@ -752,6 +768,34 @@ describeWithLean('Lean conventional comment-reference integrity', () => {
     expect(certificate.commentStory?.revised.status).toBe('not_evaluated');
     expect(certificate.commentStory?.compared.status).toBe('not_evaluated');
   };
+
+  test
+    .openspec('[LEAN-COMMENT-12] Large comment payload equality is stack-safe')
+    .conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.4.6' })
+    .conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.18.10' })(
+    'processes 400000-byte comment text and attribute payloads on the fixed stack',
+    async () => {
+      const attributePayload = deterministicXmlPayload(400_000, 0x710a);
+      const textPayload = deterministicXmlPayload(400_000, 0x710b);
+      const docx = await commentIntegrityDocx({
+        commentsXml:
+          `<w:comments xmlns:w="${W_NS}">` +
+          `<w:comment w:id="7" w:author="${attributePayload}">` +
+          `<w:p><w:r><w:t>${textPayload}</w:t></w:r></w:p>` +
+          `</w:comment></w:comments>`,
+      });
+
+      const certificate = await run(docx);
+
+      expect(certificate.status, certificate.reason).toBe('passed');
+      expect(certificate.checkerProtocolVersion).toBe(6);
+      expect(certificate.commentInventories).toHaveLength(3);
+      expect(certificate.commentInventories?.every((inventory) =>
+        inventory.status === 'passed' && inventory.definitions === 1,
+      )).toBe(true);
+    },
+    120_000,
+  );
 
   test
     .openspec('[LEAN-COMMENT-01] Selected comments resolve admitted references')
@@ -3062,7 +3106,9 @@ describe('Lean fixed-story protocol and security hardening', () => {
         await rm(fake.dir, { recursive: true, force: true });
       }
     }
-    });
+    },
+    15_000,
+  );
 
   describeWithNearEnvelope('compiled near-envelope response constructors', () => {
     test.openspec('[LEAN-REL-22] Every legal response fits the output cap')(

--- a/packages/docx-core/src/integration/nvca-structural-regression.test.ts
+++ b/packages/docx-core/src/integration/nvca-structural-regression.test.ts
@@ -1,10 +1,25 @@
-import { describe, expect } from 'vitest';
+import { describe, expect, vi } from 'vitest';
 import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
-import { compareDocuments } from '@usejunior/docx-compare';
+import {
+  atomizeTree,
+  compareDocuments,
+  parseDocumentXml,
+  runLeanXmlTripleVerifier,
+} from '@usejunior/docx-compare';
 import fs from 'fs';
 import path from 'path';
+import { DocxArchive } from '../shared/docx/DocxArchive.js';
+import { DocxDocument } from '../primitives/document.js';
+import { getParagraphText, replaceParagraphTextRange } from '../primitives/text.js';
+import { OOXML } from '../primitives/namespaces.js';
+import type { OpcPart } from '../core-types.js';
 
-const test = testAllure.epic('Document Comparison').withLabels({ feature: 'NVCA Structural Regression' });
+const TEST_FEATURE = 'NVCA Structural Regression';
+const test = testAllure.epic('Document Comparison').withLabels({ feature: TEST_FEATURE });
+const COMMENTS_RELATIONSHIP_TYPE =
+  'http://schemas.openxmlformats.org/officeDocument/2006/relationships/comments';
+const COMMENTS_PATH = 'word/comments-lean-710.xml';
+const COMMENTS_RELATIONSHIP_ID = 'rIdLean710Comments';
 
 describe('NVCA Structural Regression', () => {
   const sourcePath = path.resolve(__dirname, '../../../../tests/test_documents/nvca-regression/source.docx');
@@ -42,4 +57,179 @@ describe('NVCA Structural Regression', () => {
       expect(res.stats.deletions).toBeGreaterThan(200);
     });
   }, 60000); // 60 second timeout for large document comparison
+});
+
+async function deriveMinimallyEditedRevision(source: Buffer): Promise<Buffer> {
+  const document = await DocxDocument.load(source);
+  const paragraph = document.getParagraphs().find((candidate) => {
+    const text = getParagraphText(candidate);
+    return text.length >= 20 &&
+      candidate.getElementsByTagNameNS(OOXML.W_NS, 'fldChar').length === 0;
+  });
+  if (!paragraph) throw new Error('NVCA source has no suitable body paragraph');
+  const text = getParagraphText(paragraph);
+  replaceParagraphTextRange(paragraph, 0, 1, text[0] === 'A' ? 'B' : 'A');
+  return (await document.toBuffer({ cleanBookmarks: false })).buffer;
+}
+
+/**
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.4.6
+ * @conformance ECMA-376 edition 5, Part 1 § 17.18.10
+ */
+async function addSelectedCommentsPart(source: Buffer): Promise<Buffer> {
+  const archive = await DocxArchive.load(source);
+  const relationshipsPath = 'word/_rels/document.xml.rels';
+  const relationships = await archive.getFile(relationshipsPath);
+  if (!relationships?.includes('</Relationships>')) {
+    throw new Error('NVCA source has no conventional Main Document relationships part');
+  }
+  if (relationships.includes(`Type="${COMMENTS_RELATIONSHIP_TYPE}"`)) {
+    throw new Error('NVCA source unexpectedly already selects legacy comments');
+  }
+  archive.setFile(
+    relationshipsPath,
+    relationships.replace(
+      '</Relationships>',
+      `<Relationship Id="${COMMENTS_RELATIONSHIP_ID}" ` +
+        `Type="${COMMENTS_RELATIONSHIP_TYPE}" ` +
+        `Target="${COMMENTS_PATH.replace(/^word\//, '')}"/></Relationships>`,
+    ),
+  );
+  archive.setFile(
+    COMMENTS_PATH,
+    `<w:comments xmlns:w="${OOXML.W_NS}">` +
+      '<w:comment w:id="710"><w:p/></w:comment></w:comments>',
+  );
+  return archive.save();
+}
+
+async function addNestedCommentDefinition(
+  source: Buffer,
+  rawId: string | undefined,
+): Promise<Buffer> {
+  const archive = await DocxArchive.load(source);
+  const comments = await archive.getFile(COMMENTS_PATH);
+  if (!comments?.includes('</w:comments>')) {
+    throw new Error('NVCA comparison output has no selected Comments part');
+  }
+  const idAttribute = rawId === undefined ? '' : ` w:id="${rawId}"`;
+  archive.setFile(
+    COMMENTS_PATH,
+    comments.replace(
+      '</w:comments>',
+      `<w:custom><w:comment${idAttribute}><w:p/></w:comment></w:custom>` +
+        '</w:comments>',
+    ),
+  );
+  return archive.save();
+}
+
+const leanCheckerPath = path.resolve(
+  __dirname,
+  '../../../../verification/lean/.lake/build/bin/leanDocxChecker',
+);
+if (process.env.SAFE_DOCX_REQUIRE_LEAN_CHECKER === '1' &&
+    !fs.existsSync(leanCheckerPath)) {
+  throw new Error(`required compiled Lean checker is missing: ${leanCheckerPath}`);
+}
+const describeWithCompiledLean = fs.existsSync(leanCheckerPath) ? describe : describe.skip;
+
+describeWithCompiledLean('NVCA full-document Lean comment stack safety', () => {
+  test
+    .openspec('[LEAN-COMMENT-11] Full real NVCA comment scanning is stack-safe')
+    .conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.4.6' })
+    .conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.18.10' })(
+    'returns structured results for selected comments and nested-definition mutations',
+    async () => {
+      const sourcePath = path.resolve(
+        __dirname,
+        '../../../../tests/test_documents/nvca-regression/source.docx',
+      );
+      const original = await addSelectedCommentsPart(fs.readFileSync(sourcePath));
+      const originalArchive = await DocxArchive.load(original);
+      const originalXml = await originalArchive.getDocumentXml();
+      expect(originalXml.length).toBeGreaterThan(350_000);
+      const originalTree = parseDocumentXml(originalXml);
+      const originalBody =
+        originalTree.getElementsByTagNameNS(OOXML.W_NS, 'body').item(0);
+      expect(originalBody).not.toBeNull();
+      const originalPart: OpcPart = {
+        uri: 'word/document.xml',
+        contentType:
+          'application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml',
+      };
+      const originalAtomCount =
+        atomizeTree(originalBody!, [], originalPart).atoms.length;
+      expect(originalAtomCount).toBeGreaterThanOrEqual(41_000);
+      expect(originalAtomCount).toBe(41_615);
+
+      const revised = await deriveMinimallyEditedRevision(original);
+      const atomizerLogs: string[] = [];
+      const logSpy = vi.spyOn(console, 'log').mockImplementation((...values) => {
+        atomizerLogs.push(values.map(String).join(' '));
+      });
+      let comparison!: Awaited<ReturnType<typeof compareDocuments>>;
+      try {
+        comparison = await compareDocuments(original, revised, {
+          engine: 'atomizer',
+          reconstructionMode: 'inplace',
+          author: 'RegressionTest',
+          leanXmlVerifier: {
+            enabled: true,
+            executablePath: leanCheckerPath,
+            timeoutMs: 120_000,
+          },
+        });
+      } finally {
+        logSpy.mockRestore();
+      }
+      expect(atomizerLogs.some((message) =>
+        message.includes('word-split to 41621, punct-merged to 41621'),
+      )).toBe(true);
+      expect(
+        comparison.documentIntegrity?.status,
+        JSON.stringify(comparison.documentIntegrity, null, 2),
+      ).toBe('passed');
+      expect(comparison.reconstructionModeUsed).toBe('inplace');
+      expect(comparison.documentIntegrity?.checkerProtocolVersion).toBe(6);
+      expect(comparison.documentIntegrity?.commentInventories?.every((inventory) =>
+        inventory.status === 'passed' && inventory.definitions === 1,
+      )).toBe(true);
+
+      const revisedXml = await (await DocxArchive.load(revised)).getDocumentXml();
+      const comparedXml =
+        await (await DocxArchive.load(comparison.document)).getDocumentXml();
+      const runMutation = async (rawId: string | undefined) =>
+        runLeanXmlTripleVerifier({
+          originalDocx: original,
+          revisedDocx: revised,
+          comparedDocx: await addNestedCommentDefinition(comparison.document, rawId),
+          legacyDocumentXml: {
+            original: originalXml,
+            revised: revisedXml,
+            compared: comparedXml,
+          },
+          reconstructionMode: 'inplace',
+          options: { executablePath: leanCheckerPath, timeoutMs: 120_000 },
+        });
+
+      for (const rawId of [undefined, 'seven', '1'.repeat(65)]) {
+        const certificate = await runMutation(rawId);
+        expect(
+          certificate.status,
+          `${rawId ?? 'missing'}: ${certificate.reason}`,
+        ).toBe('failed');
+        expect(certificate.checkerProtocolVersion).toBe(6);
+        expect(certificate.commentIntegrityFailures).toEqual([
+          expect.objectContaining({
+            side: 'compared',
+            code: 'COMMENT_DEFINITION_NOT_DIRECT',
+          }),
+        ]);
+        expect(certificate.commentIntegrityFailures?.[0]?.canonicalId)
+          .toBeUndefined();
+      }
+    },
+    300_000,
+  );
 });

--- a/scripts/check_lean_comment_memory.mjs
+++ b/scripts/check_lean_comment_memory.mjs
@@ -1,0 +1,180 @@
+import { spawn } from 'node:child_process';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import JSZip from 'jszip';
+
+const W_NS =
+  'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const R_NS =
+  'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const PAYLOAD_BYTES = 16_775_168;
+const MAX_RSS_BYTES = 1.5 * 1024 * 1024 * 1024;
+const TIMEOUT_MS = 120_000;
+const CHECKER = resolve(
+  'verification/lean/.lake/build/bin/leanDocxChecker',
+);
+
+function packageXml(payloadKind) {
+  if (payloadKind === 'small') {
+    return `<w:comments xmlns:w="${W_NS}">` +
+      '<w:comment w:id="7"><w:p/></w:comment></w:comments>';
+  }
+  const alphabet =
+    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  const output = Buffer.allocUnsafe(PAYLOAD_BYTES);
+  let state = payloadKind === 'text' ? 0x7101 : 0x7102;
+  for (let index = 0; index < output.length; index++) {
+    if (index % 4 === 0) {
+      state ^= state << 13;
+      state ^= state >>> 17;
+      state ^= state << 5;
+      output[index] = alphabet.charCodeAt((state >>> 0) % alphabet.length);
+    } else {
+      output[index] = 120;
+    }
+  }
+  const payload = output.toString('ascii');
+  const comment = payloadKind === 'text'
+    ? `<w:comment w:id="7"><w:p><w:r><w:t>${payload}</w:t></w:r></w:p></w:comment>`
+    : `<w:comment w:id="7" w:author="${payload}"><w:p/></w:comment>`;
+  return `<w:comments xmlns:w="${W_NS}">${comment}</w:comments>`;
+}
+
+async function buildPackage(payloadKind) {
+  const zip = new JSZip();
+  zip.file(
+    '[Content_Types].xml',
+    '<?xml version="1.0" encoding="UTF-8"?>' +
+      '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">' +
+      '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+      '<Default Extension="xml" ContentType="application/xml"/>' +
+      '</Types>',
+  );
+  zip.file(
+    'word/document.xml',
+    `<w:document xmlns:w="${W_NS}"><w:body><w:p><w:r>` +
+      '<w:commentReference w:id="7"/>' +
+      '</w:r></w:p><w:sectPr/></w:body></w:document>',
+  );
+  zip.file(
+    'word/_rels/document.xml.rels',
+    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+      `<Relationship Id="rIdComments" Type="${R_NS}/comments" Target="comments.xml"/>` +
+      '</Relationships>',
+  );
+  zip.file('word/comments.xml', packageXml(payloadKind));
+  for (const entry of Object.values(zip.files)) {
+    if (entry.dir) delete zip.files[entry.name];
+  }
+  return zip.generateAsync({
+    type: 'nodebuffer',
+    compression: 'DEFLATE',
+    compressionOptions: { level: 6 },
+  });
+}
+
+function timingCommand() {
+  if (process.platform === 'darwin') {
+    return 'ulimit -s 8192; exec /usr/bin/time -l "$SAFE_DOCX_CHECKER"';
+  }
+  return 'ulimit -s 8192; exec /usr/bin/time -f "SAFE_DOCX_TIME:%e:%M" "$SAFE_DOCX_CHECKER"';
+}
+
+function parseMetrics(stderr) {
+  if (process.platform === 'darwin') {
+    const wall = /\s([0-9.]+) real/.exec(stderr);
+    const rss = /(\d+)\s+maximum resident set size/.exec(stderr);
+    if (!wall || !rss) throw new Error(`unable to parse macOS time output:\n${stderr}`);
+    return { wallSeconds: Number(wall[1]), peakRssBytes: Number(rss[1]) };
+  }
+  const match = /SAFE_DOCX_TIME:([0-9.]+):(\d+)/.exec(stderr);
+  if (!match) throw new Error(`unable to parse GNU time output:\n${stderr}`);
+  return {
+    wallSeconds: Number(match[1]),
+    peakRssBytes: Number(match[2]) * 1024,
+  };
+}
+
+function runChecker(request, scratch) {
+  return new Promise((resolveRun, reject) => {
+    const child = spawn('/bin/sh', ['-c', timingCommand()], {
+      detached: true,
+      env: {
+        ...process.env,
+        SAFE_DOCX_CHECKER: CHECKER,
+        SAFE_DOCX_LEAN_TEMP_ROOT: scratch,
+      },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const stdout = [];
+    const stderr = [];
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      process.kill(-child.pid, 'SIGKILL');
+    }, TIMEOUT_MS);
+    child.stdout.on('data', (chunk) => stdout.push(chunk));
+    child.stderr.on('data', (chunk) => stderr.push(chunk));
+    child.on('error', reject);
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      const errorText = Buffer.concat(stderr).toString('utf8');
+      if (timedOut) {
+        reject(new Error(`checker exceeded ${TIMEOUT_MS}ms`));
+      } else if (code !== 0) {
+        reject(new Error(
+          `checker exited ${code}:\n${errorText}\n${Buffer.concat(stdout)}`,
+        ));
+      } else {
+        resolveRun({
+          response: Buffer.concat(stdout).toString('utf8'),
+          ...parseMetrics(errorText),
+        });
+      }
+    });
+    child.stdin.end(JSON.stringify(request));
+  });
+}
+
+async function measure(payloadKind) {
+  const scratch = await mkdtemp(join(tmpdir(), `safe-docx-lean-${payloadKind}-`));
+  try {
+    const path = join(scratch, `${payloadKind}.docx`);
+    const smallPath = join(scratch, 'small.docx');
+    await Promise.all([
+      writeFile(path, await buildPackage(payloadKind)),
+      writeFile(smallPath, await buildPackage('small')),
+    ]);
+    const result = await runChecker({
+      protocolVersion: 6,
+      originalDocxPath: path,
+      revisedDocxPath: smallPath,
+      comparedDocxPath: smallPath,
+    }, scratch);
+    const parsed = JSON.parse(result.response);
+    if (parsed.protocolVersion !== 6 || parsed.passed !== true) {
+      throw new Error(`${payloadKind} checker response was not a protocol-v6 pass`);
+    }
+    if (result.peakRssBytes >= MAX_RSS_BYTES) {
+      throw new Error(
+        `${payloadKind} peak RSS ${result.peakRssBytes} exceeded ${MAX_RSS_BYTES}`,
+      );
+    }
+    return result;
+  } finally {
+    await rm(scratch, { recursive: true, force: true });
+  }
+}
+
+for (const payloadKind of ['text', 'attribute']) {
+  const result = await measure(payloadKind);
+  console.log(JSON.stringify({
+    payloadKind,
+    payloadBytes: PAYLOAD_BYTES,
+    wallSeconds: result.wallSeconds,
+    peakRssBytes: result.peakRssBytes,
+    maxRssBytes: MAX_RSS_BYTES,
+    timeoutMs: TIMEOUT_MS,
+  }));
+}

--- a/scripts/check_lean_comment_semantics_dependencies.mjs
+++ b/scripts/check_lean_comment_semantics_dependencies.mjs
@@ -6,6 +6,8 @@ const leanDirectory = fileURLToPath(
   new URL('../verification/lean/', import.meta.url),
 );
 const semanticTargets = [
+  'Tier2.CommentReferenceIntegrity.Typed.typedByteArrayEqCheck_true_iff',
+  'Tier2.CommentReferenceIntegrity.Typed.typedXmlEventListEqCheck_true_iff',
   'Tier2.CommentReferenceIntegrity.Typed.typed_comment_selector_result_sound',
   'Tier2.CommentReferenceIntegrity.Typed.typed_comment_selection_to_realization_sound',
   'Tier2.CommentReferenceIntegrity.Typed.typed_admitted_comment_source_set_complete',

--- a/scripts/check_lean_empty_axiom_targets.mjs
+++ b/scripts/check_lean_empty_axiom_targets.mjs
@@ -8,6 +8,8 @@ const targets = [
   'Tier2.NoteReferenceIntegrity.package_note_reference_integrity_sound',
   'Tier2.NoteReferenceIntegrity.incomplete_partition_zero_evidence_sound',
   'Tier2.NoteReferenceIntegrity.note_integrity_aggregate_pass_sound',
+  'Tier2.CommentReferenceIntegrity.Typed.typedByteArrayEqCheck_true_iff',
+  'Tier2.CommentReferenceIntegrity.Typed.typedXmlEventListEqCheck_true_iff',
   'Tier2.CommentReferenceIntegrity.Typed.typed_comment_selector_result_sound',
   'Tier2.CommentReferenceIntegrity.Typed.typed_comment_selection_to_realization_sound',
   'Tier2.CommentReferenceIntegrity.Typed.typed_admitted_comment_source_set_complete',

--- a/scripts/check_lean_xml_checker_coverage.mjs
+++ b/scripts/check_lean_xml_checker_coverage.mjs
@@ -10,6 +10,15 @@ const noteIntegrityPath = join(root,
   'verification/lean/Tier2/NoteReferenceIntegrity/Semantics.lean');
 const commentIntegrityPath = join(root,
   'verification/lean/Tier2/CommentReferenceIntegrity/Semantics.lean');
+const typedCommentIntegrityPath = join(root,
+  'verification/lean/Tier2/CommentReferenceIntegrity/TypedSemantics.lean');
+const typedCommentStackWitnessPath = join(root,
+  'verification/lean/TypedCommentStackSafetyWitnesses.lean');
+const typedCommentAxiomAuditPath = join(root,
+  'verification/lean/TypedCommentAxiomAudit.lean');
+const commentMemoryPath = join(root,
+  'scripts/check_lean_comment_memory.mjs');
+const leanWorkflowPath = join(root, '.github/workflows/lean-build.yml');
 const noteWitnessesPath = join(root, 'verification/lean/Tier2/NoteReferenceIntegrityWitnesses.lean');
 const executablePath = join(root, 'verification/lean/LeanDocxChecker.lean');
 const ordinaryEnvelopePath = join(root, 'verification/lean/ProtocolV6OrdinaryEnvelopeWitness.lean');
@@ -20,6 +29,11 @@ const lean = readFileSync(leanPath, 'utf8');
 const selector = readFileSync(selectorPath, 'utf8');
 const noteIntegrity = readFileSync(noteIntegrityPath, 'utf8');
 const commentIntegrity = readFileSync(commentIntegrityPath, 'utf8');
+const typedCommentIntegrity = readFileSync(typedCommentIntegrityPath, 'utf8');
+const typedCommentStackWitness = readFileSync(typedCommentStackWitnessPath, 'utf8');
+const typedCommentAxiomAudit = readFileSync(typedCommentAxiomAuditPath, 'utf8');
+const commentMemory = readFileSync(commentMemoryPath, 'utf8');
+const leanWorkflow = readFileSync(leanWorkflowPath, 'utf8');
 const noteWitnesses = readFileSync(noteWitnessesPath, 'utf8');
 const executable = readFileSync(executablePath, 'utf8');
 const ordinaryEnvelope = readFileSync(ordinaryEnvelopePath, 'utf8');
@@ -279,6 +293,114 @@ for (const required of [
 ]) {
   if (!commentIntegrity.includes(required)) {
     errors.push(`protocol v6 comment-integrity coverage requires ${required}`);
+  }
+}
+
+const typedExtractionBody = typedCommentIntegrity.slice(
+  typedCommentIntegrity.indexOf('def typedExtractionCheck'),
+  typedCommentIntegrity.indexOf('def TypedExtractionOf'),
+);
+const typedParsedPartBody = typedCommentIntegrity.slice(
+  typedCommentIntegrity.indexOf('def typedParsedPartCheck'),
+  typedCommentIntegrity.indexOf('def TypedParsedPartOf'),
+);
+const typedProductionEventBody = executable.slice(
+  executable.indexOf('def typedXmlEventOfProduction'),
+  executable.indexOf('def typedJsonOfProductionFuel'),
+);
+if (/\.data\.toList\s*=\s*/u.test(typedExtractionBody) ||
+    /\.data\.toList\s*=\s*/u.test(typedParsedPartBody)) {
+  errors.push('typed package/part admission must not use structural List equality');
+}
+if (/\.events\.(?:map|mapTR)\s+typedXmlEventIdentity/u.test(typedParsedPartBody)) {
+  errors.push('typed parsed-part admission must use the custom event-sequence comparator');
+}
+if (/attributes\.map\s/u.test(typedProductionEventBody) ||
+    !/attributes\.mapTR\s/u.test(typedProductionEventBody)) {
+  errors.push('production XML attribute conversion must use List.mapTR');
+}
+for (const comparator of [
+  'typedByteArrayEqLoop',
+  'typedByteListEqCheck',
+  'typedXmlAttributeListEqCheck',
+  'typedXmlEventEqCheck',
+  'typedXmlEventListEqCheck',
+]) {
+  const guarded = new RegExp(
+    `set_option backward\\.match\\.sparseCases false in\\s+def ${comparator}\\b`,
+    'u',
+  );
+  if (!guarded.test(typedCommentIntegrity)) {
+    errors.push(`${comparator} must disable sparse-case code generation`);
+  }
+}
+if (!typedCommentIntegrity.includes('value : BoundedByteArray') ||
+    !typedProductionEventBody.includes(
+      'value := typedBoundedByteArrayOfString item.value')) {
+  errors.push('typed XML attribute values must remain ByteArray-backed on admission');
+}
+if (!typedCommentIntegrity.includes(
+  'typedByteArrayEqLoop left right left.size') ||
+    typedCommentIntegrity.includes(
+      'typedByteListEqCheck left.data.toList right.data.toList')) {
+  errors.push('typed ByteArray equality must use the indexed comparator without List conversion');
+}
+if (!/def typedByteArrayGetFast[\s\S]{0,180}bytes\.get! index/u
+    .test(typedCommentIntegrity) ||
+    !/@\[implemented_by typedByteArrayGetFast\][\s\S]{0,100}def typedByteArrayGet\b/u
+      .test(typedCommentIntegrity)) {
+  errors.push('typed ByteArray equality must compile to the bounded constant-time accessor');
+}
+for (const required of [
+  'asciiXmlLiteralFast',
+  'xml.drop 1 |>.toString',
+]) {
+  if (!lean.includes(required)) {
+    errors.push(`large XML parser path requires ${required}`);
+  }
+}
+if (/def stripLeadingUtf8Bom[\s\S]{0,180}xml\.toList/u.test(lean)) {
+  errors.push('BOM handling must not convert the complete XML input to List');
+}
+for (const required of [
+  'readBoundedChunks',
+  'ByteArray.emptyWithCapacity total',
+  'crc32Loop bytes bytes.size 0',
+]) {
+  if (!executable.includes(required)) {
+    errors.push(`bounded extraction path requires ${required}`);
+  }
+}
+for (const required of [
+  'PAYLOAD_BYTES = 16_775_168',
+  'MAX_RSS_BYTES = 1.5 * 1024 * 1024 * 1024',
+  'TIMEOUT_MS = 120_000',
+  "['text', 'attribute']",
+]) {
+  if (!commentMemory.includes(required)) {
+    errors.push(`near-limit memory acceptance requires ${required}`);
+  }
+}
+for (const theorem of [
+  'typedByteArrayEqCheck_true_iff',
+  'typedXmlEventListEqCheck_true_iff',
+]) {
+  if (!typedCommentAxiomAudit.includes(`#print axioms Tier2.CommentReferenceIntegrity.Typed.${theorem}`)) {
+    errors.push(`typed comment axiom audit omits ${theorem}`);
+  }
+}
+if (!typedCommentStackWitness.includes('stackWitnessPayloadSize : Nat := 400000') ||
+    !typedCommentStackWitness.includes('native_decide')) {
+  errors.push('native typed comment stack witness must execute 400000-byte payloads');
+}
+for (const command of [
+  'lake env lean TypedCommentStackSafetyWitnesses.lean',
+  'npm run check:lean-comment-memory',
+  'src/integration/nvca-structural-regression.test.ts',
+  "SAFE_DOCX_REQUIRE_LEAN_CHECKER: '1'",
+]) {
+  if (!leanWorkflow.includes(command)) {
+    errors.push(`Lean CI workflow omits required stack-safety gate: ${command}`);
   }
 }
 

--- a/verification/lean/AxiomAudit.lean
+++ b/verification/lean/AxiomAudit.lean
@@ -38,6 +38,8 @@ import LeanDocxChecker
 #print axioms Tier2.NoteReferenceIntegrity.production_note_integrity_sound
 #print axioms Tier2.NoteReferenceIntegrity.production_aggregate_pass_exact
 #print axioms Tier2.NoteReferenceIntegrity.production_protocol_v5_serialization_exact
+#print axioms Tier2.CommentReferenceIntegrity.Typed.typedByteArrayEqCheck_true_iff
+#print axioms Tier2.CommentReferenceIntegrity.Typed.typedXmlEventListEqCheck_true_iff
 #print axioms Tier2.CommentReferenceIntegrity.Typed.typed_comment_selector_result_sound
 #print axioms Tier2.CommentReferenceIntegrity.Typed.typed_comment_selection_to_realization_sound
 #print axioms Tier2.CommentReferenceIntegrity.Typed.typed_admitted_comment_source_set_complete

--- a/verification/lean/CommentSemanticDependencyAudit.lean
+++ b/verification/lean/CommentSemanticDependencyAudit.lean
@@ -416,6 +416,22 @@ def productionAllowedRoots : List Name := [
 
 run_cmd do
   let environment ← getEnv
+  for (target, roots) in [
+      ( ``Tier2.CommentReferenceIntegrity.Typed.typedByteArrayEqCheck_true_iff
+      , [ ``Tier2.CommentReferenceIntegrity.Typed.typedByteArrayEqCheck
+        , ``Tier2.CommentReferenceIntegrity.Typed.typedByteArrayEqCheck_sound
+        , ``Tier2.CommentReferenceIntegrity.Typed.typedByteArrayEqCheck_refl ])
+    , ( ``Tier2.CommentReferenceIntegrity.Typed.typedXmlEventListEqCheck_true_iff
+      , [ ``Tier2.CommentReferenceIntegrity.Typed.typedXmlEventListEqCheck
+        , ``Tier2.CommentReferenceIntegrity.Typed.typedXmlEventListEqCheck_sound
+        , ``Tier2.CommentReferenceIntegrity.Typed.typedXmlEventListEqCheck_complete ])
+    ] do
+    requireNoNamespace target (completeClosure environment [target])
+      [`String, `Lean.Json, `IO, `propext, `Quot.sound,
+       `Classical.choice]
+    requireExactClosure environment target roots
+    requireAuditSelfTests environment target roots
+
   for (target, signature, roots) in semanticTargets do
     requireExactSignature environment target signature
     requireNoNamespace target (completeClosure environment [target])
@@ -472,6 +488,8 @@ run_cmd do
 
 end CommentSemanticDependencyAudit
 
+#print axioms Tier2.CommentReferenceIntegrity.Typed.typedByteArrayEqCheck_true_iff
+#print axioms Tier2.CommentReferenceIntegrity.Typed.typedXmlEventListEqCheck_true_iff
 #print axioms Tier2.CommentReferenceIntegrity.Typed.typed_comment_selector_result_sound
 #print axioms Tier2.CommentReferenceIntegrity.Typed.typed_comment_selection_to_realization_sound
 #print axioms Tier2.CommentReferenceIntegrity.Typed.typed_admitted_comment_source_set_complete

--- a/verification/lean/LeanDocxChecker.lean
+++ b/verification/lean/LeanDocxChecker.lean
@@ -106,10 +106,10 @@ def typedXmlEventOfProduction (eventOrdinal : Nat) : XmlEvent → TypedXmlEvent
   | .startElement uri localName attributes depth selfClosing =>
       .startElement (typedBoundedBytesOfString uri)
         (typedBoundedBytesOfString localName)
-        (attributes.map fun item => {
+        (attributes.mapTR fun item => {
           namespaceUri := typedBoundedBytesOfString item.uri
           localName := typedBoundedBytesOfString item.localName
-          value := typedBoundedBytesOfString item.value
+          value := typedBoundedByteArrayOfString item.value
         })
         depth selfClosing eventOrdinal
   | .endElement uri localName depth =>
@@ -381,7 +381,8 @@ def typedBoundedIdentityBytes (value : BoundedBytes) : List UInt8 :=
 def typedAttributeIdentityBytes (attr : TypedXmlAttribute) : List UInt8 :=
   typedBoundedIdentityBytes attr.namespaceUri ++
   typedBoundedIdentityBytes attr.localName ++
-  typedBoundedIdentityBytes attr.value
+  encodeNatDigits attr.value.bytes.size ++ [UInt8.ofNat 58] ++
+  attr.value.bytes.data.toList
 
 def typedXmlEventIdentityBytes : TypedXmlEvent → List UInt8
   | .startElement namespaceUri localName attributes depth selfClosing ordinal =>
@@ -677,13 +678,19 @@ structure BoundedOutput where
   stdout : ByteArray
   stderr : ByteArray
 
-partial def readBounded (handle : IO.FS.Handle) (limit : Nat) (acc : ByteArray := .empty) :
-    IO ByteArray := do
+partial def readBoundedChunks (handle : IO.FS.Handle) (limit total : Nat)
+    (chunks : List ByteArray) : IO (Nat × List ByteArray) := do
   let chunk ← handle.read 4096
-  if chunk.isEmpty then return acc
-  let next := acc ++ chunk
-  if next.size > limit then throw (IO.userError s!"process output exceeds {limit} bytes")
-  readBounded handle limit next
+  if chunk.isEmpty then return (total, chunks)
+  let nextTotal := total + chunk.size
+  if nextTotal > limit then
+    throw (IO.userError s!"process output exceeds {limit} bytes")
+  readBoundedChunks handle limit nextTotal (chunk :: chunks)
+
+def readBounded (handle : IO.FS.Handle) (limit : Nat) : IO ByteArray := do
+  let (total, reversedChunks) ← readBoundedChunks handle limit 0 []
+  return reversedChunks.reverse.foldl ByteArray.append
+    (ByteArray.emptyWithCapacity total)
 
 def runBounded (cmd : String) (args : Array String) (stdoutLimit : Nat) : IO BoundedOutput := do
   let child ← IO.Process.spawn {
@@ -700,14 +707,28 @@ def runBounded (cmd : String) (args : Array String) (stdoutLimit : Nat) : IO Bou
     discard child.wait
     throw error
 
+def crc32Bit (value : Nat) : Nat :=
+  if value % 2 == 1 then Nat.xor (value / 2) 0xedb88320 else value / 2
+
 def crc32Step (crc byte : Nat) : Nat :=
-  (List.range 8).foldl (fun value _ =>
-    if value % 2 == 1 then Nat.xor (value / 2) 0xedb88320 else value / 2)
-    (Nat.xor crc byte)
+  let bit0 := crc32Bit (Nat.xor crc byte)
+  let bit1 := crc32Bit bit0
+  let bit2 := crc32Bit bit1
+  let bit3 := crc32Bit bit2
+  let bit4 := crc32Bit bit3
+  let bit5 := crc32Bit bit4
+  let bit6 := crc32Bit bit5
+  crc32Bit bit6
+
+set_option backward.match.sparseCases false in
+def crc32Loop (bytes : ByteArray) : Nat → Nat → Nat → Nat
+  | 0, _, crc => crc
+  | remaining + 1, index, crc =>
+      crc32Loop bytes remaining (index + 1)
+        (crc32Step crc (bytes.get! index).toNat)
 
 def crc32 (bytes : ByteArray) : Nat :=
-  Nat.xor (bytes.toList.foldl (fun crc byte => crc32Step crc byte.toNat) 0xffffffff)
-    0xffffffff
+  Nat.xor (crc32Loop bytes bytes.size 0 0xffffffff) 0xffffffff
 
 def crc32Hex (bytes : ByteArray) : String :=
   let digits := Nat.toDigits 16 (crc32 bytes)
@@ -6818,15 +6839,15 @@ def typedExtractionOfProduction
 }
 
 def typedCommentRealizationOfProduction
-    (part : LoadedCommentPart) : TypedCommentRealization := {
-  selected := typedSelectedCommentOfProduction part.identity
-  entry := typedEntryOfProduction part.parseEvidence.extraction.entry
-  extraction := typedExtractionOfProduction part.parseEvidence.extraction
-  retainedParsedEvents :=
-    part.parseEvidence.parsed.events.zipIdx.map fun item =>
-      typedXmlEventOfProduction item.2 item.1
-  parsed := typedParsedPartOfProduction part.parseEvidence
-}
+    (part : LoadedCommentPart) : TypedCommentRealization :=
+  let parsed := typedParsedPartOfProduction part.parseEvidence
+  {
+    selected := typedSelectedCommentOfProduction part.identity
+    entry := typedEntryOfProduction part.parseEvidence.extraction.entry
+    extraction := typedExtractionOfProduction part.parseEvidence.extraction
+    retainedParsedEvents := parsed.events
+    parsed
+  }
 
 def typedCanonicalIdOfRaw (raw : Option String) :
     Option TypedCanonicalId :=

--- a/verification/lean/Tier2/CommentReferenceIntegrity/TypedSemantics.lean
+++ b/verification/lean/Tier2/CommentReferenceIntegrity/TypedSemantics.lean
@@ -63,7 +63,7 @@ structure TypedEocd where
 structure TypedXmlAttribute where
   namespaceUri : BoundedBytes
   localName : BoundedBytes
-  value : BoundedBytes
+  value : BoundedByteArray
   deriving DecidableEq
 
 inductive TypedXmlEvent
@@ -113,6 +113,252 @@ def typedByteAt? (bytes : ByteArray) (offset : Nat) : Option Nat :=
   if offset < bytes.size then
     (bytes.extract offset (offset + 1)).data.toList.head?.map UInt8.toNat
   else none
+
+set_option backward.match.sparseCases false in
+def typedNatEqCheck : Nat → Nat → Bool
+  | 0, 0 => true
+  | left + 1, right + 1 => typedNatEqCheck left right
+  | _, _ => false
+
+set_option backward.match.sparseCases false in
+def typedBoolEqCheck : Bool → Bool → Bool
+  | false, false => true
+  | true, true => true
+  | _, _ => false
+
+def typedNativeNatEqCheck (left right : Nat) : Bool :=
+  if left = right then true else false
+
+def typedNativeUInt8EqCheck (left right : UInt8) : Bool :=
+  if left = right then true else false
+
+set_option backward.match.sparseCases false in
+def typedNatListEqCheck : List Nat → List Nat → Bool
+  | [], [] => true
+  | left :: leftRest, right :: rightRest =>
+      typedNatEqCheck left right && typedNatListEqCheck leftRest rightRest
+  | _, _ => false
+
+set_option backward.match.sparseCases false in
+def typedByteListEqCheck : List UInt8 → List UInt8 → Bool
+  | [], [] => true
+  | left :: leftRest, right :: rightRest =>
+      typedNatEqCheck left.toNat right.toNat &&
+        typedByteListEqCheck leftRest rightRest
+  | _, _ => false
+
+def typedByteArrayGetFast (bytes : ByteArray) (index : Nat)
+    (_inBounds : index < bytes.size) : UInt8 :=
+  bytes.get! index
+
+set_option backward.match.sparseCases false in
+@[implemented_by typedByteArrayGetFast]
+def typedByteArrayGet (bytes : ByteArray) (index : Nat)
+    (inBounds : index < bytes.size) : UInt8 :=
+  bytes.data[index]'(by
+    simpa only [ByteArray.size_data] using inBounds)
+
+set_option backward.match.sparseCases false in
+def typedByteArrayEqLoop (left right : ByteArray) : Nat → Bool
+  | 0 => true
+  | index + 1 =>
+      if leftInBounds : index < left.size then
+        if rightInBounds : index < right.size then
+          typedNativeUInt8EqCheck
+              (typedByteArrayGet left index leftInBounds)
+              (typedByteArrayGet right index rightInBounds) &&
+            typedByteArrayEqLoop left right index
+        else false
+      else false
+
+def typedByteArrayEqCheck (left right : ByteArray) : Bool :=
+  typedNativeNatEqCheck left.size right.size &&
+    typedByteArrayEqLoop left right left.size
+
+theorem typedBoolAndTrueParts :
+    ∀ left right : Bool, (left && right) = true →
+      left = true ∧ right = true
+  | false, false, h => nomatch h
+  | false, true, h => nomatch h
+  | true, false, h => nomatch h
+  | true, true, _ => ⟨rfl, rfl⟩
+
+theorem typedNatEqCheck_refl : ∀ value,
+    typedNatEqCheck value value = true
+  | 0 => rfl
+  | Nat.succ value => typedNatEqCheck_refl value
+
+theorem typedNatEqCheck_sound : ∀ left right,
+    typedNatEqCheck left right = true → left = right
+  | 0, 0, _ => rfl
+  | 0, _ + 1, h => nomatch h
+  | _ + 1, 0, h => nomatch h
+  | left + 1, right + 1, h =>
+      congrArg Nat.succ (typedNatEqCheck_sound left right h)
+
+theorem typedNatEqCheck_true_iff (left right : Nat) :
+    typedNatEqCheck left right = true ↔ left = right := by
+  constructor
+  · exact typedNatEqCheck_sound left right
+  · intro h
+    subst right
+    exact typedNatEqCheck_refl left
+
+theorem typedNativeNatEqCheck_refl (value : Nat) :
+    typedNativeNatEqCheck value value = true := by
+  unfold typedNativeNatEqCheck
+  split
+  · rfl
+  · contradiction
+
+theorem typedNativeNatEqCheck_sound (left right : Nat)
+    (h : typedNativeNatEqCheck left right = true) : left = right := by
+  unfold typedNativeNatEqCheck at h
+  split at h
+  · assumption
+  · contradiction
+
+theorem typedNativeUInt8EqCheck_refl (value : UInt8) :
+    typedNativeUInt8EqCheck value value = true := by
+  unfold typedNativeUInt8EqCheck
+  split
+  · rfl
+  · contradiction
+
+theorem typedNativeUInt8EqCheck_sound (left right : UInt8)
+    (h : typedNativeUInt8EqCheck left right = true) : left = right := by
+  unfold typedNativeUInt8EqCheck at h
+  split at h
+  · assumption
+  · contradiction
+
+set_option backward.match.sparseCases false in
+theorem typedBoolEqCheck_refl : ∀ value,
+    typedBoolEqCheck value value = true
+  | false => rfl
+  | true => rfl
+
+set_option backward.match.sparseCases false in
+theorem typedBoolEqCheck_sound : ∀ left right,
+    typedBoolEqCheck left right = true → left = right
+  | false, false, _ => rfl
+  | false, true, h => nomatch h
+  | true, false, h => nomatch h
+  | true, true, _ => rfl
+
+theorem typedByteListEqCheck_refl : ∀ values,
+    typedByteListEqCheck values values = true
+  | [] => rfl
+  | _ :: rest => by
+      rw [typedByteListEqCheck, typedNatEqCheck_refl,
+        typedByteListEqCheck_refl rest]
+      rfl
+
+theorem typedByteListEqCheck_sound : ∀ left right,
+    typedByteListEqCheck left right = true → left = right
+  | [], [], _ => rfl
+  | [], _ :: _, h => nomatch h
+  | _ :: _, [], h => nomatch h
+  | left :: leftRest, right :: rightRest, h => by
+      have parts := typedBoolAndTrueParts _ _ h
+      have headEq : left = right :=
+        UInt8.toNat_inj.mp
+          (typedNatEqCheck_sound left.toNat right.toNat parts.1)
+      have restEq :=
+        typedByteListEqCheck_sound leftRest rightRest parts.2
+      rw [headEq, restEq]
+
+theorem typedByteListEqCheck_true_iff (left right : List UInt8) :
+    typedByteListEqCheck left right = true ↔ left = right := by
+  constructor
+  · exact typedByteListEqCheck_sound left right
+  · intro h
+    subst right
+    exact typedByteListEqCheck_refl left
+
+theorem typedByteArrayEqLoop_refl (value : ByteArray) :
+    ∀ count, count ≤ value.size →
+      typedByteArrayEqLoop value value count = true
+  | 0, _ => rfl
+  | count + 1, countLe => by
+      have countLt : count < value.size := countLe
+      rw [typedByteArrayEqLoop, dif_pos countLt, dif_pos countLt,
+        typedNativeUInt8EqCheck_refl,
+        typedByteArrayEqLoop_refl value count (Nat.le_of_lt countLt)]
+      rfl
+
+theorem typedByteArrayEqLoop_sound (left right : ByteArray) :
+    ∀ count, typedByteArrayEqLoop left right count = true →
+      ∀ index, index < count →
+        ∀ (leftInBounds : index < left.size)
+          (rightInBounds : index < right.size),
+          typedByteArrayGet left index leftInBounds =
+            typedByteArrayGet right index rightInBounds
+  | 0, _, _, h, _, _ => nomatch h
+  | count + 1, h, index, indexLt, leftInBounds, rightInBounds => by
+      have countLeftInBounds : count < left.size := by
+        unfold typedByteArrayEqLoop at h
+        split at h
+        · assumption
+        · contradiction
+      have countRightInBounds : count < right.size := by
+        unfold typedByteArrayEqLoop at h
+        rw [dif_pos countLeftInBounds] at h
+        split at h
+        · assumption
+        · contradiction
+      rw [typedByteArrayEqLoop, dif_pos countLeftInBounds,
+        dif_pos countRightInBounds] at h
+      have parts := typedBoolAndTrueParts _ _ h
+      by_cases indexEq : index = count
+      · subst index
+        exact typedNativeUInt8EqCheck_sound _ _ parts.1
+      · exact typedByteArrayEqLoop_sound left right count parts.2 index
+          (Nat.lt_of_le_of_ne (Nat.le_of_lt_succ indexLt) indexEq)
+          leftInBounds rightInBounds
+
+theorem typedByteArrayEqCheck_sound (left right : ByteArray)
+    (h : typedByteArrayEqCheck left right = true) :
+    left.data.toList = right.data.toList := by
+  have parts := typedBoolAndTrueParts _ _ h
+  have sizeEq := typedNativeNatEqCheck_sound _ _ parts.1
+  have elementEq := typedByteArrayEqLoop_sound left right left.size parts.2
+  have dataEq : left.data = right.data := by
+    apply Array.ext
+    · simpa only [ByteArray.size_data] using sizeEq
+    · intro index leftLt rightLt
+      have leftByteLt : index < left.size := by
+        simpa only [ByteArray.size_data] using leftLt
+      have rightByteLt : index < right.size := by
+        simpa only [ByteArray.size_data] using rightLt
+      simpa only [typedByteArrayGet] using
+        elementEq index leftByteLt leftByteLt rightByteLt
+  exact congrArg Array.toList dataEq
+
+theorem typedByteArrayEqCheck_refl (value : ByteArray) :
+    typedByteArrayEqCheck value value = true := by
+  unfold typedByteArrayEqCheck
+  rw [typedNativeNatEqCheck_refl,
+    typedByteArrayEqLoop_refl value value.size (Nat.le_refl _)]
+  rfl
+
+theorem typedByteArrayEqCheck_true_iff (left right : ByteArray) :
+    typedByteArrayEqCheck left right = true ↔
+      left.data.toList = right.data.toList := by
+  constructor
+  · exact typedByteArrayEqCheck_sound left right
+  · intro h
+    cases left with
+    | mk leftData =>
+        cases right with
+        | mk rightData =>
+            cases leftData with
+            | mk leftBytes =>
+                cases rightData with
+                | mk rightBytes =>
+                    change leftBytes = rightBytes at h
+                    subst rightBytes
+                    exact typedByteArrayEqCheck_refl _
 
 def typedUInt16At? (bytes : ByteArray) (offset : Nat) : Option Nat := do
   let low ← typedByteAt? bytes offset
@@ -444,13 +690,12 @@ def typedSelectedEntryCheck
 def typedExtractionCheck (packageBytes : ByteArray) (index : TypedPackageIndex)
     (entry : TypedEntry) (extraction : TypedExtraction) : Bool :=
   typedBinaryIndexCheck packageBytes index &&
-  decide (extraction.packageBytes.data.toList = packageBytes.data.toList) &&
-  decide (extraction.snapshotBytes.data.toList = packageBytes.data.toList) &&
+  typedByteArrayEqCheck extraction.packageBytes packageBytes &&
+  typedByteArrayEqCheck extraction.snapshotBytes packageBytes &&
   typedSelectedEntryCheck index entry.name entry &&
   typedEntryMetadataCheck extraction.entry entry &&
-  decide (extraction.compressedSlice.data.toList =
-    (byteArraySlice packageBytes
-      entry.dataOffset entry.localSpanEnd).data.toList) &&
+  typedByteArrayEqCheck extraction.compressedSlice
+    (byteArraySlice packageBytes entry.dataOffset entry.localSpanEnd) &&
   decide (extraction.compressedSlice.size = entry.compressedSize) &&
   decide (extraction.expandedBytes.size = entry.expandedSize) &&
   decide (entry.localHeaderOffset ≤ entry.dataOffset) &&
@@ -484,23 +729,393 @@ def typedXmlEventIdentity : TypedXmlEvent → TypedXmlEventIdentity
       .startElement namespaceUri.bytes localName.bytes
         (attributes.map fun attr =>
           (attr.namespaceUri.bytes, attr.localName.bytes,
-            attr.value.bytes))
+            attr.value.bytes.data.toList))
         depth selfClosing ordinal
   | .endElement namespaceUri localName depth ordinal =>
       .endElement namespaceUri.bytes localName.bytes depth ordinal
   | .text value depth ordinal =>
       .text value.bytes.data.toList depth ordinal
 
+def typedXmlAttributeEqCheck
+    (left right : TypedXmlAttribute) : Bool :=
+  typedByteListEqCheck left.namespaceUri.bytes right.namespaceUri.bytes &&
+  typedByteListEqCheck left.localName.bytes right.localName.bytes &&
+  typedByteArrayEqCheck left.value.bytes right.value.bytes
+
+set_option backward.match.sparseCases false in
+def typedXmlAttributeListEqCheck :
+    List TypedXmlAttribute → List TypedXmlAttribute → Bool
+  | [], [] => true
+  | left :: leftRest, right :: rightRest =>
+      typedXmlAttributeEqCheck left right &&
+        typedXmlAttributeListEqCheck leftRest rightRest
+  | _, _ => false
+
+set_option backward.match.sparseCases false in
+def typedXmlEventEqCheck : TypedXmlEvent → TypedXmlEvent → Bool
+  | .startElement leftUri leftName leftAttributes leftDepth
+        leftSelfClosing leftOrdinal,
+      .startElement rightUri rightName rightAttributes rightDepth
+        rightSelfClosing rightOrdinal =>
+      typedByteListEqCheck leftUri.bytes rightUri.bytes &&
+      typedByteListEqCheck leftName.bytes rightName.bytes &&
+      typedXmlAttributeListEqCheck leftAttributes rightAttributes &&
+      typedNatEqCheck leftDepth rightDepth &&
+      typedBoolEqCheck leftSelfClosing rightSelfClosing &&
+      typedNatEqCheck leftOrdinal rightOrdinal
+  | .endElement leftUri leftName leftDepth leftOrdinal,
+      .endElement rightUri rightName rightDepth rightOrdinal =>
+      typedByteListEqCheck leftUri.bytes rightUri.bytes &&
+      typedByteListEqCheck leftName.bytes rightName.bytes &&
+      typedNatEqCheck leftDepth rightDepth &&
+      typedNatEqCheck leftOrdinal rightOrdinal
+  | .text leftValue leftDepth leftOrdinal,
+      .text rightValue rightDepth rightOrdinal =>
+      typedByteArrayEqCheck leftValue.bytes rightValue.bytes &&
+      typedNatEqCheck leftDepth rightDepth &&
+      typedNatEqCheck leftOrdinal rightOrdinal
+  | _, _ => false
+
+set_option backward.match.sparseCases false in
+def typedXmlEventListEqCheck :
+    List TypedXmlEvent → List TypedXmlEvent → Bool
+  | [], [] => true
+  | left :: leftRest, right :: rightRest =>
+      typedXmlEventEqCheck left right &&
+        typedXmlEventListEqCheck leftRest rightRest
+  | _, _ => false
+
+theorem typedXmlAttributeEqCheck_sound
+    (left right : TypedXmlAttribute)
+    (h : typedXmlAttributeEqCheck left right = true) :
+    left.namespaceUri.bytes = right.namespaceUri.bytes ∧
+      left.localName.bytes = right.localName.bytes ∧
+      left.value.bytes.data.toList = right.value.bytes.data.toList := by
+  have outer := typedBoolAndTrueParts _ _ h
+  have inner := typedBoolAndTrueParts _ _ outer.1
+  exact ⟨
+    typedByteListEqCheck_sound _ _ inner.1,
+    typedByteListEqCheck_sound _ _ inner.2,
+    typedByteArrayEqCheck_sound _ _ outer.2⟩
+
+theorem typedXmlAttributeEqCheck_complete
+    (left right : TypedXmlAttribute)
+    (h : left.namespaceUri.bytes = right.namespaceUri.bytes ∧
+      left.localName.bytes = right.localName.bytes ∧
+      left.value.bytes.data.toList = right.value.bytes.data.toList) :
+    typedXmlAttributeEqCheck left right = true := by
+  unfold typedXmlAttributeEqCheck
+  rw [h.1, h.2.1, typedByteListEqCheck_refl,
+    typedByteListEqCheck_refl,
+    (typedByteArrayEqCheck_true_iff _ _).mpr h.2.2]
+  rfl
+
+theorem typedXmlAttributeEqCheck_true_iff
+    (left right : TypedXmlAttribute) :
+    typedXmlAttributeEqCheck left right = true ↔
+      left.namespaceUri.bytes = right.namespaceUri.bytes ∧
+      left.localName.bytes = right.localName.bytes ∧
+      left.value.bytes.data.toList = right.value.bytes.data.toList :=
+  ⟨typedXmlAttributeEqCheck_sound left right,
+    typedXmlAttributeEqCheck_complete left right⟩
+
+theorem typedXmlAttributeListEqCheck_sound : ∀ left right,
+    typedXmlAttributeListEqCheck left right = true →
+      left.map (fun item =>
+        (item.namespaceUri.bytes, item.localName.bytes,
+          item.value.bytes.data.toList)) =
+      right.map (fun item =>
+        (item.namespaceUri.bytes, item.localName.bytes,
+          item.value.bytes.data.toList)) := by
+  intro left
+  induction left with
+  | nil =>
+      intro right
+      cases right with
+      | nil => intro; rfl
+      | cons _ _ => intro h; nomatch h
+  | cons item rest ih =>
+      intro right
+      cases right with
+      | nil => intro h; nomatch h
+      | cons rightAttribute rightRest =>
+          intro h
+          have parts := typedBoolAndTrueParts _ _ h
+          have head :=
+            typedXmlAttributeEqCheck_sound item rightAttribute parts.1
+          have tail := ih rightRest parts.2
+          change
+            (item.namespaceUri.bytes, item.localName.bytes,
+                item.value.bytes.data.toList) ::
+                rest.map (fun candidate =>
+                  (candidate.namespaceUri.bytes, candidate.localName.bytes,
+                    candidate.value.bytes.data.toList)) =
+              (rightAttribute.namespaceUri.bytes,
+                rightAttribute.localName.bytes,
+                rightAttribute.value.bytes.data.toList) ::
+                rightRest.map (fun candidate =>
+                  (candidate.namespaceUri.bytes, candidate.localName.bytes,
+                    candidate.value.bytes.data.toList))
+          rw [head.1, head.2.1, head.2.2, tail]
+
+theorem typedXmlAttributeListEqCheck_complete : ∀ left right,
+    left.map (fun item =>
+      (item.namespaceUri.bytes, item.localName.bytes,
+        item.value.bytes.data.toList)) =
+    right.map (fun item =>
+      (item.namespaceUri.bytes, item.localName.bytes,
+        item.value.bytes.data.toList)) →
+    typedXmlAttributeListEqCheck left right = true := by
+  intro left
+  induction left with
+  | nil =>
+      intro right h
+      cases right with
+      | nil => rfl
+      | cons _ _ => nomatch h
+  | cons item rest ih =>
+      intro right
+      cases right with
+      | nil => intro h; nomatch h
+      | cons rightAttribute rightRest =>
+          intro h
+          injection h with head tail
+          injection head with namespaceEq remainingEq
+          injection remainingEq with localNameEq valueEq
+          have headCheck :=
+            typedXmlAttributeEqCheck_complete item rightAttribute
+              ⟨namespaceEq, localNameEq, valueEq⟩
+          have tailCheck := ih rightRest tail
+          rw [typedXmlAttributeListEqCheck, headCheck, tailCheck]
+          rfl
+
+theorem typedXmlAttributeListEqCheck_true_iff (left right) :
+    typedXmlAttributeListEqCheck left right = true ↔
+      left.map (fun item =>
+        (item.namespaceUri.bytes, item.localName.bytes,
+          item.value.bytes.data.toList)) =
+      right.map (fun item =>
+        (item.namespaceUri.bytes, item.localName.bytes,
+          item.value.bytes.data.toList)) :=
+  ⟨typedXmlAttributeListEqCheck_sound left right,
+    typedXmlAttributeListEqCheck_complete left right⟩
+
+theorem typedXmlEventEqCheck_sound
+    (left right : TypedXmlEvent)
+    (h : typedXmlEventEqCheck left right = true) :
+    typedXmlEventIdentity left = typedXmlEventIdentity right := by
+  cases left with
+  | startElement leftUri leftName leftAttributes leftDepth
+      leftSelfClosing leftOrdinal =>
+      cases right with
+      | startElement rightUri rightName rightAttributes rightDepth
+          rightSelfClosing rightOrdinal =>
+          have part6 := typedBoolAndTrueParts _ _ h
+          have part5 := typedBoolAndTrueParts _ _ part6.1
+          have part4 := typedBoolAndTrueParts _ _ part5.1
+          have part3 := typedBoolAndTrueParts _ _ part4.1
+          have part2 := typedBoolAndTrueParts _ _ part3.1
+          have uriEq := typedByteListEqCheck_sound _ _ part2.1
+          have nameEq := typedByteListEqCheck_sound _ _ part2.2
+          have attributesEq :=
+            typedXmlAttributeListEqCheck_sound _ _ part3.2
+          have depthEq := typedNatEqCheck_sound _ _ part4.2
+          have selfClosingEq := typedBoolEqCheck_sound _ _ part5.2
+          have ordinalEq := typedNatEqCheck_sound _ _ part6.2
+          change TypedXmlEventIdentity.startElement leftUri.bytes leftName.bytes
+              (leftAttributes.map fun item =>
+                (item.namespaceUri.bytes, item.localName.bytes,
+                  item.value.bytes.data.toList))
+              leftDepth leftSelfClosing leftOrdinal =
+            TypedXmlEventIdentity.startElement rightUri.bytes rightName.bytes
+              (rightAttributes.map fun item =>
+                (item.namespaceUri.bytes, item.localName.bytes,
+                  item.value.bytes.data.toList))
+              rightDepth rightSelfClosing rightOrdinal
+          rw [uriEq, nameEq, attributesEq, depthEq, selfClosingEq, ordinalEq]
+      | endElement _ _ _ _ => nomatch h
+      | text _ _ _ => nomatch h
+  | endElement leftUri leftName leftDepth leftOrdinal =>
+      cases right with
+      | startElement _ _ _ _ _ _ => nomatch h
+      | endElement rightUri rightName rightDepth rightOrdinal =>
+          have part4 := typedBoolAndTrueParts _ _ h
+          have part3 := typedBoolAndTrueParts _ _ part4.1
+          have part2 := typedBoolAndTrueParts _ _ part3.1
+          have uriEq := typedByteListEqCheck_sound _ _ part2.1
+          have nameEq := typedByteListEqCheck_sound _ _ part2.2
+          have depthEq := typedNatEqCheck_sound _ _ part3.2
+          have ordinalEq := typedNatEqCheck_sound _ _ part4.2
+          change TypedXmlEventIdentity.endElement leftUri.bytes leftName.bytes
+              leftDepth leftOrdinal =
+            TypedXmlEventIdentity.endElement rightUri.bytes rightName.bytes
+              rightDepth rightOrdinal
+          rw [uriEq, nameEq, depthEq, ordinalEq]
+      | text _ _ _ => nomatch h
+  | text leftValue leftDepth leftOrdinal =>
+      cases right with
+      | startElement _ _ _ _ _ _ => nomatch h
+      | endElement _ _ _ _ => nomatch h
+      | text rightValue rightDepth rightOrdinal =>
+          have part3 := typedBoolAndTrueParts _ _ h
+          have part2 := typedBoolAndTrueParts _ _ part3.1
+          have valueEq := typedByteArrayEqCheck_sound _ _ part2.1
+          have depthEq := typedNatEqCheck_sound _ _ part2.2
+          have ordinalEq := typedNatEqCheck_sound _ _ part3.2
+          change TypedXmlEventIdentity.text leftValue.bytes.data.toList
+              leftDepth leftOrdinal =
+            TypedXmlEventIdentity.text rightValue.bytes.data.toList
+              rightDepth rightOrdinal
+          rw [valueEq, depthEq, ordinalEq]
+
+theorem typedXmlEventEqCheck_complete
+    (left right : TypedXmlEvent)
+    (h : typedXmlEventIdentity left = typedXmlEventIdentity right) :
+    typedXmlEventEqCheck left right = true := by
+  cases left with
+  | startElement leftUri leftName leftAttributes leftDepth
+      leftSelfClosing leftOrdinal =>
+      cases right with
+      | startElement rightUri rightName rightAttributes rightDepth
+          rightSelfClosing rightOrdinal =>
+          injection h with uriEq nameEq attributesEq depthEq
+            selfClosingEq ordinalEq
+          have uriCheck :=
+            typedByteListEqCheck_true_iff _ _ |>.mpr uriEq
+          have nameCheck :=
+            typedByteListEqCheck_true_iff _ _ |>.mpr nameEq
+          have attributesCheck :=
+            typedXmlAttributeListEqCheck_complete _ _ attributesEq
+          have depthCheck :=
+            typedNatEqCheck_true_iff _ _ |>.mpr depthEq
+          have selfClosingCheck : typedBoolEqCheck leftSelfClosing
+              rightSelfClosing = true := by
+            subst rightSelfClosing
+            exact typedBoolEqCheck_refl leftSelfClosing
+          have ordinalCheck :=
+            typedNatEqCheck_true_iff _ _ |>.mpr ordinalEq
+          change
+            (typedByteListEqCheck leftUri.bytes rightUri.bytes &&
+                typedByteListEqCheck leftName.bytes rightName.bytes &&
+                typedXmlAttributeListEqCheck leftAttributes rightAttributes &&
+                typedNatEqCheck leftDepth rightDepth &&
+                typedBoolEqCheck leftSelfClosing rightSelfClosing &&
+                typedNatEqCheck leftOrdinal rightOrdinal) = true
+          rw [uriCheck, nameCheck, attributesCheck, depthCheck,
+            selfClosingCheck, ordinalCheck]
+          rfl
+      | endElement _ _ _ _ => nomatch h
+      | text _ _ _ => nomatch h
+  | endElement leftUri leftName leftDepth leftOrdinal =>
+      cases right with
+      | startElement _ _ _ _ _ _ => nomatch h
+      | endElement rightUri rightName rightDepth rightOrdinal =>
+          injection h with uriEq nameEq depthEq ordinalEq
+          have uriCheck :=
+            typedByteListEqCheck_true_iff _ _ |>.mpr uriEq
+          have nameCheck :=
+            typedByteListEqCheck_true_iff _ _ |>.mpr nameEq
+          have depthCheck :=
+            typedNatEqCheck_true_iff _ _ |>.mpr depthEq
+          have ordinalCheck :=
+            typedNatEqCheck_true_iff _ _ |>.mpr ordinalEq
+          change
+            (typedByteListEqCheck leftUri.bytes rightUri.bytes &&
+                typedByteListEqCheck leftName.bytes rightName.bytes &&
+                typedNatEqCheck leftDepth rightDepth &&
+                typedNatEqCheck leftOrdinal rightOrdinal) = true
+          rw [uriCheck, nameCheck, depthCheck, ordinalCheck]
+          rfl
+      | text _ _ _ => nomatch h
+  | text leftValue leftDepth leftOrdinal =>
+      cases right with
+      | startElement _ _ _ _ _ _ => nomatch h
+      | endElement _ _ _ _ => nomatch h
+      | text rightValue rightDepth rightOrdinal =>
+          injection h with valueEq depthEq ordinalEq
+          have valueCheck : typedByteArrayEqCheck leftValue.bytes
+              rightValue.bytes = true := by
+            exact (typedByteArrayEqCheck_true_iff _ _).mpr valueEq
+          have depthCheck :=
+            typedNatEqCheck_true_iff _ _ |>.mpr depthEq
+          have ordinalCheck :=
+            typedNatEqCheck_true_iff _ _ |>.mpr ordinalEq
+          change
+            (typedByteArrayEqCheck leftValue.bytes rightValue.bytes &&
+                typedNatEqCheck leftDepth rightDepth &&
+                typedNatEqCheck leftOrdinal rightOrdinal) = true
+          rw [valueCheck, depthCheck, ordinalCheck]
+          rfl
+
+theorem typedXmlEventEqCheck_true_iff
+    (left right : TypedXmlEvent) :
+    typedXmlEventEqCheck left right = true ↔
+      typedXmlEventIdentity left = typedXmlEventIdentity right :=
+  ⟨typedXmlEventEqCheck_sound left right,
+    typedXmlEventEqCheck_complete left right⟩
+
+theorem typedXmlEventListEqCheck_sound : ∀ left right,
+    typedXmlEventListEqCheck left right = true →
+      left.map typedXmlEventIdentity = right.map typedXmlEventIdentity := by
+  intro left
+  induction left with
+  | nil =>
+      intro right
+      cases right with
+      | nil => intro; rfl
+      | cons _ _ => intro h; nomatch h
+  | cons event rest ih =>
+      intro right
+      cases right with
+      | nil => intro h; nomatch h
+      | cons rightEvent rightRest =>
+          intro h
+          have parts := typedBoolAndTrueParts _ _ h
+          have head := typedXmlEventEqCheck_sound event rightEvent parts.1
+          have tail := ih rightRest parts.2
+          change typedXmlEventIdentity event ::
+              rest.map typedXmlEventIdentity =
+            typedXmlEventIdentity rightEvent ::
+              rightRest.map typedXmlEventIdentity
+          rw [head, tail]
+
+theorem typedXmlEventListEqCheck_complete : ∀ left right,
+    left.map typedXmlEventIdentity = right.map typedXmlEventIdentity →
+      typedXmlEventListEqCheck left right = true := by
+  intro left
+  induction left with
+  | nil =>
+      intro right h
+      cases right with
+      | nil => rfl
+      | cons _ _ => nomatch h
+  | cons event rest ih =>
+      intro right
+      cases right with
+      | nil => intro h; nomatch h
+      | cons rightEvent rightRest =>
+          intro h
+          injection h with head tail
+          have headCheck :=
+            typedXmlEventEqCheck_complete event rightEvent head
+          have tailCheck := ih rightRest tail
+          rw [typedXmlEventListEqCheck, headCheck, tailCheck]
+          rfl
+
+theorem typedXmlEventListEqCheck_true_iff (left right) :
+    typedXmlEventListEqCheck left right = true ↔
+      left.map typedXmlEventIdentity = right.map typedXmlEventIdentity :=
+  ⟨typedXmlEventListEqCheck_sound left right,
+    typedXmlEventListEqCheck_complete left right⟩
+
 def typedParsedPartCheck (extraction : TypedExtraction)
     (expectedRootUri expectedRootLocalName : BoundedBytes)
     (expectedEvents : List TypedXmlEvent)
     (parsed : TypedParsedPart) : Bool :=
-  decide (parsed.rawBytes.data.toList =
-    extraction.expandedBytes.data.toList) &&
+  typedByteArrayEqCheck parsed.rawBytes extraction.expandedBytes &&
   decide (parsed.expectedRootUri.bytes = expectedRootUri.bytes) &&
   decide (parsed.expectedRootLocalName.bytes = expectedRootLocalName.bytes) &&
-  decide (parsed.events.map typedXmlEventIdentity =
-    expectedEvents.map typedXmlEventIdentity) &&
+  typedXmlEventListEqCheck parsed.events expectedEvents &&
   decide (parsed.events.length ≤ parsed.eventLimit)
 
 def TypedParsedPartOf (extraction : TypedExtraction)
@@ -854,12 +1469,6 @@ def sourceOrdinals (sources : List TypedStorySource) : List Nat :=
   sources.map (·.sourceOrdinal)
 
 set_option backward.match.sparseCases false in
-def typedNatEqCheck : Nat → Nat → Bool
-  | 0, 0 => true
-  | left + 1, right + 1 => typedNatEqCheck left right
-  | _, _ => false
-
-set_option backward.match.sparseCases false in
 def typedNatLeCheck : Nat → Nat → Bool
   | 0, _ => true
   | _ + 1, 0 => false
@@ -867,13 +1476,6 @@ def typedNatLeCheck : Nat → Nat → Bool
 
 def typedNatLtCheck (left right : Nat) : Bool :=
   typedNatLeCheck (left + 1) right
-
-set_option backward.match.sparseCases false in
-def typedNatListEqCheck : List Nat → List Nat → Bool
-  | [], [] => true
-  | left :: leftRest, right :: rightRest =>
-      typedNatEqCheck left right && typedNatListEqCheck leftRest rightRest
-  | _, _ => false
 
 def typedNatMemCheck (needle : Nat) (values : List Nat) : Bool :=
   values.any fun value => typedNatEqCheck value needle
@@ -1153,7 +1755,12 @@ def typedAttributeValue? (input : TypedScanInput)
     (attributes : List TypedXmlAttribute) : Option BoundedBytes :=
   (attributes.find? fun item =>
     decide (item.namespaceUri.bytes = input.wmlNamespace.bytes) &&
-    decide (item.localName.bytes = input.idLocalName.bytes)).map (·.value)
+    decide (item.localName.bytes = input.idLocalName.bytes)).map fun item =>
+      { bytes := item.value.bytes.data.toList
+        limit := item.value.limit
+        admitted := by
+          simpa only [Array.length_toList, ByteArray.size_data] using
+            item.value.admitted }
 
 def typedReferenceCandidate? (input : TypedScanInput) :
     TypedXmlEvent → Option (Option BoundedBytes)

--- a/verification/lean/Tier2/XmlTripleChecker.lean
+++ b/verification/lean/Tier2/XmlTripleChecker.lean
@@ -60,6 +60,42 @@ def isLegalXmlChar (value : Nat) : Bool :=
     (0xE000 ≤ value && value ≤ 0xFFFD) ||
     (0x10000 ≤ value && value ≤ 0x10FFFF)
 
+def asciiXmlLiteralByte (value : UInt8) : Bool :=
+  value.toNat == 0x9 || value.toNat == 0xA || value.toNat == 0xD ||
+    (0x20 ≤ value.toNat && value.toNat ≤ 0x7F)
+
+set_option backward.match.sparseCases false in
+def asciiXmlLiteralFastLoop (bytes : ByteArray) : Nat → Bool
+  | 0 => true
+  | index + 1 =>
+      asciiXmlLiteralByte (bytes.get! index) &&
+        asciiXmlLiteralFastLoop bytes index
+
+def asciiXmlLiteralFast (value : String) : Bool :=
+  asciiXmlLiteralFastLoop value.toUTF8 value.toUTF8.size
+
+set_option backward.match.sparseCases false in
+def asciiXmlTextFastLoop (bytes : ByteArray) : Nat → Bool
+  | 0 => true
+  | index + 1 =>
+      let value := bytes.get! index
+      asciiXmlLiteralByte value && value.toNat != 0x26 &&
+        asciiXmlTextFastLoop bytes index
+
+def asciiXmlTextFast (value : String) : Bool :=
+  asciiXmlTextFastLoop value.toUTF8 value.toUTF8.size
+
+set_option backward.match.sparseCases false in
+def asciiXmlAttributeFastLoop (bytes : ByteArray) : Nat → Bool
+  | 0 => true
+  | index + 1 =>
+      let value := (bytes.get! index).toNat
+      0x20 ≤ value && value ≤ 0x7F && value != 0x26 &&
+        asciiXmlAttributeFastLoop bytes index
+
+def asciiXmlAttributeFast (value : String) : Bool :=
+  asciiXmlAttributeFastLoop value.toUTF8 value.toUTF8.size
+
 def decodeXmlReference (reference : List Char) : Except String Char := do
   let value ← match reference with
     | ['l', 't'] => pure 0x3C
@@ -91,6 +127,8 @@ partial def decodeXmlTextAux : List Char → List Char → Except String (List C
     decodeXmlTextAux rest (c :: acc)
 
 def decodeXmlText (s : String) : Except String String := do
+  if asciiXmlTextFast s then
+    return s
   return String.ofList (← decodeXmlTextAux s.toList [])
 
 partial def decodeXmlAttributeValueAux : List Char → List Char → Except String (List Char)
@@ -109,6 +147,8 @@ partial def decodeXmlAttributeValueAux : List Char → List Char → Except Stri
     decodeXmlAttributeValueAux rest (c :: acc)
 
 def decodeXmlAttributeValue (s : String) : Except String String := do
+  if asciiXmlAttributeFast s then
+    return s
   return String.ofList (← decodeXmlAttributeValueAux s.toList [])
 
 def wmlNamespace : String :=
@@ -131,18 +171,35 @@ def isStartTag (tag name : String) : Bool :=
 def isEndTag (tag name : String) : Bool :=
   tag.startsWith ("/" ++ name)
 
-def tagPayloadAux : List Char → Option Char → List Char → Except String (String × String)
-  | [], _, _ => throw "malformed XML tag without closing >"
-  | c :: rest, some quote, acc =>
-    if c == quote then tagPayloadAux rest none (c :: acc)
-    else tagPayloadAux rest (some quote) (c :: acc)
-  | c :: rest, none, acc =>
-    if c == '"' || c == '\'' then tagPayloadAux rest (some c) (c :: acc)
-    else if c == '>' then return (String.ofList acc.reverse, String.ofList rest)
-    else tagPayloadAux rest none (c :: acc)
+structure TagPayloadScanState where
+  quote : Option Char := none
+  index : Nat := 0
+  delimiter : Option Nat := none
+
+def scanTagPayloadChar
+    (state : TagPayloadScanState) (c : Char) : TagPayloadScanState :=
+  if state.delimiter.isSome then state
+  else
+    match state.quote with
+    | some quote =>
+        { state with
+          quote := if c == quote then none else some quote
+          index := state.index + 1 }
+    | none =>
+        if c == '"' || c == '\'' then
+          { state with quote := some c, index := state.index + 1 }
+        else if c == '>' then
+          { state with delimiter := some state.index }
+        else
+          { state with index := state.index + 1 }
 
 def tagPayload (segment : String) : Except String (String × String) :=
-  tagPayloadAux segment.toList none []
+  let final := segment.foldl scanTagPayloadChar {}
+  match final.delimiter with
+  | none => throw "malformed XML tag without closing >"
+  | some index =>
+      pure (segment.take index |>.toString,
+        segment.drop (index + 1) |>.toString)
 
 def isXmlNameStartChar (c : Char) : Bool :=
   let value := c.toNat
@@ -247,11 +304,10 @@ def scanAttributeChar (state : AttributeScanState) (c : Char) : AttributeScanSta
     if isXmlSpace c then state else { state with valid := false }
 
 def attributeSuffix (tag : String) : String :=
-  let chars := tag.toList.dropWhile (fun c => !isXmlSpace c)
-  String.ofList chars
+  tag.dropWhile (fun c => !isXmlSpace c) |>.toString
 
 def parseTagAttributes (tag : String) : Except String XmlAttributes := do
-  let final := (attributeSuffix tag).toList.foldl scanAttributeChar {}
+  let final := (attributeSuffix tag).foldl scanAttributeChar {}
   let complete := final.mode == .between || final.mode == .afterValue ||
     final.mode == .trailingSlash
   if !final.valid || !complete then throw "malformed XML attributes"
@@ -441,14 +497,19 @@ def parseXmlDeclaration (trimmed : String) : Except String Unit := do
   | _ => throw "unsupported or malformed XML declaration"
 
 def finishXmlSegment (state : XmlParseState) (payload : String) : Except String XmlParseState := do
-  if state.stack.isEmpty && !payload.toList.all isXmlSpace then
+  if state.stack.isEmpty && !payload.all isXmlSpace then
     throw "non-whitespace content outside the XML root"
   return state
 
 def stripLeadingUtf8Bom (xml : String) : String :=
-  match xml.toList with
-  | first :: rest => if first.toNat == 0xFEFF then String.ofList rest else xml
-  | [] => xml
+  let bytes := xml.toUTF8
+  if bytes.size ≥ 3 &&
+      (bytes.get! 0).toNat == 0xEF &&
+      (bytes.get! 1).toNat == 0xBB &&
+      (bytes.get! 2).toNat == 0xBF then
+    xml.drop 1 |>.toString
+  else
+    xml
 
 def parseXmlSegment (expectedRoot : String) (state : XmlParseState) (segment : String) :
     Except String XmlParseState := do
@@ -466,7 +527,7 @@ def parseXmlSegment (expectedRoot : String) (state : XmlParseState) (segment : S
     throw "comments, CDATA, and markup declarations are outside the accepted XML subset"
   if trimmed.startsWith "/" then
     let rawName := (trimmed.drop 1).toString
-    if rawName.toList.any isXmlSpace || rawName.endsWith "/" then
+    if rawName.any isXmlSpace || rawName.endsWith "/" then
       throw "malformed closing tag"
     let some top := state.stack.head? | throw "unexpected closing tag"
     let (uri, localName) ← resolveQName top.namespaces rawName
@@ -507,12 +568,13 @@ def parseXmlSegment (expectedRoot : String) (state : XmlParseState) (segment : S
   return { next with stack := { uri, localName, namespaces := bindings } :: next.stack }
 
 def parseXmlTokensForRoot (xml expectedRoot : String) : Except String (List XmlTok) := do
-  if !xml.toList.all (fun c => isLegalXmlChar c.toNat) then
+  if !asciiXmlLiteralFast xml &&
+      !xml.toList.all (fun c => isLegalXmlChar c.toNat) then
     throw "XML contains a disallowed literal character"
   let normalizedXml := stripLeadingUtf8Bom xml
   let pieces := normalizedXml.splitOn "<"
   let leadingText := List.getD pieces 0 ""
-  if !leadingText.toList.all isXmlSpace then throw "non-whitespace content before the XML root"
+  if !leadingText.all isXmlSpace then throw "non-whitespace content before the XML root"
   let segments := pieces.drop 1
   if segments.isEmpty then throw "XML has no root element"
   let initial : XmlParseState := { declarationAllowed := leadingText.isEmpty }
@@ -562,7 +624,7 @@ def liftXmlEventFailure (state : XmlEventParseState) (result : Except String α)
 
 def finishXmlEventSegment (state : XmlEventParseState) (payload : String) :
     Except String XmlEventParseState := do
-  if state.stack.isEmpty && !payload.toList.all isXmlSpace then
+  if state.stack.isEmpty && !payload.all isXmlSpace then
     throw "non-whitespace content outside the XML root"
   let decoded ← decodeXmlText payload
   let whitespaceIsSemantic :=
@@ -571,7 +633,7 @@ def finishXmlEventSegment (state : XmlEventParseState) (payload : String) :
       top.uri == wmlNamespace &&
         ["t", "delText", "instrText", "delInstrText"].contains top.localName
     | none => false
-  if decoded.toList.all isXmlSpace && !whitespaceIsSemantic then return state
+  if decoded.all isXmlSpace && !whitespaceIsSemantic then return state
   return { state with
     events := .text decoded state.stack.length :: state.events
     eventCount := state.eventCount + 1 }
@@ -598,7 +660,7 @@ def parseXmlEventSegment (expectedRootUri expectedRootLocalName : String)
       "comments, CDATA, and markup declarations are outside the accepted XML subset")
   if trimmed.startsWith "/" then
     let rawName := (trimmed.drop 1).toString
-    if rawName.toList.any isXmlSpace || rawName.endsWith "/" then
+    if rawName.any isXmlSpace || rawName.endsWith "/" then
       throw (xmlEventParseFailure state .invalidXml "malformed closing tag")
     let some top := state.stack.head? |
       throw (xmlEventParseFailure state .invalidXml "unexpected closing tag")
@@ -652,13 +714,14 @@ def parseXmlEventSegment (expectedRootUri expectedRootLocalName : String)
 def parseXmlEventsForRootBoundedTyped (xml expectedRootUri expectedRootLocalName : String)
     (eventLimit depthLimit : Nat) : Except XmlEventParseFailure XmlEventParseState := do
   let empty : XmlEventParseState := {}
-  if !xml.toList.all (fun c => isLegalXmlChar c.toNat) then
+  if !asciiXmlLiteralFast xml &&
+      !xml.toList.all (fun c => isLegalXmlChar c.toNat) then
     throw (xmlEventParseFailure empty .invalidXml
       "XML contains a disallowed literal character")
   let normalizedXml := stripLeadingUtf8Bom xml
   let pieces := normalizedXml.splitOn "<"
   let leadingText := List.getD pieces 0 ""
-  if !leadingText.toList.all isXmlSpace then
+  if !leadingText.all isXmlSpace then
     throw (xmlEventParseFailure empty .invalidXml
       "non-whitespace content before the XML root")
   let segments := pieces.drop 1

--- a/verification/lean/TypedCommentAxiomAudit.lean
+++ b/verification/lean/TypedCommentAxiomAudit.lean
@@ -1,5 +1,7 @@
 import Tier2.CommentReferenceIntegrity.TypedSemantics
 
+#print axioms Tier2.CommentReferenceIntegrity.Typed.typedByteArrayEqCheck_true_iff
+#print axioms Tier2.CommentReferenceIntegrity.Typed.typedXmlEventListEqCheck_true_iff
 #print axioms Tier2.CommentReferenceIntegrity.Typed.typed_comment_selector_result_sound
 #print axioms Tier2.CommentReferenceIntegrity.Typed.typed_comment_selection_to_realization_sound
 #print axioms Tier2.CommentReferenceIntegrity.Typed.typed_admitted_comment_source_set_complete

--- a/verification/lean/TypedCommentStackSafetyWitnesses.lean
+++ b/verification/lean/TypedCommentStackSafetyWitnesses.lean
@@ -1,0 +1,61 @@
+import Tier2.CommentReferenceIntegrity.TypedSemantics
+
+open Tier2.CommentReferenceIntegrity.Typed
+
+def stackWitnessPayloadSize : Nat := 400000
+
+def stackWitnessBytesA : List UInt8 :=
+  List.replicate stackWitnessPayloadSize (UInt8.ofNat 97)
+
+def stackWitnessBytesB : List UInt8 :=
+  List.replicate stackWitnessPayloadSize (UInt8.ofNat 97)
+
+def stackWitnessBoundedBytes (values : List UInt8) : BoundedBytes :=
+  { bytes := values
+    limit := values.length
+    admitted := Nat.le_refl _ }
+
+def stackWitnessBoundedByteArray (values : List UInt8) : BoundedByteArray :=
+  let bytes : ByteArray := ⟨values.toArray⟩
+  { bytes
+    limit := bytes.size
+    admitted := Nat.le_refl _ }
+
+def stackWitnessAttributeA : TypedXmlAttribute :=
+  { namespaceUri := stackWitnessBoundedBytes []
+    localName := stackWitnessBoundedBytes [UInt8.ofNat 97]
+    value := stackWitnessBoundedByteArray stackWitnessBytesA }
+
+def stackWitnessAttributeB : TypedXmlAttribute :=
+  { namespaceUri := stackWitnessBoundedBytes []
+    localName := stackWitnessBoundedBytes [UInt8.ofNat 97]
+    value := stackWitnessBoundedByteArray stackWitnessBytesB }
+
+def stackWitnessEventsA : List TypedXmlEvent :=
+  [ .startElement
+      (stackWitnessBoundedBytes [])
+      (stackWitnessBoundedBytes [UInt8.ofNat 99])
+      [stackWitnessAttributeA] 0 false 0
+  , .text (stackWitnessBoundedByteArray stackWitnessBytesA) 1 1
+  , .endElement
+      (stackWitnessBoundedBytes [])
+      (stackWitnessBoundedBytes [UInt8.ofNat 99]) 0 2
+  ]
+
+def stackWitnessEventsB : List TypedXmlEvent :=
+  [ .startElement
+      (stackWitnessBoundedBytes [])
+      (stackWitnessBoundedBytes [UInt8.ofNat 99])
+      [stackWitnessAttributeB] 0 false 0
+  , .text (stackWitnessBoundedByteArray stackWitnessBytesB) 1 1
+  , .endElement
+      (stackWitnessBoundedBytes [])
+      (stackWitnessBoundedBytes [UInt8.ofNat 99]) 0 2
+  ]
+
+example : typedByteListEqCheck stackWitnessBytesA stackWitnessBytesB = true := by
+  native_decide
+
+example :
+    typedXmlEventListEqCheck stackWitnessEventsA stackWitnessEventsB = true := by
+  native_decide


### PR DESCRIPTION
## Summary

- replace stack-proportional typed byte/event equality with proved tail-recursive comparators
- keep production attribute conversion stack-safe
- add axiom-free equivalence theorems and exact dependency/axiom audits
- run mandatory fixed-stack 400k and full-NVCA comment regressions in Lean CI
- enforce checker-only near-limit time/RSS gates without raising process stack limits

## Evidence

Normal macOS stack: 8,176 KiB.

- full real NVCA: 41,615 source atoms / 41,621 comparison atoms
- valid baseline plus missing, malformed, and overlong nested-definition mutations all returned structured protocol-v6 results
- 400k text/attribute production regression passed
- 16,775,168-byte text: 1.41s, 1,277,198,336-byte peak RSS
- 16,775,168-byte attribute: 3.11s, 1,315,045,376-byte peak RSS
- enforced ceiling: 120s and 1.5 GiB per checker invocation
- public certificate v1 and checker protocol v6 unchanged

## Validation

- full Lean build: 6,615 jobs
- zero-sorry, exact axiom allowlist, empty-target, dependency, and production-foundation audits passed
- compiled verifier suite: 96/96
- full NVCA acceptance: 2/2
- NVCA COI: 5/5
- actionlint, strict OpenSpec, spec coverage, conformance citations/document, Allure checks, builds/lints, and diff check passed
- independent final review: APPROVE, no findings
- no LibreOffice/soffice, broad local workspace suite, or `lake update`

Known unrelated gate: `check:conformance-explorer` reports pre-existing generated projection drift from section-break/page-setup registry changes and `CT_SectType`; #710 does not modify its inputs or artifact.

Refs #710
Refs #672
Refs #709