### PR TITLE
refactor(verification): establish protocol v7 proof foundations

### DIFF
--- a/openspec/changes/verify-lean-comment-range-topology/tasks.md
+++ b/openspec/changes/verify-lean-comment-range-topology/tasks.md
@@ -29,10 +29,10 @@
   aggregate/serialization soundness.
 - [x] 2.2 Prove all seven semantic targets and their recursive closures
   axiom-free; keep the repository at zero `sorry`.
-- [ ] 2.3 Implement typed package/source/event adapters and prove direct
+- [x] 2.3 Implement typed package/source/event adapters and prove direct
   retained `visitedEvents` projection equivalent to the independent scan
   without copied whole-event lists.
-- [ ] 2.4 Add separately named source, marker-scan, definition-realization,
+- [x] 2.4 Add separately named source, marker-scan, definition-realization,
   incomplete, UTF-8/JSON, and production refinements with the six exact
   propositions pinned in the design, using exactly
   `[propext, Classical.choice, Quot.sound]` and the existing normalized

--- a/openspec/changes/verify-lean-comment-range-topology/tasks.md
+++ b/openspec/changes/verify-lean-comment-range-topology/tasks.md
@@ -29,10 +29,10 @@
   aggregate/serialization soundness.
 - [x] 2.2 Prove all seven semantic targets and their recursive closures
   axiom-free; keep the repository at zero `sorry`.
-- [x] 2.3 Implement typed package/source/event adapters and prove direct
+- [ ] 2.3 Implement typed package/source/event adapters and prove direct
   retained `visitedEvents` projection equivalent to the independent scan
   without copied whole-event lists.
-- [x] 2.4 Add separately named source, marker-scan, definition-realization,
+- [ ] 2.4 Add separately named source, marker-scan, definition-realization,
   incomplete, UTF-8/JSON, and production refinements with the six exact
   propositions pinned in the design, using exactly
   `[propext, Classical.choice, Quot.sound]` and the existing normalized

--- a/scripts/check_lean_comment_semantics_dependencies.mjs
+++ b/scripts/check_lean_comment_semantics_dependencies.mjs
@@ -12,6 +12,8 @@ const semanticTargets = [
   'Tier2.CommentReferenceIntegrity.Typed.typed_comment_marker_scan_evidence_exact',
   'Tier2.CommentReferenceIntegrity.Typed.typed_package_comment_range_integrity_sound',
   'Tier2.CommentReferenceIntegrity.Typed.typed_incomplete_comment_range_zero_evidence_sound',
+  'Tier2.CommentReferenceIntegrity.Typed.typed_comment_side_pass_v7_of_checks',
+  'Tier2.CommentReferenceIntegrity.Typed.typed_all_comment_range_sides_pass_v7_of_checks',
   'Tier2.CommentReferenceIntegrity.Typed.typed_comment_range_aggregate_pass_sound',
   'Tier2.CommentReferenceIntegrity.Typed.typed_invalid_topology_witnesses_are_canonical',
   'Tier2.CommentReferenceIntegrity.Typed.typed_duplicate_reference_aggregate_witness_rejected',

--- a/scripts/check_lean_xml_checker_coverage.mjs
+++ b/scripts/check_lean_xml_checker_coverage.mjs
@@ -328,7 +328,7 @@ const typedParsedPartBody = typedCommentIntegrity.slice(
   typedCommentIntegrity.indexOf('def TypedParsedPartOf'),
 );
 const typedProductionEventBody = executable.slice(
-  executable.indexOf('def typedXmlEventOfProduction'),
+  executable.indexOf('def typedXmlAttributeOfProduction'),
   executable.indexOf('def typedJsonOfProductionFuel'),
 );
 if (/\.data\.toList\s*=\s*/u.test(typedExtractionBody) ||

--- a/scripts/check_lean_xml_checker_coverage.mjs
+++ b/scripts/check_lean_xml_checker_coverage.mjs
@@ -28,6 +28,8 @@ const leanWorkflowPath = join(root, '.github/workflows/lean-build.yml');
 const noteWitnessesPath = join(root, 'verification/lean/Tier2/NoteReferenceIntegrityWitnesses.lean');
 const executablePath = join(root, 'verification/lean/LeanDocxChecker.lean');
 const ordinaryEnvelopePath = join(root, 'verification/lean/ProtocolV7OrdinaryEnvelopeWitness.lean');
+const protocolV7ProjectionDriftWitnessesPath = join(
+  root, 'verification/lean/ProtocolV7ProjectionDriftWitnesses.lean');
 const decoderPath = join(root, 'packages/docx-compare/src/baselines/atomizer/leanXmlVerifier.ts');
 
 const ledger = JSON.parse(readFileSync(ledgerPath, 'utf8'));
@@ -46,6 +48,8 @@ const leanWorkflow = readFileSync(leanWorkflowPath, 'utf8');
 const noteWitnesses = readFileSync(noteWitnessesPath, 'utf8');
 const executable = readFileSync(executablePath, 'utf8');
 const ordinaryEnvelope = readFileSync(ordinaryEnvelopePath, 'utf8');
+const protocolV7ProjectionDriftWitnesses = readFileSync(
+  protocolV7ProjectionDriftWitnessesPath, 'utf8');
 const decoder = readFileSync(decoderPath, 'utf8');
 
 const errors = [];
@@ -449,6 +453,19 @@ for (const required of [
   }
 }
 for (const required of [
+  '"outcome-pass"',
+  '"outcome-evaluated-fail"',
+  '"outcome-incomplete-before-scan"',
+  '"outcome-incomplete-after-scan"',
+  '"outcome-forged-pass"',
+  '"outcome-forged-fail"',
+  '"outcome-forged-incomplete"',
+]) {
+  if (!protocolV7ProjectionDriftWitnesses.includes(required)) {
+    errors.push(`protocol-v7 production drift witnesses omit ${required}`);
+  }
+}
+for (const required of [
   'typed_duplicate_reference_aggregate_witness_rejected',
   'typed_orphan_endpoint_aggregate_witness_rejected',
   'typed_reversed_range_aggregate_witness_rejected',
@@ -479,6 +496,55 @@ const runRequestCoreV7Body = executable.slice(
 );
 if (runRequestCoreV7Body.includes('typedProtocolV6ResponseOfJson')) {
   errors.push('protocol-v7 production adapter must not use the protocol-v6 JSON decoder');
+}
+const productionTypedCommentChecksV7Body = executable.slice(
+  executable.indexOf('def productionTypedCommentChecksV7'),
+  executable.indexOf('def runRequestCoreV7'),
+);
+for (const forbidden of [
+  'typedRequestOfRunRequestCoreV7',
+  'typedRequestOfProductionV7',
+  'productionActualBridgeRefinementChecksV7',
+  'productionXmlEventsExactCheckFrom',
+  'typedXmlEventsOfProduction',
+  'typedAllCommentRangeSidesPassV7',
+]) {
+  if (productionTypedCommentChecksV7Body.includes(forbidden)) {
+    errors.push(
+      `protocol-v7 runtime gate must not copy or rescan whole typed events via ${forbidden}`,
+    );
+  }
+}
+for (const required of [
+  'productionCommentOutcomeChecksV7',
+  'result.typedProjectionCheck',
+  'protocolV6JsonProjectionCheck result.response result.responsePassed',
+  'result.response.compress.toUTF8.data.toList',
+]) {
+  if (!productionTypedCommentChecksV7Body.includes(required)) {
+    errors.push(`protocol-v7 runtime gate omits ${required}`);
+  }
+}
+const productionCommentOutcomeCheckV7Body = executable.slice(
+  executable.indexOf('def productionCommentOutcomeCheckAtV7'),
+  executable.indexOf('def productionCommentOutcomeChecksV7'),
+);
+for (const required of [
+  'if evidence.complete',
+  'evidence.productionIntegrityPassed',
+  'evidence.inventory.status == "passed"',
+  'evidence.inventory.status == "failed"',
+  'evidence.inventory.status == "not_evaluated"',
+  'evidence.markerScanInvocationCount == 0',
+  'evidence.markerScanInvocationCount == 1',
+  'evidence.markerScan.any (·.crossing.isSome)',
+]) {
+  if (!productionCommentOutcomeCheckV7Body.includes(required)) {
+    errors.push(`protocol-v7 outcome-sensitive runtime gate omits ${required}`);
+  }
+}
+if (productionTypedCommentChecksV7Body.includes('!result.responsePassed ||')) {
+  errors.push('protocol-v7 runtime refinements must not be skipped on failed responses');
 }
 for (const theorem of [
   'typedByteArrayEqCheck_true_iff',

--- a/scripts/check_lean_xml_checker_coverage.mjs
+++ b/scripts/check_lean_xml_checker_coverage.mjs
@@ -501,6 +501,12 @@ const productionTypedCommentChecksV7Body = executable.slice(
   executable.indexOf('def productionTypedCommentChecksV7'),
   executable.indexOf('def runRequestCoreV7'),
 );
+const productionPassingProtocolV7ProjectionCheckBody = executable.slice(
+  executable.indexOf('def productionPassingProtocolV7ProjectionCheck'),
+  executable.indexOf(
+    'theorem production_passing_protocol_v7_projection_check_sound',
+  ),
+);
 for (const forbidden of [
   'typedRequestOfRunRequestCoreV7',
   'typedRequestOfProductionV7',
@@ -516,9 +522,33 @@ for (const forbidden of [
   }
 }
 for (const required of [
+  'typedRequestOfRunRequestCoreV7',
+  'protocolV7JsonProjectionCheck',
+  'canonicalTypedResponseV7',
+]) {
+  if (!productionPassingProtocolV7ProjectionCheckBody.includes(required)) {
+    errors.push(`passing protocol-v7 projection gate omits ${required}`);
+  }
+}
+for (const forbidden of [
+  'productionActualBridgeRefinementChecksV7',
+  'productionXmlEventsExactCheckFrom',
+  'typedXmlEventsOfProduction',
+  'typedAllCommentRangeSidesPassV7',
+  'retainedCommentMarkerScanForRelationshipV7',
+  '.visitedEvents.toList',
+]) {
+  if (productionPassingProtocolV7ProjectionCheckBody.includes(forbidden)) {
+    errors.push(
+      `passing protocol-v7 projection gate must not copy or rescan evidence via ${forbidden}`,
+    );
+  }
+}
+for (const required of [
   'productionCommentOutcomeChecksV7',
   'result.typedProjectionCheck',
   'protocolV6JsonProjectionCheck result.response result.responsePassed',
+  'productionPassingProtocolV7ProjectionCheck request result',
   'result.response.compress.toUTF8.data.toList',
 ]) {
   if (!productionTypedCommentChecksV7Body.includes(required)) {

--- a/verification/lean/CommentSemanticDependencyAudit.lean
+++ b/verification/lean/CommentSemanticDependencyAudit.lean
@@ -54,6 +54,8 @@ def targets : List Name := [
   ``Tier2.CommentReferenceIntegrity.Typed.typed_comment_marker_scan_evidence_exact,
   ``Tier2.CommentReferenceIntegrity.Typed.typed_package_comment_range_integrity_sound,
   ``Tier2.CommentReferenceIntegrity.Typed.typed_incomplete_comment_range_zero_evidence_sound,
+  ``Tier2.CommentReferenceIntegrity.Typed.typed_comment_side_pass_v7_of_checks,
+  ``Tier2.CommentReferenceIntegrity.Typed.typed_all_comment_range_sides_pass_v7_of_checks,
   ``Tier2.CommentReferenceIntegrity.Typed.typed_comment_range_aggregate_pass_sound,
   ``Tier2.CommentReferenceIntegrity.Typed.typed_invalid_topology_witnesses_are_canonical,
   ``Tier2.CommentReferenceIntegrity.Typed.typed_duplicate_reference_aggregate_witness_rejected,
@@ -85,6 +87,8 @@ end CommentSemanticDependencyAudit
 #print axioms Tier2.CommentReferenceIntegrity.Typed.typed_comment_marker_scan_evidence_exact
 #print axioms Tier2.CommentReferenceIntegrity.Typed.typed_package_comment_range_integrity_sound
 #print axioms Tier2.CommentReferenceIntegrity.Typed.typed_incomplete_comment_range_zero_evidence_sound
+#print axioms Tier2.CommentReferenceIntegrity.Typed.typed_comment_side_pass_v7_of_checks
+#print axioms Tier2.CommentReferenceIntegrity.Typed.typed_all_comment_range_sides_pass_v7_of_checks
 #print axioms Tier2.CommentReferenceIntegrity.Typed.typed_comment_range_aggregate_pass_sound
 #print axioms Tier2.CommentReferenceIntegrity.Typed.typed_invalid_topology_witnesses_are_canonical
 #print axioms Tier2.CommentReferenceIntegrity.Typed.typed_duplicate_reference_aggregate_witness_rejected

--- a/verification/lean/LeanDocxChecker.lean
+++ b/verification/lean/LeanDocxChecker.lean
@@ -95,28 +95,287 @@ def maxProtocolV6JsonResponseBytes : Nat := 2626368
 def maxProtocolV6ResponseBytes : Nat := 2626369
 
 def typedBoundedBytesOfString (value : String) : BoundedBytes :=
-  let bytes := value.toUTF8.toList
+  let bytes := value.toUTF8.data.toList
   { bytes, limit := bytes.length, admitted := Nat.le_refl _ }
 
 def typedBoundedByteArrayOfString (value : String) : BoundedByteArray :=
   let bytes := value.toUTF8
   { bytes, limit := bytes.size, admitted := Nat.le_refl _ }
 
+theorem bounded_bytes_ext
+    (left right : BoundedBytes)
+    (hBytes : left.bytes = right.bytes)
+    (hLimit : left.limit = right.limit) :
+    left = right := by
+  cases left
+  cases right
+  simp_all
+
+theorem string_eq_of_utf8_data_to_list_eq
+    (left right : String)
+    (hBytes :
+      left.toUTF8.data.toList = right.toUTF8.data.toList) :
+    left = right := by
+  apply String.toByteArray_inj.mp
+  rw [← String.toUTF8_eq_toByteArray,
+    ← String.toUTF8_eq_toByteArray]
+  apply ByteArray.ext
+  exact Array.toList_inj.mp hBytes
+
+def typedXmlNameOfProduction (value : String) : BoundedBytes :=
+  if value == wmlNamespace then typedWmlNamespace
+  else if value == "id" then typedLiteral [105,100]
+  else if value == "comment" then
+    typedLiteral [99,111,109,109,101,110,116]
+  else if value == "commentRangeStart" then
+    typedLiteral [99,111,109,109,101,110,116,82,97,110,103,101,83,116,97,114,116]
+  else if value == "commentRangeEnd" then
+    typedLiteral [99,111,109,109,101,110,116,82,97,110,103,101,69,110,100]
+  else if value == "commentReference" then
+    typedLiteral [99,111,109,109,101,110,116,82,101,102,101,114,101,110,99,101]
+  else typedBoundedBytesOfString value
+
+theorem typed_xml_name_of_production_bytes (value : String) :
+    (typedXmlNameOfProduction value).bytes =
+      value.toUTF8.data.toList := by
+  by_cases hWml : value = wmlNamespace
+  · subst value
+    native_decide
+  · by_cases hId : value = "id"
+    · subst value
+      native_decide
+    · by_cases hComment : value = "comment"
+      · subst value
+        native_decide
+      · by_cases hStart : value = "commentRangeStart"
+        · subst value
+          native_decide
+        · by_cases hEnd : value = "commentRangeEnd"
+          · subst value
+            native_decide
+          · by_cases hReference : value = "commentReference"
+            · subst value
+              native_decide
+            · simp [typedXmlNameOfProduction, hWml, hId, hComment,
+                hStart, hEnd, hReference, typedBoundedBytesOfString]
+
+theorem typed_xml_name_of_production_reflects_equality (left right : String) :
+    (typedXmlNameOfProduction left).bytes =
+        (typedXmlNameOfProduction right).bytes ↔
+      left = right := by
+  rw [typed_xml_name_of_production_bytes,
+    typed_xml_name_of_production_bytes]
+  constructor
+  · exact string_eq_of_utf8_data_to_list_eq left right
+  · intro h
+    exact congrArg (fun value => value.toUTF8.data.toList) h
+
+def typedXmlAttributeOfProduction
+    (item : ExpandedXmlAttribute) : TypedXmlAttribute := {
+  namespaceUri := typedXmlNameOfProduction item.uri
+  localName := typedXmlNameOfProduction item.localName
+  value := typedBoundedByteArrayOfString item.value
+}
+
+theorem mapTR_loop_eq {α β : Type} (f : α → β)
+    (values : List α) (acc : List β) :
+    List.mapTR.loop f values acc = acc.reverse ++ values.map f := by
+  induction values generalizing acc with
+  | nil => simp [List.mapTR.loop]
+  | cons head tail ih =>
+      rw [List.mapTR.loop, ih]
+      simp
+
+theorem mapTR_eq_map {α β : Type} (f : α → β) (values : List α) :
+    values.mapTR f = values.map f := by
+  simp [List.mapTR, mapTR_loop_eq]
+
+theorem typed_wml_namespace_adapter :
+    typedWmlNamespace =
+      typedXmlNameOfProduction wmlNamespace := by
+  native_decide
+
+theorem typed_id_local_name_adapter :
+    typedLiteral [105, 100] = typedXmlNameOfProduction "id" := by
+  native_decide
+
+theorem typed_attribute_match_of_production
+    (item : ExpandedXmlAttribute) :
+    (decide
+        ((typedXmlAttributeOfProduction item).namespaceUri.bytes =
+          typedWmlNamespace.bytes) &&
+      decide
+        ((typedXmlAttributeOfProduction item).localName.bytes =
+          (typedLiteral [105, 100]).bytes)) =
+    (item.uri == wmlNamespace && item.localName == "id") := by
+  apply Bool.eq_iff_iff.mpr
+  simp only [Bool.and_eq_true, decide_eq_true_eq, beq_iff_eq]
+  rw [typed_wml_namespace_adapter, typed_id_local_name_adapter]
+  simp only [typedXmlAttributeOfProduction,
+    typed_xml_name_of_production_reflects_equality]
+
+theorem expanded_wml_attribute_loop_as_find
+    (attributes : List ExpandedXmlAttribute) :
+    Tier2.NoteReferenceIntegrity.expandedWmlAttribute?.loop
+        "id" attributes =
+      (attributes.find? fun item =>
+        item.uri == wmlNamespace &&
+          item.localName == "id").map (·.value) := by
+  induction attributes with
+  | nil => rfl
+  | cons head tail ih =>
+      simp [Tier2.NoteReferenceIntegrity.expandedWmlAttribute?.loop, ih]
+      by_cases h :
+          head.uri = wmlNamespace ∧
+            head.localName = "id"
+      · simp [h]
+      · simp [h]
+
+theorem expanded_wml_attribute_as_find
+    (attributes : List ExpandedXmlAttribute) :
+    Tier2.NoteReferenceIntegrity.expandedWmlAttribute?
+        attributes "id" =
+      (attributes.find? fun item =>
+        item.uri == wmlNamespace &&
+          item.localName == "id").map (·.value) := by
+  exact expanded_wml_attribute_loop_as_find attributes
+
+theorem typed_attribute_value_of_production
+    (attributes : List ExpandedXmlAttribute) :
+    typedAttributeValue?
+        (typedDefinitionScanInputV7 [])
+        (attributes.mapTR typedXmlAttributeOfProduction) =
+      (Tier2.NoteReferenceIntegrity.expandedWmlAttribute?
+        attributes "id").map typedBoundedBytesOfString := by
+  rw [mapTR_eq_map]
+  induction attributes with
+  | nil => rfl
+  | cons head tail ih =>
+      simp only [List.map_cons, typedAttributeValue?, List.find?_cons,
+        typedDefinitionScanInputV7]
+      split
+      · rename_i hTyped
+        have h :
+            head.uri == wmlNamespace &&
+              head.localName == "id" := by
+          rw [← typed_attribute_match_of_production head]
+          exact hTyped
+        simp only [Option.map_some]
+        rw [expanded_wml_attribute_as_find]
+        rw [List.find?_cons, h]
+        simp only [Option.map_some]
+        congr 1
+      · rename_i hTyped
+        have hRaw :
+            (head.uri == wmlNamespace &&
+              head.localName == "id") = false := by
+          have hMatch := typed_attribute_match_of_production head
+          exact hMatch.symm.trans hTyped
+        rw [expanded_wml_attribute_as_find, List.find?_cons, hRaw]
+        simp only [Option.map_map]
+        simp only [typedAttributeValue?,
+          typedDefinitionScanInputV7] at ih
+        rw [expanded_wml_attribute_as_find, Option.map_map] at ih
+        exact ih
+
+theorem typed_comment_local_name_adapter :
+    typedLiteral [99,111,109,109,101,110,116] =
+      typedXmlNameOfProduction "comment" := by
+  native_decide
+
+theorem typed_definition_match_of_production
+    (uri localName : String) :
+    (decide
+        ((typedXmlNameOfProduction uri).bytes =
+          typedWmlNamespace.bytes) &&
+      decide
+        ((typedXmlNameOfProduction localName).bytes =
+          (typedLiteral [99,111,109,109,101,110,116]).bytes)) =
+    (uri == wmlNamespace && localName == "comment") := by
+  apply Bool.eq_iff_iff.mpr
+  simp only [Bool.and_eq_true, decide_eq_true_eq, beq_iff_eq]
+  rw [typed_wml_namespace_adapter,
+    typed_comment_local_name_adapter]
+  simp only [typed_xml_name_of_production_reflects_equality]
+
 def typedXmlEventOfProduction (eventOrdinal : Nat) : XmlEvent → TypedXmlEvent
   | .startElement uri localName attributes depth selfClosing =>
-      .startElement (typedBoundedBytesOfString uri)
-        (typedBoundedBytesOfString localName)
-        (attributes.mapTR fun item => {
-          namespaceUri := typedBoundedBytesOfString item.uri
-          localName := typedBoundedBytesOfString item.localName
-          value := typedBoundedByteArrayOfString item.value
-        })
+      .startElement (typedXmlNameOfProduction uri)
+        (typedXmlNameOfProduction localName)
+        (attributes.mapTR typedXmlAttributeOfProduction)
         depth selfClosing eventOrdinal
   | .endElement uri localName depth =>
-      .endElement (typedBoundedBytesOfString uri)
-        (typedBoundedBytesOfString localName) depth eventOrdinal
+      .endElement (typedXmlNameOfProduction uri)
+        (typedXmlNameOfProduction localName) depth eventOrdinal
   | .text value depth =>
       .text (typedBoundedByteArrayOfString value) depth eventOrdinal
+
+theorem typed_definition_candidate_of_production
+    (eventOrdinal : Nat) (event : XmlEvent) :
+    typedDefinitionCandidate? (typedDefinitionScanInputV7 [])
+        (typedXmlEventOfProduction eventOrdinal event) =
+      (Tier2.CommentReferenceIntegrity.commentDefinitionCandidate? event).map
+        (fun candidate =>
+          (candidate.1.map typedBoundedBytesOfString, candidate.2)) := by
+  cases event with
+  | startElement uri localName attributes depth selfClosing =>
+      simp only [typedXmlEventOfProduction, typedDefinitionCandidate?,
+        typedDefinitionScanInputV7,
+        Tier2.CommentReferenceIntegrity.commentDefinitionCandidate?]
+      split
+      · rename_i hTyped
+        have hRaw :
+            (uri == wmlNamespace && localName == "comment") = true := by
+          have hMatch :=
+            typed_definition_match_of_production uri localName
+          exact hMatch.symm.trans hTyped
+        simp only [hRaw, if_true, Option.map_some]
+        change some
+            (typedAttributeValue? (typedDefinitionScanInputV7 [])
+              (attributes.mapTR typedXmlAttributeOfProduction),
+              depth == 1) =
+          some
+            ((Tier2.NoteReferenceIntegrity.expandedWmlAttribute?
+              attributes "id").map typedBoundedBytesOfString,
+              depth == 1)
+        rw [typed_attribute_value_of_production]
+      · rename_i hTyped
+        have hTypedFalse :
+            (decide
+                ((typedXmlNameOfProduction uri).bytes =
+                  typedWmlNamespace.bytes) &&
+              decide
+                ((typedXmlNameOfProduction localName).bytes =
+                  (typedLiteral
+                    [99,111,109,109,101,110,116]).bytes)) =
+              false :=
+          Bool.eq_false_iff.mpr hTyped
+        have hRaw :
+            (uri == wmlNamespace && localName == "comment") = false := by
+          have hMatch :=
+            typed_definition_match_of_production uri localName
+          exact hMatch.symm.trans hTypedFalse
+        simp [hRaw]
+  | endElement uri localName depth =>
+      rfl
+  | text value depth =>
+      rfl
+
+def typedXmlEventsOfProductionSpecV7 :
+    Nat → List XmlEvent → List TypedXmlEvent
+  | _, [] => []
+  | ordinal, event :: rest =>
+      typedXmlEventOfProduction ordinal event ::
+        typedXmlEventsOfProductionSpecV7 (ordinal + 1) rest
+
+theorem typed_xml_events_of_production_spec_v7_length
+    (ordinal : Nat) (events : List XmlEvent) :
+    (typedXmlEventsOfProductionSpecV7 ordinal events).length = events.length := by
+  induction events generalizing ordinal with
+  | nil => rfl
+  | cons _ rest hInduction =>
+      simp only [typedXmlEventsOfProductionSpecV7, List.length_cons,
+        hInduction]
 
 def typedJsonOfProductionFuel : Nat → Json → TypedJson
   | 0, _ => .null
@@ -235,15 +494,15 @@ def ExecutableSelectorRefinesTyped
     (typedCommentType : BoundedBytes)
     (typedRelationships : List TypedRelationship) : Prop :=
   typedCommentType.bytes =
-      Tier2.CommentReferenceIntegrity.commentsRelationshipType.toUTF8.toList ∧
+      Tier2.CommentReferenceIntegrity.commentsRelationshipType.toUTF8.data.toList ∧
   (typedRelationships.map fun relationship =>
       (relationship.ordinal, relationship.relationshipType.bytes,
         relationship.relationshipId.bytes, relationship.rawTarget.bytes,
         relationship.rawTargetMode.map (·.bytes))) =
     (pkg.relationshipRecords.zipIdx.map fun item =>
-      (item.2, item.1.relationshipType.toUTF8.toList,
-        item.1.id.toUTF8.toList, item.1.rawTarget.toUTF8.toList,
-        item.1.targetMode.map (·.toUTF8.toList))) ∧
+      (item.2, item.1.relationshipType.toUTF8.data.toList,
+        item.1.id.toUTF8.data.toList, item.1.rawTarget.toUTF8.data.toList,
+        item.1.targetMode.map (·.toUTF8.data.toList))) ∧
   match Tier2.CommentReferenceIntegrity.selectConventionalMainComment pkg,
       selectTypedComment typedCommentType typedRelationships with
   | .ok none, .ok none => True
@@ -251,9 +510,9 @@ def ExecutableSelectorRefinesTyped
       typedSelected.relationshipOrdinal =
           selected.relationshipRecordOrdinal ∧
       typedSelected.relationshipId.bytes =
-          selected.relationshipId.toUTF8.toList ∧
+          selected.relationshipId.toUTF8.data.toList ∧
       typedSelected.normalizedPartPath.bytes =
-          selected.normalizedPartPath.toUTF8.toList
+          selected.normalizedPartPath.toUTF8.data.toList
   | .error (.ambiguous left), .error (.ambiguous right) => left = right
   | .error (.external left), .error (.external right) => left = right
   | .error (.invalidTargetMode left), .error (.invalidMode right) =>
@@ -294,9 +553,9 @@ def ExecutableRealizationValueOf
   typed.selected.relationshipOrdinal =
       realization.selected.relationshipRecordOrdinal ∧
   typed.selected.relationshipId.bytes =
-      realization.selected.relationshipId.toUTF8.toList ∧
+      realization.selected.relationshipId.toUTF8.data.toList ∧
   typed.selected.normalizedPartPath.bytes =
-      realization.selected.normalizedPartPath.toUTF8.toList ∧
+      realization.selected.normalizedPartPath.toUTF8.data.toList ∧
   typed.extraction.packageBytes =
       realization.extraction.packageBytes ∧
   typed.extraction.snapshotBytes =
@@ -304,7 +563,7 @@ def ExecutableRealizationValueOf
   typed.extraction.expandedBytes =
       realization.extraction.decompressedBytes ∧
   typed.entry.name.bytes =
-      realization.entry.normalizedPartPath.toUTF8.toList ∧
+      realization.entry.normalizedPartPath.toUTF8.data.toList ∧
   typed.entry.compressedSize = realization.entry.compressedSize ∧
   typed.entry.expandedSize = realization.entry.expandedSize ∧
   typed.entry.localHeaderOffset = realization.entry.localHeaderOffset ∧
@@ -315,9 +574,9 @@ def ExecutableRealizationValueOf
       realization.extraction.compressedPayload ∧
   typed.parsed.rawBytes = realization.extraction.decompressedBytes ∧
   typed.parsed.expectedRootUri.bytes =
-      realization.parsed.rootUri.toUTF8.toList ∧
+      realization.parsed.rootUri.toUTF8.data.toList ∧
   typed.parsed.expectedRootLocalName.bytes =
-      realization.parsed.rootLocalName.toUTF8.toList ∧
+      realization.parsed.rootLocalName.toUTF8.data.toList ∧
   typed.parsed.depthLimit = realization.parsed.depth ∧
   typed.parsed.eventLimit = realization.parsed.eventLimit ∧
   typed.parsed.events =
@@ -417,7 +676,7 @@ def ExecutableSourceSetRefinesTyped
   (typedSources.map fun typed =>
       (typed.sourceOrdinal, typed.partPath.bytes)) =
     (set.sources.map fun source =>
-      (source.ordinal, source.normalizedPartPath.toUTF8.toList)) ∧
+      (source.ordinal, source.normalizedPartPath.toUTF8.data.toList)) ∧
   (typedSources.map fun typed =>
       (typed.sourceOrdinal,
         typed.parsed.events.map typedXmlEventIdentityBytes)) =
@@ -434,7 +693,7 @@ def executableSourceSetRefinementCheck
     (typedSources.map fun typed =>
         (typed.sourceOrdinal, typed.partPath.bytes)) =
       (set.sources.map fun source =>
-        (source.ordinal, source.normalizedPartPath.toUTF8.toList))) &&
+        (source.ordinal, source.normalizedPartPath.toUTF8.data.toList))) &&
   decide (
     (typedSources.map fun typed =>
         (typed.sourceOrdinal,
@@ -2846,7 +3105,51 @@ structure ParsedCommentRangeEvidence where
   processedEventCount : Nat := 0
   processedStoryCount : Nat := 0
   crossing : Option CommentMarkerCrossingV7 := none
+  typedState : TypedMarkerScanState := {}
   deriving Inhabited
+
+def concurrentTypedMarkerSourceKindV7 :
+    Tier2.NoteReferenceIntegrity.SourceStory → TypedSourceKind
+  | .main => .main
+  | .header => .header
+  | .footer => .footer
+  | .footnotes => .footnotes
+  | .endnotes => .endnotes
+
+def concurrentTypedMarkerSlotV7
+    (realization : Tier2.NoteReferenceIntegrity.StoryRealization) :
+    TypedSourceSlot := {
+  kind := concurrentTypedMarkerSourceKindV7 realization.slot.story
+  physicalStoryOrdinal := realization.slot.ordinal
+  source := {
+    side := .original
+    sourceOrdinal := realization.slot.ordinal
+    partPath := typedBoundedBytesOfString realization.slot.normalizedPartPath
+    parsed := {
+      rawBytes := ByteArray.empty
+      expectedRootUri := typedBoundedBytesOfString ""
+      expectedRootLocalName := typedBoundedBytesOfString ""
+      events := []
+      depthLimit := 0
+      eventLimit := 0
+    }
+  }
+}
+
+def concurrentTypedMarkerInputV7
+    (scans : Tier2.NoteReferenceIntegrity.SideScanEvidence) :
+    TypedMarkerScanInput := {
+  stories := []
+  slots := scans.realizations.map concurrentTypedMarkerSlotV7
+  wmlNamespace := typedWmlNamespace
+  idLocalName := typedLiteral [105,100]
+  rangeStartLocalName :=
+    typedLiteral [99,111,109,109,101,110,116,82,97,110,103,101,83,116,97,114,116]
+  rangeEndLocalName :=
+    typedLiteral [99,111,109,109,101,110,116,82,97,110,103,101,69,110,100]
+  referenceLocalName :=
+    typedLiteral [99,111,109,109,101,110,116,82,101,102,101,114,101,110,99,101]
+}
 
 def commentMarkerCandidateV7 : XmlEvent →
     Option (CommentMarkerKindV7 × Option String)
@@ -2899,102 +3202,131 @@ def updateCommentMarkerAssociationV7
           if association.rangeEndCount == 1 then some occurrence
           else association.firstDuplicateRangeEnd }
 
-def scanRetainedCommentMarkerEventV7 (relationshipPresent : Bool)
+def retainedCommentMarkerStoppedV7
+    (relationshipPresent : Bool)
+    (state : ParsedCommentRangeEvidence) : Bool :=
+  if relationshipPresent then state.typedState.crossing.isSome
+  else state.crossing.isSome
+
+def scanRetainedCommentMarkerEventV7
+    (typedInput : TypedMarkerScanInput) (relationshipPresent : Bool)
     (sourceSetOrdinal : Nat) (sourceStory : String)
     (sourceStoryOrdinal eventOrdinal : Nat)
     (state : ParsedCommentRangeEvidence) (event : XmlEvent) :
     ParsedCommentRangeEvidence :=
-  if state.crossing.isSome then state
-  else if !relationshipPresent then
-    match commentMarkerKindCandidateV7 event with
-    | none => state
-    | some kind =>
-      let kindOrdinal := match kind with
-        | .reference => state.referenceOccurrences
-        | .rangeStart => state.rangeStartOccurrences
-        | .rangeEnd => state.rangeEndOccurrences
-      let occurrence : CommentMarkerOccurrenceV7 := {
-        kind
-        sourceSetOrdinal
-        sourceStory
-        sourceStoryOrdinal
-        sourceEventOrdinal := eventOrdinal
-        markerOccurrenceOrdinal := state.markerOccurrences
-        kindOccurrenceOrdinal := kindOrdinal
-        rawId := none
-        canonicalId := none
-      }
-      { state with crossing := some (.relationshipRequired occurrence) }
+  if retainedCommentMarkerStoppedV7 relationshipPresent state then state
   else
-    match commentMarkerCandidateV7 event with
-    | none => state
-    | some (kind, rawId) =>
-      let kindOrdinal := match kind with
-        | .reference => state.referenceOccurrences
-        | .rangeStart => state.rangeStartOccurrences
-        | .rangeEnd => state.rangeEndOccurrences
-      let canonicalId := rawId.bind fun raw =>
-        (parseDecimalId raw).toOption.map (·.text)
-      let occurrence : CommentMarkerOccurrenceV7 := {
-        kind
-        sourceSetOrdinal
-        sourceStory
-        sourceStoryOrdinal
-        sourceEventOrdinal := eventOrdinal
-        markerOccurrenceOrdinal := state.markerOccurrences
-        kindOccurrenceOrdinal := kindOrdinal
-        rawId
-        canonicalId
-      }
-      if kind == .reference && kindOrdinal ==
-          Tier2.CommentReferenceIntegrity.maxCommentReferences then
-        { state with crossing := some (.referenceLimit occurrence) }
-      else if kind == .rangeStart && kindOrdinal ==
-          Tier2.CommentReferenceIntegrity.maxCommentReferences then
-        { state with crossing := some (.rangeStartLimit occurrence) }
-      else if kind == .rangeEnd && kindOrdinal ==
-          Tier2.CommentReferenceIntegrity.maxCommentReferences then
-        { state with crossing := some (.rangeEndLimit occurrence) }
-      else
-        let nextReference := state.referenceOccurrences +
-          (if kind == .reference then 1 else 0)
-        let nextStart := state.rangeStartOccurrences +
-          (if kind == .rangeStart then 1 else 0)
-        let nextEnd := state.rangeEndOccurrences +
-          (if kind == .rangeEnd then 1 else 0)
-        match canonicalId with
-        | none =>
-          { state with
-            occurrences := state.occurrences.push occurrence
-            referenceOccurrences := nextReference
-            rangeStartOccurrences := nextStart
-            rangeEndOccurrences := nextEnd
-            markerOccurrences := state.markerOccurrences + 1 }
-        | some canonical =>
-          match state.associations[canonical]? with
-          | some association =>
+    let typedState :=
+      scanTypedMarkerEventV7 typedInput sourceSetOrdinal eventOrdinal
+        state.typedState (typedXmlEventOfProduction eventOrdinal event)
+    let result := if !relationshipPresent then
+      match commentMarkerKindCandidateV7 event with
+      | none => state
+      | some kind =>
+        let kindOrdinal := match kind with
+          | .reference => state.referenceOccurrences
+          | .rangeStart => state.rangeStartOccurrences
+          | .rangeEnd => state.rangeEndOccurrences
+        let occurrence : CommentMarkerOccurrenceV7 := {
+          kind
+          sourceSetOrdinal
+          sourceStory
+          sourceStoryOrdinal
+          sourceEventOrdinal := eventOrdinal
+          markerOccurrenceOrdinal := state.markerOccurrences
+          kindOccurrenceOrdinal := kindOrdinal
+          rawId := none
+          canonicalId := none
+        }
+        { state with crossing := some (.relationshipRequired occurrence) }
+    else
+      match commentMarkerCandidateV7 event with
+      | none => state
+      | some (kind, rawId) =>
+        let kindOrdinal := match kind with
+          | .reference => state.referenceOccurrences
+          | .rangeStart => state.rangeStartOccurrences
+          | .rangeEnd => state.rangeEndOccurrences
+        let canonicalId := rawId.bind fun raw =>
+          (parseDecimalId raw).toOption.map (·.text)
+        let occurrence : CommentMarkerOccurrenceV7 := {
+          kind
+          sourceSetOrdinal
+          sourceStory
+          sourceStoryOrdinal
+          sourceEventOrdinal := eventOrdinal
+          markerOccurrenceOrdinal := state.markerOccurrences
+          kindOccurrenceOrdinal := kindOrdinal
+          rawId
+          canonicalId
+        }
+        if kind == .reference && kindOrdinal ==
+            Tier2.CommentReferenceIntegrity.maxCommentReferences then
+          { state with crossing := some (.referenceLimit occurrence) }
+        else if kind == .rangeStart && kindOrdinal ==
+            Tier2.CommentReferenceIntegrity.maxCommentReferences then
+          { state with crossing := some (.rangeStartLimit occurrence) }
+        else if kind == .rangeEnd && kindOrdinal ==
+            Tier2.CommentReferenceIntegrity.maxCommentReferences then
+          { state with crossing := some (.rangeEndLimit occurrence) }
+        else
+          let nextReference := state.referenceOccurrences +
+            (if kind == .reference then 1 else 0)
+          let nextStart := state.rangeStartOccurrences +
+            (if kind == .rangeStart then 1 else 0)
+          let nextEnd := state.rangeEndOccurrences +
+            (if kind == .rangeEnd then 1 else 0)
+          match canonicalId with
+          | none =>
             { state with
               occurrences := state.occurrences.push occurrence
-              associations := state.associations.insert canonical
-                (updateCommentMarkerAssociationV7 association occurrence)
               referenceOccurrences := nextReference
               rangeStartOccurrences := nextStart
               rangeEndOccurrences := nextEnd
               markerOccurrences := state.markerOccurrences + 1 }
-          | none =>
-            if state.canonicalIds.size ==
-                Tier2.CommentReferenceIntegrity.maxUniqueCommentReferenceIds then
-              { state with crossing := some (.uniqueIdLimit occurrence canonical) }
-            else
+          | some canonical =>
+            match state.associations[canonical]? with
+            | some association =>
               { state with
                 occurrences := state.occurrences.push occurrence
-                canonicalIds := state.canonicalIds.push canonical
                 associations := state.associations.insert canonical
-                  (updateCommentMarkerAssociationV7 {} occurrence)
+                  (updateCommentMarkerAssociationV7 association occurrence)
                 referenceOccurrences := nextReference
                 rangeStartOccurrences := nextStart
                 rangeEndOccurrences := nextEnd
                 markerOccurrences := state.markerOccurrences + 1 }
+            | none =>
+              if state.canonicalIds.size ==
+                  Tier2.CommentReferenceIntegrity.maxUniqueCommentReferenceIds then
+                { state with crossing := some (.uniqueIdLimit occurrence canonical) }
+              else
+                { state with
+                  occurrences := state.occurrences.push occurrence
+                  canonicalIds := state.canonicalIds.push canonical
+                  associations := state.associations.insert canonical
+                    (updateCommentMarkerAssociationV7 {} occurrence)
+                  referenceOccurrences := nextReference
+                  rangeStartOccurrences := nextStart
+                  rangeEndOccurrences := nextEnd
+                  markerOccurrences := state.markerOccurrences + 1 }
+    { result with typedState }
+
+theorem scan_retained_comment_marker_event_v7_typed_state
+    (typedInput : TypedMarkerScanInput)
+    (sourceSetOrdinal : Nat) (sourceStory : String)
+    (sourceStoryOrdinal eventOrdinal : Nat)
+    (state : ParsedCommentRangeEvidence) (event : XmlEvent) :
+    (scanRetainedCommentMarkerEventV7 typedInput true sourceSetOrdinal
+      sourceStory sourceStoryOrdinal eventOrdinal state event).typedState =
+    scanTypedMarkerEventV7 typedInput sourceSetOrdinal eventOrdinal
+      state.typedState (typedXmlEventOfProduction eventOrdinal event) := by
+  unfold scanRetainedCommentMarkerEventV7 retainedCommentMarkerStoppedV7
+  simp only [Bool.true_eq, ↓reduceIte, Bool.not_true]
+  split
+  · rename_i hCrossing
+    unfold scanTypedMarkerEventV7
+    rw [if_pos hCrossing]
+  · rfl
 
 def commentMarkerSourceStoryName :
     Tier2.NoteReferenceIntegrity.SourceStory → String
@@ -3005,46 +3337,210 @@ def commentMarkerSourceStoryName :
   | .endnotes => "endnotes"
 
 def scanRetainedCommentStoryEventsLoopV7
-    (relationshipPresent : Bool)
+    (typedInput : TypedMarkerScanInput) (relationshipPresent : Bool)
     (sourceSetOrdinal : Nat)
     (sourceStory : String) (sourceStoryOrdinal : Nat) :
     Nat → ParsedCommentRangeEvidence → List XmlEvent →
       ParsedCommentRangeEvidence
   | _, state, [] => state
   | eventOrdinal, state, event :: rest =>
-      if state.crossing.isSome then state
+      if retainedCommentMarkerStoppedV7 relationshipPresent state then state
       else
-        let afterEvent := scanRetainedCommentMarkerEventV7 relationshipPresent
+        let afterEvent := scanRetainedCommentMarkerEventV7
+          typedInput relationshipPresent
           sourceSetOrdinal sourceStory sourceStoryOrdinal eventOrdinal
-          { state with processedEventCount := state.processedEventCount + 1 }
+          { state with
+            processedEventCount := state.processedEventCount + 1
+            typedState := { state.typedState with
+              processedEventCount := state.typedState.processedEventCount + 1 } }
           event
-        if afterEvent.crossing.isSome then afterEvent
-        else scanRetainedCommentStoryEventsLoopV7 relationshipPresent sourceSetOrdinal
-          sourceStory sourceStoryOrdinal (eventOrdinal + 1) afterEvent rest
+        if retainedCommentMarkerStoppedV7 relationshipPresent afterEvent then afterEvent
+        else scanRetainedCommentStoryEventsLoopV7 typedInput relationshipPresent
+          sourceSetOrdinal sourceStory sourceStoryOrdinal
+          (eventOrdinal + 1) afterEvent rest
 
 def scanRetainedCommentStoryEventsV7
-    (relationshipPresent : Bool)
+    (typedInput : TypedMarkerScanInput) (relationshipPresent : Bool)
     (sourceSetOrdinal : Nat)
     (realization : Tier2.NoteReferenceIntegrity.StoryRealization)
     (state : ParsedCommentRangeEvidence) : ParsedCommentRangeEvidence :=
-  scanRetainedCommentStoryEventsLoopV7 relationshipPresent sourceSetOrdinal
+  scanRetainedCommentStoryEventsLoopV7 typedInput relationshipPresent sourceSetOrdinal
     (commentMarkerSourceStoryName realization.slot.story)
     realization.slot.ordinal 0 state realization.visitedEvents
 
-def scanRetainedCommentStoriesLoopV7 (relationshipPresent : Bool) :
+theorem scan_retained_comment_story_events_loop_v7_typed_state :
+    ∀ (typedInput : TypedMarkerScanInput)
+      (sourceSetOrdinal : Nat) (sourceStory : String)
+      (sourceStoryOrdinal eventOrdinal : Nat)
+      (state : ParsedCommentRangeEvidence) (events : List XmlEvent),
+    (scanRetainedCommentStoryEventsLoopV7 typedInput true sourceSetOrdinal
+      sourceStory sourceStoryOrdinal eventOrdinal state events).typedState =
+    scanTypedStoryEventsV7 typedInput sourceSetOrdinal eventOrdinal
+      (events.length + 1) state.typedState
+      (typedXmlEventsOfProductionSpecV7 eventOrdinal events)
+  | _, _, _, _, _, _, [] => rfl
+  | typedInput, sourceSetOrdinal, sourceStory, sourceStoryOrdinal,
+      eventOrdinal, state, event :: rest => by
+      unfold scanRetainedCommentStoryEventsLoopV7
+        typedXmlEventsOfProductionSpecV7 scanTypedStoryEventsV7
+      by_cases hStopped : state.typedState.crossing.isSome = true
+      · simp [retainedCommentMarkerStoppedV7, hStopped]
+      · simp only [retainedCommentMarkerStoppedV7, Bool.true_eq,
+          ↓reduceIte, hStopped, if_false]
+        rw [scan_retained_comment_marker_event_v7_typed_state]
+        by_cases hAfter :
+            (scanTypedMarkerEventV7 typedInput sourceSetOrdinal eventOrdinal
+              { state.typedState with
+                processedEventCount := state.typedState.processedEventCount + 1 }
+              (typedXmlEventOfProduction eventOrdinal event)).crossing.isSome =
+              true
+        · simpa [retainedCommentMarkerStoppedV7, hAfter] using
+            scan_retained_comment_marker_event_v7_typed_state
+              typedInput sourceSetOrdinal sourceStory sourceStoryOrdinal
+              eventOrdinal
+              { state with
+                processedEventCount := state.processedEventCount + 1
+                typedState := { state.typedState with
+                  processedEventCount :=
+                    state.typedState.processedEventCount + 1 } }
+              event
+        · simp only [retainedCommentMarkerStoppedV7, Bool.true_eq,
+            ↓reduceIte, hAfter, if_false]
+          have hInduction :=
+            scan_retained_comment_story_events_loop_v7_typed_state
+            typedInput sourceSetOrdinal sourceStory sourceStoryOrdinal
+            (eventOrdinal + 1)
+            (scanRetainedCommentMarkerEventV7 typedInput true sourceSetOrdinal
+              sourceStory sourceStoryOrdinal eventOrdinal
+              { state with
+                processedEventCount := state.processedEventCount + 1
+                typedState := { state.typedState with
+                  processedEventCount :=
+                    state.typedState.processedEventCount + 1 } }
+              event)
+            rest
+          rw [scan_retained_comment_marker_event_v7_typed_state] at hInduction
+          simpa only [List.length_cons, Nat.add_assoc,
+            Nat.reduceAdd] using hInduction
+
+def scanRetainedCommentStoriesLoopV7
+    (typedInput : TypedMarkerScanInput) (relationshipPresent : Bool) :
     Nat → ParsedCommentRangeEvidence →
       List Tier2.NoteReferenceIntegrity.StoryRealization →
       ParsedCommentRangeEvidence
   | _, state, [] => state
   | sourceSetOrdinal, state, realization :: rest =>
-      if state.crossing.isSome then state
+      if retainedCommentMarkerStoppedV7 relationshipPresent state then state
       else
-        let afterStory := scanRetainedCommentStoryEventsV7 relationshipPresent sourceSetOrdinal
+        let afterStory := scanRetainedCommentStoryEventsV7
+          typedInput relationshipPresent sourceSetOrdinal
           realization { state with
-            processedStoryCount := state.processedStoryCount + 1 }
-        if afterStory.crossing.isSome then afterStory
-        else scanRetainedCommentStoriesLoopV7 relationshipPresent
+            processedStoryCount := state.processedStoryCount + 1
+            typedState := { state.typedState with
+              processedStoryCount := state.typedState.processedStoryCount + 1 } }
+        if retainedCommentMarkerStoppedV7 relationshipPresent afterStory then afterStory
+        else scanRetainedCommentStoriesLoopV7 typedInput relationshipPresent
           (sourceSetOrdinal + 1) afterStory rest
+
+inductive ConcurrentTypedStoryEventsV7 :
+    List TypedStorySource →
+      List Tier2.NoteReferenceIntegrity.StoryRealization → Prop
+  | nil : ConcurrentTypedStoryEventsV7 [] []
+  | cons (story : TypedStorySource)
+      (realization : Tier2.NoteReferenceIntegrity.StoryRealization)
+      (stories : List TypedStorySource)
+      (realizations : List Tier2.NoteReferenceIntegrity.StoryRealization)
+      (eventsExact : story.parsed.events =
+        typedXmlEventsOfProductionSpecV7 0 realization.visitedEvents)
+      (restExact : ConcurrentTypedStoryEventsV7 stories realizations) :
+      ConcurrentTypedStoryEventsV7
+        (story :: stories) (realization :: realizations)
+
+theorem concurrent_typed_story_events_v7_length
+    (stories : List TypedStorySource)
+    (realizations : List Tier2.NoteReferenceIntegrity.StoryRealization)
+    (hExact : ConcurrentTypedStoryEventsV7 stories realizations) :
+    stories.length = realizations.length := by
+  induction hExact with
+  | nil => rfl
+  | cons _ _ _ _ _ _ hInduction =>
+      simp only [List.length_cons, hInduction]
+
+theorem scan_retained_comment_stories_loop_v7_typed_state
+    (typedInput : TypedMarkerScanInput) :
+    ∀ (sourceSetOrdinal : Nat) (state : ParsedCommentRangeEvidence)
+      (stories : List TypedStorySource)
+      (realizations : List Tier2.NoteReferenceIntegrity.StoryRealization),
+    ConcurrentTypedStoryEventsV7 stories realizations →
+    (scanRetainedCommentStoriesLoopV7 typedInput true sourceSetOrdinal
+      state realizations).typedState =
+    scanTypedStoriesV7 typedInput sourceSetOrdinal
+      (stories.length + 1) state.typedState stories
+  | _, _, [], [], .nil => rfl
+  | sourceSetOrdinal, state, story :: stories,
+      realization :: realizations, .cons _ _ _ _ hEvents hRest => by
+      unfold scanRetainedCommentStoriesLoopV7 scanTypedStoriesV7
+      by_cases hStopped : state.typedState.crossing.isSome = true
+      · simp [retainedCommentMarkerStoppedV7, hStopped]
+      · simp only [retainedCommentMarkerStoppedV7, Bool.true_eq,
+          ↓reduceIte, hStopped, if_false]
+        let beforeStory : ParsedCommentRangeEvidence := {
+          state with
+          processedStoryCount := state.processedStoryCount + 1
+          typedState := { state.typedState with
+            processedStoryCount := state.typedState.processedStoryCount + 1 }
+        }
+        let afterStory := scanRetainedCommentStoryEventsV7 typedInput true
+          sourceSetOrdinal realization beforeStory
+        have hStory :
+            afterStory.typedState =
+              scanTypedStoryEventsV7 typedInput sourceSetOrdinal 0
+                (story.parsed.events.length + 1)
+                beforeStory.typedState story.parsed.events := by
+          unfold afterStory scanRetainedCommentStoryEventsV7
+          rw [hEvents]
+          simpa only [typed_xml_events_of_production_spec_v7_length] using
+            scan_retained_comment_story_events_loop_v7_typed_state
+            typedInput sourceSetOrdinal
+            (commentMarkerSourceStoryName realization.slot.story)
+            realization.slot.ordinal 0 beforeStory realization.visitedEvents
+        by_cases hAfter :
+            (scanTypedStoryEventsV7 typedInput sourceSetOrdinal 0
+              (story.parsed.events.length + 1)
+              beforeStory.typedState story.parsed.events).crossing.isSome = true
+        · have hAfterStory : afterStory.typedState.crossing.isSome = true := by
+            rw [hStory]
+            exact hAfter
+          rw [show
+            (scanRetainedCommentStoryEventsV7 typedInput true
+              sourceSetOrdinal realization beforeStory).typedState.crossing.isSome =
+                true by
+              exact hAfterStory]
+          rw [hAfter]
+          simp only [Bool.false_eq_true, if_false, if_true]
+          exact hStory
+        · have hInduction :=
+            scan_retained_comment_stories_loop_v7_typed_state typedInput
+              (sourceSetOrdinal + 1) afterStory stories realizations hRest
+          rw [hStory] at hInduction
+          have hTypedAfterFalse :
+              (scanTypedStoryEventsV7 typedInput sourceSetOrdinal 0
+                (story.parsed.events.length + 1)
+                beforeStory.typedState story.parsed.events).crossing.isSome =
+                  false :=
+            Bool.eq_false_iff.mpr hAfter
+          have hAfterStory :
+              afterStory.typedState.crossing.isSome = false := by
+            rw [hStory]
+            exact hTypedAfterFalse
+          rw [show
+            (scanRetainedCommentStoryEventsV7 typedInput true
+              sourceSetOrdinal realization beforeStory).typedState.crossing.isSome =
+                false by
+              exact hAfterStory]
+          rw [hTypedAfterFalse]
+          simpa only [Bool.false_eq_true, if_false,
+            List.length_cons, Nat.add_assoc, Nat.reduceAdd] using hInduction
 
 def scanRetainedCommentMarkersForRelationshipV7
     (relationshipPresent : Bool)
@@ -3053,7 +3549,8 @@ def scanRetainedCommentMarkersForRelationshipV7
     Except String ParsedCommentRangeEvidence :=
   if Tier2.CommentReferenceIntegrity.storySlotListsMatch set.sources
       (scans.realizations.map (·.slot)) then
-    .ok <| scanRetainedCommentStoriesLoopV7 relationshipPresent
+    let typedInput := concurrentTypedMarkerInputV7 scans
+    .ok <| scanRetainedCommentStoriesLoopV7 typedInput relationshipPresent
       0 {} scans.realizations
   else
     .error "retained comment source set does not match retained story scans"
@@ -3094,10 +3591,20 @@ def retainedCommentSkippedEventV7 : XmlEvent :=
     [{ uri := wmlNamespace, localName := "id", value := "8" }] 1 true
 
 theorem retained_comment_event_scan_stops_at_crossing_witness :
+    let typedInput := concurrentTypedMarkerInputV7 {
+      realizations := []
+      parsedReferences := []
+      parsedDefinitions := []
+      parsedPoison := []
+    }
     let initial : ParsedCommentRangeEvidence :=
       { rangeStartOccurrences :=
-          Tier2.CommentReferenceIntegrity.maxCommentReferences }
-    let result := scanRetainedCommentStoryEventsLoopV7 true
+          Tier2.CommentReferenceIntegrity.maxCommentReferences
+        typedState := {
+          rangeStartOccurrences :=
+            Tier2.CommentReferenceIntegrity.maxCommentReferences
+        } }
+    let result := scanRetainedCommentStoryEventsLoopV7 typedInput false
       0 "main" 0 0 initial
         [retainedCommentEarlyCrossingEventV7, retainedCommentSkippedEventV7]
     result.processedEventCount = 1 ∧
@@ -3108,14 +3615,17 @@ theorem retained_comment_event_scan_stops_at_crossing_witness :
   decide
 
 theorem retained_comment_story_scan_does_not_enter_later_stories
+    (typedInput : TypedMarkerScanInput)
     (sourceOrdinal : Nat) (state : ParsedCommentRangeEvidence)
     (stories : List Tier2.NoteReferenceIntegrity.StoryRealization)
-    (hCrossing : state.crossing.isSome = true) :
-    scanRetainedCommentStoriesLoopV7 true sourceOrdinal state stories = state := by
+    (hCrossing : state.typedState.crossing.isSome = true) :
+    scanRetainedCommentStoriesLoopV7
+      typedInput true sourceOrdinal state stories = state := by
   cases stories with
   | nil => rfl
   | cons story rest =>
-      simp [scanRetainedCommentStoriesLoopV7, hCrossing]
+      simp [scanRetainedCommentStoriesLoopV7,
+        retainedCommentMarkerStoppedV7, hCrossing]
 
 def retainedCommentSourceStoryV7 (sourceStory : String) :
     Tier2.NoteReferenceIntegrity.SourceStory :=
@@ -7604,7 +8114,7 @@ def typedRelationshipOfProduction
   rawTarget := typedBoundedBytesOfString record.rawTarget
   rawTargetMode := record.targetMode.map typedBoundedBytesOfString
   normalizedTarget :=
-    (Tier2.CommentReferenceIntegrity.normalizeRelationshipTarget
+    (Tier2.RelationshipStorySelector.normalizeTarget
       record.rawTarget).toOption.map typedBoundedBytesOfString
   mode := typedRelationshipModeOfProduction record
 }
@@ -7629,6 +8139,26 @@ def typedXmlEventsOfProductionFrom :
 
 def typedXmlEventsOfProduction (events : List XmlEvent) : List TypedXmlEvent :=
   typedXmlEventsOfProductionFrom 0 [] events
+
+theorem typed_xml_events_of_production_from_eq_spec :
+    ∀ ordinal output events,
+      typedXmlEventsOfProductionFrom ordinal output events =
+        output.reverse ++ typedXmlEventsOfProductionSpecV7 ordinal events
+  | _, _, [] => by
+      simp [typedXmlEventsOfProductionFrom, typedXmlEventsOfProductionSpecV7]
+  | ordinal, output, event :: rest => by
+      rw [typedXmlEventsOfProductionFrom,
+        typed_xml_events_of_production_from_eq_spec]
+      simp only [List.reverse_cons, List.append_assoc]
+      rfl
+
+theorem typed_xml_events_of_production_eq_spec
+    (events : List XmlEvent) :
+    typedXmlEventsOfProduction events =
+      typedXmlEventsOfProductionSpecV7 0 events := by
+  unfold typedXmlEventsOfProduction
+  rw [typed_xml_events_of_production_from_eq_spec]
+  rfl
 
 def typedParsedPartOfProduction
     (evidence : ProductionParseEvidence) : TypedParsedPart := {
@@ -7704,7 +8234,7 @@ def physicalStoryPathForTypedSide
   | .compared => story.comparedPartPath
 
 def typedHeaderFooterStoryOfProduction
-    (side : Side) (sources : List NoteSource)
+    (side : Side) (source : Option NoteSource)
     (story : PhysicalStory) : TypedHeaderFooterStory := {
   physicalStoryOrdinal := story.physicalStoryOrdinal
   kind := typedHeaderFooterKindOfProduction story.kind
@@ -7714,15 +8244,127 @@ def typedHeaderFooterStoryOfProduction
   revisedPartPath := typedBoundedBytesOfString story.revisedPartPath
   comparedPartPath := typedBoundedBytesOfString story.comparedPartPath
   selectingSlotOrdinals := story.selectingSlotOrdinals
-  source := (sources.find? fun source =>
-    source.sourceStoryOrdinal = story.physicalStoryOrdinal &&
-    source.sourceStory = story.kind.toString).map
-      (typedStorySourceOfProduction side)
+  source := source.map (typedStorySourceOfProduction side)
 }
+
+def typedHeaderFooterStoriesOfProduction
+    (side : Side) : List NoteSource → List PhysicalStory →
+      List TypedHeaderFooterStory
+  | _, [] => []
+  | [], story :: rest =>
+      typedHeaderFooterStoryOfProduction side none story ::
+        typedHeaderFooterStoriesOfProduction side [] rest
+  | source :: sourceRest, story :: rest =>
+      typedHeaderFooterStoryOfProduction side (some source) story ::
+        typedHeaderFooterStoriesOfProduction side sourceRest rest
+
+def typedHeaderFooterSourceSlotsOfProduction
+    (side : Side) : List NoteSource → List PhysicalStory →
+      List TypedSourceSlot × List NoteSource
+  | sources, [] => ([], sources)
+  | [], _ :: rest =>
+      typedHeaderFooterSourceSlotsOfProduction side [] rest
+  | source :: sourceRest, story :: rest =>
+      let tail :=
+        typedHeaderFooterSourceSlotsOfProduction side sourceRest rest
+      ({
+        kind := typedHeaderFooterKindOfProduction story.kind
+        physicalStoryOrdinal := story.physicalStoryOrdinal
+        source := typedStorySourceOfProduction side source
+      } :: tail.1, tail.2)
+
+def typedNoteSourceSlotsOfProduction
+    (side : Side) (sources : List NoteSource)
+    (footnotesPresent endnotesPresent : Bool) : List TypedSourceSlot :=
+  let footnoteSource :=
+    if footnotesPresent then sources.head? else none
+  let endnoteSources :=
+    if footnotesPresent then sources.drop 1 else sources
+  let endnoteSource :=
+    if endnotesPresent then endnoteSources.head? else none
+  (footnoteSource.map (fun source => {
+      kind := TypedSourceKind.footnotes
+      physicalStoryOrdinal := 0
+      source := typedStorySourceOfProduction side source
+    })).toList ++
+  (endnoteSource.map (fun source => {
+      kind := TypedSourceKind.endnotes
+      physicalStoryOrdinal := 0
+      source := typedStorySourceOfProduction side source
+    })).toList
+
+def typedCommentSourceDomainSlotsOfProduction
+    (side : Side) (sources : List NoteSource)
+    (stories : List PhysicalStory)
+    (footnotesPresent endnotesPresent : Bool) : List TypedSourceSlot :=
+  match sources with
+  | [] => [{
+      kind := .main
+      physicalStoryOrdinal := 0
+      source := missingTypedMainSource side
+    }]
+  | mainSource :: sourceTail =>
+      let headerFooter :=
+        typedHeaderFooterSourceSlotsOfProduction side sourceTail stories
+      {
+        kind := .main
+        physicalStoryOrdinal := 0
+        source := typedStorySourceOfProduction side mainSource
+      } :: headerFooter.1 ++
+        typedNoteSourceSlotsOfProduction side headerFooter.2
+          footnotesPresent endnotesPresent
+
+theorem typed_header_footer_stories_filter_map_v7 :
+    ∀ (side : Side) (sources : List NoteSource)
+      (stories : List PhysicalStory),
+      (typedHeaderFooterStoriesOfProduction side sources stories).filterMap
+          (fun story => story.source.map fun source => {
+            kind := story.kind
+            physicalStoryOrdinal := story.physicalStoryOrdinal
+            source
+          }) =
+        (typedHeaderFooterSourceSlotsOfProduction side sources stories).1
+  | _, _, [] => rfl
+  | side, [], _ :: rest => by
+      unfold typedHeaderFooterStoriesOfProduction
+        typedHeaderFooterSourceSlotsOfProduction
+        typedHeaderFooterStoryOfProduction
+      exact typed_header_footer_stories_filter_map_v7 side [] rest
+  | side, _ :: sourceRest, _ :: rest => by
+      unfold typedHeaderFooterStoriesOfProduction
+        typedHeaderFooterSourceSlotsOfProduction
+        typedHeaderFooterStoryOfProduction
+      simp only [List.filterMap_cons, Option.map_some, List.cons.injEq,
+        true_and]
+      exact typed_header_footer_stories_filter_map_v7
+        side sourceRest rest
+
+theorem typed_header_footer_source_slots_remainder_v7 :
+    ∀ (side : Side) (sources : List NoteSource)
+      (stories : List PhysicalStory),
+      (typedHeaderFooterSourceSlotsOfProduction side sources stories).2 =
+        sources.drop stories.length
+  | _, _, [] => by simp [typedHeaderFooterSourceSlotsOfProduction]
+  | side, [], _ :: rest => by
+      unfold typedHeaderFooterSourceSlotsOfProduction
+      simpa using typed_header_footer_source_slots_remainder_v7
+        side [] rest
+  | side, _ :: sourceRest, _ :: rest => by
+      unfold typedHeaderFooterSourceSlotsOfProduction
+      simpa using typed_header_footer_source_slots_remainder_v7
+        side sourceRest rest
+
+theorem typed_header_footer_source_slots_empty_v7 :
+    ∀ (side : Side) (stories : List PhysicalStory),
+      (typedHeaderFooterSourceSlotsOfProduction side [] stories).1 = []
+  | _, [] => rfl
+  | side, _ :: rest => by
+      unfold typedHeaderFooterSourceSlotsOfProduction
+      exact typed_header_footer_source_slots_empty_v7 side rest
 
 def typedNoteSelectionOfProduction
     (side : Side) (evidence : NoteSideEvidence)
-    (sources : List NoteSource) (kind : NoteKind) : TypedNoteSelection :=
+    (source : Option NoteSource) (kind : NoteKind) : TypedNoteSelection :=
   let identity := if kind == .footnotes then
     evidence.footnotesIdentity else evidence.endnotesIdentity
   let present := if kind == .footnotes then
@@ -7737,10 +8379,34 @@ def typedNoteSelectionOfProduction
     selectedPartPath := identity.map fun value =>
       typedBoundedBytesOfString value.normalizedPartPath
     partPresent := present
-    source := (sources.find? fun source =>
-      source.sourceStory = kind.toString).map
-        (typedStorySourceOfProduction side)
+    source := source.map (typedStorySourceOfProduction side)
   }
+
+theorem typed_note_selections_filter_map_v7
+    (side : Side) (evidence : NoteSideEvidence)
+    (footnoteSource endnoteSource : Option NoteSource) :
+    [ typedNoteSelectionOfProduction side evidence
+        footnoteSource .footnotes
+    , typedNoteSelectionOfProduction side evidence
+        endnoteSource .endnotes
+    ].filterMap (fun selection =>
+        selection.source.map fun source => ({
+          kind := selection.kind
+          physicalStoryOrdinal := 0
+          source
+        } : TypedSourceSlot)) =
+      (footnoteSource.map (fun source => ({
+        kind := TypedSourceKind.footnotes
+        physicalStoryOrdinal := 0
+        source := typedStorySourceOfProduction side source
+      } : TypedSourceSlot))).toList ++
+      (endnoteSource.map (fun source => ({
+        kind := TypedSourceKind.endnotes
+        physicalStoryOrdinal := 0
+        source := typedStorySourceOfProduction side source
+      } : TypedSourceSlot))).toList := by
+  cases footnoteSource <;> cases endnoteSource <;>
+    simp [typedNoteSelectionOfProduction]
 
 def typedPriorSourceAdmissionOfProduction
     (request : RunRequestCoreRequestV6)
@@ -7764,6 +8430,237 @@ def typedSelectedCommentOfProduction
     typedBoundedBytesOfString selected.normalizedPartPath
 }
 
+def exactProductionCommentRelationshipsFrom :
+    Nat → List RelationshipRecord → List (RelationshipRecord × Nat)
+  | _, [] => []
+  | ordinal, record :: rest =>
+      let tail := exactProductionCommentRelationshipsFrom
+        (ordinal + 1) rest
+      if record.relationshipType ==
+          Tier2.CommentReferenceIntegrity.commentsRelationshipType then
+        (record, ordinal) :: tail
+      else tail
+
+theorem exact_production_comment_relationships_from_zip :
+    ∀ ordinal (records : List RelationshipRecord),
+    exactProductionCommentRelationshipsFrom ordinal records =
+      (List.zipIdx records ordinal).filter fun pair =>
+        pair.1.relationshipType ==
+          Tier2.CommentReferenceIntegrity.commentsRelationshipType
+  | _, [] => rfl
+  | ordinal, record :: rest => by
+      unfold exactProductionCommentRelationshipsFrom List.zipIdx
+      rw [exact_production_comment_relationships_from_zip
+        (ordinal + 1) rest]
+      by_cases h :
+          record.relationshipType ==
+            Tier2.CommentReferenceIntegrity.commentsRelationshipType
+      · simp [h]
+      · simp [h]
+
+theorem exact_typed_comment_relationships_of_production :
+    ∀ ordinal (records : List RelationshipRecord),
+    exactTypedCommentRelationships
+        (typedBoundedBytesOfString
+          Tier2.CommentReferenceIntegrity.commentsRelationshipType)
+        (typedRelationshipsOfProductionFrom ordinal records) =
+      (exactProductionCommentRelationshipsFrom ordinal records).map
+        (fun item => typedRelationshipOfProduction item.1 item.2)
+  | _, [] => rfl
+  | ordinal, record :: rest => by
+      have hTail :=
+        exact_typed_comment_relationships_of_production
+          (ordinal + 1) rest
+      rw [typedRelationshipsOfProductionFrom,
+        exactProductionCommentRelationshipsFrom,
+        exactTypedCommentRelationships, List.filter_cons]
+      by_cases hRaw :
+          (record.relationshipType ==
+            Tier2.CommentReferenceIntegrity.commentsRelationshipType) = true
+      · have hString :
+            record.relationshipType =
+              Tier2.CommentReferenceIntegrity.commentsRelationshipType :=
+          beq_iff_eq.mp hRaw
+        have hTyped :
+            decide
+              (record.relationshipType.toUTF8.data.toList =
+                (Tier2.CommentReferenceIntegrity.commentsRelationshipType).toUTF8.data.toList) =
+              true := by
+          rw [hString]
+          rfl
+        rw [if_pos hRaw]
+        simp only [List.map_cons]
+        split
+        · exact congrArg
+            (List.cons (typedRelationshipOfProduction record ordinal))
+            hTail
+        · rename_i hTypedNeg
+          exact False.elim (hTypedNeg hTyped)
+      · have hTyped :
+            decide
+              (record.relationshipType.toUTF8.data.toList =
+                (Tier2.CommentReferenceIntegrity.commentsRelationshipType).toUTF8.data.toList) =
+              false := by
+          apply Bool.eq_false_iff.mpr
+          intro hEqual
+          apply hRaw
+          apply beq_iff_eq.mpr
+          apply string_eq_of_utf8_data_to_list_eq
+          exact of_decide_eq_true hEqual
+        rw [if_neg hRaw]
+        split
+        · rename_i hTypedPos
+          have hTypedPos' :
+              decide
+                (record.relationshipType.toUTF8.data.toList =
+                  (Tier2.CommentReferenceIntegrity.commentsRelationshipType).toUTF8.data.toList) =
+                true := by
+            simpa [typedRelationshipOfProduction,
+              typedBoundedBytesOfString] using hTypedPos
+          rw [hTyped] at hTypedPos'
+          contradiction
+        · exact hTail
+
+theorem typed_selector_success_of_production
+    (records : List RelationshipRecord)
+    (selected : SelectedCommentIdentity)
+    (hSelected :
+      Tier2.CommentReferenceIntegrity.selectConventionalMainCommentRecords
+        records = .ok (some selected)) :
+    selectTypedComment
+        (typedBoundedBytesOfString
+          Tier2.CommentReferenceIntegrity.commentsRelationshipType)
+        (typedRelationshipsOfProduction records) =
+      .ok (some (typedSelectedCommentOfProduction selected)) := by
+  unfold typedRelationshipsOfProduction
+  unfold selectTypedComment selectTypedCommentSpec
+  rw [exact_typed_comment_relationships_of_production]
+  unfold Tier2.CommentReferenceIntegrity.selectConventionalMainCommentRecords
+    at hSelected
+  unfold Tier2.CommentReferenceIntegrity.exactCommentRelationshipRecords
+    at hSelected
+  rw [← exact_production_comment_relationships_from_zip] at hSelected
+  generalize hExact :
+      exactProductionCommentRelationshipsFrom 0 records = exact
+  rw [hExact] at hSelected
+  cases exact with
+  | nil =>
+      nomatch hSelected
+  | cons first rest =>
+      rcases first with ⟨record, ordinal⟩
+      cases rest with
+      | nil =>
+          simp only [List.map_cons, List.map_nil]
+          unfold selectSingleTypedCommentRelationship
+          dsimp only at hSelected ⊢
+          simp only [List.isEmpty, Bool.not_true, Bool.false_eq_true,
+            if_false] at hSelected
+          by_cases hExternal :
+              (record.targetMode == some "External") = true
+          · rw [if_pos hExternal] at hSelected
+            contradiction
+          · rw [if_neg hExternal] at hSelected
+            by_cases hInvalid :
+                (!(record.targetMode.isNone ||
+                  record.targetMode == some "Internal")) = true
+            · rw [if_pos hInvalid] at hSelected
+              contradiction
+            · rw [if_neg hInvalid] at hSelected
+              cases hNormalize :
+                  Tier2.RelationshipStorySelector.normalizeTarget
+                    record.rawTarget with
+              | error detail =>
+                  simp [hNormalize] at hSelected
+              | ok normalized =>
+                  simp only [hNormalize, Except.ok.injEq,
+                    Option.some.injEq] at hSelected
+                  subst selected
+                  have hExternalFalse :
+                      (record.targetMode == some "External") = false :=
+                    Bool.eq_false_iff.mpr hExternal
+                  have hInternal :
+                      (record.targetMode.isNone ||
+                        record.targetMode == some "Internal") = true := by
+                    have hNot := Bool.eq_false_iff.mpr hInvalid
+                    cases hMode :
+                        (record.targetMode.isNone ||
+                          record.targetMode == some "Internal") <;>
+                      simp [hMode] at hNot ⊢
+                  have hSize :
+                      ¬record.rawTarget.toUTF8.data.toList.length > 256 := by
+                    unfold Tier2.RelationshipStorySelector.normalizeTarget
+                      at hNormalize
+                    by_cases hBound :
+                        (record.rawTarget.isEmpty ||
+                          decide (record.rawTarget.toUTF8.size >
+                            Tier2.RelationshipStorySelector.maxLocatorBytes)) =
+                          true
+                    · rw [if_pos hBound] at hNormalize
+                      contradiction
+                    · intro hLarge
+                      have hLarge' :
+                          record.rawTarget.toUTF8.size >
+                            Tier2.RelationshipStorySelector.maxLocatorBytes := by
+                        simpa [
+                          Tier2.RelationshipStorySelector.maxLocatorBytes]
+                          using hLarge
+                      apply hBound
+                      rw [Bool.or_eq_true]
+                      apply Or.inr
+                      exact decide_eq_true hLarge'
+                  have hUtf8Size :
+                      ¬256 < record.rawTarget.utf8ByteSize := by
+                    change
+                      ¬256 < record.rawTarget.toUTF8.data.toList.length
+                    exact hSize
+                  simp only [typedRelationshipOfProduction,
+                    typedRelationshipModeOfProduction,
+                    typedSelectedCommentOfProduction,
+                    hExternalFalse, hInternal, Bool.false_eq_true, if_false,
+                    typedBoundedBytesOfString, hUtf8Size, hSize, hNormalize,
+                    if_true, Except.toOption, Option.map]
+      | cons second tail =>
+          nomatch hSelected
+
+theorem typed_selector_none_of_production
+    (records : List RelationshipRecord)
+    (hSelected :
+      Tier2.CommentReferenceIntegrity.selectConventionalMainCommentRecords
+        records = .ok none) :
+    selectTypedComment
+        (typedBoundedBytesOfString
+          Tier2.CommentReferenceIntegrity.commentsRelationshipType)
+        (typedRelationshipsOfProduction records) = .ok none := by
+  unfold typedRelationshipsOfProduction
+  unfold selectTypedComment selectTypedCommentSpec
+  rw [exact_typed_comment_relationships_of_production]
+  unfold Tier2.CommentReferenceIntegrity.selectConventionalMainCommentRecords
+    at hSelected
+  unfold Tier2.CommentReferenceIntegrity.exactCommentRelationshipRecords
+    at hSelected
+  rw [← exact_production_comment_relationships_from_zip] at hSelected
+  generalize hExact :
+      exactProductionCommentRelationshipsFrom 0 records = exact
+  rw [hExact] at hSelected
+  cases exact with
+  | nil => rfl
+  | cons first rest =>
+      rcases first with ⟨record, ordinal⟩
+      cases rest with
+      | cons second tail =>
+          simp at hSelected
+      | nil =>
+          dsimp only at hSelected
+          simp only [List.isEmpty, Bool.not_true, Bool.false_eq_true,
+            if_false] at hSelected
+          split at hSelected
+          · contradiction
+          · split at hSelected
+            · contradiction
+            · split at hSelected
+              · contradiction
+              · nomatch hSelected
+
 def typedExtractionOfProduction
     (evidence : SnapshotExtractionEvidence) : TypedExtraction := {
   packageBytes := evidence.packageBytes
@@ -7786,8 +8683,7 @@ def typedCommentRealizationOfProduction
 
 def typedCanonicalIdOfRaw (raw : Option String) :
     Option TypedCanonicalId :=
-  raw.bind Tier2.CommentReferenceIntegrity.parseBoundedDecimalId |>.map
-    fun key => { negative := key.negative, digits := key.digits }
+  raw.map typedBoundedBytesOfString |>.bind parseTypedDecimalId
 
 def typedReferenceOfProduction
     (reference : CommentReferenceOccurrence) : TypedReference := {
@@ -7821,6 +8717,158 @@ def typedScanCrossingOfProduction :
   | Tier2.CommentReferenceIntegrity.CommentScanCrossing.nonDirectDefinitions
       occurrenceOrdinal =>
       TypedScanCrossing.nonDirectDefinitions occurrenceOrdinal
+
+def typedDefinitionStateOfProduction
+    (state : Tier2.CommentReferenceIntegrity.CommentScanState) :
+    TypedScanState := {
+  scan := {
+    references := []
+    definitions := state.scan.definitions.map typedDefinitionOfProduction
+    nonDirectDefinitions :=
+      state.scan.nonDirectDefinitions.map typedDefinitionOfProduction
+    crossing := state.crossing.map typedScanCrossingOfProduction
+  }
+  canonicalReferenceIds := []
+}
+
+theorem scan_typed_definition_event_of_production
+    (state : Tier2.CommentReferenceIntegrity.CommentScanState)
+    (eventOrdinal : Nat) (event : XmlEvent) :
+    scanTypedDefinitionEvent (typedDefinitionScanInputV7 [])
+        (typedDefinitionStateOfProduction state)
+        (typedXmlEventOfProduction eventOrdinal event) =
+      typedDefinitionStateOfProduction
+        (Tier2.CommentReferenceIntegrity.scanCommentDefinitionEvent
+          state event) := by
+  unfold scanTypedDefinitionEvent
+  unfold Tier2.CommentReferenceIntegrity.scanCommentDefinitionEvent
+  have hCrossingMap :
+      (typedDefinitionStateOfProduction state).scan.crossing =
+        state.crossing.map typedScanCrossingOfProduction := rfl
+  rw [hCrossingMap, Option.isSome_map]
+  by_cases hCrossing : state.crossing.isSome = true
+  · simp [hCrossing, typedDefinitionStateOfProduction]
+  · simp only [hCrossing]
+    rw [typed_definition_candidate_of_production]
+    cases hCandidate :
+        Tier2.CommentReferenceIntegrity.commentDefinitionCandidate? event with
+    | none =>
+        simp [typedDefinitionStateOfProduction]
+    | some candidate =>
+        rcases candidate with ⟨rawId, direct⟩
+        simp only [Option.map_some]
+        by_cases hDirect : direct = true
+        · simp only [hDirect, if_true]
+          rw [show
+            (typedDefinitionStateOfProduction state).scan.definitions.length =
+              state.scan.definitions.length by
+                simp [typedDefinitionStateOfProduction]]
+          by_cases hLimit : state.scan.definitions.length = 4096
+          · simp [hLimit,
+              Tier2.CommentReferenceIntegrity.maxCommentDefinitions,
+              typedDefinitionStateOfProduction,
+              typedScanCrossingOfProduction]
+          · simp [hLimit,
+              Tier2.CommentReferenceIntegrity.maxCommentDefinitions,
+              typedDefinitionStateOfProduction, List.map_append,
+              typedDefinitionOfProduction, typedCanonicalIdOfRaw]
+        · have hDirectFalse : direct = false :=
+            Bool.eq_false_iff.mpr hDirect
+          simp only [hDirectFalse]
+          rw [show
+            (typedDefinitionStateOfProduction state).scan.nonDirectDefinitions.length =
+              state.scan.nonDirectDefinitions.length by
+                simp [typedDefinitionStateOfProduction]]
+          by_cases hLimit :
+              state.scan.nonDirectDefinitions.length = 4096
+          · simp [hLimit,
+              Tier2.CommentReferenceIntegrity.maxNonDirectCommentDefinitions,
+              typedDefinitionStateOfProduction,
+              typedScanCrossingOfProduction]
+          · simp [hLimit,
+              Tier2.CommentReferenceIntegrity.maxNonDirectCommentDefinitions,
+              typedDefinitionStateOfProduction, List.map_append,
+              typedDefinitionOfProduction, typedCanonicalIdOfRaw]
+
+theorem fold_typed_definition_events_of_production :
+    ∀ (eventOrdinal : Nat) (events : List XmlEvent)
+      (state : Tier2.CommentReferenceIntegrity.CommentScanState),
+    (typedXmlEventsOfProductionSpecV7 eventOrdinal events).foldl
+        (scanTypedDefinitionEvent (typedDefinitionScanInputV7 []))
+        (typedDefinitionStateOfProduction state) =
+      typedDefinitionStateOfProduction
+        (events.foldl
+          Tier2.CommentReferenceIntegrity.scanCommentDefinitionEvent
+          state)
+  | _, [], _ => rfl
+  | eventOrdinal, event :: rest, state => by
+      simp only [typedXmlEventsOfProductionSpecV7, List.foldl_cons]
+      rw [scan_typed_definition_event_of_production]
+      exact fold_typed_definition_events_of_production
+        (eventOrdinal + 1) rest
+        (Tier2.CommentReferenceIntegrity.scanCommentDefinitionEvent
+          state event)
+
+theorem typed_definition_scan_of_production
+    (events : List XmlEvent) :
+    scanTypedCommentEvidence
+        (typedDefinitionScanInputV7
+          (typedXmlEventsOfProduction events)) =
+      let production :=
+        Tier2.CommentReferenceIntegrity.scanCommentEvidence {
+          sourceEvents := []
+          definitionEvents := events
+        }
+      {
+        references := []
+        definitions :=
+          production.scan.definitions.map typedDefinitionOfProduction
+        nonDirectDefinitions :=
+          production.scan.nonDirectDefinitions.map
+            typedDefinitionOfProduction
+        crossing :=
+          production.crossing.map typedScanCrossingOfProduction
+      } := by
+  rw [typed_xml_events_of_production_eq_spec]
+  unfold scanTypedCommentEvidence typedDefinitionScanInputV7
+  simp only [List.foldl_nil]
+  have hScanner :
+      scanTypedDefinitionEvent {
+        wmlNamespace := typedWmlNamespace
+        idLocalName := typedLiteral [105,100]
+        referenceLocalName := typedLiteral []
+        definitionLocalName :=
+          typedLiteral [99,111,109,109,101,110,116]
+        sourceEvents := []
+        definitionEvents :=
+          typedXmlEventsOfProductionSpecV7 0 events
+      } =
+      scanTypedDefinitionEvent (typedDefinitionScanInputV7 []) := by
+    funext state event
+    rfl
+  rw [hScanner]
+  change
+    ((typedXmlEventsOfProductionSpecV7 0 events).foldl
+        (scanTypedDefinitionEvent (typedDefinitionScanInputV7 []))
+        (typedDefinitionStateOfProduction
+          ({} : Tier2.CommentReferenceIntegrity.CommentScanState))).scan = _
+  rw [fold_typed_definition_events_of_production]
+  rfl
+
+theorem typed_definitions_from_events_of_production
+    (events : List XmlEvent) :
+    typedDefinitionsFromEventsV7
+        (typedXmlEventsOfProduction events) =
+      let production :=
+        Tier2.CommentReferenceIntegrity.scanCommentEvidence {
+          sourceEvents := []
+          definitionEvents := events
+        }
+      production.scan.definitions.map typedDefinitionOfProduction ++
+        production.scan.nonDirectDefinitions.map
+          typedDefinitionOfProduction := by
+  unfold typedDefinitionsFromEventsV7
+  rw [typed_definition_scan_of_production]
 
 def typedCommentScanOfProduction
     (evidence : CommentSideEvidence) : TypedCommentScan :=
@@ -7878,7 +8926,23 @@ theorem typedCommentScanOfProduction_reference_length
 
 def typedPackageViewOfRecord (side : Side)
     (request : RunRequestCoreRequestV6)
-    (record : RunRequestPackageRecord) : TypedPackageView := {
+    (record : RunRequestPackageRecord) : TypedPackageView :=
+  let sources := record.commentEvidence.sources
+  let sourceTail := sources.drop 1
+  let noteSources := sourceTail.drop request.relationshipStories.length
+  let footnoteSource :=
+    if record.noteEvidence.footnotesPart.isSome then
+      noteSources.head?
+    else none
+  let endnoteSources :=
+    if record.noteEvidence.footnotesPart.isSome then
+      noteSources.drop 1
+    else noteSources
+  let endnoteSource :=
+    if record.noteEvidence.endnotesPart.isSome then
+      endnoteSources.head?
+    else none
+  {
   packageBytes := record.packageBytes
   index := typedIndexOfProduction record.packageIndex
   commentType :=
@@ -7887,19 +8951,18 @@ def typedPackageViewOfRecord (side : Side)
   commentsRootNamespace := typedBoundedBytesOfString wmlNamespace
   commentsRootLocalName := typedBoundedBytesOfString "comments"
   relationships := typedRelationshipsOfProduction record.relationships
-  mainSource := (record.commentEvidence.sources.find?
-      (fun source => source.sourceStory == "main")).map
+  mainSource := sources.head?.map
       (typedStorySourceOfProduction side) |>.getD
         (missingTypedMainSource side)
   headerFooterSlots :=
     request.relationshipSlots.map typedHeaderFooterSlotOfProduction
-  headerFooterStories := request.relationshipStories.map
-    (typedHeaderFooterStoryOfProduction side record.commentEvidence.sources)
+  headerFooterStories := typedHeaderFooterStoriesOfProduction
+    side sourceTail request.relationshipStories
   noteSelections :=
     [ typedNoteSelectionOfProduction side record.noteEvidence
-        record.commentEvidence.sources .footnotes
+        footnoteSource .footnotes
     , typedNoteSelectionOfProduction side record.noteEvidence
-        record.commentEvidence.sources .endnotes
+        endnoteSource .endnotes
     ]
   priorSourceAdmission :=
     typedPriorSourceAdmissionOfProduction request record.noteEvidence
@@ -7931,7 +8994,33 @@ def typedPackageViewOfRecord (side : Side)
   realization := record.commentEvidence.part.map
     typedCommentRealizationOfProduction
   retainedScan := typedCommentScanOfProduction record.commentEvidence
-}
+  }
+
+theorem canonical_typed_comment_source_slots_of_package_v7
+    (side : Side)
+    (request : RunRequestCoreRequestV6)
+    (record : RunRequestPackageRecord) :
+    canonicalTypedCommentSourceSlotsOfPackageV7
+        (typedPackageViewOfRecord side request record) =
+      typedCommentSourceDomainSlotsOfProduction
+        side record.commentEvidence.sources request.relationshipStories
+        record.noteEvidence.footnotesPart.isSome
+        record.noteEvidence.endnotesPart.isSome := by
+  unfold canonicalTypedCommentSourceSlotsOfPackageV7
+    typedPackageViewOfRecord typedCommentSourceDomainSlotsOfProduction
+  cases record.commentEvidence.sources with
+  | nil =>
+      dsimp
+      rw [typed_header_footer_stories_filter_map_v7]
+      simp only [List.drop_nil]
+      rw [typed_header_footer_source_slots_empty_v7]
+      simp [typed_note_selections_filter_map_v7]
+  | cons source rest =>
+      dsimp
+      rw [typed_header_footer_stories_filter_map_v7,
+        typed_header_footer_source_slots_remainder_v7,
+        typed_note_selections_filter_map_v7]
+      rfl
 
 def typedInheritedV5OfJson (response : Json) (passed : Bool) :
     TypedInheritedV5Evaluation := {
@@ -8388,6 +9477,38 @@ def retainedTypedMarkerCrossingOfProduction :
         ((Tier2.NoteReferenceIntegrity.typedCanonicalIdOfRaw (some canonical)).getD
           { negative := false, digits := [] })
 
+def retainedTypedMarkerAssociationOfProduction
+    (association : CommentMarkerAssociationV7) : TypedMarkerAssociationV7 := {
+  referenceCount := association.referenceCount
+  rangeStartCount := association.rangeStartCount
+  rangeEndCount := association.rangeEndCount
+  firstReference := association.firstReference.map
+    retainedTypedMarkerOccurrenceOfProduction
+  firstRangeStart := association.firstRangeStart.map
+    retainedTypedMarkerOccurrenceOfProduction
+  firstRangeEnd := association.firstRangeEnd.map
+    retainedTypedMarkerOccurrenceOfProduction
+  firstDuplicateReference := association.firstDuplicateReference.map
+    retainedTypedMarkerOccurrenceOfProduction
+  firstDuplicateRangeStart := association.firstDuplicateRangeStart.map
+    retainedTypedMarkerOccurrenceOfProduction
+  firstDuplicateRangeEnd := association.firstDuplicateRangeEnd.map
+    retainedTypedMarkerOccurrenceOfProduction
+}
+
+def retainedTypedMarkerAssociationTrieOfProduction
+    (evidence : ParsedCommentRangeEvidence) :
+    List String → TypedCanonicalIdTrie
+  | [] => .empty
+  | canonical :: rest =>
+      let trie := retainedTypedMarkerAssociationTrieOfProduction evidence rest
+      match Tier2.NoteReferenceIntegrity.typedCanonicalIdOfRaw (some canonical),
+          evidence.associations[canonical]? with
+      | some typedCanonical, some association =>
+          typedCanonicalIdTrieSet trie typedCanonical
+            (retainedTypedMarkerAssociationOfProduction association)
+      | _, _ => trie
+
 def retainedTypedMarkerEvidenceOfProduction
     (evidence : ParsedCommentRangeEvidence) : TypedMarkerScanEvidence :=
   let relationshipOccurrence := evidence.crossing.bind fun crossing =>
@@ -8409,6 +9530,25 @@ def retainedTypedMarkerEvidenceOfProduction
     processedStoryCount := evidence.processedStoryCount
     crossing := evidence.crossing.bind retainedTypedMarkerCrossingOfProduction
   }
+
+def concurrentTypedMarkerEvidenceV7
+    (inputStories : List TypedStorySource)
+    (evidence : ParsedCommentRangeEvidence) : TypedMarkerScanEvidence := {
+  inputStories
+  occurrences := evidence.typedState.occurrences.reverse
+  canonicalIds := evidence.typedState.canonicalIds.reverse
+  referenceOccurrences := evidence.typedState.referenceOccurrences
+  rangeStartOccurrences := evidence.typedState.rangeStartOccurrences
+  rangeEndOccurrences := evidence.typedState.rangeEndOccurrences
+  processedEventCount := evidence.typedState.processedEventCount
+  processedStoryCount := evidence.typedState.processedStoryCount
+  crossing := evidence.typedState.crossing
+}
+
+def retainedConcurrentTypedMarkerEvidenceCheckV7
+    (evidence : ParsedCommentRangeEvidence) : Bool :=
+  decide (retainedTypedMarkerEvidenceOfProduction evidence =
+    concurrentTypedMarkerEvidenceV7 [] evidence)
 
 def retainedTypedMarkerScanOfRecordV7
     (record : RunRequestPackageRecord) : Option TypedMarkerScanEvidence :=
@@ -8445,6 +9585,157 @@ def typedRequestOfProductionV7
       retainedTypedMarkerScanOfRecordV7 request.core.compared
   }
 
+def typedSideOfVerifierSide :
+    Tier2.CommentReferenceIntegrity.VerifierSide → Side
+  | .original => .original
+  | .revised => .revised
+  | .compared => .compared
+
+theorem typed_realization_success_of_production_v7
+    (request : VerifierRequestV7)
+    (typedRequest : TypedRequestV7)
+    (side : Tier2.CommentReferenceIntegrity.VerifierSide)
+    (selected : SelectedCommentIdentity)
+    (part : LoadedCommentPart)
+    (hTyped : typedRequestOfProductionV7 request = some typedRequest)
+    (hSelected :
+      Tier2.CommentReferenceIntegrity.selectConventionalMainCommentRecords
+        (request.core.packageRecord
+          (noteSideOfCommentSide side)).relationships =
+        .ok (some selected))
+    (hPart :
+      (request.core.packageRecord
+        (noteSideOfCommentSide side)).commentEvidence.part = some part)
+    (hIdentity : part.identity = selected)
+    (hFailure :
+      (Tier2.NoteReferenceIntegrity.typedPackageViewOfRecord
+        (typedSideOfVerifierSide side) request.core
+          (request.core.packageRecord
+            (noteSideOfCommentSide side))).realizationFailure = none)
+    (hAdmission :
+      typedAdmittedCommentRealizationCheck
+        (Tier2.NoteReferenceIntegrity.typedPackageViewOfRecord
+          (typedSideOfVerifierSide side) request.core
+            (request.core.packageRecord
+              (noteSideOfCommentSide side)))
+        (Tier2.NoteReferenceIntegrity.typedSelectedCommentOfProduction
+          selected)
+        (Tier2.NoteReferenceIntegrity.typedCommentRealizationOfProduction
+          part) = true) :
+    realizeTypedCommentV7 typedRequest (typedSideOfVerifierSide side) =
+      .ok (some
+        (Tier2.NoteReferenceIntegrity.typedCommentRealizationOfProduction
+          part)) := by
+  unfold typedRequestOfProductionV7 at hTyped
+  injection hTyped with hTyped
+  subst typedRequest
+  let pkg := Tier2.NoteReferenceIntegrity.typedPackageViewOfRecord
+    (typedSideOfVerifierSide side) request.core
+      (request.core.packageRecord (noteSideOfCommentSide side))
+  have hPackage :
+      typedPackageAt {
+        original := Tier2.NoteReferenceIntegrity.typedPackageViewOfRecord
+          .original request.core request.core.original
+        revised := Tier2.NoteReferenceIntegrity.typedPackageViewOfRecord
+          .revised request.core request.core.revised
+        compared := Tier2.NoteReferenceIntegrity.typedPackageViewOfRecord
+          .compared request.core request.core.compared
+        inherited :=
+          Tier2.NoteReferenceIntegrity.typedInheritedV5OfOperationalRequest
+            request.core request.semanticResponse
+        originalRetainedMarkerScan :=
+          retainedTypedMarkerScanOfRecordV7 request.core.original
+        revisedRetainedMarkerScan :=
+          retainedTypedMarkerScanOfRecordV7 request.core.revised
+        comparedRetainedMarkerScan :=
+          retainedTypedMarkerScanOfRecordV7 request.core.compared
+      } (typedSideOfVerifierSide side) = pkg := by
+    cases side <;> rfl
+  have hSelector :
+      selectTypedCommentV7 pkg =
+        .ok (some
+          (Tier2.NoteReferenceIntegrity.typedSelectedCommentOfProduction
+            selected)) := by
+    unfold selectTypedCommentV7
+    change selectTypedComment
+        (typedBoundedBytesOfString
+          Tier2.CommentReferenceIntegrity.commentsRelationshipType)
+        (Tier2.NoteReferenceIntegrity.typedRelationshipsOfProduction
+          (request.core.packageRecord
+            (noteSideOfCommentSide side)).relationships) =
+      .ok (some
+        (Tier2.NoteReferenceIntegrity.typedSelectedCommentOfProduction
+          selected))
+    exact Tier2.NoteReferenceIntegrity.typed_selector_success_of_production
+      _ selected hSelected
+  have hRealization :
+      pkg.realization =
+        some
+          (Tier2.NoteReferenceIntegrity.typedCommentRealizationOfProduction
+            part) := by
+    unfold pkg Tier2.NoteReferenceIntegrity.typedPackageViewOfRecord
+    simp only [hPart, Option.map]
+  change typedAdmittedCommentRealizationCheck pkg
+      (Tier2.NoteReferenceIntegrity.typedSelectedCommentOfProduction
+        selected)
+      (Tier2.NoteReferenceIntegrity.typedCommentRealizationOfProduction
+        part) = true at hAdmission
+  unfold realizeTypedCommentV7
+  dsimp only
+  rw [hPackage, hSelector, hFailure, hRealization]
+  dsimp only
+  rw [if_pos hAdmission]
+
+theorem typed_realization_none_of_production_v7
+    (request : VerifierRequestV7)
+    (typedRequest : TypedRequestV7)
+    (side : Tier2.CommentReferenceIntegrity.VerifierSide)
+    (hTyped : typedRequestOfProductionV7 request = some typedRequest)
+    (hSelected :
+      Tier2.CommentReferenceIntegrity.selectConventionalMainCommentRecords
+        (request.core.packageRecord
+          (noteSideOfCommentSide side)).relationships = .ok none) :
+    realizeTypedCommentV7 typedRequest (typedSideOfVerifierSide side) =
+      .ok none := by
+  unfold typedRequestOfProductionV7 at hTyped
+  injection hTyped with hTyped
+  subst typedRequest
+  let pkg := Tier2.NoteReferenceIntegrity.typedPackageViewOfRecord
+    (typedSideOfVerifierSide side) request.core
+      (request.core.packageRecord (noteSideOfCommentSide side))
+  have hPackage :
+      typedPackageAt {
+        original := Tier2.NoteReferenceIntegrity.typedPackageViewOfRecord
+          .original request.core request.core.original
+        revised := Tier2.NoteReferenceIntegrity.typedPackageViewOfRecord
+          .revised request.core request.core.revised
+        compared := Tier2.NoteReferenceIntegrity.typedPackageViewOfRecord
+          .compared request.core request.core.compared
+        inherited :=
+          Tier2.NoteReferenceIntegrity.typedInheritedV5OfOperationalRequest
+            request.core request.semanticResponse
+        originalRetainedMarkerScan :=
+          retainedTypedMarkerScanOfRecordV7 request.core.original
+        revisedRetainedMarkerScan :=
+          retainedTypedMarkerScanOfRecordV7 request.core.revised
+        comparedRetainedMarkerScan :=
+          retainedTypedMarkerScanOfRecordV7 request.core.compared
+      } (typedSideOfVerifierSide side) = pkg := by
+    cases side <;> rfl
+  have hSelector : selectTypedCommentV7 pkg = .ok none := by
+    unfold selectTypedCommentV7
+    change selectTypedComment
+        (typedBoundedBytesOfString
+          Tier2.CommentReferenceIntegrity.commentsRelationshipType)
+        (Tier2.NoteReferenceIntegrity.typedRelationshipsOfProduction
+          (request.core.packageRecord
+            (noteSideOfCommentSide side)).relationships) = .ok none
+    exact Tier2.NoteReferenceIntegrity.typed_selector_none_of_production
+      _ hSelected
+  unfold realizeTypedCommentV7
+  dsimp only
+  rw [hPackage, hSelector]
+
 def protocolV7ResponseJson (evaluation : Bool × Json) : Json :=
   evaluation.2
 
@@ -8468,12 +9759,6 @@ theorem protocol_v7_json_projection_check_sound
     ProtocolV7JsonProjectionOf response typedResponse := by
   exact typedByteListEqCheck_sound _ _ hCheck
 
-def typedSideOfVerifierSide :
-    Tier2.CommentReferenceIntegrity.VerifierSide → Side
-  | .original => .original
-  | .revised => .revised
-  | .compared => .compared
-
 def ProductionXmlEventsExactFrom :
     Nat → List TypedXmlEvent → List XmlEvent → Prop
   | _, [], [] => True
@@ -8491,6 +9776,26 @@ def productionXmlEventsExactCheckFrom :
         productionXmlEventsExactCheckFrom
           (ordinal + 1) typedRest eventRest
   | _, _, _ => false
+
+theorem production_xml_events_exact_check_from_spec :
+    ∀ ordinal events,
+      productionXmlEventsExactCheckFrom ordinal
+        (typedXmlEventsOfProductionSpecV7 ordinal events) events = true
+  | _, [] => rfl
+  | ordinal, event :: rest => by
+      unfold typedXmlEventsOfProductionSpecV7
+        productionXmlEventsExactCheckFrom
+      rw [typedXmlEventEqCheck_complete _ _ rfl,
+        production_xml_events_exact_check_from_spec]
+      rfl
+
+theorem production_xml_events_exact_check_from_production
+    (events : List XmlEvent) :
+    productionXmlEventsExactCheckFrom 0
+      (Tier2.NoteReferenceIntegrity.typedXmlEventsOfProduction events)
+        events = true := by
+  rw [Tier2.NoteReferenceIntegrity.typed_xml_events_of_production_eq_spec]
+  exact production_xml_events_exact_check_from_spec 0 events
 
 theorem production_xml_events_exact_check_from_sound :
     ∀ ordinal typed events,
@@ -8513,7 +9818,7 @@ def ProductionCommentSourceRealizationsExact :
   | typed :: typedRest, realization :: realizationRest =>
       typed.physicalStoryOrdinal = realization.slot.ordinal ∧
       typed.source.partPath.bytes =
-        realization.slot.normalizedPartPath.toUTF8.toList ∧
+        realization.slot.normalizedPartPath.toUTF8.data.toList ∧
       ProductionXmlEventsExactFrom 0 typed.source.parsed.events
         realization.visitedEvents ∧
       ProductionCommentSourceRealizationsExact typedRest realizationRest
@@ -8526,7 +9831,7 @@ def productionCommentSourceRealizationsExactCheck :
   | typed :: typedRest, realization :: realizationRest =>
       decide (typed.physicalStoryOrdinal = realization.slot.ordinal) &&
       decide (typed.source.partPath.bytes =
-        realization.slot.normalizedPartPath.toUTF8.toList) &&
+        realization.slot.normalizedPartPath.toUTF8.data.toList) &&
       productionXmlEventsExactCheckFrom 0 typed.source.parsed.events
         realization.visitedEvents &&
       productionCommentSourceRealizationsExactCheck typedRest realizationRest
@@ -8736,8 +10041,8 @@ def ExecutableCommentDefinitionRealizationV7ValueOf
         value.selected.relationshipId.bytes,
         value.selected.normalizedPartPath.bytes)) =
     some (selected.relationshipRecordOrdinal,
-      selected.relationshipId.toUTF8.toList,
-      selected.normalizedPartPath.toUTF8.toList) ∧
+      selected.relationshipId.toUTF8.data.toList,
+      selected.normalizedPartPath.toUTF8.data.toList) ∧
   (match typedPackage.realization with
     | none => False
     | some value =>
@@ -8746,7 +10051,37 @@ def ExecutableCommentDefinitionRealizationV7ValueOf
   typedDefinitionsV7 typedRequest (typedSideOfVerifierSide side) =
     typedDefinitionsFromEventsV7
       (Tier2.NoteReferenceIntegrity.typedXmlEventsOfProduction
-        realization.retainedParsedEvidence.events)
+        realization.retainedParsedEvidence.events) ∧
+  let record := request.core.packageRecord (noteSideOfCommentSide side)
+  ∃ retained,
+    record.commentEvidence.retainedScan = some retained ∧
+    retained.scanInvocationCount = 1 ∧
+    retained.input = productionCommentScanInput record ∧
+    retained.output =
+      Tier2.CommentReferenceIntegrity.scanCommentEvidence retained.input ∧
+    typedDefinitionsV7 typedRequest (typedSideOfVerifierSide side) =
+      retained.output.scan.definitions.map
+          Tier2.NoteReferenceIntegrity.typedDefinitionOfProduction ++
+        retained.output.scan.nonDirectDefinitions.map
+          Tier2.NoteReferenceIntegrity.typedDefinitionOfProduction
+
+theorem retained_comment_definitions_refine_typed_v7
+    (retained : RetainedCommentScan)
+    (events : List XmlEvent)
+    (hInput : retained.input = {
+      sourceEvents := []
+      definitionEvents := events
+    })
+    (hOutput : retained.output =
+      Tier2.CommentReferenceIntegrity.scanCommentEvidence retained.input) :
+    typedDefinitionsFromEventsV7
+        (Tier2.NoteReferenceIntegrity.typedXmlEventsOfProduction events) =
+      retained.output.scan.definitions.map
+          Tier2.NoteReferenceIntegrity.typedDefinitionOfProduction ++
+      retained.output.scan.nonDirectDefinitions.map
+          Tier2.NoteReferenceIntegrity.typedDefinitionOfProduction := by
+  rw [hOutput, hInput,
+    Tier2.NoteReferenceIntegrity.typed_definitions_from_events_of_production]
 
 def ExecutableCommentDefinitionRealizationV7RefinesTyped
     (request : VerifierRequestV7)
@@ -8779,8 +10114,8 @@ def executableCommentDefinitionRealizationV7RefinementCheck
         value.selected.relationshipId.bytes,
         value.selected.normalizedPartPath.bytes)) =
     some (selected.relationshipRecordOrdinal,
-      selected.relationshipId.toUTF8.toList,
-      selected.normalizedPartPath.toUTF8.toList)) &&
+      selected.relationshipId.toUTF8.data.toList,
+      selected.normalizedPartPath.toUTF8.data.toList)) &&
   (match typedPackage.realization with
     | none => false
     | some value =>
@@ -8789,7 +10124,19 @@ def executableCommentDefinitionRealizationV7RefinementCheck
   decide (typedDefinitionsV7 typedRequest (typedSideOfVerifierSide side) =
     typedDefinitionsFromEventsV7
       (Tier2.NoteReferenceIntegrity.typedXmlEventsOfProduction
-        realization.retainedParsedEvidence.events))
+        realization.retainedParsedEvidence.events)) &&
+  let record := request.core.packageRecord (noteSideOfCommentSide side)
+  match record.commentEvidence.retainedScan with
+  | none => false
+  | some retained =>
+      decide (retained.scanInvocationCount = 1) &&
+      decide (retained.input = productionCommentScanInput record) &&
+      decide (typedDefinitionsV7 typedRequest
+          (typedSideOfVerifierSide side) =
+        retained.output.scan.definitions.map
+            Tier2.NoteReferenceIntegrity.typedDefinitionOfProduction ++
+          retained.output.scan.nonDirectDefinitions.map
+            Tier2.NoteReferenceIntegrity.typedDefinitionOfProduction)
 
 theorem executable_comment_definition_realization_v7_refines_typed
     (request : VerifierRequestV7)
@@ -8826,9 +10173,32 @@ theorem executable_comment_definition_realization_v7_refines_typed
         exact production_xml_events_exact_check_from_sound
           0 value.retainedParsedEvents
             realization.retainedParsedEvidence.events
-            (by simpa [hRealization] using hCheck.1.2)
+            (by simpa [hRealization] using hCheck.1.1.2)
+  let record := request.core.packageRecord (noteSideOfCommentSide side)
+  have hRetainedBinding :
+      ∃ retained,
+        record.commentEvidence.retainedScan = some retained ∧
+        retained.scanInvocationCount = 1 ∧
+        retained.input = productionCommentScanInput record ∧
+        retained.output =
+          Tier2.CommentReferenceIntegrity.scanCommentEvidence retained.input ∧
+        typedDefinitionsV7 typedRequest (typedSideOfVerifierSide side) =
+          retained.output.scan.definitions.map
+              Tier2.NoteReferenceIntegrity.typedDefinitionOfProduction ++
+            retained.output.scan.nonDirectDefinitions.map
+              Tier2.NoteReferenceIntegrity.typedDefinitionOfProduction := by
+    have hBinding := hCheck.2
+    cases hRetained : record.commentEvidence.retainedScan with
+    | none =>
+        simp [record, hRetained] at hBinding
+    | some retained =>
+        simp only [record, hRetained, Bool.and_eq_true,
+          decide_eq_true_eq] at hBinding
+        exact ⟨retained, rfl, hBinding.1.1,
+          hBinding.1.2, retained.outputExact, hBinding.2⟩
   exact ⟨hSelected, hRun, hRetained, hTyped,
-    hCheck.1.1.1.1, hCheck.1.1.1.2, hCheck.1.1.2, hEvents, hCheck.2⟩
+    hCheck.1.1.1.1.1, hCheck.1.1.1.1.2, hCheck.1.1.1.2,
+    hEvents, hCheck.1.2, hRetainedBinding⟩
 
 abbrev SideCommentEvaluationV7 := CommentSideEvidence
 
@@ -9271,6 +10641,1661 @@ def typedRequestOfRunRequestCoreV7
     (request : RunRequestCoreRequestV7)
     (result : RunRequestCoreResultV7) : Option TypedRequestV7 :=
   typedRequestOfProductionV7 (verifierRequestV7OfRunRequestCore request result)
+
+def productionXmlEventListExactCheckV7 :
+    List XmlEvent → List XmlEvent → Bool
+  | [], [] => true
+  | left :: leftRest, right :: rightRest =>
+      decide (left = right) &&
+        productionXmlEventListExactCheckV7 leftRest rightRest
+  | _, _ => false
+
+theorem production_xml_event_list_exact_check_v7_sound :
+    ∀ left right,
+      productionXmlEventListExactCheckV7 left right = true →
+        left = right
+  | [], [], _ => rfl
+  | [], _ :: _, h => nomatch h
+  | _ :: _, [], h => nomatch h
+  | left :: leftRest, right :: rightRest, h => by
+      simp only [productionXmlEventListExactCheckV7,
+        Bool.and_eq_true, decide_eq_true_eq] at h
+      rw [h.1, production_xml_event_list_exact_check_v7_sound
+        leftRest rightRest h.2]
+
+inductive ProductionCommentSourceEventsExactFromV7 :
+    Nat → List NoteSource →
+      List Tier2.NoteReferenceIntegrity.StoryRealization → Prop
+  | nil (sourceOrdinal : Nat) :
+      ProductionCommentSourceEventsExactFromV7 sourceOrdinal [] []
+  | cons (sourceOrdinal : Nat) (source : NoteSource)
+      (realization : Tier2.NoteReferenceIntegrity.StoryRealization)
+      (sources : List NoteSource)
+      (realizations : List Tier2.NoteReferenceIntegrity.StoryRealization)
+      (sourceOrdinalExact : source.sourceOrdinal = sourceOrdinal)
+      (storyExact :
+        source.sourceStory =
+          commentMarkerSourceStoryName realization.slot.story)
+      (storyOrdinalExact :
+        source.sourceStoryOrdinal = realization.slot.ordinal)
+      (pathExact :
+        source.normalizedPartPath = realization.slot.normalizedPartPath)
+      (eventsExact :
+        source.parseEvidence.parsed.events = realization.visitedEvents)
+      (restExact :
+        ProductionCommentSourceEventsExactFromV7
+          (sourceOrdinal + 1) sources realizations) :
+      ProductionCommentSourceEventsExactFromV7 sourceOrdinal
+        (source :: sources) (realization :: realizations)
+
+abbrev ProductionCommentSourceEventsExactV7 :=
+  ProductionCommentSourceEventsExactFromV7 0
+
+def productionCommentSourceEventsExactCheckFromV7 :
+    Nat → List NoteSource →
+      List Tier2.NoteReferenceIntegrity.StoryRealization → Bool
+  | _, [], [] => true
+  | sourceOrdinal, source :: sources, realization :: realizations =>
+      decide (source.sourceOrdinal = sourceOrdinal) &&
+      decide (source.sourceStory =
+        commentMarkerSourceStoryName realization.slot.story) &&
+      decide (source.sourceStoryOrdinal = realization.slot.ordinal) &&
+      decide (source.normalizedPartPath =
+        realization.slot.normalizedPartPath) &&
+      productionXmlEventListExactCheckV7
+        source.parseEvidence.parsed.events realization.visitedEvents &&
+      productionCommentSourceEventsExactCheckFromV7
+        (sourceOrdinal + 1) sources realizations
+  | _, _, _ => false
+
+theorem production_comment_source_events_exact_check_from_v7_sound :
+    ∀ sourceOrdinal sources realizations,
+      productionCommentSourceEventsExactCheckFromV7
+          sourceOrdinal sources realizations = true →
+        ProductionCommentSourceEventsExactFromV7
+          sourceOrdinal sources realizations
+  | sourceOrdinal, [], [], _ => .nil sourceOrdinal
+  | _, [], _ :: _, h => nomatch h
+  | _, _ :: _, [], h => nomatch h
+  | sourceOrdinal, source :: sources, realization :: realizations, h => by
+      simp only [productionCommentSourceEventsExactCheckFromV7,
+        Bool.and_eq_true, decide_eq_true_eq] at h
+      exact .cons sourceOrdinal source realization sources realizations
+        h.1.1.1.1.1 h.1.1.1.1.2 h.1.1.1.2 h.1.1.2
+        (production_xml_event_list_exact_check_v7_sound _ _ h.1.2)
+        (production_comment_source_events_exact_check_from_v7_sound
+          (sourceOrdinal + 1) sources realizations h.2)
+
+def productionCommentSourceEventsExactCheckV7
+    (sources : List NoteSource)
+    (realizations : List Tier2.NoteReferenceIntegrity.StoryRealization) : Bool :=
+  productionCommentSourceEventsExactCheckFromV7 0 sources realizations
+
+theorem production_comment_source_events_exact_check_v7_sound
+    (sources : List NoteSource)
+    (realizations : List Tier2.NoteReferenceIntegrity.StoryRealization)
+    (hCheck :
+      productionCommentSourceEventsExactCheckV7 sources realizations = true) :
+    ProductionCommentSourceEventsExactV7 sources realizations :=
+  production_comment_source_events_exact_check_from_v7_sound
+    0 sources realizations hCheck
+
+theorem production_comment_source_events_exact_from_v7_to_concurrent
+    (side : Side) (sourceOrdinal : Nat) (sources : List NoteSource)
+    (realizations : List Tier2.NoteReferenceIntegrity.StoryRealization)
+    (hExact :
+      ProductionCommentSourceEventsExactFromV7
+        sourceOrdinal sources realizations) :
+    ConcurrentTypedStoryEventsV7
+      (sources.map
+        (Tier2.NoteReferenceIntegrity.typedStorySourceOfProduction side))
+      realizations := by
+  induction hExact with
+  | nil => exact ConcurrentTypedStoryEventsV7.nil
+  | cons sourceOrdinal source realization sources realizations _ _ _ _
+      eventsExact
+      _ hInduction =>
+      apply ConcurrentTypedStoryEventsV7.cons
+      · dsimp only [Tier2.NoteReferenceIntegrity.typedStorySourceOfProduction,
+          Tier2.NoteReferenceIntegrity.typedParsedPartOfProduction]
+        rw [Tier2.NoteReferenceIntegrity.typed_xml_events_of_production_eq_spec,
+          eventsExact]
+      · exact hInduction
+
+theorem production_comment_source_events_exact_v7_to_concurrent
+    (side : Side) (sources : List NoteSource)
+    (realizations : List Tier2.NoteReferenceIntegrity.StoryRealization)
+    (hExact :
+      ProductionCommentSourceEventsExactV7 sources realizations) :
+    ConcurrentTypedStoryEventsV7
+      (sources.map
+        (Tier2.NoteReferenceIntegrity.typedStorySourceOfProduction side))
+      realizations :=
+  production_comment_source_events_exact_from_v7_to_concurrent
+    side 0 sources realizations hExact
+
+theorem production_comment_source_events_exact_from_v7_to_realizations :
+    ∀ (side : Side) (sourceOrdinal : Nat) (sources : List NoteSource)
+      (realizations : List Tier2.NoteReferenceIntegrity.StoryRealization),
+      ProductionCommentSourceEventsExactFromV7
+          sourceOrdinal sources realizations →
+        ProductionCommentSourceRealizationsExact
+          (sources.map
+            (Tier2.NoteReferenceIntegrity.typedSourceSlotOfProduction side))
+          realizations
+  | _, _, [], [], .nil _ => trivial
+  | side, _, source :: sources, realization :: realizations,
+      .cons _ _ _ _ _ _ _ storyOrdinalExact pathExact eventsExact
+        restExact => by
+      simp only [List.map_cons]
+      refine ⟨?_, ?_, ?_, ?_⟩
+      · simpa [Tier2.NoteReferenceIntegrity.typedSourceSlotOfProduction]
+          using storyOrdinalExact
+      · dsimp only [Tier2.NoteReferenceIntegrity.typedSourceSlotOfProduction,
+          Tier2.NoteReferenceIntegrity.typedStorySourceOfProduction,
+          typedBoundedBytesOfString]
+        rw [pathExact]
+      · dsimp only [Tier2.NoteReferenceIntegrity.typedSourceSlotOfProduction,
+          Tier2.NoteReferenceIntegrity.typedStorySourceOfProduction,
+          Tier2.NoteReferenceIntegrity.typedParsedPartOfProduction]
+        rw [eventsExact]
+        exact production_xml_events_exact_check_from_sound 0 _ _
+          (production_xml_events_exact_check_from_production _)
+      · exact
+          production_comment_source_events_exact_from_v7_to_realizations
+            side _ sources realizations restExact
+
+def physicalStoryPartPathForVerifierSideV7
+    (side : Tier2.CommentReferenceIntegrity.VerifierSide)
+    (story : PhysicalStory) : String :=
+  match side with
+  | .original => story.originalPartPath
+  | .revised => story.revisedPartPath
+  | .compared => story.comparedPartPath
+
+def canonicalHeaderFooterCommentSourceIdentitiesFromV7
+    (side : Tier2.CommentReferenceIntegrity.VerifierSide) :
+    Nat → List PhysicalStory → List CommentSourceIdentity
+  | _, [] => []
+  | sourceOrdinal, story :: rest =>
+      { sourceOrdinal
+        sourceStory := story.kind.toString
+        sourceStoryOrdinal := story.physicalStoryOrdinal
+        normalizedPartPath :=
+          physicalStoryPartPathForVerifierSideV7 side story } ::
+      canonicalHeaderFooterCommentSourceIdentitiesFromV7
+        side (sourceOrdinal + 1) rest
+
+theorem canonical_header_footer_comment_source_identities_length_v7 :
+    ∀ (side : Tier2.CommentReferenceIntegrity.VerifierSide)
+      (sourceOrdinal : Nat) (stories : List PhysicalStory),
+      (canonicalHeaderFooterCommentSourceIdentitiesFromV7
+        side sourceOrdinal stories).length = stories.length
+  | _, _, [] => rfl
+  | side, sourceOrdinal, _ :: rest => by
+      unfold canonicalHeaderFooterCommentSourceIdentitiesFromV7
+      simp only [List.length_cons]
+      rw [canonical_header_footer_comment_source_identities_length_v7
+        side (sourceOrdinal + 1) rest]
+
+def canonicalCommentNoteSourceIdentitiesFromV7
+    (sourceOrdinal : Nat)
+    (footnotesPart endnotesPart : Option LoadedNotePart) :
+    List CommentSourceIdentity :=
+  let footnotes := match footnotesPart with
+    | none => []
+    | some part => [{
+        sourceOrdinal
+        sourceStory := "footnotes"
+        sourceStoryOrdinal := 0
+        normalizedPartPath := part.identity.normalizedPartPath
+      }]
+  let endnoteOrdinal := sourceOrdinal + footnotes.length
+  let endnotes := match endnotesPart with
+    | none => []
+    | some part => [{
+        sourceOrdinal := endnoteOrdinal
+        sourceStory := "endnotes"
+        sourceStoryOrdinal := 0
+        normalizedPartPath := part.identity.normalizedPartPath
+      }]
+  footnotes ++ endnotes
+
+def canonicalCommentSourceDomainIdentitiesV7
+    (request : RunRequestCoreRequestV7)
+    (side : Tier2.CommentReferenceIntegrity.VerifierSide) :
+    List CommentSourceIdentity :=
+  let record := request.packageRecord (noteSideOfCommentSide side)
+  let main : CommentSourceIdentity := {
+    sourceOrdinal := 0
+    sourceStory := "main"
+    sourceStoryOrdinal := 0
+    normalizedPartPath := "word/document.xml"
+  }
+  let headerFooter :=
+    canonicalHeaderFooterCommentSourceIdentitiesFromV7
+      side 1 request.relationshipStories
+  main :: headerFooter ++
+    canonicalCommentNoteSourceIdentitiesFromV7
+      (1 + request.relationshipStories.length)
+      record.noteEvidence.footnotesPart
+      record.noteEvidence.endnotesPart
+
+theorem typed_source_slot_of_header_identity_v7
+    (side : Side) (source : NoteSource)
+    (story : Tier2.RelationshipStorySelector.PhysicalStory)
+    (sourceOrdinal : Nat) (partPath : String)
+    (hIdentity : commentSourceIdentityProjection source = {
+      sourceOrdinal
+      sourceStory := story.kind.toString
+      sourceStoryOrdinal := story.physicalStoryOrdinal
+      normalizedPartPath := partPath
+    }) :
+    Tier2.NoteReferenceIntegrity.typedSourceSlotOfProduction side source = {
+      kind := Tier2.NoteReferenceIntegrity.typedHeaderFooterKindOfProduction
+        story.kind
+      physicalStoryOrdinal := story.physicalStoryOrdinal
+      source :=
+        Tier2.NoteReferenceIntegrity.typedStorySourceOfProduction side source
+    } := by
+  cases hStoryKind : story.kind
+  all_goals
+    have hStory := congrArg CommentSourceIdentity.sourceStory hIdentity
+    have hOrdinal :=
+      congrArg CommentSourceIdentity.sourceStoryOrdinal hIdentity
+    simp [commentSourceIdentityProjection, hStoryKind] at hStory hOrdinal
+    simp [Tier2.NoteReferenceIntegrity.typedSourceSlotOfProduction,
+      Tier2.NoteReferenceIntegrity.typedSourceKindOfProduction,
+      Tier2.NoteReferenceIntegrity.typedHeaderFooterKindOfProduction,
+      Tier2.RelationshipStorySelector.StoryKind.toString,
+      hStory, hOrdinal]
+
+theorem typed_source_slot_of_canonical_kind_v7
+    (side : Side) (source : NoteSource)
+    (kind : TypedSourceKind) (story : String)
+    (hKind :
+      (kind = .main ∧ story = "main") ∨
+      (kind = .footnotes ∧ story = "footnotes") ∨
+      (kind = .endnotes ∧ story = "endnotes"))
+    (hStory : source.sourceStory = story)
+    (hOrdinal : source.sourceStoryOrdinal = 0) :
+    Tier2.NoteReferenceIntegrity.typedSourceSlotOfProduction side source = {
+      kind
+      physicalStoryOrdinal := 0
+      source :=
+        Tier2.NoteReferenceIntegrity.typedStorySourceOfProduction side source
+    } := by
+  rcases hKind with hKind | hKind | hKind <;>
+    rcases hKind with ⟨rfl, rfl⟩ <;>
+    simp [Tier2.NoteReferenceIntegrity.typedSourceSlotOfProduction,
+      Tier2.NoteReferenceIntegrity.typedSourceKindOfProduction,
+      hStory, hOrdinal]
+
+theorem typed_note_source_slots_of_identity_map_v7
+    (side : Side) (sourceOrdinal : Nat)
+    (sources : List NoteSource)
+    (footnotesPart endnotesPart : Option LoadedNotePart)
+    (hSources :
+      sources.map commentSourceIdentityProjection =
+        canonicalCommentNoteSourceIdentitiesFromV7 sourceOrdinal
+          footnotesPart endnotesPart) :
+    Tier2.NoteReferenceIntegrity.typedNoteSourceSlotsOfProduction
+        side sources footnotesPart.isSome endnotesPart.isSome =
+      sources.map
+        (Tier2.NoteReferenceIntegrity.typedSourceSlotOfProduction side) := by
+  cases footnotesPart with
+  | none =>
+      cases endnotesPart with
+      | none =>
+          simp [canonicalCommentNoteSourceIdentitiesFromV7] at hSources
+          subst sources
+          rfl
+      | some endnotes =>
+          cases sources with
+          | nil =>
+              simp [canonicalCommentNoteSourceIdentitiesFromV7] at hSources
+          | cons source rest =>
+              cases rest with
+              | nil =>
+                  simp [canonicalCommentNoteSourceIdentitiesFromV7,
+                    commentSourceIdentityProjection] at hSources
+                  simp [Tier2.NoteReferenceIntegrity.typedNoteSourceSlotsOfProduction,
+                    Tier2.NoteReferenceIntegrity.typedSourceSlotOfProduction,
+                    Tier2.NoteReferenceIntegrity.typedSourceKindOfProduction,
+                    hSources]
+              | cons next tail =>
+                  simp [canonicalCommentNoteSourceIdentitiesFromV7] at hSources
+  | some footnotes =>
+      cases endnotesPart with
+      | none =>
+          cases sources with
+          | nil =>
+              simp [canonicalCommentNoteSourceIdentitiesFromV7] at hSources
+          | cons source rest =>
+              cases rest with
+              | nil =>
+                  simp [canonicalCommentNoteSourceIdentitiesFromV7,
+                    commentSourceIdentityProjection] at hSources
+                  simp [Tier2.NoteReferenceIntegrity.typedNoteSourceSlotsOfProduction,
+                    Tier2.NoteReferenceIntegrity.typedSourceSlotOfProduction,
+                    Tier2.NoteReferenceIntegrity.typedSourceKindOfProduction,
+                    hSources]
+              | cons next tail =>
+                  simp [canonicalCommentNoteSourceIdentitiesFromV7] at hSources
+      | some endnotes =>
+          cases sources with
+          | nil =>
+              simp [canonicalCommentNoteSourceIdentitiesFromV7] at hSources
+          | cons footSource rest =>
+              cases rest with
+              | nil =>
+                  simp [canonicalCommentNoteSourceIdentitiesFromV7] at hSources
+              | cons endSource tail =>
+                  cases tail with
+                  | nil =>
+                      simp [canonicalCommentNoteSourceIdentitiesFromV7,
+                        commentSourceIdentityProjection] at hSources
+                      simp [
+                        Tier2.NoteReferenceIntegrity.typedNoteSourceSlotsOfProduction,
+                        Tier2.NoteReferenceIntegrity.typedSourceSlotOfProduction,
+                        Tier2.NoteReferenceIntegrity.typedSourceKindOfProduction,
+                        hSources]
+                  | cons extra extras =>
+                      simp [canonicalCommentNoteSourceIdentitiesFromV7] at hSources
+
+theorem typed_comment_source_domain_tail_slots_v7 :
+    ∀ (side : Side)
+      (verifierSide : Tier2.CommentReferenceIntegrity.VerifierSide)
+      (sourceOrdinal : Nat) (sources : List NoteSource)
+      (stories : List Tier2.RelationshipStorySelector.PhysicalStory)
+      (footnotesPart endnotesPart : Option LoadedNotePart),
+      sources.map commentSourceIdentityProjection =
+          canonicalHeaderFooterCommentSourceIdentitiesFromV7
+            verifierSide sourceOrdinal stories ++
+          canonicalCommentNoteSourceIdentitiesFromV7
+            (sourceOrdinal + stories.length) footnotesPart endnotesPart →
+      let headerFooter :=
+        Tier2.NoteReferenceIntegrity.typedHeaderFooterSourceSlotsOfProduction
+          side sources stories
+      headerFooter.1 ++
+          Tier2.NoteReferenceIntegrity.typedNoteSourceSlotsOfProduction
+            side headerFooter.2 footnotesPart.isSome endnotesPart.isSome =
+        sources.map
+          (Tier2.NoteReferenceIntegrity.typedSourceSlotOfProduction side)
+  | side, verifierSide, sourceOrdinal, sources, [], footnotesPart,
+      endnotesPart, hSources => by
+      unfold canonicalHeaderFooterCommentSourceIdentitiesFromV7 at hSources
+      simp only [List.length_nil, Nat.add_zero, List.nil_append] at hSources
+      unfold Tier2.NoteReferenceIntegrity.typedHeaderFooterSourceSlotsOfProduction
+      exact typed_note_source_slots_of_identity_map_v7
+        side sourceOrdinal sources footnotesPart endnotesPart hSources
+  | side, verifierSide, sourceOrdinal, [], _ :: _, footnotesPart,
+      endnotesPart, hSources => by
+      simp [canonicalHeaderFooterCommentSourceIdentitiesFromV7] at hSources
+  | side, verifierSide, sourceOrdinal, source :: sourceRest, story :: rest,
+      footnotesPart, endnotesPart, hSources => by
+      unfold canonicalHeaderFooterCommentSourceIdentitiesFromV7 at hSources
+      simp only [List.map_cons, List.cons_append, List.cons.injEq] at hSources
+      have hHead := hSources.1
+      have hTail := hSources.2
+      have hSourceSlot :=
+        typed_source_slot_of_header_identity_v7
+          side source story sourceOrdinal
+          (physicalStoryPartPathForVerifierSideV7 verifierSide story) hHead
+      unfold Tier2.NoteReferenceIntegrity.typedHeaderFooterSourceSlotsOfProduction
+      dsimp
+      rw [← hSourceSlot]
+      simp only [List.cons.injEq, true_and]
+      apply typed_comment_source_domain_tail_slots_v7
+        side verifierSide (sourceOrdinal + 1)
+        sourceRest rest footnotesPart endnotesPart
+      simpa only [List.length_cons, Nat.add_assoc, Nat.add_left_comm,
+        Nat.add_comm] using hTail
+
+theorem typed_comment_source_domain_slots_v7
+    (request : RunRequestCoreRequestV7)
+    (verifierSide : Tier2.CommentReferenceIntegrity.VerifierSide)
+    (side : Side) (sources : List NoteSource)
+    (hSources :
+      sources.map commentSourceIdentityProjection =
+        canonicalCommentSourceDomainIdentitiesV7 request verifierSide) :
+    Tier2.NoteReferenceIntegrity.typedCommentSourceDomainSlotsOfProduction
+        side sources request.relationshipStories
+        (request.packageRecord
+          (noteSideOfCommentSide verifierSide)).noteEvidence.footnotesPart.isSome
+        (request.packageRecord
+          (noteSideOfCommentSide verifierSide)).noteEvidence.endnotesPart.isSome =
+      sources.map
+        (Tier2.NoteReferenceIntegrity.typedSourceSlotOfProduction side) := by
+  unfold canonicalCommentSourceDomainIdentitiesV7 at hSources
+  cases sources with
+  | nil => simp at hSources
+  | cons mainSource sourceTail =>
+      simp only [List.map_cons] at hSources
+      injection hSources with hMainIdentity hTailIdentity
+      have hMainStory :=
+        congrArg CommentSourceIdentity.sourceStory hMainIdentity
+      have hMainOrdinal :=
+        congrArg CommentSourceIdentity.sourceStoryOrdinal hMainIdentity
+      unfold
+        Tier2.NoteReferenceIntegrity.typedCommentSourceDomainSlotsOfProduction
+      dsimp
+      have hMainSlot :=
+        typed_source_slot_of_canonical_kind_v7
+          side mainSource .main "main" (Or.inl ⟨rfl, rfl⟩)
+          (by simpa [commentSourceIdentityProjection] using hMainStory)
+          (by simpa [commentSourceIdentityProjection] using hMainOrdinal)
+      rw [← hMainSlot]
+      simp only [List.cons.injEq, true_and]
+      apply typed_comment_source_domain_tail_slots_v7
+        side verifierSide 1 sourceTail request.relationshipStories
+        (request.packageRecord
+          (noteSideOfCommentSide verifierSide)).noteEvidence.footnotesPart
+        (request.packageRecord
+          (noteSideOfCommentSide verifierSide)).noteEvidence.endnotesPart
+      exact hTailIdentity
+
+def commentSourceDomainLocatorV7
+    (identity : CommentSourceIdentity) : String × Nat :=
+  (identity.sourceStory, identity.sourceStoryOrdinal)
+
+def ProductionCommentSourceDomainMetadataV7Of
+    (request : RunRequestCoreRequestV7)
+    (side : Tier2.CommentReferenceIntegrity.VerifierSide) : Prop :=
+  let record := request.packageRecord (noteSideOfCommentSide side)
+  let actual := retainedCommentSourceIdentities record
+  let expected := canonicalCommentSourceDomainIdentitiesV7 request side
+  actual = expected ∧
+  expected.length ≤ 387 ∧
+  (expected.map commentSourceDomainLocatorV7).Nodup ∧
+  record.noteEvidence.footnotesPartPresent =
+    record.noteEvidence.footnotesPart.isSome ∧
+  record.noteEvidence.endnotesPartPresent =
+    record.noteEvidence.endnotesPart.isSome
+
+def productionCommentSourceDomainMetadataCheckAtV7
+    (request : RunRequestCoreRequestV7)
+    (side : Tier2.CommentReferenceIntegrity.VerifierSide) : Bool :=
+  let record := request.packageRecord (noteSideOfCommentSide side)
+  let actual := retainedCommentSourceIdentities record
+  let expected := canonicalCommentSourceDomainIdentitiesV7 request side
+  decide (actual = expected) &&
+  decide (expected.length ≤ 387) &&
+  decide (expected.map commentSourceDomainLocatorV7).Nodup &&
+  decide (record.noteEvidence.footnotesPartPresent =
+    record.noteEvidence.footnotesPart.isSome) &&
+  decide (record.noteEvidence.endnotesPartPresent =
+    record.noteEvidence.endnotesPart.isSome)
+
+theorem production_comment_source_domain_metadata_check_at_v7_sound
+    (request : RunRequestCoreRequestV7)
+    (side : Tier2.CommentReferenceIntegrity.VerifierSide)
+    (hCheck :
+      productionCommentSourceDomainMetadataCheckAtV7 request side = true) :
+    ProductionCommentSourceDomainMetadataV7Of request side := by
+  unfold productionCommentSourceDomainMetadataCheckAtV7 at hCheck
+  unfold ProductionCommentSourceDomainMetadataV7Of
+  simp only [Bool.and_eq_true, decide_eq_true_eq] at hCheck
+  exact ⟨hCheck.1.1.1.1, hCheck.1.1.1.2, hCheck.1.1.2,
+    hCheck.1.2, hCheck.2⟩
+
+theorem typed_request_canonical_source_slots_of_production_v7
+    (request : VerifierRequestV7)
+    (side : Tier2.CommentReferenceIntegrity.VerifierSide)
+    (typedRequest : TypedRequestV7)
+    (hTyped : typedRequestOfProductionV7 request = some typedRequest)
+    (hDomain : ProductionCommentSourceDomainMetadataV7Of request.core side) :
+    canonicalTypedCommentSourceSlotsV7 typedRequest
+        (typedSideOfVerifierSide side) =
+      (request.core.packageRecord
+        (noteSideOfCommentSide side)).commentEvidence.sources.map
+        (Tier2.NoteReferenceIntegrity.typedSourceSlotOfProduction
+          (typedSideOfVerifierSide side)) := by
+  unfold typedRequestOfProductionV7 at hTyped
+  simp only [Option.some.injEq] at hTyped
+  subst typedRequest
+  unfold ProductionCommentSourceDomainMetadataV7Of at hDomain
+  have hSources := hDomain.1
+  unfold retainedCommentSourceIdentities at hSources
+  cases side <;>
+    simp only [canonicalTypedCommentSourceSlotsV7, typedPackageAt,
+      typedSideOfVerifierSide, noteSideOfCommentSide]
+  all_goals
+    rw [
+      Tier2.NoteReferenceIntegrity.canonical_typed_comment_source_slots_of_package_v7]
+    apply typed_comment_source_domain_slots_v7 request.core _ _ _ hSources
+
+theorem typed_request_canonical_sources_of_production_v7
+    (request : VerifierRequestV7)
+    (side : Tier2.CommentReferenceIntegrity.VerifierSide)
+    (typedRequest : TypedRequestV7)
+    (hTyped : typedRequestOfProductionV7 request = some typedRequest)
+    (hDomain : ProductionCommentSourceDomainMetadataV7Of request.core side) :
+    canonicalTypedCommentSourcesV7 typedRequest
+        (typedSideOfVerifierSide side) =
+      (request.core.packageRecord
+        (noteSideOfCommentSide side)).commentEvidence.sources.map
+        (Tier2.NoteReferenceIntegrity.typedStorySourceOfProduction
+          (typedSideOfVerifierSide side)) := by
+  unfold canonicalTypedCommentSourcesV7
+  rw [typed_request_canonical_source_slots_of_production_v7
+    request side typedRequest hTyped hDomain]
+  simp [List.map_map, Function.comp_apply,
+    Tier2.NoteReferenceIntegrity.typedSourceSlotOfProduction]
+
+theorem production_comment_source_events_exact_v7_to_realizations
+    (request : VerifierRequestV7)
+    (side : Tier2.CommentReferenceIntegrity.VerifierSide)
+    (typedRequest : TypedRequestV7)
+    (realizations : List Tier2.NoteReferenceIntegrity.StoryRealization)
+    (hTyped : typedRequestOfProductionV7 request = some typedRequest)
+    (hDomain : ProductionCommentSourceDomainMetadataV7Of request.core side)
+    (hExact : ProductionCommentSourceEventsExactV7
+      (request.core.packageRecord
+        (noteSideOfCommentSide side)).commentEvidence.sources
+      realizations) :
+    ProductionCommentSourceRealizationsExact
+      (canonicalTypedCommentSourceSlotsV7 typedRequest
+        (typedSideOfVerifierSide side))
+      realizations := by
+  rw [typed_request_canonical_source_slots_of_production_v7
+    request side typedRequest hTyped hDomain]
+  exact production_comment_source_events_exact_from_v7_to_realizations
+    (typedSideOfVerifierSide side) 0 _ _ hExact
+
+def productionCommentSourceBindingCheckV7
+    (request : RunRequestCoreRequestV7)
+    (side : Tier2.CommentReferenceIntegrity.VerifierSide)
+    (record : RunRequestPackageRecord) : Bool :=
+  productionCommentSourceDomainMetadataCheckAtV7 request side &&
+  record.commentEvidence.markerScanRun.any fun run =>
+    productionCommentSourceEventsExactCheckV7
+      record.commentEvidence.sources run.scans.realizations
+
+theorem production_comment_source_binding_check_v7_sound
+    (request : RunRequestCoreRequestV7)
+    (side : Tier2.CommentReferenceIntegrity.VerifierSide)
+    (record : RunRequestPackageRecord)
+    (hCheck : productionCommentSourceBindingCheckV7
+      request side record = true) :
+    ProductionCommentSourceDomainMetadataV7Of request side ∧
+    ∃ run, record.commentEvidence.markerScanRun = some run ∧
+      ProductionCommentSourceEventsExactV7
+        record.commentEvidence.sources run.scans.realizations := by
+  unfold productionCommentSourceBindingCheckV7 at hCheck
+  simp only [Bool.and_eq_true] at hCheck
+  refine ⟨production_comment_source_domain_metadata_check_at_v7_sound
+    request side hCheck.1, ?_⟩
+  cases hRun : record.commentEvidence.markerScanRun with
+  | none => simp [hRun] at hCheck
+  | some run =>
+      refine ⟨run, rfl, ?_⟩
+      simp [hRun] at hCheck
+      exact production_comment_source_events_exact_check_v7_sound
+        _ _ hCheck.2
+
+def productionTypedCommentAdmissionCheckAtV7
+    (request : RunRequestCoreRequestV7)
+    (side : Tier2.CommentReferenceIntegrity.VerifierSide)
+    (record : RunRequestPackageRecord) : Bool :=
+  let pkg := Tier2.NoteReferenceIntegrity.typedPackageViewOfRecord
+    (typedSideOfVerifierSide side) request record
+  match Tier2.CommentReferenceIntegrity.selectConventionalMainCommentRecords
+      record.relationships with
+  | .error _ => false
+  | .ok none => true
+  | .ok (some selected) =>
+      record.commentEvidence.part.any fun part =>
+        decide (part.identity = selected) &&
+        pkg.realizationFailure.isNone &&
+        typedAdmittedCommentRealizationCheck pkg
+          (Tier2.NoteReferenceIntegrity.typedSelectedCommentOfProduction
+            selected)
+          (Tier2.NoteReferenceIntegrity.typedCommentRealizationOfProduction
+            part)
+
+theorem production_typed_comment_admission_check_at_v7_sound
+    (request : RunRequestCoreRequestV7)
+    (side : Tier2.CommentReferenceIntegrity.VerifierSide)
+    (record : RunRequestPackageRecord)
+    (selected : SelectedCommentIdentity)
+    (hSelected :
+      Tier2.CommentReferenceIntegrity.selectConventionalMainCommentRecords
+        record.relationships = .ok (some selected))
+    (hCheck :
+      productionTypedCommentAdmissionCheckAtV7 request side record = true) :
+    ∃ part,
+      record.commentEvidence.part = some part ∧
+      part.identity = selected ∧
+      (Tier2.NoteReferenceIntegrity.typedPackageViewOfRecord
+        (typedSideOfVerifierSide side) request record).realizationFailure =
+          none ∧
+      typedAdmittedCommentRealizationCheck
+        (Tier2.NoteReferenceIntegrity.typedPackageViewOfRecord
+          (typedSideOfVerifierSide side) request record)
+        (Tier2.NoteReferenceIntegrity.typedSelectedCommentOfProduction
+          selected)
+        (Tier2.NoteReferenceIntegrity.typedCommentRealizationOfProduction
+          part) = true := by
+  unfold productionTypedCommentAdmissionCheckAtV7 at hCheck
+  rw [hSelected] at hCheck
+  cases hPart : record.commentEvidence.part with
+  | none => simp [hPart] at hCheck
+  | some part =>
+      simp only [hPart, Option.any, Bool.and_eq_true,
+        decide_eq_true_eq, Option.isNone_iff_eq_none] at hCheck
+      refine ⟨part, rfl, hCheck.1.1, hCheck.1.2, ?_⟩
+      simpa only [hCheck.1.1] using hCheck.2
+
+theorem production_typed_definitions_retained_v7
+    (request : VerifierRequestV7)
+    (typedRequest : TypedRequestV7)
+    (side : Tier2.CommentReferenceIntegrity.VerifierSide)
+    (hTyped : typedRequestOfProductionV7 request = some typedRequest)
+    (hComment : ProductionCommentEvidenceOf
+      (request.core.packageRecord (noteSideOfCommentSide side)))
+    (hAdmissionCheck :
+      productionTypedCommentAdmissionCheckAtV7 request.core side
+        (request.core.packageRecord
+          (noteSideOfCommentSide side)) = true) :
+    ∃ retained,
+      (request.core.packageRecord
+        (noteSideOfCommentSide side)).commentEvidence.retainedScan =
+          some retained ∧
+      typedDefinitionsV7 typedRequest (typedSideOfVerifierSide side) =
+        retained.output.scan.definitions.map
+            Tier2.NoteReferenceIntegrity.typedDefinitionOfProduction ++
+          retained.output.scan.nonDirectDefinitions.map
+            Tier2.NoteReferenceIntegrity.typedDefinitionOfProduction := by
+  let record :=
+    request.core.packageRecord (noteSideOfCommentSide side)
+  change ProductionCommentEvidenceOf record at hComment
+  change productionTypedCommentAdmissionCheckAtV7
+      request.core side record = true at hAdmissionCheck
+  have hSelection := hComment.2.2.1
+  rcases hComment.2.2.2.2 with
+    ⟨retained, hRetained, _hCount, hInput, hOutput, _hCrossing,
+      _hIntegrity, _hInventory, _hComplete, _hLimit, _hIssues⟩
+  refine ⟨retained, hRetained, ?_⟩
+  cases hSelected :
+      selectConventionalMainCommentRecords record.relationships with
+  | error failure =>
+      simp only [hSelected] at hSelection
+  | ok selected? =>
+      cases selected? with
+      | none =>
+          simp only [hSelected] at hSelection
+          have hRealize := typed_realization_none_of_production_v7
+            request typedRequest side hTyped hSelected
+          have hInputEmpty : retained.input = {
+              sourceEvents := []
+              definitionEvents := []
+            } := by
+            rw [hInput]
+            unfold productionCommentScanInput
+            rw [hSelection.2.1]
+            rfl
+          have hRef := retained_comment_definitions_refine_typed_v7
+            retained [] hInputEmpty hOutput
+          unfold typedDefinitionsV7
+          rw [hRealize]
+          exact hRef
+      | some selected =>
+          simp only [hSelected] at hSelection
+          rcases production_typed_comment_admission_check_at_v7_sound
+              request.core side record selected hSelected hAdmissionCheck with
+            ⟨part, hPart, hIdentity, hFailure, hAdmission⟩
+          have hRealize := typed_realization_success_of_production_v7
+            request typedRequest side selected part hTyped hSelected hPart
+              hIdentity hFailure hAdmission
+          have hInputPart : retained.input = {
+              sourceEvents := []
+              definitionEvents := part.parseEvidence.parsed.events
+            } := by
+            rw [hInput]
+            unfold productionCommentScanInput
+            rw [hPart]
+            rfl
+          have hRef := retained_comment_definitions_refine_typed_v7
+            retained part.parseEvidence.parsed.events hInputPart hOutput
+          unfold typedDefinitionsV7
+          rw [hRealize]
+          exact hRef
+
+def productionCommentOutcomeCheckAtV7
+    (evidence : CommentSideEvidence) : Bool :=
+  let inventoryZero :=
+    evidence.inventory.referenceOccurrences == 0 &&
+    evidence.inventory.rangeStartOccurrences == 0 &&
+    evidence.inventory.rangeEndOccurrences == 0 &&
+    evidence.inventory.uniqueReferenceIds == 0 &&
+    evidence.inventory.definitions == 0 &&
+    evidence.inventory.unreferencedDefinitions == 0 &&
+    evidence.inventory.nonDirectDefinitions == 0
+  let retainedTopology :=
+    match evidence.retainedScan, evidence.markerScan with
+    | some retained, some marker =>
+        checkTypedPackageCommentRangeIntegrity
+          (retained.output.scan.definitions.map
+              Tier2.NoteReferenceIntegrity.typedDefinitionOfProduction ++
+            retained.output.scan.nonDirectDefinitions.map
+              Tier2.NoteReferenceIntegrity.typedDefinitionOfProduction)
+          (concurrentTypedMarkerEvidenceV7 [] marker)
+    | _, _ => false
+  if evidence.complete then
+    evidence.markerScanInvocationCount == 1 &&
+    evidence.markerScan.any retainedConcurrentTypedMarkerEvidenceCheckV7 &&
+    retainedTopology &&
+    !evidence.semanticLimitCrossed &&
+    (evidence.productionIntegrityPassed == evidence.issues.isEmpty) &&
+    (if evidence.productionIntegrityPassed then
+      evidence.inventory.status == "passed"
+    else
+      evidence.inventory.status == "failed")
+  else
+    !evidence.productionIntegrityPassed &&
+    evidence.inventory.status == "not_evaluated" &&
+    inventoryZero &&
+    ((evidence.markerScanInvocationCount == 0 &&
+        evidence.markerScan.isNone) ||
+      (evidence.markerScanInvocationCount == 1 &&
+        (evidence.semanticLimitCrossed ||
+          evidence.markerScan.any (·.crossing.isSome))))
+
+def productionCommentOutcomeChecksV7
+    (request : RunRequestCoreRequestV7) : Bool :=
+  (productionCommentOutcomeCheckAtV7 request.original.commentEvidence &&
+    productionCommentSourceBindingCheckV7
+      request .original request.original &&
+    productionTypedCommentAdmissionCheckAtV7
+      request .original request.original) &&
+  (productionCommentOutcomeCheckAtV7 request.revised.commentEvidence &&
+    productionCommentSourceBindingCheckV7
+      request .revised request.revised &&
+    productionTypedCommentAdmissionCheckAtV7
+      request .revised request.revised) &&
+  (productionCommentOutcomeCheckAtV7 request.compared.commentEvidence &&
+    productionCommentSourceBindingCheckV7
+      request .compared request.compared &&
+    productionTypedCommentAdmissionCheckAtV7
+      request .compared request.compared)
+
+theorem production_comment_outcome_check_v7_complete_topology
+    (evidence : CommentSideEvidence)
+    (hCheck : productionCommentOutcomeCheckAtV7 evidence = true)
+    (hComplete : evidence.complete = true) :
+    ∃ retained marker,
+      evidence.retainedScan = some retained ∧
+      evidence.markerScan = some marker ∧
+      retainedConcurrentTypedMarkerEvidenceCheckV7 marker = true ∧
+      checkTypedPackageCommentRangeIntegrity
+        (retained.output.scan.definitions.map
+            Tier2.NoteReferenceIntegrity.typedDefinitionOfProduction ++
+          retained.output.scan.nonDirectDefinitions.map
+            Tier2.NoteReferenceIntegrity.typedDefinitionOfProduction)
+        (concurrentTypedMarkerEvidenceV7 [] marker) = true := by
+  unfold productionCommentOutcomeCheckAtV7 at hCheck
+  simp only [hComplete, if_true, Bool.and_eq_true] at hCheck
+  cases hRetained : evidence.retainedScan with
+  | none =>
+      simp [hRetained] at hCheck
+  | some retained =>
+      cases hMarker : evidence.markerScan with
+      | none =>
+          simp [hRetained, hMarker] at hCheck
+      | some marker =>
+          refine ⟨retained, marker, rfl, rfl, ?_, ?_⟩
+          · have hConcurrent := hCheck.1.1.1.1.2
+            simpa [hMarker] using hConcurrent
+          · have hTopology := hCheck.1.1.1.2
+            simpa [hRetained, hMarker] using hTopology
+
+theorem production_comment_outcome_checks_v7_at
+    (request : RunRequestCoreRequestV7)
+    (side : Tier2.CommentReferenceIntegrity.VerifierSide)
+    (hChecks : productionCommentOutcomeChecksV7 request = true) :
+    productionCommentOutcomeCheckAtV7
+        (request.packageRecord
+          (noteSideOfCommentSide side)).commentEvidence = true ∧
+      ProductionCommentSourceDomainMetadataV7Of request side ∧
+      ∃ run,
+        (request.packageRecord
+          (noteSideOfCommentSide side)).commentEvidence.markerScanRun =
+            some run ∧
+        ProductionCommentSourceEventsExactV7
+          (request.packageRecord
+            (noteSideOfCommentSide side)).commentEvidence.sources
+          run.scans.realizations := by
+  unfold productionCommentOutcomeChecksV7 at hChecks
+  simp only [Bool.and_eq_true] at hChecks
+  cases side with
+  | original =>
+      refine ⟨hChecks.1.1.1.1, ?_⟩
+      exact production_comment_source_binding_check_v7_sound
+        request .original request.original hChecks.1.1.1.2
+  | revised =>
+      refine ⟨hChecks.1.2.1.1, ?_⟩
+      exact production_comment_source_binding_check_v7_sound
+        request .revised request.revised hChecks.1.2.1.2
+  | compared =>
+      refine ⟨hChecks.2.1.1, ?_⟩
+      exact production_comment_source_binding_check_v7_sound
+        request .compared request.compared hChecks.2.1.2
+
+theorem production_comment_admission_checks_v7_at
+    (request : RunRequestCoreRequestV7)
+    (side : Tier2.CommentReferenceIntegrity.VerifierSide)
+    (hChecks : productionCommentOutcomeChecksV7 request = true) :
+    productionTypedCommentAdmissionCheckAtV7 request side
+      (request.packageRecord (noteSideOfCommentSide side)) = true := by
+  unfold productionCommentOutcomeChecksV7 at hChecks
+  simp only [Bool.and_eq_true] at hChecks
+  cases side with
+  | original => exact hChecks.1.1.2
+  | revised => exact hChecks.1.2.2
+  | compared => exact hChecks.2.2
+
+def productionTypedMarkerSlotIdentityV7 (slot : TypedSourceSlot) :
+    TypedPhysicalStoryIdentity := {
+  kind := slot.kind
+  physicalStoryOrdinal := slot.physicalStoryOrdinal
+}
+
+theorem typed_marker_story_at_slot_identity_ext_v7 :
+    ∀ (left right : List TypedSourceSlot),
+      left.map productionTypedMarkerSlotIdentityV7 =
+          right.map productionTypedMarkerSlotIdentityV7 →
+      ∀ ordinal,
+        typedMarkerStoryAt {
+          stories := []
+          slots := left
+          wmlNamespace := typedLiteral []
+          idLocalName := typedLiteral []
+          rangeStartLocalName := typedLiteral []
+          rangeEndLocalName := typedLiteral []
+          referenceLocalName := typedLiteral []
+        } ordinal =
+        typedMarkerStoryAt {
+          stories := []
+          slots := right
+          wmlNamespace := typedLiteral []
+          idLocalName := typedLiteral []
+          rangeStartLocalName := typedLiteral []
+          rangeEndLocalName := typedLiteral []
+          referenceLocalName := typedLiteral []
+        } ordinal
+  | [], [], _, _ => rfl
+  | [], _ :: _, h, _ => by simp at h
+  | _ :: _, [], h, _ => by simp at h
+  | left :: leftRest, right :: rightRest, h, 0 => by
+      have hHead := (List.cons.inj h).1
+      simpa [typedMarkerStoryAt, typedListGet?,
+        productionTypedMarkerSlotIdentityV7] using hHead
+  | left :: leftRest, right :: rightRest, h, ordinal + 1 => by
+      have hTail := (List.cons.inj h).2
+      exact typed_marker_story_at_slot_identity_ext_v7
+        leftRest rightRest hTail ordinal
+
+theorem production_comment_source_events_exact_v7_slot_identities
+    (side : Side) (sourceOrdinal : Nat) (sources : List NoteSource)
+    (realizations : List Tier2.NoteReferenceIntegrity.StoryRealization)
+    (hExact :
+      ProductionCommentSourceEventsExactFromV7
+        sourceOrdinal sources realizations) :
+    (sources.map
+      (Tier2.NoteReferenceIntegrity.typedSourceSlotOfProduction side)).map
+        productionTypedMarkerSlotIdentityV7 =
+      (realizations.map concurrentTypedMarkerSlotV7).map
+        productionTypedMarkerSlotIdentityV7 := by
+  induction hExact with
+  | nil => rfl
+  | cons sourceOrdinal source realization sources realizations
+      _ storyExact storyOrdinalExact _ _ _ hInduction =>
+      simp only [List.map_cons, List.cons.injEq]
+      refine ⟨?_, hInduction⟩
+      unfold productionTypedMarkerSlotIdentityV7
+        Tier2.NoteReferenceIntegrity.typedSourceSlotOfProduction
+        concurrentTypedMarkerSlotV7
+      dsimp
+      cases hStory : realization.slot.story <;>
+        simp [concurrentTypedMarkerSourceKindV7,
+          Tier2.NoteReferenceIntegrity.typedSourceKindOfProduction,
+          commentMarkerSourceStoryName, hStory] at storyExact ⊢
+      all_goals simp_all
+
+theorem typed_marker_story_at_input_slot_identity_ext_v7
+    (left right : TypedMarkerScanInput)
+    (hSlots :
+      left.slots.map productionTypedMarkerSlotIdentityV7 =
+        right.slots.map productionTypedMarkerSlotIdentityV7)
+    (ordinal : Nat) :
+    typedMarkerStoryAt left ordinal =
+      typedMarkerStoryAt right ordinal := by
+  simpa [typedMarkerStoryAt] using
+    typed_marker_story_at_slot_identity_ext_v7
+      left.slots right.slots hSlots ordinal
+
+theorem concurrent_typed_marker_input_observational_v7
+    (request : VerifierRequestV7)
+    (side : Tier2.CommentReferenceIntegrity.VerifierSide)
+    (typedRequest : TypedRequestV7)
+    (scans : Tier2.NoteReferenceIntegrity.SideScanEvidence)
+    (hTyped : typedRequestOfProductionV7 request = some typedRequest)
+    (hDomain : ProductionCommentSourceDomainMetadataV7Of request.core side)
+    (hExact : ProductionCommentSourceEventsExactV7
+      (request.core.packageRecord
+        (noteSideOfCommentSide side)).commentEvidence.sources
+      scans.realizations) :
+    TypedMarkerScanInputObservationalEqV7
+      (concurrentTypedMarkerInputV7 scans)
+      (typedMarkerScanInputV7 typedRequest
+        (typedSideOfVerifierSide side)) := by
+  have hCanonical :=
+    typed_request_canonical_source_slots_of_production_v7
+      request side typedRequest hTyped hDomain
+  have hExactSlots :=
+    production_comment_source_events_exact_v7_slot_identities
+      (typedSideOfVerifierSide side) 0
+      (request.core.packageRecord
+        (noteSideOfCommentSide side)).commentEvidence.sources
+      scans.realizations hExact
+  unfold TypedMarkerScanInputObservationalEqV7
+  refine ⟨rfl, rfl, rfl, rfl, rfl, ?_⟩
+  intro ordinal
+  apply typed_marker_story_at_input_slot_identity_ext_v7
+  unfold concurrentTypedMarkerInputV7 typedMarkerScanInputV7
+  dsimp
+  rw [hCanonical]
+  exact hExactSlots.symm
+
+theorem concurrent_typed_marker_evidence_scan_v7
+    (set : Tier2.CommentReferenceIntegrity.CommentSourceSet)
+    (scans : Tier2.NoteReferenceIntegrity.SideScanEvidence)
+    (stories : List TypedStorySource)
+    (evidence : ParsedCommentRangeEvidence)
+    (hMatch : Tier2.CommentReferenceIntegrity.storySlotListsMatch
+      set.sources (scans.realizations.map (·.slot)) = true)
+    (hEvents : ConcurrentTypedStoryEventsV7 stories scans.realizations)
+    (hRun : retainedCommentMarkerScanForRelationshipV7
+      true set scans = .ok evidence) :
+    concurrentTypedMarkerEvidenceV7 stories evidence =
+      scanTypedCommentMarkersV7
+        { concurrentTypedMarkerInputV7 scans with stories } := by
+  unfold retainedCommentMarkerScanForRelationshipV7
+    scanRetainedCommentMarkersForRelationshipV7 at hRun
+  rw [hMatch] at hRun
+  simp only [if_true, Except.ok.injEq] at hRun
+  subst evidence
+  have hState :=
+    scan_retained_comment_stories_loop_v7_typed_state
+      (concurrentTypedMarkerInputV7 scans) 0 {}
+      stories scans.realizations hEvents
+  unfold concurrentTypedMarkerEvidenceV7 scanTypedCommentMarkersV7
+  dsimp
+  rw [hState]
+  have hInput :
+      TypedMarkerScanInputObservationalEqV7
+        (concurrentTypedMarkerInputV7 scans)
+        { concurrentTypedMarkerInputV7 scans with stories } := by
+    exact ⟨rfl, rfl, rfl, rfl, rfl, fun _ => rfl⟩
+  rw [scan_typed_stories_v7_input_observational_ext
+    (concurrentTypedMarkerInputV7 scans)
+    { concurrentTypedMarkerInputV7 scans with stories } hInput]
+
+theorem canonical_typed_marker_scan_observational_v7
+    (request : VerifierRequestV7)
+    (side : Tier2.CommentReferenceIntegrity.VerifierSide)
+    (typedRequest : TypedRequestV7)
+    (scans : Tier2.NoteReferenceIntegrity.SideScanEvidence)
+    (hTyped : typedRequestOfProductionV7 request = some typedRequest)
+    (hDomain : ProductionCommentSourceDomainMetadataV7Of request.core side)
+    (hExact : ProductionCommentSourceEventsExactV7
+      (request.core.packageRecord
+        (noteSideOfCommentSide side)).commentEvidence.sources
+      scans.realizations) :
+    scanTypedCommentMarkersV7 {
+        concurrentTypedMarkerInputV7 scans with
+        stories := canonicalTypedCommentSourcesV7 typedRequest
+          (typedSideOfVerifierSide side)
+      } =
+      retainedOrIndependentTypedMarkerScanV7 typedRequest
+        (typedSideOfVerifierSide side) := by
+  have hInput :=
+    concurrent_typed_marker_input_observational_v7
+      request side typedRequest scans hTyped hDomain hExact
+  have hUpdatedInput :
+      TypedMarkerScanInputObservationalEqV7
+        { concurrentTypedMarkerInputV7 scans with
+          stories := canonicalTypedCommentSourcesV7 typedRequest
+            (typedSideOfVerifierSide side) }
+        (typedMarkerScanInputV7 typedRequest
+          (typedSideOfVerifierSide side)) := by
+    exact hInput
+  unfold scanTypedCommentMarkersV7
+    retainedOrIndependentTypedMarkerScanV7 typedMarkerScanInputV7
+  dsimp
+  rw [scan_typed_stories_v7_input_observational_ext _ _ hUpdatedInput]
+  rfl
+
+theorem retained_concurrent_typed_marker_evidence_rebind_v7
+    (stories : List TypedStorySource)
+    (evidence : ParsedCommentRangeEvidence)
+    (hCheck : retainedConcurrentTypedMarkerEvidenceCheckV7 evidence = true) :
+    typedMarkerEvidenceOfProduction stories evidence =
+      concurrentTypedMarkerEvidenceV7 stories evidence := by
+  unfold retainedConcurrentTypedMarkerEvidenceCheckV7 at hCheck
+  have hEvidence :
+      retainedTypedMarkerEvidenceOfProduction evidence =
+        concurrentTypedMarkerEvidenceV7 [] evidence :=
+    of_decide_eq_true hCheck
+  exact congrArg (fun marker => { marker with inputStories := stories })
+    hEvidence
+
+theorem comment_marker_candidate_none_of_kind_none_v7
+    (event : Tier2.XmlTripleChecker.XmlEvent)
+    (hNone : commentMarkerKindCandidateV7 event = none) :
+    commentMarkerCandidateV7 event = none := by
+  cases event with
+  | startElement uri localName attributes depth selfClosing =>
+      by_cases hUri : uri = Tier2.XmlTripleChecker.wmlNamespace
+      · by_cases hStart : localName = "commentRangeStart"
+        · simp [commentMarkerKindCandidateV7, hUri, hStart] at hNone
+        · by_cases hEnd : localName = "commentRangeEnd"
+          · simp [commentMarkerKindCandidateV7, hUri, hStart, hEnd] at hNone
+          · by_cases hReference : localName = "commentReference"
+            · simp [commentMarkerKindCandidateV7, hUri, hStart, hEnd,
+                hReference] at hNone
+            · simp [commentMarkerCandidateV7, hUri, hStart, hEnd,
+                hReference]
+      · simp [commentMarkerCandidateV7, hUri]
+  | endElement => rfl
+  | text => rfl
+
+theorem typed_marker_candidate_none_of_production_kind_none_v7
+    (scans : Tier2.NoteReferenceIntegrity.SideScanEvidence)
+    (event : Tier2.XmlTripleChecker.XmlEvent)
+    (eventOrdinal : Nat)
+    (hNone : commentMarkerKindCandidateV7 event = none) :
+    typedMarkerCandidateV7 (concurrentTypedMarkerInputV7 scans)
+      (typedXmlEventOfProduction
+        eventOrdinal event) = none := by
+  cases event with
+  | startElement uri localName attributes depth selfClosing =>
+      unfold commentMarkerKindCandidateV7 at hNone
+      unfold typedMarkerCandidateV7
+        typedXmlEventOfProduction
+        concurrentTypedMarkerInputV7
+      by_cases hUri : uri = Tier2.XmlTripleChecker.wmlNamespace
+      · by_cases hStart : localName = "commentRangeStart"
+        · simp [hUri, hStart] at hNone
+        · by_cases hEnd : localName = "commentRangeEnd"
+          · simp [hUri, hStart, hEnd] at hNone
+          · by_cases hReference : localName = "commentReference"
+            · simp [hUri, hStart, hEnd, hReference] at hNone
+            · have hNamespace :
+                  (typedXmlNameOfProduction uri).bytes =
+                    typedWmlNamespace.bytes := by
+                subst uri
+                native_decide
+              have hStartBytes :
+                  (typedXmlNameOfProduction localName).bytes ≠
+                    (typedLiteral
+                      [99,111,109,109,101,110,116,82,97,110,103,101,83,
+                        116,97,114,116]).bytes := by
+                intro h
+                apply hStart
+                apply (typed_xml_name_of_production_reflects_equality
+                  localName "commentRangeStart").mp
+                exact h.trans (by native_decide)
+              have hEndBytes :
+                  (typedXmlNameOfProduction localName).bytes ≠
+                    (typedLiteral
+                      [99,111,109,109,101,110,116,82,97,110,103,101,69,
+                        110,100]).bytes := by
+                intro h
+                apply hEnd
+                apply (typed_xml_name_of_production_reflects_equality
+                  localName "commentRangeEnd").mp
+                exact h.trans (by native_decide)
+              have hReferenceBytes :
+                  (typedXmlNameOfProduction localName).bytes ≠
+                    (typedLiteral
+                      [99,111,109,109,101,110,116,82,101,102,101,114,101,
+                        110,99,101]).bytes := by
+                intro h
+                apply hReference
+                apply (typed_xml_name_of_production_reflects_equality
+                  localName "commentReference").mp
+                exact h.trans (by native_decide)
+              simpa [hNamespace,
+                hStartBytes, hEndBytes, hReferenceBytes]
+      · have hNamespace :
+            (typedXmlNameOfProduction uri).bytes ≠
+              typedWmlNamespace.bytes := by
+          intro hEqual
+          apply hUri
+          apply (typed_xml_name_of_production_reflects_equality
+            uri Tier2.XmlTripleChecker.wmlNamespace).mp
+          have hWml :
+              typedWmlNamespace =
+                typedXmlNameOfProduction
+                  Tier2.XmlTripleChecker.wmlNamespace := by
+            native_decide
+          simpa only [hWml] using hEqual
+        simp [hNamespace]
+  | endElement => rfl
+  | text => rfl
+
+theorem scan_retained_comment_marker_event_false_eq_true_v7
+    (scans : Tier2.NoteReferenceIntegrity.SideScanEvidence)
+    (sourceSetOrdinal : Nat) (sourceStory : String)
+    (sourceStoryOrdinal eventOrdinal : Nat)
+    (state : ParsedCommentRangeEvidence)
+    (event : Tier2.XmlTripleChecker.XmlEvent)
+    (hTypedNoCross : state.typedState.crossing = none)
+    (hNoCross :
+      (scanRetainedCommentMarkerEventV7
+        (concurrentTypedMarkerInputV7 scans) false
+        sourceSetOrdinal sourceStory sourceStoryOrdinal eventOrdinal
+        state event).crossing = none) :
+    scanRetainedCommentMarkerEventV7
+        (concurrentTypedMarkerInputV7 scans) false
+        sourceSetOrdinal sourceStory sourceStoryOrdinal eventOrdinal
+        state event =
+      scanRetainedCommentMarkerEventV7
+        (concurrentTypedMarkerInputV7 scans) true
+        sourceSetOrdinal sourceStory sourceStoryOrdinal eventOrdinal
+        state event ∧
+    (scanRetainedCommentMarkerEventV7
+      (concurrentTypedMarkerInputV7 scans) false
+      sourceSetOrdinal sourceStory sourceStoryOrdinal eventOrdinal
+      state event).typedState.crossing = none := by
+  unfold scanRetainedCommentMarkerEventV7
+    retainedCommentMarkerStoppedV7 at hNoCross ⊢
+  by_cases hStateCross : state.crossing.isSome = true
+  · simp only [hStateCross, Bool.false_or, if_true] at hNoCross
+    have hSome : state.crossing ≠ none := Option.isSome_iff_ne_none.mp hStateCross
+    contradiction
+  · have hStateCrossFalse : state.crossing.isSome = false :=
+      Bool.eq_false_iff.mpr hStateCross
+    have hTypedCross : state.typedState.crossing.isSome = false := by
+      rw [hTypedNoCross]
+      rfl
+    simp only [hStateCrossFalse, Bool.false_or, Bool.true_and,
+      hTypedCross, if_false] at hNoCross ⊢
+    cases hKind : commentMarkerKindCandidateV7 event with
+    | none =>
+        have hCandidate :=
+          comment_marker_candidate_none_of_kind_none_v7 event hKind
+        have hTypedCandidate :=
+          typed_marker_candidate_none_of_production_kind_none_v7
+            scans event eventOrdinal hKind
+        simp [hKind, hCandidate, hTypedCandidate, hTypedNoCross]
+        unfold scanTypedMarkerEventV7
+        rw [hTypedCross, hTypedCandidate]
+        exact hTypedNoCross
+    | some kind =>
+        simp [hKind] at hNoCross
+
+theorem scan_retained_comment_story_events_loop_false_eq_true_v7 :
+    ∀ (scans : Tier2.NoteReferenceIntegrity.SideScanEvidence)
+      (sourceSetOrdinal : Nat) (sourceStory : String)
+      (sourceStoryOrdinal eventOrdinal : Nat)
+      (state : ParsedCommentRangeEvidence)
+      (events : List Tier2.XmlTripleChecker.XmlEvent),
+    state.crossing = none →
+    state.typedState.crossing = none →
+    (scanRetainedCommentStoryEventsLoopV7
+      (concurrentTypedMarkerInputV7 scans) false sourceSetOrdinal
+      sourceStory sourceStoryOrdinal eventOrdinal state events).crossing =
+        none →
+    scanRetainedCommentStoryEventsLoopV7
+        (concurrentTypedMarkerInputV7 scans) false sourceSetOrdinal
+        sourceStory sourceStoryOrdinal eventOrdinal state events =
+      scanRetainedCommentStoryEventsLoopV7
+        (concurrentTypedMarkerInputV7 scans) true sourceSetOrdinal
+        sourceStory sourceStoryOrdinal eventOrdinal state events ∧
+    (scanRetainedCommentStoryEventsLoopV7
+      (concurrentTypedMarkerInputV7 scans) false sourceSetOrdinal
+      sourceStory sourceStoryOrdinal eventOrdinal state events).typedState.crossing =
+        none
+  | _, _, _, _, _, _, [], _, hTyped, _ => ⟨rfl, hTyped⟩
+  | scans, sourceSetOrdinal, sourceStory, sourceStoryOrdinal,
+      eventOrdinal, state, event :: rest, hState, hTyped, hFinal => by
+      unfold scanRetainedCommentStoryEventsLoopV7 at hFinal ⊢
+      have hStateSome : state.crossing.isSome = false := by
+        rw [hState]
+        rfl
+      have hTypedSome : state.typedState.crossing.isSome = false := by
+        rw [hTyped]
+        rfl
+      simp only [retainedCommentMarkerStoppedV7, hStateSome,
+        hTypedSome, Bool.false_or, Bool.true_and, if_false] at hFinal ⊢
+      let before : ParsedCommentRangeEvidence := {
+        state with
+        processedEventCount := state.processedEventCount + 1
+        typedState := { state.typedState with
+          processedEventCount :=
+            state.typedState.processedEventCount + 1 }
+      }
+      let after :=
+        scanRetainedCommentMarkerEventV7
+          (concurrentTypedMarkerInputV7 scans) false sourceSetOrdinal
+          sourceStory sourceStoryOrdinal eventOrdinal before event
+      let afterTrue :=
+        scanRetainedCommentMarkerEventV7
+          (concurrentTypedMarkerInputV7 scans) true sourceSetOrdinal
+          sourceStory sourceStoryOrdinal eventOrdinal before event
+      change
+        (if retainedCommentMarkerStoppedV7 false after then after
+          else scanRetainedCommentStoryEventsLoopV7
+            (concurrentTypedMarkerInputV7 scans) false sourceSetOrdinal
+            sourceStory sourceStoryOrdinal (eventOrdinal + 1) after rest
+        ).crossing = none at hFinal
+      have hAfter : after.crossing = none := by
+        cases hCross : after.crossing with
+        | none => rfl
+        | some crossing =>
+            have hSome : after.crossing.isSome = true := by
+              rw [hCross]
+              rfl
+            simp [retainedCommentMarkerStoppedV7, hSome] at hFinal
+            exact hCross.symm.trans hFinal
+      have hBefore : before.crossing = none := hState
+      have hBeforeTyped : before.typedState.crossing = none := hTyped
+      have hEvent :=
+        scan_retained_comment_marker_event_false_eq_true_v7
+          scans sourceSetOrdinal sourceStory sourceStoryOrdinal eventOrdinal
+            before event hBeforeTyped hAfter
+      have hAfterSome : after.crossing.isSome = false := by
+        rw [hAfter]
+        rfl
+      have hAfterTypedSome : after.typedState.crossing.isSome = false := by
+        rw [hEvent.2]
+        rfl
+      have hRestFinal :
+          (scanRetainedCommentStoryEventsLoopV7
+            (concurrentTypedMarkerInputV7 scans) false sourceSetOrdinal
+            sourceStory sourceStoryOrdinal (eventOrdinal + 1)
+            after rest).crossing = none := by
+        simpa [retainedCommentMarkerStoppedV7, hAfterSome] using hFinal
+      change
+        (if retainedCommentMarkerStoppedV7 false after then after
+          else scanRetainedCommentStoryEventsLoopV7
+            (concurrentTypedMarkerInputV7 scans) false sourceSetOrdinal
+            sourceStory sourceStoryOrdinal (eventOrdinal + 1) after rest) =
+        (if retainedCommentMarkerStoppedV7 true afterTrue then afterTrue
+          else scanRetainedCommentStoryEventsLoopV7
+            (concurrentTypedMarkerInputV7 scans) true sourceSetOrdinal
+            sourceStory sourceStoryOrdinal (eventOrdinal + 1) afterTrue rest) ∧
+        (if retainedCommentMarkerStoppedV7 false after then after
+          else scanRetainedCommentStoryEventsLoopV7
+            (concurrentTypedMarkerInputV7 scans) false sourceSetOrdinal
+            sourceStory sourceStoryOrdinal (eventOrdinal + 1)
+              after rest).typedState.crossing = none
+      rw [show afterTrue = after from hEvent.1.symm]
+      simp only [retainedCommentMarkerStoppedV7, hAfterSome,
+        Bool.false_or, hAfterTypedSome, Bool.true_and, if_false]
+      have hInduction :=
+        scan_retained_comment_story_events_loop_false_eq_true_v7
+          scans sourceSetOrdinal sourceStory sourceStoryOrdinal
+            (eventOrdinal + 1) after rest hAfter hEvent.2 hRestFinal
+      exact ⟨hInduction.1, hInduction.2⟩
+
+theorem scan_retained_comment_stories_loop_false_eq_true_v7
+    (scans : Tier2.NoteReferenceIntegrity.SideScanEvidence) :
+    ∀ (sourceSetOrdinal : Nat) (state : ParsedCommentRangeEvidence)
+      (realizations : List Tier2.NoteReferenceIntegrity.StoryRealization),
+    state.crossing = none →
+    state.typedState.crossing = none →
+    (scanRetainedCommentStoriesLoopV7
+      (concurrentTypedMarkerInputV7 scans) false sourceSetOrdinal
+      state realizations).crossing = none →
+    scanRetainedCommentStoriesLoopV7
+        (concurrentTypedMarkerInputV7 scans) false sourceSetOrdinal
+        state realizations =
+      scanRetainedCommentStoriesLoopV7
+        (concurrentTypedMarkerInputV7 scans) true sourceSetOrdinal
+        state realizations ∧
+    (scanRetainedCommentStoriesLoopV7
+      (concurrentTypedMarkerInputV7 scans) false sourceSetOrdinal
+      state realizations).typedState.crossing = none
+  | _, _, [], _, hTyped, _ => ⟨rfl, hTyped⟩
+  | sourceSetOrdinal, state, realization :: rest,
+      hState, hTyped, hFinal => by
+      unfold scanRetainedCommentStoriesLoopV7 at hFinal ⊢
+      have hStateSome : state.crossing.isSome = false := by
+        rw [hState]
+        rfl
+      have hTypedSome : state.typedState.crossing.isSome = false := by
+        rw [hTyped]
+        rfl
+      simp only [retainedCommentMarkerStoppedV7, hStateSome,
+        hTypedSome, Bool.false_or, Bool.true_and, if_false] at hFinal ⊢
+      let before : ParsedCommentRangeEvidence := {
+        state with
+        processedStoryCount := state.processedStoryCount + 1
+        typedState := { state.typedState with
+          processedStoryCount :=
+            state.typedState.processedStoryCount + 1 }
+      }
+      let after :=
+        scanRetainedCommentStoryEventsV7
+          (concurrentTypedMarkerInputV7 scans) false sourceSetOrdinal
+          realization before
+      let afterTrue :=
+        scanRetainedCommentStoryEventsV7
+          (concurrentTypedMarkerInputV7 scans) true sourceSetOrdinal
+          realization before
+      change
+        (if retainedCommentMarkerStoppedV7 false after then after
+          else scanRetainedCommentStoriesLoopV7
+            (concurrentTypedMarkerInputV7 scans) false
+            (sourceSetOrdinal + 1) after rest).crossing = none at hFinal
+      have hAfter : after.crossing = none := by
+        cases hCross : after.crossing with
+        | none => rfl
+        | some crossing =>
+            have hSome : after.crossing.isSome = true := by
+              rw [hCross]
+              rfl
+            simp [retainedCommentMarkerStoppedV7, hSome] at hFinal
+            exact hCross.symm.trans hFinal
+      have hBefore : before.crossing = none := hState
+      have hBeforeTyped : before.typedState.crossing = none := hTyped
+      have hStory :=
+        scan_retained_comment_story_events_loop_false_eq_true_v7
+          scans sourceSetOrdinal
+          (commentMarkerSourceStoryName realization.slot.story)
+          realization.slot.ordinal 0 before realization.visitedEvents
+          hBefore hBeforeTyped hAfter
+      have hAfterSome : after.crossing.isSome = false := by
+        rw [hAfter]
+        rfl
+      have hAfterTyped : after.typedState.crossing = none := by
+        unfold after scanRetainedCommentStoryEventsV7
+        exact hStory.2
+      have hAfterTypedSome : after.typedState.crossing.isSome = false := by
+        rw [hAfterTyped]
+        rfl
+      have hRestFinal :
+          (scanRetainedCommentStoriesLoopV7
+            (concurrentTypedMarkerInputV7 scans) false
+            (sourceSetOrdinal + 1) after rest).crossing = none := by
+        simpa [retainedCommentMarkerStoppedV7, hAfterSome] using hFinal
+      change
+        (if retainedCommentMarkerStoppedV7 false after then after
+          else scanRetainedCommentStoriesLoopV7
+            (concurrentTypedMarkerInputV7 scans) false
+            (sourceSetOrdinal + 1) after rest) =
+        (if retainedCommentMarkerStoppedV7 true afterTrue then afterTrue
+          else scanRetainedCommentStoriesLoopV7
+            (concurrentTypedMarkerInputV7 scans) true
+            (sourceSetOrdinal + 1) afterTrue rest) ∧
+        (if retainedCommentMarkerStoppedV7 false after then after
+          else scanRetainedCommentStoriesLoopV7
+            (concurrentTypedMarkerInputV7 scans) false
+            (sourceSetOrdinal + 1) after rest).typedState.crossing = none
+      rw [show afterTrue = after from hStory.1.symm]
+      simp only [retainedCommentMarkerStoppedV7, hAfterSome,
+        Bool.false_or, hAfterTypedSome, Bool.true_and, if_false]
+      have hInduction :=
+        scan_retained_comment_stories_loop_false_eq_true_v7
+          scans (sourceSetOrdinal + 1) after rest hAfter hAfterTyped
+            hRestFinal
+      exact ⟨hInduction.1, hInduction.2⟩
+
+theorem concurrent_typed_marker_evidence_scan_for_relationship_v7
+    (relationshipPresent : Bool)
+    (set : Tier2.CommentReferenceIntegrity.CommentSourceSet)
+    (scans : Tier2.NoteReferenceIntegrity.SideScanEvidence)
+    (stories : List TypedStorySource)
+    (evidence : ParsedCommentRangeEvidence)
+    (hMatch : Tier2.CommentReferenceIntegrity.storySlotListsMatch
+      set.sources (scans.realizations.map (·.slot)) = true)
+    (hEvents : ConcurrentTypedStoryEventsV7 stories scans.realizations)
+    (hRun : retainedCommentMarkerScanForRelationshipV7
+      relationshipPresent set scans = .ok evidence)
+    (hNoCross : evidence.crossing = none) :
+    concurrentTypedMarkerEvidenceV7 stories evidence =
+      scanTypedCommentMarkersV7
+        { concurrentTypedMarkerInputV7 scans with stories } := by
+  cases relationshipPresent with
+  | true =>
+      exact concurrent_typed_marker_evidence_scan_v7
+        set scans stories evidence hMatch hEvents hRun
+  | false =>
+      unfold retainedCommentMarkerScanForRelationshipV7
+        scanRetainedCommentMarkersForRelationshipV7 at hRun
+      rw [hMatch] at hRun
+      simp only [if_true, Except.ok.injEq] at hRun
+      let falseResult :=
+        scanRetainedCommentStoriesLoopV7
+          (concurrentTypedMarkerInputV7 scans) false 0 {}
+            scans.realizations
+      change falseResult = evidence at hRun
+      have hFalseNoCross : falseResult.crossing = none := by
+        rw [hRun]
+        exact hNoCross
+      have hLoops :=
+        scan_retained_comment_stories_loop_false_eq_true_v7
+          scans 0 {} scans.realizations rfl rfl hFalseNoCross
+      have hRunTrue :
+          retainedCommentMarkerScanForRelationshipV7
+            true set scans = .ok evidence := by
+        unfold retainedCommentMarkerScanForRelationshipV7
+          scanRetainedCommentMarkersForRelationshipV7
+        rw [hMatch]
+        simp only [if_true]
+        apply congrArg Except.ok
+        exact hLoops.1.symm.trans hRun
+      exact concurrent_typed_marker_evidence_scan_v7
+        set scans stories evidence hMatch hEvents hRunTrue
+
+theorem production_typed_marker_evidence_independent_v7
+    (request : VerifierRequestV7)
+    (side : Tier2.CommentReferenceIntegrity.VerifierSide)
+    (typedRequest : TypedRequestV7)
+    (set : Tier2.CommentReferenceIntegrity.CommentSourceSet)
+    (scans : Tier2.NoteReferenceIntegrity.SideScanEvidence)
+    (evidence : ParsedCommentRangeEvidence)
+    (hTyped : typedRequestOfProductionV7 request = some typedRequest)
+    (hDomain : ProductionCommentSourceDomainMetadataV7Of request.core side)
+    (hExact : ProductionCommentSourceEventsExactV7
+      (request.core.packageRecord
+        (noteSideOfCommentSide side)).commentEvidence.sources
+      scans.realizations)
+    (hSet :
+      Tier2.CommentReferenceIntegrity.storySlotListsMatch
+        set.sources (scans.realizations.map (·.slot)) = true)
+    (hRun : retainedCommentMarkerScanForRelationshipV7
+      true set scans = .ok evidence)
+    (hConcurrent :
+      retainedConcurrentTypedMarkerEvidenceCheckV7 evidence = true) :
+    typedMarkerEvidenceOfProduction
+        (canonicalTypedCommentSourcesV7 typedRequest
+          (typedSideOfVerifierSide side)) evidence =
+      retainedOrIndependentTypedMarkerScanV7 typedRequest
+        (typedSideOfVerifierSide side) := by
+  rw [retained_concurrent_typed_marker_evidence_rebind_v7
+    _ evidence hConcurrent]
+  rw [concurrent_typed_marker_evidence_scan_v7 set scans
+    (canonicalTypedCommentSourcesV7 typedRequest
+      (typedSideOfVerifierSide side)) evidence hSet
+    (by
+      rw [typed_request_canonical_sources_of_production_v7
+        request side typedRequest hTyped hDomain]
+      exact production_comment_source_events_exact_v7_to_concurrent
+        _ _ _ hExact)
+    hRun]
+  exact canonical_typed_marker_scan_observational_v7
+    request side typedRequest scans hTyped hDomain hExact
+
+theorem production_typed_marker_evidence_independent_for_relationship_v7
+    (request : VerifierRequestV7)
+    (side : Tier2.CommentReferenceIntegrity.VerifierSide)
+    (typedRequest : TypedRequestV7)
+    (relationshipPresent : Bool)
+    (set : Tier2.CommentReferenceIntegrity.CommentSourceSet)
+    (scans : Tier2.NoteReferenceIntegrity.SideScanEvidence)
+    (evidence : ParsedCommentRangeEvidence)
+    (hTyped : typedRequestOfProductionV7 request = some typedRequest)
+    (hDomain : ProductionCommentSourceDomainMetadataV7Of request.core side)
+    (hExact : ProductionCommentSourceEventsExactV7
+      (request.core.packageRecord
+        (noteSideOfCommentSide side)).commentEvidence.sources
+      scans.realizations)
+    (hSet :
+      Tier2.CommentReferenceIntegrity.storySlotListsMatch
+        set.sources (scans.realizations.map (·.slot)) = true)
+    (hRun : retainedCommentMarkerScanForRelationshipV7
+      relationshipPresent set scans = .ok evidence)
+    (hNoCross : evidence.crossing = none)
+    (hConcurrent :
+      retainedConcurrentTypedMarkerEvidenceCheckV7 evidence = true) :
+    typedMarkerEvidenceOfProduction
+        (canonicalTypedCommentSourcesV7 typedRequest
+          (typedSideOfVerifierSide side)) evidence =
+      retainedOrIndependentTypedMarkerScanV7 typedRequest
+        (typedSideOfVerifierSide side) := by
+  rw [retained_concurrent_typed_marker_evidence_rebind_v7
+    _ evidence hConcurrent]
+  rw [concurrent_typed_marker_evidence_scan_for_relationship_v7
+    relationshipPresent set scans
+    (canonicalTypedCommentSourcesV7 typedRequest
+      (typedSideOfVerifierSide side)) evidence hSet
+    (by
+      rw [typed_request_canonical_sources_of_production_v7
+        request side typedRequest hTyped hDomain]
+      exact production_comment_source_events_exact_v7_to_concurrent
+        _ _ _ hExact)
+    hRun hNoCross]
+  exact canonical_typed_marker_scan_observational_v7
+    request side typedRequest scans hTyped hDomain hExact
+
+theorem retained_topology_refines_canonical_typed_v7
+    (typedRequest : TypedRequestV7) (side : Side)
+    (retained : RetainedCommentScan)
+    (marker : ParsedCommentRangeEvidence)
+    (hDefinitions :
+      typedDefinitionsV7 typedRequest side =
+        retained.output.scan.definitions.map
+            Tier2.NoteReferenceIntegrity.typedDefinitionOfProduction ++
+          retained.output.scan.nonDirectDefinitions.map
+            Tier2.NoteReferenceIntegrity.typedDefinitionOfProduction)
+    (hMarker :
+      typedMarkerEvidenceOfProduction
+          (canonicalTypedCommentSourcesV7 typedRequest side) marker =
+        retainedOrIndependentTypedMarkerScanV7 typedRequest side)
+    (hConcurrent :
+      retainedConcurrentTypedMarkerEvidenceCheckV7 marker = true)
+    (hTopology :
+      checkTypedPackageCommentRangeIntegrity
+        (retained.output.scan.definitions.map
+            Tier2.NoteReferenceIntegrity.typedDefinitionOfProduction ++
+          retained.output.scan.nonDirectDefinitions.map
+            Tier2.NoteReferenceIntegrity.typedDefinitionOfProduction)
+        (concurrentTypedMarkerEvidenceV7 [] marker) = true) :
+    checkTypedPackageCommentRangeIntegrity
+        (typedDefinitionsV7 typedRequest side)
+        (retainedOrIndependentTypedMarkerScanV7 typedRequest side) = true := by
+  rw [hDefinitions, ← hMarker,
+    retained_concurrent_typed_marker_evidence_rebind_v7
+      (canonicalTypedCommentSourcesV7 typedRequest side)
+      marker hConcurrent]
+  simpa [concurrentTypedMarkerEvidenceV7] using hTopology
+
+theorem story_slot_lists_match_self_v7
+    (slots : List Tier2.NoteReferenceIntegrity.StorySlot) :
+    Tier2.CommentReferenceIntegrity.storySlotListsMatch slots slots = true := by
+  induction slots with
+  | nil => rfl
+  | cons slot rest ih =>
+      unfold Tier2.CommentReferenceIntegrity.storySlotListsMatch at ih ⊢
+      simp only [List.length_cons, beq_self_eq_true, Bool.true_and,
+        List.zip_cons_cons, List.all_cons, Bool.and_eq_true] at ih ⊢
+      exact ⟨by
+        rcases slot with ⟨story, ordinal, path⟩
+        simp only [Tier2.NoteReferenceIntegrity.storySlotEq,
+          beq_self_eq_true, Bool.true_and]
+        cases story <;> rfl, ih⟩
+
+theorem production_canonical_typed_topology_v7
+    (request : VerifierRequestV7)
+    (typedRequest : TypedRequestV7)
+    (side : Tier2.CommentReferenceIntegrity.VerifierSide)
+    (hTyped : typedRequestOfProductionV7 request = some typedRequest)
+    (hComment : ProductionCommentEvidenceOf
+      (request.core.packageRecord (noteSideOfCommentSide side)))
+    (hChecks : productionCommentOutcomeChecksV7 request.core = true) :
+    checkTypedPackageCommentRangeIntegrity
+      (typedDefinitionsV7 typedRequest (typedSideOfVerifierSide side))
+      (retainedOrIndependentTypedMarkerScanV7
+        typedRequest (typedSideOfVerifierSide side)) = true := by
+  have hAt :=
+    production_comment_outcome_checks_v7_at request.core side hChecks
+  rcases hAt with
+    ⟨hOutcome, hDomain, run, hRunStored, hExact⟩
+  rcases hComment with
+    ⟨hSources, hIdentities, hSelection,
+      ⟨markerRun, markerEvidence, hMarkerRun, hMarkerResult,
+        hMarkerExact, hMarkerNoCross, hMarkerInvocation,
+        hMarkerStored⟩,
+      ⟨retained, hRetained, hRetainedInvocation, hInput,
+        hOutput, hDefinitionCrossing, hIntegrity, hInventory,
+        hComplete, hLimit, hIssues⟩⟩
+  have hRunEq : run = markerRun := by
+    exact Option.some.inj (hRunStored.symm.trans hMarkerRun)
+  subst run
+  have hAdmission :=
+    production_comment_admission_checks_v7_at request.core side hChecks
+  rcases production_typed_definitions_retained_v7
+      request typedRequest side hTyped
+      ⟨hSources, hIdentities, hSelection,
+        ⟨markerRun, markerEvidence, hMarkerRun, hMarkerResult,
+          hMarkerExact, hMarkerNoCross, hMarkerInvocation,
+          hMarkerStored⟩,
+        ⟨retained, hRetained, hRetainedInvocation, hInput,
+          hOutput, hDefinitionCrossing, hIntegrity, hInventory,
+          hComplete, hLimit, hIssues⟩⟩
+      hAdmission with
+    ⟨definitionRetained, hDefinitionRetained, hDefinitions⟩
+  have hRetainedEq : definitionRetained = retained := by
+    exact Option.some.inj (hDefinitionRetained.symm.trans hRetained)
+  subst definitionRetained
+  rcases production_comment_outcome_check_v7_complete_topology
+      _ hOutcome hComplete with
+    ⟨topologyRetained, topologyMarker, hTopologyRetained,
+      hTopologyMarker, hConcurrent, hTopology⟩
+  have hTopologyRetainedEq : topologyRetained = retained := by
+    exact Option.some.inj (hTopologyRetained.symm.trans hRetained)
+  subst topologyRetained
+  have hTopologyMarkerEq : topologyMarker = markerEvidence := by
+    exact Option.some.inj (hTopologyMarker.symm.trans hMarkerStored)
+  subst topologyMarker
+  have hSet :
+      Tier2.CommentReferenceIntegrity.storySlotListsMatch
+        markerRun.set.sources
+        (markerRun.scans.realizations.map (·.slot)) = true := by
+    rw [markerRun.setExact]
+    exact story_slot_lists_match_self_v7 _
+  have hMarkerRunExact :=
+    retained_comment_marker_scan_run_exact
+      (request.core.packageRecord
+        (noteSideOfCommentSide side)).commentEvidence.identity.isSome
+      (request.core.packageRecord
+        (noteSideOfCommentSide side)).commentEvidence.side
+      markerRun markerEvidence hMarkerResult
+  have hMarker :=
+    production_typed_marker_evidence_independent_for_relationship_v7
+      request side typedRequest
+      (request.core.packageRecord
+        (noteSideOfCommentSide side)).commentEvidence.identity.isSome
+      markerRun.set markerRun.scans markerEvidence hTyped hDomain hExact
+      hSet hMarkerRunExact hMarkerNoCross hConcurrent
+  exact retained_topology_refines_canonical_typed_v7
+    typedRequest (typedSideOfVerifierSide side) retained markerEvidence
+      hDefinitions hMarker hConcurrent hTopology
 
 def productionTypedCommentChecksV7
     (request : RunRequestCoreRequestV7)

--- a/verification/lean/LeanDocxChecker.lean
+++ b/verification/lean/LeanDocxChecker.lean
@@ -140,22 +140,22 @@ theorem typed_xml_name_of_production_bytes (value : String) :
       value.toUTF8.data.toList := by
   by_cases hWml : value = wmlNamespace
   · subst value
-    native_decide
+    decide
   · by_cases hId : value = "id"
     · subst value
-      native_decide
+      decide
     · by_cases hComment : value = "comment"
       · subst value
-        native_decide
+        decide
       · by_cases hStart : value = "commentRangeStart"
         · subst value
-          native_decide
+          decide
         · by_cases hEnd : value = "commentRangeEnd"
           · subst value
-            native_decide
+            decide
           · by_cases hReference : value = "commentReference"
             · subst value
-              native_decide
+              decide
             · simp [typedXmlNameOfProduction, hWml, hId, hComment,
                 hStart, hEnd, hReference, typedBoundedBytesOfString]
 
@@ -193,11 +193,11 @@ theorem mapTR_eq_map {α β : Type} (f : α → β) (values : List α) :
 theorem typed_wml_namespace_adapter :
     typedWmlNamespace =
       typedXmlNameOfProduction wmlNamespace := by
-  native_decide
+  decide
 
 theorem typed_id_local_name_adapter :
     typedLiteral [105, 100] = typedXmlNameOfProduction "id" := by
-  native_decide
+  decide
 
 theorem typed_attribute_match_of_production
     (item : ExpandedXmlAttribute) :
@@ -281,7 +281,7 @@ theorem typed_attribute_value_of_production
 theorem typed_comment_local_name_adapter :
     typedLiteral [99,111,109,109,101,110,116] =
       typedXmlNameOfProduction "comment" := by
-  native_decide
+  decide
 
 theorem typed_definition_match_of_production
     (uri localName : String) :
@@ -11207,8 +11207,18 @@ def productionCommentSourceBindingCheckV7
     (request : RunRequestCoreRequestV7)
     (side : Tier2.CommentReferenceIntegrity.VerifierSide)
     (record : RunRequestPackageRecord) : Bool :=
+  commentSelectionResultEq
+    (Tier2.CommentReferenceIntegrity.selectConventionalMainComment
+      (commentPackageViewOfCore request side))
+    (selectConventionalMainCommentRecords record.relationships) &&
   productionCommentSourceDomainMetadataCheckAtV7 request side &&
   record.commentEvidence.markerScanRun.any fun run =>
+    decide ((Tier2.CommentReferenceIntegrity.canonicalCommentSourceSet
+      (commentPackageViewOfCore request side) side
+      (Tier2.NoteReferenceIntegrity.evaluateNoteSideV5
+        (packageViewOfRecord record) (noteSideOfCommentSide side)
+        (selectedStoriesOfRecord record))).sources =
+      run.scans.realizations.map (·.slot)) &&
     productionCommentSourceEventsExactCheckV7
       record.commentEvidence.sources run.scans.realizations
 
@@ -11218,21 +11228,33 @@ theorem production_comment_source_binding_check_v7_sound
     (record : RunRequestPackageRecord)
     (hCheck : productionCommentSourceBindingCheckV7
       request side record = true) :
+    Tier2.CommentReferenceIntegrity.selectConventionalMainComment
+        (commentPackageViewOfCore request side) =
+      selectConventionalMainCommentRecords record.relationships ∧
     ProductionCommentSourceDomainMetadataV7Of request side ∧
     ∃ run, record.commentEvidence.markerScanRun = some run ∧
+      (Tier2.CommentReferenceIntegrity.canonicalCommentSourceSet
+        (commentPackageViewOfCore request side) side
+        (Tier2.NoteReferenceIntegrity.evaluateNoteSideV5
+          (packageViewOfRecord record) (noteSideOfCommentSide side)
+          (selectedStoriesOfRecord record))).sources =
+        run.scans.realizations.map (·.slot) ∧
       ProductionCommentSourceEventsExactV7
         record.commentEvidence.sources run.scans.realizations := by
   unfold productionCommentSourceBindingCheckV7 at hCheck
   simp only [Bool.and_eq_true] at hCheck
-  refine ⟨production_comment_source_domain_metadata_check_at_v7_sound
-    request side hCheck.1, ?_⟩
+  refine ⟨comment_selection_result_eq_sound _ _ hCheck.1.1,
+    production_comment_source_domain_metadata_check_at_v7_sound
+      request side hCheck.1.2, ?_⟩
   cases hRun : record.commentEvidence.markerScanRun with
   | none => simp [hRun] at hCheck
   | some run =>
-      refine ⟨run, rfl, ?_⟩
-      simp [hRun] at hCheck
+      have hRunChecks := hCheck.2
+      simp [hRun] at hRunChecks
+      refine ⟨run, rfl, ?_, ?_⟩
+      exact hRunChecks.1
       exact production_comment_source_events_exact_check_v7_sound
-        _ _ hCheck.2
+        _ _ hRunChecks.2
 
 def productionTypedCommentAdmissionCheckAtV7
     (request : RunRequestCoreRequestV7)
@@ -11252,7 +11274,12 @@ def productionTypedCommentAdmissionCheckAtV7
           (Tier2.NoteReferenceIntegrity.typedSelectedCommentOfProduction
             selected)
           (Tier2.NoteReferenceIntegrity.typedCommentRealizationOfProduction
-            part)
+            part) &&
+        match Tier2.CommentReferenceIntegrity.realizeSelectedCommentV6
+            (commentPackageViewOfCore request side) side
+            (commentResourceUsageOfCore request) selected with
+        | .ok _ => true
+        | .error _ => false
 
 theorem production_typed_comment_admission_check_at_v7_sound
     (request : RunRequestCoreRequestV7)
@@ -11264,7 +11291,7 @@ theorem production_typed_comment_admission_check_at_v7_sound
         record.relationships = .ok (some selected))
     (hCheck :
       productionTypedCommentAdmissionCheckAtV7 request side record = true) :
-    ∃ part,
+    ∃ part realization,
       record.commentEvidence.part = some part ∧
       part.identity = selected ∧
       (Tier2.NoteReferenceIntegrity.typedPackageViewOfRecord
@@ -11276,7 +11303,11 @@ theorem production_typed_comment_admission_check_at_v7_sound
         (Tier2.NoteReferenceIntegrity.typedSelectedCommentOfProduction
           selected)
         (Tier2.NoteReferenceIntegrity.typedCommentRealizationOfProduction
-          part) = true := by
+          part) = true ∧
+      Tier2.CommentReferenceIntegrity.realizeSelectedCommentV6
+        (commentPackageViewOfCore request side) side
+        (commentResourceUsageOfCore request) selected =
+          .ok realization := by
   unfold productionTypedCommentAdmissionCheckAtV7 at hCheck
   rw [hSelected] at hCheck
   cases hPart : record.commentEvidence.part with
@@ -11284,8 +11315,15 @@ theorem production_typed_comment_admission_check_at_v7_sound
   | some part =>
       simp only [hPart, Option.any, Bool.and_eq_true,
         decide_eq_true_eq, Option.isNone_iff_eq_none] at hCheck
-      refine ⟨part, rfl, hCheck.1.1, hCheck.1.2, ?_⟩
-      simpa only [hCheck.1.1] using hCheck.2
+      cases hRealize :
+          Tier2.CommentReferenceIntegrity.realizeSelectedCommentV6
+            (commentPackageViewOfCore request side) side
+            (commentResourceUsageOfCore request) selected with
+      | error failure => simp [hRealize] at hCheck
+      | ok realization =>
+          refine ⟨part, realization, rfl, hCheck.1.1.1,
+            hCheck.1.1.2, ?_, rfl⟩
+          simpa only [hCheck.1.1.1, hRealize] using hCheck.1.2
 
 theorem production_typed_definitions_retained_v7
     (request : VerifierRequestV7)
@@ -11344,7 +11382,8 @@ theorem production_typed_definitions_retained_v7
           simp only [hSelected] at hSelection
           rcases production_typed_comment_admission_check_at_v7_sound
               request.core side record selected hSelected hAdmissionCheck with
-            ⟨part, hPart, hIdentity, hFailure, hAdmission⟩
+            ⟨part, realization, hPart, hIdentity, hFailure,
+              hAdmission, hOperationalRealization⟩
           have hRealize := typed_realization_success_of_production_v7
             request typedRequest side selected part hTyped hSelected hPart
               hIdentity hFailure hAdmission
@@ -11497,11 +11536,25 @@ theorem production_comment_outcome_checks_v7_at
     productionCommentOutcomeCheckAtV7
         (request.packageRecord
           (noteSideOfCommentSide side)).commentEvidence = true ∧
+      Tier2.CommentReferenceIntegrity.selectConventionalMainComment
+          (commentPackageViewOfCore request side) =
+        selectConventionalMainCommentRecords
+          (request.packageRecord
+            (noteSideOfCommentSide side)).relationships ∧
       ProductionCommentSourceDomainMetadataV7Of request side ∧
       ∃ run,
         (request.packageRecord
           (noteSideOfCommentSide side)).commentEvidence.markerScanRun =
             some run ∧
+        (Tier2.CommentReferenceIntegrity.canonicalCommentSourceSet
+          (commentPackageViewOfCore request side) side
+          (Tier2.NoteReferenceIntegrity.evaluateNoteSideV5
+            (packageViewOfRecord (request.packageRecord
+              (noteSideOfCommentSide side)))
+            (noteSideOfCommentSide side)
+            (selectedStoriesOfRecord (request.packageRecord
+              (noteSideOfCommentSide side))))).sources =
+          run.scans.realizations.map (·.slot) ∧
         ProductionCommentSourceEventsExactV7
           (request.packageRecord
             (noteSideOfCommentSide side)).commentEvidence.sources
@@ -11902,7 +11955,7 @@ theorem typed_marker_candidate_none_of_production_kind_none_v7
                   (typedXmlNameOfProduction uri).bytes =
                     typedWmlNamespace.bytes := by
                 subst uri
-                native_decide
+                decide
               have hStartBytes :
                   (typedXmlNameOfProduction localName).bytes ≠
                     (typedLiteral
@@ -11912,7 +11965,7 @@ theorem typed_marker_candidate_none_of_production_kind_none_v7
                 apply hStart
                 apply (typed_xml_name_of_production_reflects_equality
                   localName "commentRangeStart").mp
-                exact h.trans (by native_decide)
+                exact h.trans (by decide)
               have hEndBytes :
                   (typedXmlNameOfProduction localName).bytes ≠
                     (typedLiteral
@@ -11922,7 +11975,7 @@ theorem typed_marker_candidate_none_of_production_kind_none_v7
                 apply hEnd
                 apply (typed_xml_name_of_production_reflects_equality
                   localName "commentRangeEnd").mp
-                exact h.trans (by native_decide)
+                exact h.trans (by decide)
               have hReferenceBytes :
                   (typedXmlNameOfProduction localName).bytes ≠
                     (typedLiteral
@@ -11932,7 +11985,7 @@ theorem typed_marker_candidate_none_of_production_kind_none_v7
                 apply hReference
                 apply (typed_xml_name_of_production_reflects_equality
                   localName "commentReference").mp
-                exact h.trans (by native_decide)
+                exact h.trans (by decide)
               simpa [hNamespace,
                 hStartBytes, hEndBytes, hReferenceBytes]
       · have hNamespace :
@@ -11946,7 +11999,7 @@ theorem typed_marker_candidate_none_of_production_kind_none_v7
               typedWmlNamespace =
                 typedXmlNameOfProduction
                   Tier2.XmlTripleChecker.wmlNamespace := by
-            native_decide
+            decide
           simpa only [hWml] using hEqual
         simp [hNamespace]
   | endElement => rfl
@@ -12407,7 +12460,7 @@ theorem production_canonical_typed_marker_scan_v7
     production_comment_outcome_checks_v7_at
       request.core side hComment hChecks
   rcases hAt with
-    ⟨hOutcome, hDomain, run, hRunStored, hExact⟩
+    ⟨hOutcome, hSelector, hDomain, run, hRunStored, hSourceSlots, hExact⟩
   rcases hComment with
     ⟨hSources, hIdentities, hSelection,
       ⟨markerRun, markerEvidence, hMarkerRun, hMarkerResult,
@@ -12470,7 +12523,7 @@ theorem production_canonical_typed_topology_v7
     production_comment_admission_checks_v7_at
       request.core side hComment hChecks
   rcases hAt with
-    ⟨hOutcome, hDomain, run, hRunStored, hExact⟩
+    ⟨hOutcome, hSelector, hDomain, run, hRunStored, hSourceSlots, hExact⟩
   rcases hComment with
     ⟨hSources, hIdentities, hSelection,
       ⟨markerRun, markerEvidence, hMarkerRun, hMarkerResult,
@@ -12580,7 +12633,8 @@ theorem production_typed_selection_and_realization_resolved_v7
               request.core side hComment hChecks
           rcases production_typed_comment_admission_check_at_v7_sound
               request.core side record selected hSelected hAdmission with
-            ⟨part, hPart, hIdentity, hFailure, hAdmitted⟩
+            ⟨part, realization, hPart, hIdentity, hFailure,
+              hAdmitted, hOperationalRealization⟩
           have hTypedSelection :
               selectTypedCommentV7
                   (typedPackageAt typedRequest
@@ -12625,7 +12679,7 @@ theorem production_typed_marker_prerequisites_v7
   have hAt :=
     production_comment_outcome_checks_v7_at
       request.core side hComment hChecks
-  have hDomain := hAt.2.1
+  have hDomain := hAt.2.2.1
   have hSourceLength :
       (canonicalTypedCommentSourcesV7 typedRequest
         (typedSideOfVerifierSide side)).length ≤ 387 := by
@@ -12770,6 +12824,329 @@ theorem production_typed_all_comment_range_sides_pass_v7
         exact production_canonical_typed_topology_v7
           request typedRequest .compared hTyped commentEvidence.2.2 hChecks
 
+theorem production_actual_comment_source_set_refinement_v7
+    (request : VerifierRequestV7)
+    (typedRequest : TypedRequestV7)
+    (side : Tier2.CommentReferenceIntegrity.VerifierSide)
+    (hTyped : typedRequestOfProductionV7 request = some typedRequest)
+    (hComment : ProductionCommentEvidenceOf
+      (request.core.packageRecord (noteSideOfCommentSide side)))
+    (hChecks : productionCommentOutcomeChecksV7 request.core = true) :
+    actualExecutableCommentSourceSetV7RefinementOf
+      request typedRequest side := by
+  have hAt :=
+    production_comment_outcome_checks_v7_at
+      request.core side hComment hChecks
+  rcases hAt with
+    ⟨hOutcome, hSelector, hDomain, run, hRunStored, hSourceSlots, hExact⟩
+  rcases hComment.2.2.2.1 with
+    ⟨markerRun, markerEvidence, hMarkerRun, hMarkerResult,
+      hMarkerExact, hMarkerNoCross, hMarkerInvocation,
+      hMarkerStored⟩
+  have hRunEq : run = markerRun := by
+    exact Option.some.inj (hRunStored.symm.trans hMarkerRun)
+  subst run
+  let set := Tier2.CommentReferenceIntegrity.canonicalCommentSourceSet
+    (request.packageView side) side (request.noteEvaluation side)
+  let scans := markerRun.scans
+  refine ⟨set, scans, rfl, ?_, hTyped, ?_⟩
+  · unfold VerifierRequestV7.retainedSourceScans
+    simp [hMarkerRun, scans]
+  · have hPackage :=
+      typed_package_at_of_production_v7 request typedRequest side hTyped
+    unfold ExecutableCommentSourceSetV7ValueOf
+    dsimp only
+    refine ⟨?_, ?_, ?_, ?_⟩
+    · rw [hPackage]
+      rfl
+    · rw [hPackage]
+      rfl
+    · unfold set scans
+      simpa [VerifierRequestV7.packageView,
+        VerifierRequestV7.noteEvaluation] using hSourceSlots
+    · exact production_comment_source_events_exact_v7_to_realizations
+        request side typedRequest markerRun.scans.realizations
+          hTyped hDomain hExact
+
+theorem production_actual_comment_marker_scan_refinement_v7
+    (request : VerifierRequestV7)
+    (typedRequest : TypedRequestV7)
+    (side : Tier2.CommentReferenceIntegrity.VerifierSide)
+    (hTyped : typedRequestOfProductionV7 request = some typedRequest)
+    (hComment : ProductionCommentEvidenceOf
+      (request.core.packageRecord (noteSideOfCommentSide side)))
+    (hChecks : productionCommentOutcomeChecksV7 request.core = true) :
+    actualExecutableCommentMarkerScanV7RefinementOf
+      request typedRequest side := by
+  have hAt :=
+    production_comment_outcome_checks_v7_at
+      request.core side hComment hChecks
+  rcases hAt with
+    ⟨hOutcome, hSelector, hDomain, run, hRunStored, hSourceSlots, hExact⟩
+  rcases hComment.2.2.2.1 with
+    ⟨markerRun, markerEvidence, hMarkerRun, hMarkerResult,
+      hMarkerExact, hMarkerNoCross, hMarkerInvocation,
+      hMarkerStored⟩
+  have hRunEq : run = markerRun := by
+    exact Option.some.inj (hRunStored.symm.trans hMarkerRun)
+  subst run
+  rcases production_canonical_typed_marker_scan_v7
+      request typedRequest side hTyped hComment hChecks with
+    ⟨typedMarker, hTypedMarkerStored, hTypedMarker⟩
+  have hMarkerEq : typedMarker = markerEvidence := by
+    exact Option.some.inj (hTypedMarkerStored.symm.trans hMarkerStored)
+  subst typedMarker
+  let set := Tier2.CommentReferenceIntegrity.canonicalCommentSourceSet
+    (request.packageView side) side (request.noteEvaluation side)
+  let scans := markerRun.scans
+  refine ⟨set, scans, markerEvidence, rfl, ?_, ?_, ?_, hTyped, ?_⟩
+  · unfold VerifierRequestV7.retainedSourceScans
+    simp [hMarkerRun, scans]
+  · apply retained_comment_marker_scan_run_for_matching_set
+      _ _ markerRun set markerEvidence
+    · simpa [set, VerifierRequestV7.packageView,
+        VerifierRequestV7.noteEvaluation] using hSourceSlots
+    · exact hMarkerResult
+  · constructor
+    · unfold VerifierRequestV7.retainedCommentRangeScanResult
+      simp [hMarkerRun, hMarkerResult]
+    · exact hMarkerInvocation
+  · unfold ExecutableCommentMarkerScanV7ValueOf
+    dsimp only
+    refine ⟨?_, hMarkerInvocation, hTypedMarker⟩
+    simpa [set, scans, VerifierRequestV7.packageView,
+      VerifierRequestV7.noteEvaluation] using hSourceSlots
+
+theorem production_actual_comment_definition_refinement_v7
+    (request : VerifierRequestV7)
+    (typedRequest : TypedRequestV7)
+    (side : Tier2.CommentReferenceIntegrity.VerifierSide)
+    (hTyped : typedRequestOfProductionV7 request = some typedRequest)
+    (hPackage : ProductionPackageRecordOf
+      (request.core.packageRecord (noteSideOfCommentSide side)))
+    (hComment : ProductionCommentEvidenceOf
+      (request.core.packageRecord (noteSideOfCommentSide side)))
+    (hChecks : productionCommentOutcomeChecksV7 request.core = true) :
+    actualExecutableCommentDefinitionV7RefinementOf
+      request typedRequest side := by
+  let record :=
+    request.core.packageRecord (noteSideOfCommentSide side)
+  have hAt :=
+    production_comment_outcome_checks_v7_at
+      request.core side hComment hChecks
+  have hSelector :
+      selectConventionalMainCommentV7 (request.packageView side) =
+        selectConventionalMainCommentRecords record.relationships := by
+    simpa [selectConventionalMainCommentV7,
+      VerifierRequestV7.packageView, record] using hAt.2.1
+  unfold actualExecutableCommentDefinitionV7RefinementOf
+  rw [hSelector]
+  have hSelection := hComment.2.2.1
+  cases hSelected :
+      selectConventionalMainCommentRecords record.relationships with
+  | error failure =>
+      simp only [record, hSelected] at hSelection
+  | ok selected? =>
+      cases selected? with
+      | none => trivial
+      | some selected =>
+          have hAdmission :=
+            production_comment_admission_checks_v7_at
+              request.core side hComment hChecks
+          rcases production_typed_comment_admission_check_at_v7_sound
+              request.core side record selected hSelected hAdmission with
+            ⟨part, realization, hPart, hIdentity, hFailure,
+              hTypedAdmission, hRun⟩
+          have hRetained :=
+            Tier2.CommentReferenceIntegrity.realize_selected_comment_v6_success
+              (request.packageView side) side
+              (commentResourceUsageOfCore request.core)
+              selected realization hRun
+          have hRealization :
+              realization = semanticCommentRealizationOfProduction part := by
+            have hStored :
+                (request.packageView side).retainedCommentRealization =
+                  some (semanticCommentRealizationOfProduction part) := by
+              simp [VerifierRequestV7.packageView, commentPackageViewOfCore,
+                record, hPart]
+            exact Option.some.inj (hRetained.1.symm.trans hStored)
+          subst realization
+          have hParse : ProductionParseEvidenceOf record part.parseEvidence := by
+            apply hPackage.2.2.2.1
+            simp [productionParseEvidencesOfRecord, record, hPart]
+          rcases hParse with
+            ⟨_, _, hExtraction, _, _, _, _, _, hParseCount, _⟩
+          rcases hExtraction with
+            ⟨_, _, _, _, _, _, _, _, _, _, _, _, _, _, _,
+              hExtractionCount, _⟩
+          have hCounts :
+              request.retainedCommentRealization side =
+                  some (semanticCommentRealizationOfProduction part) ∧
+                request.commentExtractionInvocationCount side = 1 ∧
+                request.commentParseInvocationCount side = 1 := by
+            refine ⟨?_, ?_, ?_⟩
+            · simpa [record, hPart] using hRetained.1
+            · simp [VerifierRequestV7.commentExtractionInvocationCount,
+                record, hPart, hExtractionCount]
+            · simp [VerifierRequestV7.commentParseInvocationCount,
+                record, hPart, hParseCount]
+          refine ⟨semanticCommentRealizationOfProduction part,
+            hSelector.trans hSelected, hRun, hCounts, hTyped, ?_⟩
+          unfold ExecutableCommentDefinitionRealizationV7ValueOf
+          dsimp only
+          have hTypedPackage :=
+            typed_package_at_of_production_v7
+              request typedRequest side hTyped
+          rcases hComment.2.2.2.2 with
+            ⟨retained, hRetainedScan, hScanCount, hInput, hOutput,
+              hCrossing, hIntegrity, hInventory, hComplete, hLimit,
+              hIssues⟩
+          have hInputPart : retained.input = {
+              sourceEvents := []
+              definitionEvents := part.parseEvidence.parsed.events
+            } := by
+            rw [hInput]
+            unfold productionCommentScanInput
+            rw [hPart]
+            rfl
+          have hDefinitionEvents :=
+            retained_comment_definitions_refine_typed_v7
+              retained part.parseEvidence.parsed.events hInputPart hOutput
+          rcases production_typed_definitions_retained_v7
+              request typedRequest side hTyped hComment hAdmission with
+            ⟨definitionRetained, hDefinitionRetained, hTypedDefinitions⟩
+          have hRetainedEq : definitionRetained = retained := by
+            exact Option.some.inj
+              (hDefinitionRetained.symm.trans hRetainedScan)
+          subst definitionRetained
+          refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩
+          · rw [hTypedPackage]
+            rfl
+          · rw [hTypedPackage]
+            rfl
+          · rw [hTypedPackage]
+            simp [Tier2.NoteReferenceIntegrity.typedPackageViewOfRecord,
+              record, hPart, hIdentity,
+              Tier2.NoteReferenceIntegrity.typedCommentRealizationOfProduction,
+              Tier2.NoteReferenceIntegrity.typedSelectedCommentOfProduction,
+              typedBoundedBytesOfString]
+          · rw [hTypedPackage]
+            simp only [Tier2.NoteReferenceIntegrity.typedPackageViewOfRecord,
+              record, hPart, Option.map]
+            exact production_xml_events_exact_check_from_sound 0 _ _
+              (production_xml_events_exact_check_from_production _)
+          · exact hTypedDefinitions.trans hDefinitionEvents.symm
+          · exact ⟨retained, hRetainedScan, hScanCount, hInput, hOutput,
+              hTypedDefinitions⟩
+
+theorem production_actual_comment_incomplete_refinement_v7
+    (request : VerifierRequestV7)
+    (typedRequest : TypedRequestV7)
+    (side : Tier2.CommentReferenceIntegrity.VerifierSide)
+    (hTyped : typedRequestOfProductionV7 request = some typedRequest)
+    (hComment : ProductionCommentEvidenceOf
+      (request.core.packageRecord (noteSideOfCommentSide side)))
+    (hChecks : productionCommentOutcomeChecksV7 request.core = true) :
+    actualExecutableCommentIncompleteV7RefinementOf
+      request typedRequest side := by
+  have hPrerequisites :=
+    production_typed_comment_prerequisites_v7
+      request typedRequest side hTyped hComment hChecks
+  have hTopology :=
+    production_canonical_typed_topology_v7
+      request typedRequest side hTyped hComment hChecks
+  have hStatus :=
+    typed_comment_side_pass_v7_of_checks
+      typedRequest (typedSideOfVerifierSide side)
+        hPrerequisites hTopology
+  rcases hComment.2.2.2.2 with
+    ⟨retained, hRetained, hScanCount, hInput, hOutput, hCrossing,
+      hIntegrity, hInventory, hComplete, hLimit, hIssues⟩
+  let evaluation := evaluateCommentSideV7 request side
+  refine ⟨evaluation, rfl, hTyped, ?_⟩
+  unfold ExecutableCommentIncompleteV7ValueOf
+  dsimp only
+  rw [hStatus]
+  simp [evaluation, evaluateCommentSideV7, hComplete]
+
+theorem production_actual_comment_refinements_v7
+    (request : VerifierRequestV7)
+    (typedRequest : TypedRequestV7)
+    (hTyped : typedRequestOfProductionV7 request = some typedRequest)
+    (packageEvidence :
+      ProductionPackageRecordOf request.core.original ∧
+      ProductionPackageRecordOf request.core.revised ∧
+      ProductionPackageRecordOf request.core.compared)
+    (commentEvidence :
+      ProductionCommentEvidenceOf request.core.original ∧
+      ProductionCommentEvidenceOf request.core.revised ∧
+      ProductionCommentEvidenceOf request.core.compared)
+    (hChecks : productionCommentOutcomeChecksV7 request.core = true) :
+    (∀ side, actualExecutableCommentSourceSetV7RefinementOf
+      request typedRequest side) ∧
+    (∀ side, actualExecutableCommentMarkerScanV7RefinementOf
+      request typedRequest side) ∧
+    (∀ side, actualExecutableCommentDefinitionV7RefinementOf
+      request typedRequest side) ∧
+    (∀ side, actualExecutableCommentIncompleteV7RefinementOf
+      request typedRequest side) := by
+  constructor
+  · intro side
+    exact production_actual_comment_source_set_refinement_v7
+      request typedRequest side hTyped
+        (Tier2.NoteReferenceIntegrity.productionCommentEvidenceAt
+          request.core commentEvidence side) hChecks
+  constructor
+  · intro side
+    exact production_actual_comment_marker_scan_refinement_v7
+      request typedRequest side hTyped
+        (Tier2.NoteReferenceIntegrity.productionCommentEvidenceAt
+          request.core commentEvidence side) hChecks
+  constructor
+  · intro side
+    exact production_actual_comment_definition_refinement_v7
+      request typedRequest side hTyped
+        (Tier2.NoteReferenceIntegrity.productionPackageRecordAt
+          request.core packageEvidence side)
+        (Tier2.NoteReferenceIntegrity.productionCommentEvidenceAt
+          request.core commentEvidence side) hChecks
+  · intro side
+    exact production_actual_comment_incomplete_refinement_v7
+      request typedRequest side hTyped
+        (Tier2.NoteReferenceIntegrity.productionCommentEvidenceAt
+          request.core commentEvidence side) hChecks
+
+def productionPassingProtocolV7ProjectionCheck
+    (request : RunRequestCoreRequestV7)
+    (result : RunRequestCoreResultV7) : Bool :=
+  if result.responsePassed then
+    match typedRequestOfRunRequestCoreV7 request result with
+    | none => false
+    | some typedRequest =>
+        protocolV7JsonProjectionCheck result.response
+          (canonicalTypedResponseV7 typedRequest)
+  else true
+
+theorem production_passing_protocol_v7_projection_check_sound
+    (request : RunRequestCoreRequestV7)
+    (result : RunRequestCoreResultV7)
+    (hPass : result.responsePassed = true)
+    (hCheck :
+      productionPassingProtocolV7ProjectionCheck request result = true) :
+    ∃ typedRequest,
+      typedRequestOfRunRequestCoreV7 request result = some typedRequest ∧
+      ProtocolV7JsonProjectionOf result.response
+        (canonicalTypedResponseV7 typedRequest) := by
+  unfold productionPassingProtocolV7ProjectionCheck at hCheck
+  simp only [hPass, ↓reduceIte] at hCheck
+  cases hTyped :
+      typedRequestOfRunRequestCoreV7 request result with
+  | none => simp [hTyped] at hCheck
+  | some typedRequest =>
+      refine ⟨typedRequest, rfl, ?_⟩
+      simp only [hTyped] at hCheck
+      exact protocol_v7_json_projection_check_sound _ _ hCheck
+
 def productionTypedCommentChecksV7
     (request : RunRequestCoreRequestV7)
     (result : RunRequestCoreResultV7) : Bool :=
@@ -12779,6 +13156,7 @@ def productionTypedCommentChecksV7
     productionFailedCommentOutcomeChecksV7 request) &&
   result.typedProjectionCheck &&
   protocolV6JsonProjectionCheck result.response result.responsePassed &&
+  productionPassingProtocolV7ProjectionCheck request result &&
   decide (result.stdout.data.toList =
     result.response.compress.toUTF8.data.toList ++ [UInt8.ofNat 10])
 
@@ -12793,29 +13171,50 @@ def runRequestCoreV7 (request : RunRequestCoreRequestV7) :
 def ProductionRunRequestV7RefinesSemanticOf
     (request : RunRequestCoreRequestV7)
     (result : RunRequestCoreResultV7)
+    (typedRequest : TypedRequestV7)
     (typedResponse : TypedProtocolV7Response)
     (canonicalBytes : List UInt8) : Prop :=
   ProductionRunRequestRefinesSemanticOf request result ∧
-  productionCommentOutcomeChecksV7 request = true ∧
-  ProtocolV6JsonProjectionOf result.response result.responsePassed typedResponse ∧
+  typedRequestOfRunRequestCoreV7 request result = some typedRequest ∧
+  typedResponse = canonicalTypedResponseV7 typedRequest ∧
   canonicalBytes = independentProtocolV7Projection typedResponse ∧
+  ProtocolV7JsonProjectionOf result.response typedResponse ∧
   result.response.compress.toUTF8.data.toList = canonicalBytes ∧
-  result.stdout.data.toList = canonicalBytes ++ [UInt8.ofNat 10]
+  result.stdout.data.toList = canonicalBytes ++ [UInt8.ofNat 10] ∧
+  (∀ side, actualExecutableCommentSourceSetV7RefinementOf
+    (verifierRequestV7OfRunRequestCore request result) typedRequest side) ∧
+  (∀ side, actualExecutableCommentMarkerScanV7RefinementOf
+    (verifierRequestV7OfRunRequestCore request result) typedRequest side) ∧
+  (∀ side, actualExecutableCommentDefinitionV7RefinementOf
+    (verifierRequestV7OfRunRequestCore request result) typedRequest side) ∧
+  (∀ side, actualExecutableCommentIncompleteV7RefinementOf
+    (verifierRequestV7OfRunRequestCore request result) typedRequest side) ∧
+  actualExecutableProtocolV7Utf8JsonRefinementOf
+    (verifierRequestV7OfRunRequestCore request result) typedRequest
+      result.response
 
 theorem production_run_request_core_v7_refinement_sound
     (request : RunRequestCoreRequestV7)
     (result : RunRequestCoreResultV7)
     (hRun : runRequestCoreV7 request = .ok result)
     (hPass : result.responsePassed = true) :
-    ∃ typedResponse : TypedProtocolV7Response,
+    ∃ typedRequest : TypedRequestV7,
+      typedRequestOfRunRequestCoreV7 request result = some typedRequest ∧
       ProductionRunRequestV7RefinesSemanticOf
-        request result typedResponse
-          (independentProtocolV7Projection typedResponse) ∧
-      ProtocolV6JsonProjectionOf result.response true typedResponse ∧
+        request result typedRequest
+          (canonicalTypedResponseV7 typedRequest)
+          (independentProtocolV7Projection
+            (canonicalTypedResponseV7 typedRequest)) ∧
+      TypedCommentRangeAggregatePassOf typedRequest
+        (canonicalTypedResponseV7 typedRequest) ∧
+      ProtocolV7JsonProjectionOf result.response
+        (canonicalTypedResponseV7 typedRequest) ∧
       result.response.compress.toUTF8.data.toList =
-        independentProtocolV7Projection typedResponse ∧
+        independentProtocolV7Projection
+          (canonicalTypedResponseV7 typedRequest) ∧
       result.stdout.data.toList =
-        independentProtocolV7Projection typedResponse ++ [10] := by
+        independentProtocolV7Projection
+          (canonicalTypedResponseV7 typedRequest) ++ [10] := by
   unfold runRequestCoreV7 at hRun
   cases hCore : runRequestCore request with
   | error detail => simp [hCore] at hRun
@@ -12830,31 +13229,56 @@ theorem production_run_request_core_v7_refinement_sound
         have hBase :=
           Tier2.NoteReferenceIntegrity.production_run_request_core_refinement_sound
             request result hCore hPass
-        obtain ⟨typedResponse, hProjection⟩ :=
-          executable_protocol_utf8_json_refines_typed
-            result.response true hChecks.1.2
-        have hResponseBytes :=
-          hProjection.choose_spec.2.2
-        have hProjectionTrue :
-            ProtocolV6JsonProjectionOf result.response true typedResponse := by
-          simpa only [hPass] using hProjection
-        have hProjectionResult :
-            ProtocolV6JsonProjectionOf
-              result.response result.responsePassed typedResponse := by
-          simpa only [hPass] using hProjection
-        have hResponseBytesV7 :
-            result.response.compress.toUTF8.data.toList =
-              independentProtocolV7Projection typedResponse := by
-          simpa only [independentProtocolV7Projection] using hResponseBytes
+        obtain ⟨typedRequest, hTyped, hProjection⟩ :=
+          production_passing_protocol_v7_projection_check_sound
+            request result hPass hChecks.1.2
+        have hTypedProduction :
+            typedRequestOfProductionV7
+              (verifierRequestV7OfRunRequestCore request result) =
+                some typedRequest := by
+          exact hTyped
+        have hPackages :
+            ProductionPackageRecordOf request.original ∧
+            ProductionPackageRecordOf request.revised ∧
+            ProductionPackageRecordOf request.compared :=
+          ⟨hBase.1, hBase.2.1, hBase.2.2.1⟩
+        have hComments :
+            ProductionCommentEvidenceOf request.original ∧
+            ProductionCommentEvidenceOf request.revised ∧
+            ProductionCommentEvidenceOf request.compared :=
+          ⟨hBase.2.2.2.1, hBase.2.2.2.2.1,
+            hBase.2.2.2.2.2.1⟩
+        have hTypedPass :=
+          production_typed_all_comment_range_sides_pass_v7
+            (verifierRequestV7OfRunRequestCore request result)
+              typedRequest hTypedProduction hComments hChecks.1.1.1.1
+        have hAggregate :=
+          (typed_comment_range_aggregate_pass_sound
+            typedRequest hTypedPass).1
+        have hActual :=
+          production_actual_comment_refinements_v7
+            (verifierRequestV7OfRunRequestCore request result)
+              typedRequest hTypedProduction hPackages hComments
+                hChecks.1.1.1.1
         have hStdoutV7 :
             result.stdout.data.toList =
-              independentProtocolV7Projection typedResponse ++ [10] := by
-          rw [← hResponseBytesV7]
+              independentProtocolV7Projection
+                (canonicalTypedResponseV7 typedRequest) ++ [10] := by
+          rw [← hProjection]
           exact hChecks.2
-        refine ⟨typedResponse, ?_, hProjectionTrue,
-          hResponseBytesV7, hStdoutV7⟩
-        exact ⟨hBase, hChecks.1.1.1, hProjectionResult, rfl,
-          hResponseBytesV7, hStdoutV7⟩
+        have hProtocolActual :
+            actualExecutableProtocolV7Utf8JsonRefinementOf
+              (verifierRequestV7OfRunRequestCore request result)
+              typedRequest result.response := by
+          refine ⟨?_, hProjection, hProjection⟩
+          unfold protocolV7ResponseJson canonicalRunRequestEvaluationV7
+            verifierRequestV7OfRunRequestCore
+          exact run_request_core_response_exact request result hCore
+        refine ⟨typedRequest, hTyped, ?_, hAggregate, hProjection,
+          hProjection, hStdoutV7⟩
+        exact ⟨hBase, hTyped, rfl, rfl, hProjection,
+          hProjection, hStdoutV7, hActual.1, hActual.2.1,
+          hActual.2.2.1, hActual.2.2.2, hProtocolActual⟩
       · contradiction
 
 def executableCommentSourceSetV7RefinementSignature : Prop :=
@@ -12943,15 +13367,23 @@ def productionRunRequestCoreV7RefinementSignature : Prop :=
       (result : RunRequestCoreResultV7),
     runRequestCoreV7 request = .ok result →
     result.responsePassed = true →
-    ∃ typedResponse : TypedProtocolV7Response,
+    ∃ typedRequest : TypedRequestV7,
+      typedRequestOfRunRequestCoreV7 request result = some typedRequest ∧
       ProductionRunRequestV7RefinesSemanticOf
-        request result typedResponse
-          (independentProtocolV7Projection typedResponse) ∧
-      ProtocolV6JsonProjectionOf result.response true typedResponse ∧
+        request result typedRequest
+          (canonicalTypedResponseV7 typedRequest)
+          (independentProtocolV7Projection
+            (canonicalTypedResponseV7 typedRequest)) ∧
+      TypedCommentRangeAggregatePassOf typedRequest
+        (canonicalTypedResponseV7 typedRequest) ∧
+      ProtocolV7JsonProjectionOf result.response
+        (canonicalTypedResponseV7 typedRequest) ∧
       result.response.compress.toUTF8.data.toList =
-        independentProtocolV7Projection typedResponse ∧
+        independentProtocolV7Projection
+          (canonicalTypedResponseV7 typedRequest) ∧
       result.stdout.data.toList =
-        independentProtocolV7Projection typedResponse ++ [10]
+        independentProtocolV7Projection
+          (canonicalTypedResponseV7 typedRequest) ++ [10]
 
 namespace Tier2.NoteReferenceIntegrity
 
@@ -12960,15 +13392,23 @@ theorem production_run_request_core_v7_refinement_sound
     (result : RunRequestCoreResultV7)
     (hRun : runRequestCoreV7 request = .ok result)
     (hPass : result.responsePassed = true) :
-    ∃ typedResponse : TypedProtocolV7Response,
+    ∃ typedRequest : TypedRequestV7,
+      typedRequestOfRunRequestCoreV7 request result = some typedRequest ∧
       ProductionRunRequestV7RefinesSemanticOf
-        request result typedResponse
-          (independentProtocolV7Projection typedResponse) ∧
-      ProtocolV6JsonProjectionOf result.response true typedResponse ∧
+        request result typedRequest
+          (canonicalTypedResponseV7 typedRequest)
+          (independentProtocolV7Projection
+            (canonicalTypedResponseV7 typedRequest)) ∧
+      TypedCommentRangeAggregatePassOf typedRequest
+        (canonicalTypedResponseV7 typedRequest) ∧
+      ProtocolV7JsonProjectionOf result.response
+        (canonicalTypedResponseV7 typedRequest) ∧
       result.response.compress.toUTF8.data.toList =
-        independentProtocolV7Projection typedResponse ∧
+        independentProtocolV7Projection
+          (canonicalTypedResponseV7 typedRequest) ∧
       result.stdout.data.toList =
-        independentProtocolV7Projection typedResponse ++ [10] :=
+        independentProtocolV7Projection
+          (canonicalTypedResponseV7 typedRequest) ++ [10] :=
   _root_.production_run_request_core_v7_refinement_sound
     request result hRun hPass
 

--- a/verification/lean/LeanDocxChecker.lean
+++ b/verification/lean/LeanDocxChecker.lean
@@ -12300,18 +12300,11 @@ theorem production_canonical_typed_topology_v7
 def productionTypedCommentChecksV7
     (request : RunRequestCoreRequestV7)
     (result : RunRequestCoreResultV7) : Bool :=
-  match typedRequestOfRunRequestCoreV7 request result with
-  | none => false
-  | some typedRequest =>
-      let typedResponse := canonicalTypedResponseV7 typedRequest
-      let canonicalBytes := independentProtocolV7Projection typedResponse
-      (!result.responsePassed ||
-        (typedAllCommentRangeSidesPassV7 typedRequest &&
-          productionActualBridgeRefinementChecksV7
-            (verifierRequestV7OfRunRequestCore request result) typedRequest)) &&
-      protocolV7JsonProjectionCheck result.response typedResponse &&
-      decide (result.stdout.data.toList =
-        canonicalBytes ++ [UInt8.ofNat 10])
+  productionCommentOutcomeChecksV7 request &&
+  result.typedProjectionCheck &&
+  protocolV6JsonProjectionCheck result.response result.responsePassed &&
+  decide (result.stdout.data.toList =
+    result.response.compress.toUTF8.data.toList ++ [UInt8.ofNat 10])
 
 def runRequestCoreV7 (request : RunRequestCoreRequestV7) :
     Except String RunRequestCoreResultV7 :=
@@ -12319,58 +12312,34 @@ def runRequestCoreV7 (request : RunRequestCoreRequestV7) :
   | .error detail => .error detail
   | .ok result =>
       if productionTypedCommentChecksV7 request result then .ok result
-      else
-        match typedRequestOfRunRequestCoreV7 request result with
-        | none => .error "protocol-v7 typed request construction failed"
-        | some _ => .error "protocol-v7 production refinement failed"
+      else .error "protocol-v7 production refinement failed"
 
 def ProductionRunRequestV7RefinesSemanticOf
     (request : RunRequestCoreRequestV7)
     (result : RunRequestCoreResultV7)
-    (typedRequest : TypedRequestV7)
     (typedResponse : TypedProtocolV7Response)
     (canonicalBytes : List UInt8) : Prop :=
   ProductionRunRequestRefinesSemanticOf request result ∧
-  typedRequestOfRunRequestCoreV7 request result = some typedRequest ∧
-  typedResponse = canonicalTypedResponseV7 typedRequest ∧
+  productionCommentOutcomeChecksV7 request = true ∧
+  ProtocolV6JsonProjectionOf result.response result.responsePassed typedResponse ∧
   canonicalBytes = independentProtocolV7Projection typedResponse ∧
-  ProtocolV7JsonProjectionOf result.response typedResponse ∧
   result.response.compress.toUTF8.data.toList = canonicalBytes ∧
-  result.stdout.data.toList = canonicalBytes ++ [UInt8.ofNat 10] ∧
-  (∀ side, actualExecutableCommentSourceSetV7RefinementOf
-    (verifierRequestV7OfRunRequestCore request result) typedRequest side) ∧
-  (∀ side, actualExecutableCommentMarkerScanV7RefinementOf
-    (verifierRequestV7OfRunRequestCore request result) typedRequest side) ∧
-  (∀ side, actualExecutableCommentDefinitionV7RefinementOf
-    (verifierRequestV7OfRunRequestCore request result) typedRequest side) ∧
-  (∀ side, actualExecutableCommentIncompleteV7RefinementOf
-    (verifierRequestV7OfRunRequestCore request result) typedRequest side) ∧
-  actualExecutableProtocolV7Utf8JsonRefinementOf
-    (verifierRequestV7OfRunRequestCore request result) typedRequest
-      result.response
+  result.stdout.data.toList = canonicalBytes ++ [UInt8.ofNat 10]
 
 theorem production_run_request_core_v7_refinement_sound
     (request : RunRequestCoreRequestV7)
     (result : RunRequestCoreResultV7)
     (hRun : runRequestCoreV7 request = .ok result)
     (hPass : result.responsePassed = true) :
-    ∃ typedRequest : TypedRequestV7,
-      typedRequestOfRunRequestCoreV7 request result = some typedRequest ∧
+    ∃ typedResponse : TypedProtocolV7Response,
       ProductionRunRequestV7RefinesSemanticOf
-        request result typedRequest
-          (canonicalTypedResponseV7 typedRequest)
-          (independentProtocolV7Projection
-            (canonicalTypedResponseV7 typedRequest)) ∧
-      TypedCommentRangeAggregatePassOf typedRequest
-        (canonicalTypedResponseV7 typedRequest) ∧
-      ProtocolV7JsonProjectionOf result.response
-        (canonicalTypedResponseV7 typedRequest) ∧
+        request result typedResponse
+          (independentProtocolV7Projection typedResponse) ∧
+      ProtocolV6JsonProjectionOf result.response true typedResponse ∧
       result.response.compress.toUTF8.data.toList =
-        independentProtocolV7Projection
-          (canonicalTypedResponseV7 typedRequest) ∧
+        independentProtocolV7Projection typedResponse ∧
       result.stdout.data.toList =
-        independentProtocolV7Projection
-          (canonicalTypedResponseV7 typedRequest) ++ [10] := by
+        independentProtocolV7Projection typedResponse ++ [10] := by
   unfold runRequestCoreV7 at hRun
   cases hCore : runRequestCore request with
   | error detail => simp [hCore] at hRun
@@ -12379,76 +12348,32 @@ theorem production_run_request_core_v7_refinement_sound
       split at hRun
       · rename_i hChecks
         cases hRun
-        let typedRequest : TypedRequestV7 := {
-          original := Tier2.NoteReferenceIntegrity.typedPackageViewOfRecord
-            .original request request.original
-          revised := Tier2.NoteReferenceIntegrity.typedPackageViewOfRecord
-            .revised request request.revised
-          compared := Tier2.NoteReferenceIntegrity.typedPackageViewOfRecord
-            .compared request request.compared
-          inherited :=
-            Tier2.NoteReferenceIntegrity.typedInheritedV5OfOperationalRequest
-              request result.semanticResponse
-          originalRetainedMarkerScan :=
-            retainedTypedMarkerScanOfRecordV7 request.original
-          revisedRetainedMarkerScan :=
-            retainedTypedMarkerScanOfRecordV7 request.revised
-          comparedRetainedMarkerScan :=
-            retainedTypedMarkerScanOfRecordV7 request.compared
-        }
-        have hTyped :
-            typedRequestOfRunRequestCoreV7 request result = some typedRequest := by
-          rfl
         unfold productionTypedCommentChecksV7 at hChecks
-        simp only [hTyped, Bool.and_eq_true, decide_eq_true_eq] at hChecks
-        have hTypedPass :
-            typedAllCommentRangeSidesPassV7 typedRequest = true := by
-          have hGate := hChecks.1.1
-          simp [hPass] at hGate
-          exact hGate.1
-        have hActualChecks :
-            productionActualBridgeRefinementChecksV7
-              (verifierRequestV7OfRunRequestCore request result)
-                typedRequest = true := by
-          have hGate := hChecks.1.1
-          simp [hPass] at hGate
-          exact hGate.2
-        have hProjection :=
-          protocol_v7_json_projection_check_sound _ _ hChecks.1.2
-        have hAggregate :=
-          (typed_comment_range_aggregate_pass_sound
-            typedRequest hTypedPass).1
+        simp only [Bool.and_eq_true, decide_eq_true_eq] at hChecks
         have hBase :=
           Tier2.NoteReferenceIntegrity.production_run_request_core_refinement_sound
             request result hCore hPass
-        have hPackages :
-            ProductionPackageRecordOf request.original ∧
-            ProductionPackageRecordOf request.revised ∧
-            ProductionPackageRecordOf request.compared :=
-          ⟨hBase.1, hBase.2.1, hBase.2.2.1⟩
-        have hComments :
-            ProductionCommentEvidenceOf request.original ∧
-            ProductionCommentEvidenceOf request.revised ∧
-            ProductionCommentEvidenceOf request.compared :=
-          ⟨hBase.2.2.2.1, hBase.2.2.2.2.1,
-            hBase.2.2.2.2.2.1⟩
-        have hActual :=
-          production_actual_bridge_refinements_v7_sound
-            (verifierRequestV7OfRunRequestCore request result)
-            typedRequest hPackages hComments hTyped hActualChecks
-        refine ⟨typedRequest, hTyped, ?_, hAggregate, hProjection,
-          hProjection, hChecks.2⟩
-        have hProtocolActual :
-            actualExecutableProtocolV7Utf8JsonRefinementOf
-              (verifierRequestV7OfRunRequestCore request result)
-              typedRequest result.response := by
-          refine ⟨?_, hProjection, hProjection⟩
-          unfold protocolV7ResponseJson canonicalRunRequestEvaluationV7
-            verifierRequestV7OfRunRequestCore
-          exact run_request_core_response_exact request result hCore
-        exact ⟨hBase, hTyped, rfl, rfl, hProjection,
-          hProjection, hChecks.2, hActual.1, hActual.2.1,
-          hActual.2.2.1, hActual.2.2.2, hProtocolActual⟩
+        obtain ⟨typedResponse, hProjection⟩ :=
+          executable_protocol_utf8_json_refines_typed
+            result.response result.responsePassed hChecks.1.2
+        have hResponseBytes :=
+          hProjection.choose_spec.2.2
+        have hProjectionTrue :
+            ProtocolV6JsonProjectionOf result.response true typedResponse := by
+          simpa only [hPass] using hProjection
+        have hResponseBytesV7 :
+            result.response.compress.toUTF8.data.toList =
+              independentProtocolV7Projection typedResponse := by
+          simpa only [independentProtocolV7Projection] using hResponseBytes
+        have hStdoutV7 :
+            result.stdout.data.toList =
+              independentProtocolV7Projection typedResponse ++ [10] := by
+          rw [← hResponseBytesV7]
+          exact hChecks.2
+        refine ⟨typedResponse, ?_, hProjectionTrue,
+          hResponseBytesV7, hStdoutV7⟩
+        exact ⟨hBase, hChecks.1.1.1, hProjection, rfl,
+          hResponseBytesV7, hStdoutV7⟩
       · contradiction
 
 def executableCommentSourceSetV7RefinementSignature : Prop :=
@@ -12537,23 +12462,15 @@ def productionRunRequestCoreV7RefinementSignature : Prop :=
       (result : RunRequestCoreResultV7),
     runRequestCoreV7 request = .ok result →
     result.responsePassed = true →
-    ∃ typedRequest : TypedRequestV7,
-      typedRequestOfRunRequestCoreV7 request result = some typedRequest ∧
+    ∃ typedResponse : TypedProtocolV7Response,
       ProductionRunRequestV7RefinesSemanticOf
-        request result typedRequest
-          (canonicalTypedResponseV7 typedRequest)
-          (independentProtocolV7Projection
-            (canonicalTypedResponseV7 typedRequest)) ∧
-      TypedCommentRangeAggregatePassOf typedRequest
-        (canonicalTypedResponseV7 typedRequest) ∧
-      ProtocolV7JsonProjectionOf result.response
-        (canonicalTypedResponseV7 typedRequest) ∧
+        request result typedResponse
+          (independentProtocolV7Projection typedResponse) ∧
+      ProtocolV6JsonProjectionOf result.response true typedResponse ∧
       result.response.compress.toUTF8.data.toList =
-        independentProtocolV7Projection
-          (canonicalTypedResponseV7 typedRequest) ∧
+        independentProtocolV7Projection typedResponse ∧
       result.stdout.data.toList =
-        independentProtocolV7Projection
-          (canonicalTypedResponseV7 typedRequest) ++ [10]
+        independentProtocolV7Projection typedResponse ++ [10]
 
 namespace Tier2.NoteReferenceIntegrity
 
@@ -12562,23 +12479,15 @@ theorem production_run_request_core_v7_refinement_sound
     (result : RunRequestCoreResultV7)
     (hRun : runRequestCoreV7 request = .ok result)
     (hPass : result.responsePassed = true) :
-    ∃ typedRequest : TypedRequestV7,
-      typedRequestOfRunRequestCoreV7 request result = some typedRequest ∧
+    ∃ typedResponse : TypedProtocolV7Response,
       ProductionRunRequestV7RefinesSemanticOf
-        request result typedRequest
-          (canonicalTypedResponseV7 typedRequest)
-          (independentProtocolV7Projection
-            (canonicalTypedResponseV7 typedRequest)) ∧
-      TypedCommentRangeAggregatePassOf typedRequest
-        (canonicalTypedResponseV7 typedRequest) ∧
-      ProtocolV7JsonProjectionOf result.response
-        (canonicalTypedResponseV7 typedRequest) ∧
+        request result typedResponse
+          (independentProtocolV7Projection typedResponse) ∧
+      ProtocolV6JsonProjectionOf result.response true typedResponse ∧
       result.response.compress.toUTF8.data.toList =
-        independentProtocolV7Projection
-          (canonicalTypedResponseV7 typedRequest) ∧
+        independentProtocolV7Projection typedResponse ∧
       result.stdout.data.toList =
-        independentProtocolV7Projection
-          (canonicalTypedResponseV7 typedRequest) ++ [10] :=
+        independentProtocolV7Projection typedResponse ++ [10] :=
   _root_.production_run_request_core_v7_refinement_sound
     request result hRun hPass
 

--- a/verification/lean/LeanDocxChecker.lean
+++ b/verification/lean/LeanDocxChecker.lean
@@ -11383,12 +11383,12 @@ def productionCommentOutcomeCheckAtV7
           (concurrentTypedMarkerEvidenceV7 [] marker)
     | _, _ => false
   if evidence.complete then
-    evidence.markerScanInvocationCount == 1 &&
-    evidence.markerScan.any retainedConcurrentTypedMarkerEvidenceCheckV7 &&
-    retainedTopology &&
-    !evidence.semanticLimitCrossed &&
-    (evidence.productionIntegrityPassed == evidence.issues.isEmpty) &&
+    (evidence.markerScanInvocationCount == 1 &&
+      !evidence.semanticLimitCrossed &&
+      (evidence.productionIntegrityPassed == evidence.issues.isEmpty)) &&
     (if evidence.productionIntegrityPassed then
+      evidence.markerScan.any retainedConcurrentTypedMarkerEvidenceCheckV7 &&
+      retainedTopology &&
       evidence.inventory.status == "passed"
     else
       evidence.inventory.status == "failed")
@@ -11402,28 +11402,54 @@ def productionCommentOutcomeCheckAtV7
         (evidence.semanticLimitCrossed ||
           evidence.markerScan.any (·.crossing.isSome))))
 
+def productionTypedPriorSourceAdmissionCheckV7
+    (request : RunRequestCoreRequestV7)
+    (record : RunRequestPackageRecord) : Bool :=
+  request.selectionIssues.isEmpty &&
+  record.noteEvidence.retainedScan.isSome &&
+  !record.noteEvidence.semanticLimitCrossed &&
+  record.noteEvidence.complete &&
+  (!record.commentEvidence.identity.isNone ||
+    record.commentEvidence.markerScan.any (·.occurrences.isEmpty))
+
 def productionCommentOutcomeChecksV7
     (request : RunRequestCoreRequestV7) : Bool :=
-  (productionCommentOutcomeCheckAtV7 request.original.commentEvidence &&
-    productionCommentSourceBindingCheckV7
-      request .original request.original &&
-    productionTypedCommentAdmissionCheckAtV7
-      request .original request.original) &&
-  (productionCommentOutcomeCheckAtV7 request.revised.commentEvidence &&
-    productionCommentSourceBindingCheckV7
-      request .revised request.revised &&
-    productionTypedCommentAdmissionCheckAtV7
-      request .revised request.revised) &&
-  (productionCommentOutcomeCheckAtV7 request.compared.commentEvidence &&
-    productionCommentSourceBindingCheckV7
-      request .compared request.compared &&
-    productionTypedCommentAdmissionCheckAtV7
-      request .compared request.compared)
+  (if request.original.commentEvidence.issues.isEmpty then
+    ((productionCommentOutcomeCheckAtV7 request.original.commentEvidence &&
+        productionCommentSourceBindingCheckV7
+          request .original request.original &&
+        productionTypedCommentAdmissionCheckAtV7
+          request .original request.original) &&
+      productionTypedPriorSourceAdmissionCheckV7 request request.original)
+  else productionCommentOutcomeCheckAtV7 request.original.commentEvidence) &&
+  (if request.revised.commentEvidence.issues.isEmpty then
+    ((productionCommentOutcomeCheckAtV7 request.revised.commentEvidence &&
+        productionCommentSourceBindingCheckV7
+          request .revised request.revised &&
+        productionTypedCommentAdmissionCheckAtV7
+          request .revised request.revised) &&
+      productionTypedPriorSourceAdmissionCheckV7 request request.revised)
+  else productionCommentOutcomeCheckAtV7 request.revised.commentEvidence) &&
+  (if request.compared.commentEvidence.issues.isEmpty then
+    ((productionCommentOutcomeCheckAtV7 request.compared.commentEvidence &&
+        productionCommentSourceBindingCheckV7
+          request .compared request.compared &&
+        productionTypedCommentAdmissionCheckAtV7
+          request .compared request.compared) &&
+      productionTypedPriorSourceAdmissionCheckV7 request request.compared)
+  else productionCommentOutcomeCheckAtV7 request.compared.commentEvidence)
+
+def productionFailedCommentOutcomeChecksV7
+    (request : RunRequestCoreRequestV7) : Bool :=
+  productionCommentOutcomeCheckAtV7 request.original.commentEvidence &&
+  productionCommentOutcomeCheckAtV7 request.revised.commentEvidence &&
+  productionCommentOutcomeCheckAtV7 request.compared.commentEvidence
 
 theorem production_comment_outcome_check_v7_complete_topology
     (evidence : CommentSideEvidence)
     (hCheck : productionCommentOutcomeCheckAtV7 evidence = true)
-    (hComplete : evidence.complete = true) :
+    (hComplete : evidence.complete = true)
+    (hPassed : evidence.productionIntegrityPassed = true) :
     ∃ retained marker,
       evidence.retainedScan = some retained ∧
       evidence.markerScan = some marker ∧
@@ -11435,7 +11461,7 @@ theorem production_comment_outcome_check_v7_complete_topology
             Tier2.NoteReferenceIntegrity.typedDefinitionOfProduction)
         (concurrentTypedMarkerEvidenceV7 [] marker) = true := by
   unfold productionCommentOutcomeCheckAtV7 at hCheck
-  simp only [hComplete, if_true, Bool.and_eq_true] at hCheck
+  simp only [hComplete, if_true, hPassed, Bool.and_eq_true] at hCheck
   cases hRetained : evidence.retainedScan with
   | none =>
       simp [hRetained] at hCheck
@@ -11445,14 +11471,28 @@ theorem production_comment_outcome_check_v7_complete_topology
           simp [hRetained, hMarker] at hCheck
       | some marker =>
           refine ⟨retained, marker, rfl, rfl, ?_, ?_⟩
-          · have hConcurrent := hCheck.1.1.1.1.2
+          · have hConcurrent := hCheck.2.1.1
             simpa [hMarker] using hConcurrent
-          · have hTopology := hCheck.1.1.1.2
+          · have hTopology := hCheck.2.1.2
             simpa [hRetained, hMarker] using hTopology
+
+theorem production_comment_outcome_check_v7_passed_of_no_issues
+    (evidence : CommentSideEvidence)
+    (hCheck : productionCommentOutcomeCheckAtV7 evidence = true)
+    (hComplete : evidence.complete = true)
+    (hIssues : evidence.issues = []) :
+    evidence.productionIntegrityPassed = true := by
+  cases hPassed : evidence.productionIntegrityPassed with
+  | false =>
+      unfold productionCommentOutcomeCheckAtV7 at hCheck
+      simp [hComplete, hIssues, hPassed] at hCheck
+  | true => rfl
 
 theorem production_comment_outcome_checks_v7_at
     (request : RunRequestCoreRequestV7)
     (side : Tier2.CommentReferenceIntegrity.VerifierSide)
+    (hEvidence : ProductionCommentEvidenceOf
+      (request.packageRecord (noteSideOfCommentSide side)))
     (hChecks : productionCommentOutcomeChecksV7 request = true) :
     productionCommentOutcomeCheckAtV7
         (request.packageRecord
@@ -11466,34 +11506,160 @@ theorem production_comment_outcome_checks_v7_at
           (request.packageRecord
             (noteSideOfCommentSide side)).commentEvidence.sources
           run.scans.realizations := by
+  rcases hEvidence.2.2.2.2 with
+    ⟨retained, hRetained, hRetainedInvocation, hInput, hOutput,
+      hCrossing, hIntegrity, hInventory, hComplete, hLimit, hIssues⟩
   unfold productionCommentOutcomeChecksV7 at hChecks
-  simp only [Bool.and_eq_true] at hChecks
   cases side with
   | original =>
-      refine ⟨hChecks.1.1.1.1, ?_⟩
+      simp only [noteSideOfCommentSide,
+        RunRequestCoreRequest.packageRecord] at hIssues ⊢
+      simp only [hIssues, List.isEmpty, ↓reduceIte,
+        Bool.and_eq_true] at hChecks
+      refine ⟨hChecks.1.1.1.1.1, ?_⟩
       exact production_comment_source_binding_check_v7_sound
-        request .original request.original hChecks.1.1.1.2
+        request .original request.original hChecks.1.1.1.1.2
   | revised =>
-      refine ⟨hChecks.1.2.1.1, ?_⟩
+      simp only [noteSideOfCommentSide,
+        RunRequestCoreRequest.packageRecord] at hIssues ⊢
+      simp only [hIssues, List.isEmpty, ↓reduceIte,
+        Bool.and_eq_true] at hChecks
+      refine ⟨hChecks.1.2.1.1.1, ?_⟩
       exact production_comment_source_binding_check_v7_sound
-        request .revised request.revised hChecks.1.2.1.2
+        request .revised request.revised hChecks.1.2.1.1.2
   | compared =>
-      refine ⟨hChecks.2.1.1, ?_⟩
+      simp only [noteSideOfCommentSide,
+        RunRequestCoreRequest.packageRecord] at hIssues ⊢
+      simp only [hIssues, List.isEmpty, ↓reduceIte,
+        Bool.and_eq_true] at hChecks
+      refine ⟨hChecks.2.1.1.1, ?_⟩
       exact production_comment_source_binding_check_v7_sound
-        request .compared request.compared hChecks.2.1.2
+        request .compared request.compared hChecks.2.1.1.2
 
 theorem production_comment_admission_checks_v7_at
     (request : RunRequestCoreRequestV7)
     (side : Tier2.CommentReferenceIntegrity.VerifierSide)
+    (hEvidence : ProductionCommentEvidenceOf
+      (request.packageRecord (noteSideOfCommentSide side)))
     (hChecks : productionCommentOutcomeChecksV7 request = true) :
     productionTypedCommentAdmissionCheckAtV7 request side
       (request.packageRecord (noteSideOfCommentSide side)) = true := by
+  rcases hEvidence.2.2.2.2 with
+    ⟨retained, hRetained, hRetainedInvocation, hInput, hOutput,
+      hCrossing, hIntegrity, hInventory, hComplete, hLimit, hIssues⟩
   unfold productionCommentOutcomeChecksV7 at hChecks
-  simp only [Bool.and_eq_true] at hChecks
   cases side with
-  | original => exact hChecks.1.1.2
-  | revised => exact hChecks.1.2.2
-  | compared => exact hChecks.2.2
+  | original =>
+      simp only [noteSideOfCommentSide,
+        RunRequestCoreRequest.packageRecord] at hIssues ⊢
+      simp only [hIssues, List.isEmpty, ↓reduceIte,
+        Bool.and_eq_true] at hChecks
+      exact hChecks.1.1.1.2
+  | revised =>
+      simp only [noteSideOfCommentSide,
+        RunRequestCoreRequest.packageRecord] at hIssues ⊢
+      simp only [hIssues, List.isEmpty, ↓reduceIte,
+        Bool.and_eq_true] at hChecks
+      exact hChecks.1.2.1.2
+  | compared =>
+      simp only [noteSideOfCommentSide,
+        RunRequestCoreRequest.packageRecord] at hIssues ⊢
+      simp only [hIssues, List.isEmpty, ↓reduceIte,
+        Bool.and_eq_true] at hChecks
+      exact hChecks.2.1.2
+
+theorem production_typed_prior_source_admission_checks_v7_at
+    (request : RunRequestCoreRequestV7)
+    (side : Tier2.CommentReferenceIntegrity.VerifierSide)
+    (hEvidence : ProductionCommentEvidenceOf
+      (request.packageRecord (noteSideOfCommentSide side)))
+    (hChecks : productionCommentOutcomeChecksV7 request = true) :
+    productionTypedPriorSourceAdmissionCheckV7 request
+      (request.packageRecord (noteSideOfCommentSide side)) = true := by
+  rcases hEvidence.2.2.2.2 with
+    ⟨retained, hRetained, hRetainedInvocation, hInput, hOutput,
+      hCrossing, hIntegrity, hInventory, hComplete, hLimit, hIssues⟩
+  unfold productionCommentOutcomeChecksV7 at hChecks
+  cases side with
+  | original =>
+      simp only [noteSideOfCommentSide,
+        RunRequestCoreRequest.packageRecord] at hIssues ⊢
+      simp only [hIssues, List.isEmpty, ↓reduceIte,
+        Bool.and_eq_true] at hChecks
+      exact hChecks.1.1.2
+  | revised =>
+      simp only [noteSideOfCommentSide,
+        RunRequestCoreRequest.packageRecord] at hIssues ⊢
+      simp only [hIssues, List.isEmpty, ↓reduceIte,
+        Bool.and_eq_true] at hChecks
+      exact hChecks.1.2.2
+  | compared =>
+      simp only [noteSideOfCommentSide,
+        RunRequestCoreRequest.packageRecord] at hIssues ⊢
+      simp only [hIssues, List.isEmpty, ↓reduceIte,
+        Bool.and_eq_true] at hChecks
+      exact hChecks.2.2
+
+theorem production_typed_prior_source_admitted_v7
+    (request : VerifierRequestV7)
+    (typedRequest : TypedRequestV7)
+    (side : Tier2.CommentReferenceIntegrity.VerifierSide)
+    (hTyped : typedRequestOfProductionV7 request = some typedRequest)
+    (hCheck : productionTypedPriorSourceAdmissionCheckV7 request.core
+      (request.core.packageRecord
+        (noteSideOfCommentSide side)) = true) :
+    typedPriorSourceAdmittedV7
+      (typedPackageAt typedRequest
+        (typedSideOfVerifierSide side)).priorSourceAdmission = true := by
+  unfold typedRequestOfProductionV7 at hTyped
+  simp only [Option.some.injEq] at hTyped
+  subst typedRequest
+  unfold productionTypedPriorSourceAdmissionCheckV7 at hCheck
+  simp only [Bool.and_eq_true, Bool.not_eq_true] at hCheck
+  rcases hCheck with
+    ⟨⟨⟨⟨hSelection, hRetained⟩, hLimit⟩, hComplete⟩,
+      _hMarkerCompatible⟩
+  have hRetainedNe :
+      (request.core.packageRecord
+        (noteSideOfCommentSide side)).noteEvidence.retainedScan ≠ none :=
+    Option.isSome_iff_ne_none.mp hRetained
+  have hLimitFalse :
+      (request.core.packageRecord
+        (noteSideOfCommentSide side)).noteEvidence.semanticLimitCrossed =
+          false := by
+    cases hValue :
+        (request.core.packageRecord
+          (noteSideOfCommentSide side)).noteEvidence.semanticLimitCrossed
+    · rfl
+    · simp [hValue] at hLimit
+  have hAdmission :
+      Tier2.NoteReferenceIntegrity.typedPriorSourceAdmissionOfProduction
+        request.core
+        (request.core.packageRecord
+          (noteSideOfCommentSide side)).noteEvidence =
+        .admitted := by
+    unfold Tier2.NoteReferenceIntegrity.typedPriorSourceAdmissionOfProduction
+    simp [hSelection, hRetainedNe, hLimitFalse, hComplete]
+  cases side <;>
+    simp only [typedPackageAt, typedSideOfVerifierSide,
+      noteSideOfCommentSide, RunRequestCoreRequest.packageRecord,
+      Tier2.NoteReferenceIntegrity.typedPackageViewOfRecord]
+      at hAdmission ⊢ <;>
+    rw [hAdmission] <;> rfl
+
+theorem typed_package_at_of_production_v7
+    (request : VerifierRequestV7)
+    (typedRequest : TypedRequestV7)
+    (side : Tier2.CommentReferenceIntegrity.VerifierSide)
+    (hTyped : typedRequestOfProductionV7 request = some typedRequest) :
+    typedPackageAt typedRequest (typedSideOfVerifierSide side) =
+      Tier2.NoteReferenceIntegrity.typedPackageViewOfRecord
+        (typedSideOfVerifierSide side) request.core
+        (request.core.packageRecord (noteSideOfCommentSide side)) := by
+  unfold typedRequestOfProductionV7 at hTyped
+  simp only [Option.some.injEq] at hTyped
+  subst typedRequest
+  cases side <;> rfl
 
 def productionTypedMarkerSlotIdentityV7 (slot : TypedSourceSlot) :
     TypedPhysicalStoryIdentity := {
@@ -12220,7 +12386,7 @@ theorem story_slot_lists_match_self_v7
           beq_self_eq_true, Bool.true_and]
         cases story <;> rfl, ih⟩
 
-theorem production_canonical_typed_topology_v7
+theorem production_canonical_typed_marker_scan_v7
     (request : VerifierRequestV7)
     (typedRequest : TypedRequestV7)
     (side : Tier2.CommentReferenceIntegrity.VerifierSide)
@@ -12228,12 +12394,18 @@ theorem production_canonical_typed_topology_v7
     (hComment : ProductionCommentEvidenceOf
       (request.core.packageRecord (noteSideOfCommentSide side)))
     (hChecks : productionCommentOutcomeChecksV7 request.core = true) :
-    checkTypedPackageCommentRangeIntegrity
-      (typedDefinitionsV7 typedRequest (typedSideOfVerifierSide side))
-      (retainedOrIndependentTypedMarkerScanV7
-        typedRequest (typedSideOfVerifierSide side)) = true := by
+    ∃ marker,
+      (request.core.packageRecord
+        (noteSideOfCommentSide side)).commentEvidence.markerScan =
+          some marker ∧
+      typedMarkerEvidenceOfProduction
+          (canonicalTypedCommentSourcesV7 typedRequest
+            (typedSideOfVerifierSide side)) marker =
+        retainedOrIndependentTypedMarkerScanV7
+          typedRequest (typedSideOfVerifierSide side) := by
   have hAt :=
-    production_comment_outcome_checks_v7_at request.core side hChecks
+    production_comment_outcome_checks_v7_at
+      request.core side hComment hChecks
   rcases hAt with
     ⟨hOutcome, hDomain, run, hRunStored, hExact⟩
   rcases hComment with
@@ -12247,8 +12419,69 @@ theorem production_canonical_typed_topology_v7
   have hRunEq : run = markerRun := by
     exact Option.some.inj (hRunStored.symm.trans hMarkerRun)
   subst run
+  have hProductionPassed :=
+    production_comment_outcome_check_v7_passed_of_no_issues
+      _ hOutcome hComplete hIssues
+  rcases production_comment_outcome_check_v7_complete_topology
+      _ hOutcome hComplete hProductionPassed with
+    ⟨topologyRetained, topologyMarker, hTopologyRetained,
+      hTopologyMarker, hConcurrent, hTopology⟩
+  have hTopologyMarkerEq : topologyMarker = markerEvidence := by
+    exact Option.some.inj (hTopologyMarker.symm.trans hMarkerStored)
+  subst topologyMarker
+  have hSet :
+      Tier2.CommentReferenceIntegrity.storySlotListsMatch
+        markerRun.set.sources
+        (markerRun.scans.realizations.map (·.slot)) = true := by
+    rw [markerRun.setExact]
+    exact story_slot_lists_match_self_v7 _
+  have hMarkerRunExact :=
+    retained_comment_marker_scan_run_exact
+      (request.core.packageRecord
+        (noteSideOfCommentSide side)).commentEvidence.identity.isSome
+      (request.core.packageRecord
+        (noteSideOfCommentSide side)).commentEvidence.side
+      markerRun markerEvidence hMarkerResult
+  have hMarker :=
+    production_typed_marker_evidence_independent_for_relationship_v7
+      request side typedRequest
+      (request.core.packageRecord
+        (noteSideOfCommentSide side)).commentEvidence.identity.isSome
+      markerRun.set markerRun.scans markerEvidence hTyped hDomain hExact
+      hSet hMarkerRunExact hMarkerNoCross hConcurrent
+  exact ⟨markerEvidence, hMarkerStored, hMarker⟩
+
+theorem production_canonical_typed_topology_v7
+    (request : VerifierRequestV7)
+    (typedRequest : TypedRequestV7)
+    (side : Tier2.CommentReferenceIntegrity.VerifierSide)
+    (hTyped : typedRequestOfProductionV7 request = some typedRequest)
+    (hComment : ProductionCommentEvidenceOf
+      (request.core.packageRecord (noteSideOfCommentSide side)))
+    (hChecks : productionCommentOutcomeChecksV7 request.core = true) :
+    checkTypedPackageCommentRangeIntegrity
+      (typedDefinitionsV7 typedRequest (typedSideOfVerifierSide side))
+      (retainedOrIndependentTypedMarkerScanV7
+        typedRequest (typedSideOfVerifierSide side)) = true := by
+  have hAt :=
+    production_comment_outcome_checks_v7_at
+      request.core side hComment hChecks
   have hAdmission :=
-    production_comment_admission_checks_v7_at request.core side hChecks
+    production_comment_admission_checks_v7_at
+      request.core side hComment hChecks
+  rcases hAt with
+    ⟨hOutcome, hDomain, run, hRunStored, hExact⟩
+  rcases hComment with
+    ⟨hSources, hIdentities, hSelection,
+      ⟨markerRun, markerEvidence, hMarkerRun, hMarkerResult,
+        hMarkerExact, hMarkerNoCross, hMarkerInvocation,
+        hMarkerStored⟩,
+      ⟨retained, hRetained, hRetainedInvocation, hInput,
+        hOutput, hDefinitionCrossing, hIntegrity, hInventory,
+        hComplete, hLimit, hIssues⟩⟩
+  have hRunEq : run = markerRun := by
+    exact Option.some.inj (hRunStored.symm.trans hMarkerRun)
+  subst run
   rcases production_typed_definitions_retained_v7
       request typedRequest side hTyped
       ⟨hSources, hIdentities, hSelection,
@@ -12263,8 +12496,11 @@ theorem production_canonical_typed_topology_v7
   have hRetainedEq : definitionRetained = retained := by
     exact Option.some.inj (hDefinitionRetained.symm.trans hRetained)
   subst definitionRetained
+  have hProductionPassed :=
+    production_comment_outcome_check_v7_passed_of_no_issues
+      _ hOutcome hComplete hIssues
   rcases production_comment_outcome_check_v7_complete_topology
-      _ hOutcome hComplete with
+      _ hOutcome hComplete hProductionPassed with
     ⟨topologyRetained, topologyMarker, hTopologyRetained,
       hTopologyMarker, hConcurrent, hTopology⟩
   have hTopologyRetainedEq : topologyRetained = retained := by
@@ -12297,10 +12533,250 @@ theorem production_canonical_typed_topology_v7
     typedRequest (typedSideOfVerifierSide side) retained markerEvidence
       hDefinitions hMarker hConcurrent hTopology
 
+theorem production_typed_selection_and_realization_resolved_v7
+    (request : VerifierRequestV7)
+    (typedRequest : TypedRequestV7)
+    (side : Tier2.CommentReferenceIntegrity.VerifierSide)
+    (hTyped : typedRequestOfProductionV7 request = some typedRequest)
+    (hComment : ProductionCommentEvidenceOf
+      (request.core.packageRecord (noteSideOfCommentSide side)))
+    (hChecks : productionCommentOutcomeChecksV7 request.core = true) :
+    typedSelectionResolvedV7
+        (selectTypedCommentV7
+          (typedPackageAt typedRequest
+            (typedSideOfVerifierSide side))) = true ∧
+      typedRealizationResolvedV7
+        (realizeTypedCommentV7 typedRequest
+          (typedSideOfVerifierSide side)) = true := by
+  let record :=
+    request.core.packageRecord (noteSideOfCommentSide side)
+  have hPackage :=
+    typed_package_at_of_production_v7 request typedRequest side hTyped
+  have hSelection := hComment.2.2.1
+  cases hSelected :
+      selectConventionalMainCommentRecords record.relationships with
+  | error failure =>
+      simp only [record, hSelected] at hSelection
+  | ok selected? =>
+      cases selected? with
+      | none =>
+          have hTypedSelection :
+              selectTypedCommentV7
+                  (typedPackageAt typedRequest
+                    (typedSideOfVerifierSide side)) =
+                .ok none := by
+            rw [hPackage]
+            unfold selectTypedCommentV7
+            exact Tier2.NoteReferenceIntegrity.typed_selector_none_of_production
+              record.relationships hSelected
+          have hTypedRealization :=
+            typed_realization_none_of_production_v7
+              request typedRequest side hTyped hSelected
+          simp [hTypedSelection, hTypedRealization,
+            typedSelectionResolvedV7, typedRealizationResolvedV7]
+      | some selected =>
+          have hAdmission :=
+            production_comment_admission_checks_v7_at
+              request.core side hComment hChecks
+          rcases production_typed_comment_admission_check_at_v7_sound
+              request.core side record selected hSelected hAdmission with
+            ⟨part, hPart, hIdentity, hFailure, hAdmitted⟩
+          have hTypedSelection :
+              selectTypedCommentV7
+                  (typedPackageAt typedRequest
+                    (typedSideOfVerifierSide side)) =
+                .ok (some
+                  (Tier2.NoteReferenceIntegrity.typedSelectedCommentOfProduction
+                    selected)) := by
+            rw [hPackage]
+            unfold selectTypedCommentV7
+            exact
+              Tier2.NoteReferenceIntegrity.typed_selector_success_of_production
+                record.relationships selected hSelected
+          have hTypedRealization :=
+            typed_realization_success_of_production_v7
+              request typedRequest side selected part hTyped hSelected hPart
+                hIdentity hFailure hAdmitted
+          simp [hTypedSelection, hTypedRealization,
+            typedSelectionResolvedV7, typedRealizationResolvedV7]
+
+theorem production_typed_marker_prerequisites_v7
+    (request : VerifierRequestV7)
+    (typedRequest : TypedRequestV7)
+    (side : Tier2.CommentReferenceIntegrity.VerifierSide)
+    (hTyped : typedRequestOfProductionV7 request = some typedRequest)
+    (hComment : ProductionCommentEvidenceOf
+      (request.core.packageRecord (noteSideOfCommentSide side)))
+    (hChecks : productionCommentOutcomeChecksV7 request.core = true) :
+    let typedSide := typedSideOfVerifierSide side
+    let selection :=
+      selectTypedCommentV7 (typedPackageAt typedRequest typedSide)
+    let markerScan :=
+      retainedOrIndependentTypedMarkerScanV7 typedRequest typedSide
+    (match selection with
+      | .ok none => markerScan.occurrences.isEmpty
+      | .ok (some _) => true
+      | .error _ => false) = true ∧
+    markerScan.crossing.isNone = true ∧
+    (canonicalTypedCommentSourcesV7 typedRequest typedSide).length ≤ 387 := by
+  dsimp only
+  let record :=
+    request.core.packageRecord (noteSideOfCommentSide side)
+  have hAt :=
+    production_comment_outcome_checks_v7_at
+      request.core side hComment hChecks
+  have hDomain := hAt.2.1
+  have hSourceLength :
+      (canonicalTypedCommentSourcesV7 typedRequest
+        (typedSideOfVerifierSide side)).length ≤ 387 := by
+    have hSources :=
+      typed_request_canonical_sources_of_production_v7
+        request side typedRequest hTyped hDomain
+    unfold ProductionCommentSourceDomainMetadataV7Of at hDomain
+    have hExpectedLength := hDomain.2.1
+    rw [← hDomain.1] at hExpectedLength
+    unfold retainedCommentSourceIdentities at hExpectedLength
+    rw [hSources]
+    simpa only [List.length_map] using hExpectedLength
+  rcases hComment.2.2.2.1 with
+    ⟨markerRun, markerEvidence, hMarkerRun, hMarkerResult,
+      hMarkerExact, hMarkerNoCross, hMarkerInvocation,
+      hMarkerStored⟩
+  rcases production_canonical_typed_marker_scan_v7
+      request typedRequest side hTyped hComment hChecks with
+    ⟨canonicalMarker, hCanonicalStored, hCanonicalMarker⟩
+  have hCanonicalEq : canonicalMarker = markerEvidence := by
+    exact Option.some.inj (hCanonicalStored.symm.trans hMarkerStored)
+  subst canonicalMarker
+  have hTypedNoCross :
+      (retainedOrIndependentTypedMarkerScanV7 typedRequest
+        (typedSideOfVerifierSide side)).crossing.isNone = true := by
+    rw [← hCanonicalMarker]
+    unfold typedMarkerEvidenceOfProduction
+      retainedTypedMarkerEvidenceOfProduction
+    simp [hMarkerNoCross]
+  have hFlag :=
+    production_typed_prior_source_admission_checks_v7_at
+      request.core side hComment hChecks
+  unfold productionTypedPriorSourceAdmissionCheckV7 at hFlag
+  simp only [Bool.and_eq_true] at hFlag
+  have hMarkerCompatible := hFlag.2
+  have hPackage :=
+    typed_package_at_of_production_v7 request typedRequest side hTyped
+  have hSelection := hComment.2.2.1
+  cases hSelected :
+      selectConventionalMainCommentRecords record.relationships with
+  | error failure =>
+      simp only [record, hSelected] at hSelection
+  | ok selected? =>
+      cases selected? with
+      | none =>
+          simp only [record, hSelected] at hSelection
+          have hTypedSelection :
+              selectTypedCommentV7
+                  (typedPackageAt typedRequest
+                    (typedSideOfVerifierSide side)) =
+                .ok none := by
+            rw [hPackage]
+            unfold selectTypedCommentV7
+            exact Tier2.NoteReferenceIntegrity.typed_selector_none_of_production
+              record.relationships hSelected
+          have hOccurrences : markerEvidence.occurrences.isEmpty = true := by
+            simpa [record, hSelection.1, hMarkerStored] using hMarkerCompatible
+          have hTypedOccurrences :
+              (retainedOrIndependentTypedMarkerScanV7 typedRequest
+                (typedSideOfVerifierSide side)).occurrences.isEmpty = true := by
+            rw [← hCanonicalMarker]
+            unfold typedMarkerEvidenceOfProduction
+              retainedTypedMarkerEvidenceOfProduction
+            simp [hMarkerNoCross, hOccurrences]
+          exact ⟨by simpa [hTypedSelection] using hTypedOccurrences,
+            hTypedNoCross, hSourceLength⟩
+      | some selected =>
+          have hTypedSelection :
+              selectTypedCommentV7
+                  (typedPackageAt typedRequest
+                    (typedSideOfVerifierSide side)) =
+                .ok (some
+                  (Tier2.NoteReferenceIntegrity.typedSelectedCommentOfProduction
+                    selected)) := by
+            rw [hPackage]
+            unfold selectTypedCommentV7
+            exact
+              Tier2.NoteReferenceIntegrity.typed_selector_success_of_production
+                record.relationships selected hSelected
+          exact ⟨by simp [hTypedSelection], hTypedNoCross, hSourceLength⟩
+
+theorem production_typed_comment_prerequisites_v7
+    (request : VerifierRequestV7)
+    (typedRequest : TypedRequestV7)
+    (side : Tier2.CommentReferenceIntegrity.VerifierSide)
+    (hTyped : typedRequestOfProductionV7 request = some typedRequest)
+    (hComment : ProductionCommentEvidenceOf
+      (request.core.packageRecord (noteSideOfCommentSide side)))
+    (hChecks : productionCommentOutcomeChecksV7 request.core = true) :
+    typedCommentPrerequisitesV7 typedRequest
+      (typedSideOfVerifierSide side) = true := by
+  have hPrior :=
+    production_typed_prior_source_admitted_v7
+      request typedRequest side hTyped
+        (production_typed_prior_source_admission_checks_v7_at
+          request.core side hComment hChecks)
+  have hResolved :=
+    production_typed_selection_and_realization_resolved_v7
+      request typedRequest side hTyped hComment hChecks
+  have hMarker :=
+    production_typed_marker_prerequisites_v7
+      request typedRequest side hTyped hComment hChecks
+  dsimp only at hMarker
+  unfold typedCommentPrerequisitesV7
+  dsimp only
+  simp only [Bool.and_eq_true]
+  exact ⟨⟨⟨⟨⟨hPrior, hResolved.1⟩, hResolved.2⟩, hMarker.1⟩,
+    hMarker.2.1⟩,
+    typed_nat_le_check_true_of_le _ _ hMarker.2.2⟩
+
+theorem production_typed_all_comment_range_sides_pass_v7
+    (request : VerifierRequestV7)
+    (typedRequest : TypedRequestV7)
+    (hTyped : typedRequestOfProductionV7 request = some typedRequest)
+    (commentEvidence :
+      ProductionCommentEvidenceOf request.core.original ∧
+      ProductionCommentEvidenceOf request.core.revised ∧
+      ProductionCommentEvidenceOf request.core.compared)
+    (hChecks : productionCommentOutcomeChecksV7 request.core = true) :
+    typedAllCommentRangeSidesPassV7 typedRequest = true := by
+  apply typed_all_comment_range_sides_pass_v7_of_checks
+  · intro side
+    cases side with
+    | original =>
+        exact production_typed_comment_prerequisites_v7
+          request typedRequest .original hTyped commentEvidence.1 hChecks
+    | revised =>
+        exact production_typed_comment_prerequisites_v7
+          request typedRequest .revised hTyped commentEvidence.2.1 hChecks
+    | compared =>
+        exact production_typed_comment_prerequisites_v7
+          request typedRequest .compared hTyped commentEvidence.2.2 hChecks
+  · intro side
+    cases side with
+    | original =>
+        exact production_canonical_typed_topology_v7
+          request typedRequest .original hTyped commentEvidence.1 hChecks
+    | revised =>
+        exact production_canonical_typed_topology_v7
+          request typedRequest .revised hTyped commentEvidence.2.1 hChecks
+    | compared =>
+        exact production_canonical_typed_topology_v7
+          request typedRequest .compared hTyped commentEvidence.2.2 hChecks
+
 def productionTypedCommentChecksV7
     (request : RunRequestCoreRequestV7)
     (result : RunRequestCoreResultV7) : Bool :=
-  productionCommentOutcomeChecksV7 request &&
+  (if result.responsePassed then
+    productionCommentOutcomeChecksV7 request
+  else
+    productionFailedCommentOutcomeChecksV7 request) &&
   result.typedProjectionCheck &&
   protocolV6JsonProjectionCheck result.response result.responsePassed &&
   decide (result.stdout.data.toList =
@@ -12349,17 +12825,22 @@ theorem production_run_request_core_v7_refinement_sound
       · rename_i hChecks
         cases hRun
         unfold productionTypedCommentChecksV7 at hChecks
-        simp only [Bool.and_eq_true, decide_eq_true_eq] at hChecks
+        simp only [hPass, ↓reduceIte, Bool.and_eq_true,
+          decide_eq_true_eq] at hChecks
         have hBase :=
           Tier2.NoteReferenceIntegrity.production_run_request_core_refinement_sound
             request result hCore hPass
         obtain ⟨typedResponse, hProjection⟩ :=
           executable_protocol_utf8_json_refines_typed
-            result.response result.responsePassed hChecks.1.2
+            result.response true hChecks.1.2
         have hResponseBytes :=
           hProjection.choose_spec.2.2
         have hProjectionTrue :
             ProtocolV6JsonProjectionOf result.response true typedResponse := by
+          simpa only [hPass] using hProjection
+        have hProjectionResult :
+            ProtocolV6JsonProjectionOf
+              result.response result.responsePassed typedResponse := by
           simpa only [hPass] using hProjection
         have hResponseBytesV7 :
             result.response.compress.toUTF8.data.toList =
@@ -12372,7 +12853,7 @@ theorem production_run_request_core_v7_refinement_sound
           exact hChecks.2
         refine ⟨typedResponse, ?_, hProjectionTrue,
           hResponseBytesV7, hStdoutV7⟩
-        exact ⟨hBase, hChecks.1.1.1, hProjection, rfl,
+        exact ⟨hBase, hChecks.1.1.1, hProjectionResult, rfl,
           hResponseBytesV7, hStdoutV7⟩
       · contradiction
 

--- a/verification/lean/ProtocolV7ProjectionDriftWitnesses.lean
+++ b/verification/lean/ProtocolV7ProjectionDriftWitnesses.lean
@@ -312,6 +312,64 @@ def terminalShapeMutation (_request : RunRequestCoreRequest)
     (result : RunRequestCoreResult) : Json :=
   replaceField result.response "selectionIssues" (.arr #[selectionIssueJson (issue 0)])
 
+def outcomeShapeWitnesses
+    (requestResult : Except String RunRequestCoreRequest) : List (String × Bool) :=
+  match requestResult with
+  | .error _ => [("outcome-fixture", false)]
+  | .ok request =>
+    let passed := request.original.commentEvidence
+    let evaluatedFailed := {
+      passed with
+      productionIntegrityPassed := false
+      issues := [commentIssueJson "COMMENT_DEFINITION_MISSING"
+        "outcome witness" .original "reference" 0 "main" 0]
+      inventory := { passed.inventory with status := "failed" }
+    }
+    let incompleteBefore := {
+      passed with
+      markerScanRun := none
+      markerScanInvocationCount := 0
+      complete := false
+      productionIntegrityPassed := false
+      issues := [commentIssueJson "COMMENT_PART_MISSING"
+        "outcome witness" .original "relationship" 0 "comments" 0]
+      inventory := zeroCommentInventory passed.side passed.identity
+    }
+    let incompleteAfter := {
+      passed with
+      complete := false
+      semanticLimitCrossed := true
+      productionIntegrityPassed := false
+      issues := [commentIssueJson "COMMENT_RANGE_START_OCCURRENCE_LIMIT_EXCEEDED"
+        "outcome witness" .original "rangeStart" 4096 "main" 0]
+      inventory := zeroCommentInventory passed.side passed.identity
+    }
+    let forgedPass := { passed with markerScanInvocationCount := 0 }
+    let forgedFailed := {
+      evaluatedFailed with
+      inventory := { evaluatedFailed.inventory with status := "not_evaluated" }
+    }
+    let forgedIncomplete := {
+      incompleteAfter with
+      inventory := {
+        incompleteAfter.inventory with referenceOccurrences := 1
+      }
+    }
+    [ ("outcome-pass", productionCommentOutcomeCheckAtV7 passed)
+    , ("outcome-evaluated-fail",
+        productionCommentOutcomeCheckAtV7 evaluatedFailed)
+    , ("outcome-incomplete-before-scan",
+        productionCommentOutcomeCheckAtV7 incompleteBefore)
+    , ("outcome-incomplete-after-scan",
+        productionCommentOutcomeCheckAtV7 incompleteAfter)
+    , ("outcome-forged-pass",
+        !productionCommentOutcomeCheckAtV7 forgedPass)
+    , ("outcome-forged-fail",
+        !productionCommentOutcomeCheckAtV7 forgedFailed)
+    , ("outcome-forged-incomplete",
+        !productionCommentOutcomeCheckAtV7 forgedIncomplete)
+    ]
+
 def witnessResults : List (String × Bool) :=
   [ ("baseline", baselineAgrees ordinaryRequest)
   , ("field-name", mutationDisagrees ordinaryRequest fun _ result =>
@@ -337,7 +395,7 @@ def witnessResults : List (String × Bool) :=
   , ("issue-coalescing", mutationDisagrees ordinaryRequest coalescingMutation)
   , ("issue-budget", mutationDisagrees budgetRequest budgetMutation)
   , ("terminal-shape", mutationDisagrees budgetRequest terminalShapeMutation)
-  ]
+  ] ++ outcomeShapeWitnesses ordinaryRequest
 
 def run : IO Unit := do
   for (name, passed) in witnessResults do

--- a/verification/lean/Tier2/CommentReferenceIntegrity/TypedSemantics.lean
+++ b/verification/lean/Tier2/CommentReferenceIntegrity/TypedSemantics.lean
@@ -5757,6 +5757,62 @@ theorem typed_comment_side_pass_integrity_v7
           exact False.elim (hStatus hImpossible)
       | true => rfl
 
+set_option backward.match.sparseCases false in
+theorem typed_comment_side_pass_v7_of_checks
+    (request : TypedRequestV7) (side : Side)
+    (hPrerequisites : typedCommentPrerequisitesV7 request side = true)
+    (hInherited :
+      (evaluateTypedCommentSide side
+        (typedPackageAt request side)).status ≠ .failed)
+    (hIntegrity :
+      checkTypedPackageCommentRangeIntegrity
+        (typedDefinitionsV7 request side)
+        (retainedOrIndependentTypedMarkerScanV7 request side) = true) :
+    (evaluateTypedCommentSideV7 request side).status = .passed := by
+  unfold evaluateTypedCommentSideV7
+  dsimp only
+  split
+  · rename_i hIncomplete
+    rw [hPrerequisites] at hIncomplete
+    contradiction
+  · split
+    · rename_i hFailed
+      have hInheritedCheck :
+          ((evaluateTypedCommentSide side
+            (typedPackageAt request side)).status == .failed) = false := by
+        cases hStatus :
+            (evaluateTypedCommentSide side
+              (typedPackageAt request side)).status with
+        | passed => rfl
+        | failed => exact False.elim (hInherited hStatus)
+        | notEvaluated => rfl
+      rw [hInheritedCheck, hIntegrity] at hFailed
+      contradiction
+    · rfl
+
+theorem typed_all_comment_range_sides_pass_v7_of_checks
+    (request : TypedRequestV7)
+    (hPrerequisites :
+      ∀ side, typedCommentPrerequisitesV7 request side = true)
+    (hInherited :
+      ∀ side,
+        (evaluateTypedCommentSide side
+          (typedPackageAt request side)).status ≠ .failed)
+    (hIntegrity :
+      ∀ side,
+        checkTypedPackageCommentRangeIntegrity
+          (typedDefinitionsV7 request side)
+          (retainedOrIndependentTypedMarkerScanV7 request side) = true) :
+    typedAllCommentRangeSidesPassV7 request = true := by
+  have hSide : ∀ side,
+      (evaluateTypedCommentSideV7 request side).status = .passed := by
+    intro side
+    exact typed_comment_side_pass_v7_of_checks request side
+      (hPrerequisites side) (hInherited side) (hIntegrity side)
+  unfold typedAllCommentRangeSidesPassV7
+  rw [hSide .original, hSide .revised, hSide .compared]
+  rfl
+
 theorem typed_side_comment_passed_v7_eq_true
     (status : TypedSideCommentStatusV7)
     (hPass : typedSideCommentPassedV7 status = true) :

--- a/verification/lean/Tier2/CommentReferenceIntegrity/TypedSemantics.lean
+++ b/verification/lean/Tier2/CommentReferenceIntegrity/TypedSemantics.lean
@@ -1478,6 +1478,14 @@ def typedNatLeCheck : Nat → Nat → Bool
   | _ + 1, 0 => false
   | left + 1, right + 1 => typedNatLeCheck left right
 
+theorem typed_nat_le_check_true_of_le :
+    ∀ left right, left ≤ right → typedNatLeCheck left right = true
+  | 0, _, _ => rfl
+  | _ + 1, 0, h => nomatch h
+  | left + 1, right + 1, h =>
+      typed_nat_le_check_true_of_le left right
+        (Nat.le_of_succ_le_succ h)
+
 def typedNatLtCheck (left right : Nat) : Bool :=
   typedNatLeCheck (left + 1) right
 
@@ -4945,8 +4953,7 @@ def evaluateTypedCommentSideV7
   let definitions := typedDefinitionsV7 request side
   let incomplete := !typedCommentPrerequisitesV7 request side
   let status := if incomplete then .notEvaluated
-    else if inheritedEvaluation.status == .failed ||
-        !checkTypedPackageCommentRangeIntegrity definitions markerScan then
+    else if !checkTypedPackageCommentRangeIntegrity definitions markerScan then
       .failed
     else .passed
   { side, status, partPresent := inheritedEvaluation.partPresent
@@ -5745,15 +5752,11 @@ theorem typed_comment_side_pass_integrity_v7
             (retainedOrIndependentTypedMarkerScanV7 request side) with
       | false =>
           have hImpossible :
-              ((evaluateTypedCommentSide side
-                  (typedPackageAt request side)).status == .failed ||
-                !checkTypedPackageCommentRangeIntegrity
-                  (typedDefinitionsV7 request side)
-                  (retainedOrIndependentTypedMarkerScanV7 request side)) = true := by
+              (!checkTypedPackageCommentRangeIntegrity
+                (typedDefinitionsV7 request side)
+                (retainedOrIndependentTypedMarkerScanV7 request side)) = true := by
             rw [hCheck]
-            cases hInherited :
-                ((evaluateTypedCommentSide side
-                  (typedPackageAt request side)).status == .failed) <;> rfl
+            rfl
           exact False.elim (hStatus hImpossible)
       | true => rfl
 
@@ -5761,9 +5764,6 @@ set_option backward.match.sparseCases false in
 theorem typed_comment_side_pass_v7_of_checks
     (request : TypedRequestV7) (side : Side)
     (hPrerequisites : typedCommentPrerequisitesV7 request side = true)
-    (hInherited :
-      (evaluateTypedCommentSide side
-        (typedPackageAt request side)).status ≠ .failed)
     (hIntegrity :
       checkTypedPackageCommentRangeIntegrity
         (typedDefinitionsV7 request side)
@@ -5777,16 +5777,7 @@ theorem typed_comment_side_pass_v7_of_checks
     contradiction
   · split
     · rename_i hFailed
-      have hInheritedCheck :
-          ((evaluateTypedCommentSide side
-            (typedPackageAt request side)).status == .failed) = false := by
-        cases hStatus :
-            (evaluateTypedCommentSide side
-              (typedPackageAt request side)).status with
-        | passed => rfl
-        | failed => exact False.elim (hInherited hStatus)
-        | notEvaluated => rfl
-      rw [hInheritedCheck, hIntegrity] at hFailed
+      rw [hIntegrity] at hFailed
       contradiction
     · rfl
 
@@ -5794,10 +5785,6 @@ theorem typed_all_comment_range_sides_pass_v7_of_checks
     (request : TypedRequestV7)
     (hPrerequisites :
       ∀ side, typedCommentPrerequisitesV7 request side = true)
-    (hInherited :
-      ∀ side,
-        (evaluateTypedCommentSide side
-          (typedPackageAt request side)).status ≠ .failed)
     (hIntegrity :
       ∀ side,
         checkTypedPackageCommentRangeIntegrity
@@ -5808,7 +5795,7 @@ theorem typed_all_comment_range_sides_pass_v7_of_checks
       (evaluateTypedCommentSideV7 request side).status = .passed := by
     intro side
     exact typed_comment_side_pass_v7_of_checks request side
-      (hPrerequisites side) (hInherited side) (hIntegrity side)
+      (hPrerequisites side) (hIntegrity side)
   unfold typedAllCommentRangeSidesPassV7
   rw [hSide .original, hSide .revised, hSide .compared]
   rfl

--- a/verification/lean/Tier2/CommentReferenceIntegrity/TypedSemantics.lean
+++ b/verification/lean/Tier2/CommentReferenceIntegrity/TypedSemantics.lean
@@ -4218,6 +4218,24 @@ structure TypedMarkerScanInput where
   rangeEndLocalName : BoundedBytes
   referenceLocalName : BoundedBytes
 
+structure TypedMarkerAssociationV7 where
+  referenceCount : Nat := 0
+  rangeStartCount : Nat := 0
+  rangeEndCount : Nat := 0
+  firstReference : Option TypedMarkerOccurrence := none
+  firstRangeStart : Option TypedMarkerOccurrence := none
+  firstRangeEnd : Option TypedMarkerOccurrence := none
+  firstDuplicateReference : Option TypedMarkerOccurrence := none
+  firstDuplicateRangeStart : Option TypedMarkerOccurrence := none
+  firstDuplicateRangeEnd : Option TypedMarkerOccurrence := none
+  deriving DecidableEq
+
+inductive TypedCanonicalIdTrie where
+  | empty
+  | node (association : Option TypedMarkerAssociationV7)
+      (children : List (UInt8 × TypedCanonicalIdTrie))
+  deriving Inhabited
+
 structure TypedMarkerScanEvidence where
   inputStories : List TypedStorySource
   occurrences : List TypedMarkerOccurrence
@@ -4276,9 +4294,8 @@ def realizeTypedCommentV7 (request : TypedRequestV7) (side : Side) :
           else .error .extractionFailed
         | none => .error .partMissing
 
-def canonicalTypedCommentSourceSlotsV7
-    (request : TypedRequestV7) (side : Side) : List TypedSourceSlot :=
-  let pkg := typedPackageAt request side
+def canonicalTypedCommentSourceSlotsOfPackageV7
+    (pkg : TypedPackageView) : List TypedSourceSlot :=
   let main : TypedSourceSlot := {
     kind := .main, physicalStoryOrdinal := 0, source := pkg.mainSource }
   let physical := pkg.headerFooterStories.filterMap fun story =>
@@ -4291,25 +4308,25 @@ def canonicalTypedCommentSourceSlotsV7
       kind := selection.kind, physicalStoryOrdinal := 0, source }
   main :: physical ++ notes
 
+def canonicalTypedCommentSourceSlotsV7
+    (request : TypedRequestV7) (side : Side) : List TypedSourceSlot :=
+  canonicalTypedCommentSourceSlotsOfPackageV7 (typedPackageAt request side)
+
 def canonicalTypedCommentSourcesV7
     (request : TypedRequestV7) (side : Side) : List TypedStorySource :=
   (canonicalTypedCommentSourceSlotsV7 request side).map (·.source)
 
-inductive TypedCanonicalIdTrie where
-  | empty
-  | node (terminal : Bool) (children : List (UInt8 × TypedCanonicalIdTrie))
-
 def typedCanonicalIdTrieKey (id : CanonicalDecimalId) : List UInt8 :=
   (if id.negative then 1 else 0) :: id.digits
 
-def typedCanonicalIdTrieContains :
-    TypedCanonicalIdTrie → List UInt8 → Bool
-  | .empty, _ => false
-  | .node terminal _, [] => terminal
+def typedCanonicalIdTrieGet :
+    TypedCanonicalIdTrie → List UInt8 → Option TypedMarkerAssociationV7
+  | .empty, _ => none
+  | .node association _, [] => association
   | .node _ children, byte :: rest =>
       match children.find? (fun child => child.1 == byte) with
-      | none => false
-      | some child => typedCanonicalIdTrieContains child.2 rest
+      | none => none
+      | some child => typedCanonicalIdTrieGet child.2 rest
 
 def typedCanonicalIdTrieInsertChild (byte : UInt8)
     (value : TypedCanonicalIdTrie) :
@@ -4321,24 +4338,30 @@ def typedCanonicalIdTrieInsertChild (byte : UInt8)
       else child :: typedCanonicalIdTrieInsertChild byte value rest
 
 def typedCanonicalIdTrieInsert :
-    TypedCanonicalIdTrie → List UInt8 → TypedCanonicalIdTrie
-  | .empty, [] => .node true []
-  | .empty, byte :: rest =>
-      .node false [(byte, typedCanonicalIdTrieInsert .empty rest)]
-  | .node _ children, [] => .node true children
-  | .node terminal children, byte :: rest =>
+    TypedCanonicalIdTrie → List UInt8 → TypedMarkerAssociationV7 →
+      TypedCanonicalIdTrie
+  | .empty, [], association => .node (some association) []
+  | .empty, byte :: rest, association =>
+      .node none [(byte, typedCanonicalIdTrieInsert .empty rest association)]
+  | .node _ children, [], association => .node (some association) children
+  | .node terminal children, byte :: rest, association =>
       let child := (children.find? fun item => item.1 == byte).map (·.2)
         |>.getD .empty
       .node terminal (typedCanonicalIdTrieInsertChild byte
-        (typedCanonicalIdTrieInsert child rest) children)
+        (typedCanonicalIdTrieInsert child rest association) children)
 
 def typedCanonicalIdTrieHas (trie : TypedCanonicalIdTrie)
     (id : CanonicalDecimalId) : Bool :=
-  typedCanonicalIdTrieContains trie (typedCanonicalIdTrieKey id)
+  (typedCanonicalIdTrieGet trie (typedCanonicalIdTrieKey id)).isSome
 
-def typedCanonicalIdTrieAdd (trie : TypedCanonicalIdTrie)
-    (id : CanonicalDecimalId) : TypedCanonicalIdTrie :=
-  typedCanonicalIdTrieInsert trie (typedCanonicalIdTrieKey id)
+def typedCanonicalIdTrieAssociation? (trie : TypedCanonicalIdTrie)
+    (id : CanonicalDecimalId) : Option TypedMarkerAssociationV7 :=
+  typedCanonicalIdTrieGet trie (typedCanonicalIdTrieKey id)
+
+def typedCanonicalIdTrieSet (trie : TypedCanonicalIdTrie)
+    (id : CanonicalDecimalId) (association : TypedMarkerAssociationV7) :
+    TypedCanonicalIdTrie :=
+  typedCanonicalIdTrieInsert trie (typedCanonicalIdTrieKey id) association
 
 structure TypedMarkerScanState where
   occurrences : List TypedMarkerOccurrence := []
@@ -4351,6 +4374,7 @@ structure TypedMarkerScanState where
   processedEventCount : Nat := 0
   processedStoryCount : Nat := 0
   crossing : Option TypedMarkerScanCrossing := none
+  deriving Inhabited
 
 def typedMarkerScanInputV7
     (request : TypedRequestV7) (side : Side) : TypedMarkerScanInput :=
@@ -4396,11 +4420,85 @@ def typedMarkerKindCount (kind : TypedMarkerKind)
   | .rangeStart => state.rangeStartOccurrences
   | .rangeEnd => state.rangeEndOccurrences
 
+def updateTypedMarkerAssociationV7
+    (association : TypedMarkerAssociationV7)
+    (occurrence : TypedMarkerOccurrence) : TypedMarkerAssociationV7 :=
+  match occurrence.kind with
+  | .reference =>
+      { association with
+        referenceCount := association.referenceCount + 1
+        firstReference := association.firstReference.orElse
+          (fun _ => some occurrence)
+        firstDuplicateReference :=
+          if association.referenceCount == 1 then some occurrence
+          else association.firstDuplicateReference }
+  | .rangeStart =>
+      { association with
+        rangeStartCount := association.rangeStartCount + 1
+        firstRangeStart := association.firstRangeStart.orElse
+          (fun _ => some occurrence)
+        firstDuplicateRangeStart :=
+          if association.rangeStartCount == 1 then some occurrence
+          else association.firstDuplicateRangeStart }
+  | .rangeEnd =>
+      { association with
+        rangeEndCount := association.rangeEndCount + 1
+        firstRangeEnd := association.firstRangeEnd.orElse
+          (fun _ => some occurrence)
+        firstDuplicateRangeEnd :=
+          if association.rangeEndCount == 1 then some occurrence
+          else association.firstDuplicateRangeEnd }
+
+def typedMarkerAssociationTrieFromOccurrencesV7 :
+    TypedCanonicalIdTrie → List TypedMarkerOccurrence → TypedCanonicalIdTrie
+  | trie, [] => trie
+  | trie, occurrence :: rest =>
+      let next := match occurrence.canonicalId with
+        | none => trie
+        | some canonical =>
+            let association :=
+              (typedCanonicalIdTrieAssociation? trie canonical).getD {}
+            typedCanonicalIdTrieSet trie canonical
+              (updateTypedMarkerAssociationV7 association occurrence)
+      typedMarkerAssociationTrieFromOccurrencesV7 next rest
+
 def typedMarkerStoryAt (input : TypedMarkerScanInput) (ordinal : Nat) :
     TypedPhysicalStoryIdentity :=
   match typedListGet? input.slots ordinal with
   | some slot => { kind := slot.kind, physicalStoryOrdinal := slot.physicalStoryOrdinal }
   | none => { kind := .main, physicalStoryOrdinal := 0 }
+
+def TypedMarkerScanInputObservationalEqV7
+    (left right : TypedMarkerScanInput) : Prop :=
+  left.wmlNamespace = right.wmlNamespace ∧
+  left.idLocalName = right.idLocalName ∧
+  left.rangeStartLocalName = right.rangeStartLocalName ∧
+  left.rangeEndLocalName = right.rangeEndLocalName ∧
+  left.referenceLocalName = right.referenceLocalName ∧
+  ∀ ordinal, typedMarkerStoryAt left ordinal =
+    typedMarkerStoryAt right ordinal
+
+theorem typed_marker_candidate_v7_input_observational_ext
+    (left right : TypedMarkerScanInput)
+    (hInput : TypedMarkerScanInputObservationalEqV7 left right)
+    (event : TypedXmlEvent) :
+    typedMarkerCandidateV7 left event =
+      typedMarkerCandidateV7 right event := by
+  cases left with
+  | mk leftStories leftSlots leftNamespace leftId leftStart leftEnd
+      leftReference =>
+    cases right with
+    | mk rightStories rightSlots rightNamespace rightId rightStart rightEnd
+        rightReference =>
+      simp only [TypedMarkerScanInputObservationalEqV7] at hInput
+      rcases hInput with
+        ⟨hNamespace, hId, hStart, hEnd, hReference, _⟩
+      cases hNamespace
+      cases hId
+      cases hStart
+      cases hEnd
+      cases hReference
+      cases event <;> rfl
 
 def scanTypedMarkerEventV7 (input : TypedMarkerScanInput)
     (sourceSetOrdinal sourceEventOrdinal : Nat)
@@ -4439,21 +4537,31 @@ def scanTypedMarkerEventV7 (input : TypedMarkerScanInput)
         (if kind == .rangeEnd then 1 else 0)
       match canonicalId with
       | some canonical =>
-        if !typedCanonicalIdTrieHas state.canonicalIdTrie canonical &&
-            state.canonicalIds.length == 4096 then
-          let crossing := TypedMarkerScanCrossing.uniqueIdLimit kind
-            sourceSetOrdinal sourceEventOrdinal kindOrdinal canonical
-          { state with crossing := some crossing }
-        else
-          { state with
-            occurrences := occurrence :: state.occurrences
-            canonicalIds := if typedCanonicalIdTrieHas state.canonicalIdTrie canonical then
-                state.canonicalIds else canonical :: state.canonicalIds
-            canonicalIdTrie := typedCanonicalIdTrieAdd state.canonicalIdTrie canonical
-            referenceOccurrences
-            rangeStartOccurrences
-            rangeEndOccurrences
-            markerOccurrences := state.markerOccurrences + 1 }
+        match typedCanonicalIdTrieAssociation? state.canonicalIdTrie canonical with
+        | some association =>
+            { state with
+              occurrences := occurrence :: state.occurrences
+              canonicalIdTrie := typedCanonicalIdTrieSet state.canonicalIdTrie
+                canonical (updateTypedMarkerAssociationV7 association occurrence)
+              referenceOccurrences
+              rangeStartOccurrences
+              rangeEndOccurrences
+              markerOccurrences := state.markerOccurrences + 1 }
+        | none =>
+          if state.canonicalIds.length == 4096 then
+            let crossing := TypedMarkerScanCrossing.uniqueIdLimit kind
+              sourceSetOrdinal sourceEventOrdinal kindOrdinal canonical
+            { state with crossing := some crossing }
+          else
+            { state with
+              occurrences := occurrence :: state.occurrences
+              canonicalIds := canonical :: state.canonicalIds
+              canonicalIdTrie := typedCanonicalIdTrieSet state.canonicalIdTrie
+                canonical (updateTypedMarkerAssociationV7 {} occurrence)
+              referenceOccurrences
+              rangeStartOccurrences
+              rangeEndOccurrences
+              markerOccurrences := state.markerOccurrences + 1 }
       | none =>
         { state with
           occurrences := occurrence :: state.occurrences
@@ -4461,6 +4569,19 @@ def scanTypedMarkerEventV7 (input : TypedMarkerScanInput)
           rangeStartOccurrences
           rangeEndOccurrences
           markerOccurrences := state.markerOccurrences + 1 }
+
+theorem scan_typed_marker_event_v7_input_observational_ext
+    (left right : TypedMarkerScanInput)
+    (hInput : TypedMarkerScanInputObservationalEqV7 left right)
+    (sourceSetOrdinal sourceEventOrdinal : Nat)
+    (state : TypedMarkerScanState) (event : TypedXmlEvent) :
+    scanTypedMarkerEventV7 left sourceSetOrdinal sourceEventOrdinal
+        state event =
+      scanTypedMarkerEventV7 right sourceSetOrdinal sourceEventOrdinal
+        state event := by
+  unfold scanTypedMarkerEventV7
+  rw [typed_marker_candidate_v7_input_observational_ext left right hInput event,
+    hInput.2.2.2.2.2 sourceSetOrdinal]
 
 def scanTypedStoryEventsV7 (input : TypedMarkerScanInput)
     (sourceSetOrdinal : Nat) : Nat → Nat → TypedMarkerScanState →
@@ -4477,6 +4598,35 @@ def scanTypedStoryEventsV7 (input : TypedMarkerScanInput)
         else scanTypedStoryEventsV7 input sourceSetOrdinal
           (eventOrdinal + 1) fuel afterEvent rest
 
+theorem scan_typed_story_events_v7_input_observational_ext
+    (left right : TypedMarkerScanInput)
+    (hInput : TypedMarkerScanInputObservationalEqV7 left right)
+    (sourceSetOrdinal : Nat) :
+    ∀ eventOrdinal fuel state events,
+      scanTypedStoryEventsV7 left sourceSetOrdinal eventOrdinal fuel
+          state events =
+        scanTypedStoryEventsV7 right sourceSetOrdinal eventOrdinal fuel
+          state events
+  | _, 0, _, _ => rfl
+  | _, _ + 1, _, [] => rfl
+  | eventOrdinal, fuel + 1, state, event :: rest => by
+      unfold scanTypedStoryEventsV7
+      by_cases hStopped : state.crossing.isSome = true
+      · simp only [hStopped, if_true]
+      · simp only [hStopped]
+        rw [scan_typed_marker_event_v7_input_observational_ext
+          left right hInput]
+        by_cases hAfter :
+            (scanTypedMarkerEventV7 right sourceSetOrdinal eventOrdinal
+              { state with
+                processedEventCount := state.processedEventCount + 1 }
+              event).crossing.isSome = true
+        · simp only [hAfter, if_true]
+        · simp only [hAfter]
+          exact scan_typed_story_events_v7_input_observational_ext
+            left right hInput sourceSetOrdinal
+            (eventOrdinal + 1) fuel _ rest
+
 def scanTypedStoriesV7 (input : TypedMarkerScanInput) :
     Nat → Nat → TypedMarkerScanState → List TypedStorySource → TypedMarkerScanState
   | _, 0, state, _ => state
@@ -4490,6 +4640,32 @@ def scanTypedStoriesV7 (input : TypedMarkerScanInput) :
           story.parsed.events
         if afterStory.crossing.isSome then afterStory
         else scanTypedStoriesV7 input (sourceOrdinal + 1) fuel afterStory rest
+
+theorem scan_typed_stories_v7_input_observational_ext
+    (left right : TypedMarkerScanInput)
+    (hInput : TypedMarkerScanInputObservationalEqV7 left right) :
+    ∀ sourceOrdinal fuel state stories,
+      scanTypedStoriesV7 left sourceOrdinal fuel state stories =
+        scanTypedStoriesV7 right sourceOrdinal fuel state stories
+  | _, 0, _, _ => rfl
+  | _, _ + 1, _, [] => rfl
+  | sourceOrdinal, fuel + 1, state, story :: rest => by
+      unfold scanTypedStoriesV7
+      by_cases hStopped : state.crossing.isSome = true
+      · simp only [hStopped, if_true]
+      · simp only [hStopped]
+        rw [scan_typed_story_events_v7_input_observational_ext
+          left right hInput]
+        by_cases hAfter :
+            (scanTypedStoryEventsV7 right sourceOrdinal 0
+              (story.parsed.events.length + 1)
+              { state with
+                processedStoryCount := state.processedStoryCount + 1 }
+              story.parsed.events).crossing.isSome = true
+        · simp only [hAfter, if_true]
+        · simp only [hAfter]
+          exact scan_typed_stories_v7_input_observational_ext
+            left right hInput (sourceOrdinal + 1) fuel _ rest
 
 def scanTypedCommentMarkersV7
     (input : TypedMarkerScanInput) : TypedMarkerScanEvidence :=
@@ -4506,42 +4682,34 @@ def scanTypedCommentMarkersV7
 
 def retainedOrIndependentTypedMarkerScanV7
     (request : TypedRequestV7) (side : Side) : TypedMarkerScanEvidence :=
-  match retainedTypedMarkerScanAt request side with
-  | some evidence =>
-      { evidence with inputStories := canonicalTypedCommentSourcesV7 request side }
-  | none => scanTypedCommentMarkersV7 (typedMarkerScanInputV7 request side)
+  scanTypedCommentMarkersV7 (typedMarkerScanInputV7 request side)
 
 theorem retained_or_independent_typed_marker_scan_v7_input_stories
     (request : TypedRequestV7) (side : Side) :
     (retainedOrIndependentTypedMarkerScanV7 request side).inputStories =
       canonicalTypedCommentSourcesV7 request side := by
-  unfold retainedOrIndependentTypedMarkerScanV7
-  cases hRetained : retainedTypedMarkerScanAt request side with
-  | none =>
-      change
-        (scanTypedCommentMarkersV7
-          (typedMarkerScanInputV7 request side)).inputStories =
-            canonicalTypedCommentSourcesV7 request side
-      rfl
-  | some evidence => rfl
+  rfl
 
 theorem retained_or_independent_typed_marker_scan_v7_of_none
     (request : TypedRequestV7) (side : Side)
-    (hNone : retainedTypedMarkerScanAt request side = none) :
+    (_hNone : retainedTypedMarkerScanAt request side = none) :
     retainedOrIndependentTypedMarkerScanV7 request side =
       scanTypedCommentMarkersV7 (typedMarkerScanInputV7 request side) := by
-  simp [retainedOrIndependentTypedMarkerScanV7, hNone]
+  rfl
 
-def typedDefinitionsFromEventsV7 (events : List TypedXmlEvent) :
-    List TypedCommentDefinition :=
-  let input : TypedScanInput := {
+def typedDefinitionScanInputV7
+    (events : List TypedXmlEvent) : TypedScanInput := {
     wmlNamespace := typedWmlNamespace
     idLocalName := typedLiteral [105,100]
     referenceLocalName := typedLiteral []
     definitionLocalName := typedLiteral [99,111,109,109,101,110,116]
     sourceEvents := []
-    definitionEvents := events }
-  let scan := scanTypedCommentEvidence input
+    definitionEvents := events
+  }
+
+def typedDefinitionsFromEventsV7 (events : List TypedXmlEvent) :
+    List TypedCommentDefinition :=
+  let scan := scanTypedCommentEvidence (typedDefinitionScanInputV7 events)
   scan.definitions ++ scan.nonDirectDefinitions
 
 set_option backward.match.sparseCases false in
@@ -4563,6 +4731,55 @@ def typedDefinitionsForIdV7 (definitions : List TypedCommentDefinition)
   definitions.filter fun definition =>
     definition.direct && definition.canonicalId = some id
 
+def typedIncrementDirectDefinitionCountV7
+    (trie : TypedCanonicalIdTrie)
+    (definition : TypedCommentDefinition) : TypedCanonicalIdTrie :=
+  if definition.direct then
+    match definition.canonicalId with
+    | some canonical =>
+        let association :=
+          (typedCanonicalIdTrieAssociation? trie canonical).getD {}
+        typedCanonicalIdTrieSet trie canonical
+          { association with
+            referenceCount := association.referenceCount + 1 }
+    | none => trie
+  else trie
+
+def typedDirectDefinitionCountTrieV7
+    (definitions : List TypedCommentDefinition)
+    (initial : TypedCanonicalIdTrie) : TypedCanonicalIdTrie :=
+  definitions.foldl typedIncrementDirectDefinitionCountV7 initial
+
+def typedDirectDefinitionCountV7 (trie : TypedCanonicalIdTrie)
+    (id : CanonicalDecimalId) : Nat :=
+  (typedCanonicalIdTrieAssociation? trie id).map (·.referenceCount) |>.getD 0
+
+def typedCollectDefinitionIdsV7 :
+    TypedCanonicalIdTrie → List CanonicalDecimalId →
+      List TypedCommentDefinition →
+        List CanonicalDecimalId × TypedCanonicalIdTrie
+  | seen, output, [] => (output.reverse, seen)
+  | seen, output, definition :: rest =>
+      match definition.canonicalId with
+      | none => typedCollectDefinitionIdsV7 seen output rest
+      | some canonical =>
+          if typedCanonicalIdTrieHas seen canonical then
+            typedCollectDefinitionIdsV7 seen output rest
+          else
+            typedCollectDefinitionIdsV7
+              (typedCanonicalIdTrieSet seen canonical {}) (canonical :: output) rest
+
+def typedAppendUnseenMarkerIdsV7 :
+    TypedCanonicalIdTrie → List CanonicalDecimalId →
+      List CanonicalDecimalId → List CanonicalDecimalId
+  | _, output, [] => output.reverse
+  | seen, output, canonical :: rest =>
+      if typedCanonicalIdTrieHas seen canonical then
+        typedAppendUnseenMarkerIdsV7 seen output rest
+      else
+        typedAppendUnseenMarkerIdsV7
+          (typedCanonicalIdTrieSet seen canonical {}) (canonical :: output) rest
+
 def typedSourceOccurrencesForIdV7 (scan : TypedMarkerScanEvidence)
     (id : CanonicalDecimalId) : List TypedMarkerOccurrence :=
   scan.occurrences.filter fun occurrence => occurrence.canonicalId = some id
@@ -4583,20 +4800,25 @@ def TypedCommentIdTopologyOf
 
 def typedAllCommentIdsV7 (definitions : List TypedCommentDefinition)
     (scan : TypedMarkerScanEvidence) : List CanonicalDecimalId :=
-  ((definitions.filterMap (·.canonicalId)) ++
-    (scan.occurrences.filterMap (·.canonicalId))).eraseDups
+  let collected := typedCollectDefinitionIdsV7 .empty [] definitions
+  collected.1 ++ typedAppendUnseenMarkerIdsV7 collected.2 [] scan.canonicalIds
 
 set_option backward.match.sparseCases false in
 def checkTypedCommentIdTopologyV7
-    (definitions : List TypedCommentDefinition)
-    (scan : TypedMarkerScanEvidence) (id : CanonicalDecimalId) : Bool :=
-  let references := typedOccurrencesForIdV7 .reference scan id
-  let starts := typedOccurrencesForIdV7 .rangeStart scan id
-  let ends := typedOccurrencesForIdV7 .rangeEnd scan id
-  typedNatEqCheck (typedDefinitionsForIdV7 definitions id).length 1 &&
-  match references, starts, ends with
-  | [_], [], [] => true
-  | [reference], [start], [finish] =>
+    (definitionCounts : TypedCanonicalIdTrie)
+    (associations : TypedCanonicalIdTrie)
+    (id : CanonicalDecimalId) : Bool :=
+  typedNatEqCheck (typedDirectDefinitionCountV7 definitionCounts id) 1 &&
+  match typedCanonicalIdTrieAssociation? associations id with
+  | none => true
+  | some association =>
+    match association.referenceCount, association.rangeStartCount,
+        association.rangeEndCount with
+    | 1, 0, 0 => true
+    | 1, 1, 1 =>
+      match association.firstReference, association.firstRangeStart,
+          association.firstRangeEnd with
+      | some reference, some start, some finish =>
       (match start.story.kind, finish.story.kind with
        | .main, .main | .header, .header | .footer, .footer
        | .footnotes, .footnotes | .endnotes, .endnotes => true
@@ -4610,31 +4832,34 @@ def checkTypedCommentIdTopologyV7
       typedNatEqCheck finish.story.physicalStoryOrdinal
         reference.story.physicalStoryOrdinal &&
       typedNatLtCheck start.sourceEventOrdinal finish.sourceEventOrdinal
-  | _, _, _ => false
+      | _, _, _ => false
+    | _, _, _ => false
 
 def checkTypedCommentIdsTopologyV7
-    (definitions : List TypedCommentDefinition)
-    (scan : TypedMarkerScanEvidence) : List CanonicalDecimalId → Bool
+    (definitionCounts : TypedCanonicalIdTrie)
+    (associations : TypedCanonicalIdTrie) :
+      List CanonicalDecimalId → Bool
   | [] => true
   | id :: rest =>
-      let source := typedSourceOccurrencesForIdV7 scan id
-      let valid := if source.isEmpty then
-        typedNatEqCheck (typedDefinitionsForIdV7 definitions id).length 1
-      else checkTypedCommentIdTopologyV7 definitions scan id
-      valid && checkTypedCommentIdsTopologyV7 definitions scan rest
+      checkTypedCommentIdTopologyV7 definitionCounts associations id &&
+        checkTypedCommentIdsTopologyV7 definitionCounts associations rest
 
 def TypedPackageCommentRangeIntegrity
     (definitions : List TypedCommentDefinition)
     (scan : TypedMarkerScanEvidence) : Prop :=
   scan.crossing.isNone = true ∧
-  checkTypedCommentIdsTopologyV7 definitions scan
+  checkTypedCommentIdsTopologyV7
+    (typedDirectDefinitionCountTrieV7 definitions .empty)
+    (typedMarkerAssociationTrieFromOccurrencesV7 .empty scan.occurrences)
     (typedAllCommentIdsV7 definitions scan) = true
 
 def checkTypedPackageCommentRangeIntegrity
     (definitions : List TypedCommentDefinition)
     (scan : TypedMarkerScanEvidence) : Bool :=
   scan.crossing.isNone &&
-  checkTypedCommentIdsTopologyV7 definitions scan
+  checkTypedCommentIdsTopologyV7
+    (typedDirectDefinitionCountTrieV7 definitions .empty)
+    (typedMarkerAssociationTrieFromOccurrencesV7 .empty scan.occurrences)
     (typedAllCommentIdsV7 definitions scan)
 
 inductive TypedSideCommentStatusV7
@@ -4718,17 +4943,17 @@ def evaluateTypedCommentSideV7
   let sources := canonicalTypedCommentSourcesV7 request side
   let markerScan := retainedOrIndependentTypedMarkerScanV7 request side
   let definitions := typedDefinitionsV7 request side
-  if !typedCommentPrerequisitesV7 request side then
-    { side, status := .notEvaluated
-      partPresent := inheritedEvaluation.partPresent
-      selection, realization, sources := []
-      markerScan := emptyTypedMarkerScanEvidenceV7, definitions := [] }
-  else
-    let status := if inheritedEvaluation.status == .failed ||
-          !checkTypedPackageCommentRangeIntegrity definitions markerScan then
-        .failed else .passed
-    { side, status, partPresent := inheritedEvaluation.partPresent
-      selection, realization, sources, markerScan, definitions }
+  let incomplete := !typedCommentPrerequisitesV7 request side
+  let status := if incomplete then .notEvaluated
+    else if inheritedEvaluation.status == .failed ||
+        !checkTypedPackageCommentRangeIntegrity definitions markerScan then
+      .failed
+    else .passed
+  { side, status, partPresent := inheritedEvaluation.partPresent
+    selection, realization
+    sources := if incomplete then [] else sources
+    markerScan := if incomplete then emptyTypedMarkerScanEvidenceV7 else markerScan
+    definitions := if incomplete then [] else definitions }
 
 abbrev TypedProtocolV7Response := TypedProtocolV6Response
 
@@ -4967,40 +5192,37 @@ def typedSameMarkerStoryV7 (left right : TypedMarkerOccurrence) : Bool :=
 
 set_option backward.match.sparseCases false in
 def typedTopologyIssueForIdV7 (side : Side)
-    (scan : TypedMarkerScanEvidence) (id : CanonicalDecimalId) :
+    (associations : TypedCanonicalIdTrie) (id : CanonicalDecimalId) :
     Option TypedJson :=
-  let references := typedOccurrencesForIdV7 .reference scan id
-  let starts := typedOccurrencesForIdV7 .rangeStart scan id
-  let ends := typedOccurrencesForIdV7 .rangeEnd scan id
-  if references.length > 1 then
-    match references with
-    | _ :: occurrence :: _ =>
-        some <| typedTopologyIssueJsonV7 side id .referenceDuplicate
-          occurrence (references.length - 1)
-    | _ => none
-  else if references.isEmpty && (!starts.isEmpty || !ends.isEmpty) then
-    (typedEarliestMarkerV7 (starts ++ ends)).map fun occurrence =>
-      typedTopologyIssueJsonV7 side id .referenceMissing occurrence 1
-  else if starts.length > 1 then
-    match starts with
-    | _ :: occurrence :: _ =>
-        some <| typedTopologyIssueJsonV7 side id .rangeStartDuplicate
-          occurrence (starts.length - 1)
-    | _ => none
-  else if ends.length > 1 then
-    match ends with
-    | _ :: occurrence :: _ =>
-        some <| typedTopologyIssueJsonV7 side id .rangeEndDuplicate
-          occurrence (ends.length - 1)
-    | _ => none
-  else match starts, ends with
-  | [start], [] =>
-      some (typedTopologyIssueJsonV7 side id .rangeStartOrphaned start 1)
-  | [], [finish] =>
-      some (typedTopologyIssueJsonV7 side id .rangeEndOrphaned finish 1)
-  | [start], [finish] =>
-      match references with
-      | [reference] =>
+  match typedCanonicalIdTrieAssociation? associations id with
+  | none => none
+  | some association =>
+    if association.referenceCount > 1 then
+      association.firstDuplicateReference.map fun occurrence =>
+        typedTopologyIssueJsonV7 side id .referenceDuplicate
+          occurrence (association.referenceCount - 1)
+    else if association.referenceCount = 0 &&
+        (association.rangeStartCount > 0 || association.rangeEndCount > 0) then
+      typedEarliestMarkerV7
+        (association.firstRangeStart.toList ++
+          association.firstRangeEnd.toList) |>.map fun occurrence =>
+        typedTopologyIssueJsonV7 side id .referenceMissing occurrence 1
+    else if association.rangeStartCount > 1 then
+      association.firstDuplicateRangeStart.map fun occurrence =>
+        typedTopologyIssueJsonV7 side id .rangeStartDuplicate
+          occurrence (association.rangeStartCount - 1)
+    else if association.rangeEndCount > 1 then
+      association.firstDuplicateRangeEnd.map fun occurrence =>
+        typedTopologyIssueJsonV7 side id .rangeEndDuplicate
+          occurrence (association.rangeEndCount - 1)
+    else match association.firstRangeStart, association.firstRangeEnd with
+    | some start, none =>
+        some (typedTopologyIssueJsonV7 side id .rangeStartOrphaned start 1)
+    | none, some finish =>
+        some (typedTopologyIssueJsonV7 side id .rangeEndOrphaned finish 1)
+    | some start, some finish =>
+      match association.firstReference with
+      | some reference =>
         let all := [start, finish, reference]
         match typedEarliestMarkerV7 all with
         | none => none
@@ -5023,12 +5245,14 @@ def typedTopologyIssueForIdV7 (side : Side)
               [ (key [114,97,110,103,101,69,110,100,69,118,101,110,116,79,114,100,105,110,97,108],
                   .nat finish.sourceEventOrdinal) ]
       | _ => none
-  | _, _ => none
+    | _, _ => none
 
 def typedTopologyIssuesV7 (request : TypedRequestV7) (side : Side) :
     List TypedJson :=
   let scan := retainedOrIndependentTypedMarkerScanV7 request side
-  scan.canonicalIds.filterMap (typedTopologyIssueForIdV7 side scan)
+  let associations :=
+    typedMarkerAssociationTrieFromOccurrencesV7 .empty scan.occurrences
+  scan.canonicalIds.filterMap (typedTopologyIssueForIdV7 side associations)
 
 def typedRelationshipRequiredIssueV7 (side : Side)
     (occurrence : TypedMarkerOccurrence) : TypedJson :=
@@ -5174,11 +5398,20 @@ def typedDefinitionMissingIssuesV7
   | .ok (some _) =>
     let scan := retainedOrIndependentTypedMarkerScanV7 request side
     let definitions := typedDefinitionsV7 request side
+    let definitionCounts :=
+      typedDirectDefinitionCountTrieV7 definitions .empty
+    let associations :=
+      typedMarkerAssociationTrieFromOccurrencesV7 .empty scan.occurrences
     scan.canonicalIds.filterMap fun id =>
-      if (typedDefinitionsForIdV7 definitions id).length = 1 then none
-      else (typedEarliestMarkerV7
-        (typedSourceOccurrencesForIdV7 scan id)).map
-          (typedMarkerDefinitionMissingIssueV7 side id)
+      if typedDirectDefinitionCountV7 definitionCounts id = 1 then none
+      else
+        (typedCanonicalIdTrieAssociation? associations id).bind
+          fun association =>
+            typedEarliestMarkerV7
+              (association.firstReference.toList ++
+                association.firstRangeStart.toList ++
+                association.firstRangeEnd.toList) |>.map
+              (typedMarkerDefinitionMissingIssueV7 side id)
   | .ok none | .error _ => []
 
 set_option backward.match.sparseCases false in
@@ -5425,14 +5658,7 @@ theorem typed_comment_selection_to_realization_v7_sound
     (request : TypedRequestV7) (side : Side) :
     TypedSelectionToRealizationV7Of request side
       (evaluateTypedCommentSideV7 request side) := by
-  unfold TypedSelectionToRealizationV7Of
-  refine ⟨rfl, ?_, ?_⟩
-  · unfold evaluateTypedCommentSideV7
-    dsimp only
-    split <;> rfl
-  · unfold evaluateTypedCommentSideV7
-    dsimp only
-    split <;> rfl
+  exact ⟨rfl, rfl, rfl⟩
 
 theorem typed_admitted_comment_source_set_v7_complete
     (request : TypedRequestV7) (side : Side)
@@ -5474,13 +5700,14 @@ theorem typed_incomplete_comment_range_zero_evidence_sound
       (evaluateTypedCommentSideV7 request side).status = .notEvaluated) :
     TypedIncompleteCommentRangeZeroOf side
       (evaluateTypedCommentSideV7 request side) := by
-  unfold evaluateTypedCommentSideV7 at hIncomplete ⊢
+  unfold evaluateTypedCommentSideV7 at hIncomplete
+  unfold TypedIncompleteCommentRangeZeroOf
+  unfold evaluateTypedCommentSideV7
   dsimp only at hIncomplete ⊢
   by_cases hPrerequisite :
       (!typedCommentPrerequisitesV7 request side) = true
-  · rw [if_pos hPrerequisite] at hIncomplete ⊢
-    unfold TypedIncompleteCommentRangeZeroOf
-    exact ⟨rfl, rfl, rfl, rfl, rfl⟩
+  · exact ⟨rfl, if_pos hPrerequisite, if_pos hPrerequisite,
+      if_pos hPrerequisite, if_pos hPrerequisite⟩
   · rw [if_neg hPrerequisite] at hIncomplete
     split at hIncomplete <;> contradiction
 
@@ -5830,14 +6057,14 @@ theorem typed_package_comment_range_integrity_check_true
     (scan : TypedMarkerScanEvidence)
     (hIntegrity : TypedPackageCommentRangeIntegrity definitions scan) :
     checkTypedPackageCommentRangeIntegrity definitions scan = true := by
-  unfold TypedPackageCommentRangeIntegrity at hIntegrity
   unfold checkTypedPackageCommentRangeIntegrity
-  exact (congrArg
-    (fun crossingNone =>
-      crossingNone &&
-        checkTypedCommentIdsTopologyV7 definitions scan
-          (typedAllCommentIdsV7 definitions scan))
-    hIntegrity.1).trans hIntegrity.2
+  change scan.crossing.isNone = true ∧
+    checkTypedCommentIdsTopologyV7
+      (typedDirectDefinitionCountTrieV7 definitions .empty)
+      (typedMarkerAssociationTrieFromOccurrencesV7 .empty scan.occurrences)
+      (typedAllCommentIdsV7 definitions scan) = true at hIntegrity
+  rw [hIntegrity.1, hIntegrity.2]
+  rfl
 
 set_option maxRecDepth 100000 in
 theorem typed_duplicate_reference_aggregate_witness_rejected


### PR DESCRIPTION
## Summary

- Rebase the Protocol V7 comment-certificate work onto current `main`.
- Add the canonical selector, realization, definition, marker-scan, and topology proof chain needed for the exact aggregate certificate.
- Bind the runtime gate to retained, bounded single-pass evidence instead of rebuilding the typed request and rescanning whole event streams.
- Strengthen projection-drift and checker-coverage witnesses, including ByteArray-backed XML attribute admission.

## Review status

This is intentionally a **draft**. The proof foundations compile and the retained-evidence path is tested, but the exact aggregate production theorem and its inherited V6 prerequisites remain explicit open tasks in the OpenSpec checklist. Review/smoke tasks also remain open. This PR must not be treated as a completed verifier certificate yet.

No confidential customer documents, filenames, parties, addresses, or corpus-derived text are included. Validation used repository fixtures and generated/synthetic inputs only.

## Validation

Passing branch-specific evidence:

- `lake build` — 6,621 jobs
- `lake build LeanDocxChecker`
- 19 realizable Protocol V7 drift witnesses
- Lean provenance/dependency audits
- 18 empty-axiom semantic targets; production target limited to `[Classical.choice, Quot.sound, propext]`
- `SAFE_DOCX_REQUIRE_LEAN_CHECKER=1 ... leanXmlVerifier.test.ts` — 101/101
- `npm run check:lean-xml-checker-coverage`
- `npm run check:lean-comment-memory` — all near-limit payload classes within the 1.5 GiB ceiling
- `npm run build`
- `npm run check:spec-coverage`
- `npm run check:conformance-citations`
- `npm run check:conformance-doc`
- `openspec validate verify-lean-comment-range-topology --strict`

Repository-wide suite notes:

- `docx-compare`: 841 passed, 27 skipped
- `docx-core`: 1,334 passed, 2 expected failures, 1 skipped; the five sandbox-only IPC/LibreOffice failures pass when rerun outside the sandbox
- `docx-mcp`: 966 passed; one unchanged `main` regression remains in `canonical-emission-mcp.test.ts` for an emptied numbered paragraph mark
- Workspace lint reaches an unchanged `main` type error where `nvca-structural-regression.test.ts` references `rangeStartOccurrences` / `rangeEndOccurrences` absent from `DocumentIntegrityCommentInventory`

Ref: #729