### PR TITLE
feat(docx-markdoc): preserve external annotation hyperlinks

### DIFF
--- a/openspec/changes/admit-annotation-run-styles/specs/docx-markdoc/spec.md
+++ b/openspec/changes/admit-annotation-run-styles/specs/docx-markdoc/spec.md
@@ -27,4 +27,5 @@ footnote. Missing or cyclic style chains SHALL fail closed.
 - **GIVEN** a real Word document containing FootnoteTextChar, FootnoteReference, and Hyperlink run styles
 - **WHEN** its annotations are imported
 - **THEN** named run styles and direct font sizes SHALL NOT cause rejection
-- **AND** a later unsupported hyperlink container SHALL still fail closed explicitly
+- **AND** admitted external hyperlink containers SHALL NOT cause rejection
+- **AND** a later unsupported bookmark marker SHALL still fail closed explicitly

--- a/openspec/changes/preserve-external-annotation-hyperlinks/design.md
+++ b/openspec/changes/preserve-external-annotation-hyperlinks/design.md
@@ -1,0 +1,99 @@
+## Context
+
+Comments and footnotes are independent OOXML source parts, so an annotation
+hyperlink's `r:id` resolves in `word/_rels/comments.xml.rels` or
+`word/_rels/footnotes.xml.rels`, not in the main document relationships. Raw
+relationship IDs are part-local and cannot survive comment/footnote projection.
+
+The canonical annotation body currently stores run text plus a closed set of
+run formatting. The importer derives those runs from visible tagged text and
+source run spans; the projectors then pass structured bodies to docx-core.
+
+## Goals / Non-Goals
+
+- Goals:
+  - Preserve external hyperlink destination, visible text, and every admitted
+    run-formatting field through import, Markdoc, and all four comment/footnote
+    source/destination combinations.
+  - Allocate valid deterministic destination-part relationships without
+    assuming source relationship IDs are reusable.
+  - Produce stable actionable failures for malformed or unsupported inputs.
+- Non-Goals:
+  - Internal `w:anchor` hyperlinks, bookmark markers, and general
+    cross-reference preservation.
+  - Hyperlink metadata beyond destination, such as tooltip, target frame, or
+    document location. Word's `w:history` display hint is admitted but is not
+    canonical link identity.
+  - Revision wrappers or other complex content nested inside annotation
+    hyperlinks.
+
+## Decisions
+
+### Canonical runs own resolved destinations
+
+`AnnotationRun` gains an optional structured hyperlink value containing the
+resolved external destination. Markdoc uses an `href` attribute on
+`annotation-run`; linked unformatted text is therefore still wrapped in an
+explicit tag. Link identity never depends on named style or visual formatting.
+
+Alternatives considered:
+
+- Preserve raw `r:id`: rejected because IDs are local to a relationship part
+  and collide or dangle after presentation conversion.
+- Infer links from the Hyperlink character style: rejected because style is
+  visual formatting, not destination identity.
+- Add a separate nested Markdoc link tag: deferred because a run-level
+  destination composes directly with the existing run-style representation and
+  keeps the admitted annotation grammar closed.
+
+### Source relationships are resolved before visible-run reconstruction
+
+Import validates each `w:hyperlink` wrapper, resolves its `r:id` in the owning
+part's relationships, and associates the destination with every descendant
+source run span. A wrapper must have no `w:anchor`, must have a non-empty
+`r:id`, and must resolve to a non-empty hyperlink relationship whose
+`TargetMode` is exactly `External`. Direct wrapper children are limited to
+admitted `w:r` nodes.
+
+### Destination parts allocate their own relationships
+
+docx-core scans structured annotation bodies for destinations before emitting
+XML. A shared relationship helper reuses an existing external hyperlink
+relationship for the same destination when available; otherwise it allocates
+the first free `rIdN` across every relationship type. Repeated destinations
+share one relationship deterministically. Adjacent runs with the same
+destination share one `w:hyperlink` wrapper, while formatting stays on each
+child run.
+
+### Fail-closed boundaries stay explicit
+
+The importer reports reason codes and relevant IDs/types/modes for missing
+`r:id`, dangling IDs, wrong relationship types, non-external targets, internal
+anchors, empty targets, and unsupported wrapper attributes or children.
+Existing bookmark rejection remains unchanged, so the real ILPA fixtures
+advance to the next boundary when it is present rather than silently dropping
+navigation markup. On fresh `origin/main`, the WOF fixture reaches
+`w:bookmarkStart` in `footnote:19`; the Deal-By-Deal fixture contains no marker
+there and imports completely.
+
+## Risks / Trade-offs
+
+- Relationship mutation spans comments and footnotes emitters. A shared helper
+  limits drift, while projection tests inspect both XML and `.rels` parts.
+- Deduplicating repeated destinations may change relationship multiplicity but
+  is semantically lossless and deterministic; tests cover pre-existing ID
+  collisions and repeated targets.
+- Markdoc gains an additive `href` attribute without changing the IR version.
+  Older content remains valid; consumers that ignore unknown runtime fields are
+  outside the canonical parser contract.
+
+## Migration Plan
+
+No stored-document migration is required. Existing canonical Markdoc parses as
+before. Newly imported external annotation hyperlinks serialize with explicit
+destinations and compile only through versions that admit the new attribute.
+
+## Open Questions
+
+None. Issue #956 and the execution handoff explicitly approve this bounded
+external-hyperlink capability while deferring internal navigation structures.

--- a/openspec/changes/preserve-external-annotation-hyperlinks/design.md
+++ b/openspec/changes/preserve-external-annotation-hyperlinks/design.md
@@ -36,6 +36,11 @@ resolved external destination. Markdoc uses an `href` attribute on
 `annotation-run`; linked unformatted text is therefore still wrapped in an
 explicit tag. Link identity never depends on named style or visual formatting.
 
+Markdoc attribute values are escaped as Markdoc string literals: only the
+backslash and the double-quote delimiter are escaped. Markdoc does not decode
+entity references, so HTML-style escaping would corrupt query-string
+destinations such as `?a=1&b=2` on the parse side.
+
 Alternatives considered:
 
 - Preserve raw `r:id`: rejected because IDs are local to a relationship part
@@ -64,6 +69,12 @@ the first free `rIdN` across every relationship type. Repeated destinations
 share one relationship deterministically. Adjacent runs with the same
 destination share one `w:hyperlink` wrapper, while formatting stays on each
 child run.
+
+Tracked footnote insertion, replacement, and deletion wrap runs per parent
+container. A linked run receives its `w:ins` / `w:del` inside the
+`w:hyperlink` wrapper (CT_Hyperlink admits run-level revision elements), so
+document order and link identity survive instead of the run being hoisted out
+of its hyperlink and left untracked.
 
 ### Fail-closed boundaries stay explicit
 

--- a/openspec/changes/preserve-external-annotation-hyperlinks/proposal.md
+++ b/openspec/changes/preserve-external-annotation-hyperlinks/proposal.md
@@ -1,0 +1,30 @@
+# Change: Preserve external annotation hyperlinks
+
+## Why
+
+Canonical annotation import currently rejects relationship-backed external
+hyperlinks in otherwise admitted comment and footnote bodies. That prevents
+real Word annotations from surviving Markdoc round trips even when their text
+and run formatting are already losslessly representable.
+
+## What Changes
+
+- Resolve annotation-body `w:hyperlink` relationship IDs against the owning
+  comment or footnote relationship part and retain the external destination in
+  canonical annotation runs.
+- Serialize and parse that destination explicitly in canonical Markdoc.
+- Re-emit hyperlink wrappers and collision-free external relationships for
+  comment and footnote projections, including cross-presentation conversion.
+- Fail closed for internal anchors, missing or invalid relationships, and
+  unsupported hyperlink contents while keeping bookmark markers unsupported.
+- Extend synthetic and real-document verification through package XML and
+  relationship inspection.
+
+## Impact
+
+- Affected specs: docx-markdoc, spec-compliance
+- Affected code: docx-markdoc annotation import/model/parser/projection;
+  docx-core comment/footnote emission and relationship helpers
+- Compatibility: additive canonical run metadata and Markdoc syntax; internal
+  hyperlinks and bookmark navigation remain explicit non-goals
+- Tracking issue: #956

--- a/openspec/changes/preserve-external-annotation-hyperlinks/specs/docx-markdoc/spec.md
+++ b/openspec/changes/preserve-external-annotation-hyperlinks/specs/docx-markdoc/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: External annotation hyperlink fidelity
+
+The annotation importer SHALL resolve each relationship-backed external
+`w:hyperlink` against the owning comment or footnote relationship part and
+retain its destination explicitly on every canonical run inside the wrapper.
+Canonical Markdoc SHALL serialize and parse that destination without inferring
+link identity from formatting. Comment and footnote projection SHALL emit a
+valid hyperlink wrapper plus a collision-free external hyperlink relationship
+in the destination part while retaining visible text and all admitted run
+formatting.
+
+Internal anchor hyperlinks, bookmark markers, unsupported wrapper contents,
+and missing, dangling, mistyped, non-external, or malformed relationships SHALL
+fail closed with stable actionable diagnostics.
+
+#### Scenario: [SDX-MDOC-104] comment and footnote links survive every projection
+
+- **GIVEN** a comment or footnote body containing a relationship-backed external hyperlink with mixed run formatting
+- **WHEN** the annotation is imported, serialized to Markdoc, parsed, and projected as either a comment or a footnote
+- **THEN** the canonical runs and output package SHALL retain the exact destination, visible text, named character style, and direct half-point size
+- **AND** the output hyperlink relationship SHALL belong to the destination annotation part with `TargetMode="External"`
+
+#### Scenario: [SDX-MDOC-105] relationship allocation is deterministic and collision-free
+
+- **GIVEN** multiple annotation hyperlinks with repeated destinations and destination relationship parts containing pre-existing IDs of any relationship type
+- **WHEN** annotations are projected
+- **THEN** repeated destinations SHALL resolve deterministically without duplicating semantic link targets
+- **AND** each new relationship ID SHALL be unique within its destination relationship part
+- **AND** source relationship IDs SHALL NOT be assumed reusable
+
+#### Scenario: [SDX-MDOC-106] invalid external hyperlink structures fail closed
+
+- **GIVEN** an annotation hyperlink with a missing or dangling ID, wrong relationship type, missing or non-external target mode, empty target, or unsupported wrapper child
+- **WHEN** annotations are imported
+- **THEN** import SHALL fail with `ANNOTATION_IMPORT_UNSUPPORTED`
+- **AND** the diagnostic SHALL identify the annotation and stable reason plus relevant relationship details
+
+#### Scenario: [SDX-MDOC-107] internal navigation stays unsupported
+
+- **GIVEN** an annotation body containing `w:hyperlink w:anchor`, `w:bookmarkStart`, or `w:bookmarkEnd`
+- **WHEN** annotations are imported
+- **THEN** import SHALL fail explicitly at that internal navigation structure
+- **AND** no navigation markup SHALL be silently discarded

--- a/openspec/changes/preserve-external-annotation-hyperlinks/specs/spec-compliance/spec.md
+++ b/openspec/changes/preserve-external-annotation-hyperlinks/specs/spec-compliance/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Annotation hyperlink relationship evidence
+
+The conformance registry SHALL bind annotation hyperlink import and emission to
+ECMA-376 5th edition Part 1 § 17.16.22 for the `w:hyperlink` relationship
+reference, Part 2 § 6.5.2.3 for the owning part Relationships part, and Part 2
+§ 6.5.3.4 for relationship identifiers, types, targets, and target modes.
+Implementation JSDoc and focused tests SHALL use the structured citation forms
+enforced by the repository conformance checks.
+
+#### Scenario: [SDX-CONF-16] annotation hyperlink citations resolve
+
+- **WHEN** annotation hyperlink import, relationship allocation, and projection claims are checked
+- **THEN** every cited edition, part, and section SHALL resolve to a targeted registry entry backed by vendored normative schemas
+- **AND** issue #956 SHALL appear only as non-normative `@see` context

--- a/openspec/changes/preserve-external-annotation-hyperlinks/tasks.md
+++ b/openspec/changes/preserve-external-annotation-hyperlinks/tasks.md
@@ -1,0 +1,30 @@
+## 1. Conformance and canonical model
+
+- [x] 1.1 Register and cite the verified WordprocessingML hyperlink and OPC
+  part-relationship requirements.
+- [x] 1.2 Extend canonical annotation runs and Markdoc parse/serialization with
+  an explicit validated external destination.
+
+## 2. Import and projection
+
+- [x] 2.1 Resolve comment and footnote hyperlink IDs against their owning
+  relationship parts and retain destination plus admitted run formatting.
+- [x] 2.2 Emit grouped hyperlink wrappers and deterministic collision-free
+  external relationships in comment and footnote destination parts.
+- [x] 2.3 Preserve explicit fail-closed diagnostics for malformed, internal,
+  dangling, mistyped, or otherwise unsupported hyperlink inputs and bookmarks.
+
+## 3. Verification
+
+- [x] 3.1 Cover comment/footnote import, all four projections, mixed formatting,
+  repeated destinations, multiple links, and relationship-ID collisions.
+- [x] 3.2 Cover missing/dangling IDs, wrong relationship types, internal modes or
+  anchors, empty targets, malformed wrappers, and Markdoc round-trip stability.
+- [x] 3.3 Update `[SDX-MDOC-103]` against fresh `origin/main`: the WOF fixture
+  reaches `w:bookmarkStart` at `footnote:19`, while the Deal-By-Deal fixture
+  (which contains no such marker there) imports completely.
+- [x] 3.4 Run bookmark-stripped real-document imports and both projection
+  directions, inspecting output XML and relationship parts for destination,
+  text, style, and size fidelity.
+- [x] 3.5 Run focused tests, strict OpenSpec validation, and the complete
+  repository pre-submit gate.

--- a/openspec/changes/preserve-external-annotation-hyperlinks/tasks.md
+++ b/openspec/changes/preserve-external-annotation-hyperlinks/tasks.md
@@ -4,6 +4,8 @@
   part-relationship requirements.
 - [x] 1.2 Extend canonical annotation runs and Markdoc parse/serialization with
   an explicit validated external destination.
+- [x] 1.3 Escape Markdoc attribute values as string literals so reserved
+  destination characters (`&`, `"`, `\`) round-trip exactly.
 
 ## 2. Import and projection
 
@@ -13,6 +15,8 @@
   external relationships in comment and footnote destination parts.
 - [x] 2.3 Preserve explicit fail-closed diagnostics for malformed, internal,
   dangling, mistyped, or otherwise unsupported hyperlink inputs and bookmarks.
+- [x] 2.4 Wrap tracked footnote runs per parent container so hyperlink-nested
+  runs stay linked and ordered under `w:ins` / `w:del`.
 
 ## 3. Verification
 
@@ -20,11 +24,14 @@
   repeated destinations, multiple links, and relationship-ID collisions.
 - [x] 3.2 Cover missing/dangling IDs, wrong relationship types, internal modes or
   anchors, empty targets, malformed wrappers, and Markdoc round-trip stability.
-- [x] 3.3 Update `[SDX-MDOC-103]` against fresh `origin/main`: the WOF fixture
+- [x] 3.3 Cover docx-core emission directly: tracked footnote insertion,
+  replacement, and deletion with linked runs, comment and reply bodies with
+  grouped wrappers, relationship reuse, and reserved-character destinations.
+- [x] 3.4 Update `[SDX-MDOC-103]` against fresh `origin/main`: the WOF fixture
   reaches `w:bookmarkStart` at `footnote:19`, while the Deal-By-Deal fixture
   (which contains no such marker there) imports completely.
-- [x] 3.4 Run bookmark-stripped real-document imports and both projection
+- [x] 3.5 Run bookmark-stripped real-document imports and both projection
   directions, inspecting output XML and relationship parts for destination,
   text, style, and size fidelity.
-- [x] 3.5 Run focused tests, strict OpenSpec validation, and the complete
+- [x] 3.6 Run focused tests, strict OpenSpec validation, and the complete
   repository pre-submit gate.

--- a/packages/docx-core/src/primitives/annotation_hyperlinks.test.ts
+++ b/packages/docx-core/src/primitives/annotation_hyperlinks.test.ts
@@ -1,0 +1,160 @@
+import { readFile } from 'node:fs/promises';
+import { describe, expect } from 'vitest';
+import { buildSyntheticDocx } from '../integration/synthetic-docx-fixture.js';
+import { testAllure } from '../testing/allure-test.js';
+import { DocxDocument } from './document.js';
+import { OOXML, W } from './namespaces.js';
+import { ensureExternalHyperlinkRelationships, parseRelationshipEntries, relationshipPartPath } from './relationships.js';
+import { createRevisionContext } from './track-changes-emitter.js';
+import { serializeXml } from './xml.js';
+import { createZipBuffer, DocxZip } from './zip.js';
+
+const test = testAllure.epic('Document Comparison').withLabels({ feature: 'Annotation hyperlinks' });
+const hyperlinkConformance = test
+  .conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.16.22' })
+  .conformance({ spec: 'ECMA-376', edition: 5, part: 2, section: '6.5.2.3' })
+  .conformance({ spec: 'ECMA-376', edition: 5, part: 2, section: '6.5.3.4' });
+
+const LINK = 'https://example.com/annotation-link';
+const OTHER = 'https://example.com/other-link';
+const REL_NS = 'http://schemas.openxmlformats.org/package/2006/relationships';
+const DEAL_BY_DEAL = new URL(
+  '../../../../tests/test_documents/redline/ILPA-Model-Limited-Parnership-Agreement-Deal-By-Deal_v1.docx',
+  import.meta.url,
+);
+
+async function loadWithParagraph(tag: string): Promise<{ document: DocxDocument; paragraphId: string }> {
+  const document = await DocxDocument.load(await buildSyntheticDocx({ paragraphs: ['Alpha beta gamma.'] }));
+  document.insertParagraphBookmarks(tag);
+  return { document, paragraphId: document.buildDocumentView().nodes[0]!.id };
+}
+
+function reviewer() {
+  return createRevisionContext({ author: 'Reviewer', date: '2026-09-01T00:00:00Z' });
+}
+
+const linkedBody = [{ runs: [
+  { text: 'see ' },
+  { text: 'link', style: { bold: true }, hyperlink: { destination: LINK } },
+  { text: ' end' },
+] }];
+
+async function footnoteXml(document: DocxDocument, noteId: number): Promise<string> {
+  const xml = serializeXml((await document.getFootnotesXmlClone())!);
+  return new RegExp(`<w:footnote w:id="${noteId}".*?</w:footnote>`, 'su').exec(xml)![0];
+}
+
+async function externalTargets(document: DocxDocument, sourcePart: string): Promise<Map<string, string>> {
+  const entries = parseRelationshipEntries(await document.getPartRelationshipsXmlClone(sourcePart));
+  return new Map([...entries.values()]
+    .filter((entry) => entry.type === OOXML.HYPERLINK_REL_TYPE && entry.targetMode === 'External')
+    .map((entry) => [entry.id, entry.target ?? '']));
+}
+
+describe('annotation hyperlink emission (#956)', () => {
+  hyperlinkConformance('tracked footnote insertion keeps linked runs ordered inside their hyperlink wrapper', async () => {
+    const { document, paragraphId } = await loadWithParagraph('tracked-link-insert');
+    await document.addFootnote(
+      { paragraphId, visibleOffset: 5, text: 'see link end', presentation: { body: linkedBody } },
+      reviewer(),
+    );
+    const note = await footnoteXml(document, 1);
+    expect(note.replace(/<[^>]+>/gu, '').trim()).toBe('see link end');
+    expect(note).toMatch(
+      /<w:ins [^>]*>(?:<w:r>.*?<\/w:r>)+<\/w:ins><w:hyperlink r:id="rId1"><w:ins [^>]*><w:r><w:rPr>.*?<\/w:rPr><w:t>link<\/w:t><\/w:r><\/w:ins><\/w:hyperlink><w:ins [^>]*><w:r>.*?<\/w:r><\/w:ins><\/w:p>/su,
+    );
+    expect((await document.getFootnotesXmlClone())!.documentElement.lookupNamespaceURI('r')).toBe(OOXML.R_NS);
+    expect(await externalTargets(document, 'word/footnotes.xml')).toEqual(new Map([['rId1', LINK]]));
+  });
+
+  hyperlinkConformance('tracked footnote deletion marks linked runs deleted without detaching them from the link', async () => {
+    const { document, paragraphId } = await loadWithParagraph('tracked-link-delete');
+    await document.addFootnote({ paragraphId, visibleOffset: 5, text: 'see link end', presentation: { body: linkedBody } });
+    await document.deleteFootnote({ noteId: 1 }, reviewer());
+    const note = await footnoteXml(document, 1);
+    expect(note).toMatch(/<w:hyperlink r:id="rId1"><w:del [^>]*><w:r>.*?<w:delText>link<\/w:delText><\/w:r><\/w:del><\/w:hyperlink>/su);
+    expect(note).not.toMatch(/<w:t[ >]/u);
+    expect(note.match(/<w:del /gu)).toHaveLength(3);
+  });
+
+  hyperlinkConformance('footnote text replacement handles linked runs in both tracked and direct modes', async () => {
+    const tracked = await loadWithParagraph('tracked-link-update');
+    await tracked.document.addFootnote({ paragraphId: tracked.paragraphId, visibleOffset: 5, text: 'see link end', presentation: { body: linkedBody } });
+    await tracked.document.updateFootnoteText({ noteId: 1, newText: 'replaced' }, reviewer());
+    const trackedNote = await footnoteXml(tracked.document, 1);
+    expect(trackedNote).toMatch(/<w:hyperlink r:id="rId1"><w:del [^>]*>.*?<w:delText>link<\/w:delText>.*?<\/w:del><\/w:hyperlink>/su);
+    expect(trackedNote).toMatch(/<\/w:hyperlink><w:del [^>]*>.*?<\/w:del><w:ins [^>]*><w:r>.*?<\/w:r><w:r><w:t>replaced<\/w:t><\/w:r><\/w:ins><\/w:p>/su);
+
+    const direct = await loadWithParagraph('direct-link-update');
+    await direct.document.addFootnote({ paragraphId: direct.paragraphId, visibleOffset: 5, text: 'see link end', presentation: { body: linkedBody } });
+    await direct.document.updateFootnoteText({ noteId: 1, newText: 'replaced' });
+    const directNote = await footnoteXml(direct.document, 1);
+    expect(directNote).not.toContain('<w:hyperlink');
+    expect(directNote.replace(/<[^>]+>/gu, '').trim()).toBe('replaced');
+  });
+
+  hyperlinkConformance('tracked deletion of a real linked footnote keeps the link and marks every run deleted', async () => {
+    const document = await DocxDocument.load(await readFile(DEAL_BY_DEAL));
+    await document.deleteFootnote({ noteId: 6 }, reviewer());
+    const note = await footnoteXml(document, 6);
+    expect(note).toMatch(/<w:hyperlink r:id="rId1" w:history="1"><w:del [^>]*>.*?<w:delText[^>]*>https:\/\/ilpa\.org.*?<\/w:delText>.*?<\/w:del><\/w:hyperlink>/su);
+    expect(note).not.toMatch(/<w:t[ >]/u);
+  });
+
+  hyperlinkConformance('comment bodies and replies group adjacent destinations and share part relationships', async () => {
+    const { document, paragraphId } = await loadWithParagraph('comment-links');
+    const root = await document.addComment({
+      paragraphId, start: 0, end: 5, author: 'Author', text: 'ab plain c\nd',
+      body: [
+        { runs: [
+          { text: 'a', hyperlink: { destination: LINK } },
+          { text: 'b', style: { bold: true }, hyperlink: { destination: LINK } },
+          { text: ' plain ' },
+          { text: 'c', hyperlink: { destination: OTHER } },
+        ] },
+        { runs: [{ text: 'd', hyperlink: { destination: LINK } }] },
+      ],
+    });
+    await document.addCommentReply({
+      parentCommentId: root.commentId, author: 'Replier', text: 'reply',
+      body: [{ runs: [{ text: 'reply', hyperlink: { destination: OTHER } }] }],
+    });
+    const comments = (await document.getCommentsXmlClone())!;
+    expect(comments.documentElement.lookupNamespaceURI('r')).toBe(OOXML.R_NS);
+    const firstHyperlink = comments.getElementsByTagNameNS(OOXML.W_NS, W.hyperlink).item(0)!;
+    expect(firstHyperlink.getAttributeNS(OOXML.R_NS, 'id')).toBe('rId1');
+
+    const xml = serializeXml(comments);
+    const rootXml = /<w:comment w:id="0".*?<\/w:comment>/su.exec(xml)![0];
+    expect(rootXml.match(/<w:hyperlink r:id="rId\d+">/gu)).toEqual([
+      '<w:hyperlink r:id="rId1">', '<w:hyperlink r:id="rId2">', '<w:hyperlink r:id="rId1">',
+    ]);
+    expect(rootXml).toMatch(/<w:hyperlink r:id="rId1"><w:r><w:t>a<\/w:t><\/w:r><w:r><w:rPr>.*?<\/w:rPr><w:t>b<\/w:t><\/w:r><\/w:hyperlink>/su);
+    const replyXml = /<w:comment w:id="1".*?<\/w:comment>/su.exec(xml)![0];
+    expect(replyXml).toContain('<w:hyperlink r:id="rId2"><w:r><w:t>reply</w:t></w:r></w:hyperlink>');
+    expect(await externalTargets(document, 'word/comments.xml')).toEqual(new Map([['rId1', LINK], ['rId2', OTHER]]));
+  });
+
+  hyperlinkConformance('rejects empty destinations and reuses only matching external relationships without rewriting the part', async () => {
+    const { document, paragraphId } = await loadWithParagraph('empty-destination');
+    await expect(document.addComment({
+      paragraphId, start: 0, end: 5, author: 'Author', text: 'x',
+      body: [{ runs: [{ text: 'x', hyperlink: { destination: '' } }] }],
+    })).rejects.toThrow('External hyperlink destinations must be non-empty');
+
+    const relsPath = 'word/_rels/footnotes.xml.rels';
+    const zip = await DocxZip.load(await createZipBuffer({
+      [relsPath]:
+        `<Relationships xmlns="${REL_NS}">` +
+        `<Relationship Id="rId1" Type="${OOXML.HYPERLINK_REL_TYPE}" Target="${LINK}"/>` +
+        `<Relationship Id="rId3" Type="${OOXML.HYPERLINK_REL_TYPE}" Target="${LINK}" TargetMode="External"/>` +
+        '</Relationships>',
+    }));
+    const before = await zip.readText(relsPath);
+    expect(await ensureExternalHyperlinkRelationships(zip, 'word/footnotes.xml', [LINK])).toEqual(new Map([[LINK, 'rId3']]));
+    expect(await zip.readText(relsPath)).toBe(before);
+    expect(await ensureExternalHyperlinkRelationships(zip, 'word/footnotes.xml', [])).toEqual(new Map());
+    expect(relationshipPartPath('document.xml')).toBe('_rels/document.xml.rels');
+    expect(relationshipPartPath('word/comments.xml')).toBe('word/_rels/comments.xml.rels');
+  });
+});

--- a/packages/docx-core/src/primitives/comments.ts
+++ b/packages/docx-core/src/primitives/comments.ts
@@ -17,6 +17,7 @@ import { getAttributeSafe } from './xml-helpers.js';
 import { getFirstChild } from './xml-helpers.js';
 import { extractEffectiveRunFormatting, parseStylesXml, parseThemeXml, type StylesModel, type ThemeModel } from './styles.js';
 import { emitFormattingTags, mergeAdjacentTags, type AnnotatedRun } from './formatting_tags.js';
+import { ensureExternalHyperlinkRelationships } from './relationships.js';
 import {
   createRevisionContainer,
   prepareElementForDeletion,
@@ -211,8 +212,16 @@ export type AddCommentParams = {
  * @conformance ECMA-376 edition 5, Part 1 § 17.3.2.38
  * @see #951
  */
-export type CommentBodyRun = { text: string; style?: { styleId?: string; fontSizeHalfPoints?: number; bold?: boolean; italic?: boolean; underline?: boolean; color?: string; highlight?: string } };
+export type CommentBodyRun = {
+  text: string;
+  style?: { styleId?: string; fontSizeHalfPoints?: number; bold?: boolean; italic?: boolean; underline?: boolean; color?: string; highlight?: string };
+  hyperlink?: { destination: string };
+};
 export type CommentBodyParagraph = { runs: CommentBodyRun[] };
+
+function commentBodyDestinations(body: CommentBodyParagraph[] | undefined): string[] {
+  return body?.flatMap((paragraph) => paragraph.runs.flatMap((run) => run.hyperlink ? [run.hyperlink.destination] : [])) ?? [];
+}
 
 export type AddCommentResult = {
   commentId: number;
@@ -359,6 +368,11 @@ export async function addComment(
 
   // Add comment element to comments.xml
   const paraId = generateParaId();
+  const hyperlinkRelationshipIds = await ensureExternalHyperlinkRelationships(
+    zip,
+    'word/comments.xml',
+    commentBodyDestinations(params.body),
+  );
   addCommentElement(commentsDoc, {
     id: commentId,
     author,
@@ -367,6 +381,7 @@ export async function addComment(
     paraId,
     date: ctx?.date,
     body: params.body,
+    hyperlinkRelationshipIds,
   });
   zip.writeText('word/comments.xml', serializeXml(commentsDoc));
 
@@ -423,6 +438,11 @@ export async function addCommentReply(
   // Allocate ID and add reply comment
   const commentId = allocateNextCommentId(commentsDoc);
   const replyParaId = generateParaId();
+  const hyperlinkRelationshipIds = await ensureExternalHyperlinkRelationships(
+    zip,
+    'word/comments.xml',
+    commentBodyDestinations(params.body),
+  );
   addCommentElement(commentsDoc, {
     id: commentId,
     author,
@@ -431,6 +451,7 @@ export async function addCommentReply(
     paraId: replyParaId,
     date: ctx?.date,
     body: params.body,
+    hyperlinkRelationshipIds,
   });
   zip.writeText('word/comments.xml', serializeXml(commentsDoc));
 
@@ -518,10 +539,22 @@ function ensureCommentPartNamespaceAliases(commentsDoc: Document): void {
  */
 function addCommentElement(
   commentsDoc: Document,
-  params: { id: number; author: string; initials: string; text: string; paraId: string; date?: string; body?: CommentBodyParagraph[] },
+  params: {
+    id: number;
+    author: string;
+    initials: string;
+    text: string;
+    paraId: string;
+    date?: string;
+    body?: CommentBodyParagraph[];
+    hyperlinkRelationshipIds?: ReadonlyMap<string, string>;
+  },
 ): void {
   ensureCommentPartNamespaceAliases(commentsDoc);
   const root = commentsDoc.documentElement;
+  if (params.hyperlinkRelationshipIds?.size && root.lookupNamespaceURI('r') !== OOXML.R_NS) {
+    root.setAttributeNS(XMLNS_NS, 'xmlns:r', OOXML.R_NS);
+  }
 
   const commentEl = commentsDoc.createElementNS(OOXML.W_NS, 'w:comment');
   commentEl.setAttribute('w:id', String(params.id));
@@ -542,15 +575,49 @@ function addCommentElement(
   p.appendChild(refRun);
 
   const body = params.body ?? [{ runs: [{ text: params.text }] }];
-  for (const run of body[0]?.runs ?? []) p.appendChild(buildCommentBodyRun(commentsDoc, run));
+  appendCommentBodyRuns(p, body[0]?.runs ?? [], commentsDoc, params.hyperlinkRelationshipIds);
 
   commentEl.appendChild(p);
   for (const paragraph of body.slice(1)) {
     const bodyParagraph = commentsDoc.createElementNS(OOXML.W_NS, 'w:p');
-    for (const run of paragraph.runs) bodyParagraph.appendChild(buildCommentBodyRun(commentsDoc, run));
+    appendCommentBodyRuns(bodyParagraph, paragraph.runs, commentsDoc, params.hyperlinkRelationshipIds);
     commentEl.appendChild(bodyParagraph);
   }
   root.appendChild(commentEl);
+}
+
+/**
+ * Emit annotation runs while retaining external hyperlink boundaries.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.22
+ * @see #956
+ */
+function appendCommentBodyRuns(
+  paragraph: Element,
+  runs: CommentBodyRun[],
+  doc: Document,
+  relationshipIds: ReadonlyMap<string, string> | undefined,
+): void {
+  let activeDestination: string | undefined;
+  let activeHyperlink: Element | undefined;
+  for (const bodyRun of runs) {
+    const destination = bodyRun.hyperlink?.destination;
+    if (!destination) {
+      activeDestination = undefined;
+      activeHyperlink = undefined;
+      paragraph.appendChild(buildCommentBodyRun(doc, bodyRun));
+      continue;
+    }
+    const relationshipId = relationshipIds?.get(destination);
+    if (!relationshipId) throw new Error(`Missing comment hyperlink relationship for ${destination}`);
+    if (activeDestination !== destination || !activeHyperlink) {
+      activeDestination = destination;
+      activeHyperlink = doc.createElementNS(OOXML.W_NS, 'w:hyperlink');
+      activeHyperlink.setAttributeNS(OOXML.R_NS, 'r:id', relationshipId);
+      paragraph.appendChild(activeHyperlink);
+    }
+    activeHyperlink.appendChild(buildCommentBodyRun(doc, bodyRun));
+  }
 }
 
 function buildCommentBodyRun(doc: Document, bodyRun: CommentBodyRun): Element {

--- a/packages/docx-core/src/primitives/document.ts
+++ b/packages/docx-core/src/primitives/document.ts
@@ -44,7 +44,7 @@ import {
   type SectionPropertiesMutationResult,
 } from './sections.js';
 import { findUniqueSubstringMatch } from './matching.js';
-import { parseDocumentRels, type RelsMap } from './relationships.js';
+import { parseDocumentRels, relationshipPartPath, type RelsMap } from './relationships.js';
 import {
   setParagraphSpacing,
   setTableCellPadding,
@@ -1431,6 +1431,13 @@ export class DocxDocument {
     const footnotesText = await this.zip.readTextOrNull('word/footnotes.xml');
     if (!footnotesText) return null;
     return parseXml(footnotesText);
+  }
+
+  /** Return a source part's Relationships DOM, or null when it has none. */
+  async getPartRelationshipsXmlClone(sourcePartPath: string): Promise<Document | null> {
+    const relationshipsText = await this.zip.readTextOrNull(relationshipPartPath(sourcePartPath));
+    if (!relationshipsText) return null;
+    return parseXml(relationshipsText);
   }
 
   /**

--- a/packages/docx-core/src/primitives/footnotes.ts
+++ b/packages/docx-core/src/primitives/footnotes.ts
@@ -21,6 +21,7 @@ import {
   type ThemeModel,
 } from './styles.js';
 import { emitFormattingTags, mergeAdjacentTags, type AnnotatedRun } from './formatting_tags.js';
+import { ensureExternalHyperlinkRelationships } from './relationships.js';
 import {
   createRevisionContainer,
   prepareElementForDeletion,
@@ -31,6 +32,7 @@ import {
 
 const REL_TYPE_FOOTNOTES = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/footnotes';
 const CT_FOOTNOTES = 'application/vnd.openxmlformats-officedocument.wordprocessingml.footnotes+xml';
+const XMLNS_NS = 'http://www.w3.org/2000/xmlns/';
 
 // ── Minimal XML template ────────────────────────────────────────────────
 
@@ -134,7 +136,7 @@ export type FootnoteNotePresentation = {
   body?: FootnoteBodyParagraph[];
 };
 
-export type FootnoteStyledRun = { text: string; style?: FootnoteRunStyle };
+export type FootnoteStyledRun = { text: string; style?: FootnoteRunStyle; hyperlink?: { destination: string } };
 export type FootnoteBodyParagraph = { runs: FootnoteStyledRun[] };
 
 export type AddFootnoteResult = {
@@ -529,7 +531,17 @@ export async function addFootnote(
   insertFootnoteReference(documentXml, paragraphEl, noteId, afterText, visibleOffset, ctx);
 
   // Add footnote body to footnotes.xml
-  const footnoteEl = addFootnoteElement(footnotesDoc, noteId, text, presentation);
+  const destinations = [
+    ...(presentation?.prefixRuns ?? []),
+    ...(presentation?.separatorRuns ?? []),
+    ...(presentation?.body?.flatMap((paragraph) => paragraph.runs) ?? []),
+  ].flatMap((run) => run.hyperlink ? [run.hyperlink.destination] : []);
+  const hyperlinkRelationshipIds = await ensureExternalHyperlinkRelationships(
+    zip,
+    'word/footnotes.xml',
+    destinations,
+  );
+  const footnoteEl = addFootnoteElement(footnotesDoc, noteId, text, presentation, hyperlinkRelationshipIds);
   if (ctx) {
     wrapFootnoteParagraphTextRuns(getFirstFootnoteParagraph(footnoteEl), 'ins', ctx);
   }
@@ -733,8 +745,12 @@ function addFootnoteElement(
   noteId: number,
   text: string,
   presentation?: FootnoteNotePresentation,
+  hyperlinkRelationshipIds?: ReadonlyMap<string, string>,
 ): Element {
   const root = footnotesDoc.documentElement;
+  if (hyperlinkRelationshipIds?.size && root.lookupNamespaceURI('r') !== OOXML.R_NS) {
+    root.setAttributeNS(XMLNS_NS, 'xmlns:r', OOXML.R_NS);
+  }
 
   const footnoteEl = footnotesDoc.createElementNS(OOXML.W_NS, 'w:footnote');
   footnoteEl.setAttributeNS(OOXML.W_NS, 'w:id', String(noteId));
@@ -775,19 +791,53 @@ function addFootnoteElement(
     ?? (presentation?.prefix ? [{ text: presentation.prefix, style: presentation.prefixStyle }] : []);
   const separatorRuns = presentation?.separatorRuns
     ?? (presentation?.prefixSeparator ? [{ text: presentation.prefixSeparator }] : []);
-  for (const run of prefixRuns) p.appendChild(buildStyledTextRun(footnotesDoc, run.text, run.style));
-  for (const run of separatorRuns) p.appendChild(buildStyledTextRun(footnotesDoc, run.text, run.style));
+  appendFootnoteRuns(p, prefixRuns, footnotesDoc, hyperlinkRelationshipIds);
+  appendFootnoteRuns(p, separatorRuns, footnotesDoc, hyperlinkRelationshipIds);
   const body = presentation?.body ?? [{ runs: [{ text, style: presentation?.bodyStyle }] }];
-  for (const run of body[0]?.runs ?? []) p.appendChild(buildStyledTextRun(footnotesDoc, run.text, run.style));
+  appendFootnoteRuns(p, body[0]?.runs ?? [], footnotesDoc, hyperlinkRelationshipIds);
 
   footnoteEl.appendChild(p);
   for (const paragraph of body.slice(1)) {
     const bodyParagraph = footnotesDoc.createElementNS(OOXML.W_NS, 'w:p');
-    for (const run of paragraph.runs) bodyParagraph.appendChild(buildStyledTextRun(footnotesDoc, run.text, run.style));
+    appendFootnoteRuns(bodyParagraph, paragraph.runs, footnotesDoc, hyperlinkRelationshipIds);
     footnoteEl.appendChild(bodyParagraph);
   }
   root.appendChild(footnoteEl);
   return footnoteEl;
+}
+
+/**
+ * Emit footnote runs under destination-grouped external hyperlink wrappers.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.22
+ * @see #956
+ */
+function appendFootnoteRuns(
+  paragraph: Element,
+  runs: FootnoteStyledRun[],
+  doc: Document,
+  relationshipIds: ReadonlyMap<string, string> | undefined,
+): void {
+  let activeDestination: string | undefined;
+  let activeHyperlink: Element | undefined;
+  for (const styledRun of runs) {
+    const destination = styledRun.hyperlink?.destination;
+    if (!destination) {
+      activeDestination = undefined;
+      activeHyperlink = undefined;
+      paragraph.appendChild(buildStyledTextRun(doc, styledRun.text, styledRun.style));
+      continue;
+    }
+    const relationshipId = relationshipIds?.get(destination);
+    if (!relationshipId) throw new Error(`Missing footnote hyperlink relationship for ${destination}`);
+    if (activeDestination !== destination || !activeHyperlink) {
+      activeDestination = destination;
+      activeHyperlink = doc.createElementNS(OOXML.W_NS, 'w:hyperlink');
+      activeHyperlink.setAttributeNS(OOXML.R_NS, 'r:id', relationshipId);
+      paragraph.appendChild(activeHyperlink);
+    }
+    activeHyperlink.appendChild(buildStyledTextRun(doc, styledRun.text, styledRun.style));
+  }
 }
 
 function buildStyledTextRun(doc: Document, text: string, style?: FootnoteRunStyle): Element {

--- a/packages/docx-core/src/primitives/footnotes.ts
+++ b/packages/docx-core/src/primitives/footnotes.ts
@@ -1037,79 +1037,79 @@ function buildFootnoteTextRuns(doc: Document, text: string): [Element, Element] 
 }
 
 function removeFootnoteParagraphTextRuns(paragraph: Element): void {
-  const collected = collectFootnoteTextRuns(paragraph);
-  if (!collected) return;
-
-  for (const run of collected.runs) {
-    run.parentNode?.removeChild(run);
+  for (const group of collectFootnoteTextRunGroups(paragraph)) {
+    for (const run of group.runs) group.parent.removeChild(run);
   }
-
-  cleanupEmptyRevisionWrappers(paragraph);
+  cleanupEmptyRunContainers(paragraph);
 }
 
+/**
+ * Wrap every text run of a footnote paragraph in a `w:ins` / `w:del`
+ * revision container. Runs are wrapped per parent container, so text that
+ * already sits inside a revision wrapper or inside a `w:hyperlink` stays
+ * where it is: the new container is created inside that parent, which keeps
+ * document order and link identity intact instead of hoisting linked runs
+ * out of their hyperlink.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.22
+ * @see #956
+ */
 function wrapFootnoteParagraphTextRuns(
   paragraph: Element,
   kind: 'ins' | 'del',
   ctx: RevisionContext,
 ): Element | null {
-  const collected = collectFootnoteTextRuns(paragraph);
-  if (!collected) return null;
+  const groups = collectFootnoteTextRunGroups(paragraph);
+  if (groups.length === 0) return null;
 
   const doc = paragraph.ownerDocument;
   if (!doc) throw new Error('Paragraph has no ownerDocument');
 
-  const { parent: anchorParent, before: anchorBefore } = collected.insertionAnchor;
-  const wrapper = createRevisionContainer(doc, kind, ctx);
-  anchorParent.insertBefore(wrapper, anchorBefore);
-
-  for (const run of collected.runs) {
-    run.parentNode?.removeChild(run);
-    wrapper.appendChild(kind === 'del' ? prepareElementForDeletion(run) : run);
+  let first: Element | null = null;
+  for (const group of groups) {
+    const wrapper = createRevisionContainer(doc, kind, ctx);
+    group.parent.insertBefore(wrapper, group.runs[0]!);
+    for (const run of group.runs) {
+      group.parent.removeChild(run);
+      wrapper.appendChild(kind === 'del' ? prepareElementForDeletion(run) : run);
+    }
+    first ??= wrapper;
   }
 
-  cleanupEmptyRevisionWrappers(paragraph);
+  cleanupEmptyRunContainers(paragraph);
 
-  return wrapper;
+  return first;
 }
 
 /**
  * Collect every `<w:r>` descendant of the paragraph that does NOT contain a
- * `footnoteRef` marker. This intentionally crosses into `<w:ins>` / `<w:del>`
- * wrappers so that footnote text already carrying revision history (e.g.,
- * third-party documents or prior tracked edits in the same session) is still
- * captured by `updateFootnoteText` and `deleteFootnote`. The first-found
- * insertion-anchor (the parent of the first match) is returned so callers
- * can place a new wrapper at the same structural position.
+ * `footnoteRef` marker, grouped by immediate parent in document order. The
+ * traversal intentionally crosses `<w:ins>` / `<w:del>` wrappers so footnote
+ * text already carrying revision history (third-party documents or prior
+ * tracked edits in the same session) is still captured by
+ * `updateFootnoteText` and `deleteFootnote`, and crosses `<w:hyperlink>`
+ * containers so linked text is captured without being detached from its link.
  */
-function collectFootnoteTextRuns(paragraph: Element): {
-  insertionAnchor: { parent: Element; before: Node | null };
-  runs: Element[];
-} | null {
-  const collected: Array<{ parent: Element; run: Element }> = [];
+function collectFootnoteTextRunGroups(paragraph: Element): Array<{ parent: Element; runs: Element[] }> {
+  const groups: Array<{ parent: Element; runs: Element[] }> = [];
 
   function visit(parent: Element): void {
     for (const child of childElements(parent)) {
       if (isW(child, W.r)) {
-        if (!runContainsFootnoteRef(child)) {
-          collected.push({ parent, run: child });
-        }
+        if (runContainsFootnoteRef(child)) continue;
+        const last = groups[groups.length - 1];
+        if (last && last.parent === parent) last.runs.push(child);
+        else groups.push({ parent, runs: [child] });
         continue;
       }
-      if (isW(child, 'ins') || isW(child, 'del')) {
+      if (isW(child, 'ins') || isW(child, 'del') || isW(child, W.hyperlink)) {
         visit(child);
       }
     }
   }
 
   visit(paragraph);
-
-  if (collected.length === 0) return null;
-
-  const first = collected[0]!;
-  return {
-    insertionAnchor: { parent: first.parent, before: first.run },
-    runs: collected.map((entry) => entry.run),
-  };
+  return groups;
 }
 
 function runContainsFootnoteRef(run: Element): boolean {
@@ -1118,15 +1118,15 @@ function runContainsFootnoteRef(run: Element): boolean {
 
 /**
  * After detaching runs from their parents, sweep up any now-empty
- * `<w:ins>`/`<w:del>` siblings of the paragraph so we do not leave orphan
- * revision wrappers behind. This pairs with `collectFootnoteTextRuns`'s
- * cross-wrapper traversal.
+ * `<w:ins>` / `<w:del>` wrappers and `<w:hyperlink>` containers at any depth
+ * so we do not leave orphan containers behind. This pairs with
+ * `collectFootnoteTextRunGroups`'s cross-container traversal.
  */
-function cleanupEmptyRevisionWrappers(paragraph: Element): void {
-  for (const child of Array.from(childElements(paragraph))) {
-    if ((isW(child, 'ins') || isW(child, 'del')) && childElements(child).length === 0) {
-      paragraph.removeChild(child);
-    }
+function cleanupEmptyRunContainers(element: Element): void {
+  for (const child of Array.from(childElements(element))) {
+    if (!(isW(child, 'ins') || isW(child, 'del') || isW(child, W.hyperlink))) continue;
+    cleanupEmptyRunContainers(child);
+    if (childElements(child).length === 0) element.removeChild(child);
   }
 }
 

--- a/packages/docx-core/src/primitives/relationships.test.ts
+++ b/packages/docx-core/src/primitives/relationships.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect } from 'vitest';
 import { testAllure } from '../testing/allure-test.js';
 import { parseXml } from './xml.js';
+import { createZipBuffer, DocxZip } from './zip.js';
 import {
+  ensureExternalHyperlinkRelationships,
   parseDocumentRels,
   parseHyperlinkRelTargets,
   parseHyperlinkRelEntries,
+  parseRelationshipEntries,
   listRelationshipIds,
 } from './relationships.js';
 
@@ -54,6 +57,7 @@ describe('document.xml.rels parsing (issue #376 helpers)', () => {
     expect(parseDocumentRels(null).size).toBe(0);
     expect(parseHyperlinkRelTargets(null).size).toBe(0);
     expect(parseHyperlinkRelEntries(null).size).toBe(0);
+    expect(parseRelationshipEntries(null).size).toBe(0);
     expect(listRelationshipIds(null).size).toBe(0);
   });
 
@@ -74,4 +78,35 @@ describe('document.xml.rels parsing (issue #376 helpers)', () => {
     expect([...listRelationshipIds(prefixed)]).toEqual(['rId7']);
     expect(parseDocumentRels(prefixed).get('rId7')).toBe('https://alpha.example.com');
   });
+
+  test
+    .conformance({ spec: 'ECMA-376', edition: 5, part: 2, section: '6.5.2.3' })
+    .conformance({ spec: 'ECMA-376', edition: 5, part: 2, section: '6.5.3.4' })(
+      '[SDX-CONF-16] allocates annotation-part hyperlink relationships against every existing ID',
+      async () => {
+        const zip = await DocxZip.load(await createZipBuffer({
+          'word/_rels/comments.xml.rels':
+            `<Relationships xmlns="${REL_NS}">` +
+            `<Relationship Id="rId1" Type="${IMAGE}" Target="https://example.com/image" TargetMode="External"/>` +
+            '</Relationships>',
+        }));
+        const mapping = await ensureExternalHyperlinkRelationships(
+          zip,
+          'word/comments.xml',
+          ['https://example.com/a', 'https://example.com/a', 'https://example.com/b'],
+        );
+        expect(mapping).toEqual(new Map([
+          ['https://example.com/a', 'rId2'],
+          ['https://example.com/b', 'rId3'],
+        ]));
+        const entries = parseRelationshipEntries(parseXml(await zip.readText('word/_rels/comments.xml.rels')));
+        expect(entries.get('rId1')).toMatchObject({ type: IMAGE });
+        expect(entries.get('rId2')).toEqual({
+          id: 'rId2', type: HYPERLINK, target: 'https://example.com/a', targetMode: 'External',
+        });
+        expect(entries.get('rId3')).toEqual({
+          id: 'rId3', type: HYPERLINK, target: 'https://example.com/b', targetMode: 'External',
+        });
+      },
+    );
 });

--- a/packages/docx-core/src/primitives/relationships.ts
+++ b/packages/docx-core/src/primitives/relationships.ts
@@ -1,8 +1,17 @@
 // Parser for word/_rels/document.xml.rels — extracts external hyperlink relationships.
 
 import { OOXML } from './namespaces.js';
+import { parseXml, serializeXml } from './xml.js';
+import type { DocxZip } from './zip.js';
 
 export type RelsMap = Map<string, string>;
+
+export interface RelationshipEntry {
+  id: string;
+  type: string | null;
+  target: string | null;
+  targetMode: string | null;
+}
 
 /** OPC package-relationships namespace (parts almost always use it unprefixed). */
 const OPC_RELATIONSHIPS_NS =
@@ -16,6 +25,95 @@ const OPC_RELATIONSHIPS_NS =
  */
 function relationshipElements(relsDoc: Document): HTMLCollectionOf<Element> {
   return relsDoc.getElementsByTagNameNS(OPC_RELATIONSHIPS_NS, 'Relationship');
+}
+
+/** Parse every declared relationship keyed by its part-local identifier. */
+export function parseRelationshipEntries(
+  relsDoc: Document | null,
+): Map<string, RelationshipEntry> {
+  const entries = new Map<string, RelationshipEntry>();
+  if (!relsDoc) return entries;
+  const relationships = relationshipElements(relsDoc);
+  for (let i = 0; i < relationships.length; i++) {
+    const relationship = relationships.item(i)!;
+    const id = relationship.getAttribute('Id');
+    if (!id) continue;
+    entries.set(id, {
+      id,
+      type: relationship.getAttribute('Type'),
+      target: relationship.getAttribute('Target'),
+      targetMode: relationship.getAttribute('TargetMode'),
+    });
+  }
+  return entries;
+}
+
+/** Return the OPC Relationships-part path owned by one source part. */
+export function relationshipPartPath(sourcePartPath: string): string {
+  const separator = sourcePartPath.lastIndexOf('/');
+  const directory = separator < 0 ? '' : sourcePartPath.slice(0, separator + 1);
+  const fileName = separator < 0 ? sourcePartPath : sourcePartPath.slice(separator + 1);
+  return `${directory}_rels/${fileName}.rels`;
+}
+
+/**
+ * Ensure external hyperlink relationships owned by a source part and return
+ * the destination-to-rId mapping used to emit that part's `w:hyperlink`s.
+ * Existing relationships of every type reserve their identifiers; repeated
+ * destinations reuse one external hyperlink relationship deterministically.
+ *
+ * @conformance ECMA-376 edition 5, Part 2 § 6.5.2.3
+ * @conformance ECMA-376 edition 5, Part 2 § 6.5.3.4
+ * @see https://github.com/UseJunior/safe-docx/issues/956
+ */
+export async function ensureExternalHyperlinkRelationships(
+  zip: DocxZip,
+  sourcePartPath: string,
+  destinations: Iterable<string>,
+): Promise<Map<string, string>> {
+  const orderedDestinations = [...new Set(destinations)];
+  const result = new Map<string, string>();
+  if (orderedDestinations.length === 0) return result;
+  if (orderedDestinations.some((destination) => destination.length === 0)) {
+    throw new Error('External hyperlink destinations must be non-empty');
+  }
+
+  const relsPath = relationshipPartPath(sourcePartPath);
+  const existingXml = await zip.readTextOrNull(relsPath);
+  const relsDoc = parseXml(existingXml ??
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<Relationships xmlns="${OPC_RELATIONSHIPS_NS}"/>`);
+  const root = relsDoc.documentElement;
+  const relationships = Array.from(relationshipElements(relsDoc)) as Element[];
+  const usedIds = new Set<string>();
+  for (const relationship of relationships) {
+    const id = relationship.getAttribute('Id');
+    if (id) usedIds.add(id);
+    if (relationship.getAttribute('Type') !== OOXML.HYPERLINK_REL_TYPE
+      || relationship.getAttribute('TargetMode') !== 'External') continue;
+    const target = relationship.getAttribute('Target');
+    if (id && target && !result.has(target)) result.set(target, id);
+  }
+
+  let changed = false;
+  let candidate = 1;
+  for (const destination of orderedDestinations) {
+    if (result.has(destination)) continue;
+    while (usedIds.has(`rId${candidate}`)) candidate++;
+    const id = `rId${candidate++}`;
+    usedIds.add(id);
+    const relationship = relsDoc.createElementNS(OPC_RELATIONSHIPS_NS, 'Relationship');
+    relationship.setAttribute('Id', id);
+    relationship.setAttribute('Type', OOXML.HYPERLINK_REL_TYPE);
+    relationship.setAttribute('Target', destination);
+    relationship.setAttribute('TargetMode', 'External');
+    root.appendChild(relationship);
+    result.set(destination, id);
+    changed = true;
+  }
+
+  if (changed || existingXml === null) zip.writeText(relsPath, serializeXml(relsDoc));
+  return new Map(orderedDestinations.map((destination) => [destination, result.get(destination)!]));
 }
 
 /**

--- a/packages/docx-core/test-primitives/footnotes.test.ts
+++ b/packages/docx-core/test-primitives/footnotes.test.ts
@@ -1413,10 +1413,10 @@ describe('footnotes', () => {
       });
     });
 
-    test('updateFootnoteText with ctx captures both direct and pre-existing-w:ins-wrapped text runs in the deletion', async ({ given, when, then }: AllureBddContext) => {
+    test('updateFootnoteText with ctx deletes direct and pre-existing-w:ins-wrapped text runs inside their own containers', async ({ given, when, then }: AllureBddContext) => {
       let zip: DocxZip;
       let noteParagraph: Element;
-      let deletion: Element;
+      let deletions: Element[];
 
       const ctx = createRevisionContext({
         author: 'SafeDocX AI',
@@ -1447,16 +1447,21 @@ describe('footnotes', () => {
         const footnotesDoc = await readFootnotesXml(zip);
         const footnoteEl = findFootnoteById(footnotesDoc, 5)!;
         noteParagraph = getFirstParagraph(footnoteEl);
-        deletion = noteParagraph.getElementsByTagNameNS(OOXML.W_NS, 'del').item(0) as Element;
+        deletions = Array.from(noteParagraph.getElementsByTagNameNS(OOXML.W_NS, 'del')) as Element[];
       });
 
-      await then('the deletion captures both wrapped and direct text content; the new replacement w:ins is hoisted to the paragraph level under SafeDocX AI authorship', async () => {
-        expect(deletion).toBeTruthy();
-        const delTexts = Array.from(deletion.getElementsByTagNameNS(OOXML.W_NS, 'delText')).map(
+      await then('each run is deleted inside its own container so prior authorship survives; the new replacement w:ins is hoisted to the paragraph level under SafeDocX AI authorship', async () => {
+        // Both "wrapped" and " direct" are deleted, but in separate <w:del>
+        // wrappers: the direct run stays a paragraph child (it was never part of
+        // OldAuthor's insertion, so rejecting that insertion must not drop it),
+        // while the wrapped run is deleted inside OldAuthor's <w:ins> (#956).
+        const delTextsOf = (deletion: Element): string[] => Array.from(deletion.getElementsByTagNameNS(OOXML.W_NS, 'delText')).map(
           (t) => t.textContent ?? '',
         );
-        // Both "wrapped" and " direct" text appear inside the new <w:del>.
-        expect(delTexts).toEqual(expect.arrayContaining(['wrapped', ' direct']));
+        expect(deletions.map(delTextsOf)).toEqual([['wrapped'], [' direct']]);
+        expect((deletions[0]!.parentNode as Element).localName).toBe('ins');
+        expect((deletions[0]!.parentNode as Element).getAttribute('w:author')).toBe('OldAuthor');
+        expect(deletions[1]!.parentNode).toBe(noteParagraph);
 
         // The new replacement <w:ins> is hoisted to the paragraph level so its
         // SafeDocX AI authorship is not nested inside the prior author's wrapper.

--- a/packages/docx-markdoc/src/annotation-roundtrip.test.ts
+++ b/packages/docx-markdoc/src/annotation-roundtrip.test.ts
@@ -268,6 +268,33 @@ describe('canonical annotation round trips', () => {
     }
   });
 
+  hyperlinkConformance('keeps reserved Markdoc characters in destinations and authors exact across the round trip', async () => {
+    const destination = 'https://example.com/search?a=1&b=2&q="quoted"\\path';
+    const base = await buildSyntheticDocx({ paragraphs: ['Alpha beta gamma.'] });
+    const document = await DocxDocument.load(base);
+    document.insertParagraphBookmarks('reserved-characters');
+    const paragraphId = document.buildDocumentView().nodes[0]!.id;
+    await document.addComment({
+      paragraphId, start: 0, end: 5, author: 'Smith & "Jones"', initials: 'SJ', text: 'link',
+      body: [{ runs: [{ text: 'link', hyperlink: { destination } }] }],
+    });
+    const imported = await importDocxToMarkdoc((await document.toBuffer({ cleanBookmarks: false })).buffer);
+    expect(imported.annotations[0]!.body[0]!.runs[0]).toEqual({ text: 'link', hyperlink: { destination } });
+    expect(imported.markdoc).toContain('href="https://example.com/search?a=1&b=2&q=\\"quoted\\"\\\\path"');
+    const parsed = requireMarkdoc(imported.markdoc);
+    expect(parsed.annotations[0]!.body[0]!.runs[0]).toEqual({ text: 'link', hyperlink: { destination } });
+    expect(parsed.annotations[0]!.author).toBe('Smith & "Jones"');
+
+    for (const target of ['comment', 'footnote'] as const) {
+      const projected = await compileMarkdoc(imported.anchoredSource, projectEveryAnnotationAs(imported.markdoc, target));
+      const zip = await JSZip.loadAsync(projected.tracked);
+      const relsPath = target === 'comment' ? 'word/_rels/comments.xml.rels' : 'word/_rels/footnotes.xml.rels';
+      const external = [...relationshipEntries(await zip.file(relsPath)!.async('string')).values()]
+        .filter((entry) => entry.type === HYPERLINK_REL_TYPE);
+      expect(external.map((entry) => entry.target)).toEqual([destination]);
+    }
+  });
+
   hyperlinkConformance('[SDX-MDOC-105] allocates repeated annotation destinations deterministically across relationship collisions', async () => {
     const source = await sourceWithLinkedAnnotation('footnote');
     const collided = await withDestinationRelationshipCollision(source, 'comment');

--- a/packages/docx-markdoc/src/annotation-roundtrip.test.ts
+++ b/packages/docx-markdoc/src/annotation-roundtrip.test.ts
@@ -1,7 +1,7 @@
 import { readFile } from 'node:fs/promises';
 import { describe, expect } from 'vitest';
 import JSZip from 'jszip';
-import { buildSyntheticDocx, DocxDocument } from '@usejunior/docx-core';
+import { buildDocxFromParts, buildSyntheticDocx, DocxDocument, OOXML, parseRelationshipEntries, parseXml } from '@usejunior/docx-core';
 import { testAllure } from '../../docx-core/src/testing/allure-test.js';
 import { compileMarkdoc } from './compile.js';
 import { importDocxToMarkdoc } from './import.js';
@@ -50,6 +50,70 @@ async function sourceWithNamedStyleComment(styles: string): Promise<Buffer> {
   ));
   zip.file('word/styles.xml', `<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">${styles}</w:styles>`);
   return zip.generateAsync({ type: 'nodebuffer' });
+}
+
+const PRIMARY_LINK = 'https://example.com/annotation-primary';
+const SECONDARY_LINK = 'https://example.com/annotation-secondary';
+const HYPERLINK_REL_TYPE = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink';
+const RELATIONSHIPS_NS = 'http://schemas.openxmlformats.org/package/2006/relationships';
+
+async function sourceWithLinkedAnnotation(source: 'comment' | 'footnote'): Promise<Buffer> {
+  const stylesXml =
+    `<w:styles xmlns:w="${OOXML.W_NS}">` +
+    `<w:style w:type="character" w:styleId="Hyperlink"><w:name w:val="Hyperlink"/><w:rPr><w:u w:val="single"/><w:color w:val="0563C1"/></w:rPr></w:style>` +
+    `</w:styles>`;
+  const base = await buildDocxFromParts({
+    bodyXml: '<w:p><w:r><w:t>Alpha beta gamma.</w:t></w:r></w:p>',
+    stylesXml,
+    documentRelEntries: [
+      '<Relationship Id="rIdStyles" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>',
+    ],
+  });
+  const document = await DocxDocument.load(base);
+  document.insertParagraphBookmarks(`linked-${source}`);
+  const paragraphId = document.buildDocumentView().nodes[0]!.id;
+  const body = [{ runs: [
+    { text: 'Before ' },
+    { text: 'Primary ', style: { styleId: 'Hyperlink', fontSizeHalfPoints: 18 }, hyperlink: { destination: PRIMARY_LINK } },
+    { text: 'formatted', style: { styleId: 'Hyperlink', fontSizeHalfPoints: 18, bold: true }, hyperlink: { destination: PRIMARY_LINK } },
+    { text: ' between ' },
+    { text: 'Secondary', style: { italic: true }, hyperlink: { destination: SECONDARY_LINK } },
+    { text: ' and ' },
+    { text: 'Primary again', style: { underline: true }, hyperlink: { destination: PRIMARY_LINK } },
+    { text: ' after' },
+  ] }];
+  if (source === 'comment') {
+    await document.addComment({ paragraphId, start: 0, end: 5, author: 'Link Tester', initials: 'LT', text: 'linked', body });
+  } else {
+    await document.addFootnote({ paragraphId, visibleOffset: 5, text: 'linked', presentation: { body } });
+  }
+  return (await document.toBuffer({ cleanBookmarks: false })).buffer;
+}
+
+async function withDestinationRelationshipCollision(buffer: Buffer, destination: 'comment' | 'footnote'): Promise<Buffer> {
+  const zip = await JSZip.loadAsync(buffer);
+  const relsPath = destination === 'comment' ? 'word/_rels/comments.xml.rels' : 'word/_rels/footnotes.xml.rels';
+  zip.file(relsPath,
+    `<Relationships xmlns="${RELATIONSHIPS_NS}">` +
+    '<Relationship Id="rId1" Type="https://example.com/relationships/reserved" Target="https://example.com/reserved" TargetMode="External"/>' +
+    '</Relationships>');
+  return zip.generateAsync({ type: 'nodebuffer' });
+}
+
+async function withoutFootnoteBookmarks(buffer: Buffer): Promise<Buffer> {
+  const zip = await JSZip.loadAsync(buffer);
+  const footnotesXml = await zip.file('word/footnotes.xml')!.async('string');
+  zip.file('word/footnotes.xml', footnotesXml.replace(/<w:bookmark(?:Start|End)\b[^>]*\/>/gu, ''));
+  return zip.generateAsync({ type: 'nodebuffer' });
+}
+
+function projectEveryAnnotationAs(markdoc: string, destination: 'comment' | 'footnote'): string {
+  return markdoc.replace(/source-presentation="(?:comment|footnote)"/gu, (sourcePresentation) =>
+    `${sourcePresentation} presentation="${destination}"`);
+}
+
+function relationshipEntries(xml: string): ReturnType<typeof parseRelationshipEntries> {
+  return parseRelationshipEntries(parseXml(xml));
 }
 
 describe('canonical annotation round trips', () => {
@@ -149,17 +213,158 @@ describe('canonical annotation round trips', () => {
     });
   });
 
-  runStyleConformance('[SDX-MDOC-103] admits real ILPA style runs before failing closed on hyperlinks', async () => {
+  runStyleConformance('[SDX-MDOC-103] admits real ILPA style runs and external hyperlinks before the next bookmark boundary', async () => {
+    const wof = await readFile(new URL('../../../tests/test_documents/redline/ILPA-Model-Limited-Partnership-Agreement-WOF_v2.docx', import.meta.url));
+    await expect(importDocxToMarkdoc(wof)).rejects.toMatchObject({
+      code: 'ANNOTATION_IMPORT_UNSUPPORTED', details: { annotationId: 'footnote:19', element: 'w:bookmarkStart' },
+    });
+
+    // The Deal-By-Deal fixture on origin/main has no bookmark markers in
+    // footnote:19, so advancing beyond footnote:6 imports it completely.
+    const dealByDeal = await readFile(new URL('../../../tests/test_documents/redline/ILPA-Model-Limited-Parnership-Agreement-Deal-By-Deal_v1.docx', import.meta.url));
+    const imported = await importDocxToMarkdoc(dealByDeal);
+    expect(imported.annotations.find((annotation) => annotation.id === 'footnote:6')?.body[0]?.runs)
+      .toContainEqual(expect.objectContaining({ hyperlink: { destination: PRIMARY_LINK.replace('example.com/annotation-primary', 'ilpa.org/wp-content/uploads/2017/06/ILPA-Subscription-Lines-of-Credit-and-Alignment-of-Interests-June-2017.pdf') } }));
+  });
+
+  const hyperlinkConformance = test
+    .conformance({ spec: 'ECMA-376', edition: 5, part: 1, section: '17.16.22' })
+    .conformance({ spec: 'ECMA-376', edition: 5, part: 2, section: '6.5.2.3' })
+    .conformance({ spec: 'ECMA-376', edition: 5, part: 2, section: '6.5.3.4' });
+
+  hyperlinkConformance('[SDX-MDOC-104] preserves external links and formatting across all annotation projections', async () => {
+    for (const source of ['comment', 'footnote'] as const) {
+      const imported = await importDocxToMarkdoc(await sourceWithLinkedAnnotation(source));
+      const linkedRuns = imported.annotations[0]!.body[0]!.runs.filter((run) => run.hyperlink);
+      expect(linkedRuns.map((run) => run.hyperlink?.destination)).toEqual([PRIMARY_LINK, PRIMARY_LINK, SECONDARY_LINK, PRIMARY_LINK]);
+      expect(linkedRuns[0]).toMatchObject({ text: 'Primary ', style: { styleId: 'Hyperlink', fontSizeHalfPoints: 18 } });
+      expect(linkedRuns[1]).toMatchObject({ text: 'formatted', style: { styleId: 'Hyperlink', fontSizeHalfPoints: 18, bold: true } });
+      expect(imported.markdoc).toContain(`href="${PRIMARY_LINK}" style="Hyperlink" size=18`);
+      const parsedBody = requireMarkdoc(imported.markdoc).annotations[0]!.body;
+      expect(parsedBody.flatMap((paragraph) => paragraph.runs).filter((run) => run.hyperlink)).toEqual(linkedRuns);
+      expect(parsedBody.map((paragraph) => paragraph.runs.map((run) => run.text).join('')).join('\n'))
+        .toBe(imported.annotations[0]!.body.map((paragraph) => paragraph.runs.map((run) => run.text).join('')).join('\n'));
+
+      for (const destination of ['comment', 'footnote'] as const) {
+        const markdoc = imported.markdoc.replace(
+          `source-presentation="${source}"`,
+          `source-presentation="${source}" presentation="${destination}"`,
+        );
+        const projected = await compileMarkdoc(imported.anchoredSource, markdoc);
+        const zip = await JSZip.loadAsync(projected.tracked);
+        const partPath = destination === 'comment' ? 'word/comments.xml' : 'word/footnotes.xml';
+        const relsPath = destination === 'comment' ? 'word/_rels/comments.xml.rels' : 'word/_rels/footnotes.xml.rels';
+        const partXml = await zip.file(partPath)!.async('string');
+        const rels = relationshipEntries(await zip.file(relsPath)!.async('string'));
+        const externalLinks = [...rels.values()].filter((entry) => entry.type === HYPERLINK_REL_TYPE && entry.targetMode === 'External');
+        expect(externalLinks.filter((entry) => entry.target === PRIMARY_LINK)).toHaveLength(1);
+        expect(externalLinks.filter((entry) => entry.target === SECONDARY_LINK)).toHaveLength(1);
+        expect(partXml).toContain('<w:hyperlink r:id=');
+        expect(partXml).toContain('<w:rStyle w:val="Hyperlink"/>');
+        expect(partXml).toContain('<w:sz w:val="18"/>');
+        expect(partXml).toContain('Primary ');
+        expect(partXml).toContain('formatted');
+      }
+    }
+  });
+
+  hyperlinkConformance('[SDX-MDOC-105] allocates repeated annotation destinations deterministically across relationship collisions', async () => {
+    const source = await sourceWithLinkedAnnotation('footnote');
+    const collided = await withDestinationRelationshipCollision(source, 'comment');
+    const imported = await importDocxToMarkdoc(collided);
+    const markdoc = imported.markdoc.replace(
+      'source-presentation="footnote"',
+      'source-presentation="footnote" presentation="comment"',
+    );
+    const first = await compileMarkdoc(imported.anchoredSource, markdoc);
+    const second = await compileMarkdoc(imported.anchoredSource, markdoc);
+    for (const projected of [first, second]) {
+      const zip = await JSZip.loadAsync(projected.tracked);
+      const entries = relationshipEntries(await zip.file('word/_rels/comments.xml.rels')!.async('string'));
+      expect(entries.get('rId1')).toMatchObject({ type: 'https://example.com/relationships/reserved' });
+      expect(entries.get('rId2')).toMatchObject({ target: PRIMARY_LINK, targetMode: 'External' });
+      expect(entries.get('rId3')).toMatchObject({ target: SECONDARY_LINK, targetMode: 'External' });
+      expect([...entries.values()].filter((entry) => entry.target === PRIMARY_LINK)).toHaveLength(1);
+    }
+    const firstRels = await (await JSZip.loadAsync(first.tracked)).file('word/_rels/comments.xml.rels')!.async('string');
+    const secondRels = await (await JSZip.loadAsync(second.tracked)).file('word/_rels/comments.xml.rels')!.async('string');
+    expect(secondRels).toBe(firstRels);
+  });
+
+  hyperlinkConformance('[SDX-MDOC-106] rejects malformed and invalid external annotation hyperlink relationships', async () => {
+    const source = await sourceWithLinkedAnnotation('comment');
+    const cases: Array<{ reason: string; mutatePart?: (xml: string) => string; mutateRels?: (xml: string) => string }> = [
+      { reason: 'missing-hyperlink-id', mutatePart: (xml) => xml.replace(/ r:id="rId1"/u, '') },
+      { reason: 'dangling-hyperlink-relationship', mutatePart: (xml) => xml.replace('r:id="rId1"', 'r:id="rId404"') },
+      { reason: 'wrong-hyperlink-relationship-type', mutateRels: (xml) => xml.replace(HYPERLINK_REL_TYPE, 'https://example.com/relationships/image') },
+      { reason: 'non-external-hyperlink', mutateRels: (xml) => xml.replace(' TargetMode="External"', '') },
+      { reason: 'non-external-hyperlink', mutateRels: (xml) => xml.replace('TargetMode="External"', 'TargetMode="Internal"') },
+      { reason: 'missing-hyperlink-target', mutateRels: (xml) => xml.replace(`Target="${PRIMARY_LINK}"`, 'Target=""') },
+      { reason: 'unsupported-hyperlink-attribute', mutatePart: (xml) => xml.replace('<w:hyperlink ', '<w:hyperlink w:tooltip="not-represented" ') },
+      { reason: 'unsupported-hyperlink-content', mutatePart: (xml) => xml.replace(/(<w:hyperlink[^>]*>)/u, '$1<w:p/>') },
+    ];
+    for (const item of cases) {
+      const zip = await JSZip.loadAsync(source);
+      if (item.mutatePart) zip.file('word/comments.xml', item.mutatePart(await zip.file('word/comments.xml')!.async('string')));
+      if (item.mutateRels) zip.file('word/_rels/comments.xml.rels', item.mutateRels(await zip.file('word/_rels/comments.xml.rels')!.async('string')));
+      await expect(importDocxToMarkdoc(await zip.generateAsync({ type: 'nodebuffer' }))).rejects.toMatchObject({
+        code: 'ANNOTATION_IMPORT_UNSUPPORTED', details: { annotationId: 'comment:0', reason: item.reason },
+      });
+    }
+  });
+
+  hyperlinkConformance('[SDX-MDOC-107] keeps internal annotation anchors and bookmark markers fail-closed', async () => {
+    const source = await sourceWithLinkedAnnotation('comment');
+    const anchorZip = await JSZip.loadAsync(source);
+    const commentXml = await anchorZip.file('word/comments.xml')!.async('string');
+    anchorZip.file('word/comments.xml', commentXml.replace('<w:hyperlink ', '<w:hyperlink w:anchor="inside" '));
+    await expect(importDocxToMarkdoc(await anchorZip.generateAsync({ type: 'nodebuffer' }))).rejects.toMatchObject({
+      code: 'ANNOTATION_IMPORT_UNSUPPORTED', details: { annotationId: 'comment:0', reason: 'internal-anchor', anchor: 'inside' },
+    });
+
+    const bookmarkZip = await JSZip.loadAsync(source);
+    bookmarkZip.file('word/comments.xml', commentXml.replace('</w:comment>', '<w:bookmarkStart w:id="9" w:name="inside"/></w:comment>'));
+    await expect(importDocxToMarkdoc(await bookmarkZip.generateAsync({ type: 'nodebuffer' }))).rejects.toMatchObject({
+      code: 'ANNOTATION_IMPORT_UNSUPPORTED', details: { annotationId: 'comment:0', element: 'w:bookmarkStart' },
+    });
+  });
+
+  hyperlinkConformance('projects bookmark-stripped real ILPA hyperlinks both ways with valid destination-part relationships', async () => {
     const fixtures = [
       '../../../tests/test_documents/redline/ILPA-Model-Limited-Partnership-Agreement-WOF_v2.docx',
       '../../../tests/test_documents/redline/ILPA-Model-Limited-Parnership-Agreement-Deal-By-Deal_v1.docx',
     ];
+    const expectedDestination = 'https://ilpa.org/wp-content/uploads/2017/06/ILPA-Subscription-Lines-of-Credit-and-Alignment-of-Interests-June-2017.pdf';
+    const expectedText = expectedDestination;
     for (const fixture of fixtures) {
-      await expect(importDocxToMarkdoc(await readFile(new URL(fixture, import.meta.url)))).rejects.toMatchObject({
-        code: 'ANNOTATION_IMPORT_UNSUPPORTED', details: { annotationId: 'footnote:6', element: 'w:hyperlink' },
+      const source = await withoutFootnoteBookmarks(await readFile(new URL(fixture, import.meta.url)));
+      const imported = await importDocxToMarkdoc(source);
+      const hyperlinkRun = imported.annotations
+        .find((annotation) => annotation.id === 'footnote:6')!
+        .body.flatMap((paragraph) => paragraph.runs)
+        .find((run) => run.hyperlink);
+      expect(hyperlinkRun).toMatchObject({
+        text: expectedText,
+        hyperlink: { destination: expectedDestination },
+        style: { styleId: 'Hyperlink', fontSizeHalfPoints: 18 },
       });
+
+      for (const destination of ['comment', 'footnote'] as const) {
+        const projected = await compileMarkdoc(imported.anchoredSource, projectEveryAnnotationAs(imported.markdoc, destination));
+        const zip = await JSZip.loadAsync(projected.tracked);
+        const partPath = destination === 'comment' ? 'word/comments.xml' : 'word/footnotes.xml';
+        const relsPath = destination === 'comment' ? 'word/_rels/comments.xml.rels' : 'word/_rels/footnotes.xml.rels';
+        const partXml = await zip.file(partPath)!.async('string');
+        const entries = relationshipEntries(await zip.file(relsPath)!.async('string'));
+        const relationship = [...entries.values()].find((entry) => entry.target === expectedDestination);
+        expect(relationship).toMatchObject({ type: HYPERLINK_REL_TYPE, targetMode: 'External' });
+        expect(partXml).toContain(`<w:hyperlink r:id="${relationship!.id}">`);
+        expect(partXml).toContain('<w:rStyle w:val="Hyperlink"/>');
+        expect(partXml).toContain('<w:sz w:val="18"/>');
+        expect(partXml).toContain(expectedText);
+      }
     }
-  });
+  }, 30_000);
 
   footnoteConformance('[SDX-MDOC-85] switches profiles and style-only recompiles from one immutable annotation', async () => {
     const imported = await importDocxToMarkdoc(await sourceWithComment(0, 5));

--- a/packages/docx-markdoc/src/import.ts
+++ b/packages/docx-markdoc/src/import.ts
@@ -1,4 +1,11 @@
-import { DocxDocument, OOXML, W, computeContentFingerprint, type StylesModel } from '@usejunior/docx-core';
+import {
+  DocxDocument,
+  OOXML,
+  W,
+  computeContentFingerprint,
+  parseRelationshipEntries,
+  type StylesModel,
+} from '@usejunior/docx-core';
 import { sha256 } from './hash.js';
 import { DocxMarkdocError } from './errors.js';
 import type { AnnotationAnchor, AnnotationParagraph, AnnotationRun, AnnotationRunStyle, CanonicalAnnotation, ImportResult } from './types.js';
@@ -71,6 +78,7 @@ function bodyFromParagraphs(
   container: Element,
   annotationId: string,
   marker: 'annotationRef' | 'footnoteRef',
+  hyperlinks: ReadonlyMap<Element, string>,
 ): AnnotationParagraph[] {
   if (paragraphs.length === 0) throw new DocxMarkdocError('ANNOTATION_IMPORT_UNSUPPORTED', `Annotation ${annotationId} has no admitted paragraphs.`, { annotationId });
   const sourceParagraphs = Array.from(container.getElementsByTagNameNS(OOXML.W_NS, W.p)) as Element[];
@@ -78,7 +86,7 @@ function bodyFromParagraphs(
     const parsed = parseTaggedRuns(paragraph.tagged_text, annotationId);
     const sourceParagraph = sourceParagraphs[paragraphIndex];
     if (!sourceParagraph) return { runs: parsed };
-    const spans: Array<{ start: number; end: number; styleId?: string; fontSizeHalfPoints?: number }> = [];
+    const spans: Array<{ start: number; end: number; styleId?: string; fontSizeHalfPoints?: number; hyperlinkDestination?: string }> = [];
     let offset = 0;
     for (const run of Array.from(sourceParagraph.getElementsByTagNameNS(OOXML.W_NS, W.r)) as Element[]) {
       if (run.getElementsByTagNameNS(OOXML.W_NS, marker).length > 0) continue;
@@ -89,7 +97,17 @@ function bodyFromParagraphs(
       const size = Array.from(run.getElementsByTagNameNS(OOXML.W_NS, 'sz'))[0] as Element | undefined;
       const rawSize = size?.getAttributeNS(OOXML.W_NS, W.val) ?? size?.getAttribute('w:val') ?? undefined;
       const fontSizeHalfPoints = rawSize && /^\d+$/u.test(rawSize) ? Number(rawSize) : undefined;
-      spans.push({ start: offset, end: offset + text.length, ...(styleId ? { styleId } : {}), ...(fontSizeHalfPoints ? { fontSizeHalfPoints } : {}) });
+      const parent = run.parentNode as Element | null;
+      const hyperlink = parent?.nodeType === 1 && parent.namespaceURI === OOXML.W_NS
+        && parent.localName === W.hyperlink ? parent : undefined;
+      const hyperlinkDestination = hyperlink ? hyperlinks.get(hyperlink) : undefined;
+      spans.push({
+        start: offset,
+        end: offset + text.length,
+        ...(styleId ? { styleId } : {}),
+        ...(fontSizeHalfPoints ? { fontSizeHalfPoints } : {}),
+        ...(hyperlinkDestination ? { hyperlinkDestination } : {}),
+      });
       offset += text.length;
     }
     const runs: AnnotationRun[] = [];
@@ -106,7 +124,11 @@ function bodyFromParagraphs(
           ...(span?.styleId ? { styleId: span.styleId } : {}),
           ...(span?.fontSizeHalfPoints ? { fontSizeHalfPoints: span.fontSizeHalfPoints } : {}),
         };
-        runs.push({ text, ...(Object.keys(style).length ? { style } : {}) });
+        runs.push({
+          text,
+          ...(Object.keys(style).length ? { style } : {}),
+          ...(span?.hyperlinkDestination ? { hyperlink: { destination: span.hyperlinkDestination } } : {}),
+        });
         consumed += length;
       }
       parsedOffset += run.text.length;
@@ -128,8 +150,25 @@ function assertNamedStyle(styles: StylesModel, styleId: string, annotationId: st
   }
 }
 
-function assertAdmittedAnnotationElement(container: Element, annotationId: string, marker: 'annotationRef' | 'footnoteRef', styles: StylesModel): void {
-  const admitted = new Set(['p', 'pPr', 'pStyle', 'r', 'rPr', 't', marker, 'b', 'i', 'u', 'color', 'highlight', 'rStyle', 'vertAlign', 'sz']);
+/**
+ * Validate the admitted annotation-body subset and resolve each external link
+ * against the relationship part owned by the annotation source part.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.22
+ * @conformance ECMA-376 edition 5, Part 2 § 6.5.2.3
+ * @conformance ECMA-376 edition 5, Part 2 § 6.5.3.4
+ * @see #956
+ */
+function assertAdmittedAnnotationElement(
+  container: Element,
+  annotationId: string,
+  marker: 'annotationRef' | 'footnoteRef',
+  styles: StylesModel,
+  relationshipsDocument: Document | null,
+): Map<Element, string> {
+  const admitted = new Set(['p', 'pPr', 'pStyle', 'r', 'rPr', 't', marker, 'b', 'i', 'u', 'color', 'highlight', 'rStyle', 'vertAlign', 'sz', 'hyperlink']);
+  const relationships = parseRelationshipEntries(relationshipsDocument);
+  const resolvedHyperlinks = new Map<Element, string>();
   for (const node of Array.from(container.getElementsByTagNameNS(OOXML.W_NS, '*'))) {
     const element = node as Element;
     let formattingOwner = element.parentNode as Element | null;
@@ -141,6 +180,28 @@ function assertAdmittedAnnotationElement(container: Element, annotationId: strin
       && !/[\u0590-\u08FF\uFB1D-\uFDFF\uFE70-\uFEFF]/u.test(formattingOwner.textContent ?? '');
     if (!admitted.has(element.localName) && !harmlessComplexScriptFallback) {
       throw new DocxMarkdocError('ANNOTATION_IMPORT_UNSUPPORTED', `Annotation ${annotationId} contains unsupported w:${element.localName}.`, { annotationId, element: `w:${element.localName}` });
+    }
+    if (element.localName === W.hyperlink) {
+      const anchor = element.getAttributeNS(OOXML.W_NS, 'anchor') ?? element.getAttribute('w:anchor');
+      if (anchor) throw new DocxMarkdocError('ANNOTATION_IMPORT_UNSUPPORTED', `Annotation ${annotationId} contains an unsupported internal hyperlink anchor.`, { annotationId, element: 'w:hyperlink', reason: 'internal-anchor', anchor });
+      const unsupportedAttribute = Array.from(element.attributes).find((attribute) =>
+        !(attribute.namespaceURI === OOXML.R_NS && attribute.localName === 'id')
+        && !(attribute.namespaceURI === OOXML.W_NS && attribute.localName === 'history')
+        && attribute.namespaceURI !== 'http://www.w3.org/2000/xmlns/',
+      );
+      if (unsupportedAttribute) throw new DocxMarkdocError('ANNOTATION_IMPORT_UNSUPPORTED', `Annotation ${annotationId} hyperlink contains unsupported attribute ${unsupportedAttribute.name}.`, { annotationId, element: 'w:hyperlink', reason: 'unsupported-hyperlink-attribute', attribute: unsupportedAttribute.name });
+      const directChildren = Array.from(element.childNodes).filter((child) => child.nodeType === 1) as Element[];
+      const unsupportedChild = directChildren.find((child) => child.namespaceURI !== OOXML.W_NS || child.localName !== W.r);
+      if (unsupportedChild) throw new DocxMarkdocError('ANNOTATION_IMPORT_UNSUPPORTED', `Annotation ${annotationId} hyperlink contains unsupported ${unsupportedChild.nodeName}.`, { annotationId, element: unsupportedChild.nodeName, reason: 'unsupported-hyperlink-content' });
+      if (directChildren.length === 0) throw new DocxMarkdocError('ANNOTATION_IMPORT_UNSUPPORTED', `Annotation ${annotationId} contains an empty hyperlink wrapper.`, { annotationId, element: 'w:hyperlink', reason: 'empty-hyperlink' });
+      const relationshipId = element.getAttributeNS(OOXML.R_NS, 'id') ?? element.getAttribute('r:id');
+      if (!relationshipId) throw new DocxMarkdocError('ANNOTATION_IMPORT_UNSUPPORTED', `Annotation ${annotationId} hyperlink has no relationship ID.`, { annotationId, element: 'w:hyperlink', reason: 'missing-hyperlink-id' });
+      const relationship = relationships.get(relationshipId);
+      if (!relationship) throw new DocxMarkdocError('ANNOTATION_IMPORT_UNSUPPORTED', `Annotation ${annotationId} hyperlink relationship ${relationshipId} is dangling.`, { annotationId, element: 'w:hyperlink', reason: 'dangling-hyperlink-relationship', relationshipId });
+      if (relationship.type !== OOXML.HYPERLINK_REL_TYPE) throw new DocxMarkdocError('ANNOTATION_IMPORT_UNSUPPORTED', `Annotation ${annotationId} relationship ${relationshipId} is not a hyperlink relationship.`, { annotationId, element: 'w:hyperlink', reason: 'wrong-hyperlink-relationship-type', relationshipId, relationshipType: relationship.type });
+      if (relationship.targetMode !== 'External') throw new DocxMarkdocError('ANNOTATION_IMPORT_UNSUPPORTED', `Annotation ${annotationId} hyperlink relationship ${relationshipId} is not external.`, { annotationId, element: 'w:hyperlink', reason: 'non-external-hyperlink', relationshipId, targetMode: relationship.targetMode ?? 'Internal' });
+      if (!relationship.target) throw new DocxMarkdocError('ANNOTATION_IMPORT_UNSUPPORTED', `Annotation ${annotationId} hyperlink relationship ${relationshipId} has no target.`, { annotationId, element: 'w:hyperlink', reason: 'missing-hyperlink-target', relationshipId });
+      resolvedHyperlinks.set(element, relationship.target);
     }
     if (element.localName === W.rPr) {
       const run = element.parentNode as Element | null;
@@ -159,6 +220,7 @@ function assertAdmittedAnnotationElement(container: Element, annotationId: strin
       }
     }
   }
+  return resolvedHyperlinks;
 }
 
 function elementByWordId(document: Document | null, localName: string, id: number): Element | null {
@@ -199,10 +261,11 @@ function annotationMarkdoc(annotation: CanonicalAnnotation): string[] {
   for (const paragraph of annotation.body) {
     const content: string[] = [];
     for (const run of paragraph.runs) {
-      const style = run.style;
-      if (!style || Object.keys(style).length === 0) content.push(escapeText(run.text));
+      const style = run.style ?? {};
+      if (Object.keys(style).length === 0 && !run.hyperlink) content.push(escapeText(run.text));
       else {
         const styleAttributes = [
+          ...(run.hyperlink ? [`href="${escapeAttribute(run.hyperlink.destination)}"`] : []),
           ...(style.styleId ? [`style="${escapeAttribute(style.styleId)}"`] : []),
           ...(style.fontSizeHalfPoints ? [`size=${style.fontSizeHalfPoints}`] : []),
           ...(style.bold ? ['bold=true'] : []), ...(style.italic ? ['italic=true'] : []), ...(style.underline ? ['underline=true'] : []),
@@ -237,7 +300,12 @@ export async function importDocxToMarkdoc(source: Buffer): Promise<ImportResult>
   }
   const annotations: CanonicalAnnotation[] = [];
   const styles = anchored.getStylesModel();
-  const [commentsXml, footnotesXml] = await Promise.all([anchored.getCommentsXmlClone(), anchored.getFootnotesXmlClone()]);
+  const [commentsXml, footnotesXml, commentsRelationships, footnotesRelationships] = await Promise.all([
+    anchored.getCommentsXmlClone(),
+    anchored.getFootnotesXmlClone(),
+    anchored.getPartRelationshipsXmlClone('word/comments.xml'),
+    anchored.getPartRelationshipsXmlClone('word/footnotes.xml'),
+  ]);
   const comments = await anchored.getComments();
   const importedCommentIds = new Set<number>();
   const addCommentTree = (comment: (typeof comments)[number], parent: CanonicalAnnotation | undefined): void => {
@@ -248,7 +316,7 @@ export async function importDocxToMarkdoc(source: Buffer): Promise<ImportResult>
     importedCommentIds.add(comment.id);
     const commentElement = elementByWordId(commentsXml, W.comment, comment.id);
     if (!commentElement) throw new DocxMarkdocError('ANNOTATION_IMPORT_UNSUPPORTED', `Comment ${comment.id} has no definition.`, { annotationId: id });
-    assertAdmittedAnnotationElement(commentElement, id, 'annotationRef', styles);
+    const hyperlinks = assertAdmittedAnnotationElement(commentElement, id, 'annotationRef', styles, commentsRelationships);
     let anchor: AnnotationAnchor;
     if (parent) anchor = parent.anchor;
     else {
@@ -261,7 +329,7 @@ export async function importDocxToMarkdoc(source: Buffer): Promise<ImportResult>
     }
     const annotation: CanonicalAnnotation = {
       id,
-      body: bodyFromParagraphs(comment.paragraphs, commentElement, id, 'annotationRef'),
+      body: bodyFromParagraphs(comment.paragraphs, commentElement, id, 'annotationRef', hyperlinks),
       author: comment.author || undefined,
       initials: comment.initials || undefined,
       date: comment.date || undefined,
@@ -291,12 +359,12 @@ export async function importDocxToMarkdoc(source: Buffer): Promise<ImportResult>
     if (footnote.referencePoints.length === 0 && footnote.text.length === 0) continue;
     const footnoteElement = elementByWordId(footnotesXml, W.footnote, footnote.id);
     if (!footnoteElement) throw new DocxMarkdocError('ANNOTATION_IMPORT_UNSUPPORTED', `Footnote ${footnote.id} has no definition.`, { annotationId: id });
-    assertAdmittedAnnotationElement(footnoteElement, id, 'footnoteRef', styles);
+    const hyperlinks = assertAdmittedAnnotationElement(footnoteElement, id, 'footnoteRef', styles, footnotesRelationships);
     if (footnote.referencePoints.length !== 1) throw new DocxMarkdocError('ANNOTATION_IMPORT_UNSUPPORTED', `Footnote ${footnote.id} must have exactly one reference.`, { annotationId: id, referenceCount: footnote.referencePoints.length });
     const reference = footnote.referencePoints[0]!;
     const anchor: AnnotationAnchor = { kind: 'point', point: { paragraphId: reference.paragraphId, offset: reference.textOffset } };
     annotations.push({
-      id, body: bodyFromParagraphs(footnote.paragraphs, footnoteElement, id, 'footnoteRef'), audience: 'unspecified', semanticRole: 'substantive-footnote',
+      id, body: bodyFromParagraphs(footnote.paragraphs, footnoteElement, id, 'footnoteRef', hyperlinks), audience: 'unspecified', semanticRole: 'substantive-footnote',
       sourcePresentation: 'footnote', sourceAnchor: anchor, anchor,
     });
   }

--- a/packages/docx-markdoc/src/import.ts
+++ b/packages/docx-markdoc/src/import.ts
@@ -29,8 +29,15 @@ function escapeText(text: string): string {
     .replace(/ +$/, (spaces) => '&#32;'.repeat(spaces.length));
 }
 
+/**
+ * Escape a value for a double-quoted Markdoc string literal. Markdoc strings
+ * are not HTML: entity references pass through verbatim, so `&`, `<`, and `>`
+ * must stay raw and only the backslash and the delimiter are escaped.
+ *
+ * @see #956
+ */
 function escapeAttribute(text: string): string {
-  return text.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  return text.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 }
 
 function parseTaggedRuns(tagged: string, annotationId: string): AnnotationRun[] {

--- a/packages/docx-markdoc/src/markdoc.ts
+++ b/packages/docx-markdoc/src/markdoc.ts
@@ -123,6 +123,7 @@ export const markdocConfig: Config = {
     'annotation-run': {
       inline: true,
       attributes: {
+        href: { type: String },
         style: { type: String },
         size: { type: Number },
         bold: { type: Boolean }, italic: { type: Boolean }, underline: { type: Boolean },
@@ -238,14 +239,18 @@ function annotationBody(node: Node, issues: ValidationIssue[]): AnnotationParagr
       continue;
     }
     const runs = [] as AnnotationParagraph['runs'];
-    const visit = (inline: Node, inherited?: AnnotationRunStyle): void => {
+    const visit = (inline: Node, inherited?: AnnotationRunStyle, inheritedDestination?: string): void => {
       if (inline.type === 'text') {
         const text = String(inline.attributes.content ?? '');
-        if (text) runs.push({ text, ...(inherited && Object.keys(inherited).length ? { style: inherited } : {}) });
+        if (text) runs.push({
+          text,
+          ...(inherited && Object.keys(inherited).length ? { style: inherited } : {}),
+          ...(inheritedDestination ? { hyperlink: { destination: inheritedDestination } } : {}),
+        });
         return;
       }
       if (inline.type === 'softbreak' || inline.type === 'hardbreak' || inline.type === 'paragraph' || inline.type === 'inline') {
-        for (const nested of inline.children) visit(nested, inherited);
+        for (const nested of inline.children) visit(nested, inherited, inheritedDestination);
         return;
       }
       if (inline.type !== 'tag' || inline.tag !== 'annotation-run') {
@@ -265,7 +270,9 @@ function annotationBody(node: Node, issues: ValidationIssue[]): AnnotationParagr
       if (style.fontSizeHalfPoints !== undefined && (!Number.isInteger(style.fontSizeHalfPoints) || style.fontSizeHalfPoints <= 0)) issues.push(issue('INVALID_ANNOTATION_STYLE', 'Annotation run sizes must be positive integer half-points.', inline));
       if (style.color && !/^[0-9A-F]{6}$/.test(style.color)) issues.push(issue('INVALID_ANNOTATION_COLOR', 'Annotation colors must be six-digit RGB values.', inline));
       if (style.highlight && !HIGHLIGHTS.has(style.highlight)) issues.push(issue('INVALID_ANNOTATION_HIGHLIGHT', `Unsupported Word highlight ${style.highlight}.`, inline));
-      for (const nested of inline.children) visit(nested, style);
+      const destination = inline.attributes.href === undefined ? undefined : String(inline.attributes.href);
+      if (destination !== undefined && destination.length === 0) issues.push(issue('INVALID_ANNOTATION_HYPERLINK', 'Annotation hyperlink destinations must be non-empty.', inline));
+      for (const nested of inline.children) visit(nested, style, destination);
     };
     for (const inline of child.children) visit(inline);
     paragraphs.push({ runs });

--- a/packages/docx-markdoc/src/presentation.ts
+++ b/packages/docx-markdoc/src/presentation.ts
@@ -28,7 +28,14 @@ function normalizeStyle(style: AnnotationRunStyle | undefined, path: string): An
 function normalizeRuns(runs: AnnotationRun[] | undefined, path: string): AnnotationRun[] | undefined {
   return runs?.map((run, index) => {
     if (typeof run.text !== 'string') throw new DocxMarkdocError('INVALID_ANNOTATION_RUN', `${path}[${index}].text must be a string.`);
-    return { text: run.text, ...(run.style ? { style: normalizeStyle(run.style, `${path}[${index}].style`) } : {}) };
+    if (run.hyperlink !== undefined && (!run.hyperlink || typeof run.hyperlink.destination !== 'string' || run.hyperlink.destination.length === 0)) {
+      throw new DocxMarkdocError('INVALID_ANNOTATION_HYPERLINK', `${path}[${index}].hyperlink.destination must be a non-empty string.`);
+    }
+    return {
+      text: run.text,
+      ...(run.style ? { style: normalizeStyle(run.style, `${path}[${index}].style`) } : {}),
+      ...(run.hyperlink ? { hyperlink: { destination: run.hyperlink.destination } } : {}),
+    };
   });
 }
 
@@ -88,7 +95,11 @@ function remapAnchor(ir: MarkdocEditIR, annotation: CanonicalAnnotation): Annota
 
 function mergedBody(annotation: CanonicalAnnotation, overlay?: AnnotationRunStyle) {
   return annotation.body.map((paragraph) => ({
-    runs: paragraph.runs.map((run) => ({ text: run.text, style: { ...(run.style ?? {}), ...(overlay ?? {}) } })),
+    runs: paragraph.runs.map((run) => ({
+      text: run.text,
+      style: { ...(run.style ?? {}), ...(overlay ?? {}) },
+      ...(run.hyperlink ? { hyperlink: { destination: run.hyperlink.destination } } : {}),
+    })),
   }));
 }
 

--- a/packages/docx-markdoc/src/presentation.ts
+++ b/packages/docx-markdoc/src/presentation.ts
@@ -1,4 +1,4 @@
-import { DocxDocument, buildParagraphIndex, createRevisionContext, findParagraphByBookmarkId, type FootnoteRunStyle } from '@usejunior/docx-core';
+import { DocxDocument, buildParagraphIndex, createRevisionContext, findParagraphByBookmarkId } from '@usejunior/docx-core';
 import { DocxMarkdocError } from './errors.js';
 import { sha256 } from './hash.js';
 import type {
@@ -176,7 +176,7 @@ export async function projectAnnotations(buffer: Buffer, ir: MarkdocEditIR, requ
         presentation: {
           prefixRuns: rule?.prefix,
           separatorRuns: rule?.separator,
-          body: mergedBody(annotation, rule?.bodyStyle) as Array<{ runs: Array<{ text: string; style?: FootnoteRunStyle }> }>,
+          body: mergedBody(annotation, rule?.bodyStyle),
         },
       });
       continue;

--- a/packages/docx-markdoc/src/types.ts
+++ b/packages/docx-markdoc/src/types.ts
@@ -40,7 +40,17 @@ export type AnnotationRunStyle = {
   highlight?: 'black' | 'blue' | 'cyan' | 'green' | 'magenta' | 'red' | 'yellow' | 'white' | 'darkBlue' | 'darkCyan' | 'darkGreen' | 'darkMagenta' | 'darkRed' | 'darkYellow' | 'darkGray' | 'lightGray' | 'none';
 };
 
-export type AnnotationRun = { text: string; style?: AnnotationRunStyle };
+/**
+ * A resolved external hyperlink destination retained independently of visual
+ * run styling and source-part relationship identifiers.
+ *
+ * @conformance ECMA-376 edition 5, Part 1 § 17.16.22
+ * @conformance ECMA-376 edition 5, Part 2 § 6.5.3.4
+ * @see #956
+ */
+export type AnnotationHyperlink = { destination: string };
+
+export type AnnotationRun = { text: string; style?: AnnotationRunStyle; hyperlink?: AnnotationHyperlink };
 export type AnnotationParagraph = { runs: AnnotationRun[] };
 export type CanonicalAnnotation = {
   id: string;

--- a/scripts/generate_conformance_explorer.mjs
+++ b/scripts/generate_conformance_explorer.mjs
@@ -77,7 +77,11 @@ export function resolveSchemaDeclaration(schemaRef, root = REPO_ROOT) {
     `schemaRef path escapes repository: ${schemaPath}`
   );
   assert(fs.existsSync(absolute), `schemaRef path not found: ${schemaPath}`);
-  const document = new DOMParser().parseFromString(fs.readFileSync(absolute, 'utf8'), 'application/xml');
+  // The official OPC relationship schema is UTF-8 with a leading BOM. xmldom
+  // treats that decoded U+FEFF as content before the XML declaration, so
+  // normalize only the transport marker before parsing the vendored bytes.
+  const xmlSource = fs.readFileSync(absolute, 'utf8').replace(/^\uFEFF/u, '');
+  const document = new DOMParser().parseFromString(xmlSource, 'application/xml');
   const schema = document.documentElement;
   assert(schema?.namespaceURI === XSD_NS && schema.localName === 'schema', `not an XSD schema: ${schemaPath}`);
   const targetNamespace = schema.getAttribute('targetNamespace');

--- a/scripts/generate_conformance_explorer.test.mjs
+++ b/scripts/generate_conformance_explorer.test.mjs
@@ -63,6 +63,20 @@ test('schema declaration resolution preserves reused local-name contexts', () =>
   assert.deepEqual(declaration.occurrences.map((item) => item.declaredType).sort(), ['xs:integer', 'xs:string']);
 });
 
+test('schema declaration resolution accepts an official-style UTF-8 BOM', () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'safe-docx-explorer-bom-'));
+  const relative = 'spec-compliance/ecma-376/schemas/opc/relationships.xsd';
+  const absolute = path.join(temp, relative);
+  fs.mkdirSync(path.dirname(absolute), { recursive: true });
+  fs.writeFileSync(absolute, `\uFEFF<?xml version="1.0"?>
+    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:test">
+      <xs:element name="Relationships" type="xs:string"/>
+    </xs:schema>`);
+  const declaration = resolveSchemaDeclaration(`${relative}#element:Relationships`, temp);
+  assert.equal(declaration.occurrences.length, 1);
+  assert.equal(declaration.occurrences[0].declaredType, 'xs:string');
+});
+
 test('an unresolved schema declaration is rejected', () => {
   assert.throws(
     () => resolveSchemaDeclaration(

--- a/spec-compliance/CONFORMANCE.md
+++ b/spec-compliance/CONFORMANCE.md
@@ -27,7 +27,9 @@ Allure labels via `testAllure.conformance({…})`; source code carries
 | `ECMA-PART1-17-13-7-2` | Permission range start | 5 | 1 | 17.13.7.2 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:permStart` | packages/docx-core/src/integration/advanced-revision-classification.test.ts |
 | `ECMA-PART1-17-13-8-1` | Proofing error anchors | 5 | 1 | 17.13.8.1 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:proofErr` | packages/docx-compare/src/tagged/taggedTreeSerializer.ts |
 | `ECMA-PART1-17-11-14` | w:footnoteReference identifier vs display number | 5 | 1 | 17.11.14 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:footnoteReference` | packages/docx-core/src/footnotes.ts; packages/docx-core/src/footnotes.test.ts |
-| `ECMA-PART1-17-16-22` | w:hyperlink container preservation under tracked changes | 5 | 1 | 17.16.22 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:hyperlink` | packages/docx-compare/src/tagged/taggedTreeSerializer.ts; packages/docx-compare/src/tagged/trackChangesAcceptorAst.ts; packages/docx-core/src/primitives/relationships.ts; packages/docx-core/src/primitives/text.ts |
+| `ECMA-PART1-17-16-22` | w:hyperlink container preservation under tracked changes | 5 | 1 | 17.16.22 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:hyperlink` | packages/docx-compare/src/tagged/taggedTreeSerializer.ts; packages/docx-compare/src/tagged/trackChangesAcceptorAst.ts; packages/docx-core/src/primitives/relationships.ts; packages/docx-core/src/primitives/comments.ts; packages/docx-core/src/primitives/footnotes.ts; packages/docx-core/src/primitives/text.ts; packages/docx-markdoc/src/import.ts |
+| `ECMA-PART2-6-5-2-3` | part Relationships part ownership and naming | 5 | 2 | 6.5.2.3 | `spec-compliance/ecma-376/schemas/opc/opc-relationships.xsd#element:Relationships` | packages/docx-core/src/primitives/relationships.ts; packages/docx-markdoc/src/import.ts |
+| `ECMA-PART2-6-5-3-4` | relationship identity, type, target, and target mode | 5 | 2 | 6.5.3.4 | `spec-compliance/ecma-376/schemas/opc/opc-relationships.xsd#type:CT_Relationship` | packages/docx-core/src/primitives/relationships.ts; packages/docx-core/src/primitives/comments.ts; packages/docx-core/src/primitives/footnotes.ts; packages/docx-markdoc/src/import.ts |
 | `ECMA-PART1-17-5-2-29` | w:sdt block-level structured document tag | 5 | 1 | 17.5.2.29 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#type:CT_SdtBlock` | packages/docx-compare/src/tagged/opaquePassthrough.ts; packages/docx-compare/src/tagged/taggedTreeConstruction.test.ts |
 | `ECMA-PART1-17-5-2-31` | w:sdt inline-level structured document tag | 5 | 1 | 17.5.2.31 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#type:CT_SdtRun` | packages/docx-compare/src/tagged/opaquePassthrough.ts; packages/docx-compare/src/tagged/taggedTreeConstruction.test.ts |
 | `ECMA-PART1-17-5-2-32` | w:sdt cell-level structured document tag | 5 | 1 | 17.5.2.32 | `spec-compliance/ecma-376/schemas/transitional/wml.xsd#type:CT_SdtCell` | packages/docx-compare/src/tagged/opaquePassthrough.ts; packages/docx-compare/src/tagged/taggedTreeConstruction.test.ts |
@@ -371,7 +373,7 @@ This claim is bounded to the runtime and test evidence listed above.
 - **Part / Section:** Part 1 § 17.16.22
 - **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
 - **Schema reference:** `spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:hyperlink`
-- **Verified by:** packages/docx-compare/src/tagged/taggedTreeSerializer.ts; packages/docx-compare/src/tagged/trackChangesAcceptorAst.ts; packages/docx-core/src/primitives/relationships.ts; packages/docx-core/src/primitives/text.ts
+- **Verified by:** packages/docx-compare/src/tagged/taggedTreeSerializer.ts; packages/docx-compare/src/tagged/trackChangesAcceptorAst.ts; packages/docx-core/src/primitives/relationships.ts; packages/docx-core/src/primitives/comments.ts; packages/docx-core/src/primitives/footnotes.ts; packages/docx-core/src/primitives/text.ts; packages/docx-markdoc/src/import.ts
 
 `w:hyperlink` (CT_Hyperlink) is a run container inside `<w:p>` whose
 `r:id` attribute carries the relationship reference to the link target.
@@ -386,6 +388,39 @@ lives in `packages/docx-compare/src/tagged/taggedTreeConstruction.ts`
 (`nearestHyperlinkAncestor`) and
 `packages/docx-compare/src/tagged/taggedTreeSerializer.ts`
 (tagged hyperlink wrapper emission).
+
+### ECMA-PART2-6-5-2-3 — part Relationships part ownership and naming
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 2 § 6.5.2.3
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/opc/opc-relationships.xsd#element:Relationships`
+- **Verified by:** packages/docx-core/src/primitives/relationships.ts; packages/docx-markdoc/src/import.ts
+
+A part Relationships part contains relationships from one source part, and its
+name is derived by inserting `_rels` immediately before the source part's last
+path segment and appending `.rels` to that segment. Annotation hyperlinks in
+`word/comments.xml` and `word/footnotes.xml` therefore resolve through
+`word/_rels/comments.xml.rels` and `word/_rels/footnotes.xml.rels`
+respectively. safe-docx derives those paths from the owning part for both
+import and emission; relationship IDs from one annotation part are never
+reused as identities in another part.
+
+### ECMA-PART2-6-5-3-4 — relationship identity, type, target, and target mode
+
+- **Edition:** ECMA-376 5
+- **Part / Section:** Part 2 § 6.5.3.4
+- **Canonical URL:** https://ecma-international.org/publications-and-standards/standards/ecma-376/
+- **Schema reference:** `spec-compliance/ecma-376/schemas/opc/opc-relationships.xsd#type:CT_Relationship`
+- **Verified by:** packages/docx-core/src/primitives/relationships.ts; packages/docx-core/src/primitives/comments.ts; packages/docx-core/src/primitives/footnotes.ts; packages/docx-markdoc/src/import.ts
+
+Each `Relationship` has a required ID unique within its Relationships part, a
+required type, a required target, and an optional target mode whose default is
+Internal. For annotation hyperlinks, safe-docx accepts only the exact hyperlink
+relationship type with `TargetMode="External"` and a non-empty target. Emission
+allocates IDs against every existing relationship in the destination part,
+sets the external mode explicitly, and reuses an existing relationship only
+when both hyperlink type and external destination match.
 
 ### ECMA-PART1-17-5-2-29 — w:sdt block-level structured document tag
 

--- a/spec-compliance/generated/conformance-explorer.json
+++ b/spec-compliance/generated/conformance-explorer.json
@@ -1483,7 +1483,19 @@
         },
         {
           "kind": "source",
+          "path": "packages/docx-core/src/primitives/comments.ts"
+        },
+        {
+          "kind": "source",
+          "path": "packages/docx-core/src/primitives/footnotes.ts"
+        },
+        {
+          "kind": "source",
           "path": "packages/docx-core/src/primitives/text.ts"
+        },
+        {
+          "kind": "source",
+          "path": "packages/docx-markdoc/src/import.ts"
         }
       ]
     },
@@ -1864,6 +1876,70 @@
         {
           "kind": "test",
           "path": "packages/docx-core/src/generation/generation-styles-formatting.test.ts"
+        }
+      ]
+    },
+    {
+      "id": "ECMA-PART1-17-3-2-29",
+      "title": "Run style",
+      "classification": "targeted",
+      "citation": {
+        "standard": "ECMA-376",
+        "edition": 5,
+        "part": 1,
+        "section": "17.3.2.29"
+      },
+      "canonicalUrl": "https://ecma-international.org/publications-and-standards/standards/ecma-376/",
+      "schemaRef": "spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:rStyle",
+      "claimRationale": "Part 1 §17.3.2.29 defines `w:rStyle` as the character style applied to a run.\nsafe-docx admits resolvable named styles in imported annotation bodies, retains\ntheir style identifiers in the canonical representation, and re-emits those\nidentifiers when projecting the annotation as a comment or footnote. Missing\nnon-character, and cyclic style chains remain outside the admitted subset and\nfail closed.",
+      "evidence": [
+        {
+          "kind": "source",
+          "path": "packages/docx-markdoc/src/import.ts"
+        },
+        {
+          "kind": "source",
+          "path": "packages/docx-core/src/primitives/comments.ts"
+        },
+        {
+          "kind": "source",
+          "path": "packages/docx-core/src/primitives/footnotes.ts"
+        },
+        {
+          "kind": "test",
+          "path": "packages/docx-markdoc/src/annotation-roundtrip.test.ts"
+        }
+      ]
+    },
+    {
+      "id": "ECMA-PART1-17-3-2-38",
+      "title": "Run font size",
+      "classification": "targeted",
+      "citation": {
+        "standard": "ECMA-376",
+        "edition": 5,
+        "part": 1,
+        "section": "17.3.2.38"
+      },
+      "canonicalUrl": "https://ecma-international.org/publications-and-standards/standards/ecma-376/",
+      "schemaRef": "spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:sz",
+      "claimRationale": "Part 1 §17.3.2.38 defines `w:sz` as a run font size expressed in half-points.\nsafe-docx retains positive integral half-point sizes from imported annotation\nbodies and re-emits them across comment and footnote projections.",
+      "evidence": [
+        {
+          "kind": "source",
+          "path": "packages/docx-markdoc/src/import.ts"
+        },
+        {
+          "kind": "source",
+          "path": "packages/docx-core/src/primitives/comments.ts"
+        },
+        {
+          "kind": "source",
+          "path": "packages/docx-core/src/primitives/footnotes.ts"
+        },
+        {
+          "kind": "test",
+          "path": "packages/docx-markdoc/src/annotation-roundtrip.test.ts"
         }
       ]
     },
@@ -3100,6 +3176,62 @@
       ]
     },
     {
+      "id": "ECMA-PART2-6-5-2-3",
+      "title": "part Relationships part ownership and naming",
+      "classification": "targeted",
+      "citation": {
+        "standard": "ECMA-376",
+        "edition": 5,
+        "part": 2,
+        "section": "6.5.2.3"
+      },
+      "canonicalUrl": "https://ecma-international.org/publications-and-standards/standards/ecma-376/",
+      "schemaRef": "spec-compliance/ecma-376/schemas/opc/opc-relationships.xsd#element:Relationships",
+      "claimRationale": "A part Relationships part contains relationships from one source part, and its\nname is derived by inserting `_rels` immediately before the source part's last\npath segment and appending `.rels` to that segment. Annotation hyperlinks in\n`word/comments.xml` and `word/footnotes.xml` therefore resolve through\n`word/_rels/comments.xml.rels` and `word/_rels/footnotes.xml.rels`\nrespectively. safe-docx derives those paths from the owning part for both\nimport and emission; relationship IDs from one annotation part are never\nreused as identities in another part.",
+      "evidence": [
+        {
+          "kind": "source",
+          "path": "packages/docx-core/src/primitives/relationships.ts"
+        },
+        {
+          "kind": "source",
+          "path": "packages/docx-markdoc/src/import.ts"
+        }
+      ]
+    },
+    {
+      "id": "ECMA-PART2-6-5-3-4",
+      "title": "relationship identity, type, target, and target mode",
+      "classification": "targeted",
+      "citation": {
+        "standard": "ECMA-376",
+        "edition": 5,
+        "part": 2,
+        "section": "6.5.3.4"
+      },
+      "canonicalUrl": "https://ecma-international.org/publications-and-standards/standards/ecma-376/",
+      "schemaRef": "spec-compliance/ecma-376/schemas/opc/opc-relationships.xsd#type:CT_Relationship",
+      "claimRationale": "Each `Relationship` has a required ID unique within its Relationships part, a\nrequired type, a required target, and an optional target mode whose default is\nInternal. For annotation hyperlinks, safe-docx accepts only the exact hyperlink\nrelationship type with `TargetMode=\"External\"` and a non-empty target. Emission\nallocates IDs against every existing relationship in the destination part,\nsets the external mode explicitly, and reuses an existing relationship only\nwhen both hyperlink type and external destination match.",
+      "evidence": [
+        {
+          "kind": "source",
+          "path": "packages/docx-core/src/primitives/relationships.ts"
+        },
+        {
+          "kind": "source",
+          "path": "packages/docx-core/src/primitives/comments.ts"
+        },
+        {
+          "kind": "source",
+          "path": "packages/docx-core/src/primitives/footnotes.ts"
+        },
+        {
+          "kind": "source",
+          "path": "packages/docx-markdoc/src/import.ts"
+        }
+      ]
+    },
+    {
       "id": "ECMA-PART4-14-9-1-1",
       "title": "VML rich text-box content (w:txbxContent)",
       "classification": "targeted",
@@ -3157,6 +3289,33 @@
     }
   ],
   "schemaDeclarations": [
+    {
+      "id": "spec-compliance/ecma-376/schemas/opc/opc-relationships.xsd#element:Relationships",
+      "schemaPath": "spec-compliance/ecma-376/schemas/opc/opc-relationships.xsd",
+      "conformanceClass": "opc",
+      "targetNamespace": "http://schemas.openxmlformats.org/package/2006/relationships",
+      "kind": "element",
+      "name": "Relationships",
+      "occurrences": [
+        {
+          "contextPath": "schema/element:Relationships",
+          "declaredType": "CT_Relationships"
+        }
+      ]
+    },
+    {
+      "id": "spec-compliance/ecma-376/schemas/opc/opc-relationships.xsd#type:CT_Relationship",
+      "schemaPath": "spec-compliance/ecma-376/schemas/opc/opc-relationships.xsd",
+      "conformanceClass": "opc",
+      "targetNamespace": "http://schemas.openxmlformats.org/package/2006/relationships",
+      "kind": "type",
+      "name": "CT_Relationship",
+      "occurrences": [
+        {
+          "contextPath": "schema/type:CT_Relationship"
+        }
+      ]
+    },
     {
       "id": "spec-compliance/ecma-376/schemas/transitional/vml-main.xsd#type:CT_Textbox",
       "schemaPath": "spec-compliance/ecma-376/schemas/transitional/vml-main.xsd",
@@ -4289,6 +4448,20 @@
       ]
     },
     {
+      "id": "spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:rStyle",
+      "schemaPath": "spec-compliance/ecma-376/schemas/transitional/wml.xsd",
+      "conformanceClass": "transitional",
+      "targetNamespace": "http://schemas.openxmlformats.org/wordprocessingml/2006/main",
+      "kind": "element",
+      "name": "rStyle",
+      "occurrences": [
+        {
+          "contextPath": "schema/group:EG_RPrBase/choice/element:rStyle",
+          "declaredType": "CT_String"
+        }
+      ]
+    },
+    {
       "id": "spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:sectPr",
       "schemaPath": "spec-compliance/ecma-376/schemas/transitional/wml.xsd",
       "conformanceClass": "transitional",
@@ -4462,6 +4635,30 @@
         {
           "contextPath": "schema/type:CT_Lvl/sequence/element:suff",
           "declaredType": "CT_LevelSuffix",
+          "minOccurs": "0"
+        }
+      ]
+    },
+    {
+      "id": "spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:sz",
+      "schemaPath": "spec-compliance/ecma-376/schemas/transitional/wml.xsd",
+      "conformanceClass": "transitional",
+      "targetNamespace": "http://schemas.openxmlformats.org/wordprocessingml/2006/main",
+      "kind": "element",
+      "name": "sz",
+      "occurrences": [
+        {
+          "contextPath": "schema/group:EG_RPrBase/choice/element:sz",
+          "declaredType": "CT_HpsMeasure"
+        },
+        {
+          "contextPath": "schema/type:CT_Frame/sequence/element:sz",
+          "declaredType": "CT_String",
+          "minOccurs": "0"
+        },
+        {
+          "contextPath": "schema/type:CT_Frameset/sequence/element:sz",
+          "declaredType": "CT_String",
           "minOccurs": "0"
         }
       ]

--- a/spec-compliance/registry/ecma-376.md
+++ b/spec-compliance/registry/ecma-376.md
@@ -294,7 +294,7 @@ part: 1
 section: "17.16.22"
 url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
 schemaRef: spec-compliance/ecma-376/schemas/transitional/wml.xsd#element:hyperlink
-verifiedBy: packages/docx-compare/src/tagged/taggedTreeSerializer.ts; packages/docx-compare/src/tagged/trackChangesAcceptorAst.ts; packages/docx-core/src/primitives/relationships.ts; packages/docx-core/src/primitives/text.ts
+verifiedBy: packages/docx-compare/src/tagged/taggedTreeSerializer.ts; packages/docx-compare/src/tagged/trackChangesAcceptorAst.ts; packages/docx-core/src/primitives/relationships.ts; packages/docx-core/src/primitives/comments.ts; packages/docx-core/src/primitives/footnotes.ts; packages/docx-core/src/primitives/text.ts; packages/docx-markdoc/src/import.ts
 ```
 
 `w:hyperlink` (CT_Hyperlink) is a run container inside `<w:p>` whose
@@ -310,6 +310,45 @@ lives in `packages/docx-compare/src/tagged/taggedTreeConstruction.ts`
 (`nearestHyperlinkAncestor`) and
 `packages/docx-compare/src/tagged/taggedTreeSerializer.ts`
 (tagged hyperlink wrapper emission).
+
+## [ECMA-PART2-6-5-2-3] part Relationships part ownership and naming
+
+```yaml
+edition: 5
+part: 2
+section: "6.5.2.3"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/opc/opc-relationships.xsd#element:Relationships
+verifiedBy: packages/docx-core/src/primitives/relationships.ts; packages/docx-markdoc/src/import.ts
+```
+
+A part Relationships part contains relationships from one source part, and its
+name is derived by inserting `_rels` immediately before the source part's last
+path segment and appending `.rels` to that segment. Annotation hyperlinks in
+`word/comments.xml` and `word/footnotes.xml` therefore resolve through
+`word/_rels/comments.xml.rels` and `word/_rels/footnotes.xml.rels`
+respectively. safe-docx derives those paths from the owning part for both
+import and emission; relationship IDs from one annotation part are never
+reused as identities in another part.
+
+## [ECMA-PART2-6-5-3-4] relationship identity, type, target, and target mode
+
+```yaml
+edition: 5
+part: 2
+section: "6.5.3.4"
+url: https://ecma-international.org/publications-and-standards/standards/ecma-376/
+schemaRef: spec-compliance/ecma-376/schemas/opc/opc-relationships.xsd#type:CT_Relationship
+verifiedBy: packages/docx-core/src/primitives/relationships.ts; packages/docx-core/src/primitives/comments.ts; packages/docx-core/src/primitives/footnotes.ts; packages/docx-markdoc/src/import.ts
+```
+
+Each `Relationship` has a required ID unique within its Relationships part, a
+required type, a required target, and an optional target mode whose default is
+Internal. For annotation hyperlinks, safe-docx accepts only the exact hyperlink
+relationship type with `TargetMode="External"` and a non-empty target. Emission
+allocates IDs against every existing relationship in the destination part,
+sets the external mode explicitly, and reuses an existing relationship only
+when both hyperlink type and external destination match.
 
 ## [ECMA-PART1-17-5-2-29] w:sdt block-level structured document tag
 


### PR DESCRIPTION
## Summary

- Resolve external annotation hyperlinks through the owning comments or footnotes relationship part.
- Preserve explicit destinations, text, named run style, and direct half-point size through Markdoc and all four comment/footnote projections.
- Allocate deterministic collision-free destination relationships while keeping internal anchors, bookmarks, and malformed inputs fail-closed.

## Why

Annotation import stopped at relationship-backed links even though the link text and admitted formatting were representable. Part-local rIds also cannot safely be reused when converting between comments and footnotes, so canonical runs now retain the resolved destination instead.

## Scope

- Canonical AnnotationRun hyperlink metadata and annotation-run href syntax.
- Comment and footnote relationship resolution and emission.
- ECMA-376 Part 1 section 17.16.22 and Part 2 sections 6.5.2.3 and 6.5.3.4 evidence.
- Synthetic coverage plus in-memory real ILPA package diagnostics.
- A leading UTF-8 BOM normalization in the conformance explorer, required to resolve the vendored official OPC relationships schema without modifying normative source material.

Internal anchors, bookmarks, general cross-references, tooltip, target-frame, and document-location metadata remain out of scope and fail closed where applicable.

## OpenSpec

- [x] Required and included: openspec/changes/preserve-external-annotation-hyperlinks/.

## ECMA-376 / OOXML Conformance

- [x] Applicable: conformance claims use structured @conformance citations.
- [x] Applicable: tests use testAllure.conformance with the verified edition, part, and section.

## Testing

- [x] npm run build
- [x] npm run lint:workspaces — passed with 0 errors and 6 pre-existing unused-disable warnings.
- [x] npm run test:run — 3,292 passed, 2 expected failures, 37 skipped across workspaces.
- [x] npm run check:spec-coverage
- [x] npm run check:conformance-citations — 121 registry entries and 51 XSDs resolved.
- [x] npm run check:conformance-doc
- [x] openspec validate preserve-external-annotation-hyperlinks --strict
- [x] npm run check:conformance-explorer — 126 sections, 114 declarations, 91 capability claims.

Exact mandatory gate passed:

    npm run build && npm run lint:workspaces && npm run test:run && npm run check:spec-coverage && npm run check:conformance-citations && npm run check:conformance-doc

## Real-document evidence

Both committed ILPA fixtures were exercised in memory with bookmark markers removed, then every annotation was projected to comments and to footnotes. ZIP inspection confirmed the exact external target, TargetMode=External, destination-part rId ownership, visible URL text, Hyperlink character style, and 18-half-point direct size. No modified client document or generated DOCX was committed.

Fresh origin/main differs from the issue premise: the WOF fixture advances to w:bookmarkStart in footnote:19, while the Deal-By-Deal fixture contains no bookmark marker there and imports completely after hyperlink support. SDX-MDOC-103 records that observed baseline rather than manufacturing a failure.

## Fixtures

- [x] Reused buildDocxFromParts and DocxDocument helpers.
- [x] Inline OOXML is limited to relationship and malformed-wrapper shapes that are themselves under test.

## Visual Changes

- [x] Not applicable. The change preserves existing hyperlink-styled text and changes package semantics, verified through XML and relationship inspection.

## Related Issues

Fixes: #956

## Review follow-up (a600d272 → this push)

A dynamic review of a600d272 found two defects, both fixed here with tests:

- **Destinations with `&` / `"` were corrupted by the Markdoc round trip.** `escapeAttribute` used HTML entities, but Markdoc string literals are not entity-decoded, so `?a=1&b=2` re-parsed as `?a=1&amp;b=2` and the projected relationship Target carried the corrupted URL. Attributes are now escaped as Markdoc string literals; the same fix repairs authors like `Smith & Jones`. Test: `keeps reserved Markdoc characters in destinations and authors exact across the round trip`.
- **Tracked footnote emission hoisted linked runs out of their hyperlink.** `collectFootnoteTextRuns` skipped `w:hyperlink`, so `addFootnote(…, ctx)` reordered the note text and left the linked run untracked; tracked `deleteFootnote` on ILPA Deal-By-Deal footnote 6 left the link text live. Runs are now wrapped per parent container (`w:ins`/`w:del` inside the `w:hyperlink`). This is the same gap the advisory LLM gate flagged. The pinned cross-wrapper test in `test-primitives/footnotes.test.ts` is updated: it accepted a direct paragraph run being pulled into another author's `w:ins` on tracked replacement (rejecting that author's insertion would have dropped original text); each run is now deleted inside its own container.
- **Coverage ratchet (required `workspace-test (20)`)** regressed because the emission code was only exercised from docx-markdoc; `packages/docx-core/src/primitives/annotation_hyperlinks.test.ts` covers it directly.

Not changed: MCP `add_comment`/`add_footnote` still take plain text (hyperlink bodies are a docx-markdoc/library capability, per the design's bounded scope).
