### PR TITLE
test(docx-compare): enforce fail-closed corpus evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -435,10 +435,6 @@ jobs:
           done
           echo "npm ci failed after 3 attempts"
           exit 1
-      - name: Run checked-in standalone tagged-package gate
-        run: >-
-          npm run test:run -w @usejunior/docx-compare --
-          src/integration/taggedTreeMinimality.corpus.test.ts
       - name: Materialize SHA-256-verified comparison corpus
         env:
           SAFE_DOCX_REAL_CORPUS_DIR: ${{ runner.temp }}/open-agreements-cache
@@ -448,10 +444,7 @@ jobs:
           SAFE_DOCX_REAL_CORPUS_DIR: ${{ runner.temp }}/open-agreements-cache
           SAFE_DOCX_REAL_CORPUS_REQUIRED: "1"
           SAFE_DOCX_STRATEGY_DIFFERENTIAL_REQUIRED: "1"
-        run: >-
-          npm run test:run -w @usejunior/docx-compare --
-          src/integration/real-corpus-paragraph-deletion.test.ts
-          src/integration/strategy-differential-manifest.corpus.test.ts
+        run: npm run test:real-corpus -w @usejunior/docx-compare
 
   mcpb-bundle:
     runs-on: ubuntu-latest

--- a/openspec/specs/docx-comparison/spec.md
+++ b/openspec/specs/docx-comparison/spec.md
@@ -543,19 +543,19 @@ representation is exercised on any other class of input.
 
 ### Requirement: Tagged migration evidence is capability-complete
 
-Before a legacy comparison capability is removed or changed, the system SHALL
-record that capability in a committed legacy-versus-tagged characterization
+Before a comparison capability is removed or changed, the system SHALL record
+that capability in a committed tagged-tree characterization
 manifest. Each fixture row SHALL identify and hash the fixture, list exercised
 capabilities and package parts, report original/revised projection results,
-summarize normalized package parts and public statistics, and record fallback,
-schema, formatting, relationship, auxiliary-definition, unrepresented-change,
-and unsupported-story diagnostics.
+summarize normalized package parts and public statistics, and record tagged-tree
+authority, schema, formatting, relationship, auxiliary-definition,
+unrepresented-change, and unsupported-story diagnostics.
 
-Legacy equality SHALL be characterization rather than a correctness oracle. A
-known difference SHALL carry a stable, explicitly adjudicated divergence ID.
+Historical equality SHALL be characterization rather than a correctness oracle.
+A known difference SHALL carry a stable, explicitly adjudicated divergence ID.
 The harness SHALL fail when its corpus is unavailable, a fixture or exercised
-package part disappears, either strategy falls back, or a divergence changes
-without review.
+package part disappears, tagged-tree does not retain sole comparison authority,
+or a divergence changes without review.
 
 #### Scenario: Missing corpus evidence fails loudly
 

--- a/packages/docx-compare/package.json
+++ b/packages/docx-compare/package.json
@@ -11,6 +11,7 @@
     "dev": "tsc -p tsconfig.build.json --watch",
     "test": "node ../../node_modules/vitest/vitest.mjs",
     "test:run": "node ../../node_modules/vitest/vitest.mjs run",
+    "test:real-corpus": "node ../../node_modules/vitest/vitest.mjs run -c vitest.corpus.config.ts",
     "test:baseline": "node ../../node_modules/vitest/vitest.mjs run -c vitest.baseline.config.ts",
     "test:coverage": "node ../../node_modules/vitest/vitest.mjs run --coverage --coverage.reporter=text-summary --coverage.reporter=json-summary --coverage.reporter=lcov",
     "check:api-removal-inventory": "node scripts/generate-api-removal-inventory.mjs --check",

--- a/packages/docx-compare/src/integration/private-comparison-corpus.corpus.test.ts
+++ b/packages/docx-compare/src/integration/private-comparison-corpus.corpus.test.ts
@@ -74,7 +74,6 @@ async function loadFixture(entry: PrivateCorpusEntry): Promise<StrategyDifferent
     revised,
     capabilityTags: entry.capabilityTags,
     expectedPackageParts: ['word/document.xml', 'word/_rels/document.xml.rels'],
-    approvedDivergenceIds: ['TD-ATOM-STATS-SEMANTICS-001'],
   };
 }
 
@@ -119,9 +118,8 @@ describe.skipIf(!available)('private comparison corpus safety', () => {
     test(`preserves projections and package safety for ${entry.id}`, async () => {
       const fixture = await loadFixture(entry);
       const row = await characterizeStrategyDifferential(fixture);
-      assertCharacterizationSafety(row, new Set(['tagged-tree.atomStatisticsSemantics']));
+      assertCharacterizationSafety(row);
       assertExpectedPackageParts(fixture, row);
-      expect(row.taggedTree.forbiddenPayloadLeaks).toEqual([]);
       expect(row.taggedTree.unsupportedStoryDiagnostics).toEqual([]);
     }, 180_000);
   }

--- a/packages/docx-compare/src/integration/strategy-differential-fixtures.ts
+++ b/packages/docx-compare/src/integration/strategy-differential-fixtures.ts
@@ -14,8 +14,6 @@ const FIXTURE_MANIFEST_PATH = resolve(
   REPO_ROOT,
   'packages/docx-compare/src/testing/fixtures/manifest.json',
 );
-const TAGGED_ATOM_STATISTICS_DIVERGENCE = 'TD-ATOM-STATS-SEMANTICS-001';
-
 interface FixtureManifest {
   base_dir: string;
   fixtures: Array<{
@@ -40,12 +38,9 @@ async function loadCheckedInFixtures(): Promise<StrategyDifferentialFixture[]> {
         : []),
     ],
     expectedPackageParts: ['word/document.xml', 'word/_rels/document.xml.rels'],
-    approvedDivergenceIds:
-      fixture.name === 'ILPA'
-        ? [
-            'TD-LEGACY-ILPA-REJECT-001',
-          ]
-        : [],
+    approvedDivergenceIds: fixture.name === 'ILPA'
+      ? ['TD-ILPA-SECTION-REL-001']
+      : [],
   })));
 }
 
@@ -127,7 +122,6 @@ async function loadMoveCapabilityFixture(): Promise<StrategyDifferentialFixture>
     revised,
     capabilityTags: ['moves', 'paragraph-reorder', 'range-boundaries'],
     expectedPackageParts: ['word/document.xml', 'word/_rels/document.xml.rels'],
-    approvedDivergenceIds: ['TD-LEGACY-MOVE-PROJECTION-001'],
   };
 }
 
@@ -171,12 +165,5 @@ export async function loadStrategyDifferentialFixtures(
     loadRealCorpusFixtures(corpusRoot),
   ]);
   return [...checkedIn, ancillary, textBox, move, ...real]
-    .map((fixture) => ({
-      ...fixture,
-      approvedDivergenceIds: [
-        ...(fixture.approvedDivergenceIds ?? []),
-        TAGGED_ATOM_STATISTICS_DIVERGENCE,
-      ],
-    }))
     .sort((left, right) => left.id.localeCompare(right.id));
 }

--- a/packages/docx-compare/src/integration/strategy-differential-harness.ts
+++ b/packages/docx-compare/src/integration/strategy-differential-harness.ts
@@ -1,5 +1,11 @@
 import { createHash } from 'node:crypto';
-import { checkGeneratedPackage, parseXml } from '@usejunior/docx-core';
+import {
+  checkGeneratedPackage,
+  collectFieldStructureIssues,
+  parseXml,
+  REVISION_ID_ELEMENT_NAMES,
+  validateBookmarkIntegrity,
+} from '@usejunior/docx-core';
 import JSZip from 'jszip';
 import type {
   CompareResult,
@@ -18,6 +24,7 @@ import { extractRoundTripComparisonText } from '../fieldComparisonSemantics.js';
 const AUTHOR = 'Strategy Differential';
 const DATE = new Date('2026-08-17T12:00:00Z');
 const XML_PART_PATTERN = /(?:\.xml|\.rels)$/u;
+const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 
 export interface StrategyDifferentialFixture {
   id: string;
@@ -25,17 +32,13 @@ export interface StrategyDifferentialFixture {
   revised: Buffer;
   capabilityTags: string[];
   expectedPackageParts?: string[];
-  forbiddenPayloads?: string[];
   approvedDivergenceIds?: string[];
 }
 
 export type ApprovedDivergenceDimension =
-  | 'legacy-tagged.semanticDifference'
-  | 'legacy.acceptProjection'
-  | 'legacy.rejectProjection'
   | 'tagged-tree.acceptProjection'
   | 'tagged-tree.rejectProjection'
-  | 'tagged-tree.atomStatisticsSemantics';
+  | 'tagged-tree.formattingFidelity';
 
 export interface PackagePartSummary {
   path: string;
@@ -66,11 +69,8 @@ export interface StrategyEvidence {
   };
   packageParts: PackagePartSummary[];
   stats: CompareStats;
-  fallback: {
+  authority: {
     comparisonStrategyUsed?: ComparisonStrategy;
-    comparisonStrategyFallbackReason?: string;
-    reconstructionModeUsed?: string;
-    fallbackReason?: string;
   };
   unrepresentedChanges: UnrepresentedChange[];
   schema: {
@@ -89,8 +89,13 @@ export interface StrategyEvidence {
     relationshipIssues: string[];
     auxiliaryDefinitionIssues: string[];
   };
+  integrity: {
+    fieldIssues: string[];
+    bookmarkIssues: string[];
+    revisionIdIssues: string[];
+    moveBalanceIssues: string[];
+  };
   unsupportedStoryDiagnostics: string[];
-  forbiddenPayloadLeaks: string[];
 }
 
 export interface StrategyDifferentialRow {
@@ -229,6 +234,201 @@ function structuralIssueKey(issue: { check: string; part: string; message: strin
   return `${issue.check}\u0000${issue.part}\u0000${issue.message}`;
 }
 
+function duplicateValues(values: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const duplicates = new Set<string>();
+  for (const value of values) {
+    if (seen.has(value)) duplicates.add(value);
+    seen.add(value);
+  }
+  return [...duplicates].sort();
+}
+
+function bookmarkNames(xml: string): string[] {
+  const document = parseXml(xml);
+  return Array.from(document.getElementsByTagNameNS(W_NS, 'bookmarkStart'))
+    .map((element) => element.getAttributeNS(W_NS, 'name') ?? element.getAttribute('w:name'))
+    .filter((name): name is string => name !== null)
+    .sort();
+}
+
+function bookmarkStructuralIssues(xml: string): string[] {
+  const diagnostics = validateBookmarkIntegrity(xml);
+  return [
+    ...diagnostics.unmatchedStartIds.map((id) => `unmatched-start:${id}`),
+    ...diagnostics.unmatchedEndIds.map((id) => `unmatched-end:${id}`),
+    ...diagnostics.duplicateStartIds.map((id) => `duplicate-start-id:${id}`),
+    ...diagnostics.duplicateEndIds.map((id) => `duplicate-end-id:${id}`),
+    ...duplicateValues(bookmarkNames(xml)).map((name) => `duplicate-name:${name}`),
+  ].sort();
+}
+
+function bookmarkIntegrityIssues(
+  candidateXml: string,
+  acceptedXml: string,
+  rejectedXml: string,
+  originalXml: string,
+  revisedXml: string,
+): string[] {
+  const issues: string[] = [];
+  const originalIssues = new Set(bookmarkStructuralIssues(rejectAllChanges(originalXml)));
+  const revisedIssues = new Set(bookmarkStructuralIssues(acceptAllChanges(revisedXml)));
+  // Compatibility hoists range boundaries out of revision wrappers so Word
+  // retains their position. A malformed source boundary can consequently
+  // remain visible in both projections. Treat that defect as inherited no
+  // matter which source authored it, while still failing every anomaly absent
+  // from both inputs (including comparison-generated duplicate names).
+  const inheritedIssues = new Set([...originalIssues, ...revisedIssues]);
+  for (const [label, xml, inherited] of [
+    ['combined', candidateXml, inheritedIssues],
+    ['accept', acceptedXml, inheritedIssues],
+    ['reject', rejectedXml, inheritedIssues],
+  ] as const) {
+    for (const issue of bookmarkStructuralIssues(xml)) {
+      if (!inherited.has(issue)) issues.push(`${label}:${issue}`);
+    }
+  }
+  // Hoisting and projection-safe source renames may intentionally change which
+  // internal name carries a range. Exact source-inventory equality is therefore
+  // not a safety invariant. Newly introduced unbalanced IDs and duplicate names,
+  // plus resolvable field targets, remain asserted on combined/projected markup;
+  // pre-existing source defects stay visible in fixture structural evidence.
+  return issues.sort();
+}
+
+interface RevisionIdentity {
+  element: string;
+  id: string;
+  author: string;
+  date: string;
+  scope: string;
+}
+
+const FORMATTING_PROPERTY_CHANGE_ELEMENTS = new Set([
+  'pPrChange', 'rPrChange', 'sectPrChange', 'tblPrChange', 'tblPrExChange',
+  'trPrChange', 'tcPrChange', 'tblGridChange', 'numberingChange',
+]);
+
+function revisionIdentitySignature(identity: RevisionIdentity): string {
+  // One logical formatting edit can require several OOXML property-change
+  // records (for example pPrChange + nested sectPrChange, or pPrChange +
+  // rPrChange for the paragraph mark). The tagged emitter intentionally gives
+  // those facets one ID; consumer-compatibility guards uniqueness within each
+  // element kind while preserving this cross-kind property-change pairing.
+  const element = FORMATTING_PROPERTY_CHANGE_ELEMENTS.has(identity.element)
+    ? 'formatting-property-change'
+    : identity.element;
+  return `${element}\u0000${identity.author}\u0000${identity.date}\u0000${identity.scope}`;
+}
+
+function revisionIdentities(xml: string): RevisionIdentity[] {
+  const document = parseXml(xml);
+  const rangeNames = new Set([
+    'moveFromRangeStart', 'moveFromRangeEnd', 'moveToRangeStart', 'moveToRangeEnd',
+    'customXmlInsRangeStart', 'customXmlInsRangeEnd',
+    'customXmlDelRangeStart', 'customXmlDelRangeEnd',
+    'customXmlMoveFromRangeStart', 'customXmlMoveFromRangeEnd',
+    'customXmlMoveToRangeStart', 'customXmlMoveToRangeEnd',
+  ]);
+  const scopeByElement = new Map<Element, string>();
+  for (const scopeName of ['p', 'tc', 'tr', 'tbl'] as const) {
+    for (const [index, element] of Array.from(
+      document.getElementsByTagNameNS(W_NS, scopeName),
+    ).entries()) {
+      scopeByElement.set(element, `${scopeName}:${index}`);
+    }
+  }
+  const scopeFor = (element: Element): string => {
+    for (let ancestor = element.parentElement; ancestor; ancestor = ancestor.parentElement) {
+      const scope = scopeByElement.get(ancestor);
+      if (scope) return scope;
+    }
+    // Block-level revision wrappers contain rather than descend from their
+    // paragraph. Anchor those identities to the first contained paragraph so
+    // separate body-level revisions cannot silently reuse an ID.
+    const paragraph = element.getElementsByTagNameNS(W_NS, 'p').item(0);
+    return (paragraph && scopeByElement.get(paragraph)) ?? 'document';
+  };
+  return REVISION_ID_ELEMENT_NAMES
+    .filter((name) => !rangeNames.has(name))
+    .flatMap((name) => Array.from(document.getElementsByTagNameNS(W_NS, name)).map((element) => ({
+      element: name,
+      id: element.getAttributeNS(W_NS, 'id') ?? element.getAttribute('w:id') ?? '',
+      author: element.getAttributeNS(W_NS, 'author') ?? element.getAttribute('w:author') ?? '',
+      date: element.getAttributeNS(W_NS, 'date') ?? element.getAttribute('w:date') ?? '',
+      scope: scopeFor(element),
+    })))
+    .filter((identity) => identity.id !== '');
+}
+
+export function collectRevisionIdIssues(
+  candidateXml: string,
+  originalXml: string,
+  revisedXml: string,
+): string[] {
+  const issues: string[] = [];
+  const sourceIdentities = [
+    ...revisionIdentities(originalXml),
+    ...revisionIdentities(revisedXml),
+  ];
+  const sourceSignaturesById = new Map<string, Set<string>>();
+  for (const identity of sourceIdentities) {
+    const signature = revisionIdentitySignature(identity);
+    const signatures = sourceSignaturesById.get(identity.id) ?? new Set<string>();
+    signatures.add(signature);
+    sourceSignaturesById.set(identity.id, signatures);
+  }
+  const identitiesById = new Map<string, Set<string>>();
+
+  for (const identity of revisionIdentities(candidateXml)) {
+    const signature = revisionIdentitySignature(identity);
+    const signatures = identitiesById.get(identity.id) ?? new Set<string>();
+    signatures.add(signature);
+    identitiesById.set(identity.id, signatures);
+    if (
+      identity.author === AUTHOR
+      && sourceSignaturesById.has(identity.id)
+      && !sourceSignaturesById.get(identity.id)?.has(signature)
+    ) {
+      issues.push(`comparison-id-collides-with-source:${identity.id}`);
+    }
+  }
+
+  for (const [id, signatures] of identitiesById) {
+    // Compatibility can split one logical revision across wrappers or linked
+    // property-change facets. The shared ID is valid only while the normalized
+    // element family and revision metadata identify that same logical revision;
+    // reuse across identities is a real allocator collision.
+    if (signatures.size > 1) issues.push(`revision-id-reused-across-identities:${id}`);
+  }
+  return [...new Set(issues)].sort();
+}
+
+function moveBalanceIssues(candidateXml: string): string[] {
+  const document = parseXml(candidateXml);
+  const ids = (name: string): string[] => Array.from(
+    document.getElementsByTagNameNS(W_NS, name),
+  ).map((element) => element.getAttributeNS(W_NS, 'id') ?? element.getAttribute('w:id'))
+    .filter((id): id is string => id !== null)
+    .sort();
+  const issues: string[] = [];
+  for (const direction of ['moveFrom', 'moveTo'] as const) {
+    const starts = ids(`${direction}RangeStart`);
+    const ends = ids(`${direction}RangeEnd`);
+    if (JSON.stringify(starts) !== JSON.stringify(ends)) {
+      issues.push(`${direction}:range-boundaries-unbalanced`);
+    }
+    if (duplicateValues(starts).length > 0) issues.push(`${direction}:duplicate-range-id`);
+  }
+  if (ids('moveFrom').length !== ids('moveTo').length) {
+    issues.push('move-wrapper-count-unbalanced');
+  }
+  if (ids('moveFromRangeStart').length !== ids('moveToRangeStart').length) {
+    issues.push('move-range-count-unbalanced');
+  }
+  return issues.sort();
+}
+
 async function characterizeStrategy(
   fixture: StrategyDifferentialFixture,
   originalXml: string,
@@ -257,9 +457,11 @@ async function characterizeStrategy(
     )
     .map((issue) => `${issue.check}:${issue.part}:${issue.message}`)
     .sort();
-  const forbiddenPayloadLeaks = (fixture.forbiddenPayloads ?? [])
-    .filter((payload) => payload && result.document.includes(Buffer.from(payload)))
-    .sort();
+  const fieldIssues = [
+    ...collectFieldStructureIssues(candidateXml).map((issue) => `combined:${issue.code}`),
+    ...collectFieldStructureIssues(acceptedXml).map((issue) => `accept:${issue.code}`),
+    ...collectFieldStructureIssues(rejectedXml).map((issue) => `reject:${issue.code}`),
+  ].sort();
 
   return {
     strategy: 'tagged-tree',
@@ -269,15 +471,8 @@ async function characterizeStrategy(
     },
     packageParts: await packagePartSummaries(result.document),
     stats: result.stats,
-    fallback: {
+    authority: {
       comparisonStrategyUsed: result.comparisonStrategyUsed,
-      ...(result.comparisonStrategyFallbackReason === undefined
-        ? {}
-        : { comparisonStrategyFallbackReason: result.comparisonStrategyFallbackReason }),
-      reconstructionModeUsed: result.reconstructionModeUsed,
-      ...(result.fallbackReason === undefined
-        ? {}
-        : { fallbackReason: result.fallbackReason }),
     },
     unrepresentedChanges: result.unrepresentedChanges ?? [],
     schema: {
@@ -298,8 +493,19 @@ async function characterizeStrategy(
       relationshipIssues,
       auxiliaryDefinitionIssues: await auxiliaryDefinitionIssues(result.document),
     },
+    integrity: {
+      fieldIssues,
+      bookmarkIssues: bookmarkIntegrityIssues(
+        candidateXml,
+        acceptedXml,
+        rejectedXml,
+        originalXml,
+        revisedXml,
+      ),
+      revisionIdIssues: collectRevisionIdIssues(candidateXml, originalXml, revisedXml),
+      moveBalanceIssues: moveBalanceIssues(candidateXml),
+    },
     unsupportedStoryDiagnostics: unsupportedStoryDiagnostics(result),
-    forbiddenPayloadLeaks,
   };
 }
 
@@ -363,28 +569,31 @@ export async function characterizeStrategyDifferential(
 export function assertCharacterizationSafety(
   row: StrategyDifferentialRow,
   approvedDimensions: ReadonlySet<ApprovedDivergenceDimension> = new Set(),
-): void {
+): Set<ApprovedDivergenceDimension> {
+  const consumedDimensions = new Set<ApprovedDivergenceDimension>();
   for (const evidence of [row.taggedTree]) {
-    if (evidence.fallback.comparisonStrategyUsed !== evidence.strategy) {
+    if (evidence.authority.comparisonStrategyUsed !== evidence.strategy) {
       throw new Error(
         `${row.fixture.id}/${evidence.strategy} fell back to ` +
-          `${String(evidence.fallback.comparisonStrategyUsed)}`,
+          `${String(evidence.authority.comparisonStrategyUsed)}`,
       );
     }
-    const acceptDimension = `${evidence.strategy}.acceptProjection` as const;
-    const rejectDimension = `${evidence.strategy}.rejectProjection` as const;
+    const acceptDimension: ApprovedDivergenceDimension = 'tagged-tree.acceptProjection';
+    const rejectDimension: ApprovedDivergenceDimension = 'tagged-tree.rejectProjection';
     if (
       !evidence.projections.accept.matchesSourceText
       && !approvedDimensions.has(acceptDimension)
     ) {
       throw new Error(`${row.fixture.id}/${evidence.strategy} accept projection drifted`);
     }
+    if (!evidence.projections.accept.matchesSourceText) consumedDimensions.add(acceptDimension);
     if (
       !evidence.projections.reject.matchesSourceText
       && !approvedDimensions.has(rejectDimension)
     ) {
       throw new Error(`${row.fixture.id}/${evidence.strategy} reject projection drifted`);
     }
+    if (!evidence.projections.reject.matchesSourceText) consumedDimensions.add(rejectDimension);
     if (evidence.schema.packageStructural === 'failed') {
       throw new Error(
         `${row.fixture.id}/${evidence.strategy} introduced package structural failures: ` +
@@ -399,9 +608,46 @@ export function assertCharacterizationSafety(
     if (evidence.closure.auxiliaryDefinitionIssues.length > 0) {
       throw new Error(`${row.fixture.id}/${evidence.strategy} has auxiliary definition issues`);
     }
-    if (evidence.forbiddenPayloadLeaks.length > 0) {
-      throw new Error(`${row.fixture.id}/${evidence.strategy} leaked forbidden payloads`);
+    if (
+      evidence.formatting.score !== 1 &&
+      !approvedDimensions.has('tagged-tree.formattingFidelity')
+    ) {
+      throw new Error(
+        `${row.fixture.id}/${evidence.strategy} formatting fidelity drifted ` +
+          `(score ${evidence.formatting.score})`,
+      );
     }
+    if (evidence.formatting.score !== 1) {
+      consumedDimensions.add('tagged-tree.formattingFidelity');
+    }
+    if (evidence.unsupportedStoryDiagnostics.length > 0) {
+      throw new Error(
+        `${row.fixture.id}/${evidence.strategy} reported unsupported story diagnostics: ` +
+          evidence.unsupportedStoryDiagnostics.join('; '),
+      );
+    }
+    for (const [label, issues] of Object.entries(evidence.integrity)) {
+      if (issues.length > 0) {
+        throw new Error(
+          `${row.fixture.id}/${evidence.strategy} failed ${label}: ${issues.join('; ')}`,
+        );
+      }
+    }
+  }
+  return consumedDimensions;
+}
+
+export function assertActiveDivergencesConsumed(
+  activeDivergenceIds: ReadonlySet<string>,
+  consumedDivergenceIds: ReadonlySet<string>,
+): void {
+  const unconsumed = [...activeDivergenceIds]
+    .filter((id) => !consumedDivergenceIds.has(id))
+    .sort();
+  if (unconsumed.length > 0) {
+    throw new Error(
+      `active divergences did not suppress an observed assertion: ${unconsumed.join(', ')}`,
+    );
   }
 }
 

--- a/packages/docx-compare/src/integration/strategy-differential-manifest.corpus.test.ts
+++ b/packages/docx-compare/src/integration/strategy-differential-manifest.corpus.test.ts
@@ -1,5 +1,5 @@
 /**
- * Committed legacy/tagged characterization over checked-in fixtures, the ILPA
+ * Committed tagged-tree characterization over checked-in fixtures, the ILPA
  * pair, and the SHA-256-pinned public NVCA corpus.
  *
  * @conformance ECMA-376 edition 5, Part 1 § 17.13.5
@@ -19,11 +19,13 @@ import {
 } from './real-corpus-fixtures.js';
 import { loadStrategyDifferentialFixtures } from './strategy-differential-fixtures.js';
 import {
+  assertActiveDivergencesConsumed,
   assertCharacterizationSafety,
   assertExpectedPackageParts,
   characterizeStrategyDifferential,
   type ApprovedDivergenceDimension,
   type StrategyDifferentialRow,
+  type StrategyEvidence,
 } from './strategy-differential-harness.js';
 
 const TEST_FEATURE = 'Refactor Tagged Tree Spine';
@@ -44,7 +46,9 @@ interface DivergenceRecord {
 interface CharacterizationManifest {
   schemaVersion: 1;
   divergences: DivergenceRecord[];
-  rows: Array<StrategyDifferentialRow & { legacy?: unknown }>;
+  rows: Array<Omit<StrategyDifferentialRow, 'taggedTree'> & {
+    taggedTree: Omit<StrategyEvidence, 'integrity'>;
+  }>;
 }
 
 const manifest = JSON.parse(await readFile(MANIFEST_PATH, 'utf8')) as CharacterizationManifest;
@@ -83,13 +87,8 @@ describe('strategy differential manifest contract', () => {
       const ids = manifest.divergences.map((entry) => entry.id);
       expect(new Set(ids).size).toBe(ids.length);
       expect(manifest.divergences).toEqual(expect.arrayContaining([
-        expect.objectContaining({ id: 'TD-FUZZY-MOVE-001', status: 'resolved' }),
-        expect.objectContaining({ id: 'TD-LEGACY-ILPA-REJECT-001', status: 'active' }),
-        expect.objectContaining({ id: 'TD-LEGACY-MOVE-PROJECTION-001', status: 'active' }),
-        expect.objectContaining({ id: 'TD-NUMBERING-001', status: 'resolved' }),
         expect.objectContaining({ id: 'TD-CONSUMER-COMPAT-001', status: 'resolved' }),
         expect.objectContaining({ id: 'TD-PAGEREF-CACHE-001', status: 'resolved' }),
-        expect.objectContaining({ id: 'TD-ATOM-STATS-SEMANTICS-001', status: 'active' }),
       ]));
       for (const divergence of manifest.divergences) {
         expect(divergence.issue).toMatch(/^#\d+$/u);
@@ -101,10 +100,11 @@ describe('strategy differential manifest contract', () => {
 });
 
 describe('strategy differential committed rows', () => {
-  const corpusTest = availability.available ? test : test.skip;
-  corpusTest(
+  test(
     'matches the reviewed manifest for every required fixture',
     async () => {
+      expect(availability.skipWarning).toBeNull();
+      expect(availability.available).toBe(true);
       const fixtures = await loadStrategyDifferentialFixtures(corpusRoot);
       const rows: StrategyDifferentialRow[] = [];
       for (const fixture of fixtures) {
@@ -124,13 +124,20 @@ describe('strategy differential committed rows', () => {
           .filter((entry) => entry.status === 'active')
           .map((entry) => [entry.id, entry] as const),
       );
+      const consumedDivergenceIds = new Set<string>();
       for (const [index, row] of rows.entries()) {
         const approvedDimensions = new Set(
           row.approvedDivergenceIds.flatMap(
             (id) => activeDivergences.get(id)?.dimensions ?? [],
           ),
         );
-        assertCharacterizationSafety(row, approvedDimensions);
+        const consumedDimensions = assertCharacterizationSafety(row, approvedDimensions);
+        for (const divergenceId of row.approvedDivergenceIds) {
+          const divergence = activeDivergences.get(divergenceId);
+          if (divergence?.dimensions.some((dimension) => consumedDimensions.has(dimension))) {
+            consumedDivergenceIds.add(divergenceId);
+          }
+        }
         assertExpectedPackageParts(fixtures[index]!, row);
       }
 
@@ -139,13 +146,20 @@ describe('strategy differential committed rows', () => {
           expect(activeDivergences.has(divergenceId), divergenceId).toBe(true);
         }
       }
+      assertActiveDivergencesConsumed(
+        new Set(activeDivergences.keys()),
+        consumedDivergenceIds,
+      );
 
-      const expectedRows = manifest.rows.map((row) => ({
-        fixture: row.fixture,
-        approvedDivergenceIds: row.approvedDivergenceIds,
-        taggedTree: row.taggedTree,
-      }));
-      expect(rows).toEqual(expectedRows);
+      const reviewedEvidence = (row: StrategyDifferentialRow) => {
+        const { integrity: _runtimeIntegrity, ...taggedTree } = row.taggedTree;
+        return {
+          fixture: row.fixture,
+          approvedDivergenceIds: row.approvedDivergenceIds,
+          taggedTree,
+        };
+      };
+      expect(rows.map(reviewedEvidence)).toEqual(manifest.rows);
     },
     600_000,
   );

--- a/packages/docx-compare/src/integration/strategy-differential-manifest.json
+++ b/packages/docx-compare/src/integration/strategy-differential-manifest.json
@@ -2,43 +2,6 @@
   "schemaVersion": 1,
   "divergences": [
     {
-      "id": "TD-FUZZY-MOVE-001",
-      "status": "resolved",
-      "issue": "#839",
-      "summary": "Tagged comparison now performs deterministic globally optimal fuzzy move pairing.",
-      "dimensions": [
-        "legacy-tagged.semanticDifference"
-      ]
-    },
-    {
-      "id": "TD-LEGACY-ILPA-REJECT-001",
-      "status": "active",
-      "issue": "#838",
-      "summary": "Legacy rejection of the checked-in ILPA pair drifts from the original while tagged-tree rejection remains exact.",
-      "dimensions": [
-        "legacy.rejectProjection"
-      ]
-    },
-    {
-      "id": "TD-LEGACY-MOVE-PROJECTION-001",
-      "status": "active",
-      "issue": "#839",
-      "summary": "Legacy move projection adds paragraph-boundary text while tagged-tree acceptance and rejection remain exact.",
-      "dimensions": [
-        "legacy.acceptProjection",
-        "legacy.rejectProjection"
-      ]
-    },
-    {
-      "id": "TD-NUMBERING-001",
-      "status": "resolved",
-      "issue": "#838",
-      "summary": "Tagged alignment now uses rendered numbering identities without publishing virtual labels.",
-      "dimensions": [
-        "legacy-tagged.semanticDifference"
-      ]
-    },
-    {
       "id": "TD-CONSUMER-COMPAT-001",
       "status": "resolved",
       "issue": "#838",
@@ -57,12 +20,12 @@
       ]
     },
     {
-      "id": "TD-ATOM-STATS-SEMANTICS-001",
+      "id": "TD-ILPA-SECTION-REL-001",
       "status": "active",
-      "issue": "#838",
-      "summary": "Tagged publication reports versioned comparison-token statistics instead of shadow-running the deleted flattened atom engine.",
+      "issue": "#917",
+      "summary": "ILPA reject-all preserves header and footer relationships under package-local relationship IDs that differ from the original IDs.",
       "dimensions": [
-        "tagged-tree.atomStatisticsSemantics"
+        "tagged-tree.formattingFidelity"
       ]
     }
   ],
@@ -91,125 +54,7 @@
         ],
         "sourceStructuralIssues": []
       },
-      "approvedDivergenceIds": [
-        "TD-ATOM-STATS-SEMANTICS-001"
-      ],
-      "legacy": {
-        "strategy": "legacy",
-        "projections": {
-          "accept": {
-            "xmlSha256": "de63e6f740896560ec7d43bcdba52ffed67826a744c445cc6ee02cfc7954bc1e",
-            "textSha256": "52d24589d11b699e3cf2363be0dda916bb6daac7755fe69400c5bfe8985ce3f7",
-            "sourceTextSha256": "52d24589d11b699e3cf2363be0dda916bb6daac7755fe69400c5bfe8985ce3f7",
-            "matchesSourceText": true,
-            "firstDifference": null
-          },
-          "reject": {
-            "xmlSha256": "a85d41b196c3ad23391cc4dc339e8cae0df95c7944e13a5d8b0d76b2b60f4b4d",
-            "textSha256": "9c1099f64ec5ded699ebbed6385bdd51503ceff19b49d5117e49f90607ac043b",
-            "sourceTextSha256": "9c1099f64ec5ded699ebbed6385bdd51503ceff19b49d5117e49f90607ac043b",
-            "matchesSourceText": true,
-            "firstDifference": null
-          }
-        },
-        "packageParts": [
-          {
-            "path": "[Content_Types].xml",
-            "bytes": 1224,
-            "sha256": "427d80e1dca4ad14bbc41967ce86b1ee8e36d465c1664879d139649bdb3fe2be",
-            "kind": "xml"
-          },
-          {
-            "path": "_rels/.rels",
-            "bytes": 599,
-            "sha256": "43bdd04f31bc9c60ecca6b3faf6a72376fc8060387613530dac16f33a95ad125",
-            "kind": "xml"
-          },
-          {
-            "path": "docProps/app.xml",
-            "bytes": 240,
-            "sha256": "5df79d0a31334db4c5219762f75da9d5481dac7b14ff74625ee992033308b974",
-            "kind": "xml"
-          },
-          {
-            "path": "docProps/core.xml",
-            "bytes": 614,
-            "sha256": "6467c3d081b0151d60bd0e132d2d383e2f8bf829cfbad24b6b88bb15a62d498f",
-            "kind": "xml"
-          },
-          {
-            "path": "word/_rels/document.xml.rels",
-            "bytes": 697,
-            "sha256": "b04f18d853437b6f9800c4babbd6f16da6929ab1153e74698675a066d3f4d178",
-            "kind": "xml"
-          },
-          {
-            "path": "word/document.xml",
-            "bytes": 2234,
-            "sha256": "b40850f2a9dd7d52786768670933a1559320a367a55941b11fbb8275758a943e",
-            "kind": "xml"
-          },
-          {
-            "path": "word/fontTable.xml",
-            "bytes": 507,
-            "sha256": "dab3a02701bb752acbac3f5160e7ccfd1e30303f6dac388963793f3cf5097de3",
-            "kind": "xml"
-          },
-          {
-            "path": "word/settings.xml",
-            "bytes": 405,
-            "sha256": "c15f810187617b76b223ca1220c7542ca0f8e21f505ca024887cd33502f6ebfa",
-            "kind": "xml"
-          },
-          {
-            "path": "word/styles.xml",
-            "bytes": 619,
-            "sha256": "39474e791b005132e5b82a4fd4e1c432840af5a504b27c76bc9916bea76ab5f6",
-            "kind": "xml"
-          },
-          {
-            "path": "word/webSettings.xml",
-            "bytes": 201,
-            "sha256": "6e1f152ff1f1be1a03477695104522ab2091039961d4d3d5745cc854a015eff0",
-            "kind": "xml"
-          }
-        ],
-        "stats": {
-          "insertions": 2,
-          "deletions": 3,
-          "modifications": 0,
-          "insertedRanges": 2,
-          "deletedRanges": 3,
-          "insertedAtoms": 16,
-          "deletedAtoms": 18,
-          "modifiedParagraphs": 0,
-          "formatChanges": 0,
-          "formatChangeAtoms": 0
-        },
-        "fallback": {
-          "comparisonStrategyUsed": "legacy",
-          "reconstructionModeUsed": "inplace"
-        },
-        "unrepresentedChanges": [],
-        "schema": {
-          "packageStructural": "passed",
-          "issues": [],
-          "introducedIssues": []
-        },
-        "formatting": {
-          "score": 1,
-          "acceptScore": 1,
-          "rejectScore": 1,
-          "acceptDivergences": 0,
-          "rejectDivergences": 0
-        },
-        "closure": {
-          "relationshipIssues": [],
-          "auxiliaryDefinitionIssues": []
-        },
-        "unsupportedStoryDiagnostics": [],
-        "forbiddenPayloadLeaks": []
-      },
+      "approvedDivergenceIds": [],
       "taggedTree": {
         "strategy": "tagged-tree",
         "projections": {
@@ -303,9 +148,8 @@
           "formatChanges": 0,
           "formatChangeAtoms": 0
         },
-        "fallback": {
-          "comparisonStrategyUsed": "tagged-tree",
-          "reconstructionModeUsed": "inplace"
+        "authority": {
+          "comparisonStrategyUsed": "tagged-tree"
         },
         "unrepresentedChanges": [],
         "schema": {
@@ -324,8 +168,7 @@
           "relationshipIssues": [],
           "auxiliaryDefinitionIssues": []
         },
-        "unsupportedStoryDiagnostics": [],
-        "forbiddenPayloadLeaks": []
+        "unsupportedStoryDiagnostics": []
       }
     },
     {
@@ -352,125 +195,7 @@
         ],
         "sourceStructuralIssues": []
       },
-      "approvedDivergenceIds": [
-        "TD-ATOM-STATS-SEMANTICS-001"
-      ],
-      "legacy": {
-        "strategy": "legacy",
-        "projections": {
-          "accept": {
-            "xmlSha256": "c5ded05b1cc1eb33ca4a9b40c1308e811ab57bf7e12d1018499749511a885b4e",
-            "textSha256": "dfa1be03ef8afdf2b7b3a58ba38235561e3145986903b13b3422e45090595537",
-            "sourceTextSha256": "dfa1be03ef8afdf2b7b3a58ba38235561e3145986903b13b3422e45090595537",
-            "matchesSourceText": true,
-            "firstDifference": null
-          },
-          "reject": {
-            "xmlSha256": "af5ba2ecb6f4587563f6f286ce4efea137b21b4ca11882199c7e52021a916ef2",
-            "textSha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-            "sourceTextSha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-            "matchesSourceText": true,
-            "firstDifference": null
-          }
-        },
-        "packageParts": [
-          {
-            "path": "[Content_Types].xml",
-            "bytes": 1224,
-            "sha256": "427d80e1dca4ad14bbc41967ce86b1ee8e36d465c1664879d139649bdb3fe2be",
-            "kind": "xml"
-          },
-          {
-            "path": "_rels/.rels",
-            "bytes": 599,
-            "sha256": "43bdd04f31bc9c60ecca6b3faf6a72376fc8060387613530dac16f33a95ad125",
-            "kind": "xml"
-          },
-          {
-            "path": "docProps/app.xml",
-            "bytes": 240,
-            "sha256": "5df79d0a31334db4c5219762f75da9d5481dac7b14ff74625ee992033308b974",
-            "kind": "xml"
-          },
-          {
-            "path": "docProps/core.xml",
-            "bytes": 614,
-            "sha256": "6467c3d081b0151d60bd0e132d2d383e2f8bf829cfbad24b6b88bb15a62d498f",
-            "kind": "xml"
-          },
-          {
-            "path": "word/_rels/document.xml.rels",
-            "bytes": 697,
-            "sha256": "b04f18d853437b6f9800c4babbd6f16da6929ab1153e74698675a066d3f4d178",
-            "kind": "xml"
-          },
-          {
-            "path": "word/document.xml",
-            "bytes": 482,
-            "sha256": "3594d590166fff67cc8b5773c601f51a2555e9aa5f3f5d02a690b35cf58813b0",
-            "kind": "xml"
-          },
-          {
-            "path": "word/fontTable.xml",
-            "bytes": 507,
-            "sha256": "dab3a02701bb752acbac3f5160e7ccfd1e30303f6dac388963793f3cf5097de3",
-            "kind": "xml"
-          },
-          {
-            "path": "word/settings.xml",
-            "bytes": 405,
-            "sha256": "c15f810187617b76b223ca1220c7542ca0f8e21f505ca024887cd33502f6ebfa",
-            "kind": "xml"
-          },
-          {
-            "path": "word/styles.xml",
-            "bytes": 619,
-            "sha256": "39474e791b005132e5b82a4fd4e1c432840af5a504b27c76bc9916bea76ab5f6",
-            "kind": "xml"
-          },
-          {
-            "path": "word/webSettings.xml",
-            "bytes": 201,
-            "sha256": "6e1f152ff1f1be1a03477695104522ab2091039961d4d3d5745cc854a015eff0",
-            "kind": "xml"
-          }
-        ],
-        "stats": {
-          "insertions": 1,
-          "deletions": 0,
-          "modifications": 0,
-          "insertedRanges": 1,
-          "deletedRanges": 0,
-          "insertedAtoms": 10,
-          "deletedAtoms": 0,
-          "modifiedParagraphs": 0,
-          "formatChanges": 0,
-          "formatChangeAtoms": 0
-        },
-        "fallback": {
-          "comparisonStrategyUsed": "legacy",
-          "reconstructionModeUsed": "inplace"
-        },
-        "unrepresentedChanges": [],
-        "schema": {
-          "packageStructural": "passed",
-          "issues": [],
-          "introducedIssues": []
-        },
-        "formatting": {
-          "score": 1,
-          "acceptScore": 1,
-          "rejectScore": 1,
-          "acceptDivergences": 0,
-          "rejectDivergences": 0
-        },
-        "closure": {
-          "relationshipIssues": [],
-          "auxiliaryDefinitionIssues": []
-        },
-        "unsupportedStoryDiagnostics": [],
-        "forbiddenPayloadLeaks": []
-      },
+      "approvedDivergenceIds": [],
       "taggedTree": {
         "strategy": "tagged-tree",
         "projections": {
@@ -564,9 +289,8 @@
           "formatChanges": 0,
           "formatChangeAtoms": 0
         },
-        "fallback": {
-          "comparisonStrategyUsed": "tagged-tree",
-          "reconstructionModeUsed": "inplace"
+        "authority": {
+          "comparisonStrategyUsed": "tagged-tree"
         },
         "unrepresentedChanges": [],
         "schema": {
@@ -585,8 +309,7 @@
           "relationshipIssues": [],
           "auxiliaryDefinitionIssues": []
         },
-        "unsupportedStoryDiagnostics": [],
-        "forbiddenPayloadLeaks": []
+        "unsupportedStoryDiagnostics": []
       }
     },
     {
@@ -670,503 +393,8 @@
         ]
       },
       "approvedDivergenceIds": [
-        "TD-ATOM-STATS-SEMANTICS-001",
-        "TD-LEGACY-ILPA-REJECT-001"
+        "TD-ILPA-SECTION-REL-001"
       ],
-      "legacy": {
-        "strategy": "legacy",
-        "projections": {
-          "accept": {
-            "xmlSha256": "f56ff8ef0e0f5b450aea53860db3646e341d66a8d05952226acbbcd820883963",
-            "textSha256": "97c196cd5e2a64c7fc89d3bcfed44be264fc2989b33fa9e09786f5c8c52e3e05",
-            "sourceTextSha256": "97c196cd5e2a64c7fc89d3bcfed44be264fc2989b33fa9e09786f5c8c52e3e05",
-            "matchesSourceText": true,
-            "firstDifference": null
-          },
-          "reject": {
-            "xmlSha256": "4374ba8faedec1f9e0c5174cb42c94d4394b40fc2d4ad858030b4feff63f3992",
-            "textSha256": "3fda724a15d5650f3cedaf0350bd92009cfe2c472d3e1f009d0c40760f237c78",
-            "sourceTextSha256": "f6c16bacb61bcd8cec2839c4cb671b4bee8576d7695bf20cc3af6451702cfd4a",
-            "matchesSourceText": false,
-            "firstDifference": {
-              "index": 87,
-              "projectedLength": 236448,
-              "sourceLength": 236448,
-              "projectedCodePoint": 84,
-              "sourceCodePoint": 10
-            }
-          }
-        },
-        "packageParts": [
-          {
-            "path": "[Content_Types].xml",
-            "bytes": 5548,
-            "sha256": "8169e396ab8830d7cf16167eb407ddfe0c99d51f4dd31c228d6a575c907b87a0",
-            "kind": "xml"
-          },
-          {
-            "path": "_rels/.rels",
-            "bytes": 736,
-            "sha256": "4464142a5b0503cde8555ba4e98fa8fd9874c2746ba09522538124ec43f8bc1a",
-            "kind": "xml"
-          },
-          {
-            "path": "customXml/_rels/item1.xml.rels",
-            "bytes": 295,
-            "sha256": "17f9862707a9096391a4a78b5fd8897ecb5686c7436e07dd1a73da7e7fa9e903",
-            "kind": "xml"
-          },
-          {
-            "path": "customXml/item1.xml",
-            "bytes": 270,
-            "sha256": "c8092edbb672f8c93f1d5ef66539a6f169462ba8738b785b59cc5d96f4aca59a",
-            "kind": "xml"
-          },
-          {
-            "path": "customXml/itemProps1.xml",
-            "bytes": 340,
-            "sha256": "c21de5788b8066b8d68de026640bc04b7624a0ae62a75474887c3ac315939ead",
-            "kind": "xml"
-          },
-          {
-            "path": "docProps/app.xml",
-            "bytes": 1045,
-            "sha256": "8cd8e25a1be413fbd7423df5c8787cd6952be0958510963cb1c90b7539eff76e",
-            "kind": "xml"
-          },
-          {
-            "path": "docProps/core.xml",
-            "bytes": 765,
-            "sha256": "dd5fc6294ddaa35027594e5bd789bd7b57b9dfff4ea5c705151f05de46f009b3",
-            "kind": "xml"
-          },
-          {
-            "path": "docProps/custom.xml",
-            "bytes": 366,
-            "sha256": "27e05ff4cf2d107a4c412a7695f9149936dfd08f4de91c614b6d2d5ec2e0b863",
-            "kind": "xml"
-          },
-          {
-            "path": "word/_rels/document.xml.rels",
-            "bytes": 4479,
-            "sha256": "f0dc7184097ae7108d79a22cfa4f28507e98aa28d4817dfaa5e1c67bd76661a7",
-            "kind": "xml"
-          },
-          {
-            "path": "word/_rels/footnotes.xml.rels",
-            "bytes": 416,
-            "sha256": "b5542b36b1b3bbea1e33f06011f3b6500ac50f7aa9dbc7be303373ed9f370fe8",
-            "kind": "xml"
-          },
-          {
-            "path": "word/document.xml",
-            "bytes": 773696,
-            "sha256": "4e95da492dc4592e6e540d49516c45b0e9292a2287e2341e9cabd016528a1f8b",
-            "kind": "xml"
-          },
-          {
-            "path": "word/endnotes.xml",
-            "bytes": 2685,
-            "sha256": "63993d128bdd3b35856d859c4f87d085fa8c0586dd8bbdb44011fa19974e4559",
-            "kind": "xml"
-          },
-          {
-            "path": "word/fontTable.xml",
-            "bytes": 4043,
-            "sha256": "0462b7e286e32df91cc21d2934cdb177cff16f968bd373b5cddc49477dda66f9",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer1.xml",
-            "bytes": 2827,
-            "sha256": "bdeaf652a210e43324fbe01edcf845e51f157accf61b7e973061c2818bd1e28e",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer10.xml",
-            "bytes": 3366,
-            "sha256": "f5892e6522f85dfa75c916f8fdb680c1df0fd37c9bcde38a1ad4d9b32365329e",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer11.xml",
-            "bytes": 5871,
-            "sha256": "a3973eb0649b3d6d8d113d644a0e47a41a08552f023ae88c597aafbbe5745768",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer12.xml",
-            "bytes": 3366,
-            "sha256": "ac1e9152052d3f399bca4609961fade6874566506e145c9af9ca6a6921d6a149",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer2.xml",
-            "bytes": 4477,
-            "sha256": "6d794ba8314391bfd686167c89a2b03466e61200b050063790ac2710ed002f39",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer3.xml",
-            "bytes": 2905,
-            "sha256": "453e8aa918b405ff76ad2649d9258502ad228693e9b11db0ee217ff359ccb599",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer4.xml",
-            "bytes": 3815,
-            "sha256": "dcb2c3bb8f85d5f82b539ea33271ed860f353589cb3a65f5b1208e692f1b786e",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer5.xml",
-            "bytes": 3366,
-            "sha256": "05ea18b5b286553023dc80b46ff83633821c0474adb99e3d47f0f96d2f24583e",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer6.xml",
-            "bytes": 3538,
-            "sha256": "425c18091e282b97bafadcdb8b287227b47e2e06435d92527c249704a3e790cb",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer7.xml",
-            "bytes": 3466,
-            "sha256": "3ffe2c132c90a7cdbcee8c123c04a0a2ef87e28799970b9f0c6dddaddee5b642",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer8.xml",
-            "bytes": 3366,
-            "sha256": "4de0bd0b460fbb68bcba7996dce6083b77b83ab60b5137bb25ab1c1e423709d9",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer9.xml",
-            "bytes": 5851,
-            "sha256": "e10b51a8c5c3c432e9bcac08f7e17d5766df509d2f385119c4e083732972c27d",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footnotes.xml",
-            "bytes": 21022,
-            "sha256": "ba113eb1c4e6b65c41b2bce039da8db252e0abe43b7cb0c90688c8dc29682b17",
-            "kind": "xml"
-          },
-          {
-            "path": "word/glossary/_rels/document.xml.rels",
-            "bytes": 684,
-            "sha256": "de9880c4b866697dcaaf9dab4e0636198293fbb286962864a479904a2c2cbcc3",
-            "kind": "xml"
-          },
-          {
-            "path": "word/glossary/document.xml",
-            "bytes": 3007,
-            "sha256": "2aecd389d3fec2cb9aae88fd718932b7e06cafa5b3b530ca51ba9a575f6fd712",
-            "kind": "xml"
-          },
-          {
-            "path": "word/glossary/fontTable.xml",
-            "bytes": 4043,
-            "sha256": "0462b7e286e32df91cc21d2934cdb177cff16f968bd373b5cddc49477dda66f9",
-            "kind": "xml"
-          },
-          {
-            "path": "word/glossary/settings.xml",
-            "bytes": 2546,
-            "sha256": "03eb254dd8ba89c0cd55d61ca81de07fd3b4963bf9ebb589af530ed38f96f0d9",
-            "kind": "xml"
-          },
-          {
-            "path": "word/glossary/styles.xml",
-            "bytes": 30142,
-            "sha256": "03d94243d689aa3b0cc69d412f89ae1b6b75c7617f17642d049c3113dd5adc9f",
-            "kind": "xml"
-          },
-          {
-            "path": "word/glossary/webSettings.xml",
-            "bytes": 802,
-            "sha256": "b1bdc1c3cdba917b9fccfa1ed9d966b56432b5007b8000e5a54f41a5d6c970bc",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header1.xml",
-            "bytes": 2439,
-            "sha256": "61a379f382d2871d03a95e3796a074ee3fea5b5a13e2650a363c48c23ff2a850",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header10.xml",
-            "bytes": 2439,
-            "sha256": "84a99a7808d465844ae4cb7e8e6eb8edc6fe1158859cc809d4e554d34d423f75",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header2.xml",
-            "bytes": 2439,
-            "sha256": "afde273fd27daa0bd7c15c55cf4dd35d57d49fb783f0dda55ca740976b28b0c3",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header3.xml",
-            "bytes": 2460,
-            "sha256": "b038b005f5066b37c66a6c1d2edfc26fc9ca40a7fc2596db2cb231a0b94245e9",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header4.xml",
-            "bytes": 2439,
-            "sha256": "38c2ee42a1565710068b988afac63ac9bf750dc74ac655b441596dfa444e43ee",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header5.xml",
-            "bytes": 2912,
-            "sha256": "05486fa10c7d2162c6af8ab701fff5efc4ae9314288c115a9d5ff4be71a63aa3",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header6.xml",
-            "bytes": 2439,
-            "sha256": "c03b65a32f8e5f1af2c1593a0d76b9da503852e5d53bcb7582630814198ec212",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header7.xml",
-            "bytes": 2439,
-            "sha256": "e64778a7ea3867ef287ec745214510d3a7a9510829af253c2de44425ed3343b2",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header8.xml",
-            "bytes": 2439,
-            "sha256": "d9d5c6af578ae22a35248a95c4aab8b6df957e72f7d9517f66642d2787f14231",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header9.xml",
-            "bytes": 2439,
-            "sha256": "7426662b8722380f3fcf8dc0f85ac6d8d88a2717e7d09005f4991f77b3f8b739",
-            "kind": "xml"
-          },
-          {
-            "path": "word/media/image1.png",
-            "bytes": 7717,
-            "sha256": "a91ad5259d7944003b90d5343bd2db937ddc11fb83907a630b8a292e19975ddb",
-            "kind": "binary"
-          },
-          {
-            "path": "word/numbering.xml",
-            "bytes": 136282,
-            "sha256": "49c140952ec750ee4dd78bdf77d5c9191e135a8941de4fb7deb92d1250e320ad",
-            "kind": "xml"
-          },
-          {
-            "path": "word/settings.xml",
-            "bytes": 4335,
-            "sha256": "0932e98c9f20a2a47ce288869b397a732125a0f5e15c9521f1f30e2265e31100",
-            "kind": "xml"
-          },
-          {
-            "path": "word/styles.xml",
-            "bytes": 68010,
-            "sha256": "af416948ed1fc4da805f62a2cd26025c7505f5339638c88b0effac58e6fc757f",
-            "kind": "xml"
-          },
-          {
-            "path": "word/theme/theme1.xml",
-            "bytes": 6798,
-            "sha256": "7a384ac82531e4f77ed57074d8b623b745ca5c722d529e3f268c344dd2344507",
-            "kind": "xml"
-          },
-          {
-            "path": "word/webSettings.xml",
-            "bytes": 1606,
-            "sha256": "ade13ddf76816b0f28030e496e2be321ea9037cf4af504397b519a0dd9d834ba",
-            "kind": "xml"
-          }
-        ],
-        "stats": {
-          "insertions": 84,
-          "deletions": 79,
-          "modifications": 53,
-          "insertedRanges": 84,
-          "deletedRanges": 79,
-          "insertedAtoms": 1865,
-          "deletedAtoms": 171,
-          "modifiedParagraphs": 53,
-          "formatChanges": 12,
-          "formatChangeAtoms": 402
-        },
-        "fallback": {
-          "comparisonStrategyUsed": "legacy",
-          "reconstructionModeUsed": "inplace"
-        },
-        "unrepresentedChanges": [
-          {
-            "scope": "footer",
-            "kind": "changed",
-            "sectionIndex": 0,
-            "role": "default"
-          },
-          {
-            "scope": "footer",
-            "kind": "changed",
-            "sectionIndex": 0,
-            "role": "even"
-          },
-          {
-            "scope": "footer",
-            "kind": "added",
-            "sectionIndex": 0,
-            "role": "first"
-          },
-          {
-            "scope": "header",
-            "kind": "added",
-            "sectionIndex": 0,
-            "role": "default"
-          },
-          {
-            "scope": "header",
-            "kind": "added",
-            "sectionIndex": 0,
-            "role": "even"
-          },
-          {
-            "scope": "header",
-            "kind": "added",
-            "sectionIndex": 0,
-            "role": "first"
-          },
-          {
-            "scope": "footer",
-            "kind": "changed",
-            "sectionIndex": 1,
-            "role": "default"
-          },
-          {
-            "scope": "footer",
-            "kind": "changed",
-            "sectionIndex": 1,
-            "role": "first"
-          },
-          {
-            "scope": "header",
-            "kind": "changed",
-            "sectionIndex": 1,
-            "role": "default"
-          },
-          {
-            "scope": "header",
-            "kind": "changed",
-            "sectionIndex": 1,
-            "role": "first"
-          },
-          {
-            "scope": "footer",
-            "kind": "changed",
-            "sectionIndex": 2,
-            "role": "default"
-          },
-          {
-            "scope": "footer",
-            "kind": "changed",
-            "sectionIndex": 2,
-            "role": "first"
-          },
-          {
-            "scope": "header",
-            "kind": "changed",
-            "sectionIndex": 2,
-            "role": "default"
-          },
-          {
-            "scope": "header",
-            "kind": "changed",
-            "sectionIndex": 2,
-            "role": "first"
-          },
-          {
-            "scope": "footer",
-            "kind": "changed",
-            "sectionIndex": 3,
-            "role": "first"
-          },
-          {
-            "scope": "header",
-            "kind": "changed",
-            "sectionIndex": 3,
-            "role": "first"
-          },
-          {
-            "scope": "footer",
-            "kind": "added",
-            "sectionIndex": 4,
-            "role": "default"
-          },
-          {
-            "scope": "footer",
-            "kind": "changed",
-            "sectionIndex": 4,
-            "role": "first"
-          },
-          {
-            "scope": "header",
-            "kind": "changed",
-            "sectionIndex": 4,
-            "role": "first"
-          },
-          {
-            "scope": "footer",
-            "kind": "changed",
-            "sectionIndex": 5,
-            "role": "default"
-          },
-          {
-            "scope": "footer",
-            "kind": "changed",
-            "sectionIndex": 5,
-            "role": "first"
-          },
-          {
-            "scope": "header",
-            "kind": "changed",
-            "sectionIndex": 5,
-            "role": "first"
-          }
-        ],
-        "schema": {
-          "packageStructural": "inherited",
-          "issues": [
-            {
-              "check": "field_pairing",
-              "part": "word/document.xml",
-              "message": "fldChar begin while a field is already open"
-            },
-            {
-              "check": "field_pairing",
-              "part": "word/document.xml",
-              "message": "fldChar end without a matching begin"
-            }
-          ],
-          "introducedIssues": []
-        },
-        "formatting": {
-          "score": 0.7470066043664094,
-          "acceptScore": 1,
-          "rejectScore": 0.7470066043664094,
-          "acceptDivergences": 0,
-          "rejectDivergences": 36
-        },
-        "closure": {
-          "relationshipIssues": [],
-          "auxiliaryDefinitionIssues": []
-        },
-        "unsupportedStoryDiagnostics": [],
-        "forbiddenPayloadLeaks": []
-      },
       "taggedTree": {
         "strategy": "tagged-tree",
         "projections": {
@@ -1590,9 +818,8 @@
           "formatChanges": 17,
           "formatChangeAtoms": 17
         },
-        "fallback": {
-          "comparisonStrategyUsed": "tagged-tree",
-          "reconstructionModeUsed": "inplace"
+        "authority": {
+          "comparisonStrategyUsed": "tagged-tree"
         },
         "unrepresentedChanges": [
           {
@@ -1755,8 +982,7 @@
           "relationshipIssues": [],
           "auxiliaryDefinitionIssues": []
         },
-        "unsupportedStoryDiagnostics": [],
-        "forbiddenPayloadLeaks": []
+        "unsupportedStoryDiagnostics": []
       }
     },
     {
@@ -1783,125 +1009,7 @@
         ],
         "sourceStructuralIssues": []
       },
-      "approvedDivergenceIds": [
-        "TD-ATOM-STATS-SEMANTICS-001"
-      ],
-      "legacy": {
-        "strategy": "legacy",
-        "projections": {
-          "accept": {
-            "xmlSha256": "83b0c29a8e8b7c47a555cd65a613dda48860b4c2baa4f18d7d9f5491fd694b4c",
-            "textSha256": "08c079a9d9160ed3507f320496a0b45e47768da79829ab3b0ee86a81154e111f",
-            "sourceTextSha256": "08c079a9d9160ed3507f320496a0b45e47768da79829ab3b0ee86a81154e111f",
-            "matchesSourceText": true,
-            "firstDifference": null
-          },
-          "reject": {
-            "xmlSha256": "dcec457e6383e9f81a1b17b2cdf99f9806dbc9cf9470f269c34b83f39a6c3cfb",
-            "textSha256": "93cb977711035d40b8da9761d815e8f86dd529976dc083b252a98389a3fe4660",
-            "sourceTextSha256": "93cb977711035d40b8da9761d815e8f86dd529976dc083b252a98389a3fe4660",
-            "matchesSourceText": true,
-            "firstDifference": null
-          }
-        },
-        "packageParts": [
-          {
-            "path": "[Content_Types].xml",
-            "bytes": 1224,
-            "sha256": "427d80e1dca4ad14bbc41967ce86b1ee8e36d465c1664879d139649bdb3fe2be",
-            "kind": "xml"
-          },
-          {
-            "path": "_rels/.rels",
-            "bytes": 599,
-            "sha256": "43bdd04f31bc9c60ecca6b3faf6a72376fc8060387613530dac16f33a95ad125",
-            "kind": "xml"
-          },
-          {
-            "path": "docProps/app.xml",
-            "bytes": 240,
-            "sha256": "5df79d0a31334db4c5219762f75da9d5481dac7b14ff74625ee992033308b974",
-            "kind": "xml"
-          },
-          {
-            "path": "docProps/core.xml",
-            "bytes": 614,
-            "sha256": "6467c3d081b0151d60bd0e132d2d383e2f8bf829cfbad24b6b88bb15a62d498f",
-            "kind": "xml"
-          },
-          {
-            "path": "word/_rels/document.xml.rels",
-            "bytes": 697,
-            "sha256": "b04f18d853437b6f9800c4babbd6f16da6929ab1153e74698675a066d3f4d178",
-            "kind": "xml"
-          },
-          {
-            "path": "word/document.xml",
-            "bytes": 1349,
-            "sha256": "580749532b30cbf9a77cd382768ef90a1a77c964804116159d250c17f5431763",
-            "kind": "xml"
-          },
-          {
-            "path": "word/fontTable.xml",
-            "bytes": 507,
-            "sha256": "dab3a02701bb752acbac3f5160e7ccfd1e30303f6dac388963793f3cf5097de3",
-            "kind": "xml"
-          },
-          {
-            "path": "word/settings.xml",
-            "bytes": 405,
-            "sha256": "c15f810187617b76b223ca1220c7542ca0f8e21f505ca024887cd33502f6ebfa",
-            "kind": "xml"
-          },
-          {
-            "path": "word/styles.xml",
-            "bytes": 619,
-            "sha256": "39474e791b005132e5b82a4fd4e1c432840af5a504b27c76bc9916bea76ab5f6",
-            "kind": "xml"
-          },
-          {
-            "path": "word/webSettings.xml",
-            "bytes": 201,
-            "sha256": "6e1f152ff1f1be1a03477695104522ab2091039961d4d3d5745cc854a015eff0",
-            "kind": "xml"
-          }
-        ],
-        "stats": {
-          "insertions": 3,
-          "deletions": 3,
-          "modifications": 1,
-          "insertedRanges": 3,
-          "deletedRanges": 3,
-          "insertedAtoms": 3,
-          "deletedAtoms": 3,
-          "modifiedParagraphs": 1,
-          "formatChanges": 0,
-          "formatChangeAtoms": 0
-        },
-        "fallback": {
-          "comparisonStrategyUsed": "legacy",
-          "reconstructionModeUsed": "inplace"
-        },
-        "unrepresentedChanges": [],
-        "schema": {
-          "packageStructural": "passed",
-          "issues": [],
-          "introducedIssues": []
-        },
-        "formatting": {
-          "score": 1,
-          "acceptScore": 1,
-          "rejectScore": 1,
-          "acceptDivergences": 0,
-          "rejectDivergences": 0
-        },
-        "closure": {
-          "relationshipIssues": [],
-          "auxiliaryDefinitionIssues": []
-        },
-        "unsupportedStoryDiagnostics": [],
-        "forbiddenPayloadLeaks": []
-      },
+      "approvedDivergenceIds": [],
       "taggedTree": {
         "strategy": "tagged-tree",
         "projections": {
@@ -1995,9 +1103,8 @@
           "formatChanges": 0,
           "formatChangeAtoms": 0
         },
-        "fallback": {
-          "comparisonStrategyUsed": "tagged-tree",
-          "reconstructionModeUsed": "inplace"
+        "authority": {
+          "comparisonStrategyUsed": "tagged-tree"
         },
         "unrepresentedChanges": [],
         "schema": {
@@ -2016,8 +1123,7 @@
           "relationshipIssues": [],
           "auxiliaryDefinitionIssues": []
         },
-        "unsupportedStoryDiagnostics": [],
-        "forbiddenPayloadLeaks": []
+        "unsupportedStoryDiagnostics": []
       }
     },
     {
@@ -2044,125 +1150,7 @@
         ],
         "sourceStructuralIssues": []
       },
-      "approvedDivergenceIds": [
-        "TD-ATOM-STATS-SEMANTICS-001"
-      ],
-      "legacy": {
-        "strategy": "legacy",
-        "projections": {
-          "accept": {
-            "xmlSha256": "104755dbec5124c6a06c1fca2711205aaa3afb71e2054a73a0c0e25e32bfe708",
-            "textSha256": "a0988910e9c4e79141fa39af150dacf7aa4b2214138ef958bf3e4c66a011c1d6",
-            "sourceTextSha256": "a0988910e9c4e79141fa39af150dacf7aa4b2214138ef958bf3e4c66a011c1d6",
-            "matchesSourceText": true,
-            "firstDifference": null
-          },
-          "reject": {
-            "xmlSha256": "104755dbec5124c6a06c1fca2711205aaa3afb71e2054a73a0c0e25e32bfe708",
-            "textSha256": "a0988910e9c4e79141fa39af150dacf7aa4b2214138ef958bf3e4c66a011c1d6",
-            "sourceTextSha256": "a0988910e9c4e79141fa39af150dacf7aa4b2214138ef958bf3e4c66a011c1d6",
-            "matchesSourceText": true,
-            "firstDifference": null
-          }
-        },
-        "packageParts": [
-          {
-            "path": "[Content_Types].xml",
-            "bytes": 1224,
-            "sha256": "427d80e1dca4ad14bbc41967ce86b1ee8e36d465c1664879d139649bdb3fe2be",
-            "kind": "xml"
-          },
-          {
-            "path": "_rels/.rels",
-            "bytes": 599,
-            "sha256": "43bdd04f31bc9c60ecca6b3faf6a72376fc8060387613530dac16f33a95ad125",
-            "kind": "xml"
-          },
-          {
-            "path": "docProps/app.xml",
-            "bytes": 240,
-            "sha256": "5df79d0a31334db4c5219762f75da9d5481dac7b14ff74625ee992033308b974",
-            "kind": "xml"
-          },
-          {
-            "path": "docProps/core.xml",
-            "bytes": 614,
-            "sha256": "6467c3d081b0151d60bd0e132d2d383e2f8bf829cfbad24b6b88bb15a62d498f",
-            "kind": "xml"
-          },
-          {
-            "path": "word/_rels/document.xml.rels",
-            "bytes": 697,
-            "sha256": "b04f18d853437b6f9800c4babbd6f16da6929ab1153e74698675a066d3f4d178",
-            "kind": "xml"
-          },
-          {
-            "path": "word/document.xml",
-            "bytes": 388,
-            "sha256": "3f0fa1201966dac33aa448195f98728be50a84ec985c40fb203d45fc7c25a45e",
-            "kind": "xml"
-          },
-          {
-            "path": "word/fontTable.xml",
-            "bytes": 507,
-            "sha256": "dab3a02701bb752acbac3f5160e7ccfd1e30303f6dac388963793f3cf5097de3",
-            "kind": "xml"
-          },
-          {
-            "path": "word/settings.xml",
-            "bytes": 405,
-            "sha256": "c15f810187617b76b223ca1220c7542ca0f8e21f505ca024887cd33502f6ebfa",
-            "kind": "xml"
-          },
-          {
-            "path": "word/styles.xml",
-            "bytes": 619,
-            "sha256": "39474e791b005132e5b82a4fd4e1c432840af5a504b27c76bc9916bea76ab5f6",
-            "kind": "xml"
-          },
-          {
-            "path": "word/webSettings.xml",
-            "bytes": 201,
-            "sha256": "6e1f152ff1f1be1a03477695104522ab2091039961d4d3d5745cc854a015eff0",
-            "kind": "xml"
-          }
-        ],
-        "stats": {
-          "insertions": 0,
-          "deletions": 0,
-          "modifications": 0,
-          "insertedRanges": 0,
-          "deletedRanges": 0,
-          "insertedAtoms": 0,
-          "deletedAtoms": 0,
-          "modifiedParagraphs": 0,
-          "formatChanges": 0,
-          "formatChangeAtoms": 0
-        },
-        "fallback": {
-          "comparisonStrategyUsed": "legacy",
-          "reconstructionModeUsed": "inplace"
-        },
-        "unrepresentedChanges": [],
-        "schema": {
-          "packageStructural": "passed",
-          "issues": [],
-          "introducedIssues": []
-        },
-        "formatting": {
-          "score": 1,
-          "acceptScore": 1,
-          "rejectScore": 1,
-          "acceptDivergences": 0,
-          "rejectDivergences": 0
-        },
-        "closure": {
-          "relationshipIssues": [],
-          "auxiliaryDefinitionIssues": []
-        },
-        "unsupportedStoryDiagnostics": [],
-        "forbiddenPayloadLeaks": []
-      },
+      "approvedDivergenceIds": [],
       "taggedTree": {
         "strategy": "tagged-tree",
         "projections": {
@@ -2256,9 +1244,8 @@
           "formatChanges": 0,
           "formatChangeAtoms": 0
         },
-        "fallback": {
-          "comparisonStrategyUsed": "tagged-tree",
-          "reconstructionModeUsed": "inplace"
+        "authority": {
+          "comparisonStrategyUsed": "tagged-tree"
         },
         "unrepresentedChanges": [],
         "schema": {
@@ -2277,8 +1264,7 @@
           "relationshipIssues": [],
           "auxiliaryDefinitionIssues": []
         },
-        "unsupportedStoryDiagnostics": [],
-        "forbiddenPayloadLeaks": []
+        "unsupportedStoryDiagnostics": []
       }
     },
     {
@@ -2309,9 +1295,7 @@
         ],
         "sourceStructuralIssues": []
       },
-      "approvedDivergenceIds": [
-        "TD-ATOM-STATS-SEMANTICS-001"
-      ],
+      "approvedDivergenceIds": [],
       "taggedTree": {
         "strategy": "tagged-tree",
         "projections": {
@@ -2411,9 +1395,8 @@
           "formatChanges": 0,
           "formatChangeAtoms": 0
         },
-        "fallback": {
-          "comparisonStrategyUsed": "tagged-tree",
-          "reconstructionModeUsed": "inplace"
+        "authority": {
+          "comparisonStrategyUsed": "tagged-tree"
         },
         "unrepresentedChanges": [],
         "schema": {
@@ -2432,8 +1415,7 @@
           "relationshipIssues": [],
           "auxiliaryDefinitionIssues": []
         },
-        "unsupportedStoryDiagnostics": [],
-        "forbiddenPayloadLeaks": []
+        "unsupportedStoryDiagnostics": []
       }
     },
     {
@@ -2469,9 +1451,7 @@
         ],
         "sourceStructuralIssues": []
       },
-      "approvedDivergenceIds": [
-        "TD-ATOM-STATS-SEMANTICS-001"
-      ],
+      "approvedDivergenceIds": [],
       "taggedTree": {
         "strategy": "tagged-tree",
         "projections": {
@@ -2601,9 +1581,8 @@
           "formatChanges": 1,
           "formatChangeAtoms": 1
         },
-        "fallback": {
-          "comparisonStrategyUsed": "tagged-tree",
-          "reconstructionModeUsed": "inplace"
+        "authority": {
+          "comparisonStrategyUsed": "tagged-tree"
         },
         "unrepresentedChanges": [],
         "schema": {
@@ -2622,8 +1601,7 @@
           "relationshipIssues": [],
           "auxiliaryDefinitionIssues": []
         },
-        "unsupportedStoryDiagnostics": [],
-        "forbiddenPayloadLeaks": []
+        "unsupportedStoryDiagnostics": []
       }
     },
     {
@@ -2650,125 +1628,7 @@
         ],
         "sourceStructuralIssues": []
       },
-      "approvedDivergenceIds": [
-        "TD-ATOM-STATS-SEMANTICS-001"
-      ],
-      "legacy": {
-        "strategy": "legacy",
-        "projections": {
-          "accept": {
-            "xmlSha256": "60347a82fa0b2661f8ec3f5cbc664e3ec4bb1cfc6e663f1403768d39704d1365",
-            "textSha256": "53566fb48a2d15378fd94f2d78060b8d7b872766dc898bac15303e21be94944e",
-            "sourceTextSha256": "53566fb48a2d15378fd94f2d78060b8d7b872766dc898bac15303e21be94944e",
-            "matchesSourceText": true,
-            "firstDifference": null
-          },
-          "reject": {
-            "xmlSha256": "36a5cafee04a231eeb3c059d5809bae5680184047620c282b5563f9aab7ad26e",
-            "textSha256": "5a6dfd8a1c8dbdc28f6a3b0141ad8f394601709305a1cec4f31f1794f7a03ac0",
-            "sourceTextSha256": "5a6dfd8a1c8dbdc28f6a3b0141ad8f394601709305a1cec4f31f1794f7a03ac0",
-            "matchesSourceText": true,
-            "firstDifference": null
-          }
-        },
-        "packageParts": [
-          {
-            "path": "[Content_Types].xml",
-            "bytes": 1224,
-            "sha256": "427d80e1dca4ad14bbc41967ce86b1ee8e36d465c1664879d139649bdb3fe2be",
-            "kind": "xml"
-          },
-          {
-            "path": "_rels/.rels",
-            "bytes": 599,
-            "sha256": "43bdd04f31bc9c60ecca6b3faf6a72376fc8060387613530dac16f33a95ad125",
-            "kind": "xml"
-          },
-          {
-            "path": "docProps/app.xml",
-            "bytes": 240,
-            "sha256": "5df79d0a31334db4c5219762f75da9d5481dac7b14ff74625ee992033308b974",
-            "kind": "xml"
-          },
-          {
-            "path": "docProps/core.xml",
-            "bytes": 614,
-            "sha256": "6467c3d081b0151d60bd0e132d2d383e2f8bf829cfbad24b6b88bb15a62d498f",
-            "kind": "xml"
-          },
-          {
-            "path": "word/_rels/document.xml.rels",
-            "bytes": 697,
-            "sha256": "b04f18d853437b6f9800c4babbd6f16da6929ab1153e74698675a066d3f4d178",
-            "kind": "xml"
-          },
-          {
-            "path": "word/document.xml",
-            "bytes": 1034,
-            "sha256": "0b5456e050d0a05c5102428577d519aa8fa32532c8c23f5b7ccae1a9c7c806c2",
-            "kind": "xml"
-          },
-          {
-            "path": "word/fontTable.xml",
-            "bytes": 507,
-            "sha256": "dab3a02701bb752acbac3f5160e7ccfd1e30303f6dac388963793f3cf5097de3",
-            "kind": "xml"
-          },
-          {
-            "path": "word/settings.xml",
-            "bytes": 405,
-            "sha256": "c15f810187617b76b223ca1220c7542ca0f8e21f505ca024887cd33502f6ebfa",
-            "kind": "xml"
-          },
-          {
-            "path": "word/styles.xml",
-            "bytes": 619,
-            "sha256": "39474e791b005132e5b82a4fd4e1c432840af5a504b27c76bc9916bea76ab5f6",
-            "kind": "xml"
-          },
-          {
-            "path": "word/webSettings.xml",
-            "bytes": 201,
-            "sha256": "6e1f152ff1f1be1a03477695104522ab2091039961d4d3d5745cc854a015eff0",
-            "kind": "xml"
-          }
-        ],
-        "stats": {
-          "insertions": 0,
-          "deletions": 1,
-          "modifications": 0,
-          "insertedRanges": 0,
-          "deletedRanges": 1,
-          "insertedAtoms": 0,
-          "deletedAtoms": 10,
-          "modifiedParagraphs": 0,
-          "formatChanges": 0,
-          "formatChangeAtoms": 0
-        },
-        "fallback": {
-          "comparisonStrategyUsed": "legacy",
-          "reconstructionModeUsed": "inplace"
-        },
-        "unrepresentedChanges": [],
-        "schema": {
-          "packageStructural": "passed",
-          "issues": [],
-          "introducedIssues": []
-        },
-        "formatting": {
-          "score": 1,
-          "acceptScore": 1,
-          "rejectScore": 1,
-          "acceptDivergences": 0,
-          "rejectDivergences": 0
-        },
-        "closure": {
-          "relationshipIssues": [],
-          "auxiliaryDefinitionIssues": []
-        },
-        "unsupportedStoryDiagnostics": [],
-        "forbiddenPayloadLeaks": []
-      },
+      "approvedDivergenceIds": [],
       "taggedTree": {
         "strategy": "tagged-tree",
         "projections": {
@@ -2862,9 +1722,8 @@
           "formatChanges": 0,
           "formatChangeAtoms": 0
         },
-        "fallback": {
-          "comparisonStrategyUsed": "tagged-tree",
-          "reconstructionModeUsed": "inplace"
+        "authority": {
+          "comparisonStrategyUsed": "tagged-tree"
         },
         "unrepresentedChanges": [],
         "schema": {
@@ -2883,8 +1742,7 @@
           "relationshipIssues": [],
           "auxiliaryDefinitionIssues": []
         },
-        "unsupportedStoryDiagnostics": [],
-        "forbiddenPayloadLeaks": []
+        "unsupportedStoryDiagnostics": []
       }
     },
     {
@@ -2911,125 +1769,7 @@
         ],
         "sourceStructuralIssues": []
       },
-      "approvedDivergenceIds": [
-        "TD-ATOM-STATS-SEMANTICS-001"
-      ],
-      "legacy": {
-        "strategy": "legacy",
-        "projections": {
-          "accept": {
-            "xmlSha256": "315c3705f294b8b39852c3da3874fe9ee30e3dcd91f1cb81e35092477a46c1e6",
-            "textSha256": "8de2a01122bf0e48a815fdef8305f6f7b067e6b979c8f1bf663bd608156f0069",
-            "sourceTextSha256": "8de2a01122bf0e48a815fdef8305f6f7b067e6b979c8f1bf663bd608156f0069",
-            "matchesSourceText": true,
-            "firstDifference": null
-          },
-          "reject": {
-            "xmlSha256": "2560c375c6584e72e15dbdad625f2e7993e163b8891386b10e6d7db1e2aceafa",
-            "textSha256": "9ca78f2ac02beda158942701e7babbf9aa65f3930a811858d94ef0a292cd05d7",
-            "sourceTextSha256": "9ca78f2ac02beda158942701e7babbf9aa65f3930a811858d94ef0a292cd05d7",
-            "matchesSourceText": true,
-            "firstDifference": null
-          }
-        },
-        "packageParts": [
-          {
-            "path": "[Content_Types].xml",
-            "bytes": 1224,
-            "sha256": "427d80e1dca4ad14bbc41967ce86b1ee8e36d465c1664879d139649bdb3fe2be",
-            "kind": "xml"
-          },
-          {
-            "path": "_rels/.rels",
-            "bytes": 599,
-            "sha256": "43bdd04f31bc9c60ecca6b3faf6a72376fc8060387613530dac16f33a95ad125",
-            "kind": "xml"
-          },
-          {
-            "path": "docProps/app.xml",
-            "bytes": 240,
-            "sha256": "5df79d0a31334db4c5219762f75da9d5481dac7b14ff74625ee992033308b974",
-            "kind": "xml"
-          },
-          {
-            "path": "docProps/core.xml",
-            "bytes": 614,
-            "sha256": "6467c3d081b0151d60bd0e132d2d383e2f8bf829cfbad24b6b88bb15a62d498f",
-            "kind": "xml"
-          },
-          {
-            "path": "word/_rels/document.xml.rels",
-            "bytes": 697,
-            "sha256": "b04f18d853437b6f9800c4babbd6f16da6929ab1153e74698675a066d3f4d178",
-            "kind": "xml"
-          },
-          {
-            "path": "word/document.xml",
-            "bytes": 675,
-            "sha256": "547ca09f68929c7fe3f311b11f63d23a794b5f00a294ea4a6a130989355a1748",
-            "kind": "xml"
-          },
-          {
-            "path": "word/fontTable.xml",
-            "bytes": 507,
-            "sha256": "dab3a02701bb752acbac3f5160e7ccfd1e30303f6dac388963793f3cf5097de3",
-            "kind": "xml"
-          },
-          {
-            "path": "word/settings.xml",
-            "bytes": 405,
-            "sha256": "c15f810187617b76b223ca1220c7542ca0f8e21f505ca024887cd33502f6ebfa",
-            "kind": "xml"
-          },
-          {
-            "path": "word/styles.xml",
-            "bytes": 619,
-            "sha256": "39474e791b005132e5b82a4fd4e1c432840af5a504b27c76bc9916bea76ab5f6",
-            "kind": "xml"
-          },
-          {
-            "path": "word/webSettings.xml",
-            "bytes": 201,
-            "sha256": "6e1f152ff1f1be1a03477695104522ab2091039961d4d3d5745cc854a015eff0",
-            "kind": "xml"
-          }
-        ],
-        "stats": {
-          "insertions": 1,
-          "deletions": 0,
-          "modifications": 0,
-          "insertedRanges": 1,
-          "deletedRanges": 0,
-          "insertedAtoms": 12,
-          "deletedAtoms": 0,
-          "modifiedParagraphs": 0,
-          "formatChanges": 0,
-          "formatChangeAtoms": 0
-        },
-        "fallback": {
-          "comparisonStrategyUsed": "legacy",
-          "reconstructionModeUsed": "inplace"
-        },
-        "unrepresentedChanges": [],
-        "schema": {
-          "packageStructural": "passed",
-          "issues": [],
-          "introducedIssues": []
-        },
-        "formatting": {
-          "score": 1,
-          "acceptScore": 1,
-          "rejectScore": 1,
-          "acceptDivergences": 0,
-          "rejectDivergences": 0
-        },
-        "closure": {
-          "relationshipIssues": [],
-          "auxiliaryDefinitionIssues": []
-        },
-        "unsupportedStoryDiagnostics": [],
-        "forbiddenPayloadLeaks": []
-      },
+      "approvedDivergenceIds": [],
       "taggedTree": {
         "strategy": "tagged-tree",
         "projections": {
@@ -3123,9 +1863,8 @@
           "formatChanges": 0,
           "formatChangeAtoms": 0
         },
-        "fallback": {
-          "comparisonStrategyUsed": "tagged-tree",
-          "reconstructionModeUsed": "inplace"
+        "authority": {
+          "comparisonStrategyUsed": "tagged-tree"
         },
         "unrepresentedChanges": [],
         "schema": {
@@ -3144,8 +1883,7 @@
           "relationshipIssues": [],
           "auxiliaryDefinitionIssues": []
         },
-        "unsupportedStoryDiagnostics": [],
-        "forbiddenPayloadLeaks": []
+        "unsupportedStoryDiagnostics": []
       }
     },
     {
@@ -3172,125 +1910,7 @@
         ],
         "sourceStructuralIssues": []
       },
-      "approvedDivergenceIds": [
-        "TD-ATOM-STATS-SEMANTICS-001"
-      ],
-      "legacy": {
-        "strategy": "legacy",
-        "projections": {
-          "accept": {
-            "xmlSha256": "bbcfa28a5215caf88596392c70acd8acea7d98211869d7a1d74eea873fdcdc50",
-            "textSha256": "a357fd67c84aea2b0d6fb4fa6b852ba7077410eecdc1ccab827e7fc55e5abc0c",
-            "sourceTextSha256": "a357fd67c84aea2b0d6fb4fa6b852ba7077410eecdc1ccab827e7fc55e5abc0c",
-            "matchesSourceText": true,
-            "firstDifference": null
-          },
-          "reject": {
-            "xmlSha256": "9b589aa05ea673258d1a41897804f8e17144886928086bd696ba30c2644c2c79",
-            "textSha256": "e03987d82402d135ced95813d268f0f37f99f5abb25ee6120e2060b484383aac",
-            "sourceTextSha256": "e03987d82402d135ced95813d268f0f37f99f5abb25ee6120e2060b484383aac",
-            "matchesSourceText": true,
-            "firstDifference": null
-          }
-        },
-        "packageParts": [
-          {
-            "path": "[Content_Types].xml",
-            "bytes": 1224,
-            "sha256": "427d80e1dca4ad14bbc41967ce86b1ee8e36d465c1664879d139649bdb3fe2be",
-            "kind": "xml"
-          },
-          {
-            "path": "_rels/.rels",
-            "bytes": 599,
-            "sha256": "43bdd04f31bc9c60ecca6b3faf6a72376fc8060387613530dac16f33a95ad125",
-            "kind": "xml"
-          },
-          {
-            "path": "docProps/app.xml",
-            "bytes": 240,
-            "sha256": "5df79d0a31334db4c5219762f75da9d5481dac7b14ff74625ee992033308b974",
-            "kind": "xml"
-          },
-          {
-            "path": "docProps/core.xml",
-            "bytes": 614,
-            "sha256": "6467c3d081b0151d60bd0e132d2d383e2f8bf829cfbad24b6b88bb15a62d498f",
-            "kind": "xml"
-          },
-          {
-            "path": "word/_rels/document.xml.rels",
-            "bytes": 697,
-            "sha256": "b04f18d853437b6f9800c4babbd6f16da6929ab1153e74698675a066d3f4d178",
-            "kind": "xml"
-          },
-          {
-            "path": "word/document.xml",
-            "bytes": 873,
-            "sha256": "466ec3cb1f8fafbb89e7981694ba549179b8453fdff282f52146045f14cdc2b4",
-            "kind": "xml"
-          },
-          {
-            "path": "word/fontTable.xml",
-            "bytes": 507,
-            "sha256": "dab3a02701bb752acbac3f5160e7ccfd1e30303f6dac388963793f3cf5097de3",
-            "kind": "xml"
-          },
-          {
-            "path": "word/settings.xml",
-            "bytes": 405,
-            "sha256": "c15f810187617b76b223ca1220c7542ca0f8e21f505ca024887cd33502f6ebfa",
-            "kind": "xml"
-          },
-          {
-            "path": "word/styles.xml",
-            "bytes": 619,
-            "sha256": "39474e791b005132e5b82a4fd4e1c432840af5a504b27c76bc9916bea76ab5f6",
-            "kind": "xml"
-          },
-          {
-            "path": "word/webSettings.xml",
-            "bytes": 201,
-            "sha256": "6e1f152ff1f1be1a03477695104522ab2091039961d4d3d5745cc854a015eff0",
-            "kind": "xml"
-          }
-        ],
-        "stats": {
-          "insertions": 1,
-          "deletions": 1,
-          "modifications": 1,
-          "insertedRanges": 1,
-          "deletedRanges": 1,
-          "insertedAtoms": 3,
-          "deletedAtoms": 3,
-          "modifiedParagraphs": 1,
-          "formatChanges": 0,
-          "formatChangeAtoms": 0
-        },
-        "fallback": {
-          "comparisonStrategyUsed": "legacy",
-          "reconstructionModeUsed": "inplace"
-        },
-        "unrepresentedChanges": [],
-        "schema": {
-          "packageStructural": "passed",
-          "issues": [],
-          "introducedIssues": []
-        },
-        "formatting": {
-          "score": 1,
-          "acceptScore": 1,
-          "rejectScore": 1,
-          "acceptDivergences": 0,
-          "rejectDivergences": 0
-        },
-        "closure": {
-          "relationshipIssues": [],
-          "auxiliaryDefinitionIssues": []
-        },
-        "unsupportedStoryDiagnostics": [],
-        "forbiddenPayloadLeaks": []
-      },
+      "approvedDivergenceIds": [],
       "taggedTree": {
         "strategy": "tagged-tree",
         "projections": {
@@ -3384,9 +2004,8 @@
           "formatChanges": 0,
           "formatChangeAtoms": 0
         },
-        "fallback": {
-          "comparisonStrategyUsed": "tagged-tree",
-          "reconstructionModeUsed": "inplace"
+        "authority": {
+          "comparisonStrategyUsed": "tagged-tree"
         },
         "unrepresentedChanges": [],
         "schema": {
@@ -3405,8 +2024,7 @@
           "relationshipIssues": [],
           "auxiliaryDefinitionIssues": []
         },
-        "unsupportedStoryDiagnostics": [],
-        "forbiddenPayloadLeaks": []
+        "unsupportedStoryDiagnostics": []
       }
     },
     {
@@ -3442,9 +2060,7 @@
         ],
         "sourceStructuralIssues": []
       },
-      "approvedDivergenceIds": [
-        "TD-ATOM-STATS-SEMANTICS-001"
-      ],
+      "approvedDivergenceIds": [],
       "taggedTree": {
         "strategy": "tagged-tree",
         "projections": {
@@ -3580,9 +2196,8 @@
           "formatChanges": 0,
           "formatChangeAtoms": 0
         },
-        "fallback": {
-          "comparisonStrategyUsed": "tagged-tree",
-          "reconstructionModeUsed": "inplace"
+        "authority": {
+          "comparisonStrategyUsed": "tagged-tree"
         },
         "unrepresentedChanges": [],
         "schema": {
@@ -3601,8 +2216,7 @@
           "relationshipIssues": [],
           "auxiliaryDefinitionIssues": []
         },
-        "unsupportedStoryDiagnostics": [],
-        "forbiddenPayloadLeaks": []
+        "unsupportedStoryDiagnostics": []
       }
     },
     {
@@ -3629,125 +2243,7 @@
         ],
         "sourceStructuralIssues": []
       },
-      "approvedDivergenceIds": [
-        "TD-ATOM-STATS-SEMANTICS-001"
-      ],
-      "legacy": {
-        "strategy": "legacy",
-        "projections": {
-          "accept": {
-            "xmlSha256": "3114469960bfdba1049f366fdcd2483352ecb7e8122cb3e39f7019dcee0b0930",
-            "textSha256": "e23279f322f590c963e6afd48a4adf8e4ddd52c54465f84155d91a281dfca890",
-            "sourceTextSha256": "e23279f322f590c963e6afd48a4adf8e4ddd52c54465f84155d91a281dfca890",
-            "matchesSourceText": true,
-            "firstDifference": null
-          },
-          "reject": {
-            "xmlSha256": "09dacec3f64d852f4fa630883df91d580b796169306f0c7666d816f4647db143",
-            "textSha256": "cd35df2ec5e65320f66306f9e9f19bd46ea7f5cfe29f7ad64d5d9fe8e5c94883",
-            "sourceTextSha256": "cd35df2ec5e65320f66306f9e9f19bd46ea7f5cfe29f7ad64d5d9fe8e5c94883",
-            "matchesSourceText": true,
-            "firstDifference": null
-          }
-        },
-        "packageParts": [
-          {
-            "path": "[Content_Types].xml",
-            "bytes": 1224,
-            "sha256": "427d80e1dca4ad14bbc41967ce86b1ee8e36d465c1664879d139649bdb3fe2be",
-            "kind": "xml"
-          },
-          {
-            "path": "_rels/.rels",
-            "bytes": 599,
-            "sha256": "43bdd04f31bc9c60ecca6b3faf6a72376fc8060387613530dac16f33a95ad125",
-            "kind": "xml"
-          },
-          {
-            "path": "docProps/app.xml",
-            "bytes": 240,
-            "sha256": "5df79d0a31334db4c5219762f75da9d5481dac7b14ff74625ee992033308b974",
-            "kind": "xml"
-          },
-          {
-            "path": "docProps/core.xml",
-            "bytes": 614,
-            "sha256": "6467c3d081b0151d60bd0e132d2d383e2f8bf829cfbad24b6b88bb15a62d498f",
-            "kind": "xml"
-          },
-          {
-            "path": "word/_rels/document.xml.rels",
-            "bytes": 697,
-            "sha256": "b04f18d853437b6f9800c4babbd6f16da6929ab1153e74698675a066d3f4d178",
-            "kind": "xml"
-          },
-          {
-            "path": "word/document.xml",
-            "bytes": 626,
-            "sha256": "340a8bc8cfca6407f43775979be66775a92dbdecd0354f071fb7b7eb8eaef781",
-            "kind": "xml"
-          },
-          {
-            "path": "word/fontTable.xml",
-            "bytes": 507,
-            "sha256": "dab3a02701bb752acbac3f5160e7ccfd1e30303f6dac388963793f3cf5097de3",
-            "kind": "xml"
-          },
-          {
-            "path": "word/settings.xml",
-            "bytes": 405,
-            "sha256": "c15f810187617b76b223ca1220c7542ca0f8e21f505ca024887cd33502f6ebfa",
-            "kind": "xml"
-          },
-          {
-            "path": "word/styles.xml",
-            "bytes": 619,
-            "sha256": "39474e791b005132e5b82a4fd4e1c432840af5a504b27c76bc9916bea76ab5f6",
-            "kind": "xml"
-          },
-          {
-            "path": "word/webSettings.xml",
-            "bytes": 201,
-            "sha256": "6e1f152ff1f1be1a03477695104522ab2091039961d4d3d5745cc854a015eff0",
-            "kind": "xml"
-          }
-        ],
-        "stats": {
-          "insertions": 1,
-          "deletions": 1,
-          "modifications": 1,
-          "insertedRanges": 1,
-          "deletedRanges": 1,
-          "insertedAtoms": 1,
-          "deletedAtoms": 1,
-          "modifiedParagraphs": 1,
-          "formatChanges": 0,
-          "formatChangeAtoms": 0
-        },
-        "fallback": {
-          "comparisonStrategyUsed": "legacy",
-          "reconstructionModeUsed": "inplace"
-        },
-        "unrepresentedChanges": [],
-        "schema": {
-          "packageStructural": "passed",
-          "issues": [],
-          "introducedIssues": []
-        },
-        "formatting": {
-          "score": 1,
-          "acceptScore": 1,
-          "rejectScore": 1,
-          "acceptDivergences": 0,
-          "rejectDivergences": 0
-        },
-        "closure": {
-          "relationshipIssues": [],
-          "auxiliaryDefinitionIssues": []
-        },
-        "unsupportedStoryDiagnostics": [],
-        "forbiddenPayloadLeaks": []
-      },
+      "approvedDivergenceIds": [],
       "taggedTree": {
         "strategy": "tagged-tree",
         "projections": {
@@ -3841,9 +2337,8 @@
           "formatChanges": 0,
           "formatChangeAtoms": 0
         },
-        "fallback": {
-          "comparisonStrategyUsed": "tagged-tree",
-          "reconstructionModeUsed": "inplace"
+        "authority": {
+          "comparisonStrategyUsed": "tagged-tree"
         },
         "unrepresentedChanges": [],
         "schema": {
@@ -3862,8 +2357,7 @@
           "relationshipIssues": [],
           "auxiliaryDefinitionIssues": []
         },
-        "unsupportedStoryDiagnostics": [],
-        "forbiddenPayloadLeaks": []
+        "unsupportedStoryDiagnostics": []
       }
     },
     {
@@ -3890,125 +2384,7 @@
         ],
         "sourceStructuralIssues": []
       },
-      "approvedDivergenceIds": [
-        "TD-ATOM-STATS-SEMANTICS-001"
-      ],
-      "legacy": {
-        "strategy": "legacy",
-        "projections": {
-          "accept": {
-            "xmlSha256": "94b1a47275879c6b9a38c1e4e79da6ac97f2ffdcf1e2331615c2241aaea39c87",
-            "textSha256": "5f36e6026780119ef4a4f961a3fa0869a6dd5548a559fd5e347dc54d423906be",
-            "sourceTextSha256": "5f36e6026780119ef4a4f961a3fa0869a6dd5548a559fd5e347dc54d423906be",
-            "matchesSourceText": true,
-            "firstDifference": null
-          },
-          "reject": {
-            "xmlSha256": "a5edfd61440eb614bf59d56301abe37e89b52f0b8769a1b67a2c710ef76ed929",
-            "textSha256": "334f6d7c1118c0e825630d31f920663b130675348ef4bbd9022519471c01789a",
-            "sourceTextSha256": "334f6d7c1118c0e825630d31f920663b130675348ef4bbd9022519471c01789a",
-            "matchesSourceText": true,
-            "firstDifference": null
-          }
-        },
-        "packageParts": [
-          {
-            "path": "[Content_Types].xml",
-            "bytes": 1224,
-            "sha256": "427d80e1dca4ad14bbc41967ce86b1ee8e36d465c1664879d139649bdb3fe2be",
-            "kind": "xml"
-          },
-          {
-            "path": "_rels/.rels",
-            "bytes": 599,
-            "sha256": "43bdd04f31bc9c60ecca6b3faf6a72376fc8060387613530dac16f33a95ad125",
-            "kind": "xml"
-          },
-          {
-            "path": "docProps/app.xml",
-            "bytes": 240,
-            "sha256": "5df79d0a31334db4c5219762f75da9d5481dac7b14ff74625ee992033308b974",
-            "kind": "xml"
-          },
-          {
-            "path": "docProps/core.xml",
-            "bytes": 614,
-            "sha256": "6467c3d081b0151d60bd0e132d2d383e2f8bf829cfbad24b6b88bb15a62d498f",
-            "kind": "xml"
-          },
-          {
-            "path": "word/_rels/document.xml.rels",
-            "bytes": 697,
-            "sha256": "b04f18d853437b6f9800c4babbd6f16da6929ab1153e74698675a066d3f4d178",
-            "kind": "xml"
-          },
-          {
-            "path": "word/document.xml",
-            "bytes": 1424,
-            "sha256": "bd1a866ffc9a443143ca4e7b0de62d84f411f3950cd9d0be66c749593bf24df9",
-            "kind": "xml"
-          },
-          {
-            "path": "word/fontTable.xml",
-            "bytes": 507,
-            "sha256": "dab3a02701bb752acbac3f5160e7ccfd1e30303f6dac388963793f3cf5097de3",
-            "kind": "xml"
-          },
-          {
-            "path": "word/settings.xml",
-            "bytes": 405,
-            "sha256": "c15f810187617b76b223ca1220c7542ca0f8e21f505ca024887cd33502f6ebfa",
-            "kind": "xml"
-          },
-          {
-            "path": "word/styles.xml",
-            "bytes": 619,
-            "sha256": "39474e791b005132e5b82a4fd4e1c432840af5a504b27c76bc9916bea76ab5f6",
-            "kind": "xml"
-          },
-          {
-            "path": "word/webSettings.xml",
-            "bytes": 201,
-            "sha256": "6e1f152ff1f1be1a03477695104522ab2091039961d4d3d5745cc854a015eff0",
-            "kind": "xml"
-          }
-        ],
-        "stats": {
-          "insertions": 2,
-          "deletions": 2,
-          "modifications": 1,
-          "insertedRanges": 2,
-          "deletedRanges": 2,
-          "insertedAtoms": 4,
-          "deletedAtoms": 10,
-          "modifiedParagraphs": 1,
-          "formatChanges": 0,
-          "formatChangeAtoms": 0
-        },
-        "fallback": {
-          "comparisonStrategyUsed": "legacy",
-          "reconstructionModeUsed": "inplace"
-        },
-        "unrepresentedChanges": [],
-        "schema": {
-          "packageStructural": "passed",
-          "issues": [],
-          "introducedIssues": []
-        },
-        "formatting": {
-          "score": 1,
-          "acceptScore": 1,
-          "rejectScore": 1,
-          "acceptDivergences": 0,
-          "rejectDivergences": 0
-        },
-        "closure": {
-          "relationshipIssues": [],
-          "auxiliaryDefinitionIssues": []
-        },
-        "unsupportedStoryDiagnostics": [],
-        "forbiddenPayloadLeaks": []
-      },
+      "approvedDivergenceIds": [],
       "taggedTree": {
         "strategy": "tagged-tree",
         "projections": {
@@ -4102,9 +2478,8 @@
           "formatChanges": 0,
           "formatChangeAtoms": 0
         },
-        "fallback": {
-          "comparisonStrategyUsed": "tagged-tree",
-          "reconstructionModeUsed": "inplace"
+        "authority": {
+          "comparisonStrategyUsed": "tagged-tree"
         },
         "unrepresentedChanges": [],
         "schema": {
@@ -4123,8 +2498,7 @@
           "relationshipIssues": [],
           "auxiliaryDefinitionIssues": []
         },
-        "unsupportedStoryDiagnostics": [],
-        "forbiddenPayloadLeaks": []
+        "unsupportedStoryDiagnostics": []
       }
     },
     {
@@ -4197,335 +2571,7 @@
           }
         ]
       },
-      "approvedDivergenceIds": [
-        "TD-ATOM-STATS-SEMANTICS-001"
-      ],
-      "legacy": {
-        "strategy": "legacy",
-        "projections": {
-          "accept": {
-            "xmlSha256": "d538fec6af1b1d03291e3442b27cea4c6277fa9cf93e9487e8e1b277fc4086cc",
-            "textSha256": "6a5d2768fa3af0eebc107f955e9950e52ec543f06d2a8b3504a5dc23067cffaf",
-            "sourceTextSha256": "6a5d2768fa3af0eebc107f955e9950e52ec543f06d2a8b3504a5dc23067cffaf",
-            "matchesSourceText": true,
-            "firstDifference": null
-          },
-          "reject": {
-            "xmlSha256": "4287b6caa8b2f53b1673f2c5d66761e2e745548ffcd307edbc2ea67eb26cedde",
-            "textSha256": "9ff29fc90eeff2dfebe4cfab4fe56e73e9798f307768e8d6d237869091dfbe72",
-            "sourceTextSha256": "9ff29fc90eeff2dfebe4cfab4fe56e73e9798f307768e8d6d237869091dfbe72",
-            "matchesSourceText": true,
-            "firstDifference": null
-          }
-        },
-        "packageParts": [
-          {
-            "path": "[Content_Types].xml",
-            "bytes": 4758,
-            "sha256": "9f8c48688c6613ec33aac351c31479b9a04ebfa47f9ba5cdf447a768d7a86e94",
-            "kind": "xml"
-          },
-          {
-            "path": "_rels/.rels",
-            "bytes": 882,
-            "sha256": "7475b604d003241b3ad58d35f3bd5d0bb842b55fd58b7cd8881803066e6b4736",
-            "kind": "xml"
-          },
-          {
-            "path": "customXml/_rels/item1.xml.rels",
-            "bytes": 295,
-            "sha256": "17f9862707a9096391a4a78b5fd8897ecb5686c7436e07dd1a73da7e7fa9e903",
-            "kind": "xml"
-          },
-          {
-            "path": "customXml/_rels/item2.xml.rels",
-            "bytes": 295,
-            "sha256": "b4d03e202767efbe0b08716f60b83ce160c8e72a5cc4b4b98db1e192b664cfd9",
-            "kind": "xml"
-          },
-          {
-            "path": "customXml/_rels/item3.xml.rels",
-            "bytes": 295,
-            "sha256": "400ba8878c755feab8e5c0eb2ac7c55514f6018f0220a1c5e8651f588c933bf1",
-            "kind": "xml"
-          },
-          {
-            "path": "customXml/item1.xml",
-            "bytes": 14622,
-            "sha256": "b9d32e3f928b60946c764d2d21be01125f38d5571f6153621f82b8de38d940f3",
-            "kind": "xml"
-          },
-          {
-            "path": "customXml/item2.xml",
-            "bytes": 219,
-            "sha256": "5efcaf9ad70d9c29f406ee438f8f428b021a881d2c5afff0e53b00b1f67ae51e",
-            "kind": "xml"
-          },
-          {
-            "path": "customXml/item3.xml",
-            "bytes": 587,
-            "sha256": "001ef0f7080eccc3f1483be722ea1174e232ffae226cae5a96cbc14b659cda84",
-            "kind": "xml"
-          },
-          {
-            "path": "customXml/itemProps1.xml",
-            "bytes": 200,
-            "sha256": "3ae5d793e139e5a681fc8f9de86ac2cbf48584903626e8fac913080bf99d45b9",
-            "kind": "xml"
-          },
-          {
-            "path": "customXml/itemProps2.xml",
-            "bytes": 200,
-            "sha256": "94cb1cc664cb5de2626ed423034b0d7d038bca115b95cdb2a68e6f8eee9b91b1",
-            "kind": "xml"
-          },
-          {
-            "path": "customXml/itemProps3.xml",
-            "bytes": 200,
-            "sha256": "3ce0dbbddfe2fe6c321a46594b93f00030115eff7b44555c48077e9663d0d4dd",
-            "kind": "xml"
-          },
-          {
-            "path": "docMetadata/LabelInfo.xml",
-            "bytes": 299,
-            "sha256": "8f812db868016f48192519abdc756248abd4f5581900c8b8e2380cfd9398b309",
-            "kind": "xml"
-          },
-          {
-            "path": "docProps/app.xml",
-            "bytes": 237,
-            "sha256": "d4dff3a2defefd93b329d86971ed3ac792aaa30765305d46645f076b52f9d75a",
-            "kind": "xml"
-          },
-          {
-            "path": "docProps/core.xml",
-            "bytes": 581,
-            "sha256": "df8a1f12ba03629cbc2c519c2a53f9a50678916ba167591289c7dc7fe1f30483",
-            "kind": "xml"
-          },
-          {
-            "path": "docProps/custom.xml",
-            "bytes": 401,
-            "sha256": "9ca0b71d560d5cbc366ab15b82f90da938d74a725e812ac173b5b3176fedea7e",
-            "kind": "xml"
-          },
-          {
-            "path": "word/_rels/document.xml.rels",
-            "bytes": 4102,
-            "sha256": "00d4ed11b9d1fcb4c67f7bdf2d6a1f6df55104f7a66890e25ce3e6f9dcf22ab8",
-            "kind": "xml"
-          },
-          {
-            "path": "word/customizations.xml",
-            "bytes": 2282,
-            "sha256": "74fa07508b9f465c36cfb761fa23ad00a5d079fdbd744f24c0942556db5f0967",
-            "kind": "xml"
-          },
-          {
-            "path": "word/document.xml",
-            "bytes": 506144,
-            "sha256": "f1410b82bf50c009c2eaba7cdb2fb602daf0f5f2e2c423151839830419c27d40",
-            "kind": "xml"
-          },
-          {
-            "path": "word/endnotes.xml",
-            "bytes": 3206,
-            "sha256": "00a35fdbabbdbc0e23eebc5f9d62b649904116b09dc59d8a562d5264ef41e549",
-            "kind": "xml"
-          },
-          {
-            "path": "word/fontTable.xml",
-            "bytes": 3308,
-            "sha256": "45d15b8db9c8de814a810670845268c5fae975ccef0a981a35c3fd0ca8f24745",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer1.xml",
-            "bytes": 3078,
-            "sha256": "4bcfe839341cfc0f5aa7380f12233ad072489660a834db463efb81f9aafaabc6",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer10.xml",
-            "bytes": 3169,
-            "sha256": "e274e590688ea64c3e9988c70ad5afeb352a923ca6c79a681c5cf108fce76ef8",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer2.xml",
-            "bytes": 3919,
-            "sha256": "790a68ca6294e627737a1f0b8790e006839e07fc2522772d32d3d0e5885547cd",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer3.xml",
-            "bytes": 3563,
-            "sha256": "78ff16ccfefa21ff9594b68504c01fc7ca489abb9d8fa8a89cef55774ef63399",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer4.xml",
-            "bytes": 2766,
-            "sha256": "5d14c1d00c0b1cf22933f71b9c64d4b5f86c66569ca30a9542c78ce0f9a8e5e3",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer5.xml",
-            "bytes": 4196,
-            "sha256": "2d6b776d6c79f92e3edb70db36709cbe545662693c092464c248b82e26d3f11c",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer6.xml",
-            "bytes": 3705,
-            "sha256": "a553b3c2c18b29172b7f0ed04c8aa72dee2e687b932c563b5bc0aa41356ededa",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer7.xml",
-            "bytes": 2766,
-            "sha256": "9fe3cb0c367df5344856551583bb89c13b54a48329d21913d716aa60123830e1",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer8.xml",
-            "bytes": 3162,
-            "sha256": "51848fd2e7d732448914dac32a864a964b658e052c12086428d8a4dda0ff696d",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer9.xml",
-            "bytes": 3621,
-            "sha256": "7cba4c26ce60ea129fb04af3ca0d822f99500a4943b0b8bd3cf01aad51bf876f",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footnotes.xml",
-            "bytes": 227039,
-            "sha256": "8faef1d85a422d4cae6f3fd623276728debdcd2b96eb71ba89dee4e6750030d4",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header1.xml",
-            "bytes": 6828,
-            "sha256": "abdd73b979b826d03b4c44cff3ccdaf5e00b085a0dd6f30413d2fac571e8f78e",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header2.xml",
-            "bytes": 2719,
-            "sha256": "524d44be2bab5a7862d566ece5644818e5e30d7e22d5061d615429f1d1650570",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header3.xml",
-            "bytes": 2871,
-            "sha256": "56459642ef09501593249cab73ecb9cad16e5f7840990a2689af6d4d4584bfe0",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header4.xml",
-            "bytes": 2765,
-            "sha256": "aab4fa5350d25823c37d22a484162d266676b388ede828864d20a65c86466c1a",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header5.xml",
-            "bytes": 2719,
-            "sha256": "26e520ef98186de7705ad59552b68ebe9346a46e2901aa12b25295a382ec81fe",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header6.xml",
-            "bytes": 2850,
-            "sha256": "797fa05d4c1d87b39c50fef648de5ddee2de886780a7276ac5ed7de7fda42cd9",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header7.xml",
-            "bytes": 2766,
-            "sha256": "68386eff1940728b7f14a2936ba612b811abc77ded11a79568f359051ee8b104",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header8.xml",
-            "bytes": 2719,
-            "sha256": "c226086c129cf69031fa939ed4550b18c8b4639399d9f3d14a149ae1b0c10994",
-            "kind": "xml"
-          },
-          {
-            "path": "word/numbering.xml",
-            "bytes": 85493,
-            "sha256": "8441ceeb57a9d6e7431cb45288641f38eea143a8fa540c436a18aaa7f5980300",
-            "kind": "xml"
-          },
-          {
-            "path": "word/settings.xml",
-            "bytes": 44865,
-            "sha256": "df190431f5914b7681a703877068cedd97d9d9d8000e231a6a9aab818571bd93",
-            "kind": "xml"
-          },
-          {
-            "path": "word/styles.xml",
-            "bytes": 48371,
-            "sha256": "3ad55167cb330030e5b4d38133e91fca30fd323223e3613519a0dfc4d14c471a",
-            "kind": "xml"
-          },
-          {
-            "path": "word/theme/theme1.xml",
-            "bytes": 6794,
-            "sha256": "3734b22b9283499bfc86a9aae98c377100a3e09700b97d1992c2ca3b07134234",
-            "kind": "xml"
-          },
-          {
-            "path": "word/webSettings.xml",
-            "bytes": 5957,
-            "sha256": "2a36b7c85d0ad966851d7a418a8a27efed119f8f94d3ee08c89dde1391072852",
-            "kind": "xml"
-          }
-        ],
-        "stats": {
-          "insertions": 10,
-          "deletions": 11,
-          "modifications": 10,
-          "insertedRanges": 10,
-          "deletedRanges": 11,
-          "insertedAtoms": 10,
-          "deletedAtoms": 193,
-          "modifiedParagraphs": 10,
-          "formatChanges": 0,
-          "formatChangeAtoms": 0
-        },
-        "fallback": {
-          "comparisonStrategyUsed": "legacy",
-          "reconstructionModeUsed": "inplace"
-        },
-        "unrepresentedChanges": [],
-        "schema": {
-          "packageStructural": "inherited",
-          "issues": [
-            {
-              "check": "xml_declaration",
-              "part": "customXml/item2.xml",
-              "message": "XML part does not begin with an <?xml declaration"
-            }
-          ],
-          "introducedIssues": []
-        },
-        "formatting": {
-          "score": 1,
-          "acceptScore": 1,
-          "rejectScore": 1,
-          "acceptDivergences": 0,
-          "rejectDivergences": 0
-        },
-        "closure": {
-          "relationshipIssues": [],
-          "auxiliaryDefinitionIssues": []
-        },
-        "unsupportedStoryDiagnostics": [],
-        "forbiddenPayloadLeaks": []
-      },
+      "approvedDivergenceIds": [],
       "taggedTree": {
         "strategy": "tagged-tree",
         "projections": {
@@ -4823,9 +2869,8 @@
           "formatChanges": 0,
           "formatChangeAtoms": 0
         },
-        "fallback": {
-          "comparisonStrategyUsed": "tagged-tree",
-          "reconstructionModeUsed": "inplace"
+        "authority": {
+          "comparisonStrategyUsed": "tagged-tree"
         },
         "unrepresentedChanges": [],
         "schema": {
@@ -4850,8 +2895,7 @@
           "relationshipIssues": [],
           "auxiliaryDefinitionIssues": []
         },
-        "unsupportedStoryDiagnostics": [],
-        "forbiddenPayloadLeaks": []
+        "unsupportedStoryDiagnostics": []
       }
     },
     {
@@ -4946,297 +2990,7 @@
           }
         ]
       },
-      "approvedDivergenceIds": [
-        "TD-ATOM-STATS-SEMANTICS-001"
-      ],
-      "legacy": {
-        "strategy": "legacy",
-        "projections": {
-          "accept": {
-            "xmlSha256": "6e3f2954d3724e43e7f9e3d2a4b0df8bd44d63fcac13b45194cc2f21906a00b7",
-            "textSha256": "fea402e2ba309cc8985eeec01588541b65045ce36e64504106246b3b70890075",
-            "sourceTextSha256": "fea402e2ba309cc8985eeec01588541b65045ce36e64504106246b3b70890075",
-            "matchesSourceText": true,
-            "firstDifference": null
-          },
-          "reject": {
-            "xmlSha256": "f9a5dc2267daacd3ca8c76d8a3b85c883b53f6728fa36fc7fd3c5f9cb7d9941f",
-            "textSha256": "ead0799c60ab7059999d1ee49a501a1fedc2861f0c2ba3ba982d749b0402b96c",
-            "sourceTextSha256": "ead0799c60ab7059999d1ee49a501a1fedc2861f0c2ba3ba982d749b0402b96c",
-            "matchesSourceText": true,
-            "firstDifference": null
-          }
-        },
-        "packageParts": [
-          {
-            "path": "[Content_Types].xml",
-            "bytes": 3244,
-            "sha256": "3ce91b949238646124802c4885edca64845a1a4f6d0c8e9b3f7a265f5debddb3",
-            "kind": "xml"
-          },
-          {
-            "path": "_rels/.rels",
-            "bytes": 589,
-            "sha256": "0e6575f491f9f7d61c3022df7efa04ca27fae2ccde341e2f5fc1f701f4739e4f",
-            "kind": "xml"
-          },
-          {
-            "path": "docProps/app.xml",
-            "bytes": 994,
-            "sha256": "e28b6e84660003172a56c5254eb32bc3ad3c48d26c4353f45bcc57346eec4dea",
-            "kind": "xml"
-          },
-          {
-            "path": "docProps/core.xml",
-            "bytes": 620,
-            "sha256": "ea58890e8da281fa818655cad2dd36785102a4ffad69ec32dee91c6055d0726c",
-            "kind": "xml"
-          },
-          {
-            "path": "word/_rels/document.xml.rels",
-            "bytes": 2760,
-            "sha256": "b3fabaa32cbda2a643cf54ae62f629c314b522902beac2fd30ff6f2ed4ecd30d",
-            "kind": "xml"
-          },
-          {
-            "path": "word/document.xml",
-            "bytes": 348735,
-            "sha256": "efa343ed180dff59766d96f386ad0cad15283e6d28357c020ed0a0c623355ee2",
-            "kind": "xml"
-          },
-          {
-            "path": "word/endnotes.xml",
-            "bytes": 2776,
-            "sha256": "f579e0aa9d6f12b46d9d8871a43f167047dfbcbdc2cc6d439a3361fd45a7e7e2",
-            "kind": "xml"
-          },
-          {
-            "path": "word/fontTable.xml",
-            "bytes": 2988,
-            "sha256": "c36699401f4985152d876e80543af7664e0ed4cc6ea6b6407fac2b38e08b80db",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer1.xml",
-            "bytes": 4066,
-            "sha256": "f9f3af39032dab593b17cec4f622b946ca1795521c1bed7213a759d61d1cc215",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer2.xml",
-            "bytes": 4426,
-            "sha256": "07a89d7f1de17d09ce32016440de7faba0a0c930b6e659091d2ce38115c1cb00",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer3.xml",
-            "bytes": 3419,
-            "sha256": "f1925fdfab02dd02d31d8955ea69df89c9f991989b9e1ca14697801b3d6944aa",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer4.xml",
-            "bytes": 4628,
-            "sha256": "5badedcb1732add2829e7e64b5028234c524fbef1744b35b3d3cebfb0d54e92e",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer5.xml",
-            "bytes": 3651,
-            "sha256": "bd7a073718bfb45fcc94778e469e336ac7d80c3102fe5c928cfdea942e6b5854",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer6.xml",
-            "bytes": 3251,
-            "sha256": "25c2e07b3635133390de5fbf180e51254b01ca12e517c2f6e85020e6f1d22979",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer7.xml",
-            "bytes": 3916,
-            "sha256": "c7984269a964211a86febd778f2608b7563714935637c0ebb575f60ecd9f4278",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footnotes.xml",
-            "bytes": 2782,
-            "sha256": "72800b242f763c1332c653d53a5c93a299e35b8eb834f9d3faf2340f9a9d5ac3",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header1.xml",
-            "bytes": 2623,
-            "sha256": "a0fc44607dc9f64dfa948bc35710d9f4e6d7e362b5f081d646f86ed2fcadb6c7",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header2.xml",
-            "bytes": 2623,
-            "sha256": "9afdd929c5e788d0257e3a150aca290612466bc08c0b5a711974adde3e3f3546",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header3.xml",
-            "bytes": 3459,
-            "sha256": "a90a727abea0a34836338fe31278021102211da8b7da5b43f79e282f4464e0b1",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header4.xml",
-            "bytes": 2530,
-            "sha256": "9355edff1af856c3732590577164cc124ddc1f473f467dc85e2db0ea3a9f72ed",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header5.xml",
-            "bytes": 2623,
-            "sha256": "45d154de3bd78ec61a0667559296b8ff3f0abd1785ac6f3c9adf799843e9f963",
-            "kind": "xml"
-          },
-          {
-            "path": "word/numbering.xml",
-            "bytes": 20164,
-            "sha256": "bcf36227ea301455eb6ce706c34a93bd7b9e37e46b3149667786b582ff84350d",
-            "kind": "xml"
-          },
-          {
-            "path": "word/settings.xml",
-            "bytes": 6456,
-            "sha256": "11d0809a9eaf4c74d1e3214881baaa877e278610d91e47fa145926dffffd10ba",
-            "kind": "xml"
-          },
-          {
-            "path": "word/styles.xml",
-            "bytes": 37760,
-            "sha256": "7e290cf277674f7c9bc99611bb81b56cf49915e0284db81d74bc499649479837",
-            "kind": "xml"
-          },
-          {
-            "path": "word/theme/theme1.xml",
-            "bytes": 6798,
-            "sha256": "7a384ac82531e4f77ed57074d8b623b745ca5c722d529e3f268c344dd2344507",
-            "kind": "xml"
-          },
-          {
-            "path": "word/webSettings.xml",
-            "bytes": 880,
-            "sha256": "9fc8a98dae8b6c9934fd30083779777d43987edf7ab251ba1053e09b2f0054dd",
-            "kind": "xml"
-          }
-        ],
-        "stats": {
-          "insertions": 0,
-          "deletions": 1,
-          "modifications": 0,
-          "insertedRanges": 0,
-          "deletedRanges": 1,
-          "insertedAtoms": 0,
-          "deletedAtoms": 350,
-          "modifiedParagraphs": 0,
-          "formatChanges": 0,
-          "formatChangeAtoms": 0
-        },
-        "fallback": {
-          "comparisonStrategyUsed": "legacy",
-          "reconstructionModeUsed": "inplace"
-        },
-        "unrepresentedChanges": [],
-        "schema": {
-          "packageStructural": "inherited",
-          "issues": [
-            {
-              "check": "field_pairing",
-              "part": "word/footer2.xml",
-              "message": "fldChar begin while a field is already open"
-            },
-            {
-              "check": "field_pairing",
-              "part": "word/footer2.xml",
-              "message": "w:instrText outside a begin→separate range"
-            },
-            {
-              "check": "field_pairing",
-              "part": "word/footer2.xml",
-              "message": "w:instrText outside a begin→separate range"
-            },
-            {
-              "check": "field_pairing",
-              "part": "word/footer2.xml",
-              "message": "w:instrText outside a begin→separate range"
-            },
-            {
-              "check": "field_pairing",
-              "part": "word/footer2.xml",
-              "message": "fldChar end without a matching begin"
-            },
-            {
-              "check": "field_pairing",
-              "part": "word/footer4.xml",
-              "message": "fldChar begin while a field is already open"
-            },
-            {
-              "check": "field_pairing",
-              "part": "word/footer4.xml",
-              "message": "w:instrText outside a begin→separate range"
-            },
-            {
-              "check": "field_pairing",
-              "part": "word/footer4.xml",
-              "message": "w:instrText outside a begin→separate range"
-            },
-            {
-              "check": "field_pairing",
-              "part": "word/footer4.xml",
-              "message": "w:instrText outside a begin→separate range"
-            },
-            {
-              "check": "field_pairing",
-              "part": "word/footer4.xml",
-              "message": "fldChar end without a matching begin"
-            },
-            {
-              "check": "field_pairing",
-              "part": "word/footer7.xml",
-              "message": "fldChar begin while a field is already open"
-            },
-            {
-              "check": "field_pairing",
-              "part": "word/footer7.xml",
-              "message": "w:instrText outside a begin→separate range"
-            },
-            {
-              "check": "field_pairing",
-              "part": "word/footer7.xml",
-              "message": "w:instrText outside a begin→separate range"
-            },
-            {
-              "check": "field_pairing",
-              "part": "word/footer7.xml",
-              "message": "w:instrText outside a begin→separate range"
-            },
-            {
-              "check": "field_pairing",
-              "part": "word/footer7.xml",
-              "message": "fldChar end without a matching begin"
-            }
-          ],
-          "introducedIssues": []
-        },
-        "formatting": {
-          "score": 1,
-          "acceptScore": 1,
-          "rejectScore": 1,
-          "acceptDivergences": 0,
-          "rejectDivergences": 0
-        },
-        "closure": {
-          "relationshipIssues": [],
-          "auxiliaryDefinitionIssues": []
-        },
-        "unsupportedStoryDiagnostics": [],
-        "forbiddenPayloadLeaks": []
-      },
+      "approvedDivergenceIds": [],
       "taggedTree": {
         "strategy": "tagged-tree",
         "projections": {
@@ -5426,9 +3180,8 @@
           "formatChanges": 0,
           "formatChangeAtoms": 0
         },
-        "fallback": {
-          "comparisonStrategyUsed": "tagged-tree",
-          "reconstructionModeUsed": "inplace"
+        "authority": {
+          "comparisonStrategyUsed": "tagged-tree"
         },
         "unrepresentedChanges": [],
         "schema": {
@@ -5523,8 +3276,7 @@
           "relationshipIssues": [],
           "auxiliaryDefinitionIssues": []
         },
-        "unsupportedStoryDiagnostics": [],
-        "forbiddenPayloadLeaks": []
+        "unsupportedStoryDiagnostics": []
       }
     },
     {
@@ -5579,257 +3331,7 @@
         ],
         "sourceStructuralIssues": []
       },
-      "approvedDivergenceIds": [
-        "TD-ATOM-STATS-SEMANTICS-001"
-      ],
-      "legacy": {
-        "strategy": "legacy",
-        "projections": {
-          "accept": {
-            "xmlSha256": "7be9ab30e275bb2aac60b23bb1dc304b2757bd7d3972fb5a60e9035f59f063ee",
-            "textSha256": "cc6d482d8879ceedf8c995fa00da7574aa7997f95fbe2dedfa105f24d8c98315",
-            "sourceTextSha256": "cc6d482d8879ceedf8c995fa00da7574aa7997f95fbe2dedfa105f24d8c98315",
-            "matchesSourceText": true,
-            "firstDifference": null
-          },
-          "reject": {
-            "xmlSha256": "0b1e3e6206b580fc4ca1e1c64778ec479cde4ae6234c057bad53749c2f4d93a6",
-            "textSha256": "d22f72831a32c3bdfce372608d4d3ed957dd20594ba711e63dfd72772f5ae7b7",
-            "sourceTextSha256": "d22f72831a32c3bdfce372608d4d3ed957dd20594ba711e63dfd72772f5ae7b7",
-            "matchesSourceText": true,
-            "firstDifference": null
-          }
-        },
-        "packageParts": [
-          {
-            "path": "[Content_Types].xml",
-            "bytes": 3852,
-            "sha256": "ffe4912ee62312aa1a0888d30871176d730a14548cd0e773d6323fad3a91efff",
-            "kind": "xml"
-          },
-          {
-            "path": "_rels/.rels",
-            "bytes": 735,
-            "sha256": "7b9ed26e45f804b81d119d3ba5a2ec70cf2e8131a4c07a796f2715ef0fbcd487",
-            "kind": "xml"
-          },
-          {
-            "path": "docMetadata/LabelInfo.xml",
-            "bytes": 299,
-            "sha256": "8f812db868016f48192519abdc756248abd4f5581900c8b8e2380cfd9398b309",
-            "kind": "xml"
-          },
-          {
-            "path": "docProps/app.xml",
-            "bytes": 996,
-            "sha256": "f2206d02609aa4a3d6d9b5a62cca4c9c8ca4e91c2679299aeebd9905d7d01a87",
-            "kind": "xml"
-          },
-          {
-            "path": "docProps/core.xml",
-            "bytes": 620,
-            "sha256": "93e400d7c2e68f37cea5ddee1b176fce1be83f739c4db1c6d5bdab510682784e",
-            "kind": "xml"
-          },
-          {
-            "path": "word/_rels/document.xml.rels",
-            "bytes": 3284,
-            "sha256": "145c894044ce04ac7d3467bec3024f83c6249a5f4831d8575d58a0c8823003da",
-            "kind": "xml"
-          },
-          {
-            "path": "word/_rels/footnotes.xml.rels",
-            "bytes": 366,
-            "sha256": "7a12e756813f3e953aa0663283330498ce2626adb2de5cea366da2f9b8311e60",
-            "kind": "xml"
-          },
-          {
-            "path": "word/customizations.xml",
-            "bytes": 2040,
-            "sha256": "896275b00484f613a759a35772adcbd794e0ebec86e73dcc32f085c03aac251f",
-            "kind": "xml"
-          },
-          {
-            "path": "word/document.xml",
-            "bytes": 544207,
-            "sha256": "a091d92caa35c9c9f7dc395e302c44c75779552772952e6dcbb76218a974f030",
-            "kind": "xml"
-          },
-          {
-            "path": "word/endnotes.xml",
-            "bytes": 3049,
-            "sha256": "26db660d0ffa49e1cc8e3e13529f9db76d2d81f713aef2d29527b0f04bb9f275",
-            "kind": "xml"
-          },
-          {
-            "path": "word/fontTable.xml",
-            "bytes": 3742,
-            "sha256": "0d4e8b7349c79ead744ce48ad8e6bc92bc8f6f4c7614f0d65f7dea88a595b402",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer1.xml",
-            "bytes": 4395,
-            "sha256": "2be86091face18c92f8b59ab123c9240ae649a0c536187c42d1eb519a7bcf932",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer2.xml",
-            "bytes": 3563,
-            "sha256": "e1d91267247fdc34847496f9415b4f97a6c8db26f96af6a6c918017aea473247",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer3.xml",
-            "bytes": 2772,
-            "sha256": "0ade6ad3eecb5731a29f65359c9554bd13d7f5c3e1b22a794ab8c0454e5cf870",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer4.xml",
-            "bytes": 4639,
-            "sha256": "e4b85c0f4f193932b623b00d659dca28f4dbfebf78aee05ba1f174ceb345aa04",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer5.xml",
-            "bytes": 2950,
-            "sha256": "83715141c03575d106c473fcaf1c5f81420c571c67725081da341203475a2933",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer6.xml",
-            "bytes": 2772,
-            "sha256": "09ffe6abe9e5e90dca5edb5386e5f40bb1eea06f69b8b0294680e92e2efa6d10",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer7.xml",
-            "bytes": 3544,
-            "sha256": "ea47cdbeaff758b036553cdadd5a4ccb4bcd48b4a196ad5c69d7237c55d351b9",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer8.xml",
-            "bytes": 4185,
-            "sha256": "b96ecdedff9a90fe6dea1f1975bee548ba5b39213b0111b062f4904536483caf",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footnotes.xml",
-            "bytes": 98282,
-            "sha256": "bb2fe3be033d9aad888b92b40a411de80e71a5acc73b415837173db67ca6aab0",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header1.xml",
-            "bytes": 4899,
-            "sha256": "2c95ebfd2456ddb02e1377717790046c96ad04e1f7bc82be6f119442ad6bd89c",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header2.xml",
-            "bytes": 2772,
-            "sha256": "c78f64e1d8cb5152d9417ae48786e50a5cf987bf0492f607e85d77c2e96428d5",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header3.xml",
-            "bytes": 2772,
-            "sha256": "60565f3dacddf15ac6258c2934a832d70bbe5c2fe0ec49ad589805d0604283d0",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header4.xml",
-            "bytes": 2819,
-            "sha256": "96fbd97475d545d02330467321d847d4b9b488568659659de6cf9de0ed670e5a",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header5.xml",
-            "bytes": 2772,
-            "sha256": "947613eb156f55382e8093ffd143c4934276c11d487e419d4069405cd2f3421e",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header6.xml",
-            "bytes": 2738,
-            "sha256": "8bd818bde60abde4cd73b2752ec6accdacfcbe35eee578e43874c0bdd67553aa",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header7.xml",
-            "bytes": 2772,
-            "sha256": "4af0b35752b55c00f202eec8517ca7f40650ae1fdb78f3aa417bb81d3537181f",
-            "kind": "xml"
-          },
-          {
-            "path": "word/numbering.xml",
-            "bytes": 65600,
-            "sha256": "8f18fbf4d9b92dce8f42ddeb4d17de2715d656a9adfe1b727d80b0c80b3c7cfa",
-            "kind": "xml"
-          },
-          {
-            "path": "word/settings.xml",
-            "bytes": 42213,
-            "sha256": "6674dc990adae1b69855ca6e5a8314ae3c5b53b994672f59a60a9f6777273044",
-            "kind": "xml"
-          },
-          {
-            "path": "word/styles.xml",
-            "bytes": 55517,
-            "sha256": "351837da0ace237c0dd835b065843d0bab48452b62add38602c120ae54d7ffa3",
-            "kind": "xml"
-          },
-          {
-            "path": "word/theme/theme1.xml",
-            "bytes": 7075,
-            "sha256": "e2671598be8ba197b34226f88263949ca9bcf8da151a515647b5dc4acabdcae0",
-            "kind": "xml"
-          },
-          {
-            "path": "word/webSettings.xml",
-            "bytes": 3895,
-            "sha256": "44ba6dc7ab6d99f7b33bd96f3f81406bcecf181b973b5e57feec38e4dae1ff7b",
-            "kind": "xml"
-          }
-        ],
-        "stats": {
-          "insertions": 0,
-          "deletions": 1,
-          "modifications": 0,
-          "insertedRanges": 0,
-          "deletedRanges": 1,
-          "insertedAtoms": 0,
-          "deletedAtoms": 4,
-          "modifiedParagraphs": 0,
-          "formatChanges": 0,
-          "formatChangeAtoms": 0
-        },
-        "fallback": {
-          "comparisonStrategyUsed": "legacy",
-          "reconstructionModeUsed": "inplace"
-        },
-        "unrepresentedChanges": [],
-        "schema": {
-          "packageStructural": "passed",
-          "issues": [],
-          "introducedIssues": []
-        },
-        "formatting": {
-          "score": 1,
-          "acceptScore": 1,
-          "rejectScore": 1,
-          "acceptDivergences": 0,
-          "rejectDivergences": 0
-        },
-        "closure": {
-          "relationshipIssues": [],
-          "auxiliaryDefinitionIssues": []
-        },
-        "unsupportedStoryDiagnostics": [],
-        "forbiddenPayloadLeaks": []
-      },
+      "approvedDivergenceIds": [],
       "taggedTree": {
         "strategy": "tagged-tree",
         "projections": {
@@ -6055,9 +3557,8 @@
           "formatChanges": 0,
           "formatChangeAtoms": 0
         },
-        "fallback": {
-          "comparisonStrategyUsed": "tagged-tree",
-          "reconstructionModeUsed": "inplace"
+        "authority": {
+          "comparisonStrategyUsed": "tagged-tree"
         },
         "unrepresentedChanges": [],
         "schema": {
@@ -6076,8 +3577,7 @@
           "relationshipIssues": [],
           "auxiliaryDefinitionIssues": []
         },
-        "unsupportedStoryDiagnostics": [],
-        "forbiddenPayloadLeaks": []
+        "unsupportedStoryDiagnostics": []
       }
     },
     {
@@ -6121,191 +3621,7 @@
         ],
         "sourceStructuralIssues": []
       },
-      "approvedDivergenceIds": [
-        "TD-ATOM-STATS-SEMANTICS-001"
-      ],
-      "legacy": {
-        "strategy": "legacy",
-        "projections": {
-          "accept": {
-            "xmlSha256": "cc288f6e2cb653c67f5d9103981f2174ef1a704169486fc0c2f19f9f54bcc774",
-            "textSha256": "568c7b6ebd9faa4e5878fce85038fdabd4579d90303f33837a0d97d9d836674d",
-            "sourceTextSha256": "568c7b6ebd9faa4e5878fce85038fdabd4579d90303f33837a0d97d9d836674d",
-            "matchesSourceText": true,
-            "firstDifference": null
-          },
-          "reject": {
-            "xmlSha256": "840442cf29961dffac3df7317f2f9cb759745be46384ab887690da04024e635a",
-            "textSha256": "9a8b34b93a30b2400b77a459cc5109d30071a8611b0189112cdc011c92367df5",
-            "sourceTextSha256": "9a8b34b93a30b2400b77a459cc5109d30071a8611b0189112cdc011c92367df5",
-            "matchesSourceText": true,
-            "firstDifference": null
-          }
-        },
-        "packageParts": [
-          {
-            "path": "[Content_Types].xml",
-            "bytes": 2604,
-            "sha256": "221200e962423e8e13389220e245f278acc47dcd6036460631ca5e5bbcf362bf",
-            "kind": "xml"
-          },
-          {
-            "path": "_rels/.rels",
-            "bytes": 589,
-            "sha256": "0e6575f491f9f7d61c3022df7efa04ca27fae2ccde341e2f5fc1f701f4739e4f",
-            "kind": "xml"
-          },
-          {
-            "path": "docProps/app.xml",
-            "bytes": 714,
-            "sha256": "1eeb8663d3453929ae32e9bb2d0c64940824b5a549bf7b91b573ac12232b230a",
-            "kind": "xml"
-          },
-          {
-            "path": "docProps/core.xml",
-            "bytes": 620,
-            "sha256": "a71a4f6a3ef9f79722c9b33a1c124f7257e192893f3b43bf012b6038f2d7b490",
-            "kind": "xml"
-          },
-          {
-            "path": "word/_rels/document.xml.rels",
-            "bytes": 2115,
-            "sha256": "8567d115acd957638a3081ab4e90f180e91151073f5e22f4ae265eed358e3337",
-            "kind": "xml"
-          },
-          {
-            "path": "word/document.xml",
-            "bytes": 38188,
-            "sha256": "07f32e09bf39a9e21c87cf3a73afeaaf15b2c4758aa393a5fdfd588087a25d6d",
-            "kind": "xml"
-          },
-          {
-            "path": "word/endnotes.xml",
-            "bytes": 3049,
-            "sha256": "b9f9c589bf9163ecf15f4d7d46470a9b96aba5c9226426b936d67f048ac9b869",
-            "kind": "xml"
-          },
-          {
-            "path": "word/fontTable.xml",
-            "bytes": 2363,
-            "sha256": "7b31893de276b549315df2e389de36b78209b8c6fc3ed01d12f540a77a3fdc5f",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer1.xml",
-            "bytes": 3477,
-            "sha256": "1081d2f5103e74b985a0f8ec8aaf3f669d8aee105a7cfe8abf005eb6518bd506",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer2.xml",
-            "bytes": 2987,
-            "sha256": "30cc9c4ec8de0017297b9dff603b24d88e58215e6aa48e218439fbc62da7fc40",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer3.xml",
-            "bytes": 3678,
-            "sha256": "d8217dfa0c9be843a7dcf5ad44a9a13a63f8537a2af6ecb13e8c2d164b8d0ff3",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer4.xml",
-            "bytes": 2929,
-            "sha256": "9a706caafb10b165cf1661b6af7c1822d96551e6397389aa0a4400dbe31b0395",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer5.xml",
-            "bytes": 3487,
-            "sha256": "009213b762898c5d6c565c220866fa7bcc38d73a608f104af2660a685358af78",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footnotes.xml",
-            "bytes": 11527,
-            "sha256": "c1acc844463ff4f706fb6a37bb13bc2af098d2c5b1f8467a1d68d1bf04709bb2",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header1.xml",
-            "bytes": 3727,
-            "sha256": "7d4b8fe7ee0d47aca7818c4884485a84666808a4091034802942c94332ee7abc",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header2.xml",
-            "bytes": 2765,
-            "sha256": "facd22c21a74fa78bbe20e26492636d6cea207b12de570ec238eed6352fc6350",
-            "kind": "xml"
-          },
-          {
-            "path": "word/numbering.xml",
-            "bytes": 10716,
-            "sha256": "59045b9a13ec8a4227805241628881e55a41579bb26823d1a3f68cec61cda574",
-            "kind": "xml"
-          },
-          {
-            "path": "word/settings.xml",
-            "bytes": 6549,
-            "sha256": "059fde9c414b9ffeccdb0dad6d88180cdd6c4cb78bf45420bf26cbdd9fa2359b",
-            "kind": "xml"
-          },
-          {
-            "path": "word/styles.xml",
-            "bytes": 37997,
-            "sha256": "5f5e5c92dd023348ba3ff5760bacee94301b17f5e3d3b7f00e5428d8ba63cb42",
-            "kind": "xml"
-          },
-          {
-            "path": "word/theme/theme1.xml",
-            "bytes": 8392,
-            "sha256": "0b91bee341551ba2b34d067fd36507fd58c350b2e127e7460fc593d6cc659ade",
-            "kind": "xml"
-          },
-          {
-            "path": "word/webSettings.xml",
-            "bytes": 1017,
-            "sha256": "1d3be27f118e1b0020b9712e6966cc2fa1ca6a10bf836fc4a58738b104db75bc",
-            "kind": "xml"
-          }
-        ],
-        "stats": {
-          "insertions": 0,
-          "deletions": 1,
-          "modifications": 0,
-          "insertedRanges": 0,
-          "deletedRanges": 1,
-          "insertedAtoms": 0,
-          "deletedAtoms": 243,
-          "modifiedParagraphs": 0,
-          "formatChanges": 0,
-          "formatChangeAtoms": 0
-        },
-        "fallback": {
-          "comparisonStrategyUsed": "legacy",
-          "reconstructionModeUsed": "inplace"
-        },
-        "unrepresentedChanges": [],
-        "schema": {
-          "packageStructural": "passed",
-          "issues": [],
-          "introducedIssues": []
-        },
-        "formatting": {
-          "score": 1,
-          "acceptScore": 1,
-          "rejectScore": 1,
-          "acceptDivergences": 0,
-          "rejectDivergences": 0
-        },
-        "closure": {
-          "relationshipIssues": [],
-          "auxiliaryDefinitionIssues": []
-        },
-        "unsupportedStoryDiagnostics": [],
-        "forbiddenPayloadLeaks": []
-      },
+      "approvedDivergenceIds": [],
       "taggedTree": {
         "strategy": "tagged-tree",
         "projections": {
@@ -6465,9 +3781,8 @@
           "formatChanges": 0,
           "formatChangeAtoms": 0
         },
-        "fallback": {
-          "comparisonStrategyUsed": "tagged-tree",
-          "reconstructionModeUsed": "inplace"
+        "authority": {
+          "comparisonStrategyUsed": "tagged-tree"
         },
         "unrepresentedChanges": [],
         "schema": {
@@ -6486,8 +3801,7 @@
           "relationshipIssues": [],
           "auxiliaryDefinitionIssues": []
         },
-        "unsupportedStoryDiagnostics": [],
-        "forbiddenPayloadLeaks": []
+        "unsupportedStoryDiagnostics": []
       }
     },
     {
@@ -6555,305 +3869,7 @@
           }
         ]
       },
-      "approvedDivergenceIds": [
-        "TD-ATOM-STATS-SEMANTICS-001"
-      ],
-      "legacy": {
-        "strategy": "legacy",
-        "projections": {
-          "accept": {
-            "xmlSha256": "a23346f3058399f190ee1d8511f87f661425f6d60eb1bb2d25cf62685cd17cfe",
-            "textSha256": "67fad86b83673dc0a929451f5fc9be1f681667c49685455852f9a155f98abb6a",
-            "sourceTextSha256": "67fad86b83673dc0a929451f5fc9be1f681667c49685455852f9a155f98abb6a",
-            "matchesSourceText": true,
-            "firstDifference": null
-          },
-          "reject": {
-            "xmlSha256": "1929ab6fd18796f2a88310ad484f5c5d5ba09cb8a41f144cb13f7e4842e9e9f2",
-            "textSha256": "6fc93e84b35c0c396e61cccd6c7d9792281107c6f2b5aa64c02ecabe93f7540b",
-            "sourceTextSha256": "6fc93e84b35c0c396e61cccd6c7d9792281107c6f2b5aa64c02ecabe93f7540b",
-            "matchesSourceText": true,
-            "firstDifference": null
-          }
-        },
-        "packageParts": [
-          {
-            "path": "[Content_Types].xml",
-            "bytes": 4007,
-            "sha256": "96810cc8c92d0b47b563aaf45816bd66cb954a0c29fe26c425d111ff83a71037",
-            "kind": "xml"
-          },
-          {
-            "path": "_rels/.rels",
-            "bytes": 882,
-            "sha256": "7475b604d003241b3ad58d35f3bd5d0bb842b55fd58b7cd8881803066e6b4736",
-            "kind": "xml"
-          },
-          {
-            "path": "customXml/_rels/item1.xml.rels",
-            "bytes": 295,
-            "sha256": "17f9862707a9096391a4a78b5fd8897ecb5686c7436e07dd1a73da7e7fa9e903",
-            "kind": "xml"
-          },
-          {
-            "path": "customXml/_rels/item2.xml.rels",
-            "bytes": 295,
-            "sha256": "b4d03e202767efbe0b08716f60b83ce160c8e72a5cc4b4b98db1e192b664cfd9",
-            "kind": "xml"
-          },
-          {
-            "path": "customXml/_rels/item3.xml.rels",
-            "bytes": 295,
-            "sha256": "400ba8878c755feab8e5c0eb2ac7c55514f6018f0220a1c5e8651f588c933bf1",
-            "kind": "xml"
-          },
-          {
-            "path": "customXml/item1.xml",
-            "bytes": 14622,
-            "sha256": "b9d32e3f928b60946c764d2d21be01125f38d5571f6153621f82b8de38d940f3",
-            "kind": "xml"
-          },
-          {
-            "path": "customXml/item2.xml",
-            "bytes": 219,
-            "sha256": "5efcaf9ad70d9c29f406ee438f8f428b021a881d2c5afff0e53b00b1f67ae51e",
-            "kind": "xml"
-          },
-          {
-            "path": "customXml/item3.xml",
-            "bytes": 587,
-            "sha256": "001ef0f7080eccc3f1483be722ea1174e232ffae226cae5a96cbc14b659cda84",
-            "kind": "xml"
-          },
-          {
-            "path": "customXml/itemProps1.xml",
-            "bytes": 200,
-            "sha256": "69366c04f7b11ad49f03e17b316fac0c139358d1a2d2f332791aea487d9ea64c",
-            "kind": "xml"
-          },
-          {
-            "path": "customXml/itemProps2.xml",
-            "bytes": 200,
-            "sha256": "47334740f04d4c3e5c238061b0f4ebcf8038234ea46df50aaee6db6adcf98023",
-            "kind": "xml"
-          },
-          {
-            "path": "customXml/itemProps3.xml",
-            "bytes": 200,
-            "sha256": "9b6a1352905b9536b88a2d335d917e26940669174760937ddf2bdf06ada1efe8",
-            "kind": "xml"
-          },
-          {
-            "path": "docMetadata/LabelInfo.xml",
-            "bytes": 299,
-            "sha256": "8f812db868016f48192519abdc756248abd4f5581900c8b8e2380cfd9398b309",
-            "kind": "xml"
-          },
-          {
-            "path": "docProps/app.xml",
-            "bytes": 237,
-            "sha256": "d4dff3a2defefd93b329d86971ed3ac792aaa30765305d46645f076b52f9d75a",
-            "kind": "xml"
-          },
-          {
-            "path": "docProps/core.xml",
-            "bytes": 581,
-            "sha256": "df8a1f12ba03629cbc2c519c2a53f9a50678916ba167591289c7dc7fe1f30483",
-            "kind": "xml"
-          },
-          {
-            "path": "docProps/custom.xml",
-            "bytes": 401,
-            "sha256": "9ca0b71d560d5cbc366ab15b82f90da938d74a725e812ac173b5b3176fedea7e",
-            "kind": "xml"
-          },
-          {
-            "path": "word/_rels/document.xml.rels",
-            "bytes": 3319,
-            "sha256": "811e6d3397392eaa07bfb3152f219b8a7b0e2a6dc1df7513022b697e7a845a80",
-            "kind": "xml"
-          },
-          {
-            "path": "word/_rels/footnotes.xml.rels",
-            "bytes": 366,
-            "sha256": "7a12e756813f3e953aa0663283330498ce2626adb2de5cea366da2f9b8311e60",
-            "kind": "xml"
-          },
-          {
-            "path": "word/document.xml",
-            "bytes": 261593,
-            "sha256": "af552d75cc841e6261369b6856f10c702b79fa46144d7674947680ce99579d65",
-            "kind": "xml"
-          },
-          {
-            "path": "word/endnotes.xml",
-            "bytes": 3206,
-            "sha256": "3bc428163efcedf0ca21a48606d14e1aa0942df418ad660b9cf5cc3f1f57a5ea",
-            "kind": "xml"
-          },
-          {
-            "path": "word/fontTable.xml",
-            "bytes": 2648,
-            "sha256": "972805185dee6e127b180ab81d9a5295629c7504abf398bde1ca5d92d8cb8d44",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer1.xml",
-            "bytes": 2765,
-            "sha256": "d24f0db5098ff110af537406f8980ceef490ec52b40da77674732f4f825a43a0",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer2.xml",
-            "bytes": 4123,
-            "sha256": "16d8ca641f3de3d70f28539efa5141ec53bded78e5335cc4d132797e78991dee",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer3.xml",
-            "bytes": 4052,
-            "sha256": "4112deb2da7e76f29d19e6920c0c6a667cdcee30e7e9edb3a72feb0da3f9db23",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer4.xml",
-            "bytes": 4067,
-            "sha256": "482e826e32902fcd2774db522e7b1c629fd3b4c52173ec26d9fa7bbdbb662616",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer5.xml",
-            "bytes": 2871,
-            "sha256": "1a945f5172bb76fceedc28a5c515fc3626fe9d7f67c94d18a2d44196be70782b",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer6.xml",
-            "bytes": 3143,
-            "sha256": "96611901e2a9d6f449e321e8565d0227ae302b434382a23f43cdf72f41de9839",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer7.xml",
-            "bytes": 2805,
-            "sha256": "96daa3b53fd17fa0a1ba5b9a51ff2105a4df96bb8bbb1f103730f8516d43dc94",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footnotes.xml",
-            "bytes": 39019,
-            "sha256": "f5d3268b5303aad6351224319e82497bfcd0ce365ba1a144d5f61daaae46b52a",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header1.xml",
-            "bytes": 2765,
-            "sha256": "2307ae888fa87a93690f2ea3a639fb66d93f9cacb8b88317a9819ad02d87a45b",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header2.xml",
-            "bytes": 2811,
-            "sha256": "22308e8880229dac8f3fd2385c3e91779bd936095295e5192fb3a5e1f040735c",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header3.xml",
-            "bytes": 6684,
-            "sha256": "94e3ef4cc4f654bac85d63100a46811b39013a700dd87723a7e94e4d6e22939f",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header4.xml",
-            "bytes": 2765,
-            "sha256": "5f7b5b6048351f536a33ef888c88619f44ff99f9805b7e74596225bcf02384c6",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header5.xml",
-            "bytes": 2772,
-            "sha256": "99db625240bfcefbb37d0e678dd8fe9c3a1b7ef09d08f724243d4013b372a933",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header6.xml",
-            "bytes": 2765,
-            "sha256": "09e9eb871cc099879fe7b7895273c8eed44d2e288d8d9ff695dcd2cd7541249c",
-            "kind": "xml"
-          },
-          {
-            "path": "word/numbering.xml",
-            "bytes": 23587,
-            "sha256": "1de6ddec405ecc59773950d015d62eb7a19e5ae6b53bf70ca2d11a67236e5d3c",
-            "kind": "xml"
-          },
-          {
-            "path": "word/settings.xml",
-            "bytes": 24941,
-            "sha256": "1b5fb4c7f3fbc9ea458f2df36a006e55902406c21d0701a83d003a44a981e177",
-            "kind": "xml"
-          },
-          {
-            "path": "word/styles.xml",
-            "bytes": 41769,
-            "sha256": "730c1e4066471cb6773748e24627f306892f9ef1ba9eeb958b0b37314df22fa2",
-            "kind": "xml"
-          },
-          {
-            "path": "word/theme/theme1.xml",
-            "bytes": 7075,
-            "sha256": "e2671598be8ba197b34226f88263949ca9bcf8da151a515647b5dc4acabdcae0",
-            "kind": "xml"
-          },
-          {
-            "path": "word/webSettings.xml",
-            "bytes": 2298,
-            "sha256": "479f47363f9bfc5c5bf3ea0f117c6ce52a1ed35164eb72a8b96821c2525a939e",
-            "kind": "xml"
-          }
-        ],
-        "stats": {
-          "insertions": 0,
-          "deletions": 1,
-          "modifications": 0,
-          "insertedRanges": 0,
-          "deletedRanges": 1,
-          "insertedAtoms": 0,
-          "deletedAtoms": 21,
-          "modifiedParagraphs": 0,
-          "formatChanges": 0,
-          "formatChangeAtoms": 0
-        },
-        "fallback": {
-          "comparisonStrategyUsed": "legacy",
-          "reconstructionModeUsed": "inplace"
-        },
-        "unrepresentedChanges": [],
-        "schema": {
-          "packageStructural": "inherited",
-          "issues": [
-            {
-              "check": "xml_declaration",
-              "part": "customXml/item2.xml",
-              "message": "XML part does not begin with an <?xml declaration"
-            }
-          ],
-          "introducedIssues": []
-        },
-        "formatting": {
-          "score": 1,
-          "acceptScore": 1,
-          "rejectScore": 1,
-          "acceptDivergences": 0,
-          "rejectDivergences": 0
-        },
-        "closure": {
-          "relationshipIssues": [],
-          "auxiliaryDefinitionIssues": []
-        },
-        "unsupportedStoryDiagnostics": [],
-        "forbiddenPayloadLeaks": []
-      },
+      "approvedDivergenceIds": [],
       "taggedTree": {
         "strategy": "tagged-tree",
         "projections": {
@@ -7121,9 +4137,8 @@
           "formatChanges": 0,
           "formatChangeAtoms": 0
         },
-        "fallback": {
-          "comparisonStrategyUsed": "tagged-tree",
-          "reconstructionModeUsed": "inplace"
+        "authority": {
+          "comparisonStrategyUsed": "tagged-tree"
         },
         "unrepresentedChanges": [],
         "schema": {
@@ -7148,8 +4163,7 @@
           "relationshipIssues": [],
           "auxiliaryDefinitionIssues": []
         },
-        "unsupportedStoryDiagnostics": [],
-        "forbiddenPayloadLeaks": []
+        "unsupportedStoryDiagnostics": []
       }
     },
     {
@@ -7203,251 +4217,7 @@
         ],
         "sourceStructuralIssues": []
       },
-      "approvedDivergenceIds": [
-        "TD-ATOM-STATS-SEMANTICS-001"
-      ],
-      "legacy": {
-        "strategy": "legacy",
-        "projections": {
-          "accept": {
-            "xmlSha256": "cbe6ee3ab0511797bc48c868041aeda06a302947fb882849e4f99c8fce6680a0",
-            "textSha256": "717f95238c38c63ff13ed1158d897d7f6c2aa3d7da9190a6f19203a140fd00f7",
-            "sourceTextSha256": "717f95238c38c63ff13ed1158d897d7f6c2aa3d7da9190a6f19203a140fd00f7",
-            "matchesSourceText": true,
-            "firstDifference": null
-          },
-          "reject": {
-            "xmlSha256": "d511495583e29d09d9d7dc06ab709ab975fa793aba492827b0db5ebce3b7b6eb",
-            "textSha256": "fc797aa399edd9b2d49a37283f709a368da07074fe4f525e4ca893c086cb694a",
-            "sourceTextSha256": "fc797aa399edd9b2d49a37283f709a368da07074fe4f525e4ca893c086cb694a",
-            "matchesSourceText": true,
-            "firstDifference": null
-          }
-        },
-        "packageParts": [
-          {
-            "path": "[Content_Types].xml",
-            "bytes": 3724,
-            "sha256": "023526ef094e4f1ac159cf0c6e05f9f375b854329271d7f0da6e3b808e8471b2",
-            "kind": "xml"
-          },
-          {
-            "path": "_rels/.rels",
-            "bytes": 735,
-            "sha256": "7b9ed26e45f804b81d119d3ba5a2ec70cf2e8131a4c07a796f2715ef0fbcd487",
-            "kind": "xml"
-          },
-          {
-            "path": "docMetadata/LabelInfo.xml",
-            "bytes": 299,
-            "sha256": "8f812db868016f48192519abdc756248abd4f5581900c8b8e2380cfd9398b309",
-            "kind": "xml"
-          },
-          {
-            "path": "docProps/app.xml",
-            "bytes": 723,
-            "sha256": "082008a71ad008e81e3e301948037b1100b963b929702d8b7ed49adfd1cdd613",
-            "kind": "xml"
-          },
-          {
-            "path": "docProps/core.xml",
-            "bytes": 620,
-            "sha256": "9b2483bbfe39fe485c0774ced93305d21577a7cb6da385762d2116c42928e55c",
-            "kind": "xml"
-          },
-          {
-            "path": "word/_rels/document.xml.rels",
-            "bytes": 3155,
-            "sha256": "2a11ad233bed0648198f2091e6fa4c92f102a855b9b6afa3b59f540e704ef34a",
-            "kind": "xml"
-          },
-          {
-            "path": "word/_rels/footnotes.xml.rels",
-            "bytes": 557,
-            "sha256": "cc13a5f3de85bcce0fd7f4824706b0ad9cd4ee65305137be24fe6fbfa1e1c7b8",
-            "kind": "xml"
-          },
-          {
-            "path": "word/customizations.xml",
-            "bytes": 2040,
-            "sha256": "896275b00484f613a759a35772adcbd794e0ebec86e73dcc32f085c03aac251f",
-            "kind": "xml"
-          },
-          {
-            "path": "word/document.xml",
-            "bytes": 404253,
-            "sha256": "0c304b673405bc35975df52975b19e3cde99fd6d25bd8b5fcb7d7814fb018ec5",
-            "kind": "xml"
-          },
-          {
-            "path": "word/endnotes.xml",
-            "bytes": 3317,
-            "sha256": "eeaec27cb3171c7c6ca3d363f704ae5365de4260307306b714025d49fc98a015",
-            "kind": "xml"
-          },
-          {
-            "path": "word/fontTable.xml",
-            "bytes": 3742,
-            "sha256": "bc4cb9c49ad2078de2cf16eb401241bc50a49e9cbd8b9cd352597ac0df15fcd7",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer1.xml",
-            "bytes": 2845,
-            "sha256": "9570c59cd731e0cb7df94d118fd197de80a03255f3aba79e0046a93d95a5c320",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer2.xml",
-            "bytes": 3884,
-            "sha256": "4ba634ca4904f231c7d52fe189c381eebcc1abacbdb80f53b8aed0c1aeaae891",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer3.xml",
-            "bytes": 3613,
-            "sha256": "c247c85d1aac07afe937651c12aa4258c2d781eeb36be0c1cfefba98298b880a",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer4.xml",
-            "bytes": 2852,
-            "sha256": "61b9ea7ead399ae2329cd18f9058f32683e6d375a005b22644929075f30cb117",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer5.xml",
-            "bytes": 4006,
-            "sha256": "983b8c41c03e794ab577ffc9256f220ea018c34a9322f4845497b9a76bcedcc8",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer6.xml",
-            "bytes": 3367,
-            "sha256": "65bb9423b61d17fc39c5b9003de428d1ed5e0c99a54213d94994be13128e8429",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer7.xml",
-            "bytes": 3379,
-            "sha256": "c03585fd72377ada4ceb9604a843fdcf9dd804b305f2088c2b75d37098c022fe",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer8.xml",
-            "bytes": 3400,
-            "sha256": "04dc4bf3383e09620a2fbfc2f2256f6eb43b2f9dd4cda3fb4f5b0f735c1f0ccf",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footnotes.xml",
-            "bytes": 128379,
-            "sha256": "dbc6749e1a785caa8c5d55ba83eb9aed9998407efa372dc0d1ea125394839de5",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header1.xml",
-            "bytes": 4739,
-            "sha256": "727156ddcace76ed5528ca4a1ee3b08aec3a59ce0bcfc5aa2249d6c16d5935dd",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header2.xml",
-            "bytes": 2772,
-            "sha256": "7a640e6d6cb06947b5bdcb53460109ebe087cbdf14954cea2db9c6b2f5089997",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header3.xml",
-            "bytes": 2784,
-            "sha256": "4c98c7d4a762372939d3ae64467b7148ccf0448f57dc8130d33d94d159bf6cea",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header4.xml",
-            "bytes": 3426,
-            "sha256": "6c706c3845468077a597f10f68cea410c27aef468db7699076610c9106d674e1",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header5.xml",
-            "bytes": 2772,
-            "sha256": "b8be8e814e16b2c20a196dde84e3f8eb2c3b1fe0bd0058e511f1ed78dbbd3b64",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header6.xml",
-            "bytes": 2772,
-            "sha256": "82b57d10b0bb2f7d4ef1f7f150e29bd2cfe2c38109851c450fb35e2d13fd84fc",
-            "kind": "xml"
-          },
-          {
-            "path": "word/numbering.xml",
-            "bytes": 634576,
-            "sha256": "3a095a913ad8785e803d893e06239aa1e14bafdfb11035a396ee9130ccb2b17d",
-            "kind": "xml"
-          },
-          {
-            "path": "word/settings.xml",
-            "bytes": 50556,
-            "sha256": "f459ffea0b88ce9feafe50d11d9ac54a9ff1f7efbbe0d2edcae29a1f27781148",
-            "kind": "xml"
-          },
-          {
-            "path": "word/styles.xml",
-            "bytes": 49902,
-            "sha256": "eb38d550deb86fd2cf5bea2c8ae93d0f1cf4b6e6811c7243701c3a99b9303b50",
-            "kind": "xml"
-          },
-          {
-            "path": "word/theme/theme1.xml",
-            "bytes": 7642,
-            "sha256": "56fa8d24ddc4674870e64dc25e3a9bb79d36d86c941b3d899ee7ff18fb72aa9c",
-            "kind": "xml"
-          },
-          {
-            "path": "word/webSettings.xml",
-            "bytes": 3497,
-            "sha256": "7e9168bbce1dc4bbecc1f78a8320311ac93aa92ebfa66923d89d5bc9629dbf1d",
-            "kind": "xml"
-          }
-        ],
-        "stats": {
-          "insertions": 0,
-          "deletions": 1,
-          "modifications": 0,
-          "insertedRanges": 0,
-          "deletedRanges": 1,
-          "insertedAtoms": 0,
-          "deletedAtoms": 288,
-          "modifiedParagraphs": 0,
-          "formatChanges": 0,
-          "formatChangeAtoms": 0
-        },
-        "fallback": {
-          "comparisonStrategyUsed": "legacy",
-          "reconstructionModeUsed": "inplace"
-        },
-        "unrepresentedChanges": [],
-        "schema": {
-          "packageStructural": "passed",
-          "issues": [],
-          "introducedIssues": []
-        },
-        "formatting": {
-          "score": 1,
-          "acceptScore": 1,
-          "rejectScore": 1,
-          "acceptDivergences": 0,
-          "rejectDivergences": 0
-        },
-        "closure": {
-          "relationshipIssues": [],
-          "auxiliaryDefinitionIssues": []
-        },
-        "unsupportedStoryDiagnostics": [],
-        "forbiddenPayloadLeaks": []
-      },
+      "approvedDivergenceIds": [],
       "taggedTree": {
         "strategy": "tagged-tree",
         "projections": {
@@ -7667,9 +4437,8 @@
           "formatChanges": 0,
           "formatChangeAtoms": 0
         },
-        "fallback": {
-          "comparisonStrategyUsed": "tagged-tree",
-          "reconstructionModeUsed": "inplace"
+        "authority": {
+          "comparisonStrategyUsed": "tagged-tree"
         },
         "unrepresentedChanges": [],
         "schema": {
@@ -7688,8 +4457,7 @@
           "relationshipIssues": [],
           "auxiliaryDefinitionIssues": []
         },
-        "unsupportedStoryDiagnostics": [],
-        "forbiddenPayloadLeaks": []
+        "unsupportedStoryDiagnostics": []
       }
     },
     {
@@ -7754,287 +4522,7 @@
           }
         ]
       },
-      "approvedDivergenceIds": [
-        "TD-ATOM-STATS-SEMANTICS-001"
-      ],
-      "legacy": {
-        "strategy": "legacy",
-        "projections": {
-          "accept": {
-            "xmlSha256": "a5f6032964728408e112275f3dcbde0e95c916c6fab4303e61772e999b509673",
-            "textSha256": "8cb11ad329fbf747fedf19d75c451c740302b49ae148478ec57c611cf6c30aeb",
-            "sourceTextSha256": "8cb11ad329fbf747fedf19d75c451c740302b49ae148478ec57c611cf6c30aeb",
-            "matchesSourceText": true,
-            "firstDifference": null
-          },
-          "reject": {
-            "xmlSha256": "9e1b4e4be24651b4c7680fbe0f082bcbcd4c241d883e80323ec14b23c444bfab",
-            "textSha256": "b5ddc19f73d0061eb611c3005fc9af7f5bdcf76a6cd21cc814550feb9e941a1f",
-            "sourceTextSha256": "b5ddc19f73d0061eb611c3005fc9af7f5bdcf76a6cd21cc814550feb9e941a1f",
-            "matchesSourceText": true,
-            "firstDifference": null
-          }
-        },
-        "packageParts": [
-          {
-            "path": "[Content_Types].xml",
-            "bytes": 3623,
-            "sha256": "1f4609319c33dfa55f867c4a7a094a3ebcc138b52e61183164c012b750db1661",
-            "kind": "xml"
-          },
-          {
-            "path": "_rels/.rels",
-            "bytes": 882,
-            "sha256": "7475b604d003241b3ad58d35f3bd5d0bb842b55fd58b7cd8881803066e6b4736",
-            "kind": "xml"
-          },
-          {
-            "path": "customXml/_rels/item1.xml.rels",
-            "bytes": 295,
-            "sha256": "17f9862707a9096391a4a78b5fd8897ecb5686c7436e07dd1a73da7e7fa9e903",
-            "kind": "xml"
-          },
-          {
-            "path": "customXml/_rels/item2.xml.rels",
-            "bytes": 295,
-            "sha256": "b4d03e202767efbe0b08716f60b83ce160c8e72a5cc4b4b98db1e192b664cfd9",
-            "kind": "xml"
-          },
-          {
-            "path": "customXml/_rels/item3.xml.rels",
-            "bytes": 295,
-            "sha256": "400ba8878c755feab8e5c0eb2ac7c55514f6018f0220a1c5e8651f588c933bf1",
-            "kind": "xml"
-          },
-          {
-            "path": "customXml/item1.xml",
-            "bytes": 14622,
-            "sha256": "b9d32e3f928b60946c764d2d21be01125f38d5571f6153621f82b8de38d940f3",
-            "kind": "xml"
-          },
-          {
-            "path": "customXml/item2.xml",
-            "bytes": 219,
-            "sha256": "5efcaf9ad70d9c29f406ee438f8f428b021a881d2c5afff0e53b00b1f67ae51e",
-            "kind": "xml"
-          },
-          {
-            "path": "customXml/item3.xml",
-            "bytes": 587,
-            "sha256": "001ef0f7080eccc3f1483be722ea1174e232ffae226cae5a96cbc14b659cda84",
-            "kind": "xml"
-          },
-          {
-            "path": "customXml/itemProps1.xml",
-            "bytes": 200,
-            "sha256": "a754f8167ef857dfb82b03aca46c3f3a47b0e209fa3a6820d4bc428c446ec156",
-            "kind": "xml"
-          },
-          {
-            "path": "customXml/itemProps2.xml",
-            "bytes": 200,
-            "sha256": "a45f483807aeba636b35b4fed6fabbc20b957cb5eb46c3c245fb3c114019243f",
-            "kind": "xml"
-          },
-          {
-            "path": "customXml/itemProps3.xml",
-            "bytes": 200,
-            "sha256": "e813811a28250ef76f8dab1c8097c907ec67f51160b937fd4563f2ca003e6c72",
-            "kind": "xml"
-          },
-          {
-            "path": "docMetadata/LabelInfo.xml",
-            "bytes": 299,
-            "sha256": "8f812db868016f48192519abdc756248abd4f5581900c8b8e2380cfd9398b309",
-            "kind": "xml"
-          },
-          {
-            "path": "docProps/app.xml",
-            "bytes": 237,
-            "sha256": "d4dff3a2defefd93b329d86971ed3ac792aaa30765305d46645f076b52f9d75a",
-            "kind": "xml"
-          },
-          {
-            "path": "docProps/core.xml",
-            "bytes": 581,
-            "sha256": "df8a1f12ba03629cbc2c519c2a53f9a50678916ba167591289c7dc7fe1f30483",
-            "kind": "xml"
-          },
-          {
-            "path": "docProps/custom.xml",
-            "bytes": 401,
-            "sha256": "9ca0b71d560d5cbc366ab15b82f90da938d74a725e812ac173b5b3176fedea7e",
-            "kind": "xml"
-          },
-          {
-            "path": "word/_rels/document.xml.rels",
-            "bytes": 2932,
-            "sha256": "2b5932c7660c267b0635f135a923b534146bcd5b2ea969b47a263a92f8283f1c",
-            "kind": "xml"
-          },
-          {
-            "path": "word/_rels/footnotes.xml.rels",
-            "bytes": 366,
-            "sha256": "7a12e756813f3e953aa0663283330498ce2626adb2de5cea366da2f9b8311e60",
-            "kind": "xml"
-          },
-          {
-            "path": "word/document.xml",
-            "bytes": 303562,
-            "sha256": "e86fcd23b19b69bc410425cd65cb820ed203bed86613388ce1fe4aa822166766",
-            "kind": "xml"
-          },
-          {
-            "path": "word/endnotes.xml",
-            "bytes": 3206,
-            "sha256": "aa8d802800088b99084cda8fa42b1e9a4466fc7a63328a24759800f9d4218c81",
-            "kind": "xml"
-          },
-          {
-            "path": "word/fontTable.xml",
-            "bytes": 2648,
-            "sha256": "eaa90fce9cb7e55095dfcb8497626e2a868dc4d303c4a29b5d3eaf45ec4d2155",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer1.xml",
-            "bytes": 4109,
-            "sha256": "8c7caeffa775207e6b887bcc6cc73d97a8cd12f2b8f09b994cc465d7860b5ad0",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer2.xml",
-            "bytes": 3988,
-            "sha256": "22fdde8b3a31fb3c5eb88cb2cf179877787b10365d129f14b96b62d939bf0167",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer3.xml",
-            "bytes": 3594,
-            "sha256": "4ed2c378e131976eb932c9660d69616d036d7823d8b42e2f4907551ccaf36ea5",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer4.xml",
-            "bytes": 2958,
-            "sha256": "4412f3ef172dcf69143bf7b9595723854327ef136cad9efcea56c84d8a3bbcaf",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer5.xml",
-            "bytes": 2978,
-            "sha256": "aa89f9855b22969e177e3d74b33278782153a5f3d15fb6d59bbef851d6812cd5",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footer6.xml",
-            "bytes": 2805,
-            "sha256": "82cc4166fd40295d986b05ea4e642cdb5fb3a51c34581074244fc4c7c1bfc891",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footnotes.xml",
-            "bytes": 74524,
-            "sha256": "33b37cb3663916246cf2cb0e193715c72364bfad4a03b5a5d3ce7a46f1ba9a3c",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header1.xml",
-            "bytes": 2925,
-            "sha256": "cf7a457781c8ed9b21e31469dce958dd054a1966ec4bb7280a388f6abdcfac8f",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header2.xml",
-            "bytes": 7023,
-            "sha256": "de81200981dd6520ef8879fa08ce737a0d4b7d828df595c5f40dc77653db88f0",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header3.xml",
-            "bytes": 2925,
-            "sha256": "676c55f4f9c17fb820fdf5e7688621f63bde62d90c9cffcc8941b8a97238be55",
-            "kind": "xml"
-          },
-          {
-            "path": "word/header4.xml",
-            "bytes": 2925,
-            "sha256": "791e97b8cc201f88d8650d4ad9f69c6f54ec5f83d73ca384e5140ebfe76b63d5",
-            "kind": "xml"
-          },
-          {
-            "path": "word/numbering.xml",
-            "bytes": 33293,
-            "sha256": "dd2d16bccba0158f769dd1d24bafc5911ab4b10e03576c194a6f79c3fb44f95d",
-            "kind": "xml"
-          },
-          {
-            "path": "word/settings.xml",
-            "bytes": 31113,
-            "sha256": "a19fb5a8ee5e6e74ee0a606d2227f498fc62b828e2878e18eb279fe228cc3e16",
-            "kind": "xml"
-          },
-          {
-            "path": "word/styles.xml",
-            "bytes": 47387,
-            "sha256": "bc37e862efc37bfac5d18856c77f7ad43acc509fcf94c8c3e8c0e9e9840a322d",
-            "kind": "xml"
-          },
-          {
-            "path": "word/theme/theme1.xml",
-            "bytes": 7075,
-            "sha256": "e2671598be8ba197b34226f88263949ca9bcf8da151a515647b5dc4acabdcae0",
-            "kind": "xml"
-          },
-          {
-            "path": "word/webSettings.xml",
-            "bytes": 3497,
-            "sha256": "eb7fb68e662d069dcb76500c8a4d07205e9ee4dab28f740716e2a6fd88c8b8e7",
-            "kind": "xml"
-          }
-        ],
-        "stats": {
-          "insertions": 0,
-          "deletions": 1,
-          "modifications": 0,
-          "insertedRanges": 0,
-          "deletedRanges": 1,
-          "insertedAtoms": 0,
-          "deletedAtoms": 176,
-          "modifiedParagraphs": 0,
-          "formatChanges": 0,
-          "formatChangeAtoms": 0
-        },
-        "fallback": {
-          "comparisonStrategyUsed": "legacy",
-          "reconstructionModeUsed": "inplace"
-        },
-        "unrepresentedChanges": [],
-        "schema": {
-          "packageStructural": "inherited",
-          "issues": [
-            {
-              "check": "xml_declaration",
-              "part": "customXml/item2.xml",
-              "message": "XML part does not begin with an <?xml declaration"
-            }
-          ],
-          "introducedIssues": []
-        },
-        "formatting": {
-          "score": 1,
-          "acceptScore": 1,
-          "rejectScore": 1,
-          "acceptDivergences": 0,
-          "rejectDivergences": 0
-        },
-        "closure": {
-          "relationshipIssues": [],
-          "auxiliaryDefinitionIssues": []
-        },
-        "unsupportedStoryDiagnostics": [],
-        "forbiddenPayloadLeaks": []
-      },
+      "approvedDivergenceIds": [],
       "taggedTree": {
         "strategy": "tagged-tree",
         "projections": {
@@ -8284,9 +4772,8 @@
           "formatChanges": 0,
           "formatChangeAtoms": 0
         },
-        "fallback": {
-          "comparisonStrategyUsed": "tagged-tree",
-          "reconstructionModeUsed": "inplace"
+        "authority": {
+          "comparisonStrategyUsed": "tagged-tree"
         },
         "unrepresentedChanges": [],
         "schema": {
@@ -8311,8 +4798,7 @@
           "relationshipIssues": [],
           "auxiliaryDefinitionIssues": []
         },
-        "unsupportedStoryDiagnostics": [],
-        "forbiddenPayloadLeaks": []
+        "unsupportedStoryDiagnostics": []
       }
     },
     {
@@ -8342,119 +4828,7 @@
         ],
         "sourceStructuralIssues": []
       },
-      "approvedDivergenceIds": [
-        "TD-ATOM-STATS-SEMANTICS-001"
-      ],
-      "legacy": {
-        "strategy": "legacy",
-        "projections": {
-          "accept": {
-            "xmlSha256": "b48425b4e72469419176457ad8a808bb9d5498ee5325c46e5626741bed03c4e3",
-            "textSha256": "901f8186b1299a01363020c1bace069365c3de8235d5afba6172b5f2169c7d02",
-            "sourceTextSha256": "901f8186b1299a01363020c1bace069365c3de8235d5afba6172b5f2169c7d02",
-            "matchesSourceText": true,
-            "firstDifference": null
-          },
-          "reject": {
-            "xmlSha256": "9d9d59f0549577169656a0ab5dc4a5760ed1490191c52b1ac597744f374cc3de",
-            "textSha256": "cbbb525a67ce2f8daa2529d5ac46cef27b702d68d76781d6bcfd93944d3cade3",
-            "sourceTextSha256": "cbbb525a67ce2f8daa2529d5ac46cef27b702d68d76781d6bcfd93944d3cade3",
-            "matchesSourceText": true,
-            "firstDifference": null
-          }
-        },
-        "packageParts": [
-          {
-            "path": "[Content_Types].xml",
-            "bytes": 1020,
-            "sha256": "f93fd8a60f7da86c799a2b981765a891848dc15d9f8aa1a390168adadba2f73c",
-            "kind": "xml"
-          },
-          {
-            "path": "_rels/.rels",
-            "bytes": 297,
-            "sha256": "d8b0bad955075e5c5a427fe596520be989739fbcaddd9d837b319ea620740fde",
-            "kind": "xml"
-          },
-          {
-            "path": "word/_rels/document.xml.rels",
-            "bytes": 798,
-            "sha256": "9a5ae0e370bd1709a9da6912b255a6e7cdabb2c4c4e6afa5b40f367a0f4dd9db",
-            "kind": "xml"
-          },
-          {
-            "path": "word/comments.xml",
-            "bytes": 380,
-            "sha256": "07b5d8808091a23e43711330f45e47036dddd4b7db24f1aafaefe9446d2dcd66",
-            "kind": "xml"
-          },
-          {
-            "path": "word/commentsExtended.xml",
-            "bytes": 204,
-            "sha256": "72b238f8bd71948a5d5bbb49c513a27cd5b5a4c030f43ce5da128f06b8201051",
-            "kind": "xml"
-          },
-          {
-            "path": "word/document.xml",
-            "bytes": 1151,
-            "sha256": "3fc8f549e6c44b0e090a1062de9697fc16480b46ce622dfc4295ef8abd4570fa",
-            "kind": "xml"
-          },
-          {
-            "path": "word/endnotes.xml",
-            "bytes": 433,
-            "sha256": "d6c8f349aaa6a752819d282e8cb67e34ce3219c12b8a125e4bf24c9f060e02dd",
-            "kind": "xml"
-          },
-          {
-            "path": "word/footnotes.xml",
-            "bytes": 442,
-            "sha256": "dd0c28fdf1b7a8134f32b1041aadeeb2b89a106b1edd761f184090092d4adf9f",
-            "kind": "xml"
-          },
-          {
-            "path": "word/people.xml",
-            "bytes": 356,
-            "sha256": "a9ac8e1379063bc8c869e2e0b31b74bb677db9f7c2e48f1248fad577ed69cc94",
-            "kind": "xml"
-          }
-        ],
-        "stats": {
-          "insertions": 1,
-          "deletions": 1,
-          "modifications": 1,
-          "insertedRanges": 1,
-          "deletedRanges": 1,
-          "insertedAtoms": 1,
-          "deletedAtoms": 1,
-          "modifiedParagraphs": 1,
-          "formatChanges": 0,
-          "formatChangeAtoms": 0
-        },
-        "fallback": {
-          "comparisonStrategyUsed": "legacy",
-          "reconstructionModeUsed": "inplace"
-        },
-        "unrepresentedChanges": [],
-        "schema": {
-          "packageStructural": "passed",
-          "issues": [],
-          "introducedIssues": []
-        },
-        "formatting": {
-          "score": 1,
-          "acceptScore": 1,
-          "rejectScore": 1,
-          "acceptDivergences": 0,
-          "rejectDivergences": 0
-        },
-        "closure": {
-          "relationshipIssues": [],
-          "auxiliaryDefinitionIssues": []
-        },
-        "unsupportedStoryDiagnostics": [],
-        "forbiddenPayloadLeaks": []
-      },
+      "approvedDivergenceIds": [],
       "taggedTree": {
         "strategy": "tagged-tree",
         "projections": {
@@ -8542,9 +4916,8 @@
           "formatChanges": 0,
           "formatChangeAtoms": 0
         },
-        "fallback": {
-          "comparisonStrategyUsed": "tagged-tree",
-          "reconstructionModeUsed": "inplace"
+        "authority": {
+          "comparisonStrategyUsed": "tagged-tree"
         },
         "unrepresentedChanges": [],
         "schema": {
@@ -8563,8 +4936,7 @@
           "relationshipIssues": [],
           "auxiliaryDefinitionIssues": []
         },
-        "unsupportedStoryDiagnostics": [],
-        "forbiddenPayloadLeaks": []
+        "unsupportedStoryDiagnostics": []
       }
     },
     {
@@ -8586,102 +4958,7 @@
         ],
         "sourceStructuralIssues": []
       },
-      "approvedDivergenceIds": [
-        "TD-ATOM-STATS-SEMANTICS-001",
-        "TD-LEGACY-MOVE-PROJECTION-001"
-      ],
-      "legacy": {
-        "strategy": "legacy",
-        "projections": {
-          "accept": {
-            "xmlSha256": "072fbb3820e644c98d5a40cfdccbae879206aec8e4acc4c41077ce857c3ae978",
-            "textSha256": "261bc72072c9f7e360438e4fd5adfa2a3a6c94e69f05d92672588460d9158802",
-            "sourceTextSha256": "17229ee87b3f4385455dc50c483b062d70386f8b6351ccec17c9be78290b96c8",
-            "matchesSourceText": false,
-            "firstDifference": {
-              "index": 0,
-              "projectedLength": 134,
-              "sourceLength": 133,
-              "projectedCodePoint": 10,
-              "sourceCodePoint": 66
-            }
-          },
-          "reject": {
-            "xmlSha256": "818bb5a083ac3435a354e2e6cf6a85bb4354e15f36ac69cd2815c88dc6745390",
-            "textSha256": "2d2a982876f43f97097149587b1cbeba47cfeab734e219983197cce2af9a453c",
-            "sourceTextSha256": "88cc50356f91e667973518ab0fe59f3f07b70f2b624792b4c627282e41d548b8",
-            "matchesSourceText": false,
-            "firstDifference": {
-              "index": 133,
-              "projectedLength": 134,
-              "sourceLength": 133,
-              "projectedCodePoint": 10,
-              "sourceCodePoint": null
-            }
-          }
-        },
-        "packageParts": [
-          {
-            "path": "[Content_Types].xml",
-            "bytes": 429,
-            "sha256": "f74571be43c4a670a93b49a64f27bab9e9e2341238a1e0b5b654daceb3023b12",
-            "kind": "xml"
-          },
-          {
-            "path": "_rels/.rels",
-            "bytes": 297,
-            "sha256": "d8b0bad955075e5c5a427fe596520be989739fbcaddd9d837b319ea620740fde",
-            "kind": "xml"
-          },
-          {
-            "path": "word/_rels/document.xml.rels",
-            "bytes": 155,
-            "sha256": "5a2d586f932fb1d244771719792d87d11d1070a07b38fe433ecb746b376285cb",
-            "kind": "xml"
-          },
-          {
-            "path": "word/document.xml",
-            "bytes": 3229,
-            "sha256": "db817ab01de5276d4d10786a7b0dd85e291a60a76fbd6bbf8f831e47b137a0d7",
-            "kind": "xml"
-          }
-        ],
-        "stats": {
-          "insertions": 0,
-          "deletions": 0,
-          "modifications": 0,
-          "insertedRanges": 0,
-          "deletedRanges": 0,
-          "insertedAtoms": 0,
-          "deletedAtoms": 0,
-          "modifiedParagraphs": 0,
-          "formatChanges": 0,
-          "formatChangeAtoms": 0
-        },
-        "fallback": {
-          "comparisonStrategyUsed": "legacy",
-          "reconstructionModeUsed": "inplace"
-        },
-        "unrepresentedChanges": [],
-        "schema": {
-          "packageStructural": "passed",
-          "issues": [],
-          "introducedIssues": []
-        },
-        "formatting": {
-          "score": 1,
-          "acceptScore": 1,
-          "rejectScore": 1,
-          "acceptDivergences": 0,
-          "rejectDivergences": 0
-        },
-        "closure": {
-          "relationshipIssues": [],
-          "auxiliaryDefinitionIssues": []
-        },
-        "unsupportedStoryDiagnostics": [],
-        "forbiddenPayloadLeaks": []
-      },
+      "approvedDivergenceIds": [],
       "taggedTree": {
         "strategy": "tagged-tree",
         "projections": {
@@ -8739,9 +5016,8 @@
           "formatChanges": 0,
           "formatChangeAtoms": 0
         },
-        "fallback": {
-          "comparisonStrategyUsed": "tagged-tree",
-          "reconstructionModeUsed": "inplace"
+        "authority": {
+          "comparisonStrategyUsed": "tagged-tree"
         },
         "unrepresentedChanges": [],
         "schema": {
@@ -8760,8 +5036,7 @@
           "relationshipIssues": [],
           "auxiliaryDefinitionIssues": []
         },
-        "unsupportedStoryDiagnostics": [],
-        "forbiddenPayloadLeaks": []
+        "unsupportedStoryDiagnostics": []
       }
     },
     {
@@ -8783,89 +5058,7 @@
         ],
         "sourceStructuralIssues": []
       },
-      "approvedDivergenceIds": [
-        "TD-ATOM-STATS-SEMANTICS-001"
-      ],
-      "legacy": {
-        "strategy": "legacy",
-        "projections": {
-          "accept": {
-            "xmlSha256": "54e336ca824d9a2a6cfcaf9978c540f43c4423c34c230fe2600708b62ec3a09d",
-            "textSha256": "00aeb4016bd9756dcdb09b86c3deb4de688b17acb53a3d3670c474531163d82e",
-            "sourceTextSha256": "00aeb4016bd9756dcdb09b86c3deb4de688b17acb53a3d3670c474531163d82e",
-            "matchesSourceText": true,
-            "firstDifference": null
-          },
-          "reject": {
-            "xmlSha256": "f97174b2a58495912f24514da7ae185458fc989afb26cb13ce4806392a3a1799",
-            "textSha256": "2abdbb971e8bd06347f4d90e0a67ae510c70e80b9e4fdfd2ac0ce7eed7a64fe5",
-            "sourceTextSha256": "2abdbb971e8bd06347f4d90e0a67ae510c70e80b9e4fdfd2ac0ce7eed7a64fe5",
-            "matchesSourceText": true,
-            "firstDifference": null
-          }
-        },
-        "packageParts": [
-          {
-            "path": "[Content_Types].xml",
-            "bytes": 429,
-            "sha256": "f74571be43c4a670a93b49a64f27bab9e9e2341238a1e0b5b654daceb3023b12",
-            "kind": "xml"
-          },
-          {
-            "path": "_rels/.rels",
-            "bytes": 297,
-            "sha256": "d8b0bad955075e5c5a427fe596520be989739fbcaddd9d837b319ea620740fde",
-            "kind": "xml"
-          },
-          {
-            "path": "word/_rels/document.xml.rels",
-            "bytes": 155,
-            "sha256": "5a2d586f932fb1d244771719792d87d11d1070a07b38fe433ecb746b376285cb",
-            "kind": "xml"
-          },
-          {
-            "path": "word/document.xml",
-            "bytes": 932,
-            "sha256": "091b9236d86fff1dadb5380fcf39404b81a973961a49de2b409f79cbc7d7e614",
-            "kind": "xml"
-          }
-        ],
-        "stats": {
-          "insertions": 1,
-          "deletions": 1,
-          "modifications": 1,
-          "insertedRanges": 1,
-          "deletedRanges": 1,
-          "insertedAtoms": 1,
-          "deletedAtoms": 1,
-          "modifiedParagraphs": 1,
-          "formatChanges": 0,
-          "formatChangeAtoms": 0
-        },
-        "fallback": {
-          "comparisonStrategyUsed": "legacy",
-          "reconstructionModeUsed": "inplace"
-        },
-        "unrepresentedChanges": [],
-        "schema": {
-          "packageStructural": "passed",
-          "issues": [],
-          "introducedIssues": []
-        },
-        "formatting": {
-          "score": 1,
-          "acceptScore": 1,
-          "rejectScore": 1,
-          "acceptDivergences": 0,
-          "rejectDivergences": 0
-        },
-        "closure": {
-          "relationshipIssues": [],
-          "auxiliaryDefinitionIssues": []
-        },
-        "unsupportedStoryDiagnostics": [],
-        "forbiddenPayloadLeaks": []
-      },
+      "approvedDivergenceIds": [],
       "taggedTree": {
         "strategy": "tagged-tree",
         "projections": {
@@ -8923,9 +5116,8 @@
           "formatChanges": 0,
           "formatChangeAtoms": 0
         },
-        "fallback": {
-          "comparisonStrategyUsed": "tagged-tree",
-          "reconstructionModeUsed": "inplace"
+        "authority": {
+          "comparisonStrategyUsed": "tagged-tree"
         },
         "unrepresentedChanges": [],
         "schema": {
@@ -8944,8 +5136,7 @@
           "relationshipIssues": [],
           "auxiliaryDefinitionIssues": []
         },
-        "unsupportedStoryDiagnostics": [],
-        "forbiddenPayloadLeaks": []
+        "unsupportedStoryDiagnostics": []
       }
     }
   ]

--- a/packages/docx-compare/src/integration/strategy-differential.test.ts
+++ b/packages/docx-compare/src/integration/strategy-differential.test.ts
@@ -1,8 +1,7 @@
 /**
- * Focused legacy/tagged characterization rows that must exist before the
- * corresponding tagged behavior changes. The full external-corpus manifest is
- * intentionally a later Phase 1 task; these synthetic rows are always present
- * and make the two known default-path defects independently reproducible.
+ * Focused tagged-tree characterization rows retained after the authority flip.
+ * These synthetic rows are always present and keep the formerly known
+ * default-path defects independently reproducible.
  *
  * @conformance ECMA-376 edition 5, Part 1 § 17.13.6.1
  * @conformance ECMA-376 edition 5, Part 1 § 17.13.6.2
@@ -27,9 +26,11 @@ import {
 } from '../tagged/trackChangesAcceptorAst.js';
 import { testAllure } from '../testing/allure-test.js';
 import {
+  assertActiveDivergencesConsumed,
   assertCharacterizationSafety,
   assertExpectedPackageParts,
   characterizeStrategyDifferential,
+  collectRevisionIdIssues,
   type StrategyDifferentialFixture,
 } from './strategy-differential-harness.js';
 
@@ -211,9 +212,9 @@ describe('strategy differential manifest evidence', () => {
         revised,
         capabilityTags: ['fallbacks', 'projections'],
       });
-      const fallback = structuredClone(row);
-      fallback.taggedTree.fallback.comparisonStrategyUsed = 'legacy';
-      expect(() => assertCharacterizationSafety(fallback)).toThrow(/fell back to legacy/u);
+      const missingAuthority = structuredClone(row);
+      delete missingAuthority.taggedTree.authority.comparisonStrategyUsed;
+      expect(() => assertCharacterizationSafety(missingAuthority)).toThrow(/fell back to undefined/u);
 
       const projectionDrift = structuredClone(row);
       projectionDrift.taggedTree.projections.accept.matchesSourceText = false;
@@ -227,8 +228,113 @@ describe('strategy differential manifest evidence', () => {
         projectionDrift,
         new Set(['tagged-tree.rejectProjection']),
       )).toThrow(/accept projection drifted/u);
+
+      const formattingDrift = structuredClone(row);
+      formattingDrift.taggedTree.formatting.score = 0.75;
+      expect(() => assertCharacterizationSafety(formattingDrift))
+        .toThrow(/formatting fidelity drifted/u);
+      expect(assertCharacterizationSafety(
+        formattingDrift,
+        new Set(['tagged-tree.formattingFidelity']),
+      )).toEqual(new Set(['tagged-tree.formattingFidelity']));
+
+      const unsupportedStory = structuredClone(row);
+      unsupportedStory.taggedTree.unsupportedStoryDiagnostics.push('text-box:unsupported');
+      expect(() => assertCharacterizationSafety(unsupportedStory))
+        .toThrow(/unsupported story diagnostics/u);
+
+      const invalidField = structuredClone(row);
+      invalidField.taggedTree.integrity.fieldIssues.push('combined:FIELD_UNCLOSED');
+      expect(() => assertCharacterizationSafety(invalidField))
+        .toThrow(/failed fieldIssues/u);
+
+      const invalidBookmark = structuredClone(row);
+      invalidBookmark.taggedTree.integrity.bookmarkIssues.push('combined:duplicate-name:Target');
+      expect(() => assertCharacterizationSafety(invalidBookmark))
+        .toThrow(/failed bookmarkIssues/u);
+
+      const reusedRevisionId = structuredClone(row);
+      reusedRevisionId.taggedTree.integrity.revisionIdIssues.push(
+        'revision-id-reused-across-identities:7',
+      );
+      expect(() => assertCharacterizationSafety(reusedRevisionId))
+        .toThrow(/failed revisionIdIssues/u);
+
+      const unbalancedMove = structuredClone(row);
+      unbalancedMove.taggedTree.integrity.moveBalanceIssues.push(
+        'moveFrom:range-boundaries-unbalanced',
+      );
+      expect(() => assertCharacterizationSafety(unbalancedMove))
+        .toThrow(/failed moveBalanceIssues/u);
     },
   );
+
+  test('rejects active divergences that did not suppress an observed assertion', () => {
+    expect(() => assertActiveDivergencesConsumed(
+      new Set(['TD-OBSERVED-001', 'TD-UNOBSERVED-002']),
+      new Set(['TD-OBSERVED-001']),
+    )).toThrow(/TD-UNOBSERVED-002/u);
+  });
+
+  test('distinguishes split revision wrappers from allocator collisions', () => {
+    const documentBodyXml = (body: string): string =>
+      `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
+      `<w:body>${body}</w:body></w:document>`;
+    const documentXml = (body: string): string => documentBodyXml(`<w:p>${body}</w:p>`);
+    const source = documentXml(
+      '<w:ins w:id="7" w:author="Human" w:date="2026-01-01T00:00:00Z">' +
+      '<w:r><w:t>source</w:t></w:r></w:ins>',
+    );
+    const comparison = (kind: 'ins' | 'del', text: string): string =>
+      `<w:${kind} w:id="7" w:author="Strategy Differential" ` +
+      `w:date="2026-08-17T12:00:00Z"><w:r><w:t>${text}</w:t></w:r></w:${kind}>`;
+
+    expect(collectRevisionIdIssues(
+      documentXml(comparison('ins', 'a') + comparison('ins', 'b')),
+      documentXml(''),
+      documentXml(''),
+    )).toEqual([]);
+    expect(collectRevisionIdIssues(
+      documentBodyXml(
+        `<w:p>${comparison('ins', 'first')}</w:p>` +
+        `<w:p>${comparison('ins', 'second')}</w:p>`,
+      ),
+      documentXml(''),
+      documentXml(''),
+    )).toContain('revision-id-reused-across-identities:7');
+    const linkedPropertyChange = (kind: 'pPrChange' | 'rPrChange' | 'sectPrChange'): string =>
+      `<w:${kind} w:id="8" w:author="Strategy Differential" ` +
+      `w:date="2026-08-17T12:00:00Z"/>`;
+    expect(collectRevisionIdIssues(
+      documentXml(linkedPropertyChange('pPrChange') + linkedPropertyChange('sectPrChange')),
+      documentXml(''),
+      documentXml(''),
+    )).toEqual([]);
+    expect(collectRevisionIdIssues(
+      documentXml(linkedPropertyChange('pPrChange') + linkedPropertyChange('rPrChange')),
+      documentXml(''),
+      documentXml(''),
+    )).toEqual([]);
+    expect(collectRevisionIdIssues(
+      documentXml(comparison('ins', 'a')),
+      source,
+      documentXml(''),
+    )).toContain('comparison-id-collides-with-source:7');
+    expect(collectRevisionIdIssues(
+      documentXml(comparison('ins', 'a') + comparison('del', 'b')),
+      documentXml(''),
+      documentXml(''),
+    )).toContain('revision-id-reused-across-identities:7');
+    expect(collectRevisionIdIssues(
+      documentXml(
+        comparison('ins', 'a') +
+        '<w:pPrChange w:id="7" w:author="Strategy Differential" ' +
+        'w:date="2026-08-17T12:00:00Z"/>',
+      ),
+      documentXml(''),
+      documentXml(''),
+    )).toContain('revision-id-reused-across-identities:7');
+  });
 });
 
 async function compareSourceXml(bodyXml: string): Promise<string> {

--- a/packages/docx-compare/vitest.config.ts
+++ b/packages/docx-compare/vitest.config.ts
@@ -51,6 +51,9 @@ export default defineConfig({
     include: ['src/**/*.test.ts'],
     exclude: [
       'src/tagged/**/*.traceability.test.ts',
+      'src/integration/real-corpus-paragraph-deletion.test.ts',
+      'src/integration/strategy-differential-manifest.corpus.test.ts',
+      'src/integration/taggedTreeMinimality.corpus.test.ts',
     ],
     coverage: {
       provider: 'v8',

--- a/packages/docx-compare/vitest.corpus.config.ts
+++ b/packages/docx-compare/vitest.corpus.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from 'vitest/config';
+import baseConfig from './vitest.config.js';
+
+const base = baseConfig as ReturnType<typeof defineConfig>;
+
+/**
+ * Required real-corpus suites live outside the default workspace run so an
+ * absent corpus can never be reported as a skipped passing test. This config
+ * has one registered command and at least one included suite fails when its
+ * required environment/corpus is absent.
+ */
+export default defineConfig({
+  ...base,
+  test: {
+    ...base.test,
+    maxWorkers: 1,
+    include: [
+      'src/integration/real-corpus-paragraph-deletion.test.ts',
+      'src/integration/strategy-differential-manifest.corpus.test.ts',
+      'src/integration/taggedTreeMinimality.corpus.test.ts',
+    ],
+    exclude: [],
+  },
+});

--- a/scripts/update_strategy_differential_manifest.ts
+++ b/scripts/update_strategy_differential_manifest.ts
@@ -4,10 +4,7 @@ import { readFile, rename, writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { loadStrategyDifferentialFixtures } from '../packages/docx-compare/src/integration/strategy-differential-fixtures.js';
-import {
-  characterizeStrategyDifferential,
-  type StrategyDifferentialRow,
-} from '../packages/docx-compare/src/integration/strategy-differential-harness.js';
+import { characterizeStrategyDifferential } from '../packages/docx-compare/src/integration/strategy-differential-harness.js';
 
 const REPO_ROOT = resolve(fileURLToPath(new URL('..', import.meta.url)));
 const MANIFEST_PATH = resolve(
@@ -16,14 +13,12 @@ const MANIFEST_PATH = resolve(
 );
 const CORPUS_ENV = 'SAFE_DOCX_REAL_CORPUS_DIR';
 
-interface PersistedRow extends StrategyDifferentialRow {
-  legacy?: unknown;
-}
-
 interface CharacterizationManifest {
   schemaVersion: 1;
   divergences: unknown[];
-  rows: PersistedRow[];
+  rows: Array<Omit<Awaited<ReturnType<typeof characterizeStrategyDifferential>>, 'taggedTree'> & {
+    taggedTree: Omit<Awaited<ReturnType<typeof characterizeStrategyDifferential>>['taggedTree'], 'integrity'>;
+  }>;
 }
 
 function parseArguments(argv: string[]): { corpusRoot: string; write: boolean } {
@@ -39,32 +34,19 @@ function parseArguments(argv: string[]): { corpusRoot: string; write: boolean } 
   return { corpusRoot: resolve(corpusRoot), write };
 }
 
-function preserveRetiredLegacyEvidence(
-  row: StrategyDifferentialRow,
-  previous: PersistedRow | undefined,
-): PersistedRow {
-  if (!previous || !Object.hasOwn(previous, 'legacy')) return row;
-  return {
-    fixture: row.fixture,
-    approvedDivergenceIds: row.approvedDivergenceIds,
-    legacy: previous.legacy,
-    taggedTree: row.taggedTree,
-  };
-}
-
 async function main(): Promise<void> {
   const { corpusRoot, write } = parseArguments(process.argv.slice(2));
   const manifest = JSON.parse(await readFile(MANIFEST_PATH, 'utf8')) as CharacterizationManifest;
-  const previousRows = new Map(manifest.rows.map((row) => [row.fixture.id, row]));
   const fixtures = await loadStrategyDifferentialFixtures(corpusRoot);
-  const rows: PersistedRow[] = [];
+  const rows: CharacterizationManifest['rows'] = [];
 
   for (const fixture of fixtures) {
-    const characterized = await characterizeStrategyDifferential(fixture);
-    rows.push(preserveRetiredLegacyEvidence(
-      characterized,
-      previousRows.get(characterized.fixture.id),
-    ));
+    const row = await characterizeStrategyDifferential(fixture);
+    // Integrity is deliberately re-executed and asserted by the corpus gate on
+    // every run. Storing it would turn current safety results into reviewed
+    // historical evidence and make the updater disagree with the replay test.
+    const { integrity: _runtimeIntegrity, ...taggedTree } = row.taggedTree;
+    rows.push({ ...row, taggedTree });
   }
 
   const updated = `${JSON.stringify({ ...manifest, rows }, null, 2)}\n`;


### PR DESCRIPTION
## Why

The tagged migration evidence could skip when the public corpus was absent,
retain legacy-only rows and divergences, and snapshot safety fields without
executing assertions. That allowed a vacuous green result after the authority
flip.

## What changed

- register one serialized `test:real-corpus` command and exclude its three
  long-running suites from the default workspace run;
- fail corpus replay loudly when required evidence is unavailable;
- remove retired legacy output/dimensions and the vacuous payload-leak field;
- execute formatting, unsupported-story, field, bookmark, revision-ID, and
  move-balance safety oracles on every corpus replay;
- require every active divergence to suppress an observed assertion;
- record the narrow current ILPA section relationship-ID formatting divergence;
- scope revision identities to their containing document block so unrelated
  revisions cannot reuse one ID undetected;
- synchronize the canonical OpenSpec requirement with tagged-tree authority.

## Evidence

- `npm run build` — exit 0
- `npm run lint:workspaces` — exit 0
- `npm run test:run` outside the restricted sandbox — exit 0; all workspaces
  green, including LibreOffice renderer probes
- `npm run check:spec-coverage` — exit 0; docx-comparison 61/61
- `npm run check:conformance-citations` — exit 0
- `npm run check:conformance-doc` — exit 0
- serialized SHA-verified public corpus gate — 3 files, 21/21 tests, exit 0
- committed 23-row manifest replay after the scoped-ID fix — 3/3 tests, exit 0
- missing-corpus invocation — exit 1 on the explicit availability assertion
- Claude dynamic public-repository review — initial APPROVE-WITH-FIXES; both
  major findings fixed; focused follow-up APPROVE

No private Escrow files or private corpus environment were accessed or sent to
Claude. Claude was confined to a detached public-repository worktree.

Ref: #917
