### PR TITLE
fix(docx-compare): preserve bookmark projection targets

### DIFF
--- a/openspec/changes/archive/2026-08-19-refactor-tagged-tree-spine/specs/docx-comparison/spec.md
+++ b/openspec/changes/archive/2026-08-19-refactor-tagged-tree-spine/specs/docx-comparison/spec.md
@@ -70,7 +70,15 @@ Consumer compatibility SHALL run against the complete tagged document using one
 revision-ID allocator seeded from every surviving numeric revision identifier.
 Bookmark identifiers SHALL NOT seed that allocator. Volatile TOC PAGEREF cache
 revisions SHALL be suppressed after compatibility enforcement and before the
-final safety and formatting checks.
+final safety and formatting checks. When equal numeric bookmark IDs identify
+differently named ranges across the independently authored inputs, the engine
+SHALL remap the original-side ID before alignment. When tagged publication would
+otherwise create a bookmark-name collision absent from both inputs, the engine
+SHALL mint a collision-safe name for the original-side bookmark and SHALL
+rewrite that side's complete or fragmented REF, PAGEREF, NOTEREF, HYPERLINK
+`\\l`, and TOC `\\b` field targets plus internal-hyperlink anchors across
+`word/*.xml` before republishing. Accept All SHALL preserve revised-side names
+and targets; Reject All MAY expose the generated internal original-side name.
 
 #### Scenario: Standalone publication has no legacy assembly dependency
 
@@ -93,6 +101,20 @@ final safety and formatting checks.
 - **WHEN** consumer compatibility splits a revision wrapper while hoisting bookmarks
 - **THEN** the newly allocated revision ID SHALL avoid every surviving revision ID
 - **AND** bookmark IDs SHALL remain unchanged
+
+#### Scenario: Original-side bookmark collisions preserve reference targets
+
+- **GIVEN** consumer-compatibility hoisting would duplicate a bookmark name that is unique in each input
+- **WHEN** one or more supported original-side bookmark fields or internal hyperlinks target that bookmark across `word/*.xml`
+- **THEN** the original-side bookmark and all corresponding original-side field and hyperlink targets SHALL use one collision-safe generated name
+- **AND** Accept All SHALL retain the revised-side name and targets while Reject All retains the generated original-side equivalents
+
+#### Scenario: Cross-version bookmark IDs are package-local
+
+- **GIVEN** original and revised packages assign the same numeric bookmark ID to differently named ranges
+- **WHEN** tagged publication aligns their bookmark boundaries
+- **THEN** the original-side range SHALL receive a collision-safe internal ID before alignment
+- **AND** the combined, Accept All, and Reject All projections SHALL contain no comparison-created duplicate or unmatched bookmark boundaries
 
 #### Scenario: Volatile TOC cache changes are suppressed before final gates
 

--- a/openspec/changes/archive/2026-08-19-refactor-tagged-tree-spine/tasks.md
+++ b/openspec/changes/archive/2026-08-19-refactor-tagged-tree-spine/tasks.md
@@ -26,6 +26,7 @@
 - [x] 3.3 Enforce consumer compatibility before serialization without repairing bookmark inventory.
 - [x] 3.4 Suppress volatile PAGEREF revisions after compatibility enforcement and before final gates.
 - [x] 3.5 Add overlapping bookmark/revision ID and refreshed-TOC cache regressions, then close their divergence rows.
+- [x] 3.6 Disambiguate package-local bookmark IDs, rewrite original-side bookmark targets across WordprocessingML parts, and make bookmark publication gates fail closed on comparison-created anomalies.
 
 ## 4. Markdoc rationale attribution
 

--- a/openspec/specs/docx-comparison/spec.md
+++ b/openspec/specs/docx-comparison/spec.md
@@ -611,7 +611,15 @@ Consumer compatibility SHALL run against the complete tagged document using one
 revision-ID allocator seeded from every surviving numeric revision identifier.
 Bookmark identifiers SHALL NOT seed that allocator. Volatile TOC PAGEREF cache
 revisions SHALL be suppressed after compatibility enforcement and before the
-final safety and formatting checks.
+final safety and formatting checks. When equal numeric bookmark IDs identify
+differently named ranges across the independently authored inputs, the engine
+SHALL remap the original-side ID before alignment. When tagged publication would
+otherwise create a bookmark-name collision absent from both inputs, the engine
+SHALL mint a collision-safe name for the original-side bookmark and SHALL
+rewrite that side's complete or fragmented REF, PAGEREF, NOTEREF, HYPERLINK
+`\\l`, and TOC `\\b` field targets plus internal-hyperlink anchors across
+`word/*.xml` before republishing. Accept All SHALL preserve revised-side names
+and targets; Reject All MAY expose the generated internal original-side name.
 
 #### Scenario: Standalone publication has no legacy assembly dependency
 
@@ -634,6 +642,20 @@ final safety and formatting checks.
 - **WHEN** consumer compatibility splits a revision wrapper while hoisting bookmarks
 - **THEN** the newly allocated revision ID SHALL avoid every surviving revision ID
 - **AND** bookmark IDs SHALL remain unchanged
+
+#### Scenario: Original-side bookmark collisions preserve reference targets
+
+- **GIVEN** consumer-compatibility hoisting would duplicate a bookmark name that is unique in each input
+- **WHEN** one or more supported original-side bookmark fields or internal hyperlinks target that bookmark across `word/*.xml`
+- **THEN** the original-side bookmark and all corresponding original-side field and hyperlink targets SHALL use one collision-safe generated name
+- **AND** Accept All SHALL retain the revised-side name and targets while Reject All retains the generated original-side equivalents
+
+#### Scenario: Cross-version bookmark IDs are package-local
+
+- **GIVEN** original and revised packages assign the same numeric bookmark ID to differently named ranges
+- **WHEN** tagged publication aligns their bookmark boundaries
+- **THEN** the original-side range SHALL receive a collision-safe internal ID before alignment
+- **AND** the combined, Accept All, and Reject All projections SHALL contain no comparison-created duplicate or unmatched bookmark boundaries
 
 #### Scenario: Volatile TOC cache changes are suppressed before final gates
 

--- a/packages/docx-compare/src/integration/strategy-differential-manifest.json
+++ b/packages/docx-compare/src/integration/strategy-differential-manifest.json
@@ -1171,14 +1171,14 @@
         "strategy": "tagged-tree",
         "projections": {
           "accept": {
-            "xmlSha256": "6e39e1c13d54d6b7d2ac4dbe446daed9fc4f37a774c711ddbf8f2a74537b4ad3",
+            "xmlSha256": "517fef3af69097a670cfcdf49616472869aab39c0c748e6f560a8e7e56a329fa",
             "textSha256": "97c196cd5e2a64c7fc89d3bcfed44be264fc2989b33fa9e09786f5c8c52e3e05",
             "sourceTextSha256": "97c196cd5e2a64c7fc89d3bcfed44be264fc2989b33fa9e09786f5c8c52e3e05",
             "matchesSourceText": true,
             "firstDifference": null
           },
           "reject": {
-            "xmlSha256": "d9e3d5f3cd240360051c7a9b90ddc97ff031a0a4d924a4892e852d568019918e",
+            "xmlSha256": "1852d0679a7a4e0a2781c2d9124a7178138ce857e4e9c6cf7314328b8d3ca7db",
             "textSha256": "f6c16bacb61bcd8cec2839c4cb671b4bee8576d7695bf20cc3af6451702cfd4a",
             "sourceTextSha256": "f6c16bacb61bcd8cec2839c4cb671b4bee8576d7695bf20cc3af6451702cfd4a",
             "matchesSourceText": true,
@@ -1248,8 +1248,8 @@
           },
           {
             "path": "word/document.xml",
-            "bytes": 1195728,
-            "sha256": "a5571fba09c9890bc9b0f953817161934794c3a13ef899e741c0d1ef326ed003",
+            "bytes": 1202363,
+            "sha256": "419cf4705157175f566597b35477a86b44cc938c09775ba79a5826ab7165b013",
             "kind": "xml"
           },
           {
@@ -1579,13 +1579,13 @@
         ],
         "stats": {
           "atomMetricVersion": "tagged-token-v1",
-          "insertions": 855,
-          "deletions": 790,
+          "insertions": 869,
+          "deletions": 802,
           "modifications": 496,
-          "insertedRanges": 855,
-          "deletedRanges": 790,
-          "insertedAtoms": 3660,
-          "deletedAtoms": 2095,
+          "insertedRanges": 869,
+          "deletedRanges": 802,
+          "insertedAtoms": 3662,
+          "deletedAtoms": 2101,
           "modifiedParagraphs": 496,
           "formatChanges": 17,
           "formatChangeAtoms": 17

--- a/packages/docx-compare/src/integration/taggedTreeMinimality.corpus.test.ts
+++ b/packages/docx-compare/src/integration/taggedTreeMinimality.corpus.test.ts
@@ -4,8 +4,11 @@ import { fileURLToPath } from 'node:url';
 import { DocxArchive, parseXml } from '@usejunior/docx-core';
 import { describe, expect } from 'vitest';
 import { testAllure } from '../testing/allure-test.js';
+import { compareDocuments } from '../index.js';
+import { collectBookmarkReferenceNamesInXml } from '../tagged/bookmarkProjectionCompatibility.js';
 import { buildTaggedTreeShadowXml } from '../tagged/taggedTreeShadow.js';
 import { compareSourceProjectedFormattingFidelity } from '../tagged/formattingFidelity.js';
+import { acceptAllChanges, rejectAllChanges } from '../tagged/trackChangesAcceptorAst.js';
 
 const ROOT = resolve(fileURLToPath(new URL('.', import.meta.url)), '../../../../');
 const ORIGINAL = resolve(ROOT, 'tests/test_documents/redline/ILPA-Model-Limited-Parnership-Agreement-Deal-By-Deal_v1.docx');
@@ -13,6 +16,64 @@ const REVISED = resolve(ROOT, 'tests/test_documents/redline/ILPA-Model-Limited-P
 
 describe('public ILPA tagged-tree redline minimality', () => {
   const test = testAllure.epic('Document Comparison').withLabels({ feature: 'Tagged-tree corpus minimality' });
+  test('publishes balanced, unique, resolved bookmarks in both ILPA directions', async () => {
+    const [deal, wof] = await Promise.all([readFile(ORIGINAL), readFile(REVISED)]);
+    const projectionIssues = (xml: string): {
+      duplicateNames: string[];
+      duplicateStartIds: string[];
+      duplicateEndIds: string[];
+      unmatchedStartIds: string[];
+      unmatchedEndIds: string[];
+      unresolvedReferences: string[];
+    } => {
+      const document = parseXml(xml);
+      const starts = Array.from(document.getElementsByTagName('w:bookmarkStart'));
+      const ends = Array.from(document.getElementsByTagName('w:bookmarkEnd'));
+      const names = starts.map((start) => start.getAttribute('w:name'))
+        .filter((name): name is string => name !== null);
+      const startIds = starts.map((start) => start.getAttribute('w:id'))
+        .filter((id): id is string => id !== null);
+      const endIds = ends.map((end) => end.getAttribute('w:id'))
+        .filter((id): id is string => id !== null);
+      const duplicates = (values: readonly string[]): string[] => [...new Set(
+        values.filter((value, index) => values.indexOf(value) !== index),
+      )].sort();
+      return {
+        duplicateNames: duplicates(names),
+        duplicateStartIds: duplicates(startIds),
+        duplicateEndIds: duplicates(endIds),
+        unmatchedStartIds: startIds.filter((id) => !endIds.includes(id)),
+        unmatchedEndIds: endIds.filter((id) => !startIds.includes(id)),
+        unresolvedReferences: collectBookmarkReferenceNamesInXml(xml)
+          .filter((name) => !names.includes(name)),
+      };
+    };
+    const expected = {
+      duplicateNames: [],
+      duplicateStartIds: [],
+      duplicateEndIds: [],
+      unmatchedStartIds: [],
+      unmatchedEndIds: [],
+      unresolvedReferences: [],
+    };
+
+    for (const [label, original, revised] of [
+      ['Deal-to-WOF', deal, wof],
+      ['WOF-to-Deal', wof, deal],
+    ] as const) {
+      const result = await compareDocuments(original, revised, {
+        author: `Corpus bookmark regression ${label}`,
+        date: new Date('2026-08-21T12:00:00Z'),
+      });
+      const combinedXml = await (await DocxArchive.load(result.document)).getDocumentXml();
+      expect(projectionIssues(combinedXml), `${label} combined`).toEqual(expected);
+      expect(projectionIssues(acceptAllChanges(combinedXml)), `${label} Accept All`)
+        .toEqual(expected);
+      expect(projectionIssues(rejectAllChanges(combinedXml)), `${label} Reject All`)
+        .toEqual(expected);
+    }
+  }, 600_000);
+
   test('preserves the four reported common-text anchors and exact source projections', async () => {
     const [original, revised] = await Promise.all([readFile(ORIGINAL), readFile(REVISED)]);
     const originalXml = await (await DocxArchive.load(original)).getDocumentXml();

--- a/packages/docx-compare/src/tagged/bookmarkProjectionCompatibility.test.ts
+++ b/packages/docx-compare/src/tagged/bookmarkProjectionCompatibility.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Original-side bookmark renames keep supported field and internal-hyperlink
+ * targets synchronized across WordprocessingML stories, including field
+ * instructions fragmented over runs.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.6.2
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.5.45
+ */
+
+import { describe, expect } from 'vitest';
+import { DocxArchive, parseXml } from '@usejunior/docx-core';
+import { testAllure } from '../testing/allure-test.js';
+import { buildDocxFromBodyXml } from '../testing/ooxml-fixtures.js';
+import {
+  collectBookmarkReferenceNamesInXml,
+  collectWordPartBookmarkNames,
+  createOriginalBookmarkRenameMap,
+  disambiguateOriginalBookmarkIds,
+  renameBookmarkTargetsInXml,
+  renameOriginalBookmarkTargetsAcrossWordParts,
+} from './bookmarkProjectionCompatibility.js';
+
+const TEST_FEATURE = 'Consumer Compatibility Bookmark Ranges';
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({
+    feature: TEST_FEATURE,
+    story: 'Original-Side Bookmark Target Renames',
+    severity: 'critical',
+  })
+  .conformance(
+    { spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.6.2' },
+    { spec: 'ECMA-376', edition: 5, part: 1, section: '17.16.5.45' },
+    { spec: 'ECMA-376', edition: 5, part: 1, section: '17.16.22' },
+  );
+
+const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+
+function instruction(documentXml: string): string {
+  const document = parseXml(documentXml);
+  return Array.from(document.getElementsByTagName('*'))
+    .filter((element) =>
+      element.tagName === 'w:instrText' || element.tagName === 'w:delInstrText')
+    .map((element) => element.textContent ?? '')
+    .join('');
+}
+
+describe('original-side bookmark target compatibility', () => {
+  test.openspec('Cross-version bookmark IDs are package-local')(
+    'disambiguates equal cross-version IDs that name different nested ranges', () => {
+      const original = `<w:document xmlns:w="${W_NS}"><w:body><w:p>` +
+        '<w:bookmarkStart w:id="101" w:name="Inner"/>' +
+        '<w:bookmarkStart w:id="102" w:name="Outer"/>' +
+        '<w:r><w:t>Heading</w:t></w:r><w:bookmarkEnd w:id="101"/>' +
+        '<w:r><w:t>Body</w:t></w:r><w:bookmarkEnd w:id="102"/>' +
+        '</w:p></w:body></w:document>';
+      const revised = `<w:document xmlns:w="${W_NS}"><w:body><w:p>` +
+        '<w:bookmarkStart w:id="102" w:name="Inner"/>' +
+        '<w:r><w:t>Heading</w:t></w:r><w:bookmarkEnd w:id="102"/>' +
+        '</w:p></w:body></w:document>';
+
+      const result = disambiguateOriginalBookmarkIds(original, revised);
+      const document = parseXml(result.xml);
+      const starts = Array.from(document.getElementsByTagName('w:bookmarkStart'));
+      const ends = Array.from(document.getElementsByTagName('w:bookmarkEnd'));
+
+      expect(result.remappedRanges).toBe(1);
+      expect(starts.map((start) => [start.getAttribute('w:name'), start.getAttribute('w:id')]))
+        .toEqual([['Inner', '101'], ['Outer', '103']]);
+      expect(ends.map((end) => end.getAttribute('w:id'))).toEqual(['101', '103']);
+    },
+  );
+
+  test('does not conflate a malformed duplicate original bookmark ID', () => {
+    const original = `<w:document xmlns:w="${W_NS}"><w:body><w:p>` +
+      '<w:bookmarkStart w:id="7" w:name="First"/><w:bookmarkEnd w:id="7"/>' +
+      '<w:bookmarkStart w:id="7" w:name="Second"/><w:bookmarkEnd w:id="7"/>' +
+      '</w:p></w:body></w:document>';
+    const revised = `<w:document xmlns:w="${W_NS}"><w:body><w:p>` +
+      '<w:bookmarkStart w:id="7" w:name="Revised"/><w:bookmarkEnd w:id="7"/>' +
+      '</w:p></w:body></w:document>';
+
+    expect(disambiguateOriginalBookmarkIds(original, revised)).toEqual({
+      xml: original,
+      remappedRanges: 0,
+    });
+  });
+
+  test.openspec('Original-side bookmark collisions preserve reference targets')(
+    'rewrites a fragmented PAGEREF and a simple REF with the bookmark',
+    () => {
+      const renames = new Map([['SharedTarget', '_safe_docx_original_1']]);
+      const xml = `<w:document xmlns:w="${W_NS}"><w:body>` +
+        '<w:p><w:bookmarkStart w:id="4" w:name="SharedTarget"/>' +
+        '<w:r><w:t>Original target</w:t></w:r><w:bookmarkEnd w:id="4"/></w:p>' +
+        '<w:p><w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+        '<w:r><w:instrText xml:space="preserve"> PAGE</w:instrText></w:r>' +
+        '<w:r><w:instrText>REF Shared</w:instrText></w:r>' +
+        '<w:r><w:instrText xml:space="preserve">Target \\h </w:instrText></w:r>' +
+        '<w:r><w:fldChar w:fldCharType="separate"/></w:r>' +
+        '<w:r><w:t>1</w:t></w:r><w:r><w:fldChar w:fldCharType="end"/></w:r></w:p>' +
+        '<w:p><w:fldSimple w:instr=" REF SharedTarget \\h "><w:r><w:t>1</w:t></w:r>' +
+        '</w:fldSimple></w:p></w:body></w:document>';
+
+      const rewritten = renameBookmarkTargetsInXml(xml, renames);
+      const document = parseXml(rewritten.xml);
+
+      expect(rewritten).toMatchObject({ renamedBookmarks: 1, rewrittenFields: 2 });
+      expect(document.getElementsByTagName('w:bookmarkStart')[0]
+        ?.getAttribute('w:name')).toBe('_safe_docx_original_1');
+      expect(instruction(rewritten.xml)).toContain(' PAGEREF _safe_docx_original_1 \\h ');
+      expect(document.getElementsByTagName('w:fldSimple')[0]
+        ?.getAttribute('w:instr')).toBe(' REF _safe_docx_original_1 \\h ');
+    },
+  );
+
+  test('uses one deterministic collision-safe map across independent word stories', () => {
+    const renames = createOriginalBookmarkRenameMap(
+      ['SharedTarget'],
+      new Set(['SharedTarget', '_safe_docx_original_1']),
+    );
+    const main = renameBookmarkTargetsInXml(
+      `<w:document xmlns:w="${W_NS}"><w:body><w:p>` +
+        '<w:bookmarkStart w:id="1" w:name="SharedTarget"/><w:bookmarkEnd w:id="1"/>' +
+        '</w:p></w:body></w:document>',
+      renames,
+    );
+    const header = renameBookmarkTargetsInXml(
+      `<w:hdr xmlns:w="${W_NS}"><w:p><w:r><w:fldChar w:fldCharType="begin"/></w:r>` +
+        '<w:r><w:instrText> REF Shared</w:instrText></w:r>' +
+        '<w:r><w:instrText>Target </w:instrText></w:r>' +
+        '<w:r><w:fldChar w:fldCharType="end"/></w:r></w:p></w:hdr>',
+      renames,
+    );
+
+    expect([...renames.entries()]).toEqual([['SharedTarget', '_safe_docx_original_2']]);
+    expect(main.xml).toContain('w:name="_safe_docx_original_2"');
+    expect(instruction(header.xml)).toBe(' REF _safe_docx_original_2 ');
+  });
+
+  test('preserves fragment whitespace and rewrites every supported bookmark reference', () => {
+    const sourceName = 'StraddlingRangeAlphaXY';
+    const generatedName = '_safe_docx_original_1';
+    const renames = new Map([[sourceName, generatedName]]);
+    const xml = `<w:document xmlns:w="${W_NS}"><w:body>` +
+      `<w:p><w:bookmarkStart w:id="7" w:name="${sourceName}"/>` +
+      '<w:r><w:t>Target</w:t></w:r><w:bookmarkEnd w:id="7"/></w:p>' +
+      '<w:p><w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+      '<w:r><w:instrText xml:space="preserve"> REF </w:instrText></w:r>' +
+      `<w:r><w:instrText>${sourceName}</w:instrText></w:r>` +
+      '<w:r><w:instrText xml:space="preserve"> \\h </w:instrText></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="end"/></w:r></w:p>' +
+      `<w:p><w:fldSimple w:instr=" NOTEREF ${sourceName} \\h "/></w:p>` +
+      `<w:p><w:fldSimple w:instr=" HYPERLINK \\l &quot;${sourceName}&quot; "/></w:p>` +
+      `<w:p><w:fldSimple w:instr=" TOC \\b ${sourceName} \\o &quot;1-3&quot; "/></w:p>` +
+      `<w:p><w:hyperlink w:anchor="${sourceName}"><w:r><w:t>Jump</w:t></w:r>` +
+      '</w:hyperlink></w:p></w:body></w:document>';
+
+    const rewritten = renameBookmarkTargetsInXml(xml, renames);
+    const document = parseXml(rewritten.xml);
+    const instructionNodes = Array.from(document.getElementsByTagName('w:instrText'));
+
+    expect(rewritten).toMatchObject({
+      renamedBookmarks: 1,
+      rewrittenFields: 4,
+      rewrittenHyperlinks: 1,
+    });
+    expect(instruction(rewritten.xml)).toBe(` REF ${generatedName} \\h `);
+    expect(instructionNodes[1]?.textContent).toBe(`${generatedName} `);
+    expect(instructionNodes[1]?.getAttribute('xml:space')).toBe('preserve');
+    expect(Array.from(document.getElementsByTagName('w:fldSimple')).map(
+      (field) => field.getAttribute('w:instr'),
+    )).toEqual([
+      ` NOTEREF ${generatedName} \\h `,
+      ` HYPERLINK \\l "${generatedName}" `,
+      ` TOC \\b ${generatedName} \\o "1-3" `,
+    ]);
+    expect(document.getElementsByTagName('w:hyperlink')[0]?.getAttribute('w:anchor'))
+      .toBe(generatedName);
+    expect(collectBookmarkReferenceNamesInXml(rewritten.xml)).toEqual([generatedName]);
+  });
+
+  test('applies one bookmark/field map to every WordprocessingML XML part', async () => {
+    const archive = await DocxArchive.load(await buildDocxFromBodyXml(
+      '<w:p><w:bookmarkStart w:id="1" w:name="SharedTarget"/>' +
+      '<w:r><w:t>Target</w:t></w:r><w:bookmarkEnd w:id="1"/></w:p>',
+    ));
+    archive.setFile(
+      'word/header1.xml',
+      `<w:hdr xmlns:w="${W_NS}"><w:p><w:r><w:fldChar w:fldCharType="begin"/></w:r>` +
+        '<w:r><w:instrText> REF Shared</w:instrText></w:r>' +
+        '<w:r><w:instrText>Target </w:instrText></w:r>' +
+        '<w:r><w:fldChar w:fldCharType="end"/></w:r></w:p></w:hdr>',
+    );
+    const renames = createOriginalBookmarkRenameMap(
+      ['SharedTarget'],
+      await collectWordPartBookmarkNames([archive]),
+    );
+
+    const result = await renameOriginalBookmarkTargetsAcrossWordParts(archive, renames);
+    const header = await archive.getFile('word/header1.xml');
+
+    expect(result).toEqual({
+      renamedBookmarks: 1,
+      rewrittenFields: 1,
+      rewrittenHyperlinks: 0,
+    });
+    expect(await archive.getDocumentXml()).toContain('w:name="_safe_docx_original_1"');
+    expect(instruction(header ?? '')).toBe(' REF _safe_docx_original_1 ');
+  });
+});

--- a/packages/docx-compare/src/tagged/bookmarkProjectionCompatibility.ts
+++ b/packages/docx-compare/src/tagged/bookmarkProjectionCompatibility.ts
@@ -1,0 +1,370 @@
+import { XMLSerializer } from '@xmldom/xmldom';
+import { DocxArchive, parseXml } from '@usejunior/docx-core';
+
+const MAX_BOOKMARK_NAME_LENGTH = 40;
+const GENERATED_NAME_PREFIX = '_safe_docx_original_';
+const XML_NS = 'http://www.w3.org/XML/1998/namespace';
+
+function bookmarkNames(document: Document): string[] {
+  return Array.from(document.getElementsByTagName('w:bookmarkStart'))
+    .map((start) => start.getAttribute('w:name'))
+    .filter((name): name is string => name !== null);
+}
+
+function replaceTargetToken(
+  matched: string,
+  prefix: string,
+  token: string,
+  renames: ReadonlyMap<string, string>,
+): string {
+  const quoted = token.startsWith('"') && token.endsWith('"');
+  const target = quoted ? token.slice(1, -1) : token;
+  const renamed = renames.get(target);
+  if (!renamed) return matched;
+  return `${prefix}${quoted ? `"${renamed}"` : renamed}`;
+}
+
+function instructionBookmarkTargets(instruction: string): string[] {
+  const targets: string[] = [];
+  const capture = (pattern: RegExp): void => {
+    const match = pattern.exec(instruction);
+    const token = match?.[1];
+    if (!token) return;
+    targets.push(token.startsWith('"') && token.endsWith('"') ? token.slice(1, -1) : token);
+  };
+  const keyword = /^\s*([A-Z]+)/iu.exec(instruction)?.[1]?.toUpperCase();
+  if (keyword && ['REF', 'PAGEREF', 'NOTEREF'].includes(keyword)) {
+    capture(/^\s*[A-Z]+\s+("[^"]+"|[^\s\\]+)/iu);
+  } else if (keyword === 'HYPERLINK') {
+    capture(/\\l\s+("[^"]+"|[^\s\\]+)/iu);
+  } else if (keyword === 'TOC') {
+    capture(/\\b\s+("[^"]+"|[^\s\\]+)/iu);
+  }
+  return targets;
+}
+
+function rewriteFieldInstruction(
+  instruction: string,
+  renames: ReadonlyMap<string, string>,
+): string {
+  const keyword = /^\s*([A-Z]+)/iu.exec(instruction)?.[1]?.toUpperCase();
+  if (keyword && ['REF', 'PAGEREF', 'NOTEREF'].includes(keyword)) {
+    return instruction.replace(
+      /^(\s*[A-Z]+\s+)("[^"]+"|[^\s\\]+)/iu,
+      (matched, prefix: string, token: string) =>
+        replaceTargetToken(matched, prefix, token, renames),
+    );
+  }
+  const bookmarkSwitch = keyword === 'HYPERLINK' ? 'l' : keyword === 'TOC' ? 'b' : undefined;
+  if (!bookmarkSwitch) return instruction;
+  const pattern = new RegExp(`(\\\\${bookmarkSwitch}\\s+)("[^"]+"|[^\\s\\\\]+)`, 'iu');
+  return instruction.replace(
+    pattern,
+    (matched, prefix: string, token: string) =>
+      replaceTargetToken(matched, prefix, token, renames),
+  );
+}
+
+function rewriteInstructionFragments(
+  nodes: readonly Element[],
+  renames: ReadonlyMap<string, string>,
+): boolean {
+  if (nodes.length === 0) return false;
+  const fragments = nodes.map((node) => node.textContent ?? '');
+  const rewritten = rewriteFieldInstruction(fragments.join(''), renames);
+  if (rewritten === fragments.join('')) return false;
+
+  let offset = 0;
+  for (let index = 0; index < nodes.length; index++) {
+    const node = nodes[index]!;
+    const length = index === nodes.length - 1
+      ? rewritten.length - offset
+      : Math.min(fragments[index]!.length, rewritten.length - offset);
+    const text = rewritten.slice(offset, offset + Math.max(0, length));
+    node.textContent = text;
+    if (/^\s|\s$/u.test(text)) node.setAttributeNS(XML_NS, 'xml:space', 'preserve');
+    offset += Math.max(0, length);
+  }
+  return true;
+}
+
+function complexFieldInstructions(document: Document): string[] {
+  interface FieldFrame {
+    instructionNodes: Element[];
+    collectingInstruction: boolean;
+  }
+  const instructions: string[] = [];
+  const stack: FieldFrame[] = [];
+  const flush = (frame: FieldFrame | undefined): void => {
+    if (!frame || frame.instructionNodes.length === 0) return;
+    instructions.push(frame.instructionNodes.map((node) => node.textContent ?? '').join(''));
+  };
+  const elements = [document.documentElement, ...Array.from(
+    document.documentElement.getElementsByTagName('*'),
+  )] as Element[];
+  for (const element of elements) {
+    if (element.tagName === 'w:fldChar') {
+      const type = element.getAttribute('w:fldCharType');
+      if (type === 'begin') stack.push({ instructionNodes: [], collectingInstruction: true });
+      else if (type === 'separate') {
+        const frame = stack.at(-1);
+        if (frame?.collectingInstruction) {
+          flush(frame);
+          frame.collectingInstruction = false;
+        }
+      } else if (type === 'end') {
+        const frame = stack.pop();
+        if (frame?.collectingInstruction) flush(frame);
+      }
+      continue;
+    }
+    if (
+      (element.tagName === 'w:instrText' || element.tagName === 'w:delInstrText') &&
+      stack.at(-1)?.collectingInstruction
+    ) stack.at(-1)!.instructionNodes.push(element);
+  }
+  for (const frame of stack) if (frame.collectingInstruction) flush(frame);
+  for (const field of Array.from(document.getElementsByTagName('w:fldSimple'))) {
+    const instruction = field.getAttribute('w:instr');
+    if (instruction !== null) instructions.push(instruction);
+  }
+  return instructions;
+}
+
+/** Collect bookmark names referenced by fields and internal hyperlinks. */
+export function collectBookmarkReferenceNamesInXml(xml: string): string[] {
+  const document = parseXml(xml);
+  const names = new Set(complexFieldInstructions(document).flatMap(instructionBookmarkTargets));
+  for (const hyperlink of Array.from(document.getElementsByTagName('w:hyperlink'))) {
+    const anchor = hyperlink.getAttribute('w:anchor');
+    if (anchor) names.add(anchor);
+  }
+  return [...names].sort();
+}
+
+/**
+ * Rewrite bookmark targets in supported complete, possibly fragmented field
+ * instructions without changing the surrounding run or field topology.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.5.45
+ */
+function rewriteComplexFieldInstructions(
+  document: Document,
+  renames: ReadonlyMap<string, string>,
+): number {
+  interface FieldFrame {
+    instructionNodes: Element[];
+    collectingInstruction: boolean;
+  }
+
+  let rewritten = 0;
+  const stack: FieldFrame[] = [];
+  const elements = [document.documentElement, ...Array.from(
+    document.documentElement.getElementsByTagName('*'),
+  )] as Element[];
+  for (const element of elements) {
+    if (element.tagName === 'w:fldChar') {
+      const type = element.getAttribute('w:fldCharType');
+      if (type === 'begin') {
+        stack.push({ instructionNodes: [], collectingInstruction: true });
+      } else if (type === 'separate') {
+        const frame = stack.at(-1);
+        if (frame?.collectingInstruction) {
+          if (rewriteInstructionFragments(frame.instructionNodes, renames)) rewritten++;
+          frame.collectingInstruction = false;
+        }
+      } else if (type === 'end') {
+        const frame = stack.pop();
+        if (frame?.collectingInstruction &&
+          rewriteInstructionFragments(frame.instructionNodes, renames)) rewritten++;
+      }
+      continue;
+    }
+    if (
+      (element.tagName === 'w:instrText' || element.tagName === 'w:delInstrText') &&
+      stack.at(-1)?.collectingInstruction
+    ) {
+      stack.at(-1)!.instructionNodes.push(element);
+    }
+  }
+  for (const frame of stack) {
+    if (rewriteInstructionFragments(frame.instructionNodes, renames)) rewritten++;
+  }
+  for (const field of Array.from(document.getElementsByTagName('w:fldSimple'))) {
+    const instruction = field.getAttribute('w:instr');
+    if (instruction === null) continue;
+    const replacement = rewriteFieldInstruction(instruction, renames);
+    if (replacement !== instruction) {
+      field.setAttribute('w:instr', replacement);
+      rewritten++;
+    }
+  }
+  return rewritten;
+}
+
+export interface BookmarkTargetRewriteResult {
+  xml: string;
+  renamedBookmarks: number;
+  rewrittenFields: number;
+  rewrittenHyperlinks: number;
+}
+
+export interface BookmarkIdDisambiguationResult {
+  xml: string;
+  remappedRanges: number;
+}
+
+/**
+ * Move original bookmark IDs out of the revised ID namespace when equal IDs
+ * identify differently named ranges. Bookmark IDs are package-local and do
+ * not identify the same semantic range across independently authored files;
+ * disambiguating them before alignment prevents unrelated nested boundaries
+ * from being paired by numeric coincidence.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.6.2
+ */
+export function disambiguateOriginalBookmarkIds(
+  originalXml: string,
+  revisedXml: string,
+): BookmarkIdDisambiguationResult {
+  const original = parseXml(originalXml);
+  const revised = parseXml(revisedXml);
+  const startsById = (document: Document): Map<string, Element[]> => {
+    const grouped = new Map<string, Element[]>();
+    for (const start of Array.from(document.getElementsByTagName('w:bookmarkStart'))) {
+      const id = start.getAttribute('w:id');
+      if (!id) continue;
+      const starts = grouped.get(id) ?? [];
+      starts.push(start);
+      grouped.set(id, starts);
+    }
+    return grouped;
+  };
+  const originalStarts = startsById(original);
+  const revisedStarts = startsById(revised);
+  const usedNumericIds = [original, revised].flatMap((document) => [
+    ...Array.from(document.getElementsByTagName('w:bookmarkStart')),
+    ...Array.from(document.getElementsByTagName('w:bookmarkEnd')),
+  ]).map((boundary) => Number(boundary.getAttribute('w:id')))
+    .filter((id) => Number.isSafeInteger(id) && id >= 0);
+  let nextId = Math.max(-1, ...usedNumericIds) + 1;
+  const replacements = new Map<string, string>();
+  for (const [id, starts] of originalStarts) {
+    if (starts.length !== 1) continue;
+    const originalName = starts[0]!.getAttribute('w:name');
+    const revisedNames = new Set((revisedStarts.get(id) ?? [])
+      .map((start) => start.getAttribute('w:name'))
+      .filter((name): name is string => name !== null));
+    if (!originalName || revisedNames.size === 0 || revisedNames.has(originalName)) continue;
+    replacements.set(id, String(nextId++));
+  }
+  if (replacements.size === 0) return { xml: originalXml, remappedRanges: 0 };
+  for (const tag of ['w:bookmarkStart', 'w:bookmarkEnd']) {
+    for (const boundary of Array.from(original.getElementsByTagName(tag))) {
+      const id = boundary.getAttribute('w:id');
+      const replacement = id === null ? undefined : replacements.get(id);
+      if (replacement) boundary.setAttribute('w:id', replacement);
+    }
+  }
+  return {
+    xml: new XMLSerializer().serializeToString(original),
+    remappedRanges: replacements.size,
+  };
+}
+
+/**
+ * Rename selected bookmark starts and every supported matching field or
+ * internal-hyperlink target in one WordprocessingML story. The same map is
+ * applied to every `word/*.xml` part by
+ * {@link renameOriginalBookmarkTargetsAcrossWordParts}, so references outside
+ * the story that owns the bookmark remain synchronized.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.6.2
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.5.45
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.22
+ */
+export function renameBookmarkTargetsInXml(
+  xml: string,
+  renames: ReadonlyMap<string, string>,
+): BookmarkTargetRewriteResult {
+  const document = parseXml(xml);
+  let renamedBookmarks = 0;
+  for (const start of Array.from(document.getElementsByTagName('w:bookmarkStart'))) {
+    const name = start.getAttribute('w:name');
+    const replacement = name === null ? undefined : renames.get(name);
+    if (!replacement) continue;
+    start.setAttribute('w:name', replacement);
+    renamedBookmarks++;
+  }
+  const rewrittenFields = rewriteComplexFieldInstructions(document, renames);
+  let rewrittenHyperlinks = 0;
+  for (const hyperlink of Array.from(document.getElementsByTagName('w:hyperlink'))) {
+    const anchor = hyperlink.getAttribute('w:anchor');
+    const replacement = anchor === null ? undefined : renames.get(anchor);
+    if (!replacement) continue;
+    hyperlink.setAttribute('w:anchor', replacement);
+    rewrittenHyperlinks++;
+  }
+  return {
+    xml: new XMLSerializer().serializeToString(document),
+    renamedBookmarks,
+    rewrittenFields,
+    rewrittenHyperlinks,
+  };
+}
+
+export function createOriginalBookmarkRenameMap(
+  names: readonly string[],
+  existingNames: ReadonlySet<string>,
+): ReadonlyMap<string, string> {
+  const used = new Set(existingNames);
+  const renames = new Map<string, string>();
+  let ordinal = 1;
+  for (const name of [...new Set(names)].sort()) {
+    let candidate: string;
+    do {
+      candidate = `${GENERATED_NAME_PREFIX}${ordinal++}`.slice(0, MAX_BOOKMARK_NAME_LENGTH);
+    } while (used.has(candidate));
+    used.add(candidate);
+    renames.set(name, candidate);
+  }
+  return renames;
+}
+
+export async function collectWordPartBookmarkNames(
+  archives: readonly DocxArchive[],
+): Promise<Set<string>> {
+  const names = new Set<string>();
+  for (const archive of archives) {
+    for (const path of archive.listFiles().filter((entry) => /^word\/.*\.xml$/u.test(entry))) {
+      const xml = await archive.getFile(path);
+      if (!xml) continue;
+      for (const name of bookmarkNames(parseXml(xml))) names.add(name);
+    }
+  }
+  return names;
+}
+
+export async function renameOriginalBookmarkTargetsAcrossWordParts(
+  archive: DocxArchive,
+  renames: ReadonlyMap<string, string>,
+): Promise<{ renamedBookmarks: number; rewrittenFields: number; rewrittenHyperlinks: number }> {
+  let renamedBookmarks = 0;
+  let rewrittenFields = 0;
+  let rewrittenHyperlinks = 0;
+  for (const path of archive.listFiles().filter((entry) => /^word\/.*\.xml$/u.test(entry)).sort()) {
+    const xml = await archive.getFile(path);
+    if (!xml) continue;
+    const rewritten = renameBookmarkTargetsInXml(xml, renames);
+    if (
+      rewritten.renamedBookmarks === 0 &&
+      rewritten.rewrittenFields === 0 &&
+      rewritten.rewrittenHyperlinks === 0
+    ) continue;
+    archive.setFile(path, rewritten.xml);
+    renamedBookmarks += rewritten.renamedBookmarks;
+    rewrittenFields += rewritten.rewrittenFields;
+    rewrittenHyperlinks += rewritten.rewrittenHyperlinks;
+  }
+  return { renamedBookmarks, rewrittenFields, rewrittenHyperlinks };
+}

--- a/packages/docx-compare/src/tagged/consumerCompatibility-bookmark-ranges.test.ts
+++ b/packages/docx-compare/src/tagged/consumerCompatibility-bookmark-ranges.test.ts
@@ -139,6 +139,15 @@ function rangeText(documentXml: string, id: string): string {
   return text;
 }
 
+function fieldInstructions(documentXml: string): string {
+  const document = parseXml(documentXml);
+  return Array.from(document.getElementsByTagName('*'))
+    .filter((element) =>
+      element.tagName === 'w:instrText' || element.tagName === 'w:delInstrText')
+    .map((element) => element.textContent ?? '')
+    .join('');
+}
+
 const REVISION_WRAPPER_TAGS = ['w:ins', 'w:del', 'w:moveFrom', 'w:moveTo'] as const;
 
 /** Assert every emitted revision wrapper carries a unique `w:id`. */
@@ -152,6 +161,23 @@ function expectUniqueWrapperIds(documentXml: string): void {
     }
   }
   expect(new Set(ids).size).toBe(ids.length);
+}
+
+/** Assert every emitted bookmark start carries a document-unique `w:name`. */
+function expectUniqueBookmarkNames(documentXml: string): void {
+  const body = bodyOf(documentXml);
+  const starts = Array.from(body.getElementsByTagName('w:bookmarkStart'));
+  const names = starts
+    .map((start) => start.getAttribute('w:name'))
+    .filter((name): name is string => name !== null);
+  expect(
+    new Set(names).size,
+    JSON.stringify(starts.map((start) => ({
+      id: start.getAttribute('w:id'),
+      name: start.getAttribute('w:name'),
+      parent: start.parentNode?.nodeName,
+    }))),
+  ).toBe(names.length);
 }
 
 const ORIGINAL_WITH_BOOKMARKED_PARAGRAPH =
@@ -336,6 +362,65 @@ describe('Bookmark ranges survive paragraph-level revisions', () => {
         expect(paragraphChildTags(accepted, 'Trailing survivor')).toContain('w:bookmarkEnd');
       });
     });
+
+  test.openspec('Original-side bookmark collisions preserve reference targets')(
+    'publishes a straddling bookmark under projection-safe names and retargets fragmented REF fields', async (
+    { given, when, then, and }: AllureBddContext
+  ) => {
+    let documentXml: string;
+    const originalReference =
+      '<w:p><w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+      '<w:r><w:instrText xml:space="preserve"> REF Straddling</w:instrText></w:r>' +
+      '<w:r><w:instrText>Range \\h </w:instrText></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="separate"/></w:r><w:r><w:t>clause</w:t></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="end"/></w:r></w:p>';
+    const revisedReference =
+      '<w:p><w:r><w:fldChar w:fldCharType="begin"/></w:r>' +
+      '<w:r><w:instrText xml:space="preserve"> REF StraddlingRange \\h </w:instrText></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="separate"/></w:r><w:r><w:t>clause</w:t></w:r>' +
+      '<w:r><w:fldChar w:fldCharType="end"/></w:r></w:p>';
+
+    await given('both source versions carry the same named bookmark across a deletion boundary', () => {});
+
+    await when('the paragraph containing the original start boundary is deleted', async () => {
+      documentXml = await compare(
+        '<w:p><w:r><w:t xml:space="preserve">doomed paragraph </w:t></w:r>' +
+          '<w:bookmarkStart w:id="1" w:name="StraddlingRange"/>' +
+          '<w:r><w:t>more doomed</w:t></w:r></w:p>' +
+          '<w:p><w:r><w:t xml:space="preserve">surviving text </w:t></w:r>' +
+          '<w:bookmarkEnd w:id="1"/><w:r><w:t>tail</w:t></w:r></w:p>' +
+          originalReference,
+        '<w:p><w:bookmarkStart w:id="1" w:name="StraddlingRange"/>' +
+          '<w:r><w:t xml:space="preserve">surviving text </w:t></w:r>' +
+          '<w:bookmarkEnd w:id="1"/><w:r><w:t>tail</w:t></w:r></w:p>' +
+          revisedReference,
+      );
+    });
+
+    await then('the published document has no duplicate bookmark name and retains both projections', () => {
+      expectUniqueBookmarkNames(documentXml);
+      const document = parseXml(documentXml);
+      const starts = Array.from(document.getElementsByTagName('w:bookmarkStart'));
+      const generated = starts.find((start) =>
+        start.getAttribute('w:name')?.startsWith('_safe_docx_original_'));
+      expect(generated).toBeDefined();
+      const generatedId = generated!.getAttribute('w:id')!;
+      expect(rangeText(acceptAllChanges(documentXml), generatedId)).toBe('surviving text ');
+      expect(rangeText(rejectAllChanges(documentXml), generatedId)).toBe(
+        'doomed paragraph more doomedsurviving text ',
+      );
+    });
+
+    await and('the accepted and rejected field instructions target their own bookmark names', () => {
+      const accepted = fieldInstructions(acceptAllChanges(documentXml));
+      const rejected = fieldInstructions(rejectAllChanges(documentXml));
+      expect(accepted).toContain('REF StraddlingRange \\h');
+      expect(accepted).not.toContain('_safe_docx_original_');
+      expect(rejected).toMatch(/REF _safe_docx_original_\d+ \\h/u);
+      expect(rejected).not.toContain('REF StraddlingRange \\h');
+    });
+  });
+
   test('a deleted bookmark retains its exact source span in the reject projection', async (
     { given, when, then, and }: AllureBddContext
   ) => {

--- a/packages/docx-compare/src/tagged/pipeline-text-box-stories.test.ts
+++ b/packages/docx-compare/src/tagged/pipeline-text-box-stories.test.ts
@@ -111,6 +111,14 @@ function paragraphWithTextBoxStory(
   );
 }
 
+function paragraphWithTextBoxParagraphs(storyParagraphs: string): string {
+  return (
+    '<w:p><w:r><w:pict><v:shape id="bookmark-shape" o:spid="_x0000_s1099">' +
+    '<v:textbox><w:txbxContent>' + storyParagraphs +
+    '</w:txbxContent></v:textbox></v:shape></w:pict></w:r></w:p>'
+  );
+}
+
 /**
  * A DrawingML text box: `wps:txbx/w:txbxContent`, with no VML anywhere.
  *
@@ -307,6 +315,45 @@ function hasTrackedRevisionAncestor(element: Element): boolean {
 }
 
 describe('VML text-box story comparison (#713)', () => {
+  test('reserves generated bookmark names across outer and text-box stories', async () => {
+    const original = await buildDocxFromBodyXml(
+      '<w:p><w:bookmarkStart w:id="1" w:name="OuterRange"/>' +
+        '<w:r><w:t>outer doomed</w:t></w:r></w:p>' +
+        '<w:p><w:r><w:t>outer survivor</w:t></w:r><w:bookmarkEnd w:id="1"/></w:p>' +
+        paragraphWithTextBoxParagraphs(
+          '<w:p w14:paraId="21000001" w14:textId="21000001">' +
+            '<w:bookmarkStart w:id="2" w:name="BoxRange"/>' +
+            '<w:r><w:t>box doomed</w:t></w:r></w:p>' +
+          '<w:p w14:paraId="21000002" w14:textId="21000002">' +
+            '<w:r><w:t>box survivor</w:t></w:r><w:bookmarkEnd w:id="2"/></w:p>',
+        ),
+      [],
+      { namespaces: TEXT_BOX_NAMESPACES },
+    );
+    const revised = await buildDocxFromBodyXml(
+      '<w:p><w:bookmarkStart w:id="1" w:name="OuterRange"/>' +
+        '<w:r><w:t>outer survivor</w:t></w:r><w:bookmarkEnd w:id="1"/></w:p>' +
+        paragraphWithTextBoxParagraphs(
+          '<w:p w14:paraId="21000002" w14:textId="21000002">' +
+            '<w:bookmarkStart w:id="2" w:name="BoxRange"/>' +
+            '<w:r><w:t>box survivor</w:t></w:r><w:bookmarkEnd w:id="2"/></w:p>',
+        ),
+      [],
+      { namespaces: TEXT_BOX_NAMESPACES },
+    );
+
+    const result = await compareDocumentsAtomizer(original, revised);
+    const output = parseXml(await documentXml(result.document));
+    const names = Array.from(output.getElementsByTagName('w:bookmarkStart'))
+      .map((start) => start.getAttribute('w:name'))
+      .filter((name): name is string => name !== null);
+    const generatedNames = names.filter((name) => name.startsWith('_safe_docx_original_'));
+
+    expect(new Set(names).size).toBe(names.length);
+    expect(generatedNames).toHaveLength(2);
+    expect(new Set(generatedNames).size).toBe(2);
+  });
+
   test('emits a text-only revision inside w:txbxContent', async ({
     given,
     when,

--- a/packages/docx-compare/src/tagged/pipeline.ts
+++ b/packages/docx-compare/src/tagged/pipeline.ts
@@ -36,7 +36,7 @@ import {
   parseDocumentXml,
   findBody,
 } from './xmlToWmlElement.js';
-import { childElements, findAllByTagName, getLeafText } from '@usejunior/docx-core';
+import { childElements, findAllByTagName } from '@usejunior/docx-core';
 import {
   acceptAllChanges,
   rejectAllChanges,
@@ -84,6 +84,13 @@ import {
 import { resolveTaggedRevisionAttributions } from './taggedTreeSerializer.js';
 import { enforceConsumerCompatibility } from './consumerCompatibility.js';
 import {
+  collectBookmarkReferenceNamesInXml,
+  collectWordPartBookmarkNames,
+  createOriginalBookmarkRenameMap,
+  disambiguateOriginalBookmarkIds,
+  renameOriginalBookmarkTargetsAcrossWordParts,
+} from './bookmarkProjectionCompatibility.js';
+import {
   allocateRevisionId,
   createRevisionIdState,
 } from './revisionMarkup.js';
@@ -128,6 +135,8 @@ export interface StandaloneTaggedPackageOptions {
   publicationSafetyEvaluator?: typeof evaluateSafetyChecks;
   /** @internal Test seam for the final source-formatting publication gate. */
   formattingFidelityEvaluator?: typeof compareSourceProjectedFormattingFidelity;
+  /** @internal Comparison-wide generated bookmark-name reservations. */
+  bookmarkNameReservations?: Set<string>;
 }
 
 export interface StandaloneTaggedPackageResult {
@@ -322,47 +331,89 @@ export async function buildStandaloneTaggedPackage(
   await restampCollidingCommentParaIds(originalArchive, revisedArchive);
   await renumberCollidingRelationshipIds(originalArchive, revisedArchive);
 
-  const [originalXml, revisedXml, originalNumberingXml, revisedNumberingXml] = await Promise.all([
+  let [originalXml, revisedXml, originalNumberingXml, revisedNumberingXml] = await Promise.all([
     originalArchive.getDocumentXml(),
     revisedArchive.getDocumentXml(),
     originalArchive.getNumberingXml(),
     revisedArchive.getNumberingXml(),
   ]);
+  const disambiguatedBookmarks = disambiguateOriginalBookmarkIds(originalXml, revisedXml);
+  if (disambiguatedBookmarks.remappedRanges > 0) {
+    originalXml = disambiguatedBookmarks.xml;
+    originalArchive.setDocumentXml(originalXml);
+  }
   if (
     !findBody(parseDocumentXml(originalXml)) ||
     !findBody(parseDocumentXml(revisedXml))
   ) {
     throw new Error('Could not find w:body in one or both documents');
   }
-  // Canonicalization needs one relationship table containing both sides, but
-  // that temporary clone is discarded so unused original parts never leak
-  // into the published revised-base package.
-  const canonicalArchive = await revisedArchive.clone();
-  await importReferencedRelationships(originalArchive, canonicalArchive, originalXml);
-  const [taggedOriginalXml, taggedRevisedXml] = await Promise.all([
-    canonicalizeRelationshipReferences(originalXml, originalArchive, canonicalArchive),
-    canonicalizeRelationshipReferences(revisedXml, revisedArchive, canonicalArchive),
-  ]);
-  const taggedPublication = buildTaggedTreePublication({
-    originalXml: taggedOriginalXml,
-    revisedXml: taggedRevisedXml,
-    author: options.author,
-    date: options.date,
-    detectFormatChanges: options.formatDetection.detectFormatChanges,
-    detectMoves: options.moveDetection.detectMoves,
-    moveSimilarityThreshold: options.moveDetection.moveSimilarityThreshold,
-    moveMinimumWordCount: options.moveDetection.moveMinimumWordCount,
-    caseInsensitiveMove: options.moveDetection.caseInsensitiveMove,
-    numberingEnabled: options.numbering.enabled,
-    originalNumberingXml: originalNumberingXml ?? undefined,
-    revisedNumberingXml: revisedNumberingXml ?? undefined,
-    revisionAttributionRanges: options.revisionAttributionRanges,
-    retainStatisticsMarkers: true,
-  });
-  const finalizedPublication = consumeTaggedPublicationStatistics(
-    finalizeTaggedDocumentXml(taggedPublication.xml),
-    taggedPublication.stats,
+  const publish = async (): Promise<{
+    taggedOriginalXml: string;
+    taggedRevisedXml: string;
+    finalizedPublication: ReturnType<typeof consumeTaggedPublicationStatistics>;
+  }> => {
+    // Canonicalization needs one relationship table containing both sides, but
+    // that temporary clone is discarded so unused original parts never leak
+    // into the published revised-base package.
+    const canonicalArchive = await revisedArchive.clone();
+    await importReferencedRelationships(originalArchive, canonicalArchive, originalXml);
+    const [taggedOriginalXml, taggedRevisedXml] = await Promise.all([
+      canonicalizeRelationshipReferences(originalXml, originalArchive, canonicalArchive),
+      canonicalizeRelationshipReferences(revisedXml, revisedArchive, canonicalArchive),
+    ]);
+    const taggedPublication = buildTaggedTreePublication({
+      originalXml: taggedOriginalXml,
+      revisedXml: taggedRevisedXml,
+      author: options.author,
+      date: options.date,
+      detectFormatChanges: options.formatDetection.detectFormatChanges,
+      detectMoves: options.moveDetection.detectMoves,
+      moveSimilarityThreshold: options.moveDetection.moveSimilarityThreshold,
+      moveMinimumWordCount: options.moveDetection.moveMinimumWordCount,
+      caseInsensitiveMove: options.moveDetection.caseInsensitiveMove,
+      numberingEnabled: options.numbering.enabled,
+      originalNumberingXml: originalNumberingXml ?? undefined,
+      revisedNumberingXml: revisedNumberingXml ?? undefined,
+      revisionAttributionRanges: options.revisionAttributionRanges,
+      retainStatisticsMarkers: true,
+    });
+    return {
+      taggedOriginalXml,
+      taggedRevisedXml,
+      finalizedPublication: consumeTaggedPublicationStatistics(
+        finalizeTaggedDocumentXml(taggedPublication.xml),
+        taggedPublication.stats,
+      ),
+    };
+  };
+
+  let publication = await publish();
+  const originalBookmarks = collectBookmarkDiagnostics(originalXml);
+  const revisedBookmarks = collectBookmarkDiagnostics(revisedXml);
+  const generatedDuplicateNames = collectBookmarkDiagnostics(
+    publication.finalizedPublication.xml,
+  ).duplicateStartNames.filter((name) =>
+    originalBookmarks.startNames.includes(name) &&
+    revisedBookmarks.startNames.includes(name) &&
+    !originalBookmarks.duplicateStartNames.includes(name) &&
+    !revisedBookmarks.duplicateStartNames.includes(name),
   );
+  if (generatedDuplicateNames.length > 0) {
+    const existingNames = await collectWordPartBookmarkNames([
+      originalArchive,
+      revisedArchive,
+    ]);
+    const reservedNames = options.bookmarkNameReservations ?? new Set<string>();
+    for (const name of existingNames) reservedNames.add(name);
+    const renames = createOriginalBookmarkRenameMap(generatedDuplicateNames, reservedNames);
+    for (const name of renames.values()) reservedNames.add(name);
+    await renameOriginalBookmarkTargetsAcrossWordParts(originalArchive, renames);
+    originalXml = await originalArchive.getDocumentXml();
+    originalNumberingXml = await originalArchive.getNumberingXml();
+    publication = await publish();
+  }
+  const { taggedOriginalXml, taggedRevisedXml, finalizedPublication } = publication;
   let taggedXml = finalizedPublication.xml;
   let revisionAttributions: RevisionAttribution[] | undefined;
   if ((options.revisionAttributionRanges?.length ?? 0) > 0) {
@@ -862,29 +913,6 @@ interface BookmarkDiagnostics {
   unmatchedEndIds: string[];
 }
 
-function arraysEqual(a: string[], b: string[]): boolean {
-  if (a.length !== b.length) return false;
-  for (let i = 0; i < a.length; i++) {
-    if (a[i] !== b[i]) return false;
-  }
-  return true;
-}
-
-function collectReferencedBookmarkNames(root: ReturnType<typeof parseDocumentXml>): string[] {
-  const refs = new Set<string>();
-  const refRegex = /\b(?:PAGEREF|REF)\s+([^\s\\]+)/g;
-
-  for (const node of findAllByTagName(root, 'w:instrText')) {
-    const instr = getLeafText(node) ?? '';
-    for (const match of instr.matchAll(refRegex)) {
-      const name = match[1]?.trim();
-      if (name) refs.add(name);
-    }
-  }
-
-  return Array.from(refs).sort();
-}
-
 function collectBookmarkDiagnostics(documentXml: string): BookmarkDiagnostics {
   const root = parseDocumentXml(documentXml);
 
@@ -918,7 +946,7 @@ function collectBookmarkDiagnostics(documentXml: string): BookmarkDiagnostics {
   const startIds = Array.from(startSet).sort();
   const endIds = Array.from(endSet).sort();
   const startNames = Array.from(startNameSet).sort();
-  const referencedBookmarkNames = collectReferencedBookmarkNames(root);
+  const referencedBookmarkNames = collectBookmarkReferenceNamesInXml(documentXml);
   const unresolvedReferenceNames = referencedBookmarkNames
     .filter((name) => !startNameSet.has(name))
     .sort();
@@ -940,25 +968,56 @@ function collectBookmarkDiagnostics(documentXml: string): BookmarkDiagnostics {
 }
 
 /**
- * Bookmark round-trip safety is semantic, not byte/ID exact:
- * - Bookmark IDs may be renumbered by reconstruction/Word and still be valid.
- * - Bookmark names and field-reference targets must stay intact.
- * - Structural integrity (balanced, no duplicates) must remain intact.
+ * Bookmark publication can normalize IDs and which source marker carries a
+ * name, but it must not introduce structural or reference anomalies absent
+ * from the corresponding source inventory.
  */
-function bookmarkDiagnosticsSemanticallyEqual(
-  expected: BookmarkDiagnostics,
-  actual: BookmarkDiagnostics
+function containsNoNewValues(actual: string[], allowed: ReadonlySet<string>): boolean {
+  return actual.every((value) => allowed.has(value));
+}
+
+function bookmarkDiagnosticsIntroduceNoStructuralAnomalies(
+  actual: BookmarkDiagnostics,
+  allowed: BookmarkDiagnostics,
 ): boolean {
-  return (
-    arraysEqual(expected.startNames, actual.startNames) &&
-    arraysEqual(expected.duplicateStartNames, actual.duplicateStartNames) &&
-    arraysEqual(expected.referencedBookmarkNames, actual.referencedBookmarkNames) &&
-    arraysEqual(expected.unresolvedReferenceNames, actual.unresolvedReferenceNames) &&
-    arraysEqual(expected.duplicateStartIds, actual.duplicateStartIds) &&
-    arraysEqual(expected.duplicateEndIds, actual.duplicateEndIds) &&
-    arraysEqual(expected.unmatchedStartIds, actual.unmatchedStartIds) &&
-    arraysEqual(expected.unmatchedEndIds, actual.unmatchedEndIds)
+  return containsNoNewValues(
+    actual.duplicateStartNames,
+    new Set(allowed.duplicateStartNames),
+  ) && containsNoNewValues(
+    actual.unresolvedReferenceNames,
+    new Set(allowed.unresolvedReferenceNames),
+  ) && containsNoNewValues(
+    actual.duplicateStartIds,
+    new Set(allowed.duplicateStartIds),
+  ) && containsNoNewValues(
+    actual.duplicateEndIds,
+    new Set(allowed.duplicateEndIds),
   );
+}
+
+function combinedBookmarkAllowance(
+  original: BookmarkDiagnostics,
+  revised: BookmarkDiagnostics,
+): BookmarkDiagnostics {
+  const union = (left: string[], right: string[]): string[] => [...new Set([...left, ...right])];
+  return {
+    startIds: union(original.startIds, revised.startIds),
+    endIds: union(original.endIds, revised.endIds),
+    startNames: union(original.startNames, revised.startNames),
+    duplicateStartNames: union(original.duplicateStartNames, revised.duplicateStartNames),
+    referencedBookmarkNames: union(
+      original.referencedBookmarkNames,
+      revised.referencedBookmarkNames,
+    ),
+    unresolvedReferenceNames: union(
+      original.unresolvedReferenceNames,
+      revised.unresolvedReferenceNames,
+    ),
+    duplicateStartIds: union(original.duplicateStartIds, revised.duplicateStartIds),
+    duplicateEndIds: union(original.duplicateEndIds, revised.duplicateEndIds),
+    unmatchedStartIds: union(original.unmatchedStartIds, revised.unmatchedStartIds),
+    unmatchedEndIds: union(original.unmatchedEndIds, revised.unmatchedEndIds),
+  };
 }
 
 function diffIds(expected: string[], actual: string[]): { missing: string[]; unexpected: string[] } {
@@ -1170,17 +1229,24 @@ function evaluateSafetyChecks(
   const rejectedText = extractRoundTripComparisonText(rejectedXml);
   const acceptedBookmarkDiagnostics = collectBookmarkDiagnostics(acceptedXml);
   const rejectedBookmarkDiagnostics = collectBookmarkDiagnostics(rejectedXml);
+  const combinedBookmarkDiagnostics = collectBookmarkDiagnostics(candidateXml);
   const acceptTextComparison = compareTexts(revisedTextForRoundTrip, acceptedText);
   const rejectTextComparison = compareTexts(originalTextForRoundTrip, rejectedText);
 
-  const acceptBookmarksOk = bookmarkDiagnosticsSemanticallyEqual(
-    revisedBookmarkDiagnostics,
-    acceptedBookmarkDiagnostics
+  const combinedBookmarksOk = bookmarkDiagnosticsIntroduceNoStructuralAnomalies(
+    combinedBookmarkDiagnostics,
+    combinedBookmarkAllowance(originalBookmarkDiagnostics, revisedBookmarkDiagnostics),
   );
-  const rejectBookmarksOk = bookmarkDiagnosticsSemanticallyEqual(
-    originalBookmarkDiagnostics,
-    rejectedBookmarkDiagnostics
-  );
+  const acceptBookmarksOk = combinedBookmarksOk &&
+    bookmarkDiagnosticsIntroduceNoStructuralAnomalies(
+      acceptedBookmarkDiagnostics,
+      revisedBookmarkDiagnostics,
+    );
+  const rejectBookmarksOk = combinedBookmarksOk &&
+    bookmarkDiagnosticsIntroduceNoStructuralAnomalies(
+      rejectedBookmarkDiagnostics,
+      originalBookmarkDiagnostics,
+    );
 
   // Validate field structure for the main-story round-trip projection. Final
   // note entries are validated after mode-specific assembly, where the gate
@@ -1207,11 +1273,14 @@ function evaluateSafetyChecks(
   const checks: ReconstructionSafetyChecks = {
     acceptText: acceptTextComparison.normalizedIdentical,
     rejectText: rejectTextComparison.normalizedIdentical,
-    // Bookmark checks are soft: consumer compatibility pass legitimately alters
-    // bookmarks (deduplication, orphan repair, hoisting out of revision wrappers).
-    // Log mismatches in diagnostics but don't trigger fallback to rebuild.
-    acceptBookmarks: true,
-    rejectBookmarks: true,
+    // Hoisting may intentionally normalize which source marker carries a
+    // bookmark name, so source-inventory equality is too strict. Publication
+    // still fails closed on new balance, uniqueness, and reference anomalies
+    // in the combined document or either projection. An anomaly already
+    // present in a source remains diagnostic rather than being silently
+    // repaired by the tagged path.
+    acceptBookmarks: acceptBookmarksOk,
+    rejectBookmarks: rejectBookmarksOk,
     fieldStructure: fieldStructureOk,
   };
 
@@ -1228,8 +1297,6 @@ function evaluateSafetyChecks(
   if (!checks.rejectText) {
     failureDetails.rejectText = buildTextMismatchDetails(originalTextForRoundTrip, rejectedText);
   }
-  // Bookmark mismatches are always collected for diagnostics even though the
-  // check itself is soft (doesn't trigger fallback).
   if (!acceptBookmarksOk) {
     failureDetails.acceptBookmarks = buildBookmarkMismatchDetails(
       revisedBookmarkDiagnostics,
@@ -1257,6 +1324,7 @@ async function compareDocumentsTaggedCore(
   original: Buffer,
   revised: Buffer,
   options: AtomizerOptions,
+  bookmarkNameReservations?: Set<string>,
 ): Promise<AtomizerCompareResult> {
   const standalone = await buildStandaloneTaggedPackage(original, revised, {
     author: options.author ?? 'Comparison',
@@ -1276,6 +1344,7 @@ async function compareDocumentsTaggedCore(
     revisionAttributionRanges: options.revisionAttributionRanges,
     publicationSafetyEvaluator: options.taggedTreePublicationSafetyEvaluator,
     formattingFidelityEvaluator: options.taggedTreeFormattingFidelityEvaluator,
+    bookmarkNameReservations,
   });
   if (options.standaloneTaggedPackageShadowObserver) {
     await options.standaloneTaggedPackageShadowObserver(
@@ -1322,10 +1391,19 @@ async function compareDocumentsTagged(
         ? (report) => { standaloneShadowReports.push(report); }
         : options.standaloneTaggedPackageShadowObserver,
   };
+  const [originalArchive, revisedArchive] = await Promise.all([
+    DocxArchive.load(original),
+    DocxArchive.load(revised),
+  ]);
+  const bookmarkNameReservations = await collectWordPartBookmarkNames([
+    originalArchive,
+    revisedArchive,
+  ]);
   const outerResult = await compareDocumentsTaggedCore(
     textBoxPlan.outerOriginal,
     textBoxPlan.outerRevised,
     nestedOptions,
+    bookmarkNameReservations,
   );
 
   const storyResults: Array<{
@@ -1351,6 +1429,7 @@ async function compareDocumentsTagged(
       story.original,
       story.container === 'ancillaryPart' ? story.original : story.revised,
       nestedOptions,
+      bookmarkNameReservations,
     );
     if (story.container === 'ancillaryPart') {
       const marked = await markInsertedAncillaryStoryParagraphs(
@@ -1396,6 +1475,23 @@ async function compareDocumentsTagged(
   );
   const comparedArchive = await DocxArchive.load(document);
   const comparedDocumentXml = await comparedArchive.getDocumentXml();
+  const assembledBookmarkDiagnostics = collectBookmarkDiagnostics(comparedDocumentXml);
+  const sourceDuplicateBookmarkNames = new Set([
+    ...collectBookmarkDiagnostics(textBoxPlan.originalDocumentXml).duplicateStartNames,
+    ...collectBookmarkDiagnostics(textBoxPlan.revisedDocumentXml).duplicateStartNames,
+  ]);
+  const introducedDuplicateBookmarkNames =
+    assembledBookmarkDiagnostics.duplicateStartNames.filter(
+      (name) => !sourceDuplicateBookmarkNames.has(name),
+    );
+  if (introducedDuplicateBookmarkNames.length > 0) {
+    throw new UnsupportedTextBoxRevisionError([{
+      index: textBoxPlan.stories[0]?.visualIndex ?? 0,
+      partPath: textBoxPlan.stories[0]?.partPath ?? 'word/document.xml',
+      reason: 'assembled nested stories introduced duplicate bookmark names: ' +
+        introducedDuplicateBookmarkNames.join(', '),
+    }]);
+  }
   const acceptedComparison = compareTexts(
     extractRoundTripComparisonText(textBoxPlan.revisedDocumentXml),
     extractRoundTripComparisonText(acceptAllChanges(comparedDocumentXml)),

--- a/packages/docx-core/src/integration/round-trip.test.ts
+++ b/packages/docx-core/src/integration/round-trip.test.ts
@@ -42,6 +42,29 @@ const REVISED_DOC = join(
   'tests/test_documents/redline/ILPA-Model-Limited-Parnership-Agreement-Deal-By-Deal_v1.docx'
 );
 
+interface IlpaRoundTripFixture {
+  originalBuffer: Buffer;
+  revisedBuffer: Buffer;
+  comparisonResult: Awaited<ReturnType<typeof compareDocuments>>;
+}
+
+let ilpaRoundTripFixturePromise: Promise<IlpaRoundTripFixture> | undefined;
+const ILPA_COMPARISON_HOOK_TIMEOUT_MS = 300_000;
+
+function loadIlpaRoundTripFixture(): Promise<IlpaRoundTripFixture> {
+  ilpaRoundTripFixturePromise ??= (async () => {
+    const [originalBuffer, revisedBuffer] = await Promise.all([
+      readFile(ORIGINAL_DOC),
+      readFile(REVISED_DOC),
+    ]);
+    const comparisonResult = await compareDocuments(originalBuffer, revisedBuffer, {
+      date: FIXTURE_STABLE_DATE,
+    });
+    return { originalBuffer, revisedBuffer, comparisonResult };
+  })();
+  return ilpaRoundTripFixturePromise;
+}
+
 // Test fixtures
 const fixturesPath = join(dirname(import.meta.url.replace('file://', '')), '../testing/fixtures');
 
@@ -179,19 +202,14 @@ describe('Round-Trip Tests - Accept All Changes', () => {
   });
 
   describe('Large Documents (ILPA)', () => {
-    let originalBuffer: Buffer;
     let revisedBuffer: Buffer;
     let comparisonResult: Awaited<ReturnType<typeof compareDocuments>>;
 
     beforeAll(async () => {
-      originalBuffer = await readFile(ORIGINAL_DOC);
-      revisedBuffer = await readFile(REVISED_DOC);
-      comparisonResult = await compareDocuments(originalBuffer, revisedBuffer, {
-        date: FIXTURE_STABLE_DATE,
-      });
-    // V8 coverage instrumentation pushes the sole tagged comparison spine past
-    // the historical 120-second ceiling on CI-class hosts.
-    }, 180000);
+      ({ revisedBuffer, comparisonResult } = await loadIlpaRoundTripFixture());
+    // V8 coverage plus bookmark-collision repair can push this real comparison
+    // close to the historical 180-second ceiling on CI-class hosts.
+    }, ILPA_COMPARISON_HOOK_TIMEOUT_MS);
 
     test('accept all changes should produce text matching revised document', async ({ given, when, then }: AllureBddContext) => {
       await given('ILPA comparison result is pre-computed in beforeAll', () => {});
@@ -365,17 +383,12 @@ describe('Round-Trip Tests - Reject All Changes', () => {
 
   describe('Large Documents (ILPA)', () => {
     let originalBuffer: Buffer;
-    let revisedBuffer: Buffer;
     let comparisonResult: Awaited<ReturnType<typeof compareDocuments>>;
 
     beforeAll(async () => {
-      originalBuffer = await readFile(ORIGINAL_DOC);
-      revisedBuffer = await readFile(REVISED_DOC);
-      comparisonResult = await compareDocuments(originalBuffer, revisedBuffer, {
-        date: FIXTURE_STABLE_DATE,
-      });
+      ({ originalBuffer, comparisonResult } = await loadIlpaRoundTripFixture());
     // Keep the reject projection on the same coverage-aware budget as accept.
-    }, 180000);
+    }, ILPA_COMPARISON_HOOK_TIMEOUT_MS);
 
     test('reject all changes should produce text matching original document', async ({ given, when, then }: AllureBddContext) => {
       await given('ILPA comparison result is pre-computed in beforeAll', () => {});

--- a/packages/docx-core/src/integration/stability-invariants.test.ts
+++ b/packages/docx-core/src/integration/stability-invariants.test.ts
@@ -261,10 +261,10 @@ describe('Stability invariants', () => {
         expect(first.failedChecks).toEqual(second.failedChecks);
       });
     },
-    // V8 coverage instrumentation compounds across the two concurrent ILPA
-    // comparisons now that the tagged path is the sole comparison spine. Keep
-    // the determinism assertion strict without racing the instrumented runner.
-    360000
+    // V8 coverage plus bookmark-collision repair compounds across these two
+    // intentionally independent ILPA comparisons. Keep the determinism
+    // assertion strict without racing a CI-class instrumented runner.
+    600000
   );
 
   for (const mode of MODES) {

--- a/packages/docx-core/src/testing/DOCX_COMPARISON_OPENSPEC_TRACEABILITY.md
+++ b/packages/docx-core/src/testing/DOCX_COMPARISON_OPENSPEC_TRACEABILITY.md
@@ -20,6 +20,7 @@ This matrix maps docx-core OpenSpec `#### Scenario:` entries to scenario mapping
 | Contained phrase scores complete containment | covered | `packages/docx-compare/src/openspec.traceability.test.ts` |  |
 | Continuation pattern inherits formatting | covered | `packages/docx-compare/src/openspec.traceability.test.ts` |  |
 | Contract violations name the offending node | covered | `packages/docx-compare/src/tagged/taggedTree.test.ts` |  |
+| Cross-version bookmark IDs are package-local | covered | `packages/docx-compare/src/tagged/bookmarkProjectionCompatibility.test.ts` |  |
 | Custom footnote marks respected | covered | `packages/docx-compare/src/openspec.traceability.test.ts` |  |
 | Custom threshold applied | covered | `packages/docx-compare/src/openspec.traceability.test.ts` |  |
 | Element with attributes | covered | `packages/docx-compare/src/openspec.traceability.test.ts` |  |
@@ -44,6 +45,7 @@ This matrix maps docx-core OpenSpec `#### Scenario:` entries to scenario mapping
 | Multiple operations retain disjoint rationale ranges | covered | `packages/docx-compare/src/integration/tagged-rationale-attribution.test.ts` |  |
 | Multiple properties changed | covered | `packages/docx-compare/src/openspec.traceability.test.ts` |  |
 | One package preserves both source projections | covered | `packages/docx-compare/src/tagged/relationshipIdCollision.test.ts` |  |
+| Original-side bookmark collisions preserve reference targets | covered | `packages/docx-compare/src/tagged/bookmarkProjectionCompatibility.test.ts`, `packages/docx-compare/src/tagged/consumerCompatibility-bookmark-ranges.test.ts` |  |
 | Orphan list item renders with parent format | covered | `packages/docx-compare/src/openspec.traceability.test.ts` |  |
 | Paired paragraph representatives are not moves | covered | `packages/docx-compare/src/tagged/taggedTreeConstruction.test.ts` |  |
 | Part from main document | covered | `packages/docx-compare/src/openspec.traceability.test.ts` |  |


### PR DESCRIPTION
## Summary

- disambiguate original-side bookmark IDs before alignment when independently authored packages reuse an ID for differently named ranges
- deterministically namespace original-side duplicate bookmark names and rewrite complete/fragmented REF, PAGEREF, NOTEREF, HYPERLINK, TOC, simple-field, and internal hyperlink targets across `word/*.xml`
- make publication gates reject newly introduced bookmark-name, reference, and duplicate-boundary anomalies while tolerating source-preexisting defects
- reserve generated names across outer and text-box stories and cover both public ILPA comparison directions
- align the canonical/archived OpenSpec and deterministic public-corpus manifest evidence

## Validation

- `npm run build && npm run lint:workspaces`
- `npm run test:run` (sandbox-blocked IPC/LibreOffice cases rerun outside the sandbox: green)
- `npm run check:spec-coverage`
- `npm run check:conformance-citations`
- `npm run check:conformance-doc`
- `openspec validate --specs --strict` (8/8)
- focused bookmark/text-box suite: 48/48
- full `@usejunior/docx-compare` suite: 469 passed, 17 skipped
- bidirectional public ILPA production comparisons: combined + Accept All + Reject All have unique/balanced bookmark ranges and resolved supported targets
- public 23-row strategy manifest regenerated and repeat-checked for determinism
- schema checker reproduces the same pre-existing move-range/section-property classes on unmodified `origin/main`; tracked separately under #926
- dynamic Claude Opus 4.6 review: **APPROVE**, with independent build, focused tests, bidirectional ILPA, conformance, OpenSpec, and diff-scope verification

## Scope

This PR contains only the bookmark runtime/publication-gate concern. It does not remove shadow-observer APIs or include sibling formatting, statistics, or fixture-cleanup work.

Ref: #915
Ref: #916
