### PR TITLE
feat(docx-markdoc): preserve revisions during annotation projection

### DIFF
--- a/openspec/changes/preserve-existing-revisions-during-annotation-projection/proposal.md
+++ b/openspec/changes/preserve-existing-revisions-during-annotation-projection/proposal.md
@@ -1,0 +1,21 @@
+# Change: Preserve existing revisions during annotation projection
+
+## Why
+
+Canonical annotation recompilation currently rejects any anchored source that
+already contains tracked revisions. Annotation-only work must not require a
+destructive accept/reject preprocessing step.
+
+## What Changes
+
+- Admit annotation-only compilation from sources with existing revisions.
+- Preserve existing revision XML and story placement exactly while projecting annotations.
+- Verify annotation output against the source's own accept/reject projections.
+- Continue to fail closed when operative text edits are mixed with existing revisions.
+
+## Impact
+
+- Affected specs: `docx-markdoc`
+- Affected code: `packages/docx-markdoc/src/compile.ts`, certificate types, and annotation regression tests
+- Compatibility: the former blanket refusal becomes a narrowly admitted annotation-only path
+

--- a/openspec/changes/preserve-existing-revisions-during-annotation-projection/proposal.md
+++ b/openspec/changes/preserve-existing-revisions-during-annotation-projection/proposal.md
@@ -17,5 +17,9 @@ destructive accept/reject preprocessing step.
 
 - Affected specs: `docx-markdoc`
 - Affected code: `packages/docx-markdoc/src/compile.ts`, certificate types, and annotation regression tests
-- Compatibility: the former blanket refusal becomes a narrowly admitted annotation-only path
+- Compatibility: the former blanket refusal becomes a narrowly admitted annotation-only path. Two consequences are deliberate:
+  - Detection now covers every revision container accept/reject resolves (including the six property-change kinds) across document, header, footer, footnote, endnote, and comment stories, instead of `w:ins|w:del|w:moveFrom|w:moveTo` in `word/document.xml` only. A source whose only revision is, for example, a `w:pPrChange`, or whose only `w:ins` sits in a footer, previously compiled operative edits and now fails closed with `EXISTING_REVISIONS_WITH_OPERATIVE_EDITS_UNSUPPORTED`.
+  - Annotations whose range markers or reference run lie inside an existing revision container (a comment on, spanning, or starting at the end of inserted text) fail closed with `ANNOTATION_REVISION_TOPOLOGY_UNSUPPORTED`, because projection re-emits annotations by delete-and-re-add and cannot reproduce the container byte-for-byte. Editing such annotations in place is tracked in #960.
+- Known gap: projection still wraps each re-emitted root comment reference in a tracked `w:ins` carrying the comment date, so `projectedRevisionCount` exceeds `existingRevisionCount` by the number of re-emitted root comments; the preservation check is therefore ordered containment per story, not equality. Tracked in #961.
+- Revisions inside comment and footnote bodies are already rejected at import, so the ancillary-story coverage effectively applies to headers and footers.
 

--- a/openspec/changes/preserve-existing-revisions-during-annotation-projection/specs/docx-markdoc/spec.md
+++ b/openspec/changes/preserve-existing-revisions-during-annotation-projection/specs/docx-markdoc/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Annotation-only projection preserves existing revisions
+
+The compiler SHALL admit annotation-only compilation from a source containing
+supported existing tracked revisions. It SHALL preserve each existing revision's
+serialized XML, type, ID, author, date, content, accept/reject semantics, order,
+and WordprocessingML story placement while applying canonical annotation body
+edits and presentation choices.
+
+#### Scenario: [SDX-MDOC-92] Existing insertion survives ranged-comment editing
+- **GIVEN** a source containing an existing insertion and an admitted ranged comment
+- **WHEN** the canonical comment body is edited and projected
+- **THEN** the edited comment SHALL reopen with its range intact
+- **AND** the existing insertion SHALL retain exact XML and accept/reject semantics
+
+#### Scenario: [SDX-MDOC-93] Existing deletion survives point-comment editing
+- **GIVEN** a source containing an existing deletion and an admitted point comment
+- **WHEN** the canonical comment body is edited and projected
+- **THEN** the edited point comment SHALL reopen at the same visible coordinate
+- **AND** the existing deletion SHALL retain exact XML and accept/reject semantics
+
+#### Scenario: [SDX-MDOC-94] Existing revisions survive footnote presentation changes
+- **GIVEN** a source containing an existing revision and an admitted point footnote
+- **WHEN** the footnote body is edited and projected as a footnote or point comment
+- **THEN** each annotation projection SHALL contain the edited body at the canonical point
+- **AND** the existing revision SHALL retain exact XML and accept/reject semantics
+
+#### Scenario: [SDX-MDOC-95] Operative edits with existing revisions fail closed
+- **GIVEN** a source containing existing revisions and a canonical compile request containing operative text edits
+- **WHEN** compilation is attempted
+- **THEN** compilation SHALL fail before document mutation with revision and operation diagnostics
+- **AND** SHALL publish no partial output
+
+#### Scenario: [SDX-MDOC-96] Reply topology survives beside existing revisions
+- **GIVEN** a source containing an existing revision and an admitted comment thread
+- **WHEN** a reply body is edited and the thread is projected as comments
+- **THEN** the edited reply SHALL reopen under its original root comment
+- **AND** the existing revision SHALL retain exact XML and accept/reject semantics

--- a/openspec/changes/preserve-existing-revisions-during-annotation-projection/specs/docx-markdoc/spec.md
+++ b/openspec/changes/preserve-existing-revisions-during-annotation-projection/specs/docx-markdoc/spec.md
@@ -4,9 +4,18 @@
 
 The compiler SHALL admit annotation-only compilation from a source containing
 supported existing tracked revisions. It SHALL preserve each existing revision's
-serialized XML, type, ID, author, date, content, accept/reject semantics, order,
-and WordprocessingML story placement while applying canonical annotation body
-edits and presentation choices.
+serialized XML, type, ID, author, date, content, accept/reject semantics,
+relative order within its story, and WordprocessingML story placement while
+applying canonical annotation body edits and presentation choices.
+
+Supported existing revisions are the containers and range markers that
+accept/reject resolves — `w:ins`, `w:del`, the move family, and the six
+property-change kinds — plus `w:tblGridChange`, in the document, header,
+footer, footnote, endnote, and comment stories. A source containing any
+supported existing revision SHALL reject operative text edits before mutation.
+An annotation whose range markers or reference run lie inside an existing
+revision container is unsupported and SHALL fail closed with revision
+diagnostics before publishing output.
 
 #### Scenario: [SDX-MDOC-92] Existing insertion survives ranged-comment editing
 - **GIVEN** a source containing an existing insertion and an admitted ranged comment
@@ -15,7 +24,7 @@ edits and presentation choices.
 - **AND** the existing insertion SHALL retain exact XML and accept/reject semantics
 
 #### Scenario: [SDX-MDOC-93] Existing deletion survives point-comment editing
-- **GIVEN** a source containing an existing deletion and an admitted point comment
+- **GIVEN** a source containing an existing deletion and an admitted point comment after the deletion
 - **WHEN** the canonical comment body is edited and projected
 - **THEN** the edited point comment SHALL reopen at the same visible coordinate
 - **AND** the existing deletion SHALL retain exact XML and accept/reject semantics
@@ -37,3 +46,14 @@ edits and presentation choices.
 - **WHEN** a reply body is edited and the thread is projected as comments
 - **THEN** the edited reply SHALL reopen under its original root comment
 - **AND** the existing revision SHALL retain exact XML and accept/reject semantics
+
+#### Scenario: [SDX-MDOC-97] Annotation inside a revision container fails closed
+- **GIVEN** a source containing an existing insertion and an admitted comment whose range lies inside that insertion
+- **WHEN** the canonical comment body is edited and projected
+- **THEN** compilation SHALL fail with revision diagnostics naming the affected revision
+- **AND** SHALL publish no partial output
+
+#### Scenario: [SDX-MDOC-98] Property-change revisions gate operative edits
+- **GIVEN** a source whose only existing revision is a paragraph property change
+- **WHEN** a canonical compile request containing an operative text edit is attempted
+- **THEN** compilation SHALL fail before document mutation with revision and operation diagnostics

--- a/openspec/changes/preserve-existing-revisions-during-annotation-projection/tasks.md
+++ b/openspec/changes/preserve-existing-revisions-during-annotation-projection/tasks.md
@@ -1,8 +1,8 @@
 ## 1. Implementation
 
-- [x] 1.1 Detect and snapshot existing revisions across admitted WordprocessingML stories.
+- [x] 1.1 Detect and snapshot existing revisions across document, header, footer, footnote, endnote, and comment stories (revisions inside comment and footnote bodies are rejected at import).
 - [x] 1.2 Admit annotation-only projection while rejecting mixed operative edits before mutation.
-- [x] 1.3 Verify source revision XML, metadata, semantics, and story placement after projection.
+- [x] 1.3 Verify source revision XML, metadata, semantics, relative order, and story placement after projection, naming missing revisions in diagnostics.
 - [x] 1.4 Compare accept/reject output against the matching source projections.
 
 ## 2. Verification
@@ -12,4 +12,6 @@
 - [x] 2.3 Cover footnote body editing and footnote-to-comment projection.
 - [x] 2.4 Cover structured fail-closed behavior for mixed operative edits.
 - [x] 2.5 Cover reply topology beside an existing revision.
+- [x] 2.7 Cover fail-closed behavior for a comment range inside an existing insertion.
+- [x] 2.8 Cover property-change-only sources rejecting operative edits.
 - [x] 2.6 Run focused tests and the full repository pre-submit suite.

--- a/openspec/changes/preserve-existing-revisions-during-annotation-projection/tasks.md
+++ b/openspec/changes/preserve-existing-revisions-during-annotation-projection/tasks.md
@@ -1,0 +1,15 @@
+## 1. Implementation
+
+- [x] 1.1 Detect and snapshot existing revisions across admitted WordprocessingML stories.
+- [x] 1.2 Admit annotation-only projection while rejecting mixed operative edits before mutation.
+- [x] 1.3 Verify source revision XML, metadata, semantics, and story placement after projection.
+- [x] 1.4 Compare accept/reject output against the matching source projections.
+
+## 2. Verification
+
+- [x] 2.1 Cover insertion plus ranged-comment body editing.
+- [x] 2.2 Cover deletion plus point-comment body editing.
+- [x] 2.3 Cover footnote body editing and footnote-to-comment projection.
+- [x] 2.4 Cover structured fail-closed behavior for mixed operative edits.
+- [x] 2.5 Cover reply topology beside an existing revision.
+- [x] 2.6 Run focused tests and the full repository pre-submit suite.

--- a/packages/docx-markdoc/src/compile.ts
+++ b/packages/docx-markdoc/src/compile.ts
@@ -139,9 +139,31 @@ export function projectionChecksPassed(checks: Pick<
     && checks.existingRevisionsPreserved;
 }
 
+/**
+ * Revision containers and range markers whose serialized XML must survive an
+ * annotation-only projection unchanged. The set is deliberately the one that
+ * docx-core accept/reject resolves — `w:ins`/`w:del`, the move family, and the
+ * six property-change kinds — plus `w:tblGridChange`. `w:numberingChange`,
+ * `w:cellIns`/`w:cellDel`/`w:cellMerge`, and the `w:customXml*Range*` markers
+ * are outside the set: they are neither preservation-checked nor treated as
+ * existing revisions when gating operative edits.
+ *
+ * Limitation: the non-greedy body match ends at the first closing tag of the
+ * same name, so a container nested inside another container of the same kind
+ * truncates the outer capture. That topology is schema-valid but rare in Word
+ * output, and the truncation is symmetric across source and projection.
+ */
 const REVISION_ELEMENT_PATTERN = /<w:(ins|del|moveFrom|moveTo|moveFromRangeStart|moveFromRangeEnd|moveToRangeStart|moveToRangeEnd|rPrChange|pPrChange|tblPrChange|tblGridChange|trPrChange|tcPrChange|sectPrChange)\b(?:[^>]*\/>|[\s\S]*?<\/w:\1>)/gu;
 
 type RevisionSnapshot = Array<{ part: string; xml: string }>;
+
+type RevisionDescriptor = { part: string; element: string; id?: string };
+
+type RevisionPreservationReport = {
+  preserved: boolean;
+  /** Source revisions, in source order, that the projection no longer contains verbatim at or after the previous match. */
+  missing: RevisionDescriptor[];
+};
 
 /**
  * Capture exact revision elements together with their WordprocessingML story.
@@ -165,19 +187,38 @@ async function revisionSnapshot(buffer: Buffer): Promise<RevisionSnapshot> {
   return snapshot;
 }
 
-function sourceRevisionsPreserved(source: RevisionSnapshot, projected: RevisionSnapshot): boolean {
-  const projectedCounts = new Map<string, number>();
+function describeRevision(item: RevisionSnapshot[number]): RevisionDescriptor {
+  const element = /^<w:(\w+)/u.exec(item.xml)?.[1] ?? 'unknown';
+  const id = /^<[^>]*?\sw:id="([^"]*)"/u.exec(item.xml)?.[1];
+  return { part: item.part, element, ...(id === undefined ? {} : { id }) };
+}
+
+/**
+ * Every source revision must reappear verbatim in the projected output, in
+ * the same story part and in the same relative order. Projection may add
+ * revision markup of its own (see issue #961), so this is an ordered
+ * subsequence check per part rather than equality.
+ */
+function verifyRevisionPreservation(source: RevisionSnapshot, projected: RevisionSnapshot): RevisionPreservationReport {
+  const projectedByPart = new Map<string, string[]>();
   for (const item of projected) {
-    const key = JSON.stringify(item);
-    projectedCounts.set(key, (projectedCounts.get(key) ?? 0) + 1);
+    const list = projectedByPart.get(item.part) ?? [];
+    list.push(item.xml);
+    projectedByPart.set(item.part, list);
   }
+  const cursors = new Map<string, number>();
+  const missing: RevisionDescriptor[] = [];
   for (const item of source) {
-    const key = JSON.stringify(item);
-    const remaining = projectedCounts.get(key) ?? 0;
-    if (remaining === 0) return false;
-    projectedCounts.set(key, remaining - 1);
+    const candidates = projectedByPart.get(item.part) ?? [];
+    let index = cursors.get(item.part) ?? 0;
+    while (index < candidates.length && candidates[index] !== item.xml) index += 1;
+    if (index >= candidates.length) {
+      missing.push(describeRevision(item));
+      continue;
+    }
+    cursors.set(item.part, index + 1);
   }
-  return true;
+  return { preserved: missing.length === 0, missing };
 }
 
 function verificationText(document: DocxDocument): string {
@@ -853,14 +894,19 @@ export async function compileMarkdoc(
     tracked = annotationProjection.buffer;
   }
   const trackedRevisions = await revisionSnapshot(tracked);
-  const existingRevisionsPreserved = sourceRevisionsPreserved(sourceRevisions, trackedRevisions);
-  if (!existingRevisionsPreserved) {
+  const revisionPreservation = verifyRevisionPreservation(sourceRevisions, trackedRevisions);
+  if (!revisionPreservation.preserved) {
     throw new DocxMarkdocError(
       'ANNOTATION_REVISION_TOPOLOGY_UNSUPPORTED',
-      'Annotation projection would change existing revision XML or story placement.',
-      { sourceRevisionCount: sourceRevisions.length, projectedRevisionCount: trackedRevisions.length },
+      'Annotation projection would change existing revision XML, order, or story placement.',
+      {
+        sourceRevisionCount: sourceRevisions.length,
+        projectedRevisionCount: trackedRevisions.length,
+        missingRevisions: revisionPreservation.missing.slice(0, 8),
+      },
     );
   }
+  const existingRevisionsPreserved = revisionPreservation.preserved;
   const acceptedDoc = await DocxDocument.load(tracked);
   const rejectedDoc = await DocxDocument.load(tracked);
   await acceptedDoc.acceptChanges();
@@ -896,6 +942,7 @@ export async function compileMarkdoc(
     unchangedPackagePartsPreserved,
     existingRevisionsPreserved,
     existingRevisionCount: sourceRevisions.length,
+    projectedRevisionCount: trackedRevisions.length,
     unsupportedStructures: unsupported,
     appliedOperations: declaredOperationIds,
     commentRendering: {

--- a/packages/docx-markdoc/src/compile.ts
+++ b/packages/docx-markdoc/src/compile.ts
@@ -77,12 +77,24 @@ export async function verifyFormattingProjections(
   source: Buffer,
   clean: Buffer,
   tracked: Buffer,
+  sourceContainsRevisions = false,
 ): Promise<{
   rejectAllFormattingEqualsSource: boolean;
   acceptAllFormattingEqualsClean: boolean;
   formattingProjections: FormattingProjectionReport;
 }> {
-  const [sourceXml, cleanXml] = await Promise.all([documentXml(source), documentXml(clean)]);
+  let projectedSource = source;
+  let projectedClean = clean;
+  if (sourceContainsRevisions) {
+    const rejectedSource = await DocxDocument.load(source);
+    const acceptedClean = await DocxDocument.load(clean);
+    await Promise.all([rejectedSource.rejectChanges(), acceptedClean.acceptChanges()]);
+    [projectedSource, projectedClean] = await Promise.all([
+      rejectedSource.toBuffer({ cleanBookmarks: false }).then((result) => result.buffer),
+      acceptedClean.toBuffer({ cleanBookmarks: false }).then((result) => result.buffer),
+    ]);
+  }
+  const [sourceXml, cleanXml] = await Promise.all([documentXml(projectedSource), documentXml(projectedClean)]);
   const accepted = await DocxDocument.load(tracked);
   const rejected = await DocxDocument.load(tracked);
   await Promise.all([accepted.acceptChanges(), rejected.rejectChanges()]);
@@ -113,6 +125,7 @@ export function projectionChecksPassed(checks: Pick<
   | 'rejectAllFormattingEqualsSource'
   | 'acceptAllFormattingEqualsClean'
   | 'unchangedPackagePartsPreserved'
+  | 'existingRevisionsPreserved'
 >): boolean {
   return checks.sourceSha256Matches
     && checks.scaffoldComplete
@@ -122,7 +135,49 @@ export function projectionChecksPassed(checks: Pick<
     && checks.acceptAllEqualsClean
     && checks.rejectAllFormattingEqualsSource
     && checks.acceptAllFormattingEqualsClean
-    && checks.unchangedPackagePartsPreserved;
+    && checks.unchangedPackagePartsPreserved
+    && checks.existingRevisionsPreserved;
+}
+
+const REVISION_ELEMENT_PATTERN = /<w:(ins|del|moveFrom|moveTo|moveFromRangeStart|moveFromRangeEnd|moveToRangeStart|moveToRangeEnd|rPrChange|pPrChange|tblPrChange|tblGridChange|trPrChange|tcPrChange|sectPrChange)\b(?:[^>]*\/>|[\s\S]*?<\/w:\1>)/gu;
+
+type RevisionSnapshot = Array<{ part: string; xml: string }>;
+
+/**
+ * Capture exact revision elements together with their WordprocessingML story.
+ * This intentionally retains serialized IDs, authors, dates, content, and
+ * wrapper structure rather than reducing revisions to visible text.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.5.20
+ * @see https://github.com/UseJunior/safe-docx/issues/949
+ */
+async function revisionSnapshot(buffer: Buffer): Promise<RevisionSnapshot> {
+  const zip = await JSZip.loadAsync(buffer);
+  const snapshot: RevisionSnapshot = [];
+  const parts = Object.keys(zip.files)
+    .filter((name) => /^word\/(?:document|footnotes|endnotes|comments|header\d+|footer\d+)\.xml$/u.test(name))
+    .sort();
+  for (const part of parts) {
+    const xml = await zip.file(part)?.async('string');
+    if (!xml) continue;
+    for (const match of xml.matchAll(REVISION_ELEMENT_PATTERN)) snapshot.push({ part, xml: match[0] });
+  }
+  return snapshot;
+}
+
+function sourceRevisionsPreserved(source: RevisionSnapshot, projected: RevisionSnapshot): boolean {
+  const projectedCounts = new Map<string, number>();
+  for (const item of projected) {
+    const key = JSON.stringify(item);
+    projectedCounts.set(key, (projectedCounts.get(key) ?? 0) + 1);
+  }
+  for (const item of source) {
+    const key = JSON.stringify(item);
+    const remaining = projectedCounts.get(key) ?? 0;
+    if (remaining === 0) return false;
+    projectedCounts.set(key, remaining - 1);
+  }
+  return true;
 }
 
 function verificationText(document: DocxDocument): string {
@@ -697,10 +752,14 @@ export async function compileMarkdoc(
   const materializations = rationaleMaterializations(resolvedCompilation, ir);
   const sourceHashMatches = sha256(sourceBuffer) === ir.source.sha256;
   if (!sourceHashMatches) throw new DocxMarkdocError('SOURCE_HASH_DRIFT', 'Source DOCX hash does not match canonical Markdoc.');
-  const sourceZip = await JSZip.loadAsync(sourceBuffer);
-  const sourceXml = await sourceZip.file('word/document.xml')?.async('string');
-  if (sourceXml && /<w:(?:ins|del|moveFrom|moveTo)\b/.test(sourceXml)) {
-    throw new DocxMarkdocError('EXISTING_REVISIONS_UNSUPPORTED', 'V1 cannot compile a source DOCX that already contains tracked changes.');
+  const sourceRevisions = await revisionSnapshot(sourceBuffer);
+  const sourceContainsRevisions = sourceRevisions.length > 0;
+  if (sourceContainsRevisions && ir.operations.length > 0) {
+    throw new DocxMarkdocError(
+      'EXISTING_REVISIONS_WITH_OPERATIVE_EDITS_UNSUPPORTED',
+      'A source with existing revisions can only compile annotation-only changes.',
+      { existingRevisionCount: sourceRevisions.length, operationIds: ir.operations.map((operation) => operation.operationId) },
+    );
   }
   const sourceDocument = await DocxDocument.load(sourceBuffer);
   const { unsupported } = validateAgainstSource(ir, sourceDocument);
@@ -793,19 +852,35 @@ export async function compileMarkdoc(
     annotationProjection = await projectAnnotations(tracked, ir, options.annotationPresentation ?? ir.compilation?.annotationPresentation);
     tracked = annotationProjection.buffer;
   }
+  const trackedRevisions = await revisionSnapshot(tracked);
+  const existingRevisionsPreserved = sourceRevisionsPreserved(sourceRevisions, trackedRevisions);
+  if (!existingRevisionsPreserved) {
+    throw new DocxMarkdocError(
+      'ANNOTATION_REVISION_TOPOLOGY_UNSUPPORTED',
+      'Annotation projection would change existing revision XML or story placement.',
+      { sourceRevisionCount: sourceRevisions.length, projectedRevisionCount: trackedRevisions.length },
+    );
+  }
   const acceptedDoc = await DocxDocument.load(tracked);
   const rejectedDoc = await DocxDocument.load(tracked);
   await acceptedDoc.acceptChanges();
   await rejectedDoc.rejectChanges();
   const cleanDoc = await DocxDocument.load(clean);
-  const sourceText = verificationText(sourceDocument);
+  let sourceProjectionDocument = sourceDocument;
+  let cleanProjectionDocument = cleanDoc;
+  if (sourceContainsRevisions) {
+    sourceProjectionDocument = await DocxDocument.load(sourceBuffer);
+    cleanProjectionDocument = await DocxDocument.load(clean);
+    await Promise.all([sourceProjectionDocument.rejectChanges(), cleanProjectionDocument.acceptChanges()]);
+  }
+  const sourceText = verificationText(sourceProjectionDocument);
   const rejectedText = verificationText(rejectedDoc);
-  const cleanText = verificationText(cleanDoc);
+  const cleanText = verificationText(cleanProjectionDocument);
   const acceptedText = verificationText(acceptedDoc);
   const completeness = assessDraftCompleteness(ir, declaredOperationIds, cleanText);
   const rejectAllEqualsSource = rejectedText === sourceText;
   const acceptAllEqualsClean = acceptedText === cleanText;
-  const formattingProjection = await verifyFormattingProjections(sourceBuffer, clean, tracked);
+  const formattingProjection = await verifyFormattingProjections(sourceBuffer, clean, tracked, sourceContainsRevisions);
   const unchangedPackagePartsPreserved = await unchangedPartsEqual(sourceBuffer, clean);
   const certificate: VerificationCertificate = {
     version: 1,
@@ -819,6 +894,8 @@ export async function compileMarkdoc(
     acceptAllFormattingEqualsClean: formattingProjection.acceptAllFormattingEqualsClean,
     formattingProjections: formattingProjection.formattingProjections,
     unchangedPackagePartsPreserved,
+    existingRevisionsPreserved,
+    existingRevisionCount: sourceRevisions.length,
     unsupportedStructures: unsupported,
     appliedOperations: declaredOperationIds,
     commentRendering: {

--- a/packages/docx-markdoc/src/existing-revisions-annotation.test.ts
+++ b/packages/docx-markdoc/src/existing-revisions-annotation.test.ts
@@ -28,37 +28,44 @@ function physicalText(document: DocxDocument): string {
 
 async function revisedSource(kind: 'ins' | 'del', annotation: 'comment' | 'footnote', reply = false): Promise<Buffer> {
   const revision = kind === 'ins' ? INSERTION : DELETION;
-  const base = await buildDocxFromBodyXml(`<w:p>${annotation === 'footnote' ? '' : revision}<w:r><w:t>Alpha beta gamma.</w:t></w:r></w:p>`);
+  const base = await buildDocxFromBodyXml(`<w:p>${revision}<w:r><w:t>Alpha beta gamma.</w:t></w:r></w:p>`);
   const document = await DocxDocument.load(base);
   document.insertParagraphBookmarks(`revision-${kind}-${annotation}`);
   const paragraphId = document.buildDocumentView().nodes[0]!.id;
+  // Visible text is "Inserted Alpha beta gamma." for an insertion and
+  // "Alpha beta gamma." for a deletion (deleted text is not visible). Every
+  // anchor below lands outside the revision container itself.
   if (annotation === 'comment') {
     const point = kind === 'ins' ? { start: 15, end: 19 } : { start: 5, end: 5 };
     const root = await document.addComment({ paragraphId, ...point, author: 'Reviewer', initials: 'RV', text: 'Original note' });
     if (reply) await document.addCommentReply({ parentCommentId: root.commentId, author: 'Responder', initials: 'RS', text: 'Original reply' });
   } else {
-    await document.addFootnote({ paragraphId, visibleOffset: 7, text: 'Original footnote' });
+    await document.addFootnote({ paragraphId, visibleOffset: kind === 'ins' ? 14 : 7, text: 'Original footnote' });
   }
-  const output = (await document.toBuffer({ cleanBookmarks: false })).buffer;
-  if (annotation !== 'footnote') return output;
-  // Add the unrelated revision after the ordinary footnote has been created;
-  // the revision must not wrap the annotation reference itself.
-  const zip = await JSZip.loadAsync(output);
-  const xml = await zip.file('word/document.xml')!.async('string');
-  zip.file('word/document.xml', xml.replace('<w:r><w:t>Alpha beta gamma.</w:t></w:r>', `${revision}<w:r><w:t>Alpha beta gamma.</w:t></w:r>`));
-  return zip.generateAsync({ type: 'nodebuffer' });
+  return (await document.toBuffer({ cleanBookmarks: false })).buffer;
+}
+
+function rewriteFirstParagraph(markdoc: string): string {
+  const paragraph = requireMarkdoc(markdoc).scaffold[0]!;
+  return markdoc.replace(
+    new RegExp(`\\{% para id="${paragraph.id}"[\\s\\S]*?\\{% /para %\\}`),
+    `{% change id="${paragraph.id}" fingerprint="${paragraph.fingerprint}" style="${paragraph.style}" operation="rewrite" format="inherit-source-paragraph" %}\n{% before %}\n${paragraph.originalText}\n{% /before %}\n{% after %}\nRewritten.\n{% /after %}\n{% /change %}`,
+  );
 }
 
 describe('annotation-only projection preserves existing revisions', () => {
   test('[SDX-MDOC-92] edits a ranged comment without changing an existing insertion', async () => {
     const imported = await importDocxToMarkdoc(await revisedSource('ins', 'comment'));
     const before = await revisionXml(imported.anchoredSource);
+    expect(before).toHaveLength(1);
     const markdoc = imported.markdoc.replace('Original note', 'Edited note')
       .replace('source-presentation="comment"', 'source-presentation="comment" presentation="comment"');
     const result = await compileMarkdoc(imported.anchoredSource, markdoc);
 
     expect(await revisionXml(result.tracked)).toEqual(before);
-    expect(result.certificate).toMatchObject({ existingRevisionsPreserved: true, existingRevisionCount: 1 });
+    // projectedRevisionCount is 2, not 1: projection re-emits the root comment
+    // reference inside a tracked w:ins carrying the comment date (issue #961).
+    expect(result.certificate).toMatchObject({ existingRevisionsPreserved: true, existingRevisionCount: 1, projectedRevisionCount: 2 });
     expect((await (await DocxDocument.load(result.tracked)).getComments())[0]?.text).toBe('Edited note');
 
     const accepted = await DocxDocument.load(result.tracked);
@@ -72,11 +79,13 @@ describe('annotation-only projection preserves existing revisions', () => {
   test('[SDX-MDOC-93] edits a point comment without changing an existing deletion', async () => {
     const imported = await importDocxToMarkdoc(await revisedSource('del', 'comment'));
     const before = await revisionXml(imported.anchoredSource);
+    expect(before).toHaveLength(1);
     const markdoc = imported.markdoc.replace('Original note', 'Edited point note')
       .replace('source-presentation="comment"', 'source-presentation="comment" presentation="comment"');
     const result = await compileMarkdoc(imported.anchoredSource, markdoc);
 
     expect(await revisionXml(result.tracked)).toEqual(before);
+    expect(result.certificate).toMatchObject({ existingRevisionsPreserved: true, existingRevisionCount: 1, projectedRevisionCount: 2 });
     const comment = (await (await DocxDocument.load(result.tracked)).getComments())[0]!;
     expect(comment).toMatchObject({ text: 'Edited point note', startTextOffset: 5, endTextOffset: 5 });
     const accepted = await DocxDocument.load(result.tracked);
@@ -90,21 +99,25 @@ describe('annotation-only projection preserves existing revisions', () => {
   test('[SDX-MDOC-94] edits and re-presents a footnote while preserving revisions', async () => {
     const imported = await importDocxToMarkdoc(await revisedSource('ins', 'footnote'));
     const before = await revisionXml(imported.anchoredSource);
+    expect(before).toHaveLength(1);
     const asFootnote = imported.markdoc.replace('Original footnote', 'Edited footnote')
       .replace('source-presentation="footnote"', 'source-presentation="footnote" presentation="footnote"');
     const footnoteResult = await compileMarkdoc(imported.anchoredSource, asFootnote);
     expect(await revisionXml(footnoteResult.tracked)).toEqual(before);
+    expect(footnoteResult.certificate).toMatchObject({ existingRevisionsPreserved: true, existingRevisionCount: 1, projectedRevisionCount: 1 });
     expect((await (await DocxDocument.load(footnoteResult.tracked)).getFootnotes())[0]?.text).toContain('Edited footnote');
 
     const asComment = asFootnote.replace(' presentation="footnote"', ' presentation="comment"');
     const commentResult = await compileMarkdoc(imported.anchoredSource, asComment);
     expect(await revisionXml(commentResult.tracked)).toEqual(before);
+    expect(commentResult.certificate).toMatchObject({ existingRevisionsPreserved: true, existingRevisionCount: 1 });
     expect((await (await DocxDocument.load(commentResult.tracked)).getComments())[0]?.text).toContain('Edited footnote');
   });
 
   test('[SDX-MDOC-96] preserves reply topology beside an existing revision', async () => {
     const imported = await importDocxToMarkdoc(await revisedSource('ins', 'comment', true));
     const before = await revisionXml(imported.anchoredSource);
+    expect(before).toHaveLength(1);
     const markdoc = imported.markdoc.replace('Original reply', 'Edited reply')
       .replaceAll('source-presentation="comment"', 'source-presentation="comment" presentation="comment"');
     const result = await compileMarkdoc(imported.anchoredSource, markdoc);
@@ -112,18 +125,45 @@ describe('annotation-only projection preserves existing revisions', () => {
     expect(await revisionXml(result.tracked)).toEqual(before);
     const comments = await (await DocxDocument.load(result.tracked)).getComments();
     expect(comments[0]?.replies[0]?.text).toBe('Edited reply');
-    expect(result.certificate).toMatchObject({ existingRevisionsPreserved: true, existingRevisionCount: 1 });
+    expect(result.certificate).toMatchObject({ existingRevisionsPreserved: true, existingRevisionCount: 1, projectedRevisionCount: 2 });
   });
 
   test('[SDX-MDOC-95] fails atomically when existing revisions are combined with operative edits', async () => {
     const imported = await importDocxToMarkdoc(await revisedSource('ins', 'comment'));
-    const paragraph = requireMarkdoc(imported.markdoc).scaffold[0]!;
-    const edited = imported.markdoc.replace(
-      new RegExp(`\\{% para id="${paragraph.id}"[\\s\\S]*?\\{% /para %\\}`),
-      `{% change id="${paragraph.id}" fingerprint="${paragraph.fingerprint}" style="${paragraph.style}" operation="rewrite" format="inherit-source-paragraph" %}\n{% before %}\n${paragraph.originalText}\n{% /before %}\n{% after %}\nRewritten.\n{% /after %}\n{% /change %}`,
-    ).replace('source-presentation="comment"', 'source-presentation="comment" presentation="comment"');
+    const edited = rewriteFirstParagraph(imported.markdoc)
+      .replace('source-presentation="comment"', 'source-presentation="comment" presentation="comment"');
 
     await expect(compileMarkdoc(imported.anchoredSource, edited)).rejects.toMatchObject({
+      code: 'EXISTING_REVISIONS_WITH_OPERATIVE_EDITS_UNSUPPORTED',
+      details: { existingRevisionCount: 1, operationIds: ['rewrite'] },
+    });
+  });
+
+  test('[SDX-MDOC-97] fails closed when a comment range lies inside an existing insertion', async () => {
+    const base = await buildDocxFromBodyXml(
+      '<w:p><w:r><w:t>Alpha </w:t></w:r><w:ins w:id="44" w:author="Prior Author" w:date="2026-08-03T12:00:00Z"><w:r><w:t>Inserted text</w:t></w:r></w:ins><w:r><w:t> gamma.</w:t></w:r></w:p>',
+    );
+    const document = await DocxDocument.load(base);
+    document.insertParagraphBookmarks('revision-inline-comment');
+    const paragraphId = document.buildDocumentView().nodes[0]!.id;
+    await document.addComment({ paragraphId, start: 8, end: 12, author: 'Reviewer', initials: 'RV', text: 'Original note' });
+    const imported = await importDocxToMarkdoc((await document.toBuffer({ cleanBookmarks: false })).buffer);
+    const markdoc = imported.markdoc.replace('Original note', 'Edited note')
+      .replace('source-presentation="comment"', 'source-presentation="comment" presentation="comment"');
+
+    await expect(compileMarkdoc(imported.anchoredSource, markdoc)).rejects.toMatchObject({
+      code: 'ANNOTATION_REVISION_TOPOLOGY_UNSUPPORTED',
+      details: { sourceRevisionCount: 1, missingRevisions: [{ part: 'word/document.xml', element: 'ins', id: '44' }] },
+    });
+  });
+
+  test('[SDX-MDOC-98] rejects operative edits when the only existing revision is a property change', async () => {
+    const base = await buildDocxFromBodyXml(
+      '<w:p><w:pPr><w:jc w:val="center"/><w:pPrChange w:id="45" w:author="Prior Author" w:date="2026-08-04T12:00:00Z"><w:pPr/></w:pPrChange></w:pPr><w:r><w:t>Alpha beta gamma.</w:t></w:r></w:p>',
+    );
+    const imported = await importDocxToMarkdoc(base);
+
+    await expect(compileMarkdoc(imported.anchoredSource, rewriteFirstParagraph(imported.markdoc))).rejects.toMatchObject({
       code: 'EXISTING_REVISIONS_WITH_OPERATIVE_EDITS_UNSUPPORTED',
       details: { existingRevisionCount: 1, operationIds: ['rewrite'] },
     });

--- a/packages/docx-markdoc/src/existing-revisions-annotation.test.ts
+++ b/packages/docx-markdoc/src/existing-revisions-annotation.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect } from 'vitest';
+import JSZip from 'jszip';
+import { DocxDocument, getParagraphRuns } from '@usejunior/docx-core';
+import { buildDocxFromBodyXml } from '../../docx-core/src/testing/ooxml-fixtures.js';
+import { testAllure } from '../../docx-core/src/testing/allure-test.js';
+import { compileMarkdoc } from './compile.js';
+import { importDocxToMarkdoc } from './import.js';
+import { requireMarkdoc } from './markdoc.js';
+
+const test = testAllure.epic('DOCX Markdoc')
+  .withLabels({ feature: 'Canonical annotations with existing revisions' })
+  .conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.5.20' });
+
+const INSERTION = '<w:ins w:id="41" w:author="Prior Author" w:date="2026-08-01T12:00:00Z"><w:r><w:t>Inserted </w:t></w:r></w:ins>';
+const DELETION = '<w:del w:id="42" w:author="Prior Author" w:date="2026-08-02T12:00:00Z"><w:r><w:delText>Deleted </w:delText></w:r></w:del>';
+
+async function revisionXml(buffer: Buffer): Promise<string[]> {
+  const zip = await JSZip.loadAsync(buffer);
+  const xml = await zip.file('word/document.xml')!.async('string');
+  return [...xml.matchAll(/<w:(?:ins|del)\b(?:[^>]*\/>|[\s\S]*?<\/w:(?:ins|del)>)/gu)]
+    .map((match) => match[0])
+    .filter((revision) => revision.includes('w:author="Prior Author"'));
+}
+
+function physicalText(document: DocxDocument): string {
+  return document.getParagraphs().map((paragraph) => getParagraphRuns(paragraph).map((run) => run.text).join('')).join('\n');
+}
+
+async function revisedSource(kind: 'ins' | 'del', annotation: 'comment' | 'footnote', reply = false): Promise<Buffer> {
+  const revision = kind === 'ins' ? INSERTION : DELETION;
+  const base = await buildDocxFromBodyXml(`<w:p>${annotation === 'footnote' ? '' : revision}<w:r><w:t>Alpha beta gamma.</w:t></w:r></w:p>`);
+  const document = await DocxDocument.load(base);
+  document.insertParagraphBookmarks(`revision-${kind}-${annotation}`);
+  const paragraphId = document.buildDocumentView().nodes[0]!.id;
+  if (annotation === 'comment') {
+    const point = kind === 'ins' ? { start: 15, end: 19 } : { start: 5, end: 5 };
+    const root = await document.addComment({ paragraphId, ...point, author: 'Reviewer', initials: 'RV', text: 'Original note' });
+    if (reply) await document.addCommentReply({ parentCommentId: root.commentId, author: 'Responder', initials: 'RS', text: 'Original reply' });
+  } else {
+    await document.addFootnote({ paragraphId, visibleOffset: 7, text: 'Original footnote' });
+  }
+  const output = (await document.toBuffer({ cleanBookmarks: false })).buffer;
+  if (annotation !== 'footnote') return output;
+  // Add the unrelated revision after the ordinary footnote has been created;
+  // the revision must not wrap the annotation reference itself.
+  const zip = await JSZip.loadAsync(output);
+  const xml = await zip.file('word/document.xml')!.async('string');
+  zip.file('word/document.xml', xml.replace('<w:r><w:t>Alpha beta gamma.</w:t></w:r>', `${revision}<w:r><w:t>Alpha beta gamma.</w:t></w:r>`));
+  return zip.generateAsync({ type: 'nodebuffer' });
+}
+
+describe('annotation-only projection preserves existing revisions', () => {
+  test('[SDX-MDOC-92] edits a ranged comment without changing an existing insertion', async () => {
+    const imported = await importDocxToMarkdoc(await revisedSource('ins', 'comment'));
+    const before = await revisionXml(imported.anchoredSource);
+    const markdoc = imported.markdoc.replace('Original note', 'Edited note')
+      .replace('source-presentation="comment"', 'source-presentation="comment" presentation="comment"');
+    const result = await compileMarkdoc(imported.anchoredSource, markdoc);
+
+    expect(await revisionXml(result.tracked)).toEqual(before);
+    expect(result.certificate).toMatchObject({ existingRevisionsPreserved: true, existingRevisionCount: 1 });
+    expect((await (await DocxDocument.load(result.tracked)).getComments())[0]?.text).toBe('Edited note');
+
+    const accepted = await DocxDocument.load(result.tracked);
+    const rejected = await DocxDocument.load(result.tracked);
+    await accepted.acceptChanges();
+    await rejected.rejectChanges();
+    expect(physicalText(accepted)).toContain('Inserted Alpha beta gamma.');
+    expect(physicalText(rejected)).not.toContain('Inserted ');
+  });
+
+  test('[SDX-MDOC-93] edits a point comment without changing an existing deletion', async () => {
+    const imported = await importDocxToMarkdoc(await revisedSource('del', 'comment'));
+    const before = await revisionXml(imported.anchoredSource);
+    const markdoc = imported.markdoc.replace('Original note', 'Edited point note')
+      .replace('source-presentation="comment"', 'source-presentation="comment" presentation="comment"');
+    const result = await compileMarkdoc(imported.anchoredSource, markdoc);
+
+    expect(await revisionXml(result.tracked)).toEqual(before);
+    const comment = (await (await DocxDocument.load(result.tracked)).getComments())[0]!;
+    expect(comment).toMatchObject({ text: 'Edited point note', startTextOffset: 5, endTextOffset: 5 });
+    const accepted = await DocxDocument.load(result.tracked);
+    const rejected = await DocxDocument.load(result.tracked);
+    await accepted.acceptChanges();
+    await rejected.rejectChanges();
+    expect(physicalText(accepted)).not.toContain('Deleted ');
+    expect(physicalText(rejected)).toContain('Deleted Alpha beta gamma.');
+  });
+
+  test('[SDX-MDOC-94] edits and re-presents a footnote while preserving revisions', async () => {
+    const imported = await importDocxToMarkdoc(await revisedSource('ins', 'footnote'));
+    const before = await revisionXml(imported.anchoredSource);
+    const asFootnote = imported.markdoc.replace('Original footnote', 'Edited footnote')
+      .replace('source-presentation="footnote"', 'source-presentation="footnote" presentation="footnote"');
+    const footnoteResult = await compileMarkdoc(imported.anchoredSource, asFootnote);
+    expect(await revisionXml(footnoteResult.tracked)).toEqual(before);
+    expect((await (await DocxDocument.load(footnoteResult.tracked)).getFootnotes())[0]?.text).toContain('Edited footnote');
+
+    const asComment = asFootnote.replace(' presentation="footnote"', ' presentation="comment"');
+    const commentResult = await compileMarkdoc(imported.anchoredSource, asComment);
+    expect(await revisionXml(commentResult.tracked)).toEqual(before);
+    expect((await (await DocxDocument.load(commentResult.tracked)).getComments())[0]?.text).toContain('Edited footnote');
+  });
+
+  test('[SDX-MDOC-96] preserves reply topology beside an existing revision', async () => {
+    const imported = await importDocxToMarkdoc(await revisedSource('ins', 'comment', true));
+    const before = await revisionXml(imported.anchoredSource);
+    const markdoc = imported.markdoc.replace('Original reply', 'Edited reply')
+      .replaceAll('source-presentation="comment"', 'source-presentation="comment" presentation="comment"');
+    const result = await compileMarkdoc(imported.anchoredSource, markdoc);
+
+    expect(await revisionXml(result.tracked)).toEqual(before);
+    const comments = await (await DocxDocument.load(result.tracked)).getComments();
+    expect(comments[0]?.replies[0]?.text).toBe('Edited reply');
+    expect(result.certificate).toMatchObject({ existingRevisionsPreserved: true, existingRevisionCount: 1 });
+  });
+
+  test('[SDX-MDOC-95] fails atomically when existing revisions are combined with operative edits', async () => {
+    const imported = await importDocxToMarkdoc(await revisedSource('ins', 'comment'));
+    const paragraph = requireMarkdoc(imported.markdoc).scaffold[0]!;
+    const edited = imported.markdoc.replace(
+      new RegExp(`\\{% para id="${paragraph.id}"[\\s\\S]*?\\{% /para %\\}`),
+      `{% change id="${paragraph.id}" fingerprint="${paragraph.fingerprint}" style="${paragraph.style}" operation="rewrite" format="inherit-source-paragraph" %}\n{% before %}\n${paragraph.originalText}\n{% /before %}\n{% after %}\nRewritten.\n{% /after %}\n{% /change %}`,
+    ).replace('source-presentation="comment"', 'source-presentation="comment" presentation="comment"');
+
+    await expect(compileMarkdoc(imported.anchoredSource, edited)).rejects.toMatchObject({
+      code: 'EXISTING_REVISIONS_WITH_OPERATIVE_EDITS_UNSUPPORTED',
+      details: { existingRevisionCount: 1, operationIds: ['rewrite'] },
+    });
+  });
+});

--- a/packages/docx-markdoc/src/formatting-projection-certificate.test.ts
+++ b/packages/docx-markdoc/src/formatting-projection-certificate.test.ts
@@ -88,6 +88,7 @@ describe('formatting-aware projection certificate', () => {
       rejectAllFormattingEqualsSource: certification.rejectAllFormattingEqualsSource,
       acceptAllFormattingEqualsClean: certification.acceptAllFormattingEqualsClean,
       unchangedPackagePartsPreserved: true,
+      existingRevisionsPreserved: true,
     })).toBe(false);
     expect(certification.formattingProjections.cleanAcceptAll).toMatchObject({
       divergenceCount: expect.any(Number),

--- a/packages/docx-markdoc/src/types.ts
+++ b/packages/docx-markdoc/src/types.ts
@@ -199,9 +199,11 @@ export type VerificationCertificate = {
   /** Bounded, actionable details for each semantic formatting projection check. */
   formattingProjections: FormattingProjectionReport;
   unchangedPackagePartsPreserved: boolean;
-  /** Exact serialized source revision elements remain in their original story parts. */
+  /** Exact serialized source revision elements remain, in order, in their original story parts. */
   existingRevisionsPreserved: boolean;
   existingRevisionCount: number;
+  /** Revision elements in the projected output; exceeds `existingRevisionCount` when projection emits tracked markup of its own. */
+  projectedRevisionCount: number;
   unsupportedStructures: string[];
   appliedOperations: string[];
   commentRendering: {

--- a/packages/docx-markdoc/src/types.ts
+++ b/packages/docx-markdoc/src/types.ts
@@ -199,6 +199,9 @@ export type VerificationCertificate = {
   /** Bounded, actionable details for each semantic formatting projection check. */
   formattingProjections: FormattingProjectionReport;
   unchangedPackagePartsPreserved: boolean;
+  /** Exact serialized source revision elements remain in their original story parts. */
+  existingRevisionsPreserved: boolean;
+  existingRevisionCount: number;
   unsupportedStructures: string[];
   appliedOperations: string[];
   commentRendering: {


### PR DESCRIPTION
## Summary

- allow annotation-only Markdoc compilation when the anchored source already contains tracked revisions
- preserve exact existing revision XML, metadata, relative order, and WordprocessingML story placement; name any missing revision in `ANNOTATION_REVISION_TOPOLOGY_UNSUPPORTED` diagnostics
- verify accept/reject output against the source's own accept/reject projections
- fail closed before mutation when existing revisions are combined with operative text edits
- publish `existingRevisionsPreserved`, `existingRevisionCount`, and `projectedRevisionCount` on the certificate
- add OpenSpec requirements and synthetic insertion, deletion, comment, footnote, conversion, reply, and atomic-failure coverage

Refs #949 — the remaining acceptance criterion (editing comments anchored on redlined text) is tracked in #960.

## Behaviour changes to be aware of

- Detection now covers every revision container accept/reject resolves (including the six property-change kinds) across document, header, footer, footnote, endnote, and comment stories, instead of `w:ins|w:del|w:moveFrom|w:moveTo` in `word/document.xml` only. A source whose only revision is a `w:pPrChange`, or whose only `w:ins` sits in a footer, previously compiled operative edits and now fails closed with `EXISTING_REVISIONS_WITH_OPERATIVE_EDITS_UNSUPPORTED` (SDX-MDOC-98).
- Annotations whose range markers or reference run lie inside an existing revision container (a comment on, spanning, or starting at the end of inserted text) fail closed with `ANNOTATION_REVISION_TOPOLOGY_UNSUPPORTED` (SDX-MDOC-97). In-place body editing to lift this is #960.
- Projection still wraps each re-emitted root comment reference in a tracked `w:ins` carrying the comment date, so `projectedRevisionCount` exceeds `existingRevisionCount` by the number of re-emitted root comments; the preservation check is therefore ordered containment per story, not equality. Tracked in #961.

## Peer review

Dynamic review (Claude Fable 5, worktree at `9a28178`) returned REQUEST-CHANGES; items 1–4 are incorporated in the follow-up commit, items 5–6 documented, 7–9 confirmed clean (oracles complementary; atomicity holds; serializer idempotent on a 537 KB Word-authored `document.xml`; timing within noise; clean merge against `origin/main` with 90/90 tests). Review prompt and output are kept locally under `.peer-review/`.

## Verification

- `packages/docx-markdoc` typecheck passed
- docx-markdoc package suite: 83 passed (8 files)
- focused annotation suite: 7 passed
- `openspec validate … --strict` passed
- `check:spec-coverage`, `check:conformance-citations`, `check:allure-labels`, `check:allure-quality`, `check:allure-filenames`, `check:changelog` all exit 0