### PR TITLE
feat(docx-markdoc): add declarative compilation profiles

### DIFF
--- a/openspec/changes/add-declarative-markdoc-compilation-profile/design.md
+++ b/openspec/changes/add-declarative-markdoc-compilation-profile/design.md
@@ -1,0 +1,99 @@
+## Context
+
+Canonical Markdoc describes the revision but not all deterministic compile input.
+The TypeScript API accepts revision and comment identities, while the CLI exposes
+neither. Internal rationale is never materialized, which is safe but prevents a
+useful internal-review artifact.
+
+## Goals / Non-Goals
+
+- Goals: reproducible CLI-only external-comment builds; explicit visibility;
+  auditable override precedence; a high-friction internal-comment artifact.
+- Non-goals: evidence-source schemas (#884), network/file resolvers, embedding
+  output paths in Markdoc, or exposing private model chain-of-thought.
+
+## Decisions
+
+### A singleton declarative profile
+
+Canonical syntax gains one optional singleton tag:
+
+```markdoc
+{% compilation
+   revision-author="AI Drafter"
+   build-date="2026-08-16T14:30:00.000Z"
+   external-rationale-comments="include"
+   comment-author="External Reviewer"
+   comment-initials="ER"
+/%}
+```
+
+`build-date` is one optional ISO-8601 instant shared by revision and comment
+metadata. When omitted, compilation captures the current system UTC instant once
+and reuses it everywhere. Pinning exists for fixtures and reproducible builds,
+not as authenticated evidence of when a human made an edit. Including external
+comments requires complete comment identity.
+
+### Explicit rationale visibility
+
+`visibility="internal|external-facing"` becomes the required authorization
+field. The legacy `category` attribute is rejected. This is an intentional clean
+break while the package has no known external production consumers.
+
+### Override precedence
+
+The CLI exposes a complete rendering override, not field-by-field identity
+inheritance. Without an override, external-facing rationales render by default
+when present (or follow the explicit Markdoc include/omit policy). A CLI
+`--no-external-comments` override wins over Markdoc and suppresses all external
+comments. If external rationales exist but are suppressed, CLI output emits a
+warning. Excluded internal rationales never produce a warning.
+
+Identity comes from the Markdoc profile for CLI-only replay or from one complete
+API option object for programmatic use. The certificate records the resolved
+configuration and source. Partial CLI identity overrides are not supported.
+
+Output paths remain runtime concerns and cannot be embedded in a revision file.
+
+### Internal export is a runtime capability
+
+Internal-comment inclusion cannot appear in Markdoc. It requires the exact
+`--dangerously-include-internal-comments` flag and a distinct explicit internal
+output path. The path's basename is rewritten to end in
+`INTERNAL COMMENTS INCLUDED.docx`; if necessary, the preceding basename is
+truncated by Unicode code points to fit the platform-safe component limit. The
+warning suffix and extension are never truncated.
+
+External-comment output is reported conspicuously by the CLI and uses a filename
+containing `EXTERNAL COMMENTS INCLUDED`. The CLI refuses an internal path equal
+to the source, clean, or external redline
+path and refuses silent overwrite. CLI output and the certificate declare the
+internal mode. A visible in-document warning is deferred because adding document
+content would change operative projections; it can be proposed separately.
+
+### Validation remains one implementation path
+
+`compile` calls the same parser and semantic validator used by `validate` before
+mutation. The standalone command remains useful for editors and CI because it
+writes no DOCX and avoids the more expensive replay/comparison steps.
+
+## Risks / Trade-offs
+
+- Profile metadata may be mistaken for authorship proof. Documentation will say
+  it is caller-supplied attribution, not authenticated identity.
+- A dangerous flag cannot prevent deliberate disclosure. The distinct path,
+  forced filename, collision checks, and certificate disclosure reduce accidental
+  disclosure.
+- Keeping legacy `category` parseable avoids abrupt breakage but intentionally
+  requires migration before it can authorize external comments.
+
+## Migration Plan
+
+Replace every rationale `category` with required `visibility`. Add a compilation
+profile to make author identity replayable. Omit `build-date` for normal builds or
+pin it when deterministic fixture bytes are required.
+
+## Open Questions
+
+- None. The approved design uses complete rendering overrides and one shared
+  build timestamp.

--- a/openspec/changes/add-declarative-markdoc-compilation-profile/proposal.md
+++ b/openspec/changes/add-declarative-markdoc-compilation-profile/proposal.md
@@ -1,0 +1,44 @@
+# Change: Add Declarative Markdoc Compilation Profiles
+
+## Why
+
+Brownfield Markdoc makes edit operations replayable, but the identity and policy
+that produce a fully attributed Word redline currently live outside the canonical
+revision in TypeScript options. That means an `.mjs` wrapper or ephemeral shell
+state is still required to reproduce external rationale comments. Internal
+rationales also need an intentionally difficult export path so an agent cannot
+casually disclose them to a counterparty.
+
+## What Changes
+
+- Add one optional, singleton compilation-profile tag to canonical Markdoc for
+  tracked-revision identity, comment identity, an optional pinned build time,
+  and the default external-comment rendering policy.
+- Make rationale visibility required and explicit as `internal` or
+  `external-facing`; this is a clean syntax break with no compatibility window.
+- Render present external-facing rationales by default, while allowing one
+  complete CLI rendering override to suppress them.
+- Keep validation mandatory inside compile while retaining standalone `validate`
+  as a no-output lint/editor/CI surface.
+- Add the exact `--dangerously-include-internal-comments` CLI-only opt-in. It
+  cannot be activated by Markdoc content.
+- Require a distinct explicit internal output path, force the complete
+  `INTERNAL COMMENTS INCLUDED` filename suffix under platform-safe length limits,
+  and disclose the mode in CLI and certificate output.
+- Document and test the complete no-JavaScript import-to-redline workflow.
+- Warn when external-facing rationales are present but intentionally suppressed,
+  and never warn merely because internal rationales remain excluded.
+
+## Impact
+
+- Affected specs: `docx-markdoc`.
+- Affected code: Markdoc schema/parser/IR, compiler option resolution,
+  verification certificate, CLI, filename policy, README, and package tests.
+- Compatibility: deliberate clean break for rationale visibility. Existing
+  private drafts must add `visibility="internal"`; external drafts must use
+  `visibility="external-facing"`. Users needing legacy syntax can pin an older
+  package version.
+- Security: external materialization remains fail-closed; internal materialization
+  requires an alarming runtime capability that document content cannot grant.
+- Related issues: #882 and #883. Structured evidence sources remain #884 and are
+  outside this change.

--- a/openspec/changes/add-declarative-markdoc-compilation-profile/specs/docx-markdoc/spec.md
+++ b/openspec/changes/add-declarative-markdoc-compilation-profile/specs/docx-markdoc/spec.md
@@ -1,0 +1,107 @@
+## ADDED Requirements
+
+### Requirement: Canonical Markdoc can declare deterministic compilation identity
+
+The system SHALL accept at most one compilation profile declaring tracked-
+revision identity, external rationale-comment identity and policy, and an
+optional pinned build date. It SHALL validate the profile before mutation. When
+the build date is omitted, it SHALL capture one current UTC instant and use that
+same instant for revision and comment metadata.
+
+#### Scenario: [SDX-MDOC-49] CLI-only replay materializes attributed external comments
+- **GIVEN** a canonical Markdoc revision with a complete compilation profile and an explicitly external-facing rationale
+- **WHEN** it is compiled through the CLI without a JavaScript wrapper
+- **THEN** the tracked revision and native rationale comment SHALL use the declared identities and dates
+- **AND** repeating the compile with identical inputs SHALL preserve semantic attribution
+
+#### Scenario: [SDX-MDOC-50] Incomplete or duplicate profiles fail before mutation
+- **GIVEN** duplicate compilation profiles or enabled comments without complete deterministic comment identity
+- **WHEN** compilation begins
+- **THEN** validation SHALL fail with a stable actionable diagnostic
+- **AND** no DOCX output SHALL be written
+
+### Requirement: Rationale visibility is explicit and fail-closed
+
+Each rationale SHALL declare exactly `internal` or `external-facing` visibility.
+Missing, unknown, misspelled, differently cased, or legacy category-only
+metadata SHALL fail validation before mutation.
+
+#### Scenario: [SDX-MDOC-51] Only exact visibility authorizes external output
+- **GIVEN** rationales with internal or external-facing visibility
+- **WHEN** external rationale comments are enabled
+- **THEN** only exact `visibility="external-facing"` rationales SHALL become native comments
+- **AND** internal rationales SHALL remain private metadata without producing a warning
+
+#### Scenario: [SDX-MDOC-57] Missing or legacy visibility fails cleanly
+- **GIVEN** a rationale with absent, unknown, misspelled, differently cased, or legacy category-only metadata
+- **WHEN** validation runs
+- **THEN** validation SHALL fail before document mutation with an actionable visibility diagnostic
+
+### Requirement: Compilation override provenance is auditable
+
+The system SHALL let a complete CLI rendering override supersede Markdoc's
+external-comment rendering policy and SHALL record the resolved configuration
+source in the verification certificate.
+
+#### Scenario: [SDX-MDOC-52] CLI suppression override is visible and wins
+- **GIVEN** a Markdoc profile that includes external comments and a CLI override that suppresses them
+- **WHEN** compilation succeeds
+- **THEN** no external rationale comment SHALL be rendered
+- **AND** the CLI SHALL warn that external rationales were present but suppressed
+- **AND** the certificate SHALL identify the rendering policy as a CLI override
+
+### Requirement: External comments are conspicuous and default to included
+
+When external-facing rationales are present, the CLI SHALL include them by
+default unless an explicit Markdoc omit policy or complete CLI suppression
+override applies. Included output SHALL be conspicuous in both the filename and
+CLI response.
+
+#### Scenario: [SDX-MDOC-58] Present external rationales render by default
+- **GIVEN** valid external-facing rationales and complete comment identity
+- **WHEN** CLI compilation runs without a rendering override
+- **THEN** those rationales SHALL become native comments
+- **AND** the tracked filename SHALL contain `EXTERNAL COMMENTS INCLUDED`
+- **AND** CLI output SHALL state that external comments were included
+
+#### Scenario: [SDX-MDOC-59] Suppressed external rationales warn
+- **GIVEN** one or more external-facing rationales and an effective omit policy
+- **WHEN** CLI compilation succeeds
+- **THEN** CLI output SHALL warn that external rationales were present but not included
+- **AND** it SHALL NOT suggest including or externalizing any internal rationale
+
+### Requirement: Internal rationale export requires an alarming runtime capability
+
+The system SHALL exclude internal rationale from DOCX comments unless the caller
+supplies the exact `--dangerously-include-internal-comments` CLI flag and a
+distinct explicit internal output path. Canonical Markdoc SHALL NOT be able to
+grant this capability.
+
+#### Scenario: [SDX-MDOC-53] Markdoc cannot silently enable internal comments
+- **GIVEN** valid Markdoc containing internal rationales and any document-level metadata
+- **WHEN** compilation runs without the dangerous CLI flag
+- **THEN** no internal rationale SHALL appear in any DOCX comment
+
+#### Scenario: [SDX-MDOC-54] Internal artifact is conspicuously named and certified
+- **GIVEN** the dangerous flag and a distinct explicit internal output path
+- **WHEN** an internal-review redline is generated
+- **THEN** its filename SHALL end in `INTERNAL COMMENTS INCLUDED.docx`
+- **AND** any necessary truncation SHALL preserve the complete warning suffix and extension
+- **AND** CLI and certificate output SHALL disclose internal-comment inclusion
+
+#### Scenario: [SDX-MDOC-55] Internal output cannot collide with another artifact
+- **GIVEN** an internal output path equal to the source, clean, or external tracked path, or an existing file without overwrite authorization
+- **WHEN** compilation begins
+- **THEN** it SHALL fail before writing or overwriting any artifact
+
+### Requirement: Compile performs validation before replay
+
+The compile command SHALL invoke the same syntactic and semantic Markdoc
+validation used by the standalone validate command before document mutation.
+Standalone validation SHALL remain available as a no-output fast-feedback path.
+
+#### Scenario: [SDX-MDOC-56] Invalid Markdoc fails identically through validate and compile
+- **GIVEN** canonical Markdoc with a validation defect
+- **WHEN** validate and compile are invoked independently
+- **THEN** both SHALL report the same stable validation code and location
+- **AND** compile SHALL write no document output

--- a/openspec/changes/add-declarative-markdoc-compilation-profile/tasks.md
+++ b/openspec/changes/add-declarative-markdoc-compilation-profile/tasks.md
@@ -1,0 +1,24 @@
+## 1. Schema and validation
+
+- [x] 1.1 Add compilation profile and explicit rationale visibility to Markdoc schema, IR, parser, and diagnostics.
+- [x] 1.2 Reject legacy rationale category and require explicit visibility.
+- [x] 1.3 Test singleton, identity completeness, date parsing, unknown visibility, and pre-mutation failures.
+
+## 2. Compile resolution and certification
+
+- [x] 2.1 Resolve Markdoc/API identity and complete CLI rendering overrides with documented precedence.
+- [x] 2.2 Record resolved values and provenance in the certificate without implying authenticated identity.
+- [x] 2.3 Prove compile and standalone validate use the same validation path.
+
+## 3. CLI-only workflows
+
+- [x] 3.1 Add safe attribution/external-comment CLI overrides and CLI-only internal-comment capability.
+- [x] 3.2 Enforce distinct paths, no overwrite, forced external/internal warning suffixes, and Unicode-safe filename truncation.
+- [x] 3.3 Warn for suppressed external rationales and stay silent for excluded internal rationales.
+- [x] 3.4 Test that Markdoc content cannot enable internal comments and omission of the dangerous flag stays external-only.
+
+## 4. Documentation and verification
+
+- [x] 4.1 Document import output, optional validate, automatic compile validation, and full no-JavaScript workflow.
+- [x] 4.2 Add real-document CLI smoke coverage for deterministic external comments and guarded internal output.
+- [x] 4.3 Run all mandatory repository pre-submit gates and update this checklist only after they pass.

--- a/packages/docx-markdoc/README.md
+++ b/packages/docx-markdoc/README.md
@@ -18,7 +18,7 @@ The New Name.
 {% /after %}
 {% /change %}
 
-{% rationale for="rename" %}
+{% rationale for="rename" visibility="internal" %}
 Use the entity's current legal name.
 {% /rationale %}
 ```
@@ -31,32 +31,69 @@ models and lawyers author familiar complete sentences.
 
 ## External-facing rationale comments
 
-Rationales remain passive metadata unless compilation explicitly enables
-native comments. Only the exact, case-sensitive category `external-facing` is
-eligible; absent, internal, misspelled, or differently cased categories are
-never inferred to be shareable.
+Rationale visibility is required. External-facing rationales become native
+comments by default when complete comment identity is available; internal
+rationales remain private metadata unless each CLI export uses the deliberately
+alarming internal-comment capability. Missing, misspelled, or differently cased
+visibility fails validation rather than guessing.
 
 ```markdoc
-{% rationale for="rename" category="external-facing" %}
+{% rationale for="rename" visibility="external-facing" %}
 The revised name matches the synthetic review record.
 {% /rationale %}
 ```
 
-Supply comment identity separately from tracked-revision identity. All three
-values are required and the compiler never substitutes the revision author,
-revision date, initials, or current time:
+Canonical Markdoc can carry replayable revision and comment identity. One build
+date governs both revisions and comments; omit it to use one UTC instant captured
+at compile time, or pin it for reproducible fixtures:
 
-```ts
-const result = await compileMarkdoc(source, markdoc, {
-  author: 'Revision Author',
-  date: new Date('2026-08-16T14:30:00.000Z'),
-  rationaleComments: {
-    author: 'External Reviewer',
-    initials: 'ER',
-    date: new Date('2026-08-16T14:30:00.000Z'),
-  },
-});
+```markdoc
+{% compilation
+   revision-author="Revision Author"
+   comment-author="External Reviewer"
+   comment-initials="ER"
+   build-date="2026-08-16T14:30:00.000Z"
+   external-comments="include"
+/%}
 ```
+
+The CLI can perform the whole workflow without a JavaScript wrapper:
+
+```bash
+# Preserve the caller's original and create the bookmark-anchored source plus
+# the initial readable revision file. Pandoc is not involved.
+docx-markdoc import source.docx anchored.docx revision.mdoc
+
+# Optional fast lint/editor/CI feedback. Compile runs this same validation
+# automatically before it mutates or compares any document.
+docx-markdoc validate revision.mdoc
+
+# Compile the edited revision file. External-facing rationales are included by
+# default and the filename and CLI output warn when comments are present.
+docx-markdoc compile anchored.docx revision.mdoc output/
+
+# Suppress external-facing comments even if the Markdoc requests them. The CLI
+# override wins and warns that external rationales were present but omitted.
+docx-markdoc compile anchored.docx revision.mdoc output/ --no-external-comments
+```
+
+`anchored.docx` differs from `source.docx` only where Safe DOCX had to add stable
+`_bk_*` paragraph bookmarks. The Markdoc hash and paragraph IDs target that
+anchored copy, so later compilation is stateless and never needs an editing
+session. The caller's original bytes remain untouched.
+
+Internal rationale never becomes a comment merely because it is present in
+Markdoc. Each internal-review export requires both the alarming capability and
+an explicit separate path:
+
+```bash
+docx-markdoc compile anchored.docx revision.mdoc output/ \
+  --dangerously-include-internal-comments \
+  --internal-output review.docx
+```
+
+The actual filename is forced to end in `INTERNAL COMMENTS INCLUDED.docx`, even
+when the requested basename must be truncated to fit the filesystem limit.
 
 Each selected rationale becomes one native root Word comment around the
 tracked edit attributable to its operation. Insertions and replacements prefer

--- a/packages/docx-markdoc/src/cli-options.test.ts
+++ b/packages/docx-markdoc/src/cli-options.test.ts
@@ -1,0 +1,26 @@
+import path from 'node:path';
+import { describe, expect } from 'vitest';
+import { itAllure } from '../../docx-core/src/testing/allure-test.js';
+import { INTERNAL_SUFFIX, parseRenderingFlags, warnedInternalPath } from './cli-options.js';
+
+describe('Markdoc CLI rendering safety', () => {
+  itAllure('[SDX-MDOC-55] requires the dangerous flag and internal output path together', () => {
+    expect(() => parseRenderingFlags(['source.docx', 'edit.mdoc', 'out', '--dangerously-include-internal-comments']))
+      .toThrow(/must be supplied together/u);
+    expect(() => parseRenderingFlags(['source.docx', 'edit.mdoc', 'out', '--internal-output', 'internal.docx']))
+      .toThrow(/must be supplied together/u);
+  });
+
+  itAllure('[SDX-MDOC-52] treats external rendering flags as complete mutually exclusive overrides', () => {
+    expect(parseRenderingFlags(['source.docx', 'edit.mdoc', 'out', '--no-external-comments']).externalComments).toBe(false);
+    expect(() => parseRenderingFlags(['--external-comments', '--no-external-comments'])).toThrow(/mutually exclusive/u);
+  });
+
+  itAllure('[SDX-MDOC-54] preserves the complete internal warning suffix within 255 UTF-8 bytes', () => {
+    const requested = path.join('/tmp', `${'😀'.repeat(100)}.docx`);
+    const warned = warnedInternalPath(requested);
+    expect(path.basename(warned)).toMatch(/INTERNAL COMMENTS INCLUDED\.docx$/u);
+    expect(Buffer.byteLength(path.basename(warned))).toBeLessThanOrEqual(255);
+    expect(path.basename(warned).endsWith(INTERNAL_SUFFIX.trimStart())).toBe(true);
+  });
+});

--- a/packages/docx-markdoc/src/cli-options.ts
+++ b/packages/docx-markdoc/src/cli-options.ts
@@ -1,0 +1,59 @@
+import path from 'node:path';
+
+export type RenderingFlags = {
+  positional: string[];
+  externalComments?: boolean;
+  includeInternalComments: boolean;
+  internalOutput?: string;
+};
+
+export function parseRenderingFlags(args: string[]): RenderingFlags {
+  const positional: string[] = [];
+  let externalComments: boolean | undefined;
+  let includeInternalComments = false;
+  let internalOutput: string | undefined;
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]!;
+    if (arg === '--external-comments' || arg === '--no-external-comments') {
+      const next = arg === '--external-comments';
+      if (externalComments !== undefined && externalComments !== next) {
+        throw new Error('--external-comments and --no-external-comments are mutually exclusive.');
+      }
+      externalComments = next;
+    } else if (arg === '--dangerously-include-internal-comments') {
+      includeInternalComments = true;
+    } else if (arg === '--internal-output') {
+      internalOutput = args[index + 1];
+      if (!internalOutput) throw new Error('--internal-output requires a .docx path.');
+      index += 1;
+    } else if (arg.startsWith('--')) {
+      throw new Error(`Unknown option ${arg}.`);
+    } else {
+      positional.push(arg);
+    }
+  }
+  if (includeInternalComments !== (internalOutput !== undefined)) {
+    throw new Error('--dangerously-include-internal-comments and --internal-output must be supplied together.');
+  }
+  return { positional, externalComments, includeInternalComments, internalOutput };
+}
+
+export const EXTERNAL_FILENAME = 'redline - EXTERNAL COMMENTS INCLUDED.docx';
+export const INTERNAL_SUFFIX = ' - INTERNAL COMMENTS INCLUDED.docx';
+
+export function warnedInternalPath(requested: string): string {
+  const directory = path.dirname(requested);
+  const extension = path.extname(requested);
+  const rawBase = path.basename(requested, extension);
+  const suffixBytes = Buffer.byteLength(INTERNAL_SUFFIX);
+  let prefix = rawBase;
+  while (Buffer.byteLength(prefix) + suffixBytes > 255) prefix = [...prefix].slice(0, -1).join('');
+  return path.join(directory, `${prefix}${INTERNAL_SUFFIX}`);
+}
+
+export function assertDistinctInternalPath(internalPath: string, paths: string[]): void {
+  const resolved = path.resolve(internalPath);
+  if (paths.some((candidate) => path.resolve(candidate) === resolved)) {
+    throw new Error('Internal-comment output must be distinct from the source, clean, and external redline paths.');
+  }
+}

--- a/packages/docx-markdoc/src/cli.ts
+++ b/packages/docx-markdoc/src/cli.ts
@@ -7,6 +7,7 @@ import { importDocxToMarkdoc } from './import.js';
 import { inspectMarkdocSource } from './inspect.js';
 import { requireMarkdoc } from './markdoc.js';
 import { DocxMarkdocError } from './errors.js';
+import { assertDistinctInternalPath, EXTERNAL_FILENAME, parseRenderingFlags, warnedInternalPath } from './cli-options.js';
 
 function usage(): never {
   throw new Error([
@@ -14,8 +15,9 @@ function usage(): never {
     '  docx-markdoc import <source.docx> <anchored.docx> <document.mdoc>',
     '  docx-markdoc validate <document.mdoc>',
     '  docx-markdoc inspect <anchored.docx> [paragraph-id ...]',
-    '  docx-markdoc compile <anchored.docx> <document.mdoc> <output-dir>',
-    '  docx-markdoc verify <anchored.docx> <document.mdoc>',
+    '  docx-markdoc compile <anchored.docx> <document.mdoc> <output-dir> [--external-comments|--no-external-comments]',
+    '    [--dangerously-include-internal-comments --internal-output <path.docx>]',
+    '  docx-markdoc verify <anchored.docx> <document.mdoc> [--external-comments|--no-external-comments]',
     '  docx-markdoc export-edits <document.mdoc> <output.json>',
   ].join('\n'));
 }
@@ -45,9 +47,18 @@ async function main(): Promise<void> {
     return;
   }
   if (command === 'compile' || command === 'verify') {
-    const [sourcePath, markdocPath, outputDir] = args;
+    const flags = parseRenderingFlags(args);
+    const [sourcePath, markdocPath, outputDir] = flags.positional;
     if (!sourcePath || !markdocPath || (command === 'compile' && !outputDir)) usage();
-    const result = await compileMarkdoc(await readFile(sourcePath), await readFile(markdocPath, 'utf8'));
+    if (command === 'verify' && flags.includeInternalComments) {
+      throw new Error('Internal comments can be materialized only by compile with an explicit output path.');
+    }
+    const hasCliOverride = flags.externalComments !== undefined || flags.includeInternalComments;
+    const result = await compileMarkdoc(await readFile(sourcePath), await readFile(markdocPath, 'utf8'), {
+      ...(flags.externalComments === undefined ? {} : { externalComments: flags.externalComments }),
+      ...(flags.includeInternalComments ? { dangerouslyIncludeInternalComments: true } : {}),
+      ...(hasCliOverride ? { configurationSource: 'cli' } : {}),
+    });
     if (command === 'compile') {
       if (!result.certificate.deliveryReady) {
         throw new DocxMarkdocError(
@@ -57,11 +68,35 @@ async function main(): Promise<void> {
         );
       }
       await mkdir(outputDir!, { recursive: true });
+      const cleanPath = path.join(outputDir!, 'clean.docx');
+      const externalPath = path.join(
+        outputDir!,
+        result.certificate.commentRendering.externalCommentsIncluded
+          && !result.certificate.commentRendering.internalCommentsIncluded
+          ? EXTERNAL_FILENAME
+          : 'redline.docx',
+      );
+      const internalPath = flags.internalOutput ? warnedInternalPath(flags.internalOutput) : undefined;
+      if (internalPath) {
+        assertDistinctInternalPath(internalPath, [sourcePath, cleanPath, externalPath]);
+        await mkdir(path.dirname(internalPath), { recursive: true });
+      }
       await Promise.all([
-        writeFile(path.join(outputDir!, 'clean.docx'), result.clean),
-        writeFile(path.join(outputDir!, 'redline.docx'), result.tracked),
+        writeFile(cleanPath, result.clean),
+        internalPath
+          ? writeFile(internalPath, result.tracked, { flag: 'wx' })
+          : writeFile(externalPath, result.tracked),
         writeFile(path.join(outputDir!, 'verification.json'), `${JSON.stringify(result.certificate, null, 2)}\n`),
       ]);
+      if (result.certificate.commentRendering.externalCommentsIncluded) {
+        process.stderr.write('WARNING: EXTERNAL COMMENTS INCLUDED in generated redline.\n');
+      }
+      if (result.certificate.commentRendering.internalCommentsIncluded) {
+        process.stderr.write(`DANGER: INTERNAL COMMENTS INCLUDED in ${internalPath}.\n`);
+      }
+      for (const warning of result.certificate.commentRendering.warnings) {
+        process.stderr.write(`WARNING: ${warning}\n`);
+      }
     }
     process.stdout.write(`${JSON.stringify(result.certificate, null, 2)}\n`);
     if (command === 'verify' && !result.certificate.deliveryReady) process.exitCode = 2;

--- a/packages/docx-markdoc/src/compile.ts
+++ b/packages/docx-markdoc/src/compile.ts
@@ -616,18 +616,69 @@ type RationaleMaterialization = {
   text: string;
 };
 
-function validateRationaleCommentOptions(options: CompileOptions, ir: MarkdocEditIR): RationaleMaterialization[] {
-  if (!options.rationaleComments) return [];
-  const { author, initials, date } = options.rationaleComments;
-  if (typeof author !== 'string' || author.trim().length === 0
-    || typeof initials !== 'string' || initials.trim().length === 0
-    || !(date instanceof Date) || !Number.isFinite(date.getTime())) {
+type ResolvedCompilation = {
+  author: string;
+  date: Date;
+  commentIdentity?: { author: string; initials: string };
+  source: 'markdoc' | 'api' | 'cli' | 'default';
+  externalRationalesFound: number;
+  internalRationalesFound: number;
+  externalCommentsIncluded: boolean;
+  internalCommentsIncluded: boolean;
+  warnings: string[];
+};
+
+function resolveCompilation(options: CompileOptions, ir: MarkdocEditIR): ResolvedCompilation {
+  const profile = ir.compilation;
+  const date = options.date ?? (profile?.buildDate ? new Date(profile.buildDate) : new Date());
+  if (!(date instanceof Date) || !Number.isFinite(date.getTime())) {
+    throw new DocxMarkdocError('INVALID_BUILD_DATE', 'Compilation date must be a valid instant.');
+  }
+  const externalRationalesFound = ir.rationales.filter((rationale) => rationale.visibility === 'external-facing').length;
+  const internalRationalesFound = ir.rationales.filter((rationale) => rationale.visibility === 'internal').length;
+  const includeExternal = options.externalComments ?? profile?.externalComments !== 'omit';
+  const includeInternal = options.dangerouslyIncludeInternalComments === true;
+  const commentAuthor = options.rationaleComments?.author ?? profile?.commentAuthor;
+  const commentInitials = options.rationaleComments?.initials ?? profile?.commentInitials;
+  if ((includeExternal && externalRationalesFound > 0) || (includeInternal && internalRationalesFound > 0)) {
+    if (typeof commentAuthor !== 'string' || commentAuthor.trim().length === 0
+      || typeof commentInitials !== 'string' || commentInitials.trim().length === 0) {
+      throw new DocxMarkdocError(
+        'INVALID_RATIONALE_COMMENT_IDENTITY',
+        'Included rationale comments require explicit non-empty comment author and initials.',
+      );
+    }
+  }
+  const hasApiConfiguration = options.author !== undefined
+    || options.date !== undefined
+    || options.rationaleComments !== undefined
+    || options.externalComments !== undefined
+    || options.dangerouslyIncludeInternalComments !== undefined;
+  return {
+    author: options.author ?? profile?.revisionAuthor ?? 'Markdoc',
+    date,
+    ...(commentAuthor && commentInitials ? { commentIdentity: { author: commentAuthor, initials: commentInitials } } : {}),
+    source: options.configurationSource ?? (hasApiConfiguration ? 'api' : profile ? 'markdoc' : 'default'),
+    externalRationalesFound,
+    internalRationalesFound,
+    externalCommentsIncluded: includeExternal && externalRationalesFound > 0,
+    internalCommentsIncluded: includeInternal && internalRationalesFound > 0,
+    warnings: !includeExternal && externalRationalesFound > 0
+      ? [`${externalRationalesFound} external-facing rationale(s) were present but not included.`]
+      : [],
+  };
+}
+
+function rationaleMaterializations(config: ResolvedCompilation, ir: MarkdocEditIR): RationaleMaterialization[] {
+  const selected = ir.rationales.filter((rationale) =>
+    (rationale.visibility === 'external-facing' && config.externalCommentsIncluded)
+    || (rationale.visibility === 'internal' && config.internalCommentsIncluded));
+  if (selected.length > 0 && !config.commentIdentity) {
     throw new DocxMarkdocError(
       'INVALID_RATIONALE_COMMENT_IDENTITY',
-      'Rationale comment author, initials, and date must be supplied explicitly and be valid.',
+      'Included rationale comments require explicit comment identity.',
     );
   }
-  const selected = ir.rationales.filter((rationale) => rationale.category === 'external-facing');
   const seen = new Set<string>();
   for (const rationale of selected) {
     if (seen.has(rationale.operationId)) {
@@ -761,13 +812,71 @@ async function resolveAndRemoveAttributionMarkers(
   return { buffer: await zip.generateAsync({ type: 'nodebuffer' }), comments };
 }
 
+async function remapResolvedCommentsToOrdinaryComparison(
+  instrumented: Buffer,
+  ordinary: Buffer,
+  comments: ResolvedRationaleComment[],
+): Promise<ResolvedRationaleComment[]> {
+  const revisionNames = new Set(['ins', 'del', 'moveFrom', 'moveTo']);
+  const revisions = async (buffer: Buffer): Promise<Element[]> => {
+    const zip = await JSZip.loadAsync(buffer);
+    const xml = await zip.file('word/document.xml')?.async('string');
+    if (!xml) throw new Error('Tracked DOCX has no word/document.xml.');
+    const document = parseXml(xml);
+    return Array.from(document.getElementsByTagName('*')).filter((element) => revisionNames.has(element.localName));
+  };
+  const [instrumentedRevisions, ordinaryRevisions] = await Promise.all([revisions(instrumented), revisions(ordinary)]);
+  const indexByLocator = new Map(instrumentedRevisions.map((revision, index) => [
+    `${revision.localName}#${getAttributeSafe(revision, OOXML.W_NS, 'id', 'w', { bareFallback: false }) ?? ''}`,
+    index,
+  ]));
+  const remap = (locator: TrackedRevisionLocator): TrackedRevisionLocator => {
+    const index = indexByLocator.get(`${locator.type}#${locator.id}`);
+    const source = index === undefined ? undefined : instrumentedRevisions[index];
+    if (!source) throw new Error(`Attributed revision ${locator.type}#${locator.id} is absent from the instrumented comparison.`);
+    const signature = `${source.localName}\0${source.textContent ?? ''}`;
+    const sourceMatches = instrumentedRevisions.filter((revision) => `${revision.localName}\0${revision.textContent ?? ''}` === signature);
+    const targetMatches = ordinaryRevisions.filter((revision) => `${revision.localName}\0${revision.textContent ?? ''}` === signature);
+    const occurrence = sourceMatches.indexOf(source);
+    let target = targetMatches[occurrence];
+    if (!target) {
+      const sourceText = source.textContent ?? '';
+      const contained = ordinaryRevisions
+        .filter((revision) => revision.localName === locator.type)
+        .filter((revision) => {
+          const text = revision.textContent ?? '';
+          return text.length > 0 && (sourceText.includes(text) || text.includes(sourceText));
+        })
+        .sort((left, right) => (right.textContent?.length ?? 0) - (left.textContent?.length ?? 0));
+      if (contained.length === 1
+        || (contained.length > 1 && (contained[0]!.textContent?.length ?? 0) > (contained[1]!.textContent?.length ?? 0))) {
+        target = contained[0];
+      }
+    }
+    if (!target) {
+      const candidates = ordinaryRevisions
+        .filter((revision) => revision.localName === locator.type)
+        .slice(0, 8)
+        .map((revision) => revision.textContent ?? '');
+      throw new Error(`Attributed revision ${locator.type}#${locator.id} text ${JSON.stringify(source.textContent ?? '')} has no identical ordinary-comparison revision among ${JSON.stringify(candidates)}.`);
+    }
+    return revisionLocator(target);
+  };
+  return comments.map((comment) => ({
+    ...comment,
+    startRevision: remap(comment.startRevision),
+    endRevision: remap(comment.endRevision),
+  }));
+}
+
 export async function compileMarkdoc(
   sourceBuffer: Buffer,
   markdoc: string,
   options: CompileOptions = {},
 ): Promise<CompileResult> {
   const ir = requireMarkdoc(markdoc);
-  const materializations = validateRationaleCommentOptions(options, ir);
+  const resolvedCompilation = resolveCompilation(options, ir);
+  const materializations = rationaleMaterializations(resolvedCompilation, ir);
   const sourceHashMatches = sha256(sourceBuffer) === ir.source.sha256;
   if (!sourceHashMatches) throw new DocxMarkdocError('SOURCE_HASH_DRIFT', 'Source DOCX hash does not match canonical Markdoc.');
   const sourceZip = await JSZip.loadAsync(sourceBuffer);
@@ -802,10 +911,10 @@ export async function compileMarkdoc(
     instrumentRanges(sourceBuffer, sourceMaterializations),
     instrumentRanges(clean, cleanMaterializations),
   ]);
-  const comparison = await compareDocuments(comparisonSource, comparisonClean, {
+  const comparisonOptions = {
     engine: 'atomizer',
-    author: options.author ?? 'Markdoc',
-    date: options.date,
+    author: resolvedCompilation.author,
+    date: resolvedCompilation.date,
     reconstructionMode: 'inplace',
     // No maxWordRefinementChangeRanges budget: a finite budget made dense
     // rewrites fall back to coarse whole-span replacement on the run-level
@@ -813,18 +922,32 @@ export async function compileMarkdoc(
     // verifier proves preservable were deleted and reinserted. Token-level
     // minimality outranks "confetti" readability for authored redlines.
     // See https://github.com/UseJunior/safe-docx/issues/846.
-  });
+  } as const;
+  const comparison = await compareDocuments(comparisonSource, comparisonClean, comparisonOptions);
   let tracked = comparison.document;
   if (materializations.length > 0) {
-    const identity = options.rationaleComments!;
+    const identity = resolvedCompilation.commentIdentity!;
     try {
       const resolved = await resolveAndRemoveAttributionMarkers(tracked, materializations);
-      tracked = await addTrackedRangeComments(resolved.buffer, resolved.comments.map((item) => ({
+      // Attribution markers are private discovery machinery, not authored
+      // document content. Dense multi-operation documents proved that asking
+      // the comparator to align those markers can perturb which source run
+      // supplies formatting even after the markers are removed. Resolve the
+      // operation-to-revision identities in the instrumented comparison, then
+      // place comments on the ordinary comparison so the delivered redline is
+      // byte-for-byte independent of marker text apart from native comments.
+      const ordinaryComparison = await compareDocuments(sourceBuffer, clean, comparisonOptions);
+      const ordinaryComments = await remapResolvedCommentsToOrdinaryComparison(
+        resolved.buffer,
+        ordinaryComparison.document,
+        resolved.comments,
+      );
+      tracked = await addTrackedRangeComments(ordinaryComparison.document, ordinaryComments.map((item) => ({
         startRevision: item.startRevision,
         endRevision: item.endRevision,
         author: identity.author,
         initials: identity.initials,
-        date: identity.date.toISOString(),
+        date: resolvedCompilation.date.toISOString(),
         text: item.text,
       })));
     } catch (error) {
@@ -863,6 +986,20 @@ export async function compileMarkdoc(
     unchangedPackagePartsPreserved,
     unsupportedStructures: unsupported,
     appliedOperations: declaredOperationIds,
+    commentRendering: {
+      configurationSource: resolvedCompilation.source,
+      buildDate: resolvedCompilation.date.toISOString(),
+      revisionAuthor: resolvedCompilation.author,
+      ...(resolvedCompilation.commentIdentity ? {
+        commentAuthor: resolvedCompilation.commentIdentity.author,
+        commentInitials: resolvedCompilation.commentIdentity.initials,
+      } : {}),
+      externalRationalesFound: resolvedCompilation.externalRationalesFound,
+      internalRationalesFound: resolvedCompilation.internalRationalesFound,
+      externalCommentsIncluded: resolvedCompilation.externalCommentsIncluded,
+      internalCommentsIncluded: resolvedCompilation.internalCommentsIncluded,
+      warnings: resolvedCompilation.warnings,
+    },
     projectionPassed: false,
     draftCompletenessPassed: completeness.passed,
     deliveryReady: false,

--- a/packages/docx-markdoc/src/docx-markdoc.test.ts
+++ b/packages/docx-markdoc/src/docx-markdoc.test.ts
@@ -18,7 +18,7 @@ function withBeforeAfterEdit(markdoc: string): string {
   return markdoc.replace(
     /\{% para ([^\n]+) %\}\nThe Old Name\.\n\{% \/para %\}/,
     `{% change ${match[1]} operation="rename" format="inherit-source-paragraph" %}\n{% before %}\nThe Old Name.\n{% /before %}\n{% after %}\nThe New Name.\n{% /after %}\n{% /change %}`,
-  ) + '\n{% rationale for="rename" category="correction" %}\nUse the current name.\n{% /rationale %}\n';
+  ) + '\n{% rationale for="rename" visibility="internal" %}\nUse the current name.\n{% /rationale %}\n';
 }
 
 describe('brownfield Markdoc authoring', () => {
@@ -46,7 +46,7 @@ describe('brownfield Markdoc authoring', () => {
     expect(result.certificate.acceptAllEqualsClean).toBe(true);
     const clean = await DocxDocument.load(result.clean);
     expect(clean.buildDocumentView().nodes.map((node) => node.raw_text)).toEqual(['The New Name.', 'Second paragraph.']);
-    expect(result.ir.rationales).toEqual([{ operationId: 'rename', text: 'Use the current name.', category: 'correction' }]);
+    expect(result.ir.rationales).toEqual([{ operationId: 'rename', text: 'Use the current name.', visibility: 'internal' }]);
   });
 
   itAllure('[SDX-MDOC-05][SDX-MDOC-15] replaces a canonical before/after paragraph and exports an edit pair', async () => {

--- a/packages/docx-markdoc/src/export.ts
+++ b/packages/docx-markdoc/src/export.ts
@@ -26,7 +26,7 @@ export function exportEditPairs(
       contextBefore: index < 0 ? [] : ir.scaffold.slice(Math.max(0, index - context), index).map((p) => p.originalText),
       contextAfter: index < 0 ? [] : ir.scaffold.slice(index + 1, index + context + 1).map((p) => p.originalText),
       rationale: rationale?.text,
-      category: rationale?.category,
+      visibility: rationale?.visibility,
       verified: options.verified,
       provenance: options.provenance,
     };

--- a/packages/docx-markdoc/src/markdoc.ts
+++ b/packages/docx-markdoc/src/markdoc.ts
@@ -1,6 +1,6 @@
 import Markdoc, { type Config, type Node } from '@markdoc/markdoc';
 import { DocxMarkdocError } from './errors.js';
-import { IR_VERSION, type AtomicChangeSet, type DraftAssertion, type DraftRequirement, type MarkdocEditIR, type Rationale, type RequirementWaiver, type RunFormat, type RunFormatSpan, type SourceParagraph, type ValidationIssue, type ValidationResult } from './types.js';
+import { IR_VERSION, type AtomicChangeSet, type CompilationProfile, type DraftAssertion, type DraftRequirement, type MarkdocEditIR, type Rationale, type RequirementWaiver, type RunFormat, type RunFormatSpan, type SourceParagraph, type ValidationIssue, type ValidationResult } from './types.js';
 
 const stringRequired = { type: String, required: true } as const;
 const runFormatAttributes = {
@@ -15,6 +15,16 @@ export const markdocConfig: Config = {
       attributes: {
         sha256: stringRequired,
         paragraphs: { type: Number, required: true },
+      },
+    },
+    compilation: {
+      selfClosing: true,
+      attributes: {
+        'revision-author': { type: String },
+        'comment-author': { type: String },
+        'comment-initials': { type: String },
+        'build-date': { type: String },
+        'external-comments': { type: String, matches: ['include', 'omit'] },
       },
     },
     para: {
@@ -86,7 +96,7 @@ export const markdocConfig: Config = {
     rationale: {
       attributes: {
         for: stringRequired,
-        category: { type: String },
+        visibility: { type: String, required: true, matches: ['internal', 'external-facing'] },
       },
     },
     requirement: {
@@ -231,6 +241,7 @@ export function parseMarkdoc(source: string): ValidationResult {
     }));
 
   let descriptor: MarkdocEditIR['source'] | undefined;
+  let compilation: CompilationProfile | undefined;
   const scaffold: SourceParagraph[] = [];
   const operations: MarkdocEditIR['operations'] = [];
   const rationales: Rationale[] = [];
@@ -256,11 +267,35 @@ export function parseMarkdoc(source: string): ValidationResult {
       descriptor = { sha256: String(a.sha256 ?? ''), paragraphs: Number(a.paragraphs) };
       continue;
     }
+    if (node.tag === 'compilation') {
+      if (compilation) issues.push(issue('DUPLICATE_COMPILATION_PROFILE', 'At most one compilation tag is permitted.', node));
+      const revisionAuthor = a['revision-author'] === undefined ? undefined : String(a['revision-author']).trim();
+      const commentAuthor = a['comment-author'] === undefined ? undefined : String(a['comment-author']).trim();
+      const commentInitials = a['comment-initials'] === undefined ? undefined : String(a['comment-initials']).trim();
+      const buildDate = a['build-date'] === undefined ? undefined : String(a['build-date']);
+      if (revisionAuthor !== undefined && !revisionAuthor) issues.push(issue('INVALID_COMPILATION_IDENTITY', 'revision-author must be non-empty.', node));
+      if (commentAuthor !== undefined && !commentAuthor) issues.push(issue('INVALID_COMPILATION_IDENTITY', 'comment-author must be non-empty.', node));
+      if (commentInitials !== undefined && !commentInitials) issues.push(issue('INVALID_COMPILATION_IDENTITY', 'comment-initials must be non-empty.', node));
+      if ((commentAuthor === undefined) !== (commentInitials === undefined)) {
+        issues.push(issue('INCOMPLETE_COMMENT_IDENTITY', 'comment-author and comment-initials must be declared together.', node));
+      }
+      if (buildDate !== undefined && (!Number.isFinite(Date.parse(buildDate)) || new Date(buildDate).toISOString() !== buildDate)) {
+        issues.push(issue('INVALID_BUILD_DATE', 'build-date must be a canonical ISO-8601 UTC instant.', node));
+      }
+      compilation = {
+        ...(revisionAuthor === undefined ? {} : { revisionAuthor }),
+        ...(commentAuthor === undefined ? {} : { commentAuthor }),
+        ...(commentInitials === undefined ? {} : { commentInitials }),
+        ...(buildDate === undefined ? {} : { buildDate }),
+        externalComments: a['external-comments'] === 'omit' ? 'omit' : 'include',
+      };
+      continue;
+    }
     if (node.tag === 'rationale') {
       rationales.push({
         operationId: String(a.for ?? ''),
         text: textProjection(node, 'revised').trim(),
-        category: a.category === undefined ? undefined : String(a.category),
+        visibility: a.visibility === 'external-facing' ? 'external-facing' : 'internal',
       });
       continue;
     }
@@ -448,7 +483,7 @@ export function parseMarkdoc(source: string): ValidationResult {
   const rationaleTargets = new Set<string>();
   const externalRationaleTargets = new Set<string>();
   for (const rationale of rationales) {
-    if (rationale.category === 'external-facing') {
+    if (rationale.visibility === 'external-facing') {
       if (externalRationaleTargets.has(rationale.operationId)) {
         issues.push(issue(
           'DUPLICATE_EXTERNAL_RATIONALE',
@@ -465,7 +500,7 @@ export function parseMarkdoc(source: string): ValidationResult {
   if (issues.length > 0 || !descriptor) return { valid: false, issues };
   return {
     valid: true,
-    ir: { version: IR_VERSION, source: descriptor, scaffold, operations, rationales, requirements, waivers, changeSets, assertions },
+    ir: { version: IR_VERSION, source: descriptor, scaffold, operations, rationales, compilation, requirements, waivers, changeSets, assertions },
   };
 }
 

--- a/packages/docx-markdoc/src/rationale-comments.test.ts
+++ b/packages/docx-markdoc/src/rationale-comments.test.ts
@@ -25,8 +25,16 @@ function replaceOperation(markdoc: string, before: string, after: string, operat
   ].join('\n'));
 }
 
-function rationale(operationId: string, category: string, text = 'Explain the synthetic edit.'): string {
-  return `\n{% rationale for="${operationId}" category="${category}" %}\n${text}\n{% /rationale %}\n`;
+function rationale(operationId: string, visibility: 'internal' | 'external-facing', text = 'Explain the synthetic edit.'): string {
+  return `\n{% rationale for="${operationId}" visibility="${visibility}" %}\n${text}\n{% /rationale %}\n`;
+}
+
+function compilationProfile(markdoc: string, externalComments: 'include' | 'omit' = 'include'): string {
+  const profile = [
+    '{% compilation revision-author="Profile Revision Author" comment-author="Profile Reviewer"',
+    `comment-initials="PR" build-date="2026-08-16T14:30:00.000Z" external-comments="${externalComments}" /%}`,
+  ].join(' ');
+  return markdoc.replace('\n\n', `\n\n${profile}\n\n`);
 }
 
 async function parts(buffer: Buffer): Promise<{ document: string; comments: string }> {
@@ -44,7 +52,61 @@ function componentCounts(xml: string): number[] {
 }
 
 describe('external-facing rationale comments', () => {
-  itAllure('[SDX-MDOC-34][SDX-MDOC-37] selects only the exact category and emits deterministic identity', async () => {
+  itAllure('[SDX-MDOC-49][SDX-MDOC-58] compiles attributed external comments from Markdoc alone', async () => {
+    const source = await buildSyntheticDocx({ paragraphs: ['Alpha term.'] });
+    const imported = await importDocxToMarkdoc(source);
+    const markdoc = compilationProfile(replaceOperation(imported.markdoc, 'Alpha term.', 'Beta term.'))
+      + rationale('edit', 'external-facing', 'Synthetic explanation.');
+    const result = await compileMarkdoc(imported.anchoredSource, markdoc);
+    const output = await parts(result.tracked);
+    expect(output.comments).toContain('w:author="Profile Reviewer"');
+    expect(output.comments).toContain('w:initials="PR"');
+    expect(output.comments).toContain('w:date="2026-08-16T14:30:00.000Z"');
+    expect(result.certificate.commentRendering).toMatchObject({
+      configurationSource: 'markdoc',
+      buildDate: '2026-08-16T14:30:00.000Z',
+      revisionAuthor: 'Profile Revision Author',
+      externalCommentsIncluded: true,
+      internalCommentsIncluded: false,
+      warnings: [],
+    });
+  });
+
+  itAllure('[SDX-MDOC-52][SDX-MDOC-59] lets CLI policy suppress external comments with a warning', async () => {
+    const source = await buildSyntheticDocx({ paragraphs: ['Alpha term.'] });
+    const imported = await importDocxToMarkdoc(source);
+    const markdoc = compilationProfile(replaceOperation(imported.markdoc, 'Alpha term.', 'Beta term.'))
+      + rationale('edit', 'external-facing');
+    const result = await compileMarkdoc(imported.anchoredSource, markdoc, {
+      externalComments: false,
+      configurationSource: 'cli',
+    });
+    expect((await parts(result.tracked)).comments).toBe('');
+    expect(result.certificate.commentRendering).toMatchObject({
+      configurationSource: 'cli',
+      externalRationalesFound: 1,
+      externalCommentsIncluded: false,
+      warnings: ['1 external-facing rationale(s) were present but not included.'],
+    });
+  });
+
+  itAllure('[SDX-MDOC-53][SDX-MDOC-54] requires explicit dangerous API capability for internal comments', async () => {
+    const source = await buildSyntheticDocx({ paragraphs: ['Alpha term.'] });
+    const imported = await importDocxToMarkdoc(source);
+    const markdoc = compilationProfile(replaceOperation(imported.markdoc, 'Alpha term.', 'Beta term.'))
+      + rationale('edit', 'internal', 'Internal synthetic explanation.');
+    const ordinary = await compileMarkdoc(imported.anchoredSource, markdoc);
+    expect((await parts(ordinary.tracked)).comments).toBe('');
+    expect(ordinary.certificate.commentRendering.warnings).toEqual([]);
+    const dangerous = await compileMarkdoc(imported.anchoredSource, markdoc, {
+      dangerouslyIncludeInternalComments: true,
+      configurationSource: 'api',
+    });
+    expect((await parts(dangerous.tracked)).comments).toContain('Internal synthetic explanation.');
+    expect(dangerous.certificate.commentRendering.internalCommentsIncluded).toBe(true);
+  });
+
+  itAllure('[SDX-MDOC-34][SDX-MDOC-37] selects external visibility and emits deterministic identity', async () => {
     const source = await buildSyntheticDocx({ paragraphs: ['Alpha term.'] });
     const imported = await importDocxToMarkdoc(source);
     const markdoc = replaceOperation(imported.markdoc, 'Alpha term.', 'Beta term.')
@@ -73,24 +135,50 @@ describe('external-facing rationale comments', () => {
     });
   });
 
-  for (const category of ['internal', 'External-facing', 'external-facing ', '']) {
-    itAllure(`[SDX-MDOC-35] leaves ${category || 'unclassified'} rationale passive`, async () => {
+  for (const visibility of ['External-facing', 'external-facing ', '']) {
+    itAllure(`[SDX-MDOC-57] rejects ${visibility || 'unclassified'} rationale visibility`, async () => {
       const source = await buildSyntheticDocx({ paragraphs: ['Alpha term.'] });
       const imported = await importDocxToMarkdoc(source);
-      const categoryAttribute = category ? ` category="${category}"` : '';
+      const visibilityAttribute = visibility ? ` visibility="${visibility}"` : '';
       const markdoc = replaceOperation(imported.markdoc, 'Alpha term.', 'Beta term.')
-        + `\n{% rationale for="edit"${categoryAttribute} %}\nPrivate synthetic note.\n{% /rationale %}\n`;
-      const result = await compileMarkdoc(imported.anchoredSource, markdoc, compileOptions);
-      expect((await parts(result.tracked)).comments).toBe('');
+        + `\n{% rationale for="edit"${visibilityAttribute} %}\nPrivate synthetic note.\n{% /rationale %}\n`;
+      await expect(compileMarkdoc(imported.anchoredSource, markdoc, compileOptions))
+        .rejects.toMatchObject({ code: 'INVALID_MARKDOC' });
     });
   }
+
+  itAllure('[SDX-MDOC-35][SDX-MDOC-51] leaves internal rationale passive without a warning', async () => {
+    const source = await buildSyntheticDocx({ paragraphs: ['Alpha term.'] });
+    const imported = await importDocxToMarkdoc(source);
+    const markdoc = replaceOperation(imported.markdoc, 'Alpha term.', 'Beta term.') + rationale('edit', 'internal');
+    const result = await compileMarkdoc(imported.anchoredSource, markdoc, compileOptions);
+    expect((await parts(result.tracked)).comments).toBe('');
+    expect(result.certificate.commentRendering.warnings).toEqual([]);
+  });
+
+  itAllure('[SDX-MDOC-50][SDX-MDOC-56] rejects invalid compilation metadata identically before replay', async () => {
+    const source = await buildSyntheticDocx({ paragraphs: ['Alpha term.'] });
+    const imported = await importDocxToMarkdoc(source);
+    const duplicate = imported.markdoc.replace('\n\n', [
+      '\n\n{% compilation build-date="not-a-date" /%}',
+      '{% compilation build-date="2026-08-16T14:30:00.000Z" /%}\n\n',
+    ].join('\n'));
+    let validateCode = '';
+    try {
+      requireMarkdoc(duplicate);
+    } catch (error) {
+      validateCode = (error as { code?: string }).code ?? '';
+    }
+    await expect(compileMarkdoc(imported.anchoredSource, duplicate)).rejects.toMatchObject({ code: validateCode });
+    expect(validateCode).toBe('INVALID_MARKDOC');
+  });
 
   itAllure('[SDX-MDOC-38] rejects missing or invalid comment identity without fallback', async () => {
     const source = await buildSyntheticDocx({ paragraphs: ['Alpha term.'] });
     const imported = await importDocxToMarkdoc(source);
     const markdoc = replaceOperation(imported.markdoc, 'Alpha term.', 'Beta term.') + rationale('edit', 'external-facing');
     await expect(compileMarkdoc(imported.anchoredSource, markdoc, {
-      rationaleComments: { author: ' ', initials: 'SR', date: identity.date },
+      rationaleComments: { author: ' ', initials: 'SR' },
     })).rejects.toMatchObject({ code: 'INVALID_RATIONALE_COMMENT_IDENTITY' });
   });
 

--- a/packages/docx-markdoc/src/types.ts
+++ b/packages/docx-markdoc/src/types.ts
@@ -8,7 +8,15 @@ export type SourceDescriptor = {
 export type Rationale = {
   operationId: string;
   text: string;
-  category?: string;
+  visibility: 'internal' | 'external-facing';
+};
+
+export type CompilationProfile = {
+  revisionAuthor?: string;
+  commentAuthor?: string;
+  commentInitials?: string;
+  buildDate?: string;
+  externalComments: 'include' | 'omit';
 };
 
 export type DraftRequirement = {
@@ -111,6 +119,7 @@ export type MarkdocEditIR = {
   scaffold: SourceParagraph[];
   operations: EditOperation[];
   rationales: Rationale[];
+  compilation?: CompilationProfile;
   /** Additive v1 fields; omitted legacy IR is treated as having no completeness declarations. */
   requirements?: DraftRequirement[];
   waivers?: RequirementWaiver[];
@@ -145,6 +154,18 @@ export type VerificationCertificate = {
   unchangedPackagePartsPreserved: boolean;
   unsupportedStructures: string[];
   appliedOperations: string[];
+  commentRendering: {
+    configurationSource: 'markdoc' | 'api' | 'cli' | 'default';
+    buildDate: string;
+    revisionAuthor: string;
+    commentAuthor?: string;
+    commentInitials?: string;
+    externalRationalesFound: number;
+    internalRationalesFound: number;
+    externalCommentsIncluded: boolean;
+    internalCommentsIncluded: boolean;
+    warnings: string[];
+  };
   /** Exact source/reject and clean/accept replay verdict. */
   projectionPassed: boolean;
   draftCompletenessPassed: boolean;
@@ -215,13 +236,15 @@ export type CompileResult = {
 export type RationaleCommentOptions = {
   author: string;
   initials: string;
-  date: Date;
 };
 
 export type CompileOptions = {
   author?: string;
   date?: Date;
   rationaleComments?: RationaleCommentOptions;
+  externalComments?: boolean;
+  dangerouslyIncludeInternalComments?: boolean;
+  configurationSource?: 'api' | 'cli';
 };
 
 export type ImportResult = {
@@ -239,7 +262,7 @@ export type EditPair = {
   contextBefore: string[];
   contextAfter: string[];
   rationale?: string;
-  category?: string;
+  visibility?: Rationale['visibility'];
   verified?: boolean;
   provenance?: Record<string, string>;
 };

--- a/packages/docx-release-verifier/src/verifier.test.ts
+++ b/packages/docx-release-verifier/src/verifier.test.ts
@@ -259,7 +259,7 @@ describe('independent release verifier', () => {
       '{% before %}', 'Synthetic old value.', '{% /before %}',
       '{% after %}', 'Synthetic new value.', '{% /after %}', '{% /change %}',
     ].join('\n');
-    const rationale = '\n{% rationale for="edit" category="external-facing" %}\nSynthetic public explanation.\n{% /rationale %}\n';
+    const rationale = '\n{% rationale for="edit" visibility="external-facing" %}\nSynthetic public explanation.\n{% /rationale %}\n';
     const compiled = await compileMarkdoc(imported.anchoredSource, imported.markdoc.replace(block, replacement) + rationale, {
       author: 'Synthetic Revision Author',
       date: new Date('2026-08-16T14:30:00.000Z'),


### PR DESCRIPTION
## Summary
- add a validated Markdoc compilation profile for revision and comment attribution
- include external-facing rationales by default with complete CLI overrides and visible artifact warnings
- keep internal rationales behind `--dangerously-include-internal-comments`, an explicit separate output, collision checks, and a forced filename suffix
- use one optionally pinned build timestamp for revisions and comments
- document the no-JavaScript import/validate/compile workflow

## Why
This makes complex Word revisions replayable and auditable while reducing accidental disclosure risk. It also removes one-off JavaScript setup from the ordinary CLI workflow and makes validation automatic during compilation.

## Validation
- mandatory repository pre-submit suite passed: build, workspace lint, all tests, spec coverage, conformance citations, and conformance document
- OpenSpec strict validation passed
- real 135-paragraph agreement replay passed privately with 16 operations, 19 requirements, exact accept/reject projections, 1.0 formatting scores, and 16 guarded internal comments; no client material is included in this PR

Fixes #882
Fixes #883