### PR TITLE
fix(docx-compare): preserve machine-readable stdout

### DIFF
--- a/packages/docx-compare/src/atomizer.test.ts
+++ b/packages/docx-compare/src/atomizer.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect } from 'vitest';
+import { describe, expect, vi } from 'vitest';
 import { testAllure, type AllureBddContext } from './testing/allure-test.js';
 import {
   sha1,
@@ -596,6 +596,29 @@ describe('atomizeTree', () => {
     uri: 'word/document.xml',
     contentType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml',
   };
+
+  test('does not write diagnostics to stdout', async ({ given, when, then }: AllureBddContext) => {
+    let document: Element;
+    const stdout = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await given('a simple paragraph element', () => {
+      document = el('w:p', {}, [
+        el('w:r', {}, [el('w:t', {}, undefined, 'Machine-readable output')]),
+      ]);
+    });
+
+    await when('the tree is atomized', () => {
+      atomizeTree(document, [], mockPart);
+    });
+
+    await then('stdout remains reserved for the caller result', () => {
+      try {
+        expect(stdout).not.toHaveBeenCalled();
+      } finally {
+        stdout.mockRestore();
+      }
+    });
+  });
 
   test('atomizes a simple paragraph', async ({ given, when, then }: AllureBddContext) => {
     let document: Element;

--- a/packages/docx-compare/src/atomizer.ts
+++ b/packages/docx-compare/src/atomizer.ts
@@ -909,9 +909,6 @@ export function atomizeTree(
     ? wordSplitAtoms
     : mergePunctuationAtoms(wordSplitAtoms, normalizedOptions);
 
-  console.log(
-    `[DEBUG] atomizeTree: created ${rawAtoms.length} atoms, field-collapsed to ${fieldCollapsedAtoms.length}, merged to ${mergedAtoms.length}, word-split to ${wordSplitAtoms.length}, punct-merged to ${atoms.length}, ${state.emptyParagraphCount} empty paragraphs`
-  );
   return { atoms, emptyParagraphCount: state.emptyParagraphCount };
 }
 


### PR DESCRIPTION
## Summary

- remove the unconditional `[DEBUG] atomizeTree` write to stdout
- add a regression test that holds `atomizeTree` silent on stdout
- preserve the existing consumer-compatibility warnings on stderr

## Root cause

`atomizeTree` called `console.log` unconditionally, so the diagnostic was interleaved with the `safe-docx compare` JSON result and broke machine consumers such as `jq`.

## Impact

Stdout once again belongs exclusively to the CLI's machine-readable comparison result. This is intentionally a narrow fix and does not introduce a logging framework or alter the result schema.

## Validation

- repository build and workspace lint
- full workspace test suite; five environment-restricted subprocess/LibreOffice tests rerun successfully with required permissions
- spec coverage and ECMA-376 conformance checks
- `safe-docx compare ... --certificate-format llm | jq -e .`
- `safe-docx compare ... --certificate-format full | jq -e .`
- focused atomizer regression: 64/64 passing

Fixes #783