### PR TITLE
fix(docx-comparison): balance self-closing revision tokens

### DIFF
--- a/packages/docx-compare/src/baselines/atomizer/leanXmlVerifier.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/leanXmlVerifier.test.ts
@@ -168,6 +168,47 @@ describeWithLean('Lean XML triple verifier certificate', () => {
       });
     },
   );
+
+  test
+    .openspec('[LEAN-XML-CHECK-01] Lean verifier accepts a valid inplace comparison triple')
+    .conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.5.20' })(
+    'balances a self-closing paragraph-mark insertion before unchanged text',
+    async () => {
+      const original = await buildDocxFromBodyXml(
+        paragraphWithText('Stable before') + paragraphWithText('Stable after'),
+      );
+      const revised = await buildDocxFromBodyXml(
+        paragraphWithText('Stable before') +
+          paragraphWithText('Inserted paragraph') +
+          paragraphWithText('Stable after'),
+      );
+      const compared = await buildDocxFromBodyXml(
+        paragraphWithText('Stable before') +
+          '<w:p>' +
+            '<w:pPr><w:rPr>' +
+              '<w:ins w:id="1" w:author="Safe DOCX" w:date="2026-07-29T00:00:00Z"/>' +
+            '</w:rPr></w:pPr>' +
+            '<w:ins w:id="2" w:author="Safe DOCX" w:date="2026-07-29T00:00:00Z">' +
+              '<w:r><w:t>Inserted paragraph</w:t></w:r>' +
+            '</w:ins>' +
+          '</w:p>' +
+          paragraphWithText('Stable after'),
+      );
+
+      const certificate = await runLeanXmlTripleVerifier({
+        originalDocx: original,
+        revisedDocx: revised,
+        comparedDocx: compared,
+        legacyDocumentXml: { original: '', revised: '', compared: '' },
+        reconstructionMode: 'inplace',
+        options: { executablePath: LEAN_EXE, timeoutMs: 120_000 },
+      });
+
+      expect(certificate.status, certificate.reason).toBe('passed');
+      expect(certificate.checks.acceptingAllTrackedChangesMatchesRevisedText.status).toBe('passed');
+      expect(certificate.checks.rejectingAllTrackedChangesMatchesOriginalText.status).toBe('passed');
+    },
+  );
 });
 
 describe('Lean XML triple verifier scope boundary', () => {

--- a/verification/lean/Tier2/XmlTripleChecker.lean
+++ b/verification/lean/Tier2/XmlTripleChecker.lean
@@ -448,6 +448,10 @@ def tagTokenDecoded (closing : Bool) (localName : String) (attributes : XmlAttri
   else if !closing && localName == "delInstrText" then [.delInstrText payload]
   else []
 
+def balanceSelfClosingTagTokens (localName : String) (selfClosing : Bool)
+    (opening : List XmlTok) : List XmlTok :=
+  if selfClosing then opening ++ tagTokenDecoded true localName [] "" else opening
+
 def tagToken (closing : Bool) (localName : String) (attributes : XmlAttributes)
     (payload : String) : Except String (List XmlTok) := do
   return tagTokenDecoded closing localName attributes (← decodeXmlText payload)
@@ -559,7 +563,10 @@ def parseXmlSegment (expectedRoot : String) (state : XmlParseState) (segment : S
   let canonicalAttributes := canonicalizeAttributes expandedAttributes
   let decodedPayload ← decodeXmlText payload
   let emitted := if uri == wmlNamespace then
-    tagTokenDecoded false localName canonicalAttributes decodedPayload else []
+    balanceSelfClosingTagTokens localName selfClosing
+      (tagTokenDecoded false localName canonicalAttributes
+        (if selfClosing then "" else decodedPayload))
+    else []
   let next := { state with
     tokens := state.tokens ++ emitted
     rootSeen := true
@@ -772,7 +779,8 @@ def tokensFromXmlEvents (events : List XmlEvent) : List XmlTok :=
       let emitted :=
         if ["t", "delText", "instrText", "delInstrText"].contains localName then []
         else if uri == wmlNamespace then
-          tagTokenDecoded false localName (canonicalizeAttributes attributes) ""
+          balanceSelfClosingTagTokens localName selfClosing
+            (tagTokenDecoded false localName (canonicalizeAttributes attributes) "")
         else []
       {
         stack := if selfClosing then state.stack else (uri, localName) :: state.stack


### PR DESCRIPTION
## What changed

- balance every self-closing WordprocessingML token with its matching closing token in both accepted Lean XML parsing paths
- keep self-closing text payloads empty instead of accidentally assigning following sibling text
- add a compiled-checker regression for an inserted paragraph mark followed by unchanged text

## Why

The event-token path emitted an opening `w:ins` token for a self-closing paragraph-mark revision but no closing token. That leaked insertion state into later unchanged content and made Lean's reject projection falsely fail on otherwise exact comparison output.

The balancing rule now has one helper shared by the legacy and event-token paths, so the two paths cannot drift on this behavior.

## Evidence

- public Word-authored reduction: production accept/reject exact; all Lean main-story checks now pass
- confidential corpus pair (aggregate result only): all Lean main-story checks now pass; no confidential filenames, text, values, hashes, or identifiers are included
- remaining certificate failure is independently isolated to `SECTION_COUNT_MISMATCH` and its cascading source-partition diagnostic (#747)
- `lake build`
- `lake env lean AxiomAudit.lean`
- zero-`sorry` source audit
- compiled Lean verifier test file: 96 passed, 1 skipped
- full repository build, lint, and all non-OS-restricted tests
- docx-core rerun outside the sandbox: 1,305 passed, 2 expected failures, 1 skipped
- spec coverage and conformance checks

Fixes #748
