### PR TITLE
docs(openspec): model round-trippable annotations

### DIFF
--- a/openspec/changes/add-configurable-note-presentation/design.md
+++ b/openspec/changes/add-configurable-note-presentation/design.md
@@ -10,6 +10,10 @@ insertion boundary while preserving operative text and unrelated package parts.
 ### Goals
 
 - Author or select notes independently from their presentation.
+- Import brownfield comment and footnote bodies into canonical Markdoc rather
+  than leaving them opaque in the pinned source package.
+- Preserve the source anchor geometry and presentation needed to regenerate the
+  original annotation faithfully.
 - Convert eligible comments transactionally and report every disposition.
 - Style a footnote label separately from its separator and body.
 - Preserve substantive footnotes and unrelated comments.
@@ -19,6 +23,7 @@ insertion boundary while preserving operative text and unrelated package parts.
 
 - Infer internal/external audience from prose or author metadata.
 - Convert substantive footnotes by default.
+- Invent a selected text range for an imported footnote.
 - Restore an interactive reply graph after flattening it into a footnote.
 - Put drafting text directly in the operative document body.
 - Complete the paragraph-index SSOT refactor tracked by #904 in this change.
@@ -27,8 +32,83 @@ insertion boundary while preserving operative text and unrelated package parts.
 
 ### Semantic notes and presentation are separate
 
-A normalized profile maps each audience to `comment`, `footnote`, or `omit`.
-Prefix, separator, and body are structured runs rather than embedded HTML.
+A canonical annotation owns its editable body, audience, optional operation
+association, source metadata, source presentation, and anchor independently of
+how a particular DOCX renders it. A normalized profile maps each audience to
+`preserve`, `comment`, `footnote`, or `omit`; an explicit per-annotation choice
+takes precedence. Prefix, separator, and body are structured runs rather than
+embedded HTML.
+
+Imported audience defaults to `unspecified`. Import MUST NOT infer that a Word
+comment is external-facing merely because it arrived in a brownfield document,
+or internal merely because of its author. Export profiles therefore route
+`unspecified` annotations explicitly and fail closed if the chosen profile has
+no rule for them.
+
+### Canonical annotations preserve semantic content and source provenance
+
+The Markdoc IR admits first-class annotations not limited to edit rationales.
+Each annotation has a stable ID; an editable structured body; optional author,
+initials, creation time, and reply-parent metadata; an explicit audience; a
+semantic role of `drafting-note`, `substantive-footnote`, or `unspecified`; and
+`sourcePresentation` of `comment`, `footnote`, or `authored`; an immutable
+`sourceAnchor`; and a current editable `anchor`. Imported bodies
+are readable Markdoc content, not opaque OOXML or text hidden only in the pinned
+source package. `sourcePresentation` is immutable provenance; an editable
+presentation preference is stored separately.
+
+Existing rationale blocks normalize into the same annotation collection with
+an operation association. Imported annotations need not bind to an edit:
+counterparty comments and substantive footnotes often discuss unchanged text.
+The import preserves supported thread structure as metadata. A presentation
+that cannot retain a reply graph remains an explicitly lossy projection and
+does not destroy the canonical thread.
+
+Import does not infer that a footnote is merely a drafting note. An imported
+footnote defaults to `substantive-footnote` unless an explicit mapping classifies
+it otherwise. Audience-wide conversion or omission rules apply automatically to
+drafting notes only; changing or omitting a substantive or unspecified
+annotation requires an explicit per-annotation choice. This preserves ordinary
+legal footnotes under the default profile.
+
+### Anchor geometry is an explicit union
+
+An annotation anchor is either:
+
+- a half-open range with exact start and end positions, used by imported ranged
+  comments; or
+- one point position, used by imported footnote references and point comments.
+
+Both `sourceAnchor` and the current `anchor` use the same union. Positions use stable paragraph identity plus the canonical visible-text
+coordinate defined by the paragraph-index work in #904. Until that index lands,
+import and export may adapt existing structural coordinates internally, but the
+Markdoc schema has one anchor representation rather than parallel ad hoc run
+lists.
+
+Import never manufactures missing geometry. A footnote therefore imports as a
+point even if nearby words appear semantically related to its body. A comment's
+range remains a range, including a zero-width point comment.
+
+Text edits validate and remap anchors through the canonical paragraph index.
+If an edit makes an anchor unresolvable or ambiguous, compilation fails with an
+annotation-specific diagnostic rather than silently moving it. Direct anchor
+editing changes only the current anchor and preserves `sourceAnchor` as
+immutable provenance.
+
+### Presentation projection has deterministic geometry rules
+
+`preserve` uses `sourcePresentation` when it exists and otherwise uses the
+authored-note default (`comment` unless explicitly set). Projecting a range as a
+comment preserves both boundaries. Projecting a range as a footnote places the
+reference at its end boundary while retaining the range in canonical Markdoc.
+Projecting a point as a footnote preserves the point. Projecting a point as a
+comment emits a point comment transparently; it MUST NOT expand to a guessed
+word, sentence, or paragraph. An editor may later replace the point anchor with
+an explicit range, after which later comment exports use that range.
+
+Changing footnote styling or changing comment/footnote presentation recompiles
+from the same canonical annotation and never requires a destructive
+comment-to-footnote-to-comment chain.
 
 ### The first implementation slice converts comments to footnotes
 
@@ -48,12 +128,16 @@ future canonical paragraph index will make this coordinate system the SSOT
 ### Threads are explicitly lossy
 
 Threaded comments fail by default. `flattenThreads` serializes root and replies
-in deterministic order and marks the report as lossy.
+in deterministic order and marks the report as lossy. In the Markdoc path,
+flattening affects only that output projection; the canonical reply graph stays
+available for later comment export.
 
 ### Styling is structured and fail-closed
 
-The admitted subset is bold, italic, underline, six-digit RGB color, and Word
-highlight values. Footnote references carry both the semantic
+The initial admitted annotation-body vocabulary is paragraphs and text runs
+with bold, italic, underline, six-digit RGB color, and Word highlight values.
+It excludes tables, drawings, fields, tracked changes, embedded objects, and
+other body constructs until separately specified. Footnote references carry both the semantic
 `FootnoteReference` style and explicit superscript so documents with a missing
 or redefined character style still render correctly.
 
@@ -66,10 +150,16 @@ or redefined character style still render correctly.
 - Footnotes change pagination; package/text invariants, not page identity, are
   the automated compatibility boundary.
 - Audience is metadata, not a disclosure or privilege guarantee.
+- OOXML footnotes do not carry a selected range; point-comment export is honest
+  but less ergonomic until an author supplies a range.
+- Some rich comment or footnote content may fall outside the admitted structured
+  body vocabulary; import must report and fail closed rather than silently drop
+  negotiation content.
 
 ## Migration Plan
 
 1. Land comment-to-footnote conversion and structured styling as a draft slice.
-2. Add Markdoc audience profile projection.
-3. Add provenance-gated reverse conversion for generated note-footnotes.
-4. Migrate coordinate consumers to the canonical paragraph index from #904.
+2. Add canonical annotation IR plus brownfield comment/footnote import.
+3. Add Markdoc audience and per-annotation presentation projection.
+4. Add provenance-aware comment/footnote regeneration from canonical annotations.
+5. Migrate coordinate consumers to the canonical paragraph index from #904.

--- a/openspec/changes/add-configurable-note-presentation/proposal.md
+++ b/openspec/changes/add-configurable-note-presentation/proposal.md
@@ -5,28 +5,45 @@
 Lawyers disagree about whether drafting communications belong in Word comment
 bubbles or footnotes, and the choice may differ for internal and external
 audiences. Authors should record what a note means once and select its DOCX
-presentation when producing an artifact. Existing comments also need a safe
-bulk-conversion path that does not conflate drafting notes with substantive
-footnotes.
+presentation when producing an artifact. Brownfield comments and footnotes must
+also remain visible and editable in canonical Markdoc; otherwise the most
+important negotiation context disappears during import.
 
 ## What Changes
 
 - Add structured note-presentation options for comments, footnotes, and omission.
-- Configure external and internal note audiences independently in Markdoc.
+- Import Word comments and footnotes as first-class canonical Markdoc
+  annotations with editable bodies, source metadata, source presentation, and
+  explicit range-or-point anchor geometry.
+- Preserve comment ranges exactly and preserve footnotes as point anchors; do
+  not invent a selected range for a footnote.
+- Distinguish drafting notes from substantive footnotes so audience profiles do
+  not convert or omit substantive content without an explicit annotation choice.
+- Configure external, internal, and unspecified note audiences independently in
+  Markdoc, with per-annotation presentation overrides.
 - Support independently styled footnote prefix, separator, and body runs.
 - Add transactional selected comment-to-footnote conversion with deterministic
   range-end placement and machine-readable reporting.
 - Preserve substantive footnotes and reject threaded comments unless explicit
   lossy flattening is enabled.
-- Keep reverse generated-footnote-to-comment conversion and complete Markdoc
-  audience projection as later tasks within this approved change.
+- Export canonical annotations as preserved source presentation, comments,
+  styled footnotes, or omission without rewriting the canonical annotation.
+- Default an imported footnote exported as a comment to a transparent point
+  comment unless a range is later supplied explicitly.
+- Keep direct primitive conversion as an interoperability path while making
+  Markdoc the durable, editable intermediate representation.
 - Track canonical paragraph coordinate indexing separately in issue #904.
 
 ## Impact
 
-- Affected specs: `docx-primitives` in this implementation slice;
-  `docx-markdoc` remains planned work.
-- Affected code: comment/footnote primitives, `DocxDocument`, and the Markdoc CLI.
+- Affected specs: `docx-primitives` and `docx-markdoc`.
+- Archive ordering: `add-brownfield-markdoc-authoring` establishes the
+  `docx-markdoc` capability and MUST archive before this delta.
+- Related change: `add-footnote-support` covers general footnote CRUD and MCP
+  tools; this change covers annotation import, provenance, and presentation
+  projection and does not replace that work.
+- Affected code: comment/footnote primitives, canonical Markdoc IR/import/compiler,
+  `DocxDocument`, verification certificates, and the Markdoc CLI.
 - Compatibility: additive; existing comment and footnote APIs remain valid.
 - Conformance: comment ranges, footnote references/definitions, and run
   properties require ECMA-376 citations and structural tests.

--- a/openspec/changes/add-configurable-note-presentation/specs/docx-markdoc/spec.md
+++ b/openspec/changes/add-configurable-note-presentation/specs/docx-markdoc/spec.md
@@ -1,0 +1,138 @@
+## ADDED Requirements
+
+### Requirement: Brownfield annotations are first-class canonical Markdoc
+
+The system SHALL import admitted Word comments and footnotes as readable,
+editable canonical annotations. Each annotation SHALL retain a stable identity,
+structured body, source presentation, explicit audience, admitted source
+metadata, semantic role, and an explicit range-or-point anchor. Import SHALL NOT leave the
+annotation body available only as opaque content in the pinned DOCX.
+
+The admitted annotation body vocabulary SHALL initially consist of paragraphs
+and text runs with bold, italic, underline, six-digit RGB color, and Word
+highlight properties. Tables, drawings, fields, tracked changes, embedded
+objects, and other unlisted body constructs are unsupported and SHALL follow
+the strict-import diagnostic behavior below.
+
+#### Scenario: [SDX-MDOC-70] Ranged comment imports with editable content
+- **GIVEN** a Word comment with an admitted body and balanced range markers
+- **WHEN** the DOCX is imported to canonical Markdoc
+- **THEN** the comment body SHALL be readable and editable in the Markdoc
+- **AND** its exact start and end positions SHALL be represented as a range
+- **AND** its source presentation SHALL be `comment`
+
+#### Scenario: [SDX-MDOC-71] Footnote imports without invented selection
+- **GIVEN** a Word footnote with an admitted body and one body reference
+- **WHEN** the DOCX is imported to canonical Markdoc
+- **THEN** the footnote body SHALL be readable and editable in the Markdoc
+- **AND** its reference position SHALL be represented as a point anchor
+- **AND** its source presentation SHALL be `footnote`
+- **AND** no range start SHALL be inferred from nearby text
+
+#### Scenario: [SDX-MDOC-79] Imported footnote remains substantive by default
+- **GIVEN** a brownfield Word footnote with no explicit drafting-note mapping
+- **WHEN** the DOCX is imported to canonical Markdoc
+- **THEN** its semantic role SHALL default to `substantive-footnote`
+- **AND** an audience-wide presentation rule SHALL NOT convert or omit it
+- **AND** conversion or omission SHALL require an explicit per-annotation choice
+
+#### Scenario: [SDX-MDOC-72] Unsupported annotation content fails visibly
+- **GIVEN** a comment or footnote whose body or topology cannot be represented by
+  the admitted canonical annotation vocabulary without loss
+- **WHEN** strict import is requested
+- **THEN** import SHALL fail with a structured diagnostic identifying the annotation
+- **AND** SHALL NOT silently omit, flatten, or hide its negotiation content
+
+#### Scenario: [SDX-MDOC-81] Strict annotation import is atomic
+- **GIVEN** a document containing admitted annotations and one unsupported annotation
+- **WHEN** strict import is requested
+- **THEN** the canonical import SHALL fail as a whole with structured diagnostics
+- **AND** SHALL NOT publish a partial canonical document
+
+### Requirement: Source annotation provenance is immutable
+
+Each canonical annotation SHALL retain immutable `sourcePresentation` of
+`comment`, `footnote`, or `authored` and an immutable `sourceAnchor` containing
+the imported or authored range-or-point geometry. Its current editable `anchor`
+and presentation preference SHALL be stored separately. Editing either SHALL
+NOT rewrite source provenance.
+
+#### Scenario: [SDX-MDOC-82] Explicit range preserves imported point provenance
+- **GIVEN** an annotation imported from a footnote with a point `sourceAnchor`
+- **WHEN** an editor replaces its current anchor with an explicit range
+- **THEN** later comment output SHALL use the current range
+- **AND** `sourcePresentation` SHALL remain `footnote`
+- **AND** `sourceAnchor` SHALL remain the imported point
+
+### Requirement: Annotation audience is explicit and never inferred from origin
+
+Canonical annotations SHALL declare `internal`, `external-facing`, or
+`unspecified` audience. Brownfield import SHALL default to `unspecified` unless
+the caller supplies an explicit mapping and SHALL NOT infer audience from
+author, comment presence, file origin, or prose.
+
+#### Scenario: [SDX-MDOC-73] Incoming Word comment has unspecified audience
+- **GIVEN** an imported Word comment with author and date metadata
+- **WHEN** no audience mapping is supplied
+- **THEN** its canonical audience SHALL be `unspecified`
+- **AND** its author and date SHALL NOT cause internal or external-facing classification
+
+### Requirement: Presentation is a reversible projection of canonical annotation
+
+The system SHALL project each canonical annotation as `preserve`, `comment`,
+`footnote`, or `omit` according to an explicit per-annotation choice or audience
+profile. Projection SHALL NOT destructively rewrite the canonical body, source
+presentation, anchor geometry, or admitted reply topology.
+
+#### Scenario: [SDX-MDOC-74] Comment range exports as styled footnote and later comment
+- **GIVEN** a canonical ranged annotation imported from a comment
+- **WHEN** one output projects it as a footnote with configured label and body styling
+- **THEN** the footnote reference SHALL be placed at the range end
+- **AND** the configured styling SHALL affect only the output presentation
+- **WHEN** a later output projects the unchanged annotation as a comment
+- **THEN** the original start and end range SHALL be restored
+
+#### Scenario: [SDX-MDOC-75] Imported footnote exports transparently as point comment
+- **GIVEN** a canonical point annotation imported from a footnote
+- **WHEN** an output profile projects it as a comment
+- **THEN** the system SHALL emit a point comment at the preserved point
+- **AND** SHALL report that no selected range was available
+- **AND** SHALL NOT guess or expand the anchor to a word, sentence, or paragraph
+
+#### Scenario: [SDX-MDOC-76] Explicit later range replaces point-comment fallback
+- **GIVEN** a canonical point annotation whose editor explicitly supplies a valid range
+- **WHEN** a later output projects it as a comment
+- **THEN** the comment SHALL use the supplied start and end positions
+- **AND** later footnote projection SHALL still use the range end deterministically
+
+#### Scenario: [SDX-MDOC-77] Unspecified audience fails closed without routing policy
+- **GIVEN** a canonical annotation whose audience is `unspecified`
+- **WHEN** export uses a profile with no `unspecified` rule and no per-annotation choice
+- **THEN** export SHALL fail before publishing output
+- **AND** SHALL identify the unrouted annotation
+
+#### Scenario: [SDX-MDOC-83] Authored annotation preserve fallback is a comment
+- **GIVEN** an authored canonical annotation with no explicit presentation preference
+- **WHEN** an output profile selects `preserve`
+- **THEN** the annotation SHALL be emitted as a comment
+- **AND** its current point or range anchor SHALL be preserved without guessed expansion
+
+### Requirement: Annotation bodies remain editable independently of presentation
+
+Editing a canonical annotation body or its admitted structured formatting SHALL
+change subsequent comment and footnote projections while leaving operative
+document text and anchor geometry unchanged unless the editor explicitly edits
+the anchor.
+
+#### Scenario: [SDX-MDOC-78] One body edit feeds both presentations
+- **GIVEN** a canonical annotation whose body is edited in Markdoc
+- **WHEN** comment and styled-footnote outputs are compiled from that revision
+- **THEN** both outputs SHALL contain the edited semantic body
+- **AND** neither output SHALL require an intermediate destructive conversion
+- **AND** operative document text SHALL remain unchanged
+
+#### Scenario: [SDX-MDOC-80] Text edit cannot silently relocate an anchor
+- **GIVEN** a canonical annotation anchored to document text
+- **WHEN** an operative-text edit makes that anchor ambiguous or unresolvable
+- **THEN** compilation SHALL fail with a diagnostic identifying the annotation
+- **AND** SHALL NOT silently move, expand, collapse, or discard the anchor

--- a/openspec/changes/add-configurable-note-presentation/tasks.md
+++ b/openspec/changes/add-configurable-note-presentation/tasks.md
@@ -8,21 +8,48 @@
 - [x] 1.6 Emit explicit superscript reference markers in both stories.
 - [x] 1.7 Add CLI options and focused synthetic regression tests.
 
-## 2. Remaining presentation profile
+## 2. Canonical Markdoc annotations
 
-- [ ] 2.1 Add explicit internal/external audience to canonical Markdoc notes.
-- [ ] 2.2 Normalize API, JSON, and CLI audience profiles.
-- [ ] 2.3 Emit each audience independently as comment, footnote, or omission.
-- [ ] 2.4 Record note dispositions and profile digest in verification output.
+- [ ] 2.1 Define a first-class annotation IR with stable ID, editable structured
+  body, optional operation association, source metadata, source presentation,
+  semantic role, explicit audience, and range-or-point anchor union.
+- [ ] 2.2 Normalize existing authored rationales into canonical annotations
+  without requiring imported annotations to bind to an edit operation.
+- [ ] 2.3 Import supported Word comment bodies, metadata, reply relationships,
+  and exact range or point anchors into readable canonical Markdoc.
+- [ ] 2.4 Import supported Word footnote bodies and metadata at their exact point
+  references without inventing range starts.
+- [ ] 2.5 Fail closed with structured diagnostics when an imported annotation
+  body or topology cannot be represented without loss.
+- [ ] 2.6 Default imported footnotes to substantive semantics and require an
+  explicit per-annotation choice before converting or omitting them.
 
-## 3. Reverse conversion
+## 3. Presentation profiles and export
 
-- [ ] 3.1 Mark generated note-footnotes with stable provenance.
-- [ ] 3.2 Convert provenance-marked footnotes back to comments.
-- [ ] 3.3 Require explicit IDs and opt-in for ordinary substantive footnotes.
+- [ ] 3.1 Normalize API, JSON, Markdoc, and CLI presentation profiles for
+  internal, external-facing, and unspecified audiences.
+- [ ] 3.2 Support `preserve`, `comment`, `footnote`, and `omit`, with explicit
+  per-annotation presentation taking precedence over the audience profile.
+- [ ] 3.3 Export ranges as exact ranged comments or end-anchored footnotes and
+  export points as point footnotes or point comments without guessed expansion.
+- [ ] 3.4 Preserve canonical anchor geometry and reply topology when an output
+  projection is lossy, so later exports can choose a different presentation.
+- [ ] 3.5 Emit independently styled footnote prefix, separator, and body from the
+  canonical annotation without mutating its semantic body.
+- [ ] 3.6 Record note dispositions, lossy projections, and profile digest in the
+  verification certificate.
 
 ## 4. Follow-up and verification
 
 - [ ] 4.1 Migrate visible/structural coordinates to the paragraph index in #904.
-- [ ] 4.2 Add conformance-tagged tests and complete repository pre-submit checks.
-- [ ] 4.3 Record Word and LibreOffice manual compatibility observations.
+- [ ] 4.2 Add synthetic round-trip tests for ranged comments, point comments,
+  point footnotes, edited bodies, profile switching, and style-only recompiles.
+- [ ] 4.3 Add anchor-remapping tests for text edits and fail closed when an
+  anchor becomes ambiguous or unresolvable.
+- [ ] 4.4 Cite registry entries `ECMA-PART1-17-13-4-4`,
+  `ECMA-PART1-17-13-4-3`, `ECMA-PART1-17-13-4-5`, and
+  `ECMA-PART1-17-11-14` through `testAllure.conformance(...)` in every test
+  that exercises the corresponding OOXML construct, and add matching source
+  JSDoc citations where the implementation makes a conformance claim.
+- [ ] 4.5 Complete repository pre-submit checks.
+- [ ] 4.6 Record Word and LibreOffice manual compatibility observations.


### PR DESCRIPTION
## Summary

- make comments and footnotes first-class readable, editable Markdoc annotations
- preserve immutable source presentation and source anchor separately from editable output choices
- model ranged comments and point-anchored footnotes without inventing selection geometry
- specify configurable comment, styled-footnote, preserve, and omit projections
- protect substantive footnotes from audience-wide conversion or omission without explicit opt-in

## OpenSpec

- expands `add-configurable-note-presentation`
- adds the `docx-markdoc` delta with scenarios SDX-MDOC-70 through SDX-MDOC-83
- documents archive ordering with `add-brownfield-markdoc-authoring` and scope separation from `add-footnote-support`

## Peer review

Claude Sonnet 4.6 (Thinking), dynamically via `agy`: **APPROVE WITH CHANGES**.

Addressed credible findings by formalizing immutable source provenance, defining the admitted body vocabulary and atomic strict import, adding authored-note fallback behavior, documenting neighboring-change dependencies, and naming the exact ECMA-376 registry entries required during implementation. The suggestion to put JSDoc `@conformance` tags in Markdown deltas was adapted to repository policy: tests use `testAllure.conformance(...)`; implementation JSDoc carries tags when it makes conformance claims.

## Validation

- `openspec validate add-configurable-note-presentation --strict`
- `npm run build`
- `npm run lint:workspaces` (0 errors; 6 pre-existing unused-disable warnings)
- workspace tests: all non-render suites passed; the IPC-dependent cross-implementation test passed outside the sandbox (8 passed, 1 skipped)
- `npm run check:spec-coverage`
- `npm run check:conformance-citations`
- `npm run check:conformance-doc`

Advisory: five existing real-LibreOffice render tests could not complete locally because LibreOffice timed out without producing PDF output. No document-rendering code changes are included; CI is authoritative for that environment-dependent job.

## Privacy

No private customer documents were used, inspected by the peer reviewer, or included in this PR.
