### PR TITLE
feat(docx-mcp): warn when an inserted run departs from the document's formatting convention

### DIFF
--- a/packages/docx-mcp/src/tools/ai_revision_guard.ts
+++ b/packages/docx-mcp/src/tools/ai_revision_guard.ts
@@ -6,6 +6,7 @@ import {
   type RevisionIdState,
 } from '@usejunior/docx-core';
 import { type DocxSession } from '../session/manager.js';
+import { checkFormattingConvention, type ConventionWarning } from './formatting_convention.js';
 import { err, type ToolResponse } from './types.js';
 
 function cloneRevisionIdState(state: RevisionIdState): RevisionIdState {
@@ -111,20 +112,30 @@ export function formatAiRevisionWarning(d: AiRevisionDiagnostic): string {
  * `blocked` is the historical `ToolResponse | null` contract: non-null means
  * validation rejected the mutation and the caller must return that response
  * without applying the edit. `warnings` carries the non-blocking diagnostics
- * that used to be structurally dropped on the success path (issue #686);
+ * that used to be structurally dropped on the success path (issue #686), plus
+ * any advisory findings computed off the same preview document (the
+ * formatting-convention check, issue #687);
  * callers should surface them on their success response as an optional
  * `warnings?: string[]` field. When `blocked` is set, `warnings` is empty —
  * the blocking response already carries the full diagnostics
  * (errors + warnings) in its `diagnostics` field.
+ *
+ * `conventionWarnings` is the *same* findings as the convention entries in
+ * `warnings`, in structured form — not an addition to them. A caller renders
+ * `warnings` and ignores this, or (like batch_edit, which must attribute a
+ * finding back to the step that produced it) reads this and ignores those.
+ * Reading both double-reports.
  */
 export type AiRevisionPreflightResult = {
   blocked: ToolResponse | null;
   warnings: string[];
+  conventionWarnings: ConventionWarning[];
 };
 
 const PREFLIGHT_PROCEED: AiRevisionPreflightResult = Object.freeze({
   blocked: null,
   warnings: [],
+  conventionWarnings: [],
 });
 
 const sessionBaselineDiagnostics = new WeakMap<DocxSession, Promise<Map<string, number>>>();
@@ -148,20 +159,59 @@ export function getAiRevisionBaseline(session: DocxSession): Promise<Map<string,
   return promise;
 }
 
+/**
+ * Non-validation advisories the caller wants computed off the same preview
+ * round trip. `insertedText` is the text the mutation adds; supplying it opts
+ * the mutation into the formatting-convention check (#687), which is skipped
+ * outright when the inserted text carries no construct the check knows about.
+ *
+ * It rides here rather than on its own document load because the preview load
+ * + mutate + validate round trip is already paid for on every AI-attributed
+ * edit (150–195 ms measured on #687); a full run scan adds 1–2 ms on top.
+ */
+export type AiRevisionPreflightAdvisories = {
+  insertedText?: string;
+};
+
 export async function preflightAiRevisionMutation(
   session: DocxSession,
   ctx: RevisionContext | undefined,
   mutatePreview: (doc: DocxDocument, ctx: RevisionContext | undefined) => Promise<void> | void,
   touched?: AiRevisionValidationTouchedContext,
+  advisories?: AiRevisionPreflightAdvisories,
 ): Promise<AiRevisionPreflightResult> {
   if (!session.aiAuthor) return PREFLIGHT_PROCEED;
 
   const snapshot = await session.doc.toBuffer({ cleanBookmarks: false });
+  // Two loads of the same bytes: `previewDoc` is mutated below, `baselineDoc`
+  // stays as the document was before this mutation so the convention check can
+  // difference them. Loading it from the same snapshot (rather than reusing
+  // `session.doc`) keeps both sides on identical run boundaries, so the
+  // difference reflects the edit and not a serialization artefact. It is only
+  // paid for when a caller actually requests the advisory.
   const previewDoc = await DocxDocument.load(snapshot.buffer);
+  const baselineDoc = advisories?.insertedText
+    ? await DocxDocument.load(snapshot.buffer)
+    : null;
   await mutatePreview(previewDoc, cloneRevisionContext(ctx));
   const validation = await previewDoc.validateAiRevisions(session.aiAuthor, touched);
+  // Advisory only, and never on the blocked path: a blocked mutation is not
+  // applied, so its formatting is not a finding the caller can act on.
+  const conventionWarnings =
+    advisories?.insertedText && baselineDoc
+      ? checkFormattingConvention(previewDoc, {
+          insertedText: advisories.insertedText,
+          aiAuthor: session.aiAuthor,
+          baselineDoc,
+        })
+      : [];
+  const conventionMessages = conventionWarnings.map((w) => w.message);
   if (validation.errors.length === 0) {
-    return { blocked: null, warnings: validation.warnings.map(formatAiRevisionWarning) };
+    return {
+      blocked: null,
+      warnings: [...validation.warnings.map(formatAiRevisionWarning), ...conventionMessages],
+      conventionWarnings,
+    };
   }
 
   // AI-attributed errors always fail. Unattributable errors (field structure,
@@ -186,7 +236,11 @@ export async function preflightAiRevisionMutation(
     // merge them into the surfaced warnings exactly as the failure path does.
     return {
       blocked: null,
-      warnings: [...validation.warnings, ...demoted].map(formatAiRevisionWarning),
+      warnings: [
+        ...[...validation.warnings, ...demoted].map(formatAiRevisionWarning),
+        ...conventionMessages,
+      ],
+      conventionWarnings,
     };
   }
 
@@ -196,5 +250,6 @@ export async function preflightAiRevisionMutation(
       warnings: [...validation.warnings, ...demoted],
     }),
     warnings: [],
+    conventionWarnings: [],
   };
 }

--- a/packages/docx-mcp/src/tools/batch_edit.ts
+++ b/packages/docx-mcp/src/tools/batch_edit.ts
@@ -14,6 +14,7 @@ import { replaceText, stripSearchTags } from './replace_text.js';
 import { insertParagraph } from './insert_paragraph.js';
 import { resolveSessionForTool } from './session_resolution.js';
 import { preflightAiRevisionMutation } from './ai_revision_guard.js';
+import { insertedConstructKeys, type ConventionWarning } from './formatting_convention.js';
 
 const REPLACE_TEXT_FIELDS = new Set([
   'target_paragraph_id',
@@ -484,6 +485,49 @@ function executeStepsOnDoc(doc: DocxDocument, steps: NormalizedStep[], ctx?: Rev
   for (const step of steps) executeStepOnDoc(doc, step, ctx);
 }
 
+/**
+ * Every step's inserted text, joined. The batch preflights once for the whole
+ * sequence, so the formatting-convention gate (#687) sees the sequence's
+ * inserted text as a unit; the newline join keeps one step's tail from fusing
+ * with the next step's head into a construct neither step contains.
+ */
+function collectInsertedText(steps: NormalizedStep[]): string {
+  return steps
+    .map((step) => step.fields.new_string)
+    .filter((value): value is string => typeof value === 'string')
+    .map((value) => stripSearchTags(value))
+    .join('\n');
+}
+
+/**
+ * Attribute each convention warning to the step whose inserted text carries
+ * that construct. The preflight runs once for the whole sequence, so the step
+ * is not otherwise recoverable — and batch_edit's `warnings` channel is
+ * per-step `{ step_id, warning }` entries, so an unattributed warning has
+ * nowhere to go. A warning that matches no step (possible only if a step's
+ * text and the document disagree) falls back to the first step rather than
+ * being dropped.
+ */
+function attributeConventionWarnings(
+  steps: NormalizedStep[],
+  warnings: ConventionWarning[],
+): Array<{ step_id: string; warning: string }> {
+  if (warnings.length === 0) return [];
+  const byStep = steps.map((step) => ({
+    stepId: step.step_id,
+    keys: insertedConstructKeys(
+      typeof step.fields.new_string === 'string' ? stripSearchTags(step.fields.new_string) : '',
+    ),
+  }));
+  const normalize = (value: string): string => value.trim().replace(/\s+/g, ' ').toLowerCase();
+
+  return warnings.map((warning) => {
+    const term = normalize(warning.term);
+    const owner = byStep.find((entry) => entry.keys.get(warning.construct)?.has(term));
+    return { step_id: owner?.stepId ?? byStep[0]?.stepId ?? '', warning: warning.message };
+  });
+}
+
 export async function batchEdit(
   manager: SessionManager,
   params: {
@@ -541,7 +585,9 @@ export async function batchEdit(
       };
     }
 
-    const allWarnings = validations.flatMap((v) => v.warnings.map((w) => ({ step_id: v.step_id, warning: w })));
+    const allWarnings: Array<{ step_id: string; warning: string }> = validations.flatMap((v) =>
+      v.warnings.map((w) => ({ step_id: v.step_id, warning: w })),
+    );
     const conflictSteps = buildConflictView(steps);
     const conflicts = [
       ...detectDuplicateStepIdConflicts(conflictSteps),
@@ -567,8 +613,14 @@ export async function batchEdit(
       session,
       ctx,
       (previewDoc, previewCtx) => executeStepsOnDoc(previewDoc, steps, previewCtx),
+      undefined,
+      { insertedText: collectInsertedText(steps) },
     );
     if (revisionPreflight.blocked) return revisionPreflight.blocked;
+    // Structured form only — `revisionPreflight.warnings` carries the same
+    // convention findings as flat strings, and reading both would report each
+    // finding twice.
+    allWarnings.push(...attributeConventionWarnings(steps, revisionPreflight.conventionWarnings));
 
     const result = await executeSteps(manager, manager.normalizePath(session.originalPath), steps, ctx);
     if (result.failed_step_id !== undefined) {

--- a/packages/docx-mcp/src/tools/formatting_convention.test.ts
+++ b/packages/docx-mcp/src/tools/formatting_convention.test.ts
@@ -1,0 +1,653 @@
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, expect } from 'vitest';
+import { DocxDocument, getParagraphRuns } from '@usejunior/docx-core';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { makeDocxWithDocumentXml } from '../testing/docx_test_utils.js';
+import { openSession, registerCleanup, assertSuccess } from '../testing/session-test-utils.js';
+import { SessionManager } from '../session/manager.js';
+import { replaceText } from './replace_text.js';
+import { insertParagraph } from './insert_paragraph.js';
+import { batchEdit } from './batch_edit.js';
+import {
+  DEFAULT_DOMINANCE_THRESHOLD,
+  DEFAULT_MIN_INSTANCES,
+  FORMATTING_CONVENTION_WARNING_CODE,
+  checkFormattingConvention,
+  findInlineDefinedTermSpans,
+  findProvisoKeywordSpans,
+  summarizeDocumentConvention,
+} from './formatting_convention.js';
+
+const test = testAllure
+  .epic('Document Editing')
+  .withLabels({ feature: 'Formatting Convention Check' });
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CORPUS = path.resolve(__dirname, '../../../../tests/test_documents');
+const NVCA_COI_SOURCE = path.join(CORPUS, 'nvca-coi-regression/source.docx');
+const ILPA_SOURCE = path.join(
+  CORPUS,
+  'redline/ILPA-Model-Limited-Parnership-Agreement-Deal-By-Deal_v1.docx',
+);
+
+const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const AI = 'SafeDocX AI';
+
+// ---------------------------------------------------------------------------
+// Synthetic fixtures
+//
+// Every fixture below is authored from scratch: generic parties, generic
+// obligations, no borrowed prose. The check compares run properties, so a
+// fixture only has to carry a consistent formatting pattern and a divergence
+// from it — nothing about any real document is needed to exercise that. The
+// two committed corpus documents are used only as read-only evidence that the
+// matcher finds real conventions in the wild.
+// ---------------------------------------------------------------------------
+
+type RunStyle = {
+  bold?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+  rStyle?: string;
+  boldOff?: boolean;
+};
+
+function rPr(style: RunStyle): string {
+  const parts: string[] = [];
+  if (style.rStyle) parts.push(`<w:rStyle w:val="${style.rStyle}"/>`);
+  if (style.boldOff) parts.push(`<w:b w:val="0"/>`);
+  if (style.bold) parts.push('<w:b/>');
+  if (style.italic) parts.push('<w:i/>');
+  if (style.underline) parts.push('<w:u w:val="single"/>');
+  return parts.length > 0 ? `<w:rPr>${parts.join('')}</w:rPr>` : '';
+}
+
+function docXml(body: string): string {
+  return (
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<w:document xmlns:w="${W_NS}"><w:body>${body}</w:body></w:document>`
+  );
+}
+
+/**
+ * A paragraph carrying one parenthetical defined term formatted as `style`.
+ * The quote marks deliberately sit in the neighbouring plain runs, which is
+ * the shape both corpus agreements use.
+ */
+function definedTermParagraph(index: number, style: RunStyle): string {
+  return (
+    `<w:p>` +
+    `<w:r><w:t xml:space="preserve">Section ${index}. The receiving party (the “</w:t></w:r>` +
+    `<w:r>${rPr(style)}<w:t>Term ${index}</w:t></w:r>` +
+    `<w:r><w:t xml:space="preserve">”) shall act reasonably.</w:t></w:r>` +
+    `</w:p>`
+  );
+}
+
+/** A paragraph carrying one semicolon-introduced proviso keyword. */
+function provisoParagraph(index: number, style: RunStyle): string {
+  return (
+    `<w:p>` +
+    `<w:r><w:t xml:space="preserve">Section ${index}. The party may assign; </w:t></w:r>` +
+    `<w:r>${rPr(style)}<w:t>provided</w:t></w:r>` +
+    `<w:r><w:t xml:space="preserve"> that notice is given.</w:t></w:r>` +
+    `</w:p>`
+  );
+}
+
+const TARGET_PLAIN =
+  `<w:p><w:r><w:t xml:space="preserve">The fee is payable on demand.</w:t></w:r></w:p>`;
+
+/** `w:ins` wrapper attributed to `author`; `runs` is raw run XML. */
+function ins(id: number, runs: string, author = AI): string {
+  return `<w:ins w:id="${id}" w:author="${author}" w:date="2026-08-12T00:00:00Z">${runs}</w:ins>`;
+}
+
+/** A paragraph whose defined term sits inside a `w:ins` attributed to `author`. */
+function insertedDefinedTermParagraph(style: RunStyle, opts?: { id?: number; author?: string }): string {
+  return (
+    `<w:p>` +
+    `<w:r><w:t xml:space="preserve">The fee is payable</w:t></w:r>` +
+    ins(
+      opts?.id ?? 900,
+      `<w:r>${rPr(style)}<w:t xml:space="preserve"> (each, a “Fee Item”)</w:t></w:r>`,
+      opts?.author ?? AI,
+    ) +
+    `<w:r><w:t xml:space="preserve"> on demand.</w:t></w:r>` +
+    `</w:p>`
+  );
+}
+
+/**
+ * Same insertion, but the defined term is split across two runs with different
+ * formatting and an equal share of the term's characters. Whichever fragment a
+ * "pick the dominant run" rule chose, the other one would go unreported.
+ */
+function insertedSplitDefinedTermParagraph(head: RunStyle, tail: RunStyle): string {
+  return (
+    `<w:p>` +
+    `<w:r><w:t xml:space="preserve">The fee is payable</w:t></w:r>` +
+    ins(
+      902,
+      `<w:r>${rPr(head)}<w:t xml:space="preserve"> (each, a “Fee </w:t></w:r>` +
+        `<w:r>${rPr(tail)}<w:t xml:space="preserve">Item”)</w:t></w:r>`,
+    ) +
+    `<w:r><w:t xml:space="preserve"> on demand.</w:t></w:r>` +
+    `</w:p>`
+  );
+}
+
+/** A paragraph whose proviso keyword sits inside a `w:ins`. */
+function insertedProvisoParagraph(style: RunStyle): string {
+  return (
+    `<w:p>` +
+    `<w:r><w:t xml:space="preserve">The party may sublicense</w:t></w:r>` +
+    ins(901, `<w:r>${rPr(style)}<w:t xml:space="preserve">; provided</w:t></w:r>`) +
+    `<w:r><w:t xml:space="preserve"> that consent is obtained.</w:t></w:r>` +
+    `</w:p>`
+  );
+}
+
+const DEFINED_TERM_STYLES_XML =
+  `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+  `<w:styles xmlns:w="${W_NS}">` +
+  `<w:style w:type="character" w:styleId="DefinedTerm">` +
+  `<w:name w:val="Defined Term"/><w:rPr><w:b/><w:i/></w:rPr>` +
+  `</w:style>` +
+  `</w:styles>`;
+
+async function loadDoc(body: string, extraFiles?: Record<string, string>): Promise<DocxDocument> {
+  return DocxDocument.load(await makeDocxWithDocumentXml(docXml(body), extraFiles));
+}
+
+/** Visible text of every paragraph, in the same coordinates the check uses. */
+function paragraphTexts(doc: DocxDocument): string[] {
+  return doc.getParagraphs().map((p) => getParagraphRuns(p).map((r) => r.text).join(''));
+}
+
+/**
+ * Counts derived from the fixture at runtime rather than written down: a
+ * hardcoded "9 of 10" turns into a false green the moment the fixture drifts.
+ */
+function definedTermPopulation(doc: DocxDocument): number {
+  return paragraphTexts(doc).reduce((n, text) => n + findInlineDefinedTermSpans(text).length, 0);
+}
+
+const INSERTED_DEFINED_TERM_TEXT = ' (each, a “Fee Item”)';
+const INSERTED_PROVISO_TEXT = '; provided that consent is obtained.';
+
+/** 9 bold-italic definitions and 1 plain one: a 90% convention, above the 80% bar. */
+const CONVENTION_BODY = [
+  ...Array.from({ length: 9 }, (_, i) => definedTermParagraph(i + 1, { bold: true, italic: true })),
+  definedTermParagraph(10, {}),
+].join('');
+
+const PROVISO_CONVENTION_BODY = Array.from({ length: 6 }, (_, i) =>
+  provisoParagraph(i + 1, { underline: true }),
+).join('');
+
+/**
+ * Run the check the way the guard does: one document as it stood before the
+ * mutation, one as it stands after.
+ */
+async function check(
+  baselineBody: string,
+  previewBody: string,
+  insertedText: string,
+  extraFiles?: Record<string, string>,
+): Promise<string[]> {
+  const baselineDoc = await loadDoc(baselineBody, extraFiles);
+  const previewDoc = await loadDoc(previewBody, extraFiles);
+  return checkFormattingConvention(previewDoc, { insertedText, aiAuthor: AI, baselineDoc }).map(
+    (w) => w.message,
+  );
+}
+
+async function openConventionSession(): Promise<Awaited<ReturnType<typeof openSession>>> {
+  return openSession([], {
+    mgr: new SessionManager({ defaultAiAuthor: AI }),
+    xml: docXml(CONVENTION_BODY + TARGET_PLAIN),
+    prefix: 'safe-docx-convention-',
+  });
+}
+
+describe('formatting-convention matchers', () => {
+  test('requires parenthetical enclosure and definitional phrasing, not merely quoted text', () => {
+    expect(findInlineDefinedTermSpans('the parties (the “Agreement”) agree')).toHaveLength(1);
+    expect(findInlineDefinedTermSpans('(each, a “Holder”)')).toHaveLength(1);
+    expect(findInlineDefinedTermSpans('(collectively, the “Parties”)')).toHaveLength(1);
+    expect(findInlineDefinedTermSpans('(the “Buyer” and the “Seller”)')).toHaveLength(2);
+    // Quoted text outside a parenthetical, and quoted text inside a
+    // parenthetical that is prose or a citation rather than a definition, must
+    // not join the population — the mode is worthless computed over both.
+    expect(findInlineDefinedTermSpans('he said “no” today')).toHaveLength(0);
+    expect(findInlineDefinedTermSpans('(see “Schedule 3” for detail)')).toHaveLength(0);
+    expect(findInlineDefinedTermSpans('(as amended, the “Note”, as restated)')).toHaveLength(0);
+    // Prose between two quoted strings: neither is a definition.
+    expect(findInlineDefinedTermSpans('(the “Buyer” shall notify the “Seller”)')).toHaveLength(0);
+    expect(
+      findInlineDefinedTermSpans('(the “Buyer” disputes the meaning of “Material”)'),
+    ).toHaveLength(0);
+  });
+
+  test('spans the term itself, not its quote marks', () => {
+    const text = 'the parties (the “Agreement”) agree';
+    const [span] = findInlineDefinedTermSpans(text);
+    expect(span).toBeDefined();
+    expect(text.slice(span!.start, span!.end)).toBe('Agreement');
+  });
+
+  test('rejects nested and unbalanced parentheses', () => {
+    expect(findInlineDefinedTermSpans('((the “Term”)')).toHaveLength(0);
+    expect(findInlineDefinedTermSpans('(the “Term” (as amended))')).toHaveLength(0);
+    expect(findInlineDefinedTermSpans('the “Term”)')).toHaveLength(0);
+    expect(findInlineDefinedTermSpans('(the “Term”')).toHaveLength(0);
+  });
+
+  test('does not treat curly single quotes as term delimiters', () => {
+    // Supporting them needs apostrophe-aware scanning: ’ is also the
+    // apostrophe, so (the ‘Company’s Assets’) would close at the possessive.
+    expect(findInlineDefinedTermSpans('(the ‘Company’s Assets’)')).toHaveLength(0);
+    expect(findInlineDefinedTermSpans('(the "Company\'s Assets")')).toHaveLength(1);
+  });
+
+  test('matches proviso keywords only when a semicolon introduces them', () => {
+    expect(findProvisoKeywordSpans('may assign; provided that notice is given')).toHaveLength(1);
+    expect(findProvisoKeywordSpans('may assign; however, notice is required')).toHaveLength(1);
+    expect(findProvisoKeywordSpans('the party provided the notice')).toHaveLength(0);
+    expect(findProvisoKeywordSpans('however the party acts')).toHaveLength(0);
+  });
+
+  test('is not left stateful by the global regexes it uses', () => {
+    const text = '(each, a “Holder”); provided that notice is given';
+    const first = [findInlineDefinedTermSpans(text).length, findProvisoKeywordSpans(text).length];
+    const second = [findInlineDefinedTermSpans(text).length, findProvisoKeywordSpans(text).length];
+    expect(second).toEqual(first);
+    expect(first).toEqual([1, 1]);
+  });
+});
+
+describe('formatting-convention detection on corpus documents', () => {
+  test('finds a real, dominant convention in both committed corpus agreements', async () => {
+    // These are the two public-source agreements the #687 cost measurements
+    // were taken against. Nothing here is hardcoded: the population, the mode
+    // and the share are all read off the documents at runtime. A matcher that
+    // degraded into "any quoted text" would pull unrelated prose into the
+    // population and the dominance would collapse below the threshold.
+    for (const source of [NVCA_COI_SOURCE, ILPA_SOURCE]) {
+      const doc = await DocxDocument.load(await fs.readFile(source));
+      const texts = paragraphTexts(doc);
+      const naiveQuotedParagraphs = texts.filter((t) => /[“"]/.test(t)).length;
+
+      const terms = summarizeDocumentConvention(doc, 'inline_defined_term');
+      expect(terms, `no defined-term convention found in ${path.basename(source)}`).not.toBeNull();
+      expect(terms!.total).toBeGreaterThanOrEqual(DEFAULT_MIN_INSTANCES);
+      expect(terms!.total).toBeLessThan(naiveQuotedParagraphs);
+      expect(terms!.modeCount / terms!.total).toBeGreaterThanOrEqual(DEFAULT_DOMINANCE_THRESHOLD);
+
+      const provisos = summarizeDocumentConvention(doc, 'proviso_keyword');
+      expect(provisos, `no proviso convention found in ${path.basename(source)}`).not.toBeNull();
+      expect(provisos!.modeCount / provisos!.total).toBeGreaterThanOrEqual(
+        DEFAULT_DOMINANCE_THRESHOLD,
+      );
+    }
+  });
+});
+
+describe('formatting-convention check', () => {
+  test('NEGATIVE CONTROL: a seeded off-convention insertion makes the check go red', async ({
+    given,
+    when,
+    then,
+    and,
+  }: AllureBddContext) => {
+    let total = 0;
+    let warnings: string[] = [];
+
+    await given('a document whose defined terms are bold italic by convention', async () => {
+      total = definedTermPopulation(await loadDoc(CONVENTION_BODY));
+      expect(total).toBeGreaterThanOrEqual(DEFAULT_MIN_INSTANCES);
+    });
+
+    await when('a deliberately plain defined term is inserted', async () => {
+      warnings = await check(
+        CONVENTION_BODY + TARGET_PLAIN,
+        CONVENTION_BODY + insertedDefinedTermParagraph({}),
+        INSERTED_DEFINED_TERM_TEXT,
+      );
+    });
+
+    await then('exactly one divergence warning is produced', () => {
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain(FORMATTING_CONVENTION_WARNING_CODE);
+      expect(warnings[0]).toContain('inline defined term');
+    });
+
+    await and('it names the construct and the observed-versus-dominant properties', () => {
+      const modeCount = total - 1; // one seeded off-convention pre-existing term
+      const share = Math.round((modeCount / total) * 100);
+      expect(warnings[0]).toContain('"Fee Item"');
+      expect(warnings[0]).toContain('is bold=false, italic=false, underline=false');
+      expect(warnings[0]).toContain(`${modeCount} of ${total} (${share}%)`);
+      expect(warnings[0]).toContain('are bold=true, italic=true, underline=false');
+    });
+  });
+
+  test('NEGATIVE CONTROL: the same fixture with an on-convention insertion is silent', async () => {
+    expect(
+      await check(
+        CONVENTION_BODY + TARGET_PLAIN,
+        CONVENTION_BODY + insertedDefinedTermParagraph({ bold: true, italic: true }),
+        INSERTED_DEFINED_TERM_TEXT,
+      ),
+    ).toEqual([]);
+  });
+
+  test('reports a divergent fragment of a term split across runs', async () => {
+    // Both fragments carry four of the term's characters, so no "largest
+    // overlap" rule can see the plain tail. Each half is checked on its own.
+    const tailPlain = await check(
+      CONVENTION_BODY + TARGET_PLAIN,
+      CONVENTION_BODY + insertedSplitDefinedTermParagraph({ bold: true, italic: true }, {}),
+      INSERTED_DEFINED_TERM_TEXT,
+    );
+    expect(tailPlain).toHaveLength(1);
+    expect(tailPlain[0]).toContain('is bold=false, italic=false, underline=false');
+
+    const headPlain = await check(
+      CONVENTION_BODY + TARGET_PLAIN,
+      CONVENTION_BODY + insertedSplitDefinedTermParagraph({}, { bold: true, italic: true }),
+      INSERTED_DEFINED_TERM_TEXT,
+    );
+    expect(headPlain).toHaveLength(1);
+
+    // Positive control for the pair: when both fragments follow the convention
+    // there is nothing to report.
+    expect(
+      await check(
+        CONVENTION_BODY + TARGET_PLAIN,
+        CONVENTION_BODY +
+          insertedSplitDefinedTermParagraph(
+            { bold: true, italic: true },
+            { bold: true, italic: true },
+          ),
+        INSERTED_DEFINED_TERM_TEXT,
+      ),
+    ).toEqual([]);
+  });
+
+  test('does not blame this edit for an off-convention insertion an earlier edit left behind', async () => {
+    // The session already carries a plain AI-authored "Fee Item". This edit
+    // inserts a second, correctly formatted one. Attributing the old one to
+    // this edit would report a divergence the caller cannot act on.
+    const historical = insertedDefinedTermParagraph({}, { id: 800 });
+    const added = insertedDefinedTermParagraph({ bold: true, italic: true }, { id: 801 });
+    expect(
+      await check(
+        CONVENTION_BODY + historical,
+        CONVENTION_BODY + historical + added,
+        INSERTED_DEFINED_TERM_TEXT,
+      ),
+    ).toEqual([]);
+
+    // Mirror image, same fixture shape: the historical insertion is on
+    // convention and the new one is not, so exactly one warning is due.
+    const historicalGood = insertedDefinedTermParagraph({ bold: true, italic: true }, { id: 800 });
+    const addedBad = insertedDefinedTermParagraph({}, { id: 801 });
+    const warnings = await check(
+      CONVENTION_BODY + historicalGood,
+      CONVENTION_BODY + historicalGood + addedBad,
+      INSERTED_DEFINED_TERM_TEXT,
+    );
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('is bold=false, italic=false, underline=false');
+  });
+
+  test('is silent when the document has no clear mode', async () => {
+    const split = [
+      ...Array.from({ length: 3 }, (_, i) =>
+        definedTermParagraph(i + 1, { bold: true, italic: true }),
+      ),
+      ...Array.from({ length: 3 }, (_, i) => definedTermParagraph(i + 4, {})),
+    ].join('');
+
+    expect(definedTermPopulation(await loadDoc(split))).toBeGreaterThanOrEqual(
+      DEFAULT_MIN_INSTANCES,
+    );
+    expect(
+      await check(
+        split + TARGET_PLAIN,
+        split + insertedDefinedTermParagraph({}),
+        INSERTED_DEFINED_TERM_TEXT,
+      ),
+    ).toEqual([]);
+
+    // Positive control on the same insertion: give the document a mode and the
+    // identical edit is reported. The silence above is the threshold's doing,
+    // not a broken pipeline.
+    const decided =
+      split +
+      Array.from({ length: 13 }, (_, i) =>
+        definedTermParagraph(i + 7, { bold: true, italic: true }),
+      ).join('');
+    expect(
+      await check(
+        decided + TARGET_PLAIN,
+        decided + insertedDefinedTermParagraph({}),
+        INSERTED_DEFINED_TERM_TEXT,
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('is silent when too few comparable instances exist to call a convention', async () => {
+    const sparse = Array.from({ length: DEFAULT_MIN_INSTANCES - 1 }, (_, i) =>
+      definedTermParagraph(i + 1, { bold: true, italic: true }),
+    ).join('');
+    expect(definedTermPopulation(await loadDoc(sparse))).toBeLessThan(DEFAULT_MIN_INSTANCES);
+    expect(
+      await check(
+        sparse + TARGET_PLAIN,
+        sparse + insertedDefinedTermParagraph({}),
+        INSERTED_DEFINED_TERM_TEXT,
+      ),
+    ).toEqual([]);
+
+    // Positive control: one more instance clears the bar and the same edit is
+    // reported, so the silence above is the count threshold and nothing else.
+    const enough = sparse + definedTermParagraph(99, { bold: true, italic: true });
+    expect(definedTermPopulation(await loadDoc(enough))).toBeGreaterThanOrEqual(
+      DEFAULT_MIN_INSTANCES,
+    );
+    expect(
+      await check(
+        enough + TARGET_PLAIN,
+        enough + insertedDefinedTermParagraph({}),
+        INSERTED_DEFINED_TERM_TEXT,
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('does not flag a run that inherits bold italic from a character style', async () => {
+    // Deliberately asymmetric: the convention is declared directly on its runs,
+    // the insertion carries the same appearance only through w:rStyle. A
+    // declared-properties comparison reads the insertion as plain and fires;
+    // only resolution through extractEffectiveRunFormatting stays silent. A
+    // fixture where both sides used the style would pass either way.
+    const styled = Array.from({ length: 6 }, (_, i) =>
+      definedTermParagraph(i + 1, { bold: true, italic: true }),
+    ).join('');
+    expect(
+      await check(
+        styled + TARGET_PLAIN,
+        styled + insertedDefinedTermParagraph({ rStyle: 'DefinedTerm' }),
+        INSERTED_DEFINED_TERM_TEXT,
+        { 'word/styles.xml': DEFINED_TERM_STYLES_XML },
+      ),
+    ).toEqual([]);
+  });
+
+  test('flags a styled run whose direct formatting turns the inherited bold off', async () => {
+    const styled = Array.from({ length: 6 }, (_, i) =>
+      definedTermParagraph(i + 1, { rStyle: 'DefinedTerm' }),
+    ).join('');
+    // Neither side declares w:b directly, so the whole comparison runs through
+    // the style chain.
+    expect(styled).not.toContain('<w:b/>');
+    const warnings = await check(
+      styled + TARGET_PLAIN,
+      styled + insertedDefinedTermParagraph({ rStyle: 'DefinedTerm', boldOff: true }),
+      INSERTED_DEFINED_TERM_TEXT,
+      { 'word/styles.xml': DEFINED_TERM_STYLES_XML },
+    );
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('is bold=false, italic=true, underline=false');
+  });
+
+  test('skips entirely when the inserted text carries no construct', async () => {
+    // Same document and same off-convention insertion as the negative control
+    // above; only the gate text differs, so a warning here would mean the gate
+    // is not doing anything.
+    const bodies = [CONVENTION_BODY + TARGET_PLAIN, CONVENTION_BODY + insertedDefinedTermParagraph({})] as const;
+    expect(await check(bodies[0], bodies[1], 'the fee is payable on demand')).toEqual([]);
+    expect(await check(bodies[0], bodies[1], INSERTED_DEFINED_TERM_TEXT)).toHaveLength(1);
+  });
+
+  test('ignores insertions attributed to another author', async () => {
+    const foreign = insertedDefinedTermParagraph({}, { author: 'Someone Else' });
+    expect(
+      await check(CONVENTION_BODY + TARGET_PLAIN, CONVENTION_BODY + foreign, INSERTED_DEFINED_TERM_TEXT),
+    ).toEqual([]);
+    // Positive control: the identical insertion attributed to this session's
+    // author is reported, so the silence above is the author test.
+    expect(
+      await check(
+        CONVENTION_BODY + TARGET_PLAIN,
+        CONVENTION_BODY + insertedDefinedTermParagraph({}),
+        INSERTED_DEFINED_TERM_TEXT,
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('warns on an off-convention proviso keyword', async () => {
+    const warnings = await check(
+      PROVISO_CONVENTION_BODY + TARGET_PLAIN,
+      PROVISO_CONVENTION_BODY + insertedProvisoParagraph({}),
+      INSERTED_PROVISO_TEXT,
+    );
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('proviso keyword');
+    expect(warnings[0]).toContain('are bold=false, italic=false, underline=true');
+
+    expect(
+      await check(
+        PROVISO_CONVENTION_BODY + TARGET_PLAIN,
+        PROVISO_CONVENTION_BODY + insertedProvisoParagraph({ underline: true }),
+        INSERTED_PROVISO_TEXT,
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe('formatting-convention warnings on the edit path', () => {
+  registerCleanup();
+
+  test('replace_text surfaces the warning and still applies the edit', async ({
+    given,
+    when,
+    then,
+    and,
+  }: AllureBddContext) => {
+    let opened: Awaited<ReturnType<typeof openSession>>;
+    let result: Awaited<ReturnType<typeof replaceText>>;
+
+    await given('a session on a document with a bold-italic defined-term convention', async () => {
+      opened = await openConventionSession();
+    });
+
+    await when('an edit inserts a plain parenthetical defined term', async () => {
+      result = await replaceText(opened.mgr, {
+        file_path: opened.filePath,
+        target_paragraph_id: opened.paraIds[opened.paraIds.length - 1]!,
+        old_string: 'The fee is payable',
+        new_string: 'The fee is payable' + INSERTED_DEFINED_TERM_TEXT,
+        instruction: 'introduce a defined term for the fee',
+      });
+    });
+
+    await then('the edit succeeds — the check never blocks', () => {
+      assertSuccess(result, 'replace_text');
+      expect(result.replacements_made).toBe(1);
+    });
+
+    await and('the divergence is reported on the warnings channel', () => {
+      const warnings = (result.warnings ?? []) as string[];
+      expect(warnings.some((w) => w.startsWith(FORMATTING_CONVENTION_WARNING_CODE))).toBe(true);
+    });
+  });
+
+  test('replace_text stays silent for an edit that introduces no construct', async () => {
+    const opened = await openConventionSession();
+    const result = await replaceText(opened.mgr, {
+      file_path: opened.filePath,
+      target_paragraph_id: opened.paraIds[opened.paraIds.length - 1]!,
+      old_string: 'on demand',
+      new_string: 'on thirty days notice',
+      instruction: 'lengthen the payment window',
+    });
+
+    assertSuccess(result, 'replace_text');
+    const warnings = (result.warnings ?? []) as string[];
+    expect(warnings.some((w) => w.startsWith(FORMATTING_CONVENTION_WARNING_CODE))).toBe(false);
+  });
+
+  test('insert_paragraph surfaces the warning on its success response', async () => {
+    const opened = await openConventionSession();
+    const result = await insertParagraph(opened.mgr, {
+      file_path: opened.filePath,
+      positional_anchor_node_id: opened.paraIds[opened.paraIds.length - 1]!,
+      new_string: 'Interest accrues on each late payment (each, a “Fee Item”) monthly.',
+      instruction: 'add an interest sentence introducing a defined term',
+    });
+
+    assertSuccess(result, 'insert_paragraph');
+    const warnings = (result.warnings ?? []) as string[];
+    expect(warnings.some((w) => w.startsWith(FORMATTING_CONVENTION_WARNING_CODE))).toBe(true);
+  });
+
+  test('batch_edit reports the warning against the step that caused it', async () => {
+    const opened = await openConventionSession();
+    const targetId = opened.paraIds[opened.paraIds.length - 1]!;
+
+    const result = await batchEdit(opened.mgr, {
+      file_path: opened.filePath,
+      steps: [
+        {
+          step_id: 'shorten-notice',
+          operation: 'replace_text',
+          target_paragraph_id: targetId,
+          old_string: 'on demand',
+          new_string: 'on notice',
+          instruction: 'shorten the payment trigger',
+        },
+        {
+          step_id: 'define-fee',
+          operation: 'replace_text',
+          target_paragraph_id: targetId,
+          old_string: 'The fee is payable',
+          new_string: 'The fee is payable' + INSERTED_DEFINED_TERM_TEXT,
+          instruction: 'introduce a defined term for the fee',
+        },
+      ],
+    });
+
+    assertSuccess(result, 'batch_edit');
+    const warnings = (result.warnings ?? []) as Array<{ step_id: string; warning: string }>;
+    const convention = warnings.filter((w) =>
+      w.warning.startsWith(FORMATTING_CONVENTION_WARNING_CODE),
+    );
+    expect(convention).toHaveLength(1);
+    expect(convention[0]!.step_id).toBe('define-fee');
+  });
+});

--- a/packages/docx-mcp/src/tools/formatting_convention.ts
+++ b/packages/docx-mcp/src/tools/formatting_convention.ts
@@ -1,0 +1,624 @@
+import {
+  DocxDocument,
+  OOXML,
+  W,
+  extractEffectiveRunFormatting,
+  getFirstChild,
+  getParagraphRuns,
+  type StylesModel,
+} from '@usejunior/docx-core';
+
+/**
+ * Formatting-convention check for inserted runs (issue #687).
+ *
+ * A well-formed edit can still be visibly wrong: an inserted inline defined
+ * term rendered in plain runs inside an agreement that sets every other
+ * parenthetical definition in bold italic round-trips, extracts byte-identical
+ * text, and passes every structural validator. Nothing compares the inserted
+ * run against the document's own distribution of the same construct, so the
+ * defect is invisible to `validate_document` (well-formedness) and to
+ * `validate_ai_revisions` (revision-markup legality) alike.
+ *
+ * This module compares an inserted construct's *resolved* run formatting
+ * against the modal formatting of the same construct class elsewhere in the
+ * document. Four properties are load-bearing:
+ *
+ * 1. **Structural, never textual.** Divergence is decided on the
+ *    `(bold, italic, underline)` tuple. Text is used only to *locate*
+ *    instances, never to judge them.
+ * 2. **Effective, not declared, formatting.** Resolution goes through
+ *    {@link extractEffectiveRunFormatting}, so a run that inherits bold italic
+ *    from a character or paragraph style is not reported as divergent. That is
+ *    the entire reason #684 was a prerequisite of #687.
+ * 3. **This mutation's insertions, not the session's.** "Inserted" is decided
+ *    by differencing the pre-mutation document against the preview, the same
+ *    multiset-consumption technique `splitIntroducedDiagnostics` uses in
+ *    `ai_revision_guard.ts`. A `w:ins` an earlier edit in the same session left
+ *    behind is part of the document now, not part of this edit.
+ * 4. **Advisory only.** The result is a list of warnings on the channel
+ *    #686/#701 built. Nothing here can block an edit, and a document with no
+ *    established convention produces silence rather than a guess.
+ *
+ * @see https://github.com/UseJunior/safe-docx/issues/687
+ */
+
+/** `w:ins` is not in the shared `W` vocabulary; `w:del` is (`W.del`). */
+const W_INS = 'ins';
+
+/** Construct classes whose formatting a document may establish a convention for. */
+export type ConventionConstruct = 'inline_defined_term' | 'proviso_keyword';
+
+const CONSTRUCT_LABELS: Record<ConventionConstruct, string> = {
+  inline_defined_term: 'inline defined term',
+  proviso_keyword: 'proviso keyword',
+};
+
+/**
+ * The comparison tuple. Deliberately the three properties a drafter actually
+ * uses to mark these constructs; font, size and colour vary for reasons that
+ * have nothing to do with the construct (headings, tables, footers) and would
+ * make the mode meaningless.
+ */
+export type ConventionTuple = {
+  bold: boolean;
+  italic: boolean;
+  underline: boolean;
+};
+
+/** One occurrence of a construct in a document, with its resolved formatting. */
+type ConventionInstance = {
+  /** Case-folded construct text, used only to match an insertion to its occurrence. */
+  key: string;
+  /** Construct text as it appears, for the warning message. */
+  label: string;
+  /** Resolved tuple of every text-bearing run overlapping the construct. */
+  runTuples: ConventionTuple[];
+  /**
+   * True when every overlapping run resolves to the same tuple. A construct
+   * split across runs that disagree carries no single formatting, so it is
+   * evidence of nothing and must not vote on the convention.
+   */
+  homogeneous: boolean;
+  /** The shared tuple; meaningful only when `homogeneous`. */
+  tuple: ConventionTuple;
+  /** Tuples of the overlapping runs that sit inside an AI-authored `w:ins`. */
+  insertedRunTuples: ConventionTuple[];
+};
+
+/** A character range inside a paragraph's visible text. */
+type ConstructSpan = { start: number; end: number; key: string; label: string };
+
+/** One divergence, structured so callers can attribute it to a step or render it. */
+export type ConventionWarning = {
+  construct: ConventionConstruct;
+  /** The construct's own text — the defined term, or the proviso keyword. */
+  term: string;
+  /** Human-readable rendering, matching the `warnings` channel's string shape. */
+  message: string;
+};
+
+export type FormattingConventionOptions = {
+  /**
+   * The text this mutation inserts. The check is gated on this: it runs only
+   * when the inserted text itself contains a construct, and is skipped
+   * entirely otherwise. Settled on #687 (2026-07-29) — cost does not constrain
+   * the check, so the trigger is chosen for precision.
+   */
+  insertedText: string;
+  /** `w:ins/@w:author` value identifying runs this session inserted. */
+  aiAuthor: string;
+  /**
+   * The document as it stood *before* this mutation. It supplies the
+   * convention — the standard an edit is judged against is the document the
+   * edit arrived at, never one this edit helped write — and it is differenced
+   * against the preview to tell this mutation's insertions apart from earlier
+   * ones by the same author.
+   */
+  baselineDoc: DocxDocument;
+  /**
+   * Minimum comparable instances before a document is treated as having a
+   * convention at all. Below this, stay silent.
+   */
+  minInstances?: number;
+  /** Share of instances the modal tuple must hold to count as a convention. */
+  dominanceThreshold?: number;
+};
+
+/**
+ * Thresholds from the #687 design comment: at least 5 comparable instances of
+ * the construct, with the modal `(bold, italic, underline)` tuple holding at
+ * least 80% of them. Evaluated over the population of *comparable constructs*,
+ * never over the document's runs at large — a naive quoted-text match hits a
+ * large share of every run in a real agreement, which would compute the mode
+ * over a polluted population.
+ */
+export const DEFAULT_MIN_INSTANCES = 5;
+export const DEFAULT_DOMINANCE_THRESHOLD = 0.8;
+
+export const FORMATTING_CONVENTION_WARNING_CODE = 'FORMATTING_CONVENTION_DIVERGENCE';
+
+// ── Construct matchers ─────────────────────────────────────────────────────
+//
+// Matcher precision, not throughput, decides whether this check is
+// trustworthy. Quoted text alone is far too common to serve as the matcher, so
+// a defined term must carry the parenthetical enclosure, definitional phrasing
+// around every quoted term, and nothing else: `(the "Term")`,
+// `(each, a "Term")`, `(collectively, the "Buyer" and the "Seller")`.
+
+/**
+ * Double quotes only. Curly single quotes were tried and removed: `’` is also
+ * the apostrophe, so `(the ‘Company’s Assets’)` closes at the possessive and
+ * the term comes out truncated. Supporting them needs apostrophe-aware
+ * scanning, and defined terms in the corpus this targets use double quotes.
+ */
+const QUOTE_PAIRS: ReadonlyArray<readonly [string, string]> = [
+  ['“', '”'], // “ ”
+  ['"', '"'],
+];
+
+/**
+ * Words allowed to precede the first quoted term inside the parenthetical.
+ * Anything else — `see`, `as defined in`, a citation — means this is not a
+ * definition and must not join the population.
+ */
+const LEAD_IN_RE =
+  /^[\s,;]*(?:(?:each|collectively|together|individually|jointly|severally|and|or|being|such|this|these|those|herein|hereinafter|referred\s+to\s+as|known\s+as|called|defined\s+as)[\s,;]*)*(?:the|a|an)?[\s,;]*$/i;
+
+/**
+ * Between two quoted terms in one parenthetical, only a conjunction may
+ * appear. Without this, `(the "Buyer" shall notify the "Seller")` — ordinary
+ * prose — donates two instances to the population and can invent or destroy
+ * the mode on its own.
+ */
+const INTER_QUOTE_RE = /^[\s,;]*(?:and|or)?[\s,;]*(?:the|a|an)?[\s,;]*$/i;
+
+/** After the last quoted term, only closing punctuation may remain. */
+const TRAILER_RE = /^[\s,;.]*$/;
+
+/**
+ * Top-level, properly closed, non-nesting parentheticals. A regex scan accepts
+ * the inner half of `((the "Term")` and calls it an enclosure; a depth-tracking
+ * scan does not. Malformed parentheses are real in tracked-change views, so
+ * this is population hygiene rather than pedantry.
+ */
+function findTopLevelParentheticals(text: string): Array<{ start: number; inner: string }> {
+  const out: Array<{ start: number; inner: string }> = [];
+  const stack: Array<{ start: number; nested: boolean }> = [];
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (ch === '(') {
+      if (stack.length > 0) stack[stack.length - 1]!.nested = true;
+      stack.push({ start: i, nested: false });
+      continue;
+    }
+    if (ch !== ')') continue;
+    const frame = stack.pop();
+    if (!frame) continue; // stray closer: no enclosure to report
+    if (stack.length > 0) continue; // a nested pair, not a top-level one
+    if (frame.nested) continue; // top-level, but it contains a nested pair
+    out.push({ start: frame.start + 1, inner: text.slice(frame.start + 1, i) });
+  }
+  return out;
+}
+
+function findQuotedSpans(text: string): Array<{ start: number; end: number; inner: string }> {
+  const spans: Array<{ start: number; end: number; inner: string }> = [];
+  for (let i = 0; i < text.length; i++) {
+    const pair = QUOTE_PAIRS.find(([open]) => text[i] === open);
+    if (!pair) continue;
+    const close = pair[1];
+    // A straight-quote pair opens and closes with the same character, so the
+    // search for the closer must start after the opener.
+    const closeIdx = text.indexOf(close, i + 1);
+    if (closeIdx < 0) continue;
+    const inner = text.slice(i + 1, closeIdx);
+    if (inner.length === 0) continue;
+    spans.push({ start: i, end: closeIdx + 1, inner });
+    i = closeIdx;
+  }
+  return spans;
+}
+
+/**
+ * Inline defined terms: quoted terms inside a parenthetical where every
+ * segment around them is definitional.
+ *
+ * The reported span covers the term text *between* the quote marks and not the
+ * marks themselves. That is not cosmetic. Measured across the two corpus
+ * agreements in `tests/test_documents`, the opening and closing quotes almost
+ * always sit in the surrounding runs — `[" (the “", plain]["Fund", bold]["”) is
+ * made on", plain]` is the typical shape — so a span including the marks reads
+ * as three disagreeing runs and the instance is discarded as incomparable.
+ * Narrowed to the term, the same instance resolves cleanly to the formatting a
+ * reader actually sees on the defined term.
+ */
+export function findInlineDefinedTermSpans(text: string): ConstructSpan[] {
+  const out: ConstructSpan[] = [];
+  for (const { start: innerStart, inner } of findTopLevelParentheticals(text)) {
+    const quoted = findQuotedSpans(inner);
+    if (quoted.length === 0) continue;
+    if (!LEAD_IN_RE.test(inner.slice(0, quoted[0]!.start))) continue;
+    if (!TRAILER_RE.test(inner.slice(quoted[quoted.length - 1]!.end))) continue;
+
+    let connected = true;
+    for (let i = 1; i < quoted.length; i++) {
+      if (!INTER_QUOTE_RE.test(inner.slice(quoted[i - 1]!.end, quoted[i]!.start))) {
+        connected = false;
+        break;
+      }
+    }
+    if (!connected) continue;
+
+    for (const q of quoted) {
+      out.push({
+        start: innerStart + q.start + 1, // skip the opening quote mark
+        end: innerStart + q.end - 1, // stop before the closing quote mark
+        key: normalizeKey(q.inner),
+        label: q.inner,
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Proviso keywords: `provided` or `however` introduced by a semicolon. The
+ * span covers the keyword itself, which is what agreements underline or
+ * italicise.
+ */
+const PROVISO_RE = /;\s*(provided|however)\b/gi;
+
+export function findProvisoKeywordSpans(text: string): ConstructSpan[] {
+  const out: ConstructSpan[] = [];
+  PROVISO_RE.lastIndex = 0;
+  let match = PROVISO_RE.exec(text);
+  while (match) {
+    const keyword = match[1]!;
+    const start = match.index + match[0].length - keyword.length;
+    out.push({
+      start,
+      end: start + keyword.length,
+      key: normalizeKey(keyword),
+      label: keyword,
+    });
+    match = PROVISO_RE.exec(text);
+  }
+  return out;
+}
+
+const MATCHERS: Record<ConventionConstruct, (text: string) => ConstructSpan[]> = {
+  inline_defined_term: findInlineDefinedTermSpans,
+  proviso_keyword: findProvisoKeywordSpans,
+};
+
+export const CONVENTION_CONSTRUCTS = Object.keys(MATCHERS) as ConventionConstruct[];
+
+function normalizeKey(value: string): string {
+  return value.trim().replace(/\s+/g, ' ').toLowerCase();
+}
+
+// ── Document scan ──────────────────────────────────────────────────────────
+
+function paragraphStyleId(pPr: Element | null): string | null {
+  if (!pPr) return null;
+  const pStyle = getFirstChild(pPr, OOXML.W_NS, W.pStyle);
+  if (!pStyle) return null;
+  return (
+    pStyle.getAttributeNS(OOXML.W_NS, 'val') ??
+    pStyle.getAttribute('w:val') ??
+    pStyle.getAttribute('val')
+  );
+}
+
+/**
+ * True when `run` sits inside a `w:ins` attributed to `author`, anywhere below
+ * `paragraph`. Structural: the revision wrapper and its author attribute are
+ * what identify an insertion, not the text it carries.
+ */
+function isInsertedByAuthor(run: Element, paragraph: Element, author: string): boolean {
+  let cur = run.parentNode as Element | null;
+  while (cur && cur !== paragraph) {
+    if (cur.namespaceURI === OOXML.W_NS && cur.localName === W_INS) {
+      const attr =
+        cur.getAttributeNS(OOXML.W_NS, 'author') ??
+        cur.getAttribute('w:author') ??
+        cur.getAttribute('author');
+      if (attr === author) return true;
+    }
+    cur = cur.parentNode as Element | null;
+  }
+  return false;
+}
+
+/** True when `run` sits inside a tracked deletion or move-from wrapper. */
+function isRemoved(run: Element, paragraph: Element): boolean {
+  let cur = run.parentNode as Element | null;
+  while (cur && cur !== paragraph) {
+    if (
+      cur.namespaceURI === OOXML.W_NS &&
+      (cur.localName === W.del || cur.localName === W.moveFrom)
+    ) {
+      return true;
+    }
+    cur = cur.parentNode as Element | null;
+  }
+  return false;
+}
+
+/**
+ * Every text-bearing run overlapping `[start, end)`, in document order. A
+ * construct is routinely split — the quote marks in one run and the term in
+ * another — and judging only the largest fragment lets a divergent fragment
+ * through unreported.
+ */
+function overlappingRuns(
+  runs: ReadonlyArray<{ r: Element; text: string }>,
+  start: number,
+  end: number,
+): Element[] {
+  const out: Element[] = [];
+  const seen = new Set<Element>();
+  let pos = 0;
+  for (const run of runs) {
+    const runStart = pos;
+    const runEnd = pos + run.text.length;
+    pos = runEnd;
+    if (run.text.length === 0) continue;
+    if (Math.min(end, runEnd) - Math.max(start, runStart) <= 0) continue;
+    if (seen.has(run.r)) continue;
+    seen.add(run.r);
+    out.push(run.r);
+  }
+  return out;
+}
+
+function collectInstances(
+  doc: DocxDocument,
+  styles: StylesModel,
+  construct: ConventionConstruct,
+  aiAuthor: string,
+): ConventionInstance[] {
+  const matcher = MATCHERS[construct];
+  const instances: ConventionInstance[] = [];
+
+  for (const p of doc.getParagraphs()) {
+    const runs = getParagraphRuns(p);
+    if (runs.length === 0) continue;
+    const text = runs.map((run) => run.text).join('');
+    if (text.length === 0) continue;
+    const spans = matcher(text);
+    if (spans.length === 0) continue;
+
+    const pPr = getFirstChild(p, OOXML.W_NS, W.pPr);
+    const styleId = paragraphStyleId(pPr);
+
+    for (const span of spans) {
+      const runTuples: ConventionTuple[] = [];
+      const insertedRunTuples: ConventionTuple[] = [];
+      for (const run of overlappingRuns(runs, span.start, span.end)) {
+        if (isRemoved(run, p)) continue;
+        // Theme is deliberately omitted: it feeds only font and colour
+        // resolution, neither of which is in the comparison tuple.
+        const fmt = extractEffectiveRunFormatting({
+          run,
+          paragraphPPr: pPr,
+          paragraphStyleId: styleId,
+          styles,
+        });
+        const tuple = { bold: fmt.bold, italic: fmt.italic, underline: fmt.underline };
+        runTuples.push(tuple);
+        if (isInsertedByAuthor(run, p, aiAuthor)) insertedRunTuples.push(tuple);
+      }
+      if (runTuples.length === 0) continue;
+
+      const first = runTuples[0]!;
+      const homogeneous = runTuples.every((t) => tupleKey(t) === tupleKey(first));
+      instances.push({
+        key: span.key,
+        label: span.label,
+        runTuples,
+        homogeneous,
+        tuple: first,
+        insertedRunTuples,
+      });
+    }
+  }
+
+  return instances;
+}
+
+// ── Convention resolution ──────────────────────────────────────────────────
+
+function tupleKey(tuple: ConventionTuple): string {
+  return `${tuple.bold ? 1 : 0}${tuple.italic ? 1 : 0}${tuple.underline ? 1 : 0}`;
+}
+
+function describeTuple(tuple: ConventionTuple): string {
+  return `bold=${tuple.bold}, italic=${tuple.italic}, underline=${tuple.underline}`;
+}
+
+/** Identity of one instance for multiset differencing: text plus every tuple. */
+function instanceFingerprint(instance: ConventionInstance): string {
+  return `${instance.key}|${instance.runTuples.map(tupleKey).join(',')}`;
+}
+
+export type ConventionSummary = {
+  /** Comparable instances the mode was computed over. */
+  total: number;
+  /** How many of them carry the modal tuple. */
+  modeCount: number;
+  tuple: ConventionTuple;
+};
+
+/**
+ * The dominant tuple, or null when the population is too small or too split to
+ * call a convention. A tie can never pass: two distinct tuples cannot each
+ * hold 80% of one population.
+ */
+function resolveConvention(
+  instances: ReadonlyArray<ConventionInstance>,
+  minInstances: number,
+  dominanceThreshold: number,
+): ConventionSummary | null {
+  if (instances.length < minInstances) return null;
+
+  const counts = new Map<string, { count: number; tuple: ConventionTuple }>();
+  for (const instance of instances) {
+    const key = tupleKey(instance.tuple);
+    const entry = counts.get(key) ?? { count: 0, tuple: instance.tuple };
+    entry.count += 1;
+    counts.set(key, entry);
+  }
+
+  let best: { count: number; tuple: ConventionTuple } | null = null;
+  for (const entry of counts.values()) {
+    if (!best || entry.count > best.count) best = entry;
+  }
+  if (!best) return null;
+  if (best.count / instances.length < dominanceThreshold) return null;
+
+  return { total: instances.length, modeCount: best.count, tuple: best.tuple };
+}
+
+/**
+ * The convention a document establishes for one construct class, or null when
+ * it establishes none. Exposed so a caller — or a test working against a real
+ * corpus document — can ask what a document's own standard is without running
+ * an edit through it.
+ */
+export function summarizeDocumentConvention(
+  doc: DocxDocument,
+  construct: ConventionConstruct,
+  opts?: { minInstances?: number; dominanceThreshold?: number },
+): ConventionSummary | null {
+  // No author can match the empty string, so nothing is classified as inserted.
+  const instances = collectInstances(doc, doc.getStylesModel(), construct, '');
+  return resolveConvention(
+    instances.filter((instance) => instance.homogeneous),
+    opts?.minInstances ?? DEFAULT_MIN_INSTANCES,
+    opts?.dominanceThreshold ?? DEFAULT_DOMINANCE_THRESHOLD,
+  );
+}
+
+// ── Entry point ────────────────────────────────────────────────────────────
+
+/**
+ * Compare the constructs this mutation inserted against the document's own
+ * convention for the same construct class, and describe every divergence.
+ *
+ * An empty result means either "nothing inserted that this checks" or "no
+ * established convention" — the two are deliberately indistinguishable to the
+ * caller, because both mean the same thing operationally: say nothing.
+ *
+ * Never throws: a convention warning that could fail an edit would violate the
+ * advisory contract, so an unexpected document shape degrades to silence.
+ *
+ * @param previewDoc the document as it will be once the mutation is applied
+ */
+export function checkFormattingConvention(
+  previewDoc: DocxDocument,
+  options: FormattingConventionOptions,
+): ConventionWarning[] {
+  const {
+    insertedText,
+    aiAuthor,
+    baselineDoc,
+    minInstances = DEFAULT_MIN_INSTANCES,
+    dominanceThreshold = DEFAULT_DOMINANCE_THRESHOLD,
+  } = options;
+
+  if (!insertedText || !aiAuthor || !baselineDoc) return [];
+
+  try {
+    let previewStyles: StylesModel | null = null;
+    let baselineStyles: StylesModel | null = null;
+    const warnings: ConventionWarning[] = [];
+
+    for (const construct of CONVENTION_CONSTRUCTS) {
+      // Gate: only run when the inserted text itself carries this construct.
+      const insertedSpans = MATCHERS[construct](insertedText);
+      if (insertedSpans.length === 0) continue;
+      const insertedKeys = new Set(insertedSpans.map((span) => span.key));
+
+      baselineStyles ??= baselineDoc.getStylesModel();
+      const baseline = collectInstances(baselineDoc, baselineStyles, construct, aiAuthor);
+
+      // The convention is the document as this edit found it. Insertions an
+      // earlier edit in the same session left behind are part of that document
+      // and keep their vote.
+      const convention = resolveConvention(
+        baseline.filter((instance) => instance.homogeneous),
+        minInstances,
+        dominanceThreshold,
+      );
+      if (!convention) continue;
+
+      previewStyles ??= previewDoc.getStylesModel();
+      const preview = collectInstances(previewDoc, previewStyles, construct, aiAuthor);
+
+      // Which insertions are *this* mutation's: consume the pre-existing
+      // AI-authored instances by fingerprint, exactly as
+      // splitIntroducedDiagnostics consumes pre-existing diagnostics. What is
+      // left over did not exist before this mutation ran.
+      const remaining = new Map<string, number>();
+      for (const instance of baseline) {
+        if (instance.insertedRunTuples.length === 0) continue;
+        const fp = instanceFingerprint(instance);
+        remaining.set(fp, (remaining.get(fp) ?? 0) + 1);
+      }
+
+      const expected = tupleKey(convention.tuple);
+      const share = Math.round((convention.modeCount / convention.total) * 100);
+      const reported = new Set<string>();
+
+      for (const instance of preview) {
+        if (instance.insertedRunTuples.length === 0) continue;
+        if (!insertedKeys.has(instance.key)) continue;
+        const fp = instanceFingerprint(instance);
+        const count = remaining.get(fp) ?? 0;
+        if (count > 0) {
+          remaining.set(fp, count - 1); // pre-existing; not this mutation's doing
+          continue;
+        }
+
+        for (const tuple of instance.insertedRunTuples) {
+          const actual = tupleKey(tuple);
+          if (actual === expected) continue;
+          const dedupeKey = `${instance.key}|${actual}`;
+          if (reported.has(dedupeKey)) continue;
+          reported.add(dedupeKey);
+
+          warnings.push({
+            construct,
+            term: instance.label,
+            message:
+              `${FORMATTING_CONVENTION_WARNING_CODE}: inserted ${CONSTRUCT_LABELS[construct]} ` +
+              `"${instance.label}" is ${describeTuple(tuple)}, but ` +
+              `${convention.modeCount} of ${convention.total} (${share}%) of this document's ` +
+              `${CONSTRUCT_LABELS[construct]}s are ${describeTuple(convention.tuple)} ` +
+              `(construct=${construct})`,
+          });
+        }
+      }
+    }
+
+    return warnings;
+  } catch {
+    // Advisory check: never let a scan failure surface as an edit failure.
+    return [];
+  }
+}
+
+/**
+ * The construct keys present in `text`, for callers that must attribute a
+ * warning back to the step that produced it (batch_edit preflights the whole
+ * sequence at once, so the step is not otherwise recoverable).
+ */
+export function insertedConstructKeys(text: string): Map<ConventionConstruct, Set<string>> {
+  const out = new Map<ConventionConstruct, Set<string>>();
+  for (const construct of CONVENTION_CONSTRUCTS) {
+    const keys = new Set(MATCHERS[construct](text).map((span) => span.key));
+    if (keys.size > 0) out.set(construct, keys);
+  }
+  return out;
+}

--- a/packages/docx-mcp/src/tools/insert_paragraph.ts
+++ b/packages/docx-mcp/src/tools/insert_paragraph.ts
@@ -214,6 +214,10 @@ export async function insertParagraph(
           session,
           revisionCtx,
           (doc, activeCtx) => { mutate(doc, activeCtx); },
+          undefined,
+          // Formatting markup is not part of the construct match, so the gate
+          // reads the plain text this insertion adds (issue #687).
+          { insertedText: stripAllInlineTags(params.new_string) },
         );
     if (revisionPreflight?.blocked) return revisionPreflight.blocked;
 
@@ -234,6 +238,11 @@ export async function insertParagraph(
     if (res.styleSourceFallback) {
       responseData.style_source_warning = `style_source_id '${params.style_source_id}' not found; fell back to anchor paragraph formatting.`;
     }
+    // Same optional `warnings?: string[]` channel #701 gave the other mutating
+    // tools; insert_paragraph was left without one, which would have made the
+    // convention check unobservable on this path.
+    const warnings = revisionPreflight?.warnings ?? [];
+    if (warnings.length > 0) responseData.warnings = warnings;
     return ok(mergeSessionResolutionMetadata(responseData, metadata));
   } catch (e: unknown) {
     return err('INSERT_ERROR', `Failed to insert paragraph: ${errorMessage(e)}`);

--- a/packages/docx-mcp/src/tools/replace_text.ts
+++ b/packages/docx-mcp/src/tools/replace_text.ts
@@ -299,7 +299,11 @@ export async function replaceText(
 
     const revisionPreflight = params.skip_ai_revision_preflight
       ? null
-      : await preflightAiRevisionMutation(session, revisionCtx, mutate);
+      : await preflightAiRevisionMutation(session, revisionCtx, mutate, undefined, {
+          // Formatting markup is not part of the construct match, so the gate
+          // reads the plain text this edit inserts (issue #687).
+          insertedText: stripAllInlineTags(newStr),
+        });
     if (revisionPreflight?.blocked) return revisionPreflight.blocked;
     const warnings = revisionPreflight?.warnings ?? [];
 


### PR DESCRIPTION
Closes #687.

## The defect class

An edit can be well-formed and still visibly wrong. A replacement that introduces an inline defined term in plain runs, inside an agreement that sets every other parenthetical definition in bold, opens in Word, extracts byte-identical text, and passes `validate_document`. Nothing in the pipeline compares an inserted run against the document's own distribution of the same construct, so the defect is invisible to well-formedness checks (`validate_document`) and to revision-markup checks (`validate_ai_revisions`) alike. It is caught, if at all, by a human reading the output.

Both of #687's prerequisites were already on `main` and unused for this purpose: `extractEffectiveRunFormatting` (#684, PR #691) and the success-path `warnings` channel (#686, PR #701).

## What this adds

`packages/docx-mcp/src/tools/formatting_convention.ts` — a structural convention check that runs on the preview document `preflightAiRevisionMutation` already parses, and returns a warning on the channel #701 built.

Two construct classes:

1. **Inline defined terms** — a quoted term inside a parenthetical carrying definitional phrasing: `(the "X")`, `(each, a "X")`, `(collectively, the "X" and the "Y")`.
2. **Proviso keywords** — `provided` / `however` introduced by a semicolon.

For each, the modal `(bold, italic, underline)` tuple is computed over every comparable instance in the document *as it stood before the edit*, and an inserted run that diverges from the mode is reported.

Five properties the design holds to:

- **Structural, never textual.** Text locates instances; only run properties judge them.
- **Effective, not declared, formatting.** Resolution goes through `extractEffectiveRunFormatting`, so a run inheriting bold italic from a character style is not flagged. That is the whole reason #684 was a prerequisite.
- **Advisory.** The check cannot block an edit and degrades to silence on any unexpected document shape. It rides on a round trip already paid for — 150–195 ms per AI-attributed mutation, measured on #687.
- **Silent without a convention.** Fewer than 5 comparable instances, or a modal tuple below 80% of them, produces nothing rather than a guess. Thresholds are the ones settled in the #687 design comment, evaluated over the population of comparable constructs rather than the document at large.
- **This mutation's insertions, not the session's.** "Inserted" is decided by differencing the pre-mutation document against the preview, using the same multiset-consumption technique `splitIntroducedDiagnostics` already uses in `ai_revision_guard.ts`. A `w:ins` an earlier edit left behind is part of the document now: it keeps its vote on the convention and is not attributed to this edit.

The trigger is gated on the inserted text — the check runs only when the text being inserted itself contains a construct, and is skipped entirely otherwise. Settled on #687 (2026-07-29): cost does not constrain the trigger, so it is chosen for precision.

### Threshold justification

`N >= 5` comparable instances with `>= 80%` dominance, from the #687 design comment. Five is the smallest population where a single outlier (1 of 5 = 20%) still leaves the mode exactly at the bar, so one anomalous instance cannot by itself manufacture a convention; below that, two instances agreeing is coincidence. 80% is high enough that a document with two competing house styles produces silence — two distinct tuples cannot each hold 80%, so a tie can never pass — and low enough to survive the handful of exceptions every real agreement carries.

### One measurement that changed the design

The construct span covers the term *between* the quote marks, not the marks themselves. Measured across the two committed corpus agreements, the opening and closing quotes almost always sit in the neighbouring runs — `[" (the "", plain]["Fund", bold]["") is made on", plain]` is the typical shape — so a span including the marks reads as three disagreeing runs and the instance is discarded as incomparable. With the span including quote marks, **1 of 26** and **2 of 43** instances were comparable and neither document yielded a convention at all. Narrowed to the term, the same documents resolve cleanly:

| Corpus document (already committed, public-source) | Defined terms | Provisos |
|---|---|---|
| `tests/test_documents/nvca-coi-regression/source.docx` | 25 of 26 bold (96%) | 11 of 13 underlined (85%) |
| `tests/test_documents/redline/ILPA-Model-Limited-Parnership-Agreement-Deal-By-Deal_v1.docx` | 41 of 42 bold (98%) | 30 of 30 underlined (100%) |

Every number above is read off the documents at runtime by the test, not written down.

## Negative control

A convention checker that never fires is indistinguishable from one that always passes. The suite ships paired controls throughout: each silence assertion has a minimally-different sibling that fires on the same fixture, differing only in the seeded formatting, the instance count, the author attribution, or the gate text.

Six mutations were run against the finished suite. Each turns it red:

| Mutation | Tests failed |
|---|---|
| `checkFormattingConvention` returns `[]` unconditionally | 12 |
| Declared `w:rPr` substituted for `extractEffectiveRunFormatting` | 2 |
| Both thresholds removed | 2 |
| Baseline differencing removed (every AI `w:ins` treated as this mutation's) | 1 |
| Only the first inserted run judged instead of every one | 1 |
| Inter-quote grammar removed | 1 |

All fixtures are synthesised from scratch — generic parties, generic obligations, no borrowed prose. The two corpus documents are used read-only, as evidence that the matcher finds real conventions in the wild.

## Plumbing

- `replace_text` — passes its inserted text; the existing `warnings` field carries the finding.
- `insert_paragraph` — gains the optional `warnings` field its siblings received in #701. Without it the check would have been computed and dropped on this path.
- `batch_edit` — preflights the whole sequence at once, so each warning is attributed back to the step whose inserted text carries the construct, and reported through the per-step `{ step_id, warning }` channel it already exposes.
- `AiRevisionPreflightResult` gains `conventionWarnings`, the structured form of the *same* findings already in `warnings` — for callers that need attribution. Reading both double-reports; this is stated on the type.

No tool input schema changed, so `docs/tool-reference.generated.md` is unchanged and `check:tool-docs` is a no-op.

## Gates (observed)

| Gate | Result |
|---|---|
| `npm ci` | clean |
| `npm run build` | pass |
| `npm run test` | pass — docx-mcp **1006 passed / 1 skipped** across 103 files; docx-core 1341 passed, 2 expected fail, 15 skipped; docx-compare 849 passed / 106 skipped; odf-core 140; google-docs-core 116 / 35 skipped; suite total green |
| `npm run lint:workspaces` | pass — 0 errors, 10 pre-existing warnings on untouched files |
| `npm run check:tool-docs` | pass (no regeneration needed) |
| `npm run preflight:ci` | pass — spec coverage, Allure label/filename/quality, conformance citations, ECMA-376 coverage, capability projection, site build + 101 internal links, 713 files with no import cycles |
| New tests | 22, all passing |

## Peer review

Reviewed with Codex on the pushed diff. `safe-docx` is public, so no code-disclosure objection applies. Verdict: **REQUEST-CHANGES**, four MAJOR and three MINOR findings. All seven are fixed in this branch:

| Finding | Severity | Disposition |
|---|---|---|
| Prior same-author insertions reported as this edit's doing | MAJOR | Fixed — baseline/preview multiset differencing; the convention is now computed from the pre-mutation document and prior insertions keep their vote. Test: `does not blame this edit for an off-convention insertion an earlier edit left behind`, both directions. |
| A construct reduced to its largest run let a divergent fragment through | MAJOR | Fixed — every text-bearing run overlapping the construct is resolved and judged; heterogeneous instances no longer vote on the convention. Test: `reports a divergent fragment of a term split across runs`, with the term split 4/4 so no largest-overlap rule could see the second half. |
| `batch_edit` silently omitted the feature | MAJOR | Fixed — wired with per-step attribution through its existing `{ step_id, warning }` channel. Test asserts the warning lands on the step that caused it and not the sibling step. |
| Arbitrary prose between two quoted strings joined the population | MAJOR | Fixed — every inter-quote segment must match a conjunction grammar. `(the "Buyer" shall notify the "Seller")` now matches nothing. |
| Nested and unbalanced parentheses treated as valid enclosures | MINOR | Fixed — depth-tracking scanner replaces the regex; `((the "Term")`, `(the "Term" (as amended))`, and both unbalanced forms are rejected. |
| Curly single quotes conflict with apostrophes | MINOR | Fixed by removal — `’` is also the apostrophe, so `(the ‘Company’s Assets’)` closed at the possessive. Double quotes only, with the reason recorded at the constant. |
| Silence tests weak against mutation | MINOR | Fixed — every silence assertion is paired with a positive control on the same fixture, and the corpus test now asserts a dominant convention is actually found rather than only that the match count is nonzero. |

Codex separately confirmed as sound: no `lastIndex` leakage on the module-level global regexes (a regression test now pins this), no catastrophic backtracking in the lead-in grammar, `dominantRun`/`overlappingRuns` offsets agreeing with `getParagraphRuns` coordinates including complex fields, the check being unable to block or throw, convention warnings correctly discarded on the blocked path, and no double-reporting in the single-edit warning merge.

## Scope

Left alone deliberately: `batch_edit` still drops `preflightAiRevisionMutation`'s validation warnings (a #686 residue, unrelated to this check — only the convention findings are routed there); no tool description or input schema changed; the check is not wired into `format_layout`, `clear_formatting` or the footnote/comment tools, none of which insert prose runs.
