### PR TITLE
fix(docx-compare): suppress phantom whitespace format changes

### DIFF
--- a/packages/docx-compare/src/baselines/atomizer/documentReconstructor.ts
+++ b/packages/docx-compare/src/baselines/atomizer/documentReconstructor.ts
@@ -1897,7 +1897,7 @@ function buildFormatChangeRun(
     // DOM-aware buildRPrChangeElement helper exists for new primitive code
     // paths (#136 onward).
     const formatChange = group.atoms[0]?.formatChange;
-    if (formatChange?.oldRunProperties) {
+    if (formatChange?.oldRunProperties && !isWhitespaceOnlyGroup(group)) {
       const id = allocateRevisionId(revState);
       parts.push(
         `<w:rPrChange w:id="${id}" w:author="${escapeXmlAttr(author)}" w:date="${dateStr}">`

--- a/packages/docx-compare/src/baselines/atomizer/inPlaceModifier-handlers.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/inPlaceModifier-handlers.test.ts
@@ -48,20 +48,39 @@ function count(xml: string, tag: string): number {
   return (xml.match(new RegExp(`<${tag.replace(':', '\\:')}\\b`, 'g')) ?? []).length;
 }
 
+function owningRun(change: Element): Element | null {
+  let current: Node | null = change.parentNode;
+  while (current) {
+    if (current.nodeType === 1 && (current as Element).tagName === 'w:r') {
+      return current as Element;
+    }
+    current = current.parentNode;
+  }
+  return null;
+}
+
 type InplaceResult = Awaited<ReturnType<typeof compareDocuments>>;
 
-async function inplaceCompareFull(
+async function compareFull(
   originalBody: string,
   revisedBody: string,
+  reconstructionMode: 'inplace' | 'rebuild',
 ): Promise<{ xml: string; result: InplaceResult }> {
   const original = await buildDocxFromBodyXml(originalBody);
   const revised = await buildDocxFromBodyXml(revisedBody);
   const result = await compareDocuments(original, revised, {
     engine: 'atomizer',
-    reconstructionMode: 'inplace',
+    reconstructionMode,
   });
-  expect(result.reconstructionModeUsed).toBe('inplace');
+  expect(result.reconstructionModeUsed).toBe(reconstructionMode);
   return { xml: await documentXml(result.document), result };
+}
+
+async function inplaceCompareFull(
+  originalBody: string,
+  revisedBody: string,
+): Promise<{ xml: string; result: InplaceResult }> {
+  return compareFull(originalBody, revisedBody, 'inplace');
 }
 
 async function inplaceCompare(originalBody: string, revisedBody: string): Promise<string> {
@@ -204,10 +223,86 @@ describe('inPlaceModifier handlers (inplace reconstruction path)', () => {
 
     await and('the revised bold formatting is applied to the run without deleting the text', () => {
       expect(xml).toContain('<w:b/>');
-      expect(xml).toContain('Formatting target text');
+      expect(normalizeText(extractTextWithParagraphs(xml))).toBe('Formatting target text');
       expect(count(xml, 'w:delText')).toBe(0);
     });
   });
+
+  formatTest(
+    'one-word edits do not emit run-property revisions on whitespace-only runs',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      let comparisons: Array<{ xml: string; result: InplaceResult }>;
+      const original =
+        '<w:p><w:r><w:t>Alpha</w:t></w:r><w:r><w:rPr><w:u w:val="single"/></w:rPr><w:t xml:space="preserve"> old </w:t></w:r><w:r><w:t>Beta</w:t></w:r></w:p>';
+      const revised =
+        '<w:p><w:r><w:t xml:space="preserve">Alpha </w:t></w:r><w:r><w:rPr><w:u w:val="single"/></w:rPr><w:t>new</w:t></w:r><w:r><w:t xml:space="preserve"> Beta</w:t></w:r></w:p>';
+
+      await given(
+        'a one-word replacement whose equivalent underline boundaries place adjacent spaces in different runs',
+        () => {},
+      );
+
+      await when('the documents are compared in both reconstruction modes', async () => {
+        comparisons = await Promise.all([
+          compareFull(original, revised, 'inplace'),
+          compareFull(original, revised, 'rebuild'),
+        ]);
+      });
+
+      await then('no generated format revision belongs to a whitespace-only run', () => {
+        for (const { xml } of comparisons) {
+          const doc = parseXml(xml);
+          const whitespaceChanges = findAllByTagName(doc.documentElement, 'w:rPrChange')
+            .filter((change) => (owningRun(change)?.textContent ?? '').trim() === '');
+          expect(whitespaceChanges).toHaveLength(0);
+        }
+      });
+
+      await and('the text replacement remains the only content change', () => {
+        for (const { xml, result } of comparisons) {
+          expect(result.stats.insertions).toBeGreaterThan(0);
+          expect(result.stats.deletions).toBeGreaterThan(0);
+          expect(result.stats.formatChanges).toBe(0);
+          expect(normalizeText(extractTextWithParagraphs(acceptAllChanges(xml)))).toBe(
+            'Alpha new Beta',
+          );
+          expect(normalizeText(extractTextWithParagraphs(rejectAllChanges(xml)))).toBe(
+            'Alpha old Beta',
+          );
+        }
+      });
+    },
+  );
+
+  formatTest(
+    'identical currency text with different run boundaries remains untracked',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      let xml: string;
+      let result: InplaceResult;
+
+      await given('an identical currency amount split differently across runs', () => {});
+
+      await when('the documents are compared in inplace mode', async () => {
+        ({ xml, result } = await inplaceCompareFull(
+          '<w:p><w:r><w:t>$</w:t></w:r><w:r><w:t>1,250.00</w:t></w:r></w:p>',
+          '<w:p><w:r><w:t>$1,</w:t></w:r><w:r><w:t>250.00</w:t></w:r></w:p>',
+        ));
+      });
+
+      await then('the identical amount produces no content or format revisions', () => {
+        expect(result.stats.insertions).toBe(0);
+        expect(result.stats.deletions).toBe(0);
+        expect(result.stats.formatChanges).toBe(0);
+      });
+
+      await and('the combined document contains no tracked-change wrappers', () => {
+        expect(count(xml, 'w:ins')).toBe(0);
+        expect(count(xml, 'w:del')).toBe(0);
+        expect(count(xml, 'w:rPrChange')).toBe(0);
+        expect(normalizeText(extractTextWithParagraphs(xml))).toBe('$1,250.00');
+      });
+    },
+  );
 
   formatTest(
     'text replacements do not clone one format revision into both change wrappers',

--- a/packages/docx-compare/src/baselines/atomizer/inPlaceModifier.ts
+++ b/packages/docx-compare/src/baselines/atomizer/inPlaceModifier.ts
@@ -777,7 +777,11 @@ function handleMovedDestination(atom: ComparisonUnitAtom, ctx: ProcessingContext
  */
 function handleFormatChanged(atom: ComparisonUnitAtom, ctx: ProcessingContext): HandlerResult {
   const run = getAtomRunAtBoundary(atom, 'start');
-  if (run && atom.formatChange?.oldRunProperties) {
+  if (
+    run &&
+    (run.textContent ?? '').trim() !== '' &&
+    atom.formatChange?.oldRunProperties
+  ) {
     addFormatChange(run, atom.formatChange.oldRunProperties, ctx.author, ctx.dateStr, ctx.state);
     resolveRevisedInsCollisionOnRun(atom, run);
     // Equal-text/changed-format content keeps its original-side w:ins lineage

--- a/packages/docx-compare/src/format-detection.test.ts
+++ b/packages/docx-compare/src/format-detection.test.ts
@@ -439,6 +439,55 @@ describe('detectFormatChangesInAtomList', () => {
     });
   });
 
+  test('skips whitespace-only text atoms with different run properties', async ({ given, when, then }: AllureBddContext) => {
+    let atom: ComparisonUnitAtom;
+
+    await given('a standalone space correlated across plain and underlined runs', () => {
+      atom = createAtomWithAncestors(' ', []);
+      atom.comparisonUnitAtomBefore = createAtomWithAncestors(' ', [
+        el('w:u', { 'w:val': 'single' }),
+      ]);
+    });
+
+    await when('format changes are detected', () => {
+      detectFormatChangesInAtomList([atom], { detectFormatChanges: true });
+    });
+
+    await then('the whitespace atom remains equal without format-change metadata', () => {
+      expect(atom.correlationStatus).toBe(CorrelationStatus.Equal);
+      expect(atom.formatChange).toBeUndefined();
+    });
+  });
+
+  test('keeps whitespace inside a genuine whole-run formatting change', async ({ given, when, then }: AllureBddContext) => {
+    let word: ComparisonUnitAtom;
+    let space: ComparisonUnitAtom;
+
+    await given('word and space atoms split from one run with the same underline removal', () => {
+      const splitFromAtom = createAtomWithAncestors('Word ', []);
+      word = createAtomWithAncestors('Word', []);
+      space = createAtomWithAncestors(' ', []);
+      word.splitFromAtom = splitFromAtom;
+      space.splitFromAtom = splitFromAtom;
+      word.comparisonUnitAtomBefore = createAtomWithAncestors('Word', [
+        el('w:u', { 'w:val': 'single' }),
+      ]);
+      space.comparisonUnitAtomBefore = createAtomWithAncestors(' ', [
+        el('w:u', { 'w:val': 'single' }),
+      ]);
+    });
+
+    await when('format changes are detected', () => {
+      detectFormatChangesInAtomList([word, space], { detectFormatChanges: true });
+    });
+
+    await then('both atoms stay in one homogeneous formatting-change span', () => {
+      expect(word.correlationStatus).toBe(CorrelationStatus.FormatChanged);
+      expect(space.correlationStatus).toBe(CorrelationStatus.FormatChanged);
+      expect(space.formatChange?.changedProperties).toContain('underline');
+    });
+  });
+
   test('detects format change when bold is added', async ({ given, when, then }: AllureBddContext) => {
     let atom: ComparisonUnitAtom;
 

--- a/packages/docx-compare/src/format-detection.ts
+++ b/packages/docx-compare/src/format-detection.ts
@@ -269,6 +269,64 @@ export function categorizePropertyChanges(
 // Main Algorithm
 // =============================================================================
 
+function isWhitespaceTextAtom(atom: ComparisonUnitAtom): boolean {
+  return (
+    atom.contentElement.tagName === 'w:t' &&
+    (getLeafText(atom.contentElement) ?? '').trim() === ''
+  );
+}
+
+/**
+ * Preserve whitespace inside a genuine whole-run formatting change.
+ *
+ * Word-level splitting gives every word and separator from one source `w:t`
+ * the same `splitFromAtom`. A separator is part of the formatting revision
+ * only when a non-whitespace sibling from that same source atom has the exact
+ * same old/new property pair. Otherwise its LCS match is merely ambiguous
+ * whitespace aligned across unrelated run boundaries.
+ */
+function hasMatchingNonWhitespaceFormatChange(
+  atoms: ComparisonUnitAtom[],
+  atomIndex: number,
+  oldRPr: Element | null,
+  newRPr: Element | null,
+): boolean {
+  const atom = atoms[atomIndex]!;
+  const splitFromAtom = atom.splitFromAtom;
+  if (!splitFromAtom) return false;
+
+  for (const direction of [-1, 1] as const) {
+    for (
+      let candidateIndex = atomIndex + direction;
+      candidateIndex >= 0 && candidateIndex < atoms.length;
+      candidateIndex += direction
+    ) {
+      const candidate = atoms[candidateIndex]!;
+      if (candidate.splitFromAtom !== splitFromAtom) break;
+      if (isWhitespaceTextAtom(candidate)) continue;
+      const hasComparableStatus =
+        candidate.correlationStatus === CorrelationStatus.Equal ||
+        candidate.correlationStatus === CorrelationStatus.FormatChanged;
+      if (hasComparableStatus && candidate.comparisonUnitAtomBefore) {
+        const candidateOldRPr = getRunPropertiesFromAtom(
+          candidate.comparisonUnitAtomBefore,
+        );
+        const candidateNewRPr = getRunPropertiesFromAtom(candidate);
+        if (
+          !areRunPropertiesEqual(candidateOldRPr, candidateNewRPr) &&
+          areRunPropertiesEqual(oldRPr, candidateOldRPr) &&
+          areRunPropertiesEqual(newRPr, candidateNewRPr)
+        ) {
+          return true;
+        }
+      }
+      break;
+    }
+  }
+
+  return false;
+}
+
 /**
  * Detect format changes in a flat list of atoms.
  *
@@ -277,6 +335,9 @@ export function categorizePropertyChanges(
  *
  * @param atoms - The atom list to process (modified in place)
  * @param settings - Format detection settings (optional, uses defaults)
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.5.31
+ * @see https://github.com/UseJunior/safe-docx/issues/743
  */
 export function detectFormatChangesInAtomList(
   atoms: ComparisonUnitAtom[],
@@ -286,7 +347,8 @@ export function detectFormatChangesInAtomList(
     return;
   }
 
-  for (const atom of atoms) {
+  for (let atomIndex = 0; atomIndex < atoms.length; atomIndex++) {
+    const atom = atoms[atomIndex]!;
     // Only check Equal atoms that have a "before" reference
     if (atom.correlationStatus !== CorrelationStatus.Equal) {
       continue;
@@ -302,6 +364,15 @@ export function detectFormatChangesInAtomList(
 
     // Compare run properties
     if (!areRunPropertiesEqual(oldRPr, newRPr)) {
+      // Standalone whitespace and whitespace whose formatting delta is not
+      // corroborated by text from the same source run are LCS alignment noise.
+      if (
+        isWhitespaceTextAtom(atom) &&
+        !hasMatchingNonWhitespaceFormatChange(atoms, atomIndex, oldRPr, newRPr)
+      ) {
+        continue;
+      }
+
       atom.correlationStatus = CorrelationStatus.FormatChanged;
       atom.formatChange = {
         oldRunProperties: oldRPr,

--- a/packages/docx-core/src/integration/table-heavy-run-fragmented-inplace.test.ts
+++ b/packages/docx-core/src/integration/table-heavy-run-fragmented-inplace.test.ts
@@ -82,12 +82,10 @@ async function fragmentRevisedTableRuns(buffer: Buffer): Promise<Buffer> {
 
 /**
  * A single-run paragraph whose revised copy splits one run at a formatting
- * boundary (a bold fragment mid-phrase) and edits a nearby word. The word-split
- * inplace pass cannot reconstruct this safely — splitting the bold run corrupts
- * the reject-side round-trip text — so it fails, and the run-level pass (which
- * deletes/inserts whole runs) rescues the output while keeping inplace mode.
- * This is a genuine fail-then-rescue that exercises the pass-supersession
- * machinery and the `inplaceSuccessDiagnostics` reporting.
+ * boundary (a bold fragment mid-phrase) and edits a nearby word. Whitespace-only
+ * formatting mismatches used to make the word-split pass fail its round-trip
+ * checks, forcing a run-level rescue. Suppressing that alignment noise lets the
+ * more precise word-split pass win directly.
  */
 async function fragmentAtFormattingBoundary(original: Buffer): Promise<Buffer> {
   const archive = await DocxArchive.load(original);
@@ -107,7 +105,7 @@ async function fragmentAtFormattingBoundary(original: Buffer): Promise<Buffer> {
 
 describe('Inplace reconstruction pass selection', () => {
   test.openspec('Inplace reconstruction reports the pass that produced the output')(
-    'reports the winning pass and the earlier pass it superseded',
+    'reports the primary word-split pass when whitespace formatting noise is suppressed',
     async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
       let original!: Buffer;
       let revised!: Buffer;
@@ -140,20 +138,14 @@ describe('Inplace reconstruction pass selection', () => {
         });
       });
 
-      await then('inplace output is kept and the diagnostics name the winning pass and the pass it superseded', () => {
+      await then('inplace output is kept and the diagnostics name the primary winning pass', () => {
         expect(result.reconstructionModeUsed).toBe('inplace');
         expect(result.fallbackReason).toBeUndefined();
 
         const diagnostics = result.inplaceSuccessDiagnostics;
         expect(diagnostics).toBeDefined();
-        // The run-level pass rescued output that word-split could not reconstruct safely.
-        expect(diagnostics!.passUsed).toBe('inplace_run_level');
-        expect(diagnostics!.precedingFailedAttempts.length).toBeGreaterThan(0);
-        expect(diagnostics!.precedingFailedAttempts[0]!.pass).toBe('inplace_word_split');
-        // Every superseded attempt records at least one failed safety check, in evaluation order.
-        for (const attempt of diagnostics!.precedingFailedAttempts) {
-          expect(attempt.failedChecks.length).toBeGreaterThan(0);
-        }
+        expect(diagnostics!.passUsed).toBe('inplace_word_split');
+        expect(diagnostics!.precedingFailedAttempts).toEqual([]);
       });
     },
   );


### PR DESCRIPTION
## Summary

- require whitespace formatting deltas to be corroborated by the nearest non-whitespace sibling from the same source run with the same old→new formatting pair
- preserve genuine whole-run formatting revisions while suppressing misaligned standalone-space artifacts
- add final whitespace-only `rPrChange` emission guards in both inplace and rebuild modes
- pin one-word underline-boundary, whole-run formatting, identical-currency/run-boundary, and pass-selection behavior

## Root cause

Word-level atomization creates standalone space atoms. LCS can align those spaces across unrelated run boundaries; inherited ancestor `rPr` then makes the aligned space appear format-changed, and reconstruction emits an isolated `w:rPrChange` that renders as a phantom underline artifact.

No broad coalescing refactor was needed. The fix also makes the preferred word-split reconstruction pass safe in the affected fragmentation fixture.

## Validation

- focused docx-compare: 62/62 passed
- affected docx-core: 2/2 passed
- package lint/typechecks passed
- full build passed
- workspace lint passed (0 errors; 9 existing warnings)
- strict spec coverage passed
- conformance citation/document checks passed
- diff check passed

The root workspace test run completed with unrelated environment/load timeouts and sandbox subprocess/LibreOffice failures. All issue-specific failures were corrected and rerun green; MCP 966/966, ODF 140/140, and remaining packages passed.

Fixes #743