### PR TITLE
fix(docx-core): track emptied paragraph mark deletion

### DIFF
--- a/packages/docx-core/src/primitives/text.test.ts
+++ b/packages/docx-core/src/primitives/text.test.ts
@@ -21,6 +21,10 @@ import {
 } from './text.js';
 
 const test = testAllure.epic('Document Comparison').withLabels({ feature: 'Text Primitives' });
+const paragraphDeletionTest = test.conformance(
+  { spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.5.14' },
+  { spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.5.15' },
+);
 
 const W_NS = OOXML.W_NS;
 
@@ -47,6 +51,15 @@ function paragraphAt(doc: Document, index: number): Element {
 
 function serialize(node: Node): string {
   return new XMLSerializer().serializeToString(node);
+}
+
+function getDirectElement(parent: Element, localName: string): Element | null {
+  return Array.from(parent.childNodes).find(
+    (child): child is Element =>
+      child.nodeType === 1 &&
+      (child as Element).namespaceURI === W_NS &&
+      (child as Element).localName === localName,
+  ) ?? null;
 }
 
 // ── getParagraphRuns — field-code state machine ─────────────────────
@@ -910,6 +923,56 @@ describe('replaceParagraphTextRange tracked-change emission', () => {
       expect(getParagraphText(p)).toBe(' world');
       expect(p.getElementsByTagNameNS(W_NS, 'ins')).toHaveLength(0);
       expect(p.getElementsByTagNameNS(W_NS, 'del')).toHaveLength(1);
+    });
+  });
+
+  paragraphDeletionTest('marks the paragraph mark deleted when a tracked replacement empties the paragraph', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    let p: Element;
+
+    await given('a numbered paragraph whose entire visible text will be deleted', () => {
+      const doc = makeDoc(
+        '<w:p>' +
+          '<w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="7"/></w:numPr></w:pPr>' +
+          '<w:r><w:t>Delete this item</w:t></w:r>' +
+        '</w:p>',
+      );
+      p = firstParagraph(doc);
+    });
+
+    await when('the complete text range is replaced with an empty string under tracked changes', () => {
+      replaceParagraphTextRange(
+        p,
+        0,
+        'Delete this item'.length,
+        '',
+        createRevisionContext({
+          author: 'SafeDocX AI',
+          date: '2026-07-29T12:00:00Z',
+          idState: createRevisionIdState(),
+        }),
+      );
+    });
+
+    await then('the content and paragraph mark carry separate deletion revisions', () => {
+      const pPr = getDirectElement(p, W.pPr);
+      const paragraphRPr = getDirectElement(pPr!, W.rPr);
+      const paragraphMarkDeletion = getDirectElement(paragraphRPr!, 'del');
+      const runDeletion = Array.from(p.childNodes).find(
+        (child): child is Element =>
+          child.nodeType === 1 &&
+          (child as Element).namespaceURI === W_NS &&
+          (child as Element).localName === 'del',
+      );
+
+      expect(runDeletion).toBeTruthy();
+      expect(paragraphMarkDeletion).toBeTruthy();
+      expect(paragraphMarkDeletion?.getAttribute('w:author')).toBe('SafeDocX AI');
+      expect(paragraphMarkDeletion?.getAttribute('w:id')).not.toBe(runDeletion?.getAttribute('w:id'));
+      expect(getDirectElement(pPr!, W.numPr)).toBeTruthy();
     });
   });
 

--- a/packages/docx-core/src/primitives/text.ts
+++ b/packages/docx-core/src/primitives/text.ts
@@ -379,6 +379,44 @@ function getDirectChild(parent: Element, localName: string): Element | null {
   return null;
 }
 
+/**
+ * Mark the paragraph mark as deleted when a tracked edit removes the
+ * paragraph's entire visible payload. The marker belongs in w:pPr/w:rPr;
+ * accepting it removes the paragraph break while the run-level w:del removes
+ * the old contents.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.5.15
+ * @see https://github.com/UseJunior/safe-docx/issues/741
+ */
+function addParagraphMarkDeletion(p: Element, ctx: RevisionContext): void {
+  const doc = p.ownerDocument;
+  if (!doc) throw new Error('Paragraph has no ownerDocument');
+
+  let pPr = getDirectChild(p, W.pPr);
+  if (!pPr) {
+    pPr = doc.createElementNS(OOXML.W_NS, `w:${W.pPr}`);
+    p.insertBefore(pPr, p.firstChild);
+  }
+
+  let rPr = getDirectChild(pPr, W.rPr);
+  if (!rPr) {
+    rPr = doc.createElementNS(OOXML.W_NS, `w:${W.rPr}`);
+    const sectPr = getDirectChild(pPr, 'sectPr');
+    const pPrChange = getDirectChild(pPr, 'pPrChange');
+    pPr.insertBefore(rPr, sectPr ?? pPrChange);
+  }
+
+  if (getDirectChild(rPr, 'del')) return;
+
+  const marker = createRevisionContainer(doc, 'del', ctx);
+  const insertionMarker = getDirectChild(rPr, 'ins');
+  if (insertionMarker) {
+    rPr.insertBefore(marker, insertionMarker.nextSibling);
+  } else {
+    rPr.insertBefore(marker, rPr.firstChild);
+  }
+}
+
 // OOXML on/off toggle properties (ECMA-376 ST_OnOff). Absence of w:val means
 // "1", and the values "1"/"true"/"on" are equivalent (likewise for the falsy
 // triple). We normalize so semantically-identical inputs hash the same.
@@ -617,8 +655,11 @@ function getContainerBoundaryError(
  * remain nested there, while cross-container ranges are refused before the
  * DOM is changed.
  *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.5.14
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.5.15
  * @conformance ECMA-376 edition 5, Part 1 § 17.16.22
  * @see #652
+ * @see #741
  */
 export function replaceParagraphTextRange(
   p: Element,
@@ -794,6 +835,10 @@ export function replaceParagraphTextRange(
         insertion.appendChild(replacementRun);
       }
       parent.insertBefore(insertion, insertBeforeNode);
+    }
+
+    if (start === 0 && end === fullText.length && replacementRuns.length === 0) {
+      addParagraphMarkDeletion(p, ctx);
     }
   } else {
     for (const replacementRun of replacementRuns) {

--- a/packages/docx-mcp/src/integration/canonical-emission-mcp.test.ts
+++ b/packages/docx-mcp/src/integration/canonical-emission-mcp.test.ts
@@ -40,6 +40,10 @@ const sectionBreakTest = test.conformance(
   { spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.5.20' },
   { spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.5.32' },
 );
+const paragraphDeletionTest = test.conformance(
+  { spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.5.14' },
+  { spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.5.15' },
+);
 
 const AI_AUTHOR = 'SafeDocX';
 const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
@@ -150,6 +154,69 @@ describe('Tool integration through SessionManager: canonical revision emission',
 
     await then('document.xml contains tracked SafeDocX insertion and deletion metadata', () => {
       expectTrackedElementsWithAuthor(documentXml, ['ins', 'del']);
+    });
+  });
+
+  paragraphDeletionTest('replace_text tracks deletion of an emptied numbered paragraph mark', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    let opened: Awaited<ReturnType<typeof openSession>>;
+    let trackedXml: string;
+    let cleanXml: string;
+
+    await given('a session with an explicitly configured AI author and a numbered paragraph', async () => {
+      const mgr = new SessionManager({ ttlMs: 60_000, defaultAiAuthor: AI_AUTHOR });
+      opened = await openSession([], {
+        mgr,
+        xml: makeDocXml(
+          '<w:p>' +
+            '<w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="7"/></w:numPr></w:pPr>' +
+            '<w:r><w:t>Delete this item</w:t></w:r>' +
+          '</w:p>' +
+          '<w:p><w:r><w:t>Keep this paragraph</w:t></w:r></w:p>',
+        ),
+      });
+    });
+
+    await when('replace_text empties the numbered paragraph and saves clean and tracked artifacts', async () => {
+      const replaced = await replaceText(opened.mgr, {
+        file_path: opened.inputPath,
+        target_paragraph_id: opened.firstParaId,
+        old_string: 'Delete this item',
+        new_string: '',
+        instruction: 'Delete the numbered paragraph.',
+      });
+      assertSuccess(replaced, 'replace_text');
+
+      const cleanPath = path.join(opened.tmpDir, 'empty-numbered-clean.docx');
+      const trackedPath = path.join(opened.tmpDir, 'empty-numbered-tracked.docx');
+      const saved = await save(opened.mgr, {
+        file_path: opened.inputPath,
+        save_to_local_path: cleanPath,
+        tracked_save_to_local_path: trackedPath,
+        save_format: 'both',
+      });
+      assertSuccess(saved, 'save');
+      cleanXml = (await readZipText(await fs.readFile(cleanPath), 'word/document.xml'))!;
+      trackedXml = (await readZipText(await fs.readFile(trackedPath), 'word/document.xml'))!;
+    });
+
+    await then('the redline deletes the paragraph mark and acceptance leaves no orphan numbered paragraph', () => {
+      expectTrackedElementsWithAuthor(trackedXml, ['del']);
+
+      const trackedDoc = parseXml(trackedXml);
+      const trackedParagraph = trackedDoc.getElementsByTagNameNS(W_NS, 'p').item(0) as Element;
+      const trackedPPr = trackedParagraph.getElementsByTagNameNS(W_NS, 'pPr').item(0) as Element;
+      const trackedRPr = trackedPPr.getElementsByTagNameNS(W_NS, 'rPr').item(0) as Element;
+      expect(trackedRPr.getElementsByTagNameNS(W_NS, 'del')).toHaveLength(1);
+
+      const cleanDoc = parseXml(cleanXml);
+      const cleanParagraphs = Array.from(cleanDoc.getElementsByTagNameNS(W_NS, 'p')) as Element[];
+      expect(cleanParagraphs).toHaveLength(1);
+      expect(cleanParagraphs[0]!.textContent).toBe('Keep this paragraph');
+      expect(cleanParagraphs[0]!.getElementsByTagNameNS(W_NS, 'numPr')).toHaveLength(0);
     });
   });
 


### PR DESCRIPTION
## Summary

- emit a paragraph-mark `w:del` when a tracked replacement removes a paragraph's full visible content
- use distinct revision metadata for the paragraph-mark deletion
- add core and MCP regressions proving accepting the tracked revision removes an emptied numbered paragraph

## Why

Run-level deletion alone leaves the paragraph mark intact. Accepting that redline therefore preserves an empty numbered paragraph and renders an orphan list label.

## Validation

- docx-core focused tests: 56/56 passed
- docx-mcp canonical-emission tests: 15/15 passed
- `npm run build`
- `npm run lint:workspaces`
- `npm run check:spec-coverage`
- `npm run check:conformance-citations`
- `npm run check:conformance-doc`

The full workspace suite was attempted both sandboxed and escalated. Changed packages passed; unrelated environment-sensitive `tsx`, LibreOffice/ODF, Lean process-group, and ILPA corpus probes failed or timed out.

Fixes #741