### PR TITLE
fix(docx-core): reject failed conversions instead of inferring success from an output file

### DIFF
--- a/packages/docx-core/src/integration/generation-package-structure.test.ts
+++ b/packages/docx-core/src/integration/generation-package-structure.test.ts
@@ -1,5 +1,5 @@
 import JSZip from 'jszip';
-import { describe, expect } from 'vitest';
+import { beforeAll, describe, expect } from 'vitest';
 import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
 import { DocxDocument } from '../primitives/document.js';
 import { parseXml } from '../primitives/xml.js';
@@ -7,7 +7,7 @@ import { childElements } from '../primitives/dom-helpers.js';
 import { generateDocx } from '../generation/compile.js';
 import { checkGeneratedPackage } from '../generation/structural-checks.js';
 import type { DocumentSpec } from '../generation/types.js';
-import { resolveSoffice } from './libreoffice-oracle.js';
+import { probeSofficeUsable, resolveSoffice } from './libreoffice-oracle.js';
 import { probeDocxIdentity, probeDocxToPdf } from './generation-probes.js';
 import { writeIntegrationArtifact, getIntegrationOutputModeLabel } from './output-artifacts.js';
 
@@ -145,9 +145,26 @@ if (!soffice) {
 }
 
 describeProbes('Traceability: LibreOffice probes over generated packages', () => {
+  // `resolveSoffice()` proves the binary EXISTS, not that it can launch: under
+  // a restricted shell it dies with SIGABRT during init, which would FAIL these
+  // tests rather than skip them (observed: exit 134, "Abort trap: 6"). Probe
+  // launchability once and skip the body when it is unusable.
+  let sofficeUsable = false;
+  beforeAll(async () => {
+    sofficeUsable = soffice ? await probeSofficeUsable(soffice) : false;
+    if (!sofficeUsable) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        '[generation-package-structure] SKIP: soffice present but not launchable ' +
+          '(sandbox abort); cross-reader probes skipped.',
+      );
+    }
+  }, 60_000); // probeSofficeUsable launches soffice; the 10s default hook timeout is too short.
+
   test.openspec('[SDX-GEN-090] LibreOffice identity round-trip succeeds')(
     'Scenario: LibreOffice identity round-trip succeeds',
     async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
+      if (!sofficeUsable) return;
       let generated!: Buffer;
       await given('a generated full-package document', async () => {
         generated = await generateDocx(phase1Spec());
@@ -174,6 +191,7 @@ describeProbes('Traceability: LibreOffice probes over generated packages', () =>
   test.openspec('[SDX-GEN-091] headless PDF conversion succeeds')(
     'Scenario: headless PDF conversion succeeds',
     async ({ given, when, then }: AllureBddContext) => {
+      if (!sofficeUsable) return;
       let generated!: Buffer;
       await given('a generated full-package document', async () => {
         generated = await generateDocx(phase1Spec());

--- a/packages/docx-core/src/integration/generation-probes.test.ts
+++ b/packages/docx-core/src/integration/generation-probes.test.ts
@@ -256,6 +256,136 @@ describe('Traceability: generation probes reject failed conversions', () => {
     });
   });
 
+  test('rejects a docx with no package relationships part', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    const soffice = await given('a converter that writes a zip with no _rels/.rels', async () =>
+      makeStubConverter({
+        name: 'writes-no-package-rels',
+        ext: 'docx',
+        writes: await createZipBuffer({ 'word/document.xml': '<w:document/>' }),
+      }),
+    );
+
+    let failure: unknown;
+    await when('the identity probe runs', async () => {
+      try {
+        await probeDocxIdentity(GENERATED, soffice);
+      } catch (error) {
+        failure = error;
+      }
+    });
+
+    await then('a readable zip is still not a package', () => {
+      expect(failure).toBeInstanceOf(ConvertProbeError);
+      expect((failure as Error).message).toContain('_rels/.rels');
+    });
+  });
+
+  test('rejects a docx whose relationships declare no main document', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    const soffice = await given('a converter that writes rels without an officeDocument type', async () =>
+      makeStubConverter({
+        name: 'writes-no-office-document-rel',
+        ext: 'docx',
+        writes: await createZipBuffer({
+          '_rels/.rels':
+            `<?xml version="1.0"?><Relationships ` +
+            `xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+            `<Relationship Id="rId1" ` +
+            `Type="http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties" ` +
+            `Target="docProps/core.xml"/></Relationships>`,
+          'word/document.xml': '<w:document/>',
+        }),
+      }),
+    );
+
+    let failure: unknown;
+    await when('the identity probe runs', async () => {
+      try {
+        await probeDocxIdentity(GENERATED, soffice);
+      } catch (error) {
+        failure = error;
+      }
+    });
+
+    await then('the missing officeDocument relationship is named', () => {
+      expect(failure).toBeInstanceOf(ConvertProbeError);
+      expect((failure as Error).message).toContain('officeDocument relationship');
+    });
+  });
+
+  test('rejects a docx whose main-document relationship dangles', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    const soffice = await given('a converter that writes rels pointing at an absent part', async () =>
+      makeStubConverter({
+        name: 'writes-dangling-main-part',
+        ext: 'docx',
+        writes: await createZipBuffer({
+          '_rels/.rels':
+            `<?xml version="1.0"?><Relationships ` +
+            `xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+            `<Relationship Id="rId1" ` +
+            `Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" ` +
+            `Target="word/absent.xml"/></Relationships>`,
+          'word/document.xml': '<w:document/>',
+        }),
+      }),
+    );
+
+    let failure: unknown;
+    await when('the identity probe runs', async () => {
+      try {
+        await probeDocxIdentity(GENERATED, soffice);
+      } catch (error) {
+        failure = error;
+      }
+    });
+
+    await then('the probe follows the relationship rather than guessing the path', () => {
+      // word/document.xml IS present; only the declared target is absent. A
+      // probe that assumed the conventional path would pass this package.
+      expect(failure).toBeInstanceOf(ConvertProbeError);
+      expect((failure as Error).message).toContain('word/absent.xml');
+    });
+  });
+
+  test('rejects a pdf with no %PDF- header', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    const soffice = await given('a converter that writes non-pdf bytes and succeeds', () =>
+      makeStubConverter({
+        name: 'writes-headerless-pdf',
+        ext: 'pdf',
+        writes: Buffer.from('this is not a pdf at all, but it does end with %%EOF', 'latin1'),
+      }),
+    );
+
+    let failure: unknown;
+    await when('the pdf probe runs', async () => {
+      try {
+        await probeDocxToPdf(GENERATED, soffice);
+      } catch (error) {
+        failure = error;
+      }
+    });
+
+    await then('the missing header is reported even though a trailer is present', () => {
+      expect(failure).toBeInstanceOf(ConvertProbeError);
+      expect((failure as Error).message).toContain('%PDF- header');
+    });
+  });
+
   test('rejects a truncated PDF that still carries the %PDF- header', async ({
     given,
     when,

--- a/packages/docx-core/src/integration/generation-probes.test.ts
+++ b/packages/docx-core/src/integration/generation-probes.test.ts
@@ -1,0 +1,370 @@
+/**
+ * Generation probes — converter-failure characterization.
+ *
+ * `probeDocxIdentity` / `probeDocxToPdf` are verification helpers: whatever
+ * they call "a pass" is what the generation suite believes about a generated
+ * package. Their pass condition used to be "a file exists at the output path",
+ * which a converter that failed *after* dropping a partial file satisfies —
+ * so a 13-byte truncated stand-in came back as a successful round-trip.
+ *
+ * These tests drive the probes against a **stub converter** rather than a real
+ * LibreOffice, so they run in CI (which installs no LibreOffice) and can
+ * script failure modes a real binary will not reproduce on demand. The stub is
+ * the reproduction from issue #796, generalized.
+ *
+ * Every rejection below is paired with a green control that differs from it
+ * only in the property under test — a check that cannot go green is as useless
+ * as one that cannot go red.
+ *
+ * @see https://github.com/UseJunior/safe-docx/issues/796
+ */
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { createZipBuffer } from '../primitives/zip.js';
+import {
+  ConvertProbeError,
+  probeDocxIdentity,
+  probeDocxToPdf,
+} from './generation-probes.js';
+
+const TEST_FEATURE = 'add-docx-generation';
+const test = testAllure
+  .epic('Document Generation')
+  .withLabels({ feature: TEST_FEATURE });
+
+let workDir: string;
+
+/**
+ * Build an executable stand-in for `soffice`.
+ *
+ * The stub parses `--outdir` exactly as the real CLI is invoked, writes the
+ * caller-supplied bytes to `<outdir>/probe.<ext>` (or writes nothing), emits
+ * `stderr`, and exits with `exitCode`. A `/bin/sh` wrapper re-execs the very
+ * Node that is running the test, so the stub does not depend on `node` being
+ * on PATH.
+ */
+function makeStubConverter(options: {
+  name: string;
+  ext: string;
+  /** Bytes written to the output path; omit to write no file at all. */
+  writes?: Buffer;
+  stderr?: string;
+  exitCode?: number;
+}): string {
+  const { name, ext, writes, stderr = '', exitCode = 0 } = options;
+  const scriptPath = path.join(workDir, `${name}.mjs`);
+  const shimPath = path.join(workDir, name);
+  const payload = writes === undefined ? null : writes.toString('base64');
+
+  writeFileSync(
+    scriptPath,
+    `import { writeFileSync } from 'node:fs';\n` +
+      `import path from 'node:path';\n` +
+      `const argv = process.argv.slice(2);\n` +
+      `const outDir = argv[argv.indexOf('--outdir') + 1];\n` +
+      `const payload = ${JSON.stringify(payload)};\n` +
+      `if (payload !== null) {\n` +
+      `  writeFileSync(path.join(outDir, 'probe.${ext}'), Buffer.from(payload, 'base64'));\n` +
+      `}\n` +
+      `if (${JSON.stringify(stderr)}) process.stderr.write(${JSON.stringify(stderr)});\n` +
+      `process.exit(${exitCode});\n`,
+    'utf8',
+  );
+  writeFileSync(
+    shimPath,
+    `#!/bin/sh\nexec ${JSON.stringify(process.execPath)} ${JSON.stringify(scriptPath)} "$@"\n`,
+    'utf8',
+  );
+  chmodSync(shimPath, 0o755);
+  return shimPath;
+}
+
+/** A minimal but genuinely readable OPC package. */
+async function readablePackage(): Promise<Buffer> {
+  return createZipBuffer({
+    '[Content_Types].xml':
+      `<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"/>`,
+    '_rels/.rels':
+      `<?xml version="1.0"?><Relationships ` +
+      `xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+      `<Relationship Id="rId1" ` +
+      `Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" ` +
+      `Target="word/document.xml"/></Relationships>`,
+    'word/document.xml':
+      `<?xml version="1.0"?><w:document ` +
+      `xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
+      `<w:body><w:p><w:r><w:t>Stub converter output.</w:t></w:r></w:p></w:body></w:document>`,
+  });
+}
+
+const COMPLETE_PDF = Buffer.from('%PDF-1.7\n1 0 obj\n<<>>\nendobj\ntrailer\n%%EOF\n', 'latin1');
+const TRUNCATED_PDF = Buffer.from('%PDF-1.7\n1 0 obj\n<<>>\nendobj\n', 'latin1');
+/** A `PK\x03\x04` local-file header and nothing else — the issue #796 artifact. */
+const TRUNCATED_PACKAGE = Buffer.from('PKTRUNCATED', 'latin1');
+
+const GENERATED = Buffer.from('not a real docx — the stub never reads its input');
+
+beforeAll(() => {
+  workDir = mkdtempSync(path.join(os.tmpdir(), 'sdx-probe-stub-'));
+});
+
+afterAll(() => {
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+describe('Traceability: generation probes reject failed conversions', () => {
+  test('rejects a converter that failed after writing an output file', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    // The #796 reproduction: a non-zero exit alongside a partial output file.
+    // The old pass condition ("a file exists") accepted this.
+    const soffice = await given('a converter that writes a truncated docx then exits 1', () =>
+      makeStubConverter({
+        name: 'fails-after-writing',
+        ext: 'docx',
+        writes: TRUNCATED_PACKAGE,
+        stderr: 'Error: source file could not be loaded\n',
+        exitCode: 1,
+      }),
+    );
+
+    let failure: unknown;
+    let returned: unknown;
+    await when('the identity probe runs', async () => {
+      try {
+        returned = await probeDocxIdentity(GENERATED, soffice);
+      } catch (error) {
+        failure = error;
+      }
+    });
+
+    await then('the exit status and the captured stderr both reach the caller', () => {
+      // Stated as a behaviour first: before #796 this resolved, handing back
+      // the 11-byte stand-in as `savedPackage`.
+      expect(returned).toBeUndefined();
+      expect(failure).toBeInstanceOf(ConvertProbeError);
+      expect((failure as ConvertProbeError).diagnostics.exitCode).toBe(1);
+      expect((failure as ConvertProbeError).diagnostics.signal).toBeNull();
+      expect((failure as ConvertProbeError).diagnostics.output).toContain(
+        'source file could not be loaded',
+      );
+      expect((failure as Error).message).toContain('exit 1');
+      expect((failure as Error).message).toContain('source file could not be loaded');
+    });
+  });
+
+  test('rejects a failed run even when its output would have passed inspection', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    // Isolates the exit-status check. Every other check in the probe passes
+    // on these bytes — the file exists, is non-empty, and is a readable
+    // package — so the ONLY thing that can reject this run is the converter's
+    // own verdict. Without this case the status check is covered incidentally
+    // by artifacts that happen to fail inspection too, and deleting it leaves
+    // the suite green.
+    const soffice = await given('a converter that writes a readable package then exits 77', async () =>
+      makeStubConverter({
+        name: 'fails-with-good-output',
+        ext: 'docx',
+        writes: await readablePackage(),
+        stderr: 'Warning: the document was recovered\n',
+        exitCode: 77,
+      }),
+    );
+
+    let failure: unknown;
+    let returned: unknown;
+    await when('the identity probe runs', async () => {
+      try {
+        returned = await probeDocxIdentity(GENERATED, soffice);
+      } catch (error) {
+        failure = error;
+      }
+    });
+
+    await then('a non-zero exit is disqualifying on its own', () => {
+      expect(returned).toBeUndefined();
+      expect(failure).toBeInstanceOf(ConvertProbeError);
+      expect((failure as ConvertProbeError).diagnostics.exitCode).toBe(77);
+      expect((failure as Error).message).toContain('exit 77');
+    });
+  });
+
+  test('rejects an empty output file left by a converter that exited 0', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    const soffice = await given('a converter that writes zero bytes and succeeds', () =>
+      makeStubConverter({
+        name: 'writes-empty',
+        ext: 'docx',
+        writes: Buffer.alloc(0),
+      }),
+    );
+
+    let failure: unknown;
+    await when('the identity probe runs', async () => {
+      try {
+        await probeDocxIdentity(GENERATED, soffice);
+      } catch (error) {
+        failure = error;
+      }
+    });
+
+    await then('an empty file is not mistaken for a package', () => {
+      expect(failure).toBeInstanceOf(ConvertProbeError);
+      expect((failure as Error).message).toContain('empty');
+    });
+  });
+
+  test('rejects a docx that is not a readable package despite a clean exit', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    // Exit 0, file present, non-zero length — everything the old check looked
+    // at. Only reading the package catches this.
+    const soffice = await given('a converter that writes a truncated zip and succeeds', () =>
+      makeStubConverter({
+        name: 'writes-truncated-zip',
+        ext: 'docx',
+        writes: TRUNCATED_PACKAGE,
+      }),
+    );
+
+    let failure: unknown;
+    await when('the identity probe runs', async () => {
+      try {
+        await probeDocxIdentity(GENERATED, soffice);
+      } catch (error) {
+        failure = error;
+      }
+    });
+
+    await then('the probe reports an unreadable package rather than a pass', () => {
+      expect(failure).toBeInstanceOf(ConvertProbeError);
+      expect((failure as ConvertProbeError).diagnostics.exitCode).toBe(0);
+      expect((failure as Error).message).toMatch(/not a readable ZIP|no _rels\/\.rels/);
+    });
+  });
+
+  test('rejects a truncated PDF that still carries the %PDF- header', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    // The magic-byte assertion the PDF probe's caller makes passes on these
+    // bytes; only the trailer check does not.
+    const soffice = await given('a converter that writes a headed but unterminated pdf', () =>
+      makeStubConverter({
+        name: 'writes-truncated-pdf',
+        ext: 'pdf',
+        writes: TRUNCATED_PDF,
+      }),
+    );
+
+    let failure: unknown;
+    await when('the pdf probe runs', async () => {
+      try {
+        await probeDocxToPdf(GENERATED, soffice);
+      } catch (error) {
+        failure = error;
+      }
+    });
+
+    await then('the missing %%EOF trailer is reported', () => {
+      expect(TRUNCATED_PDF.subarray(0, 5).toString('latin1')).toBe('%PDF-');
+      expect(TRUNCATED_PDF.length).toBeGreaterThan(0);
+      expect(failure).toBeInstanceOf(ConvertProbeError);
+      expect((failure as Error).message).toContain('%%EOF');
+    });
+  });
+
+  test('control: a clean run producing a readable package passes', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    // Green control for the three docx rejections above. Same stub harness,
+    // same code path; only the produced artifact differs.
+    const soffice = await given('a converter that writes a readable package and exits 0', async () =>
+      makeStubConverter({
+        name: 'writes-readable-package',
+        ext: 'docx',
+        writes: await readablePackage(),
+      }),
+    );
+
+    const probe = await when('the identity probe runs', () =>
+      probeDocxIdentity(GENERATED, soffice),
+    );
+
+    await then('the probe returns the saved package and a clean status', () => {
+      expect(probe.savedPackage.length).toBeGreaterThan(0);
+      expect(probe.diagnostics.exitCode).toBe(0);
+      expect(probe.diagnostics.signal).toBeNull();
+    });
+  });
+
+  test('control: a clean run producing a complete PDF passes', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    const soffice = await given('a converter that writes a terminated pdf and exits 0', () =>
+      makeStubConverter({
+        name: 'writes-complete-pdf',
+        ext: 'pdf',
+        writes: COMPLETE_PDF,
+      }),
+    );
+
+    const probe = await when('the pdf probe runs', () => probeDocxToPdf(GENERATED, soffice));
+
+    await then('the probe returns the pdf and a clean status', () => {
+      expect(probe.pdf.subarray(0, 5).toString('latin1')).toBe('%PDF-');
+      expect(probe.diagnostics.exitCode).toBe(0);
+    });
+  });
+
+  test('rejects a converter that produced no output at all', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    // The pre-existing load-failure path, kept because real LibreOffice
+    // signals a load failure this way: exit 0, stderr text, and no file.
+    // The status check added for #796 does not cover it.
+    const soffice = await given('a converter that writes nothing and exits 0', () =>
+      makeStubConverter({
+        name: 'writes-nothing',
+        ext: 'docx',
+        stderr: 'Error: source file could not be loaded\n',
+      }),
+    );
+
+    let failure: unknown;
+    await when('the identity probe runs', async () => {
+      try {
+        await probeDocxIdentity(GENERATED, soffice);
+      } catch (error) {
+        failure = error;
+      }
+    });
+
+    await then('the load-failure diagnosis still fires, with the stderr attached', () => {
+      expect(failure).toBeInstanceOf(ConvertProbeError);
+      expect((failure as ConvertProbeError).diagnostics.exitCode).toBe(0);
+      expect((failure as Error).message).toContain('likely a load failure');
+      expect((failure as Error).message).toContain('source file could not be loaded');
+    });
+  });
+});

--- a/packages/docx-core/src/integration/generation-probes.test.ts
+++ b/packages/docx-core/src/integration/generation-probes.test.ts
@@ -103,7 +103,7 @@ async function readablePackage(): Promise<Buffer> {
 const COMPLETE_PDF = Buffer.from('%PDF-1.7\n1 0 obj\n<<>>\nendobj\ntrailer\n%%EOF\n', 'latin1');
 const TRUNCATED_PDF = Buffer.from('%PDF-1.7\n1 0 obj\n<<>>\nendobj\n', 'latin1');
 /** A `PK\x03\x04` local-file header and nothing else — the issue #796 artifact. */
-const TRUNCATED_PACKAGE = Buffer.from('PKTRUNCATED', 'latin1');
+const TRUNCATED_PACKAGE = Buffer.from('PK\u0003\u0004TRUNCATED', 'latin1');
 
 const GENERATED = Buffer.from('not a real docx — the stub never reads its input');
 

--- a/packages/docx-core/src/integration/generation-probes.ts
+++ b/packages/docx-core/src/integration/generation-probes.ts
@@ -7,12 +7,24 @@
  * are dispatch-only. These probes have a different contract — a complete
  * generated package goes in, and the *saved package* (or rendered PDF) comes
  * back out — and need no macro: `--convert-to` performs exactly the
- * load→save (or load→render) cycle that exposes recovery-dialog failures,
- * because a package LibreOffice cannot load cleanly produces no output.
+ * load→save (or load→render) cycle that exposes recovery-dialog failures.
+ *
+ * A probe's pass condition is a statement about the artifact, never about a
+ * file existing at a path: the run must not have failed, and what it produced
+ * must be readable as the thing it claims to be. Do not weaken these back to
+ * `existsSync` — a converter that fails *after* writing a partial file
+ * satisfies that and nothing else (issue #796).
+ *
+ * The exit status is necessary but not sufficient, and neither is the output
+ * check. Measured on LibreOffice 25.8 (2026-08): an unloadable source exits
+ * **0**, writes `Error: source file could not be loaded` to stderr, and
+ * produces no output file — so the status check added for #796 does not
+ * subsume the file checks, and the file checks do not subsume it.
  *
  * Local-only, like the oracle: callers skip when `resolveSoffice()` is null
  * (CI does not install LibreOffice; the structural checks are the
- * CI-enforceable proxy).
+ * CI-enforceable proxy). `generation-probes.test.ts` drives the probes against
+ * a stub converter instead, so the failure paths are covered in CI.
  */
 import { execFile } from 'node:child_process';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
@@ -20,20 +32,66 @@ import os from 'node:os';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { promisify } from 'node:util';
+import { parseXml } from '../primitives/xml.js';
+import { readZipText } from '../primitives/zip.js';
 import { resolveSoffice } from './libreoffice-oracle.js';
 
 const execFileAsync = promisify(execFile);
 
+export type ConvertDiagnostics = {
+  /** Process exit code, or null when the run was terminated by a signal. */
+  readonly exitCode: number | null;
+  /** Terminating signal, when the run was killed (the 45s timeout ⇒ SIGKILL). */
+  readonly signal: string | null;
+  /** Captured soffice stderr (falling back to stdout), kept on every path. */
+  readonly output: string;
+};
+
 export type DocxIdentityProbeResult = {
   /** The package as re-saved by LibreOffice's DOCX export filter. */
   savedPackage: Buffer;
+  /** Exit status and captured output of the converting run. */
+  diagnostics: ConvertDiagnostics;
 };
 
 export type DocxPdfProbeResult = {
   pdf: Buffer;
+  /** Exit status and captured output of the converting run. */
+  diagnostics: ConvertDiagnostics;
 };
 
-async function runConvert(input: Buffer, convertTo: string, outExt: string, soffice: string): Promise<Buffer> {
+/**
+ * Raised when the converter did not produce a usable artifact.
+ *
+ * Carries the exit status and the captured output on *every* rejection path —
+ * including the path where an output file exists despite a failed run, which
+ * `runConvert` previously reported as a success.
+ *
+ * @see https://github.com/UseJunior/safe-docx/issues/796
+ */
+export class ConvertProbeError extends Error {
+  readonly diagnostics: ConvertDiagnostics;
+
+  constructor(message: string, diagnostics: ConvertDiagnostics) {
+    const status =
+      diagnostics.signal !== null
+        ? `killed by ${diagnostics.signal}`
+        : `exit ${diagnostics.exitCode ?? 'unknown'}`;
+    super(
+      `${message}\nsoffice status: ${status}\nsoffice output:\n` +
+        `${diagnostics.output.trim() || '(no output)'}`,
+    );
+    this.name = 'ConvertProbeError';
+    this.diagnostics = diagnostics;
+  }
+}
+
+async function runConvert(
+  input: Buffer,
+  convertTo: string,
+  outExt: string,
+  soffice: string,
+): Promise<{ output: Buffer; diagnostics: ConvertDiagnostics }> {
   const work = mkdtempSync(path.join(os.tmpdir(), 'sdx-gen-probe-'));
   try {
     const inDir = path.join(work, 'in');
@@ -56,47 +114,171 @@ async function runConvert(input: Buffer, convertTo: string, outExt: string, soff
       outDir,
       inPath,
     ];
-    let diag = '';
+    let diagnostics: ConvertDiagnostics;
     try {
       const r = await execFileAsync(soffice, args, { timeout: 45_000, killSignal: 'SIGKILL', maxBuffer: 8 * 1024 * 1024 });
-      diag = String(r.stderr ?? '') || String(r.stdout ?? '');
+      diagnostics = {
+        exitCode: 0,
+        signal: null,
+        output: String(r.stderr ?? '') || String(r.stdout ?? ''),
+      };
     } catch (err) {
-      const e = err as { stdout?: unknown; stderr?: unknown; message?: string };
-      diag = String(e.stderr ?? e.stdout ?? e.message ?? '');
+      const e = err as {
+        stdout?: unknown;
+        stderr?: unknown;
+        message?: string;
+        code?: unknown;
+        signal?: unknown;
+      };
+      diagnostics = {
+        // execFile surfaces a signal death with no numeric code, and a
+        // spawn failure (ENOENT) with a string code — neither is an exit
+        // status, so both land as null and the signal/status check below
+        // still rejects because exitCode !== 0.
+        exitCode: typeof e.code === 'number' ? e.code : null,
+        signal: typeof e.signal === 'string' ? e.signal : null,
+        output: String(e.stderr ?? e.stdout ?? e.message ?? ''),
+      };
+    }
+
+    // Fail on the converter's own verdict FIRST, so a failed run that still
+    // dropped a partial file at the output path cannot be read back as a
+    // success. Note that LibreOffice does NOT always signal a load failure
+    // this way (observed: exit 0 with "Error: source file could not be
+    // loaded" on stderr and no output at all), which is why the file checks
+    // below remain and are not replaced by the status check.
+    if (diagnostics.exitCode !== 0 || diagnostics.signal !== null) {
+      throw new ConvertProbeError(
+        `LibreOffice failed while converting the generated package to ${outExt}.`,
+        diagnostics,
+      );
     }
 
     const outPath = path.join(outDir, `probe.${outExt}`);
     if (!existsSync(outPath)) {
-      throw new Error(
+      throw new ConvertProbeError(
         `LibreOffice could not convert the generated package to ${outExt} — likely a load failure ` +
-          `(the recovery-dialog class of bug).\nsoffice output:\n${diag.trim() || '(no output)'}`,
+          `(the recovery-dialog class of bug).`,
+        diagnostics,
       );
     }
-    return readFileSync(outPath);
+    const output = readFileSync(outPath);
+    if (output.length === 0) {
+      throw new ConvertProbeError(
+        `LibreOffice produced an empty ${outExt} at the output path.`,
+        diagnostics,
+      );
+    }
+    return { output, diagnostics };
   } finally {
     rmSync(work, { recursive: true, force: true });
   }
 }
 
+const OFFICE_DOCUMENT_RELATIONSHIP =
+  'http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument';
+
+/**
+ * The main-document part named by the package-level officeDocument
+ * relationship, normalized to a zip entry name.
+ *
+ * OPC selects the main part by relationship, not by a fixed path, so this
+ * resolves `_rels/.rels` rather than assuming `word/document.xml`.
+ */
+function mainDocumentPartPath(packageRelsXml: string): string | undefined {
+  const relationships = parseXml(packageRelsXml).getElementsByTagName('Relationship');
+  for (const relationship of Array.from(relationships)) {
+    if (relationship.getAttribute('Type') !== OFFICE_DOCUMENT_RELATIONSHIP) continue;
+    const target = relationship.getAttribute('Target');
+    if (!target) continue;
+    // Package-relative targets may be written with a leading slash.
+    return target.replace(/^\/+/, '');
+  }
+  return undefined;
+}
+
 /**
  * Load→save a complete generated package through LibreOffice's DOCX filter.
- * Throws when LibreOffice cannot load the package (no output is produced).
+ *
+ * Throws when the converter fails, when it produces no output, or when what it
+ * produced is not a readable OPC package — the probe's pass condition is that
+ * the re-saved artifact IS a package, not that a file appeared at a path.
  */
 export async function probeDocxIdentity(
   generated: Buffer,
   soffice: string | null = resolveSoffice(),
 ): Promise<DocxIdentityProbeResult> {
   if (!soffice) throw new Error('probeDocxIdentity: no soffice binary (call resolveSoffice() and skip)');
-  const savedPackage = await runConvert(generated, 'docx:MS Word 2007 XML', 'docx', soffice);
-  return { savedPackage };
+  const { output: savedPackage, diagnostics } = await runConvert(
+    generated,
+    'docx:MS Word 2007 XML',
+    'docx',
+    soffice,
+  );
+  let packageRels: string | null;
+  try {
+    packageRels = await readZipText(savedPackage, '_rels/.rels');
+  } catch (err) {
+    throw new ConvertProbeError(
+      `LibreOffice wrote a ${savedPackage.length}-byte .docx that is not a readable ZIP ` +
+        `(${(err as Error).message}).`,
+      diagnostics,
+    );
+  }
+  if (packageRels === null) {
+    throw new ConvertProbeError(
+      `LibreOffice wrote a ${savedPackage.length}-byte .docx with no _rels/.rels part.`,
+      diagnostics,
+    );
+  }
+  // The main part is whatever the package-level officeDocument relationship
+  // points at. `word/document.xml` is only a convention — resolving the
+  // relationship is what makes this a package check rather than a guess about
+  // one producer's layout.
+  const mainPartPath = mainDocumentPartPath(packageRels);
+  if (mainPartPath === undefined) {
+    throw new ConvertProbeError(
+      `LibreOffice wrote a ${savedPackage.length}-byte .docx whose _rels/.rels declares no ` +
+        `officeDocument relationship.`,
+      diagnostics,
+    );
+  }
+  const mainPart = await readZipText(savedPackage, mainPartPath);
+  if (mainPart === null) {
+    throw new ConvertProbeError(
+      `LibreOffice wrote a ${savedPackage.length}-byte .docx whose officeDocument relationship ` +
+        `targets ${mainPartPath}, which is not in the package.`,
+      diagnostics,
+    );
+  }
+  return { savedPackage, diagnostics };
 }
 
-/** Render a generated package to PDF headlessly — the headless-renderer probe. */
+/**
+ * Render a generated package to PDF headlessly — the headless-renderer probe.
+ *
+ * Throws when the converter fails or when the rendered bytes are not a
+ * complete PDF. The `%PDF-` header alone is a magic-byte check that a
+ * truncated render passes, so the trailing `%%EOF` marker is checked too.
+ */
 export async function probeDocxToPdf(
   generated: Buffer,
   soffice: string | null = resolveSoffice(),
 ): Promise<DocxPdfProbeResult> {
   if (!soffice) throw new Error('probeDocxToPdf: no soffice binary (call resolveSoffice() and skip)');
-  const pdf = await runConvert(generated, 'pdf', 'pdf', soffice);
-  return { pdf };
+  const { output: pdf, diagnostics } = await runConvert(generated, 'pdf', 'pdf', soffice);
+  if (pdf.subarray(0, 5).toString('latin1') !== '%PDF-') {
+    throw new ConvertProbeError(
+      `LibreOffice wrote a ${pdf.length}-byte .pdf without a %PDF- header.`,
+      diagnostics,
+    );
+  }
+  // The trailer lives at the end of the file, possibly followed by whitespace.
+  if (!pdf.subarray(-1024).toString('latin1').includes('%%EOF')) {
+    throw new ConvertProbeError(
+      `LibreOffice wrote a ${pdf.length}-byte .pdf with no %%EOF trailer — the render is truncated.`,
+      diagnostics,
+    );
+  }
+  return { pdf, diagnostics };
 }


### PR DESCRIPTION
Fixes #796.

## What was wrong

`runConvert()` caught the LibreOffice subprocess error, **discarded it**, and then decided the probe had passed purely on whether a file existed at the output path. A converter that fails *after* dropping a partial file satisfies that. The captured diagnostic was already attached on the file-*missing* path — it was lost on exactly the path that mattered.

**Low severity and latent.** The two current call sites are not badly exposed; `probeDocxIdentity`'s test does check content. But `probeDocxToPdf`'s asserts only `length > 0` and the `%PDF-` magic bytes, which a truncated render passes, and the weakness is inherited by whatever calls these next.

## Reproduction, at `8035dce`

A stand-in `soffice` that writes a truncated file and exits 1:

```
$ node repro-probe.mjs ./fake-soffice.sh
  probeDocxIdentity RETURNED (no error raised)
  savedPackage bytes : 13
  savedPackage       : "PKTRUNCATED"
```

The converter exited 1 and wrote `Error: source file could not be loaded` to stderr. The probe returned a 13-byte truncated "package" as a success, and neither the exit status nor the message reached the caller. After the fix:

```
  threw: ConvertProbeError: LibreOffice failed while converting the generated package to docx.
soffice status: exit 1
soffice output:
Error: source file could not be loaded
```

## The measurement that shaped the fix

The obvious reading of the issue title is "check the exit status". On its own that would catch almost nothing. Measured against real LibreOffice 25.8:

| case | exit | stderr | output file |
|---|---|---|---|
| valid docx to docx | **0** | (macOS noise only) | written |
| valid docx to pdf | **0** | (macOS noise only) | written |
| **unloadable** source | **0** | `Error: source file could not be loaded` | **none** |

LibreOffice exits 0 even when it cannot load the source. So the status check does **not** subsume the output checks, and the output checks do not subsume it. Both are kept, and the module docstring records the measurement so a future reader does not collapse them.

The same table answers the false-failure question: no observed conversion exits non-zero on success, so adding the status check adds a rejection without removing one. The contrasting `runSoffice()` in `libreoffice-oracle.ts`, which deliberately tolerates a non-zero exit, is a different process contract — its macro terminates the desktop. Untouched.

## What changed

Success is now a statement about the artifact, not about a file existing at a path:

- exit status and terminating signal are recorded rather than discarded, and a failed run is rejected **before** the output path is consulted;
- a zero-length output is rejected;
- the re-saved `.docx` must be a readable package whose main part resolves through the package-level `officeDocument` relationship — `word/document.xml` is a convention, not an OPC rule, so the relationship is followed instead of assumed;
- the rendered `.pdf` must carry a `%%EOF` trailer, not just a `%PDF-` header;
- a new `ConvertProbeError` carries the exit status and captured output on **every** rejection path, and both probe results expose the same diagnostics.

The real-LibreOffice probes are now gated on `probeSofficeUsable()`, so a binary that is present but cannot launch (sandbox SIGABRT) skips rather than failing with exit 134.

## Tests, and proof they can go red

The probes are gated on a real LibreOffice, which CI does not install — so the new tests drive them against a **stub converter**, which both runs in CI and can script failure modes a real binary will not reproduce on demand. Every rejection is paired with a green control differing only in the property under test.

One test exists because of a negative control that came back green when it should not have: neutralising only the exit-status predicate left the whole suite passing, because the truncated artifact also failed the package check. The status check was covered only *incidentally*. `rejects a failed run even when its output would have passed inspection` — a converter that exits 77 while writing a perfectly readable package — isolates it:

| Mutation | Result |
|---|---|
| disable only the exit-status predicate | the isolating test fails |
| disable only the `%%EOF` predicate | the truncated-PDF test fails |
| none | `8 passed` |

Both bugs in this batch are instances of one class: a check that passes by construction. `undefined !== undefined` and "the file exists so it worked" are two spellings of the same mistake — and a test that passes by construction is that mistake one level up, which is what the control above caught.

## Verification

- `npm run test:run -w @usejunior/docx-core` — 130 files passed, 1 skipped; 1333 passed
- Real-LibreOffice gated probes run and pass locally with the new content checks — no false failures
- Peer-reviewed with `/peer-review --codex` (`--code` lane, full execution trace). Verdict APPROVE-WITH-CHANGES; both must-fix items (resolve the main part through `_rels/.rels`; gate on `probeSofficeUsable()`) are addressed here.

Fixtures are fully synthetic.
