### PR TITLE
docs(changelog): record the inplace comparison default as a behavior change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+- Behavior change: comparison now defaults to `reconstructionMode: 'inplace'`
+  everywhere. Previously the `@usejunior/docx-compare` library and its
+  `docx-comparison` / `safe-docx-compare` binaries defaulted to `'rebuild'`
+  while the MCP `compare_documents` tool and the `safe-docx` CLI defaulted to
+  `'inplace'`, so the same pair of documents produced different output
+  depending on which entry point you used. Callers that omit
+  `reconstructionMode` now get in-place reconstruction, which preserves the
+  revised document's existing structure; it falls back to `'rebuild'`
+  automatically when round-trip safety checks fail. Pass
+  `reconstructionMode: 'rebuild'` explicitly to keep the old behavior.
+- The `docx-comparison` / `safe-docx-compare` CLI JSON output now reports
+  `mode` as the mode actually used, alongside `mode_requested` and
+  `fallback_reason`. It previously reported the requested mode as the mode
+  used, hiding silent in-place to rebuild fallbacks.
 - Migration note: DOCX comparison and redline generation moved from
   `@usejunior/docx-core` to `@usejunior/docx-compare`. Update comparison
   imports such as `compareDocuments` to use the new package name.


### PR DESCRIPTION
## Why

PR #811 (issue #808) unified the comparison reconstruction default on `inplace` across every front door — including the **published** `@usejunior/docx-compare` library API and its `docx-comparison` / `safe-docx-compare` binaries, which had defaulted to `rebuild`.

That is a silent behavior change for external consumers: any caller omitting `reconstructionMode` gets in-place reconstruction at their next upgrade from 0.19.1. #811 merged without a release note, so there was no way to learn this from the changelog.

The same PR also changed the CLI JSON output shape — `mode_requested` and `fallback_reason` added, and `mode` redefined to report the mode *actually used* rather than the one requested. Also undocumented.

## What this adds

Two entries under `## Unreleased` in `CHANGELOG.md`: the default flip (with the `reconstructionMode: 'rebuild'` escape hatch for consumers pinning old behavior), and the CLI output-shape change.

## Notes

Neither change is a regression — in-place preserves rsids, sectPr, fields and content controls that rebuild discards (#582), and falls back to rebuild automatically when safety checks fail. The point is disclosure, not reversal.

Docs-only; no code paths touched and nothing in `scripts/` or `site/` consumes `CHANGELOG.md`. Claims were verified against merged `main` (`compare-two.ts:170-172`, `comparison-defaults.ts`, `pipeline.ts:833`).

Ref: #808