### PR TITLE
fix(docx-markdoc): preserve paired rationale consumers

### DIFF
--- a/openspec/changes/allow-dual-visibility-rationales/proposal.md
+++ b/openspec/changes/allow-dual-visibility-rationales/proposal.md
@@ -1,0 +1,20 @@
+# Change: Allow paired rationale visibility records
+
+## Why
+
+An operation may need a private decision record and a distinct external-facing
+explanation, but validation currently rejects the second rationale regardless
+of visibility.
+
+## What Changes
+
+- Permit one internal and one external-facing rationale for one operation.
+- Continue rejecting duplicates within either visibility class.
+- Prove external-only compilation does not place internal rationale text in any
+  output DOCX part.
+
+## Impact
+
+- Affected specs: docx-markdoc
+- Affected code: Markdoc validation and rationale-comment tests
+- Related issue: #886

--- a/openspec/changes/allow-dual-visibility-rationales/specs/docx-markdoc/spec.md
+++ b/openspec/changes/allow-dual-visibility-rationales/specs/docx-markdoc/spec.md
@@ -16,3 +16,13 @@ visibility and SHALL preserve the existing rendering authorization boundary.
 - **GIVEN** one operation with more than one rationale in the same visibility class
 - **WHEN** validation runs
 - **THEN** validation SHALL fail before document mutation with a stable duplicate-visibility diagnostic
+
+#### Scenario: [SDX-MDOC-62] Dangerous export renders both paired explanations
+- **GIVEN** one operation with one internal and one external-facing rationale
+- **WHEN** compilation explicitly enables both external and dangerous internal comments
+- **THEN** both rationales SHALL become distinct native comments attributed to that operation
+
+#### Scenario: [SDX-MDOC-63] Structured export preserves paired explanations
+- **GIVEN** one operation with one internal and one external-facing rationale
+- **WHEN** structured edit pairs are exported
+- **THEN** both rationale records and their visibility values SHALL be preserved without overwrite

--- a/openspec/changes/allow-dual-visibility-rationales/specs/docx-markdoc/spec.md
+++ b/openspec/changes/allow-dual-visibility-rationales/specs/docx-markdoc/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: One operation can carry separate private and public explanations
+
+The system SHALL permit one internal rationale and one external-facing rationale
+for the same operation. It SHALL enforce uniqueness independently for each
+visibility and SHALL preserve the existing rendering authorization boundary.
+
+#### Scenario: [SDX-MDOC-60] External-only compilation keeps paired internal rationale private
+- **GIVEN** one operation with one internal and one external-facing rationale
+- **WHEN** compilation includes external comments without the dangerous internal-comment capability
+- **THEN** the external-facing rationale SHALL become a native comment
+- **AND** the internal rationale text SHALL be absent from every output DOCX part
+
+#### Scenario: [SDX-MDOC-61] Duplicate rationale visibility fails before mutation
+- **GIVEN** one operation with more than one rationale in the same visibility class
+- **WHEN** validation runs
+- **THEN** validation SHALL fail before document mutation with a stable duplicate-visibility diagnostic

--- a/openspec/changes/allow-dual-visibility-rationales/tasks.md
+++ b/openspec/changes/allow-dual-visibility-rationales/tasks.md
@@ -7,3 +7,8 @@
 
 - [x] 2.1 Test that external-only output contains the external rationale and no internal rationale bytes.
 - [x] 2.2 Run strict OpenSpec validation and repository pre-submit gates.
+
+## 3. Paired consumers
+
+- [x] 3.1 Render both visibility records as distinct comments when dangerous internal export is explicitly enabled.
+- [x] 3.2 Preserve both visibility records in structured edit export without a lossy operation-only map.

--- a/openspec/changes/allow-dual-visibility-rationales/tasks.md
+++ b/openspec/changes/allow-dual-visibility-rationales/tasks.md
@@ -1,0 +1,9 @@
+## 1. Validation
+
+- [x] 1.1 Key rationale uniqueness by operation and visibility.
+- [x] 1.2 Test allowed cross-visibility pairs and rejected same-visibility duplicates.
+
+## 2. Disclosure safety
+
+- [x] 2.1 Test that external-only output contains the external rationale and no internal rationale bytes.
+- [x] 2.2 Run strict OpenSpec validation and repository pre-submit gates.

--- a/packages/docx-markdoc/src/compile.ts
+++ b/packages/docx-markdoc/src/compile.ts
@@ -613,7 +613,7 @@ type RationaleMaterialization = {
   range: AttributedRange;
   startSentinel: string;
   endSentinel: string;
-  text: string;
+  texts: string[];
 };
 
 type ResolvedCompilation = {
@@ -679,21 +679,15 @@ function rationaleMaterializations(config: ResolvedCompilation, ir: MarkdocEditI
       'Included rationale comments require explicit comment identity.',
     );
   }
-  const seen = new Set<string>();
+  const grouped = new Map<string, string[]>();
   for (const rationale of selected) {
-    if (seen.has(rationale.operationId)) {
-      throw new DocxMarkdocError(
-        'DUPLICATE_EXTERNAL_RATIONALE',
-        `Operation ${rationale.operationId} has more than one external-facing rationale.`,
-      );
-    }
-    seen.add(rationale.operationId);
+    grouped.set(rationale.operationId, [...(grouped.get(rationale.operationId) ?? []), rationale.text]);
   }
-  return selected.map((rationale, index) => ({
-    range: { operationId: rationale.operationId } as AttributedRange,
+  return [...grouped].map(([operationId, texts], index) => ({
+    range: { operationId } as AttributedRange,
     startSentinel: `\u{E000}safe-docx-rationale-${index}-start\u{E001}`,
     endSentinel: `\u{E000}safe-docx-rationale-${index}-end\u{E001}`,
-    text: rationale.text,
+    texts,
   }));
 }
 
@@ -790,7 +784,7 @@ async function resolveAndRemoveAttributionMarkers(
   const file = zip.file('word/document.xml');
   if (!file) throw new Error('Tracked DOCX has no word/document.xml.');
   const documentXml = parseXml(await file.async('string'));
-  const comments = materializations.map((item) => {
+  const comments = materializations.flatMap((item) => {
     const start = resolveSentinel(documentXml, item.startSentinel);
     const end = resolveSentinel(documentXml, item.endSentinel);
     const attributableText = start.revision === end.revision
@@ -802,11 +796,10 @@ async function resolveAndRemoveAttributionMarkers(
     const resolved = {
       startRevision: revisionLocator(start.revision),
       endRevision: revisionLocator(end.revision),
-      text: item.text,
     };
     removeAttributionMarker(start.textNode, item.startSentinel);
     removeAttributionMarker(end.textNode, item.endSentinel);
-    return resolved;
+    return item.texts.map((text) => ({ ...resolved, text }));
   });
   zip.file('word/document.xml', serializeXml(documentXml));
   return { buffer: await zip.generateAsync({ type: 'nodebuffer' }), comments };

--- a/packages/docx-markdoc/src/docx-markdoc.test.ts
+++ b/packages/docx-markdoc/src/docx-markdoc.test.ts
@@ -65,6 +65,24 @@ describe('brownfield Markdoc authoring', () => {
     const result = await compileMarkdoc(imported.anchoredSource, markdoc);
     const pairs = exportEditPairs(result.ir, { verified: result.certificate.passed });
     expect(pairs[0]).toMatchObject({ before: 'Original provision.', after: 'Revised provision.', verified: true });
+    expect(pairs[0]?.rationales).toEqual([]);
+  });
+
+  itAllure('[SDX-MDOC-63] exports paired rationale records without collapsing visibility', async () => {
+    const original = await buildSyntheticDocx({ paragraphs: ['Original provision.'] });
+    const imported = await importDocxToMarkdoc(original);
+    const paragraph = requireMarkdoc(imported.markdoc).scaffold[0]!;
+    const markdoc = imported.markdoc.replace(
+      new RegExp(`\\{% para id="${paragraph.id}"[\\s\\S]*?\\{% /para %\\}`),
+      `{% change id="${paragraph.id}" fingerprint="${paragraph.fingerprint}" style="${paragraph.style}" operation="rewrite" format="inherit-source-paragraph" %}\n{% before %}\nOriginal provision.\n{% /before %}\n{% after %}\nRevised provision.\n{% /after %}\n{% /change %}`,
+    ) + '\n{% rationale for="rewrite" visibility="internal" %}\nPrivate record.\n{% /rationale %}\n{% rationale for="rewrite" visibility="external-facing" %}\nPublic explanation.\n{% /rationale %}\n';
+    const pair = exportEditPairs(requireMarkdoc(markdoc))[0]!;
+    expect(pair.rationales).toEqual([
+      { operationId: 'rewrite', text: 'Private record.', visibility: 'internal' },
+      { operationId: 'rewrite', text: 'Public explanation.', visibility: 'external-facing' },
+    ]);
+    expect(pair).not.toHaveProperty('rationale');
+    expect(pair).not.toHaveProperty('visibility');
   });
 
   itAllure('[SDX-MDOC-04][SDX-MDOC-08] rejects nested revisions and orphan rationale', async () => {

--- a/packages/docx-markdoc/src/export.ts
+++ b/packages/docx-markdoc/src/export.ts
@@ -9,14 +9,19 @@ export function exportEditPairs(
   options: { contextParagraphs?: number; verified?: boolean; provenance?: Record<string, string> } = {},
 ): EditPair[] {
   const context = Math.max(0, options.contextParagraphs ?? 1);
-  const rationales = new Map(ir.rationales.map((item) => [item.operationId, item]));
+  const rationales = new Map<string, MarkdocEditIR['rationales']>();
+  for (const item of ir.rationales) {
+    const existing = rationales.get(item.operationId) ?? [];
+    rationales.set(item.operationId, [...existing, item]);
+  }
   const indexById = new Map(ir.scaffold.map((paragraph, index) => [paragraph.id, index]));
   return ir.operations.map((operation) => {
     const anchorId = isInsertOperation(operation) ? operation.anchorId : operation.id;
     const index = indexById.get(anchorId) ?? -1;
     const before = isInsertOperation(operation) ? '' : operation.originalText;
     const after = operation.kind === 'delete-source' ? '' : operation.revisedText;
-    const rationale = rationales.get(operation.operationId);
+    const operationRationales = rationales.get(operation.operationId) ?? [];
+    const legacyRationale = operationRationales.length === 1 ? operationRationales[0] : undefined;
     return {
       operationId: operation.operationId,
       kind: operation.kind,
@@ -25,8 +30,8 @@ export function exportEditPairs(
       after,
       contextBefore: index < 0 ? [] : ir.scaffold.slice(Math.max(0, index - context), index).map((p) => p.originalText),
       contextAfter: index < 0 ? [] : ir.scaffold.slice(index + 1, index + context + 1).map((p) => p.originalText),
-      rationale: rationale?.text,
-      visibility: rationale?.visibility,
+      rationales: operationRationales,
+      ...(legacyRationale ? { rationale: legacyRationale.text, visibility: legacyRationale.visibility } : {}),
       verified: options.verified,
       provenance: options.provenance,
     };

--- a/packages/docx-markdoc/src/markdoc.ts
+++ b/packages/docx-markdoc/src/markdoc.ts
@@ -481,21 +481,15 @@ export function parseMarkdoc(source: string): ValidationResult {
     waiverTargets.add(waiver.requirementId);
   }
   const rationaleTargets = new Set<string>();
-  const externalRationaleTargets = new Set<string>();
   for (const rationale of rationales) {
-    if (rationale.visibility === 'external-facing') {
-      if (externalRationaleTargets.has(rationale.operationId)) {
-        issues.push(issue(
-          'DUPLICATE_EXTERNAL_RATIONALE',
-          `Operation ${rationale.operationId} has more than one external-facing rationale.`,
-        ));
-      }
-      externalRationaleTargets.add(rationale.operationId);
+    const target = `${rationale.operationId}\u0000${rationale.visibility}`;
+    if (rationaleTargets.has(target)) {
+      issues.push(issue(
+        'DUPLICATE_RATIONALE_VISIBILITY',
+        `Operation ${rationale.operationId} has more than one ${rationale.visibility} rationale.`,
+      ));
     }
-    if (rationaleTargets.has(rationale.operationId)) {
-      issues.push(issue('MULTIPLE_RATIONALES', `Operation ${rationale.operationId} has more than one rationale block.`));
-    }
-    rationaleTargets.add(rationale.operationId);
+    rationaleTargets.add(target);
   }
   if (issues.length > 0 || !descriptor) return { valid: false, issues };
   return {

--- a/packages/docx-markdoc/src/rationale-comments.test.ts
+++ b/packages/docx-markdoc/src/rationale-comments.test.ts
@@ -158,6 +158,24 @@ describe('external-facing rationale comments', () => {
     });
   });
 
+  itAllure('[SDX-MDOC-62] dangerous compilation renders both paired rationales as distinct comments', async () => {
+    const source = await buildSyntheticDocx({ paragraphs: ['Alpha term.'] });
+    const imported = await importDocxToMarkdoc(source);
+    const internalText = 'Private synthetic decision record.';
+    const externalText = 'External synthetic explanation.';
+    const markdoc = compilationProfile(replaceOperation(imported.markdoc, 'Alpha term.', 'Beta term.'))
+      + rationale('edit', 'internal', internalText)
+      + rationale('edit', 'external-facing', externalText);
+    const result = await compileMarkdoc(imported.anchoredSource, markdoc, {
+      dangerouslyIncludeInternalComments: true,
+      configurationSource: 'cli',
+    });
+    const output = await parts(result.tracked);
+    expect(output.comments).toContain(internalText);
+    expect(output.comments).toContain(externalText);
+    expect((output.comments.match(/<w:comment /g) ?? [])).toHaveLength(2);
+  });
+
   for (const visibility of ['internal', 'external-facing'] as const) {
     itAllure(`[SDX-MDOC-61] rejects duplicate ${visibility} rationales`, async () => {
       const source = await buildSyntheticDocx({ paragraphs: ['Alpha term.'] });

--- a/packages/docx-markdoc/src/rationale-comments.test.ts
+++ b/packages/docx-markdoc/src/rationale-comments.test.ts
@@ -131,9 +131,46 @@ describe('external-facing rationale comments', () => {
       + rationale('edit', 'external-facing', 'Second synthetic explanation.');
     await expect(compileMarkdoc(imported.anchoredSource, markdoc, compileOptions)).rejects.toMatchObject({
       code: 'INVALID_MARKDOC',
-      issues: expect.arrayContaining([expect.objectContaining({ code: 'DUPLICATE_EXTERNAL_RATIONALE' })]),
+      issues: expect.arrayContaining([expect.objectContaining({ code: 'DUPLICATE_RATIONALE_VISIBILITY' })]),
     });
   });
+
+  itAllure('[SDX-MDOC-60] keeps internal reasoning private while exporting a paired external rationale', async () => {
+    const source = await buildSyntheticDocx({ paragraphs: ['Alpha term.'] });
+    const imported = await importDocxToMarkdoc(source);
+    const internalText = 'Private synthetic decision record.';
+    const externalText = 'External synthetic explanation.';
+    const markdoc = compilationProfile(replaceOperation(imported.markdoc, 'Alpha term.', 'Beta term.'))
+      + rationale('edit', 'internal', internalText)
+      + rationale('edit', 'external-facing', externalText);
+    const result = await compileMarkdoc(imported.anchoredSource, markdoc);
+    const zip = await JSZip.loadAsync(result.tracked);
+    const contents = await Promise.all(Object.values(zip.files)
+      .filter((entry) => !entry.dir)
+      .map((entry) => entry.async('string')));
+    expect(contents.join('\n')).toContain(externalText);
+    expect(contents.join('\n')).not.toContain(internalText);
+    expect(result.certificate.commentRendering).toMatchObject({
+      externalRationalesFound: 1,
+      internalRationalesFound: 1,
+      externalCommentsIncluded: true,
+      internalCommentsIncluded: false,
+    });
+  });
+
+  for (const visibility of ['internal', 'external-facing'] as const) {
+    itAllure(`[SDX-MDOC-61] rejects duplicate ${visibility} rationales`, async () => {
+      const source = await buildSyntheticDocx({ paragraphs: ['Alpha term.'] });
+      const imported = await importDocxToMarkdoc(source);
+      const markdoc = replaceOperation(imported.markdoc, 'Alpha term.', 'Beta term.')
+        + rationale('edit', visibility, 'First synthetic explanation.')
+        + rationale('edit', visibility, 'Second synthetic explanation.');
+      await expect(compileMarkdoc(imported.anchoredSource, markdoc, compileOptions)).rejects.toMatchObject({
+        code: 'INVALID_MARKDOC',
+        issues: expect.arrayContaining([expect.objectContaining({ code: 'DUPLICATE_RATIONALE_VISIBILITY' })]),
+      });
+    });
+  }
 
   for (const visibility of ['External-facing', 'external-facing ', '']) {
     itAllure(`[SDX-MDOC-57] rejects ${visibility || 'unclassified'} rationale visibility`, async () => {

--- a/packages/docx-markdoc/src/types.ts
+++ b/packages/docx-markdoc/src/types.ts
@@ -261,7 +261,10 @@ export type EditPair = {
   after: string;
   contextBefore: string[];
   contextAfter: string[];
+  rationales: Rationale[];
+  /** @deprecated Read `rationales`; populated only when exactly one rationale exists. */
   rationale?: string;
+  /** @deprecated Read `rationales`; populated only when exactly one rationale exists. */
   visibility?: Rationale['visibility'];
   verified?: boolean;
   provenance?: Record<string, string>;


### PR DESCRIPTION
## Summary
- group attribution discovery by operation so dangerous review exports can attach both visibility comments without marker overlap
- preserve paired rationale records in structured edit exports instead of collapsing them through an operation-only map
- add direct tests for dual native comments and lossless structured export

## Why
The advisory review on #887 correctly found that parser support alone was incomplete: the dangerous dual-comment path and structured export still assumed one rationale per operation.

## Validation
- mandatory repository pre-submit suite passed
- OpenSpec strict validation passed
- confidential two-mode real-document smoke passed locally; no fixture identity, contents, metrics, or artifacts are included

Ref #886
Follow-up to #887