### PR TITLE
docs(docx-comparison): propose side-tagged tree redline construction

### DIFF
--- a/openspec/changes/refactor-tagged-tree-redline-construction/design.md
+++ b/openspec/changes/refactor-tagged-tree-redline-construction/design.md
@@ -1,0 +1,239 @@
+## Context
+
+The comparison engine's core loop is a generate-and-test search: `pipeline.ts`
+runs the full comparison under up to four atomization configurations, checks
+each serialized candidate by accept/reject round-trip, and keeps the first
+survivor — falling back to `rebuild` if none survive.
+
+That shape follows from the intermediate representation. `atomizeTree` flattens
+OOXML into a flat `ComparisonUnitAtom[]`; LCS runs over the flat list;
+`documentReconstructor` rebuilds a tree from atoms. Tree well-formedness — what
+makes a redline valid, and what `accept`/`reject` depend on — is not preserved
+by that pipeline, so it can only be checked at the end, and recovery from a
+failed check means retrying with different knobs.
+
+Two prior findings frame this change:
+
+- `reclassify-cross-run-rescue-as-residual` measured passes 3-4 as never
+  selected and documented them as a residual (#469, follow-up #542).
+- The Lean spike carries `compareDocumentXml_output_text_roundtrip` as a named
+  residual axiom precisely because `compareDocumentXml` is not modeled
+  definitionally — the engine's behavior has to be assumed.
+
+Both are symptoms of the same thing: correctness is asserted about the output
+instead of guaranteed by the construction.
+
+## Goals / Non-Goals
+
+**Goals (this change, stage A)**
+- A representation in which `accept`/`reject` correctness is a property of the
+  construction rather than a test on serialized output.
+- A projection contract precise enough to be falsifiable.
+- Shadow-mode divergence evidence over the differential corpus.
+
+**Non-Goals (this change)**
+- Any behavior change. Nothing is deleted, nothing is flipped, no runtime check
+  is retired.
+- **Effective formatting.** The existing detector (`format-detection.ts:299`)
+  and fidelity oracle (`formattingFidelity.ts:290`) inspect *direct* `w:rPr` /
+  `w:pPr` only, not formatting resolved through the style chain or
+  `docDefaults`. The shadow gate therefore cannot establish correctness for
+  inherited toggles, and `PropertyDelta` is scoped to direct properties.
+  Resolved formatting stays a separately-tracked known-divergence class.
+- Removing the explicit `rebuild` output mode (successor D).
+- Discharging the Lean residual axiom (Tier 3).
+
+## Decisions
+
+### Decision: a side-tagged tree carrying both side representatives
+
+```
+type Side = 'both' | 'original' | 'revised'
+
+type TaggedNode =
+  | { tag: 'both'
+      original: Element            // the original-side node
+      revised:  Element            // the revised-side node (may differ)
+      propertyDelta?: PropertyDelta
+      children: TaggedNode[] }
+  | { tag: 'original'; node: Element; children: TaggedNode[] }   // deleted
+  | { tag: 'revised';  node: Element; children: TaggedNode[] }   // inserted
+```
+
+A `both` node holds **two** element references, not one. Two nodes can be
+*matched* without being *identical* — same text with different run properties,
+same paragraph with a different `pPr`, same run carrying different pre-existing
+revision provenance. A single-element `both` node cannot say which side's
+attributes each projection should emit, which is the flaw that forces
+formatting differences into delete+insert pairs today.
+
+`PropertyDelta` is **scoped**, because OOXML property changes are not one kind
+of thing:
+
+| Scope | Source | Serializes to |
+|---|---|---|
+| run | `w:rPr` | `w:rPrChange` |
+| paragraph mark | `w:pPr/w:rPr` | `w:rPrChange` on the mark |
+| paragraph | `w:pPr` | `w:pPrChange` |
+| table row / cell | `w:trPr` / `w:tcPr` | `w:trPrChange` / `w:tcPrChange` |
+| section | `w:sectPr` | `w:sectPrChange` |
+
+Each records a **direct OOXML property snapshot** of each side, not resolved
+effective formatting (see Non-Goals).
+
+**Alternatives considered**
+- *Keep flat atoms, type the reconstructor's output.* Rejected: the information
+  destroyed by flattening (containment, table topology, field boundaries) cannot
+  be typed back into existence — which is why `ContainerResolutionError` exists
+  as a pass-failure signal today.
+- *Single-element `both` with a side discriminator on each attribute.* Rejected:
+  pushes the same two-sidedness down to every attribute with no simplification.
+
+### Decision: the obligation is projection isomorphism, not coverage
+
+The first draft of this design stated two coverage obligations — "every input
+node appears exactly once, tagged `both` or its own side" — and claimed
+round-trip correctness followed. **That is false.** Peer review supplied the
+counterexample:
+
+> original children `[A, B]`, revised children `[B, A]`. An IR ordered
+> `[both(B), both(A)]` satisfies "each input node appears exactly once," yet
+> `project(_, 'original')` yields `[B, A]`, not `[A, B]`. Coverage holds;
+> round-trip fails.
+
+Membership and multiplicity say nothing about **order**, and OOXML text
+extraction is order-sensitive. The obligation is therefore stated as an
+isomorphism. For each side `s`, `project(tree, s)` must be isomorphic to input
+side `s`:
+
+- **P1 — bijection.** Every node of input side `s` corresponds to exactly one IR
+  occurrence tagged `both` or `s`, and vice versa.
+- **P2 — order.** Sibling order in the projection equals sibling order in the
+  input side.
+- **P3 — containment.** Parent/child relationships are preserved; a node's
+  projected parent is the projection of its IR parent.
+- **P4 — content.** Side-specific text, attributes, and properties are those of
+  side `s`'s representative — for a `both` node, its `original` or `revised`
+  element as appropriate.
+- **P5 — opaque payload.** Content the engine does not model (passthrough
+  subtrees) is reproduced byte-identically on the side it came from.
+
+P1-P5 are checkable on the IR in linear time without serializing.
+
+### Decision: separate the four correctness layers, and keep every runtime check
+
+P1-P5 establish **IR projection fidelity** only. Three further layers stand
+between that and a correct `.docx`, and conflating them was the first draft's
+second error:
+
+1. **IR projection fidelity** — P1-P5, established by construction.
+2. **Serializer correctness** — that emitting a `TaggedTree` as OOXML tracked
+   markup preserves the projections.
+3. **Accept/reject semantics** — that Word's and our own accept/reject agree
+   with `project`.
+4. **Package/story assembly** — headers, footers, notes, comments, text-box and
+   ancillary stories, relationship tables.
+
+Therefore the existing runtime checks for text, bookmarks, field structure, and
+ancillary stories **all stay**, unchanged, until each has its own construction
+invariant *and* executable evidence. This change retires none of them.
+
+### Decision: PRESERVE semantics need a construction invariant, not "payload"
+
+The first draft claimed pre-existing tracked changes could "ride as node
+payload, orthogonal to the tag." Peer review showed that is not what the engine
+does: `preSplitInsProvenanceRuns` (`inPlaceModifier-presplit.ts:175`) splits
+runs along provenance boundaries and reconstructs original insertion wrappers,
+and revision IDs are seeded across preserved roots (`inPlaceModifier.ts:96`).
+
+So PRESERVE needs explicit invariants, not transport:
+
+- **provenance splitting** — where a comparison-side boundary falls inside a
+  pre-existing `w:ins`/`w:del`, the IR must represent the split without losing
+  the original wrapper's author/date;
+- **nesting** — the legal nesting of a comparison revision inside a pre-existing
+  one, and which projection unwraps which;
+- **revision-ID allocation** — collision avoidance against IDs already present
+  in either input;
+- **accept/reject over multi-author stacks** — the reject-projection oracle
+  already covers this class and is the gate.
+
+These are proved on the multi-author corpus **first**, not last (task 2.5).
+
+### Decision: move ranges keep their existing certification
+
+The live requirement "Tracked move ranges are structurally certified"
+(`openspec/specs/docx-comparison/spec.md:324`) demands exactly one range per
+direction and name, balanced non-crossing markers, unique decimal IDs, and
+matching names. A subtree relation alone does not deliver marker balance,
+uniqueness, non-crossing, or name pairing.
+
+That requirement is **not modified**. The IR must satisfy it, and whether
+`coalesceMoveRangeMarkers` (`inPlaceModifier-postprocess.ts:397`) can be deleted
+is decided by evidence in stage B: if the IR guarantees one logical range per
+direction at construction, the pass goes with its cause in successor C;
+otherwise it is retained and reclassified alongside the readability passes.
+
+### Decision: nested stories compose over the IR
+
+Text-box and ancillary-part stories currently recurse into the whole pipeline
+(`pipeline.ts:609-680`) and re-validate the assembled result with another
+accept/reject round-trip. Under the IR a nested story is a subtree with its own
+tagged tree, and assembly is IR composition. This is designed for in stage A but
+only exercised in shadow; the recursive path is untouched until successor C.
+
+## Risks / Trade-offs
+
+- **This is the engine's core.** A wrong step ships bad redlines into legal
+  documents. → Stage A changes no behavior at all; the IR has no production
+  caller. Every subsequent stage is gated on corpus evidence.
+- **PRESERVE is the hardest case**, and the first draft underestimated it. →
+  Explicit invariants above; multi-author fixtures are proved before anything
+  else advances.
+- **Shadow equivalence may be equivalent-but-not-identical.** Coalescing
+  boundaries can legitimately differ. → The gate compares projections and
+  fidelity scores, not bytes; projection-inequivalent diffs block, and
+  projection-equivalent textual differences are reviewed individually and either
+  accepted with a recorded rationale or pinned.
+- **The shadow gate cannot see inherited formatting**, because neither the
+  detector nor the oracle resolves the style chain. → Declared a non-goal rather
+  than assumed away; effective-formatting divergence remains separately tracked.
+- **Two representations coexist during migration.** → Bounded: stage A is
+  additive, and the legacy path is deleted only in successor C.
+
+## Migration Plan
+
+**This change (A):** build `TaggedTree`, `project`, and the P1-P5 checks;
+property-test them in isolation; run the IR in shadow and produce a divergence
+report over the differential corpus. Nothing user-visible changes. Fully
+revertible.
+
+**Successor B:** flip the default, retaining the legacy path behind a flag and
+retaining all existing diagnostics and both explicit output modes.
+
+**Successor C:** after release evidence from B, delete the four-pass ladder, the
+automatic fallback, `suppressNoOpChangePairs`,
+`suppressDuplicatedFormatChangesInTextReplacements`, and — if stage B evidence
+supports it — `coalesceMoveRangeMarkers`. Closes #542.
+
+**Successor D (separate decision):** whether to deprecate the explicit `rebuild`
+output mode and the reconstruction-mode metadata at all. This is a public
+breaking change: the docx-compare CLI defaults to `rebuild`
+(`cli/compare-two.ts:49`) and `compare_documents` returns
+`reconstruction_mode_used` (`compare_documents.ts:149`). It may well be that
+`rebuild` simply survives as an explicit output shape and nothing is removed.
+
+Rollback: A is additive. B is a flag flip. Only C is irreversible, and it is
+gated on a green B release.
+
+## Open Questions
+
+- Does the IR guarantee one logical move range per direction at construction, or
+  is `coalesceMoveRangeMarkers` load-bearing? Decided by stage B evidence.
+- Should P1-P5 checks run in production builds or only under test? Linear-time
+  argues for always-on; profiling on the largest corpus documents decides.
+- Can `opaquePassthrough`'s counterpart binding be expressed as P5 payload, or
+  does it need to stay a separate pre-pass?
+- Does `rebuild`'s different base-archive selection (`pipeline.ts:1239`) mean
+  the IR needs two serializers, or one serializer parameterized by which side
+  supplies the package skeleton?

--- a/openspec/changes/refactor-tagged-tree-redline-construction/proposal.md
+++ b/openspec/changes/refactor-tagged-tree-redline-construction/proposal.md
@@ -1,0 +1,153 @@
+# Change: Add a side-tagged tree IR for redline construction, proved in shadow
+
+Tracking issue: #814. Related: #542 (cross-run passes as candidate dead code), #469.
+
+## Why
+
+`compareDocumentsAtomizerCore` does not construct a redline — it searches for
+one. `packages/docx-compare/src/baselines/atomizer/pipeline.ts:1128-1231`
+defines four atomization configurations, runs the **entire comparison** under
+each, and after each candidate calls `evaluateRoundTripSafety`, which
+accept-alls and reject-alls the serialized output and compares it against the
+two inputs. The first candidate that passes wins; if all four fail, the result
+is discarded and a structurally different reconstruction (`rebuild`) runs as a
+hard fallback.
+
+Two consequences are not defensible on their own terms:
+
+1. **The correctness oracle is load-bearing control flow.**
+   `accept(output) ≡ revised ∧ reject(output) ≡ original` is the *definition* of
+   a correct redline. It is currently a runtime filter used to select among
+   guesses, so the engine is correct only to the extent that the checker is
+   complete. Every gap in the checker is a silently-shipped wrong redline, and
+   every failure is a silent downgrade to lower-fidelity output.
+
+2. **The emitter needs a cleanup crew behind it.**
+   `inPlaceModifier.ts:126-145` runs `suppressNoOpChangePairs` over the tree it
+   just built, to find and delete `<w:del>x</w:del><w:ins>x</w:ins>` pairs —
+   content marked as deleted and re-inserted, identically. Its own docstring
+   (`inPlaceModifier-postprocess.ts:163-166`) calls these "false-positive
+   changes". Nothing should emit them.
+   `suppressDuplicatedFormatChangesInTextReplacements` (#724) then compensates
+   for a defect introduced by the coalescing passes themselves.
+
+The root cause is representational. `atomizeTree` flattens OOXML into a flat
+`ComparisonUnitAtom[]`, LCS runs over the flat list, and
+`documentReconstructor.ts` (2330 lines) reconstitutes a tree from it. The tree
+invariants that make output valid are destroyed by the flattening and have to be
+recovered afterwards — which is precisely why they can only be *checked*
+afterwards.
+
+## What Changes
+
+This change is **stage A only**: it adds the representation and proves it in
+shadow. It deletes nothing and changes no user-visible behavior. Deletion of the
+pass ladder and any public-surface decisions are successor changes, named below.
+
+- **Add a side-tagged tree IR (`TaggedTree`).** Every node carries a tag of
+  `both`, `original`, or `revised`. A `both` node holds **both side
+  representatives** (original and revised), not a single element, plus an
+  optional scoped `PropertyDelta` for formatting-only differences. Move pairs
+  are a relation between an `original` and a `revised` subtree.
+
+- **Specify projections as a projection-isomorphism contract, not a coverage
+  count.** `project(tree, side)` is a total fold, and the aligner's obligation
+  is that each projection is *isomorphic* to its input side — preserving
+  document and sibling order, parent/child containment, side-specific text,
+  attributes and properties, with a bijection from every input-side node to
+  exactly one IR occurrence. Membership-and-multiplicity alone is provably
+  insufficient (see `design.md` for the rejected counterexample).
+
+- **Run the IR in shadow.** The existing pipeline stays authoritative. The IR
+  path runs beside it behind `SAFE_DOCX_TAGGED_TREE=shadow` and records
+  divergence over the differential corpus. No production caller switches.
+
+- **Keep every runtime check.** Text, bookmark, field-structure, and ancillary
+  story checks all remain exactly as they are. This change adds a construction
+  invariant; it does not yet cash it in against any existing safety net.
+
+**Explicitly deferred to successor changes** (so this one stays reviewable):
+
+- **B — default flip.** Make the IR path default while retaining the legacy path
+  and all existing diagnostics.
+- **C — remove the retry ladder and automatic fallback**, and delete
+  `suppressNoOpChangePairs` /
+  `suppressDuplicatedFormatChangesInTextReplacements` with their cause. Gated on
+  release evidence from B. Closes #542.
+- **D — public-surface decisions.** Whether explicit `rebuild` output mode and
+  the reconstruction-mode metadata are deprecated at all. See the correction
+  below; this is a public breaking change and needs its own justification.
+
+## Corrections carried from peer review
+
+Three claims in the first draft of this proposal were wrong and are recorded
+here rather than quietly dropped:
+
+- **`rebuild` is a first-class requested output mode, not only a fallback.**
+  `CompareOptions.reconstructionMode` exposes it (`compare-types.ts:20`), the
+  docx-compare CLI **defaults** to it (`cli/compare-two.ts:49`), and rebuild vs.
+  inplace select different base archives (`pipeline.ts:1239`). "Collapse to a
+  single path" is therefore wrong; the correct target is *one construction
+  algorithm per requested output shape*. Removing the mode is a separate public
+  breaking change (successor D), not a side effect of this refactor.
+
+- **`fail_on_rebuild_fallback` needs no migration.** It exists only on `save`,
+  where it is already deprecated and ignored (#126,
+  `tool_catalog.ts:257-262`). The first draft invented migration work for it.
+  The real consumers of reconstruction metadata are
+  `CompareOptions.reconstructionMode`, the two CLIs' `--mode`, and
+  `compare_documents`' `reconstruction_mode_used` response field
+  (`compare_documents.ts:149`).
+
+- **Cross-run pass unreachability is empirical, not proven.** The prior change
+  established that no cross-run selection was observed across ~3,900 synthetic
+  fragmentation cases and 508 tests. That is not a proof: the safety oracle
+  checks accept/reject **bookmarks** and **field structure** as well as text
+  (`pipeline.ts:1104`), and the "text-safe by construction" argument covers only
+  the text dimension. Stated as a measured result, not a theorem.
+
+## Impact
+
+- Affected specs: `docx-comparison` — ADDED only (tagged-tree IR, projection
+  isomorphism, shadow-differential gate). **No REMOVED delta in this change**:
+  the ladder requirement stays until successor C actually deletes the code, so
+  the spec never describes a state the engine is not in.
+
+- Affected code (additive; all in `packages/docx-compare/src/`):
+  new `baselines/atomizer/taggedTree.ts`, plus shadow-mode wiring in
+  `baselines/atomizer/pipeline.ts`. `hierarchicalLcs.ts` / `atomLcs.ts` gain a
+  tag-emitting output path alongside their existing one.
+
+- Post-processing inventory (fates decided here, executed in successor C):
+
+  | Pass | Compensates for | Fate |
+  |---|---|---|
+  | `suppressNoOpChangePairs` | our emitter producing del+ins of equal content | delete with cause — **gated on field cases** |
+  | `suppressDuplicatedFormatChangesInTextReplacements` (#724) | a defect from the coalescing passes | delete with cause |
+  | `coalesceMoveRangeMarkers` | fragmented source atoms emitting duplicate range markers | delete with cause **only if** the IR guarantees one logical range per direction; otherwise retain |
+  | `mergeAdjacentTrackChangeSiblings` | redline readability | retain, reclassified |
+  | `coalesceDelInsPairChains` | redline readability | retain, reclassified |
+  | `mergeWhitespaceBridgedTrackChanges` | redline readability | retain, reclassified |
+
+  The test applied is: *does this layer exist because Word/OOXML is messy, or
+  because our own earlier stage emits garbage?* Only the second kind is
+  removable. `auxiliaryIdCollision`, `opaquePassthrough`,
+  `consumerCompatibility`, `formattingFidelity`, and `leanXmlVerifier` are the
+  first kind and are untouched.
+
+- Non-goal: **effective** (style-chain / `docDefaults`-resolved) formatting.
+  The current detector (`format-detection.ts:299`) and fidelity oracle
+  (`formattingFidelity.ts:290`) both compare *direct* `w:rPr` / `w:pPr` only, so
+  the shadow gate cannot establish correctness for inherited toggles. This
+  change scopes `PropertyDelta` to direct properties and records resolved
+  formatting as out of scope; it is already tracked separately as a
+  known-divergence class.
+
+- Spec drift observed, not fixed here: several `docx-comparison` requirements
+  cite `packages/docx-core/src/baselines/atomizer/…` paths that moved to
+  `packages/docx-compare/` in #549/#550, and the tests mapped to those scenarios
+  still live in `packages/docx-core/`. Left for a docs-only pass.
+
+- Safety net: the LibreOffice/Word differential oracles, pinned engine-bug
+  characterization cases, and the fidelity corpus are what make this attemptable
+  at all. The shadow gate runs against them, not unit tests alone.

--- a/openspec/changes/refactor-tagged-tree-redline-construction/specs/docx-comparison/spec.md
+++ b/openspec/changes/refactor-tagged-tree-redline-construction/specs/docx-comparison/spec.md
@@ -1,0 +1,159 @@
+## ADDED Requirements
+
+### Requirement: Side-tagged comparison tree carries both side representatives
+
+The comparison engine SHALL provide a side-tagged tree representation of a
+compared document pair in which every node carries a tag of `both`, `original`,
+or `revised`.
+
+A `both`-tagged node SHALL hold **two** element representatives — one for the
+original side and one for the revised side — because two nodes may be matched
+without being identical. It MAY additionally carry a scoped property delta
+recording a formatting difference between those representatives.
+
+A property delta SHALL be scoped to the OOXML property level it describes — run
+(`w:rPr`), paragraph mark (`w:pPr/w:rPr`), paragraph (`w:pPr`), table row or
+cell (`w:trPr` / `w:tcPr`), or section (`w:sectPr`) — and SHALL record a direct
+property snapshot of each side. It SHALL NOT record formatting resolved through
+the style chain or `docDefaults`; effective-formatting fidelity is out of scope
+for this representation.
+
+Content that is textually identical on both sides SHALL be tagged `both` and
+SHALL NOT be represented as a deletion paired with an insertion.
+
+#### Scenario: Matched-but-differing nodes retain both representatives
+
+- **GIVEN** a run whose text is identical on both sides but whose direct run properties differ
+- **WHEN** the pair is aligned into the tagged tree
+- **THEN** the node SHALL be tagged `both` with distinct original and revised representatives
+- **AND** it SHALL carry a run-scoped property delta holding each side's direct `w:rPr` snapshot
+
+#### Scenario: Property delta scope matches the property level
+
+- **GIVEN** a paragraph whose `w:pPr` differs between sides while its runs are unchanged
+- **WHEN** the pair is aligned
+- **THEN** the delta SHALL be recorded at paragraph scope, not run scope
+
+#### Scenario: Equal content is tagged both
+
+- **GIVEN** an original and revised document containing an identical run of text
+- **WHEN** the pair is aligned
+- **THEN** the corresponding node SHALL be tagged `both`
+- **AND** no delete/insert representation of that content SHALL be produced
+
+### Requirement: Each projection is isomorphic to its input side
+
+The engine SHALL define `project(tree, side)` as a total fold retaining nodes
+tagged `both` or `side`, and the aligner SHALL satisfy a projection-isomorphism
+contract for each side `s`:
+
+- **P1 bijection**: every node of input side `s` corresponds to exactly one tree
+  occurrence tagged `both` or `s`, and every such occurrence corresponds to
+  exactly one node of input side `s`;
+- **P2 order**: sibling order in `project(tree, s)` equals sibling order in
+  input side `s`;
+- **P3 containment**: parent/child relationships are preserved, so a projected
+  node's parent is the projection of its tree parent;
+- **P4 content**: side-specific text, attributes, and properties are those of
+  side `s`'s representative;
+- **P5 opaque payload**: subtrees the engine does not model are reproduced
+  byte-identically on the side they came from.
+
+Coverage and multiplicity alone SHALL NOT be treated as sufficient. An
+obligation stating only that each input node appears exactly once admits
+`original = [A, B]`, `revised = [B, A]`, tree `[both(B), both(A)]`, whose
+original projection is `[B, A]` rather than `[A, B]`; P2 is what excludes it.
+
+P1-P5 SHALL be checkable against the tree without serializing it.
+
+The contract SHALL be scoped to **IR projection fidelity**. It SHALL NOT be
+represented as establishing serializer correctness, accept/reject semantics, or
+package and story assembly correctness, each of which is a separate layer with
+its own evidence.
+
+#### Scenario: Projections reproduce their input sides
+
+- **GIVEN** any aligned pair
+- **WHEN** `project(tree, 'original')` and `project(tree, 'revised')` are evaluated
+- **THEN** each SHALL be isomorphic to its input side under P1-P5
+
+#### Scenario: Reordering that satisfies coverage is rejected
+
+- **GIVEN** an original side ordered `[A, B]` and a revised side ordered `[B, A]`
+- **WHEN** a candidate tree orders them `[both(B), both(A)]`
+- **THEN** the contract SHALL reject the candidate for violating P2
+- **AND** the violation SHALL be reported without requiring serialization
+
+#### Scenario: Contract violations name the offending node
+
+- **WHEN** the P1-P5 checks run against a constructed tree
+- **THEN** a violation SHALL raise a distinguishable error naming the failing
+  obligation and the offending node
+- **AND** the failure SHALL NOT be repaired by a downstream pass
+
+### Requirement: Pre-existing tracked changes are represented by construction invariants
+
+The tagged tree SHALL represent tracked-change markup already present in either
+input (`w:ins` / `w:del` from prior authors) under explicit invariants rather
+than as opaque transported payload, because the engine splits runs along
+provenance boundaries and seeds revision identifiers across preserved roots.
+
+The representation SHALL specify:
+
+- **provenance splitting**: where a comparison-side boundary falls inside a
+  pre-existing revision, the split SHALL preserve that revision's author and
+  date on every resulting fragment;
+- **nesting**: which projection unwraps a comparison revision nested inside a
+  pre-existing one;
+- **revision-identifier allocation**: identifiers SHALL NOT collide with any
+  already present in either input;
+- **multi-author resolution**: accept and reject over stacked revisions from
+  several authors SHALL agree with the reject-projection oracle.
+
+These invariants SHALL be evidenced on the multi-author corpus before the
+representation is exercised on any other class of input.
+
+#### Scenario: Provenance survives a boundary split
+
+- **GIVEN** an original document carrying `w:ins` markup from a prior author
+- **AND** a comparison-side boundary falling inside that insertion
+- **WHEN** the pair is aligned
+- **THEN** every resulting fragment SHALL retain the prior author's attribution and date
+
+#### Scenario: Allocated revision identifiers avoid input collisions
+
+- **GIVEN** inputs that already contain revision identifiers
+- **WHEN** the tree allocates identifiers for the comparison's own revisions
+- **THEN** no allocated identifier SHALL equal one present in either input
+
+### Requirement: The tagged-tree path runs in shadow and changes no behavior
+
+The tagged-tree representation SHALL run beside the existing pipeline behind an
+opt-in shadow mode, and SHALL NOT supply the output of any comparison while this
+requirement is in force. Existing runtime safety checks — text, bookmark, field
+structure, and ancillary story — SHALL remain in place unchanged.
+
+Shadow mode SHALL record divergence between the two constructions across the
+formatting-fidelity corpus, the multi-author fixtures, the OpenAgreements and
+NVCA/ILPA templates, and the pinned engine-bug characterization cases.
+
+Divergence SHALL be assessed on projections and fidelity scores rather than
+output bytes. A divergence that is not projection-equivalent SHALL be reported
+as blocking. A divergence that is projection-equivalent but textually different
+SHALL be recorded for individual review and either accepted with a rationale or
+pinned as a characterization case.
+
+#### Scenario: Shadow mode does not affect returned output
+
+- **GIVEN** shadow mode enabled
+- **WHEN** a document pair is compared
+- **THEN** the returned output SHALL be the existing pipeline's output, unchanged
+- **AND** every existing runtime safety check SHALL still run
+
+#### Scenario: Divergence is recorded with fixture identity
+
+- **GIVEN** a corpus run in shadow mode
+- **WHEN** the two constructions differ
+- **THEN** the report SHALL name the fixture and the diverging projection
+- **AND** SHALL classify the divergence as projection-inequivalent (blocking) or
+  projection-equivalent (for review)

--- a/openspec/changes/refactor-tagged-tree-redline-construction/tasks.md
+++ b/openspec/changes/refactor-tagged-tree-redline-construction/tasks.md
@@ -1,0 +1,99 @@
+Scope: **stage A only** — additive representation, invariants, and shadow
+evidence. Nothing is deleted and no default changes. Successors B/C/D are named
+in `proposal.md` and are separate changes.
+
+## 1. Representation and projections (no production caller)
+
+- [ ] 1.1 Add `TaggedNode` / `TaggedTree` to
+      `packages/docx-compare/src/baselines/atomizer/taggedTree.ts`, with `both`
+      carrying **both** side representatives plus an optional scoped
+      `PropertyDelta`.
+- [ ] 1.2 Define `PropertyDelta` by scope (run, paragraph mark, paragraph, row,
+      cell, section), recording direct OOXML snapshots per side. Do not resolve
+      through the style chain or `docDefaults` — out of scope.
+- [ ] 1.3 Implement `project(tree, side)` as a total fold.
+- [ ] 1.4 Implement the P1-P5 isomorphism checks against an
+      (original, revised, tree) triple, without serialization.
+- [ ] 1.5 Property-test P1-P5, including the rejected-counterexample case:
+      original `[A,B]`, revised `[B,A]`, tree `[both(B),both(A)]` must fail P2.
+- [ ] 1.6 Add the `TEST_FEATURE` constant and single-line `.openspec(...)` tags
+      for the new scenarios in a dedicated test file (one feature per file), and
+      regenerate the traceability matrix — never hand-edit it.
+
+## 2. Aligner emits tags
+
+- [ ] 2.1 Add a tag-emitting output path to `hierarchicalLcs` paragraph matching
+      alongside the existing correlation-status path; matching behavior
+      unchanged.
+- [ ] 2.2 Add a tag-emitting path to within-paragraph `atomLcs`, with
+      word-vs-run granularity as an alignment parameter.
+- [ ] 2.3 Represent direct formatting differences as `both` + scoped
+      `PropertyDelta`; assert no construction path emits a del/ins pair over
+      equal content.
+- [ ] 2.4 Model move pairs as a relation between an `original` and a `revised`
+      subtree, and verify the tree satisfies the live "Tracked move ranges are
+      structurally certified" requirement — one range per direction and name,
+      balanced non-crossing markers, unique decimal IDs. Record whether the tree
+      guarantees this at construction (input to the `coalesceMoveRangeMarkers`
+      decision in successor C).
+- [ ] 2.5 Implement the PRESERVE invariants — provenance splitting, nesting,
+      revision-ID allocation, multi-author resolution — and evidence them on the
+      multi-author corpus **before** proceeding to task 3. This is the
+      highest-risk surface; `preSplitInsProvenanceRuns`
+      (`inPlaceModifier-presplit.ts:175`) and the ID seeding at
+      `inPlaceModifier.ts:96` are the behavior to match.
+
+## 3. Serializer and story composition (shadow-only)
+
+- [ ] 3.1 Implement a serializer from `TaggedTree` to OOXML tracked markup,
+      exercised only in shadow.
+- [ ] 3.2 Property-test that serialization preserves both projections (layer 2
+      of the four correctness layers in `design.md`).
+- [ ] 3.3 Design nested text-box / ancillary story composition as IR subtrees;
+      verify projections compose. Do not touch the recursive pipeline path.
+- [ ] 3.4 Determine whether `rebuild`'s different base-archive selection
+      (`pipeline.ts:1239`) needs a second serializer or one parameterized by
+      which side supplies the package skeleton.
+
+## 4. Shadow mode and evidence
+
+- [ ] 4.1 Run the tree construction beside the existing pipeline behind
+      `SAFE_DOCX_TAGGED_TREE=shadow`; existing pipeline stays authoritative and
+      every existing runtime check keeps running.
+- [ ] 4.2 Emit a divergence report keyed by fixture identity and diverging
+      projection, classified projection-inequivalent (blocking) vs.
+      projection-equivalent (for review). Compare projections and fidelity
+      scores, not bytes.
+- [ ] 4.3 Run over the fidelity corpus, multi-author fixtures, OpenAgreements +
+      NVCA/ILPA templates, and pinned characterization cases.
+- [ ] 4.4 Triage every divergence: fix inline if it is an aligner or oracle
+      defect; pin and file it if it is a genuine pre-existing engine bug; record
+      a rationale for any accepted projection-equivalent difference. One fix per
+      PR.
+- [ ] 4.5 Produce the field-case evidence that successor C's deletion of
+      `suppressNoOpChangePairs` depends on: field-stable, field-modification,
+      field-delete, nested-field, and paragraph-spanning-field cases showing no
+      equal del/ins pairs are emitted and field structure survives both
+      projections. Deletion is not justified by `both`-tagging alone — field
+      fragmentation is an inherent conforming-emission constraint.
+- [ ] 4.6 Cross-reader verification on any corpus document whose shadow output
+      is proposed as equivalent (Word fidelity check, plus Pages / Google Docs
+      paths).
+
+## 5. Validation
+
+- [ ] 5.1 `openspec validate refactor-tagged-tree-redline-construction --strict`.
+- [ ] 5.2 Full gate run with explicit exit-code checks (never piped to `tail`):
+      `npm run build`, `npm run test`, `npm run check:spec-coverage`.
+- [ ] 5.3 Coverage in the correct order — `npm run test:coverage:packages`
+      **first** (it generates the summaries), then
+      `npm run coverage:packages:check`. The check alone fails with "Missing
+      coverage summary".
+- [ ] 5.4 Confirm the new scenarios are mapped before archival. Note that
+      `check:spec-coverage` validates the canonical live spec, so a green
+      pre-archive run does not by itself cover this change's ADDED scenarios.
+- [ ] 5.5 Record the successor changes (B default flip, C deletion, D public
+      rebuild-mode decision) as issues so the staging is durable, and record the
+      follow-up to narrow the Lean residual axiom
+      `compareDocumentXml_output_text_roundtrip` once the projection half is
+      definitional.


### PR DESCRIPTION
## Why

The atomizer does not construct a redline — it searches for one. `pipeline.ts:1128-1231` runs the full comparison under four atomization configurations, accept/rejects each serialized candidate against the two inputs, and keeps the first survivor; if none pass, it discards the result and falls back to `rebuild`.

That makes the correctness oracle load-bearing control flow. `accept(output) ≡ revised ∧ reject(output) ≡ original` is the *definition* of a correct redline — using it to select among guesses means the engine is correct only as far as the checker is complete, so every gap in the checker is a silently-shipped wrong redline and every failure is a silent fidelity downgrade. It also forces a cleanup crew behind the emitter: `suppressNoOpChangePairs` exists to delete `<w:del>x</w:del><w:ins>x</w:ins>` pairs that nothing should have emitted.

Root cause is representational: flattening OOXML to a flat atom list destroys the tree invariants that make output valid, so they can only be recovered — and therefore only checked — after the fact.

## What this PR contains

Documentation only. One OpenSpec change proposal, no code.

The proposal introduces a side-tagged tree where every node is tagged `both` / `original` / `revised`, a `both` node carries **both** side representatives plus a scoped property delta, and each projection must be *isomorphic* to its input side (bijection, sibling order, containment, side-specific content, opaque payload). Round-trip correctness then follows from the construction rather than from inspection.

**Scoped to stage A**: additive representation, isomorphism checks, and shadow-mode divergence evidence over the differential corpus. No behavior change, no deletions, every existing runtime check stays. The retry-ladder deletion (B/C) and the public `rebuild`-mode decision (D) are separate successor changes — nothing irreversible ships in the same change that introduces its own replacement.

## Peer review

Codex reviewed the first draft dynamically (it ran `openspec validate`, `check:spec-coverage`, targeted vitest suites, and `coverage:packages:check`) and overturned three assumptions. All corrected here, and recorded in the proposal rather than quietly dropped:

- **The coverage obligation was order-blind.** "Every input node appears exactly once" admits original `[A,B]`, revised `[B,A]`, tree `[both(B),both(A)]` — coverage holds, `project(original)` yields `[B,A]`. Replaced with a five-part isomorphism contract; the counterexample is now a required test case.
- **`rebuild` is a requested public output mode, not only a fallback.** Exposed on `CompareOptions.reconstructionMode`, the docx-compare CLI *defaults* to it (`cli/compare-two.ts:49`), and it selects a different base archive (`pipeline.ts:1239`). Removing it is a public breaking change → successor D.
- **`fail_on_rebuild_fallback` needed no migration** — it exists only on `save`, already deprecated and ignored (#126).

Also corrected: a `both` node needs two element representatives; cross-run unreachability is empirical rather than proven (the safety oracle checks bookmarks and field structure, not only text); PRESERVE needs construction invariants rather than payload transport (`preSplitInsProvenanceRuns` splits runs along provenance boundaries); and `coalesceMoveRangeMarkers` was missing from the post-processing inventory.

## Validation

- `openspec validate refactor-tagged-tree-redline-construction --strict` — valid
- `npm run check:spec-coverage` — 95/95 docx-comparison scenarios mapped (unchanged; this change adds no REMOVED delta)

## Note for review

Merging this is the approval gate — per `openspec/AGENTS.md`, implementation does not start until the proposal is approved. The substantive question is whether the staging (A → B → C → D) is the right split, and whether the isomorphism contract is now strong enough.

Refs #814