### PR TITLE
fix(docx-comparison): expose inserted-section footer stories

### DIFF
--- a/openspec/changes/surface-unrepresented-section-changes/proposal.md
+++ b/openspec/changes/surface-unrepresented-section-changes/proposal.md
@@ -12,6 +12,9 @@ running content changed.
 - Add structured `CompareResult.unrepresentedChanges` diagnostics.
 - Detect section-property and relationship-selected header/footer differences
   that are present in the inputs but not represented by emitted revisions.
+- When the selecting section is itself a tracked insertion, represent its
+  footer with tracked paragraph and safe run insertions, leaving only the
+  section-property change in `unrepresentedChanges`.
 - Keep existing revision statistics unchanged; the new field makes their scope
   explicit instead of counting non-text changes as insertions or deletions.
 
@@ -19,5 +22,4 @@ running content changed.
 
 - Affected specs: `docx-comparison`
 - Affected code: atomizer package inspection, public comparison result types,
-  and comparison integration tests
-
+  relationship-selected story assembly, and comparison integration tests

--- a/openspec/changes/surface-unrepresented-section-changes/specs/docx-comparison/spec.md
+++ b/openspec/changes/surface-unrepresented-section-changes/specs/docx-comparison/spec.md
@@ -20,3 +20,11 @@ statistics SHALL retain their existing meaning.
 - **GIVEN** identical original and revised DOCX packages
 - **WHEN** they are compared
 - **THEN** `unrepresentedChanges` SHALL be absent
+
+#### Scenario: [SDX-CMP-UNREP-03] Footer selected by a tracked inserted section is represented
+
+- **GIVEN** a revised DOCX whose tracked inserted section exclusively selects a new relationship-addressed footer
+- **WHEN** the pair is successfully compared in place
+- **THEN** every paragraph in the inserted footer story SHALL carry tracked insertion evidence
+- **AND** text insertions SHALL NOT wrap VML or DrawingML carrier objects
+- **AND** the represented footer SHALL NOT also appear in `unrepresentedChanges`

--- a/openspec/changes/surface-unrepresented-section-changes/tasks.md
+++ b/openspec/changes/surface-unrepresented-section-changes/tasks.md
@@ -5,3 +5,4 @@
 - [x] 1.3 Attach diagnostics to atomizer comparison results in both modes.
 - [x] 1.4 Add regression and no-change tests using shared DOCX fixture builders.
 - [x] 1.5 Run OpenSpec validation and repository pre-submit checks.
+- [x] 1.6 Represent inserted-section footer paragraphs and validate their selected-story projections.

--- a/packages/docx-compare/src/baselines/atomizer/pipeline-added-footer-story.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline-added-footer-story.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Relationship-selected header/footer parts are independent
+ * WordprocessingML stories. A footer selected exclusively by an inserted
+ * section can therefore carry ordinary tracked paragraph insertions.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.10.2
+ * @conformance ECMA-376 edition 5, Part 1 § 17.6.17
+ * @see https://github.com/UseJunior/safe-docx/issues/648
+ */
+
+import { describe, expect } from 'vitest';
+import {
+  DocxArchive,
+  OOXML,
+  parseXml,
+} from '@usejunior/docx-core';
+import { buildDocxFromBodyXml } from '../../testing/ooxml-fixtures.js';
+import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
+import { extractRoundTripComparisonText } from '../../fieldComparisonSemantics.js';
+import { compareDocumentsAtomizer } from './pipeline.js';
+import {
+  acceptAllChanges,
+  rejectAllChanges,
+} from './trackChangesAcceptorAst.js';
+
+const FOOTER_RELATIONSHIP =
+  'http://schemas.openxmlformats.org/officeDocument/2006/relationships/footer';
+
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({
+    feature: 'In-Place Reconstruction',
+    story: 'Inserted Section Footer Stories',
+    severity: 'critical',
+  })
+  .conformance(
+    { spec: 'ECMA-376', edition: 5, part: 1, section: '17.10.2' },
+    { spec: 'ECMA-376', edition: 5, part: 1, section: '17.6.17' },
+  );
+
+function paragraph(text: string): string {
+  return `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
+}
+
+function footerXml(): string {
+  return (
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<w:ftr xmlns:w="${OOXML.W_NS}" xmlns:v="urn:schemas-microsoft-com:vml">` +
+    `<w:p><w:r><w:pict><v:shape><v:textbox><w:txbxContent>` +
+    paragraph('First nested footer line') +
+    paragraph('Second nested footer line') +
+    `</w:txbxContent></v:textbox></v:shape></w:pict></w:r></w:p>` +
+    `<w:p/><w:p/>` +
+    paragraph('Fourth footer line') +
+    paragraph('Fifth footer line') +
+    `</w:ftr>`
+  );
+}
+
+describe('relationship-selected footer story comparison (#648)', () => {
+  test.openspec('[SDX-CMP-UNREP-03] Footer selected by a tracked inserted section is represented')(
+    'tracks every paragraph in a footer owned by an inserted section',
+    async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    const original = await given('one body section without a footer', () =>
+      buildDocxFromBodyXml(paragraph('Stable body')),
+    );
+    const insertedSection =
+      `<w:p><w:pPr><w:sectPr>` +
+      `<w:footerReference w:type="default" r:id="rIdFooter"/>` +
+      `</w:sectPr></w:pPr><w:r><w:t>Inserted section</w:t></w:r></w:p>`;
+    const revisedFooterTexts = [
+      'First nested footer line',
+      'Second nested footer line',
+      'Fourth footer line',
+      'Fifth footer line',
+    ];
+    const revised = await given('an inserted section selecting a five-paragraph footer', () =>
+      buildDocxFromBodyXml(
+        paragraph('Stable body') + insertedSection,
+        [],
+        {
+          namespaces: {
+            r: 'http://schemas.openxmlformats.org/officeDocument/2006/relationships',
+          },
+        },
+      ).then(async (buffer) => {
+        const archive = await DocxArchive.load(buffer);
+        archive.setFile(
+          'word/_rels/document.xml.rels',
+          `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+            `<Relationship Id="rIdFooter" Type="${FOOTER_RELATIONSHIP}" Target="footer1.xml"/>` +
+            `</Relationships>`,
+        );
+        archive.setFile('word/footer1.xml', footerXml());
+        return archive.save();
+      }),
+    );
+
+    const result = await when('the pair is compared in place', () =>
+      compareDocumentsAtomizer(original, revised, {
+        reconstructionMode: 'inplace',
+        author: 'Comparison',
+        date: new Date('2026-07-29T00:00:00.000Z'),
+      }),
+    );
+    const archive = await DocxArchive.load(result.document);
+    const outputFooter = await archive.getFile('word/footer1.xml');
+    const outputDocument = await archive.getDocumentXml();
+
+    await then('all five footer paragraphs are visible tracked insertions', () => {
+      expect(outputFooter).not.toBeNull();
+      const footer = parseXml(outputFooter!);
+      const revisionParagraphs = Array.from(
+        footer.documentElement.childNodes,
+      ).filter((item): item is Element =>
+        item.nodeType === 1 &&
+        (item as Element).namespaceURI === OOXML.W_NS &&
+        (item as Element).localName === 'p' &&
+        (item as Element).getElementsByTagNameNS(OOXML.W_NS, 'ins').length > 0,
+      );
+      expect(revisionParagraphs).toHaveLength(5);
+      const insertions = Array.from(
+        footer.getElementsByTagNameNS(OOXML.W_NS, 'ins'),
+      );
+      expect(insertions.every((insertion) =>
+        insertion.getElementsByTagNameNS(OOXML.W_NS, 'pict').length === 0 &&
+        insertion.getElementsByTagNameNS(OOXML.W_NS, 'drawing').length === 0
+      )).toBe(true);
+      const footerIds = insertions.map((insertion) =>
+        insertion.getAttributeNS(OOXML.W_NS, 'id') ||
+        insertion.getAttribute('w:id'),
+      );
+      const bodyIds = Array.from(
+        parseXml(outputDocument).getElementsByTagNameNS(OOXML.W_NS, 'ins'),
+      ).map((insertion) =>
+        insertion.getAttributeNS(OOXML.W_NS, 'id') ||
+        insertion.getAttribute('w:id'),
+      );
+      expect(new Set(footerIds).size).toBe(footerIds.length);
+      expect(footerIds.some((id) => bodyIds.includes(id))).toBe(false);
+      expect(result.stats.insertions).toBeGreaterThanOrEqual(5);
+      expect(result.unrepresentedChanges ?? []).toEqual(
+        expect.not.arrayContaining([
+          expect.objectContaining({
+            scope: 'footer',
+            kind: 'added',
+            role: 'default',
+          }),
+        ]),
+      );
+    });
+
+    await then('the footer story recovers its revised and absent-side text', () => {
+      const acceptedText = extractRoundTripComparisonText(
+        acceptAllChanges(outputFooter!),
+      );
+      expect(revisedFooterTexts.every((text) => acceptedText.includes(text))).toBe(true);
+      expect(
+        extractRoundTripComparisonText(rejectAllChanges(outputFooter!)).trim(),
+      ).toBe('');
+    });
+    },
+  );
+});

--- a/packages/docx-compare/src/baselines/atomizer/pipeline-added-footer-story.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline-added-footer-story.test.ts
@@ -25,11 +25,12 @@ import {
 
 const FOOTER_RELATIONSHIP =
   'http://schemas.openxmlformats.org/officeDocument/2006/relationships/footer';
+const TEST_FEATURE = 'docx-comparison';
 
 const test = testAllure
   .epic('Document Comparison')
   .withLabels({
-    feature: 'In-Place Reconstruction',
+    feature: TEST_FEATURE,
     story: 'Inserted Section Footer Stories',
     severity: 'critical',
   })

--- a/packages/docx-compare/src/baselines/atomizer/pipeline.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline.ts
@@ -130,7 +130,9 @@ import { suppressVolatileTocPagerefCacheRevisions } from './tocPagerefCache.js';
 import {
   assembleTextBoxStoryComparison,
   assertAncillaryTextBoxStoryProjection,
+  markInsertedAncillaryStoryParagraphs,
   prepareTextBoxStoryComparison,
+  rejectedSelectedAncillaryStoryPaths,
   UnsupportedTextBoxRevisionError,
 } from './textBoxRevisionSafety.js';
 
@@ -642,12 +644,22 @@ export async function compareDocumentsAtomizer(
   const storyResults: Array<{
     index: number;
     partPath: string;
+    container: 'textBox' | 'ancillaryPart';
     result: CompareResult;
   }> = [];
+  const rejectedSelectedStoryPaths =
+    await rejectedSelectedAncillaryStoryPaths(outerResult.document);
+  const representedPartPaths = new Set<string>();
   for (const story of textBoxPlan.stories) {
-    const result = await compareDocumentsAtomizerCore(
+    if (
+      story.container === 'ancillaryPart' &&
+      rejectedSelectedStoryPaths.has(story.partPath)
+    ) {
+      continue;
+    }
+    let result = await compareDocumentsAtomizerCore(
       story.original,
-      story.revised,
+      story.container === 'ancillaryPart' ? story.original : story.revised,
       nestedOptions,
     );
     if (result.reconstructionModeUsed !== 'inplace') {
@@ -657,18 +669,43 @@ export async function compareDocumentsAtomizer(
         reason: 'the nested story required rebuild fallback',
       }]);
     }
+    if (story.container === 'ancillaryPart') {
+      const marked = await markInsertedAncillaryStoryParagraphs(
+        story.revised,
+        outerResult.document,
+        options.author ?? 'Comparison',
+        options.date ?? new Date(),
+      );
+      const insertionRanges = marked.directParagraphs;
+      result = {
+        ...result,
+        document: marked.document,
+        stats: {
+          ...result.stats,
+          insertions: insertionRanges,
+          insertedRanges: insertionRanges,
+          insertedAtoms: Math.max(
+            result.stats.insertedAtoms,
+            marked.directParagraphs,
+          ),
+        },
+      };
+      representedPartPaths.add(story.partPath);
+    }
     storyResults.push({
       index: story.index,
       partPath: story.partPath,
+      container: story.container,
       result,
     });
   }
 
   const document = await assembleTextBoxStoryComparison(
     outerResult.document,
-    storyResults.map(({ index, partPath, result }) => ({
+    storyResults.map(({ index, partPath, container, result }) => ({
       index,
       partPath,
+      container,
       document: result.document,
     })),
   );
@@ -692,7 +729,10 @@ export async function compareDocumentsAtomizer(
       reason: 'assembled nested stories failed accept/reject round-trip validation',
     }]);
   }
-  if (textBoxPlan.validateAncillaryProjection) {
+  if (
+    textBoxPlan.hasAncillaryTextBoxStories ||
+    representedPartPaths.size > 0
+  ) {
     await assertAncillaryTextBoxStoryProjection(original, revised, document);
   }
 
@@ -742,7 +782,7 @@ export async function compareDocumentsAtomizer(
         exclusions: [
           ...(certificate.exclusions ?? []),
           'Nested w:txbxContent stories are not independently enumerated by the compiled verifier.',
-          ...(textBoxPlan.validateAncillaryProjection
+          ...(textBoxPlan.hasAncillaryTextBoxStories
             ? [
                 'Relationship-selected header/footer w:txbxContent stories are not independently enumerated by the compiled verifier.',
               ]
@@ -751,11 +791,26 @@ export async function compareDocumentsAtomizer(
       }))
     : undefined;
 
+  const unrepresentedChanges = outerResult.unrepresentedChanges?.filter(
+    (change) => !textBoxPlan.representedAncillaryChanges.some(
+      (represented) =>
+        representedPartPaths.has(represented.partPath) &&
+        change.scope === represented.scope &&
+        change.kind === represented.kind &&
+        change.sectionIndex === represented.sectionIndex &&
+        change.role === represented.role,
+    ),
+  );
+
   return {
     ...outerResult,
     document,
     stats,
     documentIntegrity,
+    unrepresentedChanges:
+      unrepresentedChanges && unrepresentedChanges.length > 0
+        ? unrepresentedChanges
+        : undefined,
   };
 }
 

--- a/packages/docx-compare/src/baselines/atomizer/textBoxRevisionSafety.ts
+++ b/packages/docx-compare/src/baselines/atomizer/textBoxRevisionSafety.ts
@@ -14,6 +14,14 @@ import {
 } from './trackChangesAcceptorAst.js';
 import { extractRoundTripComparisonText } from '../../fieldComparisonSemantics.js';
 import { parseDocumentXml } from './xmlToWmlElement.js';
+import {
+  createRevisionIdState,
+  formatDate,
+} from './inPlaceModifier-shared.js';
+import {
+  addParagraphMarkRevisionMarker,
+  wrapRunWithTrackChange,
+} from './inPlaceModifier-wrappers.js';
 
 const WORD_2010_NS = 'http://schemas.microsoft.com/office/word/2010/wordml';
 const VML_NS = 'urn:schemas-microsoft-com:vml';
@@ -61,6 +69,7 @@ export class UnsupportedTextBoxRevisionError extends Error {
 export interface TextBoxStoryInput {
   index: number;
   partPath: string;
+  container: 'textBox' | 'ancillaryPart';
   original: Buffer;
   revised: Buffer;
 }
@@ -72,6 +81,14 @@ export interface TextBoxStoryComparisonPlan {
   revisedDocumentXml: string;
   stories: TextBoxStoryInput[];
   validateAncillaryProjection: boolean;
+  hasAncillaryTextBoxStories: boolean;
+  representedAncillaryChanges: Array<{
+    scope: 'header' | 'footer';
+    kind: 'added';
+    sectionIndex: number;
+    role: 'default' | 'first' | 'even';
+    partPath: string;
+  }>;
 }
 
 function textBoxParagraphId(textBox: Element): string | undefined {
@@ -234,6 +251,37 @@ function storyDocumentXmlFromPart(
   return serializer.serializeToString(document);
 }
 
+function copyNamespaceDeclarations(source: Element, target: Element): void {
+  for (let index = 0; index < source.attributes.length; index += 1) {
+    const attribute = source.attributes.item(index);
+    if (
+      attribute &&
+      (attribute.name === 'xmlns' || attribute.name.startsWith('xmlns:')) &&
+      !target.hasAttribute(attribute.name)
+    ) {
+      target.setAttribute(attribute.name, attribute.value);
+    }
+  }
+}
+
+function storyDocumentXmlFromPartRoot(
+  documentXml: string,
+  partXml: string | null,
+): string {
+  const document = parseXml(documentXml);
+  const body = document.getElementsByTagNameNS(OOXML.W_NS, 'body').item(0);
+  if (!body) throw new Error('Could not isolate relationship-selected story');
+  while (body.firstChild) body.removeChild(body.firstChild);
+  if (partXml) {
+    const part = parseXml(partXml);
+    copyNamespaceDeclarations(part.documentElement, document.documentElement);
+    for (const child of Array.from(part.documentElement.childNodes)) {
+      body.appendChild(document.importNode(child, true));
+    }
+  }
+  return serializer.serializeToString(document);
+}
+
 function owningRelationshipsPath(partPath: string): string {
   const slash = partPath.lastIndexOf('/');
   const directory = slash >= 0 ? partPath.slice(0, slash) : '';
@@ -254,6 +302,7 @@ interface SelectedAncillaryStory {
 
 interface SelectedAncillaryState {
   documentXml: string;
+  bindingAuditValid: boolean;
   sectionCount: number;
   auditBindings: SectPrBinding[];
   stories: SelectedAncillaryStory[];
@@ -279,6 +328,20 @@ function partScaffoldFingerprint(xml: string): string {
     root.getElementsByTagNameNS(OOXML.W_NS, 'txbxContent'),
   )) {
     while (textBox.firstChild) textBox.removeChild(textBox.firstChild);
+  }
+  for (const propertyName of ['rPr', 'pPr']) {
+    const properties = Array.from(
+      root.getElementsByTagNameNS(OOXML.W_NS, propertyName),
+    ).reverse();
+    for (const property of properties) {
+      if (
+        property.attributes.length === 0 &&
+        directChildElements(property).length === 0 &&
+        !(property.textContent ?? '').trim()
+      ) {
+        property.parentNode?.removeChild(property);
+      }
+    }
   }
   return canonicalNode(root);
 }
@@ -316,6 +379,7 @@ async function selectedAncillaryState(
     // narrower text-box error merely because this preparatory scan runs first.
     return {
       documentXml,
+      bindingAuditValid: false,
       sectionCount: 0,
       auditBindings: [],
       stories: [],
@@ -333,6 +397,7 @@ async function selectedAncillaryState(
   if (!audit.ok) {
     return {
       documentXml,
+      bindingAuditValid: false,
       sectionCount: 0,
       auditBindings: [],
       stories: [],
@@ -366,6 +431,7 @@ async function selectedAncillaryState(
 
   return {
     documentXml,
+    bindingAuditValid: true,
     sectionCount: audit.stats.totalSectPrCount,
     auditBindings: audit.bindings,
     stories,
@@ -397,8 +463,8 @@ function pairSelectedAncillaryStories(
   unpairedOriginal: SelectedAncillaryStory[];
   unpairedRevised: SelectedAncillaryStory[];
 } {
-  const originalCandidates = original.filter((story) => story.textBoxes.length > 0);
-  const revisedCandidates = revised.filter((story) => story.textBoxes.length > 0);
+  const originalCandidates = original;
+  const revisedCandidates = revised;
   const matchedOriginal = new Set<SelectedAncillaryStory>();
   const matchedRevised = new Set<SelectedAncillaryStory>();
   const pairs: PairedAncillaryStory[] = [];
@@ -572,8 +638,8 @@ function assertLifecycleStoriesAreSectionBound(
   pairs: PairedAncillaryStory[],
   unpairedOriginal: SelectedAncillaryStory[],
   unpairedRevised: SelectedAncillaryStory[],
-): void {
-  if (unpairedOriginal.length === 0 && unpairedRevised.length === 0) return;
+): SelectedAncillaryStory[] {
+  if (unpairedOriginal.length === 0 && unpairedRevised.length === 0) return [];
   const originalPairIds = new Map(
     pairs.map((pair) => [pair.original.targetPath, pair.id]),
   );
@@ -586,7 +652,9 @@ function assertLifecycleStoriesAreSectionBound(
   );
   const changes: TextBoxRevisionChange[] = [];
 
-  for (const story of unpairedOriginal) {
+  for (const story of unpairedOriginal.filter(
+    (candidate) => candidate.textBoxes.length > 0,
+  )) {
     const lifecycle =
       originalState.sectionCount > revisedState.sectionCount &&
       story.bindings.every((binding) =>
@@ -601,7 +669,9 @@ function assertLifecycleStoriesAreSectionBound(
       });
     }
   }
-  for (const story of unpairedRevised) {
+  for (const story of unpairedRevised.filter(
+    (candidate) => candidate.textBoxes.length > 0,
+  )) {
     const lifecycle =
       revisedState.sectionCount > originalState.sectionCount &&
       story.bindings.every((binding) =>
@@ -617,6 +687,12 @@ function assertLifecycleStoriesAreSectionBound(
     }
   }
   if (changes.length > 0) throw new UnsupportedTextBoxRevisionError(changes);
+  return unpairedRevised.filter((story) =>
+    revisedState.sectionCount > originalState.sectionCount &&
+    story.bindings.every((binding) =>
+      unmatched.revised.has(binding.sectionOrdinal),
+    ),
+  );
 }
 
 async function ancillaryStoryInputs(
@@ -627,16 +703,26 @@ async function ancillaryStoryInputs(
 ): Promise<{
   stories: TextBoxStoryInput[];
   validateProjection: boolean;
+  hasTextBoxStories: boolean;
+  representedChanges: TextBoxStoryComparisonPlan['representedAncillaryChanges'];
 }> {
   const [originalState, revisedState] = await Promise.all([
     selectedAncillaryState(originalArchive),
     selectedAncillaryState(revisedArchive),
   ]);
+  if (!originalState.bindingAuditValid || !revisedState.bindingAuditValid) {
+    return {
+      stories: [],
+      validateProjection: false,
+      hasTextBoxStories: false,
+      representedChanges: [],
+    };
+  }
   const paired = pairSelectedAncillaryStories(
     originalState.stories,
     revisedState.stories,
   );
-  assertLifecycleStoriesAreSectionBound(
+  const insertedPartStories = assertLifecycleStoriesAreSectionBound(
     originalState,
     revisedState,
     paired.pairs,
@@ -720,22 +806,75 @@ async function ancillaryStoryInputs(
       stories.push({
         index,
         partPath: pair.revised.targetPath,
+        container: 'textBox',
         original: await storyOriginalArchive.save(),
         revised: await storyRevisedArchive.save(),
       });
     }
   }
 
+  for (const story of insertedPartStories) {
+    const storyOriginalArchive = await originalArchive.clone();
+    const storyRevisedArchive = await revisedArchive.clone();
+    storyOriginalArchive.setDocumentXml(
+      storyDocumentXmlFromPartRoot(originalDocumentXml, null),
+    );
+    storyRevisedArchive.setDocumentXml(
+      storyDocumentXmlFromPartRoot(revisedDocumentXml, story.xml),
+    );
+    storyOriginalArchive.setFile(
+      'word/_rels/document.xml.rels',
+      `<Relationships xmlns="${PACKAGE_RELATIONSHIPS_NS}"/>`,
+    );
+    storyRevisedArchive.setFile(
+      'word/_rels/document.xml.rels',
+      story.relationshipsXml ??
+        `<Relationships xmlns="${PACKAGE_RELATIONSHIPS_NS}"/>`,
+    );
+    stories.push({
+      index: 0,
+      partPath: story.targetPath,
+      container: 'ancillaryPart',
+      original: await storyOriginalArchive.save(),
+      revised: await storyRevisedArchive.save(),
+    });
+  }
+
   return {
     stories,
     validateProjection:
       paired.pairs.some(
-        (pair) => pair.original.targetPath !== pair.revised.targetPath,
+        (pair) =>
+          pair.original.textBoxes.length > 0 &&
+          pair.original.targetPath !== pair.revised.targetPath,
       ) ||
-      paired.unpairedOriginal.length > 0 ||
-      paired.unpairedRevised.length > 0 ||
+      paired.unpairedOriginal.some((story) => story.textBoxes.length > 0) ||
+      paired.unpairedRevised.some((story) => story.textBoxes.length > 0) ||
       stories.length > 0,
+    hasTextBoxStories: stories.some((story) => story.container === 'textBox'),
+    representedChanges: insertedPartStories.flatMap((story) =>
+      story.bindings.map((binding) => ({
+        scope: binding.kind,
+        kind: 'added' as const,
+        sectionIndex: binding.sectionOrdinal,
+        role: binding.role,
+        partPath: story.targetPath,
+      })),
+    ),
   };
+}
+
+export async function rejectedSelectedAncillaryStoryPaths(
+  compared: Buffer,
+): Promise<Set<string>> {
+  const archive = await DocxArchive.load(compared);
+  const documentXml = rejectAllChanges(await archive.getDocumentXml());
+  const relationshipsXml = await archive.getFile('word/_rels/document.xml.rels');
+  return new Set(
+    auditSectPr(documentXml, relationshipsXml).bindings.map(
+      (binding) => binding.targetPath,
+    ),
+  );
 }
 
 /**
@@ -835,6 +974,7 @@ export async function prepareTextBoxStoryComparison(
     stories.push({
       index,
       partPath: 'word/document.xml',
+      container: 'textBox',
       original: await storyOriginalArchive.save(),
       revised: await storyRevisedArchive.save(),
     });
@@ -856,6 +996,8 @@ export async function prepareTextBoxStoryComparison(
     revisedDocumentXml,
     stories,
     validateAncillaryProjection: ancillary.validateProjection,
+    hasAncillaryTextBoxStories: ancillary.hasTextBoxStories,
+    representedAncillaryChanges: ancillary.representedChanges,
   };
 }
 
@@ -868,6 +1010,7 @@ export async function assembleTextBoxStoryComparison(
   storyResults: ReadonlyArray<{
     index: number;
     partPath: string;
+    container: 'textBox' | 'ancillaryPart';
     document: Buffer;
   }>,
 ): Promise<Buffer> {
@@ -887,6 +1030,32 @@ export async function assembleTextBoxStoryComparison(
       }
       targetDocument = parseXml(targetXml);
     }
+    const storyArchive = await DocxArchive.load(storyResult.document);
+    const storyDocument = parseXml(await storyArchive.getDocumentXml());
+    const storyBody = storyDocument
+      .getElementsByTagNameNS(OOXML.W_NS, 'body')
+      .item(0);
+    if (!storyBody) {
+      throw new Error(`Compared nested story ${storyResult.index} has no w:body`);
+    }
+    if (storyResult.container === 'ancillaryPart') {
+      const target = targetDocument.documentElement;
+      while (target.firstChild) target.removeChild(target.firstChild);
+      for (const child of directChildElements(storyBody)) {
+        if (
+          child.namespaceURI === OOXML.W_NS &&
+          child.localName === 'sectPr'
+        ) {
+          continue;
+        }
+        target.appendChild(targetDocument.importNode(child, true));
+      }
+      outerArchive.setFile(
+        storyResult.partPath,
+        serializer.serializeToString(targetDocument),
+      );
+      continue;
+    }
     const target = targetDocument
       .getElementsByTagNameNS(OOXML.W_NS, 'txbxContent')
       .item(storyResult.index);
@@ -896,14 +1065,6 @@ export async function assembleTextBoxStoryComparison(
         partPath: storyResult.partPath,
         reason: 'the outer comparison changed text-box story topology',
       }]);
-    }
-    const storyArchive = await DocxArchive.load(storyResult.document);
-    const storyDocument = parseXml(await storyArchive.getDocumentXml());
-    const storyBody = storyDocument
-      .getElementsByTagNameNS(OOXML.W_NS, 'body')
-      .item(0);
-    if (!storyBody) {
-      throw new Error(`Compared text-box story ${storyResult.index} has no w:body`);
     }
     while (target.firstChild) target.removeChild(target.firstChild);
     for (const child of directChildElements(storyBody)) {
@@ -925,6 +1086,87 @@ export async function assembleTextBoxStoryComparison(
 
   outerArchive.setDocumentXml(serializer.serializeToString(outerDocument));
   return outerArchive.save();
+}
+
+/**
+ * Mark every paragraph boundary in a relationship-selected story owned by an
+ * inserted section. Paragraph-mark revisions make empty paragraphs and
+ * drawing/text-box carrier paragraphs visible without wrapping an unchanged
+ * VML/DrawingML object in a run-level revision.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.5.20
+ * @see https://github.com/UseJunior/safe-docx/issues/648
+ */
+export async function markInsertedAncillaryStoryParagraphs(
+  storyDocument: Buffer,
+  preservedPackage: Buffer,
+  author: string,
+  date: Date,
+): Promise<{ document: Buffer; directParagraphs: number }> {
+  const archive = await DocxArchive.load(storyDocument);
+  const document = parseXml(await archive.getDocumentXml());
+  const body = document.getElementsByTagNameNS(OOXML.W_NS, 'body').item(0);
+  if (!body) throw new Error('Compared ancillary story has no w:body');
+  const preservedArchive = await DocxArchive.load(preservedPackage);
+  const preservedRoots: Element[] = [document.documentElement];
+  for (const path of preservedArchive.listFiles()) {
+    if (!/^word\/.*\.xml$/u.test(path)) continue;
+    const xml = await preservedArchive.getFile(path);
+    if (!xml) continue;
+    try {
+      preservedRoots.push(parseXml(xml).documentElement);
+    } catch {
+      // Non-WordprocessingML extension parts are irrelevant to revision IDs.
+    }
+  }
+  const state = createRevisionIdState(preservedRoots);
+  const dateString = formatDate(date);
+  const directParagraphs = directChildElements(body).filter(
+    (element) =>
+      element.namespaceURI === OOXML.W_NS && element.localName === 'p',
+  );
+  const markParagraph = (paragraph: Element): void => {
+    addParagraphMarkRevisionMarker(
+      paragraph,
+      'w:ins',
+      author,
+      dateString,
+      state,
+    );
+    for (const run of directChildElements(paragraph).filter(
+      (element) =>
+        element.namespaceURI === OOXML.W_NS &&
+        element.localName === 'r' &&
+        element.getElementsByTagNameNS(OOXML.W_NS, 'drawing').length === 0 &&
+        element.getElementsByTagNameNS(OOXML.W_NS, 'pict').length === 0 &&
+        element.getElementsByTagNameNS(OOXML.W_NS, 'txbxContent').length === 0,
+    )) {
+      wrapRunWithTrackChange({
+        run,
+        tagName: 'w:ins',
+        author,
+        dateStr: dateString,
+        state,
+      });
+    }
+  };
+  for (const paragraph of directParagraphs) {
+    markParagraph(paragraph);
+    for (const textBox of Array.from(
+      paragraph.getElementsByTagNameNS(OOXML.W_NS, 'txbxContent'),
+    )) {
+      for (const nestedParagraph of Array.from(
+        textBox.getElementsByTagNameNS(OOXML.W_NS, 'p'),
+      )) {
+        markParagraph(nestedParagraph);
+      }
+    }
+  }
+  archive.setDocumentXml(serializer.serializeToString(document));
+  return {
+    document: await archive.save(),
+    directParagraphs: directParagraphs.length,
+  };
 }
 
 async function selectedStoryProjectionInventory(


### PR DESCRIPTION
## Summary
- represent a new footer selected exclusively by a tracked inserted section
- mark every footer paragraph while keeping VML and DrawingML carrier objects outside run-level insertions
- allocate package-wide collision-free revision IDs and validate selected-story accept/reject projections
- remove the represented footer from `unrepresentedChanges` while retaining the section-property diagnostic

## Validation
- exact repository pre-submit gate passed
- focused public regression covers a five-paragraph footer with empty paragraphs and nested VML text-box content
- private aggregate benchmark: 11 revision records across the same five footer paragraphs as the 12-record baseline; no object wrappers, no new duplicate IDs, and a clean 88-page render

Ref: #648