### PR TITLE
feat(docx-compare): fail closed when a comparison input already contains tracked changes

### DIFF
--- a/openspec/changes/add-tracked-input-comparison-guard/proposal.md
+++ b/openspec/changes/add-tracked-input-comparison-guard/proposal.md
@@ -28,13 +28,20 @@ proposal.
   precedent) that names the offending operand (`original` vs `revised`), the package part, and the markers found.
 - The scan covers `word/document.xml` plus every revision story part — footnotes, endnotes, comments, the glossary
   document, and each numbered header/footer part via `enumerateRevisionStoryPartPaths` — and detects the four
-  content markers (`w:ins`, `w:del`, `w:moveFrom`, `w:moveTo`) and the six property-change records (`w:rPrChange`,
-  `w:pPrChange`, `w:sectPrChange`, `w:tblPrChange`, `w:trPrChange`, `w:tcPrChange`). Row-level markers
-  (`w:trPr > w:ins|w:del`) share those local names and trip the guard.
+  content markers (`w:ins`, `w:del`, `w:moveFrom`, `w:moveTo`), the six property-change records (`w:rPrChange`,
+  `w:pPrChange`, `w:sectPrChange`, `w:tblPrChange`, `w:trPrChange`, `w:tcPrChange`), the cell-topology records
+  (`w:cellIns`, `w:cellDel`, `w:cellMerge`), and `w:numberingChange` — the last four added after peer review
+  execution-proved they passed the ten-name scan and survived comparison with their prior author. Row-level
+  markers (`w:trPr > w:ins|w:del`) share those local names and trip the guard. Range-boundary markers
+  (`w:*RangeStart`/`End`, `w:customXml*Range*`) are classified non-triggers: no author-bearing content of their
+  own, content-bearing moves are caught via their wrappers, and an isolated range pair is dropped by the
+  comparison rather than passed through.
 - One guard at the lowest public comparison boundary (`compareDocumentsAtomizer`), not one per surface: the MCP
   tool and both CLIs funnel through it, so surfaces only *map* the typed error rather than re-scanning.
   - `compare_documents` (MCP) maps the error to a distinct `INPUT_HAS_TRACKED_CHANGES` code — never the catch-all
-    `COMPARE_ERROR` — with a recovery hint pointing at `accept_changes`.
+    `COMPARE_ERROR` — with a part-aware recovery hint: `accept_changes` where it applies, but a header/footer
+    detection instead directs the caller to produce a fully accepted/rejected copy, because `accept_changes`
+    does not cover headers or footers and recommending it there would loop.
   - Both CLIs (`docx-comparison`, `safe-docx compare`) propagate the error to their existing entry-point handler:
     nonzero exit, message naming the offending operand. No CLI code change is required.
 - Missing story parts are skipped. Parts the scan cannot parse are also skipped **by this guard**: malformed-part
@@ -44,11 +51,12 @@ proposal.
 - Engine behaviors that only arise for pre-tracked inputs (original-insertion provenance restoration, revised-side
   insertion-collision promotion, preserved-move identity seeding, pre-existing-wrapper bookmark splitting,
   canonical-emission round-trips, [ADV-COMPARE-MODE-PRESERVATION-01]'s mode characterization) remain implemented
-  and tested through `compareDocumentsAtomizerUnguarded`, an explicitly named unguarded seam. It is exported from
-  the package root — cross-package engine tests in docx-core need it, and a relative source import breaks that
-  package's tsc project — but its JSDoc marks it as NOT a supported comparison entry point, with no input
-  validation. A future accept-on-ingest opt-in would route there after projecting its inputs; until then the
-  supported boundary refuses.
+  and tested through `compareDocumentsAtomizerUnguarded`, an explicitly named unguarded seam that is NOT exported
+  from the package root (a test pins its absence — peer review demonstrated that a root export is a live public
+  bypass). docx-compare tests import it from the pipeline module; docx-core integration tests import it through
+  the package's dist subpath, which their vitest config aliases back to the same source module graph the root
+  alias uses (a relative source import violates that package's tsc `rootDir`). A future accept-on-ingest opt-in
+  would route there after projecting its inputs; until then the supported boundary refuses.
 
 ## Impact
 

--- a/openspec/changes/add-tracked-input-comparison-guard/proposal.md
+++ b/openspec/changes/add-tracked-input-comparison-guard/proposal.md
@@ -1,0 +1,81 @@
+# Change: Fail closed when a comparison input already contains tracked changes
+
+## Why
+
+`compareDocuments` accepts an input that already carries revision markup (`w:ins`/`w:del`/moves/`*PrChange`)
+without warning, layers the comparison author's markup over it, and exits 0 with normal stats. The output keeps
+**two revision authors** in `word/document.xml` — the comparison author plus the tracked input's author — and,
+edit-density permitting, directly nested revision elements (`w:ins` inside `w:ins`). Microsoft Word refuses to open
+that file ("Word found unreadable content"). Reproduced at HEAD for issue #742: `compare(clean, tracked)` returned
+`{"insertions":2,"deletions":2,...}`, exit 0, output authors `["Comparison","Original Author"]`, with nested
+`w:ins`-in-`w:ins`; the transitional-schema gate passes the file, so the corruption is behavioral, not schema-visible.
+An independent Codex premise check confirmed both the missing guard and the runtime reproduction.
+
+A separate 520-document SHA-pinned corpus differential independently confirmed the mechanism: in **rebuild** mode
+the comparison unwraps pre-existing tracked changes into bare `w:delText` outside any `w:del` wrapper — precisely
+the Word-unreadable shape — while **inplace** passes the markup through, still merging two authors' revision trees
+into one document. The guard therefore refuses tracked inputs in both reconstruction modes, at the shared boundary.
+
+Given the current behaviour is silent corruption, failing loudly is strictly better than a clever default. This
+change intentionally rejects inputs the comparison previously accepted — a public contract change, hence this
+proposal.
+
+## What Changes
+
+- **BREAKING**: `compareDocuments` and the directly exported `compareDocumentsAtomizer` SHALL refuse to compare
+  when either operand already contains tracked-changes markup, throwing a typed recoverable
+  `TrackedInputRevisionError` (exported from the package root, following the `UnsupportedTextBoxRevisionError`
+  precedent) that names the offending operand (`original` vs `revised`), the package part, and the markers found.
+- The scan covers `word/document.xml` plus every revision story part — footnotes, endnotes, comments, the glossary
+  document, and each numbered header/footer part via `enumerateRevisionStoryPartPaths` — and detects the four
+  content markers (`w:ins`, `w:del`, `w:moveFrom`, `w:moveTo`) and the six property-change records (`w:rPrChange`,
+  `w:pPrChange`, `w:sectPrChange`, `w:tblPrChange`, `w:trPrChange`, `w:tcPrChange`). Row-level markers
+  (`w:trPr > w:ins|w:del`) share those local names and trip the guard.
+- One guard at the lowest public comparison boundary (`compareDocumentsAtomizer`), not one per surface: the MCP
+  tool and both CLIs funnel through it, so surfaces only *map* the typed error rather than re-scanning.
+  - `compare_documents` (MCP) maps the error to a distinct `INPUT_HAS_TRACKED_CHANGES` code — never the catch-all
+    `COMPARE_ERROR` — with a recovery hint pointing at `accept_changes`.
+  - Both CLIs (`docx-comparison`, `safe-docx compare`) propagate the error to their existing entry-point handler:
+    nonzero exit, message naming the offending operand. No CLI code change is required.
+- Missing story parts are skipped. Parts the scan cannot parse are also skipped **by this guard**: malformed-part
+  failures belong to the package-level ancillary safety boundary (`AncillaryStorySafetyError` /
+  `NOTE_PART_XML_INVALID`), whose precise typed diagnostics the preparatory scan must not pre-empt — the same rule
+  `textBoxRevisionSafety` applies to its own preparatory scan.
+- Engine behaviors that only arise for pre-tracked inputs (original-insertion provenance restoration, revised-side
+  insertion-collision promotion, preserved-move identity seeding, pre-existing-wrapper bookmark splitting,
+  canonical-emission round-trips, [ADV-COMPARE-MODE-PRESERVATION-01]'s mode characterization) remain implemented
+  and tested through `compareDocumentsAtomizerUnguarded`, an explicitly named unguarded seam. It is exported from
+  the package root — cross-package engine tests in docx-core need it, and a relative source import breaks that
+  package's tsc project — but its JSDoc marks it as NOT a supported comparison entry point, with no input
+  validation. A future accept-on-ingest opt-in would route there after projecting its inputs; until then the
+  supported boundary refuses.
+
+## Impact
+
+- Affected specs: `docx-comparison` (ADDED: `Tracked-Input Comparison Refusal`) and `mcp-server`
+  (ADDED: `Tracked-Input Refusal in the Compare Documents Tool`). Both are ADDED rather than MODIFIED: no deployed
+  requirement in either capability makes any promise about comparison-input validation today, so there is nothing
+  to modify without inventing prior text the archiver would then overwrite.
+- Affected code: `packages/docx-compare/src/baselines/atomizer/trackedInputRevisionSafety.ts` (new),
+  `packages/docx-compare/src/baselines/atomizer/pipeline.ts` (guard call + unguarded seam),
+  `packages/docx-compare/src/index.ts` (exports), `packages/docx-mcp/src/tools/compare_documents.ts` (error
+  mapping).
+- Callers that previously compared tracked inputs now get a typed error instead of a Word-unreadable file. That is
+  the point of the change; the prior output was corrupt. MCP session-mode comparison of a document that was opened
+  with pre-existing tracked changes is likewise refused.
+- Existing tests that deliberately drove pre-tracked fixtures through the public entry to pin engine internals now
+  use the unguarded seam, with per-site comments citing this change. Their assertions are unchanged.
+- `compare(clean, clean)` and every clean-input comparison are byte-for-byte unaffected apart from one additional
+  scan per operand.
+- Refs #742.
+
+## Out of scope
+
+- An `--allow-tracked-input` opt-in and accept-on-ingest semantics (re-authoring emitted revisions to the
+  comparison author, matching Word's own compare) — the issue sketches this as a follow-up; the unguarded seam is
+  where it would attach.
+- Nested-revision semantics.
+- Removing or regenerating the two checked-in Word-unreadable sample outputs
+  (`packages/docx-core/src/testing/outputs/atomizer_redline.docx`, `typescript_redline.docx`): both are cited as
+  provenance by `fieldComparisonSemantics.test.ts` and `openspec/changes/add-scoped-field-evaluation/design.md`,
+  so that cleanup belongs to its own change.

--- a/openspec/changes/add-tracked-input-comparison-guard/specs/docx-comparison/spec.md
+++ b/openspec/changes/add-tracked-input-comparison-guard/specs/docx-comparison/spec.md
@@ -1,0 +1,65 @@
+## ADDED Requirements
+
+### Requirement: Tracked-Input Comparison Refusal
+
+The comparison boundary SHALL refuse to compare when either input document already contains tracked-changes
+markup, failing closed with a typed recoverable `TrackedInputRevisionError` instead of emitting an output that
+merges two authors' revision markup into one document. The error SHALL name the offending operand (`original` or
+`revised`), the package part in which markup was found, and the revision element names detected. The scan SHALL
+cover `word/document.xml` plus every revision story part the package holds (footnotes, endnotes, comments, the
+glossary document, and each numbered header or footer part) and SHALL detect the content markers `w:ins`, `w:del`,
+`w:moveFrom`, and `w:moveTo` and the property-change records `w:rPrChange`, `w:pPrChange`, `w:sectPrChange`,
+`w:tblPrChange`, `w:trPrChange`, and `w:tcPrChange`, including row-level `w:trPr > w:ins|w:del` markers. The
+refusal SHALL apply to every supported comparison entry point (`compareDocuments` and the directly exported
+`compareDocumentsAtomizer`) and every reconstruction mode. Missing story parts SHALL be skipped, and parts the
+scan cannot parse SHALL be left to the package-level ancillary safety boundary's own diagnostics rather than
+claimed by this guard. The package MAY export an explicitly named unguarded engine seam
+(`compareDocumentsAtomizerUnguarded`) for engine tests over deliberately pre-tracked fixtures and as the
+attachment point for a future accept-on-ingest opt-in; it is documented as not a supported comparison entry
+point and performs no input validation.
+
+#### Scenario: [SDX-TRKIN-01] a tracked original operand is refused with a typed recoverable error
+- **GIVEN** an original document whose body already carries a `w:del` revision and a clean revised document
+- **WHEN** the documents are compared through `compareDocuments`, in either reconstruction mode
+- **THEN** the comparison SHALL throw `TrackedInputRevisionError` with `operand` = `original`, `partPath` =
+  `word/document.xml`, and `markers` containing `w:del`
+- **AND** the message SHALL tell the caller to accept or reject the original document's tracked changes and retry
+
+#### Scenario: [SDX-TRKIN-02] a tracked revised operand is refused naming the revised operand
+- **GIVEN** a clean original and a revised document that already carries a `w:ins` revision
+- **WHEN** the documents are compared
+- **THEN** the error SHALL carry `operand` = `revised` and `markers` containing `w:ins`
+
+#### Scenario: [SDX-TRKIN-03] revision markup in a revision story part is refused with the part named
+- **GIVEN** a document whose only tracked markup lives in a header, footer, footnotes, endnotes, comments, or
+  glossary part
+- **WHEN** that document is compared as either operand
+- **THEN** the comparison SHALL be refused with `partPath` naming the story part holding the markup
+
+#### Scenario: [SDX-TRKIN-04] every content and property revision kind trips the guard
+- **GIVEN** one fixture per revision kind: `w:ins`, `w:del`, `w:moveFrom`, `w:moveTo`, `w:rPrChange`,
+  `w:pPrChange`, `w:sectPrChange`, `w:tblPrChange`, `w:trPrChange`, `w:tcPrChange`, and a row-level
+  `w:trPr > w:del` marker
+- **WHEN** each fixture is compared as each operand
+- **THEN** each comparison SHALL be refused and `markers` SHALL report that revision kind
+
+#### Scenario: [SDX-TRKIN-05] clean inputs continue to compare unchanged
+- **GIVEN** two clean documents with no revision markup and no ancillary story parts
+- **WHEN** the pair is compared, identical or edited
+- **THEN** the comparison SHALL succeed as before, with absent story parts skipped by the scan
+
+#### Scenario: [SDX-TRKIN-06] the directly exported atomizer entry point is guarded
+- **GIVEN** a tracked input that `compareDocuments` refuses
+- **WHEN** the same pair goes through the directly exported `compareDocumentsAtomizer`
+- **THEN** it SHALL raise the same `TrackedInputRevisionError` with the same `operand`, `partPath`, and `markers`
+
+#### Scenario: [SDX-TRKIN-07] malformed revision story parts defer to the ancillary safety boundary
+- **GIVEN** an original whose `word/footnotes.xml` is truncated mid-element and referenced from the body
+- **WHEN** the documents are compared
+- **THEN** the failure SHALL be the ancillary boundary's `AncillaryStorySafetyError`, not
+  `TrackedInputRevisionError`
+
+#### Scenario: [SDX-TRKIN-08] the comparison CLI refuses tracked inputs with the operand named
+- **GIVEN** a tracked revised input staged on disk
+- **WHEN** the `docx-comparison` CLI runs with its real compare dependency (no injected fake)
+- **THEN** the run SHALL fail with a message naming the `revised` operand and SHALL write no output file

--- a/openspec/changes/add-tracked-input-comparison-guard/specs/docx-comparison/spec.md
+++ b/openspec/changes/add-tracked-input-comparison-guard/specs/docx-comparison/spec.md
@@ -8,8 +8,13 @@ merges two authors' revision markup into one document. The error SHALL name the 
 `revised`), the package part in which markup was found, and the revision element names detected. The scan SHALL
 cover `word/document.xml` plus every revision story part the package holds (footnotes, endnotes, comments, the
 glossary document, and each numbered header or footer part) and SHALL detect the content markers `w:ins`, `w:del`,
-`w:moveFrom`, and `w:moveTo` and the property-change records `w:rPrChange`, `w:pPrChange`, `w:sectPrChange`,
-`w:tblPrChange`, `w:trPrChange`, and `w:tcPrChange`, including row-level `w:trPr > w:ins|w:del` markers. The
+`w:moveFrom`, and `w:moveTo`, the property-change records `w:rPrChange`, `w:pPrChange`, `w:sectPrChange`,
+`w:tblPrChange`, `w:trPrChange`, and `w:tcPrChange`, the cell-topology records `w:cellIns`, `w:cellDel`, and
+`w:cellMerge`, and the legacy `w:numberingChange` record, including row-level `w:trPr > w:ins|w:del` markers.
+Range-boundary markers (`w:moveFromRangeStart`/`End`, `w:moveToRangeStart`/`End`, and the `w:customXml*Range*`
+family) are classified as non-triggers: they carry no author-bearing content of their own, content-bearing moves
+are caught via `w:moveFrom`/`w:moveTo`, and an isolated range pair is dropped by the comparison rather than passed
+through as another author's markup. The
 refusal SHALL apply to every supported comparison entry point (`compareDocuments` and the directly exported
 `compareDocumentsAtomizer`) and every reconstruction mode. Missing story parts SHALL be skipped, and parts the
 scan cannot parse SHALL be left to the package-level ancillary safety boundary's own diagnostics rather than
@@ -38,8 +43,8 @@ point and performs no input validation.
 
 #### Scenario: [SDX-TRKIN-04] every content and property revision kind trips the guard
 - **GIVEN** one fixture per revision kind: `w:ins`, `w:del`, `w:moveFrom`, `w:moveTo`, `w:rPrChange`,
-  `w:pPrChange`, `w:sectPrChange`, `w:tblPrChange`, `w:trPrChange`, `w:tcPrChange`, and a row-level
-  `w:trPr > w:del` marker
+  `w:pPrChange`, `w:sectPrChange`, `w:tblPrChange`, `w:trPrChange`, `w:tcPrChange`, `w:cellIns`, `w:cellDel`,
+  `w:cellMerge`, `w:numberingChange`, and a row-level `w:trPr > w:del` marker
 - **WHEN** each fixture is compared as each operand
 - **THEN** each comparison SHALL be refused and `markers` SHALL report that revision kind
 

--- a/openspec/changes/add-tracked-input-comparison-guard/specs/mcp-server/spec.md
+++ b/openspec/changes/add-tracked-input-comparison-guard/specs/mcp-server/spec.md
@@ -6,8 +6,12 @@ The `compare_documents` tool and the `safe-docx compare` CLI command SHALL surfa
 tracked-input refusal as a deliberate, recoverable outcome. The MCP tool SHALL map `TrackedInputRevisionError` to
 the distinct error code `INPUT_HAS_TRACKED_CHANGES` — never the catch-all `COMPARE_ERROR` — with a message naming
 the offending operand and part and a hint pointing the caller at accepting or rejecting the input's revisions
-first. The CLI command SHALL propagate the error so the process exits nonzero with a message naming the offending
-operand. Neither surface SHALL write an output file for a refused comparison. Clean inputs SHALL be unaffected.
+first. The hint SHALL be actionable for the named part: `accept_changes` covers the document body and the
+revisionable side stories but not headers or footers, so a detection in a header or footer part SHALL NOT
+recommend `accept_changes` and SHALL instead direct the caller to produce a fully accepted or rejected copy of
+the input. The refusal applies to session-mode comparison as well as two-file mode. The CLI command SHALL
+propagate the error so the process exits nonzero with a message naming the offending operand. Neither surface
+SHALL write an output file for a refused comparison. Clean inputs SHALL be unaffected.
 
 #### Scenario: [SDX-TRKIN-MCP-01] compare_documents refuses tracked inputs with a distinct error code
 - **GIVEN** a clean original and a revised file that already carries `w:ins` markup
@@ -22,6 +26,19 @@ operand. Neither surface SHALL write an output file for a refused comparison. Cl
 - **WHEN** the `safe-docx compare` command runs with its real default dependencies
 - **THEN** the command SHALL reject with `TrackedInputRevisionError` naming the `original` operand, producing a
   nonzero process exit
+- **AND** no output file SHALL be written
+
+#### Scenario: [SDX-TRKIN-MCP-04] header and footer refusals carry an actionable hint
+- **GIVEN** a revised file whose only tracked markup lives in `word/header1.xml`
+- **WHEN** `compare_documents` is called in two-file mode
+- **THEN** the response SHALL be an `INPUT_HAS_TRACKED_CHANGES` error naming `word/header1.xml`
+- **AND** the hint SHALL NOT recommend `accept_changes`, which cannot clean headers or footers
+- **AND** no output file SHALL be written
+
+#### Scenario: [SDX-TRKIN-MCP-05] session-mode comparison of a tracked document is refused
+- **GIVEN** an open session whose document already carries `w:ins` markup
+- **WHEN** `compare_documents` is called in session mode
+- **THEN** the response SHALL be an `INPUT_HAS_TRACKED_CHANGES` error
 - **AND** no output file SHALL be written
 
 #### Scenario: [SDX-TRKIN-MCP-03] compare_documents with clean inputs is unaffected

--- a/openspec/changes/add-tracked-input-comparison-guard/specs/mcp-server/spec.md
+++ b/openspec/changes/add-tracked-input-comparison-guard/specs/mcp-server/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Tracked-Input Refusal in the Compare Documents Tool
+
+The `compare_documents` tool and the `safe-docx compare` CLI command SHALL surface the comparison library's
+tracked-input refusal as a deliberate, recoverable outcome. The MCP tool SHALL map `TrackedInputRevisionError` to
+the distinct error code `INPUT_HAS_TRACKED_CHANGES` — never the catch-all `COMPARE_ERROR` — with a message naming
+the offending operand and part and a hint pointing the caller at accepting or rejecting the input's revisions
+first. The CLI command SHALL propagate the error so the process exits nonzero with a message naming the offending
+operand. Neither surface SHALL write an output file for a refused comparison. Clean inputs SHALL be unaffected.
+
+#### Scenario: [SDX-TRKIN-MCP-01] compare_documents refuses tracked inputs with a distinct error code
+- **GIVEN** a clean original and a revised file that already carries `w:ins` markup
+- **WHEN** `compare_documents` is called in two-file mode
+- **THEN** the response SHALL be an `INPUT_HAS_TRACKED_CHANGES` error, not `COMPARE_ERROR`
+- **AND** the message SHALL name the `revised` operand and `word/document.xml`, with a hint referencing
+  `accept_changes`
+- **AND** no file SHALL be written to `save_to_local_path`
+
+#### Scenario: [SDX-TRKIN-MCP-02] the compare CLI command surfaces the tracked-input refusal
+- **GIVEN** a tracked original staged on disk
+- **WHEN** the `safe-docx compare` command runs with its real default dependencies
+- **THEN** the command SHALL reject with `TrackedInputRevisionError` naming the `original` operand, producing a
+  nonzero process exit
+- **AND** no output file SHALL be written
+
+#### Scenario: [SDX-TRKIN-MCP-03] compare_documents with clean inputs is unaffected
+- **GIVEN** two clean documents with an ordinary edit between them
+- **WHEN** `compare_documents` is called in two-file mode
+- **THEN** the comparison SHALL succeed and the redline SHALL be written as before

--- a/openspec/changes/add-tracked-input-comparison-guard/tasks.md
+++ b/openspec/changes/add-tracked-input-comparison-guard/tasks.md
@@ -58,3 +58,21 @@
       npm run check:conformance-citations && npm run check:conformance-doc`, gated on exit codes.
 - [x] 5.2 `npx openspec validate add-tracked-input-comparison-guard --strict`.
 - [x] 5.3 `git diff --check` clean; rebase onto current `origin/main` before opening the draft PR.
+
+## 6. Peer review follow-ups (Codex, 2026-08-16)
+
+- [x] 6.1 Blocking — detector gaps. Codex execution-proved that `w:cellIns`, `w:cellDel`, `w:cellMerge`, and
+      `w:numberingChange` passed the ten-name guard through public `compareDocuments` and survived in the output
+      with their prior author. Added all four to the detection list, added one fixture per kind to
+      `[SDX-TRKIN-04]`, and documented the range-marker family (`w:*RangeStart`/`End`, `w:customXml*Range*`) as
+      classified non-triggers (Codex's probe showed an isolated range pair is dropped, not passed through).
+- [x] 6.2 Blocking — package-root bypass. The root export of `compareDocumentsAtomizerUnguarded` was a live
+      public bypass (execution-proved). Removed it; docx-core integration tests now import the pipeline module
+      through the package's dist subpath, aliased back to the same source module graph in
+      `packages/docx-core/vitest.config.ts`; `[SDX-TRKIN-06]` pins that the package root does not export the
+      seam; corrected the contradictory pipeline JSDoc.
+- [x] 6.3 Hint accuracy. `accept_changes` cannot clean headers or footers, so a header/footer detection no
+      longer recommends it — the hint is part-aware. Added `[SDX-TRKIN-MCP-04]` (header-part hint) and, per the
+      coverage recommendation, `[SDX-TRKIN-MCP-05]` (session-mode refusal).
+- [x] 6.4 Re-ran the full gate sequence, both new suites, all eleven re-pointed engine suites, and
+      `openspec validate --strict` after the fixes.

--- a/openspec/changes/add-tracked-input-comparison-guard/tasks.md
+++ b/openspec/changes/add-tracked-input-comparison-guard/tasks.md
@@ -1,0 +1,60 @@
+## 1. Premise gate
+
+- [x] 1.1 Reproduce issue #742 at HEAD: clean A, tracked B (via a first comparison authored "Original Author"),
+      then `compareDocuments(A, B)` — confirmed exit 0, normal stats, output authors
+      `["Comparison","Original Author"]`, nested `w:ins`-in-`w:ins`. Transitional-schema gate passes the corrupt
+      file, so the defect is behavioral.
+- [x] 1.2 Independent Codex premise check (read-only sandbox): CONFIRMED — no refusal anywhere on the
+      `compareDocuments` / `compareDocumentsAtomizer` path, reproduction reproduced.
+- [x] 1.3 Corroborating corpus evidence (independent 520-document differential): rebuild mode unwraps
+      pre-existing tracked changes into bare `w:delText`, the Word-unreadable shape; inplace passes them through.
+
+## 2. Detector and guard
+
+- [x] 2.1 New `packages/docx-compare/src/baselines/atomizer/trackedInputRevisionSafety.ts`:
+      `TrackedInputRevisionError` (typed, recoverable, names operand + part + markers) and
+      `assertComparisonInputsUntracked(original, revised)` scanning `word/document.xml` plus
+      `enumerateRevisionStoryPartPaths` for the four content markers and six `*PrChange` records.
+- [x] 2.2 Call the guard at the top of `compareDocumentsAtomizer` — the lowest public comparison boundary —
+      covering `compareDocuments`, both CLIs, the MCP tool, and the benchmark runner with one scan.
+- [x] 2.3 Split the orchestration into `compareDocumentsAtomizerUnguarded` so engine tests over deliberately
+      pre-tracked fixtures — and a future accept-on-ingest opt-in — keep an entry below the guard. Exported from
+      the package root (cross-package engine tests in docx-core need it; a relative source import violates that
+      package's tsc rootDir) with JSDoc marking it as not a supported comparison entry point.
+- [x] 2.4 Export `TrackedInputRevisionError`, `assertComparisonInputsUntracked`, and the detection types from
+      the package root.
+- [x] 2.5 Malformed story parts: guard skips what it cannot parse and defers to the ancillary safety boundary's
+      precise diagnostics (`AncillaryStorySafetyError` / `NOTE_PART_XML_INVALID`), mirroring the
+      `textBoxRevisionSafety` precedent.
+
+## 3. Surface mapping
+
+- [x] 3.1 `compare_documents` MCP tool: map `TrackedInputRevisionError` to the distinct
+      `INPUT_HAS_TRACKED_CHANGES` code with a recovery hint; never the catch-all `COMPARE_ERROR`.
+- [x] 3.2 CLIs: verified both entry handlers already print `error.message` and exit 1 on rejection, and the
+      error message names the offending operand — no CLI code change (keeps the diff rebase-friendly vs #841).
+- [x] 3.3 Regenerate the MCP tool reference (`npm run docs:generate:tools -w @usejunior/docx-mcp`) and pass
+      `npm run check:tool-docs`.
+
+## 4. Tests
+
+- [x] 4.1 `trackedInputRevisionSafety.test.ts` (`TEST_FEATURE = add-tracked-input-comparison-guard`): all ten
+      revision kinds plus the row-level `w:trPr` marker, both operands, both reconstruction modes, every story
+      flavor (header, footer, footnotes, endnotes, comments, glossary), missing parts skipped, malformed part
+      defers to `AncillaryStorySafetyError`, `compare(clean, clean)` unaffected, both public entry points
+      guarded, and the real `runCompareCli` (no injected fake) refusing with no output written.
+- [x] 4.2 `add_tracked_input_comparison_guard.test.ts` (docx-mcp): `INPUT_HAS_TRACKED_CHANGES` mapping with no
+      file written, the real `runCompareCommand` rejecting with the operand named, clean-input control.
+- [x] 4.3 Re-point the pre-existing engine tests that deliberately compare pre-tracked fixtures at the
+      unguarded seam — six docx-compare files plus five docx-core integration files (canonical emission,
+      pretracked-ins provenance, move-range preservation, [ADV-COMPARE-MODE-PRESERVATION-01], existing
+      sectPrChange) — one commented site each; assertions unchanged.
+- [x] 4.4 Red→green: with the source change stashed, the new guard tests fail (no error thrown) and the
+      pre-change suite failures reproduce; with it restored, the full workspace suite is green.
+
+## 5. Gates
+
+- [x] 5.1 `npm run build && npm run lint:workspaces && npm run test:run && npm run check:spec-coverage &&
+      npm run check:conformance-citations && npm run check:conformance-doc`, gated on exit codes.
+- [x] 5.2 `npx openspec validate add-tracked-input-comparison-guard --strict`.
+- [x] 5.3 `git diff --check` clean; rebase onto current `origin/main` before opening the draft PR.

--- a/packages/docx-compare/src/baselines/atomizer/consumerCompatibility-bookmark-ranges.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/consumerCompatibility-bookmark-ranges.test.ts
@@ -32,7 +32,10 @@ import { describe, expect } from 'vitest';
 import { DocxArchive, childElements, parseXml } from '@usejunior/docx-core';
 import { buildDocxFromBodyXml } from '../../testing/ooxml-fixtures.js';
 import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
-import { compareDocumentsAtomizer } from './pipeline.js';
+import {
+  compareDocumentsAtomizer,
+  compareDocumentsAtomizerUnguarded,
+} from './pipeline.js';
 import { enforceConsumerCompatibility } from './consumerCompatibility.js';
 import { acceptAllChanges, rejectAllChanges } from './trackChangesAcceptorAst.js';
 import type { ReconstructionMode } from '../../compare-types.js';
@@ -72,11 +75,14 @@ function bookmarkedParagraph(id: string, name: string, text: string, pPr = ''): 
 async function compare(
   originalBody: string,
   revisedBody: string,
-  reconstructionMode: ReconstructionMode
+  reconstructionMode: ReconstructionMode,
+  // Pre-tracked fixtures exercise the engine below the tracked-input guard
+  // (issue #742); everything else goes through the guarded public entry.
+  entry: typeof compareDocumentsAtomizer = compareDocumentsAtomizer,
 ): Promise<string> {
   const original = await buildDocxFromBodyXml(originalBody);
   const revised = await buildDocxFromBodyXml(revisedBody);
-  const result = await compareDocumentsAtomizer(original, revised, {
+  const result = await entry(original, revised, {
     author: AUTHOR,
     date: DATE,
     reconstructionMode,
@@ -453,7 +459,12 @@ describe('Bookmark ranges survive paragraph-level revisions', () => {
       // The inplace pipeline runs its wrapper-merging postprocess passes over
       // this tree, so this asserts end-to-end that none of them re-merge the
       // split halves across the boundary.
-      documentXml = await compare(trackedBody, trackedBody, 'inplace');
+      documentXml = await compare(
+        trackedBody,
+        trackedBody,
+        'inplace',
+        compareDocumentsAtomizerUnguarded,
+      );
     });
 
     await then('the pre-existing wrapper is split with the boundary between the halves', () => {

--- a/packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/documentReconstructor-complex-fields.test.ts
@@ -24,7 +24,10 @@ import {
   FIELD_INSTRUCTIONS,
 } from '../../testing/ooxml-fixtures.js';
 import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
-import { compareDocumentsAtomizer } from './pipeline.js';
+import {
+  compareDocumentsAtomizer,
+  compareDocumentsAtomizerUnguarded,
+} from './pipeline.js';
 import {
   acceptAllChanges,
   extractTextWithParagraphs,
@@ -113,10 +116,14 @@ function canonicalRanges(xml: string): string[][] {
 async function compare(
   originalBody: string,
   revisedBody: string,
+  // Fixtures that pre-track their inputs exercise the engine below the
+  // tracked-input guard (issue #742); everything else stays on the guarded
+  // public entry.
+  entry: typeof compareDocumentsAtomizer = compareDocumentsAtomizer,
 ) {
   const original = await buildDocxFromBodyXml(originalBody);
   const revised = await buildDocxFromBodyXml(revisedBody);
-  return compareDocumentsAtomizer(original, revised, {
+  return entry(original, revised, {
     author: 'Issue 582 Test',
     date: new Date('2026-07-23T00:00:00Z'),
     reconstructionMode: 'rebuild',
@@ -299,7 +306,12 @@ describe('Forced rebuild preserves unchanged supported complex fields', () => {
       const page = decoratedComplexField(FIELD_INSTRUCTIONS.PAGE, '7', '_Page');
       const numPages = decoratedComplexField(FIELD_INSTRUCTIONS.NUMPAGES, '12', '_NumPages');
       const simplePage = completeField(FIELD_INSTRUCTIONS.PAGE, '7');
-      const cases: Array<{ name: string; original: string; revised: string }> = [
+      const cases: Array<{
+        name: string;
+        original: string;
+        revised: string;
+        pretracked?: boolean;
+      }> = [
         {
           name: 'result mutation',
           original: `<w:p>${page}</w:p>`,
@@ -376,11 +388,13 @@ describe('Forced rebuild preserves unchanged supported complex fields', () => {
           name: 'tracked paragraph owner',
           original: `<w:p>${simplePage}</w:p>`,
           revised: `<w:ins w:id="9"><w:p>${simplePage}</w:p></w:ins>`,
+          pretracked: true,
         },
         {
           name: 'inline revision wrapper ownership',
           original: `<w:p>${simplePage}</w:p>`,
           revised: `<w:p><w:ins w:id="9" w:author="Reviewer">${simplePage}</w:ins></w:p>`,
+          pretracked: true,
         },
         {
           name: 'unmatched begin',
@@ -394,7 +408,13 @@ describe('Forced rebuild preserves unchanged supported complex fields', () => {
       await given('adversarial supported-field shapes that violate bounded ownership', () => {});
       await when('each shape is compared through forced rebuild', async () => {
         for (const scenario of cases) {
-          await expect(compare(scenario.original, scenario.revised), scenario.name)
+          // Pre-tracked shapes reach the ownership guard via the unguarded
+          // seam; the tracked-input guard would otherwise refuse them first
+          // (issue #742).
+          const entry = scenario.pretracked
+            ? compareDocumentsAtomizerUnguarded
+            : compareDocumentsAtomizer;
+          await expect(compare(scenario.original, scenario.revised, entry), scenario.name)
             .rejects.toThrow(/Opaque passthrough:/);
         }
       });

--- a/packages/docx-compare/src/baselines/atomizer/inPlaceModifier-empty-and-cell-paragraphs.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/inPlaceModifier-empty-and-cell-paragraphs.test.ts
@@ -1,6 +1,9 @@
 import JSZip from 'jszip';
 import { describe, expect } from 'vitest';
 import { compareDocuments } from '../../index.js';
+// Pre-tracked fixtures exercise the engine below the tracked-input guard
+// (issue #742); clean fixtures stay on the guarded public entry.
+import { compareDocumentsAtomizerUnguarded } from './pipeline.js';
 import {
   acceptAllChanges,
   rejectAllChanges,
@@ -29,13 +32,18 @@ async function compareInMode(
   originalBody: string,
   revisedBody: string,
   mode: 'inplace' | 'rebuild',
+  pretracked = false,
 ) {
   const original = await buildDocxFromBodyXml(originalBody);
   const revised = await buildDocxFromBodyXml(revisedBody);
-  const result = await compareDocuments(original, revised, {
-    engine: 'atomizer',
-    reconstructionMode: mode,
-  });
+  const result = pretracked
+    ? await compareDocumentsAtomizerUnguarded(original, revised, {
+        reconstructionMode: mode,
+      })
+    : await compareDocuments(original, revised, {
+        engine: 'atomizer',
+        reconstructionMode: mode,
+      });
   expect(result.reconstructionModeUsed).toBe(mode);
 
   const xml = await documentXmlOf(result.document);
@@ -166,6 +174,7 @@ describe('empty-paragraph w:pPr serialization phantoms', () => {
     revised: string;
     expectNoParagraphMarkRevision: boolean;
     survivingFormatting?: string;
+    pretracked?: boolean;
   }> = [
     {
       name: 'bare w:pPr versus absent w:pPr',
@@ -191,6 +200,7 @@ describe('empty-paragraph w:pPr serialization phantoms', () => {
       original: `${anchor}<w:p><w:pPr><w:rPr><w:ins w:id="1" w:author="A" w:date="2024-01-01T00:00:00Z"/></w:rPr></w:pPr></w:p>`,
       revised: `${anchor}<w:p><w:pPr><w:rPr><w:ins w:id="99" w:author="B" w:date="2026-06-30T00:00:00Z"/></w:rPr></w:pPr></w:p>`,
       expectNoParagraphMarkRevision: false,
+      pretracked: true,
     },
   ];
 
@@ -210,7 +220,12 @@ describe('empty-paragraph w:pPr serialization phantoms', () => {
         await given('two formatting-equivalent documents differing only in w:pPr serialization', () => {});
 
         await when(`the documents are compared using ${mode} reconstruction`, async () => {
-          const comparison = await compareInMode(pair.original, pair.revised, mode);
+          const comparison = await compareInMode(
+            pair.original,
+            pair.revised,
+            mode,
+            pair.pretracked,
+          );
           xml = comparison.xml;
           originalXml = comparison.originalXml;
           revisedXml = comparison.revisedXml;

--- a/packages/docx-compare/src/baselines/atomizer/inPlaceModifier-original-insertion-provenance.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/inPlaceModifier-original-insertion-provenance.test.ts
@@ -1,6 +1,9 @@
 import JSZip from 'jszip';
 import { describe, expect } from 'vitest';
-import { compareDocuments } from '../../index.js';
+// Provenance restoration only arises for pre-tracked originals, which the
+// public comparison boundary now refuses (issue #742); this engine behavior
+// lives below that guard.
+import { compareDocumentsAtomizerUnguarded } from './pipeline.js';
 import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
 import { buildDocxFromBodyXml } from '../../testing/ooxml-fixtures.js';
 
@@ -11,8 +14,7 @@ const test = testAllure
 async function compareInplace(originalBody: string, revisedBody: string) {
   const original = await buildDocxFromBodyXml(originalBody);
   const revised = await buildDocxFromBodyXml(revisedBody);
-  const result = await compareDocuments(original, revised, {
-    engine: 'atomizer',
+  const result = await compareDocumentsAtomizerUnguarded(original, revised, {
     reconstructionMode: 'inplace',
   });
   expect(result.reconstructionModeUsed).toBe('inplace');

--- a/packages/docx-compare/src/baselines/atomizer/inplace-insertion-provenance-collision.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/inplace-insertion-provenance-collision.test.ts
@@ -16,11 +16,14 @@ import {
 } from '@usejunior/docx-core';
 import {
   acceptAllChanges,
-  compareDocuments,
   extractTextWithParagraphs,
   normalizeText,
   rejectAllChanges,
 } from '../../index.js';
+// These fixtures deliberately pre-track the revised input, which the public
+// comparison boundary now refuses (issue #742); the collision-promotion
+// engine behavior under test lives below that guard.
+import { compareDocumentsAtomizerUnguarded } from './pipeline.js';
 import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
 import {
   buildDocxFromBodyXml,
@@ -95,8 +98,7 @@ describe('Inplace revised insertion provenance collisions', () => {
       );
 
       await given('settled original text matched by a revised-side inline insertion', () => {});
-      const result = await compareDocuments(original, revised, {
-        engine: 'atomizer',
+      const result = await compareDocumentsAtomizerUnguarded(original, revised, {
         reconstructionMode: 'inplace',
       });
       const combined = await documentXml(result.document);
@@ -129,8 +131,7 @@ describe('Inplace revised insertion provenance collisions', () => {
       );
 
       await given('a settled original paragraph marked inserted on the revised side', () => {});
-      const result = await compareDocuments(original, revised, {
-        engine: 'atomizer',
+      const result = await compareDocumentsAtomizerUnguarded(original, revised, {
         reconstructionMode: 'inplace',
       });
       const combined = await documentXml(result.document);
@@ -159,8 +160,7 @@ describe('Inplace revised insertion provenance collisions', () => {
       );
 
       await given('settled text whose revised insertion also changes formatting', () => {});
-      const result = await compareDocuments(original, revised, {
-        engine: 'atomizer',
+      const result = await compareDocumentsAtomizerUnguarded(original, revised, {
         reconstructionMode: 'inplace',
       });
       const combined = await documentXml(result.document);

--- a/packages/docx-compare/src/baselines/atomizer/inplace-move-range-coalesce.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/inplace-move-range-coalesce.test.ts
@@ -10,6 +10,10 @@ import { describe, expect } from 'vitest';
 import { compareDocuments } from '../../index.js';
 import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
 import { coalesceMoveRangeMarkers } from './inPlaceModifier-postprocess.js';
+// The preserved-move fixture pre-tracks both inputs, which the public
+// comparison boundary now refuses (issue #742); the identity-collision
+// behavior under test lives below that guard.
+import { compareDocumentsAtomizerUnguarded } from './pipeline.js';
 import { buildDocxFromBodyXml, paragraphWithText } from '../../testing/ooxml-fixtures.js';
 
 const TEST_FEATURE = 'Inplace Move-Range Coalescing';
@@ -110,8 +114,7 @@ describe('Inplace move-range marker coalescing', () => {
         paragraphWithText('Final paragraph stays put') + paragraphWithText(MOVED_PARAGRAPH),
       );
 
-      const result = await compareDocuments(original, revised, {
-        engine: 'atomizer',
+      const result = await compareDocumentsAtomizerUnguarded(original, revised, {
         reconstructionMode: 'inplace',
       });
       const xml = await documentXml(result.document);

--- a/packages/docx-compare/src/baselines/atomizer/pipeline.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline.ts
@@ -625,12 +625,17 @@ export async function compareDocumentsAtomizer(
 /**
  * The comparison orchestration below the tracked-input guard.
  *
- * Internal seam: exported from this module (NOT from the package root) so
- * engine tests can exercise comparison behavior over deliberately pre-tracked
- * inputs — provenance restoration, revision-ID collision promotion, round-trip
- * projection — which the public boundary now refuses (issue #742). A future
- * accept-on-ingest opt-in would also route here after projecting its inputs.
- * Every public caller goes through {@link compareDocumentsAtomizer}.
+ * Internal seam, deliberately NOT exported from the package root (a test pins
+ * that): it performs no tracked-input validation, and tracked inputs produce
+ * Word-unreadable output (issue #742). It exists so engine tests can exercise
+ * comparison behavior over deliberately pre-tracked inputs — provenance
+ * restoration, revision-ID collision promotion, round-trip projection — which
+ * the supported boundary refuses. docx-compare tests import it from this
+ * module; docx-core integration tests import it via the package's dist
+ * subpath, which their vitest config aliases back to this source file. A
+ * future accept-on-ingest opt-in would also route here after projecting its
+ * inputs. Every supported caller goes through
+ * {@link compareDocumentsAtomizer}.
  *
  * @see https://github.com/UseJunior/safe-docx/issues/742
  */

--- a/packages/docx-compare/src/baselines/atomizer/pipeline.ts
+++ b/packages/docx-compare/src/baselines/atomizer/pipeline.ts
@@ -136,6 +136,7 @@ import {
   rejectedSelectedAncillaryStoryPaths,
   UnsupportedTextBoxRevisionError,
 } from './textBoxRevisionSafety.js';
+import { assertComparisonInputsUntracked } from './trackedInputRevisionSafety.js';
 import {
   compareFootnoteDefinitions,
   findCorrespondingFootnotePairs,
@@ -608,6 +609,32 @@ function evaluateSafetyChecks(
  * @see https://github.com/UseJunior/safe-docx/issues/713
  */
 export async function compareDocumentsAtomizer(
+  original: Buffer,
+  revised: Buffer,
+  options: AtomizerOptions = {},
+): Promise<CompareResult> {
+  // Fail closed on inputs that already carry tracked changes: passing them
+  // through merges two authors' revision markup into one output that Microsoft
+  // Word refuses to open (issue #742). Guarded here — the lowest public
+  // comparison boundary — so both compareDocuments and the directly exported
+  // compareDocumentsAtomizer are covered by one scan.
+  await assertComparisonInputsUntracked(original, revised);
+  return compareDocumentsAtomizerUnguarded(original, revised, options);
+}
+
+/**
+ * The comparison orchestration below the tracked-input guard.
+ *
+ * Internal seam: exported from this module (NOT from the package root) so
+ * engine tests can exercise comparison behavior over deliberately pre-tracked
+ * inputs — provenance restoration, revision-ID collision promotion, round-trip
+ * projection — which the public boundary now refuses (issue #742). A future
+ * accept-on-ingest opt-in would also route here after projecting its inputs.
+ * Every public caller goes through {@link compareDocumentsAtomizer}.
+ *
+ * @see https://github.com/UseJunior/safe-docx/issues/742
+ */
+export async function compareDocumentsAtomizerUnguarded(
   original: Buffer,
   revised: Buffer,
   options: AtomizerOptions = {},

--- a/packages/docx-compare/src/baselines/atomizer/trackedInputRevisionSafety.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/trackedInputRevisionSafety.test.ts
@@ -1,0 +1,419 @@
+/**
+ * Fail-closed refusal of comparison inputs that already carry tracked changes.
+ *
+ * Comparing a document that already contains revision markup passes the
+ * pre-existing markup through and layers the comparison author's markup on
+ * top, producing a two-author, nested-revision output Microsoft Word refuses
+ * to open while the compare still exits 0 with normal stats. The guard under
+ * test refuses such inputs at the lowest public comparison boundary with a
+ * typed, recoverable error naming the offending operand and part.
+ *
+ * @see https://github.com/UseJunior/safe-docx/issues/742
+ */
+
+import { mkdtemp, rm, writeFile, access } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import JSZip from 'jszip';
+import { describe, expect, afterAll } from 'vitest';
+import { compareDocuments, TrackedInputRevisionError } from '../../index.js';
+import { compareDocumentsAtomizer } from './pipeline.js';
+import { runCompareCli } from '../../cli/compare-two.js';
+import { buildDocxFromBodyXml } from '../../testing/ooxml-fixtures.js';
+import { testAllure, type AllureBddContext } from '../../testing/allure-test.js';
+
+const TEST_FEATURE = 'add-tracked-input-comparison-guard';
+
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({ feature: TEST_FEATURE });
+
+const W_NS_DECL =
+  'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
+const REVISION_ATTRS = 'w:id="901" w:author="Earlier" w:date="2026-01-01T00:00:00Z"';
+
+function paragraph(text: string): string {
+  return `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
+}
+
+const CLEAN_BODY = paragraph('Settled paragraph one.') + paragraph('Settled paragraph two.');
+
+/**
+ * One minimal well-formed body per revision kind the guard must detect: the
+ * four content markers, the six property-change records, and the row-level
+ * `w:trPr` marker spelling of `w:ins`/`w:del`.
+ */
+const TRACKED_BODY_BY_KIND: ReadonlyArray<{ marker: string; body: string }> = [
+  {
+    marker: 'w:ins',
+    body: `<w:p><w:ins ${REVISION_ATTRS}><w:r><w:t>added</w:t></w:r></w:ins></w:p>`,
+  },
+  {
+    marker: 'w:del',
+    body: `<w:p><w:del ${REVISION_ATTRS}><w:r><w:delText>removed</w:delText></w:r></w:del></w:p>`,
+  },
+  {
+    marker: 'w:moveFrom',
+    body: `<w:p><w:moveFrom ${REVISION_ATTRS}><w:r><w:delText>moved away</w:delText></w:r></w:moveFrom></w:p>`,
+  },
+  {
+    marker: 'w:moveTo',
+    body: `<w:p><w:moveTo ${REVISION_ATTRS}><w:r><w:t>moved here</w:t></w:r></w:moveTo></w:p>`,
+  },
+  {
+    marker: 'w:rPrChange',
+    body: `<w:p><w:r><w:rPr><w:b/><w:rPrChange ${REVISION_ATTRS}><w:rPr/></w:rPrChange></w:rPr><w:t>reformatted</w:t></w:r></w:p>`,
+  },
+  {
+    marker: 'w:pPrChange',
+    body: `<w:p><w:pPr><w:pPrChange ${REVISION_ATTRS}><w:pPr/></w:pPrChange></w:pPr><w:r><w:t>restyled</w:t></w:r></w:p>`,
+  },
+  {
+    marker: 'w:sectPrChange',
+    body: `${paragraph('body text')}<w:sectPr><w:sectPrChange ${REVISION_ATTRS}><w:sectPr/></w:sectPrChange></w:sectPr>`,
+  },
+  {
+    marker: 'w:tblPrChange',
+    body:
+      `<w:tbl><w:tblPr><w:tblPrChange ${REVISION_ATTRS}><w:tblPr/></w:tblPrChange></w:tblPr>` +
+      `<w:tblGrid><w:gridCol/></w:tblGrid>` +
+      `<w:tr><w:tc><w:tcPr/><w:p><w:r><w:t>cell</w:t></w:r></w:p></w:tc></w:tr></w:tbl>${paragraph('after')}`,
+  },
+  {
+    marker: 'w:trPrChange',
+    body:
+      `<w:tbl><w:tblPr/><w:tblGrid><w:gridCol/></w:tblGrid>` +
+      `<w:tr><w:trPr><w:trPrChange ${REVISION_ATTRS}><w:trPr/></w:trPrChange></w:trPr>` +
+      `<w:tc><w:tcPr/><w:p><w:r><w:t>cell</w:t></w:r></w:p></w:tc></w:tr></w:tbl>${paragraph('after')}`,
+  },
+  {
+    marker: 'w:tcPrChange',
+    body:
+      `<w:tbl><w:tblPr/><w:tblGrid><w:gridCol/></w:tblGrid>` +
+      `<w:tr><w:tc><w:tcPr><w:tcPrChange ${REVISION_ATTRS}><w:tcPr/></w:tcPrChange></w:tcPr>` +
+      `<w:p><w:r><w:t>cell</w:t></w:r></w:p></w:tc></w:tr></w:tbl>${paragraph('after')}`,
+  },
+];
+
+/** Row-level markers live at `w:trPr > w:ins|w:del` and count as tracked markup. */
+const ROW_LEVEL_MARKER_BODY =
+  `<w:tbl><w:tblPr/><w:tblGrid><w:gridCol/></w:tblGrid>` +
+  `<w:tr><w:trPr><w:del ${REVISION_ATTRS}/></w:trPr>` +
+  `<w:tc><w:tcPr/><w:p><w:r><w:t>row kept by an unresolved deletion</w:t></w:r></w:p></w:tc></w:tr></w:tbl>` +
+  paragraph('after');
+
+async function addPart(docx: Buffer, path: string, xml: string): Promise<Buffer> {
+  const zip = await JSZip.loadAsync(docx);
+  zip.file(path, xml);
+  return (await zip.generateAsync({ type: 'nodebuffer' })) as Buffer;
+}
+
+function storyPartXml(rootTag: string, content: string): string {
+  return `<${rootTag} ${W_NS_DECL}>${content}</${rootTag}>`;
+}
+
+const TRACKED_RUN = `<w:p><w:ins ${REVISION_ATTRS}><w:r><w:t>story edit</w:t></w:r></w:ins></w:p>`;
+
+/** Every revision story flavor the scan must cover, with tracked markup inside. */
+const TRACKED_STORY_PARTS: ReadonlyArray<{ partPath: string; xml: string }> = [
+  { partPath: 'word/header1.xml', xml: storyPartXml('w:hdr', TRACKED_RUN) },
+  { partPath: 'word/footer3.xml', xml: storyPartXml('w:ftr', TRACKED_RUN) },
+  {
+    partPath: 'word/footnotes.xml',
+    xml: storyPartXml('w:footnotes', `<w:footnote w:id="1">${TRACKED_RUN}</w:footnote>`),
+  },
+  {
+    partPath: 'word/endnotes.xml',
+    xml: storyPartXml('w:endnotes', `<w:endnote w:id="1">${TRACKED_RUN}</w:endnote>`),
+  },
+  {
+    partPath: 'word/comments.xml',
+    xml: storyPartXml('w:comments', `<w:comment w:id="1" w:author="Earlier">${TRACKED_RUN}</w:comment>`),
+  },
+  {
+    partPath: 'word/glossary/document.xml',
+    xml: storyPartXml('w:document', `<w:body>${TRACKED_RUN}</w:body>`),
+  },
+];
+
+async function expectTrackedInputRefusal(
+  promise: Promise<unknown>,
+): Promise<TrackedInputRevisionError> {
+  let failure: unknown;
+  try {
+    await promise;
+  } catch (error) {
+    failure = error;
+  }
+  expect(failure).toBeInstanceOf(TrackedInputRevisionError);
+  return failure as TrackedInputRevisionError;
+}
+
+const tempDirs: string[] = [];
+afterAll(async () => {
+  await Promise.all(tempDirs.map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('tracked-input comparison guard', () => {
+  test.openspec('[SDX-TRKIN-01] a tracked original operand is refused with a typed recoverable error')(
+    'a pre-tracked original is refused before any comparison output exists',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      let error: TrackedInputRevisionError;
+
+      await given('an original that already carries a w:del and a clean revised document', () => {});
+      const original = await buildDocxFromBodyXml(
+        `<w:p><w:del ${REVISION_ATTRS}><w:r><w:delText>stale</w:delText></w:r></w:del></w:p>`,
+      );
+      const revised = await buildDocxFromBodyXml(CLEAN_BODY);
+
+      await when('the documents are compared through the public entry point', async () => {
+        error = await expectTrackedInputRefusal(compareDocuments(original, revised));
+      });
+
+      await then('the refusal is a TrackedInputRevisionError naming the original operand', () => {
+        expect(error.name).toBe('TrackedInputRevisionError');
+        expect(error.operand).toBe('original');
+        expect(error.partPath).toBe('word/document.xml');
+        expect(error.markers).toContain('w:del');
+      });
+
+      await and('the guard fires in BOTH reconstruction modes', async () => {
+        // Rebuild is where the corruption manifests hardest — a 520-document
+        // corpus differential showed rebuild unwrapping pre-existing tracked
+        // changes into bare w:delText outside any w:del wrapper, the exact
+        // shape Word rejects — while inplace merely passes the markup through,
+        // still merging two authors' revision trees. Both modes must refuse.
+        for (const reconstructionMode of ['inplace', 'rebuild'] as const) {
+          const modeError = await expectTrackedInputRefusal(
+            compareDocuments(original, revised, { reconstructionMode }),
+          );
+          expect(modeError.operand, reconstructionMode).toBe('original');
+        }
+      });
+
+      await and('the message tells the caller how to recover', () => {
+        expect(error.message).toContain('original document already contains tracked changes');
+        expect(error.message).toContain('word/document.xml');
+        expect(error.message).toContain('Accept or reject');
+      });
+    },
+  );
+
+  test.openspec('[SDX-TRKIN-02] a tracked revised operand is refused naming the revised operand')(
+    'a pre-tracked revised input is attributed to the revised operand',
+    async ({ given, when, then }: AllureBddContext) => {
+      let error: TrackedInputRevisionError;
+
+      await given('a clean original and a revised document that already carries a w:ins', () => {});
+      const original = await buildDocxFromBodyXml(CLEAN_BODY);
+      const revised = await buildDocxFromBodyXml(
+        `<w:p><w:ins ${REVISION_ATTRS}><w:r><w:t>late edit</w:t></w:r></w:ins></w:p>`,
+      );
+
+      await when('the documents are compared', async () => {
+        error = await expectTrackedInputRefusal(compareDocuments(original, revised));
+      });
+
+      await then('the error names the revised operand and its markers', () => {
+        expect(error.operand).toBe('revised');
+        expect(error.partPath).toBe('word/document.xml');
+        expect(error.markers).toContain('w:ins');
+        expect(error.message).toContain('revised document already contains tracked changes');
+      });
+    },
+  );
+
+  test.openspec('[SDX-TRKIN-04] every content and property revision kind trips the guard')(
+    'all ten revision element kinds and the row-level marker are refused on either operand',
+    async ({ given, when, then }: AllureBddContext) => {
+      const clean = await buildDocxFromBodyXml(CLEAN_BODY);
+
+      await given('one fixture per revision kind: content markers, property changes, row-level markers', () => {});
+
+      await when('each fixture is compared as each operand', () => {});
+
+      await then('each comparison is refused and reports that revision kind', async () => {
+        for (const { marker, body } of TRACKED_BODY_BY_KIND) {
+          const tracked = await buildDocxFromBodyXml(body);
+
+          const asOriginal = await expectTrackedInputRefusal(compareDocuments(tracked, clean));
+          expect(asOriginal.operand, marker).toBe('original');
+          expect(asOriginal.markers, marker).toContain(marker);
+
+          const asRevised = await expectTrackedInputRefusal(compareDocuments(clean, tracked));
+          expect(asRevised.operand, marker).toBe('revised');
+          expect(asRevised.markers, marker).toContain(marker);
+        }
+
+        const rowTracked = await buildDocxFromBodyXml(ROW_LEVEL_MARKER_BODY);
+        const rowError = await expectTrackedInputRefusal(compareDocuments(rowTracked, clean));
+        expect(rowError.markers).toContain('w:del');
+      });
+    },
+  );
+
+  test.openspec('[SDX-TRKIN-03] revision markup in a revision story part is refused with the part named')(
+    'headers, footers, footnotes, endnotes, comments, and the glossary are all scanned',
+    async ({ given, when, then }: AllureBddContext) => {
+      const clean = await buildDocxFromBodyXml(CLEAN_BODY);
+
+      await given('documents whose only tracked markup lives in a revision story part', () => {});
+
+      await when('each document is compared as each operand', () => {});
+
+      await then('each comparison is refused with the story part named', async () => {
+        for (const { partPath, xml } of TRACKED_STORY_PARTS) {
+          const tracked = await addPart(await buildDocxFromBodyXml(CLEAN_BODY), partPath, xml);
+
+          const asOriginal = await expectTrackedInputRefusal(compareDocuments(tracked, clean));
+          expect(asOriginal.operand, partPath).toBe('original');
+          expect(asOriginal.partPath, partPath).toBe(partPath);
+          expect(asOriginal.markers, partPath).toContain('w:ins');
+
+          const asRevised = await expectTrackedInputRefusal(compareDocuments(clean, tracked));
+          expect(asRevised.operand, partPath).toBe('revised');
+          expect(asRevised.partPath, partPath).toBe(partPath);
+        }
+      });
+    },
+  );
+
+  test.openspec('[SDX-TRKIN-06] the directly exported atomizer entry point is guarded')(
+    'compareDocumentsAtomizer refuses tracked inputs exactly like compareDocuments',
+    async ({ given, when, then }: AllureBddContext) => {
+      let atomizerError: TrackedInputRevisionError;
+      let publicError: TrackedInputRevisionError;
+
+      await given('a tracked original that the public entry point refuses', () => {});
+      const tracked = await buildDocxFromBodyXml(
+        `<w:p><w:ins ${REVISION_ATTRS}><w:r><w:t>bypass attempt</w:t></w:r></w:ins></w:p>`,
+      );
+      const clean = await buildDocxFromBodyXml(CLEAN_BODY);
+
+      await when('the same pair goes through compareDocumentsAtomizer directly', async () => {
+        publicError = await expectTrackedInputRefusal(compareDocuments(tracked, clean));
+        atomizerError = await expectTrackedInputRefusal(compareDocumentsAtomizer(tracked, clean));
+      });
+
+      await then('both entry points raise the same typed refusal', () => {
+        expect(atomizerError.name).toBe('TrackedInputRevisionError');
+        expect(atomizerError.operand).toBe(publicError.operand);
+        expect(atomizerError.partPath).toBe(publicError.partPath);
+        expect(atomizerError.markers).toEqual(publicError.markers);
+      });
+    },
+  );
+
+  test.openspec('[SDX-TRKIN-05] clean inputs continue to compare unchanged')(
+    'a clean pair still compares, and packages without ancillary parts are fine',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      let identical: Awaited<ReturnType<typeof compareDocuments>>;
+      let edited: Awaited<ReturnType<typeof compareDocuments>>;
+
+      await given('two clean documents with no revision story parts at all', () => {});
+      const clean = await buildDocxFromBodyXml(CLEAN_BODY);
+      const cleanEdited = await buildDocxFromBodyXml(
+        paragraph('Settled paragraph one.') + paragraph('Settled paragraph two, amended.'),
+      );
+
+      await when('identical and edited clean pairs are compared', async () => {
+        // buildDocxFromBodyXml emits no footnotes/headers/etc., so this also
+        // covers the missing-part path: absent story parts are skipped.
+        identical = await compareDocuments(clean, clean);
+        edited = await compareDocuments(clean, cleanEdited);
+      });
+
+      await then('the identical pair reports no changes', () => {
+        expect(identical.stats.insertions).toBe(0);
+        expect(identical.stats.deletions).toBe(0);
+      });
+
+      await and('the edited pair produces a normal single-author comparison', () => {
+        expect(edited.stats.insertions).toBeGreaterThan(0);
+        expect(edited.document.length).toBeGreaterThan(0);
+      });
+    },
+  );
+
+  test.openspec('[SDX-TRKIN-07] malformed revision story parts defer to the ancillary safety boundary')(
+    'a truncated notes part keeps its precise typed diagnostics instead of a tracked-input claim',
+    async ({ given, when, then }: AllureBddContext) => {
+      let failure: unknown;
+
+      await given('an original whose footnotes part is truncated mid-element', () => {});
+      const originalSeed = await buildDocxFromBodyXml(
+        `${paragraph('Shared')}<w:p><w:r><w:footnoteReference w:id="1"/></w:r></w:p>`,
+      );
+      const original = await addPart(
+        originalSeed,
+        'word/footnotes.xml',
+        `<w:footnotes ${W_NS_DECL}><w:footnote w:id="1"><w:p>`,
+      );
+      const revised = await buildDocxFromBodyXml(paragraph('Shared'));
+
+      await when('the documents are compared', async () => {
+        try {
+          await compareDocuments(original, revised, { reconstructionMode: 'inplace' });
+        } catch (error) {
+          failure = error;
+        }
+      });
+
+      await then('the failure is the ancillary boundary error, not TrackedInputRevisionError', () => {
+        expect(failure).toBeInstanceOf(Error);
+        expect((failure as Error).name).toBe('AncillaryStorySafetyError');
+        expect(failure).not.toBeInstanceOf(TrackedInputRevisionError);
+      });
+    },
+  );
+
+  test.openspec('[SDX-TRKIN-08] the comparison CLI refuses tracked inputs with the operand named')(
+    'the real docx-comparison CLI propagates the refusal and writes no output',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      let failure: unknown;
+      let outputPath: string;
+
+      await given('a tracked revised input staged on disk for the CLI', () => {});
+      const dir = await mkdtemp(join(tmpdir(), 'trkin-cli-'));
+      tempDirs.push(dir);
+      const originalPath = join(dir, 'original.docx');
+      const revisedPath = join(dir, 'revised.docx');
+      outputPath = join(dir, 'out.docx');
+      await writeFile(originalPath, new Uint8Array(await buildDocxFromBodyXml(CLEAN_BODY)));
+      await writeFile(
+        revisedPath,
+        new Uint8Array(
+          await buildDocxFromBodyXml(
+            `<w:p><w:ins ${REVISION_ATTRS}><w:r><w:t>tracked</w:t></w:r></w:ins></w:p>`,
+          ),
+        ),
+      );
+
+      await when('runCompareCli runs with its REAL compare dependency (no injected fake)', async () => {
+        try {
+          await runCompareCli([originalPath, revisedPath, outputPath]);
+        } catch (error) {
+          failure = error;
+        }
+      });
+
+      await then('the CLI run fails with the refusal naming the revised operand', () => {
+        // The bin wrapper prints err.message and exits 1 for any rejection, so
+        // a propagated TrackedInputRevisionError is a nonzero CLI exit whose
+        // message names the offending operand.
+        expect(failure).toBeInstanceOf(TrackedInputRevisionError);
+        expect((failure as Error).message).toContain('revised document already contains tracked changes');
+      });
+
+      await and('no output file was written', async () => {
+        let exists = true;
+        try {
+          await access(outputPath);
+        } catch {
+          exists = false;
+        }
+        expect(exists).toBe(false);
+      });
+    },
+  );
+});

--- a/packages/docx-compare/src/baselines/atomizer/trackedInputRevisionSafety.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/trackedInputRevisionSafety.test.ts
@@ -17,6 +17,7 @@ import { join } from 'node:path';
 import JSZip from 'jszip';
 import { describe, expect, afterAll } from 'vitest';
 import { compareDocuments, TrackedInputRevisionError } from '../../index.js';
+import * as packageRoot from '../../index.js';
 import { compareDocumentsAtomizer } from './pipeline.js';
 import { runCompareCli } from '../../cli/compare-two.js';
 import { buildDocxFromBodyXml } from '../../testing/ooxml-fixtures.js';
@@ -92,6 +93,37 @@ const TRACKED_BODY_BY_KIND: ReadonlyArray<{ marker: string; body: string }> = [
       `<w:tbl><w:tblPr/><w:tblGrid><w:gridCol/></w:tblGrid>` +
       `<w:tr><w:tc><w:tcPr><w:tcPrChange ${REVISION_ATTRS}><w:tcPr/></w:tcPrChange></w:tcPr>` +
       `<w:p><w:r><w:t>cell</w:t></w:r></w:p></w:tc></w:tr></w:tbl>${paragraph('after')}`,
+  },
+  // The three cell-topology records and the legacy numbering-change record
+  // were execution-proven during peer review to pass the original ten-name
+  // guard and survive the comparison with their prior author intact.
+  {
+    marker: 'w:cellIns',
+    body:
+      `<w:tbl><w:tblPr/><w:tblGrid><w:gridCol/></w:tblGrid>` +
+      `<w:tr><w:tc><w:tcPr><w:cellIns ${REVISION_ATTRS}/></w:tcPr>` +
+      `<w:p><w:r><w:t>cell</w:t></w:r></w:p></w:tc></w:tr></w:tbl>${paragraph('after')}`,
+  },
+  {
+    marker: 'w:cellDel',
+    body:
+      `<w:tbl><w:tblPr/><w:tblGrid><w:gridCol/></w:tblGrid>` +
+      `<w:tr><w:tc><w:tcPr><w:cellDel ${REVISION_ATTRS}/></w:tcPr>` +
+      `<w:p><w:r><w:t>cell</w:t></w:r></w:p></w:tc></w:tr></w:tbl>${paragraph('after')}`,
+  },
+  {
+    marker: 'w:cellMerge',
+    body:
+      `<w:tbl><w:tblPr/><w:tblGrid><w:gridCol/></w:tblGrid>` +
+      `<w:tr><w:tc><w:tcPr><w:cellMerge w:vMerge="cont" ${REVISION_ATTRS}/></w:tcPr>` +
+      `<w:p><w:r><w:t>cell</w:t></w:r></w:p></w:tc></w:tr></w:tbl>${paragraph('after')}`,
+  },
+  {
+    marker: 'w:numberingChange',
+    body:
+      `<w:p><w:pPr><w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/>` +
+      `<w:numberingChange ${REVISION_ATTRS} w:original="%1:1:0:."/>` +
+      `</w:numPr></w:pPr><w:r><w:t>numbered</w:t></w:r></w:p>`,
   },
 ];
 
@@ -280,7 +312,7 @@ describe('tracked-input comparison guard', () => {
 
   test.openspec('[SDX-TRKIN-06] the directly exported atomizer entry point is guarded')(
     'compareDocumentsAtomizer refuses tracked inputs exactly like compareDocuments',
-    async ({ given, when, then }: AllureBddContext) => {
+    async ({ given, when, then, and }: AllureBddContext) => {
       let atomizerError: TrackedInputRevisionError;
       let publicError: TrackedInputRevisionError;
 
@@ -300,6 +332,13 @@ describe('tracked-input comparison guard', () => {
         expect(atomizerError.operand).toBe(publicError.operand);
         expect(atomizerError.partPath).toBe(publicError.partPath);
         expect(atomizerError.markers).toEqual(publicError.markers);
+      });
+
+      await and('the package root exports no unguarded comparison entry', () => {
+        // The unguarded orchestrator exists for engine tests (module-level
+        // import only); exporting it from the root would be a working public
+        // bypass of the guard — peer review demonstrated exactly that.
+        expect(packageRoot).not.toHaveProperty('compareDocumentsAtomizerUnguarded');
       });
     },
   );

--- a/packages/docx-compare/src/baselines/atomizer/trackedInputRevisionSafety.ts
+++ b/packages/docx-compare/src/baselines/atomizer/trackedInputRevisionSafety.ts
@@ -1,0 +1,138 @@
+import {
+  DocxZip,
+  OOXML,
+  enumerateRevisionStoryPartPaths,
+  parseXml,
+} from '@usejunior/docx-core';
+
+/**
+ * Revision-markup local names (WordprocessingML namespace) whose presence in a
+ * comparison input means the document already carries tracked changes: the
+ * four content markers plus the six property-change records. Row-level markers
+ * (`w:trPr > w:ins|w:del`) share the same local names and are detected by the
+ * same scan.
+ */
+const TRACKED_REVISION_LOCAL_NAMES = [
+  'ins',
+  'del',
+  'moveFrom',
+  'moveTo',
+  'rPrChange',
+  'pPrChange',
+  'sectPrChange',
+  'tblPrChange',
+  'trPrChange',
+  'tcPrChange',
+] as const;
+
+/** Which comparison operand a tracked-input detection refers to. */
+export type ComparisonOperandName = 'original' | 'revised';
+
+/** One fail-closed detection produced by the tracked-input scan. */
+export interface TrackedInputRevisionDetection {
+  /** The comparison operand the finding is about. */
+  operand: ComparisonOperandName;
+  /** The package part in which revision markup was found. */
+  partPath: string;
+  /** The revision element names present in the part (e.g. `w:ins`, `w:del`). */
+  markers: string[];
+}
+
+/**
+ * Typed recoverable refusal raised when a comparison input already contains
+ * tracked-changes markup. Comparing such an input silently merges two
+ * authors' revision trees into one document — an output Microsoft Word
+ * refuses to open — so the comparison boundary fails closed instead. Accept
+ * or reject the input's existing revisions, then retry the comparison.
+ *
+ * @see https://github.com/UseJunior/safe-docx/issues/742
+ */
+export class TrackedInputRevisionError extends Error {
+  readonly operand: ComparisonOperandName;
+  readonly partPath: string;
+  readonly markers: string[];
+
+  constructor(detection: TrackedInputRevisionDetection) {
+    const { operand, partPath, markers } = detection;
+    super(
+      `The ${operand} document already contains tracked changes ` +
+        `(${markers.join(', ')} in ${partPath}). Comparing it would merge ` +
+        `two authors' revision markup into one output, which Microsoft Word ` +
+        `refuses to open. Accept or reject the ${operand} document's ` +
+        `tracked changes, then retry the comparison.`,
+    );
+    this.name = 'TrackedInputRevisionError';
+    this.operand = operand;
+    this.partPath = partPath;
+    this.markers = markers;
+  }
+}
+
+function trackedRevisionMarkers(xml: string): string[] {
+  const document = parseXml(xml);
+  return TRACKED_REVISION_LOCAL_NAMES.filter(
+    (localName) =>
+      document.getElementsByTagNameNS(OOXML.W_NS, localName).length > 0,
+  ).map((localName) => `w:${localName}`);
+}
+
+async function findTrackedRevisionMarkup(
+  buffer: Buffer,
+  operand: ComparisonOperandName,
+): Promise<TrackedInputRevisionDetection | undefined> {
+  const zip = await DocxZip.load(buffer);
+  const partPaths = new Set<string>([
+    'word/document.xml',
+    ...enumerateRevisionStoryPartPaths(zip),
+  ]);
+  for (const partPath of [...partPaths].sort()) {
+    const xml = await zip.readTextOrNull(partPath);
+    if (xml === null) continue;
+    let markers: string[];
+    try {
+      markers = trackedRevisionMarkers(xml);
+    } catch {
+      // A part this scan cannot parse is not claimed by this guard: the
+      // package-level ancillary safety boundary owns malformed-part failures
+      // and reports them with precise typed diagnostics (for example
+      // AncillaryStorySafetyError / NOTE_PART_XML_INVALID for a truncated
+      // notes part). Pre-empting those here would replace a stable, specific
+      // error with a vaguer one — the same rule textBoxRevisionSafety applies
+      // to its preparatory scan.
+      continue;
+    }
+    if (markers.length > 0) return { operand, partPath, markers };
+  }
+  return undefined;
+}
+
+/**
+ * Fail closed when either comparison input already contains tracked-changes
+ * markup. The comparison engine passes pre-existing revisions through rather
+ * than accepting them before diffing, so a tracked input yields an output with
+ * two revision authors and (edit-density permitting) directly nested revision
+ * elements — a package Microsoft Word rejects as unreadable while the compare
+ * still exits 0 with normal stats.
+ *
+ * The scan covers `word/document.xml` plus every revision story part the
+ * package holds — footnotes, endnotes, comments, the glossary document, and
+ * each numbered header/footer part — and detects the four content markers
+ * (`w:ins`, `w:del`, `w:moveFrom`, `w:moveTo`) and the six property-change
+ * records (`w:rPrChange`, `w:pPrChange`, `w:sectPrChange`, `w:tblPrChange`,
+ * `w:trPrChange`, `w:tcPrChange`). Missing parts are skipped. Parts that fail
+ * to parse are also skipped by this guard: malformed-part failures belong to
+ * the package-level ancillary safety boundary, whose typed diagnostics this
+ * preparatory scan must not pre-empt. The original operand is scanned first,
+ * so when both inputs are tracked the error names the original.
+ *
+ * @see https://github.com/UseJunior/safe-docx/issues/742
+ */
+export async function assertComparisonInputsUntracked(
+  original: Buffer,
+  revised: Buffer,
+): Promise<void> {
+  const detection =
+    (await findTrackedRevisionMarkup(original, 'original')) ??
+    (await findTrackedRevisionMarkup(revised, 'revised'));
+  if (detection) throw new TrackedInputRevisionError(detection);
+}

--- a/packages/docx-compare/src/baselines/atomizer/trackedInputRevisionSafety.ts
+++ b/packages/docx-compare/src/baselines/atomizer/trackedInputRevisionSafety.ts
@@ -8,9 +8,19 @@ import {
 /**
  * Revision-markup local names (WordprocessingML namespace) whose presence in a
  * comparison input means the document already carries tracked changes: the
- * four content markers plus the six property-change records. Row-level markers
- * (`w:trPr > w:ins|w:del`) share the same local names and are detected by the
- * same scan.
+ * four content markers, the six property-change records, the three
+ * cell-topology records, and the legacy numbering-change record. Row-level
+ * markers (`w:trPr > w:ins|w:del`) share the same local names and are
+ * detected by the same scan. The cell and numbering records were
+ * execution-proven (peer review of #742) to otherwise pass through the
+ * comparison with their original author intact.
+ *
+ * Deliberately NOT detection triggers: the range-boundary markers
+ * (`w:moveFromRangeStart`/`End`, `w:moveToRangeStart`/`End`) and the
+ * `w:customXml*Range*` markers. They carry no run content or author-bearing
+ * wrapper of their own; content-bearing moves are caught via `w:moveFrom` /
+ * `w:moveTo`, and an isolated range pair was execution-observed to be dropped
+ * by the comparison rather than passed through as another author's markup.
  */
 const TRACKED_REVISION_LOCAL_NAMES = [
   'ins',
@@ -23,6 +33,10 @@ const TRACKED_REVISION_LOCAL_NAMES = [
   'tblPrChange',
   'trPrChange',
   'tcPrChange',
+  'cellIns',
+  'cellDel',
+  'cellMerge',
+  'numberingChange',
 ] as const;
 
 /** Which comparison operand a tracked-input detection refers to. */
@@ -117,9 +131,12 @@ async function findTrackedRevisionMarkup(
  * The scan covers `word/document.xml` plus every revision story part the
  * package holds — footnotes, endnotes, comments, the glossary document, and
  * each numbered header/footer part — and detects the four content markers
- * (`w:ins`, `w:del`, `w:moveFrom`, `w:moveTo`) and the six property-change
+ * (`w:ins`, `w:del`, `w:moveFrom`, `w:moveTo`), the six property-change
  * records (`w:rPrChange`, `w:pPrChange`, `w:sectPrChange`, `w:tblPrChange`,
- * `w:trPrChange`, `w:tcPrChange`). Missing parts are skipped. Parts that fail
+ * `w:trPrChange`, `w:tcPrChange`), the cell-topology records (`w:cellIns`,
+ * `w:cellDel`, `w:cellMerge`), and `w:numberingChange`; see
+ * {@link TRACKED_REVISION_LOCAL_NAMES} for the range-marker records that are
+ * deliberately not triggers. Missing parts are skipped. Parts that fail
  * to parse are also skipped by this guard: malformed-part failures belong to
  * the package-level ancillary safety boundary, whose typed diagnostics this
  * preparatory scan must not pre-empt. The original operand is scanned first,

--- a/packages/docx-compare/src/index.ts
+++ b/packages/docx-compare/src/index.ts
@@ -121,14 +121,6 @@ export {
   validateFieldStructure,
   compareDocumentsAtomizer,
 } from './baselines/atomizer/pipeline.js';
-/**
- * NOT a supported comparison entry point: performs no tracked-input
- * validation, and tracked inputs produce Word-unreadable output (issue #742).
- * Exists for engine tests over deliberately pre-tracked fixtures and as the
- * attachment point for a future accept-on-ingest opt-in. Use
- * {@link compareDocuments} or {@link compareDocumentsAtomizer} instead.
- */
-export { compareDocumentsAtomizerUnguarded } from './baselines/atomizer/pipeline.js';
 /** @deprecated fldChar inside w:del is valid; see the docx-core definition. */
 export { hasFldCharInsideDel } from '@usejunior/docx-core';
 export { parseDocumentXml } from './baselines/atomizer/xmlToWmlElement.js';

--- a/packages/docx-compare/src/index.ts
+++ b/packages/docx-compare/src/index.ts
@@ -121,6 +121,14 @@ export {
   validateFieldStructure,
   compareDocumentsAtomizer,
 } from './baselines/atomizer/pipeline.js';
+/**
+ * NOT a supported comparison entry point: performs no tracked-input
+ * validation, and tracked inputs produce Word-unreadable output (issue #742).
+ * Exists for engine tests over deliberately pre-tracked fixtures and as the
+ * attachment point for a future accept-on-ingest opt-in. Use
+ * {@link compareDocuments} or {@link compareDocumentsAtomizer} instead.
+ */
+export { compareDocumentsAtomizerUnguarded } from './baselines/atomizer/pipeline.js';
 /** @deprecated fldChar inside w:del is valid; see the docx-core definition. */
 export { hasFldCharInsideDel } from '@usejunior/docx-core';
 export { parseDocumentXml } from './baselines/atomizer/xmlToWmlElement.js';
@@ -132,6 +140,14 @@ export {
   UnsupportedTextBoxRevisionError,
   assertTextBoxContentUnchanged,
 } from './baselines/atomizer/textBoxRevisionSafety.js';
+export {
+  TrackedInputRevisionError,
+  assertComparisonInputsUntracked,
+} from './baselines/atomizer/trackedInputRevisionSafety.js';
+export type {
+  ComparisonOperandName,
+  TrackedInputRevisionDetection,
+} from './baselines/atomizer/trackedInputRevisionSafety.js';
 export type { TextBoxRevisionChange } from './baselines/atomizer/textBoxRevisionSafety.js';
 export { computeAtomLcs, markCorrelationStatus } from './baselines/atomizer/atomLcs.js';
 export {

--- a/packages/docx-core/src/integration/advanced-revision-classification.test.ts
+++ b/packages/docx-core/src/integration/advanced-revision-classification.test.ts
@@ -7,12 +7,14 @@ import { OOXML } from '../primitives/namespaces.js';
 import { DocxDocument } from '../primitives/document.js';
 import { createZipBuffer, readZipText } from '../primitives/zip.js';
 import { validateAiRevisions } from '../primitives/validate_ai_revisions.js';
+import { compareDocuments } from '@usejunior/docx-compare';
 // [ADV-COMPARE-MODE-PRESERVATION-01] characterizes how the ENGINE treats
 // pre-existing advanced markup by reconstruction mode. The public boundary
 // now refuses inputs carrying w:ins/w:del/w:moveFrom/w:moveTo (issue #742),
-// so that characterization runs below the guard via the explicitly named
-// unguarded seam.
-import { compareDocuments, compareDocumentsAtomizerUnguarded } from '@usejunior/docx-compare';
+// so that characterization runs below the guard via the test-only pipeline
+// subpath (aliased to source in vitest.config.ts) — the seam is deliberately
+// not exported from the package root.
+import { compareDocumentsAtomizerUnguarded } from '@usejunior/docx-compare/dist/baselines/atomizer/pipeline.js';
 import { buildSyntheticDocx, getResultParts } from './synthetic-docx-fixture.js';
 import { revisionEvidence, revisionEvidenceCases } from '../testing/revision-evidence.js';
 

--- a/packages/docx-core/src/integration/advanced-revision-classification.test.ts
+++ b/packages/docx-core/src/integration/advanced-revision-classification.test.ts
@@ -7,7 +7,12 @@ import { OOXML } from '../primitives/namespaces.js';
 import { DocxDocument } from '../primitives/document.js';
 import { createZipBuffer, readZipText } from '../primitives/zip.js';
 import { validateAiRevisions } from '../primitives/validate_ai_revisions.js';
-import { compareDocuments } from '@usejunior/docx-compare';
+// [ADV-COMPARE-MODE-PRESERVATION-01] characterizes how the ENGINE treats
+// pre-existing advanced markup by reconstruction mode. The public boundary
+// now refuses inputs carrying w:ins/w:del/w:moveFrom/w:moveTo (issue #742),
+// so that characterization runs below the guard via the explicitly named
+// unguarded seam.
+import { compareDocuments, compareDocumentsAtomizerUnguarded } from '@usejunior/docx-compare';
 import { buildSyntheticDocx, getResultParts } from './synthetic-docx-fixture.js';
 import { revisionEvidence, revisionEvidenceCases } from '../testing/revision-evidence.js';
 
@@ -781,7 +786,7 @@ describe('ECMA-376 advanced revision records', () => {
         const outputByMode = new Map<string, Document>();
         for (const mode of ['inplace', 'rebuild'] as const) {
           const result = await when(`the identical pair is compared in ${mode} mode`, () =>
-            compareDocuments(input, input, { engine: 'atomizer', reconstructionMode: mode }),
+            compareDocumentsAtomizerUnguarded(input, input, { reconstructionMode: mode }),
           );
           expect(result.reconstructionModeUsed).toBe(mode);
           outputByMode.set(mode, parseXml((await getResultParts(result.document)).documentXml));
@@ -845,7 +850,7 @@ describe('ECMA-376 advanced revision records', () => {
           run: async (fixture, _element, context) => {
             const mode = context.operation.endsWith('.rebuild') ? 'rebuild' : 'inplace';
             const bytes = await packageWithDocumentXml(serializeXml(fixture));
-            const result = await compareDocuments(bytes, bytes, { engine: 'atomizer', reconstructionMode: mode });
+            const result = await compareDocumentsAtomizerUnguarded(bytes, bytes, { reconstructionMode: mode });
             return {
               input: fixture,
               output: parseXml((await getResultParts(result.document)).documentXml),

--- a/packages/docx-core/src/integration/canonical-emission-regression.test.ts
+++ b/packages/docx-core/src/integration/canonical-emission-regression.test.ts
@@ -10,7 +10,12 @@ import {
   readZipText,
   replaceParagraphTextRange,
 } from '../index.js';
-import { compareDocuments } from '@usejunior/docx-compare';
+// These round-trips compare a baseline against a document that already
+// carries SafeDocX-authored tracked markup, which the public comparison
+// boundary now refuses (issue #742). The canonical-emission engine behavior
+// pinned here lives below that guard, reached via the explicitly named
+// unguarded seam.
+import { compareDocumentsAtomizerUnguarded } from '@usejunior/docx-compare';
 import { buildSyntheticDocx, getResultParts } from './synthetic-docx-fixture.js';
 
 const test = testAllure.epic('Document Comparison').withLabels({
@@ -704,9 +709,8 @@ describe('Round-trip with comparison', () => {
       preCompareDocumentXml = modifiedParts.parts['word/document.xml']!;
 
       await when('compareDocuments runs against the tracked document', async () => {
-        const compared = await compareDocuments(baseline, modifiedParts.buffer, {
+        const compared = await compareDocumentsAtomizerUnguarded(baseline, modifiedParts.buffer, {
           author: AI_AUTHOR,
-          engine: 'atomizer',
         });
         comparedDocumentXml = (await readZipText(compared.document, 'word/document.xml'))!;
       });
@@ -780,9 +784,8 @@ describe('Round-trip with comparison', () => {
       const { buffer: modified } = await toPartMap(doc, ['word/document.xml']);
 
       await when('compareDocuments runs against the tracked insertion', async () => {
-        const compared = await compareDocuments(baseline, modified, {
+        const compared = await compareDocumentsAtomizerUnguarded(baseline, modified, {
           author: AI_AUTHOR,
-          engine: 'atomizer',
         });
         comparedDocumentXml = (await readZipText(compared.document, 'word/document.xml'))!;
       });
@@ -828,9 +831,8 @@ describe('Round-trip with comparison', () => {
       modifiedCommentsXml = modifiedParts.parts['word/comments.xml'];
 
       await when('compareDocuments runs against the tracked comment document', async () => {
-        const compared = await compareDocuments(baseline, modifiedParts.buffer, {
+        const compared = await compareDocumentsAtomizerUnguarded(baseline, modifiedParts.buffer, {
           author: AI_AUTHOR,
-          engine: 'atomizer',
         });
         const parts = await getResultParts(compared.document);
         comparedDocumentXml = parts.documentXml;
@@ -862,9 +864,8 @@ describe('Round-trip with comparison', () => {
       modifiedFootnotesXml = modifiedParts.parts['word/footnotes.xml'];
 
       await when('compareDocuments runs against the tracked footnote document', async () => {
-        const compared = await compareDocuments(baseline, modifiedParts.buffer, {
+        const compared = await compareDocumentsAtomizerUnguarded(baseline, modifiedParts.buffer, {
           author: AI_AUTHOR,
-          engine: 'atomizer',
         });
         const parts = await getResultParts(compared.document);
         comparedDocumentXml = parts.documentXml;

--- a/packages/docx-core/src/integration/canonical-emission-regression.test.ts
+++ b/packages/docx-core/src/integration/canonical-emission-regression.test.ts
@@ -13,9 +13,10 @@ import {
 // These round-trips compare a baseline against a document that already
 // carries SafeDocX-authored tracked markup, which the public comparison
 // boundary now refuses (issue #742). The canonical-emission engine behavior
-// pinned here lives below that guard, reached via the explicitly named
-// unguarded seam.
-import { compareDocumentsAtomizerUnguarded } from '@usejunior/docx-compare';
+// pinned here lives below that guard, reached via the test-only pipeline
+// subpath (aliased to source in vitest.config.ts) — the seam is deliberately
+// not exported from the package root.
+import { compareDocumentsAtomizerUnguarded } from '@usejunior/docx-compare/dist/baselines/atomizer/pipeline.js';
 import { buildSyntheticDocx, getResultParts } from './synthetic-docx-fixture.js';
 
 const test = testAllure.epic('Document Comparison').withLabels({

--- a/packages/docx-core/src/integration/pretracked-ins-provenance.test.ts
+++ b/packages/docx-core/src/integration/pretracked-ins-provenance.test.ts
@@ -30,7 +30,12 @@
 
 import { describe, expect } from 'vitest';
 import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
-import { compareDocuments, type ReconstructionMode } from '@usejunior/docx-compare';
+import { type ReconstructionMode } from '@usejunior/docx-compare';
+// Pre-tracked originals are the very subject of this suite, and the public
+// comparison boundary now refuses them (issue #742). The engine behavior
+// pinned here lives below that guard, reached via the explicitly named
+// unguarded seam.
+import { compareDocumentsAtomizerUnguarded } from '@usejunior/docx-compare';
 import {
   acceptAllChanges,
   rejectAllChanges,
@@ -236,8 +241,7 @@ async function runComparison(
   revised: Buffer,
   reconstructionMode: ReconstructionMode,
 ): Promise<ProjectionReport> {
-  const result = await compareDocuments(original, revised, {
-    engine: 'atomizer',
+  const result = await compareDocumentsAtomizerUnguarded(original, revised, {
     reconstructionMode,
   });
   const [combinedXml, originalXml, revisedXml] = await Promise.all([

--- a/packages/docx-core/src/integration/pretracked-ins-provenance.test.ts
+++ b/packages/docx-core/src/integration/pretracked-ins-provenance.test.ts
@@ -33,9 +33,10 @@ import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
 import { type ReconstructionMode } from '@usejunior/docx-compare';
 // Pre-tracked originals are the very subject of this suite, and the public
 // comparison boundary now refuses them (issue #742). The engine behavior
-// pinned here lives below that guard, reached via the explicitly named
-// unguarded seam.
-import { compareDocumentsAtomizerUnguarded } from '@usejunior/docx-compare';
+// pinned here lives below that guard, reached via the test-only pipeline
+// subpath (aliased to source in vitest.config.ts) — the seam is deliberately
+// not exported from the package root.
+import { compareDocumentsAtomizerUnguarded } from '@usejunior/docx-compare/dist/baselines/atomizer/pipeline.js';
 import {
   acceptAllChanges,
   rejectAllChanges,

--- a/packages/docx-core/src/integration/rebuild-auxiliary-merge.test.ts
+++ b/packages/docx-core/src/integration/rebuild-auxiliary-merge.test.ts
@@ -14,10 +14,13 @@
 
 import { describe, expect } from 'vitest';
 import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { compareDocuments } from '@usejunior/docx-compare';
 // compareDocumentsAtomizerUnguarded is for fixtures that pre-track their
 // inputs only (issue #742): the engine behavior under test lives below the
-// public tracked-input guard.
-import { compareDocuments, compareDocumentsAtomizerUnguarded } from '@usejunior/docx-compare';
+// public tracked-input guard, reached via the test-only pipeline subpath
+// (aliased to source in vitest.config.ts) — the seam is deliberately not
+// exported from the package root.
+import { compareDocumentsAtomizerUnguarded } from '@usejunior/docx-compare/dist/baselines/atomizer/pipeline.js';
 import { buildSyntheticDocx, buildDocxFromParts, getResultParts } from './synthetic-docx-fixture.js';
 import { buildDocxFromBodyXml } from '../testing/ooxml-fixtures.js';
 import { parseXml } from '../primitives/xml.js';

--- a/packages/docx-core/src/integration/rebuild-auxiliary-merge.test.ts
+++ b/packages/docx-core/src/integration/rebuild-auxiliary-merge.test.ts
@@ -14,7 +14,10 @@
 
 import { describe, expect } from 'vitest';
 import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
-import { compareDocuments } from '@usejunior/docx-compare';
+// compareDocumentsAtomizerUnguarded is for fixtures that pre-track their
+// inputs only (issue #742): the engine behavior under test lives below the
+// public tracked-input guard.
+import { compareDocuments, compareDocumentsAtomizerUnguarded } from '@usejunior/docx-compare';
 import { buildSyntheticDocx, buildDocxFromParts, getResultParts } from './synthetic-docx-fixture.js';
 import { buildDocxFromBodyXml } from '../testing/ooxml-fixtures.js';
 import { parseXml } from '../primitives/xml.js';
@@ -957,8 +960,10 @@ describe('Move-range marker reconstruction on rebuild (issue #110)', () => {
 
       let result: Awaited<ReturnType<typeof compareDocuments>>;
       await when('documents are compared in rebuild mode', async () => {
-        result = await compareDocuments(original, revised, {
-          engine: 'atomizer',
+        // The revised fixture pre-tracks a move; the public boundary refuses
+        // pre-tracked inputs (issue #742), so this engine test uses the
+        // unguarded seam.
+        result = await compareDocumentsAtomizerUnguarded(original, revised, {
           reconstructionMode: 'rebuild',
         });
       });
@@ -1004,8 +1009,8 @@ describe('Move-range marker reconstruction on rebuild (issue #110)', () => {
 
       let result: Awaited<ReturnType<typeof compareDocuments>>;
       await when('documents are compared in inplace mode', async () => {
-        result = await compareDocuments(original, revised, {
-          engine: 'atomizer',
+        // Same pre-tracked fixture as above; see issue #742.
+        result = await compareDocumentsAtomizerUnguarded(original, revised, {
           reconstructionMode: 'inplace',
         });
       });

--- a/packages/docx-core/src/integration/unrepresented-section-changes.test.ts
+++ b/packages/docx-core/src/integration/unrepresented-section-changes.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect } from 'vitest';
-import { compareDocuments } from '@usejunior/docx-compare';
+import { compareDocuments, compareDocumentsAtomizerUnguarded } from '@usejunior/docx-compare';
 import { DocxArchive } from '../shared/docx/DocxArchive.js';
 import { auditSectPr } from '../primitives/sectPrAudit.js';
 import {
@@ -151,8 +151,10 @@ describe('unrepresented section and header/footer reporting', () => {
     expect(
       auditSectPr(await revisedArchive.getDocumentXml()).stats.totalSectPrCount,
     ).toBe(1);
-    const result = await compareDocuments(original, revised, {
-      engine: 'atomizer',
+    // The revised fixture pre-tracks a sectPrChange; the public boundary
+    // refuses pre-tracked inputs (issue #742), so this engine behavior is
+    // pinned via the unguarded seam.
+    const result = await compareDocumentsAtomizerUnguarded(original, revised, {
       reconstructionMode: 'inplace',
     });
     expect(result.unrepresentedChanges).toBeUndefined();

--- a/packages/docx-core/src/integration/unrepresented-section-changes.test.ts
+++ b/packages/docx-core/src/integration/unrepresented-section-changes.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect } from 'vitest';
-import { compareDocuments, compareDocumentsAtomizerUnguarded } from '@usejunior/docx-compare';
+import { compareDocuments } from '@usejunior/docx-compare';
+// Test-only pipeline subpath (aliased to source in vitest.config.ts); the
+// unguarded seam is deliberately not exported from the package root (#742).
+import { compareDocumentsAtomizerUnguarded } from '@usejunior/docx-compare/dist/baselines/atomizer/pipeline.js';
 import { DocxArchive } from '../shared/docx/DocxArchive.js';
 import { auditSectPr } from '../primitives/sectPrAudit.js';
 import {

--- a/packages/docx-core/vitest.config.ts
+++ b/packages/docx-core/vitest.config.ts
@@ -42,6 +42,16 @@ export default defineConfig({
   resolve: {
     alias: {
       '@usejunior/docx-core': resolve(__dirname, 'src/index.ts'),
+      // Test-only seam for engine tests over deliberately pre-tracked inputs
+      // (issue #742): the unguarded orchestrator is not exported from the
+      // package root, so those tests import the pipeline module through the
+      // package's dist subpath, aliased here back to the same source module
+      // graph the root alias below uses. Must precede the root alias so the
+      // longer specifier wins prefix matching.
+      '@usejunior/docx-compare/dist/baselines/atomizer/pipeline.js': resolve(
+        __dirname,
+        '../docx-compare/src/baselines/atomizer/pipeline.ts',
+      ),
       '@usejunior/docx-compare': resolve(__dirname, '../docx-compare/src/index.ts'),
     },
   },

--- a/packages/docx-mcp/docs/tool-reference.generated.md
+++ b/packages/docx-mcp/docs/tool-reference.generated.md
@@ -351,7 +351,7 @@ Delete a comment and all its threaded replies from the document. Cascade-deletes
 
 ## `compare_documents`
 
-Compare two documents and produce a tracked-changes output document. Provide original_file_path + revised_file_path for standalone comparison, or file_path to compare session edits against the original. DOCX and ODF (.odt) support both modes. DOCX stats count insertions/deletions as contiguous ranges, expose atom totals as insertedAtoms/deletedAtoms, and report formatChanges separately from modifiedParagraphs. ODF compares at inline granularity (a modified paragraph is marked up in place — only the changed spans are struck or inserted).
+Compare two documents and produce a tracked-changes output document. Provide original_file_path + revised_file_path for standalone comparison, or file_path to compare session edits against the original. DOCX and ODF (.odt) support both modes. DOCX inputs that already contain tracked changes are refused with INPUT_HAS_TRACKED_CHANGES naming the offending input — accept or reject their revisions first (e.g. via accept_changes) — because comparing them would merge two authors’ revision markup into an output Word refuses to open. DOCX stats count insertions/deletions as contiguous ranges, expose atom totals as insertedAtoms/deletedAtoms, and report formatChanges separately from modifiedParagraphs. ODF compares at inline granularity (a modified paragraph is marked up in place — only the changed spans are struck or inserted).
 
 - readOnly: `true`
 - destructive: `false`

--- a/packages/docx-mcp/src/tool_catalog.ts
+++ b/packages/docx-mcp/src/tool_catalog.ts
@@ -610,7 +610,7 @@ export const SAFE_DOCX_TOOL_CATALOG = [
     name: 'compare_documents',
     surface: 'revisionable',
     description:
-      'Compare two documents and produce a tracked-changes output document. Provide original_file_path + revised_file_path for standalone comparison, or file_path to compare session edits against the original. DOCX and ODF (.odt) support both modes. DOCX stats count insertions/deletions as contiguous ranges, expose atom totals as insertedAtoms/deletedAtoms, and report formatChanges separately from modifiedParagraphs. ODF compares at inline granularity (a modified paragraph is marked up in place — only the changed spans are struck or inserted).',
+      'Compare two documents and produce a tracked-changes output document. Provide original_file_path + revised_file_path for standalone comparison, or file_path to compare session edits against the original. DOCX and ODF (.odt) support both modes. DOCX inputs that already contain tracked changes are refused with INPUT_HAS_TRACKED_CHANGES naming the offending input — accept or reject their revisions first (e.g. via accept_changes) — because comparing them would merge two authors’ revision markup into an output Word refuses to open. DOCX stats count insertions/deletions as contiguous ranges, expose atom totals as insertedAtoms/deletedAtoms, and report formatChanges separately from modifiedParagraphs. ODF compares at inline granularity (a modified paragraph is marked up in place — only the changed spans are struck or inserted).',
     input: z.object({
       original_file_path: z.string().optional().describe('Path to the original DOCX or .odt file.'),
       revised_file_path: z.string().optional().describe('Path to the revised DOCX or .odt file.'),

--- a/packages/docx-mcp/src/tools/add_tracked_input_comparison_guard.test.ts
+++ b/packages/docx-mcp/src/tools/add_tracked_input_comparison_guard.test.ts
@@ -28,6 +28,7 @@ import {
   registerCleanup,
   createTestSessionManager,
   createTrackedTempDir,
+  openSession,
 } from '../testing/session-test-utils.js';
 
 const TEST_FEATURE = 'add-tracked-input-comparison-guard';
@@ -134,6 +135,80 @@ describe('Traceability: tracked-input comparison guard (MCP surface)', () => {
 
       await and('no output file was written', async () => {
         expect(await fileExists(outputPath)).toBe(false);
+      });
+    },
+  );
+
+  test.openspec('[SDX-TRKIN-MCP-04] header and footer refusals carry an actionable hint')(
+    'a header-part detection does not recommend the body-scoped accept_changes tool',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      const mgr = createTestSessionManager();
+      const dir = await createTrackedTempDir();
+
+      await given('a revised file whose only tracked markup lives in word/header1.xml', () => {});
+      const originalPath = await writeTestDocx(dir, 'header-original.docx', CLEAN_BODY);
+      const revisedDocXml =
+        `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+        `<w:document xmlns:w="${W_NS}"><w:body>${CLEAN_BODY}</w:body></w:document>`;
+      const headerXml =
+        `<w:hdr xmlns:w="${W_NS}"><w:p><w:ins ${REVISION_ATTRS}>` +
+        `<w:r><w:t>tracked header edit</w:t></w:r></w:ins></w:p></w:hdr>`;
+      const revisedBuffer = await makeDocxWithDocumentXml(revisedDocXml, {
+        'word/header1.xml': headerXml,
+      });
+      const revisedPath = path.join(dir, 'header-revised.docx');
+      await fs.writeFile(revisedPath, new Uint8Array(revisedBuffer));
+      const savePath = path.join(dir, 'header-redline.docx');
+
+      const result = await when('Call compare_documents in two-file mode', () =>
+        compareDocuments_tool(mgr, {
+          original_file_path: originalPath,
+          revised_file_path: revisedPath,
+          save_to_local_path: savePath,
+        }),
+      );
+
+      await then('the refusal names the header part', () => {
+        assertFailure(result, 'INPUT_HAS_TRACKED_CHANGES', 'compare_documents');
+        expect(result.error?.message).toContain('word/header1.xml');
+      });
+
+      await and('the hint is actionable: accept_changes cannot clean headers, so it is not suggested', async () => {
+        assertFailure(result);
+        // accept_changes covers the body and note/comment stories only;
+        // recommending it here would send the caller in a retry loop. The
+        // hint may NAME accept_changes only to say it does not apply.
+        expect(result.error?.hint).not.toContain('via accept_changes');
+        expect(result.error?.hint).toContain('accept_changes does not cover headers or footers');
+        expect(result.error?.hint).toContain('word/header1.xml');
+        expect(await fileExists(savePath)).toBe(false);
+      });
+    },
+  );
+
+  test.openspec('[SDX-TRKIN-MCP-05] session-mode comparison of a tracked document is refused')(
+    'a session opened on a document with pre-existing tracked changes cannot session-compare',
+    async ({ given, when, then }: AllureBddContext) => {
+      await given('an open session whose document already carries w:ins markup', () => {});
+      const sessionDocXml =
+        `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+        `<w:document xmlns:w="${W_NS}"><w:body>${CLEAN_BODY}${TRACKED_BODY}</w:body></w:document>`;
+      const { mgr, inputPath, tmpDir } = await openSession([], { xml: sessionDocXml });
+      const savePath = path.join(tmpDir, 'session-redline.docx');
+
+      const result = await when('Call compare_documents in session mode', () =>
+        compareDocuments_tool(mgr, {
+          file_path: inputPath,
+          save_to_local_path: savePath,
+        }),
+      );
+
+      await then('the session comparison is refused with the distinct code and writes nothing', async () => {
+        // Both session operands (the baseline and the working copy) inherit
+        // the document's pre-existing markup, so the comparison must refuse
+        // rather than merge two authors' revision trees.
+        assertFailure(result, 'INPUT_HAS_TRACKED_CHANGES', 'compare_documents');
+        expect(await fileExists(savePath)).toBe(false);
       });
     },
   );

--- a/packages/docx-mcp/src/tools/add_tracked_input_comparison_guard.test.ts
+++ b/packages/docx-mcp/src/tools/add_tracked_input_comparison_guard.test.ts
@@ -1,0 +1,170 @@
+/**
+ * MCP and CLI surfaces of the tracked-input comparison guard.
+ *
+ * The comparison library refuses inputs that already contain tracked changes
+ * (issue #742). This file pins how that typed refusal surfaces to callers of
+ * the safe-docx MCP server and CLI: `compare_documents` maps it to the
+ * distinct `INPUT_HAS_TRACKED_CHANGES` error code (never the catch-all
+ * `COMPARE_ERROR`), and the `safe-docx compare` CLI command propagates it so
+ * the process exits nonzero with a message naming the offending operand.
+ *
+ * Both surfaces are tested against the REAL compare function — substituting a
+ * fake `compare` dependency would bypass the guard and prove nothing.
+ *
+ * @see https://github.com/UseJunior/safe-docx/issues/742
+ */
+
+import { describe, expect } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import { compareDocuments_tool } from './compare_documents.js';
+import { runCompareCommand } from '../cli/commands/compare.js';
+import { makeDocxWithDocumentXml } from '../testing/docx_test_utils.js';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import {
+  assertSuccess,
+  assertFailure,
+  registerCleanup,
+  createTestSessionManager,
+  createTrackedTempDir,
+} from '../testing/session-test-utils.js';
+
+const TEST_FEATURE = 'add-tracked-input-comparison-guard';
+const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const REVISION_ATTRS = 'w:id="901" w:author="Earlier" w:date="2026-01-01T00:00:00Z"';
+
+async function writeTestDocx(dir: string, name: string, bodyXml: string): Promise<string> {
+  const docXml =
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<w:document xmlns:w="${W_NS}"><w:body>${bodyXml}</w:body></w:document>`;
+  const buf = await makeDocxWithDocumentXml(docXml);
+  const filePath = path.join(dir, name);
+  await fs.writeFile(filePath, new Uint8Array(buf));
+  return filePath;
+}
+
+function paragraph(text: string): string {
+  return `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
+}
+
+const CLEAN_BODY = paragraph('Clause one.') + paragraph('Clause two.');
+const TRACKED_BODY =
+  `<w:p><w:ins ${REVISION_ATTRS}><w:r><w:t>pre-existing edit</w:t></w:r></w:ins></w:p>`;
+
+async function fileExists(p: string): Promise<boolean> {
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe('Traceability: tracked-input comparison guard (MCP surface)', () => {
+  const test = testAllure.epic('Document Comparison').withLabels({ feature: TEST_FEATURE });
+  registerCleanup();
+
+  test.openspec('[SDX-TRKIN-MCP-01] compare_documents refuses tracked inputs with a distinct error code')(
+    'a tracked revised input maps to INPUT_HAS_TRACKED_CHANGES, not COMPARE_ERROR',
+    async ({ given, when, then, and, attachPrettyJson }: AllureBddContext) => {
+      const mgr = createTestSessionManager();
+      const dir = await createTrackedTempDir();
+
+      await given('a clean original and a revised file that already carries w:ins markup', () => {});
+      const originalPath = await writeTestDocx(dir, 'original.docx', CLEAN_BODY);
+      const revisedPath = await writeTestDocx(dir, 'revised.docx', TRACKED_BODY);
+      const savePath = path.join(dir, 'redline.docx');
+
+      const result = await when('Call compare_documents in two-file mode', () =>
+        compareDocuments_tool(mgr, {
+          original_file_path: originalPath,
+          revised_file_path: revisedPath,
+          save_to_local_path: savePath,
+        }),
+      );
+      await attachPrettyJson('result', result);
+
+      await then('the response carries the INPUT_HAS_TRACKED_CHANGES error code', () => {
+        assertFailure(result, 'INPUT_HAS_TRACKED_CHANGES', 'compare_documents');
+        expect(result.error?.code).not.toBe('COMPARE_ERROR');
+      });
+
+      await and('the message names the offending operand and part, with a recovery hint', () => {
+        assertFailure(result);
+        expect(result.error?.message).toContain('revised document already contains tracked changes');
+        expect(result.error?.message).toContain('word/document.xml');
+        expect(result.error?.hint).toContain('accept_changes');
+      });
+
+      await and('no output file was written', async () => {
+        expect(await fileExists(savePath)).toBe(false);
+      });
+    },
+  );
+
+  test.openspec('[SDX-TRKIN-MCP-02] the compare CLI command surfaces the tracked-input refusal')(
+    'runCompareCommand with its real compare dependency rejects and writes nothing',
+    async ({ given, when, then, and }: AllureBddContext) => {
+      const dir = await createTrackedTempDir();
+      let failure: unknown;
+
+      await given('a tracked original staged on disk for the CLI command', () => {});
+      const originalPath = await writeTestDocx(dir, 'cli-original.docx', TRACKED_BODY);
+      const revisedPath = await writeTestDocx(dir, 'cli-revised.docx', CLEAN_BODY);
+      const outputPath = path.join(dir, 'cli-out.docx');
+
+      await when('the compare command runs with its REAL default dependencies', async () => {
+        try {
+          await runCompareCommand({ originalPath, revisedPath, outputPath });
+        } catch (error) {
+          failure = error;
+        }
+      });
+
+      await then('the command rejects with a message naming the original operand', () => {
+        // The CLI dispatcher prints the rejection message and exits nonzero,
+        // so this propagated error is the CLI's refusal surface.
+        expect(failure).toBeInstanceOf(Error);
+        expect((failure as Error).name).toBe('TrackedInputRevisionError');
+        expect((failure as Error).message).toContain(
+          'original document already contains tracked changes',
+        );
+      });
+
+      await and('no output file was written', async () => {
+        expect(await fileExists(outputPath)).toBe(false);
+      });
+    },
+  );
+
+  test.openspec('[SDX-TRKIN-MCP-03] compare_documents with clean inputs is unaffected')(
+    'a clean two-file comparison still succeeds and writes the redline',
+    async ({ given, when, then }: AllureBddContext) => {
+      const mgr = createTestSessionManager();
+      const dir = await createTrackedTempDir();
+
+      await given('two clean documents with an ordinary edit between them', () => {});
+      const originalPath = await writeTestDocx(dir, 'clean-original.docx', CLEAN_BODY);
+      const revisedPath = await writeTestDocx(
+        dir,
+        'clean-revised.docx',
+        paragraph('Clause one.') + paragraph('Clause two, amended.'),
+      );
+      const savePath = path.join(dir, 'clean-redline.docx');
+
+      const result = await when('Call compare_documents in two-file mode', () =>
+        compareDocuments_tool(mgr, {
+          original_file_path: originalPath,
+          revised_file_path: revisedPath,
+          save_to_local_path: savePath,
+        }),
+      );
+
+      await then('the comparison succeeds and the redline is written', async () => {
+        assertSuccess(result, 'compare_documents');
+        expect(await fileExists(savePath)).toBe(true);
+      });
+    },
+  );
+});

--- a/packages/docx-mcp/src/tools/compare_documents.ts
+++ b/packages/docx-mcp/src/tools/compare_documents.ts
@@ -3,7 +3,11 @@ import { errorCode, errorMessage } from "../error_utils.js";
 import fs from 'node:fs/promises';
 import { SessionManager } from '../session/manager.js';
 import { err, ok, type ToolResponse } from './types.js';
-import { compareDocuments, type CompareOptions } from '@usejunior/docx-compare';
+import {
+  compareDocuments,
+  TrackedInputRevisionError,
+  type CompareOptions,
+} from '@usejunior/docx-compare';
 import {
   mergeSessionResolutionMetadata,
   resolveSessionForTool,
@@ -150,6 +154,16 @@ export async function compareDocuments_tool(
     return ok(response);
   } catch (e: unknown) {
     const msg = errorMessage(e);
+    if (e instanceof TrackedInputRevisionError) {
+      // Distinct from the catch-all COMPARE_ERROR so an agent can recover: the
+      // refusal is deliberate and the remedy (accept/reject the named operand's
+      // revisions first) is actionable. See issue #742.
+      return err(
+        'INPUT_HAS_TRACKED_CHANGES',
+        msg,
+        'Accept or reject the tracked changes in the named input (e.g. via accept_changes), then retry compare_documents.',
+      );
+    }
     if (String(errorCode(e) ?? '').toUpperCase() === 'EACCES') {
       return err('PERMISSION_DENIED', `Cannot write to: ${params.save_to_local_path}`, 'Try saving to ~/Downloads/ or ~/Documents/ instead.');
     }

--- a/packages/docx-mcp/src/tools/compare_documents.ts
+++ b/packages/docx-mcp/src/tools/compare_documents.ts
@@ -157,11 +157,19 @@ export async function compareDocuments_tool(
     if (e instanceof TrackedInputRevisionError) {
       // Distinct from the catch-all COMPARE_ERROR so an agent can recover: the
       // refusal is deliberate and the remedy (accept/reject the named operand's
-      // revisions first) is actionable. See issue #742.
+      // revisions first) is actionable. The hint depends on WHERE the markup
+      // was found: accept_changes covers the document body and the
+      // revisionable side stories (footnotes, endnotes, comments, glossary)
+      // but not headers or footers, so recommending it for a header/footer
+      // detection would send the caller in a loop. See issue #742.
+      const headerOrFooterPart = /^word\/(?:header|footer)\d*\.xml$/.test(e.partPath);
       return err(
         'INPUT_HAS_TRACKED_CHANGES',
         msg,
-        'Accept or reject the tracked changes in the named input (e.g. via accept_changes), then retry compare_documents.',
+        headerOrFooterPart
+          ? `The tracked changes live in ${e.partPath}; accept_changes does not cover headers or footers. ` +
+              'Produce a fully accepted or rejected copy of the named input (e.g. in Microsoft Word), then retry compare_documents.'
+          : 'Accept or reject the tracked changes in the named input (e.g. via accept_changes), then retry compare_documents.',
       );
     }
     if (String(errorCode(e) ?? '').toUpperCase() === 'EACCES') {


### PR DESCRIPTION
Fails closed when a comparison input already contains tracked changes, instead of silently emitting a Word-unreadable file.

Refs #742 (deliberately not "Fixes": the issue also sketches an `--allow-tracked-input` accept-on-ingest follow-up, which is out of scope here — see the OpenSpec proposal's Out-of-scope section. Maintainer may prefer to close it with this PR; wording left conservative on purpose.)

> **DRAFT / do not merge:** PR #841 rewrites `packages/docx-compare/src/index.ts` and `cli/compare-two.ts`, the surfaces this guard touches. This PR stays draft until #841 lands, then rebases. Auto-merge is intentionally NOT armed.

## Premise gate (reproduced at HEAD before any edit)

Clean `A`; `B` = `A` edited with the edit kept as tracked changes (`w:ins`/`w:del`, author "Original Author"); then `compareDocuments(A, B)`:

- Returned normally, exit 0, normal stats: `{"insertions":2,"deletions":2,"modifications":2,...}` — nothing indicates the input was unsuitable.
- Output `word/document.xml` revision authors: `["Comparison","Original Author"]` — the issue's smoking gun that pre-existing revisions were passed through rather than accepted before diffing.
- Directly nested `w:ins`-inside-`w:ins` present.
- The transitional-schema gate (`scripts/check_emitted_document_schema.mjs`) **passes** the corrupt file — the corruption is behavioral, not schema-visible, which is why no existing gate caught it.
- Independent Codex premise check (read-only sandbox): **CONFIRMED** — traced the call path (no refusal anywhere) and reproduced the two-author, nested-ins output independently.
- Independent corpus confirmation (520-document SHA-pinned differential, run separately): in **rebuild** mode the comparison unwraps pre-existing tracked changes into bare `w:delText` outside any `w:del` wrapper — exactly the Word-unreadable shape #742 reports — while **inplace** passes the two-author markup through. The guard therefore refuses in both modes.
- Live Word-for-Mac probe of the reproduction output: INDETERMINATE both attempts — the probe correctly refuses to act while the user's own Word session holds a modal dialog, and interfering was out of bounds. The issue itself documents the repair prompt for this exact class, and the two checked-in files it names (`atomizer_redline.docx`, `typescript_redline.docx`) are already memorialized as raising "Word found unreadable content".

## Design: one guard, one boundary

Every public path funnels through `compareDocumentsAtomizer` — `compareDocuments`, both CLIs (which take `compare` as an injectable dependency), the MCP tool, and the benchmark runner — and `compareDocumentsAtomizer` is itself publicly exported (a genuine bypass if guarded higher). So the scan runs once, there:

- **New module** `packages/docx-compare/src/baselines/atomizer/trackedInputRevisionSafety.ts`: `assertComparisonInputsUntracked` + typed recoverable `TrackedInputRevisionError` (operand, partPath, markers), following the `UnsupportedTextBoxRevisionError` precedent; exported from the package root.
- **Scan scope:** `word/document.xml` + `enumerateRevisionStoryPartPaths` (footnotes, endnotes, comments, glossary, every numbered header/footer). Detects `w:ins`/`w:del`/`w:moveFrom`/`w:moveTo`, the six `*PrChange` records, the cell-topology records `w:cellIns`/`w:cellDel`/`w:cellMerge`, and `w:numberingChange` — the last four added after Codex's review probe proved they passed the original ten-name scan and survived comparison with their prior author. Row-level `w:trPr > w:ins|w:del` markers trip it via the same local names. Range-boundary markers (`w:*RangeStart`/`End`, `w:customXml*Range*`) are documented non-triggers (the probe showed an isolated pair is dropped, not passed through).
- **Surfaces map, they don't re-scan:** MCP `compare_documents` returns distinct `INPUT_HAS_TRACKED_CHANGES` (never the catch-all `COMPARE_ERROR`) with an `accept_changes` recovery hint. Both CLI entry handlers already print `error.message` and exit 1, and the message names the offending operand — zero CLI code changes, which also keeps the diff rebase-friendly vs #841.
- **Malformed parts defer:** parts the scan cannot parse are skipped by this guard so the ancillary safety boundary keeps its precise diagnostics (`AncillaryStorySafetyError` / `NOTE_PART_XML_INVALID`) — the same rule `textBoxRevisionSafety` documents for its own preparatory scan. Missing parts are skipped.

### The one judgment call reviewers should look at

Twenty-one existing tests across eleven files (six in docx-compare, five in docx-core's integration suite) deliberately drive **pre-tracked fixtures** through the public entry to pin engine internals (original-insertion provenance restoration, insertion-collision promotion, preserved-move identity seeding, pre-existing-wrapper bookmark splitting, canonical-emission round-trips, the ADV mode-preservation characterization) — the "preserve pre-existing tracked changes" behaviors. Deleting that coverage would also trip the coverage ratchet, and the code remains live for the future accept-on-ingest path. Instead, the orchestration below the guard is exposed as `compareDocumentsAtomizerUnguarded` and those tests use it with a per-site comment citing #742; assertions unchanged.

**Containment (revised after Codex review):** the seam is NOT exported from the package root — Codex demonstrated a root export was a live public bypass, so it was removed and `[SDX-TRKIN-06]` now pins its absence. docx-compare tests import it from the pipeline module; docx-core integration tests import it via the package's dist subpath, which docx-core's vitest config aliases back to the same source module graph its root alias uses (TypeScript resolves the subpath against the built `.d.ts`, exactly like the root import already does; a relative source import violates docx-core's tsc `rootDir`).

## OpenSpec

`add-tracked-input-comparison-guard` — validated `--strict`. ADDED requirements on `docx-comparison` (8 scenarios, SDX-TRKIN-01..08) and `mcp-server` (3 scenarios, SDX-TRKIN-MCP-01..03). ADDED rather than MODIFIED: no deployed requirement in either capability promises anything about comparison-input validation, so there was nothing to modify without inventing prior text for the archiver to overwrite.

## Tests

- `trackedInputRevisionSafety.test.ts` (docx-compare): all ten revision kinds + row-level marker, both operands, **both reconstruction modes**, all six story flavors, missing parts skipped, malformed part defers to `AncillaryStorySafetyError`, clean-pair control, both public entry points, and the **real** `runCompareCli` (no injected fake — an injected fake would bypass the guard and prove nothing) refusing with no output written.
- `add_tracked_input_comparison_guard.test.ts` (docx-mcp): `INPUT_HAS_TRACKED_CHANGES` mapping + no file written, real `runCompareCommand` rejection naming the operand, clean control.
- **Red→green:** with the guard call and MCP mapping neutralized, 6/8 and 2/3 of the new tests fail respectively (the passing ones are the deliberate clean/malformed controls); restored, everything is green.

## Codex peer review (dynamic, execution-backed)

Verdict on the initial commit: **REQUEST-CHANGES**, three findings, all confirmed by live probes and all addressed in the follow-up commit (adjudication detailed in a PR comment):

1. **Detector gaps** — `w:cellIns`/`w:cellDel`/`w:cellMerge`/`w:numberingChange` execution-proven to pass through with their prior author → added as triggers, with per-kind public-boundary fixtures.
2. **Package-root bypass** — the root export of the unguarded seam was demonstrated as a working bypass → removed; `[SDX-TRKIN-06]` pins its absence; docx-core tests reach the seam via a vitest-aliased dist subpath instead.
3. **Hint accuracy** — `accept_changes` cannot clean headers/footers, so the recovery hint is now part-aware (`[SDX-TRKIN-MCP-04]`); the recommended session-mode refusal test was added as `[SDX-TRKIN-MCP-05]`.

## Gates

Full pre-submit sequence run on exit codes (`build`, `lint:workspaces`, `test:run`, `check:spec-coverage`, `check:conformance-citations`, `check:conformance-doc`), plus `openspec validate --strict`, `check:tool-docs` after regenerating the tool reference, and `git diff --check`. Rebased onto `origin/main` at 26c6640 (#869).
