### PR TITLE
fix(docx-primitives): preserve row-level revision markers accept/reject cannot resolve

### DIFF
--- a/openspec/changes/guard-row-level-revision-resolution/oracle-probe.md
+++ b/openspec/changes/guard-row-level-revision-resolution/oracle-probe.md
@@ -1,0 +1,80 @@
+# Oracle probe: can LibreOffice adjudicate row-level revisions?
+
+Recorded so the claim in `proposal.md` (`## Out of scope`) is reproducible rather than asserted.
+Run from the worktree root with `npx tsx`, in a **real terminal** — `soffice` aborts (SIGABRT) under a
+sandboxed shell, which is a known environment limitation, not a regression.
+
+## Probe
+
+```ts
+import { resolveSoffice, runLibreOfficeOracle } from './packages/docx-core/src/integration/libreoffice-oracle.js';
+const W = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+// Row 1 carries the row-level marker AND a content deletion inside its cell.
+// The content deletion is the POSITIVE CONTROL: if LibreOffice resolves it but
+// leaves the row marker alone, LO imported content revisions and ignored the row one.
+const doc = (marker: 'ins' | 'del') =>
+  `<w:document xmlns:w="${W}"><w:body><w:tbl>`
+  + `<w:tblPr/><w:tblGrid><w:gridCol w:w="4680"/></w:tblGrid>`
+  + `<w:tr><w:trPr><w:${marker} w:id="7" w:author="Reviewer" w:date="2026-01-01T00:00:00Z"/></w:trPr>`
+  + `<w:tc><w:tcPr/><w:p><w:r><w:t>ROWMARKED</w:t></w:r>`
+  + `<w:del w:id="9" w:author="Reviewer" w:date="2026-01-01T00:00:00Z">`
+  + `<w:r><w:delText>CONTENTDEL</w:delText></w:r></w:del></w:p></w:tc></w:tr>`
+  + `<w:tr><w:tc><w:tcPr/><w:p><w:r><w:t>CONTROLROW</w:t></w:r></w:p></w:tc></w:tr>`
+  + `</w:tbl><w:p><w:r><w:t>TAIL</w:t></w:r></w:p></w:body></w:document>`;
+
+const out = await runLibreOfficeOracle([
+  { op: 'identity', documentXml: doc('del') },
+  { op: 'identity', documentXml: doc('ins') },
+  { op: 'accept',   documentXml: doc('del') },
+  { op: 'reject',   documentXml: doc('ins') },
+], resolveSoffice()!);
+// then report, per result: w:tr count, ROWMARKED/CONTROLROW/CONTENTDEL presence, and the trPr block
+```
+
+## Captured output (2026-08-14, LibreOffice via `/opt/homebrew/bin/soffice`)
+
+```text
+--- IDENTITY (load+save) with trPr>del  — does LO preserve the row marker at all?
+  rows: 2 | ROWMARKED: true | CONTROLROW: true
+  CONTENTDEL text present: true | any w:del elem: true | any w:ins elem: false
+  trPr block: <w:trPr></w:trPr>
+
+--- IDENTITY (load+save) with trPr>ins  — same question
+  rows: 2 | ROWMARKED: true | CONTROLROW: true
+  CONTENTDEL text present: true | any w:del elem: true | any w:ins elem: false
+  trPr block: <w:trPr></w:trPr>
+
+--- ACCEPT over trPr>del
+  rows: 2 | ROWMARKED: true | CONTROLROW: true
+  CONTENTDEL text present: false | any w:del elem: false | any w:ins elem: false
+  trPr block: <w:trPr></w:trPr>
+
+--- REJECT over trPr>ins
+  rows: 2 | ROWMARKED: true | CONTROLROW: true
+  CONTENTDEL text present: true | any w:del elem: false | any w:ins elem: false
+  trPr block: <w:trPr></w:trPr>
+```
+
+## Reading
+
+The `identity` jobs perform no accept or reject, and they already emit `<w:trPr></w:trPr>`. **The row-level
+marker is discarded on IMPORT**, before any operation runs. Every accept/reject result below it is therefore
+vacuous — "row kept" is what a document carrying no row revision at all would produce.
+
+The positive control separates "LibreOffice cannot read this" from "the fixture or harness is broken": the
+content deletion in the same cell round-trips through import, is removed by `accept` (`CONTENTDEL` gone) and
+restored by `reject` (`CONTENTDEL` present, wrapper gone). So the package loads, the table loads, and the
+revision machinery runs — only the row-level marker fails to survive.
+
+## Consequence
+
+LibreOffice cannot adjudicate this class of revision, so it cannot confirm or refute the four-direction
+asymmetry. The asymmetry rests instead on the vendored strict and transitional schemas (`CT_TrPr` admits only
+`ins`/`del`/`trPrChange`; `CT_TrPrBase` admits no revision children) plus the classification already encoded in
+`cli/conformance-adapter.ts`. That is sufficient warrant for preserving evidence we cannot resolve, and it is
+NOT sufficient to implement the row semantics — which is why implementation stays out of scope.
+
+Microsoft Word for Mac via AppleScript was attempted next as the canonical oracle. `open file name` left Word
+on its start screen and no fixture was rewritten; abandoned rather than pursued. A follow-up implementing the
+semantics must obtain a real Word projection first.

--- a/openspec/changes/guard-row-level-revision-resolution/proposal.md
+++ b/openspec/changes/guard-row-level-revision-resolution/proposal.md
@@ -1,0 +1,82 @@
+# Change: Preserve row-level revision markers the acceptance engine cannot resolve
+
+## Why
+
+`acceptChanges` and `rejectChanges` sweep revision wrappers by local name only. `removeAllByLocalName(root, 'del')`
+(`packages/docx-core/src/primitives/accept_changes.ts`) and `removeAllByLocalName(root, 'ins')`
+(`packages/docx-core/src/primitives/reject_changes.ts`) collect every `w:del` / `w:ins` in the story and delete it
+without inspecting the parent.
+
+Row-level revision markers live at `w:tr > w:trPr > w:del` and `w:tr > w:trPr > w:ins`. They are *property markers
+describing a row*, not wrappers around deleted or inserted content. Both sweeps match them, so the marker is removed
+and the `w:tr` it described is left in place.
+
+Two directions are genuinely unresolvable today:
+
+- **accept** over `w:trPr > w:del` — the row should disappear; the engine keeps it.
+- **reject** over `w:trPr > w:ins` — the inserted row should disappear; the engine keeps it.
+
+The other two directions are already correct by construction: accepting an inserted row means keeping the row and
+dropping its marker, and rejecting a deleted row means the same. Stripping the marker is the right outcome there.
+
+The failure is silent and unrecoverable. The marker carrying `w:id`, `w:author` and `w:date` is destroyed, so no
+later pass can tell the row was ever tracked — and the returned stats count the marker as a resolved revision, so a
+caller checking the result is told the operation succeeded:
+
+```
+acceptChanges over a row marked deleted
+  result: {"deletionsAccepted":1, ...}
+  rows remaining: 2   (the row Word removes survives)
+  trPr marker survives: false
+```
+
+The repository already classifies exactly these two combinations as unimplemented.
+`packages/docx-core/src/cli/conformance-adapter.ts` returns `supported: false` with the reason "safe-docx adapter
+does not implement accepting deleted table-row revisions", and `[XIMPL-08]` in
+`cross-implementation-suite.test.ts` pins that classification. That honesty stops at the conformance harness:
+`DocxDocument.acceptChanges` / `rejectChanges` and the `accept_changes` MCP tool call the primitives unconditionally.
+
+This change makes the engine agree with what the conformance adapter already says, using the same
+preserve-and-report convention the codebase already applies to other unresolved advanced records
+(`ADV-UNRESOLVED-RECORDS-01`, `ADV-TOPOLOGY-PRESERVATION-01`): leaving a record in place is a visible gap a caller
+can detect, whereas removing it while keeping the content is silent divergence.
+
+Implementing the row semantics themselves is deliberately out of scope — see `## Out of scope`.
+
+## What Changes
+
+- `acceptChanges` SHALL NOT remove a `w:del` whose parent is `w:trPr`, and `rejectChanges` SHALL NOT remove a
+  `w:ins` whose parent is `w:trPr`. The marker and its row are both preserved.
+- The directions the engine resolves correctly are unchanged: `acceptChanges` still strips `w:trPr > w:ins`, and
+  `rejectChanges` still strips `w:trPr > w:del`.
+- `AcceptChangesResult` and `RejectChangesResult` gain `unresolvedRowRevisions: number`, counting the markers left
+  in place. It is reported separately from the resolved-revision counters and does not make a document count as
+  changed.
+- `DocxDocument.acceptChanges` / `rejectChanges` aggregate the new counter across the body and every revisionable
+  side story.
+- The `accept_changes` MCP response carries the count through as `unresolvedRowRevisions`, so an agent driving the
+  server can see that the document still holds unresolved row revisions.
+
+## Impact
+
+- Affected specs: `docx-primitives` (ADDED: `Unresolvable Row-Level Revision Preservation`). The existing
+  `Tracked Change Acceptance Engine` scenarios are unchanged: each is scoped by its own GIVEN to `w:del`/`w:ins`
+  elements *wrapping content*, which a row-property marker is not.
+- Affected code: `packages/docx-core/src/primitives/accept_changes.ts`,
+  `packages/docx-core/src/primitives/reject_changes.ts`, `packages/docx-core/src/primitives/document.ts`
+- Behavior change is confined to documents containing row-level revision markers. Every other document produces
+  byte-identical output and an unchanged result shape apart from the added zero-valued counter.
+- Callers destructuring the result are unaffected (additive field). Callers that relied on row markers being
+  stripped now see them preserved — that is the point of the change, and the output was wrong before.
+- Refs #845.
+
+## Out of scope
+
+Resolving row-level revisions semantically (accept-deletes-the-row, reject-removes-the-inserted-row). That needs an
+oracle pass over Microsoft Word's actual projection first — `w:vMerge` chains and cells carrying their own content
+revisions have to be settled before the projection can be called correct — and it overlaps issue #764, which owns
+structural table changes and lists accept/reject round trips in its scope. This change deliberately makes the gap
+visible rather than guessing at the semantics.
+
+Extending `extract_revisions` to report row and cell topology, so a caller can inspect a document *before* deciding
+to accept it, is also left out; today the counter reports the gap after the fact.

--- a/openspec/changes/guard-row-level-revision-resolution/proposal.md
+++ b/openspec/changes/guard-row-level-revision-resolution/proposal.md
@@ -85,11 +85,27 @@ Implementing the row semantics themselves is deliberately out of scope — see `
 
 ## Out of scope
 
-Resolving row-level revisions semantically (accept-deletes-the-row, reject-removes-the-inserted-row). That needs an
-oracle pass over Microsoft Word's actual projection first — `w:vMerge` chains and cells carrying their own content
-revisions have to be settled before the projection can be called correct — and it overlaps issue #764, which owns
-structural table changes and lists accept/reject round trips in its scope. This change deliberately makes the gap
-visible rather than guessing at the semantics.
+Resolving row-level revisions semantically (accept-deletes-the-row, reject-removes-the-inserted-row). It overlaps
+issue #764, which owns structural table changes and lists accept/reject round trips in its scope.
+
+An oracle pass WAS attempted before settling on this scope, and the result reinforces it:
+
+**LibreOffice cannot serve as the oracle for this class — it discards row-level markers on import.** Driving the
+committed harness (`packages/docx-core/src/integration/libreoffice-oracle.ts`) over a two-row table whose first row
+carried a marker, an `identity` job (plain load + save, no accept/reject) returned `<w:trPr></w:trPr>`: the marker is
+gone before any operation runs. A content deletion placed in the same cell as a positive control WAS imported and
+resolved correctly — accept removed its text, reject restored it — so the harness itself works. All four
+accept/reject directions therefore returned "row kept", which is not evidence about row semantics; it is what a
+document with no row revision at all would produce.
+
+Driving Microsoft Word for Mac via AppleScript was then attempted and did not get off the ground in this
+environment: `open file name` left Word on its start screen and no fixture was ever rewritten. Not pursued further.
+
+So the four-direction asymmetry rests on the vendored strict and transitional schemas (`CT_TrPr` admits only
+`ins`/`del`/`trPrChange`) plus the classification already encoded in `conformance-adapter.ts` — not on an observed
+projection. That is sufficient for THIS change, which only needs to know which directions safe-docx does not
+implement, and it is NOT sufficient to implement the semantics. Any follow-up must obtain a real Word projection
+first; `w:vMerge` chains and cells carrying their own content revisions remain unsettled.
 
 Extending `extract_revisions` to report row and cell topology, so a caller can inspect a document *before* deciding
 to accept it, is also left out; today the counter reports the gap after the fact.

--- a/openspec/changes/guard-row-level-revision-resolution/proposal.md
+++ b/openspec/changes/guard-row-level-revision-resolution/proposal.md
@@ -49,6 +49,9 @@ Implementing the row semantics themselves is deliberately out of scope — see `
   `w:ins` whose parent is `w:trPr`. The marker and its row are both preserved.
 - The directions the engine resolves correctly are unchanged: `acceptChanges` still strips `w:trPr > w:ins`, and
   `rejectChanges` still strips `w:trPr > w:del`.
+- Rejecting a `w:trPrChange` restores the original row properties by replacing the whole `w:trPr`. That replacement
+  SHALL carry any surviving row-level marker across, so a preserved marker is not destroyed by a sibling property
+  revision and a FOREIGN marker is not destroyed by a selective reject.
 - `AcceptChangesResult` and `RejectChangesResult` gain `unresolvedRowRevisions: number`, counting the markers left
   in place. It is reported separately from the resolved-revision counters and does not make a document count as
   changed.
@@ -59,15 +62,25 @@ Implementing the row semantics themselves is deliberately out of scope — see `
 
 ## Impact
 
-- Affected specs: `docx-primitives` (ADDED: `Unresolvable Row-Level Revision Preservation`). The existing
-  `Tracked Change Acceptance Engine` scenarios are unchanged: each is scoped by its own GIVEN to `w:del`/`w:ins`
-  elements *wrapping content*, which a row-property marker is not.
+- Affected specs: `docx-primitives` (ADDED: `Unresolvable Row-Level Revision Preservation`) and `mcp-server`
+  (MODIFIED: `Accept Tracked Changes Tool`). The existing `Tracked Change Acceptance Engine` scenarios are
+  unchanged: each is scoped by its own GIVEN to `w:del`/`w:ins` elements *wrapping content*, which a row-property
+  marker is not. The `mcp-server` requirement DID need modifying — it promised "a clean .docx with no revision
+  markup in the body", which this change deliberately no longer guarantees.
 - Affected code: `packages/docx-core/src/primitives/accept_changes.ts`,
   `packages/docx-core/src/primitives/reject_changes.ts`, `packages/docx-core/src/primitives/document.ts`
 - Behavior change is confined to documents containing row-level revision markers. Every other document produces
   byte-identical output and an unchanged result shape apart from the added zero-valued counter.
-- Callers destructuring the result are unaffected (additive field). Callers that relied on row markers being
-  stripped now see them preserved — that is the point of the change, and the output was wrong before.
+- Callers destructuring the result are unaffected at runtime (additive field). It IS a source-level breaking
+  change for external TypeScript that CONSTRUCTS, mocks, or implements `AcceptChangesResult` /
+  `RejectChangesResult` — both are exported from `packages/docx-core/src/primitives/index.ts`, and a prior object
+  literal without the new property no longer type-checks. The field is deliberately required rather than optional:
+  an always-present counter is the cleaner long-term contract, and a caller that must handle unresolved markup
+  should not be able to ignore it by accident. This is a minor-version concern for the package, not a silent one.
+- Callers that relied on row markers being stripped now see them preserved — that is the point of the change, and
+  the output was wrong before.
+- `MCP accept_changes` no longer promises "a clean document with no revision markup". The tool-catalog description,
+  the generated tool reference, and the `mcp-server` spec requirement are updated to say what it actually does.
 - Refs #845.
 
 ## Out of scope

--- a/openspec/changes/guard-row-level-revision-resolution/specs/docx-primitives/spec.md
+++ b/openspec/changes/guard-row-level-revision-resolution/specs/docx-primitives/spec.md
@@ -50,3 +50,15 @@ and MCP surfaces agree with that classification.
 - **THEN** the resolved-revision counters SHALL be unchanged from the previous behavior
 - **AND** `unresolvedRowRevisions` SHALL be `0`
 - **AND** a selective accept or reject SHALL count only the row markers its `RevisionFilter` selects
+
+#### Scenario: [SDX-ROWREV-05] restoring row properties preserves surviving row markers
+- **GIVEN** a `w:trPr` carrying both a row-level revision marker and a `w:trPrChange`
+- **WHEN** `rejectChanges` restores the original row properties from the `w:trPrChange` snapshot
+- **THEN** the surviving row-level marker SHALL be carried into the restored `w:trPr` with its attributes intact
+- **AND** the reported `unresolvedRowRevisions` SHALL agree with the markers actually present in the output
+
+#### Scenario: [SDX-ROWREV-06] selective operations preserve foreign row markers byte-for-byte
+- **GIVEN** a document with one targeted and one foreign row-level revision marker
+- **WHEN** a selective accept or reject runs with a `RevisionFilter` matching only the targeted marker
+- **THEN** the foreign marker SHALL be left untouched, including when a targeted `w:trPrChange` shares its `w:trPr`
+- **AND** only the targeted marker SHALL be reported in `unresolvedRowRevisions`

--- a/openspec/changes/guard-row-level-revision-resolution/specs/docx-primitives/spec.md
+++ b/openspec/changes/guard-row-level-revision-resolution/specs/docx-primitives/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: Unresolvable Row-Level Revision Preservation
+
+The accept and reject engines SHALL NOT remove a row-level revision marker (`w:tr > w:trPr > w:ins`,
+`w:tr > w:trPr > w:del`) in the direction they cannot resolve. Such a marker describes the ROW rather than
+wrapping a span of content, so the existing content-wrapper sweeps do not apply to it.
+
+Two directions are unresolvable and SHALL preserve the marker together with its `w:tr`: `acceptChanges` over
+`w:trPr > w:del` (the row should disappear) and `rejectChanges` over `w:trPr > w:ins` (the inserted row should
+disappear). The other two directions are resolved correctly by keeping the row and dropping the marker, and SHALL
+continue to do so.
+
+Preserved markers SHALL be reported as `unresolvedRowRevisions` on `AcceptChangesResult` and
+`RejectChangesResult`, separately from the resolved-revision counters, and SHALL NOT cause a document to be
+treated as changed. Removing the marker while keeping the row would destroy the `w:id`/`w:author`/`w:date`
+evidence and leave no residual record, so this requirement follows the preserve-and-report convention already
+applied to other unresolved advanced revision records.
+
+Resolving row-level revisions semantically is out of scope; `packages/docx-core/src/cli/conformance-adapter.ts`
+already classifies both unresolvable combinations as `supported: false`, and this requirement makes the library
+and MCP surfaces agree with that classification.
+
+#### Scenario: [SDX-ROWREV-01] accepting a deleted row preserves the unresolvable marker
+- **GIVEN** a table row whose `w:trPr` carries a `w:del` row-level revision marker
+- **WHEN** `acceptChanges` processes the document
+- **THEN** the `w:del` marker SHALL be preserved with its `w:id`, `w:author` and `w:date` intact
+- **AND** the `w:tr` SHALL be preserved
+- **AND** the marker SHALL NOT be counted in `deletionsAccepted`
+- **AND** the result SHALL report `unresolvedRowRevisions` as `1`
+
+#### Scenario: [SDX-ROWREV-02] rejecting an inserted row preserves the unresolvable marker
+- **GIVEN** a table row whose `w:trPr` carries an `w:ins` row-level revision marker
+- **WHEN** `rejectChanges` processes the document
+- **THEN** the `w:ins` marker SHALL be preserved with its `w:id`, `w:author` and `w:date` intact
+- **AND** the `w:tr` SHALL be preserved
+- **AND** the marker SHALL NOT be counted in `insertionsRemoved`
+- **AND** the result SHALL report `unresolvedRowRevisions` as `1`
+
+#### Scenario: [SDX-ROWREV-03] row markers the engine resolves correctly are still removed
+- **GIVEN** a table row whose `w:trPr` carries an `w:ins` marker
+- **WHEN** `acceptChanges` processes the document
+- **THEN** the marker SHALL be removed and the `w:tr` SHALL be preserved, because accepting an inserted row keeps the row
+- **AND** the symmetric case SHALL hold for `rejectChanges` over a `w:trPr > w:del` marker
+- **AND** neither case SHALL be reported in `unresolvedRowRevisions`
+
+#### Scenario: [SDX-ROWREV-04] content revisions and selective filters are unaffected
+- **GIVEN** a document containing content revisions, property change records and moves but no row-level markers
+- **WHEN** either engine processes the document
+- **THEN** the resolved-revision counters SHALL be unchanged from the previous behavior
+- **AND** `unresolvedRowRevisions` SHALL be `0`
+- **AND** a selective accept or reject SHALL count only the row markers its `RevisionFilter` selects

--- a/openspec/changes/guard-row-level-revision-resolution/specs/mcp-server/spec.md
+++ b/openspec/changes/guard-row-level-revision-resolution/specs/mcp-server/spec.md
@@ -1,17 +1,18 @@
 ## MODIFIED Requirements
 
 ### Requirement: Accept Tracked Changes Tool
-The Safe-Docx MCP server SHALL provide an `accept_changes` tool that accepts all tracked changes in the document body that the acceptance engine can resolve. v1 scope is document body only; headers, footers, footnotes, and endnotes are deferred. Revision records the engine cannot resolve SHALL be preserved rather than stripped, and SHALL be reported to the caller, so the tool never claims a clean document while leaving unresolved markup behind.
+The Safe-Docx MCP server SHALL provide an `accept_changes` tool that accepts every tracked change the acceptance engine can resolve, across the document body and the revisionable side stories it supports (`footnotes.xml`, `endnotes.xml`, `comments.xml`, `glossary/document.xml`); headers and footers remain deferred. Revision records the engine cannot resolve SHALL be preserved rather than stripped, and SHALL be reported to the caller, so the tool never claims a clean document while leaving unresolved markup behind.
 
 #### Scenario: accept_changes produces clean document body with no revision markup
-- **GIVEN** a document containing tracked changes (insertions, deletions, formatting changes, moves) in the document body
+- **GIVEN** a document whose tracked changes (insertions, deletions, formatting changes, moves) are all of resolvable kinds
 - **WHEN** `accept_changes` is called
-- **THEN** the server SHALL return a document with all resolvable tracked changes in the body accepted
+- **THEN** the server SHALL return a document with those tracked changes accepted and no revision markup remaining
 - **AND** the response SHALL include acceptance stats (insertions accepted, deletions accepted, moves resolved, property changes resolved)
-- **AND** tracked changes in headers, footers, footnotes, and endnotes SHALL remain unmodified in v1
+- **AND** `unresolvedRowRevisions` SHALL be `0`
+- **AND** tracked changes in headers and footers SHALL remain unmodified
 
 #### Scenario: accepted document opens cleanly in Microsoft Word
-- **GIVEN** a document with tracked changes that has been processed by `accept_changes`
+- **GIVEN** a document whose tracked changes are all of resolvable kinds, processed by `accept_changes`
 - **WHEN** the resulting document is opened in Microsoft Word
 - **THEN** the document SHALL open without errors or repair prompts
 - **AND** no tracked changes SHALL appear in the review pane
@@ -28,3 +29,10 @@ The Safe-Docx MCP server SHALL provide an `accept_changes` tool that accepts all
 - **THEN** the response SHALL report `unresolvedRowRevisions` as a non-zero count
 - **AND** the marker SHALL remain in the saved document rather than being stripped
 - **AND** the row SHALL remain in the saved document
+
+#### Scenario: [SDX-ROWREV-MCP-02] a document holding unresolved row revisions stays structurally valid
+- **GIVEN** a document processed by `accept_changes` that still holds a preserved row-level revision marker
+- **WHEN** the output is inspected
+- **THEN** the preserved marker SHALL remain a child of `w:trPr`, the only position the schema admits
+- **AND** the output SHALL remain well-formed
+- **AND** this scenario SHALL NOT be read as evidence about Microsoft Word's review pane, which is covered separately and only by resolvable input

--- a/openspec/changes/guard-row-level-revision-resolution/specs/mcp-server/spec.md
+++ b/openspec/changes/guard-row-level-revision-resolution/specs/mcp-server/spec.md
@@ -1,0 +1,30 @@
+## MODIFIED Requirements
+
+### Requirement: Accept Tracked Changes Tool
+The Safe-Docx MCP server SHALL provide an `accept_changes` tool that accepts all tracked changes in the document body that the acceptance engine can resolve. v1 scope is document body only; headers, footers, footnotes, and endnotes are deferred. Revision records the engine cannot resolve SHALL be preserved rather than stripped, and SHALL be reported to the caller, so the tool never claims a clean document while leaving unresolved markup behind.
+
+#### Scenario: accept_changes produces clean document body with no revision markup
+- **GIVEN** a document containing tracked changes (insertions, deletions, formatting changes, moves) in the document body
+- **WHEN** `accept_changes` is called
+- **THEN** the server SHALL return a document with all resolvable tracked changes in the body accepted
+- **AND** the response SHALL include acceptance stats (insertions accepted, deletions accepted, moves resolved, property changes resolved)
+- **AND** tracked changes in headers, footers, footnotes, and endnotes SHALL remain unmodified in v1
+
+#### Scenario: accepted document opens cleanly in Microsoft Word
+- **GIVEN** a document with tracked changes that has been processed by `accept_changes`
+- **WHEN** the resulting document is opened in Microsoft Word
+- **THEN** the document SHALL open without errors or repair prompts
+- **AND** no tracked changes SHALL appear in the review pane
+
+#### Scenario: original document is not mutated
+- **GIVEN** a source document with tracked changes
+- **WHEN** `accept_changes` is called
+- **THEN** the original source document SHALL remain unchanged
+- **AND** the accepted output SHALL be written to a separate file or session working copy
+
+#### Scenario: [SDX-ROWREV-MCP-01] accept_changes reports unresolved row revisions instead of claiming a clean document
+- **GIVEN** a document whose table row carries a `w:trPr > w:del` row-level revision marker
+- **WHEN** `accept_changes` is called
+- **THEN** the response SHALL report `unresolvedRowRevisions` as a non-zero count
+- **AND** the marker SHALL remain in the saved document rather than being stripped
+- **AND** the row SHALL remain in the saved document

--- a/openspec/changes/guard-row-level-revision-resolution/tasks.md
+++ b/openspec/changes/guard-row-level-revision-resolution/tasks.md
@@ -57,3 +57,15 @@
   `ins`/`del`/`trPrChange` as revision children, paragraph-mark markers live under `pPr > rPr`, cell topology uses
   distinct `cellIns`/`cellDel` names, and nested tables do not change the direct-parent test. No Word or
   LibreOffice projection oracle was run, so application-specific normalization remains unverified.
+
+## 7. Oracle attempt (2026-08-14)
+
+- [x] 7.1 LibreOffice: ran the committed oracle harness over all four directions plus an `identity` control.
+      Result — LO discards `w:trPr > w:ins|w:del` on IMPORT (`<w:trPr></w:trPr>` after a plain load+save), so it
+      cannot validate this class. A content deletion in the same cell was imported and resolved correctly,
+      confirming the harness works and isolating the failure to row-level markers.
+- [x] 7.2 Microsoft Word via AppleScript: attempted, blocked. `open file name` left Word on its start screen and
+      no fixture was rewritten. The `scripts/oracle/word/` helpers referenced elsewhere do not exist on this
+      branch. Abandoned rather than pursued further.
+- Consequence: the four-direction asymmetry is supported by the schemas and by `conformance-adapter.ts`, not by an
+  observed projection. Sufficient for a preserve-and-report guard; NOT sufficient to implement the semantics.

--- a/openspec/changes/guard-row-level-revision-resolution/tasks.md
+++ b/openspec/changes/guard-row-level-revision-resolution/tasks.md
@@ -1,0 +1,41 @@
+## 1. Engine: stop stripping unresolvable row markers
+
+- [x] 1.1 `accept_changes.ts`: add a row-property-marker predicate (parent is `w:trPr`) and exclude `w:trPr > w:del`
+      from the Phase B `removeAllByLocalName(root, 'del')` sweep. Leave `w:trPr > w:ins` alone — accepting an
+      inserted row correctly keeps the row and drops the marker.
+- [x] 1.2 `reject_changes.ts`: mirror it — exclude `w:trPr > w:ins` from the Phase C
+      `removeAllByLocalName(root, 'ins')` sweep, leaving `w:trPr > w:del` handled as before.
+- [x] 1.3 Count the preserved markers and return them as `unresolvedRowRevisions` on `AcceptChangesResult` /
+      `RejectChangesResult`. Respect the `RevisionFilter`, so a selective accept/reject only counts markers it
+      would otherwise have touched.
+- [x] 1.4 `document.ts`: extend `emptyAcceptChangesResult` / `addAcceptChangesResult` and the reject equivalents to
+      carry the counter across the body and side stories. `hasAcceptedChanges` / `hasRejectedChanges` SHALL NOT
+      treat a preserved marker as a change.
+
+## 2. MCP surface
+
+- [x] 2.1 Confirmed: `packages/docx-mcp/src/tools/accept_changes.ts` spreads the primitive result into its
+      response, so `unresolvedRowRevisions` reaches the caller with no tool change. There is no `reject_changes`
+      MCP tool today; the library result carries the counter for direct callers.
+
+## 3. Tests
+
+- [x] 3.1 New test file with `TEST_FEATURE = 'guard-row-level-revision-resolution'` covering: accept over a
+      deleted row (marker + row + attributes preserved, `deletionsAccepted` unchanged, `unresolvedRowRevisions` 1),
+      reject over an inserted row (mirror), both correctly-resolved directions (marker removed, row kept, counter 0),
+      and a no-row-revision control asserting the counter is 0 and output is unchanged.
+- [x] 3.2 Assert the selective (`filter`) path counts only markers the filter selects.
+- [x] 3.3 Full `@usejunior/docx-core` suite green; `[XIMPL-08]` conformance classification still passes unchanged.
+
+## 4. Gates
+
+- [x] 4.1 `npm run build && npm run lint:workspaces && npm run test:run && npm run check:spec-coverage &&
+      npm run check:conformance-citations && npm run check:conformance-doc`
+- [x] 4.2 `openspec validate guard-row-level-revision-resolution --strict`
+
+## 5. Verification performed
+
+- Red/green confirmed: with the four source edits stashed, all four new tests fail on the exact assertions
+  (`expected null not to be null` for the stripped marker, `expected undefined to be +0` for the counter).
+- Full workspace suite green (`npm run test:run`, exit 0), including `[XIMPL-08]`, which pins the conformance
+  adapter's `supported: false` classification for both unresolvable combinations.

--- a/openspec/changes/guard-row-level-revision-resolution/tasks.md
+++ b/openspec/changes/guard-row-level-revision-resolution/tasks.md
@@ -39,3 +39,21 @@
   (`expected null not to be null` for the stripped marker, `expected undefined to be +0` for the counter).
 - Full workspace suite green (`npm run test:run`, exit 0), including `[XIMPL-08]`, which pins the conformance
   adapter's `supported: false` classification for both unresolvable combinations.
+
+## 6. Peer review follow-ups (Codex, 2026-08-14)
+
+- [x] 6.1 P1 — reject-side ordering leak. Phase F restored a `w:trPrChange` snapshot by replacing the whole
+      `w:trPr`, destroying a marker Phase C had preserved while still reporting it in `unresolvedRowRevisions`.
+      Reproduced, then fixed by carrying surviving row markers into the restored `w:trPr`. The accept side was
+      checked and is unaffected (Phase D removes the change record without replacing the parent).
+- [x] 6.2 P1/P2 — the `mcp-server` requirement promised "no revision markup in the body". Added a MODIFIED
+      delta, updated the `tool_catalog.ts` description, and regenerated `tool-reference.generated.md`.
+- [x] 6.3 P2 — documented the source-level breaking change for external TypeScript that constructs the exported
+      result types, and the reasoning for keeping the field required.
+- [x] 6.4 P2 — added `[SDX-ROWREV-05]` (trPrChange collision) and `[SDX-ROWREV-06]` (selective reject preserves
+      foreign markers) plus an MCP-level test `[SDX-ROWREV-MCP-01]`. Both new primitive tests verified red
+      against the un-fixed Phase F.
+- Codex confirmed assumptions 1 and 2 against the vendored strict/transitional schemas: `CT_TrPr` admits only
+  `ins`/`del`/`trPrChange` as revision children, paragraph-mark markers live under `pPr > rPr`, cell topology uses
+  distinct `cellIns`/`cellDel` names, and nested tables do not change the direct-parent test. No Word or
+  LibreOffice projection oracle was run, so application-specific normalization remains unverified.

--- a/packages/docx-core/src/primitives/accept_ai_edits.ts
+++ b/packages/docx-core/src/primitives/accept_ai_edits.ts
@@ -292,8 +292,20 @@ export function rejectAIEdits(doc: Document, selector: AiEditSelector): Selectiv
 }
 
 function emptyAccept(): AcceptChangesResult {
-  return { insertionsAccepted: 0, deletionsAccepted: 0, movesResolved: 0, propertyChangesResolved: 0 };
+  return {
+    insertionsAccepted: 0,
+    deletionsAccepted: 0,
+    movesResolved: 0,
+    propertyChangesResolved: 0,
+    unresolvedRowRevisions: 0,
+  };
 }
 function emptyReject(): RejectChangesResult {
-  return { insertionsRemoved: 0, deletionsRestored: 0, movesReverted: 0, propertyChangesReverted: 0 };
+  return {
+    insertionsRemoved: 0,
+    deletionsRestored: 0,
+    movesReverted: 0,
+    propertyChangesReverted: 0,
+    unresolvedRowRevisions: 0,
+  };
 }

--- a/packages/docx-core/src/primitives/accept_changes.ts
+++ b/packages/docx-core/src/primitives/accept_changes.ts
@@ -28,6 +28,13 @@ export type AcceptChangesResult = {
   deletionsAccepted: number;
   movesResolved: number;
   propertyChangesResolved: number;
+  /**
+   * Row-level revision markers left in place because this engine cannot resolve
+   * them. A non-zero count means the output still holds tracked-change markup
+   * and does not match what a word processor would project. Reported separately
+   * from the resolved counters: a preserved marker is not an accepted change.
+   */
+  unresolvedRowRevisions: number;
 };
 
 /**
@@ -70,14 +77,44 @@ function collectByLocalName(container: Document | Element, localName: string): E
   return Array.from(container.getElementsByTagNameNS(W_NS, localName));
 }
 
+/**
+ * True iff this element is a row-level revision marker — a `w:ins`/`w:del`
+ * whose direct parent is `w:trPr`.
+ *
+ * These describe the ROW rather than wrapping a span of content:
+ * `w:tr > w:trPr > w:del` marks the row itself as deleted and
+ * `w:tr > w:trPr > w:ins` marks it as inserted. A sweep that matches on local
+ * name alone cannot tell them apart from the content wrappers, and removing one
+ * strips the `w:id`/`w:author`/`w:date` evidence while leaving the `w:tr` it
+ * described in the document.
+ *
+ * @see https://github.com/UseJunior/safe-docx/issues/845
+ */
+function isRowPropertyRevisionMarker(el: Element): boolean {
+  const parent = el.parentNode;
+  return parent !== null && isW(parent, 'trPr');
+}
+
+/** Row-level markers the filter selects, which this engine cannot resolve. */
+function countUnresolvedRowRevisions(
+  container: Document | Element,
+  localName: string,
+  filter: RevisionFilter,
+): number {
+  return collectByLocalName(container, localName).filter(filter).filter(isRowPropertyRevisionMarker)
+    .length;
+}
+
 function removeAllByLocalName(
   container: Document | Element,
   localName: string,
   filter: RevisionFilter = ACCEPT_ALL,
+  exclude?: (el: Element) => boolean,
 ): number {
   const elements = collectByLocalName(container, localName).filter(filter);
   let count = 0;
   for (const el of elements) {
+    if (exclude?.(el)) continue;
     if (el.parentNode) {
       el.parentNode.removeChild(el);
       count++;
@@ -311,7 +348,13 @@ export function acceptChanges(
   const selective = filter !== ACCEPT_ALL;
   const root = doc.getElementsByTagNameNS(W_NS, 'body').item(0) ?? doc.documentElement;
   if (!root) {
-    return { insertionsAccepted: 0, deletionsAccepted: 0, movesResolved: 0, propertyChangesResolved: 0 };
+    return {
+      insertionsAccepted: 0,
+      deletionsAccepted: 0,
+      movesResolved: 0,
+      propertyChangesResolved: 0,
+      unresolvedRowRevisions: 0,
+    };
   }
 
   // Phase A — Identify paragraphs whose MARK is a tracked deletion
@@ -334,8 +377,18 @@ export function acceptChanges(
     }
   }
 
-  // Phase B — Remove deletions and move sources
-  const deletionsAccepted = removeAllByLocalName(root, 'del', filter);
+  // Phase B — Remove deletions and move sources.
+  //
+  // A `w:trPr > w:del` marks the ROW as deleted; accepting it should remove the
+  // whole `w:tr`, which this engine does not implement (conformance-adapter.ts
+  // already classifies the combination as unsupported). Sweeping it as a content
+  // deletion would strip the marker and keep the row — silent divergence with no
+  // residual record. Preserve it and report it instead (#845).
+  //
+  // The mirror direction needs no guard: accepting a `w:trPr > w:ins` correctly
+  // keeps the row and drops the marker, which Phase C's unwrap already does.
+  const unresolvedRowRevisions = countUnresolvedRowRevisions(root, 'del', filter);
+  const deletionsAccepted = removeAllByLocalName(root, 'del', filter, isRowPropertyRevisionMarker);
   const moveFromRemoved = removeAllByLocalName(root, 'moveFrom', filter);
   removeAllByLocalName(root, 'moveFromRangeStart', filter);
   removeAllByLocalName(root, 'moveFromRangeEnd', filter);
@@ -409,5 +462,6 @@ export function acceptChanges(
     deletionsAccepted,
     movesResolved: moveFromRemoved + moveToUnwrapped,
     propertyChangesResolved,
+    unresolvedRowRevisions,
   };
 }

--- a/packages/docx-core/src/primitives/document.ts
+++ b/packages/docx-core/src/primitives/document.ts
@@ -118,7 +118,13 @@ export type NormalizationResult = {
 };
 
 function emptyAcceptChangesResult(): AcceptChangesResult {
-  return { insertionsAccepted: 0, deletionsAccepted: 0, movesResolved: 0, propertyChangesResolved: 0 };
+  return {
+    insertionsAccepted: 0,
+    deletionsAccepted: 0,
+    movesResolved: 0,
+    propertyChangesResolved: 0,
+    unresolvedRowRevisions: 0,
+  };
 }
 
 function hasAcceptedChanges(result: AcceptChangesResult): boolean {
@@ -135,10 +141,17 @@ function addAcceptChangesResult(total: AcceptChangesResult, result: AcceptChange
   total.deletionsAccepted += result.deletionsAccepted;
   total.movesResolved += result.movesResolved;
   total.propertyChangesResolved += result.propertyChangesResolved;
+  total.unresolvedRowRevisions += result.unresolvedRowRevisions;
 }
 
 function emptyRejectChangesResult(): RejectChangesResult {
-  return { insertionsRemoved: 0, deletionsRestored: 0, movesReverted: 0, propertyChangesReverted: 0 };
+  return {
+    insertionsRemoved: 0,
+    deletionsRestored: 0,
+    movesReverted: 0,
+    propertyChangesReverted: 0,
+    unresolvedRowRevisions: 0,
+  };
 }
 
 function hasRejectedChanges(result: RejectChangesResult): boolean {
@@ -155,6 +168,7 @@ function addRejectChangesResult(total: RejectChangesResult, result: RejectChange
   total.deletionsRestored += result.deletionsRestored;
   total.movesReverted += result.movesReverted;
   total.propertyChangesReverted += result.propertyChangesReverted;
+  total.unresolvedRowRevisions += result.unresolvedRowRevisions;
 }
 
 function parseWId(el: Element): number | null {

--- a/packages/docx-core/src/primitives/reject_changes.ts
+++ b/packages/docx-core/src/primitives/reject_changes.ts
@@ -549,6 +549,26 @@ export function rejectChanges(
         // CT_SectPrChange carries CT_SectPrBase, which intentionally excludes
         // header/footer references. Those live bindings are not part of the
         // page-setup property revision and must survive rejection.
+        // A `w:trPr` may carry BOTH a row-level revision marker and a
+        // `w:trPrChange`. Restoring the snapshot replaces the whole `w:trPr`,
+        // which would silently destroy any surviving marker — including the
+        // unresolved `w:ins` Phase C deliberately preserved (making the reported
+        // `unresolvedRowRevisions` disagree with the document) and any FOREIGN
+        // marker a selective reject promised to leave byte-untouched.
+        //
+        // `w:trPrChange` carries CT_TrPrBase, which has no row-revision
+        // children of its own, so transplanting the survivors cannot collide
+        // with the restored properties.
+        if (localName === 'trPrChange') {
+          const survivingRowMarkers = Array.from(parentProp.childNodes)
+            .filter((node): node is Element =>
+              node.nodeType === 1
+              && (isW(node as Element, 'ins') || isW(node as Element, 'del')))
+            .map((marker) => marker.cloneNode(true));
+          for (const marker of survivingRowMarkers.reverse()) {
+            restored.insertBefore(marker, restored.firstChild);
+          }
+        }
         if (localName === 'sectPrChange') {
           const liveReferences = Array.from(parentProp.childNodes)
             .filter((node): node is Element =>

--- a/packages/docx-core/src/primitives/reject_changes.ts
+++ b/packages/docx-core/src/primitives/reject_changes.ts
@@ -46,6 +46,13 @@ export type RejectChangesResult = {
   deletionsRestored: number;
   movesReverted: number;
   propertyChangesReverted: number;
+  /**
+   * Row-level revision markers left in place because this engine cannot resolve
+   * them. A non-zero count means the output still holds tracked-change markup
+   * and does not match what a word processor would project. Reported separately
+   * from the resolved counters: a preserved marker is not a reverted change.
+   */
+  unresolvedRowRevisions: number;
 };
 
 // ── DOM helpers (internal) ──────────────────────────────────────────
@@ -72,14 +79,44 @@ function collectByLocalName(container: Document | Element, localName: string): E
   return Array.from(container.getElementsByTagNameNS(W_NS, localName));
 }
 
+/**
+ * True iff this element is a row-level revision marker — a `w:ins`/`w:del`
+ * whose direct parent is `w:trPr`.
+ *
+ * These describe the ROW rather than wrapping a span of content:
+ * `w:tr > w:trPr > w:ins` marks the row itself as inserted and
+ * `w:tr > w:trPr > w:del` marks it as deleted. A sweep that matches on local
+ * name alone cannot tell them apart from the content wrappers, and removing one
+ * strips the `w:id`/`w:author`/`w:date` evidence while leaving the `w:tr` it
+ * described in the document.
+ *
+ * @see https://github.com/UseJunior/safe-docx/issues/845
+ */
+function isRowPropertyRevisionMarker(el: Element): boolean {
+  const parent = el.parentNode;
+  return parent !== null && isW(parent, 'trPr');
+}
+
+/** Row-level markers the filter selects, which this engine cannot resolve. */
+function countUnresolvedRowRevisions(
+  container: Document | Element,
+  localName: string,
+  filter: RevisionFilter,
+): number {
+  return collectByLocalName(container, localName).filter(filter).filter(isRowPropertyRevisionMarker)
+    .length;
+}
+
 function removeAllByLocalName(
   container: Document | Element,
   localName: string,
   filter: RevisionFilter = ACCEPT_ALL,
+  exclude?: (el: Element) => boolean,
 ): number {
   const elements = collectByLocalName(container, localName).filter(filter);
   let count = 0;
   for (const el of elements) {
+    if (exclude?.(el)) continue;
     if (el.parentNode) {
       el.parentNode.removeChild(el);
       count++;
@@ -392,7 +429,13 @@ export function rejectChanges(
   const selective = filter !== ACCEPT_ALL;
   const root = doc.getElementsByTagNameNS(W_NS, 'body').item(0) ?? doc.documentElement;
   if (!root) {
-    return { insertionsRemoved: 0, deletionsRestored: 0, movesReverted: 0, propertyChangesReverted: 0 };
+    return {
+      insertionsRemoved: 0,
+      deletionsRestored: 0,
+      movesReverted: 0,
+      propertyChangesReverted: 0,
+      unresolvedRowRevisions: 0,
+    };
   }
 
   // Phase A — Identify paragraphs whose MARK is a tracked insertion
@@ -424,7 +467,16 @@ export function rejectChanges(
   }
 
   // Phase C — Remove insertions and move destinations
-  const insertionsRemoved = removeAllByLocalName(root, 'ins', filter);
+  // A `w:trPr > w:ins` marks the ROW as inserted; rejecting it should remove the
+  // whole `w:tr`, which this engine does not implement (conformance-adapter.ts
+  // already classifies the combination as unsupported). Sweeping it as a content
+  // insertion would strip the marker and keep the row — silent divergence with no
+  // residual record. Preserve it and report it instead (#845).
+  //
+  // The mirror direction needs no guard: rejecting a `w:trPr > w:del` correctly
+  // keeps the row and drops the marker, which Phase D's unwrap already does.
+  const unresolvedRowRevisions = countUnresolvedRowRevisions(root, 'ins', filter);
+  const insertionsRemoved = removeAllByLocalName(root, 'ins', filter, isRowPropertyRevisionMarker);
   const moveToRemoved = removeAllByLocalName(root, 'moveTo', filter);
   removeAllByLocalName(root, 'moveToRangeStart', filter);
   removeAllByLocalName(root, 'moveToRangeEnd', filter);
@@ -569,5 +621,6 @@ export function rejectChanges(
     deletionsRestored,
     movesReverted: moveFromUnwrapped + moveToRemoved,
     propertyChangesReverted,
+    unresolvedRowRevisions,
   };
 }

--- a/packages/docx-core/test-primitives/row_level_revision_guard.test.ts
+++ b/packages/docx-core/test-primitives/row_level_revision_guard.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect } from 'vitest';
+import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
+import { testAllure } from './helpers/allure-test.js';
+import { acceptChanges, type RevisionFilter } from '../src/primitives/accept_changes.js';
+import { rejectChanges } from '../src/primitives/reject_changes.js';
+
+const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const TEST_FEATURE = 'guard-row-level-revision-resolution';
+const test = testAllure.epic('DOCX Primitives').withLabels({ feature: TEST_FEATURE });
+
+/**
+ * A two-row table whose FIRST row carries a row-level revision marker in its
+ * `w:trPr`. The second row is untracked and must survive every projection, so a
+ * test that accidentally wipes the table still fails loudly.
+ */
+function rowRevisionDoc(marker: 'ins' | 'del'): Document {
+  return new DOMParser().parseFromString(
+    `<w:document xmlns:w="${W_NS}"><w:body><w:tbl>`
+      + `<w:tr><w:trPr>`
+      + `<w:${marker} w:id="7" w:author="Reviewer" w:date="2026-01-01T00:00:00Z"/>`
+      + `</w:trPr>`
+      + `<w:tc><w:p><w:r><w:t>ROWTEXT</w:t></w:r></w:p></w:tc></w:tr>`
+      + `<w:tr><w:tc><w:p><w:r><w:t>KEEPME</w:t></w:r></w:p></w:tc></w:tr>`
+      + `</w:tbl></w:body></w:document>`,
+    'text/xml',
+  ) as unknown as Document;
+}
+
+function serialize(doc: Document): string {
+  return new XMLSerializer().serializeToString(doc as never);
+}
+
+function rowCount(doc: Document): number {
+  return doc.getElementsByTagNameNS(W_NS, 'tr').length;
+}
+
+/** The row-level marker still attached to a `w:trPr`, if any. */
+function rowMarker(doc: Document, localName: 'ins' | 'del'): Element | null {
+  const found = doc.getElementsByTagNameNS(W_NS, localName);
+  for (let i = 0; i < found.length; i++) {
+    const el = found.item(i)!;
+    const parent = el.parentNode as Element | null;
+    if (parent && parent.namespaceURI === W_NS && parent.localName === 'trPr') return el;
+  }
+  return null;
+}
+
+function attrs(el: Element): { id: string | null; author: string | null; date: string | null } {
+  const read = (name: string) => el.getAttributeNS(W_NS, name) ?? el.getAttribute(`w:${name}`);
+  return { id: read('id'), author: read('author'), date: read('date') };
+}
+
+describe('row-level revision guard', () => {
+  test.openspec('[SDX-ROWREV-01] accepting a deleted row preserves the unresolvable marker')(
+    'keeps the marker, its attributes and the row instead of silently dropping the evidence',
+    () => {
+      const doc = rowRevisionDoc('del');
+
+      const result = acceptChanges(doc);
+
+      const marker = rowMarker(doc, 'del');
+      expect(marker).not.toBeNull();
+      expect(attrs(marker!)).toEqual({
+        id: '7',
+        author: 'Reviewer',
+        date: '2026-01-01T00:00:00Z',
+      });
+      expect(rowCount(doc)).toBe(2);
+      expect(serialize(doc)).toContain('ROWTEXT');
+      // The marker is NOT a resolved deletion: counting it there is what told
+      // callers the operation had succeeded.
+      expect(result.deletionsAccepted).toBe(0);
+      expect(result.unresolvedRowRevisions).toBe(1);
+    },
+  );
+
+  test.openspec('[SDX-ROWREV-02] rejecting an inserted row preserves the unresolvable marker')(
+    'mirrors the accept side for a row marked inserted',
+    () => {
+      const doc = rowRevisionDoc('ins');
+
+      const result = rejectChanges(doc);
+
+      const marker = rowMarker(doc, 'ins');
+      expect(marker).not.toBeNull();
+      expect(attrs(marker!)).toEqual({
+        id: '7',
+        author: 'Reviewer',
+        date: '2026-01-01T00:00:00Z',
+      });
+      expect(rowCount(doc)).toBe(2);
+      expect(serialize(doc)).toContain('ROWTEXT');
+      expect(result.insertionsRemoved).toBe(0);
+      expect(result.unresolvedRowRevisions).toBe(1);
+    },
+  );
+
+  test.openspec('[SDX-ROWREV-03] row markers the engine resolves correctly are still removed')(
+    'accepting an inserted row and rejecting a deleted row both keep the row and drop the marker',
+    () => {
+      const accepted = rowRevisionDoc('ins');
+      const acceptResult = acceptChanges(accepted);
+
+      expect(rowMarker(accepted, 'ins')).toBeNull();
+      expect(rowCount(accepted)).toBe(2);
+      expect(serialize(accepted)).toContain('ROWTEXT');
+      expect(acceptResult.unresolvedRowRevisions).toBe(0);
+
+      const rejected = rowRevisionDoc('del');
+      const rejectResult = rejectChanges(rejected);
+
+      expect(rowMarker(rejected, 'del')).toBeNull();
+      expect(rowCount(rejected)).toBe(2);
+      expect(serialize(rejected)).toContain('ROWTEXT');
+      expect(rejectResult.unresolvedRowRevisions).toBe(0);
+    },
+  );
+
+  test.openspec('[SDX-ROWREV-04] content revisions and selective filters are unaffected')(
+    'content wrappers still resolve, and a selective run counts only the markers it selects',
+    () => {
+      const contentOnly = new DOMParser().parseFromString(
+        `<w:document xmlns:w="${W_NS}"><w:body>`
+          + `<w:p><w:del w:id="1" w:author="A" w:date="2026-01-01T00:00:00Z">`
+          + `<w:r><w:delText>gone</w:delText></w:r></w:del>`
+          + `<w:ins w:id="2" w:author="A" w:date="2026-01-01T00:00:00Z">`
+          + `<w:r><w:t>added</w:t></w:r></w:ins></w:p>`
+          + `</w:body></w:document>`,
+        'text/xml',
+      ) as unknown as Document;
+
+      const result = acceptChanges(contentOnly);
+
+      expect(result.deletionsAccepted).toBe(1);
+      expect(result.insertionsAccepted).toBe(1);
+      expect(result.unresolvedRowRevisions).toBe(0);
+      expect(serialize(contentOnly)).not.toContain('gone');
+      expect(serialize(contentOnly)).toContain('added');
+
+      // Selective: a filter that selects no revision must not count the row
+      // marker it never would have touched.
+      const unselected = rowRevisionDoc('del');
+      const selectsNothing: RevisionFilter = () => false;
+      const unselectedResult = acceptChanges(unselected, { filter: selectsNothing });
+
+      expect(unselectedResult.unresolvedRowRevisions).toBe(0);
+      expect(rowMarker(unselected, 'del')).not.toBeNull();
+
+      // Selective: a filter that DOES select the row marker reports it.
+      const selected = rowRevisionDoc('del');
+      const selectsRowMarker: RevisionFilter = (el) =>
+        (el.getAttributeNS(W_NS, 'id') ?? el.getAttribute('w:id')) === '7';
+      const selectedResult = acceptChanges(selected, { filter: selectsRowMarker });
+
+      expect(selectedResult.unresolvedRowRevisions).toBe(1);
+      expect(rowMarker(selected, 'del')).not.toBeNull();
+    },
+  );
+});

--- a/packages/docx-core/test-primitives/row_level_revision_guard.test.ts
+++ b/packages/docx-core/test-primitives/row_level_revision_guard.test.ts
@@ -156,4 +156,95 @@ describe('row-level revision guard', () => {
       expect(rowMarker(selected, 'del')).not.toBeNull();
     },
   );
+
+  test.openspec('[SDX-ROWREV-05] restoring row properties preserves surviving row markers')(
+    'a w:trPrChange in the same w:trPr must not carry the preserved marker away with it',
+    () => {
+      // Regression: Phase C preserves the row marker, then Phase F restores the
+      // original row properties by REPLACING the whole `w:trPr` with the
+      // `w:trPrChange` snapshot. Before the guard extended into Phase F, the
+      // marker vanished while `unresolvedRowRevisions` still reported it — the
+      // count and the document disagreed, which is the exact failure mode this
+      // change exists to prevent.
+      const doc = new DOMParser().parseFromString(
+        `<w:document xmlns:w="${W_NS}"><w:body><w:tbl><w:tr><w:trPr>`
+          + `<w:ins w:id="7" w:author="Reviewer" w:date="2026-01-01T00:00:00Z"/>`
+          + `<w:trPrChange w:id="8" w:author="Reviewer" w:date="2026-01-01T00:00:00Z">`
+          + `<w:trPr><w:trHeight w:val="240"/></w:trPr>`
+          + `</w:trPrChange>`
+          + `</w:trPr>`
+          + `<w:tc><w:p><w:r><w:t>ROWTEXT</w:t></w:r></w:p></w:tc></w:tr>`
+          + `</w:tbl></w:body></w:document>`,
+        'text/xml',
+      ) as unknown as Document;
+
+      const result = rejectChanges(doc);
+
+      // The property change itself is reverted...
+      expect(result.propertyChangesReverted).toBe(1);
+      expect(serialize(doc)).toContain('w:trHeight');
+      expect(serialize(doc)).not.toContain('trPrChange');
+
+      // ...and the unresolvable row marker survives it, so the reported count
+      // matches what is actually in the document.
+      const marker = rowMarker(doc, 'ins');
+      expect(marker).not.toBeNull();
+      expect(attrs(marker!)).toEqual({
+        id: '7',
+        author: 'Reviewer',
+        date: '2026-01-01T00:00:00Z',
+      });
+      expect(result.unresolvedRowRevisions).toBe(1);
+      expect(rowCount(doc)).toBe(1);
+    },
+  );
+
+  test.openspec('[SDX-ROWREV-06] selective operations preserve foreign row markers byte-for-byte')(
+    'a selective reject leaves an unselected row marker untouched, including across a trPrChange restore',
+    () => {
+      // Two rows: row 1 carries the TARGETED insertion marker plus a targeted
+      // trPrChange; row 2 carries a FOREIGN marker a selective run promised not
+      // to touch (#125).
+      const doc = new DOMParser().parseFromString(
+        `<w:document xmlns:w="${W_NS}"><w:body><w:tbl>`
+          + `<w:tr><w:trPr>`
+          + `<w:ins w:id="7" w:author="Target" w:date="2026-01-01T00:00:00Z"/>`
+          + `<w:trPrChange w:id="8" w:author="Target" w:date="2026-01-01T00:00:00Z">`
+          + `<w:trPr><w:trHeight w:val="240"/></w:trPr>`
+          + `</w:trPrChange>`
+          + `</w:trPr><w:tc><w:p><w:r><w:t>TARGETROW</w:t></w:r></w:p></w:tc></w:tr>`
+          + `<w:tr><w:trPr>`
+          + `<w:ins w:id="99" w:author="Foreign" w:date="2025-06-01T00:00:00Z"/>`
+          + `</w:trPr><w:tc><w:p><w:r><w:t>FOREIGNROW</w:t></w:r></w:p></w:tc></w:tr>`
+          + `</w:tbl></w:body></w:document>`,
+        'text/xml',
+      ) as unknown as Document;
+
+      const targeted = new Set(['7', '8']);
+      const selectsTargeted: RevisionFilter = (el) => {
+        const id = el.getAttributeNS(W_NS, 'id') ?? el.getAttribute('w:id');
+        return id !== null && targeted.has(id);
+      };
+
+      const result = rejectChanges(doc, { filter: selectsTargeted });
+      const xml = serialize(doc);
+
+      // Only the targeted marker is counted — the foreign one was never attempted.
+      expect(result.unresolvedRowRevisions).toBe(1);
+
+      // Both markers survive with their own authors and dates intact.
+      expect(xml).toContain('w:id="7"');
+      expect(xml).toContain('w:author="Target"');
+      expect(xml).toContain('w:id="99"');
+      expect(xml).toContain('w:author="Foreign"');
+      expect(xml).toContain('w:date="2025-06-01T00:00:00Z"');
+
+      // The targeted property change was reverted; the foreign row is unchanged.
+      expect(xml).toContain('w:trHeight');
+      expect(xml).not.toContain('trPrChange');
+      expect(rowCount(doc)).toBe(2);
+      expect(xml).toContain('TARGETROW');
+      expect(xml).toContain('FOREIGNROW');
+    },
+  );
 });

--- a/packages/docx-mcp/docs/tool-reference.generated.md
+++ b/packages/docx-mcp/docs/tool-reference.generated.md
@@ -235,7 +235,7 @@ Insert a tracked DOCX section break after a stable direct-body paragraph. The ne
 
 ## `accept_changes`
 
-Accept all tracked changes in the document body, producing a clean document with no revision markup. Returns acceptance stats.
+Accept every tracked change in the document body that the engine can resolve. Revision records it cannot resolve (currently row-level table revisions) are preserved and reported as unresolvedRowRevisions rather than silently stripped. Returns acceptance stats.
 
 - readOnly: `false`
 - destructive: `true`

--- a/packages/docx-mcp/src/tool_catalog.ts
+++ b/packages/docx-mcp/src/tool_catalog.ts
@@ -486,7 +486,7 @@ export const SAFE_DOCX_TOOL_CATALOG = [
   {
     name: 'accept_changes',
     surface: 'internal',
-    description: 'Accept all tracked changes in the document body, producing a clean document with no revision markup. Returns acceptance stats.',
+    description: 'Accept every tracked change in the document body that the engine can resolve. Revision records it cannot resolve (currently row-level table revisions) are preserved and reported as unresolvedRowRevisions rather than silently stripped. Returns acceptance stats.',
     input: z.object({
       ...FILE_FIELD,
     }),

--- a/packages/docx-mcp/src/tools/guard_row_level_revision_resolution.test.ts
+++ b/packages/docx-mcp/src/tools/guard_row_level_revision_resolution.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { parseXml, serializeXml } from '@usejunior/docx-core';
+
+import { acceptChanges as acceptChangesTool } from './accept_changes.js';
+import { type DocxSession } from '../session/manager.js';
+import { makeDocxWithDocumentXml } from '../testing/docx_test_utils.js';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import {
+  assertSuccess,
+  registerCleanup,
+  createTestSessionManager,
+  createTrackedTempDir,
+} from '../testing/session-test-utils.js';
+
+const TEST_FEATURE = 'guard-row-level-revision-resolution';
+const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+function serializeDoc(session: DocxSession): string {
+  const documentXml = (session.doc as unknown as { documentXml: Document }).documentXml;
+  return serializeXml(documentXml);
+}
+
+async function writeTestDocx(dir: string, name: string, bodyXml: string): Promise<string> {
+  const docXml =
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>`
+    + `<w:document xmlns:w="${W_NS}"><w:body>${bodyXml}</w:body></w:document>`;
+  const buf = await makeDocxWithDocumentXml(docXml);
+  const filePath = path.join(dir, name);
+  await fs.writeFile(filePath, new Uint8Array(buf));
+  return filePath;
+}
+
+describe('Traceability: row-level revision guard (MCP surface)', () => {
+  const test = testAllure.epic('Document Editing').withLabels({ feature: TEST_FEATURE });
+  registerCleanup();
+
+  test.openspec('[SDX-ROWREV-MCP-01] accept_changes reports unresolved row revisions instead of claiming a clean document')(
+    'a row marked deleted survives the tool call, and the response says so',
+    async ({ when, then, attachPrettyJson }: AllureBddContext) => {
+      const mgr = createTestSessionManager();
+      const dir = await createTrackedTempDir();
+
+      // A row marked DELETED plus an ordinary content insertion. The insertion
+      // proves the tool still does its job; the row marker proves it stops
+      // short of claiming a clean document.
+      const bodyXml =
+        `<w:tbl><w:tr><w:trPr>`
+        + `<w:del w:id="7" w:author="Reviewer" w:date="2026-01-01T00:00:00Z"/>`
+        + `</w:trPr><w:tc><w:p><w:r><w:t>ROWTEXT</w:t></w:r></w:p></w:tc></w:tr></w:tbl>`
+        + `<w:p><w:ins w:id="1" w:author="Reviewer" w:date="2026-01-01T00:00:00Z">`
+        + `<w:r><w:t>new text</w:t></w:r></w:ins></w:p>`;
+      const filePath = await writeTestDocx(dir, 'row-revision.docx', bodyXml);
+      await attachPrettyJson('input-body-xml', bodyXml);
+
+      const result = await when('Call accept_changes on a document with a row-level revision', () =>
+        acceptChangesTool(mgr, { file_path: filePath }),
+      );
+      assertSuccess(result, 'accept_changes');
+      await attachPrettyJson('result', result);
+
+      await then('The response reports the unresolved row revision', () => {
+        expect(result.unresolvedRowRevisions).toBe(1);
+      });
+
+      await then('The row marker and its row survive in the document', async () => {
+        const session = (await mgr.getSessionByFilePath(filePath)) as DocxSession;
+        const dom = parseXml(serializeDoc(session));
+
+        const rows = dom.getElementsByTagNameNS(W_NS, 'tr');
+        expect(rows.length).toBe(1);
+
+        const dels = dom.getElementsByTagNameNS(W_NS, 'del');
+        let rowMarker: Element | null = null;
+        for (let i = 0; i < dels.length; i++) {
+          const parent = dels.item(i)!.parentNode as Element | null;
+          if (parent && parent.namespaceURI === W_NS && parent.localName === 'trPr') {
+            rowMarker = dels.item(i)!;
+          }
+        }
+        expect(rowMarker).not.toBeNull();
+        expect(rowMarker!.getAttributeNS(W_NS, 'id') ?? rowMarker!.getAttribute('w:id')).toBe('7');
+      });
+
+      await then('Ordinary content revisions were still accepted', async () => {
+        const session = (await mgr.getSessionByFilePath(filePath)) as DocxSession;
+        const dom = parseXml(serializeDoc(session));
+
+        // The inserted run survives unwrapped, and no w:ins wrapper is left.
+        // (Asserting on w:id is not safe here: opening a session mints _bk_*
+        // bookmarks that reuse low w:id values.)
+        expect(serializeDoc(session)).toContain('new text');
+        expect(dom.getElementsByTagNameNS(W_NS, 'ins').length).toBe(0);
+        expect(result.insertionsAccepted).toBeGreaterThanOrEqual(1);
+      });
+    },
+  );
+
+  // The MODIFIED `Accept Tracked Changes Tool` requirement carries three
+  // pre-existing scenarios. They are re-verified here against the new
+  // preserve-and-report behavior: a document with no row-level markers must
+  // still come out clean, well-formed, and non-mutating.
+
+  test.openspec('accept_changes produces clean document body with no revision markup')(
+    'a document without row-level markers still yields a body with no revision markup',
+    async ({ when, then }: AllureBddContext) => {
+      const mgr = createTestSessionManager();
+      const dir = await createTrackedTempDir();
+
+      const bodyXml =
+        `<w:p><w:ins w:id="60" w:author="A"><w:r><w:t>ins</w:t></w:r></w:ins>`
+        + `<w:del w:id="61" w:author="A"><w:r><w:delText>del</w:delText></w:r></w:del></w:p>`;
+      const filePath = await writeTestDocx(dir, 'clean.docx', bodyXml);
+
+      const result = await when('Call accept_changes', () =>
+        acceptChangesTool(mgr, { file_path: filePath }),
+      );
+      assertSuccess(result, 'accept_changes');
+
+      await then('No revision markup remains and nothing is reported unresolved', async () => {
+        const session = (await mgr.getSessionByFilePath(filePath)) as DocxSession;
+        const dom = parseXml(serializeDoc(session));
+        for (const local of ['ins', 'del', 'delText', 'trPrChange', 'rPrChange', 'pPrChange']) {
+          expect(dom.getElementsByTagNameNS(W_NS, local).length).toBe(0);
+        }
+        expect(result.unresolvedRowRevisions).toBe(0);
+
+        // Inserted text survives unwrapped; deleted text is gone.
+        const texts: string[] = [];
+        const tEls = dom.getElementsByTagNameNS(W_NS, 't');
+        for (let i = 0; i < tEls.length; i++) texts.push(tEls[i]!.textContent ?? '');
+        expect(texts.join('')).toBe('ins');
+      });
+    },
+  );
+
+  test.openspec('accepted document opens cleanly in Microsoft Word')(
+    'output stays well-formed with a preserved row marker present (well-formed XML proxy)',
+    async ({ when, then }: AllureBddContext) => {
+      const mgr = createTestSessionManager();
+      const dir = await createTrackedTempDir();
+
+      const bodyXml =
+        `<w:tbl><w:tr><w:trPr>`
+        + `<w:del w:id="7" w:author="Reviewer" w:date="2026-01-01T00:00:00Z"/>`
+        + `</w:trPr><w:tc><w:p><w:r><w:t>ROWTEXT</w:t></w:r></w:p></w:tc></w:tr></w:tbl>`
+        + `<w:p><w:r><w:t>body</w:t></w:r></w:p>`;
+      const filePath = await writeTestDocx(dir, 'wellformed-row.docx', bodyXml);
+
+      const result = await when('Call accept_changes', () =>
+        acceptChangesTool(mgr, { file_path: filePath }),
+      );
+      assertSuccess(result, 'accept_changes');
+
+      await then('Output parses and the preserved marker sits in valid trPr position', async () => {
+        const session = (await mgr.getSessionByFilePath(filePath)) as DocxSession;
+        const dom = parseXml(serializeDoc(session));
+        expect(dom).toBeTruthy();
+
+        // The marker must remain a child of w:trPr — a stray w:del elsewhere
+        // in the row would be schema-invalid and is exactly what Word rejects.
+        const dels = dom.getElementsByTagNameNS(W_NS, 'del');
+        expect(dels.length).toBe(1);
+        const parent = dels.item(0)!.parentNode as Element;
+        expect(parent.localName).toBe('trPr');
+      });
+    },
+  );
+
+  test.openspec('original document is not mutated')(
+    'the source file on disk is untouched when a row marker is preserved',
+    async ({ when, then }: AllureBddContext) => {
+      const mgr = createTestSessionManager();
+      const dir = await createTrackedTempDir();
+
+      const bodyXml =
+        `<w:tbl><w:tr><w:trPr>`
+        + `<w:del w:id="7" w:author="Reviewer" w:date="2026-01-01T00:00:00Z"/>`
+        + `</w:trPr><w:tc><w:p><w:r><w:t>ROWTEXT</w:t></w:r></w:p></w:tc></w:tr></w:tbl>`;
+      const filePath = await writeTestDocx(dir, 'immutable.docx', bodyXml);
+      const before = await fs.readFile(filePath);
+
+      const result = await when('Call accept_changes', () =>
+        acceptChangesTool(mgr, { file_path: filePath }),
+      );
+      assertSuccess(result, 'accept_changes');
+
+      await then('The bytes on disk are unchanged', async () => {
+        const after = await fs.readFile(filePath);
+        expect(Buffer.compare(before, after)).toBe(0);
+      });
+    },
+  );
+});

--- a/packages/docx-mcp/src/tools/guard_row_level_revision_resolution.test.ts
+++ b/packages/docx-mcp/src/tools/guard_row_level_revision_resolution.test.ts
@@ -99,8 +99,9 @@ describe('Traceability: row-level revision guard (MCP surface)', () => {
 
   // The MODIFIED `Accept Tracked Changes Tool` requirement carries three
   // pre-existing scenarios. They are re-verified here against the new
-  // preserve-and-report behavior: a document with no row-level markers must
-  // still come out clean, well-formed, and non-mutating.
+  // preserve-and-report behavior, each with a fixture that actually matches
+  // what the scenario claims — resolvable-only input where the scenario is
+  // about a clean result, not a row-marker fixture standing in for one.
 
   test.openspec('accept_changes produces clean document body with no revision markup')(
     'a document without row-level markers still yields a body with no revision markup',
@@ -136,7 +137,46 @@ describe('Traceability: row-level revision guard (MCP surface)', () => {
   );
 
   test.openspec('accepted document opens cleanly in Microsoft Word')(
-    'output stays well-formed with a preserved row marker present (well-formed XML proxy)',
+    'resolvable-only input leaves no revision markup at all (well-formed XML proxy)',
+    async ({ when, then }: AllureBddContext) => {
+      const mgr = createTestSessionManager();
+      const dir = await createTrackedTempDir();
+
+      // This scenario is about a document Word can open with an EMPTY review
+      // pane, so the fixture must contain only resolvable revisions. A
+      // row-level marker would legitimately survive and is covered by
+      // [SDX-ROWREV-MCP-02] instead.
+      const bodyXml =
+        `<w:p>`
+        + `<w:ins w:id="60" w:author="A"><w:r><w:t>ins</w:t></w:r></w:ins>`
+        + `<w:del w:id="61" w:author="A"><w:r><w:delText>del</w:delText></w:r></w:del></w:p>`
+        + `<w:p><w:pPr><w:pPrChange w:id="62" w:author="A"><w:pPr/></w:pPrChange></w:pPr>`
+        + `<w:r><w:t>para</w:t></w:r></w:p>`;
+      const filePath = await writeTestDocx(dir, 'resolvable-only.docx', bodyXml);
+
+      const result = await when('Call accept_changes', () =>
+        acceptChangesTool(mgr, { file_path: filePath }),
+      );
+      assertSuccess(result, 'accept_changes');
+
+      await then('Output parses and holds no revision markup for the review pane to show', async () => {
+        const session = (await mgr.getSessionByFilePath(filePath)) as DocxSession;
+        const dom = parseXml(serializeDoc(session));
+        expect(dom).toBeTruthy();
+
+        for (const local of [
+          'ins', 'del', 'delText', 'moveFrom', 'moveTo',
+          'rPrChange', 'pPrChange', 'sectPrChange', 'tblPrChange', 'trPrChange', 'tcPrChange',
+        ]) {
+          expect(dom.getElementsByTagNameNS(W_NS, local).length).toBe(0);
+        }
+        expect(result.unresolvedRowRevisions).toBe(0);
+      });
+    },
+  );
+
+  test.openspec('[SDX-ROWREV-MCP-02] a document holding unresolved row revisions stays structurally valid')(
+    'the preserved marker stays in the only position the schema admits',
     async ({ when, then }: AllureBddContext) => {
       const mgr = createTestSessionManager();
       const dir = await createTrackedTempDir();
@@ -146,24 +186,23 @@ describe('Traceability: row-level revision guard (MCP surface)', () => {
         + `<w:del w:id="7" w:author="Reviewer" w:date="2026-01-01T00:00:00Z"/>`
         + `</w:trPr><w:tc><w:p><w:r><w:t>ROWTEXT</w:t></w:r></w:p></w:tc></w:tr></w:tbl>`
         + `<w:p><w:r><w:t>body</w:t></w:r></w:p>`;
-      const filePath = await writeTestDocx(dir, 'wellformed-row.docx', bodyXml);
+      const filePath = await writeTestDocx(dir, 'unresolved-structural.docx', bodyXml);
 
       const result = await when('Call accept_changes', () =>
         acceptChangesTool(mgr, { file_path: filePath }),
       );
       assertSuccess(result, 'accept_changes');
 
-      await then('Output parses and the preserved marker sits in valid trPr position', async () => {
+      await then('The marker survives as a w:trPr child and the output is well-formed', async () => {
         const session = (await mgr.getSessionByFilePath(filePath)) as DocxSession;
         const dom = parseXml(serializeDoc(session));
         expect(dom).toBeTruthy();
 
-        // The marker must remain a child of w:trPr — a stray w:del elsewhere
-        // in the row would be schema-invalid and is exactly what Word rejects.
+        // A stray w:del anywhere else in the row would be schema-invalid.
         const dels = dom.getElementsByTagNameNS(W_NS, 'del');
         expect(dels.length).toBe(1);
-        const parent = dels.item(0)!.parentNode as Element;
-        expect(parent.localName).toBe('trPr');
+        expect((dels.item(0)!.parentNode as Element).localName).toBe('trPr');
+        expect(result.unresolvedRowRevisions).toBe(1);
       });
     },
   );


### PR DESCRIPTION
## What

`acceptChanges` and `rejectChanges` swept revision wrappers by local name only, with no check on the parent element. Row-level revision markers live at `w:tr > w:trPr > w:del` and `w:tr > w:trPr > w:ins` and describe the **row** rather than wrapping content, so both sweeps matched them: the marker was removed and the `w:tr` it described was left behind.

This preserves the marker in the two directions the engine cannot resolve and reports the count. It does **not** implement the row semantics — see *Out of scope*.

## Why it mattered

The marker carries `w:id`, `w:author` and `w:date`. Destroying it left no residual record that the row had ever been tracked, so nothing downstream could detect the divergence. And the marker was counted as a resolved revision:

```
acceptChanges on a row marked DELETED
  result: {"deletionsAccepted":1, ...}
  rows remaining: 2        <- the row Word removes survives
  trPr marker survives: false
```

A caller checking the return value was told the operation succeeded while holding a document that does not match what a word processor projects.

The repository already knew. `cli/conformance-adapter.ts` classifies accept-over-`trPr>del` and reject-over-`trPr>ins` as `supported: false`, and `[XIMPL-08]` pins that. The honesty stopped at the conformance harness — `DocxDocument` and the `accept_changes` MCP tool called the primitives unconditionally.

## Approach

Preserve-and-report, following the convention already applied to other unresolved advanced revision records (`ADV-UNRESOLVED-RECORDS-01`, `ADV-TOPOLOGY-PRESERVATION-01`): a record left in place is a visible gap a caller can detect; removing it while keeping the content is silent divergence.

Only the two genuinely unresolvable directions are guarded. Accepting a `trPr>ins` and rejecting a `trPr>del` already produce the correct document — keep the row, drop the marker — so those paths are untouched.

- `AcceptChangesResult` / `RejectChangesResult` gain `unresolvedRowRevisions`, aggregated across body and side stories. It is deliberately separate from the resolved counters, and `hasAcceptedChanges` / `hasRejectedChanges` do not treat a preserved marker as a change.
- Rejecting a `w:trPrChange` restores row properties by replacing the whole `w:trPr`; that replacement now carries surviving markers across (see below).

## Peer review (Codex) — one real bug caught

**Phase-ordering leak (P1).** A `w:trPr` can hold both a row marker and a `w:trPrChange`. Phase C preserved the marker, then Phase F replaced the entire `w:trPr` with the snapshot and destroyed it — while `unresolvedRowRevisions` still reported it. Reproduced, then fixed:

```
before: reject ins+trPrChange -> {"unresolvedRowRevisions":1}, w:ins in trPr: 0, w:id="7" absent
after:  same input           -> {"unresolvedRowRevisions":1}, w:ins in trPr: 1, attributes intact
```

This also protects a **foreign** marker during a selective reject, which the byte-untouched invariant (#125) requires. The accept side needed no guard — Phase D removes the change record without replacing its parent.

**MCP contract overpromised (P1/P2).** The `mcp-server` requirement, `tool_catalog.ts`, and the generated tool reference all said `accept_changes` produces "a clean document with no revision markup" — no longer true. Fixed via a MODIFIED requirement delta plus a regenerated tool reference.

**Source compatibility (P2).** `unresolvedRowRevisions` is required, not optional, on two exported types. Runtime-additive, but a source-level break for external TypeScript that *constructs* or mocks them. Documented in the proposal with the reasoning for keeping it required.

Codex also confirmed the two load-bearing assumptions against the vendored strict and transitional schemas: `CT_TrPr` admits only `ins`/`del`/`trPrChange` as revision children, paragraph-mark markers live under `pPr > rPr`, cell topology uses distinct `cellIns`/`cellDel` names, and nested tables do not change the direct-parent test.

## Verification

Red/green confirmed rather than assumed. With the source edits stashed, the four original tests fail on `expected null not to be null` (marker stripped) and `expected undefined to be +0` (no counter). The two `trPrChange` tests were separately verified red against the un-fixed Phase F.

| Gate | Result |
|---|---|
| `npm run build` | pass |
| `npm run test:run` | pass |
| `npm run lint:workspaces` | pass |
| `npm run check:spec-coverage` | pass — 6/6 primitives + 4/4 mcp-server scenarios mapped |
| `check:tool-docs` | pass |
| `check:conformance-citations` / `-doc` | pass |
| `check:allure-labels` / `-filenames` / `-quality` | pass |
| `openspec validate --strict` | valid |

## Out of scope

Resolving row revisions semantically (accept-deletes-the-row, reject-removes-the-inserted-row). That needs an oracle pass over Word's real projection — `w:vMerge` chains and cells carrying their own content revisions have to be settled first — and it overlaps #764, which owns structural table changes and lists accept/reject round trips in its scope. No Word or LibreOffice oracle was run here, so application-specific normalization is unverified; this change makes the gap visible instead of guessing.

Extending `extract_revisions` to report row and cell topology, so a caller can inspect a document *before* accepting, is also left out. Today the counter reports the gap after the fact.

## Provenance

Surfaced while triaging recurring public support signals for tracked-change handling, then independently reproduced against safe-docx. No fixture derives from any external document.

Ref #845
