### PR TITLE
feat(docx-markdoc): admit named annotation run styles

### DIFF
--- a/openspec/changes/admit-annotation-run-styles/proposal.md
+++ b/openspec/changes/admit-annotation-run-styles/proposal.md
@@ -1,0 +1,21 @@
+# Change: Admit annotation run styles
+
+## Why
+
+Annotation import currently fails closed on ordinary named character styles,
+including the FootnoteTextChar and Hyperlink styles used by real Word documents.
+The canonical annotation model must retain these references so projection does
+not flatten inherited formatting.
+
+## What Changes
+
+- Admit resolvable `w:rStyle` references and direct `w:sz` values in annotation bodies.
+- Retain style identifiers and half-point sizes in canonical Markdoc annotation runs.
+- Re-emit retained values when projecting annotations as comments or footnotes.
+- Reject missing and cyclic style chains without partially importing a document.
+
+## Impact
+
+- Affected specs: docx-markdoc
+- Affected code: docx-markdoc annotation import/model and docx-core comment/footnote emitters
+- Tracking issue: #951

--- a/openspec/changes/admit-annotation-run-styles/specs/docx-markdoc/spec.md
+++ b/openspec/changes/admit-annotation-run-styles/specs/docx-markdoc/spec.md
@@ -3,7 +3,7 @@
 ### Requirement: Annotation run style fidelity
 
 The annotation importer SHALL admit named character styles whose complete
-`basedOn` chain resolves in the source styles part, retain the original style
+`basedOn` chain resolves exclusively to character styles in the source styles part, retain the original style
 identifier and direct half-point font size in the canonical annotation body,
 and re-emit those values when projecting the body as either a comment or a
 footnote. Missing or cyclic style chains SHALL fail closed.
@@ -17,7 +17,7 @@ footnote. Missing or cyclic style chains SHALL fail closed.
 
 #### Scenario: [SDX-MDOC-102] invalid named style chains fail closed
 
-- **GIVEN** an annotation body run whose style is missing or whose `basedOn` chain is cyclic
+- **GIVEN** an annotation body run whose style is missing, has a non-character member, or whose `basedOn` chain is cyclic
 - **WHEN** the annotation is imported
 - **THEN** import SHALL fail with `ANNOTATION_IMPORT_UNSUPPORTED`
 - **AND** the error SHALL identify whether the chain is missing or cyclic
@@ -28,4 +28,3 @@ footnote. Missing or cyclic style chains SHALL fail closed.
 - **WHEN** its annotations are imported
 - **THEN** named run styles and direct font sizes SHALL NOT cause rejection
 - **AND** a later unsupported hyperlink container SHALL still fail closed explicitly
-

--- a/openspec/changes/admit-annotation-run-styles/specs/docx-markdoc/spec.md
+++ b/openspec/changes/admit-annotation-run-styles/specs/docx-markdoc/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Annotation run style fidelity
+
+The annotation importer SHALL admit named character styles whose complete
+`basedOn` chain resolves in the source styles part, retain the original style
+identifier and direct half-point font size in the canonical annotation body,
+and re-emit those values when projecting the body as either a comment or a
+footnote. Missing or cyclic style chains SHALL fail closed.
+
+#### Scenario: [SDX-MDOC-101] inherited named style survives annotation projection
+
+- **GIVEN** an annotation body run with a named character style inherited through `basedOn` and a direct `w:sz`
+- **WHEN** the annotation is imported and projected as a comment or footnote
+- **THEN** the canonical run SHALL retain the style identifier and half-point size
+- **AND** each output SHALL contain the corresponding `w:rStyle` and `w:sz`
+
+#### Scenario: [SDX-MDOC-102] invalid named style chains fail closed
+
+- **GIVEN** an annotation body run whose style is missing or whose `basedOn` chain is cyclic
+- **WHEN** the annotation is imported
+- **THEN** import SHALL fail with `ANNOTATION_IMPORT_UNSUPPORTED`
+- **AND** the error SHALL identify whether the chain is missing or cyclic
+
+#### Scenario: [SDX-MDOC-103] real styled footnotes reach the next unsupported boundary
+
+- **GIVEN** a real Word document containing FootnoteTextChar, FootnoteReference, and Hyperlink run styles
+- **WHEN** its annotations are imported
+- **THEN** named run styles and direct font sizes SHALL NOT cause rejection
+- **AND** a later unsupported hyperlink container SHALL still fail closed explicitly
+

--- a/openspec/changes/admit-annotation-run-styles/tasks.md
+++ b/openspec/changes/admit-annotation-run-styles/tasks.md
@@ -1,0 +1,13 @@
+## 1. Implementation
+
+- [x] 1.1 Extend canonical annotation runs with named style and half-point size fields.
+- [x] 1.2 Validate named style inheritance and fail closed for missing or cyclic chains.
+- [x] 1.3 Preserve admitted style data through Markdoc parsing and serialization.
+- [x] 1.4 Re-emit admitted style data in comment and footnote projections.
+
+## 2. Verification
+
+- [x] 2.1 Cover inherited, missing, and cyclic named styles with focused tests.
+- [x] 2.2 Verify comment and footnote projection output retains style and size elements.
+- [x] 2.3 Exercise the two real ILPA fixtures and pin the next unsupported boundary.
+- [x] 2.4 Run all repository pre-submit gates.

--- a/packages/docx-core/src/primitives/comments.ts
+++ b/packages/docx-core/src/primitives/comments.ts
@@ -204,7 +204,14 @@ export type AddCommentParams = {
   body?: CommentBodyParagraph[];
 };
 
-export type CommentBodyRun = { text: string; style?: { bold?: boolean; italic?: boolean; underline?: boolean; color?: string; highlight?: string } };
+/**
+ * A structured comment-body run and its admitted character formatting.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.3.2.29
+ * @conformance ECMA-376 edition 5, Part 1 § 17.3.2.38
+ * @see #951
+ */
+export type CommentBodyRun = { text: string; style?: { styleId?: string; fontSizeHalfPoints?: number; bold?: boolean; italic?: boolean; underline?: boolean; color?: string; highlight?: string } };
 export type CommentBodyParagraph = { runs: CommentBodyRun[] };
 
 export type AddCommentResult = {
@@ -551,6 +558,16 @@ function buildCommentBodyRun(doc: Document, bodyRun: CommentBodyRun): Element {
   const style = bodyRun.style;
   if (style && Object.values(style).some((value) => value !== undefined && value !== false)) {
     const rPr = doc.createElementNS(OOXML.W_NS, 'w:rPr');
+    if (style.styleId) {
+      const rStyle = doc.createElementNS(OOXML.W_NS, 'w:rStyle');
+      rStyle.setAttributeNS(OOXML.W_NS, 'w:val', style.styleId);
+      rPr.appendChild(rStyle);
+    }
+    if (style.fontSizeHalfPoints !== undefined) {
+      const size = doc.createElementNS(OOXML.W_NS, 'w:sz');
+      size.setAttributeNS(OOXML.W_NS, 'w:val', String(style.fontSizeHalfPoints));
+      rPr.appendChild(size);
+    }
     if (style.bold) rPr.appendChild(doc.createElementNS(OOXML.W_NS, 'w:b'));
     if (style.italic) rPr.appendChild(doc.createElementNS(OOXML.W_NS, 'w:i'));
     if (style.underline) {

--- a/packages/docx-core/src/primitives/footnotes.ts
+++ b/packages/docx-core/src/primitives/footnotes.ts
@@ -107,7 +107,16 @@ export type AddFootnoteParams = {
   presentation?: FootnoteNotePresentation;
 };
 
+/**
+ * Admitted character formatting for a generated footnote run.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.3.2.29
+ * @conformance ECMA-376 edition 5, Part 1 § 17.3.2.38
+ * @see #951
+ */
 export type FootnoteRunStyle = {
+  styleId?: string;
+  fontSizeHalfPoints?: number;
   bold?: boolean;
   italic?: boolean;
   underline?: boolean;
@@ -789,6 +798,16 @@ function buildStyledTextRun(doc: Document, text: string, style?: FootnoteRunStyl
       const el = doc.createElementNS(OOXML.W_NS, `w:${name}`);
       rPr.appendChild(el);
     };
+    if (style.styleId) {
+      const rStyle = doc.createElementNS(OOXML.W_NS, 'w:rStyle');
+      rStyle.setAttributeNS(OOXML.W_NS, 'w:val', style.styleId);
+      rPr.appendChild(rStyle);
+    }
+    if (style.fontSizeHalfPoints !== undefined) {
+      const size = doc.createElementNS(OOXML.W_NS, 'w:sz');
+      size.setAttributeNS(OOXML.W_NS, 'w:val', String(style.fontSizeHalfPoints));
+      rPr.appendChild(size);
+    }
     if (style.bold) onOff('b');
     if (style.italic) onOff('i');
     if (style.underline) {

--- a/packages/docx-core/src/primitives/styles.ts
+++ b/packages/docx-core/src/primitives/styles.ts
@@ -9,6 +9,7 @@ function getWAttr(el: Element, localName: string): string | null {
 
 export type StyleDef = {
   styleId: string;
+  styleType: string | null;
   name: string;
   basedOn: string | null;
   pPr: Element | null;
@@ -114,6 +115,7 @@ export function parseStylesXml(stylesDoc: Document | null): StylesModel {
 
     byId.set(id, {
       styleId: id,
+      styleType: getWAttr(st, 'type'),
       name,
       basedOn,
       pPr: pPr ?? null,

--- a/packages/docx-markdoc/src/annotation-roundtrip.test.ts
+++ b/packages/docx-markdoc/src/annotation-roundtrip.test.ts
@@ -1,3 +1,4 @@
+import { readFile } from 'node:fs/promises';
 import { describe, expect } from 'vitest';
 import JSZip from 'jszip';
 import { buildSyntheticDocx, DocxDocument } from '@usejunior/docx-core';
@@ -33,6 +34,22 @@ async function sourceWithFootnote(offset: number): Promise<Buffer> {
   const paragraphId = document.buildDocumentView().nodes[0]!.id;
   await document.addFootnote({ paragraphId, visibleOffset: offset, text: 'Substantive note' });
   return (await document.toBuffer({ cleanBookmarks: false })).buffer;
+}
+
+async function sourceWithNamedStyleComment(styles: string): Promise<Buffer> {
+  const base = await buildSyntheticDocx({ paragraphs: ['Alpha beta gamma.'] });
+  const document = await DocxDocument.load(base);
+  document.insertParagraphBookmarks('annotation-style-test');
+  const paragraphId = document.buildDocumentView().nodes[0]!.id;
+  await document.addComment({ paragraphId, start: 0, end: 5, author: 'Style Tester', initials: 'ST', text: 'Named style' });
+  const zip = await JSZip.loadAsync((await document.toBuffer({ cleanBookmarks: false })).buffer);
+  const commentsXml = await zip.file('word/comments.xml')!.async('string');
+  zip.file('word/comments.xml', commentsXml.replace(
+    '<w:t>Named style</w:t>',
+    '<w:rPr><w:rStyle w:val="AnnotationChild"/><w:sz w:val="18"/><w:szCs w:val="18"/></w:rPr><w:t>Named style</w:t>',
+  ));
+  zip.file('word/styles.xml', `<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">${styles}</w:styles>`);
+  return zip.generateAsync({ type: 'nodebuffer' });
 }
 
 describe('canonical annotation round trips', () => {
@@ -83,6 +100,60 @@ describe('canonical annotation round trips', () => {
     expect(comment.startTextOffset).toBe(7);
     expect(comment.endTextOffset).toBe(7);
     expect(result.certificate.annotationRendering.dispositions[0]).toMatchObject({ as: 'comment', lossy: false });
+  });
+
+  const runStyleConformance = test
+    .conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.3.2.29' })
+    .conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.3.2.38' });
+
+  runStyleConformance('[SDX-MDOC-101] preserves inherited named run styles and direct sizes across annotation projections', async () => {
+    const source = await sourceWithNamedStyleComment([
+      '<w:style w:type="character" w:styleId="AnnotationParent"><w:name w:val="Annotation Parent"/><w:rPr><w:b/><w:color w:val="884400"/></w:rPr></w:style>',
+      '<w:style w:type="character" w:styleId="AnnotationChild"><w:name w:val="Annotation Child"/><w:basedOn w:val="AnnotationParent"/></w:style>',
+    ].join(''));
+    const imported = await importDocxToMarkdoc(source);
+    expect(imported.annotations[0]?.body[0]?.runs).toEqual([
+      { text: 'Named style', style: { bold: true, color: '884400', styleId: 'AnnotationChild', fontSizeHalfPoints: 18 } },
+    ]);
+    expect(imported.markdoc).toContain('style="AnnotationChild" size=18 bold=true color="884400"');
+
+    const asComment = await compileMarkdoc(imported.anchoredSource, imported.markdoc.replace(
+      'source-presentation="comment"', 'source-presentation="comment" presentation="comment"',
+    ));
+    const commentXml = await (await JSZip.loadAsync(asComment.tracked)).file('word/comments.xml')!.async('string');
+    expect(commentXml).toContain('<w:rStyle w:val="AnnotationChild"/>');
+    expect(commentXml).toContain('<w:sz w:val="18"/>');
+
+    const asFootnote = await compileMarkdoc(imported.anchoredSource, imported.markdoc.replace(
+      'source-presentation="comment"', 'source-presentation="comment" presentation="footnote"',
+    ));
+    const footnoteXml = await (await JSZip.loadAsync(asFootnote.tracked)).file('word/footnotes.xml')!.async('string');
+    expect(footnoteXml).toContain('<w:rStyle w:val="AnnotationChild"/>');
+    expect(footnoteXml).toContain('<w:sz w:val="18"/>');
+  });
+
+  runStyleConformance('[SDX-MDOC-102] rejects missing and cyclic named annotation styles', async () => {
+    await expect(importDocxToMarkdoc(await sourceWithNamedStyleComment(''))).rejects.toMatchObject({
+      code: 'ANNOTATION_IMPORT_UNSUPPORTED', details: { annotationId: 'comment:0', reason: 'missing-style' },
+    });
+    await expect(importDocxToMarkdoc(await sourceWithNamedStyleComment([
+      '<w:style w:type="character" w:styleId="AnnotationChild"><w:basedOn w:val="AnnotationParent"/></w:style>',
+      '<w:style w:type="character" w:styleId="AnnotationParent"><w:basedOn w:val="AnnotationChild"/></w:style>',
+    ].join('')))).rejects.toMatchObject({
+      code: 'ANNOTATION_IMPORT_UNSUPPORTED', details: { annotationId: 'comment:0', reason: 'cyclic-style' },
+    });
+  });
+
+  runStyleConformance('[SDX-MDOC-103] admits real ILPA style runs before failing closed on hyperlinks', async () => {
+    const fixtures = [
+      '../../../tests/test_documents/redline/ILPA-Model-Limited-Partnership-Agreement-WOF_v2.docx',
+      '../../../tests/test_documents/redline/ILPA-Model-Limited-Parnership-Agreement-Deal-By-Deal_v1.docx',
+    ];
+    for (const fixture of fixtures) {
+      await expect(importDocxToMarkdoc(await readFile(new URL(fixture, import.meta.url)))).rejects.toMatchObject({
+        code: 'ANNOTATION_IMPORT_UNSUPPORTED', details: { annotationId: 'footnote:6', element: 'w:hyperlink' },
+      });
+    }
   });
 
   footnoteConformance('[SDX-MDOC-85] switches profiles and style-only recompiles from one immutable annotation', async () => {

--- a/packages/docx-markdoc/src/annotation-roundtrip.test.ts
+++ b/packages/docx-markdoc/src/annotation-roundtrip.test.ts
@@ -142,6 +142,11 @@ describe('canonical annotation round trips', () => {
     ].join('')))).rejects.toMatchObject({
       code: 'ANNOTATION_IMPORT_UNSUPPORTED', details: { annotationId: 'comment:0', reason: 'cyclic-style' },
     });
+    await expect(importDocxToMarkdoc(await sourceWithNamedStyleComment(
+      '<w:style w:type="paragraph" w:styleId="AnnotationChild"><w:name w:val="Wrong style type"/></w:style>',
+    ))).rejects.toMatchObject({
+      code: 'ANNOTATION_IMPORT_UNSUPPORTED', details: { annotationId: 'comment:0', reason: 'non-character-style', styleType: 'paragraph' },
+    });
   });
 
   runStyleConformance('[SDX-MDOC-103] admits real ILPA style runs before failing closed on hyperlinks', async () => {

--- a/packages/docx-markdoc/src/docx-markdoc.test.ts
+++ b/packages/docx-markdoc/src/docx-markdoc.test.ts
@@ -135,7 +135,7 @@ describe('brownfield Markdoc authoring', () => {
     for (const name of ['source.docx']) {
       await expect(importDocxToMarkdoc(await readFile(`${directory}${name}`))).rejects.toMatchObject({
         code: 'ANNOTATION_IMPORT_UNSUPPORTED',
-        details: { annotationId: 'footnote:2', element: 'w:sz' },
+        details: { annotationId: 'footnote:2', element: 'w:tab' },
       });
     }
   }, 60_000);

--- a/packages/docx-markdoc/src/import.ts
+++ b/packages/docx-markdoc/src/import.ts
@@ -123,6 +123,7 @@ function assertNamedStyle(styles: StylesModel, styleId: string, annotationId: st
     seen.add(current);
     const style = styles.byId.get(current);
     if (!style) throw new DocxMarkdocError('ANNOTATION_IMPORT_UNSUPPORTED', `Annotation ${annotationId} references missing run style ${current}.`, { annotationId, styleId: current, reason: 'missing-style' });
+    if (style.styleType !== 'character') throw new DocxMarkdocError('ANNOTATION_IMPORT_UNSUPPORTED', `Annotation ${annotationId} references non-character run style ${current}.`, { annotationId, styleId: current, styleType: style.styleType, reason: 'non-character-style' });
     current = style.basedOn;
   }
 }

--- a/packages/docx-markdoc/src/import.ts
+++ b/packages/docx-markdoc/src/import.ts
@@ -1,4 +1,4 @@
-import { DocxDocument, OOXML, W, computeContentFingerprint } from '@usejunior/docx-core';
+import { DocxDocument, OOXML, W, computeContentFingerprint, type StylesModel } from '@usejunior/docx-core';
 import { sha256 } from './hash.js';
 import { DocxMarkdocError } from './errors.js';
 import type { AnnotationAnchor, AnnotationParagraph, AnnotationRun, AnnotationRunStyle, CanonicalAnnotation, ImportResult } from './types.js';
@@ -49,10 +49,16 @@ function parseTaggedRuns(tagged: string, annotationId: string): AnnotationRun[] 
       const color = /\bcolor="([^"]+)"/.exec(token)?.[1] ?? 'yellow';
       next.highlight = color as AnnotationRunStyle['highlight'];
     } else if (token.startsWith('<font')) {
-      if (/\b(?:name|size|face)=/.test(token)) throw new DocxMarkdocError('ANNOTATION_IMPORT_UNSUPPORTED', `Annotation ${annotationId} uses unsupported font metadata.`, { annotationId, token });
+      if (/\b(?:name|face)=/.test(token)) throw new DocxMarkdocError('ANNOTATION_IMPORT_UNSUPPORTED', `Annotation ${annotationId} uses unsupported font metadata.`, { annotationId, token });
+      const size = /\bsize="([0-9]+(?:\.[0-9]+)?)"/.exec(token)?.[1];
+      if (size) {
+        const halfPoints = Number(size) * 2;
+        if (!Number.isInteger(halfPoints) || halfPoints <= 0) throw new DocxMarkdocError('ANNOTATION_IMPORT_UNSUPPORTED', `Annotation ${annotationId} has an unsupported font size.`, { annotationId, token });
+        next.fontSizeHalfPoints = halfPoints;
+      }
       const color = /\bcolor="([0-9A-Fa-f]{6})"/.exec(token)?.[1];
-      if (!color) throw new DocxMarkdocError('ANNOTATION_IMPORT_UNSUPPORTED', `Annotation ${annotationId} has an unsupported color declaration.`, { annotationId, token });
-      next.color = color.toUpperCase();
+      if (color) next.color = color.toUpperCase();
+      if (!color && !size) throw new DocxMarkdocError('ANNOTATION_IMPORT_UNSUPPORTED', `Annotation ${annotationId} has an unsupported font declaration.`, { annotationId, token });
     }
     stack.push(next);
   }
@@ -60,13 +66,69 @@ function parseTaggedRuns(tagged: string, annotationId: string): AnnotationRun[] 
   return runs;
 }
 
-function bodyFromParagraphs(paragraphs: Array<{ tagged_text: string }>, annotationId: string): AnnotationParagraph[] {
+function bodyFromParagraphs(
+  paragraphs: Array<{ tagged_text: string }>,
+  container: Element,
+  annotationId: string,
+  marker: 'annotationRef' | 'footnoteRef',
+): AnnotationParagraph[] {
   if (paragraphs.length === 0) throw new DocxMarkdocError('ANNOTATION_IMPORT_UNSUPPORTED', `Annotation ${annotationId} has no admitted paragraphs.`, { annotationId });
-  return paragraphs.map((paragraph) => ({ runs: parseTaggedRuns(paragraph.tagged_text, annotationId) }));
+  const sourceParagraphs = Array.from(container.getElementsByTagNameNS(OOXML.W_NS, W.p)) as Element[];
+  return paragraphs.map((paragraph, paragraphIndex) => {
+    const parsed = parseTaggedRuns(paragraph.tagged_text, annotationId);
+    const sourceParagraph = sourceParagraphs[paragraphIndex];
+    if (!sourceParagraph) return { runs: parsed };
+    const spans: Array<{ start: number; end: number; styleId?: string; fontSizeHalfPoints?: number }> = [];
+    let offset = 0;
+    for (const run of Array.from(sourceParagraph.getElementsByTagNameNS(OOXML.W_NS, W.r)) as Element[]) {
+      if (run.getElementsByTagNameNS(OOXML.W_NS, marker).length > 0) continue;
+      const text = Array.from(run.getElementsByTagNameNS(OOXML.W_NS, W.t)).map((node) => (node as Element).textContent ?? '').join('');
+      if (!text) continue;
+      const rStyle = Array.from(run.getElementsByTagNameNS(OOXML.W_NS, W.rStyle))[0] as Element | undefined;
+      const styleId = rStyle?.getAttributeNS(OOXML.W_NS, W.val) ?? rStyle?.getAttribute('w:val') ?? undefined;
+      const size = Array.from(run.getElementsByTagNameNS(OOXML.W_NS, 'sz'))[0] as Element | undefined;
+      const rawSize = size?.getAttributeNS(OOXML.W_NS, W.val) ?? size?.getAttribute('w:val') ?? undefined;
+      const fontSizeHalfPoints = rawSize && /^\d+$/u.test(rawSize) ? Number(rawSize) : undefined;
+      spans.push({ start: offset, end: offset + text.length, ...(styleId ? { styleId } : {}), ...(fontSizeHalfPoints ? { fontSizeHalfPoints } : {}) });
+      offset += text.length;
+    }
+    const runs: AnnotationRun[] = [];
+    let parsedOffset = 0;
+    for (const run of parsed) {
+      let consumed = 0;
+      while (consumed < run.text.length) {
+        const position = parsedOffset + consumed;
+        const span = spans.find((candidate) => candidate.start <= position && candidate.end > position);
+        const length = Math.min(run.text.length - consumed, span ? span.end - position : run.text.length - consumed);
+        const text = run.text.slice(consumed, consumed + length);
+        const style = {
+          ...(run.style ?? {}),
+          ...(span?.styleId ? { styleId: span.styleId } : {}),
+          ...(span?.fontSizeHalfPoints ? { fontSizeHalfPoints: span.fontSizeHalfPoints } : {}),
+        };
+        runs.push({ text, ...(Object.keys(style).length ? { style } : {}) });
+        consumed += length;
+      }
+      parsedOffset += run.text.length;
+    }
+    return { runs };
+  });
 }
 
-function assertAdmittedAnnotationElement(container: Element, annotationId: string, marker: 'annotationRef' | 'footnoteRef'): void {
-  const admitted = new Set(['p', 'pPr', 'pStyle', 'r', 'rPr', 't', marker, 'b', 'i', 'u', 'color', 'highlight', 'rStyle', 'vertAlign']);
+function assertNamedStyle(styles: StylesModel, styleId: string, annotationId: string): void {
+  const seen = new Set<string>();
+  let current: string | null = styleId;
+  while (current) {
+    if (seen.has(current)) throw new DocxMarkdocError('ANNOTATION_IMPORT_UNSUPPORTED', `Annotation ${annotationId} uses cyclic run style ${styleId}.`, { annotationId, styleId, reason: 'cyclic-style' });
+    seen.add(current);
+    const style = styles.byId.get(current);
+    if (!style) throw new DocxMarkdocError('ANNOTATION_IMPORT_UNSUPPORTED', `Annotation ${annotationId} references missing run style ${current}.`, { annotationId, styleId: current, reason: 'missing-style' });
+    current = style.basedOn;
+  }
+}
+
+function assertAdmittedAnnotationElement(container: Element, annotationId: string, marker: 'annotationRef' | 'footnoteRef', styles: StylesModel): void {
+  const admitted = new Set(['p', 'pPr', 'pStyle', 'r', 'rPr', 't', marker, 'b', 'i', 'u', 'color', 'highlight', 'rStyle', 'vertAlign', 'sz']);
   for (const node of Array.from(container.getElementsByTagNameNS(OOXML.W_NS, '*'))) {
     const element = node as Element;
     let formattingOwner = element.parentNode as Element | null;
@@ -83,10 +145,14 @@ function assertAdmittedAnnotationElement(container: Element, annotationId: strin
       const run = element.parentNode as Element | null;
       const markerRun = Boolean(run?.getElementsByTagNameNS(OOXML.W_NS, marker).length);
       for (const property of Array.from(element.childNodes).filter((child) => child.nodeType === 1) as Element[]) {
-        const allowed = ['b', 'i', 'u', 'color', 'highlight'];
+        const allowed = ['b', 'i', 'u', 'color', 'highlight', 'sz'];
         const nonApplicableFallback = property.localName === 'szCs'
           && !/[\u0590-\u08FF\uFB1D-\uFDFF\uFE70-\uFEFF]/u.test(run?.textContent ?? '');
-        if (!allowed.includes(property.localName) && !nonApplicableFallback && !(markerRun && ['rStyle', 'vertAlign'].includes(property.localName))) {
+        if (property.localName === W.rStyle && !markerRun) {
+          const styleId = property.getAttributeNS(OOXML.W_NS, W.val) ?? property.getAttribute('w:val');
+          if (!styleId) throw new DocxMarkdocError('ANNOTATION_IMPORT_UNSUPPORTED', `Annotation ${annotationId} has an empty run style reference.`, { annotationId, reason: 'missing-style-id' });
+          assertNamedStyle(styles, styleId, annotationId);
+        } else if (!allowed.includes(property.localName) && !nonApplicableFallback && !(markerRun && ['rStyle', 'vertAlign'].includes(property.localName))) {
           throw new DocxMarkdocError('ANNOTATION_IMPORT_UNSUPPORTED', `Annotation ${annotationId} contains unsupported run property w:${property.localName}.`, { annotationId, element: `w:${property.localName}` });
         }
       }
@@ -136,6 +202,8 @@ function annotationMarkdoc(annotation: CanonicalAnnotation): string[] {
       if (!style || Object.keys(style).length === 0) content.push(escapeText(run.text));
       else {
         const styleAttributes = [
+          ...(style.styleId ? [`style="${escapeAttribute(style.styleId)}"`] : []),
+          ...(style.fontSizeHalfPoints ? [`size=${style.fontSizeHalfPoints}`] : []),
           ...(style.bold ? ['bold=true'] : []), ...(style.italic ? ['italic=true'] : []), ...(style.underline ? ['underline=true'] : []),
           ...(style.color ? [`color="${style.color}"`] : []), ...(style.highlight ? [`highlight="${style.highlight}"`] : []),
         ];
@@ -167,6 +235,7 @@ export async function importDocxToMarkdoc(source: Buffer): Promise<ImportResult>
     );
   }
   const annotations: CanonicalAnnotation[] = [];
+  const styles = anchored.getStylesModel();
   const [commentsXml, footnotesXml] = await Promise.all([anchored.getCommentsXmlClone(), anchored.getFootnotesXmlClone()]);
   const comments = await anchored.getComments();
   const importedCommentIds = new Set<number>();
@@ -178,7 +247,7 @@ export async function importDocxToMarkdoc(source: Buffer): Promise<ImportResult>
     importedCommentIds.add(comment.id);
     const commentElement = elementByWordId(commentsXml, W.comment, comment.id);
     if (!commentElement) throw new DocxMarkdocError('ANNOTATION_IMPORT_UNSUPPORTED', `Comment ${comment.id} has no definition.`, { annotationId: id });
-    assertAdmittedAnnotationElement(commentElement, id, 'annotationRef');
+    assertAdmittedAnnotationElement(commentElement, id, 'annotationRef', styles);
     let anchor: AnnotationAnchor;
     if (parent) anchor = parent.anchor;
     else {
@@ -191,7 +260,7 @@ export async function importDocxToMarkdoc(source: Buffer): Promise<ImportResult>
     }
     const annotation: CanonicalAnnotation = {
       id,
-      body: bodyFromParagraphs(comment.paragraphs, id),
+      body: bodyFromParagraphs(comment.paragraphs, commentElement, id, 'annotationRef'),
       author: comment.author || undefined,
       initials: comment.initials || undefined,
       date: comment.date || undefined,
@@ -221,12 +290,12 @@ export async function importDocxToMarkdoc(source: Buffer): Promise<ImportResult>
     if (footnote.referencePoints.length === 0 && footnote.text.length === 0) continue;
     const footnoteElement = elementByWordId(footnotesXml, W.footnote, footnote.id);
     if (!footnoteElement) throw new DocxMarkdocError('ANNOTATION_IMPORT_UNSUPPORTED', `Footnote ${footnote.id} has no definition.`, { annotationId: id });
-    assertAdmittedAnnotationElement(footnoteElement, id, 'footnoteRef');
+    assertAdmittedAnnotationElement(footnoteElement, id, 'footnoteRef', styles);
     if (footnote.referencePoints.length !== 1) throw new DocxMarkdocError('ANNOTATION_IMPORT_UNSUPPORTED', `Footnote ${footnote.id} must have exactly one reference.`, { annotationId: id, referenceCount: footnote.referencePoints.length });
     const reference = footnote.referencePoints[0]!;
     const anchor: AnnotationAnchor = { kind: 'point', point: { paragraphId: reference.paragraphId, offset: reference.textOffset } };
     annotations.push({
-      id, body: bodyFromParagraphs(footnote.paragraphs, id), audience: 'unspecified', semanticRole: 'substantive-footnote',
+      id, body: bodyFromParagraphs(footnote.paragraphs, footnoteElement, id, 'footnoteRef'), audience: 'unspecified', semanticRole: 'substantive-footnote',
       sourcePresentation: 'footnote', sourceAnchor: anchor, anchor,
     });
   }

--- a/packages/docx-markdoc/src/markdoc.ts
+++ b/packages/docx-markdoc/src/markdoc.ts
@@ -123,6 +123,8 @@ export const markdocConfig: Config = {
     'annotation-run': {
       inline: true,
       attributes: {
+        style: { type: String },
+        size: { type: Number },
         bold: { type: Boolean }, italic: { type: Boolean }, underline: { type: Boolean },
         color: { type: String }, highlight: { type: String },
       },
@@ -251,12 +253,16 @@ function annotationBody(node: Node, issues: ValidationIssue[]): AnnotationParagr
         return;
       }
       const style: AnnotationRunStyle = {
+        ...(inline.attributes.style === undefined ? {} : { styleId: String(inline.attributes.style) }),
+        ...(inline.attributes.size === undefined ? {} : { fontSizeHalfPoints: Number(inline.attributes.size) }),
         ...(inline.attributes.bold === true ? { bold: true } : {}),
         ...(inline.attributes.italic === true ? { italic: true } : {}),
         ...(inline.attributes.underline === true ? { underline: true } : {}),
         ...(inline.attributes.color === undefined ? {} : { color: String(inline.attributes.color).toUpperCase() }),
         ...(inline.attributes.highlight === undefined ? {} : { highlight: String(inline.attributes.highlight) as AnnotationRunStyle['highlight'] }),
       };
+      if (style.styleId !== undefined && style.styleId.length === 0) issues.push(issue('INVALID_ANNOTATION_STYLE', 'Annotation run style IDs must be non-empty.', inline));
+      if (style.fontSizeHalfPoints !== undefined && (!Number.isInteger(style.fontSizeHalfPoints) || style.fontSizeHalfPoints <= 0)) issues.push(issue('INVALID_ANNOTATION_STYLE', 'Annotation run sizes must be positive integer half-points.', inline));
       if (style.color && !/^[0-9A-F]{6}$/.test(style.color)) issues.push(issue('INVALID_ANNOTATION_COLOR', 'Annotation colors must be six-digit RGB values.', inline));
       if (style.highlight && !HIGHLIGHTS.has(style.highlight)) issues.push(issue('INVALID_ANNOTATION_HIGHLIGHT', `Unsupported Word highlight ${style.highlight}.`, inline));
       for (const nested of inline.children) visit(nested, style);

--- a/packages/docx-markdoc/src/presentation.ts
+++ b/packages/docx-markdoc/src/presentation.ts
@@ -17,6 +17,8 @@ const HIGHLIGHTS = new Set(['black', 'blue', 'cyan', 'green', 'magenta', 'red', 
 
 function normalizeStyle(style: AnnotationRunStyle | undefined, path: string): AnnotationRunStyle | undefined {
   if (!style) return undefined;
+  if (style.styleId !== undefined && style.styleId.length === 0) throw new DocxMarkdocError('INVALID_ANNOTATION_STYLE', `${path}.styleId must be non-empty.`);
+  if (style.fontSizeHalfPoints !== undefined && (!Number.isInteger(style.fontSizeHalfPoints) || style.fontSizeHalfPoints <= 0)) throw new DocxMarkdocError('INVALID_ANNOTATION_STYLE', `${path}.fontSizeHalfPoints must be a positive integer.`);
   const color = style.color?.toUpperCase();
   if (color && !/^[0-9A-F]{6}$/.test(color)) throw new DocxMarkdocError('INVALID_ANNOTATION_COLOR', `${path}.color must be six-digit RGB.`);
   if (style.highlight && !HIGHLIGHTS.has(style.highlight)) throw new DocxMarkdocError('INVALID_ANNOTATION_HIGHLIGHT', `${path}.highlight is not a Word highlight value.`);

--- a/packages/docx-markdoc/src/types.ts
+++ b/packages/docx-markdoc/src/types.ts
@@ -21,7 +21,18 @@ export type AnnotationPointAnchor = { kind: 'point'; point: AnnotationPosition }
 export type AnnotationRangeAnchor = { kind: 'range'; start: AnnotationPosition; end: AnnotationPosition };
 export type AnnotationAnchor = AnnotationPointAnchor | AnnotationRangeAnchor;
 
+/**
+ * Canonical formatting retained while projecting annotation body runs.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.3.2.29
+ * @conformance ECMA-376 edition 5, Part 1 § 17.3.2.38
+ * @see #951
+ */
 export type AnnotationRunStyle = {
+  /** Named Word character style retained through comment/footnote projection. */
+  styleId?: string;
+  /** Direct Word run size in half-points. */
+  fontSizeHalfPoints?: number;
   bold?: boolean;
   italic?: boolean;
   underline?: boolean;

--- a/spec-compliance/CONFORMANCE.md
+++ b/spec-compliance/CONFORMANCE.md
@@ -13,6 +13,8 @@ Allure labels via `testAllure.conformance({…})`; source code carries
 
 | ID | Title | Edition | Part | Section | Schema reference | Verified by |
 | --- | --- | --- | --- | --- | --- | --- |
+| `ECMA-PART1-17-3-2-29` | Run style | 5 | 1 | 17.3.2.29 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:rStyle` | packages/docx-markdoc/src/import.ts; packages/docx-core/src/primitives/comments.ts; packages/docx-core/src/primitives/footnotes.ts; packages/docx-markdoc/src/annotation-roundtrip.test.ts |
+| `ECMA-PART1-17-3-2-38` | Run font size | 5 | 1 | 17.3.2.38 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:sz` | packages/docx-markdoc/src/import.ts; packages/docx-core/src/primitives/comments.ts; packages/docx-core/src/primitives/footnotes.ts; packages/docx-markdoc/src/annotation-roundtrip.test.ts |
 | `ECMA-PART4-14-9-1-1` | VML rich text-box content (w:txbxContent) | 5 | 4 | 14.9.1.1 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:txbxContent` | packages/docx-compare/src/tagged/textBoxRevisionSafety.ts; packages/docx-compare/src/tagged/pipeline.ts; packages/docx-compare/src/tagged/pipeline-text-box-stories.test.ts |
 | `ECMA-PART4-19-1-2-22` | VML text-box host (v:textbox) | 5 | 4 | 19.1.2.22 | `spec-compliance/ecma-376/schemas/transitional/vml-main.xsd#type:CT_Textbox` | packages/docx-compare/src/tagged/textBoxRevisionSafety.ts; packages/docx-compare/src/tagged/pipeline.ts; packages/docx-compare/src/tagged/pipeline-text-box-stories.test.ts |
 | `ECMA-PART1-17-13-5-14` | Deleted run content | 5 | 1 | 17.13.5.14 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:del` | packages/docx-compare/src/tagged/pipeline-text-box-stories.test.ts |
@@ -130,6 +132,32 @@ Allure labels via `testAllure.conformance({…})`; source code carries
 | `ECMA-PART1-17-13-5-36` | Table-cell-property revisions (w:tcPrChange) | 5 | 1 | 17.13.5.36 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:tcPrChange` | packages/docx-core/src/primitives/track-changes-emitter.ts; packages/docx-core/src/primitives/accept_changes.ts; packages/docx-core/src/primitives/reject_changes.ts; packages/docx-core/src/integration/advanced-revision-classification.test.ts |
 | `ECMA-PART1-17-13-5-37` | Table-row-property revisions (w:trPrChange) | 5 | 1 | 17.13.5.37 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:trPrChange` | packages/docx-core/src/primitives/track-changes-emitter.ts; packages/docx-core/src/primitives/accept_changes.ts; packages/docx-core/src/primitives/reject_changes.ts; packages/docx-core/src/integration/advanced-revision-classification.test.ts |
 | `ECMA-PART1-17-3-3-30` | Symbol character run content (w:sym) | 5 | 1 | 17.3.3.30 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#type:CT_Sym` | packages/docx-core/src/primitives/symbol_run_content.ts; packages/docx-compare/src/fieldComparisonSemantics.ts; packages/docx-compare/src/tagged/trackChangesAcceptorAst.ts; packages/docx-core/src/primitives/symbol_run_content.test.ts; packages/docx-compare/src/symbolCharacterProjection.test.ts |
+
+### ECMA-PART1-17-3-2-29 — Run style
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.3.2.29
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:rStyle`
+- **Verified by:** packages/docx-markdoc/src/import.ts; packages/docx-core/src/primitives/comments.ts; packages/docx-core/src/primitives/footnotes.ts; packages/docx-markdoc/src/annotation-roundtrip.test.ts
+
+Part 1 §17.3.2.29 defines `w:rStyle` as the character style applied to a run.
+safe-docx admits resolvable named styles in imported annotation bodies, retains
+their style identifiers in the canonical representation, and re-emits those
+identifiers when projecting the annotation as a comment or footnote. Missing
+and cyclic style chains remain outside the admitted subset and fail closed.
+
+### ECMA-PART1-17-3-2-38 — Run font size
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 1 § 17.3.2.38
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:sz`
+- **Verified by:** packages/docx-markdoc/src/import.ts; packages/docx-core/src/primitives/comments.ts; packages/docx-core/src/primitives/footnotes.ts; packages/docx-markdoc/src/annotation-roundtrip.test.ts
+
+Part 1 §17.3.2.38 defines `w:sz` as a run font size expressed in half-points.
+safe-docx retains positive integral half-point sizes from imported annotation
+bodies and re-emits them across comment and footnote projections.
 
 ### ECMA-PART4-14-9-1-1 — VML rich text-box content (w:txbxContent)
 

--- a/spec-compliance/CONFORMANCE.md
+++ b/spec-compliance/CONFORMANCE.md
@@ -145,7 +145,8 @@ Part 1 §17.3.2.29 defines `w:rStyle` as the character style applied to a run.
 safe-docx admits resolvable named styles in imported annotation bodies, retains
 their style identifiers in the canonical representation, and re-emits those
 identifiers when projecting the annotation as a comment or footnote. Missing
-and cyclic style chains remain outside the admitted subset and fail closed.
+non-character, and cyclic style chains remain outside the admitted subset and
+fail closed.
 
 ### ECMA-PART1-17-3-2-38 — Run font size
 

--- a/spec-compliance/registry/ecma-376.md
+++ b/spec-compliance/registry/ecma-376.md
@@ -12,6 +12,38 @@ outlive a future migration off OpenSpec. Entries are parsed by
 
 ## Targeted sections
 
+## [ECMA-PART1-17-3-2-29] Run style
+
+```yaml
+edition: 5
+part: 1
+section: "17.3.2.29"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:rStyle
+verifiedBy: packages/docx-markdoc/src/import.ts; packages/docx-core/src/primitives/comments.ts; packages/docx-core/src/primitives/footnotes.ts; packages/docx-markdoc/src/annotation-roundtrip.test.ts
+```
+
+Part 1 §17.3.2.29 defines `w:rStyle` as the character style applied to a run.
+safe-docx admits resolvable named styles in imported annotation bodies, retains
+their style identifiers in the canonical representation, and re-emits those
+identifiers when projecting the annotation as a comment or footnote. Missing
+and cyclic style chains remain outside the admitted subset and fail closed.
+
+## [ECMA-PART1-17-3-2-38] Run font size
+
+```yaml
+edition: 5
+part: 1
+section: "17.3.2.38"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:sz
+verifiedBy: packages/docx-markdoc/src/import.ts; packages/docx-core/src/primitives/comments.ts; packages/docx-core/src/primitives/footnotes.ts; packages/docx-markdoc/src/annotation-roundtrip.test.ts
+```
+
+Part 1 §17.3.2.38 defines `w:sz` as a run font size expressed in half-points.
+safe-docx retains positive integral half-point sizes from imported annotation
+bodies and re-emits them across comment and footnote projections.
+
 ## [ECMA-PART4-14-9-1-1] VML rich text-box content (w:txbxContent)
 
 ```yaml

--- a/spec-compliance/registry/ecma-376.md
+++ b/spec-compliance/registry/ecma-376.md
@@ -27,7 +27,8 @@ Part 1 §17.3.2.29 defines `w:rStyle` as the character style applied to a run.
 safe-docx admits resolvable named styles in imported annotation bodies, retains
 their style identifiers in the canonical representation, and re-emits those
 identifiers when projecting the annotation as a comment or footnote. Missing
-and cyclic style chains remain outside the admitted subset and fail closed.
+non-character, and cyclic style chains remain outside the admitted subset and
+fail closed.
 
 ## [ECMA-PART1-17-3-2-38] Run font size
 


### PR DESCRIPTION
## Summary

- admit resolvable named character styles and direct half-point sizes during annotation import
- retain style IDs through canonical Markdoc and re-emit them for comment and footnote projections
- fail closed on missing or cyclic style inheritance chains
- exercise both real ILPA fixtures and pin hyperlinks as the next unsupported annotation boundary

## Verification

- npm run build
- npm run lint:workspaces
- npm run test:run (all code suites pass; sandbox-blocked subprocess and LibreOffice cases rerun successfully outside the sandbox)
- npm run check:spec-coverage
- npm run check:conformance-citations
- npm run check:conformance-doc
- openspec validate admit-annotation-run-styles --strict

Fixes #951