### PR TITLE
feat(docx-mcp): accept compare output option

### DIFF
--- a/openspec/changes/add-compare-output-option/proposal.md
+++ b/openspec/changes/add-compare-output-option/proposal.md
@@ -1,0 +1,17 @@
+# Change: Add compare output option
+
+## Why
+
+The `compare` command accepts an output path only as a third positional argument, even though `-o`/`--output` is the established CLI convention. Worse, unknown single-dash options are currently absorbed as positional arguments and produce a misleading arity error.
+
+## What Changes
+
+- Accept `-o <path>` and `--output <path>` for `safe-docx compare`.
+- Preserve the existing positional output form for compatibility.
+- Reject conflicting output forms and unknown single-dash options with explicit errors.
+- Advertise the output option in top-level CLI help.
+
+## Impact
+
+- Affected specs: `mcp-server`
+- Affected code: `packages/docx-mcp/src/cli/index.ts`, CLI help, and CLI routing tests

--- a/openspec/changes/add-compare-output-option/specs/mcp-server/spec.md
+++ b/openspec/changes/add-compare-output-option/specs/mcp-server/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Compare CLI output option
+
+The Safe-DOCX CLI SHALL allow a comparison output path to be supplied with either `-o <path>` or `--output <path>`, while preserving the existing third positional output argument for compatibility. It SHALL reject ambiguous output declarations and SHALL report unrecognized single-dash options as options rather than absorbing them as positional arguments.
+
+#### Scenario: [CLI-OUTPUT-01] Compare accepts the short output option
+
+- **WHEN** a user runs `safe-docx compare original.docx revised.docx -o result.docx`
+- **THEN** the comparison output path is `result.docx`
+
+#### Scenario: [CLI-OUTPUT-02] Compare accepts the long output option
+
+- **WHEN** a user runs `safe-docx compare --output result.docx original.docx revised.docx`
+- **THEN** the comparison output path is `result.docx`
+
+#### Scenario: [CLI-OUTPUT-03] Compare rejects conflicting output forms
+
+- **WHEN** a user supplies both the positional output and `-o` or `--output`
+- **THEN** the command fails with an error identifying the conflicting output forms
+
+#### Scenario: [CLI-OUTPUT-04] Compare rejects unknown single-dash options
+
+- **WHEN** a user supplies an unrecognized single-dash token such as `-x`
+- **THEN** the command fails with an unknown-option error that names the token

--- a/openspec/changes/add-compare-output-option/tasks.md
+++ b/openspec/changes/add-compare-output-option/tasks.md
@@ -1,0 +1,6 @@
+## 1. Implementation
+
+- [x] 1.1 Parse `-o` and `--output` for the compare command.
+- [x] 1.2 Reject conflicting output forms and unknown single-dash options.
+- [x] 1.3 Document the option in CLI help.
+- [x] 1.4 Add acceptance tests for both aliases and error cases.

--- a/packages/docx-mcp/src/cli/help.ts
+++ b/packages/docx-mcp/src/cli/help.ts
@@ -44,6 +44,7 @@ export function renderTopLevelHelp(): string {
   lines.push('Built-in commands:');
   lines.push('  serve                                       Start the MCP server (default)');
   lines.push('  compare <original> <revised> [output]       Compare two DOCX files and write redline output');
+  lines.push('    -o, --output <path>                       Write redline output to this path');
   lines.push('    --mode <inplace|rebuild>                   Reconstruction mode (default: inplace)');
   lines.push('    --verify                                  Require a passing Lean verifier certificate');
   lines.push('    --certificate <path>                      Verify and write the certificate as JSON');

--- a/packages/docx-mcp/src/cli/index.test.ts
+++ b/packages/docx-mcp/src/cli/index.test.ts
@@ -9,6 +9,7 @@ import { createTrackedTempDir, registerCleanup } from '../testing/session-test-u
 
 registerCleanup();
 
+const TEST_FEATURE = 'add-compare-output-option';
 const test = testAllure.epic('Document Editing').withLabels({ feature: 'CLI Routing' });
 
 describe('safe-docx CLI routing', () => {
@@ -107,6 +108,87 @@ describe('safe-docx CLI routing', () => {
     });
   });
 
+  test.openspec('[CLI-OUTPUT-01] Compare accepts the short output option')(
+    'routes compare -o to the output path',
+    async ({ when, then }: AllureBddContext) => {
+      const compare = vi.fn(async (args: CompareCommandArgs) => ({
+        output: args.outputPath ?? '/tmp/default.docx',
+        engine: 'atomizer',
+        mode: 'inplace' as const,
+        mode_requested: 'inplace' as const,
+        bytes: 1,
+        stats: {},
+      }));
+      const program = createProgram({ serve: vi.fn(async () => undefined), compare, write: () => undefined });
+
+      await when('compare receives -o after its input paths', () =>
+        program.parseAsync(['node', 'safe-docx', 'compare', 'original.docx', 'revised.docx', '-o', 'result.docx']),
+      );
+
+      await then('the compare handler receives the flagged output path', () => {
+        expect(compare).toHaveBeenCalledWith(expect.objectContaining({ outputPath: 'result.docx' }));
+      });
+    },
+  );
+
+  test.openspec('[CLI-OUTPUT-02] Compare accepts the long output option')(
+    'routes compare --output to the output path',
+    async ({ when, then }: AllureBddContext) => {
+      const compare = vi.fn(async (args: CompareCommandArgs) => ({
+        output: args.outputPath ?? '/tmp/default.docx',
+        engine: 'atomizer',
+        mode: 'inplace' as const,
+        mode_requested: 'inplace' as const,
+        bytes: 1,
+        stats: {},
+      }));
+      const program = createProgram({ serve: vi.fn(async () => undefined), compare, write: () => undefined });
+
+      await when('compare receives --output before its input paths', () =>
+        program.parseAsync(['node', 'safe-docx', 'compare', '--output', 'result.docx', 'original.docx', 'revised.docx']),
+      );
+
+      await then('the compare handler receives the flagged output path', () => {
+        expect(compare).toHaveBeenCalledWith(expect.objectContaining({ outputPath: 'result.docx' }));
+      });
+    },
+  );
+
+  test.openspec('[CLI-OUTPUT-03] Compare rejects conflicting output forms')(
+    'rejects positional and flagged compare outputs together',
+    async ({ when }: AllureBddContext) => {
+      const program = createProgram({ write: () => undefined });
+
+      await when('both output forms are supplied', async () => {
+        await expect(
+          program.parseAsync([
+            'node',
+            'safe-docx',
+            'compare',
+            'original.docx',
+            'revised.docx',
+            'positional.docx',
+            '-o',
+            'flagged.docx',
+          ]),
+        ).rejects.toThrow('compare output cannot be supplied both positionally and with -o/--output.');
+      });
+    },
+  );
+
+  test.openspec('[CLI-OUTPUT-04] Compare rejects unknown single-dash options')(
+    'reports an unknown single-dash compare option',
+    async ({ when }: AllureBddContext) => {
+      const program = createProgram({ write: () => undefined });
+
+      await when('an unsupported single-dash option is supplied', async () => {
+        await expect(
+          program.parseAsync(['node', 'safe-docx', 'compare', 'original.docx', 'revised.docx', '-x']),
+        ).rejects.toThrow('Unknown option for compare command: -x');
+      });
+    },
+  );
+
   test('shows help text and does not invoke command handlers', async ({ when, then }: AllureBddContext) => {
     const serve = vi.fn(async () => undefined);
     const compare = vi.fn(async () => ({
@@ -133,6 +215,7 @@ describe('safe-docx CLI routing', () => {
       expect(output).toHaveLength(1);
       expect(output[0]).toContain('safe-docx CLI');
       expect(output[0]).toContain('compare <original> <revised> [output]');
+      expect(output[0]).toContain('-o, --output <path>');
       expect(output[0]).toContain('Reconstruction mode (default: inplace)');
       expect(output[0]).toContain('--verify');
       expect(output[0]).toContain('--certificate <path>');

--- a/packages/docx-mcp/src/cli/index.ts
+++ b/packages/docx-mcp/src/cli/index.ts
@@ -34,19 +34,20 @@ function packageVersion(): string {
 function parseCompareArgs(args: string[]): CompareCommandArgs {
   const positional: string[] = [];
   const options: Omit<CompareCommandArgs, 'originalPath' | 'revisedPath' | 'outputPath'> = {};
+  let flaggedOutputPath: string | undefined;
 
   for (let i = 0; i < args.length; i++) {
     const token = args[i];
     if (!token) continue;
 
-    if (!token.startsWith('--')) {
+    if (!token.startsWith('-')) {
       positional.push(token);
       continue;
     }
 
     const consumeValue = (flagName: string): string => {
       const next = args[i + 1];
-      if (!next || next.startsWith('--')) {
+      if (!next || next.startsWith('-')) {
         throw new Error(`Missing value for ${flagName}.`);
       }
       i += 1;
@@ -54,6 +55,13 @@ function parseCompareArgs(args: string[]): CompareCommandArgs {
     };
 
     switch (token) {
+      case '-o':
+      case '--output':
+        if (flaggedOutputPath !== undefined) {
+          throw new Error('compare output may be specified only once.');
+        }
+        flaggedOutputPath = consumeValue(token);
+        break;
       case '--engine':
         options.engine = consumeValue(token);
         break;
@@ -84,15 +92,19 @@ function parseCompareArgs(args: string[]): CompareCommandArgs {
     throw new Error('compare requires: <original> <revised> [output]');
   }
 
-  const [originalPath, revisedPath, outputPath] = positional;
+  const [originalPath, revisedPath, positionalOutputPath] = positional;
   if (!originalPath || !revisedPath) {
     throw new Error('compare requires: <original> <revised> [output]');
+  }
+
+  if (positionalOutputPath !== undefined && flaggedOutputPath !== undefined) {
+    throw new Error('compare output cannot be supplied both positionally and with -o/--output.');
   }
 
   return {
     originalPath,
     revisedPath,
-    outputPath,
+    outputPath: flaggedOutputPath ?? positionalOutputPath,
     ...options,
   };
 }


### PR DESCRIPTION
## Summary

- accept `-o <path>` and `--output <path>` for `safe-docx compare`
- preserve the existing positional output argument
- reject positional/flag conflicts and unknown single-dash options explicitly
- add CLI help, OpenSpec scenarios, and routing tests

Fixes #782

## Validation

- `npm run build` — passed
- `npm run lint:workspaces` — passed (9 existing warnings)
- `npm run test:run` — all suites passed after rerunning 5 sandbox-blocked subprocess/LibreOffice tests outside the sandbox
  - docx-compare: 765 passed, 106 skipped
  - docx-core: 1,334 passed, 2 expected failures, 16 skipped
  - docx-mcp: 980 passed, 1 skipped
  - remaining workspaces: 405 passed, 35 skipped
- `npm run check:spec-coverage` — passed, including 4/4 new scenarios
- `npm run check:conformance-citations` — passed
- `npm run check:conformance-doc` — passed
- `npx openspec validate add-compare-output-option --strict` — passed