### PR TITLE
fix(docx-render-verifier): bind text across adjacent revision boundaries

### DIFF
--- a/packages/docx-render-verifier/README.md
+++ b/packages/docx-render-verifier/README.md
@@ -20,7 +20,22 @@ budget for body-story fields. The caller's logical projection must then be
 covered by the remaining tokens, and any leftover token fails. Because
 reservation is maximal, repeated header vocabulary can never substitute for
 missing logical content, and duplicated or hallucinated rendered text is
-never absorbed. Reading order is deliberately outside this automated verdict:
+never absorbed.
+
+Adjacent revision junctions get one narrow whitespace tolerance. LibreOffice
+and `pdftotext` do not expose a stable whitespace-delimited token boundary
+between neighbouring deletion and insertion spans, so the extracted PDF may
+render `OldNew` where the projection has `Old New`, or the reverse. Where the
+emitted tracked OOXML proves a visible deletion-family span and a visible
+insertion-family span meet with no whitespace between them, the binding may
+treat whitespace at exactly that junction as optional — at most one merge or
+split per declared junction, and the substituted tokens must balance the
+junction's own character content exactly. Ordinary run splits, same-family
+adjacency, dropped or duplicated words, and punctuation changes still fail.
+The evidence reports `declaredRevisionBoundaryCount` and
+`revisionBoundaryNormalizationCount` separately from pagination reservation.
+
+Reading order is deliberately outside this automated verdict:
 the emitted review PNGs support optional human placement review, and no
 automated placement comparison is performed. The structured outcome is
 reported in `verdict.textBinding` separately from colour visibility.

--- a/packages/docx-render-verifier/fixtures/adjacent-revision-alnum.xml
+++ b/packages/docx-render-verifier/fixtures/adjacent-revision-alnum.xml
@@ -1,0 +1,1 @@
+<w:p><w:r><w:t xml:space="preserve">Synthetic clause prefix </w:t></w:r><w:del w:id="1"><w:r><w:delText>OldTerm</w:delText></w:r></w:del><w:ins w:id="2"><w:r><w:t>NewTerm</w:t></w:r></w:ins><w:r><w:t xml:space="preserve"> synthetic suffix.</w:t></w:r></w:p>

--- a/packages/docx-render-verifier/fixtures/adjacent-revision-multiword-deletion.xml
+++ b/packages/docx-render-verifier/fixtures/adjacent-revision-multiword-deletion.xml
@@ -1,0 +1,1 @@
+<w:p><w:r><w:t xml:space="preserve">Synthetic instrument label </w:t></w:r><w:del w:id="1"><w:r><w:delText>Certificate of Formation</w:delText></w:r></w:del><w:ins w:id="2"><w:r><w:t>Charter</w:t></w:r></w:ins><w:r><w:t xml:space="preserve"> synthetic closing.</w:t></w:r></w:p>

--- a/packages/docx-render-verifier/fixtures/adjacent-revision-multiword-insertion.xml
+++ b/packages/docx-render-verifier/fixtures/adjacent-revision-multiword-insertion.xml
@@ -1,0 +1,1 @@
+<w:p><w:r><w:t xml:space="preserve">Synthetic venue label </w:t></w:r><w:del w:id="1"><w:r><w:delText>StateAlpha</w:delText></w:r></w:del><w:ins w:id="2"><w:r><w:t>State Beta</w:t></w:r></w:ins><w:r><w:t xml:space="preserve"> synthetic tail.</w:t></w:r></w:p>

--- a/packages/docx-render-verifier/fixtures/adjacent-revision-punctuation.xml
+++ b/packages/docx-render-verifier/fixtures/adjacent-revision-punctuation.xml
@@ -1,0 +1,1 @@
+<w:p><w:r><w:t xml:space="preserve">Synthetic filing reference </w:t></w:r><w:del w:id="1"><w:r><w:delText>Formation</w:delText></w:r></w:del><w:ins w:id="2"><w:r><w:t>Charter</w:t></w:r></w:ins><w:r><w:t xml:space="preserve">, synthetic continuation.</w:t></w:r></w:p>

--- a/packages/docx-render-verifier/fixtures/index.json
+++ b/packages/docx-render-verifier/fixtures/index.json
@@ -16,6 +16,11 @@
     { "id": "multi-page-body", "path": "multi-page-body.xml", "purpose": "explicit page-break body spanning two rendered pages" },
     { "id": "repeated-header", "path": "repeated-header.xml", "purpose": "header story repeated once per rendered page" },
     { "id": "page-field-footer", "path": "page-field-footer.xml", "purpose": "footer story with a PAGE field rendering per-page numerals" },
-    { "id": "reordered-text-box", "path": "reordered-text-box.xml", "purpose": "anchored text box emitted out of logical order by pdftotext" }
+    { "id": "reordered-text-box", "path": "reordered-text-box.xml", "purpose": "anchored text box emitted out of logical order by pdftotext" },
+    { "id": "adjacent-revision-alnum", "path": "adjacent-revision-alnum.xml", "purpose": "adjacent deletion/insertion junction with alphanumeric text on both sides" },
+    { "id": "adjacent-revision-punctuation", "path": "adjacent-revision-punctuation.xml", "purpose": "adjacent deletion/insertion junction with punctuation immediately after the insertion" },
+    { "id": "adjacent-revision-multiword-deletion", "path": "adjacent-revision-multiword-deletion.xml", "purpose": "multiword deletion adjacent to a single-word insertion" },
+    { "id": "adjacent-revision-multiword-insertion", "path": "adjacent-revision-multiword-insertion.xml", "purpose": "single-word deletion adjacent to a multiword insertion" },
+    { "id": "ordinary-run-split", "path": "ordinary-run-split.xml", "purpose": "unchanged text split across ordinary runs as a no-boundary negative control" }
   ]
 }

--- a/packages/docx-render-verifier/fixtures/ordinary-run-split.xml
+++ b/packages/docx-render-verifier/fixtures/ordinary-run-split.xml
@@ -1,0 +1,1 @@
+<w:p><w:r><w:t xml:space="preserve">Synthetic unchanged frag</w:t></w:r><w:r><w:t xml:space="preserve">mented clause </w:t></w:r><w:ins w:id="1"><w:r><w:t>inserted-alpha</w:t></w:r></w:ins><w:r><w:t xml:space="preserve"> and </w:t></w:r><w:del w:id="2"><w:r><w:delText>removed-beta</w:delText></w:r></w:del><w:r><w:t xml:space="preserve"> synthetic tail.</w:t></w:r></w:p>

--- a/packages/docx-render-verifier/src/render.test.ts
+++ b/packages/docx-render-verifier/src/render.test.ts
@@ -732,6 +732,62 @@ describe('renderer verifier', () => {
     expect(result.textBinding).toMatchObject({ matched: true, pageCount: 2, declaredRevisionBoundaryCount: 1, revisionBoundaryNormalizationCount: 1 });
   });
 
+  itAllure('declares no boundary across a footnote reference mark between opposite revision spans', async () => {
+    const root = path.join(os.tmpdir(), `render-footnote-separator-${Date.now()}`);
+    const source = path.join(root, 'tracked.docx');
+    await mkdir(root, { recursive: true });
+    const body = '<w:p><w:r><w:t xml:space="preserve">Prefix </w:t></w:r><w:del w:id="1"><w:r><w:delText>Old</w:delText></w:r></w:del><w:r><w:footnoteReference w:id="2"/></w:r><w:ins w:id="3"><w:r><w:t>New</w:t></w:r></w:ins><w:r><w:t xml:space="preserve"> suffix.</w:t></w:r></w:p>';
+    await paginatedFixture(source, { body });
+    const result = await verifyRenderedMarkup({
+      trackedDocxPath: source, expectedMarkupText: 'Prefix Old New suffix.', outputDir: path.join(root, 'out'),
+      tools: fakeTools('Prefix OldNew suffix.'), configuredPixelFloor: 2,
+    });
+    expect(result).toMatchObject({ status: 'fail', markupTextMatchesPdf: false });
+    expect(result.textBinding).toMatchObject({ declaredRevisionBoundaryCount: 0, revisionBoundaryNormalizationCount: 0 });
+  });
+
+  itAllure('declares no boundary across an inline drawing between opposite revision spans', async () => {
+    const root = path.join(os.tmpdir(), `render-drawing-separator-${Date.now()}`);
+    const source = path.join(root, 'tracked.docx');
+    await mkdir(root, { recursive: true });
+    const body = '<w:p><w:r><w:t xml:space="preserve">Prefix </w:t></w:r><w:del w:id="1"><w:r><w:delText>Old</w:delText></w:r></w:del><w:r><w:drawing/></w:r><w:ins w:id="2"><w:r><w:t>New</w:t></w:r></w:ins><w:r><w:t xml:space="preserve"> suffix.</w:t></w:r></w:p>';
+    await paginatedFixture(source, { body });
+    const result = await verifyRenderedMarkup({
+      trackedDocxPath: source, expectedMarkupText: 'Prefix Old New suffix.', outputDir: path.join(root, 'out'),
+      tools: fakeTools('Prefix OldNew suffix.'), configuredPixelFloor: 2,
+    });
+    expect(result).toMatchObject({ status: 'fail', markupTextMatchesPdf: false });
+    expect(result.textBinding).toMatchObject({ declaredRevisionBoundaryCount: 0, revisionBoundaryNormalizationCount: 0 });
+  });
+
+  itAllure('declares no boundary across a resultless field or symbol between opposite revision spans', async () => {
+    const root = path.join(os.tmpdir(), `render-field-separator-${Date.now()}`);
+    const source = path.join(root, 'tracked.docx');
+    await mkdir(root, { recursive: true });
+    const body = '<w:p><w:r><w:t xml:space="preserve">Prefix </w:t></w:r><w:del w:id="1"><w:r><w:delText>Old</w:delText></w:r></w:del><w:fldSimple w:instr=" DATE "/><w:ins w:id="2"><w:r><w:t>New</w:t></w:r></w:ins><w:r><w:t xml:space="preserve"> and </w:t></w:r><w:del w:id="3"><w:r><w:delText>Left</w:delText></w:r></w:del><w:r><w:sym w:font="Wingdings" w:char="F0E0"/></w:r><w:ins w:id="4"><w:r><w:t>Right</w:t></w:r></w:ins><w:r><w:t xml:space="preserve"> suffix.</w:t></w:r></w:p>';
+    await paginatedFixture(source, { body });
+    const result = await verifyRenderedMarkup({
+      trackedDocxPath: source, expectedMarkupText: 'Prefix Old New and Left Right suffix.', outputDir: path.join(root, 'out'),
+      tools: fakeTools('Prefix OldNew and LeftRight suffix.'), configuredPixelFloor: 2,
+    });
+    expect(result).toMatchObject({ status: 'fail', markupTextMatchesPdf: false });
+    expect(result.textBinding).toMatchObject({ declaredRevisionBoundaryCount: 0, revisionBoundaryNormalizationCount: 0 });
+  });
+
+  itAllure('still declares a boundary across genuinely non-rendering range markers between opposite revision spans', async () => {
+    const root = path.join(os.tmpdir(), `render-marker-separator-${Date.now()}`);
+    const source = path.join(root, 'tracked.docx');
+    await mkdir(root, { recursive: true });
+    const body = '<w:p><w:r><w:t xml:space="preserve">Prefix </w:t></w:r><w:del w:id="1"><w:r><w:delText>Old</w:delText></w:r></w:del><w:bookmarkStart w:id="9" w:name="syntheticAnchor"/><w:proofErr w:type="spellStart"/><w:ins w:id="2"><w:r><w:t>New</w:t></w:r></w:ins><w:bookmarkEnd w:id="9"/><w:r><w:t xml:space="preserve"> suffix.</w:t></w:r></w:p>';
+    await paginatedFixture(source, { body });
+    const result = await verifyRenderedMarkup({
+      trackedDocxPath: source, expectedMarkupText: 'Prefix Old New suffix.', outputDir: path.join(root, 'out'),
+      tools: fakeTools('Prefix OldNew suffix.'), configuredPixelFloor: 2,
+    });
+    expect(result).toMatchObject({ status: 'pass', markupTextMatchesPdf: true });
+    expect(result.textBinding).toMatchObject({ matched: true, declaredRevisionBoundaryCount: 1, revisionBoundaryNormalizationCount: 1 });
+  });
+
   itAllure('does not declare junctions from pagination-owned header stories', async () => {
     const root = path.join(os.tmpdir(), `render-boundary-header-story-${Date.now()}`);
     const source = path.join(root, 'tracked.docx');

--- a/packages/docx-render-verifier/src/render.test.ts
+++ b/packages/docx-render-verifier/src/render.test.ts
@@ -1,11 +1,13 @@
+import { existsSync } from 'node:fs';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect } from 'vitest';
 import { itAllure } from '../../docx-core/src/testing/allure-test.js';
+import { buildDocxFromBodyXml } from '../../docx-core/src/testing/ooxml-fixtures.js';
 import JSZip from 'jszip';
-import { measurePixelBands, verifyRenderedMarkup } from './render.js';
+import { defaultRendererTools, measurePixelBands, verifyRenderedMarkup } from './render.js';
 import type { RendererTools } from './types.js';
 
 function fakeTools(markup = 'Visible markup text', profiles?: string[], hiddenDeletion = false, pageCount = 1): RendererTools {
@@ -92,6 +94,10 @@ async function paginatedFixture(pathname: string, parts: { body: string; header?
   }
   await writeFile(pathname, await zip.generateAsync({ type: 'nodebuffer' }));
 }
+
+const ALNUM_EXPECTED = 'Synthetic clause prefix OldTerm NewTerm synthetic suffix.';
+const ALNUM_JOINED_PDF = 'Synthetic clause prefix OldTermNewTerm synthetic suffix.';
+const ORDINARY_RUN_SPLIT_RENDERED = 'Synthetic unchanged fragmented clause inserted-alpha and removed-beta synthetic tail.';
 
 const MULTI_PAGE_EXPECTED = 'Synthetic first page opening text. inserted-alpha Synthetic second page closing text. removed-beta';
 const MULTI_PAGE_PDF = [
@@ -523,6 +529,224 @@ describe('renderer verifier', () => {
     expect(result).toMatchObject({ status: 'pass', markupTextMatchesPdf: true, revisionVisibility: 'visible' });
   });
 
+  itAllure('tolerates renderer-concatenated output at an OOXML-declared adjacent deletion/insertion junction', async () => {
+    const root = path.join(os.tmpdir(), `render-boundary-merge-${Date.now()}`);
+    const source = path.join(root, 'tracked.docx');
+    await mkdir(root, { recursive: true });
+    await paginatedFixture(source, { body: await fixtureFragment('adjacent-revision-alnum.xml') });
+    const result = await verifyRenderedMarkup({
+      trackedDocxPath: source, expectedMarkupText: ALNUM_EXPECTED, outputDir: path.join(root, 'out'),
+      tools: fakeTools(ALNUM_JOINED_PDF), configuredPixelFloor: 2,
+    });
+    expect(result).toMatchObject({ status: 'pass', markupTextMatchesPdf: true, revisionVisibility: 'visible' });
+    expect(result.textBinding).toMatchObject({ matched: true, declaredRevisionBoundaryCount: 1, revisionBoundaryNormalizationCount: 1 });
+  });
+
+  itAllure('binds separated renderer output at a declared junction without spending any normalization', async () => {
+    const root = path.join(os.tmpdir(), `render-boundary-separated-${Date.now()}`);
+    const source = path.join(root, 'tracked.docx');
+    await mkdir(root, { recursive: true });
+    await paginatedFixture(source, { body: await fixtureFragment('adjacent-revision-alnum.xml') });
+    const result = await verifyRenderedMarkup({
+      trackedDocxPath: source, expectedMarkupText: ALNUM_EXPECTED, outputDir: path.join(root, 'out'),
+      tools: fakeTools(ALNUM_EXPECTED), configuredPixelFloor: 2,
+    });
+    expect(result).toMatchObject({ status: 'pass', markupTextMatchesPdf: true });
+    expect(result.textBinding).toMatchObject({ matched: true, declaredRevisionBoundaryCount: 1, revisionBoundaryNormalizationCount: 0 });
+  });
+
+  itAllure('tolerates a renderer-created separator where the caller projection concatenates the junction', async () => {
+    const root = path.join(os.tmpdir(), `render-boundary-split-${Date.now()}`);
+    const source = path.join(root, 'tracked.docx');
+    await mkdir(root, { recursive: true });
+    await paginatedFixture(source, { body: await fixtureFragment('adjacent-revision-alnum.xml') });
+    const result = await verifyRenderedMarkup({
+      trackedDocxPath: source, expectedMarkupText: ALNUM_JOINED_PDF, outputDir: path.join(root, 'out'),
+      tools: fakeTools(ALNUM_EXPECTED), configuredPixelFloor: 2,
+    });
+    expect(result).toMatchObject({ status: 'pass', markupTextMatchesPdf: true });
+    expect(result.textBinding).toMatchObject({ matched: true, revisionBoundaryNormalizationCount: 1 });
+  });
+
+  itAllure('extends the junction tolerance through punctuation attached immediately after the insertion', async () => {
+    const root = path.join(os.tmpdir(), `render-boundary-punct-${Date.now()}`);
+    const source = path.join(root, 'tracked.docx');
+    await mkdir(root, { recursive: true });
+    await paginatedFixture(source, { body: await fixtureFragment('adjacent-revision-punctuation.xml') });
+    const result = await verifyRenderedMarkup({
+      trackedDocxPath: source, expectedMarkupText: 'Synthetic filing reference Formation Charter, synthetic continuation.', outputDir: path.join(root, 'out'),
+      tools: fakeTools('Synthetic filing reference FormationCharter, synthetic continuation.'), configuredPixelFloor: 2,
+    });
+    expect(result).toMatchObject({ status: 'pass', markupTextMatchesPdf: true });
+    expect(result.textBinding).toMatchObject({ matched: true, declaredRevisionBoundaryCount: 1, revisionBoundaryNormalizationCount: 1 });
+  });
+
+  itAllure('normalizes only the junction-adjacent word of a multiword deletion against a single-word insertion', async () => {
+    const root = path.join(os.tmpdir(), `render-boundary-multidel-${Date.now()}`);
+    const source = path.join(root, 'tracked.docx');
+    await mkdir(root, { recursive: true });
+    await paginatedFixture(source, { body: await fixtureFragment('adjacent-revision-multiword-deletion.xml') });
+    const result = await verifyRenderedMarkup({
+      trackedDocxPath: source, expectedMarkupText: 'Synthetic instrument label Certificate of Formation Charter synthetic closing.', outputDir: path.join(root, 'out'),
+      tools: fakeTools('Synthetic instrument label Certificate of FormationCharter synthetic closing.'), configuredPixelFloor: 2,
+    });
+    expect(result).toMatchObject({ status: 'pass', markupTextMatchesPdf: true });
+    expect(result.textBinding).toMatchObject({ matched: true, declaredRevisionBoundaryCount: 1, revisionBoundaryNormalizationCount: 1 });
+  });
+
+  itAllure('normalizes only the junction-adjacent word of a multiword insertion against a single-word deletion', async () => {
+    const root = path.join(os.tmpdir(), `render-boundary-multiins-${Date.now()}`);
+    const source = path.join(root, 'tracked.docx');
+    await mkdir(root, { recursive: true });
+    await paginatedFixture(source, { body: await fixtureFragment('adjacent-revision-multiword-insertion.xml') });
+    const result = await verifyRenderedMarkup({
+      trackedDocxPath: source, expectedMarkupText: 'Synthetic venue label StateAlpha State Beta synthetic tail.', outputDir: path.join(root, 'out'),
+      tools: fakeTools('Synthetic venue label StateAlphaState Beta synthetic tail.'), configuredPixelFloor: 2,
+    });
+    expect(result).toMatchObject({ status: 'pass', markupTextMatchesPdf: true });
+    expect(result.textBinding).toMatchObject({ matched: true, declaredRevisionBoundaryCount: 1, revisionBoundaryNormalizationCount: 1 });
+  });
+
+  itAllure('declares no optional boundary at an unchanged ordinary-run split', async () => {
+    const root = path.join(os.tmpdir(), `render-run-split-${Date.now()}`);
+    const source = path.join(root, 'tracked.docx');
+    await mkdir(root, { recursive: true });
+    await paginatedFixture(source, { body: await fixtureFragment('ordinary-run-split.xml') });
+    const result = await verifyRenderedMarkup({
+      trackedDocxPath: source, expectedMarkupText: 'Synthetic unchanged frag mented clause inserted-alpha and removed-beta synthetic tail.', outputDir: path.join(root, 'out'),
+      tools: fakeTools(ORDINARY_RUN_SPLIT_RENDERED), configuredPixelFloor: 2,
+    });
+    expect(result).toMatchObject({ status: 'fail', markupTextMatchesPdf: false });
+    expect(result.textBinding).toMatchObject({ declaredRevisionBoundaryCount: 0, revisionBoundaryNormalizationCount: 0 });
+    expect(result.textBinding?.missingTokenSample).toContain('frag');
+    expect(result.textBinding?.unexplainedTokenSample).toContain('fragmented');
+  });
+
+  itAllure('declares no optional boundary between adjacent same-family insertion wrappers', async () => {
+    const root = path.join(os.tmpdir(), `render-same-family-${Date.now()}`);
+    const source = path.join(root, 'tracked.docx');
+    await mkdir(root, { recursive: true });
+    const body = '<w:p><w:r><w:t xml:space="preserve">Synthetic opening </w:t></w:r><w:ins w:id="1"><w:r><w:t>AlphaOne</w:t></w:r></w:ins><w:ins w:id="2"><w:r><w:t>AlphaTwo</w:t></w:r></w:ins><w:r><w:t xml:space="preserve"> and </w:t></w:r><w:del w:id="3"><w:r><w:delText>removed-beta</w:delText></w:r></w:del><w:r><w:t xml:space="preserve"> tail.</w:t></w:r></w:p>';
+    await paginatedFixture(source, { body });
+    const result = await verifyRenderedMarkup({
+      trackedDocxPath: source, expectedMarkupText: 'Synthetic opening AlphaOne AlphaTwo and removed-beta tail.', outputDir: path.join(root, 'out'),
+      tools: fakeTools('Synthetic opening AlphaOneAlphaTwo and removed-beta tail.'), configuredPixelFloor: 2,
+    });
+    expect(result).toMatchObject({ status: 'fail', markupTextMatchesPdf: false });
+    expect(result.textBinding).toMatchObject({ declaredRevisionBoundaryCount: 0, revisionBoundaryNormalizationCount: 0 });
+  });
+
+  itAllure('still fails a junction render that drops the insertion word entirely', async () => {
+    const root = path.join(os.tmpdir(), `render-boundary-dropped-${Date.now()}`);
+    const source = path.join(root, 'tracked.docx');
+    await mkdir(root, { recursive: true });
+    await paginatedFixture(source, { body: await fixtureFragment('adjacent-revision-alnum.xml') });
+    const result = await verifyRenderedMarkup({
+      trackedDocxPath: source, expectedMarkupText: ALNUM_EXPECTED, outputDir: path.join(root, 'out'),
+      tools: fakeTools('Synthetic clause prefix OldTerm synthetic suffix.'), configuredPixelFloor: 2,
+    });
+    expect(result).toMatchObject({ status: 'fail', markupTextMatchesPdf: false });
+    expect(result.textBinding?.missingTokenSample).toContain('NewTerm');
+    expect(result.textBinding).toMatchObject({ revisionBoundaryNormalizationCount: 0 });
+  });
+
+  itAllure('still fails a junction render that duplicates the insertion word alongside the merge', async () => {
+    const root = path.join(os.tmpdir(), `render-boundary-duplicated-${Date.now()}`);
+    const source = path.join(root, 'tracked.docx');
+    await mkdir(root, { recursive: true });
+    await paginatedFixture(source, { body: await fixtureFragment('adjacent-revision-alnum.xml') });
+    const result = await verifyRenderedMarkup({
+      trackedDocxPath: source, expectedMarkupText: ALNUM_EXPECTED, outputDir: path.join(root, 'out'),
+      tools: fakeTools('Synthetic clause prefix OldTermNewTerm NewTerm synthetic suffix.'), configuredPixelFloor: 2,
+    });
+    expect(result).toMatchObject({ status: 'fail', markupTextMatchesPdf: false });
+    expect(result.textBinding?.unexplainedTokenSample).toContain('OldTermNewTerm');
+    expect(result.textBinding).toMatchObject({ revisionBoundaryNormalizationCount: 0 });
+  });
+
+  itAllure('still fails a punctuation change hidden inside a junction merge', async () => {
+    const root = path.join(os.tmpdir(), `render-boundary-punct-change-${Date.now()}`);
+    const source = path.join(root, 'tracked.docx');
+    await mkdir(root, { recursive: true });
+    await paginatedFixture(source, { body: await fixtureFragment('adjacent-revision-punctuation.xml') });
+    const result = await verifyRenderedMarkup({
+      trackedDocxPath: source, expectedMarkupText: 'Synthetic filing reference Formation Charter, synthetic continuation.', outputDir: path.join(root, 'out'),
+      tools: fakeTools('Synthetic filing reference FormationCharter. synthetic continuation.'), configuredPixelFloor: 2,
+    });
+    expect(result).toMatchObject({ status: 'fail', markupTextMatchesPdf: false });
+    expect(result.textBinding).toMatchObject({ revisionBoundaryNormalizationCount: 0 });
+  });
+
+  itAllure('spends at most one whitespace normalization per declared junction occurrence', async () => {
+    const root = path.join(os.tmpdir(), `render-boundary-budget-${Date.now()}`);
+    const source = path.join(root, 'tracked.docx');
+    await mkdir(root, { recursive: true });
+    await paginatedFixture(source, { body: await fixtureFragment('adjacent-revision-alnum.xml') });
+    const result = await verifyRenderedMarkup({
+      trackedDocxPath: source, expectedMarkupText: `${ALNUM_EXPECTED} OldTerm NewTerm`, outputDir: path.join(root, 'out'),
+      tools: fakeTools(`${ALNUM_JOINED_PDF} OldTermNewTerm`), configuredPixelFloor: 2,
+    });
+    expect(result).toMatchObject({ status: 'fail', markupTextMatchesPdf: false });
+    expect(result.textBinding).toMatchObject({ declaredRevisionBoundaryCount: 1, revisionBoundaryNormalizationCount: 1 });
+    expect(result.textBinding?.unexplainedTokenSample).toContain('OldTermNewTerm');
+  });
+
+  itAllure('keeps the junction tolerance from excusing an ordinary-run whitespace change elsewhere', async () => {
+    const root = path.join(os.tmpdir(), `render-boundary-elsewhere-${Date.now()}`);
+    const source = path.join(root, 'tracked.docx');
+    await mkdir(root, { recursive: true });
+    await paginatedFixture(source, { body: await fixtureFragment('adjacent-revision-alnum.xml') });
+    const result = await verifyRenderedMarkup({
+      trackedDocxPath: source, expectedMarkupText: ALNUM_EXPECTED, outputDir: path.join(root, 'out'),
+      tools: fakeTools('Syntheticclause prefix OldTermNewTerm synthetic suffix.'), configuredPixelFloor: 2,
+    });
+    expect(result).toMatchObject({ status: 'fail', markupTextMatchesPdf: false });
+    expect(result.textBinding?.missingTokenSample).toContain('Synthetic');
+    expect(result.textBinding?.unexplainedTokenSample).toContain('Syntheticclause');
+  });
+
+  itAllure('reports junction normalization separately from multi-page pagination reservation', async () => {
+    const root = path.join(os.tmpdir(), `render-boundary-multipage-${Date.now()}`);
+    const source = path.join(root, 'tracked.docx');
+    await mkdir(root, { recursive: true });
+    const body = `${await fixtureFragment('adjacent-revision-alnum.xml')}<w:p><w:r><w:br w:type="page"/></w:r></w:p><w:p><w:r><w:t>Synthetic second page closing text.</w:t></w:r></w:p>`;
+    await paginatedFixture(source, {
+      body,
+      header: await fixtureFragment('repeated-header.xml'),
+      footer: await fixtureFragment('page-field-footer.xml'),
+    });
+    const pdf = [
+      'Synthetic Neutral Draft Header',
+      ALNUM_JOINED_PDF,
+      'Page 1',
+      '\f',
+      'Synthetic Neutral Draft Header',
+      'Synthetic second page closing text.',
+      'Page 2',
+    ].join('\n');
+    const result = await verifyRenderedMarkup({
+      trackedDocxPath: source, expectedMarkupText: `${ALNUM_EXPECTED} Synthetic second page closing text.`, outputDir: path.join(root, 'out'),
+      tools: fakeTools(pdf, undefined, false, 2), configuredPixelFloor: 2,
+    });
+    expect(result).toMatchObject({ status: 'pass', markupTextMatchesPdf: true });
+    expect(result.textBinding).toMatchObject({ matched: true, pageCount: 2, declaredRevisionBoundaryCount: 1, revisionBoundaryNormalizationCount: 1 });
+  });
+
+  itAllure('does not declare junctions from pagination-owned header stories', async () => {
+    const root = path.join(os.tmpdir(), `render-boundary-header-story-${Date.now()}`);
+    const source = path.join(root, 'tracked.docx');
+    await mkdir(root, { recursive: true });
+    const junctionHeader = '<w:hdr><w:p><w:del w:id="7"><w:r><w:delText>HeadOld</w:delText></w:r></w:del><w:ins w:id="8"><w:r><w:t>HeadNew</w:t></w:r></w:ins></w:p></w:hdr>';
+    const body = 'Synthetic unchanged fragmented clause inserted-alpha and removed-beta synthetic tail.';
+    await paginatedFixture(source, { body: await fixtureFragment('ordinary-run-split.xml'), header: junctionHeader });
+    const result = await verifyRenderedMarkup({
+      trackedDocxPath: source, expectedMarkupText: body, outputDir: path.join(root, 'out'),
+      tools: fakeTools(body), configuredPixelFloor: 2,
+    });
+    expect(result).toMatchObject({ status: 'pass', markupTextMatchesPdf: true });
+    expect(result.textBinding).toMatchObject({ declaredRevisionBoundaryCount: 0, revisionBoundaryNormalizationCount: 0 });
+  });
+
   itAllure('falls back to strict zero-allowance binding when the rendered package is unreadable', async () => {
     const root = path.join(os.tmpdir(), `render-unreadable-${Date.now()}`);
     const source = path.join(root, 'tracked.docx');
@@ -536,4 +760,76 @@ describe('renderer verifier', () => {
     expect(result.textBinding).toMatchObject({ pageCount: 1 });
     expect(result.textBinding?.unexplainedTokenSample).toContain('Residue');
   });
+});
+
+// ── Real-LibreOffice boundary fixtures ──────────────────────────────────────
+// These tests exercise the shipped fixtures through an actual LibreOffice and
+// poppler toolchain when one is installed. CI has neither; the verifier's own
+// `resolve() -> null` discipline reports `not_run` there and each test accepts
+// exactly that outcome (and only that outcome) as a skip.
+
+const REAL_MACOS_SOFFICE = '/Applications/LibreOffice.app/Contents/MacOS/soffice';
+
+function realRendererTools(): RendererTools {
+  const base = defaultRendererTools();
+  return {
+    resolve: (name) => base.resolve(name) ?? (name === 'soffice' && existsSync(REAL_MACOS_SOFFICE) ? REAL_MACOS_SOFFICE : null),
+    run: (command, args, cwd) => base.run(command, args, cwd),
+  };
+}
+
+async function verifyRealBoundaryFixture(fixture: string, expectedMarkupText: string) {
+  const root = path.join(os.tmpdir(), `render-real-${fixture}-${Date.now()}`);
+  await mkdir(root, { recursive: true });
+  const source = path.join(root, 'tracked.docx');
+  await writeFile(source, await buildDocxFromBodyXml(await fixtureFragment(`${fixture}.xml`)));
+  return verifyRenderedMarkup({
+    trackedDocxPath: source,
+    expectedMarkupText,
+    outputDir: path.join(root, 'out'),
+    tools: realRendererTools(),
+    configuredPixelFloor: 2,
+  });
+}
+
+const REAL_RENDER_TIMEOUT_MS = 300_000;
+
+describe('renderer verifier real LibreOffice adjacent revision boundaries', () => {
+  itAllure('binds an independently derived projection across a real alphanumeric deletion/insertion junction', async () => {
+    const result = await verifyRealBoundaryFixture('adjacent-revision-alnum', ALNUM_EXPECTED);
+    if (result.status === 'not_run') { expect(result.reason).toContain('Missing renderer tool'); return; }
+    expect(result).toMatchObject({ status: 'pass', markupTextMatchesPdf: true, revisionVisibility: 'visible' });
+    expect(result.textBinding).toMatchObject({ matched: true, declaredRevisionBoundaryCount: 1 });
+  }, REAL_RENDER_TIMEOUT_MS);
+
+  itAllure('binds a real junction whose insertion is immediately followed by punctuation', async () => {
+    const result = await verifyRealBoundaryFixture('adjacent-revision-punctuation', 'Synthetic filing reference Formation Charter, synthetic continuation.');
+    if (result.status === 'not_run') { expect(result.reason).toContain('Missing renderer tool'); return; }
+    expect(result).toMatchObject({ status: 'pass', markupTextMatchesPdf: true });
+    expect(result.textBinding).toMatchObject({ matched: true, declaredRevisionBoundaryCount: 1 });
+  }, REAL_RENDER_TIMEOUT_MS);
+
+  itAllure('binds a real multiword deletion adjacent to a single-word insertion', async () => {
+    const result = await verifyRealBoundaryFixture('adjacent-revision-multiword-deletion', 'Synthetic instrument label Certificate of Formation Charter synthetic closing.');
+    if (result.status === 'not_run') { expect(result.reason).toContain('Missing renderer tool'); return; }
+    expect(result).toMatchObject({ status: 'pass', markupTextMatchesPdf: true });
+    expect(result.textBinding).toMatchObject({ matched: true, declaredRevisionBoundaryCount: 1 });
+  }, REAL_RENDER_TIMEOUT_MS);
+
+  itAllure('binds a real single-word deletion adjacent to a multiword insertion', async () => {
+    const result = await verifyRealBoundaryFixture('adjacent-revision-multiword-insertion', 'Synthetic venue label StateAlpha State Beta synthetic tail.');
+    if (result.status === 'not_run') { expect(result.reason).toContain('Missing renderer tool'); return; }
+    expect(result).toMatchObject({ status: 'pass', markupTextMatchesPdf: true });
+    expect(result.textBinding).toMatchObject({ matched: true, declaredRevisionBoundaryCount: 1 });
+  }, REAL_RENDER_TIMEOUT_MS);
+
+  itAllure('keeps ordinary-run splits strict in a real render while declaring no optional boundary', async () => {
+    const correct = await verifyRealBoundaryFixture('ordinary-run-split', ORDINARY_RUN_SPLIT_RENDERED);
+    if (correct.status === 'not_run') { expect(correct.reason).toContain('Missing renderer tool'); return; }
+    expect(correct).toMatchObject({ status: 'pass', markupTextMatchesPdf: true });
+    expect(correct.textBinding).toMatchObject({ matched: true, declaredRevisionBoundaryCount: 0, revisionBoundaryNormalizationCount: 0 });
+    const whitespaceChanged = await verifyRealBoundaryFixture('ordinary-run-split', 'Synthetic unchanged frag mented clause inserted-alpha and removed-beta synthetic tail.');
+    expect(whitespaceChanged).toMatchObject({ status: 'fail', markupTextMatchesPdf: false });
+    expect(whitespaceChanged.textBinding?.missingTokenSample).toContain('frag');
+  }, REAL_RENDER_TIMEOUT_MS);
 });

--- a/packages/docx-render-verifier/src/render.ts
+++ b/packages/docx-render-verifier/src/render.ts
@@ -288,37 +288,82 @@ function revisionSpanFamily(element: XmlElement): 'deletion' | 'insertion' | und
 }
 
 /**
- * Visible character stream of an element as Writer displays it with tracked
- * changes shown: `w:t` and `w:delText` text in document order, with tab and
- * break glyphs contributing whitespace. Content of a nested paragraph (for
- * example inside a text box) belongs to that paragraph's own stream and is
- * excluded here.
+ * Placeholder for content that may render a glyph this projection cannot
+ * model as text: footnote and endnote reference marks, inline drawings, VML
+ * pictures, embedded objects, symbol runs, resultless fields, foreign markup,
+ * and any element not on the explicit non-rendering allowlist. The
+ * placeholder is non-whitespace, so such content between two revision spans
+ * blocks junction declaration (the OOXML cannot prove the spans render
+ * adjacently), and such content at a junction edge produces fragments no PDF
+ * token can match — both strictly in the fail-not-pass direction.
  */
+const VISIBLE_GLYPH_PLACEHOLDER = '￼';
+
+const MC_NS = 'http://schemas.openxmlformats.org/markup-compatibility/2006';
+
+/**
+ * Elements the OOXML wordprocessing vocabulary defines as pure range
+ * markers, properties, or field plumbing that never render glyphs of their
+ * own. Only members of this allowlist may sit between two revision spans
+ * without blocking junction declaration; everything unrecognized fails closed
+ * as a possible glyph.
+ */
+const NON_RENDERING_ELEMENTS = new Set([
+  'p', 'pPr', 'rPr', 'sectPr', 'instrText', 'delInstrText', 'proofErr',
+  'bookmarkStart', 'bookmarkEnd', 'commentRangeStart', 'commentRangeEnd', 'commentReference',
+  'moveFromRangeStart', 'moveFromRangeEnd', 'moveToRangeStart', 'moveToRangeEnd',
+  'customXmlInsRangeStart', 'customXmlInsRangeEnd', 'customXmlDelRangeStart', 'customXmlDelRangeEnd',
+  'permStart', 'permEnd', 'lastRenderedPageBreak', 'softHyphen', 'sdtPr', 'sdtEndPr',
+]);
+
+/** Containers whose rendered content is exactly the rendered content of their children. */
+const CONTENT_CONTAINER_ELEMENTS = new Set([
+  'r', 'ins', 'del', 'moveFrom', 'moveTo', 'hyperlink', 'smartTag', 'sdt', 'sdtContent',
+  'customXml', 'ruby', 'rubyBase', 'rt', 'bdo', 'dir',
+]);
+
+/**
+ * Visible rendering of one element as Writer displays it with tracked changes
+ * shown: `w:t`/`w:delText` text, whitespace for tab and break glyphs, and a
+ * fail-closed placeholder for anything that may render a non-text glyph.
+ * Content of a nested paragraph (for example inside a text box) belongs to
+ * that paragraph's own stream, and drawings and pictures contribute a single
+ * placeholder rather than their embedded text.
+ */
+function elementVisibleContribution(element: XmlElement): string {
+  if (element.namespaceURI !== W_NS) {
+    // Markup-compatibility wrappers pass through (both branches contribute,
+    // which can only over-block); all other foreign markup fails closed.
+    return element.namespaceURI === MC_NS ? visibleCharacterStream(element) : VISIBLE_GLYPH_PLACEHOLDER;
+  }
+  switch (element.localName) {
+    case 't':
+    case 'delText':
+      return element.textContent ?? '';
+    case 'tab':
+    case 'br':
+    case 'cr':
+    case 'ptab':
+      return ' ';
+    case 'fldSimple': {
+      // A field renders its computed result. A cached result approximates it;
+      // a resultless field still renders something, so it fails closed.
+      const cached = visibleCharacterStream(element);
+      return cached.length > 0 ? cached : VISIBLE_GLYPH_PLACEHOLDER;
+    }
+    default:
+      if (NON_RENDERING_ELEMENTS.has(element.localName ?? '')) return '';
+      if (CONTENT_CONTAINER_ELEMENTS.has(element.localName ?? '')) return visibleCharacterStream(element);
+      return VISIBLE_GLYPH_PLACEHOLDER;
+  }
+}
+
+/** Concatenated visible contributions of an element's child elements. */
 function visibleCharacterStream(element: XmlElement): string {
   let stream = '';
   for (let child = element.firstChild; child !== null; child = child.nextSibling) {
     if (child.nodeType !== 1) continue;
-    const childElement = child as XmlElement;
-    if (childElement.namespaceURI !== W_NS) { stream += visibleCharacterStream(childElement); continue; }
-    switch (childElement.localName) {
-      case 't':
-      case 'delText':
-        stream += childElement.textContent ?? '';
-        break;
-      case 'tab':
-      case 'br':
-      case 'cr':
-        stream += ' ';
-        break;
-      case 'p':
-      case 'pPr':
-      case 'rPr':
-      case 'instrText':
-      case 'delInstrText':
-        break;
-      default:
-        stream += visibleCharacterStream(childElement);
-    }
+    stream += elementVisibleContribution(child as XmlElement);
   }
   return stream;
 }
@@ -339,7 +384,7 @@ function collectAdjacentRevisionBoundaries(document: NonNullable<ReturnType<type
     for (let child = paragraph.firstChild; child !== null; child = child.nextSibling) {
       if (child.nodeType !== 1) continue;
       const childElement = child as XmlElement;
-      const text = childElement.namespaceURI === W_NS && childElement.localName === 'pPr' ? '' : visibleCharacterStream(childElement);
+      const text = elementVisibleContribution(childElement);
       segments.push({ family: revisionSpanFamily(childElement), start: stream.length, end: stream.length + text.length });
       stream += text;
     }

--- a/packages/docx-render-verifier/src/render.ts
+++ b/packages/docx-render-verifier/src/render.ts
@@ -8,7 +8,7 @@ import { pathToFileURL } from 'node:url';
 import { promisify } from 'node:util';
 import JSZip from 'jszip';
 import { DOMParser, type Element as XmlElement } from '@xmldom/xmldom';
-import type { PaginationProfile, PixelMeasurement, RenderRequest, RendererTools, RenderVerdict, TextBindingEvidence, ToolResult } from './types.js';
+import type { AdjacentRevisionBoundary, PaginationProfile, PixelMeasurement, RenderRequest, RendererTools, RenderVerdict, TextBindingEvidence, ToolResult } from './types.js';
 
 const execFileAsync = promisify(execFile);
 const BLUE = [0, 0, 255] as const;
@@ -87,8 +87,20 @@ function isReservablePageNumber(token: string, pagination: PaginationProfile): b
  * The pagination profile is derived from the rendered artifact and the
  * rendered DOCX package only — never from the caller's projection or from any
  * Safe DOCX generator — so the binding stays an independent oracle.
+ *
+ * Adjacent-revision whitespace tolerance: LibreOffice and `pdftotext` do not
+ * expose a stable whitespace-delimited token boundary between neighbouring
+ * deletion and insertion spans, so the extracted PDF may render `OldNew`
+ * where the projection has `Old New` (or vice versa). After the strict
+ * multiset pass, each OOXML-declared adjacent revision junction may explain
+ * AT MOST ONE merge (rendered `leftToken+rightToken` standing for the
+ * projection's separate `leftToken` and `rightToken`) or ONE split (the
+ * reverse). The tolerance never removes whitespace globally, never absorbs
+ * missing or duplicated lexical content — the substitution must balance the
+ * exact junction tokens on both sides — and applies only at junctions the
+ * emitted tracked OOXML proves lie between adjacent visible revision spans.
  */
-export function bindLogicalMarkupText(expectedMarkupText: string, pdfText: string, pagination: PaginationProfile): TextBindingEvidence {
+export function bindLogicalMarkupText(expectedMarkupText: string, pdfText: string, pagination: PaginationProfile, revisionBoundaries: readonly AdjacentRevisionBoundary[] = []): TextBindingEvidence {
   const expectedCounts = countTokens(tokenizeRenderedText(expectedMarkupText));
   const bodyAvailable = new Map<string, number>();
   let bodyFieldBudget = pagination.bodyPageFieldCount;
@@ -122,20 +134,68 @@ export function bindLogicalMarkupText(expectedMarkupText: string, pdfText: strin
       if (count > 0) bodyAvailable.set(token, (bodyAvailable.get(token) ?? 0) + count);
     }
   }
-  const missingTokens: string[] = [];
+  const deficits = new Map<string, number>();
   for (const [token, expected] of expectedCounts) {
-    if ((bodyAvailable.get(token) ?? 0) < expected) missingTokens.push(token);
+    const shortfall = expected - (bodyAvailable.get(token) ?? 0);
+    if (shortfall > 0) deficits.set(token, shortfall);
   }
-  const unexplainedTokens: string[] = [];
+  const surpluses = new Map<string, number>();
   for (const [token, available] of bodyAvailable) {
-    if (available - (expectedCounts.get(token) ?? 0) > 0) unexplainedTokens.push(token);
+    const excess = available - (expectedCounts.get(token) ?? 0);
+    if (excess > 0) surpluses.set(token, excess);
   }
+  let revisionBoundaryNormalizationCount = 0;
+  for (const { leftToken, rightToken } of revisionBoundaries) {
+    if (leftToken.length === 0 || rightToken.length === 0) continue;
+    const joined = `${leftToken}${rightToken}`;
+    // Renderer concatenated the junction (projection separated), or the
+    // reverse. Each declared junction may explain at most one such swap, and
+    // the swap must balance the exact junction tokens on both sides — a
+    // dropped or duplicated token elsewhere still surfaces as residue.
+    if (applyBoundaryNormalization(deficits, [leftToken, rightToken], surpluses, [joined])
+      || applyBoundaryNormalization(deficits, [joined], surpluses, [leftToken, rightToken])) {
+      revisionBoundaryNormalizationCount++;
+    }
+  }
+  const missingTokens = [...deficits.keys()];
+  const unexplainedTokens = [...surpluses.keys()];
   return {
     matched: missingTokens.length === 0 && unexplainedTokens.length === 0,
     pageCount: pagination.pageCount,
     missingTokenSample: missingTokens.slice(0, BINDING_SAMPLE_LIMIT),
     unexplainedTokenSample: unexplainedTokens.slice(0, BINDING_SAMPLE_LIMIT),
+    declaredRevisionBoundaryCount: revisionBoundaries.length,
+    revisionBoundaryNormalizationCount,
   };
+}
+
+function hasTokenCounts(counts: ReadonlyMap<string, number>, tokens: readonly string[]): boolean {
+  const needed = countTokens(tokens);
+  for (const [token, count] of needed) {
+    if ((counts.get(token) ?? 0) < count) return false;
+  }
+  return true;
+}
+
+function consumeTokenCounts(counts: Map<string, number>, tokens: readonly string[]): void {
+  for (const token of tokens) {
+    const remaining = (counts.get(token) ?? 0) - 1;
+    if (remaining <= 0) counts.delete(token);
+    else counts.set(token, remaining);
+  }
+}
+
+/**
+ * Atomically consume one whitespace swap at a declared adjacent revision
+ * junction: the deficit side and the surplus side must BOTH hold the exact
+ * junction tokens, otherwise nothing is consumed and the mismatch stays a
+ * binding failure.
+ */
+function applyBoundaryNormalization(deficits: Map<string, number>, deficitTokens: readonly string[], surpluses: Map<string, number>, surplusTokens: readonly string[]): boolean {
+  if (!hasTokenCounts(deficits, deficitTokens) || !hasTokenCounts(surpluses, surplusTokens)) return false;
+  consumeTokenCounts(deficits, deficitTokens);
+  consumeTokenCounts(surpluses, surplusTokens);
+  return true;
 }
 
 function profileXml(mode: 'configured' | 'by-author'): string {
@@ -215,10 +275,99 @@ type RenderedStory = { name: string; kind: 'document' | 'header' | 'footer' | 'f
 type RenderedPackageEvidence = {
   revisionMarkup: { insertions: boolean; deletions: boolean };
   pagination: PaginationProfile;
+  revisionBoundaries: AdjacentRevisionBoundary[];
 };
 
+const WHITESPACE_CHAR = /\s/u;
+
+function revisionSpanFamily(element: XmlElement): 'deletion' | 'insertion' | undefined {
+  if (element.namespaceURI !== W_NS) return undefined;
+  if (element.localName === 'del' || element.localName === 'moveFrom') return 'deletion';
+  if (element.localName === 'ins' || element.localName === 'moveTo') return 'insertion';
+  return undefined;
+}
+
+/**
+ * Visible character stream of an element as Writer displays it with tracked
+ * changes shown: `w:t` and `w:delText` text in document order, with tab and
+ * break glyphs contributing whitespace. Content of a nested paragraph (for
+ * example inside a text box) belongs to that paragraph's own stream and is
+ * excluded here.
+ */
+function visibleCharacterStream(element: XmlElement): string {
+  let stream = '';
+  for (let child = element.firstChild; child !== null; child = child.nextSibling) {
+    if (child.nodeType !== 1) continue;
+    const childElement = child as XmlElement;
+    if (childElement.namespaceURI !== W_NS) { stream += visibleCharacterStream(childElement); continue; }
+    switch (childElement.localName) {
+      case 't':
+      case 'delText':
+        stream += childElement.textContent ?? '';
+        break;
+      case 'tab':
+      case 'br':
+      case 'cr':
+        stream += ' ';
+        break;
+      case 'p':
+      case 'pPr':
+      case 'rPr':
+      case 'instrText':
+      case 'delInstrText':
+        break;
+      default:
+        stream += visibleCharacterStream(childElement);
+    }
+  }
+  return stream;
+}
+
+/**
+ * Junctions where the emitted tracked OOXML proves a visible deletion-family
+ * span and a visible insertion-family span are adjacent without intervening
+ * whitespace or visible content. Only these positions are eligible for the
+ * optional-whitespace tolerance in `bindLogicalMarkupText`; ordinary run
+ * splits, same-family adjacency, and junctions that already carry whitespace
+ * declare nothing.
+ */
+function collectAdjacentRevisionBoundaries(document: NonNullable<ReturnType<typeof parseStoryXml>>): AdjacentRevisionBoundary[] {
+  const boundaries: AdjacentRevisionBoundary[] = [];
+  for (const paragraph of Array.from(document.getElementsByTagNameNS(W_NS, 'p'))) {
+    const segments: Array<{ family: 'deletion' | 'insertion' | undefined; start: number; end: number }> = [];
+    let stream = '';
+    for (let child = paragraph.firstChild; child !== null; child = child.nextSibling) {
+      if (child.nodeType !== 1) continue;
+      const childElement = child as XmlElement;
+      const text = childElement.namespaceURI === W_NS && childElement.localName === 'pPr' ? '' : visibleCharacterStream(childElement);
+      segments.push({ family: revisionSpanFamily(childElement), start: stream.length, end: stream.length + text.length });
+      stream += text;
+    }
+    for (let index = 0; index < segments.length; index++) {
+      const left = segments[index]!;
+      if (left.family === undefined || left.end === left.start) continue;
+      // Skip siblings that render nothing (bookmarks, proofing marks, empty
+      // runs); the next segment with visible payload is the rendered
+      // neighbour.
+      let nextIndex = index + 1;
+      while (nextIndex < segments.length && segments[nextIndex]!.end === segments[nextIndex]!.start) nextIndex++;
+      if (nextIndex >= segments.length) break;
+      const right = segments[nextIndex]!;
+      if (right.family === undefined || right.family === left.family) continue;
+      const junction = left.end;
+      if (WHITESPACE_CHAR.test(stream.charAt(junction - 1)) || WHITESPACE_CHAR.test(stream.charAt(junction))) continue;
+      let leftStart = junction;
+      while (leftStart > 0 && !WHITESPACE_CHAR.test(stream.charAt(leftStart - 1))) leftStart--;
+      let rightEnd = junction;
+      while (rightEnd < stream.length && !WHITESPACE_CHAR.test(stream.charAt(rightEnd))) rightEnd++;
+      boundaries.push({ leftToken: stream.slice(leftStart, junction), rightToken: stream.slice(junction, rightEnd) });
+    }
+  }
+  return boundaries;
+}
+
 async function analyzeRenderedPackage(bytes: Buffer, pageCount: number): Promise<RenderedPackageEvidence> {
-  const fallback: RenderedPackageEvidence = { revisionMarkup: { insertions: false, deletions: false }, pagination: emptyPaginationProfile(pageCount) };
+  const fallback: RenderedPackageEvidence = { revisionMarkup: { insertions: false, deletions: false }, pagination: emptyPaginationProfile(pageCount), revisionBoundaries: [] };
   try {
     const zip = await JSZip.loadAsync(bytes);
     const documentXml = await zip.file('word/document.xml')?.async('string');
@@ -227,6 +376,7 @@ async function analyzeRenderedPackage(bytes: Buffer, pageCount: number): Promise
     let insertions = false;
     let deletions = false;
     const headerFooterTokenCounts = new Map<string, number>();
+    const revisionBoundaries: AdjacentRevisionBoundary[] = [];
     let headerFooterPageFieldCount = 0;
     let bodyPageFieldCount = 0;
     let pageNumberStart = 1;
@@ -240,6 +390,9 @@ async function analyzeRenderedPackage(bytes: Buffer, pageCount: number): Promise
       const isPaginationStory = story.kind === 'header' || story.kind === 'footer';
       if (isPaginationStory) headerFooterPageFieldCount += pageFieldInstructionCount(document);
       else bodyPageFieldCount += pageFieldInstructionCount(document);
+      // Header/footer story text is pagination-owned and reserved wholesale,
+      // so only body-layer stories can declare whitespace-optional junctions.
+      if (!isPaginationStory) revisionBoundaries.push(...collectAdjacentRevisionBoundaries(document));
       if (story.kind === 'document') {
         for (const numbering of Array.from(document.getElementsByTagNameNS(W_NS, 'pgNumType'))) {
           const start = Number.parseInt(numbering.getAttributeNS(W_NS, 'start') ?? '', 10);
@@ -269,6 +422,7 @@ async function analyzeRenderedPackage(bytes: Buffer, pageCount: number): Promise
         bodyPageFieldCount,
         pageNumberUpperBound: pageCount + pageNumberStart - 1,
       },
+      revisionBoundaries,
     };
   } catch {
     return fallback;
@@ -474,7 +628,7 @@ export async function verifyRenderedMarkup(request: RenderRequest): Promise<Rend
     const configuredPixels = configuredMeasured.pixels;
     const controlPixels = controlMeasured.pixels;
     const packageEvidence = await analyzeRenderedPackage(renderedInputBytes, configuredMeasured.pageCount);
-    const textBinding = bindLogicalMarkupText(request.expectedMarkupText, pdfText, packageEvidence.pagination);
+    const textBinding = bindLogicalMarkupText(request.expectedMarkupText, pdfText, packageEvidence.pagination, packageEvidence.revisionBoundaries);
     const markupTextMatchesPdf = textBinding.matched;
     const configuredContrastPassed = configuredContrast(configuredPixels, controlPixels, request.configuredPixelFloor ?? 4);
     const measuredVisibility = revisionVisibility(configuredPixels, controlPixels, request.configuredPixelFloor ?? 4);

--- a/packages/docx-render-verifier/src/types.ts
+++ b/packages/docx-render-verifier/src/types.ts
@@ -38,6 +38,24 @@ export type PaginationProfile = {
 };
 
 /**
+ * An emitted-OOXML-proven junction where a visible deletion-family revision
+ * span (`w:del`/`w:moveFrom`) and a visible insertion-family revision span
+ * (`w:ins`/`w:moveTo`) are adjacent with no whitespace between them.
+ * LibreOffice and `pdftotext` do not expose a stable whitespace-delimited
+ * token boundary at such a junction, so text binding may treat whitespace
+ * there — and only there — as optional. The fragments are the maximal
+ * non-whitespace character runs meeting at the junction in the story's own
+ * character stream, so they can extend into neighbouring ordinary runs (for
+ * example trailing punctuation attached to the insertion).
+ */
+export type AdjacentRevisionBoundary = {
+  /** Maximal non-whitespace run ending exactly at the junction. */
+  leftToken: string;
+  /** Maximal non-whitespace run starting exactly at the junction. */
+  rightToken: string;
+};
+
+/**
  * Structured outcome of the story-scoped text binding. Token samples are
  * bounded excerpts for diagnosis; `matched` is the binding verdict.
  */
@@ -49,6 +67,20 @@ export type TextBindingEvidence = {
   missingTokenSample: string[];
   /** Bounded sample of rendered tokens not attributable to markup or pagination. */
   unexplainedTokenSample: string[];
+  /**
+   * Adjacent deletion/insertion junctions the emitted tracked OOXML declares
+   * as eligible for optional-whitespace normalization. Derived from the
+   * rendered package's revision markup, independent of pagination reservation.
+   */
+  declaredRevisionBoundaryCount: number;
+  /**
+   * Optional-whitespace normalizations actually applied at declared adjacent
+   * revision boundaries (at most one per declared junction). Reported
+   * separately from pagination reservation so a certificate consumer can
+   * distinguish renderer whitespace tolerance from header/footer/page-number
+   * accounting.
+   */
+  revisionBoundaryNormalizationCount: number;
 };
 
 export type RenderVerdict = {


### PR DESCRIPTION
## Problem

`bindLogicalMarkupText` binds whitespace-delimited tokens from extracted PDF text against a caller-supplied independent logical projection. LibreOffice/`pdftotext` do not expose a stable whitespace boundary between adjacent deletion and insertion spans, so a projection with the correct visible characters and correct revision content failed multiset binding for a purely renderer-created reason (`Old New` in the projection vs `OldNew` in the PDF), while calibrated blue/red pixel evidence and revision visibility passed.

## Invariant

Text binding tolerates renderer-created whitespace ONLY at a junction the emitted tracked OOXML proves lies between a visible deletion-family span (`w:del`/`w:moveFrom`) and a visible insertion-family span (`w:ins`/`w:moveTo`) with no whitespace or visible content between them. Everything else stays exact.

Mechanics: the strict #833 story-scoped multiset pass runs first and unchanged (pagination-first maximal reservation, completeness lower bound, zero residue). Afterwards, each OOXML-declared junction may explain **at most one** whitespace swap of its own junction tokens — the maximal non-whitespace character runs meeting at the junction in the story's own character stream (so punctuation attached to the insertion participates) — and the swap must balance exact character content on both the deficit and surplus side simultaneously. The verifier does NOT:

- globally strip whitespace (ordinary-run splits, same-family adjacency, and junctions already carrying whitespace declare nothing);
- accept missing or duplicated lexical content (the swap cannot fire unless both sides hold the junction's exact tokens);
- use the redline generator to construct its oracle (boundaries come from the rendered package's own OOXML, parsed with `@xmldom/xmldom`);
- use the rendered PDF as expected text; or
- weaken the #833 pagination/story accounting (header/footer stories are pagination-owned and declare no junctions; all #833 tests remain green and untouched).

The certificate reports `declaredRevisionBoundaryCount` and `revisionBoundaryNormalizationCount` on `TextBindingEvidence` — separate from pagination reservation.

## Real-LibreOffice evidence (local macOS, LibreOffice 25.8.7.3 + poppler pdftotext)

Each new fixture was rendered through a real headless LibreOffice configured profile and extracted with `pdftotext -layout`. Observed extractions (recorded as evidence; expectations were derived from the canonical operands, never from these outputs):

| Fixture | Independent projection (canonical operands) | Observed PDF extraction |
|---|---|---|
| `adjacent-revision-alnum` | `Synthetic clause prefix OldTerm NewTerm synthetic suffix.` | `Synthetic clause prefix OldTermNewTerm synthetic suffix.` |
| `adjacent-revision-punctuation` | `Synthetic filing reference Formation Charter, synthetic continuation.` | `Synthetic filing reference FormationCharter, synthetic continuation.` |
| `adjacent-revision-multiword-deletion` | `Synthetic instrument label Certificate of Formation Charter synthetic closing.` | `Synthetic instrument label Certificate of FormationCharter synthetic closing.` |
| `adjacent-revision-multiword-insertion` | `Synthetic venue label StateAlpha State Beta synthetic tail.` | `Synthetic venue label StateAlphaState Beta synthetic tail.` |
| `ordinary-run-split` (negative) | `Synthetic unchanged fragmented clause inserted-alpha and removed-beta synthetic tail.` | identical (ordinary-run split rendered continuously; no spurious separator) |

This LibreOffice build concatenated at every adjacent junction shape; the constrained language also accepts the separated form, and unit tests pin both directions plus the negative controls (dropped word, duplicated word, ordinary-run whitespace change, punctuation change, same-family adjacency, per-junction budget, header-story junctions).

The real-LibreOffice tests run `verifyRenderedMarkup` end-to-end (both profiles, pixel calibration, text binding) when `soffice`/`pdftotext`/`pdftoppm`/`magick` resolve locally; on CI (no LibreOffice, no poppler) they exercise the existing `resolve() → null → status: 'not_run'` discipline and accept exactly that outcome.

## Privacy

All fixtures are synthetic neutral strings; the fixtures leak scan from `fixtures/PROVENANCE.md` passes. No private documents, text, names, paths, hashes, logos, or screenshots.

## Acceptance criteria

- [x] Public synthetic real-LibreOffice fixtures for every boundary shape (registered in `fixtures/index.json`).
- [x] Expected projection independently derived from emitted OOXML or canonical operands.
- [x] Concatenated and separated PDF forms pass only at declared adjacent revision boundaries.
- [x] Dropped words, duplicated words, ordinary-run whitespace changes, and punctuation changes fail as negative controls.
- [x] Single-page and multi-page #833 regressions remain green.
- [x] Certificate reports revision-boundary normalization separately from pagination reservation.
- [x] No private material enters the repository.

Ref: #847
