### PR TITLE
test(docx-comparison): enforce revision topology corpus-wide

### DIFF
--- a/packages/docx-compare/src/integration/strategy-differential-harness.ts
+++ b/packages/docx-compare/src/integration/strategy-differential-harness.ts
@@ -91,6 +91,7 @@ export interface StrategyEvidence {
   integrity: {
     fieldIssues: string[];
     bookmarkIssues: string[];
+    revisionTopologyIssues: string[];
     revisionIdIssues: string[];
     moveBalanceIssues: string[];
   };
@@ -422,6 +423,33 @@ function moveBalanceIssues(candidateXml: string): string[] {
   return issues.sort();
 }
 
+/**
+ * Reject revision wrappers nested where WordprocessingML permits run-inner
+ * content but not tracked run-content containers.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.5.14
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.5.18
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.5.22
+ * @conformance ECMA-376 edition 5, Part 1 § 17.13.5.25
+ */
+export function collectRevisionTopologyIssues(candidateXml: string): string[] {
+  const document = parseXml(candidateXml);
+  const issues: string[] = [];
+  for (const kind of ['del', 'ins', 'moveFrom', 'moveTo'] as const) {
+    for (const revision of Array.from(document.getElementsByTagNameNS(W_NS, kind))) {
+      const parent = revision.parentElement;
+      if (
+        parent?.namespaceURI === W_NS
+        && (parent.localName === 'r' || parent.localName === 'drawing')
+      ) {
+        const id = revision.getAttributeNS(W_NS, 'id') ?? revision.getAttribute('w:id') ?? '';
+        issues.push(`${kind}:parent-${parent.localName}:id-${id}`);
+      }
+    }
+  }
+  return issues.sort();
+}
+
 async function characterizeStrategy(
   fixture: StrategyDifferentialFixture,
   originalXml: string,
@@ -495,6 +523,7 @@ async function characterizeStrategy(
         originalXml,
         revisedXml,
       ),
+      revisionTopologyIssues: collectRevisionTopologyIssues(candidateXml),
       revisionIdIssues: collectRevisionIdIssues(candidateXml, originalXml, revisedXml),
       moveBalanceIssues: moveBalanceIssues(candidateXml),
     },

--- a/packages/docx-compare/src/integration/strategy-differential-manifest.json
+++ b/packages/docx-compare/src/integration/strategy-differential-manifest.json
@@ -476,8 +476,8 @@
           },
           {
             "path": "word/document.xml",
-            "bytes": 1202363,
-            "sha256": "419cf4705157175f566597b35477a86b44cc938c09775ba79a5826ab7165b013",
+            "bytes": 1203848,
+            "sha256": "49e1bbeb6d87be1480fd6a1a5d858565408aeb78524563bf204af0b55f19d688",
             "kind": "xml"
           },
           {
@@ -815,8 +815,8 @@
           "insertedAtoms": 3662,
           "deletedAtoms": 2101,
           "modifiedParagraphs": 496,
-          "formatChanges": 17,
-          "formatChangeAtoms": 17
+          "formatChanges": 16,
+          "formatChangeAtoms": 16
         },
         "authority": {
           "comparisonStrategyUsed": "tagged-tree"
@@ -3042,8 +3042,8 @@
           },
           {
             "path": "word/document.xml",
-            "bytes": 335304,
-            "sha256": "8f02b89a2bed43f7bc21f2e5a91ba6bf6453d4addb7042fa9901e77f9d2e251b",
+            "bytes": 335316,
+            "sha256": "095ef8440dbc2d5fe6a00646bc0e8571e8ee9e992d5590550d2427df23518da8",
             "kind": "xml"
           },
           {
@@ -4287,8 +4287,8 @@
           },
           {
             "path": "word/document.xml",
-            "bytes": 387507,
-            "sha256": "518c30b6106219c49d4de85334319f0afdcf965c62693b22c0c44df1e8a81c01",
+            "bytes": 387513,
+            "sha256": "25dbd39a6531dfc847b7f58f3aeee8765f5e9236be70c9775862f51bcedbc76f",
             "kind": "xml"
           },
           {
@@ -4646,8 +4646,8 @@
           },
           {
             "path": "word/document.xml",
-            "bytes": 375116,
-            "sha256": "18de87d77fe0621c039d1d262e04ebfaad86b9c06a81906b06d7d5f1badaa357",
+            "bytes": 375128,
+            "sha256": "f2fa0402d65f971b6d657688b15dfc73480a358448f1d38b2855d56cff47f8d6",
             "kind": "xml"
           },
           {

--- a/packages/docx-compare/src/integration/strategy-differential.test.ts
+++ b/packages/docx-compare/src/integration/strategy-differential.test.ts
@@ -256,6 +256,13 @@ describe('strategy differential manifest evidence', () => {
       expect(() => assertCharacterizationSafety(invalidBookmark))
         .toThrow(/failed bookmarkIssues/u);
 
+      const invalidRevisionTopology = structuredClone(row);
+      invalidRevisionTopology.taggedTree.integrity.revisionTopologyIssues.push(
+        'del:parent-r:id-7',
+      );
+      expect(() => assertCharacterizationSafety(invalidRevisionTopology))
+        .toThrow(/failed revisionTopologyIssues/u);
+
       const reusedRevisionId = structuredClone(row);
       reusedRevisionId.taggedTree.integrity.revisionIdIssues.push(
         'revision-id-reused-across-identities:7',

--- a/packages/docx-compare/src/integration/taggedTreeMinimality.corpus.test.ts
+++ b/packages/docx-compare/src/integration/taggedTreeMinimality.corpus.test.ts
@@ -9,6 +9,7 @@ import { collectBookmarkReferenceNamesInXml } from '../tagged/bookmarkProjection
 import { buildTaggedTreeShadowXml } from '../tagged/taggedTreeShadow.js';
 import { compareSourceProjectedFormattingFidelity } from '../tagged/formattingFidelity.js';
 import { acceptAllChanges, rejectAllChanges } from '../tagged/trackChangesAcceptorAst.js';
+import { collectRevisionTopologyIssues } from './strategy-differential-harness.js';
 
 const ROOT = resolve(fileURLToPath(new URL('.', import.meta.url)), '../../../../');
 const ORIGINAL = resolve(ROOT, 'tests/test_documents/redline/ILPA-Model-Limited-Parnership-Agreement-Deal-By-Deal_v1.docx');
@@ -68,24 +69,10 @@ describe('public ILPA tagged-tree redline minimality', () => {
         date: new Date('2026-08-21T12:00:00Z'),
       });
       const combinedXml = await (await DocxArchive.load(result.document)).getDocumentXml();
-      const combinedDocument = parseXml(combinedXml);
-      const illegalRunInnerRevisions = ['del', 'ins', 'moveFrom', 'moveTo'].flatMap((kind) =>
-        Array.from(combinedDocument.getElementsByTagNameNS(
-          'http://schemas.openxmlformats.org/wordprocessingml/2006/main',
-          kind,
-        )).filter((revision) => {
-          const parent = revision.parentNode as Element | null;
-          return parent?.localName === 'r' || parent?.localName === 'drawing';
-        }).map((revision) => ({
-          kind,
-          parent: (revision.parentNode as Element).localName,
-          id: revision.getAttributeNS(
-            'http://schemas.openxmlformats.org/wordprocessingml/2006/main',
-            'id',
-          ),
-        })),
-      );
-      expect(illegalRunInnerRevisions, `${label} revision boundary topology`).toEqual([]);
+      expect(
+        collectRevisionTopologyIssues(combinedXml),
+        `${label} revision boundary topology`,
+      ).toEqual([]);
       expect(projectionIssues(combinedXml), `${label} combined`).toEqual(expected);
       expect(projectionIssues(acceptAllChanges(combinedXml)), `${label} Accept All`)
         .toEqual(expected);


### PR DESCRIPTION
## Summary

- promote the `w:del` / `w:ins` / `w:moveFrom` / `w:moveTo` parent-topology check into the shared strategy-differential safety harness
- fail every checked-in, ILPA, and public NVCA corpus row if a revision wrapper is nested directly under `w:r` or `w:drawing`
- record the four deterministic reviewed-manifest deltas caused by #953 (`checked-in/ILPA` and three public NVCA paragraph-deletion rows)
- reuse the shared checker in the bidirectional ILPA regression test

## Why

PR #953 fixed issue #945 and merged after all required checks passed, but its advisory real-corpus job correctly detected an intentional stale manifest. Claude's post-fix peer review also identified that the illegal-parent assertion was scoped only to ILPA. This follow-up records the reviewed baseline and turns that invariant into a corpus-wide fail-closed safety gate.

The three NVCA byte deltas are exactly `w:instrText` to `w:delInstrText` conversions (2, 1, and 2 nodes). ILPA converts 112 such nodes, removes all 32 illegal nested insertion/deletion wrappers, and changes one drawing replacement from a separate property change to an opaque delete/insert run pair.

## Verification

- full real-corpus gate: 3 files, 21 tests passed (7 public NVCA documents, 23 strategy rows, both ILPA directions)
- focused strategy/construction/serializer tests: 66 passed
- mandatory pre-submit chain passed: build, workspace lint, all workspace tests, spec coverage, conformance citations, and conformance document
- deterministic updater check: `strategy differential manifest is current`
- Claude dynamic peer review: core fix approved; its corpus-wide topology-coverage finding is addressed here

Ref: #945
Follow-up to: #953
