### PR TITLE
fix(docx-release-verifier): label undeclared expectations gate not_run

### DIFF
--- a/packages/docx-release-verifier/src/verifier.test.ts
+++ b/packages/docx-release-verifier/src/verifier.test.ts
@@ -335,6 +335,41 @@ describe('independent release verifier', () => {
     expect(reordered.exitCode).toBe(0);
   });
 
+  itAllure('leaves the expectations gate not_run when no expectations are declared', async () => {
+    const { manifest } = await fixture();
+    const base = { version: 1 as const, originalPath: manifest.originalPath, intendedCleanPath: manifest.intendedCleanPath, trackedPath: manifest.trackedPath };
+    // Omitted entirely: the caller requested no expectation checks, so the gate
+    // must label itself not_run/optional like every sibling undeclared gate.
+    const omitted = await verifyRelease(base);
+    expect(omitted.gates.expectations).toEqual({ status: 'not_run', required: false, reason: 'No text expectations were declared.' });
+    // Declared but explicitly empty collections carry zero checks, which is the
+    // same request as omitting them; both shapes get the same label.
+    const empty = await verifyRelease({ ...base, literalCounts: [], presentOnlyInAccept: [], absentFromAccept: [] });
+    expect(empty.gates.expectations).toEqual({ status: 'not_run', required: false, reason: 'No text expectations were declared.' });
+    // finalVerdict only weighs gates marked required, so relabelling the
+    // undeclared case must not move the overall delivery verdict or exit code.
+    for (const certificate of [omitted, empty]) {
+      expect(certificate.delivery).toEqual({ status: 'pass', required: true });
+      expect(certificate.exitCode).toBe(0);
+    }
+  });
+
+  itAllure('keeps any nonempty expectation collection required and failing on unmet checks', async () => {
+    const { manifest } = await fixture();
+    // Nonempty passing set (the fixture declares all three collections): stays a required pass.
+    const passing = await verifyRelease(manifest);
+    expect(passing.gates.expectations).toEqual({ status: 'pass', required: true });
+    expect(passing.exitCode).toBe(0);
+    // Nonempty failing set: a single declared check keeps the gate required and reds the release.
+    const failing = await verifyRelease({
+      version: 1, originalPath: manifest.originalPath, intendedCleanPath: manifest.intendedCleanPath, trackedPath: manifest.trackedPath,
+      presentOnlyInAccept: ['missing everywhere'],
+    });
+    expect(failing.gates.expectations).toEqual({ status: 'fail', required: true, reason: 'Expected "missing everywhere" only in accept projection.' });
+    expect(failing.delivery.status).toBe('fail');
+    expect(failing.exitCode).toBe(1);
+  });
+
   itAllure('fails corrupt packages independently of semantic text', async () => {
     const { manifest } = await fixture();
     await writeFile(manifest.trackedPath, 'not a zip');

--- a/packages/docx-release-verifier/src/verifier.ts
+++ b/packages/docx-release-verifier/src/verifier.ts
@@ -20,15 +20,21 @@ function expectedHash(actual: string, expected: string | undefined): boolean {
 }
 
 function expectationVerdict(manifest: ReleaseManifest, accept: string, reject: string): Verdict {
+  const literalCounts = manifest.literalCounts ?? [];
+  const presentOnlyInAccept = manifest.presentOnlyInAccept ?? [];
+  const absentFromAccept = manifest.absentFromAccept ?? [];
+  if (literalCounts.length === 0 && presentOnlyInAccept.length === 0 && absentFromAccept.length === 0) {
+    return { status: 'not_run', required: false, reason: 'No text expectations were declared.' };
+  }
   const failures: string[] = [];
-  for (const literal of manifest.literalCounts ?? []) {
+  for (const literal of literalCounts) {
     const projection = literal.projection === 'reject' ? reject : accept;
     if (count(projection, literal.text) !== literal.count) failures.push(`Expected ${JSON.stringify(literal.text)} ${literal.count} times.`);
   }
-  for (const text of manifest.presentOnlyInAccept ?? []) {
+  for (const text of presentOnlyInAccept) {
     if (!accept.includes(text) || reject.includes(text)) failures.push(`Expected ${JSON.stringify(text)} only in accept projection.`);
   }
-  for (const text of manifest.absentFromAccept ?? []) if (accept.includes(text)) failures.push(`Expected ${JSON.stringify(text)} absent from accept projection.`);
+  for (const text of absentFromAccept) if (accept.includes(text)) failures.push(`Expected ${JSON.stringify(text)} absent from accept projection.`);
   return failures.length ? { status: 'fail', required: true, reason: failures.join(' ') } : { status: 'pass', required: true };
 }
 


### PR DESCRIPTION
Fixes #864

## What

`expectationVerdict` in `packages/docx-release-verifier/src/verifier.ts` returned `{status: 'pass', required: true}` when the manifest declared no expectations at all — `literalCounts`, `presentOnlyInAccept`, and `absentFromAccept` all omitted or empty — so the certificate reported a *required* gate as *passed* having performed zero checks. It now returns `{status: 'not_run', required: false, reason: 'No text expectations were declared.'}`, matching every sibling undeclared gate (`mutationControl`, `renderer`, `humanReview`, `comments`).

## Severity framing (honest read)

This is a **certificate-label consistency fix, not a false-assurance fix**. In #858 the caller explicitly required native comments and the gate passed with none — a false assurance about a requested guarantee. Here the caller requested no expectation checks, so treating the empty conjunction as passing was defensible; nothing claimed a requested condition was met. What was actually wrong is that `required: true` contradicted how every sibling gate labels the same state, making the certificate harder to read and audit. The issue itself notes a dynamic review recommended against filing it; it is fixed for labelling consistency only, and this changelog should not be read as closing a release-integrity hole.

## Design decisions

- **Omitted vs explicitly empty**: treated identically. `literalCounts: []` declares zero checks, which is the same request as omitting the key; both now yield `not_run`/`required: false`. Tests cover both shapes separately.
- **Nonempty collections unchanged**: any declared expectation keeps the gate `required: true` with the exact pass/fail behavior it has today.
- **Delivery verdict and exit code unchanged**: `finalVerdict()` weighs only gates marked `required`, so relabelling the undeclared case cannot move the overall outcome. The new test asserts `delivery == {status: 'pass', required: true}` and `exitCode == 0` for both undeclared shapes rather than assuming it.

## Tests

Extended `packages/docx-release-verifier/src/verifier.test.ts` (the tests #863 added there for the comment gate are untouched):

- `leaves the expectations gate not_run when no expectations are declared` — omitted and explicitly-empty shapes, exact verdict object, plus unchanged delivery/exit code.
- `keeps any nonempty expectation collection required and failing on unmet checks` — nonempty passing set stays a required pass; nonempty failing set stays a required fail with exit 1.

Full pre-submit gate (`build && lint:workspaces && test:run && check:spec-coverage && check:conformance-citations && check:conformance-doc`) run in the foreground: exit 0.