### PR TITLE
fix(docx-release-verifier): require anchoring before whitespace counts as preservable

### DIFF
--- a/packages/docx-release-verifier/src/index.ts
+++ b/packages/docx-release-verifier/src/index.ts
@@ -1,5 +1,5 @@
 export { verifyRelease } from './verifier.js';
-export { emittedRedlineMinimality, tokenizeExact } from './minimality.js';
-export type { MinimalityDiagnostic, MinimalityEvidence } from './minimality.js';
+export { classifyToken, emittedRedlineMinimality, tokenizeExact } from './minimality.js';
+export type { MinimalityDiagnostic, MinimalityEvidence, TokenClass, TokenClassCounts } from './minimality.js';
 export { RELEASE_CERTIFICATE_VERSION, RELEASE_MANIFEST_VERSION } from './types.js';
 export type { ReleaseCertificate, ReleaseManifest, Verdict, VerdictStatus } from './types.js';

--- a/packages/docx-release-verifier/src/minimality.test.ts
+++ b/packages/docx-release-verifier/src/minimality.test.ts
@@ -99,6 +99,18 @@ describe('independent emitted-redline minimality', () => {
     expect(result.lostTokensByClass).toEqual({ lexical: 0, punctuation: 0, structural: 0, whitespace: 1 });
   });
 
+  itAllure('credits an anchored ordinary space despite an earlier repeated space', () => {
+    const body = paragraph(`${del('x')}${ins('y')}${plain(' ')}${del('x')}${ins('y')}${plain(' x')}`);
+    const result = check(['x x x'], ['y y x'], body);
+    expect(result).toMatchObject({ passed: true, lostTokens: 0 });
+  });
+
+  itAllure('credits an anchored ordinary space despite a later repeated space', () => {
+    const body = paragraph(`${plain('x ')}${del('x')}${ins('y')}${plain(' ')}${del('x')}${ins('y')}`);
+    const result = check(['x x x'], ['x y y'], body);
+    expect(result).toMatchObject({ passed: true, lostTokens: 0 });
+  });
+
   itAllure('anchors shared leading indentation by position', () => {
     const surgical = check(['  alpha'], ['  beta'], paragraph(`${plain('  ')}${del('alpha')}${ins('beta')}`));
     expect(surgical).toMatchObject({ passed: true, lostTokens: 0 });

--- a/packages/docx-release-verifier/src/minimality.test.ts
+++ b/packages/docx-release-verifier/src/minimality.test.ts
@@ -69,4 +69,48 @@ describe('independent emitted-redline minimality', () => {
     const result = check(['same text', 'same text'], ['same text', 'same text'], body);
     expect(result.passed).toBe(false);
   });
+
+  itAllure('does not charge unanchored whitespace to a complete phrase replacement', () => {
+    const result = check(['alpha beta gamma'], ['delta epsilon zeta'], paragraph(`${del('alpha beta gamma')}${ins('delta epsilon zeta')}`));
+    expect(result).toMatchObject({ passed: true, availableTokens: 0, preservedTokens: 0, lostTokens: 0 });
+  });
+
+  itAllure('still charges whitespace anchored to a genuinely matched neighbor', () => {
+    const surgical = check(['alpha beta gamma'], ['alpha epsilon zeta'], paragraph(`${plain('alpha ')}${del('beta gamma')}${ins('epsilon zeta')}`));
+    expect(surgical).toMatchObject({ passed: true, lostTokens: 0 });
+
+    const coarse = check(['alpha beta gamma'], ['alpha epsilon zeta'], paragraph(`${del('alpha beta gamma')}${ins('alpha epsilon zeta')}`));
+    expect(coarse.passed).toBe(false);
+    expect(coarse.lostTokens).toBe(2);
+    expect(coarse.lostTokensByClass).toEqual({ lexical: 1, punctuation: 0, structural: 0, whitespace: 1 });
+  });
+
+  itAllure('still fails a needless whitespace-only rewrite between kept words', () => {
+    const result = check(['alpha beta'], ['alpha beta'], paragraph(`${plain('alpha')}${del(' ')}${ins(' ')}${plain('beta')}`));
+    expect(result.passed).toBe(false);
+    expect(result.lostTokens).toBe(1);
+    expect(result.lostTokensByClass).toEqual({ lexical: 0, punctuation: 0, structural: 0, whitespace: 1 });
+  });
+
+  itAllure('does not let an ordinary whitespace run beyond a revision wrapper stand in for a rewritten anchored space', () => {
+    const body = paragraph(`${plain('alpha beta')}${del(' ')}${ins(' ')}${del('x')}${ins('y')}${plain(' ')}${del('gamma')}${ins('delta')}`);
+    const result = check(['alpha beta x gamma'], ['alpha beta y delta'], body);
+    expect(result.passed).toBe(false);
+    expect(result.lostTokensByClass).toEqual({ lexical: 0, punctuation: 0, structural: 0, whitespace: 1 });
+  });
+
+  itAllure('anchors shared leading indentation by position', () => {
+    const surgical = check(['  alpha'], ['  beta'], paragraph(`${plain('  ')}${del('alpha')}${ins('beta')}`));
+    expect(surgical).toMatchObject({ passed: true, lostTokens: 0 });
+
+    const coarse = check(['  alpha'], ['  beta'], paragraph(`${del('  alpha')}${ins('  beta')}`));
+    expect(coarse.passed).toBe(false);
+    expect(coarse.lostTokensByClass).toEqual({ lexical: 0, punctuation: 0, structural: 0, whitespace: 1 });
+  });
+
+  itAllure('classifies a needlessly rewritten tab as structural loss', () => {
+    const result = check(['alpha\tbeta'], ['alpha\tbeta'], paragraph(`${plain('alpha')}${del('\t')}${ins('\t')}${plain('beta')}`));
+    expect(result.passed).toBe(false);
+    expect(result.lostTokensByClass).toEqual({ lexical: 0, punctuation: 0, structural: 1, whitespace: 0 });
+  });
 });

--- a/packages/docx-release-verifier/src/minimality.ts
+++ b/packages/docx-release-verifier/src/minimality.ts
@@ -5,6 +5,16 @@ const MAX_PARAGRAPHS = 512;
 const MAX_TOKENS_PER_PARAGRAPH = 4096;
 const MAX_DIAGNOSTICS = 64;
 
+/**
+ * Loss classification for diagnostics: `lexical` covers word and number
+ * tokens, `punctuation` covers single non-word visible characters,
+ * `structural` covers whitespace runs containing a tab or line break, and
+ * `whitespace` covers plain inter-word space runs.
+ */
+export type TokenClass = 'lexical' | 'punctuation' | 'structural' | 'whitespace';
+
+export type TokenClassCounts = Record<TokenClass, number>;
+
 export interface MinimalityDiagnostic {
   originalParagraphIndex: number;
   revisedParagraphIndex: number;
@@ -12,6 +22,7 @@ export interface MinimalityDiagnostic {
   availableTokens: number;
   preservedTokens: number;
   lostTokens: number;
+  lostTokensByClass: TokenClassCounts;
   efficiencyPercent: number;
   topology: 'identified' | 'identified_repeated' | 'unresolved_ambiguous_paragraph_topology';
 }
@@ -22,6 +33,7 @@ export interface MinimalityEvidence {
   availableTokens: number;
   preservedTokens: number;
   lostTokens: number;
+  lostTokensByClass: TokenClassCounts;
   efficiencyPercent: number;
   comparedParagraphs: number;
   unresolvedTopologyParagraphs: number;
@@ -55,6 +67,127 @@ function lcsPairs<T>(left: readonly T[], right: readonly T[]): Pair[] {
 /** Exact tokens: whitespace runs, Unicode word runs, and individual punctuation. */
 export function tokenizeExact(text: string): string[] {
   return text.match(/\s+|[\p{L}\p{N}_]+|[^\s\p{L}\p{N}_]/gu) ?? [];
+}
+
+function isWhitespaceToken(token: string): boolean {
+  return /^\s/u.test(token);
+}
+
+export function classifyToken(token: string): TokenClass {
+  if (!isWhitespaceToken(token)) return /^[\p{L}\p{N}_]/u.test(token) ? 'lexical' : 'punctuation';
+  return /[\t\n\r]/u.test(token) ? 'structural' : 'whitespace';
+}
+
+function emptyTokenClassCounts(): TokenClassCounts {
+  return { lexical: 0, punctuation: 0, structural: 0, whitespace: 0 };
+}
+
+function countTokenClasses(tokens: readonly string[]): TokenClassCounts {
+  const counts = emptyTokenClassCounts();
+  for (const token of tokens) counts[classifyToken(token)] += 1;
+  return counts;
+}
+
+/**
+ * A common token that the finished redline is obliged to preserve. For a
+ * whitespace token the anchor flags record why its original/revised match is
+ * genuine rather than a coincidence of the token alphabet: every inter-word
+ * space compares equal, so an anchor names either the identical matched
+ * non-whitespace neighbor (preceding or following) or the shared paragraph
+ * extremity (start or end) the run is pinned to.
+ */
+type CommonToken = {
+  token: string;
+  anchoredByPrecedingMatch: boolean;
+  anchoredByFollowingMatch: boolean;
+  anchoredAtParagraphStart: boolean;
+  anchoredAtParagraphEnd: boolean;
+};
+
+/**
+ * Common tokens between the original and revised paragraph texts that count
+ * as preservation obligations. Non-whitespace matches always count. A
+ * whitespace match counts only when anchored: the LCS also matched the
+ * immediately adjacent token on both sides (positions `i-1`/`j-1` or
+ * `i+1`/`j+1`, which is necessarily non-whitespace because whitespace runs
+ * are tokenized maximally), or the run sits at the shared paragraph start or
+ * end in both texts. Unanchored whitespace pairs — spaces the LCS paired
+ * across otherwise unrelated rewritten phrases — are excluded, so a complete
+ * phrase replacement is not charged for spaces it never actually preserved.
+ */
+function anchoredCommonTokens(originalTokens: readonly string[], revisedTokens: readonly string[]): CommonToken[] {
+  const pairs = lcsPairs(originalTokens, revisedTokens);
+  const result: CommonToken[] = [];
+  pairs.forEach((pair, index) => {
+    const token = originalTokens[pair.left]!;
+    if (!isWhitespaceToken(token)) {
+      result.push({ token, anchoredByPrecedingMatch: false, anchoredByFollowingMatch: false, anchoredAtParagraphStart: false, anchoredAtParagraphEnd: false });
+      return;
+    }
+    const preceding = pairs[index - 1];
+    const following = pairs[index + 1];
+    const common: CommonToken = {
+      token,
+      anchoredByPrecedingMatch: preceding !== undefined
+        && preceding.left === pair.left - 1 && preceding.right === pair.right - 1
+        && !isWhitespaceToken(originalTokens[preceding.left]!),
+      anchoredByFollowingMatch: following !== undefined
+        && following.left === pair.left + 1 && following.right === pair.right + 1
+        && !isWhitespaceToken(originalTokens[following.left]!),
+      anchoredAtParagraphStart: pair.left === 0 && pair.right === 0,
+      anchoredAtParagraphEnd: pair.left === originalTokens.length - 1 && pair.right === revisedTokens.length - 1,
+    };
+    if (common.anchoredByPrecedingMatch || common.anchoredByFollowingMatch || common.anchoredAtParagraphStart || common.anchoredAtParagraphEnd) result.push(common);
+  });
+  return result;
+}
+
+/**
+ * An ordinary (non-revised) token of the tracked paragraph, tagged with the
+ * ordinary text segment it came from. Segment boundaries mark content-bearing
+ * revision wrappers, so two tokens in different segments are separated by
+ * revised content in the document even though they are adjacent in the
+ * flattened list.
+ */
+type OrdinaryToken = { token: string; segment: number };
+
+function ordinaryTokens(segments: readonly string[]): OrdinaryToken[] {
+  return segments.flatMap((text, segment) => tokenizeExact(text).map((token) => ({ token, segment })));
+}
+
+/**
+ * Indices of the common tokens the tracked paragraph genuinely preserves as
+ * ordinary text. Non-whitespace matches count directly. A whitespace match
+ * counts only through one of its recorded anchors: the anchoring neighbor
+ * must itself be matched immediately adjacent within the same ordinary text
+ * segment (a whitespace run beyond a revision wrapper is a different run, not
+ * the anchored one), or a positional anchor must map the run to the
+ * corresponding extremity of the ordinary text. This keeps the gate able to
+ * fail a needless rewrite of one specific space even when another equal-
+ * looking space elsewhere in the paragraph stayed ordinary.
+ */
+function preservedCommonTokenIndices(common: readonly CommonToken[], ordinary: readonly OrdinaryToken[]): Set<number> {
+  const pairs = lcsPairs(common.map((item) => item.token), ordinary.map((item) => item.token));
+  const preserved = new Set<number>();
+  pairs.forEach((pair, index) => {
+    const token = common[pair.left]!;
+    if (!isWhitespaceToken(token.token)) {
+      preserved.add(pair.left);
+      return;
+    }
+    const preceding = pairs[index - 1];
+    const following = pairs[index + 1];
+    const byPreceding = token.anchoredByPrecedingMatch
+      && preceding !== undefined && preceding.left === pair.left - 1 && preceding.right === pair.right - 1
+      && ordinary[preceding.right]!.segment === ordinary[pair.right]!.segment;
+    const byFollowing = token.anchoredByFollowingMatch
+      && following !== undefined && following.left === pair.left + 1 && following.right === pair.right + 1
+      && ordinary[following.right]!.segment === ordinary[pair.right]!.segment;
+    const byStart = token.anchoredAtParagraphStart && pair.left === 0 && pair.right === 0;
+    const byEnd = token.anchoredAtParagraphEnd && pair.left === common.length - 1 && pair.right === ordinary.length - 1;
+    if (byPreceding || byFollowing || byStart || byEnd) preserved.add(pair.left);
+  });
+  return preserved;
 }
 
 type ParagraphPair = {
@@ -111,38 +244,45 @@ export function emittedRedlineMinimality(
   const diagnostics = alignParagraphs(originalParagraphs, revisedParagraphs).map((pair): MinimalityDiagnostic => {
     const originalTokens = tokenizeExact(pair.originalText).slice(0, MAX_TOKENS_PER_PARAGRAPH);
     const revisedTokens = tokenizeExact(pair.revisedText).slice(0, MAX_TOKENS_PER_PARAGRAPH);
-    const commonTokens = lcsPairs(originalTokens, revisedTokens).map((match) => originalTokens[match.left]!);
+    const commonTokens = anchoredCommonTokens(originalTokens, revisedTokens);
     const candidates = physical.filter((paragraph) => paragraph.rejectText === pair.originalText && paragraph.acceptText === pair.revisedText);
     if (candidates.length === 0) {
       return {
         originalParagraphIndex: pair.originalIndex, revisedParagraphIndex: pair.revisedIndex,
         availableTokens: commonTokens.length, preservedTokens: 0, lostTokens: commonTokens.length,
+        lostTokensByClass: countTokenClasses(commonTokens.map((item) => item.token)),
         efficiencyPercent: percent(0, commonTokens.length), topology: 'unresolved_ambiguous_paragraph_topology',
       };
     }
     const scored = candidates.map((candidate) => ({
       candidate,
-      preserved: lcsPairs(commonTokens, candidate.ordinaryTextNodes.flatMap(tokenizeExact)).length,
-    })).sort((left, right) => left.preserved - right.preserved || left.candidate.index - right.candidate.index);
+      preservedIndices: preservedCommonTokenIndices(commonTokens, ordinaryTokens(candidate.ordinaryTextNodes)),
+    })).sort((left, right) => left.preservedIndices.size - right.preservedIndices.size || left.candidate.index - right.candidate.index);
     // Repeated identical logical paragraphs are conservative: the least-preserving
     // matching physical paragraph controls, preventing a surgical duplicate from
     // concealing a coarse one.
     const selected = scored[0]!;
+    const lostTokens = commonTokens.filter((_, index) => !selected.preservedIndices.has(index)).map((item) => item.token);
     return {
       originalParagraphIndex: pair.originalIndex, revisedParagraphIndex: pair.revisedIndex,
       comparedParagraphIndex: candidates.length === 1 ? selected.candidate.index : undefined,
-      availableTokens: commonTokens.length, preservedTokens: selected.preserved,
-      lostTokens: commonTokens.length - selected.preserved,
-      efficiencyPercent: percent(selected.preserved, commonTokens.length),
+      availableTokens: commonTokens.length, preservedTokens: selected.preservedIndices.size,
+      lostTokens: lostTokens.length,
+      lostTokensByClass: countTokenClasses(lostTokens),
+      efficiencyPercent: percent(selected.preservedIndices.size, commonTokens.length),
       topology: candidates.length === 1 ? 'identified' : 'identified_repeated',
     };
   });
   const availableTokens = diagnostics.reduce((sum, item) => sum + item.availableTokens, 0);
   const preservedTokens = diagnostics.reduce((sum, item) => sum + item.preservedTokens, 0);
   const lostTokens = availableTokens - preservedTokens;
+  const lostTokensByClass = diagnostics.reduce((totals, item) => {
+    for (const key of Object.keys(totals) as TokenClass[]) totals[key] += item.lostTokensByClass[key];
+    return totals;
+  }, emptyTokenClassCounts());
   return {
     policy: 'authored-zero-loss', passed: lostTokens === 0,
-    availableTokens, preservedTokens, lostTokens,
+    availableTokens, preservedTokens, lostTokens, lostTokensByClass,
     efficiencyPercent: percent(preservedTokens, availableTokens),
     comparedParagraphs: physical.length,
     unresolvedTopologyParagraphs: diagnostics.filter((item) => item.topology === 'unresolved_ambiguous_paragraph_topology').length,

--- a/packages/docx-release-verifier/src/minimality.ts
+++ b/packages/docx-release-verifier/src/minimality.ts
@@ -157,35 +157,54 @@ function ordinaryTokens(segments: readonly string[]): OrdinaryToken[] {
 
 /**
  * Indices of the common tokens the tracked paragraph genuinely preserves as
- * ordinary text. Non-whitespace matches count directly. A whitespace match
- * counts only through one of its recorded anchors: the anchoring neighbor
- * must itself be matched immediately adjacent within the same ordinary text
- * segment (a whitespace run beyond a revision wrapper is a different run, not
- * the anchored one), or a positional anchor must map the run to the
- * corresponding extremity of the ordinary text. This keeps the gate able to
- * fail a needless rewrite of one specific space even when another equal-
- * looking space elsewhere in the paragraph stayed ordinary.
+ * ordinary text. Non-whitespace tokens align by LCS over the non-whitespace
+ * subsequences and count directly. A whitespace token never aligns on its
+ * own: it is credited only through one of its recorded anchors, so it must
+ * claim the ordinary token physically adjacent to its own matched anchor —
+ * equal text, in the same ordinary text segment (a whitespace run beyond a
+ * revision wrapper is a different run, not the anchored one) — or, for a
+ * positional anchor, the exact first or last ordinary token. Claims are
+ * injective: an ordinary token credits at most one common token, so one
+ * surviving space cannot stand in for several. Driving whitespace credit
+ * from the anchor's own match, rather than from a single global LCS
+ * traceback, keeps an equal-looking space elsewhere in the paragraph from
+ * either rescuing a rewritten space or stealing credit from a kept one.
  */
 function preservedCommonTokenIndices(common: readonly CommonToken[], ordinary: readonly OrdinaryToken[]): Set<number> {
-  const pairs = lcsPairs(common.map((item) => item.token), ordinary.map((item) => item.token));
+  const commonWords = common.flatMap((item, index) => (isWhitespaceToken(item.token) ? [] : [{ token: item.token, index }]));
+  const ordinaryWords = ordinary.flatMap((item, position) => (isWhitespaceToken(item.token) ? [] : [{ token: item.token, position }]));
   const preserved = new Set<number>();
-  pairs.forEach((pair, index) => {
-    const token = common[pair.left]!;
-    if (!isWhitespaceToken(token.token)) {
-      preserved.add(pair.left);
-      return;
-    }
-    const preceding = pairs[index - 1];
-    const following = pairs[index + 1];
-    const byPreceding = token.anchoredByPrecedingMatch
-      && preceding !== undefined && preceding.left === pair.left - 1 && preceding.right === pair.right - 1
-      && ordinary[preceding.right]!.segment === ordinary[pair.right]!.segment;
-    const byFollowing = token.anchoredByFollowingMatch
-      && following !== undefined && following.left === pair.left + 1 && following.right === pair.right + 1
-      && ordinary[following.right]!.segment === ordinary[pair.right]!.segment;
-    const byStart = token.anchoredAtParagraphStart && pair.left === 0 && pair.right === 0;
-    const byEnd = token.anchoredAtParagraphEnd && pair.left === common.length - 1 && pair.right === ordinary.length - 1;
-    if (byPreceding || byFollowing || byStart || byEnd) preserved.add(pair.left);
+  const claimed = new Set<number>();
+  const anchorPositionByCommonIndex = new Map<number, number>();
+  for (const pair of lcsPairs(commonWords.map((word) => word.token), ordinaryWords.map((word) => word.token))) {
+    const commonIndex = commonWords[pair.left]!.index;
+    const position = ordinaryWords[pair.right]!.position;
+    preserved.add(commonIndex);
+    claimed.add(position);
+    anchorPositionByCommonIndex.set(commonIndex, position);
+  }
+  common.forEach((item, index) => {
+    if (!isWhitespaceToken(item.token)) return;
+    const claimAdjacent = (anchorPosition: number | undefined, offset: 1 | -1): boolean => {
+      if (anchorPosition === undefined) return false;
+      const position = anchorPosition + offset;
+      const candidate = ordinary[position];
+      if (candidate === undefined || claimed.has(position)) return false;
+      if (candidate.token !== item.token || candidate.segment !== ordinary[anchorPosition]!.segment) return false;
+      claimed.add(position);
+      return true;
+    };
+    const claimExtremity = (position: number): boolean => {
+      const candidate = ordinary[position];
+      if (candidate === undefined || claimed.has(position) || candidate.token !== item.token) return false;
+      claimed.add(position);
+      return true;
+    };
+    const credited = (item.anchoredByPrecedingMatch && claimAdjacent(anchorPositionByCommonIndex.get(index - 1), 1))
+      || (item.anchoredByFollowingMatch && claimAdjacent(anchorPositionByCommonIndex.get(index + 1), -1))
+      || (item.anchoredAtParagraphStart && index === 0 && claimExtremity(0))
+      || (item.anchoredAtParagraphEnd && index === common.length - 1 && claimExtremity(ordinary.length - 1));
+    if (credited) preserved.add(index);
   });
   return preserved;
 }


### PR DESCRIPTION
Fixes #832

## Problem

`tokenizeExact` treats whitespace runs as ordinary LCS tokens. Every inter-word space compares equal, so `lcsPairs` paired spaces across otherwise unrelated rewritten phrases and reported them as "lost preservable tokens." The zero-loss minimality gate therefore FAILED a semantically complete replacement (`alpha beta gamma` → `delta epsilon zeta`) with `availableTokens: 2, lostTokens: 2` — both alleged tokens being spaces. In the private-corpus replay that surfaced this, 210 of 221 reported lost tokens were whitespace.

## Anchoring invariant

A whitespace LCS match between original and revised text counts as a preservation obligation only when **anchored**:

- **Content anchor**: the LCS also matched the immediately adjacent token on both sides (`(i-1, j-1)` or `(i+1, j+1)`), which is necessarily non-whitespace because whitespace runs are tokenized maximally; or
- **Positional anchor**: the run sits at the shared paragraph start (`i === 0 && j === 0`) or end in both texts (covers common leading indentation / trailing whitespace).

Unanchored whitespace pairs are excluded from the available-token pool entirely, so a complete phrase replacement is charged nothing for spaces it never actually preserved.

The anchor then travels into the preservation check against the tracked paragraph's ordinary (non-revised) text: a whitespace common token counts as preserved only when its anchoring neighbor is matched immediately adjacent **within the same ordinary text segment** (content-bearing revision wrappers flush segments), or its positional anchor maps to the corresponding extremity of the ordinary text. Without this second half, a needlessly rewritten anchored space could be silently absorbed by an equal-looking ordinary whitespace run elsewhere in the paragraph — there is a regression test for exactly that borrow scenario.

## Surgical whitespace edits remain detectable

- A needless `del(' ')/ins(' ')` rewrite between two kept words still fails, classified as whitespace loss.
- A needless tab rewrite still fails, classified as structural loss.
- A coarse rewrite that discards shared leading indentation still fails.

## Diagnostics

`MinimalityDiagnostic` and `MinimalityEvidence` gain `lostTokensByClass` distinguishing `lexical`, `punctuation`, `structural` (tab/break-bearing runs), and `whitespace` loss. `classifyToken`, `TokenClass`, and `TokenClassCounts` are exported.

## Scope notes

- Self-contained in `minimality.ts` (+ exports); `xml.ts` untouched, dependency-boundary intact (`@xmldom/xmldom` only).
- All fixtures fully synthetic (alpha/beta/gamma placeholders).
- Follow-up (deferred by the issue, intentionally not filed yet): the residual 8 non-whitespace lost tokens (7 words, 1 punctuation) from the private replay must be reevaluated against this corrected gate before opening any generator-over-redlining issue.

## Verification

Full pre-submit gate green locally: `build`, `lint:workspaces`, `test:run` (1325 passed), `check:spec-coverage`, `check:conformance-citations`, `check:conformance-doc`. All 13 pre-existing minimality/verifier gate cases stay green; 6 new regression tests added.