### PR TITLE
chore(deps): refresh vulnerable release dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@vitest/runner": "4.1.8",
         "@xmldom/xmldom": "^0.9.10",
         "ajv": "^8.18.0",
-        "allure": "3.8.2",
+        "allure": "3.15.0",
         "eslint": "^10.0.1",
         "fast-xml-parser": "^5.7.0",
         "jszip": "^3.10.1",
@@ -29,74 +29,85 @@
       }
     },
     "node_modules/@allurereport/aql": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@allurereport/aql/-/aql-3.8.2.tgz",
-      "integrity": "sha512-WIjtCpzt7Spx+aCKJTbdi7VwEPnY/Ub7uwOybrPPILNngn19PCnzSfguRpLvg15piDzEqCSZ95c28po9RnH0HQ==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/aql/-/aql-3.15.0.tgz",
+      "integrity": "sha512-gUK+sMpUuJsQXe1Mq8Y2oe+y9PnCe9KSwUuzeinuttfleHO4JdMA9+HdgQu7TXL/9MkE6kR21ANDMvXltCcq1g==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@allurereport/charts-api": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@allurereport/charts-api/-/charts-api-3.8.2.tgz",
-      "integrity": "sha512-JOKJg4zA4hyEDu8FvzMIXJoROJ5PLQY7anMPoOLqhghyt3g8fG/L4KzfQPWZpwjai2PkbBg3i+RK+wplwaJMhw==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/charts-api/-/charts-api-3.15.0.tgz",
+      "integrity": "sha512-1cE3uK/W0ZQBROQHInPfzvYHx/Tt7xRfclkDQc1tKuG/wNoaaPckh17RAte9/137AsJ44xPahf7hj87kUUwXCQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/core-api": "3.8.2",
-        "@allurereport/plugin-api": "3.8.2",
+        "@allurereport/core-api": "3.15.0",
+        "@allurereport/plugin-api": "3.15.0",
         "d3-shape": "^3.2.0"
       }
     },
     "node_modules/@allurereport/ci": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@allurereport/ci/-/ci-3.8.2.tgz",
-      "integrity": "sha512-0RuSM9BqCTr4Mzqno4w2UcMuzkmaDNeeig9hSjc/Vq7kLcHSjy28M2dFCI3kkODLKkBJLEvTmcZELWN4FazIWg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/ci/-/ci-3.15.0.tgz",
+      "integrity": "sha512-2U16jt7zvD5H3ACjMCvX3wkG2PmmyZndjtPpkcTTcUrzoNlkDB7zsanG/J5g1XfuJlma5FAp+ANaobTMylWe9Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/core-api": "3.8.2"
+        "@allurereport/core-api": "3.15.0"
+      }
+    },
+    "node_modules/@allurereport/cli-commons": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/cli-commons/-/cli-commons-3.15.0.tgz",
+      "integrity": "sha512-e3K4CzrhqFXRBc+amSjWO8iMsqjaKrd1sM3rjZ8/tz5ifD6j40JZYgVXwTfYvi0luixTAd1FJTvAX3RJX30INw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.debounce": "^4.0.8"
       }
     },
     "node_modules/@allurereport/core": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@allurereport/core/-/core-3.8.2.tgz",
-      "integrity": "sha512-qUhPWunK532pTBlwqqPI8JefUKWK8YQEWEluC7waY9Kv7AHAB/4ghhNCMrY1AaE5DiaQRyv397S58qTN8xlwyA==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/core/-/core-3.15.0.tgz",
+      "integrity": "sha512-n/U6egNC7LQMqZm8AI4PaER2m4+kPxG7d0kpPqzHi6WvJyU+exSRE/zoGBWK86qm2RuCn4wJ99HQsapJiJ2cQA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/ci": "3.8.2",
-        "@allurereport/core-api": "3.8.2",
-        "@allurereport/plugin-agent": "3.8.2",
-        "@allurereport/plugin-allure2": "3.8.2",
-        "@allurereport/plugin-api": "3.8.2",
-        "@allurereport/plugin-awesome": "3.8.2",
-        "@allurereport/plugin-classic": "3.8.2",
-        "@allurereport/plugin-csv": "3.8.2",
-        "@allurereport/plugin-dashboard": "3.8.2",
-        "@allurereport/plugin-jira": "3.8.2",
-        "@allurereport/plugin-log": "3.8.2",
-        "@allurereport/plugin-progress": "3.8.2",
-        "@allurereport/plugin-slack": "3.8.2",
-        "@allurereport/plugin-testops": "3.8.2",
-        "@allurereport/plugin-testplan": "3.8.2",
-        "@allurereport/reader": "3.8.2",
-        "@allurereport/reader-api": "3.8.2",
-        "@allurereport/service": "3.8.2",
-        "@allurereport/summary": "3.8.2",
+        "@allurereport/ci": "3.15.0",
+        "@allurereport/cli-commons": "3.15.0",
+        "@allurereport/core-api": "3.15.0",
+        "@allurereport/plugin-agent": "3.15.0",
+        "@allurereport/plugin-allure2": "3.15.0",
+        "@allurereport/plugin-api": "3.15.0",
+        "@allurereport/plugin-awesome": "3.15.0",
+        "@allurereport/plugin-classic": "3.15.0",
+        "@allurereport/plugin-csv": "3.15.0",
+        "@allurereport/plugin-dashboard": "3.15.0",
+        "@allurereport/plugin-jira": "3.15.0",
+        "@allurereport/plugin-log": "3.15.0",
+        "@allurereport/plugin-progress": "3.15.0",
+        "@allurereport/plugin-slack": "3.15.0",
+        "@allurereport/plugin-testops": "3.15.0",
+        "@allurereport/plugin-testplan": "3.15.0",
+        "@allurereport/reader": "3.15.0",
+        "@allurereport/reader-api": "3.15.0",
+        "@allurereport/service": "3.15.0",
+        "@allurereport/summary": "3.15.0",
         "glob": "^13.0.6",
         "handlebars": "^4.7.9",
+        "jiti": "^2.5.1",
         "node-stream-zip": "^1.15.0",
-        "p-limit": "^7.2.0",
-        "progress": "^2.0.3",
+        "p-limit": "^7.3.0",
         "yaml": "^2.8.3",
-        "yoctocolors": "^2.1.1",
-        "zip-stream": "^7.0.2"
+        "yoctocolors": "^2.1.2",
+        "zip-stream": "^7.0.5"
       }
     },
     "node_modules/@allurereport/core-api": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@allurereport/core-api/-/core-api-3.8.2.tgz",
-      "integrity": "sha512-2MRxdfEYG3OJZ+6y0oz8yivhQiBBTSLf+CtWIUYtGuxlQsoxNjWTPbdSaOlPGwZcP1n+Fc9vhmYZcXo1IvbGIA==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/core-api/-/core-api-3.15.0.tgz",
+      "integrity": "sha512-H2Vhw+y4bpJbHAzAGA/CpVetft+YNE1HGInekQ/jA6W26nZGcWcj/NOQk695oyLPJ5xvFDsSEKJz2AvXC2FKCA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -104,293 +115,306 @@
       }
     },
     "node_modules/@allurereport/directory-watcher": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@allurereport/directory-watcher/-/directory-watcher-3.8.2.tgz",
-      "integrity": "sha512-yDNOqi5H4Hr2Ul7WkoKTJFazSuYBqRK8/a8FQgaI12AYEcnYXcBAKRspSE/0JloblzMrdFluQmb2AlAsSAkh7g==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/directory-watcher/-/directory-watcher-3.15.0.tgz",
+      "integrity": "sha512-YQv8KUxVqq4qRJXBv6dUpYHQab7zCJU59/gzIgQnTAcY7+AoL2mrWKNLOz/7qkF14oKEqIXYZQPfAiGJz9YbGw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "chokidar": "^4.0.3"
+        "chokidar": "^5.0.0"
+      }
+    },
+    "node_modules/@allurereport/git": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/git/-/git-3.15.0.tgz",
+      "integrity": "sha512-m1cPw0jYLljtMYY361fHYxuQICRbmB10yTVIheXKPxKg2pdOuAEMC1ZcnKs/81zH9AgmXfqiZYGC4QSDKqn1kA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@allurereport/core-api": "3.15.0"
       }
     },
     "node_modules/@allurereport/plugin-agent": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@allurereport/plugin-agent/-/plugin-agent-3.8.2.tgz",
-      "integrity": "sha512-d7+zdzbXbiGyOrXl/Asi4tqZr3uH1ZyAY9yL7mGGC1p7gdw5PCoaqIh8pzfR1JHlHi+cDZay86p6cDgtgp87LQ==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-agent/-/plugin-agent-3.15.0.tgz",
+      "integrity": "sha512-5WhH/90oFIkWa6Pjh/Poy6ceipIRPWNc8HTdlUo6x2QzLJ3FBRz/TeFhK1VUeX4JTxuqtaWmYao3RbrOKe2XDA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/core-api": "3.8.2",
-        "@allurereport/plugin-api": "3.8.2",
+        "@allurereport/core-api": "3.15.0",
+        "@allurereport/plugin-api": "3.15.0",
         "yaml": "^2.8.1"
       }
     },
     "node_modules/@allurereport/plugin-allure2": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@allurereport/plugin-allure2/-/plugin-allure2-3.8.2.tgz",
-      "integrity": "sha512-QlHTIcfszmpCB9uWwV1WFb6qJPEqdzoypRMdaQl2nKYLg73bCLAlZJqUMuRqpt9DMbDf5u5nH2E4eCZWUEQvYg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-allure2/-/plugin-allure2-3.15.0.tgz",
+      "integrity": "sha512-QJiwDoGOSDAZHO+To1WHlfr9pxu0HYzncYOTBXbU98KKu8LV7WBg0o0KassVHlFYClh07CIZl1os4c6bEqfg/A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/core-api": "3.8.2",
-        "@allurereport/plugin-api": "3.8.2",
+        "@allurereport/core-api": "3.15.0",
+        "@allurereport/plugin-api": "3.15.0",
         "find-up": "^8.0.0",
         "handlebars": "^4.7.9"
       }
     },
     "node_modules/@allurereport/plugin-api": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@allurereport/plugin-api/-/plugin-api-3.8.2.tgz",
-      "integrity": "sha512-ICV+vWzO7L12GpcKxry+zIVCV1LIVrAKSzXhmsWasgbXGyUly0AO4o6vvkVUPuUOicaT3r+kUydw55geMyeCpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-api/-/plugin-api-3.15.0.tgz",
+      "integrity": "sha512-oVOaX/HAgJ9qOIuraXkdgMuOpG/nMB0fd/S1vMyAnr677r92l5GEpeXbHVOKSQF3Ahr0cgR1nOVbqQkjzebG6w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/core-api": "3.8.2"
+        "@allurereport/core-api": "3.15.0"
       }
     },
     "node_modules/@allurereport/plugin-awesome": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@allurereport/plugin-awesome/-/plugin-awesome-3.8.2.tgz",
-      "integrity": "sha512-Fhl6PTYj/A1PiBUj6JfPPEHXWn8a3aNfhPSiYaWg2u/+q+2UyG7MGYs5PgEpDSNL9Q6HSB0okGVDszXZTiXuqw==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-awesome/-/plugin-awesome-3.15.0.tgz",
+      "integrity": "sha512-vrVKvfv4AVrLYk55dl8hGSDob86fq04Ok2Owyp8PF7qCpAVp1uzFsBBwNTjAzgqGcoiJV6xV/VRmYx2CBW2WrA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/charts-api": "3.8.2",
-        "@allurereport/core-api": "3.8.2",
-        "@allurereport/plugin-api": "3.8.2",
-        "@allurereport/web-awesome": "3.8.2",
-        "@allurereport/web-commons": "3.8.2",
+        "@allurereport/charts-api": "3.15.0",
+        "@allurereport/core-api": "3.15.0",
+        "@allurereport/plugin-api": "3.15.0",
+        "@allurereport/web-awesome": "3.15.0",
+        "@allurereport/web-commons": "3.15.0",
         "d3-shape": "^3.2.0",
         "handlebars": "^4.7.9",
-        "markdown-it": "^14.1.0"
+        "markdown-it": "^14.2.0"
       }
     },
     "node_modules/@allurereport/plugin-classic": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@allurereport/plugin-classic/-/plugin-classic-3.8.2.tgz",
-      "integrity": "sha512-xgKb56cIUQUarmM9yvJWrVJPkYkOLlT0Lo3Zun8mrFVIufVA4+kmZa/xwcoPaGajBX1OS9JzagjuUGK8m2M70A==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-classic/-/plugin-classic-3.15.0.tgz",
+      "integrity": "sha512-h9LVmk+fGVNwz8ePMrs5vOPIbiUlFeSKk85h+qL48NgAcI8pOHsPcPjPGg5P8+g+4sKO4fJEDiQdMy+x657O5A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/core-api": "3.8.2",
-        "@allurereport/plugin-api": "3.8.2",
-        "@allurereport/web-awesome": "3.8.2",
-        "@allurereport/web-classic": "3.8.2",
-        "@allurereport/web-commons": "3.8.2",
+        "@allurereport/core-api": "3.15.0",
+        "@allurereport/plugin-api": "3.15.0",
+        "@allurereport/web-awesome": "3.15.0",
+        "@allurereport/web-classic": "3.15.0",
+        "@allurereport/web-commons": "3.15.0",
         "d3-shape": "^3.2.0",
         "handlebars": "^4.7.9",
-        "markdown-it": "^14.1.0"
+        "markdown-it": "^14.2.0"
       }
     },
     "node_modules/@allurereport/plugin-csv": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@allurereport/plugin-csv/-/plugin-csv-3.8.2.tgz",
-      "integrity": "sha512-+mfqo5Rg93JWtWMexWzBEBDE60lK14JiC6UxTMVPIW5jrfn0SF+NfMBDnez2GcGdsJJbr9QQ8a81DwyshIdbqA==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-csv/-/plugin-csv-3.15.0.tgz",
+      "integrity": "sha512-RvSXl7ebwUu2bZIdFvZDJszW1bAOo/ze+sNs3ZMwzxmuBWvhjYV0wo6HMJKNaanxunugRvHDgM8xRKN5svNrIg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/core-api": "3.8.2",
-        "@allurereport/plugin-api": "3.8.2"
+        "@allurereport/core-api": "3.15.0",
+        "@allurereport/plugin-api": "3.15.0"
       }
     },
     "node_modules/@allurereport/plugin-dashboard": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@allurereport/plugin-dashboard/-/plugin-dashboard-3.8.2.tgz",
-      "integrity": "sha512-3jRk+AuYjeWT6ew700+z7+YuZBF4083knFrf/gab9U/5r9tdJWCpzXUWQKqRosBFbU7qddM2rhUwpfFejvtHqw==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-dashboard/-/plugin-dashboard-3.15.0.tgz",
+      "integrity": "sha512-rQB9mVEa0y/vpkcTLrvoZxN0QwYpTnkRr3qhTparFxNCEYUvgGfc/glHocQHF+ThOOQaj0SodVsaHm2/qKWNOg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/charts-api": "3.8.2",
-        "@allurereport/core-api": "3.8.2",
-        "@allurereport/plugin-api": "3.8.2",
-        "@allurereport/web-commons": "3.8.2",
-        "@allurereport/web-dashboard": "3.8.2",
+        "@allurereport/charts-api": "3.15.0",
+        "@allurereport/core-api": "3.15.0",
+        "@allurereport/plugin-api": "3.15.0",
+        "@allurereport/web-commons": "3.15.0",
+        "@allurereport/web-dashboard": "3.15.0",
         "d3-shape": "^3.2.0",
         "handlebars": "^4.7.9"
       }
     },
     "node_modules/@allurereport/plugin-jira": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@allurereport/plugin-jira/-/plugin-jira-3.8.2.tgz",
-      "integrity": "sha512-bamRQzbUECH97MYs2m73SRVQnOQHPCxsOOEk4USvMZsuJasazq9Eoi33QNEBaszH+2672/hvzrbMHf6Ylpb6jw==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-jira/-/plugin-jira-3.15.0.tgz",
+      "integrity": "sha512-zKIsCHgZXvjPprF1NQLGLr/Bz2cCJi0VnB8qlWwzsdTK4JXH1Wu5Vigjy9pT+qIV6j3ZxTAGra5/QoEXrDA/yA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/core-api": "3.8.2",
-        "@allurereport/plugin-api": "3.8.2",
-        "axios": "^1.15.2"
+        "@allurereport/core-api": "3.15.0",
+        "@allurereport/plugin-api": "3.15.0",
+        "axios": "^1.18.1"
       }
     },
     "node_modules/@allurereport/plugin-log": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@allurereport/plugin-log/-/plugin-log-3.8.2.tgz",
-      "integrity": "sha512-17Au7Fxwkziyl8DQ2YQ91RAWkTt8wYhFxOnY4psEaAhNGl87GRV04sr2NpAdIoT0lKc/QN4o09iiy4GXlbNsQg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-log/-/plugin-log-3.15.0.tgz",
+      "integrity": "sha512-etqx26I+d7csz5WAlVnW5KHj4cgtXLQVP4CBFRm2bxvDka0+nQtT8sraUPkENU69qGzQEJ/KO1E91nh+kQxHcw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/core-api": "3.8.2",
-        "@allurereport/plugin-api": "3.8.2",
-        "yoctocolors": "^2.1.1"
+        "@allurereport/core-api": "3.15.0",
+        "@allurereport/plugin-api": "3.15.0",
+        "yoctocolors": "^2.1.2"
       }
     },
     "node_modules/@allurereport/plugin-progress": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@allurereport/plugin-progress/-/plugin-progress-3.8.2.tgz",
-      "integrity": "sha512-LlbkpR00tJClvcfj48to8oSvTG5JzoLPhqkF4aSzflav7+rz/3+sGyRYd5g4+58CxhUArNE02pnI2WfY0mDNrQ==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-progress/-/plugin-progress-3.15.0.tgz",
+      "integrity": "sha512-+6blx1xE7EpTIwkHSYJ0Ah/RlM07e0V+yJzMKSMJ4Lseqyn33zvPGy/asZXv1hgSxPOn+h3gBnzhdNAc5jBStA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/core-api": "3.8.2",
-        "@allurereport/plugin-api": "3.8.2",
-        "yoctocolors": "^2.1.1"
+        "@allurereport/core-api": "3.15.0",
+        "@allurereport/plugin-api": "3.15.0",
+        "yoctocolors": "^2.1.2"
       }
     },
     "node_modules/@allurereport/plugin-server-reload": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@allurereport/plugin-server-reload/-/plugin-server-reload-3.8.2.tgz",
-      "integrity": "sha512-62qPtmjwvF682PC++9+yfvzfV6HKgrAeNb3sGyZoKdlDRdhVckMpnuasDLVSLANRCv/srF/hATsQ2+GMftaWqg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-server-reload/-/plugin-server-reload-3.15.0.tgz",
+      "integrity": "sha512-waqzQaQGVB6X3jDvpO4TuzzbcWmUhu2Q0T5RIky7LZa3MniJFtwcnLc1LDwu+A7SNDxS1CPV4cKVhpOOaHAmfw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/plugin-api": "3.8.2",
-        "@allurereport/static-server": "3.8.2"
+        "@allurereport/plugin-api": "3.15.0",
+        "@allurereport/static-server": "3.15.0"
       }
     },
     "node_modules/@allurereport/plugin-slack": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@allurereport/plugin-slack/-/plugin-slack-3.8.2.tgz",
-      "integrity": "sha512-peahx1EA+db356kpU/48wIZ+FS/kMiNlg7wgotEGC22Bd9PzqC9lNr+6pf7s4U/zYHU9RvdvfFJxgnNzGh+VaQ==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-slack/-/plugin-slack-3.15.0.tgz",
+      "integrity": "sha512-N6KlJaDdrVsLbh3jVyrAeqIuZGzFPtQfDopuE5Gfmd4GS9Z6Ed0BNRvrWuCs5V2tUm3gKESlp1x2iFdmbnhrZw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/core-api": "3.8.2",
-        "@allurereport/plugin-api": "3.8.2"
+        "@allurereport/core-api": "3.15.0",
+        "@allurereport/plugin-api": "3.15.0"
       }
     },
     "node_modules/@allurereport/plugin-testops": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@allurereport/plugin-testops/-/plugin-testops-3.8.2.tgz",
-      "integrity": "sha512-rEdYX2LLydjKPw4lVqvBuEHUAimdv871Q6Wjv64JSrmtf8P3Bg4uGnJ/9+rF4di4BaRhw2xO9MhBj0LM3xdtHA==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-testops/-/plugin-testops-3.15.0.tgz",
+      "integrity": "sha512-QQgagLx2eFreBzrxAmi1Tpjo/unmwR3l4sNVpxbUVRA0tR78ZnJ1XcGctDTKMsIinw741vijhIn7/ZHGPzfg7g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/ci": "3.8.2",
-        "@allurereport/core-api": "3.8.2",
-        "@allurereport/plugin-api": "3.8.2",
-        "@allurereport/reader-api": "3.8.2",
-        "axios": "^1.15.2",
-        "form-data": "^4.0.5",
+        "@allurereport/ci": "3.15.0",
+        "@allurereport/cli-commons": "3.15.0",
+        "@allurereport/core-api": "3.15.0",
+        "@allurereport/git": "3.15.0",
+        "@allurereport/plugin-api": "3.15.0",
+        "@allurereport/reader-api": "3.15.0",
+        "@allurereport/service": "3.15.0",
+        "axios": "^1.18.1",
+        "form-data": "^4.0.6",
         "lodash-es": "^4.18.1",
         "p-limit": "^7.3.0",
-        "progress": "^2.0.3",
         "yoctocolors": "^2"
       }
     },
     "node_modules/@allurereport/plugin-testplan": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@allurereport/plugin-testplan/-/plugin-testplan-3.8.2.tgz",
-      "integrity": "sha512-iO84XokR7fo8ECdT7l+GrQapbdtcd9Eg9c1dwyQ+4jeaPOz1U3Q7ELygH55wzwagv/4BJ+ji92b2WbiJAZPKVQ==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/plugin-testplan/-/plugin-testplan-3.15.0.tgz",
+      "integrity": "sha512-mlyrDOb1LYORpOAT8dW653q/PHbwVnHVdrGHgZc1WBMNmuwWTOx4bbFGFPMKV9efafx51pQW8Ox37vnvn8sGVg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/core-api": "3.8.2",
-        "@allurereport/plugin-api": "3.8.2"
+        "@allurereport/core-api": "3.15.0",
+        "@allurereport/plugin-api": "3.15.0"
       }
     },
     "node_modules/@allurereport/reader": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@allurereport/reader/-/reader-3.8.2.tgz",
-      "integrity": "sha512-z+soXMWKzMfmCGdAaT5xatVBUvIb8dlu+gP/mOWNiUgHl+dMvyl1mB+Ym8ehUghAxlDGsibsWxFrmyk2z8yZ0Q==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/reader/-/reader-3.15.0.tgz",
+      "integrity": "sha512-AOqjvSfdI90ou9X4ip+LCOlrcNIP7WL6ieONL8rSSMQft99hK1cKxJ7q1hsmkFWhViPHlqtfwIq4sTlnlW/uDQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/core-api": "3.8.2",
-        "@allurereport/plugin-api": "3.8.2",
-        "@allurereport/reader-api": "3.8.2",
-        "fast-xml-parser": "^5.5.7"
+        "@allurereport/core-api": "3.15.0",
+        "@allurereport/plugin-api": "3.15.0",
+        "@allurereport/reader-api": "3.15.0",
+        "fast-xml-parser": "^5.7.0"
       }
     },
     "node_modules/@allurereport/reader-api": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@allurereport/reader-api/-/reader-api-3.8.2.tgz",
-      "integrity": "sha512-dmMfFEeffTbOCtIILlY094U410Hi8HkZDHLzkm1W4zfjEs8596N8EgcfwY5sn2j5k8OSvmrCfTt7MVxTBanTNA==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/reader-api/-/reader-api-3.15.0.tgz",
+      "integrity": "sha512-HZ3mP0Y7ZkHjxgqM3aimFEsxPba7rMP8jo6E8lPve+iHzzooXFKopQleGIScZ7waJp+AACoiR0xVGheLSRpWJQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/core-api": "3.8.2",
-        "@allurereport/plugin-api": "3.8.2",
+        "@allurereport/core-api": "3.15.0",
+        "@allurereport/plugin-api": "3.15.0",
         "mime-types": "^2.1.35"
       }
     },
     "node_modules/@allurereport/service": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@allurereport/service/-/service-3.8.2.tgz",
-      "integrity": "sha512-qvB0RfnIb5J5wjGjSKQzziQnMd30h28imPi3yT3KADpu+7tZoHFd/daYJ1aTZW2RfphXjWeXUp3BZl3cQoMjEw==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/service/-/service-3.15.0.tgz",
+      "integrity": "sha512-zD4VVdFhmWr8NU1Lah1TlV5S0bIHX64xUmKcgD/Mrzp4xBYtvZYntJgvpnsuroePLSK77FrZfE4VUAURNcj87g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/core-api": "3.8.2",
-        "@allurereport/plugin-api": "3.8.2",
-        "axios": "^1.15.2",
-        "open": "^10.1.0"
+        "@allurereport/core-api": "3.15.0",
+        "@allurereport/plugin-api": "3.15.0",
+        "axios": "^1.18.1",
+        "open": "^11.0.0"
       }
     },
     "node_modules/@allurereport/static-server": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@allurereport/static-server/-/static-server-3.8.2.tgz",
-      "integrity": "sha512-RBLW3NRwtzcBZdBkYOvlr2JPqmMEYKhiJVTvYea4Is7LVeUubJEPhUQHdVrxD3gGaFa3CjKU9WxXe6n982vYbQ==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/static-server/-/static-server-3.15.0.tgz",
+      "integrity": "sha512-ZK7kg2jK8A6RlOFOio94lJgl9WuZOL31FluMFZaujW+9Wn0vSvA3+sVt20WQa8ZW5JZnracCIa1mI4DQaYZ2WA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/directory-watcher": "3.8.2",
-        "open": "^10.1.0"
+        "@allurereport/directory-watcher": "3.15.0",
+        "open": "^11.0.0"
       }
     },
     "node_modules/@allurereport/summary": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@allurereport/summary/-/summary-3.8.2.tgz",
-      "integrity": "sha512-NqeX0UpZbT7g3r2ir/Bh8gQSjKsHQLJxCjW6HqfGt/lkZxXA1oR/5rbxk/PTwmuEIEdI2wy0In8djtBVnAzcKg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/summary/-/summary-3.15.0.tgz",
+      "integrity": "sha512-WesisywhAVg0iAejphA3eacUiHGGjd3dXCPi8s3eIfU9fIwmrNUn5O0Vtrn+rDlWNWjInJttf+MxHdeOHM00Cg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/core-api": "3.8.2",
-        "@allurereport/plugin-api": "3.8.2",
-        "@allurereport/web-summary": "3.8.2",
+        "@allurereport/core-api": "3.15.0",
+        "@allurereport/plugin-api": "3.15.0",
+        "@allurereport/web-summary": "3.15.0",
         "handlebars": "^4.7.9"
       }
     },
     "node_modules/@allurereport/web-awesome": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@allurereport/web-awesome/-/web-awesome-3.8.2.tgz",
-      "integrity": "sha512-H49TtEBRloBRzyEkiSa932jVtuRYJTPk3osMPMNYwaJYQZfujwZNlngZbH7LTkJPfsqZI/arKeeYIFo3ToRZew==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/web-awesome/-/web-awesome-3.15.0.tgz",
+      "integrity": "sha512-jqxQDYUnZUc0o4q5km3go7u608ZyBn+OH7JEHlUwYDEfbWUZxDIqtin3iSyq+wOqOHXiWUvmqtxXOjIEIyOMqQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/charts-api": "3.8.2",
-        "@allurereport/core-api": "3.8.2",
-        "@allurereport/plugin-api": "3.8.2",
-        "@allurereport/web-commons": "3.8.2",
-        "@allurereport/web-components": "3.8.2",
+        "@allurereport/charts-api": "3.15.0",
+        "@allurereport/core-api": "3.15.0",
+        "@allurereport/plugin-api": "3.15.0",
+        "@allurereport/web-commons": "3.15.0",
+        "@allurereport/web-components": "3.15.0",
         "@preact/signals": "^2.6.1",
         "clsx": "^2.1.1",
         "d3-shape": "^3.2.0",
         "i18next": "^24.0.2",
         "md5": "^2.3.0",
+        "minisearch": "^7.2.0",
         "preact": "^10.28.2",
         "prismjs": "^1.30.0"
       }
     },
     "node_modules/@allurereport/web-classic": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@allurereport/web-classic/-/web-classic-3.8.2.tgz",
-      "integrity": "sha512-vT1J45gdP8ZEnABBcKjKOvyVHl+fSjCDlIjun7grSiE5M9G/mpxPuz0KAFIXt2QzBOYq1piVjJjdnVmAxSCqTQ==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/web-classic/-/web-classic-3.15.0.tgz",
+      "integrity": "sha512-4b2EKL5zXsWzVU9faFXFRELkXvikMyXO06/4W2ODL0VZq+QkJbVJygPb+jCPE3jlTTZE3jGxVxx7qG2d5g/MRg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/charts-api": "3.8.2",
-        "@allurereport/core-api": "3.8.2",
-        "@allurereport/web-commons": "3.8.2",
-        "@allurereport/web-components": "3.8.2",
+        "@allurereport/charts-api": "3.15.0",
+        "@allurereport/core-api": "3.15.0",
+        "@allurereport/web-commons": "3.15.0",
+        "@allurereport/web-components": "3.15.0",
         "@preact/signals": "^2.6.1",
         "clsx": "^2.1.1",
         "d3-shape": "^3.2.0",
@@ -402,16 +426,16 @@
       }
     },
     "node_modules/@allurereport/web-commons": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@allurereport/web-commons/-/web-commons-3.8.2.tgz",
-      "integrity": "sha512-++HbKacwRlqlyR7rm1XTyZ1G0u+j8xIHN3MpSmEcrpvIOUePbAgjPs8RKDLU2lNYlb+dL7vCLYEqecqM5K0hdQ==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/web-commons/-/web-commons-3.15.0.tgz",
+      "integrity": "sha512-x3qTt8HFgRSCYkgW12CRKurhcgikc87ys5FiOO01P5Pl5HBQN/exUTnzj1pB91sqGzIml5lUch++8S3k/fd7rw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/aql": "3.8.2",
-        "@allurereport/charts-api": "3.8.2",
-        "@allurereport/core-api": "3.8.2",
-        "@allurereport/plugin-api": "3.8.2",
+        "@allurereport/aql": "3.15.0",
+        "@allurereport/charts-api": "3.15.0",
+        "@allurereport/core-api": "3.15.0",
+        "@allurereport/plugin-api": "3.15.0",
         "@preact/signals": "^2.6.1",
         "@preact/signals-core": "^1.12.2",
         "ansi-to-html": "^0.7.2",
@@ -423,14 +447,15 @@
       }
     },
     "node_modules/@allurereport/web-components": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@allurereport/web-components/-/web-components-3.8.2.tgz",
-      "integrity": "sha512-N3aF7lxrEbrO4aTeK7vcjyxYl31zH2lI6LVllOR6237/vQ/mme1Qlja7C2TfaInoEFtCVqvDT9Rw2+QHYpwgCQ==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/web-components/-/web-components-3.15.0.tgz",
+      "integrity": "sha512-Ft0sKpFP1uKBatVw08gHKP/q+LbKSxl33exPheuyBGXcnjPvKNWfUS6lh9AAaA/B+QrUSKF/Swu8YE4HrQA/EA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/charts-api": "3.8.2",
-        "@allurereport/web-commons": "3.8.2",
+        "@allurereport/charts-api": "3.15.0",
+        "@allurereport/core-api": "3.15.0",
+        "@allurereport/web-commons": "3.15.0",
         "@floating-ui/dom": "^1.7.4",
         "@nivo/bar": "^0.99.0",
         "@nivo/core": "^0.99.0",
@@ -458,25 +483,26 @@
         "d3-tip": "^0.9.1",
         "d3-transition": "^3.0.1",
         "lodash": "^4.18.1",
+        "markdown-it": "^14.2.0",
         "preact": "^10.28.2",
         "prismjs": "^1.30.0",
         "react": "npm:@preact/compat@*",
         "react-dom": "npm:@preact/compat@*",
-        "sortablejs": "^1.15.6",
+        "sortablejs": "^1.15.7",
         "use-debounce": "^10.0.6"
       }
     },
     "node_modules/@allurereport/web-dashboard": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@allurereport/web-dashboard/-/web-dashboard-3.8.2.tgz",
-      "integrity": "sha512-Jdw1HLnIZ+3SgwBV/kRWfOeucvMfr1H99wo47kCaxL2RkJxQf9juIdZWDE7yqn78kD7ALsnX94qhm7edrb7TpQ==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/web-dashboard/-/web-dashboard-3.15.0.tgz",
+      "integrity": "sha512-9HTH69+ZDmzBqRJuh++zGpECYTBL9OBPo/UHhznsn8NugMMMEmLms0omvM1/twClrKxgmtX0DlhH41QrBmbT3g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/charts-api": "3.8.2",
-        "@allurereport/core-api": "3.8.2",
-        "@allurereport/web-commons": "3.8.2",
-        "@allurereport/web-components": "3.8.2",
+        "@allurereport/charts-api": "3.15.0",
+        "@allurereport/core-api": "3.15.0",
+        "@allurereport/web-commons": "3.15.0",
+        "@allurereport/web-components": "3.15.0",
         "@preact/signals": "^2.6.1",
         "clsx": "^2.1.1",
         "i18next": "^24.0.2",
@@ -484,15 +510,15 @@
       }
     },
     "node_modules/@allurereport/web-summary": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@allurereport/web-summary/-/web-summary-3.8.2.tgz",
-      "integrity": "sha512-tL17hwtdF0yb8ZXaK7oq838Mvf39Rr9DBD193xI3347KR6gAFZ5ElPHM1FXsplabQMR3/Mfn+lnJm3hSkzsNKQ==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@allurereport/web-summary/-/web-summary-3.15.0.tgz",
+      "integrity": "sha512-gsa1txEhWz+ueIy43K5bAha59ANxbw3RCWwEG6HE9Gr5LHt046t19yZ/AAgKg9XS7kFSDDWoszW4ZdX33BH6sQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/core-api": "3.8.2",
-        "@allurereport/web-commons": "3.8.2",
-        "@allurereport/web-components": "3.8.2",
+        "@allurereport/core-api": "3.15.0",
+        "@allurereport/web-commons": "3.15.0",
+        "@allurereport/web-components": "3.15.0",
         "@preact/signals": "^2.6.1",
         "clsx": "^2.1.1",
         "i18next": "^24.0.2",
@@ -1135,37 +1161,37 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
-      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+      "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.11"
+        "@floating-ui/utils": "^0.2.12"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
-      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+      "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.7.5",
-        "@floating-ui/utils": "^0.2.11"
+        "@floating-ui/core": "^1.8.0",
+        "@floating-ui/utils": "^0.2.12"
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
-      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+      "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "1.19.17",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
+      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -1759,13 +1785,13 @@
       }
     },
     "node_modules/@preact/signals": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@preact/signals/-/signals-2.9.1.tgz",
-      "integrity": "sha512-xVqN8mJjbSN5IB/8Ubmd9NN+Ew6zJswoRxrjZbH3YsgkMshFeO6d8zxEFpHRTq9GJZx7cnPs2CnCpFqtGXGNsw==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@preact/signals/-/signals-2.11.1.tgz",
+      "integrity": "sha512-uYoD+USkacTNU02kfCBkJEV7xabKTmA78W5pnT2GymsuGEC9n/ZO+UT4S96l0dIL6KLDk77VJyUFuOMBvftVHg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@preact/signals-core": "^1.14.0"
+        "@preact/signals-core": "^1.14.4"
       },
       "funding": {
         "type": "opencollective",
@@ -1776,9 +1802,9 @@
       }
     },
     "node_modules/@preact/signals-core": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.2.tgz",
-      "integrity": "sha512-RZHdBj9ZF4n40Rp4jS052EHHjBWf96P9oNdXPfhQTovCuWY9iQn3Gq+gOTJSgBO9A/JBuPfMOWsSX/lIU9Pc/A==",
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.4.tgz",
+      "integrity": "sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1787,29 +1813,29 @@
       }
     },
     "node_modules/@react-spring/animated": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-10.1.1.tgz",
-      "integrity": "sha512-kqdtIzr1GfBmbojnYhNdEhgu23f1rQ9H98K6KGmWHpNBP0gGZWN8KEIzGYwCAon7Q8ktGmsR1dCyy6QTI4egug==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-10.1.2.tgz",
+      "integrity": "sha512-yAsQ/bbp6+vko7WNCI1M00c6KLE9XKTGCrgRhQqS4JcK3oF5qBV4rHYrQEprvEvYXxt+1H5FsLS2eVValEPfFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@react-spring/shared": "~10.1.1",
-        "@react-spring/types": "~10.1.1"
+        "@react-spring/shared": "~10.1.2",
+        "@react-spring/types": "~10.1.2"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@react-spring/core": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@react-spring/core/-/core-10.1.1.tgz",
-      "integrity": "sha512-eCxEJuJzNxbfFXEr+BuMqp+LYv0fdvIO/lk6B+A/aUDxD4M4EBKizPqhCkMz/B+U12d99KTAUSmWaGul/Lly+w==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@react-spring/core/-/core-10.1.2.tgz",
+      "integrity": "sha512-lPGOAg0V+PV3ucopOajD+YCxoe8twALqAeG4c/+sqVjBsyUNNdx8qfz/DcNSPKA8PV3+AyQELlCxlDfap9cmBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@react-spring/animated": "~10.1.1",
-        "@react-spring/shared": "~10.1.1",
-        "@react-spring/types": "~10.1.1"
+        "@react-spring/animated": "~10.1.2",
+        "@react-spring/shared": "~10.1.2",
+        "@react-spring/types": "~10.1.2"
       },
       "funding": {
         "type": "opencollective",
@@ -1820,44 +1846,44 @@
       }
     },
     "node_modules/@react-spring/rafz": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@react-spring/rafz/-/rafz-10.1.1.tgz",
-      "integrity": "sha512-F7n2fU8EO8OokBkUHivU/tJ9HnL/QTIgd8V/2BhHFSrszt+OaLUoqEinomNeedLPIs24skiXQtki4APJHxghDQ==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@react-spring/rafz/-/rafz-10.1.2.tgz",
+      "integrity": "sha512-KC6vSFZyPnRJ2rXqipV9QqR4SaYbYXjvKfdYKWipNK2mWuV79gr20WmpVUOsTiEHGRY3WSOdWCHN+P9Pdaqb7Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@react-spring/shared": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-10.1.1.tgz",
-      "integrity": "sha512-pOoQPoOa+EPWrRndqIYlIms71fNB1p0IQVJcCi5xHtErqL8N0+jS1V9pExHfryqn9aUhHv0+7kMiVrcb6U+IBQ==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-10.1.2.tgz",
+      "integrity": "sha512-47/8bNQ/o0uEmxEnPBuERlC29VSqiTn5P9ln9tUMSVkYKYxBtouYE686F5kAGj+eHRPoNCw7drxWE9nv2d1LMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@react-spring/rafz": "~10.1.1",
-        "@react-spring/types": "~10.1.1"
+        "@react-spring/rafz": "~10.1.2",
+        "@react-spring/types": "~10.1.2"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@react-spring/types": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-10.1.1.tgz",
-      "integrity": "sha512-C35b9XigBnwv1fZsUGR/lWzAKBskGhdAmf0LIBvqhwwHTYMtat4DXHZEnFyJQvfCAmpVc/d9Yug7j2Lbv2GDEA==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-10.1.2.tgz",
+      "integrity": "sha512-G4CWowmVPz+rDG1y9QRVq/prZNxiNwQaHC0kgT/MgY6jAGgdRgTV4VThpvJDwWvUitk3xZB4soP4d36fjeQ09g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@react-spring/web": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@react-spring/web/-/web-10.1.1.tgz",
-      "integrity": "sha512-G8jVDH8YPAo9ALWio0YcpwvZjXIt6LFwSKZtS4XeTNWIMNUH+sTm2Uy8dxEobTqyzQ5kvKwnMfS3LsOpKrVOag==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@react-spring/web/-/web-10.1.2.tgz",
+      "integrity": "sha512-KxDB3zaDqy9qFsu7fdxjyraAxweHH4k5TW5WGT/OuMK6hKaxSDfhrQfRBzfFaSVvMBf+NghbJFanllV4ia6i7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@react-spring/animated": "~10.1.1",
-        "@react-spring/core": "~10.1.1",
-        "@react-spring/shared": "~10.1.1",
-        "@react-spring/types": "~10.1.1",
+        "@react-spring/animated": "~10.1.2",
+        "@react-spring/core": "~10.1.2",
+        "@react-spring/shared": "~10.1.2",
+        "@react-spring/types": "~10.1.2",
         "csstype": "^3.2.3"
       },
       "peerDependencies": {
@@ -2992,13 +3018,13 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
-      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {
@@ -3048,39 +3074,39 @@
       }
     },
     "node_modules/allure": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/allure/-/allure-3.8.2.tgz",
-      "integrity": "sha512-5zY4SN0DxU9/xFVKMaaTP7dzEaGYMfSh/0az8oz47jq+zQCEyiNE26/ncYj0a0OQ3CH0AGKhDCqb+E/OlIc59g==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/allure/-/allure-3.15.0.tgz",
+      "integrity": "sha512-sCdtC2hUkAQcFfhQAAGqbxVVPXDqJvCYfoUxstAQBYjWMsqSIrU1uOCdqIZt6OvF6GI1NbEi4bfvUntAyPbjzw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@allurereport/charts-api": "3.8.2",
-        "@allurereport/ci": "3.8.2",
-        "@allurereport/core": "3.8.2",
-        "@allurereport/core-api": "3.8.2",
-        "@allurereport/directory-watcher": "3.8.2",
-        "@allurereport/plugin-agent": "3.8.2",
-        "@allurereport/plugin-allure2": "3.8.2",
-        "@allurereport/plugin-api": "3.8.2",
-        "@allurereport/plugin-awesome": "3.8.2",
-        "@allurereport/plugin-classic": "3.8.2",
-        "@allurereport/plugin-csv": "3.8.2",
-        "@allurereport/plugin-dashboard": "3.8.2",
-        "@allurereport/plugin-jira": "3.8.2",
-        "@allurereport/plugin-log": "3.8.2",
-        "@allurereport/plugin-progress": "3.8.2",
-        "@allurereport/plugin-server-reload": "3.8.2",
-        "@allurereport/plugin-slack": "3.8.2",
-        "@allurereport/reader-api": "3.8.2",
-        "@allurereport/service": "3.8.2",
-        "@allurereport/static-server": "3.8.2",
-        "adm-zip": "^0.5.16",
+        "@allurereport/charts-api": "3.15.0",
+        "@allurereport/ci": "3.15.0",
+        "@allurereport/core": "3.15.0",
+        "@allurereport/core-api": "3.15.0",
+        "@allurereport/directory-watcher": "3.15.0",
+        "@allurereport/plugin-agent": "3.15.0",
+        "@allurereport/plugin-allure2": "3.15.0",
+        "@allurereport/plugin-api": "3.15.0",
+        "@allurereport/plugin-awesome": "3.15.0",
+        "@allurereport/plugin-classic": "3.15.0",
+        "@allurereport/plugin-csv": "3.15.0",
+        "@allurereport/plugin-dashboard": "3.15.0",
+        "@allurereport/plugin-jira": "3.15.0",
+        "@allurereport/plugin-log": "3.15.0",
+        "@allurereport/plugin-progress": "3.15.0",
+        "@allurereport/plugin-server-reload": "3.15.0",
+        "@allurereport/plugin-slack": "3.15.0",
+        "@allurereport/reader-api": "3.15.0",
+        "@allurereport/service": "3.15.0",
+        "@allurereport/static-server": "3.15.0",
+        "adm-zip": "^0.6.0",
         "clipanion": "^4.0.0-rc.4",
         "glob": "^13.0.6",
         "lodash.omit": "^4.18.0",
         "prompts": "^2.4.2",
         "typanion": "^3.14.0",
-        "yoctocolors": "^2.1.1"
+        "yoctocolors": "^2.1.2"
       },
       "bin": {
         "allure": "cli.js"
@@ -3232,14 +3258,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
-      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
+        "form-data": "^4.0.6",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
@@ -3348,16 +3374,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/buffer": {
@@ -3482,16 +3508,16 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "readdirp": "^4.0.1"
+        "readdirp": "^5.0.0"
       },
       "engines": {
-        "node": ">= 14.16.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -4159,6 +4185,15 @@
         "d3-selection": "2 - 3"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -4194,9 +4229,9 @@
       "license": "MIT"
     },
     "node_modules/default-browser": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
-      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.1.tgz",
+      "integrity": "sha512-m1pAzaJgZ/gssEqlOhJkPJp8Xly7QyW6xcrkUa2KKcDeDSEMP7X8xipU3snUcfisTQx0w1AGae+9UtJSfVnXGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4459,9 +4494,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz",
+      "integrity": "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
@@ -5176,9 +5211,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -5244,6 +5279,29 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/file-entry-cache": {
@@ -5392,6 +5450,18 @@
         "node": ">= 6"
       }
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -5434,19 +5504,17 @@
       }
     },
     "node_modules/gaxios": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
-      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.1.tgz",
+      "integrity": "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "extend": "^3.0.2",
         "https-proxy-agent": "^7.0.1",
-        "is-stream": "^2.0.0",
-        "node-fetch": "^2.6.9",
-        "uuid": "^9.0.1"
+        "node-fetch": "^3.3.2"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/gaxios/node_modules/agent-base": {
@@ -5472,17 +5540,17 @@
       }
     },
     "node_modules/gcp-metadata": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
-      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "gaxios": "^6.1.1",
-        "google-logging-utils": "^0.0.2",
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
         "json-bigint": "^1.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/get-amd-module-type": {
@@ -5591,26 +5659,26 @@
       }
     },
     "node_modules/google-auth-library": {
-      "version": "9.15.1",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
-      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
+      "integrity": "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==",
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
-        "gaxios": "^6.1.1",
-        "gcp-metadata": "^6.1.0",
-        "gtoken": "^7.0.0",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
         "jws": "^4.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/google-logging-utils": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
-      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
@@ -5634,19 +5702,6 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/gtoken": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
-      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
-      "license": "MIT",
-      "dependencies": {
-        "gaxios": "^6.0.0",
-        "jws": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
     },
     "node_modules/handlebars": {
       "version": "4.7.9",
@@ -5721,9 +5776,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.31",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
-      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
+      "version": "4.13.3",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.3.tgz",
+      "integrity": "sha512-r8AO2mYHoLxSHkgafNeC/BXyb2vWRxD3jem4Ts+ptav8oTG5FIRifAjuJEmZI4bSvvc2ns0GxmIYiZnHqN3mMw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -5889,9 +5944,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -5968,6 +6023,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-in-ssh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-inside-container": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
@@ -6021,18 +6089,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-unicode-supported": {
@@ -6126,6 +6182,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/jose": {
@@ -6579,6 +6645,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.omit": {
       "version": "4.18.0",
       "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.18.0.tgz",
@@ -6604,9 +6677,9 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "11.5.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -6690,9 +6763,9 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
-      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
+      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
       "dev": true,
       "funding": [
         {
@@ -6707,8 +6780,8 @@
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.1",
+        "entities": "^4.5.0",
+        "linkify-it": "^5.0.2",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"
@@ -6752,9 +6825,9 @@
       }
     },
     "node_modules/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.1.0.tgz",
+      "integrity": "sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==",
       "dev": true,
       "license": "MIT"
     },
@@ -6848,6 +6921,13 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/minisearch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
+      "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/module-definition": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/module-definition/-/module-definition-6.0.2.tgz",
@@ -6900,9 +6980,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "5.1.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.11.tgz",
-      "integrity": "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==",
+      "version": "5.1.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
+      "integrity": "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==",
       "dev": true,
       "funding": [
         {
@@ -6941,24 +7021,42 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
       "license": "MIT",
       "dependencies": {
-        "whatwg-url": "^5.0.0"
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
       },
       "engines": {
-        "node": "4.x || >=6.0.0"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-source-walk": {
@@ -6975,9 +7073,9 @@
       }
     },
     "node_modules/node-stream-zip": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/node-stream-zip/-/node-stream-zip-1.15.0.tgz",
-      "integrity": "sha512-LN4fydt9TqhZhThkZIVQnF9cwjU3qmUH9h78Mx/K7d3VvfRqqwthLwJEUOEL0QPZ0XQmNN7be5Ggit5+4dq3Bw==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/node-stream-zip/-/node-stream-zip-1.16.0.tgz",
+      "integrity": "sha512-ObaRrRoR8T68wF6suxHd7R4XQNamij6ZQHrwG7Dx1D2zeHcDNLsIOBcWrIwtDm7AsCXBguaPHgXhcjxDa2szrg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7070,19 +7168,21 @@
       }
     },
     "node_modules/open": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
-      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.1.tgz",
+      "integrity": "sha512-NzwMUB6C1D0+Kd+9iMS/H4k+Ck3cTX6Ckyfr/gAGlmvSE1LUQZnEZvWBi4PYmMwH/S5SMeTXnE+9uAz8uF+pWw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "default-browser": "^5.2.1",
+        "default-browser": "^5.4.0",
         "define-lazy-prop": "^3.0.0",
+        "is-in-ssh": "^1.0.0",
         "is-inside-container": "^1.0.0",
-        "wsl-utils": "^0.1.0"
+        "powershell-utils": "^0.2.0",
+        "wsl-utils": "^1.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -7131,9 +7231,9 @@
       }
     },
     "node_modules/p-limit": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.0.tgz",
-      "integrity": "sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.1.tgz",
+      "integrity": "sha512-0trZaiG7Y7kN/Egy9a8j47t9osC0Tch4PaIWd9yGF6bvmlk7muExRvGNYb8sXBwEKMoNKsbNN9P8EefuQekE4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7315,9 +7415,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -7334,7 +7434,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -7361,9 +7461,9 @@
       }
     },
     "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -7376,6 +7476,19 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/powershell-utils": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.2.0.tgz",
+      "integrity": "sha512-ZlsFlG7MtSFCoc5xreOvBAozCJ6Pf06opgJjh9ONEv418xpZSAzNjstD36C6+JwOnfSqOW/9uDkqKjezTdxZhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/preact": {
@@ -7479,16 +7592,6 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
-    },
-    "node_modules/progress": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
     },
     "node_modules/prompts": {
       "version": "2.4.2",
@@ -7681,13 +7784,13 @@
       "license": "MIT"
     },
     "node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+      "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 14.18.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "type": "individual",
@@ -8364,12 +8467,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
-    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -8622,19 +8719,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
-    "node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -8830,20 +8914,13 @@
         "defaults": "^1.0.3"
       }
     },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
       "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/which": {
@@ -8901,16 +8978,30 @@
       "license": "ISC"
     },
     "node_modules/wsl-utils": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
-      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-1.0.0.tgz",
+      "integrity": "sha512-Hl0ZOAs672vg+06kfujwRhoS6/jehvULrlFkuF2dRu6pHgA8U06h3xqNIqNNU1LTXPcedxByAR4GS6pwQK0mgA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "is-wsl": "^3.1.0"
+        "is-wsl": "^3.1.0",
+        "powershell-utils": "^0.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wsl-utils/node_modules/powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8961,9 +9052,9 @@
       }
     },
     "node_modules/yoctocolors": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
-      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
+      "integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9233,7 +9324,7 @@
       "version": "0.20.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "google-auth-library": "^9.0.0"
+        "google-auth-library": "^10.9.1"
       },
       "devDependencies": {
         "@types/node": "^22.10.0",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "@vitest/runner": "4.1.8",
     "@xmldom/xmldom": "^0.9.10",
     "ajv": "^8.18.0",
-    "allure": "3.8.2",
+    "allure": "3.15.0",
     "eslint": "^10.0.1",
     "fast-xml-parser": "^5.7.0",
     "jszip": "^3.10.1",
@@ -104,8 +104,7 @@
     "prismjs": "^1.30.0"
   },
   "overrides": {
-    "@vitest/runner": "4.1.8",
-    "uuid": "^11.1.1"
+    "@vitest/runner": "4.1.8"
   },
   "engines": {
     "node": ">=20"

--- a/packages/google-docs-core/package.json
+++ b/packages/google-docs-core/package.json
@@ -15,7 +15,7 @@
     "test:e2e": "node ../../node_modules/vitest/vitest.mjs run src/__tests__/e2e/"
   },
   "dependencies": {
-    "google-auth-library": "^9.0.0"
+    "google-auth-library": "^10.9.1"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",


### PR DESCRIPTION
## Summary
- update the dependency graph to patched releases so `npm audit` reports zero vulnerabilities
- upgrade `google-auth-library` to its supported gaxios 7 chain and remove the invalid UUID cross-major override
- upgrade Allure to 3.15.0 and refresh affected transitives

## Why
The unpublished v0.20.0 release candidate reported 10 advisories and an invalid/deprecated UUID resolution. These should be resolved before recreating the release tag.

## Verification
- `npm audit --audit-level=low` — 0 vulnerabilities
- `npm ls ... --all` — clean; UUID absent
- Google Docs build — passed
- Google Docs tests — 116 passed, 35 skipped
- Allure quality check — 0 errors
- Allure CLI 3.15.0 — passed
- full build and lint — passed
- full host-permission suite cleared all substantive tests; local LibreOffice verifier remained unavailable on this macOS host
- OpenSpec and ECMA-376 checks — passed

## Peer review
Claude Sonnet 4.6 dynamically inspected the changed files and executed the audit, dependency-tree, Google Docs build/tests, Allure quality, Allure CLI, and UUID absence checks. Verdict: **PASS — safe to merge**. It classified the remaining `node-domexception` deprecation as a non-vulnerable upstream transitive warning.

Visual evidence: n/a — dependency-only change.

No private document or customer data was used.