### PR TITLE
feat(docx-mcp): add LLM verifier certificate projection

### DIFF
--- a/docs/trust-and-conformance.md
+++ b/docs/trust-and-conformance.md
@@ -66,12 +66,20 @@ The installed CLI exposes the same opt-in boundary:
 safe-docx compare original.docx revised.docx redline.docx --verify
 safe-docx compare original.docx revised.docx redline.docx \
   --certificate redline.certificate.json
+safe-docx compare original.docx revised.docx redline.docx \
+  --certificate redline.certificate.json --certificate-format llm
 ```
 
-`--certificate` implies `--verify`. A verified CLI comparison uses a 10-second
+`--certificate` and `--certificate-format` imply `--verify`. The default
+certificate format is `full`, the unchanged public v1 certificate. Use `llm`
+for a deterministic, versioned projection that defines repeated invariants once,
+groups stories with identical results, and keeps failures, exclusions, hashes,
+and structured protocol evidence explicit for machine reasoning.
+
+A verified CLI comparison uses a 10-second
 checker budget and writes neither artifact unless the certificate passes. The
 command's JSON response includes the certificate under `verification`; the
-optional certificate file contains the same public JSON value.
+optional certificate file contains the same selected JSON value.
 
 The checker validates the documents presented to it. It is not a proof of the TypeScript source code, visual fidelity, or the complete ECMA-376 standard.
 

--- a/docs/trust-and-conformance.md
+++ b/docs/trust-and-conformance.md
@@ -71,10 +71,11 @@ safe-docx compare original.docx revised.docx redline.docx \
 ```
 
 `--certificate` and `--certificate-format` imply `--verify`. The default
-certificate format is `full`, the unchanged public v1 certificate. Use `llm`
-for a deterministic, versioned projection that defines repeated invariants once,
-groups stories with identical results, and keeps failures, exclusions, hashes,
-and structured protocol evidence explicit for machine reasoning.
+certificate format is `llm`: a deterministic, versioned progressive-disclosure
+projection that defines repeated invariants once, groups stories with identical
+results, and keeps failures, exclusions, hashes, and structured protocol
+evidence explicit for machine reasoning. Use `--certificate-format full` to
+request the unchanged canonical public v1 certificate.
 
 A verified CLI comparison uses a 10-second
 checker budget and writes neither artifact unless the certificate passes. The

--- a/openspec/changes/add-llm-verifier-certificate/design.md
+++ b/openspec/changes/add-llm-verifier-certificate/design.md
@@ -1,0 +1,87 @@
+## Context
+
+`DocumentIntegrityCertificate` is the canonical public v1 evidence object. Its
+repetition is useful for direct inspection and backwards compatibility, but it
+is not a token-efficient reasoning protocol. The CLI is the correct projection
+boundary because the Lean checker and comparison library must continue to
+produce the canonical certificate unchanged.
+
+## Goals / Non-Goals
+
+- Goals:
+  - provide an explicit LLM-oriented JSON contract;
+  - preserve every failure, anomaly, exclusion, identity, and hash needed to
+    understand the verification result;
+  - deduplicate repeated claims and uniform invariant outcomes;
+  - make schema, public certificate, and checker protocol versions unambiguous;
+  - keep output deterministic and fail closed.
+- Non-Goals:
+  - alter Lean proofs, checker protocols, or the public v1 certificate;
+  - make `llm` the default in this change;
+  - generate HTML or other human-facing presentation;
+  - interpret exclusions as failures or verified claims.
+
+## Decisions
+
+### Projection boundary and compatibility
+
+The comparison library continues to return `DocumentIntegrityCertificate`.
+The CLI projects it only after verification has passed. `--certificate-format`
+accepts `full` or `llm`; omission means `full`. Supplying the flag implies
+verification, just like `--certificate`.
+
+For `full`, the CLI JSON `verification` field and certificate file retain the
+existing canonical object. For `llm`, both contain the same normalized
+projection. The result also names `certificate_format` when verification is
+present so a caller can select the correct schema without inference.
+
+### Versioned normalized schema
+
+The LLM projection starts with:
+
+- `schemaId: "safe-docx.llm-verification-certificate"`;
+- `schemaVersion: 1`;
+- `verdict`;
+- explicit verifier metadata containing public certificate protocol v1 and the
+  internal checker protocol separately.
+
+The canonical certificate remains the source of truth. The projection carries
+its package/XML hashes, reconstruction mode, reason, exclusions, story
+identities, token counts, and every structured anomaly.
+
+### Stable invariants and grouped results
+
+Six stable invariant IDs replace repeated prose claims. Their definitions occur
+once in deterministic order. Each evaluated fixed or relationship story is
+represented once in a story registry. Stories sharing the same passed, failed,
+and not-evaluated invariant vectors are grouped into one result set that lists
+their story IDs. This preserves the complete evaluation relation without
+repeating claims or identical status maps.
+
+Note and comment evidence has its own compact story-status collection because
+those checks are inventory/topology protocols rather than the six generic
+story invariants.
+
+### Failures and exclusions
+
+No compaction rule may discard non-passing evidence. Presence mismatches,
+fixed-story failures, relationship-selection failures, note failures, and
+comment failures are copied into separately named anomaly arrays. Exclusions
+remain a top-level scope property. An LLM can therefore distinguish failure,
+unavailability, non-evaluation, and out-of-scope behavior without parsing prose.
+
+## Risks / Trade-offs
+
+- The projection duplicates a public contract. Versioning plus fixture-level
+  exact tests prevent silent drift.
+- Hard-coded invariant IDs require deliberate schema evolution if the canonical
+  certificate adds a new generic check. Exhaustiveness helpers and tests make
+  omission fail during development.
+- Keeping `full` as default limits immediate token savings but avoids breaking
+  existing automation.
+
+## Migration Plan
+
+Existing callers require no change. LLM agents add
+`--certificate-format llm`, with or without `--certificate <path>`. A future
+default change, if desired, requires a separate compatibility decision.

--- a/openspec/changes/add-llm-verifier-certificate/design.md
+++ b/openspec/changes/add-llm-verifier-certificate/design.md
@@ -17,7 +17,6 @@ produce the canonical certificate unchanged.
   - keep output deterministic and fail closed.
 - Non-Goals:
   - alter Lean proofs, checker protocols, or the public v1 certificate;
-  - make `llm` the default in this change;
   - generate HTML or other human-facing presentation;
   - interpret exclusions as failures or verified claims.
 
@@ -27,8 +26,10 @@ produce the canonical certificate unchanged.
 
 The comparison library continues to return `DocumentIntegrityCertificate`.
 The CLI projects it only after verification has passed. `--certificate-format`
-accepts `full` or `llm`; omission means `full`. Supplying the flag implies
-verification, just like `--certificate`.
+accepts `full` or `llm`; omission means `llm`. Consumers see the compact verdict
+and summaries first, then can request `full` when they need the canonical
+evidence object. Supplying the flag implies verification, just like
+`--certificate`.
 
 For `full`, the CLI JSON `verification` field and certificate file retain the
 existing canonical object. For `llm`, both contain the same normalized
@@ -77,11 +78,12 @@ unavailability, non-evaluation, and out-of-scope behavior without parsing prose.
 - Hard-coded invariant IDs require deliberate schema evolution if the canonical
   certificate adds a new generic check. Exhaustiveness helpers and tests make
   omission fail during development.
-- Keeping `full` as default limits immediate token savings but avoids breaking
-  existing automation.
+- Making `llm` the default changes the verified CLI response shape for callers
+  that relied on omission. The explicit `full` format is the compatibility
+  escape hatch, and `certificate_format` makes the selected schema unambiguous.
 
 ## Migration Plan
 
-Existing callers require no change. LLM agents add
-`--certificate-format llm`, with or without `--certificate <path>`. A future
-default change, if desired, requires a separate compatibility decision.
+LLM agents require no format flag. Existing callers that consume the canonical
+certificate add `--certificate-format full`, with or without
+`--certificate <path>`.

--- a/openspec/changes/add-llm-verifier-certificate/proposal.md
+++ b/openspec/changes/add-llm-verifier-certificate/proposal.md
@@ -1,0 +1,31 @@
+# Change: Add an LLM-optimized verifier certificate projection
+
+## Why
+
+The canonical public document-integrity certificate is evidence-complete but
+expensive for an LLM to consume. It repeats the same prose claim for every
+story, mixes public and internal protocol versions without an explicit schema
+layer, and requires a model to normalize uniform successes before it can reason
+about failures or scope exclusions.
+
+## What Changes
+
+- Add an opt-in `llm` certificate format to `safe-docx compare` while retaining
+  the existing full public v1 certificate as the default.
+- Define a deterministic, versioned LLM certificate projection with stable
+  invariant IDs, shared definitions, grouped result sets, explicit scope
+  counts, exclusions, anomalies, and cryptographic evidence.
+- Make `--certificate-format llm` affect both CLI JSON and any requested
+  certificate artifact so an LLM does not receive the full redundant value on
+  stdout.
+- Document and test the projection without changing the Lean checker protocol
+  or canonical public certificate.
+
+## Impact
+
+- Affected specs: `mcp-server`
+- Affected code: Safe DOCX CLI certificate projection, flag parsing, help,
+  command tests, and documentation
+- Tracking: GitHub issue #780
+- Compatibility: omitted or explicit `full` format preserves the existing CLI
+  result and artifact shape

--- a/openspec/changes/add-llm-verifier-certificate/proposal.md
+++ b/openspec/changes/add-llm-verifier-certificate/proposal.md
@@ -10,14 +10,15 @@ about failures or scope exclusions.
 
 ## What Changes
 
-- Add an opt-in `llm` certificate format to `safe-docx compare` while retaining
-  the existing full public v1 certificate as the default.
+- Make the LLM certificate projection the default progressive-disclosure layer
+  for `safe-docx compare`, with explicit `full` access to the canonical public
+  v1 certificate.
 - Define a deterministic, versioned LLM certificate projection with stable
   invariant IDs, shared definitions, grouped result sets, explicit scope
   counts, exclusions, anomalies, and cryptographic evidence.
-- Make `--certificate-format llm` affect both CLI JSON and any requested
-  certificate artifact so an LLM does not receive the full redundant value on
-  stdout.
+- Make the selected format affect both CLI JSON and any requested certificate
+  artifact so the default path does not send the full redundant value to an
+  LLM.
 - Document and test the projection without changing the Lean checker protocol
   or canonical public certificate.
 
@@ -27,5 +28,5 @@ about failures or scope exclusions.
 - Affected code: Safe DOCX CLI certificate projection, flag parsing, help,
   command tests, and documentation
 - Tracking: GitHub issue #780
-- Compatibility: omitted or explicit `full` format preserves the existing CLI
-  result and artifact shape
+- Compatibility: explicit `--certificate-format full` preserves the existing
+  CLI result and artifact shape

--- a/openspec/changes/add-llm-verifier-certificate/specs/mcp-server/spec.md
+++ b/openspec/changes/add-llm-verifier-certificate/specs/mcp-server/spec.md
@@ -1,0 +1,67 @@
+## ADDED Requirements
+
+### Requirement: CLI can project verifier evidence for LLM consumption
+
+The installed Safe DOCX CLI SHALL accept
+`--certificate-format <full|llm>` for verified comparisons. Omission or `full`
+SHALL preserve the canonical public v1 certificate shape. `llm` SHALL project
+that canonical certificate into a deterministic
+`safe-docx.llm-verification-certificate` schema without changing the Lean
+checker protocol or the canonical certificate producer. Supplying the format
+flag SHALL imply verification.
+
+#### Scenario: [CLI-CERT-01] Full format remains backward compatible
+
+- **GIVEN** a passing canonical public v1 certificate
+- **WHEN** certificate format is omitted or explicitly `full`
+- **THEN** the CLI JSON and requested artifact SHALL contain the unchanged
+  canonical certificate
+- **AND** the result SHALL identify the emitted format as `full`
+
+#### Scenario: [CLI-CERT-02] LLM format is consistent across outputs
+
+- **GIVEN** a passing canonical public v1 certificate
+- **WHEN** the user selects `--certificate-format llm`
+- **THEN** the CLI JSON and requested artifact SHALL contain the same normalized
+  LLM certificate
+- **AND** the result SHALL identify the emitted format as `llm`
+
+### Requirement: LLM certificate is normalized, versioned, and loss-aware
+
+The LLM certificate SHALL distinguish its schema version, the canonical public
+certificate protocol, and the internal checker protocol. It SHALL place the
+verdict, reconstruction mode, scope counts, exclusions, status summaries, and
+anomalies before detailed evidence. Generic story checks SHALL use stable
+invariant IDs whose prose definitions occur exactly once, and stories with
+identical result vectors SHALL share deterministic grouped result sets.
+
+The projection SHALL retain package and main-XML hashes, story identities and
+token counts, the canonical reason when present, and every presence mismatch,
+fixed-story failure, relationship-selection failure, note-integrity failure,
+and comment-integrity failure. Compaction SHALL NOT turn `failed`, `not_run`,
+`not_applicable`, or `not_evaluated` evidence into a pass or omit it.
+
+#### Scenario: [CLI-CERT-03] Uniform passes are grouped without repeated claims
+
+- **GIVEN** multiple fixed or relationship stories with the same invariant
+  status vector
+- **WHEN** the LLM projection is produced
+- **THEN** those story IDs SHALL share one result set
+- **AND** each invariant claim SHALL occur only in the definitions table
+- **AND** invariant and story status totals SHALL equal the canonical evidence
+
+#### Scenario: [CLI-CERT-04] Non-passing evidence survives projection
+
+- **GIVEN** canonical failed or non-evaluated checks and structured anomalies
+- **WHEN** the LLM projection is produced
+- **THEN** every non-passing invariant relation and anomaly SHALL remain
+  explicitly represented
+- **AND** exclusions SHALL remain distinct from failures
+- **AND** the projection verdict SHALL equal the canonical certificate status
+
+#### Scenario: [CLI-CERT-05] Projection ordering is deterministic
+
+- **WHEN** the same canonical certificate is projected repeatedly
+- **THEN** serialized JSON SHALL be byte-identical
+- **AND** invariant definitions, stories, result sets, and anomaly collections
+  SHALL use their documented stable order

--- a/openspec/changes/add-llm-verifier-certificate/specs/mcp-server/spec.md
+++ b/openspec/changes/add-llm-verifier-certificate/specs/mcp-server/spec.md
@@ -3,17 +3,17 @@
 ### Requirement: CLI can project verifier evidence for LLM consumption
 
 The installed Safe DOCX CLI SHALL accept
-`--certificate-format <full|llm>` for verified comparisons. Omission or `full`
-SHALL preserve the canonical public v1 certificate shape. `llm` SHALL project
-that canonical certificate into a deterministic
+`--certificate-format <full|llm>` for verified comparisons. Omission or `llm`
+SHALL project the canonical public v1 certificate into a deterministic
 `safe-docx.llm-verification-certificate` schema without changing the Lean
-checker protocol or the canonical certificate producer. Supplying the format
-flag SHALL imply verification.
+checker protocol or the canonical certificate producer. Explicit `full` SHALL
+preserve the canonical public v1 certificate shape. Supplying the format flag
+SHALL imply verification.
 
 #### Scenario: [CLI-CERT-01] Full format remains backward compatible
 
 - **GIVEN** a passing canonical public v1 certificate
-- **WHEN** certificate format is omitted or explicitly `full`
+- **WHEN** certificate format is explicitly `full`
 - **THEN** the CLI JSON and requested artifact SHALL contain the unchanged
   canonical certificate
 - **AND** the result SHALL identify the emitted format as `full`
@@ -21,7 +21,7 @@ flag SHALL imply verification.
 #### Scenario: [CLI-CERT-02] LLM format is consistent across outputs
 
 - **GIVEN** a passing canonical public v1 certificate
-- **WHEN** the user selects `--certificate-format llm`
+- **WHEN** certificate format is omitted or explicitly `llm`
 - **THEN** the CLI JSON and requested artifact SHALL contain the same normalized
   LLM certificate
 - **AND** the result SHALL identify the emitted format as `llm`

--- a/openspec/changes/add-llm-verifier-certificate/tasks.md
+++ b/openspec/changes/add-llm-verifier-certificate/tasks.md
@@ -1,0 +1,22 @@
+## 1. Specification
+
+- [x] 1.1 Validate the LLM projection, compatibility, and failure-retention requirements
+
+## 2. Projection
+
+- [x] 2.1 Define the versioned LLM certificate TypeScript contract
+- [x] 2.2 Normalize canonical checks into stable invariant definitions and grouped result sets
+- [x] 2.3 Preserve hashes, scopes, exclusions, story evidence, reasons, and all anomaly arrays
+
+## 3. CLI
+
+- [x] 3.1 Parse and validate `--certificate-format full|llm`
+- [x] 3.2 Emit the selected format consistently in CLI JSON and certificate files
+- [x] 3.3 Preserve omitted/full behavior and fail-closed atomic publication
+- [x] 3.4 Document the new flag and schema semantics
+
+## 4. Evidence
+
+- [x] 4.1 Test deterministic normalization, claim deduplication, grouping, and failure retention
+- [x] 4.2 Test CLI parsing, full compatibility, and LLM artifact/result parity
+- [x] 4.3 Run focused, OpenSpec, and mandatory pre-submit checks

--- a/openspec/changes/add-llm-verifier-certificate/tasks.md
+++ b/openspec/changes/add-llm-verifier-certificate/tasks.md
@@ -12,7 +12,7 @@
 
 - [x] 3.1 Parse and validate `--certificate-format full|llm`
 - [x] 3.2 Emit the selected format consistently in CLI JSON and certificate files
-- [x] 3.3 Preserve omitted/full behavior and fail-closed atomic publication
+- [x] 3.3 Make LLM output the default, preserve explicit full behavior, and keep fail-closed atomic publication
 - [x] 3.4 Document the new flag and schema semantics
 
 ## 4. Evidence

--- a/packages/docx-mcp/src/cli/certificates/llm_certificate.test.ts
+++ b/packages/docx-mcp/src/cli/certificates/llm_certificate.test.ts
@@ -133,40 +133,40 @@ async function documentPaths(prefix: string): Promise<{
 
 describe('LLM verifier certificate projection', () => {
   test.openspec('[CLI-CERT-01] Full format remains backward compatible')(
-    'keeps the canonical certificate unchanged by default and for full',
+    'keeps the canonical certificate unchanged when full is explicit',
     async () => {
       const certificate = canonicalCertificate();
-      for (const certificateFormat of [undefined, 'full'] as const) {
-        const paths = await documentPaths('safe-docx-full-certificate-');
-        const result = await runCompareCommand(
-          { ...paths, certificateFormat },
-          { compare: async () => comparisonResult(certificate) },
-        );
-        expect(result.certificate_format).toBe('full');
-        expect(result.verification).toEqual(certificate);
-        expect(JSON.parse(await fs.readFile(paths.certificatePath, 'utf8'))).toEqual(certificate);
-      }
+      const paths = await documentPaths('safe-docx-full-certificate-');
+      const result = await runCompareCommand(
+        { ...paths, certificateFormat: 'full' },
+        { compare: async () => comparisonResult(certificate) },
+      );
+      expect(result.certificate_format).toBe('full');
+      expect(result.verification).toEqual(certificate);
+      expect(JSON.parse(await fs.readFile(paths.certificatePath, 'utf8'))).toEqual(certificate);
     },
   );
 
   test.openspec('[CLI-CERT-02] LLM format is consistent across outputs')(
     'emits the same normalized certificate in JSON and the requested artifact',
     async () => {
-      const paths = await documentPaths('safe-docx-llm-certificate-');
-      const result = await runCompareCommand(
-        { ...paths, certificateFormat: 'llm' },
-        {
-          compare: async (_original, _revised, options) => {
-            expect(options?.leanXmlVerifier).toEqual({ enabled: true });
-            return comparisonResult(canonicalCertificate());
+      for (const certificateFormat of [undefined, 'llm'] as const) {
+        const paths = await documentPaths('safe-docx-llm-certificate-');
+        const result = await runCompareCommand(
+          { ...paths, certificateFormat },
+          {
+            compare: async (_original, _revised, options) => {
+              expect(options?.leanXmlVerifier).toEqual({ enabled: true });
+              return comparisonResult(canonicalCertificate());
+            },
           },
-        },
-      );
-      expect(result.certificate_format).toBe('llm');
-      expect(result.verification).toMatchObject({ schemaId: LLM_CERTIFICATE_SCHEMA_ID });
-      expect(JSON.parse(await fs.readFile(paths.certificatePath, 'utf8'))).toEqual(
-        result.verification,
-      );
+        );
+        expect(result.certificate_format).toBe('llm');
+        expect(result.verification).toMatchObject({ schemaId: LLM_CERTIFICATE_SCHEMA_ID });
+        expect(JSON.parse(await fs.readFile(paths.certificatePath, 'utf8'))).toEqual(
+          result.verification,
+        );
+      }
     },
   );
 

--- a/packages/docx-mcp/src/cli/certificates/llm_certificate.test.ts
+++ b/packages/docx-mcp/src/cli/certificates/llm_certificate.test.ts
@@ -1,0 +1,290 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import type { CompareResult, DocumentIntegrityCertificate } from '@usejunior/docx-compare';
+import { describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
+import { makeMinimalDocx } from '../../testing/docx_test_utils.js';
+import { createTrackedTempDir, registerCleanup } from '../../testing/session-test-utils.js';
+import { runCompareCommand } from '../commands/compare.js';
+import {
+  LLM_CERTIFICATE_SCHEMA_ID,
+  projectLlmVerificationCertificate,
+} from './llm_certificate.js';
+
+registerCleanup();
+
+const TEST_FEATURE = 'add-llm-verifier-certificate';
+const test = testAllure.epic('Document Editing').withLabels({ feature: TEST_FEATURE });
+const passedCheck = { status: 'passed' as const, claim: 'Canonical repeated claim.' };
+const failedCheck = { status: 'failed' as const, claim: 'Canonical repeated claim.' };
+
+const checks = (fieldCheck = passedCheck) => ({
+  acceptingAllTrackedChangesMatchesRevisedText: passedCheck,
+  rejectingAllTrackedChangesMatchesOriginalText: passedCheck,
+  acceptingAllTrackedChangesKeepsValidFieldStructure: fieldCheck,
+  rejectingAllTrackedChangesKeepsValidFieldStructure: passedCheck,
+  comparedStoryHasNoFieldMarkersInsideDeletions: passedCheck,
+  trackedMoveRangesAreCorrectlyPaired: passedCheck,
+});
+
+function canonicalCertificate(): DocumentIntegrityCertificate {
+  return {
+    status: 'passed',
+    verifier: 'Lean XML triple checker',
+    protocolVersion: 1,
+    checkerProtocolVersion: 7,
+    scope: 'word/document.xml',
+    reconstructionMode: 'inplace',
+    inputSha256: {
+      originalDocumentXml: 'original-xml-sha',
+      revisedDocumentXml: 'revised-xml-sha',
+      comparedDocumentXml: 'compared-xml-sha',
+    },
+    inputPackageSha256: {
+      originalDocx: 'original-package-sha',
+      revisedDocx: 'revised-package-sha',
+      comparedDocx: 'compared-package-sha',
+    },
+    checks: {
+      acceptingAllTrackedChangesMatchesRevisedText: passedCheck,
+      rejectingAllTrackedChangesMatchesOriginalText: passedCheck,
+      acceptingAllTrackedChangesKeepsValidFieldStructure: passedCheck,
+      rejectingAllTrackedChangesKeepsValidFieldStructure: passedCheck,
+      comparedDocumentHasNoFieldMarkersInsideDeletions: passedCheck,
+      trackedMoveRangesAreCorrectlyPaired: passedCheck,
+    },
+    parsedTokenCounts: { original: 10, revised: 11, compared: 12 },
+    fixedStoryScope: ['word/document.xml', 'word/footnotes.xml', 'word/endnotes.xml'],
+    stories: [
+      {
+        name: 'main',
+        status: 'passed',
+        checks: checks(),
+        parsedTokenCounts: { original: 10, revised: 11, compared: 12 },
+        presence: { original: true, revised: true, compared: true },
+      },
+      {
+        name: 'footnotes',
+        status: 'passed',
+        checks: checks(),
+        parsedTokenCounts: { original: 3, revised: 3, compared: 4 },
+        presence: { original: true, revised: true, compared: true },
+      },
+    ],
+    relationshipStories: [
+      {
+        physicalStoryOrdinal: 0,
+        kind: 'header',
+        originalPartPath: 'word/header1.xml',
+        revisedPartPath: 'word/header2.xml',
+        comparedPartPath: 'word/header2.xml',
+        selectingSlotOrdinals: [0, 2],
+        status: 'passed',
+        checks: checks(),
+        parsedTokenCounts: { original: 2, revised: 2, compared: 3 },
+      },
+    ],
+    exclusions: ['visual rendering'],
+  };
+}
+
+function comparisonResult(documentIntegrity: DocumentIntegrityCertificate): CompareResult {
+  return {
+    document: Buffer.from('redline'),
+    stats: {
+      insertions: 0,
+      deletions: 0,
+      modifications: 0,
+      insertedRanges: 0,
+      deletedRanges: 0,
+      insertedAtoms: 0,
+      deletedAtoms: 0,
+      modifiedParagraphs: 0,
+      formatChanges: 0,
+      formatChangeAtoms: 0,
+    },
+    engine: 'atomizer',
+    reconstructionModeRequested: 'inplace',
+    reconstructionModeUsed: 'inplace',
+    documentIntegrity,
+  };
+}
+
+async function documentPaths(prefix: string): Promise<{
+  originalPath: string;
+  revisedPath: string;
+  outputPath: string;
+  certificatePath: string;
+}> {
+  const tmpDir = await createTrackedTempDir(prefix);
+  const originalPath = path.join(tmpDir, 'original.docx');
+  const revisedPath = path.join(tmpDir, 'revised.docx');
+  await Promise.all([
+    fs.writeFile(originalPath, await makeMinimalDocx(['Original'])),
+    fs.writeFile(revisedPath, await makeMinimalDocx(['Revised'])),
+  ]);
+  return {
+    originalPath,
+    revisedPath,
+    outputPath: path.join(tmpDir, 'redline.docx'),
+    certificatePath: path.join(tmpDir, 'certificate.json'),
+  };
+}
+
+describe('LLM verifier certificate projection', () => {
+  test.openspec('[CLI-CERT-01] Full format remains backward compatible')(
+    'keeps the canonical certificate unchanged by default and for full',
+    async () => {
+      const certificate = canonicalCertificate();
+      for (const certificateFormat of [undefined, 'full'] as const) {
+        const paths = await documentPaths('safe-docx-full-certificate-');
+        const result = await runCompareCommand(
+          { ...paths, certificateFormat },
+          { compare: async () => comparisonResult(certificate) },
+        );
+        expect(result.certificate_format).toBe('full');
+        expect(result.verification).toEqual(certificate);
+        expect(JSON.parse(await fs.readFile(paths.certificatePath, 'utf8'))).toEqual(certificate);
+      }
+    },
+  );
+
+  test.openspec('[CLI-CERT-02] LLM format is consistent across outputs')(
+    'emits the same normalized certificate in JSON and the requested artifact',
+    async () => {
+      const paths = await documentPaths('safe-docx-llm-certificate-');
+      const result = await runCompareCommand(
+        { ...paths, certificateFormat: 'llm' },
+        {
+          compare: async (_original, _revised, options) => {
+            expect(options?.leanXmlVerifier).toEqual({ enabled: true });
+            return comparisonResult(canonicalCertificate());
+          },
+        },
+      );
+      expect(result.certificate_format).toBe('llm');
+      expect(result.verification).toMatchObject({ schemaId: LLM_CERTIFICATE_SCHEMA_ID });
+      expect(JSON.parse(await fs.readFile(paths.certificatePath, 'utf8'))).toEqual(
+        result.verification,
+      );
+    },
+  );
+
+  test('rejects an unknown certificate format before reading input files', async () => {
+    await expect(
+      runCompareCommand({
+        originalPath: 'unused-original.docx',
+        revisedPath: 'unused-revised.docx',
+        certificateFormat: 'compact',
+      }),
+    ).rejects.toThrow('Unsupported certificate format: compact. Use full or llm.');
+  });
+
+  test.openspec('[CLI-CERT-03] Uniform passes are grouped without repeated claims')(
+    'defines claims once and groups stories with identical vectors',
+    () => {
+      const projected = projectLlmVerificationCertificate(canonicalCertificate());
+      expect(projected.scope).toMatchObject({ fixedStories: 2, relationshipStories: 1 });
+      expect(projected.statusSummary.genericStories).toEqual({ passed: 3, failed: 0 });
+      expect(projected.statusSummary.invariantRelations).toEqual({
+        passed: 18,
+        failed: 0,
+        not_evaluated: 0,
+      });
+      expect(projected.resultSets).toHaveLength(1);
+      expect(projected.resultSets[0]?.storyIds).toEqual([
+        'fixed:main',
+        'fixed:footnotes',
+        'relationship:0:header',
+      ]);
+      expect(JSON.stringify(projected).match(/Canonical repeated claim\./g)).toBeNull();
+      expect(projected.invariantDefinitions).toHaveLength(6);
+    },
+  );
+
+  test.openspec('[CLI-CERT-04] Non-passing evidence survives projection')(
+    'retains failed relations, structured anomalies, reason, and exclusions',
+    () => {
+      const canonical = canonicalCertificate();
+      canonical.status = 'failed';
+      canonical.reason = 'one or more invariants failed';
+      canonical.stories![0]!.status = 'failed';
+      canonical.stories![0]!.checks.acceptingAllTrackedChangesKeepsValidFieldStructure =
+        failedCheck;
+      canonical.stories![0]!.checks.trackedMoveRangesAreCorrectlyPaired = undefined;
+      canonical.presenceMismatches = [
+        {
+          name: 'footnotes',
+          packagePart: 'word/footnotes.xml',
+          required: false,
+          presence: { original: true, revised: false, combined: true },
+        },
+      ];
+      canonical.fixedStoryFailures = [
+        {
+          code: 'OPTIONAL_STORY_INVALID_XML',
+          name: 'footnotes',
+          side: 'revised',
+          packagePart: 'word/footnotes.xml',
+          detail: 'invalid XML',
+        },
+      ];
+      canonical.relationshipSelectionFailures = [
+        { code: 'MISSING_RELATIONSHIP', detail: 'missing header relationship' },
+      ];
+      canonical.noteIntegrityFailures = [
+        {
+          code: 'MISSING_DEFINITION',
+          side: 'compared',
+          kind: 'footnotes',
+          detail: 'reference has no definition',
+          ordinalSpace: 'reference',
+          firstOccurrenceOrdinal: 0,
+          occurrenceCount: 1,
+        },
+      ];
+      canonical.commentIntegrityFailures = [
+        {
+          code: 'UNMATCHED_RANGE_START',
+          side: 'compared',
+          kind: 'comments',
+          detail: 'range start has no end',
+          ordinalSpace: 'rangeStart',
+          firstOccurrenceOrdinal: 0,
+          occurrenceCount: 1,
+        },
+      ];
+
+      const projected = projectLlmVerificationCertificate(canonical);
+      expect(projected.verdict).toBe('failed');
+      expect(projected.reason).toBe(canonical.reason);
+      expect(projected.scope.exclusions).toEqual(['visual rendering']);
+      expect(projected.statusSummary.invariantRelations).toEqual({
+        passed: 16,
+        failed: 1,
+        not_evaluated: 1,
+      });
+      expect(projected.anomalies).toEqual({
+        presenceMismatches: canonical.presenceMismatches,
+        fixedStoryFailures: canonical.fixedStoryFailures,
+        relationshipSelectionFailures: canonical.relationshipSelectionFailures,
+        noteIntegrityFailures: canonical.noteIntegrityFailures,
+        commentIntegrityFailures: canonical.commentIntegrityFailures,
+      });
+    },
+  );
+
+  test.openspec('[CLI-CERT-05] Projection ordering is deterministic')(
+    'serializes byte-identically for repeated projections',
+    async ({ given, when, then }: AllureBddContext) => {
+      const canonical = canonicalCertificate();
+      let first = '';
+      await given('one canonical certificate', () => undefined);
+      await when('it is projected once', () => {
+        first = JSON.stringify(projectLlmVerificationCertificate(canonical));
+      });
+      const second = JSON.stringify(projectLlmVerificationCertificate(canonical));
+      await then('a repeated projection has identical bytes', () => expect(second).toBe(first));
+    },
+  );
+});

--- a/packages/docx-mcp/src/cli/certificates/llm_certificate.ts
+++ b/packages/docx-mcp/src/cli/certificates/llm_certificate.ts
@@ -1,0 +1,321 @@
+import type {
+  DocumentIntegrityCertificate,
+  DocumentIntegrityCheckCertificate,
+  DocumentIntegrityCheckStatus,
+  DocumentIntegrityRelationshipStory,
+  DocumentIntegrityStoryCertificate,
+} from '@usejunior/docx-compare';
+
+export type CertificateFormat = 'full' | 'llm';
+
+export const LLM_CERTIFICATE_SCHEMA_ID = 'safe-docx.llm-verification-certificate' as const;
+
+const INVARIANTS = [
+  {
+    id: 'accept_all_matches_revised',
+    claim: 'Accepting all tracked changes yields the revised story text.',
+  },
+  {
+    id: 'reject_all_matches_original',
+    claim: 'Rejecting all tracked changes yields the original story text.',
+  },
+  {
+    id: 'accept_all_fields_valid',
+    claim: 'Accepting all tracked changes preserves valid field structure.',
+  },
+  {
+    id: 'reject_all_fields_valid',
+    claim: 'Rejecting all tracked changes preserves valid field structure.',
+  },
+  {
+    id: 'no_field_markers_in_deletions',
+    claim: 'The compared story has no field markers inside deletions.',
+  },
+  {
+    id: 'move_ranges_paired',
+    claim: 'Tracked move ranges are correctly paired.',
+  },
+] as const;
+
+export type LlmInvariantId = (typeof INVARIANTS)[number]['id'];
+
+type TokenCounts = { original: number; revised: number; compared: number };
+
+interface LlmFixedStory {
+  id: string;
+  category: 'fixed';
+  name: DocumentIntegrityStoryCertificate['name'];
+  status: DocumentIntegrityStoryCertificate['status'];
+  presence?: DocumentIntegrityStoryCertificate['presence'];
+  parsedTokenCounts?: TokenCounts;
+}
+
+interface LlmRelationshipStory {
+  id: string;
+  category: 'relationship';
+  kind: DocumentIntegrityRelationshipStory['kind'];
+  physicalStoryOrdinal: number;
+  status: DocumentIntegrityRelationshipStory['status'];
+  partPaths: {
+    original: string;
+    revised: string;
+    compared: string;
+  };
+  selectingSlotOrdinals: number[];
+  parsedTokenCounts: TokenCounts;
+}
+
+export interface LlmVerificationCertificate {
+  schemaId: typeof LLM_CERTIFICATE_SCHEMA_ID;
+  schemaVersion: 1;
+  verdict: DocumentIntegrityCertificate['status'];
+  reconstructionMode: DocumentIntegrityCertificate['reconstructionMode'];
+  scope: {
+    fixedStories: number;
+    relationshipStories: number;
+    noteStories: number;
+    commentStories: number;
+    exclusions: string[];
+  };
+  statusSummary: {
+    genericStories: { passed: number; failed: number };
+    invariantRelations: Record<DocumentIntegrityCheckStatus, number>;
+    noteStories: Record<'passed' | 'failed' | 'not_evaluated', number>;
+    commentStories: Record<'passed' | 'failed' | 'not_evaluated', number>;
+  };
+  anomalies: {
+    presenceMismatches: NonNullable<DocumentIntegrityCertificate['presenceMismatches']>;
+    fixedStoryFailures: NonNullable<DocumentIntegrityCertificate['fixedStoryFailures']>;
+    relationshipSelectionFailures: NonNullable<
+      DocumentIntegrityCertificate['relationshipSelectionFailures']
+    >;
+    noteIntegrityFailures: NonNullable<DocumentIntegrityCertificate['noteIntegrityFailures']>;
+    commentIntegrityFailures: NonNullable<
+      DocumentIntegrityCertificate['commentIntegrityFailures']
+    >;
+  };
+  reason?: string;
+  verifier: {
+    name: DocumentIntegrityCertificate['verifier'];
+    publicCertificateProtocolVersion: DocumentIntegrityCertificate['protocolVersion'];
+    checkerProtocolVersion?: NonNullable<DocumentIntegrityCertificate['checkerProtocolVersion']>;
+  };
+  hashes: {
+    mainDocumentXml: DocumentIntegrityCertificate['inputSha256'];
+    packages?: NonNullable<DocumentIntegrityCertificate['inputPackageSha256']>;
+  };
+  invariantDefinitions: ReadonlyArray<(typeof INVARIANTS)[number]>;
+  stories: Array<LlmFixedStory | LlmRelationshipStory>;
+  resultSets: Array<{
+    storyIds: string[];
+    passedInvariantIds: LlmInvariantId[];
+    failedInvariantIds: LlmInvariantId[];
+    notEvaluatedInvariantIds: LlmInvariantId[];
+  }>;
+  protocolEvidence: {
+    fixedStoryScope?: DocumentIntegrityCertificate['fixedStoryScope'];
+    relationshipStoryScope?: DocumentIntegrityCertificate['relationshipStoryScope'];
+    relationshipSlots: NonNullable<DocumentIntegrityCertificate['relationshipSlots']>;
+    noteStoryScope?: DocumentIntegrityCertificate['noteStoryScope'];
+    referenceSourcePartitions: NonNullable<
+      DocumentIntegrityCertificate['referenceSourcePartitions']
+    >;
+    noteStories: NonNullable<DocumentIntegrityCertificate['noteStories']>;
+    noteInventories: NonNullable<DocumentIntegrityCertificate['noteInventories']>;
+    commentStoryScope?: DocumentIntegrityCertificate['commentStoryScope'];
+    commentRangeTopology?: DocumentIntegrityCertificate['commentRangeTopology'];
+    commentStory?: DocumentIntegrityCertificate['commentStory'];
+    commentInventories: NonNullable<DocumentIntegrityCertificate['commentInventories']>;
+  };
+}
+
+type GenericChecks = {
+  acceptingAllTrackedChangesMatchesRevisedText: DocumentIntegrityCheckCertificate;
+  rejectingAllTrackedChangesMatchesOriginalText: DocumentIntegrityCheckCertificate;
+  acceptingAllTrackedChangesKeepsValidFieldStructure: DocumentIntegrityCheckCertificate;
+  rejectingAllTrackedChangesKeepsValidFieldStructure: DocumentIntegrityCheckCertificate;
+  comparedStoryHasNoFieldMarkersInsideDeletions?: DocumentIntegrityCheckCertificate;
+  comparedDocumentHasNoFieldMarkersInsideDeletions?: DocumentIntegrityCheckCertificate;
+  trackedMoveRangesAreCorrectlyPaired?: DocumentIntegrityCheckCertificate;
+};
+
+function checkStatuses(checks: GenericChecks): Record<LlmInvariantId, DocumentIntegrityCheckStatus> {
+  const fieldMarkerCheck =
+    checks.comparedStoryHasNoFieldMarkersInsideDeletions ??
+    checks.comparedDocumentHasNoFieldMarkersInsideDeletions;
+  return {
+    accept_all_matches_revised: checks.acceptingAllTrackedChangesMatchesRevisedText.status,
+    reject_all_matches_original: checks.rejectingAllTrackedChangesMatchesOriginalText.status,
+    accept_all_fields_valid: checks.acceptingAllTrackedChangesKeepsValidFieldStructure.status,
+    reject_all_fields_valid: checks.rejectingAllTrackedChangesKeepsValidFieldStructure.status,
+    no_field_markers_in_deletions: fieldMarkerCheck?.status ?? 'not_evaluated',
+    move_ranges_paired: checks.trackedMoveRangesAreCorrectlyPaired?.status ?? 'not_evaluated',
+  };
+}
+
+function fixedStories(certificate: DocumentIntegrityCertificate): DocumentIntegrityStoryCertificate[] {
+  if (certificate.stories && certificate.stories.length > 0) return certificate.stories;
+  return [
+    {
+      name: 'main',
+      status: certificate.status === 'passed' ? 'passed' : 'failed',
+      checks: {
+        ...certificate.checks,
+        comparedStoryHasNoFieldMarkersInsideDeletions:
+          certificate.checks.comparedDocumentHasNoFieldMarkersInsideDeletions,
+      },
+      parsedTokenCounts: certificate.parsedTokenCounts ?? { original: 0, revised: 0, compared: 0 },
+      presence: { original: true, revised: true, compared: true },
+    },
+  ];
+}
+
+function incrementStatus<T extends string>(counts: Record<T, number>, status: T): void {
+  counts[status] += 1;
+}
+
+export function projectLlmVerificationCertificate(
+  certificate: DocumentIntegrityCertificate,
+): LlmVerificationCertificate {
+  const fixed = fixedStories(certificate);
+  const relationships = certificate.relationshipStories ?? [];
+  const notes = certificate.noteStories ?? [];
+  const comments = certificate.commentStory ? [certificate.commentStory] : [];
+  const stories: LlmVerificationCertificate['stories'] = [];
+  const evaluated: Array<{
+    storyId: string;
+    statuses: Record<LlmInvariantId, DocumentIntegrityCheckStatus>;
+  }> = [];
+
+  for (const story of fixed) {
+    const id = `fixed:${story.name}`;
+    stories.push({
+      id,
+      category: 'fixed',
+      name: story.name,
+      status: story.status,
+      presence: story.presence,
+      parsedTokenCounts: story.parsedTokenCounts,
+    });
+    evaluated.push({ storyId: id, statuses: checkStatuses(story.checks) });
+  }
+
+  for (const story of relationships) {
+    const id = `relationship:${story.physicalStoryOrdinal}:${story.kind}`;
+    stories.push({
+      id,
+      category: 'relationship',
+      kind: story.kind,
+      physicalStoryOrdinal: story.physicalStoryOrdinal,
+      status: story.status,
+      partPaths: {
+        original: story.originalPartPath,
+        revised: story.revisedPartPath,
+        compared: story.comparedPartPath,
+      },
+      selectingSlotOrdinals: story.selectingSlotOrdinals,
+      parsedTokenCounts: story.parsedTokenCounts,
+    });
+    evaluated.push({ storyId: id, statuses: checkStatuses(story.checks) });
+  }
+
+  const invariantRelations: Record<DocumentIntegrityCheckStatus, number> = {
+    passed: 0,
+    failed: 0,
+    not_evaluated: 0,
+  };
+  const grouped = new Map<
+    string,
+    LlmVerificationCertificate['resultSets'][number]
+  >();
+  for (const story of evaluated) {
+    const passedInvariantIds: LlmInvariantId[] = [];
+    const failedInvariantIds: LlmInvariantId[] = [];
+    const notEvaluatedInvariantIds: LlmInvariantId[] = [];
+    for (const invariant of INVARIANTS) {
+      const status = story.statuses[invariant.id];
+      incrementStatus(invariantRelations, status);
+      if (status === 'passed') passedInvariantIds.push(invariant.id);
+      else if (status === 'failed') failedInvariantIds.push(invariant.id);
+      else notEvaluatedInvariantIds.push(invariant.id);
+    }
+    const key = JSON.stringify([passedInvariantIds, failedInvariantIds, notEvaluatedInvariantIds]);
+    const existing = grouped.get(key);
+    if (existing) existing.storyIds.push(story.storyId);
+    else {
+      grouped.set(key, {
+        storyIds: [story.storyId],
+        passedInvariantIds,
+        failedInvariantIds,
+        notEvaluatedInvariantIds,
+      });
+    }
+  }
+
+  const genericStories = { passed: 0, failed: 0 };
+  for (const story of [...fixed, ...relationships]) incrementStatus(genericStories, story.status);
+  const noteStories = { passed: 0, failed: 0, not_evaluated: 0 };
+  for (const story of notes) incrementStatus(noteStories, story.status);
+  const commentStories = { passed: 0, failed: 0, not_evaluated: 0 };
+  for (const story of comments) incrementStatus(commentStories, story.status);
+
+  return {
+    schemaId: LLM_CERTIFICATE_SCHEMA_ID,
+    schemaVersion: 1,
+    verdict: certificate.status,
+    reconstructionMode: certificate.reconstructionMode,
+    scope: {
+      fixedStories: fixed.length,
+      relationshipStories: relationships.length,
+      noteStories: notes.length,
+      commentStories: comments.length,
+      exclusions: certificate.exclusions ?? [],
+    },
+    statusSummary: { genericStories, invariantRelations, noteStories, commentStories },
+    anomalies: {
+      presenceMismatches: certificate.presenceMismatches ?? [],
+      fixedStoryFailures: certificate.fixedStoryFailures ?? [],
+      relationshipSelectionFailures: certificate.relationshipSelectionFailures ?? [],
+      noteIntegrityFailures: certificate.noteIntegrityFailures ?? [],
+      commentIntegrityFailures: certificate.commentIntegrityFailures ?? [],
+    },
+    ...(certificate.reason === undefined ? {} : { reason: certificate.reason }),
+    verifier: {
+      name: certificate.verifier,
+      publicCertificateProtocolVersion: certificate.protocolVersion,
+      ...(certificate.checkerProtocolVersion === undefined
+        ? {}
+        : { checkerProtocolVersion: certificate.checkerProtocolVersion }),
+    },
+    hashes: {
+      mainDocumentXml: certificate.inputSha256,
+      ...(certificate.inputPackageSha256 === undefined
+        ? {}
+        : { packages: certificate.inputPackageSha256 }),
+    },
+    invariantDefinitions: INVARIANTS,
+    stories,
+    resultSets: [...grouped.values()],
+    protocolEvidence: {
+      ...(certificate.fixedStoryScope === undefined
+        ? {}
+        : { fixedStoryScope: certificate.fixedStoryScope }),
+      ...(certificate.relationshipStoryScope === undefined
+        ? {}
+        : { relationshipStoryScope: certificate.relationshipStoryScope }),
+      relationshipSlots: certificate.relationshipSlots ?? [],
+      ...(certificate.noteStoryScope === undefined ? {} : { noteStoryScope: certificate.noteStoryScope }),
+      referenceSourcePartitions: certificate.referenceSourcePartitions ?? [],
+      noteStories: notes,
+      noteInventories: certificate.noteInventories ?? [],
+      ...(certificate.commentStoryScope === undefined
+        ? {}
+        : { commentStoryScope: certificate.commentStoryScope }),
+      ...(certificate.commentRangeTopology === undefined
+        ? {}
+        : { commentRangeTopology: certificate.commentRangeTopology }),
+      ...(certificate.commentStory === undefined ? {} : { commentStory: certificate.commentStory }),
+      commentInventories: certificate.commentInventories ?? [],
+    },
+  };
+}

--- a/packages/docx-mcp/src/cli/commands/compare.test.ts
+++ b/packages/docx-mcp/src/cli/commands/compare.test.ts
@@ -148,7 +148,7 @@ describe('safe-docx compare command', () => {
       let result: Awaited<ReturnType<typeof runCompareCommand>>;
       await when('the caller requests a certificate artifact', async () => {
         result = await runCompareCommand(
-          { originalPath, revisedPath, outputPath, certificatePath },
+          { originalPath, revisedPath, outputPath, certificatePath, certificateFormat: 'full' },
           { compare: async (_original, _revised, options) => {
             expect(options?.leanXmlVerifier).toEqual({ enabled: true });
             return comparisonResult(passed);
@@ -157,6 +157,7 @@ describe('safe-docx compare command', () => {
       });
 
       await then('the JSON result and durable artifact carry the same certificate', async () => {
+        expect(result.certificate_format).toBe('full');
         expect(result.verification).toEqual(passed);
         expect(result.certificate_path).toBe(certificatePath);
         expect(await fs.readFile(outputPath, 'utf8')).toBe('verified-redline');
@@ -275,14 +276,14 @@ describeWithCompiledLean('safe-docx verified comparison performance', () => {
           verify: true,
         });
         const elapsedMs = performance.now() - started;
-        expect(result.certificate_format).toBe('full');
+        expect(result.certificate_format).toBe('llm');
         expect(result.verification).toBeDefined();
-        expect(result.verification && 'status' in result.verification).toBe(true);
-        if (!result.verification || !('status' in result.verification)) {
-          throw new Error('expected the default full certificate');
+        expect(result.verification && 'verdict' in result.verification).toBe(true);
+        if (!result.verification || !('verdict' in result.verification)) {
+          throw new Error('expected the default LLM certificate');
         }
-        expect(result.verification.status, result.verification.reason).toBe('passed');
-        expect(result.verification.checkerProtocolVersion).toBe(7);
+        expect(result.verification.verdict, result.verification.reason).toBe('passed');
+        expect(result.verification.verifier.checkerProtocolVersion).toBe(7);
         expect(result.mode).toBe('inplace');
         expect(elapsedMs, `verified comparison took ${elapsedMs.toFixed(0)}ms`).toBeLessThanOrEqual(
           10_000,

--- a/packages/docx-mcp/src/cli/commands/compare.test.ts
+++ b/packages/docx-mcp/src/cli/commands/compare.test.ts
@@ -275,8 +275,14 @@ describeWithCompiledLean('safe-docx verified comparison performance', () => {
           verify: true,
         });
         const elapsedMs = performance.now() - started;
-        expect(result.verification?.status, result.verification?.reason).toBe('passed');
-        expect(result.verification?.checkerProtocolVersion).toBe(7);
+        expect(result.certificate_format).toBe('full');
+        expect(result.verification).toBeDefined();
+        expect(result.verification && 'status' in result.verification).toBe(true);
+        if (!result.verification || !('status' in result.verification)) {
+          throw new Error('expected the default full certificate');
+        }
+        expect(result.verification.status, result.verification.reason).toBe('passed');
+        expect(result.verification.checkerProtocolVersion).toBe(7);
         expect(result.mode).toBe('inplace');
         expect(elapsedMs, `verified comparison took ${elapsedMs.toFixed(0)}ms`).toBeLessThanOrEqual(
           10_000,

--- a/packages/docx-mcp/src/cli/commands/compare.ts
+++ b/packages/docx-mcp/src/cli/commands/compare.ts
@@ -7,6 +7,11 @@ import {
   type DocumentIntegrityCertificate,
 } from '@usejunior/docx-compare';
 import { DEFAULT_RECONSTRUCTION_MODE } from '../../tools/comparison_defaults.js';
+import {
+  projectLlmVerificationCertificate,
+  type CertificateFormat,
+  type LlmVerificationCertificate,
+} from '../certificates/llm_certificate.js';
 
 const SUPPORTED_ENGINES: ReadonlySet<NonNullable<CompareOptions['engine']>> = new Set([
   'auto',
@@ -23,6 +28,7 @@ export interface CompareCommandArgs {
   premergeRuns?: boolean;
   verify?: boolean;
   certificatePath?: string;
+  certificateFormat?: string;
 }
 
 export interface CompareCommandResult {
@@ -33,8 +39,9 @@ export interface CompareCommandResult {
   fallback_reason?: string;
   bytes: number;
   stats: unknown;
-  verification?: DocumentIntegrityCertificate;
+  verification?: DocumentIntegrityCertificate | LlmVerificationCertificate;
   certificate_path?: string;
+  certificate_format?: CertificateFormat;
 }
 
 export interface CompareCommandDependencies {
@@ -75,6 +82,14 @@ function normalizeMode(raw: string | undefined): 'inplace' | 'rebuild' {
   return candidate;
 }
 
+function normalizeCertificateFormat(raw: string | undefined): CertificateFormat {
+  const candidate = (raw ?? 'full').trim().toLowerCase();
+  if (candidate !== 'full' && candidate !== 'llm') {
+    throw new Error(`Unsupported certificate format: ${String(raw)}. Use full or llm.`);
+  }
+  return candidate;
+}
+
 function defaultOutputPath(revisedPath: string, engine: string, mode: 'inplace' | 'rebuild'): string {
   return revisedPath.replace(/\.docx$/i, '') + `.REDLINE.${engine}.${mode}.docx`;
 }
@@ -85,13 +100,15 @@ export async function runCompareCommand(
 ): Promise<CompareCommandResult> {
   const engine = normalizeEngine(args.engine);
   const mode = normalizeMode(args.mode);
+  const certificateFormat = normalizeCertificateFormat(args.certificateFormat);
 
   const originalAbs = resolve(args.originalPath);
   const revisedAbs = resolve(args.revisedPath);
   const outputAbs = resolve(args.outputPath ?? defaultOutputPath(revisedAbs, engine, mode));
   const certificateAbs =
     args.certificatePath === undefined ? undefined : resolve(args.certificatePath);
-  const verify = args.verify === true || certificateAbs !== undefined;
+  const verify =
+    args.verify === true || certificateAbs !== undefined || args.certificateFormat !== undefined;
 
   if (certificateAbs === outputAbs) {
     throw new Error('The certificate path must differ from the redline output path.');
@@ -117,8 +134,13 @@ export async function runCompareCommand(
     throw new Error(`Verified comparison did not pass (${status}): ${reason}`);
   }
 
-  if (certificateAbs && verification) {
-    await writeFileAtomically(certificateAbs, `${JSON.stringify(verification, null, 2)}\n`);
+  const emittedVerification =
+    verification && certificateFormat === 'llm'
+      ? projectLlmVerificationCertificate(verification)
+      : verification;
+
+  if (certificateAbs && emittedVerification) {
+    await writeFileAtomically(certificateAbs, `${JSON.stringify(emittedVerification, null, 2)}\n`);
   }
   await writeFileAtomically(outputAbs, result.document);
 
@@ -130,7 +152,8 @@ export async function runCompareCommand(
     fallback_reason: result.fallbackReason,
     bytes: result.document.length,
     stats: result.stats,
-    verification,
+    verification: emittedVerification,
     certificate_path: certificateAbs,
+    ...(emittedVerification === undefined ? {} : { certificate_format: certificateFormat }),
   };
 }

--- a/packages/docx-mcp/src/cli/commands/compare.ts
+++ b/packages/docx-mcp/src/cli/commands/compare.ts
@@ -83,7 +83,7 @@ function normalizeMode(raw: string | undefined): 'inplace' | 'rebuild' {
 }
 
 function normalizeCertificateFormat(raw: string | undefined): CertificateFormat {
-  const candidate = (raw ?? 'full').trim().toLowerCase();
+  const candidate = (raw ?? 'llm').trim().toLowerCase();
   if (candidate !== 'full' && candidate !== 'llm') {
     throw new Error(`Unsupported certificate format: ${String(raw)}. Use full or llm.`);
   }

--- a/packages/docx-mcp/src/cli/help.ts
+++ b/packages/docx-mcp/src/cli/help.ts
@@ -47,7 +47,7 @@ export function renderTopLevelHelp(): string {
   lines.push('    --mode <inplace|rebuild>                   Reconstruction mode (default: inplace)');
   lines.push('    --verify                                  Require a passing Lean verifier certificate');
   lines.push('    --certificate <path>                      Verify and write the certificate as JSON');
-  lines.push('    --certificate-format <full|llm>           Select canonical or LLM-optimized JSON');
+  lines.push('    --certificate-format <llm|full>           Certificate detail (default: llm)');
   lines.push('                                                Compare stats count revision ranges; atom totals use *Atoms fields');
   lines.push('  edit <file> [--replace ...] [-o output]     Batch edit a DOCX file');
   lines.push('  grep "pattern" <file> [files...]            Search DOCX files for text');

--- a/packages/docx-mcp/src/cli/help.ts
+++ b/packages/docx-mcp/src/cli/help.ts
@@ -47,6 +47,7 @@ export function renderTopLevelHelp(): string {
   lines.push('    --mode <inplace|rebuild>                   Reconstruction mode (default: inplace)');
   lines.push('    --verify                                  Require a passing Lean verifier certificate');
   lines.push('    --certificate <path>                      Verify and write the certificate as JSON');
+  lines.push('    --certificate-format <full|llm>           Select canonical or LLM-optimized JSON');
   lines.push('                                                Compare stats count revision ranges; atom totals use *Atoms fields');
   lines.push('  edit <file> [--replace ...] [-o output]     Batch edit a DOCX file');
   lines.push('  grep "pattern" <file> [files...]            Search DOCX files for text');

--- a/packages/docx-mcp/src/cli/index.test.ts
+++ b/packages/docx-mcp/src/cli/index.test.ts
@@ -136,7 +136,8 @@ describe('safe-docx CLI routing', () => {
       expect(output[0]).toContain('Reconstruction mode (default: inplace)');
       expect(output[0]).toContain('--verify');
       expect(output[0]).toContain('--certificate <path>');
-      expect(output[0]).toContain('--certificate-format <full|llm>');
+      expect(output[0]).toContain('--certificate-format <llm|full>');
+      expect(output[0]).toContain('Certificate detail (default: llm)');
       expect(serve).not.toHaveBeenCalled();
       expect(compare).not.toHaveBeenCalled();
     });

--- a/packages/docx-mcp/src/cli/index.test.ts
+++ b/packages/docx-mcp/src/cli/index.test.ts
@@ -82,6 +82,8 @@ describe('safe-docx CLI routing', () => {
         '--verify',
         '--certificate',
         'certificate.json',
+        '--certificate-format',
+        'llm',
       ]);
     });
 
@@ -97,6 +99,7 @@ describe('safe-docx CLI routing', () => {
         premergeRuns: true,
         verify: true,
         certificatePath: 'certificate.json',
+        certificateFormat: 'llm',
       });
       expect(serve).not.toHaveBeenCalled();
       expect(output).toHaveLength(1);
@@ -133,6 +136,7 @@ describe('safe-docx CLI routing', () => {
       expect(output[0]).toContain('Reconstruction mode (default: inplace)');
       expect(output[0]).toContain('--verify');
       expect(output[0]).toContain('--certificate <path>');
+      expect(output[0]).toContain('--certificate-format <full|llm>');
       expect(serve).not.toHaveBeenCalled();
       expect(compare).not.toHaveBeenCalled();
     });

--- a/packages/docx-mcp/src/cli/index.ts
+++ b/packages/docx-mcp/src/cli/index.ts
@@ -72,6 +72,9 @@ function parseCompareArgs(args: string[]): CompareCommandArgs {
       case '--certificate':
         options.certificatePath = consumeValue(token);
         break;
+      case '--certificate-format':
+        options.certificateFormat = consumeValue(token);
+        break;
       default:
         throw new Error(`Unknown option for compare command: ${token}`);
     }


### PR DESCRIPTION
## Summary

- make the compact LLM certificate the default progressive-disclosure output for verified CLI comparisons
- provide `--certificate-format full` as the explicit compatibility path to the unchanged canonical public v1 certificate
- emit a deterministic, versioned LLM schema with verdict/scope/anomalies first, six stable invariant definitions, grouped story result vectors, hashes, exclusions, and protocol evidence
- keep CLI JSON and certificate-file output identical for the selected format
- add a strict OpenSpec change and complete scenario coverage

## Verification

- `npm run build`
- `npm run lint:workspaces`
- `npm run test:run` outside the sandbox, including TSX IPC and LibreOffice probes
- `npm run check:spec-coverage`
- `npm run check:conformance-citations`
- `npm run check:conformance-doc`
- `openspec validate add-llm-verifier-certificate --strict`

Fixes #780
