### PR TITLE
fix(docx-core): stamp comment definitions with the RevisionContext date

### DIFF
--- a/packages/docx-core/src/primitives/comments.test.ts
+++ b/packages/docx-core/src/primitives/comments.test.ts
@@ -1629,7 +1629,8 @@ describe('comments — edge cases and branch coverage', () => {
       });
     });
 
-    test('stamps comment definitions with the caller-supplied RevisionContext date across a UTC/local day boundary', async ({ given, when, then }: AllureBddContext) => {
+    test.conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.4.2' })(
+      'stamps comment definitions with the caller-supplied RevisionContext date across a UTC/local day boundary', async ({ given, when, then }: AllureBddContext) => {
       let zip: DocxZip;
       let doc: Document;
       let paragraph: Element;
@@ -1667,6 +1668,7 @@ describe('comments — edge cases and branch coverage', () => {
             parentCommentId: commentId,
             author: 'Reply Author',
             text: 'Reply body',
+            initials: 'RA',
           }, ctx);
         });
 
@@ -1685,6 +1687,7 @@ describe('comments — edge cases and branch coverage', () => {
         expect(commentEls[0]!.getAttribute('w:author')).toBe('Comment Author');
         expect(commentEls[0]!.getAttribute('w:initials')).toBe('CA');
         expect(commentEls[1]!.getAttribute('w:author')).toBe('Reply Author');
+        expect(commentEls[1]!.getAttribute('w:initials')).toBe('RA');
 
         // Body revision and comment metadata are internally consistent.
         expect(bodyInsertion).toBeTruthy();

--- a/packages/docx-core/src/primitives/comments.test.ts
+++ b/packages/docx-core/src/primitives/comments.test.ts
@@ -1629,6 +1629,113 @@ describe('comments — edge cases and branch coverage', () => {
       });
     });
 
+    test('stamps comment definitions with the caller-supplied RevisionContext date across a UTC/local day boundary', async ({ given, when, then }: AllureBddContext) => {
+      let zip: DocxZip;
+      let doc: Document;
+      let paragraph: Element;
+      let commentsXml: string;
+      let commentEls: Element[];
+      let bodyInsertion: Element;
+
+      // 2026-01-15T23:30:00-05:00 is 2026-01-16T04:30:00Z — the local and UTC
+      // calendar dates disagree, so any current-clock leak (frozen below to
+      // 2026-05-03T14:15:16Z) is unambiguously distinguishable from the
+      // caller's date regardless of the machine's timezone.
+      const callerDate = '2026-01-15T23:30:00-05:00';
+      const frozenClock = '2026-05-03T14:15:16Z';
+      const ctx = createRevisionContext({
+        author: 'Revision Author',
+        date: callerDate,
+        idState: createRevisionIdState(),
+      });
+
+      await given('a bootstrapped document and a revision context with a fixed-offset date', async () => {
+        ({ zip, doc, p: paragraph } = await setupWithComment());
+      });
+
+      await when('a root comment and a threaded reply are added with that context under a frozen process clock', async () => {
+        await withDeterministicMetadata([0.123456789], async () => {
+          const { commentId } = await addComment(doc, zip, {
+            paragraphEl: paragraph,
+            start: 0,
+            end: 5,
+            author: 'Comment Author',
+            text: 'Root comment',
+            initials: 'CA',
+          }, ctx);
+          await addCommentReply(doc, zip, {
+            parentCommentId: commentId,
+            author: 'Reply Author',
+            text: 'Reply body',
+          }, ctx);
+        });
+
+        commentsXml = await zip.readText('word/comments.xml');
+        const commentsDoc = parseXml(commentsXml);
+        commentEls = Array.from(commentsDoc.getElementsByTagNameNS(W_NS, W.comment)) as Element[];
+        bodyInsertion = doc.getElementsByTagNameNS(W_NS, 'ins').item(0) as Element;
+      });
+
+      await then('root and reply definitions carry the caller date verbatim, matching the body revision, with no process-clock leak', () => {
+        expect(commentEls).toHaveLength(2);
+        for (const el of commentEls) {
+          expect(el.getAttribute('w:date')).toBe(callerDate);
+        }
+        // Author/initials still come from AddComment(Reply)Params, not from ctx.
+        expect(commentEls[0]!.getAttribute('w:author')).toBe('Comment Author');
+        expect(commentEls[0]!.getAttribute('w:initials')).toBe('CA');
+        expect(commentEls[1]!.getAttribute('w:author')).toBe('Reply Author');
+
+        // Body revision and comment metadata are internally consistent.
+        expect(bodyInsertion).toBeTruthy();
+        expect(bodyInsertion.getAttribute('w:date')).toBe(callerDate);
+        expect(bodyInsertion.getAttribute('w:author')).toBe('Revision Author');
+
+        // The frozen process clock must not leak into any comment definition.
+        expect(commentsXml).not.toContain(frozenClock);
+        expect(commentsXml).not.toContain('2026-05-03');
+      });
+    });
+
+    test('stamps comment definitions from the process clock when the revision context is omitted', async ({ given, when, then }: AllureBddContext) => {
+      let zip: DocxZip;
+      let doc: Document;
+      let paragraph: Element;
+      let commentEls: Element[];
+
+      await given('a bootstrapped document and no revision context', async () => {
+        ({ zip, doc, p: paragraph } = await setupWithComment());
+      });
+
+      await when('a root comment and a threaded reply are added without ctx under a frozen process clock', async () => {
+        await withDeterministicMetadata([0.987654321], async () => {
+          const { commentId } = await addComment(doc, zip, {
+            paragraphEl: paragraph,
+            start: 0,
+            end: 5,
+            author: 'Comment Author',
+            text: 'Root comment',
+          });
+          await addCommentReply(doc, zip, {
+            parentCommentId: commentId,
+            author: 'Reply Author',
+            text: 'Reply body',
+          });
+        });
+
+        const commentsXml = await zip.readText('word/comments.xml');
+        const commentsDoc = parseXml(commentsXml);
+        commentEls = Array.from(commentsDoc.getElementsByTagNameNS(W_NS, W.comment)) as Element[];
+      });
+
+      await then('both definitions default to the current-time stamp', () => {
+        expect(commentEls).toHaveLength(2);
+        for (const el of commentEls) {
+          expect(el.getAttribute('w:date')).toBe('2026-05-03T14:15:16Z');
+        }
+      });
+    });
+
     test('preserves the legacy untracked body behavior when ctx is omitted for addComment, addCommentReply, and deleteComment', async ({ given, when, then }: AllureBddContext) => {
       let zip: DocxZip;
       let doc: Document;

--- a/packages/docx-core/src/primitives/comments.ts
+++ b/packages/docx-core/src/primitives/comments.ts
@@ -248,6 +248,7 @@ export async function addComment(
     initials: initials ?? author.charAt(0).toUpperCase(),
     text,
     paraId,
+    date: ctx?.date,
   });
   zip.writeText('word/comments.xml', serializeXml(commentsDoc));
 
@@ -276,15 +277,17 @@ export type AddCommentReplyResult = {
  *
  * Replies don't have range markers in the document body.
  * Thread linkage is stored in commentsExtended.xml via paraIdParent.
- * `ctx` is accepted for API consistency with other comment mutations, but this
- * primitive only updates comment side parts for replies, so no body revision
- * markup is emitted here.
+ * Replies emit no body revision markup (there is nothing to anchor), but the
+ * reply's comment definition still claims creation metadata — so a
+ * caller-supplied `ctx.date` stamps `w:date` exactly as it does for root
+ * comments, keeping reply timestamps deterministic alongside the rest of the
+ * operation. Author and initials intentionally stay sourced from `params`.
  */
 export async function addCommentReply(
   _documentXml: Document,
   zip: DocxZip,
   params: AddCommentReplyParams,
-  _ctx?: RevisionContext,
+  ctx?: RevisionContext,
 ): Promise<AddCommentReplyResult> {
   const { parentCommentId, author, text, initials } = params;
 
@@ -307,6 +310,7 @@ export async function addCommentReply(
     initials: initials ?? author.charAt(0).toUpperCase(),
     text,
     paraId: replyParaId,
+    date: ctx?.date,
   });
   zip.writeText('word/comments.xml', serializeXml(commentsDoc));
 
@@ -378,9 +382,23 @@ function ensureCommentPartNamespaceAliases(commentsDoc: Document): void {
   }
 }
 
+/**
+ * Append a `w:comment` definition to the comments part.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.4.2
+ * The `w:date` creation stamp uses the caller-supplied revision date when one
+ * is provided, so the comment definition and the body revision markup emitted
+ * for the same operation agree on the calendar date Word displays — even
+ * across a UTC/local day boundary. Only when the caller supplies no date does
+ * the process clock remain the default. Author and initials always come from
+ * `AddCommentParams` / `AddCommentReplyParams`, never from `RevisionContext`:
+ * the comment's attribution is the commenting author, which is allowed to
+ * differ from the tracked-change author wrapping the reference run.
+ * @see #859
+ */
 function addCommentElement(
   commentsDoc: Document,
-  params: { id: number; author: string; initials: string; text: string; paraId: string },
+  params: { id: number; author: string; initials: string; text: string; paraId: string; date?: string },
 ): void {
   ensureCommentPartNamespaceAliases(commentsDoc);
   const root = commentsDoc.documentElement;
@@ -388,7 +406,7 @@ function addCommentElement(
   const commentEl = commentsDoc.createElementNS(OOXML.W_NS, 'w:comment');
   commentEl.setAttribute('w:id', String(params.id));
   commentEl.setAttribute('w:author', params.author);
-  commentEl.setAttribute('w:date', isoNow());
+  commentEl.setAttribute('w:date', params.date ?? isoNow());
   commentEl.setAttribute('w:initials', params.initials);
 
   // Comment body: <w:p w14:paraId="..."><w:pPr><w:pStyle w:val="CommentText"/></w:pPr><w:r><w:annotationRef/></w:r><w:r><w:t>text</w:t></w:r></w:p>


### PR DESCRIPTION
Fixes #859

## Problem

When a caller supplies a `RevisionContext` carrying a deterministic date, `addComment` uses it for the body revision markup (the `w:ins` wrapping the `commentReference` run) — but the shared comment-definition helper stamped `w:comment/@w:date` in `word/comments.xml` from `isoNow()`, the process clock. Across a UTC/local day boundary the two stamps disagree on the calendar date Word displays, and deterministic callers lose byte determinism in `comments.xml`.

Observed at base commit `7bd35c8` for `date: "2026-01-15T23:30:00-05:00"`:

```text
comment definition: <w:comment w:id="0" w:author="Comment Author" w:date="2026-08-15T20:28:19Z" w:initials="CA">
body insertion:     <w:ins w:id="1" w:author="Revision Author" w:date="2026-01-15T23:30:00-05:00">
```

## Fix

Date propagation only — surgical, no public signature or `RevisionContext` type change:

- The internal `addCommentElement` helper gains an optional `date`; `w:date` uses `params.date ?? isoNow()`, so current-clock behavior remains the default only when the caller omits a date.
- `addComment` passes the already-in-scope `ctx?.date`.
- `addCommentReply` previously took the context as `_ctx` and deliberately ignored it — correct for body markup (replies anchor nothing in the body), wrong for the reply's own comment definition, which claims creation metadata through the same helper. Replies now honor `ctx.date` identically.
- Comment author and initials intentionally continue to come from `AddCommentParams` / `AddCommentReplyParams`, never from `RevisionContext`: the commenting author may legitimately differ from the tracked-change author.
- The claim is led by a `@conformance ECMA-376 edition 5, Part 1 § 17.13.4.2` JSDoc tag on the helper (registered entry `ECMA-PART1-17-13-4-2`).

## Tests

Extended the existing `tracked-change emission` suite in `packages/docx-core/src/primitives/comments.test.ts`:

- A fixed-offset date `2026-01-15T23:30:00-05:00` (which is 2026-01-16 in UTC) under a frozen process clock (`2026-05-03T14:15:16Z`) proves — independently of the machine timezone — that root and reply `w:comment` definitions carry the caller date verbatim, the body `w:ins` matches, author/initials still come from params, and the process clock leaks nowhere into `comments.xml`.
- A ctx-omitted regression guard proves both root and reply definitions still default to the current-time stamp.

Existing round-trip/integrity suites stay green (`src/primitives/comments.test.ts` 47/47, `test-primitives/comments.test.ts` 29/29); the byte-identity tracked-vs-control tests remain valid because their ctx date equals the frozen clock.

Full pre-submit gate run green in the worktree (build, lint:workspaces, test:run, check:spec-coverage, check:conformance-citations, check:conformance-doc — exit 0).