### PR TITLE
fix(docx-release-verifier): fail requireNativeComments on zero comments

### DIFF
--- a/packages/docx-release-verifier/src/archive.ts
+++ b/packages/docx-release-verifier/src/archive.ts
@@ -41,6 +41,9 @@ async function boundedText(zip: JSZip, name: string): Promise<string> {
   return new TextDecoder().decode(bytes);
 }
 
+/** Requiring native comments means at least this many valid comments must exist. */
+const REQUIRED_COMMENT_MINIMUM = 1;
+
 function commentIntegrity(documentXml: string, commentsXml: string | null, required: boolean): Verdict {
   if (!required) return { status: 'not_run', required: false, reason: 'Native comments not required.' };
   const starts = commentIds(documentXml, 'commentRangeStart');
@@ -50,9 +53,20 @@ function commentIntegrity(documentXml: string, commentsXml: string | null, requi
   const exact = (left: string[], right: string[]) => left.length === right.length && left.every((id) => right.includes(id));
   const consistent = starts.every(Boolean) && ends.every(Boolean) && references.every(Boolean) && records.every(Boolean)
     && exact(starts, ends) && exact(starts, references) && exact(starts, records);
-  return consistent
-    ? { status: 'pass', required: true, details: { count: starts.length } }
-    : { status: 'fail', required: true, reason: 'Native comment records, range starts, range ends, and references disagree.', details: { starts, ends, references, records } };
+  if (!consistent) {
+    return { status: 'fail', required: true, reason: 'Native comment records, range starts, range ends, and references disagree.', details: { starts, ends, references, records } };
+  }
+  // Consistency of an empty set is vacuous: requiring native comments demands
+  // at least one valid comment, so zero comments fails closed (issue #858).
+  if (records.length < REQUIRED_COMMENT_MINIMUM) {
+    return {
+      status: 'fail',
+      required: true,
+      reason: `Native comments were required but the tracked DOCX contains none: expected minimum ${REQUIRED_COMMENT_MINIMUM}, actual ${records.length}.`,
+      details: { expectedMinimum: REQUIRED_COMMENT_MINIMUM, count: records.length },
+    };
+  }
+  return { status: 'pass', required: true, details: { expectedMinimum: REQUIRED_COMMENT_MINIMUM, count: starts.length } };
 }
 
 /**

--- a/packages/docx-release-verifier/src/verifier.test.ts
+++ b/packages/docx-release-verifier/src/verifier.test.ts
@@ -237,6 +237,69 @@ describe('independent release verifier', () => {
     expect(result.exitCode).toBe(1);
   });
 
+  itAllure('fails closed when native comments are required but the tracked DOCX has zero comments', async () => {
+    const { manifest } = await fixture();
+    const result = await verifyRelease({ ...manifest, requireNativeComments: true });
+    expect(result.gates.comments.status).toBe('fail');
+    expect(result.gates.comments.reason).toContain('expected minimum 1, actual 0');
+    expect(result.gates.comments.details).toMatchObject({ expectedMinimum: 1, count: 0 });
+    expect(result.delivery.status).toBe('fail');
+    expect(result.exitCode).toBe(1);
+  });
+
+  itAllure('leaves the zero-comment gate not_run when native comments are not required', async () => {
+    const { manifest } = await fixture();
+    const omitted = await verifyRelease(manifest);
+    expect(omitted.gates.comments).toMatchObject({ status: 'not_run', required: false });
+    expect(omitted.exitCode).toBe(0);
+    const disabled = await verifyRelease({ ...manifest, requireNativeComments: false });
+    expect(disabled.gates.comments).toMatchObject({ status: 'not_run', required: false });
+    expect(disabled.exitCode).toBe(0);
+  });
+
+  itAllure('accepts one structurally valid native comment and turns red when that final comment is removed', async () => {
+    const { manifest } = await fixture();
+    const trackedRevision = '<w:r><w:t xml:space="preserve">Hello </w:t></w:r><w:del w:id="1"><w:r><w:delText>old</w:delText></w:r></w:del><w:ins w:id="2"><w:r><w:t>new</w:t></w:r></w:ins>';
+    await writeDocx(manifest.trackedPath,
+      `<w:p><w:commentRangeStart w:id="1"/>${trackedRevision}<w:commentRangeEnd w:id="1"/><w:r><w:commentReference w:id="1"/></w:r></w:p>`,
+      `<w:comments xmlns:w="${W}"><w:comment w:id="1"/></w:comments>`);
+    const commented = await verifyRelease({ ...manifest, requireNativeComments: true });
+    expect(commented.gates.comments).toMatchObject({ status: 'pass', details: { expectedMinimum: 1, count: 1 } });
+    expect(commented.exitCode).toBe(0);
+    // Negative control: removing the final comment must flip the required gate to red.
+    await writeDocx(manifest.trackedPath, `<w:p>${trackedRevision}</w:p>`);
+    const stripped = await verifyRelease({ ...manifest, requireNativeComments: true });
+    expect(stripped.gates.comments.status).toBe('fail');
+    expect(stripped.gates.comments.reason).toContain('expected minimum 1, actual 0');
+    expect(stripped.exitCode).toBe(1);
+  });
+
+  itAllure('fails dangling references, duplicate definitions, and malformed ranges independently of the nonempty check', async () => {
+    const { manifest } = await fixture();
+    const revision = '<w:r><w:t xml:space="preserve">Hello </w:t></w:r><w:del w:id="1"><w:r><w:delText>old</w:delText></w:r></w:del><w:ins w:id="2"><w:r><w:t>new</w:t></w:r></w:ins>';
+    const commentsXml = `<w:comments xmlns:w="${W}"><w:comment w:id="1"/></w:comments>`;
+    // Dangling reference: full range markup in the document but no comment record part.
+    await writeDocx(manifest.trackedPath, `<w:p><w:commentRangeStart w:id="1"/>${revision}<w:commentRangeEnd w:id="1"/><w:r><w:commentReference w:id="1"/></w:r></w:p>`);
+    const dangling = await verifyRelease({ ...manifest, requireNativeComments: true });
+    expect(dangling.gates.comments.status).toBe('fail');
+    expect(dangling.gates.comments.reason).toContain('disagree');
+    expect(dangling.exitCode).toBe(1);
+    // Duplicate definition: two comment records for a single referenced range.
+    await writeDocx(manifest.trackedPath,
+      `<w:p><w:commentRangeStart w:id="1"/>${revision}<w:commentRangeEnd w:id="1"/><w:r><w:commentReference w:id="1"/></w:r></w:p>`,
+      `<w:comments xmlns:w="${W}"><w:comment w:id="1"/><w:comment w:id="1"/></w:comments>`);
+    const duplicated = await verifyRelease({ ...manifest, requireNativeComments: true });
+    expect(duplicated.gates.comments.status).toBe('fail');
+    expect(duplicated.gates.comments.reason).toContain('disagree');
+    expect(duplicated.exitCode).toBe(1);
+    // Malformed range: a start without a matching end, even though a record and reference exist.
+    await writeDocx(manifest.trackedPath, `<w:p><w:commentRangeStart w:id="1"/>${revision}<w:r><w:commentReference w:id="1"/></w:r></w:p>`, commentsXml);
+    const malformed = await verifyRelease({ ...manifest, requireNativeComments: true });
+    expect(malformed.gates.comments.status).toBe('fail');
+    expect(malformed.gates.comments.reason).toContain('disagree');
+    expect(malformed.exitCode).toBe(1);
+  });
+
   itAllure('fails corrupt packages independently of semantic text', async () => {
     const { manifest } = await fixture();
     await writeFile(manifest.trackedPath, 'not a zip');


### PR DESCRIPTION
Fixes #858

## Problem

`commentIntegrity` in `packages/docx-release-verifier/src/archive.ts` validated only the mutual consistency of the four comment ID lists (range starts, range ends, references, records). On a tracked DOCX with zero native comments all four lists are empty, so every `.every(Boolean)` is vacuously true and the `exact()` helper returns true for equal empty arrays. A manifest with `requireNativeComments: true` therefore produced a passing comments gate (`{status:'pass', required:true, details:{count:0}}`), a passing delivery verdict, and `exitCode: 0` from the public `verifyRelease()` API — certifying exactly the failure the caller asked the gate to catch.

## Fix

`requireNativeComments: true` now means at least one valid native comment must exist. After the existing consistency check, an empty (mutually consistent) comment set fails closed with an actionable diagnostic:

> Native comments were required but the tracked DOCX contains none: expected minimum 1, actual 0.

Both pass and fail verdicts now report `expectedMinimum` alongside `count` in details, so the certificate states the actual count against the required minimum. The manifest carries no caller-supplied expected count, so the minimum is the constant 1 — no declared-expected-count field was invented.

The consistency check still runs first, so dangling references, duplicate definitions, and malformed ranges keep failing independently with the existing "disagree" diagnostic. The documented default (`requireNativeComments` false or omitted leaves the gate `not_run`) is unchanged and now pinned by test.

## Acceptance criteria coverage (issue #858)

- Zero comments + `requireNativeComments: true` fails: test "fails closed when native comments are required but the tracked DOCX has zero comments" (asserts fail status, `expected minimum 1, actual 0` reason, `{expectedMinimum: 1, count: 0}` details, delivery fail, exit 1).
- Same DOCX passes the comment-presence gate when the option is false or omitted: test "leaves the zero-comment gate not_run when native comments are not required".
- One structurally valid comment satisfies the requirement, and the negative control turns the gate red when the final comment is removed: test "accepts one structurally valid native comment and turns red when that final comment is removed".
- Dangling references, duplicate definitions, malformed ranges still fail independently: test "fails dangling references, duplicate definitions, and malformed ranges independently of the nonempty check".
- Certificate reports actual count against the required minimum: `details: { expectedMinimum, count }` on both pass and fail.

The related nonvacuity audit of other opt-in completeness gates is deliberately out of scope for this PR (findings reported separately for follow-up filing).

## Verification

Full pre-submit gate green in the worktree (explicit exit code 0): `npm run build && npm run lint:workspaces && npm run test:run && npm run check:spec-coverage && npm run check:conformance-citations && npm run check:conformance-doc`.
