### PR TITLE
fix: harden verification projection and renderer evidence

### DIFF
--- a/packages/docx-release-verifier/src/verifier.test.ts
+++ b/packages/docx-release-verifier/src/verifier.test.ts
@@ -151,6 +151,28 @@ describe('independent release verifier', () => {
     expect(result.gates.semantic.status).toBe('pass');
   });
 
+  itAllure('projects host and nested text-box paragraphs once each in document order', async () => {
+    const { manifest } = await fixture();
+    const drawing = '<w:p xmlns:wp="urn:wp" xmlns:a="urn:a" xmlns:wps="urn:wps"><w:r><w:t>Body</w:t></w:r><w:r><w:drawing><wp:inline><a:graphic><wps:txbx><w:txbxContent><w:p><w:r><w:t>Box</w:t></w:r></w:p></w:txbxContent></wps:txbx></a:graphic></wp:inline></w:drawing></w:r></w:p>';
+    await writeDocx(manifest.originalPath, drawing);
+    await writeDocx(manifest.intendedCleanPath, drawing);
+    await writeDocx(manifest.trackedPath, drawing);
+    const result = await verifyRelease({
+      version: 1,
+      originalPath: manifest.originalPath,
+      intendedCleanPath: manifest.intendedCleanPath,
+      trackedPath: manifest.trackedPath,
+      mutationControl: { projection: 'accept', expected: 'intendedClean' },
+    });
+    expect(result.projections).toMatchObject({
+      original: { paragraphs: ['Body', 'Box'], text: 'Body\nBox' },
+      intendedClean: { paragraphs: ['Body', 'Box'], text: 'Body\nBox' },
+      accept: { paragraphs: ['Body', 'Box'], text: 'Body\nBox' },
+      reject: { paragraphs: ['Body', 'Box'], text: 'Body\nBox' },
+    });
+    expect(result.gates.minimality).toMatchObject({ status: 'pass', details: { evidence: { lostTokens: 0 } } });
+  });
+
   itAllure('derives exact accept/reject projections and proves mutation sensitivity without changing inputs', async () => {
     const { manifest } = await fixture();
     const before = await readFile(manifest.trackedPath);

--- a/packages/docx-release-verifier/src/xml.ts
+++ b/packages/docx-release-verifier/src/xml.ts
@@ -16,7 +16,7 @@ function wordText(element: XmlElement): string {
   return space === 'preserve' ? value : value.replace(/^[\u0009\u000a\u000d\u0020]+|[\u0009\u000a\u000d\u0020]+$/gu, '');
 }
 
-function textFrom(element: XmlElement, mode: 'accept' | 'reject'): string {
+function textFrom(element: XmlElement, mode: 'accept' | 'reject', skipNestedParagraphs = false): string {
   const localName = element.localName ?? '';
   const wordRevision = element.namespaceURI === W_NS;
   if (wordRevision && ((mode === 'accept' && OMIT_ON_ACCEPT.has(localName)) || (mode === 'reject' && OMIT_ON_REJECT.has(localName)))) return '';
@@ -26,7 +26,11 @@ function textFrom(element: XmlElement, mode: 'accept' | 'reject'): string {
   if (isWord(element, 'delText')) return mode === 'reject' ? wordText(element) : '';
   let text = '';
   for (const child of Array.from(element.childNodes)) {
-    if (child.nodeType === 1) text += textFrom(child as XmlElement, mode);
+    if (child.nodeType === 1) {
+      const childElement = child as XmlElement;
+      if (skipNestedParagraphs && isWord(childElement, 'p')) continue;
+      text += textFrom(childElement, mode, skipNestedParagraphs);
+    }
   }
   return text;
 }
@@ -40,7 +44,7 @@ function parse(xml: string): XmlDocument {
 
 export function projectDocumentXml(xml: string, mode: 'accept' | 'reject'): Projection {
   const document = parse(xml);
-  const paragraphs = Array.from(document.getElementsByTagNameNS(W_NS, 'p')).map((paragraph) => textFrom(paragraph, mode));
+  const paragraphs = Array.from(document.getElementsByTagNameNS(W_NS, 'p')).map((paragraph) => textFrom(paragraph, mode, true));
   return { paragraphs, text: paragraphs.join('\n') };
 }
 
@@ -63,9 +67,10 @@ function ordinaryTextNodes(element: XmlElement): string[] {
     if (node.namespaceURI === W_NS && REVISION_WRAPPERS.has(node.localName ?? '')) {
       // Empty/property-only revision wrappers do not separate visible text and
       // must not fragment an otherwise ordinary token or whitespace run.
-      if (textFrom(node, 'accept') !== '' || textFrom(node, 'reject') !== '') flush();
+      if (textFrom(node, 'accept', true) !== '' || textFrom(node, 'reject', true) !== '') flush();
       return;
     }
+    if (node !== element && isWord(node, 'p')) return;
     if (isWord(node, 'tab')) current += '\t';
     else if (isWord(node, 'br') || isWord(node, 'cr')) current += '\n';
     else if (isWord(node, 't')) current += wordText(node);
@@ -84,8 +89,8 @@ export function trackedParagraphViews(xml: string): TrackedParagraphView[] {
   const document = parse(xml);
   return Array.from(document.getElementsByTagNameNS(W_NS, 'p')).map((paragraph, index) => ({
     index,
-    acceptText: textFrom(paragraph, 'accept'),
-    rejectText: textFrom(paragraph, 'reject'),
+    acceptText: textFrom(paragraph, 'accept', true),
+    rejectText: textFrom(paragraph, 'reject', true),
     ordinaryTextNodes: ordinaryTextNodes(paragraph),
   }));
 }

--- a/packages/docx-render-verifier/src/render.test.ts
+++ b/packages/docx-render-verifier/src/render.test.ts
@@ -39,11 +39,13 @@ function fakeTools(markup = 'Visible markup text', profiles?: string[], hiddenDe
   };
 }
 
-async function trackedFixture(pathname: string, revision: 'ins' | 'del' | 'empty-del', headerDeletion: 'none' | 'orphan' | 'referenced' = 'none'): Promise<void> {
+async function trackedFixture(pathname: string, revision: 'ins' | 'del' | 'ins-del' | 'empty-del', headerDeletion: 'none' | 'orphan' | 'referenced' = 'none'): Promise<void> {
   const zip = new JSZip();
   zip.file('[Content_Types].xml', '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"/>');
   const markup = revision === 'empty-del'
     ? '<w:del w:id="1"><w:r><w:rPr><w:b/></w:rPr></w:r></w:del>'
+    : revision === 'ins-del'
+      ? '<w:ins w:id="1"><w:r><w:t>insertion</w:t></w:r></w:ins><w:del w:id="2"><w:r><w:delText>deletion</w:delText></w:r></w:del>'
     : `<w:${revision} w:id="1"><w:r><w:${revision === 'del' ? 'delText' : 't'}>revision</w:${revision === 'del' ? 'delText' : 't'}></w:r></w:${revision}>`;
   const headerReference = headerDeletion === 'referenced' ? '<w:sectPr><w:headerReference r:id="rIdHeader1"/></w:sectPr>' : '';
   zip.file('word/document.xml', `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><w:body><w:p>${markup}</w:p>${headerReference}</w:body></w:document>`);
@@ -77,7 +79,7 @@ describe('renderer verifier', () => {
     const root = path.join(os.tmpdir(), `render-fake-${Date.now()}`);
     const source = path.join(root, 'tracked.docx');
     await mkdir(root, { recursive: true });
-    await trackedFixture(source, 'del');
+    await trackedFixture(source, 'ins-del');
     const profiles: string[] = [];
     const result = await verifyRenderedMarkup({
       trackedDocxPath: source,
@@ -94,6 +96,18 @@ describe('renderer verifier', () => {
       expect.stringContaining('<value>16711680</value>'),
       expect.stringContaining('<value>-1</value>'),
     ]));
+  });
+
+  itAllure('does not infer visible configured insertions from blue pixels in a deletion-only document', async () => {
+    const root = path.join(os.tmpdir(), `render-deletion-only-${Date.now()}`);
+    const source = path.join(root, 'tracked.docx');
+    await mkdir(root, { recursive: true });
+    await trackedFixture(source, 'del');
+    const result = await verifyRenderedMarkup({
+      trackedDocxPath: source, expectedMarkupText: 'Visible markup text', outputDir: path.join(root, 'out'),
+      tools: fakeTools('Visible markup text', undefined, true), configuredPixelFloor: 2,
+    });
+    expect(result).toMatchObject({ status: 'fail', revisionVisibility: 'insufficient-contrast' });
   });
 
   itAllure('does not diagnose hidden deletions when the tracked document has insertions only', async () => {
@@ -173,7 +187,7 @@ describe('renderer verifier', () => {
         id: 'add-visible-deletion', version: '1',
         async apply(_input, workspace) {
           const output = path.join(workspace, 'render-only.docx');
-          await trackedFixture(output, 'del');
+          await trackedFixture(output, 'ins-del');
           return output;
         },
       },
@@ -205,7 +219,7 @@ describe('renderer verifier', () => {
     const root = path.join(os.tmpdir(), `render-hidden-delete-${Date.now()}`);
     const source = path.join(root, 'tracked.docx');
     await mkdir(root, { recursive: true });
-    await trackedFixture(source, 'del');
+    await trackedFixture(source, 'ins-del');
     const result = await verifyRenderedMarkup({
       trackedDocxPath: source, expectedMarkupText: 'Visible markup text', outputDir: path.join(root, 'out'),
       tools: fakeTools('Visible markup text', undefined, true), configuredPixelFloor: 2,

--- a/packages/docx-render-verifier/src/render.ts
+++ b/packages/docx-render-verifier/src/render.ts
@@ -102,19 +102,24 @@ function revisionVisibility(configured: PixelMeasurement, control: PixelMeasurem
   return 'insufficient-contrast';
 }
 
-async function hasDeletionMarkup(bytes: Buffer): Promise<boolean> {
+async function renderedRevisionMarkup(bytes: Buffer): Promise<{ insertions: boolean; deletions: boolean }> {
   try {
     const zip = await JSZip.loadAsync(bytes);
     const documentXml = await zip.file('word/document.xml')?.async('string');
-    if (documentXml === undefined) return false;
+    if (documentXml === undefined) return { insertions: false, deletions: false };
     const renderedStories = await referencedRenderedStories(zip, documentXml);
+    let insertions = false;
+    let deletions = false;
     for (const name of renderedStories) {
       const xml = await zip.file(name)?.async('string');
-      if (xml !== undefined && hasVisibleDeletionInStory(xml)) return true;
+      if (xml === undefined) continue;
+      insertions ||= hasVisibleRevisionInStory(xml, ['ins', 'moveTo']);
+      deletions ||= hasVisibleRevisionInStory(xml, ['del', 'moveFrom']);
+      if (insertions && deletions) break;
     }
-    return false;
+    return { insertions, deletions };
   } catch {
-    return false;
+    return { insertions: false, deletions: false };
   }
 }
 
@@ -152,14 +157,11 @@ async function referencedRenderedStories(zip: JSZip, documentXml: string): Promi
   return [...new Set(stories)];
 }
 
-function hasVisibleDeletionInStory(xml: string): boolean {
+function hasVisibleRevisionInStory(xml: string, wrapperNames: readonly string[]): boolean {
   try {
     const document = new DOMParser().parseFromString(xml, 'application/xml');
     if (document.getElementsByTagName('parsererror').length > 0) return false;
-    const wrappers = [
-      ...Array.from(document.getElementsByTagNameNS(W_NS, 'del')),
-      ...Array.from(document.getElementsByTagNameNS(W_NS, 'moveFrom')),
-    ];
+    const wrappers = wrapperNames.flatMap((localName) => Array.from(document.getElementsByTagNameNS(W_NS, localName)));
     return wrappers.some((wrapper) => hasVisibleRevisionPayload(wrapper));
   } catch {
     return false;
@@ -293,7 +295,8 @@ export async function verifyRenderedMarkup(request: RenderRequest): Promise<Rend
     const markupTextMatchesPdf = normalizeText(pdfText) === normalizeText(request.expectedMarkupText);
     const configuredContrastPassed = configuredContrast(configuredPixels, controlPixels, request.configuredPixelFloor ?? 4);
     const measuredVisibility = revisionVisibility(configuredPixels, controlPixels, request.configuredPixelFloor ?? 4);
-    const visibility = markupTextMatchesPdf && (measuredVisibility !== 'hidden-deletions' || await hasDeletionMarkup(renderedInputBytes))
+    const revisionMarkup = await renderedRevisionMarkup(renderedInputBytes);
+    const visibility = markupTextMatchesPdf && (measuredVisibility !== 'hidden-deletions' || (revisionMarkup.insertions && revisionMarkup.deletions))
       ? measuredVisibility
       : 'insufficient-contrast';
     const pdfOut = path.join(request.outputDir, 'tracked-configured.pdf');


### PR DESCRIPTION
## Summary

Follow-up to #827. That PR auto-merged while final exact-commit peer review was running. This PR contains only the final adversarial hardening verified by both mandatory reviewers:

- project nested text-box paragraphs exactly once
- require visible insertion and deletion payload before classifying LibreOffice output as hidden deletions
- add focused regressions for both invariants

## Verification

- repository-wide build passed
- workspace lint and tests passed
- affected packages: 65 tests passed
- PII and binary-artifact scans passed
- Agy: APPROVE, no findings
- Codex: APPROVE, no findings on commit 87c152c

A real LibreOffice probe in the Codex environment returned  because LibreOffice could not load the fixture; deterministic renderer-classification tests pass.