### PR TITLE
docs(docx-markdoc): specify external rationale comments

### DIFF
--- a/openspec/changes/add-markdoc-external-rationale-comments/design.md
+++ b/openspec/changes/add-markdoc-external-rationale-comments/design.md
@@ -1,0 +1,82 @@
+## Context
+
+`Rationale.category` is currently an optional free-form string and rationales are passive IR metadata. `compileMarkdoc` accepts only tracked-revision author/date options. The existing comment primitive accepts author, optional initials, and a revision context carrying the date, while the independent release verifier already requires at least one native comment and compares comment-ID multiplicities when `requireNativeComments` is true.
+
+The compiler must not infer whether omitted or arbitrary rationale metadata is safe to disclose. Comment materialization must also preserve the clean and original document projections that Markdoc certification protects.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Materialize explicitly external-facing rationales as native root Word comments.
+- Make selection, identity, timestamping, anchoring, and output deterministic.
+- Fail closed when selected rationale cannot be attributed to one exact operation range.
+- Preserve text and formatting projections.
+
+### Non-Goals
+
+- Inferring shareability from rationale text or an absent category.
+- Publishing internal, correction, or unknown-category rationales.
+- Supporting threaded rationale replies or resolving comment conversations.
+- Changing rationale text into operative document text.
+- Implementing product code in this proposal change.
+
+## Decisions
+
+### Selection uses one exact reserved category
+
+Only a rationale whose category is exactly `external-facing` is selected. Category matching is case-sensitive and does not trim, normalize, alias, classify, or infer. Missing and all other category values remain valid passive metadata but are excluded.
+
+This adds a reserved semantic value without narrowing the existing free-form TypeScript field and therefore avoids breaking existing IR. A boolean was rejected because it would create two competing classification surfaces. A caller predicate or arbitrary allowlist was rejected because serialized CLI/API behavior would be harder to reproduce and could accidentally authorize an internal category.
+
+At most one selected rationale may target an operation. Duplicate selected rationales for the same operation fail before mutation rather than merging text or choosing by order.
+
+### Materialization is opt-in and comment identity is separate
+
+The existing compile options object gains a nested rationale-comment option. Enabling it requires non-empty `author` and `initials` strings plus a valid caller-supplied `date`. These values are used verbatim for every materialized rationale comment.
+
+The nested identity does not fall back to the existing top-level tracked-revision `author` or `date`. Revision authorship and external-comment authorship are different assertions; requiring both explicitly prevents accidental attribution and keeps deterministic dates independent of the process clock. Omitting the nested option preserves current output with zero rationale comments.
+
+The implementation must always pass all three values to the native-comment primitive so its initials and process-clock fallbacks are unreachable on this path.
+
+### Anchors are derived after tracked changes exist
+
+Each selected rationale produces exactly one root comment record and one contiguous comment range. The compiler retains enough operation attribution through comparison to identify the tracked nodes created for that operation; it does not rediscover ownership by searching for rationale text or by guessing from neighboring edits.
+
+- Insertion: anchor exactly the inserted text emitted for the operation.
+- Deletion: anchor exactly the deleted text retained in the tracked document.
+- Replacement or inline edit with inserted text: anchor the inserted replacement text, excluding unchanged context and deleted predecessor text.
+- Replacement or inline edit with no inserted text: use the deletion rule.
+- Multi-paragraph edit: use one range beginning at the first attributable changed character and ending at the last attributable changed character, spanning only paragraphs participating in that operation. Unchanged text between those endpoints is included only when a single contiguous Word comment range cannot exclude it; unrelated leading/trailing clause text and adjacent operations are never included.
+
+If attribution is absent, overlaps another operation ambiguously, or yields no anchorable tracked content, compilation fails before returning output. A single rationale is not duplicated into paragraph-by-paragraph comments.
+
+### Comments are projection-neutral annotations
+
+Comment range markers, references, and comment parts are annotations only. Certification continues to compare accept-all with the generated clean document and reject-all with the pinned source, including semantic formatting checks. Adding comments must not change any of those projections. Comment text is never included in operative-text projection calculations.
+
+Accept-all and reject-all processing must preserve comment records, range starts, range ends, and references as a balanced set. When tracked anchor text does not survive a projection, the range collapses to one deterministic zero-width boundary at the edit location; the rationale remains available instead of being deleted with the revision it explains. Zero-width root-comment ranges are already an admitted native-comment shape in this repository.
+
+The independent release verifier's multiplicity, uniqueness, and minimum-count checks remain authoritative for structural integrity of the tracked release artifact. They do not prove that a projected zero-width range collapsed at the correct edit boundary. Package-level accept/reject tests must verify that location semantic separately for insertions, deletions, replacements, and multi-paragraph ranges; this change does not describe the existing verifier as covering that stronger property.
+
+### Independent verification remains the release gate
+
+When the caller requests `requireNativeComments: true`, the existing release verifier must observe a positive valid comment count. If compilation was enabled but no rationale was selected or materialized, the verifier's minimum-one rule fails closed. Its existing multiplicity and uniqueness checks remain authoritative for tracked-artifact structure; projection-collapse location is verified by the compiler package's accept/reject tests.
+
+### Public tests use synthetic content only
+
+All tests use synthetic DOCX fixtures and invented rationale text. Private matter artifacts, private rationale text, and private corpus extracts are prohibited from repository fixtures, snapshots, logs, and failure messages.
+
+## Risks / Trade-offs
+
+- Deleted-text and cross-paragraph comment ranges require extending or supplementing the existing paragraph-scoped primitive: its current visible-text offsets cannot address text inside tracked deletions or span paragraphs. The implementation must reuse comment-part bootstrapping and ID allocation rather than creating a second comment subsystem.
+- Exact operation attribution may require compiler-internal metadata through comparison. Failing closed is preferable to anchoring a rationale to nearby but unrelated text.
+- The exact category token is intentionally strict. Typos remain unselected and become visible when native comments are required because the release verifier reports zero comments.
+
+## Migration Plan
+
+No migration is required. Existing Markdoc remains valid and existing compile calls retain current output. Callers opt in by categorizing a rationale exactly `external-facing`, supplying deterministic comment identity, and enabling rationale-comment materialization.
+
+## Open Questions
+
+None. Implementation begins only after this proposal is approved.

--- a/openspec/changes/add-markdoc-external-rationale-comments/proposal.md
+++ b/openspec/changes/add-markdoc-external-rationale-comments/proposal.md
@@ -1,0 +1,22 @@
+# Change: Materialize external-facing Markdoc rationales as Word comments
+
+## Why
+
+Markdoc rationales are currently passive metadata and disappear from compiled DOCX output. Explicitly external-facing explanations therefore cannot travel with the tracked document for counsel review, while treating every rationale as shareable would risk exposing internal drafting context.
+
+## What Changes
+
+- Recognize the exact rationale category `external-facing` as the sole category eligible for native Word comment materialization.
+- Add an opt-in compile configuration with explicit deterministic comment author, initials, and date.
+- Anchor each selected rationale to the smallest tracked edit range attributable to its operation, with defined behavior for insertions, deletions, replacements, and multi-paragraph edits.
+- Preserve accept-all, reject-all, and formatting projections when comments are materialized.
+- Preserve native comment records and range markers as a balanced unit through accept-all and reject-all processing, collapsing the range deterministically when its tracked anchor is removed.
+- Require independent release verification to report native comments positively when requested and to fail closed when materialization produces none.
+- Require only synthetic rationale and document fixtures in this public repository.
+
+## Impact
+
+- Affected specs: `docx-markdoc`
+- Affected code after approval: `packages/docx-markdoc` compiler/types/tests and the native-comment primitive in `packages/docx-core`, whose visible-text offset model does not currently address deleted text or cross-paragraph ranges
+- Compatibility: additive and opt-in; existing Markdoc and compile calls continue to emit no rationale comments
+- Tracking: Refs #860

--- a/openspec/changes/add-markdoc-external-rationale-comments/specs/docx-markdoc/spec.md
+++ b/openspec/changes/add-markdoc-external-rationale-comments/specs/docx-markdoc/spec.md
@@ -1,0 +1,139 @@
+## ADDED Requirements
+
+### Requirement: Only explicitly external-facing rationales become comments
+
+The system SHALL materialize rationale as a native root Word comment only when
+comment materialization is enabled and the rationale category is exactly
+`external-facing`. It SHALL NOT normalize, infer, or select an absent or other
+category, and SHALL fail before output if more than one selected rationale names
+the same operation.
+
+#### Scenario: [SDX-MDOC-34] Exact external-facing category selects one rationale
+- **GIVEN** one operation with one rationale categorized exactly `external-facing`
+- **AND** rationale-comment materialization is enabled with valid deterministic identity
+- **WHEN** the Markdoc compiles
+- **THEN** the tracked DOCX SHALL contain exactly one native root comment carrying that rationale text
+- **AND** the comment SHALL be associated with that operation's tracked edit range
+
+#### Scenario: [SDX-MDOC-35] Unclassified and other categories remain private metadata
+- **GIVEN** rationales with an absent category, an internal category, or a value resembling but not equal to `external-facing`
+- **WHEN** rationale-comment materialization is enabled
+- **THEN** none of those rationales SHALL produce a comment
+- **AND** the system SHALL NOT infer shareability from rationale text or surrounding edits
+
+#### Scenario: [SDX-MDOC-36] Duplicate selected rationales fail closed
+- **GIVEN** two `external-facing` rationales naming the same operation
+- **WHEN** compilation begins
+- **THEN** compilation SHALL fail before document mutation with a stable diagnostic
+- **AND** no partial DOCX output SHALL be returned
+
+### Requirement: Rationale comment identity is explicit and deterministic
+
+The system SHALL accept rationale-comment author, initials, and date as a
+separate nested compile configuration. Every value SHALL come from caller input,
+SHALL NOT fall back to tracked-revision identity or the process clock, and SHALL
+produce identical comment metadata and identifiers for identical inputs.
+
+#### Scenario: [SDX-MDOC-37] Caller identity controls deterministic comment metadata
+- **GIVEN** valid non-empty comment author and initials plus a valid caller-supplied date
+- **WHEN** identical source, Markdoc, and compile options are compiled twice
+- **THEN** comment author, initials, date, identifiers, anchors, and serialized comment parts SHALL be identical
+- **AND** tracked-revision author and date MAY differ without changing comment identity
+
+#### Scenario: [SDX-MDOC-38] Missing comment identity never falls back
+- **GIVEN** materialization is enabled without a valid author, initials, or date
+- **WHEN** compilation begins
+- **THEN** compilation SHALL fail before mutation with a stable identity diagnostic
+- **AND** the compiler SHALL NOT substitute tracked-revision identity, defaults, or current time
+
+### Requirement: Each rationale anchors to its attributable tracked edit
+
+The system SHALL create one contiguous native comment range per selected
+rationale using compiler-retained operation attribution. The range SHALL exclude
+unrelated leading and trailing text and adjacent operations, and compilation
+SHALL fail before output when one exact attributable range cannot be produced.
+
+#### Scenario: [SDX-MDOC-39] Insertions anchor only inserted text
+- **GIVEN** a selected rationale for an insertion operation
+- **WHEN** the tracked DOCX is materialized
+- **THEN** the comment range SHALL cover exactly the inserted text attributable to that operation
+- **AND** SHALL exclude the anchor paragraph's unchanged neighboring text
+
+#### Scenario: [SDX-MDOC-40] Deletions remain commentable in tracked output
+- **GIVEN** a selected rationale for a deletion operation
+- **WHEN** the tracked DOCX is materialized
+- **THEN** the comment range SHALL cover exactly the deleted text retained in tracked markup
+- **AND** SHALL exclude unchanged neighboring text and adjacent revisions
+
+#### Scenario: [SDX-MDOC-41] Replacements prefer generated replacement text
+- **GIVEN** a selected rationale for a replacement or inline edit that emits inserted text
+- **WHEN** the tracked DOCX is materialized
+- **THEN** the comment range SHALL cover the inserted replacement text attributable to that operation
+- **AND** SHALL exclude deleted predecessor text, unchanged context, and adjacent operations
+
+#### Scenario: [SDX-MDOC-42] Multi-paragraph operation has one bounded comment
+- **GIVEN** one selected rationale whose attributable edit spans multiple paragraphs
+- **WHEN** the tracked DOCX is materialized
+- **THEN** exactly one comment range SHALL begin at the first attributable changed character and end at the last
+- **AND** unrelated leading and trailing clause text and adjacent operations SHALL remain outside the range
+- **AND** unchanged text between the endpoints MAY be included only where required by the single contiguous range
+
+#### Scenario: [SDX-MDOC-43] Ambiguous attribution emits no output
+- **GIVEN** selected rationale whose operation has no anchorable tracked content or overlaps another operation ambiguously
+- **WHEN** compilation attempts comment materialization
+- **THEN** compilation SHALL fail before returning output with a stable anchoring diagnostic
+- **AND** the compiler SHALL NOT anchor by rationale-text search or proximity
+
+### Requirement: Native comments preserve certified projections
+
+Comment materialization SHALL NOT change accept-all text, reject-all text,
+accept-all semantic formatting, or reject-all semantic formatting. Rationale
+text SHALL remain outside every operative-text projection and comment-only
+package changes SHALL NOT weaken existing delivery certification.
+
+#### Scenario: [SDX-MDOC-44] Commented and uncommented projections are equivalent
+- **GIVEN** the same source and Markdoc compiled with and without rationale-comment materialization
+- **WHEN** both tracked outputs are accepted and rejected and their formatting projections are verified
+- **THEN** both accept-all projections SHALL equal the generated clean document in text and semantic formatting
+- **AND** both reject-all projections SHALL equal the pinned source in text and semantic formatting
+- **AND** rationale text SHALL appear in neither operative-text projection
+
+#### Scenario: [SDX-MDOC-48] Projection processing preserves comment integrity
+- **GIVEN** a rationale comment anchored to inserted, deleted, replacement, or multi-paragraph tracked content
+- **WHEN** accept-all and reject-all projections are materialized
+- **THEN** each projection SHALL retain matching comment records, range starts, range ends, and references for every surviving annotation
+- **AND** when tracked anchor text does not survive, its comment range SHALL collapse to one deterministic zero-width boundary at the edit location
+- **AND** neither projection SHALL contain mismatched or partially retained native comment components
+
+### Requirement: Release verification fails closed on absent native comments
+
+When native comments are required, independent release verification SHALL report
+a positive valid native-comment count for materialized rationales and SHALL fail
+when no selected rationale produced a comment. Existing comment-record,
+range-start, range-end, reference, multiplicity, and identifier-uniqueness checks
+SHALL continue to apply.
+
+#### Scenario: [SDX-MDOC-45] Required native comments report a positive count
+- **GIVEN** compilation materialized at least one selected rationale comment
+- **WHEN** independent verification runs with `requireNativeComments: true`
+- **THEN** native-comment verification SHALL pass with a positive count
+- **AND** every comment record, range start, range end, and reference SHALL satisfy the existing integrity checks
+
+#### Scenario: [SDX-MDOC-46] Required native comments reject zero selected output
+- **GIVEN** comment materialization produced no native comment because no rationale was selected
+- **WHEN** independent verification runs with `requireNativeComments: true`
+- **THEN** native-comment verification SHALL fail its minimum-count requirement
+- **AND** the release verdict SHALL NOT treat an empty comment set as success
+
+### Requirement: Rationale comment fixtures remain synthetic and public-safe
+
+Tests and committed artifacts for rationale comments SHALL use only synthetic
+documents, identities, and rationale text. Private matter documents, private
+rationales, and extracts from a private corpus SHALL NOT enter repository
+fixtures, snapshots, logs, or diagnostics.
+
+#### Scenario: [SDX-MDOC-47] Public tests contain no matter artifacts
+- **GIVEN** rationale-comment tests in the public repository
+- **WHEN** their fixtures, snapshots, logs, and diagnostics are reviewed
+- **THEN** every document, identity, and rationale SHALL be synthetic
+- **AND** no private corpus path, text, or matter artifact SHALL be committed

--- a/openspec/changes/add-markdoc-external-rationale-comments/tasks.md
+++ b/openspec/changes/add-markdoc-external-rationale-comments/tasks.md
@@ -1,0 +1,29 @@
+## 1. Contract and validation
+
+- [ ] 1.1 Define the exact `external-facing` rationale category and reject duplicate selected rationales for one operation.
+- [ ] 1.2 Extend compile options with an opt-in rationale-comment configuration requiring non-empty author, initials, and a valid caller-supplied date.
+- [ ] 1.3 Add stable fail-closed diagnostics for invalid identity, missing operations, ambiguous attribution, and empty anchor ranges.
+
+## 2. Comment materialization
+
+- [ ] 2.1 Retain deterministic operation-to-change attribution through tracked-document compilation.
+- [ ] 2.2 Materialize one native root comment per selected rationale using the exact rationale text and caller-supplied identity.
+- [ ] 2.3 Implement the specified insertion, deletion, replacement, and cross-paragraph anchor rules.
+- [ ] 2.4 Extend or supplement the native-comment primitive so ranges can address deleted text and cross-paragraph tracked content without mapping through visible-text offsets.
+- [ ] 2.5 Keep comment-only package mutations outside tracked operative content and preserve unchanged package parts.
+
+## 3. Verification and tests
+
+- [ ] 3.1 Add synthetic tests for selection and non-selection, including unclassified and unknown-category rationales.
+- [ ] 3.2 Add synthetic anchoring tests for insertions, deletions, replacements, and multi-paragraph operations.
+- [ ] 3.3 Prove deterministic comment author, initials, date, IDs, anchors, and serialized output for identical inputs.
+- [ ] 3.4 Prove accept-all, reject-all, and semantic formatting projection invariance.
+- [ ] 3.5 Prove comment records, range starts, range ends, and references remain balanced through accept-all and reject-all processing, with deterministic zero-width collapse when tracked anchor text is removed.
+- [ ] 3.6 Exercise `requireNativeComments: true` against positive and zero-comment outputs.
+- [ ] 3.7 Confirm all fixtures contain only synthetic document and rationale content.
+
+## 4. Delivery
+
+- [ ] 4.1 Run package-scoped build, lint, and tests while iterating.
+- [ ] 4.2 Run the full repository pre-submit gate.
+- [ ] 4.3 Update public package documentation for the opt-in compile contract.


### PR DESCRIPTION
## Summary

- add an OpenSpec proposal for opt-in native Word comments from exact `external-facing` Markdoc rationales
- resolve selection, deterministic identity, insertion/deletion/replacement/multi-paragraph anchoring, projection invariance, release-verifier interaction, and public-corpus safety
- specify balanced zero-width comment collapse when tracked anchor text is removed by accept/reject processing

## Scope and approval gate

**Proposal only, no implementation. Awaiting approval per `openspec/AGENTS.md` Stage 1.** No product code under `packages/docx-markdoc/src/` or elsewhere is changed.

Resolved design decisions:

- only the exact case-sensitive `external-facing` category is selected; unclassified and other values remain private metadata
- comment author, initials, and date are separate required caller inputs with no revision-identity or process-clock fallback
- one rationale produces one operation-attributed native comment; deleted-text and cross-paragraph ranges require extending or supplementing the existing paragraph-visible-text primitive
- accept/reject projections retain balanced comment components and collapse removed tracked anchors at a deterministic zero-width edit boundary
- the independent release verifier remains authoritative for tracked-artifact structure and minimum count; compiler package tests verify projection-collapse location
- all implementation fixtures must be synthetic and public-safe

Open questions deliberately left for review: none. Implementation must not begin until this proposal is approved.

## Validation

- `openspec validate add-markdoc-external-rationale-comments --strict`
- full required pre-submit gate passed: build, workspace lint, all workspace tests, spec coverage, conformance citations, and conformance document
- independent dynamic Claude review verified current interfaces, release-verifier behavior, scenario-ID uniqueness, and all OpenSpec changes; its projection-integrity findings were incorporated

Refs #860
