### PR TITLE
fix(deps): upgrade xmldom past entity injection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@typescript-eslint/eslint-plugin": "^8.56.0",
         "@typescript-eslint/parser": "^8.56.0",
         "@vitest/runner": "4.1.8",
-        "@xmldom/xmldom": "^0.9.10",
+        "@xmldom/xmldom": "^0.9.12",
         "ajv": "^8.18.0",
         "allure": "3.15.0",
         "eslint": "^10.0.1",
@@ -2935,9 +2935,9 @@
       "license": "MIT"
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.9.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
-      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "version": "0.9.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.12.tgz",
+      "integrity": "sha512-5AXjrcMClTryPe9LgZrygpB1lj7s0S9E0+W+AHaVKAVyHanafK86iPSvG5xHVSp/jC+VH1UXu0TAEmY279xH7A==",
       "license": "MIT",
       "engines": {
         "node": ">=14.6"
@@ -9176,7 +9176,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@usejunior/docx-core": "^0.20.1",
-        "@xmldom/xmldom": "^0.9.10",
+        "@xmldom/xmldom": "^0.9.12",
         "jszip": "^3.10.1"
       },
       "bin": {
@@ -9202,7 +9202,7 @@
       "version": "0.20.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@xmldom/xmldom": "^0.9.10",
+        "@xmldom/xmldom": "^0.9.12",
         "jszip": "^3.10.1"
       },
       "bin": {
@@ -9254,7 +9254,7 @@
         "@usejunior/docx-compare": "^0.20.1",
         "@usejunior/docx-core": "^0.20.1",
         "@usejunior/odf-core": "^0.20.1",
-        "@xmldom/xmldom": "^0.9.10",
+        "@xmldom/xmldom": "^0.9.12",
         "zod": "^4.3.6"
       },
       "bin": {
@@ -9287,7 +9287,7 @@
       "version": "0.20.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@xmldom/xmldom": "^0.9.10",
+        "@xmldom/xmldom": "^0.9.12",
         "jszip": "^3.10.1"
       },
       "bin": {
@@ -9307,7 +9307,7 @@
       "version": "0.20.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@xmldom/xmldom": "^0.9.10",
+        "@xmldom/xmldom": "^0.9.12",
         "jszip": "^3.10.1"
       },
       "devDependencies": {
@@ -9341,7 +9341,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@usejunior/docx-core": "^0.20.1",
-        "@xmldom/xmldom": "^0.9.10",
+        "@xmldom/xmldom": "^0.9.12",
         "jszip": "^3.10.1"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@typescript-eslint/eslint-plugin": "^8.56.0",
     "@typescript-eslint/parser": "^8.56.0",
     "@vitest/runner": "4.1.8",
-    "@xmldom/xmldom": "^0.9.10",
+    "@xmldom/xmldom": "^0.9.12",
     "ajv": "^8.18.0",
     "allure": "3.15.0",
     "eslint": "^10.0.1",

--- a/packages/docx-compare/package.json
+++ b/packages/docx-compare/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@usejunior/docx-core": "^0.20.1",
-    "@xmldom/xmldom": "^0.9.10",
+    "@xmldom/xmldom": "^0.9.12",
     "jszip": "^3.10.1"
   },
   "devDependencies": {

--- a/packages/docx-core/package.json
+++ b/packages/docx-core/package.json
@@ -20,7 +20,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@xmldom/xmldom": "^0.9.10",
+    "@xmldom/xmldom": "^0.9.12",
     "jszip": "^3.10.1"
   },
   "devDependencies": {

--- a/packages/docx-core/src/xmldom-characterdata-nodevalue.test.ts
+++ b/packages/docx-core/src/xmldom-characterdata-nodevalue.test.ts
@@ -46,28 +46,14 @@ describe('xmldom CharacterData nodeValue/data sync', () => {
     expect(new XMLSerializer().serializeToString(doc)).toContain('updated');
   });
 
-  // This test is marked .fails() to document the upstream bug, still present in
-  // @xmldom/xmldom 0.9.x. Direct nodeValue assignment only updates the instance
-  // property — `data` stays stale, so XMLSerializer silently outputs the old text.
-  //
-  // Once the library implements nodeValue as a getter/setter on CharacterData.prototype
-  // (or via Node.prototype dispatch), change this to a normal test() with the same assertions.
-  //
-  // Fix direction:
-  //   Object.defineProperty(CharacterData.prototype, 'nodeValue', {
-  //     get() { return this.data; },
-  //     set(v) { const s = v == null ? '' : String(v); this.data = s; this.length = s.length; }
-  //   });
-  test.fails('direct nodeValue assignment updates nodeValue but NOT data or XMLSerializer output', () => {
+  test('direct nodeValue assignment keeps data and XMLSerializer output in sync', () => {
     const doc = new DOMParser().parseFromString('<r/>', 'text/xml');
     const text = doc.createTextNode('original');
     doc.documentElement!.appendChild(text);
 
     text.nodeValue = 'updated';
 
-    // nodeValue appears correct — the instance property was shadowed
     expect(text.nodeValue).toBe('updated');
-    // data is stale — these fail in xmldom 0.9.x
     expect(text.data).toBe('updated');
     expect(new XMLSerializer().serializeToString(doc)).toContain('updated');
   });

--- a/packages/docx-core/src/xmldom-characterdata-nodevalue.test.ts
+++ b/packages/docx-core/src/xmldom-characterdata-nodevalue.test.ts
@@ -58,16 +58,15 @@ describe('xmldom CharacterData nodeValue/data sync', () => {
     expect(new XMLSerializer().serializeToString(doc)).toContain('updated');
   });
 
-  // Real-world impact: simulates the setLeafText path in our DOCX comparison engine
-  // before the fix (Issue #35). The merged atom appeared correct in DOM traversal
-  // (nodeValue read back 'hello world') but XMLSerializer silently wrote stale text.
-  test.fails('merging atom text via nodeValue loses data on serialization', () => {
-    const doc = new DOMParser().parseFromString('<w:t>hello </w:t>', 'text/xml');
+  test('merging atom text via nodeValue preserves serialized data', () => {
+    const doc = new DOMParser().parseFromString(
+      '<w:t xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">hello </w:t>',
+      'text/xml',
+    );
     const textNode = doc.documentElement!.firstChild as unknown as CharacterData;
 
     textNode.nodeValue = 'hello world';
 
-    // These fail — data and serialized output remain 'hello '
     expect(textNode.data).toBe('hello world');
     expect(new XMLSerializer().serializeToString(doc)).toContain('hello world');
   });

--- a/packages/docx-core/test-primitives/xml.test.ts
+++ b/packages/docx-core/test-primitives/xml.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect } from 'vitest';
+import { DOMImplementation, XMLSerializer } from '@xmldom/xmldom';
 import { testAllure, type AllureBddContext } from './helpers/allure-test.js';
 import { parseXml, serializeXml, textContent } from '../src/primitives/xml.js';
 
@@ -75,6 +76,19 @@ describe('parseXml', () => {
 });
 
 describe('serializeXml', () => {
+  test('rejects an injected entity-reference name in well-formed mode', () => {
+    const doc = new DOMImplementation().createDocument(null, 'root', null);
+
+    expect(() => doc.createEntityReference('safe; <injected/> &x')).toThrow();
+
+    const reference = doc.createEntityReference('safe');
+    (reference as unknown as { nodeName: string }).nodeName = 'safe; <injected/> &x';
+
+    expect(() =>
+      new XMLSerializer().serializeToString(reference, { requireWellFormed: true }),
+    ).toThrowError(/not a valid XML Name/);
+  });
+
   test('round-trips simple XML back to string', async ({ given, when, then }: AllureBddContext) => {
     let doc!: Document;
     let serialized!: string;

--- a/packages/docx-mcp/package.json
+++ b/packages/docx-mcp/package.json
@@ -30,7 +30,7 @@
     "@usejunior/docx-compare": "^0.20.1",
     "@usejunior/docx-core": "^0.20.1",
     "@usejunior/odf-core": "^0.20.1",
-    "@xmldom/xmldom": "^0.9.10",
+    "@xmldom/xmldom": "^0.9.12",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/packages/docx-release-verifier/package.json
+++ b/packages/docx-release-verifier/package.json
@@ -16,7 +16,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@xmldom/xmldom": "^0.9.10",
+    "@xmldom/xmldom": "^0.9.12",
     "jszip": "^3.10.1"
   },
   "devDependencies": {

--- a/packages/docx-render-verifier/package.json
+++ b/packages/docx-render-verifier/package.json
@@ -18,7 +18,7 @@
     "vitest": "^4.1.8"
   },
   "dependencies": {
-    "@xmldom/xmldom": "^0.9.10",
+    "@xmldom/xmldom": "^0.9.12",
     "jszip": "^3.10.1"
   },
   "engines": {

--- a/packages/odf-core/package.json
+++ b/packages/odf-core/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@usejunior/docx-core": "^0.20.1",
-    "@xmldom/xmldom": "^0.9.10",
+    "@xmldom/xmldom": "^0.9.12",
     "jszip": "^3.10.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- upgrade every direct `@xmldom/xmldom` declaration from `^0.9.10` to `^0.9.12` and refresh only the corresponding lockfile entries
- add regression coverage for GHSA-6gmq-8vp8-gcm6 creation-time rejection and strict serialization of a tampered `EntityReference.nodeName`
- promote the `CharacterData.nodeValue` synchronization check from expected failure because 0.9.12 repairs it

## Security and serializer audit
Dependabot alert #172 / CVE-2026-83610 affects invalid attacker-controlled `EntityReference` names. The repository has 107 `XMLSerializer.serializeToString` call sites, including tests, but no production `createEntityReference` call or `ENTITY_REFERENCE_NODE` construction. xmldom does not create entity-reference nodes when parsing ordinary XML, so 0.9.12's default creation-time validation closes the reachable vector.

I tested `{ requireWellFormed: true }` at the shared serialization boundary because DOCX/ODF inputs are attacker-influenced. It is not appropriate globally: supported workflows serialize intermediate document fragments, and strict whole-document checks caused broad focused-suite failures. Those calls remain unchanged to preserve valid behavior; strict mode is exercised in the alert-specific tampering regression where it is applicable.

`npm audit --omit=dev` no longer reports `@xmldom/xmldom`. Two unrelated transitive advisories (`fast-uri`, `qs`) remain and are intentionally outside this focused PR.

## Verification
- `npm run test:run -w @usejunior/docx-core -- test-primitives/xml.test.ts src/xmldom-characterdata-nodevalue.test.ts`
- `npm run test:run -w @usejunior/docx-core` (1,309 passed; 1 expected failure; 1 platform-dependent skip)
- mandatory gate: `npm run build && npm run lint:workspaces && npm run test:run && npm run check:spec-coverage && npm run check:conformance-citations && npm run check:conformance-doc`
- `npm ls @xmldom/xmldom --all` resolves every workspace to `0.9.12`

Closes Dependabot alert #172.