### PR TITLE
refactor(docx-core): centralize paragraph coordinates

### DIFF
--- a/packages/docx-core/src/primitives/comments.ts
+++ b/packages/docx-core/src/primitives/comments.ts
@@ -11,7 +11,8 @@ import { parseXml, serializeXml } from './xml.js';
 import { DocxZip } from './zip.js';
 import { getParagraphRuns, getParagraphText, splitRunAtVisibleOffset, type TextRun } from './text.js';
 import { getParagraphBookmarkId } from './bookmarks.js';
-import { childElements, getLeafText, isW } from './dom-helpers.js';
+import { isW } from './dom-helpers.js';
+import { buildParagraphIndex, type IndexedParagraphNode, type ParagraphIndex } from './paragraph-index.js';
 import { getAttributeSafe } from './xml-helpers.js';
 import {
   createRevisionContainer,
@@ -795,40 +796,6 @@ type CommentRangePoint = {
   textOffset?: number;
 };
 
-type RunBoundary = {
-  visibleLength: number;
-};
-
-// A marker is recorded with one of two shapes:
-// - `inside`: marker was seen INSIDE a `<w:r>`; runIndex is exact, charOffset is the
-//   visible-text offset within that run.
-// - `between`: marker was seen at paragraph level (between/around `<w:r>` elements);
-//   resolution depends on the boundary direction and the surrounding runs.
-type MarkerCharPosition = {
-  id: number;
-  textOffset: number;
-  inside?: { runIndex: number; charOffset: number };
-  between?: { afterRunIndex: number };
-};
-
-enum FieldState {
-  OUTSIDE_FIELD = 0,
-  IN_FIELD_CODE = 1,
-  IN_FIELD_RESULT = 2,
-}
-
-type ParagraphMarkerWalkState = {
-  charPos: number;
-  fieldState: FieldState;
-  // `allRuns` records every `<w:r>` in document order, including zero-length ones.
-  // This is the source of truth for `runIndex` per the issue contract.
-  allRuns: RunBoundary[];
-  // Number of `<w:r>` entered so far during the walk; equals allRuns.length once a run exits.
-  currentRunIndex: number;
-  startMarkers: MarkerCharPosition[];
-  endMarkers: MarkerCharPosition[];
-};
-
 /**
  * Read all comments from a document, building a threaded tree.
  *
@@ -961,119 +928,26 @@ function resolveCommentRangeMetadataInParagraph(
   startById: Map<number, CommentRangePoint>,
   endById: Map<number, CommentRangePoint>,
 ): void {
-  const walkState: ParagraphMarkerWalkState = {
-    charPos: 0,
-    fieldState: FieldState.OUTSIDE_FIELD,
-    allRuns: [],
-    currentRunIndex: 0,
-    startMarkers: [],
-    endMarkers: [],
-  };
-  walkParagraphForCommentMarkers(paragraph, paragraph, walkState);
-
+  const index = buildParagraphIndex(paragraph);
   const paragraphId = getParagraphBookmarkId(paragraph);
-  for (const marker of walkState.startMarkers) {
-    if (startById.has(marker.id)) continue;
-    startById.set(marker.id, {
+  for (const marker of index.nodes.filter((node) => node.kind === 'comment-range-start')) {
+    const id = getCommentMarkerId(marker.element);
+    if (id == null || startById.has(id)) continue;
+    startById.set(id, {
       paragraphId,
-      textOffset: marker.textOffset,
-      ...resolveMarkerToRunBoundary(walkState.allRuns, marker, 'start'),
+      textOffset: marker.visibleStart,
+      ...resolveIndexedMarkerBoundary(index, marker, 'start'),
     });
   }
-
-  for (const marker of walkState.endMarkers) {
-    if (endById.has(marker.id)) continue;
-    endById.set(marker.id, {
+  for (const marker of index.nodes.filter((node) => node.kind === 'comment-range-end')) {
+    const id = getCommentMarkerId(marker.element);
+    if (id == null || endById.has(id)) continue;
+    endById.set(id, {
       paragraphId,
-      textOffset: marker.textOffset,
-      ...resolveMarkerToRunBoundary(walkState.allRuns, marker, 'end'),
+      textOffset: marker.visibleStart,
+      ...resolveIndexedMarkerBoundary(index, marker, 'end'),
     });
   }
-}
-
-function walkParagraphForCommentMarkers(
-  rootParagraph: Element,
-  node: Element,
-  state: ParagraphMarkerWalkState,
-): void {
-  for (const child of childElements(node)) {
-    if (child !== rootParagraph && isW(child, W.p)) continue;
-
-    if (isW(child, W.commentRangeStart)) {
-      recordParagraphLevelMarker(child, state.startMarkers, state);
-      continue;
-    }
-    if (isW(child, W.commentRangeEnd)) {
-      recordParagraphLevelMarker(child, state.endMarkers, state);
-      continue;
-    }
-    if (isW(child, W.r)) {
-      walkRunForCommentMarkers(child, state);
-      continue;
-    }
-
-    walkParagraphForCommentMarkers(rootParagraph, child, state);
-  }
-}
-
-function walkRunForCommentMarkers(run: Element, state: ParagraphMarkerWalkState): void {
-  const runIndex = state.currentRunIndex;
-  state.currentRunIndex += 1;
-  const runVisibleStart = state.charPos;
-
-  for (const child of childElements(run)) {
-    if (isW(child, W.commentRangeStart)) {
-      recordInRunMarker(child, state.startMarkers, runIndex, state.charPos - runVisibleStart, state.charPos);
-      continue;
-    }
-    if (isW(child, W.commentRangeEnd)) {
-      recordInRunMarker(child, state.endMarkers, runIndex, state.charPos - runVisibleStart, state.charPos);
-      continue;
-    }
-    if (!child.namespaceURI || child.namespaceURI !== OOXML.W_NS) continue;
-
-    if (child.localName === W.fldChar) {
-      const type = getWordAttribute(child, 'fldCharType') ?? '';
-      if (type === 'begin') state.fieldState = FieldState.IN_FIELD_CODE;
-      else if (type === 'separate') state.fieldState = FieldState.IN_FIELD_RESULT;
-      else if (type === 'end') state.fieldState = FieldState.OUTSIDE_FIELD;
-      continue;
-    }
-
-    if (state.fieldState === FieldState.IN_FIELD_CODE) continue;
-
-    if (child.localName === W.t) {
-      state.charPos += (getLeafText(child) ?? '').length;
-      continue;
-    }
-    if (child.localName === W.tab || child.localName === W.br) {
-      state.charPos += 1;
-    }
-  }
-
-  state.allRuns.push({ visibleLength: state.charPos - runVisibleStart });
-}
-
-function recordInRunMarker(
-  markerEl: Element,
-  bucket: MarkerCharPosition[],
-  runIndex: number,
-  charOffset: number,
-  textOffset: number,
-): void {
-  const id = getCommentMarkerId(markerEl);
-  if (id == null) return;
-  bucket.push({ id, textOffset, inside: { runIndex, charOffset } });
-}
-
-function recordParagraphLevelMarker(
-  markerEl: Element,
-  bucket: MarkerCharPosition[],
-  state: ParagraphMarkerWalkState,
-): void {
-  const id = getCommentMarkerId(markerEl);
-  if (id == null) return;
-  bucket.push({ id, textOffset: state.charPos, between: { afterRunIndex: state.currentRunIndex - 1 } });
 }
 
 function getCommentMarkerId(markerEl: Element): number | null {
@@ -1083,45 +957,20 @@ function getCommentMarkerId(markerEl: Element): number | null {
   return Number.isNaN(id) ? null : id;
 }
 
-function getWordAttribute(el: Element, localName: string): string | null {
-  return getAttributeSafe(el, OOXML.W_NS, localName, 'w');
-}
-
-function resolveMarkerToRunBoundary(
-  allRuns: RunBoundary[],
-  marker: MarkerCharPosition,
+function resolveIndexedMarkerBoundary(
+  index: ParagraphIndex,
+  marker: IndexedParagraphNode,
   boundary: 'start' | 'end',
 ): Pick<CommentRangePoint, 'runIndex' | 'charOffset'> {
-  // Marker seen INSIDE a run already carries the exact runIndex + charOffset.
-  if (marker.inside) {
-    return { runIndex: marker.inside.runIndex, charOffset: marker.inside.charOffset };
-  }
-  if (!marker.between) return {};
-  if (allRuns.length === 0) return {};
-
-  const { afterRunIndex } = marker.between;
-  const lastIndex = allRuns.length - 1;
-
-  if (boundary === 'start') {
-    // Marker sits between run `afterRunIndex` and run `afterRunIndex + 1`.
-    // For a `start` marker, the range opens at offset 0 of the next run if it exists.
-    const nextIdx = afterRunIndex + 1;
-    if (nextIdx <= lastIndex) {
-      return { runIndex: nextIdx, charOffset: 0 };
-    }
-    // Marker is past the last run — clamp to end of last run.
-    return { runIndex: lastIndex, charOffset: allRuns[lastIndex]!.visibleLength };
-  }
-
-  // boundary === 'end': range closes at the end of the previous run if one exists.
-  if (afterRunIndex < 0) {
-    // Marker is before the first run — empty range starting at run 0.
-    return { runIndex: 0, charOffset: 0 };
-  }
-  if (afterRunIndex <= lastIndex) {
-    return { runIndex: afterRunIndex, charOffset: allRuns[afterRunIndex]!.visibleLength };
-  }
-  return { runIndex: lastIndex, charOffset: allRuns[lastIndex]!.visibleLength };
+  if (marker.runIndex !== null) return { runIndex: marker.runIndex, charOffset: marker.runVisibleOffset };
+  if (index.runs.length === 0) return {};
+  const before = [...index.runs].reverse().find((run) => run.structuralIndex < marker.structuralIndex);
+  const after = index.runs.find((run) => run.structuralIndex > marker.structuralIndex);
+  if (boundary === 'start' && after) return { runIndex: after.runIndex!, charOffset: 0 };
+  if (before) return { runIndex: before.runIndex!, charOffset: before.visibleText.length };
+  // At least one run exists, and a marker with no preceding run must sort
+  // before the first run, so `after` is necessarily defined here.
+  return { runIndex: after!.runIndex!, charOffset: 0 };
 }
 
 /**

--- a/packages/docx-core/src/primitives/document.ts
+++ b/packages/docx-core/src/primitives/document.ts
@@ -1246,20 +1246,17 @@ export class DocxDocument {
       }
       const paragraph = findParagraphByBookmarkId(this.documentXml, comment.anchoredParagraphId);
       if (!paragraph) throw new Error(`Comment ID ${comment.id} anchor was not found`);
-      let afterText: string | undefined;
       if (comment.endTextOffset !== undefined) {
         const paragraphText = getParagraphText(paragraph);
         if (comment.endTextOffset > paragraphText.length) {
           throw new Error(`Comment ID ${comment.id} has an invalid visible-text range endpoint`);
         }
-        afterText = paragraphText.slice(0, comment.endTextOffset);
-        if (!afterText) afterText = undefined;
       }
       const replyText = comment.replies.map((reply) => `\n${reply.author ? `${reply.author}: ` : ''}${reply.text}`).join('');
       return {
         comment,
         paragraph,
-        afterText,
+        visibleOffset: comment.endTextOffset,
         text: `${comment.text}${replyText}`,
       };
     });
@@ -1272,7 +1269,7 @@ export class DocxDocument {
       // not the adjacent footnote run introduced here.
       const result = await addFootnoteImpl(this.documentXml, this.zip, {
         paragraphEl: item.paragraph,
-        afterText: item.afterText,
+        visibleOffset: item.visibleOffset,
         text: item.text,
         presentation: options.presentation,
       });

--- a/packages/docx-core/src/primitives/footnotes.ts
+++ b/packages/docx-core/src/primitives/footnotes.ts
@@ -8,7 +8,7 @@
 import { OOXML, W } from './namespaces.js';
 import { parseXml, serializeXml } from './xml.js';
 import { DocxZip } from './zip.js';
-import { getParagraphRuns } from './text.js';
+import { buildParagraphIndex } from './paragraph-index.js';
 import { getParagraphBookmarkId } from './bookmarks.js';
 import { findUniqueSubstringMatch } from './matching.js';
 import { childElements, isW } from './dom-helpers.js';
@@ -95,6 +95,7 @@ export type Footnote = {
 export type AddFootnoteParams = {
   paragraphEl: Element;
   afterText?: string;
+  visibleOffset?: number;
   text: string;
   presentation?: FootnoteNotePresentation;
 };
@@ -468,7 +469,10 @@ export async function addFootnote(
   params: AddFootnoteParams,
   ctx?: RevisionContext,
 ): Promise<AddFootnoteResult> {
-  const { paragraphEl, afterText, text, presentation } = params;
+  const { paragraphEl, afterText, visibleOffset, text, presentation } = params;
+  if (afterText !== undefined && visibleOffset !== undefined) {
+    throw new Error('afterText and visibleOffset are mutually exclusive footnote anchors');
+  }
 
   // Load or bootstrap footnotes.xml
   const footnotesXml = await zip.readText('word/footnotes.xml');
@@ -478,7 +482,7 @@ export async function addFootnote(
   const noteId = allocateNextFootnoteId(footnotesDoc);
 
   // Insert footnoteReference run in document body
-  insertFootnoteReference(documentXml, paragraphEl, noteId, afterText, ctx);
+  insertFootnoteReference(documentXml, paragraphEl, noteId, afterText, visibleOffset, ctx);
 
   // Add footnote body to footnotes.xml
   const footnoteEl = addFootnoteElement(footnotesDoc, noteId, text, presentation);
@@ -495,6 +499,7 @@ function insertFootnoteReference(
   paragraphEl: Element,
   noteId: number,
   afterText?: string,
+  requestedVisibleOffset?: number,
   ctx?: RevisionContext,
 ): void {
   // Create the reference run
@@ -518,51 +523,51 @@ function insertFootnoteReference(
     refAnchor.appendChild(refRun);
   }
 
-  if (!afterText) {
+  if (afterText === undefined && requestedVisibleOffset === undefined) {
     // Default: append at end of paragraph
     paragraphEl.appendChild(refAnchor);
     return;
   }
 
-  // Find the text boundary using unique substring matching
-  const runs = getParagraphRuns(paragraphEl);
-  const fullText = runs.map((r) => r.text).join('');
-  const match = findUniqueSubstringMatch(fullText, afterText);
-
-  if (match.status === 'not_found') {
-    throw new Error(`after_text '${afterText}' not found in paragraph`);
+  const index = buildParagraphIndex(paragraphEl);
+  const runs = index.runs.filter((run) => run.visibleText.length > 0);
+  let insertOffset: number;
+  if (requestedVisibleOffset !== undefined) {
+    if (!Number.isInteger(requestedVisibleOffset) || requestedVisibleOffset < 0 || requestedVisibleOffset > index.text.length) {
+      throw new Error(`visibleOffset ${requestedVisibleOffset} is outside paragraph visible text [0, ${index.text.length}]`);
+    }
+    insertOffset = requestedVisibleOffset;
+  } else {
+    const match = findUniqueSubstringMatch(index.text, afterText!);
+    if (match.status === 'not_found') throw new Error(`after_text '${afterText}' not found in paragraph`);
+    if (match.status === 'multiple') throw new Error(`after_text '${afterText}' found ${match.matchCount} times in paragraph`);
+    insertOffset = match.end;
   }
-  if (match.status === 'multiple') {
-    throw new Error(`after_text '${afterText}' found ${match.matchCount} times in paragraph`);
-  }
-
-  // We need to insert after the end of the matched text
-  const insertOffset = match.end;
 
   // Map offset to run position
   let pos = 0;
   for (let i = 0; i < runs.length; i++) {
     const run = runs[i]!;
-    const runEnd = pos + run.text.length;
+    const runEnd = pos + run.visibleText.length;
 
     if (insertOffset <= pos) {
       // Insert before this run
-      const parent = run.r.parentNode!;
-      parent.insertBefore(refAnchor, run.r);
+      const parent = run.element.parentNode!;
+      parent.insertBefore(refAnchor, run.element);
       return;
     }
 
     if (insertOffset > pos && insertOffset < runEnd) {
       // Need to split this run at the offset
       const splitOffset = insertOffset - pos;
-      splitRunAndInsertReference(run.r, splitOffset, refAnchor);
+      splitRunAndInsertReference(run.element, splitOffset, refAnchor);
       return;
     }
 
     if (insertOffset === runEnd) {
       // Insert after this run
-      const parent = run.r.parentNode!;
-      parent.insertBefore(refAnchor, run.r.nextSibling);
+      const parent = run.element.parentNode!;
+      parent.insertBefore(refAnchor, run.element.nextSibling);
       return;
     }
 

--- a/packages/docx-core/src/primitives/index.ts
+++ b/packages/docx-core/src/primitives/index.ts
@@ -14,6 +14,7 @@ export * from './serialize_plaintext.js';
 export * from './styles.js';
 export * from './symbol_run_content.js';
 export * from './text.js';
+export * from './paragraph-index.js';
 export * from './xml.js';
 export * from './dom-helpers.js';
 export * from './zip.js';

--- a/packages/docx-core/src/primitives/paragraph-index.test.ts
+++ b/packages/docx-core/src/primitives/paragraph-index.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect } from 'vitest';
+import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
+import { parseXml } from './xml.js';
+import { OOXML, W } from './namespaces.js';
+import { buildParagraphIndex } from './paragraph-index.js';
+
+const test = testAllure.epic('Document Comparison').withLabels({ feature: 'Paragraph Index' });
+
+function paragraph(xml: string): Element {
+  const doc = parseXml(`<w:document xmlns:w="${OOXML.W_NS}"><w:body>${xml}</w:body></w:document>`);
+  return doc.getElementsByTagNameNS(OOXML.W_NS, W.p).item(0) as Element;
+}
+
+describe('buildParagraphIndex', () => {
+  test('uses one field-aware traversal for visible and structural coordinates', async ({ given, then }: AllureBddContext) => {
+    let index: ReturnType<typeof buildParagraphIndex>;
+    await given('fragmented text around a field and zero-width annotation nodes', () => {
+      index = buildParagraphIndex(paragraph(
+        `<w:p>` +
+        `<w:bookmarkStart w:id="1" w:name="anchor"/>` +
+        `<w:r><w:t>A</w:t></w:r>` +
+        `<w:r><w:commentReference w:id="9"/></w:r>` +
+        `<w:commentRangeStart w:id="1"/>` +
+        `<w:r><w:fldChar w:fldCharType="begin"/></w:r>` +
+        `<w:r><w:instrText> REF X </w:instrText></w:r>` +
+        `<w:r><w:fldChar w:fldCharType="separate"/><w:t>B</w:t></w:r>` +
+        `<w:r><w:fldChar w:fldCharType="end"/></w:r>` +
+        `<w:commentRangeEnd w:id="1"/>` +
+        `<w:r><w:footnoteReference w:id="2"/></w:r>` +
+        `</w:p>`,
+      ));
+    });
+    await then('visible text and every zero-width structural coordinate remain aligned', () => {
+      expect(index.text).toBe('AB');
+      expect(index.runs).toHaveLength(7);
+      expect(index.runs.map((run) => run.runIndex)).toEqual([0, 1, 2, 3, 4, 5, 6]);
+      expect(index.nodes.find((node) => node.kind === 'comment-reference')?.visibleStart).toBe(1);
+      expect(index.nodes.find((node) => node.kind === 'comment-range-start')?.visibleStart).toBe(1);
+      expect(index.nodes.find((node) => node.kind === 'comment-range-end')?.visibleStart).toBe(2);
+      expect(index.nodes.find((node) => node.kind === 'footnote-reference')?.visibleStart).toBe(2);
+      expect(index.nodes.find((node) => node.kind === 'bookmark')?.visibleStart).toBe(0);
+      expect(index.runs.find((run) => run.visibleText === 'B')?.fieldInstruction).toBe('REF X');
+    });
+  });
+
+  test('does not descend into nested paragraphs', async ({ given, then }: AllureBddContext) => {
+    let index: ReturnType<typeof buildParagraphIndex>;
+    await given('a malformed nested paragraph beside ordinary text', () => {
+      index = buildParagraphIndex(paragraph('<w:p><w:r><w:t>Outer</w:t></w:r><w:p><w:r><w:t>Inner</w:t></w:r></w:p></w:p>'));
+    });
+    await then('only the requested paragraph contributes coordinates', () => {
+      expect(index.text).toBe('Outer');
+      expect(index.runs).toHaveLength(1);
+    });
+  });
+
+  test('keeps one coordinate space through revision, hyperlink, and content-control wrappers', async ({ given, then }: AllureBddContext) => {
+    let index: ReturnType<typeof buildParagraphIndex>;
+    await given('visible runs and a marker nested under common paragraph wrappers', () => {
+      index = buildParagraphIndex(paragraph(
+        `<w:p xmlns:r="${OOXML.R_NS}">` +
+        `<w:ins w:id="1"><w:r><w:t>A</w:t></w:r></w:ins>` +
+        `<w:hyperlink r:id="rId1"><w:r><w:t>B</w:t></w:r><w:commentRangeStart w:id="4"/></w:hyperlink>` +
+        `<w:sdt><w:sdtContent><w:r><w:t>C</w:t></w:r></w:sdtContent></w:sdt>` +
+        `<w:del w:id="2"><w:r><w:t>D</w:t></w:r></w:del>` +
+        `</w:p>`,
+      ));
+    });
+    await then('wrapper boundaries do not fork visible or structural accounting', () => {
+      expect(index.text).toBe('ABCD');
+      expect(index.runs.map((run) => [run.runIndex, run.visibleStart, run.visibleEnd])).toEqual([
+        [0, 0, 1],
+        [1, 1, 2],
+        [2, 2, 3],
+        [3, 3, 4],
+      ]);
+      const marker = index.nodes.find((node) => node.kind === 'comment-range-start');
+      expect(marker?.visibleStart).toBe(2);
+      expect(marker?.runIndex).toBeNull();
+    });
+  });
+});

--- a/packages/docx-core/src/primitives/paragraph-index.ts
+++ b/packages/docx-core/src/primitives/paragraph-index.ts
@@ -1,0 +1,170 @@
+import { OOXML, W } from './namespaces.js';
+import { getAttributeSafe } from './xml-helpers.js';
+
+export type ParagraphNodeKind =
+  | 'run'
+  | 'text'
+  | 'tab'
+  | 'break'
+  | 'comment-range-start'
+  | 'comment-range-end'
+  | 'comment-reference'
+  | 'footnote-reference'
+  | 'field-code'
+  | 'bookmark'
+  | 'other';
+
+export type IndexedParagraphNode = {
+  element: Element;
+  structuralIndex: number;
+  runIndex: number | null;
+  runVisibleOffset: number;
+  visibleStart: number;
+  visibleEnd: number;
+  kind: ParagraphNodeKind;
+  visibleText: string;
+  isFieldResult: boolean;
+  fieldResultId: number | null;
+  fieldInstruction: string | null;
+};
+
+export type ParagraphIndex = {
+  paragraph: Element;
+  text: string;
+  nodes: IndexedParagraphNode[];
+  runs: IndexedParagraphNode[];
+};
+
+type FieldFrame = { id: number; phase: 'instruction' | 'result'; instruction: string };
+
+function wordAttr(element: Element, localName: string): string | null {
+  return getAttributeSafe(element, OOXML.W_NS, localName, 'w');
+}
+
+function kindOf(element: Element): ParagraphNodeKind {
+  if (element.namespaceURI !== OOXML.W_NS) return 'other';
+  switch (element.localName) {
+    case W.r: return 'run';
+    case W.t: return 'text';
+    case W.tab: return 'tab';
+    case W.br: return 'break';
+    case W.commentRangeStart: return 'comment-range-start';
+    case W.commentRangeEnd: return 'comment-range-end';
+    case W.commentReference: return 'comment-reference';
+    case W.footnoteReference: return 'footnote-reference';
+    case W.fldChar:
+    case W.instrText:
+    case 'delInstrText': return 'field-code';
+    case 'bookmarkStart':
+    case 'bookmarkEnd': return 'bookmark';
+    default: return 'other';
+  }
+}
+
+/**
+ * Build the canonical structural and visible-coordinate index for one
+ * WordprocessingML paragraph. Every descendant run and marker receives a
+ * structural coordinate; field instruction text remains zero-width while
+ * cached field results participate in visible coordinates.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.18
+ * @see https://github.com/UseJunior/safe-docx/issues/904
+ */
+export function buildParagraphIndex(paragraph: Element): ParagraphIndex {
+  const nodes: IndexedParagraphNode[] = [];
+  const runs: IndexedParagraphNode[] = [];
+  const fieldStack: FieldFrame[] = [];
+  const instructions = new Map<number, string>();
+  let nextFieldId = 1;
+  let structuralIndex = 0;
+  let visibleOffset = 0;
+  let runIndex = -1;
+
+  const currentResultId = (): number | null => {
+    if (fieldStack.length === 0 || fieldStack.some((frame) => frame.phase === 'instruction')) return null;
+    return fieldStack.at(-1)!.id;
+  };
+
+  const visit = (element: Element, containingRun: IndexedParagraphNode | null): void => {
+    if (element !== paragraph && element.namespaceURI === OOXML.W_NS && element.localName === W.p) return;
+    const isRun = element.namespaceURI === OOXML.W_NS && element.localName === W.r;
+    let activeRun = containingRun;
+    if (isRun) {
+      runIndex += 1;
+      activeRun = {
+        element,
+        structuralIndex: structuralIndex++,
+        runIndex,
+        runVisibleOffset: 0,
+        visibleStart: visibleOffset,
+        visibleEnd: visibleOffset,
+        kind: 'run',
+        visibleText: '',
+        isFieldResult: false,
+        fieldResultId: null,
+        fieldInstruction: null,
+      };
+      nodes.push(activeRun);
+      runs.push(activeRun);
+    } else if (element !== paragraph) {
+      const node: IndexedParagraphNode = {
+        element,
+        structuralIndex: structuralIndex++,
+        runIndex: activeRun?.runIndex ?? null,
+        runVisibleOffset: activeRun ? visibleOffset - activeRun.visibleStart : 0,
+        visibleStart: visibleOffset,
+        visibleEnd: visibleOffset,
+        kind: kindOf(element),
+        visibleText: '',
+        isFieldResult: false,
+        fieldResultId: null,
+        fieldInstruction: null,
+      };
+      nodes.push(node);
+
+      if (node.kind === 'field-code' && element.localName === W.fldChar) {
+        const type = wordAttr(element, 'fldCharType') ?? '';
+        if (type === 'begin') fieldStack.push({ id: nextFieldId++, phase: 'instruction', instruction: '' });
+        else if (type === 'separate') {
+          const frame = fieldStack.at(-1);
+          if (frame) {
+            frame.phase = 'result';
+            instructions.set(frame.id, frame.instruction.trim());
+          }
+        } else if (type === 'end') fieldStack.pop();
+      } else {
+        const instructionFrame = [...fieldStack].reverse().find((frame) => frame.phase === 'instruction');
+        if (instructionFrame && (element.localName === W.instrText || element.localName === 'delInstrText')) {
+          instructionFrame.instruction += element.textContent ?? '';
+        } else if (!instructionFrame && (node.kind === 'text' || node.kind === 'tab' || node.kind === 'break')) {
+          const text = node.kind === 'text' ? (element.textContent ?? '') : node.kind === 'tab' ? '\t' : '\n';
+          const resultId = currentResultId();
+          node.visibleText = text;
+          node.visibleEnd += text.length;
+          node.isFieldResult = resultId !== null;
+          node.fieldResultId = resultId;
+          visibleOffset += text.length;
+          if (activeRun) {
+            activeRun.visibleText += text;
+            activeRun.visibleEnd = visibleOffset;
+            activeRun.isFieldResult ||= resultId !== null;
+            if (activeRun.visibleText.length === text.length) activeRun.fieldResultId = resultId;
+            else if (activeRun.fieldResultId !== resultId) activeRun.fieldResultId = null;
+          }
+        }
+      }
+    }
+
+    if (!isRun || activeRun) {
+      for (const child of Array.from(element.childNodes)) {
+        if (child.nodeType === 1) visit(child as Element, activeRun);
+      }
+    }
+  };
+
+  visit(paragraph, null);
+  for (const node of nodes) {
+    if (node.fieldResultId !== null) node.fieldInstruction = instructions.get(node.fieldResultId) ?? null;
+  }
+  return { paragraph, text: runs.map((run) => run.visibleText).join(''), nodes, runs };
+}

--- a/packages/docx-core/src/primitives/text.ts
+++ b/packages/docx-core/src/primitives/text.ts
@@ -1,12 +1,13 @@
 import { OOXML, W } from './namespaces.js';
 import { SafeDocxError } from './errors.js';
-import { getAttributeSafe, getFirstChild } from './xml-helpers.js';
+import { getFirstChild } from './xml-helpers.js';
 import {
   buildRPrChangeElement,
   createRevisionContainer,
   prepareElementForDeletion,
   type RevisionContext,
 } from './track-changes-emitter.js';
+import { buildParagraphIndex } from './paragraph-index.js';
 
 export type TextRun = {
   r: Element; // w:r
@@ -25,106 +26,15 @@ export type TextRun = {
  * @see #651
  */
 export function getParagraphRuns(p: Element): TextRun[] {
-  type FieldFrame = {
-    id: number;
-    phase: 'instruction' | 'result';
-    instruction: string;
-  };
-
-  type PendingTextRun = Pick<TextRun, 'r' | 'text' | 'isFieldResult'> & {
-    fieldResultId: number | null;
-  };
-
-  function currentResultId(stack: readonly FieldFrame[]): number | null {
-    if (stack.length === 0 || stack.some((frame) => frame.phase === 'instruction')) return null;
-    return stack.at(-1)!.id;
-  }
-
-  function getWAttr(el: Element, localName: string): string | null {
-    return getAttributeSafe(el, OOXML.W_NS, localName, 'w');
-  }
-
-  const runs: PendingTextRun[] = [];
-  const rElems = Array.from(p.getElementsByTagNameNS(OOXML.W_NS, W.r));
-
-  const fieldStack: FieldFrame[] = [];
-  const fieldInstructions = new Map<number, string>();
-  let nextFieldId = 1;
-  for (const r of rElems) {
-    let runText = '';
-    let sawResult = false;
-    let runFieldResultId: number | null | undefined;
-
-    const appendVisibleText = (text: string): void => {
-      const resultId = currentResultId(fieldStack);
-      sawResult ||= resultId !== null;
-      if (runFieldResultId === undefined) {
-        runFieldResultId = resultId;
-      } else if (runFieldResultId !== resultId) {
-        // A run whose visible content straddles a field boundary cannot be
-        // rewritten as one unit without moving content across that boundary.
-        runFieldResultId = null;
-      }
-      runText += text;
-    };
-
-    // Walk children in order so we can handle rare cases where fldChar and result text
-    // appear in the same run.
-    for (const child of Array.from(r.childNodes)) {
-      if (child.nodeType !== 1) continue;
-      const el = child as Element;
-      if (el.namespaceURI !== OOXML.W_NS) continue;
-
-      if (el.localName === W.fldChar) {
-        const typ = getWAttr(el, 'fldCharType') ?? '';
-        if (typ === 'begin') {
-          fieldStack.push({ id: nextFieldId++, phase: 'instruction', instruction: '' });
-        } else if (typ === 'separate') {
-          const frame = fieldStack.at(-1);
-          if (frame) {
-            frame.phase = 'result';
-            fieldInstructions.set(frame.id, frame.instruction.trim());
-          }
-        } else if (typ === 'end') {
-          fieldStack.pop();
-        }
-        continue;
-      }
-
-      const instructionFrame = [...fieldStack].reverse().find((frame) => frame.phase === 'instruction');
-      if (instructionFrame) {
-        if (el.localName === W.instrText || el.localName === 'delInstrText') {
-          instructionFrame.instruction += el.textContent ?? '';
-        }
-        // Skip field code/instruction text.
-        continue;
-      }
-
-      if (el.localName === W.t) {
-        appendVisibleText(el.textContent ?? '');
-      } else if (el.localName === W.tab) {
-        appendVisibleText('\t');
-      } else if (el.localName === W.br) {
-        appendVisibleText('\n');
-      }
-    }
-
-    if (runText) {
-      runs.push({
-        r,
-        text: runText,
-        isFieldResult: sawResult,
-        fieldResultId: runFieldResultId ?? null,
-      });
-    }
-  }
-
-  return runs.map((run) => ({
-    ...run,
-    fieldInstruction: run.fieldResultId === null
-      ? null
-      : (fieldInstructions.get(run.fieldResultId) ?? null),
-  }));
+  return buildParagraphIndex(p).runs
+    .filter((run) => run.visibleText.length > 0)
+    .map((run) => ({
+      r: run.element,
+      text: run.visibleText,
+      isFieldResult: run.isFieldResult,
+      fieldResultId: run.fieldResultId,
+      fieldInstruction: run.fieldInstruction,
+    }));
 }
 
 export function getParagraphText(p: Element): string {


### PR DESCRIPTION
## Summary
- add one field-aware paragraph index for structural runs, zero-width markers, and visible offsets
- preserve `getParagraphRuns()` as the visible-only projection
- migrate comment range extraction and comment-to-footnote insertion to exact indexed coordinates

## Verification
- `npm run build` ✅
- `npm run lint:workspaces` ✅ (pre-existing warnings only)
- focused docx-core suite: 227 passed
- full unsandboxed suite: all workspaces pass except 5 pre-existing LibreOffice renderer tests; local LibreOffice timed out with no PDF output
- `openspec validate add-configurable-note-presentation --strict` ✅
- spec coverage and conformance gates ✅
- Claude Opus dynamic review: APPROVE with minor findings; credible findings addressed

Fixes #904