### PR TITLE
feat(docx-comparison): compare relationship-bound text boxes

### DIFF
--- a/openspec/changes/compare-vml-text-box-stories/design.md
+++ b/openspec/changes/compare-vml-text-box-stories/design.md
@@ -11,6 +11,7 @@ text box.
 The first supported subset is deliberately narrow:
 
 - VML text boxes in `word/document.xml`;
+- VML text boxes in relationship-selected headers and footers;
 - the same number and order of boxes on both sides;
 - unchanged scaffold outside each `w:txbxContent`;
 - non-nested WordprocessingML paragraph content inside the box; and
@@ -55,13 +56,50 @@ After splicing each compared story into the preserved scaffold:
 - field, bookmark, relationship, and consumer-openability checks continue to
   apply to the assembled package.
 
-### 5. Fail closed outside the accepted subset
+### 5. Pair ancillary stories by semantic selection and scaffold
+
+Header/footer filenames are allocation details and cannot establish story
+identity. The implementation reuses the typed `auditSectPr` primitive to resolve
+each direct first/default/even selector to a normalized target part. Physical
+stories are paired first by unchanged canonical content and then by a unique
+kind-plus-scaffold identity. A same story may therefore move from one
+`headerN.xml` or `footerN.xml` path to another without becoming an insertion.
+
+For selected stories that exist on only one side, section sequences are aligned
+after replacing paired story targets with shared semantic identities. A
+side-only story is a supported whole-story lifecycle only when every binding
+selecting it belongs to an unmatched inserted/deleted section. This permits a
+new section to introduce its own footer while rejecting a changed or replaced
+story hidden behind an otherwise corresponding section.
+
+### 6. Reuse the main comparison projection for ancillary stories
+
+Each changed ancillary text box is wrapped temporarily in the same main-story
+package shape already used for main-document text boxes. Its owning
+header/footer relationship table is installed as the temporary main
+relationship table, so hyperlink and drawing relationship identity continues
+to use the shared atomizer salt. Only the compared paragraph children are
+spliced back into the selected revised ancillary part; the header/footer root,
+VML scaffold, section selectors, and package relationships remain owned by the
+outer package.
+
+### 7. Validate relationship-selected package projections
+
+After assembly, accept-all and reject-all are applied to the main document and
+to every selected header/footer part. The resulting ordered selector inventory
+is resolved through the final package relationships and compared with the
+revised and original inventories respectively. This makes a lifecycle decision
+publishable only when the accepted package selects the revised stories and the
+rejected package selects the original stories.
+
+### 8. Fail closed outside the accepted subset
 
 Inserted/deleted/reordered text boxes, changed VML/DrawingML scaffold, nested
-text boxes, and text boxes in headers/footers are not silently flattened or
-ignored. They retain a typed unsupported-story diagnostic with a stable locator.
+text boxes, ambiguous ancillary story pairing, and side-only stories selected
+from corresponding sections are not silently flattened or ignored. They retain
+a typed unsupported-story diagnostic with a stable locator.
 
-### 6. Keep verifier coverage honest
+### 9. Keep verifier coverage honest
 
 The compiled verifier must either check each supported text-box story or return
 a structured uncovered-story item. A successful document comparison is not yet
@@ -84,6 +122,9 @@ a full verifier certificate until this coverage item is discharged.
   declarations.
 - Story order alone is insufficient when boxes are inserted or reordered. This
   slice rejects those cases rather than guessing.
+- Repeated identical section/story scaffolds can make an ancillary pairing
+  ambiguous. The classifier accepts exact-content multiplicity, but requires a
+  unique semantic scaffold for a changed story and otherwise fails closed.
 - Recursive pipeline use can recurse through nested boxes. Nested discovery is
   explicitly rejected and internal story comparison runs on isolated paragraph
   content with no text-box descendants.

--- a/openspec/changes/compare-vml-text-box-stories/proposal.md
+++ b/openspec/changes/compare-vml-text-box-stories/proposal.md
@@ -15,15 +15,17 @@ outer drawing object.
 
 - Discover paired `w:txbxContent` stories in the main document and assign each a
   deterministic locator.
+- Resolve selected header/footer stories through `w:sectPr` bindings and pair
+  their physical parts by semantic story identity rather than raw package path.
 - Compare supported text-box paragraph content independently with ordinary
   WordprocessingML tracked insertions and deletions.
 - Keep the containing VML/DrawingML scaffold out of the outer-body diff and
   splice the compared nested story back into the preserved revised scaffold.
 - Require accept-all and reject-all parity for both the outer document and each
   supported text-box story.
-- Retain an explicit fail-closed boundary for inserted, deleted, reordered,
-  nested, ancillary-part, or structurally changed text boxes until those shapes
-  receive separate support.
+- Treat a side-only selected header/footer story as a whole-story lifecycle only
+  when every selector belongs to an inserted/deleted section; reject ambiguous
+  insertion, deletion, reorder, nesting, or scaffold mutation.
 - Report text-box stories as an explicit verifier coverage item; a certificate
   may not silently claim full-story coverage while the compiled verifier does
   not parse them.
@@ -35,3 +37,4 @@ outer drawing object.
   reconstruction, round-trip validation, focused fixtures, verifier coverage
 - Fixes: #713
 - Related: #647, #688, #718
+- Follow-up slice: #726

--- a/openspec/changes/compare-vml-text-box-stories/specs/docx-comparison/spec.md
+++ b/openspec/changes/compare-vml-text-box-stories/specs/docx-comparison/spec.md
@@ -31,7 +31,7 @@ The system SHALL compare the paragraph content of `w:txbxContent` as an independ
 
 #### Scenario: [SDX-TXBX-04] Unsupported text-box topology fails closed
 
-- **GIVEN** an inserted, deleted, reordered, nested, scaffold-mutated, header, or footer text box
+- **GIVEN** an inserted, deleted, reordered, nested, scaffold-mutated, or ambiguously paired text box
 - **WHEN** comparison classifies the text-box stories
 - **THEN** it SHALL fail with a typed unsupported text-box story diagnostic
 - **AND** the diagnostic SHALL identify the package part and stable story locator
@@ -43,3 +43,35 @@ The system SHALL compare the paragraph content of `w:txbxContent` as an independ
 - **WHEN** the compiled verifier evaluates the comparison triple
 - **THEN** it SHALL either verify that nested story or report it as an uncovered story
 - **AND** a certificate SHALL NOT claim complete story coverage while any text-box story remains uncovered
+
+#### Scenario: [SDX-TXBX-06] Relationship-selected story survives physical-part renumbering
+
+- **GIVEN** corresponding section slots select semantically paired header/footer stories at different physical package paths
+- **AND** their VML scaffolds match while supported nested paragraph content differs
+- **WHEN** in-place comparison runs
+- **THEN** the stories SHALL be paired through typed section bindings and semantic scaffold identity rather than raw filenames
+- **AND** tracked revisions SHALL be spliced into the revised selected part
+- **AND** the final section selectors and owning-part relationships SHALL remain closed
+
+#### Scenario: [SDX-TXBX-07] New section owns a side-only story lifecycle
+
+- **GIVEN** an inserted or deleted section whose direct selector is the only binding to a side-only header/footer text-box story
+- **WHEN** comparison classifies relationship-selected stories
+- **THEN** the complete story SHALL be treated as lifecycle content of that inserted/deleted section
+- **AND** it SHALL NOT be paired with an unrelated physical story
+- **AND** accepting and rejecting the final package SHALL select the intended revised and original story inventories
+
+#### Scenario: [SDX-TXBX-08] Ambiguous ancillary topology fails closed
+
+- **GIVEN** a changed header/footer text-box story has multiple possible semantic counterparts
+- **OR** a side-only story is selected by a section that corresponds across both inputs
+- **WHEN** comparison classifies relationship-selected stories
+- **THEN** it SHALL fail with a typed non-content-bearing diagnostic
+- **AND** it SHALL NOT publish stale, duplicated, or silently copied ancillary text
+
+#### Scenario: [SDX-TXBX-09] Ancillary text-box projections recover both sources
+
+- **GIVEN** a supported same-path or renumbered-path header/footer text-box edit
+- **WHEN** the compared package is assembled
+- **THEN** accepting all changes in every selected story SHALL recover the revised selector/story inventory
+- **AND** rejecting all changes in every selected story SHALL recover the original selector/story inventory

--- a/openspec/changes/compare-vml-text-box-stories/tasks.md
+++ b/openspec/changes/compare-vml-text-box-stories/tasks.md
@@ -33,4 +33,17 @@
 
 - [x] 6.1 Run focused tests and the mandatory repository pre-submit command.
 - [x] 6.2 Review the public diff for confidential identifiers and bounded scope.
-- [ ] 6.3 Commit, push, merge through a focused PR, and perform a real-document post-merge smoke.
+- [x] 6.3 Commit, push, merge through a focused PR, and perform a real-document post-merge smoke.
+
+## 7. Relationship-selected header/footer stories (#726)
+
+- [x] 7.1 Resolve selected physical stories with the shared `auditSectPr` primitive.
+- [x] 7.2 Pair same-path and renumbered header/footer stories by canonical content and unique scaffold identity.
+- [x] 7.3 Classify side-only stories only when all selectors belong to an inserted/deleted section.
+- [x] 7.4 Compare paired ancillary text boxes through the shared in-place atomizer pipeline.
+- [x] 7.5 Splice revisions into the selected revised part while preserving scaffold and relationship closure.
+- [x] 7.6 Validate accepted/rejected relationship-selected story inventories against both source packages.
+- [x] 7.7 Add same-path, renumbered-path, new-section lifecycle, and ambiguous-topology fixtures.
+- [x] 7.8 Report covered ancillary text-box stories as explicit compiled-verifier exclusions.
+- [x] 7.9 Re-run the private third-pair oracle and record aggregate-only results.
+- [ ] 7.10 Run mandatory pre-submit checks, publish through a focused PR, and perform a real-document smoke.

--- a/packages/docx-compare/src/baselines/atomizer/pipeline-text-box-stories.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline-text-box-stories.test.ts
@@ -5,7 +5,10 @@
  * @conformance ECMA-376 edition 5, Part 4 § 19.1.2.22
  * @conformance ECMA-376 edition 5, Part 1 § 17.13.5.14
  * @conformance ECMA-376 edition 5, Part 1 § 17.13.5.18
+ * @conformance ECMA-376 edition 5, Part 1 § 17.10.5
+ * @conformance ECMA-376 edition 5, Part 1 § 17.10.3
  * @see https://github.com/UseJunior/safe-docx/issues/713
+ * @see https://github.com/UseJunior/safe-docx/issues/726
  */
 
 import { describe, expect } from 'vitest';
@@ -36,6 +39,8 @@ const test = testAllure
     { spec: 'ECMA-376', edition: 5, part: 4, section: '19.1.2.22' },
     { spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.5.14' },
     { spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.5.18' },
+    { spec: 'ECMA-376', edition: 5, part: 1, section: '17.10.5' },
+    { spec: 'ECMA-376', edition: 5, part: 1, section: '17.10.3' },
   );
 
 const TEXT_BOX_NAMESPACES = {
@@ -43,6 +48,10 @@ const TEXT_BOX_NAMESPACES = {
   o: 'urn:schemas-microsoft-com:office:office',
   r: 'http://schemas.openxmlformats.org/officeDocument/2006/relationships',
 } as const;
+const HEADER_RELATIONSHIP =
+  'http://schemas.openxmlformats.org/officeDocument/2006/relationships/header';
+const FOOTER_RELATIONSHIP =
+  'http://schemas.openxmlformats.org/officeDocument/2006/relationships/footer';
 
 function paragraph(text: string): string {
   return `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
@@ -88,6 +97,97 @@ function paragraphWithTextBoxStory(
     `</w:txbxContent></v:textbox>` +
     `</v:shape></w:pict></w:r></w:p>`
   );
+}
+
+function ancillaryStory(
+  kind: 'header' | 'footer',
+  text: string,
+  shapeId = 'shape1',
+  hyperlinkId?: string,
+): string {
+  const root = kind === 'header' ? 'hdr' : 'ftr';
+  return (
+    `<?xml version="1.0"?>` +
+    `<w:${root} xmlns:w="${OOXML.W_NS}"` +
+    ` xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"` +
+    ` xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"` +
+    ` xmlns:v="urn:schemas-microsoft-com:vml"` +
+    ` xmlns:o="urn:schemas-microsoft-com:office:office">` +
+    paragraphWithTextBox(text, { shapeId, hyperlinkId }) +
+    `</w:${root}>`
+  );
+}
+
+interface SelectedStoryFixtureOptions {
+  text: string;
+  target?: string;
+  shapeId?: string;
+  bodyXml?: string;
+  sectPrXml?: string;
+  storyHyperlinkId?: string;
+  storyHyperlinkTarget?: string;
+}
+
+async function selectedStoryFixture(
+  kind: 'header' | 'footer',
+  options: SelectedStoryFixtureOptions,
+): Promise<Buffer> {
+  const target = options.target ?? `${kind}1.xml`;
+  const relationshipId = kind === 'header' ? 'rIdHeader' : 'rIdFooter';
+  const archive = await DocxArchive.load(
+    await buildDocxFromBodyXml(
+      options.bodyXml ?? paragraph('Body'),
+      [],
+      {
+        namespaces: {
+          r: 'http://schemas.openxmlformats.org/officeDocument/2006/relationships',
+        },
+      },
+    ),
+  );
+  archive.setDocumentXml(
+    (await archive.getDocumentXml()).replace(
+      '<w:sectPr/>',
+      options.sectPrXml ??
+        `<w:sectPr><w:${kind}Reference w:type="default" r:id="${relationshipId}"/></w:sectPr>`,
+    ),
+  );
+  archive.setFile(
+    'word/_rels/document.xml.rels',
+    `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+      `<Relationship Id="${relationshipId}"` +
+      ` Type="${kind === 'header' ? HEADER_RELATIONSHIP : FOOTER_RELATIONSHIP}"` +
+      ` Target="${target}"/>` +
+      `</Relationships>`,
+  );
+  archive.setFile(
+    `word/${target}`,
+    ancillaryStory(
+      kind,
+      options.text,
+      options.shapeId,
+      options.storyHyperlinkId,
+    ),
+  );
+  if (options.storyHyperlinkId && options.storyHyperlinkTarget) {
+    archive.setFile(
+      `word/_rels/${target}.rels`,
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="${options.storyHyperlinkId}"` +
+        ` Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink"` +
+        ` Target="${options.storyHyperlinkTarget}" TargetMode="External"/>` +
+        `</Relationships>`,
+    );
+  }
+  return archive.save();
+}
+
+function selectedHeaderFixture(options: SelectedStoryFixtureOptions): Promise<Buffer> {
+  return selectedStoryFixture('header', options);
+}
+
+function selectedFooterFixture(options: SelectedStoryFixtureOptions): Promise<Buffer> {
+  return selectedStoryFixture('footer', options);
 }
 
 async function documentXml(docx: Buffer): Promise<string> {
@@ -578,7 +678,7 @@ describe('VML text-box story comparison (#713)', () => {
     });
   });
 
-  test('reports changed header text boxes as an explicit scope boundary', async ({
+  test('ignores unselected header text boxes instead of pairing raw filenames', async ({
     given,
     when,
     then,
@@ -605,9 +705,181 @@ describe('VML text-box story comparison (#713)', () => {
     const revised = await given('a revised header text-box story', () =>
       withHeaderStory('Revised header'),
     );
+    const result = await when('comparison resolves only selected stories', () =>
+      compareDocumentsAtomizer(original, revised, {
+        reconstructionMode: 'inplace',
+      }),
+    );
+
+    await then('the unselected package allocation does not block comparison', () => {
+      expect(result.stats.insertions).toBe(0);
+      expect(result.stats.deletions).toBe(0);
+    });
+  });
+
+  test('compares a same-path selected header text box', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    const original = await given('a selected original header story', () =>
+      selectedHeaderFixture({ text: 'Original header' }),
+    );
+    const revised = await given('the same selected scaffold with edited text', () =>
+      selectedHeaderFixture({ text: 'Revised header' }),
+    );
+
+    const result = await when('the selected story is compared in place', () =>
+      compareDocumentsAtomizer(original, revised, {
+        reconstructionMode: 'inplace',
+        leanXmlVerifier: {
+          enabled: true,
+          executablePath: '/does/not/exist',
+        },
+      }),
+    );
+    const archive = await DocxArchive.load(result.document);
+    const output = await archive.getFile('word/header1.xml');
+
+    await then('revisions live inside the selected header text box', () => {
+      expect(output).not.toBeNull();
+      const textBox = parseXml(output!)
+        .getElementsByTagNameNS(OOXML.W_NS, 'txbxContent')
+        .item(0);
+      expect(textBox?.getElementsByTagNameNS(OOXML.W_NS, 'ins').length).toBeGreaterThan(0);
+      expect(textBox?.getElementsByTagNameNS(OOXML.W_NS, 'del').length).toBeGreaterThan(0);
+      expect(textBoxText(acceptAllChanges(output!))).toBe('Revised header');
+      expect(textBoxText(rejectAllChanges(output!))).toBe('Original header');
+      expect(result.documentIntegrity?.exclusions).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining('Relationship-selected header/footer'),
+        ]),
+      );
+    });
+  });
+
+  test('pairs a selected header across physical-part renumbering', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    const original = await given('the semantic story at header1.xml', () =>
+      selectedHeaderFixture({ text: 'Original header', target: 'header1.xml' }),
+    );
+    const revised = await given('the edited semantic story at header9.xml', () =>
+      selectedHeaderFixture({ text: 'Revised header', target: 'header9.xml' }),
+    );
+
+    const result = await when('comparison pairs the binding-selected scaffolds', () =>
+      compareDocumentsAtomizer(original, revised, {
+        reconstructionMode: 'inplace',
+      }),
+    );
+    const output = await (await DocxArchive.load(result.document))
+      .getFile('word/header9.xml');
+
+    await then('the revised selected part carries the nested redline', () => {
+      expect(output).not.toBeNull();
+      expect(textBoxText(acceptAllChanges(output!))).toBe('Revised header');
+      expect(textBoxText(rejectAllChanges(output!))).toBe('Original header');
+    });
+  });
+
+  test('preserves a selected story hyperlink across relationship-id renumbering', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    const original = await given('a linked original header story', () =>
+      selectedHeaderFixture({
+        text: 'Original linked header',
+        storyHyperlinkId: 'rIdLink1',
+        storyHyperlinkTarget: 'https://example.test/notice',
+      }),
+    );
+    const revised = await given('the edited story with a reallocated relationship id', () =>
+      selectedHeaderFixture({
+        text: 'Revised linked header',
+        storyHyperlinkId: 'rIdLink9',
+        storyHyperlinkTarget: 'https://example.test/notice',
+      }),
+    );
+
+    const result = await when('the owning relationship table follows the nested story', () =>
+      compareDocumentsAtomizer(original, revised, {
+        reconstructionMode: 'inplace',
+      }),
+    );
+    const archive = await DocxArchive.load(result.document);
+    const [output, relationships] = await Promise.all([
+      archive.getFile('word/header1.xml'),
+      archive.getFile('word/_rels/header1.xml.rels'),
+    ]);
+
+    await then('the revised relationship closure remains selected and resolvable', () => {
+      expect(output).toContain('r:id="rIdLink9"');
+      expect(output).not.toContain('r:id="rIdLink1"');
+      expect(relationships).toContain('Id="rIdLink9"');
+      expect(textBoxText(acceptAllChanges(output!))).toBe('Revised linked header');
+      expect(textBoxText(rejectAllChanges(output!))).toBe('Original linked header');
+    });
+  });
+
+  test('allows a side-only footer story owned by an inserted section', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    const original = await given('one section without a selected header', () =>
+      buildDocxFromBodyXml(paragraph('Body')),
+    );
+    const insertedSection =
+      `<w:p><w:pPr><w:sectPr>` +
+      `<w:footerReference w:type="default" r:id="rIdFooter"/>` +
+      `</w:sectPr></w:pPr><w:r><w:t>Inserted section</w:t></w:r></w:p>`;
+    const revised = await given('an inserted section selecting a new footer story', () =>
+      selectedFooterFixture({
+        text: 'New section footer',
+        target: 'footer9.xml',
+        bodyXml: paragraph('Body') + insertedSection,
+        sectPrXml: '<w:sectPr/>',
+      }),
+    );
+
+    const result = await when('the relationship-aware lifecycle check runs', () =>
+      compareDocumentsAtomizer(original, revised, {
+        reconstructionMode: 'inplace',
+      }),
+    );
+
+    await then('the inserted section lifecycle is publishable', () => {
+      expect(result.reconstructionModeUsed).toBe('inplace');
+      expect(result.stats.insertions).toBeGreaterThan(0);
+    });
+  });
+
+  test('fails closed when a side-only story replaces a corresponding section', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    const original = await given('one selected header scaffold', () =>
+      selectedHeaderFixture({
+        text: 'Original header',
+        target: 'header1.xml',
+        shapeId: 'shape1',
+      }),
+    );
+    const revised = await given('a non-pairable replacement in the same section', () =>
+      selectedHeaderFixture({
+        text: 'Revised header',
+        target: 'header9.xml',
+        shapeId: 'shape9',
+      }),
+    );
     let failure: unknown;
 
-    await when('comparison discovers ancillary text-box stories', async () => {
+    await when('relationship-aware classification refuses to guess', async () => {
       try {
         await compareDocumentsAtomizer(original, revised, {
           reconstructionMode: 'inplace',
@@ -617,16 +889,15 @@ describe('VML text-box story comparison (#713)', () => {
       }
     });
 
-    await then('the typed diagnostic reports the exact unsupported part', () => {
+    await then('a typed non-content-bearing diagnostic identifies the selected part', () => {
       expect(failure).toBeInstanceOf(UnsupportedTextBoxRevisionError);
-      expect(failure).toMatchObject({
-        changes: [
+      expect((failure as UnsupportedTextBoxRevisionError).changes).toEqual(
+        expect.arrayContaining([
           expect.objectContaining({
-            partPath: 'word/header1.xml',
-            reason: expect.stringContaining('ancillary'),
+            reason: expect.stringContaining('exclusively'),
           }),
-        ],
-      });
+        ]),
+      );
     });
   });
 });

--- a/packages/docx-compare/src/baselines/atomizer/pipeline.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline.ts
@@ -125,6 +125,7 @@ import { extractRoundTripComparisonText } from '../../fieldComparisonSemantics.j
 import { suppressVolatileTocPagerefCacheRevisions } from './tocPagerefCache.js';
 import {
   assembleTextBoxStoryComparison,
+  assertAncillaryTextBoxStoryProjection,
   prepareTextBoxStoryComparison,
   UnsupportedTextBoxRevisionError,
 } from './textBoxRevisionSafety.js';
@@ -611,7 +612,7 @@ export async function compareDocumentsAtomizer(
   if (options.reconstructionMode !== 'inplace') {
     throw new UnsupportedTextBoxRevisionError([{
       index: textBoxPlan.stories[0]?.index ?? 0,
-      partPath: 'word/document.xml',
+      partPath: textBoxPlan.stories[0]?.partPath ?? 'word/document.xml',
       reason: 'changed text-box stories currently require reconstructionMode=inplace',
     }]);
   }
@@ -629,12 +630,16 @@ export async function compareDocumentsAtomizer(
   if (outerResult.reconstructionModeUsed !== 'inplace') {
     throw new UnsupportedTextBoxRevisionError([{
       index: textBoxPlan.stories[0]?.index ?? 0,
-      partPath: 'word/document.xml',
+      partPath: textBoxPlan.stories[0]?.partPath ?? 'word/document.xml',
       reason: 'the outer document required rebuild fallback',
     }]);
   }
 
-  const storyResults: Array<{ index: number; result: CompareResult }> = [];
+  const storyResults: Array<{
+    index: number;
+    partPath: string;
+    result: CompareResult;
+  }> = [];
   for (const story of textBoxPlan.stories) {
     const result = await compareDocumentsAtomizerCore(
       story.original,
@@ -644,17 +649,22 @@ export async function compareDocumentsAtomizer(
     if (result.reconstructionModeUsed !== 'inplace') {
       throw new UnsupportedTextBoxRevisionError([{
         index: story.index,
-        partPath: 'word/document.xml',
+        partPath: story.partPath,
         reason: 'the nested story required rebuild fallback',
       }]);
     }
-    storyResults.push({ index: story.index, result });
+    storyResults.push({
+      index: story.index,
+      partPath: story.partPath,
+      result,
+    });
   }
 
   const document = await assembleTextBoxStoryComparison(
     outerResult.document,
-    storyResults.map(({ index, result }) => ({
+    storyResults.map(({ index, partPath, result }) => ({
       index,
+      partPath,
       document: result.document,
     })),
   );
@@ -674,9 +684,12 @@ export async function compareDocumentsAtomizer(
   ) {
     throw new UnsupportedTextBoxRevisionError([{
       index: textBoxPlan.stories[0]?.index ?? 0,
-      partPath: 'word/document.xml',
+      partPath: textBoxPlan.stories[0]?.partPath ?? 'word/document.xml',
       reason: 'assembled nested stories failed accept/reject round-trip validation',
     }]);
+  }
+  if (textBoxPlan.validateAncillaryProjection) {
+    await assertAncillaryTextBoxStoryProjection(original, revised, document);
   }
 
   const results = [outerResult, ...storyResults.map(({ result }) => result)];
@@ -725,6 +738,11 @@ export async function compareDocumentsAtomizer(
         exclusions: [
           ...(certificate.exclusions ?? []),
           'Nested w:txbxContent stories are not independently enumerated by the compiled verifier.',
+          ...(textBoxPlan.validateAncillaryProjection
+            ? [
+                'Relationship-selected header/footer w:txbxContent stories are not independently enumerated by the compiled verifier.',
+              ]
+            : []),
         ],
       }))
     : undefined;

--- a/packages/docx-compare/src/baselines/atomizer/textBoxRevisionSafety.ts
+++ b/packages/docx-compare/src/baselines/atomizer/textBoxRevisionSafety.ts
@@ -1,13 +1,26 @@
 import { createHash } from 'node:crypto';
 import { XMLSerializer } from '@xmldom/xmldom';
-import { DocxArchive, OOXML, parseXml } from '@usejunior/docx-core';
+import {
+  auditSectPr,
+  DocxArchive,
+  OOXML,
+  parseXml,
+  type SectPrBinding,
+} from '@usejunior/docx-core';
 import { canonicalNode } from './opaquePassthrough.js';
+import {
+  acceptAllChanges,
+  rejectAllChanges,
+} from './trackChangesAcceptorAst.js';
+import { extractRoundTripComparisonText } from '../../fieldComparisonSemantics.js';
 import { parseDocumentXml } from './xmlToWmlElement.js';
 
 const WORD_2010_NS = 'http://schemas.microsoft.com/office/word/2010/wordml';
 const VML_NS = 'urn:schemas-microsoft-com:vml';
 const RELATIONSHIPS_NS =
   'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const PACKAGE_RELATIONSHIPS_NS =
+  'http://schemas.openxmlformats.org/package/2006/relationships';
 const serializer = new XMLSerializer();
 
 export interface TextBoxRevisionChange {
@@ -47,6 +60,7 @@ export class UnsupportedTextBoxRevisionError extends Error {
 
 export interface TextBoxStoryInput {
   index: number;
+  partPath: string;
   original: Buffer;
   revised: Buffer;
 }
@@ -57,6 +71,7 @@ export interface TextBoxStoryComparisonPlan {
   originalDocumentXml: string;
   revisedDocumentXml: string;
   stories: TextBoxStoryInput[];
+  validateAncillaryProjection: boolean;
 }
 
 function textBoxParagraphId(textBox: Element): string | undefined {
@@ -69,59 +84,6 @@ function textBoxes(documentXml: string): Element[] {
   return Array.from(
     root.getElementsByTagNameNS(OOXML.W_NS, 'txbxContent'),
   ) as Element[];
-}
-
-const ANCILLARY_STORY_PART_RE =
-  /^word\/(?:header[^/]*|footer[^/]*|footnotes|endnotes|comments)\.xml$/u;
-
-async function assertAncillaryTextBoxStoriesUnchanged(
-  originalArchive: DocxArchive,
-  revisedArchive: DocxArchive,
-): Promise<void> {
-  const partPaths = new Set([
-    ...originalArchive.listFiles().filter((path) => ANCILLARY_STORY_PART_RE.test(path)),
-    ...revisedArchive.listFiles().filter((path) => ANCILLARY_STORY_PART_RE.test(path)),
-  ]);
-
-  for (const partPath of [...partPaths].sort()) {
-    const originalXml = await originalArchive.getFile(partPath);
-    const revisedXml = await revisedArchive.getFile(partPath);
-    if (
-      !originalXml?.includes('txbxContent') &&
-      !revisedXml?.includes('txbxContent')
-    ) {
-      continue;
-    }
-    const originalStories = originalXml?.includes('txbxContent')
-      ? textBoxes(originalXml)
-      : [];
-    const revisedStories = revisedXml?.includes('txbxContent')
-      ? textBoxes(revisedXml)
-      : [];
-    const count = Math.max(originalStories.length, revisedStories.length);
-    for (let index = 0; index < count; index += 1) {
-      const originalStory = originalStories[index];
-      const revisedStory = revisedStories[index];
-      if (
-        originalStory &&
-        revisedStory &&
-        canonicalNode(originalStory) === canonicalNode(revisedStory)
-      ) {
-        continue;
-      }
-      throw new UnsupportedTextBoxRevisionError([{
-        index,
-        partPath,
-        reason: 'changed ancillary text-box stories are outside the supported main-document scope',
-        originalParagraphId: originalStory
-          ? textBoxParagraphId(originalStory)
-          : undefined,
-        revisedParagraphId: revisedStory
-          ? textBoxParagraphId(revisedStory)
-          : undefined,
-      }]);
-    }
-  }
 }
 
 function directChildElements(element: Element): Element[] {
@@ -254,6 +216,528 @@ function storyDocumentXml(documentXml: string, textBoxIndex: number): string {
   return serializer.serializeToString(document);
 }
 
+function storyDocumentXmlFromPart(
+  documentXml: string,
+  partXml: string,
+  textBoxIndex: number,
+): string {
+  const document = parseXml(documentXml);
+  const body = document.getElementsByTagNameNS(OOXML.W_NS, 'body').item(0);
+  const part = parseXml(partXml);
+  const textBox = part
+    .getElementsByTagNameNS(OOXML.W_NS, 'txbxContent')
+    .item(textBoxIndex);
+  if (!body || !textBox) {
+    throw new Error(`Could not isolate ancillary w:txbxContent[${textBoxIndex}]`);
+  }
+  replaceChildren(body, textBox);
+  return serializer.serializeToString(document);
+}
+
+function owningRelationshipsPath(partPath: string): string {
+  const slash = partPath.lastIndexOf('/');
+  const directory = slash >= 0 ? partPath.slice(0, slash) : '';
+  const filename = slash >= 0 ? partPath.slice(slash + 1) : partPath;
+  return `${directory ? `${directory}/` : ''}_rels/${filename}.rels`;
+}
+
+interface SelectedAncillaryStory {
+  targetPath: string;
+  kind: 'header' | 'footer';
+  bindings: SectPrBinding[];
+  xml: string;
+  relationshipsXml: string | null;
+  textBoxes: Element[];
+  canonical: string;
+  scaffold: string;
+}
+
+interface SelectedAncillaryState {
+  documentXml: string;
+  sectionCount: number;
+  auditBindings: SectPrBinding[];
+  stories: SelectedAncillaryStory[];
+}
+
+interface PairedAncillaryStory {
+  id: string;
+  original: SelectedAncillaryStory;
+  revised: SelectedAncillaryStory;
+}
+
+function partTextBoxes(xml: string): Element[] {
+  const document = parseXml(xml);
+  return Array.from(
+    document.getElementsByTagNameNS(OOXML.W_NS, 'txbxContent'),
+  ) as Element[];
+}
+
+function partScaffoldFingerprint(xml: string): string {
+  const document = parseXml(xml);
+  const root = document.documentElement.cloneNode(true) as Element;
+  for (const textBox of Array.from(
+    root.getElementsByTagNameNS(OOXML.W_NS, 'txbxContent'),
+  )) {
+    while (textBox.firstChild) textBox.removeChild(textBox.firstChild);
+  }
+  return canonicalNode(root);
+}
+
+function unsupportedBindingChanges(
+  issues: ReturnType<typeof auditSectPr>['issues'],
+): TextBoxRevisionChange[] {
+  return issues.map((issue, index) => ({
+    index,
+    partPath: issue.targetPath ?? 'word/document.xml',
+    reason: `invalid relationship-selected story binding (${issue.type})`,
+  }));
+}
+
+/**
+ * Resolve only the header/footer stories that are selected by direct section
+ * bindings. Physical package filenames are allocation details and are not used
+ * as cross-document story identity.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.10.5
+ * @conformance ECMA-376 edition 5, Part 1 § 17.10.2
+ * @conformance ECMA-376 edition 5, Part 1 § 17.10.4
+ * @conformance ECMA-376 edition 5, Part 1 § 17.10.3
+ * @see https://github.com/UseJunior/safe-docx/issues/726
+ */
+async function selectedAncillaryState(
+  archive: DocxArchive,
+): Promise<SelectedAncillaryState> {
+  const documentXml = await archive.getDocumentXml();
+  const relationshipsXml = await archive.getFile('word/_rels/document.xml.rels');
+  const preliminary = auditSectPr(documentXml, relationshipsXml);
+  if (!preliminary.ok) {
+    // Relationship validation belongs to the package-level ancillary safety
+    // boundary. Do not replace its precise, stable diagnostics with the
+    // narrower text-box error merely because this preparatory scan runs first.
+    return {
+      documentXml,
+      sectionCount: 0,
+      auditBindings: [],
+      stories: [],
+    };
+  }
+
+  const parts = new Map<string, string>();
+  for (const targetPath of new Set(
+    preliminary.bindings.map((binding) => binding.targetPath),
+  )) {
+    const xml = await archive.getFile(targetPath);
+    if (xml !== null) parts.set(targetPath, xml);
+  }
+  const audit = auditSectPr(documentXml, relationshipsXml, parts);
+  if (!audit.ok) {
+    return {
+      documentXml,
+      sectionCount: 0,
+      auditBindings: [],
+      stories: [],
+    };
+  }
+
+  const bindingsByTarget = new Map<string, SectPrBinding[]>();
+  for (const binding of audit.bindings) {
+    const current = bindingsByTarget.get(binding.targetPath);
+    if (current) current.push(binding);
+    else bindingsByTarget.set(binding.targetPath, [binding]);
+  }
+
+  const stories: SelectedAncillaryStory[] = [];
+  for (const [targetPath, bindings] of [...bindingsByTarget].sort(
+    ([left], [right]) => left.localeCompare(right),
+  )) {
+    const xml = parts.get(targetPath)!;
+    const root = parseXml(xml).documentElement;
+    stories.push({
+      targetPath,
+      kind: bindings[0]!.kind,
+      bindings,
+      xml,
+      relationshipsXml: await archive.getFile(owningRelationshipsPath(targetPath)),
+      textBoxes: partTextBoxes(xml),
+      canonical: canonicalNode(root),
+      scaffold: partScaffoldFingerprint(xml),
+    });
+  }
+
+  return {
+    documentXml,
+    sectionCount: audit.stats.totalSectPrCount,
+    auditBindings: audit.bindings,
+    stories,
+  };
+}
+
+function bucketStories(
+  stories: SelectedAncillaryStory[],
+  keyOf: (story: SelectedAncillaryStory) => string,
+): Map<string, SelectedAncillaryStory[]> {
+  const buckets = new Map<string, SelectedAncillaryStory[]>();
+  for (const story of stories) {
+    const key = keyOf(story);
+    const bucket = buckets.get(key);
+    if (bucket) bucket.push(story);
+    else buckets.set(key, [story]);
+  }
+  for (const bucket of buckets.values()) {
+    bucket.sort((left, right) => left.targetPath.localeCompare(right.targetPath));
+  }
+  return buckets;
+}
+
+function pairSelectedAncillaryStories(
+  original: SelectedAncillaryStory[],
+  revised: SelectedAncillaryStory[],
+): {
+  pairs: PairedAncillaryStory[];
+  unpairedOriginal: SelectedAncillaryStory[];
+  unpairedRevised: SelectedAncillaryStory[];
+} {
+  const originalCandidates = original.filter((story) => story.textBoxes.length > 0);
+  const revisedCandidates = revised.filter((story) => story.textBoxes.length > 0);
+  const matchedOriginal = new Set<SelectedAncillaryStory>();
+  const matchedRevised = new Set<SelectedAncillaryStory>();
+  const pairs: PairedAncillaryStory[] = [];
+
+  const pair = (
+    left: SelectedAncillaryStory,
+    right: SelectedAncillaryStory,
+  ): void => {
+    matchedOriginal.add(left);
+    matchedRevised.add(right);
+    pairs.push({
+      id: `ancillary-story-${pairs.length}`,
+      original: left,
+      revised: right,
+    });
+  };
+
+  const exactOriginal = bucketStories(
+    originalCandidates,
+    (story) => `${story.kind}|${story.canonical}`,
+  );
+  const exactRevised = bucketStories(
+    revisedCandidates,
+    (story) => `${story.kind}|${story.canonical}`,
+  );
+  for (const key of [...exactOriginal.keys()].sort()) {
+    const left = exactOriginal.get(key)!;
+    const right = exactRevised.get(key) ?? [];
+    const count = Math.min(left.length, right.length);
+    for (let index = 0; index < count; index += 1) {
+      pair(left[index]!, right[index]!);
+    }
+  }
+
+  const remainingOriginal = originalCandidates.filter(
+    (story) => !matchedOriginal.has(story),
+  );
+  const remainingRevised = revisedCandidates.filter(
+    (story) => !matchedRevised.has(story),
+  );
+  const scaffoldOriginal = bucketStories(
+    remainingOriginal,
+    (story) => `${story.kind}|${story.scaffold}`,
+  );
+  const scaffoldRevised = bucketStories(
+    remainingRevised,
+    (story) => `${story.kind}|${story.scaffold}`,
+  );
+  for (const key of [...scaffoldOriginal.keys()].sort()) {
+    const left = scaffoldOriginal.get(key)!;
+    const right = scaffoldRevised.get(key) ?? [];
+    if (left.length === 1 && right.length === 1) {
+      pair(left[0]!, right[0]!);
+    }
+  }
+
+  return {
+    pairs,
+    unpairedOriginal: originalCandidates.filter(
+      (story) => !matchedOriginal.has(story),
+    ),
+    unpairedRevised: revisedCandidates.filter(
+      (story) => !matchedRevised.has(story),
+    ),
+  };
+}
+
+function hasAncestorLocalName(element: Element, name: string): boolean {
+  for (let parent = element.parentNode; parent; parent = parent.parentNode) {
+    if (
+      parent.nodeType === 1 &&
+      ((parent as Element).localName ||
+        (parent as Element).tagName.replace(/^.*:/u, '')) === name
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function sectionPropertyFingerprints(documentXml: string): string[] {
+  const document = parseXml(documentXml);
+  return Array.from(document.getElementsByTagNameNS(OOXML.W_NS, 'sectPr'))
+    .filter((section) => !hasAncestorLocalName(section, 'sectPrChange'))
+    .map((section) => {
+      const clone = section.cloneNode(true) as Element;
+      for (const child of directChildElements(clone)) {
+        if (
+          child.namespaceURI === OOXML.W_NS &&
+          (child.localName === 'headerReference' ||
+            child.localName === 'footerReference' ||
+            child.localName === 'sectPrChange')
+        ) {
+          clone.removeChild(child);
+        }
+      }
+      return canonicalNode(clone);
+    });
+}
+
+function sectionSignatures(
+  state: SelectedAncillaryState,
+  side: 'original' | 'revised',
+  pairIdByPath: ReadonlyMap<string, string>,
+): string[] {
+  const properties = sectionPropertyFingerprints(state.documentXml);
+  return properties.map((property, sectionOrdinal) => {
+    const bindings = state.auditBindings
+      .filter((binding) => binding.sectionOrdinal === sectionOrdinal)
+      .sort((left, right) =>
+        `${left.kind}:${left.role}`.localeCompare(`${right.kind}:${right.role}`),
+      );
+    const slots = bindings.map((binding) => {
+      const selected = state.stories.find(
+        (story) => story.targetPath === binding.targetPath,
+      );
+      const identity = selected?.textBoxes.length
+        ? pairIdByPath.get(binding.targetPath) ??
+          `${side}:unpaired:${binding.targetPath}`
+        : `plain:${binding.kind}:${binding.role}`;
+      return `${binding.kind}:${binding.role}:${identity}`;
+    });
+    return `${property}\n${slots.join('\n')}`;
+  });
+}
+
+function unmatchedSequenceOrdinals(
+  original: string[],
+  revised: string[],
+): { original: Set<number>; revised: Set<number> } {
+  const lengths = Array.from(
+    { length: original.length + 1 },
+    () => Array<number>(revised.length + 1).fill(0),
+  );
+  for (let left = original.length - 1; left >= 0; left -= 1) {
+    for (let right = revised.length - 1; right >= 0; right -= 1) {
+      lengths[left]![right] = original[left] === revised[right]
+        ? 1 + lengths[left + 1]![right + 1]!
+        : Math.max(lengths[left + 1]![right]!, lengths[left]![right + 1]!);
+    }
+  }
+  const matchedOriginal = new Set<number>();
+  const matchedRevised = new Set<number>();
+  let left = 0;
+  let right = 0;
+  while (left < original.length && right < revised.length) {
+    if (original[left] === revised[right]) {
+      matchedOriginal.add(left);
+      matchedRevised.add(right);
+      left += 1;
+      right += 1;
+    } else if (lengths[left + 1]![right]! >= lengths[left]![right + 1]!) {
+      left += 1;
+    } else {
+      right += 1;
+    }
+  }
+  return {
+    original: new Set(
+      original.map((_, index) => index).filter((index) => !matchedOriginal.has(index)),
+    ),
+    revised: new Set(
+      revised.map((_, index) => index).filter((index) => !matchedRevised.has(index)),
+    ),
+  };
+}
+
+function assertLifecycleStoriesAreSectionBound(
+  originalState: SelectedAncillaryState,
+  revisedState: SelectedAncillaryState,
+  pairs: PairedAncillaryStory[],
+  unpairedOriginal: SelectedAncillaryStory[],
+  unpairedRevised: SelectedAncillaryStory[],
+): void {
+  if (unpairedOriginal.length === 0 && unpairedRevised.length === 0) return;
+  const originalPairIds = new Map(
+    pairs.map((pair) => [pair.original.targetPath, pair.id]),
+  );
+  const revisedPairIds = new Map(
+    pairs.map((pair) => [pair.revised.targetPath, pair.id]),
+  );
+  const unmatched = unmatchedSequenceOrdinals(
+    sectionSignatures(originalState, 'original', originalPairIds),
+    sectionSignatures(revisedState, 'revised', revisedPairIds),
+  );
+  const changes: TextBoxRevisionChange[] = [];
+
+  for (const story of unpairedOriginal) {
+    const lifecycle =
+      originalState.sectionCount > revisedState.sectionCount &&
+      story.bindings.every((binding) =>
+        unmatched.original.has(binding.sectionOrdinal),
+      );
+    if (!lifecycle) {
+      changes.push({
+        index: 0,
+        partPath: story.targetPath,
+        reason:
+          'unpaired ancillary text-box story is not owned exclusively by a deleted section',
+      });
+    }
+  }
+  for (const story of unpairedRevised) {
+    const lifecycle =
+      revisedState.sectionCount > originalState.sectionCount &&
+      story.bindings.every((binding) =>
+        unmatched.revised.has(binding.sectionOrdinal),
+      );
+    if (!lifecycle) {
+      changes.push({
+        index: 0,
+        partPath: story.targetPath,
+        reason:
+          'unpaired ancillary text-box story is not owned exclusively by an inserted section',
+      });
+    }
+  }
+  if (changes.length > 0) throw new UnsupportedTextBoxRevisionError(changes);
+}
+
+async function ancillaryStoryInputs(
+  originalArchive: DocxArchive,
+  revisedArchive: DocxArchive,
+  originalDocumentXml: string,
+  revisedDocumentXml: string,
+): Promise<{
+  stories: TextBoxStoryInput[];
+  validateProjection: boolean;
+}> {
+  const [originalState, revisedState] = await Promise.all([
+    selectedAncillaryState(originalArchive),
+    selectedAncillaryState(revisedArchive),
+  ]);
+  const paired = pairSelectedAncillaryStories(
+    originalState.stories,
+    revisedState.stories,
+  );
+  assertLifecycleStoriesAreSectionBound(
+    originalState,
+    revisedState,
+    paired.pairs,
+    paired.unpairedOriginal,
+    paired.unpairedRevised,
+  );
+
+  const stories: TextBoxStoryInput[] = [];
+  for (const pair of paired.pairs) {
+    if (pair.original.textBoxes.length !== pair.revised.textBoxes.length) {
+      throw new UnsupportedTextBoxRevisionError([{
+        index: Math.min(
+          pair.original.textBoxes.length,
+          pair.revised.textBoxes.length,
+        ),
+        partPath: pair.revised.targetPath,
+        reason: 'inserted or deleted ancillary text-box topology is not supported',
+      }]);
+    }
+    const originalTargets = relationshipTargets(pair.original.relationshipsXml);
+    const revisedTargets = relationshipTargets(pair.revised.relationshipsXml);
+    for (let index = 0; index < pair.original.textBoxes.length; index += 1) {
+      const originalTextBox = pair.original.textBoxes[index]!;
+      const revisedTextBox = pair.revised.textBoxes[index]!;
+      if (canonicalNode(originalTextBox) === canonicalNode(revisedTextBox)) continue;
+      const originalRelationshipClosure = relationshipClosureFingerprint(
+        originalTextBox,
+        originalTargets,
+      );
+      const revisedRelationshipClosure = relationshipClosureFingerprint(
+        revisedTextBox,
+        revisedTargets,
+      );
+      const reason =
+        unsupportedStoryReason(originalTextBox) ??
+        unsupportedStoryReason(revisedTextBox) ??
+        (originalRelationshipClosure === undefined ||
+        revisedRelationshipClosure === undefined ||
+        originalRelationshipClosure !== revisedRelationshipClosure
+          ? 'the ancillary text-box relationship closure changed or could not be resolved'
+          : undefined) ??
+        (scaffoldFingerprint(originalTextBox) === scaffoldFingerprint(revisedTextBox)
+          ? undefined
+          : 'the ancillary VML shape scaffold changed or could not be paired');
+      if (reason) {
+        throw new UnsupportedTextBoxRevisionError([{
+          index,
+          partPath: pair.revised.targetPath,
+          reason,
+          originalParagraphId: textBoxParagraphId(originalTextBox),
+          revisedParagraphId: textBoxParagraphId(revisedTextBox),
+        }]);
+      }
+
+      const storyOriginalArchive = await originalArchive.clone();
+      const storyRevisedArchive = await revisedArchive.clone();
+      storyOriginalArchive.setDocumentXml(
+        storyDocumentXmlFromPart(
+          originalDocumentXml,
+          pair.original.xml,
+          index,
+        ),
+      );
+      storyRevisedArchive.setDocumentXml(
+        storyDocumentXmlFromPart(
+          revisedDocumentXml,
+          pair.revised.xml,
+          index,
+        ),
+      );
+      storyOriginalArchive.setFile(
+        'word/_rels/document.xml.rels',
+        pair.original.relationshipsXml ??
+          `<Relationships xmlns="${PACKAGE_RELATIONSHIPS_NS}"/>`,
+      );
+      storyRevisedArchive.setFile(
+        'word/_rels/document.xml.rels',
+        pair.revised.relationshipsXml ??
+          `<Relationships xmlns="${PACKAGE_RELATIONSHIPS_NS}"/>`,
+      );
+      stories.push({
+        index,
+        partPath: pair.revised.targetPath,
+        original: await storyOriginalArchive.save(),
+        revised: await storyRevisedArchive.save(),
+      });
+    }
+  }
+
+  return {
+    stories,
+    validateProjection:
+      paired.pairs.some(
+        (pair) => pair.original.targetPath !== pair.revised.targetPath,
+      ) ||
+      paired.unpairedOriginal.length > 0 ||
+      paired.unpairedRevised.length > 0 ||
+      stories.length > 0,
+  };
+}
+
 /**
  * Split supported changed VML text boxes into independent WordprocessingML
  * stories and neutralize them for the outer-body comparison.
@@ -268,12 +752,14 @@ export async function prepareTextBoxStoryComparison(
 ): Promise<TextBoxStoryComparisonPlan | undefined> {
   const originalArchive = await DocxArchive.load(original);
   const revisedArchive = await DocxArchive.load(revised);
-  await assertAncillaryTextBoxStoriesUnchanged(
-    originalArchive,
-    revisedArchive,
-  );
   const originalDocumentXml = await originalArchive.getDocumentXml();
   const revisedDocumentXml = await revisedArchive.getDocumentXml();
+  const ancillary = await ancillaryStoryInputs(
+    originalArchive,
+    revisedArchive,
+    originalDocumentXml,
+    revisedDocumentXml,
+  );
   const originalRelationshipTargets = relationshipTargets(
     await originalArchive.getFile('word/_rels/document.xml.rels'),
   );
@@ -336,9 +822,7 @@ export async function prepareTextBoxStoryComparison(
     changedIndices.push(index);
   }
 
-  if (changedIndices.length === 0) return undefined;
-
-  const stories: TextBoxStoryInput[] = [];
+  const stories: TextBoxStoryInput[] = [...ancillary.stories];
   for (const index of changedIndices) {
     const storyOriginalArchive = await originalArchive.clone();
     const storyRevisedArchive = await revisedArchive.clone();
@@ -350,12 +834,15 @@ export async function prepareTextBoxStoryComparison(
     );
     stories.push({
       index,
+      partPath: 'word/document.xml',
       original: await storyOriginalArchive.save(),
       revised: await storyRevisedArchive.save(),
     });
     createPlaceholder(originalTextBoxes[index]!, index);
     createPlaceholder(revisedTextBoxes[index]!, index);
   }
+
+  if (stories.length === 0 && !ancillary.validateProjection) return undefined;
 
   const outerOriginalArchive = await originalArchive.clone();
   const outerRevisedArchive = await revisedArchive.clone();
@@ -368,6 +855,7 @@ export async function prepareTextBoxStoryComparison(
     originalDocumentXml,
     revisedDocumentXml,
     stories,
+    validateAncillaryProjection: ancillary.validateProjection,
   };
 }
 
@@ -377,20 +865,35 @@ export async function prepareTextBoxStoryComparison(
  */
 export async function assembleTextBoxStoryComparison(
   outerCompared: Buffer,
-  storyResults: ReadonlyArray<{ index: number; document: Buffer }>,
+  storyResults: ReadonlyArray<{
+    index: number;
+    partPath: string;
+    document: Buffer;
+  }>,
 ): Promise<Buffer> {
   const outerArchive = await DocxArchive.load(outerCompared);
   const outerDocument = parseXml(await outerArchive.getDocumentXml());
-  const outerTextBoxes = Array.from(
-    outerDocument.getElementsByTagNameNS(OOXML.W_NS, 'txbxContent'),
-  );
 
   for (const storyResult of storyResults) {
-    const target = outerTextBoxes[storyResult.index];
+    let targetDocument = outerDocument;
+    if (storyResult.partPath !== 'word/document.xml') {
+      const targetXml = await outerArchive.getFile(storyResult.partPath);
+      if (targetXml === null) {
+        throw new UnsupportedTextBoxRevisionError([{
+          index: storyResult.index,
+          partPath: storyResult.partPath,
+          reason: 'the selected output story part is missing',
+        }]);
+      }
+      targetDocument = parseXml(targetXml);
+    }
+    const target = targetDocument
+      .getElementsByTagNameNS(OOXML.W_NS, 'txbxContent')
+      .item(storyResult.index);
     if (!target) {
       throw new UnsupportedTextBoxRevisionError([{
         index: storyResult.index,
-        partPath: 'word/document.xml',
+        partPath: storyResult.partPath,
         reason: 'the outer comparison changed text-box story topology',
       }]);
     }
@@ -410,12 +913,126 @@ export async function assembleTextBoxStoryComparison(
       ) {
         continue;
       }
-      target.appendChild(outerDocument.importNode(child, true));
+      target.appendChild(targetDocument.importNode(child, true));
+    }
+    if (storyResult.partPath !== 'word/document.xml') {
+      outerArchive.setFile(
+        storyResult.partPath,
+        serializer.serializeToString(targetDocument),
+      );
     }
   }
 
   outerArchive.setDocumentXml(serializer.serializeToString(outerDocument));
   return outerArchive.save();
+}
+
+async function selectedStoryProjectionInventory(
+  archive: DocxArchive,
+  documentXml: string,
+  projection: 'accept' | 'reject',
+): Promise<string[]> {
+  const relationshipsXml = await archive.getFile('word/_rels/document.xml.rels');
+  const preliminary = auditSectPr(documentXml, relationshipsXml);
+  if (!preliminary.ok) {
+    throw new UnsupportedTextBoxRevisionError(
+      unsupportedBindingChanges(preliminary.issues),
+    );
+  }
+  const parts = new Map<string, string>();
+  for (const targetPath of new Set(
+    preliminary.bindings.map((binding) => binding.targetPath),
+  )) {
+    const xml = await archive.getFile(targetPath);
+    if (xml !== null) parts.set(targetPath, xml);
+  }
+  const audit = auditSectPr(documentXml, relationshipsXml, parts);
+  if (!audit.ok) {
+    throw new UnsupportedTextBoxRevisionError(
+      unsupportedBindingChanges(audit.issues),
+    );
+  }
+  const project = projection === 'accept' ? acceptAllChanges : rejectAllChanges;
+  return audit.bindings.map((binding) => {
+    const xml = parts.get(binding.targetPath)!;
+    const projectedXml = project(xml);
+    return [
+      binding.sectionOrdinal,
+      binding.kind,
+      binding.role,
+      partScaffoldFingerprint(projectedXml),
+      extractRoundTripComparisonText(projectedXml),
+    ].join('|');
+  });
+}
+
+/**
+ * Validate the selected header/footer story graph after accept-all and
+ * reject-all, independent of physical part allocation.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.10.5
+ * @conformance ECMA-376 edition 5, Part 1 § 17.10.2
+ * @conformance ECMA-376 edition 5, Part 1 § 17.10.4
+ * @conformance ECMA-376 edition 5, Part 1 § 17.10.3
+ * @see https://github.com/UseJunior/safe-docx/issues/726
+ */
+export async function assertAncillaryTextBoxStoryProjection(
+  original: Buffer,
+  revised: Buffer,
+  compared: Buffer,
+): Promise<void> {
+  const [originalArchive, revisedArchive, comparedArchive] = await Promise.all([
+    DocxArchive.load(original),
+    DocxArchive.load(revised),
+    DocxArchive.load(compared),
+  ]);
+  const [originalXml, revisedXml, comparedXml] = await Promise.all([
+    originalArchive.getDocumentXml(),
+    revisedArchive.getDocumentXml(),
+    comparedArchive.getDocumentXml(),
+  ]);
+  const [
+    expectedOriginal,
+    expectedRevised,
+    rejectedCompared,
+    acceptedCompared,
+  ] = await Promise.all([
+    selectedStoryProjectionInventory(
+      originalArchive,
+      rejectAllChanges(originalXml),
+      'reject',
+    ),
+    selectedStoryProjectionInventory(
+      revisedArchive,
+      acceptAllChanges(revisedXml),
+      'accept',
+    ),
+    selectedStoryProjectionInventory(
+      comparedArchive,
+      rejectAllChanges(comparedXml),
+      'reject',
+    ),
+    selectedStoryProjectionInventory(
+      comparedArchive,
+      acceptAllChanges(comparedXml),
+      'accept',
+    ),
+  ]);
+  if (
+    JSON.stringify(expectedOriginal) !== JSON.stringify(rejectedCompared) ||
+    JSON.stringify(expectedRevised) !== JSON.stringify(acceptedCompared)
+  ) {
+    const digest = (items: string[]): string =>
+      createHash('sha256').update(JSON.stringify(items)).digest('hex').slice(0, 12);
+    throw new UnsupportedTextBoxRevisionError([{
+      index: 0,
+      partPath: 'word/document.xml',
+      reason:
+        'assembled relationship-selected stories failed accept/reject package projection validation ' +
+        `(original ${digest(expectedOriginal)} != ${digest(rejectedCompared)}; ` +
+        `revised ${digest(expectedRevised)} != ${digest(acceptedCompared)})`,
+    }]);
+  }
 }
 
 /**


### PR DESCRIPTION
Closes #726.

## Why

Word may renumber header/footer package parts or introduce a new selected story with a section. Raw physical filenames are therefore not stable story identity, and the comparison pipeline previously rejected otherwise supported VML text-box edits in relationship-selected headers and footers.

## What changed

- resolves only section-selected header/footer stories through the shared section-binding audit
- pairs same-path and renumbered stories by canonical identity, with a narrow inserted/deleted-section lifecycle rule
- compares nested text through the existing in-place atomizer/LCS/reconstruction core
- preserves per-part relationship closure while splicing tracked revisions into selected output stories
- validates accepted and rejected story projections before publication and fails closed on ambiguity
- reports ancillary text boxes as explicit verifier exclusions until compiled verification covers them
- extends the existing VML text-box OpenSpec and adds 16 focused scenarios

## Validation

- mandatory pre-submit command passed: build, workspace lint, full workspace tests, strict spec coverage, conformance citations, and conformance document
- focused VML text-box tests: 16 passed
- comparison package: 749 passed
- core package: 1,291 passed (plus the repository’s documented expected-failure/skip cases)
- public real-world DOCX smoke based on LibreOffice Bugzilla attachment 117142: comparison completed, ZIP valid, accept/reject projections matched, LibreOffice rendered two pages, and Microsoft Word opened without repair
- public diff scanned for confidential identifiers; no private corpus material or filenames are included

Ref #713
Ref #718