### PR TITLE
ci(docx-compare): stabilize ILPA coverage timeout

### DIFF
--- a/packages/docx-compare/src/baselines/atomizer/documentReconstructor-inline-sdt.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/documentReconstructor-inline-sdt.test.ts
@@ -600,6 +600,10 @@ describe('Real block content-control corpus preservation', () => {
         }
       });
     },
-    120_000,
+    // Node 20 coverage instrumentation has exceeded two minutes on hosted
+    // runners even though the same corpus proof passes under Node 22 and in
+    // non-coverage runs. Keep the higher budget scoped to this two-document,
+    // forced-rebuild oracle rather than weakening the suite-wide timeout.
+    240_000,
   );
 });


### PR DESCRIPTION
## Summary
- increase the timeout only for the expensive real two-document ILPA content-control oracle
- document why Node 20 coverage runners need additional headroom
- leave the suite-wide timeout unchanged

## Verification
- focused docx-compare coverage run passed (9/9 tests)
- full mandatory pre-submit gate passed outside the sandbox, including LibreOffice integration tests

Unblocks #889.