### PR TITLE
feat(docx-comparison): add side-tagged alignment evidence

### DIFF
--- a/openspec/changes/refactor-tagged-tree-redline-construction/tasks.md
+++ b/openspec/changes/refactor-tagged-tree-redline-construction/tasks.md
@@ -4,19 +4,19 @@ in `proposal.md` and are separate changes.
 
 ## 1. Representation and projections (no production caller)
 
-- [ ] 1.1 Add `TaggedNode` / `TaggedTree` to
+- [x] 1.1 Add `TaggedNode` / `TaggedTree` to
       `packages/docx-compare/src/baselines/atomizer/taggedTree.ts`, with `both`
       carrying **both** side representatives plus an optional scoped
       `PropertyDelta`.
-- [ ] 1.2 Define `PropertyDelta` by scope (run, paragraph mark, paragraph, row,
+- [x] 1.2 Define `PropertyDelta` by scope (run, paragraph mark, paragraph, row,
       cell, section), recording direct OOXML snapshots per side. Do not resolve
       through the style chain or `docDefaults` — out of scope.
-- [ ] 1.3 Implement `project(tree, side)` as a total fold.
-- [ ] 1.4 Implement the P1-P5 isomorphism checks against an
+- [x] 1.3 Implement `project(tree, side)` as a total fold.
+- [x] 1.4 Implement the P1-P5 isomorphism checks against an
       (original, revised, tree) triple, without serialization.
-- [ ] 1.5 Property-test P1-P5, including the rejected-counterexample case:
+- [x] 1.5 Property-test P1-P5, including the rejected-counterexample case:
       original `[A,B]`, revised `[B,A]`, tree `[both(B),both(A)]` must fail P2.
-- [ ] 1.6 Add the `TEST_FEATURE` constant and single-line `.openspec(...)` tags
+- [x] 1.6 Add the `TEST_FEATURE` constant and single-line `.openspec(...)` tags
       for the new scenarios in a dedicated test file (one feature per file), and
       regenerate the traceability matrix — never hand-edit it.
 

--- a/packages/docx-compare/src/baselines/atomizer/atomLcs.ts
+++ b/packages/docx-compare/src/baselines/atomizer/atomLcs.ts
@@ -85,23 +85,34 @@ export function tagAtomLcs(
   granularity: AlignmentGranularity,
 ): TaggedAtomLcsResult {
   const alignments: TaggedAtomAlignment[] = [];
-  const matchesByOriginal = new Map(lcs.matches.map((match) => [match.originalIndex, match]));
-  const deleted = new Set(lcs.deletedIndices);
-  const inserted = new Set(lcs.insertedIndices);
+  // Hierarchical similarity can pair crossing groups. A flat tagged stream
+  // cannot represent both crossing pairs without reversing one projection, so
+  // preserve the legacy LCS evidence but emit those pairs side-only here.
+  const matchesByOriginal = new Map<number, AtomMatch>();
+  const matchedOriginal = new Set<number>();
+  const matchedRevised = new Set<number>();
+  let previousRevisedIndex = -1;
+  for (const match of [...lcs.matches].sort((a, b) => a.originalIndex - b.originalIndex)) {
+    if (match.revisedIndex <= previousRevisedIndex) continue;
+    matchesByOriginal.set(match.originalIndex, match);
+    matchedOriginal.add(match.originalIndex);
+    matchedRevised.add(match.revisedIndex);
+    previousRevisedIndex = match.revisedIndex;
+  }
   let originalIndex = 0;
   let revisedIndex = 0;
 
   while (originalIndex < original.length || revisedIndex < revised.length) {
-    while (originalIndex < original.length && deleted.has(originalIndex)) {
+    while (originalIndex < original.length && !matchedOriginal.has(originalIndex)) {
       const atom = original[originalIndex++]!;
       alignments.push({ tag: 'original', original: atom, originalProvenance: revisionProvenance(atom.contentElement), revisedProvenance: [] });
     }
-    while (revisedIndex < revised.length && inserted.has(revisedIndex)) {
+    while (revisedIndex < revised.length && !matchedRevised.has(revisedIndex)) {
       const atom = revised[revisedIndex++]!;
       alignments.push({ tag: 'revised', revised: atom, originalProvenance: [], revisedProvenance: revisionProvenance(atom.contentElement) });
     }
     const match = matchesByOriginal.get(originalIndex);
-    if (match) {
+    if (match && match.revisedIndex === revisedIndex) {
       const originalAtom = original[originalIndex++]!;
       const revisedAtom = revised[match.revisedIndex]!;
       revisedIndex = match.revisedIndex + 1;
@@ -113,8 +124,9 @@ export function tagAtomLcs(
       });
       continue;
     }
-    if (originalIndex < original.length) originalIndex++;
-    else if (revisedIndex < revised.length) revisedIndex++;
+    // The only remaining case is a revised-side unmatched node preceding a
+    // later match. It must be emitted first to preserve revised document order.
+    if (revisedIndex < revised.length) continue;
   }
   return { lcs, granularity, alignments };
 }

--- a/packages/docx-compare/src/baselines/atomizer/atomLcs.ts
+++ b/packages/docx-compare/src/baselines/atomizer/atomLcs.ts
@@ -9,6 +9,7 @@ import type { ComparisonUnitAtom } from '@usejunior/docx-core';
 import { CorrelationStatus } from '@usejunior/docx-core';
 import { EMPTY_PARAGRAPH_TAG, getIdentityId } from '../../atomizer.js';
 import { debug } from './debug.js';
+import { revisionProvenance, type PropertyDelta, type RevisionProvenance } from './taggedTree.js';
 
 /**
  * Represents a match between atoms in original and revised documents.
@@ -30,6 +31,95 @@ export interface LcsResult {
   deletedIndices: number[];
   /** Indices of atoms only in revised (inserted) */
   insertedIndices: number[];
+}
+
+/** The atomization unit used before this alignment was run. */
+export type AlignmentGranularity = 'run' | 'word';
+
+/** A side-tagged counterpart of an LCS result that leaves LCS matching untouched. */
+export interface TaggedAtomAlignment {
+  tag: 'both' | 'original' | 'revised';
+  original?: ComparisonUnitAtom;
+  revised?: ComparisonUnitAtom;
+  propertyDelta?: PropertyDelta;
+  originalProvenance: RevisionProvenance[];
+  revisedProvenance: RevisionProvenance[];
+}
+
+export interface TaggedAtomLcsResult {
+  lcs: LcsResult;
+  granularity: AlignmentGranularity;
+  alignments: TaggedAtomAlignment[];
+}
+
+function directRunDelta(
+  original: ComparisonUnitAtom,
+  revised: ComparisonUnitAtom,
+): PropertyDelta | undefined {
+  const originalProps = original.rPr ?? null;
+  const revisedProps = revised.rPr ?? null;
+  const originalXml = originalProps?.toString() ?? '';
+  const revisedXml = revisedProps?.toString() ?? '';
+  if (originalXml === revisedXml) return undefined;
+  return {
+    scope: 'run',
+    original: originalProps,
+    revised: revisedProps,
+    changedProperties: ['directRunProperties'],
+  };
+}
+
+/**
+ * Emit side tags from the existing LCS result without changing its equality,
+ * tie-breaking, or status-mutating consumer path.
+ */
+export function tagAtomLcs(
+  original: ComparisonUnitAtom[],
+  revised: ComparisonUnitAtom[],
+  lcs: LcsResult,
+  granularity: AlignmentGranularity,
+): TaggedAtomLcsResult {
+  const alignments: TaggedAtomAlignment[] = [];
+  for (const match of lcs.matches) {
+    const originalAtom = original[match.originalIndex]!;
+    const revisedAtom = revised[match.revisedIndex]!;
+    alignments.push({
+      tag: 'both',
+      original: originalAtom,
+      revised: revisedAtom,
+      propertyDelta: directRunDelta(originalAtom, revisedAtom),
+      originalProvenance: revisionProvenance(originalAtom.contentElement),
+      revisedProvenance: revisionProvenance(revisedAtom.contentElement),
+    });
+  }
+  for (const index of lcs.deletedIndices) {
+    const atom = original[index]!;
+    alignments.push({
+      tag: 'original',
+      original: atom,
+      originalProvenance: revisionProvenance(atom.contentElement),
+      revisedProvenance: [],
+    });
+  }
+  for (const index of lcs.insertedIndices) {
+    const atom = revised[index]!;
+    alignments.push({
+      tag: 'revised',
+      revised: atom,
+      originalProvenance: [],
+      revisedProvenance: revisionProvenance(atom.contentElement),
+    });
+  }
+  return { lcs, granularity, alignments };
+}
+
+/** Run the existing matcher and return its independent side-tagged evidence. */
+export function computeTaggedAtomLcs(
+  original: ComparisonUnitAtom[],
+  revised: ComparisonUnitAtom[],
+  granularity: AlignmentGranularity = 'run',
+): TaggedAtomLcsResult {
+  return tagAtomLcs(original, revised, computeAtomLcs(original, revised), granularity);
 }
 
 /**

--- a/packages/docx-compare/src/baselines/atomizer/atomLcs.ts
+++ b/packages/docx-compare/src/baselines/atomizer/atomLcs.ts
@@ -9,7 +9,12 @@ import type { ComparisonUnitAtom } from '@usejunior/docx-core';
 import { CorrelationStatus } from '@usejunior/docx-core';
 import { EMPTY_PARAGRAPH_TAG, getIdentityId } from '../../atomizer.js';
 import { debug } from './debug.js';
-import { revisionProvenance, type PropertyDelta, type RevisionProvenance } from './taggedTree.js';
+import {
+  revisionProvenance,
+  subtreeSignature,
+  type PropertyDelta,
+  type RevisionProvenance,
+} from './taggedTree.js';
 
 /**
  * Represents a match between atoms in original and revised documents.
@@ -58,8 +63,8 @@ function directRunDelta(
 ): PropertyDelta | undefined {
   const originalProps = original.rPr ?? null;
   const revisedProps = revised.rPr ?? null;
-  const originalXml = originalProps?.toString() ?? '';
-  const revisedXml = revisedProps?.toString() ?? '';
+  const originalXml = originalProps ? subtreeSignature(originalProps) : '';
+  const revisedXml = revisedProps ? subtreeSignature(revisedProps) : '';
   if (originalXml === revisedXml) return undefined;
   return {
     scope: 'run',
@@ -80,35 +85,36 @@ export function tagAtomLcs(
   granularity: AlignmentGranularity,
 ): TaggedAtomLcsResult {
   const alignments: TaggedAtomAlignment[] = [];
-  for (const match of lcs.matches) {
-    const originalAtom = original[match.originalIndex]!;
-    const revisedAtom = revised[match.revisedIndex]!;
-    alignments.push({
-      tag: 'both',
-      original: originalAtom,
-      revised: revisedAtom,
-      propertyDelta: directRunDelta(originalAtom, revisedAtom),
-      originalProvenance: revisionProvenance(originalAtom.contentElement),
-      revisedProvenance: revisionProvenance(revisedAtom.contentElement),
-    });
-  }
-  for (const index of lcs.deletedIndices) {
-    const atom = original[index]!;
-    alignments.push({
-      tag: 'original',
-      original: atom,
-      originalProvenance: revisionProvenance(atom.contentElement),
-      revisedProvenance: [],
-    });
-  }
-  for (const index of lcs.insertedIndices) {
-    const atom = revised[index]!;
-    alignments.push({
-      tag: 'revised',
-      revised: atom,
-      originalProvenance: [],
-      revisedProvenance: revisionProvenance(atom.contentElement),
-    });
+  const matchesByOriginal = new Map(lcs.matches.map((match) => [match.originalIndex, match]));
+  const deleted = new Set(lcs.deletedIndices);
+  const inserted = new Set(lcs.insertedIndices);
+  let originalIndex = 0;
+  let revisedIndex = 0;
+
+  while (originalIndex < original.length || revisedIndex < revised.length) {
+    while (originalIndex < original.length && deleted.has(originalIndex)) {
+      const atom = original[originalIndex++]!;
+      alignments.push({ tag: 'original', original: atom, originalProvenance: revisionProvenance(atom.contentElement), revisedProvenance: [] });
+    }
+    while (revisedIndex < revised.length && inserted.has(revisedIndex)) {
+      const atom = revised[revisedIndex++]!;
+      alignments.push({ tag: 'revised', revised: atom, originalProvenance: [], revisedProvenance: revisionProvenance(atom.contentElement) });
+    }
+    const match = matchesByOriginal.get(originalIndex);
+    if (match) {
+      const originalAtom = original[originalIndex++]!;
+      const revisedAtom = revised[match.revisedIndex]!;
+      revisedIndex = match.revisedIndex + 1;
+      alignments.push({
+        tag: 'both', original: originalAtom, revised: revisedAtom,
+        propertyDelta: directRunDelta(originalAtom, revisedAtom),
+        originalProvenance: revisionProvenance(originalAtom.contentElement),
+        revisedProvenance: revisionProvenance(revisedAtom.contentElement),
+      });
+      continue;
+    }
+    if (originalIndex < original.length) originalIndex++;
+    else if (revisedIndex < revised.length) revisedIndex++;
   }
   return { lcs, granularity, alignments };
 }

--- a/packages/docx-compare/src/baselines/atomizer/hierarchicalLcs.ts
+++ b/packages/docx-compare/src/baselines/atomizer/hierarchicalLcs.ts
@@ -15,7 +15,13 @@
 import type { ComparisonUnitAtom } from '@usejunior/docx-core';
 import { CorrelationStatus } from '@usejunior/docx-core';
 import { EMPTY_PARAGRAPH_TAG, getIdentityId, IdentityInterner } from '../../atomizer.js';
-import { computeAtomLcs, type LcsResult } from './atomLcs.js';
+import {
+  computeAtomLcs,
+  tagAtomLcs,
+  type AlignmentGranularity,
+  type LcsResult,
+  type TaggedAtomLcsResult,
+} from './atomLcs.js';
 import { debug } from './debug.js';
 
 /**
@@ -1025,6 +1031,21 @@ export function hierarchicalCompare(
     deletedIndices,
     insertedIndices,
   };
+}
+
+/**
+ * Additive side-tagged evidence for the existing hierarchical alignment.
+ * The legacy LCS result remains the authoritative output consumed by the
+ * correlation-status path.
+ */
+export function hierarchicalCompareTagged(
+  originalAtoms: ComparisonUnitAtom[],
+  revisedAtoms: ComparisonUnitAtom[],
+  options: HierarchicalCompareOptions = {},
+  granularity: AlignmentGranularity = 'run',
+): TaggedAtomLcsResult {
+  const lcs = hierarchicalCompare(originalAtoms, revisedAtoms, options);
+  return tagAtomLcs(originalAtoms, revisedAtoms, lcs, granularity);
 }
 
 /**

--- a/packages/docx-compare/src/baselines/atomizer/pipeline.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline.ts
@@ -165,7 +165,7 @@ export interface AtomizerOptions {
    * - 'rebuild': rebuild document.xml from atoms (best reject/accept idempotency)
    * - 'inplace': modify the revised document AST in place (experimental)
    *
-   * Default: 'rebuild'
+   * Default: {@link DEFAULT_RECONSTRUCTION_MODE}.
    */
   reconstructionMode?: ReconstructionMode;
   /** Optional Lean 4 XML triple verifier for inplace outputs. */

--- a/packages/docx-compare/src/baselines/atomizer/taggedAtomLcs.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/taggedAtomLcs.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect } from 'vitest';
+import { CorrelationStatus, type ComparisonUnitAtom } from '@usejunior/docx-core';
+import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
+import { el } from '../../testing/dom-test-helpers.js';
+import { computeTaggedAtomLcs } from './atomLcs.js';
+
+const TEST_FEATURE = 'Tagged Atom LCS';
+const test = testAllure.epic('Document Comparison').withLabels({ feature: TEST_FEATURE });
+
+function atom(text: string, runProperties: Element | null = null): ComparisonUnitAtom {
+  const content = el('w:t', {}, undefined, text);
+  const run = el('w:r', {}, runProperties ? [runProperties, content] : [content]);
+  el('w:p', {}, [run]);
+  return {
+    contentElement: content,
+    ancestorElements: [run],
+    ancestorUnids: [],
+    part: { uri: 'word/document.xml', contentType: 'application/xml' },
+    sha1Hash: text,
+    correlationStatus: CorrelationStatus.Unknown,
+    rPr: runProperties,
+  };
+}
+
+describe('tagged atom LCS', () => {
+  test.allure({ story: 'formatting-only matches remain both-tagged' })(
+    'a formatting-only difference remains one both alignment with a direct property delta',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      const original = atom('settled text');
+      const revised = atom('settled text', el('w:rPr', {}, [el('w:b')]));
+      let result!: ReturnType<typeof computeTaggedAtomLcs>;
+
+      await given('equal text with different direct run properties', () => {
+        expect(original.contentElement.textContent).toBe(revised.contentElement.textContent);
+      });
+
+      await when('the existing LCS is tagged without rerunning matching', () => {
+        result = computeTaggedAtomLcs([original], [revised], 'word');
+      });
+
+      await then('the unchanged LCS result has one match and no delete or insert', () => {
+        expect(result.lcs).toEqual({
+          matches: [{ originalIndex: 0, revisedIndex: 0 }],
+          deletedIndices: [],
+          insertedIndices: [],
+        });
+      });
+
+      await and('the tag preserves both representatives and a direct run delta', () => {
+        expect(result.granularity).toBe('word');
+        expect(result.alignments).toHaveLength(1);
+        expect(result.alignments[0]).toMatchObject({ tag: 'both', original, revised });
+        expect(result.alignments[0]?.propertyDelta?.scope).toBe('run');
+      });
+    },
+  );
+
+  test.allure({ story: 'pre-existing insertion provenance survives alignment boundaries' })(
+    'each original-side fragment retains its prior author and date',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      const originalMatched = atom('kept');
+      const originalDeleted = atom('removed');
+      const originalInsertion = el(
+        'w:ins',
+        { 'w:id': '17', 'w:author': 'Prior Author', 'w:date': '2024-03-04T05:06:07Z' },
+        [originalMatched.ancestorElements[0]!, originalDeleted.ancestorElements[0]!],
+      );
+      el('w:p', {}, [originalInsertion]);
+      const revisedMatched = atom('kept');
+      let result!: ReturnType<typeof computeTaggedAtomLcs>;
+
+      await given('a comparison boundary inside one original pre-existing insertion', () => {
+        expect(originalInsertion.textContent).toBe('keptremoved');
+      });
+
+      await when('one atom matches and its sibling is deleted by the comparison', () => {
+        result = computeTaggedAtomLcs([originalMatched, originalDeleted], [revisedMatched]);
+      });
+
+      await then('the matched and deleted fragments both retain the original insertion metadata', () => {
+        for (const alignment of result.alignments) {
+          expect(alignment.originalProvenance).toEqual([
+            {
+              kind: 'w:ins',
+              id: '17',
+              author: 'Prior Author',
+              date: '2024-03-04T05:06:07Z',
+            },
+          ]);
+        }
+      });
+
+      await and('only the unmatched fragment is original-sided', () => {
+        expect(result.alignments.map((alignment) => alignment.tag).sort()).toEqual(['both', 'original']);
+      });
+    },
+  );
+});

--- a/packages/docx-compare/src/baselines/atomizer/taggedAtomLcs.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/taggedAtomLcs.test.ts
@@ -2,7 +2,7 @@ import { describe, expect } from 'vitest';
 import { CorrelationStatus, type ComparisonUnitAtom } from '@usejunior/docx-core';
 import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
 import { el } from '../../testing/dom-test-helpers.js';
-import { computeTaggedAtomLcs } from './atomLcs.js';
+import { computeTaggedAtomLcs, tagAtomLcs } from './atomLcs.js';
 import { hierarchicalCompare, hierarchicalCompareTagged } from './hierarchicalLcs.js';
 import { nextRevisionId } from './taggedTree.js';
 
@@ -134,6 +134,30 @@ describe('tagged atom LCS', () => {
 
       await then('the tagged wrapper exposes the unmodified legacy LCS result', () => {
         expect(tagged.lcs).toEqual(legacy);
+      });
+    },
+  );
+
+  test.allure({ story: 'crossing matches never reverse a tagged projection' })(
+    'crossing legacy matches remain evidence but become side-only tags',
+    async ({ when, then }: AllureBddContext) => {
+      const original = [atom('O0'), atom('O1')];
+      const revised = [atom('R0'), atom('R1')];
+      let result!: ReturnType<typeof tagAtomLcs>;
+
+      await when('a hierarchical similarity pass supplies crossing matches', () => {
+        result = tagAtomLcs(original, revised, {
+          matches: [{ originalIndex: 0, revisedIndex: 1 }, { originalIndex: 1, revisedIndex: 0 }],
+          deletedIndices: [],
+          insertedIndices: [],
+        }, 'run');
+      });
+
+      await then('the legacy result remains intact but tags preserve each side order', () => {
+        expect(result.lcs.matches).toHaveLength(2);
+        expect(result.alignments.map((alignment) => alignment.tag)).toEqual(['revised', 'both', 'original']);
+        expect(result.alignments.flatMap((alignment) => alignment.original?.contentElement.textContent ?? [])).toEqual(['O0', 'O1']);
+        expect(result.alignments.flatMap((alignment) => alignment.revised?.contentElement.textContent ?? [])).toEqual(['R0', 'R1']);
       });
     },
   );

--- a/packages/docx-compare/src/baselines/atomizer/taggedAtomLcs.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/taggedAtomLcs.test.ts
@@ -3,6 +3,8 @@ import { CorrelationStatus, type ComparisonUnitAtom } from '@usejunior/docx-core
 import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
 import { el } from '../../testing/dom-test-helpers.js';
 import { computeTaggedAtomLcs } from './atomLcs.js';
+import { hierarchicalCompare, hierarchicalCompareTagged } from './hierarchicalLcs.js';
+import { nextRevisionId } from './taggedTree.js';
 
 const TEST_FEATURE = 'Tagged Atom LCS';
 const test = testAllure.epic('Document Comparison').withLabels({ feature: TEST_FEATURE });
@@ -49,7 +51,9 @@ describe('tagged atom LCS', () => {
       await and('the tag preserves both representatives and a direct run delta', () => {
         expect(result.granularity).toBe('word');
         expect(result.alignments).toHaveLength(1);
-        expect(result.alignments[0]).toMatchObject({ tag: 'both', original, revised });
+        expect(result.alignments[0]?.tag).toBe('both');
+        expect(result.alignments[0]?.original).toBe(original);
+        expect(result.alignments[0]?.revised).toBe(revised);
         expect(result.alignments[0]?.propertyDelta?.scope).toBe('run');
       });
     },
@@ -92,6 +96,78 @@ describe('tagged atom LCS', () => {
 
       await and('only the unmatched fragment is original-sided', () => {
         expect(result.alignments.map((alignment) => alignment.tag).sort()).toEqual(['both', 'original']);
+      });
+    },
+  );
+
+  test.allure({ story: 'tagged alignment preserves comparison order' })(
+    'deleted and inserted atoms remain between their matched neighbors',
+    async ({ when, then }: AllureBddContext) => {
+      const original = [atom('A'), atom('X'), atom('B')];
+      const revised = [atom('A'), atom('Y'), atom('B')];
+      let tags: string[] = [];
+
+      await when('both atom and hierarchical alignment emit tags for an inline replacement', () => {
+        tags = computeTaggedAtomLcs(original, revised).alignments.map((alignment) => alignment.tag);
+      });
+
+      await then('the tags retain source order around the replacement boundary', () => {
+        expect(tags).toEqual(['both', 'original', 'revised', 'both']);
+      });
+    },
+  );
+
+  test.allure({ story: 'hierarchical tags retain the legacy group alignment' })(
+    'the tagged wrapper exposes exactly the hierarchical matcher result',
+    async ({ when, then }: AllureBddContext) => {
+      const original = [atom('A'), atom('X'), atom('B')];
+      const revised = [atom('A'), atom('Y'), atom('B')];
+      original.forEach((value) => { value.paragraphIndex = 0; });
+      revised.forEach((value) => { value.paragraphIndex = 0; });
+      let tagged!: ReturnType<typeof hierarchicalCompareTagged>;
+      let legacy!: ReturnType<typeof hierarchicalCompare>;
+
+      await when('the hierarchical matcher and tagged wrapper receive the same grouped atoms', () => {
+        legacy = hierarchicalCompare(original, revised);
+        tagged = hierarchicalCompareTagged(original, revised);
+      });
+
+      await then('the tagged wrapper exposes the unmodified legacy LCS result', () => {
+        expect(tagged.lcs).toEqual(legacy);
+      });
+    },
+  );
+
+  test.allure({ story: 'equivalent direct properties do not create a delta' })(
+    'attribute order alone does not create formatting evidence',
+    async ({ when, then }: AllureBddContext) => {
+      const original = atom('same', el('w:rPr', { 'w:rsidRPr': '1', 'w:lang': 'en-US' }));
+      const revised = atom('same', el('w:rPr', { 'w:lang': 'en-US', 'w:rsidRPr': '1' }));
+      let delta: unknown;
+
+      await when('the property order differs only lexically', () => {
+        delta = computeTaggedAtomLcs([original], [revised]).alignments[0]?.propertyDelta;
+      });
+
+      await then('no direct formatting delta is emitted', () => {
+        expect(delta).toBeUndefined();
+      });
+    },
+  );
+
+  test.allure({ story: 'revision IDs reserve all surviving markup IDs' })(
+    'the first allocation skips root, marker, and property-change aliases',
+    async ({ when, then }: AllureBddContext) => {
+      const original = el('w:ins', { 'w:id': '1' }, [el('w:rPrChange', { 'w:id': '+2' })]);
+      const revised = el('w:body', {}, [el('w:moveFromRangeStart', { 'w:id': '03' })]);
+      let next = 0;
+
+      await when('both roots contribute surviving revision-related markup', () => {
+        next = nextRevisionId(original, revised);
+      });
+
+      await then('the allocator skips every canonical numeric ID', () => {
+        expect(next).toBe(4);
       });
     },
   );

--- a/packages/docx-compare/src/baselines/atomizer/taggedTree.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/taggedTree.test.ts
@@ -364,8 +364,8 @@ describe('side-tagged comparison tree', () => {
         ]);
       });
 
-      await and('comparison revisions allocate after every identifier already present in either input', () => {
-        expect(firstAllocatedId).toBe(43);
+      await and('comparison revisions allocate the first identifier not present in either input', () => {
+        expect(firstAllocatedId).toBe(1);
       });
     },
   );

--- a/packages/docx-compare/src/baselines/atomizer/taggedTree.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/taggedTree.test.ts
@@ -4,7 +4,9 @@ import { testAllure, type AllureBddContext } from '../../testing/allure-test.js'
 import { el } from '../../testing/dom-test-helpers.js';
 import {
   assertTaggedTree,
+  nextRevisionId,
   project,
+  revisionProvenance,
   ProjectionContractError,
   verifyTaggedTree,
   type BothNode,
@@ -314,6 +316,56 @@ describe('side-tagged comparison tree', () => {
 
       await and('the assert form throws rather than letting the tree continue', () => {
         expect(() => assertTaggedTree(original, revised, tree)).toThrow(ProjectionContractError);
+      });
+    },
+  );
+
+  test.openspec('Pre-existing tracked changes are represented by construction invariants')(
+    'aligned content retains each side revision nesting and reserves non-colliding IDs',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      const originalText = el('w:t', {}, undefined, 'shared');
+      const revisedText = el('w:t', {}, undefined, 'shared');
+      const original = el('w:body', {}, [
+        el('w:ins', { 'w:id': '17', 'w:author': 'Original Author', 'w:date': '2024-01-01T00:00:00Z' }, [
+          el('w:del', { 'w:id': '18', 'w:author': 'Second Original Author', 'w:date': '2024-01-02T00:00:00Z' }, [
+            el('w:r', {}, [originalText]),
+          ]),
+        ]),
+      ]);
+      const revised = el('w:body', {}, [
+        el('w:ins', { 'w:id': '42', 'w:author': 'Revised Author', 'w:date': '2024-02-01T00:00:00Z' }, [
+          el('w:r', {}, [revisedText]),
+        ]),
+      ]);
+      let originalProvenance: ReturnType<typeof revisionProvenance> = [];
+      let revisedProvenance: ReturnType<typeof revisionProvenance> = [];
+      let firstAllocatedId = 0;
+
+      await given('matched content under stacked revisions from multiple authors', () => {
+        expect(originalText.textContent).toBe(revisedText.textContent);
+      });
+
+      await when('the aligner captures each input side revision lineage', () => {
+        originalProvenance = revisionProvenance(originalText);
+        revisedProvenance = revisionProvenance(revisedText);
+        firstAllocatedId = nextRevisionId(original, revised);
+      });
+
+      await then('the original lineage preserves nesting, author, and date on every boundary fragment', () => {
+        expect(originalProvenance).toEqual([
+          { kind: 'w:ins', id: '17', author: 'Original Author', date: '2024-01-01T00:00:00Z' },
+          { kind: 'w:del', id: '18', author: 'Second Original Author', date: '2024-01-02T00:00:00Z' },
+        ]);
+      });
+
+      await and('the revised lineage remains independently available to the serializer', () => {
+        expect(revisedProvenance).toEqual([
+          { kind: 'w:ins', id: '42', author: 'Revised Author', date: '2024-02-01T00:00:00Z' },
+        ]);
+      });
+
+      await and('comparison revisions allocate after every identifier already present in either input', () => {
+        expect(firstAllocatedId).toBe(43);
       });
     },
   );

--- a/packages/docx-compare/src/baselines/atomizer/taggedTree.ts
+++ b/packages/docx-compare/src/baselines/atomizer/taggedTree.ts
@@ -115,15 +115,22 @@ export function revisionProvenance(element: WmlElement): RevisionProvenance[] {
  * authors or revision kinds with the same decimal identifier.
  */
 export function nextRevisionId(originalRoot: WmlElement, revisedRoot: WmlElement): number {
-  let max = 0;
+  const used = new Set<string>();
   for (const root of [originalRoot, revisedRoot]) {
-    for (const wrapper of Array.from(root.getElementsByTagName('*'))) {
-      if (!REVISION_WRAPPER_TAGS.has(wrapper.tagName as RevisionProvenance['kind'])) continue;
-      const id = Number(wrapper.getAttribute('w:id'));
-      if (Number.isSafeInteger(id) && id >= max) max = id + 1;
+    const elements = [root, ...Array.from(root.getElementsByTagName('*'))];
+    for (const element of elements) {
+      const rawId = element.getAttribute('w:id');
+      if (rawId === null || !/^[+-]?\d+$/.test(rawId.trim())) continue;
+      try {
+        used.add(BigInt(rawId.trim()).toString());
+      } catch {
+        // Ignore values outside BigInt's grammar, matching the live allocator.
+      }
     }
   }
-  return max;
+  let next = 1;
+  while (used.has(String(next))) next++;
+  return next;
 }
 
 /**
@@ -277,7 +284,7 @@ const SIGNATURE_SEPARATOR = '\u0001';
  * `a="x b=y"` and `a="x" b="y"` collapse to the same string — and a false
  * equality here silently passes a wrong projection.
  */
-function elementSignature(element: WmlElement): string {
+export function elementSignature(element: WmlElement): string {
   const attrs: Array<[string, string, string]> = [];
   const attributes = element.attributes;
   for (let i = 0; i < attributes.length; i++) {
@@ -316,7 +323,7 @@ function elementSignature(element: WmlElement): string {
  * processing instructions do not participate. Content that depends on those
  * distinctions surviving must not be modeled as opaque payload here.
  */
-function subtreeSignature(element: WmlElement): string {
+export function subtreeSignature(element: WmlElement): string {
   const parts: string[] = [elementSignature(element)];
   for (const child of childElements(element)) {
     parts.push(subtreeSignature(child));

--- a/packages/docx-compare/src/baselines/atomizer/taggedTree.ts
+++ b/packages/docx-compare/src/baselines/atomizer/taggedTree.ts
@@ -71,6 +71,61 @@ export interface PropertyDelta {
   changedProperties: string[];
 }
 
+/** Metadata retained from an input revision wrapper rather than flattened into text. */
+export interface RevisionProvenance {
+  kind: 'w:ins' | 'w:del' | 'w:moveFrom' | 'w:moveTo';
+  id: string | null;
+  author: string | null;
+  date: string | null;
+}
+
+const REVISION_WRAPPER_TAGS = new Set<RevisionProvenance['kind']>([
+  'w:ins',
+  'w:del',
+  'w:moveFrom',
+  'w:moveTo',
+]);
+
+/**
+ * Return the enclosing input revision wrappers from outermost to innermost.
+ *
+ * This is construction metadata: serializers decide how a comparison revision
+ * nests inside it, while projections continue to use the side representative.
+ */
+export function revisionProvenance(element: WmlElement): RevisionProvenance[] {
+  const wrappers: RevisionProvenance[] = [];
+  let current: Element | null = element;
+  while (current) {
+    if (REVISION_WRAPPER_TAGS.has(current.tagName as RevisionProvenance['kind'])) {
+      wrappers.unshift({
+        kind: current.tagName as RevisionProvenance['kind'],
+        id: current.getAttribute('w:id'),
+        author: current.getAttribute('w:author'),
+        date: current.getAttribute('w:date'),
+      });
+    }
+    current = current.parentElement;
+  }
+  return wrappers;
+}
+
+/**
+ * First safe ID for comparison revisions after examining both preserved inputs.
+ * Existing IDs are never reused, even when the two documents contain different
+ * authors or revision kinds with the same decimal identifier.
+ */
+export function nextRevisionId(originalRoot: WmlElement, revisedRoot: WmlElement): number {
+  let max = 0;
+  for (const root of [originalRoot, revisedRoot]) {
+    for (const wrapper of Array.from(root.getElementsByTagName('*'))) {
+      if (!REVISION_WRAPPER_TAGS.has(wrapper.tagName as RevisionProvenance['kind'])) continue;
+      const id = Number(wrapper.getAttribute('w:id'));
+      if (Number.isSafeInteger(id) && id >= max) max = id + 1;
+    }
+  }
+  return max;
+}
+
 /**
  * Fields shared by every tagged node.
  *

--- a/packages/docx-compare/src/compare-types.ts
+++ b/packages/docx-compare/src/compare-types.ts
@@ -22,7 +22,7 @@ export interface CompareOptions {
    * - 'rebuild': rebuild document.xml from scratch (more reject/accept stable)
    * - 'inplace': modify the revised document AST in place (more experimental)
    *
-   * Default: 'rebuild'
+   * Default: {@link DEFAULT_RECONSTRUCTION_MODE}.
    */
   reconstructionMode?: ReconstructionMode;
   /**


### PR DESCRIPTION
## Why

The redline pipeline currently has only a flat correlation-status representation. Stage A needs additive side-tagged evidence that preserves formatting and pre-existing revision provenance without changing the production reconstruction path.

## What Changed

- Adds side-tagged atom and hierarchical alignment APIs that delegate to the unchanged legacy LCS result.
- Preserves direct run-property deltas, pre-existing revision wrapper stacks, and collision-safe revision-ID allocation.
- Keeps tag streams projection-safe when hierarchical similarity returns crossing matches.
- Marks shipped tagged-tree representation tasks and corrects stale public reconstruction-default documentation.

## Evidence

- Codex dynamic peer review found and verified fixes for ordering, ID reservation, canonical direct-property comparison, and crossing-match projection safety. The final dynamic review reported no findings; raw execution traces remain in the development worktree under `.peer-review/`.
- `npm run test:run -w @usejunior/docx-compare`: 849 passed, 106 skipped.
- `npm run build -w @usejunior/docx-compare`: passed.
- `npm run check:spec-coverage`, `npm run check:allure-labels`, and `npm run check:allure-quality`: passed.
- `npx openspec validate refactor-tagged-tree-redline-construction --strict`: passed.
- Workspace lint remains blocked by unrelated current-main type errors in `docx-core` and missing `projectSymbolRun` exports.

Visual evidence: skipped. This is an additive, shadow-only data representation with no production caller and no rendered output.

Refs #814
