### PR TITLE
test(docx-comparison): cover illegal revision topology

### DIFF
--- a/packages/docx-compare/src/integration/strategy-differential.test.ts
+++ b/packages/docx-compare/src/integration/strategy-differential.test.ts
@@ -31,6 +31,7 @@ import {
   assertExpectedPackageParts,
   characterizeStrategyDifferential,
   collectRevisionIdIssues,
+  collectRevisionTopologyIssues,
   type StrategyDifferentialFixture,
 } from './strategy-differential-harness.js';
 
@@ -155,6 +156,24 @@ describe('sole tagged-spine characterization', () => {
 });
 
 describe('strategy differential manifest evidence', () => {
+  test('detects every illegal run-inner revision-wrapper topology', () => {
+    const xml = '<?xml version="1.0" encoding="UTF-8"?>'
+      + '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">'
+      + '<w:body><w:p>'
+      + '<w:r><w:del w:id="7"/></w:r>'
+      + '<w:r><w:drawing><w:ins w:id="8"/></w:drawing></w:r>'
+      + '<w:r><w:moveFrom w:id="9"/></w:r>'
+      + '<w:r><w:drawing><w:moveTo w:id="10"/></w:drawing></w:r>'
+      + '</w:p></w:body></w:document>';
+
+    expect(collectRevisionTopologyIssues(xml)).toEqual([
+      'del:parent-r:id-7',
+      'ins:parent-drawing:id-8',
+      'moveFrom:parent-r:id-9',
+      'moveTo:parent-drawing:id-10',
+    ]);
+  });
+
   test.openspec('Missing corpus evidence fails loudly')(
     'records complete deterministic evidence and rejects missing package coverage',
     async () => {


### PR DESCRIPTION
## Summary

- add a first-principles malformed-OOXML test for the shared revision-topology detector
- exercise `w:del`, `w:ins`, `w:moveFrom`, and `w:moveTo`
- cover both prohibited direct parents: `w:r` and `w:drawing`

## Why

PR #954 made illegal run-inner revision topology a corpus-wide fail-closed invariant and all repository CI passed. Codecov then reported three uncovered lines: the detector's positive branch. The corpus correctly proves that public outputs are clean, but this test also proves that the detector recognizes every prohibited shape.

## Verification

- focused strategy-differential test: 9/9 passed
- docx-compare coverage suite: 488 passed, 1 skipped; 87.72% line coverage overall
- mandatory pre-submit chain passed: build, workspace lint, all workspace tests, spec coverage, conformance citations, and conformance document

Ref: #945
Follow-up to: #954
