### PR TITLE
feat(docx-markdoc): materialize external rationale comments

### DIFF
--- a/openspec/changes/add-markdoc-external-rationale-comments/tasks.md
+++ b/openspec/changes/add-markdoc-external-rationale-comments/tasks.md
@@ -1,29 +1,29 @@
 ## 1. Contract and validation
 
-- [ ] 1.1 Define the exact `external-facing` rationale category and reject duplicate selected rationales for one operation.
-- [ ] 1.2 Extend compile options with an opt-in rationale-comment configuration requiring non-empty author, initials, and a valid caller-supplied date.
-- [ ] 1.3 Add stable fail-closed diagnostics for invalid identity, missing operations, ambiguous attribution, and empty anchor ranges.
+- [x] 1.1 Define the exact `external-facing` rationale category and reject duplicate selected rationales for one operation.
+- [x] 1.2 Extend compile options with an opt-in rationale-comment configuration requiring non-empty author, initials, and a valid caller-supplied date.
+- [x] 1.3 Add stable fail-closed diagnostics for invalid identity, missing operations, ambiguous attribution, and empty anchor ranges.
 
 ## 2. Comment materialization
 
-- [ ] 2.1 Retain deterministic operation-to-change attribution through tracked-document compilation.
-- [ ] 2.2 Materialize one native root comment per selected rationale using the exact rationale text and caller-supplied identity.
-- [ ] 2.3 Implement the specified insertion, deletion, replacement, and cross-paragraph anchor rules.
-- [ ] 2.4 Extend or supplement the native-comment primitive so ranges can address deleted text and cross-paragraph tracked content without mapping through visible-text offsets.
-- [ ] 2.5 Keep comment-only package mutations outside tracked operative content and preserve unchanged package parts.
+- [x] 2.1 Retain deterministic operation-to-change attribution through tracked-document compilation.
+- [x] 2.2 Materialize one native root comment per selected rationale using the exact rationale text and caller-supplied identity.
+- [x] 2.3 Implement the specified insertion, deletion, replacement, and cross-paragraph anchor rules.
+- [x] 2.4 Extend or supplement the native-comment primitive so ranges can address deleted text and cross-paragraph tracked content without mapping through visible-text offsets.
+- [x] 2.5 Keep comment-only package mutations outside tracked operative content and preserve unchanged package parts.
 
 ## 3. Verification and tests
 
-- [ ] 3.1 Add synthetic tests for selection and non-selection, including unclassified and unknown-category rationales.
-- [ ] 3.2 Add synthetic anchoring tests for insertions, deletions, replacements, and multi-paragraph operations.
-- [ ] 3.3 Prove deterministic comment author, initials, date, IDs, anchors, and serialized output for identical inputs.
-- [ ] 3.4 Prove accept-all, reject-all, and semantic formatting projection invariance.
-- [ ] 3.5 Prove comment records, range starts, range ends, and references remain balanced through accept-all and reject-all processing, with deterministic zero-width collapse when tracked anchor text is removed.
-- [ ] 3.6 Exercise `requireNativeComments: true` against positive and zero-comment outputs.
-- [ ] 3.7 Confirm all fixtures contain only synthetic document and rationale content.
+- [x] 3.1 Add synthetic tests for selection and non-selection, including unclassified and unknown-category rationales.
+- [x] 3.2 Add synthetic anchoring tests for insertions, deletions, replacements, and multi-paragraph operations.
+- [x] 3.3 Prove deterministic comment author, initials, date, IDs, anchors, and serialized output for identical inputs.
+- [x] 3.4 Prove accept-all, reject-all, and semantic formatting projection invariance.
+- [x] 3.5 Prove comment records, range starts, range ends, and references remain balanced through accept-all and reject-all processing, with deterministic zero-width collapse when tracked anchor text is removed.
+- [x] 3.6 Exercise `requireNativeComments: true` against positive and zero-comment outputs.
+- [x] 3.7 Confirm all fixtures contain only synthetic document and rationale content.
 
 ## 4. Delivery
 
-- [ ] 4.1 Run package-scoped build, lint, and tests while iterating.
-- [ ] 4.2 Run the full repository pre-submit gate.
-- [ ] 4.3 Update public package documentation for the opt-in compile contract.
+- [x] 4.1 Run package-scoped build, lint, and tests while iterating.
+- [x] 4.2 Run the full repository pre-submit gate.
+- [x] 4.3 Update public package documentation for the opt-in compile contract.

--- a/packages/docx-core/src/primitives/comments.ts
+++ b/packages/docx-core/src/primitives/comments.ts
@@ -204,12 +204,19 @@ export type AddCommentResult = {
 };
 
 export type AddTrackedRangeCommentParams = {
-  startSentinel: string;
-  endSentinel: string;
+  startRevision: TrackedRevisionLocator;
+  endRevision: TrackedRevisionLocator;
   author: string;
   initials: string;
   date: string;
   text: string;
+};
+
+export type TrackedRevisionType = 'ins' | 'del' | 'moveFrom' | 'moveTo';
+
+export type TrackedRevisionLocator = {
+  type: TrackedRevisionType;
+  id: string;
 };
 
 function deterministicParaId(params: AddTrackedRangeCommentParams, commentId: number): string {
@@ -220,35 +227,13 @@ function deterministicParaId(params: AddTrackedRangeCommentParams, commentId: nu
     .toUpperCase();
 }
 
-function nearestRevisionContainer(node: Node): Element | null {
-  let current: Node | null = node.parentNode;
-  while (current) {
-    const element = current.nodeType === 1 ? current as Element : null;
-    if (element && (
-      isW(element, 'ins') || isW(element, 'del') || isW(element, 'moveFrom') || isW(element, 'moveTo')
-    )) return element;
-    current = current.parentNode;
-  }
-  return null;
-}
-
-function findUniqueSentinel(documentXml: Document, sentinel: string): { text: Text; revision: Element } {
-  const matches: Text[] = [];
-  const visit = (node: Node): void => {
-    if (node.nodeType === 3 && (node.nodeValue ?? '').includes(sentinel)) matches.push(node as Text);
-    for (let child = node.firstChild; child; child = child.nextSibling) visit(child);
-  };
-  visit(documentXml.documentElement);
+function findUniqueRevision(documentXml: Document, locator: TrackedRevisionLocator): Element {
+  const matches = Array.from(documentXml.getElementsByTagNameNS(OOXML.W_NS, locator.type))
+    .filter((element) => getAttributeSafe(element, OOXML.W_NS, 'id', 'w', { bareFallback: false }) === locator.id);
   if (matches.length !== 1) {
-    throw new Error(`Tracked comment sentinel must occur exactly once; found ${matches.length}.`);
+    throw new Error(`Tracked revision ${locator.type}#${locator.id} must occur exactly once; found ${matches.length}.`);
   }
-  const revision = nearestRevisionContainer(matches[0]!);
-  if (!revision) throw new Error('Tracked comment sentinel is not inside attributable revision markup.');
-  return { text: matches[0]!, revision };
-}
-
-function removeSentinel(node: Text, sentinel: string): void {
-  node.data = node.data.replace(sentinel, '');
+  return matches[0]!;
 }
 
 function createCommentReference(documentXml: Document, commentId: number): Element {
@@ -265,10 +250,10 @@ function createCommentReference(documentXml: Document, commentId: number): Eleme
 }
 
 /**
- * Materialize root comments around compiler-owned sentinels inside tracked
- * revision markup. Markers are placed immediately outside the attributable
- * revision containers so accept/reject keeps a balanced annotation and
- * naturally collapses it when that revision's text is removed.
+ * Materialize root comments around an OOXML tracked-revision range. Markers
+ * are placed immediately outside the identified revision containers so
+ * accept/reject keeps a balanced annotation and naturally collapses it when
+ * that revision's text is removed.
  *
  * @conformance ECMA-376 edition 5, Part 1 § 17.13.4.2
  * @see https://github.com/UseJunior/safe-docx/issues/860
@@ -284,29 +269,21 @@ export async function addTrackedRangeComments(
   const commentsDoc = parseXml(await zip.readText('word/comments.xml'));
 
   for (const params of comments) {
-    const start = findUniqueSentinel(documentXml, params.startSentinel);
-    const end = findUniqueSentinel(documentXml, params.endSentinel);
-    const startParent = start.revision.parentNode;
-    const endParent = end.revision.parentNode;
+    const startRevision = findUniqueRevision(documentXml, params.startRevision);
+    const endRevision = findUniqueRevision(documentXml, params.endRevision);
+    const startParent = startRevision.parentNode;
+    const endParent = endRevision.parentNode;
     if (!startParent || !endParent) throw new Error('Attributed revision container has no parent.');
-    const attributableXml = start.revision === end.revision
-      ? start.revision.textContent ?? ''
-      : `${start.revision.textContent ?? ''}${end.revision.textContent ?? ''}`;
-    const otherSentinel = attributableXml.match(/\uE000safe-docx-rationale-\d+-(?:start|end)\uE001/gu)
-      ?.some((sentinel) => sentinel !== params.startSentinel && sentinel !== params.endSentinel);
-    if (otherSentinel) throw new Error('Tracked comment attribution overlaps another operation revision.');
 
     const commentId = allocateNextCommentId(commentsDoc);
     const rangeStart = documentXml.createElementNS(OOXML.W_NS, 'w:commentRangeStart');
     rangeStart.setAttribute('w:id', String(commentId));
     const rangeEnd = documentXml.createElementNS(OOXML.W_NS, 'w:commentRangeEnd');
     rangeEnd.setAttribute('w:id', String(commentId));
-    startParent.insertBefore(rangeStart, start.revision);
-    endParent.insertBefore(rangeEnd, end.revision.nextSibling);
+    startParent.insertBefore(rangeStart, startRevision);
+    endParent.insertBefore(rangeEnd, endRevision.nextSibling);
     endParent.insertBefore(createCommentReference(documentXml, commentId), rangeEnd.nextSibling);
 
-    removeSentinel(start.text, params.startSentinel);
-    removeSentinel(end.text, params.endSentinel);
     addCommentElement(commentsDoc, {
       id: commentId,
       author: params.author,

--- a/packages/docx-core/src/primitives/comments.ts
+++ b/packages/docx-core/src/primitives/comments.ts
@@ -5,6 +5,7 @@
  * and supports threaded replies via commentsExtended.xml.
  */
 
+import { createHash } from 'node:crypto';
 import { OOXML, W } from './namespaces.js';
 import { parseXml, serializeXml } from './xml.js';
 import { DocxZip } from './zip.js';
@@ -201,6 +202,126 @@ export type AddCommentParams = {
 export type AddCommentResult = {
   commentId: number;
 };
+
+export type AddTrackedRangeCommentParams = {
+  startSentinel: string;
+  endSentinel: string;
+  author: string;
+  initials: string;
+  date: string;
+  text: string;
+};
+
+function deterministicParaId(params: AddTrackedRangeCommentParams, commentId: number): string {
+  return createHash('sha256')
+    .update(`${commentId}\0${params.author}\0${params.initials}\0${params.date}\0${params.text}`)
+    .digest('hex')
+    .slice(0, 8)
+    .toUpperCase();
+}
+
+function nearestRevisionContainer(node: Node): Element | null {
+  let current: Node | null = node.parentNode;
+  while (current) {
+    const element = current.nodeType === 1 ? current as Element : null;
+    if (element && (
+      isW(element, 'ins') || isW(element, 'del') || isW(element, 'moveFrom') || isW(element, 'moveTo')
+    )) return element;
+    current = current.parentNode;
+  }
+  return null;
+}
+
+function findUniqueSentinel(documentXml: Document, sentinel: string): { text: Text; revision: Element } {
+  const matches: Text[] = [];
+  const visit = (node: Node): void => {
+    if (node.nodeType === 3 && (node.nodeValue ?? '').includes(sentinel)) matches.push(node as Text);
+    for (let child = node.firstChild; child; child = child.nextSibling) visit(child);
+  };
+  visit(documentXml.documentElement);
+  if (matches.length !== 1) {
+    throw new Error(`Tracked comment sentinel must occur exactly once; found ${matches.length}.`);
+  }
+  const revision = nearestRevisionContainer(matches[0]!);
+  if (!revision) throw new Error('Tracked comment sentinel is not inside attributable revision markup.');
+  return { text: matches[0]!, revision };
+}
+
+function removeSentinel(node: Text, sentinel: string): void {
+  node.data = node.data.replace(sentinel, '');
+}
+
+function createCommentReference(documentXml: Document, commentId: number): Element {
+  const refRun = documentXml.createElementNS(OOXML.W_NS, 'w:r');
+  const rPr = documentXml.createElementNS(OOXML.W_NS, 'w:rPr');
+  const rStyle = documentXml.createElementNS(OOXML.W_NS, 'w:rStyle');
+  rStyle.setAttribute('w:val', 'CommentReference');
+  rPr.appendChild(rStyle);
+  refRun.appendChild(rPr);
+  const reference = documentXml.createElementNS(OOXML.W_NS, 'w:commentReference');
+  reference.setAttribute('w:id', String(commentId));
+  refRun.appendChild(reference);
+  return refRun;
+}
+
+/**
+ * Materialize root comments around compiler-owned sentinels inside tracked
+ * revision markup. Markers are placed immediately outside the attributable
+ * revision containers so accept/reject keeps a balanced annotation and
+ * naturally collapses it when that revision's text is removed.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.4.2
+ * @see https://github.com/UseJunior/safe-docx/issues/860
+ */
+export async function addTrackedRangeComments(
+  buffer: Buffer,
+  comments: AddTrackedRangeCommentParams[],
+): Promise<Buffer> {
+  if (comments.length === 0) return buffer;
+  const zip = await DocxZip.load(buffer);
+  await bootstrapCommentParts(zip);
+  const documentXml = parseXml(await zip.readText('word/document.xml'));
+  const commentsDoc = parseXml(await zip.readText('word/comments.xml'));
+
+  for (const params of comments) {
+    const start = findUniqueSentinel(documentXml, params.startSentinel);
+    const end = findUniqueSentinel(documentXml, params.endSentinel);
+    const startParent = start.revision.parentNode;
+    const endParent = end.revision.parentNode;
+    if (!startParent || !endParent) throw new Error('Attributed revision container has no parent.');
+    const attributableXml = start.revision === end.revision
+      ? start.revision.textContent ?? ''
+      : `${start.revision.textContent ?? ''}${end.revision.textContent ?? ''}`;
+    const otherSentinel = attributableXml.match(/\uE000safe-docx-rationale-\d+-(?:start|end)\uE001/gu)
+      ?.some((sentinel) => sentinel !== params.startSentinel && sentinel !== params.endSentinel);
+    if (otherSentinel) throw new Error('Tracked comment attribution overlaps another operation revision.');
+
+    const commentId = allocateNextCommentId(commentsDoc);
+    const rangeStart = documentXml.createElementNS(OOXML.W_NS, 'w:commentRangeStart');
+    rangeStart.setAttribute('w:id', String(commentId));
+    const rangeEnd = documentXml.createElementNS(OOXML.W_NS, 'w:commentRangeEnd');
+    rangeEnd.setAttribute('w:id', String(commentId));
+    startParent.insertBefore(rangeStart, start.revision);
+    endParent.insertBefore(rangeEnd, end.revision.nextSibling);
+    endParent.insertBefore(createCommentReference(documentXml, commentId), rangeEnd.nextSibling);
+
+    removeSentinel(start.text, params.startSentinel);
+    removeSentinel(end.text, params.endSentinel);
+    addCommentElement(commentsDoc, {
+      id: commentId,
+      author: params.author,
+      initials: params.initials,
+      text: params.text,
+      paraId: deterministicParaId(params, commentId),
+      date: params.date,
+    });
+    await ensureAuthorInPeople(zip, params.author);
+  }
+
+  zip.writeText('word/document.xml', serializeXml(documentXml));
+  zip.writeText('word/comments.xml', serializeXml(commentsDoc));
+  return zip.toBuffer();
+}
 
 /**
  * Insert a root comment anchored to a text range within a paragraph.

--- a/packages/docx-markdoc/README.md
+++ b/packages/docx-markdoc/README.md
@@ -26,6 +26,42 @@ comparison engine. It then proves reject-all equals source and accept-all equals
 clean. Inline `ins`/`del` is available only as generated display/export syntax;
 models and lawyers author familiar complete sentences.
 
+## External-facing rationale comments
+
+Rationales remain passive metadata unless compilation explicitly enables
+native comments. Only the exact, case-sensitive category `external-facing` is
+eligible; absent, internal, misspelled, or differently cased categories are
+never inferred to be shareable.
+
+```markdoc
+{% rationale for="rename" category="external-facing" %}
+The revised name matches the synthetic review record.
+{% /rationale %}
+```
+
+Supply comment identity separately from tracked-revision identity. All three
+values are required and the compiler never substitutes the revision author,
+revision date, initials, or current time:
+
+```ts
+const result = await compileMarkdoc(source, markdoc, {
+  author: 'Revision Author',
+  date: new Date('2026-08-16T14:30:00.000Z'),
+  rationaleComments: {
+    author: 'External Reviewer',
+    initials: 'ER',
+    date: new Date('2026-08-16T14:30:00.000Z'),
+  },
+});
+```
+
+Each selected rationale becomes one native root Word comment around the
+tracked edit attributable to its operation. Insertions and replacements prefer
+inserted text; deletion-only edits remain anchored to deleted tracked markup;
+multi-paragraph edits receive one bounded range. Accept-all and reject-all keep
+the comment components balanced, collapsing the range at the edit boundary
+when its tracked anchor disappears.
+
 ## Delivery completeness
 
 Exact DOCX replay and drafting completeness are separate claims. A required

--- a/packages/docx-markdoc/README.md
+++ b/packages/docx-markdoc/README.md
@@ -2,6 +2,9 @@
 
 Brownfield DOCX authoring as readable clean document states over a hash-pinned
 Word source. The redline is deterministic derived output, not canonical input.
+This package is an experimental compiler and conversion surface; its Markdoc
+syntax and transient comparison-attribution machinery are intentionally kept
+out of the general-purpose `@usejunior/docx-core` package.
 
 ```markdoc
 {% source sha256="..." paragraphs=2 /%}

--- a/packages/docx-markdoc/src/compile.ts
+++ b/packages/docx-markdoc/src/compile.ts
@@ -1,6 +1,7 @@
 import JSZip from 'jszip';
 import {
   DocxDocument,
+  addTrackedRangeComments,
   computeContentFingerprint,
   getParagraphRuns,
   type ReplacementPart,
@@ -12,6 +13,7 @@ import { requireMarkdoc } from './markdoc.js';
 import { assessDraftCompleteness } from './completeness.js';
 import type {
   CompileResult,
+  CompileOptions,
   EditOperation,
   FormattingProjectionDiagnostic,
   FormattingProjectionReport,
@@ -505,8 +507,18 @@ function validateAgainstSource(ir: MarkdocEditIR, source: DocxDocument): { unsup
   return { unsupported: [...unsupported].sort() };
 }
 
-async function applyOperations(sourceBuffer: Buffer, ir: MarkdocEditIR): Promise<Buffer> {
+type AttributedRange = {
+  operationId: string;
+  projection: 'source' | 'clean';
+  startParagraphId: string;
+  start: number;
+  endParagraphId: string;
+  end: number;
+};
+
+async function applyOperations(sourceBuffer: Buffer, ir: MarkdocEditIR): Promise<{ buffer: Buffer; ranges: AttributedRange[] }> {
   const document = await DocxDocument.load(sourceBuffer);
+  const ranges: AttributedRange[] = [];
   for (const operation of ir.operations) {
     if (isInsertOperation(operation)) {
       const runStyleSourceText = insertionFormatSource(document, operation);
@@ -517,6 +529,15 @@ async function applyOperations(sourceBuffer: Buffer, ir: MarkdocEditIR): Promise
         newText: operation.revisedText,
         styleSourceId: operation.styleSourceId,
         runStyleSourceText,
+      });
+      const insertedTexts = operation.revisedText.replace(/\r\n/gu, '\n').split(/\n{2,}/u);
+      ranges.push({
+        operationId: operation.operationId,
+        projection: 'clean',
+        startParagraphId: inserted.newParagraphIds[0]!,
+        start: 0,
+        endParagraphId: inserted.newParagraphIds.at(-1)!,
+        end: insertedTexts.at(-1)!.length,
       });
       if (templateRun) {
         document.replaceTextAtRange({
@@ -537,9 +558,38 @@ async function applyOperations(sourceBuffer: Buffer, ir: MarkdocEditIR): Promise
     const original = document.getParagraphTextById(operation.id);
     if (original === null) throw new DocxMarkdocError('MISSING_ANCHOR', `Paragraph ${operation.id} was not found.`);
     if (operation.kind === 'delete-source') {
+      ranges.push({
+        operationId: operation.operationId,
+        projection: 'source',
+        startParagraphId: operation.id,
+        start: 0,
+        endParagraphId: operation.id,
+        end: original.length,
+      });
       const paragraph = document.getParagraphElementById(operation.id);
       paragraph?.parentNode?.removeChild(paragraph);
       continue;
+    }
+    const operationHunks = textHunks(original, operation.revisedText);
+    const generated = operationHunks.filter((hunk) => hunk.replacement.length > 0);
+    if (generated.length > 0) {
+      ranges.push({
+        operationId: operation.operationId,
+        projection: 'clean',
+        startParagraphId: operation.id,
+        start: generated[0]!.revisedStart,
+        endParagraphId: operation.id,
+        end: generated.at(-1)!.revisedEnd,
+      });
+    } else if (operationHunks.length > 0) {
+      ranges.push({
+        operationId: operation.operationId,
+        projection: 'source',
+        startParagraphId: operation.id,
+        start: operationHunks[0]!.start,
+        endParagraphId: operation.id,
+        end: operationHunks.at(-1)!.end,
+      });
     }
     replacePreservingMixedFormatting(
       document,
@@ -551,15 +601,91 @@ async function applyOperations(sourceBuffer: Buffer, ir: MarkdocEditIR): Promise
       operation.runFormatSpans,
     );
   }
+  return { buffer: (await document.toBuffer({ cleanBookmarks: false })).buffer, ranges };
+}
+
+type RationaleMaterialization = {
+  range: AttributedRange;
+  startSentinel: string;
+  endSentinel: string;
+  text: string;
+};
+
+function validateRationaleCommentOptions(options: CompileOptions, ir: MarkdocEditIR): RationaleMaterialization[] {
+  if (!options.rationaleComments) return [];
+  const { author, initials, date } = options.rationaleComments;
+  if (typeof author !== 'string' || author.trim().length === 0
+    || typeof initials !== 'string' || initials.trim().length === 0
+    || !(date instanceof Date) || !Number.isFinite(date.getTime())) {
+    throw new DocxMarkdocError(
+      'INVALID_RATIONALE_COMMENT_IDENTITY',
+      'Rationale comment author, initials, and date must be supplied explicitly and be valid.',
+    );
+  }
+  const selected = ir.rationales.filter((rationale) => rationale.category === 'external-facing');
+  const seen = new Set<string>();
+  for (const rationale of selected) {
+    if (seen.has(rationale.operationId)) {
+      throw new DocxMarkdocError(
+        'DUPLICATE_EXTERNAL_RATIONALE',
+        `Operation ${rationale.operationId} has more than one external-facing rationale.`,
+      );
+    }
+    seen.add(rationale.operationId);
+  }
+  return selected.map((rationale, index) => ({
+    range: { operationId: rationale.operationId } as AttributedRange,
+    startSentinel: `\u{E000}safe-docx-rationale-${index}-start\u{E001}`,
+    endSentinel: `\u{E000}safe-docx-rationale-${index}-end\u{E001}`,
+    text: rationale.text,
+  }));
+}
+
+async function instrumentRanges(buffer: Buffer, materializations: RationaleMaterialization[]): Promise<Buffer> {
+  const document = await DocxDocument.load(buffer);
+  for (const item of [...materializations].reverse()) {
+    const { range } = item;
+    if (range.startParagraphId === range.endParagraphId) {
+      const paragraphText = document.getParagraphTextById(range.startParagraphId);
+      if (paragraphText === null || range.start >= range.end || range.end > paragraphText.length) {
+        throw new DocxMarkdocError('RATIONALE_ANCHOR_UNAVAILABLE', `Operation ${range.operationId} has no anchorable tracked content.`);
+      }
+      document.replaceTextAtRange({
+        targetParagraphId: range.startParagraphId,
+        start: range.start,
+        end: range.end,
+        replaceText: `${item.startSentinel}${paragraphText.slice(range.start, range.end)}${item.endSentinel}`,
+      });
+      continue;
+    }
+    const startText = document.getParagraphTextById(range.startParagraphId);
+    const endText = document.getParagraphTextById(range.endParagraphId);
+    if (startText === null || endText === null || range.start > startText.length || range.end <= 0 || range.end > endText.length) {
+      throw new DocxMarkdocError('RATIONALE_ANCHOR_UNAVAILABLE', `Operation ${range.operationId} has no anchorable tracked content.`);
+    }
+    document.replaceTextAtRange({
+      targetParagraphId: range.endParagraphId,
+      start: range.end,
+      end: range.end,
+      replaceText: item.endSentinel,
+    });
+    document.replaceTextAtRange({
+      targetParagraphId: range.startParagraphId,
+      start: range.start,
+      end: range.start,
+      replaceText: item.startSentinel,
+    });
+  }
   return (await document.toBuffer({ cleanBookmarks: false })).buffer;
 }
 
 export async function compileMarkdoc(
   sourceBuffer: Buffer,
   markdoc: string,
-  options: { author?: string; date?: Date } = {},
+  options: CompileOptions = {},
 ): Promise<CompileResult> {
   const ir = requireMarkdoc(markdoc);
+  const materializations = validateRationaleCommentOptions(options, ir);
   const sourceHashMatches = sha256(sourceBuffer) === ir.source.sha256;
   if (!sourceHashMatches) throw new DocxMarkdocError('SOURCE_HASH_DRIFT', 'Source DOCX hash does not match canonical Markdoc.');
   const sourceZip = await JSZip.loadAsync(sourceBuffer);
@@ -580,8 +706,21 @@ export async function compileMarkdoc(
       { changeSets: incompleteAtomicSets },
     );
   }
-  const clean = await applyOperations(sourceBuffer, ir);
-  const comparison = await compareDocuments(sourceBuffer, clean, {
+  const applied = await applyOperations(sourceBuffer, ir);
+  const clean = applied.buffer;
+  const rangesByOperation = new Map(applied.ranges.map((range) => [range.operationId, range]));
+  for (const item of materializations) {
+    const range = rangesByOperation.get(item.range.operationId);
+    if (!range) throw new DocxMarkdocError('RATIONALE_ANCHOR_UNAVAILABLE', `Operation ${item.range.operationId} has no attributable edit range.`);
+    item.range = range;
+  }
+  const sourceMaterializations = materializations.filter((item) => item.range.projection === 'source');
+  const cleanMaterializations = materializations.filter((item) => item.range.projection === 'clean');
+  const [comparisonSource, comparisonClean] = await Promise.all([
+    instrumentRanges(sourceBuffer, sourceMaterializations),
+    instrumentRanges(clean, cleanMaterializations),
+  ]);
+  const comparison = await compareDocuments(comparisonSource, comparisonClean, {
     engine: 'atomizer',
     author: options.author ?? 'Markdoc',
     date: options.date,
@@ -593,7 +732,26 @@ export async function compileMarkdoc(
     // minimality outranks "confetti" readability for authored redlines.
     // See https://github.com/UseJunior/safe-docx/issues/846.
   });
-  const tracked = comparison.document;
+  let tracked = comparison.document;
+  if (materializations.length > 0) {
+    const identity = options.rationaleComments!;
+    try {
+      tracked = await addTrackedRangeComments(tracked, materializations.map((item) => ({
+        startSentinel: item.startSentinel,
+        endSentinel: item.endSentinel,
+        author: identity.author,
+        initials: identity.initials,
+        date: identity.date.toISOString(),
+        text: item.text,
+      })));
+    } catch (error) {
+      throw new DocxMarkdocError(
+        'RATIONALE_ANCHOR_AMBIGUOUS',
+        'Selected rationale could not be mapped to one exact tracked edit range.',
+        { cause: (error as Error).message },
+      );
+    }
+  }
   const acceptedDoc = await DocxDocument.load(tracked);
   const rejectedDoc = await DocxDocument.load(tracked);
   await acceptedDoc.acceptChanges();

--- a/packages/docx-markdoc/src/compile.ts
+++ b/packages/docx-markdoc/src/compile.ts
@@ -4,7 +4,12 @@ import {
   addTrackedRangeComments,
   computeContentFingerprint,
   getParagraphRuns,
+  getAttributeSafe,
+  OOXML,
+  parseXml,
+  serializeXml,
   type ReplacementPart,
+  type TrackedRevisionLocator,
 } from '@usejunior/docx-core';
 import { compareDocuments, compareFormattingFidelity, type FormattingFidelityReport } from '@usejunior/docx-compare';
 import { DocxMarkdocError } from './errors.js';
@@ -679,6 +684,73 @@ async function instrumentRanges(buffer: Buffer, materializations: RationaleMater
   return (await document.toBuffer({ cleanBookmarks: false })).buffer;
 }
 
+type ResolvedRationaleComment = {
+  startRevision: TrackedRevisionLocator;
+  endRevision: TrackedRevisionLocator;
+  text: string;
+};
+
+function nearestRevision(node: Node): Element | null {
+  let current: Node | null = node.parentNode;
+  while (current) {
+    const element = current.nodeType === 1 ? current as Element : null;
+    if (element && ['ins', 'del', 'moveFrom', 'moveTo'].includes(element.localName)) return element;
+    current = current.parentNode;
+  }
+  return null;
+}
+
+function resolveSentinel(documentXml: Document, sentinel: string): { textNode: Text; revision: Element } {
+  const matches: Text[] = [];
+  const visit = (node: Node): void => {
+    if (node.nodeType === 3 && (node.nodeValue ?? '').includes(sentinel)) matches.push(node as Text);
+    for (let child = node.firstChild; child; child = child.nextSibling) visit(child);
+  };
+  visit(documentXml.documentElement);
+  if (matches.length !== 1) throw new Error(`Private attribution marker must occur exactly once; found ${matches.length}.`);
+  const revision = nearestRevision(matches[0]!);
+  if (!revision) throw new Error('Private attribution marker is not inside tracked revision markup.');
+  return { textNode: matches[0]!, revision };
+}
+
+function revisionLocator(revision: Element): TrackedRevisionLocator {
+  const id = getAttributeSafe(revision, OOXML.W_NS, 'id', 'w', { bareFallback: false });
+  if (!id || !['ins', 'del', 'moveFrom', 'moveTo'].includes(revision.localName)) {
+    throw new Error('Attributed tracked revision has no stable OOXML identity.');
+  }
+  return { type: revision.localName as TrackedRevisionLocator['type'], id };
+}
+
+async function resolveAndRemoveAttributionMarkers(
+  buffer: Buffer,
+  materializations: RationaleMaterialization[],
+): Promise<{ buffer: Buffer; comments: ResolvedRationaleComment[] }> {
+  const zip = await JSZip.loadAsync(buffer);
+  const file = zip.file('word/document.xml');
+  if (!file) throw new Error('Tracked DOCX has no word/document.xml.');
+  const documentXml = parseXml(await file.async('string'));
+  const comments = materializations.map((item) => {
+    const start = resolveSentinel(documentXml, item.startSentinel);
+    const end = resolveSentinel(documentXml, item.endSentinel);
+    const attributableText = start.revision === end.revision
+      ? start.revision.textContent ?? ''
+      : `${start.revision.textContent ?? ''}${end.revision.textContent ?? ''}`;
+    const foreignMarker = attributableText.match(/\uE000safe-docx-rationale-\d+-(?:start|end)\uE001/gu)
+      ?.some((marker) => marker !== item.startSentinel && marker !== item.endSentinel);
+    if (foreignMarker) throw new Error('Tracked comment attribution overlaps another operation revision.');
+    const resolved = {
+      startRevision: revisionLocator(start.revision),
+      endRevision: revisionLocator(end.revision),
+      text: item.text,
+    };
+    start.textNode.data = start.textNode.data.replace(item.startSentinel, '');
+    end.textNode.data = end.textNode.data.replace(item.endSentinel, '');
+    return resolved;
+  });
+  zip.file('word/document.xml', serializeXml(documentXml));
+  return { buffer: await zip.generateAsync({ type: 'nodebuffer' }), comments };
+}
+
 export async function compileMarkdoc(
   sourceBuffer: Buffer,
   markdoc: string,
@@ -736,9 +808,10 @@ export async function compileMarkdoc(
   if (materializations.length > 0) {
     const identity = options.rationaleComments!;
     try {
-      tracked = await addTrackedRangeComments(tracked, materializations.map((item) => ({
-        startSentinel: item.startSentinel,
-        endSentinel: item.endSentinel,
+      const resolved = await resolveAndRemoveAttributionMarkers(tracked, materializations);
+      tracked = await addTrackedRangeComments(resolved.buffer, resolved.comments.map((item) => ({
+        startRevision: item.startRevision,
+        endRevision: item.endRevision,
         author: identity.author,
         initials: identity.initials,
         date: identity.date.toISOString(),

--- a/packages/docx-markdoc/src/markdoc.ts
+++ b/packages/docx-markdoc/src/markdoc.ts
@@ -446,7 +446,17 @@ export function parseMarkdoc(source: string): ValidationResult {
     waiverTargets.add(waiver.requirementId);
   }
   const rationaleTargets = new Set<string>();
+  const externalRationaleTargets = new Set<string>();
   for (const rationale of rationales) {
+    if (rationale.category === 'external-facing') {
+      if (externalRationaleTargets.has(rationale.operationId)) {
+        issues.push(issue(
+          'DUPLICATE_EXTERNAL_RATIONALE',
+          `Operation ${rationale.operationId} has more than one external-facing rationale.`,
+        ));
+      }
+      externalRationaleTargets.add(rationale.operationId);
+    }
     if (rationaleTargets.has(rationale.operationId)) {
       issues.push(issue('MULTIPLE_RATIONALES', `Operation ${rationale.operationId} has more than one rationale block.`));
     }

--- a/packages/docx-markdoc/src/rationale-comments.test.ts
+++ b/packages/docx-markdoc/src/rationale-comments.test.ts
@@ -133,6 +133,23 @@ describe('external-facing rationale comments', () => {
       rejectAllFormattingEqualsSource: true,
       acceptAllFormattingEqualsClean: true,
     });
+    const accepted = await DocxDocument.load(result.tracked);
+    const rejected = await DocxDocument.load(result.tracked);
+    await accepted.acceptChanges();
+    await rejected.rejectChanges();
+    const projected = await Promise.all([
+      accepted.toBuffer({ cleanBookmarks: false }),
+      rejected.toBuffer({ cleanBookmarks: false }),
+    ]);
+    for (const artifact of [
+      imported.anchoredSource,
+      result.clean,
+      result.tracked,
+      projected[0].buffer,
+      projected[1].buffer,
+    ]) {
+      expect(JSON.stringify(await parts(artifact))).not.toContain('safe-docx-rationale-');
+    }
   });
 
   itAllure('[SDX-MDOC-42] emits one bounded comment across a multi-paragraph insertion', async () => {

--- a/packages/docx-markdoc/src/rationale-comments.test.ts
+++ b/packages/docx-markdoc/src/rationale-comments.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect } from 'vitest';
+import JSZip from 'jszip';
+import { buildSyntheticDocx, DocxDocument, getParagraphRuns, parseXml } from '@usejunior/docx-core';
+import { itAllure } from '../../docx-core/src/testing/allure-test.js';
+import { compileMarkdoc } from './compile.js';
+import { importDocxToMarkdoc } from './import.js';
+import { requireMarkdoc } from './markdoc.js';
+
+const identity = {
+  author: 'Synthetic Reviewer',
+  initials: 'SR',
+  date: new Date('2026-08-16T14:30:00.000Z'),
+};
+const compileOptions = { author: 'Synthetic Revision Author', date: identity.date, rationaleComments: identity };
+
+function replaceOperation(markdoc: string, before: string, after: string, operationId = 'edit'): string {
+  const paragraph = requireMarkdoc(markdoc).scaffold.find((item) => item.originalText === before);
+  if (!paragraph) throw new Error(`Synthetic paragraph not found: ${before}`);
+  const block = new RegExp(`\\{% para id="${paragraph.id}"[\\s\\S]*?\\{% /para %\\}`);
+  return markdoc.replace(block, [
+    `{% change id="${paragraph.id}" fingerprint="${paragraph.fingerprint}" style="${paragraph.style}" operation="${operationId}" format="inherit-source-paragraph" %}`,
+    '{% before %}', before, '{% /before %}',
+    '{% after %}', after, '{% /after %}',
+    '{% /change %}',
+  ].join('\n'));
+}
+
+function rationale(operationId: string, category: string, text = 'Explain the synthetic edit.'): string {
+  return `\n{% rationale for="${operationId}" category="${category}" %}\n${text}\n{% /rationale %}\n`;
+}
+
+async function parts(buffer: Buffer): Promise<{ document: string; comments: string }> {
+  const zip = await JSZip.loadAsync(buffer);
+  return {
+    document: (await zip.file('word/document.xml')?.async('string')) ?? '',
+    comments: (await zip.file('word/comments.xml')?.async('string')) ?? '',
+  };
+}
+
+function componentCounts(xml: string): number[] {
+  const doc = parseXml(xml);
+  return ['commentRangeStart', 'commentRangeEnd', 'commentReference']
+    .map((name) => doc.getElementsByTagNameNS('http://schemas.openxmlformats.org/wordprocessingml/2006/main', name).length);
+}
+
+describe('external-facing rationale comments', () => {
+  itAllure('[SDX-MDOC-34][SDX-MDOC-37] selects only the exact category and emits deterministic identity', async () => {
+    const source = await buildSyntheticDocx({ paragraphs: ['Alpha term.'] });
+    const imported = await importDocxToMarkdoc(source);
+    const markdoc = replaceOperation(imported.markdoc, 'Alpha term.', 'Beta term.')
+      + rationale('edit', 'external-facing', 'Synthetic explanation.');
+    const first = await compileMarkdoc(imported.anchoredSource, markdoc, compileOptions);
+    const second = await compileMarkdoc(imported.anchoredSource, markdoc, compileOptions);
+    const firstParts = await parts(first.tracked);
+    const secondParts = await parts(second.tracked);
+    expect(firstParts.comments).toBe(secondParts.comments);
+    expect(firstParts.document).toBe(secondParts.document);
+    expect(firstParts.comments).toContain('w:author="Synthetic Reviewer"');
+    expect(firstParts.comments).toContain('w:initials="SR"');
+    expect(firstParts.comments).toContain('w:date="2026-08-16T14:30:00.000Z"');
+    expect(firstParts.comments).toContain('Synthetic explanation.');
+  });
+
+  itAllure('[SDX-MDOC-36] rejects duplicate selected rationales before compilation', async () => {
+    const source = await buildSyntheticDocx({ paragraphs: ['Alpha term.'] });
+    const imported = await importDocxToMarkdoc(source);
+    const markdoc = replaceOperation(imported.markdoc, 'Alpha term.', 'Beta term.')
+      + rationale('edit', 'external-facing', 'First synthetic explanation.')
+      + rationale('edit', 'external-facing', 'Second synthetic explanation.');
+    await expect(compileMarkdoc(imported.anchoredSource, markdoc, compileOptions)).rejects.toMatchObject({
+      code: 'INVALID_MARKDOC',
+      issues: expect.arrayContaining([expect.objectContaining({ code: 'DUPLICATE_EXTERNAL_RATIONALE' })]),
+    });
+  });
+
+  for (const category of ['internal', 'External-facing', 'external-facing ', '']) {
+    itAllure(`[SDX-MDOC-35] leaves ${category || 'unclassified'} rationale passive`, async () => {
+      const source = await buildSyntheticDocx({ paragraphs: ['Alpha term.'] });
+      const imported = await importDocxToMarkdoc(source);
+      const categoryAttribute = category ? ` category="${category}"` : '';
+      const markdoc = replaceOperation(imported.markdoc, 'Alpha term.', 'Beta term.')
+        + `\n{% rationale for="edit"${categoryAttribute} %}\nPrivate synthetic note.\n{% /rationale %}\n`;
+      const result = await compileMarkdoc(imported.anchoredSource, markdoc, compileOptions);
+      expect((await parts(result.tracked)).comments).toBe('');
+    });
+  }
+
+  itAllure('[SDX-MDOC-38] rejects missing or invalid comment identity without fallback', async () => {
+    const source = await buildSyntheticDocx({ paragraphs: ['Alpha term.'] });
+    const imported = await importDocxToMarkdoc(source);
+    const markdoc = replaceOperation(imported.markdoc, 'Alpha term.', 'Beta term.') + rationale('edit', 'external-facing');
+    await expect(compileMarkdoc(imported.anchoredSource, markdoc, {
+      rationaleComments: { author: ' ', initials: 'SR', date: identity.date },
+    })).rejects.toMatchObject({ code: 'INVALID_RATIONALE_COMMENT_IDENTITY' });
+  });
+
+  itAllure('[SDX-MDOC-39] anchors insertion comments to inserted text only', async () => {
+    const source = await buildSyntheticDocx({ paragraphs: ['Anchor text.', 'Tail text.'] });
+    const imported = await importDocxToMarkdoc(source);
+    const anchor = requireMarkdoc(imported.markdoc).scaffold[0]!;
+    const insertion = `\n{% insert-after anchor="${anchor.id}" operation="add" %}\n{% after %}\nInserted synthetic text.\n{% /after %}\n{% /insert-after %}`;
+    const result = await compileMarkdoc(imported.anchoredSource, imported.markdoc + insertion + rationale('add', 'external-facing'), compileOptions);
+    const xml = (await parts(result.tracked)).document;
+    expect(xml).toMatch(/commentRangeStart[\s\S]*?<w:ins\b[\s\S]*?Inserted synthetic text\.[\s\S]*?<\/w:ins>[\s\S]*?commentRangeEnd/u);
+  });
+
+  itAllure('[SDX-MDOC-40] anchors deletion comments around deleted markup', async () => {
+    const source = await buildSyntheticDocx({ paragraphs: ['Keep prefix obsolete words keep suffix.'] });
+    const imported = await importDocxToMarkdoc(source);
+    const markdoc = replaceOperation(imported.markdoc, 'Keep prefix obsolete words keep suffix.', 'Keep prefix keep suffix.', 'remove')
+      + rationale('remove', 'external-facing');
+    const result = await compileMarkdoc(imported.anchoredSource, markdoc, compileOptions);
+    const xml = (await parts(result.tracked)).document;
+    const range = xml.slice(xml.indexOf('commentRangeStart'), xml.indexOf('commentRangeEnd'));
+    expect(range).toContain('<w:del');
+    expect(range).toContain('obsolete');
+    expect(range).toContain('words');
+  });
+
+  itAllure('[SDX-MDOC-41][SDX-MDOC-44] replacement comments prefer inserted text and preserve projections', async () => {
+    const source = await buildSyntheticDocx({ paragraphs: ['Keep old value here.'] });
+    const imported = await importDocxToMarkdoc(source);
+    const markdoc = replaceOperation(imported.markdoc, 'Keep old value here.', 'Keep new value here.')
+      + rationale('edit', 'external-facing', 'Why the value changed.');
+    const result = await compileMarkdoc(imported.anchoredSource, markdoc, compileOptions);
+    const xml = (await parts(result.tracked)).document;
+    expect(xml).toMatch(/commentRangeStart[\s\S]*?<w:ins\b[\s\S]*?new[\s\S]*?<\/w:ins>[\s\S]*?commentRangeEnd/u);
+    const range = xml.slice(xml.indexOf('commentRangeStart'), xml.indexOf('commentRangeEnd'));
+    expect(range).not.toContain('old');
+    expect(result.certificate).toMatchObject({
+      rejectAllEqualsSource: true,
+      acceptAllEqualsClean: true,
+      rejectAllFormattingEqualsSource: true,
+      acceptAllFormattingEqualsClean: true,
+    });
+  });
+
+  itAllure('[SDX-MDOC-42] emits one bounded comment across a multi-paragraph insertion', async () => {
+    const source = await buildSyntheticDocx({ paragraphs: ['Anchor text.', 'Tail text.'] });
+    const imported = await importDocxToMarkdoc(source);
+    const anchor = requireMarkdoc(imported.markdoc).scaffold[0]!;
+    const insertion = `\n{% insert-after anchor="${anchor.id}" operation="add-many" %}\n{% after %}\nFirst inserted paragraph.\n\nSecond inserted paragraph.\n{% /after %}\n{% /insert-after %}`;
+    const result = await compileMarkdoc(imported.anchoredSource, imported.markdoc + insertion + rationale('add-many', 'external-facing'), compileOptions);
+    expect(componentCounts((await parts(result.tracked)).document)).toEqual([1, 1, 1]);
+  });
+
+  itAllure('[SDX-MDOC-43] fails closed when an operation has no anchorable tracked content', async () => {
+    const source = await buildSyntheticDocx({ paragraphs: ['Unchanged synthetic text.'] });
+    const imported = await importDocxToMarkdoc(source);
+    const markdoc = replaceOperation(imported.markdoc, 'Unchanged synthetic text.', 'Unchanged synthetic text.')
+      + rationale('edit', 'external-facing');
+    await expect(compileMarkdoc(imported.anchoredSource, markdoc, compileOptions))
+      .rejects.toMatchObject({ code: 'RATIONALE_ANCHOR_UNAVAILABLE' });
+  });
+
+  itAllure('[SDX-MDOC-48] accept and reject retain balanced comments and collapse removed anchors', async () => {
+    const source = await buildSyntheticDocx({ paragraphs: ['Keep old value here.'] });
+    const imported = await importDocxToMarkdoc(source);
+    const markdoc = replaceOperation(imported.markdoc, 'Keep old value here.', 'Keep new value here.')
+      + rationale('edit', 'external-facing');
+    const result = await compileMarkdoc(imported.anchoredSource, markdoc, compileOptions);
+    const accepted = await DocxDocument.load(result.tracked);
+    const rejected = await DocxDocument.load(result.tracked);
+    await accepted.acceptChanges();
+    await rejected.rejectChanges();
+    for (const projected of [accepted, rejected]) {
+      const buffer = (await projected.toBuffer({ cleanBookmarks: false })).buffer;
+      const xml = (await parts(buffer)).document;
+      expect(componentCounts(xml)).toEqual([1, 1, 1]);
+      expect((await projected.getComments())).toHaveLength(1);
+    }
+    expect(getParagraphRuns(rejected.getParagraphs()[0]!).map((run) => run.text).join('')).toBe('Keep old value here.');
+  });
+
+  itAllure('[SDX-MDOC-47] keeps rationale fixtures synthetic and public-safe', async () => {
+    const source = await buildSyntheticDocx({ paragraphs: ['Synthetic source text.'] });
+    const imported = await importDocxToMarkdoc(source);
+    const markdoc = replaceOperation(imported.markdoc, 'Synthetic source text.', 'Synthetic revised text.')
+      + rationale('edit', 'external-facing', 'Synthetic public rationale.');
+    const result = await compileMarkdoc(imported.anchoredSource, markdoc, compileOptions);
+    const serialized = JSON.stringify(await parts(result.tracked));
+    expect(serialized).toContain('Synthetic public rationale.');
+    expect(serialized).not.toMatch(/matter|client|privileged|private corpus/iu);
+  });
+});

--- a/packages/docx-markdoc/src/types.ts
+++ b/packages/docx-markdoc/src/types.ts
@@ -212,6 +212,18 @@ export type CompileResult = {
   certificate: VerificationCertificate;
 };
 
+export type RationaleCommentOptions = {
+  author: string;
+  initials: string;
+  date: Date;
+};
+
+export type CompileOptions = {
+  author?: string;
+  date?: Date;
+  rationaleComments?: RationaleCommentOptions;
+};
+
 export type ImportResult = {
   anchoredSource: Buffer;
   markdoc: string;

--- a/packages/docx-release-verifier/src/verifier.test.ts
+++ b/packages/docx-release-verifier/src/verifier.test.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 import JSZip from 'jszip';
 import { describe, expect } from 'vitest';
 import { itAllure } from '../../docx-core/src/testing/allure-test.js';
+import { buildSyntheticDocx } from '@usejunior/docx-core';
 import { verifyRelease } from './verifier.js';
 import type { ReleaseManifest } from './types.js';
 import { compileMarkdoc, importDocxToMarkdoc, requireMarkdoc } from '../../docx-markdoc/src/index.js';
@@ -246,6 +247,53 @@ describe('independent release verifier', () => {
     expect(result.gates.comments.details).toEqual({ expectedMinimum: 1, count: 0 });
     expect(result.delivery.status).toBe('fail');
     expect(result.exitCode).toBe(1);
+  });
+
+  itAllure('[SDX-MDOC-45][SDX-MDOC-46] verifies materialized rationale comments and rejects unselected output', async () => {
+    const original = await buildSyntheticDocx({ paragraphs: ['Synthetic old value.'] });
+    const imported = await importDocxToMarkdoc(original);
+    const paragraph = requireMarkdoc(imported.markdoc).scaffold[0]!;
+    const block = new RegExp(`\\{% para id="${paragraph.id}"[\\s\\S]*?\\{% /para %\\}`);
+    const replacement = [
+      `{% change id="${paragraph.id}" fingerprint="${paragraph.fingerprint}" style="${paragraph.style}" operation="edit" format="inherit-source-paragraph" %}`,
+      '{% before %}', 'Synthetic old value.', '{% /before %}',
+      '{% after %}', 'Synthetic new value.', '{% /after %}', '{% /change %}',
+    ].join('\n');
+    const rationale = '\n{% rationale for="edit" category="external-facing" %}\nSynthetic public explanation.\n{% /rationale %}\n';
+    const compiled = await compileMarkdoc(imported.anchoredSource, imported.markdoc.replace(block, replacement) + rationale, {
+      author: 'Synthetic Revision Author',
+      date: new Date('2026-08-16T14:30:00.000Z'),
+      rationaleComments: {
+        author: 'Synthetic Reviewer',
+        initials: 'SR',
+        date: new Date('2026-08-16T14:30:00.000Z'),
+      },
+    });
+    const directory = await mkdtemp(join(tmpdir(), 'release-rationale-comments-'));
+    const manifest: ReleaseManifest = {
+      version: 1,
+      originalPath: join(directory, 'original.docx'),
+      intendedCleanPath: join(directory, 'clean.docx'),
+      trackedPath: join(directory, 'tracked.docx'),
+      requireNativeComments: true,
+      mutationControl: { projection: 'accept', expected: 'intendedClean' },
+    };
+    await Promise.all([
+      writeFile(manifest.originalPath, imported.anchoredSource),
+      writeFile(manifest.intendedCleanPath, compiled.clean),
+      writeFile(manifest.trackedPath, compiled.tracked),
+    ]);
+    const positive = await verifyRelease(manifest);
+    expect(positive.gates.comments).toMatchObject({ status: 'pass', details: { expectedMinimum: 1, count: 1 } });
+
+    const unselected = await compileMarkdoc(
+      imported.anchoredSource,
+      imported.markdoc.replace(block, replacement) + rationale.replace('external-facing', 'internal'),
+      { rationaleComments: { author: 'Synthetic Reviewer', initials: 'SR', date: new Date('2026-08-16T14:30:00.000Z') } },
+    );
+    await writeFile(manifest.trackedPath, unselected.tracked);
+    const negative = await verifyRelease(manifest);
+    expect(negative.gates.comments.status).toBe('fail');
   });
 
   itAllure('leaves the zero-comment gate not_run when native comments are not required', async () => {


### PR DESCRIPTION
## Summary

- materialize only exact `external-facing` Markdoc rationales as native root Word comments
- require explicit deterministic comment author, initials, and date independently from tracked-revision identity
- carry operation attribution through comparison so insertion, deletion, replacement, and multi-paragraph edits receive bounded native ranges
- preserve balanced comment components through accept-all and reject-all, including deterministic zero-width collapse when tracked anchor text is removed
- verify positive and zero-comment outputs through the independent release verifier

## Why

External review rationales were previously passive metadata and disappeared from compiled DOCX output. The implementation keeps internal or unknown rationale categories private while allowing explicitly shareable explanations to travel with the tracked Word document.

Compiler-owned sentinels retain exact operation attribution through redline construction. The native comment layer replaces those sentinels with markers outside the attributable revision containers, which supports deleted text and cross-paragraph ranges without relying on ordinary visible-text offsets.

## Compatibility

The feature is additive and opt-in. Existing Markdoc documents and compile calls continue to emit no rationale comments.

## Validation

- `npm run build && npm run lint:workspaces && npm run test:run && npm run check:spec-coverage && npm run check:conformance-citations && npm run check:conformance-doc`
- `openspec validate add-markdoc-external-rationale-comments --strict`
- Markdoc package: 51 tests passed
- Release verifier: 56 tests passed

Fixes #860
