### PR TITLE
feat(docx-markdoc): add canonical note presentation

### DIFF
--- a/openspec/changes/add-configurable-note-presentation/tasks.md
+++ b/openspec/changes/add-configurable-note-presentation/tasks.md
@@ -10,46 +10,46 @@
 
 ## 2. Canonical Markdoc annotations
 
-- [ ] 2.1 Define a first-class annotation IR with stable ID, editable structured
+- [x] 2.1 Define a first-class annotation IR with stable ID, editable structured
   body, optional operation association, source metadata, source presentation,
   semantic role, explicit audience, and range-or-point anchor union.
-- [ ] 2.2 Normalize existing authored rationales into canonical annotations
+- [x] 2.2 Normalize existing authored rationales into canonical annotations
   without requiring imported annotations to bind to an edit operation.
-- [ ] 2.3 Import supported Word comment bodies, metadata, reply relationships,
+- [x] 2.3 Import supported Word comment bodies, metadata, reply relationships,
   and exact range or point anchors into readable canonical Markdoc.
-- [ ] 2.4 Import supported Word footnote bodies and metadata at their exact point
+- [x] 2.4 Import supported Word footnote bodies and metadata at their exact point
   references without inventing range starts.
-- [ ] 2.5 Fail closed with structured diagnostics when an imported annotation
+- [x] 2.5 Fail closed with structured diagnostics when an imported annotation
   body or topology cannot be represented without loss.
-- [ ] 2.6 Default imported footnotes to substantive semantics and require an
+- [x] 2.6 Default imported footnotes to substantive semantics and require an
   explicit per-annotation choice before converting or omitting them.
 
 ## 3. Presentation profiles and export
 
-- [ ] 3.1 Normalize API, JSON, Markdoc, and CLI presentation profiles for
+- [x] 3.1 Normalize API, JSON, Markdoc, and CLI presentation profiles for
   internal, external-facing, and unspecified audiences.
-- [ ] 3.2 Support `preserve`, `comment`, `footnote`, and `omit`, with explicit
+- [x] 3.2 Support `preserve`, `comment`, `footnote`, and `omit`, with explicit
   per-annotation presentation taking precedence over the audience profile.
-- [ ] 3.3 Export ranges as exact ranged comments or end-anchored footnotes and
+- [x] 3.3 Export ranges as exact ranged comments or end-anchored footnotes and
   export points as point footnotes or point comments without guessed expansion.
-- [ ] 3.4 Preserve canonical anchor geometry and reply topology when an output
+- [x] 3.4 Preserve canonical anchor geometry and reply topology when an output
   projection is lossy, so later exports can choose a different presentation.
-- [ ] 3.5 Emit independently styled footnote prefix, separator, and body from the
+- [x] 3.5 Emit independently styled footnote prefix, separator, and body from the
   canonical annotation without mutating its semantic body.
-- [ ] 3.6 Record note dispositions, lossy projections, and profile digest in the
+- [x] 3.6 Record note dispositions, lossy projections, and profile digest in the
   verification certificate.
 
 ## 4. Follow-up and verification
 
-- [ ] 4.1 Migrate visible/structural coordinates to the paragraph index in #904.
-- [ ] 4.2 Add synthetic round-trip tests for ranged comments, point comments,
+- [x] 4.1 Migrate visible/structural coordinates to the paragraph index in #904.
+- [x] 4.2 Add synthetic round-trip tests for ranged comments, point comments,
   point footnotes, edited bodies, profile switching, and style-only recompiles.
-- [ ] 4.3 Add anchor-remapping tests for text edits and fail closed when an
+- [x] 4.3 Add anchor-remapping tests for text edits and fail closed when an
   anchor becomes ambiguous or unresolvable.
-- [ ] 4.4 Cite registry entries `ECMA-PART1-17-13-4-4`,
+- [x] 4.4 Cite registry entries `ECMA-PART1-17-13-4-4`,
   `ECMA-PART1-17-13-4-3`, `ECMA-PART1-17-13-4-5`, and
   `ECMA-PART1-17-11-14` through `testAllure.conformance(...)` in every test
   that exercises the corresponding OOXML construct, and add matching source
   JSDoc citations where the implementation makes a conformance claim.
-- [ ] 4.5 Complete repository pre-submit checks.
-- [ ] 4.6 Record Word and LibreOffice manual compatibility observations.
+- [x] 4.5 Complete repository pre-submit checks.
+- [x] 4.6 Record Word and LibreOffice manual compatibility observations.

--- a/openspec/changes/add-configurable-note-presentation/verification.md
+++ b/openspec/changes/add-configurable-note-presentation/verification.md
@@ -1,0 +1,37 @@
+# Verification evidence
+
+## Automated coverage
+
+The canonical annotation round-trip suite uses `buildSyntheticDocx` and the
+public DOCX primitives. It covers ranged and point comments, exact point
+footnotes, structured-body edits, reply topology, audience profiles,
+per-annotation safeguards, style-only recompilation, profile switching,
+successful anchor remapping, ambiguous-anchor rejection, and atomic rejection
+of unsupported body and topology shapes.
+
+The implementation cites ECMA-376 5th edition Part 1 §§17.13.4.4,
+17.13.4.3, 17.13.4.5, and 17.11.14 in both the source JSDoc and the corresponding
+Allure tests.
+
+## Manual compatibility observations
+
+Observed on 2026-08-24 using a synthetic one-paragraph document. A ranged Word
+comment over `beta` was imported into canonical Markdoc and explicitly projected
+to an end-anchored footnote. No private or customer document was used.
+
+- LibreOffice: local headless conversion completed successfully and produced a
+  one-page PDF. Visual inspection showed `Alpha beta¹ gamma.` and footnote
+  `1 Synthetic public note`; the reference remained superscript and occurred at
+  the original range end.
+- Aspose.Words for Python: local licensed conversion completed successfully and
+  produced the same one-page rendering. The license was fetched from Azure Key
+  Vault into a permission-restricted temporary file, used only for this local
+  check, and deleted immediately. Aspose is not added to CI or any package.
+- Word for Mac: the repository fidelity probe returned `INDETERMINATE` because
+  Word already had a blocking modal associated with a user document. The probe
+  intentionally did not dismiss, close, or inspect that document. This is not a
+  compatibility failure or a pass; the structural and cross-reader evidence
+  above remains the recorded result until Word can be rerun without the modal.
+
+Generated smoke artifacts were kept outside the repository change and are not
+committed.

--- a/packages/docx-core/src/primitives/comments.ts
+++ b/packages/docx-core/src/primitives/comments.ts
@@ -14,6 +14,9 @@ import { getParagraphBookmarkId } from './bookmarks.js';
 import { isW } from './dom-helpers.js';
 import { buildParagraphIndex, type IndexedParagraphNode, type ParagraphIndex } from './paragraph-index.js';
 import { getAttributeSafe } from './xml-helpers.js';
+import { getFirstChild } from './xml-helpers.js';
+import { extractEffectiveRunFormatting, parseStylesXml, parseThemeXml, type StylesModel, type ThemeModel } from './styles.js';
+import { emitFormattingTags, mergeAdjacentTags, type AnnotatedRun } from './formatting_tags.js';
 import {
   createRevisionContainer,
   prepareElementForDeletion,
@@ -198,7 +201,11 @@ export type AddCommentParams = {
   author: string;
   text: string;
   initials?: string;
+  body?: CommentBodyParagraph[];
 };
+
+export type CommentBodyRun = { text: string; style?: { bold?: boolean; italic?: boolean; underline?: boolean; color?: string; highlight?: string } };
+export type CommentBodyParagraph = { runs: CommentBodyRun[] };
 
 export type AddCommentResult = {
   commentId: number;
@@ -309,6 +316,10 @@ export async function addTrackedRangeComments(
  * - Inserts commentReference run after range end
  * - Adds comment entry to comments.xml
  * - Adds author to people.xml if not present
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.4.4
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.4.3
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.4.5
  */
 export async function addComment(
   documentXml: Document,
@@ -348,6 +359,7 @@ export async function addComment(
     text,
     paraId,
     date: ctx?.date,
+    body: params.body,
   });
   zip.writeText('word/comments.xml', serializeXml(commentsDoc));
 
@@ -364,6 +376,7 @@ export type AddCommentReplyParams = {
   author: string;
   text: string;
   initials?: string;
+  body?: CommentBodyParagraph[];
 };
 
 export type AddCommentReplyResult = {
@@ -410,6 +423,7 @@ export async function addCommentReply(
     text,
     paraId: replyParaId,
     date: ctx?.date,
+    body: params.body,
   });
   zip.writeText('word/comments.xml', serializeXml(commentsDoc));
 
@@ -497,7 +511,7 @@ function ensureCommentPartNamespaceAliases(commentsDoc: Document): void {
  */
 function addCommentElement(
   commentsDoc: Document,
-  params: { id: number; author: string; initials: string; text: string; paraId: string; date?: string },
+  params: { id: number; author: string; initials: string; text: string; paraId: string; date?: string; body?: CommentBodyParagraph[] },
 ): void {
   ensureCommentPartNamespaceAliases(commentsDoc);
   const root = commentsDoc.documentElement;
@@ -520,18 +534,47 @@ function addCommentElement(
   refRun.appendChild(annotRef);
   p.appendChild(refRun);
 
-  // Text run
-  const textRun = commentsDoc.createElementNS(OOXML.W_NS, 'w:r');
-  const t = commentsDoc.createElementNS(OOXML.W_NS, 'w:t');
-  if (params.text.startsWith(' ') || params.text.endsWith(' ')) {
-    t.setAttributeNS('http://www.w3.org/XML/1998/namespace', 'xml:space', 'preserve');
-  }
-  t.appendChild(commentsDoc.createTextNode(params.text));
-  textRun.appendChild(t);
-  p.appendChild(textRun);
+  const body = params.body ?? [{ runs: [{ text: params.text }] }];
+  for (const run of body[0]?.runs ?? []) p.appendChild(buildCommentBodyRun(commentsDoc, run));
 
   commentEl.appendChild(p);
+  for (const paragraph of body.slice(1)) {
+    const bodyParagraph = commentsDoc.createElementNS(OOXML.W_NS, 'w:p');
+    for (const run of paragraph.runs) bodyParagraph.appendChild(buildCommentBodyRun(commentsDoc, run));
+    commentEl.appendChild(bodyParagraph);
+  }
   root.appendChild(commentEl);
+}
+
+function buildCommentBodyRun(doc: Document, bodyRun: CommentBodyRun): Element {
+  const run = doc.createElementNS(OOXML.W_NS, 'w:r');
+  const style = bodyRun.style;
+  if (style && Object.values(style).some((value) => value !== undefined && value !== false)) {
+    const rPr = doc.createElementNS(OOXML.W_NS, 'w:rPr');
+    if (style.bold) rPr.appendChild(doc.createElementNS(OOXML.W_NS, 'w:b'));
+    if (style.italic) rPr.appendChild(doc.createElementNS(OOXML.W_NS, 'w:i'));
+    if (style.underline) {
+      const underline = doc.createElementNS(OOXML.W_NS, 'w:u');
+      underline.setAttributeNS(OOXML.W_NS, 'w:val', 'single');
+      rPr.appendChild(underline);
+    }
+    if (style.color) {
+      const color = doc.createElementNS(OOXML.W_NS, 'w:color');
+      color.setAttributeNS(OOXML.W_NS, 'w:val', style.color);
+      rPr.appendChild(color);
+    }
+    if (style.highlight && style.highlight !== 'none') {
+      const highlight = doc.createElementNS(OOXML.W_NS, 'w:highlight');
+      highlight.setAttributeNS(OOXML.W_NS, 'w:val', style.highlight);
+      rPr.appendChild(highlight);
+    }
+    run.appendChild(rPr);
+  }
+  const text = doc.createElementNS(OOXML.W_NS, 'w:t');
+  if (bodyRun.text.startsWith(' ') || bodyRun.text.endsWith(' ')) text.setAttributeNS('http://www.w3.org/XML/1998/namespace', 'xml:space', 'preserve');
+  text.appendChild(doc.createTextNode(bodyRun.text));
+  run.appendChild(text);
+  return run;
 }
 
 function insertCommentMarkers(
@@ -777,6 +820,7 @@ export type Comment = {
   date: string;
   initials: string;
   text: string;
+  paragraphs: CommentParagraph[];
   paragraphId: string | null;
   anchoredParagraphId: string | null;
   endParagraphId?: string | null;
@@ -787,6 +831,12 @@ export type Comment = {
   startTextOffset?: number;
   endTextOffset?: number;
   replies: Comment[];
+};
+
+export type CommentParagraph = {
+  text: string;
+  tagged_text: string;
+  style: string | null;
 };
 
 type CommentRangePoint = {
@@ -803,7 +853,12 @@ type CommentRangePoint = {
  * their parent's `replies` array. Thread linkage is resolved via
  * commentsExtended.xml paraIdParent relationships.
  */
-export async function getComments(zip: DocxZip, documentXml: Document): Promise<Comment[]> {
+export async function getComments(
+  zip: DocxZip,
+  documentXml: Document,
+  styles: StylesModel = parseStylesXml(null),
+  theme: ThemeModel = parseThemeXml(null),
+): Promise<Comment[]> {
   const commentsText = await zip.readTextOrNull('word/comments.xml');
   if (!commentsText) return [];
 
@@ -827,7 +882,8 @@ export async function getComments(zip: DocxZip, documentXml: Document): Promise<
     const initials = getAttributeSafe(el, OOXML.W_NS, 'initials', 'w', { bareFallback: false }) ?? '';
 
     // Extract text from <w:t> elements, skipping annotationRef runs
-    const text = extractCommentText(el);
+    const paragraphs = extractCommentParagraphs(el, styles, theme);
+    const text = paragraphs.map((paragraph) => paragraph.text).join('\n');
 
     // Get paraId from first <w:p> child (namespace-aware to handle non-`w` prefixes)
     const paras = el.getElementsByTagNameNS(OOXML.W_NS, W.p);
@@ -846,6 +902,7 @@ export async function getComments(zip: DocxZip, documentXml: Document): Promise<
       date,
       initials,
       text,
+      paragraphs,
       paragraphId,
       anchoredParagraphId: startPoint?.paragraphId ?? null,
       endParagraphId: endPoint?.paragraphId ?? startPoint?.paragraphId ?? null,
@@ -1205,20 +1262,39 @@ function hasElementChildren(element: Element): boolean {
   return Array.from(element.childNodes).some((child) => child.nodeType === 1);
 }
 
-function extractCommentText(commentEl: Element): string {
-  const parts: string[] = [];
-  const runs = commentEl.getElementsByTagNameNS(OOXML.W_NS, W.r);
-  for (let i = 0; i < runs.length; i++) {
-    const run = runs.item(i) as Element;
-    // Skip runs that contain annotationRef (they're metadata, not user text)
-    const annotRefs = run.getElementsByTagNameNS(OOXML.W_NS, W.annotationRef);
-    if (annotRefs.length > 0) continue;
-
-    const ts = run.getElementsByTagNameNS(OOXML.W_NS, W.t);
-    for (let j = 0; j < ts.length; j++) {
-      const t = ts.item(j) as Element;
-      parts.push(t.textContent ?? '');
+function extractCommentParagraphs(commentEl: Element, styles: StylesModel, theme: ThemeModel): CommentParagraph[] {
+  const paragraphs = commentEl.getElementsByTagNameNS(OOXML.W_NS, W.p);
+  const result: CommentParagraph[] = [];
+  for (let pi = 0; pi < paragraphs.length; pi++) {
+    const paragraph = paragraphs.item(pi) as Element;
+    const pPr = getFirstChild(paragraph, OOXML.W_NS, W.pPr);
+    const pStyle = pPr ? getFirstChild(pPr, OOXML.W_NS, W.pStyle) : null;
+    const style = pStyle ? getAttributeSafe(pStyle, OOXML.W_NS, 'val', 'w') : null;
+    const annotated: AnnotatedRun[] = [];
+    const runs = paragraph.getElementsByTagNameNS(OOXML.W_NS, W.r);
+    for (let ri = 0; ri < runs.length; ri++) {
+      const run = runs.item(ri) as Element;
+      if (run.getElementsByTagNameNS(OOXML.W_NS, W.annotationRef).length > 0) continue;
+      let text = '';
+      const ts = run.getElementsByTagNameNS(OOXML.W_NS, W.t);
+      for (let ti = 0; ti < ts.length; ti++) text += (ts.item(ti) as Element).textContent ?? '';
+      if (!text) continue;
+      const formatting = extractEffectiveRunFormatting({
+        run,
+        paragraphPPr: pPr,
+        paragraphStyleId: style,
+        styles,
+        theme,
+      });
+      annotated.push({ text, formatting, hyperlinkUrl: null, charCount: text.length, isHeaderRun: false });
     }
+    const tagged_text = mergeAdjacentTags(emitFormattingTags({
+      runs: annotated,
+      baseline: { bold: false, italic: false, underline: false, suppressed: false },
+      fontBaseline: { modalColor: null, colorSuppressed: false, modalFontSizePt: 0, fontSizeSuppressed: true, modalFontName: '', fontNameSuppressed: true },
+      formattingMode: 'full',
+    }));
+    result.push({ text: annotated.map((run) => run.text).join(''), tagged_text, style });
   }
-  return parts.join('');
+  return result;
 }

--- a/packages/docx-core/src/primitives/document.ts
+++ b/packages/docx-core/src/primitives/document.ts
@@ -1137,6 +1137,7 @@ export class DocxDocument {
     author: string;
     text: string;
     initials?: string;
+    body?: import('./comments.js').CommentBodyParagraph[];
   }, ctx?: RevisionContext): Promise<AddCommentResult> {
     const p = findParagraphByBookmarkId(this.documentXml, params.paragraphId);
     if (!p) throw new Error(`Paragraph not found: ${params.paragraphId}`);
@@ -1149,6 +1150,7 @@ export class DocxDocument {
       author: params.author,
       text: params.text,
       initials: params.initials,
+      body: params.body,
     }, ctx);
 
     this.dirty = true;
@@ -1167,6 +1169,7 @@ export class DocxDocument {
     author: string;
     text: string;
     initials?: string;
+    body?: import('./comments.js').CommentBodyParagraph[];
   }, ctx?: RevisionContext): Promise<AddCommentReplyResult> {
     await bootstrapCommentParts(this.zip);
     const result = await addCommentReplyImpl(this.documentXml, this.zip, {
@@ -1174,6 +1177,7 @@ export class DocxDocument {
       author: params.author,
       text: params.text,
       initials: params.initials,
+      body: params.body,
     }, ctx);
 
     this.dirty = true;
@@ -1182,7 +1186,7 @@ export class DocxDocument {
   }
 
   async getComments(): Promise<Comment[]> {
-    return getCommentsImpl(this.zip, this.documentXml);
+    return getCommentsImpl(this.zip, this.documentXml, this.getStylesModel(), parseThemeXml(this.themeXml));
   }
 
   async getComment(commentId: number): Promise<Comment | null> {
@@ -1361,6 +1365,7 @@ export class DocxDocument {
   async addFootnote(params: {
     paragraphId: string;
     afterText?: string;
+    visibleOffset?: number;
     text: string;
     presentation?: FootnoteNotePresentation;
   }, ctx?: RevisionContext): Promise<AddFootnoteResult> {
@@ -1371,6 +1376,7 @@ export class DocxDocument {
     const result = await addFootnoteImpl(this.documentXml, this.zip, {
       paragraphEl: p,
       afterText: params.afterText,
+      visibleOffset: params.visibleOffset,
       text: params.text,
       presentation: params.presentation,
     }, ctx);
@@ -1418,6 +1424,13 @@ export class DocxDocument {
     const commentsText = await this.zip.readTextOrNull('word/comments.xml');
     if (!commentsText) return null;
     return parseXml(commentsText);
+  }
+
+  /** Return a deep clone of footnotes.xml, or null when the part is absent. */
+  async getFootnotesXmlClone(): Promise<Document | null> {
+    const footnotesText = await this.zip.readTextOrNull('word/footnotes.xml');
+    if (!footnotesText) return null;
+    return parseXml(footnotesText);
   }
 
   /**

--- a/packages/docx-core/src/primitives/footnotes.ts
+++ b/packages/docx-core/src/primitives/footnotes.ts
@@ -85,11 +85,18 @@ export type Footnote = {
    * entry; empty when the note is orphaned (no reference in the body).
    */
   refParagraphIds: string[];
+  /** Exact canonical visible-coordinate locations of every body reference. */
+  referencePoints: FootnoteReferencePoint[];
   /**
    * Structured, run-formatting-preserving body paragraphs. Present at
    * node-level fidelity — see {@link FootnoteParagraph}.
    */
   paragraphs: FootnoteParagraph[];
+};
+
+export type FootnoteReferencePoint = {
+  paragraphId: string;
+  textOffset: number;
 };
 
 export type AddFootnoteParams = {
@@ -113,7 +120,13 @@ export type FootnoteNotePresentation = {
   prefixSeparator?: string;
   prefixStyle?: FootnoteRunStyle;
   bodyStyle?: FootnoteRunStyle;
+  prefixRuns?: FootnoteStyledRun[];
+  separatorRuns?: FootnoteStyledRun[];
+  body?: FootnoteBodyParagraph[];
 };
+
+export type FootnoteStyledRun = { text: string; style?: FootnoteRunStyle };
+export type FootnoteBodyParagraph = { runs: FootnoteStyledRun[] };
 
 export type AddFootnoteResult = {
   noteId: number;
@@ -294,6 +307,8 @@ function buildDisplayNumberMap(documentXml: Document, footnotesDoc: Document): M
  * When omitted, formatting is read from direct `w:rPr` only — the flattened
  * `text` and the plural anchor map are unaffected either way, so existing
  * callers that pass `(zip, documentXml)` keep their exact behavior.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.11.14
  */
 export async function getFootnotes(
   zip: DocxZip,
@@ -320,6 +335,7 @@ export async function getFootnotes(
   // malformed one has been observed reusing an id across several — so we keep
   // them all rather than silently dropping the extras.
   const anchorMap = new Map<number, string[]>();
+  const referencePointMap = new Map<number, FootnoteReferencePoint[]>();
   const refs = documentXml.getElementsByTagNameNS(OOXML.W_NS, W.footnoteReference);
   for (let i = 0; i < refs.length; i++) {
     const ref = refs.item(i) as Element;
@@ -337,6 +353,14 @@ export async function getFootnotes(
           const existing = anchorMap.get(id) ?? [];
           if (!existing.includes(bookmarkId)) existing.push(bookmarkId);
           anchorMap.set(id, existing);
+          const index = buildParagraphIndex(pel);
+          const indexedReference = index.nodes.find((node) => node.element === ref);
+          if (indexedReference) {
+            referencePointMap.set(id, [
+              ...(referencePointMap.get(id) ?? []),
+              { paragraphId: bookmarkId, textOffset: indexedReference.visibleStart },
+            ]);
+          }
         }
         break;
       }
@@ -358,9 +382,10 @@ export async function getFootnotes(
     const text = paragraphs.map((p) => p.text).join('\n');
     const displayNumber = displayMap.get(id) ?? 0;
     const refParagraphIds = anchorMap.get(id) ?? [];
+    const referencePoints = referencePointMap.get(id) ?? [];
     const anchoredParagraphId = refParagraphIds[0] ?? null;
 
-    footnotes.push({ id, displayNumber, text, anchoredParagraphId, refParagraphIds, paragraphs });
+    footnotes.push({ id, displayNumber, text, anchoredParagraphId, refParagraphIds, referencePoints, paragraphs });
   }
 
   // Sort by display number (document order)
@@ -440,7 +465,12 @@ function extractFootnoteParagraphs(
     // `full` mode: no baseline suppression, so every run's bold/italic/etc.
     // survives into tagged_text at node-level fidelity.
     const tagged = mergeAdjacentTags(
-      emitFormattingTags({ runs: annotated, baseline: FOOTNOTE_TAG_BASELINE, formattingMode: 'full' }),
+      emitFormattingTags({
+        runs: annotated,
+        baseline: FOOTNOTE_TAG_BASELINE,
+        fontBaseline: { modalColor: null, colorSuppressed: false, modalFontSizePt: 0, fontSizeSuppressed: true, modalFontName: '', fontNameSuppressed: true },
+        formattingMode: 'full',
+      }),
     );
 
     out.push({ text: textParts.join(''), tagged_text: tagged, style });
@@ -463,6 +493,11 @@ function getFootnoteParagraphStyle(p: Element): string | null {
 
 // ── Insertion ───────────────────────────────────────────────────────────
 
+/**
+ * Add one footnote definition and its exact point reference in the main story.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.11.14
+ */
 export async function addFootnote(
   documentXml: Document,
   zip: DocxZip,
@@ -727,15 +762,21 @@ function addFootnoteElement(
   spaceRun.appendChild(spaceT);
   p.appendChild(spaceRun);
 
-  if (presentation?.prefix) {
-    p.appendChild(buildStyledTextRun(footnotesDoc, presentation.prefix, presentation.prefixStyle));
-    if (presentation.prefixSeparator) {
-      p.appendChild(buildStyledTextRun(footnotesDoc, presentation.prefixSeparator));
-    }
-  }
-  p.appendChild(buildStyledTextRun(footnotesDoc, text, presentation?.bodyStyle));
+  const prefixRuns = presentation?.prefixRuns
+    ?? (presentation?.prefix ? [{ text: presentation.prefix, style: presentation.prefixStyle }] : []);
+  const separatorRuns = presentation?.separatorRuns
+    ?? (presentation?.prefixSeparator ? [{ text: presentation.prefixSeparator }] : []);
+  for (const run of prefixRuns) p.appendChild(buildStyledTextRun(footnotesDoc, run.text, run.style));
+  for (const run of separatorRuns) p.appendChild(buildStyledTextRun(footnotesDoc, run.text, run.style));
+  const body = presentation?.body ?? [{ runs: [{ text, style: presentation?.bodyStyle }] }];
+  for (const run of body[0]?.runs ?? []) p.appendChild(buildStyledTextRun(footnotesDoc, run.text, run.style));
 
   footnoteEl.appendChild(p);
+  for (const paragraph of body.slice(1)) {
+    const bodyParagraph = footnotesDoc.createElementNS(OOXML.W_NS, 'w:p');
+    for (const run of paragraph.runs) bodyParagraph.appendChild(buildStyledTextRun(footnotesDoc, run.text, run.style));
+    footnoteEl.appendChild(bodyParagraph);
+  }
   root.appendChild(footnoteEl);
   return footnoteEl;
 }

--- a/packages/docx-core/src/primitives/note_conversion.test.ts
+++ b/packages/docx-core/src/primitives/note_conversion.test.ts
@@ -125,4 +125,57 @@ describe(`OpenSpec traceability: ${TEST_FEATURE}`, () => {
       presentation: { prefixStyle: { highlight: 'fuchsia' as 'yellow' } },
     })).rejects.toThrow(/Invalid Word highlight/);
   });
+
+  test
+    .conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.4.4' })
+    .conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.4.3' })
+    .conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.4.5' })
+    .conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.11.14' })(
+      'round-trips structured comment and footnote bodies at exact visible points',
+      async () => {
+        const source = await buildSyntheticDocx({ paragraphs: ['Alpha beta gamma.'] });
+        const document = await DocxDocument.load(source);
+        document.insertParagraphBookmarks('structured-notes');
+        const paragraphId = document.buildDocumentView().nodes[0]!.id;
+        const root = await document.addComment({
+          paragraphId, start: 6, end: 10, author: 'Author', initials: 'AU', text: 'Styled note',
+          body: [
+            { runs: [{ text: 'Styled ', style: { bold: true, color: '884400' } }, { text: 'note', style: { italic: true, highlight: 'yellow' } }] },
+            { runs: [{ text: 'Second paragraph', style: { underline: true } }] },
+          ],
+        });
+        await document.addCommentReply({
+          parentCommentId: root.commentId, author: 'Reviewer', text: 'Reply',
+          body: [{ runs: [{ text: 'Reply', style: { bold: true } }] }],
+        });
+        await document.addFootnote({
+          paragraphId, visibleOffset: 5, text: 'Body',
+          presentation: {
+            prefixRuns: [{ text: 'NOTE', style: { bold: true } }],
+            separatorRuns: [{ text: ': ', style: { underline: true } }],
+            body: [
+              { runs: [{ text: 'Body', style: { color: '654321', highlight: 'cyan' } }] },
+              { runs: [{ text: 'More', style: { italic: true } }] },
+            ],
+          },
+        });
+
+        const saved = (await document.toBuffer({ cleanBookmarks: false })).buffer;
+        const reopened = await DocxDocument.load(saved);
+        const comments = await reopened.getComments();
+        expect(comments[0]).toMatchObject({ startTextOffset: 6, endTextOffset: 10 });
+        expect(comments[0]?.paragraphs.map((paragraph) => paragraph.tagged_text)).toEqual([
+          '<font color="884400"><b>Styled </b></font><i><highlight color="yellow">note</highlight></i>',
+          '<u>Second paragraph</u>',
+        ]);
+        expect(comments[0]?.replies[0]?.paragraphs[0]?.tagged_text).toBe('<b>Reply</b>');
+        const footnote = (await reopened.getFootnotes())[0]!;
+        expect(footnote.referencePoints).toEqual([{ paragraphId, textOffset: 5 }]);
+        expect(footnote.paragraphs.map((paragraph) => paragraph.text)).toEqual([' NOTE: Body', 'More']);
+        const zip = await JSZip.loadAsync(saved);
+        const footnotesXml = await zip.file('word/footnotes.xml')!.async('string');
+        expect(footnotesXml).toContain('<w:color w:val="654321"/>');
+        expect(footnotesXml).toContain('<w:highlight w:val="cyan"/>');
+      },
+    );
 });

--- a/packages/docx-core/src/primitives/paragraph-index.test.ts
+++ b/packages/docx-core/src/primitives/paragraph-index.test.ts
@@ -12,6 +12,14 @@ function paragraph(xml: string): Element {
 }
 
 describe('buildParagraphIndex', () => {
+  test('does not count paragraph tab-stop declarations as visible text', () => {
+    const paragraph = parseXml(
+      `<w:p xmlns:w="${OOXML.W_NS}"><w:pPr><w:tabs><w:tab w:val="left" w:pos="720"/></w:tabs></w:pPr><w:r><w:t>Email:</w:t><w:tab/></w:r></w:p>`,
+    ).documentElement;
+    const index = buildParagraphIndex(paragraph);
+    expect(index.text).toBe('Email:\t');
+    expect(index.nodes.find((node) => (node.element.parentNode as Element | null)?.localName === 'tabs')?.visibleStart).toBe(0);
+  });
   test('uses one field-aware traversal for visible and structural coordinates', async ({ given, then }: AllureBddContext) => {
     let index: ReturnType<typeof buildParagraphIndex>;
     await given('fragmented text around a field and zero-width annotation nodes', () => {

--- a/packages/docx-core/src/primitives/paragraph-index.ts
+++ b/packages/docx-core/src/primitives/paragraph-index.ts
@@ -136,7 +136,7 @@ export function buildParagraphIndex(paragraph: Element): ParagraphIndex {
         const instructionFrame = [...fieldStack].reverse().find((frame) => frame.phase === 'instruction');
         if (instructionFrame && (element.localName === W.instrText || element.localName === 'delInstrText')) {
           instructionFrame.instruction += element.textContent ?? '';
-        } else if (!instructionFrame && (node.kind === 'text' || node.kind === 'tab' || node.kind === 'break')) {
+        } else if (activeRun && !instructionFrame && (node.kind === 'text' || node.kind === 'tab' || node.kind === 'break')) {
           const text = node.kind === 'text' ? (element.textContent ?? '') : node.kind === 'tab' ? '\t' : '\n';
           const resultId = currentResultId();
           node.visibleText = text;

--- a/packages/docx-core/src/primitives/serialize_html.test.ts
+++ b/packages/docx-core/src/primitives/serialize_html.test.ts
@@ -82,6 +82,7 @@ function footnote(displayNumber: number, text: string): Footnote {
     text,
     anchoredParagraphId: null,
     refParagraphIds: [],
+    referencePoints: [],
     paragraphs: [{ text, tagged_text: text, style: 'FootnoteText' }],
   };
 }

--- a/packages/docx-core/src/primitives/serialize_markdown.test.ts
+++ b/packages/docx-core/src/primitives/serialize_markdown.test.ts
@@ -82,6 +82,7 @@ function footnote(displayNumber: number, text: string): Footnote {
     text,
     anchoredParagraphId: null,
     refParagraphIds: [],
+    referencePoints: [],
     paragraphs: [{ text, tagged_text: text, style: 'FootnoteText' }],
   };
 }

--- a/packages/docx-core/src/primitives/serialize_plaintext.test.ts
+++ b/packages/docx-core/src/primitives/serialize_plaintext.test.ts
@@ -82,6 +82,7 @@ function footnote(displayNumber: number, text: string): Footnote {
     text,
     anchoredParagraphId: null,
     refParagraphIds: [],
+    referencePoints: [],
     paragraphs: [{ text, tagged_text: text, style: 'FootnoteText' }],
   };
 }

--- a/packages/docx-markdoc/src/annotation-roundtrip.test.ts
+++ b/packages/docx-markdoc/src/annotation-roundtrip.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect } from 'vitest';
+import JSZip from 'jszip';
+import { buildSyntheticDocx, DocxDocument } from '@usejunior/docx-core';
+import { testAllure } from '../../docx-core/src/testing/allure-test.js';
+import { compileMarkdoc } from './compile.js';
+import { importDocxToMarkdoc } from './import.js';
+import { requireMarkdoc } from './markdoc.js';
+
+const test = testAllure.epic('DOCX Markdoc').withLabels({ feature: 'Canonical annotations' });
+const commentsConformance = test
+  .conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.4.4' })
+  .conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.4.3' })
+  .conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.4.5' });
+const footnoteConformance = test.conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.11.14' });
+
+async function sourceWithComment(start: number, end: number, reply = false): Promise<Buffer> {
+  const base = await buildSyntheticDocx({ paragraphs: ['Alpha beta gamma.'] });
+  const document = await DocxDocument.load(base);
+  document.insertParagraphBookmarks('annotation-test');
+  const paragraphId = document.buildDocumentView().nodes[0]!.id;
+  const root = await document.addComment({
+    paragraphId, start, end, author: 'Alice', initials: 'AL',
+    text: 'Original note', body: [{ runs: [{ text: 'Original ', style: { bold: true, color: '884400' } }, { text: 'note', style: { italic: true, highlight: 'yellow' } }] }],
+  });
+  if (reply) await document.addCommentReply({ parentCommentId: root.commentId, author: 'Bob', initials: 'BB', text: 'Reply' });
+  return (await document.toBuffer({ cleanBookmarks: false })).buffer;
+}
+
+async function sourceWithFootnote(offset: number): Promise<Buffer> {
+  const base = await buildSyntheticDocx({ paragraphs: ['Alpha beta gamma.'] });
+  const document = await DocxDocument.load(base);
+  document.insertParagraphBookmarks('annotation-test');
+  const paragraphId = document.buildDocumentView().nodes[0]!.id;
+  await document.addFootnote({ paragraphId, visibleOffset: offset, text: 'Substantive note' });
+  return (await document.toBuffer({ cleanBookmarks: false })).buffer;
+}
+
+describe('canonical annotation round trips', () => {
+  commentsConformance('[SDX-MDOC-82] imports and re-emits exact ranged comments with editable structured bodies', async () => {
+    const imported = await importDocxToMarkdoc(await sourceWithComment(6, 10));
+    const annotation = imported.annotations[0]!;
+    expect(annotation).toMatchObject({
+      audience: 'unspecified', semanticRole: 'unspecified', sourcePresentation: 'comment',
+      sourceAnchor: { kind: 'range', start: { offset: 6 }, end: { offset: 10 } },
+      anchor: { kind: 'range', start: { offset: 6 }, end: { offset: 10 } },
+      author: 'Alice', initials: 'AL',
+    });
+    expect(annotation.body[0]?.runs).toEqual([
+      { text: 'Original ', style: { bold: true, color: '884400' } },
+      { text: 'note', style: { italic: true, highlight: 'yellow' } },
+    ]);
+    const markdoc = imported.markdoc.replace('Original', 'Edited')
+      .replace('source-presentation="comment"', 'source-presentation="comment" presentation="comment"');
+    const result = await compileMarkdoc(imported.anchoredSource, markdoc);
+    const comments = await (await DocxDocument.load(result.tracked)).getComments();
+    expect(comments[0]).toMatchObject({ startTextOffset: 6, endTextOffset: 10 });
+    expect(comments[0]?.paragraphs[0]?.text).toBe('Edited note');
+  });
+
+  commentsConformance('[SDX-MDOC-83] preserves point comments without guessing a selected range', async () => {
+    const imported = await importDocxToMarkdoc(await sourceWithComment(5, 5));
+    expect(imported.annotations[0]?.sourceAnchor).toMatchObject({ kind: 'point', point: { offset: 5 } });
+    const markdoc = imported.markdoc.replace('source-presentation="comment"', 'source-presentation="comment" presentation="comment"');
+    const result = await compileMarkdoc(imported.anchoredSource, markdoc);
+    const comment = (await (await DocxDocument.load(result.tracked)).getComments())[0]!;
+    expect(comment.startTextOffset).toBe(5);
+    expect(comment.endTextOffset).toBe(5);
+    expect(result.certificate.annotationRendering.dispositions[0]).toMatchObject({ as: 'comment', lossy: false });
+  });
+
+  footnoteConformance('[SDX-MDOC-84] imports footnotes as substantive exact points and requires explicit conversion choices', async () => {
+    const imported = await importDocxToMarkdoc(await sourceWithFootnote(7));
+    expect(imported.annotations[0]).toMatchObject({
+      semanticRole: 'substantive-footnote', audience: 'unspecified', sourcePresentation: 'footnote',
+      sourceAnchor: { kind: 'point', point: { offset: 7 } },
+    });
+    await expect(compileMarkdoc(imported.anchoredSource, imported.markdoc, {
+      annotationPresentation: { unspecified: { as: 'comment' } },
+    })).rejects.toMatchObject({ code: 'EXPLICIT_ANNOTATION_DECISION_REQUIRED' });
+    const explicit = imported.markdoc.replace('source-presentation="footnote"', 'source-presentation="footnote" presentation="comment"');
+    const result = await compileMarkdoc(imported.anchoredSource, explicit);
+    const comment = (await (await DocxDocument.load(result.tracked)).getComments())[0]!;
+    expect(comment.startTextOffset).toBe(7);
+    expect(comment.endTextOffset).toBe(7);
+    expect(result.certificate.annotationRendering.dispositions[0]).toMatchObject({ as: 'comment', lossy: false });
+  });
+
+  footnoteConformance('[SDX-MDOC-85] switches profiles and style-only recompiles from one immutable annotation', async () => {
+    const imported = await importDocxToMarkdoc(await sourceWithComment(0, 5));
+    const parsed = requireMarkdoc(imported.markdoc);
+    parsed.annotations[0]!.audience = 'internal';
+    const commentMarkdoc = imported.markdoc
+      .replace('audience="unspecified"', 'audience="internal"')
+      .replace('role="unspecified"', 'role="drafting-note"');
+    const asComment = await compileMarkdoc(imported.anchoredSource, commentMarkdoc, {
+      annotationPresentation: { internal: { as: 'comment' } },
+    });
+    const asFootnote = await compileMarkdoc(imported.anchoredSource, commentMarkdoc, {
+      annotationPresentation: { internal: { as: 'footnote', prefix: [{ text: 'NOTE', style: { bold: true } }], separator: [{ text: ': ' }], bodyStyle: { color: '654321' } } },
+    });
+    expect((await (await DocxDocument.load(asComment.tracked)).getComments())).toHaveLength(1);
+    const notes = await (await DocxDocument.load(asFootnote.tracked)).getFootnotes();
+    expect(notes[0]?.text).toBe(' NOTE: Original note');
+    expect(asFootnote.ir.annotations[0]?.body).toEqual(asComment.ir.annotations[0]?.body);
+    expect(asFootnote.certificate.annotationRendering.profileDigest).not.toBe(asComment.certificate.annotationRendering.profileDigest);
+    expect(asFootnote.certificate.annotationRendering.dispositions[0]).toMatchObject({ as: 'footnote', lossy: true });
+  });
+
+  test('[SDX-MDOC-91] records omission as an intentional lossy projection', async () => {
+    const imported = await importDocxToMarkdoc(await sourceWithComment(0, 5));
+    const omitted = imported.markdoc.replace('source-presentation="comment"', 'source-presentation="comment" presentation="omit"');
+    const result = await compileMarkdoc(imported.anchoredSource, omitted);
+    expect(result.certificate.annotationRendering.dispositions[0]).toMatchObject({ as: 'omit', lossy: true });
+    expect(result.certificate.annotationRendering.warnings[0]).toContain('intentionally absent');
+  });
+
+  commentsConformance('[SDX-MDOC-86] retains reply topology and fails closed when the parent projection is incompatible', async () => {
+    const imported = await importDocxToMarkdoc(await sourceWithComment(0, 5, true));
+    expect(imported.annotations[1]?.replyParentId).toBe(imported.annotations[0]?.id);
+    const explicitComments = imported.markdoc.replaceAll('source-presentation="comment"', 'source-presentation="comment" presentation="comment"');
+    const result = await compileMarkdoc(imported.anchoredSource, explicitComments);
+    const roots = await (await DocxDocument.load(result.tracked)).getComments();
+    expect(roots[0]?.replies[0]?.text).toBe('Reply');
+    const lossy = imported.markdoc.replaceAll('source-presentation="comment"', 'source-presentation="comment" presentation="footnote"');
+    const footnotes = await compileMarkdoc(imported.anchoredSource, lossy);
+    expect(footnotes.certificate.annotationRendering.dispositions[1]).toMatchObject({ lossy: true });
+  });
+
+  test('[SDX-MDOC-87] fails closed for unrouted unspecified annotations and ambiguous edited anchors', async () => {
+    const imported = await importDocxToMarkdoc(await sourceWithComment(7, 8));
+    await expect(compileMarkdoc(imported.anchoredSource, imported.markdoc)).rejects.toMatchObject({ code: 'UNROUTED_ANNOTATION' });
+    const paragraph = requireMarkdoc(imported.markdoc).scaffold[0]!;
+    const edited = imported.markdoc
+      .replace(new RegExp(`\\{% para id="${paragraph.id}"[\\s\\S]*?\\{% /para %\\}`), `{% change id="${paragraph.id}" fingerprint="${paragraph.fingerprint}" style="${paragraph.style}" operation="rewrite" format="inherit-source-paragraph" %}\n{% before %}\nAlpha beta gamma.\n{% /before %}\n{% after %}\nAlpha changed gamma.\n{% /after %}\n{% /change %}`)
+      .replace('source-presentation="comment"', 'source-presentation="comment" presentation="comment"');
+    await expect(compileMarkdoc(imported.anchoredSource, edited)).rejects.toMatchObject({
+      code: 'ANNOTATION_ANCHOR_AMBIGUOUS', details: { annotationId: imported.annotations[0]!.id },
+    });
+  });
+
+  commentsConformance('[SDX-MDOC-88] remaps an anchor after an unambiguous operative-text edit', async () => {
+    const imported = await importDocxToMarkdoc(await sourceWithComment(11, 16));
+    const paragraph = requireMarkdoc(imported.markdoc).scaffold[0]!;
+    const edited = imported.markdoc
+      .replace(new RegExp(`\\{% para id="${paragraph.id}"[\\s\\S]*?\\{% /para %\\}`), `{% change id="${paragraph.id}" fingerprint="${paragraph.fingerprint}" style="${paragraph.style}" operation="rewrite" format="inherit-source-paragraph" %}\n{% before %}\nAlpha beta gamma.\n{% /before %}\n{% after %}\nNew Alpha beta gamma.\n{% /after %}\n{% /change %}`)
+      .replace('source-presentation="comment"', 'source-presentation="comment" presentation="comment"');
+    const result = await compileMarkdoc(imported.anchoredSource, edited);
+    const comment = (await (await DocxDocument.load(result.tracked)).getComments())[0]!;
+    expect(comment.startTextOffset).toBe(15);
+    expect(comment.endTextOffset).toBe(20);
+    expect(result.ir.annotations[0]?.sourceAnchor).toMatchObject({ kind: 'range', start: { offset: 11 }, end: { offset: 16 } });
+  });
+
+  commentsConformance('[SDX-MDOC-90] rejects unsupported bodies and orphan reply topology atomically', async () => {
+    const source = await sourceWithComment(0, 5, true);
+    const unsupportedZip = await JSZip.loadAsync(source);
+    const commentsXml = await unsupportedZip.file('word/comments.xml')!.async('string');
+    unsupportedZip.file('word/comments.xml', commentsXml.replace('</w:comment>', '<w:tbl/></w:comment>'));
+    const unsupported = await unsupportedZip.generateAsync({ type: 'nodebuffer' });
+    await expect(importDocxToMarkdoc(unsupported)).rejects.toMatchObject({
+      code: 'ANNOTATION_IMPORT_UNSUPPORTED', details: { annotationId: 'comment:0', element: 'w:tbl' },
+    });
+    expect(source.equals(unsupported)).toBe(false);
+
+    const topologyZip = await JSZip.loadAsync(source);
+    const extendedXml = await topologyZip.file('word/commentsExtended.xml')!.async('string');
+    topologyZip.file('word/commentsExtended.xml', extendedXml.replace(/w15:paraIdParent="[^"]+"/u, 'w15:paraIdParent="FFFFFFFF"'));
+    await expect(importDocxToMarkdoc(await topologyZip.generateAsync({ type: 'nodebuffer' }))).rejects.toMatchObject({
+      code: 'ANNOTATION_IMPORT_UNSUPPORTED', details: { annotationId: 'comment:1', topology: 'orphan-or-cycle' },
+    });
+  });
+});

--- a/packages/docx-markdoc/src/cli-options.test.ts
+++ b/packages/docx-markdoc/src/cli-options.test.ts
@@ -23,4 +23,13 @@ describe('Markdoc CLI rendering safety', () => {
     expect(Buffer.byteLength(path.basename(warned))).toBeLessThanOrEqual(255);
     expect(path.basename(warned).endsWith(INTERNAL_SUFFIX.trimStart())).toBe(true);
   });
+
+  itAllure('[SDX-MDOC-89] parses audience note profiles and rejects conflicting profile sources', () => {
+    expect(parseRenderingFlags(['source.docx', 'edit.mdoc', 'out', '--external-notes', 'footnote', '--internal-notes', 'comment', '--unspecified-notes', 'omit']).notePresentation)
+      .toEqual({ 'external-facing': 'footnote', internal: 'comment', unspecified: 'omit' });
+    expect(() => parseRenderingFlags(['--note-profile', 'profile.json', '--internal-notes', 'comment']))
+      .toThrow(/cannot be combined/u);
+    expect(() => parseRenderingFlags(['--external-notes', 'email']))
+      .toThrow(/requires preserve, comment, footnote, or omit/u);
+  });
 });

--- a/packages/docx-markdoc/src/cli-options.ts
+++ b/packages/docx-markdoc/src/cli-options.ts
@@ -1,10 +1,13 @@
 import path from 'node:path';
+import type { AnnotationAudience, AnnotationPresentation } from './types.js';
 
 export type RenderingFlags = {
   positional: string[];
   externalComments?: boolean;
   includeInternalComments: boolean;
   internalOutput?: string;
+  noteProfilePath?: string;
+  notePresentation: Partial<Record<AnnotationAudience, AnnotationPresentation>>;
 };
 
 export function parseRenderingFlags(args: string[]): RenderingFlags {
@@ -12,6 +15,8 @@ export function parseRenderingFlags(args: string[]): RenderingFlags {
   let externalComments: boolean | undefined;
   let includeInternalComments = false;
   let internalOutput: string | undefined;
+  let noteProfilePath: string | undefined;
+  const notePresentation: RenderingFlags['notePresentation'] = {};
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index]!;
     if (arg === '--external-comments' || arg === '--no-external-comments') {
@@ -26,6 +31,16 @@ export function parseRenderingFlags(args: string[]): RenderingFlags {
       internalOutput = args[index + 1];
       if (!internalOutput) throw new Error('--internal-output requires a .docx path.');
       index += 1;
+    } else if (arg === '--note-profile') {
+      noteProfilePath = args[index + 1];
+      if (!noteProfilePath) throw new Error('--note-profile requires a JSON path.');
+      index += 1;
+    } else if (arg === '--external-notes' || arg === '--internal-notes' || arg === '--unspecified-notes') {
+      const value = args[index + 1] as AnnotationPresentation | undefined;
+      if (!value || !['preserve', 'comment', 'footnote', 'omit'].includes(value)) throw new Error(`${arg} requires preserve, comment, footnote, or omit.`);
+      const audience: AnnotationAudience = arg === '--external-notes' ? 'external-facing' : arg === '--internal-notes' ? 'internal' : 'unspecified';
+      notePresentation[audience] = value;
+      index += 1;
     } else if (arg.startsWith('--')) {
       throw new Error(`Unknown option ${arg}.`);
     } else {
@@ -35,7 +50,8 @@ export function parseRenderingFlags(args: string[]): RenderingFlags {
   if (includeInternalComments !== (internalOutput !== undefined)) {
     throw new Error('--dangerously-include-internal-comments and --internal-output must be supplied together.');
   }
-  return { positional, externalComments, includeInternalComments, internalOutput };
+  if (noteProfilePath && Object.keys(notePresentation).length > 0) throw new Error('--note-profile cannot be combined with audience note overrides.');
+  return { positional, externalComments, includeInternalComments, internalOutput, noteProfilePath, notePresentation };
 }
 
 export const EXTERNAL_FILENAME = 'redline - EXTERNAL COMMENTS INCLUDED.docx';

--- a/packages/docx-markdoc/src/cli.ts
+++ b/packages/docx-markdoc/src/cli.ts
@@ -9,6 +9,8 @@ import { requireMarkdoc } from './markdoc.js';
 import { convertCommentsToFootnotes } from '@usejunior/docx-core';
 import { DocxMarkdocError } from './errors.js';
 import { assertDistinctInternalPath, EXTERNAL_FILENAME, parseRenderingFlags, warnedInternalPath } from './cli-options.js';
+import { normalizeAnnotationPresentationProfile } from './presentation.js';
+import type { AnnotationPresentationProfile } from './types.js';
 
 function usage(): string {
   return [
@@ -18,6 +20,7 @@ function usage(): string {
     '  docx-markdoc inspect <anchored.docx> [paragraph-id ...]',
     '  docx-markdoc compile <anchored.docx> <document.mdoc> <output-dir> [--external-comments|--no-external-comments]',
     '    [--dangerously-include-internal-comments --internal-output <path.docx>]',
+    '    [--note-profile profile.json | --external-notes MODE --internal-notes MODE --unspecified-notes MODE]',
     '  docx-markdoc verify <anchored.docx> <document.mdoc> [--external-comments|--no-external-comments]',
     '  docx-markdoc export-edits <document.mdoc> <output.json>',
     '  docx-markdoc comments-to-footnotes <input.docx> <output.docx> [--prefix TEXT] [--prefix-separator TEXT] [--bold-prefix] [--prefix-color RRGGBB] [--prefix-highlight COLOR] [--body-color RRGGBB] [--body-highlight COLOR] [--flatten-threads]',
@@ -59,10 +62,17 @@ async function main(): Promise<void> {
     if (command === 'verify' && flags.includeInternalComments) {
       throw new Error('Internal comments can be materialized only by compile with an explicit output path.');
     }
-    const hasCliOverride = flags.externalComments !== undefined || flags.includeInternalComments;
+    const fileProfile = flags.noteProfilePath
+      ? JSON.parse(await readFile(flags.noteProfilePath, 'utf8')) as AnnotationPresentationProfile
+      : undefined;
+    const overrideProfile = Object.fromEntries(Object.entries(flags.notePresentation).map(([audience, as]) => [audience, { as }])) as AnnotationPresentationProfile;
+    const annotationPresentation = normalizeAnnotationPresentationProfile(fileProfile ?? (Object.keys(overrideProfile).length ? overrideProfile : undefined));
+    const hasAnnotationProfile = flags.noteProfilePath !== undefined || Object.keys(overrideProfile).length > 0;
+    const hasCliOverride = flags.externalComments !== undefined || flags.includeInternalComments || hasAnnotationProfile;
     const result = await compileMarkdoc(await readFile(sourcePath), await readFile(markdocPath, 'utf8'), {
       ...(flags.externalComments === undefined ? {} : { externalComments: flags.externalComments }),
       ...(flags.includeInternalComments ? { dangerouslyIncludeInternalComments: true } : {}),
+      ...(hasAnnotationProfile ? { annotationPresentation } : {}),
       ...(hasCliOverride ? { configurationSource: 'cli' } : {}),
     });
     if (command === 'compile') {

--- a/packages/docx-markdoc/src/compile.ts
+++ b/packages/docx-markdoc/src/compile.ts
@@ -15,6 +15,7 @@ import { DocxMarkdocError } from './errors.js';
 import { sha256 } from './hash.js';
 import { requireMarkdoc } from './markdoc.js';
 import { assessDraftCompleteness } from './completeness.js';
+import { projectAnnotations, type AnnotationProjectionResult } from './presentation.js';
 import type {
   CompileResult,
   CompileOptions,
@@ -781,6 +782,17 @@ export async function compileMarkdoc(
       );
     }
   }
+  let annotationProjection: AnnotationProjectionResult = {
+    buffer: tracked,
+    profile: options.annotationPresentation ?? ir.compilation?.annotationPresentation ?? {},
+    profileDigest: sha256(Buffer.from(JSON.stringify(options.annotationPresentation ?? ir.compilation?.annotationPresentation ?? {}))),
+    dispositions: [],
+    warnings: [],
+  };
+  if (ir.annotations.some((annotation) => !annotation.id.startsWith('rationale:'))) {
+    annotationProjection = await projectAnnotations(tracked, ir, options.annotationPresentation ?? ir.compilation?.annotationPresentation);
+    tracked = annotationProjection.buffer;
+  }
   const acceptedDoc = await DocxDocument.load(tracked);
   const rejectedDoc = await DocxDocument.load(tracked);
   await acceptedDoc.acceptChanges();
@@ -822,6 +834,12 @@ export async function compileMarkdoc(
       externalCommentsIncluded: resolvedCompilation.externalCommentsIncluded,
       internalCommentsIncluded: resolvedCompilation.internalCommentsIncluded,
       warnings: resolvedCompilation.warnings,
+    },
+    annotationRendering: {
+      profile: annotationProjection.profile,
+      profileDigest: annotationProjection.profileDigest,
+      dispositions: annotationProjection.dispositions,
+      warnings: annotationProjection.warnings,
     },
     projectionPassed: false,
     draftCompletenessPassed: completeness.passed,

--- a/packages/docx-markdoc/src/docx-markdoc.test.ts
+++ b/packages/docx-markdoc/src/docx-markdoc.test.ts
@@ -130,12 +130,13 @@ describe('brownfield Markdoc authoring', () => {
     expect(result.certificate).toMatchObject({ rejectAllEqualsSource: true, acceptAllEqualsClean: true, passed: true });
   });
 
-  itAllure('[SDX-MDOC-01][SDX-MDOC-13] replays the existing public NVCA source and filled fixtures unchanged', async () => {
+  itAllure('[SDX-MDOC-01][SDX-MDOC-72][SDX-MDOC-81] rejects unsupported public NVCA footnotes atomically', async () => {
     const directory = fileURLToPath(new URL('../../../tests/test_documents/nvca-regression/', import.meta.url));
-    for (const name of ['source.docx', 'filled.docx']) {
-      const imported = await importDocxToMarkdoc(await readFile(`${directory}${name}`));
-      const result = await compileMarkdoc(imported.anchoredSource, imported.markdoc);
-      expect(result.certificate).toMatchObject({ passed: true, rejectAllEqualsSource: true, acceptAllEqualsClean: true });
+    for (const name of ['source.docx']) {
+      await expect(importDocxToMarkdoc(await readFile(`${directory}${name}`))).rejects.toMatchObject({
+        code: 'ANNOTATION_IMPORT_UNSUPPORTED',
+        details: { annotationId: 'footnote:2', element: 'w:sz' },
+      });
     }
   }, 60_000);
 

--- a/packages/docx-markdoc/src/import.ts
+++ b/packages/docx-markdoc/src/import.ts
@@ -1,6 +1,7 @@
-import { DocxDocument, computeContentFingerprint } from '@usejunior/docx-core';
+import { DocxDocument, OOXML, W, computeContentFingerprint } from '@usejunior/docx-core';
 import { sha256 } from './hash.js';
-import type { ImportResult } from './types.js';
+import { DocxMarkdocError } from './errors.js';
+import type { AnnotationAnchor, AnnotationParagraph, AnnotationRun, AnnotationRunStyle, CanonicalAnnotation, ImportResult } from './types.js';
 
 function escapeText(text: string): string {
   const escaped = text
@@ -25,6 +26,128 @@ function escapeAttribute(text: string): string {
   return text.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
 
+function parseTaggedRuns(tagged: string, annotationId: string): AnnotationRun[] {
+  const runs: AnnotationRun[] = [];
+  const stack: AnnotationRunStyle[] = [{}];
+  const tokens = tagged.split(/(<\/?(?:b|i|u|highlight|font)(?:\s[^>]*)?>)/g).filter(Boolean);
+  const current = (): AnnotationRunStyle => stack.at(-1)!;
+  for (const token of tokens) {
+    if (!token.startsWith('<')) {
+      if (token) runs.push({ text: token, ...(Object.keys(current()).length ? { style: { ...current() } } : {}) });
+      continue;
+    }
+    if (token.startsWith('</')) {
+      if (stack.length === 1) throw new DocxMarkdocError('ANNOTATION_IMPORT_UNSUPPORTED', `Annotation ${annotationId} has unbalanced formatting tags.`, { annotationId });
+      stack.pop();
+      continue;
+    }
+    const next = { ...current() };
+    if (token === '<b>') next.bold = true;
+    else if (token === '<i>') next.italic = true;
+    else if (token === '<u>') next.underline = true;
+    else if (token.startsWith('<highlight')) {
+      const color = /\bcolor="([^"]+)"/.exec(token)?.[1] ?? 'yellow';
+      next.highlight = color as AnnotationRunStyle['highlight'];
+    } else if (token.startsWith('<font')) {
+      if (/\b(?:name|size|face)=/.test(token)) throw new DocxMarkdocError('ANNOTATION_IMPORT_UNSUPPORTED', `Annotation ${annotationId} uses unsupported font metadata.`, { annotationId, token });
+      const color = /\bcolor="([0-9A-Fa-f]{6})"/.exec(token)?.[1];
+      if (!color) throw new DocxMarkdocError('ANNOTATION_IMPORT_UNSUPPORTED', `Annotation ${annotationId} has an unsupported color declaration.`, { annotationId, token });
+      next.color = color.toUpperCase();
+    }
+    stack.push(next);
+  }
+  if (stack.length !== 1) throw new DocxMarkdocError('ANNOTATION_IMPORT_UNSUPPORTED', `Annotation ${annotationId} has unbalanced formatting tags.`, { annotationId });
+  return runs;
+}
+
+function bodyFromParagraphs(paragraphs: Array<{ tagged_text: string }>, annotationId: string): AnnotationParagraph[] {
+  if (paragraphs.length === 0) throw new DocxMarkdocError('ANNOTATION_IMPORT_UNSUPPORTED', `Annotation ${annotationId} has no admitted paragraphs.`, { annotationId });
+  return paragraphs.map((paragraph) => ({ runs: parseTaggedRuns(paragraph.tagged_text, annotationId) }));
+}
+
+function assertAdmittedAnnotationElement(container: Element, annotationId: string, marker: 'annotationRef' | 'footnoteRef'): void {
+  const admitted = new Set(['p', 'pPr', 'pStyle', 'r', 'rPr', 't', marker, 'b', 'i', 'u', 'color', 'highlight', 'rStyle', 'vertAlign']);
+  for (const node of Array.from(container.getElementsByTagNameNS(OOXML.W_NS, '*'))) {
+    const element = node as Element;
+    let formattingOwner = element.parentNode as Element | null;
+    while (formattingOwner && formattingOwner !== container && formattingOwner.localName !== W.r && formattingOwner.localName !== W.p) {
+      formattingOwner = formattingOwner.parentNode as Element | null;
+    }
+    const harmlessComplexScriptFallback = element.localName === 'szCs'
+      && (formattingOwner?.localName === W.r || formattingOwner?.localName === W.p)
+      && !/[\u0590-\u08FF\uFB1D-\uFDFF\uFE70-\uFEFF]/u.test(formattingOwner.textContent ?? '');
+    if (!admitted.has(element.localName) && !harmlessComplexScriptFallback) {
+      throw new DocxMarkdocError('ANNOTATION_IMPORT_UNSUPPORTED', `Annotation ${annotationId} contains unsupported w:${element.localName}.`, { annotationId, element: `w:${element.localName}` });
+    }
+    if (element.localName === W.rPr) {
+      const run = element.parentNode as Element | null;
+      const markerRun = Boolean(run?.getElementsByTagNameNS(OOXML.W_NS, marker).length);
+      for (const property of Array.from(element.childNodes).filter((child) => child.nodeType === 1) as Element[]) {
+        const allowed = ['b', 'i', 'u', 'color', 'highlight'];
+        const nonApplicableFallback = property.localName === 'szCs'
+          && !/[\u0590-\u08FF\uFB1D-\uFDFF\uFE70-\uFEFF]/u.test(run?.textContent ?? '');
+        if (!allowed.includes(property.localName) && !nonApplicableFallback && !(markerRun && ['rStyle', 'vertAlign'].includes(property.localName))) {
+          throw new DocxMarkdocError('ANNOTATION_IMPORT_UNSUPPORTED', `Annotation ${annotationId} contains unsupported run property w:${property.localName}.`, { annotationId, element: `w:${property.localName}` });
+        }
+      }
+    }
+  }
+}
+
+function elementByWordId(document: Document | null, localName: string, id: number): Element | null {
+  if (!document) return null;
+  return Array.from(document.getElementsByTagNameNS(OOXML.W_NS, localName))
+    .find((element) => Number((element as Element).getAttributeNS(OOXML.W_NS, 'id') ?? (element as Element).getAttribute('w:id')) === id) as Element | undefined ?? null;
+}
+
+function anchorAttributes(prefix: 'source-' | '', anchor: AnnotationAnchor): string[] {
+  const kindName = prefix ? 'source-kind' : 'anchor-kind';
+  const paragraphName = prefix ? 'source-paragraph' : 'paragraph';
+  const offsetName = prefix ? 'source-offset' : 'offset';
+  const start = anchor.kind === 'point' ? anchor.point : anchor.start;
+  const attributes = [`${kindName}="${anchor.kind}"`, `${paragraphName}="${escapeAttribute(start.paragraphId)}"`, `${offsetName}=${start.offset}`];
+  if (anchor.kind === 'range') {
+    attributes.push(`${prefix ? 'source-end-paragraph' : 'end-paragraph'}="${escapeAttribute(anchor.end.paragraphId)}"`);
+    attributes.push(`${prefix ? 'source-end-offset' : 'end-offset'}=${anchor.end.offset}`);
+  }
+  return attributes;
+}
+
+function annotationMarkdoc(annotation: CanonicalAnnotation): string[] {
+  const attributes = [
+    `id="${escapeAttribute(annotation.id)}"`,
+    `audience="${annotation.audience}"`,
+    `role="${annotation.semanticRole}"`,
+    `source-presentation="${annotation.sourcePresentation}"`,
+    ...anchorAttributes('source-', annotation.sourceAnchor),
+    ...anchorAttributes('', annotation.anchor),
+    ...(annotation.operationId ? [`operation="${escapeAttribute(annotation.operationId)}"`] : []),
+    ...(annotation.author ? [`author="${escapeAttribute(annotation.author)}"`] : []),
+    ...(annotation.initials ? [`initials="${escapeAttribute(annotation.initials)}"`] : []),
+    ...(annotation.date ? [`date="${escapeAttribute(annotation.date)}"`] : []),
+    ...(annotation.replyParentId ? [`reply-parent="${escapeAttribute(annotation.replyParentId)}"`] : []),
+    ...(annotation.presentation ? [`presentation="${annotation.presentation}"`] : []),
+  ];
+  const lines = [`{% annotation ${attributes.join(' ')} %}`];
+  for (const paragraph of annotation.body) {
+    const content: string[] = [];
+    for (const run of paragraph.runs) {
+      const style = run.style;
+      if (!style || Object.keys(style).length === 0) content.push(escapeText(run.text));
+      else {
+        const styleAttributes = [
+          ...(style.bold ? ['bold=true'] : []), ...(style.italic ? ['italic=true'] : []), ...(style.underline ? ['underline=true'] : []),
+          ...(style.color ? [`color="${style.color}"`] : []), ...(style.highlight ? [`highlight="${style.highlight}"`] : []),
+        ];
+        content.push(`{% annotation-run ${styleAttributes.join(' ')} %}${escapeText(run.text)}{% /annotation-run %}`);
+      }
+    }
+    lines.push('{% annotation-p %}', content.join(''), '{% /annotation-p %}');
+  }
+  lines.push('{% /annotation %}', '');
+  return lines;
+}
+
 export async function importDocxToMarkdoc(source: Buffer): Promise<ImportResult> {
   const document = await DocxDocument.load(source);
   const attachmentId = sha256(source).slice(0, 16);
@@ -43,5 +166,70 @@ export async function importDocxToMarkdoc(source: Buffer): Promise<ImportResult>
       '',
     );
   }
-  return { anchoredSource, markdoc: `${lines.join('\n').trimEnd()}\n`, source: descriptor };
+  const annotations: CanonicalAnnotation[] = [];
+  const [commentsXml, footnotesXml] = await Promise.all([anchored.getCommentsXmlClone(), anchored.getFootnotesXmlClone()]);
+  const comments = await anchored.getComments();
+  const importedCommentIds = new Set<number>();
+  const addCommentTree = (comment: (typeof comments)[number], parent: CanonicalAnnotation | undefined): void => {
+    const id = `comment:${comment.id}`;
+    if (importedCommentIds.has(comment.id)) {
+      throw new DocxMarkdocError('ANNOTATION_IMPORT_UNSUPPORTED', `Comment ${comment.id} appears more than once in reply topology.`, { annotationId: id, topology: 'duplicate-or-cycle' });
+    }
+    importedCommentIds.add(comment.id);
+    const commentElement = elementByWordId(commentsXml, W.comment, comment.id);
+    if (!commentElement) throw new DocxMarkdocError('ANNOTATION_IMPORT_UNSUPPORTED', `Comment ${comment.id} has no definition.`, { annotationId: id });
+    assertAdmittedAnnotationElement(commentElement, id, 'annotationRef');
+    let anchor: AnnotationAnchor;
+    if (parent) anchor = parent.anchor;
+    else {
+      if (!comment.anchoredParagraphId || comment.startTextOffset === undefined || !comment.endParagraphId || comment.endTextOffset === undefined) {
+        throw new DocxMarkdocError('ANNOTATION_IMPORT_UNSUPPORTED', `Comment ${comment.id} has unresolved anchor geometry.`, { annotationId: id });
+      }
+      anchor = comment.anchoredParagraphId === comment.endParagraphId && comment.startTextOffset === comment.endTextOffset
+        ? { kind: 'point', point: { paragraphId: comment.anchoredParagraphId, offset: comment.startTextOffset } }
+        : { kind: 'range', start: { paragraphId: comment.anchoredParagraphId, offset: comment.startTextOffset }, end: { paragraphId: comment.endParagraphId, offset: comment.endTextOffset } };
+    }
+    const annotation: CanonicalAnnotation = {
+      id,
+      body: bodyFromParagraphs(comment.paragraphs, id),
+      author: comment.author || undefined,
+      initials: comment.initials || undefined,
+      date: comment.date || undefined,
+      ...(parent ? { replyParentId: parent.id } : {}),
+      audience: 'unspecified', semanticRole: 'unspecified', sourcePresentation: 'comment', sourceAnchor: anchor, anchor,
+    };
+    annotations.push(annotation);
+    for (const reply of comment.replies) addCommentTree(reply, annotation);
+  };
+  for (const comment of comments) addCommentTree(comment, undefined);
+  const definedCommentIds = commentsXml
+    ? Array.from(commentsXml.getElementsByTagNameNS(OOXML.W_NS, W.comment))
+      .map((element) => Number((element as Element).getAttributeNS(OOXML.W_NS, 'id') ?? (element as Element).getAttribute('w:id')))
+      .filter(Number.isInteger)
+    : [];
+  if (importedCommentIds.size !== definedCommentIds.length) {
+    const missing = definedCommentIds.find((id) => !importedCommentIds.has(id));
+    throw new DocxMarkdocError('ANNOTATION_IMPORT_UNSUPPORTED', `Comment reply topology is orphaned or cyclic at comment ${missing ?? 'unknown'}.`, {
+      annotationId: missing === undefined ? 'comment:unknown' : `comment:${missing}`,
+      topology: 'orphan-or-cycle',
+    });
+  }
+  for (const footnote of await anchored.getFootnotes()) {
+    const id = `footnote:${footnote.id}`;
+    // Some Word templates retain an empty, unreferenced placeholder definition.
+    // It carries no negotiation content or body anchor and is not a user note.
+    if (footnote.referencePoints.length === 0 && footnote.text.length === 0) continue;
+    const footnoteElement = elementByWordId(footnotesXml, W.footnote, footnote.id);
+    if (!footnoteElement) throw new DocxMarkdocError('ANNOTATION_IMPORT_UNSUPPORTED', `Footnote ${footnote.id} has no definition.`, { annotationId: id });
+    assertAdmittedAnnotationElement(footnoteElement, id, 'footnoteRef');
+    if (footnote.referencePoints.length !== 1) throw new DocxMarkdocError('ANNOTATION_IMPORT_UNSUPPORTED', `Footnote ${footnote.id} must have exactly one reference.`, { annotationId: id, referenceCount: footnote.referencePoints.length });
+    const reference = footnote.referencePoints[0]!;
+    const anchor: AnnotationAnchor = { kind: 'point', point: { paragraphId: reference.paragraphId, offset: reference.textOffset } };
+    annotations.push({
+      id, body: bodyFromParagraphs(footnote.paragraphs, id), audience: 'unspecified', semanticRole: 'substantive-footnote',
+      sourcePresentation: 'footnote', sourceAnchor: anchor, anchor,
+    });
+  }
+  for (const annotation of annotations) lines.push(...annotationMarkdoc(annotation));
+  return { anchoredSource, markdoc: `${lines.join('\n').trimEnd()}\n`, source: descriptor, annotations };
 }

--- a/packages/docx-markdoc/src/index.ts
+++ b/packages/docx-markdoc/src/index.ts
@@ -6,3 +6,4 @@ export * from './inspect.js';
 export * from './compile.js';
 export * from './completeness.js';
 export * from './export.js';
+export * from './presentation.js';

--- a/packages/docx-markdoc/src/markdoc.ts
+++ b/packages/docx-markdoc/src/markdoc.ts
@@ -1,6 +1,6 @@
 import Markdoc, { type Config, type Node } from '@markdoc/markdoc';
 import { DocxMarkdocError } from './errors.js';
-import { IR_VERSION, type AtomicChangeSet, type CompilationProfile, type DraftAssertion, type DraftRequirement, type MarkdocEditIR, type Rationale, type RequirementWaiver, type RunFormat, type RunFormatSpan, type SourceParagraph, type ValidationIssue, type ValidationResult } from './types.js';
+import { IR_VERSION, type AnnotationAnchor, type AnnotationParagraph, type AnnotationRunStyle, type AtomicChangeSet, type CanonicalAnnotation, type CompilationProfile, type DraftAssertion, type DraftRequirement, type MarkdocEditIR, type Rationale, type RequirementWaiver, type RunFormat, type RunFormatSpan, type SourceParagraph, type ValidationIssue, type ValidationResult } from './types.js';
 
 const stringRequired = { type: String, required: true } as const;
 const runFormatAttributes = {
@@ -25,6 +25,9 @@ export const markdocConfig: Config = {
         'comment-initials': { type: String },
         'build-date': { type: String },
         'external-comments': { type: String, matches: ['include', 'omit'] },
+        'external-notes': { type: String, matches: ['preserve', 'comment', 'footnote', 'omit'] },
+        'internal-notes': { type: String, matches: ['preserve', 'comment', 'footnote', 'omit'] },
+        'unspecified-notes': { type: String, matches: ['preserve', 'comment', 'footnote', 'omit'] },
       },
     },
     para: {
@@ -97,6 +100,31 @@ export const markdocConfig: Config = {
       attributes: {
         for: stringRequired,
         visibility: { type: String, required: true, matches: ['internal', 'external-facing'] },
+      },
+    },
+    annotation: {
+      attributes: {
+        id: stringRequired,
+        operation: { type: String },
+        audience: { type: String, required: true, matches: ['internal', 'external-facing', 'unspecified'] },
+        role: { type: String, required: true, matches: ['drafting-note', 'substantive-footnote', 'unspecified'] },
+        'source-presentation': { type: String, required: true, matches: ['comment', 'footnote', 'authored'] },
+        presentation: { type: String, matches: ['preserve', 'comment', 'footnote', 'omit'] },
+        author: { type: String }, initials: { type: String }, date: { type: String }, 'reply-parent': { type: String },
+        'source-kind': { type: String, required: true, matches: ['point', 'range'] },
+        'source-paragraph': stringRequired, 'source-offset': { type: Number, required: true },
+        'source-end-paragraph': { type: String }, 'source-end-offset': { type: Number },
+        'anchor-kind': { type: String, required: true, matches: ['point', 'range'] },
+        paragraph: stringRequired, offset: { type: Number, required: true },
+        'end-paragraph': { type: String }, 'end-offset': { type: Number },
+      },
+    },
+    'annotation-p': {},
+    'annotation-run': {
+      inline: true,
+      attributes: {
+        bold: { type: Boolean }, italic: { type: Boolean }, underline: { type: Boolean },
+        color: { type: String }, highlight: { type: String },
       },
     },
     requirement: {
@@ -183,6 +211,63 @@ function commaList(value: unknown): string[] {
   return String(value ?? '').split(',').map((item) => item.trim()).filter(Boolean);
 }
 
+const HIGHLIGHTS = new Set(['black', 'blue', 'cyan', 'green', 'magenta', 'red', 'yellow', 'white', 'darkBlue', 'darkCyan', 'darkGreen', 'darkMagenta', 'darkRed', 'darkYellow', 'darkGray', 'lightGray', 'none']);
+
+function annotationAnchor(attributes: Record<string, unknown>, prefix: 'source-' | '', node: Node, issues: ValidationIssue[]): AnnotationAnchor {
+  const kind = String(attributes[`${prefix}${prefix ? 'kind' : 'anchor-kind'}`] ?? 'point');
+  const paragraphKey = prefix ? 'source-paragraph' : 'paragraph';
+  const offsetKey = prefix ? 'source-offset' : 'offset';
+  const paragraphId = String(attributes[paragraphKey] ?? '');
+  const offset = Number(attributes[offsetKey]);
+  if (!paragraphId || !Number.isInteger(offset) || offset < 0) issues.push(issue('INVALID_ANNOTATION_ANCHOR', 'Annotation coordinates require a paragraph ID and non-negative integer offset.', node));
+  const point = { paragraphId, offset };
+  if (kind !== 'range') return { kind: 'point', point };
+  const endParagraphId = String(attributes[prefix ? 'source-end-paragraph' : 'end-paragraph'] ?? '');
+  const endOffset = Number(attributes[prefix ? 'source-end-offset' : 'end-offset']);
+  if (!endParagraphId || !Number.isInteger(endOffset) || endOffset < 0) issues.push(issue('INVALID_ANNOTATION_ANCHOR', 'Range anchors require an end paragraph ID and non-negative integer offset.', node));
+  return { kind: 'range', start: point, end: { paragraphId: endParagraphId, offset: endOffset } };
+}
+
+function annotationBody(node: Node, issues: ValidationIssue[]): AnnotationParagraph[] {
+  const paragraphs: AnnotationParagraph[] = [];
+  for (const child of node.children) {
+    if (child.type !== 'tag' || child.tag !== 'annotation-p') {
+      if (child.type !== 'text' || String(child.attributes.content ?? '').trim()) issues.push(issue('UNSUPPORTED_ANNOTATION_BODY', 'Annotation bodies admit annotation-p blocks only.', child));
+      continue;
+    }
+    const runs = [] as AnnotationParagraph['runs'];
+    const visit = (inline: Node, inherited?: AnnotationRunStyle): void => {
+      if (inline.type === 'text') {
+        const text = String(inline.attributes.content ?? '');
+        if (text) runs.push({ text, ...(inherited && Object.keys(inherited).length ? { style: inherited } : {}) });
+        return;
+      }
+      if (inline.type === 'softbreak' || inline.type === 'hardbreak' || inline.type === 'paragraph' || inline.type === 'inline') {
+        for (const nested of inline.children) visit(nested, inherited);
+        return;
+      }
+      if (inline.type !== 'tag' || inline.tag !== 'annotation-run') {
+        issues.push(issue('UNSUPPORTED_ANNOTATION_BODY', 'Annotation paragraphs admit text and annotation-run tags only.', inline));
+        return;
+      }
+      const style: AnnotationRunStyle = {
+        ...(inline.attributes.bold === true ? { bold: true } : {}),
+        ...(inline.attributes.italic === true ? { italic: true } : {}),
+        ...(inline.attributes.underline === true ? { underline: true } : {}),
+        ...(inline.attributes.color === undefined ? {} : { color: String(inline.attributes.color).toUpperCase() }),
+        ...(inline.attributes.highlight === undefined ? {} : { highlight: String(inline.attributes.highlight) as AnnotationRunStyle['highlight'] }),
+      };
+      if (style.color && !/^[0-9A-F]{6}$/.test(style.color)) issues.push(issue('INVALID_ANNOTATION_COLOR', 'Annotation colors must be six-digit RGB values.', inline));
+      if (style.highlight && !HIGHLIGHTS.has(style.highlight)) issues.push(issue('INVALID_ANNOTATION_HIGHLIGHT', `Unsupported Word highlight ${style.highlight}.`, inline));
+      for (const nested of inline.children) visit(nested, style);
+    };
+    for (const inline of child.children) visit(inline);
+    paragraphs.push({ runs });
+  }
+  if (paragraphs.length === 0) issues.push(issue('EMPTY_ANNOTATION_BODY', 'Annotations require at least one body paragraph.', node));
+  return paragraphs;
+}
+
 function runFormatFromAttributes(attributes: Record<string, unknown>, node: Node, issues: ValidationIssue[]): RunFormat | undefined {
   const underline = attributes.underline === undefined ? undefined : String(attributes.underline);
   const highlight = attributes.highlight === undefined ? undefined : String(attributes.highlight);
@@ -245,6 +330,7 @@ export function parseMarkdoc(source: string): ValidationResult {
   const scaffold: SourceParagraph[] = [];
   const operations: MarkdocEditIR['operations'] = [];
   const rationales: Rationale[] = [];
+  const annotations: CanonicalAnnotation[] = [];
   const requirements: DraftRequirement[] = [];
   const waivers: RequirementWaiver[] = [];
   const changeSets: AtomicChangeSet[] = [];
@@ -288,6 +374,11 @@ export function parseMarkdoc(source: string): ValidationResult {
         ...(commentInitials === undefined ? {} : { commentInitials }),
         ...(buildDate === undefined ? {} : { buildDate }),
         externalComments: a['external-comments'] === 'omit' ? 'omit' : 'include',
+        annotationPresentation: {
+          ...(a['external-notes'] === undefined ? {} : { 'external-facing': { as: a['external-notes'] as 'preserve' | 'comment' | 'footnote' | 'omit' } }),
+          ...(a['internal-notes'] === undefined ? {} : { internal: { as: a['internal-notes'] as 'preserve' | 'comment' | 'footnote' | 'omit' } }),
+          ...(a['unspecified-notes'] === undefined ? {} : { unspecified: { as: a['unspecified-notes'] as 'preserve' | 'comment' | 'footnote' | 'omit' } }),
+        },
       };
       continue;
     }
@@ -296,6 +387,28 @@ export function parseMarkdoc(source: string): ValidationResult {
         operationId: String(a.for ?? ''),
         text: textProjection(node, 'revised').trim(),
         visibility: a.visibility === 'external-facing' ? 'external-facing' : 'internal',
+      });
+      continue;
+    }
+    if (node.tag === 'annotation') {
+      const id = String(a.id ?? '');
+      if (annotations.some((annotation) => annotation.id === id)) issues.push(issue('DUPLICATE_ANNOTATION_ID', `Duplicate annotation ID ${id}.`, node));
+      const date = a.date === undefined ? undefined : String(a.date);
+      if (date !== undefined && !Number.isFinite(Date.parse(date))) issues.push(issue('INVALID_ANNOTATION_DATE', 'Annotation dates must be valid ISO-8601 instants.', node));
+      annotations.push({
+        id,
+        body: annotationBody(node, issues),
+        ...(a.operation === undefined ? {} : { operationId: String(a.operation) }),
+        ...(a.author === undefined ? {} : { author: String(a.author) }),
+        ...(a.initials === undefined ? {} : { initials: String(a.initials) }),
+        ...(date === undefined ? {} : { date }),
+        ...(a['reply-parent'] === undefined ? {} : { replyParentId: String(a['reply-parent']) }),
+        audience: a.audience as CanonicalAnnotation['audience'],
+        semanticRole: a.role as CanonicalAnnotation['semanticRole'],
+        sourcePresentation: a['source-presentation'] as CanonicalAnnotation['sourcePresentation'],
+        sourceAnchor: annotationAnchor(a, 'source-', node, issues),
+        anchor: annotationAnchor(a, '', node, issues),
+        ...(a.presentation === undefined ? {} : { presentation: a.presentation as CanonicalAnnotation['presentation'] }),
       });
       continue;
     }
@@ -474,6 +587,10 @@ export function parseMarkdoc(source: string): ValidationResult {
       issues.push(issue('ORPHAN_RATIONALE', `Rationale targets unknown operation ${rationale.operationId}.`));
     }
   }
+  for (const annotation of annotations) {
+    if (annotation.operationId && !operationIds.has(annotation.operationId)) issues.push(issue('ORPHAN_ANNOTATION_OPERATION', `Annotation ${annotation.id} targets unknown operation ${annotation.operationId}.`));
+    if (annotation.replyParentId && !annotations.some((parent) => parent.id === annotation.replyParentId)) issues.push(issue('ORPHAN_ANNOTATION_REPLY', `Annotation ${annotation.id} targets unknown reply parent ${annotation.replyParentId}.`));
+  }
   const waiverTargets = new Set<string>();
   for (const waiver of waivers) {
     if (!requirementIds.has(waiver.requirementId)) issues.push(issue('ORPHAN_WAIVER', `Waiver targets unknown requirement ${waiver.requirementId}.`));
@@ -481,7 +598,7 @@ export function parseMarkdoc(source: string): ValidationResult {
     waiverTargets.add(waiver.requirementId);
   }
   const rationaleTargets = new Set<string>();
-  for (const rationale of rationales) {
+  for (const [rationaleIndex, rationale] of rationales.entries()) {
     const target = `${rationale.operationId}\u0000${rationale.visibility}`;
     if (rationaleTargets.has(target)) {
       issues.push(issue(
@@ -490,11 +607,31 @@ export function parseMarkdoc(source: string): ValidationResult {
       ));
     }
     rationaleTargets.add(target);
+    const operation = operations.find((candidate) => candidate.operationId === rationale.operationId);
+    if (operation) {
+      const paragraphId = 'anchorId' in operation ? operation.anchorId : operation.id;
+      const offset = operation.kind === 'insert-after'
+        ? (scaffold.find((paragraph) => paragraph.id === paragraphId)?.originalText.length ?? 0)
+        : 0;
+      const anchor: AnnotationAnchor = operation.kind === 'insert-before' || operation.kind === 'insert-after'
+        ? { kind: 'point', point: { paragraphId, offset } }
+        : { kind: 'range', start: { paragraphId, offset: 0 }, end: { paragraphId, offset: operation.revisedText.length } };
+      annotations.push({
+        id: `rationale:${rationale.operationId}:${rationale.visibility}:${rationaleIndex}`,
+        operationId: rationale.operationId,
+        body: [{ runs: [{ text: rationale.text }] }],
+        audience: rationale.visibility,
+        semanticRole: 'drafting-note',
+        sourcePresentation: 'authored',
+        sourceAnchor: anchor,
+        anchor,
+      });
+    }
   }
   if (issues.length > 0 || !descriptor) return { valid: false, issues };
   return {
     valid: true,
-    ir: { version: IR_VERSION, source: descriptor, scaffold, operations, rationales, compilation, requirements, waivers, changeSets, assertions },
+    ir: { version: IR_VERSION, source: descriptor, scaffold, operations, rationales, annotations, compilation, requirements, waivers, changeSets, assertions },
   };
 }
 

--- a/packages/docx-markdoc/src/presentation.ts
+++ b/packages/docx-markdoc/src/presentation.ts
@@ -1,0 +1,193 @@
+import { DocxDocument, buildParagraphIndex, createRevisionContext, findParagraphByBookmarkId, type FootnoteRunStyle } from '@usejunior/docx-core';
+import { DocxMarkdocError } from './errors.js';
+import { sha256 } from './hash.js';
+import type {
+  AnnotationAnchor,
+  AnnotationPresentation,
+  AnnotationPresentationProfile,
+  AnnotationPresentationRule,
+  AnnotationRun,
+  AnnotationRunStyle,
+  CanonicalAnnotation,
+  EditOperation,
+  MarkdocEditIR,
+} from './types.js';
+
+const HIGHLIGHTS = new Set(['black', 'blue', 'cyan', 'green', 'magenta', 'red', 'yellow', 'white', 'darkBlue', 'darkCyan', 'darkGreen', 'darkMagenta', 'darkRed', 'darkYellow', 'darkGray', 'lightGray', 'none']);
+
+function normalizeStyle(style: AnnotationRunStyle | undefined, path: string): AnnotationRunStyle | undefined {
+  if (!style) return undefined;
+  const color = style.color?.toUpperCase();
+  if (color && !/^[0-9A-F]{6}$/.test(color)) throw new DocxMarkdocError('INVALID_ANNOTATION_COLOR', `${path}.color must be six-digit RGB.`);
+  if (style.highlight && !HIGHLIGHTS.has(style.highlight)) throw new DocxMarkdocError('INVALID_ANNOTATION_HIGHLIGHT', `${path}.highlight is not a Word highlight value.`);
+  return { ...style, ...(color ? { color } : {}) };
+}
+
+function normalizeRuns(runs: AnnotationRun[] | undefined, path: string): AnnotationRun[] | undefined {
+  return runs?.map((run, index) => {
+    if (typeof run.text !== 'string') throw new DocxMarkdocError('INVALID_ANNOTATION_RUN', `${path}[${index}].text must be a string.`);
+    return { text: run.text, ...(run.style ? { style: normalizeStyle(run.style, `${path}[${index}].style`) } : {}) };
+  });
+}
+
+function normalizeRule(rule: AnnotationPresentationRule, path: string): AnnotationPresentationRule {
+  if (!['preserve', 'comment', 'footnote', 'omit'].includes(rule.as)) throw new DocxMarkdocError('INVALID_ANNOTATION_PRESENTATION', `${path}.as is invalid.`);
+  return {
+    as: rule.as,
+    ...(rule.prefix ? { prefix: normalizeRuns(rule.prefix, `${path}.prefix`) } : {}),
+    ...(rule.separator ? { separator: normalizeRuns(rule.separator, `${path}.separator`) } : {}),
+    ...(rule.bodyStyle ? { bodyStyle: normalizeStyle(rule.bodyStyle, `${path}.bodyStyle`) } : {}),
+  };
+}
+
+export function normalizeAnnotationPresentationProfile(profile: AnnotationPresentationProfile | undefined): AnnotationPresentationProfile {
+  if (!profile) return {};
+  const result: AnnotationPresentationProfile = {};
+  for (const audience of ['internal', 'external-facing', 'unspecified'] as const) {
+    const rule = profile[audience];
+    if (rule) result[audience] = normalizeRule(rule, audience);
+  }
+  return result;
+}
+
+function projectedAs(annotation: CanonicalAnnotation, profile: AnnotationPresentationProfile): AnnotationPresentation {
+  const requested = annotation.presentation ?? profile[annotation.audience]?.as;
+  if (!requested) throw new DocxMarkdocError('UNROUTED_ANNOTATION', `Annotation ${annotation.id} has no presentation rule.`, { annotationId: annotation.id });
+  if (!annotation.presentation && annotation.semanticRole !== 'drafting-note') {
+    const source = annotation.sourcePresentation === 'authored' ? 'comment' : annotation.sourcePresentation;
+    if (requested === 'omit' || (requested !== 'preserve' && requested !== source)) {
+      throw new DocxMarkdocError('EXPLICIT_ANNOTATION_DECISION_REQUIRED', `Annotation ${annotation.id} requires an explicit per-annotation decision before conversion or omission.`, { annotationId: annotation.id });
+    }
+  }
+  if (requested !== 'preserve') return requested;
+  return annotation.sourcePresentation === 'authored' ? 'comment' : annotation.sourcePresentation;
+}
+
+function remapPosition(ir: MarkdocEditIR, position: { paragraphId: string; offset: number }, annotationId: string): { paragraphId: string; offset: number } {
+  const operation = ir.operations.find((item): item is Exclude<EditOperation, { anchorId: string }> => !('anchorId' in item) && item.id === position.paragraphId);
+  if (!operation || operation.originalText === operation.revisedText) return position;
+  const before = operation.originalText;
+  const after = operation.revisedText;
+  let prefix = 0;
+  while (prefix < before.length && prefix < after.length && before[prefix] === after[prefix]) prefix++;
+  let suffix = 0;
+  while (suffix < before.length - prefix && suffix < after.length - prefix
+    && before[before.length - 1 - suffix] === after[after.length - 1 - suffix]) suffix++;
+  if (position.offset <= prefix) return position;
+  if (position.offset >= before.length - suffix) return { ...position, offset: position.offset + after.length - before.length };
+  throw new DocxMarkdocError('ANNOTATION_ANCHOR_AMBIGUOUS', `Annotation ${annotationId} intersects edited text and cannot be remapped unambiguously.`, { annotationId, paragraphId: position.paragraphId, offset: position.offset });
+}
+
+function remapAnchor(ir: MarkdocEditIR, annotation: CanonicalAnnotation): AnnotationAnchor {
+  if (annotation.operationId?.length) return annotation.anchor;
+  if (annotation.anchor.kind === 'point') return { kind: 'point', point: remapPosition(ir, annotation.anchor.point, annotation.id) };
+  return { kind: 'range', start: remapPosition(ir, annotation.anchor.start, annotation.id), end: remapPosition(ir, annotation.anchor.end, annotation.id) };
+}
+
+function mergedBody(annotation: CanonicalAnnotation, overlay?: AnnotationRunStyle) {
+  return annotation.body.map((paragraph) => ({
+    runs: paragraph.runs.map((run) => ({ text: run.text, style: { ...(run.style ?? {}), ...(overlay ?? {}) } })),
+  }));
+}
+
+function flatText(annotation: CanonicalAnnotation): string {
+  return annotation.body.map((paragraph) => paragraph.runs.map((run) => run.text).join('')).join('\n');
+}
+
+export type AnnotationProjectionResult = {
+  buffer: Buffer;
+  profile: AnnotationPresentationProfile;
+  profileDigest: string;
+  dispositions: Array<{ id: string; audience: CanonicalAnnotation['audience']; as: AnnotationPresentation; lossy: boolean; warning?: string }>;
+  warnings: string[];
+};
+
+export async function projectAnnotations(buffer: Buffer, ir: MarkdocEditIR, requestedProfile?: AnnotationPresentationProfile): Promise<AnnotationProjectionResult> {
+  const profile = normalizeAnnotationPresentationProfile(requestedProfile);
+  const annotations = ir.annotations.filter((annotation) => !annotation.id.startsWith('rationale:'));
+  const planned = annotations.map((annotation) => ({ annotation, as: projectedAs(annotation, profile), anchor: remapAnchor(ir, annotation) }));
+  const preflight = await DocxDocument.load(buffer);
+  const documentXml = preflight.getDocumentXmlClone();
+  for (const item of planned) {
+    const points = item.anchor.kind === 'point' ? [item.anchor.point] : [item.anchor.start, item.anchor.end];
+    for (const point of points) {
+      const paragraph = findParagraphByBookmarkId(documentXml, point.paragraphId);
+      if (!paragraph) throw new DocxMarkdocError('ANNOTATION_ANCHOR_UNRESOLVABLE', `Annotation ${item.annotation.id} targets missing paragraph ${point.paragraphId}.`, { annotationId: item.annotation.id });
+      const length = buildParagraphIndex(paragraph).text.length;
+      if (point.offset < 0 || point.offset > length) throw new DocxMarkdocError('ANNOTATION_ANCHOR_UNRESOLVABLE', `Annotation ${item.annotation.id} offset ${point.offset} exceeds paragraph length ${length}.`, { annotationId: item.annotation.id });
+    }
+    if (item.as === 'comment' && item.anchor.kind === 'range' && item.anchor.start.paragraphId !== item.anchor.end.paragraphId) {
+      throw new DocxMarkdocError('ANNOTATION_CROSS_PARAGRAPH_COMMENT_UNSUPPORTED', `Annotation ${item.annotation.id} has a cross-paragraph comment range.`, { annotationId: item.annotation.id });
+    }
+  }
+
+  const document = await DocxDocument.load(buffer);
+  const sourceCommentRoots = annotations.filter((annotation) => annotation.sourcePresentation === 'comment' && !annotation.replyParentId);
+  for (const annotation of sourceCommentRoots) {
+    const id = Number(annotation.id.replace(/^comment:/, ''));
+    if (Number.isInteger(id)) await document.deleteComment({ commentId: id });
+  }
+  for (const annotation of annotations.filter((item) => item.sourcePresentation === 'footnote')) {
+    const id = Number(annotation.id.replace(/^footnote:/, ''));
+    if (Number.isInteger(id)) await document.deleteFootnote({ noteId: id });
+  }
+
+  const commentIds = new Map<string, number>();
+  const dispositions: AnnotationProjectionResult['dispositions'] = [];
+  const warnings: string[] = [];
+  for (const item of planned) {
+    const { annotation, as, anchor } = item;
+    const threadedLoss = Boolean(annotation.replyParentId) && as !== 'comment';
+    const rangeLoss = as === 'footnote' && anchor.kind === 'range';
+    const omissionLoss = as === 'omit';
+    const pointComment = as === 'comment' && anchor.kind === 'point';
+    const warning = threadedLoss
+      ? 'Reply topology is not representable in a footnote or omission.'
+      : rangeLoss
+        ? 'The footnote reference uses the range end; the complete range remains only in the canonical annotation.'
+        : omissionLoss
+          ? 'The annotation is intentionally absent from this document projection.'
+          : pointComment
+            ? 'Comment has no selected range and was emitted as a point comment.'
+            : undefined;
+    dispositions.push({ id: annotation.id, audience: annotation.audience, as, lossy: threadedLoss || rangeLoss || omissionLoss, ...(warning ? { warning } : {}) });
+    if (warning) warnings.push(`${annotation.id}: ${warning}`);
+    if (as === 'omit') continue;
+    const rule = profile[annotation.audience];
+    if (as === 'footnote') {
+      const point = anchor.kind === 'point' ? anchor.point : anchor.end;
+      await document.addFootnote({
+        paragraphId: point.paragraphId,
+        visibleOffset: point.offset,
+        text: flatText(annotation),
+        presentation: {
+          prefixRuns: rule?.prefix,
+          separatorRuns: rule?.separator,
+          body: mergedBody(annotation, rule?.bodyStyle) as Array<{ runs: Array<{ text: string; style?: FootnoteRunStyle }> }>,
+        },
+      });
+      continue;
+    }
+    if (annotation.replyParentId) {
+      const parentCommentId = commentIds.get(annotation.replyParentId);
+      if (parentCommentId === undefined) throw new DocxMarkdocError('ANNOTATION_REPLY_PROJECTION_UNRESOLVABLE', `Annotation ${annotation.id} reply parent was not emitted as a comment.`, { annotationId: annotation.id });
+      const result = await document.addCommentReply({
+        parentCommentId,
+        author: annotation.author ?? 'Markdoc', initials: annotation.initials,
+        text: flatText(annotation), body: mergedBody(annotation),
+      }, annotation.date ? createRevisionContext({ author: annotation.author ?? 'Markdoc', date: annotation.date }) : undefined);
+      commentIds.set(annotation.id, result.commentId);
+      continue;
+    }
+    const start = anchor.kind === 'point' ? anchor.point : anchor.start;
+    const end = anchor.kind === 'point' ? anchor.point : anchor.end;
+    const result = await document.addComment({
+      paragraphId: start.paragraphId, start: start.offset, end: end.offset,
+      author: annotation.author ?? 'Markdoc', initials: annotation.initials,
+      text: flatText(annotation), body: mergedBody(annotation),
+    }, annotation.date ? createRevisionContext({ author: annotation.author ?? 'Markdoc', date: annotation.date }) : undefined);
+    commentIds.set(annotation.id, result.commentId);
+  }
+  const output = (await document.toBuffer({ cleanBookmarks: false })).buffer;
+  return { buffer: output, profile, profileDigest: sha256(Buffer.from(JSON.stringify(profile))), dispositions, warnings };
+}

--- a/packages/docx-markdoc/src/rationale-comments.test.ts
+++ b/packages/docx-markdoc/src/rationale-comments.test.ts
@@ -440,14 +440,24 @@ describe('external-facing rationale comments', () => {
 
   itAllure('[SDX-MDOC-13][SDX-MDOC-44][SDX-MDOC-60] attributes paired rationale modes on a real public agreement', async () => {
     const fixture = fileURLToPath(new URL(
-      '../../../tests/test_documents/nvca-regression/source.docx',
+      '../../../tests/test_documents/open-agreements/letter-of-intent.docx',
       import.meta.url,
     ));
     const imported = await importDocxToMarkdoc(await readFile(fixture));
-    const paragraph = requireMarkdoc(imported.markdoc).scaffold.find((item) =>
+    const importedIr = requireMarkdoc(imported.markdoc);
+    const importedDocument = await DocxDocument.load(imported.anchoredSource);
+    const eligibleParagraphIds = new Set(importedDocument.buildDocumentView({ includeSemanticTags: false, showFormatting: false }).nodes
+      .filter((node) => !node.table_context && !node.footnote_refs?.length && !node.comments?.length)
+      .map((node) => node.id));
+    const annotationParagraphIds = new Set(importedIr.annotations.flatMap((annotation) => annotation.anchor.kind === 'point'
+      ? [annotation.anchor.point.paragraphId]
+      : [annotation.anchor.start.paragraphId, annotation.anchor.end.paragraphId]));
+    const paragraph = importedIr.scaffold.find((item) =>
       item.originalText.length >= 30 &&
       item.originalText.length <= 180 &&
-      !item.originalText.includes('\n'));
+      !item.originalText.includes('\n') &&
+      eligibleParagraphIds.has(item.id) &&
+      !annotationParagraphIds.has(item.id));
     if (!paragraph) throw new Error('real rationale smoke paragraph not found');
     const block = new RegExp(`\\{% para id="${paragraph.id}"[\\s\\S]*?\\{% /para %\\}`);
     const replacement = [
@@ -462,7 +472,8 @@ describe('external-facing rationale comments', () => {
       + rationale('real-rationale', 'internal', internalText)
       + rationale('real-rationale', 'external-facing', externalText);
 
-    const externalOnly = await compileMarkdoc(imported.anchoredSource, markdoc, compileOptions);
+    const annotationPresentation = { unspecified: { as: 'preserve' as const } };
+    const externalOnly = await compileMarkdoc(imported.anchoredSource, markdoc, { ...compileOptions, annotationPresentation });
     const externalParts = JSON.stringify(await parts(externalOnly.tracked));
     expect(externalOnly.certificate).toMatchObject({
       passed: true,
@@ -475,6 +486,7 @@ describe('external-facing rationale comments', () => {
 
     const paired = await compileMarkdoc(imported.anchoredSource, markdoc, {
       ...compileOptions,
+      annotationPresentation,
       dangerouslyIncludeInternalComments: true,
     });
     const pairedParts = JSON.stringify(await parts(paired.tracked));

--- a/packages/docx-markdoc/src/types.ts
+++ b/packages/docx-markdoc/src/types.ts
@@ -11,12 +11,58 @@ export type Rationale = {
   visibility: 'internal' | 'external-facing';
 };
 
+export type AnnotationAudience = 'internal' | 'external-facing' | 'unspecified';
+export type AnnotationSemanticRole = 'drafting-note' | 'substantive-footnote' | 'unspecified';
+export type AnnotationSourcePresentation = 'comment' | 'footnote' | 'authored';
+export type AnnotationPresentation = 'preserve' | 'comment' | 'footnote' | 'omit';
+
+export type AnnotationPosition = { paragraphId: string; offset: number };
+export type AnnotationPointAnchor = { kind: 'point'; point: AnnotationPosition };
+export type AnnotationRangeAnchor = { kind: 'range'; start: AnnotationPosition; end: AnnotationPosition };
+export type AnnotationAnchor = AnnotationPointAnchor | AnnotationRangeAnchor;
+
+export type AnnotationRunStyle = {
+  bold?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+  color?: string;
+  highlight?: 'black' | 'blue' | 'cyan' | 'green' | 'magenta' | 'red' | 'yellow' | 'white' | 'darkBlue' | 'darkCyan' | 'darkGreen' | 'darkMagenta' | 'darkRed' | 'darkYellow' | 'darkGray' | 'lightGray' | 'none';
+};
+
+export type AnnotationRun = { text: string; style?: AnnotationRunStyle };
+export type AnnotationParagraph = { runs: AnnotationRun[] };
+export type CanonicalAnnotation = {
+  id: string;
+  body: AnnotationParagraph[];
+  operationId?: string;
+  author?: string;
+  initials?: string;
+  date?: string;
+  replyParentId?: string;
+  audience: AnnotationAudience;
+  semanticRole: AnnotationSemanticRole;
+  readonly sourcePresentation: AnnotationSourcePresentation;
+  readonly sourceAnchor: AnnotationAnchor;
+  anchor: AnnotationAnchor;
+  presentation?: AnnotationPresentation;
+};
+
+export type AnnotationPresentationRule = {
+  as: AnnotationPresentation;
+  prefix?: AnnotationRun[];
+  separator?: AnnotationRun[];
+  bodyStyle?: AnnotationRunStyle;
+};
+
+export type AnnotationPresentationProfile = Partial<Record<AnnotationAudience, AnnotationPresentationRule>>;
+
 export type CompilationProfile = {
   revisionAuthor?: string;
   commentAuthor?: string;
   commentInitials?: string;
   buildDate?: string;
   externalComments: 'include' | 'omit';
+  annotationPresentation?: AnnotationPresentationProfile;
 };
 
 export type DraftRequirement = {
@@ -119,6 +165,7 @@ export type MarkdocEditIR = {
   scaffold: SourceParagraph[];
   operations: EditOperation[];
   rationales: Rationale[];
+  annotations: CanonicalAnnotation[];
   compilation?: CompilationProfile;
   /** Additive v1 fields; omitted legacy IR is treated as having no completeness declarations. */
   requirements?: DraftRequirement[];
@@ -164,6 +211,12 @@ export type VerificationCertificate = {
     internalRationalesFound: number;
     externalCommentsIncluded: boolean;
     internalCommentsIncluded: boolean;
+    warnings: string[];
+  };
+  annotationRendering: {
+    profile: AnnotationPresentationProfile;
+    profileDigest: string;
+    dispositions: Array<{ id: string; audience: AnnotationAudience; as: AnnotationPresentation; lossy: boolean; warning?: string }>;
     warnings: string[];
   };
   /** Exact source/reject and clean/accept replay verdict. */
@@ -245,12 +298,14 @@ export type CompileOptions = {
   externalComments?: boolean;
   dangerouslyIncludeInternalComments?: boolean;
   configurationSource?: 'api' | 'cli';
+  annotationPresentation?: AnnotationPresentationProfile;
 };
 
 export type ImportResult = {
   anchoredSource: Buffer;
   markdoc: string;
   source: SourceDescriptor;
+  annotations: CanonicalAnnotation[];
 };
 
 export type EditPair = {


### PR DESCRIPTION
## Summary

- add the durable canonical Markdoc annotation IR for authored rationales, Word comments, and Word footnotes
- strictly import structured note bodies, exact point/range anchors, admitted metadata, and reply topology
- project canonical annotations through API, JSON, Markdoc, and CLI profiles as preserve/comment/footnote/omit
- remap anchors through the paragraph-index visible-coordinate SSOT and fail closed on ambiguity
- record dispositions, lossy projections, warnings, and profile digest in verification certificates

## Verification

- `npm run build`
- `npm run lint:workspaces`
- `npm run test:run` (all workspaces; 76 docx-markdoc tests)
- `npm run check:spec-coverage`
- `npm run check:conformance-citations`
- `npm run check:conformance-doc`
- `openspec validate add-configurable-note-presentation --strict`

Conformance evidence covers ECMA-376 5th edition Part 1 §§17.13.4.4, 17.13.4.3, 17.13.4.5, and 17.11.14 through matching source JSDoc and Allure citations.

## Cross-reader evidence

- LibreOffice locally rendered a synthetic range-to-footnote projection with the reference at the exact range end and the note body visible.
- Locally licensed Aspose.Words produced the same one-page PDF; Aspose remains local-only and is not added to CI or package dependencies.
- Word fidelity was indeterminate because an unrelated user-document modal was already open; the probe did not inspect or dismiss it.

## Review

Dynamic Claude review: **APPROVE** after build, all 76 package tests, conformance citation validation, and strict OpenSpec validation. The review identified underreported lossy dispositions; range-to-footnote and omission are now explicitly lossy, and the suggested non-lossy point-comment regression assertions were added.

No private/customer documents were used or exposed.
