### PR TITLE
fix(docx-release-verifier): compare comment ID multiplicities, not membership

### DIFF
--- a/packages/docx-release-verifier/src/archive.ts
+++ b/packages/docx-release-verifier/src/archive.ts
@@ -56,13 +56,17 @@ function idMultiset(ids: string[]): Map<string, number> {
  * multiset, and each identifier must be defined exactly once. Comparing
  * multiplicities — not just membership and total length — rejects documents a
  * set-style comparison cannot distinguish from valid ones, such as identifiers
- * duplicated identically across all four collections. The transitional
- * `wml.xsd` alone does not reject duplicate identifiers (it permits unbounded
- * `w:comment` children and carries no uniqueness constraint); the violated
- * rule is the normative prose defining the annotation identifier as a unique
- * identifier for the comment.
+ * duplicated identically across all four collections.
  *
- * @conformance ECMA-376 edition 5, Part 1 § 17.13.4.2
+ * Rejecting duplicate identifiers is a conservative release-verifier
+ * integrity invariant, deliberately stricter than the spec: unambiguous
+ * comment linkage requires each identifier to resolve to exactly one comment
+ * record. The transitional `wml.xsd` carries no uniqueness constraint (it
+ * permits unbounded `w:comment` children), and the spec prose anticipates
+ * duplicate identifiers by defining consumer fallback behavior for them
+ * rather than prohibiting them. A release gate whose job is to fail closed
+ * does not rely on that fallback.
+ *
  * @see https://github.com/UseJunior/safe-docx/issues/863
  */
 function commentIntegrity(documentXml: string, commentsXml: string | null, required: boolean): Verdict {

--- a/packages/docx-release-verifier/src/archive.ts
+++ b/packages/docx-release-verifier/src/archive.ts
@@ -44,17 +44,53 @@ async function boundedText(zip: JSZip, name: string): Promise<string> {
 /** Requiring native comments means at least this many valid comments must exist. */
 const REQUIRED_COMMENT_MINIMUM = 1;
 
+function idMultiset(ids: string[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const id of ids) counts.set(id, (counts.get(id) ?? 0) + 1);
+  return counts;
+}
+
+/**
+ * Verifies that native comment markup is internally consistent: range starts,
+ * range ends, references, and comment records must carry the same identifier
+ * multiset, and each identifier must be defined exactly once. Comparing
+ * multiplicities — not just membership and total length — rejects documents a
+ * set-style comparison cannot distinguish from valid ones, such as identifiers
+ * duplicated identically across all four collections. The transitional
+ * `wml.xsd` alone does not reject duplicate identifiers (it permits unbounded
+ * `w:comment` children and carries no uniqueness constraint); the violated
+ * rule is the normative prose defining the annotation identifier as a unique
+ * identifier for the comment.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.4.2
+ * @see https://github.com/UseJunior/safe-docx/issues/863
+ */
 function commentIntegrity(documentXml: string, commentsXml: string | null, required: boolean): Verdict {
   if (!required) return { status: 'not_run', required: false, reason: 'Native comments not required.' };
   const starts = commentIds(documentXml, 'commentRangeStart');
   const ends = commentIds(documentXml, 'commentRangeEnd');
   const references = commentIds(documentXml, 'commentReference');
   const records = commentsXml ? commentIds(commentsXml, 'comment') : [];
-  const exact = (left: string[], right: string[]) => left.length === right.length && left.every((id) => right.includes(id));
+  const exact = (left: string[], right: string[]) => {
+    if (left.length !== right.length) return false;
+    const expected = idMultiset(right);
+    return [...idMultiset(left)].every(([id, count]) => expected.get(id) === count);
+  };
   const consistent = starts.every(Boolean) && ends.every(Boolean) && references.every(Boolean) && records.every(Boolean)
     && exact(starts, ends) && exact(starts, references) && exact(starts, records);
   if (!consistent) {
     return { status: 'fail', required: true, reason: 'Native comment records, range starts, range ends, and references disagree.', details: { starts, ends, references, records } };
+  }
+  // Identical duplication across all four collections survives the multiset
+  // comparison, so the definitions must additionally be duplicate-free.
+  const duplicates = [...idMultiset(records)].filter(([, count]) => count > 1).map(([id]) => id);
+  if (duplicates.length > 0) {
+    return {
+      status: 'fail',
+      required: true,
+      reason: `Native comment IDs are duplicated across range starts, range ends, references, and records: ${duplicates.join(', ')}. Each annotation identifier must be unique.`,
+      details: { duplicates, starts, ends, references, records },
+    };
   }
   // Consistency of an empty set is vacuous: requiring native comments demands
   // at least one valid comment, so zero comments fails closed (issue #858).

--- a/packages/docx-release-verifier/src/verifier.test.ts
+++ b/packages/docx-release-verifier/src/verifier.test.ts
@@ -300,6 +300,33 @@ describe('independent release verifier', () => {
     expect(malformed.exitCode).toBe(1);
   });
 
+  itAllure('fails comment IDs duplicated identically across starts, ends, references, and records', async () => {
+    const { manifest } = await fixture();
+    const revision = '<w:r><w:t xml:space="preserve">Hello </w:t></w:r><w:del w:id="1"><w:r><w:delText>old</w:delText></w:r></w:del><w:ins w:id="2"><w:r><w:t>new</w:t></w:r></w:ins>';
+    // Symmetric duplication: every collection is ['1', '1'], so a set-style
+    // comparison sees equal lengths and full membership on all four sides.
+    await writeDocx(manifest.trackedPath,
+      `<w:p><w:commentRangeStart w:id="1"/><w:commentRangeStart w:id="1"/>${revision}<w:commentRangeEnd w:id="1"/><w:commentRangeEnd w:id="1"/><w:r><w:commentReference w:id="1"/></w:r><w:r><w:commentReference w:id="1"/></w:r></w:p>`,
+      `<w:comments xmlns:w="${W}"><w:comment w:id="1"/><w:comment w:id="1"/></w:comments>`);
+    const symmetric = await verifyRelease({ ...manifest, requireNativeComments: true });
+    expect(symmetric.gates.comments.status).toBe('fail');
+    expect(symmetric.gates.comments.reason).toContain('duplicated');
+    expect(symmetric.gates.comments.reason).toContain('1');
+    expect(symmetric.gates.comments.details).toMatchObject({ duplicates: ['1'] });
+    expect(symmetric.delivery.status).toBe('fail');
+    expect(symmetric.exitCode).toBe(1);
+    // Multiplicity disagreement at equal length: starts double '1' while the
+    // other collections carry '1' and '2'. Membership and total length agree,
+    // so only a multiset comparison can reject it.
+    await writeDocx(manifest.trackedPath,
+      `<w:p><w:commentRangeStart w:id="1"/><w:commentRangeStart w:id="1"/>${revision}<w:commentRangeEnd w:id="1"/><w:commentRangeEnd w:id="2"/><w:r><w:commentReference w:id="1"/></w:r><w:r><w:commentReference w:id="2"/></w:r></w:p>`,
+      `<w:comments xmlns:w="${W}"><w:comment w:id="1"/><w:comment w:id="2"/></w:comments>`);
+    const skewed = await verifyRelease({ ...manifest, requireNativeComments: true });
+    expect(skewed.gates.comments.status).toBe('fail');
+    expect(skewed.gates.comments.reason).toContain('disagree');
+    expect(skewed.exitCode).toBe(1);
+  });
+
   itAllure('fails corrupt packages independently of semantic text', async () => {
     const { manifest } = await fixture();
     await writeFile(manifest.trackedPath, 'not a zip');

--- a/packages/docx-release-verifier/src/verifier.test.ts
+++ b/packages/docx-release-verifier/src/verifier.test.ts
@@ -234,6 +234,7 @@ describe('independent release verifier', () => {
       `<w:comments xmlns:w="${W}"><w:comment w:id="1"/></w:comments>`);
     const result = await verifyRelease({ ...manifest, requireNativeComments: true });
     expect(result.gates.comments.status).toBe('fail');
+    expect(result.gates.comments.reason).toBe('Native comment records, range starts, range ends, and references disagree.');
     expect(result.exitCode).toBe(1);
   });
 
@@ -241,8 +242,8 @@ describe('independent release verifier', () => {
     const { manifest } = await fixture();
     const result = await verifyRelease({ ...manifest, requireNativeComments: true });
     expect(result.gates.comments.status).toBe('fail');
-    expect(result.gates.comments.reason).toContain('expected minimum 1, actual 0');
-    expect(result.gates.comments.details).toMatchObject({ expectedMinimum: 1, count: 0 });
+    expect(result.gates.comments.reason).toBe('Native comments were required but the tracked DOCX contains none: expected minimum 1, actual 0.');
+    expect(result.gates.comments.details).toEqual({ expectedMinimum: 1, count: 0 });
     expect(result.delivery.status).toBe('fail');
     expect(result.exitCode).toBe(1);
   });
@@ -270,7 +271,7 @@ describe('independent release verifier', () => {
     await writeDocx(manifest.trackedPath, `<w:p>${trackedRevision}</w:p>`);
     const stripped = await verifyRelease({ ...manifest, requireNativeComments: true });
     expect(stripped.gates.comments.status).toBe('fail');
-    expect(stripped.gates.comments.reason).toContain('expected minimum 1, actual 0');
+    expect(stripped.gates.comments.reason).toBe('Native comments were required but the tracked DOCX contains none: expected minimum 1, actual 0.');
     expect(stripped.exitCode).toBe(1);
   });
 
@@ -282,7 +283,7 @@ describe('independent release verifier', () => {
     await writeDocx(manifest.trackedPath, `<w:p><w:commentRangeStart w:id="1"/>${revision}<w:commentRangeEnd w:id="1"/><w:r><w:commentReference w:id="1"/></w:r></w:p>`);
     const dangling = await verifyRelease({ ...manifest, requireNativeComments: true });
     expect(dangling.gates.comments.status).toBe('fail');
-    expect(dangling.gates.comments.reason).toContain('disagree');
+    expect(dangling.gates.comments.reason).toBe('Native comment records, range starts, range ends, and references disagree.');
     expect(dangling.exitCode).toBe(1);
     // Duplicate definition: two comment records for a single referenced range.
     await writeDocx(manifest.trackedPath,
@@ -290,13 +291,13 @@ describe('independent release verifier', () => {
       `<w:comments xmlns:w="${W}"><w:comment w:id="1"/><w:comment w:id="1"/></w:comments>`);
     const duplicated = await verifyRelease({ ...manifest, requireNativeComments: true });
     expect(duplicated.gates.comments.status).toBe('fail');
-    expect(duplicated.gates.comments.reason).toContain('disagree');
+    expect(duplicated.gates.comments.reason).toBe('Native comment records, range starts, range ends, and references disagree.');
     expect(duplicated.exitCode).toBe(1);
     // Malformed range: a start without a matching end, even though a record and reference exist.
     await writeDocx(manifest.trackedPath, `<w:p><w:commentRangeStart w:id="1"/>${revision}<w:r><w:commentReference w:id="1"/></w:r></w:p>`, commentsXml);
     const malformed = await verifyRelease({ ...manifest, requireNativeComments: true });
     expect(malformed.gates.comments.status).toBe('fail');
-    expect(malformed.gates.comments.reason).toContain('disagree');
+    expect(malformed.gates.comments.reason).toBe('Native comment records, range starts, range ends, and references disagree.');
     expect(malformed.exitCode).toBe(1);
   });
 
@@ -310,8 +311,7 @@ describe('independent release verifier', () => {
       `<w:comments xmlns:w="${W}"><w:comment w:id="1"/><w:comment w:id="1"/></w:comments>`);
     const symmetric = await verifyRelease({ ...manifest, requireNativeComments: true });
     expect(symmetric.gates.comments.status).toBe('fail');
-    expect(symmetric.gates.comments.reason).toContain('duplicated');
-    expect(symmetric.gates.comments.reason).toContain('1');
+    expect(symmetric.gates.comments.reason).toBe('Native comment IDs are duplicated across range starts, range ends, references, and records: 1. Each annotation identifier must be unique.');
     expect(symmetric.gates.comments.details).toMatchObject({ duplicates: ['1'] });
     expect(symmetric.delivery.status).toBe('fail');
     expect(symmetric.exitCode).toBe(1);
@@ -323,8 +323,16 @@ describe('independent release verifier', () => {
       `<w:comments xmlns:w="${W}"><w:comment w:id="1"/><w:comment w:id="2"/></w:comments>`);
     const skewed = await verifyRelease({ ...manifest, requireNativeComments: true });
     expect(skewed.gates.comments.status).toBe('fail');
-    expect(skewed.gates.comments.reason).toContain('disagree');
+    expect(skewed.gates.comments.reason).toBe('Native comment records, range starts, range ends, and references disagree.');
     expect(skewed.exitCode).toBe(1);
+    // Positive control: two distinct comments listed in different orders per
+    // collection stay order-insensitive and pass.
+    await writeDocx(manifest.trackedPath,
+      `<w:p><w:commentRangeStart w:id="2"/><w:commentRangeStart w:id="1"/>${revision}<w:commentRangeEnd w:id="1"/><w:commentRangeEnd w:id="2"/><w:r><w:commentReference w:id="2"/></w:r><w:r><w:commentReference w:id="1"/></w:r></w:p>`,
+      `<w:comments xmlns:w="${W}"><w:comment w:id="1"/><w:comment w:id="2"/></w:comments>`);
+    const reordered = await verifyRelease({ ...manifest, requireNativeComments: true });
+    expect(reordered.gates.comments).toMatchObject({ status: 'pass', details: { expectedMinimum: 1, count: 2 } });
+    expect(reordered.exitCode).toBe(0);
   });
 
   itAllure('fails corrupt packages independently of semantic text', async () => {


### PR DESCRIPTION
Fixes #863

## Problem

`commentIntegrity` in `packages/docx-release-verifier/src/archive.ts` compared comment ID lists with a set-style helper (`left.length === right.length && left.every((id) => right.includes(id))`), which ignores multiplicity. A tracked DOCX whose comment IDs are duplicated *identically* across all four collections — `commentRangeStart`, `commentRangeEnd`, `commentReference`, and the `w:comment` records, each e.g. `['1','1']` — satisfied every consistency check and returned a required `pass` through the public `verifyRelease()` API. The #858 zero-comment minimum does not catch it, because a duplicate set of length >= 1 clears the minimum.

## Fix

Two halves, because multiset equality alone is not sufficient — identical duplication on all four sides yields four *equal* multisets:

1. `exact()` now compares per-ID counts. This also rejects equal-length, set-equal shapes the old comparison passed outright (e.g. starts `['1','1']` against records `['1','2']`), keeping the existing "disagree" verdict for them.
2. The comment records must be duplicate-free. This rejects the fully symmetric duplicate shape with a diagnostic that names the duplicated IDs.

The #858 zero-comment guard is untouched and still fails closed with its existing message and `{expectedMinimum, count}` details.

## Framing (revised after peer review)

Duplicate rejection is a **conservative release-verifier integrity invariant** — deliberately stricter than the spec — because unambiguous comment linkage requires each identifier to resolve to exactly one record. It is *not* framed as an ECMA-376 conformance violation: the transitional `wml.xsd` carries no uniqueness constraint (unbounded `w:comment` children, no `xs:key`), and ECMA-376 Part 1 § 17.13.4.2 itself anticipates duplicate id values by defining consumer fallback behavior for them rather than prohibiting them. A gate whose job is to fail closed chooses not to rely on that fallback. (An earlier revision of this branch carried a `@conformance` citation claiming a normative uniqueness rule; peer review checked the actual spec text and refuted it — see the adjudication comment below.)

## Severity

Hardening, not an active false assurance. Word and safe-docx both allocate distinct sequential comment IDs, so coordinated duplication across all four sides most plausibly comes from a broken producer, hand-edited XML, or a faulty merge. It is still a real integrity hole in a gate whose job is to fail closed.

## Tests

Extended `verifier.test.ts` (no new test file) with one regression test through the public `verifyRelease()` API covering the symmetric duplicate (fails with the duplicate diagnostic, `duplicates: ['1']`, exit 1), the equal-length multiplicity skew (fails with the existing "disagree" reason), and an order-insensitivity positive control (two distinct IDs in different orders per collection pass with `count: 2`, exit 0). Existing comment-integrity tests now assert the complete diagnostic strings and exact details objects. Fixtures are built with the file's local JSZip helper, preserving the `dependency-boundary.test.ts` rule against importing Safe DOCX parsers/mutators/comparers/generators.

## Pre-submit

`npm run build && npm run lint:workspaces && npm run test:run && npm run check:spec-coverage && npm run check:conformance-citations && npm run check:conformance-doc` — exit 0 (rerun after the review revision).