### PR TITLE
chore(release): serialize docx-core coverage workers

### DIFF
--- a/packages/docx-core/package.json
+++ b/packages/docx-core/package.json
@@ -12,7 +12,7 @@
     "test": "node ../../node_modules/vitest/vitest.mjs",
     "test:run": "node ../../node_modules/vitest/vitest.mjs run",
     "test:baseline": "node ../../node_modules/vitest/vitest.mjs run -c vitest.baseline.config.ts",
-    "test:coverage": "node ../../node_modules/vitest/vitest.mjs run --coverage --coverage.reporter=text-summary --coverage.reporter=json-summary --coverage.reporter=lcov",
+    "test:coverage": "node ../../node_modules/vitest/vitest.mjs run --coverage --maxWorkers=1 --coverage.reporter=text-summary --coverage.reporter=json-summary --coverage.reporter=lcov",
     "check:spec-coverage": "npm run check:spec-coverage:openspec && npm run check:spec-coverage:primitives -- --strict && npm run check:spec-coverage:tag-density",
     "check:spec-coverage:openspec": "node scripts/validate_openspec_coverage.mjs",
     "check:spec-coverage:primitives": "node scripts/validate_primitives_openspec_coverage.mjs",


### PR DESCRIPTION
## Summary
- serialize only the docx-core coverage runner with Vitest `--maxWorkers=1`
- keep ordinary test concurrency and the in-test determinism checks unchanged
- make CI and release preflight inherit the same behavior through the existing package-script SSOT

## Root cause
V8 coverage instrumentation ran the public ILPA integration suites in competing workers. In run 32268968201, the determinism suite took 352 seconds while `round-trip.test.ts` hit its 180-second `beforeAll` timeout. The same failure blocked the v0.20.0 release workflow.

## Verification
- clean workspace build passed
- full docx-core coverage: 1,286 passed, 2 expected failures, 2 skipped; 86.40% statements; no ILPA timeout
- docx-compare coverage: 458 passed, 16 skipped
- docx-mcp coverage: 1,004 passed
- package coverage ratchet passed with no regressions
- mandatory lint passed with six pre-existing warnings
- non-coverage docx-core: 1,286 passed, 2 expected failures, 2 skipped
- docx-markdoc: 66 passed
- docx-mcp: 1,004 passed
- docx-release-verifier: 56 passed
- local suite was stopped only when the existing LibreOffice-backed render verifier did not return in this host environment; GitHub CI remains the authoritative full matrix

## Peer review
Claude Sonnet 4.6 Thinking dynamically reviewed the public diff and returned PASS. It verified the Vitest 4.1.8 flag, workflow inheritance, unchanged in-test concurrency, and independently ran the two heavy coverage files: 16/16 passed in 312 seconds.

## Privacy
Only repository-public fixtures were used. No private Hawthorn/armed-guard agreement was read, copied, uploaded, or sent.