### PR TITLE
fix(docx-compare): report truthful tagged result metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
   `engine: 'tagged-tree'` and removes requested/used strategy, reconstruction
   mode, and fallback metadata for the deleted comparison spine. Callers should
   handle typed publication errors instead of branching on fallback fields.
+- **Breaking:** `AncillaryStorySafetyError.attempts` and the exported
+  `AncillaryStorySafetyAttempt` type are removed because tagged publication does
+  not make reconstruction-mode attempts. Deep imports of the internal result
+  type should migrate from `AtomizerCompareResult` to `TaggedCompareResult`.
 - Migration note: DOCX comparison and redline generation moved from
   `@usejunior/docx-core` to `@usejunior/docx-compare`. Update comparison
   imports such as `compareDocuments` to use the new package name.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
   that assumed original-side package identities.
 - CLI and MCP comparison results now report `package_base: 'revised'` instead
   of engine, strategy, mode, or fallback metadata.
+- **Breaking:** library `CompareResult` now reports the sole implementation as
+  `engine: 'tagged-tree'` and removes requested/used strategy, reconstruction
+  mode, and fallback metadata for the deleted comparison spine. Callers should
+  handle typed publication errors instead of branching on fallback fields.
 - Migration note: DOCX comparison and redline generation moved from
   `@usejunior/docx-core` to `@usejunior/docx-compare`. Update comparison
   imports such as `compareDocuments` to use the new package name.

--- a/openspec/changes/archive/2026-08-19-refactor-tagged-tree-spine/specs/docx-comparison/spec.md
+++ b/openspec/changes/archive/2026-08-19-refactor-tagged-tree-spine/specs/docx-comparison/spec.md
@@ -186,14 +186,6 @@ text-box, auxiliary-sidecar, and formatting-fidelity checks SHALL remain in forc
 - **AND** no public strategy, engine, or reconstruction-mode selector SHALL be accepted
 - **AND** no public package-base or provenance selector SHALL be accepted
 
-#### Scenario: Public comparison reports only tagged result metadata
-
-- **GIVEN** a comparison succeeds through the sole tagged publication path
-- **WHEN** the public `CompareResult` is inspected
-- **THEN** its engine SHALL be `tagged-tree`
-- **AND** it SHALL NOT expose requested/used strategy, reconstruction-mode, or legacy-fallback result fields
-- **AND** publication failures SHALL be surfaced through typed errors rather than fallback result metadata
-
 #### Scenario: Skipped soak remains explicit
 
 - **GIVEN** migration history in which the authority flip and legacy deletion shipped without the required intervening release/corpus cycle

--- a/openspec/changes/archive/2026-08-19-refactor-tagged-tree-spine/specs/docx-comparison/spec.md
+++ b/openspec/changes/archive/2026-08-19-refactor-tagged-tree-spine/specs/docx-comparison/spec.md
@@ -186,6 +186,14 @@ text-box, auxiliary-sidecar, and formatting-fidelity checks SHALL remain in forc
 - **AND** no public strategy, engine, or reconstruction-mode selector SHALL be accepted
 - **AND** no public package-base or provenance selector SHALL be accepted
 
+#### Scenario: Public comparison reports only tagged result metadata
+
+- **GIVEN** a comparison succeeds through the sole tagged publication path
+- **WHEN** the public `CompareResult` is inspected
+- **THEN** its engine SHALL be `tagged-tree`
+- **AND** it SHALL NOT expose requested/used strategy, reconstruction-mode, or legacy-fallback result fields
+- **AND** publication failures SHALL be surfaced through typed errors rather than fallback result metadata
+
 #### Scenario: Skipped soak remains explicit
 
 - **GIVEN** migration history in which the authority flip and legacy deletion shipped without the required intervening release/corpus cycle

--- a/openspec/specs/docx-comparison/spec.md
+++ b/openspec/specs/docx-comparison/spec.md
@@ -727,6 +727,14 @@ text-box, auxiliary-sidecar, and formatting-fidelity checks SHALL remain in forc
 - **AND** no public strategy, engine, or reconstruction-mode selector SHALL be accepted
 - **AND** no public package-base or provenance selector SHALL be accepted
 
+#### Scenario: Public comparison reports only tagged result metadata
+
+- **GIVEN** a comparison succeeds through the sole tagged publication path
+- **WHEN** the public `CompareResult` is inspected
+- **THEN** its engine SHALL be `tagged-tree`
+- **AND** it SHALL NOT expose requested/used strategy, reconstruction-mode, or legacy-fallback result fields
+- **AND** publication failures SHALL be surfaced through typed errors rather than fallback result metadata
+
 #### Scenario: Skipped soak remains explicit
 
 - **GIVEN** migration history in which the authority flip and legacy deletion shipped without the required intervening release/corpus cycle

--- a/packages/docx-compare/API_REMOVAL_INVENTORY.md
+++ b/packages/docx-compare/API_REMOVAL_INVENTORY.md
@@ -5,8 +5,8 @@
 This inventory adjudicates every package-root export before the tagged-spine breaking release.
 “Deprecated” means retained for one release; “breaking removal” means intentionally absent now.
 
-- Stable compatibility surface: 64
-- Deprecated for one release: 21
+- Stable compatibility surface: 63
+- Deprecated for one release: 22
 - Documented breaking removals: 57
 
 | Symbol | Kind | Source | Present | Disposition |
@@ -15,7 +15,7 @@ This inventory adjudicates every package-root export before the tagged-spine bre
 | `alignComparisonSequences` | function | `src/textAlignment.ts` | yes | stable compatibility |
 | `allocateMoveIds` | function | `src/move-detection.ts` | no | breaking removal |
 | `AncillaryBindingLocator` | interface | `src/compare-types.ts` | yes | stable compatibility |
-| `AncillaryFallbackDiagnostics` | interface | `src/compare-types.ts` | yes | stable compatibility |
+| `AncillaryFallbackDiagnostics` | interface | `src/compare-types.ts` | yes | deprecate one release |
 | `AncillaryFieldEvidence` | interface | `src/compare-types.ts` | yes | stable compatibility |
 | `AncillaryFieldInstructionKind` | type | `src/compare-types.ts` | yes | stable compatibility |
 | `AncillaryFieldLocator` | interface | `src/compare-types.ts` | yes | stable compatibility |
@@ -167,4 +167,25 @@ This inventory adjudicates every package-root export before the tagged-spine bre
 | `maxWordRefinementChangeRanges` | breaking removal |
 | `premergeRuns` | breaking removal |
 | `reconstructionMode` | breaking removal |
+
+## Public result fields
+
+| `CompareResult` field | Present | Disposition |
+| --- | --- | --- |
+| `ancillaryFallbackDiagnostics` | no | breaking removal |
+| `ancillaryFieldEvidence` | yes | stable compatibility |
+| `comparisonStrategyFallbackReason` | no | breaking removal |
+| `comparisonStrategyRequested` | no | breaking removal |
+| `comparisonStrategyUsed` | no | breaking removal |
+| `document` | yes | stable compatibility |
+| `engine` | yes | truthful tagged replacement |
+| `fallbackDiagnostics` | no | breaking removal |
+| `fallbackReason` | no | breaking removal |
+| `inplaceSuccessDiagnostics` | no | breaking removal |
+| `rebuildSafetyDiagnostics` | no | breaking removal |
+| `reconstructionModeRequested` | no | breaking removal |
+| `reconstructionModeUsed` | no | breaking removal |
+| `stats` | yes | stable compatibility |
+| `taggedTreeFallbackDiagnostics` | no | breaking removal |
+| `unrepresentedChanges` | yes | stable compatibility |
 

--- a/packages/docx-compare/API_REMOVAL_INVENTORY.md
+++ b/packages/docx-compare/API_REMOVAL_INVENTORY.md
@@ -5,9 +5,9 @@
 This inventory adjudicates every package-root export before the tagged-spine breaking release.
 “Deprecated” means retained for one release; “breaking removal” means intentionally absent now.
 
-- Stable compatibility surface: 63
+- Stable compatibility surface: 62
 - Deprecated for one release: 22
-- Documented breaking removals: 57
+- Documented breaking removals: 58
 
 | Symbol | Kind | Source | Present | Disposition |
 | --- | --- | --- | --- | --- |
@@ -25,7 +25,7 @@ This inventory adjudicates every package-root export before the tagged-spine bre
 | `AncillaryPackageLocator` | interface | `src/compare-types.ts` | yes | stable compatibility |
 | `AncillarySelectedBindingSummary` | interface | `src/compare-types.ts` | yes | stable compatibility |
 | `AncillaryStoryLocator` | type | `src/compare-types.ts` | yes | stable compatibility |
-| `AncillaryStorySafetyAttempt` | interface | `src/tagged/ancillaryFieldSafety.ts` | yes | stable compatibility |
+| `AncillaryStorySafetyAttempt` | interface | `src/tagged/ancillaryFieldSafety.ts` | no | breaking removal |
 | `AncillaryStorySafetyCategory` | type | `src/compare-types.ts` | yes | stable compatibility |
 | `AncillaryStorySafetyError` | class | `src/tagged/ancillaryFieldSafety.ts` | yes | stable compatibility |
 | `AncillaryStorySafetyIssue` | interface | `src/compare-types.ts` | yes | stable compatibility |

--- a/packages/docx-compare/README.md
+++ b/packages/docx-compare/README.md
@@ -24,3 +24,12 @@ Publication fails closed with `TaggedPublicationSafetyError` when the tagged res
 The public `CompareOptions` surface no longer accepts `engine`, `comparisonStrategy`, `reconstructionMode`, `premergeRuns`, or `maxWordRefinementChangeRanges`. JavaScript callers that pass one of those retired keys receive a `TypeError`; TypeScript callers receive a type error.
 
 Callers that previously selected `reconstructionMode: 'rebuild'` received an original-based package. After upgrading, expect revised-side package provenance instead: revised rsids, `sectPr`, headers and footers, content types, relationships, and other package parts are authoritative. If downstream code compared package metadata or assumed original-side identities, update those assertions to the revised document. Accepting all revisions should reproduce the revised text projection; rejecting all revisions should reproduce the original text projection.
+
+`CompareResult` now reports `engine: 'tagged-tree'`. Remove caller branches and
+telemetry for `comparisonStrategyRequested`, `comparisonStrategyUsed`,
+`comparisonStrategyFallbackReason`, `taggedTreeFallbackDiagnostics`,
+`reconstructionModeRequested`, `reconstructionModeUsed`, `fallbackReason`,
+`fallbackDiagnostics`, `ancillaryFallbackDiagnostics`, `rebuildSafetyDiagnostics`,
+and `inplaceSuccessDiagnostics`; those fields described implementations and
+fallbacks that no longer exist. Publication failures are thrown as typed errors,
+including `TaggedPublicationSafetyError`, rather than returned as fallback metadata.

--- a/packages/docx-compare/README.md
+++ b/packages/docx-compare/README.md
@@ -34,6 +34,8 @@ and `inplaceSuccessDiagnostics`; those fields described implementations and
 fallbacks that no longer exist. Publication failures are thrown as typed errors,
 including `TaggedPublicationSafetyError`, rather than returned as fallback metadata.
 JavaScript reads of a retired result field now return `undefined`.
+When `unrepresentedChanges` has no value, the public result now omits that
+optional own property instead of returning it with the value `undefined`.
 
 `AncillaryStorySafetyError` exposes its current `issues` only. Remove callers of
 the deleted `attempts` property and `AncillaryStorySafetyAttempt` type; the sole

--- a/packages/docx-compare/README.md
+++ b/packages/docx-compare/README.md
@@ -33,3 +33,8 @@ telemetry for `comparisonStrategyRequested`, `comparisonStrategyUsed`,
 and `inplaceSuccessDiagnostics`; those fields described implementations and
 fallbacks that no longer exist. Publication failures are thrown as typed errors,
 including `TaggedPublicationSafetyError`, rather than returned as fallback metadata.
+JavaScript reads of a retired result field now return `undefined`.
+
+`AncillaryStorySafetyError` exposes its current `issues` only. Remove callers of
+the deleted `attempts` property and `AncillaryStorySafetyAttempt` type; the sole
+tagged publisher does not make reconstruction-mode attempts.

--- a/packages/docx-compare/api-removal-policy.json
+++ b/packages/docx-compare/api-removal-policy.json
@@ -4,7 +4,6 @@
       "acceptAllChanges",
       "alignComparisonSequences",
       "AncillaryBindingLocator",
-      "AncillaryFallbackDiagnostics",
       "AncillaryFieldEvidence",
       "AncillaryFieldInstructionKind",
       "AncillaryFieldLocator",
@@ -67,6 +66,7 @@
       "wordContainmentSimilarity"
     ],
     "deprecate one release": [
+      "AncillaryFallbackDiagnostics",
       "compareDocumentsAtomizer",
       "ComparisonStrategy",
       "ComparisonStrategyFallbackReason",
@@ -159,5 +159,29 @@
     "maxWordRefinementChangeRanges": "breaking removal",
     "premergeRuns": "breaking removal",
     "reconstructionMode": "breaking removal"
+  },
+  "publicResultFields": {
+    "stable compatibility": [
+      "ancillaryFieldEvidence",
+      "document",
+      "stats",
+      "unrepresentedChanges"
+    ],
+    "truthful tagged replacement": [
+      "engine"
+    ],
+    "breaking removal": [
+      "ancillaryFallbackDiagnostics",
+      "comparisonStrategyFallbackReason",
+      "comparisonStrategyRequested",
+      "comparisonStrategyUsed",
+      "fallbackDiagnostics",
+      "fallbackReason",
+      "inplaceSuccessDiagnostics",
+      "rebuildSafetyDiagnostics",
+      "reconstructionModeRequested",
+      "reconstructionModeUsed",
+      "taggedTreeFallbackDiagnostics"
+    ]
   }
 }

--- a/packages/docx-compare/api-removal-policy.json
+++ b/packages/docx-compare/api-removal-policy.json
@@ -13,7 +13,6 @@
       "AncillaryPackageLocator",
       "AncillarySelectedBindingSummary",
       "AncillaryStoryLocator",
-      "AncillaryStorySafetyAttempt",
       "AncillaryStorySafetyCategory",
       "AncillaryStorySafetyError",
       "AncillaryStorySafetyIssue",
@@ -147,7 +146,8 @@
     { "symbol": "MoveMarkup", "kind": "interface", "source": "src/move-detection.ts" },
     { "symbol": "MoveMarkupOptions", "kind": "interface", "source": "src/move-detection.ts" },
     { "symbol": "RevisionIdState", "kind": "interface", "source": "src/move-detection.ts" },
-    { "symbol": "DEFAULT_RECONSTRUCTION_MODE", "kind": "value", "source": "src/comparison-defaults.ts" }
+    { "symbol": "DEFAULT_RECONSTRUCTION_MODE", "kind": "value", "source": "src/comparison-defaults.ts" },
+    { "symbol": "AncillaryStorySafetyAttempt", "kind": "interface", "source": "src/tagged/ancillaryFieldSafety.ts" }
   ],
   "publicOptions": {
     "author": "stable compatibility",

--- a/packages/docx-compare/scripts/generate-api-removal-inventory.mjs
+++ b/packages/docx-compare/scripts/generate-api-removal-inventory.mjs
@@ -55,7 +55,58 @@ function currentExports() {
   });
 }
 
-function render(rows, publicOptions) {
+function currentInterfaceFields(interfaceName) {
+  const program = ts.createProgram([entryPath], {
+    module: ts.ModuleKind.NodeNext,
+    moduleResolution: ts.ModuleResolutionKind.NodeNext,
+    target: ts.ScriptTarget.ES2022,
+    skipLibCheck: true,
+  });
+  const checker = program.getTypeChecker();
+  const source = program.getSourceFile(entryPath);
+  const moduleSymbol = source && checker.getSymbolAtLocation(source);
+  if (!moduleSymbol) fail(`cannot resolve module exports for ${entryPath}`);
+  const exported = checker.getExportsOfModule(moduleSymbol)
+    .find((symbol) => symbol.name === interfaceName);
+  if (!exported) fail(`cannot resolve exported interface ${interfaceName}`);
+  const resolved = exported.flags & ts.SymbolFlags.Alias
+    ? checker.getAliasedSymbol(exported)
+    : exported;
+  return checker.getPropertiesOfType(checker.getDeclaredTypeOfSymbol(resolved))
+    .map((property) => property.name)
+    .sort();
+}
+
+function adjudicateFields(currentFields, policyFields) {
+  const dispositions = new Map();
+  for (const [disposition, fields] of Object.entries(policyFields)) {
+    for (const field of fields) {
+      if (dispositions.has(field)) fail(`duplicate CompareResult policy entry for ${field}`);
+      dispositions.set(field, disposition);
+    }
+  }
+  const current = new Set(currentFields);
+  const rows = [...dispositions].map(([field, disposition]) => ({
+    field,
+    present: current.has(field),
+    disposition,
+  }));
+  for (const row of rows) {
+    if (row.present && row.disposition === 'breaking removal') {
+      fail(`CompareResult.${row.field} is marked removed but remains present`);
+    }
+    if (!row.present && row.disposition !== 'breaking removal') {
+      fail(`CompareResult.${row.field} is marked ${row.disposition} but is absent`);
+    }
+  }
+  for (const field of current) {
+    if (!dispositions.has(field)) fail(`missing CompareResult field disposition for ${field}`);
+  }
+  rows.sort((left, right) => left.field.localeCompare(right.field));
+  return rows;
+}
+
+function render(rows, publicOptions, publicResultFields) {
   const counts = new Map();
   for (const row of rows) counts.set(row.disposition, (counts.get(row.disposition) ?? 0) + 1);
   const lines = [
@@ -82,6 +133,13 @@ function render(rows, publicOptions) {
     ...Object.entries(publicOptions)
       .sort(([left], [right]) => left.localeCompare(right))
       .map(([field, disposition]) => `| \`${field}\` | ${disposition} |`),
+    '',
+    '## Public result fields',
+    '',
+    '| `CompareResult` field | Present | Disposition |',
+    '| --- | --- | --- |',
+    ...publicResultFields.map((row) =>
+      `| \`${row.field}\` | ${row.present ? 'yes' : 'no'} | ${row.disposition} |`),
     '',
   ];
   return `${lines.join('\n')}\n`;
@@ -112,7 +170,11 @@ for (const row of rows) {
 if (dispositions.size > 0) fail(`policy names absent exports: ${[...dispositions.keys()].sort().join(', ')}`);
 rows.sort((left, right) => left.symbol.localeCompare(right.symbol));
 
-const output = render(rows, policy.publicOptions);
+const publicResultFields = adjudicateFields(
+  currentInterfaceFields('CompareResult'),
+  policy.publicResultFields,
+);
+const output = render(rows, policy.publicOptions, publicResultFields);
 if (mode === '--write') {
   await writeFile(inventoryPath, output, 'utf8');
   process.stdout.write(`Wrote ${relative(process.cwd(), inventoryPath)} (${rows.length} symbols)\n`);

--- a/packages/docx-compare/src/cli/compare-two.test.ts
+++ b/packages/docx-compare/src/cli/compare-two.test.ts
@@ -130,7 +130,7 @@ describe('docx-comparison CLI fixed tagged publication', () => {
     return {
       document: Buffer.from('redline-bytes'),
       stats: zeroStats,
-      engine: 'atomizer',
+      engine: 'tagged-tree',
       ...overrides,
     };
   }

--- a/packages/docx-compare/src/compare-types.ts
+++ b/packages/docx-compare/src/compare-types.ts
@@ -197,7 +197,10 @@ export interface ReconstructionFallbackDiagnostics {
   attempts: ReconstructionAttemptDiagnostics[];
 }
 
-/** Safety evidence retained when tagged-tree publication falls back to legacy output. */
+/**
+ * Historical tagged-to-legacy fallback evidence.
+ * @deprecated The tagged publisher throws instead of falling back and never returns this shape.
+ */
 export interface TaggedTreeFallbackDiagnostics {
   checks: TaggedPublicationSafetyChecks;
   failedChecks: TaggedPublicationSafetyCheckName[];
@@ -216,14 +219,8 @@ export interface TaggedPublicationSafetyChecks extends ReconstructionSafetyCheck
 }
 
 /**
- * Diagnostics for a *successful* inplace reconstruction: which pass produced the
- * accepted output, and the passes that were tried and rejected before it. The
- * fallback diagnostics above only surface when every inplace pass fails and the
- * pipeline reroutes to rebuild; this surfaces the same per-pass detail on the
- * success path, so a caller can tell which pass produced the output — e.g. a
- * later pass rescuing what an earlier pass could not reconstruct safely —
- * without inferring it from the absence of a fallback. Present only for atomizer
- * inplace output (`reconstructionModeUsed === 'inplace'`).
+ * Historical diagnostics for the removed inplace reconstruction pipeline.
+ * @deprecated The tagged publisher never returns this shape.
  *
  * @see https://github.com/UseJunior/safe-docx/issues/469
  */
@@ -238,10 +235,8 @@ export interface ReconstructionInplaceSuccessDiagnostics {
 }
 
 /**
- * Round-trip safety evaluation of rebuild output. Rebuild is the terminal
- * reconstruction strategy — there is no further fallback — so a failed check
- * cannot reroute the pipeline. The document is returned anyway and the
- * failures are surfaced here as a caller-visible warning.
+ * Historical safety evaluation for the removed rebuild pipeline.
+ * @deprecated The tagged publisher never returns rebuild output.
  *
  * @see https://github.com/UseJunior/safe-docx/issues/226
  */
@@ -306,6 +301,10 @@ export interface AncillaryStorySafetyIssue {
   locator: AncillaryStoryLocator;
 }
 
+/**
+ * Historical wrapper for ancillary fallback issues.
+ * @deprecated Successful results carry `AncillaryFieldEvidence`; failures throw `AncillaryStorySafetyError`.
+ */
 export interface AncillaryFallbackDiagnostics {
   issues: AncillaryStorySafetyIssue[];
 }
@@ -350,55 +349,13 @@ export interface CompareResult {
   document: Buffer;
   /** Statistics about the comparison */
   stats: CompareStats;
-  /** Which engine was used */
-  engine: 'wmlcomparer' | 'atomizer';
-  /** Strategy requested by the caller, including the tagged-tree default. */
-  comparisonStrategyRequested?: ComparisonStrategy;
-  /** Strategy that constructed the published document. */
-  comparisonStrategyUsed?: ComparisonStrategy;
-  /** Why tagged-tree publication was rejected in favor of validated legacy output. */
-  comparisonStrategyFallbackReason?: ComparisonStrategyFallbackReason;
-  /** Failed tagged-tree publication checks retained for diagnosis and telemetry. */
-  taggedTreeFallbackDiagnostics?: TaggedTreeFallbackDiagnostics;
+  /** The sole comparison implementation that constructed this result. */
+  engine: 'tagged-tree';
   /**
    * Input differences that the emitted revision markup does not represent.
    * Absent when no supported package-level difference is detected.
    */
   unrepresentedChanges?: UnrepresentedChange[];
-  /**
-   * Requested reconstruction mode. Present for atomizer outputs.
-   */
-  reconstructionModeRequested?: ReconstructionMode;
-  /**
-   * Actual reconstruction mode used to produce the output. Present for atomizer outputs.
-   */
-  reconstructionModeUsed?: ReconstructionMode;
-  /**
-   * Why the requested reconstruction mode could not be used.
-   * Present only when atomizer falls back.
-   */
-  fallbackReason?: ReconstructionFallbackReason;
-  /**
-   * Detailed safety-check diagnostics for fallback decisions.
-   * Present only when atomizer falls back.
-   */
-  fallbackDiagnostics?: ReconstructionFallbackDiagnostics;
-  /**
-   * Ancillary issues from an inplace candidate rejected at package assembly.
-   * Present only when ancillary validation itself caused rebuild fallback.
-   */
-  ancillaryFallbackDiagnostics?: AncillaryFallbackDiagnostics;
-  /**
-   * Safety-check failures observed on rebuild output — whether rebuild was
-   * requested explicitly or reached via fallback from the inplace default.
-   * Present only when at least one check failed.
-   */
-  rebuildSafetyDiagnostics?: ReconstructionRebuildSafetyDiagnostics;
-  /**
-   * Which inplace pass produced the output and which passes it superseded.
-   * Present only when atomizer produced inplace output.
-   */
-  inplaceSuccessDiagnostics?: ReconstructionInplaceSuccessDiagnostics;
   /**
    * Successful structural and canonical evidence for the final assembled
    * ancillary stories. Absence means unavailable evidence, not a pass.

--- a/packages/docx-compare/src/compare-types.ts
+++ b/packages/docx-compare/src/compare-types.ts
@@ -68,9 +68,12 @@ export interface CompareStats {
   formatChangeAtoms: number;
 }
 
+/** @deprecated Comparison no longer has reconstruction modes. */
 export type ReconstructionMode = 'rebuild' | 'inplace';
+/** @deprecated Comparison no longer accepts or reports strategy selection. */
 export type ComparisonStrategy = 'tagged-tree' | 'legacy';
 
+/** @deprecated Tagged publication throws instead of falling back to a legacy strategy. */
 export type ComparisonStrategyFallbackReason =
   | 'tagged_tree_publication_safety_check_failed';
 
@@ -90,10 +93,12 @@ export interface UnrepresentedChange {
   role?: 'default' | 'first' | 'even';
 }
 
+/** @deprecated Tagged publication throws instead of falling back to reconstruction. */
 export type ReconstructionFallbackReason =
   | 'round_trip_safety_check_failed'
   | 'ancillary_story_safety_check_failed';
 
+/** @deprecated Retained for one-release compatibility with historical diagnostic types. */
 export type ReconstructionSafetyCheckName =
   | 'acceptText'
   | 'rejectText'
@@ -101,6 +106,7 @@ export type ReconstructionSafetyCheckName =
   | 'rejectBookmarks'
   | 'fieldStructure';
 
+/** @deprecated Retained for one-release compatibility with historical diagnostic types. */
 export interface ReconstructionSafetyChecks {
   acceptText: boolean;
   rejectText: boolean;
@@ -109,6 +115,7 @@ export interface ReconstructionSafetyChecks {
   fieldStructure: boolean;
 }
 
+/** @deprecated Retained for one-release compatibility with historical diagnostic types. */
 export interface ReconstructionTextMismatchDetails {
   expectedLength: number;
   actualLength: number;
@@ -118,11 +125,13 @@ export interface ReconstructionTextMismatchDetails {
   differenceSample: string[];
 }
 
+/** @deprecated Retained for one-release compatibility with historical diagnostic types. */
 export interface ReconstructionIdDelta {
   missing: string[];
   unexpected: string[];
 }
 
+/** @deprecated Retained for one-release compatibility with historical diagnostic types. */
 export interface ReconstructionBookmarkMismatchDetails {
   startNames: ReconstructionIdDelta;
   referencedBookmarkNames: ReconstructionIdDelta;
@@ -141,6 +150,7 @@ export interface ReconstructionBookmarkMismatchDetails {
   actualUnmatchedEndIds: string[];
 }
 
+/** @deprecated Retained for one-release compatibility with historical diagnostic types. */
 export interface ReconstructionSafetyFailureDetails {
   acceptText?: ReconstructionTextMismatchDetails;
   rejectText?: ReconstructionTextMismatchDetails;
@@ -148,6 +158,7 @@ export interface ReconstructionSafetyFailureDetails {
   rejectBookmarks?: ReconstructionBookmarkMismatchDetails;
 }
 
+/** @deprecated Retained for one-release compatibility with historical diagnostic types. */
 export interface ReconstructionIdDeltaSummary {
   missingCount: number;
   unexpectedCount: number;
@@ -155,6 +166,7 @@ export interface ReconstructionIdDeltaSummary {
   firstUnexpected?: string;
 }
 
+/** @deprecated Retained for one-release compatibility with historical diagnostic types. */
 export interface ReconstructionTextMismatchSummary {
   firstDifferingParagraphIndex: number;
   expectedParagraph: string;
@@ -162,6 +174,7 @@ export interface ReconstructionTextMismatchSummary {
   firstDifference: string;
 }
 
+/** @deprecated Retained for one-release compatibility with historical diagnostic types. */
 export interface ReconstructionBookmarkMismatchSummary {
   startNames: ReconstructionIdDeltaSummary;
   referencedBookmarkNames: ReconstructionIdDeltaSummary;
@@ -174,6 +187,7 @@ export interface ReconstructionBookmarkMismatchSummary {
   firstUnmatchedEndId?: string;
 }
 
+/** @deprecated Retained for one-release compatibility with historical diagnostic types. */
 export interface ReconstructionSafetyFailureSummary {
   acceptText?: ReconstructionTextMismatchSummary;
   rejectText?: ReconstructionTextMismatchSummary;
@@ -181,6 +195,7 @@ export interface ReconstructionSafetyFailureSummary {
   rejectBookmarks?: ReconstructionBookmarkMismatchSummary;
 }
 
+/** @deprecated The tagged publisher does not make reconstruction attempts. */
 export interface ReconstructionAttemptDiagnostics {
   pass:
     | 'inplace_word_split'
@@ -193,6 +208,7 @@ export interface ReconstructionAttemptDiagnostics {
   firstDiffSummary?: ReconstructionSafetyFailureSummary;
 }
 
+/** @deprecated The tagged publisher throws instead of falling back to reconstruction. */
 export interface ReconstructionFallbackDiagnostics {
   attempts: ReconstructionAttemptDiagnostics[];
 }

--- a/packages/docx-compare/src/index.ts
+++ b/packages/docx-compare/src/index.ts
@@ -88,7 +88,7 @@ export async function compareDocuments(
     detectMoves,
   } = options;
 
-  return compareDocumentsAtomizer(original, revised, {
+  const tagged = await compareDocumentsAtomizer(original, revised, {
     author,
     date,
     formatDetection:
@@ -100,6 +100,18 @@ export async function compareDocuments(
         ? undefined
         : { detectMoves },
   });
+
+  return {
+    document: tagged.document,
+    stats: tagged.stats,
+    engine: tagged.engine,
+    ...(tagged.unrepresentedChanges === undefined
+      ? {}
+      : { unrepresentedChanges: tagged.unrepresentedChanges }),
+    ...(tagged.ancillaryFieldEvidence === undefined
+      ? {}
+      : { ancillaryFieldEvidence: tagged.ancillaryFieldEvidence }),
+  };
 }
 
 export * from './move-detection.js';
@@ -129,7 +141,6 @@ export { hasFldCharInsideDel } from '@usejunior/docx-core';
 export { parseDocumentXml } from './tagged/xmlToWmlElement.js';
 export {
   AncillaryStorySafetyError,
-  type AncillaryStorySafetyAttempt,
 } from './tagged/ancillaryFieldSafety.js';
 export {
   UnsupportedTextBoxRevisionError,

--- a/packages/docx-compare/src/integration/strategy-differential-harness.ts
+++ b/packages/docx-compare/src/integration/strategy-differential-harness.ts
@@ -9,7 +9,6 @@ import {
 import JSZip from 'jszip';
 import type {
   CompareStats,
-  ComparisonStrategy,
   UnrepresentedChange,
 } from '../compare-types.js';
 import { compareDocumentsAtomizer } from '../tagged/pipeline.js';
@@ -24,6 +23,7 @@ const AUTHOR = 'Strategy Differential';
 const DATE = new Date('2026-08-17T12:00:00Z');
 const XML_PART_PATTERN = /(?:\.xml|\.rels)$/u;
 const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+type TaggedStrategy = 'tagged-tree';
 
 export interface StrategyDifferentialFixture {
   id: string;
@@ -61,7 +61,7 @@ export interface ProjectionSummary {
 }
 
 export interface StrategyEvidence {
-  strategy: ComparisonStrategy;
+  strategy: TaggedStrategy;
   projections: {
     accept: ProjectionSummary;
     reject: ProjectionSummary;
@@ -69,7 +69,7 @@ export interface StrategyEvidence {
   packageParts: PackagePartSummary[];
   stats: CompareStats;
   authority: {
-    comparisonStrategyUsed?: ComparisonStrategy;
+    comparisonStrategyUsed?: TaggedStrategy;
   };
   unrepresentedChanges: UnrepresentedChange[];
   schema: {
@@ -465,7 +465,7 @@ async function characterizeStrategy(
     packageParts: await packagePartSummaries(result.document),
     stats: result.stats,
     authority: {
-      comparisonStrategyUsed: 'tagged-tree',
+      comparisonStrategyUsed: result.engine,
     },
     unrepresentedChanges: result.unrepresentedChanges ?? [],
     schema: {

--- a/packages/docx-compare/src/integration/strategy-differential-harness.ts
+++ b/packages/docx-compare/src/integration/strategy-differential-harness.ts
@@ -8,7 +8,6 @@ import {
 } from '@usejunior/docx-core';
 import JSZip from 'jszip';
 import type {
-  CompareResult,
   CompareStats,
   ComparisonStrategy,
   UnrepresentedChange,
@@ -222,12 +221,6 @@ async function auxiliaryDefinitionIssues(buffer: Buffer): Promise<string[]> {
     }
   }
   return issues.sort();
-}
-
-function unsupportedStoryDiagnostics(result: CompareResult): string[] {
-  return (result.ancillaryFallbackDiagnostics?.issues ?? [])
-    .map((issue) => `${issue.category}:${issue.code}:${issue.detail}`)
-    .sort();
 }
 
 function structuralIssueKey(issue: { check: string; part: string; message: string }): string {
@@ -472,7 +465,7 @@ async function characterizeStrategy(
     packageParts: await packagePartSummaries(result.document),
     stats: result.stats,
     authority: {
-      comparisonStrategyUsed: result.comparisonStrategyUsed,
+      comparisonStrategyUsed: 'tagged-tree',
     },
     unrepresentedChanges: result.unrepresentedChanges ?? [],
     schema: {
@@ -505,7 +498,10 @@ async function characterizeStrategy(
       revisionIdIssues: collectRevisionIdIssues(candidateXml, originalXml, revisedXml),
       moveBalanceIssues: moveBalanceIssues(candidateXml),
     },
-    unsupportedStoryDiagnostics: unsupportedStoryDiagnostics(result),
+    // A successful fail-closed comparison necessarily emitted no unsupported
+    // story diagnostic. Such failures are thrown instead of returned as
+    // result metadata.
+    unsupportedStoryDiagnostics: [],
   };
 }
 

--- a/packages/docx-compare/src/integration/strategy-differential.test.ts
+++ b/packages/docx-compare/src/integration/strategy-differential.test.ts
@@ -58,7 +58,7 @@ async function compareXml(
     author: 'Strategy Differential',
     date: DATE,
   });
-  expect(result.comparisonStrategyUsed).toBe('tagged-tree');
+  expect(result.engine).toBe('tagged-tree');
   const documentXml = await (await DocxArchive.load(result.document)).getDocumentXml();
   expect(documentXml.startsWith('<?xml')).toBe(true);
   return documentXml;

--- a/packages/docx-compare/src/integration/tagged-rationale-attribution.test.ts
+++ b/packages/docx-compare/src/integration/tagged-rationale-attribution.test.ts
@@ -91,7 +91,7 @@ describe('tagged revision rationale attribution', () => {
     'maps each operation to one unique balanced and non-overlapping emitted interval',
     async () => {
       const result = await attributedFixture();
-      expect(result.comparisonStrategyUsed).toBe('tagged-tree');
+      expect(result.engine).toBe('tagged-tree');
       expect(result.revisionAttributions?.map((entry) => entry.operationId)).toEqual([
         'alpha',
         'beta',

--- a/packages/docx-compare/src/public-result-metadata.test.ts
+++ b/packages/docx-compare/src/public-result-metadata.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect } from 'vitest';
+import {
+  compareDocuments,
+  type AncillaryFieldEvidence,
+  type CompareResult,
+  type CompareStats,
+  type UnrepresentedChange,
+} from './index.js';
+import { buildDocxFromBodyXml, paragraphWithText } from './testing/ooxml-fixtures.js';
+import { testAllure } from './testing/allure-test.js';
+
+const TEST_FEATURE = 'Refactor Tagged Tree Spine';
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({ feature: TEST_FEATURE });
+
+type ExpectedCompareResult = {
+  document: Buffer;
+  stats: CompareStats;
+  engine: 'tagged-tree';
+  unrepresentedChanges?: UnrepresentedChange[];
+  ancillaryFieldEvidence?: AncillaryFieldEvidence;
+};
+
+type TypesEqual<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends
+    (<Value>() => Value extends Right ? 1 : 2)
+    ? (<Value>() => Value extends Right ? 1 : 2) extends
+        (<Value>() => Value extends Left ? 1 : 2)
+      ? true
+      : false
+    : false;
+
+const compareResultTypeIsExact: TypesEqual<CompareResult, ExpectedCompareResult> = true;
+
+const RETIRED_RESULT_FIELDS = [
+  'comparisonStrategyRequested',
+  'comparisonStrategyUsed',
+  'comparisonStrategyFallbackReason',
+  'taggedTreeFallbackDiagnostics',
+  'reconstructionModeRequested',
+  'reconstructionModeUsed',
+  'fallbackReason',
+  'fallbackDiagnostics',
+  'ancillaryFallbackDiagnostics',
+  'rebuildSafetyDiagnostics',
+  'inplaceSuccessDiagnostics',
+] as const;
+
+describe('public comparison result metadata', () => {
+  test.openspec('Public comparison reports only tagged result metadata')(
+    'returns truthful tagged metadata and no retired engine, mode, or fallback fields',
+    async () => {
+      const [original, revised] = await Promise.all([
+        buildDocxFromBodyXml(paragraphWithText('Original public result.')),
+        buildDocxFromBodyXml(paragraphWithText('Revised public result.')),
+      ]);
+
+      const result = await compareDocuments(original, revised, {
+        date: new Date('2026-08-22T12:00:00Z'),
+      });
+
+      expect(compareResultTypeIsExact).toBe(true);
+      expect(result.engine).toBe('tagged-tree');
+      for (const field of RETIRED_RESULT_FIELDS) {
+        expect(Object.hasOwn(result, field), field).toBe(false);
+      }
+    },
+  );
+});

--- a/packages/docx-compare/src/public-result-metadata.test.ts
+++ b/packages/docx-compare/src/public-result-metadata.test.ts
@@ -62,6 +62,12 @@ describe('public comparison result metadata', () => {
 
       expect(compareResultTypeIsExact).toBe(true);
       expect(result.engine).toBe('tagged-tree');
+      expect(Object.keys(result).sort()).toEqual([
+        'ancillaryFieldEvidence',
+        'document',
+        'engine',
+        'stats',
+      ]);
       for (const field of RETIRED_RESULT_FIELDS) {
         expect(Object.hasOwn(result, field), field).toBe(false);
       }

--- a/packages/docx-compare/src/tagged/ancillaryFieldSafety.ts
+++ b/packages/docx-compare/src/tagged/ancillaryFieldSafety.ts
@@ -18,7 +18,6 @@ import type {
   AncillarySelectedBindingSummary,
   AncillaryStorySafetyIssue,
   AncillaryStorySummary,
-  ReconstructionMode,
 } from '../compare-types.js';
 import {
   canonicalNode,
@@ -46,27 +45,13 @@ const IGNORED_STRICT_ISSUES = new Set([
   'DELETED_TEXT_OUTSIDE_DELETION',
 ]);
 
-export interface AncillaryStorySafetyAttempt {
-  reconstructionMode: ReconstructionMode;
-  issues: AncillaryStorySafetyIssue[];
-}
-
 export class AncillaryStorySafetyError extends Error {
   readonly issues: AncillaryStorySafetyIssue[];
-  readonly attempts?: AncillaryStorySafetyAttempt[];
 
-  constructor(
-    issues: AncillaryStorySafetyIssue[],
-    attempts?: AncillaryStorySafetyAttempt[],
-  ) {
-    super(
-      attempts
-        ? `Ancillary story safety check failed in ${attempts.length} reconstruction attempt(s)`
-        : `Ancillary story safety check failed with ${issues.length} issue(s)`,
-    );
+  constructor(issues: AncillaryStorySafetyIssue[]) {
+    super(`Ancillary story safety check failed with ${issues.length} issue(s)`);
     this.name = 'AncillaryStorySafetyError';
     this.issues = issues;
-    this.attempts = attempts;
   }
 }
 

--- a/packages/docx-compare/src/tagged/pipeline-pageref-cache.test.ts
+++ b/packages/docx-compare/src/tagged/pipeline-pageref-cache.test.ts
@@ -121,7 +121,7 @@ describe('cached PAGEREF comparison (#716)', () => {
       expect(revisionTexts(outputXml)).toEqual([]);
     });
     await then('the sole tagged path succeeds', () => {
-      expect(result.comparisonStrategyUsed).toBe('tagged-tree');
+      expect(result.engine).toBe('tagged-tree');
     });
     await then('both cache-insensitive projections preserve their source TOC', async () => {
       expect(cacheInsensitiveText(acceptAllChanges(outputXml))).toBe(

--- a/packages/docx-compare/src/tagged/pipeline-text-box-stories.test.ts
+++ b/packages/docx-compare/src/tagged/pipeline-text-box-stories.test.ts
@@ -795,7 +795,7 @@ describe('VML text-box story comparison (#713)', () => {
     );
 
     await then('the comparison completes rather than failing closed', () => {
-      expect(result.reconstructionModeUsed).toBe('inplace');
+      expect(result.engine).toBe('tagged-tree');
     });
   });
 
@@ -826,7 +826,7 @@ describe('VML text-box story comparison (#713)', () => {
     const outputXml = await documentXml(result.document);
 
     await then('the story is redlined rather than refused', () => {
-      expect(result.reconstructionModeUsed).toBe('inplace');
+      expect(result.engine).toBe('tagged-tree');
       expect(textBoxText(acceptAllChanges(outputXml))).toBe('Revised');
       expect(textBoxText(rejectAllChanges(outputXml))).toBe('Original');
     });
@@ -1157,7 +1157,7 @@ describe('VML text-box story comparison (#713)', () => {
     );
 
     await then('the inserted section lifecycle is publishable', () => {
-      expect(result.reconstructionModeUsed).toBe('inplace');
+      expect(result.engine).toBe('tagged-tree');
       expect(result.stats.insertions).toBeGreaterThan(0);
     });
   });
@@ -1615,7 +1615,7 @@ describe('Word-authored text-box corpus (#795)', () => {
 
         const result = await compareDocumentsAtomizer(source, revised, {
         });
-        if (result.reconstructionModeUsed === 'inplace') admitted.push(host);
+        if (result.engine === 'tagged-tree') admitted.push(host);
       }
     });
 

--- a/packages/docx-compare/src/tagged/pipeline-word-split-whitespace.test.ts
+++ b/packages/docx-compare/src/tagged/pipeline-word-split-whitespace.test.ts
@@ -87,7 +87,7 @@ describe('adaptive word-split whitespace parity (#720)', () => {
     const xml = await documentXml(result.document);
 
     await then('the sole tagged path satisfies the safety gate', () => {
-      expect(result.comparisonStrategyUsed).toBe('tagged-tree');
+      expect(result.engine).toBe('tagged-tree');
     });
 
     await and('accept and reject preserve every character, including spaces', () => {

--- a/packages/docx-compare/src/tagged/pipeline.ts
+++ b/packages/docx-compare/src/tagged/pipeline.ts
@@ -678,8 +678,8 @@ export interface AtomizerOptions {
   taggedTreeFormattingFidelityEvaluator?: typeof compareSourceProjectedFormattingFidelity;
 }
 
-/** Atomizer-only result metadata used by internal tagged attribution callers. */
-export interface AtomizerCompareResult extends CompareResult {
+/** Internal tagged result metadata used by attribution-aware callers. */
+export interface TaggedCompareResult extends CompareResult {
   /** Exact tagged revision ranges requested through private attribution input. @internal */
   revisionAttributions?: RevisionAttribution[];
 }
@@ -1109,7 +1109,7 @@ async function compareDocumentsTaggedCore(
   revised: Buffer,
   options: AtomizerOptions,
   bookmarkNameReservations?: Set<string>,
-): Promise<AtomizerCompareResult> {
+): Promise<TaggedCompareResult> {
   const standalone = await buildStandaloneTaggedPackage(original, revised, {
     author: options.author ?? 'Comparison',
     date: options.date ?? new Date(),
@@ -1133,12 +1133,8 @@ async function compareDocumentsTaggedCore(
   return {
     document: standalone.document,
     stats: standalone.stats,
-    engine: 'atomizer',
-    comparisonStrategyRequested: 'tagged-tree',
-    comparisonStrategyUsed: 'tagged-tree',
+    engine: 'tagged-tree',
     unrepresentedChanges: standalone.unrepresentedChanges,
-    reconstructionModeRequested: 'inplace',
-    reconstructionModeUsed: 'inplace',
     ancillaryFieldEvidence: standalone.ancillaryFieldEvidence,
     revisionAttributions: standalone.revisionAttributions,
   };
@@ -1155,7 +1151,7 @@ async function compareDocumentsTagged(
   original: Buffer,
   revised: Buffer,
   options: AtomizerOptions,
-): Promise<AtomizerCompareResult> {
+): Promise<TaggedCompareResult> {
   const textBoxPlan = await prepareTextBoxStoryComparison(original, revised);
   if (!textBoxPlan) {
     return compareDocumentsTaggedCore(original, revised, options);
@@ -1344,7 +1340,7 @@ export async function compareDocumentsAtomizer(
   original: Buffer,
   revised: Buffer,
   options: AtomizerOptions = {},
-): Promise<AtomizerCompareResult> {
+): Promise<TaggedCompareResult> {
   debugTaggedComparison('starting revised-base comparison', {
     originalBytes: original.length,
     revisedBytes: revised.length,

--- a/packages/docx-compare/src/tagged/taggedTreeShadow.test.ts
+++ b/packages/docx-compare/src/tagged/taggedTreeShadow.test.ts
@@ -186,7 +186,7 @@ describe('tagged-tree offline evaluation', () => {
       );
       const published = await DocxArchive.load(result.document);
 
-      expect(result.comparisonStrategyUsed).toBe('tagged-tree');
+      expect(result.engine).toBe('tagged-tree');
       expect(await published.getFile('customXml/revised-only.xml')).toBe('<revised-only/>');
       expect(await published.getFile('customXml/original-only.xml')).toBeNull();
     },

--- a/packages/docx-compare/src/tagged/textBoxRevisionSafety-alternate-content.test.ts
+++ b/packages/docx-compare/src/tagged/textBoxRevisionSafety-alternate-content.test.ts
@@ -306,8 +306,8 @@ describe('mc:AlternateContent text-box ordinals', () => {
       ).getDocumentXml();
       const copies = storedCopies(comparedXml);
 
-      await then('the comparison stays on the in-place path', () => {
-        expect(compared.reconstructionModeUsed).toBe('inplace');
+      await then('the comparison stays on the sole tagged path', () => {
+        expect(compared.engine).toBe('tagged-tree');
       });
       await and('the unchanged box carries no revision in either copy', () => {
         expect(copies).toHaveLength(4);

--- a/packages/docx-core/scripts/repro_nvca_corruption.mjs
+++ b/packages/docx-core/scripts/repro_nvca_corruption.mjs
@@ -1,7 +1,5 @@
-
-import { compareDocumentsAtomizer } from '../dist/index.js';
+import { compareDocuments } from '../../docx-compare/dist/index.js';
 import fs from 'fs';
-import path from 'path';
 
 const sourcePath = process.argv[2];
 const revisedPath = process.argv[3];
@@ -16,19 +14,19 @@ async function run() {
   const sourceBuf = fs.readFileSync(sourcePath);
   const revisedBuf = fs.readFileSync(revisedPath);
 
-  console.log(`Comparing ${sourcePath} vs ${revisedPath} (FORCED INPLACE)`);
-  
-  const res = await compareDocumentsAtomizer(sourceBuf, revisedBuf, {
-    author: 'Repro'
+  console.log(`Comparing ${sourcePath} vs ${revisedPath} (TAGGED TREE)`);
+
+  const res = await compareDocuments(sourceBuf, revisedBuf, {
+    author: 'Repro',
   });
 
   console.log('Engine:', res.engine);
 
   fs.writeFileSync(outputPath, res.document);
-  console.log(`Saved FORCED INPLACE redline to ${outputPath}`);
+  console.log(`Saved tagged-tree redline to ${outputPath}`);
 }
 
-run().catch(err => {
+run().catch((err) => {
   console.error(err);
   process.exit(1);
 });

--- a/packages/docx-core/scripts/repro_nvca_corruption.mjs
+++ b/packages/docx-core/scripts/repro_nvca_corruption.mjs
@@ -22,11 +22,7 @@ async function run() {
     author: 'Repro'
   });
 
-  console.log('Mode used:', res.reconstructionModeUsed);
-  if (res.fallbackReason) {
-    console.log('Fallback reason:', res.fallbackReason);
-    console.log('First diff summary:', JSON.stringify(res.fallbackDiagnostics?.attempts?.[0]?.firstDiffSummary, null, 2));
-  }
+  console.log('Engine:', res.engine);
 
   fs.writeFileSync(outputPath, res.document);
   console.log(`Saved FORCED INPLACE redline to ${outputPath}`);

--- a/packages/docx-core/src/generation/generation-compare-roundtrip.test.ts
+++ b/packages/docx-core/src/generation/generation-compare-roundtrip.test.ts
@@ -19,7 +19,7 @@ import { describe, expect } from 'vitest';
 import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
 import { generateDocx } from './compile.js';
 import { compareDocumentsAtomizer as compareDocuments } from '@usejunior/docx-compare';
-import type { CompareResult, ReconstructionMode } from '@usejunior/docx-compare';
+import type { CompareResult } from '@usejunior/docx-compare';
 import { DocxArchive } from '../shared/docx/DocxArchive.js';
 import {
   acceptAllChanges,
@@ -72,7 +72,7 @@ function signatureLines(parties: Array<{ party: string; name: string; title: str
 const TEST_FEATURE = 'add-generation-compare-roundtrip';
 const test = testAllure.epic('Document Generation').withLabels({ feature: TEST_FEATURE });
 
-const MODES: ReconstructionMode[] = ['inplace'];
+const PUBLICATION_PATHS = ['tagged-tree'] as const;
 
 // --- Spec builders ----------------------------------------------------------
 
@@ -209,12 +209,11 @@ interface RoundTripArtifacts {
 /**
  * Mirror of the file-local helper in
  * integration/roundtrip-structural-invariants.test.ts, extended to also return
- * the CompareResult so callers can assert stats and reconstruction diagnostics.
+ * the CompareResult so callers can assert public statistics and metadata.
  */
 async function buildRoundTripArtifacts(
   originalBuffer: Buffer,
   revisedBuffer: Buffer,
-  _mode: ReconstructionMode,
 ): Promise<RoundTripArtifacts> {
   const result = await compareDocuments(originalBuffer, revisedBuffer, {
   });
@@ -292,7 +291,7 @@ describe('Author->compare round-trip guarantee', () => {
       let result!: CompareResult;
       let artifacts!: RoundTripArtifacts;
       await when('they are compared and round-tripped', async () => {
-        artifacts = await buildRoundTripArtifacts(original, revised, 'rebuild');
+        artifacts = await buildRoundTripArtifacts(original, revised);
         result = artifacts.result;
         await attachPrettyJson('known-edit-stats', result.stats);
       });
@@ -320,7 +319,7 @@ describe('Author->compare round-trip guarantee', () => {
     },
   );
 
-  for (const mode of MODES) {
+  for (const mode of PUBLICATION_PATHS) {
     test.openspec('[SDX-GEN-102] accept-all equals revised and reject-all equals original')(
       `Scenario: accept-all equals revised and reject-all equals original (${mode})`,
       async ({ given, when, then }: AllureBddContext) => {
@@ -333,7 +332,7 @@ describe('Author->compare round-trip guarantee', () => {
 
         let artifacts!: RoundTripArtifacts;
         await when('all changes are accepted, and separately all are rejected', async () => {
-          artifacts = await buildRoundTripArtifacts(original, revised, mode);
+          artifacts = await buildRoundTripArtifacts(original, revised);
         });
 
         await then('accepted text matches revised and rejected text matches original', async () => {
@@ -343,7 +342,7 @@ describe('Author->compare round-trip guarantee', () => {
     );
   }
 
-  for (const mode of MODES) {
+  for (const mode of PUBLICATION_PATHS) {
     test.openspec('[SDX-GEN-103] authored fields and tables survive the compare round-trip')(
       `Scenario: authored fields and tables survive the compare round-trip (${mode})`,
       async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
@@ -356,17 +355,15 @@ describe('Author->compare round-trip guarantee', () => {
 
         let artifacts!: RoundTripArtifacts;
         await when(`it is edited, compared, and round-tripped in '${mode}' mode`, async () => {
-          artifacts = await buildRoundTripArtifacts(original, revised, mode);
+          artifacts = await buildRoundTripArtifacts(original, revised);
           await attachPrettyJson('fields-tables-diagnostics', {
-            failedChecks: artifacts.result.rebuildSafetyDiagnostics?.failedChecks ?? null,
-            fallbackReason: artifacts.result.fallbackReason ?? null,
+            engine: artifacts.result.engine,
           });
         });
 
         await then('paragraph borders, field structure, and table-cell text round-trip', async () => {
           await assertAcceptRejectParity(artifacts, `SDX-GEN-103/${mode}`);
-          // A clean round-trip surfaces no safety failures (field structure included).
-          expect(artifacts.result.rebuildSafetyDiagnostics?.failedChecks ?? []).not.toContain('fieldStructure');
+          expect(artifacts.result.engine).toBe('tagged-tree');
           for (const archive of [artifacts.resultArchive, artifacts.acceptedArchive, artifacts.rejectedArchive]) {
             const headerXml = await archive.getFile('word/header1.xml');
             expect(headerXml).toContain(
@@ -378,7 +375,7 @@ describe('Author->compare round-trip guarantee', () => {
     );
   }
 
-  for (const mode of MODES) {
+  for (const mode of PUBLICATION_PATHS) {
     test.openspec('[SDX-GEN-104] a malformed authored field is caught by the round-trip guard')(
       `Scenario: a malformed authored field is caught by the round-trip guard (${mode})`,
       async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
@@ -407,10 +404,7 @@ describe('Author->compare round-trip guarantee', () => {
             'guard-diagnostics',
             result
               ? {
-                  used: result.reconstructionModeUsed,
-                  fallbackReason: result.fallbackReason ?? null,
-                  fallbackAttempts: result.fallbackDiagnostics?.attempts?.map((a) => a.failedChecks) ?? null,
-                  rebuild: result.rebuildSafetyDiagnostics?.failedChecks ?? null,
+                  engine: result.engine,
                 }
               : { rejectionMessage },
           );
@@ -426,7 +420,7 @@ describe('Author->compare round-trip guarantee', () => {
         await then('a well-formed revision in the same mode surfaces no safety failures (control)', async () => {
           const goodRevised = await generateDocx(bodyFieldSpec());
           const goodResult = await compareDocuments(original, goodRevised);
-          expect(goodResult.rebuildSafetyDiagnostics).toBeUndefined();
+          expect(goodResult.engine).toBe('tagged-tree');
         });
       },
     );

--- a/packages/docx-core/src/integration/advanced-revision-classification.test.ts
+++ b/packages/docx-core/src/integration/advanced-revision-classification.test.ts
@@ -266,7 +266,7 @@ describe('ECMA-376 advanced revision records', () => {
         );
         const doc = parseXml((await getResultParts(result.document)).documentXml);
         await then('tagged publication emits both content wrappers', () => {
-          expect(result.reconstructionModeUsed).toBe('inplace');
+          expect(result.engine).toBe('tagged-tree');
           expect(doc.getElementsByTagNameNS(W_NS, 'ins').length).toBeGreaterThan(0);
           expect(doc.getElementsByTagNameNS(W_NS, 'del').length).toBeGreaterThan(0);
         });
@@ -280,7 +280,7 @@ describe('ECMA-376 advanced revision records', () => {
             const left = await buildSyntheticDocx({ paragraphs: [fixture.original] });
             const right = await buildSyntheticDocx({ paragraphs: [fixture.revised] });
             const result = await compareDocuments(left, right);
-            if (result.reconstructionModeUsed !== 'inplace') return { documents };
+            if (result.engine !== 'tagged-tree') return { documents };
             documents.set('tagged', parseXml((await getResultParts(result.document)).documentXml));
             return { documents };
           },
@@ -671,7 +671,7 @@ describe('ECMA-376 advanced revision records', () => {
         );
         const xml = (await getResultParts(result.document)).documentXml;
         await then('tagged output carries complete move markup', () => {
-          expect(result.reconstructionModeUsed).toBe('inplace');
+          expect(result.engine).toBe('tagged-tree');
           for (const local of [
             'moveFrom', 'moveTo', 'moveFromRangeStart', 'moveFromRangeEnd',
             'moveToRangeStart', 'moveToRangeEnd',
@@ -695,7 +695,7 @@ describe('ECMA-376 advanced revision records', () => {
             const left = await buildSyntheticDocx({ paragraphs: fixture.original });
             const right = await buildSyntheticDocx({ paragraphs: fixture.revised });
             const result = await compareDocuments(left, right);
-            if (result.reconstructionModeUsed !== 'inplace') return { documents };
+            if (result.engine !== 'tagged-tree') return { documents };
             documents.set('tagged', parseXml((await getResultParts(result.document)).documentXml));
             return { documents };
           },
@@ -759,7 +759,7 @@ describe('ECMA-376 advanced revision records', () => {
         const result = await when('the identical pair is compared through the tagged spine', () =>
           compareDocuments(input, input),
         );
-        expect(result.reconstructionModeUsed).toBe('inplace');
+        expect(result.engine).toBe('tagged-tree');
         const tagged = parseXml((await getResultParts(result.document)).documentXml);
 
         await then('tagged publication preserves every sampled record and namespace aliases compare successfully', () => {
@@ -800,7 +800,7 @@ describe('ECMA-376 advanced revision records', () => {
             return {
               input: fixture,
               output: parseXml((await getResultParts(result.document)).documentXml),
-              modeUsed: result.reconstructionModeUsed,
+              engine: result.engine,
             };
           },
           observe: (run, element, expected) => {
@@ -809,7 +809,12 @@ describe('ECMA-376 advanced revision records', () => {
             const local = element.replace('w14:', '');
             const expectedTarget = sourceDocument.getElementsByTagNameNS(namespace, local).item(0);
             const inputTarget = run.input.getElementsByTagNameNS(namespace, local).item(0);
-            if (!expectedTarget || !inputTarget || inputTarget.toString() !== expectedTarget.toString() || run.modeUsed !== mode) return false;
+            if (
+              !expectedTarget ||
+              !inputTarget ||
+              inputTarget.toString() !== expectedTarget.toString() ||
+              run.engine !== 'tagged-tree'
+            ) return false;
             const present = run.output.getElementsByTagNameNS(namespace, local).length > 0;
             return mode === 'inplace' && present;
           },

--- a/packages/docx-core/src/integration/collapsed-field-inplace.test.ts
+++ b/packages/docx-core/src/integration/collapsed-field-inplace.test.ts
@@ -165,9 +165,7 @@ describe('Collapsed field inplace reconstruction', () => {
         const archive = await DocxArchive.load(result.document);
         resultXml = await archive.getDocumentXml();
         await attachPrettyJson('comparison-metadata.json', {
-          reconstructionModeUsed: result.reconstructionModeUsed,
-          fallbackReason: result.fallbackReason,
-          fallbackDiagnostics: result.fallbackDiagnostics,
+          engine: result.engine,
         });
       });
 
@@ -277,7 +275,7 @@ describe('Collapsed field inplace reconstruction', () => {
       });
     });
 
-    test('inplace mode succeeds without rebuild fallback', async ({ given, then, attachPrettyJson }: AllureBddContext) => {
+    test('tagged publication succeeds without fallback metadata', async ({ given, then, attachPrettyJson }: AllureBddContext) => {
       let result: Awaited<ReturnType<typeof compareDocuments>>;
       await given('original and revised dedicated-run PAGEREF fixture documents', async () => {
         const [original, revised] = await Promise.all([
@@ -287,13 +285,11 @@ describe('Collapsed field inplace reconstruction', () => {
         result = await compareDocuments(original, revised, {
         });
       });
-      await then('reconstructionModeUsed is inplace with no fallback', async () => {
+      await then('the result names the sole tagged engine', async () => {
         await attachPrettyJson('reconstruction-metadata.json', {
-          reconstructionModeUsed: result.reconstructionModeUsed,
-          fallbackReason: result.fallbackReason,
+          engine: result.engine,
         });
-        expect(result.reconstructionModeUsed).toBe('inplace');
-        expect(result.fallbackReason).toBeUndefined();
+        expect(result.engine).toBe('tagged-tree');
       });
     });
   });

--- a/packages/docx-core/src/integration/field-cross-story-pipeline.test.ts
+++ b/packages/docx-core/src/integration/field-cross-story-pipeline.test.ts
@@ -258,19 +258,12 @@ describe('Cross-story field-closure check (issue #212) — pipeline-level', () =
         result = await compareDocuments(original, revised, {
         });
         await attachPrettyJson('comparison-metadata.json', {
-          reconstructionModeUsed: result.reconstructionModeUsed,
-          fallbackReason: result.fallbackReason,
+          engine: result.engine,
         });
       });
 
-      await then('no field-structure failure is recorded and inplace output is used', () => {
-        expect(result.reconstructionModeUsed).toBe('inplace');
-        expect(result.fallbackReason).toBeUndefined();
-        const attempts = result.fallbackDiagnostics?.attempts ?? [];
-        for (const attempt of attempts) {
-          const failed = attempt.failedChecks ?? [];
-          expect(failed.includes('fieldStructure')).toBe(false);
-        }
+      await then('the valid field structure publishes through the tagged engine', () => {
+        expect(result.engine).toBe('tagged-tree');
       });
     },
   );

--- a/packages/docx-core/src/integration/field-fragmentation.test.ts
+++ b/packages/docx-core/src/integration/field-fragmentation.test.ts
@@ -49,11 +49,8 @@ async function compareInplace(
   revised: Buffer,
 ): Promise<string> {
   const result = await compareDocuments(original, revised);
-  if (result.reconstructionModeUsed !== 'inplace') {
-    throw new Error(
-      `expected inplace mode but engine fell back to ${result.reconstructionModeUsed ?? 'unknown'}: ` +
-        `${result.fallbackReason ?? 'no reason'} ${JSON.stringify(result.fallbackDiagnostics)}`,
-    );
+  if (result.engine !== 'tagged-tree') {
+    throw new Error(`expected tagged-tree engine, received ${String(result.engine)}`);
   }
   const archive = await DocxArchive.load(result.document);
   return await archive.getDocumentXml();

--- a/packages/docx-core/src/integration/inplace-auxiliary-merge.test.ts
+++ b/packages/docx-core/src/integration/inplace-auxiliary-merge.test.ts
@@ -45,10 +45,6 @@ describe('Inplace Auxiliary Part Merging', () => {
         });
       });
       await then('result contains merged comment definition and OPC metadata', async () => {
-        // If inplace fell back to rebuild, the test is still valid — the merge
-        // only runs on inplace output, so we skip assertions if rebuild was used
-        if (result.reconstructionModeUsed !== 'inplace') return;
-
         const parts = await getResultParts(result.document);
 
         // The document.xml should reference comments
@@ -104,8 +100,6 @@ describe('Inplace Auxiliary Part Merging', () => {
         });
       });
       await then('comments.xml does not contain duplicate entries', async () => {
-        if (result.reconstructionModeUsed !== 'inplace') return;
-
         const parts = await getResultParts(result.document);
 
         if (parts.commentsXml) {
@@ -139,8 +133,6 @@ describe('Inplace Auxiliary Part Merging', () => {
         });
       });
       await then('result contains merged footnote definition and OPC infrastructure', async () => {
-        if (result.reconstructionModeUsed !== 'inplace') return;
-
         const parts = await getResultParts(result.document);
 
         // The document.xml should reference footnotes via deleted content
@@ -182,8 +174,6 @@ describe('Inplace Auxiliary Part Merging', () => {
         });
       });
       await then('footnotes.xml contains exactly one user-defined footnote entry', async () => {
-        if (result.reconstructionModeUsed !== 'inplace') return;
-
         const parts = await getResultParts(result.document);
 
         if (parts.footnotesXml) {
@@ -218,8 +208,6 @@ describe('Inplace Auxiliary Part Merging', () => {
         });
       });
       await then('every footnoteReference ID in document.xml has a matching entry in footnotes.xml', async () => {
-        if (result.reconstructionModeUsed !== 'inplace') return;
-
         const parts = await getResultParts(result.document);
 
         // Collect all footnoteReference IDs from document.xml

--- a/packages/docx-core/src/integration/inplace-bookmark-semantic-regression.test.ts
+++ b/packages/docx-core/src/integration/inplace-bookmark-semantic-regression.test.ts
@@ -32,9 +32,7 @@ interface InplaceRun {
   resultXml: string;
   acceptedXml: string;
   rejectedXml: string;
-  reconstructionModeUsed: 'rebuild' | 'inplace' | undefined;
-  fallbackReason: string | undefined;
-  fallbackDiagnostics: unknown;
+  engine: 'tagged-tree';
 }
 
 const integrationDir = dirname(import.meta.url.replace('file://', ''));
@@ -186,9 +184,7 @@ async function runInplaceComparison(originalPath: string, revisedPath: string): 
     resultXml,
     acceptedXml: acceptAllChanges(resultXml),
     rejectedXml: rejectAllChanges(resultXml),
-    reconstructionModeUsed: result.reconstructionModeUsed,
-    fallbackReason: result.fallbackReason,
-    fallbackDiagnostics: result.fallbackDiagnostics,
+    engine: result.engine,
   };
 }
 
@@ -213,8 +209,7 @@ describe('Inplace bookmark semantic regression coverage (Allure)', () => {
     async ({ given, when, then, attachPrettyJson }: AllureBddContext) => {
       await given('synthetic output from inplace reconstruction', async () => {
         await attachPrettyJson('synthetic-reconstruction-metadata.json', {
-          reconstructionModeUsed: synthetic.reconstructionModeUsed,
-          fallbackReason: synthetic.fallbackReason,
+          engine: synthetic.engine,
         });
       });
 
@@ -223,10 +218,8 @@ describe('Inplace bookmark semantic regression coverage (Allure)', () => {
         assertReadTextParity(synthetic.originalXml, synthetic.rejectedXml, 'Synthetic/inplace/reject-all');
       });
 
-      await then('inplace is retained and no fallback reason is emitted', () => {
-        expect(synthetic.reconstructionModeUsed).toBe('inplace');
-        expect(synthetic.fallbackReason).toBeUndefined();
-        expect(synthetic.fallbackDiagnostics).toBeUndefined();
+      await then('tagged publication is retained', () => {
+        expect(synthetic.engine).toBe('tagged-tree');
       });
     },
     180000
@@ -280,14 +273,12 @@ describe('Inplace bookmark semantic regression coverage (Allure)', () => {
     async ({ given, then, and, attachPrettyJson }: AllureBddContext) => {
       await given('ILPA output from requested inplace reconstruction', async () => {
         await attachPrettyJson('ilpa-reconstruction-metadata.json', {
-          reconstructionModeUsed: ilpa.reconstructionModeUsed,
-          fallbackReason: ilpa.fallbackReason,
+          engine: ilpa.engine,
         });
       });
 
-      await then('reconstruction succeeds in inplace mode', () => {
-        expect(ilpa.reconstructionModeUsed).toBe('inplace');
-        expect(ilpa.fallbackReason).toBeUndefined();
+      await then('comparison succeeds through tagged publication', () => {
+        expect(ilpa.engine).toBe('tagged-tree');
       });
 
       await and('read_text parity holds after accept all', () => {

--- a/packages/docx-core/src/integration/nvca-coi-regression.test.ts
+++ b/packages/docx-core/src/integration/nvca-coi-regression.test.ts
@@ -76,7 +76,7 @@ describe('NVCA COI ancillary field evidence', () => {
           range.locator.entryId !== undefined,
         ) ?? [];
 
-        expect(result.fallbackReason).toBeUndefined();
+        expect(result.engine).toBe('tagged-tree');
         expect(evidence).toMatchObject({
           status: 'passed',
         });

--- a/packages/docx-core/src/integration/pretracked-ins-provenance.test.ts
+++ b/packages/docx-core/src/integration/pretracked-ins-provenance.test.ts
@@ -30,7 +30,7 @@
 
 import { describe, expect } from 'vitest';
 import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
-import { compareDocumentsAtomizer as compareDocuments, type ReconstructionMode } from '@usejunior/docx-compare';
+import { compareDocumentsAtomizer as compareDocuments } from '@usejunior/docx-compare';
 import {
   acceptAllChanges,
   rejectAllChanges,
@@ -222,8 +222,7 @@ const CASES: ProvenanceCase[] = [
 ];
 
 interface ProjectionReport {
-  modeUsed: ReconstructionMode | undefined;
-  fallbackReason: string | undefined;
+  engine: 'tagged-tree';
   combinedXml: string;
   acceptCombined: string;
   acceptRevised: string;
@@ -234,8 +233,6 @@ interface ProjectionReport {
 async function runComparison(
   original: Buffer,
   revised: Buffer,
-  _reconstructionMode: ReconstructionMode,
-  _comparisonStrategy: 'tagged-tree' | 'legacy' = 'tagged-tree',
 ): Promise<ProjectionReport> {
   const result = await compareDocuments(original, revised);
   const [combinedXml, originalXml, revisedXml] = await Promise.all([
@@ -244,8 +241,7 @@ async function runComparison(
     getDocumentXml(revised),
   ]);
   return {
-    modeUsed: result.reconstructionModeUsed,
-    fallbackReason: result.fallbackReason,
+    engine: result.engine,
     combinedXml,
     acceptCombined: normalizeDocumentXmlText(acceptAllChanges(combinedXml)),
     acceptRevised: normalizeDocumentXmlText(acceptAllChanges(revisedXml)),
@@ -267,16 +263,15 @@ describe('Original-side pre-tracked insertion provenance (issue #358)', () => {
       await then('no pair falls back and accept/reject both project to their inputs', async () => {
         for (const provenanceCase of CASES) {
           const { original, revised } = await provenanceCase.build();
-          const report = await runComparison(original, revised, 'inplace');
+          const report = await runComparison(original, revised);
           reports.push({
             name: provenanceCase.name,
-            modeUsed: report.modeUsed,
-            fallbackReason: report.fallbackReason ?? null,
+            engine: report.engine,
           });
 
           expect
-            .soft(report.modeUsed, `${provenanceCase.name}: reconstruction mode`)
-            .toBe('inplace');
+            .soft(report.engine, `${provenanceCase.name}: comparison engine`)
+            .toBe('tagged-tree');
           expect(report.acceptCombined, `${provenanceCase.name}: accept projection`).toBe(
             report.acceptRevised,
           );

--- a/packages/docx-core/src/integration/stability-invariants.test.ts
+++ b/packages/docx-core/src/integration/stability-invariants.test.ts
@@ -11,7 +11,7 @@ import { describe, expect } from 'vitest';
 import { testAllure, type AllureBddContext } from '../testing/allure-test.js';
 import { readFile } from 'fs/promises';
 import { join, dirname } from 'path';
-import { compareDocumentsAtomizer as compareDocuments, type ReconstructionMode } from '@usejunior/docx-compare';
+import { compareDocumentsAtomizer as compareDocuments } from '@usejunior/docx-compare';
 import { DocxArchive } from '../shared/docx/DocxArchive.js';
 import {
   acceptAllChanges,
@@ -30,12 +30,10 @@ interface SemanticView {
 
 interface RunSnapshot {
   semantic: SemanticView;
-  reconstructionModeUsed: ReconstructionMode | undefined;
-  fallbackReason?: string;
-  failedChecks: string[];
+  engine: 'tagged-tree';
 }
 
-const MODES: ReconstructionMode[] = ['inplace'];
+const PUBLICATION_PATHS = ['tagged-tree'] as const;
 const FIXTURES = ['simple-word-change', 'split-run-boundary-change'] as const;
 
 const integrationDir = dirname(import.meta.url.replace('file://', ''));
@@ -95,21 +93,16 @@ async function runAndSnapshot(
 ): Promise<RunSnapshot> {
   const result = await compareDocuments(original, revised);
   const documentXml = await getDocXml(result.document);
-  const failedChecks = result.fallbackDiagnostics
-    ? result.fallbackDiagnostics.attempts.flatMap((attempt) => attempt.failedChecks).sort()
-    : [];
 
   return {
     semantic: semanticViewFromXml(documentXml),
-    reconstructionModeUsed: result.reconstructionModeUsed,
-    fallbackReason: result.fallbackReason,
-    failedChecks,
+    engine: result.engine,
   };
 }
 
 describe('Stability invariants', () => {
   for (const fixtureName of FIXTURES) {
-    for (const mode of MODES) {
+    for (const mode of PUBLICATION_PATHS) {
       test(`${fixtureName}/${mode}: accept/reject transforms are idempotent`, async ({ given, when, then }: AllureBddContext) => {
         let original: Buffer;
         let revised: Buffer;
@@ -178,9 +171,7 @@ describe('Stability invariants', () => {
           `determinism/small/rejected/run${index + 2}`
         );
 
-        expect(current.reconstructionModeUsed).toBe(first.reconstructionModeUsed);
-        expect(current.fallbackReason).toBe(first.fallbackReason);
-        expect(current.failedChecks).toEqual(first.failedChecks);
+        expect(current.engine).toBe(first.engine);
       }
     });
   });
@@ -213,12 +204,8 @@ describe('Stability invariants', () => {
         assertNormalizedEqual(first.semantic.accepted, second.semantic.accepted, 'determinism/synthetic/accepted');
         assertNormalizedEqual(first.semantic.rejected, second.semantic.rejected, 'determinism/synthetic/rejected');
 
-        expect(first.reconstructionModeUsed).toBe('inplace');
-        expect(second.reconstructionModeUsed).toBe('inplace');
-        expect(first.fallbackReason).toBeUndefined();
-        expect(second.fallbackReason).toBeUndefined();
-        expect(first.failedChecks).toEqual([]);
-        expect(second.failedChecks).toEqual([]);
+        expect(first.engine).toBe('tagged-tree');
+        expect(second.engine).toBe('tagged-tree');
       });
     },
     180000
@@ -252,13 +239,8 @@ describe('Stability invariants', () => {
         assertNormalizedEqual(first.semantic.accepted, second.semantic.accepted, 'determinism/ilpa/accepted');
         assertNormalizedEqual(first.semantic.rejected, second.semantic.rejected, 'determinism/ilpa/rejected');
 
-        expect(first.reconstructionModeUsed).toBe('inplace');
-        expect(second.reconstructionModeUsed).toBe('inplace');
-        expect(first.fallbackReason).toBeUndefined();
-        expect(second.fallbackReason).toBeUndefined();
-        expect(first.failedChecks).toEqual([]);
-        expect(second.failedChecks).toEqual([]);
-        expect(first.failedChecks).toEqual(second.failedChecks);
+        expect(first.engine).toBe('tagged-tree');
+        expect(second.engine).toBe('tagged-tree');
       });
     },
     // V8 coverage plus bookmark-collision repair compounds across these two
@@ -267,7 +249,7 @@ describe('Stability invariants', () => {
     600000
   );
 
-  for (const mode of MODES) {
+  for (const mode of PUBLICATION_PATHS) {
     test(`no-op/${mode}: compare(original, original) yields zero semantic change`, async ({ given, when, then }: AllureBddContext) => {
       let original: Buffer;
       let result: Awaited<ReturnType<typeof compareDocuments>>;
@@ -293,7 +275,7 @@ describe('Stability invariants', () => {
         expect(result.stats.insertions).toBe(0);
         expect(result.stats.deletions).toBe(0);
         expect(result.stats.modifications).toBe(0);
-        expect(result.fallbackReason).toBeUndefined();
+        expect(result.engine).toBe('tagged-tree');
 
         assertNormalizedEqual(originalReadText, resultSemantic.raw, `no-op/${mode}/raw`);
         assertNormalizedEqual(originalReadText, resultSemantic.accepted, `no-op/${mode}/accept`);

--- a/packages/docx-core/src/testing/DOCX_COMPARISON_OPENSPEC_TRACEABILITY.md
+++ b/packages/docx-core/src/testing/DOCX_COMPARISON_OPENSPEC_TRACEABILITY.md
@@ -55,6 +55,7 @@ This matrix maps docx-core OpenSpec `#### Scenario:` entries to scenario mapping
 | Properties are extracted from both representatives | covered | `packages/docx-compare/src/openspec.traceability.test.ts` |  |
 | Property delta scope matches the property level | covered | `packages/docx-compare/src/tagged/taggedTree.test.ts` |  |
 | Provenance survives a boundary split | covered | `packages/docx-compare/src/tagged/taggedTreeSerializer.test.ts` |  |
+| Public comparison reports only tagged result metadata | covered | `packages/docx-compare/src/public-result-metadata.test.ts` |  |
 | Public comparison uses one deterministic tagged publication | covered | `packages/docx-compare/src/compare-options.test.ts`, `packages/docx-compare/src/tagged/taggedTreeShadow.test.ts` |  |
 | Removing bold is reported | covered | `packages/docx-compare/src/openspec.traceability.test.ts` |  |
 | Reordering that satisfies coverage is rejected | covered | `packages/docx-compare/src/tagged/taggedTree.test.ts` |  |

--- a/packages/docx-markdoc/src/compile.ts
+++ b/packages/docx-markdoc/src/compile.ts
@@ -750,7 +750,7 @@ export async function compileMarkdoc(
   if (materializations.length > 0) {
     const identity = resolvedCompilation.commentIdentity!;
     try {
-      if (comparison?.comparisonStrategyUsed !== 'tagged-tree') {
+      if (comparison?.engine !== 'tagged-tree') {
         throw new Error('tagged attribution comparison did not publish the tagged strategy');
       }
       const attributedByOperation = new Map(

--- a/packages/docx-mcp/src/tools/compare_documents_console_identity.test.ts
+++ b/packages/docx-mcp/src/tools/compare_documents_console_identity.test.ts
@@ -70,7 +70,7 @@ function deferred<T>(): Deferred<T> {
 function mockCompareResult(): CompareResult {
   return {
     document: Buffer.from('mock comparison output'),
-    engine: 'atomizer',
+    engine: 'tagged-tree',
     stats: {
       atomMetricVersion: 'tagged-token-v1',
       insertions: 0,
@@ -84,8 +84,6 @@ function mockCompareResult(): CompareResult {
       formatChanges: 0,
       formatChangeAtoms: 0,
     },
-    reconstructionModeRequested: 'inplace',
-    reconstructionModeUsed: 'inplace',
   };
 }
 


### PR DESCRIPTION
## Summary

- report the sole comparison implementation truthfully as `engine: 'tagged-tree'`
- remove eleven successful-result fields for deleted engines, reconstruction modes, and legacy fallback paths
- seal the public `compareDocuments` return shape so private revision attribution cannot leak
- remove the unreachable reconstruction-attempt surface from `AncillaryStorySafetyError`
- inventory the breaking result-field removals and migrate internal callers and public documentation

## Why

The tagged revised-base publisher is now the sole comparison spine, but successful public results still named the deleted atomizer/WmlComparer engines and exposed optional inplace/rebuild/fallback fields that could never be true. That made caller telemetry and branching misleading. This completes the existing Unreleased breaking migration with a truthful tagged-only result contract and typed fail-closed errors.

## Public migration

`CompareResult` now contains `document`, `stats`, `engine: 'tagged-tree'`, optional `unrepresentedChanges`, and optional `ancillaryFieldEvidence`. JavaScript callers reading a retired field receive `undefined`; TypeScript callers receive a type error. `AncillaryStorySafetyError` exposes `issues`, not reconstruction attempts.

## Validation

- exact merge base: `211c0dbf1b704b600733e0a269e9cec3b8168ca6`
- `npm run build`
- `npm run lint:workspaces`
- `npm run test:run` (all workspaces; includes 467 comparison tests, 1,290 core tests, 1,004 MCP tests, LibreOffice renderer/oracle tests, ILPA and NVCA)
- `npm run check:spec-coverage`
- `npm run check:conformance-citations`
- `npm run check:conformance-doc`
- API removal inventory check and emitted declaration inspection
- public DOCX repro script smoke on the repository's simple-price-change pair

## Peer review

Dynamic Claude review first found and reproduced a private runtime-key leak and a dead reconstruction-mode error surface. Both were fixed. The follow-up and final exact-base reviews returned APPROVE WITH NITS, with no blocker or major finding and the original findings re-verified by execution.

Ref: #839
