### PR TITLE
docs: add Antigravity CLI installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,23 @@ Then configure your MCP client with the installed executable's absolute path. Fo
 claude mcp add safe-docx -- /absolute/path/to/safe-docx
 ```
 
+### Antigravity CLI
+
+Add Safe Docx to `~/.gemini/config/mcp_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "safe-docx": {
+      "command": "/absolute/path/to/safe-docx",
+      "args": []
+    }
+  }
+}
+```
+
+Restart `agy`, then ask it to edit a `.docx` file. Antigravity may ask you to approve the MCP server before first use.
+
 See [Installation and verification](docs/installation.md) for locating the executable, pinning a version, and configuring clients.
 
 ## Documentation

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -78,6 +78,21 @@ Claude Code:
 claude mcp add safe-docx -- /absolute/path/to/safe-docx
 ```
 
+Antigravity CLI (`~/.gemini/config/mcp_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "safe-docx": {
+      "command": "/absolute/path/to/safe-docx",
+      "args": []
+    }
+  }
+}
+```
+
+Restart `agy` after saving the configuration. Antigravity may ask you to approve the MCP server before first use.
+
 JSON-based clients:
 
 ```json


### PR DESCRIPTION
## Summary

- add a concise Antigravity CLI setup example to the top-level README
- document Antigravity beside Claude Code in the canonical installation guide
- use the globally installed executable's absolute path instead of an unpinned `npx` invocation

## Why

Antigravity supports local MCP servers through `~/.gemini/config/mcp_config.json`. These instructions give its users a first-class setup path while preserving Safe Docx's install-once, reviewable, and reproducible execution model.

## Impact

Documentation only. No package or runtime behavior changes.

## Validation

- `git diff --check`
- `npm run check:tool-docs`
- `npm run build`
- `npm run lint:workspaces`
- `npm run test:run` (all workspaces pass; IPC-dependent docx-core tests rerun outside the sandbox)
- `npm run check:spec-coverage`
- `npm run check:conformance-citations`
- `npm run check:conformance-doc`
