### PR TITLE
docs(openspec): propose safe OPC directory records

### DIFF
--- a/openspec/changes/accept-safe-opc-directory-records/design.md
+++ b/openspec/changes/accept-safe-opc-directory-records/design.md
@@ -1,0 +1,131 @@
+## Context
+
+The protocol-v4/v6 independent verifier builds its trusted package inventory
+from classic ZIP bytes before delegating exact-name decompression to `unzip`.
+The current parser recognizes DOS and Unix directory indicators but rejects
+every directory. That fail-closed rule excludes Word-authored packages whose
+regular OPC parts are safe but whose ZIP producer emitted explicit directory
+metadata.
+
+Directory records cannot simply be ignored during central-directory parsing.
+Doing so before local-header, duplicate, collision, span, and resource checks
+would create a second, less constrained archive namespace outside the trusted
+index.
+
+## Goals / Non-Goals
+
+- Goals:
+  - accept a narrow, unambiguous, empty directory-record subset;
+  - validate directories under the same bounded central/local index as files;
+  - prevent aliasing between `name` and `name/`;
+  - keep directory metadata out of the trusted OPC part inventory;
+  - preserve the existing public certificate schema and fail-closed boundary.
+- Non-Goals:
+  - treat directories as OPC parts or selected XML resources;
+  - accept directory payloads, compressed directories, symlinks, or special
+    files;
+  - normalize case, Unicode, separators, or multiple trailing slashes;
+  - widen classic ZIP, OPC, or ECMA-376 conformance claims.
+
+## Decisions
+
+### Classify from all available central signals
+
+Classification uses three central-record signals: the decoded name's trailing
+slash, DOS external-attribute directory bit `0x10`, and the Unix file type in
+the high mode bits when present.
+
+A safe directory name ends in `/` but not `//` and has at least one directory
+attribute. If a Unix file type is present, it is directory type; a simultaneous
+Unix regular-file type and DOS directory indication is contradictory and
+rejected. A safe regular file has no trailing slash or DOS directory bit and
+has either no Unix type or Unix regular-file type. Unix symlink and other
+special types remain unsupported. Any other combination is ambiguous and
+causes process-level `not_run`.
+
+All other exact-name safety rules remain unchanged. In particular, the parser
+still rejects leading slash, backslash, controls, pattern characters, and
+`.`/`..` or empty path segments; the one final empty segment represented by a
+safe directory's terminal slash is the only new exception.
+
+This accepts DOS-only, Unix-only, and consistently dual-marked directory
+records without letting a trailing slash alone or contradictory attributes
+decide trusted identity.
+
+### Require empty stored directory records
+
+An accepted directory record uses compression method `0` and has zero CRC-32,
+compressed size, and expanded size. Its local header must match the central
+raw filename, flags, method, CRC, and sizes under the existing exact checks.
+The computed data offset therefore equals the complete local-record span end,
+proving zero payload. Extra fields remain subject to the existing bounded
+parser, ZIP64 and Unicode Path exclusions, and central/local policies.
+
+Alternative considered: accept deflate method `8` for empty directories.
+There is no OPC payload to decompress, and accepting a compressed empty stream
+would add extractor and representation ambiguity without improving part
+coverage.
+
+### Validate before projecting the trusted part inventory
+
+Directory records count toward package bytes, central-directory bytes, ZIP
+entry count, filename length, and complete local-record span validation. Their
+zero declared sizes contribute zero to compressed/expanded byte totals.
+Directories participate in exact decoded-name duplicate detection and pairwise
+local-span overlap checks. Only after every record passes are directories
+removed from the inventory exposed to exact OPC part lookup, selected-part
+admission, and decompression.
+
+This ordering prevents an omitted record from bypassing archive amplification,
+namespace, or overlap controls. Directory entries never increment selected-part
+counts and never become relationship targets or fixed stories.
+
+### Add an explicit file/directory collision identity
+
+Exact decoded names remain the primary identity and are not case-folded or
+Unicode-normalized. For collision checking only, a validated directory removes
+exactly its one final `/`; a regular file retains its full name. Any equal
+collision identities with different record kinds invalidate the entire index.
+Thus `word` and `word/` cannot coexist, while `word/` and
+`word/document.xml` remain distinct.
+
+### Preserve the certificate boundary
+
+Valid directory metadata is invisible in v4/v6 evidence and the public v1
+certificate. The certificate is determined only by the same fixed and selected
+regular-file stories as before. Invalid directory metadata prevents a trusted
+index, so the executable produces no valid protocol response and the public
+certificate remains `not_run`; it is not downgraded to a structured selection
+failure. No certificate schema or protocol version changes.
+
+## Risks / Trade-offs
+
+- Some ZIP tools emit slash-only directories without attributes. They remain
+  unsupported because their record kind is not independently corroborated.
+- Rejecting Unix-regular plus DOS-directory attributes may exclude permissive
+  readers' output, but avoids allowing contradictory type metadata into a
+  security-sensitive index.
+- Filtering after full validation retains bounded work proportional to the
+  declared entry count. Existing entry and central-directory ceilings cap that
+  cost.
+- A collision check stricter than ordinary ZIP lookup can reject archives other
+  tools open. This is intentional because the trusted inventory must expose one
+  unambiguous file namespace.
+
+## Migration Plan
+
+1. Extend the existing central-entry classification without changing public
+   request, response, or certificate types.
+2. Validate and collision-check all records, then project only regular files
+   into the trusted inventory.
+3. Add compiled accepted/adversarial fixtures and the Word-authored public
+   certificate regression.
+4. Update policy coverage and generated conformance documentation.
+
+Rollback restores unconditional directory rejection. Certificates created
+before or after the change remain protocol-v1 compatible.
+
+## Open Questions
+
+None. The accepted directory subset and certificate boundary are intentionally
+narrow.

--- a/openspec/changes/accept-safe-opc-directory-records/proposal.md
+++ b/openspec/changes/accept-safe-opc-directory-records/proposal.md
@@ -1,0 +1,45 @@
+# Change: Accept safe OPC ZIP directory records
+
+## Why
+
+Some otherwise valid Word-authored DOCX packages contain explicit ZIP directory
+records. The independent Lean verifier currently rejects every directory record
+before it can certify the document, even though OPC part lookup needs only the
+regular-file entries.
+
+## What Changes
+
+- Classify ZIP central-directory records as regular files or directories from
+  the trailing slash plus DOS and Unix type attributes, and reject ambiguous or
+  contradictory classification.
+- Accept only directory records whose central and local headers agree, use the
+  stored method, and declare zero CRC-32, compressed size, expanded size, and
+  payload.
+- Validate and charge accepted directory records against package, central
+  directory, entry-count, name-length, and complete-local-span limits before
+  omitting them from the trusted OPC part inventory.
+- Preserve exact decoded-name duplicate detection across all records and add a
+  collision identity that removes exactly one directory trailing slash, so a
+  regular file and directory cannot claim the same identity.
+- Keep malformed, ambiguous, payload-bearing, overlapping, duplicate, or
+  file/directory-colliding records at the existing process-level `not_run`
+  certificate boundary.
+- Add compiled public-certificate regression evidence for the affected
+  Word-authored package and focused adversarial directory cases.
+- Document this as a bounded SafeDocX verifier policy, without widening OPC or
+  ECMA-376 conformance claims.
+
+## Impact
+
+- Affected specs: `docx-comparison`, `spec-compliance`
+- Affected code after approval: Lean classic-ZIP indexing and inventory
+  projection, compiled verifier fixtures, public certificate regression tests,
+  checker coverage policy, verifier documentation, and generated conformance
+  documentation
+- Compatibility: no request, response, or public certificate schema change;
+  qualifying packages move from `not_run` to their ordinary verification
+  result, while unsafe directory records remain `not_run`
+- Scope: classic single-disk stored/deflated ZIP packages only; accepted
+  directory records themselves must be stored and empty
+- Conformance: SafeDocX verifier policy only; no new ECMA-376 or full OPC claim
+- Ref: #745

--- a/openspec/changes/accept-safe-opc-directory-records/specs/docx-comparison/spec.md
+++ b/openspec/changes/accept-safe-opc-directory-records/specs/docx-comparison/spec.md
@@ -1,0 +1,202 @@
+## MODIFIED Requirements
+
+### Requirement: Protocol v4 pins its accepted syntax and aggregate limits
+
+The verifier SHALL accept only the Transitional namespaces and the exact
+XML/namespace, relationship-record, ZIP, and relationship-target subsets
+specified in the change design. Strict OOXML namespace URIs SHALL remain
+outside this increment. Prefixes SHALL resolve namespace-aware; malformed
+QNames, unbound or illegally rebound prefixes, duplicate expanded attributes,
+unsupported declarations/entities, comments, non-declaration processing
+instructions, CDATA, DTDs, external entities, extra roots, or non-whitespace
+outside the root SHALL fail closed.
+
+Relationship records SHALL be direct children of the package-relationships
+root with exactly one `Id`, `Type`, and `Target` and at most one `TargetMode`.
+Both self-closing and explicit-empty records SHALL be accepted; child content
+SHALL fail structurally. Malformed records and duplicate IDs SHALL fail
+structurally even when unselected. A structurally valid unselected record's
+type/target semantics SHALL remain unchecked and SHALL receive no passing
+evidence.
+
+Lean SHALL construct the trusted package inventory by bounded binary parsing of
+a classic single-disk ZIP central directory. It SHALL perform the exact EOCD
+search/validation, central-record consumption, central/local filename and
+flags/method agreement, UTF-8-flag/printable-ASCII name policy, Unicode Path
+extra-field rejection, duplicate and unsafe-name rejection, compression/
+encryption policy, and size/offset/range/overlap checks specified in the
+design. It SHALL reject ZIP64 extra field ID `0x0001` in every central or local
+extra sequence regardless of sentinel use, require every central disk-start
+field to equal zero, and require classic size/offset fields rather than ZIP64
+sentinels.
+
+Every central record SHALL be classified from the exact decoded name's trailing
+slash, DOS directory attribute, and recognized Unix file type. A directory
+record name SHALL end in `/` but not `//`, have at least one DOS or Unix
+directory indication, and have no contradictory Unix regular-file type. The
+one final empty path segment represented by that slash SHALL be the only
+directory-specific exception to the existing safe-name policy. A regular file
+SHALL have no trailing slash or DOS directory indication and either no Unix
+type or Unix regular-file type. Ambiguous classification, symlinks, and
+special-file types SHALL be `not_run`.
+
+An accepted directory record SHALL use stored method `0` and declare zero
+CRC-32, compressed size, and expanded size. Its central and local flags,
+method, raw filename, CRC-32, compressed size, and expanded size SHALL agree,
+and its computed data offset SHALL equal its complete local-record span end.
+The verifier SHALL retain each directory through package, central-directory,
+entry-count, name-length, duplicate, complete-local-span, and overlap checks.
+For collision identity only, it SHALL remove exactly one final slash from a
+validated directory name while retaining a regular-file name unchanged, and
+SHALL reject a file/directory identity collision. Only after all checks pass
+SHALL directories be omitted from the trusted OPC part inventory and therefore
+from selected-part lookup, decompression, and certificate evidence.
+
+For stored method `0`, only UTF-8 bit 11 SHALL be allowed
+(`flags & ~0x0800 == 0`). For deflate method `8`, only option bits 1-2 and
+UTF-8 bit 11 SHALL be allowed (`flags & ~0x0806 == 0`). Central/local flags
+SHALL be equal. Every complete local-record span, comprising fixed local
+header, filename, extra field, and compressed data, SHALL agree with its
+central record, end no later than the central-directory start, remain
+package-bounded, and be pairwise non-overlapping. ZIP64, multi-disk, encrypted,
+data-descriptor/patch/strong-encryption/reserved-flag, unsupported-method,
+ambiguous-name, or invalid index input SHALL be `not_run`, not structured
+selection failure.
+
+Only after one unique safe central/local regular-file entry is proven MAY Lean
+invoke `unzip -p --` by argv for decompression. It SHALL use an absolute
+controlled snapshot path and exact pattern-safe entry name, then verify exit
+status, bounded output length, and CRC-32 against the binary index. Extractor
+correspondence failure SHALL be `not_run`; `unzip` output SHALL NOT supply
+trusted inventory metadata.
+
+The verifier SHALL enforce the exact per-item, per-package, and three-package
+limits specified in the design: 32/96 MiB packages; 4/12 MiB classic central
+directories; 1,024/3,072 ZIP entries, including directory records; 256-byte
+ZIP names; 64/192 sections; 384/1,152 direct bindings; 1,024/3,072 relationship
+records; 256/768 unique selected parts; 8 MiB compressed and 16 MiB expanded
+per XML part; 16/48 MiB cumulative compressed XML; 32/96 MiB cumulative
+expanded XML; 500,000 per-part, 1,000,000 per-package, and 3,000,000
+per-request XML events; depth 128; 1,536 issues; 128-byte relationship IDs;
+256-byte path/target/locator/detail values; 1 MiB aggregate emitted variable
+strings; 64 KiB request/stderr; and 8 MiB response.
+
+Resource admission SHALL proceed as required main first; relationship XML,
+complete unique selected-target metadata, and selected physical work next;
+footnotes next; and endnotes last. Before decompressing any selected target,
+Lean SHALL enforce every metadata-known relationship path-count, selected-part,
+compressed-byte, and expanded-byte ceiling over each package and the triple.
+A relationship metadata ceiling SHALL emit a selection issue and SHALL admit
+no selected-target decompression. Each admitted XML part SHALL be event-parsed
+under the remaining per-part and package bounds, and its semantic tokens SHALL
+be derived from that bounded event stream without an unbounded second parse.
+Aggregate event exhaustion SHALL stop later selected work. An optional note
+whose metadata would cross a byte ceiling SHALL emit its corresponding fixed
+story issue without extraction; optional processing SHALL remain ordered
+footnotes before endnotes, and truthful relationship evidence already completed
+SHALL remain visible.
+Bounded XML parse failure SHALL carry a typed reason and completed/observed
+event and depth counts. A typed event-limit failure SHALL be aggregate
+exhaustion when the remaining package allowance is less than or equal to the
+500,000-event per-part ceiling, including equality, and SHALL stop subsequent
+selected and optional extraction. It SHALL remain a per-part overflow only when
+the remaining package allowance is greater than 500,000.
+
+The response serializer SHALL use the invariant that selecting slot ordinals
+form an exact partition across physical stories. It SHALL bound relationship
+story structure as at most 384 fixed story-overhead charges of 640 bytes plus
+384 selector-ordinal charges of eight bytes, rather than a false flat bound
+that includes an unbounded selector list. Together with the other design
+charges and six-times worst-case JSON expansion of the 1 MiB string budget,
+the maximum SHALL be 7,212,032 bytes, below 8,388,608.
+
+Executable maximum-shape fixtures SHALL cover one shared story with the legal
+192-selector single-kind maximum and 384 stories with one selector each, both
+with worst-case escaping and near-ceiling string budgets. Separate fixtures
+SHALL spend the reserved 512 string bytes on `ISSUE_LIMIT_EXCEEDED` and
+`EVIDENCE_STRING_BUDGET_EXCEEDED` in turn. No within-budget input SHALL
+overflow the output cap.
+
+#### Scenario: [LEAN-REL-14] XML and namespace subset fails closed
+
+- **WHEN** selector or selected-story XML uses a Strict namespace, malformed or
+  unbound QName, duplicate expanded attribute, unsupported declaration/entity,
+  comment, processing instruction, CDATA, DTD, external entity, or extra root
+- **THEN** protocol v4 SHALL reject it under the pinned accepted subset
+- **AND** alternate prefixes correctly bound to the Transitional namespaces
+  SHALL remain accepted
+
+#### Scenario: [LEAN-REL-15] Unselected relationship records remain structurally bounded
+
+- **WHEN** an unselected direct relationship record is malformed or duplicates
+  any relationship ID
+- **THEN** selection SHALL fail with a structured issue
+- **BUT WHEN** an unselected record is structurally valid but has an unsupported
+  type, external mode, or unsafe target
+- **THEN** its target semantics SHALL remain unchecked and no passing evidence
+  SHALL be emitted for it
+
+#### Scenario: [LEAN-REL-16] Aggregate budgets prevent amplification
+
+- **WHEN** an item, package, or three-package aggregate exceeds any pinned ZIP,
+  section, binding, relationship, selected-part, byte, XML event/depth, issue,
+  locator/detail, request, diagnostic, or response limit
+- **THEN** the run SHALL fail before publishing a passing certificate
+- **AND** reaching a limit exactly SHALL remain permitted
+
+#### Scenario: [LEAN-REL-22] Metadata and event admission stop decompression
+
+- **WHEN** selected paths exceed 256, relationship metadata exceeds a byte
+  aggregate, an optional note would cross the remaining byte budget, or an
+  admitted part exhausts the aggregate XML-event budget
+- **THEN** Lean SHALL not decompress metadata-rejected selected or optional
+  parts and SHALL stop parsing later work after event exhaustion
+- **AND** relationship failures SHALL remain selection issues, optional
+  crossings SHALL remain fixed-story issues, and prior truthful relationship
+  evidence SHALL remain visible
+- **AND** exact equality between remaining aggregate events and the per-part
+  ceiling SHALL use aggregate classification without inspecting diagnostic text
+
+#### Scenario: [LEAN-REL-20] Lean binary index establishes exact extraction identity
+
+- **WHEN** a classic single-disk stored/deflated package satisfies the bounded
+  EOCD, central-directory, local-header, filename, flag, size, offset, and CRC
+  contract
+- **THEN** Lean MAY decompress one uniquely indexed safe exact regular-file name
+  through `unzip -p --`
+- **AND** SHALL accept the bytes only when output length and CRC match the index
+
+#### Scenario: [LEAN-REL-21] Archive ambiguity is not a structured verifier result
+
+- **WHEN** a package is ZIP64, multi-disk, encrypted, uses a data descriptor or
+  unsupported method, has ambiguous EOCD, mismatched central/local names,
+  invalid UTF-8/ASCII naming, Unicode Path ambiguity, duplicate/unsafe names,
+  ZIP64 `0x0001` extra field, nonzero central disk start, forbidden flag bit,
+  ambiguous or unsafe directory/symlink/special entries, file/directory
+  identity collisions, overlapping or out-of-bounds complete local-record
+  spans, or extractor correspondence failure
+- **THEN** the executable SHALL produce no valid v4 response
+- **AND** the public certificate SHALL be `not_run`
+
+#### Scenario: [LEAN-REL-23] Safe directory records do not become OPC parts
+
+- **WHEN** a classic ZIP carries a central/local directory record whose name
+  and DOS/Unix classification are unambiguous, whose method is stored, and
+  whose CRC-32, sizes, and payload are zero
+- **THEN** Lean SHALL charge and validate the record before omitting it from the
+  trusted regular-file part inventory
+- **AND** the directory SHALL produce no selected-part or certificate evidence
+- **AND** an ambiguous, contradictory, payload-bearing, duplicate,
+  file/directory-colliding, overlapping, or over-limit directory record SHALL
+  return process-level `not_run`
+
+#### Scenario: [LEAN-REL-22] Every legal response fits the output cap
+
+- **WHEN** response arrays and variable strings reach every protocol-v4
+  cardinality and aggregate evidence ceiling
+- **THEN** production serialization SHALL remain below 8 MiB even under
+  worst-case JSON escaping
+- **AND** maximum-schema fixtures SHALL cover both one shared story with the
+  legal 192-selector single-kind maximum and 384 one-selector stories
+- **AND** either terminal issue SHALL fit using its mutually exclusive reserved
+  bytes

--- a/openspec/changes/accept-safe-opc-directory-records/specs/spec-compliance/spec.md
+++ b/openspec/changes/accept-safe-opc-directory-records/specs/spec-compliance/spec.md
@@ -1,0 +1,94 @@
+## MODIFIED Requirements
+
+### Requirement: Relationship-selected Lean evidence keeps conformance claims bounded
+
+The ECMA-376 registry SHALL bind relationship-selected Lean implementation and
+test claims only to edition 5 Part 1 §17.10.5 for direct typed
+`w:headerReference` bindings, §17.10.2 for direct typed
+`w:footerReference` bindings, §17.10.4 for selected `w:hdr` roots, and
+§17.10.3 for selected `w:ftr` roots. Registry `verifiedBy` entries SHALL name
+the actual Lean selector/executable and compiled or real-DOCX tests that
+exercise each claim.
+
+Safe internal target normalization, bounded repeated percent decoding with
+unsafe or ambiguous results rejected, package containment, section ordinal
+alignment, selector-observable section-count or ordered-slot failure,
+single-direct-body and terminal-section inventory constraints, deterministic
+ordering, shared-target deduplication, partial successful-evidence retention,
+structured failure aggregation, and certificate compatibility SHALL be
+identified as SafeDocX safety or evidence policies rather than consequences of
+those Part 1 clauses.
+The checker coverage ledger and generated conformance documentation SHALL state
+the exact relationship-selected surface, Transitional-only namespace policy,
+accepted XML/target subset, classic-ZIP-only binary index, required-main
+`not_run` boundary, unconditional ZIP64-extra rejection, method-specific flag
+masks, validated zero-payload directory-record policy, directory archive-limit
+charging and file/directory collision identity, trusted part-inventory
+omission, complete local-record span policy, selector-partitioned response
+bound, aggregate verifier/evidence limits, canonical main/relationship/
+footnotes/endnotes resource admission, metadata-before-decompression
+enforcement, bounded event-to-token parsing, typed failure reasons with
+equality-inclusive aggregate event classification, and exclusions.
+
+This change SHALL NOT add a full OPC, relationship-graph, content-type, XML
+Schema, inherited-role, pagination, rendering, field-evaluation, bookmark, or
+complete ECMA-376 claim. It SHALL NOT add unsupported Part 2 citations.
+
+#### Scenario: [LEAN-REL-CONFORMANCE-01] Binding and root citations match exercised structure
+
+- **WHEN** implementation or tests claim direct typed header/footer bindings or
+  selected header/footer roots
+- **THEN** their conformance evidence SHALL cite only the corresponding
+  registered Part 1 §§17.10.2, 17.10.3, 17.10.4, or 17.10.5
+- **AND** `verifiedBy` paths SHALL identify the Lean and test evidence that
+  actually exercises the claim
+
+#### Scenario: [LEAN-REL-CONFORMANCE-02] Selector safety remains repository policy
+
+- **WHEN** target normalization, package containment, ordinal alignment,
+  deterministic ordering, deduplication, failure aggregation, or certificate
+  compatibility is documented or tested
+- **THEN** it SHALL be labeled as a SafeDocX policy or verifier invariant
+- **AND** it SHALL NOT be attributed to the bounded header/footer Part 1 clauses
+
+#### Scenario: [LEAN-REL-CONFORMANCE-03] Coverage docs preserve explicit non-goals
+
+- **WHEN** protocol v4 coverage and generated conformance documentation are
+  checked
+- **THEN** they SHALL list direct explicit selected header/footer stories as
+  covered and fixed main/footnote/endnote stories as retained
+- **AND** they SHALL explicitly exclude inherited roles, unselected parts,
+  complete relationship/OPC/schema validation, pagination, rendering, and full
+  ECMA-376 conformance
+
+#### Scenario: [LEAN-REL-CONFORMANCE-04] Parser and resource policies are not ECMA maxima
+
+- **WHEN** coverage docs state Transitional-only namespaces, accepted
+  declarations/entities/ZIP methods/targets, classic-ZIP-only binary inventory,
+  ZIP64-extra/disk-start/flag/local-span policy, accepted directory-record
+  subset, required-main process boundary, selector-partitioned serialization
+  bound, canonical resource phases, metadata-before-decompression policy, or
+  numeric resource/evidence ceilings
+- **THEN** they SHALL identify those choices as bounded verifier policy
+- **AND** they SHALL NOT present rejected Strict syntax, unsupported OPC
+  features including ZIP64, or values above the ceilings as nonconformant with
+  ECMA-376
+
+#### Scenario: [LEAN-REL-CONFORMANCE-05] Resource admission is verifier policy
+
+- **WHEN** coverage documents describe metadata-first selected-target
+  admission, optional-note ordering, typed parser failures, or aggregate
+  XML-event stopping at or below the per-part ceiling
+- **THEN** they SHALL identify these as bounded SafeDocX verifier policies
+- **AND** they SHALL not attribute those limits or processing phases to the
+  cited header/footer clauses
+
+#### Scenario: [LEAN-REL-CONFORMANCE-06] Directory records remain verifier policy
+
+- **WHEN** coverage documents describe accepting validated zero-payload ZIP
+  directory records, charging them to archive limits and collision checks, and
+  omitting them from the trusted part inventory
+- **THEN** they SHALL identify the accepted subset and certificate boundary as
+  bounded SafeDocX verifier policy
+- **AND** they SHALL NOT present that policy as full OPC or ECMA-376
+  conformance

--- a/openspec/changes/accept-safe-opc-directory-records/tasks.md
+++ b/openspec/changes/accept-safe-opc-directory-records/tasks.md
@@ -1,0 +1,53 @@
+## 1. Lean ZIP classification and validation
+
+- [ ] 1.1 Make safe-name validation directory-aware only for one terminal slash,
+  then classify every central record from that slash, the DOS directory bit,
+  and recognized Unix file type; accept only unambiguous regular-file or
+  directory identities and continue rejecting every other empty segment plus
+  symlink/special types.
+- [ ] 1.2 Admit a directory record only when its central metadata uses stored
+  method `0` with zero CRC-32, compressed size, and expanded size, and its local
+  header agrees on raw name, flags, method, CRC, and sizes with a zero-byte
+  payload.
+- [ ] 1.3 Retain directories through entry/name limits, exact-name duplicate
+  checks, central/local validation, complete-local-span bounds, and overlap
+  checks; then omit them from the trusted OPC part inventory.
+- [ ] 1.4 Compute collision identity by removing exactly one trailing slash
+  from a validated directory name and reject every regular-file/directory
+  identity collision before inventory projection.
+
+## 2. Certificate and regression evidence
+
+- [ ] 2.1 Add focused compiled Lean fixtures for accepted DOS-only,
+  Unix-only, and consistently dual-marked empty directories.
+- [ ] 2.2 Add compiled adversarial fixtures for slash/attribute ambiguity,
+  contradictory Unix/DOS type signals, non-stored method, nonzero CRC or size,
+  central/local mismatch, payload, exact duplicate, file/directory collision,
+  span overlap, and archive-limit charging.
+- [ ] 2.3 Add a compiled public-certificate regression using the Word-authored
+  package that previously returned `not_run`; prove directory records are
+  absent from package-part evidence while ordinary selected parts still
+  determine `passed` or `failed`.
+- [ ] 2.4 Preserve process-level `not_run` for every rejected directory record
+  and verify that no partial v4/v6 or public passing evidence is published.
+
+## 3. Policy and conformance documentation
+
+- [ ] 3.1 Update the Lean checker coverage ledger and verifier/Tier 2
+  documentation with the exact accepted directory subset, collision policy,
+  trusted-inventory omission, archive charging, and certificate boundary.
+- [ ] 3.2 Keep directory-record acceptance labeled as bounded SafeDocX verifier
+  policy; add no OPC-completeness or ECMA-376 citation.
+- [ ] 3.3 Regenerate conformance documentation and update coverage drift checks
+  that currently require unconditional directory rejection.
+
+## 4. Acceptance checks
+
+- [ ] 4.1 Run `openspec validate accept-safe-opc-directory-records --strict`.
+- [ ] 4.2 Run `cd verification/lean && lake build`, the normalized axiom audit,
+  and the zero-`sorry` audit.
+- [ ] 4.3 Run focused compiled verifier and public-certificate regression tests.
+- [ ] 4.4 Run `npm run check:lean-xml-checker-coverage`,
+  `npm run check:spec-coverage`, `npm run check:conformance-citations`, and
+  `npm run check:conformance-doc`.
+- [ ] 4.5 Run the repository pre-submit command from `CONTRIBUTING.md`.


### PR DESCRIPTION
## Summary

- propose a bounded accepted subset for safe ZIP directory records in the compiled Lean DOCX checker
- require consistent trailing-slash plus DOS/Unix directory classification and central/local agreement
- require stored method, zero CRC/sizes/payload, archive-limit charging, span/overlap validation, duplicate rejection, and file/directory collision rejection
- omit validated directories from the trusted package-part inventory only after all safety checks pass
- require a public compiled-checker regression and accurate process-level `not_run` certificate boundary

## OpenSpec change

`accept-safe-opc-directory-records`

This modifies the canonical `docx-comparison` and `spec-compliance` requirements. It deliberately rejects ambiguous slash-only classification, contradictory attributes, multiple terminal slashes, payload-bearing directories, and identity collisions.

## Validation

- `openspec validate accept-safe-opc-directory-records --strict`
- `openspec show accept-safe-opc-directory-records --json --deltas-only` (exactly two parsed deltas)
- `git diff --check`
- rebased/current with `origin/main`

## Approval gate

No runtime or Lean implementation is included. Per repository OpenSpec policy, implementation must not begin until this proposal is reviewed and approved.

Ref #745