### PR TITLE
fix(docx-markdoc): allow paired rationale visibility

### DIFF
--- a/openspec/changes/allow-dual-visibility-rationales/proposal.md
+++ b/openspec/changes/allow-dual-visibility-rationales/proposal.md
@@ -1,0 +1,20 @@
+# Change: Allow paired rationale visibility records
+
+## Why
+
+An operation may need a private decision record and a distinct external-facing
+explanation, but validation currently rejects the second rationale regardless
+of visibility.
+
+## What Changes
+
+- Permit one internal and one external-facing rationale for one operation.
+- Continue rejecting duplicates within either visibility class.
+- Prove external-only compilation does not place internal rationale text in any
+  output DOCX part.
+
+## Impact
+
+- Affected specs: docx-markdoc
+- Affected code: Markdoc validation and rationale-comment tests
+- Related issue: #886

--- a/openspec/changes/allow-dual-visibility-rationales/specs/docx-markdoc/spec.md
+++ b/openspec/changes/allow-dual-visibility-rationales/specs/docx-markdoc/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: One operation can carry separate private and public explanations
+
+The system SHALL permit one internal rationale and one external-facing rationale
+for the same operation. It SHALL enforce uniqueness independently for each
+visibility and SHALL preserve the existing rendering authorization boundary.
+
+#### Scenario: [SDX-MDOC-60] External-only compilation keeps paired internal rationale private
+- **GIVEN** one operation with one internal and one external-facing rationale
+- **WHEN** compilation includes external comments without the dangerous internal-comment capability
+- **THEN** the external-facing rationale SHALL become a native comment
+- **AND** the internal rationale text SHALL be absent from every output DOCX part
+
+#### Scenario: [SDX-MDOC-61] Duplicate rationale visibility fails before mutation
+- **GIVEN** one operation with more than one rationale in the same visibility class
+- **WHEN** validation runs
+- **THEN** validation SHALL fail before document mutation with a stable duplicate-visibility diagnostic

--- a/openspec/changes/allow-dual-visibility-rationales/tasks.md
+++ b/openspec/changes/allow-dual-visibility-rationales/tasks.md
@@ -1,0 +1,9 @@
+## 1. Validation
+
+- [x] 1.1 Key rationale uniqueness by operation and visibility.
+- [x] 1.2 Test allowed cross-visibility pairs and rejected same-visibility duplicates.
+
+## 2. Disclosure safety
+
+- [x] 2.1 Test that external-only output contains the external rationale and no internal rationale bytes.
+- [x] 2.2 Run strict OpenSpec validation and repository pre-submit gates.

--- a/packages/docx-markdoc/src/markdoc.ts
+++ b/packages/docx-markdoc/src/markdoc.ts
@@ -481,21 +481,15 @@ export function parseMarkdoc(source: string): ValidationResult {
     waiverTargets.add(waiver.requirementId);
   }
   const rationaleTargets = new Set<string>();
-  const externalRationaleTargets = new Set<string>();
   for (const rationale of rationales) {
-    if (rationale.visibility === 'external-facing') {
-      if (externalRationaleTargets.has(rationale.operationId)) {
-        issues.push(issue(
-          'DUPLICATE_EXTERNAL_RATIONALE',
-          `Operation ${rationale.operationId} has more than one external-facing rationale.`,
-        ));
-      }
-      externalRationaleTargets.add(rationale.operationId);
+    const target = `${rationale.operationId}\u0000${rationale.visibility}`;
+    if (rationaleTargets.has(target)) {
+      issues.push(issue(
+        'DUPLICATE_RATIONALE_VISIBILITY',
+        `Operation ${rationale.operationId} has more than one ${rationale.visibility} rationale.`,
+      ));
     }
-    if (rationaleTargets.has(rationale.operationId)) {
-      issues.push(issue('MULTIPLE_RATIONALES', `Operation ${rationale.operationId} has more than one rationale block.`));
-    }
-    rationaleTargets.add(rationale.operationId);
+    rationaleTargets.add(target);
   }
   if (issues.length > 0 || !descriptor) return { valid: false, issues };
   return {

--- a/packages/docx-markdoc/src/rationale-comments.test.ts
+++ b/packages/docx-markdoc/src/rationale-comments.test.ts
@@ -131,9 +131,46 @@ describe('external-facing rationale comments', () => {
       + rationale('edit', 'external-facing', 'Second synthetic explanation.');
     await expect(compileMarkdoc(imported.anchoredSource, markdoc, compileOptions)).rejects.toMatchObject({
       code: 'INVALID_MARKDOC',
-      issues: expect.arrayContaining([expect.objectContaining({ code: 'DUPLICATE_EXTERNAL_RATIONALE' })]),
+      issues: expect.arrayContaining([expect.objectContaining({ code: 'DUPLICATE_RATIONALE_VISIBILITY' })]),
     });
   });
+
+  itAllure('[SDX-MDOC-60] keeps internal reasoning private while exporting a paired external rationale', async () => {
+    const source = await buildSyntheticDocx({ paragraphs: ['Alpha term.'] });
+    const imported = await importDocxToMarkdoc(source);
+    const internalText = 'Private synthetic decision record.';
+    const externalText = 'External synthetic explanation.';
+    const markdoc = compilationProfile(replaceOperation(imported.markdoc, 'Alpha term.', 'Beta term.'))
+      + rationale('edit', 'internal', internalText)
+      + rationale('edit', 'external-facing', externalText);
+    const result = await compileMarkdoc(imported.anchoredSource, markdoc);
+    const zip = await JSZip.loadAsync(result.tracked);
+    const contents = await Promise.all(Object.values(zip.files)
+      .filter((entry) => !entry.dir)
+      .map((entry) => entry.async('string')));
+    expect(contents.join('\n')).toContain(externalText);
+    expect(contents.join('\n')).not.toContain(internalText);
+    expect(result.certificate.commentRendering).toMatchObject({
+      externalRationalesFound: 1,
+      internalRationalesFound: 1,
+      externalCommentsIncluded: true,
+      internalCommentsIncluded: false,
+    });
+  });
+
+  for (const visibility of ['internal', 'external-facing'] as const) {
+    itAllure(`[SDX-MDOC-61] rejects duplicate ${visibility} rationales`, async () => {
+      const source = await buildSyntheticDocx({ paragraphs: ['Alpha term.'] });
+      const imported = await importDocxToMarkdoc(source);
+      const markdoc = replaceOperation(imported.markdoc, 'Alpha term.', 'Beta term.')
+        + rationale('edit', visibility, 'First synthetic explanation.')
+        + rationale('edit', visibility, 'Second synthetic explanation.');
+      await expect(compileMarkdoc(imported.anchoredSource, markdoc, compileOptions)).rejects.toMatchObject({
+        code: 'INVALID_MARKDOC',
+        issues: expect.arrayContaining([expect.objectContaining({ code: 'DUPLICATE_RATIONALE_VISIBILITY' })]),
+      });
+    });
+  }
 
   for (const visibility of ['External-facing', 'external-facing ', '']) {
     itAllure(`[SDX-MDOC-57] rejects ${visibility || 'unclassified'} rationale visibility`, async () => {


### PR DESCRIPTION
## Summary
- permit one internal and one external-facing rationale for the same operation
- continue rejecting duplicate rationales within either visibility
- scan every generated DOCX part to prove external-only output contains no internal rationale text

## Why
The compiler already enforces separate rendering authorization for internal and external rationales, but validation previously prevented representing both explanations for one edit.

## Validation
- mandatory repository pre-submit suite passed
- OpenSpec strict validation passed
- confidential real-document playbook smoke passed locally; no fixture identity, contents, metrics, or artifacts are included in this PR

Fixes #886