### PR TITLE
fix(docx-comparison): refine fuzzy runs inside aligned paragraphs

### DIFF
--- a/packages/docx-compare/src/baselines/atomizer/pipeline-selective-word-refinement.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline-selective-word-refinement.test.ts
@@ -1,0 +1,203 @@
+/**
+ * A fuzzy changed run inside an aligned paragraph must be refined locally so
+ * unchanged inline tokens are not represented as delete+insert or false moves.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.5
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.6.1
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.6.2
+ * @see https://github.com/UseJunior/safe-docx/issues/717
+ */
+
+import {
+  DEFAULT_MOVE_DETECTION_SETTINGS,
+  DocxArchive,
+  parseXml,
+  type ComparisonUnitAtom,
+  type OpcPart,
+  type WmlElement,
+} from '@usejunior/docx-core';
+import { describe, expect } from 'vitest';
+import {
+  assignIdentityIds,
+  createComparisonUnitAtom,
+  IdentityInterner,
+} from '../../atomizer.js';
+import { getAtomText } from '../../move-detection.js';
+import { el } from '../../testing/dom-test-helpers.js';
+import { buildDocxFromBodyXml } from '../../testing/ooxml-fixtures.js';
+import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
+import { hierarchicalCompare } from './hierarchicalLcs.js';
+import { compareDocumentsAtomizer } from './pipeline.js';
+import { refineFuzzyRunsWithinAlignedParagraphs } from './selectiveWordRefinement.js';
+import { acceptAllChanges, rejectAllChanges } from './trackChangesAcceptorAst.js';
+
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({
+    feature: 'Adaptive Atomization',
+    story: 'Selective Word Refinement',
+    severity: 'critical',
+  })
+  .conformance(
+    { spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.5' },
+    { spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.6.1' },
+    { spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.6.2' },
+  );
+
+function paragraph(changedRun: string): string {
+  return (
+    '<w:p>' +
+    '<w:r><w:rPr><w:b/></w:rPr><w:t xml:space="preserve">Aligned prefix. </w:t></w:r>' +
+    `<w:r><w:t xml:space="preserve">${changedRun}</w:t></w:r>` +
+    '<w:r><w:rPr><w:i/></w:rPr><w:t xml:space="preserve"> Aligned suffix.</w:t></w:r>' +
+    '</w:p>'
+  );
+}
+
+async function documentXml(docx: Buffer): Promise<string> {
+  return (await DocxArchive.load(docx)).getDocumentXml();
+}
+
+function projectedText(xml: string, projection: 'accept' | 'reject'): string {
+  const projected = projection === 'accept' ? acceptAllChanges(xml) : rejectAllChanges(xml);
+  return parseXml(projected).documentElement.textContent ?? '';
+}
+
+function revisionAncestor(node: Element): Element | null {
+  let current = node.parentNode as Element | null;
+  while (current) {
+    if (
+      current.tagName === 'w:ins' ||
+      current.tagName === 'w:del' ||
+      current.tagName === 'w:moveFrom' ||
+      current.tagName === 'w:moveTo'
+    ) {
+      return current;
+    }
+    current = current.parentNode as Element | null;
+  }
+  return null;
+}
+
+describe('selective word refinement for aligned paragraphs (#717)', () => {
+  test('directly refines only the fuzzy run pair selected by the run-level LCS', async ({
+    given,
+    when,
+    then,
+    and,
+  }: AllureBddContext) => {
+    const part: OpcPart = { uri: 'word/document.xml', contentType: 'text/xml' };
+    const atom = (text: string): ComparisonUnitAtom => {
+      const result = createComparisonUnitAtom({
+        contentElement: el('w:t', {}, undefined, text) as WmlElement,
+        ancestors: [],
+        part,
+      });
+      result.paragraphIndex = 0;
+      return result;
+    };
+    const originalAtoms = await given('three run-level atoms with one long fuzzy changed run', () => [
+      atom('Aligned prefix. '),
+      atom('The annual allocation shall remain 10,000 units for each reporting period; review, review, under this agreement.'),
+      atom(' Aligned suffix.'),
+    ]);
+    const revisedAtoms = await given('the aligned revised atoms preserving an interior numeric token', () => [
+      atom('Aligned prefix. '),
+      atom('The annual allocation will remain 10,000 units for each reporting period; review, review, under this agreement.'),
+      atom(' Aligned suffix.'),
+    ]);
+    const interner = new IdentityInterner();
+    assignIdentityIds(originalAtoms, interner);
+    assignIdentityIds(revisedAtoms, interner);
+    const initialLcs = hierarchicalCompare(originalAtoms, revisedAtoms);
+
+    const refined = await when('the run-level result receives selective word refinement', () =>
+      refineFuzzyRunsWithinAlignedParagraphs(
+        originalAtoms,
+        revisedAtoms,
+        initialLcs,
+        DEFAULT_MOVE_DETECTION_SETTINGS,
+        interner,
+      ),
+    );
+
+    await then('exactly one original/revised run pair is refined', () => {
+      expect(refined.refinedPairCount).toBe(1);
+    });
+
+    await and('the unchanged numeric token is an exact LCS match', () => {
+      const matchingTexts = refined.lcsResult.matches.map((match) => [
+        getAtomText(refined.originalAtoms[match.originalIndex]!),
+        getAtomText(refined.revisedAtoms[match.revisedIndex]!),
+      ]);
+      expect(matchingTexts).toContainEqual(['10,000', '10,000']);
+    });
+
+    await and('neither changed side classifies the numeric token as deleted or inserted', () => {
+      expect(
+        refined.lcsResult.deletedIndices
+          .map((index) => getAtomText(refined.originalAtoms[index]!))
+          .some((text) => text.includes('10,000')),
+      ).toBe(false);
+      expect(
+        refined.lcsResult.insertedIndices
+          .map((index) => getAtomText(refined.revisedAtoms[index]!))
+          .some((text) => text.includes('10,000')),
+      ).toBe(false);
+    });
+  });
+
+  test('keeps the unchanged numeric token outside revisions when one long run changes', async ({
+    given,
+    when,
+    then,
+    and,
+  }: AllureBddContext) => {
+    const originalRun =
+      'The annual allocation shall remain 10,000 units for each reporting period; review, review, under this agreement.';
+    const revisedRun =
+      'The annual allocation will remain 10,000 units for each reporting period; review, review, under this agreement.';
+    const originalBody = paragraph(originalRun);
+    const revisedBody = paragraph(revisedRun);
+    const originalText = parseXml(
+      `<w:root xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">${originalBody}</w:root>`,
+    ).documentElement.textContent ?? '';
+    const revisedText = parseXml(
+      `<w:root xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">${revisedBody}</w:root>`,
+    ).documentElement.textContent ?? '';
+
+    const original = await given('an aligned paragraph containing a long original run', () =>
+      buildDocxFromBodyXml(originalBody),
+    );
+    const revised = await given('a fuzzy revision that preserves an interior numeric token', () =>
+      buildDocxFromBodyXml(revisedBody),
+    );
+
+    const comparison = await when('the in-place atomizer compares the documents', () =>
+      compareDocumentsAtomizer(original, revised, {
+        reconstructionMode: 'inplace',
+        date: new Date('2026-07-28T12:00:00Z'),
+      }),
+    );
+    const xml = await documentXml(comparison.document);
+    const document = parseXml(xml);
+
+    await then('the unchanged numeric token is emitted once outside every revision wrapper', () => {
+      const numericTokens = Array.from(document.getElementsByTagName('w:t'))
+        .concat(Array.from(document.getElementsByTagName('w:delText')))
+        .filter((node) => (node.textContent ?? '').includes('10,000'));
+      expect(numericTokens).toHaveLength(1);
+      expect(revisionAncestor(numericTokens[0]!)).toBeNull();
+    });
+
+    await and('the changed word is not misclassified as a move', () => {
+      expect(document.getElementsByTagName('w:moveFrom')).toHaveLength(0);
+      expect(document.getElementsByTagName('w:moveTo')).toHaveLength(0);
+    });
+
+    await and('accept and reject projections exactly recover their respective source text', () => {
+      expect(projectedText(xml, 'accept')).toBe(revisedText);
+      expect(projectedText(xml, 'reject')).toBe(originalText);
+    });
+  });
+});

--- a/packages/docx-compare/src/baselines/atomizer/pipeline.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline.ts
@@ -57,7 +57,10 @@ import {
   type HyperlinkRelEntry,
 } from '@usejunior/docx-core';
 import { OOXML } from '@usejunior/docx-core';
-import { collectPreservedMoveNames, detectMovesInAtomList } from '../../move-detection.js';
+import {
+  collectPreservedMoveNames,
+  detectMovesInAtomList,
+} from '../../move-detection.js';
 import { detectFormatChangesInAtomList } from '../../format-detection.js';
 import { detectParagraphStyleChanges } from '../../paragraph-style-detection.js';
 import {
@@ -75,6 +78,7 @@ import {
   hierarchicalCompare,
   markHierarchicalCorrelationStatus,
 } from './hierarchicalLcs.js';
+import { refineFuzzyRunsWithinAlignedParagraphs } from './selectiveWordRefinement.js';
 import {
   reconstructDocument,
   type HyperlinkRelResolver,
@@ -892,8 +896,8 @@ async function compareDocumentsAtomizerCore(
           captureComplexFieldPassthrough: reconstructionMode === 'rebuild',
         }
       : atomizeOptions;
-    const { atoms: originalAtoms } = atomizeTree(originalBody, [], originalPart, effectiveAtomizeOptions);
-    const { atoms: revisedAtoms } = atomizeTree(revisedBody, [], revisedPart, effectiveAtomizeOptions);
+    let { atoms: originalAtoms } = atomizeTree(originalBody, [], originalPart, effectiveAtomizeOptions);
+    let { atoms: revisedAtoms } = atomizeTree(revisedBody, [], revisedPart, effectiveAtomizeOptions);
 
     // Assign paragraph indices for proper grouping during reconstruction
     assignParagraphIndices(originalAtoms);
@@ -928,7 +932,26 @@ async function compareDocumentsAtomizerCore(
     assignIdentityIds(revisedAtoms, identityInterner);
 
     // Step 6: Run hierarchical LCS (paragraph-level first, then atom-level within)
-    const lcsResult = hierarchicalCompare(originalAtoms, revisedAtoms);
+    let lcsResult = hierarchicalCompare(originalAtoms, revisedAtoms);
+
+    // Run-level atomization normally preserves formatting boundaries best, but
+    // a single long changed run can contain mostly-equal prose. Refine only
+    // fuzzy deleted/inserted run pairs inside paragraphs that the first LCS
+    // already aligned, then rerun the comparison. This obtains word precision
+    // without exposing unrelated paragraphs to the global word-split strategy.
+    // (#717)
+    if (!effectiveAtomizeOptions?.splitTextIntoWords) {
+      const refined = refineFuzzyRunsWithinAlignedParagraphs(
+        originalAtoms,
+        revisedAtoms,
+        lcsResult,
+        moveSettings,
+        identityInterner,
+      );
+      originalAtoms = refined.originalAtoms;
+      revisedAtoms = refined.revisedAtoms;
+      lcsResult = refined.lcsResult;
+    }
 
     // Step 7: Mark correlation status using hierarchical result
     markHierarchicalCorrelationStatus(originalAtoms, revisedAtoms, lcsResult);
@@ -940,7 +963,36 @@ async function compareDocumentsAtomizerCore(
       // and original atoms with Deleted status
       const allAtoms = [...originalAtoms, ...revisedAtoms];
       const preservedMoveNames = collectPreservedMoveNames([originalTree, revisedTree]);
-      detectMovesInAtomList(allAtoms, moveSettings, preservedMoveNames);
+      const alignedParagraphPairs = new Set<string>();
+      for (const match of lcsResult.matches) {
+        const originalParagraph = originalAtoms[match.originalIndex]?.paragraphIndex;
+        const revisedParagraph = revisedAtoms[match.revisedIndex]?.paragraphIndex;
+        if (originalParagraph !== undefined && revisedParagraph !== undefined) {
+          alignedParagraphPairs.add(`${originalParagraph}:${revisedParagraph}`);
+        }
+      }
+      detectMovesInAtomList(
+        allAtoms,
+        moveSettings,
+        preservedMoveNames,
+        (deleted, inserted) => {
+          // A fuzzy source/destination pair inside an already-aligned paragraph
+          // is an edit, not evidence that text moved. Exact text can still be a
+          // genuine within-paragraph relocation. This preserves move detection
+          // across paragraphs while preventing broad changed runs from dragging
+          // unchanged inline content into moveFrom/moveTo wrappers. (#717)
+          if (deleted.text === inserted.text) return true;
+          return !deleted.atoms.some((originalAtom) =>
+            inserted.atoms.some((revisedAtom) =>
+              originalAtom.paragraphIndex !== undefined &&
+              revisedAtom.paragraphIndex !== undefined &&
+              alignedParagraphPairs.has(
+                `${originalAtom.paragraphIndex}:${revisedAtom.paragraphIndex}`,
+              ),
+            ),
+          );
+        },
+      );
     }
 
     // Step 9: Run format detection

--- a/packages/docx-compare/src/baselines/atomizer/selectiveWordRefinement.ts
+++ b/packages/docx-compare/src/baselines/atomizer/selectiveWordRefinement.ts
@@ -1,0 +1,136 @@
+import type {
+  ComparisonUnitAtom,
+  MoveDetectionSettings,
+} from '@usejunior/docx-core';
+import {
+  assignIdentityIds,
+  type IdentityInterner,
+  splitAtomsIntoWords,
+} from '../../atomizer.js';
+import {
+  countWords,
+  getAtomText,
+  jaccardWordSimilarity,
+} from '../../move-detection.js';
+import { hierarchicalCompare } from './hierarchicalLcs.js';
+import type { LcsResult } from './atomLcs.js';
+
+export interface SelectiveWordRefinementResult {
+  originalAtoms: ComparisonUnitAtom[];
+  revisedAtoms: ComparisonUnitAtom[];
+  lcsResult: LcsResult;
+  refinedPairCount: number;
+}
+
+/**
+ * Refine fuzzy changed runs only inside paragraph pairs already established by
+ * exact atom matches. This is the run-level precision escape hatch: it avoids
+ * applying word atomization to unrelated paragraphs while preserving unchanged
+ * inline tokens inside a broadly modified run.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.5
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.6.1
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.6.2
+ * @see https://github.com/UseJunior/safe-docx/issues/717
+ */
+export function refineFuzzyRunsWithinAlignedParagraphs(
+  originalAtoms: ComparisonUnitAtom[],
+  revisedAtoms: ComparisonUnitAtom[],
+  lcsResult: LcsResult,
+  moveSettings: MoveDetectionSettings,
+  identityInterner: IdentityInterner,
+): SelectiveWordRefinementResult {
+  const alignedParagraphPairs = new Set<string>();
+  for (const match of lcsResult.matches) {
+    const originalParagraph = originalAtoms[match.originalIndex]?.paragraphIndex;
+    const revisedParagraph = revisedAtoms[match.revisedIndex]?.paragraphIndex;
+    if (originalParagraph !== undefined && revisedParagraph !== undefined) {
+      alignedParagraphPairs.add(`${originalParagraph}:${revisedParagraph}`);
+    }
+  }
+
+  const candidates: Array<{
+    originalIndex: number;
+    revisedIndex: number;
+    similarity: number;
+  }> = [];
+  for (const originalIndex of lcsResult.deletedIndices) {
+    const originalAtom = originalAtoms[originalIndex]!;
+    const originalText = getAtomText(originalAtom);
+    if (
+      originalAtom.contentElement.tagName !== 'w:t' ||
+      originalAtom.collapsedFieldAtoms ||
+      countWords(originalText) < moveSettings.moveMinimumWordCount
+    ) {
+      continue;
+    }
+    for (const revisedIndex of lcsResult.insertedIndices) {
+      const revisedAtom = revisedAtoms[revisedIndex]!;
+      const revisedText = getAtomText(revisedAtom);
+      if (
+        revisedAtom.contentElement.tagName !== 'w:t' ||
+        revisedAtom.collapsedFieldAtoms ||
+        originalAtom.paragraphIndex === undefined ||
+        revisedAtom.paragraphIndex === undefined ||
+        !alignedParagraphPairs.has(
+          `${originalAtom.paragraphIndex}:${revisedAtom.paragraphIndex}`,
+        ) ||
+        countWords(revisedText) < moveSettings.moveMinimumWordCount ||
+        originalText === revisedText
+      ) {
+        continue;
+      }
+      const similarity = jaccardWordSimilarity(
+        originalText,
+        revisedText,
+        moveSettings.caseInsensitiveMove,
+      );
+      if (similarity >= moveSettings.moveSimilarityThreshold) {
+        candidates.push({ originalIndex, revisedIndex, similarity });
+      }
+    }
+  }
+
+  candidates.sort(
+    (left, right) =>
+      right.similarity - left.similarity ||
+      left.originalIndex - right.originalIndex ||
+      left.revisedIndex - right.revisedIndex,
+  );
+  const splitOriginal = new Set<number>();
+  const splitRevised = new Set<number>();
+  for (const candidate of candidates) {
+    if (
+      splitOriginal.has(candidate.originalIndex) ||
+      splitRevised.has(candidate.revisedIndex)
+    ) {
+      continue;
+    }
+    splitOriginal.add(candidate.originalIndex);
+    splitRevised.add(candidate.revisedIndex);
+  }
+
+  if (splitOriginal.size === 0) {
+    return {
+      originalAtoms,
+      revisedAtoms,
+      lcsResult,
+      refinedPairCount: 0,
+    };
+  }
+
+  const refinedOriginal = originalAtoms.flatMap((atom, index) =>
+    splitOriginal.has(index) ? splitAtomsIntoWords([atom]) : [atom],
+  );
+  const refinedRevised = revisedAtoms.flatMap((atom, index) =>
+    splitRevised.has(index) ? splitAtomsIntoWords([atom]) : [atom],
+  );
+  assignIdentityIds(refinedOriginal, identityInterner);
+  assignIdentityIds(refinedRevised, identityInterner);
+  return {
+    originalAtoms: refinedOriginal,
+    revisedAtoms: refinedRevised,
+    lcsResult: hierarchicalCompare(refinedOriginal, refinedRevised),
+    refinedPairCount: splitOriginal.size,
+  };
+}

--- a/packages/docx-compare/src/move-detection.test.ts
+++ b/packages/docx-compare/src/move-detection.test.ts
@@ -690,6 +690,46 @@ describe('detectMovesInAtomList', () => {
       expect(atom1.correlationStatus).toBe(CorrelationStatus.Inserted);
     });
   });
+
+  test('honors a caller guard for fuzzy candidates inside aligned paragraphs', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    let atoms: ComparisonUnitAtom[];
+
+    await given('a fuzzy deleted/inserted pair that otherwise meets the move threshold', () => {
+      atoms = [
+        createTestAtom(
+          'the annual allocation shall remain 10,000 units for each period',
+          CorrelationStatus.Deleted,
+        ),
+        createTestAtom(
+          'the annual allocation will remain 10,000 units for each period',
+          CorrelationStatus.Inserted,
+        ),
+      ];
+    });
+
+    await when('the caller rejects that candidate as an in-place edit', () => {
+      detectMovesInAtomList(
+        atoms,
+        {
+          detectMoves: true,
+          moveSimilarityThreshold: 0.8,
+          moveMinimumWordCount: 5,
+          caseInsensitiveMove: true,
+        },
+        new Set(),
+        () => false,
+      );
+    });
+
+    await then('the candidate remains an ordinary deletion and insertion', () => {
+      expect(atoms[0]?.correlationStatus).toBe(CorrelationStatus.Deleted);
+      expect(atoms[1]?.correlationStatus).toBe(CorrelationStatus.Inserted);
+    });
+  });
 });
 
 describe('generateMoveSourceMarkup', () => {

--- a/packages/docx-compare/src/move-detection.ts
+++ b/packages/docx-compare/src/move-detection.ts
@@ -213,6 +213,19 @@ interface MatchResult {
 }
 
 /**
+ * Optional candidate-level guard supplied by the comparison pipeline.
+ *
+ * Move detection remains usable as a standalone post-processing step, while
+ * callers that know paragraph correspondence can prevent a fuzzy edit from
+ * being relabeled as a relocation.
+ */
+export type MoveCandidateGuard = (
+  deleted: AtomBlock,
+  inserted: AtomBlock,
+  similarity: number,
+) => boolean;
+
+/**
  * Find the best matching inserted block for a deleted block.
  *
  * @param deleted - The deleted block to match
@@ -223,7 +236,8 @@ interface MatchResult {
 export function findBestMatch(
   deleted: AtomBlock,
   insertedBlocks: AtomBlock[],
-  settings: MoveDetectionSettings
+  settings: MoveDetectionSettings,
+  candidateGuard?: MoveCandidateGuard,
 ): MatchResult | undefined {
   let bestMatch: MatchResult | undefined;
 
@@ -242,6 +256,10 @@ export function findBestMatch(
       inserted.text,
       settings.caseInsensitiveMove
     );
+
+    if (candidateGuard && !candidateGuard(deleted, inserted, similarity)) {
+      continue;
+    }
 
     if (similarity >= settings.moveSimilarityThreshold) {
       if (!bestMatch || similarity > bestMatch.similarity) {
@@ -302,6 +320,7 @@ export function detectMovesInAtomList(
   atoms: ComparisonUnitAtom[],
   settings: MoveDetectionSettings = DEFAULT_MOVE_DETECTION_SETTINGS,
   reservedMoveNames: ReadonlySet<string> = new Set(),
+  candidateGuard?: MoveCandidateGuard,
 ): void {
   if (!settings.detectMoves) {
     return;
@@ -327,7 +346,7 @@ export function detectMovesInAtomList(
   let moveGroupId = 1;
 
   for (const deleted of deletedBlocks) {
-    const bestMatch = findBestMatch(deleted, insertedBlocks, settings);
+    const bestMatch = findBestMatch(deleted, insertedBlocks, settings, candidateGuard);
 
     if (bestMatch) {
       // 4. Convert to moves


### PR DESCRIPTION
## Summary
- Selectively word-split fuzzy changed runs only after exact atoms establish paragraph correspondence.
- Prevent remaining fuzzy same-paragraph edits from being mislabeled as moves while retaining exact and cross-paragraph moves.
- Add public synthetic regression coverage for unchanged numeric content, duplicate tokens, punctuation, move classification, and exact accept/reject projections.

## Confidential benchmark validation
- Unchanged monetary delete/reinsert artifacts: 1 to 0.
- Overlapping delete/insert tokens: 178 to 103.
- Confidential inputs, filenames, and text remain local and are not included in this PR.

## Validation
- npm run build
- npm run lint:workspaces
- npm run test:run
- npm run check:spec-coverage
- npm run check:conformance-citations
- npm run check:conformance-doc

Closes #717