### PR TITLE
test(docx-compare): document scoped revision IDs

### DIFF
--- a/docs/revision-id-policy.md
+++ b/docs/revision-id-policy.md
@@ -23,8 +23,8 @@ authors, timestamps, or normalized revision families fails the corpus safety
 gate as `revision-id-reused-across-identities`.
 
 Property-change elements are one deliberate normalization. Paragraph, run,
-section, and table property-change records can be linked facets of one
-formatting revision, so the gate maps those raw element kinds to one
+section, table, and numbering property-change records can be linked facets of
+one formatting revision, so the gate maps those raw element kinds to one
 `formatting-property-change` family when their remaining signature components
 match. An insertion and deletion, by contrast, are different normalized
 families and cannot share an identifier merely because they are adjacent.

--- a/docs/revision-id-policy.md
+++ b/docs/revision-id-policy.md
@@ -1,0 +1,70 @@
+# Revision Identifier Policy
+
+Safe Docx treats repeated tracked-change identifiers as a scoped comparison
+safety question, not as a universal OOXML uniqueness rule. The vendored
+ECMA-376 Transitional schema types tracked-change `w:id` values as decimal
+numbers but does not declare an XML Schema uniqueness constraint for revision
+wrappers.
+
+## Repository Policy
+
+One numeric revision identifier may occur on more than one sibling wrapper only
+when every wrapper has the same logical signature:
+
+- normalized revision family;
+- author;
+- timestamp; and
+- nearest containing paragraph, table cell, table row, or table scope.
+
+This permits serialization to split one logical deletion around a bookmark or
+another non-revision boundary without inventing a second logical revision. It
+does not permit an identifier to join unrelated changes. Reuse across scopes,
+authors, timestamps, or normalized revision families fails the corpus safety
+gate as `revision-id-reused-across-identities`.
+
+Property-change elements are one deliberate normalization. Paragraph, run,
+section, and table property-change records can be linked facets of one
+formatting revision, so the gate maps those raw element kinds to one
+`formatting-property-change` family when their remaining signature components
+match. An insertion and deletion, by contrast, are different normalized
+families and cannot share an identifier merely because they are adjacent.
+
+Comparison-authored identifiers are also checked against identifiers already
+present in the inputs. Reuse with a different signature fails as
+`comparison-id-collides-with-source`.
+
+The executable evidence is intentionally centralized in
+`collectRevisionIdIssues()` and the existing strategy-differential suite. The
+focused policy scenarios build minimal DOCX packages through the shared OOXML
+fixture builder; they do not introduce a second validator or a hand-built ZIP
+fixture.
+
+## Consumer Evidence
+
+The policy is narrower than any one consumer's serialization preference. The
+public minimized fixture behind [issue #926](https://github.com/UseJunior/safe-docx/issues/926)
+contains two same-ID sibling deletion fragments from one signature, separated
+by a bookmark boundary. It validates after the repository schema checker's
+Markup Compatibility preprocessing.
+
+| Consumer | Observed behavior on the public focused fixture | Boundary |
+|---|---|---|
+| Aspose.Words 25.7 | Loaded 14 revisions from the eight-wrapper input. An identity save retained 14 revisions but serialized 14 uniquely identified wrappers. Accept and Reject removed every revision and retained balanced bookmarks and resolved field targets. | Aspose normalization shows that it consumes the shared-ID input but prefers unique wrapper IDs when saving. It does not establish a normative rule. |
+| LibreOffice 26.2.5.2 | Opened and saved the input, and normalized the two sibling deletion fragments into one content-deletion wrapper. Its Accept projection matched Aspose exactly. | LibreOffice Reject produced three paragraphs and 77 package-visible characters, while Aspose produced three and 55; 55 matches the constructed original. Reject is therefore an explicit oracle disagreement, not ground truth. |
+| Microsoft Word | No safe isolated result is recorded yet because a user-document modal blocked the non-destructive probe. | No Word compatibility claim is made until that probe completes. |
+
+The public ILPA pair provides a broader Aspose check: its comparison serialized
+602 revision wrappers with unique IDs, balanced bookmarks, and resolved
+REF-family targets. Reject reproduced the original main-story text exactly.
+Accept had the revised document's paragraph and character counts but retained a
+small residual comparison difference, so full ILPA semantic equality is not
+claimed.
+
+## Decision Boundary
+
+The evidence supports accepting same-signature sibling fragments as one logical
+revision in the corpus gate. It does not show that every repeated-ID topology is
+safe, require Safe Docx to emit repeated IDs, or turn a consumer's rewrite into
+an ECMA-376 mandate. Cross-scope and cross-family collisions remain failures,
+and [issue #926](https://github.com/UseJunior/safe-docx/issues/926) remains open
+until the safe Word probe completes.

--- a/docs/trust-and-conformance.md
+++ b/docs/trust-and-conformance.md
@@ -82,5 +82,6 @@ Safe Docx makes document mutations inspectable and repeatable. It does not repla
 | [Invariant registry](../verification/INVARIANTS.md) | Verification claims, caveats, and falsifiers |
 | [Invariant registry](../verification/INVARIANTS.md) | Empirical and conventional evidence boundaries |
 | [Testing and evidence](testing-and-evidence.md) | Behavioral specifications, automated tests, and verification layers |
+| [Revision identifier policy](revision-id-policy.md) | Scoped logical revision IDs and consumer-oracle evidence |
 | [Core support contract](../packages/docx-core/SUPPORT.md) | AI-attributable edit behavior |
 | [MCP assumptions](../packages/docx-mcp/assumptions.md) | Runtime and tool assumptions |

--- a/openspec/specs/docx-comparison/spec.md
+++ b/openspec/specs/docx-comparison/spec.md
@@ -550,10 +550,10 @@ cell, table row, or table scope. Sibling wrappers MAY share an identifier only
 when every component of that signature is equal; the split wrappers then
 represent fragments of the same logical revision.
 
-Property-change elements (`w:pPrChange`, `w:rPrChange`, `w:sectPrChange`, and
-the table property-change forms) SHALL share one normalized property-change
-family so linked facets of one formatting revision can retain one identifier.
-Other element kinds SHALL remain distinct revision families.
+Property-change elements (`w:pPrChange`, `w:rPrChange`, `w:sectPrChange`, the
+table property-change forms, and `w:numberingChange`) SHALL share one normalized
+property-change family so linked facets of one formatting revision can retain
+one identifier. Other element kinds SHALL remain distinct revision families.
 
 Reuse across scopes, normalized families, authors, or timestamps SHALL fail the
 evidence gate as an allocator collision. A comparison-authored identifier that

--- a/openspec/specs/docx-comparison/spec.md
+++ b/openspec/specs/docx-comparison/spec.md
@@ -541,6 +541,45 @@ representation is exercised on any other class of input.
 - **THEN** accept SHALL reproduce the revised tree projection
 - **AND** reject SHALL reproduce the original tree projection
 
+### Requirement: Revision identifier reuse is scoped to one logical comparison revision
+
+The comparison evidence gate SHALL treat a revision identifier as identifying
+one scoped logical revision signature. A signature consists of the normalized
+revision family, author, timestamp, and nearest containing paragraph, table
+cell, table row, or table scope. Sibling wrappers MAY share an identifier only
+when every component of that signature is equal; the split wrappers then
+represent fragments of the same logical revision.
+
+Property-change elements (`w:pPrChange`, `w:rPrChange`, `w:sectPrChange`, and
+the table property-change forms) SHALL share one normalized property-change
+family so linked facets of one formatting revision can retain one identifier.
+Other element kinds SHALL remain distinct revision families.
+
+Reuse across scopes, normalized families, authors, or timestamps SHALL fail the
+evidence gate as an allocator collision. A comparison-authored identifier that
+collides with an input identifier carrying a different signature SHALL also
+fail. This is a repository safety policy backed by consumer evidence; it SHALL
+NOT be represented as an ECMA-376 uniqueness requirement.
+
+#### Scenario: Sibling fragments of one logical revision may share an identifier
+
+- **GIVEN** sibling wrappers with the same identifier, normalized family, author, timestamp, and containing scope
+- **WHEN** the revision-identifier evidence gate evaluates them
+- **THEN** it SHALL treat them as fragments of one logical revision
+
+#### Scenario: Revision identifier reuse across logical signatures fails
+
+- **GIVEN** wrappers that share an identifier across a different scope, normalized family, author, or timestamp
+- **WHEN** the revision-identifier evidence gate evaluates them
+- **THEN** it SHALL report `revision-id-reused-across-identities`
+- **AND** a comparison-authored collision with a differently signed input revision SHALL report `comparison-id-collides-with-source`
+
+#### Scenario: Linked property-change facets share a normalized logical signature
+
+- **GIVEN** linked property-change elements in the same scope with equal identifier, author, and timestamp
+- **WHEN** the revision-identifier evidence gate evaluates them
+- **THEN** it SHALL treat those facets as one normalized formatting revision
+
 ### Requirement: Tagged migration evidence is capability-complete
 
 Before a comparison capability is removed or changed, the system SHALL record

--- a/packages/docx-compare/src/integration/strategy-differential.test.ts
+++ b/packages/docx-compare/src/integration/strategy-differential.test.ts
@@ -333,6 +333,11 @@ describe('strategy differential manifest evidence', () => {
           `<w:p>${revision('ins', 'first')}` +
           `${revision('ins', 'second', 'Strategy Differential', '2026-08-18T12:00:00Z')}</w:p>`,
         ),
+        compareSourceXml(
+          `<w:p>${revision('ins', 'first')}` +
+          '<w:pPrChange w:id="7" w:author="Strategy Differential" ' +
+          'w:date="2026-08-17T12:00:00Z"><w:pPr/></w:pPrChange></w:p>',
+        ),
       ]);
 
       for (const candidate of cases) {

--- a/packages/docx-compare/src/integration/strategy-differential.test.ts
+++ b/packages/docx-compare/src/integration/strategy-differential.test.ts
@@ -44,6 +44,9 @@ const test = testAllure
     { spec: 'ECMA-376', edition: 5, part: 1, section: '17.16.18' },
     { spec: 'ECMA-376', edition: 5, part: 1, section: '17.16.5.45' },
   );
+const policyTest = testAllure
+  .epic('Document Comparison')
+  .withLabels({ feature: TEST_FEATURE });
 const DATE = new Date('2026-08-17T12:00:00Z');
 
 async function compareXml(
@@ -276,65 +279,91 @@ describe('strategy differential manifest evidence', () => {
     )).toThrow(/TD-UNOBSERVED-002/u);
   });
 
-  test('distinguishes split revision wrappers from allocator collisions', () => {
-    const documentBodyXml = (body: string): string =>
-      `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">` +
-      `<w:body>${body}</w:body></w:document>`;
-    const documentXml = (body: string): string => documentBodyXml(`<w:p>${body}</w:p>`);
-    const source = documentXml(
-      '<w:ins w:id="7" w:author="Human" w:date="2026-01-01T00:00:00Z">' +
-      '<w:r><w:t>source</w:t></w:r></w:ins>',
-    );
-    const comparison = (kind: 'ins' | 'del', text: string): string =>
-      `<w:${kind} w:id="7" w:author="Strategy Differential" ` +
-      `w:date="2026-08-17T12:00:00Z"><w:r><w:t>${text}</w:t></w:r></w:${kind}>`;
+  const revision = (
+    kind: 'ins' | 'del',
+    text: string,
+    author = 'Strategy Differential',
+    date = '2026-08-17T12:00:00Z',
+  ): string => {
+    const textElement = kind === 'del' ? 'delText' : 't';
+    return `<w:${kind} w:id="7" w:author="${author}" w:date="${date}">` +
+      `<w:r><w:${textElement}>${text}</w:${textElement}></w:r></w:${kind}>`;
+  };
 
-    expect(collectRevisionIdIssues(
-      documentXml(comparison('ins', 'a') + comparison('ins', 'b')),
-      documentXml(''),
-      documentXml(''),
-    )).toEqual([]);
-    expect(collectRevisionIdIssues(
-      documentBodyXml(
-        `<w:p>${comparison('ins', 'first')}</w:p>` +
-        `<w:p>${comparison('ins', 'second')}</w:p>`,
-      ),
-      documentXml(''),
-      documentXml(''),
-    )).toContain('revision-id-reused-across-identities:7');
-    const linkedPropertyChange = (kind: 'pPrChange' | 'rPrChange' | 'sectPrChange'): string =>
-      `<w:${kind} w:id="8" w:author="Strategy Differential" ` +
-      `w:date="2026-08-17T12:00:00Z"/>`;
-    expect(collectRevisionIdIssues(
-      documentXml(linkedPropertyChange('pPrChange') + linkedPropertyChange('sectPrChange')),
-      documentXml(''),
-      documentXml(''),
-    )).toEqual([]);
-    expect(collectRevisionIdIssues(
-      documentXml(linkedPropertyChange('pPrChange') + linkedPropertyChange('rPrChange')),
-      documentXml(''),
-      documentXml(''),
-    )).toEqual([]);
-    expect(collectRevisionIdIssues(
-      documentXml(comparison('ins', 'a')),
-      source,
-      documentXml(''),
-    )).toContain('comparison-id-collides-with-source:7');
-    expect(collectRevisionIdIssues(
-      documentXml(comparison('ins', 'a') + comparison('del', 'b')),
-      documentXml(''),
-      documentXml(''),
-    )).toContain('revision-id-reused-across-identities:7');
-    expect(collectRevisionIdIssues(
-      documentXml(
-        comparison('ins', 'a') +
-        '<w:pPrChange w:id="7" w:author="Strategy Differential" ' +
-        'w:date="2026-08-17T12:00:00Z"/>',
-      ),
-      documentXml(''),
-      documentXml(''),
-    )).toContain('revision-id-reused-across-identities:7');
-  });
+  policyTest.openspec('Sibling fragments of one logical revision may share an identifier')(
+    'allows same-signature sibling fragments separated by a bookmark boundary',
+    async () => {
+      const [candidate, emptySource] = await Promise.all([
+        compareSourceXml(
+          '<w:p>' + revision('del', 'first') +
+          '<w:bookmarkStart w:id="1" w:name="Boundary"/>' +
+          revision('del', 'second') +
+          '<w:bookmarkEnd w:id="1"/></w:p>',
+        ),
+        compareSourceXml('<w:p/>'),
+      ]);
+
+      expect(collectRevisionIdIssues(candidate, emptySource, emptySource)).toEqual([]);
+    },
+  );
+
+  policyTest.openspec('Revision identifier reuse across logical signatures fails')(
+    'rejects cross-scope, cross-kind, metadata, and source collisions',
+    async () => {
+      const [emptySource, source] = await Promise.all([
+        compareSourceXml('<w:p/>'),
+        compareSourceXml(`<w:p>${revision(
+          'ins',
+          'source',
+          'Human',
+          '2026-01-01T00:00:00Z',
+        )}</w:p>`),
+      ]);
+      const issue = 'revision-id-reused-across-identities:7';
+      const cases = await Promise.all([
+        compareSourceXml(
+          `<w:p>${revision('ins', 'first')}</w:p>` +
+          `<w:p>${revision('ins', 'second')}</w:p>`,
+        ),
+        compareSourceXml(`<w:p>${revision('ins', 'first')}${revision('del', 'second')}</w:p>`),
+        compareSourceXml(
+          `<w:p>${revision('ins', 'first')}${revision('ins', 'second', 'Another Author')}</w:p>`,
+        ),
+        compareSourceXml(
+          `<w:p>${revision('ins', 'first')}` +
+          `${revision('ins', 'second', 'Strategy Differential', '2026-08-18T12:00:00Z')}</w:p>`,
+        ),
+      ]);
+
+      for (const candidate of cases) {
+        expect(collectRevisionIdIssues(candidate, emptySource, emptySource)).toContain(issue);
+      }
+
+      const candidate = await compareSourceXml(`<w:p>${revision('ins', 'comparison')}</w:p>`);
+      expect(collectRevisionIdIssues(candidate, source, emptySource))
+        .toContain('comparison-id-collides-with-source:7');
+    },
+  );
+
+  policyTest.openspec('Linked property-change facets share a normalized logical signature')(
+    'allows linked property-change facets in the same paragraph scope',
+    async () => {
+      const propertyChangeAttributes =
+        'w:id="8" w:author="Strategy Differential" w:date="2026-08-17T12:00:00Z"';
+      const [candidate, emptySource] = await Promise.all([
+        compareSourceXml(
+          '<w:p><w:pPr>' +
+          `<w:pPrChange ${propertyChangeAttributes}><w:pPr/></w:pPrChange>` +
+          '<w:rPr>' +
+          `<w:rPrChange ${propertyChangeAttributes}><w:rPr/></w:rPrChange>` +
+          '</w:rPr></w:pPr><w:r><w:t>same paragraph</w:t></w:r></w:p>',
+        ),
+        compareSourceXml('<w:p/>'),
+      ]);
+
+      expect(collectRevisionIdIssues(candidate, emptySource, emptySource)).toEqual([]);
+    },
+  );
 });
 
 async function compareSourceXml(bodyXml: string): Promise<string> {

--- a/packages/docx-core/src/testing/DOCX_COMPARISON_OPENSPEC_TRACEABILITY.md
+++ b/packages/docx-core/src/testing/DOCX_COMPARISON_OPENSPEC_TRACEABILITY.md
@@ -38,6 +38,7 @@ This matrix maps docx-core OpenSpec `#### Scenario:` entries to scenario mapping
 | Get format change revisions | covered | `packages/docx-compare/src/openspec.traceability.test.ts` |  |
 | Identical text returns one | covered | `packages/docx-compare/src/openspec.traceability.test.ts` |  |
 | Known property has a friendly name | covered | `packages/docx-compare/src/openspec.traceability.test.ts` |  |
+| Linked property-change facets share a normalized logical signature | covered | `packages/docx-compare/src/integration/strategy-differential.test.ts` |  |
 | Matched formatting difference receives format status | covered | `packages/docx-compare/src/openspec.traceability.test.ts` |  |
 | Matched-but-differing nodes retain both representatives | covered | `packages/docx-compare/src/tagged/taggedTree.test.ts` |  |
 | Missing corpus evidence fails loudly | covered | `packages/docx-compare/src/integration/strategy-differential-manifest.corpus.test.ts`, `packages/docx-compare/src/integration/strategy-differential.test.ts` |  |
@@ -62,9 +63,11 @@ This matrix maps docx-core OpenSpec `#### Scenario:` entries to scenario mapping
 | Reserved footnote IDs excluded from numbering | covered | `packages/docx-compare/src/openspec.traceability.test.ts` |  |
 | Residual matching is globally deterministic | covered | `packages/docx-compare/src/tagged/taggedTreeConstruction.test.ts` |  |
 | Revision and bookmark identifiers may overlap numerically | covered | `packages/docx-compare/src/integration/strategy-differential.test.ts` |  |
+| Revision identifier reuse across logical signatures fails | covered | `packages/docx-compare/src/integration/strategy-differential.test.ts` |  |
 | Sequential numbering ignores XML IDs | covered | `packages/docx-compare/src/openspec.traceability.test.ts` |  |
 | Serialized multi-author stacks preserve both projections | covered | `packages/docx-compare/src/tagged/taggedTreeSerializer.test.ts` |  |
 | Serialized wrapper transformations determine range totals | covered | `packages/docx-compare/src/openspec.traceability.test.ts`, `packages/docx-compare/src/tagged/taggedTreeStatistics.test.ts` |  |
+| Sibling fragments of one logical revision may share an identifier | covered | `packages/docx-compare/src/integration/strategy-differential.test.ts` |  |
 | Skipped soak remains explicit | covered | `packages/docx-compare/src/openspec.traceability.test.ts` |  |
 | Standalone publication has no legacy assembly dependency | covered | `packages/docx-compare/src/tagged/taggedTreeShadow.test.ts` |  |
 | Tagged emission produces one range pair per logical move | covered | `packages/docx-compare/src/openspec.traceability.test.ts` |  |


### PR DESCRIPTION
## Why

Issue #926 exposed an important distinction between one logical tracked change split across sibling OOXML wrappers and an unsafe revision-ID allocator collision. The repository already enforced that distinction after #930, but the policy and consumer evidence were not committed as a focused, traceable decision.

## What changed

- document the repository policy: sibling wrappers may share an ID only when normalized revision family, author, timestamp, and nearest paragraph/table scope all match;
- keep insertions, deletions, and other revision families distinct while normalizing linked paragraph/run/section/table/numbering property-change facets;
- replace #930's monolithic validator test with focused OpenSpec scenarios using the existing validator and shared DOCX builder;
- retain rejection coverage for cross-scope, cross-kind, author/date, `w:ins` + property-change, and comparison-vs-source collisions;
- record bounded public Aspose.Words 25.7 and LibreOffice 26.2.5.2 observations, their Reject-oracle disagreement, and the still-pending Microsoft Word boundary.

This PR changes no production behavior and makes no ECMA-376 uniqueness claim.

## Evidence

- exact merge base at publication: `a1f303966c529ca06c8f100a25186807a627f541` (`origin/main`)
- focused strategy-differential suite: 8/8 passed
- strict OpenSpec validation: 8/8 specs passed
- spec traceability: docx-comparison 65/65 scenarios mapped
- full repository pre-submit passed:
  - `npm run build`
  - `npm run lint:workspaces`
  - `npm run test:run`
  - `npm run check:spec-coverage`
  - `npm run check:conformance-citations`
  - `npm run check:conformance-doc`

## Peer review

Claude Opus 4.6 dynamically reviewed a sanitized public-only copy containing zero Word documents. It executed the focused tests, strict OpenSpec validation, spec coverage, build/lint/conformance checks, requested three non-blocking corrections, and returned **APPROVE** after independently executing the corrected cases.

## Issue state

Ref: #926

The issue intentionally remains open until the separate safe Microsoft Word probe completes.
