### PR TITLE
fix(docx-compare): pin the benchmark to rebuild and finish the #808 review follow-ups

### DIFF
--- a/packages/docx-compare/src/benchmark/runner.ts
+++ b/packages/docx-compare/src/benchmark/runner.ts
@@ -75,7 +75,17 @@ async function produceRedline(
   asposeCliPath?: string,
 ): Promise<Buffer> {
   if (engine === 'atomizer') {
-    const result = await compareDocuments(originalBuffer, revisedBuffer, { engine: 'atomizer', author });
+    // Pin the benchmark to rebuild explicitly: benchmark scores predate the
+    // shared inplace front-door default (#808), and historical comparability
+    // requires the reconstruction strategy to stay fixed rather than drift
+    // with the library default. Switching the benchmark to measure the
+    // shipped default is a deliberate decision — record requested/used mode
+    // and fallback reason in the artifacts when making it.
+    const result = await compareDocuments(originalBuffer, revisedBuffer, {
+      engine: 'atomizer',
+      author,
+      reconstructionMode: 'rebuild',
+    });
     return result.document;
   }
 

--- a/packages/docx-compare/src/compare-types.ts
+++ b/packages/docx-compare/src/compare-types.ts
@@ -784,7 +784,7 @@ export interface CompareResult {
   ancillaryFallbackDiagnostics?: AncillaryFallbackDiagnostics;
   /**
    * Safety-check failures observed on rebuild output — whether rebuild was
-   * requested explicitly (the default mode) or reached via inplace fallback.
+   * requested explicitly or reached via fallback from the inplace default.
    * Present only when at least one check failed.
    */
   rebuildSafetyDiagnostics?: ReconstructionRebuildSafetyDiagnostics;

--- a/packages/docx-mcp/src/tools/compare_documents.test.ts
+++ b/packages/docx-mcp/src/tools/compare_documents.test.ts
@@ -114,6 +114,12 @@ describe('compare_documents tool', () => {
         expect(result.engine_used).toBeDefined();
       });
 
+      await then('the handler requests and uses the shared inplace default (#808)', () => {
+        expect(result.reconstruction_mode_requested).toBe('inplace');
+        expect(result.reconstruction_mode_used).toBe('inplace');
+        expect(result.fallback_reason).toBeUndefined();
+      });
+
       await then('the requested author is forwarded to generated revisions', async () => {
         expect(await readDocumentXml(outputPath)).toContain('w:author="Tool Test Author"');
       });


### PR DESCRIPTION
Refs #808. Follow-up to #811, addressing the three verified findings from its Codex peer review (adjudication posted on #811):

1. **Benchmark strategy no longer drifts with the library default.** `packages/docx-compare/src/benchmark/runner.ts` was the one non-test caller omitting `reconstructionMode`, so #811 silently flipped the benchmark from rebuild to inplace. Benchmark scores exist for historical comparison (including against Aspose), so the runner now passes `reconstructionMode: 'rebuild'` explicitly, with a comment making any future switch to the shipped default a deliberate decision that must record requested/used mode and fallback reason in benchmark artifacts.
2. **Stale JSDoc.** `CompareResult.rebuildSafetyDiagnostics` still described rebuild as "the default mode"; reworded for the shared inplace default.
3. **The MCP handler is now pinned directly.** The `compare_documents` two-file tool test asserts `reconstruction_mode_requested === 'inplace'`, `reconstruction_mode_used === 'inplace'`, and no `fallback_reason` — previously the handler's default was pinned only transitively via constant parity.

Full pre-submit gate green locally (one unrelated LibreOffice headless PDF probe flaked under load and passes in isolation: `generation-package-structure.test.ts`, 6/6).