### PR TITLE
test: repair verified CLI evidence gates

### DIFF
--- a/openspec/changes/add-verified-comparison-cli/proposal.md
+++ b/openspec/changes/add-verified-comparison-cli/proposal.md
@@ -23,9 +23,8 @@ timeout does not match its implementation.
 
 ## Impact
 
-- Affected specs: `docx-comparison`
+- Affected specs: `mcp-server`, `docx-comparison`
 - Affected code: CLI comparison parsing and command execution, verifier option
   defaults, Lean ZIP inventory parsing and typed semantics, tests, and CLI help
 - Tracking: GitHub issue #775
 - Privacy: only committed public or sanitized fixtures are permitted
-

--- a/openspec/changes/add-verified-comparison-cli/specs/docx-comparison/spec.md
+++ b/openspec/changes/add-verified-comparison-cli/specs/docx-comparison/spec.md
@@ -1,56 +1,5 @@
 ## ADDED Requirements
 
-### Requirement: CLI comparisons can require a passing verifier certificate
-
-The installed Safe DOCX CLI SHALL expose an opt-in verified comparison mode.
-When verification is requested, the CLI SHALL run the compiled Lean verifier
-over the original, revised, and compared packages, SHALL expose the complete
-public document-integrity certificate in its JSON result, and SHALL publish no
-redline or certificate artifact unless the certificate status is `passed`.
-Verification SHALL remain disabled when it is not explicitly requested.
-
-#### Scenario: [CLI-VERIFY-01] Verified comparison returns a passing certificate
-
-- **GIVEN** a supported inplace document pair and an available compiled checker
-- **WHEN** the user runs `safe-docx compare` with `--verify`
-- **THEN** the comparison SHALL run the compiled verifier
-- **AND** the CLI JSON SHALL include its passing public certificate
-- **AND** the redline SHALL be written only after that passing result exists
-
-#### Scenario: [CLI-VERIFY-02] Certificate path implies verified comparison
-
-- **WHEN** the user supplies `--certificate <path>`
-- **THEN** verification SHALL be enabled
-- **AND** the CLI SHALL atomically write the same public certificate returned in
-  its JSON result
-
-#### Scenario: [CLI-VERIFY-03] Requested verification fails closed
-
-- **WHEN** the checker is missing, times out, returns malformed output, reports
-  `failed`, `not_run`, or `not_applicable`, or the comparison falls back to an
-  unsupported reconstruction mode
-- **THEN** the command SHALL fail before publishing the redline or certificate
-- **AND** the error SHALL identify the non-passing verification status or reason
-
-#### Scenario: [CLI-VERIFY-04] Ordinary comparison remains unchanged
-
-- **WHEN** neither `--verify` nor `--certificate` is supplied
-- **THEN** the CLI SHALL not invoke the compiled verifier
-- **AND** its existing comparison output contract SHALL remain compatible
-
-### Requirement: Verified CLI comparisons use a ten-second assurance budget
-
-The production verifier default timeout SHALL be 10,000 milliseconds. A focused
-end-to-end gate SHALL compare and certify a committed public NVCA-derived DOCX
-pair within 10 seconds, excluding checker compilation from the timed region.
-
-#### Scenario: [CLI-VERIFY-05] Public real-document verification meets the budget
-
-- **GIVEN** the compiled checker and committed public NVCA-derived fixture
-- **WHEN** the focused verified comparison gate runs
-- **THEN** the certificate SHALL pass using protocol v7
-- **AND** total comparison plus certificate latency SHALL not exceed 10 seconds
-
 ### Requirement: Inert ZIP directory placeholders are accepted but never selected
 
 The compiled verifier SHALL retain a ZIP directory placeholder in its trusted

--- a/openspec/changes/add-verified-comparison-cli/specs/mcp-server/spec.md
+++ b/openspec/changes/add-verified-comparison-cli/specs/mcp-server/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: CLI comparisons can require a passing verifier certificate
+
+The installed Safe DOCX CLI SHALL expose an opt-in verified comparison mode.
+When verification is requested, the CLI SHALL run the compiled Lean verifier
+over the original, revised, and compared packages, SHALL expose the complete
+public document-integrity certificate in its JSON result, and SHALL publish no
+redline or certificate artifact unless the certificate status is `passed`.
+Verification SHALL remain disabled when it is not explicitly requested.
+
+#### Scenario: [CLI-VERIFY-01] Verified comparison returns a passing certificate
+
+- **GIVEN** a supported inplace document pair and an available compiled checker
+- **WHEN** the user runs `safe-docx compare` with `--verify`
+- **THEN** the comparison SHALL run the compiled verifier
+- **AND** the CLI JSON SHALL include its passing public certificate
+- **AND** the redline SHALL be written only after that passing result exists
+
+#### Scenario: [CLI-VERIFY-02] Certificate path implies verified comparison
+
+- **WHEN** the user supplies `--certificate <path>`
+- **THEN** verification SHALL be enabled
+- **AND** the CLI SHALL atomically write the same public certificate returned in
+  its JSON result
+
+#### Scenario: [CLI-VERIFY-03] Requested verification fails closed
+
+- **WHEN** the checker is missing, times out, returns malformed output, reports
+  `failed`, `not_run`, or `not_applicable`, or the comparison falls back to an
+  unsupported reconstruction mode
+- **THEN** the command SHALL fail before publishing the redline or certificate
+- **AND** the error SHALL identify the non-passing verification status or reason
+
+#### Scenario: [CLI-VERIFY-04] Ordinary comparison remains unchanged
+
+- **WHEN** neither `--verify` nor `--certificate` is supplied
+- **THEN** the CLI SHALL not invoke the compiled verifier
+- **AND** its existing comparison output contract SHALL remain compatible
+
+### Requirement: Verified CLI comparisons use a ten-second assurance budget
+
+The production verifier default timeout SHALL be 10,000 milliseconds. A focused
+end-to-end gate SHALL compare and certify a committed public NVCA-derived DOCX
+pair within 10 seconds, excluding checker compilation from the timed region.
+
+#### Scenario: [CLI-VERIFY-05] Public real-document verification meets the budget
+
+- **GIVEN** the compiled checker and committed public NVCA-derived fixture
+- **WHEN** the focused verified comparison gate runs
+- **THEN** the certificate SHALL pass using protocol v7
+- **AND** total comparison plus certificate latency SHALL not exceed 10 seconds

--- a/packages/docx-mcp/src/cli/commands/compare.test.ts
+++ b/packages/docx-mcp/src/cli/commands/compare.test.ts
@@ -20,7 +20,8 @@ import {
 
 registerCleanup();
 
-const test = testAllure.epic('Document Editing').withLabels({ feature: 'CLI Comparison' });
+const TEST_FEATURE = 'add-verified-comparison-cli';
+const test = testAllure.epic('Document Editing').withLabels({ feature: TEST_FEATURE });
 
 const zeroStats = {
   insertions: 0,

--- a/verification/lean/ProtocolV7ProjectionDriftWitnesses.lean
+++ b/verification/lean/ProtocolV7ProjectionDriftWitnesses.lean
@@ -28,32 +28,35 @@ def fixtureExtraction : Except String SnapshotExtractionEvidence :=
     match hFind : index.find? "word/document.xml" with
     | none => .error "fixture lacks word/document.xml"
     | some entry =>
-      if hSize : fixtureXml.toUTF8.size = entry.expandedSize then
-        if hCrc : crc32 fixtureXml.toUTF8 = entry.crc32 then
-          .ok {
-            packageBytes := fixturePackageBytes
-            snapshotBytes := fixturePackageBytes
-            snapshotPath := "/supervisor-owned/package-fixture/package.docx"
-            snapshotWriteCount := 1
-            zipIndex := index
-            zipIndexExact := hIndex
-            selectedPartPath := "word/document.xml"
-            entry
-            selectedEntryExact := hFind
-            centralOffset := index.centralOffset
-            centralSize := index.centralSize
-            compressedPayload :=
-              fixturePackageBytes.extract entry.dataOffset entry.localSpanEnd
-            decompressedBytes := fixtureXml.toUTF8
-            extractionInvocationCount := 1
-            externalDecompressionTrusted := true
-            snapshotBytesExact := rfl
-            compressedPayloadExact := rfl
-            decompressedSizeExact := hSize
-            decompressedCrcExact := hCrc
-          }
-        else .error "fixture CRC mismatch"
-      else .error "fixture size mismatch"
+      if hRegular : entry.isDirectory = false then
+        if hSize : fixtureXml.toUTF8.size = entry.expandedSize then
+          if hCrc : crc32 fixtureXml.toUTF8 = entry.crc32 then
+            .ok {
+              packageBytes := fixturePackageBytes
+              snapshotBytes := fixturePackageBytes
+              snapshotPath := "/supervisor-owned/package-fixture/package.docx"
+              snapshotWriteCount := 1
+              zipIndex := index
+              zipIndexExact := hIndex
+              selectedPartPath := "word/document.xml"
+              entry
+              selectedEntryExact := hFind
+              selectedEntryRegular := hRegular
+              centralOffset := index.centralOffset
+              centralSize := index.centralSize
+              compressedPayload :=
+                fixturePackageBytes.extract entry.dataOffset entry.localSpanEnd
+              decompressedBytes := fixtureXml.toUTF8
+              extractionInvocationCount := 1
+              externalDecompressionTrusted := true
+              snapshotBytesExact := rfl
+              compressedPayloadExact := rfl
+              decompressedSizeExact := hSize
+              decompressedCrcExact := hCrc
+            }
+          else .error "fixture CRC mismatch"
+        else .error "fixture size mismatch"
+      else .error "fixture selected entry is not a regular file"
 
 def fixtureParseEvidence : Except String ProductionParseEvidence := do
   let extraction ← fixtureExtraction


### PR DESCRIPTION
## Summary

- give the new CLI OpenSpec tests a deterministic Allure feature ID
- place CLI scenarios under the `mcp-server` delta so strict package coverage maps all 5/5 scenarios
- update the standalone protocol-v7 drift fixture with the required proof that its selected ZIP part is a regular file

## Why this follow-up exists

PR #776 squash-merged while `allure-labels` and `lean-build` were non-blocking failures. This PR contains only the corrections for those two evidence gates; the product implementation is already on `main`.

## Local evidence

- `npm run check:allure-labels`
- strict MCP OpenSpec coverage: 5/5
- `openspec validate add-verified-comparison-cli --strict`
- `lake env lean ProtocolV7ProjectionDriftWitnesses.lean`: 19 witnesses passed

Refs #775 and #776