### PR TITLE
test(docx-mcp): cover formatting convention silence gates

### DIFF
--- a/packages/docx-mcp/src/tools/formatting_convention.test.ts
+++ b/packages/docx-mcp/src/tools/formatting_convention.test.ts
@@ -205,6 +205,13 @@ async function check(
   );
 }
 
+async function conventionDocs(): Promise<{ baselineDoc: DocxDocument; previewDoc: DocxDocument }> {
+  return {
+    baselineDoc: await loadDoc(CONVENTION_BODY + TARGET_PLAIN),
+    previewDoc: await loadDoc(CONVENTION_BODY + insertedDefinedTermParagraph({})),
+  };
+}
+
 async function openConventionSession(): Promise<Awaited<ReturnType<typeof openSession>>> {
   return openSession([], {
     mgr: new SessionManager({ defaultAiAuthor: AI }),
@@ -297,6 +304,62 @@ describe('formatting-convention detection on corpus documents', () => {
 });
 
 describe('formatting-convention check', () => {
+  test('is silent only when each required master-gate input is absent', async () => {
+    const { baselineDoc, previewDoc } = await conventionDocs();
+    const positive = {
+      insertedText: INSERTED_DEFINED_TERM_TEXT,
+      aiAuthor: AI,
+      baselineDoc,
+    };
+
+    // Seed: replacing any `return []` below with the positive control's result
+    // makes its paired silence assertion fail.
+    expect(checkFormattingConvention(previewDoc, positive)).toHaveLength(1);
+    for (const missing of ['insertedText', 'aiAuthor', 'baselineDoc'] as const) {
+      const options = { ...positive, [missing]: undefined } as unknown as Parameters<
+        typeof checkFormattingConvention
+      >[1];
+      expect(checkFormattingConvention(previewDoc, options), `${missing} gate`).toEqual([]);
+    }
+  });
+
+  test('is silent only when convention resolution has no population', async () => {
+    const baselineDoc = await loadDoc(TARGET_PLAIN);
+    const previewDoc = await loadDoc(insertedDefinedTermParagraph({}));
+    const options = {
+      insertedText: INSERTED_DEFINED_TERM_TEXT,
+      aiAuthor: AI,
+      baselineDoc,
+      minInstances: 0,
+    };
+
+    // Seed: returning a tuple when `best` is null makes this assertion fail;
+    // the same insertion is reported as soon as a population exists.
+    expect(checkFormattingConvention(previewDoc, options)).toEqual([]);
+    const { baselineDoc: populatedBaseline, previewDoc: populatedPreview } = await conventionDocs();
+    expect(
+      checkFormattingConvention(populatedPreview, { ...options, baselineDoc: populatedBaseline }),
+    ).toHaveLength(1);
+  });
+
+  test('is silent only when an inserted construct has no resolvable runs', async () => {
+    const deletedInsertion = `<w:p><w:r><w:t>Fee </w:t></w:r><w:del w:id="902" w:author="${AI}">` +
+      `<w:r><w:delText xml:space="preserve">(each, a “Fee Item”)</w:delText></w:r></w:del></w:p>`;
+
+    // Seed: treating removed runs as comparable makes the paired silence
+    // assertion fail; the same baseline and construct warn when inserted.
+    expect(
+      await check(CONVENTION_BODY + TARGET_PLAIN, CONVENTION_BODY + deletedInsertion, INSERTED_DEFINED_TERM_TEXT),
+    ).toEqual([]);
+    expect(
+      await check(
+        CONVENTION_BODY + TARGET_PLAIN,
+        CONVENTION_BODY + insertedDefinedTermParagraph({}),
+        INSERTED_DEFINED_TERM_TEXT,
+      ),
+    ).toHaveLength(1);
+  });
+
   test('NEGATIVE CONTROL: a seeded off-convention insertion makes the check go red', async ({
     given,
     when,


### PR DESCRIPTION
## Summary

- Closes #829.
- add paired controls for the three required inputs at the formatting-convention master gate
- add paired controls for an empty convention population and an inserted construct with no resolvable runs
- retain advisory silence while proving each asserted silence is attributable to the intended input shape

## Verification

- `npm ci` passed
- `npm run build` passed
- `npm run test` passed
- `npm run lint:workspaces` passed with 10 pre-existing warnings and no errors
- `npm run check:tool-docs` passed
- `npm --prefix site ci` passed
- `npm run preflight:ci` passed its completed stages but exceeded the local two-minute execution ceiling during `check:conformance-explorer`; it is not claimed green

## Falsifiability controls

- The master-gate test first proves the shared fixture produces one warning, then proves each missing `insertedText`, `aiAuthor`, and `baselineDoc` input produces `[]`. Replacing any one silence return with the positive-control result makes its paired assertion fail.
- The empty-population test proves silence with no baseline instances and one warning after adding the same fixture's convention population. Returning a convention tuple when no `best` entry exists makes the silence assertion fail.
- The no-resolvable-runs test proves a deleted construct is silent and a live inserted construct on the same baseline warns. Treating removed runs as comparable makes the silence assertion fail.

## Mutation controls decision

No source-mutation job is added to CI in this change. These focused paired controls run on every PR and directly detect the silent master-gate failure class. A mutation harness remains useful as a scheduled or release gate, but adding one requires a separately maintained mutation mechanism and is outside this narrow test-coverage change.

## Public-data review

The complete branch diff and this drafted body were scanned case-insensitively for the prohibited client identifiers, email addresses, local paths, matter paths, handoff paths, binaries, and unaccounted contract prose. The scan was clean; the new fixture uses generic parties and obligations only.

## Peer review

No independent peer review completed in the local execution window. Dynamic validation above includes the full test suite and focused test file.
