### PR TITLE
fix(docx-compare): resolve terminal paragraph deletions for LibreOffice

### DIFF
--- a/packages/docx-compare/src/baselines/atomizer/taggedTreeSerializer.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/taggedTreeSerializer.test.ts
@@ -339,17 +339,82 @@ describe('tagged-tree shadow serializer', () => {
     expect(paragraphs).toHaveLength(3);
     expect(paragraphs[1]!.getElementsByTagNameNS(W_NS, 'del')).toHaveLength(1);
     expect(paragraphs[2]!.getElementsByTagNameNS(W_NS, 'pPrChange')).toHaveLength(1);
-    const generatedIds = Array.from(
-      output.matchAll(/<w:(?:del|pPrChange)\b[^>]*w:id="(\d+)"/gu),
-      (match) => Number(match[1]),
-    );
-    expect(generatedIds).toEqual([...generatedIds].sort((left, right) => left - right));
     const originalXml = `<w:document xmlns:w="${W_NS}">${new XMLSerializer().serializeToString(original)}</w:document>`;
     const revisedXml = `<w:document xmlns:w="${W_NS}">${new XMLSerializer().serializeToString(revised)}</w:document>`;
     const candidateXml = `<w:document xmlns:w="${W_NS}">${output}</w:document>`;
     expect(compareSourceProjectedFormattingFidelity(originalXml, revisedXml, candidateXml).score).toBe(1);
     expect(text(acceptAllChanges(candidateXml))).toBe('AlphaBravo');
     expect(text(rejectAllChanges(candidateXml))).toBe('AlphaBravoCharlie');
+  });
+
+  test('never places two tracked-change markers on one paragraph mark', () => {
+    const original = documentBody(
+      '<w:p><w:r><w:t>A</w:t></w:r></w:p><w:p><w:r><w:t>B</w:t></w:r></w:p>' +
+      '<w:p><w:r><w:t>C</w:t></w:r></w:p><w:p><w:r><w:t>D</w:t></w:r></w:p>',
+    );
+    const revised = documentBody('');
+    const constructed = constructTaggedTree(original, revised);
+    const output = serializeTaggedTree(constructed.tree, createPreservePlan(original, revised, constructed.tree, {
+      author: 'Comparator', date: '2026-08-17T00:00:00Z',
+    }));
+    const markProperties = Array.from(parseXml(output).getElementsByTagNameNS(W_NS, 'p'))
+      .flatMap((paragraph) => elementChildren(paragraph).filter((child) => child.localName === 'pPr'))
+      .flatMap((pPr) => elementChildren(pPr).filter((child) => child.localName === 'rPr'));
+
+    // CT_ParaRPr admits at most one of w:ins/w:del/w:moveFrom/w:moveTo.
+    for (const rPr of markProperties) {
+      const markers = elementChildren(rPr).filter((child) =>
+        ['ins', 'del', 'moveFrom', 'moveTo'].includes(child.localName));
+      expect(markers.length).toBeLessThanOrEqual(1);
+    }
+  });
+
+  test('does not move a deletion marker across an intervening table', () => {
+    const table = '<w:tbl><w:tblPr/><w:tblGrid><w:gridCol w:w="1000"/></w:tblGrid>' +
+      '<w:tr><w:tc><w:p><w:r><w:t>T</w:t></w:r></w:p></w:tc></w:tr></w:tbl>';
+    const original = documentBody(
+      `<w:p><w:r><w:t>A</w:t></w:r></w:p>${table}<w:p><w:r><w:t>B</w:t></w:r></w:p>`,
+    );
+    const revised = documentBody(`<w:p><w:r><w:t>A</w:t></w:r></w:p>${table}`);
+    const constructed = constructTaggedTree(original, revised);
+    const output = serializeTaggedTree(constructed.tree, createPreservePlan(original, revised, constructed.tree, {
+      author: 'Comparator', date: '2026-08-17T00:00:00Z',
+    }));
+    const parsed = parseXml(output);
+    const bodyParagraphs = elementChildren(
+      Array.from(parsed.getElementsByTagNameNS(W_NS, 'body'))[0] ?? parsed.documentElement!,
+    ).filter((child) => child.localName === 'p');
+
+    // "A" sits before the table, so its break is not the one preceding "B".
+    const paragraphMarkDels = (paragraph: Element): number => elementChildren(paragraph)
+      .filter((child) => child.localName === 'pPr')
+      .flatMap((pPr) => elementChildren(pPr).filter((child) => child.localName === 'rPr'))
+      .flatMap((rPr) => elementChildren(rPr).filter((child) => child.localName === 'del')).length;
+    expect(paragraphMarkDels(bodyParagraphs[0]!)).toBe(0);
+  });
+
+  test('leaves a section-bearing terminal deletion in the unrelocated topology', () => {
+    const original = documentBody(
+      '<w:p><w:pPr><w:jc w:val="center"/></w:pPr><w:r><w:t>A</w:t></w:r></w:p>' +
+      '<w:p><w:pPr><w:jc w:val="right"/><w:sectPr><w:type w:val="continuous"/></w:sectPr></w:pPr>' +
+      '<w:r><w:t>B</w:t></w:r></w:p>',
+    );
+    const revised = documentBody(
+      '<w:p><w:pPr><w:jc w:val="center"/></w:pPr><w:r><w:t>A</w:t></w:r></w:p>',
+    );
+    const constructed = constructTaggedTree(original, revised);
+    const output = serializeTaggedTree(constructed.tree, createPreservePlan(original, revised, constructed.tree, {
+      author: 'Comparator', date: '2026-08-17T00:00:00Z',
+    }));
+    const paragraphs = Array.from(parseXml(output).getElementsByTagNameNS(W_NS, 'p'));
+    const paragraphMarkDels = (paragraph: Element): number => elementChildren(paragraph)
+      .filter((child) => child.localName === 'pPr')
+      .flatMap((pPr) => elementChildren(pPr).filter((child) => child.localName === 'rPr'))
+      .flatMap((rPr) => elementChildren(rPr).filter((child) => child.localName === 'del')).length;
+
+    // Relocating across a w:sectPr boundary makes LibreOffice mis-resolve Reject All.
+    expect(paragraphMarkDels(paragraphs[0]!)).toBe(0);
+    expect(paragraphMarkDels(paragraphs[1]!)).toBe(1);
   });
 
   test('orders a relocated paragraph deletion before paragraph-mark formatting', () => {

--- a/packages/docx-compare/src/baselines/atomizer/taggedTreeSerializer.test.ts
+++ b/packages/docx-compare/src/baselines/atomizer/taggedTreeSerializer.test.ts
@@ -319,6 +319,123 @@ describe('tagged-tree shadow serializer', () => {
     expect(compareSourceProjectedFormattingFidelity(originalXml, revisedXml, candidateXml).score).toBe(1);
   });
 
+  test('places a terminal paragraph deletion on the preceding break with exact projections', () => {
+    const original = documentBody(
+      '<w:p><w:pPr><w:jc w:val="left"/></w:pPr><w:r><w:t>Alpha</w:t></w:r></w:p>' +
+      '<w:p><w:pPr><w:jc w:val="center"/></w:pPr><w:r><w:t>Bravo</w:t></w:r></w:p>' +
+      '<w:p><w:pPr><w:jc w:val="right"/></w:pPr><w:r><w:t>Charlie</w:t></w:r></w:p>',
+    );
+    const revised = documentBody(
+      '<w:p><w:pPr><w:jc w:val="left"/></w:pPr><w:r><w:t>Alpha</w:t></w:r></w:p>' +
+      '<w:p><w:pPr><w:jc w:val="center"/></w:pPr><w:r><w:t>Bravo</w:t></w:r></w:p>',
+    );
+    const constructed = constructTaggedTree(original, revised);
+    const output = serializeTaggedTree(constructed.tree, createPreservePlan(original, revised, constructed.tree, {
+      author: 'Comparator', date: '2026-08-17T00:00:00Z',
+    }));
+    const parsed = parseXml(output);
+    const paragraphs = Array.from(parsed.getElementsByTagNameNS(W_NS, 'p'));
+
+    expect(paragraphs).toHaveLength(3);
+    expect(paragraphs[1]!.getElementsByTagNameNS(W_NS, 'del')).toHaveLength(1);
+    expect(paragraphs[2]!.getElementsByTagNameNS(W_NS, 'pPrChange')).toHaveLength(1);
+    const generatedIds = Array.from(
+      output.matchAll(/<w:(?:del|pPrChange)\b[^>]*w:id="(\d+)"/gu),
+      (match) => Number(match[1]),
+    );
+    expect(generatedIds).toEqual([...generatedIds].sort((left, right) => left - right));
+    const originalXml = `<w:document xmlns:w="${W_NS}">${new XMLSerializer().serializeToString(original)}</w:document>`;
+    const revisedXml = `<w:document xmlns:w="${W_NS}">${new XMLSerializer().serializeToString(revised)}</w:document>`;
+    const candidateXml = `<w:document xmlns:w="${W_NS}">${output}</w:document>`;
+    expect(compareSourceProjectedFormattingFidelity(originalXml, revisedXml, candidateXml).score).toBe(1);
+    expect(text(acceptAllChanges(candidateXml))).toBe('AlphaBravo');
+    expect(text(rejectAllChanges(candidateXml))).toBe('AlphaBravoCharlie');
+  });
+
+  test('orders a relocated paragraph deletion before paragraph-mark formatting', () => {
+    const markProperties = '<w:rPr><w:b/></w:rPr>';
+    const original = documentBody(
+      `<w:p><w:pPr>${markProperties}</w:pPr><w:r><w:t>Keep</w:t></w:r></w:p>` +
+      '<w:p><w:r><w:t>Delete</w:t></w:r></w:p>',
+    );
+    const revised = documentBody(`<w:p><w:pPr>${markProperties}</w:pPr><w:r><w:t>Keep</w:t></w:r></w:p>`);
+    const constructed = constructTaggedTree(original, revised);
+    const output = serializeTaggedTree(constructed.tree, createPreservePlan(original, revised, constructed.tree, {
+      author: 'Comparator', date: '2026-08-17T00:00:00Z',
+    }));
+    const predecessorRPr = parseXml(output).getElementsByTagNameNS(W_NS, 'p')[0]!
+      .getElementsByTagNameNS(W_NS, 'rPr')[0]!;
+
+    expect(elementChildren(predecessorRPr).map((child) => child.localName)).toEqual(['del', 'b']);
+  });
+
+  test('does not rewrite a predecessor carrying prior paragraph-mark revisions', () => {
+    const markProperties = '<w:rPr><w:b/><w:rPrChange w:id="2" w:author="Prior" w:date="2026-08-01T00:00:00Z"><w:rPr><w:i/></w:rPr></w:rPrChange></w:rPr>';
+    const original = documentBody(
+      `<w:p><w:pPr>${markProperties}</w:pPr><w:r><w:t>Keep</w:t></w:r></w:p>` +
+      '<w:p><w:r><w:t>Delete</w:t></w:r></w:p>',
+    );
+    const revised = documentBody(`<w:p><w:pPr>${markProperties}</w:pPr><w:r><w:t>Keep</w:t></w:r></w:p>`);
+    const constructed = constructTaggedTree(original, revised);
+    const output = serializeTaggedTree(constructed.tree, createPreservePlan(original, revised, constructed.tree, {
+      author: 'Comparator', date: '2026-08-17T00:00:00Z',
+    }));
+    const paragraphs = Array.from(parseXml(output).getElementsByTagNameNS(W_NS, 'p'));
+
+    expect(paragraphs[0]!.getElementsByTagNameNS(W_NS, 'del')).toHaveLength(0);
+    expect(paragraphs[1]!.getElementsByTagNameNS(W_NS, 'del')).toHaveLength(2);
+  });
+
+  test('allocates generated IDs above every authored revision vocabulary element', () => {
+    const table = '<w:tbl><w:tblPr><w:tblPrChange w:id="0" w:author="Prior"><w:tblPr/></w:tblPrChange></w:tblPr>' +
+      '<w:tblGrid><w:gridCol w:w="1000"/></w:tblGrid><w:tr><w:tc><w:p><w:r><w:t>T</w:t></w:r></w:p></w:tc></w:tr></w:tbl>';
+    const original = documentBody(`${table}<w:p><w:r><w:t>old</w:t></w:r></w:p>`);
+    const revised = documentBody(`${table}<w:p><w:r><w:t>new</w:t></w:r></w:p>`);
+    const constructed = constructTaggedTree(original, revised);
+    const output = serializeTaggedTree(constructed.tree, createPreservePlan(original, revised, constructed.tree, {
+      author: 'Comparator', date: '2026-08-17T00:00:00Z',
+    }));
+    const ids = Array.from(output.matchAll(/w:id="(\d+)"/gu), (match) => Number(match[1]));
+
+    expect(ids[0]).toBe(0);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids.slice(1).every((id) => id > 0)).toBe(true);
+  });
+
+  test('keeps exact projections for middle, consecutive, ranged, and section-bearing deletions', () => {
+    const cases = [
+      {
+        original: '<w:p><w:r><w:t>A</w:t></w:r></w:p><w:p><w:r><w:t>B</w:t></w:r></w:p><w:p><w:r><w:t>C</w:t></w:r></w:p>',
+        revised: '<w:p><w:r><w:t>A</w:t></w:r></w:p><w:p><w:r><w:t>C</w:t></w:r></w:p>',
+      },
+      {
+        original: '<w:p><w:r><w:t>A</w:t></w:r></w:p><w:p><w:r><w:t>B</w:t></w:r></w:p><w:p><w:r><w:t>C</w:t></w:r></w:p><w:p><w:r><w:t>D</w:t></w:r></w:p>',
+        revised: '<w:p><w:r><w:t>A</w:t></w:r></w:p><w:p><w:r><w:t>B</w:t></w:r></w:p>',
+      },
+      {
+        original: '<w:p><w:r><w:t>A</w:t></w:r></w:p><w:p><w:bookmarkStart w:id="7" w:name="Deleted"/><w:r><w:t>B</w:t></w:r><w:bookmarkEnd w:id="7"/></w:p><w:p><w:r><w:t>C</w:t></w:r></w:p>',
+        revised: '<w:p><w:r><w:t>A</w:t></w:r></w:p><w:p><w:r><w:t>C</w:t></w:r></w:p>',
+      },
+      {
+        original: '<w:p><w:pPr><w:jc w:val="center"/></w:pPr><w:r><w:t>A</w:t></w:r></w:p><w:p><w:pPr><w:jc w:val="right"/><w:sectPr><w:type w:val="continuous"/></w:sectPr></w:pPr><w:r><w:t>B</w:t></w:r></w:p>',
+        revised: '<w:p><w:pPr><w:jc w:val="center"/></w:pPr><w:r><w:t>A</w:t></w:r></w:p>',
+      },
+    ];
+
+    for (const fixture of cases) {
+      const original = documentBody(fixture.original);
+      const revised = documentBody(fixture.revised);
+      const constructed = constructTaggedTree(original, revised);
+      const output = serializeTaggedTree(constructed.tree, createPreservePlan(original, revised, constructed.tree, {
+        author: 'Comparator', date: '2026-08-17T00:00:00Z',
+      }));
+      const originalXml = `<w:document xmlns:w="${W_NS}">${new XMLSerializer().serializeToString(original)}</w:document>`;
+      const revisedXml = `<w:document xmlns:w="${W_NS}">${new XMLSerializer().serializeToString(revised)}</w:document>`;
+      const candidateXml = `<w:document xmlns:w="${W_NS}">${output}</w:document>`;
+      expect(compareSourceProjectedFormattingFidelity(originalXml, revisedXml, candidateXml).score).toBe(1);
+    }
+  });
+
   test('serializes paragraph property families only through conforming property changes', () => {
     const original = documentBody(
       '<w:p><w:pPr><w:pStyle w:val="Old"/><w:numPr><w:ilvl w:val="1"/><w:numId w:val="4"/></w:numPr>' +

--- a/packages/docx-compare/src/baselines/atomizer/taggedTreeSerializer.ts
+++ b/packages/docx-compare/src/baselines/atomizer/taggedTreeSerializer.ts
@@ -1,7 +1,12 @@
 import { XMLSerializer } from '@xmldom/xmldom';
 import type { WmlElement } from '@usejunior/docx-core';
-import { childElements, parseXml } from '@usejunior/docx-core';
+import {
+  childElements,
+  parseXml,
+  REVISION_ID_ELEMENT_NAME_SET,
+} from '@usejunior/docx-core';
 import { alignComparisonSequences, tokenizeComparisonText } from '../../textAlignment.js';
+import { placeParagraphMarkRevisionMarker } from './inPlaceModifier-wrappers.js';
 import {
   nextRevisionId,
   PROPERTY_SCOPE_ELEMENT,
@@ -282,7 +287,7 @@ function markWholeParagraph(
   marker.setAttributeNS(W_NS, 'w:id', String(revision.id));
   marker.setAttributeNS(W_NS, 'w:author', revision.author);
   marker.setAttributeNS(W_NS, 'w:date', revision.date);
-  paraRPr.appendChild(marker);
+  placeParagraphMarkRevisionMarker(paraRPr, marker, `w:${kind}`);
 
   const content = childElements(paragraph).filter((child) => child !== pPr);
   for (const child of content) paragraph.removeChild(child);
@@ -313,6 +318,153 @@ function markWholeParagraph(
   }
   flush();
   return paragraph;
+}
+
+/**
+ * Encode a deleted paragraph break on the preceding paragraph when one exists.
+ *
+ * A whole-paragraph deletion has two independent edits: delete the paragraph's
+ * contents and delete the break immediately before those contents.  Keeping the
+ * break marker on the deleted paragraph works for Safe DOCX's internal projector,
+ * but LibreOffice cannot remove a terminal paragraph container that way and leaves
+ * an empty final paragraph.  Moving the marker to the preceding paragraph lets
+ * Accept All merge that survivor into the deleted container.  The deleted
+ * container temporarily carries the survivor's properties so the merged paragraph
+ * keeps its revised formatting; a conforming pPrChange snapshot restores the
+ * deleted paragraph's original properties on Reject All.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.5.15
+ * @see https://github.com/UseJunior/safe-docx/issues/891
+ */
+function normalizeWholeParagraphDeletions(
+  root: WmlElement,
+  generatedRevisionIds: ReadonlySet<number>,
+  allocateRevision: () => ComparisonRevision,
+): void {
+  const visit = (container: WmlElement): void => {
+    const children = childElements(container);
+    for (let index = 0; index < children.length; index++) {
+      const paragraph = children[index]!;
+      if (paragraph.namespaceURI !== W_NS || paragraph.localName !== 'p') {
+        visit(paragraph);
+        continue;
+      }
+      const predecessor = children.slice(0, index).reverse().find(
+        (candidate) => candidate.namespaceURI === W_NS && candidate.localName === 'p',
+      );
+      if (!predecessor) continue;
+      const revisionElements = (scope: WmlElement): WmlElement[] => {
+        const revisions: WmlElement[] = [];
+        const collect = (element: WmlElement): void => {
+          if (element.namespaceURI === W_NS && REVISION_ID_ELEMENT_NAME_SET.has(element.localName)) {
+            revisions.push(element);
+          }
+          for (const child of childElements(element)) collect(child);
+        };
+        collect(scope);
+        return revisions;
+      };
+      const revisionWasGenerated = (element: WmlElement): boolean => {
+        const id = Number(element.getAttributeNS(W_NS, 'id'));
+        return Number.isSafeInteger(id) && generatedRevisionIds.has(id);
+      };
+      const predecessorPropertiesBefore = childElements(predecessor).find((child) => child.localName === 'pPr');
+      const predecessorRevisions = predecessorPropertiesBefore
+        ? revisionElements(predecessorPropertiesBefore)
+        : [];
+      if (predecessorRevisions.some((element) => !revisionWasGenerated(element)) ||
+          predecessorRevisions.some((element) => ['ins', 'moveFrom', 'moveTo'].includes(element.localName))) {
+        continue;
+      }
+      const pPr = childElements(paragraph).find((child) => child.localName === 'pPr');
+      const markProperties = pPr && childElements(pPr).find((child) => child.localName === 'rPr');
+      const marker = markProperties && childElements(markProperties).find((child) => {
+        if (child.localName !== 'del') return false;
+        const id = Number(child.getAttributeNS(W_NS, 'id'));
+        return Number.isSafeInteger(id) && generatedRevisionIds.has(id);
+      });
+      const content = childElements(paragraph).filter((child) =>
+        child !== pPr && !RANGE_BOUNDARY_LOCALS.has(child.localName));
+      if (!pPr || !markProperties || !marker || content.length === 0 ||
+          content.some((child) => child.namespaceURI !== W_NS || child.localName !== 'del')) continue;
+      if (revisionElements(pPr).some((element) => element !== marker)) continue;
+
+      const originalProperties = cloneElement(pPr);
+      const originalMarkProperties = childElements(originalProperties).find((child) => child.localName === 'rPr');
+      const originalMarker = originalMarkProperties && childElements(originalMarkProperties).find((child) =>
+        child.localName === 'del' && child.getAttributeNS(W_NS, 'id') === marker.getAttributeNS(W_NS, 'id'));
+      originalMarker?.parentNode?.removeChild(originalMarker);
+      if (originalMarkProperties && childElements(originalMarkProperties).length === 0) {
+        originalProperties.removeChild(originalMarkProperties);
+      }
+
+      let predecessorProperties = childElements(predecessor).find((child) => child.localName === 'pPr');
+      const revisedProperties = predecessorProperties
+        ? cloneElement(predecessorProperties)
+        : predecessor.ownerDocument!.createElementNS(W_NS, 'w:pPr') as WmlElement;
+      for (const stale of revisionElements(revisedProperties)) {
+        stale.parentNode?.removeChild(stale);
+      }
+      if (!predecessorProperties) {
+        predecessorProperties = predecessor.ownerDocument!.createElementNS(W_NS, 'w:pPr') as WmlElement;
+        predecessor.insertBefore(predecessorProperties, predecessor.firstChild);
+      }
+      let predecessorMarkProperties = childElements(predecessorProperties).find((child) => child.localName === 'rPr');
+      if (!predecessorMarkProperties) {
+        predecessorMarkProperties = predecessor.ownerDocument!.createElementNS(W_NS, 'w:rPr') as WmlElement;
+        const boundary = childElements(predecessorProperties).find((child) =>
+          ['sectPr', 'pPrChange'].includes(child.localName));
+        predecessorProperties.insertBefore(predecessorMarkProperties, boundary ?? null);
+      }
+      marker.parentNode!.removeChild(marker);
+      placeParagraphMarkRevisionMarker(predecessorMarkProperties, marker, 'w:del');
+      if (childElements(markProperties).length === 0) pPr.removeChild(markProperties);
+
+      applyParagraphPropertyDelta(
+        paragraph,
+        originalProperties,
+        revisedProperties,
+        allocateRevision(),
+      );
+    }
+  };
+  visit(root);
+}
+
+/**
+ * Keep generated revision identifiers monotonic in serialized document order.
+ *
+ * Post-serialization normalizers can insert a later-allocated property change
+ * before an earlier content revision. Word tolerates that ordering, but
+ * LibreOffice can resolve the paragraph break incorrectly. A single mapping per
+ * old identifier preserves linked move-range identities while placing every
+ * generated equivalence class in first-occurrence order above all authored IDs.
+ */
+function renumberGeneratedRevisionsInDocumentOrder(
+  root: WmlElement,
+  generatedRevisionIds: ReadonlySet<number>,
+): void {
+  const revisions: WmlElement[] = [];
+  const collect = (element: WmlElement): void => {
+    if (element.namespaceURI === W_NS && REVISION_ID_ELEMENT_NAME_SET.has(element.localName)) revisions.push(element);
+    for (const child of childElements(element)) collect(child);
+  };
+  collect(root);
+  const authoredIds = revisions
+    .map((element) => Number(element.getAttributeNS(W_NS, 'id')))
+    .filter((id) => Number.isSafeInteger(id) && id >= 0 && !generatedRevisionIds.has(id));
+  let nextId = Math.max(-1, ...authoredIds) + 1;
+  const replacements = new Map<number, number>();
+  for (const revision of revisions) {
+    const oldId = Number(revision.getAttributeNS(W_NS, 'id'));
+    if (!Number.isSafeInteger(oldId) || !generatedRevisionIds.has(oldId)) continue;
+    let replacement = replacements.get(oldId);
+    if (replacement === undefined) {
+      replacement = nextId++;
+      replacements.set(oldId, replacement);
+    }
+    revision.setAttributeNS(W_NS, 'w:id', String(replacement));
+  }
 }
 
 function markWholeTableRow(
@@ -1207,12 +1359,22 @@ export function serializeTaggedTree(
   options: TaggedTreeSerializerOptions = {},
 ): string {
   if (!plan.entries.has(tree)) throw new Error('PreservePlan does not belong to this TaggedTree');
+  const representatives = tree.tag === 'both' ? [tree.original, tree.revised] : [tree.node];
+  const usedRevisionIds = representatives.flatMap((root) => [...REVISION_ID_ELEMENT_NAME_SET].flatMap((localName) =>
+    Array.from(root.getElementsByTagNameNS(W_NS, localName))))
+    .map((element) => Number(element.getAttributeNS(W_NS, 'id')))
+    .filter((id) => Number.isSafeInteger(id) && id >= 0);
   let nextId = Math.max(
     plan.comparison.id,
     ...((options.moves ?? []).flatMap((move) => [move.sourceRangeId, move.destinationRangeId])),
+    ...usedRevisionIds,
   ) + 1;
-  const allocateRevision = (): ComparisonRevision => ({ ...plan.comparison, id: nextId++ });
-  const representatives = tree.tag === 'both' ? [tree.original, tree.revised] : [tree.node];
+  const generatedRevisionIds = new Set<number>();
+  const allocateRevision = (): ComparisonRevision => {
+    const revision = { ...plan.comparison, id: nextId++ };
+    generatedRevisionIds.add(revision.id);
+    return revision;
+  };
   const usedBookmarkIds = representatives.flatMap((root) => [
     ...Array.from(root.getElementsByTagNameNS(W_NS, 'bookmarkStart')),
     ...Array.from(root.getElementsByTagNameNS(W_NS, 'bookmarkEnd')),
@@ -1247,8 +1409,10 @@ export function serializeTaggedTree(
     splitBookmarkIds,
   );
   splitCrossParagraphBookmarkCounterparts(emitted, originalBookmarkIds, allocateRevision);
+  normalizeWholeParagraphDeletions(emitted, generatedRevisionIds, allocateRevision);
   hoistFieldCharactersFromDeletions(emitted);
   hoistLiteralInsertionsFromDeletedFieldInstructions(emitted);
+  renumberGeneratedRevisionsInDocumentOrder(emitted, generatedRevisionIds);
   return new XMLSerializer().serializeToString(emitted);
 }
 

--- a/packages/docx-compare/src/baselines/atomizer/taggedTreeSerializer.ts
+++ b/packages/docx-compare/src/baselines/atomizer/taggedTreeSerializer.ts
@@ -29,6 +29,8 @@ const RANGE_BOUNDARY_LOCALS = new Set([
   'bookmarkStart', 'bookmarkEnd', 'commentRangeStart', 'commentRangeEnd',
   'moveFromRangeStart', 'moveFromRangeEnd', 'moveToRangeStart', 'moveToRangeEnd',
 ]);
+/** Tracked-change markers `CT_ParaRPr` admits on a paragraph mark, at most one of. */
+const PARAGRAPH_MARK_REVISION_LOCALS = new Set(['ins', 'del', 'moveFrom', 'moveTo']);
 
 export interface ComparisonRevision {
   id: number;
@@ -333,7 +335,19 @@ function markWholeParagraph(
  * keeps its revised formatting; a conforming pPrChange snapshot restores the
  * deleted paragraph's original properties on Reject All.
  *
+ * Relocation is deliberately conservative.  It never crosses a non-paragraph
+ * block such as a table, because the paragraph before a table is not the
+ * paragraph whose break precedes this content.  It never targets a predecessor
+ * whose own paragraph mark already carries a tracked change, because
+ * `CT_ParaRPr` admits at most one of `w:ins`/`w:del`/`w:moveFrom`/`w:moveTo`.
+ * It never touches a section-bearing paragraph, because moving the mark across
+ * a `w:sectPr` boundary makes LibreOffice resolve Reject All incorrectly.
+ * Deletions outside that envelope keep the pre-existing topology, which stays
+ * schema-valid and Word-correct even where LibreOffice still leaves an empty
+ * terminal container.
+ *
  * @conformance ECMA-376 edition 5, Part 1 § 17.13.5.15
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.5.29
  * @see https://github.com/UseJunior/safe-docx/issues/891
  */
 function normalizeWholeParagraphDeletions(
@@ -341,130 +355,116 @@ function normalizeWholeParagraphDeletions(
   generatedRevisionIds: ReadonlySet<number>,
   allocateRevision: () => ComparisonRevision,
 ): void {
+  const revisionElements = (scope: WmlElement): WmlElement[] => {
+    const revisions: WmlElement[] = [];
+    const collect = (element: WmlElement): void => {
+      if (element.namespaceURI === W_NS && REVISION_ID_ELEMENT_NAME_SET.has(element.localName)) {
+        revisions.push(element);
+      }
+      for (const child of childElements(element)) collect(child);
+    };
+    collect(scope);
+    return revisions;
+  };
+  const revisionWasGenerated = (element: WmlElement): boolean => {
+    const id = Number(element.getAttributeNS(W_NS, 'id'));
+    return Number.isSafeInteger(id) && generatedRevisionIds.has(id);
+  };
+  const paragraphProperties = (paragraph: WmlElement): WmlElement | undefined =>
+    childElements(paragraph).find((child) => child.localName === 'pPr');
+  const carriesSection = (paragraph: WmlElement): boolean => {
+    const properties = paragraphProperties(paragraph);
+    return !!properties && childElements(properties).some((child) => child.localName === 'sectPr');
+  };
+  const carriesParagraphMarkRevision = (paragraph: WmlElement): boolean => {
+    const properties = paragraphProperties(paragraph);
+    const markProperties = properties && childElements(properties).find((child) => child.localName === 'rPr');
+    return !!markProperties && childElements(markProperties).some((child) =>
+      child.namespaceURI === W_NS && PARAGRAPH_MARK_REVISION_LOCALS.has(child.localName));
+  };
+
+  const relocate = (paragraph: WmlElement, predecessor: WmlElement | undefined): void => {
+    if (!predecessor) return;
+    // CT_ParaRPr admits at most one tracked-change marker; never add a second.
+    if (carriesParagraphMarkRevision(predecessor)) return;
+    // A w:sectPr boundary changes how the merged paragraph resolves on Reject All.
+    if (carriesSection(paragraph) || carriesSection(predecessor)) return;
+    const predecessorPropertiesBefore = paragraphProperties(predecessor);
+    const predecessorRevisions = predecessorPropertiesBefore
+      ? revisionElements(predecessorPropertiesBefore)
+      : [];
+    if (predecessorRevisions.some((element) => !revisionWasGenerated(element)) ||
+        predecessorRevisions.some((element) => ['ins', 'moveFrom', 'moveTo'].includes(element.localName))) {
+      return;
+    }
+    const pPr = childElements(paragraph).find((child) => child.localName === 'pPr');
+    const markProperties = pPr && childElements(pPr).find((child) => child.localName === 'rPr');
+    const marker = markProperties && childElements(markProperties).find((child) => {
+      if (child.localName !== 'del') return false;
+      const id = Number(child.getAttributeNS(W_NS, 'id'));
+      return Number.isSafeInteger(id) && generatedRevisionIds.has(id);
+    });
+    const content = childElements(paragraph).filter((child) =>
+      child !== pPr && !RANGE_BOUNDARY_LOCALS.has(child.localName));
+    if (!pPr || !markProperties || !marker || content.length === 0 ||
+        content.some((child) => child.namespaceURI !== W_NS || child.localName !== 'del')) return;
+    if (revisionElements(pPr).some((element) => element !== marker)) return;
+
+    const originalProperties = cloneElement(pPr);
+    const originalMarkProperties = childElements(originalProperties).find((child) => child.localName === 'rPr');
+    const originalMarker = originalMarkProperties && childElements(originalMarkProperties).find((child) =>
+      child.localName === 'del' && child.getAttributeNS(W_NS, 'id') === marker.getAttributeNS(W_NS, 'id'));
+    originalMarker?.parentNode?.removeChild(originalMarker);
+    if (originalMarkProperties && childElements(originalMarkProperties).length === 0) {
+      originalProperties.removeChild(originalMarkProperties);
+    }
+
+    let predecessorProperties = childElements(predecessor).find((child) => child.localName === 'pPr');
+    const revisedProperties = predecessorProperties
+      ? cloneElement(predecessorProperties)
+      : predecessor.ownerDocument!.createElementNS(W_NS, 'w:pPr') as WmlElement;
+    for (const stale of revisionElements(revisedProperties)) {
+      stale.parentNode?.removeChild(stale);
+    }
+    if (!predecessorProperties) {
+      predecessorProperties = predecessor.ownerDocument!.createElementNS(W_NS, 'w:pPr') as WmlElement;
+      predecessor.insertBefore(predecessorProperties, predecessor.firstChild);
+    }
+    let predecessorMarkProperties = childElements(predecessorProperties).find((child) => child.localName === 'rPr');
+    if (!predecessorMarkProperties) {
+      predecessorMarkProperties = predecessor.ownerDocument!.createElementNS(W_NS, 'w:rPr') as WmlElement;
+      const boundary = childElements(predecessorProperties).find((child) =>
+        ['sectPr', 'pPrChange'].includes(child.localName));
+      predecessorProperties.insertBefore(predecessorMarkProperties, boundary ?? null);
+    }
+    marker.parentNode!.removeChild(marker);
+    placeParagraphMarkRevisionMarker(predecessorMarkProperties, marker, 'w:del');
+    if (childElements(markProperties).length === 0) pPr.removeChild(markProperties);
+
+    applyParagraphPropertyDelta(
+      paragraph,
+      originalProperties,
+      revisedProperties,
+      allocateRevision(),
+    );
+  };
+
   const visit = (container: WmlElement): void => {
-    const children = childElements(container);
-    for (let index = 0; index < children.length; index++) {
-      const paragraph = children[index]!;
-      if (paragraph.namespaceURI !== W_NS || paragraph.localName !== 'p') {
-        visit(paragraph);
+    // Track the immediately preceding sibling paragraph in a single pass.  Any
+    // intervening block clears the candidate, so a marker never crosses a table,
+    // and the walk stays linear in the number of children.
+    let predecessor: WmlElement | undefined;
+    for (const child of childElements(container)) {
+      if (child.namespaceURI !== W_NS || child.localName !== 'p') {
+        visit(child);
+        predecessor = undefined;
         continue;
       }
-      const predecessor = children.slice(0, index).reverse().find(
-        (candidate) => candidate.namespaceURI === W_NS && candidate.localName === 'p',
-      );
-      if (!predecessor) continue;
-      const revisionElements = (scope: WmlElement): WmlElement[] => {
-        const revisions: WmlElement[] = [];
-        const collect = (element: WmlElement): void => {
-          if (element.namespaceURI === W_NS && REVISION_ID_ELEMENT_NAME_SET.has(element.localName)) {
-            revisions.push(element);
-          }
-          for (const child of childElements(element)) collect(child);
-        };
-        collect(scope);
-        return revisions;
-      };
-      const revisionWasGenerated = (element: WmlElement): boolean => {
-        const id = Number(element.getAttributeNS(W_NS, 'id'));
-        return Number.isSafeInteger(id) && generatedRevisionIds.has(id);
-      };
-      const predecessorPropertiesBefore = childElements(predecessor).find((child) => child.localName === 'pPr');
-      const predecessorRevisions = predecessorPropertiesBefore
-        ? revisionElements(predecessorPropertiesBefore)
-        : [];
-      if (predecessorRevisions.some((element) => !revisionWasGenerated(element)) ||
-          predecessorRevisions.some((element) => ['ins', 'moveFrom', 'moveTo'].includes(element.localName))) {
-        continue;
-      }
-      const pPr = childElements(paragraph).find((child) => child.localName === 'pPr');
-      const markProperties = pPr && childElements(pPr).find((child) => child.localName === 'rPr');
-      const marker = markProperties && childElements(markProperties).find((child) => {
-        if (child.localName !== 'del') return false;
-        const id = Number(child.getAttributeNS(W_NS, 'id'));
-        return Number.isSafeInteger(id) && generatedRevisionIds.has(id);
-      });
-      const content = childElements(paragraph).filter((child) =>
-        child !== pPr && !RANGE_BOUNDARY_LOCALS.has(child.localName));
-      if (!pPr || !markProperties || !marker || content.length === 0 ||
-          content.some((child) => child.namespaceURI !== W_NS || child.localName !== 'del')) continue;
-      if (revisionElements(pPr).some((element) => element !== marker)) continue;
-
-      const originalProperties = cloneElement(pPr);
-      const originalMarkProperties = childElements(originalProperties).find((child) => child.localName === 'rPr');
-      const originalMarker = originalMarkProperties && childElements(originalMarkProperties).find((child) =>
-        child.localName === 'del' && child.getAttributeNS(W_NS, 'id') === marker.getAttributeNS(W_NS, 'id'));
-      originalMarker?.parentNode?.removeChild(originalMarker);
-      if (originalMarkProperties && childElements(originalMarkProperties).length === 0) {
-        originalProperties.removeChild(originalMarkProperties);
-      }
-
-      let predecessorProperties = childElements(predecessor).find((child) => child.localName === 'pPr');
-      const revisedProperties = predecessorProperties
-        ? cloneElement(predecessorProperties)
-        : predecessor.ownerDocument!.createElementNS(W_NS, 'w:pPr') as WmlElement;
-      for (const stale of revisionElements(revisedProperties)) {
-        stale.parentNode?.removeChild(stale);
-      }
-      if (!predecessorProperties) {
-        predecessorProperties = predecessor.ownerDocument!.createElementNS(W_NS, 'w:pPr') as WmlElement;
-        predecessor.insertBefore(predecessorProperties, predecessor.firstChild);
-      }
-      let predecessorMarkProperties = childElements(predecessorProperties).find((child) => child.localName === 'rPr');
-      if (!predecessorMarkProperties) {
-        predecessorMarkProperties = predecessor.ownerDocument!.createElementNS(W_NS, 'w:rPr') as WmlElement;
-        const boundary = childElements(predecessorProperties).find((child) =>
-          ['sectPr', 'pPrChange'].includes(child.localName));
-        predecessorProperties.insertBefore(predecessorMarkProperties, boundary ?? null);
-      }
-      marker.parentNode!.removeChild(marker);
-      placeParagraphMarkRevisionMarker(predecessorMarkProperties, marker, 'w:del');
-      if (childElements(markProperties).length === 0) pPr.removeChild(markProperties);
-
-      applyParagraphPropertyDelta(
-        paragraph,
-        originalProperties,
-        revisedProperties,
-        allocateRevision(),
-      );
+      relocate(child, predecessor);
+      predecessor = child;
     }
   };
   visit(root);
-}
-
-/**
- * Keep generated revision identifiers monotonic in serialized document order.
- *
- * Post-serialization normalizers can insert a later-allocated property change
- * before an earlier content revision. Word tolerates that ordering, but
- * LibreOffice can resolve the paragraph break incorrectly. A single mapping per
- * old identifier preserves linked move-range identities while placing every
- * generated equivalence class in first-occurrence order above all authored IDs.
- */
-function renumberGeneratedRevisionsInDocumentOrder(
-  root: WmlElement,
-  generatedRevisionIds: ReadonlySet<number>,
-): void {
-  const revisions: WmlElement[] = [];
-  const collect = (element: WmlElement): void => {
-    if (element.namespaceURI === W_NS && REVISION_ID_ELEMENT_NAME_SET.has(element.localName)) revisions.push(element);
-    for (const child of childElements(element)) collect(child);
-  };
-  collect(root);
-  const authoredIds = revisions
-    .map((element) => Number(element.getAttributeNS(W_NS, 'id')))
-    .filter((id) => Number.isSafeInteger(id) && id >= 0 && !generatedRevisionIds.has(id));
-  let nextId = Math.max(-1, ...authoredIds) + 1;
-  const replacements = new Map<number, number>();
-  for (const revision of revisions) {
-    const oldId = Number(revision.getAttributeNS(W_NS, 'id'));
-    if (!Number.isSafeInteger(oldId) || !generatedRevisionIds.has(oldId)) continue;
-    let replacement = replacements.get(oldId);
-    if (replacement === undefined) {
-      replacement = nextId++;
-      replacements.set(oldId, replacement);
-    }
-    revision.setAttributeNS(W_NS, 'w:id', String(replacement));
-  }
 }
 
 function markWholeTableRow(
@@ -1360,8 +1360,15 @@ export function serializeTaggedTree(
 ): string {
   if (!plan.entries.has(tree)) throw new Error('PreservePlan does not belong to this TaggedTree');
   const representatives = tree.tag === 'both' ? [tree.original, tree.revised] : [tree.node];
-  const usedRevisionIds = representatives.flatMap((root) => [...REVISION_ID_ELEMENT_NAME_SET].flatMap((localName) =>
-    Array.from(root.getElementsByTagNameNS(W_NS, localName))))
+  // getElementsByTagNameNS reports descendants only, so a representative that is
+  // itself a revision wrapper would go uncounted and its authored ID could be
+  // reissued to a generated revision. Include each root alongside its descendants.
+  const usedRevisionIds = representatives.flatMap((root) => [
+    root,
+    ...[...REVISION_ID_ELEMENT_NAME_SET].flatMap((localName) =>
+      Array.from(root.getElementsByTagNameNS(W_NS, localName))),
+  ]).filter((element) =>
+    element.namespaceURI === W_NS && REVISION_ID_ELEMENT_NAME_SET.has(element.localName))
     .map((element) => Number(element.getAttributeNS(W_NS, 'id')))
     .filter((id) => Number.isSafeInteger(id) && id >= 0);
   let nextId = Math.max(
@@ -1412,7 +1419,6 @@ export function serializeTaggedTree(
   normalizeWholeParagraphDeletions(emitted, generatedRevisionIds, allocateRevision);
   hoistFieldCharactersFromDeletions(emitted);
   hoistLiteralInsertionsFromDeletedFieldInstructions(emitted);
-  renumberGeneratedRevisionsInDocumentOrder(emitted, generatedRevisionIds);
   return new XMLSerializer().serializeToString(emitted);
 }
 

--- a/packages/docx-core/src/index.ts
+++ b/packages/docx-core/src/index.ts
@@ -90,6 +90,11 @@ export {
   type StructuralCheckResult,
   type StructuralIssue,
 } from './generation/index.js';
+
+export {
+  REVISION_ID_ELEMENT_NAMES,
+  REVISION_ID_ELEMENT_NAME_SET,
+} from './primitives/revision-vocabulary.js';
 export type {
   BlockSpec,
   BorderSpec,

--- a/packages/docx-core/src/integration/issue-891-libreoffice-terminal-paragraph.test.ts
+++ b/packages/docx-core/src/integration/issue-891-libreoffice-terminal-paragraph.test.ts
@@ -19,11 +19,15 @@ const test = testAllure
 const paragraph = (text: string, alignment: string): string =>
   `<w:p><w:pPr><w:jc w:val="${alignment}"/></w:pPr><w:r><w:t>${text}</w:t></w:r></w:p>`;
 const soffice = resolveSoffice();
-const describeOracle = soffice ? describe : describe.skip;
+// Probe once at collection time. An installed-but-unusable binary (a held profile
+// lock, a sandbox) must surface as a skipped suite: skipping the assertions inside
+// a running test would report green having verified nothing, which is
+// indistinguishable from real oracle evidence.
+const sofficeUsable = soffice ? await probeSofficeUsable(soffice) : false;
+const describeOracle = sofficeUsable ? describe : describe.skip;
 
 describeOracle('issue #891 — LibreOffice terminal paragraph deletion', () => {
   test('Accept removes the terminal paragraph and Reject restores it', async ({ then }: AllureBddContext) => {
-    if (!soffice || !(await probeSofficeUsable(soffice))) return;
     const original = await buildDocxFromBodyXml(
       paragraph('Alpha', 'left') + paragraph('Bravo', 'center') + paragraph('Charlie', 'right'),
     );

--- a/packages/docx-core/src/integration/issue-891-libreoffice-terminal-paragraph.test.ts
+++ b/packages/docx-core/src/integration/issue-891-libreoffice-terminal-paragraph.test.ts
@@ -1,0 +1,61 @@
+/**
+ * LibreOffice differential regression for a deleted terminal paragraph.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.5.15
+ * @see https://github.com/UseJunior/safe-docx/issues/891
+ */
+import { describe, expect } from 'vitest';
+import { compareDocuments } from '@usejunior/docx-compare';
+import { readZipText } from '../primitives/zip.js';
+import { buildDocxFromBodyXml } from '../testing/ooxml-fixtures.js';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { paragraphShape, probeSofficeUsable, resolveSoffice, runLibreOfficeOracle } from './libreoffice-oracle.js';
+
+const TEST_FEATURE = 'LibreOffice Oracle Trust Boundary';
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({ feature: TEST_FEATURE })
+  .conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.5.15' });
+const paragraph = (text: string, alignment: string): string =>
+  `<w:p><w:pPr><w:jc w:val="${alignment}"/></w:pPr><w:r><w:t>${text}</w:t></w:r></w:p>`;
+const soffice = resolveSoffice();
+const describeOracle = soffice ? describe : describe.skip;
+
+describeOracle('issue #891 — LibreOffice terminal paragraph deletion', () => {
+  test('Accept removes the terminal paragraph and Reject restores it', async ({ then }: AllureBddContext) => {
+    if (!soffice || !(await probeSofficeUsable(soffice))) return;
+    const original = await buildDocxFromBodyXml(
+      paragraph('Alpha', 'left') + paragraph('Bravo', 'center') + paragraph('Charlie', 'right'),
+    );
+    const revised = await buildDocxFromBodyXml(paragraph('Alpha', 'left') + paragraph('Bravo', 'center'));
+    const compared = await compareDocuments(original, revised, {
+      comparisonStrategy: 'tagged-tree',
+      author: 'Comparator',
+      date: new Date('2026-08-17T00:00:00Z'),
+    });
+    const candidateXml = await readZipText(compared.document, 'word/document.xml');
+    const originalXml = await readZipText(original, 'word/document.xml');
+    const revisedXml = await readZipText(revised, 'word/document.xml');
+    expect(candidateXml).not.toBeNull();
+    expect(originalXml).not.toBeNull();
+    expect(revisedXml).not.toBeNull();
+
+    const [accepted, rejected, expectedAccept, expectedReject] = await runLibreOfficeOracle([
+      { op: 'accept', documentXml: candidateXml! },
+      { op: 'reject', documentXml: candidateXml! },
+      { op: 'identity', documentXml: revisedXml! },
+      { op: 'identity', documentXml: originalXml! },
+    ], soffice);
+
+    await then('LibreOffice resolves the same paragraph shapes as the corresponding source resaves', () => {
+      expect(paragraphShape(accepted!)).toEqual(paragraphShape(expectedAccept!));
+      expect(paragraphShape(rejected!)).toEqual(paragraphShape(expectedReject!));
+      const visibleText = (xml: string): string => {
+        const matches = xml.matchAll(new RegExp(`<w:t(?:\\s[^>]*)?>([^<]*)</w:t>`, 'g'));
+        return Array.from(matches, (match) => match[1]).join('');
+      };
+      expect(visibleText(accepted!)).toBe(visibleText(expectedAccept!));
+      expect(visibleText(rejected!)).toBe(visibleText(expectedReject!));
+    });
+  }, 180_000);
+});


### PR DESCRIPTION
Fixes #891.

## Problem

Deleting a document's terminal paragraph produced a comparison that Word resolved
correctly but LibreOffice did not: Accept All left an empty final paragraph
container behind.

## Root cause

The paragraph-mark `w:del` sat on the deleted paragraph itself. A whole-paragraph
deletion is two edits — the contents, and the break immediately preceding them —
and LibreOffice cannot remove a terminal container when the break marker is
encoded that way. Moving the marker onto the preceding paragraph lets Accept All
merge the survivor into the deleted container.

An earlier revision of this PR also claimed revision-ID ordering was part of the
root cause. Bisecting each pass against the LibreOffice oracle disproved that:
marker relocation alone fixes #891, and the ID-renumbering pass has been removed.

## Supported envelope

Relocation is deliberately conservative and fires only where it is verified
correct. It does **not** fire when:

- the predecessor's paragraph mark already carries a tracked change
  (`CT_ParaRPr` admits at most one of `w:ins`/`w:del`/`w:moveFrom`/`w:moveTo`);
- a non-paragraph block such as a table intervenes;
- either paragraph carries a `w:sectPr`.

Deletions outside that envelope keep the pre-existing topology. They remain
schema-valid and Word-correct, and behave exactly as `origin/main` does under the
LibreOffice oracle — including the section-bearing and table-boundary shapes,
where LibreOffice still leaves an empty terminal container. Those two remain open
under #891's umbrella rather than being silently claimed as fixed.

A pre-existing LibreOffice Reject mismatch for hyperlink-bearing terminal
paragraphs is likewise unchanged by this PR.

## Evidence

- `packages/docx-compare` — 919 passed / 27 skipped
- `packages/docx-core` — 1358 passed / 2 expected fail / 1 skipped
- LibreOffice oracle (`issue-891-...test.ts`) — passes against a real `soffice`
  (~7s); an installed-but-unusable binary now skips the suite instead of
  reporting a green test that asserted nothing
- `scripts/check_emitted_document_schema.mjs` — 4/4 emitted `document.xml`
  instances validate against Transitional WML, including the all-deleted and
  table-boundary shapes that were schema-invalid before review
- `check:conformance-citations`, `check:allure-labels`, `check:allure-quality`,
  `lint:workspaces` — all exit 0

## Review

Codex peer review returned DO NOT MERGE on the first revision, with executed
evidence for four blockers (duplicate `w:del` violating the schema, predecessor
lookup crossing tables, a section-bearing Reject regression, and authored
revision IDs being rewritten). All four are fixed here, each with a regression
test that fails against the pre-fix commit.

Refs #891
