### PR TITLE
docs(docx-comparison): propose section lifecycle verification

### DIFF
--- a/openspec/changes/align-lean-section-lifecycles/design.md
+++ b/openspec/changes/align-lean-section-lifecycles/design.md
@@ -1,0 +1,238 @@
+## Context
+
+The current selector inventories direct `w:sectPr` elements and requires raw
+three-side ordinal equality. Production in-place comparison can instead emit:
+
+```xml
+<w:p>
+  <w:pPr>
+    <w:rPr><w:ins .../></w:rPr>
+    <w:sectPr>...</w:sectPr>
+  </w:pPr>
+</w:p>
+```
+
+The `w:sectPr` is not inside `w:ins`; the direct paragraph-mark insertion is
+the evidence that this boundary exists only after accepting changes. Pair C
+already has exact production accept/reject behavior and passes all six main
+story checks after #748, but protocol v6 stops at raw section-count mismatch.
+
+Deletion is not symmetric today. Production accept retains an ancillary story
+whose section was removed and supplies no trustworthy deletion-side story
+carrier. #754 owns that engine work. Treating deletion as verifier-only empty
+tokens would certify something production did not represent.
+
+## Goals / Non-Goals
+
+Goals:
+
+- certify the exact supported inserted-boundary shape;
+- align reject(compared) with original and accept(compared) with revised;
+- make absence, work, tokens, ordinals, partitions, and budgets explicit;
+- preserve strict decoding, bounded evidence, deterministic ordering, and
+  proof/audit coverage;
+- prove the behavior with an existing publicly sourced Word-authored fixture.
+
+Non-goals:
+
+- deleted-section certificate success (#754);
+- arbitrary slot insertion/removal within a stable section;
+- heuristic matching, inherited roles, pagination, rendering, or field
+  evaluation;
+- new ZIP/XML admission, rebuild certification, or private-corpus fixtures.
+
+## Decisions
+
+### 1. Exact insertion classifier
+
+For a supported paragraph boundary, the streaming inventory records direct
+child counts for `w:pPr`, its direct `w:rPr` and `w:sectPr`, direct insertion
+and deletion children of that `w:rPr`, and any revision descendant of the
+boundary `w:pPr` outside the permitted path.
+
+The normative classifier table fixes precedence. Duplicate structural nodes
+win first, deletion second, contradictory/repeated direct markers third,
+misplaced insertion/deletion descendants fourth, exact insertion fifth, and
+stable last. `w:pPrChange`, `w:sectPrChange`, move elements, and other revision
+elements are irrelevant unless they contain a misplaced `w:ins`/`w:del`.
+Content revisions in other paragraphs remain irrelevant. Terminal body
+`w:sectPr` remains stable.
+
+This is deliberately narrower than WordprocessingML generally; the certificate
+describes the implemented subset and fails closed outside it.
+
+### 2. Two projections, no correspondence heuristic
+
+Each compared section retains `comparedSectionOrdinal`. A stable section
+increments both source ordinals. An inserted section increments only revised.
+The original projection therefore has no ordinal for that section. Projected
+counts and ordered direct slots must exactly equal their respective source
+inventory before any relationship resolution begins.
+
+### 3. Protocol v8 succeeds the pending comment-range protocol v7
+
+`verify-lean-comment-range-topology` already owns protocol v7 and its exact
+16-field grammar. This change is implemented only after that change is
+complete and archived. V8 preserves its top-level grammar, range topology,
+issue/envelope semantics, and public-v1 behavior. It changes only the nested
+relationship, selection, source-partition, checker identity, and version
+surfaces named by this change.
+
+### 4. Protocol v8 makes absence and work first-class
+
+The exact slot side union is:
+
+```ts
+type SlotSide =
+  | {
+      present: false;
+      relationshipResolutionInvocations: 0;
+    }
+  | {
+      present: true;
+      sectionOrdinal: number;
+      relationshipId: string;
+      normalizedPartPath: string;
+      relationshipResolutionInvocations: 1;
+    };
+```
+
+The exact physical-story side union includes the work needed to validate the
+absence/presence claim:
+
+```ts
+type StorySide =
+  | {
+      present: false;
+      extractionInvocations: 0;
+      parseInvocations: 0;
+      compressedBytes: 0;
+      expandedBytes: 0;
+      xmlEventCount: 0;
+      tokenCount: 0;
+    }
+  | {
+      present: true;
+      normalizedPartPath: string;
+      zipEntryIndex: number;
+      extractionInvocations: 1;
+      parseInvocations: 1;
+      compressedBytes: number;
+      expandedBytes: number;
+      xmlEventCount: number;
+      tokenCount: number;
+    };
+```
+
+Only inserted/original may be absent. Revised and compared are always present
+in this increment. Public and internal evidence share these union equations;
+the launcher revalidates rather than trusting the executable.
+
+### 5. Absent means no work; present means accounted work
+
+An absent slot side performs zero relationship resolution. Each present logical
+slot side resolves exactly once before deduplication. An absent physical-story
+side contributes `[]` to the generic story triple and exactly zero tokens; it
+is excluded from extraction, ZIP-byte, parse-event, selected-part, and
+evidence-path work. A present physical-story side must complete every physical
+step and contributes its actual measures. Deduplication occurs only after exact
+three-side presence/path identity is known.
+
+Aggregate equations sum each admitted present deduplicated physical work item
+once plus the inherited fixed overhead. Per-side and three-package compressed,
+expanded, selected-part, and XML-event caps are fixed in the normative delta.
+Lean binds both slot-resolution and physical-story records to actual request
+evidence and enforces the inherited whole-request equations. Because the
+unchanged v7 16-field response does not expose every main/fixed/note/comment
+measurement, TypeScript rechecks only the exact exposed slot/story schema,
+equations, arithmetic, and per-part caps; it does not claim to recompute
+unobservable whole-request sums.
+
+### 6. Note and comment source partitions are distinct bijections
+
+For side `s`, derive:
+
+```text
+expectedSources(s) =
+  [main] ++
+  relationshipStories.filter(story => story.side(s).present)
+```
+
+The filter preserves ascending global `physicalStoryOrdinal`; the array index
+is `sourceOrdinal`. Every present physical story occurs exactly once, retains
+its global ordinal/kind/path, and every absent story occurs zero times.
+This is the note-reference partition. The comment source set is that complete
+partition followed by present footnotes and then present endnotes. Comments
+definition content is not a reference source. Resolution, extraction, parse,
+identity, resource, or either bijection failure sets that side's partition to
+incomplete and comment topology to not evaluated. A proven absence does not.
+
+### 7. Modify one canonical contract and layer successor requirements
+
+The delta reproduces the complete canonical relationship-alignment requirement
+under its exact heading and modifies it. Protocol, public-certificate, source,
+work, and evidence rules are additive successor requirements, preserving the
+canonical protocol-v4 guarantees and the pending v5-v7 changes rather than
+replacing their blocks.
+
+The production acceptor remains
+`packages/docx-compare/src/baselines/atomizer/trackChangesAcceptorAst.ts`.
+Tests use that same accept/reject implementation; no verifier-local projection
+is accepted as evidence of production exactness.
+
+### 8. Redistributable real-DOCX provenance and transformation
+
+The existing fixture
+`tests/test_documents/open-agreements/common-paper-mutual-nda.docx` has
+SHA-256
+`9a61c5b6acee7248df24ddd157c039fc6918230aee8ccbd2627cd6f7c4d9a492`.
+It is based on Common Paper's Mutual NDA, whose source repository is public
+under CC BY 4.0. Implementation first adds adjacent machine-readable
+provenance: version, official URL, hash, CC BY 4.0, derivative/redistribution
+permission, derivative status, and attribution. No restricted NVCA binary is
+used for this new gate.
+
+A focused integration test gains a deterministic helper that clones the
+package and adds the revised section paragraph, direct explicit footer
+binding, relationship record, content-type coverage, and footer part. The
+production comparator—not the helper—must create the tracked compared shape.
+
+### 9. Proof obligations
+
+The implementation SHALL prove or audit:
+
+- classifier exclusivity and lifecycle issue-or-classification completeness;
+- accept/reject projected ordinal contiguity and source correspondence;
+- slot issue-or-alignment completeness;
+- slot-to-physical-story bijection and exact presence/path keying;
+- absent-zero-work/zero-token and present-work accounting equations;
+- note-partition and comment-source-set bijections;
+- present/absent work and side/triple resource equations;
+- aggregate success implies all generic checks for all present physical work;
+- protocol serialization/refinement into the strict TypeScript bridge.
+
+All new theorem targets enter `AxiomAudit.lean`; the repository's exact
+six-name axiom allowlist and zero-`sorry` requirement remain unchanged.
+
+## Risks / Trade-offs
+
+- The classifier intentionally rejects valid but unsupported Word shapes. This
+  is preferable to a false certificate and creates a precise future subset
+  extension point.
+- Protocol work is larger than suppressing one diagnostic, but explicit
+  presence and accounting prevent unverifiable empty-story shortcuts.
+- Deletion remains a known gap until #754 changes production output; this
+  proposal does not disguise that asymmetry.
+
+## Migration and rollback
+
+After protocol v7 is archived, implement classifier/projections, then v8
+evidence and strict decoding, then work/accounting and partitions, then proof
+and real-DOCX gates. Protocol v6 remains readable only as historical public
+metadata; v8 becomes the current producer. Rollback restores the v7 producer,
+preserving v7 comment topology while reinstating raw section-count fail-closed
+behavior. No stored-document migration is required.
+
+## Open questions
+
+None. This increment is insertion-only and protocol-v8 by design.

--- a/openspec/changes/align-lean-section-lifecycles/proposal.md
+++ b/openspec/changes/align-lean-section-lifecycles/proposal.md
@@ -1,0 +1,57 @@
+# Change: Verify inserted-section relationship stories
+
+## Why
+
+The compiled verifier aligns selected header/footer stories by equal raw
+section ordinals. A valid in-place redline that inserts a paragraph-boundary
+section cannot satisfy that rule even when production accept/reject is exact:
+rejecting compared recovers the original section inventory, while accepting it
+recovers the revised inventory. The verifier consequently emits
+`SECTION_COUNT_MISMATCH` before checking the inserted footer and then reports a
+cascading incomplete comment-source partition.
+
+Production currently supplies positive tracked evidence for inserted sections.
+It does not yet supply symmetric tracked deletion evidence for removed
+header/footer stories; that separate comparison-engine gap is tracked by #754.
+This increment therefore certifies insertion only and remains fail-closed for
+deleted or ambiguous boundaries.
+
+## What Changes
+
+- Modify the existing relationship-story alignment requirement with protocol
+  v8 after the pending protocol-v7 comment-range change, rather than
+  introducing a parallel selector contract.
+- Classify only one exact direct paragraph-mark insertion shape and reject
+  duplicate, misplaced, deleted, or contradictory lifecycle markers.
+- Project compared sections under reject and accept semantics, aligning the
+  reject projection to original and the accept projection to revised.
+- Represent every slot/story side with an exact present/absent discriminated
+  union; only the original side of a proven inserted section may be absent.
+- Treat that proven-absent original story as zero tokens without resolving,
+  extracting, parsing, or charging it to resource budgets.
+- Make each package's note reference-source partition a bijection over main
+  plus present relationship stories, and its comment source set that same
+  partition plus present footnotes/endnotes.
+- Add exact per-side work/resource evidence so absence and present-work charges
+  are observable to the strict bridge.
+- Add compiled proof/audit coverage and an end-to-end regression derived from
+  an already checked-in, redistributable CC BY 4.0 Common Paper Word document.
+
+## Impact
+
+- Affected spec: `docx-comparison`
+- Affected code:
+  - `verification/lean/Tier2/RelationshipStorySelector.lean`
+  - `verification/lean/LeanDocxChecker.lean`
+  - `verification/lean/Tier2/CommentReferenceIntegrity/**`
+  - `packages/docx-compare/src/baselines/atomizer/leanXmlVerifier.ts`
+  - `packages/docx-compare/src/compare-types.ts`
+  - focused real-DOCX integration test and fixture provenance manifest
+  - compiled-verifier tests, audits, and coverage ledgers
+- Related issues: #747, #754, #718
+- Dependencies/non-goals:
+  - implement only after `verify-lean-comment-range-topology` establishes
+    protocol v7; this proposal is its protocol-v8 successor;
+  - no new ZIP syntax (#745), XML syntax (#714), or rebuild certification;
+  - no deletion-side certificate success until #754 provides production
+    tracked deletion evidence.

--- a/openspec/changes/align-lean-section-lifecycles/specs/docx-comparison/spec.md
+++ b/openspec/changes/align-lean-section-lifecycles/specs/docx-comparison/spec.md
@@ -1,0 +1,377 @@
+## MODIFIED Requirements
+
+### Requirement: Relationship stories align deterministically by logical slot
+
+The verifier SHALL align original, revised, and compared bindings by logical
+slot `(projectedSectionOrdinal, kind, role)`. It SHALL retain relationship IDs,
+normalized package paths, physical compared section ordinals, lifecycle, and
+source projected ordinals as evidence and SHALL NOT use text, relationship ID,
+target path, or LCS as cross-package section identity.
+
+Protocol v8 SHALL derive section insertion solely from this exact compared-main
+paragraph-boundary shape:
+
+1. one direct `w:pPr` child of a direct body `w:p`;
+2. one direct `w:sectPr` and at most one direct `w:rPr` child of that `w:pPr`;
+3. for `inserted`, exactly one direct `w:ins` and no direct `w:del` child of
+   that sole `w:rPr`; and
+4. no other `w:ins` or `w:del` descendant of that boundary `w:pPr`.
+
+The classifier SHALL apply the following precedence and emit at most one
+lifecycle issue per physical compared section:
+
+| Priority | Observed boundary shape | Result/code |
+| ---: | --- | --- |
+| 1 | not exactly one direct `w:pPr` or `w:sectPr`, or more than one direct `w:rPr` | `AMBIGUOUS_SECTION_STRUCTURE` |
+| 2 | any direct `w:del` in the sole direct `w:rPr` | `UNSUPPORTED_SECTION_DELETION` |
+| 3 | both direct marker kinds or more than one direct `w:ins` | `AMBIGUOUS_SECTION_LIFECYCLE` |
+| 4 | any `w:ins`/`w:del` descendant outside the permitted direct `w:rPr` path | `UNSUPPORTED_SECTION_LIFECYCLE` |
+| 5 | exactly one permitted direct `w:ins` | `inserted` |
+| 6 | otherwise | `stable` |
+
+Self-closing and explicit-empty markers SHALL classify identically.
+`w:pPrChange`, `w:sectPrChange`, move elements, and other revision elements
+without `w:ins`/`w:del` SHALL be irrelevant to boundary presence. An
+`w:ins`/`w:del` nested inside their snapshots SHALL trigger priority 4. Markers
+in another paragraph SHALL affect only that paragraph. A direct body-level
+terminal `w:sectPr` SHALL be stable. Each lifecycle issue SHALL carry exact
+keys `code`, `detail`, and `comparedSectionOrdinal`; `detail` SHALL be bounded
+to 256 UTF-8 bytes, issues SHALL order by physical compared section ordinal,
+and duplicate evidence for the same section SHALL coalesce to the highest
+priority code.
+
+The compared inventory SHALL retain a zero-based physical section ordinal and
+derive contiguous zero-based reject/original and accept/revised projections in
+document order. Stable sections SHALL occur in both projections. Inserted
+sections SHALL occur only in the accept/revised projection. Deleted-section
+success is outside protocol v8; priority 2 fails closed until production issue
+#754 supplies tracked deletion evidence.
+
+The reject projection's count and ordered explicit `(kind, role)` inventory
+SHALL equal original; the accept projection's SHALL equal revised. Any
+post-projection mismatch SHALL be a structured failure. Remaining ordinally
+aligned target permutations SHALL be checked as their actual XML triples. The
+verifier SHALL NOT claim semantic identity or permutation detection among
+selector-indistinguishable stable sections.
+
+Every logical slot SHALL have exact keys `slotOrdinal`,
+`comparedSectionOrdinal`, `sectionLifecycle`, `kind`, `role`, `original`,
+`revised`, `compared`, and `physicalStoryOrdinal`. A slot side SHALL be exactly:
+
+```ts
+type RelationshipSlotSide =
+  | {
+      present: false;
+      relationshipResolutionInvocations: 0;
+    }
+  | {
+      present: true;
+      sectionOrdinal: number;
+      relationshipId: string;
+      normalizedPartPath: string;
+      relationshipResolutionInvocations: 1;
+    };
+```
+
+Revised and compared SHALL always be present. Original SHALL be absent if and
+only if lifecycle is `inserted`; otherwise all sides SHALL be present. Present
+source ordinals SHALL equal their projected section ordinal; compared
+`sectionOrdinal` SHALL equal `comparedSectionOrdinal`. Relationship resolution
+SHALL occur and be counted once for every present logical slot side before
+physical-story deduplication; an absent slot side SHALL perform and report no
+relationship resolution.
+
+Logical evidence SHALL order compared section ordinal ascending, header before
+footer, and role first, default, then even. Slot ordinals SHALL be contiguous.
+Physical checks SHALL deduplicate if and only if kind plus the exact
+original/revised/compared side-presence/path tuple matches, while retaining
+every selecting logical slot exactly once in canonical order. Physical-story
+ordinals SHALL be contiguous.
+
+#### Scenario: [LEAN-REL-03] Side-specific identities align by slot
+
+- **GIVEN** one stable logical slot uses different valid relationship IDs and
+  normalized target paths in the three packages
+- **WHEN** protocol v8 assembles its relationship story
+- **THEN** the story SHALL align by projected section ordinal, kind, and role
+- **AND** the report SHALL retain all three side-specific IDs and paths
+
+#### Scenario: [LEAN-REL-04] Selector-observable section differences fail closed
+
+- **WHEN** projected section counts differ or ordered direct slot inventories
+  differ
+- **THEN** verification SHALL fail with a structured section alignment issue
+- **AND** no LCS, target-path match, relationship-ID match, or text match SHALL
+  manufacture an alignment
+- **AND** no claim SHALL be made about semantic identity or permutations of
+  selector-indistinguishable sections
+
+#### Scenario: [LEAN-REL-05] Shared targets check once without losing selectors
+
+- **GIVEN** multiple logical slots select the same kind and exact complete
+  three-side presence/path tuple
+- **WHEN** the collection is assembled
+- **THEN** the physical XML work SHALL execute once
+- **AND** its evidence SHALL list every selecting logical slot in canonical
+  order
+
+#### Scenario: [LEAN-REL-LIFE-01] Inserted section aligns both projections
+
+- **GIVEN** original has one stable section, revised has an additional
+  paragraph-boundary section, and compared carries the exact direct insertion
+  shape
+- **WHEN** protocol v8 projects and aligns section inventories
+- **THEN** reject-projected compared SHALL equal original
+- **AND** accept-projected compared SHALL equal revised
+- **AND** every inserted slot's original side SHALL be explicitly absent
+
+#### Scenario: [LEAN-REL-LIFE-02] Lifecycle precedence is deterministic
+
+- **GIVEN** one compared boundary contains multiple structural or lifecycle
+  defects
+- **WHEN** protocol v8 classifies it
+- **THEN** exactly the highest-priority applicable lifecycle issue SHALL be
+  emitted for that physical section
+- **AND** no slot from that section SHALL receive passing evidence
+
+#### Scenario: [LEAN-REL-LIFE-03] Deleted section remains fail-closed
+
+- **GIVEN** a paragraph-boundary section has a direct deletion marker
+- **WHEN** protocol v8 classifies it
+- **THEN** it SHALL emit `UNSUPPORTED_SECTION_DELETION`
+- **AND** it SHALL NOT infer an absent revised story or passing evidence
+
+## ADDED Requirements
+
+### Requirement: Protocol v8 binds lifecycle stories to exact work evidence
+
+This change SHALL depend on completion and archival of
+`verify-lean-comment-range-topology`. Protocol v8 SHALL preserve that change's
+exact 16-field top-level response grammar, field order, inherited issue order,
+ordinary/terminal envelope behavior, comment topology evidence, and public-v1
+semantics. It SHALL change only the nested relationship slot/story schemas,
+selection issue union, source partitions, checker identity, and protocol
+version specified here. The checker identity SHALL be
+`safe-docx-lean-section-lifecycle-comment-range-integrity-checker`; request and
+response `protocolVersion` SHALL be exactly 8; protocol v7 output SHALL be
+`not_run` under the v8 producer.
+
+Every physical story SHALL have exact keys `physicalStoryOrdinal`, `kind`,
+`original`, `revised`, `compared`, `selectingSlotOrdinals`, and `report`.
+Each side SHALL use exactly this work union:
+
+```ts
+type RelationshipStorySideWork =
+  | {
+      present: false;
+      extractionInvocations: 0;
+      parseInvocations: 0;
+      compressedBytes: 0;
+      expandedBytes: 0;
+      xmlEventCount: 0;
+      tokenCount: 0;
+    }
+  | {
+      present: true;
+      normalizedPartPath: string;
+      zipEntryIndex: number;
+      extractionInvocations: 1;
+      parseInvocations: 1;
+      compressedBytes: number;
+      expandedBytes: number;
+      xmlEventCount: number;
+      tokenCount: number;
+    };
+```
+
+Only inserted/original MAY be absent. Proven absence SHALL contribute empty
+tokens and zero physical work. Every present physical-story side SHALL identify
+exactly one regular ZIP entry, extract once, parse once, be charged once per
+deduplicated physical work item, and expose its actual counts. Relationship
+resolution SHALL instead be evidenced per logical slot side as required by the
+modified selector contract. The report's parsed token counts SHALL equal the
+three physical-story side `tokenCount` values.
+
+For each side, selected relationship work SHALL satisfy:
+
+- at most 256 unique present selected paths;
+- each present part at most 8 MiB compressed, 16 MiB expanded, and 500,000 XML
+  events;
+- main plus all present relationship/fixed/comment work at most 16 MiB
+  compressed, 32 MiB expanded, and 1,000,000 XML events;
+- across three packages, at most 768 selected parts, 48 MiB compressed,
+  96 MiB expanded, and 3,000,000 XML events; and
+- sums count each admitted present deduplicated physical work item exactly
+  once, count absent branches zero times, and retain the protocol-v7 fixed
+  overhead and terminal-collapse constants unchanged.
+
+Lean SHALL enforce the inherited whole-request side/triple resource sums and
+caps using its request-bound main, relationship, fixed-story, note, and comment
+measurements. Protocol v8 SHALL NOT add a duplicate aggregate/base-resource
+record to the unchanged 16-field response merely to restate those internal
+measurements.
+
+The strict TypeScript decoder SHALL enforce exact keys/key order, safe integer
+and per-part caps on every exposed relationship-story measurement,
+presence/lifecycle equations, per-slot relationship-resolution equations,
+physical-story extraction/parse equations, token equality, deduplication keys,
+selector bijection, contiguous ordinals, canonical ordering, the inherited
+16-field grammar and output envelopes, and the aggregate `passed` equation. It
+SHALL NOT claim to recompute unexposed inherited whole-request side/triple
+resource sums. Lean SHALL prove the exposed work records equal request-bound
+relationship resolution, ZIP index, extraction, and parser evidence;
+TypeScript consistency is a second boundary check, not the source of truth.
+
+#### Scenario: [LEAN-REL-LIFE-04] Proven absence is zero work and zero tokens
+
+- **GIVEN** an aligned inserted footer has absent original and present revised
+  and compared sides
+- **WHEN** protocol v8 checks the physical story
+- **THEN** original SHALL have every work counter and token count equal zero
+- **AND** reject(compared) SHALL equal empty original tokens
+- **AND** every present logical slot side SHALL resolve exactly once
+- **AND** every present deduplicated physical-story side SHALL be request-bound,
+  loaded, charged, and checked exactly once
+
+#### Scenario: [LEAN-REL-LIFE-05] Work mutations fail closed
+
+- **WHEN** any exposed presence, path, ZIP identity, invocation count,
+  byte/event/token count, selector, ordinal, deduplication, per-part cap, or
+  inherited envelope equation is mutated
+- **THEN** Lean or the strict TypeScript decoder SHALL fail closed
+- **AND** no public passing claim SHALL survive
+
+#### Scenario: [LEAN-REL-LIFE-06] Internal aggregate resource limits fail closed
+
+- **WHEN** request-bound main, relationship, fixed-story, note, or comment work
+  causes an inherited whole-request side or triple resource cap to be exceeded
+- **THEN** Lean SHALL fail closed before emitting passing evidence
+- **AND** the TypeScript decoder SHALL NOT claim to have independently
+  recomputed measurements that are not present in the 16-field response
+
+### Requirement: Lifecycle-aware note and comment source partitions are bijective
+
+For each package side, the note-reference source partition SHALL be exactly
+`[main] ++ present relationship physical stories` in ascending global
+`physicalStoryOrdinal`. Its `sourceOrdinal` SHALL be the contiguous array
+index; main SHALL be zero; each relationship source SHALL retain global
+physical-story ordinal, kind, and normalized path. Every present relationship
+story SHALL occur exactly once; absent stories SHALL occur zero times.
+
+For each package side, the comment-reference `CommentSourceSet` SHALL be
+exactly the complete note-reference partition followed by the present
+footnotes definition story and then the present endnotes definition story.
+Those note-definition sources SHALL retain their semantic kind and normalized
+path and SHALL receive the next contiguous source ordinals. Comments content
+SHALL remain a definition story, not a reference source.
+
+Selection, resolution, ZIP identity, extraction, UTF-8/XML parsing,
+fully-scanned evidence, ordering, cardinality, work-accounting, or either
+bijection failure SHALL make the corresponding partition incomplete and make
+comment topology `not_evaluated`. Lifecycle-proven absence alone SHALL NOT.
+Protocol v8 SHALL preserve protocol v7's one-pass retained comment event scan
+over the resulting complete `CommentSourceSet`; no package/part/parser work
+SHALL be repeated.
+
+#### Scenario: [LEAN-REL-LIFE-06] Note partition contains each present relationship story
+
+- **WHEN** protocol v8 emits a side's note-reference partition
+- **THEN** it SHALL contain main followed by exactly every relationship story
+  present on that side in global physical-story order
+- **AND** source ordinals SHALL be contiguous and absent stories SHALL not
+  appear
+
+#### Scenario: [LEAN-REL-LIFE-07] Comment partition appends present note stories
+
+- **WHEN** protocol v8 constructs a side's comment reference sources
+- **THEN** it SHALL preserve the complete note-reference partition
+- **AND** append present footnotes then present endnotes exactly once
+- **AND** the retained v7 marker scan SHALL visit that exact source sequence
+
+### Requirement: Public certificate v1 reports lifecycle evidence without weakening prior claims
+
+The public certificate SHALL remain protocol v1 and preserve every existing
+field, literal, compatibility rule, five-field relationship co-presence rule,
+comment-topology field, rebuild behavior, status meaning, and exclusion from
+the canonical protocol-v4/v5/v6 requirements and the protocol-v7 comment-range
+change.
+
+`checkerProtocolVersion` SHALL widen additively to include `8`.
+`DocumentIntegrityRelationshipScope.alignment` SHALL add the literal
+`"reject-original-accept-revised-section-lifecycle"`. Protocol v8 SHALL expose
+the exact lifecycle slot/story presence, projected ordinals, paths, token
+counts, selectors, and source partitions specified above. Internal work/ZIP
+charges SHALL remain verifier evidence and SHALL NOT expose host paths,
+filenames outside normalized package paths, document bytes, text, values, or
+hashes in the public certificate.
+
+A current protocol-v8 producer SHALL emit all inherited required v7 public
+evidence and all lifecycle relationship fields together or none. Partial,
+contradictory, noncanonical, malformed, timed-out, unbounded, or older-labeled
+v8 output SHALL be `not_run`. Structured lifecycle, selection, partition,
+comment-topology, or story failure SHALL be `failed`. Rebuild SHALL remain
+`not_applicable`.
+
+#### Scenario: [LEAN-REL-LIFE-08] Protocol v8 preserves prior certificate contracts
+
+- **WHEN** a consumer reads a legacy public-v1 certificate or current
+  protocol-v8 evidence
+- **THEN** every preexisting field and omission rule SHALL retain its meaning
+- **AND** lifecycle evidence SHALL be additive and all-or-none
+- **AND** no internal host path, source text, value, or document hash SHALL be
+  introduced by lifecycle evidence
+
+### Requirement: Inserted-section verification has compiled and redistributable real-DOCX evidence
+
+Tests SHALL preserve all existing protocol-v4 relationship-story and
+protocol-v7 comment-range evidence. Protocol v8 tests SHALL exercise the actual
+compiled executable and strict launcher for stable, inserted,
+deletion-rejected, ambiguous, misplaced, unexplained, presence-union, work,
+selector, note-partition, comment-partition, resource, and envelope cases.
+
+The real regression SHALL use
+`tests/test_documents/open-agreements/common-paper-mutual-nda.docx`, pinned at
+SHA-256
+`9a61c5b6acee7248df24ddd157c039fc6918230aee8ccbd2627cd6f7c4d9a492`.
+Before implementation, the repo SHALL add an adjacent provenance manifest
+recording: Common Paper Mutual NDA; official source
+`https://github.com/CommonPaper/Mutual-NDA`; source version; CC BY 4.0;
+redistribution and derivatives permitted with attribution; derivative status;
+and attribution `Copyright Common Paper, Inc.; licensed CC BY 4.0`. The test
+SHALL add no confidential or restricted fixture.
+
+In a focused integration test, a deterministic helper SHALL clone that
+Word-authored package and add one revised paragraph-boundary section, one
+explicit footer binding, one package-internal footer relationship, content
+type coverage, and one parser-supported footer part. Production comparison
+SHALL create the compared revision markers in true in-place mode; the helper
+SHALL NOT author compared markers. Production accept/reject through
+`trackChangesAcceptorAst.ts` SHALL be exact before verifier evidence is
+accepted.
+
+The test SHALL require a nonzero inserted-footer certificate, all six generic
+story checks, the inherited protocol-v7 comment topology checks, complete note
+and comment partitions, and no lifecycle/section/slot issue. Mutations SHALL
+cover every classifier row, presence/work union field, projected/global/source
+ordinal, selector/story/partition bijection, note-story append, resource
+equation, protocol version, and inherited envelope rule.
+
+The compiled suite, theorem/axiom audits, zero-`sorry` audit, drift witnesses,
+coverage ledger, and this redistributable real-DOCX test SHALL be wired into
+Lean CI.
+
+#### Scenario: [LEAN-REL-LIFE-09] Word-authored inserted footer receives a complete certificate
+
+- **GIVEN** the deterministic Common Paper-derived inserted-section/footer pair
+- **WHEN** production creates a true in-place comparison and protocol v8 checks
+  the package triple
+- **THEN** production accept/reject SHALL be exact
+- **AND** every main and selected-story generic check SHALL pass
+- **AND** inherited comment topology and both source partitions SHALL pass
+
+#### Scenario: [LEAN-REL-LIFE-10] Compiled trust boundary rejects mutations
+
+- **WHEN** any lifecycle, presence, work, ordinal, selector, source partition,
+  resource, inherited topology, envelope, or version mutation is applied
+- **THEN** the compiled checker or strict launcher SHALL fail closed
+- **AND** CI SHALL execute the actual compiled boundary

--- a/openspec/changes/align-lean-section-lifecycles/tasks.md
+++ b/openspec/changes/align-lean-section-lifecycles/tasks.md
@@ -1,0 +1,74 @@
+## 1. Exact lifecycle inventory and projection
+
+- [ ] 1.1 Add the direct-child-counting classifier for stable and exactly-one
+  inserted paragraph-boundary sections.
+- [ ] 1.2 Emit bounded named issues for duplicate, misplaced, ambiguous, and
+  deleted shapes; keep terminal body sections stable.
+- [ ] 1.3 Build contiguous reject/original and accept/revised projections and
+  require exact projected count/ordered-slot equality.
+- [ ] 1.4 Prove classifier exclusivity, projected-ordinal contiguity, and
+  issue-or-aligned-slot completeness.
+
+## 2. Protocol v8 and physical work
+
+- [ ] 2.0 Confirm `verify-lean-comment-range-topology` is complete and archived;
+  rebase on its protocol-v7 canonical contract before implementation.
+- [ ] 2.1 Add exact slot/story present/absent work unions, lifecycle, projected
+  ordinals, global physical ordinals, and the new scope alignment literal.
+- [ ] 2.2 Realize proven-absent original sides as zero tokens and zero work;
+  require every present logical slot side to resolve and every present
+  deduplicated physical-story side to extract, parse, and be charged.
+- [ ] 2.3 Deduplicate by exact kind plus three-side presence/path tuple and
+  prove the slot-to-physical-story bijection.
+- [ ] 2.4 Expose per-slot relationship resolution and per-physical-story ZIP
+  identity, extraction/parse invocations, compressed/expanded bytes, XML
+  events, and token counts; enforce their observable equations and per-part
+  caps at the TypeScript boundary while Lean enforces inherited whole-request
+  side/triple budgets.
+- [ ] 2.5 Update public types and strict TypeScript decoding for protocol v8;
+  reject partial, older-labeled, contradictory, or noncanonical v7 evidence.
+
+## 3. Note and comment source partitions
+
+- [ ] 3.1 Derive each note-reference side as main plus exactly every present
+  relationship physical story
+  in global physical-story order with contiguous source ordinals.
+- [ ] 3.2 Preserve global physical ordinal, kind, and path on every
+  relationship source; exclude every absent source.
+- [ ] 3.3 Derive each comment source set from that partition plus present
+  footnotes then present endnotes, without repeating v7's retained event scan.
+- [ ] 3.4 Keep resolution, extraction, parse, identity, ordering, bijection,
+  and resource failures incomplete while allowing lifecycle-proven absence.
+- [ ] 3.5 Prove both side-specific bijections and aggregate implication.
+
+## 4. Compiled and public evidence
+
+- [ ] 4.1 Add compiled stable/inserted/deletion-rejected/ambiguous/misplaced/
+  unexplained fixtures and strict-launcher protocol mutations.
+- [ ] 4.2 Add machine-readable provenance for the pinned checked-in Common
+  Paper CC BY 4.0 fixture, including source/version/license/derivative/
+  redistribution/attribution fields; add no new binary fixture.
+- [ ] 4.3 Deterministically derive one revised inserted section and explicit
+  footer, then require production true-in-place comparison and exact
+  production accept/reject.
+- [ ] 4.4 Require a nonzero inserted-footer certificate with all six generic
+  checks, inherited v7 comment topology, and complete note/comment partitions.
+- [ ] 4.5 Mutate every classifier-priority row, presence/work field and
+  ordinal, selector/story/note/comment partition, absent/present work,
+  exposed per-part cap, Lean-side whole-request resource limit, inherited
+  envelope, and protocol version; require fail-closed results.
+- [ ] 4.6 Rerun the confidential corpus with aggregate-only local reporting;
+  write no filenames, text, values, hashes, parties, or addresses to the repo,
+  logs retained for PR evidence, or GitHub.
+
+## 5. Proof, audit, and release
+
+- [ ] 5.1 Add every new proof target to `AxiomAudit.lean`; preserve the exact
+  six-name axiom allowlist and zero `sorry`.
+- [ ] 5.2 Update protocol drift witnesses, checker coverage ledger, and
+  verifier documentation.
+- [ ] 5.3 Run `lake build`, compiled focused suites, axiom audit, zero-`sorry`
+  audit, and OpenSpec strict validation.
+- [ ] 5.4 Run the mandatory repository pre-submit gate.
+- [ ] 5.5 Merge through a focused PR and perform a public real-DOCX post-merge
+  smoke.


### PR DESCRIPTION
## Summary

- define protocol-v8 lifecycle projection for inserted paragraph-boundary sections
- preserve protocol-v7 comment topology and fail closed on deletion/ambiguity
- separate per-slot relationship resolution from deduplicated physical-story work
- require a redistributable public real-DOCX gate and aggregate-only private-corpus reporting

## Dependency

Implementation must not begin until verify-lean-comment-range-topology is complete and archived as protocol v7, and until the proposal receives explicit approval.

Protocol-v7 is not implementation-ready as of 2026-07-29. Its readiness audit is recorded on #729: the focused verifier suite still exposes an over-applied production bridge and a fixed-stack overflow.

## Validation

- npx openspec validate align-lean-section-lifecycles --strict
- git diff --check
- independent focused peer review: APPROVE

Refs #747
Refs #754
Refs #718
Depends on #729