### PR TITLE
fix(docx-mcp): remove obsolete console.log suppression around compare_documents

### DIFF
--- a/packages/docx-mcp/src/integration/stdio_protocol_cleanliness.test.ts
+++ b/packages/docx-mcp/src/integration/stdio_protocol_cleanliness.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Stdio protocol cleanliness — end-to-end regression for issue #809.
+ *
+ * The MCP server serves JSON-RPC over stdio, so any stray library write to
+ * stdout corrupts the protocol stream. Issue #783 was exactly that (an
+ * unconditional atomizer debug line), fixed at the source by PR #785. The
+ * MCP tool layer used to contain the emit by swapping the process-global
+ * console.log for a no-op around each comparison — a workaround that was
+ * never concurrency-safe: with two overlapping compare_documents calls, the
+ * second call captured the first call's no-op as its "original" and restored
+ * it last, permanently silencing console.log for the whole process.
+ *
+ * This test drives the REAL server binary over stdio — the same entry MCP
+ * clients use — with real legal documents, issues two overlapping
+ * compare_documents tools/call requests (the exact interleaving the old
+ * workaround corrupted), and asserts that every line the server writes to
+ * stdout parses as a JSON-RPC message. No unit-level substitute can catch a
+ * reintroduced stdout emit anywhere on the comparison path; this does.
+ */
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, afterEach } from 'vitest';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { createTrackedTempDir, registerCleanup } from '../testing/session-test-utils.js';
+import { DocxDocument, getParagraphText, OOXML, replaceParagraphTextRange } from '@usejunior/docx-core';
+
+const test = testAllure.epic('Document Comparison').withLabels({
+  feature: 'Stdio Protocol Cleanliness',
+});
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const PACKAGE_DIR = path.resolve(__dirname, '../..');
+const CLI_ENTRY = path.resolve(PACKAGE_DIR, 'src/cli.ts');
+const REAL_DOCUMENT = path.resolve(
+  __dirname,
+  '../../../../tests/test_documents/open-agreements/mutual-nda.docx',
+);
+
+interface JsonRpcMessage {
+  jsonrpc?: string;
+  id?: number | string;
+  result?: Record<string, unknown>;
+  error?: { code: number; message: string };
+  method?: string;
+}
+
+/**
+ * Minimal newline-delimited JSON-RPC client over a spawned server process.
+ * Records EVERY raw stdout line so the test can assert protocol cleanliness
+ * — not just that the responses it awaited happened to arrive.
+ */
+class StdioProbe {
+  readonly child: ChildProcessWithoutNullStreams;
+  readonly rawStdoutLines: string[] = [];
+  readonly stderrChunks: string[] = [];
+  private stdoutBuffer = '';
+  private readonly responseWaiters = new Map<number, (msg: JsonRpcMessage) => void>();
+  private readonly responses = new Map<number, JsonRpcMessage>();
+
+  constructor() {
+    // Spawn the real CLI entry (`safedocx serve`) via tsx so the test runs the
+    // same server MCP clients launch, without requiring a prebuilt dist/.
+    this.child = spawn(process.execPath, ['--import', 'tsx', CLI_ENTRY, 'serve'], {
+      cwd: PACKAGE_DIR,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env },
+    });
+    this.child.stdout.setEncoding('utf8');
+    this.child.stderr.setEncoding('utf8');
+    this.child.stderr.on('data', (chunk: string) => {
+      this.stderrChunks.push(chunk);
+    });
+    this.child.stdout.on('data', (chunk: string) => {
+      this.stdoutBuffer += chunk;
+      let newlineIndex = this.stdoutBuffer.indexOf('\n');
+      while (newlineIndex !== -1) {
+        const line = this.stdoutBuffer.slice(0, newlineIndex);
+        this.stdoutBuffer = this.stdoutBuffer.slice(newlineIndex + 1);
+        if (line.trim().length > 0) {
+          this.rawStdoutLines.push(line);
+          this.dispatch(line);
+        }
+        newlineIndex = this.stdoutBuffer.indexOf('\n');
+      }
+    });
+  }
+
+  private dispatch(line: string): void {
+    let message: JsonRpcMessage;
+    try {
+      message = JSON.parse(line) as JsonRpcMessage;
+    } catch {
+      // Not JSON — protocol corruption. The cleanliness assertion at the end
+      // of the test reports it; nothing to dispatch.
+      return;
+    }
+    if (typeof message.id === 'number' && (message.result !== undefined || message.error !== undefined)) {
+      this.responses.set(message.id, message);
+      const waiter = this.responseWaiters.get(message.id);
+      if (waiter) {
+        this.responseWaiters.delete(message.id);
+        waiter(message);
+      }
+    }
+  }
+
+  send(message: Record<string, unknown>): void {
+    this.child.stdin.write(`${JSON.stringify(message)}\n`);
+  }
+
+  waitForResponse(id: number, timeoutMs: number): Promise<JsonRpcMessage> {
+    const existing = this.responses.get(id);
+    if (existing) return Promise.resolve(existing);
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.responseWaiters.delete(id);
+        reject(new Error(
+          `Timed out waiting for JSON-RPC response id=${id} after ${timeoutMs}ms. ` +
+          `stdout lines so far: ${JSON.stringify(this.rawStdoutLines)}; ` +
+          `stderr: ${this.stderrChunks.join('')}`,
+        ));
+      }, timeoutMs);
+      this.responseWaiters.set(id, (msg) => {
+        clearTimeout(timer);
+        resolve(msg);
+      });
+    });
+  }
+
+  async shutdown(): Promise<void> {
+    this.child.stdin.end();
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        this.child.kill('SIGKILL');
+        resolve();
+      }, 2000);
+      this.child.once('exit', () => {
+        clearTimeout(timer);
+        resolve();
+      });
+    });
+  }
+}
+
+function parseToolResult(message: JsonRpcMessage): Record<string, unknown> {
+  expect(message.error, `tools/call id=${String(message.id)} returned a JSON-RPC error`).toBeUndefined();
+  const content = (message.result as { content?: Array<{ type: string; text: string }> }).content;
+  expect(content).toBeDefined();
+  expect(content![0]!.type).toBe('text');
+  return JSON.parse(content![0]!.text) as Record<string, unknown>;
+}
+
+/** Write a minimally-revised copy of a real document so the comparison has a real diff. */
+async function writeMinimallyRevisedCopy(sourcePath: string, targetPath: string): Promise<void> {
+  const original = await fs.readFile(sourcePath);
+  const revised = await DocxDocument.load(original);
+  const paragraph = revised.getParagraphs().find((candidate) => {
+    const text = getParagraphText(candidate);
+    return text.length >= 20 && candidate.getElementsByTagNameNS(OOXML.W_NS, 'fldChar').length === 0;
+  });
+  if (!paragraph) throw new Error('real fixture has no editable body paragraph');
+  const paragraphText = getParagraphText(paragraph);
+  replaceParagraphTextRange(paragraph, 0, 1, paragraphText[0] === 'A' ? 'B' : 'A');
+  await fs.writeFile(targetPath, (await revised.toBuffer({ cleanBookmarks: false })).buffer);
+}
+
+describe('MCP stdio protocol cleanliness under concurrent compare_documents', () => {
+  registerCleanup();
+
+  let probe: StdioProbe | undefined;
+  afterEach(async () => {
+    if (probe) {
+      await probe.shutdown();
+      probe = undefined;
+    }
+  });
+
+  test(
+    'overlapping tools/call comparisons of a real document leave every stdout line valid JSON-RPC',
+    async ({ given, when, then }: AllureBddContext) => {
+      const tmpDir = await createTrackedTempDir('safe-docx-stdio-cleanliness-');
+      const revisedPath = path.join(tmpDir, 'mutual-nda-revised.docx');
+      const outputA = path.join(tmpDir, 'redline-a.docx');
+      const outputB = path.join(tmpDir, 'redline-b.docx');
+
+      await given('the real MCP server running over stdio and a real NDA with a revised copy', async () => {
+        await writeMinimallyRevisedCopy(REAL_DOCUMENT, revisedPath);
+        probe = new StdioProbe();
+        probe.send({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'initialize',
+          params: {
+            protocolVersion: '2024-11-05',
+            capabilities: {},
+            clientInfo: { name: 'stdio-cleanliness-probe', version: '0.0.0' },
+          },
+        });
+        const initResponse = await probe.waitForResponse(1, 60_000);
+        expect(initResponse.error).toBeUndefined();
+        probe.send({ jsonrpc: '2.0', method: 'notifications/initialized' });
+      });
+
+      let resultA: Record<string, unknown>;
+      let resultB: Record<string, unknown>;
+      await when('two compare_documents tools/call requests are issued back-to-back so they overlap', async () => {
+        const callParams = (savePath: string) => ({
+          name: 'compare_documents',
+          arguments: {
+            original_file_path: REAL_DOCUMENT,
+            revised_file_path: revisedPath,
+            save_to_local_path: savePath,
+          },
+        });
+        // Both requests are written before either response is awaited, so the
+        // server runs the two comparisons concurrently in one process — the
+        // interleaving that left console.log permanently dead under the old
+        // process-global suppression workaround (issue #809).
+        probe!.send({ jsonrpc: '2.0', id: 2, method: 'tools/call', params: callParams(outputA) });
+        probe!.send({ jsonrpc: '2.0', id: 3, method: 'tools/call', params: callParams(outputB) });
+        const [responseA, responseB] = await Promise.all([
+          probe!.waitForResponse(2, 90_000),
+          probe!.waitForResponse(3, 90_000),
+        ]);
+        resultA = parseToolResult(responseA);
+        resultB = parseToolResult(responseB);
+      });
+
+      await then('both comparisons succeed and every stdout line parses as JSON-RPC', async () => {
+        expect(resultA.success, JSON.stringify(resultA)).toBe(true);
+        expect(resultB.success, JSON.stringify(resultB)).toBe(true);
+        await fs.access(outputA);
+        await fs.access(outputB);
+
+        expect(probe!.rawStdoutLines.length).toBeGreaterThanOrEqual(3);
+        for (const line of probe!.rawStdoutLines) {
+          let parsed: JsonRpcMessage | undefined;
+          expect(() => {
+            parsed = JSON.parse(line) as JsonRpcMessage;
+          }, `non-JSON line on the stdio protocol stream: ${line}`).not.toThrow();
+          expect(parsed?.jsonrpc, `stdout line is JSON but not JSON-RPC: ${line}`).toBe('2.0');
+        }
+      });
+    },
+    120_000,
+  );
+});

--- a/packages/docx-mcp/src/tools/compare_documents.ts
+++ b/packages/docx-mcp/src/tools/compare_documents.ts
@@ -16,17 +16,6 @@ function expandPath(inputPath: string): string {
   return inputPath.startsWith('~') ? path.join(process.env.HOME || '', inputPath.slice(1)) : inputPath;
 }
 
-async function runWithoutConsoleLog<T>(fn: () => Promise<T>): Promise<T> {
-  if (process.env.SAFE_DOCX_ALLOW_COMPARISON_STDOUT === '1') return fn();
-  const originalLog = console.log;
-  console.log = () => {};
-  try {
-    return await fn();
-  } finally {
-    console.log = originalLog;
-  }
-}
-
 export async function compareDocuments_tool(
   manager: SessionManager,
   params: {
@@ -117,16 +106,18 @@ export async function compareDocuments_tool(
       }
     }
 
-    // Run comparison
-    const result = await runWithoutConsoleLog(() =>
-      compareDocuments(originalBuffer, revisedBuffer, {
-        author,
-        engine: compareEngine,
-        ignoreFormatting: params.ignore_formatting,
-        detectMoves: params.compare_moves,
-        reconstructionMode: DEFAULT_RECONSTRUCTION_MODE,
-      }),
-    );
+    // Run comparison. The comparison library writes nothing to stdout by default
+    // (issue #783 / PR #785 removed the last unconditional emit; remaining debug
+    // output is opt-in via DOCX_COMPARISON_DEBUG), so the stdio JSON-RPC stream
+    // stays clean without suppressing the process-global console.log — which was
+    // never concurrency-safe across an await (issue #809).
+    const result = await compareDocuments(originalBuffer, revisedBuffer, {
+      author,
+      engine: compareEngine,
+      ignoreFormatting: params.ignore_formatting,
+      detectMoves: params.compare_moves,
+      reconstructionMode: DEFAULT_RECONSTRUCTION_MODE,
+    });
 
     // Validate and write output
     const writePolicy = await enforceWritePathPolicy(savePath);


### PR DESCRIPTION
Closes #809

## What

- Remove `runWithoutConsoleLog` from `packages/docx-mcp/src/tools/compare_documents.ts` — the wrapper that swapped the process-global `console.log` for a no-op around each `compareDocuments` call — together with its `SAFE_DOCX_ALLOW_COMPARISON_STDOUT` escape hatch.
- Add `packages/docx-mcp/src/integration/stdio_protocol_cleanliness.test.ts`: an end-to-end regression test that spawns the real MCP server (`src/cli.ts serve`) over stdio, issues two overlapping `tools/call compare_documents` requests against a real legal document (`tests/test_documents/open-agreements/mutual-nda.docx` vs a minimally-revised copy), and asserts every line the server writes to stdout parses as JSON-RPC.

## Why

The wrapper existed to keep the unconditional `[DEBUG] atomizeTree:` stdout emit (issue #783) off the stdio JSON-RPC stream. PR #785 removed that emit at the source, so the suppression now protects nothing: on current main, the comparison library writes nothing to stdout by default (remaining debug output is opt-in via `DOCX_COMPARISON_DEBUG`; comparison-path warnings use `console.warn`/`console.error`, which go to stderr and are untouched by this PR).

Worse, the workaround was never concurrency-safe. It mutated process-global `console.log` across an `await`. With two overlapping calls, the second call captures the first call's no-op as its "original" and restores it last — leaving `console.log` permanently dead for the process. Reproduced with an executed probe (see #809):

```
["A-start","B-start","suppressed","A-end","after-A-real","B-end","final-not-real"]
console.log restored correctly: false
```

Overlap is reachable through the stdio server: the MCP SDK's `Protocol._onrequest` dispatches each incoming request handler without serialization, so a client that pipelines two `tools/call` requests runs both comparisons concurrently in one process.

## User-visible surface change

`SAFE_DOCX_ALLOW_COMPARISON_STDOUT` is removed. It appeared nowhere else in the repo — no docs, no tests, no packaging references (verified by repo-wide grep) — and its only effect was to bypass a suppression that no longer suppresses anything.

## Test evidence

- New test passes on this branch and was red-checked: temporarily injecting `console.log('[DEBUG] ...')` into the compare path makes it fail with `non-JSON line on the stdio protocol stream: [DEBUG] red-check: simulated stray stdout emit`; reverting the injection makes it pass.
- Repo-wide grep confirms no test asserted on `runWithoutConsoleLog` or the env var, so no test updates were needed beyond the new file.
