### PR TITLE
fix(docx-render-verifier): pin corpus expectations

### DIFF
--- a/packages/docx-render-verifier/private-corpus/README.md
+++ b/packages/docx-render-verifier/private-corpus/README.md
@@ -8,6 +8,14 @@ gitignored) and keep both input paths outside the Safe DOCX worktree. A fully
 local manifest outside the worktree is also accepted because it cannot be
 committed to this repository.
 
+Set `expectedMarkupTextSha256` to the expected-markup file's 64-character
+lowercase SHA-256 when the local corpus should fail closed on expectation-file
+drift. Replace the example placeholder when pinning, or delete that property
+from the copied manifest when not pinning. The field is optional so existing
+private manifests remain compatible.
+Every expectation file must contain non-whitespace text whether or not this pin
+is present.
+
 The runner rejects a manifest or output directory that Git does not ignore,
 and rejects outputs under public `fixtures/`. Its committed summary format
 contains only a caller label, SHA-256, verdict, and bounded reason—never DOCX,

--- a/packages/docx-render-verifier/private-corpus/manifest.example.json
+++ b/packages/docx-render-verifier/private-corpus/manifest.example.json
@@ -7,6 +7,7 @@
       "trackedDocxPath": "/absolute/local/matter/tracked.docx",
       "expectedMarkupTextPath": "/absolute/local/matter/expected-markup.txt",
       "expectedTrackedSha256": "replace-with-64-lowercase-hex",
+      "expectedMarkupTextSha256": "optional-replace-with-64-lowercase-hex",
       "requireRender": true
     }
   ]

--- a/packages/docx-render-verifier/src/corpus.test.ts
+++ b/packages/docx-render-verifier/src/corpus.test.ts
@@ -53,4 +53,98 @@ describe('private renderer corpus', () => {
 
     await expect(runPrivateCorpus(manifestPath)).rejects.toThrow('must not be Git-tracked');
   });
+
+  itAllure('fails empty expectations without stopping other corpus cases', async () => {
+    await mkdir(externalDir, { recursive: true });
+    const docx = path.join(externalDir, 'tracked.docx');
+    const empty = path.join(externalDir, 'empty.txt');
+    const whitespace = path.join(externalDir, 'whitespace.txt');
+    const valid = path.join(externalDir, 'valid.txt');
+    await writeFile(docx, 'private binary surrogate');
+    await writeFile(empty, '');
+    await writeFile(whitespace, ' \n\t');
+    await writeFile(valid, 'private expected markup');
+    const baseCase = {
+      trackedDocxPath: docx,
+      expectedTrackedSha256: sha256('private binary surrogate'),
+      requireRender: false,
+    };
+    await writeFile(manifestPath, JSON.stringify({
+      version: 1,
+      outputDir: `output/${testId}`,
+      cases: [
+        { ...baseCase, label: 'empty-case', expectedMarkupTextPath: empty },
+        { ...baseCase, label: 'whitespace-case', expectedMarkupTextPath: whitespace },
+        { ...baseCase, label: 'valid-case', expectedMarkupTextPath: valid },
+      ],
+    }));
+
+    const summary = await runPrivateCorpus(manifestPath);
+    expect(summary.cases).toEqual([
+      { label: 'empty-case', trackedSha256: sha256('private binary surrogate'), status: 'fail', reason: 'expected markup text is empty' },
+      { label: 'whitespace-case', trackedSha256: sha256('private binary surrogate'), status: 'fail', reason: 'expected markup text is empty' },
+      { label: 'valid-case', trackedSha256: sha256('private binary surrogate'), status: 'not_run', reason: 'renderer not required for this case' },
+    ]);
+  });
+
+  itAllure('fails an unreadable expectation without stopping other corpus cases', async () => {
+    await mkdir(externalDir, { recursive: true });
+    const docx = path.join(externalDir, 'tracked.docx');
+    const missing = path.join(externalDir, 'missing.txt');
+    const valid = path.join(externalDir, 'valid.txt');
+    await writeFile(docx, 'private binary surrogate');
+    await writeFile(valid, 'private expected markup');
+    const baseCase = {
+      trackedDocxPath: docx,
+      expectedTrackedSha256: sha256('private binary surrogate'),
+      requireRender: false,
+    };
+    await writeFile(manifestPath, JSON.stringify({
+      version: 1,
+      outputDir: `output/${testId}`,
+      cases: [
+        { ...baseCase, label: 'missing-case', expectedMarkupTextPath: missing },
+        { ...baseCase, label: 'valid-case', expectedMarkupTextPath: valid },
+      ],
+    }));
+
+    const summary = await runPrivateCorpus(manifestPath);
+    expect(summary.cases).toEqual([
+      { label: 'missing-case', trackedSha256: sha256('private binary surrogate'), status: 'fail', reason: 'expected markup text unreadable' },
+      { label: 'valid-case', trackedSha256: sha256('private binary surrogate'), status: 'not_run', reason: 'renderer not required for this case' },
+    ]);
+    expect(await readFile(path.join(outputDir, 'summary.json'), 'utf8')).not.toContain(missing);
+  });
+
+  itAllure('checks an optional expectation hash without exposing expectation text', async () => {
+    await mkdir(externalDir, { recursive: true });
+    const docx = path.join(externalDir, 'tracked.docx');
+    const expected = path.join(externalDir, 'expected.txt');
+    const expectedText = 'private expectation that must stay out of the summary';
+    await writeFile(docx, 'private binary surrogate');
+    await writeFile(expected, expectedText);
+    const baseCase = {
+      trackedDocxPath: docx,
+      expectedMarkupTextPath: expected,
+      expectedTrackedSha256: sha256('private binary surrogate'),
+      requireRender: false,
+    };
+    await writeFile(manifestPath, JSON.stringify({
+      version: 1,
+      outputDir: `output/${testId}`,
+      cases: [
+        { ...baseCase, label: 'matching-pin', expectedMarkupTextSha256: sha256(expectedText) },
+        { ...baseCase, label: 'mismatched-pin', expectedMarkupTextSha256: '0'.repeat(64) },
+        { ...baseCase, label: 'no-pin' },
+      ],
+    }));
+
+    const summary = await runPrivateCorpus(manifestPath);
+    expect(summary.cases).toEqual([
+      { label: 'matching-pin', trackedSha256: sha256('private binary surrogate'), status: 'not_run', reason: 'renderer not required for this case' },
+      { label: 'mismatched-pin', trackedSha256: sha256('private binary surrogate'), status: 'fail', reason: 'expected markup text SHA-256 mismatch' },
+      { label: 'no-pin', trackedSha256: sha256('private binary surrogate'), status: 'not_run', reason: 'renderer not required for this case' },
+    ]);
+    expect(await readFile(path.join(outputDir, 'summary.json'), 'utf8')).not.toContain(expectedText);
+  });
 });

--- a/packages/docx-render-verifier/src/corpus.ts
+++ b/packages/docx-render-verifier/src/corpus.ts
@@ -68,11 +68,26 @@ export async function runPrivateCorpus(manifestPath: string, tools?: RendererToo
       cases.push({ label: entry.label, trackedSha256, status: 'fail', reason: 'tracked SHA-256 mismatch' });
       continue;
     }
+    let expectedMarkupTextBytes: Buffer;
+    try {
+      expectedMarkupTextBytes = await readFile(expectedMarkupTextPath);
+    } catch {
+      cases.push({ label: entry.label, trackedSha256, status: 'fail', reason: 'expected markup text unreadable' });
+      continue;
+    }
+    const expectedMarkupText = expectedMarkupTextBytes.toString('utf8');
+    if (expectedMarkupText.trim().length === 0) {
+      cases.push({ label: entry.label, trackedSha256, status: 'fail', reason: 'expected markup text is empty' });
+      continue;
+    }
+    if (entry.expectedMarkupTextSha256 !== undefined && sha256(expectedMarkupTextBytes) !== entry.expectedMarkupTextSha256) {
+      cases.push({ label: entry.label, trackedSha256, status: 'fail', reason: 'expected markup text SHA-256 mismatch' });
+      continue;
+    }
     if (!entry.requireRender) {
       cases.push({ label: entry.label, trackedSha256, status: 'not_run', reason: 'renderer not required for this case' });
       continue;
     }
-    const expectedMarkupText = await readFile(expectedMarkupTextPath, 'utf8');
     const result = await verifyRenderedMarkup({ trackedDocxPath, expectedMarkupText, outputDir: path.join(outputDir, sha256(Buffer.from(entry.label)).slice(0, 16)), tools });
     // Tool output can contain local paths or document text. Persist only this
     // bounded category so a corpus summary remains safely non-substantive.

--- a/packages/docx-render-verifier/src/types.ts
+++ b/packages/docx-render-verifier/src/types.ts
@@ -119,6 +119,7 @@ export type PrivateCorpusCase = {
   trackedDocxPath: string;
   expectedMarkupTextPath: string;
   expectedTrackedSha256: string;
+  expectedMarkupTextSha256?: string;
   requireRender: boolean;
 };
 


### PR DESCRIPTION
## Summary

- reject unreadable, empty, and whitespace-only expected-markup files as bounded case-level failures
- optionally pin the expected-markup file by raw-byte SHA-256 while preserving manifests that omit the pin
- document the optional pin and keep summary output limited to labels, tracked hashes, statuses, and bounded literal reasons

## Why

The private corpus already pins its tracked DOCX but previously trusted the separate untracked expectation file without a hash or non-empty guard. Local truncation or drift could therefore weaken the corpus gate without leaving any tracked evidence.

This does **not** close #865 and does not resolve the public `render.ts` empty-projection policy question. `render.ts`, `RenderRequest`, and matcher semantics are unchanged. #865 should remain open for the repository owner's `allowEmptyMarkupText` / empty-projection contract decision.

## Validation

- full required pre-submit gate passed: build, workspace lint, all workspace tests, spec coverage, conformance citations, and conformance document
- focused renderer-verifier suite: 56 tests passed
- independent dynamic Claude review executed the focused and full package suites, confirmed `render.ts` byte-identical, and verified no expectation text or local path reaches `summary.json`
- review fixes incorporated: bounded unreadable-expectation handling and discoverable optional-pin documentation

Refs #865
