### PR TITLE
fix(docx-comparison): lift non-text run revisions

### DIFF
--- a/packages/docx-compare/src/integration/taggedTreeMinimality.corpus.test.ts
+++ b/packages/docx-compare/src/integration/taggedTreeMinimality.corpus.test.ts
@@ -17,6 +17,8 @@ const REVISED = resolve(ROOT, 'tests/test_documents/redline/ILPA-Model-Limited-P
 describe('public ILPA tagged-tree redline minimality', () => {
   const test = testAllure.epic('Document Comparison').withLabels({ feature: 'Tagged-tree corpus minimality' });
   test('publishes balanced, unique, resolved bookmarks in both ILPA directions', async () => {
+    testAllure.conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.5.14' });
+    testAllure.conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.5.18' });
     const [deal, wof] = await Promise.all([readFile(ORIGINAL), readFile(REVISED)]);
     const projectionIssues = (xml: string): {
       duplicateNames: string[];
@@ -66,6 +68,24 @@ describe('public ILPA tagged-tree redline minimality', () => {
         date: new Date('2026-08-21T12:00:00Z'),
       });
       const combinedXml = await (await DocxArchive.load(result.document)).getDocumentXml();
+      const combinedDocument = parseXml(combinedXml);
+      const illegalRunInnerRevisions = ['del', 'ins', 'moveFrom', 'moveTo'].flatMap((kind) =>
+        Array.from(combinedDocument.getElementsByTagNameNS(
+          'http://schemas.openxmlformats.org/wordprocessingml/2006/main',
+          kind,
+        )).filter((revision) => {
+          const parent = revision.parentNode as Element | null;
+          return parent?.localName === 'r' || parent?.localName === 'drawing';
+        }).map((revision) => ({
+          kind,
+          parent: (revision.parentNode as Element).localName,
+          id: revision.getAttributeNS(
+            'http://schemas.openxmlformats.org/wordprocessingml/2006/main',
+            'id',
+          ),
+        })),
+      );
+      expect(illegalRunInnerRevisions, `${label} revision boundary topology`).toEqual([]);
       expect(projectionIssues(combinedXml), `${label} combined`).toEqual(expected);
       expect(projectionIssues(acceptAllChanges(combinedXml)), `${label} Accept All`)
         .toEqual(expected);

--- a/packages/docx-compare/src/tagged/taggedTreeConstruction.ts
+++ b/packages/docx-compare/src/tagged/taggedTreeConstruction.ts
@@ -152,6 +152,29 @@ function alignmentKey(
   ]);
 }
 
+function runNonTextContentSignature(run: WmlElement): string {
+  return childElements(run)
+    .filter((child) => !(
+      child.namespaceURI === run.namespaceURI &&
+      ['rPr', 't', 'delText', 'lastRenderedPageBreak'].includes(child.localName)
+    ))
+    .map((child) => subtreeSignature(child))
+    .join('|');
+}
+
+/**
+ * Keep side-only run content at the run boundary so revision wrappers remain
+ * legal children of the surrounding paragraph or other run container.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.5.14
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.5.18
+ * @see https://github.com/UseJunior/safe-docx/issues/945
+ */
+function canRecursivelyAlignContent(original: WmlElement, revised: WmlElement): boolean {
+  return original.localName !== 'r' ||
+    runNonTextContentSignature(original) === runNonTextContentSignature(revised);
+}
+
 function propertyDelta(original: WmlElement, revised: WmlElement): PropertyDelta | undefined {
   const descriptor = PROPERTY_SCOPE_BY_CONTAINER[original.localName ?? original.tagName.replace(/^w:/, '')];
   if (!descriptor) return undefined;
@@ -355,6 +378,20 @@ function constructBoth(
     revisedNumberingIdentities,
   );
   const children: TaggedNode[] = [];
+  const emitAlignedPair = (left: WmlElement, right: WmlElement): void => {
+    if (!canRecursivelyAlignContent(left, right)) {
+      children.push({ tag: 'original', node: left, children: [], opaque: true });
+      children.push({ tag: 'revised', node: right, children: [], opaque: true });
+      return;
+    }
+    children.push(constructBoth(
+      left,
+      right,
+      options,
+      originalNumberingIdentities,
+      revisedNumberingIdentities,
+    ));
+  };
   const emitGap = (originalEnd: number, revisedEnd: number): void => {
     while (originalEnd - oi === revisedEnd - ri && oi < originalEnd && ri < revisedEnd) {
       const left = originalChildren[oi]!;
@@ -363,6 +400,7 @@ function constructBoth(
         (left.localName ?? left.tagName) === (right.localName ?? right.tagName) &&
         semanticAttributeSignature(left) === semanticAttributeSignature(right) &&
         (childElements(left).length > 0 || childElements(right).length > 0) &&
+        canRecursivelyAlignContent(left, right) &&
         (left.localName !== 'r' || (
           left.textContent === right.textContent &&
           left.getElementsByTagNameNS(
@@ -379,13 +417,7 @@ function constructBoth(
           ).length === 0
         ));
       if (!sameIdentity) break;
-      children.push(constructBoth(
-        left,
-        right,
-        options,
-        originalNumberingIdentities,
-        revisedNumberingIdentities,
-      ));
+      emitAlignedPair(left, right);
       oi++;
       ri++;
     }
@@ -438,13 +470,7 @@ function constructBoth(
   let ri = 0;
   for (const [matchedOriginal, matchedRevised] of pairs) {
     emitGap(matchedOriginal, matchedRevised);
-    children.push(constructBoth(
-      originalChildren[oi++]!,
-      revisedChildren[ri++]!,
-      options,
-      originalNumberingIdentities,
-      revisedNumberingIdentities,
-    ));
+    emitAlignedPair(originalChildren[oi++]!, revisedChildren[ri++]!);
   }
   emitGap(originalChildren.length, revisedChildren.length);
   return {

--- a/packages/docx-compare/src/tagged/taggedTreeSerializer.test.ts
+++ b/packages/docx-compare/src/tagged/taggedTreeSerializer.test.ts
@@ -15,6 +15,7 @@ import {
 import { constructTaggedTree } from './taggedTreeConstruction.js';
 import { compareSourceProjectedFormattingFidelity } from './formattingFidelity.js';
 import { extractRoundTripComparisonText } from '../fieldComparisonSemantics.js';
+import { completeField } from '../testing/ooxml-fixtures.js';
 
 const TEST_FEATURE = 'refactor-tagged-tree-redline-construction';
 const test = testAllure.epic('Document Comparison').withLabels({ feature: TEST_FEATURE });
@@ -821,6 +822,81 @@ describe('tagged-tree shadow serializer', () => {
     expect(document.getElementsByTagNameNS(W_NS, 'ins')).toHaveLength(0);
     expect(extractRoundTripComparisonText(acceptAllChanges(output))).toBe(textValue);
     expect(extractRoundTripComparisonText(rejectAllChanges(output))).toBe(textValue);
+  });
+
+  test('lifts changed field instructions to legal run-level revisions', () => {
+    testAllure.conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.16.13' });
+    testAllure.conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.5.14' });
+    const original = documentBody(`<w:p>${completeField('REF _Ref1 \\r \\h ', 'clause')}</w:p>`);
+    const revised = documentBody(`<w:p>${completeField(' REF _Ref1 \\r \\h ', 'clause')}</w:p>`);
+    const constructed = constructTaggedTree(original, revised);
+    const output = serializeTaggedTree(constructed.tree, createPreservePlan(
+      original, revised, constructed.tree,
+      { author: 'Comparator', date: '2026-08-25T12:00:00Z' },
+    ));
+    const document = parseXml(output);
+
+    expect(Array.from(document.getElementsByTagNameNS(W_NS, 'del')).every((wrapper) =>
+      (wrapper.parentNode as Element).localName !== 'r')).toBe(true);
+    expect(document.getElementsByTagNameNS(W_NS, 'delInstrText')).toHaveLength(1);
+    expect(document.getElementsByTagNameNS(W_NS, 'del')[0]?.getElementsByTagNameNS(W_NS, 'r')).toHaveLength(1);
+    expect(acceptAllChanges(output)).toContain(' REF _Ref1 \\r \\h ');
+    expect(rejectAllChanges(output)).toContain('REF _Ref1 \\r \\h ');
+  });
+
+  test('lifts aligned footnote references outside their containing runs', () => {
+    testAllure.conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.11.14' });
+    testAllure.conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.5.14' });
+    const original = documentBody(
+      '<w:p><w:r><w:rPr><w:rStyle w:val="FootnoteReference"/></w:rPr>' +
+      '<w:footnoteReference w:id="24"/></w:r></w:p>',
+    );
+    const revised = documentBody(
+      '<w:p><w:r><w:rPr><w:rStyle w:val="FootnoteReference"/><w:b/></w:rPr>' +
+      '<w:footnoteReference w:id="25"/></w:r></w:p>',
+    );
+    const constructed = constructTaggedTree(original, revised);
+    const output = serializeTaggedTree(constructed.tree, createPreservePlan(
+      original, revised, constructed.tree,
+      { author: 'Comparator', date: '2026-08-25T12:00:00Z' },
+    ));
+    const document = parseXml(output);
+
+    expect(Array.from(document.getElementsByTagNameNS(W_NS, 'del')).every((wrapper) =>
+      (wrapper.parentNode as Element).localName !== 'r')).toBe(true);
+    expect(Array.from(document.getElementsByTagNameNS(W_NS, 'ins')).every((wrapper) =>
+      (wrapper.parentNode as Element).localName !== 'r')).toBe(true);
+    const acceptedReference = parseXml(acceptAllChanges(output))
+      .getElementsByTagNameNS(W_NS, 'footnoteReference')[0]!;
+    const rejectedReference = parseXml(rejectAllChanges(output))
+      .getElementsByTagNameNS(W_NS, 'footnoteReference')[0]!;
+    expect(acceptedReference.getAttributeNS(W_NS, 'id')).toBe('25');
+    expect(rejectedReference.getAttributeNS(W_NS, 'id')).toBe('24');
+  });
+
+  test('lifts changed DrawingML anchors to revision-wrapped runs', () => {
+    testAllure.conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.13.5.14' });
+    const drawing = (anchorId: string) =>
+      '<w:r><w:drawing><wp:anchor xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" ' +
+      `xmlns:wp14="http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing" wp14:anchorId="${anchorId}"/>` +
+      '</w:drawing></w:r>';
+    const original = documentBody(`<w:p>${drawing('OLD')}</w:p>`);
+    const revised = documentBody(`<w:p>${drawing('NEW')}</w:p>`);
+    const constructed = constructTaggedTree(original, revised);
+    const output = serializeTaggedTree(constructed.tree, createPreservePlan(
+      original, revised, constructed.tree,
+      { author: 'Comparator', date: '2026-08-25T12:00:00Z' },
+    ));
+    const document = parseXml(output);
+
+    expect(Array.from(document.getElementsByTagNameNS(W_NS, 'del')).every((wrapper) =>
+      (wrapper.parentNode as Element).localName !== 'drawing')).toBe(true);
+    expect(Array.from(document.getElementsByTagNameNS(W_NS, 'ins')).every((wrapper) =>
+      (wrapper.parentNode as Element).localName !== 'drawing')).toBe(true);
+    expect(document.getElementsByTagNameNS(W_NS, 'del')[0]?.getElementsByTagNameNS(W_NS, 'drawing')).toHaveLength(1);
+    expect(document.getElementsByTagNameNS(W_NS, 'ins')[0]?.getElementsByTagNameNS(W_NS, 'drawing')).toHaveLength(1);
+    expect(acceptAllChanges(output)).toContain('anchorId="NEW"');
+    expect(rejectAllChanges(output)).toContain('anchorId="OLD"');
   });
 
   test('keeps deleted-paragraph bookmark boundaries around the tracked text', () => {

--- a/packages/docx-compare/src/tagged/taggedTreeSerializer.ts
+++ b/packages/docx-compare/src/tagged/taggedTreeSerializer.ts
@@ -118,12 +118,16 @@ function replaceElementChildren(target: WmlElement, children: readonly WmlElemen
   for (const child of children) target.appendChild(child);
 }
 
-function convertDeletedText(root: WmlElement): WmlElement {
-  const texts = Array.from(root.getElementsByTagNameNS(W_NS, 't'));
-  if (root.namespaceURI === W_NS && root.localName === 't') texts.unshift(root);
+function replaceDescendantVocabulary(
+  root: WmlElement,
+  sourceLocalName: string,
+  replacementQualifiedName: string,
+): WmlElement {
+  const texts = Array.from(root.getElementsByTagNameNS(W_NS, sourceLocalName));
+  if (root.namespaceURI === W_NS && root.localName === sourceLocalName) texts.unshift(root);
   let convertedRoot = root;
   for (const text of texts) {
-    const replacement = text.ownerDocument!.createElementNS(W_NS, 'w:delText');
+    const replacement = text.ownerDocument!.createElementNS(W_NS, replacementQualifiedName);
     for (let i = 0; i < text.attributes.length; i++) {
       const attr = text.attributes.item(i);
       if (attr) replacement.setAttributeNS(attr.namespaceURI, attr.name, attr.value);
@@ -136,6 +140,21 @@ function convertDeletedText(root: WmlElement): WmlElement {
     else text.parentNode?.replaceChild(replacement, text);
   }
   return convertedRoot;
+}
+
+/**
+ * Translate ordinary run text and field instructions to deletion vocabulary.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.13
+ * @see https://github.com/UseJunior/safe-docx/issues/945
+ */
+function convertDeletedText(root: WmlElement): WmlElement {
+  const withDeletedText = replaceDescendantVocabulary(root, 't', 'w:delText');
+  return replaceDescendantVocabulary(withDeletedText, 'instrText', 'w:delInstrText');
+}
+
+function convertMovedFromText(root: WmlElement): WmlElement {
+  return replaceDescendantVocabulary(root, 't', 'w:delText');
 }
 
 function operationProvenance(node: TaggedNode): readonly string[] {
@@ -168,7 +187,8 @@ function wrapRevision(
   wrapper.setAttributeNS(W_NS, 'w:date', revision.date);
   markComparisonRevision(wrapper);
   markOperationProvenance(wrapper, operationIds);
-  if (kind === 'del' || kind === 'moveFrom') node = convertDeletedText(node);
+  if (kind === 'del') node = convertDeletedText(node);
+  else if (kind === 'moveFrom') node = convertMovedFromText(node);
   wrapper.appendChild(node);
   return wrapper;
 }


### PR DESCRIPTION
## Outcome

Word now opens the public minimized comparison cleanly, and tagged comparison no longer emits revision wrappers directly inside `w:r` or `w:drawing` for changed field instructions, footnote references, or DrawingML anchors.

## What changed

- keep differing non-text run content as opaque original/revised runs during tagged-tree construction;
- continue using the existing text-refinement path for ordinary `w:t`, `xml:space`, and volatile rendered-page-break behavior;
- translate deleted `w:instrText` to `w:delInstrText` without changing move-from field vocabulary;
- add minimized regression coverage for field instructions, footnote references, and anchored DrawingML;
- add a two-direction public ILPA corpus gate for illegal `del`/`ins`/`moveFrom`/`moveTo` parentage.

## Verification

- Red-first: the three new minimized tests failed on the prior implementation; 34 existing tests passed.
- Focused: 58/58 tagged construction + serializer tests passed.
- Public ILPA corpus: 2/2 tests passed in both directions, including exact existing projection checks and the new four-kind boundary assertion.
- Fixed minimized DOCX: vendored Transitional schema validation passed.
- Fixed minimized + full public ILPA outputs: zero revision wrappers directly parented by `w:r` or `w:drawing` across all four revision kinds.
- Microsoft Word 16.112.1: fixed minimized comparison opened cleanly with no repair/recovery dialog. The prior output produced “Word found unreadable content.”
- Mandatory pre-submit passed:
  `npm run build && npm run lint:workspaces && npm run test:run && npm run check:spec-coverage && npm run check:conformance-citations && npm run check:conformance-doc`
- Dynamic Claude review executed the focused tests and schema/classifier probes: **APPROVE**, no findings.

## Scope boundary

The full ILPA comparison has zero #945-class wrappers, but Word still reports repairs and the complete document still has vendored-schema errors belonging to the separately tracked move-range and section-property defects (#941 and #944). This PR intentionally does not broaden into those concerns.

Only repository-public fixtures were used. No private or purchased-template documents were accessed.

Fixes #945
