### PR TITLE
fix(docx-compare): route DOCX_COMPARISON_DEBUG diagnostics to stderr

### DIFF
--- a/packages/docx-compare/src/baselines/atomizer/debug.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/debug.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Regression tests for the comparison debug logger (issue #820).
+ *
+ * The comparison library runs inside the safe-docx MCP server, which speaks
+ * newline-delimited JSON-RPC over stdio: anything a library writes to stdout
+ * corrupts the protocol stream. Issue #783 was an unconditional atomizer emit;
+ * issue #820 found that the opt-in DOCX_COMPARISON_DEBUG diagnostics still
+ * went through console.log — so a user enabling the variable documented in
+ * debug.ts's own header broke their MCP session. These tests pin ALL logger
+ * output (debug, warn, error) to stderr-backed console methods and would fail
+ * if any level were routed back to console.log.
+ */
+import { describe, expect, vi, afterEach } from 'vitest';
+import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
+import { debug, warn, error } from './debug.js';
+
+const test = testAllure.epic('Document Comparison').withLabels({
+  feature: 'Comparison Debug Logger Stream Routing',
+});
+
+function spyOnConsole() {
+  return {
+    log: vi.spyOn(console, 'log').mockImplementation(() => {}),
+    warn: vi.spyOn(console, 'warn').mockImplementation(() => {}),
+    error: vi.spyOn(console, 'error').mockImplementation(() => {}),
+  };
+}
+
+describe('comparison debug logger stream routing', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  test('enabled debug diagnostics go to stderr, never stdout', async ({ given, when, then }: AllureBddContext) => {
+    let spies: ReturnType<typeof spyOnConsole>;
+
+    await given('DOCX_COMPARISON_DEBUG is enabled', () => {
+      vi.stubEnv('DOCX_COMPARISON_DEBUG', '1');
+      spies = spyOnConsole();
+    });
+
+    await when('a debug message is logged with and without data', () => {
+      debug('hierarchicalLcs', '54 original groups (24 empty)');
+      debug('hierarchicalLcs', 'alignment detail', { groups: 54 });
+    });
+
+    await then('both emits use console.error and console.log is untouched', () => {
+      expect(spies.error).toHaveBeenCalledTimes(2);
+      expect(spies.error.mock.calls[0]![0]).toContain('[DEBUG] [hierarchicalLcs] 54 original groups (24 empty)');
+      expect(spies.error.mock.calls[1]![1]).toEqual({ groups: 54 });
+      expect(spies.log).not.toHaveBeenCalled();
+    });
+  });
+
+  test('disabled debug emits nothing on any stream', async ({ given, when, then }: AllureBddContext) => {
+    let spies: ReturnType<typeof spyOnConsole>;
+
+    await given('DOCX_COMPARISON_DEBUG is unset', () => {
+      vi.stubEnv('DOCX_COMPARISON_DEBUG', '');
+      spies = spyOnConsole();
+    });
+
+    await when('a debug message is logged', () => {
+      debug('hierarchicalLcs', 'should be suppressed');
+    });
+
+    await then('no console method is called', () => {
+      expect(spies.log).not.toHaveBeenCalled();
+      expect(spies.warn).not.toHaveBeenCalled();
+      expect(spies.error).not.toHaveBeenCalled();
+    });
+  });
+
+  test('module filtering still gates debug output', async ({ given, when, then }: AllureBddContext) => {
+    let spies: ReturnType<typeof spyOnConsole>;
+
+    await given('DOCX_COMPARISON_DEBUG names one module', () => {
+      vi.stubEnv('DOCX_COMPARISON_DEBUG', 'atomLcs');
+      spies = spyOnConsole();
+    });
+
+    await when('two modules log debug messages', () => {
+      debug('atomLcs', 'enabled module');
+      debug('hierarchicalLcs', 'disabled module');
+    });
+
+    await then('only the named module reaches stderr', () => {
+      expect(spies.error).toHaveBeenCalledTimes(1);
+      expect(spies.error.mock.calls[0]![0]).toContain('[atomLcs] enabled module');
+      expect(spies.log).not.toHaveBeenCalled();
+    });
+  });
+
+  test('warn and error levels keep their stderr-backed streams', async ({ given, when, then }: AllureBddContext) => {
+    let spies: ReturnType<typeof spyOnConsole>;
+
+    await given('console spies with debug disabled', () => {
+      vi.stubEnv('DOCX_COMPARISON_DEBUG', '');
+      spies = spyOnConsole();
+    });
+
+    await when('warn and error messages are logged', () => {
+      warn('inPlaceModifier', 'target paragraph is null', { atom: 3 });
+      error('documentReconstructor', 'reconstruction failed');
+    });
+
+    await then('warn uses console.warn, error uses console.error, and stdout stays clean', () => {
+      expect(spies.warn).toHaveBeenCalledTimes(1);
+      expect(spies.warn.mock.calls[0]![0]).toContain('[WARN] [inPlaceModifier] target paragraph is null');
+      expect(spies.error).toHaveBeenCalledTimes(1);
+      expect(spies.error.mock.calls[0]![0]).toContain('[ERROR] [documentReconstructor] reconstruction failed');
+      expect(spies.log).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/docx-compare/src/baselines/atomizer/debug.ts
+++ b/packages/docx-compare/src/baselines/atomizer/debug.ts
@@ -4,6 +4,12 @@
  * Provides controlled debug logging for the docx-comparison package.
  * Debug output is controlled by the DOCX_COMPARISON_DEBUG environment variable.
  *
+ * ALL output — debug, warn, and error — goes to stderr, never stdout. This
+ * library runs inside the safe-docx MCP server, which speaks newline-delimited
+ * JSON-RPC over stdio; any diagnostic written to stdout corrupts the protocol
+ * stream (issues #783, #809, #820). Do not add console.log /
+ * process.stdout.write here or anywhere on the comparison path.
+ *
  * Usage:
  *   import { debug, warn } from './debug.js';
  *   debug('inPlaceModifier', 'Processing atom', { status: atom.correlationStatus });
@@ -37,6 +43,10 @@ function formatMessage(level: LogLevel, module: string, message: string): string
 /**
  * Log a debug message (only when DOCX_COMPARISON_DEBUG is enabled).
  *
+ * Emits via console.error so diagnostics land on stderr: the MCP server owns
+ * stdout for JSON-RPC, and an enabled debug line on stdout breaks the client's
+ * protocol parser (issue #820).
+ *
  * @param module - The module name (e.g., 'inPlaceModifier', 'atomizer')
  * @param message - The message to log
  * @param data - Optional data to include
@@ -46,9 +56,9 @@ export function debug(module: string, message: string, data?: unknown): void {
 
   const formatted = formatMessage('debug', module, message);
   if (data !== undefined) {
-    console.log(formatted, data);
+    console.error(formatted, data);
   } else {
-    console.log(formatted);
+    console.error(formatted);
   }
 }
 

--- a/packages/docx-mcp/src/integration/stdio_protocol_cleanliness.test.ts
+++ b/packages/docx-mcp/src/integration/stdio_protocol_cleanliness.test.ts
@@ -10,12 +10,26 @@
  * second call captured the first call's no-op as its "original" and restored
  * it last, permanently silencing console.log for the whole process.
  *
- * This test drives the REAL server binary over stdio — the same entry MCP
- * clients use — with real legal documents, issues two overlapping
- * compare_documents tools/call requests (the exact interleaving the old
- * workaround corrupted), and asserts that every line the server writes to
- * stdout parses as a JSON-RPC message. No unit-level substitute can catch a
- * reintroduced stdout emit anywhere on the comparison path; this does.
+ * These tests drive the REAL server binary over stdio — the same entry MCP
+ * clients use — with real legal documents, and assert that every line the
+ * server writes to stdout parses as a JSON-RPC message: once with two
+ * back-to-back compare_documents tools/call requests, and once with
+ * DOCX_COMPARISON_DEBUG=1 so opt-in comparison diagnostics are live (issue
+ * #820: those diagnostics used to go through console.log and corrupt the
+ * stream). No unit-level substitute can catch a reintroduced stdout emit
+ * anywhere on the comparison path; this does.
+ *
+ * Scope note: the back-to-back requests exercise concurrent dispatch but do
+ * NOT establish a deterministic overlap, and a clean protocol stream does not
+ * prove console.log survived (responses are written with process.stdout.write).
+ * The deterministic regression for the #809 console.log race is
+ * src/tools/compare_documents_console_identity.test.ts.
+ *
+ * Standalone-run note: the spawned server resolves @usejunior/docx-compare and
+ * @usejunior/docx-core to their built dist/ via workspace resolution. Standard
+ * workspace scripts build first; if you run this file directly (e.g.
+ * `node ../../node_modules/vitest/vitest.mjs run src/integration/...`), run
+ * `npm run build` at the repo root first or you will exercise stale output.
  */
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import fs from 'node:fs/promises';
@@ -60,13 +74,15 @@ class StdioProbe {
   private readonly responseWaiters = new Map<number, (msg: JsonRpcMessage) => void>();
   private readonly responses = new Map<number, JsonRpcMessage>();
 
-  constructor() {
+  constructor(envOverrides: Record<string, string> = {}) {
     // Spawn the real CLI entry (`safedocx serve`) via tsx so the test runs the
-    // same server MCP clients launch, without requiring a prebuilt dist/.
+    // same server MCP clients launch, without requiring a prebuilt docx-mcp
+    // dist/ (workspace dependencies still resolve to their dist/ — see the
+    // standalone-run note in the file header).
     this.child = spawn(process.execPath, ['--import', 'tsx', CLI_ENTRY, 'serve'], {
       cwd: PACKAGE_DIR,
       stdio: ['pipe', 'pipe', 'pipe'],
-      env: { ...process.env },
+      env: { ...process.env, ...envOverrides },
     });
     this.child.stdout.setEncoding('utf8');
     this.child.stderr.setEncoding('utf8');
@@ -206,7 +222,7 @@ describe('MCP stdio protocol cleanliness under concurrent compare_documents', ()
 
       let resultA: Record<string, unknown>;
       let resultB: Record<string, unknown>;
-      await when('two compare_documents tools/call requests are issued back-to-back so they overlap', async () => {
+      await when('two compare_documents tools/call requests are issued back-to-back', async () => {
         const callParams = (savePath: string) => ({
           name: 'compare_documents',
           arguments: {
@@ -215,10 +231,12 @@ describe('MCP stdio protocol cleanliness under concurrent compare_documents', ()
             save_to_local_path: savePath,
           },
         });
-        // Both requests are written before either response is awaited, so the
-        // server runs the two comparisons concurrently in one process — the
-        // interleaving that left console.log permanently dead under the old
-        // process-global suppression workaround (issue #809).
+        // Both requests are written before either response is awaited, giving
+        // the server the OPPORTUNITY to run the two comparisons concurrently
+        // in one process. This does not deterministically force the overlap
+        // that broke issue #809 — that race is pinned by the injectable-
+        // dependency test in compare_documents_console_identity.test.ts; this
+        // test's job is catching real stdout emissions end-to-end.
         probe!.send({ jsonrpc: '2.0', id: 2, method: 'tools/call', params: callParams(outputA) });
         probe!.send({ jsonrpc: '2.0', id: 3, method: 'tools/call', params: callParams(outputB) });
         const [responseA, responseB] = await Promise.all([
@@ -243,6 +261,72 @@ describe('MCP stdio protocol cleanliness under concurrent compare_documents', ()
           }, `non-JSON line on the stdio protocol stream: ${line}`).not.toThrow();
           expect(parsed?.jsonrpc, `stdout line is JSON but not JSON-RPC: ${line}`).toBe('2.0');
         }
+      });
+    },
+    120_000,
+  );
+
+  test(
+    'DOCX_COMPARISON_DEBUG=1 keeps stdout pure JSON-RPC and routes diagnostics to stderr',
+    async ({ given, when, then }: AllureBddContext) => {
+      const tmpDir = await createTrackedTempDir('safe-docx-stdio-debug-');
+      const revisedPath = path.join(tmpDir, 'mutual-nda-revised.docx');
+      const outputPath = path.join(tmpDir, 'redline-debug.docx');
+
+      await given('the real MCP server running over stdio with DOCX_COMPARISON_DEBUG enabled', async () => {
+        await writeMinimallyRevisedCopy(REAL_DOCUMENT, revisedPath);
+        probe = new StdioProbe({ DOCX_COMPARISON_DEBUG: '1' });
+        probe.send({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'initialize',
+          params: {
+            protocolVersion: '2024-11-05',
+            capabilities: {},
+            clientInfo: { name: 'stdio-debug-probe', version: '0.0.0' },
+          },
+        });
+        const initResponse = await probe.waitForResponse(1, 60_000);
+        expect(initResponse.error).toBeUndefined();
+        probe.send({ jsonrpc: '2.0', method: 'notifications/initialized' });
+      });
+
+      let result: Record<string, unknown>;
+      await when('a compare_documents tools/call request runs with debug diagnostics live', async () => {
+        probe!.send({
+          jsonrpc: '2.0',
+          id: 2,
+          method: 'tools/call',
+          params: {
+            name: 'compare_documents',
+            arguments: {
+              original_file_path: REAL_DOCUMENT,
+              revised_file_path: revisedPath,
+              save_to_local_path: outputPath,
+            },
+          },
+        });
+        result = parseToolResult(await probe!.waitForResponse(2, 90_000));
+      });
+
+      await then('the comparison succeeds and every stdout line parses as JSON-RPC', async () => {
+        expect(result.success, JSON.stringify(result)).toBe(true);
+        await fs.access(outputPath);
+
+        for (const line of probe!.rawStdoutLines) {
+          let parsed: JsonRpcMessage | undefined;
+          expect(() => {
+            parsed = JSON.parse(line) as JsonRpcMessage;
+          }, `non-JSON line on the stdio protocol stream: ${line}`).not.toThrow();
+          expect(parsed?.jsonrpc, `stdout line is JSON but not JSON-RPC: ${line}`).toBe('2.0');
+        }
+      });
+
+      await then('the debug diagnostics appear on stderr instead of vanishing', () => {
+        // Guards against "fixing" the corruption by deleting the diagnostics:
+        // the enabled debug output must still exist, on the stderr channel.
+        const stderrText = probe!.stderrChunks.join('');
+        expect(stderrText, 'expected DOCX_COMPARISON_DEBUG diagnostics on stderr').toContain('[DEBUG] [');
       });
     },
     120_000,

--- a/packages/docx-mcp/src/tools/compare_documents_console_identity.test.ts
+++ b/packages/docx-mcp/src/tools/compare_documents_console_identity.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Deterministic regression for issue #809: overlapping compare_documents
+ * calls must never touch the process-global console.log.
+ *
+ * The removed runWithoutConsoleLog workaround swapped console.log for a no-op
+ * across an await. With two overlapping calls, the second call captured the
+ * first call's no-op as its "original" and restored it last — permanently
+ * silencing console.log for the whole process. The end-to-end stdio test
+ * cannot pin that defect: MCP responses are written with process.stdout.write,
+ * so the protocol stream stays clean even while console.log is dead (issue
+ * #820, finding 2 — demonstrated by reintroducing the wrapper and watching the
+ * stdio test pass).
+ *
+ * This test pins the defect directly. It mocks the comparison dependency so
+ * both tool calls can be paused INSIDE the comparison — the exact interleaving
+ * that reproduced #809 — with no reliance on timing, and asserts console.log
+ * retains strict identity at every stage. Any implementation that assigns to
+ * process-global console methods around the comparison fails here
+ * deterministically: mid-flight if it suppresses, at the end if it restores
+ * the wrong function.
+ */
+import { describe, expect, vi, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { CompareResult } from '@usejunior/docx-compare';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import {
+  assertSuccess,
+  createTestSessionManager,
+  createTrackedTempDir,
+  registerCleanup,
+} from '../testing/session-test-utils.js';
+
+// Replace the comparison engine with a controllable stand-in so the test can
+// hold both tool calls inside the comparison at once. The tool under test is
+// real; only the (expensive, timing-dependent) comparison is injected.
+vi.mock('@usejunior/docx-compare', () => ({
+  compareDocuments: vi.fn(),
+}));
+import { compareDocuments } from '@usejunior/docx-compare';
+import { compareDocuments_tool } from './compare_documents.js';
+
+const test = testAllure.epic('Document Comparison').withLabels({
+  feature: 'Compare Documents Console Identity',
+});
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REAL_DOCUMENT = path.resolve(
+  __dirname,
+  '../../../../tests/test_documents/open-agreements/mutual-nda.docx',
+);
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+function mockCompareResult(): CompareResult {
+  return {
+    document: Buffer.from('mock comparison output'),
+    engine: 'atomizer',
+    stats: {
+      insertions: 0,
+      deletions: 0,
+      modifications: 0,
+      insertedRanges: 0,
+      deletedRanges: 0,
+      insertedAtoms: 0,
+      deletedAtoms: 0,
+      modifiedParagraphs: 0,
+      formatChanges: 0,
+      formatChangeAtoms: 0,
+    },
+    reconstructionModeRequested: 'inplace',
+    reconstructionModeUsed: 'inplace',
+  };
+}
+
+describe('compare_documents leaves the process-global console untouched (#809)', () => {
+  registerCleanup();
+
+  afterEach(() => {
+    vi.mocked(compareDocuments).mockReset();
+  });
+
+  test(
+    'two overlapping tool calls preserve strict console.log identity throughout',
+    async ({ given, when, then }: AllureBddContext) => {
+      const initialConsoleLog = console.log;
+      const initialConsoleWarn = console.warn;
+      const initialConsoleError = console.error;
+
+      const manager = createTestSessionManager();
+      const tmpDir = await createTrackedTempDir('safe-docx-console-identity-');
+      const outputA = path.join(tmpDir, 'redline-a.docx');
+      const outputB = path.join(tmpDir, 'redline-b.docx');
+
+      const enteredA = deferred<void>();
+      const enteredB = deferred<void>();
+      const gateA = deferred<CompareResult>();
+      const gateB = deferred<CompareResult>();
+
+      await given('a comparison dependency that pauses inside each call', () => {
+        vi.mocked(compareDocuments)
+          .mockImplementationOnce(() => {
+            enteredA.resolve();
+            return gateA.promise;
+          })
+          .mockImplementationOnce(() => {
+            enteredB.resolve();
+            return gateB.promise;
+          });
+      });
+
+      try {
+        let responseA!: Promise<Awaited<ReturnType<typeof compareDocuments_tool>>>;
+        let responseB!: Promise<Awaited<ReturnType<typeof compareDocuments_tool>>>;
+
+        await when('call B enters the comparison while call A is still inside it', async () => {
+          responseA = compareDocuments_tool(manager, {
+            original_file_path: REAL_DOCUMENT,
+            revised_file_path: REAL_DOCUMENT,
+            save_to_local_path: outputA,
+          });
+          await enteredA.promise;
+
+          responseB = compareDocuments_tool(manager, {
+            original_file_path: REAL_DOCUMENT,
+            revised_file_path: REAL_DOCUMENT,
+            save_to_local_path: outputB,
+          });
+          await enteredB.promise;
+        });
+
+        await then('console.log is untouched while both comparisons are in flight', () => {
+          // The old wrapper fails here: call A already swapped in a no-op.
+          expect(console.log).toBe(initialConsoleLog);
+        });
+
+        await then('console.log is untouched after A finishes, then after B finishes', async () => {
+          gateA.resolve(mockCompareResult());
+          assertSuccess(await responseA, 'compare_documents call A');
+          expect(console.log).toBe(initialConsoleLog);
+
+          gateB.resolve(mockCompareResult());
+          assertSuccess(await responseB, 'compare_documents call B');
+          // The old wrapper's race ends here: B "restores" the no-op it
+          // captured from A, permanently silencing console.log (#809).
+          expect(console.log).toBe(initialConsoleLog);
+          expect(console.warn).toBe(initialConsoleWarn);
+          expect(console.error).toBe(initialConsoleError);
+        });
+
+        await then('both redlines were written', async () => {
+          await fs.access(outputA);
+          await fs.access(outputB);
+        });
+      } finally {
+        // Never leave the gates pending if an assertion throws mid-flight.
+        gateA.resolve(mockCompareResult());
+        gateB.resolve(mockCompareResult());
+      }
+    },
+  );
+});

--- a/packages/docx-mcp/src/tools/compare_documents_console_identity.test.ts
+++ b/packages/docx-mcp/src/tools/compare_documents_console_identity.test.ts
@@ -14,10 +14,12 @@
  * This test pins the defect directly. It mocks the comparison dependency so
  * both tool calls can be paused INSIDE the comparison — the exact interleaving
  * that reproduced #809 — with no reliance on timing, and asserts console.log
- * retains strict identity at every stage. Any implementation that assigns to
- * process-global console methods around the comparison fails here
- * deterministically: mid-flight if it suppresses, at the end if it restores
- * the wrong function.
+ * retains strict identity at every stage: synchronously at dependency entry
+ * (catching a swap that is restored before the caller awaits), mid-flight
+ * while both calls are suspended (catching the across-an-await suppression),
+ * and after both complete (catching the permanent wrong-function restore).
+ * Per-call handling that never mutates the process-global console identities
+ * (e.g. AsyncLocalStorage scoping) is intentionally outside this regression.
  */
 import { describe, expect, vi, afterEach } from 'vitest';
 import fs from 'node:fs/promises';
@@ -110,13 +112,28 @@ describe('compare_documents leaves the process-global console untouched (#809)',
       const gateA = deferred<CompareResult>();
       const gateB = deferred<CompareResult>();
 
+      // Console identities observed synchronously INSIDE the comparison call.
+      // A wrapper that swaps console.log and restores it before the caller
+      // awaits would look intact from the outside; these entry-time records
+      // catch it (peer review of #820).
+      const entryIdentities: Array<{
+        log: typeof console.log;
+        warn: typeof console.warn;
+        error: typeof console.error;
+      }> = [];
+      const recordEntryIdentities = () => {
+        entryIdentities.push({ log: console.log, warn: console.warn, error: console.error });
+      };
+
       await given('a comparison dependency that pauses inside each call', () => {
         vi.mocked(compareDocuments)
           .mockImplementationOnce(() => {
+            recordEntryIdentities();
             enteredA.resolve();
             return gateA.promise;
           })
           .mockImplementationOnce(() => {
+            recordEntryIdentities();
             enteredB.resolve();
             return gateB.promise;
           });
@@ -140,6 +157,17 @@ describe('compare_documents leaves the process-global console untouched (#809)',
             save_to_local_path: outputB,
           });
           await enteredB.promise;
+        });
+
+        await then('the console was untouched at entry to each comparison call', () => {
+          // Fails for a synchronous swap-and-restore around the dependency
+          // call, which the outside-the-call assertions below cannot see.
+          expect(entryIdentities).toHaveLength(2);
+          for (const identities of entryIdentities) {
+            expect(identities.log).toBe(initialConsoleLog);
+            expect(identities.warn).toBe(initialConsoleWarn);
+            expect(identities.error).toBe(initialConsoleError);
+          }
         });
 
         await then('console.log is untouched while both comparisons are in flight', () => {


### PR DESCRIPTION
Closes #820.

Follow-up to PR #812 / issue #809, addressing both findings from the post-merge Codex peer review (plus its minor third point).

## What changed

**P1 — `DOCX_COMPARISON_DEBUG` diagnostics now go to stderr.**
`debug()` in `packages/docx-compare/src/baselines/atomizer/debug.ts` emitted enabled diagnostics via `console.log`. The MCP server owns stdout for newline-delimited JSON-RPC, so enabling the variable documented in `debug.ts`'s own header corrupted the client's protocol stream (reproduced: the stdio cleanliness test fails with exit 1 and `non-JSON line on the stdio protocol stream: [...] [DEBUG] [hierarchicalLcs] ...`). `debug()` now emits via `console.error`; the opt-in gating and the existing `warn`/`error` streams are untouched, and no process-global console monkeypatch is introduced anywhere. A new unit test (`debug.test.ts`) pins every logger level to its stream.

**P2 — a deterministic regression for the #809 race itself.**
The merged stdio test could not pin the old `runWithoutConsoleLog` defect: MCP responses are written with `process.stdout.write`, so the protocol stream stays clean even with `console.log` permanently replaced by a no-op (verified: reintroducing the wrapper left the test passing). New test `compare_documents_console_identity.test.ts` mocks the comparison dependency so both `compareDocuments_tool` calls can be paused inside the comparison simultaneously — the exact interleaving that reproduced #809, with no timing dependence — and asserts `console.log` retains strict identity mid-flight and after both calls complete. Red-checked: reintroducing the exact old wrapper fails it deterministically.

**End-to-end coverage for the debug path.** The stdio suite gains a second real-server test that runs `compare_documents` with `DOCX_COMPARISON_DEBUG=1` and asserts every stdout line parses as JSON-RPC while the diagnostics appear on stderr (red-checked by reverting `debug()` to `console.log` and rebuilding — it fails with the exact corruption line).

**Wording + stale-dist (finding 3).** The stdio test no longer claims a deterministic overlap it does not establish, and its header documents that standalone runs resolve `@usejunior/docx-compare`/`docx-core` to `dist/` and require a fresh `npm run build` at the repo root. The end-to-end test intentionally keeps exercising real package resolution rather than importing private comparison source.

## Verification

- `DOCX_COMPARISON_DEBUG=1` stdio test: red on old `debug.ts` (exit 1, `non-JSON line ... [DEBUG] [hierarchicalLcs]`), green on this branch.
- Console-identity test: red with the old wrapper reintroduced (`AssertionError: expected [Function] to be [Function log]` at the mid-flight identity check), green on this branch.
- Full gate green locally: `npm run build`, `npm run lint:workspaces`, `npm run test:run` (all packages, 0 failures), `npm run check:spec-coverage`, `npm run check:conformance-citations`, `npm run check:conformance-doc`.
