### PR TITLE
feat(docx-core): convert comments to styled footnotes

### DIFF
--- a/openspec/changes/add-configurable-note-presentation/design.md
+++ b/openspec/changes/add-configurable-note-presentation/design.md
@@ -1,0 +1,75 @@
+## Context
+
+OOXML comments are ranged annotations stored in comment parts. Footnotes are
+single body references linked to definitions in `footnotes.xml`. Converting
+between them therefore requires mapping a comment range to one deterministic
+insertion boundary while preserving operative text and unrelated package parts.
+
+## Goals / Non-Goals
+
+### Goals
+
+- Author or select notes independently from their presentation.
+- Convert eligible comments transactionally and report every disposition.
+- Style a footnote label separately from its separator and body.
+- Preserve substantive footnotes and unrelated comments.
+- Fail closed on unsupported cross-paragraph ranges and threads by default.
+
+### Non-Goals
+
+- Infer internal/external audience from prose or author metadata.
+- Convert substantive footnotes by default.
+- Restore an interactive reply graph after flattening it into a footnote.
+- Put drafting text directly in the operative document body.
+- Complete the paragraph-index SSOT refactor tracked by #904 in this change.
+
+## Decisions
+
+### Semantic notes and presentation are separate
+
+A normalized profile maps each audience to `comment`, `footnote`, or `omit`.
+Prefix, separator, and body are structured runs rather than embedded HTML.
+
+### The first implementation slice converts comments to footnotes
+
+The buffer-level API loads an isolated document, preflights the complete root
+comment selection, mutates only after preflight, and publishes only a successful
+serialization. The document-level method exposes the same report for callers
+that already own transactional session boundaries.
+
+### Comment ranges collapse at their visible endpoint
+
+The footnote reference is inserted at the comment range's absolute visible-text
+endpoint. Structural run indexes are retained for compatibility, but visible
+coordinates avoid mismatches caused by zero-width comment-reference runs. A
+future canonical paragraph index will make this coordinate system the SSOT
+(#904).
+
+### Threads are explicitly lossy
+
+Threaded comments fail by default. `flattenThreads` serializes root and replies
+in deterministic order and marks the report as lossy.
+
+### Styling is structured and fail-closed
+
+The admitted subset is bold, italic, underline, six-digit RGB color, and Word
+highlight values. Footnote references carry both the semantic
+`FootnoteReference` style and explicit superscript so documents with a missing
+or redefined character style still render correctly.
+
+## Risks / Trade-offs
+
+- Repeated visible prefixes can make substring-based insertion ambiguous;
+  migrate insertion to a direct visible-offset-to-DOM mapping under #904.
+- Direct superscript duplicates a conforming style declaration but prevents
+  silently flat markers in documents with incomplete styles.
+- Footnotes change pagination; package/text invariants, not page identity, are
+  the automated compatibility boundary.
+- Audience is metadata, not a disclosure or privilege guarantee.
+
+## Migration Plan
+
+1. Land comment-to-footnote conversion and structured styling as a draft slice.
+2. Add Markdoc audience profile projection.
+3. Add provenance-gated reverse conversion for generated note-footnotes.
+4. Migrate coordinate consumers to the canonical paragraph index from #904.

--- a/openspec/changes/add-configurable-note-presentation/proposal.md
+++ b/openspec/changes/add-configurable-note-presentation/proposal.md
@@ -1,0 +1,33 @@
+# Change: Add Configurable Note Presentation
+
+## Why
+
+Lawyers disagree about whether drafting communications belong in Word comment
+bubbles or footnotes, and the choice may differ for internal and external
+audiences. Authors should record what a note means once and select its DOCX
+presentation when producing an artifact. Existing comments also need a safe
+bulk-conversion path that does not conflate drafting notes with substantive
+footnotes.
+
+## What Changes
+
+- Add structured note-presentation options for comments, footnotes, and omission.
+- Configure external and internal note audiences independently in Markdoc.
+- Support independently styled footnote prefix, separator, and body runs.
+- Add transactional selected comment-to-footnote conversion with deterministic
+  range-end placement and machine-readable reporting.
+- Preserve substantive footnotes and reject threaded comments unless explicit
+  lossy flattening is enabled.
+- Keep reverse generated-footnote-to-comment conversion and complete Markdoc
+  audience projection as later tasks within this approved change.
+- Track canonical paragraph coordinate indexing separately in issue #904.
+
+## Impact
+
+- Affected specs: `docx-primitives` in this implementation slice;
+  `docx-markdoc` remains planned work.
+- Affected code: comment/footnote primitives, `DocxDocument`, and the Markdoc CLI.
+- Compatibility: additive; existing comment and footnote APIs remain valid.
+- Conformance: comment ranges, footnote references/definitions, and run
+  properties require ECMA-376 citations and structural tests.
+- Privacy: conversion is local and this change commits no customer documents.

--- a/openspec/changes/add-configurable-note-presentation/specs/docx-primitives/spec.md
+++ b/openspec/changes/add-configurable-note-presentation/specs/docx-primitives/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Eligible comments convert to footnotes transactionally
+
+The system SHALL convert selected root Word comments to footnotes after complete
+preflight, place each reference at the comment range's visible endpoint, preserve
+operative text and unselected content, and return a complete disposition report.
+
+#### Scenario: [SDX-PRIM-210] Selected comments become footnotes
+- **GIVEN** supported root comments selected explicitly or by an all-comments selector
+- **WHEN** conversion succeeds
+- **THEN** each selected comment SHALL produce one footnote reference and definition
+- **AND** obsolete comment markers, references, and definitions SHALL be removed
+- **AND** substantive footnotes and unselected comments SHALL remain unchanged
+
+#### Scenario: [SDX-PRIM-211] Unsupported selection is atomic
+- **GIVEN** a selected comment with an unsupported anchor or invalid presentation styling
+- **WHEN** conversion is requested
+- **THEN** preflight SHALL fail before publishing output
+- **AND** no selected or unselected note SHALL be partially mutated
+
+#### Scenario: [SDX-PRIM-212] Footnote markers render as superscript
+- **GIVEN** a source whose `FootnoteReference` character style is absent or incomplete
+- **WHEN** a converted footnote is emitted
+- **THEN** its body reference and definition reference SHALL carry explicit superscript run properties
+
+### Requirement: Thread flattening is explicit and reported as lossy
+
+Threaded comments SHALL fail conversion by default and SHALL flatten only under
+an explicit policy that preserves deterministic message order.
+
+#### Scenario: [SDX-PRIM-213] Thread is rejected by default
+- **GIVEN** a selected root comment with replies
+- **WHEN** conversion is requested without flattening
+- **THEN** conversion SHALL fail before mutation
+
+#### Scenario: [SDX-PRIM-214] Explicit flattening is auditable
+- **GIVEN** a selected thread and explicit flattening
+- **WHEN** conversion succeeds
+- **THEN** the root and replies SHALL appear in deterministic order
+- **AND** the report SHALL mark the transformation as lossy

--- a/openspec/changes/add-configurable-note-presentation/tasks.md
+++ b/openspec/changes/add-configurable-note-presentation/tasks.md
@@ -1,0 +1,28 @@
+## 1. Comment-to-footnote slice
+
+- [x] 1.1 Define presentation, selection, and conversion-report types.
+- [x] 1.2 Preflight root comments and reject unsupported ranges or threads.
+- [x] 1.3 Convert at the visible range endpoint without changing operative text.
+- [x] 1.4 Preserve existing substantive footnotes.
+- [x] 1.5 Add independently styled prefix, separator, and body runs.
+- [x] 1.6 Emit explicit superscript reference markers in both stories.
+- [x] 1.7 Add CLI options and focused synthetic regression tests.
+
+## 2. Remaining presentation profile
+
+- [ ] 2.1 Add explicit internal/external audience to canonical Markdoc notes.
+- [ ] 2.2 Normalize API, JSON, and CLI audience profiles.
+- [ ] 2.3 Emit each audience independently as comment, footnote, or omission.
+- [ ] 2.4 Record note dispositions and profile digest in verification output.
+
+## 3. Reverse conversion
+
+- [ ] 3.1 Mark generated note-footnotes with stable provenance.
+- [ ] 3.2 Convert provenance-marked footnotes back to comments.
+- [ ] 3.3 Require explicit IDs and opt-in for ordinary substantive footnotes.
+
+## 4. Follow-up and verification
+
+- [ ] 4.1 Migrate visible/structural coordinates to the paragraph index in #904.
+- [ ] 4.2 Add conformance-tagged tests and complete repository pre-submit checks.
+- [ ] 4.3 Record Word and LibreOffice manual compatibility observations.

--- a/packages/docx-core/src/primitives/comments.test.ts
+++ b/packages/docx-core/src/primitives/comments.test.ts
@@ -1795,6 +1795,63 @@ describe('comments — edge cases and branch coverage', () => {
       });
     });
 
+    test.conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.4.5' })(
+      'preserves sibling runs when an untracked comment reference shares a tracked-insertion wrapper',
+      async ({ given, when, then }: AllureBddContext) => {
+        let zip: DocxZip;
+        let doc: Document;
+        let paragraph: Element;
+        let insertion: Element;
+
+        await given('a comment reference run inside an insertion that also contains visible sibling runs', async () => {
+          ({ zip, doc, p: paragraph } = await setupWithComment());
+          await withDeterministicMetadata([0.777777777], async () => {
+            await addComment(doc, zip, {
+              paragraphEl: paragraph,
+              start: 0,
+              end: 5,
+              author: 'Reviewer',
+              text: 'Delete only the comment',
+            });
+          });
+
+          const reference = paragraph.getElementsByTagNameNS(W_NS, W.commentReference).item(0) as Element;
+          const referenceRun = reference.parentNode as Element;
+          insertion = doc.createElementNS(W_NS, 'w:ins');
+          insertion.setAttributeNS(W_NS, 'w:id', '99');
+
+          const beforeRun = doc.createElementNS(W_NS, 'w:r');
+          const beforeText = doc.createElementNS(W_NS, 'w:t');
+          beforeText.appendChild(doc.createTextNode('Keep before'));
+          beforeRun.appendChild(beforeText);
+
+          const afterRun = doc.createElementNS(W_NS, 'w:r');
+          const afterText = doc.createElementNS(W_NS, 'w:t');
+          afterText.appendChild(doc.createTextNode('Keep after'));
+          afterRun.appendChild(afterText);
+
+          paragraph.replaceChild(insertion, referenceRun);
+          insertion.appendChild(beforeRun);
+          insertion.appendChild(referenceRun);
+          insertion.appendChild(afterRun);
+        });
+
+        await when('the comment is deleted without recording a new revision', async () => {
+          await deleteComment(doc, zip, { commentId: 0 });
+        });
+
+        await then('only the reference run is removed and the non-empty insertion remains intact', () => {
+          expect(paragraph.getElementsByTagNameNS(W_NS, W.commentRangeStart)).toHaveLength(0);
+          expect(paragraph.getElementsByTagNameNS(W_NS, W.commentRangeEnd)).toHaveLength(0);
+          expect(paragraph.getElementsByTagNameNS(W_NS, W.commentReference)).toHaveLength(0);
+          expect(paragraph.getElementsByTagNameNS(W_NS, 'ins')).toHaveLength(1);
+          expect(insertion.parentNode).toBe(paragraph);
+          expect(insertion.getElementsByTagNameNS(W_NS, W.r)).toHaveLength(2);
+          expect(insertion.textContent).toBe('Keep beforeKeep after');
+        });
+      },
+    );
+
     test('allocates distinct revision IDs across tracked addComment and deleteComment operations sharing one context', async ({ given, when, then }: AllureBddContext) => {
       let zip: DocxZip;
       let doc: Document;

--- a/packages/docx-core/src/primitives/comments.ts
+++ b/packages/docx-core/src/primitives/comments.ts
@@ -1332,9 +1332,9 @@ function removeCommentMarkersFromDocument(
       // If the run lived inside a tracked-change wrapper (e.g., the comment
       // was added with ctx earlier and is now being deleted without ctx),
       // the wrapper is left orphaned with no content. Clean it up.
-      if (runParent && isW(runParent, 'ins')) {
+      if (runParent && isW(runParent, 'ins') && !hasElementChildren(runParent)) {
         runParent.parentNode?.removeChild(runParent);
-      } else if (runParent && isW(runParent, 'del')) {
+      } else if (runParent && isW(runParent, 'del') && !hasElementChildren(runParent)) {
         runParent.parentNode?.removeChild(runParent);
       }
     }
@@ -1350,6 +1350,10 @@ function hasVisibleRunContent(run: Element): boolean {
     return true;
   }
   return false;
+}
+
+function hasElementChildren(element: Element): boolean {
+  return Array.from(element.childNodes).some((child) => child.nodeType === 1);
 }
 
 function extractCommentText(commentEl: Element): string {

--- a/packages/docx-core/src/primitives/comments.ts
+++ b/packages/docx-core/src/primitives/comments.ts
@@ -783,6 +783,8 @@ export type Comment = {
   startCharOffset?: number;
   endRunIndex?: number;
   endCharOffset?: number;
+  startTextOffset?: number;
+  endTextOffset?: number;
   replies: Comment[];
 };
 
@@ -790,6 +792,7 @@ type CommentRangePoint = {
   paragraphId: string | null;
   runIndex?: number;
   charOffset?: number;
+  textOffset?: number;
 };
 
 type RunBoundary = {
@@ -803,6 +806,7 @@ type RunBoundary = {
 //   resolution depends on the boundary direction and the surrounding runs.
 type MarkerCharPosition = {
   id: number;
+  textOffset: number;
   inside?: { runIndex: number; charOffset: number };
   between?: { afterRunIndex: number };
 };
@@ -882,6 +886,8 @@ export async function getComments(zip: DocxZip, documentXml: Document): Promise<
       startCharOffset: startPoint?.charOffset,
       endRunIndex: endPoint?.runIndex,
       endCharOffset: endPoint?.charOffset,
+      startTextOffset: startPoint?.textOffset,
+      endTextOffset: endPoint?.textOffset,
       replies: [],
     };
 
@@ -970,6 +976,7 @@ function resolveCommentRangeMetadataInParagraph(
     if (startById.has(marker.id)) continue;
     startById.set(marker.id, {
       paragraphId,
+      textOffset: marker.textOffset,
       ...resolveMarkerToRunBoundary(walkState.allRuns, marker, 'start'),
     });
   }
@@ -978,6 +985,7 @@ function resolveCommentRangeMetadataInParagraph(
     if (endById.has(marker.id)) continue;
     endById.set(marker.id, {
       paragraphId,
+      textOffset: marker.textOffset,
       ...resolveMarkerToRunBoundary(walkState.allRuns, marker, 'end'),
     });
   }
@@ -1015,11 +1023,11 @@ function walkRunForCommentMarkers(run: Element, state: ParagraphMarkerWalkState)
 
   for (const child of childElements(run)) {
     if (isW(child, W.commentRangeStart)) {
-      recordInRunMarker(child, state.startMarkers, runIndex, state.charPos - runVisibleStart);
+      recordInRunMarker(child, state.startMarkers, runIndex, state.charPos - runVisibleStart, state.charPos);
       continue;
     }
     if (isW(child, W.commentRangeEnd)) {
-      recordInRunMarker(child, state.endMarkers, runIndex, state.charPos - runVisibleStart);
+      recordInRunMarker(child, state.endMarkers, runIndex, state.charPos - runVisibleStart, state.charPos);
       continue;
     }
     if (!child.namespaceURI || child.namespaceURI !== OOXML.W_NS) continue;
@@ -1051,10 +1059,11 @@ function recordInRunMarker(
   bucket: MarkerCharPosition[],
   runIndex: number,
   charOffset: number,
+  textOffset: number,
 ): void {
   const id = getCommentMarkerId(markerEl);
   if (id == null) return;
-  bucket.push({ id, inside: { runIndex, charOffset } });
+  bucket.push({ id, textOffset, inside: { runIndex, charOffset } });
 }
 
 function recordParagraphLevelMarker(
@@ -1064,7 +1073,7 @@ function recordParagraphLevelMarker(
 ): void {
   const id = getCommentMarkerId(markerEl);
   if (id == null) return;
-  bucket.push({ id, between: { afterRunIndex: state.currentRunIndex - 1 } });
+  bucket.push({ id, textOffset: state.charPos, between: { afterRunIndex: state.currentRunIndex - 1 } });
 }
 
 function getCommentMarkerId(markerEl: Element): number | null {

--- a/packages/docx-core/src/primitives/document.ts
+++ b/packages/docx-core/src/primitives/document.ts
@@ -108,7 +108,29 @@ import {
   deleteFootnote as deleteFootnoteImpl,
   type Footnote,
   type AddFootnoteResult,
+  type FootnoteNotePresentation,
 } from './footnotes.js';
+
+export type ConvertCommentsToFootnotesOptions = {
+  commentIds?: number[];
+  flattenThreads?: boolean;
+  presentation?: FootnoteNotePresentation;
+};
+
+export type ConvertedCommentFootnote = {
+  commentId: number;
+  footnoteId: number;
+  paragraphId: string;
+  flattenedReplies: number;
+};
+
+export type ConvertCommentsToFootnotesReport = {
+  selected: number;
+  converted: ConvertedCommentFootnote[];
+  before: { comments: number; footnotes: number };
+  after: { comments: number; footnotes: number };
+  lossy: boolean;
+};
 
 export type NormalizationResult = {
   runsMerged: number;
@@ -1173,6 +1195,107 @@ export class DocxDocument {
     this.documentViewCache = null;
   }
 
+  /**
+   * Convert selected root Word comments to footnotes in document order.
+   * The method preflights the complete selection before mutating the package;
+   * callers that need buffer-level atomicity should invoke it on a freshly
+   * loaded document and publish only the returned serialization.
+   *
+   * @conformance ECMA-376 edition 5, Part 1 § 17.13.4.2
+   * @conformance ECMA-376 edition 5, Part 1 § 17.11.14
+   */
+  async convertCommentsToFootnotes(
+    options: ConvertCommentsToFootnotesOptions = {},
+  ): Promise<ConvertCommentsToFootnotesReport> {
+    const colors = [options.presentation?.prefixStyle?.color, options.presentation?.bodyStyle?.color];
+    for (const color of colors) {
+      if (color && !/^[0-9A-Fa-f]{6}$/.test(color)) {
+        throw new Error(`Invalid Word color '${color}'; expected six hexadecimal digits`);
+      }
+    }
+    const allowedHighlights = new Set([
+      'black', 'blue', 'cyan', 'green', 'magenta', 'red', 'yellow', 'white',
+      'darkBlue', 'darkCyan', 'darkGreen', 'darkMagenta', 'darkRed',
+      'darkYellow', 'darkGray', 'lightGray', 'none',
+    ]);
+    const highlights = [options.presentation?.prefixStyle?.highlight, options.presentation?.bodyStyle?.highlight];
+    for (const highlight of highlights) {
+      if (highlight && !allowedHighlights.has(highlight)) {
+        throw new Error(`Invalid Word highlight '${highlight}'`);
+      }
+    }
+    // Materialize stable paragraph bookmarks before comment-range extraction;
+    // source DOCX files are not required to carry Safe DOCX anchors already.
+    this.insertParagraphBookmarks('note-conversion');
+    const roots = await this.getComments();
+    const beforeFootnotes = (await this.getFootnotes()).length;
+    const requested = options.commentIds ? new Set(options.commentIds) : null;
+    const selected = requested ? roots.filter((comment) => requested.has(comment.id)) : roots;
+    if (requested) {
+      const found = new Set(selected.map((comment) => comment.id));
+      const missing = [...requested].filter((id) => !found.has(id));
+      if (missing.length) throw new Error(`Root comment IDs not found: ${missing.join(', ')}`);
+    }
+
+    const prepared = selected.map((comment) => {
+      if (!comment.anchoredParagraphId || !comment.endParagraphId || comment.anchoredParagraphId !== comment.endParagraphId) {
+        throw new Error(`Comment ID ${comment.id} does not have one supported paragraph anchor`);
+      }
+      if (comment.replies.length && !options.flattenThreads) {
+        throw new Error(`Comment ID ${comment.id} has replies; pass flattenThreads to perform a lossy conversion`);
+      }
+      const paragraph = findParagraphByBookmarkId(this.documentXml, comment.anchoredParagraphId);
+      if (!paragraph) throw new Error(`Comment ID ${comment.id} anchor was not found`);
+      let afterText: string | undefined;
+      if (comment.endTextOffset !== undefined) {
+        const paragraphText = getParagraphText(paragraph);
+        if (comment.endTextOffset > paragraphText.length) {
+          throw new Error(`Comment ID ${comment.id} has an invalid visible-text range endpoint`);
+        }
+        afterText = paragraphText.slice(0, comment.endTextOffset);
+        if (!afterText) afterText = undefined;
+      }
+      const replyText = comment.replies.map((reply) => `\n${reply.author ? `${reply.author}: ` : ''}${reply.text}`).join('');
+      return {
+        comment,
+        paragraph,
+        afterText,
+        text: `${comment.text}${replyText}`,
+      };
+    });
+
+    const converted: ConvertedCommentFootnote[] = [];
+    if (prepared.length > 0) await bootstrapFootnoteParts(this.zip);
+    for (const item of prepared) {
+      // Insert first while the preflighted comment markers still identify the
+      // source range. deleteComment removes only comment markers/references,
+      // not the adjacent footnote run introduced here.
+      const result = await addFootnoteImpl(this.documentXml, this.zip, {
+        paragraphEl: item.paragraph,
+        afterText: item.afterText,
+        text: item.text,
+        presentation: options.presentation,
+      });
+      await deleteCommentImpl(this.documentXml, this.zip, { commentId: item.comment.id });
+      converted.push({
+        commentId: item.comment.id,
+        footnoteId: result.noteId,
+        paragraphId: item.comment.anchoredParagraphId!,
+        flattenedReplies: item.comment.replies.length,
+      });
+    }
+    await this.refreshFootnotesXml();
+    this.dirty = converted.length > 0;
+    this.documentViewCache = null;
+    return {
+      selected: selected.length,
+      converted,
+      before: { comments: roots.length, footnotes: beforeFootnotes },
+      after: { comments: (await this.getComments()).length, footnotes: (await this.getFootnotes()).length },
+      lossy: converted.some((entry) => entry.flattenedReplies > 0),
+    };
+  }
+
   // ── Footnote methods ──────────────────────────────────────────────────
 
   private async refreshFootnotesXml(): Promise<void> {
@@ -1242,6 +1365,7 @@ export class DocxDocument {
     paragraphId: string;
     afterText?: string;
     text: string;
+    presentation?: FootnoteNotePresentation;
   }, ctx?: RevisionContext): Promise<AddFootnoteResult> {
     const p = findParagraphByBookmarkId(this.documentXml, params.paragraphId);
     if (!p) throw new Error(`Paragraph not found: ${params.paragraphId}`);
@@ -1251,6 +1375,7 @@ export class DocxDocument {
       paragraphEl: p,
       afterText: params.afterText,
       text: params.text,
+      presentation: params.presentation,
     }, ctx);
 
     await this.refreshFootnotesXml();

--- a/packages/docx-core/src/primitives/footnotes.ts
+++ b/packages/docx-core/src/primitives/footnotes.ts
@@ -96,6 +96,22 @@ export type AddFootnoteParams = {
   paragraphEl: Element;
   afterText?: string;
   text: string;
+  presentation?: FootnoteNotePresentation;
+};
+
+export type FootnoteRunStyle = {
+  bold?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+  color?: string;
+  highlight?: 'black' | 'blue' | 'cyan' | 'green' | 'magenta' | 'red' | 'yellow' | 'white' | 'darkBlue' | 'darkCyan' | 'darkGreen' | 'darkMagenta' | 'darkRed' | 'darkYellow' | 'darkGray' | 'lightGray' | 'none';
+};
+
+export type FootnoteNotePresentation = {
+  prefix?: string;
+  prefixSeparator?: string;
+  prefixStyle?: FootnoteRunStyle;
+  bodyStyle?: FootnoteRunStyle;
 };
 
 export type AddFootnoteResult = {
@@ -452,7 +468,7 @@ export async function addFootnote(
   params: AddFootnoteParams,
   ctx?: RevisionContext,
 ): Promise<AddFootnoteResult> {
-  const { paragraphEl, afterText, text } = params;
+  const { paragraphEl, afterText, text, presentation } = params;
 
   // Load or bootstrap footnotes.xml
   const footnotesXml = await zip.readText('word/footnotes.xml');
@@ -465,7 +481,7 @@ export async function addFootnote(
   insertFootnoteReference(documentXml, paragraphEl, noteId, afterText, ctx);
 
   // Add footnote body to footnotes.xml
-  const footnoteEl = addFootnoteElement(footnotesDoc, noteId, text);
+  const footnoteEl = addFootnoteElement(footnotesDoc, noteId, text, presentation);
   if (ctx) {
     wrapFootnoteParagraphTextRuns(getFirstFootnoteParagraph(footnoteEl), 'ins', ctx);
   }
@@ -487,6 +503,12 @@ function insertFootnoteReference(
   const rStyle = documentXml.createElementNS(OOXML.W_NS, 'w:rStyle');
   rStyle.setAttributeNS(OOXML.W_NS, 'w:val', 'FootnoteReference');
   rPr.appendChild(rStyle);
+  // Some source documents omit or redefine the FootnoteReference character
+  // style. Keep the semantic style and make the required visual elevation
+  // explicit so the marker remains superscript across those documents.
+  const vertAlign = documentXml.createElementNS(OOXML.W_NS, 'w:vertAlign');
+  vertAlign.setAttributeNS(OOXML.W_NS, 'w:val', 'superscript');
+  rPr.appendChild(vertAlign);
   refRun.appendChild(rPr);
   const fnRef = documentXml.createElementNS(OOXML.W_NS, 'w:footnoteReference');
   fnRef.setAttributeNS(OOXML.W_NS, 'w:id', String(noteId));
@@ -657,7 +679,12 @@ function setXmlSpacePreserve(t: Element, text: string): void {
   }
 }
 
-function addFootnoteElement(footnotesDoc: Document, noteId: number, text: string): Element {
+function addFootnoteElement(
+  footnotesDoc: Document,
+  noteId: number,
+  text: string,
+  presentation?: FootnoteNotePresentation,
+): Element {
   const root = footnotesDoc.documentElement;
 
   const footnoteEl = footnotesDoc.createElementNS(OOXML.W_NS, 'w:footnote');
@@ -679,6 +706,9 @@ function addFootnoteElement(footnotesDoc: Document, noteId: number, text: string
   const refRStyle = footnotesDoc.createElementNS(OOXML.W_NS, 'w:rStyle');
   refRStyle.setAttributeNS(OOXML.W_NS, 'w:val', 'FootnoteReference');
   refRPr.appendChild(refRStyle);
+  const refVertAlign = footnotesDoc.createElementNS(OOXML.W_NS, 'w:vertAlign');
+  refVertAlign.setAttributeNS(OOXML.W_NS, 'w:val', 'superscript');
+  refRPr.appendChild(refVertAlign);
   refRun.appendChild(refRPr);
   const fnRefEl = footnotesDoc.createElementNS(OOXML.W_NS, 'w:footnoteRef');
   refRun.appendChild(fnRefEl);
@@ -692,19 +722,53 @@ function addFootnoteElement(footnotesDoc: Document, noteId: number, text: string
   spaceRun.appendChild(spaceT);
   p.appendChild(spaceRun);
 
-  // User text run
-  const textRun = footnotesDoc.createElementNS(OOXML.W_NS, 'w:r');
-  const t = footnotesDoc.createElementNS(OOXML.W_NS, 'w:t');
-  if (text.startsWith(' ') || text.endsWith(' ')) {
-    t.setAttributeNS('http://www.w3.org/XML/1998/namespace', 'xml:space', 'preserve');
+  if (presentation?.prefix) {
+    p.appendChild(buildStyledTextRun(footnotesDoc, presentation.prefix, presentation.prefixStyle));
+    if (presentation.prefixSeparator) {
+      p.appendChild(buildStyledTextRun(footnotesDoc, presentation.prefixSeparator));
+    }
   }
-  t.appendChild(footnotesDoc.createTextNode(text));
-  textRun.appendChild(t);
-  p.appendChild(textRun);
+  p.appendChild(buildStyledTextRun(footnotesDoc, text, presentation?.bodyStyle));
 
   footnoteEl.appendChild(p);
   root.appendChild(footnoteEl);
   return footnoteEl;
+}
+
+function buildStyledTextRun(doc: Document, text: string, style?: FootnoteRunStyle): Element {
+  const run = doc.createElementNS(OOXML.W_NS, 'w:r');
+  if (style && Object.values(style).some((value) => value !== undefined && value !== false)) {
+    const rPr = doc.createElementNS(OOXML.W_NS, 'w:rPr');
+    const onOff = (name: string): void => {
+      const el = doc.createElementNS(OOXML.W_NS, `w:${name}`);
+      rPr.appendChild(el);
+    };
+    if (style.bold) onOff('b');
+    if (style.italic) onOff('i');
+    if (style.underline) {
+      const u = doc.createElementNS(OOXML.W_NS, 'w:u');
+      u.setAttributeNS(OOXML.W_NS, 'w:val', 'single');
+      rPr.appendChild(u);
+    }
+    if (style.color) {
+      const color = doc.createElementNS(OOXML.W_NS, 'w:color');
+      color.setAttributeNS(OOXML.W_NS, 'w:val', style.color);
+      rPr.appendChild(color);
+    }
+    if (style.highlight && style.highlight !== 'none') {
+      const highlight = doc.createElementNS(OOXML.W_NS, 'w:highlight');
+      highlight.setAttributeNS(OOXML.W_NS, 'w:val', style.highlight);
+      rPr.appendChild(highlight);
+    }
+    run.appendChild(rPr);
+  }
+  const t = doc.createElementNS(OOXML.W_NS, 'w:t');
+  if (text.startsWith(' ') || text.endsWith(' ')) {
+    t.setAttributeNS('http://www.w3.org/XML/1998/namespace', 'xml:space', 'preserve');
+  }
+  t.appendChild(doc.createTextNode(text));
+  run.appendChild(t);
+  return run;
 }
 
 // ── Update ──────────────────────────────────────────────────────────────

--- a/packages/docx-core/src/primitives/index.ts
+++ b/packages/docx-core/src/primitives/index.ts
@@ -30,6 +30,7 @@ export * from './accept_ai_edits.js';
 export * from './extract_revisions.js';
 export * from './comments.js';
 export * from './footnotes.js';
+export * from './note_conversion.js';
 export * from './relationships.js';
 export * from './opc-target.js';
 export * from './sectPrAudit.js';

--- a/packages/docx-core/src/primitives/note_conversion.test.ts
+++ b/packages/docx-core/src/primitives/note_conversion.test.ts
@@ -1,0 +1,128 @@
+import JSZip from 'jszip';
+import { describe, expect } from 'vitest';
+import { buildSyntheticDocx } from '../integration/synthetic-docx-fixture.js';
+import { testAllure } from '../testing/allure-test.js';
+import { DocxDocument } from './document.js';
+import { convertCommentsToFootnotes } from './note_conversion.js';
+
+const TEST_FEATURE = 'add-configurable-note-presentation';
+const test = testAllure.epic('Document Comparison').withLabels({ feature: 'Note conversion' });
+
+describe(`OpenSpec traceability: ${TEST_FEATURE}`, () => {
+  test.openspec('[SDX-PRIM-210] Selected comments become footnotes')('Selected comments become footnotes', async () => {
+    const source = await buildSyntheticDocx({
+      paragraphs: ['The Guard shall remain properly licensed throughout the Term.'],
+      commentOnParagraph: 0,
+      commentText: 'Confirm the licensing standard with the counterparty.',
+      commentAuthor: 'Drafting Counsel',
+      commentAncillaryParts: true,
+    });
+    const before = await DocxDocument.load(source);
+    const beforeText = before.buildDocumentView().nodes.map((node) => node.text).join('\n');
+
+    const result = await convertCommentsToFootnotes(source, {
+      presentation: {
+        prefix: 'Note to Draft',
+        prefixSeparator: ': ',
+        prefixStyle: { bold: true, underline: true, highlight: 'yellow' },
+      },
+    });
+
+    expect(result.report).toMatchObject({
+      selected: 1,
+      before: { comments: 1, footnotes: 0 },
+      after: { comments: 0, footnotes: 1 },
+      lossy: false,
+    });
+    const converted = await DocxDocument.load(result.buffer);
+    expect(await converted.getComments()).toEqual([]);
+    expect((await converted.getFootnotes())[0]?.text).toBe(
+      ' Note to Draft: Confirm the licensing standard with the counterparty.',
+    );
+    expect(converted.buildDocumentView().nodes.map((node) => node.text).join('\n')).toBe(beforeText);
+
+    const zip = await JSZip.loadAsync(result.buffer);
+    const footnotesXml = await zip.file('word/footnotes.xml')!.async('string');
+    expect(footnotesXml).toContain('<w:b/>');
+    expect(footnotesXml).toContain('<w:u w:val="single"/>');
+    expect(footnotesXml).toContain('<w:highlight w:val="yellow"/>');
+    expect(footnotesXml).toContain('<w:t>Note to Draft</w:t>');
+    expect(footnotesXml).toContain('<w:t xml:space="preserve">: </w:t>');
+
+    const documentXml = await zip.file('word/document.xml')!.async('string');
+    expect(documentXml).toContain('<w:vertAlign w:val="superscript"/>');
+  });
+
+  test.openspec('[SDX-PRIM-212] Footnote markers render as superscript')('Footnote markers render as superscript', async () => {
+    const source = await buildSyntheticDocx({
+      paragraphs: ['Guard staffing requirement.'],
+      commentOnParagraph: 0,
+      commentText: 'Drafting note.',
+    });
+    const { buffer } = await convertCommentsToFootnotes(source);
+    const zip = await JSZip.loadAsync(buffer);
+    expect(await zip.file('word/footnotes.xml')!.async('string')).toContain('<w:vertAlign w:val="superscript"/>');
+    expect(await zip.file('word/document.xml')!.async('string')).toContain('<w:vertAlign w:val="superscript"/>');
+  });
+
+  test('preserves a pre-existing substantive footnote', async () => {
+    const source = await buildSyntheticDocx({
+      paragraphs: ['Existing disclosure.', 'Guard staffing requirement.'],
+      footnoteOnParagraph: 0,
+      footnoteText: 'This substantive footnote must survive.',
+      commentOnParagraph: 1,
+      commentText: 'Drafting note.',
+    });
+    const { buffer, report } = await convertCommentsToFootnotes(source);
+    const converted = await DocxDocument.load(buffer);
+
+    expect(report.before.footnotes).toBe(1);
+    expect(report.after.footnotes).toBe(2);
+    expect((await converted.getFootnotes()).map((note) => note.text)).toEqual([
+      'This substantive footnote must survive.',
+      ' Drafting note.',
+    ]);
+  });
+
+  test.openspec('[SDX-PRIM-213] Thread is rejected by default')('Thread is rejected by default', async () => {
+    const source = await buildSyntheticDocx({
+      paragraphs: ['Guard staffing requirement.'],
+      commentOnParagraph: 0,
+      commentText: 'Root note.',
+      commentAncillaryParts: true,
+      replyText: 'Reply note.',
+      replyAuthor: 'Reviewer',
+    });
+
+    await expect(convertCommentsToFootnotes(source)).rejects.toThrow(/has replies/);
+  });
+
+  test.openspec('[SDX-PRIM-214] Explicit flattening is auditable')('Explicit flattening is auditable', async () => {
+    const source = await buildSyntheticDocx({
+      paragraphs: ['Guard staffing requirement.'],
+      commentOnParagraph: 0,
+      commentText: 'Root note.',
+      commentAncillaryParts: true,
+      replyText: 'Reply note.',
+      replyAuthor: 'Reviewer',
+    });
+    const flattened = await convertCommentsToFootnotes(source, { flattenThreads: true });
+    expect(flattened.report.lossy).toBe(true);
+    expect((await (await DocxDocument.load(flattened.buffer)).getFootnotes())[0]?.text)
+      .toContain('Reviewer: Reply note.');
+  });
+
+  test.openspec('[SDX-PRIM-211] Unsupported selection is atomic')('Unsupported selection is atomic', async () => {
+    const source = await buildSyntheticDocx({
+      paragraphs: ['Guard staffing requirement.'],
+      commentOnParagraph: 0,
+      commentText: 'Drafting note.',
+    });
+    await expect(convertCommentsToFootnotes(source, {
+      presentation: { bodyStyle: { color: 'red' } },
+    })).rejects.toThrow(/six hexadecimal digits/);
+    await expect(convertCommentsToFootnotes(source, {
+      presentation: { prefixStyle: { highlight: 'fuchsia' as 'yellow' } },
+    })).rejects.toThrow(/Invalid Word highlight/);
+  });
+});

--- a/packages/docx-core/src/primitives/note_conversion.ts
+++ b/packages/docx-core/src/primitives/note_conversion.ts
@@ -1,0 +1,20 @@
+import { DocxDocument, type ConvertCommentsToFootnotesOptions, type ConvertCommentsToFootnotesReport } from './document.js';
+
+export type ConvertCommentsToFootnotesResult = {
+  buffer: Buffer;
+  report: ConvertCommentsToFootnotesReport;
+};
+
+/**
+ * Convert comments on an isolated in-memory document and return a new DOCX.
+ * The caller's source buffer and file remain unchanged when preflight fails.
+ */
+export async function convertCommentsToFootnotes(
+  source: Buffer,
+  options: ConvertCommentsToFootnotesOptions = {},
+): Promise<ConvertCommentsToFootnotesResult> {
+  const document = await DocxDocument.load(source);
+  const report = await document.convertCommentsToFootnotes(options);
+  const { buffer } = await document.toBuffer({ cleanBookmarks: true, preserveOriginalBookmarks: true });
+  return { buffer, report };
+}

--- a/packages/docx-core/test-primitives/footnotes.test.ts
+++ b/packages/docx-core/test-primitives/footnotes.test.ts
@@ -1112,7 +1112,7 @@ describe('footnotes', () => {
       });
     });
 
-    test('preserves byte-identical legacy output when ctx is omitted for addFootnote, updateFootnoteText, and deleteFootnote', async ({ given, when, then }: AllureBddContext) => {
+    test('keeps add, update, and delete on the deterministic untracked path when ctx is omitted', async ({ given, when, then }: AllureBddContext) => {
       let addDoc: Document;
       let addZip: DocxZip;
       let addDocumentXml: string;
@@ -1175,13 +1175,13 @@ describe('footnotes', () => {
         deleteFootnotesXml = await deleteZip.readText('word/footnotes.xml');
       });
 
-      await then('all three outputs remain byte-identical to the pre-tracked-change behavior', async () => {
+      await then('all three outputs use the deterministic untracked representation', async () => {
         expect(addDocumentXml).toBe(
           serializeXml(
             makeDocument(
               '<w:p>' +
                 '<w:r><w:t>Hello</w:t></w:r>' +
-                '<w:r><w:rPr><w:rStyle w:val="FootnoteReference"/></w:rPr><w:footnoteReference w:id="1"/></w:r>' +
+                '<w:r><w:rPr><w:rStyle w:val="FootnoteReference"/><w:vertAlign w:val="superscript"/></w:rPr><w:footnoteReference w:id="1"/></w:r>' +
                 '</w:p>',
             ),
           ),
@@ -1196,7 +1196,7 @@ describe('footnotes', () => {
                 paragraphXml:
                   '<w:p>' +
                   '<w:pPr><w:pStyle w:val="FootnoteText"/></w:pPr>' +
-                  '<w:r><w:rPr><w:rStyle w:val="FootnoteReference"/></w:rPr><w:footnoteRef/></w:r>' +
+                  '<w:r><w:rPr><w:rStyle w:val="FootnoteReference"/><w:vertAlign w:val="superscript"/></w:rPr><w:footnoteRef/></w:r>' +
                   '<w:r><w:t xml:space="preserve"> </w:t></w:r>' +
                   '<w:r><w:t>Legacy note</w:t></w:r>' +
                   '</w:p>',

--- a/packages/docx-markdoc/src/cli.ts
+++ b/packages/docx-markdoc/src/cli.ts
@@ -6,6 +6,7 @@ import { exportEditPairs } from './export.js';
 import { importDocxToMarkdoc } from './import.js';
 import { inspectMarkdocSource } from './inspect.js';
 import { requireMarkdoc } from './markdoc.js';
+import { convertCommentsToFootnotes } from '@usejunior/docx-core';
 import { DocxMarkdocError } from './errors.js';
 import { assertDistinctInternalPath, EXTERNAL_FILENAME, parseRenderingFlags, warnedInternalPath } from './cli-options.js';
 
@@ -19,6 +20,7 @@ function usage(): never {
     '    [--dangerously-include-internal-comments --internal-output <path.docx>]',
     '  docx-markdoc verify <anchored.docx> <document.mdoc> [--external-comments|--no-external-comments]',
     '  docx-markdoc export-edits <document.mdoc> <output.json>',
+    '  docx-markdoc comments-to-footnotes <input.docx> <output.docx> [--prefix TEXT] [--prefix-separator TEXT] [--bold-prefix] [--prefix-color RRGGBB] [--prefix-highlight COLOR] [--body-color RRGGBB] [--body-highlight COLOR] [--flatten-threads]',
   ].join('\n'));
 }
 
@@ -107,6 +109,31 @@ async function main(): Promise<void> {
     if (!markdocPath || !outputPath) usage();
     const ir = requireMarkdoc(await readFile(markdocPath, 'utf8'));
     await writeFile(outputPath, `${JSON.stringify(exportEditPairs(ir), null, 2)}\n`);
+    return;
+  }
+  if (command === 'comments-to-footnotes') {
+    const [inputPath, outputPath, ...flags] = args;
+    if (!inputPath || !outputPath) usage();
+    const valueAfter = (flag: string): string | undefined => {
+      const index = flags.indexOf(flag);
+      return index < 0 ? undefined : flags[index + 1];
+    };
+    const prefix = valueAfter('--prefix');
+    const prefixColor = valueAfter('--prefix-color');
+    const prefixHighlight = valueAfter('--prefix-highlight') as import('@usejunior/docx-core').FootnoteRunStyle['highlight'];
+    const bodyColor = valueAfter('--body-color') ?? valueAfter('--color');
+    const bodyHighlight = (valueAfter('--body-highlight') ?? valueAfter('--highlight')) as import('@usejunior/docx-core').FootnoteRunStyle['highlight'];
+    const result = await convertCommentsToFootnotes(await readFile(inputPath), {
+      flattenThreads: flags.includes('--flatten-threads'),
+      presentation: {
+        prefix,
+        prefixSeparator: valueAfter('--prefix-separator'),
+        prefixStyle: { bold: flags.includes('--bold-prefix'), color: prefixColor, highlight: prefixHighlight },
+        bodyStyle: { color: bodyColor, highlight: bodyHighlight },
+      },
+    });
+    await writeFile(outputPath, result.buffer);
+    process.stdout.write(`${JSON.stringify(result.report, null, 2)}\n`);
     return;
   }
   usage();


### PR DESCRIPTION
## What changed

- add an OpenSpec proposal for configurable note presentation
- add transactional root-comment → footnote conversion with selection and disposition reporting
- anchor footnotes at absolute visible comment-range endpoints
- preserve existing substantive footnotes and unrelated document content
- reject threaded comments by default, with explicit lossy flattening
- style footnote prefix, separator, and body independently
- emit explicit superscript properties for both body and footnote-area markers
- expose a `docx-markdoc comments-to-footnotes` CLI command

This draft implements the comment-to-footnote slice. Audience-based Markdoc projection and provenance-gated reverse conversion remain checked-off future tasks in the proposal.

## Why

Word comment bubbles are awkward in some legal-drafting workflows, while footnotes are easier to process and visibly clear before execution. The implementation keeps note presentation configurable without changing operative text or treating substantive footnotes as drafting notes.

A real local-only DOCX exposed a structural-run/visible-run mismatch caused by zero-width comment-reference runs. The fix records absolute visible-text endpoints during comment traversal. The broader SSOT architecture is intentionally separated into #904.

## Peer review

Claude Opus 4.6 performed a dynamic review with repository access and executed builds/tests. It initially found two blockers:

1. OpenSpec scenarios were not mapped through `testAllure`.
2. The test imported bare Vitest `test`, violating repository lint policy.

It also found missing runtime highlight validation and requested safety documentation for insert-then-delete ordering. All four findings were addressed before this draft was opened:

- 5/5 delta scenarios now map and pass the strict primitive coverage gate
- the new test uses the package-local Allure helper
- invalid highlight values fail before mutation
- the conversion loop documents why comment deletion cannot consume the new footnote run

## Validation

- `npm run build -w @usejunior/docx-core` — passed
- `npm run build -w @usejunior/docx-markdoc` — passed
- focused comments + note-conversion tests — 53 passed
- note-conversion OpenSpec tests — 6 passed
- strict primitive OpenSpec coverage — passed, including 5/5 new scenarios
- `openspec validate add-configurable-note-presentation --strict` — passed
- `npm run check:conformance-citations` — passed
- cached diff whitespace check — passed

Current `main` has unrelated `comparisonStrategy` test typing errors under the broader docx-core `tsc --noEmit` lint command; package production builds and the changed-surface tests pass.

## Privacy

The real agreement used for local smoke testing was never copied into the repository, committed, uploaded, or sent to the peer reviewer. The committed tests use synthetic fixtures only.

Ref: #904