### PR TITLE
fix(docx-comparison): refine containment-heavy aligned runs

### DIFF
--- a/packages/docx-compare/src/baselines/atomizer/pipeline-selective-word-refinement.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline-selective-word-refinement.test.ts
@@ -6,6 +6,7 @@
  * @conformance ECMA-376 edition 5, Part 1 § 17.13.6.1
  * @conformance ECMA-376 edition 5, Part 1 § 17.13.6.2
  * @see https://github.com/UseJunior/safe-docx/issues/717
+ * @see https://github.com/UseJunior/safe-docx/issues/734
  */
 
 import {
@@ -22,13 +23,21 @@ import {
   createComparisonUnitAtom,
   IdentityInterner,
 } from '../../atomizer.js';
-import { getAtomText } from '../../move-detection.js';
+import {
+  getAtomText,
+  jaccardWordSimilarity,
+  wordContainmentSimilarity,
+} from '../../move-detection.js';
 import { el } from '../../testing/dom-test-helpers.js';
 import { buildDocxFromBodyXml } from '../../testing/ooxml-fixtures.js';
 import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
 import { hierarchicalCompare } from './hierarchicalLcs.js';
 import { compareDocumentsAtomizer } from './pipeline.js';
-import { refineFuzzyRunsWithinAlignedParagraphs } from './selectiveWordRefinement.js';
+import {
+  ALIGNED_RUN_REFINEMENT_CONTAINMENT_THRESHOLD,
+  ALIGNED_RUN_REFINEMENT_SIMILARITY_THRESHOLD,
+  refineFuzzyRunsWithinAlignedParagraphs,
+} from './selectiveWordRefinement.js';
 import { acceptAllChanges, rejectAllChanges } from './trackChangesAcceptorAst.js';
 
 const test = testAllure
@@ -52,6 +61,18 @@ function paragraph(changedRun: string): string {
     '<w:r><w:rPr><w:i/></w:rPr><w:t xml:space="preserve"> Aligned suffix.</w:t></w:r>' +
     '</w:p>'
   );
+}
+
+const documentPart: OpcPart = { uri: 'word/document.xml', contentType: 'text/xml' };
+
+function comparisonAtom(text: string, paragraphIndex = 0): ComparisonUnitAtom {
+  const result = createComparisonUnitAtom({
+    contentElement: el('w:t', {}, undefined, text) as WmlElement,
+    ancestors: [],
+    part: documentPart,
+  });
+  result.paragraphIndex = paragraphIndex;
+  return result;
 }
 
 async function documentXml(docx: Buffer): Promise<string> {
@@ -86,25 +107,15 @@ describe('selective word refinement for aligned paragraphs (#717)', () => {
     then,
     and,
   }: AllureBddContext) => {
-    const part: OpcPart = { uri: 'word/document.xml', contentType: 'text/xml' };
-    const atom = (text: string): ComparisonUnitAtom => {
-      const result = createComparisonUnitAtom({
-        contentElement: el('w:t', {}, undefined, text) as WmlElement,
-        ancestors: [],
-        part,
-      });
-      result.paragraphIndex = 0;
-      return result;
-    };
     const originalAtoms = await given('three run-level atoms with one long fuzzy changed run', () => [
-      atom('Aligned prefix. '),
-      atom('The annual allocation shall remain 10,000 units for each reporting period; review, review, under this agreement.'),
-      atom(' Aligned suffix.'),
+      comparisonAtom('Aligned prefix. '),
+      comparisonAtom('The annual allocation shall remain 10,000 units for each reporting period; review, review, under this agreement.'),
+      comparisonAtom(' Aligned suffix.'),
     ]);
     const revisedAtoms = await given('the aligned revised atoms preserving an interior numeric token', () => [
-      atom('Aligned prefix. '),
-      atom('The annual allocation will remain 10,000 units for each reporting period; review, review, under this agreement.'),
-      atom(' Aligned suffix.'),
+      comparisonAtom('Aligned prefix. '),
+      comparisonAtom('The annual allocation will remain 10,000 units for each reporting period; review, review, under this agreement.'),
+      comparisonAtom(' Aligned suffix.'),
     ]);
     const interner = new IdentityInterner();
     assignIdentityIds(originalAtoms, interner);
@@ -144,6 +155,58 @@ describe('selective word refinement for aligned paragraphs (#717)', () => {
           .map((index) => getAtomText(refined.revisedAtoms[index]!))
           .some((text) => text.includes('10,000')),
       ).toBe(false);
+    });
+  });
+
+  test('refines a containment-heavy aligned run below the move threshold', async ({
+    given,
+    when,
+    then,
+    and,
+  }: AllureBddContext) => {
+    const originalChanged =
+      'stable anchor one two three four five';
+    const revisedChanged =
+      'stable anchor one two three four five new gamma delta epsilon zeta eta theta iota kappa lambda mu nu xi omicron';
+    const similarity = jaccardWordSimilarity(originalChanged, revisedChanged);
+    const containment = wordContainmentSimilarity(originalChanged, revisedChanged);
+    const originalAtoms = await given('an aligned paragraph with a moderately overlapping long run', () => [
+      comparisonAtom('Exact prefix. '),
+      comparisonAtom(originalChanged),
+      comparisonAtom(' Exact suffix.'),
+    ]);
+    const revisedAtoms = await given('a longer replacement that retains most of the source vocabulary', () => [
+      comparisonAtom('Exact prefix. '),
+      comparisonAtom(revisedChanged),
+      comparisonAtom(' Exact suffix.'),
+    ]);
+    const interner = new IdentityInterner();
+    assignIdentityIds(originalAtoms, interner);
+    assignIdentityIds(revisedAtoms, interner);
+
+    const refined = await when('selective refinement evaluates the aligned changed runs', () =>
+      refineFuzzyRunsWithinAlignedParagraphs(
+        originalAtoms,
+        revisedAtoms,
+        hierarchicalCompare(originalAtoms, revisedAtoms),
+        DEFAULT_MOVE_DETECTION_SETTINGS,
+        interner,
+      ),
+    );
+
+    await then('containment is sufficient even though Jaccard overlap is below both thresholds', () => {
+      expect(similarity).toBeLessThan(ALIGNED_RUN_REFINEMENT_SIMILARITY_THRESHOLD);
+      expect(similarity).toBeLessThan(DEFAULT_MOVE_DETECTION_SETTINGS.moveSimilarityThreshold);
+      expect(containment).toBeGreaterThanOrEqual(ALIGNED_RUN_REFINEMENT_CONTAINMENT_THRESHOLD);
+      expect(refined.refinedPairCount).toBe(1);
+    });
+
+    await and('shared interior words become exact atom matches', () => {
+      const matched = refined.lcsResult.matches.map((match) =>
+        getAtomText(refined.revisedAtoms[match.revisedIndex]!),
+      );
+      expect(matched).toContain('stable');
+      expect(matched).toContain('five');
     });
   });
 
@@ -196,6 +259,70 @@ describe('selective word refinement for aligned paragraphs (#717)', () => {
     });
 
     await and('accept and reject projections exactly recover their respective source text', () => {
+      expect(projectedText(xml, 'accept')).toBe(revisedText);
+      expect(projectedText(xml, 'reject')).toBe(originalText);
+    });
+  });
+
+  test('keeps fully contained source vocabulary outside an expanded-run replacement', async ({
+    given,
+    when,
+    then,
+    and,
+  }: AllureBddContext) => {
+    const originalRun =
+      'The committee may review the annual allocation under this agreement for each reporting period.';
+    const revisedRun =
+      'The committee may after consulting its advisers and examining the applicable records review the annual allocation under this agreement for each reporting period and document its conclusions in a written report delivered promptly to all interested parties.';
+    const originalBody = paragraph(originalRun);
+    const revisedBody = paragraph(revisedRun);
+    const originalText = parseXml(
+      `<w:root xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">${originalBody}</w:root>`,
+    ).documentElement.textContent ?? '';
+    const revisedText = parseXml(
+      `<w:root xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">${revisedBody}</w:root>`,
+    ).documentElement.textContent ?? '';
+
+    const original = await given('a long run whose vocabulary is retained by an expanded revision', () =>
+      buildDocxFromBodyXml(originalBody),
+    );
+    const revised = await given('the same run with substantial new language around it', () =>
+      buildDocxFromBodyXml(revisedBody),
+    );
+    const comparison = await when('the documents are compared in place', () =>
+      compareDocumentsAtomizer(original, revised, {
+        reconstructionMode: 'inplace',
+        date: new Date('2026-07-29T12:00:00Z'),
+      }),
+    );
+    const xml = await documentXml(comparison.document);
+    const document = parseXml(xml);
+
+    await then('a retained interior word is emitted once outside revision wrappers', () => {
+      const retained = Array.from(document.getElementsByTagName('w:t'))
+        .concat(Array.from(document.getElementsByTagName('w:delText')))
+        .filter((node) => (node.textContent ?? '').includes('allocation'));
+      expect(retained).toHaveLength(1);
+      expect(revisionAncestor(retained[0]!)).toBeNull();
+    });
+
+    await and('no unchanged words overlap the deletion and insertion payloads', () => {
+      const words = (value: string): Set<string> =>
+        new Set(value.toLowerCase().match(/[a-z]+/g) ?? []);
+      const deleted = words(
+        Array.from(document.getElementsByTagName('w:del'))
+          .map((node) => node.textContent ?? '')
+          .join(' '),
+      );
+      const inserted = words(
+        Array.from(document.getElementsByTagName('w:ins'))
+          .map((node) => node.textContent ?? '')
+          .join(' '),
+      );
+      expect([...deleted].filter((word) => inserted.has(word))).toHaveLength(0);
+    });
+
+    await and('accept and reject recover the expanded and source paragraphs exactly', () => {
       expect(projectedText(xml, 'accept')).toBe(revisedText);
       expect(projectedText(xml, 'reject')).toBe(originalText);
     });

--- a/packages/docx-compare/src/baselines/atomizer/selectiveWordRefinement.ts
+++ b/packages/docx-compare/src/baselines/atomizer/selectiveWordRefinement.ts
@@ -11,6 +11,7 @@ import {
   countWords,
   getAtomText,
   jaccardWordSimilarity,
+  wordContainmentSimilarity,
 } from '../../move-detection.js';
 import { hierarchicalCompare } from './hierarchicalLcs.js';
 import type { LcsResult } from './atomLcs.js';
@@ -23,6 +24,14 @@ export interface SelectiveWordRefinementResult {
 }
 
 /**
+ * Aligned paragraphs already have exact atom evidence establishing their
+ * correspondence, so refining their changed runs does not need the stricter
+ * threshold used to infer a move between otherwise unrelated locations.
+ */
+export const ALIGNED_RUN_REFINEMENT_SIMILARITY_THRESHOLD = 0.5;
+export const ALIGNED_RUN_REFINEMENT_CONTAINMENT_THRESHOLD = 0.8;
+
+/**
  * Refine fuzzy changed runs only inside paragraph pairs already established by
  * exact atom matches. This is the run-level precision escape hatch: it avoids
  * applying word atomization to unrelated paragraphs while preserving unchanged
@@ -32,6 +41,7 @@ export interface SelectiveWordRefinementResult {
  * @conformance ECMA-376 edition 5, Part 1 § 17.13.6.1
  * @conformance ECMA-376 edition 5, Part 1 § 17.13.6.2
  * @see https://github.com/UseJunior/safe-docx/issues/717
+ * @see https://github.com/UseJunior/safe-docx/issues/734
  */
 export function refineFuzzyRunsWithinAlignedParagraphs(
   originalAtoms: ComparisonUnitAtom[],
@@ -80,13 +90,25 @@ export function refineFuzzyRunsWithinAlignedParagraphs(
       ) {
         continue;
       }
-      const similarity = jaccardWordSimilarity(
+      const jaccardSimilarity = jaccardWordSimilarity(
         originalText,
         revisedText,
         moveSettings.caseInsensitiveMove,
       );
-      if (similarity >= moveSettings.moveSimilarityThreshold) {
-        candidates.push({ originalIndex, revisedIndex, similarity });
+      const containmentSimilarity = wordContainmentSimilarity(
+        originalText,
+        revisedText,
+        moveSettings.caseInsensitiveMove,
+      );
+      if (
+        jaccardSimilarity >= ALIGNED_RUN_REFINEMENT_SIMILARITY_THRESHOLD ||
+        containmentSimilarity >= ALIGNED_RUN_REFINEMENT_CONTAINMENT_THRESHOLD
+      ) {
+        candidates.push({
+          originalIndex,
+          revisedIndex,
+          similarity: Math.max(jaccardSimilarity, containmentSimilarity),
+        });
       }
     }
   }

--- a/packages/docx-compare/src/move-detection.test.ts
+++ b/packages/docx-compare/src/move-detection.test.ts
@@ -12,6 +12,7 @@ import {
   generateMoveDestinationMarkup,
   createRevisionIdState,
   allocateMoveIds,
+  wordContainmentSimilarity,
 } from './move-detection.js';
 import { assertDefined } from './testing/test-utils.js';
 import {
@@ -129,6 +130,41 @@ describe('jaccardWordSimilarity', () => {
     await then('similarity is 1 because unique word sets are the same', () => {
       // "the the the" and "the" should have similarity 1 (same unique word set)
       expect(jaccardWordSimilarity('the the the', 'the')).toBe(1);
+    });
+  });
+});
+
+describe('wordContainmentSimilarity', () => {
+  test('stays high when the larger run preserves every source word', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    const original = await given('a short source run', () => 'alpha beta gamma delta');
+    const revised = await given(
+      'an expanded run containing every source word',
+      () => 'alpha beta gamma delta epsilon zeta eta theta',
+    );
+    const similarity = await when('word containment is computed', () =>
+      wordContainmentSimilarity(original, revised),
+    );
+    await then('the smaller word set is fully contained', () => {
+      expect(similarity).toBe(1);
+    });
+  });
+
+  test('returns the contained fraction of the smaller unique word set', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    const original = await given('a four-word source', () => 'alpha beta gamma delta');
+    const revised = await given('a four-word revision sharing two words', () => 'alpha beta one two');
+    const similarity = await when('word containment is computed', () =>
+      wordContainmentSimilarity(original, revised),
+    );
+    await then('the result is one half', () => {
+      expect(similarity).toBe(0.5);
     });
   });
 });

--- a/packages/docx-compare/src/move-detection.ts
+++ b/packages/docx-compare/src/move-detection.ts
@@ -72,6 +72,11 @@ export function countWords(text: string): number {
   return words.length;
 }
 
+function normalizedWordSet(text: string, caseInsensitive: boolean): Set<string> {
+  const normalized = caseInsensitive ? text.toLowerCase() : text;
+  return new Set(normalized.split(/\s+/).filter(Boolean));
+}
+
 // =============================================================================
 // Jaccard Similarity
 // =============================================================================
@@ -100,20 +105,8 @@ export function jaccardWordSimilarity(
   text2: string,
   caseInsensitive = true
 ): number {
-  const normalize = caseInsensitive
-    ? (s: string) => s.toLowerCase()
-    : (s: string) => s;
-
-  const words1 = new Set(
-    normalize(text1)
-      .split(/\s+/)
-      .filter(Boolean)
-  );
-  const words2 = new Set(
-    normalize(text2)
-      .split(/\s+/)
-      .filter(Boolean)
-  );
+  const words1 = normalizedWordSet(text1, caseInsensitive);
+  const words2 = normalizedWordSet(text2, caseInsensitive);
 
   if (words1.size === 0 && words2.size === 0) {
     return 1; // Both empty = identical
@@ -135,6 +128,29 @@ export function jaccardWordSimilarity(
   const unionSize = words1.size + words2.size - intersectionSize;
 
   return intersectionSize / unionSize;
+}
+
+/**
+ * Calculate how completely the smaller word set is contained in the larger.
+ *
+ * Unlike Jaccard similarity, containment remains high when an aligned run keeps
+ * all of its old vocabulary but adds substantial new text.
+ */
+export function wordContainmentSimilarity(
+  text1: string,
+  text2: string,
+  caseInsensitive = true,
+): number {
+  const words1 = normalizedWordSet(text1, caseInsensitive);
+  const words2 = normalizedWordSet(text2, caseInsensitive);
+  if (words1.size === 0 && words2.size === 0) return 1;
+  if (words1.size === 0 || words2.size === 0) return 0;
+
+  let intersectionSize = 0;
+  for (const word of words1) {
+    if (words2.has(word)) intersectionSize++;
+  }
+  return intersectionSize / Math.min(words1.size, words2.size);
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- decouple selective word refinement inside already-aligned paragraphs from the stricter cross-location move threshold
- add a shared word-containment metric for extension-heavy run revisions
- preserve the existing move-inference behavior while refining retained source vocabulary into exact word matches

## Why

Exact atoms can already establish that two paragraphs correspond even when one long changed run grows substantially. Reusing the 0.8 move threshold for that run-level refinement left containment-heavy edits as broad delete/insert replacements and re-marked retained words.

The new gate is scoped to aligned paragraphs: refine when either Jaccard overlap is at least 0.5 or the smaller unique-word set is at least 0.8 contained in the larger. Cross-location move inference still uses its existing threshold.

## Public coverage

- unit coverage for the shared containment metric
- direct aligned-run coverage below the move threshold
- end-to-end DOCX comparison coverage proving retained interior words remain outside revision wrappers
- exact accept/reject projection assertions
- unchanged-word delete/insert overlap assertion

## Private competitive oracle

Aggregate structural evidence only; no confidential documents, filenames, text, paths, or identifying metadata are included.

- Pair A overlap: 22 → 22 (pinned baseline: 22)
- Pair B overlap: 94 → 94 (pinned baseline: 146)
- Pair C overlap: 103 → 72 (pinned baseline: 84)
- revision-paragraph counts do not regress on A, B, or C
- unchanged-dollar artifacts remain zero on all three pairs
- newly visible Pair C format revisions are unique, outside text wrappers, and represent actual character-spacing differences; Safe-DOCX emits 17 versus the pinned baseline's 35

The aggregate paragraph-spread audit accounted for every Safe-DOCX revision paragraph. The dominant extra shapes are genuine full-paragraph insertions/deletions with tracked paragraph marks, not pairing misses. Those marks are retained intentionally because they preserve accept/reject paragraph topology. Safe-DOCX's actual projections are exact on A and C; B is exact on reject and cache-insensitive exact on the five volatile TOC field-result paragraphs already documented in #716.

## Verification

- mandatory full pre-submit command passed
- docx-compare: 56 files passed, 758 tests passed, 99 skipped
- docx-core: 124 files passed, 1 skipped; 1,291 tests passed, 2 expected failures, 15 skipped
- all remaining workspaces passed
- strict spec coverage and both conformance checks passed

Fixes #734
Related to #717, #718, and #724
