### PR TITLE
test(docx-core): close paragraph deletion coverage gaps

### DIFF
--- a/packages/docx-core/SUPPORT.md
+++ b/packages/docx-core/SUPPORT.md
@@ -12,7 +12,7 @@ The "OOXML revision element" column uses ECMA-376 element names from the tracked
 
 | Primitive / tool | Source path | OOXML revision element | Notes |
 | --- | --- | --- | --- |
-| `text.ts` — `replaceParagraphTextRange` | `packages/docx-core/src/primitives/text.ts` | `w:ins`, `w:del`, `w:rPrChange` | Run-level text replacement emits insertion/deletion wrappers, and formatting-aware replacements record the prior run properties with `w:rPrChange`. **Verified by [120.8] (#143) regression test (after #173).** |
+| `text.ts` — `replaceParagraphTextRange` | `packages/docx-core/src/primitives/text.ts` | `w:ins`, `w:del`, paragraph-mark `w:pPr/w:rPr/w:del`, `w:rPrChange` | Run-level text replacement emits insertion/deletion wrappers, full-paragraph tracked deletion marks the paragraph break so acceptance removes the emptied paragraph, and formatting-aware replacements record the prior run properties with `w:rPrChange`. **Verified by [120.8] (#143), #173, and #741 canonical-emission regressions.** |
 | `layout.ts` — `setParagraphSpacing` | `packages/docx-core/src/primitives/layout.ts` | `w:pPrChange` | Paragraph spacing mutations change paragraph properties, not spacer-paragraph structure. **Verified by [120.8] (#143) regression test.** |
 | `layout.ts` — `setTableRowHeight` | `packages/docx-core/src/primitives/layout.ts` | `w:trPrChange` | Row geometry changes belong under row-property revisions. **Verified by [120.8] (#143) regression test.** |
 | `layout.ts` — `setTableCellPadding` | `packages/docx-core/src/primitives/layout.ts` | `w:tcPrChange` | Cell padding changes belong under cell-property revisions. **Verified by [120.8] (#143) regression test.** |

--- a/packages/docx-core/src/integration/canonical-emission-regression.test.ts
+++ b/packages/docx-core/src/integration/canonical-emission-regression.test.ts
@@ -27,6 +27,10 @@ const sectionTest = test.conformance(
   { spec: 'ECMA-376', edition: 5, part: 1, section: '17.6.11' },
   { spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.5.32' },
 );
+const paragraphDeletionTest = test.conformance(
+  { spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.5.14' },
+  { spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.5.15' },
+);
 
 const AI_AUTHOR = 'SafeDocX';
 const FIXED_DATE = '2026-05-07T12:00:00Z';
@@ -188,6 +192,56 @@ describe('Canonical emission catalog', () => {
       expect(elementsByName(documentXml, 'b').length).toBeGreaterThan(0);
       const rPrChange = elementsByName(documentXml, 'rPrChange')[0]!;
       expect(rPrChange.getElementsByTagNameNS(W_NS, 'rPr')).toHaveLength(1);
+    });
+  });
+
+  paragraphDeletionTest('Table A: text.ts emits paragraph-mark deletion into an existing formatted rPr', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    let documentXml: string;
+
+    await given('a real-world title shape with existing paragraph-mark font and size properties', async () => {
+      const title = 'Mutual Non-Disclosure Agreement';
+      const { doc, paragraphIds } = await loadIndexedDoc(
+        await makeMinimalDocx(
+          '<w:p>' +
+            '<w:pPr><w:rPr><w:rFonts w:ascii="Georgia"/><w:sz w:val="44"/></w:rPr></w:pPr>' +
+            `<w:r><w:rPr><w:rFonts w:ascii="Georgia"/><w:sz w:val="44"/></w:rPr><w:t>${title}</w:t></w:r>` +
+          '</w:p>',
+        ),
+      );
+      const paragraph = doc.getParagraphElementById(paragraphIds[0]!);
+      expect(paragraph).toBeTruthy();
+
+      await when('the full title is deleted under tracked changes', async () => {
+        replaceParagraphTextRange(paragraph!, 0, title.length, '', createCtx());
+        ({ parts: { 'word/document.xml': documentXml } } = await toPartMap(doc, ['word/document.xml']));
+      });
+    });
+
+    await then('document.xml preserves formatting and carries separate run and paragraph-mark deletions', () => {
+      const deletions = elementsByName(documentXml, 'del');
+      const paragraphMarkDeletion = deletions.find(
+        (element) => (element.parentNode as Element | null)?.localName === 'rPr',
+      );
+      const runDeletion = deletions.find(
+        (element) => (element.parentNode as Element | null)?.localName === 'p',
+      );
+      const paragraphRPr = paragraphMarkDeletion?.parentNode as Element | undefined;
+
+      expect(paragraphMarkDeletion).toBeTruthy();
+      expect(runDeletion).toBeTruthy();
+      expect(wordAttr(paragraphMarkDeletion!, 'author')).toBe(AI_AUTHOR);
+      expect(wordAttr(paragraphMarkDeletion!, 'id')).not.toBe(wordAttr(runDeletion!, 'id'));
+      expect(paragraphRPr?.getElementsByTagNameNS(W_NS, 'rFonts')).toHaveLength(1);
+      expect(paragraphRPr?.getElementsByTagNameNS(W_NS, 'sz')).toHaveLength(1);
+      expect(Array.from(paragraphRPr!.children).map((child) => child.localName)).toEqual([
+        'del',
+        'rFonts',
+        'sz',
+      ]);
     });
   });
 

--- a/packages/docx-core/src/primitives/text.test.ts
+++ b/packages/docx-core/src/primitives/text.test.ts
@@ -4,6 +4,7 @@ import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
 import { parseXml } from './xml.js';
 import { OOXML, W } from './namespaces.js';
 import { SafeDocxError } from './errors.js';
+import { getDirectChildrenByName } from './dom-helpers.js';
 import { createRevisionContext, createRevisionIdState } from './track-changes-emitter.js';
 import { revisionEvidence, revisionEvidenceCases } from '../testing/revision-evidence.js';
 import {
@@ -51,15 +52,6 @@ function paragraphAt(doc: Document, index: number): Element {
 
 function serialize(node: Node): string {
   return new XMLSerializer().serializeToString(node);
-}
-
-function getDirectElement(parent: Element, localName: string): Element | null {
-  return Array.from(parent.childNodes).find(
-    (child): child is Element =>
-      child.nodeType === 1 &&
-      (child as Element).namespaceURI === W_NS &&
-      (child as Element).localName === localName,
-  ) ?? null;
 }
 
 // ── getParagraphRuns — field-code state machine ─────────────────────
@@ -958,9 +950,9 @@ describe('replaceParagraphTextRange tracked-change emission', () => {
     });
 
     await then('the content and paragraph mark carry separate deletion revisions', () => {
-      const pPr = getDirectElement(p, W.pPr);
-      const paragraphRPr = getDirectElement(pPr!, W.rPr);
-      const paragraphMarkDeletion = getDirectElement(paragraphRPr!, 'del');
+      const pPr = getDirectChildrenByName(p, W.pPr)[0];
+      const paragraphRPr = getDirectChildrenByName(pPr!, W.rPr)[0];
+      const paragraphMarkDeletion = getDirectChildrenByName(paragraphRPr!, 'del')[0];
       const runDeletion = Array.from(p.childNodes).find(
         (child): child is Element =>
           child.nodeType === 1 &&
@@ -972,7 +964,56 @@ describe('replaceParagraphTextRange tracked-change emission', () => {
       expect(paragraphMarkDeletion).toBeTruthy();
       expect(paragraphMarkDeletion?.getAttribute('w:author')).toBe('SafeDocX AI');
       expect(paragraphMarkDeletion?.getAttribute('w:id')).not.toBe(runDeletion?.getAttribute('w:id'));
-      expect(getDirectElement(pPr!, W.numPr)).toBeTruthy();
+      expect(getDirectChildrenByName(pPr!, W.numPr)[0]).toBeTruthy();
+    });
+  });
+
+  paragraphDeletionTest('adds paragraph deletion metadata to existing paragraph-mark formatting', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    let p: Element;
+
+    await given('a formatted paragraph whose pPr already contains paragraph-mark rPr', () => {
+      const doc = makeDoc(
+        '<w:p>' +
+          '<w:pPr><w:rPr><w:rFonts w:ascii="Georgia"/><w:sz w:val="44"/></w:rPr></w:pPr>' +
+          '<w:r><w:rPr><w:rFonts w:ascii="Georgia"/><w:sz w:val="44"/></w:rPr>' +
+          '<w:t>Mutual Non-Disclosure Agreement</w:t></w:r>' +
+        '</w:p>',
+      );
+      p = firstParagraph(doc);
+    });
+
+    await when('the complete visible text is deleted under tracked changes', () => {
+      replaceParagraphTextRange(
+        p,
+        0,
+        'Mutual Non-Disclosure Agreement'.length,
+        '',
+        createRevisionContext({
+          author: 'SafeDocX AI',
+          date: '2026-07-29T12:00:00Z',
+          idState: createRevisionIdState(),
+        }),
+      );
+    });
+
+    await then('the existing paragraph-mark formatting is preserved ahead of one deletion marker', () => {
+      const pPr = getDirectChildrenByName(p, W.pPr)[0]!;
+      const paragraphRPr = getDirectChildrenByName(pPr, W.rPr)[0]!;
+      const paragraphMarkDeletions = getDirectChildrenByName(paragraphRPr, 'del');
+
+      expect(getDirectChildrenByName(paragraphRPr, W.rFonts)).toHaveLength(1);
+      expect(getDirectChildrenByName(paragraphRPr, 'sz')).toHaveLength(1);
+      expect(paragraphMarkDeletions).toHaveLength(1);
+      expect(paragraphMarkDeletions[0]!.getAttribute('w:author')).toBe('SafeDocX AI');
+      expect(Array.from(paragraphRPr.children).map((child) => child.localName)).toEqual([
+        'del',
+        W.rFonts,
+        'sz',
+      ]);
     });
   });
 

--- a/packages/docx-core/src/primitives/validate_document.test.ts
+++ b/packages/docx-core/src/primitives/validate_document.test.ts
@@ -1,0 +1,73 @@
+import { expect } from 'vitest';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { parseXml } from './xml.js';
+import { OOXML } from './namespaces.js';
+import { validateDocument } from './validate_document.js';
+
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({ feature: 'Document Validation', story: 'Tracked-change structure' });
+const paragraphDeletionTest = test.conformance(
+  { spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.5.15' },
+);
+
+function documentWithBody(bodyXml: string): Document {
+  return parseXml(
+    `<w:document xmlns:w="${OOXML.W_NS}"><w:body>${bodyXml}</w:body></w:document>`,
+  );
+}
+
+paragraphDeletionTest('accepts an empty paragraph-mark deletion as revision metadata', async ({
+  given,
+  when,
+  then,
+}: AllureBddContext) => {
+  let result: ReturnType<typeof validateDocument>;
+
+  await given('a paragraph with a legal empty deletion marker in its paragraph-mark rPr', () => {
+    const doc = documentWithBody(
+      '<w:p><w:pPr><w:rPr>' +
+        '<w:del w:id="2" w:author="SafeDocX" w:date="2026-07-29T12:00:00Z"/>' +
+        '<w:rFonts w:ascii="Georgia"/><w:sz w:val="44"/>' +
+      '</w:rPr></w:pPr><w:del w:id="1" w:author="SafeDocX" w:date="2026-07-29T12:00:00Z">' +
+        '<w:r><w:delText>Delete me</w:delText></w:r>' +
+      '</w:del></w:p>',
+    );
+
+    result = validateDocument(doc);
+  });
+
+  await when('structural validation inspects tracked-change elements', () => {});
+
+  await then('it does not mistake paragraph-mark metadata for an empty wrapper', () => {
+    expect(result.warnings).toEqual([]);
+    expect(result.isValid).toBe(true);
+  });
+});
+
+test('still warns for an empty run-level tracked-change wrapper', async ({
+  given,
+  when,
+  then,
+}: AllureBddContext) => {
+  let result: ReturnType<typeof validateDocument>;
+
+  await given('an empty deletion wrapper at paragraph content level', () => {
+    const doc = documentWithBody(
+      '<w:p><w:del w:id="7" w:author="SafeDocX" w:date="2026-07-29T12:00:00Z"/></w:p>',
+    );
+    result = validateDocument(doc);
+  });
+
+  await when('structural validation inspects the wrapper', () => {});
+
+  await then('the empty-wrapper warning remains active', () => {
+    expect(result.warnings).toEqual([
+      expect.objectContaining({
+        code: 'EMPTY_TRACKED_CHANGE',
+        context: 'element=w:del, id=7',
+      }),
+    ]);
+    expect(result.isValid).toBe(false);
+  });
+});

--- a/packages/docx-core/src/primitives/validate_document.ts
+++ b/packages/docx-core/src/primitives/validate_document.ts
@@ -78,6 +78,30 @@ function checkOrphanedBookmarks(body: Element): ValidationWarning[] {
 const TC_LOCALS = ['ins', 'del', 'moveFrom', 'moveTo'];
 const REQUIRED_TC_ATTRS = ['id', 'author', 'date'];
 
+/**
+ * Paragraph-mark revisions are empty marker elements under w:p/w:pPr/w:rPr,
+ * not wrappers around child content.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.5.15
+ * @see https://github.com/UseJunior/safe-docx/issues/741
+ */
+function isParagraphMarkTrackedChange(el: Element): boolean {
+  const rPr = el.parentNode;
+  const pPr = rPr?.parentNode;
+  const paragraph = pPr?.parentNode;
+  return (
+    rPr?.nodeType === 1 &&
+    (rPr as Element).namespaceURI === OOXML.W_NS &&
+    (rPr as Element).localName === W.rPr &&
+    pPr?.nodeType === 1 &&
+    (pPr as Element).namespaceURI === OOXML.W_NS &&
+    (pPr as Element).localName === W.pPr &&
+    paragraph?.nodeType === 1 &&
+    (paragraph as Element).namespaceURI === OOXML.W_NS &&
+    (paragraph as Element).localName === W.p
+  );
+}
+
 function checkTrackedChangeWrappers(body: Element): ValidationWarning[] {
   const warnings: ValidationWarning[] = [];
 
@@ -103,7 +127,7 @@ function checkTrackedChangeWrappers(body: Element): ValidationWarning[] {
         if (c.nodeType === 1) { hasChildElement = true; break; }
         c = c.nextSibling;
       }
-      if (!hasChildElement) {
+      if (!hasChildElement && !isParagraphMarkTrackedChange(el)) {
         const tcId = getWAttr(el, 'id') ?? '?';
         warnings.push({
           code: 'EMPTY_TRACKED_CHANGE',


### PR DESCRIPTION
## Summary

Fix-forward for #757 / #741.

- document the paragraph-mark deletion shape in the tracked-change support matrix
- add canonical and primitive regressions for full deletion when paragraph-mark formatting already exists
- reuse the shared direct-child DOM helper
- teach document validation that paragraph-mark revisions are legal empty metadata elements while preserving warnings for empty run-level wrappers

## Why

The advisory review on #757 identified the missing support-matrix and canonical-emission evidence. A real Common Paper NDA smoke then exposed a validator false positive: the emitted `w:pPr/w:rPr/w:del` was structurally correct, but validation treated it as an empty tracked-change wrapper.

## Validation

- mandatory build and workspace lint passed
- full core test suite passed outside sandbox: 127 files, 1,301 passed, 2 expected failures, 15 skipped
- all other workspace test suites passed in the pre-submit run
- spec coverage and conformance citation/document checks passed
- real `tests/test_documents/open-agreements/common-paper-mutual-nda.docx` title deletion emitted distinct run/paragraph-mark revisions, preserved existing paragraph-mark formatting, validated cleanly, and accepted to 49 paragraphs

Ref: #741
Ref: #757