### PR TITLE
fix(docx-markdoc): preserve common tokens in dense brownfield rewrites

### DIFF
--- a/packages/docx-compare/src/baselines/atomizer/atomLcs-alignment-pinning.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/atomLcs-alignment-pinning.test.ts
@@ -2,12 +2,13 @@
  * Characterization tests pinning the LCS *alignment* chosen by `computeAtomLcs` (#584).
  *
  * LCS *length* is unique, but the *alignment* — which atom pairs get matched when
- * several optimal alignments exist — is not. The backtracker in `atomLcs.ts`
- * resolves ties with `dp[i-1][j] > dp[i][j-1]`, and that choice is user-visible:
- * matched pairs feed `comparisonUnitAtomBefore`, which drives format-change
- * detection (`w:rPrChange`), move detection, and merged-output ordering. Before
- * this file, inverting the tie-breaker (`>` → `>=`) changed which runs received
- * format-change revisions yet the entire suite stayed green.
+ * several optimal alignments exist — is not. The selector in `atomLcs.ts` walks
+ * a suffix table FORWARD from (0,0), matching equal heads eagerly and preferring
+ * the original side on `dp[i+1][j] >= dp[i][j+1]` ties, and that choice is
+ * user-visible: matched pairs feed `comparisonUnitAtomBefore`, which drives
+ * format-change detection (`w:rPrChange`), move detection, and merged-output
+ * ordering. Before this file, inverting a tie-breaker changed which runs
+ * received format-change revisions yet the entire suite stayed green.
  *
  * These tests pin the CURRENT alignment as observable behavior — they do not
  * claim it is the only correct one. Any refactor of the LCS internals (the
@@ -18,15 +19,25 @@
  * refactor could preserve these cases while changing other ambiguous alignments
  * — the corpus-wide differential harness proposed in #584 remains follow-up.)
  *
+ * One such deliberate decision has already happened: issue #846 replaced the
+ * original prefix-table backward backtracker (whose eager tail matching pinned
+ * LAST-occurrence duplicates) with the forward earliest-occurrence walk, so the
+ * emitted alignment agrees with the independent release verifier's
+ * forward-greedy convention and stops revising preservable common tokens. The
+ * "duplicate identity" pin below was updated accordingly in the same change.
+ *
  * Perturbations each test discriminates:
- * - "swapped adjacent atoms" / "reversed sequence": fail when the DP tie-breaker
- *   is inverted (`>` → `>=`), verified by executing the suite under the inversion.
- * - "duplicate identity": the inversion cannot reach the tie branch here (the
- *   backtracker eagerly matches equal heads), so this test is inversion-neutral
- *   by construction; it instead pins the eager last-occurrence match that a
- *   first-occurrence-preferring rewrite (e.g. Myers) would flip.
+ * - "swapped adjacent atoms" / "reversed sequence": fail when the forward walk's
+ *   tie preference is inverted (`>=` → `<`), which would advance the revised
+ *   side first and survive the opposite element.
+ * - "duplicate identity": tie branches are unreachable here (the walk eagerly
+ *   matches equal heads), so this test is tie-inversion-neutral by
+ *   construction; it instead pins the eager first-occurrence match that a
+ *   last-occurrence-preferring rewrite (e.g. the pre-#846 backward
+ *   backtracker) would flip.
  *
  * @see https://github.com/UseJunior/safe-docx/issues/584
+ * @see https://github.com/UseJunior/safe-docx/issues/846
  */
 
 import { describe, expect } from 'vitest';
@@ -106,10 +117,11 @@ describe('LCS alignment pinning (#584)', () => {
       await attachPrettyJson('LCS result', result);
     });
 
-    await then('the backtracker keeps the Beta pair (original index 1 ↔ revised index 0), deleting and re-inserting Alpha', () => {
-      // Both {Alpha: 0↔1} and {Beta: 1↔0} are length-1 optima. The dp tie at the
-      // top-right corner is what selects between them, so an inverted tie-breaker
-      // (`>` → `>=`) flips this to [{ originalIndex: 0, revisedIndex: 1 }].
+    await then('the walk keeps the Beta pair (original index 1 ↔ revised index 0), deleting and re-inserting Alpha', () => {
+      // Both {Alpha: 0↔1} and {Beta: 1↔0} are length-1 optima. The forward
+      // walk's `>=` tie advances the original side first and lands on Beta; an
+      // inverted tie preference (advance the revised side first) flips this to
+      // [{ originalIndex: 0, revisedIndex: 1 }].
       expect(result.matches).toEqual([{ originalIndex: 1, revisedIndex: 0 }]);
       expect(result.deletedIndices).toEqual([0]);
       expect(result.insertedIndices).toEqual([1]);
@@ -131,10 +143,10 @@ describe('LCS alignment pinning (#584)', () => {
       await attachPrettyJson('LCS result', result);
     });
 
-    await then('the backtracker survives D (original index 3 ↔ revised index 0)', () => {
-      // The backtrack from the corner crosses three consecutive dp ties; the
-      // current `>` tie-breaker walks the revised side first and lands on D.
-      // Inverting it walks the original side first and would survive A
+    await then('the walk survives D (original index 3 ↔ revised index 0)', () => {
+      // The forward walk crosses three consecutive dp ties; the `>=` tie
+      // preference advances the original side first and lands on D. Inverting
+      // it advances the revised side first and would survive A
       // ([{ originalIndex: 0, revisedIndex: 3 }]) instead.
       expect(result.matches).toEqual([{ originalIndex: 3, revisedIndex: 0 }]);
       expect(result.deletedIndices).toEqual([0, 1, 2]);
@@ -190,7 +202,7 @@ describe('LCS alignment pinning (#584)', () => {
     });
   });
 
-  test.allure({ story: 'duplicate identity: the LAST same-text original run anchors the match, not the first' })('duplicate identity: the LAST same-text original run anchors the match, not the first', async ({ given, when, then, and, attachPrettyJson }: AllureBddContext) => {
+  test.allure({ story: 'duplicate identity: the FIRST same-text original run anchors the match, not the last' })('duplicate identity: the FIRST same-text original run anchors the match, not the last', async ({ given, when, then, and, attachPrettyJson }: AllureBddContext) => {
     let xml: string;
     let stats: Awaited<ReturnType<typeof compareDocuments>>['stats'];
 
@@ -213,27 +225,27 @@ describe('LCS alignment pinning (#584)', () => {
       await attachPrettyJson('Comparison stats', stats);
     });
 
-    await then('the surviving run pairs with the ITALIC original, surfacing an italic→bold rPrChange', () => {
-      // The backtracker matches equal heads eagerly from the tail, so the revised
-      // bold "Same" pairs with the *italic* original — a format change — while the
-      // formatting-identical bold original is deleted. A first-occurrence-preferring
-      // rewrite (e.g. Myers) would pair bold↔bold and emit no rPrChange at all.
+    await then('the surviving run pairs with the BOLD original, so no rPrChange is emitted', () => {
+      // The forward walk matches equal heads eagerly from the front, so the
+      // revised bold "Same" pairs with the *bold* original — formatting
+      // identical, no format change — while the italic duplicate is deleted.
+      // A last-occurrence-preferring rewrite (e.g. the pre-#846 backward
+      // backtracker) would pair bold↔italic and surface a spurious
+      // italic→bold rPrChange instead.
       const doc = parseXml(xml);
       const rPrChanges = elementsOf(doc, 'w:rPrChange');
-      expect(stats.formatChanges).toBe(1);
-      expect(rPrChanges).toHaveLength(1);
-      const oldRPr = Array.from(rPrChanges[0]!.getElementsByTagName('w:i'));
-      expect(oldRPr).toHaveLength(1);
+      expect(stats.formatChanges).toBe(0);
+      expect(rPrChanges).toHaveLength(0);
     });
 
-    await and('the deleted run is the BOLD duplicate', () => {
+    await and('the deleted run is the ITALIC duplicate', () => {
       const doc = parseXml(xml);
       const dels = elementsOf(doc, 'w:del');
       expect(dels).toHaveLength(1);
       const deletedRun = dels[0]!;
       expect(Array.from(deletedRun.getElementsByTagName('w:delText')).map((t) => t.textContent)).toEqual(['Same']);
-      expect(Array.from(deletedRun.getElementsByTagName('w:b'))).toHaveLength(1);
-      expect(Array.from(deletedRun.getElementsByTagName('w:i'))).toHaveLength(0);
+      expect(Array.from(deletedRun.getElementsByTagName('w:i'))).toHaveLength(1);
+      expect(Array.from(deletedRun.getElementsByTagName('w:b'))).toHaveLength(0);
     });
   });
 });

--- a/packages/docx-compare/src/baselines/atomizer/atomLcs.ts
+++ b/packages/docx-compare/src/baselines/atomizer/atomLcs.ts
@@ -173,36 +173,50 @@ export function computeAtomLcs(
     ? (a: ComparisonUnitAtom, b: ComparisonUnitAtom): boolean => getIdentityId(a) === getIdentityId(b)
     : atomsEqual;
 
-  // Build LCS length table
-  // dp[i][j] = length of LCS of original[0..i-1] and revised[0..j-1]
+  // Build LCS length table over suffixes:
+  // dp[i][j] = length of LCS of original[i..] and revised[j..]
+  //
+  // A suffix table lets the traceback walk FORWARD from (0,0) and take every
+  // available equal pair immediately, so a token that repeats nearby matches
+  // its EARLIEST co-monotonic occurrence. The previous prefix-table backward
+  // traceback resolved the same ties toward the LATEST occurrence, which is an
+  // equally long LCS but systematically disagrees with the independent
+  // release verifier's forward alignment: around a dense rewrite the survivor
+  // among several equal candidates (an inter-word space, a repeated term) was
+  // the one the verifier does not credit, so ordinary source tokens were
+  // needlessly deleted and reinserted. Tie-breaking must mirror the
+  // checker-owned convention exactly: match on equality, otherwise prefer
+  // advancing the original side.
+  //
+  // @see https://github.com/UseJunior/safe-docx/issues/846
   const dp: number[][] = Array(n + 1)
     .fill(null)
     .map(() => Array(m + 1).fill(0));
 
-  for (let i = 1; i <= n; i++) {
-    for (let j = 1; j <= m; j++) {
-      if (eq(original[i - 1]!, revised[j - 1]!)) {
-        dp[i]![j] = dp[i - 1]![j - 1]! + 1;
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      if (eq(original[i]!, revised[j]!)) {
+        dp[i]![j] = dp[i + 1]![j + 1]! + 1;
       } else {
-        dp[i]![j] = Math.max(dp[i - 1]![j]!, dp[i]![j - 1]!);
+        dp[i]![j] = Math.max(dp[i + 1]![j]!, dp[i]![j + 1]!);
       }
     }
   }
 
-  // Backtrack to find the actual LCS matches
+  // Walk forward to select the actual LCS matches (earliest-occurrence ties)
   let matches: AtomMatch[] = [];
-  let i = n;
-  let j = m;
+  let i = 0;
+  let j = 0;
 
-  while (i > 0 && j > 0) {
-    if (eq(original[i - 1]!, revised[j - 1]!)) {
-      matches.unshift({ originalIndex: i - 1, revisedIndex: j - 1 });
-      i--;
-      j--;
-    } else if (dp[i - 1]![j]! > dp[i]![j - 1]!) {
-      i--;
+  while (i < n && j < m) {
+    if (eq(original[i]!, revised[j]!)) {
+      matches.push({ originalIndex: i, revisedIndex: j });
+      i++;
+      j++;
+    } else if (dp[i + 1]![j]! >= dp[i]![j + 1]!) {
+      i++;
     } else {
-      j--;
+      j++;
     }
   }
 

--- a/packages/docx-compare/src/baselines/atomizer/hierarchicalLcs-bookmark-anchor-match.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/hierarchicalLcs-bookmark-anchor-match.test.ts
@@ -111,6 +111,63 @@ describe('anchor-identity paragraph matching (#846)', () => {
     });
   });
 
+  test.allure({ story: 'a foreign sibling bookmark name never activates the identity pass' })('a foreign sibling bookmark name never activates the identity pass', async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
+    let xml = '';
+
+    await given('both sides bracket the dense pair with an identical non-safe-docx bookmark name', () => {});
+
+    await when('the documents are compared', async () => {
+      xml = await compareBodies(
+        `<w:bookmarkStart w:id="1" w:name="CustomerBookmark"/>${paragraph(DENSE_BEFORE)}<w:bookmarkEnd w:id="1"/>${paragraph('Context paragraph.')}`,
+        `<w:bookmarkStart w:id="1" w:name="CustomerBookmark"/>${paragraph(DENSE_AFTER)}<w:bookmarkEnd w:id="1"/>${paragraph('Context paragraph.')}`,
+      );
+      await attachPrettyJson('tracked document.xml', xml);
+    });
+
+    await then('the third-party bookmark does not force an alignment and the pair still splits', () => {
+      // Anchor identity is limited to the canonical safe-docx _bk_ + 12-hex
+      // name shape; arbitrary customer bookmark names must never change
+      // generic comparison behavior.
+      expect(paragraphCount(xml)).toBe(3);
+    });
+  });
+
+  test.allure({ story: 'an orphaned bookmarkStart without its bracketing end is ignored' })('an orphaned bookmarkStart without its bracketing end is ignored', async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
+    let xml = '';
+
+    await given('both sides have a _bk_ start before the paragraph but no bookmarkEnd after it', () => {});
+
+    await when('the documents are compared', async () => {
+      xml = await compareBodies(
+        `<w:bookmarkStart w:id="1" w:name="_bk_00000000000a"/>${paragraph(DENSE_BEFORE)}${paragraph('Context paragraph.')}`,
+        `<w:bookmarkStart w:id="1" w:name="_bk_00000000000a"/>${paragraph(DENSE_AFTER)}${paragraph('Context paragraph.')}`,
+      );
+      await attachPrettyJson('tracked document.xml', xml);
+    });
+
+    await then('the incomplete bracket does not qualify and the pair still splits', () => {
+      expect(paragraphCount(xml)).toBe(3);
+    });
+  });
+
+  test.allure({ story: 'a bracket whose start and end ids disagree is ignored' })('a bracket whose start and end ids disagree is ignored', async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
+    let xml = '';
+
+    await given('both sides have a _bk_ start and a following bookmarkEnd with a different w:id', () => {});
+
+    await when('the documents are compared', async () => {
+      xml = await compareBodies(
+        `<w:bookmarkStart w:id="1" w:name="_bk_00000000000b"/>${paragraph(DENSE_BEFORE)}<w:bookmarkEnd w:id="9"/>${paragraph('Context paragraph.')}`,
+        `<w:bookmarkStart w:id="1" w:name="_bk_00000000000b"/>${paragraph(DENSE_AFTER)}<w:bookmarkEnd w:id="9"/>${paragraph('Context paragraph.')}`,
+      );
+      await attachPrettyJson('tracked document.xml', xml);
+    });
+
+    await then('the mismatched bracket does not qualify and the pair still splits', () => {
+      expect(paragraphCount(xml)).toBe(3);
+    });
+  });
+
   test.allure({ story: 'a duplicated anchor name identifies nothing and is ignored' })('a duplicated anchor name identifies nothing and is ignored', async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
     let xml = '';
 

--- a/packages/docx-compare/src/baselines/atomizer/hierarchicalLcs-bookmark-anchor-match.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/hierarchicalLcs-bookmark-anchor-match.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Anchor-identity paragraph matching in `computeGroupLcs` Pass 1.5 (#846).
+ *
+ * A dense whole-paragraph rewrite can fall below every text-similarity
+ * threshold, so before this pass the pair degraded to whole-paragraph
+ * delete + insert and every preservable common token inside it was revised.
+ * safe-docx brackets managed paragraphs with uniquely named `_bk_…` bookmarks
+ * as immediate siblings (`<w:bookmarkStart/><w:p/><w:bookmarkEnd/>`); when
+ * both comparison sides carry the same bracketing anchor name, the paragraphs
+ * are the same logical paragraph by construction and are force-matched before
+ * similarity heuristics run. Bookmarks inside a paragraph never qualify.
+ *
+ * @see https://github.com/UseJunior/safe-docx/issues/846
+ */
+import { describe, expect } from 'vitest';
+import { DocxArchive } from '@usejunior/docx-core';
+import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
+import { buildDocxFromBodyXml } from '../../testing/ooxml-fixtures.js';
+import { compareDocuments } from '../../index.js';
+
+const test = testAllure.epic('Document Comparison').withLabels({ feature: 'Hierarchical LCS' });
+
+const FIXED_DATE = new Date('2026-08-14T12:00:00Z');
+
+// Word overlap between these two sentences is far below the 0.25 paragraph
+// similarity threshold, so alignment can only come from the anchor pass.
+const DENSE_BEFORE = 'Subject to approval, Northwind, together with its affiliates, will fund the program.';
+const DENSE_AFTER = 'Notwithstanding any contrary term, Northwind, acting through its designated subsidiaries, shall exclusively finance every initiative.';
+
+function paragraph(text: string): string {
+  return `<w:p><w:r><w:t xml:space="preserve">${text}</w:t></w:r></w:p>`;
+}
+
+function anchored(name: string, text: string, id: number): string {
+  return `<w:bookmarkStart w:id="${id}" w:name="${name}"/>${paragraph(text)}<w:bookmarkEnd w:id="${id}"/>`;
+}
+
+async function compareBodies(originalBody: string, revisedBody: string): Promise<string> {
+  const original = await buildDocxFromBodyXml(originalBody);
+  const revised = await buildDocxFromBodyXml(revisedBody);
+  const result = await compareDocuments(original, revised, { engine: 'atomizer', date: FIXED_DATE, detectMoves: false });
+  return (await DocxArchive.load(result.document)).getDocumentXml();
+}
+
+function paragraphCount(xml: string): number {
+  return [...xml.matchAll(/<w:p[ >]/gu)].length;
+}
+
+describe('anchor-identity paragraph matching (#846)', () => {
+  test.allure({ story: 'shared bracketing anchor keeps a dissimilar rewrite aligned as one paragraph' })('shared bracketing anchor keeps a dissimilar rewrite aligned as one paragraph', async ({ given, when, then, and, attachPrettyJson }: AllureBddContext) => {
+    let xml = '';
+
+    await given('both sides bracket the rewritten paragraph with the same _bk_ anchor', () => {});
+
+    await when('the documents are compared', async () => {
+      xml = await compareBodies(
+        `${anchored('_bk_000000000001', DENSE_BEFORE, 1)}${paragraph('Context paragraph.')}`,
+        `${anchored('_bk_000000000001', DENSE_AFTER, 1)}${paragraph('Context paragraph.')}`,
+      );
+      await attachPrettyJson('tracked document.xml', xml);
+    });
+
+    await then('the rewrite stays inside one physical paragraph instead of delete + insert paragraphs', () => {
+      expect(paragraphCount(xml)).toBe(2);
+    });
+
+    await and('the shared entity tokens survive as ordinary text', () => {
+      // "Northwind" is common to both sides; an aligned pair preserves it
+      // outside any revision wrapper, a paragraph split cannot.
+      expect(xml).not.toMatch(/<w:delText[^>]*>[^<]*Northwind/u);
+      const insertions = [...xml.matchAll(/<w:ins\b[\s\S]*?<\/w:ins>/gu)].map((match) => match[0]);
+      expect(insertions.some((block) => block.includes('Northwind'))).toBe(false);
+    });
+  });
+
+  test.allure({ story: 'without anchors the dissimilar rewrite still splits into delete + insert paragraphs' })('without anchors the dissimilar rewrite still splits into delete + insert paragraphs', async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
+    let xml = '';
+
+    await given('the same dense rewrite with no bracketing bookmarks anywhere', () => {});
+
+    await when('the documents are compared', async () => {
+      xml = await compareBodies(
+        `${paragraph(DENSE_BEFORE)}${paragraph('Context paragraph.')}`,
+        `${paragraph(DENSE_AFTER)}${paragraph('Context paragraph.')}`,
+      );
+      await attachPrettyJson('tracked document.xml', xml);
+    });
+
+    await then('similarity heuristics alone leave the pair as separate deleted and inserted paragraphs', () => {
+      // Pins the pre-existing generic behavior: the anchor pass changes
+      // nothing for ordinary third-party documents.
+      expect(paragraphCount(xml)).toBe(3);
+    });
+  });
+
+  test.allure({ story: 'mismatched anchor names do not force an alignment' })('mismatched anchor names do not force an alignment', async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
+    let xml = '';
+
+    await given('each side brackets its paragraph with a different _bk_ anchor name', () => {});
+
+    await when('the documents are compared', async () => {
+      xml = await compareBodies(
+        `${anchored('_bk_000000000001', DENSE_BEFORE, 1)}${paragraph('Context paragraph.')}`,
+        `${anchored('_bk_000000000002', DENSE_AFTER, 2)}${paragraph('Context paragraph.')}`,
+      );
+      await attachPrettyJson('tracked document.xml', xml);
+    });
+
+    await then('the pair still splits into deleted and inserted paragraphs', () => {
+      expect(paragraphCount(xml)).toBe(3);
+    });
+  });
+
+  test.allure({ story: 'a duplicated anchor name identifies nothing and is ignored' })('a duplicated anchor name identifies nothing and is ignored', async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
+    let xml = '';
+
+    await given('the original brackets two different paragraphs with the same anchor name', () => {});
+
+    await when('the documents are compared', async () => {
+      xml = await compareBodies(
+        `${anchored('_bk_000000000009', DENSE_BEFORE, 1)}${anchored('_bk_000000000009', 'Unrelated second clause.', 2)}`,
+        `${anchored('_bk_000000000009', DENSE_AFTER, 1)}${paragraph('Unrelated second clause.')}`,
+      );
+      await attachPrettyJson('tracked document.xml', xml);
+    });
+
+    await then('the ambiguous name is dropped and the dense pair falls back to delete + insert', () => {
+      // Exact text still matches "Unrelated second clause."; the dense pair
+      // cannot ride the duplicated anchor, so it splits: 3 paragraphs total.
+      expect(paragraphCount(xml)).toBe(3);
+    });
+  });
+});

--- a/packages/docx-compare/src/baselines/atomizer/hierarchicalLcs.ts
+++ b/packages/docx-compare/src/baselines/atomizer/hierarchicalLcs.ts
@@ -641,16 +641,41 @@ function similarityLcs(
 }
 
 /**
+ * Canonical safe-docx paragraph anchor name: `_bk_` plus 12 lowercase hex
+ * digits, allocated by docx-core `primitives/bookmarks.ts`
+ * (`deriveDeterministicJrParaName`). Anchor matching is deliberately limited
+ * to this exact shape so arbitrary third-party bookmark names can never
+ * activate the identity pass.
+ */
+const SAFE_DOCX_ANCHOR_NAME = /^_bk_[0-9a-f]{12}$/;
+
+const W_MAIN_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+function wAttribute(element: Element, localName: string): string | null {
+  return element.getAttributeNS(W_MAIN_NS, localName) ?? element.getAttribute(`w:${localName}`);
+}
+
+function adjacentElement(node: Node, direction: 'previousSibling' | 'nextSibling'): Element | null {
+  let sibling: Node | null = node[direction];
+  while (sibling && sibling.nodeType !== 1) sibling = sibling[direction];
+  return sibling as Element | null;
+}
+
+/**
  * Name of the paragraph-bracketing bookmark anchor for a group, or null.
  *
  * safe-docx brackets a managed paragraph with a uniquely named
  * `<w:bookmarkStart w:name="_bk_…"/>` inserted as the paragraph's immediately
- * preceding element sibling (docx-core `primitives/bookmarks.ts`). Only that
- * exact sibling pattern is honored: bookmarks that live inside the paragraph
- * (Word's `_GoBack`, `_Toc…`) never qualify, so ordinary third-party
+ * preceding element sibling and a matching `<w:bookmarkEnd/>` as its
+ * immediately following element sibling (docx-core `primitives/bookmarks.ts`).
+ * Only that complete bracket with the canonical `_bk_[0-9a-f]{12}` name and a
+ * start/end pair agreeing on `w:id` qualifies. Bookmarks that live inside the
+ * paragraph (Word's `_GoBack`, `_Toc…`), foreign sibling bookmark names, and
+ * orphaned or mismatched brackets never qualify, so ordinary third-party
  * documents are unaffected.
  *
  * @conformance ECMA-376 edition 5, Part 1 § 17.13.6.2
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.6.1
  * @see https://github.com/UseJunior/safe-docx/issues/846
  */
 function getGroupAnchorName(group: ComparisonUnitGroup): string | null {
@@ -661,15 +686,16 @@ function getGroupAnchorName(group: ComparisonUnitGroup): string | null {
     if (el.tagName === 'w:p') paragraph = el;
   }
   if (!paragraph) return null;
-  let sibling: Node | null = paragraph.previousSibling;
-  while (sibling && sibling.nodeType !== 1) sibling = sibling.previousSibling;
-  if (!sibling || (sibling as Element).tagName !== 'w:bookmarkStart') return null;
-  const element = sibling as Element;
-  const name = element.getAttributeNS(
-    'http://schemas.openxmlformats.org/wordprocessingml/2006/main',
-    'name',
-  ) ?? element.getAttribute('w:name');
-  return name && name.length > 0 ? name : null;
+  const start = adjacentElement(paragraph, 'previousSibling');
+  if (!start || start.tagName !== 'w:bookmarkStart') return null;
+  const name = wAttribute(start, 'name');
+  if (!name || !SAFE_DOCX_ANCHOR_NAME.test(name)) return null;
+  const end = adjacentElement(paragraph, 'nextSibling');
+  if (!end || end.tagName !== 'w:bookmarkEnd') return null;
+  const startId = wAttribute(start, 'id');
+  const endId = wAttribute(end, 'id');
+  if (startId === null || endId === null || startId !== endId) return null;
+  return name;
 }
 
 /**

--- a/packages/docx-compare/src/baselines/atomizer/hierarchicalLcs.ts
+++ b/packages/docx-compare/src/baselines/atomizer/hierarchicalLcs.ts
@@ -641,6 +641,59 @@ function similarityLcs(
 }
 
 /**
+ * Name of the paragraph-bracketing bookmark anchor for a group, or null.
+ *
+ * safe-docx brackets a managed paragraph with a uniquely named
+ * `<w:bookmarkStart w:name="_bk_…"/>` inserted as the paragraph's immediately
+ * preceding element sibling (docx-core `primitives/bookmarks.ts`). Only that
+ * exact sibling pattern is honored: bookmarks that live inside the paragraph
+ * (Word's `_GoBack`, `_Toc…`) never qualify, so ordinary third-party
+ * documents are unaffected.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.6.2
+ * @see https://github.com/UseJunior/safe-docx/issues/846
+ */
+function getGroupAnchorName(group: ComparisonUnitGroup): string | null {
+  const atom = group.atoms[0];
+  if (!atom) return null;
+  let paragraph: Element | undefined;
+  for (const el of atom.ancestorElements) {
+    if (el.tagName === 'w:p') paragraph = el;
+  }
+  if (!paragraph) return null;
+  let sibling: Node | null = paragraph.previousSibling;
+  while (sibling && sibling.nodeType !== 1) sibling = sibling.previousSibling;
+  if (!sibling || (sibling as Element).tagName !== 'w:bookmarkStart') return null;
+  const element = sibling as Element;
+  const name = element.getAttributeNS(
+    'http://schemas.openxmlformats.org/wordprocessingml/2006/main',
+    'name',
+  ) ?? element.getAttribute('w:name');
+  return name && name.length > 0 ? name : null;
+}
+
+/**
+ * Map each anchor name to its single bracketed group index. Names bracketing
+ * more than one group on a side (for example a mega-paragraph split on soft
+ * breaks into several groups) identify nothing unambiguously and are dropped.
+ */
+function buildAnchorNameMap(groups: ComparisonUnitGroup[]): Map<string, number> {
+  const byName = new Map<string, number[]>();
+  groups.forEach((group, index) => {
+    const name = getGroupAnchorName(group);
+    if (!name) return;
+    const list = byName.get(name);
+    if (list) list.push(index);
+    else byName.set(name, [index]);
+  });
+  const unique = new Map<string, number>();
+  for (const [name, indices] of byName) {
+    if (indices.length === 1) unique.set(name, indices[0]!);
+  }
+  return unique;
+}
+
+/**
  * Compute a container key for a paragraph group based on its first atom's ancestor chain.
  * Returns "" for body-level paragraphs, or a path like "w:tbl:0/w:tr:2/w:tc:1" for table cells.
  */
@@ -722,6 +775,46 @@ export function computeGroupLcs(
   // Find initially unmatched indices
   const matchedOriginal = new Set(matchedGroups.map((m) => m.originalIndex));
   const matchedRevised = new Set(matchedGroups.map((m) => m.revisedIndex));
+
+  // === Pass 1.5 (issue #846): deterministic anchor-identity matching ===
+  //
+  // A dense whole-paragraph rewrite can leave a paragraph pair with no exact
+  // atom match and a text similarity below every heuristic threshold, so the
+  // similarity passes below fall back to whole-paragraph delete + insert and
+  // every preservable common token inside the pair is needlessly revised.
+  // When both documents bracket a paragraph with the same uniquely named
+  // safe-docx bookmark anchor, the two paragraphs are the same logical
+  // paragraph by construction: identity evidence outranks text-similarity
+  // heuristics, so the pair is force-matched here, before similarity runs.
+  // Accepted pairs must stay order-consistent with the exact matches from
+  // Pass 1 and with each other, so a relocated or stale anchor can never
+  // reorder the alignment.
+  const originalAnchorNames = buildAnchorNameMap(originalGroups);
+  const revisedAnchorNames = buildAnchorNameMap(revisedGroups);
+  const anchorPairs: Array<{ originalIndex: number; revisedIndex: number }> = [];
+  for (const [name, originalIndex] of originalAnchorNames) {
+    const revisedIndex = revisedAnchorNames.get(name);
+    if (revisedIndex === undefined) continue;
+    if (matchedOriginal.has(originalIndex) || matchedRevised.has(revisedIndex)) continue;
+    anchorPairs.push({ originalIndex, revisedIndex });
+  }
+  anchorPairs.sort((a, b) => a.originalIndex - b.originalIndex);
+  const orderConsistent = (
+    pair: { originalIndex: number; revisedIndex: number },
+    others: Array<{ originalIndex: number; revisedIndex: number }>,
+  ): boolean => others.every((other) =>
+    Math.sign(pair.originalIndex - other.originalIndex) === Math.sign(pair.revisedIndex - other.revisedIndex));
+  const acceptedAnchorPairs: Array<{ originalIndex: number; revisedIndex: number }> = [];
+  for (const pair of anchorPairs) {
+    if (!orderConsistent(pair, matchedGroups) || !orderConsistent(pair, acceptedAnchorPairs)) continue;
+    acceptedAnchorPairs.push(pair);
+  }
+  for (const pair of acceptedAnchorPairs) {
+    matchedGroups.push(pair);
+    matchedOriginal.add(pair.originalIndex);
+    matchedRevised.add(pair.revisedIndex);
+  }
+  matchedGroups.sort((a, b) => a.originalIndex - b.originalIndex);
 
   let unmatchedOriginal: number[] = [];
   for (let idx = 0; idx < n; idx++) {

--- a/packages/docx-markdoc/src/compile.ts
+++ b/packages/docx-markdoc/src/compile.ts
@@ -586,9 +586,12 @@ export async function compileMarkdoc(
     author: options.author ?? 'Markdoc',
     date: options.date,
     reconstructionMode: 'inplace',
-    // Dense rewrites are easier to review as a coarser replacement than as
-    // scattered word-level "confetti". Small surgical edits remain refined.
-    maxWordRefinementChangeRanges: 6,
+    // No maxWordRefinementChangeRanges budget: a finite budget made dense
+    // rewrites fall back to coarse whole-span replacement on the run-level
+    // reconstruction paths, so ordinary source tokens the independent release
+    // verifier proves preservable were deleted and reinserted. Token-level
+    // minimality outranks "confetti" readability for authored redlines.
+    // See https://github.com/UseJunior/safe-docx/issues/846.
   });
   const tracked = comparison.document;
   const acceptedDoc = await DocxDocument.load(tracked);

--- a/packages/docx-markdoc/src/dense-rewrite-minimality.test.ts
+++ b/packages/docx-markdoc/src/dense-rewrite-minimality.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Dense brownfield rewrites must not revise preservable common tokens (#846).
+ *
+ * The independent release verifier can prove exact accept/reject projection
+ * while still finding ordinary source tokens that the emitted tracked document
+ * needlessly deletes and reinserts. Before the fix, a dense whole-paragraph
+ * rewrite whose word overlap fell below the comparison engine's paragraph
+ * similarity heuristics degraded to a coarse whole-paragraph delete + insert,
+ * and repeated nearby terms (inter-word spaces included) could survive as the
+ * occurrence the verifier does not credit. These tests compile canonical
+ * before/after Markdoc through the real emitter and judge the tracked output
+ * with the checker-owned oracle — `emittedRedlineMinimality` from
+ * `docx-release-verifier` — never with expectations derived from the emitter.
+ *
+ * All fixture prose is synthetic: invented entity names, generic obligations.
+ *
+ * @see https://github.com/UseJunior/safe-docx/issues/846
+ */
+import { describe, expect } from 'vitest';
+import JSZip from 'jszip';
+import { itAllure } from '../../docx-core/src/testing/allure-test.js';
+import { buildSyntheticDocx } from '@usejunior/docx-core';
+import { emittedRedlineMinimality } from '../../docx-release-verifier/src/minimality.js';
+import { compileMarkdoc } from './compile.js';
+import { importDocxToMarkdoc } from './import.js';
+import { requireMarkdoc } from './markdoc.js';
+
+const CONTEXT = 'Context paragraph.';
+
+/**
+ * Compile a single-paragraph canonical rewrite and score the emitted tracked
+ * document with the independent verifier's minimality oracle.
+ */
+async function compileAndScore(before: string, after: string) {
+  const original = await buildSyntheticDocx({ paragraphs: [before, CONTEXT] });
+  const imported = await importDocxToMarkdoc(original);
+  const paragraph = requireMarkdoc(imported.markdoc).scaffold[0]!;
+  const replaceBlock = [
+    `{% change id="${paragraph.id}" fingerprint="${paragraph.fingerprint}" style="${paragraph.style}" operation="rewrite" format="inherit-source-paragraph" %}`,
+    '{% before %}', before, '{% /before %}',
+    '{% after %}', after, '{% /after %}',
+    '{% /change %}',
+  ].join('\n');
+  const firstBlock = new RegExp(`\\{% para id="${paragraph.id}"[\\s\\S]*?\\{% /para %\\}`);
+  const markdoc = imported.markdoc.replace(firstBlock, replaceBlock);
+  const result = await compileMarkdoc(imported.anchoredSource, markdoc);
+  const zip = await JSZip.loadAsync(result.tracked);
+  const trackedXml = await zip.file('word/document.xml')!.async('string');
+  const evidence = emittedRedlineMinimality([before, CONTEXT], [after, CONTEXT], trackedXml);
+  return { certificate: result.certificate, trackedXml, evidence };
+}
+
+function expectZeroLoss(evidence: Awaited<ReturnType<typeof compileAndScore>>['evidence']): void {
+  expect(evidence.lostTokensByClass.lexical).toBe(0);
+  expect(evidence.lostTokensByClass.punctuation).toBe(0);
+  expect(evidence.passed).toBe(true);
+  expect(evidence.lostTokens).toBe(0);
+  expect(evidence.unresolvedTopologyParagraphs).toBe(0);
+}
+
+describe('dense rewrite token minimality', () => {
+  itAllure('[SDX-MDOC-05][SDX-MDOC-13] preserves a retained adjective and entity phrase inside a larger rewrite', async () => {
+    // Retained: "diligent" (adjective) and "Meridian Fund" (entity phrase),
+    // surrounded on both sides by a rewrite dense enough that the paragraph
+    // pair fails every text-similarity heuristic (pre-fix loss: 3 lexical,
+    // 1 punctuation via whole-paragraph delete + insert).
+    const { certificate, evidence } = await compileAndScore(
+      'The diligent Meridian Fund team prepared the annual summary.',
+      'Whenever practicable going forward, our diligent colleagues within the Meridian Fund will personally assemble and distribute every quarterly digest.',
+    );
+    expect(certificate.passed).toBe(true);
+    expectZeroLoss(evidence);
+  });
+
+  itAllure('[SDX-MDOC-05][SDX-MDOC-13] preserves a possessive entity reference and conjunction amid repeated nearby terms', async () => {
+    // Retained: one "Harbor Ltd's" possessive reference and the conjunction
+    // "and", while the source repeats "Harbor Ltd's" three times and the
+    // revision repeats "and" — multiple valid LCS alignments exist (pre-fix
+    // loss: 4 lexical, 2 punctuation).
+    const { certificate, evidence } = await compileAndScore(
+      "Harbor Ltd's agent and Harbor Ltd's counsel review Harbor Ltd's filings.",
+      "Effective immediately, Harbor Ltd's designated compliance officers and their delegates supervise every submission, disclosure, and records package.",
+    );
+    expect(certificate.passed).toBe(true);
+    expectZeroLoss(evidence);
+  });
+
+  itAllure('[SDX-MDOC-05][SDX-MDOC-13] preserves a retained entity noun and its adjacent comma amid a dense replacement', async () => {
+    // Retained: "Northwind" and the comma that follows it, amid a replacement
+    // dense enough to defeat similarity alignment, with repeated commas and
+    // repeated "and"/"its" nearby (pre-fix loss: 5 lexical, 4 punctuation).
+    const { certificate, evidence } = await compileAndScore(
+      'Subject to approval, Northwind, together with its affiliates, will fund the program.',
+      'Notwithstanding any contrary term, Northwind, acting through its designated affiliates and subsidiaries, shall exclusively finance and administer the entire program.',
+    );
+    expect(certificate.passed).toBe(true);
+    expectZeroLoss(evidence);
+  });
+
+  itAllure('[SDX-MDOC-05][SDX-MDOC-13] does not match two source occurrences of a repeated token to one emitted occurrence', async () => {
+    // "agent" appears twice in the source and once in the revision. The
+    // verifier's crediting is injective, so a passing verdict proves the one
+    // surviving ordinary "agent" is not double-counted; the tracked XML must
+    // also physically delete the second occurrence rather than absorb it.
+    const { certificate, evidence, trackedXml } = await compileAndScore(
+      'The agent shall pay the agent fee before closing.',
+      'The agent shall pay the closing fee.',
+    );
+    expect(certificate.passed).toBe(true);
+    expectZeroLoss(evidence);
+    const deletedAgents = [...trackedXml.matchAll(/<w:delText[^>]*>[^<]*agent[^<]*<\/w:delText>/gu)];
+    expect(deletedAgents).toHaveLength(1);
+    const allAgents = [...trackedXml.matchAll(/agent/gu)];
+    expect(allAgents).toHaveLength(2);
+  });
+
+  itAllure('[SDX-MDOC-05][SDX-MDOC-13] does not credit one source occurrence against two emitted occurrences', async () => {
+    // "Custodian" appears once in the source and twice in the revision. The
+    // second occurrence must be a genuine insertion, not a phantom
+    // preservation of the single source token.
+    const { certificate, evidence, trackedXml } = await compileAndScore(
+      'Notice must be delivered to the Custodian.',
+      'Notice must be delivered to the Custodian, and the Custodian must acknowledge receipt.',
+    );
+    expect(certificate.passed).toBe(true);
+    expectZeroLoss(evidence);
+    const insertionBlocks = [...trackedXml.matchAll(/<w:ins\b[\s\S]*?<\/w:ins>/gu)].map((match) => match[0]);
+    expect(insertionBlocks.filter((block) => block.includes('Custodian'))).toHaveLength(1);
+    const allCustodians = [...trackedXml.matchAll(/Custodian/gu)];
+    expect(allCustodians).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Problem

The independent release verifier (`docx-release-verifier`) proves exact accept/reject projection on Markdoc-compiled redlines while still reporting ordinary source tokens that the emitted tracked document needlessly deletes and reinserts. The losses concentrate in dense brownfield paragraph rewrites where repeated nearby terms admit multiple valid LCS alignments. The verifier is correct; the emitter pipeline was at fault.

Ref: #846

## Root causes and fix

Two alignment mechanisms inside the emitting pipeline lost preservable tokens:

1. **Paragraph-similarity fallback** (`docx-compare` `hierarchicalLcs.ts`). A canonical whole-paragraph rewrite whose word overlap falls below the paragraph-similarity thresholds (TF-IDF / Jaccard ≥ 0.25) degraded to whole-paragraph delete + insert — every preservable common token lost at once. Fix: new `computeGroupLcs` **Pass 1.5** force-matches paragraph pairs bracketed by the same uniquely named safe-docx `_bk_…` bookmark anchor (`<w:bookmarkStart/><w:p/><w:bookmarkEnd/>` sibling pattern, both sides) before similarity heuristics run. Identity evidence outranks similarity guessing; ordinary in-paragraph bookmarks (`_GoBack`, `_Toc…`) never qualify; accepted pairs must be order-consistent with exact matches, and duplicated anchor names are dropped.

2. **Last-occurrence tie-breaking** (`docx-compare` `atomLcs.ts`). `computeAtomLcs` backtracked a prefix table from the corner, so among equally optimal alignments it kept the LAST occurrence of a repeated token — inter-word spaces above all. The checker-owned LCS in `docx-release-verifier/src/minimality.ts` walks forward and (since #842) credits whitespace only via its own matched neighbor, so the emitted survivor was systematically the occurrence the checker does not credit. Fix: the selector now walks a suffix table forward from (0,0), matching earliest occurrences with the verifier's tie preference. The #584 alignment-pinning characterization suite exists precisely to force this to be a deliberate decision; its duplicate-identity pin was updated in the same change (side benefit: no more spurious `w:rPrChange` when a formatting-identical duplicate is available).

3. **Refinement budget** (`docx-markdoc` `compile.ts`). `compileMarkdoc` stops passing `maxWordRefinementChangeRanges: 6`: on the non-word-split reconstruction paths a finite budget made dense rewrites fall back to coarse run-level replacement, violating the issue's invariant that a paragraph must not lose preservable tokens merely because it exceeds a local refinement budget.

The verifier package is untouched; the oracle in every new test is the checker-owned `emittedRedlineMinimality`, never the emitter.

## Red → green evidence

All fixtures are public and synthetic (invented entities, generic prose). Pre-fix numbers were measured in this worktree by stashing the three source-file fixes and rebuilding (`git stash push -- …atomLcs.ts …hierarchicalLcs.ts …compile.ts`), running the new tests, then unstashing:

| Fixture (shape) | Pre-fix loss (verifier) | Post-fix |
| --- | --- | --- |
| 1. Retained adjective + entity phrase in larger rewrite | 3 lexical, 1 punctuation, 3 whitespace; `unresolved_ambiguous_paragraph_topology` | zero loss, passed |
| 2. Retained possessive entity + conjunction amid repeated terms | 4 lexical, 2 punctuation, 3 whitespace | zero loss, passed |
| 3. Retained entity noun + adjacent comma amid dense replacement | 5 lexical, 4 punctuation, 6 whitespace | zero loss, passed |

Pre-fix run: `dense-rewrite-minimality.test.ts` → 3 failed / 2 passed (the two repeated-token negative controls pass in both worlds, as controls should); `hierarchicalLcs-bookmark-anchor-match.test.ts` → 1 failed (positive anchor case) / 3 passed (the negative cases pin pre-existing generic behavior). Post-fix: all 9 pass.

## Negative controls

- Two source occurrences → one emitted occurrence (`agent` ×2 → ×1): verifier passes and the tracked XML physically deletes exactly one occurrence — no two-to-one crediting.
- One source occurrence → two emitted occurrences (`Custodian` ×1 → ×2): the second occurrence is a genuine `w:ins`, not a phantom preservation.
- Bookmark-anchor pass: mismatched names and duplicated names do not force alignment; anchorless dense rewrites keep their pre-existing delete+insert behavior.

## Acceptance criteria

- [x] One minimized public synthetic fixture per shape (3 total)
- [x] Each fails pre-fix with lexical/punctuation loss reported by `docx-release-verifier` (see table)
- [x] Each passes with zero lexical and punctuation loss after the fix (zero loss in all classes, in fact)
- [x] Repeated-token negative controls (both directions)
- [x] Existing paragraph-topology, numbering, mixed-format, accept/reject regressions green (full workspace suite + `test:baseline` below)
- [x] No private documents, text, names, paths, hashes, logos, or screenshots

All checkboxes are satisfied; the issue can be closed after post-merge smoke.

## Overlap with draft PR #841 (tagged-tree default)

This PR touches `packages/docx-compare/src/baselines/atomizer/{atomLcs.ts, hierarchicalLcs.ts, atomLcs-alignment-pinning.test.ts}`, which #841 also rewrites. The `docx-compare` half is load-bearing — the token loss originates in the atomizer's alignment, and no `docx-markdoc`-only change reaches it. For #841's rebase, the semantic change is: **`computeAtomLcs` now selects the earliest-occurrence optimal alignment (forward walk over a suffix table, ties advance the original side), instead of the latest-occurrence alignment (backward prefix-table backtrack)**; and `computeGroupLcs` gained an additive Pass 1.5 that force-matches paragraph groups bracketed by identical safe-docx `_bk_` bookmark siblings. The diffs are surgical (one hunk in `computeAtomLcs`, two additive hunks in `hierarchicalLcs.ts`), with no refactors or reformatting.

## Pre-submit

`npm run build` ✓ · `lint:workspaces` ✓ · `test:run` (full workspace) ✓ · `check:spec-coverage` ✓ · `check:conformance-citations` ✓ · `check:conformance-doc` ✓ · `check:allure-labels` / `check:allure-quality` / `check:allure-filenames` ✓ · `test:baseline -w @usejunior/docx-compare` ✓ (48 files / 556 tests) · coverage ratchet `coverage:packages:check` ✓ (docx-compare +29.7% lines vs baseline)
