### PR TITLE
docs(docx-compare): refresh tagged option matrix

### DIFF
--- a/packages/docx-compare/TAGGED_OPTION_OBSERVABLE_MATRIX.md
+++ b/packages/docx-compare/TAGGED_OPTION_OBSERVABLE_MATRIX.md
@@ -5,32 +5,33 @@ facade and the exported low-level `compareDocumentsAtomizer` entry point. Both
 entry points use the tagged-tree comparison and revised-base publication path.
 The migration decisions that retired the former selectors are recorded in the
 [archived tagged-tree change](../../openspec/changes/archive/2026-08-19-refactor-tagged-tree-spine/specs/docx-comparison/spec.md).
+The facade rejects any key in `REMOVED_COMPARISON_OPTIONS` with a `TypeError`
+instead of silently accepting an obsolete selector.
 
 “Public” means the setting is part of `CompareOptions`. “Low-level” means it is
 accepted by `compareDocumentsAtomizer`; settings marked “internal” are exported
 only because that low-level function is an attribution or test seam, rather than
 a supported selector on the stable facade.
 
+Nested move and formatting settings are declared in
+[`docx-core/src/core-types.ts`](../docx-core/src/core-types.ts); numbering settings
+are declared in [`numberingIntegration.ts`](src/tagged/numberingIntegration.ts).
+
 | Setting | Surface | Tagged observable and evidence |
 | --- | --- | --- |
 | `author` | Public / low-level | Supplies `w:author` on generated revision and property-change markup; covered by `taggedTreeSerializer.test.ts`. |
 | `date` | Public / low-level | Supplies normalized `w:date` on generated revision and property-change markup; covered by `taggedTreeSerializer.test.ts`. |
-| `ignoreFormatting` | Public | Disables representation of authored property differences while retaining publication validation; covered by `compare-options.test.ts` and `taggedTreeShadow.test.ts`. |
+| `ignoreFormatting` | Public | Disables representation of authored property differences; covered by `compare-options.test.ts`. |
 | `detectMoves` | Public | Controls tagged move classification; move and ordinary insertion/deletion serialization are covered by `taggedTreeConstruction.test.ts`. |
-| `formatDetection.detectFormatChanges` | Low-level | Controls whether authored property differences are represented as tracked property changes. Publication still validates the resulting package in either mode; covered by `taggedTreeConstruction.test.ts`, `taggedTreeSerializer.test.ts`, and `taggedTreeShadow.test.ts`. |
+| `formatDetection.detectFormatChanges` | Low-level | Controls whether authored property differences are represented as tracked property changes; covered by `taggedTreeConstruction.test.ts` and `taggedTreeSerializer.test.ts`. |
 | `moveDetection.detectMoves` | Low-level | Controls tagged move classification at the low-level entry point; covered by `taggedTreeConstruction.test.ts`. |
 | `moveDetection.moveSimilarityThreshold` | Low-level | Gates residual fuzzy candidate edges before global assignment; covered by `taggedTreeConstruction.test.ts`. |
 | `moveDetection.moveMinimumWordCount` | Low-level | Excludes short residual candidates; covered by `taggedTreeConstruction.test.ts`. |
 | `moveDetection.caseInsensitiveMove` | Low-level | Controls case folding in both portable similarity measures; covered by `taggedTreeConstruction.test.ts`. |
 | `numbering.enabled` | Low-level | Controls virtual rendered list identities used by tagged alignment; identities are not serialized. Covered by `taggedTreeConstruction.test.ts`. |
-| `revisionAttributionRanges` | Internal low-level | Carries exact Markdoc operation provenance through tagged serialization and is stripped before publication; covered by `tagged-rationale-attribution.test.ts` and `docx-markdoc/src/compile.test.ts`. |
-| `taggedTreePublicationSafetyEvaluator` | Internal low-level test seam | Replaces only the final structural publication-safety evaluation so fail-closed diagnostics can be exercised; covered by `pipeline-safety-guards.test.ts`. |
+| `revisionAttributionRanges` | Internal low-level | Carries exact Markdoc operation provenance through tagged serialization and is stripped before publication; covered by `integration/tagged-rationale-attribution.test.ts` and `docx-markdoc/src/rationale-comments.test.ts`. |
+| `taggedTreePublicationSafetyEvaluator` | Internal low-level test seam | Replaces only the final structural publication-safety evaluation so fail-closed diagnostics can be exercised; covered by `taggedTreeShadow.test.ts`. |
 | `taggedTreeFormattingFidelityEvaluator` | Internal low-level test seam | Replaces only the final source-projected formatting evaluation so fail-closed fidelity behavior can be exercised; covered by `taggedTreeShadow.test.ts`. |
-
-Successful results report `engine: 'tagged-tree'`. The stable result surface does
-not report a requested strategy, reconstruction mode, or fallback metadata:
-unsafe publication throws a typed error instead of returning an alternate
-implementation's output.
 
 ## Identity audit
 

--- a/packages/docx-compare/TAGGED_OPTION_OBSERVABLE_MATRIX.md
+++ b/packages/docx-compare/TAGGED_OPTION_OBSERVABLE_MATRIX.md
@@ -19,27 +19,27 @@ are declared in [`numberingIntegration.ts`](src/tagged/numberingIntegration.ts).
 
 | Setting | Surface | Tagged observable and evidence |
 | --- | --- | --- |
-| `author` | Public / low-level | Supplies `w:author` on generated revision and property-change markup; covered by `taggedTreeSerializer.test.ts`. |
-| `date` | Public / low-level | Supplies normalized `w:date` on generated revision and property-change markup; covered by `taggedTreeSerializer.test.ts`. |
-| `ignoreFormatting` | Public | Disables representation of authored property differences; covered by `compare-options.test.ts`. |
-| `detectMoves` | Public | Controls tagged move classification; move and ordinary insertion/deletion serialization are covered by `taggedTreeConstruction.test.ts`. |
-| `formatDetection.detectFormatChanges` | Low-level | Controls whether authored property differences are represented as tracked property changes; covered by `taggedTreeConstruction.test.ts` and `taggedTreeSerializer.test.ts`. |
-| `moveDetection.detectMoves` | Low-level | Controls tagged move classification at the low-level entry point; covered by `taggedTreeConstruction.test.ts`. |
-| `moveDetection.moveSimilarityThreshold` | Low-level | Gates residual fuzzy candidate edges before global assignment; covered by `taggedTreeConstruction.test.ts`. |
-| `moveDetection.moveMinimumWordCount` | Low-level | Excludes short residual candidates; covered by `taggedTreeConstruction.test.ts`. |
-| `moveDetection.caseInsensitiveMove` | Low-level | Controls case folding in both portable similarity measures; covered by `taggedTreeConstruction.test.ts`. |
-| `numbering.enabled` | Low-level | Controls virtual rendered list identities used by tagged alignment; identities are not serialized. Covered by `taggedTreeConstruction.test.ts`. |
-| `revisionAttributionRanges` | Internal low-level | Carries exact Markdoc operation provenance through tagged serialization and is stripped before publication; covered by `integration/tagged-rationale-attribution.test.ts` and `docx-markdoc/src/rationale-comments.test.ts`. |
-| `taggedTreePublicationSafetyEvaluator` | Internal low-level test seam | Replaces only the final structural publication-safety evaluation so fail-closed diagnostics can be exercised; covered by `taggedTreeShadow.test.ts`. |
-| `taggedTreeFormattingFidelityEvaluator` | Internal low-level test seam | Replaces only the final source-projected formatting evaluation so fail-closed fidelity behavior can be exercised; covered by `taggedTreeShadow.test.ts`. |
+| `author` | Public / low-level | Supplies `w:author` on generated revision and property-change markup; covered by `src/tagged/taggedTreeSerializer.test.ts`. |
+| `date` | Public / low-level | Supplies normalized `w:date` on generated revision and property-change markup; covered by `src/tagged/taggedTreeSerializer.test.ts`. |
+| `ignoreFormatting` | Public | Disables representation of authored property differences; covered by `src/compare-options.test.ts`. |
+| `detectMoves` | Public | Controls tagged move classification; move and ordinary insertion/deletion serialization are covered by `src/tagged/taggedTreeConstruction.test.ts`. |
+| `formatDetection.detectFormatChanges` | Low-level | Controls whether authored property differences are represented as tracked property changes; covered by `src/tagged/taggedTreeConstruction.test.ts` and `src/tagged/taggedTreeSerializer.test.ts`. |
+| `moveDetection.detectMoves` | Low-level | Controls tagged move classification at the low-level entry point; covered by `src/tagged/taggedTreeConstruction.test.ts`. |
+| `moveDetection.moveSimilarityThreshold` | Low-level | Gates residual fuzzy candidate edges before global assignment; covered by `src/tagged/taggedTreeConstruction.test.ts`. |
+| `moveDetection.moveMinimumWordCount` | Low-level | Excludes short residual candidates; covered by `src/tagged/taggedTreeConstruction.test.ts`. |
+| `moveDetection.caseInsensitiveMove` | Low-level | Controls case folding in both portable similarity measures; covered by `src/tagged/taggedTreeConstruction.test.ts`. |
+| `numbering.enabled` | Low-level | Controls virtual rendered list identities used by tagged alignment; identities are not serialized. Covered by `src/tagged/taggedTreeConstruction.test.ts`. |
+| `revisionAttributionRanges` | Internal low-level | Carries exact Markdoc operation provenance through tagged serialization and is stripped before publication; covered by `src/integration/tagged-rationale-attribution.test.ts` and `../docx-markdoc/src/rationale-comments.test.ts`. |
+| `taggedTreePublicationSafetyEvaluator` | Internal low-level test seam | Replaces only the final structural publication-safety evaluation so fail-closed diagnostics can be exercised; covered by `src/tagged/taggedTreeShadow.test.ts`. |
+| `taggedTreeFormattingFidelityEvaluator` | Internal low-level test seam | Replaces only the final source-projected formatting evaluation so fail-closed fidelity behavior can be exercised; covered by `src/tagged/taggedTreeShadow.test.ts`. |
 
 ## Identity audit
 
 | Concern | Tagged identity rule | Evidence / disposition |
 | --- | --- | --- |
-| Hyperlink destination | Pipeline canonicalization rewrites relationship references by resolved relationship semantics before tagged construction, so equal targets align across different `r:id` values and retargeted links differ. | `relationshipIdCollision.test.ts` and the selected-story hyperlink cases in `pipeline-text-box-stories.test.ts`. |
-| Paragraph style versus direct properties | Tagged property deltas compare the source `pPr`, `rPr`, row, cell, and section property containers. Paragraph-style references and direct properties remain distinct source markup. | `taggedTreeSerializer.test.ts` formatting-fidelity cases. |
-| Complex fields | Field instruction context participates in alignment; field-control runs are not fuzzy-move candidates. | The field matrix in `taggedTreeConstruction.test.ts`. |
-| Opaque passthrough | Unmodeled side-only subtrees retain their complete source node. | `taggedTree.test.ts` opaque-payload cases. |
-| Existing tracked revisions | Ordered revision provenance (kind, ID, author, date) participates in range-boundary identity and is reapplied to serialized fragments. Preserved input moves are excluded from new move pairing. | `taggedTree.test.ts` and `taggedTreeSerializer.test.ts` multi-author provenance cases. |
+| Hyperlink destination | Pipeline canonicalization rewrites relationship references by resolved relationship semantics before tagged construction, so equal targets align across different `r:id` values and retargeted links differ. | `src/tagged/relationshipIdCollision.test.ts` and the selected-story hyperlink cases in `src/tagged/pipeline-text-box-stories.test.ts`. |
+| Paragraph style versus direct properties | Tagged property deltas compare the source `pPr`, `rPr`, row, cell, and section property containers. Paragraph-style references and direct properties remain distinct source markup. | `src/tagged/taggedTreeSerializer.test.ts` formatting-fidelity cases. |
+| Complex fields | Field instruction context participates in alignment; field-control runs are not fuzzy-move candidates. | The field matrix in `src/tagged/taggedTreeConstruction.test.ts`. |
+| Opaque passthrough | Unmodeled side-only subtrees retain their complete source node. | `src/tagged/taggedTree.test.ts` opaque-payload cases. |
+| Existing tracked revisions | Ordered revision provenance (kind, ID, author, date) participates in range-boundary identity and is reapplied to serialized fragments. Preserved input moves are excluded from new move pairing. | `src/tagged/taggedTree.test.ts` and `src/tagged/taggedTreeSerializer.test.ts` multi-author provenance cases. |
 | Effective styles | Tagged story comparison intentionally uses authored property/style references, not a computed `styles.xml` cascade. Changes solely inside style definitions are package-level differences and are not represented as tracked story markup. | Accepted current boundary; no computed-style comparison option is exposed. |

--- a/packages/docx-compare/TAGGED_OPTION_OBSERVABLE_MATRIX.md
+++ b/packages/docx-compare/TAGGED_OPTION_OBSERVABLE_MATRIX.md
@@ -21,9 +21,9 @@ are declared in [`numberingIntegration.ts`](src/tagged/numberingIntegration.ts).
 | --- | --- | --- |
 | `author` | Public / low-level | Supplies `w:author` on generated revision and property-change markup; covered by `src/tagged/taggedTreeSerializer.test.ts`. |
 | `date` | Public / low-level | Supplies normalized `w:date` on generated revision and property-change markup; covered by `src/tagged/taggedTreeSerializer.test.ts`. |
-| `ignoreFormatting` | Public | Disables representation of authored property differences; covered by `src/compare-options.test.ts`. |
+| `ignoreFormatting` | Public | Disables representation of authored property differences while still requiring fidelity to the revised/Accept formatting projection; covered by `src/compare-options.test.ts` and `src/tagged/taggedTreeShadow.test.ts`. |
 | `detectMoves` | Public | Controls tagged move classification; move and ordinary insertion/deletion serialization are covered by `src/tagged/taggedTreeConstruction.test.ts`. |
-| `formatDetection.detectFormatChanges` | Low-level | Controls whether authored property differences are represented as tracked property changes; covered by `src/tagged/taggedTreeConstruction.test.ts` and `src/tagged/taggedTreeSerializer.test.ts`. |
+| `formatDetection.detectFormatChanges` | Low-level | Controls whether authored property differences are represented as tracked property changes. Disabling detection still requires fidelity to the revised/Accept formatting projection; covered by `src/tagged/taggedTreeConstruction.test.ts`, `src/tagged/taggedTreeSerializer.test.ts`, and `src/tagged/taggedTreeShadow.test.ts`. |
 | `moveDetection.detectMoves` | Low-level | Controls tagged move classification at the low-level entry point; covered by `src/tagged/taggedTreeConstruction.test.ts`. |
 | `moveDetection.moveSimilarityThreshold` | Low-level | Gates residual fuzzy candidate edges before global assignment; covered by `src/tagged/taggedTreeConstruction.test.ts`. |
 | `moveDetection.moveMinimumWordCount` | Low-level | Excludes short residual candidates; covered by `src/tagged/taggedTreeConstruction.test.ts`. |
@@ -32,6 +32,12 @@ are declared in [`numberingIntegration.ts`](src/tagged/numberingIntegration.ts).
 | `revisionAttributionRanges` | Internal low-level | Carries exact Markdoc operation provenance through tagged serialization and is stripped before publication; covered by `src/integration/tagged-rationale-attribution.test.ts` and `../docx-markdoc/src/rationale-comments.test.ts`. |
 | `taggedTreePublicationSafetyEvaluator` | Internal low-level test seam | Replaces only the final structural publication-safety evaluation so fail-closed diagnostics can be exercised; covered by `src/tagged/taggedTreeShadow.test.ts`. |
 | `taggedTreeFormattingFidelityEvaluator` | Internal low-level test seam | Replaces only the final source-projected formatting evaluation so fail-closed fidelity behavior can be exercised; covered by `src/tagged/taggedTreeShadow.test.ts`. |
+
+Successful stable results report `engine: 'tagged-tree'` and do not carry
+requested-strategy, reconstruction-mode, or fallback metadata. Unsafe
+publication throws a typed error instead of returning an alternate
+implementation's output. `src/public-result-metadata.test.ts` keeps the runtime
+shape, the exact `CompareResult` type, and `api-removal-policy.json` in sync.
 
 ## Identity audit
 

--- a/packages/docx-compare/TAGGED_OPTION_OBSERVABLE_MATRIX.md
+++ b/packages/docx-compare/TAGGED_OPTION_OBSERVABLE_MATRIX.md
@@ -1,38 +1,44 @@
-# Tagged option-to-observable matrix
+# Tagged comparison option-to-observable matrix
 
-This matrix is the Phase 5 decision record for every setting accepted by the
-public `compareDocuments` facade or the exported low-level
-`compareDocumentsAtomizer` entry point. “Retained” means the setting reaches
-tagged construction/publication and has tagged-specific evidence. “Scheduled
-removal” means the setting remains temporarily for the legacy rollback window
-but intentionally has no new tagged meaning; the breaking-removal requirement
-is recorded in `openspec/changes/refactor-tagged-tree-spine/specs/docx-comparison/spec.md`.
+This matrix inventories every setting accepted by the stable `compareDocuments`
+facade and the exported low-level `compareDocumentsAtomizer` entry point. Both
+entry points use the tagged-tree comparison and revised-base publication path.
+The migration decisions that retired the former selectors are recorded in the
+[archived tagged-tree change](../../openspec/changes/archive/2026-08-19-refactor-tagged-tree-spine/specs/docx-comparison/spec.md).
 
-| Setting | Surface | Decision | Tagged observable and evidence |
-| --- | --- | --- | --- |
-| `author` | Public | Retained | Supplies `w:author` on generated tagged revision and property markup; covered by `taggedTreeSerializer.test.ts`. |
-| `date` | Public | Retained | Supplies normalized `w:date` on generated tagged markup; covered by `taggedTreeSerializer.test.ts`. |
-| `ignoreFormatting` / `formatDetection.detectFormatChanges` | Public / low-level | Retained | Inverts/routes to `constructTaggedTree.detectFormatChanges`; enabled property deltas and disabled detection are covered by `taggedTreeConstruction.test.ts` and `taggedTreeSerializer.test.ts`. |
-| `detectMoves` / `moveDetection.detectMoves` | Public / low-level | Retained | Routes to tagged move classification; move and ordinary insertion/deletion serialization are covered by `taggedTreeConstruction.test.ts`. |
-| `moveDetection.moveSimilarityThreshold` | Low-level | Retained | Gates residual fuzzy candidate edges before global assignment; covered by `taggedTreeConstruction.test.ts`. |
-| `moveDetection.moveMinimumWordCount` | Low-level | Retained | Excludes short residual candidates; covered by `taggedTreeConstruction.test.ts`. |
-| `moveDetection.caseInsensitiveMove` | Low-level | Retained | Controls case folding in both portable similarity measures; covered by `taggedTreeConstruction.test.ts`. |
-| `numbering.enabled` | Low-level | Retained | Controls virtual rendered list identities used by tagged alignment; identities are not serialized. Covered by `taggedTreeConstruction.test.ts`. |
-| `revisionAttributionRanges` | Private low-level | Retained | Carries exact Markdoc operation provenance through tagged serialization and is stripped before publication; covered by `tagged-rationale-attribution.test.ts` and `docx-markdoc/src/compile.test.ts`. |
-| `taggedTreePublicationSafetyEvaluator` | Private test seam | Retained | Replaces only the final tagged safety evaluation and makes fallback diagnostics observable; covered by `pipeline-safety-guards.test.ts`. |
-| `comparisonStrategy` | Public | Scheduled removal | Selects the temporary legacy rollback path; it does not alter tagged behavior. Phase 9 removes it after the authority soak. |
-| `engine` | Public | Scheduled removal | Selects the atomizer entry point or rejected WmlComparer adapter; it is not a tagged construction setting. Phase 9 removes it. |
-| `reconstructionMode` | Public | Scheduled removal | Controls the legacy base assembler that tagged publication currently shadows. Standalone revised-base assembly makes it meaningless, so Phase 9 removes it. |
-| `premergeRuns` | Public / low-level | Scheduled removal | Mutates only the legacy pass; tagged construction reparses canonical source XML. Phase 9 removes it rather than inventing a second tagged normalization contract. |
-| `maxWordRefinementChangeRanges` | Public / low-level | Scheduled removal | Budgets only legacy selective word refinement. Tagged alignment has no refinement retry ladder; Phase 9 removes it. |
+“Public” means the setting is part of `CompareOptions`. “Low-level” means it is
+accepted by `compareDocumentsAtomizer`; settings marked “internal” are exported
+only because that low-level function is an attribution or test seam, rather than
+a supported selector on the stable facade.
+
+| Setting | Surface | Tagged observable and evidence |
+| --- | --- | --- |
+| `author` | Public / low-level | Supplies `w:author` on generated revision and property-change markup; covered by `taggedTreeSerializer.test.ts`. |
+| `date` | Public / low-level | Supplies normalized `w:date` on generated revision and property-change markup; covered by `taggedTreeSerializer.test.ts`. |
+| `ignoreFormatting` | Public | Disables representation of authored property differences while retaining publication validation; covered by `compare-options.test.ts` and `taggedTreeShadow.test.ts`. |
+| `detectMoves` | Public | Controls tagged move classification; move and ordinary insertion/deletion serialization are covered by `taggedTreeConstruction.test.ts`. |
+| `formatDetection.detectFormatChanges` | Low-level | Controls whether authored property differences are represented as tracked property changes. Publication still validates the resulting package in either mode; covered by `taggedTreeConstruction.test.ts`, `taggedTreeSerializer.test.ts`, and `taggedTreeShadow.test.ts`. |
+| `moveDetection.detectMoves` | Low-level | Controls tagged move classification at the low-level entry point; covered by `taggedTreeConstruction.test.ts`. |
+| `moveDetection.moveSimilarityThreshold` | Low-level | Gates residual fuzzy candidate edges before global assignment; covered by `taggedTreeConstruction.test.ts`. |
+| `moveDetection.moveMinimumWordCount` | Low-level | Excludes short residual candidates; covered by `taggedTreeConstruction.test.ts`. |
+| `moveDetection.caseInsensitiveMove` | Low-level | Controls case folding in both portable similarity measures; covered by `taggedTreeConstruction.test.ts`. |
+| `numbering.enabled` | Low-level | Controls virtual rendered list identities used by tagged alignment; identities are not serialized. Covered by `taggedTreeConstruction.test.ts`. |
+| `revisionAttributionRanges` | Internal low-level | Carries exact Markdoc operation provenance through tagged serialization and is stripped before publication; covered by `tagged-rationale-attribution.test.ts` and `docx-markdoc/src/compile.test.ts`. |
+| `taggedTreePublicationSafetyEvaluator` | Internal low-level test seam | Replaces only the final structural publication-safety evaluation so fail-closed diagnostics can be exercised; covered by `pipeline-safety-guards.test.ts`. |
+| `taggedTreeFormattingFidelityEvaluator` | Internal low-level test seam | Replaces only the final source-projected formatting evaluation so fail-closed fidelity behavior can be exercised; covered by `taggedTreeShadow.test.ts`. |
+
+Successful results report `engine: 'tagged-tree'`. The stable result surface does
+not report a requested strategy, reconstruction mode, or fallback metadata:
+unsafe publication throws a typed error instead of returning an alternate
+implementation's output.
 
 ## Identity audit
 
 | Concern | Tagged identity rule | Evidence / disposition |
 | --- | --- | --- |
 | Hyperlink destination | Pipeline canonicalization rewrites relationship references by resolved relationship semantics before tagged construction, so equal targets align across different `r:id` values and retargeted links differ. | `relationshipIdCollision.test.ts` and the selected-story hyperlink cases in `pipeline-text-box-stories.test.ts`. |
-| Paragraph style versus direct properties | Tagged property deltas compare the source `pPr`, `rPr`, row, cell, and section property containers. Paragraph-style references and direct properties remain distinct source markup. | `taggedTreeSerializer.test.ts` formatting-fidelity cases. Portable property naming remains Phase 7 work. |
-| Complex fields | Field instruction context participates in alignment; field-control runs are not fuzzy-move candidates. | The Stage A field matrix in `taggedTreeConstruction.test.ts`. |
-| Opaque passthrough | Unmodeled side-only subtrees retain their complete source node and are certified by the P5 opaque-payload invariant. | `taggedTree.test.ts` opaque-payload cases. |
+| Paragraph style versus direct properties | Tagged property deltas compare the source `pPr`, `rPr`, row, cell, and section property containers. Paragraph-style references and direct properties remain distinct source markup. | `taggedTreeSerializer.test.ts` formatting-fidelity cases. |
+| Complex fields | Field instruction context participates in alignment; field-control runs are not fuzzy-move candidates. | The field matrix in `taggedTreeConstruction.test.ts`. |
+| Opaque passthrough | Unmodeled side-only subtrees retain their complete source node. | `taggedTree.test.ts` opaque-payload cases. |
 | Existing tracked revisions | Ordered revision provenance (kind, ID, author, date) participates in range-boundary identity and is reapplied to serialized fragments. Preserved input moves are excluded from new move pairing. | `taggedTree.test.ts` and `taggedTreeSerializer.test.ts` multi-author provenance cases. |
-| Effective styles | Tagged story comparison intentionally uses authored property/style references, not a computed styles.xml cascade. Changes solely inside style definitions are package-level differences and are not represented as tracked story markup. | Accepted current boundary; the standalone assembler owns `styles.xml` in Phase 6, while portable property naming is Phase 7. |
+| Effective styles | Tagged story comparison intentionally uses authored property/style references, not a computed `styles.xml` cascade. Changes solely inside style definitions are package-level differences and are not represented as tracked story markup. | Accepted current boundary; no computed-style comparison option is exposed. |

--- a/packages/docx-compare/src/option-observable-matrix.test.ts
+++ b/packages/docx-compare/src/option-observable-matrix.test.ts
@@ -185,7 +185,7 @@ describe('tagged option-to-observable matrix freshness', () => {
     }
 
     const evidencePaths = Array.from(
-      markdown.matchAll(/`((?:src|\.\.\/)[^`\s]+?\.test\.ts)`/g),
+      markdown.matchAll(/`([^`\s]*\/[^`\s]+?\.test\.ts)`/g),
       (match) => match[1]!,
     );
     expect(evidencePaths.length).toBeGreaterThan(0);

--- a/packages/docx-compare/src/option-observable-matrix.test.ts
+++ b/packages/docx-compare/src/option-observable-matrix.test.ts
@@ -148,6 +148,28 @@ describe('tagged option-to-observable matrix freshness', () => {
     expect(markdown).not.toMatch(/Phase \d|Scheduled removal|legacy (?:assembly|path|pass)/i);
   });
 
+  test('ties result metadata and disabled-formatting claims to current implementation', () => {
+    const markdown = readFileSync(matrixPath, 'utf8');
+    const compareTypes = readFileSync(resolve(sourceDirectory, 'compare-types.ts'), 'utf8');
+    const pipeline = readFileSync(resolve(sourceDirectory, 'tagged/pipeline.ts'), 'utf8');
+    const removalPolicy = JSON.parse(
+      readFileSync(resolve(packageDirectory, 'api-removal-policy.json'), 'utf8'),
+    ) as {
+      publicResultFields: Record<string, string[]>;
+    };
+    const activeResultFields = [
+      ...removalPolicy.publicResultFields['stable compatibility']!,
+      ...removalPolicy.publicResultFields['truthful tagged replacement']!,
+    ].sort();
+
+    expect(markdown).toContain("Successful stable results report `engine: 'tagged-tree'`");
+    expect(interfaceProperties(compareTypes, 'CompareResult')).toEqual(activeResultFields);
+    expect(compareTypes).toContain("engine: 'tagged-tree';");
+    expect(markdown).toContain('revised/Accept formatting projection');
+    expect(pipeline).toContain(': formattingFidelity.accept.score === 1;');
+    expect(pipeline).not.toContain('!options.formatDetection.detectFormatChanges ||');
+  });
+
   test('links only to durable repository records', () => {
     const markdown = readFileSync(matrixPath, 'utf8');
     const links = Array.from(markdown.matchAll(/\[[^\]]+\]\(([^)#]+)(?:#[^)]+)?\)/g))

--- a/packages/docx-compare/src/option-observable-matrix.test.ts
+++ b/packages/docx-compare/src/option-observable-matrix.test.ts
@@ -21,11 +21,17 @@ function interfaceProperties(source: string, interfaceName: string): string[] {
     true,
     ts.ScriptKind.TS,
   );
-  const declaration = sourceFile.statements.find(
+  const declarations = sourceFile.statements.filter(
     (statement): statement is ts.InterfaceDeclaration =>
       ts.isInterfaceDeclaration(statement) && statement.name.text === interfaceName,
   );
-  if (!declaration) throw new Error(`Missing exported interface ${interfaceName}`);
+  if (declarations.length !== 1) {
+    throw new Error(`Expected one exported interface ${interfaceName}, found ${declarations.length}`);
+  }
+  const declaration = declarations[0]!;
+  if (declaration.heritageClauses?.length) {
+    throw new Error(`Unsupported inherited option interface ${interfaceName}`);
+  }
   return declaration.members.map((member) => {
     if (!ts.isPropertySignature(member) && !ts.isMethodSignature(member)) {
       throw new Error(`Unsupported ${interfaceName} member: ${member.getText(sourceFile)}`);
@@ -35,6 +41,40 @@ function interfaceProperties(source: string, interfaceName: string): string[] {
       return name.text;
     }
     throw new Error(`Unsupported computed ${interfaceName} member: ${name.getText(sourceFile)}`);
+  }).sort();
+}
+
+function stringArrayConstant(source: string, constantName: string): string[] {
+  const sourceFile = ts.createSourceFile(
+    `${constantName}.ts`,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const declarations = sourceFile.statements
+    .filter(ts.isVariableStatement)
+    .flatMap((statement) => Array.from(statement.declarationList.declarations))
+    .filter((declaration) => ts.isIdentifier(declaration.name) && declaration.name.text === constantName);
+  if (declarations.length !== 1) {
+    throw new Error(`Expected one array constant ${constantName}, found ${declarations.length}`);
+  }
+  let initializer = declarations[0]!.initializer;
+  while (initializer && (
+    ts.isAsExpression(initializer) ||
+    ts.isSatisfiesExpression(initializer) ||
+    ts.isParenthesizedExpression(initializer)
+  )) {
+    initializer = initializer.expression;
+  }
+  if (!initializer || !ts.isArrayLiteralExpression(initializer)) {
+    throw new Error(`Expected ${constantName} to be an array literal`);
+  }
+  return initializer.elements.map((element) => {
+    if (!ts.isStringLiteral(element)) {
+      throw new Error(`Expected ${constantName} to contain only string literals`);
+    }
+    return element.text;
   }).sort();
 }
 
@@ -49,7 +89,7 @@ function matrixRows(markdown: string): Array<{ setting: string; surface: string 
     });
 }
 
-function documentedRoots(
+function documentedSettings(
   rows: Array<{ setting: string; surface: string }>,
   surface: 'Public' | 'low-level',
 ): string[] {
@@ -57,7 +97,7 @@ function documentedRoots(
     rows
       .filter((row) => row.surface.toLowerCase().includes(surface.toLowerCase()))
       .flatMap((row) => Array.from(row.setting.matchAll(/`([^`]+)`/g)))
-      .map((match) => match[1]!.split('.')[0]!),
+      .map((match) => match[1]!),
   )).sort();
 }
 
@@ -67,13 +107,30 @@ describe('tagged option-to-observable matrix freshness', () => {
     const rows = matrixRows(markdown);
     const compareTypes = readFileSync(resolve(sourceDirectory, 'compare-types.ts'), 'utf8');
     const pipeline = readFileSync(resolve(sourceDirectory, 'tagged/pipeline.ts'), 'utf8');
+    const coreTypes = readFileSync(
+      resolve(packageDirectory, '../docx-core/src/core-types.ts'),
+      'utf8',
+    );
+    const numberingIntegration = readFileSync(
+      resolve(sourceDirectory, 'tagged/numberingIntegration.ts'),
+      'utf8',
+    );
+    const nestedLowLevelOptions = new Map<string, string[]>([
+      ['moveDetection', interfaceProperties(coreTypes, 'MoveDetectionSettings')],
+      ['formatDetection', interfaceProperties(coreTypes, 'FormatDetectionSettings')],
+      ['numbering', interfaceProperties(numberingIntegration, 'NumberingIntegrationOptions')],
+    ]);
+    const lowLevelSettings = interfaceProperties(pipeline, 'AtomizerOptions')
+      .flatMap((property) => {
+        const nested = nestedLowLevelOptions.get(property);
+        return nested ? nested.map((name) => `${property}.${name}`) : [property];
+      })
+      .sort();
 
-    expect(documentedRoots(rows, 'Public')).toEqual(
+    expect(documentedSettings(rows, 'Public')).toEqual(
       interfaceProperties(compareTypes, 'CompareOptions'),
     );
-    expect(documentedRoots(rows, 'low-level')).toEqual(
-      interfaceProperties(pipeline, 'AtomizerOptions'),
-    );
+    expect(documentedSettings(rows, 'low-level')).toEqual(lowLevelSettings);
   });
 
   test('contains no retired selector or migration-phase promises', () => {
@@ -81,25 +138,24 @@ describe('tagged option-to-observable matrix freshness', () => {
     const documentedSettings = matrixRows(markdown)
       .map((row) => row.setting)
       .join('\n');
-    for (const retiredSelector of [
-      'comparisonStrategy',
-      'engine',
-      'reconstructionMode',
-      'premergeRuns',
-      'maxWordRefinementChangeRanges',
-    ]) {
+    const publicFacade = readFileSync(resolve(sourceDirectory, 'index.ts'), 'utf8');
+    for (const retiredSelector of stringArrayConstant(
+      publicFacade,
+      'REMOVED_COMPARISON_OPTIONS',
+    )) {
       expect(documentedSettings).not.toContain(`\`${retiredSelector}\``);
     }
     expect(markdown).not.toMatch(/Phase \d|Scheduled removal|legacy (?:assembly|path|pass)/i);
   });
 
-  test('links to the durable archived migration record', () => {
+  test('links only to durable repository records', () => {
     const markdown = readFileSync(matrixPath, 'utf8');
-    const link = markdown.match(
-      /\[archived tagged-tree change\]\(([^)]+)\)/,
-    )?.[1];
+    const links = Array.from(markdown.matchAll(/\[[^\]]+\]\(([^)#]+)(?:#[^)]+)?\)/g))
+      .map((match) => match[1]!);
 
-    expect(link).toBeDefined();
-    expect(existsSync(resolve(packageDirectory, link!))).toBe(true);
+    expect(links.length).toBeGreaterThan(0);
+    for (const link of links) {
+      expect(existsSync(resolve(packageDirectory, link)), link).toBe(true);
+    }
   });
 });

--- a/packages/docx-compare/src/option-observable-matrix.test.ts
+++ b/packages/docx-compare/src/option-observable-matrix.test.ts
@@ -1,0 +1,84 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, test } from 'vitest';
+
+const sourceDirectory = dirname(fileURLToPath(import.meta.url));
+const packageDirectory = resolve(sourceDirectory, '..');
+const matrixPath = resolve(packageDirectory, 'TAGGED_OPTION_OBSERVABLE_MATRIX.md');
+
+function interfaceProperties(source: string, interfaceName: string): string[] {
+  const declaration = source.match(
+    new RegExp(`export interface ${interfaceName} \\{([\\s\\S]*?)\\n\\}`),
+  );
+  if (!declaration) throw new Error(`Missing exported interface ${interfaceName}`);
+  return Array.from(declaration[1]!.matchAll(/^\s{2}([A-Za-z][A-Za-z0-9]*)\??:/gm))
+    .map((match) => match[1]!)
+    .sort();
+}
+
+function matrixRows(markdown: string): Array<{ setting: string; surface: string }> {
+  return markdown
+    .split('\n')
+    .filter((line) => line.startsWith('| `'))
+    .map((line) => {
+      const cells = line.split('|').map((cell) => cell.trim());
+      return { setting: cells[1]!, surface: cells[2]! };
+    });
+}
+
+function documentedRoots(
+  rows: Array<{ setting: string; surface: string }>,
+  surface: 'Public' | 'low-level',
+): string[] {
+  return Array.from(new Set(
+    rows
+      .filter((row) => row.surface.toLowerCase().includes(surface.toLowerCase()))
+      .flatMap((row) => Array.from(row.setting.matchAll(/`([^`]+)`/g)))
+      .map((match) => match[1]!.split('.')[0]!),
+  )).sort();
+}
+
+describe('tagged option-to-observable matrix freshness', () => {
+  test('tracks the current public and low-level option interfaces', () => {
+    const markdown = readFileSync(matrixPath, 'utf8');
+    const rows = matrixRows(markdown);
+    const compareTypes = readFileSync(resolve(sourceDirectory, 'compare-types.ts'), 'utf8');
+    const pipeline = readFileSync(resolve(sourceDirectory, 'tagged/pipeline.ts'), 'utf8');
+
+    expect(documentedRoots(rows, 'Public')).toEqual(
+      interfaceProperties(compareTypes, 'CompareOptions'),
+    );
+    expect(documentedRoots(rows, 'low-level')).toEqual(
+      interfaceProperties(pipeline, 'AtomizerOptions'),
+    );
+  });
+
+  test('contains no retired selector or migration-phase promises', () => {
+    const markdown = readFileSync(matrixPath, 'utf8');
+    const documentedSettings = matrixRows(markdown)
+      .map((row) => row.setting)
+      .join('\n');
+    for (const retiredSelector of [
+      'comparisonStrategy',
+      'engine',
+      'reconstructionMode',
+      'premergeRuns',
+      'maxWordRefinementChangeRanges',
+    ]) {
+      expect(documentedSettings).not.toContain(`\`${retiredSelector}\``);
+    }
+    expect(markdown).not.toMatch(/Phase \d|Scheduled removal|legacy (?:assembly|path|pass)/i);
+  });
+
+  test('links to the durable archived migration record', () => {
+    const markdown = readFileSync(matrixPath, 'utf8');
+    const link = markdown.match(
+      /\[archived tagged-tree change\]\(([^)]+)\)/,
+    )?.[1];
+
+    expect(link).toBeDefined();
+    expect(existsSync(resolve(packageDirectory, link!))).toBe(true);
+  });
+});

--- a/packages/docx-compare/src/option-observable-matrix.test.ts
+++ b/packages/docx-compare/src/option-observable-matrix.test.ts
@@ -126,7 +126,11 @@ describe('tagged option-to-observable matrix freshness', () => {
         return nested ? nested.map((name) => `${property}.${name}`) : [property];
       })
       .sort();
+    const settingsByRow = rows.flatMap((row) =>
+      Array.from(row.setting.matchAll(/`([^`]+)`/g), (match) => match[1]!),
+    );
 
+    expect(settingsByRow).toHaveLength(new Set(settingsByRow).size);
     expect(documentedSettings(rows, 'Public')).toEqual(
       interfaceProperties(compareTypes, 'CompareOptions'),
     );
@@ -145,7 +149,7 @@ describe('tagged option-to-observable matrix freshness', () => {
     )) {
       expect(documentedSettings).not.toContain(`\`${retiredSelector}\``);
     }
-    expect(markdown).not.toMatch(/Phase \d|Scheduled removal|legacy (?:assembly|path|pass)/i);
+    expect(markdown).not.toMatch(/Phase \d|Scheduled removal|legacy/i);
   });
 
   test('ties result metadata and disabled-formatting claims to current implementation', () => {
@@ -178,6 +182,15 @@ describe('tagged option-to-observable matrix freshness', () => {
     expect(links.length).toBeGreaterThan(0);
     for (const link of links) {
       expect(existsSync(resolve(packageDirectory, link)), link).toBe(true);
+    }
+
+    const evidencePaths = Array.from(
+      markdown.matchAll(/`((?:src|\.\.\/)[^`\s]+?\.test\.ts)`/g),
+      (match) => match[1]!,
+    );
+    expect(evidencePaths.length).toBeGreaterThan(0);
+    for (const evidencePath of evidencePaths) {
+      expect(existsSync(resolve(packageDirectory, evidencePath)), evidencePath).toBe(true);
     }
   });
 });

--- a/packages/docx-compare/src/option-observable-matrix.test.ts
+++ b/packages/docx-compare/src/option-observable-matrix.test.ts
@@ -2,24 +2,45 @@ import { existsSync, readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { describe, expect, test } from 'vitest';
+import * as ts from 'typescript';
+import { describe, expect } from 'vitest';
+import { testAllure } from './testing/allure-test.js';
 
 const sourceDirectory = dirname(fileURLToPath(import.meta.url));
 const packageDirectory = resolve(sourceDirectory, '..');
 const matrixPath = resolve(packageDirectory, 'TAGGED_OPTION_OBSERVABLE_MATRIX.md');
+const test = testAllure
+  .epic('Document Comparison')
+  .withLabels({ feature: 'Tagged Option Matrix', story: 'Documentation Freshness' });
 
 function interfaceProperties(source: string, interfaceName: string): string[] {
-  const declaration = source.match(
-    new RegExp(`export interface ${interfaceName} \\{([\\s\\S]*?)\\n\\}`),
+  const sourceFile = ts.createSourceFile(
+    `${interfaceName}.ts`,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const declaration = sourceFile.statements.find(
+    (statement): statement is ts.InterfaceDeclaration =>
+      ts.isInterfaceDeclaration(statement) && statement.name.text === interfaceName,
   );
   if (!declaration) throw new Error(`Missing exported interface ${interfaceName}`);
-  return Array.from(declaration[1]!.matchAll(/^\s{2}([A-Za-z][A-Za-z0-9]*)\??:/gm))
-    .map((match) => match[1]!)
-    .sort();
+  return declaration.members.map((member) => {
+    if (!ts.isPropertySignature(member) && !ts.isMethodSignature(member)) {
+      throw new Error(`Unsupported ${interfaceName} member: ${member.getText(sourceFile)}`);
+    }
+    const { name } = member;
+    if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) {
+      return name.text;
+    }
+    throw new Error(`Unsupported computed ${interfaceName} member: ${name.getText(sourceFile)}`);
+  }).sort();
 }
 
 function matrixRows(markdown: string): Array<{ setting: string; surface: string }> {
-  return markdown
+  const optionTable = markdown.split('\n## Identity audit')[0]!;
+  return optionTable
     .split('\n')
     .filter((line) => line.startsWith('| `'))
     .map((line) => {

--- a/packages/docx-compare/src/tagged/pipeline-safety-guards.test.ts
+++ b/packages/docx-compare/src/tagged/pipeline-safety-guards.test.ts
@@ -53,7 +53,7 @@ describe('pipeline safety and input guards', () => {
     });
   });
 
-  test('inplace publication fails closed — the rebuild fallback also rejects a malformed contributing note part', async ({
+  test('tagged publication fails closed on a malformed contributing note part', async ({
     given,
     when,
     then,
@@ -78,7 +78,7 @@ describe('pipeline safety and input guards', () => {
       revised = await buildDocxFromBodyXml(paragraph('Shared'));
     });
 
-    await when('inplace comparison tries to publish the deleted note reference', async () => {
+    await when('tagged comparison tries to publish the deleted note reference', async () => {
       try {
         await compareDocumentsAtomizer(original, revised, {
           moveDetection: { detectMoves: false },

--- a/packages/docx-compare/src/tagged/pipeline.ts
+++ b/packages/docx-compare/src/tagged/pipeline.ts
@@ -297,10 +297,10 @@ function finalizeTaggedDocumentXml(documentXml: string): string {
 }
 
 /**
- * Assemble a revised-base tagged result without a legacy result buffer, atom
- * list, or reconstruction-mode decision. Source archives are reopened so the
- * standalone relationship/auxiliary collision plan cannot inherit mutations
- * selected for legacy assembly.
+ * Assemble a revised-base tagged result without a second result buffer,
+ * flattened atom list, or reconstruction-mode decision. Source archives are
+ * reopened so relationship and auxiliary-part collision planning starts from
+ * the caller's immutable inputs.
  *
  * @conformance ECMA-376 edition 5, Part 1 § 17.13.5
  * @conformance ECMA-376 edition 5, Part 1 § 17.11.14
@@ -948,13 +948,10 @@ const serializer = new XMLSerializer();
  * `<w:endnote>` entry independently rather than treating the whole
  * `footnotes.xml`/`endnotes.xml` as one stream.
  *
- * Accepts arrays of sidecar XMLs (one per source archive) so callers can
- * validate the union of entries from every archive that may contribute to the
- * final result. Step 12 of `compareDocumentsAtomizer` merges entries from a
- * mode-dependent source archive into the base archive; passing both archives'
- * sidecars guarantees that whichever path the merge takes, the entries it
- * could publish have already been screened. Duplicates (same `w:id` in both
- * archives) yield redundant but harmless validation work.
+ * Accepts arrays of sidecar XMLs so callers can validate one or more
+ * materialized story parts while keeping each entry's source index in its
+ * diagnostic label. Publication passes the final assembled note parts, so the
+ * gate screens exactly the definitions that the output can expose.
  *
  * Header/footer stories are not yet covered — they require relationship
  * walking to enumerate `headerN.xml`/`footerN.xml`.
@@ -1039,9 +1036,8 @@ function evaluateSafetyChecks(
       originalBookmarkDiagnostics,
     );
 
-  // Validate field structure for the main-story round-trip projection. Final
-  // note entries are validated after mode-specific assembly, where the gate
-  // knows which base and merge-source definitions actually contributed.
+  // Validate field structure for the main-story round-trip projection and the
+  // final note definitions captured after revised-base assembly.
   const acceptedStories = splitStories(
     acceptedXml,
     auxiliarySidecars.footnotesXmls,

--- a/packages/docx-compare/src/tagged/pipeline.ts
+++ b/packages/docx-compare/src/tagged/pipeline.ts
@@ -1106,7 +1106,7 @@ function evaluateSafetyChecks(
   };
 }
 
-/** Build the authoritative revised-base result without legacy construction. */
+/** Build the authoritative result through the sole revised-base tagged construction. */
 async function compareDocumentsTaggedCore(
   original: Buffer,
   revised: Buffer,
@@ -1354,11 +1354,10 @@ export async function compareDocumentsAtomizer(
 // =============================================================================
 // Auxiliary Part Merging (footnotes, endnotes, comments)
 //
-// Reconstruction may insert content whose auxiliary definitions are absent
-// from the base archive. The "source" archive is the one we pull definitions
-// from: in inplace mode that is `originalArchive` (deleted-but-referenced
-// definitions); in rebuild mode it is `revisedArchive` (added-but-referenced
-// definitions). Step 12 in the pipeline picks the correct source per mode.
+// Tagged construction may retain original-side deleted references and
+// revised-side added references whose auxiliary definitions are absent from
+// the result archive. Both source archives are merged in sequence; definitions
+// are copied only when the result still references them and they are absent.
 // =============================================================================
 
 export interface AuxiliaryMergeResult {
@@ -1548,10 +1547,8 @@ function collectReferenceIds(documentXml: string, referenceTag: string): Set<str
 
 /**
  * Merge auxiliary part definitions (footnotes, endnotes, comments) from the
- * source archive into the result archive. The source archive is whichever
- * side reconstruction may have introduced references to: original in inplace
- * mode (deleted-but-referenced definitions), revised in rebuild mode
- * (added-but-referenced definitions).
+ * source archive into the result archive. The caller invokes this once for
+ * original-side deleted references and once for revised-side added references.
  */
 async function mergeAuxiliaryPartDefinitions(
   sourceArchive: DocxArchive,

--- a/packages/docx-compare/src/tagged/taggedTree.ts
+++ b/packages/docx-compare/src/tagged/taggedTree.ts
@@ -17,10 +17,10 @@
  * own evidence. An empty violation list says nothing about them, and the
  * runtime accept/reject checks in `pipeline.ts` are not made redundant by it.
  *
- * Correction (2026-08-16): this module began as additive Stage A evidence,
- * but the completed change now routes ordinary comparison through it by
- * default while retaining the legacy strategy as an explicit rollback. See
- * `openspec/changes/refactor-tagged-tree-redline-construction/`.
+ * Both stable and low-level comparison entry points now construct and publish
+ * through this tagged-tree representation and the revised-base package path.
+ * The migration record is archived at
+ * `openspec/changes/archive/2026-08-19-refactor-tagged-tree-spine/`.
  */
 
 import type { WmlElement } from '@usejunior/docx-core';


### PR DESCRIPTION
## Summary

- replace the stale phase/migration option matrix with the current stable facade and complete low-level tagged settings surface
- align publication metadata and disabled-formatting claims with the merged #839 and #921 behavior
- remove false legacy mode/rollback commentary and repair archived OpenSpec references
- add a fail-closed AST-backed freshness contract for interfaces, nested settings, retired selectors, result metadata, formatting publication, duplicate rows, and evidence paths

## Why

The old matrix described future phases and retired inplace/rebuild paths rather than the sole tagged-tree publication spine. That made the document unreliable as a public/low-level contract and allowed interface or evidence drift to go unnoticed.

## Verification

- exact merge base: `3f7fd79a312773ba8d66e2488c53a0f85b0dd4e9`
- full unrestricted pre-submit passed on exact head:
  - `npm run build`
  - `npm run lint:workspaces`
  - `npm run test:run`
  - `npm run check:spec-coverage`
  - `npm run check:conformance-citations`
  - `npm run check:conformance-doc`
- docx-compare: 471 passed, 1 skipped
- docx-core: 1290 passed, 2 expected-fail, 1 skipped; ILPA round-trip, structural, bookmark, and determinism suites passed
- LibreOffice-backed oracle/render checks passed
- three dynamic Claude passes: APPROVE; 15 adversarial mutation probes rejected for the intended reasons, with final path-form probes demonstrated red-to-green

This changes documentation, tests, and comments only; Claude verified comment-stripped production output is byte-identical.

Ref: #922
