### PR TITLE
fix(docx-core): resolve run formatting from document defaults

### DIFF
--- a/packages/docx-core/src/primitives/styles-doc-defaults.test.ts
+++ b/packages/docx-core/src/primitives/styles-doc-defaults.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { OOXML } from './namespaces.js';
+import { extractEffectiveRunFormatting, parseStylesXml, type RunFormatting } from './styles.js';
+import { parseXml } from './xml.js';
+
+const test = testAllure.epic('Document Comparison').withLabels({ feature: 'Effective Run Formatting' });
+
+const TOGGLES = [
+  ['bold', 'b'],
+  ['italic', 'i'],
+  ['caps', 'caps'],
+  ['smallCaps', 'smallCaps'],
+  ['strike', 'strike'],
+  ['emboss', 'emboss'],
+  ['imprint', 'imprint'],
+  ['outline', 'outline'],
+  ['shadow', 'shadow'],
+  ['vanish', 'vanish'],
+] as const satisfies ReadonlyArray<readonly [keyof RunFormatting, string]>;
+
+function resolve(stylesInner: string, runRPr = ''): RunFormatting {
+  const styles = parseXml(
+    `<w:styles xmlns:w="${OOXML.W_NS}">${stylesInner}</w:styles>`,
+  );
+  const document = parseXml(
+    `<w:document xmlns:w="${OOXML.W_NS}"><w:body><w:p><w:r>` +
+      `<w:rPr>${runRPr}</w:rPr><w:t>x</w:t></w:r></w:p></w:body></w:document>`,
+  );
+  return extractEffectiveRunFormatting({
+    run: document.getElementsByTagNameNS(OOXML.W_NS, 'r').item(0)!,
+    paragraphPPr: null,
+    paragraphStyleId: null,
+    styles: parseStylesXml(styles),
+  });
+}
+
+function docDefaults(rPr: string): string {
+  return `<w:docDefaults><w:rPrDefault><w:rPr>${rPr}</w:rPr></w:rPrDefault></w:docDefaults>`;
+}
+
+describe('document-default effective run formatting', () => {
+  test
+    .conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.7.5.1' })(
+      'resolves every supported run property when it is declared only in docDefaults',
+      async ({ given, when, then }: AllureBddContext) => {
+        let formatting!: RunFormatting;
+
+        await given('a document whose complete base run formatting exists only in w:rPrDefault', async () => {});
+        await when('an otherwise unformatted run is resolved', async () => {
+          const toggles = TOGGLES.map(([, tag]) => `<w:${tag}/>`).join('');
+          formatting = resolve(docDefaults(
+            toggles +
+              '<w:u w:val="single"/><w:highlight w:val="yellow"/>' +
+              '<w:rFonts w:ascii="Courier New"/><w:sz w:val="28"/>' +
+              '<w:color w:val="123456"/>',
+          ));
+        });
+        await then('the document defaults supply every effective property', async () => {
+          for (const [field] of TOGGLES) expect(formatting[field]).toBe(true);
+          expect(formatting).toMatchObject({
+            underline: true,
+            highlightVal: 'yellow',
+            fontName: 'Courier New',
+            fontSizePt: 14,
+            colorHex: '123456',
+          });
+        });
+      },
+    );
+
+  test
+    .conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.7.5.1' })(
+      'docDefaults is the lowest-precedence tier for ordinary and toggle properties',
+      async ({ given, when, then }: AllureBddContext) => {
+        let formatting!: RunFormatting;
+
+        await given('enabled bold and Courier defaults with conflicting direct run formatting', async () => {});
+        await when('the directly formatted run is resolved', async () => {
+          formatting = resolve(
+            docDefaults('<w:b/><w:rFonts w:ascii="Courier New"/><w:sz w:val="28"/>'),
+            '<w:b w:val="0"/><w:rFonts w:ascii="Georgia"/><w:sz w:val="24"/>',
+          );
+        });
+        await then('direct formatting overrides the document-default base values', async () => {
+          expect(formatting).toMatchObject({
+            bold: false,
+            fontName: 'Georgia',
+            fontSizePt: 12,
+          });
+        });
+      },
+    );
+});

--- a/packages/docx-core/src/primitives/styles.ts
+++ b/packages/docx-core/src/primitives/styles.ts
@@ -17,6 +17,11 @@ export type StyleDef = {
 
 export type StylesModel = {
   byId: Map<string, StyleDef>;
+  /**
+   * Document-wide default run properties. Optional so callers that constructed
+   * the pre-#753 `{ byId }` model shape remain source-compatible.
+   */
+  docDefaultsRPr?: Element | null;
 };
 
 export type ThemeModel = {
@@ -98,7 +103,15 @@ export function parseThemeXml(themeDoc: Document | null): ThemeModel {
 
 export function parseStylesXml(stylesDoc: Document | null): StylesModel {
   const byId = new Map<string, StyleDef>();
-  if (!stylesDoc) return { byId };
+  if (!stylesDoc) return { byId, docDefaultsRPr: null };
+
+  const docDefaults = stylesDoc.getElementsByTagNameNS(OOXML.W_NS, W.docDefaults).item(0);
+  const rPrDefault = docDefaults
+    ? getFirstChild(docDefaults, OOXML.W_NS, W.rPrDefault)
+    : null;
+  const docDefaultsRPr = rPrDefault
+    ? getFirstChild(rPrDefault, OOXML.W_NS, W.rPr)
+    : null;
 
   const styles = Array.from(stylesDoc.getElementsByTagNameNS(OOXML.W_NS, W.style));
   for (const st of styles) {
@@ -120,7 +133,7 @@ export function parseStylesXml(stylesDoc: Document | null): StylesModel {
       rPr: rPr ?? null,
     });
   }
-  return { byId };
+  return { byId, docDefaultsRPr };
 }
 
 function resolveStyleChain(model: StylesModel, styleId: string | null): StyleDef[] {
@@ -299,23 +312,33 @@ function parseBoolProp(parent: Element | null, tagLocal: string): boolean | null
 
 type ToggleStep = {
   rPr: Element | null;
-  kind: 'style' | 'direct';
+  kind: 'default' | 'style' | 'direct';
 };
 
 /**
- * Evaluate a toggle property in hierarchy order. Style-level true values
- * invert the accumulated state while style-level false values preserve it;
- * direct formatting sets an absolute value.
+ * Evaluate a toggle property in hierarchy order. Document defaults establish
+ * the initial absolute value; style-level true values invert the accumulated
+ * state while style-level false values preserve it; direct formatting sets an
+ * absolute value.
+ *
+ * Microsoft's current ISO/IEC 29500 implementation note for §17.7.3 explicitly
+ * says Word falls back to document defaults when a hierarchy level supplies no
+ * value and describes the document-default value as the base for subsequent
+ * parity. MS-OE376 §2.7.7 documents a separate Word deviation for paragraph
+ * styles, but does not redefine `w:docDefaults` as another toggling style
+ * level. Accordingly, defaults seed rather than invert the state here.
  *
  * @conformance ECMA-376 edition 5, Part 1 § 17.7.3
  * @see https://github.com/UseJunior/safe-docx/issues/737
+ * @see https://learn.microsoft.com/en-us/openspecs/office_standards/ms-oi29500/f7130225-2368-48f3-acae-a9d278d0fb25
+ * @see https://learn.microsoft.com/en-us/openspecs/office_standards/ms-oe376/f936abaf-a9cb-439b-923d-7f688d9202e9
  */
 function resolveToggleProperty(steps: ToggleStep[], tagLocal: string): boolean {
   let effective = false;
   for (const { rPr, kind } of steps) {
     const declaration = parseBoolProp(rPr, tagLocal);
     if (declaration === null) continue;
-    if (kind === 'direct') {
+    if (kind === 'default' || kind === 'direct') {
       effective = declaration;
     } else if (declaration) {
       effective = !effective;
@@ -404,8 +427,9 @@ function parseHighlightVal(parent: Element | null): string | null {
  * the run declares. Ordinary properties are taken from the first layer that
  * specifies them: direct `w:rPr` on the run, then the `w:rStyle`
  * character-style `basedOn` chain, then the paragraph mark's `w:rPr` inside
- * `pPr`, then the paragraph style's `basedOn` chain. A property specified
- * nowhere resolves to the neutral value (`false`, `''`, `0`, or `null`).
+ * `pPr`, then the paragraph style's `basedOn` chain, and finally
+ * `w:docDefaults/w:rPrDefault/w:rPr`. A property specified nowhere resolves
+ * to the neutral value (`false`, `''`, `0`, or `null`).
  *
  * Each property is resolved independently down the chain — a style that
  * specifies only color does not mask an ancestor's bold.
@@ -417,9 +441,9 @@ function parseHighlightVal(parent: Element | null): string | null {
  * `w:caps`, `w:smallCaps`, `w:strike`, `w:emboss`, `w:imprint`, `w:outline`,
  * `w:shadow`, and `w:vanish`.
  *
- * Not resolved: `w:docDefaults`, table-style run properties, and
- * numbering-level `rPr`. A formatting change confined to one of those layers
- * is invisible to this resolver.
+ * Not resolved: table-style run properties and numbering-level `rPr`. A
+ * formatting change confined to one of those layers is invisible to this
+ * resolver.
  *
  * Part of docx-core's public surface (see `src/index.ts`) so external
  * diagnostics — `scripts/check_docx_formatting_loss.mjs` today, the planned
@@ -435,7 +459,9 @@ function parseHighlightVal(parent: Element | null): string | null {
  *   omitted, direct font/color fallbacks retain their previous behavior
  *
  * @conformance ECMA-376 edition 5, Part 1 § 17.7.3
+ * @conformance ECMA-376 edition 5, Part 1 § 17.7.5.1
  * @see https://github.com/UseJunior/safe-docx/issues/737
+ * @see https://github.com/UseJunior/safe-docx/issues/753
  */
 export function extractEffectiveRunFormatting(params: {
   run: Element;
@@ -466,6 +492,7 @@ export function extractEffectiveRunFormatting(params: {
     ...rStyleChain.map((s) => s.rPr),
     pRPr,
     ...paragraphStyleChain.map((s) => s.rPr),
+    styles.docDefaultsRPr ?? null,
   ];
   const resolve = <T>(parse: (el: Element | null) => T | null): T | null =>
     firstNonNull(sources.map(parse));
@@ -475,6 +502,7 @@ export function extractEffectiveRunFormatting(params: {
   // character style can still contribute above it before the run's own rPr
   // supplies the final absolute override.
   const toggleSteps: ToggleStep[] = [
+    { rPr: styles.docDefaultsRPr ?? null, kind: 'default' },
     ...[...paragraphStyleChain].reverse().map((style) => ({ rPr: style.rPr, kind: 'style' as const })),
     { rPr: pRPr, kind: 'direct' },
     ...[...rStyleChain].reverse().map((style) => ({ rPr: style.rPr, kind: 'style' as const })),

--- a/scripts/check_docx_formatting_loss.mjs
+++ b/scripts/check_docx_formatting_loss.mjs
@@ -57,9 +57,9 @@
  *   - Toggle properties use style-level parity and absolute direct-formatting
  *     semantics, matching the Word differential pinned for issue #737.
  *
- * What the resolver does not reach, this check does not reach: w:docDefaults,
- * table-style run properties, and numbering-level rPr. Theme fonts and colors
- * are resolved through word/theme/theme1.xml, including tint/shade transforms.
+ * What the resolver does not reach, this check does not reach: table-style run
+ * properties and numbering-level rPr. Document defaults, theme fonts, and
+ * colors are resolved, including tint/shade transforms.
  * Because the resolver reduces w:u to on/off, an underline
  * style-to-style change (single to dotted) is no longer reported; the old
  * declared-properties projection caught it, and trading that corner for one

--- a/spec-compliance/CONFORMANCE.md
+++ b/spec-compliance/CONFORMANCE.md
@@ -56,7 +56,7 @@ Allure labels via `testAllure.conformance({…})`; source code carries
 | `ECMA-PART1-17-3-2-6` | Run color and theme transforms | 5 | 1 | 17.3.2.6 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#type:CT_Color` | packages/docx-core/src/primitives/styles.ts; packages/docx-core/src/primitives/styles-theme.test.ts; scripts/check_docx_formatting_loss.test.mjs |
 | `ECMA-PART1-17-7-4-18` | w:styles style-definitions part emission | 5 | 1 | 17.7.4.18 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:styles` | — |
 | `ECMA-PART1-17-7-4-17` | w:style style-definition emission | 5 | 1 | 17.7.4.17 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:style` | — |
-| `ECMA-PART1-17-7-5-1` | w:docDefaults document-default properties | 5 | 1 | 17.7.5.1 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:docDefaults` | — |
+| `ECMA-PART1-17-7-5-1` | w:docDefaults document-default properties | 5 | 1 | 17.7.5.1 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:docDefaults` | packages/docx-core/src/primitives/styles.ts; packages/docx-core/src/primitives/styles-doc-defaults.test.ts; packages/docx-core/src/generation/generation-styles-formatting.test.ts |
 | `ECMA-PART1-17-6-18` | w:sectPr paragraph-level section break emission | 5 | 1 | 17.6.18 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:sectPr` | packages/docx-core/src/generation/generation-sections-fields.test.ts; packages/docx-core/src/primitives/sections.ts; packages/docx-core/src/primitives/sections_insert_break.test.ts; packages/docx-mcp/src/tools/insert_section_break.test.ts |
 | `ECMA-PART1-17-6-22` | w:type section start kind | 5 | 1 | 17.6.22 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#type:CT_SectType` | packages/docx-core/src/primitives/sections.ts; packages/docx-core/src/primitives/sections_insert_break.test.ts; packages/docx-mcp/src/tools/insert_section_break.test.ts |
 | `ECMA-PART1-17-6-12` | w:pgNumType page-numbering settings emission | 5 | 1 | 17.6.12 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:pgNumType` | packages/docx-core/src/generation/generation-sections-fields.test.ts; packages/docx-core/src/primitives/sections.ts; packages/docx-core/src/primitives/sections.test.ts; packages/docx-core/src/integration/canonical-emission-regression.test.ts; packages/docx-mcp/src/tools/format_section.test.ts; packages/docx-mcp/src/integration/canonical-emission-mcp.test.ts |
@@ -737,12 +737,16 @@ at spec validation, before any XML is built.
 - **Part / Section:** Part 1 § 17.7.5.1
 - **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
 - **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:docDefaults`
+- **Verified by:** packages/docx-core/src/primitives/styles.ts; packages/docx-core/src/primitives/styles-doc-defaults.test.ts; packages/docx-core/src/generation/generation-styles-formatting.test.ts
 
 `w:docDefaults` carries the document-wide default run and paragraph
 properties that styles and direct formatting layer over. Generation emits
 explicit defaults (font bound across ascii/hAnsi/cs script ranges plus an
 explicit size) rather than relying on reader fallbacks, which diverge
-between Word, LibreOffice, and Google Docs import.
+between Word, LibreOffice, and Google Docs import. Effective run formatting
+reads `w:rPrDefault/w:rPr` as its lowest-precedence tier; for toggle
+properties that tier establishes the base state before style parity and
+absolute direct formatting are applied.
 
 ### ECMA-PART1-17-6-18 — w:sectPr paragraph-level section break emission
 

--- a/spec-compliance/registry/ecma-376.md
+++ b/spec-compliance/registry/ecma-376.md
@@ -762,14 +762,17 @@ part: 1
 section: "17.7.5.1"
 url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
 schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:docDefaults
-verifiedBy:
+verifiedBy: packages/docx-core/src/primitives/styles.ts; packages/docx-core/src/primitives/styles-doc-defaults.test.ts; packages/docx-core/src/generation/generation-styles-formatting.test.ts
 ```
 
 `w:docDefaults` carries the document-wide default run and paragraph
 properties that styles and direct formatting layer over. Generation emits
 explicit defaults (font bound across ascii/hAnsi/cs script ranges plus an
 explicit size) rather than relying on reader fallbacks, which diverge
-between Word, LibreOffice, and Google Docs import.
+between Word, LibreOffice, and Google Docs import. Effective run formatting
+reads `w:rPrDefault/w:rPr` as its lowest-precedence tier; for toggle
+properties that tier establishes the base state before style parity and
+absolute direct formatting are applied.
 
 ## [ECMA-PART1-17-6-18] w:sectPr paragraph-level section break emission
 


### PR DESCRIPTION
## Summary

- parse `w:docDefaults/w:rPrDefault/w:rPr` into the styles model
- apply document defaults as the lowest-precedence tier for every supported run property
- seed toggles absolutely from document defaults before style parity and direct overrides
- keep numbering-level and table-style run properties explicitly out of scope
- add conformance-tagged resolver tests and update diagnostics/conformance records

## Toggle semantics

Document defaults are the absolute base state. ECMA-376 5th edition Part 1 §§17.7.3 and 17.7.5.1 define the inheritance/default layers. Microsoft [MS-OI29500] §17.7.3 describes document defaults as the fallback/base for toggle evaluation; [MS-OE376] §2.7.7 documents a paragraph-style reset deviation but no deviation making `docDefaults` another toggling style level.

## Corpus measurement

Across 54 DOCX files and 27,419 runs:

- empty `fontName`: 26,490 (96.6%) → 0
- zero `fontSizePt`: 3,393 (12.4%) → 347 (1.27%)

All 347 size residuals are in seven documents whose `docDefaults` omit `w:sz`; no represented higher tier supplies a size.

## Validation

- full workspace build passed
- workspace lint passed (0 errors; 9 pre-existing warnings)
- docx-core: 1,298 passed, 2 expected-fail, 15 skipped
- focused resolver tests: 6 passed
- formatting-loss tests: 41 passed plus self-test
- spec coverage passed
- conformance citation and generated-document checks passed
- all other workspace suites passed

Fixes #753