### PR TITLE
fix(docx-markdoc): pin rationale attribution strategy

### DIFF
--- a/packages/docx-markdoc/src/compile.ts
+++ b/packages/docx-markdoc/src/compile.ts
@@ -906,6 +906,12 @@ export async function compileMarkdoc(
   ]);
   const comparisonOptions = {
     engine: 'atomizer',
+    // Rationale attribution compares a sentinel-instrumented document and then
+    // remaps the discovered revision onto an ordinary comparison. Keep those
+    // two private passes on the strategy whose alignment is marker-stable;
+    // inheriting the repository-wide default can otherwise change attribution
+    // semantics when the comparator default evolves.
+    comparisonStrategy: 'legacy',
     author: resolvedCompilation.author,
     date: resolvedCompilation.date,
     reconstructionMode: 'inplace',

--- a/packages/docx-markdoc/src/rationale-comments.test.ts
+++ b/packages/docx-markdoc/src/rationale-comments.test.ts
@@ -176,6 +176,46 @@ describe('external-facing rationale comments', () => {
     expect((output.comments.match(/<w:comment /g) ?? [])).toHaveLength(2);
   });
 
+  itAllure('[SDX-MDOC-44][SDX-MDOC-60][SDX-MDOC-62] keeps paired attribution stable for multi-operation partial rewrites', async () => {
+    const firstBefore = 'The purchaser shall ensure all personnel remain employees of the purchaser.';
+    const firstAfter = 'The purchaser shall ensure all personnel remain employees of the purchaser, and not the supplier.';
+    const secondBefore = 'Reports are delivered monthly.';
+    const secondAfter = 'Reports are delivered every calendar month.';
+    const source = await buildSyntheticDocx({ paragraphs: [firstBefore, secondBefore] });
+    const imported = await importDocxToMarkdoc(source);
+    const internalText = 'Private synthetic attribution record.';
+    const externalText = 'Clarifies responsibility for the assigned personnel.';
+    let markdoc = replaceOperation(imported.markdoc, firstBefore, firstAfter, 'personnel');
+    markdoc = replaceOperation(markdoc, secondBefore, secondAfter, 'reports');
+    markdoc = compilationProfile(markdoc)
+      + rationale('personnel', 'internal', internalText)
+      + rationale('personnel', 'external-facing', externalText)
+      + rationale('reports', 'external-facing', 'Clarifies the reporting cadence.');
+
+    const externalOnly = await compileMarkdoc(imported.anchoredSource, markdoc);
+    const externalZip = await JSZip.loadAsync(externalOnly.tracked);
+    const externalContents = (await Promise.all(Object.values(externalZip.files)
+      .filter((entry) => !entry.dir)
+      .map((entry) => entry.async('string')))).join('\n');
+    expect(externalContents).toContain(externalText);
+    expect(externalContents).not.toContain(internalText);
+    expect(externalOnly.certificate).toMatchObject({
+      rejectAllEqualsSource: true,
+      acceptAllEqualsClean: true,
+      rejectAllFormattingEqualsSource: true,
+      acceptAllFormattingEqualsClean: true,
+    });
+
+    const dangerous = await compileMarkdoc(imported.anchoredSource, markdoc, {
+      dangerouslyIncludeInternalComments: true,
+      configurationSource: 'cli',
+    });
+    const dangerousComments = (await parts(dangerous.tracked)).comments;
+    expect(dangerousComments).toContain(internalText);
+    expect(dangerousComments).toContain(externalText);
+    expect((dangerousComments.match(/<w:comment /g) ?? [])).toHaveLength(3);
+  });
+
   for (const visibility of ['internal', 'external-facing'] as const) {
     itAllure(`[SDX-MDOC-61] rejects duplicate ${visibility} rationales`, async () => {
       const source = await buildSyntheticDocx({ paragraphs: ['Alpha term.'] });


### PR DESCRIPTION
## Summary
- pin both private rationale-attribution comparisons to the marker-stable legacy strategy
- preserve strict exact remapping instead of guessing when attribution differs
- add a public-safe multi-operation paired-rationale regression test

## Why
A repository-wide comparator default change caused sentinel instrumentation to perturb alignment. Valid Markdoc compiled through validation but then failed closed with `RATIONALE_ANCHOR_AMBIGUOUS`.

## Verification
- focused rationale suite: 24/24 passed
- full docx-markdoc suite: 65/65 passed
- full mandatory pre-submit gate passed
- private real-world DOCX passed external-only and explicit internal-review modes; no client artifact or details are included here

Fixes #893.