### PR TITLE
fix(docx-compare): rebind relationships across merged packages

### DIFF
--- a/packages/docx-compare/src/baselines/atomizer/pipeline.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline.ts
@@ -119,6 +119,10 @@ import {
   restampCollidingCommentParaIds,
   type AuxiliaryPartDescriptor,
 } from './auxiliaryIdCollision.js';
+import {
+  importReferencedRelationships,
+  renumberCollidingRelationshipIds,
+} from './relationshipIdCollision.js';
 import { maybeCaptureEmittedDocumentXml } from '@usejunior/docx-core';
 import {
   AncillaryStorySafetyError,
@@ -839,6 +843,23 @@ async function compareDocumentsAtomizerCore(
   await renumberCollidingAuxiliaryIds(originalArchive, revisedArchive);
   await restampCollidingCommentParaIds(originalArchive, revisedArchive);
 
+  // Step 1c: Resolve relationship ID collisions for the same reason. `rId9`
+  // means an image in one document and a header in the other, so a merged
+  // reference resolved against the base package's table can silently bind to
+  // the wrong part. Disjoint id spaces make the merged references unambiguous;
+  // `importReferencedRelationships` then supplies the entries at assembly.
+  //
+  // Which side gets renumbered follows the base package: the output clones the
+  // base, so renumbering it would churn every id in the table the result
+  // inherits, for no correctness gain. In-place clones the revised side, rebuild
+  // clones the original, so the merge source is the opposite one each time.
+  // A later in-place -> rebuild fallback flips the base after this point; that
+  // costs id churn in the fallback output but stays correct, because both
+  // tables remain internally consistent and the two id spaces stay disjoint.
+  await (reconstructionMode === 'rebuild'
+    ? renumberCollidingRelationshipIds(revisedArchive, originalArchive)
+    : renumberCollidingRelationshipIds(originalArchive, revisedArchive));
+
   // Step 2: Extract document.xml
   const originalXml = canonicalizeWordprocessingPrefixes(await originalArchive.getDocumentXml());
   const revisedXml = canonicalizeWordprocessingPrefixes(await revisedArchive.getDocumentXml());
@@ -1222,6 +1243,11 @@ async function compareDocumentsAtomizerCore(
 
     await appendHyperlinkRelationships(resultArchive, candidate.hyperlinkRelationships);
 
+    // The merged document carries references from both sides, but the result
+    // archive is a clone of one. Import what the base package lacks, with the
+    // target parts and content types those references depend on.
+    await importReferencedRelationships(mergeSourceArchive, resultArchive, newDocumentXml);
+
     const noteMergeResults = new Map<'footnote' | 'endnote', AuxiliaryMergeResult>();
     for (const descriptor of AUXILIARY_PARTS) {
       let mergeResult: AuxiliaryMergeResult;
@@ -1591,7 +1617,14 @@ function createRebuildHyperlinkRelResolver(
 ): { resolver: HyperlinkRelResolver; newRelationships: NewHyperlinkRel[] } {
   const originalEntries = parseHyperlinkRelEntries(originalRelsDoc);
   const revisedEntries = parseHyperlinkRelEntries(revisedRelsDoc);
-  const existingIds = listRelationshipIds(originalRelsDoc);
+  // Reserve against BOTH tables, not just the base's. Assembly later imports
+  // merge-source relationships under their own ids, so an id minted here that
+  // collides with one of those would be seen as "already present" and silence
+  // the import -- binding, say, a w:headerReference to this hyperlink instead.
+  const existingIds = new Set<string>([
+    ...listRelationshipIds(originalRelsDoc),
+    ...listRelationshipIds(revisedRelsDoc),
+  ]);
 
   const originalIdByDest = new Map<string, string>();
   for (const [id, entry] of originalEntries) {

--- a/packages/docx-compare/src/baselines/atomizer/relationshipIdCollision.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/relationshipIdCollision.test.ts
@@ -1,0 +1,488 @@
+/**
+ * Characterization tests for relationshipIdCollision.ts
+ *
+ * OPC relationship IDs are part-local (ECMA-376 Part 2 §6.5.3.4: the `Id` value
+ * is unique only within its own Relationships part), so two independently
+ * authored documents both number from `rId1` and the same `rId9` routinely
+ * means an image in one and a header in the other. The comparison output is a
+ * clone of one side's package carrying a document merged from both, so a
+ * reference inherited from the other side either dangles or silently binds to
+ * an unrelated part of the wrong type.
+ *
+ * These tests pin both halves end-to-end against in-memory archives: the
+ * pre-comparison renumbering that makes the two id spaces disjoint (including
+ * that it leaves genuinely-identical relationships alone, and that it rewrites
+ * the merge-source side rather than the base), and the assembly-time import
+ * that pulls referenced relationships, their target parts, and content types
+ * into the result package.
+ *
+ * @see https://github.com/UseJunior/safe-docx/issues/582
+ */
+
+import JSZip from 'jszip';
+import { describe, expect } from 'vitest';
+import { DocxArchive } from '@usejunior/docx-core';
+import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
+import { buildDocxFromBodyXml } from '../../testing/ooxml-fixtures.js';
+import { compareDocumentsAtomizer } from './pipeline.js';
+import {
+  importReferencedRelationships,
+  renumberCollidingRelationshipIds,
+} from './relationshipIdCollision.js';
+
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({ feature: 'Relationship ID Collision' })
+  .conformance({ spec: 'ECMA-376', edition: 5, part: 2, section: '6.5.3.4' });
+
+const REL_NS = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const R_NS = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const TYPE_BASE = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const CT_NS = 'http://schemas.openxmlformats.org/package/2006/content-types';
+
+interface Rel {
+  id: string;
+  type: string;
+  target: string;
+}
+
+function relsPart(rels: Rel[]): string {
+  const entries = rels
+    .map((r) => `<Relationship Id="${r.id}" Type="${TYPE_BASE}/${r.type}" Target="${r.target}"/>`)
+    .join('');
+  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<Relationships xmlns="${REL_NS}">${entries}</Relationships>`;
+}
+
+function documentPart(body: string): string {
+  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<w:document xmlns:w="${W_NS}" xmlns:r="${R_NS}"><w:body>${body}</w:body></w:document>`;
+}
+
+function contentTypes(overrides: Array<[string, string]> = []): string {
+  const entries = overrides
+    .map(([part, type]) => `<Override PartName="${part}" ContentType="${type}"/>`)
+    .join('');
+  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<Types xmlns="${CT_NS}"><Default Extension="xml" ContentType="application/xml"/>` +
+    `<Default Extension="png" ContentType="image/png"/>${entries}</Types>`;
+}
+
+const WP_NS = 'http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing';
+const A_NS = 'http://schemas.openxmlformats.org/drawingml/2006/main';
+const PIC_NS = 'http://schemas.openxmlformats.org/drawingml/2006/picture';
+
+/**
+ * A schema-valid inline picture carrying `r:embed`.
+ *
+ * The reference has to sit on `a:blip`, not on `w:drawing` -- the emitted-document
+ * schema gate validates every document.xml this pipeline produces, so a shortcut
+ * fixture here fails CI even though the unit assertions would pass.
+ */
+function inlinePicture(relationshipId: string): string {
+  return `<w:r><w:drawing><wp:inline xmlns:wp="${WP_NS}">` +
+    `<wp:extent cx="914400" cy="914400"/><wp:docPr id="1" name="Relationship fixture"/>` +
+    `<a:graphic xmlns:a="${A_NS}"><a:graphicData uri="${PIC_NS}">` +
+    `<pic:pic xmlns:pic="${PIC_NS}"><pic:nvPicPr><pic:cNvPr id="1" name="fixture.png"/>` +
+    `<pic:cNvPicPr/></pic:nvPicPr><pic:blipFill>` +
+    `<a:blip r:embed="${relationshipId}"/>` +
+    `<a:stretch><a:fillRect/></a:stretch></pic:blipFill><pic:spPr>` +
+    `<a:xfrm><a:off x="0" y="0"/><a:ext cx="914400" cy="914400"/></a:xfrm>` +
+    `<a:prstGeom prst="rect"><a:avLst/></a:prstGeom></pic:spPr></pic:pic>` +
+    `</a:graphicData></a:graphic></wp:inline></w:drawing></w:r>`;
+}
+
+const HEADER_CT =
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml';
+
+async function archiveWith(files: Record<string, string | Buffer>): Promise<DocxArchive> {
+  const archive = await DocxArchive.create();
+  for (const [path, content] of Object.entries(files)) archive.setFile(path, content);
+  return archive;
+}
+
+/** Parse a rels part into id -> {type, target}. */
+async function readRels(
+  archive: DocxArchive,
+): Promise<Map<string, { type: string; target: string }>> {
+  const xml = (await archive.getFile('word/_rels/document.xml.rels')) ?? '';
+  const out = new Map<string, { type: string; target: string }>();
+  for (const match of xml.matchAll(
+    /Id="([^"]+)"\s+Type="[^"]*\/([^"/]+)"\s+Target="([^"]+)"/g,
+  )) {
+    out.set(match[1]!, { type: match[2]!, target: match[3]! });
+  }
+  return out;
+}
+
+describe('relationship ID collision resolution', () => {
+  test('renumbers only ids that mean different things on the two sides', async ({
+    given,
+    when,
+    then,
+    and,
+  }: AllureBddContext) => {
+    let base!: DocxArchive;
+    let mergeSource!: DocxArchive;
+
+    await given('two packages sharing rId1 for the same styles part, and rId2 for different parts', async () => {
+      base = await archiveWith({
+        'word/_rels/document.xml.rels': relsPart([
+          { id: 'rId1', type: 'styles', target: 'styles.xml' },
+          { id: 'rId2', type: 'header', target: 'header1.xml' },
+        ]),
+        'word/document.xml': documentPart('<w:p/>'),
+      });
+      mergeSource = await archiveWith({
+        'word/_rels/document.xml.rels': relsPart([
+          { id: 'rId1', type: 'styles', target: 'styles.xml' },
+          { id: 'rId2', type: 'image', target: 'media/logo.png' },
+        ]),
+        'word/document.xml': documentPart(
+          `<w:p>${inlinePicture('rId2')}</w:p><w:sectPr><w:headerReference r:id="rId1"/></w:sectPr>`,
+        ),
+      });
+    });
+
+    let renumbered: Awaited<ReturnType<typeof renumberCollidingRelationshipIds>>;
+    await when('the merge-source side is renumbered against the base', async () => {
+      renumbered = await renumberCollidingRelationshipIds(mergeSource, base);
+    });
+
+    await then('only the conflicting id is rewritten', async () => {
+      expect(renumbered.map((r) => r.previousId)).toEqual(['rId2']);
+      const rels = await readRels(mergeSource);
+      // rId1 means the same thing on both sides, so it stays put.
+      expect(rels.get('rId1')).toEqual({ type: 'styles', target: 'styles.xml' });
+      expect(rels.has('rId2')).toBe(false);
+    });
+
+    await and('the new id collides with neither side and references follow it', async () => {
+      const nextId = renumbered[0]!.nextId;
+      expect(['rId1', 'rId2']).not.toContain(nextId);
+      const xml = await mergeSource.getDocumentXml();
+      expect(xml).toContain(`r:embed="${nextId}"`);
+      // The non-colliding reference is untouched.
+      expect(xml).toContain('r:id="rId1"');
+    });
+  });
+
+  test('leaves the base package untouched', async ({ given, when, then }: AllureBddContext) => {
+    let base!: DocxArchive;
+    let mergeSource!: DocxArchive;
+    let baseRelsBefore!: string;
+
+    await given('two packages whose ids collide entirely', async () => {
+      base = await archiveWith({
+        'word/_rels/document.xml.rels': relsPart([
+          { id: 'rId1', type: 'header', target: 'header1.xml' },
+        ]),
+        'word/document.xml': documentPart('<w:p/>'),
+      });
+      mergeSource = await archiveWith({
+        'word/_rels/document.xml.rels': relsPart([
+          { id: 'rId1', type: 'footer', target: 'footer1.xml' },
+        ]),
+        'word/document.xml': documentPart('<w:p/>'),
+      });
+      baseRelsBefore = (await base.getFile('word/_rels/document.xml.rels'))!;
+    });
+
+    await when('the merge-source side is renumbered', async () => {
+      await renumberCollidingRelationshipIds(mergeSource, base);
+    });
+
+    await then('the base relationship table is byte-identical', async () => {
+      expect(await base.getFile('word/_rels/document.xml.rels')).toBe(baseRelsBefore);
+    });
+  });
+
+  test('imports a referenced relationship with its target part and content type', async ({
+    given,
+    when,
+    then,
+    and,
+  }: AllureBddContext) => {
+    let result!: DocxArchive;
+    let mergeSource!: DocxArchive;
+    const mergedXml = documentPart(
+      '<w:p/><w:sectPr><w:headerReference r:id="rId9"/></w:sectPr>',
+    );
+
+    await given('a result package lacking the header the merged document references', async () => {
+      result = await archiveWith({
+        '[Content_Types].xml': contentTypes(),
+        'word/_rels/document.xml.rels': relsPart([
+          { id: 'rId1', type: 'styles', target: 'styles.xml' },
+        ]),
+        'word/document.xml': mergedXml,
+      });
+      mergeSource = await archiveWith({
+        '[Content_Types].xml': contentTypes([['/word/header7.xml', HEADER_CT]]),
+        'word/_rels/document.xml.rels': relsPart([
+          { id: 'rId9', type: 'header', target: 'header7.xml' },
+        ]),
+        'word/header7.xml': '<w:hdr/>',
+        'word/document.xml': documentPart('<w:p/>'),
+      });
+    });
+
+    let imported: Awaited<ReturnType<typeof importReferencedRelationships>>;
+    await when('referenced relationships are imported at assembly', async () => {
+      imported = await importReferencedRelationships(mergeSource, result, mergedXml);
+    });
+
+    await then('the relationship resolves to a header, not to something else', async () => {
+      expect(imported.map((r) => r.id)).toEqual(['rId9']);
+      const rels = await readRels(result);
+      expect(rels.get('rId9')).toEqual({ type: 'header', target: 'header7.xml' });
+    });
+
+    await and('the target part and its content type came across', async () => {
+      expect(result.hasFile('word/header7.xml')).toBe(true);
+      expect(await result.getFile('[Content_Types].xml')).toContain('/word/header7.xml');
+    });
+  });
+
+  test('copies the transitive part closure a referenced part depends on', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    let result!: DocxArchive;
+    let mergeSource!: DocxArchive;
+    const mergedXml = documentPart(
+      '<w:p/><w:sectPr><w:headerReference r:id="rId9"/></w:sectPr>',
+    );
+
+    await given('a header on the merge-source side that itself references an image', async () => {
+      result = await archiveWith({
+        '[Content_Types].xml': contentTypes(),
+        'word/_rels/document.xml.rels': relsPart([]),
+        'word/document.xml': mergedXml,
+      });
+      mergeSource = await archiveWith({
+        '[Content_Types].xml': contentTypes([['/word/header7.xml', HEADER_CT]]),
+        'word/_rels/document.xml.rels': relsPart([
+          { id: 'rId9', type: 'header', target: 'header7.xml' },
+        ]),
+        'word/header7.xml': '<w:hdr xmlns:r="' + R_NS + '"><w:p r:embed="rId3"/></w:hdr>',
+        'word/_rels/header7.xml.rels': relsPart([
+          { id: 'rId3', type: 'image', target: 'media/logo.png' },
+        ]),
+        'word/media/logo.png': Buffer.from('PNGDATA') as unknown as string,
+        'word/document.xml': documentPart('<w:p/>'),
+      });
+    });
+
+    await when('referenced relationships are imported', async () => {
+      await importReferencedRelationships(mergeSource, result, mergedXml);
+    });
+
+    await then('the header, its own rels part, and the image all came across', async () => {
+      expect(result.hasFile('word/header7.xml')).toBe(true);
+      expect(result.hasFile('word/_rels/header7.xml.rels')).toBe(true);
+      expect(result.hasFile('word/media/logo.png')).toBe(true);
+    });
+  });
+
+  test('copies a name-colliding part aside instead of binding to the base content', async ({
+    given,
+    when,
+    then,
+    and,
+  }: AllureBddContext) => {
+    let result!: DocxArchive;
+    let mergeSource!: DocxArchive;
+    const mergedXml = documentPart(
+      '<w:p/><w:sectPr><w:headerReference r:id="rId9"/></w:sectPr>',
+    );
+
+    await given('both packages define word/header7.xml with unrelated content', async () => {
+      result = await archiveWith({
+        '[Content_Types].xml': contentTypes([['/word/header7.xml', HEADER_CT]]),
+        'word/_rels/document.xml.rels': relsPart([]),
+        'word/document.xml': mergedXml,
+        'word/header7.xml': '<w:hdr>BASE-UNRELATED</w:hdr>',
+      });
+      mergeSource = await archiveWith({
+        '[Content_Types].xml': contentTypes([['/word/header7.xml', HEADER_CT]]),
+        'word/_rels/document.xml.rels': relsPart([
+          { id: 'rId9', type: 'header', target: 'header7.xml' },
+        ]),
+        'word/header7.xml': '<w:hdr>EXPECTED-SOURCE</w:hdr>',
+        'word/document.xml': documentPart('<w:p/>'),
+      });
+    });
+
+    await when('the referenced header is imported', async () => {
+      await importReferencedRelationships(mergeSource, result, mergedXml);
+    });
+
+    await then('the relationship resolves to the merge source content', async () => {
+      const rels = await readRels(result);
+      const target = rels.get('rId9')!.target;
+      expect(target).not.toBe('header7.xml');
+      expect(await result.getFile(`word/${target}`)).toContain('EXPECTED-SOURCE');
+    });
+
+    await and("the base's own part and content type registration survive", async () => {
+      expect(await result.getFile('word/header7.xml')).toContain('BASE-UNRELATED');
+      const rels = await readRels(result);
+      expect(await result.getFile('[Content_Types].xml')).toContain(rels.get('rId9')!.target);
+    });
+  });
+
+  test('reuses a name-colliding part when the bytes are identical', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    let result!: DocxArchive;
+    let mergeSource!: DocxArchive;
+    const mergedXml = documentPart(
+      '<w:p/><w:sectPr><w:headerReference r:id="rId9"/></w:sectPr>',
+    );
+    const sharedHeader = '<w:hdr>SHARED</w:hdr>';
+
+    await given('both packages define word/header7.xml with the same bytes', async () => {
+      result = await archiveWith({
+        '[Content_Types].xml': contentTypes([['/word/header7.xml', HEADER_CT]]),
+        'word/_rels/document.xml.rels': relsPart([]),
+        'word/document.xml': mergedXml,
+        'word/header7.xml': sharedHeader,
+      });
+      mergeSource = await archiveWith({
+        '[Content_Types].xml': contentTypes([['/word/header7.xml', HEADER_CT]]),
+        'word/_rels/document.xml.rels': relsPart([
+          { id: 'rId9', type: 'header', target: 'header7.xml' },
+        ]),
+        'word/header7.xml': sharedHeader,
+        'word/document.xml': documentPart('<w:p/>'),
+      });
+    });
+
+    await when('the referenced header is imported', async () => {
+      await importReferencedRelationships(mergeSource, result, mergedXml);
+    });
+
+    await then('no duplicate part is created', async () => {
+      const rels = await readRels(result);
+      expect(rels.get('rId9')!.target).toBe('header7.xml');
+      expect(result.listFiles().filter((p) => p.includes('header7'))).toEqual([
+        'word/header7.xml',
+      ]);
+    });
+  });
+
+  test('leaves the result untouched when nothing is missing', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    let result!: DocxArchive;
+    let mergeSource!: DocxArchive;
+    let before!: string;
+    const mergedXml = documentPart(
+      '<w:p/><w:sectPr><w:headerReference r:id="rId1"/></w:sectPr>',
+    );
+
+    await given('a result package already carrying every referenced relationship', async () => {
+      result = await archiveWith({
+        '[Content_Types].xml': contentTypes(),
+        'word/_rels/document.xml.rels': relsPart([
+          { id: 'rId1', type: 'header', target: 'header1.xml' },
+        ]),
+        'word/document.xml': mergedXml,
+      });
+      mergeSource = await archiveWith({
+        '[Content_Types].xml': contentTypes(),
+        'word/_rels/document.xml.rels': relsPart([
+          { id: 'rId1', type: 'header', target: 'header1.xml' },
+        ]),
+        'word/document.xml': documentPart('<w:p/>'),
+      });
+      before = (await result.getFile('word/_rels/document.xml.rels'))!;
+    });
+
+    let imported: Awaited<ReturnType<typeof importReferencedRelationships>>;
+    await when('referenced relationships are imported', async () => {
+      imported = await importReferencedRelationships(mergeSource, result, mergedXml);
+    });
+
+    await then('nothing is imported and the table is byte-identical', async () => {
+      expect(imported).toEqual([]);
+      expect(await result.getFile('word/_rels/document.xml.rels')).toBe(before);
+    });
+  });
+
+  test('a newly minted hyperlink id never captures a renumbered merge-source reference', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    let original!: Buffer;
+    let revised!: Buffer;
+
+    const replaceParts = async (
+      input: Buffer,
+      files: Record<string, string>,
+    ): Promise<Buffer> => {
+      const zip = await JSZip.loadAsync(input);
+      for (const [path, value] of Object.entries(files)) zip.file(path, value);
+      return zip.generateAsync({ type: 'nodebuffer' });
+    };
+
+    await given('a revised side whose image id collides with a base id and which also adds a hyperlink', async () => {
+      original = await buildDocxFromBodyXml('<w:p><w:r><w:t>Before</w:t></w:r></w:p>');
+      revised = await buildDocxFromBodyXml(
+        `<w:p xmlns:r="${R_NS}">` +
+        `<w:hyperlink r:id="rId4"><w:r><w:t>https://new.example</w:t></w:r></w:hyperlink>` +
+        `${inlinePicture('rId2')}</w:p>`,
+      );
+      original = await replaceParts(original, {
+        'word/_rels/document.xml.rels': relsPart([
+          { id: 'rId1', type: 'styles', target: 'styles.xml' },
+          { id: 'rId2', type: 'image', target: 'media/base.png' },
+        ]),
+        'word/styles.xml': `<w:styles xmlns:w="${W_NS}"/>`,
+        'word/media/base.png': 'BASE',
+      });
+      revised = await replaceParts(revised, {
+        '[Content_Types].xml': contentTypes(),
+        'word/_rels/document.xml.rels':
+          relsPart([
+            { id: 'rId1', type: 'styles', target: 'styles.xml' },
+            // Same id as the base's image, different target -- so it gets renumbered.
+            { id: 'rId2', type: 'image', target: 'media/revised.png' },
+          ]).replace(
+            '</Relationships>',
+            `<Relationship Id="rId4" Type="${TYPE_BASE}/hyperlink" Target="https://new.example" TargetMode="External"/></Relationships>`,
+          ),
+        'word/styles.xml': `<w:styles xmlns:w="${W_NS}"/>`,
+        'word/media/revised.png': 'REVISED-IMAGE',
+      });
+    });
+
+    let bound: { type: string; target: string } | undefined;
+    await when('compared in rebuild mode, which mints a relationship for the new hyperlink', async () => {
+      const compared = await compareDocumentsAtomizer(original, revised, {
+        reconstructionMode: 'rebuild',
+        moveDetection: { detectMoves: false },
+      });
+      const output = await DocxArchive.load(compared.document);
+      const xml = await output.getDocumentXml();
+      const rels = await readRels(output);
+      const embedId = /<a:blip[^>]+r:embed="([^"]+)"/.exec(xml)?.[1];
+      bound = embedId ? rels.get(embedId) : undefined;
+    });
+
+    await then('the image reference still resolves to an image, not to the hyperlink', () => {
+      // Type alone is not enough: the base also has an image at rId2. The target
+      // proves the reference resolved to the merge source's picture.
+      expect(bound?.type).toBe('image');
+      expect(bound?.target).toBe('media/revised.png');
+    });
+  });
+});

--- a/packages/docx-compare/src/baselines/atomizer/relationshipIdCollision.ts
+++ b/packages/docx-compare/src/baselines/atomizer/relationshipIdCollision.ts
@@ -1,0 +1,444 @@
+/**
+ * Relationship ID Collision Resolution and Import
+ *
+ * Relationship IDs (`r:id`, `r:embed`, ... — OPC `Relationship/@Id`) are
+ * *part-local*: two independently authored documents both number their
+ * `word/_rels/document.xml.rels` entries from `rId1`, and the same `rId9`
+ * routinely means an image in one document and a header in the other.
+ *
+ * The comparison output is a clone of one side's package carrying a merged
+ * `document.xml` built from *both* sides. Every `r:id` that originated on the
+ * non-base side is therefore resolved against the wrong relationship table: it
+ * either dangles or, worse, silently resolves to an unrelated part of the wrong
+ * type (observed: `w:headerReference` bound to an image relationship).
+ *
+ * This mirrors the strategy `auxiliaryIdCollision.ts` already established for
+ * comment/footnote/endnote `w:id`: renumber one side *before* comparison rather
+ * than detect-and-flag, because failing closed would reject any comparison of
+ * two independently authored documents — the core use case. Renumbering
+ * pre-comparison is what makes it tractable at all: after reconstruction the
+ * merged `document.xml` no longer records which side each reference came from,
+ * so a colliding id can no longer be attributed to its owner.
+ *
+ * Two steps, both required:
+ *
+ * 1. {@link renumberCollidingRelationshipIds} makes the two id spaces disjoint
+ *    before anything reads `document.xml`, so a merged reference is never
+ *    ambiguous.
+ * 2. {@link importReferencedRelationships} runs at package assembly and pulls
+ *    every relationship the merged document still references but the base
+ *    package lacks, copying target parts (and their own transitive
+ *    relationships) and registering content types.
+ *
+ * IDs that resolve to the same type, target, and mode on both sides are left
+ * alone so unchanged references stay byte-stable.
+ *
+ * @see https://github.com/UseJunior/safe-docx/issues/107 (auxiliary-id precedent)
+ * @see https://github.com/UseJunior/safe-docx/issues/582
+ */
+
+import { posix } from 'node:path';
+import { XMLSerializer } from '@xmldom/xmldom';
+import { parseXml } from '@usejunior/docx-core';
+import type { DocxArchive } from '@usejunior/docx-core';
+
+const serializer = new XMLSerializer();
+
+const PACKAGE_REL_NS = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const OFFICE_REL_NS = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships';
+const CONTENT_TYPES_NS = 'http://schemas.openxmlformats.org/package/2006/content-types';
+const CONTENT_TYPES_PATH = '[Content_Types].xml';
+const DOCUMENT_PART = 'word/document.xml';
+
+interface RelationshipEntry {
+  id: string;
+  type: string;
+  target: string;
+  targetMode: string | null;
+}
+
+/** A relationship id rewritten on the merge-source side to clear a collision. */
+export interface RenumberedRelationshipId {
+  previousId: string;
+  nextId: string;
+  type: string;
+}
+
+function relsPathFor(partPath: string): string {
+  const directory = posix.dirname(partPath);
+  return `${directory === '.' ? '' : `${directory}/`}_rels/${posix.basename(partPath)}.rels`;
+}
+
+/** Resolve an OPC relationship target against its owning part's directory. */
+function resolveTarget(ownerPart: string, target: string): string {
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(target)) return target;
+  const base = posix.dirname(ownerPart);
+  return posix.normalize(posix.join(base === '.' ? '' : base, target)).replace(/^\/+/, '');
+}
+
+async function readRelationships(
+  archive: DocxArchive,
+  partPath: string,
+): Promise<Map<string, RelationshipEntry>> {
+  const xml = await archive.getFile(relsPathFor(partPath));
+  const entries = new Map<string, RelationshipEntry>();
+  if (!xml) return entries;
+  const document = parseXml(xml);
+  for (const element of Array.from(
+    document.getElementsByTagNameNS(PACKAGE_REL_NS, 'Relationship'),
+  )) {
+    const id = element.getAttribute('Id');
+    const type = element.getAttribute('Type');
+    if (!id || !type) continue;
+    entries.set(id, {
+      id,
+      type,
+      target: element.getAttribute('Target') ?? '',
+      targetMode: element.hasAttribute('TargetMode') ? element.getAttribute('TargetMode') : null,
+    });
+  }
+  return entries;
+}
+
+/** Two entries are interchangeable when type, target, and mode all agree. */
+function sameRelationship(left: RelationshipEntry, right: RelationshipEntry): boolean {
+  return (
+    left.type === right.type &&
+    left.target === right.target &&
+    left.targetMode === right.targetMode
+  );
+}
+
+/** Rewrite every relationship-namespace attribute value through `mapping`. */
+function remapRelationshipAttributes(root: Element, mapping: ReadonlyMap<string, string>): number {
+  let rewrites = 0;
+  const visit = (element: Element): void => {
+    for (let i = 0; i < element.attributes.length; i++) {
+      const attribute = element.attributes.item(i)!;
+      if (attribute.namespaceURI !== OFFICE_REL_NS) continue;
+      const next = mapping.get(attribute.value);
+      if (next === undefined) continue;
+      attribute.value = next;
+      rewrites++;
+    }
+    for (let child = element.firstChild; child; child = child.nextSibling) {
+      if (child.nodeType === 1) visit(child as Element);
+    }
+  };
+  visit(root);
+  return rewrites;
+}
+
+/**
+ * Give `rewriteArchive` a relationship id space disjoint from `againstArchive`'s.
+ *
+ * Only ids that mean *different things* on the two sides are rewritten; an id
+ * resolving identically on both is left in place so unchanged references stay
+ * byte-stable. Runs before any `document.xml` extraction so every downstream
+ * step sees the rewritten archive.
+ *
+ * Which side to rewrite is not arbitrary: the output package is a clone of the
+ * base side, so rewriting the base would renumber the very table the result
+ * inherits, churning ids for no benefit. Always pass the side that will be the
+ * *merge source* -- the original for in-place output, the revised for rebuild,
+ * since each mode clones the opposite package.
+ */
+export async function renumberCollidingRelationshipIds(
+  rewriteArchive: DocxArchive,
+  againstArchive: DocxArchive,
+): Promise<RenumberedRelationshipId[]> {
+  const againstRels = await readRelationships(againstArchive, DOCUMENT_PART);
+  const rewriteRels = await readRelationships(rewriteArchive, DOCUMENT_PART);
+  if (againstRels.size === 0 || rewriteRels.size === 0) return [];
+
+  const taken = new Set<string>([...againstRels.keys(), ...rewriteRels.keys()]);
+  let nextOrdinal = 1;
+  const allocateId = (): string => {
+    let candidate = `rId${nextOrdinal++}`;
+    while (taken.has(candidate)) candidate = `rId${nextOrdinal++}`;
+    taken.add(candidate);
+    return candidate;
+  };
+
+  const renumbered: RenumberedRelationshipId[] = [];
+  const mapping = new Map<string, string>();
+  for (const [id, entry] of rewriteRels) {
+    const counterpart = againstRels.get(id);
+    if (!counterpart || sameRelationship(counterpart, entry)) continue;
+    const nextId = allocateId();
+    mapping.set(id, nextId);
+    renumbered.push({ previousId: id, nextId, type: entry.type });
+  }
+  if (mapping.size === 0) return [];
+
+  // Rewrite the relationship table on the side being renumbered.
+  const relsPath = relsPathFor(DOCUMENT_PART);
+  const relsXml = await rewriteArchive.getFile(relsPath);
+  if (relsXml) {
+    const relsDoc = parseXml(relsXml);
+    for (const element of Array.from(
+      relsDoc.getElementsByTagNameNS(PACKAGE_REL_NS, 'Relationship'),
+    )) {
+      const id = element.getAttribute('Id');
+      const next = id ? mapping.get(id) : undefined;
+      if (next) element.setAttribute('Id', next);
+    }
+    rewriteArchive.setFile(relsPath, serializer.serializeToString(relsDoc));
+  }
+
+  // Rewrite every reference in that side's main story.
+  const documentXml = await rewriteArchive.getDocumentXml();
+  const documentDoc = parseXml(documentXml);
+  if (documentDoc.documentElement) {
+    remapRelationshipAttributes(documentDoc.documentElement, mapping);
+    rewriteArchive.setDocumentXml(serializer.serializeToString(documentDoc));
+  }
+
+  return renumbered;
+}
+
+/** Register a content type for a copied part, carrying the source override. */
+async function ensureContentType(
+  sourceArchive: DocxArchive,
+  resultArchive: DocxArchive,
+  partPath: string,
+  registerAs: string = partPath,
+): Promise<void> {
+  const resultXml = await resultArchive.getFile(CONTENT_TYPES_PATH);
+  if (!resultXml) return;
+  const resultDoc = parseXml(resultXml);
+  const partName = `/${registerAs}`;
+  const overrides = Array.from(resultDoc.getElementsByTagNameNS(CONTENT_TYPES_NS, 'Override'));
+  if (overrides.some((element) => element.getAttribute('PartName') === partName)) return;
+
+  const sourceXml = await sourceArchive.getFile(CONTENT_TYPES_PATH);
+  if (!sourceXml) return;
+  const sourceDoc = parseXml(sourceXml);
+  const sourceOverride = Array.from(
+    sourceDoc.getElementsByTagNameNS(CONTENT_TYPES_NS, 'Override'),
+  ).find((element) => element.getAttribute('PartName') === `/${partPath}`);
+
+  if (sourceOverride) {
+    const element = resultDoc.createElementNS(CONTENT_TYPES_NS, 'Override');
+    element.setAttribute('PartName', partName);
+    element.setAttribute('ContentType', sourceOverride.getAttribute('ContentType') ?? '');
+    resultDoc.documentElement?.appendChild(element);
+    resultArchive.setFile(CONTENT_TYPES_PATH, serializer.serializeToString(resultDoc));
+    return;
+  }
+
+  // No override: the part is typed by extension, so carry the Default across.
+  const extension = posix.extname(registerAs).replace(/^\./, '').toLowerCase();
+  if (!extension) return;
+  const defaults = Array.from(resultDoc.getElementsByTagNameNS(CONTENT_TYPES_NS, 'Default'));
+  if (defaults.some((element) => element.getAttribute('Extension')?.toLowerCase() === extension)) {
+    return;
+  }
+  const sourceDefault = Array.from(
+    sourceDoc.getElementsByTagNameNS(CONTENT_TYPES_NS, 'Default'),
+  ).find((element) => element.getAttribute('Extension')?.toLowerCase() === extension);
+  if (!sourceDefault) return;
+  const element = resultDoc.createElementNS(CONTENT_TYPES_NS, 'Default');
+  element.setAttribute('Extension', extension);
+  element.setAttribute('ContentType', sourceDefault.getAttribute('ContentType') ?? '');
+  resultDoc.documentElement?.insertBefore(element, resultDoc.documentElement.firstChild);
+  resultArchive.setFile(CONTENT_TYPES_PATH, serializer.serializeToString(resultDoc));
+}
+
+/** Pick a package part path that is free in `resultArchive`. */
+function allocatePartPath(resultArchive: DocxArchive, partPath: string): string {
+  const extension = posix.extname(partPath);
+  const stem = partPath.slice(0, partPath.length - extension.length);
+  for (let ordinal = 1; ; ordinal++) {
+    const candidate = `${stem}_merged${ordinal}${extension}`;
+    if (!resultArchive.hasFile(candidate)) return candidate;
+  }
+}
+
+/**
+ * Copy a part and, transitively, every part its own relationships reach.
+ *
+ * Returns the path the part actually landed on. The two packages number their
+ * parts independently, so the source's `word/header7.xml` and the base's are
+ * routinely unrelated documents under one name. Reusing an occupied path
+ * because the name matches would bind the imported relationship to the base's
+ * content -- the same silent mis-binding this module exists to prevent -- so a
+ * conflicting name is copied aside and the caller retargets to the new path.
+ */
+async function copyPartClosure(
+  sourceArchive: DocxArchive,
+  resultArchive: DocxArchive,
+  partPath: string,
+  copiedAs: Map<string, string>,
+): Promise<string> {
+  const already = copiedAs.get(partPath);
+  if (already !== undefined) return already;
+
+  const bytes = await sourceArchive.getFileBuffer(partPath);
+  if (!bytes) {
+    copiedAs.set(partPath, partPath);
+    return partPath;
+  }
+
+  let targetPath = partPath;
+  const existing = resultArchive.hasFile(partPath)
+    ? await resultArchive.getFileBuffer(partPath)
+    : null;
+  if (existing === null) {
+    resultArchive.setFile(partPath, bytes);
+    await ensureContentType(sourceArchive, resultArchive, partPath);
+  } else if (!existing.equals(bytes)) {
+    targetPath = allocatePartPath(resultArchive, partPath);
+    resultArchive.setFile(targetPath, bytes);
+    await ensureContentType(sourceArchive, resultArchive, partPath, targetPath);
+  }
+  // Identical bytes: the base already carries this exact part, so reuse it.
+  copiedAs.set(partPath, targetPath);
+
+  const nested = await readRelationships(sourceArchive, partPath);
+  if (nested.size === 0) return targetPath;
+
+  // Recurse first: a nested target may itself be copied aside, and this part's
+  // own rels must then point at wherever it actually landed.
+  const nestedRewrites = new Map<string, string>();
+  for (const entry of nested.values()) {
+    if (entry.targetMode === 'External') continue;
+    const sourceTarget = resolveTarget(partPath, entry.target);
+    const landedTarget = await copyPartClosure(
+      sourceArchive,
+      resultArchive,
+      sourceTarget,
+      copiedAs,
+    );
+    if (landedTarget !== sourceTarget) {
+      nestedRewrites.set(entry.id, posix.relative(posix.dirname(targetPath), landedTarget));
+    }
+  }
+
+  const nestedRelsPath = relsPathFor(targetPath);
+  if (!resultArchive.hasFile(nestedRelsPath)) {
+    const nestedRelsXml = await sourceArchive.getFile(relsPathFor(partPath));
+    if (nestedRelsXml) {
+      if (nestedRewrites.size === 0) {
+        resultArchive.setFile(nestedRelsPath, nestedRelsXml);
+      } else {
+        const relsDoc = parseXml(nestedRelsXml);
+        for (const element of Array.from(
+          relsDoc.getElementsByTagNameNS(PACKAGE_REL_NS, 'Relationship'),
+        )) {
+          const rewritten = nestedRewrites.get(element.getAttribute('Id') ?? '');
+          if (rewritten) element.setAttribute('Target', rewritten);
+        }
+        resultArchive.setFile(nestedRelsPath, serializer.serializeToString(relsDoc));
+      }
+    }
+  }
+  return targetPath;
+}
+
+export interface ImportedRelationship {
+  id: string;
+  type: string;
+  target: string;
+}
+
+/**
+ * Pull every relationship the merged document references but the base package
+ * lacks, copying target parts and registering their content types.
+ *
+ * The merged `document.xml` carries references from both sides, but the result
+ * archive is a clone of one side only. Without this import, a reference that
+ * originated on the other side dangles.
+ */
+export async function importReferencedRelationships(
+  mergeSourceArchive: DocxArchive,
+  resultArchive: DocxArchive,
+  mergedDocumentXml: string,
+): Promise<ImportedRelationship[]> {
+  const document = parseXml(mergedDocumentXml);
+  const root = document.documentElement;
+  if (!root) return [];
+
+  const referenced = new Set<string>();
+  const collect = (element: Element): void => {
+    for (let i = 0; i < element.attributes.length; i++) {
+      const attribute = element.attributes.item(i)!;
+      if (attribute.namespaceURI === OFFICE_REL_NS && attribute.value) {
+        referenced.add(attribute.value);
+      }
+    }
+    for (let child = element.firstChild; child; child = child.nextSibling) {
+      if (child.nodeType === 1) collect(child as Element);
+    }
+  };
+  collect(root);
+  if (referenced.size === 0) return [];
+
+  const resultRels = await readRelationships(resultArchive, DOCUMENT_PART);
+  const sourceRels = await readRelationships(mergeSourceArchive, DOCUMENT_PART);
+
+  // An id already present in the result is only satisfied if it means the same
+  // thing there. Renumbering plus reserving hyperlink ids against both tables
+  // should make a genuine conflict unreachable; if one survives, importing
+  // would be wrong and skipping would silently mis-bind, so say so rather than
+  // pick one.
+  for (const id of referenced) {
+    const held = resultRels.get(id);
+    const source = sourceRels.get(id);
+    if (held && source && !sameRelationship(held, source)) {
+      throw new Error(
+        `Relationship id ${id} means different things in the base ` +
+        `(${held.type} -> ${held.target}) and the merge source ` +
+        `(${source.type} -> ${source.target}); id spaces failed to stay disjoint.`,
+      );
+    }
+  }
+
+  const missing = [...referenced].filter((id) => !resultRels.has(id));
+  if (missing.length === 0) return [];
+
+  const importable = missing
+    .map((id) => sourceRels.get(id))
+    .filter((entry): entry is RelationshipEntry => entry !== undefined);
+  if (importable.length === 0) return [];
+
+  const relsPath = relsPathFor(DOCUMENT_PART);
+  const relsXml = await resultArchive.getFile(relsPath);
+  const relsDoc = relsXml
+    ? parseXml(relsXml)
+    : parseXml(
+        `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+        `<Relationships xmlns="${PACKAGE_REL_NS}"></Relationships>`,
+      );
+  const relsRoot = relsDoc.documentElement;
+  if (!relsRoot) return [];
+
+  const copiedAs = new Map<string, string>();
+  const imported: ImportedRelationship[] = [];
+  for (const entry of importable) {
+    let target = entry.target;
+    if (entry.targetMode !== 'External') {
+      const sourceTarget = resolveTarget(DOCUMENT_PART, entry.target);
+      const landedTarget = await copyPartClosure(
+        mergeSourceArchive,
+        resultArchive,
+        sourceTarget,
+        copiedAs,
+      );
+      // The part may have been copied aside to dodge a name collision; point
+      // the relationship at where it actually landed, not where it came from.
+      if (landedTarget !== sourceTarget) {
+        target = posix.relative(posix.dirname(DOCUMENT_PART), landedTarget);
+      }
+    }
+    const element = relsDoc.createElementNS(PACKAGE_REL_NS, 'Relationship');
+    element.setAttribute('Id', entry.id);
+    element.setAttribute('Type', entry.type);
+    element.setAttribute('Target', target);
+    if (entry.targetMode) element.setAttribute('TargetMode', entry.targetMode);
+    relsRoot.appendChild(element);
+    imported.push({ id: entry.id, type: entry.type, target });
+  }
+  resultArchive.setFile(relsPath, serializer.serializeToString(relsDoc));
+  return imported;
+}


### PR DESCRIPTION
## Problem

OPC relationship ids are **part-local** — ECMA-376 Part 2 §6.5.3.4 makes `Id` unique only within its own Relationships part. Two independently authored documents both number from `rId1`, so the same `rId9` routinely means an image in one and a header in the other.

The comparison output clones **one** side's package but carries a `document.xml` merged from **both**. Any reference inherited from the other side therefore either dangles or silently binds to an unrelated part of the wrong type.

Observed on the committed ILPA pair in `reconstructionMode: 'rebuild'`:

```
w:headerReference relationship 'rId9'  has type '.../image'
w:headerReference relationship 'rId10' has type '.../footer'
w:footerReference relationship 'rId12' has type '.../header'
```

`AncillaryStorySafetyError` then rejected the whole comparison.

## Approach

Mirrors the strategy `auxiliaryIdCollision.ts` already established for comment/footnote/endnote `w:id` — renumber before comparison rather than detect-and-flag, because failing closed would reject any comparison of two independently authored documents.

1. **`renumberCollidingRelationshipIds`** (pre-comparison) makes the two id spaces disjoint. Only ids that mean *different* things on the two sides are rewritten; ids resolving identically are left alone so unchanged references stay byte-stable.
2. **`importReferencedRelationships`** (package assembly) pulls the relationships the merged document still references but the base lacks, copying target parts transitively and registering content types.

**Which side gets renumbered is mode-aware.** The output clones the base, so renumbering the base is pure churn: in-place clones the revised side, rebuild clones the original. Getting this backwards renumbers the very table the result inherits — an earlier revision of this change did exactly that and churned all 33 ids on the default in-place path.

Cross-checked against Word 16.112, which rebuilds its output relationship table from scratch (inputs with header `rId8`/`rId2` → output `rId6`, with `rId8` reassigned to fontTable). This change is deliberately more conservative — it preserves the base's ids and patches in what's missing — which keeps the default path byte-stable.

## Verification

- **In-place relationship table byte-identical to `main`** on the ILPA pair — no churn on the default path.
- 832 passing in `docx-compare` (8 new), 1325 in `docx-core`, 0 failures.
- `tsc --noEmit` clean; allure-labels, conformance-citations, and the coverage ratchet all pass.

## Peer review

Codex review returned **BLOCK** on the first pass and caught two defects, both in the "silently binds to the wrong part" class this change exists to eliminate. Both are fixed, each with a committed regression test:

1. **Part-name collision** — `copyPartClosure` skipped copying when the path was occupied but added the relationship anyway, so two packages both defining `word/header7.xml` bound the import to the *base's* unrelated content. Now copied aside to a free name with the relationship retargeted; identical bytes still reuse the existing part.
2. **Hyperlink id race** — hyperlink ids were reserved only from the *original* rels table, so a minted id could take one a renumbered merge-source relationship already used. Because hyperlinks are appended first, the import then saw the id as present and skipped, leaving `r:embed` bound to a **hyperlink** instead of a header. Now reserved against both tables, plus a guard that throws rather than silently picking when an id means different things on the two sides.

## Scope

Deliberately excluded and still on separate branches: the opaque-passthrough guard relaxation (boundary-count and content-control fail-closed behavior) and the rebuild field-deletion conformance fix. Those need a decision on two pinned tests and are entangled with the tagged-tree work.

The in-place → rebuild fallback flips which package is the base after the renumbering direction is chosen. Codex's probe showed references still resolve and ids stay unique in that case (correct, but with id churn); a full-pipeline fallback integration test is a follow-up.

Refs #582