### PR TITLE
fix(docx-compare): count text boxes by rendered branch, not stored copy

### DIFF
--- a/packages/docx-compare/src/baselines/atomizer/pipeline.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline.ts
@@ -617,7 +617,7 @@ export async function compareDocumentsAtomizer(
   }
   if (options.reconstructionMode !== 'inplace') {
     throw new UnsupportedTextBoxRevisionError([{
-      index: textBoxPlan.stories[0]?.index ?? 0,
+      index: textBoxPlan.stories[0]?.visualIndex ?? 0,
       partPath: textBoxPlan.stories[0]?.partPath ?? 'word/document.xml',
       reason: 'changed text-box stories currently require reconstructionMode=inplace',
     }]);
@@ -635,7 +635,7 @@ export async function compareDocumentsAtomizer(
   );
   if (outerResult.reconstructionModeUsed !== 'inplace') {
     throw new UnsupportedTextBoxRevisionError([{
-      index: textBoxPlan.stories[0]?.index ?? 0,
+      index: textBoxPlan.stories[0]?.visualIndex ?? 0,
       partPath: textBoxPlan.stories[0]?.partPath ?? 'word/document.xml',
       reason: 'the outer document required rebuild fallback',
     }]);
@@ -643,6 +643,7 @@ export async function compareDocumentsAtomizer(
 
   const storyResults: Array<{
     index: number;
+    visualIndex: number;
     partPath: string;
     container: 'textBox' | 'ancillaryPart';
     result: CompareResult;
@@ -664,7 +665,7 @@ export async function compareDocumentsAtomizer(
     );
     if (result.reconstructionModeUsed !== 'inplace') {
       throw new UnsupportedTextBoxRevisionError([{
-        index: story.index,
+        index: story.visualIndex,
         partPath: story.partPath,
         reason: 'the nested story required rebuild fallback',
       }]);
@@ -694,6 +695,7 @@ export async function compareDocumentsAtomizer(
     }
     storyResults.push({
       index: story.index,
+      visualIndex: story.visualIndex,
       partPath: story.partPath,
       container: story.container,
       result,
@@ -702,8 +704,9 @@ export async function compareDocumentsAtomizer(
 
   const document = await assembleTextBoxStoryComparison(
     outerResult.document,
-    storyResults.map(({ index, partPath, container, result }) => ({
+    storyResults.map(({ index, visualIndex, partPath, container, result }) => ({
       index,
+      visualIndex,
       partPath,
       container,
       document: result.document,
@@ -724,7 +727,7 @@ export async function compareDocumentsAtomizer(
     !rejectedComparison.normalizedIdentical
   ) {
     throw new UnsupportedTextBoxRevisionError([{
-      index: textBoxPlan.stories[0]?.index ?? 0,
+      index: textBoxPlan.stories[0]?.visualIndex ?? 0,
       partPath: textBoxPlan.stories[0]?.partPath ?? 'word/document.xml',
       reason: 'assembled nested stories failed accept/reject round-trip validation',
     }]);

--- a/packages/docx-compare/src/baselines/atomizer/textBoxRevisionSafety-alternate-content.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/textBoxRevisionSafety-alternate-content.test.ts
@@ -1,0 +1,650 @@
+/**
+ * A text box a user drew once is stored twice, so every ordinal safe-docx
+ * reports for it has to count visible boxes rather than stored copies.
+ *
+ * @conformance ECMA-376 edition 5, Part 4 § 14.9.1.1
+ * @conformance ECMA-376 edition 5, Part 4 § 19.1.2.22
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.5.14
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.5.18
+ * @see https://github.com/UseJunior/safe-docx/issues/794
+ * @see https://github.com/UseJunior/safe-docx/issues/713
+ */
+
+import { describe, expect } from 'vitest';
+import { DocxArchive, OOXML } from '@usejunior/docx-core';
+import { buildDocxFromBodyXml } from '../../testing/ooxml-fixtures.js';
+import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
+import { compareDocumentsAtomizer } from './pipeline.js';
+import {
+  assertTextBoxContentUnchanged,
+  prepareTextBoxStoryComparison,
+  UnsupportedTextBoxRevisionError,
+} from './textBoxRevisionSafety.js';
+
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({
+    feature: 'In-Place Reconstruction',
+    story: 'VML Text-Box Stories',
+    severity: 'critical',
+  })
+  .conformance(
+    { spec: 'ECMA-376', edition: 5, part: 4, section: '14.9.1.1' },
+    { spec: 'ECMA-376', edition: 5, part: 4, section: '19.1.2.22' },
+    { spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.5.14' },
+    { spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.5.18' },
+  );
+
+const FIXED_DATE = new Date('2026-08-11T12:00:00Z');
+
+const ALTERNATE_CONTENT_NAMESPACES = {
+  namespaces: {
+    wp: 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing',
+    a: 'http://schemas.openxmlformats.org/drawingml/2006/main',
+    wps: 'http://schemas.microsoft.com/office/word/2010/wordprocessingShape',
+    v: 'urn:schemas-microsoft-com:vml',
+  },
+  ignorablePrefixes: ['wps'],
+} as const;
+
+/** The DrawingML spelling Word renders. */
+function choiceBranch(text: string): string {
+  return (
+    `<mc:Choice Requires="wps"><w:drawing><wp:inline><a:graphic>` +
+    `<a:graphicData><wps:wsp><wps:txbx><w:txbxContent>` +
+    `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>` +
+    `</w:txbxContent></wps:txbx></wps:wsp></a:graphicData></a:graphic>` +
+    `</wp:inline></w:drawing></mc:Choice>`
+  );
+}
+
+/** The VML spelling Word keeps for readers that cannot render the choice. */
+function fallbackBranch(text: string): string {
+  return (
+    `<mc:Fallback><w:pict><v:shape><v:textbox><w:txbxContent>` +
+    `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>` +
+    `</w:txbxContent></v:textbox></v:shape></w:pict></mc:Fallback>`
+  );
+}
+
+/**
+ * One visual text box, stored twice inside one `mc:AlternateContent`, exactly
+ * the way Word writes a modern shape. `fallbackText` differs from `text` only
+ * in fixtures that deliberately let the two branches disagree.
+ */
+function twinTextBox(text: string, fallbackText: string = text): string {
+  return (
+    `<w:p><w:r><mc:AlternateContent>` +
+    choiceBranch(text) +
+    fallbackBranch(fallbackText) +
+    `</mc:AlternateContent></w:r></w:p>`
+  );
+}
+
+/** One `mc:Choice` box against two `mc:Fallback` boxes: the copies cannot pair. */
+function surplusFallbackBox(
+  choiceText: string,
+  fallbackText: string,
+  surplusText: string,
+): string {
+  return (
+    `<w:p><w:r><mc:AlternateContent>` +
+    choiceBranch(choiceText) +
+    `<mc:Fallback><w:pict>` +
+    `<v:shape><v:textbox><w:txbxContent>` +
+    `<w:p><w:r><w:t>${fallbackText}</w:t></w:r></w:p>` +
+    `</w:txbxContent></v:textbox></v:shape>` +
+    `<v:shape><v:textbox><w:txbxContent>` +
+    `<w:p><w:r><w:t>${surplusText}</w:t></w:r></w:p>` +
+    `</w:txbxContent></v:textbox></v:shape>` +
+    `</w:pict></mc:Fallback>` +
+    `</mc:AlternateContent></w:r></w:p>`
+  );
+}
+
+/** Two `mc:Choice` boxes against one `mc:Fallback` box. */
+function surplusChoiceBox(
+  firstText: string,
+  surplusText: string,
+  fallbackText: string,
+): string {
+  return (
+    `<w:p><w:r><mc:AlternateContent>` +
+    `<mc:Choice Requires="wps"><w:drawing><wp:inline><a:graphic>` +
+    `<a:graphicData><wps:wsp><wps:txbx><w:txbxContent>` +
+    `<w:p><w:r><w:t>${firstText}</w:t></w:r></w:p>` +
+    `</w:txbxContent></wps:txbx></wps:wsp>` +
+    `<wps:wsp><wps:txbx><w:txbxContent>` +
+    `<w:p><w:r><w:t>${surplusText}</w:t></w:r></w:p>` +
+    `</w:txbxContent></wps:txbx></wps:wsp>` +
+    `</a:graphicData></a:graphic></wp:inline></w:drawing></mc:Choice>` +
+    fallbackBranch(fallbackText) +
+    `</mc:AlternateContent></w:r></w:p>`
+  );
+}
+
+/** A pre-2010 VML text box: one stored copy, no alternate content. */
+function plainVmlTextBox(text: string): string {
+  return (
+    `<w:p><w:r><w:pict><v:shape><v:textbox><w:txbxContent>` +
+    `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>` +
+    `</w:txbxContent></v:textbox></v:shape></w:pict></w:r></w:p>`
+  );
+}
+
+function bodyXml(...boxes: string[]): string {
+  return boxes.join('');
+}
+
+async function documentXmlOf(body: string): Promise<string> {
+  const docx = await buildDocxFromBodyXml(
+    body,
+    [],
+    ALTERNATE_CONTENT_NAMESPACES,
+  );
+  return (await DocxArchive.load(docx)).getDocumentXml();
+}
+
+function refusal(
+  original: string,
+  revised: string,
+): UnsupportedTextBoxRevisionError | undefined {
+  try {
+    assertTextBoxContentUnchanged(original, revised);
+    return undefined;
+  } catch (error) {
+    return error as UnsupportedTextBoxRevisionError;
+  }
+}
+
+/** Every `w:txbxContent` subtree in the compared output, in storage order. */
+function storedCopies(xml: string): string[] {
+  return xml
+    .split('<w:txbxContent')
+    .slice(1)
+    .map((slice) => slice.slice(0, slice.indexOf('</w:txbxContent>')));
+}
+
+describe('mc:AlternateContent text-box ordinals', () => {
+  test(
+    'the reported locator names the visible box, not a stored copy',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      const original = await given(
+        'two text boxes each stored as an mc:Choice / mc:Fallback pair',
+        () => documentXmlOf(bodyXml(twinTextBox('Charlie'), twinTextBox('Echo'))),
+      );
+      const revised = await given('only the second box is edited', () =>
+        documentXmlOf(bodyXml(twinTextBox('Charlie'), twinTextBox('Foxtrot'))),
+      );
+
+      const error = await when('the guard refuses the change', () =>
+        refusal(original, revised),
+      );
+
+      await then('exactly one changed container is reported', () => {
+        expect(error?.changes).toHaveLength(1);
+      });
+      await and('its ordinal is the second visible box', () => {
+        expect(error?.changes[0]?.index).toBe(1);
+        expect(error?.message).toContain('word/document.xml#w:txbxContent[1]');
+      });
+    },
+  );
+
+  test(
+    'the reported ordinal tracks position rather than collapsing to a constant',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      // Negative control for the ordinal. An implementation that always
+      // reported 0, or that reported the raw storage index, would fail here
+      // while still passing the two-box case above.
+      const original = await given('three twinned text boxes', () =>
+        documentXmlOf(
+          bodyXml(
+            twinTextBox('Charlie'),
+            twinTextBox('Echo'),
+            twinTextBox('Foxtrot'),
+          ),
+        ),
+      );
+      const revised = await given('only the third box is edited', () =>
+        documentXmlOf(
+          bodyXml(
+            twinTextBox('Charlie'),
+            twinTextBox('Echo'),
+            twinTextBox('Golf'),
+          ),
+        ),
+      );
+
+      const error = await when('the guard refuses the change', () =>
+        refusal(original, revised),
+      );
+
+      await then('the third visible box is named', () => {
+        expect(error?.changes.map((change) => change.index)).toEqual([2]);
+      });
+      await and('the raw storage ordinals 4 and 5 are not reported', () => {
+        expect(error?.message).not.toContain('w:txbxContent[4]');
+        expect(error?.message).not.toContain('w:txbxContent[5]');
+      });
+    },
+  );
+
+  test(
+    'a change confined to the unrendered fallback branch is still refused',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      // The dangerous direction. Counting visually must not make the guard
+      // blind to content it never shows: the fallback branch is still bytes in
+      // the package that a comparison has to account for.
+      const original = await given('a twinned text box with matching branches', () =>
+        documentXmlOf(bodyXml(twinTextBox('Charlie'))),
+      );
+      const revised = await given(
+        'the same box with only its mc:Fallback copy edited',
+        () => documentXmlOf(bodyXml(twinTextBox('Charlie', 'Delta'))),
+      );
+
+      const error = await when('the guard inspects the pair', () =>
+        refusal(original, revised),
+      );
+
+      await then('the change is not silently accepted', () => {
+        expect(error).toBeInstanceOf(UnsupportedTextBoxRevisionError);
+      });
+      await and('it is attributed to the single visible box', () => {
+        expect(error?.changes.map((change) => change.index)).toEqual([0]);
+      });
+    },
+  );
+
+  test(
+    'identical documents holding twinned boxes are not reported as changed',
+    async ({ given, when, then }: AllureBddContext) => {
+      const documentXml = await given('a document with two twinned boxes', () =>
+        documentXmlOf(bodyXml(twinTextBox('Charlie'), twinTextBox('Echo'))),
+      );
+
+      const error = await when('the guard compares it with itself', () =>
+        refusal(documentXml, documentXml),
+      );
+
+      await then('nothing is refused', () => {
+        expect(error).toBeUndefined();
+      });
+    },
+  );
+
+  test(
+    'the redline still lands in every stored copy of the changed box',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      // Counting visually changes what safe-docx reports, not what it writes.
+      // Both stored copies of a twinned box must keep carrying the same
+      // revision, or the accept and reject projections disagree with each
+      // other and Word shows a redline the package cannot undo.
+      const original = await given('two twinned text boxes', () =>
+        buildDocxFromBodyXml(
+          bodyXml(twinTextBox('Charlie'), twinTextBox('Echo')),
+          [],
+          ALTERNATE_CONTENT_NAMESPACES,
+        ),
+      );
+      const revised = await given('only the second box is edited', () =>
+        buildDocxFromBodyXml(
+          bodyXml(twinTextBox('Charlie'), twinTextBox('Foxtrot')),
+          [],
+          ALTERNATE_CONTENT_NAMESPACES,
+        ),
+      );
+
+      const compared = await when('the documents are compared in place', () =>
+        compareDocumentsAtomizer(original, revised, {
+          date: FIXED_DATE,
+          reconstructionMode: 'inplace',
+        }),
+      );
+      const comparedXml = await (
+        await DocxArchive.load(compared.document)
+      ).getDocumentXml();
+      const copies = storedCopies(comparedXml);
+
+      await then('the comparison stays on the in-place path', () => {
+        expect(compared.reconstructionModeUsed).toBe('inplace');
+      });
+      await and('the unchanged box carries no revision in either copy', () => {
+        expect(copies).toHaveLength(4);
+        expect(copies[0]).not.toContain('<w:ins ');
+        expect(copies[0]).not.toContain('<w:del ');
+        expect(copies[1]).not.toContain('<w:ins ');
+        expect(copies[1]).not.toContain('<w:del ');
+      });
+      await and('both copies of the changed box carry the same revision', () => {
+        for (const copy of copies.slice(2)) {
+          expect(copy).toContain('<w:ins ');
+          expect(copy).toContain('<w:del ');
+          expect(copy).toContain('Foxtrot');
+          expect(copy).toContain('Echo');
+        }
+      });
+    },
+  );
+
+  test(
+    'a mutation in a surplus fallback copy is refused',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      // Codex peer review, #794: grouping used to pair copies by position and
+      // silently discard whatever a branch held beyond the selected branch's
+      // count, so a change in the surplus copy reached no hash at all and the
+      // fail-closed guard accepted it.
+      const original = await given(
+        'one mc:Choice box against two mc:Fallback boxes',
+        () => documentXmlOf(surplusFallbackBox('Charlie', 'Charlie', 'Echo')),
+      );
+      const revised = await given('only the surplus fallback copy is edited', () =>
+        documentXmlOf(surplusFallbackBox('Charlie', 'Charlie', 'Foxtrot')),
+      );
+
+      const error = await when('the guard inspects the pair', () =>
+        refusal(original, revised),
+      );
+
+      await then('the change is refused rather than accepted', () => {
+        expect(error).toBeInstanceOf(UnsupportedTextBoxRevisionError);
+      });
+      await and('it is attributed to the one visible box', () => {
+        expect(error?.changes.map((change) => change.index)).toEqual([0]);
+      });
+    },
+  );
+
+  test(
+    'a mutation in a surplus choice copy is refused',
+    async ({ given, when, then }: AllureBddContext) => {
+      const original = await given(
+        'two mc:Choice boxes against one mc:Fallback box',
+        () => documentXmlOf(surplusChoiceBox('Charlie', 'Echo', 'Charlie')),
+      );
+      const revised = await given('only the surplus choice copy is edited', () =>
+        documentXmlOf(surplusChoiceBox('Charlie', 'Foxtrot', 'Charlie')),
+      );
+
+      const error = await when('the guard inspects the pair', () =>
+        refusal(original, revised),
+      );
+
+      await then('the change is refused', () => {
+        expect(error).toBeInstanceOf(UnsupportedTextBoxRevisionError);
+      });
+    },
+  );
+
+  test(
+    'a mutation reachable only through an empty selected branch is refused',
+    async ({ given, when, then }: AllureBddContext) => {
+      const shape = (text: string): string =>
+        `<w:p><w:r><mc:AlternateContent>` +
+        `<mc:Choice Requires="wps"><w:drawing/></mc:Choice>` +
+        fallbackBranch(text) +
+        `</mc:AlternateContent></w:r></w:p>`;
+      const original = await given(
+        'an mc:Choice with no text box and a fallback that has one',
+        () => documentXmlOf(shape('Charlie')),
+      );
+      const revised = await given('the fallback copy is edited', () =>
+        documentXmlOf(shape('Delta')),
+      );
+
+      const error = await when('the guard inspects the pair', () =>
+        refusal(original, revised),
+      );
+
+      await then('the change is refused', () => {
+        expect(error).toBeInstanceOf(UnsupportedTextBoxRevisionError);
+      });
+    },
+  );
+
+  test(
+    'a mutation under a non-Choice, non-Fallback MC child is refused',
+    async ({ given, when, then }: AllureBddContext) => {
+      const shape = (text: string): string =>
+        `<w:p><w:r><mc:AlternateContent>` +
+        `<mc:Something><w:pict><v:shape><v:textbox><w:txbxContent>` +
+        `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>` +
+        `</w:txbxContent></v:textbox></v:shape></w:pict></mc:Something>` +
+        `</mc:AlternateContent></w:r></w:p>`;
+      const original = await given(
+        'an mc:AlternateContent child the MCE schema does not define',
+        () => documentXmlOf(shape('Charlie')),
+      );
+      const revised = await given('its text box is edited', () =>
+        documentXmlOf(shape('Delta')),
+      );
+
+      const error = await when('the guard inspects the pair', () =>
+        refusal(original, revised),
+      );
+
+      await then('the change is refused rather than walked past', () => {
+        expect(error).toBeInstanceOf(UnsupportedTextBoxRevisionError);
+      });
+    },
+  );
+
+  test(
+    'a mutation inside a nested unbalanced mc:AlternateContent is refused',
+    async ({ given, when, then }: AllureBddContext) => {
+      const shape = (text: string): string =>
+        `<w:p><w:r><mc:AlternateContent>` +
+        `<mc:Choice Requires="wps"><w:drawing><wp:inline><a:graphic>` +
+        `<a:graphicData><wps:wsp><wps:txbx>` +
+        `<mc:AlternateContent>` +
+        `<mc:Choice Requires="wps"><w:txbxContent>` +
+        `<w:p><w:r><w:t>Charlie</w:t></w:r></w:p></w:txbxContent></mc:Choice>` +
+        `<mc:Fallback><w:txbxContent>` +
+        `<w:p><w:r><w:t>Charlie</w:t></w:r></w:p></w:txbxContent>` +
+        `<w:txbxContent><w:p><w:r><w:t>${text}</w:t></w:r></w:p></w:txbxContent>` +
+        `</mc:Fallback>` +
+        `</mc:AlternateContent>` +
+        `</wps:txbx></wps:wsp></a:graphicData></a:graphic></wp:inline>` +
+        `</w:drawing></mc:Choice>` +
+        fallbackBranch('Charlie') +
+        `</mc:AlternateContent></w:r></w:p>`;
+      const original = await given('a nested, unbalanced alternate content', () =>
+        documentXmlOf(shape('Echo')),
+      );
+      const revised = await given('its innermost surplus copy is edited', () =>
+        documentXmlOf(shape('Foxtrot')),
+      );
+
+      const error = await when('the guard inspects the pair', () =>
+        refusal(original, revised),
+      );
+
+      await then('the change is refused', () => {
+        expect(error).toBeInstanceOf(UnsupportedTextBoxRevisionError);
+      });
+    },
+  );
+
+  test(
+    'a plain VML text box is unaffected by branch-aware counting',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      const original = await given('a pre-2010 VML text box with no alternate content', () =>
+        documentXmlOf(plainVmlTextBox('Charlie')),
+      );
+      const revised = await given('its text is edited', () =>
+        documentXmlOf(plainVmlTextBox('Delta')),
+      );
+
+      const error = await when('the guard refuses the change', () =>
+        refusal(original, revised),
+      );
+
+      await then('the single box is reported once', () => {
+        expect(error?.changes).toHaveLength(1);
+      });
+      await and('at the ordinal it has always had', () => {
+        expect(error?.changes[0]?.index).toBe(0);
+        expect(error?.message).toContain('word/document.xml#w:txbxContent[0]');
+      });
+    },
+  );
+});
+
+describe('mc:AlternateContent cross-document storage shape', () => {
+  // Codex peer review, #794: equal *raw* w:txbxContent counts do not imply the
+  // two sides store their boxes the same way. Two plain VML boxes and one
+  // twinned box both store two copies, so pairing by raw position silently
+  // compared the original's second visible box against the revised document's
+  // unrendered copy of its first, and reported visible ordinal 0 for it.
+  const plan = async (
+    originalBody: string,
+    revisedBody: string,
+  ): Promise<
+    | { refused: true; error: UnsupportedTextBoxRevisionError }
+    | { refused: false; stories: Array<{ index: number; visualIndex: number }> }
+  > => {
+    const original = await buildDocxFromBodyXml(
+      originalBody,
+      [],
+      ALTERNATE_CONTENT_NAMESPACES,
+    );
+    const revised = await buildDocxFromBodyXml(
+      revisedBody,
+      [],
+      ALTERNATE_CONTENT_NAMESPACES,
+    );
+    try {
+      const prepared = await prepareTextBoxStoryComparison(original, revised);
+      return {
+        refused: false,
+        stories: (prepared?.stories ?? []).map((story) => ({
+          index: story.index,
+          visualIndex: story.visualIndex,
+        })),
+      };
+    } catch (error) {
+      return { refused: true, error: error as UnsupportedTextBoxRevisionError };
+    }
+  };
+
+  test(
+    'two plain boxes against one twinned box is refused, not mispaired',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      const bodies = await given(
+        'two plain VML boxes revised into a single twinned box',
+        () => ({
+          original: bodyXml(plainVmlTextBox('Charlie'), plainVmlTextBox('Echo')),
+          revised: bodyXml(twinTextBox('Charlie')),
+        }),
+      );
+
+      const outcome = await when('a story comparison is prepared', () =>
+        plan(bodies.original, bodies.revised),
+      );
+
+      await then('the pair is refused', () => {
+        expect(outcome.refused).toBe(true);
+      });
+      await and('the reason names the storage-shape disagreement', () => {
+        expect(
+          outcome.refused ? outcome.error.changes[0]?.reason : undefined,
+        ).toContain('storage shape differs');
+      });
+    },
+  );
+
+  test(
+    'one twinned box against two plain boxes is refused',
+    async ({ given, when, then }: AllureBddContext) => {
+      const bodies = await given(
+        'a single twinned box revised into two plain VML boxes',
+        () => ({
+          original: bodyXml(twinTextBox('Charlie')),
+          revised: bodyXml(plainVmlTextBox('Charlie'), plainVmlTextBox('Echo')),
+        }),
+      );
+
+      const outcome = await when('a story comparison is prepared', () =>
+        plan(bodies.original, bodies.revised),
+      );
+
+      await then('the pair is refused', () => {
+        expect(outcome.refused).toBe(true);
+      });
+    },
+  );
+
+  test(
+    'equal raw counts with different alternate-content boundaries is refused',
+    async ({ given, when, then }: AllureBddContext) => {
+      const bodies = await given(
+        'a twin plus a plain box, revised into a plain box plus a twin',
+        () => ({
+          original: bodyXml(twinTextBox('Charlie'), plainVmlTextBox('Echo')),
+          revised: bodyXml(plainVmlTextBox('Charlie'), twinTextBox('Echo')),
+        }),
+      );
+
+      const outcome = await when('a story comparison is prepared', () =>
+        plan(bodies.original, bodies.revised),
+      );
+
+      await then('the pair is refused', () => {
+        expect(outcome.refused).toBe(true);
+      });
+    },
+  );
+
+  test(
+    'matching storage shapes still prepare a story at the visible ordinal',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      // Negative control for the guard: it must refuse only shapes that really
+      // disagree. A guard that refused everything would pass all three cases
+      // above and be useless.
+      const bodies = await given('two twinned boxes with the second edited', () => ({
+        original: bodyXml(twinTextBox('Charlie'), twinTextBox('Echo')),
+        revised: bodyXml(twinTextBox('Charlie'), twinTextBox('Foxtrot')),
+      }));
+
+      const outcome = await when('a story comparison is prepared', () =>
+        plan(bodies.original, bodies.revised),
+      );
+
+      await then('the pair is accepted', () => {
+        expect(outcome.refused).toBe(false);
+      });
+      await and('the story reports the second visible box', () => {
+        expect(outcome.refused ? [] : outcome.stories).toEqual([
+          { index: 2, visualIndex: 1 },
+          { index: 3, visualIndex: 1 },
+        ]);
+      });
+    },
+  );
+});
+
+describe('mc:AlternateContent namespace hygiene', () => {
+  test(
+    'the fixture really does bind the wordprocessingShape namespace',
+    async ({ given, when, then }: AllureBddContext) => {
+      // Guards the fixture itself: a Requires prefix that failed to resolve
+      // would send the selector to the fallback and quietly invert every
+      // assertion above.
+      const documentXml = await given('a twinned text box fixture', () =>
+        documentXmlOf(bodyXml(twinTextBox('Charlie'))),
+      );
+
+      const declared = await when('the root namespace declarations are read', () =>
+        documentXml.includes(
+          'xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape"',
+        ),
+      );
+
+      await then('the prefix the mc:Choice requires is in scope', () => {
+        expect(declared).toBe(true);
+        expect(documentXml).toContain(`xmlns:w="${OOXML.W_NS}"`);
+      });
+    },
+  );
+});

--- a/packages/docx-compare/src/baselines/atomizer/textBoxRevisionSafety-alternate-content.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/textBoxRevisionSafety-alternate-content.test.ts
@@ -624,6 +624,137 @@ describe('mc:AlternateContent cross-document storage shape', () => {
   );
 });
 
+describe('mc:AlternateContent in a relationship-selected header story', () => {
+  // Codex peer review, #794 asked for the analogous header/footer cases: the
+  // ancillary path pairs stories by raw position and builds its own locator,
+  // so it needs the same visual ordinal and the same storage-shape guard as
+  // the main document.
+  const HEADER_RELATIONSHIP =
+    'http://schemas.openxmlformats.org/officeDocument/2006/relationships/header';
+
+  const headerXml = (...boxes: string[]): string =>
+    `<?xml version="1.0"?>` +
+    `<w:hdr xmlns:w="${OOXML.W_NS}"` +
+    ` xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"` +
+    ` xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"` +
+    ` xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"` +
+    ` xmlns:wp="${ALTERNATE_CONTENT_NAMESPACES.namespaces.wp}"` +
+    ` xmlns:a="${ALTERNATE_CONTENT_NAMESPACES.namespaces.a}"` +
+    ` xmlns:wps="${ALTERNATE_CONTENT_NAMESPACES.namespaces.wps}"` +
+    ` xmlns:v="${ALTERNATE_CONTENT_NAMESPACES.namespaces.v}"` +
+    ` mc:Ignorable="w14 wps">` +
+    boxes.join('') +
+    `</w:hdr>`;
+
+  const headerFixture = async (...boxes: string[]): Promise<Buffer> => {
+    const archive = await DocxArchive.load(
+      await buildDocxFromBodyXml(
+        `<w:p><w:r><w:t>Body</w:t></w:r></w:p>`,
+        [],
+        ALTERNATE_CONTENT_NAMESPACES,
+      ),
+    );
+    archive.setDocumentXml(
+      (await archive.getDocumentXml()).replace(
+        '<w:sectPr/>',
+        `<w:sectPr><w:headerReference w:type="default" r:id="rIdHeader"/></w:sectPr>`,
+      ).replace(
+        '<w:document ',
+        `<w:document xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" `,
+      ),
+    );
+    archive.setFile(
+      'word/_rels/document.xml.rels',
+      `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rIdHeader" Type="${HEADER_RELATIONSHIP}" Target="header1.xml"/>` +
+        `</Relationships>`,
+    );
+    archive.setFile('word/header1.xml', headerXml(...boxes));
+    return archive.save();
+  };
+
+  const prepare = async (
+    originalBoxes: string[],
+    revisedBoxes: string[],
+  ): Promise<
+    | { refused: true; error: UnsupportedTextBoxRevisionError }
+    | { refused: false; stories: Array<{ index: number; visualIndex: number; partPath: string }> }
+  > => {
+    try {
+      const prepared = await prepareTextBoxStoryComparison(
+        await headerFixture(...originalBoxes),
+        await headerFixture(...revisedBoxes),
+      );
+      return {
+        refused: false,
+        stories: (prepared?.stories ?? []).map((story) => ({
+          index: story.index,
+          visualIndex: story.visualIndex,
+          partPath: story.partPath,
+        })),
+      };
+    } catch (error) {
+      return { refused: true, error: error as UnsupportedTextBoxRevisionError };
+    }
+  };
+
+  test(
+    'a changed header text box is reported at its visible ordinal',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      const boxes = await given('a header holding two twinned text boxes', () => ({
+        original: [twinTextBox('Charlie'), twinTextBox('Echo')],
+        revised: [twinTextBox('Charlie'), twinTextBox('Foxtrot')],
+      }));
+
+      const outcome = await when('the header stories are prepared', () =>
+        prepare(boxes.original, boxes.revised),
+      );
+
+      await then('the pair is accepted', () => {
+        expect(outcome.refused).toBe(false);
+      });
+      await and('every story for the changed box carries the visible ordinal', () => {
+        const stories = outcome.refused ? [] : outcome.stories;
+        expect(stories.length).toBeGreaterThan(0);
+        expect(stories.every((story) => story.partPath === 'word/header1.xml')).toBe(true);
+        expect([...new Set(stories.map((story) => story.visualIndex))]).toEqual([1]);
+        expect(stories.map((story) => story.index)).toEqual([2, 3]);
+      });
+    },
+  );
+
+  test(
+    'a header whose storage shape changed is refused, not mispaired',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      // The ancillary storage-shape check is defence in depth. Header parts are
+      // paired by canonical content and then by scaffold fingerprint, and a
+      // part whose boxes changed spelling has neither in common, so it is
+      // refused before the shape check is reached. What matters is that the
+      // engine fails closed rather than pairing a plain box against an
+      // unrendered mc:Fallback copy.
+      const boxes = await given(
+        'a header whose two plain boxes become one twinned box',
+        () => ({
+          original: [plainVmlTextBox('Charlie'), plainVmlTextBox('Echo')],
+          revised: [twinTextBox('Charlie')],
+        }),
+      );
+
+      const outcome = await when('the header stories are prepared', () =>
+        prepare(boxes.original, boxes.revised),
+      );
+
+      await then('the pair is refused', () => {
+        expect(outcome.refused).toBe(true);
+      });
+      await and('no story was planned against a mismatched copy', () => {
+        expect(outcome.refused ? outcome.error.changes.length : 0)
+          .toBeGreaterThan(0);
+      });
+    },
+  );
+});
+
 describe('mc:AlternateContent namespace hygiene', () => {
   test(
     'the fixture really does bind the wordprocessingShape namespace',

--- a/packages/docx-compare/src/baselines/atomizer/textBoxRevisionSafety.ts
+++ b/packages/docx-compare/src/baselines/atomizer/textBoxRevisionSafety.ts
@@ -9,6 +9,10 @@ import {
 } from '@usejunior/docx-core';
 import { canonicalNode } from './opaquePassthrough.js';
 import {
+  groupElementsByTagNameNS,
+  type MarkupCompatibilityGroup,
+} from '../../markupCompatibility.js';
+import {
   acceptAllChanges,
   rejectAllChanges,
 } from './trackChangesAcceptorAst.js';
@@ -67,7 +71,18 @@ export class UnsupportedTextBoxRevisionError extends Error {
 }
 
 export interface TextBoxStoryInput {
+  /**
+   * Position in the raw `w:txbxContent` sequence. This is a storage address —
+   * it addresses one stored copy of a text box and is the key the splice step
+   * resolves against. It is not the number to show anybody.
+   */
   index: number;
+  /**
+   * Position in the sequence of text boxes a reader can see, counting one
+   * `mc:AlternateContent` as one box. This is the ordinal that goes in a
+   * user-facing `#w:txbxContent[N]` locator.
+   */
+  visualIndex: number;
   partPath: string;
   container: 'textBox' | 'ancillaryPart';
   original: Buffer;
@@ -96,11 +111,55 @@ function textBoxParagraphId(textBox: Element): string | undefined {
   return paragraph?.getAttributeNS(WORD_2010_NS, 'paraId') || undefined;
 }
 
-function textBoxes(documentXml: string): Element[] {
-  const root = parseDocumentXml(documentXml);
+/**
+ * One entry per *visual* text box.
+ *
+ * Word stores a modern text box twice inside one `mc:AlternateContent` — the
+ * `mc:Choice` DrawingML spelling and the `mc:Fallback` VML spelling — and
+ * renders exactly one of them. An unfiltered `w:txbxContent` scan therefore
+ * counts one box as two. Each group carries the rendered copy plus the stored
+ * copies nobody sees, so a caller can still inspect every copy while counting
+ * and numbering the way a reader does.
+ *
+ * @conformance ECMA-376 edition 5, Part 4 § 14.9.1.1
+ * @see https://github.com/UseJunior/safe-docx/issues/794
+ */
+function textBoxGroups(root: Node): MarkupCompatibilityGroup[] {
+  return groupElementsByTagNameNS(root, OOXML.W_NS, 'txbxContent');
+}
+
+function textBoxes(documentXml: string): MarkupCompatibilityGroup[] {
+  return textBoxGroups(parseDocumentXml(documentXml));
+}
+
+/** Every stored copy of one visual text box, rendered copy first. */
+function allCopies(group: MarkupCompatibilityGroup): Element[] {
+  return [group.selected, ...group.unselected];
+}
+
+/**
+ * Map each raw `w:txbxContent` position to the position of the visual text box
+ * that owns it.
+ *
+ * Comparison, neutralization, and splice-back all address stored copies, so
+ * they keep using raw positions; only the ordinal in a diagnostic is
+ * translated. Without this, `#w:txbxContent[2]` on a document with twinned
+ * boxes names the second stored copy of the *first* box, and a reader sent to
+ * find it has nowhere to look.
+ *
+ * @see https://github.com/UseJunior/safe-docx/issues/794
+ */
+function visualTextBoxOrdinals(root: Node): number[] {
+  const visualByCopy = new Map<Element, number>();
+  for (const [visualIndex, group] of textBoxGroups(root).entries()) {
+    for (const copy of allCopies(group)) visualByCopy.set(copy, visualIndex);
+  }
   return Array.from(
-    root.getElementsByTagNameNS(OOXML.W_NS, 'txbxContent'),
-  ) as Element[];
+    (root as Element | Document).getElementsByTagNameNS(
+      OOXML.W_NS,
+      'txbxContent',
+    ),
+  ).map((copy, rawIndex) => visualByCopy.get(copy as Element) ?? rawIndex);
 }
 
 function directChildElements(element: Element): Element[] {
@@ -320,6 +379,38 @@ function partTextBoxes(xml: string): Element[] {
     document.getElementsByTagNameNS(OOXML.W_NS, 'txbxContent'),
   ) as Element[];
 }
+
+function partVisualTextBoxOrdinals(xml: string): number[] {
+  return visualTextBoxOrdinals(parseXml(xml));
+}
+
+/**
+ * The first raw position at which two documents disagree about how their text
+ * boxes are stored, or `undefined` when the two storage shapes correspond.
+ *
+ * Text-box stories are paired by raw position, and the raw-count check alone
+ * does not make that pairing sound: two plain VML boxes and one twinned
+ * `mc:AlternateContent` box both store two `w:txbxContent` elements, so equal
+ * counts can still mean raw position 1 is the second visible box on one side
+ * and the unrendered copy of the first on the other. Comparing the raw→visual
+ * maps element-wise is exactly the condition that forecloses it.
+ *
+ * @see https://github.com/UseJunior/safe-docx/issues/794
+ */
+function divergentStorageShapePosition(
+  original: readonly number[],
+  revised: readonly number[],
+): number | undefined {
+  const length = Math.max(original.length, revised.length);
+  for (let index = 0; index < length; index += 1) {
+    if (original[index] !== revised[index]) return index;
+  }
+  return undefined;
+}
+
+const DIVERGENT_STORAGE_SHAPE_REASON =
+  'the text-box storage shape differs between the documents ' +
+  '(mc:AlternateContent branches do not correspond)';
 
 function partScaffoldFingerprint(xml: string): string {
   const document = parseXml(xml);
@@ -732,14 +823,32 @@ async function ancillaryStoryInputs(
 
   const stories: TextBoxStoryInput[] = [];
   for (const pair of paired.pairs) {
+    const originalVisualOrdinals = partVisualTextBoxOrdinals(pair.original.xml);
+    const visualOrdinals = partVisualTextBoxOrdinals(pair.revised.xml);
     if (pair.original.textBoxes.length !== pair.revised.textBoxes.length) {
+      const rawIndex = Math.min(
+        pair.original.textBoxes.length,
+        pair.revised.textBoxes.length,
+      );
       throw new UnsupportedTextBoxRevisionError([{
-        index: Math.min(
-          pair.original.textBoxes.length,
-          pair.revised.textBoxes.length,
-        ),
+        index: visualOrdinals[rawIndex] ?? rawIndex,
         partPath: pair.revised.targetPath,
         reason: 'inserted or deleted ancillary text-box topology is not supported',
+      }]);
+    }
+
+    const divergentPosition = divergentStorageShapePosition(
+      originalVisualOrdinals,
+      visualOrdinals,
+    );
+    if (divergentPosition !== undefined) {
+      throw new UnsupportedTextBoxRevisionError([{
+        index: Math.min(
+          originalVisualOrdinals[divergentPosition] ?? divergentPosition,
+          visualOrdinals[divergentPosition] ?? divergentPosition,
+        ),
+        partPath: pair.revised.targetPath,
+        reason: DIVERGENT_STORAGE_SHAPE_REASON,
       }]);
     }
     const originalTargets = relationshipTargets(pair.original.relationshipsXml);
@@ -769,7 +878,7 @@ async function ancillaryStoryInputs(
           : 'the ancillary VML shape scaffold changed or could not be paired');
       if (reason) {
         throw new UnsupportedTextBoxRevisionError([{
-          index,
+          index: visualOrdinals[index] ?? index,
           partPath: pair.revised.targetPath,
           reason,
           originalParagraphId: textBoxParagraphId(originalTextBox),
@@ -805,6 +914,7 @@ async function ancillaryStoryInputs(
       );
       stories.push({
         index,
+        visualIndex: visualOrdinals[index] ?? index,
         partPath: pair.revised.targetPath,
         container: 'textBox',
         original: await storyOriginalArchive.save(),
@@ -833,6 +943,7 @@ async function ancillaryStoryInputs(
     );
     stories.push({
       index: 0,
+      visualIndex: 0,
       partPath: story.targetPath,
       container: 'ancillaryPart',
       original: await storyOriginalArchive.save(),
@@ -913,12 +1024,33 @@ export async function prepareTextBoxStoryComparison(
   const revisedTextBoxes = Array.from(
     revisedDocument.getElementsByTagNameNS(OOXML.W_NS, 'txbxContent'),
   );
+  const originalVisualOrdinals = visualTextBoxOrdinals(originalDocument);
+  const visualOrdinals = visualTextBoxOrdinals(revisedDocument);
 
   if (originalTextBoxes.length !== revisedTextBoxes.length) {
+    const rawIndex = Math.min(
+      originalTextBoxes.length,
+      revisedTextBoxes.length,
+    );
     throw new UnsupportedTextBoxRevisionError([{
-      index: Math.min(originalTextBoxes.length, revisedTextBoxes.length),
+      index: visualOrdinals[rawIndex] ?? rawIndex,
       partPath: 'word/document.xml',
       reason: 'inserted or deleted text-box topology is not supported',
+    }]);
+  }
+
+  const divergentPosition = divergentStorageShapePosition(
+    originalVisualOrdinals,
+    visualOrdinals,
+  );
+  if (divergentPosition !== undefined) {
+    throw new UnsupportedTextBoxRevisionError([{
+      index: Math.min(
+        originalVisualOrdinals[divergentPosition] ?? divergentPosition,
+        visualOrdinals[divergentPosition] ?? divergentPosition,
+      ),
+      partPath: 'word/document.xml',
+      reason: DIVERGENT_STORAGE_SHAPE_REASON,
     }]);
   }
 
@@ -951,7 +1083,7 @@ export async function prepareTextBoxStoryComparison(
         : undefined);
     if (reason) {
       throw new UnsupportedTextBoxRevisionError([{
-        index,
+        index: visualOrdinals[index] ?? index,
         partPath: 'word/document.xml',
         reason,
         originalParagraphId: textBoxParagraphId(originalTextBox),
@@ -973,6 +1105,7 @@ export async function prepareTextBoxStoryComparison(
     );
     stories.push({
       index,
+      visualIndex: visualOrdinals[index] ?? index,
       partPath: 'word/document.xml',
       container: 'textBox',
       original: await storyOriginalArchive.save(),
@@ -1009,6 +1142,7 @@ export async function assembleTextBoxStoryComparison(
   outerCompared: Buffer,
   storyResults: ReadonlyArray<{
     index: number;
+    visualIndex: number;
     partPath: string;
     container: 'textBox' | 'ancillaryPart';
     document: Buffer;
@@ -1023,7 +1157,7 @@ export async function assembleTextBoxStoryComparison(
       const targetXml = await outerArchive.getFile(storyResult.partPath);
       if (targetXml === null) {
         throw new UnsupportedTextBoxRevisionError([{
-          index: storyResult.index,
+          index: storyResult.visualIndex,
           partPath: storyResult.partPath,
           reason: 'the selected output story part is missing',
         }]);
@@ -1061,7 +1195,7 @@ export async function assembleTextBoxStoryComparison(
       .item(storyResult.index);
     if (!target) {
       throw new UnsupportedTextBoxRevisionError([{
-        index: storyResult.index,
+        index: storyResult.visualIndex,
         partPath: storyResult.partPath,
         reason: 'the outer comparison changed text-box story topology',
       }]);
@@ -1294,24 +1428,31 @@ export function assertTextBoxContentUnchanged(
   const count = Math.max(originalTextBoxes.length, revisedTextBoxes.length);
   const changes: TextBoxRevisionChange[] = [];
 
+  // Hash every stored copy, not only the rendered one: a change confined to an
+  // `mc:Fallback` twin is still a change this guard has to refuse. Only the
+  // reported ordinal counts visually, so `#w:txbxContent[N]` names a box a
+  // reader can actually find.
+  const signature = (
+    group: MarkupCompatibilityGroup | undefined,
+  ): string | undefined =>
+    group
+      ? createHash('sha256')
+          .update(allCopies(group).map(canonicalNode).join('\u0000'))
+          .digest('hex')
+      : undefined;
+
   for (let index = 0; index < count; index++) {
     const originalTextBox = originalTextBoxes[index];
     const revisedTextBox = revisedTextBoxes[index];
-    const originalSignature = originalTextBox
-      ? createHash('sha256').update(canonicalNode(originalTextBox)).digest('hex')
-      : undefined;
-    const revisedSignature = revisedTextBox
-      ? createHash('sha256').update(canonicalNode(revisedTextBox)).digest('hex')
-      : undefined;
-    if (originalSignature === revisedSignature) continue;
+    if (signature(originalTextBox) === signature(revisedTextBox)) continue;
 
     changes.push({
       index,
       originalParagraphId: originalTextBox
-        ? textBoxParagraphId(originalTextBox)
+        ? textBoxParagraphId(originalTextBox.selected)
         : undefined,
       revisedParagraphId: revisedTextBox
-        ? textBoxParagraphId(revisedTextBox)
+        ? textBoxParagraphId(revisedTextBox.selected)
         : undefined,
     });
   }

--- a/packages/docx-compare/src/index.ts
+++ b/packages/docx-compare/src/index.ts
@@ -158,3 +158,14 @@ export {
 } from './baselines/atomizer/textBoxRevisionSafety.js';
 export type { TextBoxRevisionChange } from './baselines/atomizer/textBoxRevisionSafety.js';
 export { computeAtomLcs, markCorrelationStatus } from './baselines/atomizer/atomLcs.js';
+export {
+  MC_NAMESPACE,
+  groupElementsByTagNameNS,
+  selectAlternateContentBranch,
+  selectedElementsByTagNameNS,
+} from './markupCompatibility.js';
+export type {
+  MarkupCompatibilityGroup,
+  MarkupCompatibilityOptions,
+  RequiredNamespace,
+} from './markupCompatibility.js';

--- a/packages/docx-compare/src/markupCompatibility.test.ts
+++ b/packages/docx-compare/src/markupCompatibility.test.ts
@@ -1,0 +1,433 @@
+/**
+ * Word stores one visual text box twice — an `mc:Choice` DrawingML spelling
+ * and an `mc:Fallback` VML spelling inside one `mc:AlternateContent` — and
+ * renders exactly one. A walk that visits both counts one box as two.
+ *
+ * @conformance ECMA-376 edition 5, Part 4 § 14.9.1.1
+ * @see https://github.com/UseJunior/safe-docx/issues/794
+ */
+
+import { describe, expect } from 'vitest';
+import { OOXML, parseXml } from '@usejunior/docx-core';
+import { testAllure, type AllureBddContext } from './testing/allure-test.js';
+import {
+  MC_NAMESPACE,
+  groupElementsByTagNameNS,
+  isUnselectedAlternateContentDescendant,
+  requiredNamespaces,
+  selectAlternateContentBranch,
+  selectedElementsByTagNameNS,
+} from './markupCompatibility.js';
+
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({
+    feature: 'In-Place Reconstruction',
+    story: 'Markup Compatibility Branch Selection',
+    severity: 'critical',
+  })
+  .conformance({ spec: 'ECMA-376', edition: 5, part: 4, section: '14.9.1.1' });
+
+const NAMESPACES =
+  ` xmlns:w="${OOXML.W_NS}"` +
+  ` xmlns:mc="${MC_NAMESPACE}"` +
+  ` xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"` +
+  ` xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"` +
+  ` xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape"` +
+  ` xmlns:v="urn:schemas-microsoft-com:vml"`;
+
+function documentXml(body: string): string {
+  return `<w:document${NAMESPACES}><w:body>${body}</w:body></w:document>`;
+}
+
+/** The DrawingML spelling Word renders. */
+function choiceBranch(text: string, requires = 'wps'): string {
+  return (
+    `<mc:Choice Requires="${requires}"><w:drawing><wp:inline><a:graphic>` +
+    `<a:graphicData><wps:wsp><wps:txbx><w:txbxContent>` +
+    `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>` +
+    `</w:txbxContent></wps:txbx></wps:wsp></a:graphicData></a:graphic>` +
+    `</wp:inline></w:drawing></mc:Choice>`
+  );
+}
+
+/** The VML spelling Word keeps for readers that cannot render the choice. */
+function fallbackBranch(text: string): string {
+  return (
+    `<mc:Fallback><w:pict><v:shape><v:textbox><w:txbxContent>` +
+    `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>` +
+    `</w:txbxContent></v:textbox></v:shape></w:pict></mc:Fallback>`
+  );
+}
+
+/** One visual text box, stored twice, exactly the way Word writes one. */
+function twinTextBox(text: string): string {
+  return (
+    `<w:p><w:r><mc:AlternateContent>` +
+    choiceBranch(text) +
+    fallbackBranch(text) +
+    `</mc:AlternateContent></w:r></w:p>`
+  );
+}
+
+/** A text box authored the pre-2010 way: VML only, no alternate content. */
+function plainVmlTextBox(text: string): string {
+  return (
+    `<w:p><w:r><w:pict><v:shape><v:textbox><w:txbxContent>` +
+    `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>` +
+    `</w:txbxContent></v:textbox></v:shape></w:pict></w:r></w:p>`
+  );
+}
+
+function textBoxCounts(xml: string): { raw: number; visual: number } {
+  const parsed = parseXml(xml);
+  return {
+    raw: parsed.getElementsByTagNameNS(OOXML.W_NS, 'txbxContent').length,
+    visual: selectedElementsByTagNameNS(parsed, OOXML.W_NS, 'txbxContent')
+      .length,
+  };
+}
+
+describe('markup compatibility branch selection', () => {
+  test(
+    'one authored text box counts once even though it is stored twice',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      const xml = await given(
+        'a document holding one text box as an mc:Choice / mc:Fallback pair',
+        () => documentXml(twinTextBox('Charlie')),
+      );
+
+      const counts = await when('both walks enumerate w:txbxContent', () =>
+        textBoxCounts(xml),
+      );
+
+      await then('the unfiltered DOM walk sees both stored copies', () => {
+        expect(counts.raw).toBe(2);
+      });
+      await and('the branch-aware walk sees the single visible box', () => {
+        expect(counts.visual).toBe(1);
+      });
+    },
+  );
+
+  test(
+    'two authored text boxes count twice, not four times',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      const xml = await given('a document holding two twinned text boxes', () =>
+        documentXml(twinTextBox('Charlie') + twinTextBox('Echo')),
+      );
+
+      const counts = await when('both walks enumerate w:txbxContent', () =>
+        textBoxCounts(xml),
+      );
+
+      await then('the unfiltered DOM walk sees four stored copies', () => {
+        expect(counts.raw).toBe(4);
+      });
+      await and('the branch-aware walk sees two visible boxes', () => {
+        expect(counts.visual).toBe(2);
+      });
+    },
+  );
+
+  test(
+    'a text box that exists only in the fallback branch is still enumerated',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      // The dangerous direction. Skipping every mc:Fallback unconditionally
+      // would silently drop content from a document whose mc:Choice cannot be
+      // selected, and an equality check that never sees the content agrees
+      // with itself.
+      const xml = await given(
+        'an mc:AlternateContent whose only text box lives in the fallback',
+        () =>
+          documentXml(
+            `<w:p><w:r><mc:AlternateContent>` +
+              `<mc:Choice Requires="unknownPrefix"><w:drawing/></mc:Choice>` +
+              fallbackBranch('Charlie') +
+              `</mc:AlternateContent></w:r></w:p>`,
+          ),
+      );
+
+      const selected = await when('the branch-aware walk enumerates it', () =>
+        selectedElementsByTagNameNS(
+          parseXml(xml),
+          OOXML.W_NS,
+          'txbxContent',
+        ),
+      );
+
+      await then('the fallback text box is not lost', () => {
+        expect(selected).toHaveLength(1);
+      });
+      await and('its text survives the walk', () => {
+        expect(selected[0]?.textContent).toBe('Charlie');
+      });
+    },
+  );
+
+  test(
+    'an mc:AlternateContent with only a fallback selects that fallback',
+    async ({ given, when, then }: AllureBddContext) => {
+      const alternateContent = await given(
+        'an mc:AlternateContent carrying no mc:Choice at all',
+        () => {
+          const xml = documentXml(
+            `<w:p><w:r><mc:AlternateContent>` +
+              fallbackBranch('Charlie') +
+              `</mc:AlternateContent></w:r></w:p>`,
+          );
+          return parseXml(xml)
+            .getElementsByTagNameNS(MC_NAMESPACE, 'AlternateContent')
+            .item(0) as Element;
+        },
+      );
+
+      const branch = await when('the selector picks a branch', () =>
+        selectAlternateContentBranch(alternateContent),
+      );
+
+      await then('the fallback is selected rather than nothing', () => {
+        expect(branch?.localName).toBe('Fallback');
+      });
+    },
+  );
+
+  test(
+    'a text box outside any mc:AlternateContent is untouched by the filter',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      const xml = await given('a plain VML text box with no alternate content', () =>
+        documentXml(plainVmlTextBox('Charlie')),
+      );
+
+      const counts = await when('both walks enumerate w:txbxContent', () =>
+        textBoxCounts(xml),
+      );
+
+      await then('the unfiltered walk sees one box', () => {
+        expect(counts.raw).toBe(1);
+      });
+      await and('the branch-aware walk agrees', () => {
+        expect(counts.visual).toBe(1);
+      });
+    },
+  );
+
+  test(
+    'grouping keeps the unrendered copies reachable',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      const xml = await given('a document holding two twinned text boxes', () =>
+        documentXml(twinTextBox('Charlie') + twinTextBox('Echo')),
+      );
+
+      const groups = await when('the walk groups matches by visual object', () =>
+        groupElementsByTagNameNS(parseXml(xml), OOXML.W_NS, 'txbxContent'),
+      );
+
+      await then('there is one group per visible box', () => {
+        expect(groups).toHaveLength(2);
+      });
+      await and('each group also carries its unrendered twin', () => {
+        expect(groups.map((group) => group.unselected.length)).toEqual([1, 1]);
+        expect(groups.map((group) => group.selected.textContent)).toEqual([
+          'Charlie',
+          'Echo',
+        ]);
+        expect(
+          groups.map((group) => group.unselected[0]?.textContent),
+        ).toEqual(['Charlie', 'Echo']);
+      });
+    },
+  );
+
+  test(
+    'every stored copy lands in exactly one group',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      // Totality. Codex peer review of #794 showed that pairing copies by
+      // position and discarding the surplus made a copy unreachable, so a
+      // fail-closed guard that hashes `[selected, ...unselected]` went blind
+      // to it. Every shape below is checked for coverage, not just count.
+      const shapes = await given('documents whose branches do not correspond', () => [
+        documentXml(twinTextBox('Charlie')),
+        documentXml(twinTextBox('Charlie') + plainVmlTextBox('Echo')),
+        documentXml(
+          `<w:p><w:r><mc:AlternateContent>` +
+            choiceBranch('Charlie') +
+            `<mc:Fallback><w:pict>` +
+            `<v:shape><v:textbox><w:txbxContent><w:p><w:r><w:t>Charlie</w:t></w:r></w:p></w:txbxContent></v:textbox></v:shape>` +
+            `<v:shape><v:textbox><w:txbxContent><w:p><w:r><w:t>Echo</w:t></w:r></w:p></w:txbxContent></v:textbox></v:shape>` +
+            `</w:pict></mc:Fallback>` +
+            `</mc:AlternateContent></w:r></w:p>`,
+        ),
+        documentXml(
+          `<w:p><w:r><mc:AlternateContent>` +
+            `<mc:Choice Requires="wps"><w:drawing/></mc:Choice>` +
+            fallbackBranch('Charlie') +
+            `</mc:AlternateContent></w:r></w:p>`,
+        ),
+        documentXml(
+          `<w:p><w:r><mc:AlternateContent>` +
+            `<mc:Something><w:pict><v:shape><v:textbox><w:txbxContent>` +
+            `<w:p><w:r><w:t>Charlie</w:t></w:r></w:p>` +
+            `</w:txbxContent></v:textbox></v:shape></w:pict></mc:Something>` +
+            `</mc:AlternateContent></w:r></w:p>`,
+        ),
+      ]);
+
+      const coverage = await when('each document is grouped', () =>
+        shapes.map((xml) => {
+          const parsed = parseXml(xml);
+          const raw = Array.from(
+            parsed.getElementsByTagNameNS(OOXML.W_NS, 'txbxContent'),
+          ) as Element[];
+          const grouped: Element[] = [];
+          for (const group of groupElementsByTagNameNS(
+            parsed,
+            OOXML.W_NS,
+            'txbxContent',
+          )) {
+            grouped.push(group.selected, ...group.unselected);
+          }
+          return {
+            raw: raw.length,
+            grouped: grouped.length,
+            distinct: new Set(grouped).size,
+            missing: raw.filter((element) => !grouped.includes(element)).length,
+          };
+        }),
+      );
+
+      await then('no stored copy is dropped', () => {
+        expect(coverage.map((entry) => entry.missing)).toEqual(
+          shapes.map(() => 0),
+        );
+      });
+      await and('no stored copy is counted twice', () => {
+        for (const entry of coverage) {
+          expect(entry.grouped).toBe(entry.raw);
+          expect(entry.distinct).toBe(entry.raw);
+        }
+      });
+    },
+  );
+
+  test(
+    'branches holding different numbers of matches are reported unbalanced',
+    async ({ given, when, then }: AllureBddContext) => {
+      const xml = await given(
+        'an mc:AlternateContent whose fallback holds two boxes to the choice one',
+        () =>
+          documentXml(
+            `<w:p><w:r><mc:AlternateContent>` +
+              choiceBranch('Charlie') +
+              `<mc:Fallback><w:pict>` +
+              `<v:shape><v:textbox><w:txbxContent><w:p><w:r><w:t>Charlie</w:t></w:r></w:p></w:txbxContent></v:textbox></v:shape>` +
+              `<v:shape><v:textbox><w:txbxContent><w:p><w:r><w:t>Echo</w:t></w:r></w:p></w:txbxContent></v:textbox></v:shape>` +
+              `</w:pict></mc:Fallback>` +
+              `</mc:AlternateContent></w:r></w:p>`,
+          ),
+      );
+
+      const groups = await when('the walk groups matches by visual object', () =>
+        groupElementsByTagNameNS(parseXml(xml), OOXML.W_NS, 'txbxContent'),
+      );
+
+      await then('the group flags that the copies could not be paired', () => {
+        expect(groups).toHaveLength(1);
+        expect(groups[0]?.unbalanced).toBe(true);
+      });
+    },
+  );
+
+  test(
+    'unselected-branch membership is reported for individual nodes',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      const boxes = await given('a twinned text box', () => {
+        const xml = documentXml(twinTextBox('Charlie'));
+        return Array.from(
+          parseXml(xml).getElementsByTagNameNS(OOXML.W_NS, 'txbxContent'),
+        ) as Element[];
+      });
+
+      const flags = await when('each stored copy is tested', () =>
+        boxes.map((box) => isUnselectedAlternateContentDescendant(box)),
+      );
+
+      await then('the rendered copy is not flagged', () => {
+        expect(flags[0]).toBe(false);
+      });
+      await and('the unrendered copy is', () => {
+        expect(flags[1]).toBe(true);
+      });
+    },
+  );
+
+  test(
+    'a Requires attribute naming an unbound prefix falls through to the fallback',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      const alternateContent = await given(
+        'an mc:Choice requiring a prefix nothing declares',
+        () => {
+          const xml = documentXml(
+            `<w:p><w:r><mc:AlternateContent>` +
+              choiceBranch('Charlie', 'nowhereDeclared') +
+              fallbackBranch('Echo') +
+              `</mc:AlternateContent></w:r></w:p>`,
+          );
+          return parseXml(xml)
+            .getElementsByTagNameNS(MC_NAMESPACE, 'AlternateContent')
+            .item(0) as Element;
+        },
+      );
+
+      const branch = await when('the selector picks a branch', () =>
+        selectAlternateContentBranch(alternateContent),
+      );
+
+      await then('the unsatisfiable choice is skipped', () => {
+        expect(branch?.localName).toBe('Fallback');
+      });
+      await and('the unresolved prefix is visible to callers', () => {
+        const choice = alternateContent
+          .getElementsByTagNameNS(MC_NAMESPACE, 'Choice')
+          .item(0) as Element;
+        expect(requiredNamespaces(choice)).toEqual([
+          { prefix: 'nowhereDeclared', namespaceURI: null },
+        ]);
+      });
+    },
+  );
+
+  test(
+    'the branch-aware walk can go red',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      // Negative control. This class of defect went unnoticed because the
+      // double count cancelled on both sides of an equality check, so the
+      // check agreed with itself. A test that only ever asserts "the filtered
+      // count equals the visible count" would pass against a filter that does
+      // nothing at all. These fixtures prove the assertion discriminates.
+      const cases = await given('documents whose visible box count is known', () => [
+        { body: '', visual: 0 },
+        { body: plainVmlTextBox('Charlie'), visual: 1 },
+        { body: twinTextBox('Charlie'), visual: 1 },
+        { body: twinTextBox('Charlie') + plainVmlTextBox('Echo'), visual: 2 },
+        { body: twinTextBox('Charlie') + twinTextBox('Echo'), visual: 2 },
+      ]);
+
+      const observed = await when('each document is walked both ways', () =>
+        cases.map(({ body }) => textBoxCounts(documentXml(body))),
+      );
+
+      await then('the branch-aware walk matches the visible count everywhere', () => {
+        expect(observed.map((counts) => counts.visual)).toEqual(
+          cases.map((entry) => entry.visual),
+        );
+      });
+      await and('the unfiltered walk does not, so the assertion discriminates', () => {
+        expect(observed.map((counts) => counts.raw)).toEqual([0, 1, 2, 3, 4]);
+        expect(observed.map((counts) => counts.raw)).not.toEqual(
+          cases.map((entry) => entry.visual),
+        );
+      });
+    },
+  );
+});

--- a/packages/docx-compare/src/markupCompatibility.test.ts
+++ b/packages/docx-compare/src/markupCompatibility.test.ts
@@ -398,6 +398,54 @@ describe('markup compatibility branch selection', () => {
   );
 
   test(
+    'the walk accepts an mc:AlternateContent as its own root',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      const alternateContent = await given('a twinned text box element', () => {
+        const xml = documentXml(twinTextBox('Charlie'));
+        return parseXml(xml)
+          .getElementsByTagNameNS(MC_NAMESPACE, 'AlternateContent')
+          .item(0) as Element;
+      });
+
+      const groups = await when('the walk is rooted at the element itself', () =>
+        groupElementsByTagNameNS(alternateContent, OOXML.W_NS, 'txbxContent'),
+      );
+
+      await then('branch selection still applies at the root', () => {
+        expect(groups).toHaveLength(1);
+      });
+      await and('the unrendered copy is still reachable', () => {
+        expect(groups[0]?.unselected).toHaveLength(1);
+      });
+    },
+  );
+
+  test(
+    'a branch element can itself be the match being grouped',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      // Grouping is generic over tag names, so the element being matched can be
+      // the mc:Choice or mc:Fallback itself. That is the one position where a
+      // match is a direct child of the mc:AlternateContent rather than a
+      // descendant of a branch.
+      const xml = await given('a twinned text box', () =>
+        documentXml(twinTextBox('Charlie')),
+      );
+
+      const groups = await when('mc:Fallback elements are grouped', () =>
+        groupElementsByTagNameNS(parseXml(xml), MC_NAMESPACE, 'Fallback'),
+      );
+
+      await then('the unselected branch is collected rather than dropped', () => {
+        expect(groups).toHaveLength(1);
+        expect(groups[0]?.selected.localName).toBe('Fallback');
+      });
+      await and('it is flagged as belonging to no rendered object', () => {
+        expect(groups[0]?.unbalanced).toBe(true);
+      });
+    },
+  );
+
+  test(
     'the branch-aware walk can go red',
     async ({ given, when, then, and }: AllureBddContext) => {
       // Negative control. This class of defect went unnoticed because the

--- a/packages/docx-compare/src/markupCompatibility.ts
+++ b/packages/docx-compare/src/markupCompatibility.ts
@@ -1,0 +1,345 @@
+/**
+ * Markup Compatibility and Extensibility (MCE) branch selection.
+ *
+ * Word stores one modern shape twice inside a single `mc:AlternateContent`: an
+ * `mc:Choice Requires="wps"` holding the DrawingML spelling and an
+ * `mc:Fallback` holding the VML spelling. Both carry a complete
+ * `w:txbxContent` with real `w:p`/`w:r`/`w:t`, and exactly one of them is ever
+ * rendered. A walk that does not know this counts one visual text box as two
+ * and projects its text more than once.
+ *
+ * Two kinds of walk exist in this package and they want opposite behaviour:
+ *
+ * - **Presentation walks** — counting objects, numbering the user-facing
+ *   ordinals in a diagnostic locator, projecting the text a reader sees — must
+ *   visit exactly one branch per `mc:AlternateContent`. Those are served here.
+ * - **Preservation walks** — canonicalization, scaffold fingerprinting,
+ *   byte-identity checks, and any mutation that has to keep the branches
+ *   consistent with each other — must visit *every* branch. Those must keep
+ *   using the unfiltered DOM API; filtering them would drop content.
+ *
+ * Getting that distinction wrong in the second direction loses content, so the
+ * selector here never returns "nothing" for an `mc:AlternateContent` that has
+ * at least one branch, and `groupElementsByTagNameNS` reaches every stored copy
+ * even when the branches do not correspond.
+ *
+ * **What the default selection policy is, and is not.** safe-docx is not a
+ * renderer and performs no MCE capability detection. The default policy selects
+ * the first `mc:Choice` whose `Requires` prefixes are all *declared in scope*,
+ * otherwise the `mc:Fallback`. A declared prefix means the name resolves, not
+ * that any consumer implements that namespace, so on a document whose
+ * `mc:Choice` requires an extension the reading Word does not implement, this
+ * policy selects the `mc:Choice` where that Word would render the
+ * `mc:Fallback`. What the policy guarantees is that it is deterministic, that
+ * it picks exactly one branch, and that it agrees with the *authoring* Word for
+ * the modern text-box shapes this package identifies — which is the class the
+ * text-box ordinals here exist to describe. It does not claim agreement across
+ * Word versions: a document a newer Word wrote can be opened by an older Word
+ * that selects the fallback. A caller modelling a particular consumer supplies
+ * `isChoiceSatisfiable`; the alternative default, a hard-coded list of Office
+ * extension namespaces, rots with every release and every stale entry silently
+ * moves an ordinal onto the wrong object.
+ *
+ * @see https://github.com/UseJunior/safe-docx/issues/794
+ */
+
+/** The Markup Compatibility and Extensibility namespace. */
+export const MC_NAMESPACE =
+  'http://schemas.openxmlformats.org/markup-compatibility/2006';
+
+/** A namespace prefix named by an `mc:Choice` `Requires` attribute. */
+export interface RequiredNamespace {
+  /** The prefix exactly as written in `Requires`. */
+  prefix: string;
+  /** The namespace the prefix resolves to in scope, or `null` when unbound. */
+  namespaceURI: string | null;
+}
+
+export interface MarkupCompatibilityOptions {
+  /**
+   * Decide whether an `mc:Choice` branch is one this consumer can select.
+   *
+   * The default is a *comparison policy*, not capability detection: it accepts
+   * any `mc:Choice` whose `Requires` prefixes are all declared in scope. See
+   * the module header for what that does and does not guarantee. Supply a
+   * predicate here to model a specific consumer's real capabilities.
+   */
+  isChoiceSatisfiable?: (
+    choice: Element,
+    requires: readonly RequiredNamespace[],
+  ) => boolean;
+}
+
+function isElement(node: Node): node is Element {
+  return node.nodeType === 1;
+}
+
+/** True for an `mc:AlternateContent` element. */
+export function isAlternateContent(node: Node): node is Element {
+  return (
+    isElement(node) &&
+    node.namespaceURI === MC_NAMESPACE &&
+    node.localName === 'AlternateContent'
+  );
+}
+
+function branchKind(node: Node): 'Choice' | 'Fallback' | undefined {
+  if (!isElement(node) || node.namespaceURI !== MC_NAMESPACE) return undefined;
+  if (node.localName === 'Choice') return 'Choice';
+  if (node.localName === 'Fallback') return 'Fallback';
+  return undefined;
+}
+
+/** The namespace prefixes an `mc:Choice` declares it requires. */
+export function requiredNamespaces(choice: Element): RequiredNamespace[] {
+  const attribute =
+    choice.getAttribute('Requires') ?? choice.getAttributeNS(null, 'Requires');
+  return (attribute ?? '')
+    .trim()
+    .split(/\s+/u)
+    .filter((prefix) => prefix.length > 0)
+    .map((prefix) => ({
+      prefix,
+      namespaceURI: choice.lookupNamespaceURI(prefix),
+    }));
+}
+
+function everyRequiredPrefixIsBound(
+  _choice: Element,
+  requires: readonly RequiredNamespace[],
+): boolean {
+  return requires.every((required) => required.namespaceURI !== null);
+}
+
+/**
+ * The single `mc:Choice` or `mc:Fallback` branch this policy selects.
+ *
+ * Selection follows the MCE shape: the first satisfiable `mc:Choice`, otherwise
+ * the `mc:Fallback`. "Satisfiable" is decided by
+ * {@link MarkupCompatibilityOptions.isChoiceSatisfiable}, whose default is a
+ * declaration check rather than capability detection — see the module header.
+ *
+ * When no `mc:Choice` is satisfiable and there is no `mc:Fallback`, the first
+ * branch present is returned rather than nothing. A strict MCE processor would
+ * render nothing there, but a comparison engine that walked away from authored
+ * content would hide a real change behind an equality check that agrees with
+ * itself.
+ *
+ * Returns `undefined` only for an `mc:AlternateContent` with no branches at
+ * all.
+ */
+export function selectAlternateContentBranch(
+  alternateContent: Element,
+  options: MarkupCompatibilityOptions = {},
+): Element | undefined {
+  const isChoiceSatisfiable =
+    options.isChoiceSatisfiable ?? everyRequiredPrefixIsBound;
+  let firstBranch: Element | undefined;
+  let fallback: Element | undefined;
+  for (
+    let child = alternateContent.firstChild;
+    child;
+    child = child.nextSibling
+  ) {
+    const kind = branchKind(child);
+    if (!kind) continue;
+    const branch = child as Element;
+    firstBranch ??= branch;
+    if (kind === 'Fallback') {
+      fallback ??= branch;
+      continue;
+    }
+    if (isChoiceSatisfiable(branch, requiredNamespaces(branch))) return branch;
+  }
+  return fallback ?? firstBranch;
+}
+
+/**
+ * True when `node` sits inside an `mc:AlternateContent` branch this consumer
+ * does not select — the content a reader never sees.
+ *
+ * Use this to filter an existing `getElementsByTagNameNS` result without
+ * rewriting the walk around it.
+ */
+export function isUnselectedAlternateContentDescendant(
+  node: Node,
+  options: MarkupCompatibilityOptions = {},
+): boolean {
+  let current: Node | null = node;
+  while (current) {
+    const parent: Node | null = current.parentNode;
+    if (
+      parent &&
+      branchKind(current) &&
+      isAlternateContent(parent) &&
+      selectAlternateContentBranch(parent, options) !== current
+    ) {
+      return true;
+    }
+    current = parent;
+  }
+  return false;
+}
+
+/**
+ * One visual object and every redundant spelling of it.
+ *
+ * `selected` is the element a reader sees. `unselected` holds the same
+ * object's copies in `mc:AlternateContent` branches nobody renders — a caller
+ * that rewrites `selected` needs these so the unrendered spellings do not
+ * drift away from the one on screen.
+ */
+export interface MarkupCompatibilityGroup {
+  selected: Element;
+  unselected: Element[];
+  /**
+   * True when the owning `mc:AlternateContent` could not be read as one object
+   * stored several ways: an unselected branch held a different number of
+   * matches than the selected branch, or a match sat under a child that is
+   * neither `mc:Choice` nor `mc:Fallback`. The copies were still collected —
+   * nothing is ever dropped — but they were paired by position against a
+   * sequence that does not line up, so no caller should treat them as
+   * interchangeable spellings of one thing.
+   */
+  unbalanced: boolean;
+}
+
+function matches(
+  element: Element,
+  namespaceURI: string,
+  localName: string,
+): boolean {
+  return (
+    element.namespaceURI === namespaceURI && element.localName === localName
+  );
+}
+
+/**
+ * Group every `namespaceURI`/`localName` match under `root` by the visual
+ * object it belongs to, pairing each `mc:AlternateContent` branch's matches
+ * with the selected branch's by position. Groups are in document order, except
+ * that a copy belonging to no rendered object is emitted after the groups of
+ * the `mc:AlternateContent` that owns it.
+ *
+ * **Totality:** every match the unfiltered DOM walk would return appears in
+ * exactly one group, as either its `selected` or one of its `unselected`
+ * elements. Matches that cannot be paired — a branch holding more copies than
+ * the selected one, or a child of `mc:AlternateContent` that is neither
+ * `mc:Choice` nor `mc:Fallback` — are still collected, and their group is
+ * marked `unbalanced`. A caller that hashes `[selected, ...unselected]` across
+ * every group therefore sees the whole document, which is what lets a
+ * fail-closed guard count visually without going blind to content it does not
+ * show.
+ *
+ * This is the walk to use when counting objects, numbering user-facing locator
+ * ordinals, or projecting visible text. It is *not* the walk to use when
+ * preserving or canonicalizing markup — see the module header.
+ *
+ * Companion work: `w:sym` glyph projection (#793) is the other place a naive
+ * text walk disagrees with what Word shows; it lands separately.
+ *
+ * @see https://github.com/UseJunior/safe-docx/issues/794
+ * @see https://github.com/UseJunior/safe-docx/issues/793
+ */
+export function groupElementsByTagNameNS(
+  root: Node,
+  namespaceURI: string,
+  localName: string,
+  options: MarkupCompatibilityOptions = {},
+): MarkupCompatibilityGroup[] {
+  function visit(node: Node, into: MarkupCompatibilityGroup[]): void {
+    for (let child = node.firstChild; child; child = child.nextSibling) {
+      if (!isElement(child)) continue;
+      if (matches(child, namespaceURI, localName)) {
+        into.push({ selected: child, unselected: [], unbalanced: false });
+      }
+      if (isAlternateContent(child)) {
+        into.push(...alternateContentGroups(child));
+        continue;
+      }
+      visit(child, into);
+    }
+  }
+
+  function alternateContentGroups(
+    alternateContent: Element,
+  ): MarkupCompatibilityGroup[] {
+    const chosen = selectAlternateContentBranch(alternateContent, options);
+    const selectedGroups: MarkupCompatibilityGroup[] = [];
+    if (chosen) visit(chosen, selectedGroups);
+    // Matches that belong to no rendered object. They are still real bytes in
+    // the package, so they are carried rather than dropped.
+    const unpairable: MarkupCompatibilityGroup[] = [];
+    for (
+      let branch = alternateContent.firstChild;
+      branch;
+      branch = branch.nextSibling
+    ) {
+      if (!isElement(branch) || branch === chosen) continue;
+      const branchGroups: MarkupCompatibilityGroup[] = [];
+      if (matches(branch, namespaceURI, localName)) {
+        branchGroups.push({
+          selected: branch,
+          unselected: [],
+          unbalanced: false,
+        });
+      }
+      visit(branch, branchGroups);
+      if (branchGroups.length === 0) continue;
+      const balanced =
+        branchKind(branch) !== undefined &&
+        branchGroups.length === selectedGroups.length;
+      for (const [index, group] of selectedGroups.entries()) {
+        if (!balanced) group.unbalanced = true;
+        const twin = branchGroups[index];
+        if (!twin) continue;
+        group.unselected.push(twin.selected, ...twin.unselected);
+        if (twin.unbalanced) group.unbalanced = true;
+      }
+      for (const extra of branchGroups.slice(selectedGroups.length)) {
+        const last = selectedGroups[selectedGroups.length - 1];
+        if (last) {
+          last.unbalanced = true;
+          last.unselected.push(extra.selected, ...extra.unselected);
+          continue;
+        }
+        extra.unbalanced = true;
+        unpairable.push(extra);
+      }
+    }
+    return [...selectedGroups, ...unpairable];
+  }
+
+  const groups: MarkupCompatibilityGroup[] = [];
+  if (isElement(root) && isAlternateContent(root)) {
+    groups.push(...alternateContentGroups(root));
+  } else {
+    visit(root, groups);
+  }
+  return groups;
+}
+
+/**
+ * `getElementsByTagNameNS` restricted to the selected branch of every
+ * `mc:AlternateContent` — one entry per visual object rather than one per
+ * stored copy. Results are in document order, matching the unfiltered DOM API.
+ *
+ * Copies in unselected branches are dropped from the result. When you need
+ * them — to hash them, or to keep them in step with the copy you rewrote — use
+ * {@link groupElementsByTagNameNS}, which is total over the document.
+ *
+ * @see https://github.com/UseJunior/safe-docx/issues/794
+ */
+export function selectedElementsByTagNameNS(
+  root: Node,
+  namespaceURI: string,
+  localName: string,
+  options: MarkupCompatibilityOptions = {},
+): Element[] {
+  return groupElementsByTagNameNS(
+    root,
+    namespaceURI,
+    localName,
+    options,
+  ).map((group) => group.selected);
+}


### PR DESCRIPTION
## What was wrong

Word stores one modern text box **twice** inside a single `mc:AlternateContent`: an `mc:Choice Requires="wps"` holding the DrawingML spelling and an `mc:Fallback` holding the VML spelling. Exactly one renders. Both carry a complete `w:txbxContent`.

Nothing in the repository knew that — `mc:Choice` and `mc:Fallback` appeared in no `.ts`, `.md` or `.lean` file. Every `getElementsByTagNameNS(W_NS, 'txbxContent')` counted one authored box as two.

### Severity: wrong counts and wrong diagnostics, not wrong redline

This is the honest framing from #794 and it survives into this PR. Three scenarios were tried — both branches changed, two boxes with only the second changed, and only the `mc:Choice` branch changed — and **all produced correct revisions in the right branch**. The double count is self-consistent across baseline and candidate, so it cancels for the equality check.

What it does not cancel for:

- **every count safe-docx reports is inflated by one per twinned box**, and that count is visible output;
- **every `#w:txbxContent[N]` locator in `UnsupportedTextBoxRevisionError` misnumbers.** A user chasing a diagnostic is sent to a container that does not exist on their page. That is a real defect, not a cosmetic one.

## Reproduction

Synthetic fixture from #794 — one text box authored the way Word writes one.

**Before** (at `8035dce`):

```
A. COUNTING
  visual text boxes authored                    : 1
  <w:txbxContent> elements found by a w-NS scan : 2   <-- expected 1
  <w:p> elements found by a w-NS scan           : 3   (1 body para + the box, twice)

  projection of the box before the edit : "CharlieCharlie\nCharlie\nCharlie"
  projection of the box after  the edit : "DeltaDelta\nDelta\nDelta"

  txbxContent scan count for 2 visual boxes     : 4   <-- expected 2

D. REPORTED COUNT AND LOCATOR
  visual text boxes authored   : 2
  visual text boxes changed    : 1  (the second one)
  changed containers reported  : 2
  ... Changed container(s): word/document.xml#w:txbxContent[2], word/document.xml#w:txbxContent[3]
```

**After:**

```
COUNT
  1 authored box   raw w:txbxContent = 2   branch-aware = 1
  2 authored boxes raw w:txbxContent = 4   branch-aware = 2

LOCATOR  (two boxes, only the second edited)
  changed containers reported : 1
  ... Changed container(s): word/document.xml#w:txbxContent[1]
```

The redline itself is unchanged: two twinned boxes with only the second edited still compare in place, still put `w:ins`/`w:del` in both stored copies of the second box and none in the first. That is asserted by a test, not assumed.

## What changed

**`markupCompatibility.ts` (new).** MCE branch selection, exported from the package so a consumer writing their own DOCX verifier gets the corrected walk rather than a paragraph of documentation telling them to remember. `selectAlternateContentBranch`, `selectedElementsByTagNameNS`, `groupElementsByTagNameNS`, `MC_NAMESPACE`.

Two properties matter and both are tested:

- **Never selects nothing.** First satisfiable `mc:Choice`, else `mc:Fallback`, else the first branch present. A strict MCE processor renders nothing when no `mc:Choice` is satisfiable and there is no `mc:Fallback`; a comparison engine that walked away from authored content there would hide a real change behind an equality check that agrees with itself.
- **Grouping is total.** Every match the unfiltered DOM walk returns appears in exactly one group, as `selected` or one of `unselected` — including surplus copies in a branch that holds more than the selected one, and matches under a child that is neither `mc:Choice` nor `mc:Fallback`. Those groups are flagged `unbalanced`. This is what lets a fail-closed guard count visually without going blind to content it does not show.

The default satisfiability policy is documented for what it is: a **deterministic comparison policy, not MCE capability detection.** A declared prefix means the name resolves, not that any consumer implements the namespace. Callers who need real capability detection pass `isChoiceSatisfiable`. The alternative — a hard-coded list of Office extension namespaces — rots with every release, and every stale entry silently moves an ordinal onto the wrong object.

**`textBoxRevisionSafety.ts`.** `index` and the reported ordinal are now separate concepts: `index` stays the raw storage address that isolation and splice-back resolve against, and `TextBoxStoryInput.visualIndex` is the number a user sees. Every `TextBoxRevisionChange` is built from the visual ordinal. `assertTextBoxContentUnchanged` enumerates groups but hashes **every stored copy**, so its detection strength is unchanged and only its numbering moved.

New fail-closed guard: the two documents' raw→visual maps must correspond. Equal raw counts do not imply equal storage shape — two plain VML boxes and one twinned box both store two `w:txbxContent` elements — and pairing by raw position across mismatched shapes compares unrelated objects.

**Deliberately not changed: which branches the comparison walks.** The redline is currently correct, and the round-trip projection that would have to move with it lives in `fieldComparisonSemantics.ts`, which #793 owns right now. Filtering the comparison enumeration alone was tried and fails: the projection still walks the unrendered branch, sees stale text, and the pair dies with `assembled nested stories failed accept/reject round-trip validation`.

### Audit of the other walks

`getElementsByTagNameNS` on a `w:`-namespace tag is the smell, so every site in `docx-compare` was classified as *presentation* (must see one branch) or *preservation* (must see all).

| Site | Class | Action |
|---|---|---|
| `textBoxRevisionSafety` counts and locators | presentation | fixed here |
| `fieldComparisonSemantics.extractRoundTripComparisonText` | presentation | genuinely affected; deferred, #793 owns the file |
| `ancillaryFieldSafety.inventoryEligibleFields` | both — inventory is preservation, `paragraphOrdinal` is public | left alone; filtering would weaken a fail-closed inventory. Needs the same raw/visual split. Follow-up. |
| `tocPagerefCache` | preservation mutation | unchanged — must touch both branches or they drift |
| `scaffoldFingerprint`, `partScaffoldFingerprint`, `unsupportedStoryReason` | preservation / fail-closed | unchanged |
| `documentReconstructor`, `opaquePassthrough`, `xmlToWmlElement` | structural identity and normalization | unchanged |
| `benchmark/gates.ts` | benchmark only | unchanged |

## Tests

`markupCompatibility.test.ts` (11) and `textBoxRevisionSafety-alternate-content.test.ts` (16), all synthetic.

Including negative controls, because this class of bug — a check that agrees with itself — is exactly why the double count went unnoticed:

- the branch-aware count is compared against a table of known visible counts **and** asserted to differ from the raw count, so a filter that did nothing would fail;
- the reported ordinal is checked on a three-box document, so an implementation returning a constant or the raw index fails;
- the storage-shape guard has a case asserting it still **accepts** matching shapes, so a guard that refused everything would fail;
- every otherwise-unreachable stored copy has a test that mutates it and asserts the guard **refuses**, not merely that a flag is set.

All three fixed behaviours were confirmed red against the pre-fix source before being made green.

## Follow-ups (not filed — flagging rather than opening issues on a public repo)

1. Route `extractRoundTripComparisonText` through `selectedElementsByTagNameNS`, once #793 releases `fieldComparisonSemantics.ts`. That is what fixes the four-times text projection.
2. Give `AncillaryFieldLocator.paragraphOrdinal` the same raw/visual split.
3. Consider promoting `markupCompatibility.ts` to `@usejunior/docx-core`; it is not intrinsically comparison-specific. It sits in `docx-compare` here because `docx-core/src/primitives/text.ts` is held by #793.

Fixes #794
