### PR TITLE
ci(verification): allow full Lean acceptance runtime

### DIFF
--- a/.github/workflows/lean-build.yml
+++ b/.github/workflows/lean-build.yml
@@ -69,7 +69,9 @@ permissions:
 jobs:
   lean-build:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Cold Lean builds take about 22 minutes; full-document and memory gates
+    # leave the differential harnesses needing headroom beyond the old 30-minute cap.
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
@@ -109,8 +111,8 @@ jobs:
 
       # `lake exe cache get` downloads mathlib pre-built .olean files from
       # the leanprover-community CDN. Cold-from-source compilation of
-      # mathlib takes ~30 minutes — i.e. it would consume the entire job
-      # timeout below — so we treat CDN unreachability as a job failure
+      # mathlib takes ~30 minutes, leaving no budget for the acceptance and
+      # differential gates below, so we treat CDN unreachability as a job failure
       # rather than silently falling back to a multi-hour source compile.
       # The committed lake-manifest.json is the source of truth; we
       # deliberately do NOT run `lake update` here (it would mutate the
@@ -127,7 +129,7 @@ jobs:
               sleep $((attempt * 10))
             fi
           done
-          echo "lake exe cache get failed after 3 attempts; aborting rather than attempting a ~30min source compile under a 30min job timeout"
+          echo "lake exe cache get failed after 3 attempts; aborting rather than spending most of the 40min job timeout on source compilation"
           exit 1
 
       - name: Build LeanSpike


### PR DESCRIPTION
## Summary
- raise the advisory Lean workflow job cap from 30 to 40 minutes
- update stale cache-failure diagnostics to match the new cap
- leave the compiled checker's 120-second invocation limit and all failure propagation unchanged

## Why
PR #722 merged while its advisory Lean workflow was still running. Every #710-specific acceptance gate passed, including the full build, axiom audit, fixed-stack memory checks, full NVCA verifier test, and LCS differential. The cold build consumed 22m04s, and the workflow reached the old 30-minute job cap during the final Tier2 helper differential. This gives the complete gate enough CI headroom without weakening any product acceptance limit.

## Validation
- `actionlint .github/workflows/lean-build.yml`
- `git diff --check`
- independent review: approved

Refs #710
Refs #722