### PR TITLE
fix(docx-core): preserve embedded objects through text replacement

### DIFF
--- a/packages/docx-core/src/primitives/merge_runs.ts
+++ b/packages/docx-core/src/primitives/merge_runs.ts
@@ -3,7 +3,7 @@
  *
  * Safety barriers: never merge across fldChar/instrText, comment range,
  * bookmark, or tracked-change wrapper boundaries, and never merge runs
- * carrying embedded objects (drawing/pict/object).
+ * carrying embedded content (drawing/pict/object/contentPart).
  */
 
 import { XMLSerializer } from '@xmldom/xmldom';
@@ -37,13 +37,14 @@ const BARRIER_LOCALS = new Set([
   W.bookmarkEnd,
   'commentRangeStart',
   'commentRangeEnd',
-  // Embedded objects: folding an image/picture/object run into an adjacent
-  // text run makes later text edits treat the object as part of the text
-  // payload, so removing that text drags the object with it. Keep
-  // object-bearing runs unmerged (issue #739).
+  // Embedded content: folding an image/picture/object/content-part run into
+  // an adjacent text run makes later text edits treat the embedded content as
+  // part of the text payload, so removing that text drags the content with
+  // it. Keep embedded-content runs unmerged (issue #739).
   W.drawing,
   W.pict,
   W.object,
+  W.contentPart,
 ]);
 
 const TC_WRAPPER_LOCALS = new Set([
@@ -299,7 +300,7 @@ function mergeParagraphRuns(paragraph: Element, preserveRsidIdentity: boolean): 
  * - Comment range boundaries (commentRangeStart, commentRangeEnd)
  * - Bookmark boundaries (bookmarkStart, bookmarkEnd)
  * - Tracked-change wrapper boundaries (ins, del, moveFrom, moveTo)
- * - Embedded-object runs (drawing, pict, object) — see #739
+ * - Embedded-content runs (drawing, pict, object, contentPart) — see #739
  */
 export function mergeRuns(doc: Document, opts: MergeRunsOptions = {}): MergeRunsResult {
   const body = doc.getElementsByTagNameNS(OOXML.W_NS, W.body).item(0);

--- a/packages/docx-core/src/primitives/merge_runs.ts
+++ b/packages/docx-core/src/primitives/merge_runs.ts
@@ -2,7 +2,8 @@
  * merge_runs — merge adjacent format-identical runs within paragraphs.
  *
  * Safety barriers: never merge across fldChar/instrText, comment range,
- * bookmark, or tracked-change wrapper boundaries.
+ * bookmark, or tracked-change wrapper boundaries, and never merge runs
+ * carrying embedded objects (drawing/pict/object).
  */
 
 import { XMLSerializer } from '@xmldom/xmldom';
@@ -36,6 +37,13 @@ const BARRIER_LOCALS = new Set([
   W.bookmarkEnd,
   'commentRangeStart',
   'commentRangeEnd',
+  // Embedded objects: folding an image/picture/object run into an adjacent
+  // text run makes later text edits treat the object as part of the text
+  // payload, so removing that text drags the object with it. Keep
+  // object-bearing runs unmerged (issue #739).
+  W.drawing,
+  W.pict,
+  W.object,
 ]);
 
 const TC_WRAPPER_LOCALS = new Set([
@@ -104,7 +112,7 @@ function runRsidKey(run: Element): string {
     .join('|');
 }
 
-/** Check whether a run contains barrier content (fldChar, instrText). */
+/** Check whether a run contains barrier content (fldChar, instrText, embedded objects, …). */
 function runContainsBarrierContent(run: Element): boolean {
   let child = run.firstChild;
   while (child) {
@@ -291,6 +299,7 @@ function mergeParagraphRuns(paragraph: Element, preserveRsidIdentity: boolean): 
  * - Comment range boundaries (commentRangeStart, commentRangeEnd)
  * - Bookmark boundaries (bookmarkStart, bookmarkEnd)
  * - Tracked-change wrapper boundaries (ins, del, moveFrom, moveTo)
+ * - Embedded-object runs (drawing, pict, object) — see #739
  */
 export function mergeRuns(doc: Document, opts: MergeRunsOptions = {}): MergeRunsResult {
   const body = doc.getElementsByTagNameNS(OOXML.W_NS, W.body).item(0);

--- a/packages/docx-core/src/primitives/namespaces.ts
+++ b/packages/docx-core/src/primitives/namespaces.ts
@@ -182,6 +182,7 @@ export const W = {
   drawing: 'drawing',
   pict: 'pict',
   object: 'object',
+  contentPart: 'contentPart',
 
   // Revision wrappers
   del: 'del',

--- a/packages/docx-core/src/primitives/text.test.ts
+++ b/packages/docx-core/src/primitives/text.test.ts
@@ -6,6 +6,8 @@ import { OOXML, W } from './namespaces.js';
 import { SafeDocxError } from './errors.js';
 import { getDirectChildrenByName } from './dom-helpers.js';
 import { createRevisionContext, createRevisionIdState } from './track-changes-emitter.js';
+import { rejectChanges } from './reject_changes.js';
+import { acceptChanges } from './accept_changes.js';
 import { revisionEvidence, revisionEvidenceCases } from '../testing/revision-evidence.js';
 import {
   fldChar,
@@ -1605,6 +1607,40 @@ function trackedCtx() {
   });
 }
 
+/**
+ * Structural fingerprint of a paragraph's direct content, in document order.
+ * Embedded content renders as a bracketed tag, live runs as their visible
+ * text, and revision wrappers as `del:`/`ins:` plus their concatenated text —
+ * so ordering assertions catch reordering that concatenated-text assertions
+ * cannot.
+ */
+function paragraphContentSequence(p: Element): string[] {
+  const out: string[] = [];
+  const embeddedTag = (el: Element): string | null => {
+    for (const local of ['drawing', 'pict', 'object', 'contentPart']) {
+      if (el.getElementsByTagNameNS(W_NS, local).length > 0 || (el.namespaceURI === W_NS && el.localName === local)) {
+        return `[${local}]`;
+      }
+    }
+    return null;
+  };
+  for (const child of Array.from(p.childNodes)) {
+    if (child.nodeType !== 1) continue;
+    const el = child as Element;
+    if (el.namespaceURI !== W_NS) continue;
+    if (el.localName === W.pPr) continue;
+    if (el.localName === W.r) {
+      const tag = embeddedTag(el);
+      out.push(tag ?? Array.from(el.getElementsByTagNameNS(W_NS, W.t)).map((t) => t.textContent ?? '').join(''));
+    } else if (el.localName === 'del') {
+      out.push('del:' + Array.from(el.getElementsByTagNameNS(W_NS, 'delText')).map((t) => t.textContent ?? '').join(''));
+    } else if (el.localName === 'ins') {
+      out.push('ins:' + Array.from(el.getElementsByTagNameNS(W_NS, W.t)).map((t) => t.textContent ?? '').join(''));
+    }
+  }
+  return out;
+}
+
 describe('replaceParagraphTextRange — embedded object preservation', () => {
   test('clean full blanking preserves a drawing-only run between text runs', async ({ given, when, then }: AllureBddContext) => {
     let p: Element;
@@ -1701,7 +1737,7 @@ describe('replaceParagraphTextRange — embedded object preservation', () => {
     });
   });
 
-  test('tracked replacement of a run with co-resident text and drawing extracts the drawing before the deletion', async ({ given, when, then }: AllureBddContext) => {
+  test('tracked replacement of a run with co-resident text and drawing keeps the drawing live in original order', async ({ given, when, then }: AllureBddContext) => {
     let p: Element;
 
     await given('a single run holding caption text and a drawing', () => {
@@ -1713,7 +1749,7 @@ describe('replaceParagraphTextRange — embedded object preservation', () => {
       replaceParagraphTextRange(p, 0, 'caption'.length, 'new caption', trackedCtx());
     });
 
-    await then('the drawing stays live while text moves through w:del/w:ins', () => {
+    await then('the drawing stays live while text moves through w:del/w:ins, deletion first (original order)', () => {
       expect(getParagraphText(p)).toBe('new caption');
       const drawings = embeddedObjectsIn(p, W.drawing);
       expect(drawings).toHaveLength(1);
@@ -1722,6 +1758,11 @@ describe('replaceParagraphTextRange — embedded object preservation', () => {
       const del = p.getElementsByTagNameNS(W_NS, 'del').item(0)!;
       expect(del.getElementsByTagNameNS(W_NS, 'delText').item(0)?.textContent).toBe('caption');
       expect(del.getElementsByTagNameNS(W_NS, W.drawing)).toHaveLength(0);
+
+      // Original order was caption-then-drawing, so the deletion segment must
+      // precede the preserved drawing run for reject to restore that order.
+      const sequence = paragraphContentSequence(p);
+      expect(sequence).toEqual(['del:caption', '[drawing]', 'ins:new caption']);
     });
   });
 
@@ -1848,6 +1889,118 @@ describe('replaceParagraphTextRange — embedded object preservation', () => {
       expect(isInsideRevisionWrapper(objects[0]!, p)).toBe(false);
       const del = p.getElementsByTagNameNS(W_NS, 'del').item(0)!;
       expect(del.getElementsByTagNameNS(W_NS, W.object)).toHaveLength(0);
+    });
+  });
+
+  test('clean full blanking preserves a w:contentPart reference run', async ({ given, when, then }: AllureBddContext) => {
+    let p: Element;
+
+    await given('a contentPart-only run between text runs', () => {
+      const doc = makeDoc(
+        '<w:p>' +
+          '<w:r><w:t>lead</w:t></w:r>' +
+          '<w:r><w:contentPart r:id="rId5"/></w:r>' +
+          '<w:r><w:t>tail</w:t></w:r>' +
+        '</w:p>',
+      );
+      p = firstParagraph(doc);
+    });
+
+    await when('the full visible text is blanked (clean)', () => {
+      replaceParagraphTextRange(p, 0, 'leadtail'.length, '');
+    });
+
+    await then('the contentPart survives as a live run with its relationship id', () => {
+      expect(getParagraphText(p)).toBe('');
+      const parts = embeddedObjectsIn(p, W.contentPart);
+      expect(parts).toHaveLength(1);
+      expect(isInsideRevisionWrapper(parts[0]!, p)).toBe(false);
+      expect(serialize(p)).toContain('r:id="rId5"');
+    });
+  });
+
+  test('rejectChanges restores the exact original order around a preserved drawing', async ({ given, when, then }: AllureBddContext) => {
+    let doc: Document;
+    let p: Element;
+
+    await given('text runs around a drawing-only run', () => {
+      doc = makeDoc(
+        '<w:p>' +
+          '<w:r><w:t>before</w:t></w:r>' +
+          `<w:r>${MINIMAL_DRAWING}</w:r>` +
+          '<w:r><w:t>after</w:t></w:r>' +
+        '</w:p>',
+      );
+      p = firstParagraph(doc);
+    });
+
+    await when('the full visible text is replaced under tracked changes and then rejected', () => {
+      replaceParagraphTextRange(p, 0, 'beforeafter'.length, 'X', trackedCtx());
+      // Deletion segments must sit at the removed text's original positions.
+      expect(paragraphContentSequence(p)).toEqual(['del:before', '[drawing]', 'del:after', 'ins:X']);
+      rejectChanges(doc);
+    });
+
+    await then('the paragraph is structurally identical to the original order', () => {
+      expect(paragraphContentSequence(p)).toEqual(['before', '[drawing]', 'after']);
+      expect(getParagraphText(p)).toBe('beforeafter');
+    });
+  });
+
+  test('acceptChanges keeps the revised ordering with the drawing live', async ({ given, when, then }: AllureBddContext) => {
+    let doc: Document;
+    let p: Element;
+
+    await given('text runs around a drawing-only run', () => {
+      doc = makeDoc(
+        '<w:p>' +
+          '<w:r><w:t>before</w:t></w:r>' +
+          `<w:r>${MINIMAL_DRAWING}</w:r>` +
+          '<w:r><w:t>after</w:t></w:r>' +
+        '</w:p>',
+      );
+      p = firstParagraph(doc);
+    });
+
+    await when('the full visible text is replaced under tracked changes and then accepted', () => {
+      replaceParagraphTextRange(p, 0, 'beforeafter'.length, 'X', trackedCtx());
+      acceptChanges(doc);
+    });
+
+    await then('the drawing survives live and the replacement text follows it', () => {
+      expect(paragraphContentSequence(p)).toEqual(['[drawing]', 'X']);
+      expect(getParagraphText(p)).toBe('X');
+      expect(embeddedObjectsIn(p, W.drawing)).toHaveLength(1);
+    });
+  });
+
+  test('rejectChanges restores order across multiple preserved objects in one replaced span', async ({ given, when, then }: AllureBddContext) => {
+    let doc: Document;
+    let p: Element;
+
+    await given('three text runs interleaved with a drawing and a pict', () => {
+      doc = makeDoc(
+        '<w:p>' +
+          '<w:r><w:t>aa</w:t></w:r>' +
+          `<w:r>${MINIMAL_DRAWING}</w:r>` +
+          '<w:r><w:t>bb</w:t></w:r>' +
+          `<w:r>${MINIMAL_PICT}</w:r>` +
+          '<w:r><w:t>cc</w:t></w:r>' +
+        '</w:p>',
+      );
+      p = firstParagraph(doc);
+    });
+
+    await when('the full visible text is deleted under tracked changes and then rejected', () => {
+      replaceParagraphTextRange(p, 0, 'aabbcc'.length, '', trackedCtx());
+      // One deletion segment per contiguous removed stretch, in place.
+      expect(paragraphContentSequence(p)).toEqual(['del:aa', '[drawing]', 'del:bb', '[pict]', 'del:cc']);
+      rejectChanges(doc);
+    });
+
+    await then('every text stretch returns to its original position', () => {
+      expect(paragraphContentSequence(p)).toEqual(['aa', '[drawing]', 'bb', '[pict]', 'cc']);
+      expect(getParagraphText(p)).toBe('aabbcc');
     });
   });
 });

--- a/packages/docx-core/src/primitives/text.test.ts
+++ b/packages/docx-core/src/primitives/text.test.ts
@@ -1558,3 +1558,296 @@ describe('findOffsetInRuns (via replaceParagraphTextRange)', () => {
     });
   });
 });
+
+// ── replaceParagraphTextRange — embedded object preservation (#739) ──
+
+const MINIMAL_DRAWING =
+  '<w:drawing>' +
+  '<wp:inline xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing">' +
+  '<wp:extent cx="914400" cy="914400"/><wp:docPr id="1" name="Picture 1"/>' +
+  '<a:graphic xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">' +
+  '<a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture">' +
+  '<pic:pic xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture">' +
+  '<pic:nvPicPr><pic:cNvPr id="1" name="Picture 1"/><pic:cNvPicPr/></pic:nvPicPr>' +
+  '<pic:blipFill><a:blip r:embed="rId9"/></pic:blipFill>' +
+  '<pic:spPr/></pic:pic></a:graphicData></a:graphic></wp:inline></w:drawing>';
+
+const MINIMAL_PICT =
+  '<w:pict><v:shape xmlns:v="urn:schemas-microsoft-com:vml" id="_s1" style="width:100pt;height:80pt"/></w:pict>';
+
+const MINIMAL_OBJECT =
+  '<w:object><v:shape xmlns:v="urn:schemas-microsoft-com:vml" id="_s2" style="width:60pt;height:20pt"/></w:object>';
+
+function embeddedObjectsIn(p: Element, localName: string): Element[] {
+  return Array.from(p.getElementsByTagNameNS(W_NS, localName));
+}
+
+function isInsideRevisionWrapper(el: Element, stopAt: Element): boolean {
+  let cur: Node | null = el.parentNode;
+  while (cur && cur !== stopAt) {
+    if (
+      cur.nodeType === 1 &&
+      (cur as Element).namespaceURI === W_NS &&
+      ['ins', 'del', 'moveFrom', 'moveTo'].includes((cur as Element).localName ?? '')
+    ) {
+      return true;
+    }
+    cur = cur.parentNode;
+  }
+  return false;
+}
+
+function trackedCtx() {
+  return createRevisionContext({
+    author: 'SafeDocX AI',
+    date: '2026-08-15T10:00:00Z',
+    idState: createRevisionIdState(),
+  });
+}
+
+describe('replaceParagraphTextRange — embedded object preservation', () => {
+  test('clean full blanking preserves a drawing-only run between text runs', async ({ given, when, then }: AllureBddContext) => {
+    let p: Element;
+
+    await given('a paragraph with text runs around a drawing-only run', () => {
+      const doc = makeDoc(
+        '<w:p>' +
+          '<w:r><w:t>before</w:t></w:r>' +
+          `<w:r>${MINIMAL_DRAWING}</w:r>` +
+          '<w:r><w:t>after</w:t></w:r>' +
+        '</w:p>',
+      );
+      p = firstParagraph(doc);
+    });
+
+    await when('the full visible text is replaced with an empty string (clean)', () => {
+      replaceParagraphTextRange(p, 0, 'beforeafter'.length, '');
+    });
+
+    await then('the drawing survives as a live run with its relationship reference', () => {
+      expect(getParagraphText(p)).toBe('');
+      const drawings = embeddedObjectsIn(p, W.drawing);
+      expect(drawings).toHaveLength(1);
+      expect(isInsideRevisionWrapper(drawings[0]!, p)).toBe(false);
+      expect(serialize(p)).toContain('r:embed="rId9"');
+    });
+  });
+
+  test('clean full blanking of a run carrying both text and a drawing keeps the drawing with its formatting', async ({ given, when, then }: AllureBddContext) => {
+    let p: Element;
+
+    await given('a single run holding bold caption text and a drawing', () => {
+      const doc = makeDoc(
+        `<w:p><w:r><w:rPr><w:b/></w:rPr><w:t>caption</w:t>${MINIMAL_DRAWING}</w:r></w:p>`,
+      );
+      p = firstParagraph(doc);
+    });
+
+    await when('the caption text is fully blanked (clean)', () => {
+      replaceParagraphTextRange(p, 0, 'caption'.length, '');
+    });
+
+    await then('the drawing lives on in a run that kept the source run formatting', () => {
+      expect(getParagraphText(p)).toBe('');
+      const drawings = embeddedObjectsIn(p, W.drawing);
+      expect(drawings).toHaveLength(1);
+      const keeperRun = drawings[0]!.parentNode as Element;
+      expect(keeperRun.localName).toBe(W.r);
+      expect(isInsideRevisionWrapper(drawings[0]!, p)).toBe(false);
+      const rPr = getDirectChildrenByName(keeperRun, W.rPr)[0];
+      expect(rPr).toBeTruthy();
+      expect(getDirectChildrenByName(rPr!, W.b)[0]).toBeTruthy();
+      expect(serialize(p)).toContain('r:embed="rId9"');
+    });
+  });
+
+  paragraphDeletionTest('tracked full blanking keeps the drawing live, outside w:del, and keeps the paragraph mark', async ({ given, when, then }: AllureBddContext) => {
+    let p: Element;
+
+    await given('a paragraph with text runs around a drawing-only run', () => {
+      const doc = makeDoc(
+        '<w:p>' +
+          '<w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr></w:pPr>' +
+          '<w:r><w:t>before</w:t></w:r>' +
+          `<w:r>${MINIMAL_DRAWING}</w:r>` +
+          '<w:r><w:t>after</w:t></w:r>' +
+        '</w:p>',
+      );
+      p = firstParagraph(doc);
+    });
+
+    await when('the full visible text is deleted under tracked changes', () => {
+      replaceParagraphTextRange(p, 0, 'beforeafter'.length, '', trackedCtx());
+    });
+
+    await then('the deletion covers only the text and the paragraph mark stays undeleted', () => {
+      const drawings = embeddedObjectsIn(p, W.drawing);
+      expect(drawings).toHaveLength(1);
+      expect(isInsideRevisionWrapper(drawings[0]!, p)).toBe(false);
+
+      const deletions = embeddedObjectsIn(p, 'del').filter((d) => !isInsideRevisionWrapper(d, p));
+      const deletedText = deletions
+        .flatMap((d) => Array.from(d.getElementsByTagNameNS(W_NS, 'delText')))
+        .map((t) => t.textContent ?? '')
+        .join('');
+      expect(deletedText).toBe('beforeafter');
+      expect(deletions.flatMap((d) => Array.from(d.getElementsByTagNameNS(W_NS, W.drawing)))).toHaveLength(0);
+
+      // The paragraph still visibly carries the image, so its mark must not be deleted.
+      const pPr = getDirectChildrenByName(p, W.pPr)[0];
+      const markRPr = pPr ? getDirectChildrenByName(pPr, W.rPr)[0] : undefined;
+      const markDeletion = markRPr ? getDirectChildrenByName(markRPr, 'del')[0] : undefined;
+      expect(markDeletion).toBeUndefined();
+    });
+  });
+
+  test('tracked replacement of a run with co-resident text and drawing extracts the drawing before the deletion', async ({ given, when, then }: AllureBddContext) => {
+    let p: Element;
+
+    await given('a single run holding caption text and a drawing', () => {
+      const doc = makeDoc(`<w:p><w:r><w:t>caption</w:t>${MINIMAL_DRAWING}</w:r></w:p>`);
+      p = firstParagraph(doc);
+    });
+
+    await when('the caption is replaced under tracked changes', () => {
+      replaceParagraphTextRange(p, 0, 'caption'.length, 'new caption', trackedCtx());
+    });
+
+    await then('the drawing stays live while text moves through w:del/w:ins', () => {
+      expect(getParagraphText(p)).toBe('new caption');
+      const drawings = embeddedObjectsIn(p, W.drawing);
+      expect(drawings).toHaveLength(1);
+      expect(isInsideRevisionWrapper(drawings[0]!, p)).toBe(false);
+
+      const del = p.getElementsByTagNameNS(W_NS, 'del').item(0)!;
+      expect(del.getElementsByTagNameNS(W_NS, 'delText').item(0)?.textContent).toBe('caption');
+      expect(del.getElementsByTagNameNS(W_NS, W.drawing)).toHaveLength(0);
+    });
+  });
+
+  test('clean partial replacement inside a run preserves an interior drawing', async ({ given, when, then }: AllureBddContext) => {
+    let p: Element;
+
+    await given('one run with text on both sides of a drawing', () => {
+      const doc = makeDoc(`<w:p><w:r><w:t>abc</w:t>${MINIMAL_DRAWING}<w:t>def</w:t></w:r></w:p>`);
+      p = firstParagraph(doc);
+    });
+
+    await when('the middle of the text is replaced (clean)', () => {
+      replaceParagraphTextRange(p, 1, 5, 'X');
+    });
+
+    await then('the text changes and the drawing survives live', () => {
+      expect(getParagraphText(p)).toBe('aXf');
+      const drawings = embeddedObjectsIn(p, W.drawing);
+      expect(drawings).toHaveLength(1);
+      expect(isInsideRevisionWrapper(drawings[0]!, p)).toBe(false);
+      expect(serialize(p)).toContain('r:embed="rId9"');
+    });
+  });
+
+  test('tracked partial replacement across runs preserves an intervening drawing-only run', async ({ given, when, then }: AllureBddContext) => {
+    let p: Element;
+
+    await given('separate text runs around a drawing-only run', () => {
+      const doc = makeDoc(
+        '<w:p>' +
+          '<w:r><w:t>aaa</w:t></w:r>' +
+          `<w:r>${MINIMAL_DRAWING}</w:r>` +
+          '<w:r><w:t>bbb</w:t></w:r>' +
+        '</w:p>',
+      );
+      p = firstParagraph(doc);
+    });
+
+    await when('a range spanning the drawing is replaced under tracked changes', () => {
+      replaceParagraphTextRange(p, 2, 4, 'X', trackedCtx());
+    });
+
+    await then('the drawing stays a live sibling run outside every revision wrapper', () => {
+      expect(getParagraphText(p)).toBe('aaXbb');
+      const drawings = embeddedObjectsIn(p, W.drawing);
+      expect(drawings).toHaveLength(1);
+      expect(isInsideRevisionWrapper(drawings[0]!, p)).toBe(false);
+    });
+  });
+
+  test('clean full blanking leaves drawing runs before and after the text untouched', async ({ given, when, then }: AllureBddContext) => {
+    let p: Element;
+
+    await given('drawing-only runs before and after a single text run', () => {
+      const doc = makeDoc(
+        '<w:p>' +
+          `<w:r>${MINIMAL_DRAWING}</w:r>` +
+          '<w:r><w:t>text</w:t></w:r>' +
+          `<w:r>${MINIMAL_DRAWING}</w:r>` +
+        '</w:p>',
+      );
+      p = firstParagraph(doc);
+    });
+
+    await when('the text is fully blanked (clean)', () => {
+      replaceParagraphTextRange(p, 0, 'text'.length, '');
+    });
+
+    await then('both drawings remain live runs', () => {
+      expect(getParagraphText(p)).toBe('');
+      const drawings = embeddedObjectsIn(p, W.drawing);
+      expect(drawings).toHaveLength(2);
+      for (const d of drawings) expect(isInsideRevisionWrapper(d, p)).toBe(false);
+    });
+  });
+
+  test('clean full blanking preserves a VML w:pict run', async ({ given, when, then }: AllureBddContext) => {
+    let p: Element;
+
+    await given('a pict-only run between text runs', () => {
+      const doc = makeDoc(
+        '<w:p>' +
+          '<w:r><w:t>lead</w:t></w:r>' +
+          `<w:r>${MINIMAL_PICT}</w:r>` +
+          '<w:r><w:t>tail</w:t></w:r>' +
+        '</w:p>',
+      );
+      p = firstParagraph(doc);
+    });
+
+    await when('the full visible text is blanked (clean)', () => {
+      replaceParagraphTextRange(p, 0, 'leadtail'.length, '');
+    });
+
+    await then('the pict survives as a live run', () => {
+      expect(getParagraphText(p)).toBe('');
+      const picts = embeddedObjectsIn(p, W.pict);
+      expect(picts).toHaveLength(1);
+      expect(isInsideRevisionWrapper(picts[0]!, p)).toBe(false);
+    });
+  });
+
+  test('tracked full blanking preserves an embedded w:object run', async ({ given, when, then }: AllureBddContext) => {
+    let p: Element;
+
+    await given('an object-only run between text runs', () => {
+      const doc = makeDoc(
+        '<w:p>' +
+          '<w:r><w:t>lead</w:t></w:r>' +
+          `<w:r>${MINIMAL_OBJECT}</w:r>` +
+          '<w:r><w:t>tail</w:t></w:r>' +
+        '</w:p>',
+      );
+      p = firstParagraph(doc);
+    });
+
+    await when('the full visible text is deleted under tracked changes', () => {
+      replaceParagraphTextRange(p, 0, 'leadtail'.length, '', trackedCtx());
+    });
+
+    await then('the object survives live and outside w:del', () => {
+      const objects = embeddedObjectsIn(p, W.object);
+      expect(objects).toHaveLength(1);
+      expect(isInsideRevisionWrapper(objects[0]!, p)).toBe(false);
+      const del = p.getElementsByTagNameNS(W_NS, 'del').item(0)!;
+      expect(del.getElementsByTagNameNS(W_NS, W.object)).toHaveLength(0);
+    });
+  });
+});

--- a/packages/docx-core/src/primitives/text.ts
+++ b/packages/docx-core/src/primitives/text.ts
@@ -351,14 +351,28 @@ function getRunVisibleLength(run: Element): number {
   return getDirectContentElements(run).reduce((sum, child) => sum + visibleLengthForEl(child), 0);
 }
 
-// OOXML embedded-object run content: DrawingML drawing (w:drawing), VML
-// picture (w:pict), and embedded OLE object (w:object). These carry no
-// visible text length, so a caller-approved text match never covers them —
-// a text replacement must not destroy them (issue #739).
-const EMBEDDED_OBJECT_LOCALS: ReadonlySet<string> = new Set([W.drawing, W.pict, W.object]);
+// OOXML embedded run content that references package parts: DrawingML drawing
+// (w:drawing), VML picture (w:pict), embedded OLE object (w:object), and
+// imported content part (w:contentPart, a CT_Rel relationship reference).
+// These carry no visible text length, so a caller-approved text match never
+// covers them — a text replacement must not destroy them (issue #739).
+const EMBEDDED_CONTENT_LOCALS: ReadonlySet<string> = new Set([
+  W.drawing,
+  W.pict,
+  W.object,
+  W.contentPart,
+]);
 
-function getEmbeddedObjectElements(run: Element): Element[] {
-  return getDirectContentElements(run).filter((el) => EMBEDDED_OBJECT_LOCALS.has(el.localName ?? ''));
+function isEmbeddedContentElement(node: Node): boolean {
+  return (
+    node.nodeType === 1 &&
+    (node as Element).namespaceURI === OOXML.W_NS &&
+    EMBEDDED_CONTENT_LOCALS.has((node as Element).localName ?? '')
+  );
+}
+
+function getEmbeddedContentElements(run: Element): Element[] {
+  return getDirectContentElements(run).filter((el) => EMBEDDED_CONTENT_LOCALS.has(el.localName ?? ''));
 }
 
 export type AddRunProps = {
@@ -665,9 +679,11 @@ function getContainerBoundaryError(
  * remain nested there, while cross-container ranges are refused before the
  * DOM is changed.
  *
- * Embedded objects (`w:drawing`, `w:pict`, `w:object`) inside the replaced
- * range are preserved as live runs: they contribute no visible text, so no
- * text match ever covers them and no text edit may delete them.
+ * Embedded content (`w:drawing`, `w:pict`, `w:object`, `w:contentPart`)
+ * inside the replaced range is preserved as live runs: it contributes no
+ * visible text, so no text match ever covers it and no text edit may delete
+ * it. Tracked deletions around preserved content are emitted as in-place
+ * segments so rejectChanges() restores the original content order exactly.
  *
  * @conformance ECMA-376 edition 5, Part 1 § 17.13.5.14
  * @conformance ECMA-376 edition 5, Part 1 § 17.13.5.15
@@ -802,41 +818,124 @@ export function replaceParagraphTextRange(
 
   // Remove runs in [rangeStartRunEl, rangeEndRunEl] inclusive (only w:r elements).
   //
-  // Embedded objects (w:drawing / w:pict / w:object) have zero visible text
-  // length, so the text match the caller approved never covered them. They
-  // must survive the replacement as live content (issue #739): an object-only
-  // run stays in place untouched, and an object co-resident with replaced
-  // text is moved into its own run at the same position before the text run
-  // is removed. Without this, an object-only run would be detached here but
-  // never recorded in removedRuns (getRunVisibleLength returns 0 for it), so
-  // neither the tracked nor the clean branch could re-emit it.
+  // Embedded content (w:drawing / w:pict / w:object / w:contentPart) has zero
+  // visible text length, so the text match the caller approved never covered
+  // it. It must survive the replacement as live content (issue #739): an
+  // embedded-only run stays in place untouched, and embedded content
+  // co-resident with replaced text is split into its own run at the same
+  // relative position before the text is removed. Without this, an
+  // embedded-only run would be detached here but never recorded
+  // (getRunVisibleLength returns 0 for it), so neither the tracked nor the
+  // clean branch could re-emit it.
+  //
+  // When embedded content is preserved, tracked deletions are emitted as
+  // IN-PLACE SEGMENTS — one w:del per contiguous stretch of removed text,
+  // inserted at that stretch's original position — instead of one terminal
+  // w:del after the range. A single terminal w:del would make rejectChanges()
+  // restore the removed text AFTER the preserved object, permanently
+  // reordering content the user never touched. When no embedded content is
+  // involved the historical single-deletion emission is kept unchanged.
+  let rangeContainsEmbeddedContent = false;
+  for (let node: Node | null = rangeStartRunEl; node; node = node.nextSibling) {
+    if (
+      node.nodeType === 1 &&
+      isW(node as Element, W.r) &&
+      getEmbeddedContentElements(node as Element).length > 0
+    ) {
+      rangeContainsEmbeddedContent = true;
+    }
+    if (node === rangeEndRunEl) break;
+  }
+
   const removedRuns: Element[] = [];
-  let preservedEmbeddedObjects = false;
-  let cur: Node | null = rangeStartRunEl;
-  while (cur) {
-    const nextNode: Node | null = cur.nextSibling as Node | null;
-    if (cur.nodeType === 1 && isW(cur as Element, W.r)) {
-      const runEl = cur as Element;
-      const embeddedObjects = getEmbeddedObjectElements(runEl);
-      if (embeddedObjects.length > 0 && getRunVisibleLength(runEl) === 0) {
-        // Object-only run: the replaced text lives entirely in sibling runs.
-        // Leave it in the paragraph as-is.
-        preservedEmbeddedObjects = true;
-      } else {
-        if (embeddedObjects.length > 0) {
-          const keeper = cloneRunFormattingOnly(doc, runEl);
-          for (const embedded of embeddedObjects) keeper.appendChild(embedded);
-          runEl.parentNode?.insertBefore(keeper, runEl);
-          preservedEmbeddedObjects = true;
-        }
+  let preservedEmbeddedContent = false;
+
+  if (!rangeContainsEmbeddedContent) {
+    let cur: Node | null = rangeStartRunEl;
+    while (cur) {
+      const nextNode: Node | null = cur.nextSibling as Node | null;
+      if (cur.nodeType === 1 && isW(cur as Element, W.r)) {
+        const runEl = cur as Element;
         runEl.parentNode?.removeChild(runEl);
         if (getRunVisibleLength(runEl) > 0) {
           removedRuns.push(runEl);
         }
       }
+      if (cur === rangeEndRunEl) break;
+      cur = nextNode;
     }
-    if (cur === rangeEndRunEl) break;
-    cur = nextNode;
+  } else {
+    // The open deletion segment; reset to null whenever preserved embedded
+    // content interrupts the removed stretch so the next removed run starts
+    // a new w:del at its own position.
+    let currentDeletion: Element | null = null;
+
+    const removeRunInPlace = (runEl: Element): void => {
+      const parentNode = runEl.parentNode;
+      if (!parentNode) return;
+      if (ctx && getRunVisibleLength(runEl) > 0) {
+        if (!currentDeletion) {
+          currentDeletion = createRevisionContainer(doc, 'del', ctx);
+          parentNode.insertBefore(currentDeletion, runEl);
+        }
+        parentNode.removeChild(runEl);
+        currentDeletion.appendChild(prepareElementForDeletion(runEl));
+      } else {
+        parentNode.removeChild(runEl);
+      }
+    };
+
+    // Split a run holding both text and embedded content into consecutive
+    // homogeneous runs (formatting cloned), inserted at the run's position in
+    // original child order, so both the preserved content and the removed
+    // text keep their exact relative positions.
+    const splitMixedRun = (runEl: Element): Array<{ el: Element; embedded: boolean }> => {
+      const parentNode = runEl.parentNode;
+      if (!parentNode) throw new Error('Run has no parent');
+      const pieces: Array<{ el: Element; embedded: boolean }> = [];
+      let currentPiece: { el: Element; embedded: boolean } | null = null;
+      for (const child of Array.from(runEl.childNodes)) {
+        if (child.nodeType === 1 && isW(child as Element, W.rPr)) continue;
+        const embedded = isEmbeddedContentElement(child);
+        if (!currentPiece || currentPiece.embedded !== embedded) {
+          currentPiece = { el: cloneRunFormattingOnly(doc, runEl), embedded };
+          pieces.push(currentPiece);
+        }
+        currentPiece.el.appendChild(child);
+      }
+      for (const piece of pieces) parentNode.insertBefore(piece.el, runEl);
+      parentNode.removeChild(runEl);
+      return pieces;
+    };
+
+    let cur: Node | null = rangeStartRunEl;
+    while (cur) {
+      const nextNode: Node | null = cur.nextSibling as Node | null;
+      const atRangeEnd = cur === rangeEndRunEl;
+      if (cur.nodeType === 1 && isW(cur as Element, W.r)) {
+        const runEl = cur as Element;
+        const embeddedContent = getEmbeddedContentElements(runEl);
+        if (embeddedContent.length === 0) {
+          removeRunInPlace(runEl);
+        } else if (getRunVisibleLength(runEl) === 0) {
+          // Embedded-only run: the replaced text lives entirely in sibling
+          // runs. Leave it in the paragraph as-is.
+          preservedEmbeddedContent = true;
+          currentDeletion = null;
+        } else {
+          for (const piece of splitMixedRun(runEl)) {
+            if (piece.embedded) {
+              preservedEmbeddedContent = true;
+              currentDeletion = null;
+            } else {
+              removeRunInPlace(piece.el);
+            }
+          }
+        }
+      }
+      if (atRangeEnd) break;
+      cur = nextNode;
+    }
   }
 
   // Build replacement runs using the same formatting/template logic as the legacy path.
@@ -876,10 +975,10 @@ export function replaceParagraphTextRange(
     }
 
     // Only delete the paragraph mark when the edit leaves nothing live behind.
-    // A preserved embedded object keeps the paragraph meaningful, and merging
+    // Preserved embedded content keeps the paragraph meaningful, and merging
     // it into the following paragraph on accept would move the image the user
     // never touched (issue #739).
-    if (start === 0 && end === fullText.length && replacementRuns.length === 0 && !preservedEmbeddedObjects) {
+    if (start === 0 && end === fullText.length && replacementRuns.length === 0 && !preservedEmbeddedContent) {
       addParagraphMarkDeletion(p, ctx);
     }
   } else {

--- a/packages/docx-core/src/primitives/text.ts
+++ b/packages/docx-core/src/primitives/text.ts
@@ -351,6 +351,16 @@ function getRunVisibleLength(run: Element): number {
   return getDirectContentElements(run).reduce((sum, child) => sum + visibleLengthForEl(child), 0);
 }
 
+// OOXML embedded-object run content: DrawingML drawing (w:drawing), VML
+// picture (w:pict), and embedded OLE object (w:object). These carry no
+// visible text length, so a caller-approved text match never covers them —
+// a text replacement must not destroy them (issue #739).
+const EMBEDDED_OBJECT_LOCALS: ReadonlySet<string> = new Set([W.drawing, W.pict, W.object]);
+
+function getEmbeddedObjectElements(run: Element): Element[] {
+  return getDirectContentElements(run).filter((el) => EMBEDDED_OBJECT_LOCALS.has(el.localName ?? ''));
+}
+
 export type AddRunProps = {
   // Additive or subtractive formatting.
   // Set to true to enable, false to explicitly disable/remove.
@@ -655,11 +665,16 @@ function getContainerBoundaryError(
  * remain nested there, while cross-container ranges are refused before the
  * DOM is changed.
  *
+ * Embedded objects (`w:drawing`, `w:pict`, `w:object`) inside the replaced
+ * range are preserved as live runs: they contribute no visible text, so no
+ * text match ever covers them and no text edit may delete them.
+ *
  * @conformance ECMA-376 edition 5, Part 1 § 17.13.5.14
  * @conformance ECMA-376 edition 5, Part 1 § 17.13.5.15
  * @conformance ECMA-376 edition 5, Part 1 § 17.16.22
  * @see #652
  * @see #741
+ * @see #739
  */
 export function replaceParagraphTextRange(
   p: Element,
@@ -786,15 +801,38 @@ export function replaceParagraphTextRange(
   const insertBeforeNode = rangeEndRunEl.nextSibling;
 
   // Remove runs in [rangeStartRunEl, rangeEndRunEl] inclusive (only w:r elements).
+  //
+  // Embedded objects (w:drawing / w:pict / w:object) have zero visible text
+  // length, so the text match the caller approved never covered them. They
+  // must survive the replacement as live content (issue #739): an object-only
+  // run stays in place untouched, and an object co-resident with replaced
+  // text is moved into its own run at the same position before the text run
+  // is removed. Without this, an object-only run would be detached here but
+  // never recorded in removedRuns (getRunVisibleLength returns 0 for it), so
+  // neither the tracked nor the clean branch could re-emit it.
   const removedRuns: Element[] = [];
+  let preservedEmbeddedObjects = false;
   let cur: Node | null = rangeStartRunEl;
   while (cur) {
     const nextNode: Node | null = cur.nextSibling as Node | null;
     if (cur.nodeType === 1 && isW(cur as Element, W.r)) {
       const runEl = cur as Element;
-      runEl.parentNode?.removeChild(runEl);
-      if (getRunVisibleLength(runEl) > 0) {
-        removedRuns.push(runEl);
+      const embeddedObjects = getEmbeddedObjectElements(runEl);
+      if (embeddedObjects.length > 0 && getRunVisibleLength(runEl) === 0) {
+        // Object-only run: the replaced text lives entirely in sibling runs.
+        // Leave it in the paragraph as-is.
+        preservedEmbeddedObjects = true;
+      } else {
+        if (embeddedObjects.length > 0) {
+          const keeper = cloneRunFormattingOnly(doc, runEl);
+          for (const embedded of embeddedObjects) keeper.appendChild(embedded);
+          runEl.parentNode?.insertBefore(keeper, runEl);
+          preservedEmbeddedObjects = true;
+        }
+        runEl.parentNode?.removeChild(runEl);
+        if (getRunVisibleLength(runEl) > 0) {
+          removedRuns.push(runEl);
+        }
       }
     }
     if (cur === rangeEndRunEl) break;
@@ -837,7 +875,11 @@ export function replaceParagraphTextRange(
       parent.insertBefore(insertion, insertBeforeNode);
     }
 
-    if (start === 0 && end === fullText.length && replacementRuns.length === 0) {
+    // Only delete the paragraph mark when the edit leaves nothing live behind.
+    // A preserved embedded object keeps the paragraph meaningful, and merging
+    // it into the following paragraph on accept would move the image the user
+    // never touched (issue #739).
+    if (start === 0 && end === fullText.length && replacementRuns.length === 0 && !preservedEmbeddedObjects) {
       addParagraphMarkDeletion(p, ctx);
     }
   } else {

--- a/packages/docx-core/test-primitives/merge_runs.test.ts
+++ b/packages/docx-core/test-primitives/merge_runs.test.ts
@@ -488,3 +488,148 @@ describe('merge_runs', () => {
     });
   });
 });
+
+// ── Embedded-object barriers (#739) ────────────────────────────────────
+
+const BARRIER_DRAWING =
+  '<w:drawing>' +
+  '<wp:inline xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing">' +
+  '<wp:extent cx="914400" cy="914400"/><wp:docPr id="1" name="Picture 1"/>' +
+  '<a:graphic xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">' +
+  '<a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture">' +
+  '<pic:pic xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture">' +
+  '<pic:nvPicPr><pic:cNvPr id="1" name="Picture 1"/><pic:cNvPicPr/></pic:nvPicPr>' +
+  '<pic:blipFill><a:blip xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" r:embed="rId9"/></pic:blipFill>' +
+  '<pic:spPr/></pic:pic></a:graphicData></a:graphic></wp:inline></w:drawing>';
+
+const BARRIER_PICT =
+  '<w:pict><v:shape xmlns:v="urn:schemas-microsoft-com:vml" id="_s1" style="width:100pt;height:80pt"/></w:pict>';
+
+const BARRIER_OBJECT =
+  '<w:object><v:shape xmlns:v="urn:schemas-microsoft-com:vml" id="_s2" style="width:60pt;height:20pt"/></w:object>';
+
+describe('merge_runs — embedded-object barriers', () => {
+  test('does not merge a drawing-only run into an adjacent format-identical text run', async ({ given, when, then }: AllureBddContext) => {
+    let doc!: Document;
+    let result!: ReturnType<typeof mergeRuns>;
+
+    await given('a caption run followed by a drawing-only run, both without rPr', () => {
+      doc = makeDoc(
+        '<w:p>' +
+        '<w:r><w:t xml:space="preserve">Figure 1 caption.</w:t></w:r>' +
+        `<w:r>${BARRIER_DRAWING}</w:r>` +
+        '</w:p>',
+      );
+    });
+
+    await when('mergeRuns is called', async () => {
+      result = mergeRuns(doc);
+    });
+
+    await then('no runs are merged and the drawing keeps its own run', () => {
+      expect(result.runsMerged).toBe(0);
+      expect(countRuns(doc)).toBe(2);
+      const drawing = doc.getElementsByTagNameNS(W_NS, 'drawing').item(0)!;
+      const drawingRun = drawing.parentNode as Element;
+      expect(drawingRun.localName).toBe(W.r);
+      expect(drawingRun.getElementsByTagNameNS(W_NS, W.t)).toHaveLength(0);
+    });
+  });
+
+  test('does not merge a text run into a preceding pict-only run', async ({ given, when, then }: AllureBddContext) => {
+    let doc!: Document;
+    let result!: ReturnType<typeof mergeRuns>;
+
+    await given('a pict-only run followed by a format-identical text run', () => {
+      doc = makeDoc(
+        '<w:p>' +
+        `<w:r>${BARRIER_PICT}</w:r>` +
+        '<w:r><w:t>after the picture</w:t></w:r>' +
+        '</w:p>',
+      );
+    });
+
+    await when('mergeRuns is called', async () => {
+      result = mergeRuns(doc);
+    });
+
+    await then('no runs are merged', () => {
+      expect(result.runsMerged).toBe(0);
+      expect(countRuns(doc)).toBe(2);
+    });
+  });
+
+  test('does not merge an embedded-object run with its neighbors', async ({ given, when, then }: AllureBddContext) => {
+    let doc!: Document;
+    let result!: ReturnType<typeof mergeRuns>;
+
+    await given('text runs on both sides of an object-only run, all without rPr', () => {
+      doc = makeDoc(
+        '<w:p>' +
+        '<w:r><w:t>lead</w:t></w:r>' +
+        `<w:r>${BARRIER_OBJECT}</w:r>` +
+        '<w:r><w:t>tail</w:t></w:r>' +
+        '</w:p>',
+      );
+    });
+
+    await when('mergeRuns is called', async () => {
+      result = mergeRuns(doc);
+    });
+
+    await then('all three runs remain separate', () => {
+      expect(result.runsMerged).toBe(0);
+      expect(countRuns(doc)).toBe(3);
+      expect(bodyText(doc)).toBe('leadtail');
+    });
+  });
+
+  test('does not merge a run already carrying both text and a drawing', async ({ given, when, then }: AllureBddContext) => {
+    let doc!: Document;
+    let result!: ReturnType<typeof mergeRuns>;
+
+    await given('a mixed text+drawing run next to a plain text run', () => {
+      doc = makeDoc(
+        '<w:p>' +
+        `<w:r><w:t>caption</w:t>${BARRIER_DRAWING}</w:r>` +
+        '<w:r><w:t>plain</w:t></w:r>' +
+        '</w:p>',
+      );
+    });
+
+    await when('mergeRuns is called', async () => {
+      result = mergeRuns(doc);
+    });
+
+    await then('the mixed run is left alone', () => {
+      expect(result.runsMerged).toBe(0);
+      expect(countRuns(doc)).toBe(2);
+    });
+  });
+
+  test('still merges plain text runs in a paragraph that also contains a drawing run', async ({ given, when, then }: AllureBddContext) => {
+    let doc!: Document;
+    let result!: ReturnType<typeof mergeRuns>;
+
+    await given('two mergeable text runs followed by a drawing-only run', () => {
+      doc = makeDoc(
+        '<w:p>' +
+        '<w:r><w:t>Hello </w:t></w:r>' +
+        '<w:r><w:t>World</w:t></w:r>' +
+        `<w:r>${BARRIER_DRAWING}</w:r>` +
+        '</w:p>',
+      );
+    });
+
+    await when('mergeRuns is called', async () => {
+      result = mergeRuns(doc);
+    });
+
+    await then('only the text runs merge and the drawing run survives', () => {
+      expect(result.runsMerged).toBe(1);
+      expect(countRuns(doc)).toBe(2);
+      expect(bodyText(doc)).toBe('Hello World');
+      expect(doc.getElementsByTagNameNS(W_NS, 'drawing')).toHaveLength(1);
+    });
+  });
+});

--- a/packages/docx-core/test-primitives/merge_runs.test.ts
+++ b/packages/docx-core/test-primitives/merge_runs.test.ts
@@ -607,6 +607,30 @@ describe('merge_runs — embedded-object barriers', () => {
     });
   });
 
+  test('does not merge a contentPart reference run into an adjacent text run', async ({ given, when, then }: AllureBddContext) => {
+    let doc!: Document;
+    let result!: ReturnType<typeof mergeRuns>;
+
+    await given('a text run followed by a contentPart-only run, both without rPr', () => {
+      doc = makeDoc(
+        '<w:p>' +
+        '<w:r><w:t>imported content follows</w:t></w:r>' +
+        '<w:r><w:contentPart xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" r:id="rId5"/></w:r>' +
+        '</w:p>',
+      );
+    });
+
+    await when('mergeRuns is called', async () => {
+      result = mergeRuns(doc);
+    });
+
+    await then('no runs are merged and the contentPart keeps its own run', () => {
+      expect(result.runsMerged).toBe(0);
+      expect(countRuns(doc)).toBe(2);
+      expect(doc.getElementsByTagNameNS(W_NS, 'contentPart')).toHaveLength(1);
+    });
+  });
+
   test('still merges plain text runs in a paragraph that also contains a drawing run', async ({ given, when, then }: AllureBddContext) => {
     let doc!: Document;
     let result!: ReturnType<typeof mergeRuns>;

--- a/packages/docx-mcp/src/testing/docx_test_utils.ts
+++ b/packages/docx-mcp/src/testing/docx_test_utils.ts
@@ -31,7 +31,7 @@ const MINIMAL_RELS_XML = [
   '</Relationships>',
 ].join('\n');
 
-export async function makeDocxWithDocumentXml(documentXml: string, extraFiles?: Record<string, string>): Promise<Buffer> {
+export async function makeDocxWithDocumentXml(documentXml: string, extraFiles?: Record<string, string | Buffer | Uint8Array>): Promise<Buffer> {
   return createZipBuffer({
     '[Content_Types].xml': MINIMAL_CONTENT_TYPES_XML,
     '_rels/.rels': MINIMAL_RELS_XML,

--- a/packages/docx-mcp/src/testing/session-test-utils.ts
+++ b/packages/docx-mcp/src/testing/session-test-utils.ts
@@ -52,7 +52,7 @@ export function createTestSessionManager(opts?: { ttlMs?: number; defaultAiAutho
 
 interface OpenSessionOptions {
   xml?: string;
-  extraFiles?: Record<string, string>;
+  extraFiles?: Record<string, string | Buffer | Uint8Array>;
   format?: 'toon' | 'simple' | 'json';
   mgr?: SessionManager;
   prefix?: string;

--- a/packages/docx-mcp/src/tools/replace_text_embedded_image.regression.test.ts
+++ b/packages/docx-mcp/src/tools/replace_text_embedded_image.regression.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Regression test for issue #739: blanking a paragraph's visible text with
+ * replace_text must not destroy an inline image in the same paragraph.
+ *
+ * Exercises the full package path — open a DOCX carrying a DrawingML inline
+ * picture (w:drawing + r:embed relationship + word/media part), blank the
+ * caption through the real replace_text tool, save, and assert the drawing
+ * node, the relationship entry, and the media part all survive and the saved
+ * package reopens cleanly. Covers both the clean and the tracked flow; in the
+ * tracked flow the image must remain a live run, not part of w:del.
+ */
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { describe, expect } from 'vitest';
+import { DocxArchive, parseXml } from '@usejunior/docx-core';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import {
+  openSession,
+  assertSuccess,
+  registerCleanup,
+  createTestSessionManager,
+} from '../testing/session-test-utils.js';
+import { replaceText } from './replace_text.js';
+import { save } from './save.js';
+import { openDocument } from './open_document.js';
+
+const test = testAllure.epic('Document Editing').withLabels({ feature: 'Embedded Object Preservation' });
+
+const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+const PNG_1X1 = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+  'base64',
+);
+
+const INLINE_IMAGE_RUN =
+  '<w:r><w:drawing>' +
+  '<wp:inline distT="0" distB="0" distL="0" distR="0">' +
+  '<wp:extent cx="914400" cy="914400"/>' +
+  '<wp:docPr id="1" name="Picture 1"/>' +
+  '<a:graphic xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">' +
+  '<a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture">' +
+  '<pic:pic xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture">' +
+  '<pic:nvPicPr><pic:cNvPr id="1" name="Picture 1"/><pic:cNvPicPr/></pic:nvPicPr>' +
+  '<pic:blipFill><a:blip r:embed="rId9"/><a:stretch><a:fillRect/></a:stretch></pic:blipFill>' +
+  '<pic:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="914400" cy="914400"/></a:xfrm>' +
+  '<a:prstGeom prst="rect"><a:avLst/></a:prstGeom></pic:spPr>' +
+  '</pic:pic></a:graphicData></a:graphic></wp:inline></w:drawing></w:r>';
+
+const DOCUMENT_XML =
+  '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+  '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"' +
+  ' xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"' +
+  ' xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"' +
+  ' xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"' +
+  ' xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="w14">' +
+  '<w:body>' +
+  '<w:p><w:r><w:t xml:space="preserve">Intro paragraph.</w:t></w:r></w:p>' +
+  '<w:p><w:r><w:t xml:space="preserve">Figure 1 caption.</w:t></w:r>' + INLINE_IMAGE_RUN + '</w:p>' +
+  '<w:p><w:r><w:t xml:space="preserve">Outro paragraph.</w:t></w:r></w:p>' +
+  '</w:body></w:document>';
+
+const IMAGE_PACKAGE_EXTRA_FILES: Record<string, string | Buffer> = {
+  '[Content_Types].xml':
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+    '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">' +
+    '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+    '<Default Extension="xml" ContentType="application/xml"/>' +
+    '<Default Extension="png" ContentType="image/png"/>' +
+    '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+    '</Types>',
+  'word/_rels/document.xml.rels':
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+    '<Relationship Id="rId9" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/image1.png"/>' +
+    '</Relationships>',
+  'word/media/image1.png': PNG_1X1,
+};
+
+function findDrawings(doc: Document): Element[] {
+  return Array.from(doc.getElementsByTagNameNS(W_NS, 'drawing'));
+}
+
+function hasRevisionWrapperAncestor(el: Element): boolean {
+  let cur: Node | null = el.parentNode;
+  while (cur) {
+    if (
+      cur.nodeType === 1 &&
+      (cur as Element).namespaceURI === W_NS &&
+      ['ins', 'del', 'moveFrom', 'moveTo'].includes((cur as Element).localName ?? '')
+    ) {
+      return true;
+    }
+    cur = cur.parentNode;
+  }
+  return false;
+}
+
+async function assertImagePackageIntact(outPath: string): Promise<Document> {
+  const buffer = await fs.readFile(outPath);
+  const archive = await DocxArchive.load(buffer);
+
+  const documentXml = await archive.getFile('word/document.xml');
+  expect(documentXml).toBeTruthy();
+  const doc = parseXml(documentXml!);
+  const drawings = findDrawings(doc);
+  expect(drawings).toHaveLength(1);
+  expect(documentXml).toContain('r:embed="rId9"');
+
+  const rels = await archive.getFile('word/_rels/document.xml.rels');
+  expect(rels).toContain('Id="rId9"');
+  expect(rels).toContain('Target="media/image1.png"');
+
+  const media = await archive.getFileBuffer('word/media/image1.png');
+  expect(media).toBeTruthy();
+  expect(Buffer.compare(media!, PNG_1X1)).toBe(0);
+
+  return doc;
+}
+
+describe('replace_text — embedded image survives caption blanking (#739)', () => {
+  registerCleanup();
+
+  test('clean flow: blanking the caption keeps the drawing, relationship, and media part', async ({ given, when, then }: AllureBddContext) => {
+    const mgr = createTestSessionManager({ defaultAiAuthor: null });
+
+    const session = await given('a DOCX whose second paragraph holds a caption and an inline image', () =>
+      openSession([], { mgr, xml: DOCUMENT_XML, extraFiles: IMAGE_PACKAGE_EXTRA_FILES }),
+    );
+    const captionParaId = session.paraIds[1]!;
+
+    const outPath = path.join(session.tmpDir, 'out-clean.docx');
+    await when('replace_text blanks the caption and the session is saved clean', async () => {
+      const replaced = await replaceText(mgr, {
+        file_path: session.inputPath,
+        target_paragraph_id: captionParaId,
+        old_string: 'Figure 1 caption.',
+        new_string: '',
+        instruction: 'blank the figure caption',
+      });
+      assertSuccess(replaced, 'replace_text');
+      const saved = await save(mgr, {
+        file_path: session.inputPath,
+        save_to_local_path: outPath,
+        save_format: 'clean',
+      });
+      assertSuccess(saved, 'save');
+    });
+
+    await then('the drawing, its relationship, and the media part survive and the package reopens', async () => {
+      const doc = await assertImagePackageIntact(outPath);
+      expect(hasRevisionWrapperAncestor(findDrawings(doc)[0]!)).toBe(false);
+
+      const reopened = await openDocument(createTestSessionManager(), { file_path: outPath });
+      assertSuccess(reopened, 'reopen');
+    });
+  });
+
+  test('tracked flow: the drawing stays a live run outside w:del while the caption is tracked-deleted', async ({ given, when, then }: AllureBddContext) => {
+    const mgr = createTestSessionManager({ defaultAiAuthor: 'SafeDocX AI' });
+
+    const session = await given('a DOCX whose second paragraph holds a caption and an inline image', () =>
+      openSession([], { mgr, xml: DOCUMENT_XML, extraFiles: IMAGE_PACKAGE_EXTRA_FILES }),
+    );
+    const captionParaId = session.paraIds[1]!;
+
+    const outPath = path.join(session.tmpDir, 'out-tracked.docx');
+    await when('replace_text blanks the caption under tracked changes and the session is saved tracked', async () => {
+      const replaced = await replaceText(mgr, {
+        file_path: session.inputPath,
+        target_paragraph_id: captionParaId,
+        old_string: 'Figure 1 caption.',
+        new_string: '',
+        instruction: 'blank the figure caption',
+      });
+      assertSuccess(replaced, 'replace_text');
+      const saved = await save(mgr, {
+        file_path: session.inputPath,
+        save_to_local_path: outPath,
+        save_format: 'tracked',
+      });
+      assertSuccess(saved, 'save');
+    });
+
+    await then('the drawing survives live and the caption text sits inside w:del', async () => {
+      const doc = await assertImagePackageIntact(outPath);
+      const drawing = findDrawings(doc)[0]!;
+      expect(hasRevisionWrapperAncestor(drawing)).toBe(false);
+
+      const delTexts = Array.from(doc.getElementsByTagNameNS(W_NS, 'delText'))
+        .map((t) => t.textContent ?? '')
+        .join('');
+      expect(delTexts).toContain('Figure 1 caption.');
+
+      const reopened = await openDocument(createTestSessionManager(), { file_path: outPath });
+      assertSuccess(reopened, 'reopen');
+    });
+  });
+});


### PR DESCRIPTION
Fixes: #739

## Summary

Blanking or replacing a paragraph's visible text with `replace_text` silently destroyed any inline image (`w:drawing`), VML picture (`w:pict`), or embedded OLE object (`w:object`) caught in the replaced range — `success: true`, no warning, image gone.

This PR:

1. **Preserves embedded-content runs through `replaceParagraphTextRange()`** (`packages/docx-core/src/primitives/text.ts`) — the actual fix, covering `w:drawing`, `w:pict`, `w:object`, and `w:contentPart` (all relationship-bearing `EG_RunInnerContent`). An embedded-only run inside the replaced range stays in place untouched; content co-resident with replaced text is split into its own run (cloned formatting, original child order) before the text is removed. Preserved content stays **live** — never wrapped in `w:del` — because the caller's approved text match never covered it. Tracked deletions are emitted as **in-place segments** (one `w:del` per contiguous removed stretch, at its original position) so `rejectChanges()` restores the original content order exactly; ranges without embedded content keep the historical single-deletion emission unchanged. The paragraph-mark deletion emitted for a tracked full blanking is suppressed when content was preserved, so the paragraph that still visibly carries the image is not merged into its neighbor on accept.
2. **Adds `drawing`/`pict`/`object`/`contentPart` to `BARRIER_LOCALS` in `merge_runs.ts`** as defensive hardening (separately tested): on-open normalization can no longer fold an rPr-less image run into an adjacent text run, which was the path that made the issue's exact repro shape lossy.
3. Widens `makeDocxWithDocumentXml`/`openSession` `extraFiles` to accept `Buffer` values so package fixtures can carry real binary media (`createZipBuffer` already accepted them).

## Root cause — corrected from the issue

The issue blames `mergeRunsOnly` and proposes only the barrier change. That change alone would **not** fix the data loss. The primary defect is in `replaceParagraphTextRange()`: the run-removal loop detaches every `w:r` in the replaced range but only records a run in `removedRuns` when `getRunVisibleLength(runEl) > 0`. `visibleLengthForEl()` returns a length only for `w:t`/`w:tab`/`w:br` and `0` for everything else — so an image-only run is detached from the DOM and never re-emitted by either the clean or the tracked branch.

XML-level probe, run against origin/main sources (8f84295) and re-run against this branch (paragraph `[w:r "before"][w:r w:drawing r:embed="rId9"][w:r "after"]`, replace the full visible text with `"replacement"`, clean mode):

```
=== PRE-FIX (origin/main sources) ===
# replaceParagraphTextRange() ONLY, no merge:
REPLACE_ONLY_XML = <w:p><w:r><w:t>replacement</w:t></w:r></w:p>          <- drawing and rId9 GONE
# mergeRuns() ONLY:
MERGE_RESULT = {"runsMerged":2,"proofErrRemoved":0}
MERGE_XML = <w:p><w:r><w:t>before</w:t><w:drawing>...r:embed="rId9"...</w:drawing><w:t>after</w:t></w:r></w:p>   <- drawing PRESERVED

=== POST-FIX (this branch) ===
REPLACE_ONLY_XML = <w:p><w:r><w:drawing>...r:embed="rId9"...</w:drawing></w:r><w:r><w:t>replacement</w:t></w:r></w:p>
MERGE_RESULT = {"runsMerged":0,"proofErrRemoved":0}   <- barrier holds; drawing keeps its own run
```

The merge is a *contributing* path (it converts the issue's `[caption][image-run]` shape into a co-resident `[caption+drawing]` run that the removal loop then destroys), which is why it gets the separate hardening in (2). An independent Codex premise check on the unmodified tree reached the same conclusion: "Adding those embedded-content elements to the merge barrier list alone would **not** fix the loss."

## Premise-gate evidence (end-to-end through the real `replace_text` MCP path)

Full generated DOCX package: 3 paragraphs, the second `[w:r "Figure 1 caption."][w:r w:drawing r:embed="rId9"]`, `word/_rels/document.xml.rels` carrying `rId9 → media/image1.png`, and a real 70-byte PNG at `word/media/image1.png`. Flow: `open_document` → `replace_text` (old_string `"Figure 1 caption."`, new_string `""`) → `save`.

**Before the fix (origin/main @ 8f84295), both clean and tracked saves:**

```
--- BEFORE ---                          --- AFTER (clean AND tracked) ---
w:drawing count : 1                     w:drawing count : 0
a:blip count    : 1                     a:blip count    : 0
r:embed="rId9"  : 1                     r:embed="rId9"  : 0
rels has rId9   : true                  rels has rId9   : true   (orphaned)
media/image1.png: 70 bytes              media/image1.png: 70 bytes (orphaned)
replace_text: success:true, no warning; paragraph emitted with no drawing at all
```

**After the fix, same probe:** `w:drawing`/`a:blip`/`r:embed="rId9"` all `1` in both clean and tracked output; the paragraph retains the drawing as a live run.

## Tests (red → green verified by stashing the source fix)

- `packages/docx-core/src/primitives/text.test.ts` — 13 new preservation tests (**8 of the original 9 red pre-fix**; the before/after-guard passes by construction): drawing before / between / after text runs; drawing co-resident with text in the same run; with and without `w:rPr`; partial replacement and full blanking; clean and tracked; `w:pict`, `w:object`, and `w:contentPart`; tracked full blanking keeps the paragraph mark undeleted and the content outside `w:del`; and — added after peer review — structural-order regressions that call the real `rejectChanges()`/`acceptChanges()` primitives: reject restores `text → drawing → text` exactly, accept keeps the drawing live before the replacement text, and a span with two preserved objects emits three correctly-placed deletion segments.
- `packages/docx-core/test-primitives/merge_runs.test.ts` — 6 new barrier tests (**5 red pre-fix**), kept separate from the preservation tests, including a `contentPart` barrier and a control that plain text runs still merge in a paragraph containing a drawing run.
- `packages/docx-mcp/src/tools/replace_text_embedded_image.regression.test.ts` — new end-to-end package regression (**2 red pre-fix**): clean and tracked flows through the real `replace_text` tool assert the `w:drawing` node, the `rId9` relationship entry, byte-identical `word/media/image1.png`, drawing outside any revision wrapper, tracked `delText` for the caption, and a successful package reopen.

## Scope discipline

Pure preservation of intended behavior — no OpenSpec proposal needed, no new `UNSUPPORTED_EDIT` refusal, no new warning semantics. Surfacing a runtime warning for "embedded object preserved outside the replaced range" needs a core→MCP warnings channel that does not exist today (`replaceParagraphTextRange` returns `void`, and `preflightAiRevisionMutation` invokes the mutation callback before the `warnings` const is initialized); that is split into a follow-up issue rather than grown into this PR.

## Pre-submit

`npm run build && npm run lint:workspaces && npm run test:run && npm run check:spec-coverage && npm run check:conformance-citations && npm run check:conformance-doc` — exit 0.

## Peer review

Dynamic Codex review requested changes; the blocker (single terminal `w:del` broke `rejectChanges()` ordering around a preserved drawing) was accepted and fixed with in-place deletion segments in 26f2e01, and `w:contentPart` was added to the preservation/barrier sets per the review's schema finding. Full adjudication in the PR comments.
