### PR TITLE
ci(verification): stop an unrelated failing test from silencing the Lean↔TS harnesses

### DIFF
--- a/.github/workflows/lean-build.yml
+++ b/.github/workflows/lean-build.yml
@@ -250,17 +250,23 @@ jobs:
       # NVCA acceptance step suppressed both harnesses across a window in which #802
       # edited the Lean model and its TypeScript counterparts together.
       #
-      # `always()` would be the WRONG relaxation. Both harnesses self-gate on the compiled
-      # Lean executable (`describe.skip` when it is absent) and an all-skipped vitest file
-      # exits 0 — so under `always()`, a run whose `lake build` failed would execute these
-      # steps, skip every case, and report them GREEN. That is the same defect wearing a
-      # passing checkmark, and strictly harder to notice than a skip.
+      # `!cancelled()` plus explicit prerequisite success, rather than `always()`, for two
+      # reasons. It respects cancellation — `always()` would keep launching a ~10-minute
+      # exhaustive sweep on a run an operator has already abandoned or that a newer push
+      # superseded. And it declines to run the harnesses at all when their own inputs were
+      # never built: after a failed `lake build` or `npm ci` there is nothing meaningful to
+      # compare, and a step that cannot be meaningful should not report at all. GitHub
+      # documents `!cancelled()` as the recommended form for steps that must survive an
+      # earlier failure.
       #
-      # `!cancelled()` plus explicit prerequisite success is the precise condition: run
-      # whenever the harnesses CAN be meaningful (their own inputs were built) and an
-      # operator has not cancelled the run, regardless of unrelated failures. Paired with
-      # SAFE_DOCX_REQUIRE_LEAN_DIFFERENTIAL below, which turns the self-skip into a hard
-      # failure, a green harness step now implies the harness actually ran.
+      # Historically `always()` carried a second, sharper hazard: both harnesses self-gate
+      # on the compiled Lean executable (`describe.skip` when absent) and an all-skipped
+      # vitest file exits 0, so a run whose `lake build` failed would have executed these
+      # steps, skipped every case, and reported them GREEN — the same defect wearing a
+      # passing checkmark. SAFE_DOCX_REQUIRE_LEAN_DIFFERENTIAL below now closes that
+      # independently, turning a missing executable into a hard failure, so it is defense
+      # in depth rather than the reason for the condition. Together: a green harness step
+      # implies the harness actually ran.
       #
       # Reordering ahead of the acceptance steps would only invert the problem (a harness
       # failure would then suppress the acceptance gates). A separate job would re-pay the

--- a/.github/workflows/lean-build.yml
+++ b/.github/workflows/lean-build.yml
@@ -139,6 +139,7 @@ jobs:
           exit 1
 
       - name: Build LeanSpike
+        id: lean_build
         working-directory: verification/lean
         run: |
           lake build
@@ -205,6 +206,7 @@ jobs:
           node-version: 20
           cache: npm
       - name: Install dependencies (npm ci with retry)
+        id: npm_ci
         run: |
           for attempt in 1 2 3; do
             echo "npm ci attempt ${attempt}/3"
@@ -236,9 +238,38 @@ jobs:
           SAFE_DOCX_REQUIRE_LEAN_CHECKER: '1'
         run: npm run test:run -w @usejunior/docx-core -- src/integration/nvca-structural-regression.test.ts
 
+      # The two differential harnesses below are the only checks that verify the Lean
+      # model still DESCRIBES the TypeScript engine. Every other Lean step above proves
+      # the model compiles and is internally sound, which stays true even as the engine
+      # drifts away from it.
+      #
+      # They therefore must not inherit the default `if: success()`. Under it, any earlier
+      # failure — including an acceptance test about document-comparison behavior, which
+      # says nothing about the Lean↔TS correspondence — silently skips them. That is
+      # exactly what happened between 2026-08-10 and 2026-08-11 (issue #804): a failing
+      # NVCA acceptance step suppressed both harnesses across a window in which #802
+      # edited the Lean model and its TypeScript counterparts together.
+      #
+      # `always()` would be the WRONG relaxation. Both harnesses self-gate on the compiled
+      # Lean executable (`describe.skip` when it is absent) and an all-skipped vitest file
+      # exits 0 — so under `always()`, a run whose `lake build` failed would execute these
+      # steps, skip every case, and report them GREEN. That is the same defect wearing a
+      # passing checkmark, and strictly harder to notice than a skip.
+      #
+      # `!cancelled()` plus explicit prerequisite success is the precise condition: run
+      # whenever the harnesses CAN be meaningful (their own inputs were built) and an
+      # operator has not cancelled the run, regardless of unrelated failures. Paired with
+      # SAFE_DOCX_REQUIRE_LEAN_DIFFERENTIAL below, which turns the self-skip into a hard
+      # failure, a green harness step now implies the harness actually ran.
+      #
+      # Reordering ahead of the acceptance steps would only invert the problem (a harness
+      # failure would then suppress the acceptance gates). A separate job would re-pay the
+      # ~22-minute cold Lean build for no added isolation.
       - name: Lean↔TS LCS differential harness (exhaustive)
+        if: ${{ !cancelled() && steps.lean_build.conclusion == 'success' && steps.npm_ci.conclusion == 'success' }}
         env:
           LEAN_DIFF_EXHAUSTIVE: '1'
+          SAFE_DOCX_REQUIRE_LEAN_DIFFERENTIAL: '1'
         run: npm run test:run -w @usejunior/docx-core -- src/integration/lean-differential-lcs.test.ts
 
       # Lean↔TS Tier 2-helper differential harness (Tier 2.5, second increment). `lake build`
@@ -248,6 +279,8 @@ jobs:
       # accept/reject/validate engine over a widened randomized sweep, reusing the Node setup
       # and `npm ci` above. `LEAN_DIFF_EXHAUSTIVE=1` widens this harness's random sweep too.
       - name: Lean↔TS Tier 2-helper differential harness (extended)
+        if: ${{ !cancelled() && steps.lean_build.conclusion == 'success' && steps.npm_ci.conclusion == 'success' }}
         env:
           LEAN_DIFF_EXHAUSTIVE: '1'
+          SAFE_DOCX_REQUIRE_LEAN_DIFFERENTIAL: '1'
         run: npm run test:run -w @usejunior/docx-core -- src/integration/lean-differential-helpers.test.ts

--- a/packages/docx-core/src/integration/lean-differential-helpers.test.ts
+++ b/packages/docx-core/src/integration/lean-differential-helpers.test.ts
@@ -493,6 +493,18 @@ const G5_DOC: WireDoc = [
 ];
 
 const exeExists = existsSync(LEAN_EXE);
+
+// See the matching note in lean-differential-lcs.test.ts. The skip is a developer
+// affordance; in CI a skipped harness exits 0 and is indistinguishable from a passing
+// one, which would let the Lean↔TS correspondence go unchecked behind a green step.
+// `SAFE_DOCX_REQUIRE_LEAN_DIFFERENTIAL=1` makes a missing executable fail loudly. See #804.
+if (!exeExists && process.env.SAFE_DOCX_REQUIRE_LEAN_DIFFERENTIAL === '1') {
+  throw new Error(
+    `[lean-differential-helpers] SAFE_DOCX_REQUIRE_LEAN_DIFFERENTIAL=1 but ${LEAN_EXE} is missing. ` +
+      `Refusing to skip: a skipped differential harness reports success without verifying ` +
+      `anything. Build it with: (cd verification/lean && lake build leanHelperDifferential)`,
+  );
+}
 if (!exeExists) {
   // eslint-disable-next-line no-console
   console.warn(

--- a/packages/docx-core/src/integration/lean-differential-lcs.test.ts
+++ b/packages/docx-core/src/integration/lean-differential-lcs.test.ts
@@ -254,6 +254,21 @@ function buildCases(): Pair[] {
 }
 
 const exeExists = existsSync(LEAN_EXE);
+
+// The skip below is a developer affordance: without the Lean toolchain there is nothing
+// to compare against, and a local `npm test` should not fail for that. In CI it is a
+// liability — an all-skipped vitest file exits 0, so a silently skipped harness is
+// indistinguishable from a passing one, and this harness is the only check that the Lean
+// model still describes the TS engine. `SAFE_DOCX_REQUIRE_LEAN_DIFFERENTIAL=1` (set by
+// .github/workflows/lean-build.yml) makes a missing executable a hard failure instead, so
+// a green step implies the sweep actually ran. See issue #804.
+if (!exeExists && process.env.SAFE_DOCX_REQUIRE_LEAN_DIFFERENTIAL === '1') {
+  throw new Error(
+    `[lean-differential-lcs] SAFE_DOCX_REQUIRE_LEAN_DIFFERENTIAL=1 but ${LEAN_EXE} is missing. ` +
+      `Refusing to skip: a skipped differential harness reports success without verifying ` +
+      `anything. Build it with: (cd verification/lean && lake build leanDifferential)`,
+  );
+}
 if (!exeExists) {
   // eslint-disable-next-line no-console
   console.warn(

--- a/packages/docx-core/src/integration/nvca-structural-regression.test.ts
+++ b/packages/docx-core/src/integration/nvca-structural-regression.test.ts
@@ -287,6 +287,17 @@ describeWithCompiledLean('NVCA full-document Lean comment stack safety', () => {
       expect(originalAtomCount).toBe(41_621);
 
       const revised = await deriveMinimallyEditedRevision(original);
+      // This used to assert the `[DEBUG] atomizeTree: ... word-split to N, punct-merged to M`
+      // line was emitted. `8035dce` (#785, fixing #783) deleted that line so CLI stdout stays
+      // valid machine-readable JSON, and added a unit regression in atomizer.test.ts holding
+      // atomization silent — leaving this assertion requiring a log another test forbids, which
+      // is why this step began failing on exactly that commit and, until #804, silently skipped
+      // both Lean↔TS differential harnesses behind it.
+      //
+      // Inverted rather than deleted: the original intent (the word-split and punct-merge passes
+      // actually ran) is already covered more strongly and directly by the exact atom-count
+      // fingerprint asserted above, and #785's stdout-silence property is worth pinning here at
+      // full-document scale, where code paths a unit test cannot reach are exercised.
       const atomizerLogs: string[] = [];
       const logSpy = vi.spyOn(console, 'log').mockImplementation((...values) => {
         atomizerLogs.push(values.map(String).join(' '));
@@ -306,9 +317,7 @@ describeWithCompiledLean('NVCA full-document Lean comment stack safety', () => {
       } finally {
         logSpy.mockRestore();
       }
-      expect(atomizerLogs.some((message) =>
-        message.includes('word-split to ') && message.includes('punct-merged to '),
-      )).toBe(true);
+      expect(atomizerLogs).toEqual([]);
       expect(
         comparison.documentIntegrity?.status,
         JSON.stringify(comparison.documentIntegrity, null, 2),

--- a/packages/docx-core/src/integration/nvca-structural-regression.test.ts
+++ b/packages/docx-core/src/integration/nvca-structural-regression.test.ts
@@ -294,10 +294,13 @@ describeWithCompiledLean('NVCA full-document Lean comment stack safety', () => {
       // is why this step began failing on exactly that commit and, until #804, silently skipped
       // both Lean↔TS differential harnesses behind it.
       //
-      // Inverted rather than deleted: the original intent (the word-split and punct-merge passes
-      // actually ran) is already covered more strongly and directly by the exact atom-count
-      // fingerprint asserted above, and #785's stdout-silence property is worth pinning here at
-      // full-document scale, where code paths a unit test cannot reach are exercised.
+      // Inverted rather than deleted. The original intent — evidence that the word-split and
+      // punct-merge passes ran — is carried by the exact atom-count fingerprint asserted above:
+      // a composite regression fingerprint over the whole pipeline, which would move if either
+      // pass stopped running, though it does not isolate them individually. That is the same
+      // grade of evidence the log line gave, without depending on stdout. Asserting silence
+      // here additionally pins #785's property at full-document scale, where paths the atomizer
+      // unit test cannot reach are exercised.
       const atomizerLogs: string[] = [];
       const logSpy = vi.spyOn(console, 'log').mockImplementation((...values) => {
         atomizerLogs.push(values.map(String).join(' '));


### PR DESCRIPTION
Fixes #804.

One failing acceptance test was silently disabling the two Lean↔TS differential harnesses — the only checks that verify the Lean model still *describes* the TypeScript engine. They had not run on `main` since **2026-08-10**, a window that includes the merge of #802, which edited `Tier2/RoundTripText.lean`, `Tier2/OoxmlModel.lean`, `Tier2/FieldStructure.lean` and `DifferentialHelpers.lean` **alongside their TypeScript counterparts**. The harness whose entire job is to check those two agree never ran on it.

The Lean steps stayed green throughout — `Build LeanSpike`, the axiom allowlist and zero-sorry all pass — because they prove the model compiles and is internally sound. That property remains true no matter how far the engine drifts.

## Both defects are fixed

### (a) The wiring

Steps ran under the default `if: success()`, so step 15 (`Complete NVCA selected-comment fixed-stack acceptance`) skipped steps 16–17 after it. Step 15 tests document-comparison behavior on an NVCA fixture and has no bearing on the Lean↔TS correspondence.

- `id: lean_build` and `id: npm_ci` on the two genuine prerequisites.
- Both harness steps gated on `!cancelled() && steps.lean_build.conclusion == 'success' && steps.npm_ci.conclusion == 'success'`.
- `SAFE_DOCX_REQUIRE_LEAN_DIFFERENTIAL: '1'` on both, with a matching guard in each harness file.

**Why not `if: always()`.** Both harnesses self-gate on the compiled Lean executable (`describe.skip` when absent), and an all-skipped vitest file exits `0`. Under `always()`, a run whose `lake build` failed would execute these steps, skip every case, and report them **green** — the same defect wearing a passing checkmark. Demonstrated by moving the executable aside:

```console
$ npm run test:run -w @usejunior/docx-core -- src/integration/lean-differential-helpers.test.ts
 Test Files  1 passed (1)
      Tests  3 passed | 9 skipped (12)
# exit 0  ← a job summary shows this as success

$ SAFE_DOCX_REQUIRE_LEAN_DIFFERENTIAL=1 npm run test:run -w @usejunior/docx-core -- src/integration/lean-differential-helpers.test.ts
Error: [lean-differential-helpers] SAFE_DOCX_REQUIRE_LEAN_DIFFERENTIAL=1 but .../leanHelperDifferential is missing.
Refusing to skip: a skipped differential harness reports success without verifying anything.
 Test Files  1 failed (1)
# exit 1
```

The guard follows the pattern already used and CI-proven in this repo for `SAFE_DOCX_REQUIRE_LEAN_CHECKER` (`leanXmlVerifier.test.ts:102`).

`!cancelled()` rather than `always()` because it respects cancellation instead of launching a ten-minute exhaustive sweep on an abandoned or superseded run; the prerequisite clauses because a harness whose inputs were never built cannot be meaningful. Reordering ahead of the acceptance steps would merely invert the problem; a separate job would re-pay the ~22-minute cold Lean build.

### (b) Step 15 itself — fixed here, because the cause was unambiguous

`nvca-structural-regression.test.ts` asserted that the `[DEBUG] atomizeTree: ... word-split to N, punct-merged to M` line was emitted. Those strings exist nowhere in the source tree. `8035dce` (#785, fixing #783) deleted that line so CLI stdout stays valid machine-readable JSON — and added a unit regression in `atomizer.test.ts` asserting `console.log` is **not** called during atomization.

The two tests were in direct contradiction: one required the log, the other forbade it. That is why step 15 began failing on exactly the commit that removed the line.

Inverted rather than deleted, so the step now pins #785's stdout-silence property at full-document scale. The original intent is carried by the exact atom-count fingerprint (`expect(originalAtomCount).toBe(41_621)`) asserted just above, which is computed through the full pipeline.

## What the harnesses said once turned back on

Both pass, and both genuinely ran — not skipped:

| Harness | Result |
|---|---|
| `lean-differential-lcs` (`LEAN_DIFF_EXHAUSTIVE=1`, ~1.19M pairs) | 2/2 passed, 23.4s |
| `lean-differential-helpers` (extended sweep) | 12/12 passed, 26.9s |
| `nvca-structural-regression` (step 15, with Lean checker required) | 2/2 passed |

**No Lean↔TS divergence surfaced.** #802's Lean and TypeScript changes do not break the correspondence the harnesses check.

## ⚠️ But that pass does not cover #802 — filed as #805

The harnesses cannot exercise the `sym` constructor #802 added. Both sides of the wire block it:

- `WireAtom` in `lean-differential-helpers.test.ts` is a five-way union (`text`, `delText`, `instrText`, `delInstrText`, `fldChar`) with no `sym` member, and the generator emits only `text`/`delText`.
- `DifferentialHelpers.lean` encodes `.sym` in `ToJson Atom` but **never decodes it** in `FromJson Atom`.

```console
$ printf '%s' '{"cases":[{"doc":[{"body":[{"run":{"content":[{"text":"a"},{"sym":"✓"}]}}]}]}]}' \
    | ./verification/lean/.lake/build/bin/leanHelperDifferential
uncaught exception: case parse error: unknown Atom: {"sym":"✓"}
```

So the green sweep above says nothing about #802's constructor. This is a **coverage gap, not a divergence** — the harness rejects the case before either model is compared. Nothing is known to be wrong; nothing is known to be right either. Tracked in **#805** with a concrete fix plan. Nothing was loosened to make anything pass.

## Peer review

Codex, `--code` lane, dynamic with full execution trace — stored under `.peer-review/lean-harness-skip/`. Verdict **NEEDS-CHANGES**, three findings:

1. **High** — the harness is vacuous w.r.t. `sym`. Codex independently reproduced the `WireAtom` union, the missing `FromJson` case and the `unknown Atom` rejection, and argued it should be fixed *in this PR*.
2. **Medium** — the `always()` rationale comment was stale, since the guard added in the same change means `always()` would now *fail* rather than report green. **Correct catch; fixed in `797e90e`.**
3. Defect (b) — no blocking issue, but the comment overclaimed that the atom-count fingerprint covers each pass "more strongly and directly". **Fixed in `797e90e`.**

Codex also produced a failure-mode table confirming the condition behaves correctly across job failure, timeout, cancellation, prerequisite failure and runner loss, and found **no normal failure mode that silently yields a green job**. It confirmed GitHub documents `!cancelled()` as the recommended form here.

**Adjudication on finding 1 — deferred to #805, against Codex's preference.** Extending the harness means adding a Lean decoder case, a TS wire variant, real `<w:sym>` XML rendering matching the production `@w:char` contract, two token projections, seeded cases across five wrapper types, and generator changes. That is a decision about what the harness's documented "faithful subset" should contain, not a wiring fix — and it may itself surface a genuine divergence needing its own investigation. Blocking a narrow, provable wiring fix that protects *every future change* on an open-ended investigation would leave the wiring defect in place longer for no gain. The gap is pre-existing and is not made worse here; it becomes visible only because the harnesses run again.

## Flagged, deliberately not changed: `lean-build` is not a required status context

This is why none of the above blocked a merge, and it is arguably the deeper problem. Making it required affects every open PR and all org seats, and interacts with the pending merge-queue decision. **Left alone — that is a call for @stevenobiajulu, not this PR.**

## Verification

- `npm run lint:workspaces` — exit 0. (Note: a stale `dist/` produces phantom `projectSymbolRun` errors; run `TURBO_FORCE=1 npm run build` first.)
- Proof that a failing step 15 no longer suppresses 16–17: a deliberate-sabotage branch, run via `workflow_dispatch`, posted as a comment below.
