### PR TITLE
fix(docx-comparison): ignore volatile TOC page caches

### DIFF
--- a/packages/docx-compare/src/baselines/atomizer/pipeline-pageref-cache.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline-pageref-cache.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Cached PAGEREF results are layout artifacts, not authored TOC edits.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.18
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.5.45
+ * @see https://github.com/UseJunior/safe-docx/issues/716
+ */
+
+import { DocxArchive, parseXml } from '@usejunior/docx-core';
+import { describe, expect } from 'vitest';
+import {
+  buildDocxFromBodyXml,
+  completeField,
+  fldChar,
+  instrText,
+  resultText,
+} from '../../testing/ooxml-fixtures.js';
+import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
+import { compareDocumentsAtomizer } from './pipeline.js';
+import {
+  acceptAllChanges,
+  extractTextWithParagraphs,
+  rejectAllChanges,
+} from './trackChangesAcceptorAst.js';
+
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({
+    feature: 'In-Place Reconstruction',
+    story: 'TOC PAGEREF Cached Results',
+    severity: 'critical',
+  })
+  .conformance(
+    { spec: 'ECMA-376', edition: 5, part: 1, section: '17.16.18' },
+    { spec: 'ECMA-376', edition: 5, part: 1, section: '17.16.5.45' },
+  );
+
+interface TocEntry {
+  title: string;
+  target: string;
+  page: string;
+}
+
+function tocEntry(entry: TocEntry): string {
+  return (
+    '<w:p>' +
+    '<w:pPr><w:pStyle w:val="TOC1"/></w:pPr>' +
+    `<w:hyperlink w:anchor="${entry.target}">` +
+    resultText(entry.title) +
+    '<w:r><w:tab/></w:r>' +
+    completeField(` PAGEREF ${entry.target} \\h `, entry.page) +
+    '</w:hyperlink>' +
+    '</w:p>'
+  );
+}
+
+function tocBody(entries: TocEntry[]): string {
+  const [first, ...rest] = entries;
+  if (!first) throw new Error('TOC fixture requires at least one entry');
+  return (
+    '<w:p>' +
+    fldChar('begin') +
+    instrText(' TOC \\o "1-3" \\h \\z \\u ', { preserve: true }) +
+    fldChar('separate') +
+    '</w:p>' +
+    tocEntry(first) +
+    rest.map(tocEntry).join('') +
+    `<w:p>${fldChar('end')}</w:p>`
+  );
+}
+
+async function documentXml(docx: Buffer): Promise<string> {
+  return (await DocxArchive.load(docx)).getDocumentXml();
+}
+
+function revisionTexts(xml: string): string[] {
+  const document = parseXml(xml);
+  return ['ins', 'del'].flatMap((localName) =>
+    Array.from(
+      document.getElementsByTagNameNS(
+        'http://schemas.openxmlformats.org/wordprocessingml/2006/main',
+        localName,
+      ),
+    ).map((element) => element.textContent ?? ''),
+  );
+}
+
+function cacheInsensitiveText(xml: string): string {
+  return extractTextWithParagraphs(xml).replace(/\d+/gu, '{PAGE}');
+}
+
+const ORIGINAL: TocEntry[] = [
+  { title: 'Alpha Topic', target: '_Toc100', page: '3' },
+  { title: 'Beta Topic', target: '_Toc200', page: '5' },
+  { title: 'Gamma Topic', target: '_Toc300', page: '8' },
+];
+
+describe('cached PAGEREF comparison (#716)', () => {
+  test('does not mark repaginated cached results as authored changes', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    const original = await given('a multi-paragraph TOC with three PAGEREF fields', () =>
+      buildDocxFromBodyXml(tocBody(ORIGINAL)),
+    );
+    const revised = await given('the same TOC after pagination changes every cached result', () =>
+      buildDocxFromBodyXml(
+        tocBody(ORIGINAL.map((entry, index) => ({ ...entry, page: String(10 + index) }))),
+      ),
+    );
+
+    const result = await when('the adaptive in-place comparison runs', () =>
+      compareDocumentsAtomizer(original, revised, {
+        reconstructionMode: 'inplace',
+        date: new Date('2026-07-28T12:00:00Z'),
+      }),
+    );
+    const outputXml = await documentXml(result.document);
+
+    await then('the cached page numbers produce no insertion or deletion', async () => {
+      expect(revisionTexts(outputXml)).toEqual([]);
+    });
+    await then('the highest-fidelity pass succeeds without a fallback attempt', () => {
+      expect(result.inplaceSuccessDiagnostics?.passUsed).toBe('inplace_word_split');
+      expect(result.inplaceSuccessDiagnostics?.precedingFailedAttempts).toEqual([]);
+    });
+    await then('both cache-insensitive projections preserve their source TOC', async () => {
+      expect(cacheInsensitiveText(acceptAllChanges(outputXml))).toBe(
+        cacheInsensitiveText(await documentXml(revised)),
+      );
+      expect(cacheInsensitiveText(rejectAllChanges(outputXml))).toBe(
+        cacheInsensitiveText(await documentXml(original)),
+      );
+    });
+  });
+
+  test('still represents a renamed and newly added TOC entry without revising page caches', async ({
+    given,
+    when,
+    then,
+    and,
+  }: AllureBddContext) => {
+    const original = await given('the original three-entry TOC', () =>
+      buildDocxFromBodyXml(tocBody(ORIGINAL)),
+    );
+    const revisedEntries: TocEntry[] = [
+      ORIGINAL[0]!,
+      { ...ORIGINAL[1]!, title: 'Beta Topic Revised' },
+      { title: 'Delta Topic', target: '_Toc250', page: '12' },
+      ORIGINAL[2]!,
+    ];
+    const revised = await given('a renamed entry and a new entry with stable existing caches', () =>
+      buildDocxFromBodyXml(tocBody(revisedEntries)),
+    );
+
+    const result = await when('the adaptive in-place comparison runs', () =>
+      compareDocumentsAtomizer(original, revised, {
+        reconstructionMode: 'inplace',
+        date: new Date('2026-07-28T12:00:00Z'),
+      }),
+    );
+    const outputXml = await documentXml(result.document);
+    const revisions = revisionTexts(outputXml);
+
+    await then('the substantive entry edits remain visible', () => {
+      expect(revisions.join(' ')).toContain('Revised');
+      expect(revisions.join(' ')).toContain('Delta Topic');
+    });
+    await and('no cached page number is marked as inserted or deleted', () => {
+      expect(revisions).not.toContainEqual(expect.stringMatching(/^\d+$/u));
+    });
+    await and('accept and reject recover the intended TOC apart from volatile caches', async () => {
+      expect(cacheInsensitiveText(acceptAllChanges(outputXml))).toBe(
+        cacheInsensitiveText(await documentXml(revised)),
+      );
+      expect(cacheInsensitiveText(rejectAllChanges(outputXml))).toBe(
+        cacheInsensitiveText(await documentXml(original)),
+      );
+    });
+  });
+});

--- a/packages/docx-compare/src/baselines/atomizer/pipeline.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline.ts
@@ -90,7 +90,6 @@ import { runLeanXmlTripleVerifier } from './leanXmlVerifier.js';
 import {
   acceptAllChanges,
   rejectAllChanges,
-  extractTextWithParagraphs,
   compareTexts,
 } from './trackChangesAcceptorAst.js';
 import { detectUnrepresentedChanges } from './unrepresentedChanges.js';
@@ -123,6 +122,8 @@ import {
   evaluateAncillaryFieldSafety,
 } from './ancillaryFieldSafety.js';
 import { assertTextBoxContentUnchanged } from './textBoxRevisionSafety.js';
+import { extractRoundTripComparisonText } from '../../fieldComparisonSemantics.js';
+import { suppressVolatileTocPagerefCacheRevisions } from './tocPagerefCache.js';
 
 /**
  * Options for the atomizer pipeline.
@@ -476,8 +477,8 @@ function evaluateSafetyChecks(
 } {
   const acceptedXml = acceptAllChanges(candidateXml);
   const rejectedXml = rejectAllChanges(candidateXml);
-  const acceptedText = extractTextWithParagraphs(acceptedXml);
-  const rejectedText = extractTextWithParagraphs(rejectedXml);
+  const acceptedText = extractRoundTripComparisonText(acceptedXml);
+  const rejectedText = extractRoundTripComparisonText(rejectedXml);
   const acceptedBookmarkDiagnostics = collectBookmarkDiagnostics(acceptedXml);
   const rejectedBookmarkDiagnostics = collectBookmarkDiagnostics(rejectedXml);
   const acceptTextComparison = compareTexts(revisedTextForRoundTrip, acceptedText);
@@ -683,8 +684,12 @@ export async function compareDocumentsAtomizer(
   // input already carries its own tracked changes (pre-tracked w:ins / w:del,
   // comment anchors, multi-author stacks). For a clean input these equal the raw
   // extraction, so behavior on the common case is unchanged. (#347)
-  const originalTextForRoundTrip = extractTextWithParagraphs(rejectAllChanges(originalXml));
-  const revisedTextForRoundTrip = extractTextWithParagraphs(acceptAllChanges(revisedXml));
+  const originalTextForRoundTrip = extractRoundTripComparisonText(
+    rejectAllChanges(originalXml),
+  );
+  const revisedTextForRoundTrip = extractRoundTripComparisonText(
+    acceptAllChanges(revisedXml),
+  );
   const originalBookmarkDiagnostics = collectBookmarkDiagnostics(originalXml);
   const revisedBookmarkDiagnostics = collectBookmarkDiagnostics(revisedXml);
 
@@ -806,6 +811,7 @@ export async function compareDocumentsAtomizer(
         mergedAtoms,
         { author, date, preservedRoots: [originalTree] }
       );
+      newDocumentXml = suppressVolatileTocPagerefCacheRevisions(newDocumentXml);
     } else {
       // Rebuild mode: reconstruct from atoms using original as the structural base.
       // Ship a resolvable relationship for any inserted/retargeted link whose

--- a/packages/docx-compare/src/baselines/atomizer/tocPagerefCache.ts
+++ b/packages/docx-compare/src/baselines/atomizer/tocPagerefCache.ts
@@ -1,0 +1,240 @@
+/**
+ * Remove tracked changes caused only by refreshed TOC PAGEREF cached results.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.18
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.5.45
+ * @see https://github.com/UseJunior/safe-docx/issues/716
+ */
+
+import { OOXML, parseXml } from '@usejunior/docx-core';
+import { XMLSerializer } from '@xmldom/xmldom';
+import {
+  isTocParagraphStyle,
+  pagerefComparisonIdentity,
+} from '../../fieldComparisonSemantics.js';
+import { acceptAllChanges, rejectAllChanges } from './trackChangesAcceptorAst.js';
+
+const serializer = new XMLSerializer();
+const CACHE_SENTINEL = '__safe_docx_pageref_cache__';
+
+function paragraphStyleId(paragraph: Element): string | null {
+  const style = Array.from(
+    paragraph.getElementsByTagNameNS(OOXML.W_NS, 'pStyle'),
+  )[0];
+  return (
+    style?.getAttributeNS(OOXML.W_NS, 'val') ??
+    style?.getAttribute('w:val') ??
+    null
+  );
+}
+
+function hasTrackedInsertionOrDeletion(paragraph: Element): boolean {
+  return (
+    paragraph.getElementsByTagNameNS(OOXML.W_NS, 'ins').length > 0 ||
+    paragraph.getElementsByTagNameNS(OOXML.W_NS, 'del').length > 0
+  );
+}
+
+function namespaceDeclarations(document: Document): string {
+  return Array.from(document.documentElement.attributes)
+    .filter(
+      (attribute) =>
+        attribute.name === 'xmlns' || attribute.name.startsWith('xmlns:'),
+    )
+    .map(
+      (attribute) =>
+        `${attribute.name}="${attribute.value
+          .replaceAll('&', '&amp;')
+          .replaceAll('"', '&quot;')}"`,
+    )
+    .join(' ');
+}
+
+function wrapParagraph(document: Document, paragraph: Element): string {
+  return (
+    `<w:document ${namespaceDeclarations(document)}>` +
+    `<w:body>${serializer.serializeToString(paragraph)}</w:body>` +
+    '</w:document>'
+  );
+}
+
+function firstParagraph(documentXml: string): Element | undefined {
+  return Array.from(
+    parseXml(documentXml).getElementsByTagNameNS(OOXML.W_NS, 'p'),
+  )[0];
+}
+
+/**
+ * Produce a run-boundary-insensitive structural fingerprint while replacing
+ * the visible result of each PAGEREF field with a sentinel. Run boundaries can
+ * differ after projecting tracked changes even when their formatting is the
+ * same, so run properties are retained but bare w:r wrappers are not.
+ */
+function cacheInsensitiveFingerprint(paragraph: Element): string | undefined {
+  const stack: Array<{
+    instruction: string[];
+    separated: boolean;
+    pageref: boolean;
+  }> = [];
+  const tokens: string[] = [];
+  let sawPagerefCache = false;
+
+  const walk = (node: Node): void => {
+    for (let child = node.firstChild; child; child = child.nextSibling) {
+      if (child.nodeType === 3) continue;
+      if (child.nodeType !== 1) continue;
+      const element = child as Element;
+
+      if (
+        element.namespaceURI === OOXML.W_NS &&
+        element.localName === 'fldChar'
+      ) {
+        const type =
+          element.getAttributeNS(OOXML.W_NS, 'fldCharType') ??
+          element.getAttribute('w:fldCharType');
+        if (type === 'begin') {
+          stack.push({ instruction: [], separated: false, pageref: false });
+        } else if (type === 'separate' && stack.length > 0) {
+          const field = stack[stack.length - 1]!;
+          field.separated = true;
+          field.pageref =
+            pagerefComparisonIdentity(field.instruction.join('')) !== undefined;
+        } else if (type === 'end' && stack.length > 0) {
+          stack.pop();
+        }
+        tokens.push(`field:${type ?? ''}`);
+      } else if (
+        element.namespaceURI === OOXML.W_NS &&
+        (element.localName === 'instrText' ||
+          element.localName === 'delInstrText') &&
+        stack.length > 0 &&
+        !stack[stack.length - 1]!.separated
+      ) {
+        const instructionText = element.textContent ?? '';
+        stack[stack.length - 1]!.instruction.push(instructionText);
+        tokens.push(`instruction:${instructionText.trim().replace(/\s+/gu, ' ')}`);
+      } else if (
+        element.namespaceURI === OOXML.W_NS &&
+        (element.localName === 't' || element.localName === 'delText') &&
+        stack.some((field) => field.separated && field.pageref)
+      ) {
+        tokens.push(`text:${CACHE_SENTINEL}`);
+        sawPagerefCache = true;
+      } else if (
+        element.namespaceURI === OOXML.W_NS &&
+        (element.localName === 't' || element.localName === 'delText')
+      ) {
+        tokens.push(`text:${element.textContent ?? ''}`);
+      } else if (
+        element.namespaceURI === OOXML.W_NS &&
+        element.localName === 'r'
+      ) {
+        // Bare run boundaries are an artifact of tracked-change projection.
+        walk(element);
+        continue;
+      } else if (
+        element.namespaceURI === OOXML.W_NS &&
+        element.localName === 'rPr' &&
+        element.parentNode?.nodeType === 1 &&
+        (element.parentNode as Element).namespaceURI === OOXML.W_NS &&
+        (element.parentNode as Element).localName === 'r' &&
+        Array.from((element.parentNode as Element).childNodes)
+          .filter((sibling) => sibling.nodeType === 1)
+          .every((sibling) => {
+            const siblingElement = sibling as Element;
+            return (
+              siblingElement.namespaceURI === OOXML.W_NS &&
+              (siblingElement.localName === 'rPr' ||
+                siblingElement.localName === 'fldChar')
+            );
+          })
+      ) {
+        // The accept/reject projector can leave an empty field skeleton whose
+        // boundary-only runs retain their properties. Those properties do not
+        // format any visible content and disappear with the skeleton below.
+        continue;
+      } else {
+        const attributes = Array.from(element.attributes)
+          .filter(
+            (attribute) =>
+              attribute.name !== 'xmlns' &&
+              !attribute.name.startsWith('xmlns:'),
+          )
+          .map(
+            (attribute) =>
+              `${attribute.namespaceURI ?? ''}:${attribute.localName}=${attribute.value}`,
+          )
+          .sort()
+          .join('|');
+        tokens.push(
+          `start:${element.namespaceURI ?? ''}:${element.localName}:${attributes}`,
+        );
+        walk(element);
+        tokens.push(`end:${element.namespaceURI ?? ''}:${element.localName}`);
+        continue;
+      }
+
+      walk(element);
+    }
+  };
+
+  walk(paragraph);
+  const normalizedTokens: string[] = [];
+  for (let index = 0; index < tokens.length; index += 1) {
+    if (
+      tokens[index] === 'field:begin' &&
+      tokens[index + 1] === 'field:separate' &&
+      tokens[index + 2] === 'field:end'
+    ) {
+      index += 2;
+      continue;
+    }
+    normalizedTokens.push(tokens[index]!);
+  }
+  return sawPagerefCache ? normalizedTokens.join('\n') : undefined;
+}
+
+/**
+ * Preserve the original cached page number when a tracked TOC paragraph's two
+ * projections are otherwise structurally identical. The original cache is
+ * deliberately retained because emitting the revised value without a tracked
+ * change would make reject-all unable to recover the original package.
+ */
+export function suppressVolatileTocPagerefCacheRevisions(
+  documentXml: string,
+): string {
+  const document = parseXml(documentXml);
+  const paragraphs = Array.from(
+    document.getElementsByTagNameNS(OOXML.W_NS, 'p'),
+  );
+
+  for (const paragraph of paragraphs) {
+    if (
+      !isTocParagraphStyle(paragraphStyleId(paragraph)) ||
+      !hasTrackedInsertionOrDeletion(paragraph)
+    ) {
+      continue;
+    }
+
+    const wrapped = wrapParagraph(document, paragraph);
+    const accepted = firstParagraph(acceptAllChanges(wrapped));
+    const rejected = firstParagraph(rejectAllChanges(wrapped));
+    if (!accepted || !rejected) continue;
+
+    const acceptedFingerprint = cacheInsensitiveFingerprint(accepted);
+    const rejectedFingerprint = cacheInsensitiveFingerprint(rejected);
+    if (
+      acceptedFingerprint === undefined ||
+      acceptedFingerprint !== rejectedFingerprint
+    ) {
+      continue;
+    }
+
+    paragraph.parentNode?.replaceChild(
+      document.importNode(rejected, true),
+      paragraph,
+    );
+  }
+
+  return serializer.serializeToString(document);
+}

--- a/packages/docx-compare/src/fieldComparisonSemantics.ts
+++ b/packages/docx-compare/src/fieldComparisonSemantics.ts
@@ -1,0 +1,105 @@
+import { OOXML, parseXml } from '@usejunior/docx-core';
+
+/**
+ * Stable comparison identity for volatile PAGEREF cached results.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.5.45
+ * @see https://github.com/UseJunior/safe-docx/issues/716
+ */
+export function pagerefComparisonIdentity(instructionText: string): string | undefined {
+  const instruction = instructionText.trim().replace(/\s+/gu, ' ');
+  if (!/^PAGEREF(?:\s|$)/iu.test(instruction)) return undefined;
+  return `__safe_docx_pageref__|${instruction.replace(/^PAGEREF/iu, 'PAGEREF')}`;
+}
+
+/** True for the built-in TOC paragraph style identifiers used by Word. */
+export function isTocParagraphStyle(styleId: string | null | undefined): boolean {
+  return /^TOC(?:\s*\d+)?$/iu.test(styleId?.trim() ?? '');
+}
+
+/**
+ * Extract paragraph-delimited text for comparison round-trip invariants while
+ * replacing TOC PAGEREF cached results with their stable field instructions.
+ *
+ * This is intentionally separate from the user-facing plain-text extractor:
+ * rendered page numbers remain useful when reading a document, but they are
+ * pagination output rather than authored comparison content.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.18
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.5.45
+ * @see https://github.com/UseJunior/safe-docx/issues/716
+ */
+export function extractRoundTripComparisonText(documentXml: string): string {
+  const document = parseXml(documentXml);
+  const paragraphs = Array.from(
+    document.getElementsByTagNameNS(OOXML.W_NS, 'p'),
+  );
+  const paragraphTexts: string[] = [];
+
+  for (const paragraph of paragraphs) {
+    const text: string[] = [];
+    const paragraphStyle = Array.from(
+      paragraph.getElementsByTagNameNS(OOXML.W_NS, 'pStyle'),
+    )[0];
+    const styleId =
+      paragraphStyle?.getAttributeNS(OOXML.W_NS, 'val') ??
+      paragraphStyle?.getAttribute('w:val');
+    const suppressPagerefCache = isTocParagraphStyle(styleId);
+    const stack: Array<{
+      instruction: string[];
+      separated: boolean;
+      comparisonIdentity?: string;
+    }> = [];
+    const walk = (node: Node): void => {
+      for (let child = node.firstChild; child; child = child.nextSibling) {
+        if (child.nodeType !== 1) continue;
+        const element = child as Element;
+        if (element.namespaceURI === OOXML.W_NS && element.localName === 'fldChar') {
+          const type =
+            element.getAttributeNS(OOXML.W_NS, 'fldCharType') ??
+            element.getAttribute('w:fldCharType');
+          if (type === 'begin') {
+            stack.push({
+              instruction: [],
+              separated: false,
+            });
+          } else if (type === 'separate' && stack.length > 0) {
+            const field = stack[stack.length - 1]!;
+            field.separated = true;
+            field.comparisonIdentity = suppressPagerefCache
+              ? pagerefComparisonIdentity(field.instruction.join(''))
+              : undefined;
+            if (field.comparisonIdentity) text.push(field.comparisonIdentity);
+          } else if (type === 'end' && stack.length > 0) {
+            stack.pop();
+          }
+        } else if (
+          element.namespaceURI === OOXML.W_NS &&
+          (element.localName === 'instrText' ||
+            element.localName === 'delInstrText') &&
+          stack.length > 0 &&
+          !stack[stack.length - 1]!.separated
+        ) {
+          stack[stack.length - 1]!.instruction.push(element.textContent ?? '');
+        } else if (
+          element.namespaceURI === OOXML.W_NS &&
+          (element.localName === 't' || element.localName === 'delText')
+        ) {
+          const insidePagerefResult = stack.some(
+            (field) =>
+              field.separated && field.comparisonIdentity !== undefined,
+          );
+          if (!insidePagerefResult) {
+            const value = element.textContent ?? '';
+            if (value) text.push(value);
+          }
+        }
+        walk(element);
+      }
+    };
+    walk(paragraph);
+    paragraphTexts.push(text.join(''));
+  }
+
+  return paragraphTexts.join('\n');
+}

--- a/packages/docx-compare/src/index.ts
+++ b/packages/docx-compare/src/index.ts
@@ -133,6 +133,7 @@ export * from './atomizer.js';
 export * from './move-detection.js';
 export * from './format-detection.js';
 export * from './paragraph-style-detection.js';
+export { extractRoundTripComparisonText } from './fieldComparisonSemantics.js';
 export * from './baselines/atomizer/formattingFidelity.js';
 export {
   acceptAllChanges,

--- a/packages/docx-core/src/integration/inplace-bookmark-semantic-regression.test.ts
+++ b/packages/docx-core/src/integration/inplace-bookmark-semantic-regression.test.ts
@@ -7,7 +7,7 @@ import { DocxArchive } from '../shared/docx/DocxArchive.js';
 import {
   acceptAllChanges,
   compareTexts,
-  extractTextWithParagraphs,
+  extractRoundTripComparisonText,
   rejectAllChanges,
 } from '@usejunior/docx-compare';
 import { parseDocumentXml } from '@usejunior/docx-compare';
@@ -130,8 +130,8 @@ function bookmarkDiagnostics(documentXml: string): BookmarkSemanticDiagnostics {
 }
 
 function assertReadTextParity(expectedXml: string, actualXml: string, context: string): void {
-  const expectedReadText = extractTextWithParagraphs(expectedXml);
-  const actualReadText = extractTextWithParagraphs(actualXml);
+  const expectedReadText = extractRoundTripComparisonText(expectedXml);
+  const actualReadText = extractRoundTripComparisonText(actualXml);
   const comparison = compareTexts(expectedReadText, actualReadText);
   const hint = comparison.differences.slice(0, 3).join('\n');
   expect(

--- a/packages/docx-core/src/integration/round-trip.test.ts
+++ b/packages/docx-core/src/integration/round-trip.test.ts
@@ -22,6 +22,7 @@ import {
   acceptAllChanges,
   rejectAllChanges,
   extractTextWithParagraphs,
+  extractRoundTripComparisonText,
   compareTexts,
 } from '@usejunior/docx-compare';
 import {
@@ -200,12 +201,12 @@ describe('Round-Trip Tests - Accept All Changes', () => {
         const resultArchive = await DocxArchive.load(comparisonResult.document);
         const resultXml = await resultArchive.getDocumentXml();
         const acceptedXml = acceptAllChanges(resultXml);
-        acceptedText = extractTextWithParagraphs(acceptedXml);
+        acceptedText = extractRoundTripComparisonText(acceptedXml);
 
         // Extract text from revised document
         const revisedArchive = await DocxArchive.load(revisedBuffer);
         const revisedXml = await revisedArchive.getDocumentXml();
-        revisedText = extractTextWithParagraphs(revisedXml);
+        revisedText = extractRoundTripComparisonText(revisedXml);
 
         // Save for debugging
         await writeIntegrationArtifact('accepted_text.txt', acceptedText);
@@ -393,12 +394,12 @@ describe('Round-Trip Tests - Reject All Changes', () => {
         // Save rejected XML for debugging
         await writeIntegrationArtifact('rejected.xml', rejectedXml);
 
-        rejectedText = extractTextWithParagraphs(rejectedXml);
+        rejectedText = extractRoundTripComparisonText(rejectedXml);
 
         // Extract text from original document
         const originalArchive = await DocxArchive.load(originalBuffer);
         const originalXml = await originalArchive.getDocumentXml();
-        originalText = extractTextWithParagraphs(originalXml);
+        originalText = extractRoundTripComparisonText(originalXml);
 
         // Save for debugging
         await writeIntegrationArtifact('rejected_text.txt', rejectedText);

--- a/packages/docx-core/src/integration/roundtrip-structural-invariants.test.ts
+++ b/packages/docx-core/src/integration/roundtrip-structural-invariants.test.ts
@@ -19,7 +19,7 @@ import { compareDocuments } from '@usejunior/docx-compare';
 import { DocxArchive, DOCX_PATHS } from '../shared/docx/DocxArchive.js';
 import {
   acceptAllChanges,
-  extractTextWithParagraphs,
+  extractRoundTripComparisonText,
   compareTexts,
   rejectAllChanges,
 } from '@usejunior/docx-compare';
@@ -202,13 +202,13 @@ async function expectReadTextParity(
   expectedArchive: DocxArchive,
   context: string
 ): Promise<void> {
-  // `extractTextWithParagraphs` is the docx-comparison package's semantic
-  // read_text-equivalent surface used by round-trip validation.
+  // Round-trip parity treats TOC PAGEREF caches as pagination output while
+  // preserving ordinary visible text everywhere else.
   const actualDocumentXml = await actualArchive.getDocumentXml();
   const expectedDocumentXml = await expectedArchive.getDocumentXml();
 
-  const actualReadText = extractTextWithParagraphs(actualDocumentXml);
-  const expectedReadText = extractTextWithParagraphs(expectedDocumentXml);
+  const actualReadText = extractRoundTripComparisonText(actualDocumentXml);
+  const expectedReadText = extractRoundTripComparisonText(expectedDocumentXml);
   const comparison = compareTexts(expectedReadText, actualReadText);
   if (!comparison.normalizedIdentical) {
     const expectedParas = expectedReadText.split('\n');


### PR DESCRIPTION
## Summary
- suppress tracked changes caused solely by refreshed `PAGEREF` cached results in TOC-styled paragraphs
- require accepted/rejected structural fingerprints to match after masking only the cache before cleaning a revision
- share the cache-insensitive projection between runtime round-trip safety and corpus invariants
- add generic ECMA-376 regression coverage for cache-only refreshes plus substantive renamed/added TOC entries

## Confidential-oracle result
- TOC revision paragraphs: 11 -> 6 genuine changes
- TOC revision containers: 27 -> 12
- accept projection: all 12 revised semantic TOC paragraphs recovered
- reject projection: all 10 original semantic TOC paragraphs recovered
- unchanged currency delete/reinsert artifacts remain 0
- no confidential filenames, text, parties, or paths are included in this PR

## Validation
- `npm run build && npm run lint:workspaces && npm run test:run && npm run check:spec-coverage && npm run check:conformance-citations && npm run check:conformance-doc`
- confidential aggregate oracle benchmark

Fixes #716
Ref #718