### PR TITLE
test(docx-compare): preserve verifier integration timeout

### DIFF
--- a/packages/docx-compare/src/baselines/atomizer/leanXmlVerifier.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/leanXmlVerifier.test.ts
@@ -1389,7 +1389,7 @@ describeWithLean('Lean fixed-story package protocol', () => {
       originalDocx, revisedDocx, comparedDocx,
       legacyDocumentXml: { original: '', revised: '', compared: '' },
       reconstructionMode: 'inplace',
-      options: { executablePath: LEAN_EXE },
+      options: { executablePath: LEAN_EXE, timeoutMs: 120_000 },
     });
 
   test.openspec('[LEAN-STORY-01] Fixed stories pass together')(
@@ -2189,7 +2189,7 @@ describeWithLean('Lean direct relationship-story protocol v5', () => {
       originalDocx, revisedDocx, comparedDocx,
       legacyDocumentXml: { original: '', revised: '', compared: '' },
       reconstructionMode: 'inplace',
-      options: { executablePath: LEAN_EXE },
+      options: { executablePath: LEAN_EXE, timeoutMs: 120_000 },
     });
 
   // coverage-rationale: One certificate exposes selection, side identities, and
@@ -4137,7 +4137,7 @@ describeWithLean('Lean compiled package extraction limits', () => {
     comparedDocx: docx,
     legacyDocumentXml: { original: '', revised: '', compared: '' },
     reconstructionMode: 'inplace',
-    options: { executablePath: LEAN_EXE },
+    options: { executablePath: LEAN_EXE, timeoutMs: 120_000 },
   });
 
   test.openspec('[LEAN-STORY-07] Unsafe package extraction fails closed')(


### PR DESCRIPTION
## Summary
- keep the product verifier timeout at 10 seconds
- give corpus-scale compiled-checker integration helpers their historical 120-second test budget
- leave dedicated timeout behavior tests unchanged

## Why
PR #776 intentionally lowered the production default from 120 seconds to 10 seconds. The Lean CI runner then timed out a near-envelope test at 10.264 seconds before it could return the expected failed certificate. This patch separates the integration-test budget from the product default.

## Validation
- exact Lean verifier test file: 104/104 passed in 44.75s
- formerly failing case completed in 6.68s locally
- npm run check:allure-labels
- git diff --check

Ref: #777