### PR TITLE
fix: verify real DOCX projections and hidden deletions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9216,6 +9216,7 @@
       "version": "0.19.1",
       "license": "Apache-2.0",
       "dependencies": {
+        "@xmldom/xmldom": "^0.9.10",
         "jszip": "^3.10.1"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -503,7 +503,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
       "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -513,7 +513,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -9215,6 +9215,9 @@
       "name": "@usejunior/docx-render-verifier",
       "version": "0.19.1",
       "license": "Apache-2.0",
+      "dependencies": {
+        "jszip": "^3.10.1"
+      },
       "devDependencies": {
         "@types/node": "^22.10.0",
         "typescript": "^5.7.2",

--- a/packages/docx-markdoc/src/docx-markdoc.test.ts
+++ b/packages/docx-markdoc/src/docx-markdoc.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect } from 'vitest';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
 import { itAllure } from '../../docx-core/src/testing/allure-test.js';
 import JSZip from 'jszip';
 import { buildDocxFromParts, buildSyntheticDocx, DocxDocument, parseXml } from '@usejunior/docx-core';
@@ -95,6 +97,29 @@ describe('brownfield Markdoc authoring', () => {
     const result = await compileMarkdoc(imported.anchoredSource, imported.markdoc);
     expect(result.certificate.passed).toBe(true);
   });
+
+  itAllure('[SDX-MDOC-01][SDX-MDOC-13] preserves trailing tabs in signature-label paragraphs during untouched replay', async () => {
+    // Public form documents commonly use literal tabs as blank signature lines.
+    // CommonMark discards them at line boundaries unless import encodes them.
+    const original = await buildSyntheticDocx({ paragraphs: ['By:\t\t', 'Address:\t\t\n\t', 'Total Cash \nPurchase Price'] });
+    const imported = await importDocxToMarkdoc(original);
+    expect(imported.markdoc).toContain('By:&#9;&#9;');
+    expect(imported.markdoc).toContain('Address:&#9;&#9;&#10;&#9;');
+    expect(imported.markdoc).toContain('Total Cash &#10;Purchase Price');
+    expect(requireMarkdoc(imported.markdoc).scaffold.map((paragraph) => paragraph.originalText))
+      .toEqual(['By:\t\t', 'Address:\t\t\n\t', 'Total Cash \nPurchase Price']);
+    const result = await compileMarkdoc(imported.anchoredSource, imported.markdoc);
+    expect(result.certificate).toMatchObject({ rejectAllEqualsSource: true, acceptAllEqualsClean: true, passed: true });
+  });
+
+  itAllure('[SDX-MDOC-01][SDX-MDOC-13] replays the existing public NVCA source and filled fixtures unchanged', async () => {
+    const directory = fileURLToPath(new URL('../../../tests/test_documents/nvca-regression/', import.meta.url));
+    for (const name of ['source.docx', 'filled.docx']) {
+      const imported = await importDocxToMarkdoc(await readFile(`${directory}${name}`));
+      const result = await compileMarkdoc(imported.anchoredSource, imported.markdoc);
+      expect(result.certificate).toMatchObject({ passed: true, rejectAllEqualsSource: true, acceptAllEqualsClean: true });
+    }
+  }, 20_000);
 
   itAllure('[SDX-MDOC-05][SDX-MDOC-13] applies and verifies paragraph insertion and deletion from stable anchors', async () => {
     const original = await buildSyntheticDocx({ paragraphs: ['Keep.', 'Delete me.', 'Stable tail context.'] });

--- a/packages/docx-markdoc/src/docx-markdoc.test.ts
+++ b/packages/docx-markdoc/src/docx-markdoc.test.ts
@@ -119,7 +119,7 @@ describe('brownfield Markdoc authoring', () => {
       const result = await compileMarkdoc(imported.anchoredSource, imported.markdoc);
       expect(result.certificate).toMatchObject({ passed: true, rejectAllEqualsSource: true, acceptAllEqualsClean: true });
     }
-  }, 20_000);
+  }, 60_000);
 
   itAllure('[SDX-MDOC-05][SDX-MDOC-13] applies and verifies paragraph insertion and deletion from stable anchors', async () => {
     const original = await buildSyntheticDocx({ paragraphs: ['Keep.', 'Delete me.', 'Stable tail context.'] });

--- a/packages/docx-markdoc/src/import.ts
+++ b/packages/docx-markdoc/src/import.ts
@@ -7,7 +7,12 @@ function escapeText(text: string): string {
     .replace(/&/g, '&amp;')
     .replace(/\\/g, '\\\\')
     .replace(/([`*_\[\]{}<>#!])/g, '\\$1')
-    .replace(/^(\d+)\./, '$1\\.');
+    .replace(/^(\d+)\./, '$1\\.')
+    // Keep OOXML tabs and explicit line breaks inside one CommonMark line.
+    // At Markdown line boundaries the parser discards adjacent horizontal
+    // whitespace before character references are materialized.
+    .replace(/\t/g, '&#9;')
+    .replace(/\n/g, '&#10;');
   // CommonMark discards syntactic whitespace at block boundaries. Character
   // references survive parsing as text, so preserve source-significant spaces
   // without introducing a second representation or raw OOXML.

--- a/packages/docx-release-verifier/src/minimality.test.ts
+++ b/packages/docx-release-verifier/src/minimality.test.ts
@@ -35,6 +35,21 @@ describe('independent emitted-redline minimality', () => {
     expect(whitespace.passed).toBe(true);
   });
 
+  itAllure('does not charge ordinary Word run, tab, or proofing fragmentation as a revision', () => {
+    const runAndTab = check(
+      ['Hourly Rate: \t$48.86  \t \tHourly rate includes: '],
+      ['Hourly Rate: \t$48.86  \t \tHourly rate includes: '],
+      paragraph('<w:r><w:t xml:space="preserve">Hourly Rate: </w:t><w:tab/></w:r><w:r><w:t>$48.</w:t></w:r><w:proofErr w:type="gramStart"/><w:r><w:t xml:space="preserve">86  </w:t><w:tab/></w:r><w:proofErr w:type="gramEnd"/><w:r><w:t xml:space="preserve"> </w:t><w:tab/></w:r><w:r><w:t xml:space="preserve">Hourly rate includes: </w:t></w:r>'),
+    );
+    const splitUnderscore = check(
+      ['\tCLIENT:____________________________      \tDate :__________________ '],
+      ['\tCLIENT:____________________________      \tDate :__________________ '],
+      paragraph('<w:r><w:tab/></w:r><w:proofErr w:type="gramStart"/><w:r><w:t>CLIENT:_</w:t></w:r><w:proofErr w:type="gramEnd"/><w:r><w:t xml:space="preserve">___________________________      </w:t><w:tab/></w:r><w:proofErr w:type="gramStart"/><w:r><w:t>Date :</w:t></w:r><w:proofErr w:type="gramEnd"/><w:r><w:t xml:space="preserve">__________________ </w:t></w:r>'),
+    );
+    expect(runAndTab).toMatchObject({ passed: true, lostTokens: 0 });
+    expect(splitUnderscore).toMatchObject({ passed: true, lostTokens: 0 });
+  });
+
   itAllure('admits true insertion and deletion without charging neighboring text', () => {
     const insertion = check(['a b'], ['a x b'], paragraph(`${plain('a ')}${ins('x ')}${plain('b')}`));
     const deletion = check(['a x b'], ['a b'], paragraph(`${plain('a ')}${del('x ')}${plain('b')}`));

--- a/packages/docx-release-verifier/src/verifier.test.ts
+++ b/packages/docx-release-verifier/src/verifier.test.ts
@@ -131,6 +131,26 @@ describe('independent release verifier', () => {
     expect(result.gates.minimality).toMatchObject({ status: 'pass', details: { evidence: { lostTokens: 0 } } });
   });
 
+  itAllure('does not apply Word revision semantics to foreign namespace name collisions', async () => {
+    const { manifest } = await fixture();
+    const visible = '<w:p xmlns:x="urn:foreign"><x:del><w:r><w:t>VISIBLE</w:t></w:r></x:del><x:ins><w:r><w:t>ADD</w:t></w:r></x:ins></w:p>';
+    await writeDocx(manifest.originalPath, visible);
+    await writeDocx(manifest.intendedCleanPath, visible);
+    await writeDocx(manifest.trackedPath, visible);
+    const result = await verifyRelease({
+      version: 1,
+      originalPath: manifest.originalPath,
+      intendedCleanPath: manifest.intendedCleanPath,
+      trackedPath: manifest.trackedPath,
+      mutationControl: { projection: 'accept', expected: 'intendedClean' },
+    });
+    expect(result.projections).toMatchObject({
+      original: { paragraphs: ['VISIBLEADD'] }, intendedClean: { paragraphs: ['VISIBLEADD'] },
+      accept: { paragraphs: ['VISIBLEADD'] }, reject: { paragraphs: ['VISIBLEADD'] },
+    });
+    expect(result.gates.semantic.status).toBe('pass');
+  });
+
   itAllure('derives exact accept/reject projections and proves mutation sensitivity without changing inputs', async () => {
     const { manifest } = await fixture();
     const before = await readFile(manifest.trackedPath);

--- a/packages/docx-release-verifier/src/verifier.test.ts
+++ b/packages/docx-release-verifier/src/verifier.test.ts
@@ -78,11 +78,15 @@ describe('independent release verifier', () => {
         <w:pPr><w:spacing w:before="120"/></w:pPr>
         <w:r><w:t>Hello</w:t></w:r>
         <w:r><w:t xml:space="preserve"> old</w:t></w:r>
+        <w:r><w:t>&#160;semantic&#160;</w:t></w:r>
+        <w:r><w:t>&#8195;em&#8195;</w:t></w:r>
       </w:p>`);
     await writeDocx(manifest.intendedCleanPath, `
       <w:p>
         <w:r><w:t>Hello</w:t></w:r>
         <w:r><w:t xml:space="preserve"> new</w:t></w:r>
+        <w:r><w:t>&#160;semantic&#160;</w:t></w:r>
+        <w:r><w:t>&#8195;em&#8195;</w:t></w:r>
       </w:p>`);
     await writeDocx(manifest.trackedPath, `
       <w:p>
@@ -90,14 +94,41 @@ describe('independent release verifier', () => {
         <w:r><w:t xml:space="preserve"> </w:t></w:r>
         <w:del w:id="1"><w:r><w:delText>old</w:delText></w:r></w:del>
         <w:ins w:id="2"><w:r><w:t>new</w:t></w:r></w:ins>
+        <w:r><w:t>&#160;semantic&#160;</w:t></w:r>
+        <w:r><w:t>&#8195;em&#8195;</w:t></w:r>
       </w:p>`);
-    const result = await verifyRelease(manifest);
+    const result = await verifyRelease({
+      version: 1,
+      originalPath: manifest.originalPath,
+      intendedCleanPath: manifest.intendedCleanPath,
+      trackedPath: manifest.trackedPath,
+      mutationControl: { projection: 'accept', expected: 'intendedClean' },
+    });
     expect(result.projections).toMatchObject({
-      original: { paragraphs: ['Hello old'] }, intendedClean: { paragraphs: ['Hello new'] },
-      accept: { paragraphs: ['Hello new'] }, reject: { paragraphs: ['Hello old'] },
+      original: { paragraphs: ['Hello old\u00a0semantic\u00a0\u2003em\u2003'] }, intendedClean: { paragraphs: ['Hello new\u00a0semantic\u00a0\u2003em\u2003'] },
+      accept: { paragraphs: ['Hello new\u00a0semantic\u00a0\u2003em\u2003'] }, reject: { paragraphs: ['Hello old\u00a0semantic\u00a0\u2003em\u2003'] },
     });
     expect(result.gates.semantic.status).toBe('pass');
     expect(result.gates.minimality.status).toBe('pass');
+  });
+
+  itAllure('does not fragment minimality tokens at empty or property-only revision wrappers', async () => {
+    const { manifest } = await fixture();
+    await writeDocx(manifest.originalPath, '<w:p><w:r><w:t>fragmented</w:t></w:r></w:p>');
+    await writeDocx(manifest.intendedCleanPath, '<w:p><w:r><w:t>fragmented</w:t></w:r></w:p>');
+    await writeDocx(manifest.trackedPath, '<w:p><w:r><w:t>frag</w:t></w:r><w:ins w:id="1"><w:r><w:rPr><w:b/></w:rPr></w:r></w:ins><w:r><w:t>mented</w:t></w:r></w:p>');
+    const result = await verifyRelease({
+      version: 1,
+      originalPath: manifest.originalPath,
+      intendedCleanPath: manifest.intendedCleanPath,
+      trackedPath: manifest.trackedPath,
+      mutationControl: { projection: 'accept', expected: 'intendedClean' },
+    });
+    expect(result.projections).toMatchObject({
+      original: { paragraphs: ['fragmented'] }, intendedClean: { paragraphs: ['fragmented'] },
+      accept: { paragraphs: ['fragmented'] }, reject: { paragraphs: ['fragmented'] },
+    });
+    expect(result.gates.minimality).toMatchObject({ status: 'pass', details: { evidence: { lostTokens: 0 } } });
   });
 
   itAllure('derives exact accept/reject projections and proves mutation sensitivity without changing inputs', async () => {

--- a/packages/docx-release-verifier/src/verifier.test.ts
+++ b/packages/docx-release-verifier/src/verifier.test.ts
@@ -2,11 +2,13 @@ import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
 import { createHash } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import JSZip from 'jszip';
 import { describe, expect } from 'vitest';
 import { itAllure } from '../../docx-core/src/testing/allure-test.js';
 import { verifyRelease } from './verifier.js';
 import type { ReleaseManifest } from './types.js';
+import { compileMarkdoc, importDocxToMarkdoc, requireMarkdoc } from '../../docx-markdoc/src/index.js';
 
 const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 
@@ -29,11 +31,75 @@ async function fixture(): Promise<{ directory: string; manifest: ReleaseManifest
   const trackedPath = join(directory, 'tracked.docx');
   await writeDocx(originalPath, '<w:p><w:r><w:t>Hello old</w:t></w:r></w:p>');
   await writeDocx(intendedCleanPath, '<w:p><w:r><w:t>Hello new</w:t></w:r></w:p>');
-  await writeDocx(trackedPath, '<w:p><w:r><w:t>Hello </w:t></w:r><w:del w:id="1"><w:r><w:delText>old</w:delText></w:r></w:del><w:ins w:id="2"><w:r><w:t>new</w:t></w:r></w:ins></w:p>');
+  await writeDocx(trackedPath, '<w:p><w:r><w:t xml:space="preserve">Hello </w:t></w:r><w:del w:id="1"><w:r><w:delText>old</w:delText></w:r></w:del><w:ins w:id="2"><w:r><w:t>new</w:t></w:r></w:ins></w:p>');
   return { directory, manifest: { version: 1, originalPath, intendedCleanPath, trackedPath, literalCounts: [{ text: 'Hello new', count: 1 }], presentOnlyInAccept: ['new'], absentFromAccept: ['old'], mutationControl: { projection: 'accept', expected: 'intendedClean' } } };
 }
 
 describe('independent release verifier', () => {
+  itAllure('verifies one surgical edit against the public OpenAgreements Letter of Intent', async () => {
+    const fixturePath = fileURLToPath(new URL('../../../tests/test_documents/open-agreements/letter-of-intent.docx', import.meta.url));
+    const original = await readFile(fixturePath);
+    const imported = await importDocxToMarkdoc(original);
+    const paragraph = requireMarkdoc(imported.markdoc).scaffold.find((entry) => entry.originalText === 'Letter of Intent');
+    if (!paragraph) throw new Error('Public LOI title paragraph missing');
+    const block = new RegExp(`\\{% para id="${paragraph.id}"[\\s\\S]*?\\{% /para %\\}`);
+    const replacement = [
+      `{% change id="${paragraph.id}" fingerprint="${paragraph.fingerprint}" style="${paragraph.style}" operation="clarify-title" format="inherit-source-paragraph" %}`,
+      '{% before %}', 'Letter of Intent', '{% /before %}',
+      '{% after %}', 'Mutual Letter of Intent', '{% /after %}', '{% /change %}',
+    ].join('\n');
+    const compiled = await compileMarkdoc(imported.anchoredSource, imported.markdoc.replace(block, replacement));
+    const directory = await mkdtemp(join(tmpdir(), 'release-loi-public-'));
+    const originalPath = join(directory, 'anchored.docx');
+    const intendedCleanPath = join(directory, 'clean.docx');
+    const trackedPath = join(directory, 'tracked.docx');
+    await Promise.all([
+      writeFile(originalPath, imported.anchoredSource), writeFile(intendedCleanPath, compiled.clean), writeFile(trackedPath, compiled.tracked),
+    ]);
+    const beforeTracked = await readFile(trackedPath);
+    const result = await verifyRelease({
+      version: 1, originalPath, intendedCleanPath, trackedPath,
+      presentOnlyInAccept: ['Mutual Letter of Intent'],
+      mutationControl: { projection: 'accept', expected: 'intendedClean' },
+    });
+    expect(result.gates.semantic.status).toBe('pass');
+    expect(result.gates.minimality).toMatchObject({ status: 'pass', details: { evidence: { lostTokens: 0 } } });
+    expect(result.gates.package.status).toBe('pass');
+    expect(result.gates.mutationControl.status).toBe('pass');
+    expect(result.exitCode).toBe(0);
+    expect(await readFile(trackedPath)).toEqual(beforeTracked);
+    expect(await readFile(fixturePath)).toEqual(original);
+  });
+
+  itAllure('projects namespace-aware visible OOXML without indentation or run-fragmentation noise', async () => {
+    const { manifest } = await fixture();
+    await writeDocx(manifest.originalPath, `
+      <w:p>
+        <w:pPr><w:spacing w:before="120"/></w:pPr>
+        <w:r><w:t>Hello</w:t></w:r>
+        <w:r><w:t xml:space="preserve"> old</w:t></w:r>
+      </w:p>`);
+    await writeDocx(manifest.intendedCleanPath, `
+      <w:p>
+        <w:r><w:t>Hello</w:t></w:r>
+        <w:r><w:t xml:space="preserve"> new</w:t></w:r>
+      </w:p>`);
+    await writeDocx(manifest.trackedPath, `
+      <w:p>
+        <w:r><w:t>Hello</w:t></w:r>
+        <w:r><w:t xml:space="preserve"> </w:t></w:r>
+        <w:del w:id="1"><w:r><w:delText>old</w:delText></w:r></w:del>
+        <w:ins w:id="2"><w:r><w:t>new</w:t></w:r></w:ins>
+      </w:p>`);
+    const result = await verifyRelease(manifest);
+    expect(result.projections).toMatchObject({
+      original: { paragraphs: ['Hello old'] }, intendedClean: { paragraphs: ['Hello new'] },
+      accept: { paragraphs: ['Hello new'] }, reject: { paragraphs: ['Hello old'] },
+    });
+    expect(result.gates.semantic.status).toBe('pass');
+    expect(result.gates.minimality.status).toBe('pass');
+  });
+
   itAllure('derives exact accept/reject projections and proves mutation sensitivity without changing inputs', async () => {
     const { manifest } = await fixture();
     const before = await readFile(manifest.trackedPath);
@@ -70,7 +136,7 @@ describe('independent release verifier', () => {
   itAllure('fails native comment integrity when OOXML comment IDs disagree', async () => {
     const { manifest } = await fixture();
     await writeDocx(manifest.trackedPath,
-      '<w:p><w:commentRangeStart w:id="1"/><w:r><w:t>Hello </w:t></w:r><w:del w:id="1"><w:r><w:delText>old</w:delText></w:r></w:del><w:ins w:id="2"><w:r><w:t>new</w:t></w:r></w:ins><w:commentRangeEnd w:id="2"/><w:r><w:commentReference w:id="1"/></w:r></w:p>',
+      '<w:p><w:commentRangeStart w:id="1"/><w:r><w:t xml:space="preserve">Hello </w:t></w:r><w:del w:id="1"><w:r><w:delText>old</w:delText></w:r></w:del><w:ins w:id="2"><w:r><w:t>new</w:t></w:r></w:ins><w:commentRangeEnd w:id="2"/><w:r><w:commentReference w:id="1"/></w:r></w:p>',
       `<w:comments xmlns:w="${W}"><w:comment w:id="1"/></w:comments>`);
     const result = await verifyRelease({ ...manifest, requireNativeComments: true });
     expect(result.gates.comments.status).toBe('fail');

--- a/packages/docx-release-verifier/src/xml.ts
+++ b/packages/docx-release-verifier/src/xml.ts
@@ -13,7 +13,7 @@ function isWord(element: XmlElement, localName: string): boolean {
 function wordText(element: XmlElement): string {
   const value = element.textContent ?? '';
   const space = element.getAttributeNS('http://www.w3.org/XML/1998/namespace', 'space') ?? element.getAttribute('xml:space');
-  return space === 'preserve' ? value : value.replace(/^\s+|\s+$/gu, '');
+  return space === 'preserve' ? value : value.replace(/^[\u0009\u000a\u000d\u0020]+|[\u0009\u000a\u000d\u0020]+$/gu, '');
 }
 
 function textFrom(element: XmlElement, mode: 'accept' | 'reject'): string {
@@ -60,7 +60,9 @@ function ordinaryTextNodes(element: XmlElement): string[] {
   };
   const visit = (node: XmlElement): void => {
     if (node.namespaceURI === W_NS && REVISION_WRAPPERS.has(node.localName ?? '')) {
-      flush();
+      // Empty/property-only revision wrappers do not separate visible text and
+      // must not fragment an otherwise ordinary token or whitespace run.
+      if (textFrom(node, 'accept') !== '' || textFrom(node, 'reject') !== '') flush();
       return;
     }
     if (isWord(node, 'tab')) current += '\t';

--- a/packages/docx-release-verifier/src/xml.ts
+++ b/packages/docx-release-verifier/src/xml.ts
@@ -18,7 +18,8 @@ function wordText(element: XmlElement): string {
 
 function textFrom(element: XmlElement, mode: 'accept' | 'reject'): string {
   const localName = element.localName ?? '';
-  if ((mode === 'accept' && OMIT_ON_ACCEPT.has(localName)) || (mode === 'reject' && OMIT_ON_REJECT.has(localName))) return '';
+  const wordRevision = element.namespaceURI === W_NS;
+  if (wordRevision && ((mode === 'accept' && OMIT_ON_ACCEPT.has(localName)) || (mode === 'reject' && OMIT_ON_REJECT.has(localName)))) return '';
   if (isWord(element, 'tab')) return '\t';
   if (isWord(element, 'br') || isWord(element, 'cr')) return '\n';
   if (isWord(element, 't')) return wordText(element);

--- a/packages/docx-release-verifier/src/xml.ts
+++ b/packages/docx-release-verifier/src/xml.ts
@@ -10,15 +10,22 @@ function isWord(element: XmlElement, localName: string): boolean {
   return element.namespaceURI === W_NS && element.localName === localName;
 }
 
+function wordText(element: XmlElement): string {
+  const value = element.textContent ?? '';
+  const space = element.getAttributeNS('http://www.w3.org/XML/1998/namespace', 'space') ?? element.getAttribute('xml:space');
+  return space === 'preserve' ? value : value.replace(/^\s+|\s+$/gu, '');
+}
+
 function textFrom(element: XmlElement, mode: 'accept' | 'reject'): string {
   const localName = element.localName ?? '';
   if ((mode === 'accept' && OMIT_ON_ACCEPT.has(localName)) || (mode === 'reject' && OMIT_ON_REJECT.has(localName))) return '';
   if (isWord(element, 'tab')) return '\t';
   if (isWord(element, 'br') || isWord(element, 'cr')) return '\n';
+  if (isWord(element, 't')) return wordText(element);
+  if (isWord(element, 'delText')) return mode === 'reject' ? wordText(element) : '';
   let text = '';
   for (const child of Array.from(element.childNodes)) {
-    if (child.nodeType === 3 || child.nodeType === 4) text += child.nodeValue ?? '';
-    else if (child.nodeType === 1) text += textFrom(child as XmlElement, mode);
+    if (child.nodeType === 1) text += textFrom(child as XmlElement, mode);
   }
   return text;
 }
@@ -44,16 +51,29 @@ export interface TrackedParagraphView {
   ordinaryTextNodes: string[];
 }
 
-function ordinaryTextNodes(element: XmlElement, insideRevision = false): string[] {
-  const revision = insideRevision || (element.namespaceURI === W_NS && REVISION_WRAPPERS.has(element.localName ?? ''));
-  if (revision) return [];
-  if (isWord(element, 'tab')) return ['\t'];
-  if (isWord(element, 'br') || isWord(element, 'cr')) return ['\n'];
-  if (isWord(element, 't')) return [element.textContent ?? ''];
+function ordinaryTextNodes(element: XmlElement): string[] {
   const result: string[] = [];
-  for (const child of Array.from(element.childNodes)) {
-    if (child.nodeType === 1) result.push(...ordinaryTextNodes(child as XmlElement, revision));
-  }
+  let current = '';
+  const flush = (): void => {
+    if (current !== '') result.push(current);
+    current = '';
+  };
+  const visit = (node: XmlElement): void => {
+    if (node.namespaceURI === W_NS && REVISION_WRAPPERS.has(node.localName ?? '')) {
+      flush();
+      return;
+    }
+    if (isWord(node, 'tab')) current += '\t';
+    else if (isWord(node, 'br') || isWord(node, 'cr')) current += '\n';
+    else if (isWord(node, 't')) current += wordText(node);
+    else {
+      for (const child of Array.from(node.childNodes)) {
+        if (child.nodeType === 1) visit(child as XmlElement);
+      }
+    }
+  };
+  visit(element);
+  flush();
   return result;
 }
 

--- a/packages/docx-render-verifier/README.md
+++ b/packages/docx-render-verifier/README.md
@@ -10,6 +10,10 @@ text, measures broad blue/red pixel bands after downsampling, and writes only
 selected PDF-page PNGs to the requested output path. Required missing tools are
 reported as `not_run`, not pass.
 
+If Writer displays configured insertions but suppresses deletions, verification
+fails with `revisionVisibility: "hidden-deletions"` rather than reporting only
+a generic colour-contrast failure.
+
 An optional render transform receives only a copied input and a disposable
 workspace. The verifier hashes the authoritative DOCX before and after and
 rejects any transform that changes it or returns a path outside the workspace.

--- a/packages/docx-render-verifier/package.json
+++ b/packages/docx-render-verifier/package.json
@@ -18,6 +18,7 @@
     "vitest": "^4.1.8"
   },
   "dependencies": {
+    "@xmldom/xmldom": "^0.9.10",
     "jszip": "^3.10.1"
   },
   "engines": { "node": ">=20.0.0" },

--- a/packages/docx-render-verifier/package.json
+++ b/packages/docx-render-verifier/package.json
@@ -17,6 +17,9 @@
     "typescript": "^5.7.2",
     "vitest": "^4.1.8"
   },
+  "dependencies": {
+    "jszip": "^3.10.1"
+  },
   "engines": { "node": ">=20.0.0" },
   "repository": { "type": "git", "url": "git+https://github.com/UseJunior/safe-docx.git" },
   "license": "Apache-2.0"

--- a/packages/docx-render-verifier/src/render.test.ts
+++ b/packages/docx-render-verifier/src/render.test.ts
@@ -39,15 +39,19 @@ function fakeTools(markup = 'Visible markup text', profiles?: string[], hiddenDe
   };
 }
 
-async function trackedFixture(pathname: string, revision: 'ins' | 'del' | 'empty-del', headerDeletion = false): Promise<void> {
+async function trackedFixture(pathname: string, revision: 'ins' | 'del' | 'empty-del', headerDeletion: 'none' | 'orphan' | 'referenced' = 'none'): Promise<void> {
   const zip = new JSZip();
   zip.file('[Content_Types].xml', '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"/>');
   const markup = revision === 'empty-del'
     ? '<w:del w:id="1"><w:r><w:rPr><w:b/></w:rPr></w:r></w:del>'
     : `<w:${revision} w:id="1"><w:r><w:${revision === 'del' ? 'delText' : 't'}>revision</w:${revision === 'del' ? 'delText' : 't'}></w:r></w:${revision}>`;
-  zip.file('word/document.xml', `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p>${markup}</w:p></w:body></w:document>`);
-  if (headerDeletion) {
+  const headerReference = headerDeletion === 'referenced' ? '<w:sectPr><w:headerReference r:id="rIdHeader1"/></w:sectPr>' : '';
+  zip.file('word/document.xml', `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><w:body><w:p>${markup}</w:p>${headerReference}</w:body></w:document>`);
+  if (headerDeletion !== 'none') {
     zip.file('word/header1.xml', '<w:hdr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:p><w:del w:id="2"><w:r><w:delText>header deletion</w:delText></w:r></w:del></w:p></w:hdr>');
+  }
+  if (headerDeletion === 'referenced') {
+    zip.file('word/_rels/document.xml.rels', '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rIdHeader1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/header" Target="header1.xml"/></Relationships>');
   }
   await writeFile(pathname, await zip.generateAsync({ type: 'nodebuffer' }));
 }
@@ -137,12 +141,24 @@ describe('renderer verifier', () => {
     const root = path.join(os.tmpdir(), `render-header-deletion-${Date.now()}`);
     const source = path.join(root, 'tracked.docx');
     await mkdir(root, { recursive: true });
-    await trackedFixture(source, 'ins', true);
+    await trackedFixture(source, 'ins', 'referenced');
     const result = await verifyRenderedMarkup({
       trackedDocxPath: source, expectedMarkupText: 'Visible markup text', outputDir: path.join(root, 'out'),
       tools: fakeTools('Visible markup text', undefined, true), configuredPixelFloor: 2,
     });
     expect(result).toMatchObject({ status: 'fail', revisionVisibility: 'hidden-deletions' });
+  });
+
+  itAllure('ignores deletion payload in an orphaned unreferenced header part', async () => {
+    const root = path.join(os.tmpdir(), `render-orphan-header-${Date.now()}`);
+    const source = path.join(root, 'tracked.docx');
+    await mkdir(root, { recursive: true });
+    await trackedFixture(source, 'ins', 'orphan');
+    const result = await verifyRenderedMarkup({
+      trackedDocxPath: source, expectedMarkupText: 'Visible markup text', outputDir: path.join(root, 'out'),
+      tools: fakeTools('Visible markup text', undefined, true), configuredPixelFloor: 2,
+    });
+    expect(result).toMatchObject({ status: 'fail', revisionVisibility: 'insufficient-contrast' });
   });
 
   itAllure('classifies deletion evidence from the disposable transformed input', async () => {

--- a/packages/docx-render-verifier/src/render.test.ts
+++ b/packages/docx-render-verifier/src/render.test.ts
@@ -39,13 +39,16 @@ function fakeTools(markup = 'Visible markup text', profiles?: string[], hiddenDe
   };
 }
 
-async function trackedFixture(pathname: string, revision: 'ins' | 'del' | 'empty-del'): Promise<void> {
+async function trackedFixture(pathname: string, revision: 'ins' | 'del' | 'empty-del', headerDeletion = false): Promise<void> {
   const zip = new JSZip();
   zip.file('[Content_Types].xml', '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"/>');
   const markup = revision === 'empty-del'
     ? '<w:del w:id="1"><w:r><w:rPr><w:b/></w:rPr></w:r></w:del>'
     : `<w:${revision} w:id="1"><w:r><w:${revision === 'del' ? 'delText' : 't'}>revision</w:${revision === 'del' ? 'delText' : 't'}></w:r></w:${revision}>`;
   zip.file('word/document.xml', `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p>${markup}</w:p></w:body></w:document>`);
+  if (headerDeletion) {
+    zip.file('word/header1.xml', '<w:hdr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:p><w:del w:id="2"><w:r><w:delText>header deletion</w:delText></w:r></w:del></w:p></w:hdr>');
+  }
   await writeFile(pathname, await zip.generateAsync({ type: 'nodebuffer' }));
 }
 
@@ -128,6 +131,18 @@ describe('renderer verifier', () => {
     });
     expect(result).toMatchObject({ status: 'fail', revisionVisibility: 'insufficient-contrast' });
     expect(result.reason).not.toContain('hid configured deletions');
+  });
+
+  itAllure('recognizes visible deletion payload in a rendered header story', async () => {
+    const root = path.join(os.tmpdir(), `render-header-deletion-${Date.now()}`);
+    const source = path.join(root, 'tracked.docx');
+    await mkdir(root, { recursive: true });
+    await trackedFixture(source, 'ins', true);
+    const result = await verifyRenderedMarkup({
+      trackedDocxPath: source, expectedMarkupText: 'Visible markup text', outputDir: path.join(root, 'out'),
+      tools: fakeTools('Visible markup text', undefined, true), configuredPixelFloor: 2,
+    });
+    expect(result).toMatchObject({ status: 'fail', revisionVisibility: 'hidden-deletions' });
   });
 
   itAllure('classifies deletion evidence from the disposable transformed input', async () => {

--- a/packages/docx-render-verifier/src/render.test.ts
+++ b/packages/docx-render-verifier/src/render.test.ts
@@ -7,7 +7,7 @@ import { itAllure } from '../../docx-core/src/testing/allure-test.js';
 import { measurePixelBands, verifyRenderedMarkup } from './render.js';
 import type { RendererTools } from './types.js';
 
-function fakeTools(markup = 'Visible markup text', profiles?: string[]): RendererTools {
+function fakeTools(markup = 'Visible markup text', profiles?: string[], hiddenDeletion = false): RendererTools {
   return {
     resolve: () => 'fake-tool',
     async run(_command, args) {
@@ -30,7 +30,9 @@ function fakeTools(markup = 'Visible markup text', profiles?: string[]): Rendere
       const control = args[0]?.includes('control') ?? false;
       const pixels = control
         ? '0,0: #000000\n1,0: #000000\n'
-        : '0,0: #0000ff\n1,0: #ff0000\n2,0: #0000ff\n3,0: #ff0000\n';
+        : hiddenDeletion
+          ? '0,0: #0000ff\n1,0: #0000ff\n2,0: #000000\n3,0: #000000\n'
+          : '0,0: #0000ff\n1,0: #ff0000\n2,0: #0000ff\n3,0: #ff0000\n';
       return { code: 0, stdout: pixels, stderr: '' };
     },
   };
@@ -66,7 +68,7 @@ describe('renderer verifier', () => {
       tools: fakeTools('Visible markup text', profiles),
       configuredPixelFloor: 2,
     });
-    expect(result).toMatchObject({ status: 'pass', markupTextMatchesPdf: true, configuredContrastPassed: true });
+    expect(result).toMatchObject({ status: 'pass', markupTextMatchesPdf: true, configuredContrastPassed: true, revisionVisibility: 'visible' });
     expect(result.reviewPngs).toHaveLength(1);
     expect(profiles).toEqual(expect.arrayContaining([
       expect.stringContaining('/org.openoffice.Office.Writer/Revision/TextDisplay/Insert'),
@@ -74,6 +76,21 @@ describe('renderer verifier', () => {
       expect.stringContaining('<value>16711680</value>'),
       expect.stringContaining('<value>-1</value>'),
     ]));
+  });
+
+  itAllure('classifies blue-only revision output as hidden deletions and never passes it', async () => {
+    const root = path.join(os.tmpdir(), `render-hidden-delete-${Date.now()}`);
+    const source = path.join(root, 'tracked.docx');
+    await mkdir(root, { recursive: true });
+    await writeFile(source, 'tracked content');
+    const result = await verifyRenderedMarkup({
+      trackedDocxPath: source, expectedMarkupText: 'Visible markup text', outputDir: path.join(root, 'out'),
+      tools: fakeTools('Visible markup text', undefined, true), configuredPixelFloor: 2,
+    });
+    expect(result).toMatchObject({
+      status: 'fail', revisionVisibility: 'hidden-deletions', configuredContrastPassed: false,
+      reason: expect.stringContaining('hid configured deletions'),
+    });
   });
 
   itAllure('refuses a transform that mutates the authoritative DOCX', async () => {

--- a/packages/docx-render-verifier/src/render.test.ts
+++ b/packages/docx-render-verifier/src/render.test.ts
@@ -39,10 +39,13 @@ function fakeTools(markup = 'Visible markup text', profiles?: string[], hiddenDe
   };
 }
 
-async function trackedFixture(pathname: string, revision: 'ins' | 'del'): Promise<void> {
+async function trackedFixture(pathname: string, revision: 'ins' | 'del' | 'empty-del'): Promise<void> {
   const zip = new JSZip();
   zip.file('[Content_Types].xml', '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"/>');
-  zip.file('word/document.xml', `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:${revision} w:id="1"><w:r><w:${revision === 'del' ? 'delText' : 't'}>revision</w:${revision === 'del' ? 'delText' : 't'}></w:r></w:${revision}></w:p></w:body></w:document>`);
+  const markup = revision === 'empty-del'
+    ? '<w:del w:id="1"><w:r><w:rPr><w:b/></w:rPr></w:r></w:del>'
+    : `<w:${revision} w:id="1"><w:r><w:${revision === 'del' ? 'delText' : 't'}>revision</w:${revision === 'del' ? 'delText' : 't'}></w:r></w:${revision}>`;
+  zip.file('word/document.xml', `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p>${markup}</w:p></w:body></w:document>`);
   await writeFile(pathname, await zip.generateAsync({ type: 'nodebuffer' }));
 }
 
@@ -112,6 +115,19 @@ describe('renderer verifier', () => {
       status: 'fail', revisionVisibility: 'insufficient-contrast',
       reason: expect.stringContaining('PDF text does not equal'),
     });
+  });
+
+  itAllure('does not diagnose hidden deletions from an empty property-only deletion wrapper', async () => {
+    const root = path.join(os.tmpdir(), `render-empty-deletion-${Date.now()}`);
+    const source = path.join(root, 'tracked.docx');
+    await mkdir(root, { recursive: true });
+    await trackedFixture(source, 'empty-del');
+    const result = await verifyRenderedMarkup({
+      trackedDocxPath: source, expectedMarkupText: 'Visible markup text', outputDir: path.join(root, 'out'),
+      tools: fakeTools('Visible markup text', undefined, true), configuredPixelFloor: 2,
+    });
+    expect(result).toMatchObject({ status: 'fail', revisionVisibility: 'insufficient-contrast' });
+    expect(result.reason).not.toContain('hid configured deletions');
   });
 
   itAllure('classifies blue-only revision output as hidden deletions and never passes it', async () => {

--- a/packages/docx-render-verifier/src/render.test.ts
+++ b/packages/docx-render-verifier/src/render.test.ts
@@ -130,6 +130,46 @@ describe('renderer verifier', () => {
     expect(result.reason).not.toContain('hid configured deletions');
   });
 
+  itAllure('classifies deletion evidence from the disposable transformed input', async () => {
+    const root = path.join(os.tmpdir(), `render-transform-add-deletion-${Date.now()}`);
+    const source = path.join(root, 'tracked.docx');
+    await mkdir(root, { recursive: true });
+    await trackedFixture(source, 'ins');
+    const result = await verifyRenderedMarkup({
+      trackedDocxPath: source, expectedMarkupText: 'Visible markup text', outputDir: path.join(root, 'out'),
+      tools: fakeTools('Visible markup text', undefined, true), configuredPixelFloor: 2,
+      transform: {
+        id: 'add-visible-deletion', version: '1',
+        async apply(_input, workspace) {
+          const output = path.join(workspace, 'render-only.docx');
+          await trackedFixture(output, 'del');
+          return output;
+        },
+      },
+    });
+    expect(result).toMatchObject({ status: 'fail', revisionVisibility: 'hidden-deletions' });
+  });
+
+  itAllure('does not use authoritative-source deletion evidence removed by a render transform', async () => {
+    const root = path.join(os.tmpdir(), `render-transform-remove-deletion-${Date.now()}`);
+    const source = path.join(root, 'tracked.docx');
+    await mkdir(root, { recursive: true });
+    await trackedFixture(source, 'del');
+    const result = await verifyRenderedMarkup({
+      trackedDocxPath: source, expectedMarkupText: 'Visible markup text', outputDir: path.join(root, 'out'),
+      tools: fakeTools('Visible markup text', undefined, true), configuredPixelFloor: 2,
+      transform: {
+        id: 'remove-visible-deletion', version: '1',
+        async apply(_input, workspace) {
+          const output = path.join(workspace, 'render-only.docx');
+          await trackedFixture(output, 'ins');
+          return output;
+        },
+      },
+    });
+    expect(result).toMatchObject({ status: 'fail', revisionVisibility: 'insufficient-contrast' });
+  });
+
   itAllure('classifies blue-only revision output as hidden deletions and never passes it', async () => {
     const root = path.join(os.tmpdir(), `render-hidden-delete-${Date.now()}`);
     const source = path.join(root, 'tracked.docx');

--- a/packages/docx-render-verifier/src/render.test.ts
+++ b/packages/docx-render-verifier/src/render.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect } from 'vitest';
 import { itAllure } from '../../docx-core/src/testing/allure-test.js';
+import JSZip from 'jszip';
 import { measurePixelBands, verifyRenderedMarkup } from './render.js';
 import type { RendererTools } from './types.js';
 
@@ -38,6 +39,13 @@ function fakeTools(markup = 'Visible markup text', profiles?: string[], hiddenDe
   };
 }
 
+async function trackedFixture(pathname: string, revision: 'ins' | 'del'): Promise<void> {
+  const zip = new JSZip();
+  zip.file('[Content_Types].xml', '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"/>');
+  zip.file('word/document.xml', `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:${revision} w:id="1"><w:r><w:${revision === 'del' ? 'delText' : 't'}>revision</w:${revision === 'del' ? 'delText' : 't'}></w:r></w:${revision}></w:p></w:body></w:document>`);
+  await writeFile(pathname, await zip.generateAsync({ type: 'nodebuffer' }));
+}
+
 describe('renderer verifier', () => {
   itAllure('counts broad blue and red pixel bands rather than requiring exact antialiasing pixels', () => {
     expect(measurePixelBands('0,0: #0a10ef\n1,0: #ef120c\n2,0: #202020\n')).toEqual({ sampledPixels: 3, bluePixels: 1, redPixels: 1 });
@@ -59,7 +67,7 @@ describe('renderer verifier', () => {
     const root = path.join(os.tmpdir(), `render-fake-${Date.now()}`);
     const source = path.join(root, 'tracked.docx');
     await mkdir(root, { recursive: true });
-    await writeFile(source, 'tracked content');
+    await trackedFixture(source, 'del');
     const profiles: string[] = [];
     const result = await verifyRenderedMarkup({
       trackedDocxPath: source,
@@ -78,11 +86,39 @@ describe('renderer verifier', () => {
     ]));
   });
 
+  itAllure('does not diagnose hidden deletions when the tracked document has insertions only', async () => {
+    const root = path.join(os.tmpdir(), `render-insertion-only-${Date.now()}`);
+    const source = path.join(root, 'tracked.docx');
+    await mkdir(root, { recursive: true });
+    await trackedFixture(source, 'ins');
+    const result = await verifyRenderedMarkup({
+      trackedDocxPath: source, expectedMarkupText: 'Visible markup text', outputDir: path.join(root, 'out'),
+      tools: fakeTools('Visible markup text', undefined, true), configuredPixelFloor: 2,
+    });
+    expect(result).toMatchObject({ status: 'fail', revisionVisibility: 'insufficient-contrast' });
+    expect(result.reason).not.toContain('hid configured deletions');
+  });
+
+  itAllure('prioritizes a PDF text mismatch over a hidden-deletion pixel pattern', async () => {
+    const root = path.join(os.tmpdir(), `render-text-mismatch-${Date.now()}`);
+    const source = path.join(root, 'tracked.docx');
+    await mkdir(root, { recursive: true });
+    await trackedFixture(source, 'del');
+    const result = await verifyRenderedMarkup({
+      trackedDocxPath: source, expectedMarkupText: 'Different expected text', outputDir: path.join(root, 'out'),
+      tools: fakeTools('Visible markup text', undefined, true), configuredPixelFloor: 2,
+    });
+    expect(result).toMatchObject({
+      status: 'fail', revisionVisibility: 'insufficient-contrast',
+      reason: expect.stringContaining('PDF text does not equal'),
+    });
+  });
+
   itAllure('classifies blue-only revision output as hidden deletions and never passes it', async () => {
     const root = path.join(os.tmpdir(), `render-hidden-delete-${Date.now()}`);
     const source = path.join(root, 'tracked.docx');
     await mkdir(root, { recursive: true });
-    await writeFile(source, 'tracked content');
+    await trackedFixture(source, 'del');
     const result = await verifyRenderedMarkup({
       trackedDocxPath: source, expectedMarkupText: 'Visible markup text', outputDir: path.join(root, 'out'),
       tools: fakeTools('Visible markup text', undefined, true), configuredPixelFloor: 2,

--- a/packages/docx-render-verifier/src/render.ts
+++ b/packages/docx-render-verifier/src/render.ts
@@ -102,9 +102,21 @@ function revisionVisibility(configured: PixelMeasurement, control: PixelMeasurem
 async function hasDeletionMarkup(bytes: Buffer): Promise<boolean> {
   try {
     const zip = await JSZip.loadAsync(bytes);
-    const documentXml = await zip.file('word/document.xml')?.async('string');
-    if (documentXml === undefined) return false;
-    const document = new DOMParser().parseFromString(documentXml, 'application/xml');
+    const renderedStories = Object.keys(zip.files).filter((name) =>
+      /^word\/(?:document|header[^/]*|footer[^/]*|footnotes|endnotes)\.xml$/u.test(name));
+    for (const name of renderedStories) {
+      const xml = await zip.file(name)?.async('string');
+      if (xml !== undefined && hasVisibleDeletionInStory(xml)) return true;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+function hasVisibleDeletionInStory(xml: string): boolean {
+  try {
+    const document = new DOMParser().parseFromString(xml, 'application/xml');
     if (document.getElementsByTagName('parsererror').length > 0) return false;
     const wrappers = [
       ...Array.from(document.getElementsByTagNameNS(W_NS, 'del')),

--- a/packages/docx-render-verifier/src/render.ts
+++ b/packages/docx-render-verifier/src/render.ts
@@ -14,6 +14,9 @@ const execFileAsync = promisify(execFile);
 const BLUE = [0, 0, 255] as const;
 const RED = [255, 0, 0] as const;
 const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const R_NS = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const PKG_REL_NS = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OFFICE_REL_PREFIX = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/';
 
 function sha256(bytes: Buffer): string {
   return createHash('sha256').update(bytes).digest('hex');
@@ -102,8 +105,9 @@ function revisionVisibility(configured: PixelMeasurement, control: PixelMeasurem
 async function hasDeletionMarkup(bytes: Buffer): Promise<boolean> {
   try {
     const zip = await JSZip.loadAsync(bytes);
-    const renderedStories = Object.keys(zip.files).filter((name) =>
-      /^word\/(?:document|header[^/]*|footer[^/]*|footnotes|endnotes)\.xml$/u.test(name));
+    const documentXml = await zip.file('word/document.xml')?.async('string');
+    if (documentXml === undefined) return false;
+    const renderedStories = await referencedRenderedStories(zip, documentXml);
     for (const name of renderedStories) {
       const xml = await zip.file(name)?.async('string');
       if (xml !== undefined && hasVisibleDeletionInStory(xml)) return true;
@@ -112,6 +116,40 @@ async function hasDeletionMarkup(bytes: Buffer): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+async function referencedRenderedStories(zip: JSZip, documentXml: string): Promise<string[]> {
+  const stories = ['word/document.xml'];
+  const document = new DOMParser().parseFromString(documentXml, 'application/xml');
+  if (document.getElementsByTagName('parsererror').length > 0) return stories;
+  const referencedIds = new Set<string>();
+  for (const localName of ['headerReference', 'footerReference'] as const) {
+    for (const reference of Array.from(document.getElementsByTagNameNS(W_NS, localName))) {
+      const id = reference.getAttributeNS(R_NS, 'id');
+      if (id) referencedIds.add(id);
+    }
+  }
+  const hasFootnotes = document.getElementsByTagNameNS(W_NS, 'footnoteReference').length > 0;
+  const hasEndnotes = document.getElementsByTagNameNS(W_NS, 'endnoteReference').length > 0;
+  const relationshipsXml = await zip.file('word/_rels/document.xml.rels')?.async('string');
+  if (relationshipsXml === undefined) return stories;
+  const relationships = new DOMParser().parseFromString(relationshipsXml, 'application/xml');
+  if (relationships.getElementsByTagName('parsererror').length > 0) return stories;
+  for (const relationship of Array.from(relationships.getElementsByTagNameNS(PKG_REL_NS, 'Relationship'))) {
+    if (relationship.getAttribute('TargetMode') === 'External') continue;
+    const id = relationship.getAttribute('Id');
+    const type = relationship.getAttribute('Type');
+    const target = relationship.getAttribute('Target');
+    if (!id || !type || !target) continue;
+    const kind = type.startsWith(OFFICE_REL_PREFIX) ? type.slice(OFFICE_REL_PREFIX.length) : '';
+    const referenced = (kind === 'header' || kind === 'footer') ? referencedIds.has(id)
+      : kind === 'footnotes' ? hasFootnotes
+        : kind === 'endnotes' ? hasEndnotes : false;
+    if (!referenced) continue;
+    const resolved = target.startsWith('/') ? target.slice(1) : path.posix.normalize(path.posix.join('word', target));
+    if (zip.file(resolved)) stories.push(resolved);
+  }
+  return [...new Set(stories)];
 }
 
 function hasVisibleDeletionInStory(xml: string): boolean {

--- a/packages/docx-render-verifier/src/render.ts
+++ b/packages/docx-render-verifier/src/render.ts
@@ -88,6 +88,14 @@ function configuredContrast(configured: PixelMeasurement, control: PixelMeasurem
   return configured.bluePixels >= blueFloor && configured.redPixels >= redFloor;
 }
 
+function revisionVisibility(configured: PixelMeasurement, control: PixelMeasurement, floor: number): NonNullable<RenderVerdict['revisionVisibility']> {
+  const blueFloor = Math.max(floor, Math.ceil(control.bluePixels * 1.5));
+  const redFloor = Math.max(floor, Math.ceil(control.redPixels * 1.5));
+  if (configured.bluePixels >= blueFloor && configured.redPixels < redFloor) return 'hidden-deletions';
+  if (configured.bluePixels >= blueFloor && configured.redPixels >= redFloor) return 'visible';
+  return 'insufficient-contrast';
+}
+
 async function configureProfile(profile: string, mode: 'configured' | 'by-author'): Promise<void> {
   const user = path.join(profile, 'user');
   await mkdir(user, { recursive: true });
@@ -202,11 +210,14 @@ export async function verifyRenderedMarkup(request: RenderRequest): Promise<Rend
     ]);
     const markupTextMatchesPdf = normalizeText(pdfText) === normalizeText(request.expectedMarkupText);
     const configuredContrastPassed = configuredContrast(configuredPixels, controlPixels, request.configuredPixelFloor ?? 4);
+    const visibility = revisionVisibility(configuredPixels, controlPixels, request.configuredPixelFloor ?? 4);
     const pdfOut = path.join(request.outputDir, 'tracked-configured.pdf');
     await copyFile(configured.pdfPath, pdfOut);
     return {
       status: markupTextMatchesPdf && configuredContrastPassed ? 'pass' : 'fail',
-      reason: markupTextMatchesPdf ? (configuredContrastPassed ? undefined : 'Configured render did not exceed by-author control colour bands.') : 'PDF text does not equal caller-supplied independent markup text.',
+      reason: visibility === 'hidden-deletions'
+        ? 'LibreOffice rendered configured insertions but hid configured deletions.'
+        : markupTextMatchesPdf ? (configuredContrastPassed ? undefined : 'Configured render did not exceed by-author control colour bands.') : 'PDF text does not equal caller-supplied independent markup text.',
       trackedSha256,
       renderedInputSha256: sha256(await readFile(renderInput)),
       transform,
@@ -216,6 +227,7 @@ export async function verifyRenderedMarkup(request: RenderRequest): Promise<Rend
       configured: configuredPixels,
       byAuthorControl: controlPixels,
       configuredContrastPassed,
+      revisionVisibility: visibility,
     };
   } catch (error) {
     return { status: 'not_run', reason: `Renderer invocation unavailable: ${(error as Error).message}`, trackedSha256, reviewPngs: [] };

--- a/packages/docx-render-verifier/src/render.ts
+++ b/packages/docx-render-verifier/src/render.ts
@@ -6,6 +6,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { promisify } from 'node:util';
+import JSZip from 'jszip';
 import type { PixelMeasurement, RenderRequest, RendererTools, RenderVerdict, ToolResult } from './types.js';
 
 const execFileAsync = promisify(execFile);
@@ -94,6 +95,16 @@ function revisionVisibility(configured: PixelMeasurement, control: PixelMeasurem
   if (configured.bluePixels >= blueFloor && configured.redPixels < redFloor) return 'hidden-deletions';
   if (configured.bluePixels >= blueFloor && configured.redPixels >= redFloor) return 'visible';
   return 'insufficient-contrast';
+}
+
+async function hasDeletionMarkup(bytes: Buffer): Promise<boolean> {
+  try {
+    const zip = await JSZip.loadAsync(bytes);
+    const documentXml = await zip.file('word/document.xml')?.async('string');
+    return documentXml !== undefined && /<(?:[A-Za-z_][\w.-]*:)?(?:del|moveFrom)\b/u.test(documentXml);
+  } catch {
+    return false;
+  }
 }
 
 async function configureProfile(profile: string, mode: 'configured' | 'by-author'): Promise<void> {
@@ -210,14 +221,19 @@ export async function verifyRenderedMarkup(request: RenderRequest): Promise<Rend
     ]);
     const markupTextMatchesPdf = normalizeText(pdfText) === normalizeText(request.expectedMarkupText);
     const configuredContrastPassed = configuredContrast(configuredPixels, controlPixels, request.configuredPixelFloor ?? 4);
-    const visibility = revisionVisibility(configuredPixels, controlPixels, request.configuredPixelFloor ?? 4);
+    const measuredVisibility = revisionVisibility(configuredPixels, controlPixels, request.configuredPixelFloor ?? 4);
+    const visibility = markupTextMatchesPdf && (measuredVisibility !== 'hidden-deletions' || await hasDeletionMarkup(trackedBytes))
+      ? measuredVisibility
+      : 'insufficient-contrast';
     const pdfOut = path.join(request.outputDir, 'tracked-configured.pdf');
     await copyFile(configured.pdfPath, pdfOut);
     return {
       status: markupTextMatchesPdf && configuredContrastPassed ? 'pass' : 'fail',
-      reason: visibility === 'hidden-deletions'
-        ? 'LibreOffice rendered configured insertions but hid configured deletions.'
-        : markupTextMatchesPdf ? (configuredContrastPassed ? undefined : 'Configured render did not exceed by-author control colour bands.') : 'PDF text does not equal caller-supplied independent markup text.',
+      reason: !markupTextMatchesPdf
+        ? 'PDF text does not equal caller-supplied independent markup text.'
+        : visibility === 'hidden-deletions'
+          ? 'LibreOffice rendered configured insertions but hid configured deletions.'
+          : configuredContrastPassed ? undefined : 'Configured render did not exceed by-author control colour bands.',
       trackedSha256,
       renderedInputSha256: sha256(await readFile(renderInput)),
       transform,

--- a/packages/docx-render-verifier/src/render.ts
+++ b/packages/docx-render-verifier/src/render.ts
@@ -7,11 +7,13 @@ import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { promisify } from 'node:util';
 import JSZip from 'jszip';
+import { DOMParser, type Element as XmlElement } from '@xmldom/xmldom';
 import type { PixelMeasurement, RenderRequest, RendererTools, RenderVerdict, ToolResult } from './types.js';
 
 const execFileAsync = promisify(execFile);
 const BLUE = [0, 0, 255] as const;
 const RED = [255, 0, 0] as const;
+const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 
 function sha256(bytes: Buffer): string {
   return createHash('sha256').update(bytes).digest('hex');
@@ -101,10 +103,28 @@ async function hasDeletionMarkup(bytes: Buffer): Promise<boolean> {
   try {
     const zip = await JSZip.loadAsync(bytes);
     const documentXml = await zip.file('word/document.xml')?.async('string');
-    return documentXml !== undefined && /<(?:[A-Za-z_][\w.-]*:)?(?:del|moveFrom)\b/u.test(documentXml);
+    if (documentXml === undefined) return false;
+    const document = new DOMParser().parseFromString(documentXml, 'application/xml');
+    if (document.getElementsByTagName('parsererror').length > 0) return false;
+    const wrappers = [
+      ...Array.from(document.getElementsByTagNameNS(W_NS, 'del')),
+      ...Array.from(document.getElementsByTagNameNS(W_NS, 'moveFrom')),
+    ];
+    return wrappers.some((wrapper) => hasVisibleRevisionPayload(wrapper));
   } catch {
     return false;
   }
+}
+
+function hasVisibleRevisionPayload(wrapper: XmlElement): boolean {
+  for (const localName of ['t', 'delText'] as const) {
+    for (const text of Array.from(wrapper.getElementsByTagNameNS(W_NS, localName))) {
+      const value = text.textContent ?? '';
+      const preserve = text.getAttributeNS('http://www.w3.org/XML/1998/namespace', 'space') === 'preserve';
+      if ((preserve ? value : value.replace(/^[\u0009\u000a\u000d\u0020]+|[\u0009\u000a\u000d\u0020]+$/gu, '')) !== '') return true;
+    }
+  }
+  return ['tab', 'br', 'cr'].some((localName) => wrapper.getElementsByTagNameNS(W_NS, localName).length > 0);
 }
 
 async function configureProfile(profile: string, mode: 'configured' | 'by-author'): Promise<void> {

--- a/packages/docx-render-verifier/src/render.ts
+++ b/packages/docx-render-verifier/src/render.ts
@@ -231,6 +231,7 @@ export async function verifyRenderedMarkup(request: RenderRequest): Promise<Rend
       }
       transform = { id: request.transform.id, version: request.transform.version, inputSha256: sha256(await readFile(inputPath)), outputSha256: sha256(await readFile(renderInput)) };
     }
+    const renderedInputBytes = await readFile(renderInput);
     const configured = await renderOne(tools, soffice, renderInput, workspace, 'configured');
     const control = await renderOne(tools, soffice, renderInput, workspace, 'by-author');
     const pdfText = await extractPdfText(tools, pdftotext, configured.pdfPath);
@@ -242,7 +243,7 @@ export async function verifyRenderedMarkup(request: RenderRequest): Promise<Rend
     const markupTextMatchesPdf = normalizeText(pdfText) === normalizeText(request.expectedMarkupText);
     const configuredContrastPassed = configuredContrast(configuredPixels, controlPixels, request.configuredPixelFloor ?? 4);
     const measuredVisibility = revisionVisibility(configuredPixels, controlPixels, request.configuredPixelFloor ?? 4);
-    const visibility = markupTextMatchesPdf && (measuredVisibility !== 'hidden-deletions' || await hasDeletionMarkup(trackedBytes))
+    const visibility = markupTextMatchesPdf && (measuredVisibility !== 'hidden-deletions' || await hasDeletionMarkup(renderedInputBytes))
       ? measuredVisibility
       : 'insufficient-contrast';
     const pdfOut = path.join(request.outputDir, 'tracked-configured.pdf');
@@ -255,7 +256,7 @@ export async function verifyRenderedMarkup(request: RenderRequest): Promise<Rend
           ? 'LibreOffice rendered configured insertions but hid configured deletions.'
           : configuredContrastPassed ? undefined : 'Configured render did not exceed by-author control colour bands.',
       trackedSha256,
-      renderedInputSha256: sha256(await readFile(renderInput)),
+      renderedInputSha256: sha256(renderedInputBytes),
       transform,
       pdfPath: pdfOut,
       reviewPngs,

--- a/packages/docx-render-verifier/src/types.ts
+++ b/packages/docx-render-verifier/src/types.ts
@@ -31,6 +31,7 @@ export type RenderVerdict = {
   configured?: PixelMeasurement;
   byAuthorControl?: PixelMeasurement;
   configuredContrastPassed?: boolean;
+  revisionVisibility?: 'visible' | 'hidden-deletions' | 'insufficient-contrast';
 };
 
 export type RenderRequest = {


### PR DESCRIPTION
## Summary

Corrects independent OOXML projection and minimality accounting for real Word run fragmentation. Adds public, de-identified LOI and NVCA replay regressions and classifies LibreOffice hidden deletions separately from generic contrast failures.

## Verification

- [x] Full workspace build
- [x] Full workspace lint (zero errors; six pre-existing warning-only directives)
- [x] Full workspace test suite
- [x] Conformance citations, generated conformance document, and strict spec coverage
- [x] PII, absolute-path, email, and new-binary scan
- [ ] Mandatory peer review by agy and Codex

Ref: #826