### PR TITLE
fix(docx-compare): compare aligned footnote definitions

### DIFF
--- a/packages/docx-compare/src/baselines/atomizer/ancillaryNoteComparison.ts
+++ b/packages/docx-compare/src/baselines/atomizer/ancillaryNoteComparison.ts
@@ -1,0 +1,179 @@
+import { XMLSerializer } from '@xmldom/xmldom';
+import {
+  CorrelationStatus,
+  DEFAULT_FORMAT_DETECTION_SETTINGS,
+  DEFAULT_MOVE_DETECTION_SETTINGS,
+  type ComparisonUnitAtom,
+  type FormatDetectionSettings,
+  type OpcPart,
+} from '@usejunior/docx-core';
+import {
+  assignIdentityIds,
+  assignParagraphIndices,
+  atomizeTree,
+  IdentityInterner,
+} from '../../atomizer.js';
+import { detectFormatChangesInAtomList } from '../../format-detection.js';
+import { detectParagraphStyleChanges } from '../../paragraph-style-detection.js';
+import { assignUnifiedParagraphIndices, createMergedAtomList } from './atomLcs.js';
+import {
+  hierarchicalCompare,
+  markHierarchicalCorrelationStatus,
+} from './hierarchicalLcs.js';
+import { modifyRevisedDocument } from './inPlaceModifier.js';
+import { premergeAdjacentRuns } from './premergeRuns.js';
+import { refineFuzzyRunsWithinAlignedParagraphs } from './selectiveWordRefinement.js';
+import {
+  backfillParentReferences,
+  findBody,
+  parseDocumentXml,
+} from './xmlToWmlElement.js';
+
+const serializer = new XMLSerializer();
+const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const STORY_PART: OpcPart = {
+  uri: 'word/footnotes.xml',
+  contentType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.footnotes+xml',
+};
+
+export interface NoteDefinitionComparisonOptions {
+  author: string;
+  date: Date;
+  formatDetection?: FormatDetectionSettings;
+  premergeRuns?: boolean;
+  maxWordRefinementChangeRanges?: number;
+  preservedRoots?: readonly Element[];
+}
+
+function namespaceAttributes(entry: Element): string {
+  const declarations = new Map<string, string>();
+  let current: Element | null = entry;
+  while (current) {
+    for (let i = 0; i < current.attributes.length; i++) {
+      const attr = current.attributes.item(i)!;
+      if (attr.name === 'xmlns' || attr.name.startsWith('xmlns:')) {
+        if (!declarations.has(attr.name)) declarations.set(attr.name, attr.value);
+      }
+    }
+    current = current.parentNode?.nodeType === 1 ? current.parentNode as Element : null;
+  }
+  if (!declarations.has('xmlns:w')) declarations.set('xmlns:w', W_NS);
+  return [...declarations]
+    .map(([name, value]) => ` ${name}="${value.replaceAll('&', '&amp;').replaceAll('"', '&quot;')}"`)
+    .join('');
+}
+
+function wrapDefinition(entry: Element): string {
+  let content = '';
+  for (let child = entry.firstChild; child; child = child.nextSibling) {
+    content += serializer.serializeToString(child);
+  }
+  return `<w:document${namespaceAttributes(entry)}><w:body>${content}</w:body></w:document>`;
+}
+
+/**
+ * Compare one corresponding footnote definition as an independent Word story.
+ * The regular atomizer and in-place revision emitter are reused so paragraphs,
+ * runs, fields, and formatting receive the same structural treatment as the
+ * main story while matches cannot leak across definition boundaries.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.5.14
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.5.18
+ * @see https://github.com/UseJunior/safe-docx/issues/763
+ */
+export function compareFootnoteDefinitions(
+  originalEntry: Element,
+  revisedEntry: Element,
+  options: NoteDefinitionComparisonOptions,
+): Element[] {
+  const originalTree = parseDocumentXml(wrapDefinition(originalEntry));
+  const revisedTree = parseDocumentXml(wrapDefinition(revisedEntry));
+  backfillParentReferences(originalTree);
+  backfillParentReferences(revisedTree);
+  const originalBody = findBody(originalTree);
+  const revisedBody = findBody(revisedTree);
+  if (!originalBody || !revisedBody) throw new Error('Could not create footnote comparison story');
+
+  if (options.premergeRuns !== false) {
+    premergeAdjacentRuns(originalBody);
+    premergeAdjacentRuns(revisedBody);
+  }
+
+  let { atoms: originalAtoms } = atomizeTree(originalBody, [], STORY_PART);
+  let { atoms: revisedAtoms } = atomizeTree(revisedBody, [], STORY_PART);
+  assignParagraphIndices(originalAtoms);
+  assignParagraphIndices(revisedAtoms);
+
+  const identityInterner = new IdentityInterner();
+  assignIdentityIds(originalAtoms, identityInterner);
+  assignIdentityIds(revisedAtoms, identityInterner);
+  let lcsResult = hierarchicalCompare(originalAtoms, revisedAtoms);
+  const refined = refineFuzzyRunsWithinAlignedParagraphs(
+    originalAtoms,
+    revisedAtoms,
+    lcsResult,
+    { ...DEFAULT_MOVE_DETECTION_SETTINGS, detectMoves: false },
+    identityInterner,
+    options.maxWordRefinementChangeRanges,
+  );
+  originalAtoms = refined.originalAtoms;
+  revisedAtoms = refined.revisedAtoms;
+  lcsResult = refined.lcsResult;
+  markHierarchicalCorrelationStatus(originalAtoms, revisedAtoms, lcsResult);
+
+  const formatSettings = options.formatDetection ?? DEFAULT_FORMAT_DETECTION_SETTINGS;
+  detectParagraphStyleChanges(originalAtoms, revisedAtoms, formatSettings.detectFormatChanges);
+  if (formatSettings.detectFormatChanges) detectFormatChangesInAtomList(revisedAtoms, formatSettings);
+
+  const mergedAtoms = createMergedAtomList(originalAtoms, revisedAtoms, lcsResult);
+  assignUnifiedParagraphIndices(originalAtoms, revisedAtoms, mergedAtoms, lcsResult);
+  const comparedXml = modifyRevisedDocument(
+    revisedTree,
+    originalAtoms,
+    revisedAtoms,
+    mergedAtoms,
+    {
+      author: options.author,
+      date: options.date,
+      preservedRoots: [originalTree, ...(options.preservedRoots ?? [])],
+    },
+  );
+  const comparedBody = findBody(parseDocumentXml(comparedXml));
+  if (!comparedBody) throw new Error('Footnote comparison emitted no story body');
+  return Array.from(comparedBody.childNodes)
+    .filter((node): node is Element => node.nodeType === 1);
+}
+
+export interface CorrespondingFootnotePair {
+  originalId: string;
+  revisedId: string;
+}
+
+function referenceId(atom: ComparisonUnitAtom): string | null {
+  return atom.contentElement.tagName === 'w:footnoteReference'
+    ? atom.contentElement.getAttribute('w:id')
+    : null;
+}
+
+/**
+ * Reconcile only collision-renumbered references that the main-story LCS puts
+ * in the same aligned paragraph as a delete/insert pair. This keeps arbitrary
+ * same-ID definitions from independently authored documents collision-safe.
+ */
+export function findCorrespondingFootnotePairs(
+  mergedAtoms: readonly ComparisonUnitAtom[],
+  renumberings: readonly { label: string; fromId: string; toId: string }[],
+): CorrespondingFootnotePair[] {
+  const pairs: CorrespondingFootnotePair[] = [];
+  for (const { label, fromId, toId } of renumberings) {
+    if (label !== 'footnote') continue;
+    const deleted = mergedAtoms.filter((atom) =>
+      atom.correlationStatus === CorrelationStatus.Deleted && referenceId(atom) === fromId);
+    const inserted = mergedAtoms.filter((atom) =>
+      atom.correlationStatus === CorrelationStatus.Inserted && referenceId(atom) === toId);
+    if (deleted.length !== 1 || inserted.length !== 1) continue;
+    if (deleted[0]!.paragraphIndex !== inserted[0]!.paragraphIndex) continue;
+    pairs.push({ originalId: fromId, revisedId: toId });
+  }
+  return pairs;
+}

--- a/packages/docx-compare/src/baselines/atomizer/ancillaryNoteComparison.ts
+++ b/packages/docx-compare/src/baselines/atomizer/ancillaryNoteComparison.ts
@@ -15,12 +15,14 @@ import {
 } from '../../atomizer.js';
 import { detectFormatChangesInAtomList } from '../../format-detection.js';
 import { detectParagraphStyleChanges } from '../../paragraph-style-detection.js';
+import { extractRoundTripComparisonText } from '../../fieldComparisonSemantics.js';
 import { assignUnifiedParagraphIndices, createMergedAtomList } from './atomLcs.js';
 import {
   hierarchicalCompare,
   markHierarchicalCorrelationStatus,
 } from './hierarchicalLcs.js';
 import { modifyRevisedDocument } from './inPlaceModifier.js';
+import { acceptAllChanges, rejectAllChanges } from './trackChangesAcceptorAst.js';
 import { premergeAdjacentRuns } from './premergeRuns.js';
 import { refineFuzzyRunsWithinAlignedParagraphs } from './selectiveWordRefinement.js';
 import {
@@ -99,8 +101,14 @@ export function compareFootnoteDefinitions(
     premergeAdjacentRuns(revisedBody);
   }
 
-  let { atoms: originalAtoms } = atomizeTree(originalBody, [], STORY_PART);
-  let { atoms: revisedAtoms } = atomizeTree(revisedBody, [], STORY_PART);
+  const atomizeOptions = {
+    cloneLeafNodes: true,
+    mergeAcrossRuns: false,
+    mergePunctuationAcrossRuns: false,
+    splitTextIntoWords: true,
+  } as const;
+  let { atoms: originalAtoms } = atomizeTree(originalBody, [], STORY_PART, atomizeOptions);
+  let { atoms: revisedAtoms } = atomizeTree(revisedBody, [], STORY_PART, atomizeOptions);
   assignParagraphIndices(originalAtoms);
   assignParagraphIndices(revisedAtoms);
 
@@ -138,6 +146,17 @@ export function compareFootnoteDefinitions(
       preservedRoots: [originalTree, ...(options.preservedRoots ?? [])],
     },
   );
+  const expectedAccepted = extractRoundTripComparisonText(
+    acceptAllChanges(wrapDefinition(revisedEntry)),
+  );
+  const expectedRejected = extractRoundTripComparisonText(
+    rejectAllChanges(wrapDefinition(originalEntry)),
+  );
+  const actualAccepted = extractRoundTripComparisonText(acceptAllChanges(comparedXml));
+  const actualRejected = extractRoundTripComparisonText(rejectAllChanges(comparedXml));
+  if (actualAccepted !== expectedAccepted || actualRejected !== expectedRejected) {
+    throw new Error('Footnote definition comparison failed accept/reject projection safety');
+  }
   const comparedBody = findBody(parseDocumentXml(comparedXml));
   if (!comparedBody) throw new Error('Footnote comparison emitted no story body');
   return Array.from(comparedBody.childNodes)

--- a/packages/docx-compare/src/baselines/atomizer/ancillaryNoteComparison.ts
+++ b/packages/docx-compare/src/baselines/atomizer/ancillaryNoteComparison.ts
@@ -183,7 +183,7 @@ export function findCorrespondingFootnotePairs(
   mergedAtoms: readonly ComparisonUnitAtom[],
   renumberings: readonly { label: string; fromId: string; toId: string }[],
 ): CorrespondingFootnotePair[] {
-  const pairs: CorrespondingFootnotePair[] = [];
+  const candidates: Array<CorrespondingFootnotePair & { paragraphIndex: number }> = [];
   for (const { label, fromId, toId } of renumberings) {
     if (label !== 'footnote') continue;
     const deleted = mergedAtoms.filter((atom) =>
@@ -192,7 +192,26 @@ export function findCorrespondingFootnotePairs(
       atom.correlationStatus === CorrelationStatus.Inserted && referenceId(atom) === toId);
     if (deleted.length !== 1 || inserted.length !== 1) continue;
     if (deleted[0]!.paragraphIndex !== inserted[0]!.paragraphIndex) continue;
-    pairs.push({ originalId: fromId, revisedId: toId });
+    if (deleted[0]!.paragraphIndex === undefined) continue;
+    candidates.push({
+      originalId: fromId,
+      revisedId: toId,
+      paragraphIndex: deleted[0]!.paragraphIndex,
+    });
   }
-  return pairs;
+  const countByParagraph = new Map<number, number>();
+  for (const candidate of candidates) {
+    countByParagraph.set(
+      candidate.paragraphIndex,
+      (countByParagraph.get(candidate.paragraphIndex) ?? 0) + 1,
+    );
+  }
+  return candidates
+    .filter((candidate) => {
+      if (countByParagraph.get(candidate.paragraphIndex) !== 1) return false;
+      const referencesInParagraph = mergedAtoms.filter((atom) =>
+        atom.paragraphIndex === candidate.paragraphIndex && referenceId(atom) !== null);
+      return referencesInParagraph.length === 2;
+    })
+    .map(({ originalId, revisedId }) => ({ originalId, revisedId }));
 }

--- a/packages/docx-compare/src/baselines/atomizer/pipeline-auxiliary-notes.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline-auxiliary-notes.test.ts
@@ -22,6 +22,20 @@ async function resultParts(docx: Buffer) {
   };
 }
 
+async function replaceUserFootnoteContent(docx: Buffer, content: string): Promise<Buffer> {
+  const zip = await JSZip.loadAsync(docx);
+  const path = 'word/footnotes.xml';
+  const xml = await zip.file(path)!.async('string');
+  zip.file(
+    path,
+    xml.replace(
+      /(<w:footnote w:id="1">)[\s\S]*?(<\/w:footnote>)/,
+      `$1${content}$2`,
+    ),
+  );
+  return zip.generateAsync({ type: 'nodebuffer' });
+}
+
 describe('pipeline auxiliary note publication', () => {
   test('rebuild creates referenced footnote and endnote parts with package metadata', async ({
     given,
@@ -223,5 +237,101 @@ describe('pipeline auxiliary note publication', () => {
     expect(footnoteDefinitionRequiresCollisionSafeFallback(parseEntry('<w:p><w:hyperlink r:id="rId7"><w:r><w:t>source</w:t></w:r></w:hyperlink></w:p>'))).toBe(true);
     expect(footnoteDefinitionRequiresCollisionSafeFallback(parseEntry('<w:p><w:drawing r:embed="rId8"/></w:p>'))).toBe(true);
     expect(footnoteDefinitionRequiresCollisionSafeFallback(parseEntry('<w:p><w:r><w:t>plain</w:t></w:r></w:p>'))).toBe(false);
+  });
+
+  test('rsid-split two-run definitions do not duplicate retained text', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    let original: Buffer;
+    let revised: Buffer;
+    let result: Awaited<ReturnType<typeof compareDocumentsAtomizer>>;
+
+    await given('aligned footnotes split unchanged and changed text across separate rsid runs', async () => {
+      original = await buildSyntheticDocx({
+        paragraphs: ['Aligned body'],
+        footnoteOnParagraph: 0,
+        footnoteText: 'placeholder',
+      });
+      revised = await buildSyntheticDocx({
+        paragraphs: ['Aligned body'],
+        footnoteOnParagraph: 0,
+        footnoteText: 'placeholder',
+      });
+      original = await replaceUserFootnoteContent(
+        original,
+        '<w:p><w:r w:rsidR="00000001"><w:t>Shared </w:t></w:r>' +
+          '<w:r w:rsidR="00000002"><w:t>before</w:t></w:r></w:p>',
+      );
+      revised = await replaceUserFootnoteContent(
+        revised,
+        '<w:p><w:r w:rsidR="00000003"><w:t>Shared </w:t></w:r>' +
+          '<w:r w:rsidR="00000004"><w:t>after</w:t></w:r></w:p>',
+      );
+    });
+
+    await when('the pair is compared in place', async () => {
+      result = await compareDocumentsAtomizer(original, revised, {
+        reconstructionMode: 'inplace',
+        moveDetection: { detectMoves: false },
+      });
+    });
+
+    await then('one definition retains one shared prefix and tracks only the changed suffix', async () => {
+      const parts = await resultParts(result.document);
+      expect(parts.footnotesXml?.match(/Shared /g)).toHaveLength(1);
+      expect(parts.footnotesXml).toContain('<w:delText>before</w:delText>');
+      expect(parts.footnotesXml).toContain('<w:t>after</w:t>');
+      expect(parts.footnotesXml?.match(/<w:footnote\b/g)).toHaveLength(3);
+    });
+  });
+
+  test('unrepresentable table-to-paragraph definitions retain collision-safe definitions', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    let original: Buffer;
+    let revised: Buffer;
+    let result: Awaited<ReturnType<typeof compareDocumentsAtomizer>>;
+
+    await given('an aligned footnote changes from table content to a paragraph', async () => {
+      original = await buildSyntheticDocx({
+        paragraphs: ['Aligned body'],
+        footnoteOnParagraph: 0,
+        footnoteText: 'placeholder',
+      });
+      revised = await buildSyntheticDocx({
+        paragraphs: ['Aligned body'],
+        footnoteOnParagraph: 0,
+        footnoteText: 'placeholder',
+      });
+      original = await replaceUserFootnoteContent(
+        original,
+        '<w:tbl><w:tr><w:tc><w:p><w:r><w:t>Original table note</w:t></w:r></w:p></w:tc></w:tr></w:tbl>',
+      );
+      revised = await replaceUserFootnoteContent(
+        revised,
+        '<w:p><w:r><w:t>Revised paragraph note</w:t></w:r></w:p>',
+      );
+    });
+
+    await when('the document is compared', async () => {
+      result = await compareDocumentsAtomizer(original, revised, {
+        reconstructionMode: 'rebuild',
+        moveDetection: { detectMoves: false },
+      });
+    });
+
+    await then('comparison succeeds with both definitions and resolvable distinct references', async () => {
+      const parts = await resultParts(result.document);
+      expect(parts.footnotesXml).toContain('Original table note');
+      expect(parts.footnotesXml).toContain('Revised paragraph note');
+      expect(parts.footnotesXml).toMatch(/<w:footnote w:id="1"/);
+      expect(parts.footnotesXml).toMatch(/<w:footnote w:id="2"/);
+      expect(parts.documentXml).toMatch(/<w:footnoteReference w:id="1"/);
+      expect(parts.documentXml).toMatch(/<w:footnoteReference w:id="2"/);
+    });
   });
 });

--- a/packages/docx-compare/src/baselines/atomizer/pipeline-auxiliary-notes.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline-auxiliary-notes.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect } from 'vitest';
 import JSZip from 'jszip';
+import { DOMParser } from '@xmldom/xmldom';
 import { buildSyntheticDocx } from '@usejunior/docx-core';
-import { compareDocumentsAtomizer } from './pipeline.js';
+import { compareDocumentsAtomizer, footnoteDefinitionRequiresCollisionSafeFallback } from './pipeline.js';
 import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
 
 const test = testAllure
@@ -211,5 +212,16 @@ describe('pipeline auxiliary note publication', () => {
       expect(parts.footnotesXml).toContain('<w:t>After</w:t>');
       expect(parts.documentXml?.match(/<w:footnoteReference w:id="2"/g)).toHaveLength(1);
     });
+  });
+
+  test('field and relationship-bearing definitions retain the collision-safe fallback', () => {
+    const parseEntry = (content: string) => new DOMParser().parseFromString(
+      `<w:footnote xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">${content}</w:footnote>`,
+      'application/xml',
+    ).documentElement;
+    expect(footnoteDefinitionRequiresCollisionSafeFallback(parseEntry('<w:p><w:fldSimple w:instr=" PAGE "><w:r><w:t>7</w:t></w:r></w:fldSimple></w:p>'))).toBe(true);
+    expect(footnoteDefinitionRequiresCollisionSafeFallback(parseEntry('<w:p><w:hyperlink r:id="rId7"><w:r><w:t>source</w:t></w:r></w:hyperlink></w:p>'))).toBe(true);
+    expect(footnoteDefinitionRequiresCollisionSafeFallback(parseEntry('<w:p><w:drawing r:embed="rId8"/></w:p>'))).toBe(true);
+    expect(footnoteDefinitionRequiresCollisionSafeFallback(parseEntry('<w:p><w:r><w:t>plain</w:t></w:r></w:p>'))).toBe(false);
   });
 });

--- a/packages/docx-compare/src/baselines/atomizer/pipeline-auxiliary-notes.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline-auxiliary-notes.test.ts
@@ -82,7 +82,7 @@ describe('pipeline auxiliary note publication', () => {
     });
   });
 
-  test('rebuild appends a renumbered revised footnote to an existing original part', async ({
+  test('rebuild compares corresponding collision-renumbered footnote definitions in place', async ({
     given,
     when,
     then,
@@ -112,18 +112,104 @@ describe('pipeline auxiliary note publication', () => {
       });
     });
 
-    await then('the output preserves both independently authored definitions', async () => {
+    await then('one definition carries the old and new text as tracked content', async () => {
       const parts = await resultParts(result.document);
-      expect(parts.footnotesXml).toContain('Original footnote definition');
-      expect(parts.footnotesXml).toContain('Revised footnote definition');
+      expect(parts.footnotesXml?.match(/<w:footnote\b/g)).toHaveLength(3);
+      expect(parts.footnotesXml).toContain('<w:del');
+      expect(parts.footnotesXml).toContain('<w:delText>Original</w:delText>');
+      expect(parts.footnotesXml).toContain('<w:ins');
+      expect(parts.footnotesXml).toContain('<w:t>Revised</w:t>');
+      testAllure.conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.5.14' });
+      testAllure.conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.5.18' });
     });
 
-    await and('the revised anchor points at a distinct non-reserved id', async () => {
+    await and('both tracked reference sides resolve to that one definition', async () => {
       const parts = await resultParts(result.document);
-      expect(parts.documentXml).toMatch(/<w:footnoteReference w:id="2"/);
-      expect(parts.footnotesXml).toMatch(/<w:footnote w:id="2"/);
+      expect(parts.documentXml?.match(/<w:footnoteReference w:id="1"/g)).toHaveLength(2);
+      expect(parts.footnotesXml).not.toMatch(/<w:footnote w:id="2"/);
       expect(result.stats.insertions).toBeGreaterThan(0);
       expect(result.stats.deletions).toBeGreaterThan(0);
+    });
+  });
+
+  test('rebuild keeps structurally unrelated colliding footnotes distinct', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    let original: Buffer;
+    let revised: Buffer;
+    let result: Awaited<ReturnType<typeof compareDocumentsAtomizer>>;
+
+    await given('same-ID footnotes are anchored in unrelated deleted and inserted paragraphs', async () => {
+      original = await buildSyntheticDocx({
+        paragraphs: ['Original note anchor', 'Stable paragraph'],
+        footnoteOnParagraph: 0,
+        footnoteText: 'Original independent definition',
+      });
+      revised = await buildSyntheticDocx({
+        paragraphs: ['Stable paragraph', 'Revised note anchor'],
+        footnoteOnParagraph: 1,
+        footnoteText: 'Revised independent definition',
+      });
+    });
+
+    await when('the collision-aware pipeline compares the documents', async () => {
+      result = await compareDocumentsAtomizer(original, revised, {
+        reconstructionMode: 'rebuild',
+        moveDetection: { detectMoves: false },
+      });
+    });
+
+    await then('renumbering preserves two definitions and two reference identities', async () => {
+      const parts = await resultParts(result.document);
+      expect(parts.footnotesXml).toContain('Original independent definition');
+      expect(parts.footnotesXml).toContain('Revised independent definition');
+      expect(parts.footnotesXml).toMatch(/<w:footnote w:id="1"/);
+      expect(parts.footnotesXml).toMatch(/<w:footnote w:id="2"/);
+      expect(parts.documentXml).toMatch(/<w:footnoteReference w:id="1"/);
+      expect(parts.documentXml).toMatch(/<w:footnoteReference w:id="2"/);
+    });
+  });
+
+  test('inplace compares a corresponding definition under the revised collision-safe id', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    let original: Buffer;
+    let revised: Buffer;
+    let result: Awaited<ReturnType<typeof compareDocumentsAtomizer>>;
+
+    await given('one aligned footnote changes text while retaining its source-local id', async () => {
+      original = await buildSyntheticDocx({
+        paragraphs: ['Aligned body'],
+        footnoteOnParagraph: 0,
+        footnoteText: 'Before note text',
+      });
+      revised = await buildSyntheticDocx({
+        paragraphs: ['Aligned body'],
+        footnoteOnParagraph: 0,
+        footnoteText: 'After note text',
+      });
+    });
+
+    await when('the pair is compared in place', async () => {
+      result = await compareDocumentsAtomizer(original, revised, {
+        reconstructionMode: 'inplace',
+        moveDetection: { detectMoves: false },
+      });
+    });
+
+    await then('one revised-ID definition contains both tracked text sides', async () => {
+      const parts = await resultParts(result.document);
+      expect(result.reconstructionModeUsed).toBe('inplace');
+      expect(parts.footnotesXml?.match(/<w:footnote\b/g)).toHaveLength(3);
+      expect(parts.footnotesXml).toMatch(/<w:footnote w:id="2"/);
+      expect(parts.footnotesXml).not.toMatch(/<w:footnote w:id="1"/);
+      expect(parts.footnotesXml).toContain('<w:delText>Before</w:delText>');
+      expect(parts.footnotesXml).toContain('<w:t>After</w:t>');
+      expect(parts.documentXml?.match(/<w:footnoteReference w:id="2"/g)).toHaveLength(1);
     });
   });
 });

--- a/packages/docx-compare/src/baselines/atomizer/pipeline-auxiliary-notes.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline-auxiliary-notes.test.ts
@@ -218,7 +218,7 @@ describe('pipeline auxiliary note publication', () => {
     const parseEntry = (content: string) => new DOMParser().parseFromString(
       `<w:footnote xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">${content}</w:footnote>`,
       'application/xml',
-    ).documentElement;
+    ).documentElement as unknown as Element;
     expect(footnoteDefinitionRequiresCollisionSafeFallback(parseEntry('<w:p><w:fldSimple w:instr=" PAGE "><w:r><w:t>7</w:t></w:r></w:fldSimple></w:p>'))).toBe(true);
     expect(footnoteDefinitionRequiresCollisionSafeFallback(parseEntry('<w:p><w:hyperlink r:id="rId7"><w:r><w:t>source</w:t></w:r></w:hyperlink></w:p>'))).toBe(true);
     expect(footnoteDefinitionRequiresCollisionSafeFallback(parseEntry('<w:p><w:drawing r:embed="rId8"/></w:p>'))).toBe(true);

--- a/packages/docx-compare/src/baselines/atomizer/pipeline-auxiliary-notes.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline-auxiliary-notes.test.ts
@@ -3,6 +3,7 @@ import JSZip from 'jszip';
 import { DOMParser } from '@xmldom/xmldom';
 import { buildSyntheticDocx } from '@usejunior/docx-core';
 import { compareDocumentsAtomizer, footnoteDefinitionRequiresCollisionSafeFallback } from './pipeline.js';
+import { acceptAllChanges, rejectAllChanges } from './trackChangesAcceptorAst.js';
 import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
 
 const test = testAllure
@@ -31,6 +32,30 @@ async function replaceUserFootnoteContent(docx: Buffer, content: string): Promis
     xml.replace(
       /(<w:footnote w:id="1">)[\s\S]*?(<\/w:footnote>)/,
       `$1${content}$2`,
+    ),
+  );
+  return zip.generateAsync({ type: 'nodebuffer' });
+}
+
+async function addSecondFootnote(docx: Buffer, text: string): Promise<Buffer> {
+  const zip = await JSZip.loadAsync(docx);
+  const documentPath = 'word/document.xml';
+  const documentXml = await zip.file(documentPath)!.async('string');
+  zip.file(
+    documentPath,
+    documentXml.replace(
+      '</w:p>',
+      '<w:r><w:footnoteReference w:id="2"/></w:r></w:p>',
+    ),
+  );
+  const footnotePath = 'word/footnotes.xml';
+  const footnotesXml = await zip.file(footnotePath)!.async('string');
+  zip.file(
+    footnotePath,
+    footnotesXml.replace(
+      '</w:footnotes>',
+      `<w:footnote w:id="2"><w:p><w:r><w:t>${text}</w:t></w:r></w:p></w:footnote>` +
+        '</w:footnotes>',
     ),
   );
   return zip.generateAsync({ type: 'nodebuffer' });
@@ -332,6 +357,64 @@ describe('pipeline auxiliary note publication', () => {
       expect(parts.footnotesXml).toMatch(/<w:footnote w:id="2"/);
       expect(parts.documentXml).toMatch(/<w:footnoteReference w:id="1"/);
       expect(parts.documentXml).toMatch(/<w:footnoteReference w:id="2"/);
+    });
+  });
+
+  test('two edited footnotes in one aligned paragraph skip ambiguous ID reconciliation', async ({
+    given,
+    when,
+    then,
+  }: AllureBddContext) => {
+    let original: Buffer;
+    let revised: Buffer;
+    let result: Awaited<ReturnType<typeof compareDocumentsAtomizer>>;
+
+    await given('one aligned paragraph contains two independently edited footnote anchors', async () => {
+      original = await buildSyntheticDocx({
+        paragraphs: ['Stable body'],
+        footnoteOnParagraph: 0,
+        footnoteText: 'Original first note',
+      });
+      revised = await buildSyntheticDocx({
+        paragraphs: ['Stable body'],
+        footnoteOnParagraph: 0,
+        footnoteText: 'Revised first note',
+      });
+      original = await addSecondFootnote(original, 'Original second note');
+      revised = await addSecondFootnote(revised, 'Revised second note');
+    });
+
+    await when('the pair is compared in rebuild mode', async () => {
+      result = await compareDocumentsAtomizer(original, revised, {
+        reconstructionMode: 'rebuild',
+        moveDetection: { detectMoves: false },
+      });
+    });
+
+    await then('the ambiguous pairs are not rewritten and projections retain both anchors', async () => {
+      const parts = await resultParts(result.document);
+      expect(parts.footnotesXml).toContain('Original first note');
+      expect(parts.footnotesXml).toContain('Original second note');
+      expect(parts.footnotesXml).toContain('Revised first note');
+      expect(parts.footnotesXml).not.toContain('<w:ins');
+      expect(parts.footnotesXml).not.toContain('<w:del');
+
+      const accepted = acceptAllChanges(parts.documentXml!);
+      const rejected = rejectAllChanges(parts.documentXml!);
+      expect(accepted.match(/<w:footnoteReference\b/g)?.length ?? 0).toBeGreaterThan(0);
+      expect(rejected.match(/<w:footnoteReference\b/g)?.length ?? 0).toBeGreaterThan(0);
+      expect(accepted).not.toContain('<w:del');
+      expect(rejected).not.toContain('<w:ins');
+
+      const definitionIds = new Set(
+        [...parts.footnotesXml!.matchAll(/<w:footnote\b[^>]*w:id="([^\"]+)"/g)]
+          .map((match) => match[1]),
+      );
+      for (const projection of [accepted, rejected]) {
+        for (const match of projection.matchAll(/<w:footnoteReference\b[^>]*w:id="([^\"]+)"/g)) {
+          expect(definitionIds.has(match[1]!)).toBe(true);
+        }
+      }
     });
   });
 });

--- a/packages/docx-compare/src/baselines/atomizer/pipeline.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline.ts
@@ -1448,18 +1448,10 @@ async function reconcileCorrespondingFootnoteDefinitions(
     // auxiliary anchors need their own relationship-aware story comparison.
     // Keep the collision-safe two-definition representation for those shapes
     // until their dedicated structural comparers can participate here.
-    const unsupportedTags = [
-      'w:fldChar',
-      'w:commentReference',
-      'w:commentRangeStart',
-      'w:commentRangeEnd',
-      'w:footnoteReference',
-      'w:endnoteReference',
-    ];
-    if (unsupportedTags.some((tag) =>
-      originalEntry.getElementsByTagName(tag).length > 0 ||
-      revisedEntry.getElementsByTagName(tag).length > 0
-    )) continue;
+    if (
+      footnoteDefinitionRequiresCollisionSafeFallback(originalEntry) ||
+      footnoteDefinitionRequiresCollisionSafeFallback(revisedEntry)
+    ) continue;
 
     const comparedChildren = compareFootnoteDefinitions(originalEntry, revisedEntry, {
       author: options.author,
@@ -1483,6 +1475,31 @@ async function reconcileCorrespondingFootnoteDefinitions(
 
   options.resultArchive.setFile('word/footnotes.xml', serializer.serializeToString(resultParsed.doc));
   return serializer.serializeToString(documentDoc);
+}
+
+export function footnoteDefinitionRequiresCollisionSafeFallback(entry: Element): boolean {
+  const unsupportedTags = [
+    'w:fldChar',
+    'w:fldSimple',
+    'w:hyperlink',
+    'w:commentReference',
+    'w:commentRangeStart',
+    'w:commentRangeEnd',
+    'w:footnoteReference',
+    'w:endnoteReference',
+  ];
+  if (unsupportedTags.some((tag) => entry.getElementsByTagName(tag).length > 0)) return true;
+  const elements = [entry, ...Array.from(entry.getElementsByTagName('*'))] as Element[];
+  return elements.some((element) => {
+    for (let index = 0; index < element.attributes.length; index++) {
+      const attribute = element.attributes.item(index)!;
+      if (
+        attribute.namespaceURI === 'http://schemas.openxmlformats.org/officeDocument/2006/relationships' ||
+        attribute.name.startsWith('r:')
+      ) return true;
+    }
+    return false;
+  });
 }
 
 /**

--- a/packages/docx-compare/src/baselines/atomizer/pipeline.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline.ts
@@ -1453,14 +1453,22 @@ async function reconcileCorrespondingFootnoteDefinitions(
       footnoteDefinitionRequiresCollisionSafeFallback(revisedEntry)
     ) continue;
 
-    const comparedChildren = compareFootnoteDefinitions(originalEntry, revisedEntry, {
-      author: options.author,
-      date: options.date,
-      formatDetection: options.formatDetection,
-      premergeRuns: options.premergeRuns,
-      maxWordRefinementChangeRanges: options.maxWordRefinementChangeRanges,
-      preservedRoots: [documentDoc.documentElement, resultParsed.doc.documentElement],
-    });
+    let comparedChildren: Element[];
+    try {
+      comparedChildren = compareFootnoteDefinitions(originalEntry, revisedEntry, {
+        author: options.author,
+        date: options.date,
+        formatDetection: options.formatDetection,
+        premergeRuns: options.premergeRuns,
+        maxWordRefinementChangeRanges: options.maxWordRefinementChangeRanges,
+        preservedRoots: [documentDoc.documentElement, resultParsed.doc.documentElement],
+      });
+    } catch {
+      // A note definition is an independent optional comparison story. If its
+      // topology cannot be represented safely, retain both collision-renumbered
+      // definitions rather than failing or weakening the whole document result.
+      continue;
+    }
     while (targetEntry.firstChild) targetEntry.removeChild(targetEntry.firstChild);
     for (const child of comparedChildren) {
       targetEntry.appendChild(resultParsed.doc.importNode(child, true));

--- a/packages/docx-compare/src/baselines/atomizer/pipeline.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline.ts
@@ -138,6 +138,10 @@ import {
   rejectedSelectedAncillaryStoryPaths,
   UnsupportedTextBoxRevisionError,
 } from './textBoxRevisionSafety.js';
+import {
+  compareFootnoteDefinitions,
+  findCorrespondingFootnotePairs,
+} from './ancillaryNoteComparison.js';
 
 /**
  * Options for the atomizer pipeline.
@@ -840,7 +844,10 @@ async function compareDocumentsAtomizerCore(
   // row in the merged output can bind to the other document's definition.
   // Must run before any document.xml extraction so every downstream step sees
   // the rewritten archive.
-  await renumberCollidingAuxiliaryIds(originalArchive, revisedArchive);
+  const auxiliaryIdRenumberings = await renumberCollidingAuxiliaryIds(
+    originalArchive,
+    revisedArchive,
+  );
   await restampCollidingCommentParaIds(originalArchive, revisedArchive);
 
   // Step 1c: Resolve relationship ID collisions for the same reason. `rId9`
@@ -1231,13 +1238,27 @@ async function compareDocumentsAtomizerCore(
     resultBuffer: Buffer;
     ancillaryFieldEvidence: AncillaryFieldEvidence;
   }> => {
-    const { newDocumentXml } = candidate;
+    let { newDocumentXml } = candidate;
     // Step 12: Clone the mode-selected archive and update document.xml.
     const baseArchive = candidate.outputMode === 'inplace' ? revisedArchive : originalArchive;
     const mergeSourceArchive = candidate.outputMode === 'inplace' ? originalArchive : revisedArchive;
     const baseSide = candidate.outputMode === 'inplace' ? 'revised' : 'original';
     const mergeSourceSide = candidate.outputMode === 'inplace' ? 'original' : 'revised';
     const resultArchive = await baseArchive.clone();
+    newDocumentXml = await reconcileCorrespondingFootnoteDefinitions({
+      originalArchive,
+      revisedArchive,
+      resultArchive,
+      documentXml: newDocumentXml,
+      outputMode: candidate.outputMode,
+      mergedAtoms: candidate.mergedAtoms,
+      auxiliaryIdRenumberings,
+      author,
+      date,
+      formatDetection: formatSettings,
+      premergeRuns,
+      maxWordRefinementChangeRanges,
+    });
     maybeCaptureEmittedDocumentXml(newDocumentXml);
     resultArchive.setDocumentXml(newDocumentXml);
 
@@ -1370,6 +1391,98 @@ async function compareDocumentsAtomizerCore(
 export interface AuxiliaryMergeResult {
   mergedIds: Set<string>;
   createdPart: boolean;
+}
+
+interface ReconcileFootnoteDefinitionsOptions {
+  originalArchive: DocxArchive;
+  revisedArchive: DocxArchive;
+  resultArchive: DocxArchive;
+  documentXml: string;
+  outputMode: ReconstructionMode;
+  mergedAtoms: readonly ComparisonUnitAtom[];
+  auxiliaryIdRenumberings: readonly { label: string; fromId: string; toId: string }[];
+  author: string;
+  date: Date;
+  formatDetection: FormatDetectionSettings;
+  premergeRuns: boolean;
+  maxWordRefinementChangeRanges?: number;
+}
+
+/**
+ * Collapse an aligned delete/insert footnote reference pair back onto one
+ * definition and compare that definition as an independent story. Collision
+ * renumbering still runs first and remains authoritative for every unrelated
+ * auxiliary-ID collision.
+ *
+ * @see https://github.com/UseJunior/safe-docx/issues/763
+ */
+async function reconcileCorrespondingFootnoteDefinitions(
+  options: ReconcileFootnoteDefinitionsOptions,
+): Promise<string> {
+  const pairs = findCorrespondingFootnotePairs(
+    options.mergedAtoms,
+    options.auxiliaryIdRenumberings,
+  );
+  if (pairs.length === 0) return options.documentXml;
+
+  const [originalXml, revisedXml, resultXml] = await Promise.all([
+    options.originalArchive.getFile('word/footnotes.xml'),
+    options.revisedArchive.getFile('word/footnotes.xml'),
+    options.resultArchive.getFile('word/footnotes.xml'),
+  ]);
+  if (!originalXml || !revisedXml || !resultXml) return options.documentXml;
+
+  const originalParsed = parseEntries(originalXml, 'w:footnote');
+  const revisedParsed = parseEntries(revisedXml, 'w:footnote');
+  const resultParsed = parseEntries(resultXml, 'w:footnote');
+  const documentDoc = parseXml(options.documentXml);
+
+  for (const pair of pairs) {
+    const originalEntry = originalParsed.entries.get(pair.originalId);
+    const revisedEntry = revisedParsed.entries.get(pair.revisedId);
+    const targetId = options.outputMode === 'inplace' ? pair.revisedId : pair.originalId;
+    const discardedId = options.outputMode === 'inplace' ? pair.originalId : pair.revisedId;
+    const targetEntry = resultParsed.entries.get(targetId);
+    if (!originalEntry || !revisedEntry || !targetEntry) continue;
+    // Field ranges have a separate exact-preservation gate, and nested
+    // auxiliary anchors need their own relationship-aware story comparison.
+    // Keep the collision-safe two-definition representation for those shapes
+    // until their dedicated structural comparers can participate here.
+    const unsupportedTags = [
+      'w:fldChar',
+      'w:commentReference',
+      'w:commentRangeStart',
+      'w:commentRangeEnd',
+      'w:footnoteReference',
+      'w:endnoteReference',
+    ];
+    if (unsupportedTags.some((tag) =>
+      originalEntry.getElementsByTagName(tag).length > 0 ||
+      revisedEntry.getElementsByTagName(tag).length > 0
+    )) continue;
+
+    const comparedChildren = compareFootnoteDefinitions(originalEntry, revisedEntry, {
+      author: options.author,
+      date: options.date,
+      formatDetection: options.formatDetection,
+      premergeRuns: options.premergeRuns,
+      maxWordRefinementChangeRanges: options.maxWordRefinementChangeRanges,
+      preservedRoots: [documentDoc.documentElement, resultParsed.doc.documentElement],
+    });
+    while (targetEntry.firstChild) targetEntry.removeChild(targetEntry.firstChild);
+    for (const child of comparedChildren) {
+      targetEntry.appendChild(resultParsed.doc.importNode(child, true));
+    }
+
+    const references = documentDoc.getElementsByTagName('w:footnoteReference');
+    for (let i = 0; i < references.length; i++) {
+      const reference = references[i] as Element;
+      if (reference.getAttribute('w:id') === discardedId) reference.setAttribute('w:id', targetId);
+    }
+  }
+
+  options.resultArchive.setFile('word/footnotes.xml', serializer.serializeToString(resultParsed.doc));
+  return serializer.serializeToString(documentDoc);
 }
 
 /**

--- a/packages/docx-compare/src/baselines/atomizer/pipeline.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline.ts
@@ -1425,10 +1425,12 @@ async function reconcileCorrespondingFootnoteDefinitions(
   );
   if (pairs.length === 0) return options.documentXml;
 
-  const [originalXml, revisedXml, resultXml] = await Promise.all([
+  const [originalXml, revisedXml, resultXml, originalDocumentXml, revisedDocumentXml] = await Promise.all([
     options.originalArchive.getFile('word/footnotes.xml'),
     options.revisedArchive.getFile('word/footnotes.xml'),
     options.resultArchive.getFile('word/footnotes.xml'),
+    options.originalArchive.getDocumentXml(),
+    options.revisedArchive.getDocumentXml(),
   ]);
   if (!originalXml || !revisedXml || !resultXml) return options.documentXml;
 
@@ -1436,6 +1438,8 @@ async function reconcileCorrespondingFootnoteDefinitions(
   const revisedParsed = parseEntries(revisedXml, 'w:footnote');
   const resultParsed = parseEntries(resultXml, 'w:footnote');
   const documentDoc = parseXml(options.documentXml);
+  const originalDocumentDoc = parseXml(originalDocumentXml);
+  const revisedDocumentDoc = parseXml(revisedDocumentXml);
 
   for (const pair of pairs) {
     const originalEntry = originalParsed.entries.get(pair.originalId);
@@ -1444,6 +1448,13 @@ async function reconcileCorrespondingFootnoteDefinitions(
     const discardedId = options.outputMode === 'inplace' ? pair.originalId : pair.revisedId;
     const targetEntry = resultParsed.entries.get(targetId);
     if (!originalEntry || !revisedEntry || !targetEntry) continue;
+    if (!isOnlyFootnoteAnchorInSourceParagraph(originalDocumentDoc, pair.originalId) ||
+        !isOnlyFootnoteAnchorInSourceParagraph(revisedDocumentDoc, pair.revisedId)) continue;
+    if (!hasSafeEmittedFootnoteReferenceShape(
+      documentDoc,
+      pair.originalId,
+      pair.revisedId,
+    )) continue;
     // Field ranges have a separate exact-preservation gate, and nested
     // auxiliary anchors need their own relationship-aware story comparison.
     // Keep the collision-safe two-definition representation for those shapes
@@ -1483,6 +1494,96 @@ async function reconcileCorrespondingFootnoteDefinitions(
 
   options.resultArchive.setFile('word/footnotes.xml', serializer.serializeToString(resultParsed.doc));
   return serializer.serializeToString(documentDoc);
+}
+
+function isOnlyFootnoteAnchorInSourceParagraph(documentDoc: Document, id: string): boolean {
+  const matches: Element[] = [];
+  const references = documentDoc.getElementsByTagName('w:footnoteReference');
+  for (let i = 0; i < references.length; i++) {
+    const reference = references[i] as Element;
+    if (reference.getAttribute('w:id') === id) matches.push(reference);
+  }
+  if (matches.length !== 1) return false;
+  const paragraph = ancestorElement(matches[0]!, 'w:p');
+  return paragraph?.getElementsByTagName('w:footnoteReference').length === 1;
+}
+
+function hasAncestorTag(element: Element, tagName: string): boolean {
+  let current = element.parentNode;
+  while (current?.nodeType === 1) {
+    if ((current as Element).tagName === tagName) return true;
+    current = current.parentNode;
+  }
+  return false;
+}
+
+function ancestorElement(element: Element, tagName: string): Element | null {
+  let current = element.parentNode;
+  while (current?.nodeType === 1) {
+    if ((current as Element).tagName === tagName) return current as Element;
+    current = current.parentNode;
+  }
+  return null;
+}
+
+/**
+ * Require either Word's explicit deleted/inserted reference pair or a single
+ * unchanged live reference. Ambiguous multiplicity and mixed wrapper shapes
+ * retain collision-safe definitions rather than rewriting every matching ID.
+ *
+ * Endnote definition reconciliation is intentionally outside #763; endnotes
+ * continue to use collision-safe renumbering and merge behavior.
+ */
+function hasSafeEmittedFootnoteReferenceShape(
+  documentDoc: Document,
+  originalId: string,
+  revisedId: string,
+): boolean {
+  const original: Element[] = [];
+  const revised: Element[] = [];
+  const references = documentDoc.getElementsByTagName('w:footnoteReference');
+  for (let i = 0; i < references.length; i++) {
+    const reference = references[i] as Element;
+    const id = reference.getAttribute('w:id');
+    if (id === originalId) original.push(reference);
+    if (id === revisedId) revised.push(reference);
+  }
+  const originalParagraph = original[0] ? ancestorElement(original[0], 'w:p') : null;
+  const revisedParagraph = revised[0] ? ancestorElement(revised[0], 'w:p') : null;
+  const pairParagraphIsUnambiguous =
+    originalParagraph !== null &&
+    originalParagraph === revisedParagraph &&
+    originalParagraph.getElementsByTagName('w:footnoteReference').length === 2;
+  const explicitPair =
+    original.length === 1 &&
+    revised.length === 1 &&
+    pairParagraphIsUnambiguous &&
+    hasAncestorTag(original[0]!, 'w:del') &&
+    hasAncestorTag(revised[0]!, 'w:ins');
+  const stableReference =
+    original.length === 0 &&
+    revised.length === 1 &&
+    revisedParagraph?.getElementsByTagName('w:footnoteReference').length === 1 &&
+    !hasAncestorTag(revised[0]!, 'w:del') &&
+    !hasAncestorTag(revised[0]!, 'w:ins');
+  const projectionPair = (() => {
+    if (original.length !== 1 || revised.length !== 1 || !pairParagraphIsUnambiguous) return false;
+    const accepted = parseXml(acceptAllChanges(serializer.serializeToString(documentDoc)));
+    const rejected = parseXml(rejectAllChanges(serializer.serializeToString(documentDoc)));
+    const count = (doc: Document, id: string): number => {
+      let matches = 0;
+      const refs = doc.getElementsByTagName('w:footnoteReference');
+      for (let i = 0; i < refs.length; i++) {
+        if ((refs[i] as Element).getAttribute('w:id') === id) matches++;
+      }
+      return matches;
+    };
+    return count(accepted, originalId) === 0 &&
+      count(accepted, revisedId) === 1 &&
+      count(rejected, originalId) === 1 &&
+      count(rejected, revisedId) === 0;
+  })();
+  return explicitPair || stableReference || projectionPair;
 }
 
 export function footnoteDefinitionRequiresCollisionSafeFallback(entry: Element): boolean {

--- a/packages/docx-compare/src/baselines/atomizer/pipeline.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline.ts
@@ -1440,6 +1440,14 @@ async function reconcileCorrespondingFootnoteDefinitions(
   const documentDoc = parseXml(options.documentXml);
   const originalDocumentDoc = parseXml(originalDocumentXml);
   const revisedDocumentDoc = parseXml(revisedDocumentXml);
+  let projectionDocs: FootnoteReferenceProjectionDocs | undefined;
+  const getProjectionDocs = (): FootnoteReferenceProjectionDocs => {
+    projectionDocs ??= {
+      accepted: parseXml(acceptAllChanges(options.documentXml)),
+      rejected: parseXml(rejectAllChanges(options.documentXml)),
+    };
+    return projectionDocs;
+  };
 
   for (const pair of pairs) {
     const originalEntry = originalParsed.entries.get(pair.originalId);
@@ -1448,21 +1456,20 @@ async function reconcileCorrespondingFootnoteDefinitions(
     const discardedId = options.outputMode === 'inplace' ? pair.originalId : pair.revisedId;
     const targetEntry = resultParsed.entries.get(targetId);
     if (!originalEntry || !revisedEntry || !targetEntry) continue;
+    // Cheap definition-local exclusions precede every document-wide reference
+    // or projection check.
+    if (
+      footnoteDefinitionRequiresCollisionSafeFallback(originalEntry) ||
+      footnoteDefinitionRequiresCollisionSafeFallback(revisedEntry)
+    ) continue;
     if (!isOnlyFootnoteAnchorInSourceParagraph(originalDocumentDoc, pair.originalId) ||
         !isOnlyFootnoteAnchorInSourceParagraph(revisedDocumentDoc, pair.revisedId)) continue;
     if (!hasSafeEmittedFootnoteReferenceShape(
       documentDoc,
       pair.originalId,
       pair.revisedId,
+      getProjectionDocs,
     )) continue;
-    // Field ranges have a separate exact-preservation gate, and nested
-    // auxiliary anchors need their own relationship-aware story comparison.
-    // Keep the collision-safe two-definition representation for those shapes
-    // until their dedicated structural comparers can participate here.
-    if (
-      footnoteDefinitionRequiresCollisionSafeFallback(originalEntry) ||
-      footnoteDefinitionRequiresCollisionSafeFallback(revisedEntry)
-    ) continue;
 
     let comparedChildren: Element[];
     try {
@@ -1526,6 +1533,11 @@ function ancestorElement(element: Element, tagName: string): Element | null {
   return null;
 }
 
+interface FootnoteReferenceProjectionDocs {
+  accepted: Document;
+  rejected: Document;
+}
+
 /**
  * Require either Word's explicit deleted/inserted reference pair or a single
  * unchanged live reference. Ambiguous multiplicity and mixed wrapper shapes
@@ -1538,6 +1550,7 @@ function hasSafeEmittedFootnoteReferenceShape(
   documentDoc: Document,
   originalId: string,
   revisedId: string,
+  getProjectionDocs: () => FootnoteReferenceProjectionDocs,
 ): boolean {
   const original: Element[] = [];
   const revised: Element[] = [];
@@ -1566,24 +1579,22 @@ function hasSafeEmittedFootnoteReferenceShape(
     revisedParagraph?.getElementsByTagName('w:footnoteReference').length === 1 &&
     !hasAncestorTag(revised[0]!, 'w:del') &&
     !hasAncestorTag(revised[0]!, 'w:ins');
-  const projectionPair = (() => {
-    if (original.length !== 1 || revised.length !== 1 || !pairParagraphIsUnambiguous) return false;
-    const accepted = parseXml(acceptAllChanges(serializer.serializeToString(documentDoc)));
-    const rejected = parseXml(rejectAllChanges(serializer.serializeToString(documentDoc)));
-    const count = (doc: Document, id: string): number => {
-      let matches = 0;
-      const refs = doc.getElementsByTagName('w:footnoteReference');
-      for (let i = 0; i < refs.length; i++) {
-        if ((refs[i] as Element).getAttribute('w:id') === id) matches++;
-      }
-      return matches;
-    };
-    return count(accepted, originalId) === 0 &&
-      count(accepted, revisedId) === 1 &&
-      count(rejected, originalId) === 1 &&
-      count(rejected, revisedId) === 0;
-  })();
-  return explicitPair || stableReference || projectionPair;
+  if (explicitPair || stableReference) return true;
+  if (original.length !== 1 || revised.length !== 1 || !pairParagraphIsUnambiguous) return false;
+
+  const { accepted, rejected } = getProjectionDocs();
+  const count = (doc: Document, id: string): number => {
+    let matches = 0;
+    const refs = doc.getElementsByTagName('w:footnoteReference');
+    for (let i = 0; i < refs.length; i++) {
+      if ((refs[i] as Element).getAttribute('w:id') === id) matches++;
+    }
+    return matches;
+  };
+  return count(accepted, originalId) === 0 &&
+    count(accepted, revisedId) === 1 &&
+    count(rejected, originalId) === 1 &&
+    count(rejected, revisedId) === 0;
 }
 
 export function footnoteDefinitionRequiresCollisionSafeFallback(entry: Element): boolean {

--- a/packages/docx-core/src/integration/auxiliary-id-collision.test.ts
+++ b/packages/docx-core/src/integration/auxiliary-id-collision.test.ts
@@ -7,9 +7,10 @@
  * the result part" as success and skip the source side, leaving one side's
  * anchors bound to the other side's content (or missing entirely).
  *
- * The fix renumbers the revised side's colliding IDs before comparison, so
- * each anchor in the output resolves to the definition it was authored
- * against, in both reconstruction modes.
+ * The fix renumbers the revised side's colliding IDs before comparison. The
+ * comparison layer may later reconcile aligned footnote references into one
+ * tracked definition; unrelated collisions remain distinct. In either case,
+ * every surviving anchor resolves without binding to unrelated content.
  *
  * Reported in https://github.com/UseJunior/safe-docx/issues/107 (surfaced by
  * peer review of PR #101).
@@ -237,7 +238,7 @@ describe('Auxiliary part ID collisions (issue #107)', () => {
   });
 
   describe('Footnote w:id="1" means different content on each side', () => {
-    test('rebuild ships both footnotes under distinct IDs', async ({ given, when, then }: AllureBddContext) => {
+    test('rebuild reconciles aligned footnotes into one tracked definition', async ({ given, when, then }: AllureBddContext) => {
       let original: Buffer, revised: Buffer;
       await given('both sides define a different footnote under w:id="1"', async () => {
         original = await buildSyntheticDocx({
@@ -260,7 +261,7 @@ describe('Auxiliary part ID collisions (issue #107)', () => {
         });
       });
 
-      await then('both footnotes ship and every reference resolves', async () => {
+      await then('one tracked footnote ships and every reference resolves', async () => {
         expect(result.reconstructionModeUsed).toBe('rebuild');
         const parts = await getResultParts(result.document);
         expect(parts.footnotesXml).not.toBeNull();
@@ -268,9 +269,13 @@ describe('Auxiliary part ID collisions (issue #107)', () => {
         const definitions = expectAnchorsResolve(
           parts.documentXml, parts.footnotesXml!, 'w:footnoteReference', 'w:footnote'
         );
-        const texts = new Set(Array.from(definitions.values()).map((d) => d.text));
-        expect(texts).toContain('Original footnote');
-        expect(texts).toContain('Revised footnote');
+        const userDefinitions = [...definitions].filter(([id]) => Number(id) > 0);
+        expect(userDefinitions).toHaveLength(1);
+        expect(userDefinitions[0]![1].text).toBe('OriginalRevised footnote');
+        expect(parts.footnotesXml).toContain('<w:del');
+        expect(parts.footnotesXml).toContain('<w:ins');
+        testAllure.conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.5.14' });
+        testAllure.conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.5.18' });
       });
     });
   });


### PR DESCRIPTION
## Summary
- compare aligned footnote definitions structurally instead of emitting duplicate collision-renumbered definitions
- fail closed to the existing collision-safe path for fields, nested auxiliary anchors, exceptions, projection mismatches, and ambiguous references
- memoize document projections so ambiguity guards remain linear

## Verification
- docx-compare: 845 passed, 27 skipped
- focused docx-core collision and safety tests: 21 passed
- real ILPA: 25 definitions, 2 insertions, 2 deletions, 0 duplicate texts
- Transitional schema validation: 1/1 valid
- typecheck, lint, conformance citations, Allure labels, and coverage passed

Endnote reconciliation is deliberately out of scope and retains renumber-and-merge behavior. Broader pre-existing topology handling remains tracked in #852.

Refs #763
Refs #852
