### PR TITLE
feat(docx-comparison): side-tagged comparison tree and projection contract

### DIFF
--- a/openspec/changes/refactor-tagged-tree-redline-construction/proposal.md
+++ b/openspec/changes/refactor-tagged-tree-redline-construction/proposal.md
@@ -84,12 +84,22 @@ Three claims in the first draft of this proposal were wrong and are recorded
 here rather than quietly dropped:
 
 - **`rebuild` is a first-class requested output mode, not only a fallback.**
-  `CompareOptions.reconstructionMode` exposes it (`compare-types.ts:20`), the
-  docx-compare CLI **defaults** to it (`cli/compare-two.ts:49`), and rebuild vs.
-  inplace select different base archives (`pipeline.ts:1239`). "Collapse to a
-  single path" is therefore wrong; the correct target is *one construction
-  algorithm per requested output shape*. Removing the mode is a separate public
-  breaking change (successor D), not a side effect of this refactor.
+  `CompareOptions.reconstructionMode` exposes it, both CLIs accept
+  `--mode rebuild`, and rebuild vs. inplace select different base archives
+  (`pipeline.ts:1239`). "Collapse to a single path" is therefore wrong; the
+  correct target is *one construction algorithm per requested output shape*.
+  Removing the mode is a separate public breaking change (successor D), not a
+  side effect of this refactor.
+
+  *Amended after merge:* this bullet originally said the docx-compare CLI
+  **defaults** to `rebuild`. That was true of the branch it was verified
+  against, but #811 (issue #808) had already unified every front door on
+  `inplace`, and #816 recorded that as a behavior change. The default clause is
+  withdrawn; the substantive point — `rebuild` is a requested output shape, not
+  merely a fallback — is unaffected, and successor D still owns any removal.
+  Note that `CompareOptions.reconstructionMode`'s own doc comment
+  (`compare-types.ts:25`) still advertises `Default: 'rebuild'` and is now
+  wrong on a published API surface; tracked separately, not fixed here.
 
 - **`fail_on_rebuild_fallback` needs no migration.** It exists only on `save`,
   where it is already deprecated and ignored (#126,

--- a/openspec/changes/refactor-tagged-tree-redline-construction/specs/docx-comparison/spec.md
+++ b/openspec/changes/refactor-tagged-tree-redline-construction/specs/docx-comparison/spec.md
@@ -49,15 +49,28 @@ contract for each side `s`:
 
 - **P1 bijection**: every node of input side `s` corresponds to exactly one tree
   occurrence tagged `both` or `s`, and every such occurrence corresponds to
-  exactly one node of input side `s`;
+  exactly one node of input side `s`. An explicitly opaque subtree counts as a
+  single atomic input unit and its descendants are not separately accounted;
 - **P2 order**: sibling order in `project(tree, s)` equals sibling order in
   input side `s`;
 - **P3 containment**: parent/child relationships are preserved, so a projected
   node's parent is the projection of its tree parent;
-- **P4 content**: side-specific text, attributes, and properties are those of
-  side `s`'s representative;
-- **P5 opaque payload**: subtrees the engine does not model are reproduced
-  byte-identically on the side they came from.
+- **P4 content**: side-specific namespace, name, attributes and text are those
+  of side `s`'s representative. Element identity SHALL be namespace URI plus
+  local name, never the lexical qualified name, because prefixes are aliasable;
+- **P5 opaque payload**: a subtree the engine explicitly declines to model is
+  carried through equivalent to the input subtree it stands for.
+
+A subtree the engine does not model SHALL be marked opaque **explicitly**. The
+absence of modeled children SHALL NOT be interpreted as a declaration of
+opacity, because that is also what an incomplete construction looks like: a
+representation that cannot distinguish "not modeled deliberately" from "not
+modeled by mistake" certifies the second as the first.
+
+P5 equivalence is **canonical, not byte-level**: attribute order is normalized,
+adjacent text nodes are concatenated, CDATA and text are treated alike, and
+comments and processing instructions do not participate. Content depending on
+those distinctions SHALL NOT be modeled as opaque payload.
 
 Coverage and multiplicity alone SHALL NOT be treated as sufficient. An
 obligation stating only that each input node appears exactly once admits
@@ -76,6 +89,13 @@ its own evidence.
 - **GIVEN** any aligned pair
 - **WHEN** `project(tree, 'original')` and `project(tree, 'revised')` are evaluated
 - **THEN** each SHALL be isomorphic to its input side under P1-P5
+
+#### Scenario: An unmodeled subtree must declare itself opaque
+
+- **GIVEN** a tree node whose input element has child elements
+- **WHEN** the node carries no modeled children and is not marked opaque
+- **THEN** the contract SHALL report a P1 violation naming the unaccounted children
+- **AND** the same shape marked opaque SHALL verify clean
 
 #### Scenario: Reordering that satisfies coverage is rejected
 

--- a/packages/docx-compare/src/baselines/atomizer/taggedTree.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/taggedTree.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
+import { el } from '../../testing/dom-test-helpers.js';
+import {
+  assertTaggedTree,
+  project,
+  ProjectionContractError,
+  verifyTaggedTree,
+  type BothNode,
+  type PropertyDelta,
+  type ProjectionViolation,
+  type TaggedNode,
+} from './taggedTree.js';
+
+const TEST_FEATURE = 'refactor-tagged-tree-redline-construction';
+const test = testAllure.epic('Document Comparison').withLabels({ feature: TEST_FEATURE });
+
+/** A `w:p` holding a single run of `text`, optionally with run properties. */
+function para(text: string, runProps?: Element[]): Element {
+  const runChildren: Element[] = [];
+  if (runProps) runChildren.push(el('w:rPr', {}, runProps));
+  runChildren.push(el('w:t', {}, undefined, text));
+  return el('w:p', {}, [el('w:r', {}, runChildren)]);
+}
+
+function body(children: Element[]): Element {
+  return el('w:body', {}, children);
+}
+
+function elementChildren(element: Element): Element[] {
+  return Array.from(element.childNodes).filter((n): n is Element => n.nodeType === 1);
+}
+
+/** Tag a pair of structurally parallel elements as `both`, recursively. */
+function bothTree(original: Element, revised: Element): BothNode {
+  const originalChildren = elementChildren(original);
+  const revisedChildren = elementChildren(revised);
+  return {
+    tag: 'both',
+    original,
+    revised,
+    children: originalChildren.map((child, i) => bothTree(child, revisedChildren[i]!)),
+  };
+}
+
+describe('side-tagged comparison tree', () => {
+  test.openspec('Matched-but-differing nodes retain both representatives')(
+    'a both node carries each side own representative and a scoped delta',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      const originalRun = el('w:r', {}, [el('w:t', {}, undefined, 'Confidential')]);
+      const revisedRun = el('w:r', {}, [
+        el('w:rPr', {}, [el('w:b', {})]),
+        el('w:t', {}, undefined, 'Confidential'),
+      ]);
+      let node!: BothNode;
+
+      await given('the same text matched across a run-property difference', () => {
+        expect(originalRun.textContent).toBe(revisedRun.textContent);
+      });
+
+      await when('the pair is tagged as one node with two representatives', () => {
+        const delta: PropertyDelta = {
+          scope: 'run',
+          original: null,
+          revised: el('w:rPr', {}, [el('w:b', {})]),
+          changedProperties: ['bold'],
+        };
+        node = {
+          tag: 'both',
+          original: originalRun,
+          revised: revisedRun,
+          propertyDelta: delta,
+          children: [],
+        };
+      });
+
+      await then('each projection takes that side own element', () => {
+        expect(project(node, 'original')?.element).toBe(originalRun);
+        expect(project(node, 'revised')?.element).toBe(revisedRun);
+      });
+
+      await and('the difference is carried as a run-scoped delta', () => {
+        expect(node.propertyDelta?.scope).toBe('run');
+        expect(node.propertyDelta?.original).toBeNull();
+        expect(node.propertyDelta?.revised?.tagName).toBe('w:rPr');
+      });
+    },
+  );
+
+  test.openspec('Property delta scope matches the property level')(
+    'a paragraph-property difference is recorded at paragraph scope',
+    async ({ given, when, then }: AllureBddContext) => {
+      let delta!: PropertyDelta;
+
+      await given('a paragraph whose justification differs between sides', () => {
+        expect(true).toBe(true);
+      });
+
+      await when('the difference is recorded as a property delta', () => {
+        delta = {
+          scope: 'paragraph',
+          original: el('w:pPr', {}, [el('w:jc', { 'w:val': 'left' })]),
+          revised: el('w:pPr', {}, [el('w:jc', { 'w:val': 'center' })]),
+          changedProperties: ['justification'],
+        };
+      });
+
+      await then('the delta carries paragraph scope and pPr snapshots', () => {
+        // A run-scoped and a paragraph-scoped change serialize to different
+        // revision elements, so the level has to travel with the delta.
+        expect(delta.scope).toBe('paragraph');
+        expect(delta.original?.tagName).toBe('w:pPr');
+        expect(delta.revised?.tagName).toBe('w:pPr');
+      });
+    },
+  );
+
+  test.openspec('Equal content is tagged both')(
+    'identical content projects to both sides from a single node',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      const original = body([para('Unchanged clause.')]);
+      const revised = body([para('Unchanged clause.')]);
+      let tree!: TaggedNode;
+
+      await given('an identical clause on both sides', () => {
+        expect(original.textContent).toBe(revised.textContent);
+      });
+
+      await when('the pair is aligned', () => {
+        tree = bothTree(original, revised);
+      });
+
+      await then('both projections reproduce their input', () => {
+        expect(verifyTaggedTree(original, revised, tree)).toEqual([]);
+      });
+
+      await and('the content reaches both sides from one node', () => {
+        // Equal content has a single home in the tree, so no code path can emit
+        // it as a deletion paired with an insertion of the same text.
+        expect(project(tree, 'original')?.children).toHaveLength(1);
+        expect(project(tree, 'revised')?.children).toHaveLength(1);
+      });
+    },
+  );
+
+  test.openspec('Projections reproduce their input sides')(
+    'a tree with a deletion and an insertion projects back to both inputs',
+    async ({ given, when, then }: AllureBddContext) => {
+      const keptOriginal = para('Term A.');
+      const keptRevised = para('Term A.');
+      const removed = para('Term B.');
+      const added = para('Term C.');
+      const original = body([keptOriginal, removed]);
+      const revised = body([keptRevised, added]);
+      let tree!: TaggedNode;
+
+      await given('one kept paragraph, one removed and one added', () => {
+        expect(elementChildren(original)).toHaveLength(2);
+        expect(elementChildren(revised)).toHaveLength(2);
+      });
+
+      await when('the pair is aligned into a tagged tree', () => {
+        tree = {
+          tag: 'both',
+          original,
+          revised,
+          children: [
+            bothTree(keptOriginal, keptRevised),
+            { tag: 'original', node: removed, children: [] },
+            { tag: 'revised', node: added, children: [] },
+          ],
+        };
+      });
+
+      await then('both projections are isomorphic to their inputs', () => {
+        // Checked on the tree itself — nothing is serialized, and no
+        // accept/reject round trip is involved.
+        expect(verifyTaggedTree(original, revised, tree)).toEqual([]);
+      });
+    },
+  );
+
+  test.openspec('Reordering that satisfies coverage is rejected')(
+    'original [A,B] against revised [B,A] tagged [both(B),both(A)] violates P2',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      const originalA = para('A');
+      const originalB = para('B');
+      const revisedB = para('B');
+      const revisedA = para('A');
+      const original = body([originalA, originalB]);
+      const revised = body([revisedB, revisedA]);
+      let tree!: TaggedNode;
+      let violations: ProjectionViolation[] = [];
+
+      await given('an original ordered [A, B] and a revised ordered [B, A]', () => {
+        expect(original.textContent).toBe('AB');
+        expect(revised.textContent).toBe('BA');
+      });
+
+      await when('every node is tagged both, exactly once', () => {
+        // This is the candidate a coverage-only obligation accepts: each input
+        // node appears exactly once and carries the right tag.
+        tree = {
+          tag: 'both',
+          original,
+          revised,
+          children: [bothTree(originalB, revisedB), bothTree(originalA, revisedA)],
+        };
+        violations = verifyTaggedTree(original, revised, tree);
+      });
+
+      await then('the contract rejects it for violating P2', () => {
+        const ordering = violations.filter((v) => v.obligation === 'P2-order');
+        expect(ordering.length).toBeGreaterThan(0);
+        expect(ordering[0]?.side).toBe('original');
+      });
+
+      await and('the original projection really does read back in the wrong order', () => {
+        // Why order cannot be left to a coverage count: OOXML text extraction
+        // is order-sensitive, so this tree would certify a redline that reads
+        // back as [B, A] against an original of [A, B].
+        const projected = project(tree, 'original');
+        const text = projected?.children.map((c) => c.element.textContent).join('');
+        expect(text).toBe('BA');
+      });
+    },
+  );
+
+  test.openspec('Contract violations name the offending node')(
+    'a violation reports its obligation and a document-order path, and asserts loudly',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      const originalPara = para('Original text.');
+      const revisedPara = para('Original text.');
+      const dropped = para('Dropped clause.');
+      const original = body([originalPara, dropped]);
+      const revised = body([revisedPara]);
+      let tree!: TaggedNode;
+      let violations: ProjectionViolation[] = [];
+
+      await given('an original paragraph that the tree never tags', () => {
+        expect(elementChildren(original)).toHaveLength(2);
+      });
+
+      await when('the tree is verified against both inputs', () => {
+        tree = {
+          tag: 'both',
+          original,
+          revised,
+          children: [bothTree(originalPara, revisedPara)],
+        };
+        violations = verifyTaggedTree(original, revised, tree);
+      });
+
+      await then('the untagged node is reported with its obligation and path', () => {
+        const missing = violations.find((v) => v.obligation === 'P1-bijection');
+        expect(missing).toBeDefined();
+        expect(missing?.side).toBe('original');
+        expect(missing?.path).toContain('w:p');
+      });
+
+      await and('the assert form throws rather than letting the tree continue', () => {
+        // A violation is an engine defect, not something a later pass repairs.
+        expect(() => assertTaggedTree(original, revised, tree)).toThrow(ProjectionContractError);
+      });
+    },
+  );
+});

--- a/packages/docx-compare/src/baselines/atomizer/taggedTree.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/taggedTree.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect } from 'vitest';
+import fc from 'fast-check';
 import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
 import { el } from '../../testing/dom-test-helpers.js';
 import {
@@ -43,6 +44,10 @@ function bothTree(original: Element, revised: Element): BothNode {
   };
 }
 
+function obligations(violations: ProjectionViolation[]): string[] {
+  return [...new Set(violations.map((v) => v.obligation))].sort();
+}
+
 describe('side-tagged comparison tree', () => {
   test.openspec('Matched-but-differing nodes retain both representatives')(
     'a both node carries each side own representative and a scoped delta',
@@ -71,6 +76,7 @@ describe('side-tagged comparison tree', () => {
           revised: revisedRun,
           propertyDelta: delta,
           children: [],
+          opaque: true,
         };
       });
 
@@ -81,36 +87,53 @@ describe('side-tagged comparison tree', () => {
 
       await and('the difference is carried as a run-scoped delta', () => {
         expect(node.propertyDelta?.scope).toBe('run');
-        expect(node.propertyDelta?.original).toBeNull();
         expect(node.propertyDelta?.revised?.tagName).toBe('w:rPr');
       });
     },
   );
 
   test.openspec('Property delta scope matches the property level')(
-    'a paragraph-property difference is recorded at paragraph scope',
-    async ({ given, when, then }: AllureBddContext) => {
-      let delta!: PropertyDelta;
+    'a delta whose snapshot contradicts its scope is rejected',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      const original = body([para('Clause.')]);
+      const revised = body([para('Clause.')]);
+      let wrong: ProjectionViolation[] = [];
+      let right: ProjectionViolation[] = [];
 
-      await given('a paragraph whose justification differs between sides', () => {
+      await given('a paragraph-scoped delta carrying a w:rPr snapshot', () => {
         expect(true).toBe(true);
       });
 
-      await when('the difference is recorded as a property delta', () => {
-        delta = {
+      await when('the tree is verified', () => {
+        const tree = bothTree(original, revised);
+        tree.propertyDelta = {
+          scope: 'paragraph',
+          original: el('w:rPr', {}, [el('w:b', {})]),
+          revised: null,
+          changedProperties: ['bold'],
+        };
+        wrong = verifyTaggedTree(original, revised, tree);
+
+        const corrected = bothTree(original, revised);
+        corrected.propertyDelta = {
           scope: 'paragraph',
           original: el('w:pPr', {}, [el('w:jc', { 'w:val': 'left' })]),
           revised: el('w:pPr', {}, [el('w:jc', { 'w:val': 'center' })]),
           changedProperties: ['justification'],
         };
+        right = verifyTaggedTree(original, revised, corrected);
       });
 
-      await then('the delta carries paragraph scope and pPr snapshots', () => {
+      await then('the mismatched scope is reported', () => {
         // A run-scoped and a paragraph-scoped change serialize to different
-        // revision elements, so the level has to travel with the delta.
-        expect(delta.scope).toBe('paragraph');
-        expect(delta.original?.tagName).toBe('w:pPr');
-        expect(delta.revised?.tagName).toBe('w:pPr');
+        // revision elements, so a delta that mislabels its level cannot be
+        // serialized correctly.
+        expect(wrong.length).toBeGreaterThan(0);
+        expect(wrong.some((v) => v.detail.includes('w:pPr'))).toBe(true);
+      });
+
+      await and('a correctly-scoped delta passes', () => {
+        expect(right).toEqual([]);
       });
     },
   );
@@ -135,8 +158,6 @@ describe('side-tagged comparison tree', () => {
       });
 
       await and('the content reaches both sides from one node', () => {
-        // Equal content has a single home in the tree, so no code path can emit
-        // it as a deletion paired with an insertion of the same text.
         expect(project(tree, 'original')?.children).toHaveLength(1);
         expect(project(tree, 'revised')?.children).toHaveLength(1);
       });
@@ -166,16 +187,54 @@ describe('side-tagged comparison tree', () => {
           revised,
           children: [
             bothTree(keptOriginal, keptRevised),
-            { tag: 'original', node: removed, children: [] },
-            { tag: 'revised', node: added, children: [] },
+            { tag: 'original', node: removed, children: [], opaque: true },
+            { tag: 'revised', node: added, children: [], opaque: true },
           ],
         };
       });
 
       await then('both projections are isomorphic to their inputs', () => {
-        // Checked on the tree itself — nothing is serialized, and no
-        // accept/reject round trip is involved.
         expect(verifyTaggedTree(original, revised, tree)).toEqual([]);
+      });
+    },
+  );
+
+  test.openspec('An unmodeled subtree must declare itself opaque')(
+    'forgetting descendants is reported; declaring them opaque verifies clean',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      const original = body([para('Clause.')]);
+      const revised = body([para('Clause.')]);
+      let forgetful: ProjectionViolation[] = [];
+      let deliberate: ProjectionViolation[] = [];
+
+      await given('a node whose input element has children', () => {
+        expect(elementChildren(original)).toHaveLength(1);
+      });
+
+      await when('one tree omits them silently and another marks itself opaque', () => {
+        forgetful = verifyTaggedTree(original, revised, {
+          tag: 'both',
+          original,
+          revised,
+          children: [],
+        });
+        deliberate = verifyTaggedTree(original, revised, {
+          tag: 'both',
+          original,
+          revised,
+          children: [],
+          opaque: true,
+        });
+      });
+
+      await then('the silent omission is reported as unaccounted children', () => {
+        // An earlier revision read "no children" as "opaque" and compared the
+        // projected element against itself, so this tree passed clean.
+        expect(obligations(forgetful)).toContain('P1-bijection');
+      });
+
+      await and('the explicit declaration verifies clean', () => {
+        expect(deliberate).toEqual([]);
       });
     },
   );
@@ -198,8 +257,6 @@ describe('side-tagged comparison tree', () => {
       });
 
       await when('every node is tagged both, exactly once', () => {
-        // This is the candidate a coverage-only obligation accepts: each input
-        // node appears exactly once and carries the right tag.
         tree = {
           tag: 'both',
           original,
@@ -216,12 +273,8 @@ describe('side-tagged comparison tree', () => {
       });
 
       await and('the original projection really does read back in the wrong order', () => {
-        // Why order cannot be left to a coverage count: OOXML text extraction
-        // is order-sensitive, so this tree would certify a redline that reads
-        // back as [B, A] against an original of [A, B].
         const projected = project(tree, 'original');
-        const text = projected?.children.map((c) => c.element.textContent).join('');
-        expect(text).toBe('BA');
+        expect(projected?.children.map((c) => c.element.textContent).join('')).toBe('BA');
       });
     },
   );
@@ -242,26 +295,250 @@ describe('side-tagged comparison tree', () => {
       });
 
       await when('the tree is verified against both inputs', () => {
-        tree = {
-          tag: 'both',
-          original,
-          revised,
-          children: [bothTree(originalPara, revisedPara)],
-        };
+        tree = { tag: 'both', original, revised, children: [bothTree(originalPara, revisedPara)] };
         violations = verifyTaggedTree(original, revised, tree);
       });
 
       await then('the untagged node is reported with its obligation and path', () => {
-        const missing = violations.find((v) => v.obligation === 'P1-bijection');
-        expect(missing).toBeDefined();
-        expect(missing?.side).toBe('original');
-        expect(missing?.path).toContain('w:p');
+        const bijection = violations.filter((v) => v.obligation === 'P1-bijection');
+        expect(bijection.length).toBeGreaterThan(0);
+        expect(bijection.every((v) => v.side === 'original')).toBe(true);
+
+        // The parent is reported for the count mismatch, but the dropped child
+        // has to be named too — "two children, one projected" is not actionable
+        // on its own when a paragraph has many siblings.
+        const named = bijection.find((v) => v.path.includes('w:p['));
+        expect(named).toBeDefined();
+        expect(named?.path).toBe('w:body/w:p[2]');
       });
 
       await and('the assert form throws rather than letting the tree continue', () => {
-        // A violation is an engine defect, not something a later pass repairs.
         expect(() => assertTaggedTree(original, revised, tree)).toThrow(ProjectionContractError);
       });
     },
   );
+});
+
+/**
+ * Falsification cases.
+ *
+ * Every one of these passed an earlier revision of the verifier. They are kept
+ * as named regressions because the failure mode they share is the dangerous
+ * one: the checker stayed silent on a wrong tree, so nothing downstream had any
+ * reason to look.
+ */
+describe('side-tagged tree: falsification', () => {
+  test('rejects a tree that forgot every descendant instead of declaring it opaque', () => {
+    const original = body([para('Clause.')]);
+    const revised = body([para('Clause.')]);
+
+    // The aligner simply never descended. Before `opaque` was explicit, this
+    // was indistinguishable from a deliberate whole-subtree carry, because the
+    // verifier compared the projected element against itself.
+    const forgetful: TaggedNode = { tag: 'both', original, revised, children: [] };
+
+    const violations = verifyTaggedTree(original, revised, forgetful);
+    expect(violations.length).toBeGreaterThan(0);
+    expect(obligations(violations)).toContain('P1-bijection');
+  });
+
+  test('accepts the same shape when the subtree is explicitly opaque', () => {
+    const original = body([para('Clause.')]);
+    const revised = body([para('Clause.')]);
+    const deliberate: TaggedNode = {
+      tag: 'both',
+      original,
+      revised,
+      children: [],
+      opaque: true,
+    };
+    expect(verifyTaggedTree(original, revised, deliberate)).toEqual([]);
+  });
+
+  test('rejects an opaque node whose subtree is not the input subtree', () => {
+    const original = body([para('Original clause.')]);
+    const revised = body([para('Revised clause.')]);
+    const wrongPayload = body([para('Something else entirely.')]);
+
+    const tree: TaggedNode = {
+      tag: 'both',
+      original: wrongPayload,
+      revised,
+      children: [],
+      opaque: true,
+    };
+
+    const violations = verifyTaggedTree(original, revised, tree);
+    expect(obligations(violations)).toContain('P5-opaque-payload');
+  });
+
+  test('distinguishes elements that share a tagName across namespaces', () => {
+    const foreign = 'urn:not-wordprocessingml';
+    const originalDoc = el('w:body', {}, [para('Clause.')]);
+    const impostorBody = testElementInNamespace(foreign, 'w:body');
+    const impostorPara = testElementInNamespace(foreign, 'w:p');
+    impostorBody.appendChild(impostorPara);
+
+    const tree: TaggedNode = {
+      tag: 'both',
+      original: impostorBody,
+      revised: impostorBody,
+      children: [{ tag: 'both', original: impostorPara, revised: impostorPara, children: [], opaque: true }],
+    };
+
+    // Comparing lexical tagName alone would call these equal.
+    const violations = verifyTaggedTree(originalDoc, originalDoc, tree);
+    expect(violations.length).toBeGreaterThan(0);
+  });
+
+  test('does not let a delimiter-bearing attribute value forge another attribute set', () => {
+    const combined = el('w:p', { a: 'x b=y' });
+    const split = el('w:p', { a: 'x', b: 'y' });
+    const originalBody = body([combined]);
+    const impostorBody = body([split]);
+
+    const tree: TaggedNode = {
+      tag: 'both',
+      original: impostorBody,
+      revised: impostorBody,
+      children: [
+        { tag: 'both', original: split, revised: split, children: [], opaque: true },
+      ],
+    };
+
+    // `a="x b=y"` and `a="x" b="y"` concatenate identically around delimiters.
+    const violations = verifyTaggedTree(originalBody, originalBody, tree);
+    expect(violations.length).toBeGreaterThan(0);
+  });
+
+  test('reports a reorder combined with an edit rather than going silent', () => {
+    const originalA = para('A');
+    const originalB = para('B');
+    const revisedB = para('B');
+    const revisedAEdited = para('A edited');
+    const original = body([originalA, originalB]);
+    const revised = body([revisedB, revisedAEdited]);
+
+    const tree: TaggedNode = {
+      tag: 'both',
+      original,
+      revised,
+      children: [bothTree(originalB, revisedB), bothTree(originalA, revisedAEdited)],
+    };
+
+    // Not a clean permutation, so it is reported as content rather than order.
+    // What matters is that it is reported at all.
+    const violations = verifyTaggedTree(original, revised, tree);
+    expect(violations.length).toBeGreaterThan(0);
+  });
+
+  test('rejects a duplicated occurrence of the same input node', () => {
+    const only = para('Only clause.');
+    const original = body([only]);
+    const revised = body([para('Only clause.')]);
+
+    const tree: TaggedNode = {
+      tag: 'both',
+      original,
+      revised,
+      children: [
+        { tag: 'both', original: only, revised: only, children: [], opaque: true },
+        { tag: 'both', original: only, revised: only, children: [], opaque: true },
+      ],
+    };
+
+    const violations = verifyTaggedTree(original, revised, tree);
+    expect(obligations(violations)).toContain('P3-containment');
+  });
+
+  test('rejects wrong containment — a grandchild promoted to child', () => {
+    const run = el('w:r', {}, [el('w:t', {}, undefined, 'text')]);
+    const paragraph = el('w:p', {}, [run]);
+    const original = body([paragraph]);
+    const revised = body([para('text')]);
+
+    // The run is tagged as a sibling of its own paragraph.
+    const tree: TaggedNode = {
+      tag: 'both',
+      original,
+      revised,
+      children: [
+        { tag: 'both', original: paragraph, revised: paragraph, children: [], opaque: true },
+        { tag: 'both', original: run, revised: run, children: [], opaque: true },
+      ],
+    };
+
+    const violations = verifyTaggedTree(original, revised, tree);
+    expect(violations.length).toBeGreaterThan(0);
+  });
+
+  test('would fail if verification were stubbed out', () => {
+    // Guards against the mutation "make verifyTaggedTree return []": at least
+    // one case above must be non-vacuous for every obligation the module
+    // claims to check.
+    const original = body([para('A'), para('B')]);
+    const revised = body([para('A')]);
+    const tree: TaggedNode = { tag: 'both', original, revised, children: [] };
+    expect(verifyTaggedTree(original, revised, tree)).not.toEqual([]);
+  });
+});
+
+function testElementInNamespace(namespaceURI: string, qualifiedName: string): Element {
+  const doc = el('w:body', {}).ownerDocument!;
+  return doc.createElementNS(namespaceURI, qualifiedName);
+}
+
+/**
+ * Property test: any tree built by tagging two structurally parallel documents
+ * as `both` must verify clean, and dropping any single tagged child must make
+ * it fail. The second half is what stops the suite from passing vacuously.
+ */
+describe('side-tagged tree: properties', () => {
+  const paragraphTexts = fc.array(fc.string({ minLength: 1, maxLength: 8 }), {
+    minLength: 1,
+    maxLength: 6,
+  });
+
+  test('a fully-tagged parallel pair always verifies clean', () => {
+    fc.assert(
+      fc.property(paragraphTexts, (texts) => {
+        const original = body(texts.map((t) => para(t)));
+        const revised = body(texts.map((t) => para(t)));
+        return verifyTaggedTree(original, revised, bothTree(original, revised)).length === 0;
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  test('dropping any single top-level child always produces a violation', () => {
+    fc.assert(
+      fc.property(paragraphTexts, fc.nat(), (texts, seed) => {
+        const original = body(texts.map((t) => para(t)));
+        const revised = body(texts.map((t) => para(t)));
+        const tree = bothTree(original, revised);
+        const dropAt = seed % tree.children.length;
+        tree.children.splice(dropAt, 1);
+        return verifyTaggedTree(original, revised, tree).length > 0;
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  test('reversing the tagged children of a multi-child pair always produces a violation', () => {
+    fc.assert(
+      fc.property(
+        fc
+          .uniqueArray(fc.string({ minLength: 1, maxLength: 8 }), { minLength: 2, maxLength: 6 })
+          .filter((t) => t.length >= 2),
+        (texts) => {
+          const original = body(texts.map((t) => para(t)));
+          const revised = body(texts.map((t) => para(t)));
+          const tree = bothTree(original, revised);
+          tree.children.reverse();
+          return verifyTaggedTree(original, revised, tree).length > 0;
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
 });

--- a/packages/docx-compare/src/baselines/atomizer/taggedTree.ts
+++ b/packages/docx-compare/src/baselines/atomizer/taggedTree.ts
@@ -8,9 +8,14 @@
  * keeps whichever one passes an accept/reject round trip.
  *
  * This module provides the representation that removes the need to search: a
- * single tree in which every node records which side(s) it belongs to. The two
- * projections are then folds over that tree, and their fidelity to the inputs
- * is a property that can be established before anything is serialized.
+ * single tree in which every node records which side(s) it belongs to, and two
+ * projections that fold it back down to each input.
+ *
+ * **Scope.** What this establishes is *IR projection fidelity* — that each
+ * projection reproduces its input side. Serializer correctness, accept/reject
+ * semantics, and package/story assembly are three further layers, each with its
+ * own evidence. An empty violation list says nothing about them, and the
+ * runtime accept/reject checks in `pipeline.ts` are not made redundant by it.
  *
  * Stage A (this module) is additive and has no production caller. See
  * `openspec/changes/refactor-tagged-tree-redline-construction/`.
@@ -37,6 +42,16 @@ export type PropertyScope =
   | 'tableCell'
   | 'section';
 
+/** The direct property element each scope is carried by. */
+export const PROPERTY_SCOPE_ELEMENT: Readonly<Record<PropertyScope, string>> = {
+  run: 'w:rPr',
+  paragraphMark: 'w:rPr',
+  paragraph: 'w:pPr',
+  tableRow: 'w:trPr',
+  tableCell: 'w:tcPr',
+  section: 'w:sectPr',
+};
+
 /**
  * A formatting difference between the two representatives of a `both` node.
  *
@@ -57,6 +72,20 @@ export interface PropertyDelta {
 }
 
 /**
+ * Fields shared by every tagged node.
+ *
+ * `opaque` marks a subtree the IR deliberately does not model: the element is
+ * carried whole and `children` stays empty. It has to be explicit, because an
+ * empty `children` array is also what an *incomplete* construction looks like.
+ * A representation that cannot tell "I chose not to model this" from "I forgot
+ * to model this" will certify the second as the first.
+ */
+interface TaggedNodeBase {
+  children: TaggedNode[];
+  opaque?: true;
+}
+
+/**
  * A node present on both sides.
  *
  * It carries **two** element representatives because matched is not the same as
@@ -65,26 +94,23 @@ export interface PropertyDelta {
  * say which side's attributes each projection should emit, which is what forces
  * formatting differences into delete+insert pairs in the flat-atom pipeline.
  */
-export interface BothNode {
+export interface BothNode extends TaggedNodeBase {
   tag: 'both';
   original: WmlElement;
   revised: WmlElement;
   propertyDelta?: PropertyDelta;
-  children: TaggedNode[];
 }
 
 /** A node present only in the original document — a deletion. */
-export interface OriginalNode {
+export interface OriginalNode extends TaggedNodeBase {
   tag: 'original';
   node: WmlElement;
-  children: TaggedNode[];
 }
 
 /** A node present only in the revised document — an insertion. */
-export interface RevisedNode {
+export interface RevisedNode extends TaggedNodeBase {
   tag: 'revised';
   node: WmlElement;
-  children: TaggedNode[];
 }
 
 export type TaggedNode = BothNode | OriginalNode | RevisedNode;
@@ -107,14 +133,15 @@ export function representative(node: TaggedNode, side: Side): WmlElement | undef
 export interface ProjectedNode {
   element: WmlElement;
   children: ProjectedNode[];
+  /** Carried through so the verifier can tell modeled from unmodeled nodes. */
+  opaque: boolean;
 }
 
 /**
  * Fold a tagged tree down to one side.
  *
  * Total by construction: every node either contributes its representative for
- * `side` or is dropped, and no case is left unhandled. `accept` corresponds to
- * `project(tree, 'revised')` and `reject` to `project(tree, 'original')`.
+ * `side` or is dropped, and no case is left unhandled.
  */
 export function project(node: TaggedNode, side: Side): ProjectedNode | undefined {
   const element = representative(node, side);
@@ -124,7 +151,7 @@ export function project(node: TaggedNode, side: Side): ProjectedNode | undefined
     const projected = project(child, side);
     if (projected !== undefined) children.push(projected);
   }
-  return { element, children };
+  return { element, children, opaque: node.opaque === true };
 }
 
 /** Fold a forest of tagged nodes down to one side. */
@@ -153,15 +180,15 @@ export function projectAll(nodes: TaggedNode[], side: Side): ProjectedNode[] {
  * obligation would certify a redline that reads back wrong.
  */
 export type ProjectionObligation =
-  /** Every input-side node corresponds to exactly one projected node. */
+  /** Every input-side element corresponds to exactly one projected node. */
   | 'P1-bijection'
   /** Sibling order in the projection equals sibling order in the input. */
   | 'P2-order'
   /** Parent/child relationships are preserved. */
   | 'P3-containment'
-  /** Side-specific text, attributes and properties are the side's own. */
+  /** Side-specific namespace, name, attributes and text are the side's own. */
   | 'P4-content'
-  /** Unmodeled subtrees are reproduced verbatim. */
+  /** An explicitly opaque subtree is carried through equivalent to its input. */
   | 'P5-opaque-payload';
 
 export interface ProjectionViolation {
@@ -175,25 +202,39 @@ export interface ProjectionViolation {
 /**
  * Separator between sibling signatures.
  *
- * Explicit and named because a signature is only meaningful if every producer
- * uses the same one: a mismatch here makes two identical subtrees compare
- * unequal and silently disables the ordering check that depends on them.
+ * U+0001 is not a legal XML 1.0 character, so it cannot occur in document data
+ * and cannot be forged by content. Named and explicit because a signature is
+ * only meaningful if every producer uses the same one: an earlier revision
+ * joined on a stray NUL in one of two places, which made identical subtrees
+ * compare unequal and silently disabled the ordering check that depends on them.
  */
 const SIGNATURE_SEPARATOR = '\u0001';
 
 /**
- * Structural signature of an element's own identity — tag name, attributes, and
- * its immediate text, excluding descendants (which are compared separately as
- * their own nodes).
+ * Structural signature of an element's own identity.
+ *
+ * Identity is namespace URI plus local name, never the lexical `tagName`:
+ * prefixes are aliasable, so two elements in different namespaces can share a
+ * `tagName` and two elements in the same namespace can differ in it.
+ *
+ * Attributes and text are encoded with `JSON.stringify` rather than
+ * concatenated around delimiters. Delimiter-joined encoding is not injective —
+ * `a="x b=y"` and `a="x" b="y"` collapse to the same string — and a false
+ * equality here silently passes a wrong projection.
  */
 function elementSignature(element: WmlElement): string {
-  const attrs: string[] = [];
+  const attrs: Array<[string, string, string]> = [];
   const attributes = element.attributes;
   for (let i = 0; i < attributes.length; i++) {
     const attr = attributes.item(i);
-    if (attr) attrs.push(`${attr.name}=${attr.value}`);
+    if (!attr) continue;
+    // Namespace declarations describe the serialization rather than the
+    // content, and the writer re-emits them; comparing them would report a
+    // difference where the projected content is the same.
+    if (attr.name === 'xmlns' || attr.name.startsWith('xmlns:')) continue;
+    attrs.push([attr.namespaceURI ?? '', attr.localName ?? attr.name, attr.value]);
   }
-  attrs.sort();
+  attrs.sort((a, b) => (a[0] === b[0] ? a[1].localeCompare(b[1]) : a[0].localeCompare(b[0])));
 
   let ownText = '';
   for (let i = 0; i < element.childNodes.length; i++) {
@@ -203,10 +244,23 @@ function elementSignature(element: WmlElement): string {
     }
   }
 
-  return `${element.tagName}|${attrs.join(' ')}|${ownText}`;
+  return JSON.stringify([
+    element.namespaceURI ?? '',
+    element.localName ?? element.tagName,
+    attrs,
+    ownText,
+  ]);
 }
 
-/** Serialized form of a subtree, for the P5 verbatim comparison. */
+/**
+ * Signature of a whole input subtree.
+ *
+ * This is the **canonical equivalence** P5 is defined against, and it is
+ * deliberately not byte equality: attribute order is normalized, adjacent text
+ * nodes are concatenated, CDATA and text are treated alike, and comments and
+ * processing instructions do not participate. Content that depends on those
+ * distinctions surviving must not be modeled as opaque payload here.
+ */
 function subtreeSignature(element: WmlElement): string {
   const parts: string[] = [elementSignature(element)];
   for (const child of childElements(element)) {
@@ -215,15 +269,9 @@ function subtreeSignature(element: WmlElement): string {
   return parts.join(SIGNATURE_SEPARATOR);
 }
 
-/**
- * Serialized form of a projected subtree.
- *
- * A projected node with no children stands for its whole element, so it signs
- * as the full input subtree would — that is what lets an unmodeled (opaque)
- * subtree compare equal to the input it was carried from.
- */
+/** Signature of a projected subtree, mirroring {@link subtreeSignature}. */
 function projectedSubtreeSignature(node: ProjectedNode): string {
-  if (node.children.length === 0) return subtreeSignature(node.element);
+  if (node.opaque) return subtreeSignature(node.element);
   const parts: string[] = [elementSignature(node.element)];
   for (const child of node.children) {
     parts.push(projectedSubtreeSignature(child));
@@ -239,12 +287,8 @@ function childPath(path: string, element: WmlElement, ordinal: number): string {
  * Verify that `projected` is isomorphic to `input` under P1-P5.
  *
  * Runs against the tree without serializing it, in time linear in the size of
- * the input side.
- *
- * Scope: this establishes **IR projection fidelity** only. Serializer
- * correctness, accept/reject semantics, and package/story assembly are separate
- * layers with their own evidence, and a clean result here does not speak to
- * them.
+ * the input side. Establishes IR projection fidelity only — see this module's
+ * header for the three layers it does not speak to.
  */
 export function verifyProjection(
   input: WmlElement,
@@ -271,36 +315,42 @@ export function verifyProjection(
       path,
       detail:
         `projected <${projected.element.tagName}> does not carry the ${side} ` +
-        `side's own name, attributes or text`,
+        `side's own namespace, name, attributes or text`,
     });
   }
 
   const inputChildren = childElements(input);
 
-  // A tree node with no children stands for the whole input subtree, so the
-  // subtree must survive verbatim rather than being silently dropped.
-  if (projected.children.length === 0 && inputChildren.length > 0) {
+  // An opaque node stands for its whole subtree by explicit declaration, so the
+  // subtree is compared as a unit and its children are not separately accounted.
+  if (projected.opaque) {
     if (subtreeSignature(projected.element) !== subtreeSignature(input)) {
       violations.push({
         obligation: 'P5-opaque-payload',
         side,
         path,
         detail:
-          `unmodeled subtree under <${input.tagName}> is not reproduced ` +
-          `verbatim in the ${side} projection`,
+          `opaque subtree under <${input.tagName}> is not equivalent to the ` +
+          `${side} input subtree it stands for`,
       });
     }
     return violations;
   }
 
+  // Not opaque: every input child must be accounted for. This is the case an
+  // implicit "no children means opaque" convention silently certified — a tree
+  // that forgot its descendants was indistinguishable from one that carried
+  // them whole, and passed clean.
   if (projected.children.length !== inputChildren.length) {
     violations.push({
-      obligation: 'P3-containment',
+      obligation:
+        inputChildren.length > projected.children.length ? 'P1-bijection' : 'P3-containment',
       side,
       path,
       detail:
         `<${input.tagName}> has ${inputChildren.length} child element(s) on the ` +
-        `${side} side but ${projected.children.length} in the projection`,
+        `${side} side but ${projected.children.length} in the projection; a subtree ` +
+        `that is deliberately unmodeled must be marked opaque`,
     });
   }
 
@@ -308,9 +358,6 @@ export function verifyProjection(
   // projection must reproduce are a *sequence*, so when the same set comes back
   // in a different order the defect is the order — recursing first would report
   // it as a pile of content mismatches deeper down and name the wrong thing.
-  // This is the case that a coverage-only obligation cannot see at all:
-  // original [A, B] against revised [B, A], tagged [both(B), both(A)], has every
-  // input node present exactly once and is still wrong.
   const inputSignatures = inputChildren.map(subtreeSignature);
   const projectedSignatures = projected.children.map(projectedSubtreeSignature);
   const sameSequence =
@@ -343,8 +390,9 @@ export function verifyProjection(
   for (let i = 0; i < shared; i++) {
     const inputChild = inputChildren[i]!;
     const projectedChild = projected.children[i]!;
-    const here = childPath(path, inputChild, i + 1);
-    violations.push(...verifyProjection(inputChild, projectedChild, side, here));
+    violations.push(
+      ...verifyProjection(inputChild, projectedChild, side, childPath(path, inputChild, i + 1)),
+    );
   }
 
   for (let i = shared; i < inputChildren.length; i++) {
@@ -361,12 +409,64 @@ export function verifyProjection(
 }
 
 /**
- * Verify both projections of a tagged tree against the documents it was built
- * from.
+ * Check that a property delta is internally consistent: its snapshots are the
+ * element its scope names, and it records something on at least one side.
  *
- * This is the whole obligation of the aligner. When it returns empty, the
- * round-trip property holds by construction of the tree rather than by
- * inspecting serialized output.
+ * Whether the snapshots agree with the node's representatives is the aligner's
+ * obligation, and stage A has no aligner — so it is deliberately not checked.
+ */
+export function verifyPropertyDelta(delta: PropertyDelta, path: string): ProjectionViolation[] {
+  const violations: ProjectionViolation[] = [];
+  const expected = PROPERTY_SCOPE_ELEMENT[delta.scope];
+
+  for (const side of ['original', 'revised'] as const) {
+    const snapshot = delta[side];
+    if (snapshot !== null && snapshot.tagName !== expected) {
+      violations.push({
+        obligation: 'P4-content',
+        side,
+        path,
+        detail:
+          `property delta at ${delta.scope} scope carries <${snapshot.tagName}> on the ` +
+          `${side} side, but ${delta.scope} scope is carried by <${expected}>`,
+      });
+    }
+  }
+
+  if (delta.original === null && delta.revised === null) {
+    violations.push({
+      obligation: 'P4-content',
+      side: 'original',
+      path,
+      detail: `property delta at ${delta.scope} scope records no snapshot on either side`,
+    });
+  }
+
+  return violations;
+}
+
+/** Walk the tree and verify every property delta it carries. */
+function verifyDeltas(node: TaggedNode, path: string): ProjectionViolation[] {
+  const violations: ProjectionViolation[] = [];
+  if (node.tag === 'both' && node.propertyDelta) {
+    violations.push(...verifyPropertyDelta(node.propertyDelta, path));
+  }
+  node.children.forEach((child, i) => {
+    const element = child.tag === 'both' ? child.original : child.node;
+    violations.push(...verifyDeltas(child, childPath(path, element, i + 1)));
+  });
+  return violations;
+}
+
+/**
+ * Verify both projections of a tagged tree against the documents it was built
+ * from, plus the internal consistency of any property deltas.
+ *
+ * An empty result establishes **IR projection fidelity**: each projection
+ * reproduces its input side. It does not establish serializer correctness,
+ * accept/reject semantics, or package assembly — those are separate layers, and
+ * the runtime round-trip checks covering them today are not made redundant by
+ * this.
  */
 export function verifyTaggedTree(
   originalRoot: WmlElement,
@@ -376,21 +476,20 @@ export function verifyTaggedTree(
   return [
     ...verifyProjection(originalRoot, project(tree, 'original'), 'original'),
     ...verifyProjection(revisedRoot, project(tree, 'revised'), 'revised'),
+    ...verifyDeltas(tree, originalRoot.tagName),
   ];
 }
 
 /** Formats violations for an error message or a divergence report. */
 export function describeViolations(violations: ProjectionViolation[]): string {
-  return violations
-    .map((v) => `${v.obligation} [${v.side}] at ${v.path}: ${v.detail}`)
-    .join('\n');
+  return violations.map((v) => `${v.obligation} [${v.side}] at ${v.path}: ${v.detail}`).join('\n');
 }
 
 /**
  * Error raised when a constructed tree fails its projection obligations.
  *
  * A violation is an engine defect, not something a downstream pass repairs —
- * the pipeline it replaces reacts to a failed check by trying a different
+ * the pipeline this replaces reacts to a failed check by trying a different
  * atomization, which is what lets an incomplete checker ship a wrong redline.
  */
 export class ProjectionContractError extends Error {

--- a/packages/docx-compare/src/baselines/atomizer/taggedTree.ts
+++ b/packages/docx-compare/src/baselines/atomizer/taggedTree.ts
@@ -1,0 +1,414 @@
+/**
+ * Side-tagged comparison tree.
+ *
+ * The atomizer pipeline flattens OOXML into a flat atom list, runs LCS over it,
+ * and reconstitutes a tree afterwards. The tree invariants that make a redline
+ * valid do not survive that round trip, so they can only be *checked* after
+ * serialization — which is why `pipeline.ts` produces several candidates and
+ * keeps whichever one passes an accept/reject round trip.
+ *
+ * This module provides the representation that removes the need to search: a
+ * single tree in which every node records which side(s) it belongs to. The two
+ * projections are then folds over that tree, and their fidelity to the inputs
+ * is a property that can be established before anything is serialized.
+ *
+ * Stage A (this module) is additive and has no production caller. See
+ * `openspec/changes/refactor-tagged-tree-redline-construction/`.
+ */
+
+import type { WmlElement } from '@usejunior/docx-core';
+import { childElements } from '@usejunior/docx-core';
+
+/** The two input documents a comparison projects back to. */
+export type Side = 'original' | 'revised';
+
+/**
+ * OOXML property level a {@link PropertyDelta} describes.
+ *
+ * Property changes are not one kind of thing: a run-property change and a
+ * paragraph-property change serialize to different revision elements, so a
+ * delta that does not carry its own level cannot be serialized unambiguously.
+ */
+export type PropertyScope =
+  | 'run'
+  | 'paragraphMark'
+  | 'paragraph'
+  | 'tableRow'
+  | 'tableCell'
+  | 'section';
+
+/**
+ * A formatting difference between the two representatives of a `both` node.
+ *
+ * Snapshots are **direct** property elements (`w:rPr`, `w:pPr`, …) as they
+ * appear in each input. Formatting resolved through the style chain or
+ * `docDefaults` is deliberately not modeled: neither the format detector nor
+ * the fidelity oracle resolves it, so a delta claiming to carry effective
+ * formatting could not be checked against anything.
+ */
+export interface PropertyDelta {
+  scope: PropertyScope;
+  /** Direct property element on the original side, or null when absent. */
+  original: WmlElement | null;
+  /** Direct property element on the revised side, or null when absent. */
+  revised: WmlElement | null;
+  /** Names of the properties that differ, for reporting. */
+  changedProperties: string[];
+}
+
+/**
+ * A node present on both sides.
+ *
+ * It carries **two** element representatives because matched is not the same as
+ * identical: the same text can appear under different run properties, and the
+ * same paragraph under a different `w:pPr`. A single-element `both` node cannot
+ * say which side's attributes each projection should emit, which is what forces
+ * formatting differences into delete+insert pairs in the flat-atom pipeline.
+ */
+export interface BothNode {
+  tag: 'both';
+  original: WmlElement;
+  revised: WmlElement;
+  propertyDelta?: PropertyDelta;
+  children: TaggedNode[];
+}
+
+/** A node present only in the original document — a deletion. */
+export interface OriginalNode {
+  tag: 'original';
+  node: WmlElement;
+  children: TaggedNode[];
+}
+
+/** A node present only in the revised document — an insertion. */
+export interface RevisedNode {
+  tag: 'revised';
+  node: WmlElement;
+  children: TaggedNode[];
+}
+
+export type TaggedNode = BothNode | OriginalNode | RevisedNode;
+
+/** True when `node` contributes to the projection of `side`. */
+export function appearsOn(node: TaggedNode, side: Side): boolean {
+  return node.tag === 'both' || node.tag === side;
+}
+
+/** The element `node` contributes to the projection of `side`. */
+export function representative(node: TaggedNode, side: Side): WmlElement | undefined {
+  if (node.tag === 'both') return side === 'original' ? node.original : node.revised;
+  return node.tag === side ? node.node : undefined;
+}
+
+/**
+ * A projected tree: the shape one side of the comparison takes when the tagged
+ * tree is folded down to it.
+ */
+export interface ProjectedNode {
+  element: WmlElement;
+  children: ProjectedNode[];
+}
+
+/**
+ * Fold a tagged tree down to one side.
+ *
+ * Total by construction: every node either contributes its representative for
+ * `side` or is dropped, and no case is left unhandled. `accept` corresponds to
+ * `project(tree, 'revised')` and `reject` to `project(tree, 'original')`.
+ */
+export function project(node: TaggedNode, side: Side): ProjectedNode | undefined {
+  const element = representative(node, side);
+  if (element === undefined) return undefined;
+  const children: ProjectedNode[] = [];
+  for (const child of node.children) {
+    const projected = project(child, side);
+    if (projected !== undefined) children.push(projected);
+  }
+  return { element, children };
+}
+
+/** Fold a forest of tagged nodes down to one side. */
+export function projectAll(nodes: TaggedNode[], side: Side): ProjectedNode[] {
+  const out: ProjectedNode[] = [];
+  for (const node of nodes) {
+    const projected = project(node, side);
+    if (projected !== undefined) out.push(projected);
+  }
+  return out;
+}
+
+// =============================================================================
+// Projection isomorphism
+// =============================================================================
+
+/**
+ * The obligations an aligner must satisfy for a projection to reproduce its
+ * input side.
+ *
+ * Coverage alone is not enough, and the gap is not academic. An obligation
+ * stating only that each input node appears exactly once admits
+ * `original = [A, B]`, `revised = [B, A]`, tree `[both(B), both(A)]`: every
+ * input node appears once, yet the original projection is `[B, A]`. P2 is what
+ * excludes it. OOXML text extraction is order-sensitive, so an order-blind
+ * obligation would certify a redline that reads back wrong.
+ */
+export type ProjectionObligation =
+  /** Every input-side node corresponds to exactly one projected node. */
+  | 'P1-bijection'
+  /** Sibling order in the projection equals sibling order in the input. */
+  | 'P2-order'
+  /** Parent/child relationships are preserved. */
+  | 'P3-containment'
+  /** Side-specific text, attributes and properties are the side's own. */
+  | 'P4-content'
+  /** Unmodeled subtrees are reproduced verbatim. */
+  | 'P5-opaque-payload';
+
+export interface ProjectionViolation {
+  obligation: ProjectionObligation;
+  side: Side;
+  /** Document-order path to the offending node, e.g. `w:body/w:p[2]/w:r[1]`. */
+  path: string;
+  detail: string;
+}
+
+/**
+ * Separator between sibling signatures.
+ *
+ * Explicit and named because a signature is only meaningful if every producer
+ * uses the same one: a mismatch here makes two identical subtrees compare
+ * unequal and silently disables the ordering check that depends on them.
+ */
+const SIGNATURE_SEPARATOR = '\u0001';
+
+/**
+ * Structural signature of an element's own identity — tag name, attributes, and
+ * its immediate text, excluding descendants (which are compared separately as
+ * their own nodes).
+ */
+function elementSignature(element: WmlElement): string {
+  const attrs: string[] = [];
+  const attributes = element.attributes;
+  for (let i = 0; i < attributes.length; i++) {
+    const attr = attributes.item(i);
+    if (attr) attrs.push(`${attr.name}=${attr.value}`);
+  }
+  attrs.sort();
+
+  let ownText = '';
+  for (let i = 0; i < element.childNodes.length; i++) {
+    const child = element.childNodes[i]!;
+    if (child.nodeType === 3 /* TEXT_NODE */ || child.nodeType === 4 /* CDATA */) {
+      ownText += child.nodeValue ?? '';
+    }
+  }
+
+  return `${element.tagName}|${attrs.join(' ')}|${ownText}`;
+}
+
+/** Serialized form of a subtree, for the P5 verbatim comparison. */
+function subtreeSignature(element: WmlElement): string {
+  const parts: string[] = [elementSignature(element)];
+  for (const child of childElements(element)) {
+    parts.push(subtreeSignature(child));
+  }
+  return parts.join(SIGNATURE_SEPARATOR);
+}
+
+/**
+ * Serialized form of a projected subtree.
+ *
+ * A projected node with no children stands for its whole element, so it signs
+ * as the full input subtree would — that is what lets an unmodeled (opaque)
+ * subtree compare equal to the input it was carried from.
+ */
+function projectedSubtreeSignature(node: ProjectedNode): string {
+  if (node.children.length === 0) return subtreeSignature(node.element);
+  const parts: string[] = [elementSignature(node.element)];
+  for (const child of node.children) {
+    parts.push(projectedSubtreeSignature(child));
+  }
+  return parts.join(SIGNATURE_SEPARATOR);
+}
+
+function childPath(path: string, element: WmlElement, ordinal: number): string {
+  return `${path}/${element.tagName}[${ordinal}]`;
+}
+
+/**
+ * Verify that `projected` is isomorphic to `input` under P1-P5.
+ *
+ * Runs against the tree without serializing it, in time linear in the size of
+ * the input side.
+ *
+ * Scope: this establishes **IR projection fidelity** only. Serializer
+ * correctness, accept/reject semantics, and package/story assembly are separate
+ * layers with their own evidence, and a clean result here does not speak to
+ * them.
+ */
+export function verifyProjection(
+  input: WmlElement,
+  projected: ProjectedNode | undefined,
+  side: Side,
+  path = input.tagName,
+): ProjectionViolation[] {
+  const violations: ProjectionViolation[] = [];
+
+  if (projected === undefined) {
+    violations.push({
+      obligation: 'P1-bijection',
+      side,
+      path,
+      detail: `input node <${input.tagName}> has no counterpart in the ${side} projection`,
+    });
+    return violations;
+  }
+
+  if (elementSignature(projected.element) !== elementSignature(input)) {
+    violations.push({
+      obligation: 'P4-content',
+      side,
+      path,
+      detail:
+        `projected <${projected.element.tagName}> does not carry the ${side} ` +
+        `side's own name, attributes or text`,
+    });
+  }
+
+  const inputChildren = childElements(input);
+
+  // A tree node with no children stands for the whole input subtree, so the
+  // subtree must survive verbatim rather than being silently dropped.
+  if (projected.children.length === 0 && inputChildren.length > 0) {
+    if (subtreeSignature(projected.element) !== subtreeSignature(input)) {
+      violations.push({
+        obligation: 'P5-opaque-payload',
+        side,
+        path,
+        detail:
+          `unmodeled subtree under <${input.tagName}> is not reproduced ` +
+          `verbatim in the ${side} projection`,
+      });
+    }
+    return violations;
+  }
+
+  if (projected.children.length !== inputChildren.length) {
+    violations.push({
+      obligation: 'P3-containment',
+      side,
+      path,
+      detail:
+        `<${input.tagName}> has ${inputChildren.length} child element(s) on the ` +
+        `${side} side but ${projected.children.length} in the projection`,
+    });
+  }
+
+  // Reordering is diagnosed at this level, before recursing. The children a
+  // projection must reproduce are a *sequence*, so when the same set comes back
+  // in a different order the defect is the order — recursing first would report
+  // it as a pile of content mismatches deeper down and name the wrong thing.
+  // This is the case that a coverage-only obligation cannot see at all:
+  // original [A, B] against revised [B, A], tagged [both(B), both(A)], has every
+  // input node present exactly once and is still wrong.
+  const inputSignatures = inputChildren.map(subtreeSignature);
+  const projectedSignatures = projected.children.map(projectedSubtreeSignature);
+  const sameSequence =
+    inputSignatures.length === projectedSignatures.length &&
+    inputSignatures.every((sig, i) => sig === projectedSignatures[i]);
+
+  if (!sameSequence) {
+    const isPermutation =
+      inputSignatures.length === projectedSignatures.length &&
+      [...inputSignatures].sort().join(SIGNATURE_SEPARATOR) ===
+        [...projectedSignatures].sort().join(SIGNATURE_SEPARATOR);
+
+    if (isPermutation) {
+      const firstDiff = inputSignatures.findIndex((sig, i) => sig !== projectedSignatures[i]);
+      const offending = inputChildren[firstDiff]!;
+      violations.push({
+        obligation: 'P2-order',
+        side,
+        path: childPath(path, offending, firstDiff + 1),
+        detail:
+          `children of <${input.tagName}> are reordered in the ${side} projection: ` +
+          `position ${firstDiff + 1} holds <${offending.tagName}> on the ${side} side ` +
+          `but a different sibling in the projection`,
+      });
+      return violations;
+    }
+  }
+
+  const shared = Math.min(projected.children.length, inputChildren.length);
+  for (let i = 0; i < shared; i++) {
+    const inputChild = inputChildren[i]!;
+    const projectedChild = projected.children[i]!;
+    const here = childPath(path, inputChild, i + 1);
+    violations.push(...verifyProjection(inputChild, projectedChild, side, here));
+  }
+
+  for (let i = shared; i < inputChildren.length; i++) {
+    const inputChild = inputChildren[i]!;
+    violations.push({
+      obligation: 'P1-bijection',
+      side,
+      path: childPath(path, inputChild, i + 1),
+      detail: `input node <${inputChild.tagName}> has no counterpart in the ${side} projection`,
+    });
+  }
+
+  return violations;
+}
+
+/**
+ * Verify both projections of a tagged tree against the documents it was built
+ * from.
+ *
+ * This is the whole obligation of the aligner. When it returns empty, the
+ * round-trip property holds by construction of the tree rather than by
+ * inspecting serialized output.
+ */
+export function verifyTaggedTree(
+  originalRoot: WmlElement,
+  revisedRoot: WmlElement,
+  tree: TaggedNode,
+): ProjectionViolation[] {
+  return [
+    ...verifyProjection(originalRoot, project(tree, 'original'), 'original'),
+    ...verifyProjection(revisedRoot, project(tree, 'revised'), 'revised'),
+  ];
+}
+
+/** Formats violations for an error message or a divergence report. */
+export function describeViolations(violations: ProjectionViolation[]): string {
+  return violations
+    .map((v) => `${v.obligation} [${v.side}] at ${v.path}: ${v.detail}`)
+    .join('\n');
+}
+
+/**
+ * Error raised when a constructed tree fails its projection obligations.
+ *
+ * A violation is an engine defect, not something a downstream pass repairs —
+ * the pipeline it replaces reacts to a failed check by trying a different
+ * atomization, which is what lets an incomplete checker ship a wrong redline.
+ */
+export class ProjectionContractError extends Error {
+  readonly violations: ProjectionViolation[];
+
+  constructor(violations: ProjectionViolation[]) {
+    super(`tagged tree violates its projection contract:\n${describeViolations(violations)}`);
+    this.name = 'ProjectionContractError';
+    this.violations = violations;
+  }
+}
+
+/** Throws {@link ProjectionContractError} unless both projections are isomorphic. */
+export function assertTaggedTree(
+  originalRoot: WmlElement,
+  revisedRoot: WmlElement,
+  tree: TaggedNode,
+): void {
+  const violations = verifyTaggedTree(originalRoot, revisedRoot, tree);
+  if (violations.length > 0) throw new ProjectionContractError(violations);
+}


### PR DESCRIPTION
Implements stage A tasks 1.1-1.6 of `refactor-tagged-tree-redline-construction` (#818, #814).

## Why

`compareDocumentsAtomizerCore` does not construct a redline — it searches for one. `pipeline.ts:1128-1231` runs the full comparison under four atomization configurations, accept/rejects each serialized candidate against the two inputs, and keeps the first survivor; if none pass, it falls back to `rebuild`.

That makes the correctness oracle load-bearing control flow. `accept(output) ≡ revised ∧ reject(output) ≡ original` is the *definition* of a correct redline, so using it to pick among guesses means the engine is correct only as far as the checker is complete. The cause is representational: flattening OOXML to a flat atom list destroys the tree invariants that make output valid, so they can only be recovered — and therefore only checked — after serialization.

## What this adds

Additive only. No production caller, no behavior change, every existing runtime check untouched.

- `TaggedNode` = `both` | `original` | `revised`. A `both` node carries **two** element representatives, because matched is not identical — the same text under different run properties must stay one node, or the projection cannot know which side supplies the attributes and the difference has to be expressed as a delete plus an insert of the same text. That is the defect `suppressNoOpChangePairs` exists to clean up.
- `PropertyDelta` scoped by OOXML property level (run / paragraph mark / paragraph / row / cell / section), carrying **direct** snapshots. Effective (style-chain / `docDefaults`) formatting is an explicit non-goal — neither the detector nor the fidelity oracle resolves it, so a delta claiming to carry it could not be checked against anything.
- `project(tree, side)` as a total fold, and `verifyProjection` checking five obligations without serializing.

Coverage alone is not sufficient, and the gap is not academic: original `[A,B]` against revised `[B,A]` tagged `[both(B), both(A)]` has every input node present exactly once and still projects the original as `[B,A]`. OOXML text extraction is order-sensitive, so an order-blind obligation would certify a redline that reads back wrong. That counterexample is a test.

## Peer review

Codex reviewed the first cut dynamically — it ran the suite, `openspec validate`, `check:spec-coverage`, and its own adversarial probe — and **requested changes**. Four findings were real and are fixed in `61b83a8`:

1. **The opaque rule was vacuous.** A projected node with no children was read as standing for its whole subtree, then compared against the input by signature — but in the ordinary case those are *the same object*, so the check compared a thing with itself. A tree that forgot every descendant passed clean. Opacity is now explicit (`opaque: true`), and a non-opaque node must account for every input child. An empty child list is also what an incomplete construction looks like, so the two meanings cannot share a representation.
2. **Signatures were neither namespace-aware nor injective.** Identity was the lexical `tagName`, so elements from different namespaces sharing a prefix compared equal — and attributes were joined around delimiters, so `a="x b=y"` and `a="x" b="y"` collapsed to the same string. Now namespace URI + local name, with JSON-encoded attributes and text.
3. **P5 claimed byte identity it does not check.** The comparison normalizes attribute order, concatenates adjacent text, treats CDATA as text, and ignores comments/PIs. The spec now defines P5 as canonical equivalence and warns off modeling anything opaquely that depends on those distinctions.
4. **The round-trip claim overreached.** `verifyTaggedTree`'s doc comment said an empty result meant round-trip correctness held by construction — which this change's own spec explicitly forbids. IR projection fidelity is one of four layers; the runtime accept/reject checks are not made redundant by it.

Also from the review: property deltas are validated against their declared scope instead of being an unchecked bag, and the tests are falsifying rather than constructive — nine named regressions (forgotten descendants, wrong opaque payload, cross-namespace impostor, delimiter forgery, reorder-plus-edit, duplicated occurrence, promoted grandchild) plus three fast-check properties. **Every one of those cases passed the first cut.**

One earlier self-inflicted bug is also recorded in the code: sibling signatures were joined on a stray NUL in one of two places, which made identical subtrees compare unequal and silently disabled the ordering check. The separator is now a named constant on U+0001, which is not a legal XML character and so cannot be forged by content.

## Spec amendments in this PR

- P1 gains the opaque carve-out; P4 requires namespace-based identity; P5 is redefined as canonical equivalence, with a new scenario requiring unmodeled subtrees to declare themselves.
- The merged proposal's "the docx-compare CLI **defaults** to `rebuild`" bullet is withdrawn: #811 had already unified every front door on `inplace` before #818 merged, and #816 recorded it. The substantive point stands — `rebuild` is a requested output shape, not merely a fallback — so successor D's scope is unchanged.

## Validation

- `npm run build` — exit 0
- `npm run lint --workspaces --if-present` — exit 0
- `npm run test:run -w @usejunior/docx-compare` — 837 passed, 106 skipped (was 824 before this PR)
- `npm run check:spec-coverage` — exit 0
- `npm run check:allure-labels` / `check:allure-quality` — 0 errors
- `openspec validate refactor-tagged-tree-redline-construction --strict` — valid

## Known gap, flagged not fixed

`CompareOptions.reconstructionMode` still advertises `Default: 'rebuild'` in its doc comment (`packages/docx-compare/src/compare-types.ts:25`), which is wrong on a published API surface since #811. Out of scope here.

Refs #814