### PR TITLE
feat(docx-mcp): add verified CLI comparisons

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,6 +37,8 @@ Running `safe-docx` with no command starts the MCP server. The CLI can also invo
 ```bash
 safe-docx grep "governing law" contract.docx
 safe-docx compare original.docx revised.docx comparison.docx
+safe-docx compare original.docx revised.docx comparison.docx --verify \
+  --certificate comparison.certificate.json
 safe-docx export --file-path contract.docx --format markdown
 ```
 

--- a/docs/trust-and-conformance.md
+++ b/docs/trust-and-conformance.md
@@ -60,6 +60,19 @@ verification/lean/.lake/build/bin/leanDocxChecker
 
 Set `SAFE_DOCX_LEAN_XML_CHECKER` to use another executable. Normal package usage does not require Lean or Lake.
 
+The installed CLI exposes the same opt-in boundary:
+
+```bash
+safe-docx compare original.docx revised.docx redline.docx --verify
+safe-docx compare original.docx revised.docx redline.docx \
+  --certificate redline.certificate.json
+```
+
+`--certificate` implies `--verify`. A verified CLI comparison uses a 10-second
+checker budget and writes neither artifact unless the certificate passes. The
+command's JSON response includes the certificate under `verification`; the
+optional certificate file contains the same public JSON value.
+
 The checker validates the documents presented to it. It is not a proof of the TypeScript source code, visual fidelity, or the complete ECMA-376 standard.
 
 ## Runtime Dependencies

--- a/openspec/changes/add-verified-comparison-cli/design.md
+++ b/openspec/changes/add-verified-comparison-cli/design.md
@@ -1,0 +1,86 @@
+## Context
+
+The comparison library already supports `leanXmlVerifier.enabled`, but the
+installed CLI never supplies it and discards `CompareResult.documentIntegrity`.
+The compiled verifier owns package parsing so its certificate does not trust a
+TypeScript-selected XML subset. That parser currently treats every ZIP
+directory entry as archive ambiguity, including conventional zero-byte
+placeholders such as `word/`.
+
+## Goals / Non-Goals
+
+- Goals:
+  - make verified comparison a deliberate CLI choice;
+  - preserve a machine-readable certificate;
+  - fail closed when a requested certificate does not pass;
+  - accept only inert and unambiguous directory placeholders;
+  - keep ordinary verified comparisons within the user-accepted 10-second
+    latency budget.
+- Non-Goals:
+  - enable verification by default;
+  - claim that rebuild output is verified;
+  - accept symlinks, special files, non-empty directory payloads, ambiguous
+    directory identities, or directory entries selected as XML stories;
+  - publish or test against confidential documents.
+
+## Decisions
+
+### CLI contract
+
+`safe-docx compare ... --verify` enables the compiled verifier. The normal JSON
+result gains a `verification` field containing the complete public certificate.
+`--certificate <path>` both implies verification and atomically writes the same
+JSON value to that path. A requested verification status other than `passed`
+throws before either the redline or certificate is published.
+
+The checker path remains configurable through
+`SAFE_DOCX_LEAN_XML_CHECKER`. This avoids exposing an installation-specific
+path flag as a stable CLI contract while retaining the library option for
+programmatic callers.
+
+### Timeout
+
+The default is 10,000 ms in both documentation and implementation. The CLI does
+not expose a longer timeout in this slice. Library callers may continue to
+override `timeoutMs`.
+
+### ZIP directory placeholders
+
+The trusted binary index may retain a directory entry only when all of the
+following are true:
+
+- the safe normalized name ends in `/`;
+- central attributes identify a directory consistently;
+- method is stored (`0`);
+- CRC-32, compressed size, and expanded size are all zero;
+- the matching local header has identical metadata and no payload;
+- all existing filename, extra-field, bounds, overlap, and flag checks pass.
+
+Directories count toward entry and central-directory limits. Exact part
+selection remains regular-file-only, so a relationship cannot select a
+directory as XML evidence. Symlinks, special files, non-empty directories, and
+ambiguous central/local identities remain `not_run`.
+
+### Performance evidence
+
+A focused real-document test uses the committed public NVCA-derived fixture,
+requires a passing protocol-v7 certificate, and asserts total comparison plus
+verification time is no more than 10 seconds. The gate does not compile Lean
+inside the timed region and skips only when the checker is not present outside
+the Lean-enabled job.
+
+## Risks / Trade-offs
+
+- Wall-clock gates can be noisy. The 10-second ceiling is materially above the
+  observed healthy path and the test records elapsed time in its failure.
+- Fail-closed publication means a verifier timeout produces no redline. This is
+  intentional because `--verify` is an assurance request, not best effort.
+- Accepting directory placeholders expands the parser subset. The exact inert
+  profile and typed-semantics bridge prevent this from becoming arbitrary
+  special-entry support.
+
+## Migration Plan
+
+The default CLI remains unchanged. Users opt in with `--verify`; automation that
+needs a durable artifact adds `--certificate <path>`.
+

--- a/openspec/changes/add-verified-comparison-cli/proposal.md
+++ b/openspec/changes/add-verified-comparison-cli/proposal.md
@@ -1,0 +1,31 @@
+# Change: Add verified comparisons to the Safe DOCX CLI
+
+## Why
+
+`safe-docx compare` currently runs reconstruction safety checks but does not
+expose the compiled Lean verifier, so CLI users cannot request or retain a
+document-integrity certificate. The verifier also rejects harmless zero-byte
+ZIP directory placeholders emitted by common DOCX tooling, and its documented
+timeout does not match its implementation.
+
+## What Changes
+
+- Add an explicit `--verify` mode to `safe-docx compare`.
+- Include the public document-integrity certificate in CLI JSON and optionally
+  write it to a caller-selected JSON file.
+- Fail closed without publishing a redline when requested verification does not
+  return `passed`.
+- Use a consistent 10-second verifier timeout by default.
+- Admit unambiguous, zero-byte ZIP directory placeholders into the trusted
+  package inventory while continuing to forbid them as selected XML parts.
+- Add public NVCA-derived end-to-end evidence that verified comparison completes
+  within 10 seconds on the supported test environment.
+
+## Impact
+
+- Affected specs: `docx-comparison`
+- Affected code: CLI comparison parsing and command execution, verifier option
+  defaults, Lean ZIP inventory parsing and typed semantics, tests, and CLI help
+- Tracking: GitHub issue #775
+- Privacy: only committed public or sanitized fixtures are permitted
+

--- a/openspec/changes/add-verified-comparison-cli/specs/docx-comparison/spec.md
+++ b/openspec/changes/add-verified-comparison-cli/specs/docx-comparison/spec.md
@@ -1,0 +1,84 @@
+## ADDED Requirements
+
+### Requirement: CLI comparisons can require a passing verifier certificate
+
+The installed Safe DOCX CLI SHALL expose an opt-in verified comparison mode.
+When verification is requested, the CLI SHALL run the compiled Lean verifier
+over the original, revised, and compared packages, SHALL expose the complete
+public document-integrity certificate in its JSON result, and SHALL publish no
+redline or certificate artifact unless the certificate status is `passed`.
+Verification SHALL remain disabled when it is not explicitly requested.
+
+#### Scenario: [CLI-VERIFY-01] Verified comparison returns a passing certificate
+
+- **GIVEN** a supported inplace document pair and an available compiled checker
+- **WHEN** the user runs `safe-docx compare` with `--verify`
+- **THEN** the comparison SHALL run the compiled verifier
+- **AND** the CLI JSON SHALL include its passing public certificate
+- **AND** the redline SHALL be written only after that passing result exists
+
+#### Scenario: [CLI-VERIFY-02] Certificate path implies verified comparison
+
+- **WHEN** the user supplies `--certificate <path>`
+- **THEN** verification SHALL be enabled
+- **AND** the CLI SHALL atomically write the same public certificate returned in
+  its JSON result
+
+#### Scenario: [CLI-VERIFY-03] Requested verification fails closed
+
+- **WHEN** the checker is missing, times out, returns malformed output, reports
+  `failed`, `not_run`, or `not_applicable`, or the comparison falls back to an
+  unsupported reconstruction mode
+- **THEN** the command SHALL fail before publishing the redline or certificate
+- **AND** the error SHALL identify the non-passing verification status or reason
+
+#### Scenario: [CLI-VERIFY-04] Ordinary comparison remains unchanged
+
+- **WHEN** neither `--verify` nor `--certificate` is supplied
+- **THEN** the CLI SHALL not invoke the compiled verifier
+- **AND** its existing comparison output contract SHALL remain compatible
+
+### Requirement: Verified CLI comparisons use a ten-second assurance budget
+
+The production verifier default timeout SHALL be 10,000 milliseconds. A focused
+end-to-end gate SHALL compare and certify a committed public NVCA-derived DOCX
+pair within 10 seconds, excluding checker compilation from the timed region.
+
+#### Scenario: [CLI-VERIFY-05] Public real-document verification meets the budget
+
+- **GIVEN** the compiled checker and committed public NVCA-derived fixture
+- **WHEN** the focused verified comparison gate runs
+- **THEN** the certificate SHALL pass using protocol v7
+- **AND** total comparison plus certificate latency SHALL not exceed 10 seconds
+
+### Requirement: Inert ZIP directory placeholders are accepted but never selected
+
+The compiled verifier SHALL retain a ZIP directory placeholder in its trusted
+inventory only when its safe name, attributes, stored method, zero CRC, zero
+compressed and expanded sizes, matching local header, empty payload, bounds,
+flags, extra fields, and non-overlap checks prove that it is inert and
+unambiguous. Such entries SHALL count against archive limits but SHALL never be
+eligible as selected XML parts. All other directory, symlink, and special-entry
+shapes SHALL remain archive ambiguity and produce no passing certificate.
+
+#### Scenario: [LEAN-ZIP-DIR-01] Conventional empty directory is inert
+
+- **GIVEN** a classic single-disk DOCX containing a safe `word/` entry whose
+  central and local records consistently describe an empty stored directory
+- **WHEN** the compiled verifier indexes the package
+- **THEN** it SHALL retain the entry for limits and span validation
+- **AND** ordinary XML part selection and verification SHALL proceed
+
+#### Scenario: [LEAN-ZIP-DIR-02] Directory cannot become a selected XML story
+
+- **WHEN** a relationship target resolves to an accepted directory placeholder
+- **THEN** selection SHALL fail closed
+- **AND** the directory SHALL receive no parsed or passing XML evidence
+
+#### Scenario: [LEAN-ZIP-DIR-03] Ambiguous or non-empty directory remains rejected
+
+- **WHEN** a directory has inconsistent name/attributes, a nonzero CRC or size,
+  a payload, compression, unsafe naming, a mismatched local header, or a special
+  Unix file type
+- **THEN** the executable SHALL publish no valid protocol response
+- **AND** the public certificate SHALL be `not_run`

--- a/openspec/changes/add-verified-comparison-cli/tasks.md
+++ b/openspec/changes/add-verified-comparison-cli/tasks.md
@@ -1,0 +1,23 @@
+## 1. Specification
+
+- [x] 1.1 Validate the CLI, timeout, directory-entry, and performance requirements
+
+## 2. CLI
+
+- [x] 2.1 Parse and document `--verify` and `--certificate`
+- [x] 2.2 Enable the compiled verifier and return the public certificate
+- [x] 2.3 Fail closed before publishing output when verification does not pass
+- [x] 2.4 Atomically write an optional certificate JSON artifact
+
+## 3. Verifier compatibility
+
+- [x] 3.1 Align the documented and implemented default timeout at 10 seconds
+- [x] 3.2 Admit only inert, unambiguous ZIP directory placeholders
+- [x] 3.3 Update typed semantics and proof bridges for the expanded ZIP subset
+
+## 4. Evidence
+
+- [x] 4.1 Add CLI parsing, certificate-output, and fail-closed tests
+- [x] 4.2 Add accepted and adversarial ZIP-directory tests
+- [x] 4.3 Add a public NVCA-derived verified-comparison gate at 10 seconds
+- [x] 4.4 Run focused Lean, CLI, conformance, and full pre-submit checks

--- a/packages/docx-compare/src/baselines/atomizer/leanXmlVerifier.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/leanXmlVerifier.test.ts
@@ -285,6 +285,16 @@ async function replacePart(
   return zip.generateAsync({ type: 'nodebuffer', compression });
 }
 
+async function addInertZipDirectory(docx: Buffer, name = 'word/'): Promise<Buffer> {
+  const zip = await JSZip.loadAsync(docx);
+  zip.file(name, Buffer.alloc(0), {
+    createFolders: false,
+    dir: true,
+    compression: 'STORE',
+  });
+  return zip.generateAsync({ type: 'nodebuffer', compression: 'DEFLATE' });
+}
+
 async function readPart(docx: Buffer, path: string): Promise<string> {
   const part = (await JSZip.loadAsync(docx)).file(path);
   if (!part) throw new Error(`missing test part: ${path}`);
@@ -518,6 +528,14 @@ function mutateZipMethod(docx: Buffer, name: string, method: number): Buffer {
   const record = centralRecordFor(mutated, name);
   mutated.writeUInt16LE(method, record.central + 10);
   mutated.writeUInt16LE(method, record.local + 8);
+  return mutated;
+}
+
+function mutateZipCrc32(docx: Buffer, name: string, crc32: number): Buffer {
+  const mutated = Buffer.from(docx);
+  const record = centralRecordFor(mutated, name);
+  mutated.writeUInt32LE(crc32, record.central + 16);
+  mutated.writeUInt32LE(crc32, record.local + 14);
   return mutated;
 }
 
@@ -4128,6 +4146,57 @@ describeWithLean('Lean compiled package extraction limits', () => {
     expect(result.status).toBe('not_run');
     expect(result.reason).toContain('ZIP is too short for EOCD');
     });
+
+  test.openspec('[LEAN-ZIP-DIR-01] Conventional empty directory is inert')(
+    'accepts a safe zero-byte stored ZIP directory placeholder',
+    async () => {
+      const base = await buildDocxFromBodyXml(paragraphWithText('Body'));
+      const withDirectory = await addInertZipDirectory(base);
+      const result = await run(withDirectory);
+      expect(result.status, result.reason).toBe('passed');
+      expect(result.checkerProtocolVersion).toBe(7);
+    },
+  );
+
+  test.openspec('[LEAN-ZIP-DIR-03] Ambiguous or non-empty directory remains rejected')(
+    'rejects directory placeholders with non-inert metadata',
+    async () => {
+      const base = await addInertZipDirectory(
+        await buildDocxFromBodyXml(paragraphWithText('Body')),
+      );
+      for (const malformed of [
+        mutateZipMethod(base, 'word/', 8),
+        mutateZipCrc32(base, 'word/', 1),
+        mutateExpandedSize(base, 'word/', 1),
+      ]) {
+        const result = await run(malformed);
+        expect(result.status).toBe('not_run');
+        expect(result.reason).toContain('ZIP directory entry is not an inert placeholder');
+      }
+    },
+  );
+
+  test.openspec('[LEAN-ZIP-DIR-02] Directory cannot become a selected XML story')(
+    'never extracts an accepted directory placeholder as relationship XML',
+    async () => {
+      const missingTarget = await relationshipDocx({
+        headerTarget: 'header-dir/',
+        headerPartPath: 'word/header-dir/',
+      });
+      const selectedDirectory = await addInertZipDirectory(
+        missingTarget,
+        'word/header-dir/',
+      );
+      const result = await run(selectedDirectory);
+      expect(result.status).toBe('failed');
+      expect(result.relationshipSelectionFailures?.length).toBeGreaterThan(0);
+      expect(result.relationshipStories?.some((story) =>
+        story.originalPartPath === 'word/header-dir/' ||
+        story.revisedPartPath === 'word/header-dir/' ||
+        story.comparedPartPath === 'word/header-dir/'
+      )).toBe(false);
+    },
+  );
 
   test('rejects oversized expanded story output before buffering it', async () => {
     const base = await buildSyntheticDocx({ paragraphs: ['Body'], footnoteOnParagraph: 0 });

--- a/packages/docx-compare/src/baselines/atomizer/leanXmlVerifier.ts
+++ b/packages/docx-compare/src/baselines/atomizer/leanXmlVerifier.ts
@@ -22,7 +22,7 @@ import type {
   ReconstructionMode,
 } from '../../compare-types.js';
 
-const DEFAULT_TIMEOUT_MS = 120_000;
+const DEFAULT_TIMEOUT_MS = 10_000;
 const DEFAULT_EXECUTABLE = 'verification/lean/.lake/build/bin/leanDocxChecker';
 const MAX_RESPONSE_BYTES = 2_626_369;
 const MAX_RESPONSE_JSON_BYTES = MAX_RESPONSE_BYTES - 1;

--- a/packages/docx-mcp/src/cli/commands/compare.test.ts
+++ b/packages/docx-mcp/src/cli/commands/compare.test.ts
@@ -1,14 +1,80 @@
 import fs from 'node:fs/promises';
+import { existsSync } from 'node:fs';
 import path from 'node:path';
+import { performance } from 'node:perf_hooks';
 import { describe, expect } from 'vitest';
 import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
 import { makeMinimalDocx } from '../../testing/docx_test_utils.js';
 import { createTrackedTempDir, registerCleanup } from '../../testing/session-test-utils.js';
 import { runCompareCommand } from './compare.js';
+import type {
+  CompareResult,
+  DocumentIntegrityCertificate,
+} from '@usejunior/docx-compare';
+import {
+  DocxDocument,
+  getParagraphText,
+  OOXML,
+  replaceParagraphTextRange,
+} from '@usejunior/docx-core';
 
 registerCleanup();
 
 const test = testAllure.epic('Document Editing').withLabels({ feature: 'CLI Comparison' });
+
+const zeroStats = {
+  insertions: 0,
+  deletions: 0,
+  modifications: 0,
+  insertedRanges: 0,
+  deletedRanges: 0,
+  insertedAtoms: 0,
+  deletedAtoms: 0,
+  modifiedParagraphs: 0,
+  formatChanges: 0,
+  formatChangeAtoms: 0,
+};
+
+function certificate(
+  status: DocumentIntegrityCertificate['status'],
+  reason?: string,
+): DocumentIntegrityCertificate {
+  const check = { status: 'passed' as const, claim: 'Test claim.' };
+  return {
+    status,
+    verifier: 'Lean XML triple checker',
+    protocolVersion: 1,
+    scope: 'word/document.xml',
+    reconstructionMode: 'inplace',
+    inputSha256: {
+      originalDocumentXml: 'original',
+      revisedDocumentXml: 'revised',
+      comparedDocumentXml: 'compared',
+    },
+    checks: {
+      acceptingAllTrackedChangesMatchesRevisedText: check,
+      rejectingAllTrackedChangesMatchesOriginalText: check,
+      acceptingAllTrackedChangesKeepsValidFieldStructure: check,
+      rejectingAllTrackedChangesKeepsValidFieldStructure: check,
+      comparedDocumentHasNoFieldMarkersInsideDeletions: check,
+    },
+    checkerProtocolVersion: 7,
+    reason,
+  };
+}
+
+function comparisonResult(
+  documentIntegrity?: DocumentIntegrityCertificate,
+): CompareResult {
+  return {
+    document: Buffer.from('verified-redline'),
+    stats: zeroStats,
+    engine: 'atomizer',
+    reconstructionModeRequested: 'inplace',
+    reconstructionModeUsed: 'inplace',
+    documentIntegrity,
+  };
+}
 
 describe('safe-docx compare command', () => {
   test('defaults to the shared inplace reconstruction mode', async ({
@@ -59,4 +125,169 @@ describe('safe-docx compare command', () => {
       expect(result.output).toBe(path.join(tmpDir, 'revised.REDLINE.atomizer.rebuild.docx'));
     });
   });
+
+  test
+    .openspec('[CLI-VERIFY-01] Verified comparison returns a passing certificate')
+    .openspec('[CLI-VERIFY-02] Certificate path implies verified comparison')(
+    'publishes a passing certificate and redline only after verification',
+    async ({ given, when, then }: AllureBddContext) => {
+      const tmpDir = await createTrackedTempDir('safe-docx-compare-verified-');
+      const originalPath = path.join(tmpDir, 'original.docx');
+      const revisedPath = path.join(tmpDir, 'revised.docx');
+      const outputPath = path.join(tmpDir, 'verified.docx');
+      const certificatePath = path.join(tmpDir, 'certificate.json');
+      await given('a document pair and a passing compiled-verifier result', async () => {
+        await Promise.all([
+          fs.writeFile(originalPath, await makeMinimalDocx(['Original text'])),
+          fs.writeFile(revisedPath, await makeMinimalDocx(['Revised text'])),
+        ]);
+      });
+
+      const passed = certificate('passed');
+      let result: Awaited<ReturnType<typeof runCompareCommand>>;
+      await when('the caller requests a certificate artifact', async () => {
+        result = await runCompareCommand(
+          { originalPath, revisedPath, outputPath, certificatePath },
+          { compare: async (_original, _revised, options) => {
+            expect(options?.leanXmlVerifier).toEqual({ enabled: true });
+            return comparisonResult(passed);
+          } },
+        );
+      });
+
+      await then('the JSON result and durable artifact carry the same certificate', async () => {
+        expect(result.verification).toEqual(passed);
+        expect(result.certificate_path).toBe(certificatePath);
+        expect(await fs.readFile(outputPath, 'utf8')).toBe('verified-redline');
+        expect(JSON.parse(await fs.readFile(certificatePath, 'utf8'))).toEqual(passed);
+      });
+    },
+  );
+
+  test.openspec('[CLI-VERIFY-03] Requested verification fails closed')(
+    'writes neither output when requested verification does not pass',
+    async ({ given, when, then }: AllureBddContext) => {
+      const tmpDir = await createTrackedTempDir('safe-docx-compare-rejected-');
+      const originalPath = path.join(tmpDir, 'original.docx');
+      const revisedPath = path.join(tmpDir, 'revised.docx');
+      const outputPath = path.join(tmpDir, 'must-not-exist.docx');
+      const certificatePath = path.join(tmpDir, 'must-not-exist.json');
+      await given('a document pair and a non-passing verifier result', async () => {
+        await Promise.all([
+          fs.writeFile(originalPath, await makeMinimalDocx(['Original text'])),
+          fs.writeFile(revisedPath, await makeMinimalDocx(['Revised text'])),
+        ]);
+      });
+
+      await when('verified comparison returns not_run', async () => {
+        await expect(runCompareCommand(
+          {
+            originalPath,
+            revisedPath,
+            outputPath,
+            certificatePath,
+            verify: true,
+          },
+          {
+            compare: async () =>
+              comparisonResult(certificate('not_run', 'unsupported package subset')),
+          },
+        )).rejects.toThrow(
+          'Verified comparison did not pass (not_run): unsupported package subset',
+        );
+      });
+
+      await then('neither requested artifact was published', async () => {
+        await expect(fs.stat(outputPath)).rejects.toThrow();
+        await expect(fs.stat(certificatePath)).rejects.toThrow();
+      });
+    },
+  );
+
+  test.openspec('[CLI-VERIFY-04] Ordinary comparison remains unchanged')(
+    'does not configure the verifier without an explicit request',
+    async () => {
+      const tmpDir = await createTrackedTempDir('safe-docx-compare-unverified-');
+      const originalPath = path.join(tmpDir, 'original.docx');
+      const revisedPath = path.join(tmpDir, 'revised.docx');
+      await Promise.all([
+        fs.writeFile(originalPath, await makeMinimalDocx(['Original text'])),
+        fs.writeFile(revisedPath, await makeMinimalDocx(['Revised text'])),
+      ]);
+
+      await runCompareCommand(
+        { originalPath, revisedPath },
+        { compare: async (_original, _revised, options) => {
+          expect(options?.leanXmlVerifier).toBeUndefined();
+          return comparisonResult();
+        } },
+      );
+    },
+  );
+});
+
+const leanCheckerPath = path.resolve(
+  __dirname,
+  '../../../../../verification/lean/.lake/build/bin/leanDocxChecker',
+);
+const describeWithCompiledLean = existsSync(leanCheckerPath) ? describe : describe.skip;
+
+describeWithCompiledLean('safe-docx verified comparison performance', () => {
+  test
+    .openspec('[CLI-VERIFY-05] Public real-document verification meets the budget')(
+    'compares and certifies the public NVCA-derived pair within ten seconds',
+    async () => {
+      const tmpDir = await createTrackedTempDir('safe-docx-cli-verified-nvca-');
+      const originalPath = path.resolve(
+        __dirname,
+        '../../../../../tests/test_documents/nvca-regression/source.docx',
+      );
+      const revisedPath = path.join(tmpDir, 'minimally-revised.docx');
+      const outputPath = path.join(tmpDir, 'verified-redline.docx');
+      const original = await fs.readFile(originalPath);
+      const revised = await DocxDocument.load(original);
+      const paragraph = revised.getParagraphs().find((candidate) => {
+        const text = getParagraphText(candidate);
+        return text.length >= 20 &&
+          candidate.getElementsByTagNameNS(OOXML.W_NS, 'fldChar').length === 0;
+      });
+      if (!paragraph) throw new Error('public NVCA fixture has no editable body paragraph');
+      const paragraphText = getParagraphText(paragraph);
+      replaceParagraphTextRange(
+        paragraph,
+        0,
+        1,
+        paragraphText[0] === 'A' ? 'B' : 'A',
+      );
+      await fs.writeFile(
+        revisedPath,
+        (await revised.toBuffer({ cleanBookmarks: false })).buffer,
+      );
+      const previousChecker = process.env.SAFE_DOCX_LEAN_XML_CHECKER;
+      process.env.SAFE_DOCX_LEAN_XML_CHECKER = leanCheckerPath;
+      try {
+        const started = performance.now();
+        const result = await runCompareCommand({
+          originalPath,
+          revisedPath,
+          outputPath,
+          verify: true,
+        });
+        const elapsedMs = performance.now() - started;
+        expect(result.verification?.status, result.verification?.reason).toBe('passed');
+        expect(result.verification?.checkerProtocolVersion).toBe(7);
+        expect(result.mode).toBe('inplace');
+        expect(elapsedMs, `verified comparison took ${elapsedMs.toFixed(0)}ms`).toBeLessThanOrEqual(
+          10_000,
+        );
+      } finally {
+        if (previousChecker === undefined) {
+          delete process.env.SAFE_DOCX_LEAN_XML_CHECKER;
+        } else {
+          process.env.SAFE_DOCX_LEAN_XML_CHECKER = previousChecker;
+        }
+      }
+    },
+    20_000,
+  );
 });

--- a/packages/docx-mcp/src/cli/commands/compare.ts
+++ b/packages/docx-mcp/src/cli/commands/compare.ts
@@ -1,6 +1,11 @@
-import { readFile, writeFile, mkdir } from 'node:fs/promises';
-import { dirname, resolve } from 'node:path';
-import { compareDocuments, type CompareOptions } from '@usejunior/docx-compare';
+import { randomUUID } from 'node:crypto';
+import { readFile, writeFile, mkdir, rename, rm } from 'node:fs/promises';
+import { basename, dirname, join, resolve } from 'node:path';
+import {
+  compareDocuments,
+  type CompareOptions,
+  type DocumentIntegrityCertificate,
+} from '@usejunior/docx-compare';
 import { DEFAULT_RECONSTRUCTION_MODE } from '../../tools/comparison_defaults.js';
 
 const SUPPORTED_ENGINES: ReadonlySet<NonNullable<CompareOptions['engine']>> = new Set([
@@ -16,6 +21,8 @@ export interface CompareCommandArgs {
   mode?: string;
   author?: string;
   premergeRuns?: boolean;
+  verify?: boolean;
+  certificatePath?: string;
 }
 
 export interface CompareCommandResult {
@@ -26,6 +33,30 @@ export interface CompareCommandResult {
   fallback_reason?: string;
   bytes: number;
   stats: unknown;
+  verification?: DocumentIntegrityCertificate;
+  certificate_path?: string;
+}
+
+export interface CompareCommandDependencies {
+  compare: typeof compareDocuments;
+}
+
+const DEFAULT_DEPENDENCIES: CompareCommandDependencies = {
+  compare: compareDocuments,
+};
+
+async function writeFileAtomically(target: string, contents: Buffer | string): Promise<void> {
+  await mkdir(dirname(target), { recursive: true });
+  const temporary = join(
+    dirname(target),
+    `.${basename(target)}.${process.pid}.${randomUUID()}.tmp`,
+  );
+  try {
+    await writeFile(temporary, contents, { flag: 'wx' });
+    await rename(temporary, target);
+  } finally {
+    await rm(temporary, { force: true });
+  }
 }
 
 function normalizeEngine(raw: string | undefined): NonNullable<CompareOptions['engine']> {
@@ -48,28 +79,48 @@ function defaultOutputPath(revisedPath: string, engine: string, mode: 'inplace' 
   return revisedPath.replace(/\.docx$/i, '') + `.REDLINE.${engine}.${mode}.docx`;
 }
 
-export async function runCompareCommand(args: CompareCommandArgs): Promise<CompareCommandResult> {
+export async function runCompareCommand(
+  args: CompareCommandArgs,
+  dependencies: CompareCommandDependencies = DEFAULT_DEPENDENCIES,
+): Promise<CompareCommandResult> {
   const engine = normalizeEngine(args.engine);
   const mode = normalizeMode(args.mode);
 
   const originalAbs = resolve(args.originalPath);
   const revisedAbs = resolve(args.revisedPath);
   const outputAbs = resolve(args.outputPath ?? defaultOutputPath(revisedAbs, engine, mode));
+  const certificateAbs =
+    args.certificatePath === undefined ? undefined : resolve(args.certificatePath);
+  const verify = args.verify === true || certificateAbs !== undefined;
+
+  if (certificateAbs === outputAbs) {
+    throw new Error('The certificate path must differ from the redline output path.');
+  }
 
   const [originalBuffer, revisedBuffer] = await Promise.all([
     readFile(originalAbs),
     readFile(revisedAbs),
   ]);
 
-  const result = await compareDocuments(originalBuffer, revisedBuffer, {
+  const result = await dependencies.compare(originalBuffer, revisedBuffer, {
     engine,
     author: args.author ?? 'Comparison',
     reconstructionMode: mode,
     premergeRuns: args.premergeRuns,
+    leanXmlVerifier: verify ? { enabled: true } : undefined,
   });
 
-  await mkdir(dirname(outputAbs), { recursive: true });
-  await writeFile(outputAbs, result.document);
+  const verification = result.documentIntegrity;
+  if (verify && verification?.status !== 'passed') {
+    const status = verification?.status ?? 'not_run';
+    const reason = verification?.reason ?? 'The verifier returned no certificate.';
+    throw new Error(`Verified comparison did not pass (${status}): ${reason}`);
+  }
+
+  if (certificateAbs && verification) {
+    await writeFileAtomically(certificateAbs, `${JSON.stringify(verification, null, 2)}\n`);
+  }
+  await writeFileAtomically(outputAbs, result.document);
 
   return {
     output: outputAbs,
@@ -79,5 +130,7 @@ export async function runCompareCommand(args: CompareCommandArgs): Promise<Compa
     fallback_reason: result.fallbackReason,
     bytes: result.document.length,
     stats: result.stats,
+    verification,
+    certificate_path: certificateAbs,
   };
 }

--- a/packages/docx-mcp/src/cli/help.ts
+++ b/packages/docx-mcp/src/cli/help.ts
@@ -45,6 +45,8 @@ export function renderTopLevelHelp(): string {
   lines.push('  serve                                       Start the MCP server (default)');
   lines.push('  compare <original> <revised> [output]       Compare two DOCX files and write redline output');
   lines.push('    --mode <inplace|rebuild>                   Reconstruction mode (default: inplace)');
+  lines.push('    --verify                                  Require a passing Lean verifier certificate');
+  lines.push('    --certificate <path>                      Verify and write the certificate as JSON');
   lines.push('                                                Compare stats count revision ranges; atom totals use *Atoms fields');
   lines.push('  edit <file> [--replace ...] [-o output]     Batch edit a DOCX file');
   lines.push('  grep "pattern" <file> [files...]            Search DOCX files for text');

--- a/packages/docx-mcp/src/cli/index.test.ts
+++ b/packages/docx-mcp/src/cli/index.test.ts
@@ -79,6 +79,9 @@ describe('safe-docx CLI routing', () => {
         'Junior',
         '--premerge-runs',
         'true',
+        '--verify',
+        '--certificate',
+        'certificate.json',
       ]);
     });
 
@@ -92,6 +95,8 @@ describe('safe-docx CLI routing', () => {
         mode: 'inplace',
         author: 'Junior',
         premergeRuns: true,
+        verify: true,
+        certificatePath: 'certificate.json',
       });
       expect(serve).not.toHaveBeenCalled();
       expect(output).toHaveLength(1);
@@ -126,6 +131,8 @@ describe('safe-docx CLI routing', () => {
       expect(output[0]).toContain('safe-docx CLI');
       expect(output[0]).toContain('compare <original> <revised> [output]');
       expect(output[0]).toContain('Reconstruction mode (default: inplace)');
+      expect(output[0]).toContain('--verify');
+      expect(output[0]).toContain('--certificate <path>');
       expect(serve).not.toHaveBeenCalled();
       expect(compare).not.toHaveBeenCalled();
     });

--- a/packages/docx-mcp/src/cli/index.ts
+++ b/packages/docx-mcp/src/cli/index.ts
@@ -66,6 +66,12 @@ function parseCompareArgs(args: string[]): CompareCommandArgs {
       case '--premerge-runs':
         options.premergeRuns = parseBoolean(consumeValue(token), token);
         break;
+      case '--verify':
+        options.verify = true;
+        break;
+      case '--certificate':
+        options.certificatePath = consumeValue(token);
+        break;
       default:
         throw new Error(`Unknown option for compare command: ${token}`);
     }

--- a/scripts/check_lean_xml_checker_coverage.mjs
+++ b/scripts/check_lean_xml_checker_coverage.mjs
@@ -262,8 +262,13 @@ for (const required of [
 if (selector.includes('selectionCompleteProof') || selector.includes('structure SelectorResult')) {
   errors.push('selector theorem results must not carry caller-supplied proof fields');
 }
-if (!selector.includes('if isDirectory then throw')) {
-  errors.push('classic ZIP policy must explicitly reject directory records');
+if (!selector.includes('if isDirectory &&') ||
+    !selector.includes('ZIP directory entry is not an inert placeholder') ||
+    !typedCommentIntegrity.includes('if entry.isDirectory then') ||
+    !executable.includes('archive extraction target is a directory')) {
+  errors.push(
+    'classic ZIP policy must admit only inert directory placeholders and reject them as selected XML',
+  );
 }
 if (ledger.limits?.ordinaryEnvelopeEvidence?.producer !==
     'verification/lean/ProtocolV7OrdinaryEnvelopeWitness.lean' ||

--- a/verification/lean/LeanDocxChecker.lean
+++ b/verification/lean/LeanDocxChecker.lean
@@ -1109,6 +1109,7 @@ structure SnapshotExtractionEvidence where
   selectedPartPath : String
   entry : ZipEntry
   selectedEntryExact : zipIndex.find? selectedPartPath = some entry
+  selectedEntryRegular : entry.isDirectory = false
   centralOffset : Nat
   centralSize : Nat
   compressedPayload : ByteArray
@@ -1132,38 +1133,44 @@ def extractPart (package : Package) (partPath : String) : IO ExtractedPart := do
   match hFind : package.index.find? partPath with
   | none => return .missing
   | some entry =>
-    let output ← runBounded "unzip" #["-p", "--", package.snapshotPath, entry.name]
-      entry.expandedSize
-    if output.exitCode != 0 then
-      throw (IO.userError
-        s!"archive extraction failed for {partPath}: {decodeDiagnostics output.stderr}")
-    if hSize : output.stdout.size = entry.expandedSize then
-      if hCrc : crc32 output.stdout = entry.crc32 then
-        return .present {
-          packageBytes := package.bytes
-          snapshotBytes := package.snapshotBytes
-          snapshotPath := package.snapshotPath
-          snapshotWriteCount := package.snapshotWriteCount
-          zipIndex := package.index
-          zipIndexExact := package.indexExact
-          selectedPartPath := partPath
-          entry
-          selectedEntryExact := hFind
-          centralOffset := package.index.centralOffset
-          centralSize := package.index.centralSize
-          compressedPayload := package.bytes.extract entry.dataOffset entry.localSpanEnd
-          decompressedBytes := output.stdout
-          extractionInvocationCount := 1
-          externalDecompressionTrusted := true
-          snapshotBytesExact := package.snapshotBytesExact
-          compressedPayloadExact := rfl
-          decompressedSizeExact := hSize
-          decompressedCrcExact := hCrc
-        }
-      else
-        throw (IO.userError s!"archive extraction CRC mismatch for {partPath}")
+    if hDirectory : entry.isDirectory then
+      throw (IO.userError s!"archive extraction target is a directory: {partPath}")
     else
-      throw (IO.userError s!"archive extraction size mismatch for {partPath}")
+      have hRegular : entry.isDirectory = false := by
+        simpa using hDirectory
+      let output ← runBounded "unzip" #["-p", "--", package.snapshotPath, entry.name]
+        entry.expandedSize
+      if output.exitCode != 0 then
+        throw (IO.userError
+          s!"archive extraction failed for {partPath}: {decodeDiagnostics output.stderr}")
+      if hSize : output.stdout.size = entry.expandedSize then
+        if hCrc : crc32 output.stdout = entry.crc32 then
+          return .present {
+            packageBytes := package.bytes
+            snapshotBytes := package.snapshotBytes
+            snapshotPath := package.snapshotPath
+            snapshotWriteCount := package.snapshotWriteCount
+            zipIndex := package.index
+            zipIndexExact := package.indexExact
+            selectedPartPath := partPath
+            entry
+            selectedEntryExact := hFind
+            selectedEntryRegular := hRegular
+            centralOffset := package.index.centralOffset
+            centralSize := package.index.centralSize
+            compressedPayload := package.bytes.extract entry.dataOffset entry.localSpanEnd
+            decompressedBytes := output.stdout
+            extractionInvocationCount := 1
+            externalDecompressionTrusted := true
+            snapshotBytesExact := package.snapshotBytesExact
+            compressedPayloadExact := rfl
+            decompressedSizeExact := hSize
+            decompressedCrcExact := hCrc
+          }
+        else
+          throw (IO.userError s!"archive extraction CRC mismatch for {partPath}")
+      else
+        throw (IO.userError s!"archive extraction size mismatch for {partPath}")
 
 def partLimitExceeded (package : Package) (partPath : String) : Bool :=
   match package.index.find? partPath with
@@ -5455,7 +5462,8 @@ theorem production_comment_part_admitted_sound
     · exact hSnapshot.trans hExtractionPackage
     · refine ⟨?_, part.parseEvidence.extraction.entry, ?_,
         hNormalizedPath, rfl, rfl, rfl, rfl, rfl,
-        rfl, hBounds.1, hBounds.2.1, hBounds.2.2.1,
+        rfl, part.parseEvidence.extraction.selectedEntryRegular,
+        hBounds.2.1, hBounds.2.2.1,
         hBounds.2.2.2.1, ?_, hBounds.2.2.2.2, ?_, hPayloadSize⟩
       · simpa [hExtractionPackage, hPackage] using hPayload
       · simpa [hIndex] using hSelectedEntryAtIdentity

--- a/verification/lean/Tier2/CommentReferenceIntegrity/Semantics.lean
+++ b/verification/lean/Tier2/CommentReferenceIntegrity/Semantics.lean
@@ -1335,7 +1335,9 @@ def IndependentBinaryIndexOf
   (∀ entry ∈ index.entries,
     (index.entries.filter (·.name == entry.name)).length = 1) ∧
   ∀ entry ∈ index.entries,
-    entry.isDirectory = false ∧
+    (entry.isDirectory = true →
+      entry.method = 0 ∧ entry.crc32 = 0 ∧
+      entry.compressedSize = 0 ∧ entry.expandedSize = 0) ∧
     entry.localHeaderOffset + 30 ≤ entry.dataOffset ∧
     entry.dataOffset ≤ entry.localSpanEnd ∧
     entry.localSpanEnd ≤ index.centralOffset ∧
@@ -1356,7 +1358,12 @@ def independentBinaryIndexCheck
   index.entries.all (fun entry =>
     decide ((index.entries.filter (·.name == entry.name)).length = 1)) &&
   index.entries.all fun entry =>
-    decide (entry.isDirectory = false) &&
+    (if entry.isDirectory then
+      decide (entry.method = 0) &&
+      decide (entry.crc32 = 0) &&
+      decide (entry.compressedSize = 0) &&
+      decide (entry.expandedSize = 0)
+     else true) &&
     decide (entry.localHeaderOffset + 30 ≤ entry.dataOffset) &&
     decide (entry.dataOffset ≤ entry.localSpanEnd) &&
     decide (entry.localSpanEnd ≤ index.centralOffset) &&
@@ -1373,8 +1380,12 @@ theorem independent_binary_index_check_sound
   have hEntry := h.2 entry hMember
   unfold localFileHeaderSignatureCheck at hEntry
   simp only [Bool.and_eq_true, decide_eq_true_eq] at hEntry
-  refine ⟨hEntry.1.1.1.1, hEntry.1.1.1.2, hEntry.1.1.2,
-    hEntry.1.2, ?_⟩
+  refine ⟨?_, hEntry.1.1.1.2, hEntry.1.1.2, hEntry.1.2, ?_⟩
+  intro hDirectory
+  simp only [hDirectory, ↓reduceIte, Bool.and_eq_true,
+    decide_eq_true_eq] at hEntry
+  rcases hEntry.1.1.1.1 with ⟨⟨⟨hMethod, hCrc⟩, hCompressed⟩, hExpanded⟩
+  exact ⟨hMethod, hCrc, hCompressed, hExpanded⟩
   unfold LocalFileHeaderSignatureAt
   simpa [byteAtEquals, and_assoc] using hEntry.2
 

--- a/verification/lean/Tier2/CommentReferenceIntegrity/TypedSemantics.lean
+++ b/verification/lean/Tier2/CommentReferenceIntegrity/TypedSemantics.lean
@@ -525,7 +525,10 @@ def typedEntryLocalHeaderCheck
   typedZipNameEncodingCheck entry.name entry.flags &&
   typedZipFlagsAllowed entry.method entry.flags &&
   (entry.method == 0 || entry.method == 8) &&
-  !entry.isDirectory &&
+  (if entry.isDirectory then
+    entry.method == 0 && entry.crc32 == 0 &&
+      entry.compressedSize == 0 && entry.expandedSize == 0
+   else true) &&
   typedLocalHeaderSignatureCheck packageBytes entry.localHeaderOffset &&
   typedUInt16At? packageBytes (entry.localHeaderOffset + 6) =
     some entry.flags &&
@@ -594,9 +597,14 @@ def typedCentralEntriesCheck (bytes : ByteArray) (stop : Nat) :
       (entry.method == 0 || entry.method == 8) &&
       typedSafeEntryNameCheck entry.name entry.isDirectory &&
       typedZipNameEncodingCheck entry.name entry.flags &&
-      !entry.isDirectory &&
-      !typedZipBitSet (externalAttributes.getD 0) 4 &&
-      (unixType == 0 || unixType == 8) &&
+      (if entry.isDirectory then
+        (typedZipBitSet (externalAttributes.getD 0) 4 || unixType == 4) &&
+        (unixType == 0 || unixType == 4) &&
+        entry.method == 0 && entry.crc32 == 0 &&
+        entry.compressedSize == 0 && entry.expandedSize == 0
+       else
+        !typedZipBitSet (externalAttributes.getD 0) 4 &&
+        (unixType == 0 || unixType == 8)) &&
       typedByteSliceEquals bytes (position + 46) entry.name.bytes &&
       typedZipExtraFieldsCheck bytes
         (position + 46 + entry.name.bytes.length) (extraLength.getD 0) &&

--- a/verification/lean/Tier2/RelationshipStorySelector.lean
+++ b/verification/lean/Tier2/RelationshipStorySelector.lean
@@ -239,7 +239,9 @@ def parseCentralEntries (bytes : ByteArray) (eocd : Eocd) : Except String (List 
       let isDirectory := dosDirectory || unixType == 4
       if ![0, 4, 8].contains unixType then throw "non-regular ZIP entry is unsupported"
       if isDirectory != name.endsWith "/" then throw "ZIP directory identity is ambiguous"
-      if isDirectory then throw s!"ZIP directory entry is unsupported: {name}"
+      if isDirectory &&
+          (method != 0 || crc32 != 0 || compressedSize != 0 || expandedSize != 0) then
+        throw s!"ZIP directory entry is not an inert placeholder: {name}"
       loop remaining next
         (entries ++ [{
           name := name

--- a/verification/registry/lean-xml-checker-coverage.json
+++ b/verification/registry/lean-xml-checker-coverage.json
@@ -110,7 +110,7 @@
   "packagePolicy": [
     "Lean constructs a bounded binary classic single-disk ZIP central/local index before extraction",
     "ZIP64, encryption, data descriptors, unsupported methods or flag bits, ambiguous names, duplicate names, unsafe paths, and overlapping local spans reject as not_run",
-    "ZIP directory records are rejected during binary indexing; only regular file entries enter the trusted inventory",
+    "safe zero-byte stored ZIP directory placeholders remain in the trusted inventory for limits and span checks but cannot be selected as XML; ambiguous, non-empty, compressed, symlink, and special entries reject",
     "unzip -p -- is invoked only for one exact indexed safe name; output length and CRC-32 must match the binary index"
   ],
   "checkedProperties": [


### PR DESCRIPTION
## Summary

- add `safe-docx compare --verify` and `--certificate <path>`
- fail closed before publishing a redline when the Lean certificate does not pass
- use a 10-second default verifier timeout and exercise a public NVCA-derived document pair
- admit only inert ZIP directory placeholders while proving they cannot be selected as XML stories

## Evidence

- full mandatory pre-submit sequence passes
- full Lean build passes (6,628 jobs)
- axiom audit matches the reviewed production boundary: `Classical.choice`, `Quot.sound`, `propext`
- no `sorry` in Lean sources
- strict OpenSpec validation passes
- public verified CLI performance gate: 6.65 seconds under full-suite load (10-second ceiling)

## Notes

Ordinary CLI comparisons remain unverified unless explicitly requested. Certificate and redline files are published only after verification passes. No confidential corpus material or identifying metadata is included.

Fixes #775