### PR TITLE
fix(docx-render-verifier): make PDF text binding pagination- and story-aware

### DIFF
--- a/packages/docx-render-verifier/README.md
+++ b/packages/docx-render-verifier/README.md
@@ -5,14 +5,27 @@ no dependency on Safe DOCX generators, mutators, comparison engines, or IR.
 
 `verifyRenderedMarkup` renders a disposable configured LibreOffice profile
 (blue/underlined insertions, red/struck deletions) and a same-input by-author
-control. It compares `pdftotext` output to caller-supplied independent markup
+control. It binds `pdftotext` output to caller-supplied independent markup
 text, measures broad blue/red pixel bands after downsampling, and writes only
 selected PDF-page PNGs to the requested output path. Required missing tools are
 reported as `not_run`, not pass.
 
+Text binding is story-scoped and pagination-aware rather than exact equality:
+every token of the caller's logical projection must appear in the PDF text at
+least as often as in the projection, and every extra PDF token must be
+attributable to renderer-created pagination artifacts with explicit occurrence
+bounds — referenced header/footer story tokens up to `pageCount x` their story
+occurrence, and numeric page-number residue only when a PAGE-family field
+exists, capped at `pageCount x` the field count. Missing logical content or
+unattributable residue still fails; reading order is deliberately left to the
+image-review domain. The structured outcome is reported in
+`verdict.textBinding` separately from colour visibility.
+
 If Writer displays configured insertions but suppresses deletions, verification
 fails with `revisionVisibility: "hidden-deletions"` rather than reporting only
-a generic colour-contrast failure.
+a generic colour-contrast failure. A text-binding failure keeps
+`revisionVisibility` truthful to the pixel and revision-markup evidence; it is
+never relabelled `insufficient-contrast`.
 
 An optional render transform receives only a copied input and a disposable
 workspace. The verifier hashes the authoritative DOCX before and after and

--- a/packages/docx-render-verifier/README.md
+++ b/packages/docx-render-verifier/README.md
@@ -10,16 +10,20 @@ text, measures broad blue/red pixel bands after downsampling, and writes only
 selected PDF-page PNGs to the requested output path. Required missing tools are
 reported as `not_run`, not pass.
 
-Text binding is story-scoped and pagination-aware rather than exact equality:
-every token of the caller's logical projection must appear in the PDF text at
-least as often as in the projection, and every extra PDF token must be
-attributable to renderer-created pagination artifacts with explicit occurrence
-bounds — referenced header/footer story tokens up to `pageCount x` their story
-occurrence, and numeric page-number residue only when a PAGE-family field
-exists, capped at `pageCount x` the field count. Missing logical content or
-unattributable residue still fails; reading order is deliberately left to the
-image-review domain. The structured outcome is reported in
-`verdict.textBinding` separately from colour visibility.
+Text binding is story-scoped and pagination-aware rather than exact equality.
+The extracted PDF text is split into rendered pages; on each page,
+pagination-owned material is reserved first and maximally — referenced
+header/footer story tokens up to their story occurrence count, and numeric
+page-number renderings (values within the rendered page-number range) up to
+the header/footer PAGE-family field count per page plus a whole-document
+budget for body-story fields. The caller's logical projection must then be
+covered by the remaining tokens, and any leftover token fails. Because
+reservation is maximal, repeated header vocabulary can never substitute for
+missing logical content, and duplicated or hallucinated rendered text is
+never absorbed. Reading order is deliberately outside this automated verdict:
+the emitted review PNGs support optional human placement review, and no
+automated placement comparison is performed. The structured outcome is
+reported in `verdict.textBinding` separately from colour visibility.
 
 If Writer displays configured insertions but suppresses deletions, verification
 fails with `revisionVisibility: "hidden-deletions"` rather than reporting only

--- a/packages/docx-render-verifier/fixtures/index.json
+++ b/packages/docx-render-verifier/fixtures/index.json
@@ -11,6 +11,11 @@
     { "id": "color-control", "path": "color-control.xml", "purpose": "renderer colour-control text" },
     { "id": "corrupt-zip", "path": "corrupt.docx", "purpose": "unreadable package negative control" },
     { "id": "header-wrap", "path": "header-wrap.xml", "purpose": "minimized de-identified header-wrap shape" },
-    { "id": "signature-table", "path": "signature-table.xml", "purpose": "minimized de-identified table layout shape" }
+    { "id": "signature-table", "path": "signature-table.xml", "purpose": "minimized de-identified table layout shape" },
+    { "id": "single-page-body", "path": "single-page-body.xml", "purpose": "single-page tracked body for exact text binding" },
+    { "id": "multi-page-body", "path": "multi-page-body.xml", "purpose": "explicit page-break body spanning two rendered pages" },
+    { "id": "repeated-header", "path": "repeated-header.xml", "purpose": "header story repeated once per rendered page" },
+    { "id": "page-field-footer", "path": "page-field-footer.xml", "purpose": "footer story with a PAGE field rendering per-page numerals" },
+    { "id": "reordered-text-box", "path": "reordered-text-box.xml", "purpose": "anchored text box emitted out of logical order by pdftotext" }
   ]
 }

--- a/packages/docx-render-verifier/fixtures/multi-page-body.xml
+++ b/packages/docx-render-verifier/fixtures/multi-page-body.xml
@@ -1,0 +1,1 @@
+<w:p><w:r><w:t>Synthetic first page opening text.</w:t></w:r><w:ins w:id="1"><w:r><w:t>inserted-alpha</w:t></w:r></w:ins></w:p><w:p><w:r><w:br w:type="page"/></w:r></w:p><w:p><w:r><w:t>Synthetic second page closing text.</w:t></w:r><w:del w:id="2"><w:r><w:delText>removed-beta</w:delText></w:r></w:del></w:p>

--- a/packages/docx-render-verifier/fixtures/page-field-footer.xml
+++ b/packages/docx-render-verifier/fixtures/page-field-footer.xml
@@ -1,0 +1,1 @@
+<w:ftr><w:p><w:r><w:t>Page</w:t></w:r><w:fldSimple w:instr=" PAGE "><w:r><w:t>1</w:t></w:r></w:fldSimple></w:p></w:ftr>

--- a/packages/docx-render-verifier/fixtures/reordered-text-box.xml
+++ b/packages/docx-render-verifier/fixtures/reordered-text-box.xml
@@ -1,0 +1,1 @@
+<w:p><w:r><w:t>Anchor paragraph before floating content.</w:t></w:r><w:ins w:id="1"><w:r><w:t>inserted-alpha</w:t></w:r></w:ins></w:p><w:p><w:r><w:pict><v:shape><v:textbox><w:txbxContent><w:p><w:r><w:t>Floating box narrative sentence.</w:t></w:r><w:del w:id="2"><w:r><w:delText>removed-beta</w:delText></w:r></w:del></w:p></w:txbxContent></v:textbox></v:shape></w:pict></w:r></w:p>

--- a/packages/docx-render-verifier/fixtures/repeated-header.xml
+++ b/packages/docx-render-verifier/fixtures/repeated-header.xml
@@ -1,0 +1,1 @@
+<w:hdr><w:p><w:r><w:t>Synthetic Neutral Draft Header</w:t></w:r></w:p></w:hdr>

--- a/packages/docx-render-verifier/fixtures/single-page-body.xml
+++ b/packages/docx-render-verifier/fixtures/single-page-body.xml
@@ -1,0 +1,1 @@
+<w:p><w:r><w:t>Synthetic single page opening clause.</w:t></w:r><w:ins w:id="1"><w:r><w:t>inserted-alpha</w:t></w:r></w:ins><w:del w:id="2"><w:r><w:delText>removed-beta</w:delText></w:r></w:del></w:p>

--- a/packages/docx-render-verifier/src/render.test.ts
+++ b/packages/docx-render-verifier/src/render.test.ts
@@ -72,10 +72,10 @@ function storyPartXml(fragment: string): string {
   return fragment.replace(/^<w:(hdr|ftr)>/u, `<w:$1 xmlns:w="${W_XMLNS}">`);
 }
 
-async function paginatedFixture(pathname: string, parts: { body: string; header?: string; footer?: string }): Promise<void> {
+async function paginatedFixture(pathname: string, parts: { body: string; header?: string; footer?: string; pgNumStart?: number }): Promise<void> {
   const zip = new JSZip();
   zip.file('[Content_Types].xml', '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"/>');
-  const references = `${parts.header ? '<w:headerReference r:id="rIdHeader1"/>' : ''}${parts.footer ? '<w:footerReference r:id="rIdFooter1"/>' : ''}`;
+  const references = `${parts.header ? '<w:headerReference r:id="rIdHeader1"/>' : ''}${parts.footer ? '<w:footerReference r:id="rIdFooter1"/>' : ''}${parts.pgNumStart === undefined ? '' : `<w:pgNumType w:start="${parts.pgNumStart}"/>`}`;
   const sectPr = references.length > 0 ? `<w:sectPr>${references}</w:sectPr>` : '';
   zip.file('word/document.xml', `<w:document xmlns:w="${W_XMLNS}" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:v="urn:schemas-microsoft-com:vml"><w:body>${parts.body}${sectPr}</w:body></w:document>`);
   const relationships: string[] = [];
@@ -405,7 +405,7 @@ describe('renderer verifier', () => {
     expect(result.textBinding?.unexplainedTokenSample).toContain('7');
   });
 
-  itAllure('caps page-field numeric residue at page count times declared page fields', async () => {
+  itAllure('rejects numeric residue outside the rendered page-number range even when page fields exist', async () => {
     const root = path.join(os.tmpdir(), `render-numeric-cap-${Date.now()}`);
     const source = path.join(root, 'tracked.docx');
     await mkdir(root, { recursive: true });
@@ -419,7 +419,94 @@ describe('renderer verifier', () => {
       tools: fakeTools(`${MULTI_PAGE_PDF}\n3 4 5 6 7`, undefined, false, 2), configuredPixelFloor: 2,
     });
     expect(result).toMatchObject({ status: 'fail', markupTextMatchesPdf: false });
-    expect(result.textBinding?.unexplainedTokenSample?.join(' ')).toContain('page-field allowance');
+    expect(result.textBinding?.unexplainedTokenSample).toContain('7');
+  });
+
+  itAllure('does not let a PAGE field launder a meaningful out-of-range number such as an amount', async () => {
+    const root = path.join(os.tmpdir(), `render-numeric-smuggle-${Date.now()}`);
+    const source = path.join(root, 'tracked.docx');
+    await mkdir(root, { recursive: true });
+    const body = 'Synthetic single page opening clause. inserted-alpha removed-beta';
+    await paginatedFixture(source, {
+      body: await fixtureFragment('single-page-body.xml'),
+      footer: await fixtureFragment('page-field-footer.xml'),
+    });
+    const result = await verifyRenderedMarkup({
+      trackedDocxPath: source, expectedMarkupText: body, outputDir: path.join(root, 'out'),
+      tools: fakeTools(`${body}\nPage 1\n999`), configuredPixelFloor: 2,
+    });
+    expect(result).toMatchObject({ status: 'fail', markupTextMatchesPdf: false });
+    expect(result.textBinding?.unexplainedTokenSample).toContain('999');
+  });
+
+  itAllure('fails when repeated header vocabulary would otherwise mask a missing body token', async () => {
+    const root = path.join(os.tmpdir(), `render-header-mask-${Date.now()}`);
+    const source = path.join(root, 'tracked.docx');
+    await mkdir(root, { recursive: true });
+    const body = 'Synthetic single page opening clause. inserted-alpha removed-beta';
+    await paginatedFixture(source, {
+      body: await fixtureFragment('single-page-body.xml'),
+      header: await fixtureFragment('repeated-header.xml'),
+    });
+    // The caller's projection requires a body occurrence of "Draft"; the body
+    // dropped it, and only the per-page repeated header supplies that token.
+    const result = await verifyRenderedMarkup({
+      trackedDocxPath: source, expectedMarkupText: `${body} Draft`, outputDir: path.join(root, 'out'),
+      tools: fakeTools(`Synthetic Neutral Draft Header\n${body}\f\nSynthetic Neutral Draft Header`, undefined, false, 2), configuredPixelFloor: 2,
+    });
+    expect(result).toMatchObject({ status: 'fail', markupTextMatchesPdf: false });
+    expect(result.textBinding?.missingTokenSample).toContain('Draft');
+  });
+
+  itAllure('grants a body PAGE field one rendered occurrence rather than one per page', async () => {
+    const root = path.join(os.tmpdir(), `render-body-field-${Date.now()}`);
+    const source = path.join(root, 'tracked.docx');
+    await mkdir(root, { recursive: true });
+    const body = 'Synthetic single page opening clause. inserted-alpha removed-beta';
+    const bodyWithField = `${await fixtureFragment('single-page-body.xml')}<w:p><w:fldSimple w:instr=" PAGE "><w:r><w:t>1</w:t></w:r></w:fldSimple></w:p>`;
+    await paginatedFixture(source, { body: bodyWithField });
+    const oneRendering = await verifyRenderedMarkup({
+      trackedDocxPath: source, expectedMarkupText: body, outputDir: path.join(root, 'out-one'),
+      tools: fakeTools(`${body}\f\n2`, undefined, false, 2), configuredPixelFloor: 2,
+    });
+    expect(oneRendering).toMatchObject({ status: 'pass', markupTextMatchesPdf: true });
+    const twoRenderings = await verifyRenderedMarkup({
+      trackedDocxPath: source, expectedMarkupText: body, outputDir: path.join(root, 'out-two'),
+      tools: fakeTools(`${body} 1\f\n2`, undefined, false, 2), configuredPixelFloor: 2,
+    });
+    expect(twoRenderings).toMatchObject({ status: 'fail', markupTextMatchesPdf: false });
+    expect(twoRenderings.textBinding?.unexplainedTokenSample).toContain('2');
+  });
+
+  itAllure('reserves offset page numbers when the section declares an explicit numbering start', async () => {
+    const root = path.join(os.tmpdir(), `render-pgnum-start-${Date.now()}`);
+    const source = path.join(root, 'tracked.docx');
+    await mkdir(root, { recursive: true });
+    const body = 'Synthetic single page opening clause. inserted-alpha removed-beta';
+    await paginatedFixture(source, {
+      body: await fixtureFragment('single-page-body.xml'),
+      footer: await fixtureFragment('page-field-footer.xml'),
+      pgNumStart: 5,
+    });
+    const result = await verifyRenderedMarkup({
+      trackedDocxPath: source, expectedMarkupText: body, outputDir: path.join(root, 'out'),
+      tools: fakeTools(`${body}\nPage 5`), configuredPixelFloor: 2,
+    });
+    expect(result).toMatchObject({ status: 'pass', markupTextMatchesPdf: true });
+  });
+
+  itAllure('accepts an insertion and deletion order swap as the documented order-insensitivity limitation', async () => {
+    const root = path.join(os.tmpdir(), `render-order-swap-${Date.now()}`);
+    const source = path.join(root, 'tracked.docx');
+    await mkdir(root, { recursive: true });
+    await paginatedFixture(source, { body: await fixtureFragment('single-page-body.xml') });
+    // Placement is deliberately outside the automated text-binding verdict;
+    // the review PNGs exist for optional human placement review.
+    const result = await verifyRenderedMarkup({
+      trackedDocxPath: source, expectedMarkupText: 'Synthetic single page opening clause. inserted-alpha removed-beta', outputDir: path.join(root, 'out'),
+      tools: fakeTools('removed-beta Synthetic single page opening clause. inserted-alpha'), configuredPixelFloor: 2,
+    });
+    expect(result).toMatchObject({ status: 'pass', markupTextMatchesPdf: true });
   });
 
   itAllure('accepts renderer-reordered text-box content because binding is order-independent', async () => {

--- a/packages/docx-render-verifier/src/render.test.ts
+++ b/packages/docx-render-verifier/src/render.test.ts
@@ -8,7 +8,7 @@ import JSZip from 'jszip';
 import { measurePixelBands, verifyRenderedMarkup } from './render.js';
 import type { RendererTools } from './types.js';
 
-function fakeTools(markup = 'Visible markup text', profiles?: string[], hiddenDeletion = false): RendererTools {
+function fakeTools(markup = 'Visible markup text', profiles?: string[], hiddenDeletion = false, pageCount = 1): RendererTools {
   return {
     resolve: () => 'fake-tool',
     async run(_command, args) {
@@ -25,7 +25,10 @@ function fakeTools(markup = 'Visible markup text', profiles?: string[], hiddenDe
       }
       if (args[0] === '-layout') return { code: 0, stdout: markup, stderr: '' };
       if (args.includes('-png')) {
-        await writeFile(`${args[args.length - 1]}-1.png`, 'synthetic png');
+        // Review rasterization passes -f/-l for a single page; full-document
+        // rasterization emits one PNG per simulated rendered page.
+        const pages = args.includes('-f') ? 1 : pageCount;
+        for (let page = 1; page <= pages; page++) await writeFile(`${args[args.length - 1]}-${page}.png`, 'synthetic png');
         return { code: 0, stdout: '', stderr: '' };
       }
       const control = args[0]?.includes('control') ?? false;
@@ -57,6 +60,49 @@ async function trackedFixture(pathname: string, revision: 'ins' | 'del' | 'ins-d
   }
   await writeFile(pathname, await zip.generateAsync({ type: 'nodebuffer' }));
 }
+
+const W_XMLNS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const FIXTURES_DIR = fileURLToPath(new URL('../fixtures/', import.meta.url));
+
+async function fixtureFragment(name: string): Promise<string> {
+  return (await readFile(path.join(FIXTURES_DIR, name), 'utf8')).trim();
+}
+
+function storyPartXml(fragment: string): string {
+  return fragment.replace(/^<w:(hdr|ftr)>/u, `<w:$1 xmlns:w="${W_XMLNS}">`);
+}
+
+async function paginatedFixture(pathname: string, parts: { body: string; header?: string; footer?: string }): Promise<void> {
+  const zip = new JSZip();
+  zip.file('[Content_Types].xml', '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"/>');
+  const references = `${parts.header ? '<w:headerReference r:id="rIdHeader1"/>' : ''}${parts.footer ? '<w:footerReference r:id="rIdFooter1"/>' : ''}`;
+  const sectPr = references.length > 0 ? `<w:sectPr>${references}</w:sectPr>` : '';
+  zip.file('word/document.xml', `<w:document xmlns:w="${W_XMLNS}" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:v="urn:schemas-microsoft-com:vml"><w:body>${parts.body}${sectPr}</w:body></w:document>`);
+  const relationships: string[] = [];
+  if (parts.header) {
+    zip.file('word/header1.xml', storyPartXml(parts.header));
+    relationships.push('<Relationship Id="rIdHeader1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/header" Target="header1.xml"/>');
+  }
+  if (parts.footer) {
+    zip.file('word/footer1.xml', storyPartXml(parts.footer));
+    relationships.push('<Relationship Id="rIdFooter1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/footer" Target="footer1.xml"/>');
+  }
+  if (relationships.length > 0) {
+    zip.file('word/_rels/document.xml.rels', `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">${relationships.join('')}</Relationships>`);
+  }
+  await writeFile(pathname, await zip.generateAsync({ type: 'nodebuffer' }));
+}
+
+const MULTI_PAGE_EXPECTED = 'Synthetic first page opening text. inserted-alpha Synthetic second page closing text. removed-beta';
+const MULTI_PAGE_PDF = [
+  'Synthetic Neutral Draft Header',
+  'Synthetic first page opening text. inserted-alpha',
+  'Page 1',
+  '\f',
+  'Synthetic Neutral Draft Header',
+  'Synthetic second page closing text. removed-beta',
+  'Page 2',
+].join('\n');
 
 describe('renderer verifier', () => {
   itAllure('counts broad blue and red pixel bands rather than requiring exact antialiasing pixels', () => {
@@ -123,7 +169,7 @@ describe('renderer verifier', () => {
     expect(result.reason).not.toContain('hid configured deletions');
   });
 
-  itAllure('prioritizes a PDF text mismatch over a hidden-deletion pixel pattern', async () => {
+  itAllure('reports a text-binding failure alongside, not instead of, pixel-derived colour evidence', async () => {
     const root = path.join(os.tmpdir(), `render-text-mismatch-${Date.now()}`);
     const source = path.join(root, 'tracked.docx');
     await mkdir(root, { recursive: true });
@@ -133,9 +179,10 @@ describe('renderer verifier', () => {
       tools: fakeTools('Visible markup text', undefined, true), configuredPixelFloor: 2,
     });
     expect(result).toMatchObject({
-      status: 'fail', revisionVisibility: 'insufficient-contrast',
-      reason: expect.stringContaining('PDF text does not equal'),
+      status: 'fail', revisionVisibility: 'insufficient-contrast', markupTextMatchesPdf: false,
+      reason: expect.stringContaining('PDF text binding failed'),
     });
+    expect(result.reason).toContain('colour bands');
   });
 
   itAllure('does not diagnose hidden deletions from an empty property-only deletion wrapper', async () => {
@@ -252,5 +299,154 @@ describe('renderer verifier', () => {
     });
     expect(result).toMatchObject({ status: 'fail', reason: expect.stringContaining('mutate authoritative') });
     expect(await readFile(source, 'utf8')).toBe('mutated');
+  });
+
+  itAllure('binds exact single-page text through the fixture body without pagination residue', async () => {
+    const root = path.join(os.tmpdir(), `render-single-page-${Date.now()}`);
+    const source = path.join(root, 'tracked.docx');
+    await mkdir(root, { recursive: true });
+    const text = 'Synthetic single page opening clause. inserted-alpha removed-beta';
+    await paginatedFixture(source, { body: await fixtureFragment('single-page-body.xml') });
+    const result = await verifyRenderedMarkup({
+      trackedDocxPath: source, expectedMarkupText: text, outputDir: path.join(root, 'out'),
+      tools: fakeTools(text), configuredPixelFloor: 2,
+    });
+    expect(result).toMatchObject({ status: 'pass', markupTextMatchesPdf: true, revisionVisibility: 'visible' });
+    expect(result.textBinding).toMatchObject({ matched: true, pageCount: 1, missingTokenSample: [], unexplainedTokenSample: [] });
+  });
+
+  itAllure('passes multi-page renders whose repeated header, footer, and page numbers are pagination artifacts', async () => {
+    const root = path.join(os.tmpdir(), `render-multi-page-${Date.now()}`);
+    const source = path.join(root, 'tracked.docx');
+    await mkdir(root, { recursive: true });
+    await paginatedFixture(source, {
+      body: await fixtureFragment('multi-page-body.xml'),
+      header: await fixtureFragment('repeated-header.xml'),
+      footer: await fixtureFragment('page-field-footer.xml'),
+    });
+    const result = await verifyRenderedMarkup({
+      trackedDocxPath: source, expectedMarkupText: MULTI_PAGE_EXPECTED, outputDir: path.join(root, 'out'),
+      tools: fakeTools(MULTI_PAGE_PDF, undefined, false, 2), configuredPixelFloor: 2,
+    });
+    expect(result).toMatchObject({ status: 'pass', markupTextMatchesPdf: true, revisionVisibility: 'visible' });
+    expect(result.textBinding).toMatchObject({ matched: true, pageCount: 2 });
+  });
+
+  itAllure('fails text binding when logical content is missing while keeping colour visibility truthful', async () => {
+    const root = path.join(os.tmpdir(), `render-missing-content-${Date.now()}`);
+    const source = path.join(root, 'tracked.docx');
+    await mkdir(root, { recursive: true });
+    await paginatedFixture(source, {
+      body: await fixtureFragment('multi-page-body.xml'),
+      header: await fixtureFragment('repeated-header.xml'),
+      footer: await fixtureFragment('page-field-footer.xml'),
+    });
+    const result = await verifyRenderedMarkup({
+      trackedDocxPath: source, expectedMarkupText: MULTI_PAGE_EXPECTED, outputDir: path.join(root, 'out'),
+      tools: fakeTools(MULTI_PAGE_PDF.replace('removed-beta', ''), undefined, false, 2), configuredPixelFloor: 2,
+    });
+    expect(result).toMatchObject({
+      status: 'fail', markupTextMatchesPdf: false, revisionVisibility: 'visible',
+      reason: expect.stringContaining('missing from the rendered PDF'),
+    });
+    expect(result.textBinding?.missingTokenSample).toContain('removed-beta');
+    expect(result.reason).not.toContain('colour bands');
+  });
+
+  itAllure('fails rendered residue that no header, footer, or page field can account for', async () => {
+    const root = path.join(os.tmpdir(), `render-unexplained-${Date.now()}`);
+    const source = path.join(root, 'tracked.docx');
+    await mkdir(root, { recursive: true });
+    await paginatedFixture(source, {
+      body: await fixtureFragment('multi-page-body.xml'),
+      header: await fixtureFragment('repeated-header.xml'),
+      footer: await fixtureFragment('page-field-footer.xml'),
+    });
+    const result = await verifyRenderedMarkup({
+      trackedDocxPath: source, expectedMarkupText: MULTI_PAGE_EXPECTED, outputDir: path.join(root, 'out'),
+      tools: fakeTools(`${MULTI_PAGE_PDF}\nleaked-residue-sentence`, undefined, false, 2), configuredPixelFloor: 2,
+    });
+    expect(result).toMatchObject({
+      status: 'fail', markupTextMatchesPdf: false,
+      reason: expect.stringContaining('not attributable'),
+    });
+    expect(result.textBinding?.unexplainedTokenSample).toContain('leaked-residue-sentence');
+  });
+
+  itAllure('bounds repeated header residue by the rendered page count', async () => {
+    const root = path.join(os.tmpdir(), `render-header-bound-${Date.now()}`);
+    const source = path.join(root, 'tracked.docx');
+    await mkdir(root, { recursive: true });
+    const body = 'Synthetic single page opening clause. inserted-alpha removed-beta';
+    await paginatedFixture(source, {
+      body: await fixtureFragment('single-page-body.xml'),
+      header: await fixtureFragment('repeated-header.xml'),
+    });
+    const doubledHeader = `Synthetic Neutral Draft Header\n${body}\nSynthetic Neutral Draft Header`;
+    const result = await verifyRenderedMarkup({
+      trackedDocxPath: source, expectedMarkupText: body, outputDir: path.join(root, 'out'),
+      tools: fakeTools(doubledHeader), configuredPixelFloor: 2,
+    });
+    expect(result).toMatchObject({ status: 'fail', markupTextMatchesPdf: false });
+    expect(result.textBinding?.unexplainedTokenSample).toContain('Neutral');
+  });
+
+  itAllure('rejects numeric residue when no rendered story declares a page field', async () => {
+    const root = path.join(os.tmpdir(), `render-no-page-field-${Date.now()}`);
+    const source = path.join(root, 'tracked.docx');
+    await mkdir(root, { recursive: true });
+    const body = 'Synthetic single page opening clause. inserted-alpha removed-beta';
+    await paginatedFixture(source, { body: await fixtureFragment('single-page-body.xml') });
+    const result = await verifyRenderedMarkup({
+      trackedDocxPath: source, expectedMarkupText: body, outputDir: path.join(root, 'out'),
+      tools: fakeTools(`${body}\n7`), configuredPixelFloor: 2,
+    });
+    expect(result).toMatchObject({ status: 'fail', markupTextMatchesPdf: false });
+    expect(result.textBinding?.unexplainedTokenSample).toContain('7');
+  });
+
+  itAllure('caps page-field numeric residue at page count times declared page fields', async () => {
+    const root = path.join(os.tmpdir(), `render-numeric-cap-${Date.now()}`);
+    const source = path.join(root, 'tracked.docx');
+    await mkdir(root, { recursive: true });
+    await paginatedFixture(source, {
+      body: await fixtureFragment('multi-page-body.xml'),
+      header: await fixtureFragment('repeated-header.xml'),
+      footer: await fixtureFragment('page-field-footer.xml'),
+    });
+    const result = await verifyRenderedMarkup({
+      trackedDocxPath: source, expectedMarkupText: MULTI_PAGE_EXPECTED, outputDir: path.join(root, 'out'),
+      tools: fakeTools(`${MULTI_PAGE_PDF}\n3 4 5 6 7`, undefined, false, 2), configuredPixelFloor: 2,
+    });
+    expect(result).toMatchObject({ status: 'fail', markupTextMatchesPdf: false });
+    expect(result.textBinding?.unexplainedTokenSample?.join(' ')).toContain('page-field allowance');
+  });
+
+  itAllure('accepts renderer-reordered text-box content because binding is order-independent', async () => {
+    const root = path.join(os.tmpdir(), `render-text-box-${Date.now()}`);
+    const source = path.join(root, 'tracked.docx');
+    await mkdir(root, { recursive: true });
+    await paginatedFixture(source, { body: await fixtureFragment('reordered-text-box.xml') });
+    const logicalOrder = 'Anchor paragraph before floating content. inserted-alpha Floating box narrative sentence. removed-beta';
+    const rendererOrder = 'Floating box narrative sentence. removed-beta\nAnchor paragraph before floating content. inserted-alpha';
+    const result = await verifyRenderedMarkup({
+      trackedDocxPath: source, expectedMarkupText: logicalOrder, outputDir: path.join(root, 'out'),
+      tools: fakeTools(rendererOrder), configuredPixelFloor: 2,
+    });
+    expect(result).toMatchObject({ status: 'pass', markupTextMatchesPdf: true, revisionVisibility: 'visible' });
+  });
+
+  itAllure('falls back to strict zero-allowance binding when the rendered package is unreadable', async () => {
+    const root = path.join(os.tmpdir(), `render-unreadable-${Date.now()}`);
+    const source = path.join(root, 'tracked.docx');
+    await mkdir(root, { recursive: true });
+    await writeFile(source, 'not a zip package');
+    const result = await verifyRenderedMarkup({
+      trackedDocxPath: source, expectedMarkupText: 'Visible markup text', outputDir: path.join(root, 'out'),
+      tools: fakeTools('Visible markup text\nRepeated Header Residue'), configuredPixelFloor: 2,
+    });
+    expect(result).toMatchObject({ status: 'fail', markupTextMatchesPdf: false });
+    expect(result.textBinding).toMatchObject({ pageCount: 1 });
+    expect(result.textBinding?.unexplainedTokenSample).toContain('Residue');
   });
 });

--- a/packages/docx-render-verifier/src/render.ts
+++ b/packages/docx-render-verifier/src/render.ts
@@ -41,32 +41,48 @@ const NUMERIC_TOKEN = /^[0-9]+$/u;
 const BINDING_SAMPLE_LIMIT = 8;
 
 export function emptyPaginationProfile(pageCount: number): PaginationProfile {
-  return { pageCount, headerFooterTokenCounts: new Map(), pageFieldCount: 0 };
+  return { pageCount, headerFooterTokenCounts: new Map(), headerFooterPageFieldCount: 0, bodyPageFieldCount: 0, pageNumberUpperBound: pageCount };
+}
+
+function isReservablePageNumber(token: string, pagination: PaginationProfile): boolean {
+  if (!NUMERIC_TOKEN.test(token)) return false;
+  const value = Number.parseInt(token, 10);
+  return value >= 1 && value <= pagination.pageNumberUpperBound;
 }
 
 /**
- * Story-scoped text binding: multiset containment with a pagination allowance.
+ * Story-scoped text binding: per-page maximal reservation of pagination
+ * artifacts, then multiset containment of the caller's logical projection.
  *
  * Invariant:
- * 1. Completeness lower bound — every whitespace-delimited token of the
- *    caller's logical markup projection must occur in the extracted PDF text
- *    at least as many times as it occurs in the projection. A render that
- *    drops any logical content therefore still fails.
- * 2. Bounded residue upper bound — every PDF token occurrence beyond the
- *    projection's count (the residue) must be attributable to renderer-created
- *    pagination artifacts with explicit occurrence bounds: a token drawn from
- *    a referenced header/footer story is allowed at most
- *    `pageCount x (its occurrence count in those stories)` residual
- *    occurrences, and purely numeric residue is allowed only when a
- *    PAGE-family field instruction exists in a rendered story, bounded in
- *    total by `pageCount x pageFieldCount`. Duplicated or hallucinated body
- *    content therefore also fails.
+ * 1. Pagination-first reservation — the extracted PDF text is split into
+ *    rendered pages (form feeds). On each page, pagination-owned material is
+ *    reserved FIRST and MAXIMALLY: each referenced header/footer story token
+ *    up to its occurrence count in those stories, and numeric page-number
+ *    renderings (integer value within the rendered page-number range) up to
+ *    the header/footer PAGE-family field count per page plus a
+ *    whole-document budget for body-story PAGE-family fields.
+ * 2. Completeness lower bound — every whitespace-delimited token of the
+ *    caller's logical projection must be covered by the tokens REMAINING
+ *    after reservation. Because reservation is maximal, repeated header or
+ *    footer vocabulary can never substitute for genuinely missing logical
+ *    content: dropping any logical token still fails.
+ * 3. Zero residue — every remaining token beyond the projection is
+ *    unexplained and fails, so duplicated or hallucinated rendered content
+ *    also fails.
  *
- * The binding deliberately does not check reading order: LibreOffice emits
- * text in renderer-created page and float positions (repeated headers,
- * footers, anchored text boxes), which a logical DOCX projection cannot
- * predict without reimplementing pagination. Order and placement remain the
- * image-review domain; colour visibility is verified separately.
+ * Accepted limitations, all in the strict (fail-not-pass) direction or
+ * covered by a separate check:
+ * - Reading order is not checked by this automated verdict; LibreOffice emits
+ *   text in renderer-created page and float positions that a logical DOCX
+ *   projection cannot predict. The emitted review PNGs support optional human
+ *   placement review; no automated placement comparison happens here.
+ * - Header/footer story text is pagination-owned and reserved, not itself
+ *   bound; revision visibility inside headers is covered by the pixel and
+ *   revision-markup path.
+ * - A bare integer in body text that falls within the rendered page-number
+ *   range may be attributed to pagination, which can only cause a failure,
+ *   never a false pass.
  *
  * The pagination profile is derived from the rendered artifact and the
  * rendered DOCX package only — never from the caller's projection or from any
@@ -74,27 +90,45 @@ export function emptyPaginationProfile(pageCount: number): PaginationProfile {
  */
 export function bindLogicalMarkupText(expectedMarkupText: string, pdfText: string, pagination: PaginationProfile): TextBindingEvidence {
   const expectedCounts = countTokens(tokenizeRenderedText(expectedMarkupText));
-  const pdfCounts = countTokens(tokenizeRenderedText(pdfText));
+  const bodyAvailable = new Map<string, number>();
+  let bodyFieldBudget = pagination.bodyPageFieldCount;
+  const pageNumberStart = pagination.pageNumberUpperBound - pagination.pageCount + 1;
+  for (const [pageIndex, page] of pdfText.split('\f').entries()) {
+    const remaining = new Map<string, number>();
+    for (const [token, count] of countTokens(tokenizeRenderedText(page))) {
+      const afterStories = count - Math.min(count, pagination.headerFooterTokenCounts.get(token) ?? 0);
+      if (afterStories > 0) remaining.set(token, afterStories);
+    }
+    let pageNumericBudget = pagination.headerFooterPageFieldCount;
+    const reserveNumeric = (token: string): void => {
+      let available = remaining.get(token) ?? 0;
+      while (available > 0 && (pageNumericBudget > 0 || bodyFieldBudget > 0)) {
+        if (pageNumericBudget > 0) pageNumericBudget--;
+        else bodyFieldBudget--;
+        available--;
+      }
+      remaining.set(token, available);
+    };
+    // Attribute the page's own PAGE rendering and the NUMPAGES total before
+    // any other in-range numeral, so a bare body integer is not attributed to
+    // pagination while the actual page number goes unaccounted.
+    for (const preferred of new Set([String(pageNumberStart + pageIndex), String(pagination.pageNumberUpperBound)])) {
+      if (isReservablePageNumber(preferred, pagination)) reserveNumeric(preferred);
+    }
+    for (const token of [...remaining.keys()]) {
+      if (isReservablePageNumber(token, pagination)) reserveNumeric(token);
+    }
+    for (const [token, count] of remaining) {
+      if (count > 0) bodyAvailable.set(token, (bodyAvailable.get(token) ?? 0) + count);
+    }
+  }
   const missingTokens: string[] = [];
   for (const [token, expected] of expectedCounts) {
-    if ((pdfCounts.get(token) ?? 0) < expected) missingTokens.push(token);
+    if ((bodyAvailable.get(token) ?? 0) < expected) missingTokens.push(token);
   }
   const unexplainedTokens: string[] = [];
-  let numericResidueTotal = 0;
-  for (const [token, rendered] of pdfCounts) {
-    const residue = rendered - (expectedCounts.get(token) ?? 0);
-    if (residue <= 0) continue;
-    const storyAllowance = pagination.pageCount * (pagination.headerFooterTokenCounts.get(token) ?? 0);
-    const beyondStories = residue - storyAllowance;
-    if (beyondStories <= 0) continue;
-    if (NUMERIC_TOKEN.test(token) && pagination.pageFieldCount > 0) {
-      numericResidueTotal += beyondStories;
-      continue;
-    }
-    unexplainedTokens.push(token);
-  }
-  if (numericResidueTotal > pagination.pageCount * pagination.pageFieldCount) {
-    unexplainedTokens.push(`${numericResidueTotal} numeric token occurrence(s) beyond the page-field allowance`);
+  for (const [token, available] of bodyAvailable) {
+    if (available - (expectedCounts.get(token) ?? 0) > 0) unexplainedTokens.push(token);
   }
   return {
     matched: missingTokens.length === 0 && unexplainedTokens.length === 0,
@@ -193,7 +227,9 @@ async function analyzeRenderedPackage(bytes: Buffer, pageCount: number): Promise
     let insertions = false;
     let deletions = false;
     const headerFooterTokenCounts = new Map<string, number>();
-    let pageFieldCount = 0;
+    let headerFooterPageFieldCount = 0;
+    let bodyPageFieldCount = 0;
+    let pageNumberStart = 1;
     for (const story of renderedStories) {
       const xml = await zip.file(story.name)?.async('string');
       if (xml === undefined) continue;
@@ -201,17 +237,39 @@ async function analyzeRenderedPackage(bytes: Buffer, pageCount: number): Promise
       deletions ||= hasVisibleRevisionInStory(xml, ['del', 'moveFrom']);
       const document = parseStoryXml(xml);
       if (document === null) continue;
-      pageFieldCount += pageFieldInstructionCount(document);
-      if (story.kind !== 'header' && story.kind !== 'footer') continue;
+      const isPaginationStory = story.kind === 'header' || story.kind === 'footer';
+      if (isPaginationStory) headerFooterPageFieldCount += pageFieldInstructionCount(document);
+      else bodyPageFieldCount += pageFieldInstructionCount(document);
+      if (story.kind === 'document') {
+        for (const numbering of Array.from(document.getElementsByTagNameNS(W_NS, 'pgNumType'))) {
+          const start = Number.parseInt(numbering.getAttributeNS(W_NS, 'start') ?? '', 10);
+          if (Number.isInteger(start) && start > pageNumberStart) pageNumberStart = start;
+        }
+      }
+      if (!isPaginationStory) continue;
       for (const localName of ['t', 'delText'] as const) {
         for (const text of Array.from(document.getElementsByTagNameNS(W_NS, localName))) {
+          // A cached field result (e.g. the stored "1" of a PAGE fldSimple) is
+          // not literal story text: at render time the field value replaces
+          // it. Counting it would double-reserve alongside the numeric
+          // page-field budget and could eat a legitimate body token.
+          if (hasFieldResultAncestor(text)) continue;
           for (const token of tokenizeRenderedText(text.textContent ?? '')) {
             headerFooterTokenCounts.set(token, (headerFooterTokenCounts.get(token) ?? 0) + 1);
           }
         }
       }
     }
-    return { revisionMarkup: { insertions, deletions }, pagination: { pageCount, headerFooterTokenCounts, pageFieldCount } };
+    return {
+      revisionMarkup: { insertions, deletions },
+      pagination: {
+        pageCount,
+        headerFooterTokenCounts,
+        headerFooterPageFieldCount,
+        bodyPageFieldCount,
+        pageNumberUpperBound: pageCount + pageNumberStart - 1,
+      },
+    };
   } catch {
     return fallback;
   }
@@ -224,6 +282,13 @@ function parseStoryXml(xml: string): ReturnType<DOMParser['parseFromString']> | 
   } catch {
     return null;
   }
+}
+
+function hasFieldResultAncestor(node: XmlElement): boolean {
+  for (let ancestor = node.parentNode; ancestor !== null; ancestor = ancestor.parentNode) {
+    if (ancestor.nodeType === 1 && (ancestor as XmlElement).namespaceURI === W_NS && (ancestor as XmlElement).localName === 'fldSimple') return true;
+  }
+  return false;
 }
 
 function pageFieldInstructionCount(document: NonNullable<ReturnType<typeof parseStoryXml>>): number {

--- a/packages/docx-render-verifier/src/render.ts
+++ b/packages/docx-render-verifier/src/render.ts
@@ -8,7 +8,7 @@ import { pathToFileURL } from 'node:url';
 import { promisify } from 'node:util';
 import JSZip from 'jszip';
 import { DOMParser, type Element as XmlElement } from '@xmldom/xmldom';
-import type { PixelMeasurement, RenderRequest, RendererTools, RenderVerdict, ToolResult } from './types.js';
+import type { PaginationProfile, PixelMeasurement, RenderRequest, RendererTools, RenderVerdict, TextBindingEvidence, ToolResult } from './types.js';
 
 const execFileAsync = promisify(execFile);
 const BLUE = [0, 0, 255] as const;
@@ -22,12 +22,86 @@ function sha256(bytes: Buffer): string {
   return createHash('sha256').update(bytes).digest('hex');
 }
 
-function normalizeText(value: string): string {
-  // PDF extraction is a reading-order oracle, not a pagination oracle. Line
-  // wrapping, page breaks, and indentation legitimately vary by renderer, so
-  // bind the complete non-whitespace character sequence while layout remains
-  // the separate image-review domain.
-  return value.replace(/\s+/gu, ' ').trim();
+function tokenizeRenderedText(value: string): string[] {
+  // PDF extraction is a content oracle, not a pagination oracle. Line
+  // wrapping, page breaks, form feeds, and indentation legitimately vary by
+  // renderer, so bind whitespace-delimited tokens while layout remains the
+  // separate image-review domain.
+  return value.split(/\s+/u).filter((token) => token.length > 0);
+}
+
+function countTokens(tokens: readonly string[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const token of tokens) counts.set(token, (counts.get(token) ?? 0) + 1);
+  return counts;
+}
+
+const PAGE_FIELD_INSTRUCTION = /\b(?:PAGE|NUMPAGES|SECTIONPAGES|PAGEREF)\b/u;
+const NUMERIC_TOKEN = /^[0-9]+$/u;
+const BINDING_SAMPLE_LIMIT = 8;
+
+export function emptyPaginationProfile(pageCount: number): PaginationProfile {
+  return { pageCount, headerFooterTokenCounts: new Map(), pageFieldCount: 0 };
+}
+
+/**
+ * Story-scoped text binding: multiset containment with a pagination allowance.
+ *
+ * Invariant:
+ * 1. Completeness lower bound — every whitespace-delimited token of the
+ *    caller's logical markup projection must occur in the extracted PDF text
+ *    at least as many times as it occurs in the projection. A render that
+ *    drops any logical content therefore still fails.
+ * 2. Bounded residue upper bound — every PDF token occurrence beyond the
+ *    projection's count (the residue) must be attributable to renderer-created
+ *    pagination artifacts with explicit occurrence bounds: a token drawn from
+ *    a referenced header/footer story is allowed at most
+ *    `pageCount x (its occurrence count in those stories)` residual
+ *    occurrences, and purely numeric residue is allowed only when a
+ *    PAGE-family field instruction exists in a rendered story, bounded in
+ *    total by `pageCount x pageFieldCount`. Duplicated or hallucinated body
+ *    content therefore also fails.
+ *
+ * The binding deliberately does not check reading order: LibreOffice emits
+ * text in renderer-created page and float positions (repeated headers,
+ * footers, anchored text boxes), which a logical DOCX projection cannot
+ * predict without reimplementing pagination. Order and placement remain the
+ * image-review domain; colour visibility is verified separately.
+ *
+ * The pagination profile is derived from the rendered artifact and the
+ * rendered DOCX package only — never from the caller's projection or from any
+ * Safe DOCX generator — so the binding stays an independent oracle.
+ */
+export function bindLogicalMarkupText(expectedMarkupText: string, pdfText: string, pagination: PaginationProfile): TextBindingEvidence {
+  const expectedCounts = countTokens(tokenizeRenderedText(expectedMarkupText));
+  const pdfCounts = countTokens(tokenizeRenderedText(pdfText));
+  const missingTokens: string[] = [];
+  for (const [token, expected] of expectedCounts) {
+    if ((pdfCounts.get(token) ?? 0) < expected) missingTokens.push(token);
+  }
+  const unexplainedTokens: string[] = [];
+  let numericResidueTotal = 0;
+  for (const [token, rendered] of pdfCounts) {
+    const residue = rendered - (expectedCounts.get(token) ?? 0);
+    if (residue <= 0) continue;
+    const storyAllowance = pagination.pageCount * (pagination.headerFooterTokenCounts.get(token) ?? 0);
+    const beyondStories = residue - storyAllowance;
+    if (beyondStories <= 0) continue;
+    if (NUMERIC_TOKEN.test(token) && pagination.pageFieldCount > 0) {
+      numericResidueTotal += beyondStories;
+      continue;
+    }
+    unexplainedTokens.push(token);
+  }
+  if (numericResidueTotal > pagination.pageCount * pagination.pageFieldCount) {
+    unexplainedTokens.push(`${numericResidueTotal} numeric token occurrence(s) beyond the page-field allowance`);
+  }
+  return {
+    matched: missingTokens.length === 0 && unexplainedTokens.length === 0,
+    pageCount: pagination.pageCount,
+    missingTokenSample: missingTokens.slice(0, BINDING_SAMPLE_LIMIT),
+    unexplainedTokenSample: unexplainedTokens.slice(0, BINDING_SAMPLE_LIMIT),
+  };
 }
 
 function profileXml(mode: 'configured' | 'by-author'): string {
@@ -102,29 +176,69 @@ function revisionVisibility(configured: PixelMeasurement, control: PixelMeasurem
   return 'insufficient-contrast';
 }
 
-async function renderedRevisionMarkup(bytes: Buffer): Promise<{ insertions: boolean; deletions: boolean }> {
+type RenderedStory = { name: string; kind: 'document' | 'header' | 'footer' | 'footnotes' | 'endnotes' };
+
+type RenderedPackageEvidence = {
+  revisionMarkup: { insertions: boolean; deletions: boolean };
+  pagination: PaginationProfile;
+};
+
+async function analyzeRenderedPackage(bytes: Buffer, pageCount: number): Promise<RenderedPackageEvidence> {
+  const fallback: RenderedPackageEvidence = { revisionMarkup: { insertions: false, deletions: false }, pagination: emptyPaginationProfile(pageCount) };
   try {
     const zip = await JSZip.loadAsync(bytes);
     const documentXml = await zip.file('word/document.xml')?.async('string');
-    if (documentXml === undefined) return { insertions: false, deletions: false };
+    if (documentXml === undefined) return fallback;
     const renderedStories = await referencedRenderedStories(zip, documentXml);
     let insertions = false;
     let deletions = false;
-    for (const name of renderedStories) {
-      const xml = await zip.file(name)?.async('string');
+    const headerFooterTokenCounts = new Map<string, number>();
+    let pageFieldCount = 0;
+    for (const story of renderedStories) {
+      const xml = await zip.file(story.name)?.async('string');
       if (xml === undefined) continue;
       insertions ||= hasVisibleRevisionInStory(xml, ['ins', 'moveTo']);
       deletions ||= hasVisibleRevisionInStory(xml, ['del', 'moveFrom']);
-      if (insertions && deletions) break;
+      const document = parseStoryXml(xml);
+      if (document === null) continue;
+      pageFieldCount += pageFieldInstructionCount(document);
+      if (story.kind !== 'header' && story.kind !== 'footer') continue;
+      for (const localName of ['t', 'delText'] as const) {
+        for (const text of Array.from(document.getElementsByTagNameNS(W_NS, localName))) {
+          for (const token of tokenizeRenderedText(text.textContent ?? '')) {
+            headerFooterTokenCounts.set(token, (headerFooterTokenCounts.get(token) ?? 0) + 1);
+          }
+        }
+      }
     }
-    return { insertions, deletions };
+    return { revisionMarkup: { insertions, deletions }, pagination: { pageCount, headerFooterTokenCounts, pageFieldCount } };
   } catch {
-    return { insertions: false, deletions: false };
+    return fallback;
   }
 }
 
-async function referencedRenderedStories(zip: JSZip, documentXml: string): Promise<string[]> {
-  const stories = ['word/document.xml'];
+function parseStoryXml(xml: string): ReturnType<DOMParser['parseFromString']> | null {
+  try {
+    const document = new DOMParser().parseFromString(xml, 'application/xml');
+    return document.getElementsByTagName('parsererror').length > 0 ? null : document;
+  } catch {
+    return null;
+  }
+}
+
+function pageFieldInstructionCount(document: NonNullable<ReturnType<typeof parseStoryXml>>): number {
+  let count = 0;
+  for (const instruction of Array.from(document.getElementsByTagNameNS(W_NS, 'instrText'))) {
+    if (PAGE_FIELD_INSTRUCTION.test(instruction.textContent ?? '')) count++;
+  }
+  for (const field of Array.from(document.getElementsByTagNameNS(W_NS, 'fldSimple'))) {
+    if (PAGE_FIELD_INSTRUCTION.test(field.getAttributeNS(W_NS, 'instr') ?? '')) count++;
+  }
+  return count;
+}
+
+async function referencedRenderedStories(zip: JSZip, documentXml: string): Promise<RenderedStory[]> {
+  const stories: RenderedStory[] = [{ name: 'word/document.xml', kind: 'document' }];
   const document = new DOMParser().parseFromString(documentXml, 'application/xml');
   if (document.getElementsByTagName('parsererror').length > 0) return stories;
   const referencedIds = new Set<string>();
@@ -147,14 +261,14 @@ async function referencedRenderedStories(zip: JSZip, documentXml: string): Promi
     const target = relationship.getAttribute('Target');
     if (!id || !type || !target) continue;
     const kind = type.startsWith(OFFICE_REL_PREFIX) ? type.slice(OFFICE_REL_PREFIX.length) : '';
+    if (kind !== 'header' && kind !== 'footer' && kind !== 'footnotes' && kind !== 'endnotes') continue;
     const referenced = (kind === 'header' || kind === 'footer') ? referencedIds.has(id)
-      : kind === 'footnotes' ? hasFootnotes
-        : kind === 'endnotes' ? hasEndnotes : false;
+      : kind === 'footnotes' ? hasFootnotes : hasEndnotes;
     if (!referenced) continue;
     const resolved = target.startsWith('/') ? target.slice(1) : path.posix.normalize(path.posix.join('word', target));
-    if (zip.file(resolved)) stories.push(resolved);
+    if (zip.file(resolved) && !stories.some((story) => story.name === resolved)) stories.push({ name: resolved, kind });
   }
-  return [...new Set(stories)];
+  return stories;
 }
 
 function hasVisibleRevisionInStory(xml: string, wrapperNames: readonly string[]): boolean {
@@ -212,7 +326,7 @@ async function extractPdfText(tools: RendererTools, command: string, pdfPath: st
   return result.stdout;
 }
 
-async function measurePdf(tools: RendererTools, pdftoppm: string, magick: string, pdfPath: string, workspace: string, name: string): Promise<PixelMeasurement> {
+async function measurePdf(tools: RendererTools, pdftoppm: string, magick: string, pdfPath: string, workspace: string, name: string): Promise<{ pixels: PixelMeasurement; pageCount: number }> {
   const prefix = path.join(workspace, name);
   const raster = await tools.run(pdftoppm, ['-png', '-r', '96', pdfPath, prefix]);
   if (raster.code !== 0) throw new Error(`pdftoppm failed: ${(raster.stderr || raster.stdout).trim()}`);
@@ -233,7 +347,7 @@ async function measurePdf(tools: RendererTools, pdftoppm: string, magick: string
     total.bluePixels += measured.bluePixels;
     total.redPixels += measured.redPixels;
   }
-  return total;
+  return { pixels: total, pageCount: pages.length };
 }
 
 async function reviewPages(tools: RendererTools, pdftoppm: string, pdfPath: string, outputDir: string, pages: number[]): Promise<string[]> {
@@ -287,33 +401,45 @@ export async function verifyRenderedMarkup(request: RenderRequest): Promise<Rend
     const configured = await renderOne(tools, soffice, renderInput, workspace, 'configured');
     const control = await renderOne(tools, soffice, renderInput, workspace, 'by-author');
     const pdfText = await extractPdfText(tools, pdftotext, configured.pdfPath);
-    const [configuredPixels, controlPixels, reviewPngs] = await Promise.all([
+    const [configuredMeasured, controlMeasured, reviewPngs] = await Promise.all([
       measurePdf(tools, pdftoppm, magick, configured.pdfPath, workspace, 'configured'),
       measurePdf(tools, pdftoppm, magick, control.pdfPath, workspace, 'control'),
       reviewPages(tools, pdftoppm, configured.pdfPath, request.outputDir, request.reviewPages ?? [1]),
     ]);
-    const markupTextMatchesPdf = normalizeText(pdfText) === normalizeText(request.expectedMarkupText);
+    const configuredPixels = configuredMeasured.pixels;
+    const controlPixels = controlMeasured.pixels;
+    const packageEvidence = await analyzeRenderedPackage(renderedInputBytes, configuredMeasured.pageCount);
+    const textBinding = bindLogicalMarkupText(request.expectedMarkupText, pdfText, packageEvidence.pagination);
+    const markupTextMatchesPdf = textBinding.matched;
     const configuredContrastPassed = configuredContrast(configuredPixels, controlPixels, request.configuredPixelFloor ?? 4);
     const measuredVisibility = revisionVisibility(configuredPixels, controlPixels, request.configuredPixelFloor ?? 4);
-    const revisionMarkup = await renderedRevisionMarkup(renderedInputBytes);
-    const visibility = markupTextMatchesPdf && (measuredVisibility !== 'hidden-deletions' || (revisionMarkup.insertions && revisionMarkup.deletions))
+    const revisionMarkup = packageEvidence.revisionMarkup;
+    // Colour visibility is classified from pixel and revision-markup evidence
+    // only. A text-binding failure is reported as its own reason and never
+    // relabels calibrated colour evidence as insufficient-contrast.
+    const visibility = measuredVisibility !== 'hidden-deletions' || (revisionMarkup.insertions && revisionMarkup.deletions)
       ? measuredVisibility
       : 'insufficient-contrast';
+    const reasons: string[] = [];
+    if (!markupTextMatchesPdf) {
+      reasons.push(textBinding.missingTokenSample.length > 0
+        ? 'PDF text binding failed: expected logical markup content is missing from the rendered PDF.'
+        : 'PDF text binding failed: rendered text is not attributable to logical markup or pagination artifacts.');
+    }
+    if (visibility === 'hidden-deletions') reasons.push('LibreOffice rendered configured insertions but hid configured deletions.');
+    else if (!configuredContrastPassed) reasons.push('Configured render did not exceed by-author control colour bands.');
     const pdfOut = path.join(request.outputDir, 'tracked-configured.pdf');
     await copyFile(configured.pdfPath, pdfOut);
     return {
       status: markupTextMatchesPdf && configuredContrastPassed ? 'pass' : 'fail',
-      reason: !markupTextMatchesPdf
-        ? 'PDF text does not equal caller-supplied independent markup text.'
-        : visibility === 'hidden-deletions'
-          ? 'LibreOffice rendered configured insertions but hid configured deletions.'
-          : configuredContrastPassed ? undefined : 'Configured render did not exceed by-author control colour bands.',
+      reason: reasons.length > 0 ? reasons.join(' ') : undefined,
       trackedSha256,
       renderedInputSha256: sha256(renderedInputBytes),
       transform,
       pdfPath: pdfOut,
       reviewPngs,
       markupTextMatchesPdf,
+      textBinding,
       configured: configuredPixels,
       byAuthorControl: controlPixels,
       configuredContrastPassed,

--- a/packages/docx-render-verifier/src/types.ts
+++ b/packages/docx-render-verifier/src/types.ts
@@ -27,10 +27,14 @@ export type PixelMeasurement = {
 export type PaginationProfile = {
   /** Number of rasterized pages in the configured render. */
   pageCount: number;
-  /** Rendered token occurrence counts from referenced header and footer stories. */
+  /** Per-page reservation quota: rendered token occurrence counts from referenced header and footer stories. */
   headerFooterTokenCounts: ReadonlyMap<string, number>;
-  /** Count of PAGE-family field instructions across rendered stories. */
-  pageFieldCount: number;
+  /** Per-page numeric reservation quota: PAGE-family field instructions in referenced header/footer stories. */
+  headerFooterPageFieldCount: number;
+  /** Whole-document numeric reservation quota: PAGE-family field instructions in body-layer stories. */
+  bodyPageFieldCount: number;
+  /** Highest integer accepted as a rendered page number (pageCount adjusted by any explicit numbering start). */
+  pageNumberUpperBound: number;
 };
 
 /**

--- a/packages/docx-render-verifier/src/types.ts
+++ b/packages/docx-render-verifier/src/types.ts
@@ -19,6 +19,34 @@ export type PixelMeasurement = {
   redPixels: number;
 };
 
+/**
+ * Renderer-created pagination facts used to bound PDF text residue. All values
+ * are derived from the rendered artifact and the rendered DOCX package itself,
+ * never from the caller's expected markup projection.
+ */
+export type PaginationProfile = {
+  /** Number of rasterized pages in the configured render. */
+  pageCount: number;
+  /** Rendered token occurrence counts from referenced header and footer stories. */
+  headerFooterTokenCounts: ReadonlyMap<string, number>;
+  /** Count of PAGE-family field instructions across rendered stories. */
+  pageFieldCount: number;
+};
+
+/**
+ * Structured outcome of the story-scoped text binding. Token samples are
+ * bounded excerpts for diagnosis; `matched` is the binding verdict.
+ */
+export type TextBindingEvidence = {
+  matched: boolean;
+  /** Rendered page count the occurrence bounds were computed against. */
+  pageCount: number;
+  /** Bounded sample of expected tokens missing from the rendered PDF text. */
+  missingTokenSample: string[];
+  /** Bounded sample of rendered tokens not attributable to markup or pagination. */
+  unexplainedTokenSample: string[];
+};
+
 export type RenderVerdict = {
   status: Verdict;
   reason?: string;
@@ -27,7 +55,10 @@ export type RenderVerdict = {
   transform?: { id: string; version: string; inputSha256: string; outputSha256: string };
   pdfPath?: string;
   reviewPngs: string[];
+  /** True when the story-scoped text binding matched; see `textBinding`. */
   markupTextMatchesPdf?: boolean;
+  /** Structured text-binding evidence, reported separately from colour visibility. */
+  textBinding?: TextBindingEvidence;
   configured?: PixelMeasurement;
   byAuthorControl?: PixelMeasurement;
   configuredContrastPassed?: boolean;


### PR DESCRIPTION
Fixes #833

## Problem

`verifyRenderedMarkup()` required normalized `pdftotext` output to equal one caller-supplied logical markup string. For a paginated Word document, LibreOffice's PDF contains repeated headers, repeated footers, page-number field renderings, and text in renderer-created page/float order. A logical DOCX body/story projection cannot predict that sequence without reimplementing pagination, so a render with correctly calibrated blue insertions and red deletions failed anyway — and the failure was mislabeled `insufficient-contrast`.

## Selected invariant: story-scoped per-page reservation, then exact multiset coverage

1. **Pagination-first reservation** — extracted PDF text is split into rendered pages (form feeds). On each page, pagination-owned material is reserved FIRST and MAXIMALLY: each referenced header/footer story token up to its occurrence count in those stories (cached field results excluded), and numeric page-number renderings up to the header/footer PAGE-family field count per page plus a whole-document budget for body-story fields. Numeric reservation is value-constrained to the rendered page-number range (`w:pgNumType` start offsets included) and prioritizes each page's own number and the NUMPAGES total.
2. **Completeness lower bound** — every token of the caller's logical projection must be covered by the tokens remaining after reservation. Because reservation is maximal, repeated header/footer vocabulary can never substitute for genuinely missing logical content.
3. **Zero residue** — every remaining token beyond the projection fails, so duplicated or hallucinated rendered content also fails.

The pagination profile is derived from the rendered DOCX package (via the existing `referencedRenderedStories()` resolver, now story-kind-aware) and the rasterized page count of the configured render — never from the caller's projection and never from any Safe DOCX generator — so the package remains an independent verifier.

**Why it can still fail on genuinely missing content:** a dropped logical token is not covered by post-reservation remainders (verified by fake-harness regressions and a real-render negative control), a body token that only header repetition could supply is still reported missing (header-masking regression), an out-of-range numeral such as an amount is never absorbed by a PAGE field, and any unattributable residue fails outright. If the rendered package is unreadable, reservation degrades to zero — strict multiset equality — rather than to leniency.

**Documented limitations (strict direction or separately covered):** reading order is outside the automated verdict (review PNGs support optional human placement review; no automated placement comparison); header/footer story text is pagination-owned and not itself bound (header revision visibility is covered by the pixel/revision-markup path); a bare in-range integer in body text may be attributed to pagination, which can only cause a failure, never a false pass.

## Separate failure reporting

- `RenderVerdict.textBinding` is new structured evidence (`matched`, `pageCount`, `missingTokenSample`, `unexplainedTokenSample`); `markupTextMatchesPdf` keeps its meaning for existing consumers (docx-release-verifier).
- `revisionVisibility` is now classified purely from pixel + revision-markup evidence. A text-binding failure produces its own reason string and never relabels calibrated colour evidence as `insufficient-contrast`.

## Fixtures

New generated fixtures (all synthetic, leak-scanned, registered in `fixtures/index.json`): `single-page-body.xml`, `multi-page-body.xml` (explicit page break), `repeated-header.xml`, `page-field-footer.xml` (PAGE field), `reordered-text-box.xml`. Tests drive the existing fake `RendererTools` harness (extended with a simulated page count) — no real binaries needed in CI. No private corpus content is included anywhere.

## Peer review + real-render validation

Codex peer review (dynamic, with executed probes) returned REQUEST-CHANGES on the first-cut design; all four findings were fixed in the follow-up commit — see the adjudication comment. Real-binary validation (`soffice`/`pdftotext`/`pdftoppm`/`magick`) on a synthetic 2-page tracked DOCX with repeated header and `Page <PAGE>` footer: correct projection passes (`textBinding.matched: true`, `pageCount: 2`, blue 29 / red 30 vs by-author control 0/0, `revisionVisibility: "visible"`); a corrupted projection fails with the text-binding reason and `missingTokenSample: ["phantom-token-that-was-never-rendered"]` while `revisionVisibility` stays `"visible"`.
