### PR TITLE
feat(docx-comparison): compare main-story VML text boxes

### DIFF
--- a/openspec/changes/compare-vml-text-box-stories/design.md
+++ b/openspec/changes/compare-vml-text-box-stories/design.md
@@ -1,0 +1,89 @@
+# Design: Nested text-box story comparison
+
+## Context
+
+The atomizer can see descendant text under `w:txbxContent`, but treating those
+atoms as members of the outer `w:body` comparison lets reconstruction place
+revision markup around the containing `w:pict`/shape. Microsoft Word rejects
+that output. The current preflight hash guard therefore rejects every changed
+text box.
+
+The first supported subset is deliberately narrow:
+
+- VML text boxes in `word/document.xml`;
+- the same number and order of boxes on both sides;
+- unchanged scaffold outside each `w:txbxContent`;
+- non-nested WordprocessingML paragraph content inside the box; and
+- text/run/paragraph edits representable by the existing in-place comparison.
+
+## Decisions
+
+### 1. Treat each `w:txbxContent` as a nested story
+
+Each story receives a locator containing the package part and document-order
+ordinal, with paragraph/shape identifiers retained as diagnostics when present.
+Outer-body comparison must not infer correspondence between text-box content
+and ordinary body text.
+
+### 2. Separate scaffold identity from story content identity
+
+Before comparison, each paired text box is split into:
+
+- the preserved outer scaffold, compared after replacing nested content with a
+  deterministic neutral placeholder; and
+- the nested WordprocessingML story, compared independently.
+
+The implementation may publish only when the scaffolds are semantically equal.
+This prevents a text edit from turning into deletion/insertion of the complete
+drawing object.
+
+### 3. Reuse comparison semantics, not a second diff implementation
+
+Nested stories use the same atomization, LCS, revision construction, and
+accept/reject logic as the main document. Story orchestration may wrap the
+paragraph sequence in a temporary WordprocessingML body, but it must not
+reimplement tokenization or revision semantics.
+
+### 4. Validate the assembled output as a triple
+
+After splicing each compared story into the preserved scaffold:
+
+- accept-all must recover the revised outer document and revised text-box
+  stories under the normal comparison projection;
+- reject-all must recover the original outer document and original text-box
+  stories; and
+- field, bookmark, relationship, and consumer-openability checks continue to
+  apply to the assembled package.
+
+### 5. Fail closed outside the accepted subset
+
+Inserted/deleted/reordered text boxes, changed VML/DrawingML scaffold, nested
+text boxes, and text boxes in headers/footers are not silently flattened or
+ignored. They retain a typed unsupported-story diagnostic with a stable locator.
+
+### 6. Keep verifier coverage honest
+
+The compiled verifier must either check each supported text-box story or return
+a structured uncovered-story item. A successful document comparison is not yet
+a full verifier certificate until this coverage item is discharged.
+
+## Alternatives considered
+
+- **Remove the safety gate and rely on current atomization.** Rejected because
+  the prior corruption reproduction produced a Word-unreadable drawing-level
+  revision.
+- **Treat changed text boxes as opaque delete/insert objects.** Rejected because
+  revision markup around VML objects is not a reliable Word-readable redline.
+- **Implement separate text tokenization for text boxes.** Rejected because it
+  would duplicate comparison semantics and create a drift-prone second engine.
+
+## Risks
+
+- Temporary story wrapping can lose namespace or relationship context. The
+  splice step therefore preserves the original scaffold and effective namespace
+  declarations.
+- Story order alone is insufficient when boxes are inserted or reordered. This
+  slice rejects those cases rather than guessing.
+- Recursive pipeline use can recurse through nested boxes. Nested discovery is
+  explicitly rejected and internal story comparison runs on isolated paragraph
+  content with no text-box descendants.

--- a/openspec/changes/compare-vml-text-box-stories/proposal.md
+++ b/openspec/changes/compare-vml-text-box-stories/proposal.md
@@ -1,0 +1,37 @@
+# Change: Compare text inside VML text-box stories
+
+## Why
+
+Safe-DOCX currently fails closed whenever `w:txbxContent` changes. That guard
+prevents the outer comparison from wrapping a complete VML drawing in revision
+markup that Word cannot read, but it also means one edited notice or address box
+can block an otherwise valid legal-document redline.
+
+Text inside a VML text box is WordprocessingML content with its own paragraph
+sequence. It should be compared as a nested story rather than as part of the
+outer drawing object.
+
+## What Changes
+
+- Discover paired `w:txbxContent` stories in the main document and assign each a
+  deterministic locator.
+- Compare supported text-box paragraph content independently with ordinary
+  WordprocessingML tracked insertions and deletions.
+- Keep the containing VML/DrawingML scaffold out of the outer-body diff and
+  splice the compared nested story back into the preserved revised scaffold.
+- Require accept-all and reject-all parity for both the outer document and each
+  supported text-box story.
+- Retain an explicit fail-closed boundary for inserted, deleted, reordered,
+  nested, ancillary-part, or structurally changed text boxes until those shapes
+  receive separate support.
+- Report text-box stories as an explicit verifier coverage item; a certificate
+  may not silently claim full-story coverage while the compiled verifier does
+  not parse them.
+
+## Impact
+
+- Affected spec: `docx-comparison`
+- Affected code: atomizer pipeline, text-box safety/classification, in-place
+  reconstruction, round-trip validation, focused fixtures, verifier coverage
+- Fixes: #713
+- Related: #647, #688, #718

--- a/openspec/changes/compare-vml-text-box-stories/specs/docx-comparison/spec.md
+++ b/openspec/changes/compare-vml-text-box-stories/specs/docx-comparison/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Supported VML text boxes are compared as nested WordprocessingML stories
+
+The system SHALL compare the paragraph content of `w:txbxContent` as an independent nested story and preserve the surrounding drawing/VML scaffold when a paired VML text box in `word/document.xml` has an unchanged outer scaffold. It SHALL NOT represent a text-only story edit by wrapping the complete `w:pict`, `v:shape`, or `v:textbox` object in revision markup.
+
+#### Scenario: [SDX-TXBX-01] Text-only edit emits revisions inside the text-box story
+
+- **GIVEN** original and revised documents with one paired VML text box
+- **AND** only text inside its `w:txbxContent` differs
+- **WHEN** in-place comparison runs
+- **THEN** the output SHALL contain ordinary tracked insertion/deletion markup inside `w:txbxContent`
+- **AND** the containing `w:pict`, `v:shape`, and `v:textbox` scaffold SHALL remain present exactly once
+- **AND** the complete drawing object SHALL NOT be wrapped as an insertion or deletion
+
+#### Scenario: [SDX-TXBX-02] Mixed body and text-box edits round-trip independently
+
+- **GIVEN** a paired document with one authored body edit and one authored text-box edit
+- **WHEN** in-place comparison runs
+- **THEN** both edits SHALL be represented in their respective stories
+- **AND** accepting all changes SHALL recover the revised body and revised text-box story
+- **AND** rejecting all changes SHALL recover the original body and original text-box story
+
+#### Scenario: [SDX-TXBX-03] Multiple paired text boxes retain locator and order
+
+- **GIVEN** multiple VML text boxes with unchanged scaffolds and one or more changed nested stories
+- **WHEN** comparison runs
+- **THEN** each story SHALL be paired by a deterministic main-part locator
+- **AND** each compared story SHALL be spliced back into its original shape in document order
+- **AND** content SHALL NOT move between text boxes or between a text box and the outer body
+
+#### Scenario: [SDX-TXBX-04] Unsupported text-box topology fails closed
+
+- **GIVEN** an inserted, deleted, reordered, nested, scaffold-mutated, header, or footer text box
+- **WHEN** comparison classifies the text-box stories
+- **THEN** it SHALL fail with a typed unsupported text-box story diagnostic
+- **AND** the diagnostic SHALL identify the package part and stable story locator
+- **AND** it SHALL NOT emit a flattened, stale, duplicated, or drawing-level revision
+
+#### Scenario: [SDX-TXBX-05] Verifier coverage is explicit for nested stories
+
+- **GIVEN** a successful comparison containing a supported changed text-box story
+- **WHEN** the compiled verifier evaluates the comparison triple
+- **THEN** it SHALL either verify that nested story or report it as an uncovered story
+- **AND** a certificate SHALL NOT claim complete story coverage while any text-box story remains uncovered

--- a/openspec/changes/compare-vml-text-box-stories/tasks.md
+++ b/openspec/changes/compare-vml-text-box-stories/tasks.md
@@ -1,0 +1,36 @@
+## 1. Specification
+
+- [x] 1.1 Validate this OpenSpec proposal and delta requirements.
+- [x] 1.2 Register the exact ECMA-376 sections governing VML text-box hosted WordprocessingML content and tracked revisions.
+
+## 2. Story classification and orchestration
+
+- [x] 2.1 Discover main-document `w:txbxContent` stories with deterministic locators.
+- [x] 2.2 Separate and compare scaffold identity from nested story content identity.
+- [x] 2.3 Reject inserted/deleted/reordered/nested/ancillary/scaffold-mutated text boxes with typed diagnostics.
+
+## 3. In-place comparison
+
+- [x] 3.1 Neutralize supported nested stories during outer-body comparison.
+- [x] 3.2 Compare each supported paragraph sequence with the shared atomizer/LCS/revision pipeline.
+- [x] 3.3 Splice each compared story into the preserved revised scaffold without drawing-level revisions.
+- [x] 3.4 Validate accept/reject parity for the assembled document and every nested story.
+
+## 4. Evidence
+
+- [x] 4.1 Convert the published #647 VML reproduction into positive tracked-revision coverage.
+- [x] 4.2 Add mixed body/story, multiple-box, formatting, and field-bearing positive fixtures.
+- [x] 4.3 Add negative fixtures for topology, scaffold, nesting, and ancillary-story boundaries.
+- [x] 4.4 Run Microsoft Word/LibreOffice openability smoke checks where available.
+- [x] 4.5 Re-run the confidentiality-safe third-pair oracle and record aggregate-only results.
+
+## 5. Verification coverage
+
+- [x] 5.1 Add text-box story coverage to verifier input/output reporting.
+- [x] 5.2 Keep certificates incomplete until the compiled verifier checks every supported nested story.
+
+## 6. Delivery
+
+- [x] 6.1 Run focused tests and the mandatory repository pre-submit command.
+- [x] 6.2 Review the public diff for confidential identifiers and bounded scope.
+- [ ] 6.3 Commit, push, merge through a focused PR, and perform a real-document post-merge smoke.

--- a/packages/docx-compare/src/baselines/atomizer/pipeline-safety-guards.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline-safety-guards.test.ts
@@ -3,7 +3,6 @@ import { describe, expect } from 'vitest';
 import type { ComparisonUnitAtom } from '@usejunior/docx-core';
 import { CorrelationStatus } from '@usejunior/docx-core';
 import { compareDocumentsAtomizer, computeAtomizerStats } from './pipeline.js';
-import { UnsupportedTextBoxRevisionError } from './textBoxRevisionSafety.js';
 import { buildDocxFromBodyXml } from '../../testing/ooxml-fixtures.js';
 import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
 import { el } from '../../testing/dom-test-helpers.js';
@@ -22,116 +21,7 @@ function paragraph(text: string): string {
   return `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
 }
 
-const TEXT_BOX_NAMESPACES = {
-  v: 'urn:schemas-microsoft-com:vml',
-  o: 'urn:schemas-microsoft-com:office:office',
-} as const;
-
-function paragraphWithTextBox(text: string, paragraphId = '20000001'): string {
-  return (
-    `<w:p><w:r><w:pict>` +
-    `<v:shape id="shape1" o:spid="_x0000_s1026">` +
-    `<v:textbox><w:txbxContent>` +
-    `<w:p w14:paraId="${paragraphId}" w14:textId="${paragraphId}">` +
-    `<w:r><w:t>${text}</w:t></w:r>` +
-    `</w:p>` +
-    `</w:txbxContent></v:textbox>` +
-    `</v:shape></w:pict></w:r></w:p>`
-  );
-}
-
 describe('pipeline safety and input guards', () => {
-  test('fails closed before emitting a revision inside w:txbxContent', async ({
-    given,
-    when,
-    then,
-    and,
-  }: AllureBddContext) => {
-    let original: Buffer;
-    let revised: Buffer;
-    const failures = new Map<'inplace' | 'rebuild', unknown>();
-
-    await given('a DOCX pair whose only change is text inside one VML text box', async () => {
-      original = await buildDocxFromBodyXml(
-        paragraphWithTextBox('05 Main Street'),
-        [],
-        { namespaces: TEXT_BOX_NAMESPACES },
-      );
-      revised = await buildDocxFromBodyXml(
-        paragraphWithTextBox('405 Main Street'),
-        [],
-        { namespaces: TEXT_BOX_NAMESPACES },
-      );
-    });
-
-    await when('the pair is compared using both reconstruction modes', async () => {
-      for (const reconstructionMode of ['inplace', 'rebuild'] as const) {
-        try {
-          await compareDocumentsAtomizer(original, revised, { reconstructionMode });
-        } catch (error) {
-          failures.set(reconstructionMode, error);
-        }
-      }
-    });
-
-    await then('comparison rejects the unsupported text-box revision explicitly', () => {
-      for (const reconstructionMode of ['inplace', 'rebuild'] as const) {
-        const failure = failures.get(reconstructionMode);
-        expect(failure, reconstructionMode).toBeInstanceOf(UnsupportedTextBoxRevisionError);
-        expect((failure as Error).message, reconstructionMode).toContain(
-          'Tracked revisions inside w:txbxContent are unsupported',
-        );
-      }
-    });
-
-    await and('the diagnostic identifies the affected text-box paragraph', () => {
-      for (const reconstructionMode of ['inplace', 'rebuild'] as const) {
-        expect(failures.get(reconstructionMode), reconstructionMode).toMatchObject({
-          changes: [{
-            index: 0,
-            originalParagraphId: '20000001',
-            revisedParagraphId: '20000001',
-          }],
-        });
-      }
-    });
-  });
-
-  test('permits body revisions when unchanged text boxes are present', async ({
-    given,
-    when,
-    then,
-  }: AllureBddContext) => {
-    let original: Buffer;
-    let revised: Buffer;
-    let result: Awaited<ReturnType<typeof compareDocumentsAtomizer>>;
-
-    await given('a DOCX pair with an unchanged text box and changed body text', async () => {
-      original = await buildDocxFromBodyXml(
-        `${paragraph('Original body')}${paragraphWithTextBox('05 Main Street')}`,
-        [],
-        { namespaces: TEXT_BOX_NAMESPACES },
-      );
-      revised = await buildDocxFromBodyXml(
-        `${paragraph('Revised body')}${paragraphWithTextBox('05 Main Street')}`,
-        [],
-        { namespaces: TEXT_BOX_NAMESPACES },
-      );
-    });
-
-    await when('the pair is compared', async () => {
-      result = await compareDocumentsAtomizer(original, revised, {
-        reconstructionMode: 'inplace',
-      });
-    });
-
-    await then('comparison succeeds without treating the unchanged text box as a change', () => {
-      expect(result.document.length).toBeGreaterThan(0);
-      expect(result.stats.insertions).toBeGreaterThan(0);
-      expect(result.stats.deletions).toBeGreaterThan(0);
-    });
-  });
-
   test('rejects a loadable package whose main part has no body', async ({
     given,
     when,

--- a/packages/docx-compare/src/baselines/atomizer/pipeline-text-box-stories.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline-text-box-stories.test.ts
@@ -1,0 +1,632 @@
+/**
+ * VML text boxes host nested WordprocessingML paragraph stories.
+ *
+ * @conformance ECMA-376 edition 5, Part 4 § 14.9.1.1
+ * @conformance ECMA-376 edition 5, Part 4 § 19.1.2.22
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.5.14
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.5.18
+ * @see https://github.com/UseJunior/safe-docx/issues/713
+ */
+
+import { describe, expect } from 'vitest';
+import { DocxArchive, OOXML, parseXml } from '@usejunior/docx-core';
+import {
+  buildDocxFromBodyXml,
+  COMPLETE_PAGE_FIELD,
+} from '../../testing/ooxml-fixtures.js';
+import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
+import { compareDocumentsAtomizer } from './pipeline.js';
+import {
+  UnsupportedTextBoxRevisionError,
+} from './textBoxRevisionSafety.js';
+import {
+  acceptAllChanges,
+  rejectAllChanges,
+} from './trackChangesAcceptorAst.js';
+
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({
+    feature: 'In-Place Reconstruction',
+    story: 'VML Text-Box Stories',
+    severity: 'critical',
+  })
+  .conformance(
+    { spec: 'ECMA-376', edition: 5, part: 4, section: '14.9.1.1' },
+    { spec: 'ECMA-376', edition: 5, part: 4, section: '19.1.2.22' },
+    { spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.5.14' },
+    { spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.5.18' },
+  );
+
+const TEXT_BOX_NAMESPACES = {
+  v: 'urn:schemas-microsoft-com:vml',
+  o: 'urn:schemas-microsoft-com:office:office',
+  r: 'http://schemas.openxmlformats.org/officeDocument/2006/relationships',
+} as const;
+
+function paragraph(text: string): string {
+  return `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
+}
+
+interface TextBoxFixtureOptions {
+  paragraphId?: string;
+  shapeId?: string;
+  hyperlinkId?: string;
+}
+
+function paragraphWithTextBox(
+  text: string,
+  {
+    paragraphId = '20000001',
+    shapeId = 'shape1',
+    hyperlinkId,
+  }: TextBoxFixtureOptions = {},
+): string {
+  const storyText = hyperlinkId
+    ? `<w:hyperlink r:id="${hyperlinkId}"><w:r><w:t>${text}</w:t></w:r></w:hyperlink>`
+    : `<w:r><w:t>${text}</w:t></w:r>`;
+  return paragraphWithTextBoxStory(storyText, {
+    paragraphId,
+    shapeId,
+  });
+}
+
+function paragraphWithTextBoxStory(
+  storyXml: string,
+  {
+    paragraphId = '20000001',
+    shapeId = 'shape1',
+  }: TextBoxFixtureOptions = {},
+): string {
+  return (
+    `<w:p><w:r><w:pict>` +
+    `<v:shape id="${shapeId}" o:spid="_x0000_s1026">` +
+    `<v:textbox><w:txbxContent>` +
+    `<w:p w14:paraId="${paragraphId}" w14:textId="${paragraphId}">` +
+    storyXml +
+    `</w:p>` +
+    `</w:txbxContent></v:textbox>` +
+    `</v:shape></w:pict></w:r></w:p>`
+  );
+}
+
+async function documentXml(docx: Buffer): Promise<string> {
+  return (await DocxArchive.load(docx)).getDocumentXml();
+}
+
+function textBoxText(documentXml: string, index = 0): string {
+  return (
+    parseXml(documentXml)
+      .getElementsByTagNameNS(OOXML.W_NS, 'txbxContent')
+      .item(index)?.textContent ?? ''
+  );
+}
+
+function paragraphText(documentXml: string, index = 0): string {
+  return (
+    parseXml(documentXml)
+      .getElementsByTagNameNS(OOXML.W_NS, 'p')
+      .item(index)?.textContent ?? ''
+  );
+}
+
+function hasTrackedRevisionAncestor(element: Element): boolean {
+  let ancestor: Node | null = element.parentNode;
+  while (ancestor?.nodeType === 1) {
+    const candidate = ancestor as Element;
+    if (
+      candidate.namespaceURI === OOXML.W_NS &&
+      (candidate.localName === 'ins' || candidate.localName === 'del')
+    ) {
+      return true;
+    }
+    ancestor = ancestor.parentNode;
+  }
+  return false;
+}
+
+describe('VML text-box story comparison (#713)', () => {
+  test('emits a text-only revision inside w:txbxContent', async ({
+    given,
+    when,
+    then,
+    and,
+  }: AllureBddContext) => {
+    const original = await given('one VML text box with its original address', () =>
+      buildDocxFromBodyXml(
+        paragraphWithTextBox('05 Main Street'),
+        [],
+        { namespaces: TEXT_BOX_NAMESPACES },
+      ),
+    );
+    const revised = await given('the same shape with an edited nested story', () =>
+      buildDocxFromBodyXml(
+        paragraphWithTextBox('405 Main Street'),
+        [],
+        { namespaces: TEXT_BOX_NAMESPACES },
+      ),
+    );
+
+    const result = await when('the documents are compared in place', () =>
+      compareDocumentsAtomizer(original, revised, {
+        reconstructionMode: 'inplace',
+      }),
+    );
+    const outputXml = await documentXml(result.document);
+
+    await then('tracked revisions are nested inside the text-box story', () => {
+      const output = parseXml(outputXml);
+      const textBox = output
+        .getElementsByTagNameNS(OOXML.W_NS, 'txbxContent')
+        .item(0);
+      expect(textBox).not.toBeNull();
+      expect(
+        textBox!.getElementsByTagNameNS(OOXML.W_NS, 'ins').length,
+      ).toBeGreaterThan(0);
+      expect(
+        textBox!.getElementsByTagNameNS(OOXML.W_NS, 'del').length,
+      ).toBeGreaterThan(0);
+      const shapes = output.getElementsByTagNameNS(
+        'urn:schemas-microsoft-com:vml',
+        'shape',
+      );
+      const pict = output.getElementsByTagNameNS(OOXML.W_NS, 'pict').item(0);
+      expect(shapes.length).toBe(1);
+      expect(pict).not.toBeNull();
+      expect(hasTrackedRevisionAncestor(pict!)).toBe(false);
+    });
+    await and('accept and reject recover their source stories', () => {
+      expect(textBoxText(acceptAllChanges(outputXml))).toBe('405 Main Street');
+      expect(textBoxText(rejectAllChanges(outputXml))).toBe('05 Main Street');
+    });
+  });
+
+  test('represents mixed body and text-box edits independently', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    const original = await given('an original body and nested story', () =>
+      buildDocxFromBodyXml(
+        paragraph('Original body') + paragraphWithTextBox('Original notice'),
+        [],
+        { namespaces: TEXT_BOX_NAMESPACES },
+      ),
+    );
+    const revised = await given('authored edits in both stories', () =>
+      buildDocxFromBodyXml(
+        paragraph('Revised body') + paragraphWithTextBox('Revised notice'),
+        [],
+        { namespaces: TEXT_BOX_NAMESPACES },
+      ),
+    );
+
+    const result = await when('the documents are compared in place', () =>
+      compareDocumentsAtomizer(original, revised, {
+        reconstructionMode: 'inplace',
+      }),
+    );
+    const outputXml = await documentXml(result.document);
+
+    await then('both accept and reject recover the complete intended text', () => {
+      const accepted = acceptAllChanges(outputXml);
+      const rejected = rejectAllChanges(outputXml);
+      expect(paragraphText(accepted)).toBe('Revised body');
+      expect(textBoxText(accepted)).toBe('Revised notice');
+      expect(paragraphText(rejected)).toBe('Original body');
+      expect(textBoxText(rejected)).toBe('Original notice');
+    });
+  });
+
+  test('keeps multiple changed stories in their original shape order', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    const original = await given('two original text-box stories', () =>
+      buildDocxFromBodyXml(
+        paragraphWithTextBox('Alpha', {
+          paragraphId: '20000001',
+          shapeId: 'shape1',
+        }) +
+          paragraphWithTextBox('Beta', {
+            paragraphId: '20000002',
+            shapeId: 'shape2',
+          }),
+        [],
+        { namespaces: TEXT_BOX_NAMESPACES },
+      ),
+    );
+    const revised = await given('edits in both corresponding stories', () =>
+      buildDocxFromBodyXml(
+        paragraphWithTextBox('Alpha revised', {
+          paragraphId: '20000001',
+          shapeId: 'shape1',
+        }) +
+          paragraphWithTextBox('Beta revised', {
+            paragraphId: '20000002',
+            shapeId: 'shape2',
+          }),
+        [],
+        { namespaces: TEXT_BOX_NAMESPACES },
+      ),
+    );
+
+    const result = await when('the documents are compared', () =>
+      compareDocumentsAtomizer(original, revised, {
+        reconstructionMode: 'inplace',
+      }),
+    );
+    const outputXml = await documentXml(result.document);
+
+    await then('each accepted and rejected story stays in its own shape', () => {
+      const accepted = acceptAllChanges(outputXml);
+      const rejected = rejectAllChanges(outputXml);
+      expect([textBoxText(accepted, 0), textBoxText(accepted, 1)]).toEqual([
+        'Alpha revised',
+        'Beta revised',
+      ]);
+      expect([textBoxText(rejected, 0), textBoxText(rejected, 1)]).toEqual([
+        'Alpha',
+        'Beta',
+      ]);
+    });
+  });
+
+  test('supports a stable resolved hyperlink around changed story text', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    const relationships = [{ id: 'rId5', target: 'https://example.test/' }];
+    const original = await given('a linked original notice', () =>
+      buildDocxFromBodyXml(
+        paragraphWithTextBox('Original notice', { hyperlinkId: 'rId5' }),
+        relationships,
+        { namespaces: TEXT_BOX_NAMESPACES },
+      ),
+    );
+    const revised = await given('the same link target with revised text', () =>
+      buildDocxFromBodyXml(
+        paragraphWithTextBox('Revised notice', { hyperlinkId: 'rId5' }),
+        relationships,
+        { namespaces: TEXT_BOX_NAMESPACES },
+      ),
+    );
+
+    const result = await when('the documents are compared', () =>
+      compareDocumentsAtomizer(original, revised, {
+        reconstructionMode: 'inplace',
+      }),
+    );
+    const outputXml = await documentXml(result.document);
+
+    await then('the hyperlink survives and the nested story round-trips', () => {
+      const output = parseXml(outputXml);
+      const textBox = output
+        .getElementsByTagNameNS(OOXML.W_NS, 'txbxContent')
+        .item(0)!;
+      expect(
+        textBox.getElementsByTagNameNS(OOXML.W_NS, 'hyperlink').length,
+      ).toBe(1);
+      expect(textBoxText(acceptAllChanges(outputXml))).toBe('Revised notice');
+      expect(textBoxText(rejectAllChanges(outputXml))).toBe('Original notice');
+    });
+  });
+
+  test('preserves direct formatting and an unchanged complex field', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    const story = (text: string): string =>
+      `<w:r><w:rPr><w:b/></w:rPr><w:t>${text}</w:t></w:r>` +
+      COMPLETE_PAGE_FIELD;
+    const original = await given('a formatted story containing a PAGE field', () =>
+      buildDocxFromBodyXml(
+        paragraphWithTextBoxStory(story('Original notice ')),
+        [],
+        { namespaces: TEXT_BOX_NAMESPACES },
+      ),
+    );
+    const revised = await given('an edit beside the unchanged field', () =>
+      buildDocxFromBodyXml(
+        paragraphWithTextBoxStory(story('Revised notice ')),
+        [],
+        { namespaces: TEXT_BOX_NAMESPACES },
+      ),
+    );
+
+    const result = await when('the formatted field-bearing story is compared', () =>
+      compareDocumentsAtomizer(original, revised, {
+        reconstructionMode: 'inplace',
+      }),
+    );
+    const outputXml = await documentXml(result.document);
+
+    await then('formatting, field topology, and projections survive', () => {
+      const output = parseXml(outputXml);
+      const textBox = output
+        .getElementsByTagNameNS(OOXML.W_NS, 'txbxContent')
+        .item(0)!;
+      expect(textBox.getElementsByTagNameNS(OOXML.W_NS, 'b').length)
+        .toBeGreaterThan(0);
+      expect(textBox.getElementsByTagNameNS(OOXML.W_NS, 'fldChar').length)
+        .toBe(3);
+      expect(textBoxText(acceptAllChanges(outputXml)))
+        .toBe('Revised notice  PAGE 1');
+      expect(textBoxText(rejectAllChanges(outputXml)))
+        .toBe('Original notice  PAGE 1');
+    });
+  });
+
+  test('fails closed when the VML shape scaffold changes', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    const original = await given('an original shape and story', () =>
+      buildDocxFromBodyXml(
+        paragraphWithTextBox('Original', { shapeId: 'shape1' }),
+        [],
+        { namespaces: TEXT_BOX_NAMESPACES },
+      ),
+    );
+    const revised = await given('a changed shape identity and story', () =>
+      buildDocxFromBodyXml(
+        paragraphWithTextBox('Revised', { shapeId: 'shape2' }),
+        [],
+        { namespaces: TEXT_BOX_NAMESPACES },
+      ),
+    );
+    let failure: unknown;
+
+    await when('comparison classifies the changed topology', async () => {
+      try {
+        await compareDocumentsAtomizer(original, revised, {
+          reconstructionMode: 'inplace',
+        });
+      } catch (error) {
+        failure = error;
+      }
+    });
+
+    await then('the typed diagnostic identifies scaffold mismatch', () => {
+      expect(failure).toBeInstanceOf(UnsupportedTextBoxRevisionError);
+      expect(failure).toMatchObject({
+        changes: [
+          expect.objectContaining({
+            index: 0,
+            partPath: 'word/document.xml',
+            reason: expect.stringContaining('scaffold'),
+          }),
+        ],
+      });
+    });
+  });
+
+  test('fails closed when text-box topology is inserted or deleted', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    const original = await given('a document without a text box', () =>
+      buildDocxFromBodyXml(paragraph('Body')),
+    );
+    const revised = await given('the same body with an inserted text box', () =>
+      buildDocxFromBodyXml(
+        paragraph('Body') + paragraphWithTextBox('Inserted'),
+        [],
+        { namespaces: TEXT_BOX_NAMESPACES },
+      ),
+    );
+    let failure: unknown;
+
+    await when('comparison classifies the changed topology', async () => {
+      try {
+        await compareDocumentsAtomizer(original, revised, {
+          reconstructionMode: 'inplace',
+        });
+      } catch (error) {
+        failure = error;
+      }
+    });
+
+    await then('the typed diagnostic identifies unsupported topology', () => {
+      expect(failure).toBeInstanceOf(UnsupportedTextBoxRevisionError);
+      expect(failure).toMatchObject({
+        changes: [
+          expect.objectContaining({
+            reason: expect.stringContaining('topology'),
+          }),
+        ],
+      });
+    });
+  });
+
+  test('fails closed for nested text boxes', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    const nestedStory = (text: string): string =>
+      `<w:r><w:t>${text}</w:t></w:r>` +
+      `<w:r><w:pict><v:shape id="nested" o:spid="_x0000_s1099">` +
+      `<v:textbox><w:txbxContent><w:p><w:r><w:t>Nested</w:t></w:r></w:p>` +
+      `</w:txbxContent></v:textbox></v:shape></w:pict></w:r>`;
+    const original = await given('a nested original text box', () =>
+      buildDocxFromBodyXml(
+        paragraphWithTextBoxStory(nestedStory('Original')),
+        [],
+        { namespaces: TEXT_BOX_NAMESPACES },
+      ),
+    );
+    const revised = await given('an edit in its outer story', () =>
+      buildDocxFromBodyXml(
+        paragraphWithTextBoxStory(nestedStory('Revised')),
+        [],
+        { namespaces: TEXT_BOX_NAMESPACES },
+      ),
+    );
+    let failure: unknown;
+
+    await when('comparison classifies the prohibited nesting', async () => {
+      try {
+        await compareDocumentsAtomizer(original, revised, {
+          reconstructionMode: 'inplace',
+        });
+      } catch (error) {
+        failure = error;
+      }
+    });
+
+    await then('the typed diagnostic identifies nested text boxes', () => {
+      expect(failure).toBeInstanceOf(UnsupportedTextBoxRevisionError);
+      expect(failure).toMatchObject({
+        changes: [
+          expect.objectContaining({
+            reason: expect.stringContaining('nested text boxes'),
+          }),
+        ],
+      });
+    });
+  });
+
+  test('fails closed when a changed story is explicitly rebuilt', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    const original = await given('an original text-box story', () =>
+      buildDocxFromBodyXml(
+        paragraphWithTextBox('Original'),
+        [],
+        { namespaces: TEXT_BOX_NAMESPACES },
+      ),
+    );
+    const revised = await given('a revised text-box story', () =>
+      buildDocxFromBodyXml(
+        paragraphWithTextBox('Revised'),
+        [],
+        { namespaces: TEXT_BOX_NAMESPACES },
+      ),
+    );
+    let failure: unknown;
+
+    await when('rebuild comparison is explicitly requested', async () => {
+      try {
+        await compareDocumentsAtomizer(original, revised, {
+          reconstructionMode: 'rebuild',
+        });
+      } catch (error) {
+        failure = error;
+      }
+    });
+
+    await then('the typed diagnostic states the in-place boundary', () => {
+      expect(failure).toBeInstanceOf(UnsupportedTextBoxRevisionError);
+      expect(failure).toMatchObject({
+        changes: [
+          expect.objectContaining({
+            reason: expect.stringContaining('reconstructionMode=inplace'),
+          }),
+        ],
+      });
+    });
+  });
+
+  test('fails closed when a story hyperlink target changes', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    const original = await given('an original linked story', () =>
+      buildDocxFromBodyXml(
+        paragraphWithTextBox('Original', { hyperlinkId: 'rId5' }),
+        [{ id: 'rId5', target: 'https://example.test/original' }],
+        { namespaces: TEXT_BOX_NAMESPACES },
+      ),
+    );
+    const revised = await given('a revised story with a different target', () =>
+      buildDocxFromBodyXml(
+        paragraphWithTextBox('Revised', { hyperlinkId: 'rId5' }),
+        [{ id: 'rId5', target: 'https://example.test/revised' }],
+        { namespaces: TEXT_BOX_NAMESPACES },
+      ),
+    );
+    let failure: unknown;
+
+    await when('comparison resolves the relationship closure', async () => {
+      try {
+        await compareDocumentsAtomizer(original, revised, {
+          reconstructionMode: 'inplace',
+        });
+      } catch (error) {
+        failure = error;
+      }
+    });
+
+    await then('the typed diagnostic identifies the changed closure', () => {
+      expect(failure).toBeInstanceOf(UnsupportedTextBoxRevisionError);
+      expect(failure).toMatchObject({
+        changes: [
+          expect.objectContaining({
+            reason: expect.stringContaining('relationship closure'),
+          }),
+        ],
+      });
+    });
+  });
+
+  test('reports changed header text boxes as an explicit scope boundary', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    const withHeaderStory = async (text: string): Promise<Buffer> => {
+      const archive = await DocxArchive.load(
+        await buildDocxFromBodyXml(paragraph('Body')),
+      );
+      archive.setFile(
+        'word/header1.xml',
+        `<?xml version="1.0"?>` +
+          `<w:hdr xmlns:w="${OOXML.W_NS}"` +
+          ` xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"` +
+          ` xmlns:v="urn:schemas-microsoft-com:vml"` +
+          ` xmlns:o="urn:schemas-microsoft-com:office:office">` +
+          paragraphWithTextBox(text) +
+          `</w:hdr>`,
+      );
+      return archive.save();
+    };
+    const original = await given('an original header text-box story', () =>
+      withHeaderStory('Original header'),
+    );
+    const revised = await given('a revised header text-box story', () =>
+      withHeaderStory('Revised header'),
+    );
+    let failure: unknown;
+
+    await when('comparison discovers ancillary text-box stories', async () => {
+      try {
+        await compareDocumentsAtomizer(original, revised, {
+          reconstructionMode: 'inplace',
+        });
+      } catch (error) {
+        failure = error;
+      }
+    });
+
+    await then('the typed diagnostic reports the exact unsupported part', () => {
+      expect(failure).toBeInstanceOf(UnsupportedTextBoxRevisionError);
+      expect(failure).toMatchObject({
+        changes: [
+          expect.objectContaining({
+            partPath: 'word/header1.xml',
+            reason: expect.stringContaining('ancillary'),
+          }),
+        ],
+      });
+    });
+  });
+});

--- a/packages/docx-compare/src/baselines/atomizer/pipeline.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline.ts
@@ -121,9 +121,13 @@ import {
   AncillaryStorySafetyError,
   evaluateAncillaryFieldSafety,
 } from './ancillaryFieldSafety.js';
-import { assertTextBoxContentUnchanged } from './textBoxRevisionSafety.js';
 import { extractRoundTripComparisonText } from '../../fieldComparisonSemantics.js';
 import { suppressVolatileTocPagerefCacheRevisions } from './tocPagerefCache.js';
+import {
+  assembleTextBoxStoryComparison,
+  prepareTextBoxStoryComparison,
+  UnsupportedTextBoxRevisionError,
+} from './textBoxRevisionSafety.js';
 
 /**
  * Options for the atomizer pipeline.
@@ -588,7 +592,152 @@ function evaluateSafetyChecks(
  * @param options - Pipeline options
  * @returns Comparison result with track changes document
  */
+/**
+ * Compare supported VML text-box content as independent nested stories.
+ *
+ * @conformance ECMA-376 edition 5, Part 4 § 14.9.1.1
+ * @conformance ECMA-376 edition 5, Part 4 § 19.1.2.22
+ * @see https://github.com/UseJunior/safe-docx/issues/713
+ */
 export async function compareDocumentsAtomizer(
+  original: Buffer,
+  revised: Buffer,
+  options: AtomizerOptions = {},
+): Promise<CompareResult> {
+  const textBoxPlan = await prepareTextBoxStoryComparison(original, revised);
+  if (!textBoxPlan) {
+    return compareDocumentsAtomizerCore(original, revised, options);
+  }
+  if (options.reconstructionMode !== 'inplace') {
+    throw new UnsupportedTextBoxRevisionError([{
+      index: textBoxPlan.stories[0]?.index ?? 0,
+      partPath: 'word/document.xml',
+      reason: 'changed text-box stories currently require reconstructionMode=inplace',
+    }]);
+  }
+
+  const nestedOptions: AtomizerOptions = {
+    ...options,
+    reconstructionMode: 'inplace',
+    leanXmlVerifier: undefined,
+  };
+  const outerResult = await compareDocumentsAtomizerCore(
+    textBoxPlan.outerOriginal,
+    textBoxPlan.outerRevised,
+    nestedOptions,
+  );
+  if (outerResult.reconstructionModeUsed !== 'inplace') {
+    throw new UnsupportedTextBoxRevisionError([{
+      index: textBoxPlan.stories[0]?.index ?? 0,
+      partPath: 'word/document.xml',
+      reason: 'the outer document required rebuild fallback',
+    }]);
+  }
+
+  const storyResults: Array<{ index: number; result: CompareResult }> = [];
+  for (const story of textBoxPlan.stories) {
+    const result = await compareDocumentsAtomizerCore(
+      story.original,
+      story.revised,
+      nestedOptions,
+    );
+    if (result.reconstructionModeUsed !== 'inplace') {
+      throw new UnsupportedTextBoxRevisionError([{
+        index: story.index,
+        partPath: 'word/document.xml',
+        reason: 'the nested story required rebuild fallback',
+      }]);
+    }
+    storyResults.push({ index: story.index, result });
+  }
+
+  const document = await assembleTextBoxStoryComparison(
+    outerResult.document,
+    storyResults.map(({ index, result }) => ({
+      index,
+      document: result.document,
+    })),
+  );
+  const comparedArchive = await DocxArchive.load(document);
+  const comparedDocumentXml = await comparedArchive.getDocumentXml();
+  const acceptedComparison = compareTexts(
+    extractRoundTripComparisonText(textBoxPlan.revisedDocumentXml),
+    extractRoundTripComparisonText(acceptAllChanges(comparedDocumentXml)),
+  );
+  const rejectedComparison = compareTexts(
+    extractRoundTripComparisonText(textBoxPlan.originalDocumentXml),
+    extractRoundTripComparisonText(rejectAllChanges(comparedDocumentXml)),
+  );
+  if (
+    !acceptedComparison.normalizedIdentical ||
+    !rejectedComparison.normalizedIdentical
+  ) {
+    throw new UnsupportedTextBoxRevisionError([{
+      index: textBoxPlan.stories[0]?.index ?? 0,
+      partPath: 'word/document.xml',
+      reason: 'assembled nested stories failed accept/reject round-trip validation',
+    }]);
+  }
+
+  const results = [outerResult, ...storyResults.map(({ result }) => result)];
+  const stats = results.reduce<CompareStats>(
+    (combined, result) => ({
+      insertions: combined.insertions + result.stats.insertions,
+      deletions: combined.deletions + result.stats.deletions,
+      modifications: combined.modifications + result.stats.modifications,
+      insertedRanges: combined.insertedRanges + result.stats.insertedRanges,
+      deletedRanges: combined.deletedRanges + result.stats.deletedRanges,
+      insertedAtoms: combined.insertedAtoms + result.stats.insertedAtoms,
+      deletedAtoms: combined.deletedAtoms + result.stats.deletedAtoms,
+      modifiedParagraphs:
+        combined.modifiedParagraphs + result.stats.modifiedParagraphs,
+      formatChanges: combined.formatChanges + result.stats.formatChanges,
+      formatChangeAtoms:
+        combined.formatChangeAtoms + result.stats.formatChangeAtoms,
+    }),
+    {
+      insertions: 0,
+      deletions: 0,
+      modifications: 0,
+      insertedRanges: 0,
+      deletedRanges: 0,
+      insertedAtoms: 0,
+      deletedAtoms: 0,
+      modifiedParagraphs: 0,
+      formatChanges: 0,
+      formatChangeAtoms: 0,
+    },
+  );
+  const documentIntegrity = options.leanXmlVerifier?.enabled
+    ? await runLeanXmlTripleVerifier({
+        originalDocx: original,
+        revisedDocx: revised,
+        comparedDocx: document,
+        legacyDocumentXml: {
+          original: textBoxPlan.originalDocumentXml,
+          revised: textBoxPlan.revisedDocumentXml,
+          compared: comparedDocumentXml,
+        },
+        reconstructionMode: 'inplace',
+        options: options.leanXmlVerifier,
+      }).then((certificate) => ({
+        ...certificate,
+        exclusions: [
+          ...(certificate.exclusions ?? []),
+          'Nested w:txbxContent stories are not independently enumerated by the compiled verifier.',
+        ],
+      }))
+    : undefined;
+
+  return {
+    ...outerResult,
+    document,
+    stats,
+    documentIntegrity,
+  };
+}
+
+async function compareDocumentsAtomizerCore(
   original: Buffer,
   revised: Buffer,
   options: AtomizerOptions = {}
@@ -642,7 +791,6 @@ export async function compareDocumentsAtomizer(
   // Step 2: Extract document.xml
   const originalXml = canonicalizeWordprocessingPrefixes(await originalArchive.getDocumentXml());
   const revisedXml = canonicalizeWordprocessingPrefixes(await revisedArchive.getDocumentXml());
-  assertTextBoxContentUnchanged(originalXml, revisedXml);
 
   // Extract numbering.xml if available
   const originalNumberingXml = await originalArchive.getNumberingXml() ?? undefined;

--- a/packages/docx-compare/src/baselines/atomizer/textBoxRevisionSafety.ts
+++ b/packages/docx-compare/src/baselines/atomizer/textBoxRevisionSafety.ts
@@ -1,12 +1,19 @@
 import { createHash } from 'node:crypto';
-import { OOXML } from '@usejunior/docx-core';
+import { XMLSerializer } from '@xmldom/xmldom';
+import { DocxArchive, OOXML, parseXml } from '@usejunior/docx-core';
 import { canonicalNode } from './opaquePassthrough.js';
 import { parseDocumentXml } from './xmlToWmlElement.js';
 
 const WORD_2010_NS = 'http://schemas.microsoft.com/office/word/2010/wordml';
+const VML_NS = 'urn:schemas-microsoft-com:vml';
+const RELATIONSHIPS_NS =
+  'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const serializer = new XMLSerializer();
 
 export interface TextBoxRevisionChange {
   index: number;
+  partPath?: string;
+  reason?: string;
   originalParagraphId?: string;
   revisedParagraphId?: string;
 }
@@ -16,25 +23,40 @@ export class UnsupportedTextBoxRevisionError extends Error {
 
   constructor(changes: TextBoxRevisionChange[]) {
     const locations = changes
-      .map(({ index, originalParagraphId, revisedParagraphId }) => {
+      .map(({ index, partPath, reason, originalParagraphId, revisedParagraphId }) => {
         const paragraphIds = [...new Set(
           [originalParagraphId, revisedParagraphId].filter(
             (value): value is string => value !== undefined,
           ),
         )];
-        return paragraphIds.length > 0
-          ? `w:txbxContent[${index}] (paragraph ${paragraphIds.join(' → ')})`
-          : `w:txbxContent[${index}]`;
+        const locator = `${partPath ?? 'word/document.xml'}#w:txbxContent[${index}]`;
+        const paragraphSuffix = paragraphIds.length > 0
+          ? ` (paragraph ${paragraphIds.join(' → ')})`
+          : '';
+        return `${locator}${paragraphSuffix}${reason ? `: ${reason}` : ''}`;
       })
       .join(', ');
     super(
-      `Tracked revisions inside w:txbxContent are unsupported because the comparison ` +
-        `engine cannot currently emit a Word-readable redline for that container. ` +
-        `Changed container(s): ${locations}`,
+      `The requested w:txbxContent change is outside the comparison engine's ` +
+        `supported Word-readable story subset. Changed container(s): ${locations}`,
     );
     this.name = 'UnsupportedTextBoxRevisionError';
     this.changes = changes;
   }
+}
+
+export interface TextBoxStoryInput {
+  index: number;
+  original: Buffer;
+  revised: Buffer;
+}
+
+export interface TextBoxStoryComparisonPlan {
+  outerOriginal: Buffer;
+  outerRevised: Buffer;
+  originalDocumentXml: string;
+  revisedDocumentXml: string;
+  stories: TextBoxStoryInput[];
 }
 
 function textBoxParagraphId(textBox: Element): string | undefined {
@@ -47,6 +69,353 @@ function textBoxes(documentXml: string): Element[] {
   return Array.from(
     root.getElementsByTagNameNS(OOXML.W_NS, 'txbxContent'),
   ) as Element[];
+}
+
+const ANCILLARY_STORY_PART_RE =
+  /^word\/(?:header[^/]*|footer[^/]*|footnotes|endnotes|comments)\.xml$/u;
+
+async function assertAncillaryTextBoxStoriesUnchanged(
+  originalArchive: DocxArchive,
+  revisedArchive: DocxArchive,
+): Promise<void> {
+  const partPaths = new Set([
+    ...originalArchive.listFiles().filter((path) => ANCILLARY_STORY_PART_RE.test(path)),
+    ...revisedArchive.listFiles().filter((path) => ANCILLARY_STORY_PART_RE.test(path)),
+  ]);
+
+  for (const partPath of [...partPaths].sort()) {
+    const originalXml = await originalArchive.getFile(partPath);
+    const revisedXml = await revisedArchive.getFile(partPath);
+    if (
+      !originalXml?.includes('txbxContent') &&
+      !revisedXml?.includes('txbxContent')
+    ) {
+      continue;
+    }
+    const originalStories = originalXml?.includes('txbxContent')
+      ? textBoxes(originalXml)
+      : [];
+    const revisedStories = revisedXml?.includes('txbxContent')
+      ? textBoxes(revisedXml)
+      : [];
+    const count = Math.max(originalStories.length, revisedStories.length);
+    for (let index = 0; index < count; index += 1) {
+      const originalStory = originalStories[index];
+      const revisedStory = revisedStories[index];
+      if (
+        originalStory &&
+        revisedStory &&
+        canonicalNode(originalStory) === canonicalNode(revisedStory)
+      ) {
+        continue;
+      }
+      throw new UnsupportedTextBoxRevisionError([{
+        index,
+        partPath,
+        reason: 'changed ancillary text-box stories are outside the supported main-document scope',
+        originalParagraphId: originalStory
+          ? textBoxParagraphId(originalStory)
+          : undefined,
+        revisedParagraphId: revisedStory
+          ? textBoxParagraphId(revisedStory)
+          : undefined,
+      }]);
+    }
+  }
+}
+
+function directChildElements(element: Element): Element[] {
+  return Array.from(element.childNodes)
+    .filter((child): child is Element => child.nodeType === 1);
+}
+
+function replaceChildren(target: Element, source: Element): void {
+  while (target.firstChild) target.removeChild(target.firstChild);
+  for (const child of Array.from(source.childNodes)) {
+    target.appendChild(target.ownerDocument!.importNode(child, true));
+  }
+}
+
+function createPlaceholder(textBox: Element, index: number): void {
+  while (textBox.firstChild) textBox.removeChild(textBox.firstChild);
+  const document = textBox.ownerDocument!;
+  const paragraph = document.createElementNS(OOXML.W_NS, 'w:p');
+  const run = document.createElementNS(OOXML.W_NS, 'w:r');
+  const text = document.createElementNS(OOXML.W_NS, 'w:t');
+  text.appendChild(
+    document.createTextNode(`__safe_docx_text_box_story_${index}__`),
+  );
+  run.appendChild(text);
+  paragraph.appendChild(run);
+  textBox.appendChild(paragraph);
+}
+
+function nearestShape(textBox: Element): Element | undefined {
+  let node: Node | null = textBox.parentNode;
+  while (node?.nodeType === 1) {
+    const element = node as Element;
+    if (element.namespaceURI === VML_NS && element.localName === 'shape') {
+      return element;
+    }
+    node = node.parentNode;
+  }
+  return undefined;
+}
+
+function scaffoldFingerprint(textBox: Element): string | undefined {
+  const shape = nearestShape(textBox);
+  if (!shape) return undefined;
+  const clone = shape.cloneNode(true) as Element;
+  for (const nested of Array.from(
+    clone.getElementsByTagNameNS(OOXML.W_NS, 'txbxContent'),
+  )) {
+    while (nested.firstChild) nested.removeChild(nested.firstChild);
+  }
+  return canonicalNode(clone);
+}
+
+function unsupportedStoryReason(textBox: Element): string | undefined {
+  if (
+    textBox.getElementsByTagNameNS(OOXML.W_NS, 'txbxContent').length > 0
+  ) {
+    return 'nested text boxes are not supported';
+  }
+
+  const unsupportedReferences = new Set([
+    'commentReference',
+    'endnoteReference',
+    'footnoteReference',
+    'object',
+    'pict',
+  ]);
+  for (const element of Array.from(textBox.getElementsByTagName('*'))) {
+    if (
+      element.namespaceURI === OOXML.W_NS &&
+      unsupportedReferences.has(element.localName)
+    ) {
+      return `nested ${element.tagName} is not supported in this story slice`;
+    }
+  }
+  return undefined;
+}
+
+function relationshipTargets(
+  relationshipsXml: string | null,
+): ReadonlyMap<string, string> {
+  if (!relationshipsXml) return new Map();
+  const document = parseXml(relationshipsXml);
+  const targets = new Map<string, string>();
+  for (const relationship of Array.from(
+    document.getElementsByTagName('Relationship'),
+  )) {
+    const id = relationship.getAttribute('Id');
+    if (!id) continue;
+    targets.set(
+      id,
+      [
+        relationship.getAttribute('Type') ?? '',
+        relationship.getAttribute('Target') ?? '',
+        relationship.getAttribute('TargetMode') ?? '',
+      ].join('|'),
+    );
+  }
+  return targets;
+}
+
+function relationshipClosureFingerprint(
+  textBox: Element,
+  targets: ReadonlyMap<string, string>,
+): string | undefined {
+  const references: string[] = [];
+  for (const element of Array.from(textBox.getElementsByTagName('*'))) {
+    const relationshipId =
+      element.getAttributeNS(RELATIONSHIPS_NS, 'id') ||
+      element.getAttribute('r:id');
+    if (!relationshipId) continue;
+    const target = targets.get(relationshipId);
+    if (!target) return undefined;
+    references.push(
+      `{${element.namespaceURI ?? ''}}${element.localName}|${target}`,
+    );
+  }
+  return references.join('\n');
+}
+
+function storyDocumentXml(documentXml: string, textBoxIndex: number): string {
+  const document = parseXml(documentXml);
+  const body = document.getElementsByTagNameNS(OOXML.W_NS, 'body').item(0);
+  const textBox = document
+    .getElementsByTagNameNS(OOXML.W_NS, 'txbxContent')
+    .item(textBoxIndex);
+  if (!body || !textBox) {
+    throw new Error(`Could not isolate w:txbxContent[${textBoxIndex}]`);
+  }
+  replaceChildren(body, textBox);
+  return serializer.serializeToString(document);
+}
+
+/**
+ * Split supported changed VML text boxes into independent WordprocessingML
+ * stories and neutralize them for the outer-body comparison.
+ *
+ * @conformance ECMA-376 edition 5, Part 4 § 14.9.1.1
+ * @conformance ECMA-376 edition 5, Part 4 § 19.1.2.22
+ * @see https://github.com/UseJunior/safe-docx/issues/713
+ */
+export async function prepareTextBoxStoryComparison(
+  original: Buffer,
+  revised: Buffer,
+): Promise<TextBoxStoryComparisonPlan | undefined> {
+  const originalArchive = await DocxArchive.load(original);
+  const revisedArchive = await DocxArchive.load(revised);
+  await assertAncillaryTextBoxStoriesUnchanged(
+    originalArchive,
+    revisedArchive,
+  );
+  const originalDocumentXml = await originalArchive.getDocumentXml();
+  const revisedDocumentXml = await revisedArchive.getDocumentXml();
+  const originalRelationshipTargets = relationshipTargets(
+    await originalArchive.getFile('word/_rels/document.xml.rels'),
+  );
+  const revisedRelationshipTargets = relationshipTargets(
+    await revisedArchive.getFile('word/_rels/document.xml.rels'),
+  );
+  const originalDocument = parseXml(originalDocumentXml);
+  const revisedDocument = parseXml(revisedDocumentXml);
+  const originalTextBoxes = Array.from(
+    originalDocument.getElementsByTagNameNS(OOXML.W_NS, 'txbxContent'),
+  );
+  const revisedTextBoxes = Array.from(
+    revisedDocument.getElementsByTagNameNS(OOXML.W_NS, 'txbxContent'),
+  );
+
+  if (originalTextBoxes.length !== revisedTextBoxes.length) {
+    throw new UnsupportedTextBoxRevisionError([{
+      index: Math.min(originalTextBoxes.length, revisedTextBoxes.length),
+      partPath: 'word/document.xml',
+      reason: 'inserted or deleted text-box topology is not supported',
+    }]);
+  }
+
+  const changedIndices: number[] = [];
+  for (let index = 0; index < originalTextBoxes.length; index += 1) {
+    const originalTextBox = originalTextBoxes[index]!;
+    const revisedTextBox = revisedTextBoxes[index]!;
+    if (canonicalNode(originalTextBox) === canonicalNode(revisedTextBox)) {
+      continue;
+    }
+    const originalRelationshipClosure = relationshipClosureFingerprint(
+      originalTextBox,
+      originalRelationshipTargets,
+    );
+    const revisedRelationshipClosure = relationshipClosureFingerprint(
+      revisedTextBox,
+      revisedRelationshipTargets,
+    );
+    const reason =
+      unsupportedStoryReason(originalTextBox) ??
+      unsupportedStoryReason(revisedTextBox) ??
+      (originalRelationshipClosure === undefined ||
+      revisedRelationshipClosure === undefined ||
+      originalRelationshipClosure !== revisedRelationshipClosure
+        ? 'the text-box relationship closure changed or could not be resolved'
+        : undefined) ??
+      (scaffoldFingerprint(originalTextBox) !==
+      scaffoldFingerprint(revisedTextBox)
+        ? 'the containing VML shape scaffold changed or could not be paired'
+        : undefined);
+    if (reason) {
+      throw new UnsupportedTextBoxRevisionError([{
+        index,
+        partPath: 'word/document.xml',
+        reason,
+        originalParagraphId: textBoxParagraphId(originalTextBox),
+        revisedParagraphId: textBoxParagraphId(revisedTextBox),
+      }]);
+    }
+    changedIndices.push(index);
+  }
+
+  if (changedIndices.length === 0) return undefined;
+
+  const stories: TextBoxStoryInput[] = [];
+  for (const index of changedIndices) {
+    const storyOriginalArchive = await originalArchive.clone();
+    const storyRevisedArchive = await revisedArchive.clone();
+    storyOriginalArchive.setDocumentXml(
+      storyDocumentXml(originalDocumentXml, index),
+    );
+    storyRevisedArchive.setDocumentXml(
+      storyDocumentXml(revisedDocumentXml, index),
+    );
+    stories.push({
+      index,
+      original: await storyOriginalArchive.save(),
+      revised: await storyRevisedArchive.save(),
+    });
+    createPlaceholder(originalTextBoxes[index]!, index);
+    createPlaceholder(revisedTextBoxes[index]!, index);
+  }
+
+  const outerOriginalArchive = await originalArchive.clone();
+  const outerRevisedArchive = await revisedArchive.clone();
+  outerOriginalArchive.setDocumentXml(serializer.serializeToString(originalDocument));
+  outerRevisedArchive.setDocumentXml(serializer.serializeToString(revisedDocument));
+
+  return {
+    outerOriginal: await outerOriginalArchive.save(),
+    outerRevised: await outerRevisedArchive.save(),
+    originalDocumentXml,
+    revisedDocumentXml,
+    stories,
+  };
+}
+
+/**
+ * Splice independently compared text-box stories into the preserved outer
+ * document scaffold.
+ */
+export async function assembleTextBoxStoryComparison(
+  outerCompared: Buffer,
+  storyResults: ReadonlyArray<{ index: number; document: Buffer }>,
+): Promise<Buffer> {
+  const outerArchive = await DocxArchive.load(outerCompared);
+  const outerDocument = parseXml(await outerArchive.getDocumentXml());
+  const outerTextBoxes = Array.from(
+    outerDocument.getElementsByTagNameNS(OOXML.W_NS, 'txbxContent'),
+  );
+
+  for (const storyResult of storyResults) {
+    const target = outerTextBoxes[storyResult.index];
+    if (!target) {
+      throw new UnsupportedTextBoxRevisionError([{
+        index: storyResult.index,
+        partPath: 'word/document.xml',
+        reason: 'the outer comparison changed text-box story topology',
+      }]);
+    }
+    const storyArchive = await DocxArchive.load(storyResult.document);
+    const storyDocument = parseXml(await storyArchive.getDocumentXml());
+    const storyBody = storyDocument
+      .getElementsByTagNameNS(OOXML.W_NS, 'body')
+      .item(0);
+    if (!storyBody) {
+      throw new Error(`Compared text-box story ${storyResult.index} has no w:body`);
+    }
+    while (target.firstChild) target.removeChild(target.firstChild);
+    for (const child of directChildElements(storyBody)) {
+      if (
+        child.namespaceURI === OOXML.W_NS &&
+        child.localName === 'sectPr'
+      ) {
+        continue;
+      }
+      target.appendChild(outerDocument.importNode(child, true));
+    }
+  }
+
+  outerArchive.setDocumentXml(serializer.serializeToString(outerDocument));
+  return outerArchive.save();
 }
 
 /**

--- a/spec-compliance/CONFORMANCE.md
+++ b/spec-compliance/CONFORMANCE.md
@@ -13,6 +13,10 @@ Allure labels via `testAllure.conformance({…})`; source code carries
 
 | ID | Title | Edition | Part | Section | Schema reference | Verified by |
 | --- | --- | --- | --- | --- | --- | --- |
+| `ECMA-PART4-14-9-1-1` | VML rich text-box content (w:txbxContent) | 5 | 4 | 14.9.1.1 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:txbxContent` | packages/docx-compare/src/baselines/atomizer/textBoxRevisionSafety.ts; packages/docx-compare/src/baselines/atomizer/pipeline.ts; packages/docx-compare/src/baselines/atomizer/pipeline-text-box-stories.test.ts |
+| `ECMA-PART4-19-1-2-22` | VML text-box host (v:textbox) | 5 | 4 | 19.1.2.22 | `spec-compliance/ecma-376/schemas/transitional/vml-main.xsd#type:CT_Textbox` | packages/docx-compare/src/baselines/atomizer/textBoxRevisionSafety.ts; packages/docx-compare/src/baselines/atomizer/pipeline.ts; packages/docx-compare/src/baselines/atomizer/pipeline-text-box-stories.test.ts |
+| `ECMA-PART1-17-13-5-14` | Deleted run content | 5 | 1 | 17.13.5.14 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:del` | packages/docx-compare/src/baselines/atomizer/pipeline-text-box-stories.test.ts |
+| `ECMA-PART1-17-13-5-18` | Inserted run content | 5 | 1 | 17.13.5.18 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:ins` | packages/docx-compare/src/baselines/atomizer/pipeline-text-box-stories.test.ts |
 | `ECMA-PART1-17-16-13` | w:delInstrText containment in tracked deletions | 5 | 1 | 17.16.13 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:delInstrText` | packages/docx-compare/src/baselines/atomizer/pipeline.ts; packages/docx-compare/src/baselines/atomizer/inPlaceModifier-deletion.ts; packages/docx-compare/src/baselines/atomizer/pipeline.field-validation.test.ts; packages/docx-core/src/integration/lean-spec-bridge.test.ts; verification/lean/Tier2/XmlTripleChecker.lean; verification/registry/lean-xml-checker-coverage.json |
 | `ECMA-PART1-17-13-5` | Paragraph-level OOXML markers | 5 | 1 | 17.13.5 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:pPrChange` | packages/docx-compare/src/atomizer.ts; packages/docx-core/src/integration/cross-implementation-suite.test.ts; packages/docx-core/src/integration/libreoffice-oracle-trust-boundary.test.ts |
 | `ECMA-PART1-17-13-6-1` | Bookmark end | 5 | 1 | 17.13.6.1 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:bookmarkEnd` | packages/docx-core/src/integration/advanced-revision-classification.test.ts |
@@ -131,6 +135,62 @@ Allure labels via `testAllure.conformance({…})`; source code carries
 | `ECMA-PART1-17-13-5-34` | Table-property revisions (w:tblPrChange) | 5 | 1 | 17.13.5.34 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:tblPrChange` | packages/docx-core/src/primitives/accept_changes.ts; packages/docx-core/src/primitives/reject_changes.ts; packages/docx-core/src/integration/advanced-revision-classification.test.ts |
 | `ECMA-PART1-17-13-5-36` | Table-cell-property revisions (w:tcPrChange) | 5 | 1 | 17.13.5.36 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:tcPrChange` | packages/docx-core/src/primitives/track-changes-emitter.ts; packages/docx-core/src/primitives/accept_changes.ts; packages/docx-core/src/primitives/reject_changes.ts; packages/docx-core/src/integration/advanced-revision-classification.test.ts |
 | `ECMA-PART1-17-13-5-37` | Table-row-property revisions (w:trPrChange) | 5 | 1 | 17.13.5.37 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:trPrChange` | packages/docx-core/src/primitives/track-changes-emitter.ts; packages/docx-core/src/primitives/accept_changes.ts; packages/docx-core/src/primitives/reject_changes.ts; packages/docx-core/src/integration/advanced-revision-classification.test.ts |
+
+### ECMA-PART4-14-9-1-1 — VML rich text-box content (w:txbxContent)
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 4 § 14.9.1.1
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:txbxContent`
+- **Verified by:** packages/docx-compare/src/baselines/atomizer/textBoxRevisionSafety.ts; packages/docx-compare/src/baselines/atomizer/pipeline.ts; packages/docx-compare/src/baselines/atomizer/pipeline-text-box-stories.test.ts
+
+Part 4 §14.9.1.1 defines `w:txbxContent` as the rich
+WordprocessingML-content container inside a VML drawing object. It prohibits
+references to comments, footnotes, and endnotes, as well as nested
+`w:txbxContent`. safe-docx compares a bounded main-document subset as an
+independent story, preserves its surrounding VML scaffold, and rejects those
+prohibited nested forms before comparison. This claim does not cover
+DrawingML text boxes, ancillary-part text boxes, inserted/deleted text-box
+topology, or changes to the containing VML scaffold or relationship closure.
+
+### ECMA-PART4-19-1-2-22 — VML text-box host (v:textbox)
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 4 § 19.1.2.22
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/vml-main.xsd#type:CT_Textbox`
+- **Verified by:** packages/docx-compare/src/baselines/atomizer/textBoxRevisionSafety.ts; packages/docx-compare/src/baselines/atomizer/pipeline.ts; packages/docx-compare/src/baselines/atomizer/pipeline-text-box-stories.test.ts
+
+Part 4 §19.1.2.22 defines the Transitional VML `v:textbox` host. For the
+accepted comparison subset, safe-docx requires a stable containing
+`v:shape`/`v:textbox` scaffold and places tracked changes only in the hosted
+WordprocessingML story, never around the drawing object.
+
+### ECMA-PART1-17-13-5-14 — Deleted run content
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.13.5.14
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:del`
+- **Verified by:** packages/docx-compare/src/baselines/atomizer/pipeline-text-box-stories.test.ts
+
+Part 1 §17.13.5.14 defines `w:del` as deleted inline run content.
+safe-docx emits this ordinary run-level revision form inside supported VML
+text-box stories and validates that rejecting the assembled comparison
+recovers the original story text.
+
+### ECMA-PART1-17-13-5-18 — Inserted run content
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.13.5.18
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:ins`
+- **Verified by:** packages/docx-compare/src/baselines/atomizer/pipeline-text-box-stories.test.ts
+
+Part 1 §17.13.5.18 defines `w:ins` as inserted inline run content.
+safe-docx emits this ordinary run-level revision form inside supported VML
+text-box stories and validates that accepting the assembled comparison
+recovers the revised story text.
 
 ### ECMA-PART1-17-16-13 — w:delInstrText containment in tracked deletions
 

--- a/spec-compliance/registry/ecma-376.md
+++ b/spec-compliance/registry/ecma-376.md
@@ -12,6 +12,74 @@ outlive a future migration off OpenSpec. Entries are parsed by
 
 ## Targeted sections
 
+## [ECMA-PART4-14-9-1-1] VML rich text-box content (w:txbxContent)
+
+```yaml
+edition: 5
+part: 4
+section: "14.9.1.1"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:txbxContent
+verifiedBy: packages/docx-compare/src/baselines/atomizer/textBoxRevisionSafety.ts; packages/docx-compare/src/baselines/atomizer/pipeline.ts; packages/docx-compare/src/baselines/atomizer/pipeline-text-box-stories.test.ts
+```
+
+Part 4 §14.9.1.1 defines `w:txbxContent` as the rich
+WordprocessingML-content container inside a VML drawing object. It prohibits
+references to comments, footnotes, and endnotes, as well as nested
+`w:txbxContent`. safe-docx compares a bounded main-document subset as an
+independent story, preserves its surrounding VML scaffold, and rejects those
+prohibited nested forms before comparison. This claim does not cover
+DrawingML text boxes, ancillary-part text boxes, inserted/deleted text-box
+topology, or changes to the containing VML scaffold or relationship closure.
+
+## [ECMA-PART4-19-1-2-22] VML text-box host (v:textbox)
+
+```yaml
+edition: 5
+part: 4
+section: "19.1.2.22"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/vml-main.xsd#type:CT_Textbox
+verifiedBy: packages/docx-compare/src/baselines/atomizer/textBoxRevisionSafety.ts; packages/docx-compare/src/baselines/atomizer/pipeline.ts; packages/docx-compare/src/baselines/atomizer/pipeline-text-box-stories.test.ts
+```
+
+Part 4 §19.1.2.22 defines the Transitional VML `v:textbox` host. For the
+accepted comparison subset, safe-docx requires a stable containing
+`v:shape`/`v:textbox` scaffold and places tracked changes only in the hosted
+WordprocessingML story, never around the drawing object.
+
+## [ECMA-PART1-17-13-5-14] Deleted run content
+
+```yaml
+edition: 5
+part: 1
+section: "17.13.5.14"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:del
+verifiedBy: packages/docx-compare/src/baselines/atomizer/pipeline-text-box-stories.test.ts
+```
+
+Part 1 §17.13.5.14 defines `w:del` as deleted inline run content.
+safe-docx emits this ordinary run-level revision form inside supported VML
+text-box stories and validates that rejecting the assembled comparison
+recovers the original story text.
+
+## [ECMA-PART1-17-13-5-18] Inserted run content
+
+```yaml
+edition: 5
+part: 1
+section: "17.13.5.18"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:ins
+verifiedBy: packages/docx-compare/src/baselines/atomizer/pipeline-text-box-stories.test.ts
+```
+
+Part 1 §17.13.5.18 defines `w:ins` as inserted inline run content.
+safe-docx emits this ordinary run-level revision form inside supported VML
+text-box stories and validates that accepting the assembled comparison
+recovers the revised story text.
+
 ## [ECMA-PART1-17-16-13] w:delInstrText containment in tracked deletions
 
 ```yaml


### PR DESCRIPTION
## What changed

- isolate supported main-document VML `w:txbxContent` paragraph stories
- compare each story through the shared in-place atomizer pipeline
- splice tracked revisions back into the preserved VML scaffold
- validate whole-document accept/reject projections after assembly
- fail closed with typed, content-free diagnostics for unsupported topology, relationships, scaffold changes, nesting, rebuild, and ancillary stories
- disclose nested text-box stories as a Lean certificate exclusion until compiled coverage lands
- register the exact ECMA-376 Part 4 VML clauses and Part 1 run-revision clauses

## Why

The prior corruption guard correctly rejected changed text boxes, but that meant one ordinary notice or address edit could stop an otherwise valid comparison. This adds the bounded main-document capability without weakening fail-closed behavior outside the accepted subset.

Relationship-bound header/footer text-box comparison remains separately tracked in #726. This PR detects that boundary instead of silently copying an unrepresented ancillary edit.

## Validation

- focused text-box and safety suites: 14 passed
- mandatory monorepo build and workspace lint: passed
- mandatory full test suite: passed outside the sandbox, including LibreOffice and CLI IPC probes
- spec coverage, conformance citations, generated conformance document: passed
- OpenSpec strict validation: passed
- confidential-term scan of the public diff: clean
- confidentiality-safe private oracle: main story advances to successful in-place comparison; relationship-bound footer scope now fails closed and is tracked by #726

Ref: #713
Ref: #718
Ref: #726
