### PR TITLE
test(docx-compare): cover range-stat transformations

### DIFF
--- a/packages/docx-compare/src/tagged/taggedTreeShadow.ts
+++ b/packages/docx-compare/src/tagged/taggedTreeShadow.ts
@@ -109,9 +109,9 @@ function comparisonAtomKeys(element: Element): string[] {
 }
 
 /**
- * Preserve the public word/control atom weighting without consulting the
- * legacy merged-atom result. Each maximal tagged change subtree is atomized
- * independently with the documented word-split settings.
+ * Derive the versioned `tagged-token-v1` word/control weighting without
+ * consulting the deleted flattened-atom engine. Each maximal tagged change
+ * subtree is tokenized independently under the tagged metric contract.
  */
 function taggedAtomWeight(node: TaggedNode, side: 'original' | 'revised'): number {
   const element = representative(node, side);

--- a/packages/docx-compare/src/tagged/taggedTreeStatistics.test.ts
+++ b/packages/docx-compare/src/tagged/taggedTreeStatistics.test.ts
@@ -28,9 +28,12 @@ function paragraph(text: string): string {
 }
 
 function table(rowTexts: readonly string[]): string {
-  return `<w:tbl>${rowTexts.map((text) =>
+  return '<w:tbl><w:tblPr><w:tblW w:w="0" w:type="auto"/></w:tblPr>'
+    + '<w:tblGrid><w:gridCol w:w="4000"/></w:tblGrid>'
+    + rowTexts.map((text) =>
     `<w:tr><w:tc><w:p><w:r><w:t>${text}</w:t></w:r></w:p></w:tc></w:tr>`,
-  ).join('')}</w:tbl>`;
+    ).join('')
+    + '</w:tbl>';
 }
 
 function publish(
@@ -154,8 +157,6 @@ describe('tagged publication range statistics', () => {
       // public total contains two boundary-only wrappers plus a separate
       // trailing-text deletion caused by suffix-alignment loss. #938 tracks
       // both the range-counting rule and the avoidable alignment churn.
-      expect(generatedDeletions.filter((element) => element.textContent === ''), boundary.name)
-        .toHaveLength(2);
       expect(generatedDeletions.map((element) => element.textContent), boundary.name)
         .toEqual(['', 'beta gamma', '', ' omega']);
       expect(generatedInsertions[0]!.textContent, boundary.name).toBe('new omega');
@@ -239,7 +240,7 @@ describe('tagged publication range statistics', () => {
     expect((deletions[0]!.parentNode?.parentNode as Element).localName).toBe('tr');
   });
 
-  transformationTest('excludes preserved prior-author revisions while counting nested comparison ranges', () => {
+  transformationTest('excludes preserved same-author prior revisions from comparison counts', () => {
     const priorRevision = (value: string) => '<w:p>'
       + `<w:ins w:id="4" w:author="${AUTHOR}" w:date="2026-08-01T00:00:00Z">`
       + `<w:r><w:t>${value}</w:t></w:r></w:ins>`
@@ -285,6 +286,9 @@ describe('tagged publication range statistics', () => {
     expectRangeStatsMatchSerializedMarkup(publication);
     expect(publication.serializedRangeStats.moveFromRanges).toBe(1);
     expect(publication.serializedRangeStats.moveToRanges).toBe(1);
+    // CompareStats has no public move fields, so pure moves otherwise report
+    // all-zero public stats (#940). The serialized move shape itself also has
+    // a separately tracked ECMA schema defect (#941).
     expect(publication.stats.insertedRanges).toBe(0);
     expect(publication.stats.deletedRanges).toBe(0);
   });

--- a/packages/docx-compare/src/tagged/taggedTreeStatistics.test.ts
+++ b/packages/docx-compare/src/tagged/taggedTreeStatistics.test.ts
@@ -56,7 +56,7 @@ function generatedElements(publication: TaggedTreePublication, localName: string
     .filter((element) => element.getAttribute(COMPARISON_REVISION_ATTRIBUTE) === '1');
 }
 
-function expectRangeStatsMatchSerializedMarkup(
+function expectRetainedMarkersAndStatsAliasesAgree(
   publication: TaggedTreePublication,
   options: { assertFormatting?: boolean } = {},
 ): void {
@@ -98,7 +98,7 @@ describe('tagged publication range statistics', () => {
       { retainStatisticsMarkers: false },
     );
 
-    expectRangeStatsMatchSerializedMarkup(publication);
+    expectRetainedMarkersAndStatsAliasesAgree(publication);
     expect(publication.stats.insertedRanges).toBe(1);
     expect(publication.stats.deletedRanges).toBe(1);
     expect(generatedElements(publication, 'del')[0]!.textContent).toBe('old');
@@ -112,9 +112,10 @@ describe('tagged publication range statistics', () => {
       paragraph('alpha delta'),
     );
 
-    expectRangeStatsMatchSerializedMarkup(publication);
+    expectRetainedMarkersAndStatsAliasesAgree(publication);
     expect(publication.stats.insertedRanges).toBe(0);
     expect(publication.stats.deletedRanges).toBe(1);
+    expect(publication.stats.deletedAtoms).toBe(4);
     expect(generatedElements(publication, 'del')[0]!.textContent).toBe('beta gamma ');
   });
 
@@ -149,7 +150,7 @@ describe('tagged publication range statistics', () => {
       const generatedDeletions = generatedElements(publication, 'del');
       const generatedInsertions = generatedElements(publication, 'ins');
 
-      expectRangeStatsMatchSerializedMarkup(publication);
+      expectRetainedMarkersAndStatsAliasesAgree(publication);
       expect(publication.stats.insertedRanges, boundary.name).toBe(1);
       expect(publication.stats.deletedRanges, boundary.name).toBe(4);
       expect(withoutBoundary.stats.deletedRanges, boundary.name).toBe(1);
@@ -178,9 +179,27 @@ describe('tagged publication range statistics', () => {
     const publication = publish(formatted('<w:i/>'), formatted('<w:b/>'));
     const propertyChanges = generatedElements(publication, 'rPrChange');
 
-    expectRangeStatsMatchSerializedMarkup(publication);
+    expectRetainedMarkersAndStatsAliasesAgree(publication);
     expect(publication.stats.formatChanges).toBe(1);
     expect(propertyChanges).toHaveLength(1);
+  });
+
+  test('characterizes split run-property revisions absent from formatting totals', () => {
+    const formatted = (property: string, text: string) => '<w:p><w:r>'
+      + `<w:rPr>${property}</w:rPr><w:t>${text}</w:t>`
+      + '</w:r></w:p>';
+    const publication = publish(
+      formatted('<w:i/>', 'alpha beta'),
+      formatted('<w:b/>', 'alpha gamma'),
+    );
+
+    expectRetainedMarkersAndStatsAliasesAgree(publication, { assertFormatting: false });
+    expect(publication.stats.insertedRanges).toBe(1);
+    expect(publication.stats.deletedRanges).toBe(1);
+    // #937 tracks the crossed text-and-formatting path separately from its
+    // restorative whole-paragraph property-revision case.
+    expect(generatedElements(publication, 'rPrChange')).toHaveLength(2);
+    expect(publication.stats.formatChanges).toBe(0);
   });
 
   transformationTest('counts an opaque inline subtree after whole-node wrapping', () => {
@@ -201,8 +220,8 @@ describe('tagged publication range statistics', () => {
     );
     const emitted = parseXml(publication.xml);
 
-    expectRangeStatsMatchSerializedMarkup(publication);
-    expectRangeStatsMatchSerializedMarkup(plainRuns);
+    expectRetainedMarkersAndStatsAliasesAgree(publication);
+    expectRetainedMarkersAndStatsAliasesAgree(plainRuns);
     expect(publication.stats.insertedRanges).toBe(1);
     expect(plainRuns.stats.insertedRanges).toBe(3);
     expect(publication.stats.deletedRanges).toBe(0);
@@ -216,7 +235,7 @@ describe('tagged publication range statistics', () => {
       paragraph('stable'),
     );
 
-    expectRangeStatsMatchSerializedMarkup(publication, { assertFormatting: false });
+    expectRetainedMarkersAndStatsAliasesAgree(publication, { assertFormatting: false });
     expect(publication.stats.deletedRanges).toBe(2);
     // Characterize the serializer-restorative property wrapper separately:
     // #937 tracks why it does not yet contribute to formatChanges.
@@ -234,7 +253,7 @@ describe('tagged publication range statistics', () => {
     const publication = publish(table(['deleted row', 'stable row']), table(['stable row']));
     const deletions = generatedElements(publication, 'del');
 
-    expectRangeStatsMatchSerializedMarkup(publication);
+    expectRetainedMarkersAndStatsAliasesAgree(publication);
     expect(deletions).toHaveLength(1);
     expect((deletions[0]!.parentNode as Element).localName).toBe('trPr');
     expect((deletions[0]!.parentNode?.parentNode as Element).localName).toBe('tr');
@@ -248,15 +267,15 @@ describe('tagged publication range statistics', () => {
     const publication = publish(priorRevision('old text'), priorRevision('new text'));
     const emitted = parseXml(publication.xml);
 
-    expectRangeStatsMatchSerializedMarkup(publication);
-    expect(publication.stats.insertedRanges).toBeGreaterThan(0);
-    expect(publication.stats.deletedRanges).toBeGreaterThan(0);
+    expectRetainedMarkersAndStatsAliasesAgree(publication);
+    expect(publication.stats.insertedRanges).toBe(1);
+    expect(publication.stats.deletedRanges).toBe(1);
     expect(Array.from(emitted.getElementsByTagNameNS(W_NS, 'ins')).filter((element) =>
       element.getAttributeNS(W_NS, 'author') === AUTHOR &&
           !element.hasAttribute(COMPARISON_REVISION_ATTRIBUTE),
-    )).not.toHaveLength(0);
+      )).toHaveLength(1);
     expect(emitted.getElementsByTagNameNS(W_NS, 'ins').length)
-      .toBeGreaterThan(publication.stats.insertedRanges);
+      .toBe(2);
   });
 
   transformationTest('counts wrappers after complex-field controls force atomic replacement', () => {
@@ -266,7 +285,7 @@ describe('tagged publication range statistics', () => {
     );
     const emitted = parseXml(publication.xml);
 
-    expectRangeStatsMatchSerializedMarkup(publication);
+    expectRetainedMarkersAndStatsAliasesAgree(publication);
     expect(publication.stats.insertedRanges).toBe(1);
     expect(publication.stats.deletedRanges).toBe(1);
     expect(generatedElements(publication, 'del')[0]!
@@ -283,7 +302,7 @@ describe('tagged publication range statistics', () => {
       paragraph('stable paragraph') + paragraph('this complete paragraph moves away'),
     );
 
-    expectRangeStatsMatchSerializedMarkup(publication);
+    expectRetainedMarkersAndStatsAliasesAgree(publication);
     expect(publication.serializedRangeStats.moveFromRanges).toBe(1);
     expect(publication.serializedRangeStats.moveToRanges).toBe(1);
     // CompareStats has no public move fields, so pure moves otherwise report

--- a/packages/docx-compare/src/tagged/taggedTreeStatistics.test.ts
+++ b/packages/docx-compare/src/tagged/taggedTreeStatistics.test.ts
@@ -53,7 +53,10 @@ function generatedElements(publication: TaggedTreePublication, localName: string
     .filter((element) => element.getAttribute(COMPARISON_REVISION_ATTRIBUTE) === '1');
 }
 
-function expectRangeStatsMatchSerializedMarkup(publication: TaggedTreePublication): void {
+function expectRangeStatsMatchSerializedMarkup(
+  publication: TaggedTreePublication,
+  options: { assertFormatting?: boolean } = {},
+): void {
   const inserted = generatedElements(publication, 'ins');
   const deleted = generatedElements(publication, 'del');
   const movedFrom = generatedElements(publication, 'moveFrom');
@@ -70,6 +73,11 @@ function expectRangeStatsMatchSerializedMarkup(publication: TaggedTreePublicatio
     moveFromRanges: movedFrom.length,
     moveToRanges: movedTo.length,
   });
+  if (options.assertFormatting !== false) {
+    const propertyChanges = generatedElements(publication, 'rPrChange').length
+      + generatedElements(publication, 'pPrChange').length;
+    expect(publication.stats.formatChanges).toBe(propertyChanges);
+  }
 }
 
 describe('tagged publication range statistics', () => {
@@ -104,6 +112,7 @@ describe('tagged publication range statistics', () => {
     expectRangeStatsMatchSerializedMarkup(publication);
     expect(publication.stats.insertedRanges).toBe(0);
     expect(publication.stats.deletedRanges).toBe(1);
+    expect(generatedElements(publication, 'del')[0]!.textContent).toBe('beta gamma ');
   });
 
   transformationTest('counts wrappers split around bookmark and comment-range boundaries', () => {
@@ -206,7 +215,7 @@ describe('tagged publication range statistics', () => {
       paragraph('stable'),
     );
 
-    expectRangeStatsMatchSerializedMarkup(publication);
+    expectRangeStatsMatchSerializedMarkup(publication, { assertFormatting: false });
     expect(publication.stats.deletedRanges).toBe(2);
     // Characterize the serializer-restorative property wrapper separately:
     // #937 tracks why it does not yet contribute to formatChanges.

--- a/packages/docx-compare/src/tagged/taggedTreeStatistics.test.ts
+++ b/packages/docx-compare/src/tagged/taggedTreeStatistics.test.ts
@@ -10,6 +10,8 @@ import {
   buildTaggedTreePublication,
   type TaggedTreePublication,
 } from './taggedTreeShadow.js';
+import { constructTaggedTree } from './taggedTreeConstruction.js';
+import type { TaggedNode } from './taggedTree.js';
 
 const TEST_FEATURE = 'refactor-tagged-tree-redline-construction';
 const test = testAllure.epic('Document Comparison').withLabels({ feature: TEST_FEATURE });
@@ -41,13 +43,14 @@ function publish(
     revisedXml: documentWithBody(revisedBody),
     author: AUTHOR,
     date: DATE,
+    retainStatisticsMarkers: true,
     ...options,
   });
 }
 
 function generatedElements(publication: TaggedTreePublication, localName: string): Element[] {
   return Array.from(parseXml(publication.xml).getElementsByTagNameNS(W_NS, localName))
-    .filter((element) => element.getAttributeNS(W_NS, 'author') === AUTHOR);
+    .filter((element) => element.getAttribute('data-safe-docx-comparison-revision') === '1');
 }
 
 function expectRangeStatsMatchSerializedMarkup(publication: TaggedTreePublication): void {
@@ -58,6 +61,7 @@ function expectRangeStatsMatchSerializedMarkup(publication: TaggedTreePublicatio
 
   expect(publication.stats.insertions).toBe(inserted.length);
   expect(publication.stats.deletions).toBe(deleted.length);
+  // Pin both historical aliases to the same final-wrapper source of truth.
   expect(publication.stats.insertedRanges).toBe(inserted.length);
   expect(publication.stats.deletedRanges).toBe(deleted.length);
   expect(publication.serializedRangeStats).toEqual({
@@ -66,7 +70,6 @@ function expectRangeStatsMatchSerializedMarkup(publication: TaggedTreePublicatio
     moveFromRanges: movedFrom.length,
     moveToRanges: movedTo.length,
   });
-  expect(publication.xml).not.toContain('data-safe-docx-comparison-revision');
 }
 
 describe('tagged publication range statistics', () => {
@@ -89,38 +92,56 @@ describe('tagged publication range statistics', () => {
   test.openspec('Serialized wrapper transformations determine range totals')(
     'counts wrappers split around bookmark boundaries',
     () => {
-      const bookmarked = (value: string) => '<w:p>'
+      const original = '<w:p><w:r><w:t>alpha </w:t></w:r>'
         + '<w:bookmarkStart w:id="7" w:name="Clause"/>'
-        + `<w:r><w:t>${value}</w:t></w:r>`
+        + '<w:r><w:t>beta gamma</w:t></w:r>'
         + '<w:bookmarkEnd w:id="7"/>'
-        + '</w:p>';
-      const publication = publish(bookmarked('old clause'), bookmarked('new clause'));
+        + '<w:r><w:t> omega</w:t></w:r></w:p>';
+      const publication = publish(original, paragraph('alpha new omega'));
+      const withoutBoundary = publish(
+        paragraph('alpha beta gamma omega'),
+        paragraph('alpha new omega'),
+      );
       const emitted = parseXml(publication.xml);
 
       expectRangeStatsMatchSerializedMarkup(publication);
-      expect(publication.stats.insertedRanges).toBeGreaterThan(0);
-      expect(publication.stats.deletedRanges).toBeGreaterThan(0);
+      expect(publication.stats.insertedRanges).toBe(1);
+      expect(publication.stats.deletedRanges).toBe(4);
+      expect(withoutBoundary.stats.deletedRanges).toBe(1);
       expect(emitted.getElementsByTagNameNS(W_NS, 'bookmarkStart')).toHaveLength(1);
       expect(emitted.getElementsByTagNameNS(W_NS, 'bookmarkEnd')).toHaveLength(1);
+      expect((emitted.getElementsByTagNameNS(W_NS, 'bookmarkStart')[0]!.parentNode as Element).localName)
+        .toBe('del');
+      expect((emitted.getElementsByTagNameNS(W_NS, 'bookmarkEnd')[0]!.parentNode as Element).localName)
+        .toBe('del');
     },
   );
 
   test.openspec('Serialized wrapper transformations determine range totals')(
     'counts wrappers split around non-bookmark range boundaries',
     () => {
-      const ranged = (value: string) => '<w:p>'
+      const original = '<w:p><w:r><w:t>alpha </w:t></w:r>'
         + '<w:commentRangeStart w:id="3"/>'
-        + `<w:r><w:t>${value}</w:t></w:r>`
+        + '<w:r><w:t>beta gamma</w:t></w:r>'
         + '<w:commentRangeEnd w:id="3"/>'
-        + '</w:p>';
-      const publication = publish(ranged('old comment span'), ranged('new comment span'));
+        + '<w:r><w:t> omega</w:t></w:r></w:p>';
+      const publication = publish(original, paragraph('alpha new omega'));
+      const withoutBoundary = publish(
+        paragraph('alpha beta gamma omega'),
+        paragraph('alpha new omega'),
+      );
       const emitted = parseXml(publication.xml);
 
       expectRangeStatsMatchSerializedMarkup(publication);
-      expect(publication.stats.insertedRanges).toBeGreaterThan(0);
-      expect(publication.stats.deletedRanges).toBeGreaterThan(0);
+      expect(publication.stats.insertedRanges).toBe(1);
+      expect(publication.stats.deletedRanges).toBe(4);
+      expect(withoutBoundary.stats.deletedRanges).toBe(1);
       expect(emitted.getElementsByTagNameNS(W_NS, 'commentRangeStart')).toHaveLength(1);
       expect(emitted.getElementsByTagNameNS(W_NS, 'commentRangeEnd')).toHaveLength(1);
+      expect((emitted.getElementsByTagNameNS(W_NS, 'commentRangeStart')[0]!.parentNode as Element).localName)
+        .toBe('del');
+      expect((emitted.getElementsByTagNameNS(W_NS, 'commentRangeEnd')[0]!.parentNode as Element).localName)
+        .toBe('del');
     },
   );
 
@@ -151,10 +172,19 @@ describe('tagged publication range statistics', () => {
         `<w:p><w:r><w:t>stable</w:t></w:r>${opaque}</w:p>`,
       );
       const emitted = parseXml(publication.xml);
+      const constructed = constructTaggedTree(
+        parseXml(documentWithBody('<w:p><w:r><w:t>stable</w:t></w:r></w:p>')).documentElement,
+        parseXml(documentWithBody(`<w:p><w:r><w:t>stable</w:t></w:r>${opaque}</w:p>`)).documentElement,
+      );
+      const descendants = (node: TaggedNode): TaggedNode[] =>
+        [node, ...node.children.flatMap(descendants)];
+      const opaqueControl = descendants(constructed.tree).find((node) =>
+        node.tag === 'revised' && node.node.localName === 'sdt');
 
       expectRangeStatsMatchSerializedMarkup(publication);
       expect(publication.stats.insertedRanges).toBeGreaterThan(0);
       expect(publication.stats.deletedRanges).toBe(0);
+      expect(opaqueControl?.opaque).toBe(true);
       const control = emitted.getElementsByTagNameNS(W_NS, 'sdt')[0]!;
       expect((control.parentNode as Element).localName).toBe('ins');
     },
@@ -167,14 +197,13 @@ describe('tagged publication range statistics', () => {
         paragraph('stable') + paragraph('deleted paragraph'),
         paragraph('stable'),
       );
-      const emitted = parseXml(publication.xml);
 
       expectRangeStatsMatchSerializedMarkup(publication);
       expect(publication.stats.deletedRanges).toBe(2);
-      expect(Array.from(emitted.getElementsByTagNameNS(W_NS, 'del')).some((element) =>
+      expect(generatedElements(publication, 'del').some((element) =>
         (element.parentNode as Element | null)?.localName === 'rPr',
       )).toBe(true);
-      expect(Array.from(emitted.getElementsByTagNameNS(W_NS, 'del')).some((element) =>
+      expect(generatedElements(publication, 'del').some((element) =>
         element.getElementsByTagNameNS(W_NS, 'delText').length > 0,
       )).toBe(true);
     },
@@ -197,7 +226,7 @@ describe('tagged publication range statistics', () => {
     'excludes preserved prior-author revisions while counting nested comparison ranges',
     () => {
       const priorRevision = (value: string) => '<w:p>'
-        + '<w:ins w:id="4" w:author="Prior Author" w:date="2026-08-01T00:00:00Z">'
+        + `<w:ins w:id="4" w:author="${AUTHOR}" w:date="2026-08-01T00:00:00Z">`
         + `<w:r><w:t>${value}</w:t></w:r></w:ins>`
         + '</w:p>';
       const publication = publish(priorRevision('old text'), priorRevision('new text'));
@@ -207,7 +236,8 @@ describe('tagged publication range statistics', () => {
       expect(publication.stats.insertedRanges).toBeGreaterThan(0);
       expect(publication.stats.deletedRanges).toBeGreaterThan(0);
       expect(Array.from(emitted.getElementsByTagNameNS(W_NS, 'ins')).filter((element) =>
-        element.getAttributeNS(W_NS, 'author') === 'Prior Author',
+        element.getAttributeNS(W_NS, 'author') === AUTHOR &&
+          !element.hasAttribute('data-safe-docx-comparison-revision'),
       )).not.toHaveLength(0);
       expect(emitted.getElementsByTagNameNS(W_NS, 'ins').length)
         .toBeGreaterThan(publication.stats.insertedRanges);

--- a/packages/docx-compare/src/tagged/taggedTreeStatistics.test.ts
+++ b/packages/docx-compare/src/tagged/taggedTreeStatistics.test.ts
@@ -91,9 +91,8 @@ describe('tagged publication range statistics', () => {
     expectRangeStatsMatchSerializedMarkup(publication);
     expect(publication.stats.insertedRanges).toBe(1);
     expect(publication.stats.deletedRanges).toBe(1);
-    expect(publication.xml).toContain('Shared prefix ');
-    expect(publication.xml).toContain(' shared suffix.');
-    expect(publicPublication.stats).toEqual(publication.stats);
+    expect(generatedElements(publication, 'del')[0]!.textContent).toBe('old');
+    expect(generatedElements(publication, 'ins')[0]!.textContent).toBe('new');
     expect(publicPublication.xml).not.toContain(COMPARISON_REVISION_ATTRIBUTE);
   });
 
@@ -136,13 +135,22 @@ describe('tagged publication range statistics', () => {
         paragraph('alpha new omega'),
       );
       const emitted = parseXml(publication.xml);
+      const generatedDeletions = generatedElements(publication, 'del');
+      const generatedInsertions = generatedElements(publication, 'ins');
 
       expectRangeStatsMatchSerializedMarkup(publication);
       expect(publication.stats.insertedRanges, boundary.name).toBe(1);
-      // Characterization: two boundary-only wrappers currently contribute to
-      // this public total. #938 tracks whether they should remain ranges.
       expect(publication.stats.deletedRanges, boundary.name).toBe(4);
       expect(withoutBoundary.stats.deletedRanges, boundary.name).toBe(1);
+      // Characterization: compared with the control's one text deletion, this
+      // public total contains two boundary-only wrappers plus a separate
+      // trailing-text deletion caused by suffix-alignment loss. #938 tracks
+      // both the range-counting rule and the avoidable alignment churn.
+      expect(generatedDeletions.filter((element) => element.textContent === ''), boundary.name)
+        .toHaveLength(2);
+      expect(generatedDeletions.map((element) => element.textContent), boundary.name)
+        .toEqual(['', 'beta gamma', '', ' omega']);
+      expect(generatedInsertions[0]!.textContent, boundary.name).toBe('new omega');
       expect(emitted.getElementsByTagNameNS(W_NS, boundary.startLocalName), boundary.name)
         .toHaveLength(1);
       expect(emitted.getElementsByTagNameNS(W_NS, boundary.endLocalName), boundary.name)
@@ -246,8 +254,10 @@ describe('tagged publication range statistics', () => {
     const emitted = parseXml(publication.xml);
 
     expectRangeStatsMatchSerializedMarkup(publication);
-    expect(publication.stats.insertedRanges).toBeGreaterThan(0);
-    expect(publication.stats.deletedRanges).toBeGreaterThan(0);
+    expect(publication.stats.insertedRanges).toBe(1);
+    expect(publication.stats.deletedRanges).toBe(1);
+    expect(generatedElements(publication, 'del')[0]!
+      .getElementsByTagNameNS(W_NS, 'fldChar')).toHaveLength(3);
     expect(emitted.getElementsByTagNameNS(W_NS, 'fldChar')).toHaveLength(6);
     expect(Array.from(emitted.getElementsByTagNameNS(W_NS, 'fldChar')).filter((field) =>
       field.getAttributeNS(W_NS, 'fldCharType') === 'begin',

--- a/packages/docx-compare/src/tagged/taggedTreeStatistics.test.ts
+++ b/packages/docx-compare/src/tagged/taggedTreeStatistics.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect } from 'vitest';
+import { parseXml } from '@usejunior/docx-core';
+import { testAllure } from '../testing/allure-test.js';
+import {
+  completeField,
+  FIELD_INSTRUCTIONS,
+  paragraphWithField,
+} from '../testing/ooxml-fixtures.js';
+import {
+  buildTaggedTreePublication,
+  type TaggedTreePublication,
+} from './taggedTreeShadow.js';
+
+const TEST_FEATURE = 'refactor-tagged-tree-redline-construction';
+const test = testAllure.epic('Document Comparison').withLabels({ feature: TEST_FEATURE });
+const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const AUTHOR = 'Range Statistics';
+const DATE = new Date('2026-08-23T12:00:00Z');
+
+function documentWithBody(body: string): string {
+  return `<w:document xmlns:w="${W_NS}"><w:body>${body}</w:body></w:document>`;
+}
+
+function paragraph(text: string): string {
+  return `<w:p><w:r><w:t>${text}</w:t></w:r></w:p>`;
+}
+
+function table(rowTexts: readonly string[]): string {
+  return `<w:tbl>${rowTexts.map((text) =>
+    `<w:tr><w:tc><w:p><w:r><w:t>${text}</w:t></w:r></w:p></w:tc></w:tr>`,
+  ).join('')}</w:tbl>`;
+}
+
+function publish(
+  originalBody: string,
+  revisedBody: string,
+  options: Partial<Parameters<typeof buildTaggedTreePublication>[0]> = {},
+): TaggedTreePublication {
+  return buildTaggedTreePublication({
+    originalXml: documentWithBody(originalBody),
+    revisedXml: documentWithBody(revisedBody),
+    author: AUTHOR,
+    date: DATE,
+    ...options,
+  });
+}
+
+function generatedElements(publication: TaggedTreePublication, localName: string): Element[] {
+  return Array.from(parseXml(publication.xml).getElementsByTagNameNS(W_NS, localName))
+    .filter((element) => element.getAttributeNS(W_NS, 'author') === AUTHOR);
+}
+
+function expectRangeStatsMatchSerializedMarkup(publication: TaggedTreePublication): void {
+  const inserted = generatedElements(publication, 'ins');
+  const deleted = generatedElements(publication, 'del');
+  const movedFrom = generatedElements(publication, 'moveFrom');
+  const movedTo = generatedElements(publication, 'moveTo');
+
+  expect(publication.stats.insertions).toBe(inserted.length);
+  expect(publication.stats.deletions).toBe(deleted.length);
+  expect(publication.stats.insertedRanges).toBe(inserted.length);
+  expect(publication.stats.deletedRanges).toBe(deleted.length);
+  expect(publication.serializedRangeStats).toEqual({
+    insertedRanges: inserted.length,
+    deletedRanges: deleted.length,
+    moveFromRanges: movedFrom.length,
+    moveToRanges: movedTo.length,
+  });
+  expect(publication.xml).not.toContain('data-safe-docx-comparison-revision');
+}
+
+describe('tagged publication range statistics', () => {
+  test.openspec('Serialized wrapper transformations determine range totals')(
+    'counts wrappers after word-level refinement splits and coalesces replacement tokens',
+    () => {
+      const publication = publish(
+        paragraph('Shared prefix old middle shared suffix.'),
+        paragraph('Shared prefix new middle shared suffix.'),
+      );
+
+      expectRangeStatsMatchSerializedMarkup(publication);
+      expect(publication.stats.insertedRanges).toBeGreaterThan(0);
+      expect(publication.stats.deletedRanges).toBeGreaterThan(0);
+      expect(publication.xml).toContain('Shared prefix ');
+      expect(publication.xml).toContain(' shared suffix.');
+    },
+  );
+
+  test.openspec('Serialized wrapper transformations determine range totals')(
+    'counts wrappers split around bookmark boundaries',
+    () => {
+      const bookmarked = (value: string) => '<w:p>'
+        + '<w:bookmarkStart w:id="7" w:name="Clause"/>'
+        + `<w:r><w:t>${value}</w:t></w:r>`
+        + '<w:bookmarkEnd w:id="7"/>'
+        + '</w:p>';
+      const publication = publish(bookmarked('old clause'), bookmarked('new clause'));
+      const emitted = parseXml(publication.xml);
+
+      expectRangeStatsMatchSerializedMarkup(publication);
+      expect(publication.stats.insertedRanges).toBeGreaterThan(0);
+      expect(publication.stats.deletedRanges).toBeGreaterThan(0);
+      expect(emitted.getElementsByTagNameNS(W_NS, 'bookmarkStart')).toHaveLength(1);
+      expect(emitted.getElementsByTagNameNS(W_NS, 'bookmarkEnd')).toHaveLength(1);
+    },
+  );
+
+  test.openspec('Serialized wrapper transformations determine range totals')(
+    'counts wrappers split around non-bookmark range boundaries',
+    () => {
+      const ranged = (value: string) => '<w:p>'
+        + '<w:commentRangeStart w:id="3"/>'
+        + `<w:r><w:t>${value}</w:t></w:r>`
+        + '<w:commentRangeEnd w:id="3"/>'
+        + '</w:p>';
+      const publication = publish(ranged('old comment span'), ranged('new comment span'));
+      const emitted = parseXml(publication.xml);
+
+      expectRangeStatsMatchSerializedMarkup(publication);
+      expect(publication.stats.insertedRanges).toBeGreaterThan(0);
+      expect(publication.stats.deletedRanges).toBeGreaterThan(0);
+      expect(emitted.getElementsByTagNameNS(W_NS, 'commentRangeStart')).toHaveLength(1);
+      expect(emitted.getElementsByTagNameNS(W_NS, 'commentRangeEnd')).toHaveLength(1);
+    },
+  );
+
+  test.openspec('Serialized wrapper transformations determine range totals')(
+    'reports a property-node range from the emitted property revision',
+    () => {
+      const formatted = (property: string) => '<w:p><w:r>'
+        + `<w:rPr>${property}</w:rPr><w:t>same words</w:t>`
+        + '</w:r></w:p>';
+      const publication = publish(formatted('<w:i/>'), formatted('<w:b/>'));
+      const propertyChanges = generatedElements(publication, 'rPrChange');
+
+      expectRangeStatsMatchSerializedMarkup(publication);
+      expect(publication.stats.formatChanges).toBe(propertyChanges.length);
+      expect(propertyChanges).toHaveLength(1);
+    },
+  );
+
+  test.openspec('Serialized wrapper transformations determine range totals')(
+    'counts an opaque inline subtree after whole-node wrapping',
+    () => {
+      const opaque = '<w:sdt>'
+        + '<w:sdtPr><w:tag w:val="fixture"/></w:sdtPr>'
+        + '<w:sdtContent><w:r><w:t>opaque payload</w:t></w:r></w:sdtContent>'
+        + '</w:sdt>';
+      const publication = publish(
+        '<w:p><w:r><w:t>stable</w:t></w:r></w:p>',
+        `<w:p><w:r><w:t>stable</w:t></w:r>${opaque}</w:p>`,
+      );
+      const emitted = parseXml(publication.xml);
+
+      expectRangeStatsMatchSerializedMarkup(publication);
+      expect(publication.stats.insertedRanges).toBeGreaterThan(0);
+      expect(publication.stats.deletedRanges).toBe(0);
+      const control = emitted.getElementsByTagNameNS(W_NS, 'sdt')[0]!;
+      expect((control.parentNode as Element).localName).toBe('ins');
+    },
+  );
+
+  test.openspec('Serialized wrapper transformations determine range totals')(
+    'counts both paragraph-mark and content ranges emitted for a whole paragraph deletion',
+    () => {
+      const publication = publish(
+        paragraph('stable') + paragraph('deleted paragraph'),
+        paragraph('stable'),
+      );
+      const emitted = parseXml(publication.xml);
+
+      expectRangeStatsMatchSerializedMarkup(publication);
+      expect(publication.stats.deletedRanges).toBe(2);
+      expect(Array.from(emitted.getElementsByTagNameNS(W_NS, 'del')).some((element) =>
+        (element.parentNode as Element | null)?.localName === 'rPr',
+      )).toBe(true);
+      expect(Array.from(emitted.getElementsByTagNameNS(W_NS, 'del')).some((element) =>
+        element.getElementsByTagNameNS(W_NS, 'delText').length > 0,
+      )).toBe(true);
+    },
+  );
+
+  test.openspec('Serialized wrapper transformations determine range totals')(
+    'counts a whole-row deletion from its row-property marker',
+    () => {
+      const publication = publish(table(['deleted row', 'stable row']), table(['stable row']));
+      const deletions = generatedElements(publication, 'del');
+
+      expectRangeStatsMatchSerializedMarkup(publication);
+      expect(deletions).toHaveLength(1);
+      expect((deletions[0]!.parentNode as Element).localName).toBe('trPr');
+      expect((deletions[0]!.parentNode?.parentNode as Element).localName).toBe('tr');
+    },
+  );
+
+  test.openspec('Serialized wrapper transformations determine range totals')(
+    'excludes preserved prior-author revisions while counting nested comparison ranges',
+    () => {
+      const priorRevision = (value: string) => '<w:p>'
+        + '<w:ins w:id="4" w:author="Prior Author" w:date="2026-08-01T00:00:00Z">'
+        + `<w:r><w:t>${value}</w:t></w:r></w:ins>`
+        + '</w:p>';
+      const publication = publish(priorRevision('old text'), priorRevision('new text'));
+      const emitted = parseXml(publication.xml);
+
+      expectRangeStatsMatchSerializedMarkup(publication);
+      expect(publication.stats.insertedRanges).toBeGreaterThan(0);
+      expect(publication.stats.deletedRanges).toBeGreaterThan(0);
+      expect(Array.from(emitted.getElementsByTagNameNS(W_NS, 'ins')).filter((element) =>
+        element.getAttributeNS(W_NS, 'author') === 'Prior Author',
+      )).not.toHaveLength(0);
+      expect(emitted.getElementsByTagNameNS(W_NS, 'ins').length)
+        .toBeGreaterThan(publication.stats.insertedRanges);
+    },
+  );
+
+  test.openspec('Serialized wrapper transformations determine range totals')(
+    'counts wrappers after complex-field controls force atomic replacement',
+    () => {
+      const publication = publish(
+        paragraphWithField('Pages: ', completeField(FIELD_INSTRUCTIONS.PAGE, '1'), '.'),
+        paragraphWithField('Pages: ', completeField(FIELD_INSTRUCTIONS.NUMPAGES, '3'), '.'),
+      );
+      const emitted = parseXml(publication.xml);
+
+      expectRangeStatsMatchSerializedMarkup(publication);
+      expect(publication.stats.insertedRanges).toBeGreaterThan(0);
+      expect(publication.stats.deletedRanges).toBeGreaterThan(0);
+      expect(emitted.getElementsByTagNameNS(W_NS, 'fldChar')).toHaveLength(6);
+      expect(Array.from(emitted.getElementsByTagNameNS(W_NS, 'fldChar')).filter((field) =>
+        field.getAttributeNS(W_NS, 'fldCharType') === 'begin',
+      )).toHaveLength(2);
+    },
+  );
+
+  test.openspec('Serialized wrapper transformations determine range totals')(
+    'reports balanced move ranges from the serialized move wrappers',
+    () => {
+      const publication = publish(
+        paragraph('this complete paragraph moves away') + paragraph('stable paragraph'),
+        paragraph('stable paragraph') + paragraph('this complete paragraph moves away'),
+      );
+
+      expectRangeStatsMatchSerializedMarkup(publication);
+      expect(publication.serializedRangeStats.moveFromRanges).toBe(1);
+      expect(publication.serializedRangeStats.moveToRanges).toBe(1);
+      expect(publication.stats.insertedRanges).toBe(0);
+      expect(publication.stats.deletedRanges).toBe(0);
+    },
+  );
+});

--- a/packages/docx-compare/src/tagged/taggedTreeStatistics.test.ts
+++ b/packages/docx-compare/src/tagged/taggedTreeStatistics.test.ts
@@ -11,6 +11,7 @@ import {
   type TaggedTreePublication,
 } from './taggedTreeShadow.js';
 import { constructTaggedTree } from './taggedTreeConstruction.js';
+import { COMPARISON_REVISION_ATTRIBUTE } from './taggedTreeSerializer.js';
 import type { TaggedNode } from './taggedTree.js';
 
 const TEST_FEATURE = 'refactor-tagged-tree-redline-construction';
@@ -50,7 +51,7 @@ function publish(
 
 function generatedElements(publication: TaggedTreePublication, localName: string): Element[] {
   return Array.from(parseXml(publication.xml).getElementsByTagNameNS(W_NS, localName))
-    .filter((element) => element.getAttribute('data-safe-docx-comparison-revision') === '1');
+    .filter((element) => element.getAttribute(COMPARISON_REVISION_ATTRIBUTE) === '1');
 }
 
 function expectRangeStatsMatchSerializedMarkup(publication: TaggedTreePublication): void {
@@ -73,29 +74,61 @@ function expectRangeStatsMatchSerializedMarkup(publication: TaggedTreePublicatio
 }
 
 describe('tagged publication range statistics', () => {
-  test.openspec('Serialized wrapper transformations determine range totals')(
-    'counts wrappers after word-level refinement splits and coalesces replacement tokens',
-    () => {
-      const publication = publish(
-        paragraph('Shared prefix old middle shared suffix.'),
-        paragraph('Shared prefix new middle shared suffix.'),
-      );
+  // This matrix covers serialized insertion, deletion, and move wrappers. The
+  // distinct contract for serializer-restorative property markup is tracked by
+  // #937 instead of being treated as settled range-stat evidence here.
+  test('counts wrappers after word-level refinement splits replacement tokens', () => {
+    const publication = publish(
+      paragraph('Shared prefix old middle shared suffix.'),
+      paragraph('Shared prefix new middle shared suffix.'),
+    );
+    const publicPublication = publish(
+      paragraph('Shared prefix old middle shared suffix.'),
+      paragraph('Shared prefix new middle shared suffix.'),
+      { retainStatisticsMarkers: false },
+    );
 
-      expectRangeStatsMatchSerializedMarkup(publication);
-      expect(publication.stats.insertedRanges).toBeGreaterThan(0);
-      expect(publication.stats.deletedRanges).toBeGreaterThan(0);
-      expect(publication.xml).toContain('Shared prefix ');
-      expect(publication.xml).toContain(' shared suffix.');
-    },
-  );
+    expectRangeStatsMatchSerializedMarkup(publication);
+    expect(publication.stats.insertedRanges).toBe(1);
+    expect(publication.stats.deletedRanges).toBe(1);
+    expect(publication.xml).toContain('Shared prefix ');
+    expect(publication.xml).toContain(' shared suffix.');
+    expect(publicPublication.stats).toEqual(publication.stats);
+    expect(publicPublication.xml).not.toContain(COMPARISON_REVISION_ATTRIBUTE);
+  });
 
-  test.openspec('Serialized wrapper transformations determine range totals')(
-    'counts wrappers split around bookmark boundaries',
-    () => {
+  test('coalesces a contiguous multi-token deletion into one wrapper', () => {
+    const publication = publish(
+      paragraph('alpha beta gamma delta'),
+      paragraph('alpha delta'),
+    );
+
+    expectRangeStatsMatchSerializedMarkup(publication);
+    expect(publication.stats.insertedRanges).toBe(0);
+    expect(publication.stats.deletedRanges).toBe(1);
+  });
+
+  test('counts wrappers split around bookmark and comment-range boundaries', () => {
+    for (const boundary of [
+      {
+        name: 'bookmark',
+        start: '<w:bookmarkStart w:id="7" w:name="Clause"/>',
+        end: '<w:bookmarkEnd w:id="7"/>',
+        startLocalName: 'bookmarkStart',
+        endLocalName: 'bookmarkEnd',
+      },
+      {
+        name: 'comment',
+        start: '<w:commentRangeStart w:id="3"/>',
+        end: '<w:commentRangeEnd w:id="3"/>',
+        startLocalName: 'commentRangeStart',
+        endLocalName: 'commentRangeEnd',
+      },
+    ] as const) {
       const original = '<w:p><w:r><w:t>alpha </w:t></w:r>'
-        + '<w:bookmarkStart w:id="7" w:name="Clause"/>'
+        + boundary.start
         + '<w:r><w:t>beta gamma</w:t></w:r>'
-        + '<w:bookmarkEnd w:id="7"/>'
+        + boundary.end
         + '<w:r><w:t> omega</w:t></w:r></w:p>';
       const publication = publish(original, paragraph('alpha new omega'));
       const withoutBoundary = publish(
@@ -105,177 +138,132 @@ describe('tagged publication range statistics', () => {
       const emitted = parseXml(publication.xml);
 
       expectRangeStatsMatchSerializedMarkup(publication);
-      expect(publication.stats.insertedRanges).toBe(1);
-      expect(publication.stats.deletedRanges).toBe(4);
-      expect(withoutBoundary.stats.deletedRanges).toBe(1);
-      expect(emitted.getElementsByTagNameNS(W_NS, 'bookmarkStart')).toHaveLength(1);
-      expect(emitted.getElementsByTagNameNS(W_NS, 'bookmarkEnd')).toHaveLength(1);
-      expect((emitted.getElementsByTagNameNS(W_NS, 'bookmarkStart')[0]!.parentNode as Element).localName)
+      expect(publication.stats.insertedRanges, boundary.name).toBe(1);
+      // Characterization: two boundary-only wrappers currently contribute to
+      // this public total. #938 tracks whether they should remain ranges.
+      expect(publication.stats.deletedRanges, boundary.name).toBe(4);
+      expect(withoutBoundary.stats.deletedRanges, boundary.name).toBe(1);
+      expect(emitted.getElementsByTagNameNS(W_NS, boundary.startLocalName), boundary.name)
+        .toHaveLength(1);
+      expect(emitted.getElementsByTagNameNS(W_NS, boundary.endLocalName), boundary.name)
+        .toHaveLength(1);
+      expect((emitted.getElementsByTagNameNS(W_NS, boundary.startLocalName)[0]!.parentNode as Element).localName)
         .toBe('del');
-      expect((emitted.getElementsByTagNameNS(W_NS, 'bookmarkEnd')[0]!.parentNode as Element).localName)
+      expect((emitted.getElementsByTagNameNS(W_NS, boundary.endLocalName)[0]!.parentNode as Element).localName)
         .toBe('del');
-    },
-  );
+    }
+  });
 
-  test.openspec('Serialized wrapper transformations determine range totals')(
-    'counts wrappers split around non-bookmark range boundaries',
-    () => {
-      const original = '<w:p><w:r><w:t>alpha </w:t></w:r>'
-        + '<w:commentRangeStart w:id="3"/>'
-        + '<w:r><w:t>beta gamma</w:t></w:r>'
-        + '<w:commentRangeEnd w:id="3"/>'
-        + '<w:r><w:t> omega</w:t></w:r></w:p>';
-      const publication = publish(original, paragraph('alpha new omega'));
-      const withoutBoundary = publish(
-        paragraph('alpha beta gamma omega'),
-        paragraph('alpha new omega'),
-      );
-      const emitted = parseXml(publication.xml);
+  test('reports a property-node range from the emitted property revision', () => {
+    const formatted = (property: string) => '<w:p><w:r>'
+      + `<w:rPr>${property}</w:rPr><w:t>same words</w:t>`
+      + '</w:r></w:p>';
+    const publication = publish(formatted('<w:i/>'), formatted('<w:b/>'));
+    const propertyChanges = generatedElements(publication, 'rPrChange');
 
-      expectRangeStatsMatchSerializedMarkup(publication);
-      expect(publication.stats.insertedRanges).toBe(1);
-      expect(publication.stats.deletedRanges).toBe(4);
-      expect(withoutBoundary.stats.deletedRanges).toBe(1);
-      expect(emitted.getElementsByTagNameNS(W_NS, 'commentRangeStart')).toHaveLength(1);
-      expect(emitted.getElementsByTagNameNS(W_NS, 'commentRangeEnd')).toHaveLength(1);
-      expect((emitted.getElementsByTagNameNS(W_NS, 'commentRangeStart')[0]!.parentNode as Element).localName)
-        .toBe('del');
-      expect((emitted.getElementsByTagNameNS(W_NS, 'commentRangeEnd')[0]!.parentNode as Element).localName)
-        .toBe('del');
-    },
-  );
+    expectRangeStatsMatchSerializedMarkup(publication);
+    expect(publication.stats.formatChanges).toBe(propertyChanges.length);
+    expect(propertyChanges).toHaveLength(1);
+  });
 
-  test.openspec('Serialized wrapper transformations determine range totals')(
-    'reports a property-node range from the emitted property revision',
-    () => {
-      const formatted = (property: string) => '<w:p><w:r>'
-        + `<w:rPr>${property}</w:rPr><w:t>same words</w:t>`
-        + '</w:r></w:p>';
-      const publication = publish(formatted('<w:i/>'), formatted('<w:b/>'));
-      const propertyChanges = generatedElements(publication, 'rPrChange');
+  test('counts an opaque inline subtree after whole-node wrapping', () => {
+    const opaque = '<w:sdt>'
+      + '<w:sdtPr><w:tag w:val="fixture"/></w:sdtPr>'
+      + '<w:sdtContent><w:r><w:t>opaque payload</w:t></w:r></w:sdtContent>'
+      + '</w:sdt>';
+    const publication = publish(
+      '<w:p><w:r><w:t>stable</w:t></w:r></w:p>',
+      `<w:p><w:r><w:t>stable</w:t></w:r>${opaque}</w:p>`,
+    );
+    const emitted = parseXml(publication.xml);
+    const constructed = constructTaggedTree(
+      parseXml(documentWithBody('<w:p><w:r><w:t>stable</w:t></w:r></w:p>')).documentElement,
+      parseXml(documentWithBody(`<w:p><w:r><w:t>stable</w:t></w:r>${opaque}</w:p>`)).documentElement,
+    );
+    const descendants = (node: TaggedNode): TaggedNode[] =>
+      [node, ...node.children.flatMap(descendants)];
+    const opaqueControl = descendants(constructed.tree).find((node) =>
+      node.tag === 'revised' && node.node.localName === 'sdt');
 
-      expectRangeStatsMatchSerializedMarkup(publication);
-      expect(publication.stats.formatChanges).toBe(propertyChanges.length);
-      expect(propertyChanges).toHaveLength(1);
-    },
-  );
+    expectRangeStatsMatchSerializedMarkup(publication);
+    expect(publication.stats.insertedRanges).toBeGreaterThan(0);
+    expect(publication.stats.deletedRanges).toBe(0);
+    expect(opaqueControl?.opaque).toBe(true);
+    const control = emitted.getElementsByTagNameNS(W_NS, 'sdt')[0]!;
+    expect((control.parentNode as Element).localName).toBe('ins');
+  });
 
-  test.openspec('Serialized wrapper transformations determine range totals')(
-    'counts an opaque inline subtree after whole-node wrapping',
-    () => {
-      const opaque = '<w:sdt>'
-        + '<w:sdtPr><w:tag w:val="fixture"/></w:sdtPr>'
-        + '<w:sdtContent><w:r><w:t>opaque payload</w:t></w:r></w:sdtContent>'
-        + '</w:sdt>';
-      const publication = publish(
-        '<w:p><w:r><w:t>stable</w:t></w:r></w:p>',
-        `<w:p><w:r><w:t>stable</w:t></w:r>${opaque}</w:p>`,
-      );
-      const emitted = parseXml(publication.xml);
-      const constructed = constructTaggedTree(
-        parseXml(documentWithBody('<w:p><w:r><w:t>stable</w:t></w:r></w:p>')).documentElement,
-        parseXml(documentWithBody(`<w:p><w:r><w:t>stable</w:t></w:r>${opaque}</w:p>`)).documentElement,
-      );
-      const descendants = (node: TaggedNode): TaggedNode[] =>
-        [node, ...node.children.flatMap(descendants)];
-      const opaqueControl = descendants(constructed.tree).find((node) =>
-        node.tag === 'revised' && node.node.localName === 'sdt');
+  test('counts both paragraph-mark and content ranges emitted for a whole paragraph deletion', () => {
+    const publication = publish(
+      paragraph('stable') + paragraph('deleted paragraph'),
+      paragraph('stable'),
+    );
 
-      expectRangeStatsMatchSerializedMarkup(publication);
-      expect(publication.stats.insertedRanges).toBeGreaterThan(0);
-      expect(publication.stats.deletedRanges).toBe(0);
-      expect(opaqueControl?.opaque).toBe(true);
-      const control = emitted.getElementsByTagNameNS(W_NS, 'sdt')[0]!;
-      expect((control.parentNode as Element).localName).toBe('ins');
-    },
-  );
+    expectRangeStatsMatchSerializedMarkup(publication);
+    expect(publication.stats.deletedRanges).toBe(2);
+    expect(generatedElements(publication, 'del').some((element) =>
+      (element.parentNode as Element | null)?.localName === 'rPr',
+    )).toBe(true);
+    expect(generatedElements(publication, 'del').some((element) =>
+      element.getElementsByTagNameNS(W_NS, 'delText').length > 0,
+    )).toBe(true);
+  });
 
-  test.openspec('Serialized wrapper transformations determine range totals')(
-    'counts both paragraph-mark and content ranges emitted for a whole paragraph deletion',
-    () => {
-      const publication = publish(
-        paragraph('stable') + paragraph('deleted paragraph'),
-        paragraph('stable'),
-      );
+  test('counts a whole-row deletion from its row-property marker', () => {
+    const publication = publish(table(['deleted row', 'stable row']), table(['stable row']));
+    const deletions = generatedElements(publication, 'del');
 
-      expectRangeStatsMatchSerializedMarkup(publication);
-      expect(publication.stats.deletedRanges).toBe(2);
-      expect(generatedElements(publication, 'del').some((element) =>
-        (element.parentNode as Element | null)?.localName === 'rPr',
-      )).toBe(true);
-      expect(generatedElements(publication, 'del').some((element) =>
-        element.getElementsByTagNameNS(W_NS, 'delText').length > 0,
-      )).toBe(true);
-    },
-  );
+    expectRangeStatsMatchSerializedMarkup(publication);
+    expect(deletions).toHaveLength(1);
+    expect((deletions[0]!.parentNode as Element).localName).toBe('trPr');
+    expect((deletions[0]!.parentNode?.parentNode as Element).localName).toBe('tr');
+  });
 
-  test.openspec('Serialized wrapper transformations determine range totals')(
-    'counts a whole-row deletion from its row-property marker',
-    () => {
-      const publication = publish(table(['deleted row', 'stable row']), table(['stable row']));
-      const deletions = generatedElements(publication, 'del');
+  test('excludes preserved prior-author revisions while counting nested comparison ranges', () => {
+    const priorRevision = (value: string) => '<w:p>'
+      + `<w:ins w:id="4" w:author="${AUTHOR}" w:date="2026-08-01T00:00:00Z">`
+      + `<w:r><w:t>${value}</w:t></w:r></w:ins>`
+      + '</w:p>';
+    const publication = publish(priorRevision('old text'), priorRevision('new text'));
+    const emitted = parseXml(publication.xml);
 
-      expectRangeStatsMatchSerializedMarkup(publication);
-      expect(deletions).toHaveLength(1);
-      expect((deletions[0]!.parentNode as Element).localName).toBe('trPr');
-      expect((deletions[0]!.parentNode?.parentNode as Element).localName).toBe('tr');
-    },
-  );
+    expectRangeStatsMatchSerializedMarkup(publication);
+    expect(publication.stats.insertedRanges).toBeGreaterThan(0);
+    expect(publication.stats.deletedRanges).toBeGreaterThan(0);
+    expect(Array.from(emitted.getElementsByTagNameNS(W_NS, 'ins')).filter((element) =>
+      element.getAttributeNS(W_NS, 'author') === AUTHOR &&
+          !element.hasAttribute(COMPARISON_REVISION_ATTRIBUTE),
+    )).not.toHaveLength(0);
+    expect(emitted.getElementsByTagNameNS(W_NS, 'ins').length)
+      .toBeGreaterThan(publication.stats.insertedRanges);
+  });
 
-  test.openspec('Serialized wrapper transformations determine range totals')(
-    'excludes preserved prior-author revisions while counting nested comparison ranges',
-    () => {
-      const priorRevision = (value: string) => '<w:p>'
-        + `<w:ins w:id="4" w:author="${AUTHOR}" w:date="2026-08-01T00:00:00Z">`
-        + `<w:r><w:t>${value}</w:t></w:r></w:ins>`
-        + '</w:p>';
-      const publication = publish(priorRevision('old text'), priorRevision('new text'));
-      const emitted = parseXml(publication.xml);
+  test('counts wrappers after complex-field controls force atomic replacement', () => {
+    const publication = publish(
+      paragraphWithField('Pages: ', completeField(FIELD_INSTRUCTIONS.PAGE, '1'), '.'),
+      paragraphWithField('Pages: ', completeField(FIELD_INSTRUCTIONS.NUMPAGES, '3'), '.'),
+    );
+    const emitted = parseXml(publication.xml);
 
-      expectRangeStatsMatchSerializedMarkup(publication);
-      expect(publication.stats.insertedRanges).toBeGreaterThan(0);
-      expect(publication.stats.deletedRanges).toBeGreaterThan(0);
-      expect(Array.from(emitted.getElementsByTagNameNS(W_NS, 'ins')).filter((element) =>
-        element.getAttributeNS(W_NS, 'author') === AUTHOR &&
-          !element.hasAttribute('data-safe-docx-comparison-revision'),
-      )).not.toHaveLength(0);
-      expect(emitted.getElementsByTagNameNS(W_NS, 'ins').length)
-        .toBeGreaterThan(publication.stats.insertedRanges);
-    },
-  );
+    expectRangeStatsMatchSerializedMarkup(publication);
+    expect(publication.stats.insertedRanges).toBeGreaterThan(0);
+    expect(publication.stats.deletedRanges).toBeGreaterThan(0);
+    expect(emitted.getElementsByTagNameNS(W_NS, 'fldChar')).toHaveLength(6);
+    expect(Array.from(emitted.getElementsByTagNameNS(W_NS, 'fldChar')).filter((field) =>
+      field.getAttributeNS(W_NS, 'fldCharType') === 'begin',
+    )).toHaveLength(2);
+  });
 
-  test.openspec('Serialized wrapper transformations determine range totals')(
-    'counts wrappers after complex-field controls force atomic replacement',
-    () => {
-      const publication = publish(
-        paragraphWithField('Pages: ', completeField(FIELD_INSTRUCTIONS.PAGE, '1'), '.'),
-        paragraphWithField('Pages: ', completeField(FIELD_INSTRUCTIONS.NUMPAGES, '3'), '.'),
-      );
-      const emitted = parseXml(publication.xml);
+  test('reports balanced move ranges from the serialized move wrappers', () => {
+    const publication = publish(
+      paragraph('this complete paragraph moves away') + paragraph('stable paragraph'),
+      paragraph('stable paragraph') + paragraph('this complete paragraph moves away'),
+    );
 
-      expectRangeStatsMatchSerializedMarkup(publication);
-      expect(publication.stats.insertedRanges).toBeGreaterThan(0);
-      expect(publication.stats.deletedRanges).toBeGreaterThan(0);
-      expect(emitted.getElementsByTagNameNS(W_NS, 'fldChar')).toHaveLength(6);
-      expect(Array.from(emitted.getElementsByTagNameNS(W_NS, 'fldChar')).filter((field) =>
-        field.getAttributeNS(W_NS, 'fldCharType') === 'begin',
-      )).toHaveLength(2);
-    },
-  );
-
-  test.openspec('Serialized wrapper transformations determine range totals')(
-    'reports balanced move ranges from the serialized move wrappers',
-    () => {
-      const publication = publish(
-        paragraph('this complete paragraph moves away') + paragraph('stable paragraph'),
-        paragraph('stable paragraph') + paragraph('this complete paragraph moves away'),
-      );
-
-      expectRangeStatsMatchSerializedMarkup(publication);
-      expect(publication.serializedRangeStats.moveFromRanges).toBe(1);
-      expect(publication.serializedRangeStats.moveToRanges).toBe(1);
-      expect(publication.stats.insertedRanges).toBe(0);
-      expect(publication.stats.deletedRanges).toBe(0);
-    },
-  );
+    expectRangeStatsMatchSerializedMarkup(publication);
+    expect(publication.serializedRangeStats.moveFromRanges).toBe(1);
+    expect(publication.serializedRangeStats.moveToRanges).toBe(1);
+    expect(publication.stats.insertedRanges).toBe(0);
+    expect(publication.stats.deletedRanges).toBe(0);
+  });
 });

--- a/packages/docx-compare/src/tagged/taggedTreeStatistics.test.ts
+++ b/packages/docx-compare/src/tagged/taggedTreeStatistics.test.ts
@@ -10,12 +10,11 @@ import {
   buildTaggedTreePublication,
   type TaggedTreePublication,
 } from './taggedTreeShadow.js';
-import { constructTaggedTree } from './taggedTreeConstruction.js';
 import { COMPARISON_REVISION_ATTRIBUTE } from './taggedTreeSerializer.js';
-import type { TaggedNode } from './taggedTree.js';
 
 const TEST_FEATURE = 'refactor-tagged-tree-redline-construction';
 const test = testAllure.epic('Document Comparison').withLabels({ feature: TEST_FEATURE });
+const transformationTest = test.openspec('Serialized wrapper transformations determine range totals');
 const W_NS = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
 const AUTHOR = 'Range Statistics';
 const DATE = new Date('2026-08-23T12:00:00Z');
@@ -77,7 +76,7 @@ describe('tagged publication range statistics', () => {
   // This matrix covers serialized insertion, deletion, and move wrappers. The
   // distinct contract for serializer-restorative property markup is tracked by
   // #937 instead of being treated as settled range-stat evidence here.
-  test('counts wrappers after word-level refinement splits replacement tokens', () => {
+  transformationTest('counts wrappers after word-level refinement splits replacement tokens', () => {
     const publication = publish(
       paragraph('Shared prefix old middle shared suffix.'),
       paragraph('Shared prefix new middle shared suffix.'),
@@ -96,7 +95,7 @@ describe('tagged publication range statistics', () => {
     expect(publicPublication.xml).not.toContain(COMPARISON_REVISION_ATTRIBUTE);
   });
 
-  test('coalesces a contiguous multi-token deletion into one wrapper', () => {
+  transformationTest('coalesces a contiguous multi-token deletion into one wrapper', () => {
     const publication = publish(
       paragraph('alpha beta gamma delta'),
       paragraph('alpha delta'),
@@ -107,7 +106,7 @@ describe('tagged publication range statistics', () => {
     expect(publication.stats.deletedRanges).toBe(1);
   });
 
-  test('counts wrappers split around bookmark and comment-range boundaries', () => {
+  transformationTest('counts wrappers split around bookmark and comment-range boundaries', () => {
     for (const boundary of [
       {
         name: 'bookmark',
@@ -162,7 +161,7 @@ describe('tagged publication range statistics', () => {
     }
   });
 
-  test('reports a property-node range from the emitted property revision', () => {
+  transformationTest('reports a property-node range from the emitted property revision', () => {
     const formatted = (property: string) => '<w:p><w:r>'
       + `<w:rPr>${property}</w:rPr><w:t>same words</w:t>`
       + '</w:r></w:p>';
@@ -170,33 +169,33 @@ describe('tagged publication range statistics', () => {
     const propertyChanges = generatedElements(publication, 'rPrChange');
 
     expectRangeStatsMatchSerializedMarkup(publication);
-    expect(publication.stats.formatChanges).toBe(propertyChanges.length);
+    expect(publication.stats.formatChanges).toBe(1);
     expect(propertyChanges).toHaveLength(1);
   });
 
-  test('counts an opaque inline subtree after whole-node wrapping', () => {
+  transformationTest('counts an opaque inline subtree after whole-node wrapping', () => {
+    const insertedRuns = '<w:r><w:t>opaque one</w:t></w:r>'
+      + '<w:r><w:t> opaque two</w:t></w:r>'
+      + '<w:r><w:t> opaque three</w:t></w:r>';
     const opaque = '<w:sdt>'
       + '<w:sdtPr><w:tag w:val="fixture"/></w:sdtPr>'
-      + '<w:sdtContent><w:r><w:t>opaque payload</w:t></w:r></w:sdtContent>'
+      + `<w:sdtContent>${insertedRuns}</w:sdtContent>`
       + '</w:sdt>';
     const publication = publish(
       '<w:p><w:r><w:t>stable</w:t></w:r></w:p>',
       `<w:p><w:r><w:t>stable</w:t></w:r>${opaque}</w:p>`,
     );
-    const emitted = parseXml(publication.xml);
-    const constructed = constructTaggedTree(
-      parseXml(documentWithBody('<w:p><w:r><w:t>stable</w:t></w:r></w:p>')).documentElement,
-      parseXml(documentWithBody(`<w:p><w:r><w:t>stable</w:t></w:r>${opaque}</w:p>`)).documentElement,
+    const plainRuns = publish(
+      '<w:p><w:r><w:t>stable</w:t></w:r></w:p>',
+      `<w:p><w:r><w:t>stable</w:t></w:r>${insertedRuns}</w:p>`,
     );
-    const descendants = (node: TaggedNode): TaggedNode[] =>
-      [node, ...node.children.flatMap(descendants)];
-    const opaqueControl = descendants(constructed.tree).find((node) =>
-      node.tag === 'revised' && node.node.localName === 'sdt');
+    const emitted = parseXml(publication.xml);
 
     expectRangeStatsMatchSerializedMarkup(publication);
-    expect(publication.stats.insertedRanges).toBeGreaterThan(0);
+    expectRangeStatsMatchSerializedMarkup(plainRuns);
+    expect(publication.stats.insertedRanges).toBe(1);
+    expect(plainRuns.stats.insertedRanges).toBe(3);
     expect(publication.stats.deletedRanges).toBe(0);
-    expect(opaqueControl?.opaque).toBe(true);
     const control = emitted.getElementsByTagNameNS(W_NS, 'sdt')[0]!;
     expect((control.parentNode as Element).localName).toBe('ins');
   });
@@ -209,6 +208,10 @@ describe('tagged publication range statistics', () => {
 
     expectRangeStatsMatchSerializedMarkup(publication);
     expect(publication.stats.deletedRanges).toBe(2);
+    // Characterize the serializer-restorative property wrapper separately:
+    // #937 tracks why it does not yet contribute to formatChanges.
+    expect(generatedElements(publication, 'pPrChange')).toHaveLength(1);
+    expect(publication.stats.formatChanges).toBe(0);
     expect(generatedElements(publication, 'del').some((element) =>
       (element.parentNode as Element | null)?.localName === 'rPr',
     )).toBe(true);
@@ -217,7 +220,7 @@ describe('tagged publication range statistics', () => {
     )).toBe(true);
   });
 
-  test('counts a whole-row deletion from its row-property marker', () => {
+  transformationTest('counts a whole-row deletion from its row-property marker', () => {
     const publication = publish(table(['deleted row', 'stable row']), table(['stable row']));
     const deletions = generatedElements(publication, 'del');
 
@@ -227,7 +230,7 @@ describe('tagged publication range statistics', () => {
     expect((deletions[0]!.parentNode?.parentNode as Element).localName).toBe('tr');
   });
 
-  test('excludes preserved prior-author revisions while counting nested comparison ranges', () => {
+  transformationTest('excludes preserved prior-author revisions while counting nested comparison ranges', () => {
     const priorRevision = (value: string) => '<w:p>'
       + `<w:ins w:id="4" w:author="${AUTHOR}" w:date="2026-08-01T00:00:00Z">`
       + `<w:r><w:t>${value}</w:t></w:r></w:ins>`
@@ -246,7 +249,7 @@ describe('tagged publication range statistics', () => {
       .toBeGreaterThan(publication.stats.insertedRanges);
   });
 
-  test('counts wrappers after complex-field controls force atomic replacement', () => {
+  transformationTest('counts wrappers after complex-field controls force atomic replacement', () => {
     const publication = publish(
       paragraphWithField('Pages: ', completeField(FIELD_INSTRUCTIONS.PAGE, '1'), '.'),
       paragraphWithField('Pages: ', completeField(FIELD_INSTRUCTIONS.NUMPAGES, '3'), '.'),
@@ -264,7 +267,7 @@ describe('tagged publication range statistics', () => {
     )).toHaveLength(2);
   });
 
-  test('reports balanced move ranges from the serialized move wrappers', () => {
+  transformationTest('reports balanced move ranges from the serialized move wrappers', () => {
     const publication = publish(
       paragraph('this complete paragraph moves away') + paragraph('stable paragraph'),
       paragraph('stable paragraph') + paragraph('this complete paragraph moves away'),

--- a/packages/docx-core/src/testing/DOCX_COMPARISON_OPENSPEC_TRACEABILITY.md
+++ b/packages/docx-core/src/testing/DOCX_COMPARISON_OPENSPEC_TRACEABILITY.md
@@ -64,7 +64,7 @@ This matrix maps docx-core OpenSpec `#### Scenario:` entries to scenario mapping
 | Revision and bookmark identifiers may overlap numerically | covered | `packages/docx-compare/src/integration/strategy-differential.test.ts` |  |
 | Sequential numbering ignores XML IDs | covered | `packages/docx-compare/src/openspec.traceability.test.ts` |  |
 | Serialized multi-author stacks preserve both projections | covered | `packages/docx-compare/src/tagged/taggedTreeSerializer.test.ts` |  |
-| Serialized wrapper transformations determine range totals | covered | `packages/docx-compare/src/openspec.traceability.test.ts`, `packages/docx-compare/src/tagged/taggedTreeStatistics.test.ts` |  |
+| Serialized wrapper transformations determine range totals | covered | `packages/docx-compare/src/openspec.traceability.test.ts` |  |
 | Skipped soak remains explicit | covered | `packages/docx-compare/src/openspec.traceability.test.ts` |  |
 | Standalone publication has no legacy assembly dependency | covered | `packages/docx-compare/src/tagged/taggedTreeShadow.test.ts` |  |
 | Tagged emission produces one range pair per logical move | covered | `packages/docx-compare/src/openspec.traceability.test.ts` |  |

--- a/packages/docx-core/src/testing/DOCX_COMPARISON_OPENSPEC_TRACEABILITY.md
+++ b/packages/docx-core/src/testing/DOCX_COMPARISON_OPENSPEC_TRACEABILITY.md
@@ -64,7 +64,7 @@ This matrix maps docx-core OpenSpec `#### Scenario:` entries to scenario mapping
 | Revision and bookmark identifiers may overlap numerically | covered | `packages/docx-compare/src/integration/strategy-differential.test.ts` |  |
 | Sequential numbering ignores XML IDs | covered | `packages/docx-compare/src/openspec.traceability.test.ts` |  |
 | Serialized multi-author stacks preserve both projections | covered | `packages/docx-compare/src/tagged/taggedTreeSerializer.test.ts` |  |
-| Serialized wrapper transformations determine range totals | covered | `packages/docx-compare/src/openspec.traceability.test.ts` |  |
+| Serialized wrapper transformations determine range totals | covered | `packages/docx-compare/src/openspec.traceability.test.ts`, `packages/docx-compare/src/tagged/taggedTreeStatistics.test.ts` |  |
 | Skipped soak remains explicit | covered | `packages/docx-compare/src/openspec.traceability.test.ts` |  |
 | Standalone publication has no legacy assembly dependency | covered | `packages/docx-compare/src/tagged/taggedTreeShadow.test.ts` |  |
 | Tagged emission produces one range pair per logical move | covered | `packages/docx-compare/src/openspec.traceability.test.ts` |  |


### PR DESCRIPTION
## Summary

- add an 11-test tagged publication matrix covering word refinement,
  coalescing, bookmark/comment boundaries, property nodes, opaque subtrees,
  whole paragraphs and rows, same-author prior revisions, complex fields, and
  moves
- pin absolute emitted wrapper topology and counts, comparison-owned provenance,
  public marker stripping, atom weights, and canonical OpenSpec traceability
- describe `tagged-token-v1` directly instead of implying compatibility with the
  removed flattened-atom weighting model
- explicitly characterize known public-stat or markup gaps tracked by #937,
  #938, #940, and #941; add the newly reachable deleted-field evidence to #209

## Review

Dynamic Claude review repeatedly executed the focused and full package suites,
inspected emitted XML, and confirmed every named transformation is non-vacuous.
Final verdict: **APPROVE-WITH-FIXES (non-blocking)**. Its remaining suggestions
concern already tracked production behavior or broader finalization coverage,
not incorrect assertions in this focused test PR.

## Validation

Run unrestricted on exact `origin/main` merge-base
`0bd08bf77a675b36e01660441cf6dad29b2e870e`:

```bash
npm run build && npm run lint:workspaces && npm run test:run && \
  npm run check:spec-coverage && npm run check:conformance-citations && \
  npm run check:conformance-doc
```

- docx-compare: 482 passed, 1 skipped
- docx-core: 1,290 passed, 2 expected failures, 1 skipped, including ILPA and
  LibreOffice integration checks
- docx-mcp: 1,004 passed
- all remaining workspaces, strict spec coverage, and conformance gates passed

Ref: #923
