### PR TITLE
fix(docx-markdoc): preserve rationale boundary spaces

### DIFF
--- a/packages/docx-markdoc/src/compile.ts
+++ b/packages/docx-markdoc/src/compile.ts
@@ -721,6 +721,16 @@ function revisionLocator(revision: Element): TrackedRevisionLocator {
   return { type: revision.localName as TrackedRevisionLocator['type'], id };
 }
 
+function removeAttributionMarker(textNode: Text, marker: string): void {
+  textNode.data = textNode.data.replace(marker, '');
+  if (/^\s|\s$/u.test(textNode.data)) {
+    const textElement = textNode.parentNode;
+    if (textElement?.nodeType === 1) {
+      (textElement as Element).setAttributeNS('http://www.w3.org/XML/1998/namespace', 'xml:space', 'preserve');
+    }
+  }
+}
+
 async function resolveAndRemoveAttributionMarkers(
   buffer: Buffer,
   materializations: RationaleMaterialization[],
@@ -743,8 +753,8 @@ async function resolveAndRemoveAttributionMarkers(
       endRevision: revisionLocator(end.revision),
       text: item.text,
     };
-    start.textNode.data = start.textNode.data.replace(item.startSentinel, '');
-    end.textNode.data = end.textNode.data.replace(item.endSentinel, '');
+    removeAttributionMarker(start.textNode, item.startSentinel);
+    removeAttributionMarker(end.textNode, item.endSentinel);
     return resolved;
   });
   zip.file('word/document.xml', serializeXml(documentXml));

--- a/packages/docx-markdoc/src/rationale-comments.test.ts
+++ b/packages/docx-markdoc/src/rationale-comments.test.ts
@@ -152,6 +152,17 @@ describe('external-facing rationale comments', () => {
     }
   });
 
+  itAllure('[SDX-MDOC-44] preserves boundary whitespace exposed by private marker removal', async () => {
+    const source = await buildSyntheticDocx({ paragraphs: ['Letter of Intent'] });
+    const imported = await importDocxToMarkdoc(source);
+    const markdoc = replaceOperation(imported.markdoc, 'Letter of Intent', 'Mutual Letter of Intent')
+      + rationale('edit', 'external-facing');
+    const result = await compileMarkdoc(imported.anchoredSource, markdoc, compileOptions);
+    const xml = (await parts(result.tracked)).document;
+    expect(xml).toContain('<w:t xml:space="preserve">Mutual </w:t>');
+    expect(result.certificate).toMatchObject({ acceptAllEqualsClean: true, rejectAllEqualsSource: true });
+  });
+
   itAllure('[SDX-MDOC-42] emits one bounded comment across a multi-paragraph insertion', async () => {
     const source = await buildSyntheticDocx({ paragraphs: ['Anchor text.', 'Tail text.'] });
     const imported = await importDocxToMarkdoc(source);


### PR DESCRIPTION
## Summary\n- restore `xml:space="preserve"` when private rationale-attribution marker removal exposes boundary whitespace\n- add a regression test for a prefix insertion whose attributed text ends in a space\n\n## Why\nPost-merge real-document smoke for #880 found that the compiler certificate passed while the independent release verifier observed `MutualLetter of Intent` instead of `Mutual Letter of Intent`. The marker was removed from a `w:t` node without restoring OOXML whitespace preservation.\n\n## Verification\n- full mandatory local pre-submit gate passes\n- 52 docx-markdoc tests pass\n- real `tests/test_documents/open-agreements/letter-of-intent.docx` smoke passes the independent release verifier with one native comment, 100% zero-loss minimality, correct accept/reject projections, and no private-marker leakage\n\nRef: #860\nFollow-up to #880